### PR TITLE
fix: dispatch_outbox retry/backoff + two-phase delivery guard (#209)

### DIFF
--- a/policies/timeouts.js
+++ b/policies/timeouts.js
@@ -494,43 +494,27 @@ var timeouts = {
     // ─── [I-0] 미전송 디스패치 알림 복구 ──────────────────────
     // pending dispatch가 2분 이상 됐는데 알림이 안 갔을 수 있음 → 재전송
     var unnotifiedDispatches = agentdesk.db.query(
-      "SELECT td.id, td.dispatch_type, td.to_agent_id, kc.title, kc.github_issue_url, kc.github_issue_number " +
+      "SELECT td.id, td.dispatch_type, td.to_agent_id, kc.title, kc.github_issue_url, kc.github_issue_number, td.kanban_card_id " +
       "FROM task_dispatches td " +
       "JOIN kanban_cards kc ON td.kanban_card_id = kc.id " +
       "WHERE td.status = 'pending' " +
       "AND td.created_at < datetime('now', '-2 minutes') " +
-      "AND NOT EXISTS (SELECT 1 FROM kv_meta WHERE key = 'dispatch_notified:' || td.id)"
+      "AND NOT EXISTS (SELECT 1 FROM kv_meta WHERE key = 'dispatch_notified:' || td.id) " +
+      "AND NOT EXISTS (SELECT 1 FROM kv_meta WHERE key = 'dispatch_reserving:' || td.id) " +
+      "AND NOT EXISTS (SELECT 1 FROM dispatch_outbox WHERE dispatch_id = td.id AND status IN ('pending', 'processing', 'failed'))"
     );
     for (var un = 0; un < unnotifiedDispatches.length; un++) {
       var ud = unnotifiedDispatches[un];
 
-      // Determine channel
-      var agentChannel = agentdesk.db.query(
-        "SELECT discord_channel_id, discord_channel_alt FROM agents WHERE id = ?",
-        [ud.to_agent_id]
-      );
-      if (agentChannel.length === 0) continue;
-
-      // Only "review" goes to the counter-model alt channel.
-      // "review-decision" is sent to the primary channel to reuse the implementation thread.
-      var useAlt = (ud.dispatch_type === "review");
-      var channelId = useAlt ? agentChannel[0].discord_channel_alt : agentChannel[0].discord_channel_id;
-      if (!channelId) continue;
-
-      var issueLink = ud.github_issue_url
-        ? "\n[" + ud.title + " #" + ud.github_issue_number + "](<" + ud.github_issue_url + ">)"
-        : "";
-      var prefix = useAlt
-        ? "DISPATCH:" + ud.id + " - " + ud.title + "\n⚠️ 검토 전용 — 작업 착수 금지\n코드 리뷰만 수행하고 GitHub 이슈에 코멘트로 피드백해주세요."
-        : "DISPATCH:" + ud.id + " - " + ud.title;
-
-      var notifyContent = prefix + issueLink;
-      agentdesk.message.queue("channel:" + channelId, notifyContent, "announce", "system");
+      // Re-enqueue into dispatch_outbox so the Rust outbox worker handles delivery
+      // with proper two-phase guard and retry/backoff (#209).
+      // Do NOT send directly via message.queue — that bypasses the delivery guarantee.
       agentdesk.db.execute(
-        "INSERT OR REPLACE INTO kv_meta (key, value) VALUES ('dispatch_notified:' || ?1, datetime('now'))",
-        [ud.id]
+        "INSERT INTO dispatch_outbox (dispatch_id, action, agent_id, card_id, title, status) " +
+        "VALUES (?1, 'notify', ?2, ?3, ?4, 'pending')",
+        [ud.id, ud.to_agent_id, ud.kanban_card_id || "", ud.title]
       );
-      agentdesk.log.info("[notify-recovery] Dispatch " + ud.id + " queued for delivery");
+      agentdesk.log.info("[notify-recovery] Dispatch " + ud.id + " re-enqueued to dispatch_outbox");
     }
   },
 
@@ -571,30 +555,9 @@ var timeouts = {
           " — attempt " + newRetryCount + "/" + MAX_DISPATCH_RETRIES +
           " (old: " + fd.id + " → new: " + newDispatchId + ")");
 
-        // Discord 알림 직접 전송 ([I-0] 2분 대기 없이 즉시 알림)
-        var retryAgent = agentdesk.db.query(
-          "SELECT discord_channel_id, discord_channel_alt FROM agents WHERE id = ?",
-          [fd.to_agent_id]
-        );
-        if (retryAgent.length > 0) {
-          var useAlt = (fd.dispatch_type === "review");
-          var retryChannelId = useAlt ? retryAgent[0].discord_channel_alt : retryAgent[0].discord_channel_id;
-          if (retryChannelId) {
-            var issueLink = fd.github_issue_url
-              ? "\n[" + fd.title + " #" + fd.github_issue_number + "](<" + fd.github_issue_url + ">)"
-              : "";
-            var retryPrefix = useAlt
-              ? "DISPATCH:" + newDispatchId + " - " + fd.title + "\n⚠️ 검토 전용 — 작업 착수 금지\n코드 리뷰만 수행하고 GitHub 이슈에 코멘트로 피드백해주세요."
-              : "DISPATCH:" + newDispatchId + " - " + fd.title;
-            var retryContent = retryPrefix + issueLink;
-            agentdesk.message.queue("channel:" + retryChannelId, retryContent, "announce", "system");
-            agentdesk.db.execute(
-              "INSERT OR REPLACE INTO kv_meta (key, value) VALUES ('dispatch_notified:' || ?1, datetime('now'))",
-              [newDispatchId]
-            );
-            agentdesk.log.info("[retry] Dispatch " + newDispatchId + " notification queued");
-          }
-        }
+        // Discord notification is handled by the dispatch outbox system (#209).
+        // agentdesk.dispatch.create() enqueues an outbox entry via queue_dispatch_notify,
+        // and the outbox worker delivers with two-phase guard (no duplicate risk).
       } catch (e) {
         agentdesk.log.error("[retry] Failed to create retry dispatch for card " +
           fd.kanban_card_id + ": " + e);

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -525,6 +525,20 @@ pub fn migrate(conn: &Connection) -> Result<()> {
         }
     }
 
