### PR TITLE
#383 Move Discord auth to YAML and runtime state to DB

### DIFF
--- a/agentdesk.example.yaml
+++ b/agentdesk.example.yaml
@@ -3,12 +3,19 @@ server:
   host: "0.0.0.0"
 
 discord:
+  guild_id: "YOUR_GUILD_ID"
+  owner_id: "YOUR_DISCORD_USER_ID"
   bots:
     command:
       token: "YOUR_COMMAND_BOT_TOKEN"
+      provider: "claude"
+      auth:
+        allowed_channel_ids:
+          - "123456789012345678"
+        allowed_user_ids:
+          - "123456789012345678"
     notify:
       token: "YOUR_NOTIFY_BOT_TOKEN"
-  guild_id: "YOUR_GUILD_ID"
 
 shared_prompt: "~/.adk/release/config/agents/_shared.prompt.md"
 

--- a/src/cli/dcserver.rs
+++ b/src/cli/dcserver.rs
@@ -282,8 +282,16 @@ pub fn dcserver_instance_pids() -> Vec<u32> {
     Vec::new()
 }
 
-pub fn instance_bot_settings_path() -> Option<PathBuf> {
-    agentdesk_runtime_root().map(|root| root.join("config").join("bot_settings.json"))
+pub fn instance_agentdesk_config_path() -> Option<PathBuf> {
+    agentdesk_runtime_root().map(|root| {
+        let canonical = crate::runtime_layout::config_file_path(&root);
+        let legacy = crate::runtime_layout::legacy_config_file_path(&root);
+        if canonical.is_file() || !legacy.is_file() {
+            canonical
+        } else {
+            legacy
+        }
+    })
 }
 
 pub fn dcserver_stdout_log_path() -> Option<PathBuf> {
@@ -538,28 +546,16 @@ pub fn handle_restart_dcserver(
         }
     };
 
-    // Read bot_settings.json to find stored token(s)
-    let settings_path = match instance_bot_settings_path() {
-        Some(p) => p,
-        None => {
-            eprintln!("Error: Cannot determine runtime root for bot_settings.json");
-            write_restart_report(
-                "failed",
-                "runtime root를 결정할 수 없어서 dcserver restart를 시작하지 못했습니다."
-                    .to_string(),
-            );
-            return;
-        }
-    };
-
-    let has_settings_file = std::fs::read_to_string(&settings_path).is_ok();
+    let settings_display = instance_agentdesk_config_path()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| "agentdesk.yaml".to_string());
     let configs = load_discord_bot_launch_configs();
-    let onboarding_mode = !has_settings_file || configs.is_empty();
+    let onboarding_mode = configs.is_empty();
 
     if onboarding_mode {
         eprintln!(
-            "  ⚠ No bot tokens found in {} — dcserver will start in onboarding mode",
-            settings_path.display()
+            "  ⚠ No configured Discord bots found in {} — dcserver will start in onboarding mode",
+            settings_display
         );
     }
 
@@ -1061,7 +1057,7 @@ pub fn handle_dcserver(token: Option<String>) {
             std::process::exit(1);
         }
     };
-    let settings_path = instance_bot_settings_path();
+    let settings_path = instance_agentdesk_config_path();
 
     let title = format!("  AgentDesk v{}  |  Discord Bot Server  ", VERSION);
     let width = title.chars().count();
