### PR TITLE
feat: seamless inflight turn reconnect after dcserver restart (#199)

### DIFF
--- a/src/services/discord/recovery.rs
+++ b/src/services/discord/recovery.rs
@@ -726,10 +726,103 @@ pub(super) async fn restore_inflight_turns(
                 shared,
             )
             .await;
-            // Keep the inflight state until the watcher either relays the
-            // final response or triggers watcher-death handoff. Clearing it
-            // here breaks the handoff path if the recovered tmux session dies
-            // before producing a result.
+
+            // Mark user message as completed: ⏳ → ✅
+            let user_msg_id = MessageId::new(state.user_msg_id);
+            super::formatting::remove_reaction_raw(http, channel_id, user_msg_id, '⏳').await;
+            super::formatting::add_reaction_raw(http, channel_id, user_msg_id, '✅').await;
+
+            // Complete the dispatch if this was an implementation/rework turn.
+            // Review dispatches require the verdict flow (review_verdict.rs)
+            // and must not be generically finalized here.
+            let recovered_dispatch_id = parse_dispatch_id(&state.user_text);
+            let mut dispatch_completed = recovered_dispatch_id.is_none();
+            if let Some(ref did) = recovered_dispatch_id {
+                let dispatch_type = shared.db.as_ref().and_then(|db| {
+                    db.separate_conn().ok().and_then(|conn| {
+                        conn.query_row(
+                            "SELECT dispatch_type FROM task_dispatches WHERE id = ?1",
+                            [did.as_str()],
+                            |row| row.get::<_, String>(0),
+                        )
+                        .ok()
+                    })
+                });
+
+                match dispatch_type.as_deref() {
+                    Some("implementation") | Some("rework") => {
+                        if let (Some(db), Some(engine)) = (&shared.db, &shared.engine) {
+                            for attempt in 1..=3u8 {
+                                match crate::dispatch::finalize_dispatch(
+                                    db,
+                                    engine,
+                                    did,
+                                    "recovery_output_completed",
+                                    None,
+                                ) {
+                                    Ok(_) => {
+                                        let ts = chrono::Local::now().format("%H:%M:%S");
+                                        println!(
+                                            "  [{ts}] ✓ recovery: completed dispatch {did} via finalize_dispatch"
+                                        );
+                                        crate::server::routes::dispatches::queue_dispatch_followup(
+                                            db, did,
+                                        );
+                                        dispatch_completed = true;
+                                        break;
+                                    }
+                                    Err(e) => {
+                                        let ts = chrono::Local::now().format("%H:%M:%S");
+                                        eprintln!(
+                                            "  [{ts}] ⚠ recovery: finalize_dispatch failed for {did} (attempt {attempt}/3): {e}"
+                                        );
+                                        if attempt < 3 {
+                                            tokio::time::sleep(std::time::Duration::from_secs(1))
+                                                .await;
+                                        }
+                                    }
+                                }
+                            }
+                            if !dispatch_completed {
+                                dispatch_completed =
+                                    super::turn_bridge::runtime_db_fallback_complete(
+                                        did,
+                                        "recovery_output_db_fallback",
+                                    );
+                            }
+                        } else {
+                            dispatch_completed = super::turn_bridge::runtime_db_fallback_complete(
+                                did,
+                                "recovery_output_db_fallback",
+                            );
+                        }
+                        if !dispatch_completed {
+                            let ts = chrono::Local::now().format("%H:%M:%S");
+                            eprintln!(
+                                "  [{ts}] ❌ recovery: dispatch {did} completion failed — preserving state for retry"
+                            );
+                        }
+                    }
+                    Some(_) => {
+                        // Non-work dispatches (review, review-decision) need their
+                        // own completion flow — clear inflight but leave dispatch
+                        // status for the appropriate handler (see follow-up #xxx).
+                        dispatch_completed = true;
+                    }
+                    None => {
+                        // DB unavailable — cannot determine dispatch type.
+                        // Preserve inflight state so the next recovery pass can retry.
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        eprintln!(
+                            "  [{ts}] ⚠ recovery: cannot determine dispatch type for {did} — preserving state"
+                        );
+                    }
+                }
+            }
+
+            if dispatch_completed {
+                clear_inflight_state(provider, state.channel_id);
+            }
             continue;
         }
 
@@ -949,7 +1042,10 @@ pub(super) async fn restore_inflight_turns(
                 }
             }
 