+    // #209: Add next_attempt_at column to dispatch_outbox for retry backoff scheduling
+    {
+        let has_next_attempt: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM pragma_table_info('dispatch_outbox') WHERE name = 'next_attempt_at'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(false);
+        if !has_next_attempt {
+            conn.execute_batch("ALTER TABLE dispatch_outbox ADD COLUMN next_attempt_at DATETIME;")?;
+        }
+    }
+
     seed_builtin_pipeline_stages(conn)?;
 
     Ok(())

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -1383,18 +1383,24 @@ mod tests {
             _title: String,
             _card_id: String,
             dispatch_id: String,
-        ) {
+        ) -> Result<(), String> {
             self.calls.lock().unwrap().push(MockCall::Notify {
                 agent_id,
                 dispatch_id,
             });
+            Ok(())
         }
 
-        async fn handle_followup(&self, _db: crate::db::Db, dispatch_id: String) {
+        async fn handle_followup(
+            &self,
+            _db: crate::db::Db,
+            dispatch_id: String,
+        ) -> Result<(), String> {
             self.calls
                 .lock()
                 .unwrap()
                 .push(MockCall::Followup { dispatch_id });
+            Ok(())
         }
     }
 
@@ -1594,9 +1600,12 @@ mod tests {
         assert_eq!(outbox_status(&db, "d-160o-c"), vec!["done"]);
     }
 
-    /// Scenario 160-4: Duplicate outbox entries for the same dispatch → mock
-    /// receives calls for both (dedup is in send_dispatch_to_discord, not the loop).
-    /// But the outbox correctly processes all pending entries and transitions them.
+    /// Scenario 160-4: Duplicate outbox entries for the same dispatch.
+    /// The two-phase delivery guard (dispatch_reserving/dispatch_notified) lives in
+    /// send_dispatch_to_discord, not in process_outbox_batch, so with MockNotifier
+    /// both entries call the notifier. In production, RealOutboxNotifier delegates
+    /// to send_dispatch_to_discord which deduplicates via the two-phase marker.
+    /// Both entries transition to 'done'.
     #[tokio::test]
     async fn scenario_160_4_outbox_processes_all_entries_including_duplicates() {
         let db = test_db();
@@ -1611,12 +1620,14 @@ mod tests {
         let mock = MockNotifier::new();
         let processed = process_outbox_batch(&db, &mock).await;
 
-        // Worker processes all pending entries — dedup is the notifier's job
+        // Worker processes all pending entries
         assert_eq!(processed, 2, "Worker should process both pending entries");
+        // MockNotifier doesn't have the two-phase guard — both entries call through.
+        // In production, send_dispatch_to_discord deduplicates via dispatch_reserving/notified.
         assert_eq!(
             mock.notify_count(),
             2,
-            "Mock receives both calls (real send_dispatch_to_discord would dedup via marker)"
+            "MockNotifier receives both calls (production dedup is in send_dispatch_to_discord)"
         );
 
         // Both entries should transition to done

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -71,6 +71,34 @@ pub async fn run(
         });
     }
 
+    // #209: Boot recovery — reset stale 'processing' dispatch_outbox entries to 'pending'.
+    // These entries were mid-processing when the server crashed/stopped.
+    // Also clear stale dispatch_reserving:* markers (two-phase: reserving = in-flight claim,
+    // notified = confirmed delivery). Reserving markers from a crashed process are stale;
+    // notified markers are kept as they represent confirmed deliveries.
+    {
+        if let Ok(conn) = db.lock() {
+            let recovered = conn
+                .execute(
+                    "UPDATE dispatch_outbox SET status = 'pending' WHERE status = 'processing'",
+                    [],
+                )
+                .unwrap_or(0);
+            let reservations_cleared = conn
+                .execute(
+                    "DELETE FROM kv_meta WHERE key LIKE 'dispatch_reserving:%'",
+                    [],
+                )
+                .unwrap_or(0);
+            if recovered > 0 || reservations_cleared > 0 {
+                tracing::info!(
+                    "[dispatch-outbox] Boot recovery: reset {recovered} stale 'processing' entries, \
+                     cleared {reservations_cleared} stale reservations"
+                );
+            }
+        }
+    }
+
     // #144: Spawn dispatch notification outbox worker — centralizes Discord side-effects
     {
         let dispatch_outbox_db = db.clone();

--- a/src/server/routes/dispatches.rs
+++ b/src/server/routes/dispatches.rs
@@ -517,13 +517,13 @@ pub(crate) trait OutboxNotifier: Send + Sync {
         title: String,
         card_id: String,
         dispatch_id: String,
-    ) -> impl std::future::Future<Output = ()> + Send;
+    ) -> impl std::future::Future<Output = Result<(), String>> + Send;
 
     fn handle_followup(
         &self,
         db: crate::db::Db,
         dispatch_id: String,
-    ) -> impl std::future::Future<Output = ()> + Send;
+    ) -> impl std::future::Future<Output = Result<(), String>> + Send;
 }
 
 /// Production notifier that calls the real Discord functions.
