### PR TITLE
fix(gemini): retry on silent stream watchdog

### DIFF
--- a/src/services/gemini.rs
+++ b/src/services/gemini.rs
@@ -335,9 +335,7 @@ where
                 if !state.meaningful_progress_seen {
                     startup_silent_for += poll_timeout;
                     if startup_silent_for >= startup_watchdog {
-                        if !definitive_failure_observed() {
-                            continue;
-                        }
+                        let _ = definitive_failure_observed();
                         return GeminiStreamLoopResult::RetrySession {
                             message: format!(
                                 "Gemini stream produced no output for {} seconds before first progress",
@@ -349,9 +347,7 @@ where
                 }
                 silent_for += poll_timeout;
                 if silent_for >= idle_watchdog {
-                    if !definitive_failure_observed() {
-                        continue;
-                    }
+                    let _ = definitive_failure_observed();
                     return GeminiStreamLoopResult::RetrySession {
                         message: format!(
                             "Gemini stream produced no output for {} seconds",
@@ -1333,7 +1329,7 @@ mod tests {
     }
 
     #[test]
-    fn idle_watchdog_waits_if_process_is_still_alive_during_extended_silence() {
+    fn idle_watchdog_retries_if_process_is_still_alive_during_extended_silence() {
         let (tx, rx) = mpsc::channel();
         let (stream_tx, stream_rx) = mpsc::channel();
         let mut state = GeminiAttemptState::new(None);
@@ -1341,17 +1337,11 @@ mod tests {
             r#"{"type":"message","role":"assistant","content":"partial"}"#.to_string(),
         ))
         .unwrap();
-        let token = Arc::new(CancelToken::new());
-        let token_for_thread = token.clone();
-        std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_millis(5));
-            token_for_thread.cancelled.store(true, Ordering::Relaxed);
-        });
 
         let result = collect_gemini_stream_events(
             &rx,
             &stream_tx,
-            Some(token.as_ref()),
+            None,
             &mut state,
             Duration::from_millis(1),
             Duration::from_millis(3),
@@ -1359,7 +1349,12 @@ mod tests {
             || false,
         );
 
-        assert_eq!(result, GeminiStreamLoopResult::Cancelled);
+        match result {
+            GeminiStreamLoopResult::RetrySession { message } => {
+                assert!(message.contains("Gemini stream produced no output"));
+            }
+            other => panic!("expected RetrySession, got {:?}", other),
+        }
         assert_eq!(state.final_text, "partial");
         assert!(state.meaningful_progress_seen);
         match stream_rx.recv().unwrap() {
@@ -1523,33 +1518,31 @@ mod tests {
     }
 
     #[test]
-    fn startup_watchdog_does_not_fire_if_process_still_alive() {
-        // If process is still alive (definitive_failure_observed returns false),
-        // startup watchdog threshold exceeded but should keep waiting until cancelled.
-        let token = Arc::new(CancelToken::new());
+    fn startup_watchdog_fires_if_process_is_still_alive() {
         let (_tx, rx) = mpsc::channel::<GeminiStreamEvent>(); // keep alive
         let (stream_tx, _stream_rx) = mpsc::channel();
         let mut state = GeminiAttemptState::new(None);
 
-        let token_for_thread = token.clone();
-        std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_millis(10));
-            token_for_thread.cancelled.store(true, Ordering::Relaxed);
-        });
-
         let result = collect_gemini_stream_events(
             &rx,
             &stream_tx,
-            Some(token.as_ref()),
+            None,
             &mut state,
             Duration::from_millis(1),
             Duration::from_millis(100),
-            Duration::from_millis(3), // startup_watchdog fires early but process alive
-            || false,                 // process still alive → keep waiting
+            Duration::from_millis(3),
+            || false,
         );
 
-        // Should be Cancelled (not RetrySession) because process is alive.
-        assert_eq!(result, GeminiStreamLoopResult::Cancelled);
+        match result {
+            GeminiStreamLoopResult::RetrySession { message } => {
+                assert!(
+                    message.contains("before first progress"),
+                    "expected startup watchdog message, got: {message}"
+                );
+            }
+            other => panic!("expected RetrySession, got {:?}", other),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## 목표

- Gemini가 프로세스는 살아 있으나 출력이 멈춘 상태에서 turn이 hang처럼 보이던 문제를 bounded retry로 수렴시키도록 수정합니다.
- startup silence와 idle silence가 모두 동일한 retry 경로로 수렴하도록 watchdog 동작을 정리합니다.

## 겪은 문제

- `src/services/gemini.rs`의 `collect_gemini_stream_events`는 startup watchdog 또는 idle watchdog 임계치를 넘겨도, `definitive_failure_observed()`가 false이면 무조건 `continue`했습니다.
- 그 결과 Gemini CLI 프로세스가 아직 살아 있지만 실제 출력이 더 이상 나오지 않는 경우, AgentDesk는 retry로 전환하지 못하고 계속 대기했습니다.
- 사용자 관점에서는 Gemini가 대답을 이어가지 못한 채 hang된 것처럼 보였습니다.

## 해결한 내용

- startup watchdog 분기와 idle watchdog 분기에서 `definitive_failure_observed()`를 retry의 필수 조건으로 두지 않도록 수정했습니다.
- watchdog 임계치를 초과하면 프로세스 생존 여부와 무관하게 `RetrySession`을 반환하도록 바꿨습니다.
- `definitive_failure_observed()` 호출은 관측 용도로만 유지하고, retry 여부를 막지 않도록 정리했습니다.
- 관련 테스트를 갱신해 startup silence와 extended idle silence 모두 retry로 수렴하는지 검증했습니다.

## 주요 변경

- `src/services/gemini.rs`
  - startup watchdog timeout 초과 시 silent Gemini process도 `RetrySession`으로 전환
  - idle watchdog timeout 초과 시 silent Gemini process도 `RetrySession`으로 전환
  - 테스트 갱신:
    - `idle_watchdog_retries_if_process_is_still_alive_during_extended_silence`
    - `startup_watchdog_fires_if_process_is_still_alive`

## 검증

- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo test services::gemini::tests -- --nocapture`
- 결과: `34 passed, 0 failed`

## 포팅 메모

- 이 PR은 `kunkunGames/AgentDesk#18`를 현재 upstream `main` 위에 그대로 이식한 것입니다.
- `src/services/gemini.rs` 하나만 변경되었고, 체리픽은 충돌 없이 적용되었습니다.