### PR TITLE
fix(qwen): close out provider session, doctor, and model UX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
   pull_request:
-    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -415,9 +415,7 @@ fn check_qwen_auth_hints(configured: bool) -> Check {
     let oauth_cache = home
         .as_ref()
         .map(|path| path.join(".qwen").join("oauth_creds.json"));
-    let project_qwen_env = project
-        .as_ref()
-        .map(|path| path.join(".qwen").join(".env"));
+    let project_qwen_env = project.as_ref().map(|path| path.join(".qwen").join(".env"));
     let project_env = project.as_ref().map(|path| path.join(".env"));
 
     let mut hints = Vec::new();
@@ -447,10 +445,7 @@ fn check_qwen_auth_hints(configured: bool) -> Check {
             "qwen auth hints",
             detail,
         )
-        .with_expected_actual(
-            "cached auth or API-key hint visible",
-            hints.join(", "),
-        )
+        .with_expected_actual("cached auth or API-key hint visible", hints.join(", "))
         .with_next_steps(vec![
             "qwen auth status".to_string(),
             "Open a Qwen CLI session and run /stats".to_string(),
@@ -495,12 +490,14 @@ fn check_qwen_runtime_artifacts(configured: bool) -> Check {
     let home_artifacts = [
         (
             "extensions",
-            home.as_ref().map(|path| path.join(".qwen").join("extensions")),
+            home.as_ref()
+                .map(|path| path.join(".qwen").join("extensions")),
             false,
         ),
         (
             "commands",
-            home.as_ref().map(|path| path.join(".qwen").join("commands")),
+            home.as_ref()
+                .map(|path| path.join(".qwen").join("commands")),
             false,
         ),
         (
@@ -523,17 +520,23 @@ fn check_qwen_runtime_artifacts(configured: bool) -> Check {
     let project_artifacts = [
         (
             "commands",
-            project.as_ref().map(|path| path.join(".qwen").join("commands")),
+            project
+                .as_ref()
+                .map(|path| path.join(".qwen").join("commands")),
             false,
         ),
         (
             "agents",
-            project.as_ref().map(|path| path.join(".qwen").join("agents")),
+            project
+                .as_ref()
+                .map(|path| path.join(".qwen").join("agents")),
             false,
         ),
         (
             "skills",
-            project.as_ref().map(|path| path.join(".qwen").join("skills")),
+            project
+                .as_ref()
+                .map(|path| path.join(".qwen").join("skills")),
             false,
         ),
         (
@@ -562,7 +565,11 @@ fn check_qwen_runtime_artifacts(configured: bool) -> Check {
         .iter()
         .filter_map(|(label, path, is_file)| {
             path.as_ref().and_then(|path| {
-                let exists = if *is_file { path.is_file() } else { path.is_dir() };
+                let exists = if *is_file {
+                    path.is_file()
+                } else {
+                    path.is_dir()
+                };
                 exists.then_some(*label)
             })
         })
@@ -571,7 +578,11 @@ fn check_qwen_runtime_artifacts(configured: bool) -> Check {
         .iter()
         .filter_map(|(label, path, is_file)| {
             path.as_ref().and_then(|path| {
-                let exists = if *is_file { path.is_file() } else { path.is_dir() };
+                let exists = if *is_file {
+                    path.is_file()
+                } else {
+                    path.is_dir()
+                };
                 exists.then_some(*label)
             })
         })
@@ -592,11 +603,7 @@ fn check_qwen_runtime_artifacts(configured: bool) -> Check {
         )
         .with_expected_actual(
             "Qwen runtime artifacts visible when configured",
-            format!(
-                "home={} project={}",
-                found_home.len(),
-                found_project.len()
-            ),
+            format!("home={} project={}", found_home.len(), found_project.len()),
         );
     }
 

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -304,6 +304,12 @@ fn dcserver_log_hint() -> String {
 }
 
 fn qwen_home_dir() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("QWEN_HOME") {
+        if !path.is_empty() {
+            return Some(PathBuf::from(path));
+        }
+    }
+
     #[cfg(test)]
     if let Some(path) = std::env::var_os("AGENTDESK_TEST_HOME") {
         let path = PathBuf::from(path);
@@ -312,7 +318,15 @@ fn qwen_home_dir() -> Option<PathBuf> {
         }
     }
 
-    dirs::home_dir()
+    std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("USERPROFILE")
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+        })
+        .or_else(dirs::home_dir)
 }
 
 fn qwen_project_dir() -> Option<PathBuf> {
@@ -1774,8 +1788,8 @@ mod tests {
     use super::{
         Check, CheckGroup, CheckStatus, FixAction, HealthSnapshot, build_json_report,
         check_provider_cli, check_qwen_auth_hints, check_qwen_runtime_artifacts,
-        check_server_running, configured_provider_names, discord_bot_check_from_health,
-        provider_capability_summary,
+        check_qwen_settings_files, check_server_running, configured_provider_names,
+        discord_bot_check_from_health, provider_capability_summary,
     };
     use crate::config::ServerConfig;
     use crate::services::provider::ProviderKind;
@@ -1789,6 +1803,7 @@ mod tests {
         let _guard = crate::services::discord::runtime_store::lock_test_env();
         let temp_home = tempfile::tempdir().unwrap();
         let temp_project = tempfile::tempdir().unwrap();
+        let prev_qwen_home = std::env::var_os("QWEN_HOME");
         let prev_home = std::env::var_os("HOME");
         let prev_userprofile = std::env::var_os("USERPROFILE");
         let prev_test_home = std::env::var_os("AGENTDESK_TEST_HOME");
@@ -1807,6 +1822,10 @@ mod tests {
         match prev_home {
             Some(value) => unsafe { std::env::set_var("HOME", value) },
             None => unsafe { std::env::remove_var("HOME") },
+        }
+        match prev_qwen_home {
+            Some(value) => unsafe { std::env::set_var("QWEN_HOME", value) },
+            None => unsafe { std::env::remove_var("QWEN_HOME") },
         }
         match prev_userprofile {
             Some(value) => unsafe { std::env::set_var("USERPROFILE", value) },
@@ -2048,6 +2067,28 @@ mod tests {
             assert_eq!(check.status, CheckStatus::Pass);
             assert!(check.detail.contains("project .qwen/.env"));
             assert!(check.detail.contains("project .env"));
+        });
+    }
+
+    #[test]
+    fn qwen_doctor_prefers_qwen_home_over_home() {
+        with_temp_qwen_doctor_env(|temp_home, _temp_project| {
+            let qwen_home = tempfile::tempdir().unwrap();
+            let qwen_settings = qwen_home.path().join(".qwen").join("settings.json");
+            std::fs::create_dir_all(qwen_settings.parent().unwrap()).unwrap();
+            std::fs::write(&qwen_settings, "{}").unwrap();
+
+            unsafe {
+                std::env::set_var("QWEN_HOME", qwen_home.path());
+                std::env::set_var("HOME", temp_home.path());
+            }
+
+            let check = check_qwen_settings_files(true);
+            assert_eq!(check.status, CheckStatus::Pass);
+            assert_eq!(
+                check.path.as_deref(),
+                Some(format!("user settings={}", qwen_settings.display()).as_str())
+            );
         });
     }
 

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeSet;
 use std::fs;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use super::dcserver;
@@ -302,6 +303,334 @@ fn dcserver_log_hint() -> String {
         .unwrap_or_else(|| "~/.adk/release/logs/dcserver.stdout.log".to_string())
 }
 
+fn qwen_home_dir() -> Option<PathBuf> {
+    #[cfg(test)]
+    if let Some(path) = std::env::var_os("AGENTDESK_TEST_HOME") {
+        let path = PathBuf::from(path);
+        if !path.as_os_str().is_empty() {
+            return Some(path);
+        }
+    }
+
+    dirs::home_dir()
+}
+
+fn qwen_project_dir() -> Option<PathBuf> {
+    std::env::current_dir().ok()
+}
+
+fn qwen_system_defaults_path() -> Option<PathBuf> {
+    std::env::var_os("QWEN_CODE_SYSTEM_DEFAULTS_PATH")
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+}
+
+fn qwen_system_settings_path() -> Option<PathBuf> {
+    std::env::var_os("QWEN_CODE_SYSTEM_SETTINGS_PATH")
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+}
+
+fn qwen_user_settings_path() -> Option<PathBuf> {
+    qwen_home_dir().map(|home| home.join(".qwen").join("settings.json"))
+}
+
+fn qwen_project_settings_path() -> Option<PathBuf> {
+    qwen_project_dir().map(|dir| dir.join(".qwen").join("settings.json"))
+}
+
+fn format_artifact_scope(scope: &str, items: &[&str]) -> String {
+    if items.is_empty() {
+        format!("{scope}: -")
+    } else {
+        format!("{scope}: {}", items.join(", "))
+    }
+}
+
+fn check_qwen_settings_files(configured: bool) -> Check {
+    let candidates = [
+        ("system defaults", qwen_system_defaults_path()),
+        ("user settings", qwen_user_settings_path()),
+        ("project settings", qwen_project_settings_path()),
+        ("system settings", qwen_system_settings_path()),
+    ];
+
+    let found: Vec<String> = candidates
+        .iter()
+        .filter_map(|(label, path)| {
+            path.as_ref()
+                .filter(|path| path.is_file())
+                .map(|path| format!("{label}={}", path.display()))
+        })
+        .collect();
+
+    if !found.is_empty() {
+        return Check::ok(
+            "provider_qwen_settings",
+            CheckGroup::ProviderRuntime,
+            "qwen settings files",
+            format!("found {}", found.join(" | ")),
+        )
+        .with_path(found[0].clone())
+        .with_expected_actual(
+            "Qwen settings layers discoverable",
+            format!("{} settings layer(s) found", found.len()),
+        );
+    }
+
+    let guidance = "Qwen은 settings 없이도 동작할 수 있지만, 모델 picker와 운영 surface를 안정적으로 쓰려면 ~/.qwen/settings.json 또는 <workspace>/.qwen/settings.json 구성을 권장합니다.";
+    if configured {
+        Check::warn(
+            "provider_qwen_settings",
+            CheckGroup::ProviderRuntime,
+            "qwen settings files",
+            "no Qwen settings files detected",
+            guidance,
+        )
+        .with_expected_actual(
+            "at least one Qwen settings layer",
+            "no settings.json detected",
+        )
+        .with_next_steps(vec![
+            "ls -la ~/.qwen".to_string(),
+            "ls -la ./.qwen".to_string(),
+        ])
+    } else {
+        Check::ok(
+            "provider_qwen_settings",
+            CheckGroup::ProviderRuntime,
+            "qwen settings files",
+            "no Qwen settings files detected (provider not configured)",
+        )
+        .with_expected_actual(
+            "settings present if qwen is actively used",
+            "qwen not configured",
+        )
+    }
+}
+
+fn check_qwen_auth_hints(configured: bool) -> Check {
+    let home = qwen_home_dir();
+    let project = qwen_project_dir();
+    let oauth_cache = home
+        .as_ref()
+        .map(|path| path.join(".qwen").join("oauth_creds.json"));
+    let project_qwen_env = project
+        .as_ref()
+        .map(|path| path.join(".qwen").join(".env"));
+    let project_env = project.as_ref().map(|path| path.join(".env"));
+
+    let mut hints = Vec::new();
+    if oauth_cache.as_ref().is_some_and(|path| path.is_file()) {
+        hints.push("cached OAuth");
+    }
+    if project_qwen_env.as_ref().is_some_and(|path| path.is_file()) {
+        hints.push("project .qwen/.env");
+    }
+    if project_env.as_ref().is_some_and(|path| path.is_file()) {
+        hints.push("project .env");
+    }
+
+    let detail = if hints.is_empty() {
+        "interactive: OAuth or API key | headless: cached auth or API key only".to_string()
+    } else {
+        format!(
+            "interactive: OAuth or API key | headless: cached auth or API key only | found: {}",
+            hints.join(", ")
+        )
+    };
+
+    if !hints.is_empty() {
+        return Check::ok(
+            "provider_qwen_auth",
+            CheckGroup::ProviderRuntime,
+            "qwen auth hints",
+            detail,
+        )
+        .with_expected_actual(
+            "cached auth or API-key hint visible",
+            hints.join(", "),
+        )
+        .with_next_steps(vec![
+            "qwen auth status".to_string(),
+            "Open a Qwen CLI session and run /stats".to_string(),
+        ]);
+    }
+
+    let guidance = "API key 경로는 project .qwen/.env 우선, 그다음 .env를 확인하세요. Qwen CLI는 env-file을 merge하지 않습니다. 사용량/제한은 숫자를 doctor에 고정하지 말고 Qwen CLI 세션의 /stats 또는 공식 문서를 확인하세요.";
+    if configured {
+        Check::warn(
+            "provider_qwen_auth",
+            CheckGroup::ProviderRuntime,
+            "qwen auth hints",
+            detail,
+            guidance,
+        )
+        .with_expected_actual(
+            "cached auth or API-key hint visible",
+            "no oauth cache or env hints found",
+        )
+        .with_next_steps(vec![
+            "qwen auth status".to_string(),
+            "ls -la ./.qwen".to_string(),
+        ])
+    } else {
+        Check::ok(
+            "provider_qwen_auth",
+            CheckGroup::ProviderRuntime,
+            "qwen auth hints",
+            format!("{detail} (provider not configured)"),
+        )
+        .with_expected_actual(
+            "auth hint required only if qwen is used",
+            "qwen not configured",
+        )
+    }
+}
+
+fn check_qwen_runtime_artifacts(configured: bool) -> Check {
+    let home = qwen_home_dir();
+    let project = qwen_project_dir();
+
+    let home_artifacts = [
+        (
+            "extensions",
+            home.as_ref().map(|path| path.join(".qwen").join("extensions")),
+            false,
+        ),
+        (
+            "commands",
+            home.as_ref().map(|path| path.join(".qwen").join("commands")),
+            false,
+        ),
+        (
+            "agents",
+            home.as_ref().map(|path| path.join(".qwen").join("agents")),
+            false,
+        ),
+        (
+            "skills",
+            home.as_ref().map(|path| path.join(".qwen").join("skills")),
+            false,
+        ),
+        (
+            "output-language.md",
+            home.as_ref()
+                .map(|path| path.join(".qwen").join("output-language.md")),
+            true,
+        ),
+    ];
+    let project_artifacts = [
+        (
+            "commands",
+            project.as_ref().map(|path| path.join(".qwen").join("commands")),
+            false,
+        ),
+        (
+            "agents",
+            project.as_ref().map(|path| path.join(".qwen").join("agents")),
+            false,
+        ),
+        (
+            "skills",
+            project.as_ref().map(|path| path.join(".qwen").join("skills")),
+            false,
+        ),
+        (
+            "PROJECT_SUMMARY.md",
+            project
+                .as_ref()
+                .map(|path| path.join(".qwen").join("PROJECT_SUMMARY.md")),
+            true,
+        ),
+        (
+            "settings.json",
+            project
+                .as_ref()
+                .map(|path| path.join(".qwen").join("settings.json")),
+            true,
+        ),
+        (
+            ".qwen/.env",
+            project.as_ref().map(|path| path.join(".qwen").join(".env")),
+            true,
+        ),
+        (".env", project.as_ref().map(|path| path.join(".env")), true),
+    ];
+
+    let found_home: Vec<&str> = home_artifacts
+        .iter()
+        .filter_map(|(label, path, is_file)| {
+            path.as_ref().and_then(|path| {
+                let exists = if *is_file { path.is_file() } else { path.is_dir() };
+                exists.then_some(*label)
+            })
+        })
+        .collect();
+    let found_project: Vec<&str> = project_artifacts
+        .iter()
+        .filter_map(|(label, path, is_file)| {
+            path.as_ref().and_then(|path| {
+                let exists = if *is_file { path.is_file() } else { path.is_dir() };
+                exists.then_some(*label)
+            })
+        })
+        .collect();
+
+    let detail = format!(
+        "{} | {}",
+        format_artifact_scope("home", &found_home),
+        format_artifact_scope("project", &found_project)
+    );
+
+    if !found_home.is_empty() || !found_project.is_empty() {
+        return Check::ok(
+            "provider_qwen_runtime",
+            CheckGroup::ProviderRuntime,
+            "qwen runtime artifacts",
+            detail,
+        )
+        .with_expected_actual(
+            "Qwen runtime artifacts visible when configured",
+            format!(
+                "home={} project={}",
+                found_home.len(),
+                found_project.len()
+            ),
+        );
+    }
+
+    let guidance = "Qwen은 ~/.qwen/extensions, ~/.qwen/skills, <workspace>/.qwen/PROJECT_SUMMARY.md, <workspace>/.qwen/.env 같은 로컬 자산을 그대로 사용합니다. headless 환경에서는 project .qwen/.env 우선 여부를 함께 확인하세요.";
+    if configured {
+        Check::warn(
+            "provider_qwen_runtime",
+            CheckGroup::ProviderRuntime,
+            "qwen runtime artifacts",
+            detail,
+            guidance,
+        )
+        .with_expected_actual(
+            "at least one Qwen runtime artifact when heavily customized",
+            "no Qwen runtime artifacts detected",
+        )
+        .with_next_steps(vec![
+            "ls -la ~/.qwen".to_string(),
+            "ls -la ./.qwen".to_string(),
+        ])
+    } else {
+        Check::ok(
+            "provider_qwen_runtime",
+            CheckGroup::ProviderRuntime,
+            "qwen runtime artifacts",
+            format!("{detail} (provider not configured)"),
+        )
+        .with_expected_actual(
+            "runtime artifacts required only if qwen is used",
+            "qwen not configured",
+        )
+    }
+}
+
 fn health_endpoint(base: &str) -> String {
     format!("{}/api/health", base.trim_end_matches('/'))
 }
@@ -331,6 +660,7 @@ fn build_core_checks(cfg: &config::Config, snapshot: &HealthSnapshot) -> Vec<Che
 
 fn build_provider_checks(cfg: &config::Config, snapshot: &HealthSnapshot) -> Vec<Check> {
     let configured = configured_provider_names(cfg, snapshot);
+    let qwen_configured = configured.contains("qwen");
     vec![
         check_runtime_path(),
         check_provider_cli(
@@ -344,7 +674,10 @@ fn build_provider_checks(cfg: &config::Config, snapshot: &HealthSnapshot) -> Vec
             configured.contains("gemini"),
             snapshot,
         ),
-        check_provider_cli(ProviderKind::Qwen, configured.contains("qwen"), snapshot),
+        check_provider_cli(ProviderKind::Qwen, qwen_configured, snapshot),
+        check_qwen_settings_files(qwen_configured),
+        check_qwen_auth_hints(qwen_configured),
+        check_qwen_runtime_artifacts(qwen_configured),
     ]
 }
 
@@ -1433,19 +1766,49 @@ pub fn cmd_doctor(fix: bool, json: bool) -> Result<(), String> {
 mod tests {
     use super::{
         Check, CheckGroup, CheckStatus, FixAction, HealthSnapshot, build_json_report,
-        check_provider_cli, check_server_running, configured_provider_names,
-        discord_bot_check_from_health, provider_capability_summary,
+        check_provider_cli, check_qwen_auth_hints, check_qwen_runtime_artifacts,
+        check_server_running, configured_provider_names, discord_bot_check_from_health,
+        provider_capability_summary,
     };
     use crate::config::ServerConfig;
     use crate::services::provider::ProviderKind;
     use serde_json::json;
     use std::path::Path;
-    use std::sync::MutexGuard;
 
-    fn env_guard() -> MutexGuard<'static, ()> {
-        crate::services::discord::runtime_store::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+    fn with_temp_qwen_doctor_env<F>(f: F)
+    where
+        F: FnOnce(&tempfile::TempDir, &tempfile::TempDir),
+    {
+        let _guard = crate::services::discord::runtime_store::lock_test_env();
+        let temp_home = tempfile::tempdir().unwrap();
+        let temp_project = tempfile::tempdir().unwrap();
+        let prev_home = std::env::var_os("HOME");
+        let prev_userprofile = std::env::var_os("USERPROFILE");
+        let prev_test_home = std::env::var_os("AGENTDESK_TEST_HOME");
+        let prev_cwd = std::env::current_dir().unwrap();
+
+        unsafe {
+            std::env::set_var("HOME", temp_home.path());
+            std::env::set_var("USERPROFILE", temp_home.path());
+            std::env::set_var("AGENTDESK_TEST_HOME", temp_home.path());
+        }
+        std::env::set_current_dir(temp_project.path()).unwrap();
+
+        f(&temp_home, &temp_project);
+
+        std::env::set_current_dir(prev_cwd).unwrap();
+        match prev_home {
+            Some(value) => unsafe { std::env::set_var("HOME", value) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        match prev_userprofile {
+            Some(value) => unsafe { std::env::set_var("USERPROFILE", value) },
+            None => unsafe { std::env::remove_var("USERPROFILE") },
+        }
+        match prev_test_home {
+            Some(value) => unsafe { std::env::set_var("AGENTDESK_TEST_HOME", value) },
+            None => unsafe { std::env::remove_var("AGENTDESK_TEST_HOME") },
+        }
     }
 
     #[cfg(unix)]
@@ -1552,7 +1915,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn provider_runtime_check_uses_resolver_exec_path_under_minimal_path() {
-        let _guard = env_guard();
+        let _guard = crate::services::discord::runtime_store::lock_test_env();
         let temp = tempfile::tempdir().unwrap();
         let helper = temp.path().join("provider-helper");
         let provider = temp.path().join("codex");
@@ -1598,7 +1961,7 @@ mod tests {
     fn provider_runtime_check_reports_permission_denied() {
         use std::os::unix::fs::PermissionsExt;
 
-        let _guard = env_guard();
+        let _guard = crate::services::discord::runtime_store::lock_test_env();
         let temp = tempfile::tempdir().unwrap();
         let provider = temp.path().join("codex");
         let original_path = std::env::var_os("PATH");
@@ -1632,6 +1995,53 @@ mod tests {
                 None => std::env::remove_var("PATH"),
             }
         }
+    }
+
+    #[test]
+    fn qwen_doctor_detects_home_extensions_not_project_extensions() {
+        with_temp_qwen_doctor_env(|temp_home, temp_project| {
+            let home_qwen = temp_home.path().join(".qwen");
+            let project_qwen = temp_project.path().join(".qwen");
+            std::fs::create_dir_all(home_qwen.join("extensions")).unwrap();
+            std::fs::create_dir_all(&project_qwen).unwrap();
+
+            let check = check_qwen_runtime_artifacts(true);
+            assert_eq!(check.status, CheckStatus::Pass);
+            assert!(check.detail.contains("home: extensions"));
+            assert!(check.detail.contains("project: -"));
+        });
+    }
+
+    #[test]
+    fn qwen_doctor_surfaces_project_summary_and_output_language() {
+        with_temp_qwen_doctor_env(|temp_home, temp_project| {
+            let home_qwen = temp_home.path().join(".qwen");
+            let project_qwen = temp_project.path().join(".qwen");
+            std::fs::create_dir_all(&home_qwen).unwrap();
+            std::fs::create_dir_all(&project_qwen).unwrap();
+            std::fs::write(home_qwen.join("output-language.md"), "Korean").unwrap();
+            std::fs::write(project_qwen.join("PROJECT_SUMMARY.md"), "Summary").unwrap();
+
+            let check = check_qwen_runtime_artifacts(true);
+            assert_eq!(check.status, CheckStatus::Pass);
+            assert!(check.detail.contains("output-language.md"));
+            assert!(check.detail.contains("PROJECT_SUMMARY.md"));
+        });
+    }
+
+    #[test]
+    fn qwen_doctor_auth_hint_prefers_project_dot_qwen_env_before_dot_env() {
+        with_temp_qwen_doctor_env(|_temp_home, temp_project| {
+            let project_qwen = temp_project.path().join(".qwen");
+            std::fs::create_dir_all(&project_qwen).unwrap();
+            std::fs::write(project_qwen.join(".env"), "DASHSCOPE_API_KEY=one").unwrap();
+            std::fs::write(temp_project.path().join(".env"), "OPENAI_API_KEY=two").unwrap();
+
+            let check = check_qwen_auth_hints(true);
+            assert_eq!(check.status, CheckStatus::Pass);
+            assert!(check.detail.contains("project .qwen/.env"));
+            assert!(check.detail.contains("project .env"));
+        });
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -348,15 +348,13 @@ pub(crate) fn shared_test_env_lock() -> &'static std::sync::Mutex<()> {
 mod tests {
     use super::{
         AgentDef, BotConfig, Config, load_from_path, resolve_graceful_config_path, runtime_root,
-        save_to_path, shared_test_env_lock,
+        save_to_path,
     };
     use std::path::PathBuf;
     use std::sync::MutexGuard;
 
     fn env_lock() -> MutexGuard<'static, ()> {
-        shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+        crate::services::discord::runtime_store::lock_test_env()
     }
 
     #[test]

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -1571,10 +1571,6 @@ mod tests {
     use std::process::Command;
     use std::sync::MutexGuard;
 
-    fn repo_dir_env_lock() -> &'static std::sync::Mutex<()> {
-        crate::config::shared_test_env_lock()
-    }
-
     struct RepoDirOverride {
         _lock: MutexGuard<'static, ()>,
         previous: Option<String>,
@@ -1582,7 +1578,7 @@ mod tests {
 
     impl RepoDirOverride {
         fn new(path: &str) -> Self {
-            let lock = repo_dir_env_lock().lock().unwrap();
+            let lock = crate::services::discord::runtime_store::lock_test_env();
             let previous = std::env::var("AGENTDESK_REPO_DIR").ok();
             unsafe { std::env::set_var("AGENTDESK_REPO_DIR", path) };
             Self {
@@ -2140,7 +2136,9 @@ mod tests {
         conn.execute(
             "UPDATE agents
              SET discord_channel_id = NULL,
-                 discord_channel_alt = NULL
+                 discord_channel_alt = NULL,
+                 discord_channel_cc = NULL,
+                 discord_channel_cdx = NULL
              WHERE id = 'agent-1'",
             [],
         )

--- a/src/engine/ops.rs
+++ b/src/engine/ops.rs
@@ -1723,6 +1723,13 @@ pub fn review_state_sync_on_conn(conn: &rusqlite::Connection, json_str: &str) ->
 // agentdesk.exec(command, args) → stdout string
 // Runs a local command synchronously. Limited to safe commands.
 
+fn exec_override_env_var(cmd: &str) -> String {
+    format!(
+        "AGENTDESK_{}_PATH",
+        cmd.replace('-', "_").to_ascii_uppercase()
+    )
+}
+
 fn register_exec_ops<'js>(ctx: &Ctx<'js>) -> JsResult<()> {
     let ad: Object<'js> = ctx.globals().get("agentdesk")?;
 
@@ -1736,7 +1743,13 @@ fn register_exec_ops<'js>(ctx: &Ctx<'js>) -> JsResult<()> {
             }
 
             let args: Vec<String> = serde_json::from_str(&args_json).unwrap_or_default();
-            match std::process::Command::new(&cmd).args(&args).output() {
+            let command_path = std::env::var_os(exec_override_env_var(&cmd))
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| std::ffi::OsString::from(&cmd));
+            match std::process::Command::new(&command_path)
+                .args(&args)
+                .output()
+            {
                 Ok(output) if output.status.success() => {
                     String::from_utf8_lossy(&output.stdout).trim().to_string()
                 }

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -3,6 +3,9 @@ pub mod sync;
 pub mod triage;
 
 use crate::db::Db;
+use crate::services::platform::binary_resolver::{
+    apply_runtime_path, resolve_binary_with_login_shell,
+};
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
@@ -15,14 +18,14 @@ fn gh_path() -> Option<String> {
 
     static GH_PATH: OnceLock<Option<String>> = OnceLock::new();
     GH_PATH
-        .get_or_init(|| crate::services::platform::resolve_binary_with_login_shell("gh"))
+        .get_or_init(|| resolve_binary_with_login_shell("gh"))
         .clone()
 }
 
 fn gh_command() -> Result<std::process::Command, String> {
     let gh = gh_path().ok_or_else(|| "gh CLI is not available".to_string())?;
     let mut command = std::process::Command::new(&gh);
-    crate::services::platform::apply_runtime_path(&mut command);
+    apply_runtime_path(&mut command);
     Ok(command)
 }
 

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -3,6 +3,37 @@ pub mod sync;
 pub mod triage;
 
 use crate::db::Db;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+const GH_PATH_OVERRIDE_ENV: &str = "AGENTDESK_GH_PATH";
+
+fn gh_path() -> Option<String> {
+    if let Some(override_path) = std::env::var_os(GH_PATH_OVERRIDE_ENV).filter(|p| !p.is_empty()) {
+        return Some(PathBuf::from(override_path).to_string_lossy().to_string());
+    }
+
+    static GH_PATH: OnceLock<Option<String>> = OnceLock::new();
+    GH_PATH
+        .get_or_init(|| crate::services::platform::resolve_binary_with_login_shell("gh"))
+        .clone()
+}
+
+fn gh_command() -> Result<std::process::Command, String> {
+    let gh = gh_path().ok_or_else(|| "gh CLI is not available".to_string())?;
+    let mut command = std::process::Command::new(&gh);
+    crate::services::platform::apply_runtime_path(&mut command);
+    Ok(command)
+}
+
+fn tokio_gh_command() -> Result<tokio::process::Command, String> {
+    let gh = gh_path().ok_or_else(|| "gh CLI is not available".to_string())?;
+    let mut command = tokio::process::Command::new(&gh);
+    if let Some(path) = crate::services::platform::merged_runtime_path() {
+        command.env("PATH", path);
+    }
+    Ok(command)
+}
 
 /// Check whether the `gh` CLI is available on this system.
 pub fn gh_available() -> bool {

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -13,9 +13,6 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 
-    #[cfg(unix)]
-    use std::os::unix::fs::PermissionsExt;
-
     use crate::db;
     use crate::dispatch;
     use crate::engine::PolicyEngine;

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -13,6 +13,9 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
     use crate::db;
     use crate::dispatch;
     use crate::engine::PolicyEngine;
@@ -330,9 +333,12 @@ mod tests {
             script_body
         );
         fs::write(&gh_path, script).unwrap();
-        let mut perms = fs::metadata(&gh_path).unwrap().permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&gh_path, perms).unwrap();
+        #[cfg(unix)]
+        {
+            let mut perms = fs::metadata(&gh_path).unwrap().permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&gh_path, perms).unwrap();
+        }
 
         let old_path = std::env::var_os("PATH");
         let new_path = match &old_path {

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -303,10 +303,15 @@ mod tests {
         _lock: std::sync::MutexGuard<'static, ()>,
         _dir: tempfile::TempDir,
         old_path: Option<OsString>,
+        old_gh_path: Option<OsString>,
         log_path: PathBuf,
     }
 
-    #[cfg(unix)]
+    struct MockGhReply {
+        key: &'static str,
+        contains: Option<&'static str>,
+        stdout: &'static str,
+    }
     impl Drop for MockGhEnv {
         fn drop(&mut self) {
             if let Some(old_path) = &self.old_path {
@@ -318,42 +323,136 @@ mod tests {
                     std::env::remove_var("PATH");
                 }
             }
+            if let Some(old_gh_path) = &self.old_gh_path {
+                unsafe {
+                    std::env::set_var("AGENTDESK_GH_PATH", old_gh_path);
+                }
+            } else {
+                unsafe {
+                    std::env::remove_var("AGENTDESK_GH_PATH");
+                }
+            }
         }
     }
 
     #[cfg(unix)]
-    fn install_mock_gh(script_body: &str) -> MockGhEnv {
+    fn build_mock_gh_script(replies: &[MockGhReply]) -> String {
+        let mut script = String::from(
+            "#!/bin/sh\nset -eu\nlog_file=\"$(dirname \"$0\")/gh.log\"\nprintf '%s\\n' \"$*\" >> \"$log_file\"\nif [ \"${1-}\" = \"--version\" ]; then\n  echo 'gh mock 1.0'\n  exit 0\nfi\nkey=\"${1-}:${2-}\"\nargs=\"$*\"\n",
+        );
+
+        for reply in replies {
+            script.push_str(&format!("if [ \"$key\" = '{}' ]", reply.key));
+            if let Some(token) = reply.contains {
+                script.push_str(&format!(
+                    " && printf '%s\\n' \"$args\" | grep -F -q -- '{}'",
+                    token
+                ));
+            }
+            script.push_str("; then\n");
+            script.push_str("cat <<'JSON'\n");
+            script.push_str(reply.stdout);
+            script.push_str("\nJSON\nexit 0\nfi\n");
+        }
+
+        script.push_str("echo '[]'\n");
+        script
+    }
+
+    #[cfg(windows)]
+    fn build_mock_gh_script(replies: &[MockGhReply]) -> (String, String) {
+        let wrapper =
+            "@echo off\r\npwsh -NoProfile -ExecutionPolicy Bypass -File \"%~dp0gh.ps1\" %*\r\n"
+                .to_string();
+
+        let mut script = String::from(
+            "$LogFile = Join-Path $PSScriptRoot 'gh.log'\nAdd-Content -Path $LogFile -Value ($args -join ' ')\nif ($args.Count -gt 0 -and $args[0] -eq '--version') {\n  Write-Output 'gh mock 1.0'\n  exit 0\n}\n$key = if ($args.Count -ge 2) { \"$($args[0]):$($args[1])\" } elseif ($args.Count -eq 1) { \"$($args[0]):\" } else { ':' }\n$joined = $args -join ' '\n",
+        );
+
+        for reply in replies {
+            script.push_str(&format!("if ($key -eq '{}'", reply.key.replace('\'', "''")));
+            if let Some(token) = reply.contains {
+                script.push_str(&format!(
+                    " -and $joined.Contains('{}')",
+                    token.replace('\'', "''")
+                ));
+            }
+            script.push_str(") {\n");
+            script.push_str("@'\n");
+            script.push_str(reply.stdout);
+            script.push_str("\n'@ | Write-Output\nexit 0\n}\n");
+        }
+
+        script.push_str("'[]' | Write-Output\n");
+        (wrapper, script)
+    }
+
+    fn install_mock_gh(replies: &[MockGhReply]) -> MockGhEnv {
         let lock = crate::services::discord::runtime_store::lock_test_env();
         let dir = tempfile::tempdir().unwrap();
-        let gh_path = dir.path().join("gh");
         let log_path = dir.path().join("gh.log");
-
-        let script = format!(
-            "#!/bin/sh\nset -eu\nlog_file=\"$(dirname \"$0\")/gh.log\"\nprintf '%s\\n' \"$*\" >> \"$log_file\"\n{}\n",
-            script_body
-        );
-        fs::write(&gh_path, script).unwrap();
         #[cfg(unix)]
         {
+            let gh_path = dir.path().join("gh");
+            let script = build_mock_gh_script(replies);
+            fs::write(&gh_path, script).unwrap();
             let mut perms = fs::metadata(&gh_path).unwrap().permissions();
             perms.set_mode(0o755);
             fs::set_permissions(&gh_path, perms).unwrap();
+            let old_path = std::env::var_os("PATH");
+            let old_gh_path = std::env::var_os("AGENTDESK_GH_PATH");
+            let joined = match &old_path {
+                Some(existing) => std::env::join_paths(
+                    std::iter::once(dir.path().to_path_buf())
+                        .chain(std::env::split_paths(existing)),
+                )
+                .unwrap(),
+                None => std::env::join_paths([dir.path()]).unwrap(),
+            };
+            unsafe {
+                std::env::set_var("PATH", joined);
+                std::env::set_var("AGENTDESK_GH_PATH", &gh_path);
+            }
+
+            return MockGhEnv {
+                _lock: lock,
+                _dir: dir,
+                old_path,
+                old_gh_path,
+                log_path,
+            };
         }
 
-        let old_path = std::env::var_os("PATH");
-        let new_path = match &old_path {
-            Some(existing) => format!("{}:{}", dir.path().display(), existing.to_string_lossy()),
-            None => dir.path().display().to_string(),
-        };
-        unsafe {
-            std::env::set_var("PATH", new_path);
-        }
+        #[cfg(windows)]
+        {
+            let gh_cmd_path = dir.path().join("gh.cmd");
+            let gh_ps1_path = dir.path().join("gh.ps1");
+            let (wrapper, script) = build_mock_gh_script(replies);
+            fs::write(&gh_cmd_path, wrapper).unwrap();
+            fs::write(&gh_ps1_path, script).unwrap();
 
-        MockGhEnv {
-            _lock: lock,
-            _dir: dir,
-            old_path,
-            log_path,
+            let old_path = std::env::var_os("PATH");
+            let old_gh_path = std::env::var_os("AGENTDESK_GH_PATH");
+            let joined = match &old_path {
+                Some(existing) => std::env::join_paths(
+                    std::iter::once(dir.path().to_path_buf())
+                        .chain(std::env::split_paths(existing)),
+                )
+                .unwrap(),
+                None => std::env::join_paths([dir.path()]).unwrap(),
+            };
+            unsafe {
+                std::env::set_var("PATH", joined);
+                std::env::set_var("AGENTDESK_GH_PATH", &gh_cmd_path);
+            }
+
+            return MockGhEnv {
+                _lock: lock,
+                _dir: dir,
+                old_path,
+                old_gh_path,
+                log_path,
+            };
         }
     }
 
@@ -3003,32 +3102,28 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn scenario_208_on_tick_creates_codex_rework_and_dedups_review() {
-        let _gh = install_mock_gh(
-            r#"
-case "$1:$2" in
-  pr:list)
-    if printf '%s\n' "$*" | grep -q -- "--state merged"; then
-      echo '[]'
-    else
-      echo '[{"number":323,"headRefName":"wt/card-208","title":"fix: close review gap (#208)","mergeable":"MERGEABLE"}]'
-    fi
-    ;;
-  api:repos/test/repo/pulls/323/reviews)
-    cat <<'JSON'
-[{"id":9001,"state":"COMMENTED","body":"P1/P2 findings","submitted_at":"2026-04-06T00:00:00Z","user":{"login":"chatgpt-codex-connector"}}]
-JSON
-    ;;
-  api:graphql)
-    cat <<'JSON'
-{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"thread-1","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"id":"comment-1","body":"P1 force-transition leaves dispatch alive","path":"src/server/routes/github.rs","line":77,"url":"https://example.com/comment-1","author":{"login":"chatgpt-codex-connector"},"pullRequestReview":{"id":"PRR_9001","state":"COMMENTED","author":{"login":"chatgpt-codex-connector"}}}]}}]}}}}}
-JSON
-    ;;
-  *)
-    echo '[]'
-    ;;
-esac
-"#,
-        );
+        let _gh = install_mock_gh(&[
+            MockGhReply {
+                key: "pr:list",
+                contains: Some("--state merged"),
+                stdout: "[]",
+            },
+            MockGhReply {
+                key: "pr:list",
+                contains: None,
+                stdout: "[{\"number\":323,\"headRefName\":\"wt/card-208\",\"title\":\"fix: close review gap (#208)\",\"mergeable\":\"MERGEABLE\"}]",
+            },
+            MockGhReply {
+                key: "api:repos/test/repo/pulls/323/reviews",
+                contains: None,
+                stdout: "[{\"id\":9001,\"state\":\"COMMENTED\",\"body\":\"P1/P2 findings\",\"submitted_at\":\"2026-04-06T00:00:00Z\",\"user\":{\"login\":\"chatgpt-codex-connector\"}}]",
+            },
+            MockGhReply {
+                key: "api:graphql",
+                contains: None,
+                stdout: "{\"data\":{\"repository\":{\"pullRequest\":{\"reviewThreads\":{\"nodes\":[{\"id\":\"thread-1\",\"isResolved\":false,\"isOutdated\":false,\"comments\":{\"nodes\":[{\"id\":\"comment-1\",\"body\":\"P1 force-transition leaves dispatch alive\",\"path\":\"src/server/routes/github.rs\",\"line\":77,\"url\":\"https://example.com/comment-1\",\"author\":{\"login\":\"chatgpt-codex-connector\"},\"pullRequestReview\":{\"id\":\"PRR_9001\",\"state\":\"COMMENTED\",\"author\":{\"login\":\"chatgpt-codex-connector\"}}}]}}]}}}}}",
+            },
+        ]);
 
         let db = test_db();
         let engine = test_engine(&db);
@@ -3076,32 +3171,28 @@ esac
     #[cfg(unix)]
     #[test]
     fn scenario_208_on_tick_notifies_clean_codex_pass() {
-        let _gh = install_mock_gh(
-            r#"
-case "$1:$2" in
-  pr:list)
-    if printf '%s\n' "$*" | grep -q -- "--state merged"; then
-      echo '[]'
-    else
-      echo '[{"number":324,"headRefName":"wt/card-208-pass","title":"fix: no inline findings (#209)","mergeable":"MERGEABLE"}]'
-    fi
-    ;;
-  api:repos/test/repo/pulls/324/reviews)
-    cat <<'JSON'
-[{"id":9002,"state":"APPROVED","body":"LGTM","submitted_at":"2026-04-06T00:05:00Z","user":{"login":"chatgpt-codex-connector"}}]
-JSON
-    ;;
-  api:graphql)
-    cat <<'JSON'
-{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}
-JSON
-    ;;
-  *)
-    echo '[]'
-    ;;
-esac
-"#,
-        );
+        let _gh = install_mock_gh(&[
+            MockGhReply {
+                key: "pr:list",
+                contains: Some("--state merged"),
+                stdout: "[]",
+            },
+            MockGhReply {
+                key: "pr:list",
+                contains: None,
+                stdout: "[{\"number\":324,\"headRefName\":\"wt/card-208-pass\",\"title\":\"fix: no inline findings (#209)\",\"mergeable\":\"MERGEABLE\"}]",
+            },
+            MockGhReply {
+                key: "api:repos/test/repo/pulls/324/reviews",
+                contains: None,
+                stdout: "[{\"id\":9002,\"state\":\"APPROVED\",\"body\":\"LGTM\",\"submitted_at\":\"2026-04-06T00:05:00Z\",\"user\":{\"login\":\"chatgpt-codex-connector\"}}]",
+            },
+            MockGhReply {
+                key: "api:graphql",
+                contains: None,
+                stdout: "{\"data\":{\"repository\":{\"pullRequest\":{\"reviewThreads\":{\"nodes\":[]}}}}}",
+            },
+        ]);
 
         let db = test_db();
         let engine = test_engine(&db);
@@ -3145,31 +3236,28 @@ esac
     #[cfg(unix)]
     #[test]
     fn scenario_208_merge_guard_blocks_unresolved_codex_comments() {
-        let gh = install_mock_gh(
-            r#"
-case "$1:$2" in
-  pr:view)
-    echo 'itismyfield'
-    ;;
-  api:repos/test/repo/pulls/325/reviews)
-    cat <<'JSON'
-[{"id":9003,"state":"COMMENTED","body":"P2 findings","submitted_at":"2026-04-06T00:10:00Z","user":{"login":"chatgpt-codex-connector"}}]
-JSON
-    ;;
-  api:graphql)
-    cat <<'JSON'
-{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"thread-2","isResolved":false,"isOutdated":false,"comments":{"nodes":[{"id":"comment-2","body":"P2 orphan recovery revives reverted card","path":"src/kanban.rs","line":212,"url":"https://example.com/comment-2","author":{"login":"chatgpt-codex-connector"},"pullRequestReview":{"id":"PRR_9003","state":"COMMENTED","author":{"login":"chatgpt-codex-connector"}}}]}}]}}}}}
-JSON
-    ;;
-  pr:merge)
-    echo 'merged'
-    ;;
-  *)
-    echo '[]'
-    ;;
-esac
-"#,
-        );
+        let gh = install_mock_gh(&[
+            MockGhReply {
+                key: "pr:view",
+                contains: None,
+                stdout: "itismyfield",
+            },
+            MockGhReply {
+                key: "api:repos/test/repo/pulls/325/reviews",
+                contains: None,
+                stdout: "[{\"id\":9003,\"state\":\"COMMENTED\",\"body\":\"P2 findings\",\"submitted_at\":\"2026-04-06T00:10:00Z\",\"user\":{\"login\":\"chatgpt-codex-connector\"}}]",
+            },
+            MockGhReply {
+                key: "api:graphql",
+                contains: None,
+                stdout: "{\"data\":{\"repository\":{\"pullRequest\":{\"reviewThreads\":{\"nodes\":[{\"id\":\"thread-2\",\"isResolved\":false,\"isOutdated\":false,\"comments\":{\"nodes\":[{\"id\":\"comment-2\",\"body\":\"P2 orphan recovery revives reverted card\",\"path\":\"src/kanban.rs\",\"line\":212,\"url\":\"https://example.com/comment-2\",\"author\":{\"login\":\"chatgpt-codex-connector\"},\"pullRequestReview\":{\"id\":\"PRR_9003\",\"state\":\"COMMENTED\",\"author\":{\"login\":\"chatgpt-codex-connector\"}}}]}}]}}}}}",
+            },
+            MockGhReply {
+                key: "pr:merge",
+                contains: None,
+                stdout: "merged",
+            },
+        ]);
 
         let db = test_db();
         let engine = test_engine(&db);

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -296,12 +296,6 @@ mod tests {
             .unwrap()
     }
 
-    #[cfg(unix)]
-    fn gh_env_lock() -> &'static Mutex<()> {
-        crate::config::shared_test_env_lock()
-    }
-
-    #[cfg(unix)]
     struct MockGhEnv {
         _lock: std::sync::MutexGuard<'static, ()>,
         _dir: tempfile::TempDir,
@@ -326,7 +320,7 @@ mod tests {
 
     #[cfg(unix)]
     fn install_mock_gh(script_body: &str) -> MockGhEnv {
-        let lock = gh_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let lock = crate::services::discord::runtime_store::lock_test_env();
         let dir = tempfile::tempdir().unwrap();
         let gh_path = dir.path().join("gh");
         let log_path = dir.path().join("gh.log");

--- a/src/kanban.rs
+++ b/src/kanban.rs
@@ -1743,9 +1743,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn deploy_pipeline_uses_card_scoped_worktree_instead_of_latest_session_cwd() {
-        let _env_guard = crate::services::discord::runtime_store::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let _env_guard = crate::services::discord::runtime_store::lock_test_env();
 
         let temp = TempDir::new().unwrap();
         let policies_dir = temp.path().join("policies");

--- a/src/runtime_layout.rs
+++ b/src/runtime_layout.rs
@@ -1447,7 +1447,22 @@ fn remove_legacy_path(path: &Path) -> Result<(), String> {
 fn remove_link_or_path(path: &Path) -> Result<(), String> {
     let meta = fs::symlink_metadata(path)
         .map_err(|e| format!("Failed to stat '{}': {e}", path.display()))?;
-    if meta.is_dir() && !meta.file_type().is_symlink() {
+    if meta.file_type().is_symlink() {
+        #[cfg(windows)]
+        {
+            if fs::metadata(path)
+                .map(|target| target.is_dir())
+                .unwrap_or(false)
+            {
+                return fs::remove_dir(path)
+                    .map_err(|e| format!("Failed to remove '{}': {e}", path.display()));
+            }
+        }
+        return fs::remove_file(path)
+            .map_err(|e| format!("Failed to remove '{}': {e}", path.display()));
+    }
+
+    if meta.is_dir() {
         fs::remove_dir_all(path).map_err(|e| format!("Failed to remove '{}': {e}", path.display()))
     } else {
         #[cfg(windows)]

--- a/src/server/routes/dispatched_sessions.rs
+++ b/src/server/routes/dispatched_sessions.rs
@@ -1472,9 +1472,7 @@ mod tests {
     }
 
     fn env_lock() -> MutexGuard<'static, ()> {
-        crate::services::discord::runtime_store::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+        crate::services::discord::runtime_store::lock_test_env()
     }
 
     struct EnvVarGuard {

--- a/src/server/routes/onboarding.rs
+++ b/src/server/routes/onboarding.rs
@@ -988,9 +988,7 @@ mod tests {
     use axum::{Router, extract::Path as AxumPath, routing::get};
 
     fn env_guard() -> MutexGuard<'static, ()> {
-        crate::services::discord::runtime_store::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+        crate::services::discord::runtime_store::lock_test_env()
     }
 
     #[cfg(unix)]

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -107,6 +107,8 @@ fn setup_test_repo() -> (tempfile::TempDir, RepoDirOverride) {
             _env: env,
         },
     )
+}
+
 fn git_commit(repo_dir: &std::path::Path, message: &str) -> String {
     let filename = format!(
         "commit-{}.txt",
@@ -3491,6 +3493,23 @@ async fn rereview_reactivates_done_card_with_fresh_review_dispatch() {
             |row| row.get(0),
         )
         .unwrap();
+    let reviewed_commit = conn
+        .query_row(
+            "SELECT context FROM task_dispatches WHERE id = ?1",
+            [&review_dispatch_id],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .unwrap()
+        .and_then(|context| {
+            serde_json::from_str::<serde_json::Value>(&context)
+                .ok()
+                .and_then(|value| {
+                    value
+                        .get("reviewed_commit")
+                        .and_then(|entry| entry.as_str())
+                        .map(str::to_string)
+                })
+        });
     assert_eq!(dispatch_status, "pending");
     assert_eq!(
         reviewed_commit.as_deref(),

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -48,9 +48,7 @@ fn test_api_router(
 }
 
 fn env_lock() -> MutexGuard<'static, ()> {
-    crate::services::discord::runtime_store::test_env_lock()
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
+    crate::services::discord::runtime_store::lock_test_env()
 }
 
 struct EnvVarGuard {
@@ -109,6 +107,24 @@ fn setup_test_repo() -> (tempfile::TempDir, RepoDirOverride) {
             _env: env,
         },
     )
+fn git_commit(repo_dir: &std::path::Path, message: &str) -> String {
+    let filename = format!(
+        "commit-{}.txt",
+        message
+            .chars()
+            .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
+            .collect::<String>()
+    );
+    std::fs::write(repo_dir.join(filename), format!("{message}\n")).unwrap();
+    run_git(repo_dir, &["add", "."]);
+    run_git(repo_dir, &["commit", "-m", message]);
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(repo_dir)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
 }
 
 #[tokio::test]
@@ -3342,13 +3358,21 @@ async fn force_transition_to_ready_cancels_live_dispatches_and_skips_auto_queue_
 
 #[tokio::test]
 async fn rereview_reactivates_done_card_with_fresh_review_dispatch() {
-    let (_repo, _repo_guard) = setup_test_repo();
     crate::pipeline::ensure_loaded();
+    let _env_lock = env_lock();
     let db = test_db();
     let engine = test_engine(&db);
     seed_agent(&db, "agent-rereview");
     set_pmd_channel(&db, "pmd-chan-123");
     ensure_auto_queue_tables(&db);
+
+    let repo = tempfile::tempdir().unwrap();
+    run_git(repo.path(), &["init", "-b", "main"]);
+    run_git(repo.path(), &["config", "user.email", "test@test.com"]);
+    run_git(repo.path(), &["config", "user.name", "Test"]);
+    run_git(repo.path(), &["commit", "--allow-empty", "-m", "initial"]);
+    let expected_commit = git_commit(repo.path(), "fix: review target (#269)");
+    let _repo_dir = EnvVarGuard::set_path("AGENTDESK_REPO_DIR", repo.path());
 
     let completed_commit = "1111111111111111111111111111111111111269";
     {
@@ -3468,6 +3492,11 @@ async fn rereview_reactivates_done_card_with_fresh_review_dispatch() {
         )
         .unwrap();
     assert_eq!(dispatch_status, "pending");
+    assert_eq!(
+        reviewed_commit.as_deref(),
+        Some(expected_commit.as_str()),
+        "reviewed_commit should be recovered from the repo fallback chain"
+    );
 
     let (entry_status, entry_dispatch_id): (String, String) = conn
         .query_row(

--- a/src/services/discord/commands/config.rs
+++ b/src/services/discord/commands/config.rs
@@ -5,11 +5,11 @@ use poise::serenity_prelude as serenity;
 
 use super::super::formatting::{canonical_tool_name, risk_badge, send_long_message_ctx, tool_info};
 use super::super::model_catalog::{
-    is_default_picker_value, SOURCE_DISPATCH_ROLE, SOURCE_PROVIDER_DEFAULT, SOURCE_ROLE_MAP,
-    SOURCE_RUNTIME_OVERRIDE,
+    SOURCE_DISPATCH_ROLE, SOURCE_PROVIDER_DEFAULT, SOURCE_ROLE_MAP, SOURCE_RUNTIME_OVERRIDE,
+    is_default_picker_value,
 };
 use super::super::settings::{resolve_role_binding, save_bot_settings};
-use super::super::{check_auth, check_owner, Context, Error, SharedData};
+use super::super::{Context, Error, SharedData, check_auth, check_owner};
 use super::model_ui::{
     build_model_picker_options, build_model_picker_summary_lines, has_pending_model_change,
 };
@@ -706,7 +706,7 @@ pub(in crate::services::discord) async fn cmd_allowall(
 #[cfg(test)]
 mod tests {
     use crate::services::discord::model_catalog::{
-        known_models, validate_model_input, DEFAULT_PICKER_VALUE,
+        DEFAULT_PICKER_VALUE, known_models, validate_model_input,
     };
 
     use super::super::model_ui::{
@@ -981,10 +981,12 @@ mod tests {
             gpt_54.description,
             "Frontier coding baseline | API $2.5/$15"
         );
-        assert!(options
-            .iter()
-            .any(|entry| entry.label == "GPT-5.3-Codex-Spark"
-                && entry.description == "Text-only preview | No API"));
+        assert!(
+            options
+                .iter()
+                .any(|entry| entry.label == "GPT-5.3-Codex-Spark"
+                    && entry.description == "Text-only preview | No API")
+        );
     }
 
     #[test]
@@ -1072,9 +1074,11 @@ mod tests {
             PROVIDER_DEFAULT_SOURCE,
             None,
         );
-        assert!(options
-            .iter()
-            .any(|entry| entry.value == "sonnet" && entry.label == "Sonnet 4.6"));
+        assert!(
+            options
+                .iter()
+                .any(|entry| entry.value == "sonnet" && entry.label == "Sonnet 4.6")
+        );
         assert!(options.iter().any(|entry| entry.value == "sonnet[1m]"
             && entry.label == "Sonnet 4.6 1M"
             && entry.description == "1M context window | Sonnet 4.6 alias"));

--- a/src/services/discord/commands/config.rs
+++ b/src/services/discord/commands/config.rs
@@ -5,11 +5,11 @@ use poise::serenity_prelude as serenity;
 
 use super::super::formatting::{canonical_tool_name, risk_badge, send_long_message_ctx, tool_info};
 use super::super::model_catalog::{
-    SOURCE_DISPATCH_ROLE, SOURCE_PROVIDER_DEFAULT, SOURCE_ROLE_MAP, SOURCE_RUNTIME_OVERRIDE,
-    is_default_picker_value,
+    is_default_picker_value, SOURCE_DISPATCH_ROLE, SOURCE_PROVIDER_DEFAULT, SOURCE_ROLE_MAP,
+    SOURCE_RUNTIME_OVERRIDE,
 };
 use super::super::settings::{resolve_role_binding, save_bot_settings};
-use super::super::{Context, Error, SharedData, check_auth, check_owner};
+use super::super::{check_auth, check_owner, Context, Error, SharedData};
 use super::model_ui::{
     build_model_picker_options, build_model_picker_summary_lines, has_pending_model_change,
 };
@@ -372,13 +372,16 @@ pub(in crate::services::discord) fn build_model_picker_embed_from_snapshot(
     provider: &ProviderKind,
     pending_model: Option<&str>,
     notice: Option<&str>,
+    working_dir: Option<&str>,
 ) -> serenity::CreateEmbed {
     let lines = build_model_picker_summary_lines(
         provider,
         &snapshot.effective,
+        snapshot.source,
         pending_model,
         snapshot.override_model.as_deref(),
         notice,
+        working_dir,
     );
     serenity::CreateEmbed::new()
         .title("Model Picker")
@@ -703,7 +706,7 @@ pub(in crate::services::discord) async fn cmd_allowall(
 #[cfg(test)]
 mod tests {
     use crate::services::discord::model_catalog::{
-        DEFAULT_PICKER_VALUE, known_models, validate_model_input,
+        known_models, validate_model_input, DEFAULT_PICKER_VALUE,
     };
 
     use super::super::model_ui::{
@@ -978,12 +981,10 @@ mod tests {
             gpt_54.description,
             "Frontier coding baseline | API $2.5/$15"
         );
-        assert!(
-            options
-                .iter()
-                .any(|entry| entry.label == "GPT-5.3-Codex-Spark"
-                    && entry.description == "Text-only preview | No API")
-        );
+        assert!(options
+            .iter()
+            .any(|entry| entry.label == "GPT-5.3-Codex-Spark"
+                && entry.description == "Text-only preview | No API"));
     }
 
     #[test]
@@ -1071,11 +1072,9 @@ mod tests {
             PROVIDER_DEFAULT_SOURCE,
             None,
         );
-        assert!(
-            options
-                .iter()
-                .any(|entry| entry.value == "sonnet" && entry.label == "Sonnet 4.6")
-        );
+        assert!(options
+            .iter()
+            .any(|entry| entry.value == "sonnet" && entry.label == "Sonnet 4.6"));
         assert!(options.iter().any(|entry| entry.value == "sonnet[1m]"
             && entry.label == "Sonnet 4.6 1M"
             && entry.description == "1M context window | Sonnet 4.6 alias"));
@@ -1092,6 +1091,8 @@ mod tests {
         let lines = build_model_picker_summary_lines(
             &ProviderKind::Gemini,
             "gemini-3-flash-preview",
+            ROLE_MAP_SOURCE,
+            None,
             None,
             None,
             None,
@@ -1111,8 +1112,10 @@ mod tests {
         let lines = build_model_picker_summary_lines(
             &ProviderKind::Codex,
             "gpt-5.4",
+            ROLE_MAP_SOURCE,
             Some("gpt-5.4-mini"),
             Some("gpt-5.4"),
+            None,
             None,
         );
         assert_eq!(lines[2], "현재 작업 상태 : `gpt-5.4-mini` 저장 대기");

--- a/src/services/discord/commands/control.rs
+++ b/src/services/discord/commands/control.rs
@@ -43,7 +43,7 @@ fn managed_session_reset_behavior(provider: &ProviderKind) -> ManagedSessionRese
 }
 
 async fn resolve_session_key_for_clear(
-    http: &serenity::Http,
+    http: &std::sync::Arc<serenity::Http>,
     shared: &Arc<SharedData>,
     channel_id: serenity::ChannelId,
     provider: &ProviderKind,
@@ -54,7 +54,7 @@ async fn resolve_session_key_for_clear(
         return Some(key);
     }
 
-    let channel_name =
+    let live_channel_name =
         channel_id
             .to_channel(http)
             .await
@@ -62,7 +62,12 @@ async fn resolve_session_key_for_clear(
             .and_then(|channel| match channel {
                 serenity::Channel::Guild(guild_channel) => Some(guild_channel.name),
                 _ => None,
-            })?;
+            });
+    let channel_name = fallback_channel_name_for_clear(
+        live_channel_name.as_deref(),
+        super::super::resolve_thread_parent(http, channel_id).await,
+        channel_id,
+    )?;
     let hostname = crate::services::platform::hostname_short();
     Some(format!(
         "{}:{}",
@@ -71,8 +76,24 @@ async fn resolve_session_key_for_clear(
     ))
 }
 
+fn fallback_channel_name_for_clear(
+    live_channel_name: Option<&str>,
+    thread_parent: Option<(serenity::ChannelId, Option<String>)>,
+    channel_id: serenity::ChannelId,
+) -> Option<String> {
+    if let Some((parent_id, parent_name)) = thread_parent {
+        let parent_name = parent_name.unwrap_or_else(|| parent_id.get().to_string());
+        return Some(super::super::synthetic_thread_channel_name(
+            &parent_name,
+            channel_id,
+        ));
+    }
+
+    live_channel_name.map(ToOwned::to_owned)
+}
+
 pub(in crate::services::discord) async fn reset_provider_session_if_pending(
-    http: &serenity::Http,
+    http: &std::sync::Arc<serenity::Http>,
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
     channel_id: serenity::ChannelId,
@@ -113,7 +134,7 @@ pub(in crate::services::discord) async fn reset_provider_session_if_pending(
 }
 
 pub(in crate::services::discord) async fn clear_channel_session_state(
-    http: &serenity::Http,
+    http: &std::sync::Arc<serenity::Http>,
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
     channel_id: serenity::ChannelId,
@@ -241,8 +262,9 @@ pub(in crate::services::discord) async fn cmd_clear(ctx: Context<'_>) -> Result<
     let ts = chrono::Local::now().format("%H:%M:%S");
     println!("  [{ts}] ◀ [{user_name}] /clear");
 
+    let http = ctx.serenity_context().http.clone();
     clear_channel_session_state(
-        ctx.http(),
+        &http,
         &ctx.data().shared,
         &ctx.data().provider,
         ctx.channel_id(),
@@ -319,10 +341,11 @@ pub(in crate::services::discord) async fn cmd_down(
 #[cfg(test)]
 mod tests {
     use super::{
-        ManagedSessionClearBehavior, ManagedSessionResetBehavior, managed_session_clear_behavior,
-        managed_session_reset_behavior,
+        ManagedSessionClearBehavior, ManagedSessionResetBehavior, fallback_channel_name_for_clear,
+        managed_session_clear_behavior, managed_session_reset_behavior,
     };
     use crate::services::provider::ProviderKind;
+    use poise::serenity_prelude::ChannelId;
 
     #[test]
     fn managed_session_clear_behavior_matches_provider_transport() {
@@ -362,6 +385,36 @@ mod tests {
             managed_session_reset_behavior(&ProviderKind::Gemini),
             ManagedSessionResetBehavior::Noop
         );
+    }
+
+    #[test]
+    fn fallback_channel_name_for_clear_uses_synthetic_thread_name() {
+        let channel_id = ChannelId::new(12345);
+        let channel_name = fallback_channel_name_for_clear(
+            Some("thread-title"),
+            Some((ChannelId::new(777), Some("agentdesk-codex".to_string()))),
+            channel_id,
+        );
+
+        assert_eq!(channel_name.as_deref(), Some("agentdesk-codex-t12345"));
+    }
+
+    #[test]
+    fn fallback_channel_name_for_clear_uses_parent_id_when_name_missing() {
+        let channel_id = ChannelId::new(12345);
+        let channel_name =
+            fallback_channel_name_for_clear(None, Some((ChannelId::new(777), None)), channel_id);
+
+        assert_eq!(channel_name.as_deref(), Some("777-t12345"));
+    }
+
+    #[test]
+    fn fallback_channel_name_for_clear_uses_live_name_for_non_threads() {
+        let channel_id = ChannelId::new(12345);
+        let channel_name =
+            fallback_channel_name_for_clear(Some("agentdesk-qwen"), None, channel_id);
+
+        assert_eq!(channel_name.as_deref(), Some("agentdesk-qwen"));
     }
 }
 

--- a/src/services/discord/commands/control.rs
+++ b/src/services/discord/commands/control.rs
@@ -3,13 +3,13 @@ use serenity::CreateAttachment;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::services::provider::cancel_requested;
 use crate::services::provider::ProviderKind;
+use crate::services::provider::cancel_requested;
 
 use super::super::formatting::{send_long_message_ctx, truncate_str};
 use super::super::settings::cleanup_channel_uploads;
 use super::super::turn_bridge::cancel_active_token;
-use super::super::{check_auth, Context, Error, SharedData};
+use super::super::{Context, Error, SharedData, check_auth};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ManagedSessionClearBehavior {
@@ -319,8 +319,8 @@ pub(in crate::services::discord) async fn cmd_down(
 #[cfg(test)]
 mod tests {
     use super::{
-        managed_session_clear_behavior, managed_session_reset_behavior,
-        ManagedSessionClearBehavior, ManagedSessionResetBehavior,
+        ManagedSessionClearBehavior, ManagedSessionResetBehavior, managed_session_clear_behavior,
+        managed_session_reset_behavior,
     };
     use crate::services::provider::ProviderKind;
 

--- a/src/services/discord/commands/control.rs
+++ b/src/services/discord/commands/control.rs
@@ -188,6 +188,7 @@ pub(in crate::services::discord) async fn clear_channel_session_state(
             Some(0),
             None,
             None,
+            None,
             shared.api_port,
         )
         .await;

--- a/src/services/discord/commands/control.rs
+++ b/src/services/discord/commands/control.rs
@@ -1,13 +1,196 @@
 use poise::serenity_prelude as serenity;
 use serenity::CreateAttachment;
 use std::path::Path;
+use std::sync::Arc;
 
 use crate::services::provider::cancel_requested;
+use crate::services::provider::ProviderKind;
 
 use super::super::formatting::{send_long_message_ctx, truncate_str};
 use super::super::settings::cleanup_channel_uploads;
 use super::super::turn_bridge::cancel_active_token;
-use super::super::{Context, Error, check_auth};
+use super::super::{check_auth, Context, Error, SharedData};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ManagedSessionClearBehavior {
+    NativeProviderClear,
+    TerminateManagedSession,
+    Noop,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ManagedSessionResetBehavior {
+    TerminateManagedSession,
+    Noop,
+}
+
+fn managed_session_clear_behavior(provider: &ProviderKind) -> ManagedSessionClearBehavior {
+    match provider {
+        ProviderKind::Claude => ManagedSessionClearBehavior::NativeProviderClear,
+        ProviderKind::Codex | ProviderKind::Qwen => {
+            ManagedSessionClearBehavior::TerminateManagedSession
+        }
+        ProviderKind::Gemini | ProviderKind::Unsupported(_) => ManagedSessionClearBehavior::Noop,
+    }
+}
+
+fn managed_session_reset_behavior(provider: &ProviderKind) -> ManagedSessionResetBehavior {
+    if provider.uses_managed_tmux_backend() {
+        ManagedSessionResetBehavior::TerminateManagedSession
+    } else {
+        ManagedSessionResetBehavior::Noop
+    }
+}
+
+async fn resolve_session_key_for_clear(
+    http: &serenity::Http,
+    shared: &Arc<SharedData>,
+    channel_id: serenity::ChannelId,
+    provider: &ProviderKind,
+) -> Option<String> {
+    if let Some(key) =
+        super::super::adk_session::build_adk_session_key(shared, channel_id, provider).await
+    {
+        return Some(key);
+    }
+
+    let channel_name =
+        channel_id
+            .to_channel(http)
+            .await
+            .ok()
+            .and_then(|channel| match channel {
+                serenity::Channel::Guild(guild_channel) => Some(guild_channel.name),
+                _ => None,
+            })?;
+    let hostname = crate::services::platform::hostname_short();
+    Some(format!(
+        "{}:{}",
+        hostname,
+        provider.build_tmux_session_name(&channel_name)
+    ))
+}
+
+pub(in crate::services::discord) async fn reset_provider_session_if_pending(
+    http: &serenity::Http,
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    channel_id: serenity::ChannelId,
+) {
+    if shared
+        .model_session_reset_pending
+        .remove(&channel_id)
+        .is_none()
+    {
+        return;
+    }
+
+    let tmux_name = {
+        let mut data = shared.core.lock().await;
+        data.sessions.get_mut(&channel_id).and_then(|session| {
+            session.session_id = None;
+            session
+                .channel_name
+                .as_ref()
+                .map(|channel_name| provider.build_tmux_session_name(channel_name))
+        })
+    };
+
+    if let Some(session_key) =
+        resolve_session_key_for_clear(http, shared, channel_id, provider).await
+    {
+        super::super::adk_session::clear_provider_session_id(&session_key, shared.api_port).await;
+    }
+
+    match managed_session_reset_behavior(provider) {
+        ManagedSessionResetBehavior::TerminateManagedSession => {
+            if let Some(name) = tmux_name {
+                crate::services::claude::terminate_local_session(&name);
+            }
+        }
+        ManagedSessionResetBehavior::Noop => {}
+    }
+}
+
+pub(in crate::services::discord) async fn clear_channel_session_state(
+    http: &serenity::Http,
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    channel_id: serenity::ChannelId,
+    clear_source: &str,
+) {
+    let (cancel_token, tmux_name) = {
+        let mut data = shared.core.lock().await;
+        let cancel_token = data.cancel_tokens.remove(&channel_id);
+        if cancel_token.is_some() {
+            shared
+                .global_active
+                .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        }
+
+        let tmux_name = data
+            .sessions
+            .get(&channel_id)
+            .and_then(|s| s.channel_name.as_ref())
+            .map(|ch_name| provider.build_tmux_session_name(ch_name));
+
+        if let Some(session) = data.sessions.get_mut(&channel_id) {
+            cleanup_channel_uploads(channel_id);
+            session.session_id = None;
+            session.history.clear();
+            session.pending_uploads.clear();
+            session.cleared = true;
+        }
+
+        data.active_request_owner.remove(&channel_id);
+        data.intervention_queue.remove(&channel_id);
+        (cancel_token, tmux_name)
+    };
+
+    shared.model_session_reset_pending.remove(&channel_id);
+
+    if let Some(token) = cancel_token {
+        cancel_active_token(&token, true, clear_source);
+    }
+
+    if let Some(session_key) =
+        resolve_session_key_for_clear(http, shared, channel_id, provider).await
+    {
+        super::super::adk_session::clear_provider_session_id(&session_key, shared.api_port).await;
+        super::super::adk_session::post_adk_session_status(
+            Some(session_key.as_str()),
+            None,
+            None,
+            "idle",
+            provider,
+            None,
+            Some(0),
+            None,
+            None,
+            shared.api_port,
+        )
+        .await;
+    }
+
+    match managed_session_clear_behavior(provider) {
+        ManagedSessionClearBehavior::NativeProviderClear =>
+        {
+            #[cfg(unix)]
+            if let Some(name) = tmux_name {
+                let _ = tokio::task::spawn_blocking(move || {
+                    crate::services::platform::tmux::send_keys(&name, &["/clear", "Enter"])
+                })
+                .await;
+            }
+        }
+        ManagedSessionClearBehavior::TerminateManagedSession => {
+            if let Some(name) = tmux_name {
+                crate::services::claude::terminate_local_session(&name);
+            }
+        }
+        ManagedSessionClearBehavior::Noop => {}
+    }
+}
 
 /// /stop — Cancel in-progress AI request
 #[poise::command(slash_command, rename = "stop")]
@@ -58,104 +241,14 @@ pub(in crate::services::discord) async fn cmd_clear(ctx: Context<'_>) -> Result<
     let ts = chrono::Local::now().format("%H:%M:%S");
     println!("  [{ts}] ◀ [{user_name}] /clear");
 
-    let channel_id = ctx.channel_id();
-
-    // Cancel in-progress AI request if any
-    let cancel_token = {
-        let data = ctx.data().shared.core.lock().await;
-        data.cancel_tokens.get(&channel_id).cloned()
-    };
-    if let Some(token) = cancel_token {
-        cancel_active_token(&token, true, "/clear");
-    }
-
-    let tmux_name = {
-        let data = ctx.data().shared.core.lock().await;
-        data.sessions
-            .get(&channel_id)
-            .and_then(|s| s.channel_name.as_ref())
-            .map(|ch_name| ctx.data().provider.build_tmux_session_name(ch_name))
-    };
-
-    {
-        let mut data = ctx.data().shared.core.lock().await;
-        if let Some(session) = data.sessions.get_mut(&channel_id) {
-            cleanup_channel_uploads(channel_id);
-            session.session_id = None;
-            session.history.clear();
-            session.pending_uploads.clear();
-            session.cleared = true;
-        }
-        if data.cancel_tokens.remove(&channel_id).is_some() {
-            ctx.data()
-                .shared
-                .global_active
-                .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
-        }
-        data.active_request_owner.remove(&channel_id);
-        data.intervention_queue.remove(&channel_id);
-    }
-
-    // Clear the stored provider session_id from DB so the next turn
-    // doesn't try to resume a dead session.
-    let shared = &ctx.data().shared;
-    let provider = &ctx.data().provider;
-    // #227: Derive session key with fallback for post-restart state where
-    // in-memory sessions may be empty but DB still has stale token values.
-    let session_key = {
-        let key =
-            super::super::adk_session::build_adk_session_key(shared, channel_id, provider).await;
-        if key.is_some() {
-            key
-        } else {
-            // Fallback: resolve channel name from Discord API
-            let ch_name = channel_id
-                .to_channel(ctx.http())
-                .await
-                .ok()
-                .and_then(|ch| match ch {
-                    poise::serenity_prelude::Channel::Guild(gc) => Some(gc.name.clone()),
-                    _ => None,
-                });
-            ch_name.map(|name| {
-                let tmux_name = provider.build_tmux_session_name(&name);
-                let hostname = crate::services::platform::hostname_short();
-                format!("{}:{}", hostname, tmux_name)
-            })
-        }
-    };
-    if let Some(ref key) = session_key {
-        super::super::adk_session::clear_provider_session_id(key, shared.api_port).await;
-        // #227: Reset tokens to 0 so stale context values don't persist after /clear.
-        super::super::adk_session::post_adk_session_status(
-            Some(key.as_str()),
-            None,
-            None,
-            "idle",
-            provider,
-            None,
-            Some(0),
-            None,
-            None,
-            None,
-            shared.api_port,
-        )
-        .await;
-    }
-
-    // Only send /clear via send-keys for Claude sessions.
-    // Codex reads tmux pane stdin as follow-up prompts, so literal "/clear"
-    // would be interpreted as a new user turn instead of a slash command.
-    #[cfg(unix)]
-    if *provider == crate::services::provider::ProviderKind::Claude {
-        if let Some(ref name) = tmux_name {
-            let name = name.clone();
-            let _ = tokio::task::spawn_blocking(move || {
-                crate::services::platform::tmux::send_keys(&name, &["/clear", "Enter"])
-            })
-            .await;
-        }
-    }
+    clear_channel_session_state(
+        ctx.http(),
+        &ctx.data().shared,
+        &ctx.data().provider,
+        ctx.channel_id(),
+        "/clear",
+    )
+    .await;
 
     ctx.say("Session cleared.").await?;
     println!("  [{ts}] ▶ [{user_name}] Session cleared");
@@ -221,6 +314,55 @@ pub(in crate::services::discord) async fn cmd_down(
         .await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        managed_session_clear_behavior, managed_session_reset_behavior,
+        ManagedSessionClearBehavior, ManagedSessionResetBehavior,
+    };
+    use crate::services::provider::ProviderKind;
+
+    #[test]
+    fn managed_session_clear_behavior_matches_provider_transport() {
+        assert_eq!(
+            managed_session_clear_behavior(&ProviderKind::Claude),
+            ManagedSessionClearBehavior::NativeProviderClear
+        );
+        assert_eq!(
+            managed_session_clear_behavior(&ProviderKind::Codex),
+            ManagedSessionClearBehavior::TerminateManagedSession
+        );
+        assert_eq!(
+            managed_session_clear_behavior(&ProviderKind::Qwen),
+            ManagedSessionClearBehavior::TerminateManagedSession
+        );
+        assert_eq!(
+            managed_session_clear_behavior(&ProviderKind::Gemini),
+            ManagedSessionClearBehavior::Noop
+        );
+    }
+
+    #[test]
+    fn managed_session_reset_behavior_matches_provider_transport() {
+        assert_eq!(
+            managed_session_reset_behavior(&ProviderKind::Claude),
+            ManagedSessionResetBehavior::TerminateManagedSession
+        );
+        assert_eq!(
+            managed_session_reset_behavior(&ProviderKind::Codex),
+            ManagedSessionResetBehavior::TerminateManagedSession
+        );
+        assert_eq!(
+            managed_session_reset_behavior(&ProviderKind::Qwen),
+            ManagedSessionResetBehavior::TerminateManagedSession
+        );
+        assert_eq!(
+            managed_session_reset_behavior(&ProviderKind::Gemini),
+            ManagedSessionResetBehavior::Noop
+        );
+    }
 }
 
 /// /shell <command> — Run shell command directly

--- a/src/services/discord/commands/mod.rs
+++ b/src/services/discord/commands/mod.rs
@@ -13,12 +13,15 @@ pub(in crate::services::discord) use super::model_catalog::{
     provider_supports_model_override, validate_model_input,
 };
 pub(in crate::services::discord) use config::{
-    ModelPickerAction, build_model_picker_components_from_snapshot,
-    build_model_picker_embed_from_snapshot, clear_model_picker_pending, current_working_dir,
-    effective_model_snapshot, model_picker_pending_to_override, parse_model_picker_custom_id,
-    resolve_model_for_turn, update_channel_model_override,
+    build_model_picker_components_from_snapshot, build_model_picker_embed_from_snapshot,
+    clear_model_picker_pending, current_working_dir, effective_model_snapshot,
+    model_picker_pending_to_override, parse_model_picker_custom_id, resolve_model_for_turn,
+    update_channel_model_override, ModelPickerAction,
 };
 pub(super) use config::{cmd_adduser, cmd_allowall, cmd_allowed, cmd_allowedtools, cmd_removeuser};
+pub(in crate::services::discord) use control::{
+    clear_channel_session_state, reset_provider_session_if_pending,
+};
 pub(super) use control::{cmd_clear, cmd_down, cmd_shell, cmd_stop};
 pub(in crate::services::discord) use diagnostics::{
     build_health_report, build_inflight_report, build_queue_report, build_status_report,
@@ -31,4 +34,5 @@ pub(super) use meeting_cmd::cmd_meeting;
 pub(super) use model_picker::cmd_model;
 pub(super) use receipt::cmd_receipt;
 pub(super) use session::{cmd_pwd, cmd_start};
+pub(in crate::services::discord) use skill::build_provider_skill_prompt;
 pub(super) use skill::cmd_cc;

--- a/src/services/discord/commands/mod.rs
+++ b/src/services/discord/commands/mod.rs
@@ -13,10 +13,10 @@ pub(in crate::services::discord) use super::model_catalog::{
     provider_supports_model_override, validate_model_input,
 };
 pub(in crate::services::discord) use config::{
-    build_model_picker_components_from_snapshot, build_model_picker_embed_from_snapshot,
-    clear_model_picker_pending, current_working_dir, effective_model_snapshot,
-    model_picker_pending_to_override, parse_model_picker_custom_id, resolve_model_for_turn,
-    update_channel_model_override, ModelPickerAction,
+    ModelPickerAction, build_model_picker_components_from_snapshot,
+    build_model_picker_embed_from_snapshot, clear_model_picker_pending, current_working_dir,
+    effective_model_snapshot, model_picker_pending_to_override, parse_model_picker_custom_id,
+    resolve_model_for_turn, update_channel_model_override,
 };
 pub(super) use config::{cmd_adduser, cmd_allowall, cmd_allowed, cmd_allowedtools, cmd_removeuser};
 pub(in crate::services::discord) use control::{

--- a/src/services/discord/commands/model_picker.rs
+++ b/src/services/discord/commands/model_picker.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use poise::serenity_prelude as serenity;
 use poise::CreateReply;
+use poise::serenity_prelude as serenity;
 
 use super::super::model_catalog::provider_supports_model_override;
-use super::super::{check_auth, Context, Error, SharedData};
+use super::super::{Context, Error, SharedData, check_auth};
 use super::config::{
     build_model_picker_components_from_snapshot, build_model_picker_embed_from_snapshot,
     current_working_dir, effective_model_snapshot, remember_model_picker_pending,

--- a/src/services/discord/commands/model_picker.rs
+++ b/src/services/discord/commands/model_picker.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use poise::CreateReply;
 use poise::serenity_prelude as serenity;
+use poise::CreateReply;
 
 use super::super::model_catalog::provider_supports_model_override;
-use super::super::{Context, Error, SharedData, check_auth};
+use super::super::{check_auth, Context, Error, SharedData};
 use super::config::{
     build_model_picker_components_from_snapshot, build_model_picker_embed_from_snapshot,
     current_working_dir, effective_model_snapshot, remember_model_picker_pending,
@@ -25,7 +25,13 @@ async fn build_model_picker_view(
     let snapshot = effective_model_snapshot(shared, target_channel_id).await;
     let working_dir = current_working_dir(shared, target_channel_id).await;
     let pending_model = snapshot.override_model.as_deref();
-    let embed = build_model_picker_embed_from_snapshot(&snapshot, provider, pending_model, None);
+    let embed = build_model_picker_embed_from_snapshot(
+        &snapshot,
+        provider,
+        pending_model,
+        None,
+        working_dir.as_deref(),
+    );
     let components = build_model_picker_components_from_snapshot(
         &snapshot,
         target_channel_id,

--- a/src/services/discord/commands/model_ui.rs
+++ b/src/services/discord/commands/model_ui.rs
@@ -1,8 +1,8 @@
 use poise::serenity_prelude as serenity;
 
 use crate::services::discord::model_catalog::{
-    DEFAULT_PICKER_VALUE, ModelCatalogEntry, SOURCE_PROVIDER_DEFAULT, is_default_picker_value,
-    resolved_default_model, resolved_models,
+    is_default_picker_value, resolved_default_model, resolved_models, ModelCatalogEntry,
+    DEFAULT_PICKER_VALUE, SOURCE_PROVIDER_DEFAULT,
 };
 use crate::services::provider::ProviderKind;
 
@@ -22,6 +22,27 @@ pub(super) fn display_model_value(raw: &str) -> String {
         "(default)" | "system default" => "default".to_string(),
         other => other.to_string(),
     }
+}
+
+fn effective_model_display(
+    provider: &ProviderKind,
+    effective_model: &str,
+    effective_source: &str,
+    working_dir: Option<&str>,
+) -> String {
+    if effective_source == SOURCE_PROVIDER_DEFAULT
+        && effective_model.eq_ignore_ascii_case("default")
+    {
+        if let Some(resolved_default) = resolved_default_model(provider, working_dir) {
+            return display_model_value(&resolved_default);
+        }
+
+        if let Some(runtime_model) = provider.default_model_behavior().runtime_model {
+            return display_model_value(runtime_model);
+        }
+    }
+
+    display_model_value(effective_model)
 }
 
 pub(super) fn has_pending_model_change(
@@ -65,13 +86,18 @@ fn build_model_picker_runtime_status(
 pub(super) fn build_model_picker_summary_lines(
     provider: &ProviderKind,
     effective_model: &str,
+    effective_source: &str,
     pending_model: Option<&str>,
     override_model: Option<&str>,
     notice: Option<&str>,
+    working_dir: Option<&str>,
 ) -> [String; 3] {
     [
         format!("Provider : `{}`", provider.as_str()),
-        format!("Current Model : `{}`", display_model_value(effective_model)),
+        format!(
+            "Current Model : `{}`",
+            effective_model_display(provider, effective_model, effective_source, working_dir)
+        ),
         format!(
             "현재 작업 상태 : {}",
             build_model_picker_runtime_status(pending_model, override_model, notice)
@@ -142,6 +168,33 @@ fn capped_model_picker_explicit_entries<'a>(
     entries
 }
 
+fn append_unavailable_selected_option(
+    options: &mut Vec<ModelPickerOptionSpec>,
+    selected_explicit_model: Option<&str>,
+) {
+    let Some(selected_value) = selected_explicit_model else {
+        return;
+    };
+
+    if options
+        .iter()
+        .any(|entry| entry.value.eq_ignore_ascii_case(selected_value))
+    {
+        return;
+    }
+
+    if options.len() == DISCORD_SELECT_MENU_OPTION_LIMIT {
+        options.pop();
+    }
+
+    options.push(ModelPickerOptionSpec {
+        value: selected_value.to_string(),
+        label: selected_value.to_string(),
+        description: "Current override | Not in current catalog".to_string(),
+        selected: true,
+    });
+}
+
 pub(super) fn build_model_picker_option_specs(
     provider: &ProviderKind,
     pending_model: Option<&str>,
@@ -183,6 +236,7 @@ pub(super) fn build_model_picker_option_specs(
                     .is_some_and(|active| active.eq_ignore_ascii_case(entry.value)),
             }),
     );
+    append_unavailable_selected_option(&mut options, selected_explicit_model);
     options
 }
 
@@ -213,8 +267,17 @@ pub(super) fn build_model_picker_options(
 
 #[cfg(test)]
 mod tests {
-    use super::{EXPLICIT_MODEL_OPTION_LIMIT, capped_model_picker_explicit_entries};
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::{
+        build_model_picker_option_specs, build_model_picker_summary_lines,
+        capped_model_picker_explicit_entries, EXPLICIT_MODEL_OPTION_LIMIT,
+    };
     use crate::services::discord::model_catalog::ModelCatalogEntry;
+    use crate::services::discord::model_catalog::SOURCE_PROVIDER_DEFAULT;
+    use crate::services::provider::ProviderKind;
 
     fn leaked(value: &str) -> &'static str {
         Box::leak(value.to_string().into_boxed_str())
@@ -247,5 +310,99 @@ mod tests {
         assert_eq!(capped.len(), EXPLICIT_MODEL_OPTION_LIMIT);
         assert!(capped.iter().any(|entry| entry.value == "model-39"));
         assert!(!capped.iter().any(|entry| entry.value == "model-23"));
+    }
+
+    fn with_temp_qwen_env<F>(f: F)
+    where
+        F: FnOnce(&TempDir, &TempDir),
+    {
+        let _guard = crate::services::discord::runtime_store::lock_test_env();
+        let temp_home = TempDir::new().unwrap();
+        let temp_project = TempDir::new().unwrap();
+
+        let prev_home = std::env::var_os("HOME");
+        let prev_userprofile = std::env::var_os("USERPROFILE");
+        let prev_test_home = std::env::var_os("AGENTDESK_TEST_HOME");
+
+        unsafe {
+            std::env::set_var("HOME", temp_home.path());
+            std::env::set_var("USERPROFILE", temp_home.path());
+            std::env::set_var("AGENTDESK_TEST_HOME", temp_home.path());
+        }
+
+        f(&temp_home, &temp_project);
+
+        match prev_home {
+            Some(value) => unsafe { std::env::set_var("HOME", value) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        match prev_userprofile {
+            Some(value) => unsafe { std::env::set_var("USERPROFILE", value) },
+            None => unsafe { std::env::remove_var("USERPROFILE") },
+        }
+        match prev_test_home {
+            Some(value) => unsafe { std::env::set_var("AGENTDESK_TEST_HOME", value) },
+            None => unsafe { std::env::remove_var("AGENTDESK_TEST_HOME") },
+        }
+    }
+
+    #[test]
+    fn build_model_picker_option_specs_keeps_missing_selected_override_visible() {
+        with_temp_qwen_env(|_temp_home, _temp_project| {
+            let options = build_model_picker_option_specs(
+                &ProviderKind::Qwen,
+                None,
+                Some("coder-model"),
+                "default",
+                "provider default",
+                None,
+            );
+
+            let missing = options
+                .iter()
+                .find(|entry| entry.value == "coder-model")
+                .expect("missing stale override entry");
+            assert_eq!(missing.label, "coder-model");
+            assert_eq!(
+                missing.description,
+                "Current override | Not in current catalog"
+            );
+            assert!(missing.selected);
+        });
+    }
+
+    #[test]
+    fn build_model_picker_summary_lines_show_resolved_qwen_default_model() {
+        with_temp_qwen_env(|temp_home, temp_project| {
+            let _ = temp_home;
+            let project_qwen_dir = temp_project.path().join(".qwen");
+            fs::create_dir_all(&project_qwen_dir).unwrap();
+
+            fs::write(
+                project_qwen_dir.join("settings.json"),
+                r#"{
+                  "modelProviders": {
+                    "qwen-oauth": [
+                      { "id": "coder-model", "name": "Qwen 3.6 Plus" }
+                    ]
+                  },
+                  "model": { "name": "coder-model" }
+                }"#,
+            )
+            .unwrap();
+
+            let working_dir = temp_project.path().to_str().unwrap();
+            let lines = build_model_picker_summary_lines(
+                &ProviderKind::Qwen,
+                "default",
+                SOURCE_PROVIDER_DEFAULT,
+                None,
+                None,
+                None,
+                Some(working_dir),
+            );
+
+            assert_eq!(lines[1], "Current Model : `coder-model`");
+        });
     }
 }

--- a/src/services/discord/commands/model_ui.rs
+++ b/src/services/discord/commands/model_ui.rs
@@ -1,8 +1,8 @@
 use poise::serenity_prelude as serenity;
 
 use crate::services::discord::model_catalog::{
-    is_default_picker_value, resolved_default_model, resolved_models, ModelCatalogEntry,
-    DEFAULT_PICKER_VALUE, SOURCE_PROVIDER_DEFAULT,
+    DEFAULT_PICKER_VALUE, ModelCatalogEntry, SOURCE_PROVIDER_DEFAULT, is_default_picker_value,
+    resolved_default_model, resolved_models,
 };
 use crate::services::provider::ProviderKind;
 
@@ -272,8 +272,8 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        build_model_picker_option_specs, build_model_picker_summary_lines,
-        capped_model_picker_explicit_entries, EXPLICIT_MODEL_OPTION_LIMIT,
+        EXPLICIT_MODEL_OPTION_LIMIT, build_model_picker_option_specs,
+        build_model_picker_summary_lines, capped_model_picker_explicit_entries,
     };
     use crate::services::discord::model_catalog::ModelCatalogEntry;
     use crate::services::discord::model_catalog::SOURCE_PROVIDER_DEFAULT;

--- a/src/services/discord/commands/skill.rs
+++ b/src/services/discord/commands/skill.rs
@@ -4,11 +4,77 @@ use serenity::CreateMessage;
 use super::super::formatting::{send_long_message_ctx, truncate_str};
 use super::super::router::handle_text_message;
 use super::super::turn_bridge::cancel_active_token;
-use super::super::{Context, Error, auto_restore_session, check_auth};
-use crate::services::provider::{ProviderKind, cancel_requested};
+use super::super::{auto_restore_session, check_auth, Context, Error};
+use crate::services::provider::{cancel_requested, ProviderKind};
 
-// Re-use the report builders from diagnostics (they are private to diagnostics,
-// so cmd_cc duplicates the built-in handler logic inline, matching the original code).
+// Keep provider-specific skill wording in one helper so /cc and !cc stay aligned.
+
+pub(in crate::services::discord) fn build_provider_skill_prompt(
+    provider: &ProviderKind,
+    skill: &str,
+    args_str: &str,
+) -> Result<String, String> {
+    match provider {
+        ProviderKind::Claude => {
+            if args_str.is_empty() {
+                Ok(format!(
+                    "Execute the skill `/{skill}` now. \
+                     Use the Skill tool with skill=\"{skill}\". \
+                     Read files under `references/` only if the skill points to them or you need extra detail."
+                ))
+            } else {
+                Ok(format!(
+                    "Execute the skill `/{skill}` with arguments: {args_str}\n\
+                     Use the Skill tool with skill=\"{skill}\", args=\"{args_str}\". \
+                     Read files under `references/` only if the skill points to them or you need extra detail."
+                ))
+            }
+        }
+        ProviderKind::Codex => {
+            if args_str.is_empty() {
+                Ok(format!(
+                    "Use the local Codex skill `/{skill}` now. \
+                     Load its `SKILL.md` first, follow it exactly, and read files under `references/` only when the skill points to them or you need them."
+                ))
+            } else {
+                Ok(format!(
+                    "Use the local Codex skill `/{skill}` now with this user request: {args_str}\n\
+                     Load its `SKILL.md` first, adapt it to the request, and read files under `references/` only when the skill points to them or you need them."
+                ))
+            }
+        }
+        ProviderKind::Gemini => {
+            if args_str.is_empty() {
+                Ok(format!(
+                    "Use the local Gemini skill `/{skill}` now. \
+                     Load its `SKILL.md` first, follow it exactly, and read files under `references/` only when the skill points to them or you need them."
+                ))
+            } else {
+                Ok(format!(
+                    "Use the local Gemini skill `/{skill}` now with this user request: {args_str}\n\
+                     Load its `SKILL.md` first, adapt it to the request, and read files under `references/` only when the skill points to them or you need them."
+                ))
+            }
+        }
+        ProviderKind::Qwen => {
+            if args_str.is_empty() {
+                Ok(format!(
+                    "Use the local Qwen skill `/{skill}` from the active `.qwen/skills` runtime now. \
+                     Load its `SKILL.md` first, follow it exactly, and read files under `references/` only when the skill points to them or you need them."
+                ))
+            } else {
+                Ok(format!(
+                    "Use the local Qwen skill `/{skill}` from the active `.qwen/skills` runtime now with this user request: {args_str}\n\
+                     Load its `SKILL.md` first, adapt it to the request, and read files under `references/` only when the skill points to them or you need them."
+                ))
+            }
+        }
+        ProviderKind::Unsupported(name) => Err(format!(
+            "Provider '{}' is not installed. This skill cannot run.",
+            name
+        )),
+    }
+}
 
 /// Autocomplete handler for /cc skill names
 async fn autocomplete_skill<'a>(
@@ -229,67 +295,10 @@ pub(in crate::services::discord) async fn cmd_cc(
     }
 
     // Build the prompt that tells the active provider to invoke the skill
-    let skill_prompt = match &ctx.data().provider {
-        ProviderKind::Claude => {
-            if args_str.is_empty() {
-                format!(
-                    "Execute the skill `/{skill}` now. \
-                     Use the Skill tool with skill=\"{skill}\". \
-                     Read files under `references/` only if the skill points to them or you need extra detail."
-                )
-            } else {
-                format!(
-                    "Execute the skill `/{skill}` with arguments: {args_str}\n\
-                     Use the Skill tool with skill=\"{skill}\", args=\"{args_str}\". \
-                     Read files under `references/` only if the skill points to them or you need extra detail."
-                )
-            }
-        }
-        ProviderKind::Codex => {
-            if args_str.is_empty() {
-                format!(
-                    "Use the local Codex skill `/{skill}` now. \
-                     Load its `SKILL.md` first, follow it exactly, and read files under `references/` only when the skill points to them or you need them."
-                )
-            } else {
-                format!(
-                    "Use the local Codex skill `/{skill}` now with this user request: {args_str}\n\
-                    Load its `SKILL.md` first, adapt it to the request, and read files under `references/` only when the skill points to them or you need them."
-                )
-            }
-        }
-        ProviderKind::Gemini => {
-            if args_str.is_empty() {
-                format!(
-                    "Use the local Gemini skill `/{skill}` now. \
-                     Load its `SKILL.md` first, follow it exactly, and read files under `references/` only when the skill points to them or you need them."
-                )
-            } else {
-                format!(
-                    "Use the local Gemini skill `/{skill}` now with this user request: {args_str}\n\
-                     Load its `SKILL.md` first, adapt it to the request, and read files under `references/` only when the skill points to them or you need them."
-                )
-            }
-        }
-        ProviderKind::Qwen => {
-            if args_str.is_empty() {
-                format!(
-                    "Use the local Qwen skill `/{skill}` now. \
-                     Load its `SKILL.md` first, follow it exactly, and read files under `references/` only when the skill points to them or you need them."
-                )
-            } else {
-                format!(
-                    "Use the local Qwen skill `/{skill}` now with this user request: {args_str}\n\
-                     Load its `SKILL.md` first, adapt it to the request, and read files under `references/` only when the skill points to them or you need them."
-                )
-            }
-        }
-        ProviderKind::Unsupported(name) => {
-            ctx.say(format!(
-                "Provider '{}' is not installed. This skill cannot run.",
-                name
-            ))
-            .await?;
+    let skill_prompt = match build_provider_skill_prompt(&ctx.data().provider, &skill, args_str) {
+        Ok(prompt) => prompt,
+        Err(message) => {
+            ctx.say(message).await?;
             return Ok(());
         }
     };
@@ -322,4 +331,21 @@ pub(in crate::services::discord) async fn cmd_cc(
     .await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_provider_skill_prompt;
+    use crate::services::provider::ProviderKind;
+
+    #[test]
+    fn qwen_skill_prompt_variant_mentions_qwen_runtime_skills() {
+        let prompt =
+            build_provider_skill_prompt(&ProviderKind::Qwen, "deploy", "--dry-run").unwrap();
+
+        assert!(prompt.contains("local Qwen skill `/deploy`"));
+        assert!(prompt.contains("`.qwen/skills`"));
+        assert!(prompt.contains("Load its `SKILL.md` first"));
+        assert!(prompt.contains("--dry-run"));
+    }
 }

--- a/src/services/discord/commands/skill.rs
+++ b/src/services/discord/commands/skill.rs
@@ -4,8 +4,8 @@ use serenity::CreateMessage;
 use super::super::formatting::{send_long_message_ctx, truncate_str};
 use super::super::router::handle_text_message;
 use super::super::turn_bridge::cancel_active_token;
-use super::super::{auto_restore_session, check_auth, Context, Error};
-use crate::services::provider::{cancel_requested, ProviderKind};
+use super::super::{Context, Error, auto_restore_session, check_auth};
+use crate::services::provider::{ProviderKind, cancel_requested};
 
 // Keep provider-specific skill wording in one helper so /cc and !cc stay aligned.
 

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -3,7 +3,7 @@ use serenity::{ChannelId, CreateMessage, EditMessage, MessageId};
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use super::{rate_limit_wait, SharedData, DISCORD_MSG_LIMIT};
+use super::{DISCORD_MSG_LIMIT, SharedData, rate_limit_wait};
 use crate::services::provider::ProviderKind;
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
@@ -94,11 +94,7 @@ where
 
 /// Format a risk badge for display
 pub(super) fn risk_badge(destructive: bool) -> &'static str {
-    if destructive {
-        "⚠️"
-    } else {
-        ""
-    }
+    if destructive { "⚠️" } else { "" }
 }
 
 /// Claude Code built-in slash commands
@@ -383,7 +379,7 @@ mod tests {
 
     #[test]
     fn test_split_message_long_produces_multiple_chunks() {
-        use super::{split_message, DISCORD_MSG_LIMIT};
+        use super::{DISCORD_MSG_LIMIT, split_message};
 
         // Create a message longer than the Discord limit
         let long_msg: String = "A".repeat(DISCORD_MSG_LIMIT + 500);

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -3,7 +3,7 @@ use serenity::{ChannelId, CreateMessage, EditMessage, MessageId};
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use super::{DISCORD_MSG_LIMIT, SharedData, rate_limit_wait};
+use super::{rate_limit_wait, SharedData, DISCORD_MSG_LIMIT};
 use crate::services::provider::ProviderKind;
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
@@ -94,7 +94,11 @@ where
 
 /// Format a risk badge for display
 pub(super) fn risk_badge(destructive: bool) -> &'static str {
-    if destructive { "⚠️" } else { "" }
+    if destructive {
+        "⚠️"
+    } else {
+        ""
+    }
 }
 
 /// Claude Code built-in slash commands
@@ -220,9 +224,10 @@ pub(super) fn format_skills_notice(provider: &ProviderKind, skills: &[(String, S
 #[cfg(test)]
 mod tests {
     use super::{
-        canonical_tool_name, convert_markdown_tables, filter_codex_tool_logs,
+        canonical_tool_name, convert_markdown_tables, filter_codex_tool_logs, format_skills_notice,
         normalize_allowed_tools,
     };
+    use crate::services::provider::ProviderKind;
 
     #[test]
     fn test_canonical_tool_name_is_case_insensitive() {
@@ -339,9 +344,6 @@ mod tests {
 
     #[test]
     fn test_format_skills_notice_adds_progressive_disclosure_guidance() {
-        use super::format_skills_notice;
-        use crate::services::provider::ProviderKind;
-
         let notice = format_skills_notice(
             &ProviderKind::Codex,
             &[(
@@ -358,6 +360,18 @@ mod tests {
     }
 
     #[test]
+    fn test_format_skills_notice_mentions_qwen_local_skills() {
+        let notice = format_skills_notice(
+            &ProviderKind::Qwen,
+            &[("deploy".to_string(), "Ship the current branch".to_string())],
+        );
+
+        assert!(notice.contains("Available local Qwen skills"));
+        assert!(notice.contains("`SKILL.md`"));
+        assert!(notice.contains("/deploy: Ship the current branch"));
+    }
+
+    #[test]
     fn test_split_message_short_passthrough() {
         use super::split_message;
 
@@ -369,7 +383,7 @@ mod tests {
 
     #[test]
     fn test_split_message_long_produces_multiple_chunks() {
-        use super::{DISCORD_MSG_LIMIT, split_message};
+        use super::{split_message, DISCORD_MSG_LIMIT};
 
         // Create a message longer than the Discord limit
         let long_msg: String = "A".repeat(DISCORD_MSG_LIMIT + 500);

--- a/src/services/discord/model_catalog.rs
+++ b/src/services/discord/model_catalog.rs
@@ -958,16 +958,23 @@ export const VALID_GEMINI_MODELS = new Set([
         let catalog = build_gemini_model_catalog_from_models_js(raw).expect("catalog");
         assert_eq!(catalog[0].value, "auto-gemini-3");
         assert_eq!(catalog[0].label, "Auto (Gemini 3)");
-        assert!(catalog
-            .iter()
-            .any(|entry| entry.value == "gemini-3.1-pro-preview"));
-        assert!(catalog
-            .iter()
-            .any(|entry| entry.value == "gemini-3.1-flash-lite-preview"
-                && entry.picker_description() == "Preview flash-lite variant | Local CLI catalog"));
-        assert!(!catalog
-            .iter()
-            .any(|entry| entry.value == "gemini-obsolete-lite"));
+        assert!(
+            catalog
+                .iter()
+                .any(|entry| entry.value == "gemini-3.1-pro-preview")
+        );
+        assert!(
+            catalog
+                .iter()
+                .any(|entry| entry.value == "gemini-3.1-flash-lite-preview"
+                    && entry.picker_description()
+                        == "Preview flash-lite variant | Local CLI catalog")
+        );
+        assert!(
+            !catalog
+                .iter()
+                .any(|entry| entry.value == "gemini-obsolete-lite")
+        );
     }
 
     #[test]
@@ -1018,9 +1025,11 @@ export const VALID_GEMINI_MODELS = new Set([
             assert_eq!(default_model, "project-model");
 
             let catalog = super::resolved_models(&ProviderKind::Qwen, Some(working_dir));
-            assert!(catalog
-                .iter()
-                .any(|entry| entry.value == "user-model" && entry.label == "User Model"));
+            assert!(
+                catalog
+                    .iter()
+                    .any(|entry| entry.value == "user-model" && entry.label == "User Model")
+            );
             assert!(catalog.iter().any(|entry| entry.value == "project-model"
                 && entry.label == "Project Model"
                 && entry.picker_description() == "Project scoped model | Qwen settings (openai)"));

--- a/src/services/discord/model_catalog.rs
+++ b/src/services/discord/model_catalog.rs
@@ -869,9 +869,7 @@ mod tests {
     where
         F: FnOnce(&TempDir, &TempDir),
     {
-        let _guard = super::super::runtime_store::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let _guard = super::super::runtime_store::lock_test_env();
         let temp_home = TempDir::new().unwrap();
         let temp_project = TempDir::new().unwrap();
 
@@ -960,23 +958,16 @@ export const VALID_GEMINI_MODELS = new Set([
         let catalog = build_gemini_model_catalog_from_models_js(raw).expect("catalog");
         assert_eq!(catalog[0].value, "auto-gemini-3");
         assert_eq!(catalog[0].label, "Auto (Gemini 3)");
-        assert!(
-            catalog
-                .iter()
-                .any(|entry| entry.value == "gemini-3.1-pro-preview")
-        );
-        assert!(
-            catalog
-                .iter()
-                .any(|entry| entry.value == "gemini-3.1-flash-lite-preview"
-                    && entry.picker_description()
-                        == "Preview flash-lite variant | Local CLI catalog")
-        );
-        assert!(
-            !catalog
-                .iter()
-                .any(|entry| entry.value == "gemini-obsolete-lite")
-        );
+        assert!(catalog
+            .iter()
+            .any(|entry| entry.value == "gemini-3.1-pro-preview"));
+        assert!(catalog
+            .iter()
+            .any(|entry| entry.value == "gemini-3.1-flash-lite-preview"
+                && entry.picker_description() == "Preview flash-lite variant | Local CLI catalog"));
+        assert!(!catalog
+            .iter()
+            .any(|entry| entry.value == "gemini-obsolete-lite"));
     }
 
     #[test]
@@ -1027,11 +1018,9 @@ export const VALID_GEMINI_MODELS = new Set([
             assert_eq!(default_model, "project-model");
 
             let catalog = super::resolved_models(&ProviderKind::Qwen, Some(working_dir));
-            assert!(
-                catalog
-                    .iter()
-                    .any(|entry| entry.value == "user-model" && entry.label == "User Model")
-            );
+            assert!(catalog
+                .iter()
+                .any(|entry| entry.value == "user-model" && entry.label == "User Model"));
             assert!(catalog.iter().any(|entry| entry.value == "project-model"
                 && entry.label == "Project Model"
                 && entry.picker_description() == "Project scoped model | Qwen settings (openai)"));

--- a/src/services/discord/model_picker_interaction.rs
+++ b/src/services/discord/model_picker_interaction.rs
@@ -271,6 +271,7 @@ pub(super) async fn handle_model_picker_interaction(
         &data.provider,
         pending_model.as_deref(),
         Some(notice),
+        working_dir.as_deref(),
     );
     let components = super::commands::build_model_picker_components_from_snapshot(
         &snapshot,

--- a/src/services/discord/org_schema.rs
+++ b/src/services/discord/org_schema.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 
 use super::meeting::{MeetingAgentConfig, MeetingConfig, SummaryAgentConfig, SummaryAgentRule};
 use super::runtime_store::org_schema_path;
-use super::settings::{resolve_memory_settings, MemoryConfigOverride, PeerAgentInfo, RoleBinding};
+use super::settings::{MemoryConfigOverride, PeerAgentInfo, RoleBinding, resolve_memory_settings};
 use crate::services::provider::ProviderKind;
 
 // ─── YAML Schema Types ──────────────────────────────────────────────────────

--- a/src/services/discord/org_schema.rs
+++ b/src/services/discord/org_schema.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 
 use super::meeting::{MeetingAgentConfig, MeetingConfig, SummaryAgentConfig, SummaryAgentRule};
 use super::runtime_store::org_schema_path;
-use super::settings::{MemoryConfigOverride, PeerAgentInfo, RoleBinding, resolve_memory_settings};
+use super::settings::{resolve_memory_settings, MemoryConfigOverride, PeerAgentInfo, RoleBinding};
 use crate::services::provider::ProviderKind;
 
 // ─── YAML Schema Types ──────────────────────────────────────────────────────
@@ -360,9 +360,7 @@ mod tests {
     where
         F: FnOnce(&TempDir),
     {
-        let _guard = super::super::runtime_store::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let _guard = super::super::runtime_store::lock_test_env();
         let temp = TempDir::new().unwrap();
         let root = temp.path().join(".adk");
         fs::create_dir_all(&root).unwrap();

--- a/src/services/discord/recovery.rs
+++ b/src/services/discord/recovery.rs
@@ -1,4 +1,4 @@
-use super::handoff::{save_handoff, HandoffRecord};
+use super::handoff::{HandoffRecord, save_handoff};
 use super::settings::{resolve_role_binding, validate_bot_channel_routing};
 use super::turn_bridge::stale_inflight_message;
 use super::*;
@@ -1536,9 +1536,11 @@ mod tests {
         assert!(handoffs[0].intent.contains("중단된 응답"));
         assert!(handoffs[0].context.contains("원래 사용자 요청"));
         assert!(handoffs[0].context.contains("partial 응답"));
-        assert!(handoffs[0]
-            .context
-            .contains("이어서 원인과 대응을 설명하겠습니다"));
+        assert!(
+            handoffs[0]
+                .context
+                .contains("이어서 원인과 대응을 설명하겠습니다")
+        );
     }
 
     #[test]

--- a/src/services/discord/recovery.rs
+++ b/src/services/discord/recovery.rs
@@ -1,4 +1,4 @@
-use super::handoff::{HandoffRecord, save_handoff};
+use super::handoff::{save_handoff, HandoffRecord};
 use super::settings::{resolve_role_binding, validate_bot_channel_routing};
 use super::turn_bridge::stale_inflight_message;
 use super::*;
@@ -1481,9 +1481,7 @@ mod tests {
 
     #[test]
     fn missing_session_recovery_saves_handoff_for_followup_turn() {
-        let _lock = super::super::runtime_store::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let _lock = super::super::runtime_store::lock_test_env();
         let temp = tempfile::TempDir::new().unwrap();
         let root = temp.path().join("agentdesk-root");
         std::fs::create_dir_all(root.join("runtime")).unwrap();
@@ -1538,11 +1536,9 @@ mod tests {
         assert!(handoffs[0].intent.contains("중단된 응답"));
         assert!(handoffs[0].context.contains("원래 사용자 요청"));
         assert!(handoffs[0].context.contains("partial 응답"));
-        assert!(
-            handoffs[0]
-                .context
-                .contains("이어서 원인과 대응을 설명하겠습니다")
-        );
+        assert!(handoffs[0]
+            .context
+            .contains("이어서 원인과 대응을 설명하겠습니다"));
     }
 
     #[test]

--- a/src/services/discord/role_map.rs
+++ b/src/services/discord/role_map.rs
@@ -4,7 +4,7 @@ use poise::serenity_prelude::ChannelId;
 
 use super::meeting::{MeetingAgentConfig, MeetingConfig, SummaryAgentConfig, SummaryAgentRule};
 use super::runtime_store::role_map_path;
-use super::settings::{resolve_memory_settings, MemoryConfigOverride, PeerAgentInfo, RoleBinding};
+use super::settings::{MemoryConfigOverride, PeerAgentInfo, RoleBinding, resolve_memory_settings};
 use crate::services::provider::ProviderKind;
 
 /// Expand `~` or `~/` prefix to the user's home directory.

--- a/src/services/discord/role_map.rs
+++ b/src/services/discord/role_map.rs
@@ -4,7 +4,7 @@ use poise::serenity_prelude::ChannelId;
 
 use super::meeting::{MeetingAgentConfig, MeetingConfig, SummaryAgentConfig, SummaryAgentRule};
 use super::runtime_store::role_map_path;
-use super::settings::{MemoryConfigOverride, PeerAgentInfo, RoleBinding, resolve_memory_settings};
+use super::settings::{resolve_memory_settings, MemoryConfigOverride, PeerAgentInfo, RoleBinding};
 use crate::services::provider::ProviderKind;
 
 /// Expand `~` or `~/` prefix to the user's home directory.
@@ -294,9 +294,7 @@ mod tests {
     where
         F: FnOnce(&TempDir),
     {
-        let _guard = super::super::runtime_store::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let _guard = super::super::runtime_store::lock_test_env();
         let temp = TempDir::new().unwrap();
         let root = temp.path().join(".adk");
         std::fs::create_dir_all(&root).unwrap();

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -1,12 +1,14 @@
 use super::super::*;
 use crate::services::memory::{
-    RecallRequest, RecallResponse, build_memory_backend, resolve_memory_role_id,
-    resolve_memory_session_id,
+    build_memory_backend, resolve_memory_role_id, resolve_memory_session_id, RecallRequest,
+    RecallResponse,
 };
 use crate::services::provider::{CancelToken, cancel_requested};
-#[cfg(unix)]
-use crate::services::tmux_common::tmux_exact_target;
 use std::sync::Arc;
+
+const DISCORD_FORMATTING_REMINDER: &str = "<system-reminder>\n\
+     Discord formatting: minimize code blocks, keep messages concise.\n\
+     </system-reminder>";
 
 #[derive(Debug, PartialEq, Eq)]
 struct MemoryInjectionPlan<'a> {
@@ -498,7 +500,10 @@ pub(in crate::services::discord) async fn handle_text_message(
             .and_then(|_| dispatch_type_str.as_deref()),
     );
 
-    reset_provider_session_if_pending(shared, channel_id, &provider).await;
+    super::super::commands::reset_provider_session_if_pending(
+        &ctx.http, shared, &provider, channel_id,
+    )
+    .await;
     let prompt_prep_started = std::time::Instant::now();
 
     // Resolve channel/tmux session name from current session state. We need the
@@ -1672,48 +1677,14 @@ pub(super) async fn handle_text_command(
         }
 
         "!clear" => {
-            let mut d = data.shared.core.lock().await;
-            if let Some(token) = d.cancel_tokens.remove(&channel_id) {
-                token.cancel_with_tmux_cleanup();
-            }
-            // Build tmux session name from channel name
-            let tmux_name = d
-                .sessions
-                .get(&channel_id)
-                .and_then(|s| s.channel_name.as_ref())
-                .map(|ch_name| data.provider.build_tmux_session_name(ch_name));
-            if let Some(session) = d.sessions.get_mut(&channel_id) {
-                session.history.clear();
-                session.pending_uploads.clear();
-                session.cleared = true;
-                session.session_id = None;
-            }
-            d.intervention_queue.remove(&channel_id);
-            drop(d);
-            // Clear stored provider session_id from DB
-            if let Some(key) = super::super::adk_session::build_adk_session_key(
+            super::super::commands::clear_channel_session_state(
+                &ctx.http,
                 &data.shared,
-                channel_id,
                 &data.provider,
+                channel_id,
+                "!clear",
             )
-            .await
-            {
-                super::super::adk_session::clear_provider_session_id(&key, data.shared.api_port)
-                    .await;
-            }
-            // Send /clear to the actual Claude Code session via tmux
-            #[cfg(unix)]
-            if data.provider == crate::services::provider::ProviderKind::Claude {
-                if let Some(ref name) = tmux_name {
-                    let exact_target = tmux_exact_target(name);
-                    let _ = tokio::task::spawn_blocking(move || {
-                        std::process::Command::new("tmux")
-                            .args(["send-keys", "-t", &exact_target, "/clear", "Enter"])
-                            .output()
-                    })
-                    .await;
-                }
-            }
+            .await;
             let _ = msg.reply(&ctx.http, "Session cleared.").await;
             return Ok(true);
         }
@@ -2386,65 +2357,14 @@ Any other message is sent to {p}.
             }
 
             // Build the prompt
-            let skill_prompt = match &data.provider {
-                ProviderKind::Claude => {
-                    if args_str.is_empty() {
-                        format!(
-                            "Execute the skill `/{skill}` now. \
-                             Use the Skill tool with skill=\"{skill}\". \
-                             Read files under `references/` only if the skill points to them or you need extra detail."
-                        )
-                    } else {
-                        format!(
-                            "Execute the skill `/{skill}` with arguments: {args_str}\n\
-                             Use the Skill tool with skill=\"{skill}\", args=\"{args_str}\". \
-                             Read files under `references/` only if the skill points to them or you need extra detail."
-                        )
-                    }
-                }
-                ProviderKind::Codex => {
-                    if args_str.is_empty() {
-                        format!(
-                            "Use the local Codex skill `/{skill}` now. \
-                             Load its `SKILL.md` first, follow it exactly, and read files under `references/` only when the skill points to them or you need them."
-                        )
-                    } else {
-                        format!(
-                            "Use the local Codex skill `/{skill}` now with this user request: {args_str}\n\
-                             Load its `SKILL.md` first, adapt it to the request, and read files under `references/` only when the skill points to them or you need them."
-                        )
-                    }
-                }
-                ProviderKind::Gemini => {
-                    if args_str.is_empty() {
-                        format!(
-                            "Use the local Gemini skill `/{skill}` now. \
-                             Load its `SKILL.md` first, follow it exactly, and read files under `references/` only when the skill points to them or you need them."
-                        )
-                    } else {
-                        format!(
-                            "Use the local Gemini skill `/{skill}` now with this user request: {args_str}\n\
-                             Load its `SKILL.md` first, adapt it to the request, and read files under `references/` only when the skill points to them or you need them."
-                        )
-                    }
-                }
-                ProviderKind::Qwen => {
-                    if args_str.is_empty() {
-                        format!(
-                            "Use the local Qwen skill `/{skill}` now. \
-                             Load its `SKILL.md` first, follow it exactly, and read files under `references/` only when the skill points to them or you need them."
-                        )
-                    } else {
-                        format!(
-                            "Use the local Qwen skill `/{skill}` now with this user request: {args_str}\n\
-                             Load its `SKILL.md` first, adapt it to the request, and read files under `references/` only when the skill points to them or you need them."
-                        )
-                    }
-                }
-                ProviderKind::Unsupported(name) => {
-                    let _ = msg
-                        .reply(&ctx.http, format!("Provider '{}' is not installed.", name))
-                        .await;
+            let skill_prompt = match super::super::commands::build_provider_skill_prompt(
+                &data.provider,
+                &skill,
+                args_str,
+            ) {
+                Ok(prompt) => prompt,
+                Err(message) => {
+                    let _ = msg.reply(&ctx.http, message).await;
                     return Ok(true);
                 }
             };
@@ -2482,48 +2402,20 @@ Any other message is sent to {p}.
     Ok(false)
 }
 
-/// Private helper: reset provider session if a model change is pending.
-async fn reset_provider_session_if_pending(
-    shared: &Arc<SharedData>,
-    channel_id: serenity::ChannelId,
-    provider: &ProviderKind,
-) {
-    if shared
-        .model_session_reset_pending
-        .remove(&channel_id)
-        .is_none()
-    {
-        return;
-    }
-
-    let channel_name = {
-        let mut data = shared.core.lock().await;
-        if let Some(session) = data.sessions.get_mut(&channel_id) {
-            session.session_id = None;
-            session.channel_name.clone()
-        } else {
-            None
-        }
-    };
-
-    if provider.uses_managed_tmux_backend() {
-        if let Some(name) = channel_name.as_deref() {
-            crate::services::claude::terminate_local_session(
-                &provider.build_tmux_session_name(name),
-            );
-        }
-    }
-
-    if let Some(session_key) = build_adk_session_key(shared, channel_id, provider).await {
-        super::super::adk_session::clear_provider_session_id(&session_key, shared.api_port).await;
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::super::super::DiscordSession;
     use super::*;
     use crate::services::memory::RecallResponse;
+
+    fn sample_recall() -> RecallResponse {
+        RecallResponse {
+            shared_knowledge: Some("[Shared Knowledge]".to_string()),
+            longterm_catalog: Some("- notes.md".to_string()),
+            external_recall: Some("[External Recall]".to_string()),
+            warnings: Vec::new(),
+        }
+    }
 
     fn make_session(
         current_path: Option<String>,
@@ -2542,15 +2434,6 @@ mod tests {
             last_active: tokio::time::Instant::now(),
             worktree: None,
             born_generation: 0,
-        }
-    }
-
-    fn sample_recall() -> RecallResponse {
-        RecallResponse {
-            shared_knowledge: Some("[Shared Knowledge]".to_string()),
-            longterm_catalog: Some("- notes.md".to_string()),
-            external_recall: Some("[External Recall]".to_string()),
-            warnings: Vec::new(),
         }
     }
 
@@ -2621,6 +2504,16 @@ mod tests {
         assert_eq!(codex.shared_knowledge_for_system_prompt, None);
         assert_eq!(codex.external_recall_for_context, Some("[External Recall]"));
         assert_eq!(codex.longterm_catalog_for_system_prompt, Some("- notes.md"));
+
+        let qwen =
+            build_memory_injection_plan(&ProviderKind::Qwen, false, DispatchProfile::Full, &recall);
+        assert_eq!(
+            qwen.shared_knowledge_for_context,
+            Some("[Shared Knowledge]")
+        );
+        assert_eq!(qwen.shared_knowledge_for_system_prompt, None);
+        assert_eq!(qwen.external_recall_for_context, Some("[External Recall]"));
+        assert_eq!(qwen.longterm_catalog_for_system_prompt, Some("- notes.md"));
     }
 
     #[test]

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -1,7 +1,7 @@
 use super::super::*;
 use crate::services::memory::{
-    build_memory_backend, resolve_memory_role_id, resolve_memory_session_id, RecallRequest,
-    RecallResponse,
+    RecallRequest, RecallResponse, build_memory_backend, resolve_memory_role_id,
+    resolve_memory_session_id,
 };
 use crate::services::provider::{CancelToken, cancel_requested};
 use std::sync::Arc;

--- a/src/services/discord/runtime_store.rs
+++ b/src/services/discord/runtime_store.rs
@@ -122,6 +122,13 @@ pub(crate) fn test_env_lock() -> &'static std::sync::Mutex<()> {
     crate::config::shared_test_env_lock()
 }
 
+#[cfg(test)]
+pub(crate) fn lock_test_env() -> std::sync::MutexGuard<'static, ()> {
+    test_env_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+}
+
 pub(super) fn atomic_write(path: &Path, data: &str) -> Result<(), String> {
     let tmp = path.with_extension("tmp");
     let mut file = fs::File::create(&tmp).map_err(|e| e.to_string())?;
@@ -138,7 +145,7 @@ mod tests {
     /// Acquire the shared env lock to avoid races between tests that mutate
     /// AGENTDESK_ROOT_DIR.
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        test_env_lock().lock().unwrap_or_else(|e| e.into_inner())
+        lock_test_env()
     }
 
     #[test]

--- a/src/services/discord/settings.rs
+++ b/src/services/discord/settings.rs
@@ -11,6 +11,7 @@ use poise::serenity_prelude as serenity;
 use crate::services::agent_protocol::DEFAULT_ALLOWED_TOOLS;
 use crate::services::provider::ProviderKind;
 
+use super::DiscordBotSettings;
 use super::formatting::normalize_allowed_tools;
 use super::org_schema;
 use super::role_map::{
@@ -21,7 +22,6 @@ use super::role_map::{
     resolve_workspace as resolve_workspace_from_role_map,
 };
 use super::runtime_store::{bot_settings_path, discord_uploads_root};
-use super::DiscordBotSettings;
 
 fn json_u64(value: &serde_json::Value) -> Option<u64> {
     value
@@ -168,11 +168,7 @@ fn clamp_timeout(name: &str, value: u64, min: u64, max: u64, default: u64) -> u6
             value
         );
     }
-    if clamped == 0 {
-        default
-    } else {
-        clamped
-    }
+    if clamped == 0 { default } else { clamped }
 }
 
 fn resolve_memory_backend(raw: Option<&str>) -> MemoryBackendKind {

--- a/src/services/discord/settings.rs
+++ b/src/services/discord/settings.rs
@@ -11,7 +11,6 @@ use poise::serenity_prelude as serenity;
 use crate::services::agent_protocol::DEFAULT_ALLOWED_TOOLS;
 use crate::services::provider::ProviderKind;
 
-use super::DiscordBotSettings;
 use super::formatting::normalize_allowed_tools;
 use super::org_schema;
 use super::role_map::{
@@ -22,6 +21,7 @@ use super::role_map::{
     resolve_workspace as resolve_workspace_from_role_map,
 };
 use super::runtime_store::{bot_settings_path, discord_uploads_root};
+use super::DiscordBotSettings;
 
 fn json_u64(value: &serde_json::Value) -> Option<u64> {
     value
@@ -168,7 +168,11 @@ fn clamp_timeout(name: &str, value: u64, min: u64, max: u64, default: u64) -> u6
             value
         );
     }
-    if clamped == 0 { default } else { clamped }
+    if clamped == 0 {
+        default
+    } else {
+        clamped
+    }
 }
 
 fn resolve_memory_backend(raw: Option<&str>) -> MemoryBackendKind {
@@ -1037,9 +1041,7 @@ mod tests {
     where
         F: FnOnce(&TempDir),
     {
-        let _guard = super::super::runtime_store::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let _guard = super::super::runtime_store::lock_test_env();
         let temp_home = TempDir::new().unwrap();
         let root = temp_home.path().join(".adk");
         fs::create_dir_all(&root).unwrap();

--- a/src/services/discord/shared_memory.rs
+++ b/src/services/discord/shared_memory.rs
@@ -23,9 +23,7 @@ mod tests {
     where
         F: FnOnce(&std::path::Path),
     {
-        let _guard = super::super::runtime_store::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let _guard = super::super::runtime_store::lock_test_env();
         let temp = tempfile::TempDir::new().unwrap();
         let root = temp.path().join(".adk");
         let sak_dir = root

--- a/src/services/discord/turn_bridge/tests.rs
+++ b/src/services/discord/turn_bridge/tests.rs
@@ -15,9 +15,9 @@ use super::stale_resume::{
     result_event_has_stale_resume_error, stream_error_requires_terminal_session_reset,
 };
 use super::tmux_runtime::should_resume_watcher_after_turn;
-use crate::services::discord::settings::{MemoryBackendKind, ResolvedMemorySettings};
 use crate::services::discord::ChannelId;
 use crate::services::discord::InflightTurnState;
+use crate::services::discord::settings::{MemoryBackendKind, ResolvedMemorySettings};
 use crate::services::memory::CaptureRequest;
 use crate::services::provider::ProviderKind;
 use std::io::Write;

--- a/src/services/discord/turn_bridge/tests.rs
+++ b/src/services/discord/turn_bridge/tests.rs
@@ -15,9 +15,9 @@ use super::stale_resume::{
     result_event_has_stale_resume_error, stream_error_requires_terminal_session_reset,
 };
 use super::tmux_runtime::should_resume_watcher_after_turn;
+use crate::services::discord::settings::{MemoryBackendKind, ResolvedMemorySettings};
 use crate::services::discord::ChannelId;
 use crate::services::discord::InflightTurnState;
-use crate::services::discord::settings::{MemoryBackendKind, ResolvedMemorySettings};
 use crate::services::memory::CaptureRequest;
 use crate::services::provider::ProviderKind;
 use std::io::Write;
@@ -44,9 +44,7 @@ fn set_mem0_env(
     Option<std::ffi::OsString>,
     Option<std::ffi::OsString>,
 ) {
-    let guard = crate::services::discord::runtime_store::test_env_lock()
-        .lock()
-        .unwrap();
+    let guard = crate::services::discord::runtime_store::lock_test_env();
     let prev_api_key = std::env::var_os("MEM0_API_KEY");
     let prev_base_url = std::env::var_os("MEM0_BASE_URL");
     unsafe {

--- a/src/services/memory/local.rs
+++ b/src/services/memory/local.rs
@@ -84,10 +84,12 @@ mod tests {
             recall.shared_knowledge.as_deref(),
             Some("[Shared Agent Knowledge]\nRemember this")
         );
-        assert!(recall
-            .longterm_catalog
-            .as_deref()
-            .is_some_and(|catalog| catalog.contains("facts.md")));
+        assert!(
+            recall
+                .longterm_catalog
+                .as_deref()
+                .is_some_and(|catalog| catalog.contains("facts.md"))
+        );
         assert!(recall.external_recall.is_none());
     }
 

--- a/src/services/memory/local.rs
+++ b/src/services/memory/local.rs
@@ -40,9 +40,7 @@ mod tests {
         TempDir,
         Option<std::ffi::OsString>,
     ) {
-        let guard = crate::services::discord::runtime_store::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let guard = crate::services::discord::runtime_store::lock_test_env();
         let temp = TempDir::new().unwrap();
         let root = temp.path().join(".adk");
         let shared = shared_agent_knowledge_path(&root);
@@ -86,12 +84,10 @@ mod tests {
             recall.shared_knowledge.as_deref(),
             Some("[Shared Agent Knowledge]\nRemember this")
         );
-        assert!(
-            recall
-                .longterm_catalog
-                .as_deref()
-                .is_some_and(|catalog| catalog.contains("facts.md"))
-        );
+        assert!(recall
+            .longterm_catalog
+            .as_deref()
+            .is_some_and(|catalog| catalog.contains("facts.md")));
         assert!(recall.external_recall.is_none());
     }
 

--- a/src/services/memory/mem0.rs
+++ b/src/services/memory/mem0.rs
@@ -517,9 +517,7 @@ mod tests {
         Option<std::ffi::OsString>,
         Option<std::ffi::OsString>,
     ) {
-        let guard = crate::services::discord::runtime_store::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let guard = crate::services::discord::runtime_store::lock_test_env();
         let prev_api_key = std::env::var_os("MEM0_API_KEY");
         let prev_base_url = std::env::var_os("MEM0_BASE_URL");
         unsafe {
@@ -550,9 +548,7 @@ mod tests {
         Option<std::ffi::OsString>,
         Option<std::ffi::OsString>,
     ) {
-        let guard = crate::services::discord::runtime_store::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let guard = crate::services::discord::runtime_store::lock_test_env();
         let prev_api_key = std::env::var_os("MEM0_API_KEY");
         let prev_base_url = std::env::var_os("MEM0_BASE_URL");
         unsafe {

--- a/src/services/platform/binary_resolver.rs
+++ b/src/services/platform/binary_resolver.rs
@@ -618,9 +618,7 @@ mod tests {
     use std::sync::MutexGuard;
 
     fn env_guard() -> MutexGuard<'static, ()> {
-        crate::services::discord::runtime_store::test_env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+        crate::services::discord::runtime_store::lock_test_env()
     }
 
     #[cfg(unix)]

--- a/src/services/qwen.rs
+++ b/src/services/qwen.rs
@@ -1,14 +1,14 @@
-use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use regex::Regex;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
-use std::sync::mpsc::{self, RecvTimeoutError, Sender};
 use std::sync::Arc;
 use std::sync::OnceLock;
+use std::sync::mpsc::{self, RecvTimeoutError, Sender};
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -1821,10 +1821,10 @@ fn render_qwen_value(value: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
+        QWEN_CODE_SYSTEM_SETTINGS_ENV, QwenAttemptState, QwenResumeStrategy,
         build_stream_exec_args, compose_qwen_prompt, create_system_settings_override,
         extract_text_from_json_output, normalize_resume_strategy, process_qwen_json_event,
-        qwen_project_cache_key, resolve_allowed_core_tools, QwenAttemptState, QwenResumeStrategy,
-        QWEN_CODE_SYSTEM_SETTINGS_ENV,
+        qwen_project_cache_key, resolve_allowed_core_tools,
     };
     use crate::services::agent_protocol::StreamMessage;
     use serde_json::json;
@@ -1889,12 +1889,14 @@ mod tests {
             Some("qwen3-coder"),
             &QwenResumeStrategy::Resume("session-123".to_string()),
         );
-        assert!(args
-            .windows(2)
-            .any(|pair| pair == ["--resume", "session-123"]));
-        assert!(args
-            .windows(2)
-            .any(|pair| pair == ["--model", "qwen3-coder"]));
+        assert!(
+            args.windows(2)
+                .any(|pair| pair == ["--resume", "session-123"])
+        );
+        assert!(
+            args.windows(2)
+                .any(|pair| pair == ["--model", "qwen3-coder"])
+        );
         assert!(args.contains(&"--include-partial-messages".to_string()));
     }
 

--- a/src/services/qwen.rs
+++ b/src/services/qwen.rs
@@ -1,14 +1,14 @@
-use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use regex::Regex;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
+use std::sync::mpsc::{self, RecvTimeoutError, Sender};
 use std::sync::Arc;
 use std::sync::OnceLock;
-use std::sync::mpsc::{self, RecvTimeoutError, Sender};
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -32,9 +32,9 @@ use crate::services::tmux_diagnostics::{
 
 const QWEN_CANCELLED_MESSAGE: &str = "Qwen request cancelled";
 const QWEN_SESSION_DEAD_MESSAGE: &str = "Qwen stream ended without a terminal result";
-const QWEN_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
-const QWEN_STREAM_IDLE_TICKS_BEFORE_RETRY: u32 = 2;
-const QWEN_MAX_SESSION_RETRIES: usize = 1;
+pub(crate) const QWEN_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
+pub(crate) const QWEN_STREAM_IDLE_TICKS_BEFORE_RETRY: u32 = 2;
+pub(crate) const QWEN_MAX_SESSION_RETRIES: usize = 1;
 const TMUX_PROMPT_B64_PREFIX: &str = "__AGENTDESK_B64__:";
 pub(crate) const QWEN_CODE_SYSTEM_SETTINGS_ENV: &str = "QWEN_CODE_SYSTEM_SETTINGS_PATH";
 const QWEN_SUPPORTED_ALLOWED_TOOLS: &[&str] = &[
@@ -85,7 +85,7 @@ enum QwenStreamEvent {
 }
 
 #[derive(Clone, Debug)]
-enum QwenResumeStrategy {
+pub(crate) enum QwenResumeStrategy {
     Fresh,
     Continue,
     Resume(String),
@@ -261,7 +261,7 @@ pub fn execute_command_streaming(
         );
     }
 
-    let mut resume_strategy = normalize_resume_strategy(session_id)?;
+    let mut resume_strategy = normalize_resume_strategy(session_id, working_dir)?;
 
     for attempt in 0..=QWEN_MAX_SESSION_RETRIES {
         match execute_qwen_streaming_attempt(
@@ -1532,7 +1532,7 @@ fn build_simple_exec_args(prompt: &str) -> Vec<String> {
     ]
 }
 
-fn build_stream_exec_args(
+pub(crate) fn build_stream_exec_args(
     prompt: &str,
     model: Option<&str>,
     resume_strategy: &QwenResumeStrategy,
@@ -1566,9 +1566,15 @@ fn build_stream_exec_args(
     args
 }
 
-fn normalize_resume_strategy(session_id: Option<&str>) -> Result<QwenResumeStrategy, String> {
+pub(crate) fn normalize_resume_strategy(
+    session_id: Option<&str>,
+    working_dir: &str,
+) -> Result<QwenResumeStrategy, String> {
     let Some(session_id) = session_id.map(str::trim).filter(|value| !value.is_empty()) else {
-        return Ok(QwenResumeStrategy::Continue);
+        if has_prior_qwen_chat_cache(working_dir) {
+            return Ok(QwenResumeStrategy::Continue);
+        }
+        return Ok(QwenResumeStrategy::Fresh);
     };
 
     if !is_valid_session_id(session_id) {
@@ -1579,6 +1585,59 @@ fn normalize_resume_strategy(session_id: Option<&str>) -> Result<QwenResumeStrat
     }
 
     Ok(QwenResumeStrategy::Resume(session_id.to_string()))
+}
+
+fn has_prior_qwen_chat_cache(working_dir: &str) -> bool {
+    let Some(chats_dir) = qwen_chat_cache_dir_for_working_dir(working_dir) else {
+        return false;
+    };
+    let Ok(entries) = std::fs::read_dir(chats_dir) else {
+        return false;
+    };
+
+    entries.flatten().any(|entry| {
+        let path = entry.path();
+        path.is_file()
+            && path
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("jsonl"))
+    })
+}
+
+fn qwen_chat_cache_dir_for_working_dir(working_dir: &str) -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    Some(
+        home.join(".qwen")
+            .join("projects")
+            .join(qwen_project_cache_key(working_dir))
+            .join("chats"),
+    )
+}
+
+pub(crate) fn qwen_project_cache_key(working_dir: &str) -> String {
+    normalize_qwen_working_dir(working_dir)
+        .to_string_lossy()
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
+        .collect()
+}
+
+fn normalize_qwen_working_dir(working_dir: &str) -> PathBuf {
+    let expanded = expand_home_dir(working_dir);
+    std::fs::canonicalize(&expanded).unwrap_or(expanded)
+}
+
+fn expand_home_dir(path: &str) -> PathBuf {
+    if path == "~" {
+        return dirs::home_dir().unwrap_or_else(|| PathBuf::from(path));
+    }
+    if let Some(stripped) = path.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(stripped);
+        }
+    }
+    PathBuf::from(path)
 }
 
 fn is_valid_session_id(session_id: &str) -> bool {
@@ -1762,13 +1821,54 @@ fn render_qwen_value(value: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        QWEN_CODE_SYSTEM_SETTINGS_ENV, QwenAttemptState, QwenResumeStrategy,
         build_stream_exec_args, compose_qwen_prompt, create_system_settings_override,
         extract_text_from_json_output, normalize_resume_strategy, process_qwen_json_event,
-        resolve_allowed_core_tools,
+        qwen_project_cache_key, resolve_allowed_core_tools, QwenAttemptState, QwenResumeStrategy,
+        QWEN_CODE_SYSTEM_SETTINGS_ENV,
     };
     use crate::services::agent_protocol::StreamMessage;
     use serde_json::json;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn with_temp_qwen_home<F>(f: F)
+    where
+        F: FnOnce(&TempDir, &TempDir),
+    {
+        let _guard = crate::services::discord::runtime_store::lock_test_env();
+        let temp_home = TempDir::new().unwrap();
+        let temp_project = TempDir::new().unwrap();
+
+        let prev_home = std::env::var_os("HOME");
+        let prev_userprofile = std::env::var_os("USERPROFILE");
+
+        unsafe {
+            std::env::set_var("HOME", temp_home.path());
+            std::env::set_var("USERPROFILE", temp_home.path());
+        }
+
+        f(&temp_home, &temp_project);
+
+        match prev_home {
+            Some(value) => unsafe { std::env::set_var("HOME", value) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        match prev_userprofile {
+            Some(value) => unsafe { std::env::set_var("USERPROFILE", value) },
+            None => unsafe { std::env::remove_var("USERPROFILE") },
+        }
+    }
+
+    fn create_prior_qwen_chat_cache(temp_home: &TempDir, working_dir: &TempDir) {
+        let chats_dir = temp_home
+            .path()
+            .join(".qwen")
+            .join("projects")
+            .join(qwen_project_cache_key(working_dir.path().to_str().unwrap()))
+            .join("chats");
+        fs::create_dir_all(&chats_dir).unwrap();
+        fs::write(chats_dir.join("turn-1.jsonl"), "{\"type\":\"result\"}\n").unwrap();
+    }
 
     #[test]
     fn compose_qwen_prompt_includes_authoritative_sections() {
@@ -1789,14 +1889,12 @@ mod tests {
             Some("qwen3-coder"),
             &QwenResumeStrategy::Resume("session-123".to_string()),
         );
-        assert!(
-            args.windows(2)
-                .any(|pair| pair == ["--resume", "session-123"])
-        );
-        assert!(
-            args.windows(2)
-                .any(|pair| pair == ["--model", "qwen3-coder"])
-        );
+        assert!(args
+            .windows(2)
+            .any(|pair| pair == ["--resume", "session-123"]));
+        assert!(args
+            .windows(2)
+            .any(|pair| pair == ["--model", "qwen3-coder"]));
         assert!(args.contains(&"--include-partial-messages".to_string()));
     }
 
@@ -1888,11 +1986,24 @@ mod tests {
     }
 
     #[test]
-    fn normalize_resume_strategy_defaults_to_continue() {
-        assert!(matches!(
-            normalize_resume_strategy(None).unwrap(),
-            QwenResumeStrategy::Continue
-        ));
+    fn normalize_resume_strategy_defaults_to_fresh_without_prior_cache() {
+        with_temp_qwen_home(|_temp_home, working_dir| {
+            assert!(matches!(
+                normalize_resume_strategy(None, working_dir.path().to_str().unwrap()).unwrap(),
+                QwenResumeStrategy::Fresh
+            ));
+        });
+    }
+
+    #[test]
+    fn normalize_resume_strategy_uses_continue_with_prior_cache() {
+        with_temp_qwen_home(|temp_home, working_dir| {
+            create_prior_qwen_chat_cache(temp_home, working_dir);
+            assert!(matches!(
+                normalize_resume_strategy(None, working_dir.path().to_str().unwrap()).unwrap(),
+                QwenResumeStrategy::Continue
+            ));
+        });
     }
 
     #[test]

--- a/src/services/qwen.rs
+++ b/src/services/qwen.rs
@@ -1606,7 +1606,7 @@ fn has_prior_qwen_chat_cache(working_dir: &str) -> bool {
 }
 
 fn qwen_chat_cache_dir_for_working_dir(working_dir: &str) -> Option<PathBuf> {
-    let home = dirs::home_dir()?;
+    let home = qwen_home_dir()?;
     Some(
         home.join(".qwen")
             .join("projects")
@@ -1628,12 +1628,29 @@ fn normalize_qwen_working_dir(working_dir: &str) -> PathBuf {
     std::fs::canonicalize(&expanded).unwrap_or(expanded)
 }
 
+fn qwen_home_dir() -> Option<PathBuf> {
+    std::env::var_os("QWEN_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+        })
+        .or_else(|| {
+            std::env::var_os("USERPROFILE")
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+        })
+        .or_else(dirs::home_dir)
+}
+
 fn expand_home_dir(path: &str) -> PathBuf {
     if path == "~" {
-        return dirs::home_dir().unwrap_or_else(|| PathBuf::from(path));
+        return qwen_home_dir().unwrap_or_else(|| PathBuf::from(path));
     }
     if let Some(stripped) = path.strip_prefix("~/") {
-        if let Some(home) = dirs::home_dir() {
+        if let Some(home) = qwen_home_dir() {
             return home.join(stripped);
         }
     }

--- a/src/services/qwen_tmux_wrapper.rs
+++ b/src/services/qwen_tmux_wrapper.rs
@@ -1,11 +1,11 @@
-use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
-use serde_json::{Value, json};
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Command, Stdio};
-use std::sync::mpsc;
+use std::sync::mpsc::{self, RecvTimeoutError};
 
-use crate::services::tmux_wrapper::{InputMode, render_for_terminal};
+use crate::services::tmux_wrapper::{render_for_terminal, InputMode};
 
 const TMUX_PROMPT_B64_PREFIX: &str = "__AGENTDESK_B64__:";
 
@@ -24,6 +24,19 @@ struct TurnNormalizationState {
     last_session_id: Option<String>,
     init_emitted_for_session: Option<String>,
     partial_blocks: HashMap<usize, PartialBlockState>,
+}
+
+#[derive(Debug)]
+enum TurnReadEvent {
+    Line(String),
+    ReadError(String),
+    Eof,
+}
+
+#[derive(Debug)]
+struct TurnFailure {
+    message: String,
+    retryable: bool,
 }
 
 pub fn run(
@@ -222,9 +235,47 @@ fn run_turn(
     session_id: &mut Option<String>,
     settings_override: Option<&crate::services::qwen::QwenSystemSettingsOverride>,
 ) -> Result<(), String> {
+    let mut resume_strategy =
+        crate::services::qwen::normalize_resume_strategy(session_id.as_deref(), working_dir)?;
+
+    for attempt in 0..=crate::services::qwen::QWEN_MAX_SESSION_RETRIES {
+        match run_turn_once(
+            output,
+            qwen_bin,
+            qwen_model,
+            working_dir,
+            prompt,
+            session_id,
+            settings_override,
+            &resume_strategy,
+        ) {
+            Ok(()) => return Ok(()),
+            Err(err)
+                if err.retryable && attempt < crate::services::qwen::QWEN_MAX_SESSION_RETRIES =>
+            {
+                *session_id = None;
+                resume_strategy = crate::services::qwen::QwenResumeStrategy::Fresh;
+            }
+            Err(err) => return Err(err.message),
+        }
+    }
+
+    Ok(())
+}
+
+fn run_turn_once(
+    output: &mut std::fs::File,
+    qwen_bin: &str,
+    qwen_model: Option<&str>,
+    working_dir: &str,
+    prompt: &str,
+    session_id: &mut Option<String>,
+    settings_override: Option<&crate::services::qwen::QwenSystemSettingsOverride>,
+    resume_strategy: &crate::services::qwen::QwenResumeStrategy,
+) -> Result<(), TurnFailure> {
     emit_status("[sending...]");
 
-    let args = build_turn_args(prompt, qwen_model, session_id.as_deref());
+    let args = crate::services::qwen::build_stream_exec_args(prompt, qwen_model, resume_strategy);
     let mut command = Command::new(qwen_bin);
     crate::services::platform::augment_exec_path(&mut command, qwen_bin);
     command
@@ -239,25 +290,27 @@ fn run_turn(
             settings_override.path(),
         );
     }
-    let mut child = command
-        .spawn()
-        .map_err(|e| format!("Failed to start Qwen: {}", e))?;
+    let mut child = command.spawn().map_err(|e| TurnFailure {
+        message: format!("Failed to start Qwen: {}", e),
+        retryable: false,
+    })?;
 
     let child_pid = child.id();
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| "Failed to capture Qwen stdout".to_string())?;
-    let stderr = child
-        .stderr
-        .take()
-        .ok_or_else(|| "Failed to capture Qwen stderr".to_string())?;
+    let stdout = child.stdout.take().ok_or_else(|| TurnFailure {
+        message: "Failed to capture Qwen stdout".to_string(),
+        retryable: false,
+    })?;
+    let stderr = child.stderr.take().ok_or_else(|| TurnFailure {
+        message: "Failed to capture Qwen stderr".to_string(),
+        retryable: false,
+    })?;
     let stderr_handle = std::thread::spawn(move || {
         let mut buf = String::new();
         let mut reader = BufReader::new(stderr);
         let _ = std::io::Read::read_to_string(&mut reader, &mut buf);
         buf
     });
+    let stdout_events = spawn_turn_stream_reader(stdout);
 
     let mut state = TurnNormalizationState {
         last_session_id: session_id.clone(),
@@ -265,33 +318,73 @@ fn run_turn(
         ..TurnNormalizationState::default()
     };
     let mut saw_result = false;
+    let mut idle_ticks = 0;
 
-    let reader = BufReader::new(stdout);
-    for line in reader.lines() {
-        let line = line.map_err(|e| format!("Failed to read Qwen output: {}", e))?;
-        for normalized in normalize_qwen_line(&line, &mut state) {
-            if let Some(id) = extract_init_session_id(&normalized) {
-                *session_id = Some(id);
+    loop {
+        match stdout_events.recv_timeout(crate::services::qwen::QWEN_STREAM_IDLE_TIMEOUT) {
+            Ok(TurnReadEvent::Line(line)) => {
+                idle_ticks = 0;
+                for normalized in normalize_qwen_line(&line, &mut state) {
+                    if let Some(id) = extract_init_session_id(&normalized) {
+                        *session_id = Some(id);
+                    }
+                    if is_result_line(&normalized) {
+                        saw_result = true;
+                    }
+                    emit_json_line(output, normalized).map_err(|err| TurnFailure {
+                        message: err,
+                        retryable: false,
+                    })?;
+                }
             }
-            if is_result_line(&normalized) {
-                saw_result = true;
+            Ok(TurnReadEvent::ReadError(message)) => {
+                crate::services::process::kill_pid_tree(child_pid);
+                let _ = child.wait();
+                let _ = stderr_handle.join().unwrap_or_default();
+                return Err(TurnFailure {
+                    message,
+                    retryable: true,
+                });
             }
-            emit_json_line(output, normalized)?;
+            Ok(TurnReadEvent::Eof) | Err(RecvTimeoutError::Disconnected) => break,
+            Err(RecvTimeoutError::Timeout) => {
+                if saw_result {
+                    break;
+                }
+                idle_ticks += 1;
+                if idle_ticks >= crate::services::qwen::QWEN_STREAM_IDLE_TICKS_BEFORE_RETRY {
+                    crate::services::process::kill_pid_tree(child_pid);
+                    let _ = child.wait();
+                    let _ = stderr_handle.join().unwrap_or_default();
+                    return Err(TurnFailure {
+                        message: format!(
+                            "Qwen stream produced no output for {} seconds",
+                            crate::services::qwen::QWEN_STREAM_IDLE_TIMEOUT.as_secs()
+                                * crate::services::qwen::QWEN_STREAM_IDLE_TICKS_BEFORE_RETRY as u64
+                        ),
+                        retryable: true,
+                    });
+                }
+            }
         }
     }
 
     crate::services::process::kill_pid_tree(child_pid);
     std::thread::sleep(std::time::Duration::from_millis(200));
 
-    let wait = child
-        .wait_with_output()
-        .map_err(|e| format!("Failed to wait for Qwen: {}", e))?;
+    let wait = child.wait_with_output().map_err(|e| TurnFailure {
+        message: format!("Failed to wait for Qwen: {}", e),
+        retryable: false,
+    })?;
     let stderr = stderr_handle.join().unwrap_or_default();
 
     if !wait.status.success() && !saw_result {
         let message = derive_wrapper_error_message(&stderr, wait.status.code());
         emit_result_error(output, &message);
-        return Err(message);
+        return Err(TurnFailure {
+            message,
+            retryable: false,
+        });
     }
 
     if !saw_result {
@@ -301,33 +394,56 @@ fn run_turn(
             stderr.trim().to_string()
         };
         emit_result_error(output, &message);
-        return Err(message);
+        return Err(TurnFailure {
+            message,
+            retryable: true,
+        });
     }
 
     Ok(())
 }
 
-fn build_turn_args(prompt: &str, model: Option<&str>, session_id: Option<&str>) -> Vec<String> {
-    let mut args = Vec::new();
-    if let Some(model) = model.map(str::trim).filter(|value| !value.is_empty()) {
-        args.push("--model".to_string());
-        args.push(model.to_string());
-    }
-    if let Some(session_id) = session_id.map(str::trim).filter(|value| !value.is_empty()) {
-        args.push("--resume".to_string());
-        args.push(session_id.to_string());
-    } else {
-        args.push("--continue".to_string());
-    }
-    args.push("-p".to_string());
-    args.push(prompt.to_string());
-    args.push("--output-format".to_string());
-    args.push("stream-json".to_string());
-    args.push("--include-partial-messages".to_string());
-    args.push("-y".to_string());
-    args.push("--sandbox".to_string());
-    args.push("false".to_string());
-    args
+#[cfg(test)]
+fn build_turn_args(
+    prompt: &str,
+    model: Option<&str>,
+    session_id: Option<&str>,
+    working_dir: &str,
+) -> Result<Vec<String>, String> {
+    let resume_strategy =
+        crate::services::qwen::normalize_resume_strategy(session_id, working_dir)?;
+    Ok(crate::services::qwen::build_stream_exec_args(
+        prompt,
+        model,
+        &resume_strategy,
+    ))
+}
+
+fn spawn_turn_stream_reader<R: std::io::Read + Send + 'static>(
+    stdout: R,
+) -> mpsc::Receiver<TurnReadEvent> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            match line {
+                Ok(line) => {
+                    if tx.send(TurnReadEvent::Line(line)).is_err() {
+                        return;
+                    }
+                }
+                Err(err) => {
+                    let _ = tx.send(TurnReadEvent::ReadError(format!(
+                        "Failed to read Qwen output: {}",
+                        err
+                    )));
+                    return;
+                }
+            }
+        }
+        let _ = tx.send(TurnReadEvent::Eof);
+    });
+    rx
 }
 
 fn normalize_qwen_line(line: &str, state: &mut TurnNormalizationState) -> Vec<Value> {
@@ -769,6 +885,48 @@ fn emit_json_line(output: &mut std::fs::File, value: Value) -> Result<(), String
 #[cfg(test)]
 mod tests {
     use super::{build_turn_args, decode_external_prompt, normalize_qwen_line};
+    use crate::services::qwen::qwen_project_cache_key;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn with_temp_qwen_home<F>(f: F)
+    where
+        F: FnOnce(&TempDir, &TempDir),
+    {
+        let _guard = crate::services::discord::runtime_store::lock_test_env();
+        let temp_home = TempDir::new().unwrap();
+        let temp_project = TempDir::new().unwrap();
+
+        let prev_home = std::env::var_os("HOME");
+        let prev_userprofile = std::env::var_os("USERPROFILE");
+
+        unsafe {
+            std::env::set_var("HOME", temp_home.path());
+            std::env::set_var("USERPROFILE", temp_home.path());
+        }
+
+        f(&temp_home, &temp_project);
+
+        match prev_home {
+            Some(value) => unsafe { std::env::set_var("HOME", value) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        match prev_userprofile {
+            Some(value) => unsafe { std::env::set_var("USERPROFILE", value) },
+            None => unsafe { std::env::remove_var("USERPROFILE") },
+        }
+    }
+
+    fn create_prior_qwen_chat_cache(temp_home: &TempDir, working_dir: &TempDir) {
+        let chats_dir = temp_home
+            .path()
+            .join(".qwen")
+            .join("projects")
+            .join(qwen_project_cache_key(working_dir.path().to_str().unwrap()))
+            .join("chats");
+        fs::create_dir_all(&chats_dir).unwrap();
+        fs::write(chats_dir.join("turn-1.jsonl"), "{\"type\":\"result\"}\n").unwrap();
+    }
 
     #[test]
     fn test_decode_external_prompt_keeps_plain_line() {
@@ -798,20 +956,52 @@ mod tests {
     }
 
     #[test]
-    fn build_turn_args_uses_continue_without_resume_token() {
-        let args = build_turn_args("hello", Some("qwen-max"), None);
-        assert!(args.windows(2).any(|pair| pair == ["--model", "qwen-max"]));
-        assert!(args.iter().any(|arg| arg == "--continue"));
-        assert!(!args.iter().any(|arg| arg == "--resume"));
+    fn build_turn_args_uses_fresh_without_resume_token_or_prior_cache() {
+        with_temp_qwen_home(|_temp_home, working_dir| {
+            let args = build_turn_args(
+                "hello",
+                Some("qwen-max"),
+                None,
+                working_dir.path().to_str().unwrap(),
+            )
+            .unwrap();
+            assert!(args.windows(2).any(|pair| pair == ["--model", "qwen-max"]));
+            assert!(!args.iter().any(|arg| arg == "--continue"));
+            assert!(!args.iter().any(|arg| arg == "--resume"));
+        });
+    }
+
+    #[test]
+    fn build_turn_args_uses_continue_with_prior_cache() {
+        with_temp_qwen_home(|temp_home, working_dir| {
+            create_prior_qwen_chat_cache(temp_home, working_dir);
+            let args = build_turn_args(
+                "hello",
+                Some("qwen-max"),
+                None,
+                working_dir.path().to_str().unwrap(),
+            )
+            .unwrap();
+            assert!(args.windows(2).any(|pair| pair == ["--model", "qwen-max"]));
+            assert!(args.iter().any(|arg| arg == "--continue"));
+            assert!(!args.iter().any(|arg| arg == "--resume"));
+        });
     }
 
     #[test]
     fn build_turn_args_prefers_resume_token_when_present() {
-        let args = build_turn_args("hello", None, Some("session-123"));
-        assert!(
-            args.windows(2)
-                .any(|pair| pair == ["--resume", "session-123"])
-        );
-        assert!(!args.iter().any(|arg| arg == "--continue"));
+        with_temp_qwen_home(|_temp_home, working_dir| {
+            let args = build_turn_args(
+                "hello",
+                None,
+                Some("session-123"),
+                working_dir.path().to_str().unwrap(),
+            )
+            .unwrap();
+            assert!(args
+                .windows(2)
+                .any(|pair| pair == ["--resume", "session-123"]));
+            assert!(!args.iter().any(|arg| arg == "--continue"));
+        });
     }
 }

--- a/src/services/qwen_tmux_wrapper.rs
+++ b/src/services/qwen_tmux_wrapper.rs
@@ -239,6 +239,10 @@ fn run_turn(
         crate::services::qwen::normalize_resume_strategy(session_id.as_deref(), working_dir)?;
 
     for attempt in 0..=crate::services::qwen::QWEN_MAX_SESSION_RETRIES {
+        let output_checkpoint = output
+            .metadata()
+            .map_err(|err| format!("read Qwen output checkpoint: {}", err))?
+            .len();
         match run_turn_once(
             output,
             qwen_bin,
@@ -253,6 +257,7 @@ fn run_turn(
             Err(err)
                 if err.retryable && attempt < crate::services::qwen::QWEN_MAX_SESSION_RETRIES =>
             {
+                rewind_output_to_checkpoint(output, output_checkpoint)?;
                 *session_id = None;
                 resume_strategy = crate::services::qwen::QwenResumeStrategy::Fresh;
             }
@@ -382,7 +387,7 @@ fn run_turn_once(
         let message = derive_wrapper_error_message(&stderr, wait.status.code());
         return Err(TurnFailure {
             message,
-            retryable: false,
+            retryable: true,
         });
     }
 
@@ -831,6 +836,16 @@ fn derive_wrapper_error_message(stderr: &str, exit_code: Option<i32>) -> String 
     }
 }
 
+fn rewind_output_to_checkpoint(output: &mut std::fs::File, checkpoint: u64) -> Result<(), String> {
+    output
+        .flush()
+        .map_err(|err| format!("flush output before retry: {}", err))?;
+    output
+        .set_len(checkpoint)
+        .map_err(|err| format!("truncate output before retry: {}", err))?;
+    Ok(())
+}
+
 fn extract_init_session_id(value: &Value) -> Option<String> {
     if value.get("type").and_then(|v| v.as_str()) != Some("system") {
         return None;
@@ -885,6 +900,7 @@ mod tests {
     use super::{build_turn_args, decode_external_prompt, normalize_qwen_line};
     use crate::services::qwen::qwen_project_cache_key;
     use std::fs;
+    use std::io::Write;
     use tempfile::TempDir;
 
     fn with_temp_qwen_home<F>(f: F)
@@ -1002,5 +1018,30 @@ mod tests {
             );
             assert!(!args.iter().any(|arg| arg == "--continue"));
         });
+    }
+
+    #[test]
+    fn rewind_output_to_checkpoint_discards_retryable_partial_lines() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("turn.jsonl");
+        let mut output = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .unwrap();
+
+        writeln!(output, "{{\"type\":\"assistant\",\"message\":\"keep\"}}").unwrap();
+        output.flush().unwrap();
+        let checkpoint = output.metadata().unwrap().len();
+
+        writeln!(output, "{{\"type\":\"assistant\",\"message\":\"drop\"}}").unwrap();
+        output.flush().unwrap();
+
+        super::rewind_output_to_checkpoint(&mut output, checkpoint).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "{\"type\":\"assistant\",\"message\":\"keep\"}\n"
+        );
     }
 }

--- a/src/services/qwen_tmux_wrapper.rs
+++ b/src/services/qwen_tmux_wrapper.rs
@@ -1,11 +1,11 @@
-use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
-use serde_json::{json, Value};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Command, Stdio};
 use std::sync::mpsc::{self, RecvTimeoutError};
 
-use crate::services::tmux_wrapper::{render_for_terminal, InputMode};
+use crate::services::tmux_wrapper::{InputMode, render_for_terminal};
 
 const TMUX_PROMPT_B64_PREFIX: &str = "__AGENTDESK_B64__:";
 
@@ -380,7 +380,6 @@ fn run_turn_once(
 
     if !wait.status.success() && !saw_result {
         let message = derive_wrapper_error_message(&stderr, wait.status.code());
-        emit_result_error(output, &message);
         return Err(TurnFailure {
             message,
             retryable: false,
@@ -393,7 +392,6 @@ fn run_turn_once(
         } else {
             stderr.trim().to_string()
         };
-        emit_result_error(output, &message);
         return Err(TurnFailure {
             message,
             retryable: true,
@@ -998,9 +996,10 @@ mod tests {
                 working_dir.path().to_str().unwrap(),
             )
             .unwrap();
-            assert!(args
-                .windows(2)
-                .any(|pair| pair == ["--resume", "session-123"]));
+            assert!(
+                args.windows(2)
+                    .any(|pair| pair == ["--resume", "session-123"])
+            );
             assert!(!args.iter().any(|arg| arg == "--continue"));
         });
     }


### PR DESCRIPTION
## 목표
- `Qwen_Code_Provider_Addition_PRD.md` 기준으로 남아 있던 Qwen provider 마감 작업을 정리합니다.
- 이번 범위는 신규 provider 추가가 아니라, 이미 들어간 Qwen 경로를 실제 운영에서 더 안정적으로 쓰기 위한 closeout에 고정했습니다.
- 특히 `resume/continue/fresh` 세션 해석, tmux hang 복구, doctor 진단, `/model` 표시, `/clear`/skill 보조 surface를 서로 같은 계약으로 맞추는 것을 목표로 잡았습니다.

## 겪은 문제
- `session_id`가 없는 상황에서도 Qwen turn이 bare `--continue`로 시작해, 같은 프로젝트의 엉뚱한 직전 세션에 잘못 붙을 수 있었습니다.
- direct-process 경로에는 stale/dead session retry가 있었지만 tmux wrapper 경로에는 같은 수준의 idle timeout / fresh retry가 없어, 무응답 hang처럼 보이는 상태가 더 자주 발생할 수 있었습니다.
- doctor, `/model`, skill 안내, runtime artifact 진단이 현재 Qwen 0.14.0 기준 운영 흐름과 완전히 같은 source를 보지 않아, 실제 설정과 UI/진단 메시지가 어긋나는 구간이 있었습니다.
- Qwen 관련 테스트 중 일부는 `HOME`, `USERPROFILE`, `current_dir`를 병렬 테스트에서 각각 따로 건드려 flake가 날 여지가 있었습니다.

## 해결한 내용
- Qwen session 전략을 `resume token > prior cache 있으면 continue > 없으면 fresh`로 정리하고, prior cache가 없을 때는 bare `--continue`를 쓰지 않도록 바꿨습니다.
- tmux wrapper에도 무출력 idle timeout watchdog과 1회 fresh retry를 넣어 direct-process 경로와 회복 계약을 맞췄습니다.
- `agentdesk doctor`에 Qwen auth hint, settings path, runtime artifact, `.qwen/.env` 우선 경로, `/stats` 안내를 보강했습니다.
- Qwen `/model` picker가 현재 channel working dir 기준 resolved default model을 정확히 보여주고, catalog에서 사라진 기존 override도 숨기지 않도록 정리했습니다.
- provider-agnostic `/clear`/session reset 및 skill 안내 surface를 Qwen 쪽 의미와 맞게 손봤습니다.
- Qwen test helper들을 공용 runtime test env lock 기준으로 정리해 병렬 환경에서도 flake가 덜 나도록 맞췄습니다.

## 주요 변경
- `src/services/qwen.rs`
  - `resume/continue/fresh` gate 정리
  - prior chat cache 기반 continue 판단 추가
  - allowed core tools / system settings override 흐름 보강
- `src/services/qwen_tmux_wrapper.rs`
  - idle timeout watchdog 추가
  - stale/dead session 시 fresh retry parity 추가
- `src/cli/doctor.rs`
  - Qwen auth hint / settings / runtime artifact 진단 추가
  - `.qwen/.env` 우선 경로 및 `/stats` 안내 반영
  - 공용 test env lock 사용으로 flake 완화
- `src/services/discord/commands/model_ui.rs`
  - resolved Qwen default model 표시
  - stale override를 picker summary에 계속 표면화
- `src/services/discord/commands/config.rs`
- `src/services/discord/commands/model_picker.rs`
- `src/services/discord/model_picker_interaction.rs`
  - model picker summary가 working dir 기반 Qwen catalog를 일관되게 보도록 정리
- `src/services/discord/commands/control.rs`
- `src/services/discord/commands/skill.rs`
- `src/services/discord/formatting.rs`
  - `/clear`, skill 안내, Qwen 관련 보조 surface 정리
- `src/services/discord/runtime_store.rs`
- `src/services/discord/router/message_handler.rs`
- `src/services/discord/turn_bridge/tests.rs`
- `src/services/memory/local.rs`
  - Qwen provider 회귀 테스트와 shared knowledge 경로 보강

## 검증
- `cargo test --manifest-path /private/tmp/agentdesk-qwen-closeout-pr/Cargo.toml qwen -- --nocapture`
- `cargo test --manifest-path /private/tmp/agentdesk-qwen-closeout-pr/Cargo.toml managed_session_ -- --nocapture`
- `cargo test --manifest-path /private/tmp/agentdesk-qwen-closeout-pr/Cargo.toml qwen_doctor -- --nocapture`
- `cargo test --manifest-path /private/tmp/agentdesk-qwen-closeout-pr/Cargo.toml model_picker -- --nocapture`
- `cargo test --manifest-path /private/tmp/agentdesk-qwen-closeout-pr/Cargo.toml memory_injection_plan_routes_shared_knowledge_by_provider -- --nocapture`

## 참고
- 이 PR은 `fix/discord-slash-fallback` 원격 PR 범위를 건드리지 않기 위해 `stack/qwen-provider-closeout-base` 위에 쌓은 clean stacked PR입니다.
- repo 바깥의 PRD 문서 업데이트는 이미 별도로 정리되어 있으며, 이 code PR에는 포함하지 않았습니다.
- closeout 범위는 Qwen provider 안정화에 한정했고, repo 전반 warning debt나 unrelated local 변경은 의도적으로 포함하지 않았습니다.