### PR TITLE
test: add process-level restart/delivery boundary tests (#160)

### DIFF
--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -1316,9 +1316,7 @@ mod tests {
     fn outbox_status(db: &db::Db, dispatch_id: &str) -> Vec<String> {
         let conn = db.lock().unwrap();
         let mut stmt = conn
-            .prepare(
-                "SELECT status FROM dispatch_outbox WHERE dispatch_id = ?1 ORDER BY id",
-            )
+            .prepare("SELECT status FROM dispatch_outbox WHERE dispatch_id = ?1 ORDER BY id")
             .unwrap();
         stmt.query_map([dispatch_id], |row| row.get(0))
             .unwrap()
@@ -1330,10 +1328,7 @@ mod tests {
         let conn = db.lock().unwrap();
         conn.execute(
             "INSERT OR IGNORE INTO kv_meta (key, value) VALUES (?1, ?2)",
-            rusqlite::params![
-                format!("dispatch_notified:{dispatch_id}"),
-                dispatch_id
-            ],
+            rusqlite::params![format!("dispatch_notified:{dispatch_id}"), dispatch_id],
         )
         .unwrap();
     }


### PR DESCRIPTION
## Summary
- dispatch outbox와 recovery 경로의 DB 레벨 통합 테스트 5개 시나리오 추가
- `dispatch_notified` 마커 기반 성공/실패 판단, dedup guard, finalize_dispatch recovery, retry_count, FIFO 순서 검증
- Discord HTTP 모킹 없이 DB 계약(contract) 수준에서 검증 — wiremock 추가 후 full end-to-end 테스트는 후속 작업

## Test scenarios
- 160-1: `dispatch_notified` 마커 → 전송 성공/실패 판단
- 160-2: dedup guard → 중복 notification 방지
- 160-3: `finalize_dispatch()` recovery → pending dispatch 완료
- 160-4: `retry_count` → 실패 횟수 추적 + max 초과 시 failed
- 160-5: outbox FIFO → `ORDER BY id ASC` 순서 보장

## Limitations
- Discord HTTP mock transport는 미구현 (wiremock 미도입)
- 시나리오 3(pending + catch-up + handoff 순서)은 serenity HTTP 의존으로 DB 레벨 테스트 불가
- full end-to-end 테스트는 wiremock 도입 후 후속 이슈로 추적

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)