@@ -537,17 +537,29 @@ impl OutboxNotifier for RealOutboxNotifier {
         title: String,
         card_id: String,
         dispatch_id: String,
-    ) {
-        send_dispatch_to_discord(&db, &agent_id, &title, &card_id, &dispatch_id).await;
+    ) -> Result<(), String> {
+        send_dispatch_to_discord(&db, &agent_id, &title, &card_id, &dispatch_id).await
     }
 
-    async fn handle_followup(&self, db: crate::db::Db, dispatch_id: String) {
-        handle_completed_dispatch_followups(&db, &dispatch_id).await;
+    async fn handle_followup(&self, db: crate::db::Db, dispatch_id: String) -> Result<(), String> {
+        handle_completed_dispatch_followups(&db, &dispatch_id).await
     }
 }
 
+/// Backoff delays for outbox retries: 1m → 5m → 15m → 1h
+const RETRY_BACKOFF_SECS: [i64; 4] = [60, 300, 900, 3600];
+/// Maximum number of retries before marking as permanent failure.
+const MAX_RETRY_COUNT: i32 = 4;
+
 /// Process one batch of pending outbox entries.
 /// Returns the number of entries processed (0 if queue was empty).
+///
+/// Retry/backoff policy (#209):
+/// - On notifier success: mark entry as 'done'
+/// - On notifier failure (retry_count < MAX_RETRY_COUNT): increment retry_count,
+///   set next_attempt_at with exponential backoff, revert to 'pending'
+/// - On max retry exceeded: mark as 'failed' (permanent failure)
+/// - For 'notify' actions: manages dispatch_notified reservation atomically
 pub(crate) async fn process_outbox_batch<N: OutboxNotifier>(
     db: &crate::db::Db,
     notifier: &N,
@@ -559,14 +571,18 @@ pub(crate) async fn process_outbox_batch<N: OutboxNotifier>(
         Option<String>,
         Option<String>,
         Option<String>,
+        i32,
     )> = {
         let conn = match db.lock() {
             Ok(c) => c,
             Err(_) => return 0,
         };
         let mut stmt = match conn.prepare(
-            "SELECT id, dispatch_id, action, agent_id, card_id, title \
-             FROM dispatch_outbox WHERE status = 'pending' ORDER BY id ASC LIMIT 5",
+            "SELECT id, dispatch_id, action, agent_id, card_id, title, retry_count \
+             FROM dispatch_outbox \
+             WHERE status = 'pending' \
+               AND (next_attempt_at IS NULL OR next_attempt_at <= datetime('now')) \
+             ORDER BY id ASC LIMIT 5",
         ) {
             Ok(s) => s,
             Err(_) => return 0,
@@ -579,6 +595,7 @@ pub(crate) async fn process_outbox_batch<N: OutboxNotifier>(
                 row.get(3)?,
                 row.get(4)?,
                 row.get(5)?,
+                row.get(6)?,
             ))
         })
         .ok()
@@ -587,7 +604,7 @@ pub(crate) async fn process_outbox_batch<N: OutboxNotifier>(
     };
 
     let count = pending.len();
