### PR TITLE
feat(discord): add interactive model picker UI

### DIFF
--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -16,8 +16,6 @@ use crate::services::tmux_diagnostics::{
     record_tmux_exit_reason, should_recreate_session_after_followup_fifo_error,
     tmux_session_exists, tmux_session_has_live_pane,
 };
-use crate::utils::format::safe_prefix;
-
 /// Cached path to the claude binary.
 /// Once resolved, reused for all subsequent calls.
 static CLAUDE_PATH: OnceLock<Option<String>> = OnceLock::new();
@@ -138,6 +136,7 @@ pub fn kill_child_tree(child: &mut std::process::Child) {
     let _ = child.wait();
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 #[derive(Debug, Clone)]
 pub struct ClaudeResponse {
     pub success: bool,
@@ -280,6 +279,7 @@ pub struct CancelToken {
     pub cancelled: std::sync::atomic::AtomicBool,
     pub child_pid: std::sync::Mutex<Option<u32>>,
     /// SSH cancel flag — set to true to signal remote execution to close the channel
+    #[allow(dead_code)]
     pub ssh_cancel: std::sync::Mutex<Option<std::sync::Arc<std::sync::atomic::AtomicBool>>>,
     /// tmux session name for cleanup on cancel
     pub tmux_session: std::sync::Mutex<Option<String>>,
@@ -355,6 +355,7 @@ pub const DEFAULT_ALLOWED_TOOLS: &[&str] = &[
 ];
 
 /// Execute a command using Claude CLI
+#[allow(dead_code)]
 pub fn execute_command(
     prompt: &str,
     session_id: Option<&str>,
@@ -491,6 +492,7 @@ IMPORTANT: Format your responses using Markdown for better readability:
 }
 
 /// Parse Claude CLI JSON output
+#[cfg_attr(not(test), allow(dead_code))]
 fn parse_claude_output(output: &str) -> ClaudeResponse {
     let mut session_id: Option<String> = None;
     let mut response_text = String::new();
@@ -530,6 +532,7 @@ fn parse_claude_output(output: &str) -> ClaudeResponse {
 }
 
 /// Check if Claude CLI is available
+#[allow(dead_code)]
 pub fn is_claude_available() -> bool {
     #[cfg(not(unix))]
     {
@@ -543,6 +546,7 @@ pub fn is_claude_available() -> bool {
 }
 
 /// Check if platform supports AI features
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn is_ai_supported() -> bool {
     cfg!(unix)
 }
@@ -2501,6 +2505,22 @@ pub(crate) static PROCESS_HANDLES: std::sync::LazyLock<
         std::collections::HashMap<String, crate::services::session_backend::SessionHandle>,
     >,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+pub fn terminate_local_session(session_name: &str) {
+    if let Some(handle) = PROCESS_HANDLES.lock().unwrap().remove(session_name) {
+        let crate::services::session_backend::SessionHandle::Process { pid, .. } = handle;
+        kill_pid_tree(pid);
+    }
+
+    #[cfg(unix)]
+    if tmux_session_exists(session_name) {
+        record_tmux_exit_reason(session_name, "model change requested fresh session");
+        let exact_target = tmux_exact_target(session_name);
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", &exact_target])
+            .status();
+    }
+}
 
 /// Execute Claude inside a tmux session on a remote host via SSH.
 /// NOTE: Remote SSH execution is not available in AgentDesk — always returns Err.

--- a/src/services/discord/commands/config.rs
+++ b/src/services/discord/commands/config.rs
@@ -1,624 +1,434 @@
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
-use poise::CreateReply;
 use poise::serenity_prelude as serenity;
 
 use super::super::formatting::{canonical_tool_name, risk_badge, send_long_message_ctx, tool_info};
+use super::super::model_catalog::{
+    SOURCE_DISPATCH_ROLE, SOURCE_PROVIDER_DEFAULT, SOURCE_ROLE_MAP, SOURCE_RUNTIME_OVERRIDE,
+    is_default_picker_value,
+};
 use super::super::settings::{resolve_role_binding, save_bot_settings};
 use super::super::{Context, Error, SharedData, check_auth, check_owner};
+use super::model_ui::{
+    build_model_picker_options, build_model_picker_summary_lines, has_pending_model_change,
+};
 use crate::services::provider::ProviderKind;
 
-const MODEL_CLEAR_KEYWORDS: &[&str] = &["default", "none", "clear"];
-const MODEL_INFO_KEYWORDS: &[&str] = &["info"];
-const MODEL_LIST_KEYWORDS: &[&str] = &["list"];
+const MODEL_PICKER_PENDING_TTL: Duration = Duration::from_secs(30 * 60);
 pub(in crate::services::discord) const MODEL_PICKER_CUSTOM_ID: &str = "agentdesk:model-picker";
+pub(in crate::services::discord) const MODEL_SUBMIT_CUSTOM_ID: &str = "agentdesk:model-submit";
 pub(in crate::services::discord) const MODEL_RESET_CUSTOM_ID: &str = "agentdesk:model-reset";
-
-#[derive(Clone, Copy)]
-struct ModelCatalogEntry {
-    value: &'static str,
-    label: &'static str,
-    description: &'static str,
+pub(in crate::services::discord) const MODEL_CANCEL_CUSTOM_ID: &str = "agentdesk:model-cancel";
+const MODEL_PICKER_SUBMIT_LABEL: &str = "저장";
+const MODEL_PICKER_RESET_LABEL: &str = "기본값";
+const MODEL_PICKER_CANCEL_LABEL: &str = "취소";
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::services::discord) enum ModelPickerAction {
+    Select,
+    Submit,
+    Reset,
+    Cancel,
 }
 
-// Curated from current official provider model docs as of 2026-03-27.
-const CLAUDE_MODEL_CATALOG: &[ModelCatalogEntry] = &[
-    ModelCatalogEntry {
-        value: "claude-opus-4-6",
-        label: "Claude Opus 4.6",
-        description: "latest flagship",
-    },
-    ModelCatalogEntry {
-        value: "claude-sonnet-4-6",
-        label: "Claude Sonnet 4.6",
-        description: "latest balanced model",
-    },
-    ModelCatalogEntry {
-        value: "claude-opus-4-5-20251101",
-        label: "Claude Opus 4.5",
-        description: "previous opus generation",
-    },
-    ModelCatalogEntry {
-        value: "claude-sonnet-4-5-20250929",
-        label: "Claude Sonnet 4.5",
-        description: "strong coding and agents",
-    },
-    ModelCatalogEntry {
-        value: "claude-haiku-4-5-20251001",
-        label: "Claude Haiku 4.5",
-        description: "latest fast model",
-    },
-    ModelCatalogEntry {
-        value: "claude-opus-4-1-20250805",
-        label: "Claude Opus 4.1",
-        description: "stable legacy opus",
-    },
-    ModelCatalogEntry {
-        value: "claude-opus-4-0",
-        label: "Claude Opus 4",
-        description: "older opus generation",
-    },
-    ModelCatalogEntry {
-        value: "claude-sonnet-4-0",
-        label: "Claude Sonnet 4",
-        description: "older balanced model",
-    },
-];
-
-const CODEX_MODEL_CATALOG: &[ModelCatalogEntry] = &[
-    ModelCatalogEntry {
-        value: "gpt-5.4",
-        label: "GPT-5.4",
-        description: "latest frontier model",
-    },
-    ModelCatalogEntry {
-        value: "gpt-5.4-pro",
-        label: "GPT-5.4 Pro",
-        description: "highest precision reasoning",
-    },
-    ModelCatalogEntry {
-        value: "gpt-5.4-mini",
-        label: "GPT-5.4 Mini",
-        description: "fast strong mini",
-    },
-    ModelCatalogEntry {
-        value: "gpt-5-mini",
-        label: "GPT-5 Mini",
-        description: "lower-latency general model",
-    },
-    ModelCatalogEntry {
-        value: "gpt-5",
-        label: "GPT-5",
-        description: "previous frontier baseline",
-    },
-    ModelCatalogEntry {
-        value: "gpt-5.3-codex",
-        label: "GPT-5.3 Codex",
-        description: "latest codex-specific model",
-    },
-    ModelCatalogEntry {
-        value: "gpt-5.2-codex",
-        label: "GPT-5.2 Codex",
-        description: "long-horizon coding",
-    },
-    ModelCatalogEntry {
-        value: "gpt-5.1-codex-max",
-        label: "GPT-5.1 Codex Max",
-        description: "best long-running agent",
-    },
-];
-
-const GEMINI_MODEL_CATALOG: &[ModelCatalogEntry] = &[
-    ModelCatalogEntry {
-        value: "gemini-3-flash-preview",
-        label: "Gemini 3 Flash Preview",
-        description: "latest general preview",
-    },
-    ModelCatalogEntry {
-        value: "gemini-2.5-pro",
-        label: "Gemini 2.5 Pro",
-        description: "best stable reasoning",
-    },
-    ModelCatalogEntry {
-        value: "gemini-2.5-flash",
-        label: "Gemini 2.5 Flash",
-        description: "stable fast model",
-    },
-    ModelCatalogEntry {
-        value: "gemini-2.5-flash-preview-09-2025",
-        label: "Gemini 2.5 Flash Preview",
-        description: "latest flash preview",
-    },
-    ModelCatalogEntry {
-        value: "gemini-2.5-flash-lite",
-        label: "Gemini 2.5 Flash-Lite",
-        description: "fastest cheap stable model",
-    },
-    ModelCatalogEntry {
-        value: "gemini-2.5-flash-lite-preview-09-2025",
-        label: "Gemini 2.5 Flash-Lite Preview",
-        description: "latest lite preview",
-    },
-    ModelCatalogEntry {
-        value: "gemini-2.5-flash-native-audio-preview-12-2025",
-        label: "Gemini 2.5 Flash Live",
-        description: "latest live audio model",
-    },
-    ModelCatalogEntry {
-        value: "gemini-flash-latest",
-        label: "Gemini Flash Latest",
-        description: "latest rolling flash alias",
-    },
-];
-
-const CLAUDE_MODEL_ALIASES: &[(&str, &str)] = &[
-    ("opus", "claude-opus-4-6"),
-    ("sonnet", "claude-sonnet-4-6"),
-    ("haiku", "claude-haiku-4-5-20251001"),
-];
-
-const CODEX_MODEL_ALIASES: &[(&str, &str)] = &[
-    ("gpt-5-codex", "gpt-5-codex"),
-    ("o3", "o3"),
-    ("o4-mini", "o4-mini"),
-];
-
-const GEMINI_MODEL_ALIASES: &[(&str, &str)] = &[
-    ("gemini-2.5-pro", "gemini-2.5-pro"),
-    ("gemini-2.5-flash", "gemini-2.5-flash"),
-    ("gemini-2.0-flash", "gemini-2.0-flash"),
-];
-
-pub(in crate::services::discord) fn provider_supports_model_override(
-    provider: &ProviderKind,
+pub(in crate::services::discord) fn same_model_override(
+    current: Option<&str>,
+    next: Option<&str>,
 ) -> bool {
-    matches!(
-        provider,
-        ProviderKind::Claude | ProviderKind::Codex | ProviderKind::Gemini
-    )
-}
-
-pub(in crate::services::discord) fn model_hint(provider: &ProviderKind) -> &'static str {
-    match provider {
-        ProviderKind::Claude => "default + 최신 Claude top 8",
-        ProviderKind::Codex => "default + 최신 Codex top 8",
-        ProviderKind::Gemini => "default + 최신 Gemini top 8",
-        ProviderKind::Unsupported(_) => "모델 이름 또는 default",
+    match (current, next) {
+        (None, None) => true,
+        (Some(lhs), Some(rhs)) => lhs.eq_ignore_ascii_case(rhs),
+        _ => false,
     }
 }
 
-fn known_models(provider: &ProviderKind) -> &'static [ModelCatalogEntry] {
-    match provider {
-        ProviderKind::Claude => CLAUDE_MODEL_CATALOG,
-        ProviderKind::Codex => CODEX_MODEL_CATALOG,
-        ProviderKind::Gemini => GEMINI_MODEL_CATALOG,
-        ProviderKind::Unsupported(_) => &[],
-    }
-}
-
-fn model_aliases(provider: &ProviderKind) -> &'static [(&'static str, &'static str)] {
-    match provider {
-        ProviderKind::Claude => CLAUDE_MODEL_ALIASES,
-        ProviderKind::Codex => CODEX_MODEL_ALIASES,
-        ProviderKind::Gemini => GEMINI_MODEL_ALIASES,
-        ProviderKind::Unsupported(_) => &[],
-    }
-}
-
-fn normalize_keyword<'a>(raw: &'a str, keywords: &[&str]) -> Option<&'a str> {
-    let trimmed = raw.trim();
-    if keywords.iter().any(|kw| kw.eq_ignore_ascii_case(trimmed)) {
-        Some(trimmed)
-    } else {
-        None
-    }
-}
-
-pub(in crate::services::discord) fn is_clear_model_keyword(raw: &str) -> bool {
-    normalize_keyword(raw, MODEL_CLEAR_KEYWORDS).is_some()
-}
-
-fn canonical_known_model(provider: &ProviderKind, raw: &str) -> Option<&'static str> {
-    let trimmed = raw.trim();
-    if let Some(entry) = known_models(provider)
-        .iter()
-        .find(|entry| entry.value.eq_ignore_ascii_case(trimmed))
-    {
-        return Some(entry.value);
-    }
-
-    model_aliases(provider)
-        .iter()
-        .find(|(alias, _)| alias.eq_ignore_ascii_case(trimmed))
-        .map(|(_, canonical)| *canonical)
-}
-
-fn looks_like_model_identifier(raw: &str) -> bool {
-    let trimmed = raw.trim();
-    !trimmed.is_empty()
-        && trimmed.len() <= 64
-        && trimmed
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | ':'))
-}
-
-pub(in crate::services::discord) fn validate_model_input(
-    provider: &ProviderKind,
-    raw: &str,
-) -> Result<String, String> {
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        return Err("Model name cannot be empty.".to_string());
-    }
-
-    if let Some(canonical) = canonical_known_model(provider, trimmed) {
-        return Ok(canonical.to_string());
-    }
-
-    if looks_like_model_identifier(trimmed) {
-        return Ok(trimmed.to_string());
-    }
-
-    Err(format!(
-        "Unrecognized model `{}` for {}.\n{}\nUse `/model list` to see known examples.",
-        trimmed,
-        provider.display_name(),
-        model_hint(provider)
-    ))
-}
-
-fn doctor_guidance_suffix(provider: &ProviderKind) -> String {
-    match provider.probe_runtime() {
-        Some(probe) if probe.binary_path.is_some() && probe.version.is_some() => String::new(),
-        _ => format!(
-            "\nRuntime check: `{}` CLI probe is unavailable. Try `agentdesk doctor` or `agentdesk doctor --json`.",
-            provider.as_str()
-        ),
-    }
-}
-
-fn runtime_probe_detail(provider: &ProviderKind) -> (String, String, String) {
-    match provider.probe_runtime() {
-        Some(probe) => {
-            let binary_path = probe
-                .binary_path
-                .unwrap_or_else(|| "(not found)".to_string());
-            let version = probe
-                .version
-                .unwrap_or_else(|| "(version unavailable)".to_string());
-            let runtime_status = if binary_path == "(not found)" {
-                "missing"
-            } else if version == "(version unavailable)" {
-                "degraded"
-            } else {
-                "ok"
-            };
-            (runtime_status.to_string(), binary_path, version)
-        }
-        None => (
-            "unsupported".to_string(),
-            "(unsupported)".to_string(),
-            "(unsupported)".to_string(),
-        ),
-    }
-}
-
-async fn effective_model_snapshot(
-    shared: &Arc<SharedData>,
-    channel_id: serenity::ChannelId,
-) -> (Option<String>, Option<String>, String, String, String) {
-    let override_model = shared.model_overrides.get(&channel_id).map(|v| v.clone());
-    let ch_name = {
-        let d = shared.core.lock().await;
-        d.sessions
-            .get(&channel_id)
-            .and_then(|s| s.channel_name.clone())
-    };
-    let role_model = resolve_role_binding(channel_id, ch_name.as_deref()).and_then(|rb| rb.model);
-    let effective = override_model
-        .as_deref()
-        .or(role_model.as_deref())
-        .unwrap_or("(default)")
-        .to_string();
-    let source = if override_model.is_some() {
-        "runtime override"
-    } else if role_model.is_some() {
-        "role-map"
-    } else {
-        "system default"
-    }
-    .to_string();
-    let default_model = role_model
-        .clone()
-        .unwrap_or_else(|| "system default".to_string());
-
-    (override_model, role_model, effective, source, default_model)
-}
-
-pub(in crate::services::discord) async fn build_model_status_message(
-    shared: &Arc<SharedData>,
-    channel_id: serenity::ChannelId,
-    provider: &ProviderKind,
-) -> String {
-    let (override_model, role_model, effective, source, _) =
-        effective_model_snapshot(shared, channel_id).await;
-
-    format!(
-        "Provider: **{}**\nModel: **{}**\nSource: **{}**\nRuntime override: `{}`\nRole default: `{}`\nApplies: next turn\n{}",
-        provider.display_name(),
-        effective,
-        source,
-        override_model.as_deref().unwrap_or("(none)"),
-        role_model.as_deref().unwrap_or("(none)"),
-        model_hint(provider)
-    )
-}
-
-pub(in crate::services::discord) async fn build_model_info_message(
-    shared: &Arc<SharedData>,
-    channel_id: serenity::ChannelId,
-    provider: &ProviderKind,
-) -> String {
-    let (override_model, role_model, effective, source, _) =
-        effective_model_snapshot(shared, channel_id).await;
-    let (runtime_status, binary_path, version) = runtime_probe_detail(provider);
-    let mut msg = format!(
-        "Provider: **{}**\nModel: **{}**\nSource: **{}**\nRuntime override: `{}`\nRole default: `{}`\nRuntime CLI: **{}**\nBinary: `{}`\nVersion: `{}`\nApplies: next turn\n{}",
-        provider.display_name(),
-        effective,
-        source,
-        override_model.as_deref().unwrap_or("(none)"),
-        role_model.as_deref().unwrap_or("(none)"),
-        runtime_status,
-        binary_path,
-        version,
-        model_hint(provider)
-    );
-    msg.push_str(&doctor_guidance_suffix(provider));
-    msg
-}
-
-pub(in crate::services::discord) fn build_model_list_message(provider: &ProviderKind) -> String {
-    let examples = known_models(provider);
-    let list = if examples.is_empty() {
-        "(no known examples)".to_string()
-    } else {
-        examples
-            .iter()
-            .map(|entry| format!("- {} — `{}`", entry.label, entry.value))
-            .collect::<Vec<_>>()
-            .join("\n")
-    };
-
-    format!(
-        "**{} model examples**\n{}\n{}\nUse `/model <name>` to set one for this channel.{}",
-        provider.display_name(),
-        list,
-        model_hint(provider),
-        doctor_guidance_suffix(provider)
-    )
-}
-
-fn build_model_picker_options(
+fn session_reset_required_for_model_change(
     provider: &ProviderKind,
     current_override: Option<&str>,
-) -> Vec<serenity::CreateSelectMenuOption> {
-    let mut options = vec![
-        serenity::CreateSelectMenuOption::new("default", "__default__")
-            .description("use role-map or system default")
-            .default_selection(current_override.is_none()),
-    ];
-
-    for entry in known_models(provider) {
-        let option = serenity::CreateSelectMenuOption::new(entry.label, entry.value)
-            .description(entry.description)
-            .default_selection(
-                current_override.is_some_and(|active| active.eq_ignore_ascii_case(entry.value)),
-            );
-        options.push(option);
+    next_override: Option<&str>,
+) -> bool {
+    if same_model_override(current_override, next_override) {
+        return false;
     }
 
-    options
+    if next_override.is_none() {
+        return !provider.default_model_behavior().resume_without_reset;
+    }
+
+    true
 }
 
-pub(in crate::services::discord) async fn build_model_picker_embed(
+// Source-label constants live in model_catalog; re-export locally for test readability.
+use SOURCE_DISPATCH_ROLE as DISPATCH_ROLE_OVERRIDE_SOURCE;
+use SOURCE_PROVIDER_DEFAULT as PROVIDER_DEFAULT_SOURCE;
+use SOURCE_ROLE_MAP as ROLE_MAP_SOURCE;
+use SOURCE_RUNTIME_OVERRIDE as RUNTIME_OVERRIDE_SOURCE;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(in crate::services::discord) struct EffectiveModelSnapshot {
+    pub(in crate::services::discord) override_model: Option<String>,
+    pub(in crate::services::discord) dispatch_role_model: Option<String>,
+    pub(in crate::services::discord) role_model: Option<String>,
+    pub(in crate::services::discord) effective: String,
+    pub(in crate::services::discord) source: &'static str,
+    pub(in crate::services::discord) default_model: String,
+    pub(in crate::services::discord) default_source: &'static str,
+}
+
+fn resolve_effective_model(
+    override_model: Option<&str>,
+    dispatch_role_model: Option<&str>,
+    role_model: Option<&str>,
+) -> (String, &'static str) {
+    if let Some(model) = override_model {
+        (model.to_string(), RUNTIME_OVERRIDE_SOURCE)
+    } else if let Some(model) = dispatch_role_model {
+        (model.to_string(), DISPATCH_ROLE_OVERRIDE_SOURCE)
+    } else if let Some(model) = role_model {
+        (model.to_string(), ROLE_MAP_SOURCE)
+    } else {
+        ("default".to_string(), PROVIDER_DEFAULT_SOURCE)
+    }
+}
+
+fn resolve_default_model(
+    dispatch_role_model: Option<&str>,
+    role_model: Option<&str>,
+) -> (String, &'static str) {
+    if let Some(model) = dispatch_role_model {
+        (model.to_string(), DISPATCH_ROLE_OVERRIDE_SOURCE)
+    } else if let Some(model) = role_model {
+        (model.to_string(), ROLE_MAP_SOURCE)
+    } else {
+        ("default".to_string(), PROVIDER_DEFAULT_SOURCE)
+    }
+}
+
+fn resolve_dispatch_role_model(
+    shared: &Arc<SharedData>,
+    channel_id: serenity::ChannelId,
+) -> Option<String> {
+    let override_channel = shared
+        .dispatch_role_overrides
+        .get(&channel_id)
+        .map(|value| *value)?;
+    resolve_role_binding(override_channel, None).and_then(|binding| binding.model)
+}
+
+pub(in crate::services::discord) async fn effective_model_snapshot(
+    shared: &Arc<SharedData>,
+    channel_id: serenity::ChannelId,
+) -> EffectiveModelSnapshot {
+    let override_model = shared
+        .model_overrides
+        .get(&channel_id)
+        .map(|value| value.clone());
+    let dispatch_role_model = resolve_dispatch_role_model(shared, channel_id);
+    let channel_name = {
+        let data = shared.core.lock().await;
+        data.sessions
+            .get(&channel_id)
+            .and_then(|session| session.channel_name.clone())
+    };
+    let role_model =
+        resolve_role_binding(channel_id, channel_name.as_deref()).and_then(|binding| binding.model);
+    let (effective, source) = resolve_effective_model(
+        override_model.as_deref(),
+        dispatch_role_model.as_deref(),
+        role_model.as_deref(),
+    );
+    let (default_model, default_source) =
+        resolve_default_model(dispatch_role_model.as_deref(), role_model.as_deref());
+
+    EffectiveModelSnapshot {
+        override_model,
+        dispatch_role_model,
+        role_model,
+        effective,
+        source,
+        default_model,
+        default_source,
+    }
+}
+
+fn runtime_model_for_turn(
+    provider: &ProviderKind,
+    effective_model: &str,
+    source: &'static str,
+) -> Option<String> {
+    if source == PROVIDER_DEFAULT_SOURCE && effective_model.eq_ignore_ascii_case("default") {
+        provider
+            .default_model_behavior()
+            .runtime_model
+            .map(ToString::to_string)
+    } else {
+        Some(effective_model.to_string())
+    }
+}
+
+pub(in crate::services::discord) async fn update_channel_model_override(
+    shared: &Arc<SharedData>,
+    token: &str,
+    channel_id: serenity::ChannelId,
+    provider: &ProviderKind,
+    next_override: Option<String>,
+) -> bool {
+    let current_override = shared
+        .model_overrides
+        .get(&channel_id)
+        .map(|value| value.clone());
+    if same_model_override(current_override.as_deref(), next_override.as_deref()) {
+        return false;
+    }
+
+    let reset_required = session_reset_required_for_model_change(
+        provider,
+        current_override.as_deref(),
+        next_override.as_deref(),
+    );
+
+    match next_override {
+        Some(model) => {
+            shared.model_overrides.insert(channel_id, model.clone());
+            let mut settings = shared.settings.write().await;
+            settings
+                .channel_model_overrides
+                .insert(channel_id.get().to_string(), model);
+            save_bot_settings(token, &settings);
+        }
+        None => {
+            shared.model_overrides.remove(&channel_id);
+            let mut settings = shared.settings.write().await;
+            settings
+                .channel_model_overrides
+                .remove(&channel_id.get().to_string());
+            save_bot_settings(token, &settings);
+        }
+    }
+
+    if reset_required {
+        shared.model_session_reset_pending.insert(channel_id);
+    } else {
+        shared.model_session_reset_pending.remove(&channel_id);
+    }
+
+    true
+}
+
+pub(in crate::services::discord) async fn resolve_model_for_turn(
     shared: &Arc<SharedData>,
     channel_id: serenity::ChannelId,
     provider: &ProviderKind,
-) -> serenity::CreateEmbed {
-    let (_, _, effective, source, default_model) =
-        effective_model_snapshot(shared, channel_id).await;
-    let mut description = format!(
-        "Provider: **{}** (fixed)\nCurrent model: **{}**\nDefault: **{}**\nSource: **{}**\nApply: next turn\n\nSelect menu changes the server value immediately.",
-        provider.display_name(),
-        effective,
-        default_model,
-        source,
+) -> Option<String> {
+    let snapshot = effective_model_snapshot(shared, channel_id).await;
+    runtime_model_for_turn(provider, &snapshot.effective, snapshot.source)
+}
+
+fn prune_model_picker_pending(shared: &Arc<SharedData>) {
+    let now = Instant::now();
+    let expired: Vec<_> = shared
+        .model_picker_pending
+        .iter()
+        .filter_map(|entry| {
+            if now.duration_since(entry.updated_at) > MODEL_PICKER_PENDING_TTL {
+                Some(*entry.key())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    for message_id in expired {
+        shared.model_picker_pending.remove(&message_id);
+    }
+}
+
+pub(in crate::services::discord) fn remember_model_picker_pending(
+    shared: &Arc<SharedData>,
+    message_id: serenity::MessageId,
+    owner_user_id: serenity::UserId,
+    target_channel_id: serenity::ChannelId,
+    pending_model: Option<String>,
+) {
+    prune_model_picker_pending(shared);
+    shared.model_picker_pending.insert(
+        message_id,
+        super::super::ModelPickerPendingState {
+            owner_user_id,
+            target_channel_id,
+            pending_model,
+            updated_at: Instant::now(),
+        },
     );
-    let doctor_hint = doctor_guidance_suffix(provider);
-    if !doctor_hint.is_empty() {
-        description.push_str(&format!("\n{}", doctor_hint.trim()));
+}
+
+pub(in crate::services::discord) fn clear_model_picker_pending(
+    shared: &Arc<SharedData>,
+    message_id: serenity::MessageId,
+) {
+    shared.model_picker_pending.remove(&message_id);
+}
+
+pub(in crate::services::discord) fn model_picker_pending_to_override(
+    pending_model: Option<&str>,
+) -> Option<Option<String>> {
+    match pending_model {
+        None => None,
+        Some(value) if is_default_picker_value(value) => Some(None),
+        Some(value) => Some(Some(value.to_string())),
+    }
+}
+
+fn provider_card_color(provider: &ProviderKind) -> u32 {
+    match provider {
+        ProviderKind::Claude => 0xD97706,
+        ProviderKind::Codex => 0x10B981,
+        ProviderKind::Gemini => 0x3B82F6,
+        ProviderKind::Unsupported(_) => 0x5865F2,
+    }
+}
+
+pub(in crate::services::discord) fn build_model_picker_custom_id(
+    target_channel_id: serenity::ChannelId,
+) -> String {
+    format!("{}:{}", MODEL_PICKER_CUSTOM_ID, target_channel_id.get())
+}
+
+pub(in crate::services::discord) fn build_model_submit_custom_id(
+    target_channel_id: serenity::ChannelId,
+) -> String {
+    format!("{}:{}", MODEL_SUBMIT_CUSTOM_ID, target_channel_id.get())
+}
+
+pub(in crate::services::discord) fn build_model_reset_custom_id(
+    target_channel_id: serenity::ChannelId,
+) -> String {
+    format!("{}:{}", MODEL_RESET_CUSTOM_ID, target_channel_id.get())
+}
+
+pub(in crate::services::discord) fn build_model_cancel_custom_id(
+    target_channel_id: serenity::ChannelId,
+) -> String {
+    format!("{}:{}", MODEL_CANCEL_CUSTOM_ID, target_channel_id.get())
+}
+
+pub(in crate::services::discord) fn parse_model_picker_custom_id(
+    custom_id: &str,
+    fallback_channel_id: serenity::ChannelId,
+) -> Option<(ModelPickerAction, serenity::ChannelId)> {
+    fn parse_target(
+        custom_id: &str,
+        prefix: &str,
+        fallback_channel_id: serenity::ChannelId,
+    ) -> Option<serenity::ChannelId> {
+        if custom_id == prefix {
+            return Some(fallback_channel_id);
+        }
+
+        let raw_id = custom_id.strip_prefix(prefix)?.strip_prefix(':')?;
+        let parsed = raw_id.parse::<u64>().ok()?;
+        Some(serenity::ChannelId::new(parsed))
     }
 
+    parse_target(custom_id, MODEL_PICKER_CUSTOM_ID, fallback_channel_id)
+        .map(|channel_id| (ModelPickerAction::Select, channel_id))
+        .or_else(|| {
+            parse_target(custom_id, MODEL_SUBMIT_CUSTOM_ID, fallback_channel_id)
+                .map(|channel_id| (ModelPickerAction::Submit, channel_id))
+        })
+        .or_else(|| {
+            parse_target(custom_id, MODEL_RESET_CUSTOM_ID, fallback_channel_id)
+                .map(|channel_id| (ModelPickerAction::Reset, channel_id))
+        })
+        .or_else(|| {
+            parse_target(custom_id, MODEL_CANCEL_CUSTOM_ID, fallback_channel_id)
+                .map(|channel_id| (ModelPickerAction::Cancel, channel_id))
+        })
+}
+
+pub(in crate::services::discord) fn build_model_picker_embed_from_snapshot(
+    snapshot: &EffectiveModelSnapshot,
+    provider: &ProviderKind,
+    pending_model: Option<&str>,
+    notice: Option<&str>,
+) -> serenity::CreateEmbed {
+    let lines = build_model_picker_summary_lines(
+        provider,
+        &snapshot.effective,
+        pending_model,
+        snapshot.override_model.as_deref(),
+        notice,
+    );
     serenity::CreateEmbed::new()
         .title("Model Picker")
-        .description(description)
-        .color(0x5865F2)
+        .description(lines.join("\n"))
+        .color(provider_card_color(provider))
 }
 
-pub(in crate::services::discord) async fn build_model_picker_components(
-    shared: &Arc<SharedData>,
-    channel_id: serenity::ChannelId,
+pub(in crate::services::discord) fn build_model_picker_action_rows(
+    target_channel_id: serenity::ChannelId,
     provider: &ProviderKind,
+    pending_model: Option<&str>,
+    override_model: Option<&str>,
+    default_model: &str,
+    default_source: &'static str,
 ) -> Vec<serenity::CreateActionRow> {
-    let (override_model, _, _, _, _) = effective_model_snapshot(shared, channel_id).await;
     let menu = serenity::CreateSelectMenu::new(
-        MODEL_PICKER_CUSTOM_ID,
+        build_model_picker_custom_id(target_channel_id),
         serenity::CreateSelectMenuKind::String {
-            options: build_model_picker_options(provider, override_model.as_deref()),
+            options: build_model_picker_options(
+                provider,
+                pending_model,
+                override_model,
+                default_model,
+                default_source,
+            ),
         },
     )
-    .placeholder("Select a model override")
+    .placeholder("모델 선택")
     .min_values(1)
     .max_values(1);
 
-    let reset_button = serenity::CreateButton::new(MODEL_RESET_CUSTOM_ID)
-        .label("Reset to default")
+    let can_submit = has_pending_model_change(pending_model, override_model);
+
+    let submit_button =
+        serenity::CreateButton::new(build_model_submit_custom_id(target_channel_id))
+            .label(MODEL_PICKER_SUBMIT_LABEL)
+            .style(serenity::ButtonStyle::Primary)
+            .disabled(!can_submit);
+
+    let can_reset = override_model.is_some()
+        || pending_model.is_some_and(|pending| !is_default_picker_value(pending));
+    let reset_button = serenity::CreateButton::new(build_model_reset_custom_id(target_channel_id))
+        .label(MODEL_PICKER_RESET_LABEL)
         .style(serenity::ButtonStyle::Secondary)
-        .disabled(override_model.is_none());
+        .disabled(!can_reset);
+
+    let cancel_button =
+        serenity::CreateButton::new(build_model_cancel_custom_id(target_channel_id))
+            .label(MODEL_PICKER_CANCEL_LABEL)
+            .style(serenity::ButtonStyle::Danger);
 
     vec![
         serenity::CreateActionRow::SelectMenu(menu),
-        serenity::CreateActionRow::Buttons(vec![reset_button]),
+        serenity::CreateActionRow::Buttons(vec![submit_button, reset_button, cancel_button]),
     ]
 }
 
-async fn autocomplete_model<'a>(
-    ctx: Context<'a>,
-    partial: &'a str,
-) -> Vec<serenity::AutocompleteChoice> {
-    let mut choices = Vec::new();
-    let partial_lower = partial.to_ascii_lowercase();
-    let provider = &ctx.data().provider;
-
-    for keyword in ["info", "list", "default"] {
-        if partial.is_empty() || keyword.contains(&partial_lower) {
-            let label = format!(
-                "{} — {}",
-                keyword,
-                match keyword {
-                    "info" => "show provider, model, and source",
-                    "list" => "show known model examples",
-                    "default" => "clear runtime override",
-                    _ => "",
-                }
-            );
-            choices.push(serenity::AutocompleteChoice::new(
-                label,
-                keyword.to_string(),
-            ));
-        }
-    }
-
-    for entry in known_models(provider) {
-        if choices.len() >= 25 {
-            break;
-        }
-        let searchable = format!(
-            "{} {} {}",
-            entry.label.to_ascii_lowercase(),
-            entry.value.to_ascii_lowercase(),
-            entry.description.to_ascii_lowercase()
-        );
-        if partial.is_empty() || searchable.contains(&partial_lower) {
-            let label = format!("{} — {}", entry.label, entry.description);
-            choices.push(serenity::AutocompleteChoice::new(
-                label,
-                entry.value.to_string(),
-            ));
-        }
-    }
-
-    choices
-}
-
-/// /model — Set or view the model override for this channel
-#[poise::command(slash_command, rename = "model")]
-pub(in crate::services::discord) async fn cmd_model(
-    ctx: Context<'_>,
-    #[autocomplete = "autocomplete_model"]
-    #[description = "Model name or 'default' to clear"]
-    model: Option<String>,
-) -> Result<(), Error> {
-    let user_id = ctx.author().id;
-    let user_name = &ctx.author().name;
-    if !check_auth(user_id, user_name, &ctx.data().shared, &ctx.data().token).await {
-        return Ok(());
-    }
-
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    let channel_id = ctx.channel_id();
-
-    if !provider_supports_model_override(&ctx.data().provider) {
-        println!("  [{ts}] ◀ [{user_name}] /model (unsupported provider)");
-        ctx.say("Model override is only supported for Claude, Codex, and Gemini channels.")
-            .await?;
-        return Ok(());
-    }
-
-    match model {
-        Some(m) => {
-            println!("  [{ts}] ◀ [{user_name}] /model {m}");
-
-            if normalize_keyword(&m, MODEL_LIST_KEYWORDS).is_some() {
-                let embed =
-                    build_model_picker_embed(&ctx.data().shared, channel_id, &ctx.data().provider)
-                        .await;
-                let components = build_model_picker_components(
-                    &ctx.data().shared,
-                    channel_id,
-                    &ctx.data().provider,
-                )
-                .await;
-                ctx.send(CreateReply::default().embed(embed).components(components))
-                    .await?;
-                return Ok(());
-            }
-
-            if normalize_keyword(&m, MODEL_INFO_KEYWORDS).is_some() {
-                let msg =
-                    build_model_info_message(&ctx.data().shared, channel_id, &ctx.data().provider)
-                        .await;
-                ctx.say(msg).await?;
-                return Ok(());
-            }
-
-            if normalize_keyword(&m, MODEL_CLEAR_KEYWORDS).is_some() {
-                ctx.data().shared.model_overrides.remove(&channel_id);
-                let msg = build_model_status_message(
-                    &ctx.data().shared,
-                    channel_id,
-                    &ctx.data().provider,
-                )
-                .await;
-                ctx.say(format!("Model override cleared.\n{}", msg)).await?;
-                return Ok(());
-            }
-
-            let validated = match validate_model_input(&ctx.data().provider, &m) {
-                Ok(model) => model,
-                Err(message) => {
-                    ctx.say(message).await?;
-                    return Ok(());
-                }
-            };
-
-            ctx.data()
-                .shared
-                .model_overrides
-                .insert(channel_id, validated.clone());
-            let msg =
-                build_model_status_message(&ctx.data().shared, channel_id, &ctx.data().provider)
-                    .await;
-            ctx.say(format!(
-                "Model set to **{}** for this channel.\n{}",
-                validated, msg
-            ))
-            .await?;
-        }
-        None => {
-            println!("  [{ts}] ◀ [{user_name}] /model");
-            let embed =
-                build_model_picker_embed(&ctx.data().shared, channel_id, &ctx.data().provider)
-                    .await;
-            let components =
-                build_model_picker_components(&ctx.data().shared, channel_id, &ctx.data().provider)
-                    .await;
-            ctx.send(CreateReply::default().embed(embed).components(components))
-                .await?;
-        }
-    }
-    Ok(())
+pub(in crate::services::discord) fn build_model_picker_components_from_snapshot(
+    snapshot: &EffectiveModelSnapshot,
+    target_channel_id: serenity::ChannelId,
+    provider: &ProviderKind,
+    pending_model: Option<&str>,
+) -> Vec<serenity::CreateActionRow> {
+    build_model_picker_action_rows(
+        target_channel_id,
+        provider,
+        pending_model,
+        snapshot.override_model.as_deref(),
+        &snapshot.default_model,
+        snapshot.default_source,
+    )
 }
 
 /// /allowedtools — Show currently allowed tools
@@ -819,4 +629,428 @@ pub(in crate::services::discord) async fn cmd_removeuser(
         .await?;
     println!("  [{ts}] ▶ Removed user: {target_name} (id:{target_id})");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::services::discord::model_catalog::{
+        DEFAULT_PICKER_VALUE, known_models, validate_model_input,
+    };
+
+    use super::super::model_ui::{
+        build_model_picker_option_specs, build_model_picker_summary_lines,
+    };
+    use super::*;
+
+    #[test]
+    fn model_picker_custom_id_round_trip() {
+        let channel_id = serenity::ChannelId::new(123_456_789);
+        let custom_id = build_model_picker_custom_id(channel_id);
+        let parsed = parse_model_picker_custom_id(&custom_id, serenity::ChannelId::new(1));
+        assert_eq!(parsed, Some((ModelPickerAction::Select, channel_id)));
+    }
+
+    #[test]
+    fn model_reset_custom_id_round_trip() {
+        let channel_id = serenity::ChannelId::new(987_654_321);
+        let custom_id = build_model_reset_custom_id(channel_id);
+        let parsed = parse_model_picker_custom_id(&custom_id, serenity::ChannelId::new(1));
+        assert_eq!(parsed, Some((ModelPickerAction::Reset, channel_id)));
+    }
+
+    #[test]
+    fn model_submit_custom_id_round_trip() {
+        let channel_id = serenity::ChannelId::new(111_222_333);
+        let custom_id = build_model_submit_custom_id(channel_id);
+        let parsed = parse_model_picker_custom_id(&custom_id, serenity::ChannelId::new(1));
+        assert_eq!(parsed, Some((ModelPickerAction::Submit, channel_id)));
+    }
+
+    #[test]
+    fn model_cancel_custom_id_round_trip() {
+        let channel_id = serenity::ChannelId::new(777_888_999);
+        let custom_id = build_model_cancel_custom_id(channel_id);
+        let parsed = parse_model_picker_custom_id(&custom_id, serenity::ChannelId::new(1));
+        assert_eq!(parsed, Some((ModelPickerAction::Cancel, channel_id)));
+    }
+
+    #[test]
+    fn legacy_custom_id_uses_fallback_channel() {
+        let fallback = serenity::ChannelId::new(42);
+        let parsed = parse_model_picker_custom_id(MODEL_PICKER_CUSTOM_ID, fallback);
+        assert_eq!(parsed, Some((ModelPickerAction::Select, fallback)));
+    }
+
+    #[test]
+    fn model_picker_option_specs_include_default_first_for_all_supported_providers() {
+        for provider in [
+            ProviderKind::Claude,
+            ProviderKind::Codex,
+            ProviderKind::Gemini,
+        ] {
+            let options = build_model_picker_option_specs(
+                &provider,
+                None,
+                None,
+                "default",
+                PROVIDER_DEFAULT_SOURCE,
+            );
+            assert_eq!(options[0].value, DEFAULT_PICKER_VALUE);
+            assert_eq!(options[0].label, "기본값");
+            let expected = match provider {
+                ProviderKind::Claude => "오버라이드 해제 -> default (Claude default alias)",
+                ProviderKind::Codex | ProviderKind::Gemini => "오버라이드 해제 -> provider default",
+                ProviderKind::Unsupported(_) => unreachable!(),
+            };
+            assert_eq!(options[0].description, expected);
+            assert!(options[0].selected);
+        }
+    }
+
+    #[test]
+    fn model_picker_option_specs_show_role_map_default_metadata() {
+        let options = build_model_picker_option_specs(
+            &ProviderKind::Claude,
+            None,
+            Some("claude-sonnet-4-6"),
+            "claude-opus-4-6",
+            ROLE_MAP_SOURCE,
+        );
+        assert_eq!(options[0].label, "기본값");
+        assert_eq!(
+            options[0].description,
+            "오버라이드 해제 -> claude-opus-4-6 (role-map)"
+        );
+        assert!(!options[0].selected);
+        assert_eq!(options[1].value, "sonnet");
+    }
+
+    #[test]
+    fn model_picker_pending_to_override_interprets_default_sentinel() {
+        assert_eq!(
+            model_picker_pending_to_override(Some(DEFAULT_PICKER_VALUE)),
+            Some(None)
+        );
+        assert_eq!(
+            model_picker_pending_to_override(Some("gpt-5.4")),
+            Some(Some("gpt-5.4".to_string()))
+        );
+    }
+
+    #[test]
+    fn pending_model_change_treats_default_as_clear_override() {
+        assert!(!has_pending_model_change(None, None));
+        assert!(!has_pending_model_change(Some(DEFAULT_PICKER_VALUE), None));
+        assert!(has_pending_model_change(
+            Some(DEFAULT_PICKER_VALUE),
+            Some("gpt-5.4")
+        ));
+        assert!(!has_pending_model_change(Some("gpt-5.4"), Some("gpt-5.4")));
+        assert!(has_pending_model_change(
+            Some("gpt-5.4"),
+            Some("gpt-5.4-mini")
+        ));
+    }
+
+    #[test]
+    fn clearing_override_skips_session_reset_for_codex_and_gemini() {
+        assert!(!session_reset_required_for_model_change(
+            &ProviderKind::Codex,
+            Some("gpt-5.4"),
+            None,
+        ));
+        assert!(!session_reset_required_for_model_change(
+            &ProviderKind::Gemini,
+            Some("gemini-2.5-pro"),
+            None,
+        ));
+    }
+
+    #[test]
+    fn clearing_override_skips_session_reset_for_claude_default_alias() {
+        assert!(!session_reset_required_for_model_change(
+            &ProviderKind::Claude,
+            Some("opus"),
+            None,
+        ));
+    }
+
+    #[test]
+    fn runtime_turn_model_uses_claude_default_alias_after_clear() {
+        assert_eq!(
+            runtime_model_for_turn(&ProviderKind::Claude, "default", PROVIDER_DEFAULT_SOURCE),
+            Some("default".to_string())
+        );
+    }
+
+    #[test]
+    fn runtime_turn_model_omits_provider_default_for_codex_and_gemini() {
+        assert_eq!(
+            runtime_model_for_turn(&ProviderKind::Codex, "default", PROVIDER_DEFAULT_SOURCE),
+            None
+        );
+        assert_eq!(
+            runtime_model_for_turn(&ProviderKind::Gemini, "default", PROVIDER_DEFAULT_SOURCE),
+            None
+        );
+    }
+
+    #[test]
+    fn effective_resolution_prefers_dispatch_role_over_role_map() {
+        let (model, source) = resolve_effective_model(None, Some("gpt-5.4"), Some("gpt-5.4-mini"));
+        assert_eq!(model, "gpt-5.4");
+        assert_eq!(source, DISPATCH_ROLE_OVERRIDE_SOURCE);
+    }
+
+    #[test]
+    fn default_resolution_reports_provider_default_when_no_fallbacks_exist() {
+        let (model, source) = resolve_default_model(None, None);
+        assert_eq!(model, "default");
+        assert_eq!(source, PROVIDER_DEFAULT_SOURCE);
+    }
+
+    #[test]
+    fn validate_model_input_accepts_claude_1m_aliases_and_full_names() {
+        assert_eq!(
+            validate_model_input(&ProviderKind::Claude, "sonnet[1m]").unwrap(),
+            "sonnet[1m]"
+        );
+        assert_eq!(
+            validate_model_input(
+                &ProviderKind::Claude,
+                "anthropic.claude-sonnet-4-20250514-v1:0[1m]"
+            )
+            .unwrap(),
+            "anthropic.claude-sonnet-4-20250514-v1:0[1m]"
+        );
+    }
+
+    #[test]
+    fn validate_model_input_accepts_gemini_31_preview_and_auto_aliases() {
+        assert_eq!(
+            validate_model_input(&ProviderKind::Gemini, "gemini-3.1-pro-preview").unwrap(),
+            "gemini-3.1-pro-preview"
+        );
+        assert_eq!(
+            validate_model_input(&ProviderKind::Gemini, "auto").unwrap(),
+            "auto-gemini-3"
+        );
+        assert_eq!(
+            validate_model_input(&ProviderKind::Gemini, "pro").unwrap(),
+            "gemini-3.1-pro-preview"
+        );
+        assert_eq!(
+            validate_model_input(&ProviderKind::Gemini, "flash-lite").unwrap(),
+            "gemini-2.5-flash-lite"
+        );
+    }
+
+    #[test]
+    fn codex_catalog_includes_spark_preview_entry() {
+        let spark = known_models(&ProviderKind::Codex)
+            .iter()
+            .find(|entry| entry.value == "gpt-5.3-codex-spark")
+            .expect("spark entry missing");
+        assert_eq!(spark.label, "GPT-5.3-Codex-Spark");
+        let description = spark.picker_description();
+        assert!(description.to_ascii_lowercase().contains("text-only"));
+        assert!(description.contains("API"));
+    }
+
+    #[test]
+    fn all_catalog_entries_use_compact_pipe_summaries() {
+        for catalog in [
+            known_models(&ProviderKind::Claude),
+            known_models(&ProviderKind::Codex),
+            known_models(&ProviderKind::Gemini),
+        ] {
+            for entry in catalog {
+                let description = entry.picker_description();
+                assert!(
+                    description.matches('|').count() == 1,
+                    "description format drift for {}",
+                    entry.value
+                );
+                assert!(
+                    description.len() <= 100,
+                    "description too long for {}",
+                    entry.value
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn picker_options_keep_descriptions_in_dropdown_for_curated_models() {
+        let options = build_model_picker_option_specs(
+            &ProviderKind::Codex,
+            None,
+            None,
+            "gpt-5.4",
+            ROLE_MAP_SOURCE,
+        );
+        assert_eq!(options[0].label, "기본값");
+        assert_eq!(
+            options[0].description,
+            "오버라이드 해제 -> gpt-5.4 (role-map)"
+        );
+        let gpt_54 = options
+            .iter()
+            .find(|entry| entry.value == "gpt-5.4")
+            .expect("gpt-5.4 entry missing");
+        assert_eq!(gpt_54.label, "gpt-5.4");
+        assert_eq!(
+            gpt_54.description,
+            "Frontier coding baseline | API $2.5/$15"
+        );
+        assert!(
+            options
+                .iter()
+                .any(|entry| entry.label == "GPT-5.3-Codex-Spark"
+                    && entry.description == "Text-only preview | No API")
+        );
+    }
+
+    #[test]
+    fn picker_options_use_system_default_description_without_role_map() {
+        let options = build_model_picker_option_specs(
+            &ProviderKind::Gemini,
+            None,
+            None,
+            "default",
+            PROVIDER_DEFAULT_SOURCE,
+        );
+        assert_eq!(options[0].label, "기본값");
+        assert_eq!(
+            options[0].description,
+            "오버라이드 해제 -> provider default"
+        );
+        assert!(options.iter().any(|entry| entry.label == "Auto (Gemini 3)"
+            && entry.description == "Preview auto routing | Pro/Flash preview"));
+        assert!(
+            options
+                .iter()
+                .any(|entry| entry.label == "Auto (Gemini 2.5)"
+                    && entry.description == "Stable auto routing | Pro/Flash stable")
+        );
+        assert!(
+            options
+                .iter()
+                .any(|entry| entry.label == "gemini-3.1-pro-preview"
+                    && entry.description == "Gemini 3.1 Pro preview | Local CLI catalog")
+        );
+        assert!(
+            options
+                .iter()
+                .any(|entry| entry.label == "gemini-3-pro-preview"
+                    && entry.description == "Frontier reasoning and coding | $2/$12")
+        );
+        assert!(
+            options
+                .iter()
+                .any(|entry| entry.label == "gemini-3-flash-preview"
+                    && entry.description == "Low-latency frontier work | $0.5/$3")
+        );
+        assert!(
+            options
+                .iter()
+                .any(|entry| entry.label == "gemini-2.5-flash-lite"
+                    && entry.description == "Low-cost flash-lite | Local CLI catalog")
+        );
+        assert!(
+            options
+                .iter()
+                .any(|entry| entry.label == "gemini-3.1-flash-lite-preview"
+                    && entry.description == "Preview flash-lite variant | Local CLI catalog")
+        );
+    }
+
+    #[test]
+    fn claude_picker_mentions_default_alias_without_role_map() {
+        let options = build_model_picker_option_specs(
+            &ProviderKind::Claude,
+            None,
+            None,
+            "default",
+            PROVIDER_DEFAULT_SOURCE,
+        );
+        assert_eq!(options[0].label, "기본값");
+        assert_eq!(
+            options[0].description,
+            "오버라이드 해제 -> default (Claude default alias)"
+        );
+    }
+
+    #[test]
+    fn claude_picker_uses_cli_safe_aliases() {
+        let options = build_model_picker_option_specs(
+            &ProviderKind::Claude,
+            None,
+            None,
+            "default",
+            PROVIDER_DEFAULT_SOURCE,
+        );
+        assert!(
+            options
+                .iter()
+                .any(|entry| entry.value == "sonnet" && entry.label == "Sonnet 4.6")
+        );
+        assert!(options.iter().any(|entry| entry.value == "sonnet[1m]"
+            && entry.label == "Sonnet 4.6 1M"
+            && entry.description == "1M context window | Sonnet 4.6 alias"));
+        assert!(options.iter().any(|entry| entry.value == "opus[1m]"
+            && entry.label == "Opus 4.6 1M"
+            && entry.description == "1M context window | Opus 4.6 alias"));
+        assert!(options.iter().any(|entry| entry.value == "opusplan"
+            && entry.label == "Opus Plan 4.6"
+            && entry.description == "Opus 4.6 planning | Sonnet 4.6 executes"));
+    }
+
+    #[test]
+    fn model_picker_summary_lines_stay_compact() {
+        let lines = build_model_picker_summary_lines(
+            &ProviderKind::Gemini,
+            "gemini-3-flash-preview",
+            None,
+            None,
+            None,
+        );
+        assert_eq!(
+            lines,
+            [
+                "Provider : `gemini`".to_string(),
+                "Current Model : `gemini-3-flash-preview`".to_string(),
+                "현재 작업 상태 : 기본 설정 사용 중".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn model_picker_summary_lines_show_pending_save_state() {
+        let lines = build_model_picker_summary_lines(
+            &ProviderKind::Codex,
+            "gpt-5.4",
+            Some("gpt-5.4-mini"),
+            Some("gpt-5.4"),
+            None,
+        );
+        assert_eq!(lines[2], "현재 작업 상태 : `gpt-5.4-mini` 저장 대기");
+    }
+
+    #[test]
+    fn model_picker_action_rows_include_submit_reset_cancel_buttons() {
+        let rows = build_model_picker_action_rows(
+            serenity::ChannelId::new(42),
+            &ProviderKind::Codex,
+            None,
+            None,
+            "gpt-5.4",
+            ROLE_MAP_SOURCE,
+        );
+        assert_eq!(rows.len(), 2);
+        let controls = format!("{:?}", rows[1]);
+        assert!(controls.contains(MODEL_PICKER_SUBMIT_LABEL));
+        assert!(controls.contains(MODEL_PICKER_RESET_LABEL));
+        assert!(controls.contains(MODEL_PICKER_CANCEL_LABEL));
+    }
 }

--- a/src/services/discord/commands/mod.rs
+++ b/src/services/discord/commands/mod.rs
@@ -3,16 +3,22 @@ mod control;
 mod diagnostics;
 mod help;
 mod meeting_cmd;
+mod model_picker;
+mod model_ui;
 mod receipt;
 mod session;
 mod skill;
 
-pub(in crate::services::discord) use config::{
-    MODEL_PICKER_CUSTOM_ID, MODEL_RESET_CUSTOM_ID, build_model_info_message,
-    build_model_picker_components, build_model_picker_embed, build_model_status_message,
-    is_clear_model_keyword, provider_supports_model_override, validate_model_input,
+pub(in crate::services::discord) use super::model_catalog::{
+    provider_supports_model_override, validate_model_input,
 };
-pub(super) use config::{cmd_adduser, cmd_allowed, cmd_allowedtools, cmd_model, cmd_removeuser};
+pub(in crate::services::discord) use config::{
+    ModelPickerAction, build_model_picker_components_from_snapshot,
+    build_model_picker_embed_from_snapshot, clear_model_picker_pending, effective_model_snapshot,
+    model_picker_pending_to_override, parse_model_picker_custom_id, resolve_model_for_turn,
+    update_channel_model_override,
+};
+pub(super) use config::{cmd_adduser, cmd_allowed, cmd_allowedtools, cmd_removeuser};
 pub(super) use control::{cmd_clear, cmd_down, cmd_shell, cmd_stop};
 pub(in crate::services::discord) use diagnostics::{
     build_health_report, build_inflight_report, build_queue_report, build_status_report,
@@ -22,6 +28,7 @@ pub(super) use diagnostics::{
 };
 pub(super) use help::cmd_help;
 pub(super) use meeting_cmd::cmd_meeting;
+pub(super) use model_picker::cmd_model;
 pub(super) use receipt::cmd_receipt;
 pub(super) use session::{cmd_pwd, cmd_start};
 pub(super) use skill::cmd_cc;

--- a/src/services/discord/commands/model_picker.rs
+++ b/src/services/discord/commands/model_picker.rs
@@ -1,0 +1,175 @@
+use std::sync::Arc;
+
+use poise::CreateReply;
+use poise::serenity_prelude as serenity;
+
+use super::super::model_catalog::provider_supports_model_override;
+use super::super::{Context, Error, SharedData, check_auth};
+use super::config::{
+    build_model_picker_components_from_snapshot, build_model_picker_embed_from_snapshot,
+    effective_model_snapshot, remember_model_picker_pending,
+};
+use crate::services::provider::ProviderKind;
+
+struct ModelPickerView {
+    override_model: Option<String>,
+    embed: serenity::CreateEmbed,
+    components: Vec<serenity::CreateActionRow>,
+}
+
+async fn build_model_picker_view(
+    shared: &Arc<SharedData>,
+    target_channel_id: serenity::ChannelId,
+    provider: &ProviderKind,
+) -> ModelPickerView {
+    let snapshot = effective_model_snapshot(shared, target_channel_id).await;
+    let pending_model = snapshot.override_model.as_deref();
+    let embed = build_model_picker_embed_from_snapshot(&snapshot, provider, pending_model, None);
+    let components = build_model_picker_components_from_snapshot(
+        &snapshot,
+        target_channel_id,
+        provider,
+        pending_model,
+    );
+
+    ModelPickerView {
+        override_model: snapshot.override_model,
+        embed,
+        components,
+    }
+}
+
+async fn send_model_picker_card(
+    ctx: &serenity::Context,
+    shared: &Arc<SharedData>,
+    destination_channel_id: serenity::ChannelId,
+    target_channel_id: serenity::ChannelId,
+    provider: &ProviderKind,
+    owner_user_id: serenity::UserId,
+) -> serenity::Result<serenity::Message> {
+    let view = build_model_picker_view(shared, target_channel_id, provider).await;
+    let message = destination_channel_id
+        .send_message(
+            &ctx.http,
+            serenity::CreateMessage::new()
+                .embed(view.embed)
+                .components(view.components),
+        )
+        .await?;
+    remember_model_picker_pending(
+        shared,
+        message.id,
+        owner_user_id,
+        target_channel_id,
+        view.override_model,
+    );
+    Ok(message)
+}
+
+async fn resolve_channel_kind(
+    ctx: &serenity::Context,
+    channel_id: serenity::ChannelId,
+) -> Option<serenity::ChannelType> {
+    let channel = channel_id.to_channel(&ctx.http).await.ok()?;
+    match channel {
+        serenity::Channel::Guild(guild_channel) => Some(guild_channel.kind),
+        serenity::Channel::Private(_) => None,
+        _ => None,
+    }
+}
+
+async fn create_model_picker_forum_post(
+    ctx: &serenity::Context,
+    shared: &Arc<SharedData>,
+    forum_channel_id: serenity::ChannelId,
+    target_channel_id: serenity::ChannelId,
+    provider: &ProviderKind,
+    owner_user_id: serenity::UserId,
+) -> serenity::Result<serenity::Message> {
+    let post = forum_channel_id
+        .create_forum_post(
+            &ctx.http,
+            serenity::CreateForumPost::new(
+                format!("Model Picker • {}", provider.display_name()),
+                serenity::CreateMessage::new().content(format!(
+                    "Interactive model picker for <#{}>",
+                    target_channel_id.get()
+                )),
+            ),
+        )
+        .await?;
+    send_model_picker_card(
+        ctx,
+        shared,
+        post.id,
+        target_channel_id,
+        provider,
+        owner_user_id,
+    )
+    .await
+}
+
+async fn run_model_command(ctx: Context<'_>) -> Result<(), Error> {
+    let user_id = ctx.author().id;
+    let user_name = &ctx.author().name;
+    if !check_auth(user_id, user_name, &ctx.data().shared, &ctx.data().token).await {
+        return Ok(());
+    }
+
+    let ts = chrono::Local::now().format("%H:%M:%S");
+    let channel_id = ctx.channel_id();
+
+    if !provider_supports_model_override(&ctx.data().provider) {
+        println!("  [{ts}] ◀ [{user_name}] /model (unsupported provider)");
+        ctx.say("Model override is only supported for Claude, Codex, and Gemini channels.")
+            .await?;
+        return Ok(());
+    }
+
+    println!("  [{ts}] ◀ [{user_name}] /model");
+    match resolve_channel_kind(ctx.serenity_context(), channel_id).await {
+        Some(serenity::ChannelType::Forum) => {
+            let posted = create_model_picker_forum_post(
+                ctx.serenity_context(),
+                &ctx.data().shared,
+                channel_id,
+                channel_id,
+                &ctx.data().provider,
+                user_id,
+            )
+            .await?;
+            ctx.send(CreateReply::default().ephemeral(true).content(format!(
+                "This forum parent cannot host the picker directly. I sent it to <#{}>.",
+                posted.channel_id.get()
+            )))
+            .await?;
+        }
+        _ => {
+            let view =
+                build_model_picker_view(&ctx.data().shared, channel_id, &ctx.data().provider).await;
+            let posted = ctx
+                .send(
+                    CreateReply::default()
+                        .embed(view.embed)
+                        .components(view.components),
+                )
+                .await?
+                .into_message()
+                .await?;
+            remember_model_picker_pending(
+                &ctx.data().shared,
+                posted.id,
+                user_id,
+                channel_id,
+                view.override_model,
+            );
+        }
+    }
+    Ok(())
+}
+
+/// /model — Open the interactive model picker for this channel
+#[poise::command(slash_command, rename = "model")]
+pub(in crate::services::discord) async fn cmd_model(ctx: Context<'_>) -> Result<(), Error> {
+    run_model_command(ctx).await
+}

--- a/src/services/discord/commands/model_ui.rs
+++ b/src/services/discord/commands/model_ui.rs
@@ -1,0 +1,161 @@
+use poise::serenity_prelude as serenity;
+
+use crate::services::discord::model_catalog::{
+    DEFAULT_PICKER_VALUE, SOURCE_PROVIDER_DEFAULT, is_default_picker_value, known_models,
+};
+use crate::services::provider::ProviderKind;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct ModelPickerOptionSpec {
+    pub value: String,
+    pub label: String,
+    pub description: String,
+    pub selected: bool,
+}
+
+pub(super) fn display_model_value(raw: &str) -> String {
+    match raw {
+        "(default)" | "system default" => "default".to_string(),
+        other => other.to_string(),
+    }
+}
+
+pub(super) fn has_pending_model_change(
+    pending_model: Option<&str>,
+    override_model: Option<&str>,
+) -> bool {
+    match pending_model {
+        None => false,
+        Some(value) if is_default_picker_value(value) => override_model.is_some(),
+        Some(pending) => {
+            !override_model.is_some_and(|current| current.eq_ignore_ascii_case(pending))
+        }
+    }
+}
+
+fn build_model_picker_runtime_status(
+    pending_model: Option<&str>,
+    override_model: Option<&str>,
+    notice: Option<&str>,
+) -> String {
+    if let Some(notice) = notice {
+        return notice.to_string();
+    }
+
+    match pending_model {
+        Some(value) if is_default_picker_value(value) && override_model.is_some() => {
+            "기본값 복귀 대기".to_string()
+        }
+        Some(value) if is_default_picker_value(value) => "기본 설정 유지".to_string(),
+        Some(value)
+            if override_model.is_some_and(|current| current.eq_ignore_ascii_case(value)) =>
+        {
+            "현재 오버라이드 유지".to_string()
+        }
+        Some(value) => format!("`{}` 저장 대기", display_model_value(value)),
+        None if override_model.is_some() => "채널 오버라이드 적용 중".to_string(),
+        None => "기본 설정 사용 중".to_string(),
+    }
+}
+
+pub(super) fn build_model_picker_summary_lines(
+    provider: &ProviderKind,
+    effective_model: &str,
+    pending_model: Option<&str>,
+    override_model: Option<&str>,
+    notice: Option<&str>,
+) -> [String; 3] {
+    [
+        format!("Provider : `{}`", provider.as_str()),
+        format!("Current Model : `{}`", display_model_value(effective_model)),
+        format!(
+            "현재 작업 상태 : {}",
+            build_model_picker_runtime_status(pending_model, override_model, notice)
+        ),
+    ]
+}
+
+fn default_picker_option_label() -> String {
+    "기본값".to_string()
+}
+
+fn default_picker_option_description(
+    provider: &ProviderKind,
+    default_model: &str,
+    default_source: &str,
+) -> String {
+    match default_source {
+        SOURCE_PROVIDER_DEFAULT => match provider.default_model_behavior().runtime_model {
+            Some(model) => format!(
+                "오버라이드 해제 -> {} ({})",
+                display_model_value(model),
+                provider.default_model_behavior().source_label
+            ),
+            None => format!(
+                "오버라이드 해제 -> {}",
+                provider.default_model_behavior().source_label
+            ),
+        },
+        other => format!("오버라이드 해제 -> {} ({})", default_model, other),
+    }
+}
+
+pub(super) fn build_model_picker_option_specs(
+    provider: &ProviderKind,
+    pending_model: Option<&str>,
+    override_model: Option<&str>,
+    default_model: &str,
+    default_source: &str,
+) -> Vec<ModelPickerOptionSpec> {
+    let default_selected = match pending_model {
+        Some(value) => is_default_picker_value(value),
+        None => override_model.is_none(),
+    };
+    let selected_explicit_model = match pending_model {
+        Some(value) if !is_default_picker_value(value) => Some(value),
+        _ => override_model,
+    };
+
+    let mut options = Vec::with_capacity(known_models(provider).len() + 1);
+    options.push(ModelPickerOptionSpec {
+        value: DEFAULT_PICKER_VALUE.to_string(),
+        label: default_picker_option_label(),
+        description: default_picker_option_description(provider, default_model, default_source),
+        selected: default_selected,
+    });
+    options.extend(
+        known_models(provider)
+            .iter()
+            .map(|entry| ModelPickerOptionSpec {
+                value: entry.value.to_string(),
+                label: entry.label.to_string(),
+                description: entry.picker_description(),
+                selected: selected_explicit_model
+                    .is_some_and(|active| active.eq_ignore_ascii_case(entry.value)),
+            }),
+    );
+    options
+}
+
+pub(super) fn build_model_picker_options(
+    provider: &ProviderKind,
+    pending_model: Option<&str>,
+    override_model: Option<&str>,
+    default_model: &str,
+    default_source: &str,
+) -> Vec<serenity::CreateSelectMenuOption> {
+    build_model_picker_option_specs(
+        provider,
+        pending_model,
+        override_model,
+        default_model,
+        default_source,
+    )
+    .iter()
+    .map(|entry| {
+        serenity::CreateSelectMenuOption::new(entry.label.clone(), entry.value.clone())
+            .description(entry.description.clone())
+            .default_selection(entry.selected)
+    })
+    .collect()
+}

--- a/src/services/discord/meeting.rs
+++ b/src/services/discord/meeting.rs
@@ -2,7 +2,6 @@ use std::fs;
 use std::sync::Arc;
 
 use poise::serenity_prelude as serenity;
-use rand::Rng;
 use serenity::{ChannelId, CreateMessage};
 
 use crate::services::provider::ProviderKind;
@@ -903,6 +902,7 @@ async fn execute_agent_turn(
             provider: None,
             model: None,
             reasoning_effort: None,
+            peer_agents_enabled: true,
         })
         .unwrap_or_default()
     } else {
@@ -1112,6 +1112,7 @@ async fn conclude_meeting(
             provider: None,
             model: None,
             reasoning_effort: None,
+            peer_agents_enabled: true,
         })
         .unwrap_or_default()
     } else {

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -6,6 +6,8 @@ pub(crate) mod health;
 mod inflight;
 mod meeting;
 mod metrics;
+mod model_catalog;
+mod model_picker_interaction;
 mod org_schema;
 mod prompt_builder;
 mod recovery;
@@ -59,8 +61,8 @@ use restart_report::flush_restart_reports;
 use router::{handle_event, handle_text_message};
 use runtime_store::worktrees_root;
 use settings::{
-    RoleBinding, channel_supports_provider, channel_upload_dir, cleanup_old_uploads,
-    load_bot_settings, resolve_role_binding, save_bot_settings,
+    RoleBinding, bot_settings_allow_channel, channel_supports_provider, channel_upload_dir,
+    cleanup_old_uploads, load_bot_settings, resolve_role_binding, save_bot_settings,
 };
 use shared_memory::load_shared_knowledge;
 #[cfg(unix)]
@@ -119,9 +121,6 @@ pub(super) fn turn_watchdog_timeout() -> Duration {
 static WATCHDOG_DEADLINE_OVERRIDES: std::sync::LazyLock<
     std::sync::Mutex<std::collections::HashMap<u64, i64>>,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
-
-/// Maximum watchdog extension: 3 hours from the original turn start.
-const WATCHDOG_MAX_EXTENSION_MS: i64 = 3 * 3600 * 1000;
 
 /// Extend the watchdog deadline for a channel. Returns the new deadline_ms or None if at cap.
 pub fn extend_watchdog_deadline(channel_id: u64, extend_by_secs: u64) -> Option<i64> {
@@ -253,10 +252,15 @@ pub(super) struct Intervention {
 pub(super) struct DiscordBotSettings {
     pub(super) provider: ProviderKind,
     pub(super) allowed_tools: Vec<String>,
+    /// Explicit Discord channel allowlist for this bot token.
+    /// Empty means "no channel restriction".
+    pub(super) allowed_channel_ids: Vec<u64>,
     /// channel_id (string) → last working directory path
     pub(super) last_sessions: std::collections::HashMap<String, String>,
     /// channel_id (string) → last remote profile name
     pub(super) last_remotes: std::collections::HashMap<String, String>,
+    /// channel_id (string) → persisted model override
+    pub(super) channel_model_overrides: std::collections::HashMap<String, String>,
     /// Discord user ID of the registered owner (imprinting auth)
     pub(super) owner_user_id: Option<u64>,
     /// Additional authorized user IDs (added by owner via /adduser)
@@ -273,8 +277,10 @@ impl Default for DiscordBotSettings {
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
+            allowed_channel_ids: Vec::new(),
             last_sessions: std::collections::HashMap::new(),
             last_remotes: std::collections::HashMap::new(),
+            channel_model_overrides: std::collections::HashMap::new(),
             owner_user_id: None,
             allowed_user_ids: Vec::new(),
             allowed_bot_ids: Vec::new(),
@@ -297,6 +303,14 @@ pub(super) struct TmuxWatcherHandle {
     /// Set by turn_bridge when it delivers the response directly (non-handoff path).
     /// Watcher checks this before relay to avoid duplicate messages.
     pub(super) turn_delivered: Arc<std::sync::atomic::AtomicBool>,
+}
+
+#[derive(Clone)]
+pub(super) struct ModelPickerPendingState {
+    pub(super) owner_user_id: UserId,
+    pub(super) target_channel_id: ChannelId,
+    pub(super) pending_model: Option<String>,
+    pub(super) updated_at: Instant,
 }
 
 /// Core state that requires atomic multi-field access (always locked together)
@@ -369,8 +383,14 @@ pub(super) struct SharedData {
     /// ISO 8601 timestamp of the last completed turn (for health reporting).
     pub(super) last_turn_at: std::sync::Mutex<Option<String>>,
     /// Per-channel model override, independent of session lifecycle.
-    /// Takes priority over role-map model. Cleared via `/model default`.
+    /// Takes priority over role-map model. Cleared via the `/model` picker default option.
     pub(super) model_overrides: dashmap::DashMap<ChannelId, String>,
+    /// Channels that must start a fresh provider session on the next turn
+    /// because the effective model override changed.
+    pub(super) model_session_reset_pending: dashmap::DashSet<ChannelId>,
+    /// Per-message staged model picker selection.
+    /// Key: picker message id. Value tracks owner, target channel, and staged model until submit.
+    pub(super) model_picker_pending: dashmap::DashMap<MessageId, ModelPickerPendingState>,
     /// Per-thread role/model override for cross-channel dispatch reuse.
     /// When a review dispatch reuses an implementation thread, this maps
     /// thread_channel_id → alt_channel_id so role_binding and model_for_turn
@@ -1479,6 +1499,17 @@ pub async fn run_bot(
     let provider_for_shutdown = provider.clone();
     let provider_for_error = provider.clone();
 
+    let restored_model_overrides: Vec<(ChannelId, String)> = bot_settings
+        .channel_model_overrides
+        .iter()
+        .filter_map(|(channel_id, model)| {
+            channel_id
+                .parse::<u64>()
+                .ok()
+                .map(|id| (ChannelId::new(id), model.clone()))
+        })
+        .collect();
+
     let shared = Arc::new(SharedData {
         core: Mutex::new(CoreState {
             sessions: HashMap::new(),
@@ -1505,7 +1536,21 @@ pub async fn run_bot(
         dispatch_thread_parents: dashmap::DashMap::new(),
         bot_connected: std::sync::atomic::AtomicBool::new(false),
         last_turn_at: std::sync::Mutex::new(None),
-        model_overrides: dashmap::DashMap::new(),
+        model_overrides: {
+            let map = dashmap::DashMap::new();
+            for (channel_id, model) in &restored_model_overrides {
+                map.insert(*channel_id, model.clone());
+            }
+            map
+        },
+        model_session_reset_pending: {
+            let set = dashmap::DashSet::new();
+            for (channel_id, _) in &restored_model_overrides {
+                set.insert(*channel_id);
+            }
+            set
+        },
+        model_picker_pending: dashmap::DashMap::new(),
         dispatch_role_overrides: dashmap::DashMap::new(),
         last_message_ids: dashmap::DashMap::new(),
         turn_start_times: dashmap::DashMap::new(),
@@ -1523,6 +1568,12 @@ pub async fn run_bot(
             "  [{ts}] 🔑 dcserver generation: {}",
             shared.current_generation
         );
+        if !restored_model_overrides.is_empty() {
+            println!(
+                "  [{ts}] 🧩 restored model overrides: {} channel(s)",
+                restored_model_overrides.len()
+            );
+        }
     }
 
     // Register this provider with the health check registry
@@ -1558,6 +1609,28 @@ pub async fn run_bot(
                 commands::cmd_help(),
                 commands::cmd_meeting(),
             ],
+            command_check: Some(|ctx| {
+                Box::pin(async move {
+                    let settings_snapshot = { ctx.data().shared.settings.read().await.clone() };
+                    let allowed = provider_handles_channel(
+                        ctx.serenity_context(),
+                        &ctx.data().provider,
+                        &settings_snapshot,
+                        ctx.channel_id(),
+                    )
+                    .await;
+                    if !allowed {
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        println!(
+                            "  [{ts}] ⏭ CMD-GUARD: skipping /{} in channel {} for provider {}",
+                            ctx.command().name,
+                            ctx.channel_id(),
+                            ctx.data().provider.as_str()
+                        );
+                    }
+                    Ok(allowed)
+                })
+            }),
             event_handler: |ctx, event, _framework, data| Box::pin(handle_event(ctx, event, data)),
             ..Default::default()
         })
@@ -2978,6 +3051,34 @@ pub(super) async fn resolve_channel_category(
         None
     };
     (ch_name, cat_name)
+}
+
+pub(super) async fn provider_handles_channel(
+    ctx: &serenity::prelude::Context,
+    provider: &ProviderKind,
+    settings: &DiscordBotSettings,
+    channel_id: serenity::model::id::ChannelId,
+) -> bool {
+    let is_dm = matches!(
+        channel_id.to_channel(&ctx.http).await,
+        Ok(serenity::model::channel::Channel::Private(_))
+    );
+    let (channel_name, _) = resolve_channel_category(ctx, channel_id).await;
+    let (effective_channel_id, effective_channel_name) =
+        if let Some((parent_id, parent_name)) = resolve_thread_parent(ctx, channel_id).await {
+            (parent_id, parent_name.or(channel_name))
+        } else {
+            (channel_id, channel_name)
+        };
+    let role_binding =
+        resolve_role_binding(effective_channel_id, effective_channel_name.as_deref());
+
+    channel_supports_provider(
+        provider,
+        effective_channel_name.as_deref(),
+        is_dm,
+        role_binding.as_ref(),
+    ) && bot_settings_allow_channel(settings, effective_channel_id, is_dm)
 }
 
 /// If `channel_id` is a Discord thread, return the parent channel ID and name.

--- a/src/services/discord/model_catalog.rs
+++ b/src/services/discord/model_catalog.rs
@@ -1,0 +1,652 @@
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use regex::Regex;
+use serde::Deserialize;
+
+use crate::services::provider::ProviderKind;
+
+/// Sentinel value stored in the picker's pending state when the user selects "Default".
+/// Callers use `is_default_picker_value()` rather than comparing this directly.
+pub(in crate::services::discord) const DEFAULT_PICKER_VALUE: &str = "__agentdesk_default__";
+
+pub(in crate::services::discord) fn is_default_picker_value(raw: &str) -> bool {
+    raw == DEFAULT_PICKER_VALUE
+}
+
+/// Source labels used in `EffectiveModelSnapshot` and display functions.
+pub(in crate::services::discord) const SOURCE_RUNTIME_OVERRIDE: &str = "runtime override";
+pub(in crate::services::discord) const SOURCE_DISPATCH_ROLE: &str = "dispatch role override";
+pub(in crate::services::discord) const SOURCE_ROLE_MAP: &str = "role-map";
+pub(in crate::services::discord) const SOURCE_PROVIDER_DEFAULT: &str = "provider default";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ModelCatalogEntry {
+    pub value: &'static str,
+    pub label: &'static str,
+    pub primary_summary: &'static str,
+    pub secondary_summary: &'static str,
+}
+
+impl ModelCatalogEntry {
+    pub(crate) fn picker_description(&self) -> String {
+        format!("{} | {}", self.primary_summary, self.secondary_summary)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct CatalogSummary {
+    primary: &'static str,
+    secondary: &'static str,
+}
+
+// Curated from installed provider CLIs and Anthropic Claude Code docs as of 2026-03-30.
+const CLAUDE_MODEL_CATALOG: &[ModelCatalogEntry] = &[
+    ModelCatalogEntry {
+        value: "sonnet",
+        label: "Sonnet 4.6",
+        primary_summary: "Latest Sonnet 4.6 alias",
+        secondary_summary: "Claude Code plan",
+    },
+    ModelCatalogEntry {
+        value: "opus",
+        label: "Opus 4.6",
+        primary_summary: "Highest quality 4.6 alias",
+        secondary_summary: "Claude Code plan",
+    },
+    ModelCatalogEntry {
+        value: "haiku",
+        label: "Haiku 4.5",
+        primary_summary: "Fast simple-task 4.5 alias",
+        secondary_summary: "Claude Code plan",
+    },
+    ModelCatalogEntry {
+        value: "sonnet[1m]",
+        label: "Sonnet 4.6 1M",
+        primary_summary: "1M context window",
+        secondary_summary: "Sonnet 4.6 alias",
+    },
+    ModelCatalogEntry {
+        value: "opus[1m]",
+        label: "Opus 4.6 1M",
+        primary_summary: "1M context window",
+        secondary_summary: "Opus 4.6 alias",
+    },
+    ModelCatalogEntry {
+        value: "opusplan",
+        label: "Opus Plan 4.6",
+        primary_summary: "Opus 4.6 planning",
+        secondary_summary: "Sonnet 4.6 executes",
+    },
+];
+
+const CODEX_MODEL_CATALOG: &[ModelCatalogEntry] = &[
+    ModelCatalogEntry {
+        value: "gpt-5.4",
+        label: "gpt-5.4",
+        primary_summary: "Frontier coding baseline",
+        secondary_summary: "API $2.5/$15",
+    },
+    ModelCatalogEntry {
+        value: "gpt-5.4-mini",
+        label: "GPT-5.4-Mini",
+        primary_summary: "Fast strong mini",
+        secondary_summary: "API $0.75/$4.5",
+    },
+    ModelCatalogEntry {
+        value: "gpt-5.3-codex",
+        label: "gpt-5.3-codex",
+        primary_summary: "Fast Codex line",
+        secondary_summary: "API $1.75/$14",
+    },
+    ModelCatalogEntry {
+        value: "gpt-5.3-codex-spark",
+        label: "GPT-5.3-Codex-Spark",
+        primary_summary: "Text-only preview",
+        secondary_summary: "No API",
+    },
+    ModelCatalogEntry {
+        value: "gpt-5.2-codex",
+        label: "gpt-5.2-codex",
+        primary_summary: "Long-horizon coding",
+        secondary_summary: "API $1.75/$14",
+    },
+    ModelCatalogEntry {
+        value: "gpt-5.2",
+        label: "gpt-5.2",
+        primary_summary: "Long-running pro work",
+        secondary_summary: "Local CLI catalog",
+    },
+    ModelCatalogEntry {
+        value: "gpt-5.1-codex-max",
+        label: "gpt-5.1-codex-max",
+        primary_summary: "Legacy max agent model",
+        secondary_summary: "API $1.25/$10",
+    },
+    ModelCatalogEntry {
+        value: "gpt-5.1-codex-mini",
+        label: "gpt-5.1-codex-mini",
+        primary_summary: "Cheap fast codex mini",
+        secondary_summary: "Local CLI catalog",
+    },
+];
+
+const GEMINI_MODEL_CATALOG: &[ModelCatalogEntry] = &[
+    ModelCatalogEntry {
+        value: "auto-gemini-3",
+        label: "Auto (Gemini 3)",
+        primary_summary: "Preview auto routing",
+        secondary_summary: "Pro/Flash preview",
+    },
+    ModelCatalogEntry {
+        value: "auto-gemini-2.5",
+        label: "Auto (Gemini 2.5)",
+        primary_summary: "Stable auto routing",
+        secondary_summary: "Pro/Flash stable",
+    },
+    ModelCatalogEntry {
+        value: "gemini-3.1-pro-preview",
+        label: "gemini-3.1-pro-preview",
+        primary_summary: "Gemini 3.1 Pro preview",
+        secondary_summary: "Local CLI catalog",
+    },
+    ModelCatalogEntry {
+        value: "gemini-3-pro-preview",
+        label: "gemini-3-pro-preview",
+        primary_summary: "Frontier reasoning and coding",
+        secondary_summary: "$2/$12",
+    },
+    ModelCatalogEntry {
+        value: "gemini-3-flash-preview",
+        label: "gemini-3-flash-preview",
+        primary_summary: "Low-latency frontier work",
+        secondary_summary: "$0.5/$3",
+    },
+    ModelCatalogEntry {
+        value: "gemini-2.5-pro",
+        label: "gemini-2.5-pro",
+        primary_summary: "Stable advanced reasoning",
+        secondary_summary: "$1.25/$10",
+    },
+    ModelCatalogEntry {
+        value: "gemini-2.5-flash",
+        label: "gemini-2.5-flash",
+        primary_summary: "Stable fast fallback",
+        secondary_summary: "$0.3/$2.5",
+    },
+    ModelCatalogEntry {
+        value: "gemini-2.5-flash-lite",
+        label: "gemini-2.5-flash-lite",
+        primary_summary: "Low-cost flash-lite",
+        secondary_summary: "Local CLI catalog",
+    },
+    ModelCatalogEntry {
+        value: "gemini-3.1-flash-lite-preview",
+        label: "gemini-3.1-flash-lite-preview",
+        primary_summary: "Preview flash-lite variant",
+        secondary_summary: "Local CLI catalog",
+    },
+];
+
+static CODEX_MODEL_CATALOG_DYNAMIC: OnceLock<Vec<ModelCatalogEntry>> = OnceLock::new();
+static GEMINI_MODEL_CATALOG_DYNAMIC: OnceLock<Vec<ModelCatalogEntry>> = OnceLock::new();
+
+#[derive(Debug, Deserialize)]
+struct CodexModelsCache {
+    models: Vec<CodexModelsCacheEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexModelsCacheEntry {
+    slug: String,
+    #[serde(default)]
+    display_name: String,
+    #[serde(default)]
+    visibility: Option<String>,
+}
+
+fn intern_owned(value: String) -> &'static str {
+    Box::leak(value.into_boxed_str())
+}
+
+fn codex_model_cache_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".codex").join("models_cache.json"))
+}
+
+fn gemini_models_js_path() -> Option<PathBuf> {
+    let gemini_bin = crate::services::gemini::resolve_gemini_path()?;
+    let resolved = fs::canonicalize(gemini_bin).ok()?;
+    let package_root = resolved.parent()?.parent()?;
+    Some(
+        package_root
+            .join("node_modules")
+            .join("@google")
+            .join("gemini-cli-core")
+            .join("dist")
+            .join("src")
+            .join("config")
+            .join("models.js"),
+    )
+}
+
+fn codex_catalog_summary(model: &str) -> CatalogSummary {
+    match model {
+        "gpt-5.4" => CatalogSummary {
+            primary: "Frontier coding baseline",
+            secondary: "API $2.5/$15",
+        },
+        "gpt-5.4-mini" => CatalogSummary {
+            primary: "Fast strong mini",
+            secondary: "API $0.75/$4.5",
+        },
+        "gpt-5.3-codex-spark" => CatalogSummary {
+            primary: "Text-only preview",
+            secondary: "No API",
+        },
+        "gpt-5" => CatalogSummary {
+            primary: "Prior frontier baseline",
+            secondary: "API $1.25/$10",
+        },
+        "gpt-5.3-codex" => CatalogSummary {
+            primary: "Fast Codex line",
+            secondary: "API $1.75/$14",
+        },
+        "gpt-5.2-codex" => CatalogSummary {
+            primary: "Long-horizon coding",
+            secondary: "API $1.75/$14",
+        },
+        "gpt-5.2" => CatalogSummary {
+            primary: "Long-running pro work",
+            secondary: "Local CLI catalog",
+        },
+        "gpt-5.1-codex-max" => CatalogSummary {
+            primary: "Legacy max agent model",
+            secondary: "API $1.25/$10",
+        },
+        "gpt-5.1-codex-mini" => CatalogSummary {
+            primary: "Cheap fast codex mini",
+            secondary: "Local CLI catalog",
+        },
+        _ => CatalogSummary {
+            primary: "Installed Codex model",
+            secondary: "Local CLI catalog",
+        },
+    }
+}
+
+fn codex_visibility_allows_picker(visibility: Option<&str>) -> bool {
+    match visibility {
+        Some(raw) => raw.eq_ignore_ascii_case("list"),
+        None => true,
+    }
+}
+
+fn gemini_catalog_summary(model: &str) -> CatalogSummary {
+    match model {
+        "auto-gemini-3" => CatalogSummary {
+            primary: "Preview auto routing",
+            secondary: "Pro/Flash preview",
+        },
+        "auto-gemini-2.5" => CatalogSummary {
+            primary: "Stable auto routing",
+            secondary: "Pro/Flash stable",
+        },
+        "gemini-3.1-pro-preview" => CatalogSummary {
+            primary: "Gemini 3.1 Pro preview",
+            secondary: "Local CLI catalog",
+        },
+        "gemini-3-pro-preview" => CatalogSummary {
+            primary: "Frontier reasoning and coding",
+            secondary: "$2/$12",
+        },
+        "gemini-3-flash-preview" => CatalogSummary {
+            primary: "Low-latency frontier work",
+            secondary: "$0.5/$3",
+        },
+        "gemini-2.5-pro" => CatalogSummary {
+            primary: "Stable advanced reasoning",
+            secondary: "$1.25/$10",
+        },
+        "gemini-2.5-flash" => CatalogSummary {
+            primary: "Stable fast fallback",
+            secondary: "$0.3/$2.5",
+        },
+        "gemini-2.5-flash-lite" => CatalogSummary {
+            primary: "Low-cost flash-lite",
+            secondary: "Local CLI catalog",
+        },
+        "gemini-3.1-flash-lite-preview" => CatalogSummary {
+            primary: "Preview flash-lite variant",
+            secondary: "Local CLI catalog",
+        },
+        _ => CatalogSummary {
+            primary: "Installed Gemini model",
+            secondary: "Local CLI catalog",
+        },
+    }
+}
+
+fn build_codex_model_catalog() -> Vec<ModelCatalogEntry> {
+    let Some(path) = codex_model_cache_path() else {
+        return CODEX_MODEL_CATALOG.to_vec();
+    };
+    let Ok(raw) = fs::read_to_string(path) else {
+        return CODEX_MODEL_CATALOG.to_vec();
+    };
+    build_codex_model_catalog_from_cache(&raw).unwrap_or_else(|| CODEX_MODEL_CATALOG.to_vec())
+}
+
+fn build_codex_model_catalog_from_cache(raw: &str) -> Option<Vec<ModelCatalogEntry>> {
+    let parsed: CodexModelsCache = serde_json::from_str(raw).ok()?;
+    let mut seen = HashSet::new();
+    let mut entries = Vec::new();
+
+    for model in parsed.models {
+        if model.slug.trim().is_empty() {
+            continue;
+        }
+        if !codex_visibility_allows_picker(model.visibility.as_deref()) {
+            continue;
+        }
+        if !seen.insert(model.slug.to_ascii_lowercase()) {
+            continue;
+        }
+        let summary = codex_catalog_summary(&model.slug);
+        let label = if model.display_name.trim().is_empty() {
+            model.slug.clone()
+        } else {
+            model.display_name
+        };
+        entries.push(ModelCatalogEntry {
+            value: intern_owned(model.slug),
+            label: intern_owned(label),
+            primary_summary: summary.primary,
+            secondary_summary: summary.secondary,
+        });
+    }
+
+    (!entries.is_empty()).then_some(entries)
+}
+
+fn parse_gemini_model_exports(raw: &str) -> HashMap<String, String> {
+    static EXPORT_RE: OnceLock<Regex> = OnceLock::new();
+    let export_re =
+        EXPORT_RE.get_or_init(|| Regex::new(r#"export const ([A-Z0-9_]+) = '([^']+)';"#).unwrap());
+
+    export_re
+        .captures_iter(raw)
+        .filter_map(|caps| {
+            Some((
+                caps.get(1)?.as_str().to_string(),
+                caps.get(2)?.as_str().to_string(),
+            ))
+        })
+        .collect()
+}
+
+fn parse_gemini_valid_model_exports(raw: &str) -> HashSet<String> {
+    static VALID_SET_RE: OnceLock<Regex> = OnceLock::new();
+    static EXPORT_NAME_RE: OnceLock<Regex> = OnceLock::new();
+
+    let Some(block) = VALID_SET_RE
+        .get_or_init(|| {
+            Regex::new(r#"VALID_GEMINI_MODELS\s*=\s*new Set\(\[(?s)(.*?)\]\)"#).unwrap()
+        })
+        .captures(raw)
+        .and_then(|caps| caps.get(1).map(|value| value.as_str().to_string()))
+    else {
+        return HashSet::new();
+    };
+
+    let exports = parse_gemini_model_exports(raw);
+    EXPORT_NAME_RE
+        .get_or_init(|| Regex::new(r#"[A-Z0-9_]+"#).unwrap())
+        .find_iter(&block)
+        .filter_map(|name| exports.get(name.as_str()).cloned())
+        .collect()
+}
+
+fn gemini_display_label(model: &str) -> String {
+    match model {
+        "auto-gemini-3" => "Auto (Gemini 3)".to_string(),
+        "auto-gemini-2.5" => "Auto (Gemini 2.5)".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn build_gemini_model_catalog() -> Vec<ModelCatalogEntry> {
+    let Some(path) = gemini_models_js_path() else {
+        return GEMINI_MODEL_CATALOG.to_vec();
+    };
+    let Ok(raw) = fs::read_to_string(path) else {
+        return GEMINI_MODEL_CATALOG.to_vec();
+    };
+    build_gemini_model_catalog_from_models_js(&raw).unwrap_or_else(|| GEMINI_MODEL_CATALOG.to_vec())
+}
+
+fn build_gemini_model_catalog_from_models_js(raw: &str) -> Option<Vec<ModelCatalogEntry>> {
+    const GEMINI_EXPORT_ORDER: &[&str] = &[
+        "PREVIEW_GEMINI_MODEL_AUTO",
+        "DEFAULT_GEMINI_MODEL_AUTO",
+        "PREVIEW_GEMINI_3_1_MODEL",
+        "PREVIEW_GEMINI_MODEL",
+        "PREVIEW_GEMINI_FLASH_MODEL",
+        "DEFAULT_GEMINI_MODEL",
+        "DEFAULT_GEMINI_FLASH_MODEL",
+        "DEFAULT_GEMINI_FLASH_LITE_MODEL",
+        "PREVIEW_GEMINI_3_1_FLASH_LITE_MODEL",
+    ];
+
+    let exports = parse_gemini_model_exports(raw);
+    let valid_models = parse_gemini_valid_model_exports(raw);
+    let mut seen = HashSet::new();
+    let mut entries = Vec::new();
+
+    for export_name in GEMINI_EXPORT_ORDER {
+        let Some(model) = exports.get(*export_name) else {
+            continue;
+        };
+        let is_auto_model = export_name.ends_with("_AUTO");
+        if !valid_models.is_empty() && !is_auto_model && !valid_models.contains(model) {
+            continue;
+        }
+        if !seen.insert(model.to_ascii_lowercase()) {
+            continue;
+        }
+        let summary = gemini_catalog_summary(model);
+        entries.push(ModelCatalogEntry {
+            value: intern_owned(model.clone()),
+            label: intern_owned(gemini_display_label(model)),
+            primary_summary: summary.primary,
+            secondary_summary: summary.secondary,
+        });
+    }
+
+    (!entries.is_empty()).then_some(entries)
+}
+
+const CLAUDE_MODEL_ALIASES: &[(&str, &str)] = &[
+    ("opus", "claude-opus-4-6"),
+    ("sonnet", "claude-sonnet-4-6"),
+    ("haiku", "claude-haiku-4-5-20251001"),
+];
+
+const CODEX_MODEL_ALIASES: &[(&str, &str)] = &[
+    ("gpt-5-codex", "gpt-5-codex"),
+    ("o3", "o3"),
+    ("o4-mini", "o4-mini"),
+];
+
+const GEMINI_MODEL_ALIASES: &[(&str, &str)] = &[
+    ("auto", "auto-gemini-3"),
+    ("pro", "gemini-3.1-pro-preview"),
+    ("flash", "gemini-3-flash-preview"),
+    ("flash-lite", "gemini-2.5-flash-lite"),
+    ("gemini-3.1-pro", "gemini-3.1-pro-preview"),
+    ("gemini-3-pro", "gemini-3-pro-preview"),
+    ("gemini-3-flash", "gemini-3-flash-preview"),
+    ("gemini-2.5-pro", "gemini-2.5-pro"),
+    ("gemini-2.5-flash", "gemini-2.5-flash"),
+];
+
+pub(in crate::services::discord) fn provider_supports_model_override(
+    provider: &ProviderKind,
+) -> bool {
+    matches!(
+        provider,
+        ProviderKind::Claude | ProviderKind::Codex | ProviderKind::Gemini
+    )
+}
+
+pub(in crate::services::discord) fn model_hint(provider: &ProviderKind) -> &'static str {
+    match provider {
+        ProviderKind::Claude => "default + curated Claude models + custom model id",
+        ProviderKind::Codex => "default + curated Codex models + custom model id",
+        ProviderKind::Gemini => "default + curated Gemini models + custom model id",
+        ProviderKind::Unsupported(_) => "모델 이름 또는 default",
+    }
+}
+
+pub(crate) fn known_models(provider: &ProviderKind) -> &'static [ModelCatalogEntry] {
+    match provider {
+        ProviderKind::Claude => CLAUDE_MODEL_CATALOG,
+        ProviderKind::Codex => CODEX_MODEL_CATALOG_DYNAMIC
+            .get_or_init(build_codex_model_catalog)
+            .as_slice(),
+        ProviderKind::Gemini => GEMINI_MODEL_CATALOG_DYNAMIC
+            .get_or_init(build_gemini_model_catalog)
+            .as_slice(),
+        ProviderKind::Unsupported(_) => &[],
+    }
+}
+
+fn model_aliases(provider: &ProviderKind) -> &'static [(&'static str, &'static str)] {
+    match provider {
+        ProviderKind::Claude => CLAUDE_MODEL_ALIASES,
+        ProviderKind::Codex => CODEX_MODEL_ALIASES,
+        ProviderKind::Gemini => GEMINI_MODEL_ALIASES,
+        ProviderKind::Unsupported(_) => &[],
+    }
+}
+
+fn canonical_known_model(provider: &ProviderKind, raw: &str) -> Option<&'static str> {
+    let trimmed = raw.trim();
+    if let Some(entry) = known_models(provider)
+        .iter()
+        .find(|entry| entry.value.eq_ignore_ascii_case(trimmed))
+    {
+        return Some(entry.value);
+    }
+
+    model_aliases(provider)
+        .iter()
+        .find(|(alias, _)| alias.eq_ignore_ascii_case(trimmed))
+        .map(|(_, canonical)| *canonical)
+}
+
+fn looks_like_model_identifier(raw: &str) -> bool {
+    let trimmed = raw.trim();
+    !trimmed.is_empty()
+        && trimmed.len() <= 64
+        && trimmed
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | ':' | '[' | ']'))
+}
+
+pub(in crate::services::discord) fn validate_model_input(
+    provider: &ProviderKind,
+    raw: &str,
+) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("Model name cannot be empty.".to_string());
+    }
+
+    if let Some(canonical) = canonical_known_model(provider, trimmed) {
+        return Ok(canonical.to_string());
+    }
+
+    if looks_like_model_identifier(trimmed) {
+        return Ok(trimmed.to_string());
+    }
+
+    Err(format!(
+        "Unrecognized model `{}` for {}.\n{}\nUse `/model` to open the interactive picker.",
+        trimmed,
+        provider.display_name(),
+        model_hint(provider)
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_codex_model_catalog_from_cache, build_gemini_model_catalog_from_models_js};
+
+    #[test]
+    fn codex_dynamic_catalog_uses_local_display_names() {
+        let raw = r#"{
+          "models": [
+            { "slug": "gpt-5.4", "display_name": "gpt-5.4", "visibility": "list" },
+            { "slug": "gpt-5.4-mini", "display_name": "GPT-5.4-Mini", "visibility": "list" },
+            { "slug": "gpt-5.1", "display_name": "gpt-5.1", "visibility": "hide" },
+            { "slug": "gpt-5.3-codex-spark", "display_name": "GPT-5.3-Codex-Spark", "visibility": "list" }
+          ]
+        }"#;
+
+        let catalog = build_codex_model_catalog_from_cache(raw).expect("catalog");
+        assert_eq!(catalog[0].value, "gpt-5.4");
+        assert_eq!(catalog[0].label, "gpt-5.4");
+        assert_eq!(catalog[1].label, "GPT-5.4-Mini");
+        assert_eq!(
+            catalog[2].picker_description(),
+            "Text-only preview | No API"
+        );
+        assert!(!catalog.iter().any(|entry| entry.value == "gpt-5.1"));
+    }
+
+    #[test]
+    fn gemini_dynamic_catalog_reads_models_js_exports() {
+        let raw = r#"
+export const PREVIEW_GEMINI_MODEL = 'gemini-3-pro-preview';
+export const PREVIEW_GEMINI_3_1_MODEL = 'gemini-3.1-pro-preview';
+export const PREVIEW_GEMINI_FLASH_MODEL = 'gemini-3-flash-preview';
+export const PREVIEW_GEMINI_3_1_FLASH_LITE_MODEL = 'gemini-3.1-flash-lite-preview';
+export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro';
+export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash';
+export const DEFAULT_GEMINI_FLASH_LITE_MODEL = 'gemini-obsolete-lite';
+export const PREVIEW_GEMINI_MODEL_AUTO = 'auto-gemini-3';
+export const DEFAULT_GEMINI_MODEL_AUTO = 'auto-gemini-2.5';
+export const VALID_GEMINI_MODELS = new Set([
+  PREVIEW_GEMINI_MODEL,
+  PREVIEW_GEMINI_3_1_MODEL,
+  PREVIEW_GEMINI_FLASH_MODEL,
+  PREVIEW_GEMINI_3_1_FLASH_LITE_MODEL,
+  DEFAULT_GEMINI_MODEL,
+  DEFAULT_GEMINI_FLASH_MODEL
+]);
+"#;
+
+        let catalog = build_gemini_model_catalog_from_models_js(raw).expect("catalog");
+        assert_eq!(catalog[0].value, "auto-gemini-3");
+        assert_eq!(catalog[0].label, "Auto (Gemini 3)");
+        assert!(
+            catalog
+                .iter()
+                .any(|entry| entry.value == "gemini-3.1-pro-preview")
+        );
+        assert!(
+            catalog
+                .iter()
+                .any(|entry| entry.value == "gemini-3.1-flash-lite-preview"
+                    && entry.picker_description()
+                        == "Preview flash-lite variant | Local CLI catalog")
+        );
+        assert!(
+            !catalog
+                .iter()
+                .any(|entry| entry.value == "gemini-obsolete-lite")
+        );
+    }
+}

--- a/src/services/discord/model_picker_interaction.rs
+++ b/src/services/discord/model_picker_interaction.rs
@@ -1,0 +1,288 @@
+use std::time::{Duration, Instant};
+
+use poise::serenity_prelude as serenity;
+
+use crate::services::discord::model_catalog::is_default_picker_value;
+
+use super::{Data, Error, check_auth};
+
+pub(super) fn build_model_picker_close_response() -> serenity::CreateInteractionResponse {
+    serenity::CreateInteractionResponse::Acknowledge
+}
+
+async fn close_model_picker_interaction(
+    ctx: &serenity::Context,
+    component: &serenity::ComponentInteraction,
+) -> Result<(), Error> {
+    component
+        .create_response(ctx, build_model_picker_close_response())
+        .await?;
+    let _ = component.message.delete(&ctx.http).await;
+
+    Ok(())
+}
+
+pub(super) async fn handle_model_picker_interaction(
+    ctx: &serenity::Context,
+    component: &serenity::ComponentInteraction,
+    data: &Data,
+) -> Result<(), Error> {
+    let ts = chrono::Local::now().format("%H:%M:%S");
+    let display_channel_id = component.channel_id;
+    let user_id = component.user.id;
+    let user_name = &component.user.name;
+    println!(
+        "  [{ts}] ◀ [{}] model picker {}",
+        user_name, display_channel_id
+    );
+
+    if !check_auth(user_id, user_name, &data.shared, &data.token).await {
+        component
+            .create_response(
+                ctx,
+                serenity::CreateInteractionResponse::Message(
+                    serenity::CreateInteractionResponseMessage::new()
+                        .content("Not authorized for this bot.")
+                        .ephemeral(true),
+                ),
+            )
+            .await?;
+        return Ok(());
+    }
+
+    if !super::commands::provider_supports_model_override(&data.provider) {
+        component
+            .create_response(
+                ctx,
+                serenity::CreateInteractionResponse::Message(
+                    serenity::CreateInteractionResponseMessage::new()
+                        .content(
+                            "Model override is only supported for Claude, Codex, and Gemini channels.",
+                        )
+                        .ephemeral(true),
+                ),
+            )
+            .await?;
+        return Ok(());
+    }
+
+    let Some((action, target_channel_id)) = super::commands::parse_model_picker_custom_id(
+        &component.data.custom_id,
+        display_channel_id,
+    ) else {
+        component
+            .create_response(
+                ctx,
+                serenity::CreateInteractionResponse::Message(
+                    serenity::CreateInteractionResponseMessage::new()
+                        .content("Unsupported model picker interaction.")
+                        .ephemeral(true),
+                ),
+            )
+            .await?;
+        return Ok(());
+    };
+
+    let message_id = component.message.id;
+    let Some(state_snapshot) = data
+        .shared
+        .model_picker_pending
+        .get(&message_id)
+        .map(|entry| entry.clone())
+    else {
+        component
+            .create_response(
+                ctx,
+                serenity::CreateInteractionResponse::Message(
+                    serenity::CreateInteractionResponseMessage::new()
+                        .content("This model picker has expired. Run `/model` again.")
+                        .ephemeral(true),
+                ),
+            )
+            .await?;
+        return Ok(());
+    };
+
+    if Instant::now().duration_since(state_snapshot.updated_at) > Duration::from_secs(30 * 60) {
+        data.shared.model_picker_pending.remove(&message_id);
+        component
+            .create_response(
+                ctx,
+                serenity::CreateInteractionResponse::Message(
+                    serenity::CreateInteractionResponseMessage::new()
+                        .content("This model picker has expired. Run `/model` again.")
+                        .ephemeral(true),
+                ),
+            )
+            .await?;
+        return Ok(());
+    }
+
+    if state_snapshot.owner_user_id != user_id {
+        component
+            .create_response(
+                ctx,
+                serenity::CreateInteractionResponse::Message(
+                    serenity::CreateInteractionResponseMessage::new()
+                        .content("Only the original requester can use this model picker.")
+                        .ephemeral(true),
+                ),
+            )
+            .await?;
+        return Ok(());
+    }
+
+    if state_snapshot.target_channel_id != target_channel_id {
+        component
+            .create_response(
+                ctx,
+                serenity::CreateInteractionResponse::Message(
+                    serenity::CreateInteractionResponseMessage::new()
+                        .content("This picker no longer matches the target channel.")
+                        .ephemeral(true),
+                ),
+            )
+            .await?;
+        return Ok(());
+    }
+
+    let notice = match action {
+        super::commands::ModelPickerAction::Select => {
+            let selected = match &component.data.kind {
+                serenity::ComponentInteractionDataKind::StringSelect { values } => {
+                    values.first().cloned()
+                }
+                _ => None,
+            };
+
+            let Some(selected) = selected else {
+                component
+                    .create_response(
+                        ctx,
+                        serenity::CreateInteractionResponse::Message(
+                            serenity::CreateInteractionResponseMessage::new()
+                                .content("Unsupported model picker interaction.")
+                                .ephemeral(true),
+                        ),
+                    )
+                    .await?;
+                return Ok(());
+            };
+
+            let pending_model = if is_default_picker_value(&selected) {
+                Some(selected)
+            } else {
+                let validated =
+                    match super::commands::validate_model_input(&data.provider, &selected) {
+                        Ok(model) => model,
+                        Err(message) => {
+                            component
+                                .create_response(
+                                    ctx,
+                                    serenity::CreateInteractionResponse::Message(
+                                        serenity::CreateInteractionResponseMessage::new()
+                                            .content(message)
+                                            .ephemeral(true),
+                                    ),
+                                )
+                                .await?;
+                            return Ok(());
+                        }
+                    };
+                Some(validated)
+            };
+
+            if let Some(mut state) = data.shared.model_picker_pending.get_mut(&message_id) {
+                state.pending_model = pending_model;
+                state.updated_at = Instant::now();
+            }
+            "선택을 임시 저장했습니다. `저장`을 눌러 적용하세요."
+        }
+        super::commands::ModelPickerAction::Submit => {
+            let pending_model = data
+                .shared
+                .model_picker_pending
+                .get(&message_id)
+                .and_then(|state| state.pending_model.clone());
+
+            super::commands::clear_model_picker_pending(&data.shared, message_id);
+            close_model_picker_interaction(ctx, component).await?;
+
+            match super::commands::model_picker_pending_to_override(pending_model.as_deref()) {
+                Some(Some(model)) => {
+                    super::commands::update_channel_model_override(
+                        &data.shared,
+                        &data.token,
+                        target_channel_id,
+                        &data.provider,
+                        Some(model),
+                    )
+                    .await;
+                }
+                Some(None) => {
+                    super::commands::update_channel_model_override(
+                        &data.shared,
+                        &data.token,
+                        target_channel_id,
+                        &data.provider,
+                        None,
+                    )
+                    .await;
+                }
+                None => {}
+            }
+
+            return Ok(());
+        }
+        super::commands::ModelPickerAction::Reset => {
+            super::commands::clear_model_picker_pending(&data.shared, message_id);
+            close_model_picker_interaction(ctx, component).await?;
+            super::commands::update_channel_model_override(
+                &data.shared,
+                &data.token,
+                target_channel_id,
+                &data.provider,
+                None,
+            )
+            .await;
+            return Ok(());
+        }
+        super::commands::ModelPickerAction::Cancel => {
+            super::commands::clear_model_picker_pending(&data.shared, message_id);
+            close_model_picker_interaction(ctx, component).await?;
+            return Ok(());
+        }
+    };
+
+    // Only Select reaches here — update the picker embed in-place.
+    let pending_model = data
+        .shared
+        .model_picker_pending
+        .get(&message_id)
+        .and_then(|state| state.pending_model.clone());
+
+    let snapshot = super::commands::effective_model_snapshot(&data.shared, target_channel_id).await;
+    let embed = super::commands::build_model_picker_embed_from_snapshot(
+        &snapshot,
+        &data.provider,
+        pending_model.as_deref(),
+        Some(notice),
+    );
+    let components = super::commands::build_model_picker_components_from_snapshot(
+        &snapshot,
+        target_channel_id,
+        &data.provider,
+        pending_model.as_deref(),
+    );
+    component
+        .create_response(
+            ctx,
+            serenity::CreateInteractionResponse::UpdateMessage(
+                serenity::CreateInteractionResponseMessage::new()
+                    .embed(embed)
+                    .components(components),
+            ),
+        )
+        .await?;
+    Ok(())
+}

--- a/src/services/discord/org_schema.rs
+++ b/src/services/discord/org_schema.rs
@@ -38,6 +38,7 @@ pub(super) struct AgentDef {
     pub provider: Option<String>,
     pub model: Option<String>,
     pub workspace: Option<String>,
+    pub peer_agents: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -52,6 +53,7 @@ pub(super) struct ChannelBinding {
     pub workspace: Option<String>,
     pub provider: Option<String>,
     pub model: Option<String>,
+    pub peer_agents: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -171,6 +173,10 @@ pub(super) fn resolve_role_binding(
         .and_then(ProviderKind::from_str);
 
     let model = ch_binding.model.clone().or_else(|| agent_def.model.clone());
+    let peer_agents_enabled = ch_binding
+        .peer_agents
+        .or(agent_def.peer_agents)
+        .unwrap_or(true);
 
     // Explicit prompt_file > auto-derived from prompts_root > empty
     let prompt_file = agent_def
@@ -191,6 +197,7 @@ pub(super) fn resolve_role_binding(
         provider,
         model,
         reasoning_effort: None,
+        peer_agents_enabled,
     })
 }
 
@@ -448,6 +455,31 @@ channels:
 
             let ws = resolve_workspace(ChannelId::new(100), None).unwrap();
             assert!(ws.ends_with("/override-ws"));
+        });
+    }
+
+    #[test]
+    fn test_channel_binding_can_disable_peer_agents() {
+        with_temp_root(|temp_home: &TempDir| {
+            write_org_yaml(
+                temp_home.path(),
+                r#"
+version: 1
+agents:
+  spark:
+    display_name: "Spark"
+    prompt_file: "~/prompts/spark.md"
+    peer_agents: true
+channels:
+  by_id:
+    "1488022491992424448":
+      agent: spark
+      peer_agents: false
+"#,
+            );
+
+            let binding = resolve_role_binding(ChannelId::new(1488022491992424448), None).unwrap();
+            assert!(!binding.peer_agents_enabled);
         });
     }
 

--- a/src/services/discord/prompt_builder.rs
+++ b/src/services/discord/prompt_builder.rs
@@ -151,9 +151,11 @@ pub(super) fn build_system_prompt(
                 system_prompt_owned.push_str(&catalog);
             }
 
-            if let Some(peer_guidance) = render_peer_agent_guidance(&binding.role_id) {
-                system_prompt_owned.push_str("\n\n");
-                system_prompt_owned.push_str(&peer_guidance);
+            if binding.peer_agents_enabled {
+                if let Some(peer_guidance) = render_peer_agent_guidance(&binding.role_id) {
+                    system_prompt_owned.push_str("\n\n");
+                    system_prompt_owned.push_str(&peer_guidance);
+                }
             }
         }
     }
@@ -319,6 +321,7 @@ mod tests {
             provider: None,
             model: None,
             reasoning_effort: None,
+            peer_agents_enabled: true,
         };
         let review_prompt = build_system_prompt(
             "ctx",
@@ -351,5 +354,34 @@ mod tests {
         assert!(decision_prompt.contains("/api/review-decision"));
         assert!(decision_prompt.contains("accept/dispute/dismiss"));
         assert!(decision_prompt.contains("[Review Decision Rules]"));
+    }
+
+    #[test]
+    fn test_full_prompt_omits_peer_agent_directory_when_disabled() {
+        use super::super::settings::RoleBinding;
+
+        let binding = RoleBinding {
+            role_id: "spark".to_string(),
+            prompt_file: "/nonexistent".to_string(),
+            provider: None,
+            model: None,
+            reasoning_effort: None,
+            peer_agents_enabled: false,
+        };
+
+        let prompt = build_system_prompt(
+            "ctx",
+            "/tmp",
+            ChannelId::new(1488022491992424448),
+            "tok",
+            "",
+            "",
+            Some(&binding),
+            false,
+            DispatchProfile::Full,
+            None,
+        );
+
+        assert!(!prompt.contains("[Peer Agent Directory]"));
     }
 }

--- a/src/services/discord/role_map.rs
+++ b/src/services/discord/role_map.rs
@@ -42,12 +42,17 @@ fn parse_role_binding(value: &serde_json::Value) -> Option<RoleBinding> {
         .get("reasoningEffort")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
+    let peer_agents_enabled = obj
+        .get("peerAgents")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
     Some(RoleBinding {
         role_id,
         prompt_file,
         provider,
         model,
         reasoning_effort,
+        peer_agents_enabled,
     })
 }
 

--- a/src/services/discord/router.rs
+++ b/src/services/discord/router.rs
@@ -10,6 +10,45 @@ pub(super) fn should_process_turn_message(kind: serenity::model::channel::Messag
     )
 }
 
+fn is_model_picker_component_custom_id(
+    custom_id: &str,
+    fallback_channel_id: serenity::ChannelId,
+) -> bool {
+    super::commands::parse_model_picker_custom_id(custom_id, fallback_channel_id).is_some()
+}
+
+async fn reset_provider_session_if_pending(
+    shared: &Arc<SharedData>,
+    channel_id: serenity::ChannelId,
+    provider: &ProviderKind,
+) {
+    if shared
+        .model_session_reset_pending
+        .remove(&channel_id)
+        .is_none()
+    {
+        return;
+    }
+
+    let channel_name = {
+        let mut data = shared.core.lock().await;
+        if let Some(session) = data.sessions.get_mut(&channel_id) {
+            session.session_id = None;
+            session.channel_name.clone()
+        } else {
+            None
+        }
+    };
+
+    if let Some(name) = channel_name.as_deref() {
+        crate::services::claude::terminate_local_session(&provider.build_tmux_session_name(name));
+    }
+
+    if let Some(session_key) = build_adk_session_key(shared, channel_id, provider).await {
+        super::adk_session::clear_claude_session_id(&session_key, shared.api_port).await;
+    }
+}
+
 pub(super) async fn handle_event(
     ctx: &serenity::Context,
     event: &serenity::FullEvent,
@@ -19,9 +58,27 @@ pub(super) async fn handle_event(
     match event {
         serenity::FullEvent::InteractionCreate { interaction } => {
             if let Some(component) = interaction.as_message_component() {
-                if component.data.custom_id == super::commands::MODEL_PICKER_CUSTOM_ID
-                    || component.data.custom_id == super::commands::MODEL_RESET_CUSTOM_ID
-                {
+                if is_model_picker_component_custom_id(
+                    &component.data.custom_id,
+                    component.channel_id,
+                ) {
+                    let settings_snapshot = { data.shared.settings.read().await.clone() };
+                    if !super::provider_handles_channel(
+                        ctx,
+                        &data.provider,
+                        &settings_snapshot,
+                        component.channel_id,
+                    )
+                    .await
+                    {
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        println!(
+                            "  [{ts}] ⏭ COMPONENT-GUARD: skipping model picker in channel {} for provider {}",
+                            component.channel_id,
+                            data.provider.as_str()
+                        );
+                        return Ok(());
+                    }
                     return handle_model_picker_interaction(ctx, component, data).await;
                 }
             }
@@ -119,24 +176,13 @@ pub(super) async fn handle_event(
                 }
             }
 
-            // If the message looks like a known slash command, skip it (poise handles it).
-            // Unknown `/`-prefixed messages fall through to the AI provider as regular text.
+            // Ignore messages that look like slash commands (but allow from trusted bots)
             if new_message.content.starts_with('/') && !new_message.author.bot {
-                let cmd_name = new_message.content[1..]
-                    .split_whitespace()
-                    .next()
-                    .unwrap_or("");
-                let is_known = data
-                    .shared
-                    .known_slash_commands
-                    .get()
-                    .map_or(false, |set| set.contains(cmd_name));
-                if is_known {
-                    return Ok(());
-                }
+                return Ok(());
             }
 
-            // this bot. Bot mentions are excluded because Discord auto-adds the
+            // Ignore messages that mention other (human) users — not directed at
+            // this bot.  Bot mentions are excluded because Discord auto-adds the
             // replied-to author to the mentions array for InlineReply messages;
             // filtering on those would silently drop legitimate replies to
             // announce/notify/codex bot messages.
@@ -169,6 +215,10 @@ pub(super) async fn handle_event(
             };
             let role_binding =
                 resolve_role_binding(effective_channel_id, effective_channel_name.as_deref());
+            let settings_snapshot = { data.shared.settings.read().await.clone() };
+            if !bot_settings_allow_channel(&settings_snapshot, effective_channel_id, is_dm) {
+                return Ok(());
+            }
             if !channel_supports_provider(
                 &data.provider,
                 effective_channel_name.as_deref(),
@@ -672,109 +722,7 @@ pub(super) async fn handle_event(
     Ok(())
 }
 
-async fn handle_model_picker_interaction(
-    ctx: &serenity::Context,
-    component: &serenity::ComponentInteraction,
-    data: &Data,
-) -> Result<(), Error> {
-    let ts = chrono::Local::now().format("%H:%M:%S");
-    let channel_id = component.channel_id;
-    let user_id = component.user.id;
-    let user_name = &component.user.name;
-    println!("  [{ts}] ◀ [{}] model picker {}", user_name, channel_id);
-
-    if !check_auth(user_id, user_name, &data.shared, &data.token).await {
-        component
-            .create_response(
-                ctx,
-                serenity::CreateInteractionResponse::Message(
-                    serenity::CreateInteractionResponseMessage::new()
-                        .content("Not authorized for this bot.")
-                        .ephemeral(true),
-                ),
-            )
-            .await?;
-        return Ok(());
-    }
-
-    if !super::commands::provider_supports_model_override(&data.provider) {
-        component
-            .create_response(
-                ctx,
-                serenity::CreateInteractionResponse::Message(
-                    serenity::CreateInteractionResponseMessage::new()
-                        .content("Model override is only supported for Claude, Codex, and Gemini channels.")
-                        .ephemeral(true),
-                ),
-            )
-            .await?;
-        return Ok(());
-    }
-
-    if component.data.custom_id == super::commands::MODEL_RESET_CUSTOM_ID {
-        data.shared.model_overrides.remove(&channel_id);
-    } else {
-        let selected = match &component.data.kind {
-            serenity::ComponentInteractionDataKind::StringSelect { values } => {
-                values.first().cloned()
-            }
-            _ => None,
-        };
-
-        let Some(selected) = selected else {
-            component
-                .create_response(
-                    ctx,
-                    serenity::CreateInteractionResponse::Message(
-                        serenity::CreateInteractionResponseMessage::new()
-                            .content("Unsupported model picker interaction.")
-                            .ephemeral(true),
-                    ),
-                )
-                .await?;
-            return Ok(());
-        };
-
-        if selected == "__default__" || super::commands::is_clear_model_keyword(&selected) {
-            data.shared.model_overrides.remove(&channel_id);
-        } else {
-            let validated = match super::commands::validate_model_input(&data.provider, &selected) {
-                Ok(model) => model,
-                Err(message) => {
-                    component
-                        .create_response(
-                            ctx,
-                            serenity::CreateInteractionResponse::Message(
-                                serenity::CreateInteractionResponseMessage::new()
-                                    .content(message)
-                                    .ephemeral(true),
-                            ),
-                        )
-                        .await?;
-                    return Ok(());
-                }
-            };
-            data.shared.model_overrides.insert(channel_id, validated);
-        }
-    }
-
-    let embed =
-        super::commands::build_model_picker_embed(&data.shared, channel_id, &data.provider).await;
-    let components =
-        super::commands::build_model_picker_components(&data.shared, channel_id, &data.provider)
-            .await;
-    component
-        .create_response(
-            ctx,
-            serenity::CreateInteractionResponse::UpdateMessage(
-                serenity::CreateInteractionResponseMessage::new()
-                    .embed(embed)
-                    .components(components),
-            ),
-        )
-        .await?;
-    Ok(())
-}
+use super::model_picker_interaction::handle_model_picker_interaction;
 
 pub(super) async fn handle_text_message(
     ctx: &serenity::Context,
@@ -901,7 +849,6 @@ pub(super) async fn handle_text_message(
                     let (ch_name_resolved, cat_name) =
                         resolve_channel_category(ctx, channel_id).await;
                     {
-                        // Session ID comes from DB (sessions.claude_session_id), not from file.
                         let mut data = shared.core.lock().await;
                         let session =
                             data.sessions
@@ -1265,7 +1212,7 @@ pub(super) async fn handle_text_message(
             .and_then(|_| dispatch_type_str.as_deref()),
     );
 
-    let mut system_prompt_owned = build_system_prompt(
+    let system_prompt_owned = build_system_prompt(
         &discord_context,
         &current_path,
         channel_id,
@@ -1277,29 +1224,6 @@ pub(super) async fn handle_text_message(
         dispatch_profile,
         dispatch_type_str.as_deref(),
     );
-
-    // Inject session retry context (Discord history from stale session auto-retry).
-    // Consumed once — deleted after reading so subsequent turns don't see it.
-    if let Some(ref db) = shared.db {
-        let kv_key = format!("session_retry_context:{}", channel_id);
-        if let Ok(conn) = db.lock() {
-            let ctx: Option<String> = conn
-                .query_row(
-                    "SELECT value FROM kv_meta WHERE key = ?1",
-                    [&kv_key],
-                    |row| row.get::<_, String>(0),
-                )
-                .ok();
-            if let Some(history) = ctx {
-                system_prompt_owned.push_str(&format!(
-                    "\n\n[이전 대화 복원 — 세션이 만료되어 최근 대화를 컨텍스트로 제공합니다]\n{}",
-                    history
-                ));
-                conn.execute("DELETE FROM kv_meta WHERE key = ?1", [&kv_key])
-                    .ok();
-            }
-        }
-    }
 
     // Create cancel token — with second check to close the TOCTOU race window.
     // Multiple messages can pass the initial cancel_tokens check (line 169) concurrently
@@ -1520,6 +1444,8 @@ pub(super) async fn handle_text_message(
             })
     };
 
+    reset_provider_session_if_pending(shared, channel_id, &provider).await;
+
     // Resolve channel/tmux session name from current session state
     let (channel_name, tmux_session_name) = {
         let data = shared.core.lock().await;
@@ -1612,7 +1538,7 @@ pub(super) async fn handle_text_message(
         }
     };
 
-    let mut inflight_state = InflightTurnState::new(
+    let inflight_state = InflightTurnState::new(
         provider.clone(),
         channel_id.get(),
         channel_name.clone(),
@@ -1626,8 +1552,6 @@ pub(super) async fn handle_text_message(
         inflight_input_fifo.clone(),
         inflight_offset,
     );
-    inflight_state.session_key = adk_session_key.clone();
-    inflight_state.dispatch_id = dispatch_id.clone();
     if let Err(e) = save_inflight_state(&inflight_state) {
         let ts = chrono::Local::now().format("%H:%M:%S");
         println!("  [{ts}]   ⚠ inflight state save failed: {e}");
@@ -1684,41 +1608,8 @@ pub(super) async fn handle_text_message(
         }
     }
 
-    // Resolve model + reasoning_effort: DashMap override > dispatch role override > role-map > default
-    let (model_for_turn, reasoning_effort_for_turn): (Option<String>, Option<String>) = {
-        let dashmap_model = shared.model_overrides.get(&channel_id).map(|v| v.clone());
-        if dashmap_model.is_some() {
-            (dashmap_model, None)
-        } else if let Some(override_ch) = shared.dispatch_role_overrides.get(&channel_id) {
-            let alt_ch = *override_ch;
-            let rb = resolve_role_binding(alt_ch, None);
-            (
-                rb.as_ref().and_then(|r| r.model.clone()),
-                rb.as_ref().and_then(|r| r.reasoning_effort.clone()),
-            )
-        } else {
-            let ch_name = {
-                let data = shared.core.lock().await;
-                data.sessions
-                    .get(&channel_id)
-                    .and_then(|s| s.channel_name.clone())
-            };
-            let rb = resolve_role_binding(channel_id, ch_name.as_deref());
-            (
-                rb.as_ref().and_then(|r| r.model.clone()),
-                rb.as_ref().and_then(|r| r.reasoning_effort.clone()),
-            )
-        }
-    };
-
-    // Pass reasoning_effort to codex via environment variable
-    if let Some(ref effort) = reasoning_effort_for_turn {
-        // SAFETY: This runs on the tokio blocking thread pool before spawning the provider.
-        // No concurrent reads of this env var occur at this point.
-        unsafe {
-            std::env::set_var("AGENTDESK_CODEX_REASONING_EFFORT", effort);
-        }
-    }
+    let model_for_turn =
+        super::commands::resolve_model_for_turn(shared, channel_id, &provider).await;
 
     // Run the provider in a blocking thread
     let provider_for_blocking = provider.clone();
@@ -2289,9 +2180,11 @@ async fn handle_text_command(
             // Send /clear to the actual Claude Code session via tmux
             #[cfg(unix)]
             if let Some(ref name) = tmux_name {
-                let name = name.clone();
+                let exact_target = tmux_exact_target(name);
                 let _ = tokio::task::spawn_blocking(move || {
-                    crate::services::platform::tmux::send_keys(&name, &["/clear", "Enter"])
+                    std::process::Command::new("tmux")
+                        .args(["send-keys", "-t", &exact_target, "/clear", "Enter"])
+                        .output()
                 })
                 .await;
             }
@@ -2436,7 +2329,7 @@ Any other message is sent to {p}.
 `!cc <skill>` — Run a provider skill
 
 **Settings**
-`!model [get|set|clear] [name]` — Model management
+`/model` — Open the interactive model picker
 `!debug` — Toggle debug logging
 `!metrics [date]` — Show turn metrics
 `!queue [all]` — Show pending queue
@@ -2483,144 +2376,12 @@ Any other message is sent to {p}.
         "!model" => {
             let ts = chrono::Local::now().format("%H:%M:%S");
             println!("  [{ts}] ◀ [{}] !model {} {}", msg.author.name, arg1, arg2);
-
-            if !super::commands::provider_supports_model_override(&data.provider) {
-                let _ = msg
-                    .reply(
-                        &ctx.http,
-                        "Model override is only supported for Claude, Codex, and Gemini channels.",
-                    )
-                    .await;
-                return Ok(true);
-            }
-
-            match *arg1 {
-                "list" => {
-                    let embed = super::commands::build_model_picker_embed(
-                        &data.shared,
-                        channel_id,
-                        &data.provider,
-                    )
-                    .await;
-                    let components = super::commands::build_model_picker_components(
-                        &data.shared,
-                        channel_id,
-                        &data.provider,
-                    )
-                    .await;
-                    let _ = channel_id
-                        .send_message(
-                            &ctx.http,
-                            CreateMessage::new().embed(embed).components(components),
-                        )
-                        .await;
-                }
-                "info" => {
-                    let status = super::commands::build_model_info_message(
-                        &data.shared,
-                        channel_id,
-                        &data.provider,
-                    )
-                    .await;
-                    let _ = msg.reply(&ctx.http, status).await;
-                }
-                "set" => {
-                    if arg2.is_empty() {
-                        let _ = msg
-                            .reply(&ctx.http, "Usage: `!model set <model_name>`")
-                            .await;
-                    } else {
-                        let validated =
-                            match super::commands::validate_model_input(&data.provider, arg2) {
-                                Ok(model) => model,
-                                Err(message) => {
-                                    let _ = msg.reply(&ctx.http, message).await;
-                                    return Ok(true);
-                                }
-                            };
-                        data.shared
-                            .model_overrides
-                            .insert(channel_id, validated.clone());
-                        let status = super::commands::build_model_status_message(
-                            &data.shared,
-                            channel_id,
-                            &data.provider,
-                        )
-                        .await;
-                        let _ = msg
-                            .reply(
-                                &ctx.http,
-                                format!(
-                                    "Model set to **{}** for this channel.\n{}",
-                                    validated, status
-                                ),
-                            )
-                            .await;
-                    }
-                }
-                "clear" | "default" | "none" => {
-                    data.shared.model_overrides.remove(&channel_id);
-                    let status = super::commands::build_model_status_message(
-                        &data.shared,
-                        channel_id,
-                        &data.provider,
-                    )
-                    .await;
-                    let _ = msg
-                        .reply(&ctx.http, format!("Model override cleared.\n{}", status))
-                        .await;
-                }
-                "get" | "" => {
-                    let embed = super::commands::build_model_picker_embed(
-                        &data.shared,
-                        channel_id,
-                        &data.provider,
-                    )
-                    .await;
-                    let components = super::commands::build_model_picker_components(
-                        &data.shared,
-                        channel_id,
-                        &data.provider,
-                    )
-                    .await;
-                    let _ = msg
-                        .channel_id
-                        .send_message(
-                            &ctx.http,
-                            CreateMessage::new().embed(embed).components(components),
-                        )
-                        .await;
-                }
-                _ => {
-                    // Treat bare arg as shorthand for "set"
-                    let validated =
-                        match super::commands::validate_model_input(&data.provider, arg1) {
-                            Ok(model) => model,
-                            Err(message) => {
-                                let _ = msg.reply(&ctx.http, message).await;
-                                return Ok(true);
-                            }
-                        };
-                    data.shared
-                        .model_overrides
-                        .insert(channel_id, validated.clone());
-                    let status = super::commands::build_model_status_message(
-                        &data.shared,
-                        channel_id,
-                        &data.provider,
-                    )
-                    .await;
-                    let _ = msg
-                        .reply(
-                            &ctx.http,
-                            format!(
-                                "Model set to **{}** for this channel.\n{}",
-                                validated, status
-                            ),
-                        )
-                        .await;
-                }
-            }
+            let _ = msg
+                .reply(
+                    &ctx.http,
+                    "Model picker text commands are deprecated. Use `/model`.",
+                )
+                .await;
             return Ok(true);
         }
 
@@ -3122,6 +2883,7 @@ struct DispatchInfo {
     discord_channel_alt: Option<String>,
 }
 
+#[allow(dead_code)]
 async fn lookup_card_thread(api_port: u16, dispatch_id: &str) -> Option<String> {
     let info = lookup_dispatch_info(api_port, dispatch_id).await?;
     info.active_thread_id
@@ -3209,7 +2971,10 @@ async fn link_dispatch_thread(api_port: u16, dispatch_id: &str, thread_id: u64, 
 
 #[cfg(test)]
 mod tests {
-    use super::should_process_turn_message;
+    use super::super::model_picker_interaction::build_model_picker_close_response;
+    use super::{is_model_picker_component_custom_id, should_process_turn_message};
+    use poise::serenity_prelude::ChannelId;
+    use serde_json::json;
     use serenity::model::channel::MessageType;
 
     #[test]
@@ -3338,5 +3103,37 @@ mod tests {
         // is_thread_context=false → always blocked by the main branch
         let is_dup = now.duration_since(ts3) < msg_dedup_ttl;
         assert!(is_dup, "parent duplicate after thread must be blocked");
+    }
+
+    #[test]
+    fn model_picker_component_dispatch_matches_all_actions() {
+        let channel_id = ChannelId::new(42);
+        let custom_ids = [
+            format!("agentdesk:model-picker:{}", channel_id.get()),
+            format!("agentdesk:model-submit:{}", channel_id.get()),
+            format!("agentdesk:model-reset:{}", channel_id.get()),
+            format!("agentdesk:model-cancel:{}", channel_id.get()),
+        ];
+
+        for custom_id in custom_ids {
+            assert!(
+                is_model_picker_component_custom_id(&custom_id, channel_id),
+                "expected model picker dispatch for {custom_id}"
+            );
+        }
+
+        assert!(!is_model_picker_component_custom_id(
+            "agentdesk:other:42",
+            channel_id
+        ));
+    }
+
+    #[test]
+    fn model_picker_close_response_acknowledges_component_close() {
+        let payload = serde_json::to_value(build_model_picker_close_response())
+            .expect("close response should serialize");
+
+        assert_eq!(payload["type"], json!(6));
+        assert_eq!(payload["data"], json!(null));
     }
 }

--- a/src/services/discord/settings.rs
+++ b/src/services/discord/settings.rs
@@ -46,6 +46,8 @@ pub(super) struct RoleBinding {
     pub model: Option<String>,
     /// Optional reasoning effort for Codex (e.g. "low", "normal", "high", "xhigh")
     pub reasoning_effort: Option<String>,
+    /// Whether this role may see peer-agent handoff guidance in the system prompt.
+    pub peer_agents_enabled: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -83,7 +85,26 @@ pub(super) fn channel_supports_provider(
         }
     }
 
+    // When org.yaml is present, require an explicit channel binding or suffix match.
+    // This avoids the legacy "Claude catches all generic channels" behavior leaking
+    // into deployments that already opted into explicit org routing.
+    if org_schema::org_schema_exists() {
+        return false;
+    }
+
     provider.is_channel_supported(channel_name, is_dm)
+}
+
+pub(super) fn bot_settings_allow_channel(
+    settings: &DiscordBotSettings,
+    channel_id: ChannelId,
+    is_dm: bool,
+) -> bool {
+    if is_dm {
+        return true;
+    }
+    settings.allowed_channel_ids.is_empty()
+        || settings.allowed_channel_ids.contains(&channel_id.get())
 }
 
 /// Look up the provider for a channel name using the global suffix_map
@@ -420,6 +441,11 @@ pub(super) fn load_bot_settings(token: &str) -> DiscordBotSettings {
                 .collect()
         })
         .unwrap_or_default();
+    let allowed_channel_ids = entry
+        .get("allowed_channel_ids")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(json_u64).collect())
+        .unwrap_or_default();
     let allowed_user_ids = entry
         .get("allowed_user_ids")
         .and_then(|v| v.as_array())
@@ -430,6 +456,19 @@ pub(super) fn load_bot_settings(token: &str) -> DiscordBotSettings {
         .and_then(|v| v.as_array())
         .map(|arr| arr.iter().filter_map(json_u64).collect())
         .unwrap_or_default();
+    let channel_model_overrides = entry
+        .get("channel_model_overrides")
+        .and_then(|v| v.as_object())
+        .map(|obj| {
+            obj.iter()
+                .filter_map(|(channel_id, model)| {
+                    model
+                        .as_str()
+                        .map(|model| (channel_id.clone(), model.to_string()))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
     let allowed_tools = match entry.get("allowed_tools") {
         None => DEFAULT_ALLOWED_TOOLS
             .iter()
@@ -439,6 +478,7 @@ pub(super) fn load_bot_settings(token: &str) -> DiscordBotSettings {
             let Some(tools_arr) = value.as_array() else {
                 return DiscordBotSettings {
                     provider,
+                    allowed_channel_ids,
                     owner_user_id,
                     last_sessions,
                     last_remotes,
@@ -453,8 +493,10 @@ pub(super) fn load_bot_settings(token: &str) -> DiscordBotSettings {
     DiscordBotSettings {
         provider,
         allowed_tools,
+        allowed_channel_ids,
         last_sessions,
         last_remotes,
+        channel_model_overrides,
         owner_user_id,
         allowed_user_ids,
         allowed_bot_ids,
@@ -480,8 +522,10 @@ pub(super) fn save_bot_settings(token: &str, settings: &DiscordBotSettings) {
         "token": token,
         "provider": settings.provider.as_str(),
         "allowed_tools": normalized_tools,
+        "allowed_channel_ids": settings.allowed_channel_ids,
         "last_sessions": settings.last_sessions,
         "last_remotes": settings.last_remotes,
+        "channel_model_overrides": settings.channel_model_overrides,
         "allowed_user_ids": settings.allowed_user_ids,
         "allowed_bot_ids": settings.allowed_bot_ids,
     });
@@ -554,9 +598,9 @@ mod tests {
     use crate::services::provider::ProviderKind;
 
     use super::{
-        channel_supports_provider, discord_token_hash, load_bot_settings,
-        load_discord_bot_launch_configs, load_peer_agents, render_peer_agent_guidance,
-        resolve_role_binding,
+        bot_settings_allow_channel, channel_supports_provider, discord_token_hash,
+        load_bot_settings, load_discord_bot_launch_configs, load_peer_agents,
+        render_peer_agent_guidance, resolve_role_binding, save_bot_settings,
     };
 
     fn with_temp_home<F>(f: F)
@@ -681,6 +725,116 @@ mod tests {
             assert_eq!(settings.owner_user_id, Some(343742347365974000));
             assert_eq!(settings.allowed_user_ids, vec![429955158974136300]);
             assert_eq!(settings.allowed_bot_ids, vec![1479017284805722200]);
+        });
+    }
+
+    #[test]
+    fn test_load_bot_settings_reads_channel_model_overrides() {
+        with_temp_home(|temp_home: &TempDir| {
+            let settings_dir = temp_home.path().join(".adk").join("config");
+            fs::create_dir_all(&settings_dir).unwrap();
+            let token = "test-token";
+            let key = discord_token_hash(token);
+            let json = serde_json::json!({
+                key: {
+                    "token": token,
+                    "channel_model_overrides": {
+                        "123": "gpt-5.4",
+                        "456": "sonnet"
+                    }
+                }
+            });
+            fs::write(
+                settings_dir.join("bot_settings.json"),
+                serde_json::to_string_pretty(&json).unwrap(),
+            )
+            .unwrap();
+
+            let settings = load_bot_settings(token);
+            assert_eq!(
+                settings
+                    .channel_model_overrides
+                    .get("123")
+                    .map(String::as_str),
+                Some("gpt-5.4")
+            );
+            assert_eq!(
+                settings
+                    .channel_model_overrides
+                    .get("456")
+                    .map(String::as_str),
+                Some("sonnet")
+            );
+        });
+    }
+
+    #[test]
+    fn test_load_bot_settings_reads_allowed_channel_ids() {
+        with_temp_home(|temp_home: &TempDir| {
+            let settings_dir = temp_home.path().join(".adk").join("config");
+            fs::create_dir_all(&settings_dir).unwrap();
+            let token = "test-token";
+            let key = discord_token_hash(token);
+            let json = serde_json::json!({
+                key: {
+                    "token": token,
+                    "allowed_channel_ids": ["123", 456]
+                }
+            });
+            fs::write(
+                settings_dir.join("bot_settings.json"),
+                serde_json::to_string_pretty(&json).unwrap(),
+            )
+            .unwrap();
+
+            let settings = load_bot_settings(token);
+            assert_eq!(settings.allowed_channel_ids, vec![123, 456]);
+        });
+    }
+
+    #[test]
+    fn test_save_bot_settings_persists_channel_model_overrides() {
+        with_temp_home(|_temp_home: &TempDir| {
+            let token = "test-token";
+            let mut settings = super::super::DiscordBotSettings::default();
+            settings
+                .channel_model_overrides
+                .insert("123".to_string(), "gpt-5.4".to_string());
+            settings
+                .channel_model_overrides
+                .insert("456".to_string(), "sonnet".to_string());
+
+            save_bot_settings(token, &settings);
+
+            let loaded = load_bot_settings(token);
+            assert_eq!(
+                loaded
+                    .channel_model_overrides
+                    .get("123")
+                    .map(String::as_str),
+                Some("gpt-5.4")
+            );
+            assert_eq!(
+                loaded
+                    .channel_model_overrides
+                    .get("456")
+                    .map(String::as_str),
+                Some("sonnet")
+            );
+        });
+    }
+
+    #[test]
+    fn test_save_bot_settings_persists_allowed_channel_ids() {
+        with_temp_home(|_temp_home: &TempDir| {
+            let token = "test-token";
+            let mut settings = super::super::DiscordBotSettings::default();
+            settings.allowed_channel_ids = vec![123, 456];
+
+            save_bot_settings(token, &settings);
+
+            let loaded = load_bot_settings(token);
+            assert_eq!(loaded.allowed_channel_ids, vec![123, 456]);
         });
     }
 
@@ -836,6 +990,28 @@ mod tests {
     }
 
     #[test]
+    fn test_bot_settings_allow_channel_honors_allowlist() {
+        let mut settings = super::super::DiscordBotSettings::default();
+        settings.allowed_channel_ids = vec![1488022491992424448];
+
+        assert!(bot_settings_allow_channel(
+            &settings,
+            ChannelId::new(1488022491992424448),
+            false
+        ));
+        assert!(!bot_settings_allow_channel(
+            &settings,
+            ChannelId::new(1486017489027469493),
+            false
+        ));
+        assert!(bot_settings_allow_channel(
+            &settings,
+            ChannelId::new(999),
+            true
+        ));
+    }
+
+    #[test]
     fn test_channel_supports_provider_cc_claude_only() {
         use super::RoleBinding;
 
@@ -845,6 +1021,7 @@ mod tests {
             provider: Some(ProviderKind::Claude),
             model: None,
             reasoning_effort: None,
+            peer_agents_enabled: true,
         };
 
         // With a role binding specifying Claude, only Claude should match
@@ -860,5 +1037,80 @@ mod tests {
             false,
             Some(&binding),
         ));
+    }
+
+    #[test]
+    fn test_channel_supports_provider_org_schema_disables_generic_claude_fallback() {
+        with_temp_home(|temp_home: &TempDir| {
+            let settings_dir = temp_home.path().join(".adk").join("config");
+            fs::create_dir_all(&settings_dir).unwrap();
+            fs::write(
+                settings_dir.join("org.yaml"),
+                r#"
+version: 1
+name: "Test Org"
+agents:
+  claude:
+    display_name: "claude"
+    provider: claude
+channels:
+  by_name:
+    enabled: true
+    mappings:
+      "agentdesk-claude":
+        agent: claude
+        provider: claude
+"#,
+            )
+            .unwrap();
+
+            assert!(!channel_supports_provider(
+                &ProviderKind::Claude,
+                Some("random-general"),
+                false,
+                None,
+            ));
+            assert!(!channel_supports_provider(
+                &ProviderKind::Codex,
+                Some("random-general"),
+                false,
+                None,
+            ));
+        });
+    }
+
+    #[test]
+    fn test_channel_supports_provider_org_schema_suffix_match_still_works() {
+        with_temp_home(|temp_home: &TempDir| {
+            let settings_dir = temp_home.path().join(".adk").join("config");
+            fs::create_dir_all(&settings_dir).unwrap();
+            fs::write(
+                settings_dir.join("org.yaml"),
+                r#"
+version: 1
+name: "Test Org"
+agents:
+  codex:
+    display_name: "codex"
+    provider: codex
+suffix_map:
+  "-cdx": "codex"
+"#,
+            )
+            .unwrap();
+
+            assert!(channel_supports_provider(
+                &ProviderKind::Codex,
+                Some("agentdesk-cdx"),
+                false,
+                None,
+            ));
+            assert!(!channel_supports_provider(
+                &ProviderKind::Claude,
+                Some("agentdesk-cdx"),
+                false,
+                None,
+            ));
+        });
     }
 }

--- a/src/services/provider.rs
+++ b/src/services/provider.rs
@@ -39,6 +39,13 @@ pub struct ProviderRuntimeProbe {
     pub version: Option<String>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProviderDefaultBehavior {
+    pub resume_without_reset: bool,
+    pub runtime_model: Option<&'static str>,
+    pub source_label: &'static str,
+}
+
 impl ProviderKind {
     pub fn as_str(&self) -> &str {
         match self {
@@ -88,6 +95,23 @@ impl ProviderKind {
                 supports_tool_stream: true,
             }),
             Self::Unsupported(_) => None,
+        }
+    }
+
+    /// Provider-specific behavior when AgentDesk clears its explicit model
+    /// override and falls through to the provider-managed default path.
+    pub fn default_model_behavior(&self) -> ProviderDefaultBehavior {
+        match self {
+            Self::Claude => ProviderDefaultBehavior {
+                resume_without_reset: true,
+                runtime_model: Some("default"),
+                source_label: "Claude default alias",
+            },
+            Self::Codex | Self::Gemini | Self::Unsupported(_) => ProviderDefaultBehavior {
+                resume_without_reset: true,
+                runtime_model: None,
+                source_label: "provider default",
+            },
         }
     }
 


### PR DESCRIPTION
## 목표
Discord `/model` 설정을 대화형 picker UI로 전환하고, 채널별 model override 저장/복원과 한글화된 안내 문구, 액션 후 카드 즉시 닫힘까지 정리

## 추가 기능
기존 텍스트 중심 모델 전환 흐름을 Discord 컴포넌트 기반 picker 카드로 바꿔, 채널 운영자가 현재 provider에 맞는 모델을 바로 선택하고 기본값으로 되돌릴 수 있게 개선

## 주요 변경
- `/model` slash command picker flow와 component handler 추가
- Discord model picker 로직을 config, catalog, UI, interaction 모듈로 분리
- `bot_settings.json`에 `channel_model_overrides`를 저장하고 시작 시 복원
- 기본 옵션 label/description과 picker placeholder를 한글로 정리
- `저장`, `기본값`, `취소` 클릭 시 picker 카드 즉시 삭제
- legacy `!model` 사용을 `/model`로 유도
- 이 PR은 Discord model picker UI와 이를 성립시키는 최소 지원 코드만 포함

## 검증
- `cargo build --manifest-path /tmp/agentdesk-upstream-model-picker-pr/Cargo.toml`
- `cargo test -q --manifest-path /tmp/agentdesk-upstream-model-picker-pr/Cargo.toml model_picker`

## 참고
- current `upstream/main` 기준으로 cherry-pick 및 로컬 검증 완료
- codex/spark 채널 라우팅 hotfix는 별도 변경으로 분리
