### PR TITLE
fix: block REPLACE INTO bypass on card_review_state guard (#158)

### DIFF
--- a/src/engine/intent.rs
+++ b/src/engine/intent.rs
@@ -384,7 +384,7 @@ fn execute_sql(db: &crate::db::Db, sql: &str, params: &[serde_json::Value]) -> a
     }
     // Block direct card_review_state mutation (#158 — same guard as ops.rs)
     let re_review_state = regex::Regex::new(
-        r"(?i)\b(?:INSERT(?:\s+OR\s+REPLACE)?\s+INTO|UPDATE|DELETE\s+FROM)\s+card_review_state\b",
+        r"(?i)\b(?:INSERT(?:\s+OR\s+REPLACE)?\s+INTO|REPLACE\s+INTO|UPDATE|DELETE\s+FROM)\s+card_review_state\b",
     )
     .unwrap();
     if re_review_state.is_match(sql) {
@@ -714,6 +714,18 @@ mod tests {
         let intents = vec![Intent::ExecuteSQL {
             sql: "INSERT OR REPLACE INTO card_review_state (card_id, state) VALUES ('c1', 'idle')"
                 .into(),
+            params: vec![],
+        }];
+        let result = execute_intents(&db, intents);
+        assert_eq!(result.errors, 1);
+    }
+
+    // #158: ExecuteSQL guard blocks direct card_review_state REPLACE INTO
+    #[test]
+    fn test_blocked_card_review_state_replace_into_sql() {
+        let db = test_db();
+        let intents = vec![Intent::ExecuteSQL {
+            sql: "REPLACE INTO card_review_state (card_id, state) VALUES ('c1', 'idle')".into(),
             params: vec![],
         }];
         let result = execute_intents(&db, intents);

--- a/src/engine/ops.rs
+++ b/src/engine/ops.rs
@@ -126,8 +126,8 @@ fn register_db_ops<'js>(ctx: &Ctx<'js>, db: Db) -> JsResult<()> {
                 if (/(?:INSERT\s+INTO|UPDATE)\s+task_dispatches\b/i.test(sql)) {
                     throw new Error("Direct task_dispatches mutation is blocked. Use agentdesk.dispatch.create() instead.");
                 }
-                // Block direct INSERT/UPDATE/DELETE on card_review_state — use agentdesk.reviewState.sync() instead (#158).
-                if (/(?:INSERT(?:\s+OR\s+REPLACE)?\s+INTO|UPDATE|DELETE\s+FROM)\s+card_review_state\b/i.test(sql)) {
+                // Block direct INSERT/REPLACE/UPDATE/DELETE on card_review_state — use agentdesk.reviewState.sync() instead (#158).
+                if (/(?:INSERT(?:\s+OR\s+REPLACE)?\s+INTO|REPLACE\s+INTO|UPDATE|DELETE\s+FROM)\s+card_review_state\b/i.test(sql)) {
                     throw new Error("Direct card_review_state mutation is blocked. Use agentdesk.reviewState.sync(cardId, state, opts) instead.");
                 }
                 // Direct write — db.execute remains synchronous by design.

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -1094,6 +1094,18 @@ mod tests {
             "INSERT OR REPLACE into card_review_state via ExecuteSQL must be rejected"
         );
 
+        // Attempt REPLACE INTO via ExecuteSQL intent — must also fail
+        let replace_into_intent = crate::engine::intent::Intent::ExecuteSQL {
+            sql: "REPLACE INTO card_review_state (card_id, state, updated_at) VALUES ('card-158b', 'idle', datetime('now'))".to_string(),
+            params: vec![],
+        };
+        let result_replace_into =
+            crate::engine::intent::execute_intents(&db, vec![replace_into_intent]);
+        assert_eq!(
+            result_replace_into.errors, 1,
+            "REPLACE INTO card_review_state via ExecuteSQL must be rejected"
+        );
+
         // Attempt UPDATE via ExecuteSQL intent — must also fail
         let update_intent = crate::engine::intent::Intent::ExecuteSQL {
             sql: "UPDATE card_review_state SET state = 'idle' WHERE card_id = 'card-158b'"
@@ -1166,6 +1178,24 @@ mod tests {
         assert_eq!(
             replace_result, "blocked",
             "JS db.execute INSERT OR REPLACE into card_review_state must be blocked"
+        );
+
+        // Try REPLACE INTO via agentdesk.db.execute — must throw
+        let replace_into_result: String = engine
+            .eval_js(r#"
+                try {
+                    agentdesk.db.execute(
+                        "REPLACE INTO card_review_state (card_id, state, updated_at) VALUES ('card-158c', 'idle', datetime('now'))"
+                    );
+                    "unexpected_success"
+                } catch(e) {
+                    e.message.indexOf("card_review_state") >= 0 ? "blocked" : "wrong_error: " + e.message
+                }
+            "#)
+            .unwrap();
+        assert_eq!(
+            replace_into_result, "blocked",
+            "JS db.execute REPLACE INTO card_review_state must be blocked"
         );
 
         // Try UPDATE via agentdesk.db.execute — must throw


### PR DESCRIPTION
## Summary
- `REPLACE INTO card_review_state` 구문이 기존 INSERT/INSERT OR REPLACE 가드를 우회하던 문제 수정
- JS(ops.rs)와 Rust(intent.rs) 양쪽 정규식에 `REPLACE\s+INTO` 패턴 추가
- 단위 테스트 및 통합 테스트 추가

## Test plan
- [ ] `cargo test` — 새 테스트 3개 통과 확인
- [ ] `REPLACE INTO card_review_state` SQL이 JS/Rust 양쪽에서 차단 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)