-            clear_inflight_state(provider, state.channel_id);
+            // Keep the inflight state until the watcher either relays the
+            // final response or triggers watcher-death handoff. Clearing it
+            // here breaks the handoff path if the recovered tmux session
+            // dies before producing a result.
             continue;
         }
 

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -256,6 +256,7 @@ pub(super) async fn tmux_output_watcher(
 
     let mut current_offset = initial_offset;
     let mut prompt_too_long_killed = false;
+    let mut turn_result_relayed = false;
     // Guard against duplicate relay: track the offset from which the last relay was sent.
     // If the outer loop circles back and current_offset hasn't advanced past this point,
     // the relay is suppressed.
@@ -329,7 +330,7 @@ pub(super) async fn tmux_output_watcher(
             } else {
                 println!("  [{ts}] 👁 tmux session {tmux_session_name} ended, watcher stopping");
             }
-            if !prompt_too_long_killed {
+            if !prompt_too_long_killed && !turn_result_relayed {
                 // Suppress warning for normal dispatch completion — not an error
                 let is_normal_completion = read_tmux_exit_reason(&tmux_session_name)
                     .map(|r| r.contains("dispatch turn completed"))
@@ -839,6 +840,83 @@ pub(super) async fn tmux_output_watcher(
                 let user_msg_id = serenity::MessageId::new(state.user_msg_id);
                 super::formatting::remove_reaction_raw(&http, channel_id, user_msg_id, '⏳').await;
                 super::formatting::add_reaction_raw(&http, channel_id, user_msg_id, '✅').await;
+
+                // Finalize implementation/rework dispatches only — review
+                // dispatches require the verdict flow (review_verdict.rs).
+                let mut dispatch_ok = true;
+                if let Some(did) = super::adk_session::parse_dispatch_id(&state.user_text) {
+                    let dispatch_type = shared.db.as_ref().and_then(|db| {
+                        db.separate_conn().ok().and_then(|conn| {
+                            conn.query_row(
+                                "SELECT dispatch_type FROM task_dispatches WHERE id = ?1",
+                                [did.as_str()],
+                                |row| row.get::<_, String>(0),
+                            )
+                            .ok()
+                        })
+                    });
+
+                    match dispatch_type.as_deref() {
+                        Some("implementation") | Some("rework") => {
+                            dispatch_ok = false;
+                            if let (Some(db), Some(engine)) = (&shared.db, &shared.engine) {
+                                match crate::dispatch::finalize_dispatch(
+                                    db,
+                                    engine,
+                                    &did,
+                                    "watcher_completed",
+                                    None,
+                                ) {
+                                    Ok(_) => {
+                                        let ts = chrono::Local::now().format("%H:%M:%S");
+                                        println!(
+                                            "  [{ts}] ✓ watcher: completed dispatch {did} via finalize_dispatch"
+                                        );
+                                        crate::server::routes::dispatches::queue_dispatch_followup(
+                                            db, &did,
+                                        );
+                                        dispatch_ok = true;
+                                    }
+                                    Err(e) => {
+                                        let ts = chrono::Local::now().format("%H:%M:%S");
+                                        eprintln!(
+                                            "  [{ts}] ⚠ watcher: finalize_dispatch failed for {did}: {e}"
+                                        );
+                                        dispatch_ok =
+                                            super::turn_bridge::runtime_db_fallback_complete(
+                                                &did,
+                                                "watcher_db_fallback",
+                                            );
+                                    }
+                                }
+                            } else {
+                                dispatch_ok = super::turn_bridge::runtime_db_fallback_complete(
+                                    &did,
+                                    "watcher_db_fallback",
+                                );
+                            }
+                        }
+                        Some(_) => {
+                            // Non-work dispatches — leave for their own completion flow
+                        }
+                        None => {
+                            // DB unavailable — preserve inflight for retry
+                            let ts = chrono::Local::now().format("%H:%M:%S");
+                            eprintln!(
+                                "  [{ts}] ⚠ watcher: cannot determine dispatch type for {did} — preserving state"
+                            );
+                            dispatch_ok = false;
+                        }
+                    }
+                }
+
+                // Response was relayed — prevent duplicate handoff on session death
+                turn_result_relayed = true;
+                // Only clear inflight state if dispatch was completed (or no dispatch).
+                // Preserving state on failure allows the next recovery pass to retry.
+                if dispatch_ok {
+                    super::inflight::clear_inflight_state(&provider_kind, channel_id.get());
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Fix 4 bugs preventing proper turn completion after recovery reconnect (dispatch finalization, inflight state preservation, duplicate handoff prevention)
- Guard dispatch completion to `implementation|rework` types only — review dispatches use verdict flow
- Handle DB-unavailable case by preserving inflight state for retry
- Remove promote-release.sh 5-min turn-wait workaround (no longer needed)

## Test plan
- [ ] Restart dcserver while an implementation dispatch is in progress — turn continues and dispatch is finalized
- [ ] Restart dcserver while tmux session is alive — watcher reconnects at correct offset
- [ ] Restart dcserver when tmux session is dead — "interrupted by restart" message appears
- [ ] Promote release without turn-wait delay — recovery handles reconnect seamlessly

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)