### PR TITLE
#389 Import legacy PR tracking into canonical lifecycle

### DIFF
--- a/policies/00-pr-tracking.js
+++ b/policies/00-pr-tracking.js
@@ -1,0 +1,242 @@
+(function() {
+  var legacyScanStamp = null;
+
+  function parseJsonObject(raw) {
+    if (!raw) return {};
+    try {
+      return JSON.parse(raw) || {};
+    } catch (e) {
+      return {};
+    }
+  }
+
+  function extractRepoFromIssueUrl(url) {
+    var match = String(url || "").match(/github\.com\/([^/]+\/[^/]+)/);
+    return match ? match[1] : null;
+  }
+
+  function loadCardMeta(cardId) {
+    var rows = agentdesk.db.query(
+      "SELECT id, status, blocked_reason, repo_id, github_issue_url " +
+      "FROM kanban_cards WHERE id = ? LIMIT 1",
+      [cardId]
+    );
+    return rows.length > 0 ? rows[0] : null;
+  }
+
+  function loadPrTrackingCanonical(cardId) {
+    var rows = agentdesk.db.query(
+      "SELECT card_id, repo_id, worktree_path, branch, pr_number, head_sha, state, last_error " +
+      "FROM pr_tracking WHERE card_id = ?",
+      [cardId]
+    );
+    return rows.length > 0 ? rows[0] : null;
+  }
+
+  function upsertPrTracking(cardId, repoId, worktreePath, branch, prNumber, headSha, state, lastError) {
+    agentdesk.db.execute(
+      "INSERT INTO pr_tracking (card_id, repo_id, worktree_path, branch, pr_number, head_sha, state, last_error, created_at, updated_at) " +
+      "VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now')) " +
+      "ON CONFLICT(card_id) DO UPDATE SET " +
+      "repo_id = COALESCE(excluded.repo_id, pr_tracking.repo_id), " +
+      "worktree_path = COALESCE(excluded.worktree_path, pr_tracking.worktree_path), " +
+      "branch = COALESCE(excluded.branch, pr_tracking.branch), " +
+      "pr_number = COALESCE(excluded.pr_number, pr_tracking.pr_number), " +
+      "head_sha = COALESCE(excluded.head_sha, pr_tracking.head_sha), " +
+      "state = COALESCE(excluded.state, pr_tracking.state), " +
+      "last_error = excluded.last_error, " +
+      "updated_at = datetime('now')",
+      [cardId, repoId, worktreePath, branch, prNumber, headSha, state, lastError]
+    );
+  }
+
+  function inferLegacyState(card, info, fallbackState) {
+    if (info && info.state) return String(info.state);
+    if (fallbackState) return fallbackState;
+
+    var blockedReason = card && card.blocked_reason ? String(card.blocked_reason) : "";
+    if (blockedReason.indexOf("ci:") === 0) return "wait-ci";
+    if (info && (info.number || info.pr_number)) return "merge";
+    return "create-pr";
+  }
+
+  function importLegacyPrTracking(cardId, fallbackState) {
+    var existing = loadPrTrackingCanonical(cardId);
+    if (existing) return existing;
+
+    var cached = agentdesk.kv.get("pr:" + cardId);
+    if (!cached) return null;
+
+    var info = parseJsonObject(cached);
+    if (!info || (!info.number && !info.pr_number && !info.branch && !info.headRefName)) {
+      return null;
+    }
+
+    var card = loadCardMeta(cardId);
+    var repoId = info.repo || (card ? (card.repo_id || extractRepoFromIssueUrl(card.github_issue_url)) : null);
+    upsertPrTracking(
+      cardId,
+      repoId,
+      null,
+      info.branch || info.headRefName || null,
+      info.number || info.pr_number || null,
+      info.sha || info.head_sha || null,
+      inferLegacyState(card, info, fallbackState),
+      null
+    );
+    return loadPrTrackingCanonical(cardId);
+  }
+
+  function legacyScanStampValue() {
+    var rows = agentdesk.db.query(
+      "SELECT COUNT(*) AS count, COALESCE(MIN(key), '') AS min_key, COALESCE(MAX(key), '') AS max_key " +
+      "FROM kv_meta WHERE key LIKE 'pr:%' AND (expires_at IS NULL OR expires_at > datetime('now'))",
+      []
+    );
+    if (rows.length === 0) return "0::";
+    return String(rows[0].count || 0) + ":" + String(rows[0].min_key || "") + ":" + String(rows[0].max_key || "");
+  }
+
+  function importLegacyPrTrackingOnce(fallbackState) {
+    var nextStamp = legacyScanStampValue();
+    if (legacyScanStamp === nextStamp) return;
+
+    var cached = agentdesk.db.query(
+      "SELECT key FROM kv_meta WHERE key LIKE 'pr:%' AND (expires_at IS NULL OR expires_at > datetime('now'))",
+      []
+    );
+    for (var i = 0; i < cached.length; i++) {
+      var cardId = String(cached[i].key || "").replace("pr:", "");
+      if (!cardId) continue;
+      if (loadPrTrackingCanonical(cardId)) continue;
+      importLegacyPrTracking(cardId, fallbackState);
+    }
+    legacyScanStamp = nextStamp;
+  }
+
+  function loadPrTracking(cardId, options) {
+    var tracking = loadPrTrackingCanonical(cardId);
+    if (tracking) return tracking;
+    var fallbackState = options && options.fallback_state ? options.fallback_state : null;
+    return importLegacyPrTracking(cardId, fallbackState);
+  }
+
+  function findByRepoPr(repoId, prNumber, options) {
+    var rows = agentdesk.db.query(
+      "SELECT card_id, repo_id, worktree_path, branch, pr_number, head_sha, state, last_error " +
+      "FROM pr_tracking WHERE repo_id = ? AND pr_number = ? LIMIT 1",
+      [repoId, prNumber]
+    );
+    if (rows.length > 0) return rows[0];
+
+    var fallbackState = options && options.fallback_state ? options.fallback_state : null;
+    importLegacyPrTrackingOnce(fallbackState);
+    rows = agentdesk.db.query(
+      "SELECT card_id, repo_id, worktree_path, branch, pr_number, head_sha, state, last_error " +
+      "FROM pr_tracking WHERE repo_id = ? AND pr_number = ? LIMIT 1",
+      [repoId, prNumber]
+    );
+    return rows.length > 0 ? rows[0] : null;
+  }
+
+  function listTrackedPrRows(whereClause, params, options) {
+    var fallbackState = options && options.fallback_state ? options.fallback_state : null;
+    importLegacyPrTrackingOnce(fallbackState);
+
+    var query =
+      "SELECT card_id, repo_id, worktree_path, branch, pr_number, head_sha, state, last_error " +
+      "FROM pr_tracking";
+    if (whereClause) query += " WHERE " + whereClause;
+    return agentdesk.db.query(query, params || []);
+  }
+
+  function findOpenPrByTrackedBranch(repoId, branch) {
+    if (!repoId || !branch) return null;
+    var prJson = agentdesk.exec("gh", [
+      "pr", "list",
+      "--head", branch,
+      "--state", "open",
+      "--json", "number,headRefName,headRefOid",
+      "--limit", "1",
+      "--repo", repoId
+    ]);
+    if (!prJson || prJson.indexOf("ERROR") === 0) return null;
+    try {
+      var prs = JSON.parse(prJson);
+      if (!prs || prs.length === 0) return null;
+      return {
+        number: prs[0].number,
+        branch: prs[0].headRefName,
+        sha: prs[0].headRefOid,
+        repo: repoId
+      };
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function repoForCard(cardId) {
+    var card = loadCardMeta(cardId);
+    if (!card) return null;
+    return card.repo_id || extractRepoFromIssueUrl(card.github_issue_url);
+  }
+
+  function resolvePrInfoForCard(cardId, options) {
+    var fallbackState = options && options.fallback_state ? options.fallback_state : null;
+    var tracking = loadPrTracking(cardId, options);
+    if (!tracking) return null;
+
+    var repo = tracking.repo_id || repoForCard(cardId);
+    if (!repo) {
+      var repos = agentdesk.db.query("SELECT id FROM github_repos LIMIT 1", []);
+      if (repos.length > 0) repo = repos[0].id;
+    }
+    if (!repo) return null;
+
+    if ((!tracking.pr_number || !tracking.head_sha) && tracking.branch) {
+      var discovered = findOpenPrByTrackedBranch(repo, tracking.branch);
+      if (discovered) {
+        upsertPrTracking(
+          cardId,
+          repo,
+          tracking.worktree_path,
+          discovered.branch || tracking.branch,
+          discovered.number,
+          discovered.sha,
+          tracking.state || fallbackState || "wait-ci",
+          null
+        );
+        tracking = loadPrTrackingCanonical(cardId) || tracking;
+      }
+    }
+
+    if (!tracking.pr_number || !tracking.branch) return null;
+    return {
+      number: tracking.pr_number,
+      branch: tracking.branch,
+      sha: tracking.head_sha,
+      repo: repo,
+      worktree_path: tracking.worktree_path
+    };
+  }
+
+  agentdesk.prTracking = {
+    parseJsonObject: parseJsonObject,
+    extractRepoFromIssueUrl: extractRepoFromIssueUrl,
+    loadCanonical: loadPrTrackingCanonical,
+    load: loadPrTracking,
+    upsert: upsertPrTracking,
+    list: listTrackedPrRows,
+    findByRepoPr: findByRepoPr,
+    findOpenPrByBranch: findOpenPrByTrackedBranch,
+    repoForCard: repoForCard,
+    resolvePrInfoForCard: resolvePrInfoForCard,
+    importLegacyForCard: importLegacyPrTracking,
+    importLegacyOnce: importLegacyPrTrackingOnce
+  };
+})();
+
+agentdesk.registerPolicy({
+  name: "pr-tracking",
+  priority: 1
+});

--- a/policies/ci-recovery.js
+++ b/policies/ci-recovery.js
@@ -15,6 +15,8 @@
  *      - ambiguous/exhausted: escalate to pending_decision
  */
 
+var prTracking = agentdesk.prTracking;
+
 var CI_MAX_RETRIES = 3;
 var CI_LOG_MAX_LINES = 50;
 
@@ -47,145 +49,22 @@ var CODE_JOB_PATTERNS = [
   "scripts"
 ];
 
-function parseJsonObject(raw) {
-  if (!raw) return {};
-  try {
-    return JSON.parse(raw) || {};
-  } catch (e) {
-    return {};
-  }
-}
-
-function extractRepoFromIssueUrl(url) {
-  var match = String(url || "").match(/github\.com\/([^/]+\/[^/]+)/);
-  return match ? match[1] : null;
-}
-
 function getRepoForCard(cardId) {
-  var cards = agentdesk.db.query(
-    "SELECT github_issue_url FROM kanban_cards WHERE id = ?", [cardId]
-  );
-  if (cards.length === 0 || !cards[0].github_issue_url) return null;
-  // Extract "owner/repo" from "https://github.com/owner/repo/issues/123"
-  var match = cards[0].github_issue_url.match(/github\.com\/([^/]+\/[^/]+)/);
-  return match ? match[1] : null;
+  return prTracking.repoForCard(cardId);
 }
 
 function loadPrTracking(cardId) {
-  var rows = agentdesk.db.query(
-    "SELECT card_id, repo_id, worktree_path, branch, pr_number, head_sha, state, last_error " +
-    "FROM pr_tracking WHERE card_id = ?",
-    [cardId]
-  );
-  return rows.length > 0 ? rows[0] : null;
+  return prTracking.load(cardId, { fallback_state: "wait-ci" });
 }
 
 function upsertPrTracking(cardId, repoId, worktreePath, branch, prNumber, headSha, state, lastError) {
-  agentdesk.db.execute(
-    "INSERT INTO pr_tracking (card_id, repo_id, worktree_path, branch, pr_number, head_sha, state, last_error, created_at, updated_at) " +
-    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now')) " +
-    "ON CONFLICT(card_id) DO UPDATE SET " +
-    "repo_id = COALESCE(excluded.repo_id, pr_tracking.repo_id), " +
-    "worktree_path = COALESCE(excluded.worktree_path, pr_tracking.worktree_path), " +
-    "branch = COALESCE(excluded.branch, pr_tracking.branch), " +
-    "pr_number = COALESCE(excluded.pr_number, pr_tracking.pr_number), " +
-    "head_sha = COALESCE(excluded.head_sha, pr_tracking.head_sha), " +
-    "state = COALESCE(excluded.state, pr_tracking.state), " +
-    "last_error = excluded.last_error, " +
-    "updated_at = datetime('now')",
-    [cardId, repoId, worktreePath, branch, prNumber, headSha, state, lastError]
-  );
-}
-
-function findOpenPrByTrackedBranch(repo, branch) {
-  if (!repo || !branch) return null;
-  var prJson = agentdesk.exec("gh", [
-    "pr", "list",
-    "--head", branch,
-    "--state", "open",
-    "--json", "number,headRefName,headRefOid",
-    "--limit", "1",
-    "--repo", repo
-  ]);
-  if (!prJson || prJson.indexOf("ERROR") === 0) return null;
-  try {
-    var prs = JSON.parse(prJson);
-    if (!prs || prs.length === 0) return null;
-    return {
-      number: prs[0].number,
-      branch: prs[0].headRefName,
-      sha: prs[0].headRefOid,
-      repo: repo
-    };
-  } catch (e) {
-    return null;
-  }
-}
-
-function importLegacyPrTracking(cardId) {
-  var cached = agentdesk.kv.get("pr:" + cardId);
-  if (!cached) return null;
-  try {
-    var info = JSON.parse(cached);
-    var rows = agentdesk.db.query(
-      "SELECT repo_id, github_issue_url FROM kanban_cards WHERE id = ?",
-      [cardId]
-    );
-    var repoId = info.repo || (rows.length > 0 ? (rows[0].repo_id || extractRepoFromIssueUrl(rows[0].github_issue_url)) : null);
-    upsertPrTracking(
-      cardId,
-      repoId,
-      null,
-      info.branch || info.headRefName || null,
-      info.number || info.pr_number || null,
-      info.sha || info.head_sha || null,
-      "wait-ci",
-      null
-    );
-    return loadPrTracking(cardId);
-  } catch (e) {
-    return null;
-  }
+  return prTracking.upsert(cardId, repoId, worktreePath, branch, prNumber, headSha, state, lastError);
 }
 
 // ── Helper: Find canonical PR info for card via pr_tracking ──
 
 function findPrInfoForCard(cardId) {
-  var tracking = loadPrTracking(cardId) || importLegacyPrTracking(cardId);
-  if (!tracking) return null;
-
-  var repo = tracking.repo_id || getRepoForCard(cardId);
-  if (!repo) {
-    var repos = agentdesk.db.query("SELECT id FROM github_repos LIMIT 1", []);
-    if (repos.length > 0) repo = repos[0].id;
-  }
-  if (!repo) return null;
-
-  if ((!tracking.pr_number || !tracking.head_sha) && tracking.branch) {
-    var discovered = findOpenPrByTrackedBranch(repo, tracking.branch);
-    if (discovered) {
-      upsertPrTracking(
-        cardId,
-        repo,
-        tracking.worktree_path,
-        discovered.branch || tracking.branch,
-        discovered.number,
-        discovered.sha,
-        tracking.state || "wait-ci",
-        null
-      );
-      tracking = loadPrTracking(cardId) || tracking;
-    }
-  }
-
-  if (!tracking.pr_number || !tracking.branch) return null;
-  return {
-    number: tracking.pr_number,
-    branch: tracking.branch,
-    sha: tracking.head_sha,
-    repo: repo,
-    worktree_path: tracking.worktree_path
-  };
+  return prTracking.resolvePrInfoForCard(cardId, { fallback_state: "wait-ci" });
 }
 
 // ── Helper: Get current PR head SHA ──
@@ -561,6 +440,8 @@ var ciRecovery = {
   priority: 46,
 
   onTick1min: function() {
+    prTracking.importLegacyOnce("wait-ci");
+
     // Find canonical PR lifecycle entries that are waiting for CI.
     var cards = agentdesk.db.query(
       "SELECT p.card_id AS id, c.blocked_reason AS blocked_reason " +

--- a/policies/merge-automation.js
+++ b/policies/merge-automation.js
@@ -19,6 +19,8 @@
 //   Set kv: merge_request:{pr_number} = "{owner/repo}"
 //   OnTick5min picks it up and merges (no author check — explicit request)
 
+var prTracking = agentdesk.prTracking;
+
 var CODEX_REVIEWERS = {
   "chatgpt-codex-connector": true,
   "chatgpt-codex-connector[bot]": true
@@ -107,116 +109,24 @@ function loadCardContext(cardId) {
   return cards.length > 0 ? cards[0] : null;
 }
 
-function parseJsonObject(raw) {
-  if (!raw) return {};
-  try {
-    return JSON.parse(raw) || {};
-  } catch (e) {
-    return {};
-  }
-}
-
 function loadTrackedPrForCard(cardId) {
-  importLegacyPrCacheRows();
-  var rows = agentdesk.db.query(
-    "SELECT card_id, repo_id, worktree_path, branch, pr_number, head_sha, state, last_error " +
-    "FROM pr_tracking WHERE card_id = ?",
-    [cardId]
-  );
-  return rows.length > 0 ? rows[0] : null;
+  return prTracking.load(cardId);
 }
 
 function loadTrackedPrForRepoPr(repoId, prNumber) {
-  importLegacyPrCacheRows();
-  var rows = agentdesk.db.query(
-    "SELECT card_id, repo_id, worktree_path, branch, pr_number, head_sha, state, last_error " +
-    "FROM pr_tracking WHERE repo_id = ? AND pr_number = ? LIMIT 1",
-    [repoId, prNumber]
-  );
-  return rows.length > 0 ? rows[0] : null;
+  return prTracking.findByRepoPr(repoId, prNumber);
 }
 
 function upsertPrTracking(cardId, repoId, worktreePath, branch, prNumber, headSha, state, lastError) {
-  agentdesk.db.execute(
-    "INSERT INTO pr_tracking (card_id, repo_id, worktree_path, branch, pr_number, head_sha, state, last_error, created_at, updated_at) " +
-    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now')) " +
-    "ON CONFLICT(card_id) DO UPDATE SET " +
-    "repo_id = COALESCE(excluded.repo_id, pr_tracking.repo_id), " +
-    "worktree_path = COALESCE(excluded.worktree_path, pr_tracking.worktree_path), " +
-    "branch = COALESCE(excluded.branch, pr_tracking.branch), " +
-    "pr_number = COALESCE(excluded.pr_number, pr_tracking.pr_number), " +
-    "head_sha = COALESCE(excluded.head_sha, pr_tracking.head_sha), " +
-    "state = COALESCE(excluded.state, pr_tracking.state), " +
-    "last_error = excluded.last_error, " +
-    "updated_at = datetime('now')",
-    [cardId, repoId, worktreePath, branch, prNumber, headSha, state, lastError]
-  );
-}
-
-function importLegacyPrCacheRows() {
-  var cached = agentdesk.db.query(
-    "SELECT key, value FROM kv_meta WHERE key LIKE 'pr:%' AND (expires_at IS NULL OR expires_at > datetime('now'))",
-    []
-  );
-  for (var i = 0; i < cached.length; i++) {
-    var cardId = cached[i].key.replace("pr:", "");
-    var existing = agentdesk.db.query(
-      "SELECT 1 FROM pr_tracking WHERE card_id = ? LIMIT 1",
-      [cardId]
-    );
-    if (existing.length > 0) continue;
-    var info = parseJsonObject(cached[i].value);
-    if (!info || (!info.number && !info.pr_number && !info.branch && !info.headRefName)) continue;
-    var card = agentdesk.db.query(
-      "SELECT repo_id, github_issue_url FROM kanban_cards WHERE id = ?",
-      [cardId]
-    );
-    var repoId = info.repo || (card.length > 0 ? (card[0].repo_id || extractRepo(card[0].github_issue_url)) : null);
-    upsertPrTracking(
-      cardId,
-      repoId,
-      null,
-      info.branch || info.headRefName || null,
-      info.number || info.pr_number || null,
-      info.sha || info.head_sha || null,
-      info.state || ((info.number || info.pr_number) ? "merge" : "create-pr"),
-      null
-    );
-  }
+  return prTracking.upsert(cardId, repoId, worktreePath, branch, prNumber, headSha, state, lastError);
 }
 
 function listTrackedPrRows(whereClause, params) {
-  importLegacyPrCacheRows();
-  var query =
-    "SELECT card_id, repo_id, worktree_path, branch, pr_number, head_sha, state, last_error " +
-    "FROM pr_tracking";
-  if (whereClause) query += " WHERE " + whereClause;
-  return agentdesk.db.query(query, params || []);
+  return prTracking.list(whereClause, params);
 }
 
 function findOpenPrByTrackedBranch(repoId, branch) {
-  if (!repoId || !branch) return null;
-  var prJson = agentdesk.exec("gh", [
-    "pr", "list",
-    "--head", branch,
-    "--state", "open",
-    "--json", "number,headRefName,headRefOid",
-    "--limit", "1",
-    "--repo", repoId
-  ]);
-  if (!prJson || prJson.indexOf("ERROR") === 0) return null;
-  try {
-    var prs = JSON.parse(prJson);
-    if (!prs || prs.length === 0) return null;
-    return {
-      number: prs[0].number,
-      branch: prs[0].headRefName,
-      sha: prs[0].headRefOid,
-      repo: repoId
-    };
-  } catch (e) {
-    return null;
-  }
+  return prTracking.findOpenPrByBranch(repoId, branch);
 }
 
 function getCurrentPrHeadSha(prNumber, repo) {
@@ -928,13 +838,6 @@ function findPrForCard(cardId) {
     repo: tracking.repo_id,
     sha: tracking.head_sha
   };
-}
-
-function extractRepo(githubUrl) {
-  if (!githubUrl) return null;
-  // https://github.com/owner/repo/issues/42 → owner/repo
-  var match = githubUrl.match(/github\.com\/([^\/]+\/[^\/]+)/);
-  return match ? match[1] : null;
 }
 
 function getBranchFromWorktree(cwd) {

--- a/policies/review-automation.js
+++ b/policies/review-automation.js
@@ -8,6 +8,8 @@
  *   onReviewVerdict     — 외부 API verdict 수신 처리
  */
 
+var prTracking = agentdesk.prTracking;
+
 function sendDiscordReview(target, content, bot) {
   agentdesk.message.queue(target, content, bot || "announce", "system");
 }
@@ -420,8 +422,7 @@ function firstPresent() {
 }
 
 function extractRepoFromIssueUrl(url) {
-  var match = String(url || "").match(/github\.com\/([^/]+\/[^/]+)/);
-  return match ? match[1] : null;
+  return prTracking.extractRepoFromIssueUrl(url);
 }
 
 function loadLatestCompletedWorkTarget(cardId) {
@@ -480,53 +481,15 @@ function loadLatestCompletedWorkTarget(cardId) {
 }
 
 function loadPrTracking(cardId) {
-  var rows = agentdesk.db.query(
-    "SELECT card_id, repo_id, worktree_path, branch, pr_number, head_sha, state, last_error " +
-    "FROM pr_tracking WHERE card_id = ?",
-    [cardId]
-  );
-  return rows.length > 0 ? rows[0] : null;
+  return prTracking.load(cardId);
 }
 
 function upsertPrTracking(cardId, repoId, worktreePath, branch, prNumber, headSha, state, lastError) {
-  agentdesk.db.execute(
-    "INSERT INTO pr_tracking (card_id, repo_id, worktree_path, branch, pr_number, head_sha, state, last_error, created_at, updated_at) " +
-    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now')) " +
-    "ON CONFLICT(card_id) DO UPDATE SET " +
-    "repo_id = COALESCE(excluded.repo_id, pr_tracking.repo_id), " +
-    "worktree_path = COALESCE(excluded.worktree_path, pr_tracking.worktree_path), " +
-    "branch = COALESCE(excluded.branch, pr_tracking.branch), " +
-    "pr_number = COALESCE(excluded.pr_number, pr_tracking.pr_number), " +
-    "head_sha = COALESCE(excluded.head_sha, pr_tracking.head_sha), " +
-    "state = COALESCE(excluded.state, pr_tracking.state), " +
-    "last_error = excluded.last_error, " +
-    "updated_at = datetime('now')",
-    [cardId, repoId, worktreePath, branch, prNumber, headSha, state, lastError]
-  );
+  return prTracking.upsert(cardId, repoId, worktreePath, branch, prNumber, headSha, state, lastError);
 }
 
 function findOpenPrByTrackedBranch(repoId, branch) {
-  if (!repoId || !branch) return null;
-  var prJson = agentdesk.exec("gh", [
-    "pr", "list",
-    "--head", branch,
-    "--state", "open",
-    "--json", "number,headRefName,headRefOid",
-    "--limit", "1",
-    "--repo", repoId
-  ]);
-  if (!prJson || prJson.indexOf("ERROR") === 0) return null;
-  try {
-    var prs = JSON.parse(prJson);
-    if (!prs || prs.length === 0) return null;
-    return {
-      number: prs[0].number,
-      branch: prs[0].headRefName,
-      sha: prs[0].headRefOid
-    };
-  } catch (e) {
-    return null;
-  }
+  return prTracking.findOpenPrByBranch(repoId, branch);
 }
 
 function processVerdict(cardId, verdict, result) {

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -3422,6 +3422,71 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn scenario_389_legacy_wait_ci_tracking_imports_into_canonical_lifecycle() {
+        let _gh = install_mock_gh(&[
+            MockGhReply {
+                key: "pr:list",
+                contains: Some("--head wt/card-389"),
+                stdout: "[{\"number\":389,\"headRefName\":\"wt/card-389\",\"headRefOid\":\"eee5555\"}]",
+            },
+            MockGhReply {
+                key: "pr:view",
+                contains: Some("--json headRefOid"),
+                stdout: "eee5555",
+            },
+            MockGhReply {
+                key: "run:list",
+                contains: Some("--branch wt/card-389"),
+                stdout: "[{\"databaseId\":839,\"status\":\"completed\",\"conclusion\":\"success\",\"headSha\":\"eee5555\",\"event\":\"pull_request\"}]",
+            },
+        ]);
+
+        let db = test_db();
+        let engine = test_engine(&db);
+        seed_agent(&db);
+        seed_repo(&db, "test/repo");
+        seed_card_with_repo(&db, "card-389", "review", "test/repo", 389, None);
+        seed_completed_review_dispatch(&db, "review-389-pass", "card-389", "pass");
+        {
+            let conn = db.lock().unwrap();
+            conn.execute(
+                "UPDATE kanban_cards SET blocked_reason = 'ci:waiting' WHERE id = 'card-389'",
+                [],
+            )
+            .unwrap();
+        }
+        set_kv(
+            &db,
+            "pr:card-389",
+            r#"{"number":389,"repo":"test/repo","branch":"wt/card-389"}"#,
+        );
+
+        engine
+            .try_fire_hook_by_name("OnTick1min", serde_json::json!({}))
+            .unwrap();
+        kanban::drain_hook_side_effects(&db, &engine);
+
+        assert_eq!(pr_tracking_state(&db, "card-389").as_deref(), Some("merge"));
+        assert_eq!(pr_tracking_pr_number(&db, "card-389"), Some(389));
+        assert_eq!(
+            pr_tracking_branch(&db, "card-389").as_deref(),
+            Some("wt/card-389")
+        );
+        assert_eq!(get_card_status(&db, "card-389"), "done");
+
+        let conn = db.lock().unwrap();
+        let blocked_reason: Option<String> = conn
+            .query_row(
+                "SELECT blocked_reason FROM kanban_cards WHERE id = 'card-389'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(blocked_reason, None);
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn scenario_208_on_tick_creates_codex_rework_and_dedups_review() {
         let _gh = install_mock_gh(&[
             MockGhReply {

--- a/src/server/routes/review_verdict/tests.rs
+++ b/src/server/routes/review_verdict/tests.rs
@@ -786,6 +786,7 @@ async fn accept_on_done_card_fails_closed_without_stranding() {
 
 #[tokio::test]
 async fn accept_skip_rework_falls_back_to_rework_when_direct_review_creates_no_dispatch() {
+    let _env_lock = crate::services::discord::runtime_store::lock_test_env();
     let _worktree_override = WorktreeCommitOverrideGuard::set("bbb2222");
     let db = test_db();
     let engine = test_engine(&db);
@@ -1529,6 +1530,7 @@ fn latest_completed_review_lookup_prefers_completed_at() {
 /// review_status='reviewing'. The accept cleanup must NOT clear it.
 #[tokio::test]
 async fn accept_direct_review_preserves_reviewing_status() {
+    let _env_lock = crate::services::discord::runtime_store::lock_test_env();
     let _worktree_override = WorktreeCommitOverrideGuard::set("bbb2222");
     let db = test_db();
     {


### PR DESCRIPTION
Closes #389

## Summary
- centralize canonical PR tracking and legacy import helpers into a shared policy path
- stop repeated steady-state scans of legacy `kv_meta` `pr:*` rows while preserving backward compatibility
- add regression coverage for the canonical lifecycle with legacy-only PR metadata

## Testing
- `cargo test`