### PR TITLE
fix(discord): isolate routing by agent and channel

### DIFF
--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -61,8 +61,8 @@ use restart_report::flush_restart_reports;
 use router::{handle_event, handle_text_message};
 use runtime_store::worktrees_root;
 use settings::{
-    RoleBinding, bot_settings_allow_channel, channel_supports_provider, channel_upload_dir,
-    cleanup_old_uploads, load_bot_settings, resolve_role_binding, save_bot_settings,
+    RoleBinding, channel_upload_dir, cleanup_old_uploads, load_bot_settings,
+    resolve_role_binding, save_bot_settings, validate_bot_channel_routing,
 };
 use shared_memory::load_shared_knowledge;
 #[cfg(unix)]
@@ -250,6 +250,8 @@ pub(super) struct Intervention {
 /// Bot-level settings persisted to disk
 #[derive(Clone)]
 pub(super) struct DiscordBotSettings {
+    /// Optional agent identity (e.g. "codex", "spark") for same-provider isolation.
+    pub(super) agent: Option<String>,
     pub(super) provider: ProviderKind,
     pub(super) allowed_tools: Vec<String>,
     /// Explicit Discord channel allowlist for this bot token.
@@ -272,6 +274,7 @@ pub(super) struct DiscordBotSettings {
 impl Default for DiscordBotSettings {
     fn default() -> Self {
         Self {
+            agent: None,
             provider: ProviderKind::Claude,
             allowed_tools: DEFAULT_ALLOWED_TOOLS
                 .iter()

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -61,8 +61,8 @@ use restart_report::flush_restart_reports;
 use router::{handle_event, handle_text_message};
 use runtime_store::worktrees_root;
 use settings::{
-    RoleBinding, channel_upload_dir, cleanup_old_uploads, load_bot_settings,
-    resolve_role_binding, save_bot_settings, validate_bot_channel_routing,
+    RoleBinding, channel_upload_dir, cleanup_old_uploads, load_bot_settings, resolve_role_binding,
+    save_bot_settings, validate_bot_channel_routing,
 };
 use shared_memory::load_shared_knowledge;
 #[cfg(unix)]
@@ -3087,15 +3087,14 @@ pub(super) async fn provider_handles_channel(
         } else {
             (channel_id, channel_name)
         };
-    let role_binding =
-        resolve_role_binding(effective_channel_id, effective_channel_name.as_deref());
-
-    channel_supports_provider(
+    validate_bot_channel_routing(
+        settings,
         provider,
+        effective_channel_id,
         effective_channel_name.as_deref(),
         is_dm,
-        role_binding.as_ref(),
-    ) && bot_settings_allow_channel(settings, effective_channel_id, is_dm)
+    )
+    .is_ok()
 }
 
 /// If `channel_id` is a Discord thread, return the parent channel ID and name.

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -2984,7 +2984,7 @@ async fn bootstrap_thread_session(
 ) {
     let (_thread_title, cat_name) = resolve_channel_category(serenity_ctx, thread_channel_id).await;
     // Build a short, stable channel_name: "{parent_channel}-t{thread_id}"
-    let parent_info = resolve_thread_parent(serenity_ctx, thread_channel_id).await;
+    let parent_info = resolve_thread_parent(&serenity_ctx.http, thread_channel_id).await;
     let ch_name = if let Some((_parent_id, parent_name)) = parent_info {
         let parent = parent_name.unwrap_or_else(|| format!("{}", _parent_id));
         Some(format!("{}-t{}", parent, thread_channel_id.get()))
@@ -3081,12 +3081,13 @@ pub(super) async fn provider_handles_channel(
         Ok(serenity::model::channel::Channel::Private(_))
     );
     let (channel_name, _) = resolve_channel_category(ctx, channel_id).await;
-    let (effective_channel_id, effective_channel_name) =
-        if let Some((parent_id, parent_name)) = resolve_thread_parent(ctx, channel_id).await {
-            (parent_id, parent_name.or(channel_name))
-        } else {
-            (channel_id, channel_name)
-        };
+    let (effective_channel_id, effective_channel_name) = if let Some((parent_id, parent_name)) =
+        resolve_thread_parent(&ctx.http, channel_id).await
+    {
+        (parent_id, parent_name.or(channel_name))
+    } else {
+        (channel_id, channel_name)
+    };
     validate_bot_channel_routing(
         settings,
         provider,
@@ -3099,11 +3100,11 @@ pub(super) async fn provider_handles_channel(
 
 /// If `channel_id` is a Discord thread, return the parent channel ID and name.
 /// For non-thread channels, returns `None`.
-async fn resolve_thread_parent(
-    ctx: &serenity::prelude::Context,
+pub(super) async fn resolve_thread_parent(
+    http: &Arc<serenity::Http>,
     channel_id: serenity::model::id::ChannelId,
 ) -> Option<(serenity::model::id::ChannelId, Option<String>)> {
-    let channel = channel_id.to_channel(&ctx.http).await.ok()?;
+    let channel = channel_id.to_channel(http).await.ok()?;
     let serenity::model::channel::Channel::Guild(gc) = channel else {
         return None;
     };
@@ -3111,7 +3112,7 @@ async fn resolve_thread_parent(
     match gc.kind {
         ChannelType::PublicThread | ChannelType::PrivateThread => {
             let parent_id = gc.parent_id?;
-            let parent_name = if let Ok(parent_ch) = parent_id.to_channel(&ctx.http).await {
+            let parent_name = if let Ok(parent_ch) = parent_id.to_channel(http).await {
                 match parent_ch {
                     serenity::model::channel::Channel::Guild(pg) => Some(pg.name.clone()),
                     _ => None,

--- a/src/services/discord/recovery.rs
+++ b/src/services/discord/recovery.rs
@@ -248,6 +248,12 @@ pub(super) async fn restore_inflight_turns(
     let current_gen = shared.current_generation;
 
     for state in states {
+        let channel_id = ChannelId::new(state.channel_id);
+        let is_dm = matches!(
+            channel_id.to_channel(http).await,
+            Ok(serenity::model::channel::Channel::Private(_))
+        );
+
         // No generation gate — adopt mode allows old-gen session recovery.
         // If a restart report exists for this channel, check whether the agent
         // has already finished before deciding to skip recovery.  When the output
@@ -472,13 +478,12 @@ pub(super) async fn restore_inflight_turns(
                             .map(|(_, ch)| ch)
                     })
                 });
-                let channel_id = ChannelId::new(state.channel_id);
                 if let Err(reason) = validate_bot_channel_routing(
                     &settings_snapshot,
                     provider,
                     channel_id,
                     effective_channel_name.as_deref(),
-                    false,
+                    is_dm,
                 ) {
                     let ts = chrono::Local::now().format("%H:%M:%S");
                     match reason {
@@ -609,7 +614,6 @@ pub(super) async fn restore_inflight_turns(
             }
         }
 
-        let channel_id = ChannelId::new(state.channel_id);
         let current_msg_id = MessageId::new(state.current_msg_id);
         let user_msg_id = MessageId::new(state.user_msg_id);
         let channel_name = state.channel_name.clone();
@@ -629,7 +633,7 @@ pub(super) async fn restore_inflight_turns(
             provider,
             channel_id,
             channel_name.as_deref(),
-            false,
+            is_dm,
         ) {
             let ts = chrono::Local::now().format("%H:%M:%S");
             match reason {

--- a/src/services/discord/recovery.rs
+++ b/src/services/discord/recovery.rs
@@ -1,4 +1,8 @@
 use super::handoff::{HandoffRecord, save_handoff};
+use super::settings::{
+    bot_settings_allow_agent, bot_settings_allow_channel, channel_supports_provider,
+    resolve_role_binding,
+};
 use super::turn_bridge::stale_inflight_message;
 use super::*;
 use crate::services::tmux_common::tmux_exact_target;
@@ -470,6 +474,37 @@ pub(super) async fn restore_inflight_turns(
                     })
                 });
                 let channel_id = ChannelId::new(state.channel_id);
+                let role_binding =
+                    resolve_role_binding(channel_id, effective_channel_name.as_deref());
+                if !bot_settings_allow_channel(&settings_snapshot, channel_id, false) {
+                    let ts = chrono::Local::now().format("%H:%M:%S");
+                    println!(
+                        "  [{ts}] ⏭ inflight recovery skip for channel {} — not allowed for bot settings",
+                        state.channel_id
+                    );
+                    continue;
+                }
+                if !bot_settings_allow_agent(&settings_snapshot, role_binding.as_ref(), false) {
+                    let ts = chrono::Local::now().format("%H:%M:%S");
+                    println!(
+                        "  [{ts}] ⏭ inflight recovery skip for channel {} — agent mismatch",
+                        state.channel_id
+                    );
+                    continue;
+                }
+                if !channel_supports_provider(
+                    provider,
+                    effective_channel_name.as_deref(),
+                    false,
+                    role_binding.as_ref(),
+                ) {
+                    let ts = chrono::Local::now().format("%H:%M:%S");
+                    println!(
+                        "  [{ts}] ⏭ inflight recovery skip for channel {} — provider mismatch",
+                        state.channel_id
+                    );
+                    continue;
+                }
                 {
                     let mut data = shared.core.lock().await;
                     let session =
@@ -588,6 +623,42 @@ pub(super) async fn restore_inflight_turns(
                 .as_ref()
                 .map(|name| provider.build_tmux_session_name(name))
         });
+        let channel_name = channel_name.or_else(|| {
+            tmux_session_name.as_deref().and_then(|name| {
+                crate::services::provider::parse_provider_and_channel_from_tmux_name(name)
+                    .map(|(_, ch)| ch)
+            })
+        });
+        let role_binding = resolve_role_binding(channel_id, channel_name.as_deref());
+        if !bot_settings_allow_channel(&settings_snapshot, channel_id, false) {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            println!(
+                "  [{ts}] ⏭ inflight recovery skip for channel {} — not allowed for bot settings",
+                state.channel_id
+            );
+            continue;
+        }
+        if !bot_settings_allow_agent(&settings_snapshot, role_binding.as_ref(), false) {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            println!(
+                "  [{ts}] ⏭ inflight recovery skip for channel {} — agent mismatch",
+                state.channel_id
+            );
+            continue;
+        }
+        if !channel_supports_provider(
+            provider,
+            channel_name.as_deref(),
+            false,
+            role_binding.as_ref(),
+        ) {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            println!(
+                "  [{ts}] ⏭ inflight recovery skip for channel {} — provider mismatch",
+                state.channel_id
+            );
+            continue;
+        }
         let (fallback_output, fallback_input) = tmux_session_name
             .as_deref()
             .map(tmux_runtime_paths)
@@ -935,7 +1006,6 @@ pub(super) async fn restore_inflight_turns(
                 .insert(channel_id, UserId::new(state.request_owner_user_id));
         }
 
-        let role_binding = resolve_role_binding(channel_id, channel_name.as_deref());
         let adk_session_key = build_adk_session_key(shared, channel_id, provider).await;
         let adk_session_name = channel_name.clone();
         let adk_session_info = derive_adk_session_info(

--- a/src/services/discord/recovery.rs
+++ b/src/services/discord/recovery.rs
@@ -1,7 +1,6 @@
 use super::handoff::{HandoffRecord, save_handoff};
 use super::settings::{
-    bot_settings_allow_agent, bot_settings_allow_channel, channel_supports_provider,
-    resolve_role_binding,
+    BotChannelRoutingGuardFailure, resolve_role_binding, validate_bot_channel_routing,
 };
 use super::turn_bridge::stale_inflight_message;
 use super::*;
@@ -474,35 +473,31 @@ pub(super) async fn restore_inflight_turns(
                     })
                 });
                 let channel_id = ChannelId::new(state.channel_id);
-                let role_binding =
-                    resolve_role_binding(channel_id, effective_channel_name.as_deref());
-                if !bot_settings_allow_channel(&settings_snapshot, channel_id, false) {
-                    let ts = chrono::Local::now().format("%H:%M:%S");
-                    println!(
-                        "  [{ts}] ⏭ inflight recovery skip for channel {} — not allowed for bot settings",
-                        state.channel_id
-                    );
-                    continue;
-                }
-                if !bot_settings_allow_agent(&settings_snapshot, role_binding.as_ref(), false) {
-                    let ts = chrono::Local::now().format("%H:%M:%S");
-                    println!(
-                        "  [{ts}] ⏭ inflight recovery skip for channel {} — agent mismatch",
-                        state.channel_id
-                    );
-                    continue;
-                }
-                if !channel_supports_provider(
+                if let Err(reason) = validate_bot_channel_routing(
+                    &settings_snapshot,
                     provider,
+                    channel_id,
                     effective_channel_name.as_deref(),
                     false,
-                    role_binding.as_ref(),
                 ) {
                     let ts = chrono::Local::now().format("%H:%M:%S");
-                    println!(
-                        "  [{ts}] ⏭ inflight recovery skip for channel {} — provider mismatch",
-                        state.channel_id
-                    );
+                    match reason {
+                        BotChannelRoutingGuardFailure::ChannelNotAllowed => println!(
+                            "  [{ts}] ⏭ inflight recovery skip for channel {} — {}",
+                            state.channel_id,
+                            reason.message()
+                        ),
+                        BotChannelRoutingGuardFailure::AgentMismatch => println!(
+                            "  [{ts}] ⏭ inflight recovery skip for channel {} — {}",
+                            state.channel_id,
+                            reason.message()
+                        ),
+                        BotChannelRoutingGuardFailure::ProviderMismatch => println!(
+                            "  [{ts}] ⏭ inflight recovery skip for channel {} — {}",
+                            state.channel_id,
+                            reason.message()
+                        ),
+                    }
                     continue;
                 }
                 {
@@ -629,34 +624,31 @@ pub(super) async fn restore_inflight_turns(
                     .map(|(_, ch)| ch)
             })
         });
-        let role_binding = resolve_role_binding(channel_id, channel_name.as_deref());
-        if !bot_settings_allow_channel(&settings_snapshot, channel_id, false) {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            println!(
-                "  [{ts}] ⏭ inflight recovery skip for channel {} — not allowed for bot settings",
-                state.channel_id
-            );
-            continue;
-        }
-        if !bot_settings_allow_agent(&settings_snapshot, role_binding.as_ref(), false) {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            println!(
-                "  [{ts}] ⏭ inflight recovery skip for channel {} — agent mismatch",
-                state.channel_id
-            );
-            continue;
-        }
-        if !channel_supports_provider(
+        if let Err(reason) = validate_bot_channel_routing(
+            &settings_snapshot,
             provider,
+            channel_id,
             channel_name.as_deref(),
             false,
-            role_binding.as_ref(),
         ) {
             let ts = chrono::Local::now().format("%H:%M:%S");
-            println!(
-                "  [{ts}] ⏭ inflight recovery skip for channel {} — provider mismatch",
-                state.channel_id
-            );
+            match reason {
+                BotChannelRoutingGuardFailure::ChannelNotAllowed => println!(
+                    "  [{ts}] ⏭ inflight recovery skip for channel {} — {}",
+                    state.channel_id,
+                    reason.message()
+                ),
+                BotChannelRoutingGuardFailure::AgentMismatch => println!(
+                    "  [{ts}] ⏭ inflight recovery skip for channel {} — {}",
+                    state.channel_id,
+                    reason.message()
+                ),
+                BotChannelRoutingGuardFailure::ProviderMismatch => println!(
+                    "  [{ts}] ⏭ inflight recovery skip for channel {} — {}",
+                    state.channel_id,
+                    reason.message()
+                ),
+            }
             continue;
         }
         let (fallback_output, fallback_input) = tmux_session_name
@@ -1100,6 +1092,7 @@ pub(super) async fn restore_inflight_turns(
         let mut state = state;
         state.session_key = state.session_key.or_else(|| adk_session_key.clone());
         state.dispatch_id = state.dispatch_id.or_else(|| recovery_dispatch_id.clone());
+        let role_binding = resolve_role_binding(channel_id, channel_name.as_deref());
 
         spawn_turn_bridge(
             http.clone(),

--- a/src/services/discord/recovery.rs
+++ b/src/services/discord/recovery.rs
@@ -1,7 +1,5 @@
 use super::handoff::{HandoffRecord, save_handoff};
-use super::settings::{
-    BotChannelRoutingGuardFailure, resolve_role_binding, validate_bot_channel_routing,
-};
+use super::settings::{resolve_role_binding, validate_bot_channel_routing};
 use super::turn_bridge::stale_inflight_message;
 use super::*;
 use crate::services::tmux_common::tmux_exact_target;
@@ -495,23 +493,10 @@ pub(super) async fn restore_inflight_turns(
                     is_dm,
                 ) {
                     let ts = chrono::Local::now().format("%H:%M:%S");
-                    match reason {
-                        BotChannelRoutingGuardFailure::ChannelNotAllowed => println!(
-                            "  [{ts}] ⏭ inflight recovery skip for channel {} — {}",
-                            state.channel_id,
-                            reason.message()
-                        ),
-                        BotChannelRoutingGuardFailure::AgentMismatch => println!(
-                            "  [{ts}] ⏭ inflight recovery skip for channel {} — {}",
-                            state.channel_id,
-                            reason.message()
-                        ),
-                        BotChannelRoutingGuardFailure::ProviderMismatch => println!(
-                            "  [{ts}] ⏭ inflight recovery skip for channel {} — {}",
-                            state.channel_id,
-                            reason.message()
-                        ),
-                    }
+                    println!(
+                        "  [{ts}] ⏭ inflight recovery skip for channel {} — {reason}",
+                        state.channel_id,
+                    );
                     continue;
                 }
                 {
@@ -653,23 +638,10 @@ pub(super) async fn restore_inflight_turns(
             is_dm,
         ) {
             let ts = chrono::Local::now().format("%H:%M:%S");
-            match reason {
-                BotChannelRoutingGuardFailure::ChannelNotAllowed => println!(
-                    "  [{ts}] ⏭ inflight recovery skip for channel {} — {}",
-                    state.channel_id,
-                    reason.message()
-                ),
-                BotChannelRoutingGuardFailure::AgentMismatch => println!(
-                    "  [{ts}] ⏭ inflight recovery skip for channel {} — {}",
-                    state.channel_id,
-                    reason.message()
-                ),
-                BotChannelRoutingGuardFailure::ProviderMismatch => println!(
-                    "  [{ts}] ⏭ inflight recovery skip for channel {} — {}",
-                    state.channel_id,
-                    reason.message()
-                ),
-            }
+            println!(
+                "  [{ts}] ⏭ inflight recovery skip for channel {} — {reason}",
+                state.channel_id,
+            );
             continue;
         }
         let (fallback_output, fallback_input) = tmux_session_name

--- a/src/services/discord/recovery.rs
+++ b/src/services/discord/recovery.rs
@@ -478,11 +478,20 @@ pub(super) async fn restore_inflight_turns(
                             .map(|(_, ch)| ch)
                     })
                 });
+                // Resolve thread parent so validation uses the same semantics
+                // as normal message routing (router.rs).
+                let (eff_id, eff_name) = if let Some((pid, pname)) =
+                    super::resolve_thread_parent(http, channel_id).await
+                {
+                    (pid, pname.or(effective_channel_name.clone()))
+                } else {
+                    (channel_id, effective_channel_name.clone())
+                };
                 if let Err(reason) = validate_bot_channel_routing(
                     &settings_snapshot,
                     provider,
-                    channel_id,
-                    effective_channel_name.as_deref(),
+                    eff_id,
+                    eff_name.as_deref(),
                     is_dm,
                 ) {
                     let ts = chrono::Local::now().format("%H:%M:%S");
@@ -628,11 +637,19 @@ pub(super) async fn restore_inflight_turns(
                     .map(|(_, ch)| ch)
             })
         });
+        // Resolve thread parent so validation uses the same semantics
+        // as normal message routing (router.rs).
+        let (eff_id, eff_name) =
+            if let Some((pid, pname)) = super::resolve_thread_parent(http, channel_id).await {
+                (pid, pname.or(channel_name.clone()))
+            } else {
+                (channel_id, channel_name.clone())
+            };
         if let Err(reason) = validate_bot_channel_routing(
             &settings_snapshot,
             provider,
-            channel_id,
-            channel_name.as_deref(),
+            eff_id,
+            eff_name.as_deref(),
             is_dm,
         ) {
             let ts = chrono::Local::now().format("%H:%M:%S");

--- a/src/services/discord/restart_report.rs
+++ b/src/services/discord/restart_report.rs
@@ -9,6 +9,10 @@ use serde::{Deserialize, Serialize};
 use super::SharedData;
 use super::formatting::send_long_message_raw;
 use super::runtime_store::{atomic_write, discord_restart_reports_root};
+use super::settings::{
+    bot_settings_allow_agent, bot_settings_allow_channel, channel_supports_provider,
+    resolve_role_binding,
+};
 use crate::services::provider::ProviderKind;
 
 const RESTART_REPORT_VERSION: u32 = 1;
@@ -228,6 +232,40 @@ pub(super) async fn flush_restart_reports(
 
     for report in reports {
         let channel_id = serenity::ChannelId::new(report.channel_id);
+        let role_binding = resolve_role_binding(channel_id, report.channel_name.as_deref());
+        let settings_snapshot = { shared.settings.read().await.clone() };
+
+        if !bot_settings_allow_channel(&settings_snapshot, channel_id, false) {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            println!(
+                "  [{ts}] ⏭ restart report skip for channel {} — not allowed for bot settings",
+                report.channel_id
+            );
+            continue;
+        }
+
+        if !bot_settings_allow_agent(&settings_snapshot, role_binding.as_ref(), false) {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            println!(
+                "  [{ts}] ⏭ restart report skip for channel {} — agent mismatch",
+                report.channel_id
+            );
+            continue;
+        }
+
+        if !channel_supports_provider(
+            provider,
+            report.channel_name.as_deref(),
+            false,
+            role_binding.as_ref(),
+        ) {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            println!(
+                "  [{ts}] ⏭ restart report skip for channel {} — provider mismatch",
+                report.channel_id
+            );
+            continue;
+        }
 
         // "skipped" reports don't need Discord follow-up — just clean up
         if report.status == "skipped" {

--- a/src/services/discord/restart_report.rs
+++ b/src/services/discord/restart_report.rs
@@ -9,10 +9,7 @@ use serde::{Deserialize, Serialize};
 use super::SharedData;
 use super::formatting::send_long_message_raw;
 use super::runtime_store::{atomic_write, discord_restart_reports_root};
-use super::settings::{
-    bot_settings_allow_agent, bot_settings_allow_channel, channel_supports_provider,
-    resolve_role_binding,
-};
+use super::settings::{BotChannelRoutingGuardFailure, validate_bot_channel_routing};
 use crate::services::provider::ProviderKind;
 
 const RESTART_REPORT_VERSION: u32 = 1;
@@ -232,38 +229,33 @@ pub(super) async fn flush_restart_reports(
 
     for report in reports {
         let channel_id = serenity::ChannelId::new(report.channel_id);
-        let role_binding = resolve_role_binding(channel_id, report.channel_name.as_deref());
         let settings_snapshot = { shared.settings.read().await.clone() };
 
-        if !bot_settings_allow_channel(&settings_snapshot, channel_id, false) {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            println!(
-                "  [{ts}] ⏭ restart report skip for channel {} — not allowed for bot settings",
-                report.channel_id
-            );
-            continue;
-        }
-
-        if !bot_settings_allow_agent(&settings_snapshot, role_binding.as_ref(), false) {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            println!(
-                "  [{ts}] ⏭ restart report skip for channel {} — agent mismatch",
-                report.channel_id
-            );
-            continue;
-        }
-
-        if !channel_supports_provider(
+        if let Err(reason) = validate_bot_channel_routing(
+            &settings_snapshot,
             provider,
+            channel_id,
             report.channel_name.as_deref(),
             false,
-            role_binding.as_ref(),
         ) {
             let ts = chrono::Local::now().format("%H:%M:%S");
-            println!(
-                "  [{ts}] ⏭ restart report skip for channel {} — provider mismatch",
-                report.channel_id
-            );
+            match reason {
+                BotChannelRoutingGuardFailure::ChannelNotAllowed => println!(
+                    "  [{ts}] ⏭ restart report skip for channel {} — {}",
+                    report.channel_id,
+                    reason.message()
+                ),
+                BotChannelRoutingGuardFailure::AgentMismatch => println!(
+                    "  [{ts}] ⏭ restart report skip for channel {} — {}",
+                    report.channel_id,
+                    reason.message()
+                ),
+                BotChannelRoutingGuardFailure::ProviderMismatch => println!(
+                    "  [{ts}] ⏭ restart report skip for channel {} — {}",
+                    report.channel_id,
+                    reason.message()
+                ),
+            }
             continue;
         }
 

--- a/src/services/discord/restart_report.rs
+++ b/src/services/discord/restart_report.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use super::SharedData;
 use super::formatting::send_long_message_raw;
 use super::runtime_store::{atomic_write, discord_restart_reports_root};
-use super::settings::{BotChannelRoutingGuardFailure, validate_bot_channel_routing};
+use super::settings::validate_bot_channel_routing;
 use crate::services::provider::ProviderKind;
 
 const RESTART_REPORT_VERSION: u32 = 1;
@@ -243,23 +243,10 @@ pub(super) async fn flush_restart_reports(
             is_dm,
         ) {
             let ts = chrono::Local::now().format("%H:%M:%S");
-            match reason {
-                BotChannelRoutingGuardFailure::ChannelNotAllowed => println!(
-                    "  [{ts}] ⏭ restart report skip for channel {} — {}",
-                    report.channel_id,
-                    reason.message()
-                ),
-                BotChannelRoutingGuardFailure::AgentMismatch => println!(
-                    "  [{ts}] ⏭ restart report skip for channel {} — {}",
-                    report.channel_id,
-                    reason.message()
-                ),
-                BotChannelRoutingGuardFailure::ProviderMismatch => println!(
-                    "  [{ts}] ⏭ restart report skip for channel {} — {}",
-                    report.channel_id,
-                    reason.message()
-                ),
-            }
+            println!(
+                "  [{ts}] ⏭ restart report skip for channel {} — {reason}",
+                report.channel_id,
+            );
             continue;
         }
 

--- a/src/services/discord/restart_report.rs
+++ b/src/services/discord/restart_report.rs
@@ -230,13 +230,17 @@ pub(super) async fn flush_restart_reports(
     for report in reports {
         let channel_id = serenity::ChannelId::new(report.channel_id);
         let settings_snapshot = { shared.settings.read().await.clone() };
+        let is_dm = matches!(
+            channel_id.to_channel(http.as_ref()).await,
+            Ok(serenity::model::channel::Channel::Private(_))
+        );
 
         if let Err(reason) = validate_bot_channel_routing(
             &settings_snapshot,
             provider,
             channel_id,
             report.channel_name.as_deref(),
-            false,
+            is_dm,
         ) {
             let ts = chrono::Local::now().format("%H:%M:%S");
             match reason {

--- a/src/services/discord/router.rs
+++ b/src/services/discord/router.rs
@@ -213,18 +213,16 @@ pub(super) async fn handle_event(
             } else {
                 (channel_id, channel_name.clone())
             };
-            let role_binding =
-                resolve_role_binding(effective_channel_id, effective_channel_name.as_deref());
             let settings_snapshot = { data.shared.settings.read().await.clone() };
-            if !bot_settings_allow_channel(&settings_snapshot, effective_channel_id, is_dm) {
-                return Ok(());
-            }
-            if !channel_supports_provider(
+            if validate_bot_channel_routing(
+                &settings_snapshot,
                 &data.provider,
+                effective_channel_id,
                 effective_channel_name.as_deref(),
                 is_dm,
-                role_binding.as_ref(),
-            ) {
+            )
+            .is_err()
+            {
                 return Ok(());
             }
 

--- a/src/services/discord/router.rs
+++ b/src/services/discord/router.rs
@@ -119,7 +119,7 @@ pub(super) async fn handle_event(
                 }
 
                 // Check if this arrival is from a thread context
-                let is_thread_context = resolve_thread_parent(ctx, new_message.channel_id)
+                let is_thread_context = resolve_thread_parent(&ctx.http, new_message.channel_id)
                     .await
                     .is_some();
 
@@ -203,16 +203,14 @@ pub(super) async fn handle_event(
             let is_dm = new_message.guild_id.is_none();
             let (channel_name, _) = resolve_channel_category(ctx, channel_id).await;
             // For threads, inherit role binding from the parent channel
-            let (effective_channel_id, effective_channel_name) = if let Some((
-                parent_id,
-                parent_name,
-            )) =
-                resolve_thread_parent(ctx, channel_id).await
-            {
-                (parent_id, parent_name.or_else(|| channel_name.clone()))
-            } else {
-                (channel_id, channel_name.clone())
-            };
+            let (effective_channel_id, effective_channel_name) =
+                if let Some((parent_id, parent_name)) =
+                    resolve_thread_parent(&ctx.http, channel_id).await
+                {
+                    (parent_id, parent_name.or_else(|| channel_name.clone()))
+                } else {
+                    (channel_id, channel_name.clone())
+                };
             let settings_snapshot = { data.shared.settings.read().await.clone() };
             if validate_bot_channel_routing(
                 &settings_snapshot,
@@ -779,7 +777,7 @@ pub(super) async fn handle_text_message(
             // Fallback: if this is a thread, try resolving workspace from parent channel
             if workspace.is_none() {
                 if let Some((parent_id, parent_name)) =
-                    super::resolve_thread_parent(ctx, channel_id).await
+                    super::resolve_thread_parent(&ctx.http, channel_id).await
                 {
                     // Use parent name from Discord API first, fall back to session map
                     let parent_ch_name = parent_name.or_else(|| {
@@ -908,7 +906,7 @@ pub(super) async fn handle_text_message(
     // Skip if already inside a thread (threads cannot nest).
     // Thread reuse: if the card already has an active_thread_id, redirect
     // to the existing thread instead of creating a new one.
-    let is_already_thread = super::resolve_thread_parent(ctx, channel_id)
+    let is_already_thread = super::resolve_thread_parent(&ctx.http, channel_id)
         .await
         .is_some();
     let dispatch_id_for_thread = super::adk_session::parse_dispatch_id(user_text);

--- a/src/services/discord/settings.rs
+++ b/src/services/discord/settings.rs
@@ -107,6 +107,66 @@ pub(super) fn bot_settings_allow_channel(
         || settings.allowed_channel_ids.contains(&channel_id.get())
 }
 
+pub(super) fn bot_settings_allow_agent(
+    settings: &DiscordBotSettings,
+    role_binding: Option<&RoleBinding>,
+    is_dm: bool,
+) -> bool {
+    if is_dm {
+        return true;
+    }
+
+    let Some(expected_agent) = settings
+        .agent
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return true;
+    };
+
+    role_binding.is_some_and(|binding| binding.role_id.eq_ignore_ascii_case(expected_agent))
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum BotChannelRoutingGuardFailure {
+    ChannelNotAllowed,
+    AgentMismatch,
+    ProviderMismatch,
+}
+
+impl BotChannelRoutingGuardFailure {
+    pub(super) fn message(self) -> &'static str {
+        match self {
+            Self::ChannelNotAllowed => "not allowed for bot settings",
+            Self::AgentMismatch => "agent mismatch",
+            Self::ProviderMismatch => "provider mismatch",
+        }
+    }
+}
+
+pub(super) fn validate_bot_channel_routing(
+    settings: &DiscordBotSettings,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    channel_name: Option<&str>,
+    is_dm: bool,
+) -> Result<(), BotChannelRoutingGuardFailure> {
+    let role_binding = resolve_role_binding(channel_id, channel_name);
+
+    if !bot_settings_allow_channel(settings, channel_id, is_dm) {
+        return Err(BotChannelRoutingGuardFailure::ChannelNotAllowed);
+    }
+    if !bot_settings_allow_agent(settings, role_binding.as_ref(), is_dm) {
+        return Err(BotChannelRoutingGuardFailure::AgentMismatch);
+    }
+    if !channel_supports_provider(provider, channel_name, is_dm, role_binding.as_ref()) {
+        return Err(BotChannelRoutingGuardFailure::ProviderMismatch);
+    }
+
+    Ok(())
+}
+
 /// Look up the provider for a channel name using the global suffix_map
 /// from org.yaml or bot_settings.json.
 fn lookup_suffix_provider(channel_name: &str) -> Option<ProviderKind> {
@@ -417,6 +477,12 @@ pub(super) fn load_bot_settings(token: &str) -> DiscordBotSettings {
     let Some(entry) = json.get(&key) else {
         return DiscordBotSettings::default();
     };
+    let agent = entry
+        .get("agent")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
     let owner_user_id = entry.get("owner_user_id").and_then(json_u64);
     let provider = entry
         .get("provider")
@@ -477,6 +543,7 @@ pub(super) fn load_bot_settings(token: &str) -> DiscordBotSettings {
         Some(value) => {
             let Some(tools_arr) = value.as_array() else {
                 return DiscordBotSettings {
+                    agent,
                     provider,
                     allowed_channel_ids,
                     owner_user_id,
@@ -491,6 +558,7 @@ pub(super) fn load_bot_settings(token: &str) -> DiscordBotSettings {
         }
     };
     DiscordBotSettings {
+        agent,
         provider,
         allowed_tools,
         allowed_channel_ids,
@@ -520,6 +588,7 @@ pub(super) fn save_bot_settings(token: &str, settings: &DiscordBotSettings) {
     let normalized_tools = normalize_allowed_tools(&settings.allowed_tools);
     let mut entry = serde_json::json!({
         "token": token,
+        "agent": settings.agent,
         "provider": settings.provider.as_str(),
         "allowed_tools": normalized_tools,
         "allowed_channel_ids": settings.allowed_channel_ids,
@@ -598,8 +667,8 @@ mod tests {
     use crate::services::provider::ProviderKind;
 
     use super::{
-        bot_settings_allow_channel, channel_supports_provider, discord_token_hash,
-        load_bot_settings, load_discord_bot_launch_configs, load_peer_agents,
+        bot_settings_allow_agent, bot_settings_allow_channel, channel_supports_provider,
+        discord_token_hash, load_bot_settings, load_discord_bot_launch_configs, load_peer_agents,
         render_peer_agent_guidance, resolve_role_binding, save_bot_settings,
     };
 
@@ -839,6 +908,44 @@ mod tests {
     }
 
     #[test]
+    fn test_load_bot_settings_reads_agent_identity() {
+        with_temp_home(|temp_home: &TempDir| {
+            let settings_dir = temp_home.path().join(".adk").join("config");
+            fs::create_dir_all(&settings_dir).unwrap();
+            let token = "test-token";
+            let key = discord_token_hash(token);
+            let json = serde_json::json!({
+                key: {
+                    "token": token,
+                    "agent": "spark"
+                }
+            });
+            fs::write(
+                settings_dir.join("bot_settings.json"),
+                serde_json::to_string_pretty(&json).unwrap(),
+            )
+            .unwrap();
+
+            let settings = load_bot_settings(token);
+            assert_eq!(settings.agent.as_deref(), Some("spark"));
+        });
+    }
+
+    #[test]
+    fn test_save_bot_settings_persists_agent_identity() {
+        with_temp_home(|_temp_home: &TempDir| {
+            let token = "test-token";
+            let mut settings = super::super::DiscordBotSettings::default();
+            settings.agent = Some("codex".to_string());
+
+            save_bot_settings(token, &settings);
+
+            let loaded = load_bot_settings(token);
+            assert_eq!(loaded.agent.as_deref(), Some("codex"));
+        });
+    }
+
+    #[test]
     fn test_resolve_role_binding_reads_optional_provider() {
         with_temp_home(|temp_home: &TempDir| {
             let settings_dir = temp_home.path().join(".adk").join("config");
@@ -945,6 +1052,34 @@ mod tests {
         });
     }
 
+    #[test]
+    fn test_save_bot_settings_persists_allowed_channel_ids() {
+        with_temp_home(|_temp_home: &TempDir| {
+            let token = "test-token";
+            let mut settings = super::super::DiscordBotSettings::default();
+            settings.allowed_channel_ids = vec![123, 456];
+
+            save_bot_settings(token, &settings);
+
+            let loaded = load_bot_settings(token);
+            assert_eq!(loaded.allowed_channel_ids, vec![123, 456]);
+        });
+    }
+
+    #[test]
+    fn test_save_bot_settings_persists_agent_identity() {
+        with_temp_home(|_temp_home: &TempDir| {
+            let token = "test-token";
+            let mut settings = super::super::DiscordBotSettings::default();
+            settings.agent = Some("codex".to_string());
+
+            save_bot_settings(token, &settings);
+
+            let loaded = load_bot_settings(token);
+            assert_eq!(loaded.agent.as_deref(), Some("codex"));
+        });
+    }
+
     // ── P0 tests ─────────────────────────────────────────────────────────
 
     #[test]
@@ -1009,6 +1144,42 @@ mod tests {
             ChannelId::new(999),
             true
         ));
+    }
+
+    #[test]
+    fn test_bot_settings_allow_agent_requires_matching_role_binding() {
+        let mut settings = super::super::DiscordBotSettings::default();
+        settings.agent = Some("codex".to_string());
+
+        let codex_binding = super::RoleBinding {
+            role_id: "codex".to_string(),
+            prompt_file: "/tmp/codex.md".to_string(),
+            provider: Some(ProviderKind::Codex),
+            model: None,
+            reasoning_effort: None,
+            peer_agents_enabled: false,
+        };
+        let spark_binding = super::RoleBinding {
+            role_id: "spark".to_string(),
+            prompt_file: "/tmp/spark.md".to_string(),
+            provider: Some(ProviderKind::Codex),
+            model: None,
+            reasoning_effort: None,
+            peer_agents_enabled: false,
+        };
+
+        assert!(bot_settings_allow_agent(
+            &settings,
+            Some(&codex_binding),
+            false
+        ));
+        assert!(!bot_settings_allow_agent(
+            &settings,
+            Some(&spark_binding),
+            false
+        ));
+        assert!(!bot_settings_allow_agent(&settings, None, false));
+        assert!(bot_settings_allow_agent(&settings, None, true));
     }
 
     #[test]

--- a/src/services/discord/settings.rs
+++ b/src/services/discord/settings.rs
@@ -1053,34 +1053,6 @@ mod tests {
         });
     }
 
-    #[test]
-    fn test_save_bot_settings_persists_allowed_channel_ids() {
-        with_temp_home(|_temp_home: &TempDir| {
-            let token = "test-token";
-            let mut settings = super::super::DiscordBotSettings::default();
-            settings.allowed_channel_ids = vec![123, 456];
-
-            save_bot_settings(token, &settings);
-
-            let loaded = load_bot_settings(token);
-            assert_eq!(loaded.allowed_channel_ids, vec![123, 456]);
-        });
-    }
-
-    #[test]
-    fn test_save_bot_settings_persists_agent_identity() {
-        with_temp_home(|_temp_home: &TempDir| {
-            let token = "test-token";
-            let mut settings = super::super::DiscordBotSettings::default();
-            settings.agent = Some("codex".to_string());
-
-            save_bot_settings(token, &settings);
-
-            let loaded = load_bot_settings(token);
-            assert_eq!(loaded.agent.as_deref(), Some("codex"));
-        });
-    }
-
     // ── P0 tests ─────────────────────────────────────────────────────────
 
     #[test]

--- a/src/services/discord/settings.rs
+++ b/src/services/discord/settings.rs
@@ -667,9 +667,10 @@ mod tests {
     use crate::services::provider::ProviderKind;
 
     use super::{
-        bot_settings_allow_agent, bot_settings_allow_channel, channel_supports_provider,
-        discord_token_hash, load_bot_settings, load_discord_bot_launch_configs, load_peer_agents,
-        render_peer_agent_guidance, resolve_role_binding, save_bot_settings,
+        BotChannelRoutingGuardFailure, bot_settings_allow_agent, bot_settings_allow_channel,
+        channel_supports_provider, discord_token_hash, load_bot_settings,
+        load_discord_bot_launch_configs, load_peer_agents, render_peer_agent_guidance,
+        resolve_role_binding, save_bot_settings, validate_bot_channel_routing,
     };
 
     fn with_temp_home<F>(f: F)
@@ -1180,6 +1181,25 @@ mod tests {
         ));
         assert!(!bot_settings_allow_agent(&settings, None, false));
         assert!(bot_settings_allow_agent(&settings, None, true));
+    }
+
+    #[test]
+    fn test_validate_bot_channel_routing_reports_channel_not_allowed() {
+        let mut settings = super::super::DiscordBotSettings::default();
+        settings.allowed_channel_ids = vec![1488022491992424448];
+
+        let result = validate_bot_channel_routing(
+            &settings,
+            &ProviderKind::Codex,
+            ChannelId::new(1486017489027469493),
+            Some("agentdesk-codex"),
+            false,
+        );
+
+        assert_eq!(
+            result,
+            Err(BotChannelRoutingGuardFailure::ChannelNotAllowed)
+        );
     }
 
     #[test]

--- a/src/services/discord/settings.rs
+++ b/src/services/discord/settings.rs
@@ -135,12 +135,12 @@ pub(super) enum BotChannelRoutingGuardFailure {
     ProviderMismatch,
 }
 
-impl BotChannelRoutingGuardFailure {
-    pub(super) fn message(self) -> &'static str {
+impl std::fmt::Display for BotChannelRoutingGuardFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::ChannelNotAllowed => "not allowed for bot settings",
-            Self::AgentMismatch => "agent mismatch",
-            Self::ProviderMismatch => "provider mismatch",
+            Self::ChannelNotAllowed => f.write_str("not allowed for bot settings"),
+            Self::AgentMismatch => f.write_str("agent mismatch"),
+            Self::ProviderMismatch => f.write_str("provider mismatch"),
         }
     }
 }

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -14,7 +14,10 @@ use crate::services::tmux_diagnostics::{
 use super::formatting::{
     format_for_discord, format_tool_input, normalize_empty_lines, send_long_message_raw,
 };
-use super::settings::{channel_supports_provider, resolve_role_binding};
+use super::settings::{
+    bot_settings_allow_agent, bot_settings_allow_channel, channel_supports_provider,
+    resolve_role_binding,
+};
 use super::{DISCORD_MSG_LIMIT, SharedData, TmuxWatcherHandle, rate_limit_wait};
 
 use crate::utils::format::tail_with_ellipsis;
@@ -1150,7 +1153,8 @@ pub(super) fn process_watcher_lines(
 /// On startup, scan for surviving tmux sessions (AgentDesk-*) and restore watchers.
 /// This handles the case where AgentDesk was restarted but tmux sessions are still alive.
 pub(super) async fn restore_tmux_watchers(http: &Arc<serenity::Http>, shared: &Arc<SharedData>) {
-    let provider = shared.settings.read().await.provider.clone();
+    let settings_snapshot = { shared.settings.read().await.clone() };
+    let provider = settings_snapshot.provider.clone();
 
     // List tmux sessions matching our naming convention
     let output = match tokio::time::timeout(
@@ -1278,6 +1282,31 @@ pub(super) async fn restore_tmux_watchers(http: &Arc<serenity::Http>, shared: &A
 
         // #148: Do NOT register in owned_sessions yet — QUARANTINE check below may
         // skip this session. Registering early blocks new session creation for the channel.
+        let role_binding = resolve_role_binding(*channel_id, Some(channel_name));
+        if !bot_settings_allow_channel(&settings_snapshot, *channel_id, false) {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            println!(
+                "  [{ts}] ⏭ watcher skip for {} — channel {} not allowed for bot settings",
+                session_name, channel_id
+            );
+            continue;
+        }
+        if !bot_settings_allow_agent(&settings_snapshot, role_binding.as_ref(), false) {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            println!(
+                "  [{ts}] ⏭ watcher skip for {} — agent mismatch for channel {}",
+                session_name, channel_id
+            );
+            continue;
+        }
+        if !channel_supports_provider(&provider, Some(channel_name), false, role_binding.as_ref()) {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            println!(
+                "  [{ts}] ⏭ watcher skip for {} — provider mismatch for channel {}",
+                session_name, channel_id
+            );
+            continue;
+        }
 
         if let Some(started) = shared.recovering_channels.get(channel_id) {
             if started.elapsed() < std::time::Duration::from_secs(60) {

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -15,8 +15,8 @@ use super::formatting::{
     format_for_discord, format_tool_input, normalize_empty_lines, send_long_message_raw,
 };
 use super::settings::{
-    bot_settings_allow_agent, bot_settings_allow_channel, channel_supports_provider,
-    resolve_role_binding,
+    BotChannelRoutingGuardFailure, channel_supports_provider, resolve_role_binding,
+    validate_bot_channel_routing,
 };
 use super::{DISCORD_MSG_LIMIT, SharedData, TmuxWatcherHandle, rate_limit_wait};
 
@@ -1282,29 +1282,34 @@ pub(super) async fn restore_tmux_watchers(http: &Arc<serenity::Http>, shared: &A
 
         // #148: Do NOT register in owned_sessions yet — QUARANTINE check below may
         // skip this session. Registering early blocks new session creation for the channel.
-        let role_binding = resolve_role_binding(*channel_id, Some(channel_name));
-        if !bot_settings_allow_channel(&settings_snapshot, *channel_id, false) {
+        if let Err(reason) = validate_bot_channel_routing(
+            &settings_snapshot,
+            &provider,
+            *channel_id,
+            Some(channel_name),
+            false,
+        ) {
             let ts = chrono::Local::now().format("%H:%M:%S");
-            println!(
-                "  [{ts}] ⏭ watcher skip for {} — channel {} not allowed for bot settings",
-                session_name, channel_id
-            );
-            continue;
-        }
-        if !bot_settings_allow_agent(&settings_snapshot, role_binding.as_ref(), false) {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            println!(
-                "  [{ts}] ⏭ watcher skip for {} — agent mismatch for channel {}",
-                session_name, channel_id
-            );
-            continue;
-        }
-        if !channel_supports_provider(&provider, Some(channel_name), false, role_binding.as_ref()) {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            println!(
-                "  [{ts}] ⏭ watcher skip for {} — provider mismatch for channel {}",
-                session_name, channel_id
-            );
+            match reason {
+                BotChannelRoutingGuardFailure::ChannelNotAllowed => println!(
+                    "  [{ts}] ⏭ watcher skip for {} — channel {} {}",
+                    session_name,
+                    channel_id,
+                    reason.message()
+                ),
+                BotChannelRoutingGuardFailure::AgentMismatch => println!(
+                    "  [{ts}] ⏭ watcher skip for {} — {} for channel {}",
+                    session_name,
+                    reason.message(),
+                    channel_id
+                ),
+                BotChannelRoutingGuardFailure::ProviderMismatch => println!(
+                    "  [{ts}] ⏭ watcher skip for {} — {} for channel {}",
+                    session_name,
+                    reason.message(),
+                    channel_id
+                ),
+            }
             continue;
         }
 

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -15,8 +15,7 @@ use super::formatting::{
     format_for_discord, format_tool_input, normalize_empty_lines, send_long_message_raw,
 };
 use super::settings::{
-    BotChannelRoutingGuardFailure, channel_supports_provider, resolve_role_binding,
-    validate_bot_channel_routing,
+    channel_supports_provider, resolve_role_binding, validate_bot_channel_routing,
 };
 use super::{DISCORD_MSG_LIMIT, SharedData, TmuxWatcherHandle, rate_limit_wait};
 
@@ -1282,34 +1281,30 @@ pub(super) async fn restore_tmux_watchers(http: &Arc<serenity::Http>, shared: &A
 
         // #148: Do NOT register in owned_sessions yet — QUARANTINE check below may
         // skip this session. Registering early blocks new session creation for the channel.
+        let is_dm = matches!(
+            channel_id.to_channel(http.as_ref()).await,
+            Ok(serenity::model::channel::Channel::Private(_))
+        );
+        // Resolve thread parent so validation uses the same semantics
+        // as normal message routing (router.rs).
+        let (eff_id, eff_name) =
+            if let Some((pid, pname)) = super::resolve_thread_parent(http, *channel_id).await {
+                (pid, pname.unwrap_or_else(|| channel_name.clone()))
+            } else {
+                (*channel_id, channel_name.clone())
+            };
         if let Err(reason) = validate_bot_channel_routing(
             &settings_snapshot,
             &provider,
-            *channel_id,
-            Some(channel_name),
-            false,
+            eff_id,
+            Some(&eff_name),
+            is_dm,
         ) {
             let ts = chrono::Local::now().format("%H:%M:%S");
-            match reason {
-                BotChannelRoutingGuardFailure::ChannelNotAllowed => println!(
-                    "  [{ts}] ⏭ watcher skip for {} — channel {} {}",
-                    session_name,
-                    channel_id,
-                    reason.message()
-                ),
-                BotChannelRoutingGuardFailure::AgentMismatch => println!(
-                    "  [{ts}] ⏭ watcher skip for {} — {} for channel {}",
-                    session_name,
-                    reason.message(),
-                    channel_id
-                ),
-                BotChannelRoutingGuardFailure::ProviderMismatch => println!(
-                    "  [{ts}] ⏭ watcher skip for {} — {} for channel {}",
-                    session_name,
-                    reason.message(),
-                    channel_id
-                ),
-            }
+            println!(
+                "  [{ts}] ⏭ watcher skip for {} — {reason} for channel {}",
+                session_name, channel_id
+            );
             continue;
         }
 


### PR DESCRIPTION
## 목표
- 같은 provider를 공유하는 여러 Discord bot이 채널/에이전트 경계를 넘어서 응답하거나 세션을 복구하지 않도록 라우팅 가드를 일관되게 적용합니다.
- 일반 메시지 처리뿐 아니라 watcher 복구, restart follow-up, inflight recovery까지 동일한 기준으로 막습니다.

## 겪은 문제
- 같은 provider를 쓰는 bot이 `provider` 기준만으로 채널을 판단해서, role binding상 다른 agent가 맡아야 하는 채널에도 응답할 수 있었습니다.
- 재시작 이후에는 일반 turn 라우팅만으로는 부족했고, watcher 복구 / restart follow-up / inflight recovery 경로에서 잘못된 채널로 다시 붙거나 후속 메시지를 보내는 문제가 있었습니다.
- 특히 recovery 경로에서는 thread를 parent channel이 아니라 thread 자체 정보로 검증할 수 있었고, restart report 경로에서는 DM follow-up도 non-DM 규칙으로 검증될 수 있었습니다.
- 라우팅 판단 로직이 여러 파일에 흩어져 있어서 한 경로를 고쳐도 다른 경로에는 동일한 보호가 빠지기 쉬웠습니다.

## 이 PR로 해결한 내용
- `allowed_channel_ids + agent + provider`를 함께 검증하는 공용 helper를 추가해 라우팅 기준을 한 곳으로 모았습니다.
- 일반 turn, provider channel 판정, watcher 복구, restart follow-up, inflight recovery가 같은 helper를 사용하도록 통일했습니다.
- recovery 경로에서는 thread parent를 먼저 해석한 뒤 같은 effective channel로 라우팅 검증과 role binding을 수행하도록 맞췄습니다.
- restart report 경로에서는 실제 `is_dm` 여부를 다시 계산해서, DM follow-up이 non-DM 검증에 잘못 막히지 않도록 했습니다.

## 주요 변경
- `/src/services/discord/settings.rs`
  - `bot_settings_allow_agent(...)`
  - `BotChannelRoutingGuardFailure`
  - `validate_bot_channel_routing(...)`
- `/src/services/discord/mod.rs`
  - provider channel 판정을 공용 helper 기반으로 통일
  - `channel_is_dm_http(...)`
  - `resolve_routing_channel_http(...)`
  - `resolve_thread_parent_http(...)`
- `/src/services/discord/router.rs`
  - 일반 turn 진입 시 공용 helper 사용
- `/src/services/discord/tmux.rs`
  - watcher 복구 시 공용 helper 사용
- `/src/services/discord/restart_report.rs`
  - restart follow-up 전송 시 공용 helper 사용
  - restart report 검증 전에 실제 DM 여부 계산
- `/src/services/discord/recovery.rs`
  - inflight recovery 시 공용 helper 사용
  - recovery 검증 전에 thread parent 기준 effective channel 해석
  - recovery 이후 role binding도 같은 effective channel 기준으로 정렬

## 검증
- `cargo test -q --manifest-path /tmp/agentdesk-pr221-fix/Cargo.toml bot_channel_routing`
- `cargo test -q --manifest-path /tmp/agentdesk-pr221-fix/Cargo.toml recovery_`
- `cargo test -q --manifest-path /tmp/agentdesk-pr221-fix/Cargo.toml restart_report`
- `cargo build --manifest-path /tmp/agentdesk-pr221-fix/Cargo.toml`

## 참고
- Discord model picker UI 변경은 별도 PR로 분리되어 있습니다.
- 이 PR은 Discord 라우팅/복구 경로의 안전장치에만 집중합니다.
