### PR TITLE
refactor: card_review_state 쓰기 권한 Rust 단일화 — JS direct SQL write 차단 (#158)

### DIFF
--- a/src/engine/intent.rs
+++ b/src/engine/intent.rs
@@ -383,9 +383,11 @@ fn execute_sql(db: &crate::db::Db, sql: &str, params: &[serde_json::Value]) -> a
         ));
     }
     // Block direct card_review_state mutation (#158 — same guard as ops.rs)
-    if sql_upper.contains("CARD_REVIEW_STATE")
-        && (sql_upper.contains("INSERT") || sql_upper.contains("UPDATE"))
-    {
+    let re_review_state = regex::Regex::new(
+        r"(?i)\b(?:INSERT(?:\s+OR\s+REPLACE)?\s+INTO|UPDATE|DELETE\s+FROM)\s+card_review_state\b",
+    )
+    .unwrap();
+    if re_review_state.is_match(sql) {
         return Err(anyhow::anyhow!(
             "Direct card_review_state mutation is blocked. Use reviewState.sync bridge."
         ));
@@ -703,5 +705,30 @@ mod tests {
             dispatch_id.is_none(),
             "idle state must clear pending_dispatch_id"
         );
+    }
+
+    // #158: ExecuteSQL guard blocks direct card_review_state INSERT OR REPLACE
+    #[test]
+    fn test_blocked_card_review_state_insert_or_replace_sql() {
+        let db = test_db();
+        let intents = vec![Intent::ExecuteSQL {
+            sql: "INSERT OR REPLACE INTO card_review_state (card_id, state) VALUES ('c1', 'idle')"
+                .into(),
+            params: vec![],
+        }];
+        let result = execute_intents(&db, intents);
+        assert_eq!(result.errors, 1);
+    }
+
+    // #158: ExecuteSQL guard blocks direct card_review_state DELETE
+    #[test]
+    fn test_blocked_card_review_state_delete_sql() {
+        let db = test_db();
+        let intents = vec![Intent::ExecuteSQL {
+            sql: "DELETE FROM card_review_state WHERE card_id = 'c1'".into(),
+            params: vec![],
+        }];
+        let result = execute_intents(&db, intents);
+        assert_eq!(result.errors, 1);
     }
 }

