### PR TITLE
feat: add OpenClaw migrate import CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "dirs",
  "futures",
  "hex",
+ "json5",
  "libc",
  "notify",
  "poise",
@@ -1271,6 +1272,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1574,6 +1586,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2893,6 +2948,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+json5 = "0.4"
 
 # Utils
 futures = "0.3"

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ A React-based dashboard served from the same binary:
 ### Round-Table Meetings
 Coordinate multi-agent discussions with structured rounds, automatic transcript recording, and post-meeting issue extraction to GitHub.
 
+### OpenClaw Migration
+Import OpenClaw agent/runtime state into AgentDesk with `agentdesk migrate openclaw`. See [`docs/openclaw-migrate.md`](docs/openclaw-migrate.md) for dry-run, apply, resume, and audit output details.
+
 ## Configuration
 
 ### agentdesk.yaml

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ A React-based dashboard served from the same binary:
 Coordinate multi-agent discussions with structured rounds, automatic transcript recording, and post-meeting issue extraction to GitHub.
 
 ### OpenClaw Migration
-Import OpenClaw agent/runtime state into AgentDesk with `agentdesk migrate openclaw`. See [`docs/openclaw-migrate.md`](docs/openclaw-migrate.md) for dry-run, apply, resume, and audit output details.
+Import OpenClaw agent/runtime state into AgentDesk with `agentdesk migrate openclaw`. Generated role prompts point at the imported AgentDesk memory/workspace paths so migrated agents use runtime-managed data instead of raw OpenClaw source paths. See [`docs/openclaw-migrate.md`](docs/openclaw-migrate.md) for dry-run, apply, resume, and audit output details.
 
 ## Configuration
 

--- a/docs/openclaw-migrate.md
+++ b/docs/openclaw-migrate.md
@@ -1,0 +1,93 @@
+# OpenClaw Migration
+
+`agentdesk migrate openclaw`는 OpenClaw의 durable state를 AgentDesk 런타임으로 이관하기 위한 CLI입니다.
+
+## 지원 범위
+
+- `openclaw.json` 또는 그 상위 루트 탐색
+- JSON5 + `$include` 해석
+- 기본/default agent 또는 명시 agent 선택
+- provider/model 힌트 해석과 fallback provider 매핑
+- 프롬프트 부트스트랩 파일 병합
+- `MEMORY.md`, 일자별 memory markdown, workspace 복사
+- Discord channel binding 미리보기와 `org.yaml` 반영
+- `bot_settings.json` 토큰/허용 채널 반영
+- `ai_sessions` 및 DB 세션 이관
+- audit 산출물 생성과 `--resume` 재개
+
+## 기본 사용 예시
+
+Dry-run으로 import plan만 확인:
+
+`agentdesk migrate openclaw /path/to/openclaw --dry-run`
+
+선택한 agent 하나를 실제 반영:
+
+`agentdesk migrate openclaw /path/to/openclaw --agent alpha --write-org --write-db`
+
+channel binding, bot 설정, 세션까지 함께 이관:
+
+`agentdesk migrate openclaw /path/to/openclaw --all-agents --write-org --write-bot-settings --write-db --with-channel-bindings --with-sessions --snapshot-source`
+
+중단된 import 재개:
+
+`agentdesk migrate openclaw --resume <import_id> --write-org --write-db`
+
+## 주요 동작
+
+1. 소스 루트와 `openclaw.json`을 해석합니다.
+2. agent 선택 규칙에 따라 import 대상을 확정합니다.
+3. provider/workspace 유효성을 검사하고 import plan을 만듭니다.
+4. apply 시 `AGENTDESK_ROOT_DIR/openclaw/imports/<import_id>` 아래에 audit 결과를 남깁니다.
+5. 선택된 경우 prompt/memory/workspace/org/bot_settings/session/DB를 순서대로 반영합니다.
+
+## Audit 출력
+
+아래 파일이 import audit 루트에 생성됩니다.
+
+- `manifest.json`
+- `agent-map.json`
+- `write-plan.json`
+- `apply-result.json`
+- `resume-state.json`
+- `warnings.txt`
+- `tool-policy-report.json`
+- `discord-auth-report.json`
+- `channel-binding-preview.yaml`
+
+## 프롬프트/메모리 입력
+
+다음 bootstrap 파일이 있으면 AgentDesk prompt로 병합합니다.
+
+- `IDENTITY.md`
+- `AGENTS.md`
+- `SOUL.md`
+- `USER.md`
+- `TOOLS.md`
+- `BOOT.md`
+- `BOOTSTRAP.md`
+- `HEARTBEAT.md`
+
+추가로 `MEMORY.md`와 `memory/` 아래 markdown 파일을 AgentDesk memory 구조로 복사합니다.
+
+## 주요 플래그
+
+- `--agent <id>`: 특정 agent만 선택
+- `--all-agents`: 모든 source agent 선택
+- `--agentdesk-root <path>`: 대상 AgentDesk runtime root override
+- `--fallback-provider <provider>`: 미지원 source provider를 강제 매핑
+- `--workspace-root-rewrite OLD=NEW`: 절대 workspace prefix 재작성
+- `--write-org`: `config/org.yaml` 반영
+- `--write-bot-settings`: `config/bot_settings.json` 반영
+- `--write-db`: SQLite upsert 반영
+- `--with-channel-bindings`: Discord channel binding import 적용
+- `--with-sessions`: 세션 이관 활성화
+- `--snapshot-source`: source tree snapshot 남김
+- `--overwrite`: 기존 role/channel binding 덮어쓰기
+- `--resume <import_id>`: audit 상태를 기준으로 재개
+
+## 주의 사항
+
+- multi-agent source인데 기본 agent 표기가 없으면 `--agent` 또는 `--all-agents`가 필요합니다.
+- workspace가 없거나 provider 매핑이 불가능한 agent는 audit에는 남지만 apply에서 건너뜁니다.
+- token/tool policy는 기본적으로 `report` 모드이며, 실제 쓰기 전 dry-run과 audit 결과를 먼저 확인하는 것이 안전합니다.

--- a/docs/openclaw-migrate.md
+++ b/docs/openclaw-migrate.md
@@ -98,5 +98,6 @@ channel binding, bot 설정, 세션까지 함께 이관:
 ## 주의 사항
 
 - multi-agent source인데 기본 agent 표기가 없으면 `--agent` 또는 `--all-agents`가 필요합니다.
+- 같은 source를 다시 migrate할 때 runtime에 기존 `openclaw-<id>` role이 있으면 새 bare id 대신 그 role id를 재사용합니다.
 - workspace가 없거나 provider 매핑이 불가능한 agent는 audit에는 남지만 apply에서 건너뜁니다.
 - token/tool policy는 기본적으로 `report` 모드이며, 실제 쓰기 전 dry-run과 audit 결과를 먼저 확인하는 것이 안전합니다.

--- a/docs/openclaw-migrate.md
+++ b/docs/openclaw-migrate.md
@@ -99,5 +99,7 @@ channel binding, bot 설정, 세션까지 함께 이관:
 
 - multi-agent source인데 기본 agent 표기가 없으면 `--agent` 또는 `--all-agents`가 필요합니다.
 - 같은 source를 다시 migrate할 때 runtime에 기존 `openclaw-<id>` role이 있으면 새 bare id 대신 그 role id를 재사용합니다.
+- `--resume <import_id>`는 현재 runtime 상태로 role id를 다시 계산하지 않고, audit의 `agent-map.json`에 저장된 source→role 매핑을 그대로 재사용합니다.
+- Windows source에서 넘어온 `C:\...` 또는 `D:/...` workspace 경로는 절대경로로 유지한 뒤, 필요하면 `--workspace-root-rewrite`로 현 환경 경로에 맞춰 바꿔야 합니다.
 - workspace가 없거나 provider 매핑이 불가능한 agent는 audit에는 남지만 apply에서 건너뜁니다.
 - token/tool policy는 기본적으로 `report` 모드이며, 실제 쓰기 전 dry-run과 audit 결과를 먼저 확인하는 것이 안전합니다.

--- a/docs/openclaw-migrate.md
+++ b/docs/openclaw-migrate.md
@@ -10,6 +10,7 @@
 - provider/model 힌트 해석과 fallback provider 매핑
 - 프롬프트 부트스트랩 파일 병합
 - `MEMORY.md`, 일자별 memory markdown, workspace 복사
+- 생성된 AgentDesk prompt에 migrated memory/workspace 경로 고정
 - Discord channel binding 미리보기와 `org.yaml` 반영
 - `bot_settings.json` 토큰/허용 채널 반영
 - `ai_sessions` 및 DB 세션 이관
@@ -69,6 +70,14 @@ channel binding, bot 설정, 세션까지 함께 이관:
 - `HEARTBEAT.md`
 
 추가로 `MEMORY.md`와 `memory/` 아래 markdown 파일을 AgentDesk memory 구조로 복사합니다.
+
+생성된 `prompts/agents/<role>/IDENTITY.md` 상단에는 아래 migrated runtime 참조가 함께 기록됩니다.
+
+- `role-context/<role>.memory/` 경로
+- `openclaw/workspaces/<role>/` 경로
+- 원본 OpenClaw workspace 경로
+
+운영 기준은 AgentDesk가 생성한 memory/workspace 경로이며, 원본 OpenClaw 경로는 provenance로만 남깁니다. `--no-memory` 또는 `--no-workspace`를 쓴 경우에는 prompt에 해당 상태가 그대로 표시됩니다.
 
 ## 주요 플래그
 

--- a/scripts/deploy-dev.sh
+++ b/scripts/deploy-dev.sh
@@ -116,7 +116,8 @@ _sync_dev_credentials() {
     fi
 
     if [ -e "$dev_credential_dir" ] && [ ! -L "$dev_credential_dir" ]; then
-        local backup_dir="${dev_credential_dir}.bak.$(date '+%Y%m%d-%H%M%S')"
+        local backup_dir
+        backup_dir="${dev_credential_dir}.bak.$(date '+%Y%m%d-%H%M%S')"
         mv "$dev_credential_dir" "$backup_dir"
         echo "▸ Backed up stale dev credential dir to $backup_dir"
     else

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -1,0 +1,318 @@
+use std::path::{Path, PathBuf};
+
+use clap::Args;
+
+use crate::config;
+use crate::utils::format::expand_tilde_path;
+
+mod apply;
+mod plan;
+mod source;
+#[cfg(test)]
+mod tests;
+
+use apply::apply_import_plan;
+use plan::build_import_plan;
+use source::resolve_source_root;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ToolPolicyMode {
+    Report,
+    BotIntersection,
+    BotUnion,
+}
+
+impl ToolPolicyMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Report => "report",
+            Self::BotIntersection => "bot-intersection",
+            Self::BotUnion => "bot-union",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "report" => Ok(Self::Report),
+            "bot-intersection" => Ok(Self::BotIntersection),
+            "bot-union" => Ok(Self::BotUnion),
+            _ => Err(format!(
+                "Unsupported --tool-policy-mode '{}'. Expected one of: report, bot-intersection, bot-union.",
+                raw
+            )),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DiscordTokenMode {
+    Report,
+    PlaintextOnly,
+    ResolveEnvFile,
+    ResolveAll,
+}
+
+impl DiscordTokenMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Report => "report",
+            Self::PlaintextOnly => "plaintext-only",
+            Self::ResolveEnvFile => "resolve-env-file",
+            Self::ResolveAll => "resolve-all",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "report" => Ok(Self::Report),
+            "plaintext-only" => Ok(Self::PlaintextOnly),
+            "resolve-env-file" => Ok(Self::ResolveEnvFile),
+            "resolve-all" => Ok(Self::ResolveAll),
+            _ => Err(format!(
+                "Unsupported --discord-token-mode '{}'. Expected one of: report, plaintext-only, resolve-env-file, resolve-all.",
+                raw
+            )),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct OpenClawMigrateArgs {
+    /// OpenClaw root path or openclaw.json path. Defaults to the current directory.
+    #[arg(conflicts_with = "resume")]
+    pub root_path: Option<String>,
+    /// Override the target AgentDesk runtime root.
+    #[arg(long = "agentdesk-root", value_name = "PATH")]
+    pub agentdesk_root: Option<String>,
+    /// Select a specific source agent id. May be repeated.
+    #[arg(long = "agent", value_name = "AGENT_ID", conflicts_with = "all_agents")]
+    pub agent_ids: Vec<String>,
+    /// Import every source agent.
+    #[arg(long, conflicts_with = "agent_ids")]
+    pub all_agents: bool,
+    /// Print the canonical import plan without writing files.
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Resume an unfinished import from $AGENTDESK_ROOT_DIR/openclaw/imports/<import_id>.
+    #[arg(long, value_name = "IMPORT_ID", conflicts_with = "root_path")]
+    pub resume: Option<String>,
+    /// Fallback provider to use when the source provider is unsupported.
+    #[arg(long)]
+    pub fallback_provider: Option<String>,
+    /// Rewrite absolute OpenClaw workspace prefixes during import planning. May be repeated as OLD=NEW.
+    #[arg(long = "workspace-root-rewrite", value_name = "OLD=NEW")]
+    pub workspace_root_rewrite: Vec<String>,
+    /// Preview writing config/org.yaml mutations.
+    #[arg(long)]
+    pub write_org: bool,
+    /// Preview writing config/bot_settings.json mutations.
+    #[arg(long)]
+    pub write_bot_settings: bool,
+    /// Preview SQLite upserts.
+    #[arg(long)]
+    pub write_db: bool,
+    /// Preview replacing generated artifacts for the selected role(s).
+    #[arg(long)]
+    pub overwrite: bool,
+    /// Preview Discord channel binding imports.
+    #[arg(long)]
+    pub with_channel_bindings: bool,
+    /// Preview lossy session import.
+    #[arg(long)]
+    pub with_sessions: bool,
+    /// Preview snapshotting the source tree into audit outputs.
+    #[arg(long)]
+    pub snapshot_source: bool,
+    /// Skip workspace copy while still inspecting source workspaces for prompt/memory.
+    #[arg(long)]
+    pub no_workspace: bool,
+    /// Skip Markdown memory import.
+    #[arg(long)]
+    pub no_memory: bool,
+    /// Skip merged prompt generation.
+    #[arg(long)]
+    pub no_prompts: bool,
+    /// Tool-policy handling mode for bot_settings import.
+    #[arg(long, default_value = "report")]
+    pub tool_policy_mode: String,
+    /// Discord token handling mode for bot_settings import.
+    #[arg(long, default_value = "report")]
+    pub discord_token_mode: String,
+}
+
+pub fn cmd_migrate_openclaw(args: OpenClawMigrateArgs) -> Result<(), String> {
+    let cwd = std::env::current_dir().map_err(|e| format!("Failed to read current dir: {e}"))?;
+    let runtime_root = resolve_runtime_root(&args, &cwd);
+    let args = resolve_resume_args(&args, runtime_root.as_deref())?;
+    let source = resolve_source_root(args.root_path.as_deref(), &cwd, runtime_root.as_deref())?;
+    let plan = build_import_plan(&source, &args, runtime_root.as_deref())?;
+
+    if args.dry_run {
+        return render_import_plan(&plan);
+    }
+
+    let runtime_root = runtime_root.ok_or_else(|| {
+        "OpenClaw migrate apply requires a resolved AGENTDESK_ROOT_DIR runtime root.".to_string()
+    })?;
+    apply_import_plan(&plan, &source, &args, &runtime_root)
+}
+
+fn render_import_plan(plan: &impl serde::Serialize) -> Result<(), String> {
+    let rendered = serde_json::to_string_pretty(plan)
+        .map_err(|e| format!("Failed to serialize import plan: {e}"))?;
+    println!("{rendered}");
+    Ok(())
+}
+
+fn runtime_root_path(runtime_root: Option<&Path>) -> Option<String> {
+    runtime_root.map(|path| path.display().to_string())
+}
+
+fn resolve_runtime_root(args: &OpenClawMigrateArgs, cwd: &Path) -> Option<PathBuf> {
+    args.agentdesk_root
+        .as_deref()
+        .map(expand_tilde_path)
+        .map(|path| absolutize_path(cwd, &path))
+        .or_else(config::runtime_root)
+}
+
+fn absolutize_path(cwd: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    }
+}
+
+fn resolve_resume_args(
+    args: &OpenClawMigrateArgs,
+    runtime_root: Option<&Path>,
+) -> Result<OpenClawMigrateArgs, String> {
+    let Some(import_id) = args.resume.as_deref() else {
+        return Ok(args.clone());
+    };
+    let runtime_root = runtime_root.ok_or_else(|| {
+        "--resume requires a resolved AGENTDESK_ROOT_DIR runtime root.".to_string()
+    })?;
+    let audit_root = runtime_root
+        .join("openclaw")
+        .join("imports")
+        .join(import_id);
+    let resume_state_path = audit_root.join("resume-state.json");
+    let write_plan_path = audit_root.join("write-plan.json");
+    let manifest_path = audit_root.join("manifest.json");
+
+    let resume_state = read_json_file(&resume_state_path)?;
+    let _ = read_json_file(&manifest_path)?;
+    let write_plan = read_json_file(&write_plan_path)?;
+
+    let source_path = json_string(&resume_state, "source_path")
+        .or_else(|| json_string(&write_plan, "config_path"))
+        .ok_or_else(|| {
+            format!(
+                "Resume state '{}' is missing source_path/config_path.",
+                resume_state_path.display()
+            )
+        })?;
+    let selected_agents = json_string_list(&resume_state, "selected_agents")
+        .or_else(|| json_string_list(&write_plan, "selected_agent_ids"));
+
+    let requested_flags = write_plan
+        .get("requested_flags")
+        .and_then(serde_json::Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+
+    let mut effective = args.clone();
+    effective.root_path = Some(source_path);
+    effective.agent_ids = selected_agents.unwrap_or_default();
+    effective.all_agents = false;
+    effective.fallback_provider = effective
+        .fallback_provider
+        .clone()
+        .or_else(|| json_string_map(&requested_flags, "fallback_provider"));
+    merge_missing_strings(
+        &mut effective.workspace_root_rewrite,
+        json_string_list_map(&requested_flags, "workspace_root_rewrite"),
+    );
+    effective.write_org = effective.write_org || json_bool_map(&requested_flags, "write_org");
+    effective.write_bot_settings =
+        effective.write_bot_settings || json_bool_map(&requested_flags, "write_bot_settings");
+    effective.write_db = effective.write_db || json_bool_map(&requested_flags, "write_db");
+    effective.overwrite = effective.overwrite || json_bool_map(&requested_flags, "overwrite");
+    effective.with_channel_bindings =
+        effective.with_channel_bindings || json_bool_map(&requested_flags, "with_channel_bindings");
+    effective.with_sessions =
+        effective.with_sessions || json_bool_map(&requested_flags, "with_sessions");
+    effective.snapshot_source =
+        effective.snapshot_source || json_bool_map(&requested_flags, "snapshot_source");
+    effective.no_workspace =
+        effective.no_workspace || json_bool_map(&requested_flags, "no_workspace");
+    effective.no_memory = effective.no_memory || json_bool_map(&requested_flags, "no_memory");
+    effective.no_prompts = effective.no_prompts || json_bool_map(&requested_flags, "no_prompts");
+    if effective.tool_policy_mode == "report" {
+        if let Some(stored) = json_string_map(&requested_flags, "tool_policy_mode") {
+            effective.tool_policy_mode = stored;
+        }
+    }
+    if effective.discord_token_mode == "report" {
+        if let Some(stored) = json_string_map(&requested_flags, "discord_token_mode") {
+            effective.discord_token_mode = stored;
+        }
+    }
+
+    Ok(effective)
+}
+
+fn read_json_file(path: &Path) -> Result<serde_json::Value, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("Failed to read '{}': {e}", path.display()))?;
+    serde_json::from_str(&content).map_err(|e| format!("Failed to parse '{}': {e}", path.display()))
+}
+
+fn json_string(value: &serde_json::Value, key: &str) -> Option<String> {
+    value.get(key)?.as_str().map(ToOwned::to_owned)
+}
+
+fn json_string_list(value: &serde_json::Value, key: &str) -> Option<Vec<String>> {
+    let values = value.get(key)?.as_array()?;
+    Some(
+        values
+            .iter()
+            .filter_map(|item| item.as_str().map(ToOwned::to_owned))
+            .collect(),
+    )
+}
+
+fn json_bool_map(map: &serde_json::Map<String, serde_json::Value>, key: &str) -> bool {
+    map.get(key)
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn json_string_map(map: &serde_json::Map<String, serde_json::Value>, key: &str) -> Option<String> {
+    map.get(key)?.as_str().map(ToOwned::to_owned)
+}
+
+fn json_string_list_map(
+    map: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Vec<String> {
+    map.get(key)
+        .and_then(serde_json::Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|item| item.as_str().map(ToOwned::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn merge_missing_strings(target: &mut Vec<String>, values: Vec<String>) {
+    for value in values {
+        if !target.contains(&value) {
+            target.push(value);
+        }
+    }
+}

--- a/src/cli/migrate/apply.rs
+++ b/src/cli/migrate/apply.rs
@@ -2157,6 +2157,13 @@ fn build_bot_settings_entry_plans(
         } else {
             None
         };
+        if accumulator.role_ids.len() > 1 && allowed_channel_ids.is_none() {
+            warnings.push(format!(
+                "Skipping bot_settings import for Discord account '{}': multiple imported agents share the same token, but no live channel allowlist could be written to keep routing scoped.",
+                account_id
+            ));
+            continue;
+        }
         entries.push(BotSettingsEntryPlan {
             account_id,
             provider,
@@ -2255,10 +2262,10 @@ fn render_bot_settings_json(
     _overwrite: bool,
 ) -> Result<String, String> {
     let mut root = if path.exists() {
-        fs::read_to_string(path)
-            .ok()
-            .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
-            .unwrap_or_else(|| serde_json::json!({}))
+        let content = fs::read_to_string(path)
+            .map_err(|e| format!("Failed to read '{}': {e}", path.display()))?;
+        serde_json::from_str::<serde_json::Value>(&content)
+            .map_err(|e| format!("Failed to parse '{}': {e}", path.display()))?
     } else {
         serde_json::json!({})
     };

--- a/src/cli/migrate/apply.rs
+++ b/src/cli/migrate/apply.rs
@@ -1738,27 +1738,24 @@ fn upsert_imported_sessions(
                 .display()
                 .to_string()
         };
-        let status = match session.status.as_deref() {
-            Some("running") => "working",
-            Some("failed") | Some("timeout") | Some("killed") => "idle",
-            Some("done") => "idle",
-            _ => "idle",
-        };
+        let status = "idle";
         let session_info = serde_json::json!({
             "imported_from": "openclaw",
             "source_agent_id": session.source_agent_id,
             "source_session_key": session.session_key,
             "source_session_id": session.session_id,
+            "source_status": session.status,
+            "source_updated_at": session.updated_at,
             "source_cwd": session.cwd,
             "ai_session_path": session_map.ai_session_path,
         })
         .to_string();
         let thread_channel_id = session.thread_id.clone();
-        let claude_session_id = (provider == "claude").then_some(session.session_id.clone());
+        let last_heartbeat = None::<String>;
 
         conn.execute(
             "INSERT INTO sessions (session_key, agent_id, provider, status, session_info, model, tokens, cwd, active_dispatch_id, thread_channel_id, claude_session_id, last_heartbeat)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, ?9, ?10, datetime('now'))
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, ?9, NULL, ?10)
              ON CONFLICT(session_key) DO UPDATE SET
                status = excluded.status,
                provider = excluded.provider,
@@ -1768,8 +1765,8 @@ fn upsert_imported_sessions(
                cwd = COALESCE(excluded.cwd, sessions.cwd),
                agent_id = COALESCE(excluded.agent_id, sessions.agent_id),
                thread_channel_id = COALESCE(excluded.thread_channel_id, sessions.thread_channel_id),
-               claude_session_id = COALESCE(excluded.claude_session_id, sessions.claude_session_id),
-               last_heartbeat = datetime('now')",
+               claude_session_id = excluded.claude_session_id,
+               last_heartbeat = excluded.last_heartbeat",
             rusqlite::params![
                 session_map.db_session_key,
                 session.final_role_id,
@@ -1780,7 +1777,7 @@ fn upsert_imported_sessions(
                 0,
                 cwd,
                 thread_channel_id,
-                claude_session_id,
+                last_heartbeat,
             ],
         )
         .map_err(|e| format!("Failed to upsert imported session '{}': {e}", session.session_key))?;

--- a/src/cli/migrate/apply.rs
+++ b/src/cli/migrate/apply.rs
@@ -201,7 +201,7 @@ struct BotSettingsEntryPlan {
     provider: String,
     role_id: Option<String>,
     token: String,
-    allowed_channel_ids: Vec<u64>,
+    allowed_channel_ids: Option<Vec<u64>>,
     allowed_tools: Option<Vec<String>>,
 }
 
@@ -335,11 +335,15 @@ pub(super) fn apply_import_plan(
     )?;
 
     let result = (|| -> Result<(), String> {
-        let mut config = config::load_from_path_graceful(&yaml_path);
-        if !yaml_path.exists() {
+        let mut config = if yaml_path.exists() {
+            config::load_from_path(&yaml_path)
+                .map_err(|e| format!("Failed to load '{}': {e}", yaml_path.display()))?
+        } else {
+            let mut config = config::Config::default();
             config.data.dir = runtime_root.join("data");
             config.policies.dir = runtime_root.join("policies");
-        }
+            config
+        };
         merge_imported_agents(&mut config, plan, args.overwrite)?;
         if !args.write_db && !importable_agents.is_empty() {
             warnings.push(
@@ -2145,12 +2149,20 @@ fn build_bot_settings_entry_plans(
             tool_policy_mode,
             warnings,
         );
+        let allowed_channel_ids = if args.with_channel_bindings
+            && args.write_org
+            && !accumulator.channel_ids.is_empty()
+        {
+            Some(accumulator.channel_ids.into_iter().collect())
+        } else {
+            None
+        };
         entries.push(BotSettingsEntryPlan {
             account_id,
             provider,
             role_id,
             token,
-            allowed_channel_ids: accumulator.channel_ids.into_iter().collect(),
+            allowed_channel_ids,
             allowed_tools,
         });
     }
@@ -2263,10 +2275,12 @@ fn render_bot_settings_json(
         entry_json.insert("token".to_string(), serde_json::json!(entry.token));
         entry_json.insert("provider".to_string(), serde_json::json!(entry.provider));
         entry_json.insert("agent".to_string(), serde_json::json!(entry.role_id));
-        entry_json.insert(
-            "allowed_channel_ids".to_string(),
-            serde_json::json!(entry.allowed_channel_ids),
-        );
+        if let Some(allowed_channel_ids) = entry.allowed_channel_ids.as_ref() {
+            entry_json.insert(
+                "allowed_channel_ids".to_string(),
+                serde_json::json!(allowed_channel_ids),
+            );
+        }
         if let Some(allowed_tools) = entry.allowed_tools.as_ref() {
             entry_json.insert(
                 "allowed_tools".to_string(),
@@ -2312,6 +2326,7 @@ struct SecretRefSpec {
     source: String,
     provider: String,
     id: String,
+    implicit_provider: bool,
 }
 
 fn resolve_token_value(
@@ -2363,6 +2378,9 @@ fn parse_secret_ref(
                 source: "env".to_string(),
                 provider,
                 id: name.to_string(),
+                implicit_provider: secrets
+                    .and_then(|value| value.defaults.env.as_ref())
+                    .is_none(),
             }));
         }
         return Ok(None);
@@ -2385,6 +2403,13 @@ fn parse_secret_ref(
     else {
         return Err("SecretRef token is missing id".to_string());
     };
+    let implicit_provider = object.get("provider").is_none()
+        && match source.as_str() {
+            "env" => secrets
+                .and_then(|secrets| secrets.defaults.env.as_ref())
+                .is_none(),
+            _ => false,
+        };
     let provider = object
         .get("provider")
         .and_then(serde_json::Value::as_str)
@@ -2402,6 +2427,7 @@ fn parse_secret_ref(
         source,
         provider,
         id: id.to_string(),
+        implicit_provider,
     }))
 }
 
@@ -2410,6 +2436,15 @@ fn resolve_secret_ref_value(
     secrets: Option<&OpenClawSecretsConfig>,
     source_root: &Path,
 ) -> Result<String, String> {
+    if secret_ref.source == "env" && secret_ref.implicit_provider {
+        return std::env::var(&secret_ref.id).map_err(|_| {
+            format!(
+                "Env SecretRef '{}' is not set in the current environment.",
+                secret_ref.id
+            )
+        });
+    }
+
     let provider = secrets
         .and_then(|secrets| secrets.providers.get(&secret_ref.provider))
         .ok_or_else(|| {

--- a/src/cli/migrate/apply.rs
+++ b/src/cli/migrate/apply.rs
@@ -432,7 +432,7 @@ pub(super) fn apply_import_plan(
                         .as_ref()
                         .and_then(|entry| entry.prompt_path.clone())
                 } else {
-                    let prompt_content = render_imported_prompt(agent);
+                    let prompt_content = render_imported_prompt(agent, runtime_root, args);
                     write_text_file(
                         &prompt_path,
                         &prompt_content,
@@ -2663,11 +2663,34 @@ fn merge_imported_agents(
     Ok(())
 }
 
-fn render_imported_prompt(agent: &ImportAgentPlan) -> String {
+fn render_imported_prompt(
+    agent: &ImportAgentPlan,
+    runtime_root: &Path,
+    args: &OpenClawMigrateArgs,
+) -> String {
     let workspace = Path::new(&agent.workspace_source);
+    let memory_dir = runtime_root
+        .join("role-context")
+        .join(format!("{}.memory", agent.final_role_id));
+    let workspace_dir = runtime_root
+        .join("openclaw")
+        .join("workspaces")
+        .join(&agent.final_role_id);
     let mut sections = vec![format!(
-        "# Imported OpenClaw Role\n\n- role_id: `{}`\n- source_agent: `{}`\n- workspace: `{}`",
-        agent.final_role_id, agent.source_id, agent.workspace_source
+        "# Imported OpenClaw Role\n\n- role_id: `{}`\n- source_agent: `{}`\n- agentdesk_memory_dir: `{}`\n- agentdesk_workspace_dir: `{}`\n- source_workspace: `{}`\n\n## AgentDesk Runtime References\n\nUse AgentDesk-managed runtime paths when they exist. Treat the original OpenClaw workspace as provenance, not the default live runtime state.",
+        agent.final_role_id,
+        agent.source_id,
+        if args.no_memory {
+            "not imported (--no-memory)".to_string()
+        } else {
+            memory_dir.display().to_string()
+        },
+        if args.no_workspace {
+            "not copied (--no-workspace)".to_string()
+        } else {
+            workspace_dir.display().to_string()
+        },
+        agent.workspace_source
     )];
 
     for (file_name, heading) in BOOTSTRAP_PROMPT_SECTIONS {

--- a/src/cli/migrate/apply.rs
+++ b/src/cli/migrate/apply.rs
@@ -10,7 +10,7 @@ use sha2::{Digest, Sha256};
 use crate::config::{self, AgentDef as RuntimeAgentDef};
 use crate::db;
 use crate::db::agents::sync_agents_from_config;
-use crate::services::claude::DEFAULT_ALLOWED_TOOLS;
+use crate::services::agent_protocol::DEFAULT_ALLOWED_TOOLS;
 use crate::services::discord::org_writer::{self, OrgAgentUpdate, OrgChannelBindingUpdate};
 use crate::services::discord::runtime_store::org_schema_path_for_root;
 use crate::services::discord::settings::discord_token_hash;

--- a/src/cli/migrate/apply.rs
+++ b/src/cli/migrate/apply.rs
@@ -3013,19 +3013,15 @@ fn source_fingerprint(
         if !args.no_workspace {
             collect_tree_file_hashes(workspace, &source.root, &mut inputs)?;
         }
-    }
-
-    if args.with_sessions {
-        for session in &plan.sessions {
-            collect_source_file_hash(
-                Path::new(&session.session_store_path),
-                &source.root,
-                &mut inputs,
-            )?;
-            if let Some(transcript_path) = session.transcript_path.as_deref() {
-                collect_source_file_hash(Path::new(transcript_path), &source.root, &mut inputs)?;
-            }
-        }
+        collect_tree_file_hashes(
+            &source
+                .root
+                .join("agents")
+                .join(&agent.source_id)
+                .join("sessions"),
+            &source.root,
+            &mut inputs,
+        )?;
     }
 
     collect_resolved_bot_token_hashes(source, plan, args, &mut inputs)?;

--- a/src/cli/migrate/apply.rs
+++ b/src/cli/migrate/apply.rs
@@ -1,0 +1,3089 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use sha2::{Digest, Sha256};
+
+use crate::config::{self, AgentDef as RuntimeAgentDef};
+use crate::db;
+use crate::db::agents::sync_agents_from_config;
+use crate::services::claude::DEFAULT_ALLOWED_TOOLS;
+use crate::services::discord::org_writer::{self, OrgAgentUpdate, OrgChannelBindingUpdate};
+use crate::services::discord::runtime_store::org_schema_path_for_root;
+use crate::services::discord::settings::discord_token_hash;
+use crate::services::provider::ProviderKind;
+use crate::ui::ai_screen::{HistoryItem, HistoryType, SessionData};
+
+use super::DiscordTokenMode;
+use super::OpenClawMigrateArgs;
+use super::ToolPolicyMode;
+use super::plan::{ImportAgentPlan, ImportPlan, ImportSessionPlan};
+use super::source::{
+    OpenClawBindingConfig, OpenClawDiscordGuildConfig, OpenClawSecretProviderConfig,
+    OpenClawSecretsConfig, ResolvedSourceRoot,
+};
+
+const BOOTSTRAP_PROMPT_SECTIONS: &[(&str, &str)] = &[
+    ("IDENTITY.md", "Imported OpenClaw Identity"),
+    ("AGENTS.md", "Imported OpenClaw Agent Rules"),
+    ("SOUL.md", "Imported OpenClaw Persona"),
+    ("USER.md", "Imported OpenClaw User Context"),
+    ("TOOLS.md", "Imported OpenClaw Tool Notes"),
+    ("BOOT.md", "Imported OpenClaw Boot Intent"),
+    ("BOOTSTRAP.md", "Imported OpenClaw Bootstrap"),
+    ("HEARTBEAT.md", "Imported OpenClaw Heartbeat"),
+];
+
+const COPY_PRUNE_DIR_NAMES: &[&str] =
+    &[".git", "node_modules", "target", "dist", ".venv", ".cache"];
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct AgentMapEntry {
+    source_id: String,
+    role_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ManifestAgent {
+    source_id: String,
+    role_id: String,
+    provider: String,
+    prompt_path: Option<String>,
+    memory_dir: Option<String>,
+    workspace_source: String,
+    workspace_target: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct Manifest {
+    import_id: String,
+    source_root: String,
+    config_path: String,
+    selected_agent_ids: Vec<String>,
+    selected_discord_account_ids: Vec<String>,
+    written_paths: Vec<String>,
+    warnings: Vec<String>,
+    agents: Vec<ManifestAgent>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ApplyTaskState {
+    status: String,
+    outputs: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ApplyAgentState {
+    tasks: BTreeMap<String, ApplyTaskState>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ApplyPhaseState {
+    status: String,
+    started_at: String,
+    ended_at: String,
+    error: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ApplyResult {
+    status: String,
+    import_id: String,
+    source_root: String,
+    phases: BTreeMap<String, ApplyPhaseState>,
+    agents: BTreeMap<String, ApplyAgentState>,
+    warnings: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ResumeAgentState {
+    tasks: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ResumeState {
+    status: String,
+    source_path: String,
+    source_fingerprint: String,
+    import_id: String,
+    selected_agents: Vec<String>,
+    completed_phases: Vec<String>,
+    pending_phases: Vec<String>,
+    phases: BTreeMap<String, String>,
+    agents: BTreeMap<String, ResumeAgentState>,
+    next_recommended_step: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct DiscordAuthReportData {
+    default_token_configured: bool,
+    has_named_accounts: bool,
+    requested_token_mode: String,
+    write_bot_settings_enabled: bool,
+    accounts: Vec<DiscordAccountReportEntry>,
+    account_to_bot_mappings: Vec<DiscordAccountToBotMapping>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct DiscordAccountReportEntry {
+    account_id: String,
+    source: &'static str,
+    enabled: bool,
+    has_token: bool,
+    token_kind: String,
+    token_status: String,
+    importable: bool,
+    guild_count: usize,
+    channel_override_count: usize,
+    user_allowlist_count: usize,
+    role_allowlist_count: usize,
+    binding_roles_present: bool,
+    allow_bots_enabled: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct DiscordAccountToBotMapping {
+    account_id: String,
+    role_ids: Vec<String>,
+    providers: Vec<String>,
+    live_channel_ids: Vec<String>,
+    live_binding_agents: Vec<String>,
+    preview_only_binding_agents: Vec<String>,
+    mode: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct DiscordAuthReport<'a> {
+    default_token_configured: bool,
+    has_named_accounts: bool,
+    requested_token_mode: &'a str,
+    write_bot_settings_enabled: bool,
+    accounts: &'a [DiscordAccountReportEntry],
+    account_to_bot_mappings: &'a [DiscordAccountToBotMapping],
+    bindings: &'a [super::source::DiscordBindingImportPlan],
+    selected_account_ids: &'a [String],
+    warnings: &'a [String],
+}
+
+#[derive(Debug, Serialize)]
+struct ChannelBindingPreview<'a> {
+    bindings: &'a [super::source::DiscordBindingImportPlan],
+    warnings: &'a [String],
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct SessionMapEntry {
+    source_agent_id: String,
+    role_id: String,
+    session_key: String,
+    session_id: String,
+    transcript_path: Option<String>,
+    ai_session_path: String,
+    db_session_key: String,
+}
+
+#[derive(Default)]
+struct RestoredAuditState {
+    manifest_agents: Vec<ManifestAgent>,
+    written_paths: Vec<String>,
+    warnings: Vec<String>,
+    apply_agents: BTreeMap<String, ApplyAgentState>,
+    phase_status: BTreeMap<String, ApplyPhaseState>,
+    session_map: Vec<SessionMapEntry>,
+}
+
+#[derive(Clone, Debug)]
+struct BotSettingsEntryPlan {
+    account_id: String,
+    provider: String,
+    role_id: Option<String>,
+    token: String,
+    allowed_channel_ids: Vec<u64>,
+    allowed_tools: Option<Vec<String>>,
+}
+
+pub(super) fn apply_import_plan(
+    plan: &ImportPlan,
+    source: &ResolvedSourceRoot,
+    args: &OpenClawMigrateArgs,
+    runtime_root: &Path,
+) -> Result<(), String> {
+    let importable_agents = plan
+        .agents
+        .iter()
+        .filter(|agent| agent.eligible_for_v1)
+        .collect::<Vec<_>>();
+    if importable_agents.is_empty() {
+        let blocked_agents = plan
+            .agents
+            .iter()
+            .map(|agent| agent.source_id.clone())
+            .collect::<Vec<_>>();
+        return Err(format!(
+            "OpenClaw migrate apply has no importable agents after provider/workspace validation. Blocked: {}.",
+            blocked_agents.join(", ")
+        ));
+    }
+
+    let skipped_agents = plan
+        .agents
+        .iter()
+        .filter(|agent| !agent.eligible_for_v1)
+        .map(|agent| agent.source_id.clone())
+        .collect::<Vec<_>>();
+
+    let audit_root = plan
+        .audit_root
+        .as_ref()
+        .map(PathBuf::from)
+        .ok_or_else(|| "OpenClaw migrate apply requires a resolved audit root.".to_string())?;
+    let import_id = audit_root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("openclaw-import")
+        .to_string();
+    let backups_root = audit_root.join("backups");
+    fs::create_dir_all(&audit_root)
+        .map_err(|e| format!("Failed to create '{}': {e}", audit_root.display()))?;
+    fs::create_dir_all(&backups_root)
+        .map_err(|e| format!("Failed to create '{}': {e}", backups_root.display()))?;
+
+    let yaml_path = runtime_root.join("agentdesk.yaml");
+    let org_yaml_path = org_schema_path_for_root(runtime_root);
+    let bot_settings_path = runtime_root.join("config").join("bot_settings.json");
+    let ai_sessions_root = runtime_root.join("ai_sessions");
+    let prompts_root = runtime_root.join("prompts").join("agents");
+    let role_context_root = runtime_root.join("role-context");
+    let workspaces_root = runtime_root.join("openclaw").join("workspaces");
+    if !args.no_prompts {
+        fs::create_dir_all(&prompts_root)
+            .map_err(|e| format!("Failed to create '{}': {e}", prompts_root.display()))?;
+    }
+    if !args.no_memory {
+        fs::create_dir_all(&role_context_root)
+            .map_err(|e| format!("Failed to create '{}': {e}", role_context_root.display()))?;
+    }
+    if !args.no_workspace {
+        fs::create_dir_all(&workspaces_root)
+            .map_err(|e| format!("Failed to create '{}': {e}", workspaces_root.display()))?;
+    }
+    if args.with_sessions {
+        fs::create_dir_all(&ai_sessions_root)
+            .map_err(|e| format!("Failed to create '{}': {e}", ai_sessions_root.display()))?;
+    }
+
+    let mut warnings = plan.warnings.clone();
+    let mut written_paths = Vec::new();
+    let mut manifest_agents = Vec::new();
+    let mut session_map = planned_session_map(plan, runtime_root);
+    let agent_map = plan
+        .agents
+        .iter()
+        .map(|agent| AgentMapEntry {
+            source_id: agent.source_id.clone(),
+            role_id: agent.final_role_id.clone(),
+        })
+        .collect::<Vec<_>>();
+    let mut apply_agents = build_initial_apply_agents(plan, args);
+    let mut phase_status = build_initial_phase_status(plan, args);
+    let source_fingerprint = source_fingerprint(source, plan, args)?;
+    let discord_auth_report = build_discord_auth_report(plan, source, args)?;
+    if let Some(restored) = load_restored_audit_state(&audit_root, &source_fingerprint, args)? {
+        warnings = merge_strings(plan.warnings.clone(), restored.warnings);
+        written_paths = restored.written_paths;
+        manifest_agents = restored.manifest_agents;
+        if !restored.apply_agents.is_empty() {
+            apply_agents = restored.apply_agents;
+        }
+        if !restored.phase_status.is_empty() {
+            phase_status = restored.phase_status;
+        }
+        if !restored.session_map.is_empty() {
+            session_map = restored.session_map;
+        }
+    }
+    normalize_resumable_state(&mut apply_agents, &mut phase_status);
+
+    if !skipped_agents.is_empty() {
+        warnings.push(format!(
+            "Skipped non-importable OpenClaw agents during live apply: {}.",
+            skipped_agents.join(", ")
+        ));
+        warnings.sort();
+        warnings.dedup();
+    }
+
+    persist_audit_state(
+        &audit_root,
+        &import_id,
+        source,
+        plan,
+        &discord_auth_report,
+        &agent_map,
+        &manifest_agents,
+        &written_paths,
+        &warnings,
+        &apply_agents,
+        &phase_status,
+        &source_fingerprint,
+        "running",
+        "running",
+        Some(&session_map),
+    )?;
+
+    let result = (|| -> Result<(), String> {
+        let mut config = config::load_from_path_graceful(&yaml_path);
+        if !yaml_path.exists() {
+            config.data.dir = runtime_root.join("data");
+            config.policies.dir = runtime_root.join("policies");
+        }
+        merge_imported_agents(&mut config, plan, args.overwrite)?;
+        if !args.write_db && !importable_agents.is_empty() {
+            warnings.push(
+                "Imported agents updated agentdesk.yaml only; runtime DB visibility may wait for the next standard sync or restart."
+                    .to_string(),
+            );
+        }
+
+        if args.with_sessions && phase_needs_apply(&phase_status, "sessions") {
+            mark_phase_running(&mut phase_status, "sessions");
+            persist_audit_state(
+                &audit_root,
+                &import_id,
+                source,
+                plan,
+                &discord_auth_report,
+                &agent_map,
+                &manifest_agents,
+                &written_paths,
+                &warnings,
+                &apply_agents,
+                &phase_status,
+                &source_fingerprint,
+                "running",
+                "running",
+                Some(&session_map),
+            )?;
+
+            let session_outputs = import_sessions(
+                plan,
+                runtime_root,
+                &ai_sessions_root,
+                &backups_root,
+                args.overwrite || args.resume.is_some(),
+                args.no_workspace,
+            )?;
+            for (role_id, outputs) in &session_outputs.agent_outputs {
+                if let Some(state) = apply_agents.get_mut(role_id) {
+                    update_task_state(state, "session_import", "completed", outputs.clone());
+                }
+            }
+            written_paths.extend(session_outputs.written_paths);
+            write_json_file(&audit_root.join("session-map.json"), &session_map)?;
+            mark_phase_completed(&mut phase_status, "sessions");
+        }
+
+        if phase_needs_apply(&phase_status, "apply_files") {
+            mark_phase_running(&mut phase_status, "apply_files");
+            persist_audit_state(
+                &audit_root,
+                &import_id,
+                source,
+                plan,
+                &discord_auth_report,
+                &agent_map,
+                &manifest_agents,
+                &written_paths,
+                &warnings,
+                &apply_agents,
+                &phase_status,
+                &source_fingerprint,
+                "running",
+                "running",
+                Some(&session_map),
+            )?;
+
+            let rendered_yaml = serde_yaml::to_string(&config)
+                .map_err(|e| format!("Failed to serialize '{}': {e}", yaml_path.display()))?;
+            write_text_file(
+                &yaml_path,
+                &rendered_yaml,
+                runtime_root,
+                &backups_root,
+                true,
+            )?;
+            written_paths.push(yaml_path.display().to_string());
+
+            for agent in importable_agents.iter().copied() {
+                let existing_manifest =
+                    manifest_agent_lookup(&manifest_agents, &agent.final_role_id).cloned();
+                let prompt_already_done =
+                    task_is_finished(&apply_agents, &agent.final_role_id, "prompt_write");
+                let memory_already_done =
+                    task_is_finished(&apply_agents, &agent.final_role_id, "memory_import");
+                let workspace_already_done =
+                    task_is_finished(&apply_agents, &agent.final_role_id, "workspace_copy");
+                let prompt_path = prompts_root.join(&agent.final_role_id).join("IDENTITY.md");
+                let written_prompt_path = if args.no_prompts || prompt_already_done {
+                    existing_manifest
+                        .as_ref()
+                        .and_then(|entry| entry.prompt_path.clone())
+                } else {
+                    let prompt_content = render_imported_prompt(agent);
+                    write_text_file(
+                        &prompt_path,
+                        &prompt_content,
+                        runtime_root,
+                        &backups_root,
+                        args.overwrite || args.resume.is_some(),
+                    )?;
+                    Some(prompt_path.display().to_string())
+                };
+
+                let memory_dir = role_context_root.join(format!("{}.memory", agent.final_role_id));
+                let memory_outputs = if args.no_memory || memory_already_done {
+                    existing_manifest
+                        .as_ref()
+                        .and_then(|entry| entry.memory_dir.as_ref().map(PathBuf::from))
+                        .map(|root| collect_existing_tree_files(&root))
+                        .transpose()?
+                        .unwrap_or_default()
+                } else {
+                    import_memory_files(
+                        agent,
+                        &memory_dir,
+                        runtime_root,
+                        &backups_root,
+                        args.overwrite || args.resume.is_some(),
+                    )?
+                };
+                let written_memory_dir = if args.no_memory {
+                    None
+                } else if memory_already_done {
+                    existing_manifest
+                        .as_ref()
+                        .and_then(|entry| entry.memory_dir.clone())
+                } else {
+                    Some(memory_dir.display().to_string())
+                };
+
+                let workspace_target = if args.no_workspace {
+                    None
+                } else {
+                    let destination = workspaces_root.join(&agent.final_role_id);
+                    if !workspace_already_done {
+                        copy_workspace_snapshot(
+                            Path::new(&agent.workspace_source),
+                            &destination,
+                            runtime_root,
+                            &backups_root,
+                            args.overwrite || args.resume.is_some(),
+                            &mut warnings,
+                        )?;
+                    }
+                    Some(destination)
+                };
+
+                if let Some(prompt_path) = &written_prompt_path {
+                    written_paths.push(prompt_path.clone());
+                }
+                written_paths.extend(memory_outputs.iter().map(|path| path.display().to_string()));
+                if let Some(workspace_target) = &workspace_target {
+                    written_paths.push(workspace_target.display().to_string());
+                }
+
+                upsert_manifest_agent(
+                    &mut manifest_agents,
+                    ManifestAgent {
+                        source_id: agent.source_id.clone(),
+                        role_id: agent.final_role_id.clone(),
+                        provider: agent
+                            .mapped_provider
+                            .clone()
+                            .unwrap_or_else(|| "unknown".to_string()),
+                        prompt_path: written_prompt_path.clone(),
+                        memory_dir: written_memory_dir,
+                        workspace_source: agent.workspace_source.clone(),
+                        workspace_target: workspace_target
+                            .as_ref()
+                            .map(|path| path.display().to_string()),
+                    },
+                );
+
+                if let Some(state) = apply_agents.get_mut(&agent.final_role_id) {
+                    update_task_state(
+                        state,
+                        "workspace_copy",
+                        if args.no_workspace {
+                            "skipped"
+                        } else {
+                            "completed"
+                        },
+                        workspace_target
+                            .as_ref()
+                            .map(|path| vec![path.display().to_string()])
+                            .unwrap_or_default(),
+                    );
+                    update_task_state(
+                        state,
+                        "prompt_write",
+                        if args.no_prompts {
+                            "skipped"
+                        } else {
+                            "completed"
+                        },
+                        written_prompt_path.clone().into_iter().collect(),
+                    );
+                    update_task_state(
+                        state,
+                        "memory_import",
+                        if args.no_memory {
+                            "skipped"
+                        } else {
+                            "completed"
+                        },
+                        memory_outputs
+                            .iter()
+                            .map(|path| path.display().to_string())
+                            .collect(),
+                    );
+                }
+
+                persist_audit_state(
+                    &audit_root,
+                    &import_id,
+                    source,
+                    plan,
+                    &discord_auth_report,
+                    &agent_map,
+                    &manifest_agents,
+                    &written_paths,
+                    &warnings,
+                    &apply_agents,
+                    &phase_status,
+                    &source_fingerprint,
+                    "running",
+                    "running",
+                    Some(&session_map),
+                )?;
+            }
+
+            mark_phase_completed(&mut phase_status, "apply_files");
+        }
+        if args.write_org && phase_needs_apply(&phase_status, "apply_org") {
+            mark_phase_running(&mut phase_status, "apply_org");
+            persist_audit_state(
+                &audit_root,
+                &import_id,
+                source,
+                plan,
+                &discord_auth_report,
+                &agent_map,
+                &manifest_agents,
+                &written_paths,
+                &warnings,
+                &apply_agents,
+                &phase_status,
+                &source_fingerprint,
+                "running",
+                "running",
+                Some(&session_map),
+            )?;
+
+            let rendered_org = org_writer::merge_org_updates(
+                runtime_root,
+                &build_org_agent_updates(plan, runtime_root, args),
+                &build_org_channel_updates(plan, runtime_root, args),
+                args.overwrite || args.resume.is_some(),
+            )?;
+            write_text_file(
+                &org_yaml_path,
+                &rendered_org,
+                runtime_root,
+                &backups_root,
+                true,
+            )?;
+            written_paths.push(org_yaml_path.display().to_string());
+
+            for state in apply_agents.values_mut() {
+                update_task_state(
+                    state,
+                    "org_agent_write",
+                    "completed",
+                    org_task_outputs(&org_yaml_path, args.with_channel_bindings),
+                );
+            }
+            mark_phase_completed(&mut phase_status, "apply_org");
+        }
+
+        if args.write_bot_settings && phase_needs_apply(&phase_status, "apply_bot_settings") {
+            mark_phase_running(&mut phase_status, "apply_bot_settings");
+            persist_audit_state(
+                &audit_root,
+                &import_id,
+                source,
+                plan,
+                &discord_auth_report,
+                &agent_map,
+                &manifest_agents,
+                &written_paths,
+                &warnings,
+                &apply_agents,
+                &phase_status,
+                &source_fingerprint,
+                "running",
+                "running",
+                Some(&session_map),
+            )?;
+
+            let bot_entries = build_bot_settings_entry_plans(plan, source, args, &mut warnings)?;
+            if !bot_entries.is_empty() {
+                let rendered_bot_settings = render_bot_settings_json(
+                    &bot_settings_path,
+                    &bot_entries,
+                    args.overwrite || args.resume.is_some(),
+                )?;
+                write_text_file(
+                    &bot_settings_path,
+                    &rendered_bot_settings,
+                    runtime_root,
+                    &backups_root,
+                    true,
+                )?;
+                written_paths.push(bot_settings_path.display().to_string());
+            }
+            mark_phase_completed(&mut phase_status, "apply_bot_settings");
+        }
+
+        if args.write_db && phase_needs_apply(&phase_status, "apply_db") {
+            mark_phase_running(&mut phase_status, "apply_db");
+            persist_audit_state(
+                &audit_root,
+                &import_id,
+                source,
+                plan,
+                &discord_auth_report,
+                &agent_map,
+                &manifest_agents,
+                &written_paths,
+                &warnings,
+                &apply_agents,
+                &phase_status,
+                &source_fingerprint,
+                "running",
+                "running",
+                Some(&session_map),
+            )?;
+
+            let db_path = apply_db_import(
+                &config,
+                plan,
+                &session_map,
+                args,
+                runtime_root,
+                &mut warnings,
+            )?;
+            written_paths.push(db_path.display().to_string());
+            for state in apply_agents.values_mut() {
+                update_task_state(
+                    state,
+                    "db_upsert",
+                    "completed",
+                    vec![db_path.display().to_string()],
+                );
+            }
+            mark_phase_completed(&mut phase_status, "apply_db");
+        }
+
+        if phase_needs_apply(&phase_status, "finalize") {
+            mark_phase_running(&mut phase_status, "finalize");
+            if args.snapshot_source {
+                let snapshot_root = audit_root.join("snapshot");
+                copy_source_snapshot(
+                    &source.root,
+                    &snapshot_root,
+                    args.overwrite || args.resume.is_some(),
+                    &mut warnings,
+                )?;
+                written_paths.push(snapshot_root.display().to_string());
+            }
+            warnings.sort();
+            warnings.dedup();
+            written_paths.sort();
+            written_paths.dedup();
+            persist_audit_state(
+                &audit_root,
+                &import_id,
+                source,
+                plan,
+                &discord_auth_report,
+                &agent_map,
+                &manifest_agents,
+                &written_paths,
+                &warnings,
+                &apply_agents,
+                &phase_status,
+                &source_fingerprint,
+                "running",
+                "running",
+                Some(&session_map),
+            )?;
+            mark_phase_completed(&mut phase_status, "finalize");
+        }
+        persist_audit_state(
+            &audit_root,
+            &import_id,
+            source,
+            plan,
+            &discord_auth_report,
+            &agent_map,
+            &manifest_agents,
+            &written_paths,
+            &warnings,
+            &apply_agents,
+            &phase_status,
+            &source_fingerprint,
+            "completed",
+            "finalized",
+            Some(&session_map),
+        )?;
+        Ok(())
+    })();
+
+    if let Err(err) = result {
+        mark_first_running_phase_failed(&mut phase_status, &err);
+        warnings.sort();
+        warnings.dedup();
+        written_paths.sort();
+        written_paths.dedup();
+        let _ = persist_audit_state(
+            &audit_root,
+            &import_id,
+            source,
+            plan,
+            &discord_auth_report,
+            &agent_map,
+            &manifest_agents,
+            &written_paths,
+            &warnings,
+            &apply_agents,
+            &phase_status,
+            &source_fingerprint,
+            "failed",
+            "failed",
+            Some(&session_map),
+        );
+        return Err(err);
+    }
+
+    Ok(())
+}
+
+fn build_org_agent_updates(
+    plan: &ImportPlan,
+    runtime_root: &Path,
+    args: &OpenClawMigrateArgs,
+) -> Vec<OrgAgentUpdate> {
+    plan.agents
+        .iter()
+        .filter(|agent| agent.eligible_for_v1)
+        .map(|agent| OrgAgentUpdate {
+            role_id: agent.final_role_id.clone(),
+            display_name: agent.display_name.clone(),
+            prompt_file: if args.no_prompts {
+                None
+            } else {
+                Some(
+                    runtime_root
+                        .join("prompts")
+                        .join("agents")
+                        .join(&agent.final_role_id)
+                        .join("IDENTITY.md")
+                        .display()
+                        .to_string(),
+                )
+            },
+            provider: agent.mapped_provider.clone(),
+            model: agent.model_hint.clone(),
+            workspace: if args.no_workspace {
+                None
+            } else {
+                Some(
+                    runtime_root
+                        .join("openclaw")
+                        .join("workspaces")
+                        .join(&agent.final_role_id)
+                        .display()
+                        .to_string(),
+                )
+            },
+        })
+        .collect()
+}
+
+fn build_org_channel_updates(
+    plan: &ImportPlan,
+    runtime_root: &Path,
+    args: &OpenClawMigrateArgs,
+) -> Vec<OrgChannelBindingUpdate> {
+    if !args.with_channel_bindings {
+        return Vec::new();
+    }
+
+    let agent_lookup = plan
+        .agents
+        .iter()
+        .filter(|agent| agent.eligible_for_v1)
+        .map(|agent| (agent.source_id.as_str(), agent))
+        .collect::<BTreeMap<_, _>>();
+    let mut updates = Vec::new();
+
+    for binding in plan
+        .discord
+        .bindings
+        .iter()
+        .filter(|binding| binding.mode == "live_applicable")
+    {
+        let Some(agent) = agent_lookup.get(binding.agent_id.as_str()) else {
+            continue;
+        };
+        for channel_id in &binding.channel_ids {
+            updates.push(OrgChannelBindingUpdate {
+                channel_id: channel_id.clone(),
+                agent: agent.final_role_id.clone(),
+                workspace: if args.no_workspace {
+                    None
+                } else {
+                    Some(
+                        runtime_root
+                            .join("openclaw")
+                            .join("workspaces")
+                            .join(&agent.final_role_id)
+                            .display()
+                            .to_string(),
+                    )
+                },
+                provider: agent.mapped_provider.clone(),
+                model: agent.model_hint.clone(),
+            });
+        }
+    }
+
+    updates
+}
+
+fn org_task_outputs(org_yaml_path: &Path, with_channel_bindings: bool) -> Vec<String> {
+    let mut outputs = vec![org_yaml_path.display().to_string()];
+    if with_channel_bindings {
+        outputs.push(format!("{}#channels.by_id", org_yaml_path.display()));
+    }
+    outputs
+}
+
+fn build_initial_apply_agents(
+    plan: &ImportPlan,
+    args: &OpenClawMigrateArgs,
+) -> BTreeMap<String, ApplyAgentState> {
+    plan.agents
+        .iter()
+        .map(|agent| {
+            let mut tasks = BTreeMap::new();
+            let live_enabled = agent.eligible_for_v1;
+            tasks.insert(
+                "workspace_copy".to_string(),
+                ApplyTaskState {
+                    status: if !live_enabled || args.no_workspace {
+                        "skipped".to_string()
+                    } else {
+                        "pending".to_string()
+                    },
+                    outputs: Vec::new(),
+                },
+            );
+            tasks.insert(
+                "prompt_write".to_string(),
+                ApplyTaskState {
+                    status: if !live_enabled || args.no_prompts {
+                        "skipped".to_string()
+                    } else {
+                        "pending".to_string()
+                    },
+                    outputs: Vec::new(),
+                },
+            );
+            tasks.insert(
+                "memory_import".to_string(),
+                ApplyTaskState {
+                    status: if !live_enabled || args.no_memory {
+                        "skipped".to_string()
+                    } else {
+                        "pending".to_string()
+                    },
+                    outputs: Vec::new(),
+                },
+            );
+            tasks.insert(
+                "session_import".to_string(),
+                ApplyTaskState {
+                    status: if live_enabled && args.with_sessions {
+                        "pending".to_string()
+                    } else {
+                        "skipped".to_string()
+                    },
+                    outputs: Vec::new(),
+                },
+            );
+            tasks.insert(
+                "org_agent_write".to_string(),
+                ApplyTaskState {
+                    status: if live_enabled && args.write_org {
+                        "pending".to_string()
+                    } else {
+                        "skipped".to_string()
+                    },
+                    outputs: Vec::new(),
+                },
+            );
+            tasks.insert(
+                "db_upsert".to_string(),
+                ApplyTaskState {
+                    status: if live_enabled && args.write_db {
+                        "pending".to_string()
+                    } else {
+                        "skipped".to_string()
+                    },
+                    outputs: Vec::new(),
+                },
+            );
+            (agent.final_role_id.clone(), ApplyAgentState { tasks })
+        })
+        .collect()
+}
+
+fn build_initial_phase_status(
+    plan: &ImportPlan,
+    args: &OpenClawMigrateArgs,
+) -> BTreeMap<String, ApplyPhaseState> {
+    let now = Utc::now().to_rfc3339();
+    plan.phases
+        .iter()
+        .map(|phase| {
+            let status = match phase.phase {
+                "scan" | "map" | "prompt" | "memory" | "policy_discord" => "completed",
+                "sessions" if args.with_sessions => "pending",
+                "apply_org" if args.write_org => "pending",
+                "apply_bot_settings" if args.write_bot_settings => "pending",
+                "apply_db" if args.write_db => "pending",
+                "apply_org" | "apply_bot_settings" | "apply_db" | "sessions" => "skipped",
+                _ => "pending",
+            };
+            (
+                phase.phase.to_string(),
+                ApplyPhaseState {
+                    status: status.to_string(),
+                    started_at: if status == "completed" {
+                        now.clone()
+                    } else {
+                        String::new()
+                    },
+                    ended_at: if status == "completed" {
+                        now.clone()
+                    } else {
+                        String::new()
+                    },
+                    error: None,
+                },
+            )
+        })
+        .collect()
+}
+
+fn mark_phase_running(phases: &mut BTreeMap<String, ApplyPhaseState>, phase: &str) {
+    if let Some(entry) = phases.get_mut(phase) {
+        entry.status = "running".to_string();
+        entry.started_at = Utc::now().to_rfc3339();
+        entry.ended_at.clear();
+        entry.error = None;
+    }
+}
+
+fn mark_phase_completed(phases: &mut BTreeMap<String, ApplyPhaseState>, phase: &str) {
+    if let Some(entry) = phases.get_mut(phase) {
+        if entry.started_at.is_empty() {
+            entry.started_at = Utc::now().to_rfc3339();
+        }
+        entry.status = "completed".to_string();
+        entry.ended_at = Utc::now().to_rfc3339();
+        entry.error = None;
+    }
+}
+
+fn mark_first_running_phase_failed(phases: &mut BTreeMap<String, ApplyPhaseState>, error: &str) {
+    if let Some((_, entry)) = phases
+        .iter_mut()
+        .find(|(_, phase)| phase.status == "running")
+    {
+        if entry.started_at.is_empty() {
+            entry.started_at = Utc::now().to_rfc3339();
+        }
+        entry.status = "failed".to_string();
+        entry.ended_at = Utc::now().to_rfc3339();
+        entry.error = Some(error.to_string());
+        return;
+    }
+    if let Some(entry) = phases.get_mut("finalize") {
+        entry.status = "failed".to_string();
+        entry.started_at = Utc::now().to_rfc3339();
+        entry.ended_at = Utc::now().to_rfc3339();
+        entry.error = Some(error.to_string());
+    }
+}
+
+fn update_task_state(
+    state: &mut ApplyAgentState,
+    key: &str,
+    status: &'static str,
+    outputs: Vec<String>,
+) {
+    state.tasks.insert(
+        key.to_string(),
+        ApplyTaskState {
+            status: status.to_string(),
+            outputs,
+        },
+    );
+}
+
+fn load_restored_audit_state(
+    audit_root: &Path,
+    source_fingerprint: &str,
+    args: &OpenClawMigrateArgs,
+) -> Result<Option<RestoredAuditState>, String> {
+    if args.resume.is_none() {
+        return Ok(None);
+    }
+
+    let resume_state: ResumeState =
+        match read_json_if_exists(&audit_root.join("resume-state.json"))? {
+            Some(value) => value,
+            None => return Ok(None),
+        };
+    if resume_state.source_fingerprint != source_fingerprint {
+        return Err(format!(
+            "Resume fingerprint mismatch for '{}'. Expected '{}', found '{}'.",
+            audit_root.display(),
+            source_fingerprint,
+            resume_state.source_fingerprint
+        ));
+    }
+
+    let manifest: Option<Manifest> = read_json_if_exists(&audit_root.join("manifest.json"))?;
+    let apply_result: Option<ApplyResult> =
+        read_json_if_exists(&audit_root.join("apply-result.json"))?;
+    let session_map: Option<Vec<SessionMapEntry>> =
+        read_json_if_exists(&audit_root.join("session-map.json"))?;
+
+    Ok(Some(RestoredAuditState {
+        manifest_agents: manifest
+            .as_ref()
+            .map(|value| value.agents.clone())
+            .unwrap_or_default(),
+        written_paths: manifest
+            .as_ref()
+            .map(|value| value.written_paths.clone())
+            .unwrap_or_default(),
+        warnings: merge_strings(
+            manifest
+                .as_ref()
+                .map(|value| value.warnings.clone())
+                .unwrap_or_default(),
+            apply_result
+                .as_ref()
+                .map(|value| value.warnings.clone())
+                .unwrap_or_default(),
+        ),
+        apply_agents: apply_result
+            .as_ref()
+            .map(|value| value.agents.clone())
+            .unwrap_or_default(),
+        phase_status: apply_result
+            .as_ref()
+            .map(|value| value.phases.clone())
+            .unwrap_or_default(),
+        session_map: session_map.unwrap_or_default(),
+    }))
+}
+
+fn read_json_if_exists<T: DeserializeOwned>(path: &Path) -> Result<Option<T>, String> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = fs::read_to_string(path)
+        .map_err(|e| format!("Failed to read '{}': {e}", path.display()))?;
+    serde_json::from_str(&content)
+        .map(Some)
+        .map_err(|e| format!("Failed to parse '{}': {e}", path.display()))
+}
+
+fn merge_strings(mut left: Vec<String>, right: Vec<String>) -> Vec<String> {
+    left.extend(right);
+    left.sort();
+    left.dedup();
+    left
+}
+
+fn normalize_resumable_state(
+    apply_agents: &mut BTreeMap<String, ApplyAgentState>,
+    phase_status: &mut BTreeMap<String, ApplyPhaseState>,
+) {
+    for phase in phase_status.values_mut() {
+        if phase.status == "running" || phase.status == "failed" {
+            phase.status = "pending".to_string();
+            phase.error = None;
+            phase.started_at.clear();
+            phase.ended_at.clear();
+        }
+    }
+
+    for agent in apply_agents.values_mut() {
+        for task in agent.tasks.values_mut() {
+            if task.status == "running" || task.status == "failed" {
+                task.status = "pending".to_string();
+            }
+        }
+    }
+}
+
+fn phase_needs_apply(phases: &BTreeMap<String, ApplyPhaseState>, phase: &str) -> bool {
+    phases
+        .get(phase)
+        .map(|state| state.status != "completed" && state.status != "skipped")
+        .unwrap_or(true)
+}
+
+fn task_is_finished(
+    apply_agents: &BTreeMap<String, ApplyAgentState>,
+    role_id: &str,
+    task_key: &str,
+) -> bool {
+    apply_agents
+        .get(role_id)
+        .and_then(|state| state.tasks.get(task_key))
+        .map(|task| task.status == "completed" || task.status == "skipped")
+        .unwrap_or(false)
+}
+
+fn manifest_agent_lookup<'a>(
+    manifest_agents: &'a [ManifestAgent],
+    role_id: &str,
+) -> Option<&'a ManifestAgent> {
+    manifest_agents
+        .iter()
+        .find(|entry| entry.role_id == role_id)
+}
+
+fn upsert_manifest_agent(manifest_agents: &mut Vec<ManifestAgent>, next: ManifestAgent) {
+    if let Some(existing) = manifest_agents
+        .iter_mut()
+        .find(|entry| entry.role_id == next.role_id)
+    {
+        *existing = next;
+    } else {
+        manifest_agents.push(next);
+    }
+}
+
+fn collect_existing_tree_files(root: &Path) -> Result<Vec<PathBuf>, String> {
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+    if root.is_file() {
+        return Ok(vec![root.to_path_buf()]);
+    }
+
+    let mut outputs = Vec::new();
+    let mut queue = VecDeque::from([root.to_path_buf()]);
+    while let Some(dir) = queue.pop_front() {
+        let entries =
+            fs::read_dir(&dir).map_err(|e| format!("Failed to read '{}': {e}", dir.display()))?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_symlink() {
+                continue;
+            }
+            if file_type.is_dir() {
+                queue.push_back(path);
+                continue;
+            }
+            if file_type.is_file() {
+                outputs.push(path);
+            }
+        }
+    }
+    outputs.sort();
+    Ok(outputs)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn persist_audit_state(
+    audit_root: &Path,
+    import_id: &str,
+    source: &ResolvedSourceRoot,
+    plan: &ImportPlan,
+    discord_auth_report: &DiscordAuthReportData,
+    agent_map: &[AgentMapEntry],
+    manifest_agents: &[ManifestAgent],
+    written_paths: &[String],
+    warnings: &[String],
+    apply_agents: &BTreeMap<String, ApplyAgentState>,
+    phase_status: &BTreeMap<String, ApplyPhaseState>,
+    source_fingerprint: &str,
+    apply_status: &'static str,
+    resume_status: &'static str,
+    session_map: Option<&[SessionMapEntry]>,
+) -> Result<(), String> {
+    let manifest = Manifest {
+        import_id: import_id.to_string(),
+        source_root: source.root.display().to_string(),
+        config_path: source.config_path.display().to_string(),
+        selected_agent_ids: plan.selected_agent_ids.clone(),
+        selected_discord_account_ids: plan.selected_discord_account_ids.clone(),
+        written_paths: written_paths.to_vec(),
+        warnings: warnings.to_vec(),
+        agents: manifest_agents.to_vec(),
+    };
+    write_json_file(&audit_root.join("manifest.json"), &manifest)?;
+    write_json_file(&audit_root.join("agent-map.json"), &agent_map)?;
+    write_json_file(&audit_root.join("write-plan.json"), plan)?;
+    write_json_file(
+        &audit_root.join("tool-policy-report.json"),
+        &plan.tool_policy,
+    )?;
+    write_json_file(
+        &audit_root.join("discord-auth-report.json"),
+        &DiscordAuthReport {
+            default_token_configured: discord_auth_report.default_token_configured,
+            has_named_accounts: discord_auth_report.has_named_accounts,
+            requested_token_mode: &discord_auth_report.requested_token_mode,
+            write_bot_settings_enabled: discord_auth_report.write_bot_settings_enabled,
+            accounts: &discord_auth_report.accounts,
+            account_to_bot_mappings: &discord_auth_report.account_to_bot_mappings,
+            bindings: &plan.discord.bindings,
+            selected_account_ids: &plan.selected_discord_account_ids,
+            warnings,
+        },
+    )?;
+    write_yaml_file(
+        &audit_root.join("channel-binding-preview.yaml"),
+        &ChannelBindingPreview {
+            bindings: &plan.discord.bindings,
+            warnings,
+        },
+    )?;
+    if let Some(session_map) = session_map {
+        write_json_file(&audit_root.join("session-map.json"), &session_map)?;
+    }
+
+    let apply_result = ApplyResult {
+        status: apply_status.to_string(),
+        import_id: import_id.to_string(),
+        source_root: source.root.display().to_string(),
+        phases: phase_status.clone(),
+        agents: apply_agents.clone(),
+        warnings: warnings.to_vec(),
+    };
+    write_json_file(&audit_root.join("apply-result.json"), &apply_result)?;
+
+    let completed_phases = phase_status
+        .iter()
+        .filter_map(|(phase, state)| (state.status == "completed").then_some(phase.clone()))
+        .collect::<Vec<_>>();
+    let pending_phases = phase_status
+        .iter()
+        .filter_map(|(phase, state)| {
+            (state.status == "pending" || state.status == "running").then_some(phase.clone())
+        })
+        .collect::<Vec<_>>();
+    let agents = apply_agents
+        .iter()
+        .map(|(role_id, state)| {
+            (
+                role_id.clone(),
+                ResumeAgentState {
+                    tasks: state
+                        .tasks
+                        .iter()
+                        .map(|(key, value)| (key.clone(), value.status.clone()))
+                        .collect(),
+                },
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let next_recommended_step = if resume_status == "finalized" {
+        "finalized"
+    } else if phase_status.values().any(|phase| phase.status == "failed") {
+        "manual_intervention_required"
+    } else if !pending_phases.is_empty() {
+        "resume_phase"
+    } else {
+        "resume_agent_tasks"
+    };
+    let resume_state = ResumeState {
+        status: resume_status.to_string(),
+        source_path: source.config_path.display().to_string(),
+        source_fingerprint: source_fingerprint.to_string(),
+        import_id: import_id.to_string(),
+        selected_agents: plan.selected_agent_ids.clone(),
+        completed_phases,
+        pending_phases,
+        phases: phase_status
+            .iter()
+            .map(|(phase, state)| (phase.clone(), state.status.clone()))
+            .collect(),
+        agents,
+        next_recommended_step: next_recommended_step.to_string(),
+    };
+    write_json_file(&audit_root.join("resume-state.json"), &resume_state)?;
+    fs::write(audit_root.join("warnings.txt"), warnings.join("\n"))
+        .map_err(|e| format!("Failed to write warnings.txt: {e}"))?;
+    Ok(())
+}
+
+fn planned_session_map(plan: &ImportPlan, runtime_root: &Path) -> Vec<SessionMapEntry> {
+    let ai_sessions_root = runtime_root.join("ai_sessions");
+    plan.sessions
+        .iter()
+        .map(|session| SessionMapEntry {
+            source_agent_id: session.source_agent_id.clone(),
+            role_id: session.final_role_id.clone(),
+            session_key: session.session_key.clone(),
+            session_id: session.session_id.clone(),
+            transcript_path: session.transcript_path.clone(),
+            ai_session_path: ai_sessions_root
+                .join(format!("{}.json", session_output_stem(session)))
+                .display()
+                .to_string(),
+            db_session_key: build_db_session_key(session),
+        })
+        .collect()
+}
+
+struct SessionImportOutputs {
+    written_paths: Vec<String>,
+    agent_outputs: BTreeMap<String, Vec<String>>,
+}
+
+fn import_sessions(
+    plan: &ImportPlan,
+    runtime_root: &Path,
+    ai_sessions_root: &Path,
+    backups_root: &Path,
+    overwrite: bool,
+    no_workspace: bool,
+) -> Result<SessionImportOutputs, String> {
+    let mut written_paths = Vec::new();
+    let mut agent_outputs = BTreeMap::<String, Vec<String>>::new();
+    let agent_lookup = plan
+        .agents
+        .iter()
+        .map(|agent| (agent.final_role_id.as_str(), agent))
+        .collect::<BTreeMap<_, _>>();
+
+    for session in &plan.sessions {
+        let output_path = ai_sessions_root.join(format!("{}.json", session_output_stem(session)));
+        let Some(agent) = agent_lookup.get(session.final_role_id.as_str()) else {
+            continue;
+        };
+        let history = match session.transcript_path.as_deref() {
+            Some(transcript_path) => parse_openclaw_transcript(Path::new(transcript_path))?,
+            None => Vec::new(),
+        };
+        let current_path = if no_workspace {
+            session
+                .cwd
+                .clone()
+                .unwrap_or_else(|| agent.workspace_source.clone())
+        } else {
+            runtime_root
+                .join("openclaw")
+                .join("workspaces")
+                .join(&agent.final_role_id)
+                .display()
+                .to_string()
+        };
+        let session_data = SessionData {
+            session_id: session.session_id.clone(),
+            history,
+            current_path,
+            created_at: timestamp_to_rfc3339(session.updated_at),
+            discord_channel_id: session.channel.as_deref().and_then(parse_u64_str),
+            discord_channel_name: session.channel.clone(),
+            discord_category_name: None,
+            remote_profile_name: None,
+            born_generation: 0,
+        };
+        let rendered = serde_json::to_string_pretty(&session_data)
+            .map_err(|e| format!("Failed to serialize '{}': {e}", output_path.display()))?;
+        write_text_file(
+            &output_path,
+            &rendered,
+            runtime_root,
+            backups_root,
+            overwrite,
+        )?;
+        let rendered_path = output_path.display().to_string();
+        written_paths.push(rendered_path.clone());
+        agent_outputs
+            .entry(session.final_role_id.clone())
+            .or_default()
+            .push(rendered_path);
+    }
+
+    Ok(SessionImportOutputs {
+        written_paths,
+        agent_outputs,
+    })
+}
+
+fn parse_openclaw_transcript(path: &Path) -> Result<Vec<HistoryItem>, String> {
+    let content = fs::read_to_string(path)
+        .map_err(|e| format!("Failed to read '{}': {e}", path.display()))?;
+    let mut history = Vec::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+            continue;
+        };
+        if value.get("type").and_then(serde_json::Value::as_str) == Some("session") {
+            continue;
+        }
+
+        let message = value.get("message").unwrap_or(&value);
+        let role = message
+            .get("role")
+            .and_then(serde_json::Value::as_str)
+            .or_else(|| value.get("role").and_then(serde_json::Value::as_str));
+        let Some(role) = role else {
+            continue;
+        };
+        let items =
+            extract_transcript_history_items(message.get("content").unwrap_or(message), role);
+        if items.is_empty() {
+            if let Some(content) =
+                extract_transcript_text(&value).filter(|text| !text.trim().is_empty())
+            {
+                history.push(HistoryItem {
+                    item_type: map_transcript_role(role),
+                    content,
+                });
+            }
+            continue;
+        }
+        history.extend(items);
+    }
+
+    Ok(history)
+}
+
+fn extract_transcript_history_items(
+    value: &serde_json::Value,
+    fallback_role: &str,
+) -> Vec<HistoryItem> {
+    let Some(items) = value.as_array() else {
+        return extract_transcript_text(value)
+            .filter(|text| !text.trim().is_empty())
+            .map(|content| {
+                vec![HistoryItem {
+                    item_type: map_transcript_role(fallback_role),
+                    content,
+                }]
+            })
+            .unwrap_or_default();
+    };
+
+    let mut history = Vec::new();
+    for item in items {
+        let item_type = item
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .map(|value| value.trim().to_ascii_lowercase());
+        match item_type.as_deref() {
+            Some("tool_use") | Some("toolcall") | Some("tool_call") => {
+                let tool_name = item
+                    .get("name")
+                    .or_else(|| item.get("tool"))
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("tool");
+                let payload = item
+                    .get("input")
+                    .or_else(|| item.get("arguments"))
+                    .map(render_transcript_block)
+                    .unwrap_or_default();
+                let content = if payload.is_empty() {
+                    tool_name.to_string()
+                } else {
+                    format!("{tool_name}\n{payload}")
+                };
+                history.push(HistoryItem {
+                    item_type: HistoryType::ToolUse,
+                    content,
+                });
+            }
+            Some("tool_result") | Some("tool_result_error") => {
+                if let Some(content) = item
+                    .get("result")
+                    .or_else(|| item.get("output"))
+                    .or_else(|| item.get("text"))
+                    .map(render_transcript_block)
+                    .filter(|text| !text.trim().is_empty())
+                {
+                    history.push(HistoryItem {
+                        item_type: HistoryType::ToolResult,
+                        content,
+                    });
+                }
+            }
+            _ => {
+                if let Some(content) =
+                    extract_transcript_text(item).filter(|text| !text.trim().is_empty())
+                {
+                    history.push(HistoryItem {
+                        item_type: map_transcript_role(fallback_role),
+                        content,
+                    });
+                }
+            }
+        }
+    }
+
+    history
+}
+
+fn extract_transcript_text(value: &serde_json::Value) -> Option<String> {
+    if let Some(text) = value.as_str() {
+        return Some(text.to_string());
+    }
+    if let Some(object) = value.as_object() {
+        if let Some(text) = object.get("text").and_then(serde_json::Value::as_str) {
+            return Some(text.to_string());
+        }
+        if let Some(content) = object.get("content") {
+            return extract_transcript_text(content);
+        }
+    }
+    let Some(items) = value.as_array() else {
+        return None;
+    };
+    let parts = items
+        .iter()
+        .filter_map(|item| {
+            item.get("text")
+                .and_then(serde_json::Value::as_str)
+                .map(ToOwned::to_owned)
+                .or_else(|| item.as_str().map(ToOwned::to_owned))
+        })
+        .collect::<Vec<_>>();
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("\n\n"))
+    }
+}
+
+fn render_transcript_block(value: &serde_json::Value) -> String {
+    if let Some(text) = extract_transcript_text(value) {
+        return text;
+    }
+    if value.is_null() {
+        return String::new();
+    }
+    serde_json::to_string(value).unwrap_or_default()
+}
+
+fn map_transcript_role(role: &str) -> HistoryType {
+    match role.trim().to_ascii_lowercase().as_str() {
+        "user" => HistoryType::User,
+        "assistant" => HistoryType::Assistant,
+        "system" => HistoryType::System,
+        "tool" => HistoryType::ToolResult,
+        _ => HistoryType::Assistant,
+    }
+}
+
+fn build_db_session_key(session: &ImportSessionPlan) -> String {
+    format!("openclaw:{}:{}", session.final_role_id, session.session_key)
+}
+
+fn session_output_stem(session: &ImportSessionPlan) -> String {
+    let base = format!("openclaw-{}-{}", session.final_role_id, session.session_id);
+    let sanitized = sanitize_file_component(&base);
+    let mut hasher = Sha256::new();
+    hasher.update(session.session_key.as_bytes());
+    let digest = hex::encode(hasher.finalize());
+    format!("{}-{}", sanitized, &digest[..8])
+}
+
+fn sanitize_file_component(raw: &str) -> String {
+    let mut out = String::new();
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+            out.push(ch);
+        } else {
+            out.push('-');
+        }
+    }
+    while out.contains("--") {
+        out = out.replace("--", "-");
+    }
+    out.trim_matches('-').to_string()
+}
+
+fn timestamp_to_rfc3339(updated_at_ms: i64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp_millis(updated_at_ms)
+        .unwrap_or_else(Utc::now)
+        .to_rfc3339()
+}
+
+fn parse_u64_str(raw: &str) -> Option<u64> {
+    raw.trim().parse::<u64>().ok()
+}
+
+fn apply_db_import(
+    config: &config::Config,
+    plan: &ImportPlan,
+    session_map: &[SessionMapEntry],
+    args: &OpenClawMigrateArgs,
+    runtime_root: &Path,
+    warnings: &mut Vec<String>,
+) -> Result<PathBuf, String> {
+    fs::create_dir_all(&config.data.dir).map_err(|e| {
+        format!(
+            "Failed to create data directory '{}': {e}",
+            config.data.dir.display()
+        )
+    })?;
+    let db = db::init(config).map_err(|e| format!("Failed to initialize DB: {e}"))?;
+    sync_agents_from_config(&db, &config.agents)
+        .map_err(|e| format!("Failed to sync imported agents into DB: {e}"))?;
+
+    if args.with_sessions {
+        upsert_imported_sessions(&db, plan, session_map, args, runtime_root)?;
+    }
+
+    warnings.push(format!(
+        "Imported agents were synced into '{}'.",
+        config.data.dir.join(&config.data.db_name).display()
+    ));
+    Ok(config.data.dir.join(&config.data.db_name))
+}
+
+fn upsert_imported_sessions(
+    db: &db::Db,
+    plan: &ImportPlan,
+    session_map: &[SessionMapEntry],
+    args: &OpenClawMigrateArgs,
+    runtime_root: &Path,
+) -> Result<(), String> {
+    let mut session_map_lookup = HashMap::<(&str, &str), &SessionMapEntry>::new();
+    for entry in session_map {
+        session_map_lookup.insert((entry.role_id.as_str(), entry.session_key.as_str()), entry);
+    }
+    let agent_lookup = plan
+        .agents
+        .iter()
+        .map(|agent| (agent.final_role_id.as_str(), agent))
+        .collect::<BTreeMap<_, _>>();
+
+    let conn = db
+        .lock()
+        .map_err(|e| format!("DB lock error during session import: {e}"))?;
+    for session in &plan.sessions {
+        let Some(agent) = agent_lookup.get(session.final_role_id.as_str()) else {
+            continue;
+        };
+        let Some(session_map) = session_map_lookup
+            .get(&(session.final_role_id.as_str(), session.session_key.as_str()))
+            .copied()
+        else {
+            continue;
+        };
+        let provider = session
+            .provider_hint
+            .as_deref()
+            .and_then(ProviderKind::from_str)
+            .map(|provider| provider.as_str().to_string())
+            .or_else(|| agent.mapped_provider.clone())
+            .unwrap_or_else(|| "claude".to_string());
+        let model = session.model.clone().or_else(|| agent.model_hint.clone());
+        let cwd = if args.no_workspace {
+            session
+                .cwd
+                .clone()
+                .unwrap_or_else(|| agent.workspace_source.clone())
+        } else {
+            runtime_root
+                .join("openclaw")
+                .join("workspaces")
+                .join(&agent.final_role_id)
+                .display()
+                .to_string()
+        };
+        let status = match session.status.as_deref() {
+            Some("running") => "working",
+            Some("failed") | Some("timeout") | Some("killed") => "idle",
+            Some("done") => "idle",
+            _ => "idle",
+        };
+        let session_info = serde_json::json!({
+            "imported_from": "openclaw",
+            "source_agent_id": session.source_agent_id,
+            "source_session_key": session.session_key,
+            "source_session_id": session.session_id,
+            "source_cwd": session.cwd,
+            "ai_session_path": session_map.ai_session_path,
+        })
+        .to_string();
+        let thread_channel_id = session.thread_id.clone();
+        let claude_session_id = (provider == "claude").then_some(session.session_id.clone());
+
+        conn.execute(
+            "INSERT INTO sessions (session_key, agent_id, provider, status, session_info, model, tokens, cwd, active_dispatch_id, thread_channel_id, claude_session_id, last_heartbeat)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, NULL, ?9, ?10, datetime('now'))
+             ON CONFLICT(session_key) DO UPDATE SET
+               status = excluded.status,
+               provider = excluded.provider,
+               session_info = excluded.session_info,
+               model = COALESCE(excluded.model, sessions.model),
+               tokens = excluded.tokens,
+               cwd = COALESCE(excluded.cwd, sessions.cwd),
+               agent_id = COALESCE(excluded.agent_id, sessions.agent_id),
+               thread_channel_id = COALESCE(excluded.thread_channel_id, sessions.thread_channel_id),
+               claude_session_id = COALESCE(excluded.claude_session_id, sessions.claude_session_id),
+               last_heartbeat = datetime('now')",
+            rusqlite::params![
+                session_map.db_session_key,
+                session.final_role_id,
+                provider,
+                status,
+                session_info,
+                model,
+                0,
+                cwd,
+                thread_channel_id,
+                claude_session_id,
+            ],
+        )
+        .map_err(|e| format!("Failed to upsert imported session '{}': {e}", session.session_key))?;
+    }
+
+    Ok(())
+}
+
+fn planned_bot_account_ids(plan: &ImportPlan) -> BTreeSet<String> {
+    let importable_agents = plan
+        .agents
+        .iter()
+        .filter(|agent| agent.eligible_for_v1)
+        .map(|agent| agent.source_id.as_str())
+        .collect::<BTreeSet<_>>();
+    plan.discord
+        .bindings
+        .iter()
+        .filter(|binding| importable_agents.contains(binding.agent_id.as_str()))
+        .filter_map(|binding| binding.selected_account_id.clone())
+        .collect()
+}
+
+#[derive(Default)]
+struct DiscordGuildStats {
+    guild_count: usize,
+    channel_override_count: usize,
+    user_allowlist_count: usize,
+    role_allowlist_count: usize,
+}
+
+fn collect_discord_guild_stats(
+    guilds: &BTreeMap<String, OpenClawDiscordGuildConfig>,
+) -> DiscordGuildStats {
+    let mut stats = DiscordGuildStats::default();
+    for guild in guilds.values() {
+        stats.guild_count += 1;
+        stats.channel_override_count += guild.channels.len();
+        stats.user_allowlist_count += guild.users.len();
+        stats.role_allowlist_count += guild.roles.len();
+        for channel in guild.channels.values() {
+            stats.user_allowlist_count += channel.users.len();
+            stats.role_allowlist_count += channel.roles.len();
+        }
+    }
+    stats
+}
+
+fn allow_bots_enabled(value: Option<&serde_json::Value>) -> bool {
+    match value {
+        Some(serde_json::Value::Bool(value)) => *value,
+        Some(serde_json::Value::Number(value)) => value.as_u64().unwrap_or_default() > 0,
+        Some(serde_json::Value::String(value)) => {
+            let normalized = value.trim().to_ascii_lowercase();
+            !normalized.is_empty()
+                && normalized != "false"
+                && normalized != "off"
+                && normalized != "disabled"
+                && normalized != "no"
+        }
+        _ => false,
+    }
+}
+
+fn binding_targets_account(
+    binding: &OpenClawBindingConfig,
+    account_id: &str,
+    plan: &ImportPlan,
+) -> bool {
+    if !binding.r#match.channel.eq_ignore_ascii_case("discord") {
+        return false;
+    }
+    if binding.r#match.account_id.as_deref() == Some(account_id) {
+        return true;
+    }
+    if binding.r#match.account_id.is_some() {
+        return false;
+    }
+    plan.discord.bindings.iter().any(|planned| {
+        planned.agent_id == binding.agent_id
+            && planned.requested_account_id.is_none()
+            && planned.selected_account_id.as_deref() == Some(account_id)
+    })
+}
+
+fn build_discord_account_mappings(plan: &ImportPlan) -> Vec<DiscordAccountToBotMapping> {
+    #[derive(Default)]
+    struct MappingAccumulator {
+        role_ids: BTreeSet<String>,
+        providers: BTreeSet<String>,
+        live_channel_ids: BTreeSet<String>,
+        live_binding_agents: BTreeSet<String>,
+        preview_only_binding_agents: BTreeSet<String>,
+    }
+
+    let agent_lookup = plan
+        .agents
+        .iter()
+        .filter(|agent| agent.eligible_for_v1)
+        .map(|agent| (agent.source_id.as_str(), agent))
+        .collect::<BTreeMap<_, _>>();
+    let mut mappings = BTreeMap::<String, MappingAccumulator>::new();
+
+    for binding in &plan.discord.bindings {
+        let Some(account_id) = binding.selected_account_id.as_deref() else {
+            continue;
+        };
+        let Some(agent) = agent_lookup.get(binding.agent_id.as_str()) else {
+            continue;
+        };
+        let entry = mappings.entry(account_id.to_string()).or_default();
+        entry.role_ids.insert(agent.final_role_id.clone());
+        if let Some(provider) = agent.mapped_provider.as_ref() {
+            entry.providers.insert(provider.clone());
+        }
+        if binding.mode == "live_applicable" {
+            entry.live_binding_agents.insert(agent.source_id.clone());
+            entry
+                .live_channel_ids
+                .extend(binding.channel_ids.iter().cloned());
+        } else {
+            entry
+                .preview_only_binding_agents
+                .insert(agent.source_id.clone());
+        }
+    }
+
+    mappings
+        .into_iter()
+        .map(|(account_id, entry)| {
+            let mode = if entry.live_channel_ids.is_empty() {
+                "preview_only"
+            } else {
+                "live_applicable"
+            };
+            DiscordAccountToBotMapping {
+                account_id,
+                role_ids: entry.role_ids.into_iter().collect(),
+                providers: entry.providers.into_iter().collect(),
+                live_channel_ids: entry.live_channel_ids.into_iter().collect(),
+                live_binding_agents: entry.live_binding_agents.into_iter().collect(),
+                preview_only_binding_agents: entry
+                    .preview_only_binding_agents
+                    .into_iter()
+                    .collect(),
+                mode,
+            }
+        })
+        .collect()
+}
+
+fn classify_discord_token_status(
+    source: &ResolvedSourceRoot,
+    account_id: &str,
+    has_token: bool,
+    token_kind_name: &str,
+    token_mode: DiscordTokenMode,
+    write_bot_settings: bool,
+    planned_bot_accounts: &BTreeSet<String>,
+) -> String {
+    if !has_token {
+        return "missing".to_string();
+    }
+    if !write_bot_settings || !planned_bot_accounts.contains(account_id) {
+        return "skipped".to_string();
+    }
+    if token_mode == DiscordTokenMode::Report {
+        return "skipped".to_string();
+    }
+    if token_mode == DiscordTokenMode::PlaintextOnly && token_kind_name != "plaintext" {
+        return "skipped".to_string();
+    }
+    if token_mode == DiscordTokenMode::ResolveEnvFile && token_kind_name == "exec" {
+        return "skipped".to_string();
+    }
+    match resolve_account_token(source, account_id, token_mode) {
+        Ok(Some(_)) => "imported".to_string(),
+        Ok(None) => "missing".to_string(),
+        Err(_) => "could_not_be_resolved".to_string(),
+    }
+}
+
+fn build_discord_auth_report(
+    plan: &ImportPlan,
+    source: &ResolvedSourceRoot,
+    args: &OpenClawMigrateArgs,
+) -> Result<DiscordAuthReportData, String> {
+    let token_mode = DiscordTokenMode::parse(&args.discord_token_mode)?;
+    let planned_bot_accounts = planned_bot_account_ids(plan);
+    let mut accounts = Vec::new();
+
+    if let Some(discord) = source.config.channels.discord.as_ref() {
+        for account in &plan.discord.accounts {
+            let (guilds, allow_bots) = if account.account_id == "default" {
+                (&discord.guilds, discord.allow_bots.as_ref())
+            } else {
+                let account_config = discord.accounts.get(&account.account_id);
+                (
+                    account_config
+                        .map(|value| &value.guilds)
+                        .unwrap_or(&discord.guilds),
+                    account_config.and_then(|value| value.allow_bots.as_ref()),
+                )
+            };
+            let stats = collect_discord_guild_stats(guilds);
+            let binding_roles_present = source.config.bindings.iter().any(|binding| {
+                !binding.r#match.roles.is_empty()
+                    && binding_targets_account(binding, &account.account_id, plan)
+            });
+            accounts.push(DiscordAccountReportEntry {
+                account_id: account.account_id.clone(),
+                source: account.source,
+                enabled: account.enabled,
+                has_token: account.has_token,
+                token_kind: account.token_kind.clone(),
+                token_status: classify_discord_token_status(
+                    source,
+                    &account.account_id,
+                    account.has_token,
+                    &account.token_kind,
+                    token_mode,
+                    args.write_bot_settings,
+                    &planned_bot_accounts,
+                ),
+                importable: account.importable,
+                guild_count: stats.guild_count,
+                channel_override_count: stats.channel_override_count,
+                user_allowlist_count: stats.user_allowlist_count,
+                role_allowlist_count: stats.role_allowlist_count,
+                binding_roles_present,
+                allow_bots_enabled: allow_bots_enabled(allow_bots),
+            });
+        }
+    }
+
+    Ok(DiscordAuthReportData {
+        default_token_configured: source
+            .config
+            .channels
+            .discord
+            .as_ref()
+            .and_then(|discord| discord.token.as_ref())
+            .is_some(),
+        has_named_accounts: source
+            .config
+            .channels
+            .discord
+            .as_ref()
+            .map(|discord| !discord.accounts.is_empty())
+            .unwrap_or(false),
+        requested_token_mode: args.discord_token_mode.clone(),
+        write_bot_settings_enabled: args.write_bot_settings,
+        accounts,
+        account_to_bot_mappings: build_discord_account_mappings(plan),
+    })
+}
+
+fn build_bot_settings_entry_plans(
+    plan: &ImportPlan,
+    source: &ResolvedSourceRoot,
+    args: &OpenClawMigrateArgs,
+    warnings: &mut Vec<String>,
+) -> Result<Vec<BotSettingsEntryPlan>, String> {
+    let token_mode = DiscordTokenMode::parse(&args.discord_token_mode)?;
+    let tool_policy_mode = ToolPolicyMode::parse(&args.tool_policy_mode)?;
+
+    if token_mode == DiscordTokenMode::Report {
+        warnings.push(
+            "Discord token mode is report-only, so bot_settings.json live import is skipped."
+                .to_string(),
+        );
+        return Ok(Vec::new());
+    }
+
+    let agent_lookup = plan
+        .agents
+        .iter()
+        .map(|agent| (agent.source_id.as_str(), agent))
+        .collect::<BTreeMap<_, _>>();
+
+    #[derive(Default)]
+    struct BotAccountAccumulator {
+        role_ids: BTreeSet<String>,
+        providers: BTreeSet<String>,
+        channel_ids: BTreeSet<u64>,
+        source_agent_ids: BTreeSet<String>,
+    }
+
+    let mut by_account = BTreeMap::<String, BotAccountAccumulator>::new();
+    for binding in &plan.discord.bindings {
+        let Some(account_id) = binding.selected_account_id.as_deref() else {
+            continue;
+        };
+        let Some(agent) = agent_lookup.get(binding.agent_id.as_str()) else {
+            continue;
+        };
+        if !agent.eligible_for_v1 {
+            continue;
+        }
+        let entry = by_account.entry(account_id.to_string()).or_default();
+        entry.role_ids.insert(agent.final_role_id.clone());
+        entry.source_agent_ids.insert(agent.source_id.clone());
+        if let Some(provider) = agent.mapped_provider.as_ref() {
+            entry.providers.insert(provider.clone());
+        }
+        if args.with_channel_bindings && args.write_org && binding.mode == "live_applicable" {
+            for channel_id in &binding.channel_ids {
+                if let Some(parsed) = parse_u64_str(channel_id) {
+                    entry.channel_ids.insert(parsed);
+                }
+            }
+        }
+    }
+
+    let mut entries = Vec::new();
+    for (account_id, accumulator) in by_account {
+        let Some(token) = resolve_account_token(source, &account_id, token_mode)? else {
+            warnings.push(format!(
+                "Skipping bot_settings import for Discord account '{}': token could not be resolved under mode '{}'.",
+                account_id,
+                token_mode.as_str()
+            ));
+            continue;
+        };
+        if accumulator.providers.len() > 1 {
+            warnings.push(format!(
+                "Skipping bot_settings import for Discord account '{}': multiple providers map to one token ({:?}).",
+                account_id,
+                accumulator.providers
+            ));
+            continue;
+        }
+        let provider = accumulator
+            .providers
+            .iter()
+            .next()
+            .cloned()
+            .unwrap_or_else(|| "claude".to_string());
+        if tool_policy_mode == ToolPolicyMode::BotIntersection
+            && plan
+                .tool_policy
+                .agents
+                .iter()
+                .filter(|scan| accumulator.source_agent_ids.contains(&scan.agent_id))
+                .any(|scan| scan.has_sender_scoped_policy)
+        {
+            warnings.push(format!(
+                "Skipping bot_settings tool auto-apply for Discord account '{}': bot-intersection cannot preserve sender-scoped OpenClaw tool policy.",
+                account_id
+            ));
+            continue;
+        }
+        let role_id = if accumulator.role_ids.len() == 1 {
+            accumulator.role_ids.iter().next().cloned()
+        } else {
+            None
+        };
+        let allowed_tools = build_bot_allowed_tools(
+            plan,
+            &accumulator.source_agent_ids,
+            &provider,
+            tool_policy_mode,
+            warnings,
+        );
+        entries.push(BotSettingsEntryPlan {
+            account_id,
+            provider,
+            role_id,
+            token,
+            allowed_channel_ids: accumulator.channel_ids.into_iter().collect(),
+            allowed_tools,
+        });
+    }
+
+    Ok(entries)
+}
+
+fn build_bot_allowed_tools(
+    plan: &ImportPlan,
+    source_agent_ids: &BTreeSet<String>,
+    provider: &str,
+    mode: ToolPolicyMode,
+    warnings: &mut Vec<String>,
+) -> Option<Vec<String>> {
+    if mode == ToolPolicyMode::Report {
+        return None;
+    }
+
+    let mut sets = Vec::new();
+    for agent in plan
+        .tool_policy
+        .agents
+        .iter()
+        .filter(|agent| source_agent_ids.contains(&agent.agent_id))
+    {
+        let tools = agent.normalized_candidate_tools.clone();
+        if !tools.is_empty() {
+            sets.push(tools);
+        }
+    }
+
+    if sets.is_empty() {
+        warnings.push(format!(
+            "No explicit OpenClaw allowlist was recognized for provider '{}'; using AgentDesk default allowed tools.",
+            provider
+        ));
+        return Some(
+            DEFAULT_ALLOWED_TOOLS
+                .iter()
+                .map(|tool| (*tool).to_string())
+                .collect(),
+        );
+    }
+
+    let combined = match mode {
+        ToolPolicyMode::BotUnion => {
+            let mut union = BTreeSet::new();
+            for set in sets {
+                union.extend(set);
+            }
+            union.into_iter().collect::<Vec<_>>()
+        }
+        ToolPolicyMode::BotIntersection => {
+            let mut iter = sets.into_iter();
+            let Some(first) = iter.next() else {
+                return Some(
+                    DEFAULT_ALLOWED_TOOLS
+                        .iter()
+                        .map(|tool| (*tool).to_string())
+                        .collect(),
+                );
+            };
+            let mut intersection = first.into_iter().collect::<BTreeSet<_>>();
+            for set in iter {
+                let current = set.into_iter().collect::<BTreeSet<_>>();
+                intersection = intersection.intersection(&current).cloned().collect();
+            }
+            if intersection.is_empty() {
+                warnings.push(
+                    "Tool-policy intersection resolved to an empty allowlist; using AgentDesk default allowed tools."
+                        .to_string(),
+                );
+                DEFAULT_ALLOWED_TOOLS
+                    .iter()
+                    .map(|tool| (*tool).to_string())
+                    .collect()
+            } else {
+                intersection.into_iter().collect()
+            }
+        }
+        ToolPolicyMode::Report => unreachable!(),
+    };
+
+    Some(combined)
+}
+
+fn render_bot_settings_json(
+    path: &Path,
+    entries: &[BotSettingsEntryPlan],
+    _overwrite: bool,
+) -> Result<String, String> {
+    let mut root = if path.exists() {
+        fs::read_to_string(path)
+            .ok()
+            .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
+            .unwrap_or_else(|| serde_json::json!({}))
+    } else {
+        serde_json::json!({})
+    };
+    let object = root
+        .as_object_mut()
+        .ok_or_else(|| format!("'{}' root must be a JSON object.", path.display()))?;
+    for entry in entries {
+        let key = discord_token_hash(&entry.token);
+        let mut entry_json = object
+            .get(&key)
+            .and_then(serde_json::Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+        entry_json.insert("token".to_string(), serde_json::json!(entry.token));
+        entry_json.insert("provider".to_string(), serde_json::json!(entry.provider));
+        entry_json.insert("agent".to_string(), serde_json::json!(entry.role_id));
+        entry_json.insert(
+            "allowed_channel_ids".to_string(),
+            serde_json::json!(entry.allowed_channel_ids),
+        );
+        if let Some(allowed_tools) = entry.allowed_tools.as_ref() {
+            entry_json.insert(
+                "allowed_tools".to_string(),
+                serde_json::json!(allowed_tools),
+            );
+        }
+        object.insert(key, serde_json::Value::Object(entry_json));
+    }
+    serde_json::to_string_pretty(&root)
+        .map_err(|e| format!("Failed to serialize '{}': {e}", path.display()))
+}
+
+fn resolve_account_token(
+    source: &ResolvedSourceRoot,
+    account_id: &str,
+    mode: DiscordTokenMode,
+) -> Result<Option<String>, String> {
+    let Some(discord) = source.config.channels.discord.as_ref() else {
+        return Ok(None);
+    };
+    let token_value = if account_id == "default" {
+        discord.token.as_ref()
+    } else {
+        discord
+            .accounts
+            .get(account_id)
+            .and_then(|account| account.token.as_ref())
+    };
+    let Some(token_value) = token_value else {
+        return Ok(None);
+    };
+    resolve_token_value(
+        token_value,
+        source.config.secrets.as_ref(),
+        &source.root,
+        mode,
+    )
+    .map(Some)
+}
+
+#[derive(Clone, Debug)]
+struct SecretRefSpec {
+    source: String,
+    provider: String,
+    id: String,
+}
+
+fn resolve_token_value(
+    token_value: &serde_json::Value,
+    secrets: Option<&OpenClawSecretsConfig>,
+    source_root: &Path,
+    mode: DiscordTokenMode,
+) -> Result<String, String> {
+    if let Some(value) = token_value.as_str() {
+        let trimmed = value.trim();
+        if !(trimmed.starts_with("${") && trimmed.ends_with('}')) {
+            return Ok(trimmed.to_string());
+        }
+    }
+
+    let secret_ref = parse_secret_ref(token_value, secrets)?;
+    let Some(secret_ref) = secret_ref else {
+        return Err("unsupported Discord token shape".to_string());
+    };
+
+    match (mode, secret_ref.source.as_str()) {
+        (DiscordTokenMode::PlaintextOnly, _) => {
+            Err("token mode plaintext-only does not allow SecretRef tokens".to_string())
+        }
+        (DiscordTokenMode::ResolveEnvFile, "exec") => {
+            Err("token mode resolve-env-file does not allow exec SecretRefs".to_string())
+        }
+        (DiscordTokenMode::Report, _) => {
+            Err("token mode report does not resolve tokens".to_string())
+        }
+        _ => resolve_secret_ref_value(&secret_ref, secrets, source_root),
+    }
+}
+
+fn parse_secret_ref(
+    token_value: &serde_json::Value,
+    secrets: Option<&OpenClawSecretsConfig>,
+) -> Result<Option<SecretRefSpec>, String> {
+    if let Some(raw) = token_value.as_str() {
+        let trimmed = raw.trim();
+        if let Some(name) = trimmed
+            .strip_prefix("${")
+            .and_then(|value| value.strip_suffix('}'))
+        {
+            let provider = secrets
+                .and_then(|secrets| secrets.defaults.env.clone())
+                .unwrap_or_else(|| "default".to_string());
+            return Ok(Some(SecretRefSpec {
+                source: "env".to_string(),
+                provider,
+                id: name.to_string(),
+            }));
+        }
+        return Ok(None);
+    }
+    let Some(object) = token_value.as_object() else {
+        return Ok(None);
+    };
+    let Some(source) = object
+        .get("source")
+        .and_then(serde_json::Value::as_str)
+        .map(|value| value.trim().to_ascii_lowercase())
+    else {
+        return Ok(None);
+    };
+    let Some(id) = object
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Err("SecretRef token is missing id".to_string());
+    };
+    let provider = object
+        .get("provider")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| match source.as_str() {
+            "env" => secrets.and_then(|secrets| secrets.defaults.env.clone()),
+            "file" => secrets.and_then(|secrets| secrets.defaults.file.clone()),
+            "exec" => secrets.and_then(|secrets| secrets.defaults.exec.clone()),
+            _ => None,
+        })
+        .unwrap_or_else(|| "default".to_string());
+    Ok(Some(SecretRefSpec {
+        source,
+        provider,
+        id: id.to_string(),
+    }))
+}
+
+fn resolve_secret_ref_value(
+    secret_ref: &SecretRefSpec,
+    secrets: Option<&OpenClawSecretsConfig>,
+    source_root: &Path,
+) -> Result<String, String> {
+    let provider = secrets
+        .and_then(|secrets| secrets.providers.get(&secret_ref.provider))
+        .ok_or_else(|| {
+            format!(
+                "Missing OpenClaw secrets provider '{}' for {} SecretRef.",
+                secret_ref.provider, secret_ref.source
+            )
+        })?;
+
+    match provider {
+        OpenClawSecretProviderConfig::Env { allowlist } => {
+            if !allowlist.is_empty() && !allowlist.iter().any(|item| item == &secret_ref.id) {
+                return Err(format!(
+                    "Env SecretRef '{}' is not in allowlist for provider '{}'.",
+                    secret_ref.id, secret_ref.provider
+                ));
+            }
+            std::env::var(&secret_ref.id).map_err(|_| {
+                format!(
+                    "Env SecretRef '{}' is not set in the current environment.",
+                    secret_ref.id
+                )
+            })
+        }
+        OpenClawSecretProviderConfig::File {
+            path,
+            mode,
+            max_bytes,
+            ..
+        } => {
+            let resolved_path = {
+                let path = PathBuf::from(path);
+                if path.is_absolute() {
+                    path
+                } else {
+                    source_root.join(path)
+                }
+            };
+            let bytes = fs::read(&resolved_path).map_err(|e| {
+                format!(
+                    "Failed to read SecretRef file provider '{}' at '{}': {e}",
+                    secret_ref.provider,
+                    resolved_path.display()
+                )
+            })?;
+            if let Some(limit) = max_bytes {
+                if bytes.len() as u64 > *limit {
+                    return Err(format!(
+                        "SecretRef file provider '{}' exceeded maxBytes.",
+                        secret_ref.provider
+                    ));
+                }
+            }
+            let raw = String::from_utf8(bytes).map_err(|e| {
+                format!(
+                    "SecretRef file '{}' is not UTF-8: {e}",
+                    resolved_path.display()
+                )
+            })?;
+            if mode.as_deref() == Some("json") {
+                let value: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
+                    format!(
+                        "Failed to parse JSON SecretRef file '{}': {e}",
+                        resolved_path.display()
+                    )
+                })?;
+                extract_secret_json_value(&value, &secret_ref.id)
+            } else {
+                Ok(raw.trim().to_string())
+            }
+        }
+        OpenClawSecretProviderConfig::Exec {
+            command,
+            args,
+            json_only,
+            env,
+            pass_env,
+            ..
+        } => {
+            let mut cmd = Command::new(command);
+            cmd.args(args);
+            cmd.stdin(Stdio::null());
+            cmd.stderr(Stdio::piped());
+            cmd.stdout(Stdio::piped());
+            for (key, value) in env {
+                cmd.env(key, value);
+            }
+            for key in pass_env {
+                if let Ok(value) = std::env::var(key) {
+                    cmd.env(key, value);
+                }
+            }
+            let output = cmd.output().map_err(|e| {
+                format!(
+                    "Failed to execute SecretRef provider '{}': {e}",
+                    secret_ref.provider
+                )
+            })?;
+            if !output.status.success() {
+                return Err(format!(
+                    "SecretRef exec provider '{}' failed: {}",
+                    secret_ref.provider,
+                    String::from_utf8_lossy(&output.stderr).trim()
+                ));
+            }
+            let stdout = String::from_utf8(output.stdout).map_err(|e| {
+                format!(
+                    "SecretRef exec provider '{}' returned non UTF-8 output: {e}",
+                    secret_ref.provider
+                )
+            })?;
+            let trimmed = stdout.trim();
+            if json_only == &Some(true) || trimmed.starts_with('{') || trimmed.starts_with('[') {
+                let value: serde_json::Value = serde_json::from_str(trimmed).map_err(|e| {
+                    format!(
+                        "SecretRef exec provider '{}' returned invalid JSON: {e}",
+                        secret_ref.provider
+                    )
+                })?;
+                extract_secret_json_value(&value, &secret_ref.id)
+            } else {
+                Ok(trimmed.to_string())
+            }
+        }
+    }
+}
+
+fn extract_secret_json_value(value: &serde_json::Value, id: &str) -> Result<String, String> {
+    if let Some(pointer_value) = value.pointer(id).and_then(serde_json::Value::as_str) {
+        return Ok(pointer_value.to_string());
+    }
+    if let Some(object_value) = value.get(id).and_then(serde_json::Value::as_str) {
+        return Ok(object_value.to_string());
+    }
+    if let Some(text) = value.as_str() {
+        return Ok(text.to_string());
+    }
+    Err(format!(
+        "SecretRef JSON payload did not contain string id '{}'.",
+        id
+    ))
+}
+
+fn copy_source_snapshot(
+    source_root: &Path,
+    snapshot_root: &Path,
+    overwrite: bool,
+    warnings: &mut Vec<String>,
+) -> Result<(), String> {
+    if snapshot_root.exists() {
+        if !overwrite {
+            return Err(format!(
+                "Source snapshot '{}' already exists. Re-run with --overwrite to replace it.",
+                snapshot_root.display()
+            ));
+        }
+        fs::remove_dir_all(snapshot_root).map_err(|e| {
+            format!(
+                "Failed to replace existing source snapshot '{}': {e}",
+                snapshot_root.display()
+            )
+        })?;
+    }
+    copy_tree_filtered(source_root, snapshot_root, warnings)
+}
+
+fn merge_imported_agents(
+    config: &mut config::Config,
+    plan: &ImportPlan,
+    overwrite: bool,
+) -> Result<(), String> {
+    for agent in plan.agents.iter().filter(|agent| agent.eligible_for_v1) {
+        let provider = agent
+            .mapped_provider
+            .clone()
+            .ok_or_else(|| format!("agent '{}' is missing a mapped provider", agent.source_id))?;
+        let incoming = RuntimeAgentDef {
+            id: agent.final_role_id.clone(),
+            name: agent.display_name.clone(),
+            name_ko: None,
+            provider,
+            channels: std::collections::HashMap::new(),
+            department: None,
+            avatar_emoji: agent.avatar_emoji.clone(),
+        };
+
+        if let Some(existing) = config
+            .agents
+            .iter_mut()
+            .find(|existing| existing.id == incoming.id)
+        {
+            let same_agent = existing.name == incoming.name
+                && existing.provider == incoming.provider
+                && existing.avatar_emoji == incoming.avatar_emoji
+                && existing.channels == incoming.channels
+                && existing.department == incoming.department;
+            if same_agent {
+                continue;
+            }
+            if !overwrite {
+                return Err(format!(
+                    "Target agent '{}' already exists in agentdesk.yaml. Re-run with --overwrite to replace generated assets.",
+                    incoming.id
+                ));
+            }
+            *existing = incoming;
+        } else {
+            config.agents.push(incoming);
+        }
+    }
+
+    config.agents.sort_by(|left, right| left.id.cmp(&right.id));
+    Ok(())
+}
+
+fn render_imported_prompt(agent: &ImportAgentPlan) -> String {
+    let workspace = Path::new(&agent.workspace_source);
+    let mut sections = vec![format!(
+        "# Imported OpenClaw Role\n\n- role_id: `{}`\n- source_agent: `{}`\n- workspace: `{}`",
+        agent.final_role_id, agent.source_id, agent.workspace_source
+    )];
+
+    for (file_name, heading) in BOOTSTRAP_PROMPT_SECTIONS {
+        let path = workspace.join(file_name);
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let trimmed = content.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        sections.push(format!("## {heading}\n\n{trimmed}"));
+    }
+
+    sections.join("\n\n")
+}
+
+fn import_memory_files(
+    agent: &ImportAgentPlan,
+    destination_root: &Path,
+    runtime_root: &Path,
+    backups_root: &Path,
+    overwrite: bool,
+) -> Result<Vec<PathBuf>, String> {
+    fs::create_dir_all(destination_root)
+        .map_err(|e| format!("Failed to create '{}': {e}", destination_root.display()))?;
+
+    let workspace = Path::new(&agent.workspace_source);
+    let mut outputs = Vec::new();
+
+    let memory_md = workspace.join("MEMORY.md");
+    if memory_md.is_file() {
+        let content = fs::read_to_string(&memory_md)
+            .map_err(|e| format!("Failed to read '{}': {e}", memory_md.display()))?;
+        let destination = destination_root.join("MEMORY.md");
+        write_text_file(
+            &destination,
+            &content,
+            runtime_root,
+            backups_root,
+            overwrite,
+        )?;
+        outputs.push(destination);
+    }
+
+    let daily_root = workspace.join("memory");
+    if daily_root.is_dir() {
+        let mut queue = VecDeque::from([daily_root.clone()]);
+        while let Some(dir) = queue.pop_front() {
+            let entries = fs::read_dir(&dir)
+                .map_err(|e| format!("Failed to read '{}': {e}", dir.display()))?;
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let Ok(file_type) = entry.file_type() else {
+                    continue;
+                };
+                if file_type.is_symlink() {
+                    continue;
+                }
+                if file_type.is_dir() {
+                    queue.push_back(path);
+                    continue;
+                }
+                if !file_type.is_file()
+                    || path.extension().and_then(|ext| ext.to_str()) != Some("md")
+                {
+                    continue;
+                }
+
+                let relative = path
+                    .strip_prefix(workspace)
+                    .unwrap_or(&path)
+                    .display()
+                    .to_string();
+                let daily_name = format!(
+                    "daily-{}",
+                    path.strip_prefix(&daily_root)
+                        .unwrap_or(&path)
+                        .display()
+                        .to_string()
+                        .replace('/', "-")
+                        .replace('\\', "-")
+                );
+                let content = fs::read_to_string(&path)
+                    .map_err(|e| format!("Failed to read '{}': {e}", path.display()))?;
+                let rendered = format!(
+                    "---\nimported_from: openclaw\nsource_agent: {}\nsource_path: {}\n---\n\n{}",
+                    agent.source_id, relative, content
+                );
+                let destination = destination_root.join(daily_name);
+                write_text_file(
+                    &destination,
+                    &rendered,
+                    runtime_root,
+                    backups_root,
+                    overwrite,
+                )?;
+                outputs.push(destination);
+            }
+        }
+    }
+
+    outputs.sort();
+    Ok(outputs)
+}
+
+fn copy_workspace_snapshot(
+    source_root: &Path,
+    destination_root: &Path,
+    runtime_root: &Path,
+    backups_root: &Path,
+    overwrite: bool,
+    warnings: &mut Vec<String>,
+) -> Result<(), String> {
+    if destination_root.exists() {
+        if !overwrite {
+            return Err(format!(
+                "Workspace snapshot '{}' already exists. Re-run with --overwrite to replace it.",
+                destination_root.display()
+            ));
+        }
+        backup_existing_path(destination_root, runtime_root, backups_root)?;
+        fs::remove_dir_all(destination_root).map_err(|e| {
+            format!(
+                "Failed to replace existing workspace '{}': {e}",
+                destination_root.display()
+            )
+        })?;
+    }
+
+    copy_tree_filtered(source_root, destination_root, warnings)
+}
+
+fn copy_tree_filtered(
+    source_root: &Path,
+    destination_root: &Path,
+    warnings: &mut Vec<String>,
+) -> Result<(), String> {
+    fs::create_dir_all(destination_root)
+        .map_err(|e| format!("Failed to create '{}': {e}", destination_root.display()))?;
+
+    let mut queue = VecDeque::from([(source_root.to_path_buf(), destination_root.to_path_buf())]);
+    while let Some((source_dir, destination_dir)) = queue.pop_front() {
+        let entries = fs::read_dir(&source_dir)
+            .map_err(|e| format!("Failed to read '{}': {e}", source_dir.display()))?;
+        for entry in entries.flatten() {
+            let source_path = entry.path();
+            let destination_path = destination_dir.join(entry.file_name());
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_symlink() {
+                warnings.push(format!(
+                    "Skipped symlink during workspace copy: {}",
+                    source_path.display()
+                ));
+                continue;
+            }
+            if file_type.is_dir() {
+                if should_prune_workspace_dir(&source_path) {
+                    warnings.push(format!(
+                        "Skipped workspace directory during copy: {}",
+                        source_path.display()
+                    ));
+                    continue;
+                }
+                fs::create_dir_all(&destination_path).map_err(|e| {
+                    format!("Failed to create '{}': {e}", destination_path.display())
+                })?;
+                queue.push_back((source_path, destination_path));
+                continue;
+            }
+            if file_type.is_file() {
+                if let Some(parent) = destination_path.parent() {
+                    fs::create_dir_all(parent)
+                        .map_err(|e| format!("Failed to create '{}': {e}", parent.display()))?;
+                }
+                fs::copy(&source_path, &destination_path).map_err(|e| {
+                    format!(
+                        "Failed to copy '{}' to '{}': {e}",
+                        source_path.display(),
+                        destination_path.display()
+                    )
+                })?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn should_prune_workspace_dir(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| {
+            COPY_PRUNE_DIR_NAMES
+                .iter()
+                .any(|candidate| candidate == &name)
+        })
+        .unwrap_or(false)
+}
+
+fn write_text_file(
+    path: &Path,
+    content: &str,
+    runtime_root: &Path,
+    backups_root: &Path,
+    overwrite: bool,
+) -> Result<(), String> {
+    if path.exists() {
+        let existing = fs::read_to_string(path).unwrap_or_default();
+        if existing == content {
+            return Ok(());
+        }
+        if !overwrite {
+            return Err(format!(
+                "Target file '{}' already exists. Re-run with --overwrite to replace it.",
+                path.display()
+            ));
+        }
+        backup_existing_path(path, runtime_root, backups_root)?;
+    }
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create '{}': {e}", parent.display()))?;
+    }
+    fs::write(path, content).map_err(|e| format!("Failed to write '{}': {e}", path.display()))?;
+    Ok(())
+}
+
+fn backup_existing_path(
+    path: &Path,
+    runtime_root: &Path,
+    backups_root: &Path,
+) -> Result<(), String> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let relative = path
+        .strip_prefix(runtime_root)
+        .ok()
+        .map(Path::to_path_buf)
+        .or_else(|| path.file_name().map(PathBuf::from))
+        .ok_or_else(|| format!("Failed to derive backup path for '{}'.", path.display()))?;
+    let backup_path = backups_root.join(relative);
+    if backup_path.exists() {
+        return Ok(());
+    }
+
+    if path.is_dir() {
+        let mut backup_warnings = Vec::new();
+        copy_tree_filtered(path, &backup_path, &mut backup_warnings)?;
+    } else {
+        if let Some(parent) = backup_path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create '{}': {e}", parent.display()))?;
+        }
+        fs::copy(path, &backup_path).map_err(|e| {
+            format!(
+                "Failed to back up '{}' to '{}': {e}",
+                path.display(),
+                backup_path.display()
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+fn write_json_file(path: &Path, value: &impl Serialize) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create '{}': {e}", parent.display()))?;
+    }
+    let rendered = serde_json::to_string_pretty(value)
+        .map_err(|e| format!("Failed to serialize '{}': {e}", path.display()))?;
+    fs::write(path, rendered).map_err(|e| format!("Failed to write '{}': {e}", path.display()))?;
+    Ok(())
+}
+
+fn write_yaml_file(path: &Path, value: &impl Serialize) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create '{}': {e}", parent.display()))?;
+    }
+    let rendered = serde_yaml::to_string(value)
+        .map_err(|e| format!("Failed to serialize '{}': {e}", path.display()))?;
+    fs::write(path, rendered).map_err(|e| format!("Failed to write '{}': {e}", path.display()))?;
+    Ok(())
+}
+
+fn source_fingerprint(
+    source: &ResolvedSourceRoot,
+    plan: &ImportPlan,
+    args: &OpenClawMigrateArgs,
+) -> Result<String, String> {
+    let mut hasher = Sha256::new();
+    hasher.update(source.resolved_config_json.as_bytes());
+    for path in &source.resolved_config_paths {
+        hasher.update(path.display().to_string().as_bytes());
+    }
+
+    for agent_id in &plan.selected_agent_ids {
+        hasher.update(agent_id.as_bytes());
+    }
+
+    let mut inputs = BTreeMap::<String, String>::new();
+    for agent in plan.agents.iter().filter(|agent| agent.eligible_for_v1) {
+        let workspace = Path::new(&agent.workspace_source);
+        collect_source_file_hash(&workspace.join("MEMORY.md"), &source.root, &mut inputs)?;
+        collect_markdown_tree_hashes(&workspace.join("memory"), &source.root, &mut inputs)?;
+        for (file_name, _) in BOOTSTRAP_PROMPT_SECTIONS {
+            collect_source_file_hash(&workspace.join(file_name), &source.root, &mut inputs)?;
+        }
+        if !args.no_workspace {
+            collect_tree_file_hashes(workspace, &source.root, &mut inputs)?;
+        }
+    }
+
+    if args.with_sessions {
+        for session in &plan.sessions {
+            collect_source_file_hash(
+                Path::new(&session.session_store_path),
+                &source.root,
+                &mut inputs,
+            )?;
+            if let Some(transcript_path) = session.transcript_path.as_deref() {
+                collect_source_file_hash(Path::new(transcript_path), &source.root, &mut inputs)?;
+            }
+        }
+    }
+
+    collect_resolved_bot_token_hashes(source, plan, args, &mut inputs)?;
+
+    for (path, digest) in inputs {
+        hasher.update(path.as_bytes());
+        hasher.update(digest.as_bytes());
+    }
+
+    Ok(hex::encode(hasher.finalize()))
+}
+
+fn collect_resolved_bot_token_hashes(
+    source: &ResolvedSourceRoot,
+    plan: &ImportPlan,
+    args: &OpenClawMigrateArgs,
+    inputs: &mut BTreeMap<String, String>,
+) -> Result<(), String> {
+    if !args.write_bot_settings {
+        return Ok(());
+    }
+    let token_mode = DiscordTokenMode::parse(&args.discord_token_mode)?;
+    if token_mode == DiscordTokenMode::Report {
+        return Ok(());
+    }
+
+    for account_id in planned_bot_account_ids(plan) {
+        let value = match resolve_account_token(source, &account_id, token_mode) {
+            Ok(Some(token)) => token,
+            Ok(None) => "__missing__".to_string(),
+            Err(err) => format!("__error__:{err}"),
+        };
+        let mut file_hasher = Sha256::new();
+        file_hasher.update(value.as_bytes());
+        inputs.insert(
+            format!("discord-token:{account_id}"),
+            hex::encode(file_hasher.finalize()),
+        );
+    }
+
+    Ok(())
+}
+
+fn collect_markdown_tree_hashes(
+    root: &Path,
+    source_root: &Path,
+    inputs: &mut BTreeMap<String, String>,
+) -> Result<(), String> {
+    if !root.is_dir() {
+        return Ok(());
+    }
+    let mut queue = VecDeque::from([root.to_path_buf()]);
+    while let Some(dir) = queue.pop_front() {
+        let entries =
+            fs::read_dir(&dir).map_err(|e| format!("Failed to read '{}': {e}", dir.display()))?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_symlink() {
+                continue;
+            }
+            if file_type.is_dir() {
+                queue.push_back(path);
+                continue;
+            }
+            if file_type.is_file() && path.extension().and_then(|ext| ext.to_str()) == Some("md") {
+                collect_source_file_hash(&path, source_root, inputs)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn collect_tree_file_hashes(
+    root: &Path,
+    source_root: &Path,
+    inputs: &mut BTreeMap<String, String>,
+) -> Result<(), String> {
+    if !root.is_dir() {
+        return Ok(());
+    }
+    let mut queue = VecDeque::from([root.to_path_buf()]);
+    while let Some(dir) = queue.pop_front() {
+        let entries =
+            fs::read_dir(&dir).map_err(|e| format!("Failed to read '{}': {e}", dir.display()))?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_symlink() {
+                continue;
+            }
+            if file_type.is_dir() {
+                queue.push_back(path);
+                continue;
+            }
+            if file_type.is_file() {
+                collect_source_file_hash(&path, source_root, inputs)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn collect_source_file_hash(
+    path: &Path,
+    source_root: &Path,
+    inputs: &mut BTreeMap<String, String>,
+) -> Result<(), String> {
+    if !path.is_file() {
+        return Ok(());
+    }
+    let bytes = fs::read(path).map_err(|e| format!("Failed to read '{}': {e}", path.display()))?;
+    let mut file_hasher = Sha256::new();
+    file_hasher.update(bytes);
+    let relative = path
+        .strip_prefix(source_root)
+        .map(|value| value.display().to_string())
+        .unwrap_or_else(|_| path.display().to_string());
+    inputs.insert(relative, hex::encode(file_hasher.finalize()));
+    Ok(())
+}

--- a/src/cli/migrate/apply.rs
+++ b/src/cli/migrate/apply.rs
@@ -410,15 +410,11 @@ pub(super) fn apply_import_plan(
                 Some(&session_map),
             )?;
 
-            let rendered_yaml = serde_yaml::to_string(&config)
-                .map_err(|e| format!("Failed to serialize '{}': {e}", yaml_path.display()))?;
-            write_text_file(
-                &yaml_path,
-                &rendered_yaml,
-                runtime_root,
-                &backups_root,
-                true,
-            )?;
+            if yaml_path.exists() {
+                backup_existing_path(&yaml_path, runtime_root, &backups_root)?;
+            }
+            config::save_to_path(&yaml_path, &config)
+                .map_err(|e| format!("Failed to write '{}': {e}", yaml_path.display()))?;
             written_paths.push(yaml_path.display().to_string());
 
             for agent in importable_agents.iter().copied() {

--- a/src/cli/migrate/plan.rs
+++ b/src/cli/migrate/plan.rs
@@ -1074,18 +1074,24 @@ fn resolve_workspace_value_with_rewrites(
     workspace_rewrite_rules: &[WorkspaceRewriteRule],
     warnings: &mut Vec<String>,
 ) -> PathBuf {
-    let path = PathBuf::from(raw_workspace);
-    if !path.is_absolute() {
-        return source_root.join(path);
-    }
-
-    let normalized = raw_workspace.trim().trim_end_matches('/');
+    let trimmed_workspace = raw_workspace.trim();
+    let path = PathBuf::from(trimmed_workspace);
+    let normalized = trimmed_workspace.trim_end_matches(|ch| ch == '/' || ch == '\\');
     for rule in workspace_rewrite_rules {
-        if normalized == rule.from || normalized.starts_with(&format!("{}/", rule.from)) {
+        let from = rule
+            .from
+            .trim()
+            .trim_end_matches(|ch| ch == '/' || ch == '\\');
+        let matches_rule = normalized == from
+            || normalized
+                .strip_prefix(from)
+                .map(|suffix| suffix.starts_with('/') || suffix.starts_with('\\'))
+                .unwrap_or(false);
+        if matches_rule {
             let suffix = normalized
-                .strip_prefix(&rule.from)
+                .strip_prefix(from)
                 .unwrap_or_default()
-                .trim_start_matches('/');
+                .trim_start_matches(|ch| ch == '/' || ch == '\\');
             let target_root = if rule.to.is_absolute() {
                 rule.to.clone()
             } else {
@@ -1104,6 +1110,13 @@ fn resolve_workspace_value_with_rewrites(
             ));
             return rewritten;
         }
+    }
+
+    let looks_absolute = path.is_absolute()
+        || trimmed_workspace.starts_with('/')
+        || trimmed_workspace.starts_with('\\');
+    if !looks_absolute {
+        return source_root.join(path);
     }
 
     if !path.exists() {

--- a/src/cli/migrate/plan.rs
+++ b/src/cli/migrate/plan.rs
@@ -798,11 +798,18 @@ fn available_agent_ids(config: &OpenClawConfig) -> String {
 
 fn assign_role_id(source_id: &str, used: &mut BTreeSet<String>) -> String {
     let base = sanitize_role_id(source_id);
+    let prefixed = sanitize_role_id(&format!("openclaw-{source_id}"));
+
+    // Stable reruns should keep reusing an existing imported role id instead
+    // of drifting back to a bare source id once it becomes available again.
+    if used.contains(&prefixed) {
+        return prefixed;
+    }
+
     if used.insert(base.clone()) {
         return base;
     }
 
-    let prefixed = sanitize_role_id(&format!("openclaw-{source_id}"));
     if used.insert(prefixed.clone()) {
         return prefixed;
     }

--- a/src/cli/migrate/plan.rs
+++ b/src/cli/migrate/plan.rs
@@ -1,0 +1,1401 @@
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use crate::services::provider::ProviderKind;
+
+use super::runtime_root_path;
+use super::source::{
+    DiscordChannelImportResult, OpenClawAgentConfig, OpenClawAgentDefaultsConfig, OpenClawConfig,
+    ResolvedSourceRoot, ToolPolicyScanResult, collect_representable_discord_channel_imports,
+    scan_tool_policy,
+};
+use super::{DiscordTokenMode, OpenClawMigrateArgs, ToolPolicyMode};
+
+const BOOTSTRAP_FILE_NAMES: &[&str] = &[
+    "IDENTITY.md",
+    "AGENTS.md",
+    "SOUL.md",
+    "USER.md",
+    "TOOLS.md",
+    "BOOT.md",
+    "BOOTSTRAP.md",
+    "HEARTBEAT.md",
+];
+
+const REQUIRED_AUDIT_OUTPUTS: &[&str] = &[
+    "manifest.json",
+    "agent-map.json",
+    "write-plan.json",
+    "apply-result.json",
+    "resume-state.json",
+    "warnings.txt",
+    "tool-policy-report.json",
+    "discord-auth-report.json",
+    "channel-binding-preview.yaml",
+];
+
+#[derive(Clone, Debug)]
+enum AgentSelectionMode {
+    Explicit,
+    AllAgents,
+    DefaultAgent,
+    SingleAgent,
+}
+
+impl AgentSelectionMode {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Explicit => "explicit",
+            Self::AllAgents => "all_agents",
+            Self::DefaultAgent => "default_agent",
+            Self::SingleAgent => "single_agent",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct ImportPlan {
+    pub(super) status: &'static str,
+    pub(super) mode: &'static str,
+    pub(super) selection_mode: &'static str,
+    pub(super) source_root: String,
+    pub(super) config_path: String,
+    pub(super) runtime_root: Option<String>,
+    pub(super) audit_root: Option<String>,
+    pub(super) discovered_candidate_roots: Vec<String>,
+    pub(super) selected_agent_ids: Vec<String>,
+    pub(super) importable_agent_ids: Vec<String>,
+    pub(super) selected_discord_account_ids: Vec<String>,
+    pub(super) existing_role_ids: Vec<String>,
+    pub(super) requested_flags: RequestedFlagsPlan,
+    pub(super) effective_modes: EffectiveModesPlan,
+    pub(super) phases: Vec<PhasePlan>,
+    pub(super) audit_outputs: Vec<AuditOutputPlan>,
+    pub(super) warnings: Vec<String>,
+    pub(super) discord: DiscordChannelImportResult,
+    pub(super) tool_policy: ToolPolicyScanResult,
+    pub(super) sessions: Vec<ImportSessionPlan>,
+    pub(super) agents: Vec<ImportAgentPlan>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct RequestedFlagsPlan {
+    pub(super) dry_run: bool,
+    pub(super) agentdesk_root: Option<String>,
+    pub(super) resume: Option<String>,
+    pub(super) fallback_provider: Option<String>,
+    pub(super) workspace_root_rewrite: Vec<String>,
+    pub(super) write_org: bool,
+    pub(super) write_bot_settings: bool,
+    pub(super) write_db: bool,
+    pub(super) overwrite: bool,
+    pub(super) with_channel_bindings: bool,
+    pub(super) with_sessions: bool,
+    pub(super) snapshot_source: bool,
+    pub(super) no_workspace: bool,
+    pub(super) no_memory: bool,
+    pub(super) no_prompts: bool,
+    pub(super) tool_policy_mode: String,
+    pub(super) discord_token_mode: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct EffectiveModesPlan {
+    pub(super) prompt_generation: &'static str,
+    pub(super) memory_import: &'static str,
+    pub(super) workspace_copy: &'static str,
+    pub(super) tool_policy: &'static str,
+    pub(super) bot_tokens: &'static str,
+    pub(super) channel_bindings: &'static str,
+    pub(super) sessions: &'static str,
+    pub(super) apply_org: &'static str,
+    pub(super) apply_bot_settings: &'static str,
+    pub(super) apply_db: &'static str,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct PhasePlan {
+    pub(super) phase: &'static str,
+    pub(super) mode: &'static str,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct AuditOutputPlan {
+    pub(super) path: &'static str,
+    pub(super) mode: &'static str,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct ImportAgentPlan {
+    pub(super) source_id: String,
+    pub(super) display_name: String,
+    pub(super) final_role_id: String,
+    pub(super) avatar_emoji: Option<String>,
+    pub(super) provider_hint: Option<String>,
+    pub(super) mapped_provider: Option<String>,
+    pub(super) model_hint: Option<String>,
+    pub(super) workspace_source: String,
+    pub(super) workspace_exists: bool,
+    pub(super) bootstrap_files: Vec<String>,
+    pub(super) has_memory_md: bool,
+    pub(super) daily_memory_files: usize,
+    pub(super) eligible_for_v1: bool,
+    pub(super) tasks: Vec<AgentTaskPlan>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct ImportSessionPlan {
+    pub(super) source_agent_id: String,
+    pub(super) final_role_id: String,
+    pub(super) session_key: String,
+    pub(super) session_id: String,
+    pub(super) session_store_path: String,
+    pub(super) transcript_path: Option<String>,
+    pub(super) updated_at: i64,
+    pub(super) model: Option<String>,
+    pub(super) provider_hint: Option<String>,
+    pub(super) cwd: Option<String>,
+    pub(super) channel: Option<String>,
+    pub(super) account_id: Option<String>,
+    pub(super) thread_id: Option<String>,
+    pub(super) status: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct AgentTaskPlan {
+    pub(super) key: &'static str,
+    pub(super) mode: &'static str,
+}
+
+pub(super) fn build_import_plan(
+    source: &ResolvedSourceRoot,
+    args: &OpenClawMigrateArgs,
+    runtime_root: Option<&Path>,
+) -> Result<ImportPlan, String> {
+    let fallback_provider = parse_fallback_provider(args.fallback_provider.as_deref())?;
+    let _tool_policy_mode = parse_tool_policy_mode(&args.tool_policy_mode)?;
+    let _discord_token_mode = parse_discord_token_mode(&args.discord_token_mode)?;
+    let workspace_rewrite_rules = parse_workspace_rewrite_rules(&args.workspace_root_rewrite)?;
+    let existing_role_ids = load_existing_role_ids(runtime_root);
+    let default_agent_id = source.config.agents.default_agent_id()?;
+    let (selected_agents, selection_mode) = select_agents(&source.config, args)?;
+    let selected_agent_ids = selected_agents
+        .iter()
+        .map(|agent| agent.id.clone())
+        .collect::<BTreeSet<_>>();
+    let mut used_role_ids = existing_role_ids.clone();
+    let mut warnings = Vec::new();
+    let mut agents = Vec::new();
+    collect_preview_flag_warnings(args, &mut warnings);
+
+    for agent in selected_agents {
+        let is_default_agent = default_agent_id
+            .map(|selected_default_agent_id| selected_default_agent_id == agent.id)
+            .unwrap_or(false);
+        let final_role_id = assign_role_id(&agent.id, &mut used_role_ids);
+        let provider_hint = direct_provider_hint(agent).map(|value| value.to_string());
+        let model_hint =
+            model_hint(agent, &source.config.agents.defaults).map(|value| value.to_string());
+        let mapped_provider = map_provider(
+            agent,
+            &source.config.agents.defaults,
+            fallback_provider.as_ref(),
+            &mut warnings,
+        );
+        let workspace_source = resolve_workspace_path(
+            &source.root,
+            is_default_agent,
+            agent,
+            source.config.agents.defaults.workspace.as_deref(),
+            &workspace_rewrite_rules,
+            &mut warnings,
+        );
+        let workspace_exists = workspace_source.exists();
+        let bootstrap_files = existing_bootstrap_files(&workspace_source);
+        let has_memory_md = workspace_source.join("MEMORY.md").is_file();
+        let daily_memory_files = count_markdown_files(&workspace_source.join("memory"));
+        let eligible_for_v1 = workspace_exists && mapped_provider.is_some();
+        let task_modes = build_agent_task_preview(args, workspace_exists, eligible_for_v1);
+
+        if !workspace_exists {
+            warnings.push(format!(
+                "agent '{}' workspace path does not exist: {}",
+                agent.id,
+                workspace_source.display()
+            ));
+        }
+
+        agents.push(ImportAgentPlan {
+            source_id: agent.id.clone(),
+            display_name: agent.name.clone().unwrap_or_else(|| agent.id.clone()),
+            final_role_id,
+            avatar_emoji: agent
+                .identity
+                .as_ref()
+                .and_then(|identity| identity.emoji.clone()),
+            provider_hint,
+            mapped_provider,
+            model_hint,
+            workspace_source: workspace_source.display().to_string(),
+            workspace_exists,
+            bootstrap_files,
+            has_memory_md,
+            daily_memory_files,
+            eligible_for_v1,
+            tasks: task_modes,
+        });
+    }
+
+    let discord =
+        collect_representable_discord_channel_imports(&source.config, &selected_agent_ids);
+    let tool_policy = scan_tool_policy(&source.config, &selected_agent_ids);
+    let importable_agent_ids = agents
+        .iter()
+        .filter(|agent| agent.eligible_for_v1)
+        .map(|agent| agent.source_id.clone())
+        .collect::<BTreeSet<_>>();
+    if importable_agent_ids.is_empty() && agents.iter().all(|agent| agent.mapped_provider.is_none())
+    {
+        return Err(
+            "No importable OpenClaw agents remain after provider mapping. Supply --fallback-provider or select a directly supported agent."
+                .to_string(),
+        );
+    }
+
+    let mut discord = discord;
+    restrict_discord_plan_to_importable_agents(&mut discord, &importable_agent_ids, &mut warnings);
+    warnings.extend(discord.warnings.iter().cloned());
+    warnings.extend(tool_policy.warnings.iter().cloned());
+    let importable_agents = agents
+        .iter()
+        .filter(|agent| agent.eligible_for_v1)
+        .cloned()
+        .collect::<Vec<_>>();
+    let sessions = if args.with_sessions {
+        collect_session_plans(source, &importable_agents, &mut warnings)
+    } else {
+        Vec::new()
+    };
+    warnings.sort();
+    warnings.dedup();
+
+    let audit_root = runtime_root.map(|root| {
+        if let Some(import_id) = args.resume.as_deref() {
+            root.join("openclaw")
+                .join("imports")
+                .join(import_id)
+                .display()
+                .to_string()
+        } else {
+            root.join("openclaw")
+                .join("imports")
+                .join(build_import_id(source, &agents))
+                .display()
+                .to_string()
+        }
+    });
+
+    Ok(ImportPlan {
+        status: if args.dry_run { "preview" } else { "planned" },
+        mode: if args.dry_run {
+            "dry_run"
+        } else {
+            "live_apply"
+        },
+        selection_mode: selection_mode.as_str(),
+        source_root: source.root.display().to_string(),
+        config_path: source.config_path.display().to_string(),
+        runtime_root: runtime_root_path(runtime_root),
+        audit_root,
+        discovered_candidate_roots: source
+            .discovered_candidate_roots
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect(),
+        selected_agent_ids: agents.iter().map(|agent| agent.source_id.clone()).collect(),
+        importable_agent_ids: importable_agent_ids.into_iter().collect(),
+        selected_discord_account_ids: discord.selected_account_ids.clone(),
+        existing_role_ids: existing_role_ids.into_iter().collect(),
+        requested_flags: RequestedFlagsPlan::from_args(args),
+        effective_modes: build_effective_modes(args),
+        phases: build_phase_preview(args),
+        audit_outputs: build_audit_output_preview(args),
+        warnings,
+        discord,
+        tool_policy,
+        sessions,
+        agents,
+    })
+}
+
+impl RequestedFlagsPlan {
+    fn from_args(args: &OpenClawMigrateArgs) -> Self {
+        Self {
+            dry_run: args.dry_run,
+            agentdesk_root: args.agentdesk_root.clone(),
+            resume: args.resume.clone(),
+            fallback_provider: args.fallback_provider.clone(),
+            workspace_root_rewrite: args.workspace_root_rewrite.clone(),
+            write_org: args.write_org,
+            write_bot_settings: args.write_bot_settings,
+            write_db: args.write_db,
+            overwrite: args.overwrite,
+            with_channel_bindings: args.with_channel_bindings,
+            with_sessions: args.with_sessions,
+            snapshot_source: args.snapshot_source,
+            no_workspace: args.no_workspace,
+            no_memory: args.no_memory,
+            no_prompts: args.no_prompts,
+            tool_policy_mode: args.tool_policy_mode.clone(),
+            discord_token_mode: args.discord_token_mode.clone(),
+        }
+    }
+}
+
+fn parse_fallback_provider(raw: Option<&str>) -> Result<Option<ProviderKind>, String> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let parsed = ProviderKind::from_str(raw).ok_or_else(|| {
+        format!(
+            "Unsupported --fallback-provider '{}'. Expected one of: claude, codex, gemini, qwen.",
+            raw
+        )
+    })?;
+    Ok(Some(parsed))
+}
+
+fn build_effective_modes(args: &OpenClawMigrateArgs) -> EffectiveModesPlan {
+    let tool_policy_mode = parse_tool_policy_mode(&args.tool_policy_mode).ok();
+    let discord_token_mode = parse_discord_token_mode(&args.discord_token_mode).ok();
+    EffectiveModesPlan {
+        prompt_generation: if args.no_prompts {
+            "disabled"
+        } else {
+            "preview_only"
+        },
+        memory_import: if args.no_memory {
+            "disabled"
+        } else {
+            "preview_only"
+        },
+        workspace_copy: if args.no_workspace {
+            "disabled"
+        } else {
+            "preview_only"
+        },
+        tool_policy: match tool_policy_mode.unwrap_or(ToolPolicyMode::Report) {
+            ToolPolicyMode::Report => "report_only",
+            ToolPolicyMode::BotIntersection | ToolPolicyMode::BotUnion => "preview_only",
+        },
+        bot_tokens: match discord_token_mode.unwrap_or(DiscordTokenMode::Report) {
+            DiscordTokenMode::Report => "report_only",
+            DiscordTokenMode::PlaintextOnly
+            | DiscordTokenMode::ResolveEnvFile
+            | DiscordTokenMode::ResolveAll => preview_mode(args.write_bot_settings),
+        },
+        channel_bindings: preview_mode(args.with_channel_bindings),
+        sessions: preview_mode(args.with_sessions),
+        apply_org: preview_mode(args.write_org),
+        apply_bot_settings: preview_mode(args.write_bot_settings),
+        apply_db: preview_mode(args.write_db),
+    }
+}
+
+fn build_phase_preview(args: &OpenClawMigrateArgs) -> Vec<PhasePlan> {
+    vec![
+        PhasePlan {
+            phase: "scan",
+            mode: "preview_only",
+        },
+        PhasePlan {
+            phase: "map",
+            mode: "preview_only",
+        },
+        PhasePlan {
+            phase: "prompt",
+            mode: "preview_only",
+        },
+        PhasePlan {
+            phase: "memory",
+            mode: "preview_only",
+        },
+        PhasePlan {
+            phase: "policy_discord",
+            mode: "preview_only",
+        },
+        PhasePlan {
+            phase: "sessions",
+            mode: preview_mode(args.with_sessions),
+        },
+        PhasePlan {
+            phase: "apply_files",
+            mode: "preview_only",
+        },
+        PhasePlan {
+            phase: "apply_org",
+            mode: preview_mode(args.write_org),
+        },
+        PhasePlan {
+            phase: "apply_bot_settings",
+            mode: preview_mode(args.write_bot_settings),
+        },
+        PhasePlan {
+            phase: "apply_db",
+            mode: preview_mode(args.write_db),
+        },
+        PhasePlan {
+            phase: "finalize",
+            mode: "preview_only",
+        },
+    ]
+}
+
+fn build_audit_output_preview(args: &OpenClawMigrateArgs) -> Vec<AuditOutputPlan> {
+    let mut outputs = REQUIRED_AUDIT_OUTPUTS
+        .iter()
+        .map(|path| AuditOutputPlan {
+            path,
+            mode: "preview_only",
+        })
+        .collect::<Vec<_>>();
+    outputs.push(AuditOutputPlan {
+        path: "session-map.json",
+        mode: preview_mode(args.with_sessions),
+    });
+    outputs.push(AuditOutputPlan {
+        path: "snapshot/",
+        mode: preview_mode(args.snapshot_source),
+    });
+    outputs.push(AuditOutputPlan {
+        path: "backups/",
+        mode: preview_mode(args.overwrite),
+    });
+    outputs
+}
+
+fn build_agent_task_preview(
+    args: &OpenClawMigrateArgs,
+    workspace_exists: bool,
+    eligible_for_v1: bool,
+) -> Vec<AgentTaskPlan> {
+    if !eligible_for_v1 {
+        return vec![
+            AgentTaskPlan {
+                key: "workspace_copy",
+                mode: "disabled",
+            },
+            AgentTaskPlan {
+                key: "prompt_write",
+                mode: "disabled",
+            },
+            AgentTaskPlan {
+                key: "memory_import",
+                mode: "disabled",
+            },
+            AgentTaskPlan {
+                key: "session_import",
+                mode: "disabled",
+            },
+            AgentTaskPlan {
+                key: "org_agent_write",
+                mode: "disabled",
+            },
+            AgentTaskPlan {
+                key: "db_upsert",
+                mode: "disabled",
+            },
+        ];
+    }
+
+    vec![
+        AgentTaskPlan {
+            key: "workspace_copy",
+            mode: if !workspace_exists || args.no_workspace {
+                "disabled"
+            } else {
+                "preview_only"
+            },
+        },
+        AgentTaskPlan {
+            key: "prompt_write",
+            mode: if workspace_exists && !args.no_prompts {
+                "preview_only"
+            } else {
+                "disabled"
+            },
+        },
+        AgentTaskPlan {
+            key: "memory_import",
+            mode: if workspace_exists && !args.no_memory {
+                "preview_only"
+            } else {
+                "disabled"
+            },
+        },
+        AgentTaskPlan {
+            key: "session_import",
+            mode: preview_mode(args.with_sessions),
+        },
+        AgentTaskPlan {
+            key: "org_agent_write",
+            mode: if args.write_org && eligible_for_v1 {
+                "preview_only"
+            } else {
+                "disabled"
+            },
+        },
+        AgentTaskPlan {
+            key: "db_upsert",
+            mode: if args.write_db && eligible_for_v1 {
+                "preview_only"
+            } else {
+                "disabled"
+            },
+        },
+    ]
+}
+
+fn restrict_discord_plan_to_importable_agents(
+    discord: &mut DiscordChannelImportResult,
+    importable_agent_ids: &BTreeSet<String>,
+    warnings: &mut Vec<String>,
+) {
+    for binding in &mut discord.bindings {
+        if importable_agent_ids.contains(&binding.agent_id) || binding.mode != "live_applicable" {
+            continue;
+        }
+        let warning = format!(
+            "Discord binding for agent '{}' stays preview-only because that agent is not importable.",
+            binding.agent_id
+        );
+        warnings.push(warning.clone());
+        binding.mode = "preview_only";
+        binding.reason = Some(
+            "Target agent is not importable because provider mapping or workspace resolution is incomplete."
+                .to_string(),
+        );
+        binding.warnings.push(warning);
+    }
+
+    let mut selected_account_ids = BTreeSet::new();
+    let mut agent_channels = BTreeMap::<String, BTreeSet<String>>::new();
+    for binding in discord
+        .bindings
+        .iter()
+        .filter(|binding| binding.mode == "live_applicable")
+    {
+        if let Some(account_id) = binding.selected_account_id.as_ref() {
+            selected_account_ids.insert(account_id.clone());
+        }
+        agent_channels
+            .entry(binding.agent_id.clone())
+            .or_default()
+            .extend(binding.channel_ids.iter().cloned());
+    }
+
+    discord.selected_account_ids = selected_account_ids.into_iter().collect();
+    discord.agent_channels = agent_channels
+        .into_iter()
+        .map(|(agent_id, channel_ids)| (agent_id, channel_ids.into_iter().collect()))
+        .collect();
+}
+
+fn collect_preview_flag_warnings(args: &OpenClawMigrateArgs, warnings: &mut Vec<String>) {
+    let tool_policy_mode = parse_tool_policy_mode(&args.tool_policy_mode).ok();
+    let discord_token_mode = parse_discord_token_mode(&args.discord_token_mode).ok();
+
+    if args.with_channel_bindings && !args.write_org {
+        warnings.push(
+            "--with-channel-bindings without --write-org stays preview-only; no live org.yaml bindings can be applied."
+                .to_string(),
+        );
+    }
+
+    if args.write_bot_settings && !args.write_org && args.with_channel_bindings {
+        warnings.push(
+            "--write-bot-settings with channel bindings but without --write-org cannot produce live allowed_channel_ids safely."
+                .to_string(),
+        );
+    }
+
+    if args.with_sessions && !args.write_db {
+        warnings.push(
+            "--with-sessions without --write-db can only target file-based session artifacts; DB rows remain preview-only."
+                .to_string(),
+        );
+    }
+
+    if args.no_workspace {
+        warnings.push(
+            "--no-workspace disables copied workspace output; prompt and memory preview still reads the source workspace."
+                .to_string(),
+        );
+    }
+
+    if args.no_memory {
+        warnings.push("--no-memory skips Markdown memory import.".to_string());
+    }
+
+    if args.no_prompts {
+        warnings.push("--no-prompts skips merged prompt generation.".to_string());
+    }
+
+    if args.write_bot_settings
+        && matches!(discord_token_mode, Some(DiscordTokenMode::Report) | None)
+    {
+        warnings.push(
+            "--write-bot-settings with --discord-token-mode report stays audit-only for bot tokens."
+                .to_string(),
+        );
+    }
+
+    if !args.write_bot_settings
+        && !matches!(discord_token_mode, Some(DiscordTokenMode::Report) | None)
+    {
+        warnings.push(
+            "--discord-token-mode without --write-bot-settings stays report-only.".to_string(),
+        );
+    }
+
+    if !args.write_bot_settings
+        && matches!(
+            tool_policy_mode,
+            Some(ToolPolicyMode::BotIntersection | ToolPolicyMode::BotUnion)
+        )
+    {
+        warnings
+            .push("--tool-policy-mode without --write-bot-settings stays report-only.".to_string());
+    }
+}
+
+fn preview_mode(enabled: bool) -> &'static str {
+    if enabled { "preview_only" } else { "disabled" }
+}
+
+fn parse_tool_policy_mode(raw: &str) -> Result<ToolPolicyMode, String> {
+    ToolPolicyMode::parse(raw)
+}
+
+fn parse_discord_token_mode(raw: &str) -> Result<DiscordTokenMode, String> {
+    DiscordTokenMode::parse(raw)
+}
+
+fn load_existing_role_ids(runtime_root: Option<&Path>) -> BTreeSet<String> {
+    let Some(runtime_root) = runtime_root else {
+        return BTreeSet::new();
+    };
+    let mut ids = BTreeSet::new();
+
+    let org_path = runtime_root.join("config").join("org.yaml");
+    if let Ok(content) = fs::read_to_string(org_path) {
+        if let Ok(value) = serde_yaml::from_str::<serde_yaml::Value>(&content) {
+            if let Some(agents) = value.get("agents").and_then(serde_yaml::Value::as_mapping) {
+                ids.extend(
+                    agents
+                        .keys()
+                        .filter_map(serde_yaml::Value::as_str)
+                        .map(ToOwned::to_owned),
+                );
+            }
+        }
+    }
+
+    let agentdesk_path = runtime_root.join("agentdesk.yaml");
+    if let Ok(content) = fs::read_to_string(agentdesk_path) {
+        if let Ok(value) = serde_yaml::from_str::<serde_yaml::Value>(&content) {
+            if let Some(agents) = value.get("agents").and_then(serde_yaml::Value::as_sequence) {
+                ids.extend(agents.iter().filter_map(|agent| {
+                    agent
+                        .get("id")
+                        .and_then(serde_yaml::Value::as_str)
+                        .map(ToOwned::to_owned)
+                }));
+            }
+        }
+    }
+
+    ids
+}
+
+fn select_agents<'a>(
+    config: &'a OpenClawConfig,
+    args: &OpenClawMigrateArgs,
+) -> Result<(Vec<&'a OpenClawAgentConfig>, AgentSelectionMode), String> {
+    if !args.agent_ids.is_empty() {
+        let by_id = config
+            .agents
+            .list
+            .iter()
+            .map(|agent| (agent.id.as_str(), agent))
+            .collect::<BTreeMap<_, _>>();
+        let mut selected = Vec::new();
+        let mut seen = BTreeSet::new();
+        for requested in &args.agent_ids {
+            let normalized = requested.trim();
+            let Some(agent) = by_id.get(normalized) else {
+                return Err(format!(
+                    "Unknown OpenClaw agent '{}'. Available agents: {}.",
+                    requested,
+                    available_agent_ids(config)
+                ));
+            };
+            if seen.insert(normalized.to_string()) {
+                selected.push(*agent);
+            }
+        }
+        return Ok((selected, AgentSelectionMode::Explicit));
+    }
+
+    if args.all_agents {
+        return Ok((
+            config.agents.list.iter().collect(),
+            AgentSelectionMode::AllAgents,
+        ));
+    }
+
+    if let Some(default_agent) = config.agents.default_agent_id()? {
+        let Some(agent) = config
+            .agents
+            .list
+            .iter()
+            .find(|agent| agent.id == default_agent)
+        else {
+            return Err(format!(
+                "openclaw.json default agent '{}' is missing from agents.list.",
+                default_agent
+            ));
+        };
+        return Ok((vec![agent], AgentSelectionMode::DefaultAgent));
+    }
+
+    if config.agents.list.len() == 1 {
+        return Ok((
+            vec![&config.agents.list[0]],
+            AgentSelectionMode::SingleAgent,
+        ));
+    }
+
+    Err(format!(
+        "Multiple OpenClaw agents found ({}). Pass --agent or --all-agents.",
+        available_agent_ids(config)
+    ))
+}
+
+fn available_agent_ids(config: &OpenClawConfig) -> String {
+    config
+        .agents
+        .list
+        .iter()
+        .map(|agent| agent.id.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn assign_role_id(source_id: &str, used: &mut BTreeSet<String>) -> String {
+    let base = sanitize_role_id(source_id);
+    if used.insert(base.clone()) {
+        return base;
+    }
+
+    let prefixed = sanitize_role_id(&format!("openclaw-{source_id}"));
+    if used.insert(prefixed.clone()) {
+        return prefixed;
+    }
+
+    for suffix in 2.. {
+        let candidate = format!("{prefixed}-{suffix}");
+        if used.insert(candidate.clone()) {
+            return candidate;
+        }
+    }
+
+    unreachable!("role id generation exhausted");
+}
+
+fn sanitize_role_id(raw: &str) -> String {
+    let mut out = String::new();
+    let mut last_dash = false;
+
+    for ch in raw.trim().chars() {
+        let mapped = match ch {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-' => Some(ch),
+            _ => Some('-'),
+        };
+
+        let Some(mapped) = mapped else {
+            continue;
+        };
+
+        if mapped == '-' {
+            if last_dash || out.is_empty() {
+                continue;
+            }
+            last_dash = true;
+            out.push(mapped);
+            continue;
+        }
+
+        last_dash = false;
+        out.push(mapped);
+    }
+
+    while out.ends_with('-') {
+        out.pop();
+    }
+
+    if out.is_empty() {
+        "openclaw-agent".to_string()
+    } else {
+        out
+    }
+}
+
+fn direct_provider_hint(agent: &OpenClawAgentConfig) -> Option<&str> {
+    agent
+        .runtime
+        .get("provider")
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| {
+            agent
+                .runtime
+                .get("agent")
+                .and_then(serde_json::Value::as_str)
+        })
+        .or_else(|| {
+            agent
+                .runtime
+                .get("acp")
+                .and_then(|acp| acp.get("agent"))
+                .and_then(serde_json::Value::as_str)
+        })
+        .or_else(|| {
+            agent
+                .runtime
+                .get("acp")
+                .and_then(|acp| acp.get("backend"))
+                .and_then(serde_json::Value::as_str)
+        })
+}
+
+fn model_hint<'a>(
+    agent: &'a OpenClawAgentConfig,
+    defaults: &'a OpenClawAgentDefaultsConfig,
+) -> Option<&'a str> {
+    agent
+        .model
+        .as_ref()
+        .and_then(|model| model.primary())
+        .or_else(|| {
+            agent
+                .runtime
+                .get("model")
+                .and_then(serde_json::Value::as_str)
+        })
+        .or_else(|| defaults.model.as_ref().and_then(|model| model.primary()))
+}
+
+fn map_known_provider(raw: &str) -> Option<ProviderKind> {
+    if let Some(mapped) = ProviderKind::from_str(raw) {
+        return Some(mapped);
+    }
+    let normalized = raw.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "anthropic" => Some(ProviderKind::Claude),
+        "openai" | "openai-codex" | "codex" => Some(ProviderKind::Codex),
+        "google" | "gemini" => Some(ProviderKind::Gemini),
+        _ => None,
+    }
+}
+
+fn map_provider_from_model(model: &str) -> Option<ProviderKind> {
+    let normalized = model.trim().to_ascii_lowercase();
+    if normalized.starts_with("anthropic/") {
+        return Some(ProviderKind::Claude);
+    }
+    if normalized.starts_with("openai-codex/") || normalized.starts_with("openai/") {
+        return Some(ProviderKind::Codex);
+    }
+    if normalized.starts_with("google/") || normalized.contains("gemini") {
+        return Some(ProviderKind::Gemini);
+    }
+    None
+}
+
+fn map_provider(
+    agent: &OpenClawAgentConfig,
+    defaults: &OpenClawAgentDefaultsConfig,
+    fallback_provider: Option<&ProviderKind>,
+    warnings: &mut Vec<String>,
+) -> Option<String> {
+    if let Some(raw_provider) = direct_provider_hint(agent) {
+        if let Some(mapped) = map_known_provider(raw_provider) {
+            return Some(mapped.as_str().to_string());
+        }
+        if let Some(model) = model_hint(agent, defaults).and_then(map_provider_from_model) {
+            warnings.push(format!(
+                "agent '{}' runtime/provider hint '{}' is unsupported; inferred provider '{}' from model '{}'.",
+                agent.id,
+                raw_provider,
+                model.as_str(),
+                model_hint(agent, defaults).unwrap_or("unknown")
+            ));
+            return Some(model.as_str().to_string());
+        }
+        if let Some(fallback_provider) = fallback_provider {
+            warnings.push(format!(
+                "agent '{}' provider hint '{}' is unsupported; dry-run mapped it to fallback '{}'.",
+                agent.id,
+                raw_provider,
+                fallback_provider.as_str()
+            ));
+            return Some(fallback_provider.as_str().to_string());
+        }
+        warnings.push(format!(
+            "agent '{}' provider hint '{}' is unsupported and no --fallback-provider was supplied.",
+            agent.id, raw_provider
+        ));
+        return None;
+    }
+
+    if let Some(model_hint) = model_hint(agent, defaults) {
+        if let Some(mapped) = map_provider_from_model(model_hint) {
+            return Some(mapped.as_str().to_string());
+        }
+        if let Some(fallback_provider) = fallback_provider {
+            warnings.push(format!(
+                "agent '{}' model '{}' is unsupported; dry-run mapped it to fallback '{}'.",
+                agent.id,
+                model_hint,
+                fallback_provider.as_str()
+            ));
+            return Some(fallback_provider.as_str().to_string());
+        }
+        warnings.push(format!(
+            "agent '{}' model '{}' is unsupported and no --fallback-provider was supplied.",
+            agent.id, model_hint
+        ));
+        return None;
+    }
+
+    if let Some(fallback_provider) = fallback_provider {
+        warnings.push(format!(
+            "agent '{}' has no provider or model hint; dry-run mapped it to fallback '{}'.",
+            agent.id,
+            fallback_provider.as_str()
+        ));
+        return Some(fallback_provider.as_str().to_string());
+    }
+
+    warnings.push(format!(
+        "agent '{}' has no provider or model hint; live apply will require an explicit fallback later.",
+        agent.id
+    ));
+    None
+}
+
+#[derive(Clone, Debug)]
+struct WorkspaceRewriteRule {
+    from: String,
+    to: PathBuf,
+}
+
+fn parse_workspace_rewrite_rules(
+    raw_rules: &[String],
+) -> Result<Vec<WorkspaceRewriteRule>, String> {
+    raw_rules
+        .iter()
+        .map(|raw| {
+            let Some((from, to)) = raw.split_once('=') else {
+                return Err(format!(
+                    "Invalid --workspace-root-rewrite '{}'. Expected OLD=NEW.",
+                    raw
+                ));
+            };
+            let from = from.trim().trim_end_matches('/');
+            let to = to.trim();
+            if from.is_empty() || to.is_empty() {
+                return Err(format!(
+                    "Invalid --workspace-root-rewrite '{}'. OLD and NEW must be non-empty.",
+                    raw
+                ));
+            }
+            Ok(WorkspaceRewriteRule {
+                from: from.to_string(),
+                to: PathBuf::from(to),
+            })
+        })
+        .collect()
+}
+
+fn resolve_workspace_path(
+    source_root: &Path,
+    is_default_agent: bool,
+    agent: &OpenClawAgentConfig,
+    defaults_workspace: Option<&str>,
+    workspace_rewrite_rules: &[WorkspaceRewriteRule],
+    warnings: &mut Vec<String>,
+) -> PathBuf {
+    if let Some(raw_workspace) = agent.workspace.as_deref() {
+        return resolve_workspace_value_with_rewrites(
+            source_root,
+            raw_workspace,
+            &agent.id,
+            workspace_rewrite_rules,
+            warnings,
+        );
+    }
+
+    if let Some(defaults_workspace) = defaults_workspace {
+        return resolve_workspace_value_with_rewrites(
+            source_root,
+            defaults_workspace,
+            &agent.id,
+            workspace_rewrite_rules,
+            warnings,
+        );
+    }
+
+    if is_default_agent {
+        return source_root.join("workspace");
+    }
+
+    source_root.join(format!("workspace-{}", agent.id))
+}
+
+fn resolve_workspace_value_with_rewrites(
+    source_root: &Path,
+    raw_workspace: &str,
+    agent_id: &str,
+    workspace_rewrite_rules: &[WorkspaceRewriteRule],
+    warnings: &mut Vec<String>,
+) -> PathBuf {
+    let path = PathBuf::from(raw_workspace);
+    if !path.is_absolute() {
+        return source_root.join(path);
+    }
+
+    let normalized = raw_workspace.trim().trim_end_matches('/');
+    for rule in workspace_rewrite_rules {
+        if normalized == rule.from || normalized.starts_with(&format!("{}/", rule.from)) {
+            let suffix = normalized
+                .strip_prefix(&rule.from)
+                .unwrap_or_default()
+                .trim_start_matches('/');
+            let target_root = if rule.to.is_absolute() {
+                rule.to.clone()
+            } else {
+                source_root.join(&rule.to)
+            };
+            let rewritten = if suffix.is_empty() {
+                target_root
+            } else {
+                target_root.join(suffix)
+            };
+            warnings.push(format!(
+                "agent '{}' workspace '{}' was remapped via --workspace-root-rewrite to '{}'.",
+                agent_id,
+                raw_workspace,
+                rewritten.display()
+            ));
+            return rewritten;
+        }
+    }
+
+    if !path.exists() {
+        if let Some(file_name) = path.file_name() {
+            let relocated = source_root.join(file_name);
+            if relocated.exists() {
+                warnings.push(format!(
+                    "agent '{}' workspace '{}' was auto-relocated to '{}' under the discovered OpenClaw root.",
+                    agent_id,
+                    raw_workspace,
+                    relocated.display()
+                ));
+                return relocated;
+            }
+        }
+    }
+
+    path
+}
+
+fn existing_bootstrap_files(workspace_path: &Path) -> Vec<String> {
+    BOOTSTRAP_FILE_NAMES
+        .iter()
+        .filter_map(|name| {
+            let path = workspace_path.join(name);
+            path.is_file().then(|| (*name).to_string())
+        })
+        .collect()
+}
+
+fn count_markdown_files(root: &Path) -> usize {
+    if !root.exists() {
+        return 0;
+    }
+
+    let mut count = 0;
+    let mut queue = VecDeque::from([root.to_path_buf()]);
+    while let Some(dir) = queue.pop_front() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_symlink() {
+                continue;
+            }
+            if file_type.is_dir() {
+                queue.push_back(path);
+                continue;
+            }
+            if file_type.is_file()
+                && path
+                    .extension()
+                    .and_then(|ext| ext.to_str())
+                    .map(|ext| ext.eq_ignore_ascii_case("md"))
+                    .unwrap_or(false)
+            {
+                count += 1;
+            }
+        }
+    }
+
+    count
+}
+
+fn build_import_id(source: &ResolvedSourceRoot, agents: &[ImportAgentPlan]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(source.config_path.as_os_str().to_string_lossy().as_bytes());
+    for agent in agents {
+        hasher.update(agent.source_id.as_bytes());
+        hasher.update(agent.final_role_id.as_bytes());
+    }
+    let digest = hex::encode(hasher.finalize());
+    let root_name = source
+        .root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("openclaw");
+    format!("openclaw-{}-{}", sanitize_role_id(root_name), &digest[..12])
+}
+
+fn collect_session_plans(
+    source: &ResolvedSourceRoot,
+    agents: &[ImportAgentPlan],
+    warnings: &mut Vec<String>,
+) -> Vec<ImportSessionPlan> {
+    let mut sessions = Vec::new();
+
+    for agent in agents {
+        let sessions_dir = source
+            .root
+            .join("agents")
+            .join(&agent.source_id)
+            .join("sessions");
+        let store_path = sessions_dir.join("sessions.json");
+        if !store_path.is_file() {
+            continue;
+        }
+
+        let raw = match fs::read_to_string(&store_path) {
+            Ok(raw) => raw,
+            Err(err) => {
+                warnings.push(format!(
+                    "Failed to read OpenClaw session store '{}': {err}",
+                    store_path.display()
+                ));
+                continue;
+            }
+        };
+
+        let parsed = match serde_json::from_str::<serde_json::Value>(&raw) {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                warnings.push(format!(
+                    "Failed to parse OpenClaw session store '{}': {err}",
+                    store_path.display()
+                ));
+                continue;
+            }
+        };
+
+        let Some(entries) = parsed.as_object() else {
+            warnings.push(format!(
+                "OpenClaw session store '{}' is not a JSON object.",
+                store_path.display()
+            ));
+            continue;
+        };
+
+        for (session_key, entry) in entries {
+            let Some(session_id) = entry
+                .get("sessionId")
+                .and_then(serde_json::Value::as_str)
+                .map(ToOwned::to_owned)
+            else {
+                warnings.push(format!(
+                    "Skipping OpenClaw session '{}' in '{}': missing sessionId.",
+                    session_key,
+                    store_path.display()
+                ));
+                continue;
+            };
+
+            let transcript_path = resolve_session_transcript_path(
+                &sessions_dir,
+                &session_id,
+                entry.get("sessionFile").and_then(serde_json::Value::as_str),
+                warnings,
+            )
+            .map(|path| path.display().to_string());
+
+            sessions.push(ImportSessionPlan {
+                source_agent_id: agent.source_id.clone(),
+                final_role_id: agent.final_role_id.clone(),
+                session_key: session_key.clone(),
+                session_id,
+                session_store_path: store_path.display().to_string(),
+                transcript_path,
+                updated_at: json_i64(entry.get("updatedAt")).unwrap_or_default(),
+                model: entry
+                    .get("model")
+                    .and_then(serde_json::Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .or_else(|| {
+                        entry
+                            .get("modelOverride")
+                            .and_then(serde_json::Value::as_str)
+                            .map(ToOwned::to_owned)
+                    }),
+                provider_hint: entry
+                    .get("modelProvider")
+                    .and_then(serde_json::Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .or_else(|| {
+                        entry
+                            .get("providerOverride")
+                            .and_then(serde_json::Value::as_str)
+                            .map(ToOwned::to_owned)
+                    })
+                    .or_else(|| {
+                        entry
+                            .get("origin")
+                            .and_then(|origin| origin.get("provider"))
+                            .and_then(serde_json::Value::as_str)
+                            .map(ToOwned::to_owned)
+                    }),
+                cwd: entry
+                    .get("spawnedWorkspaceDir")
+                    .and_then(serde_json::Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .or_else(|| {
+                        entry
+                            .get("cwd")
+                            .and_then(serde_json::Value::as_str)
+                            .map(ToOwned::to_owned)
+                    })
+                    .or_else(|| {
+                        entry
+                            .get("acp")
+                            .and_then(|acp| acp.get("cwd"))
+                            .and_then(serde_json::Value::as_str)
+                            .map(ToOwned::to_owned)
+                    }),
+                channel: entry
+                    .get("lastChannel")
+                    .and_then(serde_json::Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .or_else(|| {
+                        entry
+                            .get("channel")
+                            .and_then(serde_json::Value::as_str)
+                            .map(ToOwned::to_owned)
+                    }),
+                account_id: entry
+                    .get("lastAccountId")
+                    .and_then(serde_json::Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .or_else(|| {
+                        entry
+                            .get("origin")
+                            .and_then(|origin| origin.get("accountId"))
+                            .and_then(serde_json::Value::as_str)
+                            .map(ToOwned::to_owned)
+                    }),
+                thread_id: entry
+                    .get("lastThreadId")
+                    .and_then(json_stringish)
+                    .or_else(|| {
+                        entry
+                            .get("origin")
+                            .and_then(|origin| origin.get("threadId"))
+                            .and_then(json_stringish)
+                    }),
+                status: entry
+                    .get("status")
+                    .and_then(serde_json::Value::as_str)
+                    .map(ToOwned::to_owned),
+            });
+        }
+    }
+
+    sessions.sort_by(|left, right| {
+        left.source_agent_id
+            .cmp(&right.source_agent_id)
+            .then_with(|| left.session_key.cmp(&right.session_key))
+    });
+    sessions
+}
+
+fn resolve_session_transcript_path(
+    sessions_dir: &Path,
+    session_id: &str,
+    session_file: Option<&str>,
+    warnings: &mut Vec<String>,
+) -> Option<PathBuf> {
+    let candidate = match session_file {
+        Some(raw) if !raw.trim().is_empty() => {
+            let path = PathBuf::from(raw.trim());
+            if path.is_absolute() {
+                path
+            } else {
+                sessions_dir.join(path)
+            }
+        }
+        _ => sessions_dir.join(format!("{session_id}.jsonl")),
+    };
+
+    if candidate.is_file() {
+        Some(candidate)
+    } else {
+        warnings.push(format!(
+            "OpenClaw transcript file is missing for session '{}' at '{}'.",
+            session_id,
+            candidate.display()
+        ));
+        None
+    }
+}
+
+fn json_i64(value: Option<&serde_json::Value>) -> Option<i64> {
+    value
+        .and_then(serde_json::Value::as_i64)
+        .or_else(|| value.and_then(serde_json::Value::as_u64).map(|v| v as i64))
+}
+
+fn json_stringish(value: &serde_json::Value) -> Option<String> {
+    value
+        .as_str()
+        .map(ToOwned::to_owned)
+        .or_else(|| value.as_i64().map(|v| v.to_string()))
+        .or_else(|| value.as_u64().map(|v| v.to_string()))
+}

--- a/src/cli/migrate/plan.rs
+++ b/src/cli/migrate/plan.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::services::provider::ProviderKind;
@@ -171,6 +171,12 @@ pub(super) struct AgentTaskPlan {
     pub(super) mode: &'static str,
 }
 
+#[derive(Clone, Debug, Deserialize)]
+struct StoredAgentMapEntry {
+    source_id: String,
+    role_id: String,
+}
+
 pub(super) fn build_import_plan(
     source: &ResolvedSourceRoot,
     args: &OpenClawMigrateArgs,
@@ -180,9 +186,11 @@ pub(super) fn build_import_plan(
     let _tool_policy_mode = parse_tool_policy_mode(&args.tool_policy_mode)?;
     let _discord_token_mode = parse_discord_token_mode(&args.discord_token_mode)?;
     let workspace_rewrite_rules = parse_workspace_rewrite_rules(&args.workspace_root_rewrite)?;
-    let existing_role_ids = load_existing_role_ids(runtime_root);
     let default_agent_id = source.config.agents.default_agent_id()?;
     let (selected_agents, selection_mode) = select_agents(&source.config, args)?;
+    let resume_role_ids =
+        load_resume_role_ids(runtime_root, args.resume.as_deref(), &selected_agents)?;
+    let existing_role_ids = load_existing_role_ids(runtime_root);
     let selected_agent_ids = selected_agents
         .iter()
         .map(|agent| agent.id.clone())
@@ -196,7 +204,12 @@ pub(super) fn build_import_plan(
         let is_default_agent = default_agent_id
             .map(|selected_default_agent_id| selected_default_agent_id == agent.id)
             .unwrap_or(false);
-        let final_role_id = assign_role_id(&agent.id, &mut used_role_ids);
+        let final_role_id = if let Some(stored_role_id) = resume_role_ids.get(&agent.id) {
+            used_role_ids.insert(stored_role_id.clone());
+            stored_role_id.clone()
+        } else {
+            assign_role_id(&agent.id, &mut used_role_ids)
+        };
         let provider_hint = direct_provider_hint(agent).map(|value| value.to_string());
         let model_hint =
             model_hint(agent, &source.config.agents.defaults).map(|value| value.to_string());
@@ -824,6 +837,70 @@ fn assign_role_id(source_id: &str, used: &mut BTreeSet<String>) -> String {
     unreachable!("role id generation exhausted");
 }
 
+fn load_resume_role_ids(
+    runtime_root: Option<&Path>,
+    import_id: Option<&str>,
+    selected_agents: &[&OpenClawAgentConfig],
+) -> Result<BTreeMap<String, String>, String> {
+    let Some(import_id) = import_id else {
+        return Ok(BTreeMap::new());
+    };
+    let runtime_root = runtime_root
+        .ok_or_else(|| "OpenClaw migrate resume requires an AgentDesk runtime root.".to_string())?;
+    let agent_map_path = runtime_root
+        .join("openclaw")
+        .join("imports")
+        .join(import_id)
+        .join("agent-map.json");
+    let agent_map_raw = fs::read_to_string(&agent_map_path)
+        .map_err(|e| format!("Failed to read '{}': {e}", agent_map_path.display()))?;
+    let agent_map: Vec<StoredAgentMapEntry> = serde_json::from_str(&agent_map_raw)
+        .map_err(|e| format!("Failed to parse '{}': {e}", agent_map_path.display()))?;
+
+    let mut by_source = BTreeMap::new();
+    for entry in agent_map {
+        if entry.source_id.trim().is_empty() || entry.role_id.trim().is_empty() {
+            return Err(format!(
+                "Resume agent map '{}' contains an empty source_id or role_id entry.",
+                agent_map_path.display()
+            ));
+        }
+        if let Some(existing_role_id) =
+            by_source.insert(entry.source_id.clone(), entry.role_id.clone())
+        {
+            if existing_role_id != entry.role_id {
+                return Err(format!(
+                    "Resume agent map '{}' contains conflicting role ids for source agent '{}'.",
+                    agent_map_path.display(),
+                    entry.source_id
+                ));
+            }
+        }
+    }
+
+    let mut selected_map = BTreeMap::new();
+    let mut seen_role_ids = BTreeSet::new();
+    for agent in selected_agents {
+        let role_id = by_source.get(&agent.id).cloned().ok_or_else(|| {
+            format!(
+                "Resume agent map '{}' is missing source agent '{}'.",
+                agent_map_path.display(),
+                agent.id
+            )
+        })?;
+        if !seen_role_ids.insert(role_id.clone()) {
+            return Err(format!(
+                "Resume agent map '{}' assigns duplicate role id '{}' across selected agents.",
+                agent_map_path.display(),
+                role_id
+            ));
+        }
+        selected_map.insert(agent.id.clone(), role_id);
+    }
+
+    Ok(selected_map)
+}
+
 fn sanitize_role_id(raw: &str) -> String {
     let mut out = String::new();
     let mut last_dash = false;
@@ -1119,9 +1196,7 @@ fn resolve_workspace_value_with_rewrites(
         }
     }
 
-    let looks_absolute = path.is_absolute()
-        || trimmed_workspace.starts_with('/')
-        || trimmed_workspace.starts_with('\\');
+    let looks_absolute = workspace_path_is_absolute(trimmed_workspace);
     if !looks_absolute {
         return source_root.join(path);
     }
@@ -1142,6 +1217,18 @@ fn resolve_workspace_value_with_rewrites(
     }
 
     path
+}
+
+fn workspace_path_is_absolute(raw: &str) -> bool {
+    let trimmed = raw.trim();
+    let bytes = trimmed.as_bytes();
+    Path::new(trimmed).is_absolute()
+        || trimmed.starts_with('/')
+        || trimmed.starts_with('\\')
+        || (bytes.len() >= 3
+            && bytes[0].is_ascii_alphabetic()
+            && bytes[1] == b':'
+            && (bytes[2] == b'\\' || bytes[2] == b'/'))
 }
 
 fn existing_bootstrap_files(workspace_path: &Path) -> Vec<String> {

--- a/src/cli/migrate/source.rs
+++ b/src/cli/migrate/source.rs
@@ -1,0 +1,1610 @@
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::utils::format::expand_tilde_path;
+
+pub(super) const OPENCLAW_CONFIG_NAME: &str = "openclaw.json";
+const INCLUDE_KEY: &str = "$include";
+const MAX_INCLUDE_DEPTH: usize = 10;
+
+const PRUNE_DIR_NAMES: &[&str] = &[".git", "node_modules", "target", "dist", ".venv", ".cache"];
+
+#[derive(Clone, Debug)]
+struct OpenClawCandidate {
+    root: PathBuf,
+    config_path: PathBuf,
+    config: OpenClawConfig,
+    resolved_config_json: String,
+    resolved_config_paths: Vec<PathBuf>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct ResolvedSourceRoot {
+    pub(super) root: PathBuf,
+    pub(super) config_path: PathBuf,
+    pub(super) config: OpenClawConfig,
+    pub(super) resolved_config_json: String,
+    pub(super) resolved_config_paths: Vec<PathBuf>,
+    pub(super) discovered_candidate_roots: Vec<PathBuf>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub(super) struct OpenClawConfig {
+    #[serde(default)]
+    pub(super) agents: OpenClawAgentsConfig,
+    #[serde(default)]
+    pub(super) bindings: Vec<OpenClawBindingConfig>,
+    #[serde(default)]
+    pub(super) channels: OpenClawChannelsConfig,
+    #[serde(default)]
+    pub(super) secrets: Option<OpenClawSecretsConfig>,
+    #[serde(default)]
+    pub(super) tools: Option<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub(super) struct OpenClawSecretsConfig {
+    #[serde(default)]
+    pub(super) providers: BTreeMap<String, OpenClawSecretProviderConfig>,
+    #[serde(default)]
+    pub(super) defaults: OpenClawSecretDefaultsConfig,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub(super) struct OpenClawSecretDefaultsConfig {
+    #[serde(default)]
+    pub(super) env: Option<String>,
+    #[serde(default)]
+    pub(super) file: Option<String>,
+    #[serde(default)]
+    pub(super) exec: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(tag = "source", rename_all = "lowercase")]
+pub(super) enum OpenClawSecretProviderConfig {
+    Env {
+        #[serde(default)]
+        allowlist: Vec<String>,
+    },
+    File {
+        path: String,
+        #[serde(default)]
+        mode: Option<String>,
+        #[serde(rename = "timeoutMs")]
+        #[serde(default)]
+        timeout_ms: Option<u64>,
+        #[serde(rename = "maxBytes")]
+        #[serde(default)]
+        max_bytes: Option<u64>,
+    },
+    Exec {
+        command: String,
+        #[serde(default)]
+        args: Vec<String>,
+        #[serde(rename = "timeoutMs")]
+        #[serde(default)]
+        timeout_ms: Option<u64>,
+        #[serde(rename = "noOutputTimeoutMs")]
+        #[serde(default)]
+        no_output_timeout_ms: Option<u64>,
+        #[serde(rename = "maxOutputBytes")]
+        #[serde(default)]
+        max_output_bytes: Option<u64>,
+        #[serde(rename = "jsonOnly")]
+        #[serde(default)]
+        json_only: Option<bool>,
+        #[serde(default)]
+        env: BTreeMap<String, String>,
+        #[serde(rename = "passEnv")]
+        #[serde(default)]
+        pass_env: Vec<String>,
+        #[serde(rename = "trustedDirs")]
+        #[serde(default)]
+        trusted_dirs: Vec<String>,
+        #[serde(rename = "allowInsecurePath")]
+        #[serde(default)]
+        allow_insecure_path: Option<bool>,
+        #[serde(rename = "allowSymlinkCommand")]
+        #[serde(default)]
+        allow_symlink_command: Option<bool>,
+    },
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub(super) struct OpenClawAgentsConfig {
+    #[serde(rename = "defaultAgent")]
+    pub(super) legacy_default_agent: Option<String>,
+    #[serde(default)]
+    pub(super) defaults: OpenClawAgentDefaultsConfig,
+    #[serde(default)]
+    pub(super) list: Vec<OpenClawAgentConfig>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub(super) struct OpenClawAgentDefaultsConfig {
+    #[serde(default)]
+    pub(super) workspace: Option<String>,
+    #[serde(default)]
+    pub(super) model: Option<OpenClawModelConfig>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+pub(super) enum OpenClawModelConfig {
+    String(String),
+    Structured {
+        #[serde(default)]
+        primary: Option<String>,
+        #[serde(default)]
+        fallbacks: Vec<String>,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct OpenClawAgentConfig {
+    pub(super) id: String,
+    #[serde(default)]
+    pub(super) default: bool,
+    #[serde(default)]
+    pub(super) name: Option<String>,
+    #[serde(default)]
+    pub(super) workspace: Option<String>,
+    #[serde(default)]
+    pub(super) model: Option<OpenClawModelConfig>,
+    #[serde(default)]
+    pub(super) identity: Option<OpenClawIdentityConfig>,
+    #[serde(default)]
+    pub(super) runtime: serde_json::Value,
+    #[serde(default)]
+    pub(super) tools: Option<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub(super) struct OpenClawIdentityConfig {
+    #[serde(default)]
+    pub(super) emoji: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub(super) struct OpenClawChannelsConfig {
+    #[serde(default)]
+    pub(super) discord: Option<OpenClawDiscordConfig>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub(super) struct OpenClawDiscordConfig {
+    #[serde(rename = "defaultAccount")]
+    pub(super) default_account: Option<String>,
+    #[serde(default)]
+    pub(super) token: Option<serde_json::Value>,
+    #[serde(rename = "allowBots")]
+    #[serde(default)]
+    pub(super) allow_bots: Option<serde_json::Value>,
+    #[serde(default)]
+    pub(super) guilds: BTreeMap<String, OpenClawDiscordGuildConfig>,
+    #[serde(default)]
+    pub(super) accounts: BTreeMap<String, OpenClawDiscordAccountConfig>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub(super) struct OpenClawDiscordAccountConfig {
+    #[serde(default)]
+    pub(super) enabled: Option<bool>,
+    #[serde(default)]
+    pub(super) token: Option<serde_json::Value>,
+    #[serde(rename = "allowBots")]
+    #[serde(default)]
+    pub(super) allow_bots: Option<serde_json::Value>,
+    #[serde(default)]
+    pub(super) guilds: BTreeMap<String, OpenClawDiscordGuildConfig>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub(super) struct OpenClawDiscordGuildConfig {
+    #[serde(default)]
+    pub(super) require_mention: Option<bool>,
+    #[serde(default)]
+    pub(super) ignore_other_mentions: Option<bool>,
+    #[serde(default)]
+    pub(super) users: Vec<String>,
+    #[serde(default)]
+    pub(super) roles: Vec<String>,
+    #[serde(default)]
+    pub(super) tools: Option<serde_json::Value>,
+    #[serde(rename = "toolsBySender")]
+    #[serde(default)]
+    pub(super) tools_by_sender: Option<serde_json::Value>,
+    #[serde(default)]
+    pub(super) channels: BTreeMap<String, OpenClawDiscordGuildChannelConfig>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub(super) struct OpenClawDiscordGuildChannelConfig {
+    #[serde(default)]
+    pub(super) allow: Option<bool>,
+    #[serde(default)]
+    pub(super) require_mention: Option<bool>,
+    #[serde(default)]
+    pub(super) ignore_other_mentions: Option<bool>,
+    #[serde(default)]
+    pub(super) users: Vec<String>,
+    #[serde(default)]
+    pub(super) roles: Vec<String>,
+    #[serde(default)]
+    pub(super) tools: Option<serde_json::Value>,
+    #[serde(rename = "toolsBySender")]
+    #[serde(default)]
+    pub(super) tools_by_sender: Option<serde_json::Value>,
+    #[serde(default)]
+    pub(super) system_prompt: Option<String>,
+    #[serde(default)]
+    pub(super) enabled: Option<bool>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct OpenClawBindingConfig {
+    #[serde(default)]
+    pub(super) r#type: Option<String>,
+    #[serde(rename = "agentId")]
+    pub(super) agent_id: String,
+    pub(super) r#match: OpenClawBindingMatchConfig,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct OpenClawBindingMatchConfig {
+    pub(super) channel: String,
+    #[serde(rename = "accountId")]
+    pub(super) account_id: Option<String>,
+    #[serde(default)]
+    pub(super) peer: Option<OpenClawBindingPeerConfig>,
+    #[serde(rename = "guildId")]
+    #[serde(default)]
+    pub(super) guild_id: Option<String>,
+    #[serde(rename = "teamId")]
+    #[serde(default)]
+    pub(super) team_id: Option<String>,
+    #[serde(default)]
+    pub(super) roles: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(super) struct OpenClawBindingPeerConfig {
+    pub(super) kind: String,
+    pub(super) id: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(super) struct DiscordChannelImportResult {
+    pub(super) agent_channels: BTreeMap<String, Vec<String>>,
+    pub(super) selected_account_ids: Vec<String>,
+    pub(super) warnings: Vec<String>,
+    pub(super) accounts: Vec<DiscordAccountImportPlan>,
+    pub(super) bindings: Vec<DiscordBindingImportPlan>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct DiscordAccountImportPlan {
+    pub(super) account_id: String,
+    pub(super) source: &'static str,
+    pub(super) enabled: bool,
+    pub(super) has_token: bool,
+    pub(super) token_kind: String,
+    pub(super) importable: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct DiscordBindingImportPlan {
+    pub(super) agent_id: String,
+    pub(super) requested_account_id: Option<String>,
+    pub(super) selected_account_id: Option<String>,
+    pub(super) candidate_account_ids: Vec<String>,
+    pub(super) channel_ids: Vec<String>,
+    pub(super) mode: &'static str,
+    pub(super) reason: Option<String>,
+    pub(super) warnings: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(super) struct ToolPolicyScanResult {
+    pub(super) global_sources: Vec<String>,
+    pub(super) global_normalized_candidate_tools: Vec<String>,
+    pub(super) global_unsupported_tools: Vec<String>,
+    pub(super) has_channel_scoped_policy: bool,
+    pub(super) has_sender_scoped_policy: bool,
+    pub(super) has_subagent_scoped_policy: bool,
+    pub(super) agents: Vec<ToolPolicyAgentScan>,
+    pub(super) warnings: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct ToolPolicyAgentScan {
+    pub(super) agent_id: String,
+    pub(super) sources: Vec<String>,
+    pub(super) normalized_candidate_tools: Vec<String>,
+    pub(super) unsupported_tools: Vec<String>,
+    pub(super) has_channel_scoped_policy: bool,
+    pub(super) has_sender_scoped_policy: bool,
+    pub(super) has_subagent_scoped_policy: bool,
+}
+
+#[derive(Default)]
+struct ToolPolicySignals {
+    sources: Vec<String>,
+    normalized_candidate_tools: Vec<String>,
+    unsupported_tools: Vec<String>,
+    has_channel_scoped_policy: bool,
+    has_sender_scoped_policy: bool,
+    has_subagent_scoped_policy: bool,
+}
+
+impl OpenClawAgentsConfig {
+    pub(super) fn default_agent_id(&self) -> Result<Option<&str>, String> {
+        let mut flagged_default = None;
+        for agent in &self.list {
+            if agent.default {
+                if let Some(existing) = flagged_default {
+                    return Err(format!(
+                        "openclaw.json marks multiple default agents in agents.list: '{existing}' and '{}'.",
+                        agent.id
+                    ));
+                }
+                flagged_default = Some(agent.id.as_str());
+            }
+        }
+
+        if let Some(legacy_default) = self.legacy_default_agent.as_deref() {
+            let exists = self.list.iter().any(|agent| agent.id == legacy_default);
+            if !exists {
+                return Err(format!(
+                    "openclaw.json legacy defaultAgent '{}' is missing from agents.list.",
+                    legacy_default
+                ));
+            }
+
+            if let Some(flagged_default) = flagged_default {
+                if flagged_default != legacy_default {
+                    return Err(format!(
+                        "openclaw.json default agent markers disagree: agents.list[].default='{}', legacy defaultAgent='{}'.",
+                        flagged_default, legacy_default
+                    ));
+                }
+            } else {
+                return Ok(Some(legacy_default));
+            }
+        }
+
+        Ok(flagged_default)
+    }
+}
+
+impl OpenClawModelConfig {
+    pub(super) fn primary(&self) -> Option<&str> {
+        match self {
+            Self::String(value) => Some(value.as_str()),
+            Self::Structured { primary, .. } => primary.as_deref(),
+        }
+    }
+}
+
+pub(super) fn normalize_tool_names_with_unmapped<I>(tools: I) -> (Vec<String>, Vec<String>)
+where
+    I: IntoIterator<Item = String>,
+{
+    const KNOWN: &[&str] = &[
+        "Bash",
+        "Read",
+        "Edit",
+        "Write",
+        "Glob",
+        "Grep",
+        "Task",
+        "TaskOutput",
+        "TaskStop",
+        "WebFetch",
+        "WebSearch",
+        "NotebookEdit",
+        "Skill",
+        "TaskCreate",
+        "TaskGet",
+        "TaskUpdate",
+        "TaskList",
+        "AskUserQuestion",
+        "EnterPlanMode",
+        "ExitPlanMode",
+    ];
+
+    let mut seen_known = BTreeSet::new();
+    let mut seen_unknown = BTreeSet::new();
+    let mut normalized = Vec::new();
+    let mut unsupported = Vec::new();
+
+    for tool in tools {
+        let trimmed = tool.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Some(canonical) = KNOWN
+            .iter()
+            .find(|candidate| candidate.eq_ignore_ascii_case(trimmed))
+        {
+            if seen_known.insert((*canonical).to_string()) {
+                normalized.push((*canonical).to_string());
+            }
+        } else if seen_unknown.insert(trimmed.to_string()) {
+            unsupported.push(trimmed.to_string());
+        }
+    }
+
+    (normalized, unsupported)
+}
+
+fn collect_tool_policy_candidates(
+    value: Option<&serde_json::Value>,
+    signals: &mut ToolPolicySignals,
+) {
+    let Some(value) = value else {
+        return;
+    };
+    let mut raw_tools = Vec::new();
+    let mut has_subagent_scoped_policy = false;
+    let mut path = Vec::new();
+    collect_tool_policy_candidates_inner(
+        value,
+        &mut path,
+        &mut raw_tools,
+        &mut has_subagent_scoped_policy,
+    );
+    let (normalized, unsupported) = normalize_tool_names_with_unmapped(raw_tools);
+    signals.normalized_candidate_tools.extend(normalized);
+    signals.unsupported_tools.extend(unsupported);
+    signals.has_subagent_scoped_policy |= has_subagent_scoped_policy;
+}
+
+fn collect_tool_policy_candidates_inner(
+    value: &serde_json::Value,
+    path: &mut Vec<String>,
+    raw_tools: &mut Vec<String>,
+    has_subagent_scoped_policy: &mut bool,
+) {
+    match value {
+        serde_json::Value::Array(items) => {
+            let should_collect = path.is_empty()
+                || path
+                    .last()
+                    .map(|key| {
+                        key.eq_ignore_ascii_case("allow") || key.eq_ignore_ascii_case("alsoAllow")
+                    })
+                    .unwrap_or(false);
+            if should_collect {
+                raw_tools.extend(
+                    items
+                        .iter()
+                        .filter_map(serde_json::Value::as_str)
+                        .map(ToOwned::to_owned),
+                );
+            }
+            for item in items {
+                if item.is_object() || item.is_array() {
+                    path.push("[]".to_string());
+                    collect_tool_policy_candidates_inner(
+                        item,
+                        path,
+                        raw_tools,
+                        has_subagent_scoped_policy,
+                    );
+                    path.pop();
+                }
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for (key, nested) in map {
+                if key.eq_ignore_ascii_case("subagents") {
+                    *has_subagent_scoped_policy = true;
+                }
+                path.push(key.clone());
+                collect_tool_policy_candidates_inner(
+                    nested,
+                    path,
+                    raw_tools,
+                    has_subagent_scoped_policy,
+                );
+                path.pop();
+            }
+        }
+        _ => {}
+    }
+}
+
+fn merge_tool_policy_signals(target: &mut ToolPolicySignals, source: &ToolPolicySignals) {
+    target.sources.extend(source.sources.iter().cloned());
+    target
+        .normalized_candidate_tools
+        .extend(source.normalized_candidate_tools.iter().cloned());
+    target
+        .unsupported_tools
+        .extend(source.unsupported_tools.iter().cloned());
+    target.has_channel_scoped_policy |= source.has_channel_scoped_policy;
+    target.has_sender_scoped_policy |= source.has_sender_scoped_policy;
+    target.has_subagent_scoped_policy |= source.has_subagent_scoped_policy;
+}
+
+fn finalize_tool_policy_signals(signals: &mut ToolPolicySignals) {
+    signals.sources.sort();
+    signals.sources.dedup();
+    signals.normalized_candidate_tools.sort();
+    signals.normalized_candidate_tools.dedup();
+    signals.unsupported_tools.sort();
+    signals.unsupported_tools.dedup();
+}
+
+pub(super) fn scan_tool_policy(
+    config: &OpenClawConfig,
+    selected_agent_ids: &BTreeSet<String>,
+) -> ToolPolicyScanResult {
+    let mut global_signals = ToolPolicySignals::default();
+    let mut agent_entries = Vec::new();
+
+    if config.tools.is_some() {
+        global_signals.sources.push("tools".to_string());
+        collect_tool_policy_candidates(config.tools.as_ref(), &mut global_signals);
+    }
+    collect_discord_tool_sources(&config.channels, &mut global_signals, "channels.discord");
+    finalize_tool_policy_signals(&mut global_signals);
+
+    for agent in config
+        .agents
+        .list
+        .iter()
+        .filter(|agent| selected_agent_ids.contains(&agent.id))
+    {
+        let mut signals = ToolPolicySignals::default();
+        merge_tool_policy_signals(&mut signals, &global_signals);
+        if agent.tools.is_some() {
+            signals
+                .sources
+                .push(format!("agents.list[{}].tools", agent.id));
+            collect_tool_policy_candidates(agent.tools.as_ref(), &mut signals);
+        }
+        finalize_tool_policy_signals(&mut signals);
+        agent_entries.push(ToolPolicyAgentScan {
+            agent_id: agent.id.clone(),
+            sources: signals.sources,
+            normalized_candidate_tools: signals.normalized_candidate_tools,
+            unsupported_tools: signals.unsupported_tools,
+            has_channel_scoped_policy: signals.has_channel_scoped_policy,
+            has_sender_scoped_policy: signals.has_sender_scoped_policy,
+            has_subagent_scoped_policy: signals.has_subagent_scoped_policy,
+        });
+    }
+
+    ToolPolicyScanResult {
+        global_sources: global_signals.sources,
+        global_normalized_candidate_tools: global_signals.normalized_candidate_tools,
+        global_unsupported_tools: global_signals.unsupported_tools,
+        has_channel_scoped_policy: global_signals.has_channel_scoped_policy,
+        has_sender_scoped_policy: global_signals.has_sender_scoped_policy,
+        has_subagent_scoped_policy: global_signals.has_subagent_scoped_policy,
+        agents: agent_entries,
+        warnings: if global_signals.has_sender_scoped_policy {
+            vec![
+                "OpenClaw Discord sender-scoped tool policy remains report-only in AgentDesk."
+                    .to_string(),
+            ]
+        } else {
+            Vec::new()
+        },
+    }
+}
+
+pub(super) fn collect_representable_discord_channel_imports(
+    config: &OpenClawConfig,
+    selected_agent_ids: &BTreeSet<String>,
+) -> DiscordChannelImportResult {
+    let mut warnings = Vec::new();
+    let mut records = Vec::new();
+    let accounts = collect_importable_discord_accounts(config.channels.discord.as_ref());
+
+    let discord_bindings = config
+        .bindings
+        .iter()
+        .filter(|binding| {
+            binding.r#type.as_deref().unwrap_or("route") == "route"
+                && binding.r#match.channel.eq_ignore_ascii_case("discord")
+                && selected_agent_ids.contains(&binding.agent_id)
+        })
+        .collect::<Vec<_>>();
+
+    if discord_bindings.is_empty() {
+        return DiscordChannelImportResult {
+            accounts,
+            ..DiscordChannelImportResult::default()
+        };
+    }
+
+    let Some(discord) = config.channels.discord.as_ref() else {
+        warnings.push(
+            "OpenClaw config has Discord route bindings but no channels.discord section; channel bindings stay preview-only."
+                .to_string(),
+        );
+        return DiscordChannelImportResult {
+            accounts,
+            warnings,
+            ..DiscordChannelImportResult::default()
+        };
+    };
+
+    let mut binding_plans = Vec::new();
+    for binding in discord_bindings {
+        if !binding_is_representable(binding) {
+            let reason = format!(
+                "Discord binding for agent '{}' is not representable in AgentDesk org.yaml.",
+                binding.agent_id
+            );
+            warnings.push(format!("{reason} It stays preview-only."));
+            binding_plans.push(DiscordBindingImportPlan {
+                agent_id: binding.agent_id.clone(),
+                requested_account_id: binding.r#match.account_id.clone(),
+                selected_account_id: None,
+                candidate_account_ids: Vec::new(),
+                channel_ids: Vec::new(),
+                mode: "preview_only",
+                reason: Some(reason),
+                warnings: Vec::new(),
+            });
+            continue;
+        }
+
+        let mut binding_warnings = Vec::new();
+        let resolution =
+            resolve_binding_channel_ids(discord, binding, &accounts, &mut binding_warnings);
+        warnings.extend(binding_warnings.iter().cloned());
+        let channel_ids = resolution
+            .channel_ids
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        if channel_ids.is_empty() {
+            let reason = resolution.reason.clone().unwrap_or_else(|| {
+                format!(
+                    "Discord binding for agent '{}' did not resolve any importable live channel ids.",
+                    binding.agent_id
+                )
+            });
+            warnings.push(reason.clone());
+            binding_plans.push(DiscordBindingImportPlan {
+                agent_id: binding.agent_id.clone(),
+                requested_account_id: binding.r#match.account_id.clone(),
+                selected_account_id: resolution.selected_account_id.clone(),
+                candidate_account_ids: resolution.candidate_account_ids.clone(),
+                channel_ids: Vec::new(),
+                mode: "preview_only",
+                reason: Some(reason),
+                warnings: dedupe_warnings(binding_warnings),
+            });
+            continue;
+        }
+
+        for channel_id in channel_ids {
+            records.push((
+                binding.agent_id.clone(),
+                channel_id,
+                resolution
+                    .selected_account_id
+                    .clone()
+                    .into_iter()
+                    .collect::<BTreeSet<_>>(),
+            ));
+        }
+
+        binding_plans.push(DiscordBindingImportPlan {
+            agent_id: binding.agent_id.clone(),
+            requested_account_id: binding.r#match.account_id.clone(),
+            selected_account_id: resolution.selected_account_id,
+            candidate_account_ids: resolution.candidate_account_ids,
+            channel_ids: resolution.channel_ids,
+            mode: "live_applicable",
+            reason: None,
+            warnings: dedupe_warnings(binding_warnings),
+        });
+    }
+
+    let mut by_channel = BTreeMap::<String, BTreeSet<String>>::new();
+    for (agent_id, channel_id, _) in &records {
+        by_channel
+            .entry(channel_id.clone())
+            .or_default()
+            .insert(agent_id.clone());
+    }
+    let conflicts = by_channel
+        .iter()
+        .filter(|(_, agent_ids)| agent_ids.len() > 1)
+        .map(|(channel_id, _)| channel_id.clone())
+        .collect::<BTreeSet<_>>();
+    if !conflicts.is_empty() {
+        warnings.push(format!(
+            "Some Discord channel ids resolve to multiple selected agents and will be skipped from live channel imports: {}.",
+            conflicts.iter().cloned().collect::<Vec<_>>().join(", ")
+        ));
+    }
+
+    let mut agent_channels = BTreeMap::<String, BTreeSet<String>>::new();
+    let mut selected_account_ids = BTreeSet::<String>::new();
+    for (agent_id, channel_id, account_ids) in records {
+        if conflicts.contains(&channel_id) {
+            continue;
+        }
+        agent_channels
+            .entry(agent_id)
+            .or_default()
+            .insert(channel_id);
+        selected_account_ids.extend(account_ids);
+    }
+
+    for binding in &mut binding_plans {
+        if binding.mode != "live_applicable" {
+            continue;
+        }
+        let conflicting_channels = binding
+            .channel_ids
+            .iter()
+            .filter(|channel_id| conflicts.contains(*channel_id))
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        if conflicting_channels.is_empty() {
+            continue;
+        }
+        binding
+            .channel_ids
+            .retain(|channel_id| !conflicts.contains(channel_id));
+        let warning = format!(
+            "Conflicting Discord channel ids were skipped from live import: {}.",
+            conflicting_channels
+                .into_iter()
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        binding.warnings.push(warning);
+        if binding.channel_ids.is_empty() {
+            binding.mode = "preview_only";
+            binding.reason =
+                Some("All resolved channel ids conflict with another selected agent.".to_string());
+        }
+        binding.warnings = dedupe_warnings(std::mem::take(&mut binding.warnings));
+    }
+
+    DiscordChannelImportResult {
+        agent_channels: agent_channels
+            .into_iter()
+            .map(|(agent_id, channel_ids)| (agent_id, channel_ids.into_iter().collect()))
+            .collect(),
+        selected_account_ids: selected_account_ids.into_iter().collect(),
+        warnings: dedupe_warnings(warnings),
+        accounts,
+        bindings: binding_plans,
+    }
+}
+
+fn binding_is_representable(binding: &OpenClawBindingConfig) -> bool {
+    binding.r#match.peer.is_none()
+        && binding.r#match.guild_id.is_none()
+        && binding.r#match.team_id.is_none()
+        && binding.r#match.roles.is_empty()
+}
+
+#[derive(Clone, Debug)]
+struct BindingResolution {
+    selected_account_id: Option<String>,
+    candidate_account_ids: Vec<String>,
+    channel_ids: Vec<String>,
+    reason: Option<String>,
+}
+
+fn collect_discord_tool_sources(
+    channels: &OpenClawChannelsConfig,
+    signals: &mut ToolPolicySignals,
+    prefix: &str,
+) {
+    let Some(discord) = channels.discord.as_ref() else {
+        return;
+    };
+
+    collect_discord_guild_tool_sources(&discord.guilds, signals, &format!("{prefix}.guilds"));
+    for (account_id, account) in &discord.accounts {
+        collect_discord_guild_tool_sources(
+            &account.guilds,
+            signals,
+            &format!("{prefix}.accounts.{account_id}.guilds"),
+        );
+    }
+}
+
+fn collect_discord_guild_tool_sources(
+    guilds: &BTreeMap<String, OpenClawDiscordGuildConfig>,
+    signals: &mut ToolPolicySignals,
+    prefix: &str,
+) {
+    for (guild_id, guild) in guilds {
+        if guild.tools.is_some() {
+            signals.sources.push(format!("{prefix}.{guild_id}.tools"));
+            signals.has_channel_scoped_policy = true;
+            collect_tool_policy_candidates(guild.tools.as_ref(), signals);
+        }
+        if guild.tools_by_sender.is_some() {
+            signals.has_channel_scoped_policy = true;
+            signals.has_sender_scoped_policy = true;
+            signals
+                .sources
+                .push(format!("{prefix}.{guild_id}.toolsBySender"));
+            collect_tool_policy_candidates(guild.tools_by_sender.as_ref(), signals);
+        }
+        for (channel_id, channel) in &guild.channels {
+            if channel.tools.is_some() {
+                signals
+                    .sources
+                    .push(format!("{prefix}.{guild_id}.channels.{channel_id}.tools"));
+                signals.has_channel_scoped_policy = true;
+                collect_tool_policy_candidates(channel.tools.as_ref(), signals);
+            }
+            if channel.tools_by_sender.is_some() {
+                signals.has_channel_scoped_policy = true;
+                signals.has_sender_scoped_policy = true;
+                signals.sources.push(format!(
+                    "{prefix}.{guild_id}.channels.{channel_id}.toolsBySender"
+                ));
+                collect_tool_policy_candidates(channel.tools_by_sender.as_ref(), signals);
+            }
+        }
+    }
+}
+
+fn collect_importable_discord_accounts(
+    discord: Option<&OpenClawDiscordConfig>,
+) -> Vec<DiscordAccountImportPlan> {
+    let Some(discord) = discord else {
+        return Vec::new();
+    };
+
+    let mut accounts = Vec::new();
+    if let Some(token) = discord.token.as_ref() {
+        accounts.push(DiscordAccountImportPlan {
+            account_id: "default".to_string(),
+            source: "top_level",
+            enabled: true,
+            has_token: true,
+            token_kind: token_kind(token).to_string(),
+            importable: true,
+        });
+    }
+
+    for (account_id, account) in &discord.accounts {
+        let enabled = account.enabled != Some(false);
+        let has_token = account.token.is_some();
+        accounts.push(DiscordAccountImportPlan {
+            account_id: account_id.clone(),
+            source: "named",
+            enabled,
+            has_token,
+            token_kind: account
+                .token
+                .as_ref()
+                .map(token_kind)
+                .unwrap_or("missing")
+                .to_string(),
+            importable: enabled && has_token,
+        });
+    }
+
+    accounts.sort_by(|left, right| left.account_id.cmp(&right.account_id));
+    accounts
+}
+
+fn resolve_binding_channel_ids(
+    discord: &OpenClawDiscordConfig,
+    binding: &OpenClawBindingConfig,
+    accounts: &[DiscordAccountImportPlan],
+    warnings: &mut Vec<String>,
+) -> BindingResolution {
+    let mut channel_ids = BTreeSet::new();
+    let importable_account_ids = accounts
+        .iter()
+        .filter(|account| account.importable)
+        .map(|account| account.account_id.clone())
+        .collect::<Vec<_>>();
+    let selected_account_id = match binding.r#match.account_id.as_deref() {
+        Some("*") => {
+            return BindingResolution {
+                selected_account_id: None,
+                candidate_account_ids: importable_account_ids,
+                channel_ids: Vec::new(),
+                reason: Some(format!(
+                    "Discord binding for agent '{}' uses wildcard account '*' and stays preview-only.",
+                    binding.agent_id
+                )),
+            };
+        }
+        Some(account_id) => {
+            resolve_explicit_account(discord, binding, account_id, accounts, warnings)
+        }
+        None => resolve_implicit_account(discord, binding, accounts),
+    };
+
+    let Some(account_id) = selected_account_id.clone() else {
+        if importable_account_ids.is_empty() {
+            channel_ids.extend(collect_channels_from_guilds(
+                &discord.guilds,
+                "channels.discord.guilds",
+                warnings,
+            ));
+            return BindingResolution {
+                selected_account_id: None,
+                candidate_account_ids: Vec::new(),
+                channel_ids: channel_ids.into_iter().collect(),
+                reason: None,
+            };
+        }
+        return BindingResolution {
+            selected_account_id: None,
+            candidate_account_ids: importable_account_ids,
+            channel_ids: Vec::new(),
+            reason: Some(format!(
+                "Discord binding for agent '{}' could not select a unique importable account and stays preview-only.",
+                binding.agent_id
+            )),
+        };
+    };
+
+    if account_id != "default" {
+        if let Some(account) = discord.accounts.get(&account_id) {
+            channel_ids.extend(collect_channels_from_guilds(
+                &account.guilds,
+                &format!("channels.discord.accounts.{account_id}.guilds"),
+                warnings,
+            ));
+        }
+    }
+
+    if channel_ids.is_empty() {
+        channel_ids.extend(collect_channels_from_guilds(
+            &discord.guilds,
+            "channels.discord.guilds",
+            warnings,
+        ));
+    }
+
+    BindingResolution {
+        selected_account_id: Some(account_id),
+        candidate_account_ids: importable_account_ids,
+        channel_ids: channel_ids.into_iter().collect(),
+        reason: None,
+    }
+}
+
+fn resolve_explicit_account(
+    discord: &OpenClawDiscordConfig,
+    binding: &OpenClawBindingConfig,
+    account_id: &str,
+    accounts: &[DiscordAccountImportPlan],
+    warnings: &mut Vec<String>,
+) -> Option<String> {
+    if account_id == "default" {
+        if discord.token.is_some() {
+            return Some("default".to_string());
+        }
+        warnings.push(format!(
+            "Discord binding for agent '{}' references default account but channels.discord.token is missing.",
+            binding.agent_id
+        ));
+        return None;
+    }
+
+    let Some(account) = discord.accounts.get(account_id) else {
+        warnings.push(format!(
+            "Discord binding for agent '{}' references unknown account '{}'.",
+            binding.agent_id, account_id
+        ));
+        return None;
+    };
+
+    if account.enabled == Some(false) {
+        warnings.push(format!(
+            "Discord binding for agent '{}' points at disabled account '{}'.",
+            binding.agent_id, account_id
+        ));
+        return None;
+    }
+
+    if !accounts
+        .iter()
+        .any(|candidate| candidate.account_id == account_id && candidate.importable)
+    {
+        warnings.push(format!(
+            "Discord binding for agent '{}' points at account '{}' without an importable token.",
+            binding.agent_id, account_id
+        ));
+        return None;
+    }
+
+    Some(account_id.to_string())
+}
+
+fn resolve_implicit_account(
+    discord: &OpenClawDiscordConfig,
+    binding: &OpenClawBindingConfig,
+    accounts: &[DiscordAccountImportPlan],
+) -> Option<String> {
+    let importable_accounts = accounts
+        .iter()
+        .filter(|account| account.importable)
+        .map(|account| account.account_id.clone())
+        .collect::<Vec<_>>();
+    if importable_accounts.len() == 1 {
+        return importable_accounts.into_iter().next();
+    }
+
+    if let Some(default_account) = discord.default_account.as_ref() {
+        if accounts
+            .iter()
+            .any(|account| account.account_id == *default_account && account.importable)
+        {
+            return Some(default_account.clone());
+        }
+    }
+
+    if accounts
+        .iter()
+        .any(|account| account.account_id == "default" && account.importable)
+    {
+        return Some("default".to_string());
+    }
+
+    let _ = binding;
+    None
+}
+
+pub(super) fn token_kind(token: &serde_json::Value) -> &'static str {
+    match token {
+        serde_json::Value::String(value) => {
+            let trimmed = value.trim();
+            if trimmed.starts_with("${") && trimmed.ends_with('}') {
+                "env"
+            } else {
+                "plaintext"
+            }
+        }
+        serde_json::Value::Object(map) => {
+            if let Some(source) = map.get("source").and_then(serde_json::Value::as_str) {
+                match source {
+                    "env" => "env",
+                    "file" => "file",
+                    "exec" => "exec",
+                    _ => "structured",
+                }
+            } else if map.contains_key("env") {
+                "env"
+            } else if map.contains_key("file") {
+                "file"
+            } else if map.contains_key("exec") {
+                "exec"
+            } else {
+                "structured"
+            }
+        }
+        serde_json::Value::Null => "missing",
+        _ => "structured",
+    }
+}
+
+fn collect_channels_from_guilds(
+    guilds: &BTreeMap<String, OpenClawDiscordGuildConfig>,
+    source_label: &str,
+    warnings: &mut Vec<String>,
+) -> BTreeSet<String> {
+    let mut channel_ids = BTreeSet::new();
+    for (guild_id, guild) in guilds {
+        if !guild_entry_is_representable(guild) {
+            warnings.push(format!(
+                "{source_label}.{guild_id} has guild-level Discord routing semantics AgentDesk cannot preserve; keeping those channels preview-only."
+            ));
+            continue;
+        }
+        for (channel_id, channel) in &guild.channels {
+            if channel.enabled == Some(false) || channel.allow != Some(true) {
+                continue;
+            }
+            if !guild_channel_is_representable(channel) {
+                warnings.push(format!(
+                    "{source_label}.{guild_id}.channels.{channel_id} has channel-level Discord semantics AgentDesk cannot preserve; keeping it preview-only."
+                ));
+                continue;
+            }
+            channel_ids.insert(channel_id.clone());
+        }
+    }
+    channel_ids
+}
+
+fn guild_entry_is_representable(guild: &OpenClawDiscordGuildConfig) -> bool {
+    guild.require_mention.is_none()
+        && guild.ignore_other_mentions.is_none()
+        && guild.users.is_empty()
+        && guild.roles.is_empty()
+        && guild.tools.is_none()
+        && guild.tools_by_sender.is_none()
+}
+
+fn guild_channel_is_representable(channel: &OpenClawDiscordGuildChannelConfig) -> bool {
+    channel.require_mention.is_none()
+        && channel.ignore_other_mentions.is_none()
+        && channel.users.is_empty()
+        && channel.roles.is_empty()
+        && channel.tools.is_none()
+        && channel.tools_by_sender.is_none()
+        && channel.system_prompt.is_none()
+}
+
+fn dedupe_warnings(warnings: Vec<String>) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    warnings
+        .into_iter()
+        .filter(|warning| seen.insert(warning.clone()))
+        .collect()
+}
+
+pub(super) fn resolve_source_root(
+    raw_root_path: Option<&str>,
+    cwd: &Path,
+    runtime_root: Option<&Path>,
+) -> Result<ResolvedSourceRoot, String> {
+    let requested_path = match raw_root_path {
+        Some(raw) => expand_tilde_path(raw),
+        None => cwd.to_path_buf(),
+    };
+    let absolute_path = absolutize_path(cwd, &requested_path);
+    let metadata = fs::metadata(&absolute_path).map_err(|e| {
+        format!(
+            "Failed to access OpenClaw path '{}': {e}",
+            absolute_path.display()
+        )
+    })?;
+
+    if metadata.is_file() {
+        if absolute_path.file_name().and_then(|name| name.to_str()) != Some(OPENCLAW_CONFIG_NAME) {
+            return Err(format!(
+                "Expected '{}' or a directory to search, got file '{}'.",
+                OPENCLAW_CONFIG_NAME,
+                absolute_path.display()
+            ));
+        }
+        let candidate = load_candidate(&absolute_path)?;
+        return Ok(ResolvedSourceRoot {
+            root: candidate.root.clone(),
+            config_path: candidate.config_path.clone(),
+            config: candidate.config,
+            resolved_config_json: candidate.resolved_config_json,
+            resolved_config_paths: candidate.resolved_config_paths,
+            discovered_candidate_roots: vec![candidate.root],
+        });
+    }
+
+    if !metadata.is_dir() {
+        return Err(format!(
+            "OpenClaw path '{}' is neither a file nor a directory.",
+            absolute_path.display()
+        ));
+    }
+
+    let candidates = discover_candidates(&absolute_path, runtime_root)?;
+    match candidates.len() {
+        0 => Err(format!(
+            "No valid '{}' candidate found under '{}'.",
+            OPENCLAW_CONFIG_NAME,
+            absolute_path.display()
+        )),
+        1 => {
+            let candidate = candidates.into_iter().next().expect("one candidate");
+            Ok(ResolvedSourceRoot {
+                root: candidate.root.clone(),
+                config_path: candidate.config_path.clone(),
+                config: candidate.config,
+                resolved_config_json: candidate.resolved_config_json,
+                resolved_config_paths: candidate.resolved_config_paths,
+                discovered_candidate_roots: vec![candidate.root],
+            })
+        }
+        _ => {
+            let candidates_list = candidates
+                .iter()
+                .map(|candidate| candidate.root.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(format!(
+                "Multiple valid '{}' candidates found under '{}': {}. Re-run with an explicit path.",
+                OPENCLAW_CONFIG_NAME,
+                absolute_path.display(),
+                candidates_list
+            ))
+        }
+    }
+}
+
+fn discover_candidates(
+    search_root: &Path,
+    runtime_root: Option<&Path>,
+) -> Result<Vec<OpenClawCandidate>, String> {
+    let import_root = runtime_root.map(|root| root.join("openclaw"));
+    let mut queue = VecDeque::from([search_root.to_path_buf()]);
+    let mut visited = BTreeSet::new();
+    let mut candidates_by_root = BTreeMap::new();
+    let mut invalid_candidate_errors = Vec::new();
+
+    while let Some(dir) = queue.pop_front() {
+        let canonical_dir = fs::canonicalize(&dir).unwrap_or_else(|_| dir.clone());
+        if !visited.insert(canonical_dir) || should_prune_dir(&dir, import_root.as_deref()) {
+            continue;
+        }
+
+        let entries = match fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(err) => {
+                if dir == search_root {
+                    return Err(format!("Failed to read '{}': {err}", dir.display()));
+                }
+                continue;
+            }
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+
+            if file_type.is_symlink() {
+                continue;
+            }
+
+            if file_type.is_dir() {
+                if !should_prune_dir(&path, import_root.as_deref()) {
+                    queue.push_back(path);
+                }
+                continue;
+            }
+
+            if !file_type.is_file() {
+                continue;
+            }
+
+            if entry.file_name().to_string_lossy() != OPENCLAW_CONFIG_NAME {
+                continue;
+            }
+
+            match load_candidate(&path) {
+                Ok(candidate) => {
+                    let key = fs::canonicalize(&candidate.root)
+                        .unwrap_or_else(|_| candidate.root.clone());
+                    candidates_by_root.entry(key).or_insert(candidate);
+                }
+                Err(err) => invalid_candidate_errors.push(err),
+            }
+        }
+    }
+
+    if candidates_by_root.is_empty() && !invalid_candidate_errors.is_empty() {
+        invalid_candidate_errors.sort();
+        invalid_candidate_errors.dedup();
+        return Err(format!(
+            "Discovered '{}' candidates under '{}', but all failed validation: {}",
+            OPENCLAW_CONFIG_NAME,
+            search_root.display(),
+            invalid_candidate_errors.join(" | ")
+        ));
+    }
+
+    Ok(candidates_by_root.into_values().collect())
+}
+
+fn should_prune_dir(path: &Path, import_root: Option<&Path>) -> bool {
+    if let Some(import_root) = import_root {
+        if path.starts_with(import_root) {
+            return true;
+        }
+    }
+
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| PRUNE_DIR_NAMES.iter().any(|candidate| candidate == &name))
+        .unwrap_or(false)
+}
+
+fn deep_merge_json(target: serde_json::Value, source: serde_json::Value) -> serde_json::Value {
+    match (target, source) {
+        (serde_json::Value::Array(mut left), serde_json::Value::Array(right)) => {
+            left.extend(right);
+            serde_json::Value::Array(left)
+        }
+        (serde_json::Value::Object(mut left), serde_json::Value::Object(right)) => {
+            for (key, value) in right {
+                match left.remove(&key) {
+                    Some(existing) => {
+                        left.insert(key, deep_merge_json(existing, value));
+                    }
+                    None => {
+                        left.insert(key, value);
+                    }
+                }
+            }
+            serde_json::Value::Object(left)
+        }
+        (_, source) => source,
+    }
+}
+
+fn resolve_includes(
+    value: serde_json::Value,
+    current_path: &Path,
+    root_dir: &Path,
+    include_paths: &mut BTreeSet<PathBuf>,
+    visited: &mut Vec<PathBuf>,
+    depth: usize,
+) -> Result<serde_json::Value, String> {
+    if depth > MAX_INCLUDE_DEPTH {
+        return Err(format!(
+            "Maximum include depth ({MAX_INCLUDE_DEPTH}) exceeded while resolving '{}'.",
+            current_path.display()
+        ));
+    }
+
+    match value {
+        serde_json::Value::Array(values) => Ok(serde_json::Value::Array(
+            values
+                .into_iter()
+                .map(|entry| {
+                    resolve_includes(entry, current_path, root_dir, include_paths, visited, depth)
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+        )),
+        serde_json::Value::Object(mut object) => {
+            if let Some(include_value) = object.remove(INCLUDE_KEY) {
+                let included = resolve_include_value(
+                    include_value,
+                    current_path,
+                    root_dir,
+                    include_paths,
+                    visited,
+                    depth + 1,
+                )?;
+                if object.is_empty() {
+                    return Ok(included);
+                }
+                let rest = resolve_includes(
+                    serde_json::Value::Object(object),
+                    current_path,
+                    root_dir,
+                    include_paths,
+                    visited,
+                    depth,
+                )?;
+                if !included.is_object() {
+                    return Err(format!(
+                        "Config include at '{}' must resolve to an object when sibling keys are present.",
+                        current_path.display()
+                    ));
+                }
+                return Ok(deep_merge_json(included, rest));
+            }
+
+            let mut resolved = serde_json::Map::new();
+            for (key, value) in object {
+                resolved.insert(
+                    key,
+                    resolve_includes(value, current_path, root_dir, include_paths, visited, depth)?,
+                );
+            }
+            Ok(serde_json::Value::Object(resolved))
+        }
+        other => Ok(other),
+    }
+}
+
+fn resolve_include_value(
+    include_value: serde_json::Value,
+    current_path: &Path,
+    root_dir: &Path,
+    include_paths: &mut BTreeSet<PathBuf>,
+    visited: &mut Vec<PathBuf>,
+    depth: usize,
+) -> Result<serde_json::Value, String> {
+    match include_value {
+        serde_json::Value::String(path) => {
+            load_include_path(&path, current_path, root_dir, include_paths, visited, depth)
+        }
+        serde_json::Value::Array(paths) => {
+            let mut merged = serde_json::Value::Object(serde_json::Map::new());
+            for path in paths {
+                let serde_json::Value::String(path) = path else {
+                    return Err(format!(
+                        "Invalid $include array item in '{}': expected string path.",
+                        current_path.display()
+                    ));
+                };
+                let loaded = load_include_path(
+                    &path,
+                    current_path,
+                    root_dir,
+                    include_paths,
+                    visited,
+                    depth,
+                )?;
+                merged = deep_merge_json(merged, loaded);
+            }
+            Ok(merged)
+        }
+        other => Err(format!(
+            "Invalid $include value in '{}': expected string or array of strings, got {}.",
+            current_path.display(),
+            json_type_name(&other)
+        )),
+    }
+}
+
+fn load_include_path(
+    include_path: &str,
+    current_path: &Path,
+    root_dir: &Path,
+    include_paths: &mut BTreeSet<PathBuf>,
+    visited: &mut Vec<PathBuf>,
+    depth: usize,
+) -> Result<serde_json::Value, String> {
+    let current_dir = current_path.parent().ok_or_else(|| {
+        format!(
+            "Failed to resolve parent directory for include path '{}'.",
+            current_path.display()
+        )
+    })?;
+    let resolved = if Path::new(include_path).is_absolute() {
+        PathBuf::from(include_path)
+    } else {
+        current_dir.join(include_path)
+    };
+    let canonical = fs::canonicalize(&resolved).map_err(|e| {
+        format!(
+            "Failed to resolve include '{}' from '{}': {e}",
+            include_path,
+            current_path.display()
+        )
+    })?;
+    let canonical_root = fs::canonicalize(root_dir).unwrap_or_else(|_| root_dir.to_path_buf());
+    if !canonical.starts_with(&canonical_root) {
+        return Err(format!(
+            "Include path '{}' escapes config directory '{}'.",
+            include_path,
+            root_dir.display()
+        ));
+    }
+    if visited.contains(&canonical) {
+        let chain = visited
+            .iter()
+            .chain(std::iter::once(&canonical))
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(" -> ");
+        return Err(format!("Circular include detected: {chain}."));
+    }
+
+    let raw = fs::read_to_string(&canonical).map_err(|e| {
+        format!(
+            "Failed to read include '{}' (resolved '{}'): {e}",
+            include_path,
+            canonical.display()
+        )
+    })?;
+    let parsed = json5::from_str::<serde_json::Value>(&raw).map_err(|e| {
+        format!(
+            "Failed to parse include '{}' (resolved '{}'): {e}",
+            include_path,
+            canonical.display()
+        )
+    })?;
+    include_paths.insert(canonical.clone());
+    visited.push(canonical.clone());
+    let resolved = resolve_includes(parsed, &canonical, root_dir, include_paths, visited, depth)?;
+    visited.pop();
+    Ok(resolved)
+}
+
+fn json_type_name(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "boolean",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
+fn load_candidate(config_path: &Path) -> Result<OpenClawCandidate, String> {
+    let content = fs::read_to_string(config_path)
+        .map_err(|e| format!("Failed to read '{}': {e}", config_path.display()))?;
+    let parsed = json5::from_str::<serde_json::Value>(&content)
+        .map_err(|e| format!("Failed to parse '{}': {e}", config_path.display()))?;
+    let root = config_path
+        .parent()
+        .ok_or_else(|| format!("Failed to resolve parent for '{}'.", config_path.display()))?
+        .to_path_buf();
+    let canonical_config_path =
+        fs::canonicalize(config_path).unwrap_or_else(|_| config_path.to_path_buf());
+    let mut include_paths = BTreeSet::from([canonical_config_path.clone()]);
+    let mut visited = vec![canonical_config_path];
+    let resolved = resolve_includes(
+        parsed,
+        config_path,
+        &root,
+        &mut include_paths,
+        &mut visited,
+        0,
+    )?;
+    let resolved_config_json = serde_json::to_string_pretty(&resolved).map_err(|e| {
+        format!(
+            "Failed to serialize resolved '{}': {e}",
+            config_path.display()
+        )
+    })?;
+    let config: OpenClawConfig = serde_json::from_value(resolved)
+        .map_err(|e| format!("Failed to decode resolved '{}': {e}", config_path.display()))?;
+
+    if config.agents.list.is_empty() {
+        return Err(format!(
+            "'{}' is not a valid OpenClaw root: agents.list is empty.",
+            config_path.display()
+        ));
+    }
+
+    let mut agent_ids = BTreeSet::new();
+    for agent in &config.agents.list {
+        let trimmed = agent.id.trim();
+        if trimmed.is_empty() {
+            return Err(format!(
+                "'{}' contains an agent with an empty id.",
+                config_path.display()
+            ));
+        }
+        if !agent_ids.insert(trimmed.to_string()) {
+            return Err(format!(
+                "'{}' contains duplicate agent id '{}'.",
+                config_path.display(),
+                trimmed
+            ));
+        }
+    }
+
+    if !root.join("agents").is_dir() {
+        return Err(format!(
+            "'{}' is not a valid OpenClaw root: missing required agents/ directory under '{}'.",
+            config_path.display(),
+            root.display()
+        ));
+    }
+
+    config.agents.default_agent_id()?;
+
+    Ok(OpenClawCandidate {
+        root,
+        config_path: config_path.to_path_buf(),
+        config,
+        resolved_config_json,
+        resolved_config_paths: include_paths.into_iter().collect(),
+    })
+}
+
+fn absolutize_path(cwd: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    }
+}

--- a/src/cli/migrate/tests.rs
+++ b/src/cli/migrate/tests.rs
@@ -921,6 +921,62 @@ fn live_write_bot_settings_resolves_env_placeholder_without_provider() {
 }
 
 #[test]
+fn live_write_bot_settings_skips_shared_account_without_live_channel_scope() {
+    let temp = TempDir::new().unwrap();
+    let runtime = TempDir::new().unwrap();
+    let alpha_workspace = temp.path().join("workspace-alpha");
+    let beta_workspace = temp.path().join("workspace-beta");
+    fs::create_dir_all(&alpha_workspace).unwrap();
+    fs::create_dir_all(&beta_workspace).unwrap();
+    fs::write(alpha_workspace.join("IDENTITY.md"), "# Alpha\n").unwrap();
+    fs::write(alpha_workspace.join("MEMORY.md"), "# Memory\n").unwrap();
+    fs::write(beta_workspace.join("IDENTITY.md"), "# Beta\n").unwrap();
+    fs::write(beta_workspace.join("MEMORY.md"), "# Memory\n").unwrap();
+
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{
+                "list":[
+                    {"id":"alpha","model":"openai/gpt-5","workspace":"workspace-alpha"},
+                    {"id":"beta","model":"openai/gpt-5","workspace":"workspace-beta"}
+                ]
+            },
+            "bindings":[
+                {"agentId":"alpha","match":{"channel":"discord"}},
+                {"agentId":"beta","match":{"channel":"discord"}}
+            ],
+            "channels":{
+                "discord":{
+                    "token":"discord-token-shared",
+                    "guilds":{"g1":{"channels":{"1234567890":{"allow":true}}}}
+                }
+            }
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.all_agents = true;
+    args.dry_run = false;
+    args.write_bot_settings = true;
+    args.discord_token_mode = "plaintext-only".to_string();
+
+    let plan = build_import_plan(&source, &args, Some(runtime.path())).unwrap();
+    apply::apply_import_plan(&plan, &source, &args, runtime.path()).unwrap();
+
+    assert!(
+        !runtime
+            .path()
+            .join("config")
+            .join("bot_settings.json")
+            .exists()
+    );
+    let warnings = fs::read_to_string(audit_root(&plan).join("warnings.txt")).unwrap();
+    assert!(warnings.contains("multiple imported agents share the same token"));
+}
+
+#[test]
 fn session_import_writes_ai_sessions_session_map_and_db_rows() {
     let temp = TempDir::new().unwrap();
     let runtime = TempDir::new().unwrap();
@@ -932,22 +988,20 @@ fn session_import_writes_ai_sessions_session_map_and_db_rows() {
     fs::write(workspace.join("MEMORY.md"), "# Memory\n").unwrap();
     fs::write(
         sessions_dir.join("sessions.json"),
-        format!(
-            r#"{{
-                "session-key-1": {{
-                    "sessionId": "session-1",
-                    "sessionFile": "session-1.jsonl",
-                    "updatedAt": 1710000000000,
-                    "model": "openai/gpt-5",
-                    "modelProvider": "codex",
-                    "cwd": "{}",
-                    "lastChannel": "1234567890",
-                    "lastThreadId": "777",
-                    "status": "done"
-                }}
-            }}"#,
-            workspace.display()
-        ),
+        serde_json::json!({
+            "session-key-1": {
+                "sessionId": "session-1",
+                "sessionFile": "session-1.jsonl",
+                "updatedAt": 1710000000000i64,
+                "model": "openai/gpt-5",
+                "modelProvider": "codex",
+                "cwd": workspace.display().to_string(),
+                "lastChannel": "1234567890",
+                "lastThreadId": "777",
+                "status": "done"
+            }
+        })
+        .to_string(),
     )
     .unwrap();
     fs::write(
@@ -1010,7 +1064,13 @@ fn session_import_writes_ai_sessions_session_map_and_db_rows() {
     assert_eq!(agent_id, "alpha");
     assert_eq!(provider, "codex");
     assert_eq!(model, "openai/gpt-5");
-    assert!(cwd.ends_with("/openclaw/workspaces/alpha"));
+    assert!(
+        std::path::Path::new(&cwd).ends_with(
+            std::path::Path::new("openclaw")
+                .join("workspaces")
+                .join("alpha")
+        )
+    );
     assert!(session_info.contains("\"source_session_id\":\"session-1\""));
 }
 
@@ -1376,6 +1436,47 @@ fn apply_fails_when_existing_agentdesk_yaml_is_invalid() {
     let err = apply::apply_import_plan(&plan, &source, &args, runtime.path()).unwrap_err();
     assert!(err.contains("Failed to load"));
     assert!(err.contains("agentdesk.yaml"));
+}
+
+#[test]
+fn apply_fails_when_existing_bot_settings_json_is_invalid() {
+    let temp = TempDir::new().unwrap();
+    let runtime = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    fs::create_dir_all(runtime.path().join("config")).unwrap();
+    fs::write(workspace.join("IDENTITY.md"), "# Alpha\n").unwrap();
+    fs::write(workspace.join("MEMORY.md"), "# Memory\n").unwrap();
+    fs::write(
+        runtime.path().join("config").join("bot_settings.json"),
+        "{not valid json",
+    )
+    .unwrap();
+
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{"list":[{"id":"alpha","default":true,"model":"openai/gpt-5","workspace":"workspace"}]},
+            "bindings":[{"agentId":"alpha","match":{"channel":"discord"}}],
+            "channels":{
+                "discord":{
+                    "token":"discord-token-plaintext",
+                    "guilds":{"g1":{"channels":{"1234567890":{"allow":true}}}}
+                }
+            }
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.dry_run = false;
+    args.write_bot_settings = true;
+    args.discord_token_mode = "plaintext-only".to_string();
+
+    let plan = build_import_plan(&source, &args, Some(runtime.path())).unwrap();
+    let err = apply::apply_import_plan(&plan, &source, &args, runtime.path()).unwrap_err();
+    assert!(err.contains("bot_settings.json"));
+    assert!(err.contains("Failed to parse"));
 }
 
 #[test]

--- a/src/cli/migrate/tests.rs
+++ b/src/cli/migrate/tests.rs
@@ -1,0 +1,1297 @@
+use std::fs;
+use std::path::Path;
+
+use tempfile::TempDir;
+
+use super::*;
+
+fn write_openclaw_config(root: &Path, body: &str) {
+    fs::create_dir_all(root.join("agents")).unwrap();
+    fs::write(root.join(source::OPENCLAW_CONFIG_NAME), body).unwrap();
+}
+
+fn base_args() -> OpenClawMigrateArgs {
+    OpenClawMigrateArgs {
+        root_path: None,
+        agentdesk_root: None,
+        agent_ids: Vec::new(),
+        all_agents: false,
+        dry_run: true,
+        resume: None,
+        fallback_provider: None,
+        workspace_root_rewrite: Vec::new(),
+        write_org: false,
+        write_bot_settings: false,
+        write_db: false,
+        overwrite: false,
+        with_channel_bindings: false,
+        with_sessions: false,
+        snapshot_source: false,
+        no_workspace: false,
+        no_memory: false,
+        no_prompts: false,
+        tool_policy_mode: "report".to_string(),
+        discord_token_mode: "report".to_string(),
+    }
+}
+
+fn resolve_source(temp: &TempDir) -> source::ResolvedSourceRoot {
+    resolve_source_root(Some(temp.path().to_str().unwrap()), temp.path(), None).unwrap()
+}
+
+fn read_json_value(path: &Path) -> serde_json::Value {
+    serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap()
+}
+
+fn audit_root(plan: &plan::ImportPlan) -> std::path::PathBuf {
+    std::path::PathBuf::from(plan.audit_root.as_ref().unwrap())
+}
+
+#[test]
+fn resolves_explicit_openclaw_json_file() {
+    let temp = TempDir::new().unwrap();
+    write_openclaw_config(
+        temp.path(),
+        r#"{"agents":{"list":[{"id":"alpha","model":"openai/gpt-5"}]}}"#,
+    );
+
+    let resolved = resolve_source_root(
+        Some(
+            temp.path()
+                .join(source::OPENCLAW_CONFIG_NAME)
+                .to_str()
+                .unwrap(),
+        ),
+        temp.path(),
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(resolved.root, temp.path());
+    assert_eq!(
+        resolved.config_path,
+        temp.path().join(source::OPENCLAW_CONFIG_NAME)
+    );
+}
+
+#[test]
+fn resolves_json5_with_include_and_model_union() {
+    let temp = TempDir::new().unwrap();
+    fs::create_dir_all(temp.path().join("workspace")).unwrap();
+    fs::write(
+        temp.path().join("agents.json5"),
+        r#"{
+            list: [
+                {
+                    id: "alpha",
+                    default: true,
+                    workspace: "workspace",
+                    model: {
+                        primary: "openai/gpt-5",
+                        fallbacks: ["anthropic/claude-3"],
+                    },
+                },
+            ],
+        }"#,
+    )
+    .unwrap();
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            // JSON5 comments and trailing commas are allowed.
+            agents: { $include: "./agents.json5", },
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let plan = build_import_plan(&source, &base_args(), None).unwrap();
+
+    assert_eq!(plan.agents[0].model_hint.as_deref(), Some("openai/gpt-5"));
+    assert_eq!(plan.agents[0].mapped_provider.as_deref(), Some("codex"));
+    assert!(source.resolved_config_paths.len() >= 2);
+    assert!(
+        source
+            .resolved_config_paths
+            .iter()
+            .any(|path| path.ends_with("agents.json5"))
+    );
+}
+
+#[test]
+fn fails_when_multiple_candidates_exist() {
+    let temp = TempDir::new().unwrap();
+    let root_a = temp.path().join("a");
+    let root_b = temp.path().join("b");
+    fs::create_dir_all(&root_a).unwrap();
+    fs::create_dir_all(&root_b).unwrap();
+    write_openclaw_config(
+        &root_a,
+        r#"{"agents":{"list":[{"id":"alpha","model":"openai/gpt-5"}]}}"#,
+    );
+    write_openclaw_config(
+        &root_b,
+        r#"{"agents":{"list":[{"id":"beta","model":"openai/gpt-5"}]}}"#,
+    );
+
+    let err =
+        resolve_source_root(Some(temp.path().to_str().unwrap()), temp.path(), None).unwrap_err();
+    assert!(err.contains("Multiple valid 'openclaw.json' candidates"));
+}
+
+#[test]
+fn defaults_to_default_agent_selection() {
+    let temp = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{
+                "list":[
+                    {"id":"alpha","model":"openai/gpt-5","workspace":"workspace-alpha"},
+                    {"id":"beta","default":true,"model":"openai/gpt-5","workspace":"workspace"}
+                ]
+            }
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let plan = build_import_plan(&source, &base_args(), None).unwrap();
+
+    assert_eq!(plan.selection_mode, "default_agent");
+    assert_eq!(plan.selected_agent_ids, vec!["beta"]);
+    assert!(plan.selected_discord_account_ids.is_empty());
+    assert_eq!(plan.agents.len(), 1);
+    assert_eq!(plan.agents[0].source_id, "beta");
+}
+
+#[test]
+fn legacy_default_agent_selection_still_resolves() {
+    let temp = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{
+                "defaultAgent":"alpha",
+                "list":[
+                    {"id":"alpha","model":"openai/gpt-5","workspace":"workspace"},
+                    {"id":"beta","model":"openai/gpt-5","workspace":"workspace-beta"}
+                ]
+            }
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let plan = build_import_plan(&source, &base_args(), None).unwrap();
+
+    assert_eq!(plan.selection_mode, "default_agent");
+    assert_eq!(plan.selected_agent_ids, vec!["alpha"]);
+}
+
+#[test]
+fn fails_without_agent_hint_for_multi_agent_source() {
+    let temp = TempDir::new().unwrap();
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{
+                "list":[
+                    {"id":"alpha","model":"openai/gpt-5"},
+                    {"id":"beta","model":"openai/gpt-5"}
+                ]
+            }
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let err = build_import_plan(&source, &base_args(), None).unwrap_err();
+    assert!(err.contains("Pass --agent or --all-agents"));
+}
+
+#[test]
+fn rejects_candidate_without_agents_state_dir() {
+    let temp = TempDir::new().unwrap();
+    fs::write(
+        temp.path().join(source::OPENCLAW_CONFIG_NAME),
+        r#"{"agents":{"list":[{"id":"alpha","model":"openai/gpt-5"}]}}"#,
+    )
+    .unwrap();
+
+    let err =
+        resolve_source_root(Some(temp.path().to_str().unwrap()), temp.path(), None).unwrap_err();
+    assert!(err.contains("missing required agents/ directory"));
+}
+
+#[test]
+fn role_ids_prefix_when_org_yaml_collides() {
+    let temp = TempDir::new().unwrap();
+    let runtime = TempDir::new().unwrap();
+    let config_dir = runtime.path().join("config");
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::create_dir_all(&workspace).unwrap();
+    fs::write(
+        config_dir.join("org.yaml"),
+        "agents:\n  alpha:\n    name: Existing\n",
+    )
+    .unwrap();
+    write_openclaw_config(
+        temp.path(),
+        r#"{"agents":{"list":[{"id":"alpha","default":true,"model":"openai/gpt-5","workspace":"workspace"}]}}"#,
+    );
+
+    let source = resolve_source(&temp);
+    let plan = build_import_plan(&source, &base_args(), Some(runtime.path())).unwrap();
+
+    assert_eq!(plan.agents[0].final_role_id, "openclaw-alpha");
+    assert_eq!(plan.existing_role_ids, vec!["alpha"]);
+}
+
+#[test]
+fn fallback_provider_maps_unsupported_sources() {
+    let temp = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    write_openclaw_config(
+        temp.path(),
+        r#"{"agents":{"list":[{"id":"alpha","default":true,"model":"meta/llama-3","workspace":"workspace"}]}}"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.fallback_provider = Some("qwen".to_string());
+    let plan = build_import_plan(&source, &args, None).unwrap();
+
+    assert_eq!(plan.agents[0].mapped_provider.as_deref(), Some("qwen"));
+    assert!(
+        plan.warnings
+            .iter()
+            .any(|warning| warning.contains("fallback 'qwen'"))
+    );
+}
+
+#[test]
+fn defaults_workspace_is_used_for_agents_without_workspace() {
+    let temp = TempDir::new().unwrap();
+    let workspace = temp.path().join("shared-workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{
+                "defaults":{"workspace":"shared-workspace"},
+                "list":[{"id":"alpha","default":true,"model":"openai/gpt-5"}]
+            }
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let plan = build_import_plan(&source, &base_args(), None).unwrap();
+
+    assert!(
+        plan.agents[0]
+            .workspace_source
+            .ends_with("shared-workspace")
+    );
+    assert!(plan.agents[0].workspace_exists);
+}
+
+#[test]
+fn workspace_root_rewrite_remaps_absolute_openclaw_paths() {
+    let temp = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace-main");
+    fs::create_dir_all(&workspace).unwrap();
+    fs::write(workspace.join("IDENTITY.md"), "# Alpha\n").unwrap();
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{
+                "list":[
+                    {
+                        "id":"alpha",
+                        "default":true,
+                        "model":"openai/gpt-5",
+                        "workspace":"/home/node/.openclaw/workspace-main"
+                    }
+                ]
+            }
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.workspace_root_rewrite = vec![format!("/home/node/.openclaw={}", temp.path().display())];
+    let plan = build_import_plan(&source, &args, None).unwrap();
+
+    assert_eq!(
+        plan.agents[0].workspace_source,
+        workspace.display().to_string()
+    );
+    assert!(plan.agents[0].workspace_exists);
+    assert!(plan.agents[0].eligible_for_v1);
+    assert!(
+        plan.warnings
+            .iter()
+            .any(|warning| { warning.contains("remapped via --workspace-root-rewrite") })
+    );
+}
+
+#[test]
+fn channel_bindings_without_write_org_emit_preview_warning() {
+    let temp = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    write_openclaw_config(
+        temp.path(),
+        r#"{"agents":{"list":[{"id":"alpha","default":true,"model":"openai/gpt-5","workspace":"workspace"}]}}"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.with_channel_bindings = true;
+    let plan = build_import_plan(&source, &args, None).unwrap();
+
+    assert!(plan.warnings.iter().any(|warning| {
+        warning.contains("--with-channel-bindings without --write-org stays preview-only")
+    }));
+    assert_eq!(plan.effective_modes.channel_bindings, "preview_only");
+}
+
+#[test]
+fn no_workspace_disables_workspace_copy_task() {
+    let temp = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    write_openclaw_config(
+        temp.path(),
+        r#"{"agents":{"list":[{"id":"alpha","default":true,"model":"openai/gpt-5","workspace":"workspace"}]}}"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.no_workspace = true;
+    let plan = build_import_plan(&source, &args, None).unwrap();
+
+    let task = plan.agents[0]
+        .tasks
+        .iter()
+        .find(|task| task.key == "workspace_copy")
+        .unwrap();
+    assert_eq!(task.mode, "disabled");
+}
+
+#[test]
+fn with_sessions_enables_session_phase_and_task() {
+    let temp = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    write_openclaw_config(
+        temp.path(),
+        r#"{"agents":{"list":[{"id":"alpha","default":true,"model":"openai/gpt-5","workspace":"workspace"}]}}"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.with_sessions = true;
+    let plan = build_import_plan(&source, &args, None).unwrap();
+
+    let phase = plan
+        .phases
+        .iter()
+        .find(|phase| phase.phase == "sessions")
+        .unwrap();
+    assert_eq!(phase.mode, "preview_only");
+
+    let task = plan.agents[0]
+        .tasks
+        .iter()
+        .find(|task| task.key == "session_import")
+        .unwrap();
+    assert_eq!(task.mode, "preview_only");
+}
+
+#[test]
+fn base_apply_writes_agentdesk_prompt_memory_workspace_and_audit() {
+    let temp = TempDir::new().unwrap();
+    let runtime = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(workspace.join("memory")).unwrap();
+    fs::write(workspace.join("IDENTITY.md"), "# Alpha Identity\nalpha").unwrap();
+    fs::write(workspace.join("AGENTS.md"), "# Alpha Rules\nrules").unwrap();
+    fs::write(workspace.join("BOOT.md"), "# Alpha Boot\nboot").unwrap();
+    fs::write(workspace.join("MEMORY.md"), "# Memory\nstable").unwrap();
+    fs::write(
+        workspace.join("memory").join("2026-04-02.md"),
+        "# Daily\nentry",
+    )
+    .unwrap();
+    fs::create_dir_all(workspace.join("skills")).unwrap();
+    fs::write(workspace.join("skills").join("local-skill.txt"), "skill").unwrap();
+
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{
+                "list":[
+                    {"id":"alpha","default":true,"model":"openai/gpt-5","workspace":"workspace"}
+                ]
+            }
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.dry_run = false;
+    args.write_org = true;
+    let plan = build_import_plan(&source, &args, Some(runtime.path())).unwrap();
+
+    apply::apply_import_plan(&plan, &source, &args, runtime.path()).unwrap();
+
+    let agentdesk_yaml = fs::read_to_string(runtime.path().join("agentdesk.yaml")).unwrap();
+    assert!(agentdesk_yaml.contains("id: alpha"));
+    assert!(agentdesk_yaml.contains("provider: codex"));
+
+    let prompt = fs::read_to_string(
+        runtime
+            .path()
+            .join("prompts")
+            .join("agents")
+            .join("alpha")
+            .join("IDENTITY.md"),
+    )
+    .unwrap();
+    assert!(prompt.contains("Imported OpenClaw Identity"));
+    assert!(prompt.contains("Imported OpenClaw Agent Rules"));
+    assert!(prompt.contains("Imported OpenClaw Boot Intent"));
+
+    let memory_md = fs::read_to_string(
+        runtime
+            .path()
+            .join("role-context")
+            .join("alpha.memory")
+            .join("MEMORY.md"),
+    )
+    .unwrap();
+    assert!(memory_md.contains("# Memory"));
+
+    let daily_md = fs::read_to_string(
+        runtime
+            .path()
+            .join("role-context")
+            .join("alpha.memory")
+            .join("daily-2026-04-02.md"),
+    )
+    .unwrap();
+    assert!(daily_md.contains("imported_from: openclaw"));
+    assert!(daily_md.contains("source_agent: alpha"));
+
+    let org_yaml = fs::read_to_string(runtime.path().join("config").join("org.yaml")).unwrap();
+    assert!(org_yaml.contains("alpha:"));
+    assert!(org_yaml.contains("display_name: alpha"));
+    assert!(org_yaml.contains("provider: codex"));
+    assert!(org_yaml.contains("workspace:"));
+    assert!(org_yaml.contains("prompt_file:"));
+
+    let copied_workspace_file = runtime
+        .path()
+        .join("openclaw")
+        .join("workspaces")
+        .join("alpha")
+        .join("skills")
+        .join("local-skill.txt");
+    assert!(copied_workspace_file.is_file());
+
+    let audit_root = std::path::PathBuf::from(plan.audit_root.as_ref().unwrap());
+    assert!(audit_root.join("manifest.json").is_file());
+    assert!(audit_root.join("agent-map.json").is_file());
+    assert!(audit_root.join("write-plan.json").is_file());
+    assert!(audit_root.join("apply-result.json").is_file());
+    assert!(audit_root.join("resume-state.json").is_file());
+    assert!(audit_root.join("tool-policy-report.json").is_file());
+    assert!(audit_root.join("discord-auth-report.json").is_file());
+    assert!(audit_root.join("channel-binding-preview.yaml").is_file());
+}
+
+#[test]
+fn live_write_org_imports_representable_discord_channel_bindings() {
+    let temp = TempDir::new().unwrap();
+    let runtime = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    fs::write(workspace.join("IDENTITY.md"), "# Alpha\n").unwrap();
+    fs::write(workspace.join("MEMORY.md"), "# Memory\n").unwrap();
+
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{
+                "list":[
+                    {"id":"alpha","default":true,"model":"openai/gpt-5","workspace":"workspace"}
+                ]
+            },
+            "bindings":[
+                {"agentId":"alpha","match":{"channel":"discord"}}
+            ],
+            "channels":{
+                "discord":{
+                    "guilds":{
+                        "guild-1":{
+                            "channels":{
+                                "1234567890":{"allow":true},
+                                "9999999999":{"allow":false}
+                            }
+                        }
+                    }
+                }
+            }
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.dry_run = false;
+    args.write_org = true;
+    args.with_channel_bindings = true;
+
+    let plan = build_import_plan(&source, &args, Some(runtime.path())).unwrap();
+    apply::apply_import_plan(&plan, &source, &args, runtime.path()).unwrap();
+
+    let org_yaml = fs::read_to_string(runtime.path().join("config").join("org.yaml")).unwrap();
+    assert!(org_yaml.contains("1234567890"));
+    assert!(org_yaml.contains("agent: alpha"));
+    assert!(org_yaml.contains("provider: codex"));
+    assert!(!org_yaml.contains("\"9999999999\""));
+}
+
+#[test]
+fn live_channel_binding_conflicts_skip_only_shared_channel_ids() {
+    let temp = TempDir::new().unwrap();
+    let runtime = TempDir::new().unwrap();
+    let alpha_workspace = temp.path().join("workspace-alpha");
+    let beta_workspace = temp.path().join("workspace-beta");
+    fs::create_dir_all(&alpha_workspace).unwrap();
+    fs::create_dir_all(&beta_workspace).unwrap();
+    fs::write(alpha_workspace.join("IDENTITY.md"), "# Alpha\n").unwrap();
+    fs::write(alpha_workspace.join("MEMORY.md"), "# Memory\n").unwrap();
+    fs::write(beta_workspace.join("IDENTITY.md"), "# Beta\n").unwrap();
+    fs::write(beta_workspace.join("MEMORY.md"), "# Memory\n").unwrap();
+
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{
+                "list":[
+                    {"id":"alpha","model":"openai/gpt-5","workspace":"workspace-alpha"},
+                    {"id":"beta","model":"openai/gpt-5","workspace":"workspace-beta"}
+                ]
+            },
+            "bindings":[
+                {"agentId":"alpha","match":{"channel":"discord","accountId":"a"}},
+                {"agentId":"beta","match":{"channel":"discord","accountId":"b"}}
+            ],
+            "channels":{
+                "discord":{
+                    "accounts":{
+                        "a":{
+                            "token":"discord-token-a",
+                            "guilds":{"g1":{"channels":{"999":{"allow":true},"111":{"allow":true}}}}
+                        },
+                        "b":{
+                            "token":"discord-token-b",
+                            "guilds":{"g2":{"channels":{"999":{"allow":true},"222":{"allow":true}}}}
+                        }
+                    }
+                }
+            }
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.all_agents = true;
+    args.dry_run = false;
+    args.write_org = true;
+    args.write_bot_settings = true;
+    args.with_channel_bindings = true;
+    args.discord_token_mode = "plaintext-only".to_string();
+
+    let plan = build_import_plan(&source, &args, Some(runtime.path())).unwrap();
+
+    assert_eq!(plan.selected_discord_account_ids, vec!["a", "b"]);
+    assert_eq!(plan.discord.bindings.len(), 2);
+    assert_eq!(plan.discord.bindings[0].mode, "live_applicable");
+    assert_eq!(plan.discord.bindings[0].channel_ids, vec!["111"]);
+    assert!(
+        plan.discord.bindings[0]
+            .warnings
+            .iter()
+            .any(|warning| { warning.contains("Conflicting Discord channel ids were skipped") })
+    );
+    assert_eq!(plan.discord.bindings[1].mode, "live_applicable");
+    assert_eq!(plan.discord.bindings[1].channel_ids, vec!["222"]);
+    assert!(
+        plan.warnings
+            .iter()
+            .any(|warning| { warning.contains("will be skipped from live channel imports: 999") })
+    );
+
+    apply::apply_import_plan(&plan, &source, &args, runtime.path()).unwrap();
+
+    let org_yaml = fs::read_to_string(runtime.path().join("config").join("org.yaml")).unwrap();
+    assert!(org_yaml.contains("111"));
+    assert!(org_yaml.contains("222"));
+    assert!(!org_yaml.contains("999"));
+
+    let bot_settings = read_json_value(&runtime.path().join("config").join("bot_settings.json"));
+    let alpha_key = crate::services::discord::settings::discord_token_hash("discord-token-a");
+    let beta_key = crate::services::discord::settings::discord_token_hash("discord-token-b");
+    assert_eq!(
+        bot_settings[&alpha_key]["allowed_channel_ids"],
+        serde_json::json!([111u64])
+    );
+    assert_eq!(
+        bot_settings[&beta_key]["allowed_channel_ids"],
+        serde_json::json!([222u64])
+    );
+}
+
+#[test]
+fn ambiguous_discord_account_selection_stays_preview_only() {
+    let temp = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{
+                "list":[
+                    {"id":"alpha","default":true,"model":"openai/gpt-5","workspace":"workspace"}
+                ]
+            },
+            "bindings":[
+                {"agentId":"alpha","match":{"channel":"discord"}}
+            ],
+            "channels":{
+                "discord":{
+                    "accounts":{
+                        "a":{
+                            "token":"token-a",
+                            "guilds":{"g1":{"channels":{"111":{"allow":true}}}}
+                        },
+                        "b":{
+                            "token":"token-b",
+                            "guilds":{"g2":{"channels":{"222":{"allow":true}}}}
+                        }
+                    }
+                }
+            }
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.with_channel_bindings = true;
+    let plan = build_import_plan(&source, &args, None).unwrap();
+
+    assert!(plan.selected_discord_account_ids.is_empty());
+    assert_eq!(plan.discord.bindings.len(), 1);
+    assert_eq!(plan.discord.bindings[0].mode, "preview_only");
+    assert!(plan.discord.bindings[0].selected_account_id.is_none());
+}
+
+#[test]
+fn live_write_bot_settings_imports_plaintext_token_and_allowed_channels() {
+    let temp = TempDir::new().unwrap();
+    let runtime = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    fs::write(workspace.join("IDENTITY.md"), "# Alpha\n").unwrap();
+    fs::write(workspace.join("MEMORY.md"), "# Memory\n").unwrap();
+
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{"list":[{"id":"alpha","default":true,"model":"openai/gpt-5","workspace":"workspace"}]},
+            "bindings":[{"agentId":"alpha","match":{"channel":"discord"}}],
+            "channels":{
+                "discord":{
+                    "token":"discord-token-plaintext",
+                    "guilds":{"g1":{"channels":{"1234567890":{"allow":true}}}}
+                }
+            }
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.dry_run = false;
+    args.write_org = true;
+    args.write_bot_settings = true;
+    args.with_channel_bindings = true;
+    args.discord_token_mode = "plaintext-only".to_string();
+
+    let plan = build_import_plan(&source, &args, Some(runtime.path())).unwrap();
+    apply::apply_import_plan(&plan, &source, &args, runtime.path()).unwrap();
+
+    let bot_settings = read_json_value(&runtime.path().join("config").join("bot_settings.json"));
+    let key = crate::services::discord::settings::discord_token_hash("discord-token-plaintext");
+    assert_eq!(bot_settings[&key]["provider"], "codex");
+    assert_eq!(bot_settings[&key]["agent"], "alpha");
+    assert_eq!(
+        bot_settings[&key]["allowed_channel_ids"],
+        serde_json::json!([1234567890u64])
+    );
+}
+
+#[test]
+fn live_write_bot_settings_resolves_file_secret_tokens() {
+    let temp = TempDir::new().unwrap();
+    let runtime = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    fs::write(workspace.join("IDENTITY.md"), "# Alpha\n").unwrap();
+    fs::write(workspace.join("MEMORY.md"), "# Memory\n").unwrap();
+    fs::write(
+        temp.path().join("secrets.json"),
+        r#"{"discord_token":"discord-token-file"}"#,
+    )
+    .unwrap();
+
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{"list":[{"id":"alpha","default":true,"model":"openai/gpt-5","workspace":"workspace"}]},
+            "bindings":[{"agentId":"alpha","match":{"channel":"discord","accountId":"primary"}}],
+            "secrets":{
+                "defaults":{"file":"disk"},
+                "providers":{"disk":{"source":"file","path":"./secrets.json","mode":"json"}}
+            },
+            "channels":{
+                "discord":{
+                    "accounts":{
+                        "primary":{
+                            "token":{"source":"file","provider":"disk","id":"discord_token"},
+                            "guilds":{"g1":{"channels":{"333":{"allow":true}}}}
+                        }
+                    }
+                }
+            }
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.dry_run = false;
+    args.write_org = true;
+    args.write_bot_settings = true;
+    args.with_channel_bindings = true;
+    args.discord_token_mode = "resolve-env-file".to_string();
+
+    let plan = build_import_plan(&source, &args, Some(runtime.path())).unwrap();
+    apply::apply_import_plan(&plan, &source, &args, runtime.path()).unwrap();
+
+    let bot_settings = read_json_value(&runtime.path().join("config").join("bot_settings.json"));
+    let key = crate::services::discord::settings::discord_token_hash("discord-token-file");
+    assert_eq!(bot_settings[&key]["provider"], "codex");
+    assert_eq!(bot_settings[&key]["agent"], "alpha");
+    assert_eq!(
+        bot_settings[&key]["allowed_channel_ids"],
+        serde_json::json!([333u64])
+    );
+}
+
+#[test]
+fn session_import_writes_ai_sessions_session_map_and_db_rows() {
+    let temp = TempDir::new().unwrap();
+    let runtime = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    let sessions_dir = temp.path().join("agents").join("alpha").join("sessions");
+    fs::create_dir_all(&workspace).unwrap();
+    fs::create_dir_all(&sessions_dir).unwrap();
+    fs::write(workspace.join("IDENTITY.md"), "# Alpha\n").unwrap();
+    fs::write(workspace.join("MEMORY.md"), "# Memory\n").unwrap();
+    fs::write(
+        sessions_dir.join("sessions.json"),
+        format!(
+            r#"{{
+                "session-key-1": {{
+                    "sessionId": "session-1",
+                    "sessionFile": "session-1.jsonl",
+                    "updatedAt": 1710000000000,
+                    "model": "openai/gpt-5",
+                    "modelProvider": "codex",
+                    "cwd": "{}",
+                    "lastChannel": "1234567890",
+                    "lastThreadId": "777",
+                    "status": "done"
+                }}
+            }}"#,
+            workspace.display()
+        ),
+    )
+    .unwrap();
+    fs::write(
+        sessions_dir.join("session-1.jsonl"),
+        concat!(
+            "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}}\n",
+            "{\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"name\":\"Read\",\"input\":{\"path\":\"README.md\"}}]}}\n",
+            "{\"message\":{\"role\":\"tool\",\"content\":[{\"type\":\"tool_result\",\"result\":\"done\"}]}}\n",
+            "{\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"finished\"}]}}\n"
+        ),
+    )
+    .unwrap();
+
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{"list":[{"id":"alpha","default":true,"model":"openai/gpt-5","workspace":"workspace"}]}
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.dry_run = false;
+    args.with_sessions = true;
+    args.write_db = true;
+
+    let plan = build_import_plan(&source, &args, Some(runtime.path())).unwrap();
+    apply::apply_import_plan(&plan, &source, &args, runtime.path()).unwrap();
+
+    let audit_root = audit_root(&plan);
+    let session_map = read_json_value(&audit_root.join("session-map.json"));
+    let ai_session_path =
+        std::path::PathBuf::from(session_map[0]["ai_session_path"].as_str().unwrap());
+    assert!(ai_session_path.is_file());
+
+    let ai_session = read_json_value(&ai_session_path);
+    let history = ai_session["history"].as_array().unwrap();
+    assert_eq!(history[0]["item_type"], "User");
+    assert_eq!(history[1]["item_type"], "ToolUse");
+    assert_eq!(history[2]["item_type"], "ToolResult");
+    assert_eq!(history[3]["item_type"], "Assistant");
+
+    let db_path = runtime.path().join("data").join("agentdesk.sqlite");
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let (agent_id, provider, model, cwd, session_info): (String, String, String, String, String) =
+        conn.query_row(
+            "SELECT agent_id, provider, model, cwd, session_info FROM sessions WHERE session_key = ?1",
+            rusqlite::params![session_map[0]["db_session_key"].as_str().unwrap()],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
+            },
+        )
+        .unwrap();
+    assert_eq!(agent_id, "alpha");
+    assert_eq!(provider, "codex");
+    assert_eq!(model, "openai/gpt-5");
+    assert!(cwd.ends_with("/openclaw/workspaces/alpha"));
+    assert!(session_info.contains("\"source_session_id\":\"session-1\""));
+}
+
+#[test]
+fn resume_skips_completed_apply_files_tasks() {
+    let temp = TempDir::new().unwrap();
+    let runtime = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(workspace.join("memory")).unwrap();
+    fs::write(workspace.join("IDENTITY.md"), "# Alpha\n").unwrap();
+    fs::write(workspace.join("MEMORY.md"), "# Memory\n").unwrap();
+    fs::write(workspace.join("memory").join("2026-04-02.md"), "# Daily\n").unwrap();
+
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{"list":[{"id":"alpha","default":true,"model":"openai/gpt-5","workspace":"workspace"}]}
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.dry_run = false;
+    args.write_org = true;
+
+    let plan = build_import_plan(&source, &args, Some(runtime.path())).unwrap();
+    apply::apply_import_plan(&plan, &source, &args, runtime.path()).unwrap();
+
+    let audit_root = audit_root(&plan);
+    let import_id = audit_root
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    let mut apply_result = read_json_value(&audit_root.join("apply-result.json"));
+    apply_result["status"] = serde_json::json!("failed");
+    apply_result["phases"]["apply_org"]["status"] = serde_json::json!("pending");
+    apply_result["phases"]["apply_org"]["started_at"] = serde_json::json!("");
+    apply_result["phases"]["apply_org"]["ended_at"] = serde_json::json!("");
+    apply_result["phases"]["apply_org"]["error"] = serde_json::Value::Null;
+    apply_result["phases"]["finalize"]["status"] = serde_json::json!("pending");
+    apply_result["phases"]["finalize"]["started_at"] = serde_json::json!("");
+    apply_result["phases"]["finalize"]["ended_at"] = serde_json::json!("");
+    apply_result["phases"]["finalize"]["error"] = serde_json::Value::Null;
+    apply_result["agents"]["alpha"]["tasks"]["org_agent_write"]["status"] =
+        serde_json::json!("pending");
+    fs::write(
+        audit_root.join("apply-result.json"),
+        serde_json::to_string_pretty(&apply_result).unwrap(),
+    )
+    .unwrap();
+
+    let mut resume_state = read_json_value(&audit_root.join("resume-state.json"));
+    resume_state["status"] = serde_json::json!("failed");
+    resume_state["completed_phases"] = serde_json::json!([
+        "scan",
+        "map",
+        "prompt",
+        "memory",
+        "policy_discord",
+        "apply_files"
+    ]);
+    resume_state["pending_phases"] = serde_json::json!(["apply_org", "finalize"]);
+    resume_state["phases"]["apply_org"] = serde_json::json!("pending");
+    resume_state["phases"]["finalize"] = serde_json::json!("pending");
+    resume_state["agents"]["alpha"]["tasks"]["org_agent_write"] = serde_json::json!("pending");
+    resume_state["next_recommended_step"] = serde_json::json!("resume_phase");
+    fs::write(
+        audit_root.join("resume-state.json"),
+        serde_json::to_string_pretty(&resume_state).unwrap(),
+    )
+    .unwrap();
+
+    let mut resume_args = base_args();
+    resume_args.dry_run = false;
+    resume_args.write_org = true;
+    resume_args.resume = Some(import_id);
+
+    let resume_plan = build_import_plan(&source, &resume_args, Some(runtime.path())).unwrap();
+    apply::apply_import_plan(&resume_plan, &source, &resume_args, runtime.path()).unwrap();
+
+    assert!(
+        !audit_root
+            .join("backups")
+            .join("openclaw")
+            .join("workspaces")
+            .join("alpha")
+            .exists()
+    );
+    let resumed_apply = read_json_value(&audit_root.join("apply-result.json"));
+    assert_eq!(resumed_apply["status"], "completed");
+    assert_eq!(
+        resumed_apply["phases"]["apply_files"]["status"],
+        "completed"
+    );
+    assert_eq!(resumed_apply["phases"]["apply_org"]["status"], "completed");
+}
+
+#[test]
+fn fails_when_every_selected_agent_is_unsupported_without_fallback() {
+    let temp = TempDir::new().unwrap();
+    fs::create_dir_all(temp.path().join("workspace-alpha")).unwrap();
+    fs::create_dir_all(temp.path().join("workspace-beta")).unwrap();
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{
+                "list":[
+                    {"id":"alpha","model":"meta/llama-3","workspace":"workspace-alpha"},
+                    {"id":"beta","model":"xai/grok-2","workspace":"workspace-beta"}
+                ]
+            }
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.all_agents = true;
+    let err = build_import_plan(&source, &args, None).unwrap_err();
+    assert!(err.contains("No importable OpenClaw agents remain after provider mapping"));
+}
+
+#[test]
+fn unsupported_agents_stay_audit_visible_but_are_skipped_on_apply() {
+    let temp = TempDir::new().unwrap();
+    let runtime = TempDir::new().unwrap();
+    fs::create_dir_all(temp.path().join("workspace-alpha")).unwrap();
+    fs::create_dir_all(temp.path().join("workspace-beta")).unwrap();
+    fs::write(
+        temp.path().join("workspace-alpha").join("IDENTITY.md"),
+        "# Alpha\n",
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("workspace-alpha").join("MEMORY.md"),
+        "# Memory\n",
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("workspace-beta").join("IDENTITY.md"),
+        "# Beta\n",
+    )
+    .unwrap();
+    fs::write(
+        temp.path().join("workspace-beta").join("MEMORY.md"),
+        "# Memory\n",
+    )
+    .unwrap();
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{
+                "list":[
+                    {"id":"alpha","model":"openai/gpt-5","workspace":"workspace-alpha"},
+                    {"id":"beta","model":"meta/llama-3","workspace":"workspace-beta"}
+                ]
+            }
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.all_agents = true;
+    args.dry_run = false;
+    args.write_org = true;
+
+    let plan = build_import_plan(&source, &args, Some(runtime.path())).unwrap();
+    assert_eq!(plan.selected_agent_ids, vec!["alpha", "beta"]);
+    assert_eq!(plan.importable_agent_ids, vec!["alpha"]);
+    let beta = plan
+        .agents
+        .iter()
+        .find(|agent| agent.source_id == "beta")
+        .unwrap();
+    assert!(beta.tasks.iter().all(|task| task.mode == "disabled"));
+
+    apply::apply_import_plan(&plan, &source, &args, runtime.path()).unwrap();
+
+    let agentdesk_yaml = fs::read_to_string(runtime.path().join("agentdesk.yaml")).unwrap();
+    assert!(agentdesk_yaml.contains("id: alpha"));
+    assert!(!agentdesk_yaml.contains("id: beta"));
+
+    let audit_root = audit_root(&plan);
+    let manifest = read_json_value(&audit_root.join("manifest.json"));
+    assert_eq!(
+        manifest["selected_agent_ids"],
+        serde_json::json!(["alpha", "beta"])
+    );
+    let apply_result = read_json_value(&audit_root.join("apply-result.json"));
+    assert_eq!(
+        apply_result["agents"]["beta"]["tasks"]["workspace_copy"]["status"],
+        "skipped"
+    );
+    assert!(
+        apply_result["warnings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|value| value
+                .as_str()
+                .unwrap()
+                .contains("Skipped non-importable OpenClaw agents"))
+    );
+}
+
+#[test]
+fn audit_reports_include_richer_tool_and_discord_details() {
+    let temp = TempDir::new().unwrap();
+    let runtime = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    fs::write(workspace.join("IDENTITY.md"), "# Alpha\n").unwrap();
+    fs::write(workspace.join("MEMORY.md"), "# Memory\n").unwrap();
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{
+                "list":[
+                    {
+                        "id":"alpha",
+                        "default":true,
+                        "model":"openai/gpt-5",
+                        "workspace":"workspace",
+                        "tools":{"allow":["TaskCreate","custom-agent-tool"]}
+                    }
+                ]
+            },
+            "tools":{
+                "allow":["Bash","unknown-global"],
+                "subagents":{"tools":{"allow":["Write"]}}
+            },
+            "bindings":[
+                {"agentId":"alpha","match":{"channel":"discord","accountId":"primary"}},
+                {"agentId":"alpha","match":{"channel":"discord","accountId":"primary","roles":["ops"]}}
+            ],
+            "channels":{
+                "discord":{
+                    "accounts":{
+                        "primary":{
+                            "token":"discord-token-primary",
+                            "allowBots":"mentions",
+                            "guilds":{
+                                "g1":{
+                                    "users":["user-1"],
+                                    "roles":["role-1"],
+                                    "tools":["Read","unknown-guild-tool"],
+                                    "channels":{
+                                        "123":{
+                                            "allow":true,
+                                            "users":["user-2"],
+                                            "roles":["role-2"],
+                                            "toolsBySender":{"*":{"allow":["Edit"]}}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.dry_run = false;
+    let plan = build_import_plan(&source, &args, Some(runtime.path())).unwrap();
+    apply::apply_import_plan(&plan, &source, &args, runtime.path()).unwrap();
+
+    let audit_root = audit_root(&plan);
+    let tool_report = read_json_value(&audit_root.join("tool-policy-report.json"));
+    assert_eq!(tool_report["has_channel_scoped_policy"], true);
+    assert_eq!(tool_report["has_sender_scoped_policy"], true);
+    assert_eq!(tool_report["has_subagent_scoped_policy"], true);
+    let agent_report = &tool_report["agents"][0];
+    assert_eq!(agent_report["agent_id"], "alpha");
+    assert!(
+        agent_report["normalized_candidate_tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|value| value == "TaskCreate")
+    );
+    assert!(
+        agent_report["normalized_candidate_tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|value| value == "Edit")
+    );
+    assert!(
+        agent_report["unsupported_tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|value| value == "custom-agent-tool")
+    );
+    assert!(
+        agent_report["unsupported_tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|value| value == "unknown-global")
+    );
+
+    let discord_report = read_json_value(&audit_root.join("discord-auth-report.json"));
+    assert_eq!(discord_report["default_token_configured"], false);
+    assert_eq!(discord_report["has_named_accounts"], true);
+    assert_eq!(discord_report["requested_token_mode"], "report");
+    let account = discord_report["accounts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|value| value["account_id"] == "primary")
+        .unwrap();
+    assert_eq!(account["token_status"], "skipped");
+    assert_eq!(account["guild_count"], 1);
+    assert_eq!(account["channel_override_count"], 1);
+    assert_eq!(account["user_allowlist_count"], 2);
+    assert_eq!(account["role_allowlist_count"], 2);
+    assert_eq!(account["binding_roles_present"], true);
+    assert_eq!(account["allow_bots_enabled"], true);
+    let mapping = discord_report["account_to_bot_mappings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|value| value["account_id"] == "primary")
+        .unwrap();
+    assert_eq!(mapping["mode"], "preview_only");
+    assert!(mapping["live_channel_ids"].as_array().unwrap().is_empty());
+    assert!(
+        mapping["preview_only_binding_agents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|value| value == "alpha")
+    );
+}
+
+#[test]
+fn report_mode_preserves_existing_allowed_tools_in_bot_settings() {
+    let temp = TempDir::new().unwrap();
+    let runtime = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    let config_dir = runtime.path().join("config");
+    fs::create_dir_all(&workspace).unwrap();
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(workspace.join("IDENTITY.md"), "# Alpha\n").unwrap();
+    fs::write(workspace.join("MEMORY.md"), "# Memory\n").unwrap();
+    fs::write(
+        config_dir.join("bot_settings.json"),
+        serde_json::json!({
+            crate::services::discord::settings::discord_token_hash("discord-token-plaintext"): {
+                "token": "discord-token-plaintext",
+                "provider": "claude",
+                "agent": "legacy",
+                "allowed_tools": ["Read"],
+                "allowed_channel_ids": [1]
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{"list":[{"id":"alpha","default":true,"model":"openai/gpt-5","workspace":"workspace"}]},
+            "bindings":[{"agentId":"alpha","match":{"channel":"discord"}}],
+            "channels":{
+                "discord":{
+                    "token":"discord-token-plaintext",
+                    "guilds":{"g1":{"channels":{"1234567890":{"allow":true}}}}
+                }
+            }
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.dry_run = false;
+    args.write_org = true;
+    args.write_bot_settings = true;
+    args.with_channel_bindings = true;
+    args.discord_token_mode = "plaintext-only".to_string();
+    args.tool_policy_mode = "report".to_string();
+
+    let plan = build_import_plan(&source, &args, Some(runtime.path())).unwrap();
+    apply::apply_import_plan(&plan, &source, &args, runtime.path()).unwrap();
+
+    let bot_settings = read_json_value(&runtime.path().join("config").join("bot_settings.json"));
+    let key = crate::services::discord::settings::discord_token_hash("discord-token-plaintext");
+    assert_eq!(
+        bot_settings[&key]["allowed_tools"],
+        serde_json::json!(["Read"])
+    );
+    assert_eq!(
+        bot_settings[&key]["allowed_channel_ids"],
+        serde_json::json!([1234567890u64])
+    );
+}

--- a/src/cli/migrate/tests.rs
+++ b/src/cli/migrate/tests.rs
@@ -803,6 +803,124 @@ fn live_write_bot_settings_resolves_file_secret_tokens() {
 }
 
 #[test]
+fn live_write_bot_settings_preserves_existing_allowlist_when_bindings_disabled() {
+    let temp = TempDir::new().unwrap();
+    let runtime = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    fs::write(workspace.join("IDENTITY.md"), "# Alpha\n").unwrap();
+    fs::write(workspace.join("MEMORY.md"), "# Memory\n").unwrap();
+
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{"list":[{"id":"alpha","default":true,"model":"openai/gpt-5","workspace":"workspace"}]},
+            "bindings":[{"agentId":"alpha","match":{"channel":"discord"}}],
+            "channels":{
+                "discord":{
+                    "token":"discord-token-plaintext",
+                    "guilds":{"g1":{"channels":{"1234567890":{"allow":true}}}}
+                }
+            }
+        }"#,
+    );
+
+    let existing_key =
+        crate::services::discord::settings::discord_token_hash("discord-token-plaintext");
+    fs::create_dir_all(runtime.path().join("config")).unwrap();
+    fs::write(
+        runtime.path().join("config").join("bot_settings.json"),
+        serde_json::json!({
+            existing_key.clone(): {
+                "token": "discord-token-plaintext",
+                "provider": "codex",
+                "agent": "alpha",
+                "allowed_channel_ids": [777u64]
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.dry_run = false;
+    args.write_bot_settings = true;
+    args.discord_token_mode = "plaintext-only".to_string();
+
+    let plan = build_import_plan(&source, &args, Some(runtime.path())).unwrap();
+    apply::apply_import_plan(&plan, &source, &args, runtime.path()).unwrap();
+
+    let bot_settings = read_json_value(&runtime.path().join("config").join("bot_settings.json"));
+    assert_eq!(
+        bot_settings[&existing_key]["allowed_channel_ids"],
+        serde_json::json!([777u64])
+    );
+}
+
+#[test]
+fn live_write_bot_settings_resolves_env_placeholder_without_provider() {
+    let temp = TempDir::new().unwrap();
+    let runtime = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    fs::write(workspace.join("IDENTITY.md"), "# Alpha\n").unwrap();
+    fs::write(workspace.join("MEMORY.md"), "# Memory\n").unwrap();
+
+    let env_key = format!(
+        "OPENCLAW_MIGRATE_TOKEN_{}",
+        temp.path()
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .replace('-', "_")
+    );
+    unsafe {
+        std::env::set_var(&env_key, "discord-token-env");
+    }
+
+    write_openclaw_config(
+        temp.path(),
+        &format!(
+            r#"{{
+                "agents":{{"list":[{{"id":"alpha","default":true,"model":"openai/gpt-5","workspace":"workspace"}}]}},
+                "bindings":[{{"agentId":"alpha","match":{{"channel":"discord"}}}}],
+                "channels":{{
+                    "discord":{{
+                        "token":"${{{}}}",
+                        "guilds":{{"g1":{{"channels":{{"1234567890":{{"allow":true}}}}}}}}
+                    }}
+                }}
+            }}"#,
+            env_key
+        ),
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.dry_run = false;
+    args.write_org = true;
+    args.write_bot_settings = true;
+    args.with_channel_bindings = true;
+    args.discord_token_mode = "resolve-env-file".to_string();
+
+    let plan = build_import_plan(&source, &args, Some(runtime.path())).unwrap();
+    apply::apply_import_plan(&plan, &source, &args, runtime.path()).unwrap();
+
+    let bot_settings = read_json_value(&runtime.path().join("config").join("bot_settings.json"));
+    let key = crate::services::discord::settings::discord_token_hash("discord-token-env");
+    assert_eq!(bot_settings[&key]["provider"], "codex");
+    assert_eq!(
+        bot_settings[&key]["allowed_channel_ids"],
+        serde_json::json!([1234567890u64])
+    );
+
+    unsafe {
+        std::env::remove_var(&env_key);
+    }
+}
+
+#[test]
 fn session_import_writes_ai_sessions_session_map_and_db_rows() {
     let temp = TempDir::new().unwrap();
     let runtime = TempDir::new().unwrap();
@@ -1231,6 +1349,33 @@ fn audit_reports_include_richer_tool_and_discord_details() {
             .iter()
             .any(|value| value == "alpha")
     );
+}
+
+#[test]
+fn apply_fails_when_existing_agentdesk_yaml_is_invalid() {
+    let temp = TempDir::new().unwrap();
+    let runtime = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    fs::write(workspace.join("IDENTITY.md"), "# Alpha\n").unwrap();
+    fs::write(workspace.join("MEMORY.md"), "# Memory\n").unwrap();
+    fs::write(runtime.path().join("agentdesk.yaml"), "server: [").unwrap();
+
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{"list":[{"id":"alpha","default":true,"model":"openai/gpt-5","workspace":"workspace"}]}
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.dry_run = false;
+
+    let plan = build_import_plan(&source, &args, Some(runtime.path())).unwrap();
+    let err = apply::apply_import_plan(&plan, &source, &args, runtime.path()).unwrap_err();
+    assert!(err.contains("Failed to load"));
+    assert!(err.contains("agentdesk.yaml"));
 }
 
 #[test]

--- a/src/cli/migrate/tests.rs
+++ b/src/cli/migrate/tests.rs
@@ -250,6 +250,33 @@ fn role_ids_prefix_when_org_yaml_collides() {
 }
 
 #[test]
+fn rerun_reuses_existing_prefixed_role_id() {
+    let temp = TempDir::new().unwrap();
+    let runtime = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    fs::create_dir_all(runtime.path().join("config")).unwrap();
+    fs::create_dir_all(&workspace).unwrap();
+    fs::write(
+        runtime.path().join("agentdesk.yaml"),
+        r#"agents:
+- id: openclaw-alpha
+  name: alpha
+  provider: codex
+"#,
+    )
+    .unwrap();
+    write_openclaw_config(
+        temp.path(),
+        r#"{"agents":{"list":[{"id":"alpha","default":true,"model":"openai/gpt-5","workspace":"workspace"}]}}"#,
+    );
+
+    let source = resolve_source(&temp);
+    let plan = build_import_plan(&source, &base_args(), Some(runtime.path())).unwrap();
+
+    assert_eq!(plan.agents[0].final_role_id, "openclaw-alpha");
+}
+
+#[test]
 fn fallback_provider_maps_unsupported_sources() {
     let temp = TempDir::new().unwrap();
     let workspace = temp.path().join("workspace");

--- a/src/cli/migrate/tests.rs
+++ b/src/cli/migrate/tests.rs
@@ -1217,9 +1217,17 @@ fn session_import_writes_ai_sessions_session_map_and_db_rows() {
 
     let db_path = runtime.path().join("data").join("agentdesk.sqlite");
     let conn = rusqlite::Connection::open(&db_path).unwrap();
-    let (agent_id, provider, model, cwd, session_info): (String, String, String, String, String) =
+    let (agent_id, provider, status, model, cwd, session_info, last_heartbeat): (
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+        Option<String>,
+    ) =
         conn.query_row(
-            "SELECT agent_id, provider, model, cwd, session_info FROM sessions WHERE session_key = ?1",
+            "SELECT agent_id, provider, status, model, cwd, session_info, last_heartbeat FROM sessions WHERE session_key = ?1",
             rusqlite::params![session_map[0]["db_session_key"].as_str().unwrap()],
             |row| {
                 Ok((
@@ -1228,12 +1236,15 @@ fn session_import_writes_ai_sessions_session_map_and_db_rows() {
                     row.get(2)?,
                     row.get(3)?,
                     row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
                 ))
             },
         )
         .unwrap();
     assert_eq!(agent_id, "alpha");
     assert_eq!(provider, "codex");
+    assert_eq!(status, "idle");
     assert_eq!(model, "openai/gpt-5");
     assert!(
         std::path::Path::new(&cwd).ends_with(
@@ -1243,6 +1254,79 @@ fn session_import_writes_ai_sessions_session_map_and_db_rows() {
         )
     );
     assert!(session_info.contains("\"source_session_id\":\"session-1\""));
+    assert!(last_heartbeat.is_none());
+}
+
+#[test]
+fn session_import_keeps_claude_runtime_session_id_null_for_running_source_sessions() {
+    let temp = TempDir::new().unwrap();
+    let runtime = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    let sessions_dir = temp.path().join("agents").join("alpha").join("sessions");
+    fs::create_dir_all(&workspace).unwrap();
+    fs::create_dir_all(&sessions_dir).unwrap();
+    fs::write(workspace.join("IDENTITY.md"), "# Alpha\n").unwrap();
+    fs::write(workspace.join("MEMORY.md"), "# Memory\n").unwrap();
+    fs::write(
+        sessions_dir.join("sessions.json"),
+        serde_json::json!({
+            "session-key-1": {
+                "sessionId": "claude-source-session-1",
+                "sessionFile": "session-1.jsonl",
+                "updatedAt": 1710000000000i64,
+                "model": "anthropic/claude-3-5-sonnet-latest",
+                "modelProvider": "claude",
+                "cwd": workspace.display().to_string(),
+                "status": "running"
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+    fs::write(
+        sessions_dir.join("session-1.jsonl"),
+        "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}}\n",
+    )
+    .unwrap();
+
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{"list":[{"id":"alpha","default":true,"model":"anthropic/claude-3-5-sonnet-latest","workspace":"workspace"}]}
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.dry_run = false;
+    args.with_sessions = true;
+    args.write_db = true;
+
+    let plan = build_import_plan(&source, &args, Some(runtime.path())).unwrap();
+    apply::apply_import_plan(&plan, &source, &args, runtime.path()).unwrap();
+
+    let audit_root = audit_root(&plan);
+    let session_map = read_json_value(&audit_root.join("session-map.json"));
+    let db_path = runtime.path().join("data").join("agentdesk.sqlite");
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let (status, claude_session_id, session_info, last_heartbeat): (
+        String,
+        Option<String>,
+        String,
+        Option<String>,
+    ) = conn
+        .query_row(
+            "SELECT status, claude_session_id, session_info, last_heartbeat FROM sessions WHERE session_key = ?1",
+            rusqlite::params![session_map[0]["db_session_key"].as_str().unwrap()],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .unwrap();
+
+    assert_eq!(status, "idle");
+    assert!(claude_session_id.is_none());
+    assert!(last_heartbeat.is_none());
+    assert!(session_info.contains("\"source_session_id\":\"claude-source-session-1\""));
+    assert!(session_info.contains("\"source_status\":\"running\""));
 }
 
 #[test]

--- a/src/cli/migrate/tests.rs
+++ b/src/cli/migrate/tests.rs
@@ -465,6 +465,29 @@ fn base_apply_writes_agentdesk_prompt_memory_workspace_and_audit() {
     assert!(prompt.contains("Imported OpenClaw Identity"));
     assert!(prompt.contains("Imported OpenClaw Agent Rules"));
     assert!(prompt.contains("Imported OpenClaw Boot Intent"));
+    assert!(prompt.contains("AgentDesk Runtime References"));
+    assert!(
+        prompt.contains(
+            &runtime
+                .path()
+                .join("role-context")
+                .join("alpha.memory")
+                .display()
+                .to_string()
+        )
+    );
+    assert!(
+        prompt.contains(
+            &runtime
+                .path()
+                .join("openclaw")
+                .join("workspaces")
+                .join("alpha")
+                .display()
+                .to_string()
+        )
+    );
+    assert!(prompt.contains(&workspace.display().to_string()));
 
     let memory_md = fs::read_to_string(
         runtime

--- a/src/cli/migrate/tests.rs
+++ b/src/cli/migrate/tests.rs
@@ -277,6 +277,55 @@ fn rerun_reuses_existing_prefixed_role_id() {
 }
 
 #[test]
+fn resume_reuses_stored_role_id_from_agent_map() {
+    let temp = TempDir::new().unwrap();
+    let runtime = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    let import_id = "resume-import-123";
+    let audit_root = runtime
+        .path()
+        .join("openclaw")
+        .join("imports")
+        .join(import_id);
+    fs::create_dir_all(runtime.path().join("config")).unwrap();
+    fs::create_dir_all(&workspace).unwrap();
+    fs::create_dir_all(&audit_root).unwrap();
+    fs::write(
+        runtime.path().join("agentdesk.yaml"),
+        r#"agents:
+- id: alpha
+  name: Existing alpha
+  provider: codex
+- id: openclaw-alpha
+  name: Existing imported alpha
+  provider: codex
+- id: openclaw-alpha-2
+  name: Previously imported alpha
+  provider: codex
+"#,
+    )
+    .unwrap();
+    fs::write(
+        audit_root.join("agent-map.json"),
+        r#"[
+  {"source_id":"alpha","role_id":"openclaw-alpha-2"}
+]"#,
+    )
+    .unwrap();
+    write_openclaw_config(
+        temp.path(),
+        r#"{"agents":{"list":[{"id":"alpha","default":true,"model":"openai/gpt-5","workspace":"workspace"}]}}"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.resume = Some(import_id.to_string());
+    let plan = build_import_plan(&source, &args, Some(runtime.path())).unwrap();
+
+    assert_eq!(plan.agents[0].final_role_id, "openclaw-alpha-2");
+}
+
+#[test]
 fn fallback_provider_maps_unsupported_sources() {
     let temp = TempDir::new().unwrap();
     let workspace = temp.path().join("workspace");
@@ -323,6 +372,23 @@ fn defaults_workspace_is_used_for_agents_without_workspace() {
             .ends_with("shared-workspace")
     );
     assert!(plan.agents[0].workspace_exists);
+}
+
+#[test]
+fn windows_absolute_workspace_path_is_not_joined_to_source_root() {
+    let temp = TempDir::new().unwrap();
+    write_openclaw_config(
+        temp.path(),
+        r#"{"agents":{"list":[{"id":"alpha","default":true,"model":"openai/gpt-5","workspace":"C:\\openclaw\\workspace-alpha"}]}}"#,
+    );
+
+    let source = resolve_source(&temp);
+    let plan = build_import_plan(&source, &base_args(), None).unwrap();
+
+    assert_eq!(
+        plan.agents[0].workspace_source,
+        r"C:\openclaw\workspace-alpha"
+    );
 }
 
 #[test]

--- a/src/cli/migrate/tests.rs
+++ b/src/cli/migrate/tests.rs
@@ -1246,6 +1246,118 @@ fn session_import_writes_ai_sessions_session_map_and_db_rows() {
 }
 
 #[test]
+fn resume_allows_enabling_sessions_without_fingerprint_mismatch() {
+    let temp = TempDir::new().unwrap();
+    let runtime = TempDir::new().unwrap();
+    let workspace = temp.path().join("workspace");
+    let sessions_dir = temp.path().join("agents").join("alpha").join("sessions");
+    fs::create_dir_all(&workspace).unwrap();
+    fs::create_dir_all(&sessions_dir).unwrap();
+    fs::write(workspace.join("IDENTITY.md"), "# Alpha\n").unwrap();
+    fs::write(workspace.join("MEMORY.md"), "# Memory\n").unwrap();
+    fs::write(
+        sessions_dir.join("sessions.json"),
+        serde_json::json!({
+            "session-key-1": {
+                "sessionId": "session-1",
+                "sessionFile": "session-1.jsonl",
+                "updatedAt": 1710000000000i64,
+                "model": "openai/gpt-5",
+                "modelProvider": "codex",
+                "cwd": workspace.display().to_string(),
+                "status": "done"
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+    fs::write(
+        sessions_dir.join("session-1.jsonl"),
+        "{\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}}\n",
+    )
+    .unwrap();
+
+    write_openclaw_config(
+        temp.path(),
+        r#"{
+            "agents":{"list":[{"id":"alpha","default":true,"model":"openai/gpt-5","workspace":"workspace"}]}
+        }"#,
+    );
+
+    let source = resolve_source(&temp);
+    let mut args = base_args();
+    args.dry_run = false;
+    args.write_db = true;
+
+    let plan = build_import_plan(&source, &args, Some(runtime.path())).unwrap();
+    apply::apply_import_plan(&plan, &source, &args, runtime.path()).unwrap();
+
+    let audit_root = audit_root(&plan);
+    let import_id = audit_root
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    let mut apply_result = read_json_value(&audit_root.join("apply-result.json"));
+    apply_result["status"] = serde_json::json!("failed");
+    apply_result["phases"]["sessions"]["status"] = serde_json::json!("pending");
+    apply_result["phases"]["sessions"]["started_at"] = serde_json::json!("");
+    apply_result["phases"]["sessions"]["ended_at"] = serde_json::json!("");
+    apply_result["phases"]["sessions"]["error"] = serde_json::Value::Null;
+    apply_result["phases"]["finalize"]["status"] = serde_json::json!("pending");
+    apply_result["phases"]["finalize"]["started_at"] = serde_json::json!("");
+    apply_result["phases"]["finalize"]["ended_at"] = serde_json::json!("");
+    apply_result["phases"]["finalize"]["error"] = serde_json::Value::Null;
+    apply_result["agents"]["alpha"]["tasks"]["session_import"]["status"] =
+        serde_json::json!("pending");
+    fs::write(
+        audit_root.join("apply-result.json"),
+        serde_json::to_string_pretty(&apply_result).unwrap(),
+    )
+    .unwrap();
+
+    let mut resume_state = read_json_value(&audit_root.join("resume-state.json"));
+    resume_state["status"] = serde_json::json!("failed");
+    resume_state["completed_phases"] = serde_json::json!([
+        "scan",
+        "map",
+        "prompt",
+        "memory",
+        "policy_discord",
+        "apply_files",
+        "apply_bot_settings",
+        "apply_db"
+    ]);
+    resume_state["pending_phases"] = serde_json::json!(["sessions", "finalize"]);
+    resume_state["phases"]["sessions"] = serde_json::json!("pending");
+    resume_state["phases"]["finalize"] = serde_json::json!("pending");
+    resume_state["agents"]["alpha"]["tasks"]["session_import"] = serde_json::json!("pending");
+    resume_state["next_recommended_step"] = serde_json::json!("resume_phase");
+    fs::write(
+        audit_root.join("resume-state.json"),
+        serde_json::to_string_pretty(&resume_state).unwrap(),
+    )
+    .unwrap();
+
+    let mut resume_args = base_args();
+    resume_args.dry_run = false;
+    resume_args.write_db = true;
+    resume_args.with_sessions = true;
+    resume_args.resume = Some(import_id);
+
+    let resume_plan = build_import_plan(&source, &resume_args, Some(runtime.path())).unwrap();
+    apply::apply_import_plan(&resume_plan, &source, &resume_args, runtime.path()).unwrap();
+
+    let resumed_apply = read_json_value(&audit_root.join("apply-result.json"));
+    assert_eq!(resumed_apply["status"], "completed");
+    assert_eq!(resumed_apply["phases"]["sessions"]["status"], "completed");
+
+    let session_map = read_json_value(&audit_root.join("session-map.json"));
+    assert_eq!(session_map.as_array().unwrap().len(), 1);
+}
+
+#[test]
 fn resume_skips_completed_apply_files_tasks() {
     let temp = TempDir::new().unwrap();
     let runtime = TempDir::new().unwrap();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod dcserver;
 pub(crate) mod discord;
 pub(crate) mod doctor;
 pub(crate) mod init;
+pub(crate) mod migrate;
 pub(crate) mod utils;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/config.rs
+++ b/src/config.rs
@@ -310,7 +310,10 @@ pub fn load_graceful() -> Config {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_graceful_config_path, runtime_root};
+    use super::{
+        AgentDef, BotConfig, Config, load_from_path, resolve_graceful_config_path, runtime_root,
+        save_to_path,
+    };
     use std::path::PathBuf;
     use std::sync::{Mutex, MutexGuard, OnceLock};
 
@@ -416,6 +419,64 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(cwd);
         let _ = std::fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn save_and_load_round_trip_preserves_config_fields() {
+        let dir = make_temp_dir("roundtrip");
+        let path = dir.join("nested").join("agentdesk.yaml");
+
+        let mut config = Config::default();
+        config.server.port = 4317;
+        config.server.host = "127.0.0.42".to_string();
+        config.server.auth_token = Some("secret-token".to_string());
+        config.discord.guild_id = Some("guild-123".to_string());
+        config.discord.bots.insert(
+            "announce".to_string(),
+            BotConfig {
+                token: Some("bot-token".to_string()),
+                description: Some("announce bot".to_string()),
+            },
+        );
+        config.agents.push(AgentDef {
+            id: "agent-1".to_string(),
+            name: "Agent One".to_string(),
+            name_ko: Some("에이전트 원".to_string()),
+            provider: "codex".to_string(),
+            channels: std::collections::HashMap::from([(
+                "claude".to_string(),
+                "123456789012345678".to_string(),
+            )]),
+            department: Some("platform".to_string()),
+            avatar_emoji: Some(":robot:".to_string()),
+        });
+
+        save_to_path(&path, &config).unwrap();
+        assert!(path.exists());
+        let loaded = load_from_path(&path).unwrap();
+
+        assert_eq!(loaded.server.port, 4317);
+        assert_eq!(loaded.server.host, "127.0.0.42");
+        assert_eq!(loaded.server.auth_token.as_deref(), Some("secret-token"));
+        assert_eq!(loaded.discord.guild_id.as_deref(), Some("guild-123"));
+        assert_eq!(loaded.discord.bots.len(), 1);
+        assert_eq!(
+            loaded.discord.bots["announce"].description.as_deref(),
+            Some("announce bot")
+        );
+        assert_eq!(loaded.agents.len(), 1);
+        assert_eq!(loaded.agents[0].id, "agent-1");
+        assert_eq!(loaded.agents[0].name, "Agent One");
+        assert_eq!(loaded.agents[0].name_ko.as_deref(), Some("에이전트 원"));
+        assert_eq!(loaded.agents[0].provider, "codex");
+        assert_eq!(loaded.agents[0].department.as_deref(), Some("platform"));
+        assert_eq!(loaded.agents[0].avatar_emoji.as_deref(), Some(":robot:"));
+        assert_eq!(
+            loaded.agents[0].channels.get("claude").map(String::as_str),
+            Some("123456789012345678")
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -223,14 +223,12 @@ pub fn load() -> Result<Config> {
     Ok(config)
 }
 
-pub fn load_from_path_graceful(path: &Path) -> Config {
-    match std::fs::read_to_string(path) {
-        Ok(contents) => match serde_yaml::from_str::<Config>(&contents) {
-            Ok(config) => config,
-            Err(_) => Config::default(),
-        },
-        Err(_) => Config::default(),
-    }
+pub fn load_from_path(path: &Path) -> Result<Config> {
+    let contents = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read config {}", path.display()))?;
+    let config = serde_yaml::from_str::<Config>(&contents)
+        .with_context(|| format!("Failed to parse config {}", path.display()))?;
+    Ok(config)
 }
 
 pub fn save_to_path(path: &Path, config: &Config) -> Result<()> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result};
-use serde::Deserialize;
-use std::path::PathBuf;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Config {
     pub server: ServerConfig,
     #[serde(default)]
@@ -17,7 +17,7 @@ pub struct Config {
     pub data: DataConfig,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ServerConfig {
     #[serde(default = "default_port")]
     pub port: u16,
@@ -27,7 +27,7 @@ pub struct ServerConfig {
     pub auth_token: Option<String>,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct DiscordConfig {
     #[serde(default)]
     pub bots: std::collections::HashMap<String, BotConfig>,
@@ -35,7 +35,7 @@ pub struct DiscordConfig {
     pub guild_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BotConfig {
     #[serde(default)]
     pub token: Option<String>,
@@ -43,7 +43,7 @@ pub struct BotConfig {
     pub description: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AgentDef {
     pub id: String,
     pub name: String,
@@ -59,7 +59,7 @@ pub struct AgentDef {
     pub avatar_emoji: Option<String>,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct GitHubConfig {
     #[serde(default)]
     pub repos: Vec<String>,
@@ -67,7 +67,7 @@ pub struct GitHubConfig {
     pub sync_interval_minutes: u64,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct PoliciesConfig {
     #[serde(default = "default_policies_dir")]
     pub dir: PathBuf,
@@ -75,7 +75,7 @@ pub struct PoliciesConfig {
     pub hot_reload: bool,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DataConfig {
     #[serde(default = "default_data_dir")]
     pub dir: PathBuf,
@@ -221,6 +221,27 @@ pub fn load() -> Result<Config> {
     std::fs::create_dir_all(&config.data.dir)?;
 
     Ok(config)
+}
+
+pub fn load_from_path_graceful(path: &Path) -> Config {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => match serde_yaml::from_str::<Config>(&contents) {
+            Ok(config) => config,
+            Err(_) => Config::default(),
+        },
+        Err(_) => Config::default(),
+    }
+}
+
+pub fn save_to_path(path: &Path, config: &Config) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let rendered = serde_yaml::to_string(config)
+        .with_context(|| format!("Failed to serialize config for {}", path.display()))?;
+    std::fs::write(path, rendered)
+        .with_context(|| format!("Failed to write config {}", path.display()))?;
+    Ok(())
 }
 
 fn resolve_graceful_config_path(

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,6 +261,11 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Migration helpers
+    Migrate {
+        #[command(subcommand)]
+        action: MigrateAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -277,6 +282,12 @@ enum DispatchAction {
         /// Kanban card ID
         card_id: String,
     },
+}
+
+#[derive(Subcommand)]
+enum MigrateAction {
+    /// Import OpenClaw durable state into AgentDesk
+    Openclaw(cli::migrate::OpenClawMigrateArgs),
 }
 
 #[derive(Subcommand)]
@@ -525,6 +536,11 @@ fn main() -> Result<()> {
                 } else {
                     exit_for_cli(cli::doctor::cmd_doctor(fix, json))
                 };
+            }
+            Some(Commands::Migrate { action }) => {
+                return exit_for_cli(match action {
+                    MigrateAction::Openclaw(args) => cli::migrate::cmd_migrate_openclaw(args),
+                });
             }
             None => {
                 // No subcommand — fall through to server start

--- a/src/server/routes/dispatches.rs
+++ b/src/server/routes/dispatches.rs
@@ -2069,7 +2069,7 @@ pub fn resolve_channel_alias_pub(alias: &str) -> Option<u64> {
     resolve_channel_alias(alias)
 }
 
-fn use_counter_model_channel(dispatch_type: Option<&str>) -> bool {
+pub(crate) fn use_counter_model_channel(dispatch_type: Option<&str>) -> bool {
     // "review" and "e2e-test" (#197) go to the counter-model channel.
     // "review-decision" is sent to the original agent's primary channel
     // so it reuses the implementation thread.

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -9,6 +9,7 @@ mod metrics;
 mod model_catalog;
 mod model_picker_interaction;
 mod org_schema;
+pub(crate) mod org_writer;
 mod prompt_builder;
 mod recovery;
 pub(crate) mod restart_report;

--- a/src/services/discord/org_writer.rs
+++ b/src/services/discord/org_writer.rs
@@ -1,0 +1,237 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use serde_yaml::Value;
+
+use super::runtime_store::org_schema_path_for_root;
+
+#[derive(Clone, Debug)]
+pub(crate) struct OrgAgentUpdate {
+    pub(crate) role_id: String,
+    pub(crate) display_name: String,
+    pub(crate) prompt_file: Option<String>,
+    pub(crate) provider: Option<String>,
+    pub(crate) model: Option<String>,
+    pub(crate) workspace: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct OrgChannelBindingUpdate {
+    pub(crate) channel_id: String,
+    pub(crate) agent: String,
+    pub(crate) workspace: Option<String>,
+    pub(crate) provider: Option<String>,
+    pub(crate) model: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+struct OrgDocument {
+    #[serde(default = "default_org_version")]
+    version: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    shared_prompt: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    prompts_root: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    skills_root: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    agents: BTreeMap<String, OrgAgentDef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    channels: Option<OrgChannelsConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    meeting: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    suffix_map: Option<Value>,
+    #[serde(default, flatten, skip_serializing_if = "BTreeMap::is_empty")]
+    extra: BTreeMap<String, Value>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+struct OrgAgentDef {
+    #[serde(default)]
+    display_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    prompt_file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    keywords: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    workspace: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    peer_agents: Option<bool>,
+    #[serde(default, flatten, skip_serializing_if = "BTreeMap::is_empty")]
+    extra: BTreeMap<String, Value>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+struct OrgChannelsConfig {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    by_id: BTreeMap<String, OrgChannelBinding>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    by_name: Option<Value>,
+    #[serde(default, flatten, skip_serializing_if = "BTreeMap::is_empty")]
+    extra: BTreeMap<String, Value>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+struct OrgChannelBinding {
+    #[serde(default)]
+    agent: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    workspace: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    peer_agents: Option<bool>,
+    #[serde(default, flatten, skip_serializing_if = "BTreeMap::is_empty")]
+    extra: BTreeMap<String, Value>,
+}
+
+fn default_org_version() -> u32 {
+    1
+}
+
+pub(crate) fn merge_org_agents(
+    runtime_root: &Path,
+    updates: &[OrgAgentUpdate],
+    overwrite: bool,
+) -> Result<String, String> {
+    merge_org_updates(runtime_root, updates, &[], overwrite)
+}
+
+pub(crate) fn merge_org_updates(
+    runtime_root: &Path,
+    agent_updates: &[OrgAgentUpdate],
+    channel_updates: &[OrgChannelBindingUpdate],
+    overwrite: bool,
+) -> Result<String, String> {
+    let org_path = org_schema_path_for_root(runtime_root);
+    let mut document = load_org_document(&org_path)?;
+
+    for update in agent_updates {
+        let existing = document.agents.get(&update.role_id).cloned();
+        if existing.is_some() && !overwrite {
+            return Err(format!(
+                "Target org role '{}' already exists in '{}'. Re-run with --overwrite to replace it.",
+                update.role_id,
+                org_path.display()
+            ));
+        }
+
+        let mut agent = existing.unwrap_or_default();
+        agent.display_name = update.display_name.clone();
+        agent.prompt_file = update.prompt_file.clone();
+        agent.provider = update.provider.clone();
+        agent.model = update.model.clone();
+        agent.workspace = update.workspace.clone();
+        document.agents.insert(update.role_id.clone(), agent);
+    }
+
+    if !channel_updates.is_empty() {
+        let channels = document
+            .channels
+            .get_or_insert_with(OrgChannelsConfig::default);
+        for update in channel_updates {
+            let existing = channels.by_id.get(&update.channel_id).cloned();
+            if existing.is_some() && !overwrite {
+                return Err(format!(
+                    "Target org channel binding '{}' already exists in '{}'. Re-run with --overwrite to replace it.",
+                    update.channel_id,
+                    org_path.display()
+                ));
+            }
+
+            let mut binding = existing.unwrap_or_default();
+            binding.agent = update.agent.clone();
+            binding.workspace = update.workspace.clone();
+            binding.provider = update.provider.clone();
+            binding.model = update.model.clone();
+            channels.by_id.insert(update.channel_id.clone(), binding);
+        }
+    }
+
+    serde_yaml::to_string(&document)
+        .map_err(|e| format!("Failed to serialize '{}': {e}", org_path.display()))
+}
+
+fn load_org_document(path: &Path) -> Result<OrgDocument, String> {
+    if !path.exists() {
+        return Ok(OrgDocument {
+            version: default_org_version(),
+            ..OrgDocument::default()
+        });
+    }
+
+    let content = fs::read_to_string(path)
+        .map_err(|e| format!("Failed to read '{}': {e}", path.display()))?;
+    serde_yaml::from_str(&content).map_err(|e| format!("Failed to parse '{}': {e}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::{OrgAgentUpdate, OrgChannelBindingUpdate, merge_org_updates};
+
+    #[test]
+    fn merge_org_agents_preserves_existing_sections() {
+        let runtime = tempdir().unwrap();
+        let config_dir = runtime.path().join("config");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(
+            config_dir.join("org.yaml"),
+            r#"version: 1
+prompts_root: ~/.adk/prompts
+channels:
+  by_id:
+    "123":
+      agent: existing
+agents:
+  existing:
+    display_name: Existing
+    provider: claude
+"#,
+        )
+        .unwrap();
+
+        let rendered = merge_org_updates(
+            runtime.path(),
+            &[OrgAgentUpdate {
+                role_id: "alpha".to_string(),
+                display_name: "Alpha".to_string(),
+                prompt_file: Some("/tmp/alpha.md".to_string()),
+                provider: Some("codex".to_string()),
+                model: Some("gpt-5.4".to_string()),
+                workspace: Some("/tmp/ws".to_string()),
+            }],
+            &[OrgChannelBindingUpdate {
+                channel_id: "555".to_string(),
+                agent: "alpha".to_string(),
+                workspace: Some("/tmp/ws".to_string()),
+                provider: Some("codex".to_string()),
+                model: Some("gpt-5.4".to_string()),
+            }],
+            true,
+        )
+        .unwrap();
+
+        assert!(rendered.contains("prompts_root: ~/.adk/prompts"));
+        assert!(rendered.contains("\"123\""));
+        assert!(rendered.contains("existing:"));
+        assert!(rendered.contains("alpha:"));
+        assert!(rendered.contains("display_name: Alpha"));
+        assert!(rendered.contains("provider: codex"));
+        assert!(rendered.contains("\"555\""));
+    }
+}

--- a/src/services/discord/org_writer.rs
+++ b/src/services/discord/org_writer.rs
@@ -180,6 +180,7 @@ fn load_org_document(path: &Path) -> Result<OrgDocument, String> {
 mod tests {
     use std::fs;
 
+    use serde_yaml::Value;
     use tempfile::tempdir;
 
     use super::{OrgAgentUpdate, OrgChannelBindingUpdate, merge_org_updates};
@@ -227,11 +228,11 @@ agents:
         .unwrap();
 
         assert!(rendered.contains("prompts_root: ~/.adk/prompts"));
-        assert!(rendered.contains("\"123\""));
-        assert!(rendered.contains("existing:"));
-        assert!(rendered.contains("alpha:"));
-        assert!(rendered.contains("display_name: Alpha"));
-        assert!(rendered.contains("provider: codex"));
-        assert!(rendered.contains("\"555\""));
+        let document: Value = serde_yaml::from_str(&rendered).unwrap();
+        assert_eq!(document["channels"]["by_id"]["123"]["agent"], "existing");
+        assert_eq!(document["agents"]["existing"]["display_name"], "Existing");
+        assert_eq!(document["agents"]["alpha"]["display_name"], "Alpha");
+        assert_eq!(document["agents"]["alpha"]["provider"], "codex");
+        assert_eq!(document["channels"]["by_id"]["555"]["agent"], "alpha");
     }
 }

--- a/src/services/discord/runtime_store.rs
+++ b/src/services/discord/runtime_store.rs
@@ -29,7 +29,11 @@ pub(super) fn role_map_path() -> Option<PathBuf> {
 }
 
 pub(super) fn org_schema_path() -> Option<PathBuf> {
-    agentdesk_root().map(|root| root.join("config").join("org.yaml"))
+    agentdesk_root().map(|root| org_schema_path_for_root(&root))
+}
+
+pub(crate) fn org_schema_path_for_root(root: &Path) -> PathBuf {
+    root.join("config").join("org.yaml")
 }
 
 pub(super) fn discord_uploads_root() -> Option<PathBuf> {

--- a/tests/e2e/smoke_test.rs
+++ b/tests/e2e/smoke_test.rs
@@ -148,6 +148,7 @@ async fn smoke_test_full_lifecycle() {
                 "id": agent_id,
                 "name": "Test Agent",
                 "provider": "claude",
+                "discord_channel_id": "123456789012345678",
             }))
             .send()
             .await


### PR DESCRIPTION
## 목표
- OpenClaw의 durable state를 AgentDesk 런타임으로 가져오는 전용 CLI를 추가합니다.
- source config 해석, agent 선택, prompt/memory/workspace import, Discord/org/bot settings preview, DB/session import를 하나의 migration 흐름으로 묶습니다.
- dry-run, audit 산출물, resume 경로를 함께 제공해 실제 반영 전에 계획을 검토하고 중단된 이관을 재개할 수 있게 합니다.

## 해결한 내용
- `agentdesk migrate openclaw` CLI를 추가하고 `--dry-run`, `--resume`, `--agent`, `--all-agents`, `--fallback-provider`, `--workspace-root-rewrite` 등 migration 제어 플래그를 정의했습니다.
- `src/cli/migrate/source.rs`에서 OpenClaw source root 탐색, JSON5 + `$include` 해석, agent/default agent 해석, Discord/tool policy 스캔을 처리하도록 구현했습니다.
- `src/cli/migrate/plan.rs`에서 import 대상 agent, provider 매핑, workspace/prompt/memory/session/channel-binding 작업 계획과 audit 출력 목록을 canonical plan으로 만들도록 했습니다.
- `src/cli/migrate/apply.rs`에서 prompt/memory/workspace 복사, `org.yaml`/`bot_settings.json` 반영, DB upsert, session import, audit 산출물(`manifest.json`, `write-plan.json`, `apply-result.json`, `resume-state.json` 등) 기록을 처리하도록 추가했습니다.
- `src/services/discord/org_writer.rs`를 추가해 기존 `org.yaml` 섹션을 보존하면서 agent/channel binding을 병합할 수 있게 했습니다.
- `README.md`와 `docs/openclaw-migrate.md`를 추가/보강해 dry-run/apply/resume 흐름, 주요 플래그, audit 출력 경로를 문서화했습니다.

## 추가 보완
- migrated prompt가 원본 OpenClaw workspace만 보지 않고 AgentDesk가 만든 `role-context/<role>.memory/`와 `openclaw/workspaces/<role>/`를 명시적으로 참조하도록 보완했습니다.
- rerun 시 runtime에 이미 있는 `openclaw-<id>` role을 재사용하도록 role id 배정 로직을 안정화했습니다.
- `--resume` 시 audit의 `agent-map.json`을 읽어 source→role 매핑을 그대로 재사용하도록 수정했고, Windows drive-letter workspace 경로도 절대경로로 올바르게 인식하도록 보강했습니다.
- `scripts/deploy-dev.sh`의 `shellcheck` 경고(`SC2155`)를 수정해 CI `Script checks` 실패를 해소했습니다.

## 검증
- `cargo fmt -- --check`
- `cargo check --all-targets`
- `cargo test --all-targets`
- `cargo clippy --all-targets -- -W clippy::all`
- `bash -n scripts/*.sh`

## 참고
- audit 결과는 `$AGENTDESK_ROOT_DIR/openclaw/imports/<import_id>` 아래에 기록됩니다.
- 문서에는 dry-run, apply, resume 예시와 필수 audit 파일 목록을 같이 정리했습니다.
- staging mirror PR: `kunkunGames/AgentDesk#10`