### PR TITLE
fix: dispatch outbox worker retries on Discord send failure (#174)

### DIFF
--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -483,5 +483,21 @@ pub fn migrate(conn: &Connection) -> Result<()> {
         }
     }
 
+    // #174: Add retry_count column to dispatch_outbox for retry tracking
+    {
+        let has_retry: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM pragma_table_info('dispatch_outbox') WHERE name = 'retry_count'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(false);
+        if !has_retry {
+            conn.execute_batch(
+                "ALTER TABLE dispatch_outbox ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0;",
+            )?;
+        }
+    }
+
     Ok(())
 }

--- a/src/server/routes/dispatches.rs
+++ b/src/server/routes/dispatches.rs
@@ -2038,11 +2038,31 @@ pub(crate) async fn dispatch_outbox_loop(db: crate::db::Db) {
                 .ok();
             }
 
+            let mut should_retry = false;
+
             match action.as_str() {
                 "notify" => {
                     if let (Some(ref aid), Some(ref cid), Some(ref t)) = (agent_id, card_id, title)
                     {
                         send_dispatch_to_discord(&db, aid, t, cid, &dispatch_id).await;
+
+                        // #174: Check if dispatch_notified marker was rolled back
+                        // (indicates Discord send failure). If absent, retry.
+                        let notified = db
+                            .lock()
+                            .ok()
+                            .and_then(|conn| {
+                                conn.query_row(
+                                    "SELECT 1 FROM kv_meta WHERE key = ?1",
+                                    [&format!("dispatch_notified:{dispatch_id}")],
+                                    |_| Ok(()),
+                                )
+                                .ok()
+                            })
+                            .is_some();
+                        if !notified {
+                            should_retry = true;
+                        }
                     }
                 }
                 "followup" => {
@@ -2053,13 +2073,56 @@ pub(crate) async fn dispatch_outbox_loop(db: crate::db::Db) {
                 }
             }
 
-            // Mark done
-            if let Ok(conn) = db.lock() {
-                conn.execute(
-                    "UPDATE dispatch_outbox SET status = 'done', processed_at = datetime('now') WHERE id = ?1",
-                    [id],
-                )
-                .ok();
+            // #174: Retry on transient Discord failure (max 3 attempts)
+            if should_retry {
+                let retry_count: i64 = db
+                    .lock()
+                    .ok()
+                    .and_then(|conn| {
+                        conn.query_row(
+                            "SELECT retry_count FROM dispatch_outbox WHERE id = ?1",
+                            [id],
+                            |row| row.get(0),
+                        )
+                        .ok()
+                    })
+                    .unwrap_or(0);
+
+                if retry_count < 3 {
+                    if let Ok(conn) = db.lock() {
+                        conn.execute(
+                            "UPDATE dispatch_outbox SET status = 'pending', retry_count = retry_count + 1, \
+                             error = 'Discord send failed, will retry' WHERE id = ?1",
+                            [id],
+                        )
+                        .ok();
+                    }
+                    tracing::warn!(
+                        "[dispatch-outbox] Discord send failed for {dispatch_id}, retry {}/3",
+                        retry_count + 1
+                    );
+                } else {
+                    if let Ok(conn) = db.lock() {
+                        conn.execute(
+                            "UPDATE dispatch_outbox SET status = 'failed', processed_at = datetime('now'), \
+                             error = 'Discord send failed after 3 retries' WHERE id = ?1",
+                            [id],
+                        )
+                        .ok();
+                    }
+                    tracing::warn!(
+                        "[dispatch-outbox] Discord send failed for {dispatch_id} after 3 retries, marking failed"
+                    );
+                }
+            } else {
+                // Mark done
+                if let Ok(conn) = db.lock() {
+                    conn.execute(
+                        "UPDATE dispatch_outbox SET status = 'done', processed_at = datetime('now') WHERE id = ?1",
+                        [id],
+                    )
+                    .ok();
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- dispatch outbox worker가 Discord 전송 실패 시 outbox entry를 `done`으로 마킹하여 재시도 불가능했던 버그 수정
- `dispatch_notified` 마커 존재 여부로 성공/실패 판단 → 실패 시 `pending`으로 되돌려 재시도
- 최대 3회 재시도 후 `failed` 상태 + 경고 로그

## Changed files
- `src/db/schema.rs` — `dispatch_outbox` 테이블에 `retry_count` 컬럼 마이그레이션
- `src/server/routes/dispatches.rs` — outbox worker 재시도 로직

## Test plan
- [ ] Discord 전송 실패 시 outbox entry가 `pending`으로 되돌아감 확인
- [ ] 3회 초과 실패 시 `failed` 상태 마킹 확인
- [ ] 정상 전송 시 기존 `done` 처리 변경 없음

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)