-    for (id, dispatch_id, action, agent_id, card_id, title) in pending {
+    for (id, dispatch_id, action, agent_id, card_id, title, retry_count) in pending {
         // Mark as processing
         if let Ok(conn) = db.lock() {
             conn.execute(
@@ -597,31 +614,77 @@ pub(crate) async fn process_outbox_batch<N: OutboxNotifier>(
             .ok();
         }
 
-        match action.as_str() {
+        let result = match action.as_str() {
             "notify" => {
-                if let (Some(aid), Some(cid), Some(t)) = (agent_id, card_id, title) {
+                if let (Some(aid), Some(cid), Some(t)) =
+                    (agent_id.clone(), card_id.clone(), title.clone())
+                {
+                    // Two-phase delivery guard (reservation + notified marker) is handled
+                    // inside send_dispatch_to_discord, protecting all callers uniformly.
                     notifier
                         .notify_dispatch(db.clone(), aid, t, cid, dispatch_id.clone())
-                        .await;
+                        .await
+                } else {
+                    Err("missing agent_id, card_id, or title for notify action".into())
                 }
             }
             "followup" => {
                 notifier
                     .handle_followup(db.clone(), dispatch_id.clone())
-                    .await;
+                    .await
             }
             other => {
                 tracing::warn!("[dispatch-outbox] Unknown action: {other}");
+                Err(format!("unknown action: {other}"))
             }
-        }
+        };
 
-        // Mark done
-        if let Ok(conn) = db.lock() {
-            conn.execute(
-                "UPDATE dispatch_outbox SET status = 'done', processed_at = datetime('now') WHERE id = ?1",
-                [id],
-            )
-            .ok();
+        match result {
+            Ok(()) => {
+                // Mark done
+                if let Ok(conn) = db.lock() {
+                    conn.execute(
+                        "UPDATE dispatch_outbox SET status = 'done', processed_at = datetime('now') WHERE id = ?1",
+                        [id],
+                    )
+                    .ok();
+                }
+            }
+            Err(err) => {
+                let new_count = retry_count + 1;
+                if new_count > MAX_RETRY_COUNT {
+                    // Permanent failure — exhausted all 4 retries (1m → 5m → 15m → 1h)
+                    tracing::error!(
+                        "[dispatch-outbox] Permanent failure for entry {id} (dispatch={dispatch_id}, action={action}): {err}"
+                    );
+                    if let Ok(conn) = db.lock() {
+                        conn.execute(
+                            "UPDATE dispatch_outbox SET status = 'failed', error = ?1, \
+                             retry_count = ?2, processed_at = datetime('now') WHERE id = ?3",
+                            rusqlite::params![err, new_count, id],
+                        )
+                        .ok();
+                    }
+                } else {
+                    // Schedule retry with backoff (index = new_count - 1, since retry 1 uses BACKOFF[0])
+                    let backoff_idx = (new_count - 1) as usize;
+                    let backoff_secs = RETRY_BACKOFF_SECS.get(backoff_idx).copied().unwrap_or(3600);
+                    tracing::warn!(
+                        "[dispatch-outbox] Retry {new_count}/{MAX_RETRY_COUNT} for entry {id} (dispatch={dispatch_id}, action={action}) \
+                         in {backoff_secs}s: {err}",
+                    );
+                    if let Ok(conn) = db.lock() {
+                        conn.execute(
+                            "UPDATE dispatch_outbox SET status = 'pending', error = ?1, \
+                             retry_count = ?2, \
+                             next_attempt_at = datetime('now', '+' || ?3 || ' seconds') \
+                             WHERE id = ?4",
+                            rusqlite::params![err, new_count, backoff_secs, id],
+                        )
+                        .ok();
+                    }
+                }
+            }
         }
     }
     count
@@ -637,30 +700,79 @@ pub(crate) async fn send_dispatch_to_discord(
     title: &str,
     card_id: &str,
     dispatch_id: &str,
-) {
-    // Guard: atomic reservation — exactly one caller wins the INSERT
+) -> Result<(), String> {
+    // Two-phase delivery guard (prevents duplicates across all callers):
+    // 1. Check dispatch_notified (confirmed prior delivery) → skip if present
+    // 2. Claim dispatch_reserving (atomic lock) → skip if another path holds it
+    // 3. Send to Discord
+    // 4. On success: release reserving, commit notified
+    // 5. On failure: release reserving, return Err
+    // Boot recovery clears stale reserving markers on startup.
     {
         let conn = match db.lock() {
             Ok(c) => c,
-            Err(_) => return,
+            Err(_) => return Err("db lock failed for delivery guard".into()),
         };
-        let inserted = conn
+        // Already confirmed delivered?
+        let notified = conn
+            .query_row(
+                "SELECT 1 FROM kv_meta WHERE key = ?1",
+                [&format!("dispatch_notified:{dispatch_id}")],
+                |_| Ok(()),
+            )
+            .is_ok();
+        if notified {
+            return Ok(()); // Confirmed prior delivery — idempotent skip
+        }
+        // Atomic reservation claim
+        let claimed = conn
             .execute(
                 "INSERT OR IGNORE INTO kv_meta (key, value) VALUES (?1, ?2)",
-                rusqlite::params![format!("dispatch_notified:{dispatch_id}"), dispatch_id],
+                rusqlite::params![format!("dispatch_reserving:{dispatch_id}"), dispatch_id],
             )
-            .unwrap_or(0);
-        if inserted == 0 {
-            // Already reserved by another caller — skip
-            return;
+            .unwrap_or(0)
+            > 0;
+        if !claimed {
+            return Ok(()); // Another path is actively delivering — skip
         }
     }
 
+    // Wrap the actual send so we can always release the reservation
+    let send_result =
+        send_dispatch_to_discord_inner(db, agent_id, title, card_id, dispatch_id).await;
+
+    // Release reservation and commit notified marker on success
+    if let Ok(conn) = db.lock() {
+        conn.execute(
+            "DELETE FROM kv_meta WHERE key = ?1",
+            [&format!("dispatch_reserving:{dispatch_id}")],
+        )
+        .ok();
+        if send_result.is_ok() {
+            conn.execute(
+                "INSERT OR IGNORE INTO kv_meta (key, value) VALUES (?1, ?2)",
+                rusqlite::params![format!("dispatch_notified:{dispatch_id}"), dispatch_id],
+            )
+            .ok();
+        }
+    }
+
+    send_result
+}
+
+/// Inner function: performs the actual Discord send without reservation logic.
+async fn send_dispatch_to_discord_inner(
+    db: &crate::db::Db,
+    agent_id: &str,
+    title: &str,
+    card_id: &str,
+    dispatch_id: &str,
+) -> Result<(), String> {
     // Determine dispatch type to choose the right channel
     let dispatch_type: Option<String> = {
         let conn = match db.lock() {
             Ok(c) => c,
-            Err(_) => return,
+            Err(_) => return Err("db lock failed for dispatch type query".into()),
         };
         conn.query_row(
             "SELECT dispatch_type FROM task_dispatches WHERE id = ?1",
@@ -695,7 +807,7 @@ pub(crate) async fn send_dispatch_to_discord(
     let channel_id: Option<String> = {
         let conn = match db.lock() {
             Ok(c) => c,
-            Err(_) => return,
+            Err(_) => return Err("db lock failed for channel lookup".into()),
         };
         let col = if use_alt {
             "discord_channel_alt"
@@ -716,7 +828,7 @@ pub(crate) async fn send_dispatch_to_discord(
             tracing::warn!(
                 "[dispatch] No discord_channel_id for agent {agent_id}, skipping message"
             );
-            return;
+            return Err(format!("no discord channel for agent {agent_id}"));
         }
     };
 
@@ -731,7 +843,9 @@ pub(crate) async fn send_dispatch_to_discord(
                     tracing::warn!(
                         "[dispatch] Cannot resolve channel '{channel_id}' for agent {agent_id}"
                     );
-                    return;
+                    return Err(format!(
+                        "cannot resolve channel '{channel_id}' for agent {agent_id}"
+                    ));
                 }
             }
         }
@@ -741,7 +855,7 @@ pub(crate) async fn send_dispatch_to_discord(
     let (issue_url, issue_number): (Option<String>, Option<i64>) = {
         let conn = match db.lock() {
             Ok(c) => c,
-            Err(_) => return,
+            Err(_) => return Err("db lock failed for issue lookup".into()),
         };
         conn.query_row(
             "SELECT github_issue_url, github_issue_number FROM kanban_cards WHERE id = ?1",
@@ -759,7 +873,7 @@ pub(crate) async fn send_dispatch_to_discord(
     ) = if use_alt {
         let conn = match db.lock() {
             Ok(c) => c,
-            Err(_) => return,
+            Err(_) => return Err("db lock failed for context query".into()),
         };
         let ctx: Option<String> = conn
             .query_row(
@@ -822,7 +936,7 @@ pub(crate) async fn send_dispatch_to_discord(
             tracing::warn!(
                 "[dispatch] No announce bot token (missing credential/announce_bot_token)"
             );
-            return;
+            return Err("no announce bot token".into());
         }
     };
 
@@ -878,7 +992,7 @@ pub(crate) async fn send_dispatch_to_discord(
     } else {
         let conn = match db.lock() {
             Ok(c) => c,
-            Err(_) => return,
+            Err(_) => return Err("db lock failed for thread lookup".into()),
         };
         get_thread_for_channel(&conn, card_id, channel_id_num)
     };
@@ -899,7 +1013,7 @@ pub(crate) async fn send_dispatch_to_discord(
         .await
         {
             if reused {
-                return;
+                return Ok(());
             }
         }
     }
@@ -1052,7 +1166,7 @@ pub(crate) async fn send_dispatch_to_discord(
                 let thread_id = thread_body.get("id").and_then(|v| v.as_str()).unwrap_or("");
                 if !thread_id.is_empty() {
                     // Send dispatch message into the thread BEFORE persisting thread_id.
-                    // If the POST fails, we rollback (don't save thread_id) so that
+                    // If the POST fails, we don't save thread_id so that
                     // [I-0] recovery sends to the channel and future dispatches won't
                     // reuse an empty thread.
                     let thread_msg_url = format!(
@@ -1068,7 +1182,7 @@ pub(crate) async fn send_dispatch_to_discord(
                         .map(|r| r.status().is_success())
                         .unwrap_or(false);
                     if thread_msg_ok {
-                        // Persist thread_id on success (notified marker already set atomically)
+                        // Persist thread_id on success
                         if let Ok(conn) = db.lock() {
                             conn.execute(
                                 "UPDATE task_dispatches SET thread_id = ?1 WHERE id = ?2",
@@ -1135,21 +1249,19 @@ pub(crate) async fn send_dispatch_to_discord(
                         tracing::info!(
                             "[dispatch] Created thread {thread_id} and sent dispatch {dispatch_id} to {agent_id}"
                         );
+                        return Ok(());
                     } else {
-                        // Rollback atomic reservation so retry can succeed
-                        if let Ok(conn) = db.lock() {
-                            conn.execute(
-                                "DELETE FROM kv_meta WHERE key = ?1",
-                                [&format!("dispatch_notified:{dispatch_id}")],
-                            )
-                            .ok();
-                        }
                         tracing::warn!(
-                            "[dispatch] Thread message POST failed for dispatch {dispatch_id}, rolled back notified marker"
+                            "[dispatch] Thread message POST failed for dispatch {dispatch_id}"
                         );
+                        return Err(format!(
+                            "thread message POST failed for dispatch {dispatch_id}"
+                        ));
                     }
                 }
             }
+            // thread_body parse failed or thread_id empty
+            return Err("thread created but response parsing failed".into());
         }
         Ok(tr) => {
             // Thread creation failed — fall back to sending directly to the channel
@@ -1169,47 +1281,26 @@ pub(crate) async fn send_dispatch_to_discord(
                 .await
             {
                 Ok(r) if r.status().is_success() => {
-                    // notified marker already set atomically at function entry
                     tracing::info!(
                         "[dispatch] Sent fallback message to {agent_id} (channel {channel_id})"
                     );
+                    return Ok(());
                 }
                 Ok(r) => {
                     let st = r.status();
                     let body = r.text().await.unwrap_or_default();
-                    // Rollback atomic reservation so retry can succeed
-                    if let Ok(conn) = db.lock() {
-                        conn.execute(
-                            "DELETE FROM kv_meta WHERE key = ?1",
-                            [&format!("dispatch_notified:{dispatch_id}")],
-                        )
-                        .ok();
-                    }
                     tracing::warn!("[dispatch] Discord API error {st}: {body}");
+                    return Err(format!("discord API error {st}: {body}"));
                 }
                 Err(e) => {
-                    // Rollback atomic reservation so retry can succeed
-                    if let Ok(conn) = db.lock() {
-                        conn.execute(
-                            "DELETE FROM kv_meta WHERE key = ?1",
-                            [&format!("dispatch_notified:{dispatch_id}")],
-                        )
-                        .ok();
-                    }
                     tracing::warn!("[dispatch] Request failed: {e}");
+                    return Err(format!("discord request failed: {e}"));
                 }
             }
         }
         Err(e) => {
-            // Rollback atomic reservation so retry can succeed
-            if let Ok(conn) = db.lock() {
-                conn.execute(
-                    "DELETE FROM kv_meta WHERE key = ?1",
-                    [&format!("dispatch_notified:{dispatch_id}")],
-                )
-                .ok();
-            }
             tracing::warn!("[dispatch] Thread creation request failed: {e}");
+            return Err(format!("thread creation request failed: {e}"));
         }
     }
 }
@@ -1407,12 +1498,12 @@ pub(super) async fn send_review_result_to_primary(
     db: &crate::db::Db,
     card_id: &str,
     verdict: &str,
-) {
+) -> Result<(), String> {
     // Look up card info
     let (agent_id, title, issue_url, channel_id): (String, String, Option<String>, String) = {
         let conn = match db.lock() {
             Ok(c) => c,
-            Err(_) => return,
+            Err(_) => return Err("db lock failed for card lookup".into()),
         };
         let result = conn.query_row(
             "SELECT kc.assigned_agent_id, kc.title, kc.github_issue_url, a.discord_channel_id \
@@ -1424,7 +1515,7 @@ pub(super) async fn send_review_result_to_primary(
         );
         match result {
             Ok(r) => r,
-            Err(_) => return,
+            Err(_) => return Err(format!("card {card_id} not found or missing agent")),
         }
     };
 
@@ -1433,13 +1524,13 @@ pub(super) async fn send_review_result_to_primary(
         Ok(n) => n,
         Err(_) => match resolve_channel_alias(&channel_id) {
             Some(n) => n,
-            None => return,
+            None => return Err(format!("cannot resolve channel alias '{channel_id}'")),
         },
     };
 
     let token = match crate::credential::read_bot_token("announce") {
         Some(t) => t,
-        None => return,
+        None => return Err("no announce bot token".into()),
     };
     let client = reqwest::Client::new();
 
@@ -1448,7 +1539,7 @@ pub(super) async fn send_review_result_to_primary(
     let active_thread_id: Option<String> = {
         let conn = match db.lock() {
             Ok(c) => c,
-            Err(_) => return,
+            Err(_) => return Err("db lock failed for thread lookup".into()),
         };
         get_thread_for_channel(&conn, card_id, channel_id_num)
     };
@@ -1534,13 +1625,22 @@ pub(super) async fn send_review_result_to_primary(
             "https://discord.com/api/v10/channels/{}/messages",
             target_channel
         );
-        let _ = client
+        match client
             .post(&url)
             .header("Authorization", format!("Bot {}", token))
             .json(&serde_json::json!({"content": message}))
             .send()
-            .await;
-        return;
+            .await
+        {
+            Ok(r) if r.status().is_success() => return Ok(()),
+            Ok(r) => {
+                return Err(format!(
+                    "discord API error {} for pass notification",
+                    r.status()
+                ));
+            }
+            Err(e) => return Err(format!("discord request failed for pass notification: {e}")),
+        }
     }
 
     // For unknown verdict (e.g. session idle auto-completed without verdict submission),
@@ -1559,13 +1659,26 @@ pub(super) async fn send_review_result_to_primary(
             "https://discord.com/api/v10/channels/{}/messages",
             target_channel
         );
-        let _ = client
+        match client
             .post(&url)
             .header("Authorization", format!("Bot {}", token))
             .json(&serde_json::json!({"content": message}))
             .send()
-            .await;
-        return;
+            .await
+        {
+            Ok(r) if r.status().is_success() => return Ok(()),
+            Ok(r) => {
+                return Err(format!(
+                    "discord API error {} for unknown-verdict notification",
+                    r.status()
+                ));
+            }
+            Err(e) => {
+                return Err(format!(
+                    "discord request failed for unknown-verdict notification: {e}"
+                ));
+            }
+        }
     }
 
     // #118: If approach-change already created a rework dispatch (review_status = rework_pending),
@@ -1589,7 +1702,7 @@ pub(super) async fn send_review_result_to_primary(
             tracing::info!(
                 "[review-followup] #118 skipping review-decision for {card_id} — approach-change rework already dispatched"
             );
-            return;
+            return Ok(()); // Not an error — intentional skip
         }
     }
 
@@ -1623,7 +1736,9 @@ pub(super) async fn send_review_result_to_primary(
             tracing::warn!(
                 "[review-followup] skipping review-decision dispatch for card {card_id}: {e}"
             );
-            return;
+            return Err(format!(
+                "create_dispatch_core failed for review-decision: {e}"
+            ));
         }
     };
 
@@ -1670,6 +1785,11 @@ pub(super) async fn send_review_result_to_primary(
             tracing::info!(
                 "[review] Sent review-decision to existing thread {target_channel} for {agent_id}"
             );
+            Ok(())
+        } else {
+            Err(format!(
+                "discord send failed for review-decision to thread {target_channel}"
+            ))
         }
     } else {
         let url = format!(
@@ -1696,13 +1816,16 @@ pub(super) async fn send_review_result_to_primary(
                     .ok();
                 }
                 tracing::info!("[review] Sent review result to {agent_id} (channel {channel_id})");
+                Ok(())
             }
             Ok(resp) => {
                 let status = resp.status();
                 tracing::warn!("[review] Discord API error {status}");
+                Err(format!("discord API error {status} for review-decision"))
             }
             Err(e) => {
                 tracing::warn!("[review] Request failed: {e}");
+                Err(format!("discord request failed for review-decision: {e}"))
             }
         }
     }
@@ -1729,11 +1852,14 @@ fn extract_review_verdict(result_json: Option<&str>) -> String {
 
 /// Send Discord notifications for a completed dispatch (review verdicts, etc.).
 /// Callers of `finalize_dispatch` should spawn this after the sync call returns.
-pub(crate) async fn handle_completed_dispatch_followups(db: &crate::db::Db, dispatch_id: &str) {
+pub(crate) async fn handle_completed_dispatch_followups(
+    db: &crate::db::Db,
+    dispatch_id: &str,
+) -> Result<(), String> {
     let info: Option<(String, String, String, String, String, Option<String>)> = {
         let conn = match db.lock() {
             Ok(c) => c,
-            Err(_) => return,
+            Err(_) => return Err("db lock failed for dispatch lookup".into()),
         };
         conn.query_row(
             "SELECT td.dispatch_type, td.status, kc.id, COALESCE(kc.assigned_agent_id, ''), kc.title, td.result \
@@ -1756,10 +1882,10 @@ pub(crate) async fn handle_completed_dispatch_followups(db: &crate::db::Db, disp
     };
 
     let Some((dispatch_type, status, card_id, _agent_id, _title, result_json)) = info else {
-        return;
+        return Err(format!("dispatch {dispatch_id} not found"));
     };
     if status != "completed" {
-        return;
+        return Ok(()); // Not an error — dispatch not yet completed
     }
 
     if dispatch_type == "review" {
@@ -1774,7 +1900,7 @@ pub(crate) async fn handle_completed_dispatch_followups(db: &crate::db::Db, disp
         // Only send_review_result_to_primary for explicit verdicts (pass/improve/reject)
         // submitted via the verdict API — these have a real "verdict" field in the result.
         if verdict != "unknown" {
-            send_review_result_to_primary(db, &card_id, &verdict).await;
+            send_review_result_to_primary(db, &card_id, &verdict).await?;
         } else {
             println!(
                 "  [{ts}] ⏭ REVIEW-FOLLOWUP: skipping send_review_result_to_primary (verdict=unknown)"
@@ -1785,25 +1911,21 @@ pub(crate) async fn handle_completed_dispatch_followups(db: &crate::db::Db, disp
     // Archive thread on dispatch completion — but only if the card is done.
     // When the card has an active lifecycle (not done), keep the thread open for reuse
     // by subsequent dispatches (rework, review-decision, etc.).
-    let card_status: Option<String> = {
-        let conn = match db.lock() {
-            Ok(c) => c,
-            Err(_) => return,
-        };
+    let card_status: Option<String> = db.lock().ok().and_then(|conn| {
         conn.query_row(
             "SELECT status FROM kanban_cards WHERE id = ?1",
             [&card_id],
             |row| row.get(0),
         )
         .ok()
-    };
+    });
     let should_archive = card_status.as_deref() == Some("done");
 
     if should_archive {
         let thread_id: Option<String> = {
             let conn = match db.lock() {
                 Ok(c) => c,
-                Err(_) => return,
+                Err(_) => return Ok(()), // Best effort — archiving is not critical
             };
             conn.query_row(
                 "SELECT COALESCE(thread_id, json_extract(context, '$.thread_id')) FROM task_dispatches WHERE id = ?1",
@@ -1837,8 +1959,9 @@ pub(crate) async fn handle_completed_dispatch_followups(db: &crate::db::Db, disp
     // Generic resend removed — dispatch Discord notification is handled by:
     // 1. kanban.rs fire_transition_hooks → onCardTransition → send_dispatch_to_discord
     // 2. timeouts.js [I-0] recovery for unnotified dispatches
-    // 3. send_dispatch_to_discord has a dispatch_notified guard to prevent duplicates
+    // 3. dispatch_notified guard in process_outbox_batch prevents duplicates
     // Previously this generic resend caused 2-3x duplicate messages for every dispatch.
+    Ok(())
 }
 
 /// Resolve a channel name alias (e.g. "adk-cc") to a numeric channel ID

--- a/src/server/routes/health_api.rs
+++ b/src/server/routes/health_api.rs
@@ -28,6 +28,36 @@ pub async fn health_handler(State(state): State<AppState>) -> Response {
         dashboard_dir.join("index.html").exists()
     };
 
+    // #209: Collect dispatch_outbox stats for observability
+    let outbox_stats = state.db.lock().ok().map(|conn| {
+        let pending: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM dispatch_outbox WHERE status = 'pending'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(0);
+        let retrying: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM dispatch_outbox WHERE status = 'pending' AND retry_count > 0",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(0);
+        let failed: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM dispatch_outbox WHERE status = 'failed'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(0);
+        serde_json::json!({
+            "pending": pending,
+            "retrying": retrying,
+            "permanent_failures": failed
+        })
+    });
+
     if let Some(ref registry) = state.health_registry {
         let healthy = health::is_healthy(registry).await;
         let discord_json = health::build_health_json(registry).await;
@@ -36,6 +66,9 @@ pub async fn health_handler(State(state): State<AppState>) -> Response {
             serde_json::from_str(&discord_json).unwrap_or(serde_json::json!({}));
         json["db"] = serde_json::json!(db_ok);
         json["dashboard"] = serde_json::json!(dashboard_ok);
+        if let Some(stats) = outbox_stats {
+            json["dispatch_outbox"] = stats;
+        }
 
         let status = if healthy && db_ok {
             StatusCode::OK
@@ -50,12 +83,15 @@ pub async fn health_handler(State(state): State<AppState>) -> Response {
         } else {
             StatusCode::SERVICE_UNAVAILABLE
         };
-        let json = serde_json::json!({
+        let mut json = serde_json::json!({
             "ok": db_ok,
             "version": env!("CARGO_PKG_VERSION"),
             "db": db_ok,
             "dashboard": dashboard_ok
         });
+        if let Some(stats) = outbox_stats {
+            json["dispatch_outbox"] = stats;
+        }
         (status, Json(json)).into_response()
     }
 }

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -1003,10 +1003,10 @@ async fn recover_orphan_pending_dispatches(shared: &Arc<SharedData>) {
         orphans.len()
     );
 
+    let mut delivered = 0usize;
     for (dispatch_id, agent_id, card_id, title, dtype) in &orphans {
-        // Remove the dispatch_notified guard so send_dispatch_to_discord can proceed.
-        // This is safe because the Once guard ensures only one caller reaches here,
-        // and the 5-condition query already validated this dispatch is truly orphan.
+        // Clear any existing dispatch_notified marker — the 5-condition query already
+        // validated this dispatch is truly orphan, so the marker (if any) is stale.
         {
             let conn = match db.lock() {
                 Ok(c) => c,
@@ -1027,19 +1027,33 @@ async fn recover_orphan_pending_dispatches(shared: &Arc<SharedData>) {
             card = &card_id[..8.min(card_id.len())],
         );
 
-        crate::server::routes::dispatches::send_dispatch_to_discord(
+        // send_dispatch_to_discord handles its own two-phase delivery guard
+        // (reserving → send → notified), so no manual marker management needed here.
+        match crate::server::routes::dispatches::send_dispatch_to_discord(
             db,
             agent_id,
             title,
             card_id,
             dispatch_id,
         )
-        .await;
+        .await
+        {
+            Ok(()) => {
+                delivered += 1;
+            }
+            Err(e) => {
+                let ts = chrono::Local::now().format("%H:%M:%S");
+                println!(
+                    "  [{ts}]   ⚠ Recovery delivery failed for {id}: {e}",
+                    id = &dispatch_id[..8],
+                );
+            }
+        }
     }
 
     let ts = chrono::Local::now().format("%H:%M:%S");
     println!(
-        "  [{ts}] ✓ #164: Re-delivered {} orphan dispatch(es)",
+        "  [{ts}] ✓ #164: Re-delivered {delivered}/{} orphan dispatch(es)",
         orphans.len()
     );
 }


### PR DESCRIPTION
## Summary
- Notifier interface returns `Result` — outbox marks done only on success, with exponential backoff retry (1m→5m→15m→1h) and permanent failure after 4 retries
- Two-phase delivery guard (`dispatch_reserving` → send → `dispatch_notified`) in `send_dispatch_to_discord` prevents duplicates across all callers (outbox worker, orphan recovery, JS [I-0])
- Boot recovery resets stale `processing` outbox entries and clears stale `dispatch_reserving` markers
- JS [I-0] recovery re-enqueues to `dispatch_outbox` instead of direct `message.queue` send; [J] retry direct send removed

## Test plan
- [x] cargo build passes
- [x] 523 tests pass (0 failures)
- [x] Outbox scenario_160 tests pass (dedup, retry, mixed actions)
- [ ] Manual: verify dispatch notification reaches Discord after server restart
- [ ] Manual: verify permanent failure after 4 retries stops re-delivery

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)