### PR TITLE
fix: hang recovery gap 보완 및 routing validation 분리

### DIFF
--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -68,6 +68,7 @@ use runtime_store::worktrees_root;
 use settings::{
     RoleBinding, channel_upload_dir, cleanup_old_uploads, load_bot_settings, resolve_role_binding,
     save_bot_settings, validate_bot_channel_routing,
+    validate_bot_channel_routing_with_provider_channel,
 };
 #[cfg(unix)]
 use tmux::{
@@ -1164,17 +1165,18 @@ async fn execute_handoff_turns(
             channel_id.to_channel(http).await,
             Ok(serenity::model::channel::Channel::Private(_))
         );
-        let (eff_id, eff_name) =
+        let (allowlist_channel_id, provider_channel_name) =
             if let Some((pid, pname)) = resolve_thread_parent(http, channel_id).await {
                 (pid, pname.or(record.channel_name.clone()))
             } else {
                 (channel_id, record.channel_name.clone())
             };
-        if let Err(reason) = validate_bot_channel_routing(
+        if let Err(reason) = validate_bot_channel_routing_with_provider_channel(
             &settings_snapshot,
             provider,
-            eff_id,
-            eff_name.as_deref(),
+            allowlist_channel_id,
+            record.channel_name.as_deref(),
+            provider_channel_name.as_deref(),
             is_dm,
         ) {
             println!(
@@ -3513,18 +3515,19 @@ pub(in crate::services::discord) async fn validate_live_channel_routing_with_dm_
         ),
     };
     let (channel_name, _) = resolve_channel_category(ctx, channel_id).await;
-    let (effective_channel_id, effective_channel_name) = if let Some((parent_id, parent_name)) =
+    let (allowlist_channel_id, provider_channel_name) = if let Some((parent_id, parent_name)) =
         resolve_thread_parent(&ctx.http, channel_id).await
     {
-        (parent_id, parent_name.or(channel_name))
+        (parent_id, parent_name.or(channel_name.clone()))
     } else {
-        (channel_id, channel_name)
+        (channel_id, channel_name.clone())
     };
-    validate_bot_channel_routing(
+    validate_bot_channel_routing_with_provider_channel(
         settings,
         provider,
-        effective_channel_id,
-        effective_channel_name.as_deref(),
+        allowlist_channel_id,
+        channel_name.as_deref(),
+        provider_channel_name.as_deref(),
         is_dm,
     )
 }

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -1169,7 +1169,7 @@ async fn execute_handoff_turns(
             if let Some((pid, pname)) = resolve_thread_parent(http, channel_id).await {
                 (pid, pname.or(record.channel_name.clone()))
             } else {
-                record.channel_name.clone()
+                (channel_id, record.channel_name.clone())
             };
         if let Err(reason) = validate_bot_channel_routing_with_provider_channel(
             &settings_snapshot,

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -1169,7 +1169,7 @@ async fn execute_handoff_turns(
             if let Some((pid, pname)) = resolve_thread_parent(http, channel_id).await {
                 (pid, pname.or(record.channel_name.clone()))
             } else {
-                (channel_id, record.channel_name.clone())
+                record.channel_name.clone()
             };
         if let Err(reason) = validate_bot_channel_routing_with_provider_channel(
             &settings_snapshot,

--- a/src/services/discord/recovery.rs
+++ b/src/services/discord/recovery.rs
@@ -1,5 +1,8 @@
 use super::handoff::{HandoffRecord, save_handoff};
-use super::settings::{resolve_role_binding, validate_bot_channel_routing};
+use super::settings::{
+    resolve_role_binding, validate_bot_channel_routing,
+    validate_bot_channel_routing_with_provider_channel,
+};
 use super::turn_bridge::stale_inflight_message;
 use super::*;
 #[cfg(unix)]
@@ -482,18 +485,19 @@ pub(super) async fn restore_inflight_turns(
                 });
                 // Resolve thread parent so validation uses the same semantics
                 // as normal message routing (router.rs).
-                let (eff_id, eff_name) = if let Some((pid, pname)) =
+                let (allowlist_channel_id, provider_channel_name) = if let Some((pid, pname)) =
                     super::resolve_thread_parent(http, channel_id).await
                 {
                     (pid, pname.or(effective_channel_name.clone()))
                 } else {
                     (channel_id, effective_channel_name.clone())
                 };
-                if let Err(reason) = validate_bot_channel_routing(
+                if let Err(reason) = validate_bot_channel_routing_with_provider_channel(
                     &settings_snapshot,
                     provider,
-                    eff_id,
-                    eff_name.as_deref(),
+                    allowlist_channel_id,
+                    effective_channel_name.as_deref(),
+                    provider_channel_name.as_deref(),
                     is_dm,
                 ) {
                     let ts = chrono::Local::now().format("%H:%M:%S");
@@ -641,17 +645,18 @@ pub(super) async fn restore_inflight_turns(
         });
         // Resolve thread parent so validation uses the same semantics
         // as normal message routing (router.rs).
-        let (eff_id, eff_name) =
+        let (allowlist_channel_id, provider_channel_name) =
             if let Some((pid, pname)) = super::resolve_thread_parent(http, channel_id).await {
                 (pid, pname.or(channel_name.clone()))
             } else {
                 (channel_id, channel_name.clone())
             };
-        if let Err(reason) = validate_bot_channel_routing(
+        if let Err(reason) = validate_bot_channel_routing_with_provider_channel(
             &settings_snapshot,
             provider,
-            eff_id,
-            eff_name.as_deref(),
+            allowlist_channel_id,
+            channel_name.as_deref(),
+            provider_channel_name.as_deref(),
             is_dm,
         ) {
             let ts = chrono::Local::now().format("%H:%M:%S");

--- a/src/services/discord/recovery.rs
+++ b/src/services/discord/recovery.rs
@@ -1,8 +1,5 @@
 use super::handoff::{HandoffRecord, save_handoff};
-use super::settings::{
-    resolve_role_binding, validate_bot_channel_routing,
-    validate_bot_channel_routing_with_provider_channel,
-};
+use super::settings::{resolve_role_binding, validate_bot_channel_routing_with_provider_channel};
 use super::turn_bridge::stale_inflight_message;
 use super::*;
 #[cfg(unix)]

--- a/src/services/discord/runtime_store.rs
+++ b/src/services/discord/runtime_store.rs
@@ -130,7 +130,12 @@ pub(crate) fn lock_test_env() -> std::sync::MutexGuard<'static, ()> {
 }
 
 pub(super) fn atomic_write(path: &Path, data: &str) -> Result<(), String> {
-    let tmp = path.with_extension("tmp");
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let unique = uuid::Uuid::new_v4().simple();
+    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("file");
+    let tmp = path.with_file_name(format!(".{}.{}.tmp", file_name, unique));
     let mut file = fs::File::create(&tmp).map_err(|e| e.to_string())?;
     file.write_all(data.as_bytes()).map_err(|e| e.to_string())?;
     file.sync_all().map_err(|e| e.to_string())?;
@@ -270,5 +275,55 @@ mod tests {
         );
 
         unsafe { std::env::remove_var(AGENTDESK_ROOT_DIR_ENV) };
+    }
+
+    #[test]
+    fn test_atomic_write_creates_parent_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("nested").join("dir").join("file.txt");
+        // Parent directories do not exist yet — atomic_write must create them.
+        atomic_write(&path, "hello").expect("should succeed");
+        assert_eq!(fs::read_to_string(&path).unwrap(), "hello");
+        // No stale .tmp file should remain.
+        let entries: Vec<_> = fs::read_dir(path.parent().unwrap())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert_eq!(entries.len(), 1, "only the final file should exist");
+    }
+
+    #[test]
+    fn test_atomic_write_concurrent_no_race() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let path = Arc::new(tmp.path().join("shared.txt"));
+        let mut handles = vec![];
+        for i in 0..8 {
+            let p = Arc::clone(&path);
+            handles.push(thread::spawn(move || {
+                atomic_write(&p, &i.to_string()).expect("concurrent write should succeed");
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        // Final content must be a valid single digit written by one of the threads.
+        let content = fs::read_to_string(&*path).unwrap();
+        let val: u8 = content.trim().parse().expect("should be a digit");
+        assert!(val < 8);
+        // No .tmp files should remain.
+        let leftovers: Vec<_> = fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name()
+                    .to_str()
+                    .map(|n| n.ends_with(".tmp"))
+                    .unwrap_or(false)
+            })
+            .collect();
+        assert!(leftovers.is_empty(), "no .tmp files should remain");
     }
 }

--- a/src/services/discord/settings.rs
+++ b/src/services/discord/settings.rs
@@ -418,15 +418,41 @@ pub(super) fn validate_bot_channel_routing(
     channel_name: Option<&str>,
     is_dm: bool,
 ) -> Result<(), BotChannelRoutingGuardFailure> {
-    let role_binding = resolve_role_binding(channel_id, channel_name);
+    validate_bot_channel_routing_with_provider_channel(
+        settings,
+        provider,
+        channel_id,
+        channel_name,
+        channel_name,
+        is_dm,
+    )
+}
 
-    if !bot_settings_allow_channel(settings, channel_id, is_dm) {
+pub(super) fn validate_bot_channel_routing_with_provider_channel(
+    settings: &DiscordBotSettings,
+    provider: &ProviderKind,
+    allowlist_channel_id: ChannelId,
+    binding_channel_name: Option<&str>,
+    provider_channel_name: Option<&str>,
+    is_dm: bool,
+) -> Result<(), BotChannelRoutingGuardFailure> {
+    let role_binding = resolve_role_binding(
+        allowlist_channel_id,
+        binding_channel_name.or(provider_channel_name),
+    );
+
+    if !bot_settings_allow_channel(settings, allowlist_channel_id, is_dm) {
         return Err(BotChannelRoutingGuardFailure::ChannelNotAllowed);
     }
     if !bot_settings_allow_agent(settings, role_binding.as_ref(), is_dm) {
         return Err(BotChannelRoutingGuardFailure::AgentMismatch);
     }
-    if !channel_supports_provider(provider, channel_name, is_dm, role_binding.as_ref()) {
+    if !channel_supports_provider(
+        provider,
+        provider_channel_name.or(binding_channel_name),
+        is_dm,
+        role_binding.as_ref(),
+    ) {
         return Err(BotChannelRoutingGuardFailure::ProviderMismatch);
     }
 

--- a/src/services/discord/settings.rs
+++ b/src/services/discord/settings.rs
@@ -1057,6 +1057,7 @@ mod tests {
         load_discord_bot_launch_configs, load_narrate_progress, load_peer_agents,
         render_peer_agent_guidance, resolve_memory_settings, resolve_role_binding,
         save_bot_settings, validate_bot_channel_routing,
+        validate_bot_channel_routing_with_provider_channel,
     };
 
     fn with_temp_home<F>(f: F)
@@ -1792,6 +1793,60 @@ mod tests {
             result,
             Err(BotChannelRoutingGuardFailure::ChannelNotAllowed)
         );
+    }
+
+    #[test]
+    fn test_validate_bot_channel_routing_with_provider_channel_keeps_thread_binding() {
+        with_temp_home(|temp_home: &TempDir| {
+            let settings_dir = temp_home.path().join(".adk").join("config");
+            fs::create_dir_all(&settings_dir).unwrap();
+            fs::write(
+                settings_dir.join("org.yaml"),
+                r#"
+version: 1
+name: "Test Org"
+agents:
+  openclaw-maker:
+    display_name: "Maker"
+    provider: codex
+channels:
+  by_id:
+    '1470034105176424533':
+      agent: openclaw-maker
+      provider: codex
+"#,
+            )
+            .unwrap();
+
+            let mut settings = super::super::DiscordBotSettings::default();
+            settings.provider = ProviderKind::Codex;
+            settings.agent = Some("openclaw-maker".to_string());
+            settings.allowed_channel_ids = vec![1470034105176424533];
+
+            let result = validate_bot_channel_routing_with_provider_channel(
+                &settings,
+                &ProviderKind::Codex,
+                ChannelId::new(1470034105176424533),
+                Some("openclaw-maker-thread"),
+                Some("agent-sandbox-lab"),
+                false,
+            );
+
+            assert_eq!(result, Ok(()));
+
+            let parent_result = validate_bot_channel_routing(
+                &settings,
+                &ProviderKind::Codex,
+                ChannelId::new(1470643507201839189),
+                Some("agent-sandbox-lab"),
+                false,
+            );
+
+            assert_eq!(
+                parent_result,
+                Err(BotChannelRoutingGuardFailure::ChannelNotAllowed)
+            );
+        });
     }
 
     #[test]

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -14,6 +14,7 @@ use crate::services::tmux_diagnostics::{
 use super::formatting::{format_tool_input, normalize_empty_lines, send_long_message_raw};
 use super::settings::{
     channel_supports_provider, resolve_role_binding, validate_bot_channel_routing,
+    validate_bot_channel_routing_with_provider_channel,
 };
 use super::{DISCORD_MSG_LIMIT, SharedData, TmuxWatcherHandle, rate_limit_wait};
 
@@ -1603,17 +1604,18 @@ pub(super) async fn restore_tmux_watchers(http: &Arc<serenity::Http>, shared: &A
         );
         // Resolve thread parent so validation uses the same semantics
         // as normal message routing (router.rs).
-        let (eff_id, eff_name) =
+        let (allowlist_channel_id, provider_channel_name) =
             if let Some((pid, pname)) = super::resolve_thread_parent(http, *channel_id).await {
                 (pid, pname.unwrap_or_else(|| channel_name.clone()))
             } else {
                 (*channel_id, channel_name.clone())
             };
-        if let Err(reason) = validate_bot_channel_routing(
+        if let Err(reason) = validate_bot_channel_routing_with_provider_channel(
             &settings_snapshot,
             &provider,
-            eff_id,
-            Some(&eff_name),
+            allowlist_channel_id,
+            Some(&channel_name),
+            Some(&provider_channel_name),
             is_dm,
         ) {
             let ts = chrono::Local::now().format("%H:%M:%S");

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -13,7 +13,7 @@ use crate::services::tmux_diagnostics::{
 
 use super::formatting::{format_tool_input, normalize_empty_lines, send_long_message_raw};
 use super::settings::{
-    channel_supports_provider, resolve_role_binding, validate_bot_channel_routing,
+    channel_supports_provider, resolve_role_binding,
     validate_bot_channel_routing_with_provider_channel,
 };
 use super::{DISCORD_MSG_LIMIT, SharedData, TmuxWatcherHandle, rate_limit_wait};

--- a/src/services/gemini.rs
+++ b/src/services/gemini.rs
@@ -21,6 +21,7 @@ const GEMINI_INVALID_RESUME_SELECTOR_MESSAGE: &str =
     "InvalidArgument: Gemini resume selector must be `latest` or a numeric session index";
 const GEMINI_STREAM_POLL_TIMEOUT: Duration = Duration::from_secs(5);
 const GEMINI_STREAM_IDLE_WATCHDOG: Duration = Duration::from_secs(120);
+const GEMINI_STREAM_STARTUP_WATCHDOG: Duration = Duration::from_secs(60);
 const GEMINI_MAX_SESSION_RETRIES: usize = 1;
 
 #[derive(Debug)]
@@ -226,6 +227,7 @@ fn execute_gemini_streaming_attempt(
         &mut state,
         GEMINI_STREAM_POLL_TIMEOUT,
         GEMINI_STREAM_IDLE_WATCHDOG,
+        GEMINI_STREAM_STARTUP_WATCHDOG,
         || {
             child
                 .try_wait()
@@ -297,12 +299,14 @@ fn collect_gemini_stream_events<F>(
     state: &mut GeminiAttemptState,
     poll_timeout: Duration,
     idle_watchdog: Duration,
+    startup_watchdog: Duration,
     mut definitive_failure_observed: F,
 ) -> GeminiStreamLoopResult
 where
     F: FnMut() -> bool,
 {
     let mut silent_for = Duration::ZERO;
+    let mut startup_silent_for = Duration::ZERO;
 
     loop {
         if is_cancelled(cancel_token) {
@@ -312,6 +316,7 @@ where
         match stdout_events.recv_timeout(poll_timeout) {
             Ok(GeminiStreamEvent::Line(line)) => {
                 silent_for = Duration::ZERO;
+                startup_silent_for = Duration::ZERO;
                 process_gemini_stream_line(&line, state, sender);
             }
             Ok(GeminiStreamEvent::ReadError(message)) => {
@@ -328,6 +333,18 @@ where
                     return GeminiStreamLoopResult::Eof;
                 }
                 if !state.meaningful_progress_seen {
+                    startup_silent_for += poll_timeout;
+                    if startup_silent_for >= startup_watchdog {
+                        if !definitive_failure_observed() {
+                            continue;
+                        }
+                        return GeminiStreamLoopResult::RetrySession {
+                            message: format!(
+                                "Gemini stream produced no output for {} seconds before first progress",
+                                startup_watchdog.as_secs()
+                            ),
+                        };
+                    }
                     continue;
                 }
                 silent_for += poll_timeout;
@@ -1270,6 +1287,7 @@ mod tests {
             &mut state,
             Duration::from_millis(5),
             Duration::from_millis(10),
+            Duration::from_millis(100),
             || false,
         );
 
@@ -1300,6 +1318,7 @@ mod tests {
             &mut state,
             Duration::from_millis(1),
             Duration::from_millis(2),
+            Duration::from_millis(100), // startup_watchdog >> cancel delay → won't fire
             || false,
         );
 
@@ -1336,6 +1355,7 @@ mod tests {
             &mut state,
             Duration::from_millis(1),
             Duration::from_millis(3),
+            Duration::from_millis(100),
             || false,
         );
 
@@ -1366,6 +1386,7 @@ mod tests {
             &mut state,
             Duration::from_millis(1),
             Duration::from_millis(3),
+            Duration::from_millis(100),
             || true,
         );
 
@@ -1465,6 +1486,70 @@ mod tests {
             other => panic!("expected Done, got {:?}", other),
         }
         assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn startup_watchdog_fires_retry_before_first_progress() {
+        // Before any meaningful output, silence >= startup_watchdog with process exited
+        // must trigger RetrySession.
+        let (_tx, rx) = mpsc::channel::<GeminiStreamEvent>(); // keep alive so Timeout fires
+        let (stream_tx, _stream_rx) = mpsc::channel();
+        let mut state = GeminiAttemptState::new(None);
+
+        let result = collect_gemini_stream_events(
+            &rx,
+            &stream_tx,
+            None,
+            &mut state,
+            Duration::from_millis(1),   // poll_timeout
+            Duration::from_millis(100), // idle_watchdog (never reached)
+            Duration::from_millis(3),   // startup_watchdog: short for test
+            || true,                    // process has exited
+        );
+
+        match result {
+            GeminiStreamLoopResult::RetrySession { message } => {
+                assert!(
+                    message.contains("before first progress"),
+                    "expected startup watchdog message, got: {message}"
+                );
+            }
+            other => panic!(
+                "expected RetrySession from startup watchdog, got {:?}",
+                other
+            ),
+        }
+        assert!(!state.meaningful_progress_seen);
+    }
+
+    #[test]
+    fn startup_watchdog_does_not_fire_if_process_still_alive() {
+        // If process is still alive (definitive_failure_observed returns false),
+        // startup watchdog threshold exceeded but should keep waiting until cancelled.
+        let token = Arc::new(CancelToken::new());
+        let (_tx, rx) = mpsc::channel::<GeminiStreamEvent>(); // keep alive
+        let (stream_tx, _stream_rx) = mpsc::channel();
+        let mut state = GeminiAttemptState::new(None);
+
+        let token_for_thread = token.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(10));
+            token_for_thread.cancelled.store(true, Ordering::Relaxed);
+        });
+
+        let result = collect_gemini_stream_events(
+            &rx,
+            &stream_tx,
+            Some(token.as_ref()),
+            &mut state,
+            Duration::from_millis(1),
+            Duration::from_millis(100),
+            Duration::from_millis(3), // startup_watchdog fires early but process alive
+            || false,                 // process still alive → keep waiting
+        );
+
+        // Should be Cancelled (not RetrySession) because process is alive.
+        assert_eq!(result, GeminiStreamLoopResult::Cancelled);
     }
 
     #[test]


### PR DESCRIPTION
## 목표

- `kunkunGames/AgentDesk#17`에서 구현한 Hang Recovery 보완과 routing validation 분리를 upstream `main` 기준으로 이식합니다.
- thread 환경에서 allowlist 및 role binding 검사는 parent channel 기준으로, provider name 검사는 실제 thread/provider channel name 기준으로 분리해 잘못된 routing guard 판정을 막습니다.

## 겪은 문제

- `atomic_write`는 고정된 `.tmp` 확장자를 사용해 같은 파일에 동시 쓰기가 발생할 경우 temp 파일이 충돌하고 `ENOENT`가 날 수 있었습니다. 부모 디렉터리가 없는 경우에도 별도 처리가 없었습니다.
- `collect_gemini_stream_events`는 `meaningful_progress_seen`이 false인 동안 timeout이 발생해도 무조건 `continue`해 startup silence가 사실상 무기한이었습니다. Gemini CLI가 첫 출력 전에 hang하면 세션이 영원히 기다릴 수 있었습니다.
- routing validation이 thread에서 호출될 때 thread parent의 channel ID와 실제 provider channel name을 분리하지 못해, thread 환경에서 routing guard가 잘못 판정될 수 있었습니다.
- upstream `main`은 원형 PR 작성 시점보다 앞서 있어 `src/services/discord/mod.rs`, `src/services/discord/recovery.rs`, `src/services/discord/settings.rs`, `src/services/discord/tmux.rs`에서 포팅 충돌을 함께 해결해야 했습니다.

## 해결한 내용

- `runtime_store::atomic_write`는 `uuid::Uuid::new_v4()` 기반의 고유 temp 파일명을 사용하고, `fs::create_dir_all`로 부모 디렉터리를 자동 생성하도록 수정했습니다.
- `gemini::collect_gemini_stream_events`에는 `GEMINI_STREAM_STARTUP_WATCHDOG`와 `startup_silent_for` 카운터를 추가해, 첫 의미 있는 출력 이전의 silence도 bounded timeout으로 수렴하도록 수정했습니다.
- `settings::validate_bot_channel_routing_with_provider_channel`를 추가해 binding channel lookup과 provider channel name 검사를 분리된 인자로 처리하도록 정리했습니다. 기존 `validate_bot_channel_routing`은 wrapper로 유지합니다.
- `src/services/discord/mod.rs`, `src/services/discord/recovery.rs`, `src/services/discord/tmux.rs`의 routing guard 호출부를 새 helper 기준으로 통일했고, upstream 기준으로는 parent channel ID를 allowlist/binding 검사에 사용하도록 유지했습니다.
- upstream 포팅 과정에서 `src/services/discord/mod.rs:1169` 부근 handoff 경로의 tuple 복원까지 반영해 실제 빌드가 깨지지 않도록 마무리했습니다.

## 주요 변경

- `src/services/discord/runtime_store.rs`
  - `atomic_write`에 고유 temp 파일명과 부모 디렉터리 자동 생성 추가
  - 테스트 추가: `test_atomic_write_creates_parent_dirs`, `test_atomic_write_concurrent_no_race`
- `src/services/gemini.rs`
  - `GEMINI_STREAM_STARTUP_WATCHDOG` 상수 추가
  - `collect_gemini_stream_events`에 startup watchdog 인자와 startup silence timeout 처리 추가
  - 테스트 추가: `startup_watchdog_fires_retry_before_first_progress`, `startup_watchdog_does_not_fire_if_process_still_alive`
- `src/services/discord/settings.rs`
  - `validate_bot_channel_routing_with_provider_channel` 추가
  - 테스트 추가: `test_validate_bot_channel_routing_with_provider_channel_keeps_thread_binding`
- `src/services/discord/mod.rs`
  - handoff 및 live routing guard 호출부를 upstream current semantics에 맞게 정리
- `src/services/discord/recovery.rs`
  - inflight recovery routing guard 호출부 정리
- `src/services/discord/tmux.rs`
  - tmux watcher recovery routing guard 호출부 정리

## 검증

- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo test test_atomic_write_creates_parent_dirs -- --nocapture`
- `cargo test test_atomic_write_concurrent_no_race -- --nocapture`
- `cargo test startup_watchdog_fires_retry_before_first_progress -- --nocapture`
- `cargo test startup_watchdog_does_not_fire_if_process_still_alive -- --nocapture`
- `cargo test test_validate_bot_channel_routing_with_provider_channel_keeps_thread_binding -- --nocapture`
