### PR TITLE
feat: unify multiplatform provider binary resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,7 @@ dependencies = [
  "unicode-width",
  "ureq",
  "uuid",
+ "which 8.0.2",
 ]
 
 [[package]]
@@ -258,7 +259,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.117",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -3217,6 +3218,15 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.44",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 anyhow = "1"
 thiserror = "2"
 dirs = "6.0.0"
+which = "8.0.2"
 
 # From RCC — text/formatting
 unicode-width = "0.2"

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -815,14 +815,20 @@ fn check_provider_cli(
     let log_hint = dcserver_log_hint();
     let binary_name = provider.as_str().to_string();
     match provider.probe_runtime() {
-        Some(probe) => match (probe.binary_path, probe.version) {
+        Some(probe) => match (probe.resolution.resolved_path.clone(), probe.version) {
             (Some(path), Some(ver)) => {
                 let health_note = match connected {
                     Some(true) => "health=connected".to_string(),
                     Some(false) => "health=disconnected".to_string(),
                     None => "health=unknown".to_string(),
                 };
-                let detail = format!("{ver} — {path} [{capability_summary}; {health_note}]");
+                let source = probe
+                    .resolution
+                    .source
+                    .as_deref()
+                    .unwrap_or("unknown_source");
+                let detail =
+                    format!("{ver} — {path} [{source}; {capability_summary}; {health_note}]");
 
                 if !configured {
                     Check::warn(
@@ -862,7 +868,18 @@ fn check_provider_cli(
                 }
             }
             (Some(path), None) => {
-                let detail = format!("{path} — version probe failed [{capability_summary}]");
+                let source = probe
+                    .resolution
+                    .source
+                    .as_deref()
+                    .unwrap_or("unknown_source");
+                let probe_failure_kind = probe
+                    .probe_failure_kind
+                    .clone()
+                    .unwrap_or_else(|| "version_probe_failed".to_string());
+                let detail = format!(
+                    "{path} — version probe failed [{source}; {probe_failure_kind}; {capability_summary}]"
+                );
                 if configured {
                     Check::fail(
                         id,
@@ -900,12 +917,17 @@ fn check_provider_cli(
             )
             .with_expected_actual("provider path known", "version known but path unknown"),
             (None, None) => {
+                let failure_kind = probe
+                    .resolution
+                    .failure_kind
+                    .clone()
+                    .unwrap_or_else(|| "not_found".to_string());
                 if configured {
                     Check::fail(
                         id,
                         CheckGroup::ProviderRuntime,
                         name,
-                        format!("not found in runtime PATH [{capability_summary}]"),
+                        format!("not found in runtime PATH [{failure_kind}; {capability_summary}]"),
                         provider_runtime_guidance(&provider),
                     )
                     .with_expected_actual(
@@ -1412,12 +1434,29 @@ pub fn cmd_doctor(fix: bool, json: bool) -> Result<(), String> {
 mod tests {
     use super::{
         Check, CheckGroup, CheckStatus, FixAction, HealthSnapshot, build_json_report,
-        check_server_running, configured_provider_names, discord_bot_check_from_health,
-        provider_capability_summary,
+        check_provider_cli, check_server_running, configured_provider_names,
+        discord_bot_check_from_health, provider_capability_summary,
     };
     use crate::config::ServerConfig;
     use crate::services::provider::ProviderKind;
     use serde_json::json;
+    use std::path::Path;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    fn env_guard() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    #[cfg(unix)]
+    fn write_executable(path: &Path, contents: &str) {
+        use std::os::unix::fs::PermissionsExt;
+
+        std::fs::write(path, contents).unwrap();
+        let mut perms = std::fs::metadata(path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
 
     fn test_base_url() -> String {
         format!(
@@ -1508,6 +1547,91 @@ mod tests {
         let configured = configured_provider_names(&cfg, &snapshot);
         assert!(configured.contains("claude"));
         assert!(configured.contains("codex"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provider_runtime_check_uses_resolver_exec_path_under_minimal_path() {
+        let _guard = env_guard();
+        let temp = tempfile::tempdir().unwrap();
+        let helper = temp.path().join("provider-helper");
+        let provider = temp.path().join("codex");
+        let original_path = std::env::var_os("PATH");
+
+        write_executable(&helper, "#!/bin/sh\nprintf 'codex-test 1.2.3\\n'\n");
+        write_executable(
+            &provider,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  provider-helper\nelse\n  exit 64\nfi\n",
+        );
+
+        unsafe {
+            std::env::set_var("PATH", "/usr/bin:/bin:/usr/sbin:/sbin");
+            std::env::set_var("AGENTDESK_CODEX_PATH", &provider);
+        }
+
+        let snapshot = HealthSnapshot {
+            base: test_base_url(),
+            body: None,
+            error: None,
+        };
+        let check = check_provider_cli(ProviderKind::Codex, true, &snapshot);
+
+        assert_eq!(check.status, CheckStatus::Pass);
+        assert!(check.detail.contains("codex-test 1.2.3"));
+        assert!(check.detail.contains("env_override"));
+        assert_eq!(
+            check.path.as_deref(),
+            Some(provider.to_string_lossy().as_ref())
+        );
+
+        unsafe {
+            std::env::remove_var("AGENTDESK_CODEX_PATH");
+            match original_path {
+                Some(value) => std::env::set_var("PATH", value),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provider_runtime_check_reports_permission_denied() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = env_guard();
+        let temp = tempfile::tempdir().unwrap();
+        let provider = temp.path().join("codex");
+        let original_path = std::env::var_os("PATH");
+
+        std::fs::write(&provider, "#!/bin/sh\nprintf 'codex-test 1.2.3\\n'\n").unwrap();
+        let mut perms = std::fs::metadata(&provider).unwrap().permissions();
+        perms.set_mode(0o644);
+        std::fs::set_permissions(&provider, perms).unwrap();
+
+        unsafe {
+            std::env::set_var("PATH", "/usr/bin:/bin:/usr/sbin:/sbin");
+            std::env::set_var("AGENTDESK_CODEX_PATH", &provider);
+        }
+
+        let snapshot = HealthSnapshot {
+            base: test_base_url(),
+            body: None,
+            error: None,
+        };
+        let check = check_provider_cli(ProviderKind::Codex, true, &snapshot);
+
+        assert_eq!(check.status, CheckStatus::Fail);
+        assert!(check.detail.contains("permission_denied"));
+        assert!(check.detail.contains("not found in runtime PATH"));
+        assert_eq!(check.path.as_deref(), None);
+
+        unsafe {
+            std::env::remove_var("AGENTDESK_CODEX_PATH");
+            match original_path {
+                Some(value) => std::env::set_var("PATH", value),
+                None => std::env::remove_var("PATH"),
+            }
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,6 @@ pub(crate) use cli::agentdesk_runtime_root;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
-use std::path::PathBuf;
 use tracing_subscriber::EnvFilter;
 
 // ── Clap CLI definition ──────────────────────────────────────
@@ -229,11 +228,6 @@ enum Commands {
         #[command(subcommand)]
         action: ConfigAction,
     },
-    /// Migration helpers
-    Migrate {
-        #[command(subcommand)]
-        action: MigrateAction,
-    },
     /// Call any API endpoint (curl replacement)
     Api {
         /// HTTP method (GET, POST, PATCH, PUT, DELETE)
@@ -293,19 +287,6 @@ enum ConfigAction {
     Set {
         /// JSON value to set
         json: String,
-    },
-}
-
-#[derive(Subcommand)]
-enum MigrateAction {
-    /// Export OpenClaw env files and runtime secrets into the AgentDesk release root
-    Openclaw {
-        /// Source path (`openclaw.json`, OpenClaw config dir, or OpenClaw repo root)
-        #[arg(long)]
-        source: Option<PathBuf>,
-        /// Override AgentDesk runtime root (defaults to `~/.adk/release`)
-        #[arg(long)]
-        runtime_root: Option<PathBuf>,
     },
 }
 
@@ -522,14 +503,6 @@ fn main() -> Result<()> {
                 return exit_for_cli(match action {
                     ConfigAction::Get => cli::client::cmd_config_get(),
                     ConfigAction::Set { json } => cli::client::cmd_config_set(&json),
-                });
-            }
-            Some(Commands::Migrate { action }) => {
-                return exit_for_cli(match action {
-                    MigrateAction::Openclaw {
-                        source,
-                        runtime_root,
-                    } => cli::handle_migrate_openclaw(source, runtime_root),
                 });
             }
             Some(Commands::Api { method, path, body }) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ pub(crate) use cli::agentdesk_runtime_root;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
+use std::path::PathBuf;
 use tracing_subscriber::EnvFilter;
 
 // ── Clap CLI definition ──────────────────────────────────────
@@ -51,7 +52,7 @@ enum Commands {
         /// Discord channel ID for restart completion report
         #[arg(long)]
         report_channel_id: Option<u64>,
-        /// Provider for restart report (claude, codex, or gemini)
+        /// Provider for restart report (claude, codex, gemini, or qwen)
         #[arg(long, value_enum)]
         report_provider: Option<ReportProvider>,
         /// Existing message ID to edit for restart report
@@ -228,6 +229,11 @@ enum Commands {
         #[command(subcommand)]
         action: ConfigAction,
     },
+    /// Migration helpers
+    Migrate {
+        #[command(subcommand)]
+        action: MigrateAction,
+    },
     /// Call any API endpoint (curl replacement)
     Api {
         /// HTTP method (GET, POST, PATCH, PUT, DELETE)
@@ -290,10 +296,25 @@ enum ConfigAction {
     },
 }
 
+#[derive(Subcommand)]
+enum MigrateAction {
+    /// Export OpenClaw env files and runtime secrets into the AgentDesk release root
+    Openclaw {
+        /// Source path (`openclaw.json`, OpenClaw config dir, or OpenClaw repo root)
+        #[arg(long)]
+        source: Option<PathBuf>,
+        /// Override AgentDesk runtime root (defaults to `~/.adk/release`)
+        #[arg(long)]
+        runtime_root: Option<PathBuf>,
+    },
+}
+
 #[derive(Clone, ValueEnum)]
 enum ReportProvider {
     Claude,
     Codex,
+    Gemini,
+    Qwen,
 }
 
 #[derive(Clone, ValueEnum)]
@@ -503,6 +524,14 @@ fn main() -> Result<()> {
                     ConfigAction::Set { json } => cli::client::cmd_config_set(&json),
                 });
             }
+            Some(Commands::Migrate { action }) => {
+                return exit_for_cli(match action {
+                    MigrateAction::Openclaw {
+                        source,
+                        runtime_root,
+                    } => cli::handle_migrate_openclaw(source, runtime_root),
+                });
+            }
             Some(Commands::Api { method, path, body }) => {
                 return exit_for_cli(cli::client::cmd_api(&method, &path, body.as_deref()));
             }
@@ -610,6 +639,8 @@ fn build_restart_report_context(
             let provider = match provider_arg {
                 ReportProvider::Claude => ProviderKind::Claude,
                 ReportProvider::Codex => ProviderKind::Codex,
+                ReportProvider::Gemini => ProviderKind::Gemini,
+                ReportProvider::Qwen => ProviderKind::Qwen,
             };
             Ok(Some(RestartReportContext {
                 provider,

--- a/src/server/routes/onboarding.rs
+++ b/src/server/routes/onboarding.rs
@@ -889,17 +889,20 @@ pub async fn check_provider(
     }
 
     // Check login (heuristic: config directory exists with content)
-    let home = std::env::var("HOME").unwrap_or_default();
-    let config_dir = if cmd == "claude" {
-        format!("{home}/.claude")
-    } else if cmd == "codex" {
-        format!("{home}/.codex")
-    } else if cmd == "qwen" {
-        format!("{home}/.qwen")
-    } else {
-        format!("{home}/.gemini")
-    };
-    let logged_in = std::path::Path::new(&config_dir).is_dir();
+    let logged_in = dirs::home_dir()
+        .map(|home| {
+            let config_dir = if cmd == "claude" {
+                home.join(".claude")
+            } else if cmd == "codex" {
+                home.join(".codex")
+            } else if cmd == "qwen" {
+                home.join(".qwen")
+            } else {
+                home.join(".gemini")
+            };
+            config_dir.is_dir()
+        })
+        .unwrap_or(false);
 
     (
         StatusCode::OK,

--- a/src/server/routes/onboarding.rs
+++ b/src/server/routes/onboarding.rs
@@ -652,6 +652,23 @@ pub async fn complete(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    fn env_guard() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    #[cfg(unix)]
+    fn write_executable(path: &Path, contents: &str) {
+        use std::os::unix::fs::PermissionsExt;
+
+        std::fs::write(path, contents).unwrap();
+        let mut perms = std::fs::metadata(path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
 
     #[test]
     fn strip_legacy_discord_section_removes_top_level_block() {
@@ -701,6 +718,99 @@ mod tests {
             "notify-token\n"
         );
     }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn check_provider_uses_resolver_exec_path_under_minimal_path() {
+        let _guard = env_guard();
+        let temp = tempfile::tempdir().unwrap();
+        let helper = temp.path().join("provider-helper");
+        let provider = temp.path().join("claude");
+        let original_path = std::env::var_os("PATH");
+        let original_home = std::env::var_os("HOME");
+
+        write_executable(&helper, "#!/bin/sh\nprintf 'claude-test 9.9.9\\n'\n");
+        write_executable(
+            &provider,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  provider-helper\nelse\n  exit 64\nfi\n",
+        );
+
+        unsafe {
+            std::env::set_var("PATH", "/usr/bin:/bin:/usr/sbin:/sbin");
+            std::env::set_var("HOME", temp.path());
+            std::env::set_var("AGENTDESK_CLAUDE_PATH", &provider);
+        }
+
+        let (status, Json(body)) = check_provider(Json(CheckProviderBody {
+            provider: "claude".to_string(),
+        }))
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["installed"], json!(true));
+        assert_eq!(body["logged_in"], json!(false));
+        assert_eq!(body["version"], json!("claude-test 9.9.9"));
+        assert_eq!(body["source"], json!("env_override"));
+        assert_eq!(body["path"], json!(provider.to_string_lossy().to_string()));
+
+        unsafe {
+            std::env::remove_var("AGENTDESK_CLAUDE_PATH");
+            match original_path {
+                Some(value) => std::env::set_var("PATH", value),
+                None => std::env::remove_var("PATH"),
+            }
+            match original_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn check_provider_reports_permission_denied() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = env_guard();
+        let temp = tempfile::tempdir().unwrap();
+        let provider = temp.path().join("claude");
+        let original_path = std::env::var_os("PATH");
+        let original_home = std::env::var_os("HOME");
+
+        std::fs::write(&provider, "#!/bin/sh\nprintf 'claude-test 9.9.9\\n'\n").unwrap();
+        let mut perms = std::fs::metadata(&provider).unwrap().permissions();
+        perms.set_mode(0o644);
+        std::fs::set_permissions(&provider, perms).unwrap();
+
+        unsafe {
+            std::env::set_var("PATH", "/usr/bin:/bin:/usr/sbin:/sbin");
+            std::env::set_var("HOME", temp.path());
+            std::env::set_var("AGENTDESK_CLAUDE_PATH", &provider);
+        }
+
+        let (status, Json(body)) = check_provider(Json(CheckProviderBody {
+            provider: "claude".to_string(),
+        }))
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["installed"], json!(false));
+        assert_eq!(body["version"], json!(null));
+        assert_eq!(body["failure_kind"], json!("permission_denied"));
+        assert_eq!(body["path"], json!(null));
+
+        unsafe {
+            std::env::remove_var("AGENTDESK_CLAUDE_PATH");
+            match original_path {
+                Some(value) => std::env::set_var("PATH", value),
+                None => std::env::remove_var("PATH"),
+            }
+            match original_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
 }
 
 // ── Provider Check ──────────────────────────────────────────
@@ -731,60 +841,65 @@ pub async fn check_provider(
     // Resolve binary using the exact same provider-specific resolver as the runtime,
     // including known-path fallbacks (~/bin, /opt/homebrew/bin, etc.).
     // This ensures onboarding and actual launch always agree on availability.
-    let resolved_path = {
+    let resolution = {
         let provider = cmd.to_string();
         tokio::task::spawn_blocking(move || match provider.as_str() {
-            "claude" => crate::services::claude::resolve_claude_path(),
-            "codex" => crate::services::codex::resolve_codex_path(),
-            "gemini" => crate::services::gemini::resolve_gemini_path(),
-            "qwen" => crate::services::qwen::resolve_qwen_path(),
+            "claude" | "codex" | "gemini" | "qwen" => Some(
+                crate::services::platform::resolve_provider_binary(&provider),
+            ),
             _ => None,
         })
         .await
         .ok()
         .flatten()
-    };
+    }
+    .unwrap_or_else(|| crate::services::platform::resolve_provider_binary(cmd));
+    let mut failure_kind = resolution.failure_kind.clone();
 
-    let Some(bin_path) = resolved_path else {
+    let Some(bin_path) = resolution.resolved_path.clone() else {
         return (
             StatusCode::OK,
             Json(json!({
                 "installed": false,
                 "logged_in": false,
                 "version": null,
+                "path": null,
+                "canonical_path": null,
+                "source": null,
+                "failure_kind": resolution.failure_kind,
+                "attempts": resolution.attempts,
             })),
         );
     };
 
     // Get version using the resolved binary path (not bare command name)
     // so it works even when PATH doesn't contain the provider.
-    let version_out = tokio::process::Command::new(&bin_path)
-        .arg("--version")
-        .output()
-        .await;
-    let version = version_out.ok().and_then(|o| {
-        if o.status.success() {
-            Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
-        } else {
-            None
-        }
-    });
+    let (version, probe_failure_kind) = {
+        let resolution = resolution.clone();
+        let bin_path = bin_path.clone();
+        tokio::task::spawn_blocking(move || {
+            crate::services::platform::probe_resolved_binary_version(&bin_path, &resolution)
+        })
+        .await
+        .ok()
+        .unwrap_or((None, Some("version_probe_spawn_failed".to_string())))
+    };
+    if failure_kind.is_none() {
+        failure_kind = probe_failure_kind.clone();
+    }
 
     // Check login (heuristic: config directory exists with content)
-    let logged_in = dirs::home_dir()
-        .map(|home| {
-            let config_dir = if cmd == "claude" {
-                home.join(".claude")
-            } else if cmd == "codex" {
-                home.join(".codex")
-            } else if cmd == "qwen" {
-                home.join(".qwen")
-            } else {
-                home.join(".gemini")
-            };
-            config_dir.is_dir()
-        })
-        .unwrap_or(false);
+    let home = std::env::var("HOME").unwrap_or_default();
+    let config_dir = if cmd == "claude" {
+        format!("{home}/.claude")
+    } else if cmd == "codex" {
+        format!("{home}/.codex")
+    } else if cmd == "qwen" {
+        format!("{home}/.qwen")
+    } else {
+        format!("{home}/.gemini")
+    };
+    let logged_in = std::path::Path::new(&config_dir).is_dir();
 
     (
         StatusCode::OK,
@@ -792,6 +907,11 @@ pub async fn check_provider(
             "installed": true,
             "logged_in": logged_in,
             "version": version,
+            "path": resolution.resolved_path,
+            "canonical_path": resolution.canonical_path,
+            "source": resolution.source,
+            "failure_kind": failure_kind,
+            "attempts": resolution.attempts,
         })),
     )
 }

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -2568,12 +2568,14 @@ fn execute_streaming_remote_tmux(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use crate::services::discord::restart_report::{
         RESTART_REPORT_CHANNEL_ENV, RESTART_REPORT_PROVIDER_ENV,
     };
 
     // ========== is_valid_session_id tests ==========
 
+    #[cfg(unix)]
     #[test]
     fn test_tmux_launch_env_lines_include_exec_path_and_report_envs() {
         let env_lines = build_tmux_launch_env_lines(

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -16,46 +16,58 @@ use crate::services::tmux_diagnostics::{
     record_tmux_exit_reason, should_recreate_session_after_followup_fifo_error,
     tmux_session_exists, tmux_session_has_live_pane,
 };
-/// Cached path to the claude binary.
-/// Once resolved, reused for all subsequent calls.
-static CLAUDE_PATH: OnceLock<Option<String>> = OnceLock::new();
+use crate::utils::format::safe_prefix;
 
 /// Resolve the path to the claude binary.
-/// Uses platform::resolve_binary_with_login_shell, then falls back to known paths.
-/// Public so onboarding/health-check can use the exact same resolution contract.
 pub fn resolve_claude_path() -> Option<String> {
-    // Try platform-aware binary resolution (which/where + login shell fallback)
-    if let Some(path) = crate::services::platform::resolve_binary_with_login_shell("claude") {
-        return Some(path);
-    }
-
-    // Fallback: check known installation paths
-    let home = dirs::home_dir().unwrap_or_default();
-    let mut known_paths = vec![home.join(".local/bin/claude"), home.join("bin/claude")];
-    #[cfg(unix)]
-    {
-        known_paths.push(std::path::PathBuf::from("/usr/local/bin/claude"));
-        known_paths.push(std::path::PathBuf::from("/opt/homebrew/bin/claude"));
-    }
-    #[cfg(windows)]
-    {
-        known_paths.push(home.join("AppData/Local/Programs/claude/claude.exe"));
-        known_paths.push(std::path::PathBuf::from(
-            "C:/Program Files/claude/claude.exe",
-        ));
-    }
-    for path in &known_paths {
-        if path.is_file() {
-            return Some(path.display().to_string());
-        }
-    }
-
-    None
+    crate::services::platform::resolve_provider_binary("claude").resolved_path
 }
 
-/// Get the cached claude binary path, resolving it on first call.
-fn get_claude_path() -> Option<&'static str> {
-    CLAUDE_PATH.get_or_init(|| resolve_claude_path()).as_deref()
+fn resolve_claude_binary() -> crate::services::platform::BinaryResolution {
+    crate::services::platform::resolve_provider_binary("claude")
+}
+
+fn get_claude_path() -> Option<String> {
+    resolve_claude_path()
+}
+
+#[cfg(unix)]
+fn build_tmux_launch_env_lines(
+    exec_path: Option<&str>,
+    report_channel_id: Option<u64>,
+    report_provider: Option<ProviderKind>,
+) -> String {
+    let mut env_lines = String::from("unset CLAUDECODE\n");
+    if let Some(exec_path) = exec_path {
+        env_lines.push_str(&format!(
+            "export PATH='{}'\n",
+            exec_path.replace('\'', "'\\''")
+        ));
+    }
+    if let Ok(root_dir) = std::env::var("AGENTDESK_ROOT_DIR") {
+        let trimmed = root_dir.trim();
+        if !trimmed.is_empty() {
+            env_lines.push_str(&format!(
+                "export AGENTDESK_ROOT_DIR='{}'\n",
+                trimmed.replace('\'', "'\\''")
+            ));
+        }
+    }
+    if let Some(channel_id) = report_channel_id {
+        env_lines.push_str(&format!(
+            "export {}={}\n",
+            RESTART_REPORT_CHANNEL_ENV, channel_id
+        ));
+    }
+    if let Some(provider) = report_provider {
+        env_lines.push_str(&format!(
+            "export {}={}\n",
+            RESTART_REPORT_PROVIDER_ENV,
+            provider.as_str()
+        ));
+    }
+
+    env_lines
 }
 
 #[cfg(unix)]
@@ -417,7 +429,8 @@ IMPORTANT: Format your responses using Markdown for better readability:
         args.push(sid.to_string());
     }
 
-    let claude_bin = match get_claude_path() {
+    let resolution = resolve_claude_binary();
+    let claude_bin = match resolution.resolved_path.clone() {
         Some(path) => path,
         None => {
             return ClaudeResponse {
@@ -429,8 +442,8 @@ IMPORTANT: Format your responses using Markdown for better readability:
         }
     };
 
-    let mut bootstrap = Command::new(claude_bin);
-    crate::services::platform::apply_runtime_path(&mut bootstrap);
+    let mut bootstrap = Command::new(&claude_bin);
+    crate::services::platform::apply_binary_resolution(&mut bootstrap, &resolution);
     let mut child = match bootstrap
         .args(&args)
         .current_dir(working_dir)
@@ -555,10 +568,14 @@ pub fn is_ai_supported() -> bool {
 /// Used for short synchronous tasks like meeting participant selection.
 /// This is a blocking function — call from tokio::task::spawn_blocking.
 pub fn execute_command_simple(prompt: &str) -> Result<String, String> {
-    let claude_bin = get_claude_path().ok_or("Claude CLI not found")?;
+    let resolution = resolve_claude_binary();
+    let claude_bin = resolution
+        .resolved_path
+        .clone()
+        .ok_or("Claude CLI not found")?;
 
-    let mut command = Command::new(claude_bin);
-    crate::services::platform::apply_runtime_path(&mut command);
+    let mut command = Command::new(&claude_bin);
+    crate::services::platform::apply_binary_resolution(&mut command, &resolution);
     let mut child = command
         .args(["-p", "--output-format", "text"])
         .env("CLAUDE_CODE_MAX_OUTPUT_TOKENS", "4096")
@@ -761,7 +778,8 @@ IMPORTANT: Format your responses using Markdown for better readability:
         return execute_streaming_remote(profile, &args, prompt, working_dir, sender, cancel_token);
     }
 
-    let claude_bin = get_claude_path().ok_or_else(|| {
+    let resolution = resolve_claude_binary();
+    let claude_bin = resolution.resolved_path.clone().ok_or_else(|| {
         debug_log("ERROR: Claude CLI not found");
         "Claude CLI not found. Is Claude CLI installed?".to_string()
     })?;
@@ -786,8 +804,8 @@ IMPORTANT: Format your responses using Markdown for better readability:
     debug_log("Env: BASH_MAX_TIMEOUT_MS=86400000");
 
     let spawn_start = std::time::Instant::now();
-    let mut command = Command::new(claude_bin);
-    crate::services::platform::apply_runtime_path(&mut command);
+    let mut command = Command::new(&claude_bin);
+    crate::services::platform::apply_binary_resolution(&mut command, &resolution);
     command
         .args(&args)
         .current_dir(working_dir)
@@ -1745,7 +1763,11 @@ fn execute_streaming_local_tmux(
     // Get paths
     let exe =
         std::env::current_exe().map_err(|e| format!("Failed to get executable path: {}", e))?;
-    let claude_bin = get_claude_path().ok_or_else(|| "Claude CLI not found".to_string())?;
+    let resolution = resolve_claude_binary();
+    let claude_bin = resolution
+        .resolved_path
+        .clone()
+        .ok_or_else(|| "Claude CLI not found".to_string())?;
 
     // Build wrapper command via script file to avoid tmux "command too long" errors.
     // The system prompt in --append-system-prompt can be thousands of chars, exceeding
@@ -1753,29 +1775,11 @@ fn execute_streaming_local_tmux(
     let escaped_args: Vec<String> = args.iter().map(|a| shell_escape(a)).collect();
     let script_path = crate::services::tmux_common::session_temp_path(tmux_session_name, "sh");
 
-    let mut env_lines = String::from("unset CLAUDECODE\n");
-    if let Ok(root_dir) = std::env::var("AGENTDESK_ROOT_DIR") {
-        let trimmed = root_dir.trim();
-        if !trimmed.is_empty() {
-            env_lines.push_str(&format!(
-                "export AGENTDESK_ROOT_DIR='{}'\n",
-                trimmed.replace('\'', "'\\''")
-            ));
-        }
-    }
-    if let Some(channel_id) = report_channel_id {
-        env_lines.push_str(&format!(
-            "export {}={}\n",
-            RESTART_REPORT_CHANNEL_ENV, channel_id
-        ));
-    }
-    if let Some(provider) = report_provider {
-        env_lines.push_str(&format!(
-            "export {}={}\n",
-            RESTART_REPORT_PROVIDER_ENV,
-            provider.as_str()
-        ));
-    }
+    let env_lines = build_tmux_launch_env_lines(
+        resolution.exec_path.as_deref(),
+        report_channel_id,
+        report_provider,
+    );
 
     let script_content = format!(
         "#!/bin/bash\n\
@@ -1792,7 +1796,7 @@ fn execute_streaming_local_tmux(
         input_fifo = shell_escape(&input_fifo_path),
         prompt = shell_escape(&prompt_path),
         wd = shell_escape(working_dir),
-        claude_bin = claude_bin,
+        claude_bin = shell_escape(&claude_bin),
         claude_args = escaped_args.join(" "),
     );
 
@@ -2366,7 +2370,11 @@ pub(crate) fn execute_streaming_local_process(
 
     // Build wrapper args — no shell_escape here because ProcessBackend uses
     // Command::new().args() (direct argv), not a shell script.
-    let claude_bin = get_claude_path().ok_or_else(|| "Claude CLI not found".to_string())?;
+    let resolution = resolve_claude_binary();
+    let claude_bin = resolution
+        .resolved_path
+        .clone()
+        .ok_or_else(|| "Claude CLI not found".to_string())?;
     let mut wrapper_args: Vec<String> = vec!["--".to_string(), claude_bin.to_string()];
     wrapper_args.extend(args.iter().map(|a| a.to_string()));
 
@@ -2381,7 +2389,11 @@ pub(crate) fn execute_streaming_local_process(
         prompt_path: prompt_path.clone(),
         wrapper_subcommand: "tmux-wrapper".to_string(),
         wrapper_args,
-        env_vars: vec![],
+        env_vars: resolution
+            .exec_path
+            .clone()
+            .map(|path| vec![("PATH".to_string(), path)])
+            .unwrap_or_default(),
     };
 
     let backend = ProcessBackend::new();
@@ -2556,8 +2568,25 @@ fn execute_streaming_remote_tmux(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::services::discord::restart_report::{
+        RESTART_REPORT_CHANNEL_ENV, RESTART_REPORT_PROVIDER_ENV,
+    };
 
     // ========== is_valid_session_id tests ==========
+
+    #[test]
+    fn test_tmux_launch_env_lines_include_exec_path_and_report_envs() {
+        let env_lines = build_tmux_launch_env_lines(
+            Some("/tmp/provider:/usr/bin"),
+            Some(7),
+            Some(ProviderKind::Claude),
+        );
+
+        assert!(env_lines.contains("unset CLAUDECODE"));
+        assert!(env_lines.contains("export PATH='/tmp/provider:/usr/bin'"));
+        assert!(env_lines.contains(&format!("export {}=7", RESTART_REPORT_CHANNEL_ENV)));
+        assert!(env_lines.contains(&format!("export {}=claude", RESTART_REPORT_PROVIDER_ENV)));
+    }
 
     #[test]
     fn test_session_id_valid() {

--- a/src/services/codex.rs
+++ b/src/services/codex.rs
@@ -971,18 +971,22 @@ mod tests {
     use std::sync::mpsc;
 
     #[cfg(unix)]
+    use super::build_tmux_launch_env_lines;
+    #[cfg(unix)]
     use super::send_followup_to_tmux;
     use super::{
-        TMUX_PROMPT_B64_PREFIX, base_exec_args, build_tmux_launch_env_lines, compose_codex_prompt,
-        handle_codex_json_line,
+        TMUX_PROMPT_B64_PREFIX, base_exec_args, compose_codex_prompt, handle_codex_json_line,
     };
-    use crate::services::claude::StreamMessage;
+    #[cfg(unix)]
     use crate::services::discord::restart_report::{
         RESTART_REPORT_CHANNEL_ENV, RESTART_REPORT_PROVIDER_ENV,
     };
+    #[cfg(unix)]
     use crate::services::provider::ProviderKind;
+    use crate::services::claude::StreamMessage;
     use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 
+    #[cfg(unix)]
     #[test]
     fn test_tmux_launch_env_lines_include_exec_path_and_report_envs() {
         let env_lines = build_tmux_launch_env_lines(

--- a/src/services/codex.rs
+++ b/src/services/codex.rs
@@ -977,13 +977,13 @@ mod tests {
     use super::{
         TMUX_PROMPT_B64_PREFIX, base_exec_args, compose_codex_prompt, handle_codex_json_line,
     };
+    use crate::services::claude::StreamMessage;
     #[cfg(unix)]
     use crate::services::discord::restart_report::{
         RESTART_REPORT_CHANNEL_ENV, RESTART_REPORT_PROVIDER_ENV,
     };
     #[cfg(unix)]
     use crate::services::provider::ProviderKind;
-    use crate::services::claude::StreamMessage;
     use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 
     #[cfg(unix)]

--- a/src/services/codex.rs
+++ b/src/services/codex.rs
@@ -3,7 +3,6 @@ use serde_json::Value;
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
-use std::sync::OnceLock;
 use std::sync::mpsc::Sender;
 
 use crate::services::claude::{
@@ -21,28 +20,74 @@ use crate::services::tmux_diagnostics::{
     tmux_session_exists, tmux_session_has_live_pane,
 };
 
-static CODEX_PATH: OnceLock<Option<String>> = OnceLock::new();
 const TMUX_PROMPT_B64_PREFIX: &str = "__AGENTDESK_B64__:";
 
 /// Public so onboarding/health-check can use the exact same resolution contract.
 pub fn resolve_codex_path() -> Option<String> {
-    crate::services::platform::resolve_binary_with_login_shell("codex")
+    crate::services::platform::resolve_provider_binary("codex").resolved_path
 }
 
-fn get_codex_path() -> Option<&'static str> {
-    CODEX_PATH.get_or_init(resolve_codex_path).as_deref()
+fn resolve_codex_binary() -> crate::services::platform::BinaryResolution {
+    crate::services::platform::resolve_provider_binary("codex")
+}
+
+fn get_codex_path() -> Option<String> {
+    resolve_codex_path()
+}
+
+#[cfg(unix)]
+fn build_tmux_launch_env_lines(
+    exec_path: Option<&str>,
+    report_channel_id: Option<u64>,
+    report_provider: Option<ProviderKind>,
+) -> String {
+    let mut env_lines = String::from("unset CLAUDECODE\n");
+    if let Some(exec_path) = exec_path {
+        env_lines.push_str(&format!(
+            "export PATH='{}'\n",
+            exec_path.replace('\'', "'\\''")
+        ));
+    }
+    if let Ok(root_dir) = std::env::var("AGENTDESK_ROOT_DIR") {
+        let trimmed = root_dir.trim();
+        if !trimmed.is_empty() {
+            env_lines.push_str(&format!(
+                "export AGENTDESK_ROOT_DIR='{}'\n",
+                trimmed.replace('\'', "'\\''")
+            ));
+        }
+    }
+    if let Some(channel_id) = report_channel_id {
+        env_lines.push_str(&format!(
+            "export {}={}\n",
+            RESTART_REPORT_CHANNEL_ENV, channel_id
+        ));
+    }
+    if let Some(provider) = report_provider {
+        env_lines.push_str(&format!(
+            "export {}={}\n",
+            RESTART_REPORT_PROVIDER_ENV,
+            provider.as_str()
+        ));
+    }
+
+    env_lines
 }
 
 #[cfg(unix)]
 use crate::services::tmux_common::{tmux_exact_target, tmux_owner_path, write_tmux_owner_marker};
 
 pub fn execute_command_simple(prompt: &str) -> Result<String, String> {
-    let codex_bin = get_codex_path().ok_or_else(|| "Codex CLI not found".to_string())?;
+    let resolution = resolve_codex_binary();
+    let codex_bin = resolution
+        .resolved_path
+        .clone()
+        .ok_or_else(|| "Codex CLI not found".to_string())?;
     let args = base_exec_args(None, prompt, None);
     let working_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
-    let mut command = Command::new(codex_bin);
-    crate::services::platform::apply_runtime_path(&mut command);
+    let mut command = Command::new(&codex_bin);
+    crate::services::platform::apply_binary_resolution(&mut command, &resolution);
     let output = command
         .args(&args)
         .current_dir(working_dir)
@@ -232,11 +277,15 @@ fn execute_streaming_direct(
     report_channel_id: Option<u64>,
     report_provider: Option<ProviderKind>,
 ) -> Result<(), String> {
-    let codex_bin = get_codex_path().ok_or_else(|| "Codex CLI not found".to_string())?;
+    let resolution = resolve_codex_binary();
+    let codex_bin = resolution
+        .resolved_path
+        .clone()
+        .ok_or_else(|| "Codex CLI not found".to_string())?;
     let args = base_exec_args(session_id, prompt, model);
 
-    let mut command = Command::new(codex_bin);
-    crate::services::platform::apply_runtime_path(&mut command);
+    let mut command = Command::new(&codex_bin);
+    crate::services::platform::apply_binary_resolution(&mut command, &resolution);
     command
         .args(&args)
         .current_dir(working_dir)
@@ -434,52 +483,20 @@ fn execute_streaming_local_tmux(
 
     let exe =
         std::env::current_exe().map_err(|e| format!("Failed to get executable path: {}", e))?;
-    let codex_bin = get_codex_path().ok_or_else(|| "Codex CLI not found".to_string())?;
+    let resolution = resolve_codex_binary();
+    let codex_bin = resolution
+        .resolved_path
+        .clone()
+        .ok_or_else(|| "Codex CLI not found".to_string())?;
 
     // Write launch script to file to avoid tmux "command too long" errors
     let script_path = crate::services::tmux_common::session_temp_path(tmux_session_name, "sh");
 
-    let mut env_lines = String::from("unset CLAUDECODE\n");
-    // Build a PATH that includes the codex binary's parent directory.
-    // Codex is a `#!/usr/bin/env node` script, so `node` must be in PATH.
-    // When launchd spawns the server, PATH is minimal (/usr/bin:/bin:…)
-    // and lacks Homebrew paths, so we explicitly prepend them.
-    {
-        let mut path = std::env::var("PATH").unwrap_or_default();
-        if let Some(codex_dir) = std::path::Path::new(codex_bin).parent() {
-            let dir = codex_dir.to_string_lossy();
-            if !path.split(':').any(|p| p == dir.as_ref()) {
-                path = format!("{}:{}", dir, path);
-            }
-        }
-        // Also ensure /opt/homebrew/bin is present (common node location on Apple Silicon)
-        if !path.split(':').any(|p| p == "/opt/homebrew/bin") {
-            path = format!("/opt/homebrew/bin:{}", path);
-        }
-        env_lines.push_str(&format!("export PATH='{}'\n", path.replace('\'', "'\\''")));
-    }
-    if let Ok(root_dir) = std::env::var("AGENTDESK_ROOT_DIR") {
-        let trimmed = root_dir.trim();
-        if !trimmed.is_empty() {
-            env_lines.push_str(&format!(
-                "export AGENTDESK_ROOT_DIR='{}'\n",
-                trimmed.replace('\'', "'\\''")
-            ));
-        }
-    }
-    if let Some(channel_id) = report_channel_id {
-        env_lines.push_str(&format!(
-            "export {}={}\n",
-            RESTART_REPORT_CHANNEL_ENV, channel_id
-        ));
-    }
-    if let Some(provider) = report_provider {
-        env_lines.push_str(&format!(
-            "export {}={}\n",
-            RESTART_REPORT_PROVIDER_ENV,
-            provider.as_str()
-        ));
-    }
+    let env_lines = build_tmux_launch_env_lines(
+        resolution.exec_path.as_deref(),
+        report_channel_id,
+        report_provider,
+    );
 
     let script_content = format!(
         "#!/bin/bash\n\
@@ -496,7 +513,7 @@ fn execute_streaming_local_tmux(
         input_fifo = shell_escape(&input_fifo_path),
         prompt = shell_escape(&prompt_path),
         wd = shell_escape(working_dir),
-        codex_bin = shell_escape(codex_bin),
+        codex_bin = shell_escape(&codex_bin),
         model_arg = model
             .map(str::trim)
             .filter(|value| !value.is_empty())
@@ -719,7 +736,11 @@ fn execute_streaming_local_process_codex(
     std::fs::write(&prompt_path, prompt)
         .map_err(|e| format!("Failed to write prompt file: {}", e))?;
 
-    let codex_bin = get_codex_path().ok_or_else(|| "Codex CLI not found".to_string())?;
+    let resolution = resolve_codex_binary();
+    let codex_bin = resolution
+        .resolved_path
+        .clone()
+        .ok_or_else(|| "Codex CLI not found".to_string())?;
     let exe =
         std::env::current_exe().map_err(|e| format!("Failed to get executable path: {}", e))?;
 
@@ -744,7 +765,11 @@ fn execute_streaming_local_process_codex(
             }
             args
         },
-        env_vars: vec![],
+        env_vars: resolution
+            .exec_path
+            .clone()
+            .map(|path| vec![("PATH".to_string(), path)])
+            .unwrap_or_default(),
     };
 
     let backend = ProcessBackend::new();
@@ -948,10 +973,29 @@ mod tests {
     #[cfg(unix)]
     use super::send_followup_to_tmux;
     use super::{
-        TMUX_PROMPT_B64_PREFIX, base_exec_args, compose_codex_prompt, handle_codex_json_line,
+        TMUX_PROMPT_B64_PREFIX, base_exec_args, build_tmux_launch_env_lines, compose_codex_prompt,
+        handle_codex_json_line,
     };
     use crate::services::claude::StreamMessage;
+    use crate::services::discord::restart_report::{
+        RESTART_REPORT_CHANNEL_ENV, RESTART_REPORT_PROVIDER_ENV,
+    };
+    use crate::services::provider::ProviderKind;
     use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
+
+    #[test]
+    fn test_tmux_launch_env_lines_include_exec_path_and_report_envs() {
+        let env_lines = build_tmux_launch_env_lines(
+            Some("/tmp/provider:/usr/bin"),
+            Some(42),
+            Some(ProviderKind::Codex),
+        );
+
+        assert!(env_lines.contains("unset CLAUDECODE"));
+        assert!(env_lines.contains("export PATH='/tmp/provider:/usr/bin'"));
+        assert!(env_lines.contains(&format!("export {}=42", RESTART_REPORT_CHANNEL_ENV)));
+        assert!(env_lines.contains(&format!("export {}=codex", RESTART_REPORT_PROVIDER_ENV)));
+    }
 
     #[test]
     fn test_handle_codex_json_line_maps_thread_and_turn_completion() {

--- a/src/services/codex_tmux_wrapper.rs
+++ b/src/services/codex_tmux_wrapper.rs
@@ -234,23 +234,8 @@ fn run_turn(
         prompt.to_string(),
     ]);
 
-    // Ensure node is discoverable: codex is a `#!/usr/bin/env node` script.
-    // Prepend the codex binary's parent dir and /opt/homebrew/bin to PATH
-    // so `env` can find `node` even when launched from launchd (minimal PATH).
     let mut cmd = Command::new(codex_bin);
-    {
-        let mut path = std::env::var("PATH").unwrap_or_default();
-        if let Some(parent) = std::path::Path::new(codex_bin).parent() {
-            let dir = parent.to_string_lossy();
-            if !path.split(':').any(|p| p == dir.as_ref()) {
-                path = format!("{}:{}", dir, path);
-            }
-        }
-        if !path.split(':').any(|p| p == "/opt/homebrew/bin") {
-            path = format!("/opt/homebrew/bin:{}", path);
-        }
-        cmd.env("PATH", &path);
-    }
+    crate::services::platform::augment_exec_path(&mut cmd, codex_bin);
     let mut child = cmd
         .args(&args)
         .current_dir(working_dir)

--- a/src/services/gemini.rs
+++ b/src/services/gemini.rs
@@ -3,52 +3,35 @@ use std::io::{BufRead, BufReader, Read};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::Arc;
-use std::sync::OnceLock;
 use std::sync::mpsc::Sender;
 
 use crate::services::claude::{self, CancelToken, StreamMessage};
 use crate::services::provider::ProviderKind;
 use crate::services::remote::RemoteProfile;
 
-static GEMINI_PATH: OnceLock<Option<String>> = OnceLock::new();
 pub const DEFAULT_GEMINI_MODEL: &str = "gemini-2.5-flash";
 
 pub fn resolve_gemini_path() -> Option<String> {
-    if let Some(path) = crate::services::platform::resolve_binary_with_login_shell("gemini") {
-        return Some(path);
-    }
-
-    let home = dirs::home_dir().unwrap_or_default();
-    let mut known_paths = vec![home.join(".local/bin/gemini"), home.join("bin/gemini")];
-    #[cfg(unix)]
-    {
-        known_paths.push(PathBuf::from("/usr/local/bin/gemini"));
-        known_paths.push(PathBuf::from("/opt/homebrew/bin/gemini"));
-    }
-    #[cfg(windows)]
-    {
-        known_paths.push(home.join("AppData/Local/Programs/gemini/gemini.exe"));
-        known_paths.push(PathBuf::from("C:/Program Files/gemini/gemini.exe"));
-    }
-
-    for path in &known_paths {
-        if path.is_file() {
-            return Some(path.display().to_string());
-        }
-    }
-
-    None
+    crate::services::platform::resolve_provider_binary("gemini").resolved_path
 }
 
-fn get_gemini_path() -> Option<&'static str> {
-    GEMINI_PATH.get_or_init(resolve_gemini_path).as_deref()
+fn resolve_gemini_binary() -> crate::services::platform::BinaryResolution {
+    crate::services::platform::resolve_provider_binary("gemini")
+}
+
+fn get_gemini_path() -> Option<String> {
+    resolve_gemini_path()
 }
 
 pub fn execute_command_simple(prompt: &str) -> Result<String, String> {
-    let gemini_bin = get_gemini_path().ok_or_else(|| "Gemini CLI not found".to_string())?;
+    let resolution = resolve_gemini_binary();
+    let gemini_bin = resolution
+        .resolved_path
+        .clone()
+        .ok_or_else(|| "Gemini CLI not found".to_string())?;
     let working_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let mut command = Command::new(gemini_bin);
-    crate::services::platform::apply_runtime_path(&mut command);
+    let mut command = Command::new(&gemini_bin);
+    crate::services::platform::apply_binary_resolution(&mut command, &resolution);
     let output = command
         .args(build_exec_args(prompt, None, None))
         .current_dir(working_dir)
@@ -96,11 +79,15 @@ pub fn execute_command_streaming(
         return Err("Gemini provider does not support remote execution yet".to_string());
     }
 
-    let gemini_bin = get_gemini_path().ok_or_else(|| "Gemini CLI not found".to_string())?;
+    let resolution = resolve_gemini_binary();
+    let gemini_bin = resolution
+        .resolved_path
+        .clone()
+        .ok_or_else(|| "Gemini CLI not found".to_string())?;
     let prompt = compose_gemini_prompt(prompt, system_prompt, allowed_tools);
 
-    let mut command = Command::new(gemini_bin);
-    crate::services::platform::apply_runtime_path(&mut command);
+    let mut command = Command::new(&gemini_bin);
+    crate::services::platform::apply_binary_resolution(&mut command, &resolution);
     let mut child = command
         .args(build_exec_args(&prompt, model, session_id))
         .current_dir(working_dir)

--- a/src/services/platform/binary_resolver.rs
+++ b/src/services/platform/binary_resolver.rs
@@ -367,7 +367,11 @@ fn standard_fallback_dirs() -> Vec<PathBuf> {
             push_unique_path(root.join("Volta/bin"), &mut dirs, &mut seen);
             push_unique_path(root.join("Programs"), &mut dirs, &mut seen);
             for provider_dir in ["claude", "codex", "gemini", "qwen"] {
-                push_unique_path(root.join("Programs").join(provider_dir), &mut dirs, &mut seen);
+                push_unique_path(
+                    root.join("Programs").join(provider_dir),
+                    &mut dirs,
+                    &mut seen,
+                );
             }
         }
         if let Some(user_profile) = std::env::var_os("USERPROFILE") {

--- a/src/services/platform/binary_resolver.rs
+++ b/src/services/platform/binary_resolver.rs
@@ -366,6 +366,9 @@ fn standard_fallback_dirs() -> Vec<PathBuf> {
             let root = PathBuf::from(local_app_data);
             push_unique_path(root.join("Volta/bin"), &mut dirs, &mut seen);
             push_unique_path(root.join("Programs"), &mut dirs, &mut seen);
+            for provider_dir in ["claude", "codex", "gemini", "qwen"] {
+                push_unique_path(root.join("Programs").join(provider_dir), &mut dirs, &mut seen);
+            }
         }
         if let Some(user_profile) = std::env::var_os("USERPROFILE") {
             push_unique_path(

--- a/src/services/platform/binary_resolver.rs
+++ b/src/services/platform/binary_resolver.rs
@@ -617,11 +617,16 @@ mod tests {
             .collect::<Vec<_>>();
 
         #[cfg(unix)]
-        assert!(dirs.iter().any(|entry| entry == "/usr/local/bin"));
-        assert!(dirs.iter().any(|entry| entry.ends_with("/.volta/bin")));
+        {
+            assert!(dirs.iter().any(|entry| entry == "/usr/local/bin"));
+            assert!(dirs.iter().any(|entry| entry.ends_with("/.volta/bin")));
+        }
 
         #[cfg(target_os = "macos")]
         assert!(dirs.iter().any(|entry| entry == "/opt/homebrew/bin"));
+
+        #[cfg(windows)]
+        assert!(dirs.iter().any(|entry| entry == "C:/ProgramData/chocolatey/bin"));
     }
 
     #[cfg(unix)]

--- a/src/services/platform/binary_resolver.rs
+++ b/src/services/platform/binary_resolver.rs
@@ -626,7 +626,10 @@ mod tests {
         assert!(dirs.iter().any(|entry| entry == "/opt/homebrew/bin"));
 
         #[cfg(windows)]
-        assert!(dirs.iter().any(|entry| entry == "C:/ProgramData/chocolatey/bin"));
+        assert!(
+            dirs.iter()
+                .any(|entry| entry == "C:/ProgramData/chocolatey/bin")
+        );
     }
 
     #[cfg(unix)]

--- a/src/services/platform/binary_resolver.rs
+++ b/src/services/platform/binary_resolver.rs
@@ -1,147 +1,163 @@
 //! Platform-aware binary resolution.
 //!
-//! Replaces direct `which`/`where` and `bash -lc "which X"` calls with a
-//! unified API that works across macOS, Linux, and Windows.
+//! Provides a single resolution contract for provider CLIs across macOS,
+//! Linux, and Windows.
 
 use std::collections::BTreeSet;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
+use std::time::{Duration, Instant};
 
-/// Resolve a binary by name using the platform's standard lookup mechanism.
-///
-/// - **Unix**: `which <name>`
-/// - **Windows**: `where.exe <name>`
-///
-/// Returns `None` if the binary is not found on PATH.
+const LOGIN_SHELL_TIMEOUT: Duration = Duration::from_secs(3);
+const SHELL_ENV_DELIMITER: &str = "__AGENTDESK_SHELL_ENV__";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BinaryResolution {
+    pub requested_binary: String,
+    pub resolved_path: Option<String>,
+    pub canonical_path: Option<String>,
+    pub source: Option<String>,
+    pub attempts: Vec<String>,
+    pub failure_kind: Option<String>,
+    pub exec_path: Option<String>,
+}
+
 pub fn resolve_binary(name: &str) -> Option<String> {
-    #[cfg(unix)]
-    let output = Command::new("which").arg(name).output();
-    #[cfg(windows)]
-    let output = Command::new("where.exe").arg(name).output();
-
-    output.ok().filter(|o| o.status.success()).and_then(|o| {
-        let path = String::from_utf8_lossy(&o.stdout)
-            .lines()
-            .next()
-            .unwrap_or("")
-            .trim()
-            .to_string();
-        if path.is_empty() { None } else { Some(path) }
-    })
+    resolve_in_paths(name, std::env::var_os("PATH"), &current_dir_fallback())
+        .map(|path| path.to_string_lossy().to_string())
 }
 
-/// Resolve a binary using a login shell to pick up the user's full PATH.
-///
-/// Useful for non-interactive contexts (e.g., launchd services, SSH sessions)
-/// where `~/.profile` / `~/.zshrc` are not sourced.
-///
-/// - **Unix**: Tries `zsh -lc "which <name>"`, then `bash -lc "which <name>"`
-/// - **Windows**: Falls back to `resolve_binary` (login shell not applicable)
 pub fn resolve_binary_with_login_shell(name: &str) -> Option<String> {
-    // Fast path: try standard PATH first
-    if let Some(path) = resolve_binary(name) {
-        return Some(path);
+    let cwd = current_dir_fallback();
+    if let Some(path) = resolve_in_paths(name, std::env::var_os("PATH"), &cwd) {
+        return Some(path.to_string_lossy().to_string());
     }
+    if let Some(path) = resolve_in_paths(name, resolve_login_shell_path_os(), &cwd) {
+        return Some(path.to_string_lossy().to_string());
+    }
+    resolve_in_paths(name, join_paths_lossy(standard_fallback_dirs()), &cwd)
+        .map(|path| path.to_string_lossy().to_string())
+}
 
-    #[cfg(unix)]
-    {
-        let which_cmd = format!("which {}", name);
-        for shell in &["zsh", "bash"] {
-            if let Ok(output) = Command::new(shell).args(["-lc", &which_cmd]).output() {
-                if output.status.success() {
-                    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                    if !path.is_empty() {
-                        return Some(path);
-                    }
+pub fn resolve_provider_binary(provider: &str) -> BinaryResolution {
+    let requested_binary = normalize_name(provider);
+    let override_var = override_var_name(&requested_binary);
+    let cwd = current_dir_fallback();
+    let mut attempts = Vec::new();
+
+    match std::env::var_os(&override_var).filter(|value| !os_value_is_empty(value)) {
+        Some(raw_override) => {
+            let expanded = expand_user_path(&raw_override);
+            match resolve_candidate_path(&expanded, &cwd) {
+                Ok(path) => {
+                    attempts.push(format!(
+                        "env_override:{}=found:{}",
+                        override_var,
+                        path.display()
+                    ));
+                    return finalize_resolution(
+                        requested_binary,
+                        path,
+                        "env_override".to_string(),
+                        attempts,
+                    );
+                }
+                Err(error) => {
+                    attempts.push(format!(
+                        "env_override:{}=miss:{}:{}",
+                        override_var,
+                        expanded.display(),
+                        error
+                    ));
+                    return BinaryResolution {
+                        requested_binary,
+                        resolved_path: None,
+                        canonical_path: None,
+                        source: None,
+                        attempts,
+                        failure_kind: Some(error),
+                        exec_path: merged_runtime_path(),
+                    };
                 }
             }
         }
+        None => attempts.push(format!("env_override:{}=unset", override_var)),
     }
 
-    #[cfg(windows)]
-    {
-        // On Windows, try PowerShell Get-Command as fallback
-        if let Ok(output) = Command::new("powershell")
-            .args([
-                "-NoProfile",
-                "-Command",
-                &format!(
-                    "(Get-Command {} -ErrorAction SilentlyContinue).Source",
-                    name
-                ),
-            ])
-            .output()
-        {
-            if output.status.success() {
-                let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                if !path.is_empty() {
-                    return Some(path);
-                }
+    let current_path = std::env::var_os("PATH").filter(|value| !os_value_is_empty(value));
+    match resolve_in_paths(&requested_binary, current_path.clone(), &cwd) {
+        Some(path) => {
+            attempts.push(format!("current_path=found:{}", path.display()));
+            return finalize_resolution(
+                requested_binary,
+                path,
+                "current_path".to_string(),
+                attempts,
+            );
+        }
+        None => attempts.push(if current_path.is_some() {
+            "current_path=miss".to_string()
+        } else {
+            "current_path=unset".to_string()
+        }),
+    }
+
+    let login_path = resolve_login_shell_path_os().filter(|value| !os_value_is_empty(value));
+    match resolve_in_paths(&requested_binary, login_path.clone(), &cwd) {
+        Some(path) => {
+            attempts.push(format!("login_shell_path=found:{}", path.display()));
+            return finalize_resolution(
+                requested_binary,
+                path,
+                "login_shell_path".to_string(),
+                attempts,
+            );
+        }
+        None => attempts.push(if login_path.is_some() {
+            "login_shell_path=miss".to_string()
+        } else {
+            "login_shell_path=unavailable".to_string()
+        }),
+    }
+
+    let fallback_dirs = standard_fallback_dirs();
+    match resolve_in_paths(
+        &requested_binary,
+        join_paths_lossy(fallback_dirs.clone()),
+        &cwd,
+    ) {
+        Some(path) => {
+            attempts.push(format!("fallback_path=found:{}", path.display()));
+            finalize_resolution(
+                requested_binary,
+                path,
+                "fallback_path".to_string(),
+                attempts,
+            )
+        }
+        None => {
+            attempts.push(format!("fallback_path=miss:{}dirs", fallback_dirs.len()));
+            BinaryResolution {
+                requested_binary,
+                resolved_path: None,
+                canonical_path: None,
+                source: None,
+                attempts,
+                failure_kind: Some("not_found".to_string()),
+                exec_path: merged_runtime_path(),
             }
         }
     }
-
-    None
-}
-
-fn merge_path_entries(primary: &str, secondary: &str) -> Option<String> {
-    let mut seen = BTreeSet::new();
-    let mut merged = Vec::new();
-    for raw in [primary, secondary] {
-        for entry in std::env::split_paths(raw) {
-            let normalized = entry.to_string_lossy().trim().to_string();
-            if normalized.is_empty() || !seen.insert(normalized.clone()) {
-                continue;
-            }
-            merged.push(entry);
-        }
-    }
-    std::env::join_paths(merged)
-        .ok()
-        .map(|value| value.to_string_lossy().to_string())
-}
-
-#[cfg(unix)]
-fn resolve_login_shell_path_uncached() -> Option<String> {
-    for shell in &["zsh", "bash"] {
-        if let Ok(output) = Command::new(shell)
-            .args(["-lc", r#"printf '%s' "$PATH""#])
-            .output()
-        {
-            if output.status.success() {
-                let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                if !path.is_empty() {
-                    return Some(path);
-                }
-            }
-        }
-    }
-    None
-}
-
-#[cfg(not(unix))]
-fn resolve_login_shell_path_uncached() -> Option<String> {
-    None
 }
 
 pub fn resolve_login_shell_path() -> Option<String> {
-    static LOGIN_SHELL_PATH: OnceLock<Option<String>> = OnceLock::new();
-    LOGIN_SHELL_PATH
-        .get_or_init(resolve_login_shell_path_uncached)
-        .clone()
+    resolve_login_shell_path_os().map(|value| value.to_string_lossy().to_string())
 }
 
 pub fn merged_runtime_path() -> Option<String> {
-    let current = std::env::var("PATH")
-        .ok()
-        .filter(|value| !value.trim().is_empty());
-    let login_shell = resolve_login_shell_path().filter(|value| !value.trim().is_empty());
-    match (current, login_shell) {
-        (Some(current), Some(login_shell)) => merge_path_entries(&login_shell, &current),
-        (Some(current), None) => Some(current),
-        (None, Some(login_shell)) => Some(login_shell),
-        (None, None) => None,
-    }
+    join_paths_lossy(runtime_path_entries()).map(|value| value.to_string_lossy().to_string())
 }
 
 pub fn apply_runtime_path(command: &mut Command) {
@@ -150,10 +166,56 @@ pub fn apply_runtime_path(command: &mut Command) {
     }
 }
 
-/// Async version of `resolve_binary_with_login_shell`.
-///
-/// Runs the full resolution chain (which/where → login shell → known paths)
-/// on a blocking thread so it can be used from async contexts.
+pub fn augment_exec_path(command: &mut Command, binary_path: impl AsRef<Path>) {
+    if let Some(path) = exec_path_for_binary(binary_path.as_ref()) {
+        command.env("PATH", path);
+    } else {
+        apply_runtime_path(command);
+    }
+}
+
+pub fn apply_binary_resolution(command: &mut Command, resolution: &BinaryResolution) {
+    if let Some(path) = &resolution.exec_path {
+        command.env("PATH", path);
+    } else if let Some(path) = &resolution.resolved_path {
+        augment_exec_path(command, path);
+    } else {
+        apply_runtime_path(command);
+    }
+}
+
+pub fn prepare_provider_command(resolution: &BinaryResolution) -> Option<Command> {
+    let resolved_path = resolution.resolved_path.as_ref()?;
+    let mut command = Command::new(resolved_path);
+    apply_binary_resolution(&mut command, resolution);
+    Some(command)
+}
+
+pub fn probe_resolved_binary_version(
+    binary_path: impl AsRef<OsStr>,
+    resolution: &BinaryResolution,
+) -> (Option<String>, Option<String>) {
+    let mut command = Command::new(binary_path);
+    apply_binary_resolution(&mut command, resolution);
+    command.arg("--version");
+
+    match command.output() {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if stdout.is_empty() {
+                (None, Some("version_probe_empty".to_string()))
+            } else {
+                (Some(stdout), None)
+            }
+        }
+        Ok(_) => (None, Some("version_probe_failed".to_string())),
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+            (None, Some("permission_denied".to_string()))
+        }
+        Err(_) => (None, Some("version_probe_spawn_failed".to_string())),
+    }
+}
+
 pub async fn async_resolve_binary_with_login_shell(name: &str) -> Option<String> {
     let name = name.to_string();
     tokio::task::spawn_blocking(move || resolve_binary_with_login_shell(&name))
@@ -162,13 +224,365 @@ pub async fn async_resolve_binary_with_login_shell(name: &str) -> Option<String>
         .flatten()
 }
 
+fn finalize_resolution(
+    requested_binary: String,
+    resolved_path: PathBuf,
+    source: String,
+    attempts: Vec<String>,
+) -> BinaryResolution {
+    let canonical_path = std::fs::canonicalize(&resolved_path).ok();
+    BinaryResolution {
+        requested_binary,
+        resolved_path: Some(resolved_path.to_string_lossy().to_string()),
+        canonical_path: canonical_path
+            .as_ref()
+            .map(|path| path.to_string_lossy().to_string()),
+        source: Some(source),
+        attempts,
+        failure_kind: None,
+        exec_path: build_exec_path(&resolved_path, canonical_path.as_deref()),
+    }
+}
+
+fn resolve_in_paths(
+    binary_name: impl AsRef<OsStr>,
+    paths: Option<OsString>,
+    cwd: &Path,
+) -> Option<PathBuf> {
+    which::which_in(binary_name, paths, cwd).ok()
+}
+
+fn resolve_candidate_path(candidate: &Path, cwd: &Path) -> Result<PathBuf, String> {
+    if candidate.exists() && !is_effectively_executable(candidate) {
+        return Err("permission_denied".to_string());
+    }
+    which::which_in(candidate.as_os_str(), Option::<OsString>::None, cwd)
+        .map_err(|error| error.to_string())
+}
+
+fn is_effectively_executable(path: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        return std::fs::metadata(path)
+            .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false);
+    }
+
+    #[cfg(not(unix))]
+    {
+        path.is_file()
+    }
+}
+
+fn build_exec_path(resolved_path: &Path, canonical_path: Option<&Path>) -> Option<String> {
+    join_paths_lossy(exec_path_entries(resolved_path, canonical_path))
+        .map(|value| value.to_string_lossy().to_string())
+}
+
+fn exec_path_for_binary(binary_path: &Path) -> Option<String> {
+    let canonical = std::fs::canonicalize(binary_path).ok();
+    build_exec_path(binary_path, canonical.as_deref())
+}
+
+fn runtime_path_entries() -> Vec<PathBuf> {
+    let mut entries = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    extend_split_paths(std::env::var_os("PATH"), &mut entries, &mut seen);
+    extend_split_paths(resolve_login_shell_path_os(), &mut entries, &mut seen);
+    for dir in standard_fallback_dirs() {
+        push_unique_path(dir, &mut entries, &mut seen);
+    }
+
+    entries
+}
+
+fn exec_path_entries(resolved_path: &Path, canonical_path: Option<&Path>) -> Vec<PathBuf> {
+    let mut entries = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    if let Some(parent) = resolved_path.parent() {
+        push_unique_path(parent.to_path_buf(), &mut entries, &mut seen);
+    }
+    if let Some(parent) = canonical_path.and_then(Path::parent) {
+        push_unique_path(parent.to_path_buf(), &mut entries, &mut seen);
+    }
+    for entry in runtime_path_entries() {
+        push_unique_path(entry, &mut entries, &mut seen);
+    }
+
+    entries
+}
+
+fn standard_fallback_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    let mut seen = BTreeSet::new();
+    let home = dirs::home_dir();
+
+    if let Some(home) = &home {
+        push_unique_path(home.join(".local/bin"), &mut dirs, &mut seen);
+        push_unique_path(home.join("bin"), &mut dirs, &mut seen);
+        push_unique_path(home.join(".volta/bin"), &mut dirs, &mut seen);
+        push_unique_path(home.join(".bun/bin"), &mut dirs, &mut seen);
+        push_unique_path(home.join(".asdf/shims"), &mut dirs, &mut seen);
+        push_unique_path(home.join(".npm-global/bin"), &mut dirs, &mut seen);
+    }
+
+    #[cfg(unix)]
+    push_unique_path(PathBuf::from("/usr/local/bin"), &mut dirs, &mut seen);
+
+    #[cfg(target_os = "macos")]
+    {
+        push_unique_path(PathBuf::from("/opt/homebrew/bin"), &mut dirs, &mut seen);
+        if let Some(home) = &home {
+            push_unique_path(home.join("Library/pnpm"), &mut dirs, &mut seen);
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if let Some(home) = &home {
+            push_unique_path(home.join(".local/share/pnpm"), &mut dirs, &mut seen);
+            push_unique_path(home.join(".local/share/mise/shims"), &mut dirs, &mut seen);
+            push_unique_path(home.join(".local/share/rtx/shims"), &mut dirs, &mut seen);
+        }
+    }
+
+    push_env_dir("PNPM_HOME", None, &mut dirs, &mut seen);
+    push_env_dir("VOLTA_HOME", Some("bin"), &mut dirs, &mut seen);
+    push_env_dir("BUN_INSTALL", Some("bin"), &mut dirs, &mut seen);
+    push_env_dir("ASDF_DATA_DIR", Some("shims"), &mut dirs, &mut seen);
+    push_env_dir("MISE_DATA_DIR", Some("shims"), &mut dirs, &mut seen);
+    push_env_dir("RTX_DATA_DIR", Some("shims"), &mut dirs, &mut seen);
+    push_env_dir("N_PREFIX", Some("bin"), &mut dirs, &mut seen);
+
+    #[cfg(windows)]
+    {
+        if let Some(appdata) = std::env::var_os("APPDATA") {
+            push_unique_path(PathBuf::from(appdata).join("npm"), &mut dirs, &mut seen);
+        }
+        if let Some(local_app_data) = std::env::var_os("LOCALAPPDATA") {
+            let root = PathBuf::from(local_app_data);
+            push_unique_path(root.join("Volta/bin"), &mut dirs, &mut seen);
+            push_unique_path(root.join("Programs"), &mut dirs, &mut seen);
+        }
+        if let Some(user_profile) = std::env::var_os("USERPROFILE") {
+            push_unique_path(
+                PathBuf::from(user_profile).join("scoop/shims"),
+                &mut dirs,
+                &mut seen,
+            );
+        }
+        push_unique_path(
+            PathBuf::from("C:/ProgramData/chocolatey/bin"),
+            &mut dirs,
+            &mut seen,
+        );
+    }
+
+    dirs
+}
+
+#[cfg(unix)]
+fn resolve_login_shell_path_os() -> Option<OsString> {
+    static LOGIN_SHELL_PATH: OnceLock<Option<OsString>> = OnceLock::new();
+    LOGIN_SHELL_PATH
+        .get_or_init(resolve_login_shell_path_uncached)
+        .clone()
+}
+
+#[cfg(not(unix))]
+fn resolve_login_shell_path_os() -> Option<OsString> {
+    None
+}
+
+#[cfg(unix)]
+fn resolve_login_shell_path_uncached() -> Option<OsString> {
+    let env_cmd = format!(
+        "printf '%s' '{delimiter}'; command env; printf '%s' '{delimiter}'; exit",
+        delimiter = SHELL_ENV_DELIMITER
+    );
+
+    for shell in login_shell_candidates() {
+        let mut command = Command::new(&shell);
+        command
+            .args(["-ilc", &env_cmd])
+            .env("DISABLE_AUTO_UPDATE", "true")
+            .env("ZSH_TMUX_AUTOSTARTED", "true")
+            .env("ZSH_TMUX_AUTOSTART", "false")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+
+        let Ok(mut child) = command.spawn() else {
+            continue;
+        };
+
+        let deadline = Instant::now() + LOGIN_SHELL_TIMEOUT;
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => break,
+                Ok(None) if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(25));
+                }
+                Ok(None) | Err(_) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    break;
+                }
+            }
+        }
+
+        let Ok(output) = child.wait_with_output() else {
+            continue;
+        };
+        if !output.status.success() {
+            continue;
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let Some((_, after_start)) = stdout.split_once(SHELL_ENV_DELIMITER) else {
+            continue;
+        };
+        let Some((env_block, _)) = after_start.split_once(SHELL_ENV_DELIMITER) else {
+            continue;
+        };
+        if let Some(path) = env_block
+            .lines()
+            .find_map(|line| line.strip_prefix("PATH="))
+        {
+            let trimmed = path.trim();
+            if !trimmed.is_empty() {
+                return Some(OsString::from(trimmed));
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(unix)]
+fn login_shell_candidates() -> Vec<PathBuf> {
+    let mut shells = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    if let Some(shell) = std::env::var_os("SHELL").filter(|value| !os_value_is_empty(value)) {
+        push_unique_path(PathBuf::from(shell), &mut shells, &mut seen);
+    }
+    push_unique_path(PathBuf::from("/bin/zsh"), &mut shells, &mut seen);
+    push_unique_path(PathBuf::from("/bin/bash"), &mut shells, &mut seen);
+
+    shells
+}
+
+fn current_dir_fallback() -> PathBuf {
+    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+}
+
+fn override_var_name(provider: &str) -> String {
+    let mut normalized = String::new();
+    for ch in provider.chars() {
+        if ch.is_ascii_alphanumeric() {
+            normalized.push(ch.to_ascii_uppercase());
+        } else {
+            normalized.push('_');
+        }
+    }
+    format!("AGENTDESK_{}_PATH", normalized)
+}
+
+fn normalize_name(name: &str) -> String {
+    name.trim().to_ascii_lowercase()
+}
+
+fn os_value_is_empty(value: &OsStr) -> bool {
+    value.to_string_lossy().trim().is_empty()
+}
+
+fn expand_user_path(raw: &OsStr) -> PathBuf {
+    let raw = raw.to_string_lossy();
+    if raw == "~" {
+        return dirs::home_dir().unwrap_or_else(|| PathBuf::from(raw.as_ref()));
+    }
+    if let Some(rest) = raw.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest);
+        }
+    }
+    PathBuf::from(raw.as_ref())
+}
+
+fn push_env_dir(
+    env_name: &str,
+    suffix: Option<&str>,
+    entries: &mut Vec<PathBuf>,
+    seen: &mut BTreeSet<String>,
+) {
+    let Some(value) = std::env::var_os(env_name).filter(|value| !os_value_is_empty(value)) else {
+        return;
+    };
+    let mut path = expand_user_path(&value);
+    if let Some(suffix) = suffix {
+        path = path.join(suffix);
+    }
+    push_unique_path(path, entries, seen);
+}
+
+fn extend_split_paths(
+    value: Option<OsString>,
+    entries: &mut Vec<PathBuf>,
+    seen: &mut BTreeSet<String>,
+) {
+    let Some(value) = value.filter(|value| !os_value_is_empty(value)) else {
+        return;
+    };
+    for entry in std::env::split_paths(&value) {
+        push_unique_path(entry, entries, seen);
+    }
+}
+
+fn push_unique_path(path: PathBuf, entries: &mut Vec<PathBuf>, seen: &mut BTreeSet<String>) {
+    let normalized = path.to_string_lossy().trim().to_string();
+    if normalized.is_empty() || !seen.insert(normalized) {
+        return;
+    }
+    entries.push(path);
+}
+
+fn join_paths_lossy(paths: Vec<PathBuf>) -> Option<OsString> {
+    if paths.is_empty() {
+        return None;
+    }
+    std::env::join_paths(paths).ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, MutexGuard};
+
+    fn env_guard() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    #[cfg(unix)]
+    fn write_executable(path: &Path) {
+        write_executable_with_contents(path, "#!/bin/sh\nexit 0\n");
+    }
+
+    #[cfg(unix)]
+    fn write_executable_with_contents(path: &Path, contents: &str) {
+        use std::os::unix::fs::PermissionsExt;
+
+        std::fs::write(path, contents).unwrap();
+        let mut perms = std::fs::metadata(path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
 
     #[test]
     fn resolve_binary_finds_known_tool() {
-        // `ls` exists on all Unix, `cmd.exe` on Windows
         #[cfg(unix)]
         assert!(resolve_binary("ls").is_some());
         #[cfg(windows)]
@@ -189,18 +603,168 @@ mod tests {
     }
 
     #[test]
-    fn merge_path_entries_dedupes_and_preserves_order() {
-        #[cfg(unix)]
-        let joined = merge_path_entries("/opt/homebrew/bin:/usr/bin", "/usr/bin:/bin").unwrap();
-        #[cfg(windows)]
-        let joined = merge_path_entries(r"C:\Tools;C:\Windows", r"C:\Windows;C:\Bin").unwrap();
-
-        let parts = std::env::split_paths(&joined)
+    fn standard_fallback_dirs_include_common_entries() {
+        let dirs = standard_fallback_dirs()
+            .into_iter()
             .map(|entry| entry.to_string_lossy().to_string())
             .collect::<Vec<_>>();
+
         #[cfg(unix)]
-        assert_eq!(parts, vec!["/opt/homebrew/bin", "/usr/bin", "/bin"]);
-        #[cfg(windows)]
-        assert_eq!(parts, vec![r"C:\Tools", r"C:\Windows", r"C:\Bin"]);
+        assert!(dirs.iter().any(|entry| entry == "/usr/local/bin"));
+        assert!(dirs.iter().any(|entry| entry.ends_with("/.volta/bin")));
+
+        #[cfg(target_os = "macos")]
+        assert!(dirs.iter().any(|entry| entry == "/opt/homebrew/bin"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provider_override_reloads_on_each_call() {
+        let _guard = env_guard();
+        let temp = tempfile::tempdir().unwrap();
+        let first = temp.path().join("codex-first");
+        let second = temp.path().join("codex-second");
+        write_executable(&first);
+        write_executable(&second);
+
+        unsafe {
+            std::env::set_var("AGENTDESK_CODEX_PATH", &first);
+        }
+        let first_resolution = resolve_provider_binary("codex");
+        assert_eq!(
+            first_resolution.resolved_path,
+            Some(first.to_string_lossy().to_string())
+        );
+        assert_eq!(first_resolution.source.as_deref(), Some("env_override"));
+
+        unsafe {
+            std::env::set_var("AGENTDESK_CODEX_PATH", &second);
+        }
+        let second_resolution = resolve_provider_binary("codex");
+        assert_eq!(
+            second_resolution.resolved_path,
+            Some(second.to_string_lossy().to_string())
+        );
+        assert_eq!(second_resolution.source.as_deref(), Some("env_override"));
+
+        unsafe {
+            std::env::remove_var("AGENTDESK_CODEX_PATH");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provider_override_reports_permission_denied_for_non_executable_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = env_guard();
+        let temp = tempfile::tempdir().unwrap();
+        let provider = temp.path().join("codex");
+        std::fs::write(&provider, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut perms = std::fs::metadata(&provider).unwrap().permissions();
+        perms.set_mode(0o644);
+        std::fs::set_permissions(&provider, perms).unwrap();
+
+        unsafe {
+            std::env::set_var("AGENTDESK_CODEX_PATH", &provider);
+        }
+        let resolution = resolve_provider_binary("codex");
+
+        assert_eq!(resolution.resolved_path, None);
+        assert_eq!(
+            resolution.failure_kind.as_deref(),
+            Some("permission_denied")
+        );
+        assert!(
+            resolution
+                .attempts
+                .iter()
+                .any(|attempt| attempt.contains("permission_denied"))
+        );
+
+        unsafe {
+            std::env::remove_var("AGENTDESK_CODEX_PATH");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exec_path_includes_resolved_and_canonical_parent_dirs() {
+        let _guard = env_guard();
+        let temp = tempfile::tempdir().unwrap();
+        let real_dir = temp.path().join("real");
+        let link_dir = temp.path().join("link");
+        std::fs::create_dir_all(&real_dir).unwrap();
+        std::fs::create_dir_all(&link_dir).unwrap();
+
+        let real_bin = real_dir.join("claude");
+        let link_bin = link_dir.join("claude");
+        write_executable(&real_bin);
+        std::os::unix::fs::symlink(&real_bin, &link_bin).unwrap();
+
+        unsafe {
+            std::env::set_var("AGENTDESK_CLAUDE_PATH", &link_bin);
+        }
+        let resolution = resolve_provider_binary("claude");
+        let exec_path = resolution.exec_path.unwrap();
+        let parts = std::env::split_paths(&exec_path)
+            .map(|entry| entry.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        let canonical_real_dir = std::fs::canonicalize(&real_dir).unwrap();
+        let expected_link_dir = link_dir.to_string_lossy().to_string();
+        let expected_real_dir = canonical_real_dir.to_string_lossy().to_string();
+
+        assert_eq!(
+            parts.first().map(String::as_str),
+            Some(expected_link_dir.as_str())
+        );
+        assert_eq!(
+            parts.get(1).map(String::as_str),
+            Some(expected_real_dir.as_str())
+        );
+
+        unsafe {
+            std::env::remove_var("AGENTDESK_CLAUDE_PATH");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn apply_binary_resolution_makes_sibling_helpers_visible_with_minimal_path() {
+        let _guard = env_guard();
+        let temp = tempfile::tempdir().unwrap();
+        let provider = temp.path().join("claude");
+        let helper = temp.path().join("provider-helper");
+        let original_path = std::env::var_os("PATH");
+
+        write_executable_with_contents(&helper, "#!/bin/sh\nprintf 'helper:%s' \"$1\"\n");
+        write_executable_with_contents(&provider, "#!/bin/sh\nprovider-helper \"$1\"\n");
+
+        unsafe {
+            std::env::set_var("PATH", "/usr/bin:/bin:/usr/sbin:/sbin");
+            std::env::set_var("AGENTDESK_CLAUDE_PATH", &provider);
+        }
+
+        let resolution = resolve_provider_binary("claude");
+        let mut command = Command::new(
+            resolution
+                .resolved_path
+                .as_ref()
+                .expect("resolved path should exist"),
+        );
+        apply_binary_resolution(&mut command, &resolution);
+        let output = command.arg("ok").output().unwrap();
+
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "helper:ok");
+        assert_eq!(resolution.source.as_deref(), Some("env_override"));
+
+        unsafe {
+            std::env::remove_var("AGENTDESK_CLAUDE_PATH");
+            match original_path {
+                Some(value) => std::env::set_var("PATH", value),
+                None => std::env::remove_var("PATH"),
+            }
+        }
     }
 }

--- a/src/services/platform/mod.rs
+++ b/src/services/platform/mod.rs
@@ -9,8 +9,10 @@ pub mod shell;
 pub mod tmux;
 
 pub use binary_resolver::{
-    apply_runtime_path, async_resolve_binary_with_login_shell, merged_runtime_path, resolve_binary,
-    resolve_binary_with_login_shell, resolve_login_shell_path,
+    BinaryResolution, apply_binary_resolution, apply_runtime_path,
+    async_resolve_binary_with_login_shell, augment_exec_path, merged_runtime_path,
+    prepare_provider_command, probe_resolved_binary_version, resolve_binary,
+    resolve_binary_with_login_shell, resolve_login_shell_path, resolve_provider_binary,
 };
 pub use dump_tool::capture_process_dump;
 pub use shell::{

--- a/src/services/provider.rs
+++ b/src/services/provider.rs
@@ -1,5 +1,6 @@
 use crate::utils::format::safe_prefix;
-use std::process::Command;
+
+use crate::services::platform::BinaryResolution;
 
 /// Tmux session name prefix — always "AgentDesk".
 pub const TMUX_SESSION_PREFIX: &str = "AgentDesk";
@@ -36,8 +37,9 @@ pub struct ProviderCapabilities {
 pub struct ProviderRuntimeProbe {
     pub provider: ProviderKind,
     pub capabilities: ProviderCapabilities,
-    pub binary_path: Option<String>,
+    pub resolution: BinaryResolution,
     pub version: Option<String>,
+    pub probe_failure_kind: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -139,29 +141,18 @@ impl ProviderKind {
 
     pub fn probe_runtime(&self) -> Option<ProviderRuntimeProbe> {
         let capabilities = self.capabilities()?;
-        let binary_path = self.resolve_runtime_path();
-        let version = binary_path.as_ref().and_then(|path| {
-            let mut command = Command::new(path);
-            crate::services::platform::apply_runtime_path(&mut command);
-            command
-                .arg("--version")
-                .output()
-                .ok()
-                .filter(|output| output.status.success())
-                .and_then(|output| {
-                    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                    if stdout.is_empty() {
-                        None
-                    } else {
-                        Some(stdout)
-                    }
-                })
-        });
+        let resolution = crate::services::platform::resolve_provider_binary(self.as_str());
+        let (version, probe_failure_kind) = resolution
+            .resolved_path
+            .as_ref()
+            .map(|path| crate::services::platform::probe_resolved_binary_version(path, &resolution))
+            .unwrap_or((None, None));
         Some(ProviderRuntimeProbe {
             provider: self.clone(),
             capabilities,
-            binary_path,
+            resolution,
             version,
+            probe_failure_kind,
         })
     }
 

--- a/src/services/tmux_wrapper.rs
+++ b/src/services/tmux_wrapper.rs
@@ -92,7 +92,9 @@ pub fn run(
     };
 
     // Spawn Claude with piped stdin (kept open for multi-turn)
-    let mut child = match Command::new(claude_bin)
+    let mut claude_command = Command::new(claude_bin);
+    crate::services::platform::augment_exec_path(&mut claude_command, claude_bin);
+    let mut child = match claude_command
         .args(claude_args)
         .current_dir(&expanded_dir)
         .env("CLAUDE_CODE_MAX_OUTPUT_TOKENS", "64000")


### PR DESCRIPTION
## Summary
- Ports the implementation from `kunkunGames/AgentDesk#11` to upstream.
- Unifies provider binary lookup behind `src/services/platform/binary_resolver.rs`.
- Makes macOS/Linux/Windows resolution follow the same order: `env override -> current PATH -> login shell PATH -> fallback path`.
- Carries `exec_path` through direct exec, onboarding, doctor, and tmux/local backends so shebang-based helper runtimes stay visible.
- Aligns the diagnostic/runtime surface for `claude`, `codex`, `gemini`, and `qwen`.

## Main Changes
- Add shared `BinaryResolution` / version-probe plumbing in `src/services/platform/binary_resolver.rs` and `src/services/platform/mod.rs`.
- Replace provider-specific path caches/resolvers with the shared resolver in `src/services/provider.rs`, `src/services/claude.rs`, `src/services/codex.rs`, `src/services/gemini.rs`, and `src/services/qwen.rs`.
- Export resolver-derived execution PATH into `src/services/tmux_wrapper.rs` and `src/services/codex_tmux_wrapper.rs`.
- Surface resolver details (`path`, `canonical_path`, `source`, `failure_kind`, `attempts`) from `src/server/routes/onboarding.rs` and `src/cli/doctor.rs`.
- Wire `qwen` through the provider/model/Discord surfaces touched by this refactor.
- Add the `which` crate and move fallback lookup to in-process `which::which_in()` resolution.

## Validation
- `cargo check --bin agentdesk`
- `cargo test -q binary_resolver`
- `cargo test -q test_provider_channel_support`
- `cargo test -q apply_binary_resolution_makes_sibling_helpers_visible_with_minimal_path`
- `cargo test -q check_provider_uses_resolver_exec_path_under_minimal_path`
- `cargo test -q provider_runtime_check_uses_resolver_exec_path_under_minimal_path`
- `cargo test -q tmux_launch_env_lines_include_exec_path_and_report_envs`
- `cargo test -q qwen::tests`
- `cargo test -q provider_override_reports_permission_denied_for_non_executable_file`
- `cargo test -q provider_runtime_check_reports_permission_denied`
- `cargo test -q check_provider_reports_permission_denied`
- macOS minimal-PATH validation with `agentdesk doctor --json`
- macOS `launchd` validation with restart + `dcserver.stdout.log` confirmation

## Notes
- The source branch is currently `6` commits ahead of upstream `main` and `0` commits behind.
- Remaining follow-up scope from the original staging PR is Windows service / systemd / macOS Intel real-host verification.
- Original staging PR: `kunkunGames/AgentDesk#11`.