### PR TITLE
fix: process tree cleanup + Windows build/runtime fixes

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::io::{self, BufRead, Write as IoWrite};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use super::dcserver;
 

--- a/src/server/routes/session_activity.rs
+++ b/src/server/routes/session_activity.rs
@@ -3,6 +3,7 @@ use std::process::Command;
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 
+#[cfg(unix)]
 use crate::services::tmux_diagnostics::tmux_session_has_live_pane;
 
 const REMOTE_HEARTBEAT_GRACE_SECS: i64 = 90;
@@ -39,7 +40,10 @@ impl SessionActivityResolver {
             if let Some(cached) = cache.get(tmux_name) {
                 return *cached;
             }
+            #[cfg(unix)]
             let live = tmux_session_has_live_pane(tmux_name);
+            #[cfg(not(unix))]
+            let live = false; // tmux not available on Windows
             cache.insert(tmux_name.to_string(), live);
             live
         };

--- a/src/services/codex_tmux_wrapper.rs
+++ b/src/services/codex_tmux_wrapper.rs
@@ -224,6 +224,8 @@ fn run_turn(
         .spawn()
         .map_err(|e| format!("Failed to start Codex: {}", e))?;
 
+    let child_pid = child.id();
+
     let stdout = child
         .stdout
         .take()
@@ -311,6 +313,11 @@ fn run_turn(
             _ => {}
         }
     }
+
+    // Kill Codex process tree (including any cmd.exe / bash children) before waiting.
+    // Without this, child processes spawned by Codex survive as orphan processes.
+    crate::services::claude::kill_pid_tree(child_pid);
+    std::thread::sleep(std::time::Duration::from_millis(200));
 
     let wait = child
         .wait_with_output()

--- a/src/services/session_backend.rs
+++ b/src/services/session_backend.rs
@@ -122,6 +122,18 @@ impl SessionBackend for ProcessBackend {
             cmd.process_group(0); // new process group = wrapper PID
         }
 
+        #[cfg(not(unix))]
+        {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
+            // CREATE_NO_WINDOW gives the wrapper a hidden console that children
+            // inherit. Without this, every cmd.exe spawned by Claude/Codex
+            // creates its own *visible* console window when the parent process
+            // has no console (e.g. running as a Windows service via NSSM).
+            const CREATE_NO_WINDOW: u32 = 0x08000000;
+            cmd.creation_flags(CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
+        }
+
         let mut child = cmd
             .spawn()
             .map_err(|e| format!("Failed to spawn wrapper process: {}", e))?;

--- a/src/services/tmux_wrapper.rs
+++ b/src/services/tmux_wrapper.rs
@@ -397,10 +397,11 @@ pub fn run(
         Err(e) => format!("wait_error:{e}"),
     };
 
-    // Kill Claude if still running (handles case where output thread exited early
-    // due to fatal error while Claude is still waiting for stdin input)
-    let _ = child.kill();
-    let _ = child.wait();
+    // Kill Claude AND all its descendants (cmd.exe, bash, etc.).
+    // Using kill_child_tree() instead of child.kill() ensures that child processes
+    // spawned by Claude (e.g. cmd.exe on Windows, bash on Unix) are also terminated.
+    // Without this, those descendants survive as orphan processes.
+    crate::services::claude::kill_child_tree(&mut child);
 
     // Write exit reason file for recovery diagnostics
     let exit_reason_path = format!("{}.exit_reason", output_file);


### PR DESCRIPTION
## Summary

5 fixes for process cleanup and Windows support:

1. **tmux_wrapper.rs** — Replace `child.kill()` with `kill_child_tree()`. Previously only the direct child (Claude CLI) was killed; its descendants (cmd.exe, bash) survived as orphans.
2. **codex_tmux_wrapper.rs** — Add `kill_pid_tree()` after stdout read loop to clean up Codex's child processes.
3. **session_backend.rs** — Add `CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP` flags on Windows. Prevents cmd.exe spawned by Claude/Codex from creating visible console windows (especially when running as a service via NSSM).
4. **session_activity.rs** — Gate `tmux_session_has_live_pane` behind `#[cfg(unix)]` to fix Windows compilation error.
5. **cli/init.rs** — Add missing `PathBuf` import for Windows build.

## Problem

- (1, 2) When a session ends, `child.kill()` only terminates Claude/Codex — not their child processes. On Windows this causes cmd.exe windows to accumulate; on Unix the orphans consume resources until reaped.
- (3) Without `CREATE_NO_WINDOW`, every cmd.exe spawned by Claude/Codex creates its own visible console window when the parent has no console (service mode).
- (4, 5) `cargo check` fails on Windows due to missing cfg guard and import.

## Test plan

- [x] `cargo check` passes on Windows
- [ ] Run session, verify no orphan cmd.exe windows after `/stop` or `/clear`
- [ ] Run as Windows service (NSSM), verify no visible console windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)