### PR TITLE
feat(gemini): 0.35.3 호환성과 provider 구조 정리

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -92,7 +92,7 @@ impl SessionRuntime for TmuxRuntime {
             return false;
         }
         // Use the provider-specific readiness check
-        crate::services::claude::tmux_session_ready_for_input(session_name)
+        crate::services::provider::tmux_session_ready_for_input(session_name)
     }
 
     fn kill_session(&self, session_name: &str) -> Result<()> {

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -9,7 +9,7 @@ use std::sync::mpsc::Sender;
 use crate::services::discord::restart_report::{
     RESTART_REPORT_CHANNEL_ENV, RESTART_REPORT_PROVIDER_ENV,
 };
-use crate::services::provider::ProviderKind;
+use crate::services::provider::{CancelToken, ProviderKind, cancel_requested, register_child_pid};
 use crate::services::remote::RemoteProfile;
 #[cfg(unix)]
 use crate::services::tmux_diagnostics::{
@@ -271,54 +271,6 @@ pub(crate) fn tmux_session_ready_for_input(tmux_session_name: &str) -> bool {
 #[cfg(not(unix))]
 pub(crate) fn tmux_session_ready_for_input(_tmux_session_name: &str) -> bool {
     false
-}
-
-/// Token for cooperative cancellation of streaming requests.
-/// Holds a flag and the child process PID so the caller can kill it externally.
-pub struct CancelToken {
-    pub cancelled: std::sync::atomic::AtomicBool,
-    pub child_pid: std::sync::Mutex<Option<u32>>,
-    /// SSH cancel flag — set to true to signal remote execution to close the channel
-    #[allow(dead_code)]
-    pub ssh_cancel: std::sync::Mutex<Option<std::sync::Arc<std::sync::atomic::AtomicBool>>>,
-    /// tmux session name for cleanup on cancel
-    pub tmux_session: std::sync::Mutex<Option<String>>,
-    /// Watchdog deadline as Unix timestamp in milliseconds.
-    /// The watchdog fires when `now_ms >= deadline_ms`. Extend by setting a future value.
-    /// Maximum absolute cap: initial deadline + MAX_EXTENSION (3 hours).
-    pub watchdog_deadline_ms: std::sync::atomic::AtomicI64,
-    /// The hard ceiling for watchdog_deadline_ms (initial + 3h). Extensions cannot exceed this.
-    pub watchdog_max_deadline_ms: std::sync::atomic::AtomicI64,
-}
-
-impl CancelToken {
-    pub fn new() -> Self {
-        Self {
-            cancelled: std::sync::atomic::AtomicBool::new(false),
-            child_pid: std::sync::Mutex::new(None),
-            ssh_cancel: std::sync::Mutex::new(None),
-            tmux_session: std::sync::Mutex::new(None),
-            watchdog_deadline_ms: std::sync::atomic::AtomicI64::new(0),
-            watchdog_max_deadline_ms: std::sync::atomic::AtomicI64::new(0),
-        }
-    }
-
-    /// Cancel and clean up any associated tmux session
-    pub fn cancel_with_tmux_cleanup(&self) {
-        self.cancelled
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-        if let Some(name) = self.tmux_session.lock().unwrap().take() {
-            #[cfg(unix)]
-            {
-                record_tmux_exit_reason(&name, "explicit cleanup via cancel_with_tmux_cleanup");
-                crate::services::platform::tmux::kill_session(&name);
-            }
-            #[cfg(not(unix))]
-            {
-                let _ = &name; // suppress unused warning
-            }
-        }
-    }
 }
 
 /// Cached regex pattern for session ID validation
@@ -820,9 +772,7 @@ IMPORTANT: Format your responses using Markdown for better readability:
     ));
 
     // Store child PID in cancel token so the caller can kill it externally
-    if let Some(ref token) = cancel_token {
-        *token.child_pid.lock().unwrap() = Some(child.id());
-    }
+    register_child_pid(cancel_token.as_deref(), child.id());
 
     // Write prompt to stdin
     if let Some(mut stdin) = child.stdin.take() {
@@ -863,12 +813,10 @@ IMPORTANT: Format your responses using Markdown for better readability:
     debug_log("Entering lines loop - will block until first line arrives...");
     for line in reader.lines() {
         // Check cancel token before processing each line
-        if let Some(ref token) = cancel_token {
-            if token.cancelled.load(std::sync::atomic::Ordering::Relaxed) {
-                debug_log("Cancel detected — killing child process tree");
-                kill_child_tree(&mut child);
-                return Ok(());
-            }
+        if cancel_requested(cancel_token.as_deref()) {
+            debug_log("Cancel detected — killing child process tree");
+            kill_child_tree(&mut child);
+            return Ok(());
         }
 
         debug_log(&format!("Line {} - read started", line_count + 1));
@@ -1129,12 +1077,10 @@ IMPORTANT: Format your responses using Markdown for better readability:
     debug_log(&format!("last_session_id: {:?}", last_session_id));
 
     // Check cancel token after exiting the loop
-    if let Some(ref token) = cancel_token {
-        if token.cancelled.load(std::sync::atomic::Ordering::Relaxed) {
-            debug_log("Cancel detected after loop — killing child process tree");
-            kill_child_tree(&mut child);
-            return Ok(());
-        }
+    if cancel_requested(cancel_token.as_deref()) {
+        debug_log("Cancel detected after loop — killing child process tree");
+        kill_child_tree(&mut child);
+        return Ok(());
     }
 
     // Wait for process to finish
@@ -2094,7 +2040,6 @@ pub(crate) fn read_output_file_until_result(
     probe: SessionProbe,
 ) -> Result<ReadOutputResult, String> {
     use std::io::{Read, Seek, SeekFrom};
-    use std::sync::atomic::Ordering;
     use std::time::Duration;
 
     debug_log(&format!(
@@ -2114,12 +2059,10 @@ pub(crate) fn read_output_file_until_result(
         if wait_start.elapsed() > Duration::from_secs(30) {
             return Err("Timeout waiting for output file".to_string());
         }
-        if let Some(ref token) = cancel_token {
-            if token.cancelled.load(Ordering::Relaxed) {
-                return Ok(ReadOutputResult::Cancelled {
-                    offset: start_offset,
-                });
-            }
+        if cancel_requested(cancel_token.as_deref()) {
+            return Ok(ReadOutputResult::Cancelled {
+                offset: start_offset,
+            });
         }
         std::thread::sleep(wait_interval);
         wait_interval = std::cmp::min(
@@ -2143,13 +2086,11 @@ pub(crate) fn read_output_file_until_result(
 
     loop {
         // Check cancellation
-        if let Some(ref token) = cancel_token {
-            if token.cancelled.load(Ordering::Relaxed) {
-                debug_log("Cancel detected during output file read");
-                return Ok(ReadOutputResult::Cancelled {
-                    offset: current_offset,
-                });
-            }
+        if cancel_requested(cancel_token.as_deref()) {
+            debug_log("Cancel detected during output file read");
+            return Ok(ReadOutputResult::Cancelled {
+                offset: current_offset,
+            });
         }
 
         match file.read(&mut buf) {

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -9,7 +9,10 @@ use std::sync::mpsc::Sender;
 use crate::services::discord::restart_report::{
     RESTART_REPORT_CHANNEL_ENV, RESTART_REPORT_PROVIDER_ENV,
 };
-use crate::services::provider::{CancelToken, ProviderKind, cancel_requested, register_child_pid};
+use crate::services::provider::{
+    CancelToken, FollowupResult, ProviderKind, ReadOutputResult, cancel_requested,
+    fold_read_output_result, register_child_pid,
+};
 use crate::services::remote::RemoteProfile;
 #[cfg(unix)]
 use crate::services::tmux_diagnostics::{
@@ -206,40 +209,6 @@ pub enum StreamMessage {
     },
     /// Latest read offset in a growing tmux output file
     OutputOffset { offset: u64 },
-}
-
-/// Result from reading a tmux output file until completion or session death.
-pub enum ReadOutputResult {
-    /// Normal completion (result event received)
-    Completed { offset: u64 },
-    /// Session died without producing a result
-    #[allow(dead_code)]
-    SessionDied { offset: u64 },
-    /// User cancelled the operation
-    Cancelled { offset: u64 },
-}
-
-/// Result from sending a follow-up message to an existing tmux session.
-///
-/// When `RecreateSession` is returned, the caller should kill the current
-/// tmux session and fall through to the full session-creation path, replaying
-/// the same prompt in a fresh session.
-///
-/// **Partial-output note:** If the session dies *after* some streaming output
-/// has already been forwarded to Discord, the recreated session will produce
-/// the full response again, which may appear as duplicate text to the user.
-/// This is an acceptable trade-off: the alternative (leaving the task
-/// unfinished) is worse, and Claude/Codex prompts are generally idempotent
-/// for read/analysis tasks.  For prompts that trigger side-effects (file
-/// writes, git operations), the agent CLI itself is responsible for
-/// idempotency — the same prompt re-sent to a fresh session will not blindly
-/// re-apply already-committed changes.
-#[derive(Debug)]
-pub enum FollowupResult {
-    /// Message delivered and output successfully read to completion.
-    Delivered,
-    /// Session needs to be killed and recreated (FIFO broken or session died).
-    RecreateSession { error: String },
 }
 
 #[cfg(unix)]
@@ -1958,24 +1927,24 @@ fn send_followup_to_tmux(
         SessionProbe::tmux(tmux_session_name.to_string()),
     )?;
 
-    match read_result {
-        ReadOutputResult::Completed { offset } | ReadOutputResult::Cancelled { offset } => {
-            // Notify caller that tmux session is ready for background monitoring
+    Ok(fold_read_output_result(
+        read_result,
+        |offset| {
             let _ = sender.send(StreamMessage::TmuxReady {
                 output_path: output_path.to_string(),
                 input_fifo_path: input_fifo_path.to_string(),
                 tmux_session_name: tmux_session_name.to_string(),
                 last_offset: offset,
             });
-            Ok(FollowupResult::Delivered)
-        }
-        ReadOutputResult::SessionDied { .. } => {
+            FollowupResult::Delivered
+        },
+        |_| {
             debug_log("tmux session died during follow-up — requesting recreation");
-            Ok(FollowupResult::RecreateSession {
+            FollowupResult::RecreateSession {
                 error: "session died during follow-up output reading".to_string(),
-            })
-        }
-    }
+            }
+        },
+    ))
 }
 
 /// Callbacks for session status checks during output file polling.
@@ -2349,24 +2318,24 @@ pub(crate) fn execute_streaming_local_process(
         SessionProbe::process(session_name.to_string()),
     )?;
 
-    match read_result {
-        ReadOutputResult::Completed { offset } | ReadOutputResult::Cancelled { offset } => {
+    fold_read_output_result(
+        read_result,
+        |offset| {
             let _ = sender.send(StreamMessage::ProcessReady {
                 output_path,
                 session_name: session_name.to_string(),
                 last_offset: offset,
             });
-        }
-        ReadOutputResult::SessionDied { .. } => {
+        },
+        |_| {
             let _ = sender.send(StreamMessage::Done {
                 result: "⚠ 프로세스가 종료되었습니다. 새 메시지를 보내면 새 세션이 시작됩니다."
                     .to_string(),
                 session_id: None,
             });
-            // Clean up dead handle
             PROCESS_HANDLES.lock().unwrap().remove(session_name);
-        }
-    }
+        },
+    );
 
     debug_log("=== execute_streaming_local_process END ===");
     Ok(())
@@ -2436,23 +2405,24 @@ fn send_followup_to_process(
         SessionProbe::process(session_name.to_string()),
     )?;
 
-    match read_result {
-        ReadOutputResult::Completed { offset } | ReadOutputResult::Cancelled { offset } => {
+    Ok(fold_read_output_result(
+        read_result,
+        |offset| {
             let _ = sender.send(StreamMessage::ProcessReady {
                 output_path: output_path.to_string(),
                 session_name: session_name.to_string(),
                 last_offset: offset,
             });
-            Ok(FollowupResult::Delivered)
-        }
-        ReadOutputResult::SessionDied { .. } => {
+            FollowupResult::Delivered
+        },
+        |_| {
             debug_log("process session died during follow-up — requesting recreation");
             PROCESS_HANDLES.lock().unwrap().remove(session_name);
-            Ok(FollowupResult::RecreateSession {
+            FollowupResult::RecreateSession {
                 error: "process died during follow-up output reading".to_string(),
-            })
-        }
-    }
+            }
+        },
+    ))
 }
 
 /// Global storage for ProcessBackend session handles.
@@ -2887,28 +2857,18 @@ mod tests {
     #[test]
     fn test_followup_result_maps_completed_to_delivered() {
         let read_result = ReadOutputResult::Completed { offset: 100 };
-        let followup = match read_result {
-            ReadOutputResult::Completed { .. } | ReadOutputResult::Cancelled { .. } => {
-                FollowupResult::Delivered
-            }
-            ReadOutputResult::SessionDied { .. } => FollowupResult::RecreateSession {
-                error: "died".to_string(),
-            },
-        };
+        let followup =
+            crate::services::provider::followup_result_from_read_output_result(read_result, "died");
         assert!(matches!(followup, FollowupResult::Delivered));
     }
 
     #[test]
     fn test_followup_result_maps_session_died_to_recreate() {
         let read_result = ReadOutputResult::SessionDied { offset: 42 };
-        let followup = match read_result {
-            ReadOutputResult::Completed { .. } | ReadOutputResult::Cancelled { .. } => {
-                FollowupResult::Delivered
-            }
-            ReadOutputResult::SessionDied { .. } => FollowupResult::RecreateSession {
-                error: "session died during follow-up output reading".to_string(),
-            },
-        };
+        let followup = crate::services::provider::followup_result_from_read_output_result(
+            read_result,
+            "session died during follow-up output reading",
+        );
         match followup {
             FollowupResult::RecreateSession { error } => {
                 assert!(error.contains("session died"));

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -322,14 +322,14 @@ impl CancelToken {
 }
 
 /// Cached regex pattern for session ID validation
-fn session_id_regex() -> &'static Regex {
+pub(crate) fn session_id_regex() -> &'static Regex {
     static REGEX: OnceLock<Regex> = OnceLock::new();
     REGEX.get_or_init(|| Regex::new(r"^[a-zA-Z0-9_-]+$").expect("Invalid session ID regex pattern"))
 }
 
 /// Validate session ID format (alphanumeric, dashes, underscores only)
 /// Max length reduced to 64 characters for security
-fn is_valid_session_id(session_id: &str) -> bool {
+pub(crate) fn is_valid_session_id(session_id: &str) -> bool {
     !session_id.is_empty() && session_id.len() <= 64 && session_id_regex().is_match(session_id)
 }
 

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -10,7 +10,7 @@ use crate::services::discord::restart_report::{
     RESTART_REPORT_CHANNEL_ENV, RESTART_REPORT_PROVIDER_ENV,
 };
 use crate::services::provider::{
-    CancelToken, FollowupResult, ProviderKind, ReadOutputResult, cancel_requested,
+    CancelToken, FollowupResult, ProviderKind, ReadOutputResult, SessionProbe, cancel_requested,
     fold_read_output_result, register_child_pid,
 };
 use crate::services::remote::RemoteProfile;
@@ -209,37 +209,6 @@ pub enum StreamMessage {
     },
     /// Latest read offset in a growing tmux output file
     OutputOffset { offset: u64 },
-}
-
-#[cfg(unix)]
-fn tmux_session_alive(tmux_session_name: &str) -> bool {
-    tmux_session_has_live_pane(tmux_session_name)
-}
-
-#[cfg(unix)]
-fn tmux_capture_indicates_ready_for_input(capture: &str) -> bool {
-    // Only check the last few non-empty lines of the capture.
-    // The "Ready for input" prompt from a *previous* turn can linger in
-    // the scrollback buffer while a new message is being processed, so
-    // checking the entire capture leads to false positives.
-    capture
-        .lines()
-        .rev()
-        .filter(|l| !l.trim().is_empty())
-        .take(3)
-        .any(|l| l.contains("Ready for input (type message + Enter)"))
-}
-
-#[cfg(unix)]
-pub(crate) fn tmux_session_ready_for_input(tmux_session_name: &str) -> bool {
-    crate::services::platform::tmux::capture_pane(tmux_session_name, -80)
-        .map(|stdout| tmux_capture_indicates_ready_for_input(&stdout))
-        .unwrap_or(false)
-}
-
-#[cfg(not(unix))]
-pub(crate) fn tmux_session_ready_for_input(_tmux_session_name: &str) -> bool {
-    false
 }
 
 /// Cached regex pattern for session ID validation
@@ -1947,54 +1916,6 @@ fn send_followup_to_tmux(
     ))
 }
 
-/// Callbacks for session status checks during output file polling.
-pub(crate) struct SessionProbe {
-    /// Returns true if the session process is still running.
-    pub is_alive: Box<dyn Fn() -> bool + Send>,
-    /// Returns true if the session is idle and ready for new input.
-    /// Only meaningful for tmux sessions (capture-pane check).
-    /// ProcessBackend returns false (relies on JSONL "result" event instead).
-    pub is_ready_for_input: Box<dyn Fn() -> bool + Send>,
-}
-
-impl SessionProbe {
-    /// Create a tmux-based probe (existing behavior).
-    #[cfg(unix)]
-    pub fn tmux(session_name: String) -> Self {
-        let name_alive = session_name.clone();
-        let name_ready = session_name;
-        Self {
-            is_alive: Box::new(move || tmux_session_alive(&name_alive)),
-            is_ready_for_input: Box::new(move || tmux_session_ready_for_input(&name_ready)),
-        }
-    }
-
-    /// Non-unix stub: tmux is not available.
-    #[cfg(not(unix))]
-    pub fn tmux(_session_name: String) -> Self {
-        Self {
-            is_alive: Box::new(|| false),
-            is_ready_for_input: Box::new(|| false),
-        }
-    }
-
-    /// Create a process-based probe (PID check, no ready-for-input).
-    pub fn process(session_name: String) -> Self {
-        Self {
-            is_alive: Box::new(move || {
-                let handles = PROCESS_HANDLES.lock().unwrap();
-                if let Some(handle) = handles.get(&session_name) {
-                    use crate::services::session_backend::{ProcessBackend, SessionBackend};
-                    ProcessBackend::new().is_alive(handle)
-                } else {
-                    false
-                }
-            }),
-            is_ready_for_input: Box::new(|| false),
-        }
-    }
-}
-
 /// Poll-read the output file from a given offset until a "result" event is received.
 /// Uses raw File::read to handle growing file (not BufReader which caches EOF).
 /// Returns ReadOutputResult indicating how the read ended.
@@ -2185,7 +2106,18 @@ pub(crate) fn execute_streaming_local_process(
         0,
         sender.clone(),
         cancel_token,
-        SessionProbe::process(session_name.to_string()),
+        SessionProbe::process({
+            let session_name = session_name.to_string();
+            move || {
+                let handles = PROCESS_HANDLES.lock().unwrap();
+                if let Some(handle) = handles.get(&session_name) {
+                    use crate::services::session_backend::{ProcessBackend, SessionBackend};
+                    ProcessBackend::new().is_alive(handle)
+                } else {
+                    false
+                }
+            }
+        }),
     )?;
 
     fold_read_output_result(
@@ -2272,7 +2204,18 @@ fn send_followup_to_process(
         start_offset,
         sender.clone(),
         cancel_token,
-        SessionProbe::process(session_name.to_string()),
+        SessionProbe::process({
+            let session_name = session_name.to_string();
+            move || {
+                let handles = PROCESS_HANDLES.lock().unwrap();
+                if let Some(handle) = handles.get(&session_name) {
+                    use crate::services::session_backend::{ProcessBackend, SessionBackend};
+                    ProcessBackend::new().is_alive(handle)
+                } else {
+                    false
+                }
+            }
+        }),
     )?;
 
     Ok(fold_read_output_result(
@@ -2598,14 +2541,14 @@ mod tests {
     #[cfg(unix)]
     fn test_tmux_capture_detects_ready_prompt() {
         let capture = "...\n▶ Ready for input (type message + Enter)\n";
-        assert!(tmux_capture_indicates_ready_for_input(capture));
+        assert!(crate::services::provider::tmux_capture_indicates_ready_for_input(capture));
     }
 
     #[test]
     #[cfg(unix)]
     fn test_tmux_capture_ignores_non_ready_prompt() {
         let capture = "Claude is still working...\n";
-        assert!(!tmux_capture_indicates_ready_for_input(capture));
+        assert!(!crate::services::provider::tmux_capture_indicates_ready_for_input(capture));
     }
 
     // ========== parse_stream_message thinking tests ==========

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -2008,187 +2008,57 @@ pub(crate) fn read_output_file_until_result(
     cancel_token: Option<std::sync::Arc<CancelToken>>,
     probe: SessionProbe,
 ) -> Result<ReadOutputResult, String> {
-    use std::io::{Read, Seek, SeekFrom};
-    use std::time::Duration;
-
     debug_log(&format!(
         "=== read_output_file_until_result: offset={} ===",
         start_offset
     ));
 
-    // Wait for output file to exist (wrapper might not have created it yet)
-    // Uses exponential backoff: 10ms → 500ms
-    let wait_start = std::time::Instant::now();
-    let mut wait_interval = Duration::from_millis(10);
-    let max_wait_interval = Duration::from_millis(500);
-    loop {
-        if std::fs::metadata(output_path).is_ok() {
-            break;
-        }
-        if wait_start.elapsed() > Duration::from_secs(30) {
-            return Err("Timeout waiting for output file".to_string());
-        }
-        if cancel_requested(cancel_token.as_deref()) {
-            return Ok(ReadOutputResult::Cancelled {
-                offset: start_offset,
-            });
-        }
-        std::thread::sleep(wait_interval);
-        wait_interval = std::cmp::min(
-            Duration::from_millis((wait_interval.as_millis() as f64 * 1.5) as u64),
-            max_wait_interval,
-        );
-    }
-
-    let mut file = std::fs::File::open(output_path)
-        .map_err(|e| format!("Failed to open output file: {}", e))?;
-    file.seek(SeekFrom::Start(start_offset))
-        .map_err(|e| format!("Failed to seek output file: {}", e))?;
-
-    let mut current_offset = start_offset;
-    let mut partial_line = String::new();
     let mut state = StreamLineState::new();
-    let mut buf = [0u8; 8192];
-    let mut no_data_count: u32 = 0;
-    let mut consecutive_ready_count: u32 = 0;
-    let mut first_ready_at: Option<std::time::Instant> = None;
+    let SessionProbe {
+        is_alive,
+        is_ready_for_input,
+    } = probe;
+    let offset_sender = sender.clone();
+    let line_sender = sender.clone();
+    let synthetic_sender = sender.clone();
+    let error_sender = sender.clone();
 
-    loop {
-        // Check cancellation
-        if cancel_requested(cancel_token.as_deref()) {
-            debug_log("Cancel detected during output file read");
-            return Ok(ReadOutputResult::Cancelled {
-                offset: current_offset,
-            });
-        }
-
-        match file.read(&mut buf) {
-            Ok(0) => {
-                // No new data — check if session is still alive
-                no_data_count += 1;
-                if no_data_count % 25 == 0 {
-                    // Approximately every 3-5 seconds (varies with backoff)
-                    if !(probe.is_alive)() {
-                        debug_log("Session ended while reading output");
-                        // Check for unread data before breaking
-                        let file_len = std::fs::metadata(output_path)
-                            .map(|meta| meta.len())
-                            .unwrap_or(current_offset);
-                        if file_len > current_offset {
-                            continue; // Still data to read
-                        }
-                        break;
-                    }
-
-                    let file_len = std::fs::metadata(output_path)
-                        .map(|meta| meta.len())
-                        .unwrap_or(current_offset);
-                    let has_new_bytes = file_len > current_offset;
-                    // Only consider ready-for-input if output has grown at least
-                    // once since the turn started.  When a follow-up message is
-                    // written to the FIFO but Claude hasn't begun processing yet,
-                    // the previous turn's "Ready for input" prompt still lingers
-                    // in the tmux pane — causing a false-positive completion.
-                    let output_ever_grew = current_offset > start_offset;
-                    if !has_new_bytes && output_ever_grew && (probe.is_ready_for_input)() {
-                        if first_ready_at.is_none() {
-                            first_ready_at = Some(std::time::Instant::now());
-                        }
-                        consecutive_ready_count += 1;
-                        // Time-based guard: require at least 15 seconds of continuous
-                        // ready state to avoid false positives during Claude Code
-                        // auto-continue transitions. With adaptive backoff the loop
-                        // cadence varies, so wall-clock time is the reliable measure.
-                        let ready_elapsed = first_ready_at.unwrap().elapsed();
-                        if ready_elapsed >= Duration::from_secs(15) && consecutive_ready_count >= 3
-                        {
-                            debug_log(
-                                "Session returned to ready prompt without result event; synthesizing completion",
-                            );
-                            let synthetic = StreamMessage::Done {
-                                result: String::new(),
-                                session_id: state.last_session_id.clone(),
-                            };
-                            if sender.send(synthetic).is_err() {
-                                return Ok(ReadOutputResult::Cancelled {
-                                    offset: current_offset,
-                                });
-                            }
-                            state.final_result = Some(String::new());
-                            return Ok(ReadOutputResult::Completed {
-                                offset: current_offset,
-                            });
-                        }
-                    } else {
-                        consecutive_ready_count = 0;
-                        first_ready_at = None;
-                    }
-                }
-                // Adaptive backoff: start fast (10ms), slow down to 200ms when idle
-                let read_interval = if no_data_count < 5 {
-                    Duration::from_millis(10)
-                } else if no_data_count < 20 {
-                    Duration::from_millis(50)
-                } else {
-                    Duration::from_millis(200)
-                };
-                std::thread::sleep(read_interval);
-            }
-            Ok(n) => {
-                no_data_count = 0;
-                consecutive_ready_count = 0;
-                first_ready_at = None;
-                current_offset += n as u64;
-                let _ = sender.send(StreamMessage::OutputOffset {
-                    offset: current_offset,
+    let result = crate::services::provider::poll_output_file_until_result(
+        output_path,
+        start_offset,
+        cancel_token,
+        &mut state,
+        move || is_alive(),
+        move || is_ready_for_input(),
+        move |offset| {
+            let _ = offset_sender.send(StreamMessage::OutputOffset { offset });
+        },
+        move |line, state| process_stream_line(line, &line_sender, state),
+        |state| state.final_result.is_some(),
+        move |state| {
+            let synthetic = StreamMessage::Done {
+                result: String::new(),
+                session_id: state.last_session_id.clone(),
+            };
+            synthetic_sender.send(synthetic).is_ok()
+        },
+        move |state| {
+            if let Some((message, stdout_raw)) = &state.stdout_error {
+                let _ = error_sender.send(StreamMessage::Error {
+                    message: message.clone(),
+                    stdout: stdout_raw.clone(),
+                    stderr: String::new(),
+                    exit_code: None,
                 });
-                partial_line.push_str(&String::from_utf8_lossy(&buf[..n]));
-
-                // Process complete lines
-                while let Some(pos) = partial_line.find('\n') {
-                    let line: String = partial_line.drain(..=pos).collect();
-                    let trimmed = line.trim();
-                    if trimmed.is_empty() {
-                        continue;
-                    }
-
-                    if !process_stream_line(trimmed, &sender, &mut state) {
-                        debug_log("Channel disconnected during output file read");
-                        return Ok(ReadOutputResult::Cancelled {
-                            offset: current_offset,
-                        });
-                    }
-
-                    // Check if we got a result (turn complete)
-                    if state.final_result.is_some() {
-                        debug_log("Result received — returning from output file read");
-                        return Ok(ReadOutputResult::Completed {
-                            offset: current_offset,
-                        });
-                    }
-                }
             }
-            Err(e) => {
-                debug_log(&format!("Error reading output file: {}", e));
-                break;
-            }
-        }
+        },
+    );
+
+    if let Ok(ReadOutputResult::SessionDied { .. }) = &result {
+        debug_log("=== read_output_file_until_result END (session died) ===");
     }
 
-    // Handle deferred error or missing Done message
-    if let Some((message, stdout_raw)) = state.stdout_error {
-        let _ = sender.send(StreamMessage::Error {
-            message,
-            stdout: stdout_raw,
-            stderr: String::new(),
-            exit_code: None,
-        });
-    }
-
-    debug_log("=== read_output_file_until_result END (session died) ===");
-    Ok(ReadOutputResult::SessionDied {
-        offset: current_offset,
-    })
+    result
 }
 
 // ─── ProcessBackend execution path ────────────────────────────────────────────

--- a/src/services/codex.rs
+++ b/src/services/codex.rs
@@ -7,13 +7,16 @@ use std::sync::OnceLock;
 use std::sync::mpsc::Sender;
 
 use crate::services::claude::{
-    self, FollowupResult, ReadOutputResult, SessionProbe, StreamLineState, StreamMessage,
-    process_stream_line, read_output_file_until_result, shell_escape,
+    self, SessionProbe, StreamLineState, StreamMessage, process_stream_line,
+    read_output_file_until_result, shell_escape,
 };
 use crate::services::discord::restart_report::{
     RESTART_REPORT_CHANNEL_ENV, RESTART_REPORT_PROVIDER_ENV,
 };
-use crate::services::provider::{CancelToken, ProviderKind, cancel_requested, register_child_pid};
+use crate::services::provider::{
+    CancelToken, FollowupResult, ProviderKind, cancel_requested, fold_read_output_result,
+    register_child_pid,
+};
 use crate::services::remote::RemoteProfile;
 #[cfg(unix)]
 use crate::services::tmux_diagnostics::{
@@ -520,23 +523,24 @@ fn execute_streaming_local_tmux(
         SessionProbe::tmux(tmux_session_name.to_string()),
     )?;
 
-    match read_result {
-        ReadOutputResult::Completed { offset } | ReadOutputResult::Cancelled { offset } => {
+    fold_read_output_result(
+        read_result,
+        |offset| {
             let _ = sender.send(StreamMessage::TmuxReady {
                 output_path,
                 input_fifo_path,
                 tmux_session_name: tmux_session_name.to_string(),
                 last_offset: offset,
             });
-        }
-        ReadOutputResult::SessionDied { .. } => {
+        },
+        |_| {
             let _ = sender.send(StreamMessage::Done {
                 result: "⚠ 세션이 종료되었습니다. 새 메시지를 보내면 새 세션이 시작됩니다."
                     .to_string(),
                 session_id: None,
             });
-        }
-    }
+        },
+    );
 
     Ok(())
 }
@@ -589,20 +593,21 @@ fn send_followup_to_tmux(
         SessionProbe::tmux(tmux_session_name.to_string()),
     )?;
 
-    match read_result {
-        ReadOutputResult::Completed { offset } | ReadOutputResult::Cancelled { offset } => {
+    Ok(fold_read_output_result(
+        read_result,
+        |offset| {
             let _ = sender.send(StreamMessage::TmuxReady {
                 output_path: output_path.to_string(),
                 input_fifo_path: input_fifo_path.to_string(),
                 tmux_session_name: tmux_session_name.to_string(),
                 last_offset: offset,
             });
-            Ok(FollowupResult::Delivered)
-        }
-        ReadOutputResult::SessionDied { .. } => Ok(FollowupResult::RecreateSession {
+            FollowupResult::Delivered
+        },
+        |_| FollowupResult::RecreateSession {
             error: "session died during follow-up output reading".to_string(),
-        }),
-    }
+        },
+    ))
 }
 
 /// Execute Codex via ProcessBackend (direct child process, no tmux).
@@ -662,23 +667,23 @@ fn execute_streaming_local_process_codex(
                     claude::SessionProbe::process(session_name.to_string()),
                 )?;
 
-                match read_result {
-                    ReadOutputResult::Completed { offset }
-                    | ReadOutputResult::Cancelled { offset } => {
+                fold_read_output_result(
+                    read_result,
+                    |offset| {
                         let _ = sender.send(StreamMessage::ProcessReady {
                             output_path: output_path.to_string(),
                             session_name: session_name.to_string(),
                             last_offset: offset,
                         });
-                    }
-                    ReadOutputResult::SessionDied { .. } => {
+                    },
+                    |_| {
                         let _ = sender.send(StreamMessage::Done {
                             result: "⚠ 세션이 종료되었습니다.".to_string(),
                             session_id: None,
                         });
                         claude::PROCESS_HANDLES.lock().unwrap().remove(session_name);
-                    }
-                }
+                    },
+                );
                 return Ok(());
             }
         }
@@ -739,22 +744,23 @@ fn execute_streaming_local_process_codex(
         claude::SessionProbe::process(session_name.to_string()),
     )?;
 
-    match read_result {
-        ReadOutputResult::Completed { offset } | ReadOutputResult::Cancelled { offset } => {
+    fold_read_output_result(
+        read_result,
+        |offset| {
             let _ = sender.send(StreamMessage::ProcessReady {
                 output_path,
                 session_name: session_name.to_string(),
                 last_offset: offset,
             });
-        }
-        ReadOutputResult::SessionDied { .. } => {
+        },
+        |_| {
             let _ = sender.send(StreamMessage::Done {
                 result: "⚠ 프로세스가 종료되었습니다.".to_string(),
                 session_id: None,
             });
             claude::PROCESS_HANDLES.lock().unwrap().remove(session_name);
-        }
-    }
+        },
+    );
 
     Ok(())
 }
@@ -1067,7 +1073,7 @@ mod tests {
     #[test]
     fn test_codex_followup_fifo_not_found_returns_recreate() {
         use super::send_followup_to_tmux;
-        use crate::services::claude::FollowupResult;
+        use crate::services::provider::FollowupResult;
 
         let (sender, _receiver) = mpsc::channel();
         let dir = std::env::temp_dir();

--- a/src/services/codex.rs
+++ b/src/services/codex.rs
@@ -194,32 +194,7 @@ fn compose_codex_prompt(
     system_prompt: Option<&str>,
     allowed_tools: Option<&[String]>,
 ) -> String {
-    let mut sections = Vec::new();
-
-    if let Some(system_prompt) = system_prompt
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        sections.push(format!(
-            "[Authoritative Instructions]\n{}\n\nThese instructions are authoritative for this turn. \
-Follow them over any generic assistant persona unless the user explicitly asks to inspect or compare them.",
-            system_prompt
-        ));
-    }
-
-    if let Some(allowed_tools) = allowed_tools.filter(|tools| !tools.is_empty()) {
-        sections.push(format!(
-            "[Tool Policy]\nIf tools are needed, stay within this allowlist unless the user explicitly asks to change it: {}",
-            allowed_tools.join(", ")
-        ));
-    }
-
-    if sections.is_empty() {
-        return prompt.to_string();
-    }
-
-    sections.push(format!("[User Request]\n{}", prompt));
-    sections.join("\n\n")
+    crate::services::provider::compose_structured_turn_prompt(prompt, system_prompt, allowed_tools)
 }
 
 fn execute_streaming_direct(

--- a/src/services/codex.rs
+++ b/src/services/codex.rs
@@ -7,13 +7,13 @@ use std::sync::OnceLock;
 use std::sync::mpsc::Sender;
 
 use crate::services::claude::{
-    self, CancelToken, FollowupResult, ReadOutputResult, SessionProbe, StreamLineState,
-    StreamMessage, process_stream_line, read_output_file_until_result, shell_escape,
+    self, FollowupResult, ReadOutputResult, SessionProbe, StreamLineState, StreamMessage,
+    process_stream_line, read_output_file_until_result, shell_escape,
 };
 use crate::services::discord::restart_report::{
     RESTART_REPORT_CHANNEL_ENV, RESTART_REPORT_PROVIDER_ENV,
 };
-use crate::services::provider::ProviderKind;
+use crate::services::provider::{CancelToken, ProviderKind, cancel_requested, register_child_pid};
 use crate::services::remote::RemoteProfile;
 #[cfg(unix)]
 use crate::services::tmux_diagnostics::{
@@ -229,14 +229,12 @@ fn execute_streaming_direct(
         .spawn()
         .map_err(|e| format!("Failed to start Codex: {}", e))?;
 
-    if let Some(ref token) = cancel_token {
-        *token.child_pid.lock().unwrap() = Some(child.id());
-        // Race condition fix: if /stop arrived before PID was stored, kill now
-        if token.cancelled.load(std::sync::atomic::Ordering::Relaxed) {
-            claude::kill_child_tree(&mut child);
-            let _ = child.wait();
-            return Ok(());
-        }
+    register_child_pid(cancel_token.as_deref(), child.id());
+    // Race condition fix: if /stop arrived before PID was stored, kill now
+    if cancel_requested(cancel_token.as_deref()) {
+        claude::kill_child_tree(&mut child);
+        let _ = child.wait();
+        return Ok(());
     }
 
     let stdout = child
@@ -251,11 +249,9 @@ fn execute_streaming_direct(
     let started_at = std::time::Instant::now();
 
     for line in reader.lines() {
-        if let Some(ref token) = cancel_token {
-            if token.cancelled.load(std::sync::atomic::Ordering::Relaxed) {
-                claude::kill_child_tree(&mut child);
-                return Ok(());
-            }
+        if cancel_requested(cancel_token.as_deref()) {
+            claude::kill_child_tree(&mut child);
+            return Ok(());
         }
 
         let line = match line {

--- a/src/services/codex.rs
+++ b/src/services/codex.rs
@@ -6,16 +6,13 @@ use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 use std::sync::mpsc::Sender;
 
-use crate::services::claude::{
-    self, SessionProbe, StreamLineState, StreamMessage, process_stream_line,
-    read_output_file_until_result, shell_escape,
-};
+use crate::services::claude::{self, StreamMessage, read_output_file_until_result, shell_escape};
 use crate::services::discord::restart_report::{
     RESTART_REPORT_CHANNEL_ENV, RESTART_REPORT_PROVIDER_ENV,
 };
 use crate::services::provider::{
-    CancelToken, FollowupResult, ProviderKind, cancel_requested, fold_read_output_result,
-    register_child_pid,
+    CancelToken, FollowupResult, ProviderKind, SessionProbe, cancel_requested,
+    fold_read_output_result, register_child_pid,
 };
 use crate::services::remote::RemoteProfile;
 #[cfg(unix)]
@@ -664,7 +661,20 @@ fn execute_streaming_local_process_codex(
                     start_offset,
                     sender.clone(),
                     cancel_token,
-                    claude::SessionProbe::process(session_name.to_string()),
+                    SessionProbe::process({
+                        let session_name = session_name.to_string();
+                        move || {
+                            let handles = claude::PROCESS_HANDLES.lock().unwrap();
+                            if let Some(handle) = handles.get(&session_name) {
+                                use crate::services::session_backend::{
+                                    ProcessBackend, SessionBackend,
+                                };
+                                ProcessBackend::new().is_alive(handle)
+                            } else {
+                                false
+                            }
+                        }
+                    }),
                 )?;
 
                 fold_read_output_result(
@@ -741,7 +751,18 @@ fn execute_streaming_local_process_codex(
         0,
         sender.clone(),
         cancel_token,
-        claude::SessionProbe::process(session_name.to_string()),
+        SessionProbe::process({
+            let session_name = session_name.to_string();
+            move || {
+                let handles = claude::PROCESS_HANDLES.lock().unwrap();
+                if let Some(handle) = handles.get(&session_name) {
+                    use crate::services::session_backend::{ProcessBackend, SessionBackend};
+                    ProcessBackend::new().is_alive(handle)
+                } else {
+                    false
+                }
+            }
+        }),
     )?;
 
     fold_read_output_result(

--- a/src/services/discord/commands/control.rs
+++ b/src/services/discord/commands/control.rs
@@ -1,9 +1,8 @@
-use std::path::Path;
-use std::sync::atomic::Ordering;
-
 use poise::serenity_prelude as serenity;
 use serenity::CreateAttachment;
+use std::path::Path;
 
+use crate::services::provider::cancel_requested;
 #[cfg(unix)]
 use crate::services::tmux_common::tmux_exact_target;
 
@@ -32,7 +31,7 @@ pub(in crate::services::discord) async fn cmd_stop(ctx: Context<'_>) -> Result<(
 
     match token {
         Some(token) => {
-            if token.cancelled.load(Ordering::Relaxed) {
+            if cancel_requested(Some(token.as_ref())) {
                 ctx.say("Already stopping...").await?;
                 return Ok(());
             }

--- a/src/services/discord/commands/skill.rs
+++ b/src/services/discord/commands/skill.rs
@@ -1,5 +1,3 @@
-use std::sync::atomic::Ordering;
-
 use poise::serenity_prelude as serenity;
 use serenity::CreateMessage;
 
@@ -7,7 +5,7 @@ use super::super::formatting::{send_long_message_ctx, truncate_str};
 use super::super::router::handle_text_message;
 use super::super::turn_bridge::cancel_active_token;
 use super::super::{Context, Error, auto_restore_session, check_auth};
-use crate::services::provider::ProviderKind;
+use crate::services::provider::{ProviderKind, cancel_requested};
 
 // Re-use the report builders from diagnostics (they are private to diagnostics,
 // so cmd_cc duplicates the built-in handler logic inline, matching the original code).
@@ -82,7 +80,7 @@ pub(in crate::services::discord) async fn cmd_cc(
             };
             match token {
                 Some(token) => {
-                    if token.cancelled.load(Ordering::Relaxed) {
+                    if cancel_requested(Some(token.as_ref())) {
                         ctx.say("Already stopping...").await?;
                         return Ok(());
                     }

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -35,12 +35,10 @@ use tokio::sync::Mutex;
 use poise::serenity_prelude as serenity;
 use serenity::{ChannelId, CreateAttachment, CreateMessage, EditMessage, MessageId, UserId};
 
-use crate::services::claude::{
-    self, CancelToken, DEFAULT_ALLOWED_TOOLS, ReadOutputResult, StreamMessage,
-};
+use crate::services::claude::{self, DEFAULT_ALLOWED_TOOLS, ReadOutputResult, StreamMessage};
 use crate::services::codex;
 use crate::services::gemini;
-use crate::services::provider::ProviderKind;
+use crate::services::provider::{CancelToken, ProviderKind};
 use crate::ui::ai_screen::{self, HistoryItem, HistoryType};
 
 use adk_session::{

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -35,10 +35,10 @@ use tokio::sync::Mutex;
 use poise::serenity_prelude as serenity;
 use serenity::{ChannelId, CreateAttachment, CreateMessage, EditMessage, MessageId, UserId};
 
-use crate::services::claude::{self, DEFAULT_ALLOWED_TOOLS, ReadOutputResult, StreamMessage};
+use crate::services::claude::{self, DEFAULT_ALLOWED_TOOLS, StreamMessage};
 use crate::services::codex;
 use crate::services::gemini;
-use crate::services::provider::{CancelToken, ProviderKind};
+use crate::services::provider::{CancelToken, ProviderKind, ReadOutputResult};
 use crate::ui::ai_screen::{self, HistoryItem, HistoryType};
 
 use adk_session::{

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -309,6 +309,25 @@ pub(super) struct TmuxWatcherHandle {
     pub(super) turn_delivered: Arc<std::sync::atomic::AtomicBool>,
 }
 
+/// Atomically claim a channel for watcher creation using DashMap::entry().
+/// Returns true if the claim succeeded (caller should spawn the watcher).
+/// Returns false if a watcher already exists (caller should skip).
+pub(super) fn try_claim_watcher(
+    watchers: &dashmap::DashMap<ChannelId, TmuxWatcherHandle>,
+    channel_id: ChannelId,
+    handle: TmuxWatcherHandle,
+) -> bool {
+    use dashmap::mapref::entry::Entry;
+
+    match watchers.entry(channel_id) {
+        Entry::Occupied(_) => false,
+        Entry::Vacant(entry) => {
+            entry.insert(handle);
+            true
+        }
+    }
+}
+
 #[derive(Clone)]
 pub(super) struct ModelPickerPendingState {
     pub(super) owner_user_id: UserId,

--- a/src/services/discord/recovery.rs
+++ b/src/services/discord/recovery.rs
@@ -554,8 +554,7 @@ pub(super) async fn restore_inflight_turns(
                             pause_epoch: pause_epoch.clone(),
                             turn_delivered: turn_delivered.clone(),
                         };
-                        if super::tmux::try_claim_watcher(&shared.tmux_watchers, channel_id, handle)
-                        {
+                        if super::try_claim_watcher(&shared.tmux_watchers, channel_id, handle) {
                             let ts2 = chrono::Local::now().format("%H:%M:%S");
                             if truncated {
                                 println!(
@@ -1019,7 +1018,7 @@ pub(super) async fn restore_inflight_turns(
                     pause_epoch: pause_epoch.clone(),
                     turn_delivered: turn_delivered.clone(),
                 };
-                if super::tmux::try_claim_watcher(&shared.tmux_watchers, channel_id, handle) {
+                if super::try_claim_watcher(&shared.tmux_watchers, channel_id, handle) {
                     let ts2 = chrono::Local::now().format("%H:%M:%S");
                     if truncated {
                         println!(

--- a/src/services/discord/recovery.rs
+++ b/src/services/discord/recovery.rs
@@ -836,7 +836,7 @@ pub(super) async fn restore_inflight_turns(
         }
 
         let tmux_ready_without_new_output = tmux_session_name.as_deref().map_or(false, |name| {
-            !output_has_new_bytes && claude::tmux_session_ready_for_input(name)
+            !output_has_new_bytes && crate::services::provider::tmux_session_ready_for_input(name)
         });
 
         if tmux_ready_without_new_output {
@@ -1149,7 +1149,7 @@ pub(super) async fn restore_inflight_turns(
                 start_offset,
                 tx.clone(),
                 Some(cancel_for_reader),
-                claude::SessionProbe::tmux(tmux_for_reader.clone()),
+                crate::services::provider::SessionProbe::tmux(tmux_for_reader.clone()),
             ) {
                 Ok(ReadOutputResult::Completed { offset })
                 | Ok(ReadOutputResult::Cancelled { offset }) => {

--- a/src/services/discord/turn_bridge.rs
+++ b/src/services/discord/turn_bridge.rs
@@ -241,6 +241,13 @@ fn stream_error_has_stale_resume_error(message: &str, stderr: &str) -> bool {
     contains_stale_resume_error_text(message) || contains_stale_resume_error_text(stderr)
 }
 
+fn stream_error_requires_terminal_session_reset(message: &str, stderr: &str) -> bool {
+    let lower = format!("{} {}", message, stderr).to_ascii_lowercase();
+    lower.contains("gemini session could not be recovered after retry")
+        || lower.contains("gemini stream ended without a terminal result")
+        || lower.contains("invalidargument: gemini resume selector must be")
+}
+
 /// Decide the final response text when a Done event arrives.
 ///
 /// Returns the text that should be used as `full_response`.
@@ -895,6 +902,7 @@ pub(super) fn spawn_turn_bridge(
         let mut tmux_handed_off = false;
         let mut transport_error = false;
         let mut resume_failure_detected = false;
+        let mut terminal_session_reset_required = false;
         let mut restart_recovery_handoff = false;
         let mut recovery_retry = false;
         let mut last_adk_heartbeat = std::time::Instant::now();
@@ -1112,6 +1120,8 @@ pub(super) fn spawn_turn_bridge(
                         } => {
                             let is_stale_resume =
                                 stream_error_has_stale_resume_error(&message, &stderr);
+                            let session_reset_required =
+                                stream_error_requires_terminal_session_reset(&message, &stderr);
                             transport_error = true;
                             let combined = format!("{} {}", message, stderr).to_lowercase();
                             if combined.contains("prompt is too long")
@@ -1147,6 +1157,15 @@ pub(super) fn spawn_turn_bridge(
                                 );
                             } else {
                                 full_response = format!("Error: {}", message);
+                            }
+                            if session_reset_required {
+                                terminal_session_reset_required = true;
+                                clear_local_session_state(&mut new_session_id, &mut inflight_state);
+                                let ts = chrono::Local::now().format("%H:%M:%S");
+                                eprintln!(
+                                    "  [{ts}] ⚠ Clearing stored provider session after terminal Gemini session failure (channel {})",
+                                    channel_id
+                                );
                             }
                             inflight_state.full_response = full_response.clone();
                             state_dirty = true;
@@ -1959,7 +1978,7 @@ pub(super) fn spawn_turn_bridge(
             let mut data = shared_owned.core.lock().await;
             if let Some(session) = data.sessions.get_mut(&channel_id) {
                 if !session.cleared && !is_prompt_too_long {
-                    if resume_failure_detected {
+                    if resume_failure_detected || terminal_session_reset_required {
                         session.session_id = None;
                     } else if let Some(sid) = new_session_id {
                         session.session_id = Some(sid);
@@ -1982,7 +2001,7 @@ pub(super) fn spawn_turn_bridge(
         };
 
         // Persist provider session_id to DB so it survives dcserver restarts.
-        if !resume_failure_detected {
+        if !resume_failure_detected && !terminal_session_reset_required {
             if let (Some(ref session_key), Some(ref persisted_sid)) =
                 (adk_session_key, session_id_to_persist)
             {
@@ -1993,6 +2012,11 @@ pub(super) fn spawn_turn_bridge(
                     shared_owned.api_port,
                 )
                 .await;
+            }
+        } else if terminal_session_reset_required {
+            if let Some(ref session_key) = adk_session_key {
+                super::adk_session::clear_claude_session_id(session_key, shared_owned.api_port)
+                    .await;
             }
         }
 
@@ -2225,7 +2249,8 @@ mod tests {
         extract_explicit_review_verdict, extract_review_decision,
         output_file_has_stale_resume_error_after_offset, persisted_context_tokens,
         resolve_done_response, result_event_has_stale_resume_error,
-        should_resume_watcher_after_turn, total_context_tokens,
+        should_resume_watcher_after_turn, stream_error_requires_terminal_session_reset,
+        total_context_tokens,
     };
     use crate::services::discord::InflightTurnState;
     use crate::services::provider::ProviderKind;
@@ -2290,6 +2315,22 @@ mod tests {
         ));
         assert!(!contains_stale_resume_error_text(
             "The assistant explained why a conversation was missing context."
+        ));
+    }
+
+    #[test]
+    fn terminal_session_reset_helper_matches_gemini_recovery_failure() {
+        assert!(stream_error_requires_terminal_session_reset(
+            "Gemini session could not be recovered after retry: Gemini stream ended without a terminal result",
+            "",
+        ));
+        assert!(stream_error_requires_terminal_session_reset(
+            "InvalidArgument: Gemini resume selector must be `latest` or a numeric session index",
+            "",
+        ));
+        assert!(!stream_error_requires_terminal_session_reset(
+            "Gemini CLI not found",
+            "",
         ));
     }
 

--- a/src/services/discord/turn_bridge.rs
+++ b/src/services/discord/turn_bridge.rs
@@ -2,6 +2,7 @@ use super::handoff::{HandoffRecord, save_handoff};
 use super::restart_report::{RestartCompletionReport, clear_restart_report, save_restart_report};
 use super::*;
 use crate::config::local_api_url;
+use crate::services::provider::cancel_requested;
 #[cfg(unix)]
 use crate::services::tmux_common::tmux_exact_target;
 #[cfg(unix)]
@@ -953,14 +954,14 @@ pub(super) fn spawn_turn_bridge(
         while !done {
             let mut state_dirty = false;
 
-            if cancel_token.cancelled.load(Ordering::Relaxed) {
+            if cancel_requested(Some(cancel_token.as_ref())) {
                 cancelled = true;
                 break;
             }
 
             tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
 
-            if cancel_token.cancelled.load(Ordering::Relaxed) {
+            if cancel_requested(Some(cancel_token.as_ref())) {
                 cancelled = true;
                 break;
             }

--- a/src/services/discord/turn_bridge.rs
+++ b/src/services/discord/turn_bridge.rs
@@ -105,6 +105,42 @@ fn clear_local_session_state(
     inflight_state.session_id = None;
 }
 
+fn should_reset_gemini_retry_attempt_state(
+    full_response: &str,
+    current_tool_line: Option<&str>,
+    any_tool_used: bool,
+    has_post_tool_text: bool,
+) -> bool {
+    !full_response.trim().is_empty()
+        || current_tool_line.is_some()
+        || any_tool_used
+        || has_post_tool_text
+}
+
+fn reset_gemini_retry_attempt_state(
+    full_response: &mut String,
+    current_tool_line: &mut Option<String>,
+    last_tool_name: &mut Option<String>,
+    last_tool_summary: &mut Option<String>,
+    any_tool_used: &mut bool,
+    has_post_tool_text: &mut bool,
+    response_sent_offset: &mut usize,
+    inflight_state: &mut InflightTurnState,
+) {
+    full_response.clear();
+    *current_tool_line = None;
+    *last_tool_name = None;
+    *last_tool_summary = None;
+    *any_tool_used = false;
+    *has_post_tool_text = false;
+    *response_sent_offset = 0;
+    inflight_state.full_response.clear();
+    inflight_state.current_tool_line = None;
+    inflight_state.any_tool_used = false;
+    inflight_state.has_post_tool_text = false;
+    inflight_state.response_sent_offset = 0;
+}
+
 async fn reset_session_for_auto_retry(
     shared: &Arc<SharedData>,
     channel_id: ChannelId,
@@ -908,7 +944,7 @@ pub(super) fn spawn_turn_bridge(
         let mut recovery_retry = false;
         let mut last_adk_heartbeat = std::time::Instant::now();
         let current_msg_id = bridge.current_msg_id;
-        let response_sent_offset = bridge.response_sent_offset;
+        let mut response_sent_offset = bridge.response_sent_offset;
         let mut tmux_last_offset = bridge.tmux_last_offset;
         let mut new_session_id = bridge.new_session_id.clone();
         let defer_watcher_resume = bridge.defer_watcher_resume;
@@ -970,6 +1006,26 @@ pub(super) fn spawn_turn_bridge(
                 match rx.try_recv() {
                     Ok(msg) => match msg {
                         StreamMessage::Init { session_id: sid } => {
+                            if provider == ProviderKind::Gemini
+                                && should_reset_gemini_retry_attempt_state(
+                                    &full_response,
+                                    current_tool_line.as_deref(),
+                                    any_tool_used,
+                                    has_post_tool_text,
+                                )
+                            {
+                                reset_gemini_retry_attempt_state(
+                                    &mut full_response,
+                                    &mut current_tool_line,
+                                    &mut last_tool_name,
+                                    &mut last_tool_summary,
+                                    &mut any_tool_used,
+                                    &mut has_post_tool_text,
+                                    &mut response_sent_offset,
+                                    &mut inflight_state,
+                                );
+                                last_edit_text.clear();
+                            }
                             new_session_id = Some(sid.clone());
                             inflight_state.session_id = Some(sid);
                             state_dirty = true;
@@ -2249,7 +2305,8 @@ mod tests {
         build_verdict_payload, clear_local_session_state, contains_stale_resume_error_text,
         extract_explicit_review_verdict, extract_review_decision,
         output_file_has_stale_resume_error_after_offset, persisted_context_tokens,
-        resolve_done_response, result_event_has_stale_resume_error,
+        reset_gemini_retry_attempt_state, resolve_done_response,
+        result_event_has_stale_resume_error, should_reset_gemini_retry_attempt_state,
         should_resume_watcher_after_turn, stream_error_requires_terminal_session_reset,
         total_context_tokens,
     };
@@ -2333,6 +2390,79 @@ mod tests {
             "Gemini CLI not found",
             "",
         ));
+    }
+
+    #[test]
+    fn gemini_retry_reset_helper_requires_current_turn_partial_state() {
+        assert!(should_reset_gemini_retry_attempt_state(
+            "partial answer",
+            None,
+            false,
+            false,
+        ));
+        assert!(should_reset_gemini_retry_attempt_state(
+            "",
+            Some("⚙ Bash: pwd"),
+            true,
+            false,
+        ));
+        assert!(!should_reset_gemini_retry_attempt_state(
+            "", None, false, false,
+        ));
+    }
+
+    #[test]
+    fn reset_gemini_retry_attempt_state_clears_partial_output_and_tool_flags() {
+        let mut full_response = "partial answer".to_string();
+        let mut current_tool_line = Some("⚙ Bash: pwd".to_string());
+        let mut last_tool_name = Some("Bash".to_string());
+        let mut last_tool_summary = Some("pwd".to_string());
+        let mut any_tool_used = true;
+        let mut has_post_tool_text = true;
+        let mut response_sent_offset = 42usize;
+        let mut inflight_state = InflightTurnState::new(
+            ProviderKind::Gemini,
+            1479671298497183835,
+            Some("adk-gm".to_string()),
+            343742347365974026,
+            1,
+            2,
+            "resume me".to_string(),
+            Some("latest".to_string()),
+            Some("AgentDesk-gemini-adk-gm".to_string()),
+            Some("/tmp/out.jsonl".to_string()),
+            Some("/tmp/in.fifo".to_string()),
+            0,
+        );
+        inflight_state.full_response = full_response.clone();
+        inflight_state.current_tool_line = current_tool_line.clone();
+        inflight_state.any_tool_used = true;
+        inflight_state.has_post_tool_text = true;
+        inflight_state.response_sent_offset = response_sent_offset;
+
+        reset_gemini_retry_attempt_state(
+            &mut full_response,
+            &mut current_tool_line,
+            &mut last_tool_name,
+            &mut last_tool_summary,
+            &mut any_tool_used,
+            &mut has_post_tool_text,
+            &mut response_sent_offset,
+            &mut inflight_state,
+        );
+
+        assert!(full_response.is_empty());
+        assert_eq!(current_tool_line, None);
+        assert_eq!(last_tool_name, None);
+        assert_eq!(last_tool_summary, None);
+        assert!(!any_tool_used);
+        assert!(!has_post_tool_text);
+        assert_eq!(response_sent_offset, 0);
+        assert!(inflight_state.full_response.is_empty());
+        assert_eq!(inflight_state.current_tool_line, None);
+        assert!(!inflight_state.any_tool_used);
+        assert!(!inflight_state.has_post_tool_text);
+        assert_eq!(inflight_state.response_sent_offset, 0);
     }
 
     #[test]

--- a/src/services/discord/turn_bridge.rs
+++ b/src/services/discord/turn_bridge.rs
@@ -1213,7 +1213,7 @@ pub(super) fn spawn_turn_bridge(
                                 pause_epoch: pause_epoch.clone(),
                                 turn_delivered: turn_delivered.clone(),
                             };
-                            if super::tmux::try_claim_watcher(
+                            if super::try_claim_watcher(
                                 &shared_owned.tmux_watchers,
                                 channel_id,
                                 handle,

--- a/src/services/gemini.rs
+++ b/src/services/gemini.rs
@@ -28,6 +28,13 @@ enum GeminiStreamEvent {
     Eof,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum GeminiStreamLoopResult {
+    Eof,
+    RetrySession { message: String },
+    Cancelled,
+}
+
 #[derive(Debug)]
 enum GeminiAttemptResult {
     Completed,
@@ -270,53 +277,30 @@ fn execute_gemini_streaming_attempt(
     }
 
     let mut state = GeminiAttemptState::new(resume_selector);
-    let mut idle_ticks = 0;
-
-    loop {
-        if is_cancelled(cancel_token.as_deref()) {
+    match collect_gemini_stream_events(
+        &stdout_events,
+        cancel_token.as_deref(),
+        &mut state,
+        GEMINI_STREAM_IDLE_TIMEOUT,
+    ) {
+        GeminiStreamLoopResult::Cancelled => {
             claude::kill_child_tree(&mut child);
             let _ = child.wait();
             let _ = stderr_handle.join();
             return Ok(GeminiAttemptResult::Cancelled);
         }
-
-        match stdout_events.recv_timeout(GEMINI_STREAM_IDLE_TIMEOUT) {
-            Ok(GeminiStreamEvent::Line(line)) => {
-                idle_ticks = 0;
-                process_gemini_stream_line(&line, &mut state);
-            }
-            Ok(GeminiStreamEvent::ReadError(message)) => {
-                claude::kill_child_tree(&mut child);
-                let stderr = stderr_handle.join().unwrap_or_default();
-                return Ok(GeminiAttemptResult::RetrySession {
-                    message,
-                    stdout: state.raw_stdout,
-                    stderr,
-                    exit_code: None,
-                });
-            }
-            Ok(GeminiStreamEvent::Eof) | Err(RecvTimeoutError::Disconnected) => break,
-            Err(RecvTimeoutError::Timeout) => {
-                if state.terminal_result_seen {
-                    break;
-                }
-                idle_ticks += 1;
-                if idle_ticks >= GEMINI_STREAM_IDLE_TICKS_BEFORE_RETRY {
-                    claude::kill_child_tree(&mut child);
-                    let stderr = stderr_handle.join().unwrap_or_default();
-                    return Ok(GeminiAttemptResult::RetrySession {
-                        message: format!(
-                            "Gemini stream produced no output for {} seconds",
-                            GEMINI_STREAM_IDLE_TIMEOUT.as_secs()
-                                * GEMINI_STREAM_IDLE_TICKS_BEFORE_RETRY as u64
-                        ),
-                        stdout: state.raw_stdout,
-                        stderr,
-                        exit_code: None,
-                    });
-                }
-            }
+        GeminiStreamLoopResult::RetrySession { message } => {
+            claude::kill_child_tree(&mut child);
+            let _ = child.wait();
+            let stderr = stderr_handle.join().unwrap_or_default();
+            return Ok(GeminiAttemptResult::RetrySession {
+                message,
+                stdout: state.raw_stdout,
+                stderr,
+                exit_code: None,
+            });
         }
+        GeminiStreamLoopResult::Eof => {}
     }
 
     let status = child
@@ -360,6 +344,51 @@ fn execute_gemini_streaming_attempt(
             stderr,
             exit_code,
         }),
+    }
+}
+
+fn collect_gemini_stream_events(
+    stdout_events: &mpsc::Receiver<GeminiStreamEvent>,
+    cancel_token: Option<&CancelToken>,
+    state: &mut GeminiAttemptState,
+    idle_timeout: Duration,
+) -> GeminiStreamLoopResult {
+    let mut idle_ticks = 0;
+
+    loop {
+        if is_cancelled(cancel_token) {
+            return GeminiStreamLoopResult::Cancelled;
+        }
+
+        match stdout_events.recv_timeout(idle_timeout) {
+            Ok(GeminiStreamEvent::Line(line)) => {
+                idle_ticks = 0;
+                process_gemini_stream_line(&line, state);
+            }
+            Ok(GeminiStreamEvent::ReadError(message)) => {
+                return GeminiStreamLoopResult::RetrySession { message };
+            }
+            Ok(GeminiStreamEvent::Eof) | Err(RecvTimeoutError::Disconnected) => {
+                return GeminiStreamLoopResult::Eof;
+            }
+            Err(RecvTimeoutError::Timeout) => {
+                if is_cancelled(cancel_token) {
+                    return GeminiStreamLoopResult::Cancelled;
+                }
+                if state.terminal_result_seen {
+                    return GeminiStreamLoopResult::Eof;
+                }
+                idle_ticks += 1;
+                if idle_ticks >= GEMINI_STREAM_IDLE_TICKS_BEFORE_RETRY {
+                    return GeminiStreamLoopResult::RetrySession {
+                        message: format!(
+                            "Gemini stream produced no output for {} seconds",
+                            idle_timeout.as_secs() * GEMINI_STREAM_IDLE_TICKS_BEFORE_RETRY as u64
+                        ),
+                    };
+                }
+            }
+        }
     }
 }
 
@@ -802,8 +831,9 @@ fn render_gemini_value(value: &Value) -> String {
 mod tests {
     use super::{
         GEMINI_INVALID_RESUME_SELECTOR_MESSAGE, GEMINI_SESSION_DEAD_MESSAGE, GeminiAttemptResult,
-        GeminiAttemptState, GeminiFinalState, build_exec_args, build_gemini_tool_result_message,
-        build_gemini_tool_use_message, execute_command_streaming, extract_gemini_error_message,
+        GeminiAttemptState, GeminiFinalState, GeminiStreamEvent, GeminiStreamLoopResult,
+        build_exec_args, build_gemini_tool_result_message, build_gemini_tool_use_message,
+        collect_gemini_stream_events, execute_command_streaming, extract_gemini_error_message,
         extract_text_from_stream_output, finalize_gemini_attempt, flush_buffered_stream_messages,
         looks_like_uuid, normalize_resume_selector, observed_session_to_resume_selector,
         process_gemini_stream_line, remote_profile_not_supported_message,
@@ -815,6 +845,7 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::Ordering;
     use std::sync::mpsc;
+    use std::time::Duration;
 
     #[test]
     fn build_exec_args_includes_resume_when_session_present() {
@@ -1210,6 +1241,32 @@ mod tests {
         assert!(result.is_ok());
         assert!(rx.try_recv().is_err());
         assert!(token.child_pid.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn cancelled_during_stream_returns_cancelled() {
+        let token = Arc::new(CancelToken::new());
+        let (tx, rx) = mpsc::channel();
+        let mut state = GeminiAttemptState::new(None);
+        tx.send(GeminiStreamEvent::Line(
+            r#"{"type":"message","role":"assistant","content":"partial"}"#.to_string(),
+        ))
+        .unwrap();
+        let token_for_thread = token.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(1));
+            token_for_thread.cancelled.store(true, Ordering::Relaxed);
+        });
+
+        let result = collect_gemini_stream_events(
+            &rx,
+            Some(token.as_ref()),
+            &mut state,
+            Duration::from_millis(5),
+        );
+
+        assert_eq!(result, GeminiStreamLoopResult::Cancelled);
+        assert_eq!(state.final_text, "partial");
     }
 
     #[test]

--- a/src/services/gemini.rs
+++ b/src/services/gemini.rs
@@ -15,6 +15,8 @@ static GEMINI_PATH: OnceLock<Option<String>> = OnceLock::new();
 pub const DEFAULT_GEMINI_MODEL: &str = "gemini-2.5-flash";
 const GEMINI_RESUME_LATEST: &str = "latest";
 const GEMINI_SESSION_DEAD_MESSAGE: &str = "Gemini stream ended without a terminal result";
+const GEMINI_INVALID_RESUME_SELECTOR_MESSAGE: &str =
+    "InvalidArgument: Gemini resume selector must be `latest` or a numeric session index";
 const GEMINI_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
 const GEMINI_STREAM_IDLE_TICKS_BEFORE_RETRY: u32 = 2;
 const GEMINI_MAX_SESSION_RETRIES: usize = 1;
@@ -162,20 +164,36 @@ pub fn execute_command_streaming(
         return Err(remote_profile_not_supported_message());
     }
 
+    let resume_selector = normalize_resume_selector(session_id)?;
+    if is_cancelled(cancel_token.as_deref()) {
+        return Ok(());
+    }
+
     let gemini_bin = get_gemini_path().ok_or_else(|| "Gemini CLI not found".to_string())?;
     let prompt = compose_gemini_prompt(prompt, system_prompt, allowed_tools);
-    let mut resume_selector = normalize_resume_selector(session_id)?;
-
-    for attempt in 0..=GEMINI_MAX_SESSION_RETRIES {
-        match execute_gemini_streaming_attempt(
+    run_gemini_streaming_attempts(&sender, resume_selector, |resume_selector| {
+        execute_gemini_streaming_attempt(
             gemini_bin,
             &prompt,
             model,
-            resume_selector.clone(),
+            resume_selector,
             working_dir,
             sender.clone(),
             cancel_token.clone(),
-        )? {
+        )
+    })
+}
+
+fn run_gemini_streaming_attempts<F>(
+    sender: &Sender<StreamMessage>,
+    mut resume_selector: Option<String>,
+    mut execute_attempt: F,
+) -> Result<(), String>
+where
+    F: FnMut(Option<String>) -> Result<GeminiAttemptResult, String>,
+{
+    for attempt in 0..=GEMINI_MAX_SESSION_RETRIES {
+        match execute_attempt(resume_selector.clone())? {
             GeminiAttemptResult::Completed | GeminiAttemptResult::Cancelled => return Ok(()),
             GeminiAttemptResult::RetrySession {
                 message,
@@ -628,14 +646,35 @@ fn normalize_resume_selector(session_id: Option<&str>) -> Result<Option<String>,
         return Ok(Some(GEMINI_RESUME_LATEST.to_string()));
     }
 
-    Err(
-        "InvalidArgument: Gemini resume selector must be `latest` or a numeric session index"
-            .to_string(),
-    )
+    if is_common_session_metadata(session_id) {
+        return Err(GEMINI_INVALID_RESUME_SELECTOR_MESSAGE.to_string());
+    }
+
+    Err(GEMINI_INVALID_RESUME_SELECTOR_MESSAGE.to_string())
 }
 
-fn observed_session_to_resume_selector(_session_id: &str) -> Option<String> {
-    Some(GEMINI_RESUME_LATEST.to_string())
+fn observed_session_to_resume_selector(session_id: &str) -> Option<String> {
+    let session_id = session_id.trim();
+    if session_id.is_empty() {
+        return None;
+    }
+
+    if session_id.eq_ignore_ascii_case(GEMINI_RESUME_LATEST)
+        || session_id.chars().all(|ch| ch.is_ascii_digit())
+        || looks_like_uuid(session_id)
+        || is_common_session_metadata(session_id)
+    {
+        return Some(GEMINI_RESUME_LATEST.to_string());
+    }
+
+    None
+}
+
+fn is_common_session_metadata(session_id: &str) -> bool {
+    let session_id = session_id.trim();
+    !session_id.is_empty()
+        && claude::session_id_regex().is_match(session_id)
+        && claude::is_valid_session_id(session_id)
 }
 
 fn looks_like_uuid(value: &str) -> bool {
@@ -762,16 +801,19 @@ fn render_gemini_value(value: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        GEMINI_SESSION_DEAD_MESSAGE, GeminiAttemptState, GeminiFinalState, build_exec_args,
-        build_gemini_tool_result_message, build_gemini_tool_use_message, execute_command_streaming,
-        extract_gemini_error_message, extract_text_from_stream_output, finalize_gemini_attempt,
-        flush_buffered_stream_messages, looks_like_uuid, normalize_resume_selector,
-        observed_session_to_resume_selector, process_gemini_stream_line,
-        remote_profile_not_supported_message,
+        GEMINI_INVALID_RESUME_SELECTOR_MESSAGE, GEMINI_SESSION_DEAD_MESSAGE, GeminiAttemptResult,
+        GeminiAttemptState, GeminiFinalState, build_exec_args, build_gemini_tool_result_message,
+        build_gemini_tool_use_message, execute_command_streaming, extract_gemini_error_message,
+        extract_text_from_stream_output, finalize_gemini_attempt, flush_buffered_stream_messages,
+        looks_like_uuid, normalize_resume_selector, observed_session_to_resume_selector,
+        process_gemini_stream_line, remote_profile_not_supported_message,
+        run_gemini_streaming_attempts,
     };
-    use crate::services::claude::StreamMessage;
+    use crate::services::claude::{CancelToken, StreamMessage};
     use crate::services::remote::{RemoteAuth, RemoteProfile};
     use serde_json::json;
+    use std::sync::Arc;
+    use std::sync::atomic::Ordering;
     use std::sync::mpsc;
 
     #[test]
@@ -833,6 +875,14 @@ mod tests {
     }
 
     #[test]
+    fn observed_session_to_resume_selector_maps_common_metadata_to_latest() {
+        assert_eq!(
+            observed_session_to_resume_selector("session-alpha").as_deref(),
+            Some("latest")
+        );
+    }
+
+    #[test]
     fn extract_text_from_stream_output_ignores_plaintext_retry_logs() {
         let output = concat!(
             "Attempt 1 failed with status 429. Retrying with backoff...\n",
@@ -877,6 +927,38 @@ mod tests {
             }
             other => panic!("expected ToolResult, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn tool_use_then_tool_result_preserves_order() {
+        let (tx, rx) = mpsc::channel();
+        let mut state = GeminiAttemptState::new(None);
+        process_gemini_stream_line(
+            r#"{"type":"tool_use","tool_name":"run_shell_command","parameters":{"command":"pwd"}}"#,
+            &mut state,
+        );
+        process_gemini_stream_line(
+            r#"{"type":"tool_result","status":"success","output":"/tmp/example"}"#,
+            &mut state,
+        );
+
+        flush_buffered_stream_messages(&tx, &mut state);
+
+        match rx.recv().unwrap() {
+            StreamMessage::ToolUse { name, input } => {
+                assert_eq!(name, "Bash");
+                assert!(input.contains("\"command\":\"pwd\""));
+            }
+            other => panic!("expected ToolUse, got {:?}", other),
+        }
+        match rx.recv().unwrap() {
+            StreamMessage::ToolResult { content, is_error } => {
+                assert_eq!(content, "/tmp/example");
+                assert!(!is_error);
+            }
+            other => panic!("expected ToolResult, got {:?}", other),
+        }
+        assert!(rx.try_recv().is_err());
     }
 
     #[test]
@@ -945,6 +1027,84 @@ mod tests {
     }
 
     #[test]
+    fn execute_complete_flushes_buffered_messages_before_done() {
+        let (tx, rx) = mpsc::channel();
+        let mut state = GeminiAttemptState::new(None);
+        process_gemini_stream_line(
+            r#"{"type":"init","session_id":"session-alpha","model":"gemini-2.5-flash"}"#,
+            &mut state,
+        );
+        process_gemini_stream_line(
+            r#"{"type":"message","role":"assistant","content":"hello"}"#,
+            &mut state,
+        );
+        process_gemini_stream_line(
+            r#"{"type":"tool_use","tool_name":"run_shell_command","parameters":{"command":"pwd"}}"#,
+            &mut state,
+        );
+        process_gemini_stream_line(
+            r#"{"type":"tool_result","status":"success","output":"/tmp/example"}"#,
+            &mut state,
+        );
+        process_gemini_stream_line(
+            r#"{"type":"result","result":"hello","stats":{"input_tokens":10,"output_tokens":4,"duration_ms":20}}"#,
+            &mut state,
+        );
+
+        let final_state = finalize_gemini_attempt(&mut state, String::new(), Some(0));
+        flush_buffered_stream_messages(&tx, &mut state);
+        match final_state {
+            GeminiFinalState::Done { result, session_id } => {
+                let _ = tx.send(StreamMessage::Done { result, session_id });
+            }
+            other => panic!("expected Done, got {:?}", other),
+        }
+
+        match rx.recv().unwrap() {
+            StreamMessage::Init { session_id } => assert_eq!(session_id, "latest"),
+            other => panic!("expected Init, got {:?}", other),
+        }
+        match rx.recv().unwrap() {
+            StreamMessage::Text { content } => assert_eq!(content, "hello"),
+            other => panic!("expected Text, got {:?}", other),
+        }
+        match rx.recv().unwrap() {
+            StreamMessage::ToolUse { name, .. } => assert_eq!(name, "Bash"),
+            other => panic!("expected ToolUse, got {:?}", other),
+        }
+        match rx.recv().unwrap() {
+            StreamMessage::ToolResult { content, is_error } => {
+                assert_eq!(content, "/tmp/example");
+                assert!(!is_error);
+            }
+            other => panic!("expected ToolResult, got {:?}", other),
+        }
+        match rx.recv().unwrap() {
+            StreamMessage::StatusUpdate {
+                model,
+                input_tokens,
+                output_tokens,
+                duration_ms,
+                ..
+            } => {
+                assert_eq!(model.as_deref(), Some("gemini-2.5-flash"));
+                assert_eq!(input_tokens, Some(10));
+                assert_eq!(output_tokens, Some(4));
+                assert_eq!(duration_ms, Some(20));
+            }
+            other => panic!("expected StatusUpdate, got {:?}", other),
+        }
+        match rx.recv().unwrap() {
+            StreamMessage::Done { result, session_id } => {
+                assert_eq!(result, "hello");
+                assert_eq!(session_id.as_deref(), Some("latest"));
+            }
+            other => panic!("expected Done, got {:?}", other),
+        }
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
     fn terminal_result_is_authoritative_even_if_error_seen() {
         let mut state = GeminiAttemptState::new(Some("latest".to_string()));
         state.last_error_message = Some("quota exceeded".to_string());
@@ -1002,6 +1162,89 @@ mod tests {
         let message = remote_profile_not_supported_message();
         assert!(message.contains("NotSupported"));
         assert!(message.contains("remote_profile"));
+    }
+
+    #[test]
+    fn execute_command_streaming_rejects_invalid_resume_selector_before_binary_lookup() {
+        let (tx, _rx) = mpsc::channel();
+        let error = execute_command_streaming(
+            "hello",
+            Some("session-alpha"),
+            ".",
+            tx,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap_err();
+
+        assert_eq!(error, GEMINI_INVALID_RESUME_SELECTOR_MESSAGE);
+    }
+
+    #[test]
+    fn execute_command_streaming_returns_ok_when_cancelled_before_spawn() {
+        let (tx, rx) = mpsc::channel();
+        let token = Arc::new(CancelToken::new());
+        token.cancelled.store(true, Ordering::Relaxed);
+
+        let result = execute_command_streaming(
+            "hello",
+            None,
+            ".",
+            tx,
+            None,
+            None,
+            Some(token.clone()),
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        assert!(result.is_ok());
+        assert!(rx.try_recv().is_err());
+        assert!(token.child_pid.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn session_died_retry_once_then_error() {
+        let (tx, rx) = mpsc::channel();
+        let mut attempt_calls = Vec::new();
+
+        let result = run_gemini_streaming_attempts(&tx, Some("latest".to_string()), |selector| {
+            attempt_calls.push(selector);
+            Ok(GeminiAttemptResult::RetrySession {
+                message: GEMINI_SESSION_DEAD_MESSAGE.to_string(),
+                stdout: "partial".to_string(),
+                stderr: String::new(),
+                exit_code: None,
+            })
+        });
+
+        assert!(result.is_ok());
+        assert_eq!(attempt_calls, vec![Some("latest".to_string()), None]);
+        match rx.recv().unwrap() {
+            StreamMessage::Error {
+                message,
+                stdout,
+                stderr,
+                exit_code,
+            } => {
+                assert!(message.contains("could not be recovered after retry"));
+                assert!(message.contains(GEMINI_SESSION_DEAD_MESSAGE));
+                assert_eq!(stdout, "partial");
+                assert!(stderr.is_empty());
+                assert_eq!(exit_code, None);
+            }
+            other => panic!("expected Error, got {:?}", other),
+        }
+        assert!(rx.try_recv().is_err());
     }
 
     #[test]

--- a/src/services/gemini.rs
+++ b/src/services/gemini.rs
@@ -604,31 +604,7 @@ fn compose_gemini_prompt(
     system_prompt: Option<&str>,
     allowed_tools: Option<&[String]>,
 ) -> String {
-    let mut sections = Vec::new();
-
-    if let Some(system_prompt) = system_prompt
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        sections.push(format!(
-            "[Authoritative Instructions]\n{}\n\nThese instructions are authoritative for this turn. Follow them over any generic assistant persona unless the user explicitly asks to inspect or compare them.",
-            system_prompt
-        ));
-    }
-
-    if let Some(allowed_tools) = allowed_tools.filter(|tools| !tools.is_empty()) {
-        sections.push(format!(
-            "[Tool Policy]\nIf tools are needed, stay within this allowlist unless the user explicitly asks to change it: {}",
-            allowed_tools.join(", ")
-        ));
-    }
-
-    if sections.is_empty() {
-        return prompt.to_string();
-    }
-
-    sections.push(format!("[User Request]\n{}", prompt));
-    sections.join("\n\n")
+    crate::services::provider::compose_structured_turn_prompt(prompt, system_prompt, allowed_tools)
 }
 
 fn build_exec_args(prompt: &str, model: Option<&str>, session_id: Option<&str>) -> Vec<String> {

--- a/src/services/gemini.rs
+++ b/src/services/gemini.rs
@@ -7,8 +7,8 @@ use std::sync::OnceLock;
 use std::sync::mpsc::{self, RecvTimeoutError, Sender};
 use std::time::Duration;
 
-use crate::services::claude::{self, CancelToken, StreamMessage};
-use crate::services::provider::ProviderKind;
+use crate::services::claude::{self, StreamMessage};
+use crate::services::provider::{CancelToken, ProviderKind, cancel_requested, register_child_pid};
 use crate::services::remote::RemoteProfile;
 
 static GEMINI_PATH: OnceLock<Option<String>> = OnceLock::new();
@@ -249,9 +249,7 @@ fn execute_gemini_streaming_attempt(
         .spawn()
         .map_err(|e| format!("Failed to start Gemini: {}", e))?;
 
-    if let Some(ref token) = cancel_token {
-        *token.child_pid.lock().unwrap() = Some(child.id());
-    }
+    register_child_pid(cancel_token.as_deref(), child.id());
 
     let stdout = child
         .stdout
@@ -590,9 +588,7 @@ fn flush_buffered_stream_messages(sender: &Sender<StreamMessage>, state: &mut Ge
 }
 
 fn is_cancelled(token: Option<&CancelToken>) -> bool {
-    token
-        .map(|token| token.cancelled.load(std::sync::atomic::Ordering::Relaxed))
-        .unwrap_or(false)
+    cancel_requested(token)
 }
 
 fn remote_profile_not_supported_message() -> String {
@@ -815,7 +811,8 @@ mod tests {
         process_gemini_stream_line, remote_profile_not_supported_message,
         run_gemini_streaming_attempts,
     };
-    use crate::services::claude::{CancelToken, StreamMessage};
+    use crate::services::claude::StreamMessage;
+    use crate::services::provider::CancelToken;
     use crate::services::remote::{RemoteAuth, RemoteProfile};
     use serde_json::json;
     use std::sync::Arc;

--- a/src/services/gemini.rs
+++ b/src/services/gemini.rs
@@ -4,7 +4,8 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::sync::OnceLock;
-use std::sync::mpsc::Sender;
+use std::sync::mpsc::{self, RecvTimeoutError, Sender};
+use std::time::Duration;
 
 use crate::services::claude::{self, CancelToken, StreamMessage};
 use crate::services::provider::ProviderKind;
@@ -12,6 +13,72 @@ use crate::services::remote::RemoteProfile;
 
 static GEMINI_PATH: OnceLock<Option<String>> = OnceLock::new();
 pub const DEFAULT_GEMINI_MODEL: &str = "gemini-2.5-flash";
+const GEMINI_RESUME_LATEST: &str = "latest";
+const GEMINI_CANCELLED_MESSAGE: &str = "Gemini request cancelled";
+const GEMINI_SESSION_DEAD_MESSAGE: &str = "Gemini stream ended without a terminal result";
+const GEMINI_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
+const GEMINI_STREAM_IDLE_TICKS_BEFORE_RETRY: u32 = 2;
+const GEMINI_MAX_SESSION_RETRIES: usize = 1;
+
+#[derive(Debug)]
+enum GeminiStreamEvent {
+    Line(String),
+    ReadError(String),
+    Eof,
+}
+
+#[derive(Debug)]
+enum GeminiAttemptResult {
+    Completed,
+    RetrySession {
+        message: String,
+        stdout: String,
+        stderr: String,
+        exit_code: Option<i32>,
+    },
+    Cancelled,
+}
+
+#[derive(Debug)]
+enum GeminiFinalState {
+    Done {
+        result: String,
+        session_id: Option<String>,
+    },
+    Error {
+        message: String,
+        stdout: String,
+        stderr: String,
+        exit_code: Option<i32>,
+    },
+    RetrySession {
+        message: String,
+        stdout: String,
+        stderr: String,
+        exit_code: Option<i32>,
+    },
+}
+
+#[derive(Debug, Default)]
+struct GeminiAttemptState {
+    final_text: String,
+    raw_stdout: String,
+    last_resume_selector: Option<String>,
+    init_model: Option<String>,
+    last_error_message: Option<String>,
+    terminal_result_seen: bool,
+    terminal_result_text: Option<String>,
+    buffered_messages: Vec<StreamMessage>,
+}
+
+impl GeminiAttemptState {
+    fn new(last_resume_selector: Option<String>) -> Self {
+        Self {
+            last_resume_selector,
+            ..Self::default()
+        }
+    }
+}
 
 pub fn resolve_gemini_path() -> Option<String> {
     if let Some(path) = crate::services::platform::resolve_binary_with_login_shell("gemini") {
@@ -93,16 +160,64 @@ pub fn execute_command_streaming(
     model: Option<&str>,
 ) -> Result<(), String> {
     if remote_profile.is_some() {
-        return Err("Gemini provider does not support remote execution yet".to_string());
+        return Err(remote_profile_not_supported_message());
     }
 
     let gemini_bin = get_gemini_path().ok_or_else(|| "Gemini CLI not found".to_string())?;
     let prompt = compose_gemini_prompt(prompt, system_prompt, allowed_tools);
+    let mut resume_selector = normalize_resume_selector(session_id)?;
 
+    for attempt in 0..=GEMINI_MAX_SESSION_RETRIES {
+        match execute_gemini_streaming_attempt(
+            gemini_bin,
+            &prompt,
+            model,
+            resume_selector.clone(),
+            working_dir,
+            sender.clone(),
+            cancel_token.clone(),
+        )? {
+            GeminiAttemptResult::Completed | GeminiAttemptResult::Cancelled => return Ok(()),
+            GeminiAttemptResult::RetrySession {
+                message,
+                stdout,
+                stderr,
+                exit_code,
+            } => {
+                if attempt < GEMINI_MAX_SESSION_RETRIES {
+                    resume_selector = None;
+                    continue;
+                }
+                let _ = sender.send(StreamMessage::Error {
+                    message: format!(
+                        "Gemini session could not be recovered after retry: {}",
+                        message
+                    ),
+                    stdout,
+                    stderr,
+                    exit_code,
+                });
+                return Ok(());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn execute_gemini_streaming_attempt(
+    gemini_bin: &str,
+    prompt: &str,
+    model: Option<&str>,
+    resume_selector: Option<String>,
+    working_dir: &str,
+    sender: Sender<StreamMessage>,
+    cancel_token: Option<Arc<CancelToken>>,
+) -> Result<GeminiAttemptResult, String> {
     let mut command = Command::new(gemini_bin);
     crate::services::platform::apply_runtime_path(&mut command);
     let mut child = command
-        .args(build_exec_args(&prompt, model, session_id))
+        .args(build_exec_args(prompt, model, resume_selector.as_deref()))
         .current_dir(working_dir)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -112,11 +227,6 @@ pub fn execute_command_streaming(
 
     if let Some(ref token) = cancel_token {
         *token.child_pid.lock().unwrap() = Some(child.id());
-        if token.cancelled.load(std::sync::atomic::Ordering::Relaxed) {
-            claude::kill_child_tree(&mut child);
-            let _ = child.wait();
-            return Ok(());
-        }
     }
 
     let stdout = child
@@ -127,7 +237,7 @@ pub fn execute_command_streaming(
         .stderr
         .take()
         .ok_or_else(|| "Failed to capture Gemini stderr".to_string())?;
-
+    let stdout_events = spawn_gemini_stream_reader(stdout);
     let stderr_handle = std::thread::spawn(move || {
         let mut buf = String::new();
         let mut reader = BufReader::new(stderr);
@@ -135,104 +245,60 @@ pub fn execute_command_streaming(
         buf
     });
 
-    let mut final_text = String::new();
-    let mut raw_stdout = String::new();
-    let mut last_session_id: Option<String> = None;
-    let mut init_model: Option<String> = None;
-    let mut last_error_message: Option<String> = None;
+    if is_cancelled(cancel_token.as_deref()) {
+        claude::kill_child_tree(&mut child);
+        let stderr = stderr_handle.join().unwrap_or_default();
+        emit_cancellation_error(&sender, String::new(), stderr, None);
+        return Ok(GeminiAttemptResult::Cancelled);
+    }
 
-    for line_result in BufReader::new(stdout).lines() {
-        if let Some(ref token) = cancel_token {
-            if token.cancelled.load(std::sync::atomic::Ordering::Relaxed) {
+    let mut state = GeminiAttemptState::new(resume_selector);
+    let mut idle_ticks = 0;
+
+    loop {
+        if is_cancelled(cancel_token.as_deref()) {
+            claude::kill_child_tree(&mut child);
+            let stderr = stderr_handle.join().unwrap_or_default();
+            emit_cancellation_error(&sender, state.raw_stdout, stderr, None);
+            return Ok(GeminiAttemptResult::Cancelled);
+        }
+
+        match stdout_events.recv_timeout(GEMINI_STREAM_IDLE_TIMEOUT) {
+            Ok(GeminiStreamEvent::Line(line)) => {
+                idle_ticks = 0;
+                process_gemini_stream_line(&line, &mut state);
+            }
+            Ok(GeminiStreamEvent::ReadError(message)) => {
                 claude::kill_child_tree(&mut child);
-                let _ = child.wait();
-                return Ok(());
-            }
-        }
-
-        let line = match line_result {
-            Ok(line) => line,
-            Err(e) => return Err(format!("Failed reading Gemini output: {}", e)),
-        };
-        if line.trim().is_empty() {
-            continue;
-        }
-        raw_stdout.push_str(&line);
-        raw_stdout.push('\n');
-
-        let Ok(json) = serde_json::from_str::<Value>(line.trim()) else {
-            continue;
-        };
-
-        match json.get("type").and_then(|v| v.as_str()) {
-            Some("init") => {
-                if let Some(session_id) = json.get("session_id").and_then(|v| v.as_str()) {
-                    last_session_id = Some(session_id.to_string());
-                    let _ = sender.send(StreamMessage::Init {
-                        session_id: session_id.to_string(),
-                    });
-                }
-                init_model = json
-                    .get("model")
-                    .and_then(|v| v.as_str())
-                    .map(str::to_string);
-            }
-            Some("message") => {
-                let role = json.get("role").and_then(|v| v.as_str());
-                let content = json.get("content").and_then(|v| v.as_str()).unwrap_or("");
-                if role == Some("assistant") && !content.is_empty() {
-                    final_text.push_str(content);
-                    let _ = sender.send(StreamMessage::Text {
-                        content: content.to_string(),
-                    });
-                }
-            }
-            Some("tool_use") => {
-                if let Some(tool_use) = build_gemini_tool_use_message(&json) {
-                    let _ = sender.send(tool_use);
-                }
-            }
-            Some("tool_result") => {
-                if let Some(tool_result) = build_gemini_tool_result_message(&json) {
-                    let _ = sender.send(tool_result);
-                }
-            }
-            Some("error") => {
-                last_error_message = extract_gemini_error_message(&json);
-            }
-            Some("result") => {
-                let stats = json.get("stats");
-                let model_name = init_model.clone().or_else(|| {
-                    stats
-                        .and_then(|value| value.get("models"))
-                        .and_then(|value| value.as_object())
-                        .and_then(|models| models.keys().next().cloned())
-                });
-                let input_tokens = stats
-                    .and_then(|value| value.get("input_tokens"))
-                    .and_then(|value| value.as_u64())
-                    .or_else(|| {
-                        stats
-                            .and_then(|value| value.get("input"))
-                            .and_then(|value| value.as_u64())
-                    });
-                let output_tokens = stats
-                    .and_then(|value| value.get("output_tokens"))
-                    .and_then(|value| value.as_u64());
-                let duration_ms = stats
-                    .and_then(|value| value.get("duration_ms"))
-                    .and_then(|value| value.as_u64());
-                let _ = sender.send(StreamMessage::StatusUpdate {
-                    model: model_name,
-                    cost_usd: None,
-                    total_cost_usd: None,
-                    duration_ms,
-                    num_turns: None,
-                    input_tokens,
-                    output_tokens,
+                let stderr = stderr_handle.join().unwrap_or_default();
+                return Ok(GeminiAttemptResult::RetrySession {
+                    message,
+                    stdout: state.raw_stdout,
+                    stderr,
+                    exit_code: None,
                 });
             }
-            _ => {}
+            Ok(GeminiStreamEvent::Eof) | Err(RecvTimeoutError::Disconnected) => break,
+            Err(RecvTimeoutError::Timeout) => {
+                if state.terminal_result_seen {
+                    break;
+                }
+                idle_ticks += 1;
+                if idle_ticks >= GEMINI_STREAM_IDLE_TICKS_BEFORE_RETRY {
+                    claude::kill_child_tree(&mut child);
+                    let stderr = stderr_handle.join().unwrap_or_default();
+                    return Ok(GeminiAttemptResult::RetrySession {
+                        message: format!(
+                            "Gemini stream produced no output for {} seconds",
+                            GEMINI_STREAM_IDLE_TIMEOUT.as_secs()
+                                * GEMINI_STREAM_IDLE_TICKS_BEFORE_RETRY as u64
+                        ),
+                        stdout: state.raw_stdout,
+                        stderr,
+                        exit_code: None,
+                    });
+                }
+            }
         }
     }
 
@@ -241,36 +307,265 @@ pub fn execute_command_streaming(
         .map_err(|e| format!("Failed waiting for Gemini: {}", e))?;
     let stderr = stderr_handle.join().unwrap_or_default();
 
-    if !status.success() {
-        let _ = sender.send(StreamMessage::Error {
-            message: last_error_message.clone().unwrap_or_else(|| {
-                derive_error_message(&raw_stdout, &stderr, status.code(), "Gemini")
-            }),
-            stdout: raw_stdout,
-            stderr,
-            exit_code: status.code(),
-        });
-        return Ok(());
+    if is_cancelled(cancel_token.as_deref()) {
+        emit_cancellation_error(&sender, state.raw_stdout, stderr, status.code());
+        return Ok(GeminiAttemptResult::Cancelled);
     }
 
-    let result = final_text.trim().to_string();
-    if result.is_empty() {
-        let _ = sender.send(StreamMessage::Error {
-            message: last_error_message
-                .clone()
-                .unwrap_or_else(|| "Empty response from Gemini".to_string()),
-            stdout: raw_stdout,
+    match finalize_gemini_attempt(&mut state, stderr, status.code()) {
+        GeminiFinalState::Done { result, session_id } => {
+            flush_buffered_stream_messages(&sender, &mut state);
+            let _ = sender.send(StreamMessage::Done { result, session_id });
+            Ok(GeminiAttemptResult::Completed)
+        }
+        GeminiFinalState::Error {
+            message,
+            stdout,
             stderr,
-            exit_code: status.code(),
-        });
-        return Ok(());
+            exit_code,
+        } => {
+            flush_buffered_stream_messages(&sender, &mut state);
+            let _ = sender.send(StreamMessage::Error {
+                message,
+                stdout,
+                stderr,
+                exit_code,
+            });
+            Ok(GeminiAttemptResult::Completed)
+        }
+        GeminiFinalState::RetrySession {
+            message,
+            stdout,
+            stderr,
+            exit_code,
+        } => Ok(GeminiAttemptResult::RetrySession {
+            message,
+            stdout,
+            stderr,
+            exit_code,
+        }),
     }
+}
 
-    let _ = sender.send(StreamMessage::Done {
-        result,
-        session_id: last_session_id,
+fn spawn_gemini_stream_reader<R>(stdout: R) -> mpsc::Receiver<GeminiStreamEvent>
+where
+    R: Read + Send + 'static,
+{
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            match line {
+                Ok(line) => {
+                    if tx.send(GeminiStreamEvent::Line(line)).is_err() {
+                        return;
+                    }
+                }
+                Err(e) => {
+                    let _ = tx.send(GeminiStreamEvent::ReadError(format!(
+                        "Failed reading Gemini output: {}",
+                        e
+                    )));
+                    return;
+                }
+            }
+        }
+        let _ = tx.send(GeminiStreamEvent::Eof);
     });
-    Ok(())
+    rx
+}
+
+fn process_gemini_stream_line(line: &str, state: &mut GeminiAttemptState) {
+    if line.trim().is_empty() {
+        return;
+    }
+    state.raw_stdout.push_str(line);
+    state.raw_stdout.push('\n');
+
+    let Ok(json) = serde_json::from_str::<Value>(line.trim()) else {
+        return;
+    };
+
+    process_gemini_json_event(&json, state);
+}
+
+fn process_gemini_json_event(json: &Value, state: &mut GeminiAttemptState) {
+    match json.get("type").and_then(|v| v.as_str()) {
+        Some("init") => {
+            if let Some(session_id) = json.get("session_id").and_then(|v| v.as_str()) {
+                state.last_resume_selector = observed_session_to_resume_selector(session_id);
+                state.buffered_messages.push(StreamMessage::Init {
+                    session_id: state
+                        .last_resume_selector
+                        .clone()
+                        .unwrap_or_else(|| GEMINI_RESUME_LATEST.to_string()),
+                });
+            }
+            state.init_model = json
+                .get("model")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+        }
+        Some("message") => {
+            let role = json.get("role").and_then(|v| v.as_str());
+            let content = json.get("content").and_then(|v| v.as_str()).unwrap_or("");
+            if role == Some("assistant") && !content.is_empty() {
+                state.final_text.push_str(content);
+                state.buffered_messages.push(StreamMessage::Text {
+                    content: content.to_string(),
+                });
+            }
+        }
+        Some("tool_use") => {
+            if let Some(tool_use) = build_gemini_tool_use_message(json) {
+                state.buffered_messages.push(tool_use);
+            }
+        }
+        Some("tool_result") => {
+            if let Some(tool_result) = build_gemini_tool_result_message(json) {
+                state.buffered_messages.push(tool_result);
+            }
+        }
+        Some("error") => {
+            state.last_error_message = extract_gemini_error_message(json);
+        }
+        Some("result") => {
+            state.terminal_result_seen = true;
+            state.terminal_result_text = json
+                .get("result")
+                .map(render_gemini_value)
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty());
+            let stats = json.get("stats");
+            let model_name = state.init_model.clone().or_else(|| {
+                stats
+                    .and_then(|value| value.get("models"))
+                    .and_then(|value| value.as_object())
+                    .and_then(|models| models.keys().next().cloned())
+            });
+            let input_tokens = stats
+                .and_then(|value| value.get("input_tokens"))
+                .and_then(|value| value.as_u64())
+                .or_else(|| {
+                    stats
+                        .and_then(|value| value.get("input"))
+                        .and_then(|value| value.as_u64())
+                });
+            let output_tokens = stats
+                .and_then(|value| value.get("output_tokens"))
+                .and_then(|value| value.as_u64());
+            let duration_ms = stats
+                .and_then(|value| value.get("duration_ms"))
+                .and_then(|value| value.as_u64());
+            state.buffered_messages.push(StreamMessage::StatusUpdate {
+                model: model_name,
+                cost_usd: None,
+                total_cost_usd: None,
+                duration_ms,
+                num_turns: None,
+                input_tokens,
+                output_tokens,
+            });
+        }
+        _ => {}
+    }
+}
+
+fn finalize_gemini_attempt(
+    state: &mut GeminiAttemptState,
+    stderr: String,
+    exit_code: Option<i32>,
+) -> GeminiFinalState {
+    let final_text = std::mem::take(&mut state.final_text);
+    let raw_stdout = std::mem::take(&mut state.raw_stdout);
+    let last_resume_selector = state.last_resume_selector.take();
+    let last_error_message = state.last_error_message.take();
+    let terminal_result_seen = state.terminal_result_seen;
+    let terminal_result_text = state.terminal_result_text.take();
+
+    if terminal_result_seen {
+        let result = final_text.trim().to_string();
+        let result = if result.is_empty() {
+            terminal_result_text.unwrap_or_default()
+        } else {
+            result
+        };
+        if result.is_empty() {
+            return GeminiFinalState::Error {
+                message: "Gemini emitted a terminal result without any response text".to_string(),
+                stdout: raw_stdout,
+                stderr,
+                exit_code,
+            };
+        }
+        return GeminiFinalState::Done {
+            result,
+            session_id: last_resume_selector,
+        };
+    }
+
+    if let Some(message) = last_error_message {
+        return GeminiFinalState::Error {
+            message,
+            stdout: raw_stdout,
+            stderr,
+            exit_code,
+        };
+    }
+
+    if exit_code.unwrap_or(0) != 0 {
+        return GeminiFinalState::RetrySession {
+            message: derive_error_message(&raw_stdout, &stderr, exit_code, "Gemini"),
+            stdout: raw_stdout,
+            stderr,
+            exit_code,
+        };
+    }
+
+    if !stderr.trim().is_empty() {
+        return GeminiFinalState::Error {
+            message: derive_error_message(&raw_stdout, &stderr, exit_code, "Gemini"),
+            stdout: raw_stdout,
+            stderr,
+            exit_code,
+        };
+    }
+
+    GeminiFinalState::RetrySession {
+        message: GEMINI_SESSION_DEAD_MESSAGE.to_string(),
+        stdout: raw_stdout,
+        stderr,
+        exit_code,
+    }
+}
+
+fn flush_buffered_stream_messages(sender: &Sender<StreamMessage>, state: &mut GeminiAttemptState) {
+    for message in state.buffered_messages.drain(..) {
+        let _ = sender.send(message);
+    }
+}
+
+fn emit_cancellation_error(
+    sender: &Sender<StreamMessage>,
+    stdout: String,
+    stderr: String,
+    exit_code: Option<i32>,
+) {
+    let _ = sender.send(StreamMessage::Error {
+        message: GEMINI_CANCELLED_MESSAGE.to_string(),
+        stdout,
+        stderr,
+        exit_code,
+    });
+}
+
+fn is_cancelled(token: Option<&CancelToken>) -> bool {
+    token
+        .map(|token| token.cancelled.load(std::sync::atomic::Ordering::Relaxed))
+        .unwrap_or(false)
+}
+
+fn remote_profile_not_supported_message() -> String {
+    "NotSupported: Gemini provider does not support remote execution yet. Remove `remote_profile` or use a provider with remote support.".to_string()
 }
 
 fn compose_gemini_prompt(
@@ -307,14 +602,16 @@ fn compose_gemini_prompt(
 
 fn build_exec_args(prompt: &str, model: Option<&str>, session_id: Option<&str>) -> Vec<String> {
     let mut args = Vec::new();
-    let model = model
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or(DEFAULT_GEMINI_MODEL);
-
-    args.push("-m".to_string());
-    args.push(model.to_string());
-    if let Some(session_id) = session_id.map(str::trim).filter(|value| !value.is_empty()) {
+    let session_id = session_id.map(str::trim).filter(|value| !value.is_empty());
+    if session_id.is_none() {
+        let model = model
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(DEFAULT_GEMINI_MODEL);
+        args.push("-m".to_string());
+        args.push(model.to_string());
+    }
+    if let Some(session_id) = session_id {
         args.push("--resume".to_string());
         args.push(session_id.to_string());
     }
@@ -326,6 +623,49 @@ fn build_exec_args(prompt: &str, model: Option<&str>, session_id: Option<&str>) 
     args.push("--sandbox".to_string());
     args.push("false".to_string());
     args
+}
+
+fn normalize_resume_selector(session_id: Option<&str>) -> Result<Option<String>, String> {
+    let Some(session_id) = session_id.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+
+    if session_id.eq_ignore_ascii_case(GEMINI_RESUME_LATEST) {
+        return Ok(Some(GEMINI_RESUME_LATEST.to_string()));
+    }
+
+    if session_id.chars().all(|ch| ch.is_ascii_digit()) {
+        return Ok(Some(session_id.to_string()));
+    }
+
+    if looks_like_uuid(session_id) {
+        // Gemini 0.35.3 exposes UUID-like session metadata in `init`, but `--resume`
+        // accepts `latest` or a numeric index. Normalize persisted legacy values.
+        return Ok(Some(GEMINI_RESUME_LATEST.to_string()));
+    }
+
+    Err(
+        "InvalidArgument: Gemini resume selector must be `latest` or a numeric session index"
+            .to_string(),
+    )
+}
+
+fn observed_session_to_resume_selector(_session_id: &str) -> Option<String> {
+    Some(GEMINI_RESUME_LATEST.to_string())
+}
+
+fn looks_like_uuid(value: &str) -> bool {
+    let mut parts = value.split('-');
+    let expected = [8, 4, 4, 4, 12];
+    for len in expected {
+        let Some(part) = parts.next() else {
+            return false;
+        };
+        if part.len() != len || !part.chars().all(|ch| ch.is_ascii_hexdigit()) {
+            return false;
+        }
+    }
+    parts.next().is_none()
 }
 
 fn extract_text_from_stream_output(output: &str) -> String {
@@ -438,17 +778,85 @@ fn render_gemini_value(value: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_exec_args, build_gemini_tool_result_message, build_gemini_tool_use_message,
-        extract_gemini_error_message,
+        GEMINI_CANCELLED_MESSAGE, GEMINI_SESSION_DEAD_MESSAGE, GeminiAttemptState,
+        GeminiFinalState, build_exec_args, build_gemini_tool_result_message,
+        build_gemini_tool_use_message, emit_cancellation_error, execute_command_streaming,
+        extract_gemini_error_message, extract_text_from_stream_output, finalize_gemini_attempt,
+        flush_buffered_stream_messages, looks_like_uuid, normalize_resume_selector,
+        observed_session_to_resume_selector, process_gemini_stream_line,
+        remote_profile_not_supported_message,
     };
     use crate::services::claude::StreamMessage;
+    use crate::services::remote::{RemoteAuth, RemoteProfile};
     use serde_json::json;
+    use std::sync::mpsc;
 
     #[test]
     fn build_exec_args_includes_resume_when_session_present() {
         let args = build_exec_args("hello", Some("gemini-2.5-flash"), Some("latest"));
         assert!(args.windows(2).any(|pair| pair == ["--resume", "latest"]));
         assert!(args.windows(2).any(|pair| pair == ["-p", "hello"]));
+        assert!(
+            !args
+                .windows(2)
+                .any(|pair| pair == ["-m", "gemini-2.5-flash"])
+        );
+    }
+
+    #[test]
+    fn build_exec_args_includes_model_for_fresh_session() {
+        let args = build_exec_args("hello", Some("gemini-2.5-flash"), None);
+        assert!(
+            args.windows(2)
+                .any(|pair| pair == ["-m", "gemini-2.5-flash"])
+        );
+        assert!(!args.iter().any(|arg| arg == "--resume"));
+    }
+
+    #[test]
+    fn normalize_resume_selector_accepts_latest_and_numeric_index() {
+        assert_eq!(
+            normalize_resume_selector(Some("latest"))
+                .unwrap()
+                .as_deref(),
+            Some("latest")
+        );
+        assert_eq!(
+            normalize_resume_selector(Some("12")).unwrap().as_deref(),
+            Some("12")
+        );
+    }
+
+    #[test]
+    fn normalize_resume_selector_maps_uuid_like_metadata_to_latest() {
+        let observed = "aa678e6b-c6d3-4dd2-9197-58580c00cc6c";
+        assert!(looks_like_uuid(observed));
+        assert_eq!(
+            normalize_resume_selector(Some(observed))
+                .unwrap()
+                .as_deref(),
+            Some("latest")
+        );
+        assert_eq!(
+            observed_session_to_resume_selector(observed).as_deref(),
+            Some("latest")
+        );
+    }
+
+    #[test]
+    fn normalize_resume_selector_rejects_arbitrary_strings() {
+        let error = normalize_resume_selector(Some("session-alpha")).unwrap_err();
+        assert!(error.contains("InvalidArgument"));
+    }
+
+    #[test]
+    fn extract_text_from_stream_output_ignores_plaintext_retry_logs() {
+        let output = concat!(
+            "Attempt 1 failed with status 429. Retrying with backoff...\n",
+            "{\"type\":\"init\",\"session_id\":\"aa678e6b-c6d3-4dd2-9197-58580c00cc6c\"}\n",
+            "{\"type\":\"message\",\"role\":\"assistant\",\"content\":\"OK\"}\n"
+        );
+        assert_eq!(extract_text_from_stream_output(output), "OK");
     }
 
     #[test]
@@ -499,5 +907,152 @@ mod tests {
             extract_gemini_error_message(&event).as_deref(),
             Some("quota exceeded")
         );
+    }
+
+    #[test]
+    fn parser_schema_drift_is_ignored_without_panicking() {
+        let (_tx, rx): (mpsc::Sender<StreamMessage>, mpsc::Receiver<StreamMessage>) =
+            mpsc::channel();
+        let mut state = GeminiAttemptState::new(None);
+        process_gemini_stream_line(
+            r#"{"type":"message","role":42,"content":["bad-shape"]}"#,
+            &mut state,
+        );
+
+        assert!(state.final_text.is_empty());
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn parser_empty_payload_is_ignored() {
+        let (_tx, rx): (mpsc::Sender<StreamMessage>, mpsc::Receiver<StreamMessage>) =
+            mpsc::channel();
+        let mut state = GeminiAttemptState::new(None);
+        process_gemini_stream_line("{}", &mut state);
+
+        assert!(!state.terminal_result_seen);
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn attempt_messages_are_buffered_until_flush() {
+        let (tx, rx) = mpsc::channel();
+        let mut state = GeminiAttemptState::new(None);
+        process_gemini_stream_line(
+            r#"{"type":"init","session_id":"aa678e6b-c6d3-4dd2-9197-58580c00cc6c","model":"gemini-2.5-flash"}"#,
+            &mut state,
+        );
+        process_gemini_stream_line(
+            r#"{"type":"message","role":"assistant","content":"hello"}"#,
+            &mut state,
+        );
+
+        assert!(rx.try_recv().is_err());
+        flush_buffered_stream_messages(&tx, &mut state);
+
+        match rx.recv().unwrap() {
+            StreamMessage::Init { session_id } => assert_eq!(session_id, "latest"),
+            other => panic!("expected Init, got {:?}", other),
+        }
+        match rx.recv().unwrap() {
+            StreamMessage::Text { content } => assert_eq!(content, "hello"),
+            other => panic!("expected Text, got {:?}", other),
+        }
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn terminal_result_is_authoritative_even_if_error_seen() {
+        let mut state = GeminiAttemptState::new(Some("latest".to_string()));
+        state.last_error_message = Some("quota exceeded".to_string());
+        state.final_text = "done".to_string();
+        state.terminal_result_seen = true;
+
+        match finalize_gemini_attempt(&mut state, String::new(), Some(0)) {
+            GeminiFinalState::Done { result, session_id } => {
+                assert_eq!(result, "done");
+                assert_eq!(session_id.as_deref(), Some("latest"));
+            }
+            other => panic!("expected Done, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn assistant_text_without_terminal_result_requests_retry() {
+        let mut state = GeminiAttemptState::new(None);
+        state.final_text = "partial text".to_string();
+        state.raw_stdout =
+            "{\"type\":\"message\",\"role\":\"assistant\",\"content\":\"partial text\"}\n"
+                .to_string();
+
+        match finalize_gemini_attempt(&mut state, String::new(), Some(0)) {
+            GeminiFinalState::RetrySession { message, .. } => {
+                assert_eq!(message, GEMINI_SESSION_DEAD_MESSAGE);
+            }
+            other => panic!("expected RetrySession, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cancellation_emits_single_error_message() {
+        let (tx, rx) = mpsc::channel();
+        emit_cancellation_error(&tx, "out".to_string(), "err".to_string(), Some(130));
+
+        match rx.recv().unwrap() {
+            StreamMessage::Error {
+                message,
+                stdout,
+                stderr,
+                exit_code,
+            } => {
+                assert_eq!(message, GEMINI_CANCELLED_MESSAGE);
+                assert_eq!(stdout, "out");
+                assert_eq!(stderr, "err");
+                assert_eq!(exit_code, Some(130));
+            }
+            other => panic!("expected Error, got {:?}", other),
+        }
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn remote_profile_not_supported_message_has_guidance() {
+        let message = remote_profile_not_supported_message();
+        assert!(message.contains("NotSupported"));
+        assert!(message.contains("remote_profile"));
+    }
+
+    #[test]
+    fn execute_command_streaming_rejects_remote_profile_before_spawn() {
+        let (tx, _rx) = mpsc::channel();
+        let remote_profile = RemoteProfile {
+            name: "test".to_string(),
+            host: "example.com".to_string(),
+            port: 22,
+            user: "kunkun".to_string(),
+            auth: RemoteAuth::Password {
+                password: "secret".to_string(),
+            },
+            default_path: "/tmp".to_string(),
+            claude_path: None,
+        };
+
+        let error = execute_command_streaming(
+            "hello",
+            None,
+            ".",
+            tx,
+            None,
+            None,
+            None,
+            Some(&remote_profile),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap_err();
+
+        assert!(error.contains("NotSupported"));
     }
 }

--- a/src/services/gemini.rs
+++ b/src/services/gemini.rs
@@ -20,8 +20,8 @@ const GEMINI_RESUME_LATEST: &str = "latest";
 const GEMINI_SESSION_DEAD_MESSAGE: &str = "Gemini stream ended without a terminal result";
 const GEMINI_INVALID_RESUME_SELECTOR_MESSAGE: &str =
     "InvalidArgument: Gemini resume selector must be `latest` or a numeric session index";
-const GEMINI_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
-const GEMINI_STREAM_IDLE_TICKS_BEFORE_RETRY: u32 = 2;
+const GEMINI_STREAM_POLL_TIMEOUT: Duration = Duration::from_secs(5);
+const GEMINI_STREAM_IDLE_WATCHDOG: Duration = Duration::from_secs(120);
 const GEMINI_MAX_SESSION_RETRIES: usize = 1;
 
 #[derive(Debug)]
@@ -229,7 +229,8 @@ fn execute_gemini_streaming_attempt(
         &stdout_events,
         cancel_token.as_deref(),
         &mut state,
-        GEMINI_STREAM_IDLE_TIMEOUT,
+        GEMINI_STREAM_POLL_TIMEOUT,
+        GEMINI_STREAM_IDLE_WATCHDOG,
     ) {
         GeminiStreamLoopResult::Cancelled => {
             claude::kill_child_tree(&mut child);
@@ -294,18 +295,19 @@ fn collect_gemini_stream_events(
     stdout_events: &mpsc::Receiver<GeminiStreamEvent>,
     cancel_token: Option<&CancelToken>,
     state: &mut GeminiAttemptState,
-    idle_timeout: Duration,
+    poll_timeout: Duration,
+    idle_watchdog: Duration,
 ) -> GeminiStreamLoopResult {
-    let mut idle_ticks = 0;
+    let mut silent_for = Duration::ZERO;
 
     loop {
         if is_cancelled(cancel_token) {
             return GeminiStreamLoopResult::Cancelled;
         }
 
-        match stdout_events.recv_timeout(idle_timeout) {
+        match stdout_events.recv_timeout(poll_timeout) {
             Ok(GeminiStreamEvent::Line(line)) => {
-                idle_ticks = 0;
+                silent_for = Duration::ZERO;
                 process_gemini_stream_line(&line, state);
             }
             Ok(GeminiStreamEvent::ReadError(message)) => {
@@ -321,12 +323,15 @@ fn collect_gemini_stream_events(
                 if state.terminal_result_seen {
                     return GeminiStreamLoopResult::Eof;
                 }
-                idle_ticks += 1;
-                if idle_ticks >= GEMINI_STREAM_IDLE_TICKS_BEFORE_RETRY {
+                if state.raw_stdout.is_empty() {
+                    continue;
+                }
+                silent_for += poll_timeout;
+                if silent_for >= idle_watchdog {
                     return GeminiStreamLoopResult::RetrySession {
                         message: format!(
                             "Gemini stream produced no output for {} seconds",
-                            idle_timeout.as_secs() * GEMINI_STREAM_IDLE_TICKS_BEFORE_RETRY as u64
+                            idle_watchdog.as_secs()
                         ),
                     };
                 }
@@ -605,11 +610,15 @@ fn observed_session_to_resume_selector(session_id: &str) -> Option<String> {
         return None;
     }
 
-    if session_id.eq_ignore_ascii_case(GEMINI_RESUME_LATEST)
-        || session_id.chars().all(|ch| ch.is_ascii_digit())
-        || looks_like_uuid(session_id)
-        || is_common_session_metadata(session_id)
-    {
+    if session_id.eq_ignore_ascii_case(GEMINI_RESUME_LATEST) {
+        return Some(GEMINI_RESUME_LATEST.to_string());
+    }
+
+    if session_id.chars().all(|ch| ch.is_ascii_digit()) {
+        return Some(session_id.to_string());
+    }
+
+    if looks_like_uuid(session_id) || is_common_session_metadata(session_id) {
         return Some(GEMINI_RESUME_LATEST.to_string());
     }
 
@@ -816,6 +825,14 @@ mod tests {
         assert_eq!(
             observed_session_to_resume_selector(observed).as_deref(),
             Some("latest")
+        );
+    }
+
+    #[test]
+    fn observed_session_to_resume_selector_preserves_numeric_selector() {
+        assert_eq!(
+            observed_session_to_resume_selector("12").as_deref(),
+            Some("12")
         );
     }
 
@@ -1178,9 +1195,59 @@ mod tests {
             Some(token.as_ref()),
             &mut state,
             Duration::from_millis(5),
+            Duration::from_millis(10),
         );
 
         assert_eq!(result, GeminiStreamLoopResult::Cancelled);
+        assert_eq!(state.final_text, "partial");
+    }
+
+    #[test]
+    fn idle_watchdog_does_not_retry_before_first_stream_progress() {
+        let token = Arc::new(CancelToken::new());
+        let (_tx, rx) = mpsc::channel();
+        let mut state = GeminiAttemptState::new(None);
+        let token_for_thread = token.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(4));
+            token_for_thread.cancelled.store(true, Ordering::Relaxed);
+        });
+
+        let result = collect_gemini_stream_events(
+            &rx,
+            Some(token.as_ref()),
+            &mut state,
+            Duration::from_millis(1),
+            Duration::from_millis(2),
+        );
+
+        assert_eq!(result, GeminiStreamLoopResult::Cancelled);
+        assert!(state.raw_stdout.is_empty());
+    }
+
+    #[test]
+    fn idle_watchdog_retries_after_extended_silence_following_progress() {
+        let (tx, rx) = mpsc::channel();
+        let mut state = GeminiAttemptState::new(None);
+        tx.send(GeminiStreamEvent::Line(
+            r#"{"type":"message","role":"assistant","content":"partial"}"#.to_string(),
+        ))
+        .unwrap();
+
+        let result = collect_gemini_stream_events(
+            &rx,
+            None,
+            &mut state,
+            Duration::from_millis(1),
+            Duration::from_millis(3),
+        );
+
+        match result {
+            GeminiStreamLoopResult::RetrySession { message } => {
+                assert!(message.contains("Gemini stream produced no output"));
+            }
+            other => panic!("expected RetrySession, got {:?}", other),
+        }
         assert_eq!(state.final_text, "partial");
     }
 

--- a/src/services/gemini.rs
+++ b/src/services/gemini.rs
@@ -14,7 +14,6 @@ use crate::services::remote::RemoteProfile;
 static GEMINI_PATH: OnceLock<Option<String>> = OnceLock::new();
 pub const DEFAULT_GEMINI_MODEL: &str = "gemini-2.5-flash";
 const GEMINI_RESUME_LATEST: &str = "latest";
-const GEMINI_CANCELLED_MESSAGE: &str = "Gemini request cancelled";
 const GEMINI_SESSION_DEAD_MESSAGE: &str = "Gemini stream ended without a terminal result";
 const GEMINI_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
 const GEMINI_STREAM_IDLE_TICKS_BEFORE_RETRY: u32 = 2;
@@ -247,8 +246,8 @@ fn execute_gemini_streaming_attempt(
 
     if is_cancelled(cancel_token.as_deref()) {
         claude::kill_child_tree(&mut child);
-        let stderr = stderr_handle.join().unwrap_or_default();
-        emit_cancellation_error(&sender, String::new(), stderr, None);
+        let _ = child.wait();
+        let _ = stderr_handle.join();
         return Ok(GeminiAttemptResult::Cancelled);
     }
 
@@ -258,8 +257,8 @@ fn execute_gemini_streaming_attempt(
     loop {
         if is_cancelled(cancel_token.as_deref()) {
             claude::kill_child_tree(&mut child);
-            let stderr = stderr_handle.join().unwrap_or_default();
-            emit_cancellation_error(&sender, state.raw_stdout, stderr, None);
+            let _ = child.wait();
+            let _ = stderr_handle.join();
             return Ok(GeminiAttemptResult::Cancelled);
         }
 
@@ -308,7 +307,6 @@ fn execute_gemini_streaming_attempt(
     let stderr = stderr_handle.join().unwrap_or_default();
 
     if is_cancelled(cancel_token.as_deref()) {
-        emit_cancellation_error(&sender, state.raw_stdout, stderr, status.code());
         return Ok(GeminiAttemptResult::Cancelled);
     }
 
@@ -513,7 +511,7 @@ fn finalize_gemini_attempt(
     }
 
     if exit_code.unwrap_or(0) != 0 {
-        return GeminiFinalState::RetrySession {
+        return GeminiFinalState::Error {
             message: derive_error_message(&raw_stdout, &stderr, exit_code, "Gemini"),
             stdout: raw_stdout,
             stderr,
@@ -542,20 +540,6 @@ fn flush_buffered_stream_messages(sender: &Sender<StreamMessage>, state: &mut Ge
     for message in state.buffered_messages.drain(..) {
         let _ = sender.send(message);
     }
-}
-
-fn emit_cancellation_error(
-    sender: &Sender<StreamMessage>,
-    stdout: String,
-    stderr: String,
-    exit_code: Option<i32>,
-) {
-    let _ = sender.send(StreamMessage::Error {
-        message: GEMINI_CANCELLED_MESSAGE.to_string(),
-        stdout,
-        stderr,
-        exit_code,
-    });
 }
 
 fn is_cancelled(token: Option<&CancelToken>) -> bool {
@@ -778,9 +762,8 @@ fn render_gemini_value(value: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        GEMINI_CANCELLED_MESSAGE, GEMINI_SESSION_DEAD_MESSAGE, GeminiAttemptState,
-        GeminiFinalState, build_exec_args, build_gemini_tool_result_message,
-        build_gemini_tool_use_message, emit_cancellation_error, execute_command_streaming,
+        GEMINI_SESSION_DEAD_MESSAGE, GeminiAttemptState, GeminiFinalState, build_exec_args,
+        build_gemini_tool_result_message, build_gemini_tool_use_message, execute_command_streaming,
         extract_gemini_error_message, extract_text_from_stream_output, finalize_gemini_attempt,
         flush_buffered_stream_messages, looks_like_uuid, normalize_resume_selector,
         observed_session_to_resume_selector, process_gemini_stream_line,
@@ -994,25 +977,24 @@ mod tests {
     }
 
     #[test]
-    fn cancellation_emits_single_error_message() {
-        let (tx, rx) = mpsc::channel();
-        emit_cancellation_error(&tx, "out".to_string(), "err".to_string(), Some(130));
+    fn non_zero_exit_without_structured_error_is_terminal_error() {
+        let mut state = GeminiAttemptState::new(Some("latest".to_string()));
+        state.raw_stdout = "plain stdout".to_string();
 
-        match rx.recv().unwrap() {
-            StreamMessage::Error {
+        match finalize_gemini_attempt(&mut state, "plain stderr".to_string(), Some(2)) {
+            GeminiFinalState::Error {
                 message,
                 stdout,
                 stderr,
                 exit_code,
             } => {
-                assert_eq!(message, GEMINI_CANCELLED_MESSAGE);
-                assert_eq!(stdout, "out");
-                assert_eq!(stderr, "err");
-                assert_eq!(exit_code, Some(130));
+                assert!(message.contains("plain stderr"));
+                assert_eq!(stdout, "plain stdout");
+                assert_eq!(stderr, "plain stderr");
+                assert_eq!(exit_code, Some(2));
             }
             other => panic!("expected Error, got {:?}", other),
         }
-        assert!(rx.try_recv().is_err());
     }
 
     #[test]

--- a/src/services/gemini.rs
+++ b/src/services/gemini.rs
@@ -8,7 +8,10 @@ use std::sync::mpsc::{self, RecvTimeoutError, Sender};
 use std::time::Duration;
 
 use crate::services::claude::{self, StreamMessage};
-use crate::services::provider::{CancelToken, ProviderKind, cancel_requested, register_child_pid};
+use crate::services::provider::{
+    CancelToken, ProviderKind, StreamAttemptFailure, StreamAttemptResult, StreamFinalState,
+    cancel_requested, register_child_pid, run_retrying_stream_attempts,
+};
 use crate::services::remote::RemoteProfile;
 
 static GEMINI_PATH: OnceLock<Option<String>> = OnceLock::new();
@@ -33,38 +36,6 @@ enum GeminiStreamLoopResult {
     Eof,
     RetrySession { message: String },
     Cancelled,
-}
-
-#[derive(Debug)]
-enum GeminiAttemptResult {
-    Completed,
-    RetrySession {
-        message: String,
-        stdout: String,
-        stderr: String,
-        exit_code: Option<i32>,
-    },
-    Cancelled,
-}
-
-#[derive(Debug)]
-enum GeminiFinalState {
-    Done {
-        result: String,
-        session_id: Option<String>,
-    },
-    Error {
-        message: String,
-        stdout: String,
-        stderr: String,
-        exit_code: Option<i32>,
-    },
-    RetrySession {
-        message: String,
-        stdout: String,
-        stderr: String,
-        exit_code: Option<i32>,
-    },
 }
 
 #[derive(Debug, Default)]
@@ -193,40 +164,19 @@ pub fn execute_command_streaming(
 
 fn run_gemini_streaming_attempts<F>(
     sender: &Sender<StreamMessage>,
-    mut resume_selector: Option<String>,
-    mut execute_attempt: F,
+    resume_selector: Option<String>,
+    execute_attempt: F,
 ) -> Result<(), String>
 where
-    F: FnMut(Option<String>) -> Result<GeminiAttemptResult, String>,
+    F: FnMut(Option<String>) -> Result<StreamAttemptResult, String>,
 {
-    for attempt in 0..=GEMINI_MAX_SESSION_RETRIES {
-        match execute_attempt(resume_selector.clone())? {
-            GeminiAttemptResult::Completed | GeminiAttemptResult::Cancelled => return Ok(()),
-            GeminiAttemptResult::RetrySession {
-                message,
-                stdout,
-                stderr,
-                exit_code,
-            } => {
-                if attempt < GEMINI_MAX_SESSION_RETRIES {
-                    resume_selector = None;
-                    continue;
-                }
-                let _ = sender.send(StreamMessage::Error {
-                    message: format!(
-                        "Gemini session could not be recovered after retry: {}",
-                        message
-                    ),
-                    stdout,
-                    stderr,
-                    exit_code,
-                });
-                return Ok(());
-            }
-        }
-    }
-
-    Ok(())
+    run_retrying_stream_attempts(
+        "Gemini",
+        resume_selector,
+        GEMINI_MAX_SESSION_RETRIES,
+        execute_attempt,
+        |failure| send_gemini_stream_failure(sender, failure),
+    )
 }
 
 fn execute_gemini_streaming_attempt(
@@ -237,7 +187,7 @@ fn execute_gemini_streaming_attempt(
     working_dir: &str,
     sender: Sender<StreamMessage>,
     cancel_token: Option<Arc<CancelToken>>,
-) -> Result<GeminiAttemptResult, String> {
+) -> Result<StreamAttemptResult, String> {
     let mut command = Command::new(gemini_bin);
     crate::services::platform::apply_runtime_path(&mut command);
     let mut child = command
@@ -271,7 +221,7 @@ fn execute_gemini_streaming_attempt(
         claude::kill_child_tree(&mut child);
         let _ = child.wait();
         let _ = stderr_handle.join();
-        return Ok(GeminiAttemptResult::Cancelled);
+        return Ok(StreamAttemptResult::Cancelled);
     }
 
     let mut state = GeminiAttemptState::new(resume_selector);
@@ -285,18 +235,18 @@ fn execute_gemini_streaming_attempt(
             claude::kill_child_tree(&mut child);
             let _ = child.wait();
             let _ = stderr_handle.join();
-            return Ok(GeminiAttemptResult::Cancelled);
+            return Ok(StreamAttemptResult::Cancelled);
         }
         GeminiStreamLoopResult::RetrySession { message } => {
             claude::kill_child_tree(&mut child);
             let _ = child.wait();
             let stderr = stderr_handle.join().unwrap_or_default();
-            return Ok(GeminiAttemptResult::RetrySession {
+            return Ok(StreamAttemptResult::RetrySession(StreamAttemptFailure {
                 message,
                 stdout: state.raw_stdout,
                 stderr,
                 exit_code: None,
-            });
+            }));
         }
         GeminiStreamLoopResult::Eof => {}
     }
@@ -307,42 +257,37 @@ fn execute_gemini_streaming_attempt(
     let stderr = stderr_handle.join().unwrap_or_default();
 
     if is_cancelled(cancel_token.as_deref()) {
-        return Ok(GeminiAttemptResult::Cancelled);
+        return Ok(StreamAttemptResult::Cancelled);
     }
 
     match finalize_gemini_attempt(&mut state, stderr, status.code()) {
-        GeminiFinalState::Done { result, session_id } => {
+        StreamFinalState::Done { result, session_id } => {
             flush_buffered_stream_messages(&sender, &mut state);
             let _ = sender.send(StreamMessage::Done { result, session_id });
-            Ok(GeminiAttemptResult::Completed)
+            Ok(StreamAttemptResult::Completed)
         }
-        GeminiFinalState::Error {
-            message,
-            stdout,
-            stderr,
-            exit_code,
-        } => {
+        StreamFinalState::Error(failure) => {
             flush_buffered_stream_messages(&sender, &mut state);
-            let _ = sender.send(StreamMessage::Error {
-                message,
-                stdout,
-                stderr,
-                exit_code,
-            });
-            Ok(GeminiAttemptResult::Completed)
+            send_gemini_stream_failure(&sender, failure);
+            Ok(StreamAttemptResult::Completed)
         }
-        GeminiFinalState::RetrySession {
-            message,
-            stdout,
-            stderr,
-            exit_code,
-        } => Ok(GeminiAttemptResult::RetrySession {
-            message,
-            stdout,
-            stderr,
-            exit_code,
-        }),
+        StreamFinalState::RetrySession(failure) => Ok(StreamAttemptResult::RetrySession(failure)),
     }
+}
+
+fn send_gemini_stream_failure(sender: &Sender<StreamMessage>, failure: StreamAttemptFailure) {
+    let StreamAttemptFailure {
+        message,
+        stdout,
+        stderr,
+        exit_code,
+    } = failure;
+    let _ = sender.send(StreamMessage::Error {
+        message,
+        stdout,
+        stderr,
+        exit_code,
+    });
 }
 
 fn collect_gemini_stream_events(
@@ -517,7 +462,7 @@ fn finalize_gemini_attempt(
     state: &mut GeminiAttemptState,
     stderr: String,
     exit_code: Option<i32>,
-) -> GeminiFinalState {
+) -> StreamFinalState {
     let final_text = std::mem::take(&mut state.final_text);
     let raw_stdout = std::mem::take(&mut state.raw_stdout);
     let last_resume_selector = state.last_resume_selector.take();
@@ -533,52 +478,52 @@ fn finalize_gemini_attempt(
             result
         };
         if result.is_empty() {
-            return GeminiFinalState::Error {
+            return StreamFinalState::Error(StreamAttemptFailure {
                 message: "Gemini emitted a terminal result without any response text".to_string(),
                 stdout: raw_stdout,
                 stderr,
                 exit_code,
-            };
+            });
         }
-        return GeminiFinalState::Done {
+        return StreamFinalState::Done {
             result,
             session_id: last_resume_selector,
         };
     }
 
     if let Some(message) = last_error_message {
-        return GeminiFinalState::Error {
+        return StreamFinalState::Error(StreamAttemptFailure {
             message,
             stdout: raw_stdout,
             stderr,
             exit_code,
-        };
+        });
     }
 
     if exit_code.unwrap_or(0) != 0 {
-        return GeminiFinalState::Error {
+        return StreamFinalState::Error(StreamAttemptFailure {
             message: derive_error_message(&raw_stdout, &stderr, exit_code, "Gemini"),
             stdout: raw_stdout,
             stderr,
             exit_code,
-        };
+        });
     }
 
     if !stderr.trim().is_empty() {
-        return GeminiFinalState::Error {
+        return StreamFinalState::Error(StreamAttemptFailure {
             message: derive_error_message(&raw_stdout, &stderr, exit_code, "Gemini"),
             stdout: raw_stdout,
             stderr,
             exit_code,
-        };
+        });
     }
 
-    GeminiFinalState::RetrySession {
+    StreamFinalState::RetrySession(StreamAttemptFailure {
         message: GEMINI_SESSION_DEAD_MESSAGE.to_string(),
         stdout: raw_stdout,
         stderr,
         exit_code,
-    }
+    })
 }
 
 fn flush_buffered_stream_messages(sender: &Sender<StreamMessage>, state: &mut GeminiAttemptState) {
@@ -802,9 +747,9 @@ fn render_gemini_value(value: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        GEMINI_INVALID_RESUME_SELECTOR_MESSAGE, GEMINI_SESSION_DEAD_MESSAGE, GeminiAttemptResult,
-        GeminiAttemptState, GeminiFinalState, GeminiStreamEvent, GeminiStreamLoopResult,
-        build_exec_args, build_gemini_tool_result_message, build_gemini_tool_use_message,
+        GEMINI_INVALID_RESUME_SELECTOR_MESSAGE, GEMINI_SESSION_DEAD_MESSAGE, GeminiAttemptState,
+        GeminiStreamEvent, GeminiStreamLoopResult, build_exec_args,
+        build_gemini_tool_result_message, build_gemini_tool_use_message,
         collect_gemini_stream_events, execute_command_streaming, extract_gemini_error_message,
         extract_text_from_stream_output, finalize_gemini_attempt, flush_buffered_stream_messages,
         looks_like_uuid, normalize_resume_selector, observed_session_to_resume_selector,
@@ -812,7 +757,9 @@ mod tests {
         run_gemini_streaming_attempts,
     };
     use crate::services::claude::StreamMessage;
-    use crate::services::provider::CancelToken;
+    use crate::services::provider::{
+        CancelToken, StreamAttemptFailure, StreamAttemptResult, StreamFinalState,
+    };
     use crate::services::remote::{RemoteAuth, RemoteProfile};
     use serde_json::json;
     use std::sync::Arc;
@@ -1058,7 +1005,7 @@ mod tests {
         let final_state = finalize_gemini_attempt(&mut state, String::new(), Some(0));
         flush_buffered_stream_messages(&tx, &mut state);
         match final_state {
-            GeminiFinalState::Done { result, session_id } => {
+            StreamFinalState::Done { result, session_id } => {
                 let _ = tx.send(StreamMessage::Done { result, session_id });
             }
             other => panic!("expected Done, got {:?}", other),
@@ -1116,7 +1063,7 @@ mod tests {
         state.terminal_result_seen = true;
 
         match finalize_gemini_attempt(&mut state, String::new(), Some(0)) {
-            GeminiFinalState::Done { result, session_id } => {
+            StreamFinalState::Done { result, session_id } => {
                 assert_eq!(result, "done");
                 assert_eq!(session_id.as_deref(), Some("latest"));
             }
@@ -1133,8 +1080,8 @@ mod tests {
                 .to_string();
 
         match finalize_gemini_attempt(&mut state, String::new(), Some(0)) {
-            GeminiFinalState::RetrySession { message, .. } => {
-                assert_eq!(message, GEMINI_SESSION_DEAD_MESSAGE);
+            StreamFinalState::RetrySession(failure) => {
+                assert_eq!(failure.message, GEMINI_SESSION_DEAD_MESSAGE);
             }
             other => panic!("expected RetrySession, got {:?}", other),
         }
@@ -1146,16 +1093,11 @@ mod tests {
         state.raw_stdout = "plain stdout".to_string();
 
         match finalize_gemini_attempt(&mut state, "plain stderr".to_string(), Some(2)) {
-            GeminiFinalState::Error {
-                message,
-                stdout,
-                stderr,
-                exit_code,
-            } => {
-                assert!(message.contains("plain stderr"));
-                assert_eq!(stdout, "plain stdout");
-                assert_eq!(stderr, "plain stderr");
-                assert_eq!(exit_code, Some(2));
+            StreamFinalState::Error(failure) => {
+                assert!(failure.message.contains("plain stderr"));
+                assert_eq!(failure.stdout, "plain stdout");
+                assert_eq!(failure.stderr, "plain stderr");
+                assert_eq!(failure.exit_code, Some(2));
             }
             other => panic!("expected Error, got {:?}", other),
         }
@@ -1249,12 +1191,12 @@ mod tests {
 
         let result = run_gemini_streaming_attempts(&tx, Some("latest".to_string()), |selector| {
             attempt_calls.push(selector);
-            Ok(GeminiAttemptResult::RetrySession {
+            Ok(StreamAttemptResult::RetrySession(StreamAttemptFailure {
                 message: GEMINI_SESSION_DEAD_MESSAGE.to_string(),
                 stdout: "partial".to_string(),
                 stderr: String::new(),
                 exit_code: None,
-            })
+            }))
         });
 
         assert!(result.is_ok());

--- a/src/services/gemini.rs
+++ b/src/services/gemini.rs
@@ -47,7 +47,7 @@ struct GeminiAttemptState {
     last_error_message: Option<String>,
     terminal_result_seen: bool,
     terminal_result_text: Option<String>,
-    buffered_messages: Vec<StreamMessage>,
+    meaningful_progress_seen: bool,
 }
 
 impl GeminiAttemptState {
@@ -227,6 +227,7 @@ fn execute_gemini_streaming_attempt(
     let mut state = GeminiAttemptState::new(resume_selector);
     match collect_gemini_stream_events(
         &stdout_events,
+        &sender,
         cancel_token.as_deref(),
         &mut state,
         GEMINI_STREAM_POLL_TIMEOUT,
@@ -263,12 +264,10 @@ fn execute_gemini_streaming_attempt(
 
     match finalize_gemini_attempt(&mut state, stderr, status.code()) {
         StreamFinalState::Done { result, session_id } => {
-            flush_buffered_stream_messages(&sender, &mut state);
             let _ = sender.send(StreamMessage::Done { result, session_id });
             Ok(StreamAttemptResult::Completed)
         }
         StreamFinalState::Error(failure) => {
-            flush_buffered_stream_messages(&sender, &mut state);
             send_gemini_stream_failure(&sender, failure);
             Ok(StreamAttemptResult::Completed)
         }
@@ -293,6 +292,7 @@ fn send_gemini_stream_failure(sender: &Sender<StreamMessage>, failure: StreamAtt
 
 fn collect_gemini_stream_events(
     stdout_events: &mpsc::Receiver<GeminiStreamEvent>,
+    sender: &Sender<StreamMessage>,
     cancel_token: Option<&CancelToken>,
     state: &mut GeminiAttemptState,
     poll_timeout: Duration,
@@ -308,7 +308,7 @@ fn collect_gemini_stream_events(
         match stdout_events.recv_timeout(poll_timeout) {
             Ok(GeminiStreamEvent::Line(line)) => {
                 silent_for = Duration::ZERO;
-                process_gemini_stream_line(&line, state);
+                process_gemini_stream_line(&line, state, sender);
             }
             Ok(GeminiStreamEvent::ReadError(message)) => {
                 return GeminiStreamLoopResult::RetrySession { message };
@@ -323,7 +323,7 @@ fn collect_gemini_stream_events(
                 if state.terminal_result_seen {
                     return GeminiStreamLoopResult::Eof;
                 }
-                if state.raw_stdout.is_empty() {
+                if !state.meaningful_progress_seen {
                     continue;
                 }
                 silent_for += poll_timeout;
@@ -367,7 +367,11 @@ where
     rx
 }
 
-fn process_gemini_stream_line(line: &str, state: &mut GeminiAttemptState) {
+fn process_gemini_stream_line(
+    line: &str,
+    state: &mut GeminiAttemptState,
+    sender: &Sender<StreamMessage>,
+) {
     if line.trim().is_empty() {
         return;
     }
@@ -378,15 +382,19 @@ fn process_gemini_stream_line(line: &str, state: &mut GeminiAttemptState) {
         return;
     };
 
-    process_gemini_json_event(&json, state);
+    process_gemini_json_event(&json, state, sender);
 }
 
-fn process_gemini_json_event(json: &Value, state: &mut GeminiAttemptState) {
+fn process_gemini_json_event(
+    json: &Value,
+    state: &mut GeminiAttemptState,
+    sender: &Sender<StreamMessage>,
+) {
     match json.get("type").and_then(|v| v.as_str()) {
         Some("init") => {
             if let Some(session_id) = json.get("session_id").and_then(|v| v.as_str()) {
                 state.last_resume_selector = observed_session_to_resume_selector(session_id);
-                state.buffered_messages.push(StreamMessage::Init {
+                let _ = sender.send(StreamMessage::Init {
                     session_id: state
                         .last_resume_selector
                         .clone()
@@ -402,20 +410,23 @@ fn process_gemini_json_event(json: &Value, state: &mut GeminiAttemptState) {
             let role = json.get("role").and_then(|v| v.as_str());
             let content = json.get("content").and_then(|v| v.as_str()).unwrap_or("");
             if role == Some("assistant") && !content.is_empty() {
+                state.meaningful_progress_seen = true;
                 state.final_text.push_str(content);
-                state.buffered_messages.push(StreamMessage::Text {
+                let _ = sender.send(StreamMessage::Text {
                     content: content.to_string(),
                 });
             }
         }
         Some("tool_use") => {
             if let Some(tool_use) = build_gemini_tool_use_message(json) {
-                state.buffered_messages.push(tool_use);
+                state.meaningful_progress_seen = true;
+                let _ = sender.send(tool_use);
             }
         }
         Some("tool_result") => {
             if let Some(tool_result) = build_gemini_tool_result_message(json) {
-                state.buffered_messages.push(tool_result);
+                state.meaningful_progress_seen = true;
+                let _ = sender.send(tool_result);
             }
         }
         Some("error") => {
@@ -449,7 +460,7 @@ fn process_gemini_json_event(json: &Value, state: &mut GeminiAttemptState) {
             let duration_ms = stats
                 .and_then(|value| value.get("duration_ms"))
                 .and_then(|value| value.as_u64());
-            state.buffered_messages.push(StreamMessage::StatusUpdate {
+            let _ = sender.send(StreamMessage::StatusUpdate {
                 model: model_name,
                 cost_usd: None,
                 total_cost_usd: None,
@@ -529,12 +540,6 @@ fn finalize_gemini_attempt(
         stderr,
         exit_code,
     })
-}
-
-fn flush_buffered_stream_messages(sender: &Sender<StreamMessage>, state: &mut GeminiAttemptState) {
-    for message in state.buffered_messages.drain(..) {
-        let _ = sender.send(message);
-    }
 }
 
 fn is_cancelled(token: Option<&CancelToken>) -> bool {
@@ -760,10 +765,9 @@ mod tests {
         GeminiStreamEvent, GeminiStreamLoopResult, build_exec_args,
         build_gemini_tool_result_message, build_gemini_tool_use_message,
         collect_gemini_stream_events, execute_command_streaming, extract_gemini_error_message,
-        extract_text_from_stream_output, finalize_gemini_attempt, flush_buffered_stream_messages,
-        looks_like_uuid, normalize_resume_selector, observed_session_to_resume_selector,
-        process_gemini_stream_line, remote_profile_not_supported_message,
-        run_gemini_streaming_attempts,
+        extract_text_from_stream_output, finalize_gemini_attempt, looks_like_uuid,
+        normalize_resume_selector, observed_session_to_resume_selector, process_gemini_stream_line,
+        remote_profile_not_supported_message, run_gemini_streaming_attempts,
     };
     use crate::services::claude::StreamMessage;
     use crate::services::provider::{
@@ -904,13 +908,13 @@ mod tests {
         process_gemini_stream_line(
             r#"{"type":"tool_use","tool_name":"run_shell_command","parameters":{"command":"pwd"}}"#,
             &mut state,
+            &tx,
         );
         process_gemini_stream_line(
             r#"{"type":"tool_result","status":"success","output":"/tmp/example"}"#,
             &mut state,
+            &tx,
         );
-
-        flush_buffered_stream_messages(&tx, &mut state);
 
         match rx.recv().unwrap() {
             StreamMessage::ToolUse { name, input } => {
@@ -950,6 +954,7 @@ mod tests {
         process_gemini_stream_line(
             r#"{"type":"message","role":42,"content":["bad-shape"]}"#,
             &mut state,
+            &_tx,
         );
 
         assert!(state.final_text.is_empty());
@@ -961,27 +966,26 @@ mod tests {
         let (_tx, rx): (mpsc::Sender<StreamMessage>, mpsc::Receiver<StreamMessage>) =
             mpsc::channel();
         let mut state = GeminiAttemptState::new(None);
-        process_gemini_stream_line("{}", &mut state);
+        process_gemini_stream_line("{}", &mut state, &_tx);
 
         assert!(!state.terminal_result_seen);
         assert!(rx.try_recv().is_err());
     }
 
     #[test]
-    fn attempt_messages_are_buffered_until_flush() {
+    fn attempt_messages_are_emitted_immediately() {
         let (tx, rx) = mpsc::channel();
         let mut state = GeminiAttemptState::new(None);
         process_gemini_stream_line(
             r#"{"type":"init","session_id":"aa678e6b-c6d3-4dd2-9197-58580c00cc6c","model":"gemini-2.5-flash"}"#,
             &mut state,
+            &tx,
         );
         process_gemini_stream_line(
             r#"{"type":"message","role":"assistant","content":"hello"}"#,
             &mut state,
+            &tx,
         );
-
-        assert!(rx.try_recv().is_err());
-        flush_buffered_stream_messages(&tx, &mut state);
 
         match rx.recv().unwrap() {
             StreamMessage::Init { session_id } => assert_eq!(session_id, "latest"),
@@ -995,32 +999,36 @@ mod tests {
     }
 
     #[test]
-    fn execute_complete_flushes_buffered_messages_before_done() {
+    fn execute_complete_emits_stream_events_before_done() {
         let (tx, rx) = mpsc::channel();
         let mut state = GeminiAttemptState::new(None);
         process_gemini_stream_line(
             r#"{"type":"init","session_id":"session-alpha","model":"gemini-2.5-flash"}"#,
             &mut state,
+            &tx,
         );
         process_gemini_stream_line(
             r#"{"type":"message","role":"assistant","content":"hello"}"#,
             &mut state,
+            &tx,
         );
         process_gemini_stream_line(
             r#"{"type":"tool_use","tool_name":"run_shell_command","parameters":{"command":"pwd"}}"#,
             &mut state,
+            &tx,
         );
         process_gemini_stream_line(
             r#"{"type":"tool_result","status":"success","output":"/tmp/example"}"#,
             &mut state,
+            &tx,
         );
         process_gemini_stream_line(
             r#"{"type":"result","result":"hello","stats":{"input_tokens":10,"output_tokens":4,"duration_ms":20}}"#,
             &mut state,
+            &tx,
         );
 
         let final_state = finalize_gemini_attempt(&mut state, String::new(), Some(0));
-        flush_buffered_stream_messages(&tx, &mut state);
         match final_state {
             StreamFinalState::Done { result, session_id } => {
                 let _ = tx.send(StreamMessage::Done { result, session_id });
@@ -1179,6 +1187,7 @@ mod tests {
     fn cancelled_during_stream_returns_cancelled() {
         let token = Arc::new(CancelToken::new());
         let (tx, rx) = mpsc::channel();
+        let (stream_tx, _stream_rx) = mpsc::channel();
         let mut state = GeminiAttemptState::new(None);
         tx.send(GeminiStreamEvent::Line(
             r#"{"type":"message","role":"assistant","content":"partial"}"#.to_string(),
@@ -1192,6 +1201,7 @@ mod tests {
 
         let result = collect_gemini_stream_events(
             &rx,
+            &stream_tx,
             Some(token.as_ref()),
             &mut state,
             Duration::from_millis(5),
@@ -1205,8 +1215,13 @@ mod tests {
     #[test]
     fn idle_watchdog_does_not_retry_before_first_stream_progress() {
         let token = Arc::new(CancelToken::new());
-        let (_tx, rx) = mpsc::channel();
+        let (tx, rx) = mpsc::channel();
+        let (stream_tx, stream_rx) = mpsc::channel();
         let mut state = GeminiAttemptState::new(None);
+        tx.send(GeminiStreamEvent::Line(
+            r#"{"type":"init","session_id":"latest","model":"gemini-2.5-flash"}"#.to_string(),
+        ))
+        .unwrap();
         let token_for_thread = token.clone();
         std::thread::spawn(move || {
             std::thread::sleep(Duration::from_millis(4));
@@ -1215,6 +1230,7 @@ mod tests {
 
         let result = collect_gemini_stream_events(
             &rx,
+            &stream_tx,
             Some(token.as_ref()),
             &mut state,
             Duration::from_millis(1),
@@ -1222,12 +1238,19 @@ mod tests {
         );
 
         assert_eq!(result, GeminiStreamLoopResult::Cancelled);
-        assert!(state.raw_stdout.is_empty());
+        assert!(!state.raw_stdout.is_empty());
+        assert!(!state.meaningful_progress_seen);
+        match stream_rx.recv().unwrap() {
+            StreamMessage::Init { session_id } => assert_eq!(session_id, "latest"),
+            other => panic!("expected Init, got {:?}", other),
+        }
+        assert!(stream_rx.try_recv().is_err());
     }
 
     #[test]
     fn idle_watchdog_retries_after_extended_silence_following_progress() {
         let (tx, rx) = mpsc::channel();
+        let (stream_tx, stream_rx) = mpsc::channel();
         let mut state = GeminiAttemptState::new(None);
         tx.send(GeminiStreamEvent::Line(
             r#"{"type":"message","role":"assistant","content":"partial"}"#.to_string(),
@@ -1236,6 +1259,7 @@ mod tests {
 
         let result = collect_gemini_stream_events(
             &rx,
+            &stream_tx,
             None,
             &mut state,
             Duration::from_millis(1),
@@ -1249,6 +1273,12 @@ mod tests {
             other => panic!("expected RetrySession, got {:?}", other),
         }
         assert_eq!(state.final_text, "partial");
+        assert!(state.meaningful_progress_seen);
+        match stream_rx.recv().unwrap() {
+            StreamMessage::Text { content } => assert_eq!(content, "partial"),
+            other => panic!("expected Text, got {:?}", other),
+        }
+        assert!(stream_rx.try_recv().is_err());
     }
 
     #[test]

--- a/src/services/provider.rs
+++ b/src/services/provider.rs
@@ -256,9 +256,43 @@ pub fn parse_provider_and_channel_from_tmux_name(
     Some((ProviderKind::Claude, without_suffix.to_string()))
 }
 
+pub fn compose_structured_turn_prompt(
+    prompt: &str,
+    system_prompt: Option<&str>,
+    allowed_tools: Option<&[String]>,
+) -> String {
+    let mut sections = Vec::new();
+
+    if let Some(system_prompt) = system_prompt
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        sections.push(format!(
+            "[Authoritative Instructions]\n{}\n\nThese instructions are authoritative for this turn. Follow them over any generic assistant persona unless the user explicitly asks to inspect or compare them.",
+            system_prompt
+        ));
+    }
+
+    if let Some(allowed_tools) = allowed_tools.filter(|tools| !tools.is_empty()) {
+        sections.push(format!(
+            "[Tool Policy]\nIf tools are needed, stay within this allowlist unless the user explicitly asks to change it: {}",
+            allowed_tools.join(", ")
+        ));
+    }
+
+    if sections.is_empty() {
+        return prompt.to_string();
+    }
+
+    sections.push(format!("[User Request]\n{}", prompt));
+    sections.join("\n\n")
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{ProviderKind, parse_provider_and_channel_from_tmux_name};
+    use super::{
+        ProviderKind, compose_structured_turn_prompt, parse_provider_and_channel_from_tmux_name,
+    };
     use crate::dispatch::extract_thread_channel_id;
 
     #[test]
@@ -620,5 +654,26 @@ mod tests {
             assert!(capabilities.supports_tool_stream);
             assert!(!capabilities.binary_name.is_empty());
         }
+    }
+
+    #[test]
+    fn test_compose_structured_turn_prompt_includes_authoritative_sections() {
+        let prompt = compose_structured_turn_prompt(
+            "role과 mission만 답해줘.",
+            Some("role: PMD\nmission: 백로그 관리"),
+            Some(&["Bash".to_string(), "Read".to_string()]),
+        );
+
+        assert!(prompt.contains("[Authoritative Instructions]"));
+        assert!(prompt.contains("role: PMD"));
+        assert!(prompt.contains("[Tool Policy]"));
+        assert!(prompt.contains("Bash, Read"));
+        assert!(prompt.contains("[User Request]\nrole과 mission만 답해줘."));
+    }
+
+    #[test]
+    fn test_compose_structured_turn_prompt_returns_plain_prompt_without_overrides() {
+        let prompt = compose_structured_turn_prompt("just answer", None, None);
+        assert_eq!(prompt, "just answer");
     }
 }

--- a/src/services/provider.rs
+++ b/src/services/provider.rs
@@ -349,6 +349,54 @@ pub fn register_child_pid(token: Option<&CancelToken>, child_pid: u32) {
     }
 }
 
+/// Result from reading a provider session output stream until completion or session death.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReadOutputResult {
+    /// Normal completion (terminal result observed)
+    Completed { offset: u64 },
+    /// Session died without producing a terminal result
+    SessionDied { offset: u64 },
+    /// User cancelled the operation
+    Cancelled { offset: u64 },
+}
+
+/// Result from sending a follow-up message to an existing provider session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FollowupResult {
+    /// Message delivered and output successfully read to completion.
+    Delivered,
+    /// Session needs to be killed and recreated.
+    RecreateSession { error: String },
+}
+
+pub fn fold_read_output_result<T>(
+    read_result: ReadOutputResult,
+    on_ready: impl FnOnce(u64) -> T,
+    on_session_died: impl FnOnce(u64) -> T,
+) -> T {
+    match read_result {
+        ReadOutputResult::Completed { offset } | ReadOutputResult::Cancelled { offset } => {
+            on_ready(offset)
+        }
+        ReadOutputResult::SessionDied { offset } => on_session_died(offset),
+    }
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn followup_result_from_read_output_result(
+    read_result: ReadOutputResult,
+    session_died_error: impl Into<String>,
+) -> FollowupResult {
+    let session_died_error = session_died_error.into();
+    fold_read_output_result(
+        read_result,
+        |_| FollowupResult::Delivered,
+        |_| FollowupResult::RecreateSession {
+            error: session_died_error,
+        },
+    )
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StreamAttemptFailure {
     pub message: String,
@@ -416,8 +464,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        CancelToken, ProviderKind, StreamAttemptFailure, StreamAttemptResult, StreamFinalState,
-        cancel_requested, compose_structured_turn_prompt,
+        CancelToken, FollowupResult, ProviderKind, ReadOutputResult, StreamAttemptFailure,
+        StreamAttemptResult, StreamFinalState, cancel_requested, compose_structured_turn_prompt,
+        fold_read_output_result, followup_result_from_read_output_result,
         parse_provider_and_channel_from_tmux_name, register_child_pid,
         run_retrying_stream_attempts,
     };
@@ -894,5 +943,48 @@ mod tests {
     fn test_compose_structured_turn_prompt_returns_plain_prompt_without_overrides() {
         let prompt = compose_structured_turn_prompt("just answer", None, None);
         assert_eq!(prompt, "just answer");
+    }
+
+    #[test]
+    fn test_fold_read_output_result_maps_completed_to_ready_offset() {
+        let outcome = fold_read_output_result(
+            ReadOutputResult::Completed { offset: 42 },
+            |offset| format!("ready:{offset}"),
+            |offset| format!("dead:{offset}"),
+        );
+        assert_eq!(outcome, "ready:42");
+    }
+
+    #[test]
+    fn test_fold_read_output_result_maps_session_died_to_dead_branch() {
+        let outcome = fold_read_output_result(
+            ReadOutputResult::SessionDied { offset: 7 },
+            |offset| format!("ready:{offset}"),
+            |offset| format!("dead:{offset}"),
+        );
+        assert_eq!(outcome, "dead:7");
+    }
+
+    #[test]
+    fn test_followup_result_from_read_output_result_maps_completed_to_delivered() {
+        let outcome = followup_result_from_read_output_result(
+            ReadOutputResult::Completed { offset: 99 },
+            "session died during follow-up output reading",
+        );
+        assert_eq!(outcome, FollowupResult::Delivered);
+    }
+
+    #[test]
+    fn test_followup_result_from_read_output_result_maps_session_died_to_recreate() {
+        let outcome = followup_result_from_read_output_result(
+            ReadOutputResult::SessionDied { offset: 99 },
+            "session died during follow-up output reading",
+        );
+        assert_eq!(
+            outcome,
+            FollowupResult::RecreateSession {
+                error: "session died during follow-up output reading".to_string(),
+            }
+        );
     }
 }

--- a/src/services/provider.rs
+++ b/src/services/provider.rs
@@ -1,5 +1,7 @@
 use crate::utils::format::safe_prefix;
 use std::process::Command;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 
 /// Tmux session name prefix — always "AgentDesk".
 pub const TMUX_SESSION_PREFIX: &str = "AgentDesk";
@@ -288,10 +290,70 @@ pub fn compose_structured_turn_prompt(
     sections.join("\n\n")
 }
 
+/// Cooperative cancellation token shared by provider runtimes and Discord orchestration.
+pub struct CancelToken {
+    pub cancelled: AtomicBool,
+    pub child_pid: Mutex<Option<u32>>,
+    /// SSH cancel flag — set to true to signal remote execution to close the channel
+    #[allow(dead_code)]
+    pub ssh_cancel: Mutex<Option<std::sync::Arc<AtomicBool>>>,
+    /// tmux session name for cleanup on cancel
+    pub tmux_session: Mutex<Option<String>>,
+    /// Watchdog deadline as Unix timestamp in milliseconds.
+    /// The watchdog fires when `now_ms >= deadline_ms`. Extend by setting a future value.
+    /// Maximum absolute cap: initial deadline + MAX_EXTENSION (3 hours).
+    pub watchdog_deadline_ms: AtomicI64,
+    /// The hard ceiling for watchdog_deadline_ms (initial + 3h). Extensions cannot exceed this.
+    pub watchdog_max_deadline_ms: AtomicI64,
+}
+
+impl CancelToken {
+    pub fn new() -> Self {
+        Self {
+            cancelled: AtomicBool::new(false),
+            child_pid: Mutex::new(None),
+            ssh_cancel: Mutex::new(None),
+            tmux_session: Mutex::new(None),
+            watchdog_deadline_ms: AtomicI64::new(0),
+            watchdog_max_deadline_ms: AtomicI64::new(0),
+        }
+    }
+
+    /// Cancel and clean up any associated tmux session.
+    pub fn cancel_with_tmux_cleanup(&self) {
+        self.cancelled.store(true, Ordering::Relaxed);
+        if let Some(name) = self.tmux_session.lock().unwrap().take() {
+            #[cfg(unix)]
+            {
+                crate::services::tmux_diagnostics::record_tmux_exit_reason(
+                    &name,
+                    "explicit cleanup via cancel_with_tmux_cleanup",
+                );
+                crate::services::platform::tmux::kill_session(&name);
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = &name;
+            }
+        }
+    }
+}
+
+pub fn cancel_requested(token: Option<&CancelToken>) -> bool {
+    token.is_some_and(|token| token.cancelled.load(Ordering::Relaxed))
+}
+
+pub fn register_child_pid(token: Option<&CancelToken>, child_pid: u32) {
+    if let Some(token) = token {
+        *token.child_pid.lock().unwrap() = Some(child_pid);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        ProviderKind, compose_structured_turn_prompt, parse_provider_and_channel_from_tmux_name,
+        CancelToken, ProviderKind, cancel_requested, compose_structured_turn_prompt,
+        parse_provider_and_channel_from_tmux_name, register_child_pid,
     };
     use crate::dispatch::extract_thread_channel_id;
 
@@ -654,6 +716,21 @@ mod tests {
             assert!(capabilities.supports_tool_stream);
             assert!(!capabilities.binary_name.is_empty());
         }
+    }
+
+    #[test]
+    fn test_cancel_token_helpers_register_and_report_state() {
+        let token = CancelToken::new();
+        assert!(!cancel_requested(Some(&token)));
+        assert!(!cancel_requested(None));
+
+        register_child_pid(Some(&token), 4242);
+        assert_eq!(*token.child_pid.lock().unwrap(), Some(4242));
+
+        token
+            .cancelled
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        assert!(cancel_requested(Some(&token)));
     }
 
     #[test]

--- a/src/services/provider.rs
+++ b/src/services/provider.rs
@@ -369,6 +369,72 @@ pub enum FollowupResult {
     RecreateSession { error: String },
 }
 
+/// Callbacks for session status checks during output file polling.
+pub(crate) struct SessionProbe {
+    /// Returns true if the session process is still running.
+    pub is_alive: Box<dyn Fn() -> bool + Send>,
+    /// Returns true if the session is idle and ready for new input.
+    pub is_ready_for_input: Box<dyn Fn() -> bool + Send>,
+}
+
+impl SessionProbe {
+    pub fn new(
+        is_alive: impl Fn() -> bool + Send + 'static,
+        is_ready_for_input: impl Fn() -> bool + Send + 'static,
+    ) -> Self {
+        Self {
+            is_alive: Box::new(is_alive),
+            is_ready_for_input: Box::new(is_ready_for_input),
+        }
+    }
+
+    #[cfg(unix)]
+    pub fn tmux(session_name: String) -> Self {
+        let name_alive = session_name.clone();
+        let name_ready = session_name;
+        Self::new(
+            move || tmux_session_alive(&name_alive),
+            move || tmux_session_ready_for_input(&name_ready),
+        )
+    }
+
+    #[cfg(not(unix))]
+    pub fn tmux(_session_name: String) -> Self {
+        Self::new(|| false, || false)
+    }
+
+    pub fn process(is_alive: impl Fn() -> bool + Send + 'static) -> Self {
+        Self::new(is_alive, || false)
+    }
+}
+
+#[cfg(unix)]
+fn tmux_session_alive(tmux_session_name: &str) -> bool {
+    crate::services::tmux_diagnostics::tmux_session_has_live_pane(tmux_session_name)
+}
+
+#[cfg(unix)]
+pub(crate) fn tmux_capture_indicates_ready_for_input(capture: &str) -> bool {
+    capture
+        .lines()
+        .rev()
+        .filter(|l| !l.trim().is_empty())
+        .take(3)
+        .any(|l| l.contains("Ready for input (type message + Enter)"))
+}
+
+#[cfg(unix)]
+pub(crate) fn tmux_session_ready_for_input(tmux_session_name: &str) -> bool {
+    crate::services::platform::tmux::capture_pane(tmux_session_name, -80)
+        .map(|stdout| tmux_capture_indicates_ready_for_input(&stdout))
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+pub(crate) fn tmux_session_ready_for_input(_tmux_session_name: &str) -> bool {
+    false
+}
+
 pub fn fold_read_output_result<T>(
     read_result: ReadOutputResult,
     on_ready: impl FnOnce(u64) -> T,

--- a/src/services/provider.rs
+++ b/src/services/provider.rs
@@ -1222,6 +1222,46 @@ mod tests {
     }
 
     #[test]
+    fn test_fold_read_output_result_maps_cancelled_to_ready_offset() {
+        let outcome = fold_read_output_result(
+            ReadOutputResult::Cancelled { offset: 15 },
+            |offset| format!("ready:{offset}"),
+            |offset| format!("dead:{offset}"),
+        );
+        assert_eq!(outcome, "ready:15");
+    }
+
+    #[test]
+    fn test_followup_result_from_read_output_result_maps_cancelled_to_delivered() {
+        let outcome = followup_result_from_read_output_result(
+            ReadOutputResult::Cancelled { offset: 99 },
+            "session died during follow-up output reading",
+        );
+        assert_eq!(outcome, FollowupResult::Delivered);
+    }
+
+    #[test]
+    fn test_run_retrying_stream_attempts_returns_early_on_cancelled() {
+        let mut exhausted: Option<StreamAttemptFailure> = None;
+        let mut calls = 0usize;
+
+        let result = run_retrying_stream_attempts(
+            "Gemini",
+            Some("latest".to_string()),
+            1,
+            |_| {
+                calls += 1;
+                Ok(StreamAttemptResult::Cancelled)
+            },
+            |failure| exhausted = Some(failure),
+        );
+
+        assert!(result.is_ok());
+        assert_eq!(calls, 1);
+        assert!(exhausted.is_none());
+    }
+
+    #[test]
     fn test_poll_output_file_until_result_completes_after_terminal_line() {
         #[derive(Default)]
         struct TestState {
@@ -1295,5 +1335,68 @@ mod tests {
         .unwrap();
 
         assert_eq!(result, ReadOutputResult::Cancelled { offset: 17 });
+    }
+
+    #[test]
+    fn test_poll_output_file_until_result_reports_session_died_without_terminal_result() {
+        #[derive(Default)]
+        struct TestState {
+            lines: Vec<String>,
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let output_path = dir.path().join("stream.jsonl");
+        std::fs::write(&output_path, "partial\n").unwrap();
+
+        let mut state = TestState::default();
+        let mut alive_checks = 0usize;
+        let result = poll_output_file_until_result(
+            output_path.to_str().unwrap(),
+            0,
+            None,
+            &mut state,
+            || {
+                alive_checks += 1;
+                alive_checks < 25
+            },
+            || false,
+            |_| {},
+            |line: &str, state| {
+                state.lines.push(line.to_string());
+                true
+            },
+            |_| false,
+            |_| true,
+            |_| {},
+        )
+        .unwrap();
+
+        assert_eq!(
+            result,
+            ReadOutputResult::SessionDied {
+                offset: std::fs::metadata(&output_path).unwrap().len(),
+            }
+        );
+        assert_eq!(state.lines, vec!["partial".to_string()]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_tmux_capture_indicates_ready_for_input_detects_recent_ready_banner() {
+        let capture = "\
+build logs\n\
+Ready for input (type message + Enter)\n\
+> ";
+        assert!(super::tmux_capture_indicates_ready_for_input(capture));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_tmux_capture_indicates_ready_for_input_rejects_non_ready_capture() {
+        let capture = "\
+build logs\n\
+waiting for tool output\n\
+still running";
+        assert!(!super::tmux_capture_indicates_ready_for_input(capture));
     }
 }

--- a/src/services/provider.rs
+++ b/src/services/provider.rs
@@ -397,6 +397,173 @@ pub fn followup_result_from_read_output_result(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
+pub fn poll_output_file_until_result<
+    State,
+    IsAlive,
+    IsReady,
+    EmitOffset,
+    ProcessLine,
+    HasFinal,
+    EmitSyntheticDone,
+    EmitDeferredError,
+>(
+    output_path: &str,
+    start_offset: u64,
+    cancel_token: Option<std::sync::Arc<CancelToken>>,
+    state: &mut State,
+    mut is_alive: IsAlive,
+    mut is_ready_for_input: IsReady,
+    mut emit_output_offset: EmitOffset,
+    mut process_line: ProcessLine,
+    has_final: HasFinal,
+    mut emit_synthetic_done: EmitSyntheticDone,
+    mut emit_deferred_error: EmitDeferredError,
+) -> Result<ReadOutputResult, String>
+where
+    IsAlive: FnMut() -> bool,
+    IsReady: FnMut() -> bool,
+    EmitOffset: FnMut(u64),
+    ProcessLine: FnMut(&str, &mut State) -> bool,
+    HasFinal: Fn(&State) -> bool,
+    EmitSyntheticDone: FnMut(&State) -> bool,
+    EmitDeferredError: FnMut(&State),
+{
+    use std::io::{Read, Seek, SeekFrom};
+    use std::time::{Duration, Instant};
+
+    let wait_start = Instant::now();
+    let mut wait_interval = Duration::from_millis(10);
+    let max_wait_interval = Duration::from_millis(500);
+    loop {
+        if std::fs::metadata(output_path).is_ok() {
+            break;
+        }
+        if wait_start.elapsed() > Duration::from_secs(30) {
+            return Err("Timeout waiting for output file".to_string());
+        }
+        if cancel_requested(cancel_token.as_deref()) {
+            return Ok(ReadOutputResult::Cancelled {
+                offset: start_offset,
+            });
+        }
+        std::thread::sleep(wait_interval);
+        wait_interval = std::cmp::min(
+            Duration::from_millis((wait_interval.as_millis() as f64 * 1.5) as u64),
+            max_wait_interval,
+        );
+    }
+
+    let mut file = std::fs::File::open(output_path)
+        .map_err(|e| format!("Failed to open output file: {}", e))?;
+    file.seek(SeekFrom::Start(start_offset))
+        .map_err(|e| format!("Failed to seek output file: {}", e))?;
+
+    let mut current_offset = start_offset;
+    let mut partial_line = String::new();
+    let mut buf = [0u8; 8192];
+    let mut no_data_count: u32 = 0;
+    let mut consecutive_ready_count: u32 = 0;
+    let mut first_ready_at: Option<Instant> = None;
+
+    loop {
+        if cancel_requested(cancel_token.as_deref()) {
+            return Ok(ReadOutputResult::Cancelled {
+                offset: current_offset,
+            });
+        }
+
+        match file.read(&mut buf) {
+            Ok(0) => {
+                no_data_count += 1;
+                if no_data_count % 25 == 0 {
+                    if !is_alive() {
+                        let file_len = std::fs::metadata(output_path)
+                            .map(|meta| meta.len())
+                            .unwrap_or(current_offset);
+                        if file_len > current_offset {
+                            continue;
+                        }
+                        break;
+                    }
+
+                    let file_len = std::fs::metadata(output_path)
+                        .map(|meta| meta.len())
+                        .unwrap_or(current_offset);
+                    let has_new_bytes = file_len > current_offset;
+                    let output_ever_grew = current_offset > start_offset;
+                    if !has_new_bytes && output_ever_grew && is_ready_for_input() {
+                        if first_ready_at.is_none() {
+                            first_ready_at = Some(Instant::now());
+                        }
+                        consecutive_ready_count += 1;
+                        let ready_elapsed = first_ready_at
+                            .expect("first_ready_at set above before elapsed check")
+                            .elapsed();
+                        if ready_elapsed >= Duration::from_secs(15) && consecutive_ready_count >= 3
+                        {
+                            if !emit_synthetic_done(state) {
+                                return Ok(ReadOutputResult::Cancelled {
+                                    offset: current_offset,
+                                });
+                            }
+                            return Ok(ReadOutputResult::Completed {
+                                offset: current_offset,
+                            });
+                        }
+                    } else {
+                        consecutive_ready_count = 0;
+                        first_ready_at = None;
+                    }
+                }
+
+                let read_interval = if no_data_count < 5 {
+                    Duration::from_millis(10)
+                } else if no_data_count < 20 {
+                    Duration::from_millis(50)
+                } else {
+                    Duration::from_millis(200)
+                };
+                std::thread::sleep(read_interval);
+            }
+            Ok(n) => {
+                no_data_count = 0;
+                consecutive_ready_count = 0;
+                first_ready_at = None;
+                current_offset += n as u64;
+                emit_output_offset(current_offset);
+                partial_line.push_str(&String::from_utf8_lossy(&buf[..n]));
+
+                while let Some(pos) = partial_line.find('\n') {
+                    let line: String = partial_line.drain(..=pos).collect();
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+
+                    if !process_line(trimmed, state) {
+                        return Ok(ReadOutputResult::Cancelled {
+                            offset: current_offset,
+                        });
+                    }
+
+                    if has_final(state) {
+                        return Ok(ReadOutputResult::Completed {
+                            offset: current_offset,
+                        });
+                    }
+                }
+            }
+            Err(_) => break,
+        }
+    }
+
+    emit_deferred_error(state);
+    Ok(ReadOutputResult::SessionDied {
+        offset: current_offset,
+    })
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StreamAttemptFailure {
     pub message: String,
@@ -467,8 +634,8 @@ mod tests {
         CancelToken, FollowupResult, ProviderKind, ReadOutputResult, StreamAttemptFailure,
         StreamAttemptResult, StreamFinalState, cancel_requested, compose_structured_turn_prompt,
         fold_read_output_result, followup_result_from_read_output_result,
-        parse_provider_and_channel_from_tmux_name, register_child_pid,
-        run_retrying_stream_attempts,
+        parse_provider_and_channel_from_tmux_name, poll_output_file_until_result,
+        register_child_pid, run_retrying_stream_attempts,
     };
     use crate::dispatch::extract_thread_channel_id;
 
@@ -986,5 +1153,81 @@ mod tests {
                 error: "session died during follow-up output reading".to_string(),
             }
         );
+    }
+
+    #[test]
+    fn test_poll_output_file_until_result_completes_after_terminal_line() {
+        #[derive(Default)]
+        struct TestState {
+            saw_done: bool,
+            lines: Vec<String>,
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let output_path = dir.path().join("stream.jsonl");
+        std::fs::write(&output_path, "hello\nDONE\n").unwrap();
+
+        let mut state = TestState::default();
+        let mut offsets = Vec::new();
+        let result = poll_output_file_until_result(
+            output_path.to_str().unwrap(),
+            0,
+            None,
+            &mut state,
+            || true,
+            || false,
+            |offset| offsets.push(offset),
+            |line: &str, state| {
+                state.lines.push(line.to_string());
+                if line == "DONE" {
+                    state.saw_done = true;
+                }
+                true
+            },
+            |state| state.saw_done,
+            |_| true,
+            |_| {},
+        )
+        .unwrap();
+
+        assert_eq!(
+            result,
+            ReadOutputResult::Completed {
+                offset: std::fs::metadata(&output_path).unwrap().len(),
+            }
+        );
+        assert_eq!(state.lines, vec!["hello".to_string(), "DONE".to_string()]);
+        assert_eq!(
+            offsets,
+            vec![std::fs::metadata(&output_path).unwrap().len()],
+        );
+    }
+
+    #[test]
+    fn test_poll_output_file_until_result_honors_preexisting_cancel_before_file_exists() {
+        let token = std::sync::Arc::new(CancelToken::new());
+        token
+            .cancelled
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let dir = tempfile::tempdir().unwrap();
+        let missing_path = dir.path().join("missing.jsonl");
+
+        let mut state = ();
+        let result = poll_output_file_until_result(
+            missing_path.to_str().unwrap(),
+            17,
+            Some(token),
+            &mut state,
+            || true,
+            || false,
+            |_| {},
+            |_, _| true,
+            |_| false,
+            |_| true,
+            |_| {},
+        )
+        .unwrap();
+
+        assert_eq!(result, ReadOutputResult::Cancelled { offset: 17 });
     }
 }

--- a/src/services/provider.rs
+++ b/src/services/provider.rs
@@ -349,11 +349,77 @@ pub fn register_child_pid(token: Option<&CancelToken>, child_pid: u32) {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StreamAttemptFailure {
+    pub message: String,
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: Option<i32>,
+}
+
+impl StreamAttemptFailure {
+    pub fn with_message(mut self, message: String) -> Self {
+        self.message = message;
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StreamAttemptResult {
+    Completed,
+    RetrySession(StreamAttemptFailure),
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StreamFinalState {
+    Done {
+        result: String,
+        session_id: Option<String>,
+    },
+    Error(StreamAttemptFailure),
+    RetrySession(StreamAttemptFailure),
+}
+
+pub fn run_retrying_stream_attempts<F, G>(
+    provider_name: &str,
+    mut resume_selector: Option<String>,
+    max_session_retries: usize,
+    mut execute_attempt: F,
+    mut on_retry_exhausted: G,
+) -> Result<(), String>
+where
+    F: FnMut(Option<String>) -> Result<StreamAttemptResult, String>,
+    G: FnMut(StreamAttemptFailure),
+{
+    for attempt in 0..=max_session_retries {
+        match execute_attempt(resume_selector.clone())? {
+            StreamAttemptResult::Completed | StreamAttemptResult::Cancelled => return Ok(()),
+            StreamAttemptResult::RetrySession(failure) => {
+                if attempt < max_session_retries {
+                    resume_selector = None;
+                    continue;
+                }
+                let exhausted_message = format!(
+                    "{} session could not be recovered after retry: {}",
+                    provider_name, failure.message
+                );
+                on_retry_exhausted(failure.with_message(exhausted_message));
+                return Ok(());
+            }
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        CancelToken, ProviderKind, cancel_requested, compose_structured_turn_prompt,
+        CancelToken, ProviderKind, StreamAttemptFailure, StreamAttemptResult, StreamFinalState,
+        cancel_requested, compose_structured_turn_prompt,
         parse_provider_and_channel_from_tmux_name, register_child_pid,
+        run_retrying_stream_attempts,
     };
     use crate::dispatch::extract_thread_channel_id;
 
@@ -731,6 +797,82 @@ mod tests {
             .cancelled
             .store(true, std::sync::atomic::Ordering::Relaxed);
         assert!(cancel_requested(Some(&token)));
+    }
+
+    #[test]
+    fn test_run_retrying_stream_attempts_resets_resume_selector_after_retry() {
+        let mut selectors = Vec::new();
+
+        let result = run_retrying_stream_attempts(
+            "Gemini",
+            Some("latest".to_string()),
+            1,
+            |selector| {
+                selectors.push(selector.clone());
+                if selectors.len() == 1 {
+                    Ok(StreamAttemptResult::RetrySession(StreamAttemptFailure {
+                        message: "dead session".to_string(),
+                        stdout: String::new(),
+                        stderr: String::new(),
+                        exit_code: None,
+                    }))
+                } else {
+                    Ok(StreamAttemptResult::Completed)
+                }
+            },
+            |_| panic!("retry should have recovered"),
+        );
+
+        assert!(result.is_ok());
+        assert_eq!(selectors, vec![Some("latest".to_string()), None]);
+    }
+
+    #[test]
+    fn test_run_retrying_stream_attempts_reports_exhausted_failure() {
+        let mut exhausted: Option<StreamAttemptFailure> = None;
+
+        let result = run_retrying_stream_attempts(
+            "Gemini",
+            Some("latest".to_string()),
+            1,
+            |_| {
+                Ok(StreamAttemptResult::RetrySession(StreamAttemptFailure {
+                    message: "dead session".to_string(),
+                    stdout: "partial".to_string(),
+                    stderr: String::new(),
+                    exit_code: None,
+                }))
+            },
+            |failure| exhausted = Some(failure),
+        );
+
+        assert!(result.is_ok());
+        assert_eq!(
+            exhausted,
+            Some(StreamAttemptFailure {
+                message: "Gemini session could not be recovered after retry: dead session"
+                    .to_string(),
+                stdout: "partial".to_string(),
+                stderr: String::new(),
+                exit_code: None,
+            })
+        );
+    }
+
+    #[test]
+    fn test_stream_final_state_done_preserves_result_and_session_id() {
+        let final_state = StreamFinalState::Done {
+            result: "hello".to_string(),
+            session_id: Some("latest".to_string()),
+        };
+
+        assert_eq!(
+            final_state,
+            StreamFinalState::Done {
+                result: "hello".to_string(),
+                session_id: Some("latest".to_string()),
+            }
+        );
     }
 
     #[test]

--- a/src/services/provider.rs
+++ b/src/services/provider.rs
@@ -1357,7 +1357,7 @@ mod tests {
             &mut state,
             || {
                 alive_checks += 1;
-                alive_checks < 25
+                alive_checks < 1
             },
             || false,
             |_| {},


### PR DESCRIPTION
## 요약
- Gemini 0.35.3 direct-process contract에 맞춰 resume/session 흐름을 정리했습니다.
- retry, cancel, terminal failure 처리와 Discord session reset 경로를 안정화했습니다.
- provider 공통 prompt/cancellation/retry orchestration primitive를 `src/services/provider.rs`로 올려 중복과 결합도를 줄였습니다.
- `ReadOutputResult`, `FollowupResult`, `fold_read_output_result()`도 `src/services/provider.rs`로 공통화해 Claude/Codex follow-up 및 session-ready 분기 중복을 줄였습니다.
- output file polling/backoff/session-dead 판정 루프를 `poll_output_file_until_result()`로 `src/services/provider.rs`에 올렸습니다.
- `SessionProbe`, tmux ready 판정 helper도 `src/services/provider.rs`로 옮겨 Codex, Discord recovery, runtime이 Claude 내부 타입에 덜 의존하도록 정리했습니다.

## 겪은 문제
- Gemini가 `init` 이벤트에서 UUID-like session metadata를 주는 경우가 있는데, 실제 `--resume`은 `latest` 또는 숫자 selector만 허용해서 resume이 실패할 수 있었습니다.
- terminal result 없이 stream이 끝나면 실패한 `session_id`가 메모리와 DB에 남아 다음 턴에서도 같은 resume 실패를 반복할 수 있었습니다.
- retry되는 attempt의 partial text/tool 이벤트가 최종 Discord 응답에 섞이거나, 반대로 live `Init/ToolUse` handoff를 놓치면 recovery/session continuity가 깨질 수 있었습니다.
- `CancelToken`, structured prompt envelope, retry outcome vocabulary가 provider-specific 파일에 흩어져 있어 Gemini/Codex/Discord가 공통 수명주기 규칙을 재사용하기 어려운 구조였습니다.
- Claude/Codex가 `ReadOutputResult -> ready/recreate` 분기를 각자 반복 구현하고 있어 후속 세션 처리 규칙을 한 곳에서 유지하기 어려웠습니다.
- output file poll loop 자체도 `claude.rs`에 붙어 있어, Codex가 같은 루프를 써도 실제 polling 변경은 Claude 구현을 같이 따라 읽어야 했습니다.
- `SessionProbe`, tmux ready 판정, runtime/recovery probe wiring도 Claude에 묶여 있어 provider 공통 레이어 관점에서 의존 방향이 뒤틀려 있었습니다.

## 해결 내용
- persisted/observed session 값을 `latest` 또는 숫자 selector로 정규화하고, resume turn에서는 explicit `-m`을 붙이지 않도록 조정했습니다.
- invalid selector는 preflight에서 바로 거절하고, dead-session 계열 failure는 1회 fresh-session retry 후에도 실패하면 stored `session_id`를 즉시 비우도록 맞췄습니다.
- Gemini stream event는 live `Init/Text/ToolUse/ToolResult/StatusUpdate`로 즉시 전달하고, retry로 새 `Init`가 오면 Discord turn bridge가 partial turn state를 reset하도록 맞췄습니다.
- `compose_structured_turn_prompt()`, `CancelToken`, `cancel_requested()`, `register_child_pid()`, `StreamAttemptFailure`, `StreamAttemptResult`, `StreamFinalState`, `run_retrying_stream_attempts()`를 `src/services/provider.rs`로 이동해 provider 공통 레이어에서 재사용하도록 정리했습니다.
- `ReadOutputResult`, `FollowupResult`, `fold_read_output_result()`, `followup_result_from_read_output_result()`를 `src/services/provider.rs`로 옮기고, Claude/Codex의 follow-up 및 local-process ready 분기를 이 helper 기준으로 정리했습니다.
- `poll_output_file_until_result()`를 `src/services/provider.rs`로 추가하고, `src/services/claude.rs`의 `read_output_file_until_result()`는 Claude-specific `process_stream_line()` wiring만 담당하는 얇은 wrapper로 바꿨습니다.
- `SessionProbe`, `tmux_capture_indicates_ready_for_input()`, `tmux_session_ready_for_input()`도 `src/services/provider.rs`로 옮기고, Codex/Discord recovery/runtime이 provider 경로를 직접 쓰도록 바꿨습니다.
- provider 레벨에서 `terminal line 읽기`, `파일 생성 전 취소` 테스트를 직접 추가해 polling helper 자체도 검증했습니다.

## 변경 파일
- `src/services/gemini.rs`
- `src/services/provider.rs`
- `src/services/claude.rs`
- `src/services/codex.rs`
- `src/services/discord/turn_bridge.rs`
- `src/services/discord/mod.rs`
- `src/services/discord/recovery.rs`
- `src/services/discord/commands/control.rs`
- `src/services/discord/commands/skill.rs`
- `src/runtime.rs`

## 검증
- `cargo fmt --all`
- `cargo test services::provider::tests:: --package agentdesk`
- `cargo test services::gemini::tests:: --package agentdesk`
- `cargo test services::claude::tests:: --package agentdesk`
- `cargo test services::codex::tests:: --package agentdesk`
- `cargo test services::discord::turn_bridge::tests:: --package agentdesk`
- `cargo check --all-targets`
- `cargo test --package agentdesk`
- `cargo test --package agentdesk --test e2e smoke_test::smoke_test_full_lifecycle -- --nocapture`
- `cargo run -- doctor --json`
- raw `gemini` smoke (`stream-json`, `--resume latest`)