### PR TITLE
chore: separate credential sync from #218 scope (#253)

### DIFF
--- a/scripts/deploy-dev.sh
+++ b/scripts/deploy-dev.sh
@@ -51,6 +51,82 @@ _tail_for_summary() {
     tail -n 12 "$log_path" 2>/dev/null || true
 }
 
+# ── Credential Sync ──────────────────────────────────────────────────
+# Dev and release runtimes share a single credential directory so that
+# bot tokens, OAuth secrets, etc. stay in sync across environments.
+#
+# Source-of-truth resolution chain (_resolve_shared_credential_dir):
+#   1. $AGENTDESK_SHARED_CREDENTIAL_DIR env var  (explicit override)
+#   2. Release credential symlink target          (~/.adk/release/credential -> …)
+#   3. Hardcoded fallback                         (~/ObsidianVault/…/adk-config/credential)
+#
+# _sync_dev_credentials creates (or updates) a symlink at
+# ~/.adk/dev/credential -> <shared dir>, so every dev deploy
+# guarantees the dev bot uses the same credentials as release.
+#
+# Why here: the sync is idempotent and fast, consistent with the
+# existing policy sync (step 3.7) and dashboard symlink (step 3.6).
+#
+# Release credential is manually maintained (symlink created once by
+# the operator). deploy.sh does NOT auto-sync credentials.
+# ─────────────────────────────────────────────────────────────────────
+_resolve_shared_credential_dir() {
+    local configured="${AGENTDESK_SHARED_CREDENTIAL_DIR:-}"
+    if [ -n "$configured" ] && [ -d "$configured" ]; then
+        printf '%s\n' "$configured"
+        return 0
+    fi
+
+    local release_credential="$HOME/.adk/release/credential"
+    if [ -L "$release_credential" ]; then
+        local target
+        target=$(readlink "$release_credential" 2>/dev/null || true)
+        if [ -n "$target" ]; then
+            # Resolve relative symlinks against the symlink's parent directory
+            if [[ "$target" != /* ]]; then
+                target="$(cd "$(dirname "$release_credential")" && cd "$(dirname "$target")" && pwd)/$(basename "$target")"
+            fi
+            if [ -d "$target" ]; then
+                printf '%s\n' "$target"
+                return 0
+            fi
+        fi
+    fi
+
+    local fallback="$HOME/ObsidianVault/RemoteVault/adk-config/credential"
+    if [ -d "$fallback" ]; then
+        printf '%s\n' "$fallback"
+        return 0
+    fi
+
+    return 1
+}
+
+_sync_dev_credentials() {
+    local shared_credential_dir
+    shared_credential_dir=$(_resolve_shared_credential_dir) || {
+        echo "▸ Shared credential dir not found; leaving dev credential as-is"
+        return 0
+    }
+
+    local dev_credential_dir="$ADK_DEV/credential"
+    if [ -L "$dev_credential_dir" ] && [ "$(readlink "$dev_credential_dir" 2>/dev/null || true)" = "$shared_credential_dir" ]; then
+        echo "▸ Dev credential already linked to shared credential"
+        return 0
+    fi
+
+    if [ -e "$dev_credential_dir" ] && [ ! -L "$dev_credential_dir" ]; then
+        local backup_dir="${dev_credential_dir}.bak.$(date '+%Y%m%d-%H%M%S')"
+        mv "$dev_credential_dir" "$backup_dir"
+        echo "▸ Backed up stale dev credential dir to $backup_dir"
+    else
+        rm -f "$dev_credential_dir"
+    fi
+
+    ln -sfn "$shared_credential_dir" "$dev_credential_dir"
+    echo "▸ Linked dev credential -> $shared_credential_dir"
+}
+
 _finalize_detached_helper() {
     local status="${1:-0}"
     [ "$DEV_DEPLOY_DETACHED_CHILD" = "1" ] || return 0
@@ -113,6 +189,7 @@ export AGENTDESK_REPO_DIR=$(printf '%q' "$REPO")
 export AGENTDESK_DEPLOY_DEV_DETACHED_CHILD=1
 export AGENTDESK_DEPLOY_DEV_LOG_PATH=$(printf '%q' "$log_path")
 export AGENTDESK_DEPLOY_DEV_TEST_MODE=$(printf '%q' "$DEV_DEPLOY_TEST_MODE")
+${AGENTDESK_SHARED_CREDENTIAL_DIR:+export AGENTDESK_SHARED_CREDENTIAL_DIR=$(printf '%q' "$AGENTDESK_SHARED_CREDENTIAL_DIR")}
 cd $(printf '%q' "$REPO")
 exec $(printf '%q' "$SCRIPT_DIR/deploy-dev.sh")${quoted_args}
 EOF
@@ -197,7 +274,11 @@ echo "▸ Syncing policies..."
 mkdir -p "$DEV_POLICY_DIR"
 rsync -a --delete "$REPO/policies/" "$DEV_POLICY_DIR/"
 
-# 3.8. Ensure the user-facing CLI wrapper is reachable via PATH.
+# 3.8. Keep dev bot credentials aligned with the shared runtime credential.
+echo "▸ Syncing credentials..."
+_sync_dev_credentials
+
+# 3.9. Ensure the user-facing CLI wrapper is reachable via PATH.
 echo "▸ Ensuring global agentdesk CLI..."
 "$SCRIPT_DIR/ensure-agentdesk-cli.sh"
 

--- a/scripts/deploy-dev.sh
+++ b/scripts/deploy-dev.sh
@@ -116,7 +116,8 @@ _sync_dev_credentials() {
     fi
 
     if [ -e "$dev_credential_dir" ] && [ ! -L "$dev_credential_dir" ]; then
-        local backup_dir="${dev_credential_dir}.bak.$(date '+%Y%m%d-%H%M%S')"
+        local backup_dir
+        backup_dir="${dev_credential_dir}.bak.$(date '+%Y%m%d-%H%M%S')"
         mv "$dev_credential_dir" "$backup_dir"
         echo "▸ Backed up stale dev credential dir to $backup_dir"
     else

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -148,27 +148,138 @@ pub fn cancel_dispatch_and_reset_auto_queue_on_conn(
     Ok(cancelled)
 }
 
-/// Core dispatch creation: DB operations only, no hooks fired.
-///
-/// - Inserts a record into `task_dispatches`
-/// - Updates `kanban_cards.latest_dispatch_id` and sets status to "requested" (non-review)
-/// - Returns `(dispatch_id, old_card_status)`
-///
-/// Caller is responsible for firing hooks after this returns.
-///
-/// Returns `(dispatch_id, old_card_status, reused)`.
-/// When `reused` is true the returned ID belongs to an existing pending/dispatched
-/// dispatch of the same type — no new row was inserted (#173 dedup).
-pub fn create_dispatch_core(
+fn dispatch_uses_alt_channel(dispatch_type: &str) -> bool {
+    matches!(dispatch_type, "review" | "e2e-test")
+}
+
+fn resolve_dispatch_channel_id(channel: &str) -> Option<u64> {
+    channel
+        .parse::<u64>()
+        .ok()
+        .or_else(|| crate::server::routes::dispatches::resolve_channel_alias_pub(channel))
+}
+
+fn load_existing_thread_for_channel(
+    conn: &rusqlite::Connection,
+    card_id: &str,
+    channel_id: u64,
+) -> Result<Option<String>> {
+    let map_json: Option<String> = conn
+        .query_row(
+            "SELECT channel_thread_map FROM kanban_cards WHERE id = ?1",
+            [card_id],
+            |row| row.get(0),
+        )
+        .ok()
+        .flatten();
+
+    if let Some(json_str) = map_json.as_deref() {
+        if !json_str.is_empty() && json_str != "{}" {
+            let map: serde_json::Map<String, serde_json::Value> = serde_json::from_str(json_str)
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "Cannot create dispatch for card {}: invalid channel_thread_map JSON: {}",
+                        card_id,
+                        e
+                    )
+                })?;
+
+            if let Some(value) = map.get(&channel_id.to_string()) {
+                let thread_id = value.as_str().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Cannot create dispatch for card {}: non-string thread mapping for channel {}",
+                        card_id,
+                        channel_id
+                    )
+                })?;
+                return Ok(Some(thread_id.to_string()));
+            }
+            return Ok(None);
+        }
+    }
+
+    Ok(conn
+        .query_row(
+            "SELECT active_thread_id FROM kanban_cards WHERE id = ?1 AND active_thread_id IS NOT NULL",
+            [card_id],
+            |row| row.get(0),
+        )
+        .ok())
+}
+
+fn validate_dispatch_target_on_conn(
+    conn: &rusqlite::Connection,
+    card_id: &str,
+    to_agent_id: &str,
+    dispatch_type: &str,
+) -> Result<()> {
+    let channel_column = if dispatch_uses_alt_channel(dispatch_type) {
+        "discord_channel_alt"
+    } else {
+        "discord_channel_id"
+    };
+    let channel_role = if dispatch_uses_alt_channel(dispatch_type) {
+        "alternate"
+    } else {
+        "primary"
+    };
+
+    let channel_value: Option<String> = conn
+        .query_row(
+            &format!("SELECT {channel_column} FROM agents WHERE id = ?1"),
+            [to_agent_id],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .ok()
+        .flatten()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    let channel_value = channel_value.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Cannot create {} dispatch: agent '{}' has no {} discord channel (card {})",
+            dispatch_type,
+            to_agent_id,
+            channel_role,
+            card_id
+        )
+    })?;
+
+    let channel_id = resolve_dispatch_channel_id(&channel_value).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Cannot create {} dispatch: agent '{}' has invalid {} discord channel '{}' (card {})",
+            dispatch_type,
+            to_agent_id,
+            channel_role,
+            channel_value,
+            card_id
+        )
+    })?;
+
+    if let Some(thread_id) = load_existing_thread_for_channel(conn, card_id, channel_id)? {
+        if thread_id.parse::<u64>().is_err() {
+            return Err(anyhow::anyhow!(
+                "Cannot create {} dispatch: card '{}' has invalid thread '{}' for channel {}",
+                dispatch_type,
+                card_id,
+                thread_id,
+                channel_id
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn create_dispatch_core_internal(
     db: &Db,
+    dispatch_id: &str,
     kanban_card_id: &str,
     to_agent_id: &str,
     dispatch_type: &str,
     title: &str,
     context: &serde_json::Value,
 ) -> Result<(String, String, bool)> {
-    let dispatch_id = uuid::Uuid::new_v4().to_string();
-
     let context_str = if dispatch_type == "review" {
         build_review_context(db, kanban_card_id, to_agent_id, context)?
     } else {
@@ -190,8 +301,8 @@ pub fn create_dispatch_core(
         )
         .map_err(|e| anyhow::anyhow!("Card not found: {e}"))?;
 
-    // #245: Guard — reject dispatches to non-existent agents.
-    // Catches phantom agent IDs (e.g. "project-agentdesk-cdx") before DB INSERT.
+    // Guard: reject dispatches to non-existent agents or invalid Discord routing
+    // before any row is created.
     let agent_exists: bool = conn
         .query_row("SELECT 1 FROM agents WHERE id = ?1", [to_agent_id], |_| {
             Ok(())
@@ -205,6 +316,7 @@ pub fn create_dispatch_core(
             kanban_card_id
         ));
     }
+    validate_dispatch_target_on_conn(&conn, kanban_card_id, to_agent_id, dispatch_type)?;
 
     // Guard: prevent ALL dispatches for terminal cards (pipeline-driven).
     crate::pipeline::ensure_loaded();
@@ -220,9 +332,8 @@ pub fn create_dispatch_core(
         ));
     }
 
-    // #173: Dedup — if same card already has a pending/dispatched dispatch of the SAME type,
-    // return the existing dispatch_id idempotently instead of creating a duplicate.
-    // review-decision handles its own dedup below (#116: cancel previous then insert).
+    // Dedup on the canonical path after validation so malformed targets do not
+    // silently reuse an existing dispatch.
     if dispatch_type != "review-decision" {
         let existing_id: Option<String> = conn
             .query_row(
@@ -248,8 +359,6 @@ pub fn create_dispatch_core(
         || dispatch_type == "review-decision"
         || dispatch_type == "rework";
 
-    // #116: Cancel any existing pending review-decision for this card before creating a new one.
-    // Enforces the invariant: at most 1 pending/dispatched review-decision per card.
     if dispatch_type == "review-decision" {
         let mut stmt = conn.prepare(
             "SELECT id FROM task_dispatches \
@@ -278,14 +387,11 @@ pub fn create_dispatch_core(
         }
     }
 
-    // #155: Dispatch INSERT + card-state intents in a single transaction.
-    // The dispatch row and card-state update must be atomic — if intents fail,
-    // the dispatch row must also be rolled back to prevent orphaned dispatches.
     apply_dispatch_attached_intents(
         &conn,
         kanban_card_id,
         to_agent_id,
-        &dispatch_id,
+        dispatch_id,
         dispatch_type,
         is_review_type,
         &old_status,
@@ -294,7 +400,38 @@ pub fn create_dispatch_core(
         &context_str,
     )?;
 
-    Ok((dispatch_id, old_status, false))
+    Ok((dispatch_id.to_string(), old_status, false))
+}
+
+/// Core dispatch creation: DB operations only, no hooks fired.
+///
+/// - Inserts a record into `task_dispatches`
+/// - Updates `kanban_cards.latest_dispatch_id` and sets status to "requested" (non-review)
+/// - Returns `(dispatch_id, old_card_status)`
+///
+/// Caller is responsible for firing hooks after this returns.
+///
+/// Returns `(dispatch_id, old_card_status, reused)`.
+/// When `reused` is true the returned ID belongs to an existing pending/dispatched
+/// dispatch of the same type — no new row was inserted (#173 dedup).
+pub fn create_dispatch_core(
+    db: &Db,
+    kanban_card_id: &str,
+    to_agent_id: &str,
+    dispatch_type: &str,
+    title: &str,
+    context: &serde_json::Value,
+) -> Result<(String, String, bool)> {
+    let dispatch_id = uuid::Uuid::new_v4().to_string();
+    create_dispatch_core_internal(
+        db,
+        &dispatch_id,
+        kanban_card_id,
+        to_agent_id,
+        dispatch_type,
+        title,
+        context,
+    )
 }
 
 /// Like `create_dispatch_core` but uses a pre-assigned dispatch ID (#121 intent model).
@@ -310,121 +447,15 @@ pub fn create_dispatch_core_with_id(
     title: &str,
     context: &serde_json::Value,
 ) -> Result<(String, String, bool)> {
-    let context_str = if dispatch_type == "review" {
-        build_review_context(db, kanban_card_id, to_agent_id, context)?
-    } else {
-        serde_json::to_string(context)?
-    };
-
-    let conn = db
-        .separate_conn()
-        .map_err(|e| anyhow::anyhow!("DB conn error: {e}"))?;
-
-    // #245: Guard — reject dispatches to non-existent agents.
-    let agent_exists: bool = conn
-        .query_row("SELECT 1 FROM agents WHERE id = ?1", [to_agent_id], |_| {
-            Ok(())
-        })
-        .is_ok();
-    if !agent_exists {
-        return Err(anyhow::anyhow!(
-            "Cannot create {} dispatch: agent '{}' not found (card {})",
-            dispatch_type,
-            to_agent_id,
-            kanban_card_id
-        ));
-    }
-
-    let (old_status, card_repo_id, card_agent_id): (String, Option<String>, Option<String>) = conn
-        .query_row(
-            "SELECT status, repo_id, assigned_agent_id FROM kanban_cards WHERE id = ?1",
-            [kanban_card_id],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-        )
-        .map_err(|e| anyhow::anyhow!("Card not found: {e}"))?;
-
-    crate::pipeline::ensure_loaded();
-    let effective =
-        crate::pipeline::resolve_for_card(&conn, card_repo_id.as_deref(), card_agent_id.as_deref());
-    let is_terminal = effective.is_terminal(&old_status);
-    if is_terminal {
-        return Err(anyhow::anyhow!(
-            "Cannot create {} dispatch for terminal card {} (status: {}) — cannot revert terminal card",
-            dispatch_type,
-            kanban_card_id,
-            old_status
-        ));
-    }
-
-    // #173: Dedup guard (same logic as create_dispatch_core).
-    if dispatch_type != "review-decision" {
-        let existing_id: Option<String> = conn
-            .query_row(
-                "SELECT id FROM task_dispatches \
-                 WHERE kanban_card_id = ?1 AND dispatch_type = ?2 \
-                 AND status IN ('pending', 'dispatched') LIMIT 1",
-                rusqlite::params![kanban_card_id, dispatch_type],
-                |row| row.get(0),
-            )
-            .ok();
-        if let Some(eid) = existing_id {
-            tracing::info!(
-                "DEDUP: reusing existing dispatch {} for card {} type {}",
-                eid,
-                kanban_card_id,
-                dispatch_type
-            );
-            return Ok((eid, old_status, true));
-        }
-    }
-
-    let is_review_type = dispatch_type == "review"
-        || dispatch_type == "review-decision"
-        || dispatch_type == "rework";
-
-    if dispatch_type == "review-decision" {
-        let mut stmt = conn.prepare(
-            "SELECT id FROM task_dispatches \
-             WHERE kanban_card_id = ?1 AND dispatch_type = 'review-decision' \
-             AND status IN ('pending', 'dispatched')",
-        )?;
-        let stale_ids: Vec<String> = stmt
-            .query_map([kanban_card_id], |row| row.get::<_, String>(0))?
-            .filter_map(|r| r.ok())
-            .collect();
-        drop(stmt);
-        let mut cancelled = 0;
-        for stale_id in &stale_ids {
-            cancelled += cancel_dispatch_and_reset_auto_queue_on_conn(
-                &conn,
-                stale_id,
-                Some("superseded_by_new_review_decision"),
-            )?;
-        }
-        if cancelled > 0 {
-            tracing::info!(
-                "[dispatch] Cancelled {} stale review-decision(s) for card {} before creating new one",
-                cancelled,
-                kanban_card_id
-            );
-        }
-    }
-
-    // #155: Dispatch INSERT + card-state intents in a single transaction
-    apply_dispatch_attached_intents(
-        &conn,
+    create_dispatch_core_internal(
+        db,
+        dispatch_id,
         kanban_card_id,
         to_agent_id,
-        dispatch_id,
         dispatch_type,
-        is_review_type,
-        &old_status,
-        &effective,
         title,
-        &context_str,
-    )?;
-
-    Ok((dispatch_id.to_string(), old_status, false))
+        context,
+    )
 }
 
 /// Create a new dispatch for a kanban card.
@@ -728,15 +759,6 @@ fn complete_dispatch_inner(
         })
         .unwrap_or_default();
 
-    // Capture max rowid before hooks fire — any dispatches created by hooks
-    // (JS agentdesk.dispatch.create()) will have a higher rowid.
-    let pre_hook_max_rowid: i64 = conn
-        .query_row(
-            "SELECT COALESCE(MAX(rowid), 0) FROM task_dispatches",
-            [],
-            |row| row.get(0),
-        )
-        .unwrap_or(0);
     drop(conn);
 
     // Fire event hooks for dispatch completion (#134 — pipeline-defined events)
@@ -755,12 +777,6 @@ fn complete_dispatch_inner(
     // After OnDispatchCompleted, policies may have queued follow-up transitions
     // and dispatch intents (OnReviewEnter, retry dispatches, etc.).
     crate::kanban::drain_hook_side_effects(db, engine);
-
-    // After all hooks and transitions drained, check for dispatches created by
-    // OnDispatchCompleted hooks (e.g. pipeline.js, review-automation.js, timeouts.js)
-    // that were NOT covered by fire_transition_hooks' notify_new_dispatches_after_hooks.
-    // These are dispatches created outside any card transition context.
-    notify_hook_created_dispatches(db, pre_hook_max_rowid);
 
     // #139/#220: Safety net — if card transitioned to review but OnReviewEnter
     // failed to create a review dispatch (engine lock contention causing
@@ -807,53 +823,10 @@ fn complete_dispatch_inner(
             );
             let _ = engine.fire_hook_by_name_blocking("OnReviewEnter", json!({ "card_id": cid }));
             crate::kanban::drain_hook_side_effects(db, engine);
-            notify_hook_created_dispatches(db, pre_hook_max_rowid);
         }
     }
 
     Ok(dispatch)
-}
-
-/// Backfill missing notify outbox rows for pending dispatches created after `pre_hook_max_rowid`.
-/// This is a fallback for legacy/manual dispatch creation paths that may still
-/// bypass the authoritative transaction helper.
-pub(crate) fn notify_hook_created_dispatches(db: &Db, pre_hook_max_rowid: i64) {
-    let dispatches: Vec<(String, String, String, String)> = db
-        .separate_conn()
-        .ok()
-        .map(|conn| {
-            let mut stmt = conn
-                .prepare(
-                    "SELECT td.id, td.to_agent_id, td.kanban_card_id, kc.title \
-                     FROM task_dispatches td \
-                     JOIN kanban_cards kc ON td.kanban_card_id = kc.id \
-                     WHERE td.status = 'pending' \
-                       AND td.rowid > ?1 \
-                       AND NOT EXISTS (SELECT 1 FROM kv_meta WHERE key = 'dispatch_notified:' || td.id)",
-                )
-                .ok();
-            stmt.as_mut()
-                .and_then(|s| {
-                    s.query_map(rusqlite::params![pre_hook_max_rowid], |row| {
-                        Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
-                    })
-                    .ok()
-                })
-                .map(|rows| rows.filter_map(|r| r.ok()).collect())
-                .unwrap_or_default()
-        })
-        .unwrap_or_default();
-
-    if dispatches.is_empty() {
-        return;
-    }
-
-    if let Ok(conn) = db.separate_conn() {
-        for (dispatch_id, agent_id, card_id, title) in dispatches {
-            ensure_dispatch_notify_outbox_on_conn(&conn, &dispatch_id, &agent_id, &card_id, &title)
-                .ok();
-        }
-    }
 }
 
 /// Read a single dispatch row as JSON.
@@ -1057,19 +1030,19 @@ fn provider_from_channel_suffix(channel: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Arc, Mutex};
 
     fn test_db() -> Db {
         let conn = rusqlite::Connection::open_in_memory().unwrap();
         conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
         crate::db::schema::migrate(&conn).unwrap();
         let db = crate::db::wrap_conn(conn);
-        // #245: Seed common test agents so agent-exists guard passes
+        // Seed common test agents with valid primary/alternate channels so the
+        // canonical dispatch target validation can run in unit tests.
         {
             let c = db.separate_conn().unwrap();
             c.execute_batch(
-                "INSERT OR IGNORE INTO agents (id, name, discord_channel_id) VALUES ('agent-1', 'Agent 1', 'ch-1');
-                 INSERT OR IGNORE INTO agents (id, name, discord_channel_id) VALUES ('agent-2', 'Agent 2', 'ch-2');"
+                "INSERT OR IGNORE INTO agents (id, name, discord_channel_id, discord_channel_alt) VALUES ('agent-1', 'Agent 1', '111', '222');
+                 INSERT OR IGNORE INTO agents (id, name, discord_channel_id, discord_channel_alt) VALUES ('agent-2', 'Agent 2', '333', '444');"
             ).unwrap();
         }
         db
@@ -1085,16 +1058,6 @@ mod tests {
         conn.execute(
             "INSERT INTO kanban_cards (id, title, status, created_at, updated_at) VALUES (?1, 'Test Card', ?2, datetime('now'), datetime('now'))",
             rusqlite::params![card_id, status],
-        )
-        .unwrap();
-    }
-
-    /// Seed a test agent in the DB so dispatch creation agent-exists guard passes.
-    fn seed_agent(db: &Db, agent_id: &str) {
-        let conn = db.separate_conn().unwrap();
-        conn.execute(
-            "INSERT OR IGNORE INTO agents (id, name, discord_channel_id) VALUES (?1, ?1, ?1)",
-            [agent_id],
         )
         .unwrap();
     }
@@ -1459,6 +1422,112 @@ mod tests {
     }
 
     #[test]
+    fn create_dispatch_core_rejects_missing_primary_channel_before_insert() {
+        let db = test_db();
+        seed_card(&db, "card-no-channel", "ready");
+        let conn = db.separate_conn().unwrap();
+        conn.execute(
+            "UPDATE agents SET discord_channel_id = NULL WHERE id = 'agent-1'",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let result = create_dispatch_core(
+            &db,
+            "card-no-channel",
+            "agent-1",
+            "implementation",
+            "Should fail",
+            &json!({}),
+        );
+        let err = format!("{}", result.unwrap_err());
+        assert!(err.contains("no primary discord channel"));
+
+        let conn = db.separate_conn().unwrap();
+        let dispatch_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM task_dispatches WHERE kanban_card_id = 'card-no-channel'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(dispatch_count, 0, "failed validation must not persist rows");
+    }
+
+    #[test]
+    fn create_dispatch_core_with_id_rejects_invalid_channel_alias_before_insert() {
+        let db = test_db();
+        seed_card(&db, "card-bad-channel", "ready");
+        let conn = db.separate_conn().unwrap();
+        conn.execute(
+            "UPDATE agents SET discord_channel_id = 'not-a-channel' WHERE id = 'agent-1'",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let result = create_dispatch_core_with_id(
+            &db,
+            "dispatch-bad-channel",
+            "card-bad-channel",
+            "agent-1",
+            "implementation",
+            "Should fail",
+            &json!({}),
+        );
+        let err = format!("{}", result.unwrap_err());
+        assert!(err.contains("invalid primary discord channel"));
+
+        let conn = db.separate_conn().unwrap();
+        let dispatch_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM task_dispatches WHERE id = 'dispatch-bad-channel'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            dispatch_count, 0,
+            "invalid channels must fail before INSERT"
+        );
+    }
+
+    #[test]
+    fn create_dispatch_core_rejects_invalid_existing_thread_before_insert() {
+        let db = test_db();
+        seed_card(&db, "card-bad-thread", "ready");
+        let conn = db.separate_conn().unwrap();
+        conn.execute(
+            "UPDATE kanban_cards SET active_thread_id = 'thread-not-numeric' WHERE id = 'card-bad-thread'",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let result = create_dispatch_core(
+            &db,
+            "card-bad-thread",
+            "agent-1",
+            "implementation",
+            "Should fail",
+            &json!({}),
+        );
+        let err = format!("{}", result.unwrap_err());
+        assert!(err.contains("invalid thread"));
+
+        let conn = db.separate_conn().unwrap();
+        let dispatch_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM task_dispatches WHERE kanban_card_id = 'card-bad-thread'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(dispatch_count, 0, "invalid thread must fail before INSERT");
+    }
+
+    #[test]
     fn concurrent_dispatches_for_different_cards_have_distinct_ids() {
         // Regression: concurrent dispatches from different cards must not share
         // dispatch IDs or card state — each must be independently routable.
@@ -1737,35 +1806,6 @@ mod tests {
             count_notify_outbox(&conn, &id1),
             1,
             "reused dispatch must not create a second notify outbox row"
-        );
-    }
-
-    #[test]
-    fn notify_hook_created_dispatches_backfills_missing_outbox_idempotently() {
-        let db = test_db();
-        let conn = db.separate_conn().unwrap();
-        conn.execute(
-            "INSERT INTO kanban_cards (id, title, status, created_at, updated_at) \
-             VALUES ('card-backfill', 'Backfill Card', 'requested', datetime('now'), datetime('now'))",
-            [],
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO task_dispatches (id, kanban_card_id, to_agent_id, dispatch_type, status, title, created_at, updated_at) \
-             VALUES ('dispatch-backfill', 'card-backfill', 'agent-1', 'implementation', 'pending', 'Backfill Title', datetime('now'), datetime('now'))",
-            [],
-        )
-        .unwrap();
-        drop(conn);
-
-        notify_hook_created_dispatches(&db, 0);
-        notify_hook_created_dispatches(&db, 0);
-
-        let conn = db.separate_conn().unwrap();
-        assert_eq!(
-            count_notify_outbox(&conn, "dispatch-backfill"),
-            1,
-            "fallback backfill must create at most one notify outbox row"
         );
     }
 }

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -487,10 +487,39 @@ pub fn create_dispatch(
     Ok(dispatch)
 }
 
+/// Ensure a durable notify outbox row exists for a dispatch.
+///
+/// Used both by the authoritative dispatch creation transaction and by
+/// fallback/backfill paths that must avoid duplicate notify entries.
+pub(crate) fn ensure_dispatch_notify_outbox_on_conn(
+    conn: &rusqlite::Connection,
+    dispatch_id: &str,
+    agent_id: &str,
+    card_id: &str,
+    title: &str,
+) -> rusqlite::Result<bool> {
+    let exists: bool = conn.query_row(
+        "SELECT COUNT(*) > 0 FROM dispatch_outbox WHERE dispatch_id = ?1 AND action = 'notify'",
+        [dispatch_id],
+        |row| row.get(0),
+    )?;
+    if exists {
+        return Ok(false);
+    }
+
+    conn.execute(
+        "INSERT INTO dispatch_outbox (dispatch_id, action, agent_id, card_id, title) \
+         VALUES (?1, 'notify', ?2, ?3, ?4)",
+        rusqlite::params![dispatch_id, agent_id, card_id, title],
+    )?;
+    Ok(true)
+}
+
 /// #155: Insert dispatch row + apply DispatchAttached transition intents atomically.
 ///
 /// Both the `task_dispatches` INSERT and the card-state intents execute inside
 /// a single transaction so that reducer failure rolls back the dispatch row too.
+/// #249 also inserts the notify outbox row inside the same transaction.
 fn apply_dispatch_attached_intents(
     conn: &rusqlite::Connection,
     card_id: &str,
@@ -558,6 +587,7 @@ fn apply_dispatch_attached_intents(
             }
             return Err(e.into());
         }
+        ensure_dispatch_notify_outbox_on_conn(conn, dispatch_id, to_agent_id, card_id, title)?;
         for intent in &decision.intents {
             transition::execute_intent_on_conn(conn, intent)?;
         }
@@ -784,9 +814,9 @@ fn complete_dispatch_inner(
     Ok(dispatch)
 }
 
-/// Send Discord notifications for any pending dispatches created after `pre_hook_max_rowid`.
-/// Uses the `dispatch_notified` dedup guard in `send_dispatch_to_discord` to avoid
-/// double-notifying dispatches already handled by `notify_new_dispatches_after_hooks`.
+/// Backfill missing notify outbox rows for pending dispatches created after `pre_hook_max_rowid`.
+/// This is a fallback for legacy/manual dispatch creation paths that may still
+/// bypass the authoritative transaction helper.
 pub(crate) fn notify_hook_created_dispatches(db: &Db, pre_hook_max_rowid: i64) {
     let dispatches: Vec<(String, String, String, String)> = db
         .separate_conn()
@@ -818,15 +848,11 @@ pub(crate) fn notify_hook_created_dispatches(db: &Db, pre_hook_max_rowid: i64) {
         return;
     }
 
-    // #144: Queue via dispatch outbox instead of tokio::spawn.
-    for (dispatch_id, agent_id, card_id, title) in dispatches {
-        crate::server::routes::dispatches::queue_dispatch_notify(
-            db,
-            &dispatch_id,
-            &agent_id,
-            &card_id,
-            &title,
-        );
+    if let Ok(conn) = db.separate_conn() {
+        for (dispatch_id, agent_id, card_id, title) in dispatches {
+            ensure_dispatch_notify_outbox_on_conn(&conn, &dispatch_id, &agent_id, &card_id, &title)
+                .ok();
+        }
     }
 }
 
@@ -1071,6 +1097,15 @@ mod tests {
             [agent_id],
         )
         .unwrap();
+    }
+
+    fn count_notify_outbox(conn: &rusqlite::Connection, dispatch_id: &str) -> i64 {
+        conn.query_row(
+            "SELECT COUNT(*) FROM dispatch_outbox WHERE dispatch_id = ?1 AND action = 'notify'",
+            [dispatch_id],
+            |row| row.get(0),
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1357,6 +1392,11 @@ mod tests {
         let dispatch = query_dispatch_row(&conn, &dispatch_id).unwrap();
         assert_eq!(dispatch["status"], "pending");
         assert_eq!(dispatch["kanban_card_id"], "card-core");
+        assert_eq!(
+            count_notify_outbox(&conn, &dispatch_id),
+            1,
+            "core creation must atomically enqueue exactly one notify outbox row"
+        );
         drop(conn);
 
         // create_dispatch delegates to core — verify same invariants
@@ -1372,6 +1412,34 @@ mod tests {
         )
         .unwrap();
         assert_eq!(full_dispatch["status"], "pending");
+    }
+
+    #[test]
+    fn create_dispatch_core_with_id_atomically_inserts_notify_outbox() {
+        let db = test_db();
+        seed_card(&db, "card-core-id", "ready");
+
+        let (dispatch_id, old_status, reused) = create_dispatch_core_with_id(
+            &db,
+            "dispatch-core-id",
+            "card-core-id",
+            "agent-1",
+            "implementation",
+            "Core with id",
+            &json!({}),
+        )
+        .unwrap();
+
+        assert_eq!(dispatch_id, "dispatch-core-id");
+        assert_eq!(old_status, "ready");
+        assert!(!reused);
+
+        let conn = db.separate_conn().unwrap();
+        assert_eq!(
+            count_notify_outbox(&conn, "dispatch-core-id"),
+            1,
+            "pre-assigned dispatch creation must also enqueue notify outbox inside the transaction"
+        );
     }
 
     #[test]
@@ -1663,5 +1731,41 @@ mod tests {
         .unwrap();
         assert!(reused2, "duplicate must be flagged as reused");
         assert_eq!(id1, id2);
+
+        let conn = db.separate_conn().unwrap();
+        assert_eq!(
+            count_notify_outbox(&conn, &id1),
+            1,
+            "reused dispatch must not create a second notify outbox row"
+        );
+    }
+
+    #[test]
+    fn notify_hook_created_dispatches_backfills_missing_outbox_idempotently() {
+        let db = test_db();
+        let conn = db.separate_conn().unwrap();
+        conn.execute(
+            "INSERT INTO kanban_cards (id, title, status, created_at, updated_at) \
+             VALUES ('card-backfill', 'Backfill Card', 'requested', datetime('now'), datetime('now'))",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO task_dispatches (id, kanban_card_id, to_agent_id, dispatch_type, status, title, created_at, updated_at) \
+             VALUES ('dispatch-backfill', 'card-backfill', 'agent-1', 'implementation', 'pending', 'Backfill Title', datetime('now'), datetime('now'))",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        notify_hook_created_dispatches(&db, 0);
+        notify_hook_created_dispatches(&db, 0);
+
+        let conn = db.separate_conn().unwrap();
+        assert_eq!(
+            count_notify_outbox(&conn, "dispatch-backfill"),
+            1,
+            "fallback backfill must create at most one notify outbox row"
+        );
     }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -565,8 +565,6 @@ impl PolicyEngine {
     /// Calls `intent::execute_intents` to apply them and returns the result.
     /// Transitions in the result should be fed into `fire_transition_hooks`.
     ///
-    /// #248: Also collects dispatches created synchronously by dispatch.create()
-    /// from the `__createdDispatches` outbox (populated by dispatch_create_sync).
     pub fn drain_pending_intents(&self) -> intent::IntentExecutionResult {
         let inner = match self.inner.lock() {
             Ok(g) => g,
@@ -580,35 +578,19 @@ impl PolicyEngine {
                 };
             }
         };
-        // #248: Drain both pending intents AND created dispatches outbox in one JS eval
-        let (json_str, outbox_str): (String, String) = inner.context.with(|ctx| {
+        let json_str: String = inner.context.with(|ctx| {
             let code = r#"
                 var arr = agentdesk.__pendingIntents || [];
                 agentdesk.__pendingIntents = [];
-                var outbox = agentdesk.__createdDispatches || [];
-                agentdesk.__createdDispatches = [];
-                JSON.stringify([arr, outbox]);
+                JSON.stringify(arr);
             "#;
             let result: rquickjs::Result<String> = ctx.eval(code);
             match result {
-                Ok(json) => {
-                    // Parse the two-element array
-                    let parsed: serde_json::Value =
-                        serde_json::from_str(&json).unwrap_or(serde_json::json!([[], []]));
-                    let intents = parsed
-                        .get(0)
-                        .map(|v| v.to_string())
-                        .unwrap_or_else(|| "[]".to_string());
-                    let outbox = parsed
-                        .get(1)
-                        .map(|v| v.to_string())
-                        .unwrap_or_else(|| "[]".to_string());
-                    (intents, outbox)
-                }
+                Ok(json) => json,
                 Err(e) => {
                     let ts = chrono::Local::now().format("%H:%M:%S");
                     println!("  [{ts}] ⚠ drain_pending_intents: JS eval error: {e}");
-                    ("[]".to_string(), "[]".to_string())
+                    "[]".to_string()
                 }
             }
         });
@@ -617,7 +599,7 @@ impl PolicyEngine {
         drop(inner);
 
         let intents: Vec<intent::Intent> = serde_json::from_str(&json_str).unwrap_or_default();
-        let mut result = if intents.is_empty() {
+        let result = if intents.is_empty() {
             intent::IntentExecutionResult {
                 transitions: Vec::new(),
                 created_dispatches: Vec::new(),
@@ -627,44 +609,6 @@ impl PolicyEngine {
             intent::execute_intents(&self.db, intents)
         };
 
-        // #248: Collect synchronously created dispatches from outbox
-        let outbox_items: Vec<serde_json::Value> =
-            serde_json::from_str(&outbox_str).unwrap_or_default();
-        for item in outbox_items {
-            let dispatch_id = item
-                .get("dispatch_id")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-            let card_id = item
-                .get("card_id")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-            let agent_id = item
-                .get("agent_id")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-            let dispatch_type = item
-                .get("dispatch_type")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-            let issue_url = item
-                .get("issue_url")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-            if !dispatch_id.is_empty() {
-                result.created_dispatches.push(intent::CreatedDispatch {
-                    dispatch_id,
-                    card_id,
-                    agent_id,
-                    dispatch_type,
-                    issue_url,
-                });
-            }
-        }
         result
     }
 

--- a/src/engine/ops.rs
+++ b/src/engine/ops.rs
@@ -21,7 +21,7 @@ pub fn register_globals(ctx: &Ctx<'_>, db: Db) -> JsResult<()> {
     globals.set("agentdesk", ad)?;
 
     // ── agentdesk.__pendingIntents — intent accumulator for deferred mutations (#121)
-    ctx.eval::<(), _>(r#"agentdesk.__pendingIntents = []; agentdesk.__createdDispatches = [];"#)?;
+    ctx.eval::<(), _>(r#"agentdesk.__pendingIntents = [];"#)?;
 
     // ── agentdesk.__generateId — UUID v4 generation from Rust
     let gen_id = Function::new(ctx.clone(), || -> String {
@@ -486,7 +486,7 @@ fn register_dispatch_ops<'js>(ctx: &Ctx<'js>, db: Db) -> JsResult<()> {
 
     ad.set("dispatch", dispatch_obj)?;
 
-    // JS wrapper — #121: push CreateDispatch intent with pre-assigned ID
+    // JS wrapper — synchronous dispatch creation with Rust-side validation/INSERT
     let _: rquickjs::Value = ctx.eval(
         r#"
         (function() {
@@ -499,11 +499,6 @@ fn register_dispatch_ops<'js>(ctx: &Ctx<'js>, db: Db) -> JsResult<()> {
                 var result = JSON.parse(sync(cardId, agentId, dt, t));
                 if (result.error) throw new Error(result.error);
                 var dispatchId = result.dispatch_id;
-                // #248: Push to outbox for post-hook notification dispatch
-                if (result.outbox && !result.reused) {
-                    agentdesk.__createdDispatches = agentdesk.__createdDispatches || [];
-                    agentdesk.__createdDispatches.push(result.outbox);
-                }
                 return dispatchId;
             };
             var rawFail = agentdesk.dispatch.__mark_failed_raw;
@@ -540,9 +535,9 @@ fn register_dispatch_ops<'js>(ctx: &Ctx<'js>, db: Db) -> JsResult<()> {
     Ok(())
 }
 
-/// #248: Synchronous dispatch creation — validates, inserts into DB immediately,
-/// and returns the dispatch ID. Side effects (kickoff hooks, notifications) are
-/// deferred to the `__createdDispatches` outbox, drained after hook execution.
+/// #248/#249: Synchronous dispatch creation — validates and inserts into DB
+/// immediately. The notify outbox row is now inserted atomically inside
+/// `create_dispatch_core`, so no JS-side outbox buffering is needed.
 fn dispatch_create_sync(
     db: &Db,
     card_id: &str,
@@ -561,9 +556,7 @@ fn dispatch_create_sync(
     ) {
         Ok((dispatch_id, _old_status, reused)) => {
             if reused {
-                return format!(
-                    r#"{{"dispatch_id":"{dispatch_id}","card_id":"{card_id}","agent_id":"{agent_id}","reused":true}}"#
-                );
+                return format!(r#"{{"dispatch_id":"{dispatch_id}","reused":true}}"#);
             }
             // #117/#158: Update card_review_state for review-decision dispatches
             if dispatch_type == "review-decision" {
@@ -577,28 +570,7 @@ fn dispatch_create_sync(
                     .to_string(),
                 );
             }
-            // Get issue URL for Discord notification (used by drain outbox)
-            let issue_url: Option<String> = db.separate_conn().ok().and_then(|conn| {
-                conn.query_row(
-                    "SELECT github_issue_url FROM kanban_cards WHERE id = ?1",
-                    [card_id],
-                    |row| row.get(0),
-                )
-                .ok()
-                .flatten()
-            });
-            // Serialize created dispatch info for outbox collection
-            let outbox_json = serde_json::json!({
-                "dispatch_id": dispatch_id,
-                "card_id": card_id,
-                "agent_id": agent_id,
-                "dispatch_type": dispatch_type,
-                "issue_url": issue_url,
-            });
-            format!(
-                r#"{{"dispatch_id":"{dispatch_id}","card_id":"{card_id}","agent_id":"{agent_id}","outbox":{}}}"#,
-                outbox_json
-            )
+            format!(r#"{{"dispatch_id":"{dispatch_id}"}}"#)
         }
         Err(e) => {
             format!(r#"{{"error":"{}"}}"#, e.to_string().replace('"', "'"))

--- a/src/kanban.rs
+++ b/src/kanban.rs
@@ -452,23 +452,7 @@ pub fn fire_state_hooks(db: &Db, engine: &PolicyEngine, card_id: &str, from: &st
 ///
 /// Used when re-entering the same state (e.g., restarting review from awaiting_dod)
 /// where `fire_state_hooks` would no-op because from == to.
-///
-/// #108: Also detects dispatches created by on_enter hooks (e.g., OnReviewEnter
-/// creating a review dispatch during dispute) and queues Discord notifications.
-/// Without this, callers had to manually re-query the DB to find new dispatches,
-/// which introduced race conditions.
 pub fn fire_enter_hooks(db: &Db, engine: &PolicyEngine, card_id: &str, state: &str) {
-    // Capture pre-hook dispatch ID to detect new dispatches created by hooks (#108)
-    let pre_dispatch_id: Option<String> = db.lock().ok().and_then(|conn| {
-        conn.query_row(
-            "SELECT latest_dispatch_id FROM kanban_cards WHERE id = ?1",
-            [card_id],
-            |row| row.get(0),
-        )
-        .ok()
-        .flatten()
-    });
-
     crate::pipeline::ensure_loaded();
     let effective = db.lock().ok().map(|conn| {
         let repo_id: Option<String> = conn
@@ -503,10 +487,6 @@ pub fn fire_enter_hooks(db: &Db, engine: &PolicyEngine, card_id: &str, state: &s
         }
     }
     drain_hook_side_effects(db, engine);
-
-    // #108: After all hooks, check if new dispatches were created and queue
-    // Discord notifications. Same pattern as fire_transition_hooks.
-    notify_new_dispatches_after_hooks(db, card_id, pre_dispatch_id.as_deref());
 }
 
 /// Fire hooks for a status transition that already happened in the DB.
@@ -520,17 +500,6 @@ pub fn fire_transition_hooks(db: &Db, engine: &PolicyEngine, card_id: &str, from
     if let Ok(conn) = db.lock() {
         log_audit(&conn, card_id, from, to, "hook", "OK");
     }
-
-    // Capture pre-hook dispatch ID to detect new dispatches created by hooks
-    let pre_dispatch_id: Option<String> = db.lock().ok().and_then(|conn| {
-        conn.query_row(
-            "SELECT latest_dispatch_id FROM kanban_cards WHERE id = ?1",
-            [card_id],
-            |row| row.get(0),
-        )
-        .ok()
-        .flatten()
-    });
 
     // Resolve effective pipeline for this card (#135)
     crate::pipeline::ensure_loaded();
@@ -577,100 +546,6 @@ pub fn fire_transition_hooks(db: &Db, engine: &PolicyEngine, card_id: &str, from
     }
 
     drain_hook_side_effects(db, engine);
-
-    // After all hooks, check if a new dispatch was created (by onCardTerminal, onReviewEnter, etc.)
-    // and send Discord notification. This handles auto-queue's next dispatch creation.
-    notify_new_dispatches_after_hooks(db, card_id, pre_dispatch_id.as_deref());
-}
-
-/// Check if hooks created new dispatches and backfill missing notify outbox rows.
-///
-/// Uses rowid-based ordering to find dispatches created during hook execution.
-/// Cross-card misroute is prevented by using each dispatch's own kanban_card_id
-/// for routing (not the triggering card's ID). The card_id filter is intentionally
-/// NOT applied because hooks (e.g. OnCardTerminal → auto-queue) legitimately
-/// create dispatches for OTHER cards.
-fn notify_new_dispatches_after_hooks(db: &Db, card_id: &str, pre_dispatch_id: Option<&str>) {
-    // Query ALL pending dispatches inserted after the pre-hook snapshot (by rowid).
-    // Uses rowid comparison instead of timestamp — SQLite datetime('now') has only
-    // second-level resolution, so dispatches created in the same second would be missed.
-    // Rowid is monotonically increasing and survives same-second inserts.
-    //
-    // No card_id filter: hooks like OnCardTerminal can create dispatches for different
-    // cards (e.g. auto-queue dispatching the next ready card). Each dispatch's own
-    // kanban_card_id is used for Discord routing below, preventing cross-card misroute.
-    let pending_dispatches: Vec<(String, String, String, String)> = db
-        .lock()
-        .ok()
-        .map(|conn| {
-            if let Some(pre_id) = pre_dispatch_id {
-                // Find any pending dispatches inserted after the pre-hook dispatch (by rowid)
-                let mut stmt = conn
-                    .prepare(
-                        "SELECT td.id, td.to_agent_id, td.kanban_card_id, kc.title \
-                         FROM task_dispatches td \
-                         JOIN kanban_cards kc ON td.kanban_card_id = kc.id \
-                         WHERE td.status = 'pending' \
-                           AND td.rowid > (SELECT rowid FROM task_dispatches WHERE id = ?1)",
-                    )
-                    .ok();
-                stmt.as_mut()
-                    .and_then(|s| {
-                        s.query_map(rusqlite::params![pre_id], |row| {
-                            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
-                        })
-                        .ok()
-                    })
-                    .map(|rows| rows.filter_map(|r| r.ok()).collect())
-                    .unwrap_or_default()
-            } else {
-                // No pre-hook dispatch — find any pending dispatch for this card
-                // that matches the current latest_dispatch_id
-                let latest_id: Option<String> = conn
-                    .query_row(
-                        "SELECT latest_dispatch_id FROM kanban_cards WHERE id = ?1",
-                        [card_id],
-                        |row| row.get(0),
-                    )
-                    .ok()
-                    .flatten();
-                let Some(lid) = latest_id else {
-                    return Vec::new();
-                };
-                let mut stmt = conn
-                    .prepare(
-                        "SELECT td.id, td.to_agent_id, td.kanban_card_id, kc.title \
-                         FROM task_dispatches td \
-                         JOIN kanban_cards kc ON td.kanban_card_id = kc.id \
-                         WHERE td.id = ?1 AND td.status = 'pending'",
-                    )
-                    .ok();
-                stmt.as_mut()
-                    .and_then(|s| {
-                        s.query_map([&lid], |row| {
-                            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
-                        })
-                        .ok()
-                    })
-                    .map(|rows| rows.filter_map(|r| r.ok()).collect())
-                    .unwrap_or_default()
-            }
-        })
-        .unwrap_or_default();
-
-    if pending_dispatches.is_empty() {
-        return;
-    }
-
-    for (dispatch_id, agent_id, dispatch_card_id, title) in pending_dispatches {
-        crate::server::routes::dispatches::queue_dispatch_notify(
-            db,
-            &dispatch_id,
-            &agent_id,
-            &dispatch_card_id,
-            &title,
-        );
-    }
 }
 
 /// Sync GitHub issue state when kanban card transitions (pipeline-driven).
@@ -1166,147 +1041,6 @@ mod tests {
         let result =
             transition_status_with_opts(&db, &engine, "card-force", "in_progress", "pmd", true);
         assert!(result.is_ok(), "force=true should bypass dispatch check");
-    }
-
-    /// Regression: same-second dispatch creation must still be detected by rowid comparison.
-    /// Previously used `created_at >` which has only second-level resolution and missed
-    /// dispatches created in the same wall-clock second.
-    #[test]
-    fn notify_query_detects_same_second_dispatch_via_rowid() {
-        let db = test_db();
-        seed_card(&db, "card-notify", "in_progress");
-
-        // Insert pre-hook dispatch (simulates the dispatch that existed before hooks ran)
-        let pre_dispatch_id = "dispatch-pre";
-        {
-            let conn = db.lock().unwrap();
-            conn.execute(
-                "INSERT INTO task_dispatches (id, kanban_card_id, to_agent_id, dispatch_type, status, title, created_at, updated_at) \
-                 VALUES (?1, 'card-notify', 'agent-1', 'implementation', 'dispatched', 'Pre', datetime('now'), datetime('now'))",
-                [pre_dispatch_id],
-            ).unwrap();
-        }
-
-        // Insert hook-created dispatch in the SAME second (same datetime('now'))
-        let new_dispatch_id = "dispatch-new";
-        {
-            let conn = db.lock().unwrap();
-            // Use the exact same timestamp to simulate same-second creation
-            let pre_ts: String = conn
-                .query_row(
-                    "SELECT created_at FROM task_dispatches WHERE id = ?1",
-                    [pre_dispatch_id],
-                    |row| row.get(0),
-                )
-                .unwrap();
-            conn.execute(
-                "INSERT INTO task_dispatches (id, kanban_card_id, to_agent_id, dispatch_type, status, title, created_at, updated_at) \
-                 VALUES (?1, 'card-notify', 'agent-1', 'review', 'pending', 'New', ?2, ?2)",
-                rusqlite::params![new_dispatch_id, pre_ts],
-            ).unwrap();
-            conn.execute(
-                "UPDATE kanban_cards SET latest_dispatch_id = ?1 WHERE id = 'card-notify'",
-                [new_dispatch_id],
-            )
-            .unwrap();
-        }
-
-        // Verify: the rowid-based query used by notify_new_dispatches_after_hooks
-        // finds the new dispatch even though created_at is identical.
-        // No card_id filter — hooks can create dispatches for any card.
-        let found: Vec<String> = {
-            let conn = db.lock().unwrap();
-            let mut stmt = conn
-                .prepare(
-                    "SELECT td.id FROM task_dispatches td \
-                 JOIN kanban_cards kc ON td.kanban_card_id = kc.id \
-                 WHERE td.status = 'pending' \
-                   AND td.rowid > (SELECT rowid FROM task_dispatches WHERE id = ?1)",
-                )
-                .unwrap();
-            stmt.query_map(rusqlite::params![pre_dispatch_id], |row| row.get(0))
-                .unwrap()
-                .filter_map(|r| r.ok())
-                .collect()
-        };
-
-        assert_eq!(found.len(), 1, "must find exactly 1 new dispatch");
-        assert_eq!(found[0], new_dispatch_id);
-
-        // Counter-check: the old timestamp-based approach would fail here
-        let found_by_ts: i64 = {
-            let conn = db.lock().unwrap();
-            conn.query_row(
-                "SELECT COUNT(*) FROM task_dispatches td \
-                 WHERE td.status = 'pending' \
-                   AND td.created_at > (SELECT created_at FROM task_dispatches WHERE id = ?1)",
-                [pre_dispatch_id],
-                |row| row.get(0),
-            )
-            .unwrap()
-        };
-        assert_eq!(
-            found_by_ts, 0,
-            "timestamp-based query misses same-second dispatch (proving rowid fix is necessary)"
-        );
-    }
-
-    /// Regression: cross-card dispatches created by hooks (e.g. auto-queue) must be
-    /// found by the notification query AND each dispatch must carry its own card_id
-    /// so that send_dispatch_to_discord routes to the correct thread/issue.
-    #[test]
-    fn notify_query_finds_cross_card_dispatch_with_correct_card_id() {
-        let db = test_db();
-        seed_card(&db, "card-x", "in_progress");
-        seed_card(&db, "card-y", "ready");
-
-        // Pre-hook dispatch for card-x (the card going through transition)
-        let pre_id = "dispatch-x-pre";
-        {
-            let conn = db.lock().unwrap();
-            conn.execute(
-                "INSERT INTO task_dispatches (id, kanban_card_id, to_agent_id, dispatch_type, status, title, created_at, updated_at) \
-                 VALUES (?1, 'card-x', 'agent-1', 'implementation', 'dispatched', 'X-Pre', datetime('now'), datetime('now'))",
-                [pre_id],
-            ).unwrap();
-        }
-
-        // Hook creates dispatch for card-y (auto-queue dispatching next card)
-        {
-            let conn = db.lock().unwrap();
-            conn.execute(
-                "INSERT INTO task_dispatches (id, kanban_card_id, to_agent_id, dispatch_type, status, title, created_at, updated_at) \
-                 VALUES ('dispatch-y-new', 'card-y', 'agent-1', 'implementation', 'pending', 'Y-New', datetime('now'), datetime('now'))",
-                [],
-            ).unwrap();
-        }
-
-        // The rowid-based query (no card_id filter) must find card-y's dispatch
-        let found: Vec<(String, String)> = {
-            let conn = db.lock().unwrap();
-            let mut stmt = conn
-                .prepare(
-                    "SELECT td.id, td.kanban_card_id FROM task_dispatches td \
-                 JOIN kanban_cards kc ON td.kanban_card_id = kc.id \
-                 WHERE td.status = 'pending' \
-                   AND td.rowid > (SELECT rowid FROM task_dispatches WHERE id = ?1)",
-                )
-                .unwrap();
-            stmt.query_map(rusqlite::params![pre_id], |row| {
-                Ok((row.get(0)?, row.get(1)?))
-            })
-            .unwrap()
-            .filter_map(|r| r.ok())
-            .collect()
-        };
-
-        assert_eq!(found.len(), 1, "must find cross-card dispatch");
-        assert_eq!(found[0].0, "dispatch-y-new");
-        // Critical: the dispatch carries card-y's ID, not card-x's
-        assert_eq!(
-            found[0].1, "card-y",
-            "dispatch must carry its own card_id for correct routing"
-        );
     }
 
     #[test]

--- a/src/kanban.rs
+++ b/src/kanban.rs
@@ -377,32 +377,6 @@ pub fn drain_hook_side_effects(db: &Db, engine: &PolicyEngine) {
         let mut transitions = intent_result.transitions;
         transitions.extend(engine.drain_pending_transitions());
 
-        // #108: Immediately notify dispatches created by JS policy intents.
-        // Without this, dispatches created outside fire_transition_hooks
-        // (e.g. timeouts.js, review-automation.js) would sit pending until
-        // the [I-0] 2min recovery sweep picked them up.
-        for cd in &intent_result.created_dispatches {
-            let title: String = db
-                .separate_conn()
-                .ok()
-                .and_then(|conn| {
-                    conn.query_row(
-                        "SELECT title FROM kanban_cards WHERE id = ?1",
-                        [&cd.card_id],
-                        |row| row.get(0),
-                    )
-                    .ok()
-                })
-                .unwrap_or_default();
-            crate::server::routes::dispatches::queue_dispatch_notify(
-                db,
-                &cd.dispatch_id,
-                &cd.agent_id,
-                &cd.card_id,
-                &title,
-            );
-        }
-
         if transitions.is_empty() {
             break;
         }
@@ -609,7 +583,7 @@ pub fn fire_transition_hooks(db: &Db, engine: &PolicyEngine, card_id: &str, from
     notify_new_dispatches_after_hooks(db, card_id, pre_dispatch_id.as_deref());
 }
 
-/// Check if hooks created new dispatches and send Discord notifications.
+/// Check if hooks created new dispatches and backfill missing notify outbox rows.
 ///
 /// Uses rowid-based ordering to find dispatches created during hook execution.
 /// Cross-card misroute is prevented by using each dispatch's own kanban_card_id
@@ -688,8 +662,6 @@ fn notify_new_dispatches_after_hooks(db: &Db, card_id: &str, pre_dispatch_id: Op
         return;
     }
 
-    // #144: Queue via dispatch outbox instead of tokio::spawn.
-    // Each dispatch uses its own kanban_card_id for correct thread/issue routing.
     for (dispatch_id, agent_id, dispatch_card_id, title) in pending_dispatches {
         crate::server::routes::dispatches::queue_dispatch_notify(
             db,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -239,19 +239,6 @@ fn fire_tick_hook_by_name(engine: &PolicyEngine, db: &Db, hook_name: &str, label
     let start = std::time::Instant::now();
     let now_ms = chrono::Utc::now().timestamp_millis().to_string();
 
-    // Capture pre-hook max dispatch rowid so we can detect dispatches created by JS policies
-    let pre_hook_max_rowid: i64 = db
-        .lock()
-        .ok()
-        .and_then(|conn| {
-            conn.query_row(
-                "SELECT COALESCE(MAX(rowid), 0) FROM task_dispatches",
-                [],
-                |row| row.get(0),
-            )
-            .ok()
-        })
-        .unwrap_or(0);
     let key_ms = format!("last_tick_{}_ms", label);
     let key_status = format!("last_tick_{}_status", label);
 
@@ -297,11 +284,6 @@ fn fire_tick_hook_by_name(engine: &PolicyEngine, db: &Db, hook_name: &str, label
     }
 
     crate::kanban::drain_hook_side_effects(db, engine);
-
-    // Notify any dispatches created by JS policies during this hook.
-    // Without this, dispatches created in onTick (e.g., auto-queue.js dispatchNextEntry)
-    // would only be picked up by [I-0] recovery 30s later.
-    crate::dispatch::notify_hook_created_dispatches(db, pre_hook_max_rowid);
 }
 
 /// Drain pending transitions after each tier execution.

--- a/src/server/routes/auto_queue.rs
+++ b/src/server/routes/auto_queue.rs
@@ -1291,14 +1291,6 @@ pub async fn activate(
         .ok();
         drop(conn);
 
-        super::dispatches::queue_dispatch_notify(
-            &state.db,
-            &dispatch_id,
-            &agent_id,
-            &card_id,
-            &title,
-        );
-
         // #140: Update local per-agent count so subsequent iterations respect max_concurrent_per_agent
         *agent_dispatch_counts.entry(agent_id.clone()).or_insert(0) += 1;
 

--- a/src/server/routes/dispatched_sessions.rs
+++ b/src/server/routes/dispatched_sessions.rs
@@ -1148,11 +1148,6 @@ pub async fn force_kill_session(
                     .ok();
                 }
                 retry_dispatch_id = Some(new_id.clone());
-
-                // Send to Discord (hooks already fired by create_dispatch)
-                crate::server::routes::dispatches::queue_dispatch_notify(
-                    &state.db, &new_id, agent, dtitle, &card_id,
-                );
             }
             Err(e) => {
                 tracing::warn!(

--- a/src/server/routes/dispatches.rs
+++ b/src/server/routes/dispatches.rs
@@ -2418,30 +2418,6 @@ pub async fn get_card_thread(
 
 // ── #144: Dispatch Notification Outbox ───────────────────────
 
-/// Ensure a dispatch notification exists for async delivery via the outbox worker.
-///
-/// Replaces `tokio::spawn(send_dispatch_to_discord(...))` with a durable
-/// outbox insert. The worker loop drains these entries and calls
-/// `send_dispatch_to_discord` / `handle_completed_dispatch_followups`.
-pub(crate) fn queue_dispatch_notify(
-    db: &crate::db::Db,
-    dispatch_id: &str,
-    agent_id: &str,
-    card_id: &str,
-    title: &str,
-) {
-    if let Ok(conn) = db.separate_conn() {
-        crate::dispatch::ensure_dispatch_notify_outbox_on_conn(
-            &conn,
-            dispatch_id,
-            agent_id,
-            card_id,
-            title,
-        )
-        .ok();
-    }
-}
-
 /// Queue a dispatch completion followup for async processing.
 ///
 /// Replaces `tokio::spawn(handle_completed_dispatch_followups(...))`.

--- a/src/server/routes/dispatches.rs
+++ b/src/server/routes/dispatches.rs
@@ -255,18 +255,7 @@ pub async fn create_dispatch(
         &context,
     ) {
         Ok(d) => {
-            let dispatch_id = d["id"].as_str().unwrap_or("").to_string();
             let was_reused = d.get("__reused").and_then(|v| v.as_bool()).unwrap_or(false);
-            // Only send Discord notification for genuinely new dispatches (#173)
-            if !was_reused {
-                queue_dispatch_notify(
-                    &state.db,
-                    &dispatch_id,
-                    &body.to_agent_id,
-                    &body.kanban_card_id,
-                    &body.title,
-                );
-            }
             let status_code = if was_reused {
                 StatusCode::OK
             } else {
@@ -889,7 +878,7 @@ async fn send_dispatch_to_discord_inner(
     };
 
     // For review dispatches, use the alternate channel (counter-model)
-    let mut use_alt = use_counter_model_channel(dispatch_type.as_deref());
+    let use_alt = use_counter_model_channel(dispatch_type.as_deref());
 
     // #145: Check if this dispatch is in a unified thread auto-queue run (dispatch_id path)
     // #218: Check unified run by dispatch_id first, then card_id for review/rework
@@ -1668,8 +1657,9 @@ async fn try_reuse_thread(
     }
 }
 
-/// Send review result notification to the agent's PRIMARY channel.
-/// Called after a counter-model review dispatch completes.
+/// Handle primary-channel followup after a counter-model review completes.
+/// pass/unknown verdicts send an immediate message; improve/rework/reject
+/// create a review-decision dispatch whose notify row is delivered by outbox.
 pub(super) async fn send_review_result_to_primary(
     db: &crate::db::Db,
     card_id: &str,
@@ -1694,6 +1684,73 @@ pub(super) async fn send_review_result_to_primary(
             Err(_) => return Err(format!("card {card_id} not found or missing agent")),
         }
     };
+
+    // For improve/rework/reject: create a review-decision dispatch via the
+    // authoritative path and let the outbox worker deliver the message.
+    if verdict != "pass" && verdict != "approved" && verdict != "unknown" {
+        // #118: If approach-change already created a rework dispatch (review_status = rework_pending),
+        // skip creating the review-decision dispatch to avoid double dispatch.
+        {
+            let skip = db
+                .lock()
+                .ok()
+                .and_then(|conn| {
+                    conn.query_row(
+                        "SELECT review_status FROM kanban_cards WHERE id = ?1",
+                        [card_id],
+                        |row| row.get::<_, Option<String>>(0),
+                    )
+                    .ok()
+                    .flatten()
+                })
+                .map(|s| s == "rework_pending")
+                .unwrap_or(false);
+            if skip {
+                tracing::info!(
+                    "[review-followup] #118 skipping review-decision for {card_id} — approach-change rework already dispatched"
+                );
+                return Ok(());
+            }
+        }
+
+        return match crate::dispatch::create_dispatch_core(
+            db,
+            card_id,
+            &agent_id,
+            "review-decision",
+            &format!("[리뷰 검토] {title}"),
+            &serde_json::json!({"verdict": verdict}),
+        ) {
+            Ok((id, _old_status, _reused)) => {
+                if let Ok(conn) = db.lock() {
+                    crate::engine::ops::review_state_sync_on_conn(
+                        &conn,
+                        &serde_json::json!({
+                            "card_id": card_id,
+                            "state": "suggestion_pending",
+                            "pending_dispatch_id": id,
+                            "last_verdict": verdict,
+                        })
+                        .to_string(),
+                    );
+                }
+                tracing::info!(
+                    "[review-followup] enqueued review-decision dispatch {} for card {}",
+                    id,
+                    card_id
+                );
+                Ok(())
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "[review-followup] skipping review-decision dispatch for card {card_id}: {e}"
+                );
+                Err(format!(
+                    "create_dispatch_core failed for review-decision: {e}"
+                ))
+            }
+        };
+    }
 
     // Resolve channel ID (may be a name alias)
     let channel_id_num: u64 = match channel_id.parse() {
@@ -1804,11 +1861,6 @@ pub(super) async fn send_review_result_to_primary(
     } else {
         channel_id.clone()
     };
-    let sending_to_thread = active_thread_id
-        .as_ref()
-        .map(|t| *t == target_channel)
-        .unwrap_or(false);
-
     // For pass/approved verdict, just send a simple notification (no action needed).
     // #116: accept is NOT a counter-model verdict — it's a review-decision action.
     if verdict == "pass" || verdict == "approved" {
@@ -1875,154 +1927,7 @@ pub(super) async fn send_review_result_to_primary(
         }
     }
 
-    // #118: If approach-change already created a rework dispatch (review_status = rework_pending),
-    // skip creating the review-decision dispatch to avoid double dispatch.
-    {
-        let skip = db
-            .lock()
-            .ok()
-            .and_then(|conn| {
-                conn.query_row(
-                    "SELECT review_status FROM kanban_cards WHERE id = ?1",
-                    [card_id],
-                    |row| row.get::<_, Option<String>>(0),
-                )
-                .ok()
-                .flatten()
-            })
-            .map(|s| s == "rework_pending")
-            .unwrap_or(false);
-        if skip {
-            tracing::info!(
-                "[review-followup] #118 skipping review-decision for {card_id} — approach-change rework already dispatched"
-            );
-            return Ok(()); // Not an error — intentional skip
-        }
-    }
-
-    // For improve/rework/reject: create a review-decision dispatch via central create_dispatch_core
-    // to enforce the done terminal guard (prevents review-decision on done cards).
-    let dispatch_id = match crate::dispatch::create_dispatch_core(
-        db,
-        card_id,
-        &agent_id,
-        "review-decision",
-        &format!("[리뷰 검토] {title}"),
-        &serde_json::json!({"verdict": verdict}),
-    ) {
-        Ok((id, _old_status, _reused)) => {
-            // #117/#158: Update canonical card_review_state via unified entrypoint
-            if let Ok(conn) = db.lock() {
-                crate::engine::ops::review_state_sync_on_conn(
-                    &conn,
-                    &serde_json::json!({
-                        "card_id": card_id,
-                        "state": "suggestion_pending",
-                        "pending_dispatch_id": id,
-                        "last_verdict": verdict,
-                    })
-                    .to_string(),
-                );
-            }
-            id
-        }
-        Err(e) => {
-            tracing::warn!(
-                "[review-followup] skipping review-decision dispatch for card {card_id}: {e}"
-            );
-            return Err(format!(
-                "create_dispatch_core failed for review-decision: {e}"
-            ));
-        }
-    };
-
-    let url_line = issue_url.map(|u| format!("\n{u}")).unwrap_or_default();
-    let message = format!(
-        "DISPATCH:{dispatch_id} [⚖️ 리뷰 검토] - {title}\n\
-         ⛔ 코드 리뷰 금지 — 이미 완료된 리뷰 결과를 검토하는 단계입니다\n\
-         📝 카운터모델 리뷰 결과: **{verdict}**\n\
-         GitHub 이슈 코멘트에서 피드백을 확인하고 다음 중 하나를 선택하세요:\n\
-         • **수용** → 피드백 반영 수정 후 review-decision API에 `accept` 호출\n\
-         • **반론** → GitHub 코멘트로 이의 제기 후 review-decision API에 `dispute` 호출\n\
-         • **무시** → review-decision API에 `dismiss` 호출{url_line}"
-    );
-    let message = prefix_dispatch_message("review-decision", &message);
-
-    // Send a single review-decision message to existing thread, or just to channel
-    if sending_to_thread {
-        let msg_url = format!(
-            "https://discord.com/api/v10/channels/{}/messages",
-            target_channel
-        );
-        let ok = client
-            .post(&msg_url)
-            .header("Authorization", format!("Bot {}", token))
-            .json(&serde_json::json!({"content": message}))
-            .send()
-            .await
-            .map(|r| r.status().is_success())
-            .unwrap_or(false);
-        if ok {
-            if let Ok(conn) = db.lock() {
-                conn.execute(
-                    "UPDATE task_dispatches SET thread_id = ?1 WHERE id = ?2",
-                    rusqlite::params![target_channel, dispatch_id],
-                )
-                .ok();
-                // Mark as notified so timeouts.js [I-0] won't resend
-                conn.execute(
-                    "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?1, ?2)",
-                    rusqlite::params![format!("dispatch_notified:{}", dispatch_id), dispatch_id],
-                )
-                .ok();
-            }
-            tracing::info!(
-                "[review] Sent review-decision to existing thread {target_channel} for {agent_id}"
-            );
-            Ok(())
-        } else {
-            Err(format!(
-                "discord send failed for review-decision to thread {target_channel}"
-            ))
-        }
-    } else {
-        let url = format!(
-            "https://discord.com/api/v10/channels/{}/messages",
-            target_channel
-        );
-        match client
-            .post(&url)
-            .header("Authorization", format!("Bot {}", token))
-            .json(&serde_json::json!({"content": message}))
-            .send()
-            .await
-        {
-            Ok(resp) if resp.status().is_success() => {
-                // Mark as notified so timeouts.js [I-0] won't resend
-                if let Ok(conn) = db.lock() {
-                    conn.execute(
-                        "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?1, ?2)",
-                        rusqlite::params![
-                            format!("dispatch_notified:{}", dispatch_id),
-                            dispatch_id
-                        ],
-                    )
-                    .ok();
-                }
-                tracing::info!("[review] Sent review result to {agent_id} (channel {channel_id})");
-                Ok(())
-            }
-            Ok(resp) => {
-                let status = resp.status();
-                tracing::warn!("[review] Discord API error {status}");
-                Err(format!("discord API error {status} for review-decision"))
-            }
-            Err(e) => {
-                tracing::warn!("[review] Request failed: {e}");
-                Err(format!("discord request failed for review-decision: {e}"))
-            }
-        }
-    }
+    unreachable!("explicit review verdicts should return earlier");
 }
 
 fn extract_review_verdict(result_json: Option<&str>) -> String {
@@ -2183,6 +2088,10 @@ fn format_dispatch_message(
     dispatch_type: Option<&str>,
     dispatch_context: Option<&str>,
 ) -> String {
+    let context_json = dispatch_context
+        .and_then(|ctx| serde_json::from_str::<serde_json::Value>(ctx).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+
     // Format issue link as markdown hyperlink with angle brackets to suppress embed
     let issue_link = match (issue_url, issue_number) {
         (Some(url), Some(num)) => format!("[{title} #{num}](<{url}>)"),
@@ -2203,41 +2112,45 @@ fn format_dispatch_message(
     };
 
     // Extract reason from context JSON
-    let reason = dispatch_context
-        .and_then(|ctx| serde_json::from_str::<serde_json::Value>(ctx).ok())
-        .and_then(|v| {
-            // Try common reason fields
-            v.get("resumed_from")
-                .and_then(|r| r.as_str())
-                .map(|s| format!("resume from {s}"))
-                .or_else(|| {
-                    if v.get("retry").and_then(|r| r.as_bool()).unwrap_or(false) {
-                        Some("retry".to_string())
-                    } else if v
-                        .get("redispatch")
-                        .and_then(|r| r.as_bool())
-                        .unwrap_or(false)
-                    {
-                        Some("redispatch".to_string())
-                    } else if v
-                        .get("auto_queue")
-                        .and_then(|r| r.as_bool())
-                        .unwrap_or(false)
-                    {
-                        Some("auto-queue".to_string())
-                    } else if v
-                        .get("auto_accept")
-                        .and_then(|r| r.as_bool())
-                        .unwrap_or(false)
-                    {
-                        Some("auto-accept rework".to_string())
-                    } else {
-                        None
-                    }
-                })
+    let reason = context_json
+        .get("resumed_from")
+        .and_then(|r| r.as_str())
+        .map(|s| format!("resume from {s}"))
+        .or_else(|| {
+            if context_json
+                .get("retry")
+                .and_then(|r| r.as_bool())
+                .unwrap_or(false)
+            {
+                Some("retry".to_string())
+            } else if context_json
+                .get("redispatch")
+                .and_then(|r| r.as_bool())
+                .unwrap_or(false)
+            {
+                Some("redispatch".to_string())
+            } else if context_json
+                .get("auto_queue")
+                .and_then(|r| r.as_bool())
+                .unwrap_or(false)
+            {
+                Some("auto-queue".to_string())
+            } else if context_json
+                .get("auto_accept")
+                .and_then(|r| r.as_bool())
+                .unwrap_or(false)
+            {
+                Some("auto-accept rework".to_string())
+            } else {
+                None
+            }
         });
 
     let reason_suffix = reason.map(|r| format!(" ({r})")).unwrap_or_default();
+    let review_verdict = context_json
+        .get("verdict")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
 
     if use_alt {
         let mut message = format!(
@@ -2278,6 +2191,21 @@ fn format_dispatch_message(
              \"items\":[{{\"category\":\"bug|style|perf|security|logic\",\"summary\":\"개별 지적 사항\"}}]\
              {commit_arg}{provider_arg}}}'`"
         ));
+        message
+    } else if dispatch_type == Some("review-decision") {
+        let mut message = format!(
+            "DISPATCH:{dispatch_id} [{type_label}] - {title}\n\
+             ⛔ 코드 리뷰 금지 — 이미 완료된 리뷰 결과를 검토하는 단계입니다\n\
+             📝 카운터모델 리뷰 결과: **{review_verdict}**\n\
+             GitHub 이슈 코멘트에서 피드백을 확인하고 다음 중 하나를 선택하세요:\n\
+             • **수용** → 피드백 반영 수정 후 review-decision API에 `accept` 호출\n\
+             • **반론** → GitHub 코멘트로 이의 제기 후 review-decision API에 `dispute` 호출\n\
+             • **무시** → review-decision API에 `dismiss` 호출"
+        );
+        if !issue_link.is_empty() {
+            message.push('\n');
+            message.push_str(&issue_link);
+        }
         message
     } else if !issue_link.is_empty() {
         format!("DISPATCH:{dispatch_id} [{type_label}] - {title}{reason_suffix}\n{issue_link}")
@@ -2490,7 +2418,7 @@ pub async fn get_card_thread(
 
 // ── #144: Dispatch Notification Outbox ───────────────────────
 
-/// Queue a dispatch notification for async delivery via the outbox worker.
+/// Ensure a dispatch notification exists for async delivery via the outbox worker.
 ///
 /// Replaces `tokio::spawn(send_dispatch_to_discord(...))` with a durable
 /// outbox insert. The worker loop drains these entries and calls
@@ -2503,10 +2431,12 @@ pub(crate) fn queue_dispatch_notify(
     title: &str,
 ) {
     if let Ok(conn) = db.separate_conn() {
-        conn.execute(
-            "INSERT INTO dispatch_outbox (dispatch_id, action, agent_id, card_id, title) \
-             VALUES (?1, 'notify', ?2, ?3, ?4)",
-            rusqlite::params![dispatch_id, agent_id, card_id, title],
+        crate::dispatch::ensure_dispatch_notify_outbox_on_conn(
+            &conn,
+            dispatch_id,
+            agent_id,
+            card_id,
+            title,
         )
         .ok();
     }
@@ -2754,6 +2684,30 @@ mod tests {
         ));
         assert!(!message.contains("검토 전용"));
         // Implementation dispatches should NOT include verdict instructions
+        assert!(!message.contains("review-verdict"));
+    }
+
+    #[test]
+    fn review_decision_primary_message_includes_action_instructions() {
+        let message = format_dispatch_message(
+            "dispatch-rd",
+            "[리뷰 검토] Test Card",
+            Some("https://github.com/itismyfield/AgentDesk/issues/249"),
+            Some(249),
+            false,
+            None,
+            None,
+            None,
+            Some("review-decision"),
+            Some(r#"{"verdict":"rework"}"#),
+        );
+
+        assert!(message.contains("[⚖️ 리뷰 검토]"));
+        assert!(message.contains("카운터모델 리뷰 결과: **rework**"));
+        assert!(message.contains("review-decision API에 `accept` 호출"));
+        assert!(message.contains("review-decision API에 `dispute` 호출"));
+        assert!(message.contains("review-decision API에 `dismiss` 호출"));
+        assert!(message.contains("#249](<https://github.com/itismyfield/AgentDesk/issues/249>)"));
         assert!(!message.contains("review-verdict"));
     }
 

--- a/src/server/routes/kanban.rs
+++ b/src/server/routes/kanban.rs
@@ -733,7 +733,7 @@ pub async fn retry_card(
 
         // Create dispatch directly (bypass policy to avoid from===requested skip)
         if !agent_id_for_dispatch.is_empty() {
-            let retry_result = crate::dispatch::create_dispatch(
+            let _retry_result = crate::dispatch::create_dispatch(
                 &state.db,
                 &state.engine,
                 &card_id_owned,
@@ -742,18 +742,6 @@ pub async fn retry_card(
                 &card_title,
                 &json!({"retry": true}),
             );
-            // Async Discord notification — use exact dispatch_id to avoid
-            // latest_dispatch_id re-query race.
-            if let Ok(ref d) = retry_result {
-                let dispatch_id = d["id"].as_str().unwrap_or("").to_string();
-                super::dispatches::queue_dispatch_notify(
-                    &state.db,
-                    &dispatch_id,
-                    &agent_id_for_dispatch,
-                    &card_id_owned,
-                    &card_title,
-                );
-            }
         }
     } // drop conn lock
 
@@ -861,7 +849,7 @@ pub async fn redispatch_card(
 
         // Create dispatch directly (bypass policy to avoid from===requested skip)
         if !agent_id.is_empty() {
-            let redispatch_result = crate::dispatch::create_dispatch(
+            let _redispatch_result = crate::dispatch::create_dispatch(
                 &state.db,
                 &state.engine,
                 &card_id_owned,
@@ -870,18 +858,6 @@ pub async fn redispatch_card(
                 &card_title,
                 &json!({"redispatch": true}),
             );
-            // Async Discord notification — use exact dispatch_id to avoid
-            // latest_dispatch_id re-query race.
-            if let Ok(ref d) = redispatch_result {
-                let dispatch_id = d["id"].as_str().unwrap_or("").to_string();
-                super::dispatches::queue_dispatch_notify(
-                    &state.db,
-                    &dispatch_id,
-                    &agent_id,
-                    &card_id_owned,
-                    &card_title,
-                );
-            }
         }
     }
 

--- a/src/server/routes/resume.rs
+++ b/src/server/routes/resume.rs
@@ -865,16 +865,6 @@ fn create_and_notify(
     )
     .map_err(|e| format!("dispatch creation failed: {e}"))?;
 
-    let dispatch_id = dispatch["id"].as_str().unwrap_or("").to_string();
-    let was_reused = dispatch
-        .get("__reused")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-
-    if !was_reused {
-        super::dispatches::queue_dispatch_notify(&state.db, &dispatch_id, agent_id, card_id, title);
-    }
-
     Ok(dispatch)
 }
 

--- a/src/server/routes/review_verdict.rs
+++ b/src/server/routes/review_verdict.rs
@@ -2368,6 +2368,30 @@ mod tests {
         .await;
         assert_eq!(status1, StatusCode::OK);
 
+        let conn = db.lock().unwrap();
+        let latest_dispatch_id: String = conn
+            .query_row(
+                "SELECT latest_dispatch_id FROM kanban_cards WHERE id = 'card-dup'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let (dispatch_type, notify_count): (String, i64) = conn
+            .query_row(
+                "SELECT td.dispatch_type, \
+                        (SELECT COUNT(*) FROM dispatch_outbox o WHERE o.dispatch_id = td.id AND o.action = 'notify') \
+                 FROM task_dispatches td WHERE td.id = ?1",
+                [&latest_dispatch_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(dispatch_type, "rework");
+        assert_eq!(
+            notify_count, 1,
+            "review-decision accept must create rework dispatch via canonical notify persistence"
+        );
+        drop(conn);
+
         // Second accept should fail — dispatch already consumed
         let (status2, _) = submit_review_decision(
             State(state),

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tower::ServiceExt;
 
 fn test_db() -> Db {
@@ -15,9 +15,9 @@ fn test_db() -> Db {
 fn seed_test_agents(db: &Db) {
     let c = db.separate_conn().unwrap();
     c.execute_batch(
-        "INSERT OR IGNORE INTO agents (id, name, discord_channel_id) VALUES ('ch-td', 'TD', 'ch-td');
-         INSERT OR IGNORE INTO agents (id, name, discord_channel_id) VALUES ('ag1', 'Agent1', 'ag1');
-         INSERT OR IGNORE INTO agents (id, name, discord_channel_id) VALUES ('agent-1', 'Agent 1', 'ch-1');"
+        "INSERT OR IGNORE INTO agents (id, name, discord_channel_id, discord_channel_alt) VALUES ('ch-td', 'TD', '111', '222');
+         INSERT OR IGNORE INTO agents (id, name, discord_channel_id, discord_channel_alt) VALUES ('ag1', 'Agent1', '333', '444');
+         INSERT OR IGNORE INTO agents (id, name, discord_channel_id, discord_channel_alt) VALUES ('agent-1', 'Agent 1', '555', '666');"
     ).unwrap();
 }
 
@@ -766,6 +766,14 @@ async fn dispatch_create_and_get() {
         })
         .unwrap();
     assert_eq!(card_status, "requested");
+    let notify_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM dispatch_outbox WHERE dispatch_id = ?1 AND action = 'notify'",
+            [&dispatch_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(notify_count, 1, "API create must persist notify outbox");
     drop(conn);
 
     // GET single dispatch
@@ -786,6 +794,84 @@ async fn dispatch_create_and_get() {
         .unwrap();
     let json2: serde_json::Value = serde_json::from_slice(&body2).unwrap();
     assert_eq!(json2["dispatch"]["id"], dispatch_id);
+}
+
+#[tokio::test]
+async fn resume_requested_creates_single_notify_backed_dispatch() {
+    crate::pipeline::ensure_loaded();
+    let db = test_db();
+    let engine = test_engine(&db);
+    seed_agent(&db, "agent-resume");
+
+    {
+        let conn = db.lock().unwrap();
+        conn.execute(
+            "INSERT INTO kanban_cards (
+                id, title, status, priority, assigned_agent_id, created_at, updated_at
+            ) VALUES (
+                'card-resume', 'Resume Card', 'requested', 'medium', 'agent-resume',
+                datetime('now'), datetime('now')
+            )",
+            [],
+        )
+        .unwrap();
+    }
+
+    let app = test_api_router(db.clone(), engine, None);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/kanban-cards/card-resume/resume")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let dispatch_id = json["action"]["dispatch_id"].as_str().unwrap().to_string();
+    assert_eq!(json["action"]["type"], "new_implementation_dispatch");
+
+    let conn = db.lock().unwrap();
+    let (dispatch_type, dispatch_status, context, latest_dispatch_id): (
+        String,
+        String,
+        String,
+        Option<String>,
+    ) = conn
+        .query_row(
+            "SELECT td.dispatch_type, td.status, td.context, kc.latest_dispatch_id
+             FROM task_dispatches td
+             JOIN kanban_cards kc ON kc.id = td.kanban_card_id
+             WHERE td.id = ?1",
+            [&dispatch_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .unwrap();
+    assert_eq!(dispatch_type, "implementation");
+    assert_eq!(dispatch_status, "pending");
+    assert_eq!(latest_dispatch_id.as_deref(), Some(dispatch_id.as_str()));
+    let context_json: serde_json::Value = serde_json::from_str(&context).unwrap();
+    assert_eq!(context_json["resume"], true);
+    assert_eq!(context_json["resumed_from"], "requested");
+
+    let notify_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM dispatch_outbox WHERE dispatch_id = ?1 AND action = 'notify'",
+            [&dispatch_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        notify_count, 1,
+        "resume(requested) must create exactly one notify outbox row via canonical core"
+    );
 }
 
 #[tokio::test]
@@ -1283,7 +1369,7 @@ fn seed_repo(db: &Db, repo_id: &str) {
 fn seed_agent(db: &Db, agent_id: &str) {
     let conn = db.lock().unwrap();
     conn.execute(
-        "INSERT OR IGNORE INTO agents (id, name, discord_channel_id, discord_channel_alt) VALUES (?1, ?1, 'ch1', 'ch2')",
+        "INSERT OR IGNORE INTO agents (id, name, discord_channel_id, discord_channel_alt) VALUES (?1, ?1, '111', '222')",
         [agent_id],
     )
     .unwrap();
@@ -2294,17 +2380,28 @@ async fn auto_queue_activate_unified_thread_run_dispatches_to_same_run() {
         )
         .unwrap();
     assert_eq!(entry_status, "dispatched");
-    assert!(dispatch_id.is_some(), "entry must have linked dispatch_id");
+    let dispatch_id = dispatch_id.expect("entry must have linked dispatch_id");
 
     // Verify the dispatch references the correct card
     let dispatch_card: String = conn
         .query_row(
             "SELECT kanban_card_id FROM task_dispatches WHERE id = ?1",
-            [&dispatch_id.unwrap()],
+            [&dispatch_id],
             |row| row.get(0),
         )
         .unwrap();
     assert_eq!(dispatch_card, "card-unified-1");
+    let notify_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM dispatch_outbox WHERE dispatch_id = ?1 AND action = 'notify'",
+            [&dispatch_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        notify_count, 1,
+        "auto-queue activation must use canonical notify persistence"
+    );
 
     // Second entry stays pending (sequential within group)
     let entry2_status: String = conn
@@ -2470,7 +2567,10 @@ fn seed_parallel_test_cards(db: &Db) -> Vec<String> {
     for i in 1..=4 {
         conn.execute(
             &format!(
-                "INSERT INTO agents (id, name, provider, status) VALUES ('agent-{i}', 'Agent{i}', 'claude', 'idle')"
+                "INSERT INTO agents (id, name, provider, status, discord_channel_id, discord_channel_alt)
+                 VALUES ('agent-{i}', 'Agent{i}', 'claude', 'idle', '{}', '{}')",
+                1000 + i,
+                2000 + i,
             ),
             [],
         )

--- a/tests/e2e/smoke_test.rs
+++ b/tests/e2e/smoke_test.rs
@@ -148,6 +148,7 @@ async fn smoke_test_full_lifecycle() {
                 "id": agent_id,
                 "name": "Test Agent",
                 "provider": "claude",
+                "discord_channel_id": "123456789012345678",
             }))
             .send()
             .await


### PR DESCRIPTION
## Summary
- `scripts/deploy-dev.sh`에 dev deploy credential sync 로직을 #218 범위에서 분리하여 별도 추적
- Source-of-truth 해석 체인(env var → release symlink target → fallback) 문서화
- Relative symlink를 symlink parent dir 기준으로 resolve하도록 수정
- `AGENTDESK_SHARED_CREDENTIAL_DIR`을 detached helper에 전달

## Test plan
- [x] `bash -n scripts/deploy-dev.sh` 문법 검증 통과
- [x] 카운터모델 리뷰 pass (improve → rework → pass)

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)