### PR TITLE
fix: unified thread lookup includes paused runs in review notification

### DIFF
--- a/src/server/routes/dispatches/discord_delivery.rs
+++ b/src/server/routes/dispatches/discord_delivery.rs
@@ -813,7 +813,7 @@ pub(super) async fn send_review_result_to_primary(
                 "SELECT r.unified_thread_id, COALESCE(e.thread_group, 0), COALESCE(r.thread_group_count, 1) \
                  FROM auto_queue_runs r \
                  JOIN auto_queue_entries e ON e.run_id = r.id \
-                 WHERE e.kanban_card_id = ?1 AND r.unified_thread = 1 AND r.status = 'active' \
+                 WHERE e.kanban_card_id = ?1 AND r.unified_thread = 1 AND r.status IN ('active', 'paused') \
                  AND r.unified_thread_id IS NOT NULL",
                 [card_id],
                 |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?, row.get::<_, i64>(2)?)),


### PR DESCRIPTION
## Summary
- `send_review_result_to_primary()`의 unified thread lookup이 `status = 'active'`만 체크하여, paused 상태의 auto-queue run에서 review-decision 알림이 통합스레드를 못 찾고 fallback되는 문제 수정
- 같은 파일의 cleanup/update 경로(369-397행)에서 이미 사용 중인 `status IN ('active', 'paused')` 패턴과 일관성 확보

Closes #218

## Test plan
- [x] `cargo build` 성공 (0 errors)
- [x] `unified_thread_parallel_format_parsed_correctly` 통과
- [x] `unified_thread_card_id_fallback_finds_thread` 통과
- [x] `test_dynamic_hook_dispatch_create_produces_db_row` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)