@@ -1269,9 +1265,9 @@ pub fn handle_dcserver(token: Option<String>) {
                     let settings_display = settings_path
                         .as_deref()
                         .map(|p| p.display().to_string())
-                        .unwrap_or_else(|| "bot_settings.json".to_string());
+                        .unwrap_or_else(|| "agentdesk.yaml".to_string());
                     eprintln!(
-                        "  ⚠ No bot tokens found in {} — waiting for HTTP server...",
+                        "  ⚠ No configured Discord bots found in {} — waiting for HTTP server...",
                         settings_display
                     );
                     // Gate onboarding-ready signal on actual /api/health success.

--- a/src/cli/discord.rs
+++ b/src/cli/discord.rs
@@ -44,7 +44,9 @@ pub fn handle_discord_sendmessage(message: &str, channel_id: u64, hash_key: Opti
     };
 
     if tokens.is_empty() {
-        eprintln!("Error: no Discord bot tokens found in ~/.adk/release/config/bot_settings.json");
+        eprintln!(
+            "Error: no configured Discord bot tokens found in agentdesk.yaml or credential files"
+        );
         std::process::exit(1);
     }
 
@@ -91,7 +93,9 @@ pub fn handle_discord_senddm(message: &str, user_id: u64, hash_key: Option<&str>
     };
 
     if tokens.is_empty() {
-        eprintln!("Error: no Discord bot tokens found in ~/.adk/release/config/bot_settings.json");
+        eprintln!(
+            "Error: no configured Discord bot tokens found in agentdesk.yaml or credential files"
+        );
         std::process::exit(1);
     }
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -397,40 +397,75 @@ fn xml_escape(value: &str) -> String {
         .replace('\'', "&apos;")
 }
 
-// ── Bot settings generation ────────────────────────────────────────
+// ── AgentDesk config generation ────────────────────────────────────
 
-/// Merge new bot entry into existing bot_settings.json content.
-/// Preserves suffix_map, other bot entries, and custom fields.
-fn generate_bot_settings(
-    existing_path: &Path,
+fn init_config_path(root: &Path) -> PathBuf {
+    let canonical = crate::runtime_layout::config_file_path(root);
+    let legacy = crate::runtime_layout::legacy_config_file_path(root);
+    if canonical.is_file() || !legacy.is_file() {
+        canonical
+    } else {
+        legacy
+    }
+}
+
+fn init_has_existing_configuration(root: &Path) -> bool {
+    init_config_path(root).exists() || crate::runtime_layout::org_schema_path(root).exists()
+}
+
+fn parse_owner_id(owner_id: Option<&str>) -> Option<u64> {
+    owner_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .and_then(|value| value.parse::<u64>().ok())
+}
+
+fn upsert_command_bot(
+    config: &mut crate::config::Config,
+    token: &str,
+    provider: &str,
+    allowed_channel_ids: &[u64],
+) {
+    let mut bot = config
+        .discord
+        .bots
+        .get("command")
+        .cloned()
+        .unwrap_or_default();
+    bot.token = Some(token.trim().to_string());
+    bot.provider = Some(provider.trim().to_string());
+    bot.auth.allowed_channel_ids =
+        (!allowed_channel_ids.is_empty()).then_some(allowed_channel_ids.to_vec());
+    config.discord.bots.insert("command".to_string(), bot);
+}
+
+fn write_agentdesk_discord_config(
+    root: &Path,
+    guild_id: &str,
     token: &str,
     provider: &str,
     owner_id: Option<&str>,
-) -> Result<String, String> {
-    let token_hash = crate::services::discord::settings::discord_token_hash(token);
-    let mut entry = serde_json::json!({
-        "token": token,
-        "provider": provider,
-    });
-    if let Some(oid) = owner_id {
-        entry["owner_user_id"] = serde_json::Value::String(oid.into());
-    }
-
-    // Read existing file and merge, preserving all other keys
-    let mut root: serde_json::Value = if existing_path.exists() {
-        let content = fs::read_to_string(existing_path)
-            .map_err(|e| format!("Failed to read {}: {e}", existing_path.display()))?;
-        serde_json::from_str(&content)
-            .map_err(|e| format!("Failed to parse {}: {e}", existing_path.display()))?
+    allowed_channel_ids: &[u64],
+    reconfigure: bool,
+) -> Result<PathBuf, String> {
+    let config_path = init_config_path(root);
+    let mut config = if config_path.is_file() {
+        crate::config::load_from_path(&config_path)
+            .map_err(|e| format!("Failed to load config {}: {e}", config_path.display()))?
     } else {
-        serde_json::json!({})
+        crate::config::Config::default()
     };
 
-    if let Some(obj) = root.as_object_mut() {
-        obj.insert(token_hash, entry);
-    }
+    config.discord.guild_id = Some(guild_id.trim().to_string());
+    config.discord.owner_id = parse_owner_id(owner_id);
+    upsert_command_bot(&mut config, token, provider, allowed_channel_ids);
 
-    serde_json::to_string_pretty(&root).map_err(|e| format!("JSON serialization failed: {e}"))
+    let rendered = serde_yaml::to_string(&config)
+        .map_err(|e| format!("Failed to serialize config {}: {e}", config_path.display()))?;
+    write_with_backup(&config_path, &rendered, reconfigure)
+        .map_err(|e| format!("Failed to write config {}: {e}", config_path.display()))?;
+
+    Ok(config_path)
 }
 
 // ── Main init flow ─────────────────────────────────────────────────
@@ -441,7 +476,7 @@ pub fn handle_init(reconfigure: bool) {
         std::process::exit(1);
     });
 
-    if !reconfigure && root.join("config").join("bot_settings.json").exists() {
+    if !reconfigure && init_has_existing_configuration(&root) {
         println!("기존 설정이 발견되었습니다: {}", root.display());
         println!("재설정하려면 reconfigure를 사용하세요.");
         return;
@@ -596,6 +631,11 @@ pub fn handle_init(reconfigure: bool) {
     } else {
         Some(owner_input.as_str())
     };
+    let allowed_channel_ids = selected
+        .iter()
+        .filter_map(|idx| text_channels.get(*idx))
+        .filter_map(|(_, channel_id)| channel_id.parse::<u64>().ok())
+        .collect::<Vec<_>>();
 
     // Generate configs
     println!("\nStep 5/5: 설정 파일 생성\n");
@@ -641,20 +681,29 @@ pub fn handle_init(reconfigure: bool) {
     }
     println!("  [OK] {}", org_path.display());
 
-    // bot_settings.json
-    let bs_path = config_dir.join("bot_settings.json");
-    let bot_settings = match generate_bot_settings(&bs_path, &token, provider, owner_id) {
-        Ok(s) => s,
+    let agentdesk_config_path = match write_agentdesk_discord_config(
+        &root,
+        &guild.id,
+        &token,
+        provider,
+        owner_id,
+        &allowed_channel_ids,
+        reconfigure,
+    ) {
+        Ok(path) => path,
         Err(e) => {
-            eprintln!("bot_settings.json 생성 실패: {}", e);
+            eprintln!("agentdesk.yaml 생성 실패: {}", e);
             return;
         }
     };
-    if let Err(e) = write_with_backup(&bs_path, &bot_settings, reconfigure) {
-        eprintln!("Failed to write {}: {}", bs_path.display(), e);
+    if !agentdesk_config_path.exists() {
+        eprintln!(
+            "Failed to write {}: file was not created",
+            agentdesk_config_path.display()
+        );
         return;
     }
-    println!("  [OK] {}", bs_path.display());
+    println!("  [OK] {}", agentdesk_config_path.display());
 
     // Create prompts
     let agents_root = crate::runtime_layout::managed_agents_root(&root);
@@ -751,10 +800,7 @@ pub fn handle_init(reconfigure: bool) {
         println!("═══════════════════════════════════════");
         println!("\n생성된 파일:");
         println!("  {} (org.yaml)", config_dir.join("org.yaml").display());
-        println!(
-            "  {} (bot_settings.json)",
-            config_dir.join("bot_settings.json").display()
-        );
+        println!("  {} (agentdesk.yaml)", agentdesk_config_path.display());
         println!("  {} (agents)", agents_root.display());
         println!("\n다음 단계:");
         println!("  1. 프롬프트 파일을 편집하여 에이전트 성격을 정의하세요");

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -12,7 +12,7 @@ pub fn print_help() {
     println!("    -h, --help              Print help information");
     println!("    -v, --version           Print version information");
     println!(
-        "    dcserver [TOKEN]        Start Discord bot server(s); without TOKEN uses bot_settings.json"
+        "    dcserver [TOKEN]        Start Discord bot server(s); without TOKEN uses configured Discord bots"
     );
     println!(
         "    restart-dcserver [--report-channel-id <ID> --report-provider <claude|codex|gemini|qwen> [--report-message-id <ID>]]"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -48,14 +49,101 @@ pub struct DiscordConfig {
     pub bots: std::collections::HashMap<String, BotConfig>,
     #[serde(default)]
     pub guild_id: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_u64",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub owner_id: Option<u64>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
 pub struct BotConfig {
     #[serde(default)]
     pub token: Option<String>,
     #[serde(default)]
     pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+    #[serde(default, skip_serializing_if = "DiscordBotAuthConfig::is_empty")]
+    pub auth: DiscordBotAuthConfig,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct DiscordBotAuthConfig {
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_u64_vec",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allowed_channel_ids: Option<Vec<u64>>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_u64_vec",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allowed_user_ids: Option<Vec<u64>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_tools: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_all_users: Option<bool>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_u64_vec",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allowed_bot_ids: Option<Vec<u64>>,
+}
+
+impl DiscordBotAuthConfig {
+    pub fn is_empty(&self) -> bool {
+        self.allowed_channel_ids.is_none()
+            && self.allowed_user_ids.is_none()
+            && self.allowed_tools.is_none()
+            && self.allow_all_users.is_none()
+            && self.allowed_bot_ids.is_none()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum U64Like {
+    Int(u64),
+    String(String),
+}
+
+impl U64Like {
+    fn into_u64(self) -> Option<u64> {
+        match self {
+            Self::Int(value) => Some(value),
+            Self::String(raw) => raw.trim().parse::<u64>().ok(),
+        }
+    }
+}
+
+fn deserialize_optional_u64<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Option::<U64Like>::deserialize(deserializer)?.and_then(U64Like::into_u64))
+}
+
+fn deserialize_optional_u64_vec<'de, D>(deserializer: D) -> Result<Option<Vec<u64>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(
+        Option::<Vec<U64Like>>::deserialize(deserializer)?.map(|values| {
+            values
+                .into_iter()
+                .filter_map(U64Like::into_u64)
+                .collect::<Vec<_>>()
+        }),
+    )
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -101,16 +189,6 @@ impl AgentChannels {
                 .and_then(AgentChannel::target)
                 .is_none()
             && self.qwen.as_ref().and_then(AgentChannel::target).is_none()
-    }
-
-    pub fn channel_for_provider(&self, provider: &str) -> Option<&AgentChannel> {
-        match provider.trim().to_ascii_lowercase().as_str() {
-            "claude" => self.claude.as_ref(),
-            "codex" => self.codex.as_ref(),
-            "gemini" => self.gemini.as_ref(),
-            "qwen" => self.qwen.as_ref(),
-            _ => None,
-        }
     }
 
     pub fn iter(&self) -> [(&'static str, Option<&AgentChannel>); 4] {
@@ -851,9 +929,9 @@ pub(crate) fn shared_test_env_lock() -> &'static std::sync::Mutex<()> {
 mod tests {
     use super::{
         AgentChannel, AgentChannels, AgentDef, AutomationConfig, BotConfig, Config,
-        FileMemoryConfig, KanbanConfig, McpMemoryConfig, MemoryConfig, ReviewConfig,
-        RuntimeSettingsConfig, load_from_path, resolve_graceful_config_path, runtime_root,
-        save_to_path,
+        DiscordBotAuthConfig, FileMemoryConfig, KanbanConfig, McpMemoryConfig, MemoryConfig,
+        ReviewConfig, RuntimeSettingsConfig, load_from_path, resolve_graceful_config_path,
+        runtime_root, save_to_path,
     };
     use std::path::PathBuf;
     use std::sync::MutexGuard;
@@ -1027,11 +1105,21 @@ mod tests {
         config.server.host = "127.0.0.42".to_string();
         config.server.auth_token = Some("secret-token".to_string());
         config.discord.guild_id = Some("guild-123".to_string());
+        config.discord.owner_id = Some(343742347365974026);
         config.discord.bots.insert(
             "announce".to_string(),
             BotConfig {
                 token: Some("bot-token".to_string()),
                 description: Some("announce bot".to_string()),
+                provider: Some("codex".to_string()),
+                agent: Some("agent-1".to_string()),
+                auth: DiscordBotAuthConfig {
+                    allowed_channel_ids: Some(vec![123456789012345678]),
+                    allowed_user_ids: Some(vec![343742347365974026]),
+                    allowed_tools: Some(vec!["Bash".to_string(), "WebFetch".to_string()]),
+                    allow_all_users: Some(false),
+                    allowed_bot_ids: Some(vec![1479017284805722200]),
+                },
             },
         );
         config.agents.push(AgentDef {
@@ -1108,10 +1196,51 @@ mod tests {
         assert_eq!(loaded.server.host, "127.0.0.42");
         assert_eq!(loaded.server.auth_token.as_deref(), Some("secret-token"));
         assert_eq!(loaded.discord.guild_id.as_deref(), Some("guild-123"));
+        assert_eq!(loaded.discord.owner_id, Some(343742347365974026));
         assert_eq!(loaded.discord.bots.len(), 1);
         assert_eq!(
             loaded.discord.bots["announce"].description.as_deref(),
             Some("announce bot")
+        );
+        assert_eq!(
+            loaded.discord.bots["announce"].provider.as_deref(),
+            Some("codex")
+        );
+        assert_eq!(
+            loaded.discord.bots["announce"].agent.as_deref(),
+            Some("agent-1")
+        );
+        assert_eq!(
+            loaded.discord.bots["announce"]
+                .auth
+                .allowed_channel_ids
+                .as_deref(),
+            Some(&[123456789012345678][..])
+        );
+        assert_eq!(
+            loaded.discord.bots["announce"]
+                .auth
+                .allowed_user_ids
+                .as_deref(),
+            Some(&[343742347365974026][..])
+        );
+        assert_eq!(
+            loaded.discord.bots["announce"]
+                .auth
+                .allowed_tools
+                .as_deref(),
+            Some(&["Bash".to_string(), "WebFetch".to_string()][..])
+        );
+        assert_eq!(
+            loaded.discord.bots["announce"].auth.allow_all_users,
+            Some(false)
+        );
+        assert_eq!(
+            loaded.discord.bots["announce"]
+                .auth
+                .allowed_bot_ids
+                .as_deref(),
+            Some(&[1479017284805722200][..])
         );
         assert_eq!(loaded.agents.len(), 1);
         assert_eq!(loaded.agents[0].id, "agent-1");

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ struct Cli {
 enum Commands {
     /// Start Discord bot server(s)
     Dcserver {
-        /// Bot token (defaults to bot_settings.json or AGENTDESK_TOKEN env)
+        /// Bot token (defaults to configured Discord bots or AGENTDESK_TOKEN env)
         token: Option<String>,
     },
     /// Run the initial setup wizard
@@ -79,7 +79,7 @@ enum Commands {
         /// Message text
         #[arg(long)]
         message: String,
-        /// Authentication key hash (optional; falls back to AGENTDESK_TOKEN or bot_settings.json)
+        /// Authentication key hash (optional; falls back to AGENTDESK_TOKEN or configured Discord bots)
         #[arg(long)]
         key: Option<String>,
     },
@@ -91,7 +91,7 @@ enum Commands {
         /// Message text
         #[arg(long)]
         message: String,
-        /// Authentication key hash (optional; falls back to AGENTDESK_TOKEN or bot_settings.json)
+        /// Authentication key hash (optional; falls back to AGENTDESK_TOKEN or configured Discord bots)
         #[arg(long)]
         key: Option<String>,
     },

--- a/src/server/routes/onboarding.rs
+++ b/src/server/routes/onboarding.rs
@@ -23,7 +23,7 @@ pub async fn status(State(state): State<AppState>) -> (StatusCode, Json<serde_js
         }
     };
 
-    // Check if bot_settings exists (indicates onboarding was done)
+    // Check whether onboarding created any agents yet.
     let has_bots: bool = conn
         .query_row("SELECT COUNT(*) > 0 FROM agents", [], |row| row.get(0))
         .unwrap_or(false);
@@ -537,74 +537,6 @@ async fn resolve_channel_mapping(
     })
 }
 
-fn upsert_bot_settings_entry(
-    object: &mut serde_json::Map<String, serde_json::Value>,
-    token: &str,
-    provider: &str,
-    owner_id: Option<&str>,
-) {
-    let trimmed = token.trim();
-    if trimmed.is_empty() {
-        return;
-    }
-
-    let key = crate::services::discord::settings::discord_token_hash(trimmed);
-    let mut entry = json!({
-        "token": trimmed,
-        "provider": provider,
-    });
-    if let Some(owner_id) = owner_id.filter(|value| !value.trim().is_empty()) {
-        entry["owner_user_id"] = json!(owner_id.trim());
-    }
-    object.insert(key, entry);
-}
-
-fn write_bot_settings(
-    runtime_root: &Path,
-    primary_token: &str,
-    primary_provider: &str,
-    secondary_token: Option<&str>,
-    secondary_provider: Option<&str>,
-    owner_id: Option<&str>,
-) -> Result<(), String> {
-    let config_dir = runtime_root.join("config");
-    std::fs::create_dir_all(&config_dir).map_err(|e| e.to_string())?;
-    let path = config_dir.join("bot_settings.json");
-
-    let mut root: serde_json::Value = if path.exists() {
-        std::fs::read_to_string(&path)
-            .ok()
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or_else(|| json!({}))
-    } else {
-        json!({})
-    };
-
-    let obj = root
-        .as_object_mut()
-        .ok_or_else(|| "bot_settings.json root must be a JSON object".to_string())?;
-
-    upsert_bot_settings_entry(obj, primary_token, primary_provider, owner_id);
-
-    if let Some(token) = secondary_token
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        let secondary_provider = secondary_provider
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .unwrap_or(match primary_provider {
-                "codex" => "claude",
-                "gemini" => "codex",
-                _ => "codex",
-            });
-        upsert_bot_settings_entry(obj, token, secondary_provider, owner_id);
-    }
-
-    let content = serde_json::to_string_pretty(&root).map_err(|e| e.to_string())?;
-    std::fs::write(&path, content).map_err(|e| e.to_string())
-}
-
 fn write_credential_token(
     runtime_root: &Path,
     bot_name: &str,
@@ -625,51 +557,84 @@ fn write_credential_token(
     }
 }
 
-fn strip_legacy_discord_section(existing: &str) -> String {
-    let mut lines: Vec<String> = Vec::new();
-    let mut in_discord = false;
-
-    for line in existing.lines() {
-        let is_top_level = !line.starts_with(' ') && !line.starts_with('\t');
-        if !in_discord && is_top_level && line.trim_end() == "discord:" {
-            in_discord = true;
-            continue;
-        }
-
-        if in_discord {
-            if !line.trim().is_empty() && is_top_level {
-                in_discord = false;
-            } else {
-                continue;
-            }
-        }
-
-        lines.push(line.to_string());
-    }
-
-    if lines.is_empty() {
-        String::new()
-    } else {
-        format!("{}\n", lines.join("\n"))
+fn default_secondary_command_provider(primary_provider: &str) -> &'static str {
+    match primary_provider {
+        "codex" => "claude",
+        "gemini" => "codex",
+        _ => "codex",
     }
 }
 
-fn cleanup_legacy_yaml_discord_section(runtime_root: &Path) -> Result<(), String> {
-    let yaml_path = if crate::runtime_layout::config_file_path(runtime_root).exists() {
-        crate::runtime_layout::config_file_path(runtime_root)
+fn parse_owner_id(owner_id: Option<&str>) -> Option<u64> {
+    owner_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .and_then(|value| value.parse::<u64>().ok())
+}
+
+fn upsert_command_bot(
+    config: &mut crate::config::Config,
+    bot_name: &str,
+    token: &str,
+    provider: &str,
+) {
+    let mut bot = config
+        .discord
+        .bots
+        .get(bot_name)
+        .cloned()
+        .unwrap_or_default();
+    bot.token = Some(token.trim().to_string());
+    bot.provider = Some(provider.trim().to_string());
+    config.discord.bots.insert(bot_name.to_string(), bot);
+}
+
+fn write_agentdesk_discord_config(
+    runtime_root: &Path,
+    guild_id: &str,
+    primary_token: &str,
+    primary_provider: &str,
+    secondary_token: Option<&str>,
+    secondary_provider: Option<&str>,
+    owner_id: Option<&str>,
+) -> Result<(), String> {
+    let canonical = crate::runtime_layout::config_file_path(runtime_root);
+    let legacy = crate::runtime_layout::legacy_config_file_path(runtime_root);
+    let config_path = if canonical.is_file() || !legacy.is_file() {
+        canonical
     } else {
-        crate::runtime_layout::legacy_config_file_path(runtime_root)
+        legacy
     };
-    if !yaml_path.exists() {
-        return Ok(());
+    let mut config = if config_path.is_file() {
+        crate::config::load_from_path(&config_path)
+            .map_err(|e| format!("Failed to load config {}: {e}", config_path.display()))?
+    } else {
+        crate::config::Config::default()
+    };
+
+    config.discord.guild_id = Some(guild_id.trim().to_string());
+    config.discord.owner_id = parse_owner_id(owner_id);
+
+    upsert_command_bot(&mut config, "command", primary_token, primary_provider);
+
+    match secondary_token
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(token) => {
+            let provider = secondary_provider
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .unwrap_or(default_secondary_command_provider(primary_provider));
+            upsert_command_bot(&mut config, "command_2", token, provider);
+        }
+        None => {
+            config.discord.bots.remove("command_2");
+        }
     }
 
-    let existing = std::fs::read_to_string(&yaml_path).map_err(|e| e.to_string())?;
-    let stripped = strip_legacy_discord_section(&existing);
-    if stripped != existing {
-        std::fs::write(&yaml_path, stripped).map_err(|e| e.to_string())?;
-    }
-    Ok(())
+    crate::config::save_to_path(&config_path, &config)
+        .map_err(|e| format!("Failed to write config {}: {e}", config_path.display()))
 }
 
 fn tilde_display_path(path: &Path) -> String {
@@ -1044,8 +1009,9 @@ pub async fn complete(
     .ok();
     drop(conn);
 
-    if let Err(e) = write_bot_settings(
+    if let Err(e) = write_agentdesk_discord_config(
         &root,
+        &body.guild_id,
         &body.token,
         provider,
         body.command_token_2.as_deref(),
@@ -1054,7 +1020,7 @@ pub async fn complete(
     ) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("failed to write bot_settings.json: {e}")})),
+            Json(json!({"error": format!("failed to write agentdesk.yaml discord config: {e}")})),
         );
     }
 
@@ -1069,13 +1035,6 @@ pub async fn complete(
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({"error": format!("failed to write notify credential: {e}")})),
-        );
-    }
-
-    if let Err(e) = cleanup_legacy_yaml_discord_section(&root) {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": format!("failed to clean legacy yaml tokens: {e}")})),
         );
     }
 
@@ -1116,37 +1075,51 @@ mod tests {
     }
 
     #[test]
-    fn strip_legacy_discord_section_removes_top_level_block() {
-        let input = "server:\n  port: 8791\ndiscord:\n  bots:\n    claude:\n      token: \"secret\"\ndata:\n  dir: ./data\n";
-
-        let output = strip_legacy_discord_section(input);
-        assert_eq!(output, "server:\n  port: 8791\ndata:\n  dir: ./data\n");
-    }
-
-    #[test]
-    fn cleanup_legacy_yaml_discord_section_uses_v2_config_path() {
+    fn write_agentdesk_discord_config_prefers_config_dir_path() {
         let temp = tempfile::tempdir().unwrap();
         let root = temp.path();
         std::fs::create_dir_all(root.join("config")).unwrap();
         std::fs::write(
             root.join("config").join("agentdesk.yaml"),
-            "server:\n  port: 8791\ndiscord:\n  bots:\n    claude:\n      token: \"secret\"\n",
+            "server:\n  port: 8791\n",
         )
         .unwrap();
 
-        cleanup_legacy_yaml_discord_section(root).unwrap();
+        write_agentdesk_discord_config(
+            root,
+            "guild-123",
+            "primary-token",
+            "claude",
+            None,
+            None,
+            Some("42"),
+        )
+        .unwrap();
 
-        let output = std::fs::read_to_string(root.join("config").join("agentdesk.yaml")).unwrap();
-        assert_eq!(output, "server:\n  port: 8791\n");
+        assert!(!root.join("agentdesk.yaml").exists());
+        let config =
+            crate::config::load_from_path(&root.join("config").join("agentdesk.yaml")).unwrap();
+        assert_eq!(config.server.port, 8791);
+        assert_eq!(config.discord.guild_id.as_deref(), Some("guild-123"));
+        assert_eq!(config.discord.owner_id, Some(42));
+        assert_eq!(
+            config.discord.bots["command"].provider.as_deref(),
+            Some("claude")
+        );
+        assert_eq!(
+            config.discord.bots["command"].token.as_deref(),
+            Some("primary-token")
+        );
     }
 
     #[test]
-    fn write_bot_and_credential_artifacts_use_runtime_dirs() {
+    fn write_discord_and_credential_artifacts_use_runtime_dirs() {
         let temp = tempfile::tempdir().unwrap();
         let root = temp.path();
 
-        write_bot_settings(
+        write_agentdesk_discord_config(
             root,
+            "guild-123",
             "primary-token",
             "claude",
             Some("secondary-token"),
@@ -1157,19 +1130,19 @@ mod tests {
         write_credential_token(root, "announce", Some("announce-token")).unwrap();
         write_credential_token(root, "notify", Some("notify-token")).unwrap();
 
-        let bot_settings =
-            std::fs::read_to_string(root.join("config").join("bot_settings.json")).unwrap();
-        let parsed: serde_json::Value = serde_json::from_str(&bot_settings).unwrap();
-        let obj = parsed.as_object().unwrap();
-        assert_eq!(obj.len(), 2);
-
-        let providers: Vec<String> = obj
-            .values()
-            .filter_map(|entry| entry.get("provider").and_then(|v| v.as_str()))
-            .map(ToString::to_string)
-            .collect();
-        assert!(providers.contains(&"claude".to_string()));
-        assert!(providers.contains(&"codex".to_string()));
+        let config =
+            crate::config::load_from_path(&root.join("config").join("agentdesk.yaml")).unwrap();
+        assert_eq!(config.discord.guild_id.as_deref(), Some("guild-123"));
+        assert_eq!(config.discord.owner_id, Some(42));
+        assert_eq!(config.discord.bots.len(), 2);
+        assert_eq!(
+            config.discord.bots["command"].provider.as_deref(),
+            Some("claude")
+        );
+        assert_eq!(
+            config.discord.bots["command_2"].provider.as_deref(),
+            Some("codex")
+        );
 
         assert_eq!(
             std::fs::read_to_string(root.join("credential").join("announce_bot_token")).unwrap(),

--- a/src/services/discord/agentdesk_config.rs
+++ b/src/services/discord/agentdesk_config.rs
@@ -32,6 +32,26 @@ fn load_agentdesk_config() -> Option<Config> {
     None
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct ResolvedDiscordBotConfig {
+    pub name: String,
+    pub token: String,
+    pub provider: Option<ProviderKind>,
+    pub agent: Option<String>,
+    pub auth: crate::config::DiscordBotAuthConfig,
+    pub description: Option<String>,
+    pub owner_id: Option<u64>,
+}
+
+fn resolve_bot_token(bot_name: &str, bot: &crate::config::BotConfig) -> Option<String> {
+    bot.token
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .or_else(|| crate::credential::read_bot_token(bot_name))
+}
+
 fn default_prompt_path(role_id: &str) -> Option<String> {
     let root = crate::config::runtime_root()?;
     let agents_root = crate::runtime_layout::managed_agents_root(&root);
@@ -227,6 +247,42 @@ pub(super) fn load_shared_prompt_path() -> Option<String> {
     load_agentdesk_config()
         .and_then(|config| config.shared_prompt.as_deref().map(expand_tilde))
         .or_else(shared_prompt_fallback_path)
+}
+
+pub(super) fn load_discord_bot_configs() -> Vec<ResolvedDiscordBotConfig> {
+    let Some(config) = load_agentdesk_config() else {
+        return Vec::new();
+    };
+
+    let owner_id = config.discord.owner_id;
+    let mut bots = config
+        .discord
+        .bots
+        .into_iter()
+        .filter_map(|(name, bot)| {
+            let token = resolve_bot_token(&name, &bot)?;
+            Some(ResolvedDiscordBotConfig {
+                name,
+                token,
+                provider: bot
+                    .provider
+                    .as_deref()
+                    .and_then(crate::services::provider::ProviderKind::from_str),
+                agent: bot.agent,
+                auth: bot.auth,
+                description: bot.description,
+                owner_id,
+            })
+        })
+        .collect::<Vec<_>>();
+    bots.sort_by(|left, right| left.name.cmp(&right.name));
+    bots
+}
+
+pub(super) fn find_discord_bot_by_token(token: &str) -> Option<ResolvedDiscordBotConfig> {
+    load_discord_bot_configs()
+        .into_iter()
+        .find(|bot| bot.token == token)
 }
 
 pub(super) fn is_known_agent(role_id: &str) -> Option<bool> {

--- a/src/services/discord/commands/config.rs
+++ b/src/services/discord/commands/config.rs
@@ -8,7 +8,7 @@ use super::super::model_catalog::{
     SOURCE_DISPATCH_ROLE, SOURCE_PROVIDER_DEFAULT, SOURCE_ROLE_MAP, SOURCE_RUNTIME_OVERRIDE,
     is_default_picker_value,
 };
-use super::super::settings::{resolve_role_binding, save_bot_settings};
+use super::super::settings::{load_last_session_path, resolve_role_binding, save_bot_settings};
 use super::super::{Context, Error, SharedData, check_auth, check_owner};
 use super::model_ui::{
     build_model_picker_options, build_model_picker_summary_lines, has_pending_model_change,
@@ -164,11 +164,7 @@ pub(in crate::services::discord) async fn current_working_dir(
         return Some(path);
     }
 
-    let settings = shared.settings.read().await;
-    settings
-        .last_sessions
-        .get(&channel_id.get().to_string())
-        .cloned()
+    load_last_session_path(shared.db.as_ref(), &shared.token_hash, channel_id.get())
 }
 
 fn runtime_model_for_turn(

--- a/src/services/discord/commands/session.rs
+++ b/src/services/discord/commands/session.rs
@@ -5,10 +5,10 @@ use poise::serenity_prelude as serenity;
 
 use super::super::formatting::send_long_message_ctx;
 use super::super::runtime_store::{self, workspace_root};
+use super::super::settings::save_last_session_runtime;
 use super::super::{
     Context, DiscordSession, Error, WorktreeInfo, auto_restore_session, check_auth,
-    create_git_worktree, detect_worktree_conflict, resolve_channel_category, save_bot_settings,
-    scan_skills,
+    create_git_worktree, detect_worktree_conflict, resolve_channel_category, scan_skills,
 };
 
 /// Autocomplete handler for remote profile names in /start
@@ -302,26 +302,18 @@ pub(in crate::services::discord) async fn cmd_start(
         };
         drop(data);
 
-        let mut settings = ctx.data().shared.settings.write().await;
-        settings
-            .last_sessions
-            .insert(ch_key.clone(), canonical_path.clone());
-        // Persist remote profile: store if active, remove if cleared
-        match &remote_override {
-            Some(Some(name)) => {
-                settings.last_remotes.insert(ch_key, name.clone());
-            }
-            Some(None) => {
-                settings.last_remotes.remove(&ch_key);
-            }
-            None => {
-                if let Some(name) = current_remote_for_settings {
-                    settings.last_remotes.insert(ch_key, name);
-                }
-            }
-        }
-        save_bot_settings(&ctx.data().token, &settings);
-        drop(settings);
+        let remote_for_runtime = match &remote_override {
+            Some(Some(name)) => Some(name.as_str()),
+            Some(None) => None,
+            None => current_remote_for_settings.as_deref(),
+        };
+        save_last_session_runtime(
+            ctx.data().shared.db.as_ref(),
+            &ctx.data().shared.token_hash,
+            ch_key.parse::<u64>().unwrap_or_default(),
+            &canonical_path,
+            remote_for_runtime,
+        );
 
         // Rescan skills with project path to pick up project-level commands
         let new_skills = scan_skills(&ctx.data().provider, Some(&effective_path));

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -69,8 +69,9 @@ use restart_report::flush_restart_reports;
 use router::{handle_event, handle_text_message};
 use runtime_store::worktrees_root;
 use settings::{
-    RoleBinding, channel_upload_dir, cleanup_old_uploads, load_bot_settings, resolve_role_binding,
-    save_bot_settings, validate_bot_channel_routing_with_provider_channel,
+    RoleBinding, channel_upload_dir, cleanup_old_uploads, load_bot_settings,
+    load_last_remote_profile, load_last_session_path, resolve_role_binding, save_bot_settings,
+    validate_bot_channel_routing_with_provider_channel,
 };
 #[cfg(unix)]
 use tmux::{
@@ -330,10 +331,6 @@ pub(super) struct DiscordBotSettings {
     /// Explicit Discord channel allowlist for this bot token.
     /// Empty means "no channel restriction".
     pub(super) allowed_channel_ids: Vec<u64>,
-    /// channel_id (string) → last working directory path
-    pub(super) last_sessions: std::collections::HashMap<String, String>,
-    /// channel_id (string) → last remote profile name
-    pub(super) last_remotes: std::collections::HashMap<String, String>,
     /// channel_id (string) → persisted model override
     pub(super) channel_model_overrides: std::collections::HashMap<String, String>,
     /// Discord user ID of the registered owner (imprinting auth)
@@ -356,8 +353,6 @@ impl Default for DiscordBotSettings {
                 .map(|s| s.to_string())
                 .collect(),
             allowed_channel_ids: Vec::new(),
-            last_sessions: std::collections::HashMap::new(),
-            last_remotes: std::collections::HashMap::new(),
             channel_model_overrides: std::collections::HashMap::new(),
             owner_user_id: None,
             allowed_user_ids: Vec::new(),
@@ -3512,14 +3507,13 @@ pub(super) async fn auto_restore_session(
         channel_id,
     );
 
-    // Read settings first to get last_sessions/last_remotes info
+    // Read settings first to get provider and runtime restore metadata.
     let (last_path, saved_remote, provider) = {
         let settings = shared.settings.read().await;
-        let channel_key = channel_id.get().to_string();
-        let yaml_path = settings.last_sessions.get(&channel_key).cloned();
-        let saved_remote = settings.last_remotes.get(&channel_key).cloned();
         let provider = settings.provider.clone();
         let configured_path = settings::resolve_workspace(channel_id, restore_ch_name.as_deref());
+        let saved_remote =
+            load_last_remote_profile(shared.db.as_ref(), &shared.token_hash, channel_id.get());
 
         // Use the effective tmux channel name here so restart recovery keeps
         // looking up the same session key for thread sessions that intentionally
@@ -3544,6 +3538,8 @@ pub(super) async fn auto_restore_session(
                 })
             })
         });
+        let persisted_path =
+            load_last_session_path(shared.db.as_ref(), &shared.token_hash, channel_id.get());
 
         if let (Some(configured), Some(restored)) = (configured_path.as_ref(), db_cwd.as_ref()) {
             if configured != restored {
@@ -3558,7 +3554,7 @@ pub(super) async fn auto_restore_session(
         let last_path = select_restored_session_path(
             configured_path,
             db_cwd,
-            yaml_path,
+            persisted_path,
             saved_remote.as_deref(),
         );
 

--- a/src/services/discord/recovery.rs
+++ b/src/services/discord/recovery.rs
@@ -1,5 +1,8 @@
 use super::handoff::{HandoffRecord, save_handoff};
-use super::settings::{resolve_role_binding, validate_bot_channel_routing_with_provider_channel};
+use super::settings::{
+    load_last_remote_profile, load_last_session_path, resolve_role_binding,
+    validate_bot_channel_routing_with_provider_channel,
+};
 use super::turn_bridge::stale_inflight_message;
 use super::*;
 #[cfg(unix)]
@@ -992,9 +995,16 @@ pub(super) async fn restore_inflight_turns(
                 .map(|(_, ch)| ch)
             });
             {
-                let channel_key = channel_id.get().to_string();
-                let last_path = settings_snapshot.last_sessions.get(&channel_key).cloned();
-                let saved_remote = settings_snapshot.last_remotes.get(&channel_key).cloned();
+                let last_path = load_last_session_path(
+                    shared.db.as_ref(),
+                    &shared.token_hash,
+                    channel_id.get(),
+                );
+                let saved_remote = load_last_remote_profile(
+                    shared.db.as_ref(),
+                    &shared.token_hash,
+                    channel_id.get(),
+                );
                 let mut data = shared.core.lock().await;
                 let session = data
                     .sessions
@@ -1095,9 +1105,10 @@ pub(super) async fn restore_inflight_turns(
             .recovering_channels
             .insert(channel_id, std::time::Instant::now());
 
-        let channel_key = channel_id.get().to_string();
-        let last_path = settings_snapshot.last_sessions.get(&channel_key).cloned();
-        let saved_remote = settings_snapshot.last_remotes.get(&channel_key).cloned();
+        let last_path =
+            load_last_session_path(shared.db.as_ref(), &shared.token_hash, channel_id.get());
+        let saved_remote =
+            load_last_remote_profile(shared.db.as_ref(), &shared.token_hash, channel_id.get());
 
         let cancel_token = Arc::new(CancelToken::new());
         if let Ok(mut guard) = cancel_token.tmux_session.lock() {

--- a/src/services/discord/settings.rs
+++ b/src/services/discord/settings.rs
@@ -66,6 +66,281 @@ fn find_bot_settings_entry<'a>(
     })
 }
 
+#[derive(Clone, Debug, Default)]
+struct LegacyBotSettingsEntry {
+    agent: Option<String>,
+    provider: Option<ProviderKind>,
+    allowed_tools: Option<Vec<String>>,
+    allowed_channel_ids: Vec<u64>,
+    channel_model_overrides: std::collections::HashMap<String, String>,
+    owner_user_id: Option<u64>,
+    allowed_user_ids: Vec<u64>,
+    allow_all_users: Option<bool>,
+    allowed_bot_ids: Vec<u64>,
+}
+
+fn load_legacy_bot_settings_json() -> Option<serde_json::Value> {
+    let path = bot_settings_path()?;
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str::<serde_json::Value>(&content).ok()
+}
+
+fn load_legacy_bot_settings_entry(token: &str) -> LegacyBotSettingsEntry {
+    let Some(json) = load_legacy_bot_settings_json() else {
+        return LegacyBotSettingsEntry::default();
+    };
+    let Some(obj) = json.as_object() else {
+        return LegacyBotSettingsEntry::default();
+    };
+    let Some((_, entry)) = find_bot_settings_entry(obj, token) else {
+        return LegacyBotSettingsEntry::default();
+    };
+
+    let agent = entry
+        .get("agent")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
+    let provider = entry
+        .get("provider")
+        .and_then(|v| v.as_str())
+        .map(ProviderKind::from_str_or_unsupported);
+    let allowed_channel_ids = entry
+        .get("allowed_channel_ids")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(json_u64).collect())
+        .unwrap_or_default();
+    let channel_model_overrides = entry
+        .get("channel_model_overrides")
+        .and_then(|v| v.as_object())
+        .map(|obj| {
+            obj.iter()
+                .filter_map(|(channel_id, model)| {
+                    model
+                        .as_str()
+                        .map(|model| (channel_id.clone(), model.to_string()))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let owner_user_id = entry.get("owner_user_id").and_then(json_u64);
+    let allowed_user_ids = entry
+        .get("allowed_user_ids")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(json_u64).collect())
+        .unwrap_or_default();
+    let allow_all_users = entry.get("allow_all_users").and_then(|v| v.as_bool());
+    let allowed_bot_ids = entry
+        .get("allowed_bot_ids")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(json_u64).collect())
+        .unwrap_or_default();
+
+    let allowed_tools = match entry.get("allowed_tools") {
+        None => None,
+        Some(value) => value
+            .as_array()
+            .map(|tools_arr| normalize_allowed_tools(tools_arr.iter().filter_map(|v| v.as_str()))),
+    };
+
+    LegacyBotSettingsEntry {
+        agent,
+        provider,
+        allowed_tools,
+        allowed_channel_ids,
+        channel_model_overrides,
+        owner_user_id,
+        allowed_user_ids,
+        allow_all_users,
+        allowed_bot_ids,
+    }
+}
+
+fn config_path_for_write() -> Option<PathBuf> {
+    let root = crate::config::runtime_root()?;
+    let canonical = crate::runtime_layout::config_file_path(&root);
+    let legacy = crate::runtime_layout::legacy_config_file_path(&root);
+    if canonical.is_file() || !legacy.is_file() {
+        Some(canonical)
+    } else {
+        Some(legacy)
+    }
+}
+
+fn resolved_config_bot_name(config: &crate::config::Config, token: &str) -> Option<String> {
+    let mut bot_names = config.discord.bots.keys().cloned().collect::<Vec<_>>();
+    bot_names.sort();
+    bot_names.into_iter().find(|name| {
+        config
+            .discord
+            .bots
+            .get(name)
+            .and_then(|bot| {
+                bot.token
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(ToString::to_string)
+                    .or_else(|| crate::credential::read_bot_token(name))
+            })
+            .as_deref()
+            == Some(token)
+    })
+}
+
+fn persist_bot_auth_to_yaml(token: &str, settings: &DiscordBotSettings) {
+    let Some(path) = config_path_for_write() else {
+        return;
+    };
+
+    let mut config = if path.is_file() {
+        crate::config::load_from_path(&path).unwrap_or_default()
+    } else {
+        crate::config::Config::default()
+    };
+
+    config.discord.owner_id = settings.owner_user_id;
+
+    let Some(bot_name) = resolved_config_bot_name(&config, token) else {
+        let _ = crate::config::save_to_path(&path, &config);
+        return;
+    };
+
+    if let Some(bot) = config.discord.bots.get_mut(&bot_name) {
+        bot.provider = Some(settings.provider.as_str().to_string());
+        bot.agent = settings.agent.clone();
+        bot.auth.allowed_channel_ids = Some(settings.allowed_channel_ids.clone());
+        bot.auth.allowed_user_ids = Some(settings.allowed_user_ids.clone());
+        bot.auth.allowed_tools = Some(normalize_allowed_tools(&settings.allowed_tools));
+        bot.auth.allow_all_users = Some(settings.allow_all_users);
+        bot.auth.allowed_bot_ids = Some(settings.allowed_bot_ids.clone());
+    }
+
+    let _ = crate::config::save_to_path(&path, &config);
+}
+
+fn save_runtime_bot_settings(token: &str, settings: &DiscordBotSettings) {
+    let Some(path) = bot_settings_path() else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+
+    let mut json: serde_json::Value = if let Ok(content) = fs::read_to_string(&path) {
+        serde_json::from_str(&content).unwrap_or_else(|_| serde_json::json!({}))
+    } else {
+        serde_json::json!({})
+    };
+    let Some(obj) = json.as_object_mut() else {
+        return;
+    };
+
+    let key = discord_token_hash(token);
+    obj.retain(|existing_key, existing_entry| {
+        if existing_key == &key {
+            return false;
+        }
+        existing_entry
+            .get("token")
+            .and_then(|value| value.as_str())
+            .map(|existing_token| existing_token != token)
+            .unwrap_or(true)
+    });
+
+    if !settings.channel_model_overrides.is_empty() {
+        obj.insert(
+            key,
+            serde_json::json!({
+                "channel_model_overrides": settings.channel_model_overrides,
+            }),
+        );
+    }
+
+    if obj.is_empty() {
+        let _ = fs::remove_file(&path);
+        return;
+    }
+
+    if let Ok(rendered) = serde_json::to_string_pretty(&json) {
+        let _ = fs::write(&path, rendered);
+    }
+}
+
+fn last_session_path_key(token_hash: &str, channel_id: u64) -> String {
+    format!("discord:last_session:{token_hash}:{channel_id}")
+}
+
+fn last_remote_profile_key(token_hash: &str, channel_id: u64) -> String {
+    format!("discord:last_remote:{token_hash}:{channel_id}")
+}
+
+fn load_kv_meta_value(db: Option<&crate::db::Db>, key: &str) -> Option<String> {
+    let db = db?;
+    let conn = db.read_conn().ok()?;
+    conn.query_row("SELECT value FROM kv_meta WHERE key = ?1", [key], |row| {
+        row.get::<_, String>(0)
+    })
+    .ok()
+    .filter(|value| !value.trim().is_empty())
+}
+
+pub(super) fn load_last_session_path(
+    db: Option<&crate::db::Db>,
+    token_hash: &str,
+    channel_id: u64,
+) -> Option<String> {
+    load_kv_meta_value(db, &last_session_path_key(token_hash, channel_id))
+}
+
+pub(super) fn load_last_remote_profile(
+    db: Option<&crate::db::Db>,
+    token_hash: &str,
+    channel_id: u64,
+) -> Option<String> {
+    load_kv_meta_value(db, &last_remote_profile_key(token_hash, channel_id))
+}
+
+pub(super) fn save_last_session_runtime(
+    db: Option<&crate::db::Db>,
+    token_hash: &str,
+    channel_id: u64,
+    current_path: &str,
+    remote_profile_name: Option<&str>,
+) {
+    let Some(db) = db else {
+        return;
+    };
+    let Ok(conn) = db.lock() else {
+        return;
+    };
+
+    let _ = conn.execute(
+        "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?1, ?2)",
+        [
+            last_session_path_key(token_hash, channel_id),
+            current_path.to_string(),
+        ],
+    );
+
+    let remote_key = last_remote_profile_key(token_hash, channel_id);
+    match remote_profile_name
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(remote) => {
+            let _ = conn.execute(
+                "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?1, ?2)",
+                [remote_key, remote.to_string()],
+            );
+        }
+        None => {
+            let _ = conn.execute("DELETE FROM kv_meta WHERE key = ?1", [remote_key]);
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct RoleBinding {
     pub role_id: String,
@@ -908,180 +1183,84 @@ pub(super) fn cleanup_channel_uploads(channel_id: ChannelId) {
     }
 }
 
-/// Load Discord bot settings from bot_settings.json
+/// Load Discord bot settings from agentdesk.yaml plus runtime-only bot_settings.json.
 pub(super) fn load_bot_settings(token: &str) -> DiscordBotSettings {
-    let Some(path) = bot_settings_path() else {
-        return DiscordBotSettings::default();
-    };
-    let Ok(content) = fs::read_to_string(&path) else {
-        return DiscordBotSettings::default();
-    };
-    let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
-        return DiscordBotSettings::default();
-    };
-    let Some(obj) = json.as_object() else {
-        return DiscordBotSettings::default();
-    };
-    let Some((_, entry)) = find_bot_settings_entry(obj, token) else {
-        return DiscordBotSettings::default();
-    };
-    let agent = entry
-        .get("agent")
-        .and_then(|v| v.as_str())
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToString::to_string);
-    let owner_user_id = entry.get("owner_user_id").and_then(json_u64);
-    let provider = entry
-        .get("provider")
-        .and_then(|v| v.as_str())
-        .map(ProviderKind::from_str_or_unsupported)
+    let configured = agentdesk_config::find_discord_bot_by_token(token);
+    let legacy = load_legacy_bot_settings_entry(token);
+    let provider = configured
+        .as_ref()
+        .and_then(|bot| bot.provider.clone())
+        .or(legacy.provider.clone())
         .unwrap_or(ProviderKind::Claude);
-    let last_sessions = entry
-        .get("last_sessions")
-        .and_then(|v| v.as_object())
-        .map(|obj| {
-            obj.iter()
-                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                .collect()
-        })
-        .unwrap_or_default();
-    let last_remotes = entry
-        .get("last_remotes")
-        .and_then(|v| v.as_object())
-        .map(|obj| {
-            obj.iter()
-                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                .collect()
-        })
-        .unwrap_or_default();
-    let allowed_channel_ids = entry
-        .get("allowed_channel_ids")
-        .and_then(|v| v.as_array())
-        .map(|arr| arr.iter().filter_map(json_u64).collect())
-        .unwrap_or_default();
-    let allowed_user_ids = entry
-        .get("allowed_user_ids")
-        .and_then(|v| v.as_array())
-        .map(|arr| arr.iter().filter_map(json_u64).collect())
-        .unwrap_or_default();
-    let allow_all_users = entry
-        .get("allow_all_users")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    let allowed_bot_ids = entry
-        .get("allowed_bot_ids")
-        .and_then(|v| v.as_array())
-        .map(|arr| arr.iter().filter_map(json_u64).collect())
-        .unwrap_or_default();
-    let channel_model_overrides = entry
-        .get("channel_model_overrides")
-        .and_then(|v| v.as_object())
-        .map(|obj| {
-            obj.iter()
-                .filter_map(|(channel_id, model)| {
-                    model
-                        .as_str()
-                        .map(|model| (channel_id.clone(), model.to_string()))
-                })
-                .collect()
-        })
-        .unwrap_or_default();
-    let allowed_tools = match entry.get("allowed_tools") {
-        None => default_allowed_tools_for_provider(&provider),
-        Some(value) => {
-            let Some(tools_arr) = value.as_array() else {
-                let allowed_tools = default_allowed_tools_for_provider(&provider);
-                return DiscordBotSettings {
-                    agent,
-                    provider,
-                    allowed_tools,
-                    allowed_channel_ids,
-                    owner_user_id,
-                    last_sessions,
-                    last_remotes,
-                    allowed_user_ids,
-                    allow_all_users,
-                    allowed_bot_ids,
-                    ..DiscordBotSettings::default()
-                };
-            };
-            normalize_allowed_tools(tools_arr.iter().filter_map(|v| v.as_str()))
-        }
-    };
+    let allowed_tools = configured
+        .as_ref()
+        .and_then(|bot| bot.auth.allowed_tools.as_ref().cloned())
+        .map(|tools| normalize_allowed_tools(&tools))
+        .or(legacy.allowed_tools.clone())
+        .unwrap_or_else(|| default_allowed_tools_for_provider(&provider));
+
     DiscordBotSettings {
-        agent,
+        agent: configured
+            .as_ref()
+            .and_then(|bot| bot.agent.clone())
+            .or(legacy.agent),
         provider,
         allowed_tools,
-        allowed_channel_ids,
-        last_sessions,
-        last_remotes,
-        channel_model_overrides,
-        owner_user_id,
-        allowed_user_ids,
-        allow_all_users,
-        allowed_bot_ids,
+        allowed_channel_ids: configured
+            .as_ref()
+            .and_then(|bot| bot.auth.allowed_channel_ids.clone())
+            .unwrap_or(legacy.allowed_channel_ids),
+        channel_model_overrides: legacy.channel_model_overrides,
+        owner_user_id: configured
+            .as_ref()
+            .and_then(|bot| bot.owner_id)
+            .or(legacy.owner_user_id),
+        allowed_user_ids: configured
+            .as_ref()
+            .and_then(|bot| bot.auth.allowed_user_ids.clone())
+            .unwrap_or(legacy.allowed_user_ids),
+        allow_all_users: configured
+            .as_ref()
+            .and_then(|bot| bot.auth.allow_all_users)
+            .or(legacy.allow_all_users)
+            .unwrap_or(false),
+        allowed_bot_ids: configured
+            .as_ref()
+            .and_then(|bot| bot.auth.allowed_bot_ids.clone())
+            .unwrap_or(legacy.allowed_bot_ids),
     }
 }
 
-/// Save Discord bot settings to bot_settings.json
+/// Save Discord bot settings.
+/// Auth moves to agentdesk.yaml; runtime-only overrides remain in bot_settings.json.
 pub(super) fn save_bot_settings(token: &str, settings: &DiscordBotSettings) {
-    let Some(path) = bot_settings_path() else {
-        return;
-    };
-    if let Some(parent) = path.parent() {
-        let _ = fs::create_dir_all(parent);
-    }
-    let mut json: serde_json::Value = if let Ok(content) = fs::read_to_string(&path) {
-        serde_json::from_str(&content).unwrap_or_else(|_| serde_json::json!({}))
-    } else {
-        serde_json::json!({})
-    };
-    let key = discord_token_hash(token);
-    let normalized_tools = normalize_allowed_tools(&settings.allowed_tools);
-    let mut entry = serde_json::json!({
-        "token": token,
-        "agent": settings.agent,
-        "provider": settings.provider.as_str(),
-        "allowed_tools": normalized_tools,
-        "allowed_channel_ids": settings.allowed_channel_ids,
-        "last_sessions": settings.last_sessions,
-        "last_remotes": settings.last_remotes,
-        "channel_model_overrides": settings.channel_model_overrides,
-        "allowed_user_ids": settings.allowed_user_ids,
-        "allow_all_users": settings.allow_all_users,
-        "allowed_bot_ids": settings.allowed_bot_ids,
-    });
-    if let Some(owner_id) = settings.owner_user_id {
-        entry["owner_user_id"] = serde_json::json!(owner_id);
-    }
-    let Some(obj) = json.as_object_mut() else {
-        return;
-    };
-    obj.retain(|existing_key, existing_entry| {
-        if existing_key == &key {
-            return true;
-        }
-        existing_entry
-            .get("token")
-            .and_then(|value| value.as_str())
-            .map(|existing_token| existing_token != token)
-            .unwrap_or(true)
-    });
-    obj.insert(key, entry);
-    if let Ok(s) = serde_json::to_string_pretty(&json) {
-        let _ = fs::write(&path, s);
-    }
+    persist_bot_auth_to_yaml(token, settings);
+    save_runtime_bot_settings(token, settings);
 }
 
 pub fn load_discord_bot_launch_configs() -> Vec<DiscordBotLaunchConfig> {
-    let Some(path) = bot_settings_path() else {
-        return Vec::new();
-    };
-    let Ok(content) = fs::read_to_string(&path) else {
-        return Vec::new();
-    };
-    let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
+    let configured = agentdesk_config::load_discord_bot_configs();
+    if !configured.is_empty() {
+        let mut configs = configured
+            .into_iter()
+            .map(|bot| {
+                let legacy = load_legacy_bot_settings_entry(&bot.token);
+                DiscordBotLaunchConfig {
+                    hash_key: discord_token_hash(&bot.token),
+                    token: bot.token,
+                    provider: bot
+                        .provider
+                        .or(legacy.provider)
+                        .unwrap_or(ProviderKind::Claude),
+                }
+            })
+            .collect::<Vec<_>>();
+        configs.sort_by(|left, right| left.hash_key.cmp(&right.hash_key));
+        configs.dedup_by(|left, right| left.token == right.token);
+        return configs;
+    }
+
+    let Some(json) = load_legacy_bot_settings_json() else {
         return Vec::new();
     };
     let Some(obj) = json.as_object() else {
@@ -1119,11 +1298,18 @@ pub fn load_discord_bot_launch_configs() -> Vec<DiscordBotLaunchConfig> {
     configs_by_token.into_values().collect()
 }
 
-/// Resolve a Discord bot token from its hash by searching bot_settings.json
+/// Resolve a Discord bot token from its hash by searching agentdesk.yaml first,
+/// then falling back to legacy bot_settings.json entries.
 pub fn resolve_discord_token_by_hash(hash: &str) -> Option<String> {
-    let path = bot_settings_path()?;
-    let content = fs::read_to_string(&path).ok()?;
-    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+    if let Some(token) = agentdesk_config::load_discord_bot_configs()
+        .into_iter()
+        .find(|bot| discord_token_hash(&bot.token) == hash)
+        .map(|bot| bot.token)
+    {
+        return Some(token);
+    }
+
+    let json = load_legacy_bot_settings_json()?;
     let obj = json.as_object()?;
     let entry = obj.get(hash)?;
     entry
@@ -1881,8 +2067,14 @@ memory:
 
     #[test]
     fn test_save_bot_settings_persists_allowed_channel_ids() {
-        with_temp_home(|_temp_home: &TempDir| {
+        with_temp_home(|temp_home: &TempDir| {
             let token = "test-token";
+            write_agentdesk_yaml(
+                temp_home,
+                &format!(
+                    "server:\n  port: 8791\ndiscord:\n  bots:\n    command:\n      token: \"{token}\"\n"
+                ),
+            );
             let mut settings = super::super::DiscordBotSettings::default();
             settings.allowed_channel_ids = vec![123, 456];
 
@@ -1908,6 +2100,12 @@ memory:
                 other_key.clone(): { "token": other_token, "owner_user_id": 2 }
             });
             fs::write(&path, serde_json::to_string_pretty(&json).unwrap()).unwrap();
+            write_agentdesk_yaml(
+                temp_home,
+                &format!(
+                    "server:\n  port: 8791\ndiscord:\n  bots:\n    command:\n      token: \"{token}\"\n"
+                ),
+            );
 
             let mut settings = super::super::DiscordBotSettings::default();
             settings.owner_user_id = Some(42);
@@ -1917,9 +2115,9 @@ memory:
             let saved: serde_json::Value = serde_json::from_str(&raw).unwrap();
             let obj = saved.as_object().unwrap();
             assert!(obj.get("claude").is_none());
-            assert!(obj.get(&canonical_key).is_some());
+            assert!(obj.get(&canonical_key).is_none());
             assert!(obj.get(&other_key).is_some());
-            assert_eq!(obj.len(), 2);
+            assert_eq!(obj.len(), 1);
 
             let loaded = load_bot_settings(token);
             assert_eq!(loaded.owner_user_id, Some(42));
@@ -1952,8 +2150,14 @@ memory:
 
     #[test]
     fn test_save_bot_settings_persists_allow_all_users() {
-        with_temp_home(|_temp_home: &TempDir| {
+        with_temp_home(|temp_home: &TempDir| {
             let token = "test-token";
+            write_agentdesk_yaml(
+                temp_home,
+                &format!(
+                    "server:\n  port: 8791\ndiscord:\n  bots:\n    command:\n      token: \"{token}\"\n"
+                ),
+            );
             let mut settings = super::super::DiscordBotSettings::default();
             settings.allow_all_users = true;
 
@@ -1990,8 +2194,14 @@ memory:
 
     #[test]
     fn test_save_bot_settings_persists_agent_identity() {
-        with_temp_home(|_temp_home: &TempDir| {
+        with_temp_home(|temp_home: &TempDir| {
             let token = "test-token";
+            write_agentdesk_yaml(
+                temp_home,
+                &format!(
+                    "server:\n  port: 8791\ndiscord:\n  bots:\n    command:\n      token: \"{token}\"\n"
+                ),
+            );
             let mut settings = super::super::DiscordBotSettings::default();
             settings.agent = Some("codex".to_string());
 

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -15,8 +15,8 @@ use super::formatting::{
     format_tool_input, normalize_empty_lines, send_long_message_raw, truncate_str,
 };
 use super::settings::{
-    channel_supports_provider, resolve_role_binding,
-    validate_bot_channel_routing_with_provider_channel,
+    channel_supports_provider, load_last_remote_profile, load_last_session_path,
+    resolve_role_binding, validate_bot_channel_routing_with_provider_channel,
 };
 use super::{DISCORD_MSG_LIMIT, SharedData, TmuxWatcherHandle, rate_limit_wait};
 
@@ -2161,12 +2161,12 @@ pub(super) async fn restore_tmux_watchers(http: &Arc<serenity::Http>, shared: &A
     // Register sessions in CoreState so cleanup_orphan_tmux_sessions recognizes them
     // and message handlers find an active session with current_path
     if !owned_sessions.is_empty() {
-        let settings = shared.settings.read().await;
         let mut data = shared.core.lock().await;
         for (channel_id, channel_name) in &owned_sessions {
-            let channel_key = channel_id.get().to_string();
-            let yaml_path = settings.last_sessions.get(&channel_key).cloned();
-            let remote_profile = settings.last_remotes.get(&channel_key).cloned();
+            let persisted_path =
+                load_last_session_path(shared.db.as_ref(), &shared.token_hash, channel_id.get());
+            let remote_profile =
+                load_last_remote_profile(shared.db.as_ref(), &shared.token_hash, channel_id.get());
             let configured_path =
                 super::settings::resolve_workspace(*channel_id, Some(channel_name.as_str()));
 
@@ -2228,7 +2228,7 @@ pub(super) async fn restore_tmux_watchers(http: &Arc<serenity::Http>, shared: &A
                 let effective_path = super::select_restored_session_path(
                     configured_path,
                     db_cwd,
-                    yaml_path,
+                    persisted_path,
                     remote_profile.as_deref(),
                 );
                 if let Some(path) = effective_path {


### PR DESCRIPTION
Closes #383

## Summary
- move Discord owner and bot auth settings into `agentdesk.yaml` as the source of truth
- persist last session/runtime state in DB `kv_meta` instead of `bot_settings.json`
- keep boot, onboarding, recovery, and session restore paths working without legacy bot settings state

## Testing
- `cargo test`