### PR TITLE
fix: kill process tree on session cleanup + Windows process flags

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::io::{self, BufRead, Write as IoWrite};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use super::dcserver;
 

--- a/src/server/routes/session_activity.rs
+++ b/src/server/routes/session_activity.rs
@@ -3,6 +3,7 @@ use std::process::Command;
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 
+#[cfg(unix)]
 use crate::services::tmux_diagnostics::tmux_session_has_live_pane;
 
 const REMOTE_HEARTBEAT_GRACE_SECS: i64 = 90;
@@ -39,7 +40,10 @@ impl SessionActivityResolver {
             if let Some(cached) = cache.get(tmux_name) {
                 return *cached;
             }
+            #[cfg(unix)]
             let live = tmux_session_has_live_pane(tmux_name);
+            #[cfg(not(unix))]
+            let live = false; // tmux not available on Windows
             cache.insert(tmux_name.to_string(), live);
             live
         };

--- a/src/services/codex_tmux_wrapper.rs
+++ b/src/services/codex_tmux_wrapper.rs
@@ -224,6 +224,8 @@ fn run_turn(
         .spawn()
         .map_err(|e| format!("Failed to start Codex: {}", e))?;
 
+    let child_pid = child.id();
+
     let stdout = child
         .stdout
         .take()
@@ -311,6 +313,11 @@ fn run_turn(
             _ => {}
         }
     }
+
+    // Kill Codex process tree (including any cmd.exe / bash children) before waiting.
+    // Without this, child processes spawned by Codex survive as orphan processes.
+    crate::services::claude::kill_pid_tree(child_pid);
+    std::thread::sleep(std::time::Duration::from_millis(200));
 
     let wait = child
         .wait_with_output()

--- a/src/services/session_backend.rs
+++ b/src/services/session_backend.rs
@@ -122,6 +122,18 @@ impl SessionBackend for ProcessBackend {
             cmd.process_group(0); // new process group = wrapper PID
         }
 
+        #[cfg(not(unix))]
+        {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
+            // CREATE_NO_WINDOW gives the wrapper a hidden console that children
+            // inherit. Without this, every cmd.exe spawned by Claude/Codex
+            // creates its own *visible* console window when the parent process
+            // has no console (e.g. running as a Windows service via NSSM).
+            const CREATE_NO_WINDOW: u32 = 0x08000000;
+            cmd.creation_flags(CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
+        }
+
         let mut child = cmd
             .spawn()
             .map_err(|e| format!("Failed to spawn wrapper process: {}", e))?;

--- a/src/services/tmux_wrapper.rs
+++ b/src/services/tmux_wrapper.rs
@@ -397,10 +397,11 @@ pub fn run(
         Err(e) => format!("wait_error:{e}"),
     };
 
-    // Kill Claude if still running (handles case where output thread exited early
-    // due to fatal error while Claude is still waiting for stdin input)
-    let _ = child.kill();
-    let _ = child.wait();
+    // Kill Claude AND all its descendants (cmd.exe, bash, etc.).
+    // Using kill_child_tree() instead of child.kill() ensures that child processes
+    // spawned by Claude (e.g. cmd.exe on Windows, bash on Unix) are also terminated.
+    // Without this, those descendants survive as orphan processes.
+    crate::services::claude::kill_child_tree(&mut child);
 
     // Write exit reason file for recovery diagnostics
     let exit_reason_path = format!("{}.exit_reason", output_file);


### PR DESCRIPTION
## Summary

- **tmux_wrapper.rs**: Replace `child.kill()` with `kill_child_tree()` — kills Claude AND all its descendants (cmd.exe, bash), not just the direct child process. This is the root cause of orphan processes accumulating after session cleanup.
- **codex_tmux_wrapper.rs**: Add `kill_pid_tree(child_pid)` after the stdout read loop to clean up Codex's child processes before `wait_with_output()`.
- **session_backend.rs**: Add `CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP` flags on Windows. `CREATE_NO_WINDOW` gives the wrapper a hidden console that children inherit, preventing every cmd.exe spawned by Claude/Codex from creating its own visible console window (especially when running as a service with NSSM).
- **session_activity.rs**: Gate `tmux_session_has_live_pane` import behind `#[cfg(unix)]` — fixes Windows compilation.
- **cli/init.rs**: Add missing `PathBuf` import for Windows build.

## Problem

When a session ends, `child.kill()` only terminates the Claude/Codex CLI process — not its descendants. On Windows, this leaves `cmd.exe` processes running as orphans with visible console windows. Over time, dozens of windows accumulate on the desktop.

## Test plan

- [x] Verified `cargo check` passes on Windows (no new warnings)
- [ ] Run session, verify no orphan cmd.exe windows remain after `/stop` or `/clear`
- [ ] Run as Windows service (NSSM), verify no visible console windows appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)