--- a/src/engine/ops.rs
+++ b/src/engine/ops.rs
@@ -126,8 +126,8 @@ fn register_db_ops<'js>(ctx: &Ctx<'js>, db: Db) -> JsResult<()> {
                 if (/(?:INSERT\s+INTO|UPDATE)\s+task_dispatches\b/i.test(sql)) {
                     throw new Error("Direct task_dispatches mutation is blocked. Use agentdesk.dispatch.create() instead.");
                 }
-                // Block direct INSERT/UPDATE on card_review_state — use agentdesk.reviewState.sync() instead (#158).
-                if (/(?:INSERT\s+INTO|UPDATE)\s+card_review_state\b/i.test(sql)) {
+                // Block direct INSERT/UPDATE/DELETE on card_review_state — use agentdesk.reviewState.sync() instead (#158).
+                if (/(?:INSERT(?:\s+OR\s+REPLACE)?\s+INTO|UPDATE|DELETE\s+FROM)\s+card_review_state\b/i.test(sql)) {
                     throw new Error("Direct card_review_state mutation is blocked. Use agentdesk.reviewState.sync(cardId, state, opts) instead.");
                 }
                 // Direct write — db.execute remains synchronous by design.
@@ -805,10 +805,14 @@ mod tests {
         )
         .unwrap();
 
-        let n =
-            review_state_sync_on_conn(&conn, "rs-1", "idle", None, None, None, None, None, None)
-                .unwrap();
-        assert_eq!(n, 1);
+        let result = review_state_sync_on_conn(
+            &conn,
+            &serde_json::json!({"card_id": "rs-1", "state": "idle"}).to_string(),
+        );
+        assert!(
+            result.contains("\"ok\":true"),
+            "sync should succeed: {result}"
+        );
 
         let (state, pd): (String, Option<String>) = conn
             .query_row(
@@ -821,6 +825,47 @@ mod tests {
         assert!(pd.is_none(), "idle should clear pending_dispatch_id");
     }
 
+    // #158: leaving suggestion_pending must clear stale pending_dispatch_id
+    #[test]
+    fn test_review_state_sync_non_suggestion_pending_clears_pending_dispatch_id() {
+        let db = test_db();
+        let conn = db.separate_conn().unwrap();
+        seed_card_for_review(&conn, "rs-1b");
+        conn.execute(
+            "INSERT INTO card_review_state (card_id, state, pending_dispatch_id, updated_at) \
+             VALUES ('rs-1b', 'suggestion_pending', 'disp-2', datetime('now'))",
+            [],
+        )
+        .unwrap();
+
+        let result = review_state_sync_on_conn(
+            &conn,
+            &serde_json::json!({
+                "card_id": "rs-1b",
+                "state": "rework_pending",
+                "last_decision": "pm_rework"
+            })
+            .to_string(),
+        );
+        assert!(
+            result.contains("\"ok\":true"),
+            "sync should succeed: {result}"
+        );
+
+        let (state, pd): (String, Option<String>) = conn
+            .query_row(
+                "SELECT state, pending_dispatch_id FROM card_review_state WHERE card_id = 'rs-1b'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(state, "rework_pending");
+        assert!(
+            pd.is_none(),
+            "non-suggestion_pending states must clear stale pending_dispatch_id"
+        );
+    }
+
     // #158: review_state_sync_on_conn — reviewing state auto-sets review_entered_at
     #[test]
     fn test_review_state_sync_reviewing() {
@@ -828,8 +873,12 @@ mod tests {
         let conn = db.separate_conn().unwrap();
         seed_card_for_review(&conn, "rs-2");
 
-        review_state_sync_on_conn(&conn, "rs-2", "reviewing", Some(1), None, None, None, None, None)
-            .unwrap();
+        let result = review_state_sync_on_conn(
+            &conn,
+            &serde_json::json!({"card_id": "rs-2", "state": "reviewing", "review_round": 1})
+                .to_string(),
+        );
+        assert!(result.contains("\"ok\":true"));
 
         let (state, rr, entered): (String, Option<i64>, Option<String>) = conn
             .query_row(
@@ -859,18 +908,14 @@ mod tests {
         )
         .unwrap();
 
-        review_state_sync_on_conn(
+        let result = review_state_sync_on_conn(
             &conn,
-            "rs-3",
-            "clear_verdict",
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        )
-        .unwrap();
+            &serde_json::json!({"card_id": "rs-3", "state": "clear_verdict"}).to_string(),
+        );
+        assert!(
+            result.contains("\"ok\":true"),
+            "sync should succeed: {result}"
+        );
 
         let (state, verdict): (String, Option<String>) = conn
             .query_row(
@@ -1425,6 +1470,18 @@ pub fn review_state_sync_on_conn(conn: &rusqlite::Connection, json_str: &str) ->
         return r#"{"error":"card_id and state are required"}"#.to_string();
     }
 
+    // Special case: clear_verdict only NULLs last_verdict without changing state
+    if state == "clear_verdict" {
+        let result = conn.execute(
+            "UPDATE card_review_state SET last_verdict = NULL, updated_at = datetime('now') WHERE card_id = ?1",
+            rusqlite::params![card_id],
+        );
+        return match result {
+            Ok(n) => format!(r#"{{"ok":true,"rows_affected":{n}}}"#),
+            Err(e) => format!(r#"{{"error":"sql error: {}"}}"#, e),
+        };
+    }
+
     // Build dynamic SET clause based on provided fields
     let review_round = params["review_round"].as_i64();
     let last_verdict = params["last_verdict"].as_str();
@@ -1442,7 +1499,11 @@ pub fn review_state_sync_on_conn(conn: &rusqlite::Connection, json_str: &str) ->
          review_round = COALESCE(?3, review_round), \
          last_verdict = COALESCE(?4, last_verdict), \
          last_decision = COALESCE(?5, last_decision), \
-         pending_dispatch_id = CASE WHEN ?2 = 'idle' THEN NULL ELSE COALESCE(?6, pending_dispatch_id) END, \
+         pending_dispatch_id = CASE \
+             WHEN ?6 IS NOT NULL THEN ?6 \
+             WHEN ?2 = 'suggestion_pending' THEN pending_dispatch_id \
+             ELSE NULL \
+         END, \
          approach_change_round = COALESCE(?7, approach_change_round), \
          review_entered_at = COALESCE(?8, CASE WHEN ?2 = 'reviewing' THEN datetime('now') ELSE review_entered_at END), \
          updated_at = datetime('now')",

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -994,7 +994,10 @@ mod tests {
     // ── #158: card_review_state write centralisation tests ──────────
 
     /// Helper: query card_review_state for a card.
-    fn get_review_state(db: &db::Db, card_id: &str) -> Option<(String, Option<String>, Option<String>)> {
+    fn get_review_state(
+        db: &db::Db,
+        card_id: &str,
+    ) -> Option<(String, Option<String>, Option<String>)> {
         let conn = db.lock().unwrap();
         conn.query_row(
             "SELECT state, last_verdict, last_decision FROM card_review_state WHERE card_id = ?1",
@@ -1017,9 +1020,13 @@ mod tests {
             &db,
             r#"{"card_id":"card-158a","state":"reviewing","review_round":1}"#,
         );
-        assert!(result.contains("\"ok\":true"), "sync to reviewing must succeed: {result}");
+        assert!(
+            result.contains("\"ok\":true"),
+            "sync to reviewing must succeed: {result}"
+        );
 
-        let (state, _, _) = get_review_state(&db, "card-158a").expect("card_review_state row must exist");
+        let (state, _, _) =
+            get_review_state(&db, "card-158a").expect("card_review_state row must exist");
         assert_eq!(state, "reviewing", "bridge must create reviewing state");
 
         // Step 2: Update with verdict
@@ -1027,28 +1034,35 @@ mod tests {
             &db,
             r#"{"card_id":"card-158a","state":"suggestion_pending","last_verdict":"improve"}"#,
         );
-        assert!(result2.contains("\"ok\":true"), "sync to suggestion_pending must succeed: {result2}");
+        assert!(
+            result2.contains("\"ok\":true"),
+            "sync to suggestion_pending must succeed: {result2}"
+        );
 
         let (state2, verdict, _) = get_review_state(&db, "card-158a").unwrap();
         assert_eq!(state2, "suggestion_pending");
         assert_eq!(verdict.as_deref(), Some("improve"));
 
         // Step 3: Set to idle — must clear pending_dispatch_id
-        let result3 = crate::engine::ops::review_state_sync(
-            &db,
-            r#"{"card_id":"card-158a","state":"idle"}"#,
+        let result3 =
+            crate::engine::ops::review_state_sync(&db, r#"{"card_id":"card-158a","state":"idle"}"#);
+        assert!(
+            result3.contains("\"ok\":true"),
+            "sync to idle must succeed: {result3}"
         );
-        assert!(result3.contains("\"ok\":true"), "sync to idle must succeed: {result3}");
 
         let (state3, _, _) = get_review_state(&db, "card-158a").unwrap();
         assert_eq!(state3, "idle", "bridge must allow idle transition");
 
         // Step 4: Verify JS bridge is registered and callable (smoke test)
         let engine = test_engine(&db);
-        let js_check: String = engine.eval_js(
-            r#"typeof agentdesk.reviewState.sync === "function" ? "ok" : "missing""#
-        ).unwrap();
-        assert_eq!(js_check, "ok", "agentdesk.reviewState.sync must be registered as a function");
+        let js_check: String = engine
+            .eval_js(r#"typeof agentdesk.reviewState.sync === "function" ? "ok" : "missing""#)
+            .unwrap();
+        assert_eq!(
+            js_check, "ok",
+            "agentdesk.reviewState.sync must be registered as a function"
+        );
     }
 
     /// #158: ExecuteSQL intent rejects direct card_review_state mutations.
@@ -1064,15 +1078,44 @@ mod tests {
             params: vec![],
         };
         let result = crate::engine::intent::execute_intents(&db, vec![insert_intent]);
-        assert_eq!(result.errors, 1, "INSERT into card_review_state via ExecuteSQL must be rejected");
+        assert_eq!(
+            result.errors, 1,
+            "INSERT into card_review_state via ExecuteSQL must be rejected"
+        );
+
+        // Attempt INSERT OR REPLACE via ExecuteSQL intent — must also fail
+        let replace_intent = crate::engine::intent::Intent::ExecuteSQL {
+            sql: "INSERT OR REPLACE INTO card_review_state (card_id, state, updated_at) VALUES ('card-158b', 'idle', datetime('now'))".to_string(),
+            params: vec![],
+        };
+        let result_replace = crate::engine::intent::execute_intents(&db, vec![replace_intent]);
+        assert_eq!(
+            result_replace.errors, 1,
+            "INSERT OR REPLACE into card_review_state via ExecuteSQL must be rejected"
+        );
 
         // Attempt UPDATE via ExecuteSQL intent — must also fail
         let update_intent = crate::engine::intent::Intent::ExecuteSQL {
-            sql: "UPDATE card_review_state SET state = 'idle' WHERE card_id = 'card-158b'".to_string(),
+            sql: "UPDATE card_review_state SET state = 'idle' WHERE card_id = 'card-158b'"
+                .to_string(),
             params: vec![],
         };
         let result2 = crate::engine::intent::execute_intents(&db, vec![update_intent]);
-        assert_eq!(result2.errors, 1, "UPDATE card_review_state via ExecuteSQL must be rejected");
+        assert_eq!(
+            result2.errors, 1,
+            "UPDATE card_review_state via ExecuteSQL must be rejected"
+        );
+
+        // Attempt DELETE via ExecuteSQL intent — must also fail
+        let delete_intent = crate::engine::intent::Intent::ExecuteSQL {
+            sql: "DELETE FROM card_review_state WHERE card_id = 'card-158b'".to_string(),
+            params: vec![],
+        };
+        let result3 = crate::engine::intent::execute_intents(&db, vec![delete_intent]);
+        assert_eq!(
+            result3.errors, 1,
+            "DELETE from card_review_state via ExecuteSQL must be rejected"
+        );
 
         // Verify no row was created
         assert!(
@@ -1102,7 +1145,28 @@ mod tests {
                 }
             "#)
             .unwrap();
-        assert_eq!(insert_result, "blocked", "JS db.execute INSERT into card_review_state must be blocked");
+        assert_eq!(
+            insert_result, "blocked",
+            "JS db.execute INSERT into card_review_state must be blocked"
+        );
+
+        // Try INSERT OR REPLACE via agentdesk.db.execute — must throw
+        let replace_result: String = engine
+            .eval_js(r#"
+                try {
+                    agentdesk.db.execute(
+                        "INSERT OR REPLACE INTO card_review_state (card_id, state, updated_at) VALUES ('card-158c', 'idle', datetime('now'))"
+                    );
+                    "unexpected_success"
+                } catch(e) {
+                    e.message.indexOf("card_review_state") >= 0 ? "blocked" : "wrong_error: " + e.message
+                }
+            "#)
+            .unwrap();
+        assert_eq!(
+            replace_result, "blocked",
+            "JS db.execute INSERT OR REPLACE into card_review_state must be blocked"
+        );
 
         // Try UPDATE via agentdesk.db.execute — must throw
         let update_result: String = engine
@@ -1117,7 +1181,28 @@ mod tests {
                 }
             "#)
             .unwrap();
-        assert_eq!(update_result, "blocked", "JS db.execute UPDATE on card_review_state must be blocked");
+        assert_eq!(
+            update_result, "blocked",
+            "JS db.execute UPDATE on card_review_state must be blocked"
+        );
+
+        // Try DELETE via agentdesk.db.execute — must throw
+        let delete_result: String = engine
+            .eval_js(r#"
+                try {
+                    agentdesk.db.execute(
+                        "DELETE FROM card_review_state WHERE card_id = 'card-158c'"
+                    );
+                    "unexpected_success"
+                } catch(e) {
+                    e.message.indexOf("card_review_state") >= 0 ? "blocked" : "wrong_error: " + e.message
+                }
+            "#)
+            .unwrap();
+        assert_eq!(
+            delete_result, "blocked",
+            "JS db.execute DELETE on card_review_state must be blocked"
+        );
 
         // Verify no row was created by blocked operations
         assert!(
@@ -1143,7 +1228,11 @@ mod tests {
             "d-158d",
             &serde_json::json!({"completion_source": "test_harness"}),
         );
-        assert!(result.is_ok(), "complete_dispatch should succeed: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "complete_dispatch should succeed: {:?}",
+            result.err()
+        );
 
         // Card should be in review
         assert_eq!(get_card_status(&db, "card-158d"), "review");
@@ -1151,15 +1240,64 @@ mod tests {
         // card_review_state must be "reviewing" (synced via single entrypoint during transition)
         let (state, _, _) = get_review_state(&db, "card-158d")
             .expect("card_review_state must exist after review transition");
-        assert_eq!(state, "reviewing", "canonical review state must be 'reviewing' after entering review");
+        assert_eq!(
+            state, "reviewing",
+            "canonical review state must be 'reviewing' after entering review"
+        );
 
         // Force card to done — review state must reset to idle
         assert!(
-            kanban::transition_status_with_opts(&db, &engine, "card-158d", "done", "test", true).is_ok()
+            kanban::transition_status_with_opts(&db, &engine, "card-158d", "done", "test", true)
+                .is_ok()
         );
         assert_eq!(get_card_status(&db, "card-158d"), "done");
 
         let (state2, _, _) = get_review_state(&db, "card-158d").unwrap();
-        assert_eq!(state2, "idle", "canonical review state must be 'idle' after terminal transition");
+        assert_eq!(
+            state2, "idle",
+            "canonical review state must be 'idle' after terminal transition"
+        );
+    }
+
+    /// #158: review-automation.js OnReviewEnter hook uses reviewState.sync bridge.
+    #[test]
+    fn scenario_158e_on_review_enter_js_hook_syncs_canonical_state() {
+        let db = test_db();
+        let engine = test_engine(&db);
+        seed_agent(&db);
+        seed_card(&db, "card-158e", "review");
+
+        kanban::fire_enter_hooks(&db, &engine, "card-158e", "review");
+
+        let (state, _, _) = get_review_state(&db, "card-158e")
+            .expect("card_review_state must exist after OnReviewEnter hook");
+        assert_eq!(
+            state, "reviewing",
+            "OnReviewEnter policy hook must sync canonical review state via bridge"
+        );
+
+        let conn = db.lock().unwrap();
+        let review_round: i64 = conn
+            .query_row(
+                "SELECT review_round FROM kanban_cards WHERE id = 'card-158e'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(review_round, 1, "OnReviewEnter must increment review_round");
+
+        let review_dispatch_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM task_dispatches \
+                 WHERE kanban_card_id = 'card-158e' AND dispatch_type = 'review' \
+                 AND status IN ('pending', 'dispatched')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            review_dispatch_count, 1,
+            "OnReviewEnter must create exactly one pending review dispatch"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- `card_review_state` 테이블의 모든 쓰기 경로를 `review_state_sync_on_conn()` 단일 entrypoint로 통합
- JS policies에서 direct SQL write 0개 — `agentdesk.reviewState.sync()` bridge 사용
- `ExecuteSQL` intent에서 `card_review_state` mutation 차단 guard 추가
- `dispatches.rs:send_review_result_to_primary()`의 마지막 direct SQL을 `review_state_sync()` 호출로 교체

## Changed files (11)
- `src/engine/ops.rs` — `review_state_sync_on_conn()` entrypoint + JS bridge
- `src/engine/intent.rs` — `ExecuteSQL` guard for card_review_state
- `src/engine/transition.rs` — `TransitionIntent::SyncReviewState`
- `src/server/routes/dispatches.rs` — direct SQL → `review_state_sync()` 교체
- `policies/kanban-rules.js`, `policies/timeouts.js` — bridge 호출 정리
- `src/integration_tests.rs` — guard 통합 테스트 추가

## Test plan
- [ ] JS policy에서 `agentdesk.reviewState.sync()` 통해 review-state 변경 동작 확인
- [ ] `ExecuteSQL`로 `card_review_state` direct mutation 시 reject 확인
- [ ] `dispatches.rs`의 direct write가 `review_state_sync()` 경유 확인
- [ ] 기존 review-automation, timeout, kanban-rules 시나리오 회귀 없음
- [ ] cargo build 통과

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)