### PR TITLE
#517 feat: 연속 메시지 큐 병합 — 답장 경계 기준 자동 합침

### DIFF
--- a/src/services/discord/commands/skill.rs
+++ b/src/services/discord/commands/skill.rs
@@ -262,6 +262,7 @@ pub(in crate::services::discord) async fn cmd_cc(
             false,
             false,
             false,
+            false,
             None,
         )
         .await?;
@@ -319,6 +320,7 @@ pub(in crate::services::discord) async fn cmd_cc(
         &skill_prompt,
         &ctx.data().shared,
         &ctx.data().token,
+        false,
         false,
         false,
         false,

--- a/src/services/discord/gateway.rs
+++ b/src/services/discord/gateway.rs
@@ -8,7 +8,7 @@ use serenity::{ChannelId, MessageId, UserId};
 use super::router::handle_text_message;
 use super::turn_bridge::auto_retry_with_history;
 use super::{
-    SharedData, formatting, rate_limit_wait, resolve_discord_bot_provider,
+    Intervention, SharedData, formatting, rate_limit_wait, resolve_discord_bot_provider,
     validate_live_channel_routing,
 };
 use crate::services::provider::ProviderKind;
@@ -54,9 +54,8 @@ pub(super) trait TurnGateway: Send + Sync {
     fn dispatch_queued_turn<'a>(
         &'a self,
         channel_id: ChannelId,
-        message_id: MessageId,
+        intervention: &'a Intervention,
         request_owner_name: &'a str,
-        text: &'a str,
         has_more_queued_turns: bool,
     ) -> GatewayFuture<'a, Result<(), String>>;
 
@@ -186,9 +185,8 @@ impl TurnGateway for DiscordGateway {
     fn dispatch_queued_turn<'a>(
         &'a self,
         channel_id: ChannelId,
-        message_id: MessageId,
+        intervention: &'a Intervention,
         request_owner_name: &'a str,
-        text: &'a str,
         has_more_queued_turns: bool,
     ) -> GatewayFuture<'a, Result<(), String>> {
         Box::pin(async move {
@@ -196,20 +194,22 @@ impl TurnGateway for DiscordGateway {
                 return Err("missing live Discord context".to_string());
             };
 
-            formatting::remove_reaction_raw(&self.http, channel_id, message_id, '📬').await;
+            for message_id in &intervention.source_message_ids {
+                formatting::remove_reaction_raw(&self.http, channel_id, *message_id, '📬').await;
+            }
             handle_text_message(
                 &live_turn.ctx,
                 channel_id,
-                message_id,
+                intervention.message_id,
                 live_turn.request_owner,
                 request_owner_name,
-                text,
+                &intervention.text,
                 &self.shared,
                 &live_turn.token,
                 true,
                 has_more_queued_turns,
                 true,
-                None,
+                intervention.reply_context.clone(),
             )
             .await
             .map_err(|e| e.to_string())

--- a/src/services/discord/gateway.rs
+++ b/src/services/discord/gateway.rs
@@ -209,6 +209,7 @@ impl TurnGateway for DiscordGateway {
                 true,
                 has_more_queued_turns,
                 true,
+                intervention.merge_consecutive,
                 intervention.reply_context.clone(),
             )
             .await

--- a/src/services/discord/health.rs
+++ b/src/services/discord/health.rs
@@ -827,9 +827,13 @@ impl TestHealthHarness {
             .map(|idx| super::Intervention {
                 author_id: serenity::UserId::new(idx as u64 + 1),
                 message_id: serenity::MessageId::new(idx as u64 + 1),
+                source_message_ids: vec![serenity::MessageId::new(idx as u64 + 1)],
                 text: format!("queued-{idx}"),
                 mode: super::InterventionMode::Soft,
                 created_at: Instant::now(),
+                reply_context: None,
+                has_reply_boundary: false,
+                merge_consecutive: false,
             })
             .collect::<Vec<_>>();
         super::mailbox_replace_queue(&self.shared, &provider, ChannelId::new(channel_id), queue)
@@ -923,9 +927,13 @@ impl TestHealthHarness {
             .map(|(message_id, text)| super::Intervention {
                 author_id: serenity::UserId::new(1),
                 message_id: serenity::MessageId::new(*message_id),
+                source_message_ids: vec![serenity::MessageId::new(*message_id)],
                 text: (*text).to_string(),
                 mode: super::InterventionMode::Soft,
                 created_at: Instant::now(),
+                reply_context: None,
+                has_reply_boundary: false,
+                merge_consecutive: false,
             })
             .collect::<Vec<_>>();
         super::mailbox_replace_queue(

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -155,11 +155,15 @@ pub(in crate::services::discord) fn should_phase2_recover_message(
 pub(in crate::services::discord) fn recovery_known_message_ids(
     snapshot: &ChannelMailboxSnapshot,
 ) -> std::collections::HashSet<u64> {
-    let mut ids = snapshot
-        .intervention_queue
-        .iter()
-        .map(|item| item.message_id.get())
-        .collect::<std::collections::HashSet<_>>();
+    let mut ids = std::collections::HashSet::new();
+    for item in &snapshot.intervention_queue {
+        ids.insert(item.message_id.get());
+        ids.extend(
+            item.source_message_ids
+                .iter()
+                .map(|message_id| message_id.get()),
+        );
+    }
     if let Some(active_id) = snapshot.active_user_message_id {
         ids.insert(active_id.get());
     }
@@ -633,9 +637,13 @@ async fn enqueue_internal_followup(
         Intervention {
             author_id: UserId::new(1),
             message_id: reply_message_id,
+            source_message_ids: vec![reply_message_id],
             text: text.into(),
             mode: InterventionMode::Soft,
             created_at: Instant::now(),
+            reply_context: None,
+            has_reply_boundary: false,
+            merge_consecutive: false,
         },
     )
     .await;
@@ -971,9 +979,16 @@ async fn catch_up_missed_messages(
                 Intervention {
                     author_id: msg.author.id,
                     message_id: msg.id,
+                    source_message_ids: vec![msg.id],
                     text: text.to_string(),
                     mode: InterventionMode::Soft,
                     created_at: now,
+                    reply_context: None,
+                    has_reply_boundary: msg.message_reference.is_some(),
+                    merge_consecutive: !msg.author.bot
+                        && !text.starts_with('!')
+                        && !text.starts_with('/')
+                        && !text.starts_with("DISPATCH:"),
                 },
             )
             .await;
@@ -1124,9 +1139,16 @@ async fn catch_up_missed_messages(
                 Intervention {
                     author_id: msg.author.id,
                     message_id: msg.id,
+                    source_message_ids: vec![msg.id],
                     text: text.to_string(),
                     mode: InterventionMode::Soft,
                     created_at: now,
+                    reply_context: None,
+                    has_reply_boundary: msg.message_reference.is_some(),
+                    merge_consecutive: !msg.author.bot
+                        && !text.starts_with('!')
+                        && !text.starts_with('/')
+                        && !text.starts_with("DISPATCH:"),
                 },
             )
             .await;
@@ -1805,14 +1827,19 @@ mod tests {
             intervention_queue: vec![Intervention {
                 author_id: UserId::new(42),
                 message_id: MessageId::new(100),
+                source_message_ids: vec![MessageId::new(90), MessageId::new(100)],
                 text: "queued".to_string(),
                 mode: InterventionMode::Soft,
                 created_at: Instant::now(),
+                reply_context: None,
+                has_reply_boundary: false,
+                merge_consecutive: false,
             }],
             ..Default::default()
         };
 
         let existing = recovery_known_message_ids(&snapshot);
+        assert!(existing.contains(&90));
         assert!(existing.contains(&100));
         assert!(existing.contains(&200));
         assert!(!should_phase2_recover_message(200, None, &existing));

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -1263,7 +1263,8 @@ pub(super) async fn kickoff_idle_queues(
             true,     // reply_to_user_message
             has_more, // defer_watcher_resume
             false,    // wait_for_completion — don't block, let channels run concurrently
-            None,     // reply_context
+            intervention.merge_consecutive,
+            None, // reply_context
         )
         .await
         {

--- a/src/services/discord/queue_io.rs
+++ b/src/services/discord/queue_io.rs
@@ -117,9 +117,13 @@ mod tests {
         Intervention {
             author_id: UserId::new(1),
             message_id: MessageId::new(100),
+            source_message_ids: vec![MessageId::new(100)],
             text: text.to_string(),
             mode: InterventionMode::Soft,
             created_at: Instant::now(),
+            reply_context: None,
+            has_reply_boundary: false,
+            merge_consecutive: false,
         }
     }
 
@@ -139,9 +143,13 @@ mod tests {
             vec![Intervention {
                 author_id: UserId::new(42),
                 message_id: MessageId::new(7),
+                source_message_ids: vec![MessageId::new(7)],
                 text: "pending".to_string(),
                 mode: InterventionMode::Soft,
                 created_at,
+                reply_context: None,
+                has_reply_boundary: false,
+                merge_consecutive: false,
             }],
         );
 
@@ -163,9 +171,13 @@ mod tests {
             vec![Intervention {
                 author_id: UserId::new(42),
                 message_id: MessageId::new(7),
+                source_message_ids: vec![MessageId::new(7)],
                 text: "stale".to_string(),
                 mode: InterventionMode::Soft,
                 created_at,
+                reply_context: None,
+                has_reply_boundary: false,
+                merge_consecutive: false,
             }],
         );
 
@@ -186,9 +198,13 @@ mod tests {
             vec![Intervention {
                 author_id: UserId::new(42),
                 message_id: MessageId::new(7),
+                source_message_ids: vec![MessageId::new(7)],
                 text: "pending".to_string(),
                 mode: InterventionMode::Soft,
                 created_at: Instant::now(),
+                reply_context: None,
+                has_reply_boundary: false,
+                merge_consecutive: false,
             }],
         );
 
@@ -383,6 +399,10 @@ mod tests {
         let old_json = r#"[{"author_id":1,"message_id":100,"text":"hello"}]"#;
         let items: Vec<PendingQueueItem> = serde_json::from_str(old_json).unwrap();
         assert_eq!(items[0].text, "hello");
+        assert!(items[0].source_message_ids.is_empty());
+        assert!(items[0].reply_context.is_none());
+        assert!(!items[0].has_reply_boundary);
+        assert!(!items[0].merge_consecutive);
         assert!(items[0].channel_id.is_none());
         assert!(items[0].channel_name.is_none());
         assert!(items[0].override_channel_id.is_none());
@@ -390,13 +410,21 @@ mod tests {
         let new_item = PendingQueueItem {
             author_id: 1,
             message_id: 100,
+            source_message_ids: vec![100, 101],
             text: "hello".to_string(),
+            reply_context: Some("[Reply context]".to_string()),
+            has_reply_boundary: true,
+            merge_consecutive: true,
             channel_id: Some(42),
             channel_name: Some("test-channel".to_string()),
             override_channel_id: None,
         };
         let json = serde_json::to_string(&new_item).unwrap();
         let parsed: PendingQueueItem = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.source_message_ids, vec![100, 101]);
+        assert_eq!(parsed.reply_context.as_deref(), Some("[Reply context]"));
+        assert!(parsed.has_reply_boundary);
+        assert!(parsed.merge_consecutive);
         assert_eq!(parsed.channel_id, Some(42));
         assert_eq!(parsed.channel_name.as_deref(), Some("test-channel"));
     }
@@ -511,7 +539,11 @@ mod tests {
         let item = PendingQueueItem {
             author_id: 1,
             message_id: 100,
+            source_message_ids: vec![100],
             text: "legacy msg".to_string(),
+            reply_context: None,
+            has_reply_boundary: false,
+            merge_consecutive: false,
             channel_id: None,
             channel_name: None,
             override_channel_id: None,

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -30,13 +30,20 @@ fn build_soft_intervention(
     author_id: serenity::UserId,
     message_id: serenity::MessageId,
     text: &str,
+    reply_context: Option<String>,
+    has_reply_boundary: bool,
+    merge_consecutive: bool,
 ) -> Intervention {
     Intervention {
         author_id,
         message_id,
+        source_message_ids: vec![message_id],
         text: text.to_string(),
         mode: InterventionMode::Soft,
         created_at: Instant::now(),
+        reply_context,
+        has_reply_boundary,
+        merge_consecutive,
     }
 }
 
@@ -46,14 +53,93 @@ async fn enqueue_soft_intervention(
     author_id: serenity::UserId,
     message_id: serenity::MessageId,
     text: &str,
+    reply_context: Option<String>,
+    has_reply_boundary: bool,
+    merge_consecutive: bool,
 ) -> bool {
     mailbox_enqueue_intervention(
         &data.shared,
         &data.provider,
         channel_id,
-        build_soft_intervention(author_id, message_id, text),
+        build_soft_intervention(
+            author_id,
+            message_id,
+            text,
+            reply_context,
+            has_reply_boundary,
+            merge_consecutive,
+        ),
     )
     .await
+}
+
+fn should_merge_consecutive_messages(text: &str, is_allowed_bot: bool) -> bool {
+    !is_allowed_bot
+        && !text.starts_with('!')
+        && !text.starts_with('/')
+        && !text.starts_with("DISPATCH:")
+}
+
+async fn build_reply_context(
+    ctx: &serenity::Context,
+    channel_id: serenity::ChannelId,
+    new_message: &serenity::Message,
+) -> Option<String> {
+    let ref_msg = new_message.referenced_message.as_ref()?;
+    let ref_author = &ref_msg.author.name;
+    let ref_content = ref_msg.content.trim();
+    let ref_text = if ref_content.is_empty() {
+        format!("[Reply to {}'s message (no text content)]", ref_author)
+    } else {
+        let truncated = truncate_str(ref_content, 500);
+        format!(
+            "[Reply context]\nAuthor: {}\nContent: {}",
+            ref_author, truncated
+        )
+    };
+
+    let mut context_parts = Vec::new();
+    if let Ok(preceding) = channel_id
+        .messages(
+            &ctx.http,
+            serenity::builder::GetMessages::new()
+                .before(ref_msg.id)
+                .limit(4),
+        )
+        .await
+    {
+        let mut msgs: Vec<_> = preceding
+            .iter()
+            .filter(|m| !m.content.trim().is_empty())
+            .collect();
+        msgs.reverse();
+        let mut budget: usize = 1000;
+        for m in msgs
+            .iter()
+            .rev()
+            .take(4)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+        {
+            let entry = format!("{}: {}", m.author.name, truncate_str(m.content.trim(), 300));
+            if entry.len() > budget {
+                break;
+            }
+            budget -= entry.len();
+            context_parts.push(entry);
+        }
+    }
+
+    if context_parts.is_empty() {
+        Some(ref_text)
+    } else {
+        let preceding_ctx = context_parts.join("\n");
+        Some(format!(
+            "[Reply context — preceding conversation]\n{}\n\n{}",
+            preceding_ctx, ref_text
+        ))
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -562,6 +648,14 @@ pub(in crate::services::discord) async fn handle_event(
                 }
             }
 
+            let has_reply_boundary = new_message.message_reference.is_some();
+            let reply_context = if has_reply_boundary {
+                build_reply_context(ctx, channel_id, &new_message).await
+            } else {
+                None
+            };
+            let merge_consecutive = should_merge_consecutive_messages(text, is_allowed_bot);
+
             // ── Dispatch-thread guard ─────────────────────────────────
             // When a dispatch thread is active for this channel, bot messages
             // to the parent channel are queued so they don't start a parallel
@@ -585,6 +679,9 @@ pub(in crate::services::discord) async fn handle_event(
                             user_id,
                             new_message.id,
                             text,
+                            None,
+                            false,
+                            false,
                         )
                         .await;
                         add_reaction(ctx, channel_id, new_message.id, '📬').await;
@@ -606,9 +703,17 @@ pub(in crate::services::discord) async fn handle_event(
             // placeholder.
             if text.starts_with("DISPATCH:") {
                 if mailbox_has_active_turn(&data.shared, channel_id).await {
-                    let _ =
-                        enqueue_soft_intervention(data, channel_id, user_id, new_message.id, text)
-                            .await;
+                    let _ = enqueue_soft_intervention(
+                        data,
+                        channel_id,
+                        user_id,
+                        new_message.id,
+                        text,
+                        None,
+                        false,
+                        false,
+                    )
+                    .await;
                     let ts = chrono::Local::now().format("%H:%M:%S");
                     tracing::info!(
                         "  [{ts}] 📬 DISPATCH-GUARD: queued dispatch message in channel {} (active turn in progress)",
@@ -625,9 +730,17 @@ pub(in crate::services::discord) async fn handle_event(
 
             // Queue messages while AI is in progress (executed as next turn after current finishes)
             if mailbox_has_active_turn(&data.shared, channel_id).await {
-                let inserted =
-                    enqueue_soft_intervention(data, channel_id, user_id, new_message.id, text)
-                        .await;
+                let inserted = enqueue_soft_intervention(
+                    data,
+                    channel_id,
+                    user_id,
+                    new_message.id,
+                    text,
+                    reply_context.clone(),
+                    has_reply_boundary,
+                    merge_consecutive,
+                )
+                .await;
                 let is_shutting_down = data
                     .shared
                     .shutting_down
@@ -666,8 +779,17 @@ pub(in crate::services::discord) async fn handle_event(
                 .reconcile_done
                 .load(std::sync::atomic::Ordering::Relaxed)
             {
-                let _ = enqueue_soft_intervention(data, channel_id, user_id, new_message.id, text)
-                    .await;
+                let _ = enqueue_soft_intervention(
+                    data,
+                    channel_id,
+                    user_id,
+                    new_message.id,
+                    text,
+                    reply_context.clone(),
+                    has_reply_boundary,
+                    merge_consecutive,
+                )
+                .await;
                 // Checkpoint: track last processed message
                 data.shared
                     .last_message_ids
@@ -688,8 +810,17 @@ pub(in crate::services::discord) async fn handle_event(
                     .shutting_down
                     .load(std::sync::atomic::Ordering::Relaxed);
 
-                let _ = enqueue_soft_intervention(data, channel_id, user_id, new_message.id, text)
-                    .await;
+                let _ = enqueue_soft_intervention(
+                    data,
+                    channel_id,
+                    user_id,
+                    new_message.id,
+                    text,
+                    reply_context.clone(),
+                    has_reply_boundary,
+                    merge_consecutive,
+                )
+                .await;
 
                 let ts = chrono::Local::now().format("%H:%M:%S");
                 tracing::info!(
@@ -740,8 +871,17 @@ pub(in crate::services::discord) async fn handle_event(
                     None
                 } else {
                     Some(
-                        enqueue_soft_intervention(data, channel_id, user_id, new_message.id, text)
-                            .await,
+                        enqueue_soft_intervention(
+                            data,
+                            channel_id,
+                            user_id,
+                            new_message.id,
+                            text,
+                            reply_context.clone(),
+                            has_reply_boundary,
+                            merge_consecutive,
+                        )
+                        .await,
                     )
                 }
             };
@@ -804,70 +944,6 @@ pub(in crate::services::discord) async fn handle_event(
             let ts = chrono::Local::now().format("%H:%M:%S");
             let preview = truncate_str(text, 60);
             tracing::info!("  [{ts}] ◀ [{user_name}] {preview}");
-
-            // Extract reply context if user replied to another message
-            let reply_context = if let Some(ref_msg) = new_message.referenced_message.as_ref() {
-                let ref_author = &ref_msg.author.name;
-                let ref_content = ref_msg.content.trim();
-                let ref_text = if ref_content.is_empty() {
-                    format!("[Reply to {}'s message (no text content)]", ref_author)
-                } else {
-                    let truncated = truncate_str(ref_content, 500);
-                    format!(
-                        "[Reply context]\nAuthor: {}\nContent: {}",
-                        ref_author, truncated
-                    )
-                };
-
-                // Fetch preceding messages for Q&A context (best-effort)
-                let mut context_parts = Vec::new();
-                if let Ok(preceding) = channel_id
-                    .messages(
-                        &ctx.http,
-                        serenity::builder::GetMessages::new()
-                            .before(ref_msg.id)
-                            .limit(4),
-                    )
-                    .await
-                {
-                    // preceding comes newest-first; reverse for chronological order
-                    let mut msgs: Vec<_> = preceding
-                        .iter()
-                        .filter(|m| !m.content.trim().is_empty())
-                        .collect();
-                    msgs.reverse();
-                    // Keep last 2 Q&A-style messages (budget: ~1000 chars total)
-                    let mut budget: usize = 1000;
-                    for m in msgs
-                        .iter()
-                        .rev()
-                        .take(4)
-                        .collect::<Vec<_>>()
-                        .into_iter()
-                        .rev()
-                    {
-                        let entry =
-                            format!("{}: {}", m.author.name, truncate_str(m.content.trim(), 300));
-                        if entry.len() > budget {
-                            break;
-                        }
-                        budget -= entry.len();
-                        context_parts.push(entry);
-                    }
-                }
-
-                if context_parts.is_empty() {
-                    Some(ref_text)
-                } else {
-                    let preceding_ctx = context_parts.join("\n");
-                    Some(format!(
-                        "[Reply context — preceding conversation]\n{}\n\n{}",
-                        preceding_ctx, ref_text
-                    ))
-                }
-            } else {
-                None
-            };
 
             // Checkpoint: message about to be processed as a turn
             data.shared

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -962,6 +962,7 @@ pub(in crate::services::discord) async fn handle_event(
                 false,
                 false,
                 false,
+                merge_consecutive,
                 reply_context,
             )
             .await?;

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -174,6 +174,28 @@ fn session_runtime_state_after_redirect(
     load_session_runtime_state(sessions, effective_channel_id).unwrap_or(original_state)
 }
 
+fn build_race_requeued_intervention(
+    request_owner: UserId,
+    user_msg_id: MessageId,
+    user_text: &str,
+    reply_context: Option<String>,
+    reply_to_user_message: bool,
+) -> Intervention {
+    Intervention {
+        author_id: request_owner,
+        message_id: user_msg_id,
+        source_message_ids: vec![user_msg_id],
+        text: user_text.to_string(),
+        mode: super::super::InterventionMode::Soft,
+        created_at: std::time::Instant::now(),
+        reply_context,
+        has_reply_boundary: reply_to_user_message,
+        merge_consecutive: !user_text.starts_with('!')
+            && !user_text.starts_with('/')
+            && !user_text.starts_with("DISPATCH:"),
+    }
+}
+
 pub(in crate::services::discord) async fn handle_text_message(
     ctx: &serenity::Context,
     channel_id: ChannelId,
@@ -735,19 +757,13 @@ pub(in crate::services::discord) async fn handle_text_message(
             shared,
             &bot_owner_provider,
             channel_id,
-            super::super::Intervention {
-                author_id: request_owner,
-                message_id: user_msg_id,
-                source_message_ids: vec![user_msg_id],
-                text: user_text.to_string(),
-                mode: super::super::InterventionMode::Soft,
-                created_at: std::time::Instant::now(),
-                reply_context: reply_context.clone(),
-                has_reply_boundary: reply_context.is_some(),
-                merge_consecutive: !user_text.starts_with('!')
-                    && !user_text.starts_with('/')
-                    && !user_text.starts_with("DISPATCH:"),
-            },
+            build_race_requeued_intervention(
+                request_owner,
+                user_msg_id,
+                user_text,
+                reply_context.clone(),
+                reply_to_user_message,
+            ),
         )
         .await;
         // Clean up: remove placeholder and reaction created before this check
@@ -2810,7 +2826,7 @@ mod tests {
     use super::super::super::DiscordSession;
     use super::*;
     use crate::services::memory::RecallResponse;
-    use poise::serenity_prelude::ChannelId;
+    use poise::serenity_prelude::{ChannelId, MessageId, UserId};
 
     fn sample_recall() -> RecallResponse {
         RecallResponse {
@@ -3059,5 +3075,20 @@ mod tests {
         );
 
         assert_eq!(resolved, original);
+    }
+
+    #[test]
+    fn race_requeue_preserves_reply_boundary_without_reply_context() {
+        let queued = build_race_requeued_intervention(
+            UserId::new(7),
+            MessageId::new(8),
+            "hello",
+            None,
+            true,
+        );
+
+        assert!(queued.has_reply_boundary);
+        assert!(queued.reply_context.is_none());
+        assert!(queued.merge_consecutive);
     }
 }

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -738,9 +738,15 @@ pub(in crate::services::discord) async fn handle_text_message(
             super::super::Intervention {
                 author_id: request_owner,
                 message_id: user_msg_id,
+                source_message_ids: vec![user_msg_id],
                 text: user_text.to_string(),
                 mode: super::super::InterventionMode::Soft,
                 created_at: std::time::Instant::now(),
+                reply_context: reply_context.clone(),
+                has_reply_boundary: reply_context.is_some(),
+                merge_consecutive: !user_text.starts_with('!')
+                    && !user_text.starts_with('/')
+                    && !user_text.starts_with("DISPATCH:"),
             },
         )
         .await;

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -180,6 +180,7 @@ fn build_race_requeued_intervention(
     user_text: &str,
     reply_context: Option<String>,
     reply_to_user_message: bool,
+    merge_consecutive: bool,
 ) -> Intervention {
     Intervention {
         author_id: request_owner,
@@ -190,9 +191,7 @@ fn build_race_requeued_intervention(
         created_at: std::time::Instant::now(),
         reply_context,
         has_reply_boundary: reply_to_user_message,
-        merge_consecutive: !user_text.starts_with('!')
-            && !user_text.starts_with('/')
-            && !user_text.starts_with("DISPATCH:"),
+        merge_consecutive,
     }
 }
 
@@ -208,6 +207,7 @@ pub(in crate::services::discord) async fn handle_text_message(
     reply_to_user_message: bool,
     defer_watcher_resume: bool,
     wait_for_completion: bool,
+    merge_consecutive: bool,
     reply_context: Option<String>,
 ) -> Result<(), Error> {
     let original_channel_id = channel_id;
@@ -763,6 +763,7 @@ pub(in crate::services::discord) async fn handle_text_message(
                 user_text,
                 reply_context.clone(),
                 reply_to_user_message,
+                merge_consecutive,
             ),
         )
         .await;
@@ -2810,6 +2811,7 @@ Any other message is sent to {p}.
                 false,
                 false,
                 false,
+                false,
                 None,
             )
             .await?;
@@ -3085,10 +3087,26 @@ mod tests {
             "hello",
             None,
             true,
+            true,
         );
 
         assert!(queued.has_reply_boundary);
         assert!(queued.reply_context.is_none());
         assert!(queued.merge_consecutive);
+    }
+
+    #[test]
+    fn race_requeue_preserves_non_mergeable_turns() {
+        let queued = build_race_requeued_intervention(
+            UserId::new(7),
+            MessageId::new(8),
+            "hello",
+            None,
+            false,
+            false,
+        );
+
+        assert!(!queued.has_reply_boundary);
+        assert!(!queued.merge_consecutive);
     }
 }

--- a/src/services/discord/runtime_bootstrap.rs
+++ b/src/services/discord/runtime_bootstrap.rs
@@ -188,9 +188,13 @@ async fn execute_handoff_turns(
             Intervention {
                 author_id: serenity::UserId::new(1), // system-generated sentinel
                 message_id: placeholder.id,
+                source_message_ids: vec![placeholder.id],
                 text: handoff_prompt,
                 mode: InterventionMode::Soft,
                 created_at: Instant::now(),
+                reply_context: None,
+                has_reply_boundary: false,
+                merge_consecutive: false,
             },
         )
         .await;
@@ -801,11 +805,22 @@ pub(crate) async fn run_bot(token: &str, provider: ProviderKind, context: RunBot
                                         skipped += 1;
                                         continue;
                                     }
-                                    if existing_ids.insert(item.message_id.get()) {
+                                    let mut item_ids: Vec<u64> =
+                                        item.source_message_ids.iter().map(|id| id.get()).collect();
+                                    if item_ids.is_empty() {
+                                        item_ids.push(item.message_id.get());
+                                    } else if !item_ids.contains(&item.message_id.get()) {
+                                        item_ids.push(item.message_id.get());
+                                    }
+                                    if item_ids
+                                        .iter()
+                                        .any(|message_id| existing_ids.contains(message_id))
+                                    {
+                                        skipped += 1;
+                                    } else {
+                                        existing_ids.extend(item_ids);
                                         queue.push(item);
                                         added += 1;
-                                    } else {
-                                        skipped += 1;
                                     }
                                 }
                                 mailbox_replace_queue(

--- a/src/services/discord/runtime_bootstrap.rs
+++ b/src/services/discord/runtime_bootstrap.rs
@@ -10,6 +10,37 @@ pub(crate) struct RunBotContext {
     pub(crate) engine: Option<crate::engine::PolicyEngine>,
 }
 
+fn restored_intervention_message_ids(item: &Intervention) -> Vec<u64> {
+    let mut item_ids: Vec<u64> = item.source_message_ids.iter().map(|id| id.get()).collect();
+    if item_ids.is_empty() {
+        item_ids.push(item.message_id.get());
+    } else if !item_ids.contains(&item.message_id.get()) {
+        item_ids.push(item.message_id.get());
+    }
+    item_ids
+}
+
+fn enqueue_restored_intervention(
+    existing_ids: &mut std::collections::HashSet<u64>,
+    queue: &mut Vec<Intervention>,
+    item: Intervention,
+) -> bool {
+    let item_ids = restored_intervention_message_ids(&item);
+    // Persisted merged queue items may represent multiple source messages. If startup
+    // catch-up already recovered only some of them, dropping the whole item would lose
+    // the unseen messages because the merged text is no longer separable.
+    if item_ids
+        .iter()
+        .all(|message_id| existing_ids.contains(message_id))
+    {
+        return false;
+    }
+
+    existing_ids.extend(item_ids);
+    queue.push(item);
+    true
+}
+
 fn spawn_startup_thread_map_validation(db: crate::db::Db, token: String) {
     tokio::spawn(async move {
         let (checked, cleared) =
@@ -805,22 +836,14 @@ pub(crate) async fn run_bot(token: &str, provider: ProviderKind, context: RunBot
                                         skipped += 1;
                                         continue;
                                     }
-                                    let mut item_ids: Vec<u64> =
-                                        item.source_message_ids.iter().map(|id| id.get()).collect();
-                                    if item_ids.is_empty() {
-                                        item_ids.push(item.message_id.get());
-                                    } else if !item_ids.contains(&item.message_id.get()) {
-                                        item_ids.push(item.message_id.get());
-                                    }
-                                    if item_ids
-                                        .iter()
-                                        .any(|message_id| existing_ids.contains(message_id))
-                                    {
-                                        skipped += 1;
-                                    } else {
-                                        existing_ids.extend(item_ids);
-                                        queue.push(item);
+                                    if enqueue_restored_intervention(
+                                        &mut existing_ids,
+                                        &mut queue,
+                                        item,
+                                    ) {
                                         added += 1;
+                                    } else {
+                                        skipped += 1;
                                     }
                                 }
                                 mailbox_replace_queue(
@@ -1273,5 +1296,61 @@ async fn gc_stale_fixed_working_sessions(shared: &Arc<SharedData>) {
         tracing::info!(
             "  [{ts}] 🧹 GC: disconnected {cleared} stale fixed-channel working session(s)"
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use poise::serenity_prelude::{MessageId, UserId};
+    use std::collections::HashSet;
+    use std::time::Instant;
+
+    fn make_intervention(message_id: u64, source_message_ids: &[u64], text: &str) -> Intervention {
+        Intervention {
+            author_id: UserId::new(42),
+            message_id: MessageId::new(message_id),
+            source_message_ids: source_message_ids
+                .iter()
+                .copied()
+                .map(MessageId::new)
+                .collect(),
+            text: text.to_string(),
+            mode: InterventionMode::Soft,
+            created_at: Instant::now(),
+            reply_context: None,
+            has_reply_boundary: false,
+            merge_consecutive: true,
+        }
+    }
+
+    #[test]
+    fn enqueue_restored_intervention_keeps_partially_overlapping_merged_item() {
+        let mut existing_ids = HashSet::from([100u64]);
+        let mut queue = Vec::new();
+
+        assert!(enqueue_restored_intervention(
+            &mut existing_ids,
+            &mut queue,
+            make_intervention(101, &[100, 101], "first\nsecond"),
+        ));
+
+        assert_eq!(queue.len(), 1);
+        assert!(existing_ids.contains(&100));
+        assert!(existing_ids.contains(&101));
+    }
+
+    #[test]
+    fn enqueue_restored_intervention_skips_only_when_all_ids_are_known() {
+        let mut existing_ids = HashSet::from([100u64, 101u64]);
+        let mut queue = Vec::new();
+
+        assert!(!enqueue_restored_intervention(
+            &mut existing_ids,
+            &mut queue,
+            make_intervention(101, &[100, 101], "first\nsecond"),
+        ));
+
+        assert!(queue.is_empty());
     }
 }

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -570,9 +570,13 @@ pub(super) async fn start_restart_handoff_from_state(
             super::Intervention {
                 author_id,
                 message_id: placeholder_id,
+                source_message_ids: vec![placeholder_id],
                 text: handoff_prompt,
                 mode: super::InterventionMode::Soft,
                 created_at: std::time::Instant::now(),
+                reply_context: None,
+                has_reply_boundary: false,
+                merge_consecutive: false,
             },
         )
         .await;

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -539,6 +539,7 @@ pub(super) async fn start_restart_handoff_from_state(
             true,
             false,
             false,
+            false,
             None,
         )
         .await

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -1633,9 +1633,8 @@ pub(super) fn spawn_turn_bridge(
                         if let Err(e) = gateway
                             .dispatch_queued_turn(
                                 channel_id,
-                                intervention.message_id,
+                                &intervention,
                                 &request_owner_name,
-                                &intervention.text,
                                 has_more_queued_turns,
                             )
                             .await

--- a/src/services/turn_orchestrator.rs
+++ b/src/services/turn_orchestrator.rs
@@ -25,9 +25,13 @@ pub(crate) enum InterventionMode {
 pub(crate) struct Intervention {
     pub(crate) author_id: UserId,
     pub(crate) message_id: MessageId,
+    pub(crate) source_message_ids: Vec<MessageId>,
     pub(crate) text: String,
     pub(crate) mode: InterventionMode,
     pub(crate) created_at: Instant,
+    pub(crate) reply_context: Option<String>,
+    pub(crate) has_reply_boundary: bool,
+    pub(crate) merge_consecutive: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -73,19 +77,87 @@ fn prune_interventions(queue: &mut Vec<Intervention>) -> Vec<QueueExitEvent> {
     queue_exit_events
 }
 
+fn intervention_age_since(last: &Intervention, current: &Intervention) -> Duration {
+    current
+        .created_at
+        .checked_duration_since(last.created_at)
+        .unwrap_or_default()
+}
+
+fn ensure_source_message_ids(intervention: &mut Intervention) {
+    if intervention.source_message_ids.is_empty() {
+        intervention
+            .source_message_ids
+            .push(intervention.message_id);
+    }
+}
+
+fn push_unique_message_ids(
+    existing: &mut Vec<MessageId>,
+    incoming: impl IntoIterator<Item = MessageId>,
+) {
+    for message_id in incoming {
+        if !existing.contains(&message_id) {
+            existing.push(message_id);
+        }
+    }
+}
+
+fn should_merge_intervention(last: &Intervention, incoming: &Intervention) -> bool {
+    last.mode == InterventionMode::Soft
+        && incoming.mode == InterventionMode::Soft
+        && last.merge_consecutive
+        && incoming.merge_consecutive
+        && last.author_id == incoming.author_id
+        && !last.has_reply_boundary
+        && !incoming.has_reply_boundary
+}
+
 pub(crate) fn enqueue_intervention(
     queue: &mut Vec<Intervention>,
-    intervention: Intervention,
+    mut intervention: Intervention,
 ) -> EnqueueInterventionResult {
     let mut queue_exit_events = prune_interventions(queue);
+    ensure_source_message_ids(&mut intervention);
+
+    if queue
+        .iter()
+        .any(|item| item.source_message_ids.contains(&intervention.message_id))
+    {
+        return EnqueueInterventionResult {
+            enqueued: false,
+            queue_exit_events,
+        };
+    }
 
     if let Some(last) = queue.last() {
         if last.author_id == intervention.author_id
             && last.text == intervention.text
-            && intervention.created_at.duration_since(last.created_at) <= INTERVENTION_DEDUP_WINDOW
+            && last.reply_context == intervention.reply_context
+            && last.has_reply_boundary == intervention.has_reply_boundary
+            && intervention_age_since(last, &intervention) <= INTERVENTION_DEDUP_WINDOW
         {
             return EnqueueInterventionResult {
                 enqueued: false,
+                queue_exit_events,
+            };
+        }
+    }
+
+    if let Some(last) = queue.last_mut() {
+        if should_merge_intervention(last, &intervention) {
+            if !last.text.is_empty() && !intervention.text.is_empty() {
+                last.text.push('\n');
+            }
+            last.text.push_str(&intervention.text);
+            last.message_id = intervention.message_id;
+            push_unique_message_ids(
+                &mut last.source_message_ids,
+                intervention.source_message_ids.into_iter(),
+            );
+            last.created_at = intervention.created_at;
+            return EnqueueInterventionResult {
+                enqueued: true,
                 queue_exit_events,
             };
         }
@@ -135,7 +207,10 @@ pub(crate) fn cancel_soft_intervention_by_message_id(
     let mut queue_exit_events = prune_interventions(queue);
     let removed = queue
         .iter()
-        .position(|item| item.mode == InterventionMode::Soft && item.message_id == message_id)
+        .position(|item| {
+            item.mode == InterventionMode::Soft
+                && (item.message_id == message_id || item.source_message_ids.contains(&message_id))
+        })
         .map(|index| queue.remove(index));
     if let Some(ref intervention) = removed {
         queue_exit_events.push(QueueExitEvent::new(
@@ -170,7 +245,15 @@ pub(crate) fn requeue_intervention_front(
 pub(crate) struct PendingQueueItem {
     pub(crate) author_id: u64,
     pub(crate) message_id: u64,
+    #[serde(default)]
+    pub(crate) source_message_ids: Vec<u64>,
     pub(crate) text: String,
+    #[serde(default)]
+    pub(crate) reply_context: Option<String>,
+    #[serde(default)]
+    pub(crate) has_reply_boundary: bool,
+    #[serde(default)]
+    pub(crate) merge_consecutive: bool,
     /// Channel this item belongs to (routing snapshot — used by the kickoff guard).
     #[serde(default)]
     pub(crate) channel_id: Option<u64>,
@@ -210,7 +293,15 @@ pub(crate) fn save_channel_queue(
         .map(|i| PendingQueueItem {
             author_id: i.author_id.get(),
             message_id: i.message_id.get(),
+            source_message_ids: if i.source_message_ids.is_empty() {
+                vec![i.message_id.get()]
+            } else {
+                i.source_message_ids.iter().map(|id| id.get()).collect()
+            },
             text: i.text.clone(),
+            reply_context: i.reply_context.clone(),
+            has_reply_boundary: i.has_reply_boundary,
+            merge_consecutive: i.merge_consecutive,
             channel_id: Some(channel_id.get()),
             channel_name: None,
             override_channel_id: dispatch_role_override,
@@ -251,7 +342,15 @@ pub(crate) fn save_pending_queues(
             .map(|i| PendingQueueItem {
                 author_id: i.author_id.get(),
                 message_id: i.message_id.get(),
+                source_message_ids: if i.source_message_ids.is_empty() {
+                    vec![i.message_id.get()]
+                } else {
+                    i.source_message_ids.iter().map(|id| id.get()).collect()
+                },
                 text: i.text.clone(),
+                reply_context: i.reply_context.clone(),
+                has_reply_boundary: i.has_reply_boundary,
+                merge_consecutive: i.merge_consecutive,
                 channel_id: Some(channel_id.get()),
                 channel_name: None,
                 override_channel_id: override_id,
@@ -308,12 +407,26 @@ pub(crate) fn load_pending_queues(
         }
         let interventions: Vec<Intervention> = items
             .into_iter()
-            .map(|item| Intervention {
-                author_id: UserId::new(item.author_id),
-                message_id: MessageId::new(item.message_id),
-                text: item.text,
-                mode: InterventionMode::Soft,
-                created_at: now,
+            .map(|item| {
+                let mut source_message_ids: Vec<MessageId> = item
+                    .source_message_ids
+                    .into_iter()
+                    .map(MessageId::new)
+                    .collect();
+                if source_message_ids.is_empty() {
+                    source_message_ids.push(MessageId::new(item.message_id));
+                }
+                Intervention {
+                    author_id: UserId::new(item.author_id),
+                    message_id: MessageId::new(item.message_id),
+                    source_message_ids,
+                    text: item.text,
+                    mode: InterventionMode::Soft,
+                    created_at: now,
+                    reply_context: item.reply_context,
+                    has_reply_boundary: item.has_reply_boundary,
+                    merge_consecutive: item.merge_consecutive,
+                }
             })
             .collect();
         if !interventions.is_empty() {
@@ -1253,10 +1366,24 @@ mod tests {
         Intervention {
             author_id: UserId::new(1),
             message_id: MessageId::new(message_id),
+            source_message_ids: vec![MessageId::new(message_id)],
             text: text.to_string(),
             mode: InterventionMode::Soft,
             created_at,
+            reply_context: None,
+            has_reply_boundary: false,
+            merge_consecutive: false,
         }
+    }
+
+    fn make_mergeable_intervention(
+        message_id: u64,
+        text: &str,
+        created_at: Instant,
+    ) -> Intervention {
+        let mut intervention = make_intervention(message_id, text, created_at);
+        intervention.merge_consecutive = true;
+        intervention
     }
 
     fn lock_test_env() -> std::sync::MutexGuard<'static, ()> {
@@ -1660,6 +1787,177 @@ mod tests {
                 .all(|event| event.kind == QueueExitKind::Superseded)
         );
         assert!(handle.snapshot().await.intervention_queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn enqueue_merges_consecutive_non_reply_messages_and_persists_source_ids() {
+        let _lock = lock_test_env();
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var(AGENTDESK_ROOT_DIR_ENV, tmp.path().to_str().unwrap()) };
+
+        let provider = ProviderKind::Claude;
+        let token_hash = "mailbox-merge-consecutive";
+        let channel_id = ChannelId::new(143);
+        let registry = ChannelMailboxRegistry::default();
+        let handle = registry.handle(channel_id);
+        let persistence = QueuePersistenceContext::new(&provider, token_hash, None);
+        let now = Instant::now();
+
+        assert!(
+            handle
+                .enqueue(
+                    make_mergeable_intervention(20, "first", now),
+                    persistence.clone(),
+                )
+                .await
+                .enqueued
+        );
+        assert!(
+            handle
+                .enqueue(
+                    make_mergeable_intervention(21, "second", now + Duration::from_secs(1)),
+                    persistence.clone(),
+                )
+                .await
+                .enqueued
+        );
+
+        let snapshot = handle.snapshot().await;
+        assert_eq!(snapshot.intervention_queue.len(), 1);
+        assert_eq!(snapshot.intervention_queue[0].message_id.get(), 21);
+        assert_eq!(
+            snapshot.intervention_queue[0]
+                .source_message_ids
+                .iter()
+                .map(|id| id.get())
+                .collect::<Vec<_>>(),
+            vec![20, 21]
+        );
+        assert_eq!(snapshot.intervention_queue[0].text, "first\nsecond");
+
+        let items = read_saved_items(tmp.path(), &provider, token_hash, channel_id);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].message_id, 21);
+        assert_eq!(items[0].source_message_ids, vec![20, 21]);
+        assert_eq!(items[0].text, "first\nsecond");
+
+        unsafe { std::env::remove_var(AGENTDESK_ROOT_DIR_ENV) };
+    }
+
+    #[tokio::test]
+    async fn enqueue_reply_boundary_breaks_merge_chain() {
+        let registry = ChannelMailboxRegistry::default();
+        let channel_id = ChannelId::new(144);
+        let handle = registry.handle(channel_id);
+        let persistence =
+            QueuePersistenceContext::new(&ProviderKind::Claude, "reply-boundary", None);
+        let now = Instant::now();
+
+        let mut reply = make_mergeable_intervention(31, "reply", now + Duration::from_secs(1));
+        reply.has_reply_boundary = true;
+        reply.reply_context = Some("[Reply context]".to_string());
+
+        assert!(
+            handle
+                .enqueue(
+                    make_mergeable_intervention(30, "first", now),
+                    persistence.clone(),
+                )
+                .await
+                .enqueued
+        );
+        assert!(handle.enqueue(reply, persistence.clone()).await.enqueued);
+        assert!(
+            handle
+                .enqueue(
+                    make_mergeable_intervention(32, "after", now + Duration::from_secs(2)),
+                    persistence.clone(),
+                )
+                .await
+                .enqueued
+        );
+        assert!(
+            handle
+                .enqueue(
+                    make_mergeable_intervention(33, "tail", now + Duration::from_secs(3)),
+                    persistence,
+                )
+                .await
+                .enqueued
+        );
+
+        let snapshot = handle.snapshot().await;
+        assert_eq!(snapshot.intervention_queue.len(), 3);
+        assert_eq!(snapshot.intervention_queue[0].text, "first");
+        assert_eq!(snapshot.intervention_queue[1].text, "reply");
+        assert_eq!(snapshot.intervention_queue[2].text, "after\ntail");
+        assert_eq!(
+            snapshot.intervention_queue[2]
+                .source_message_ids
+                .iter()
+                .map(|id| id.get())
+                .collect::<Vec<_>>(),
+            vec![32, 33]
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_queued_message_matches_any_merged_source_message_id() {
+        let _lock = lock_test_env();
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var(AGENTDESK_ROOT_DIR_ENV, tmp.path().to_str().unwrap()) };
+
+        let provider = ProviderKind::Claude;
+        let token_hash = "mailbox-cancel-merged";
+        let channel_id = ChannelId::new(145);
+        let registry = ChannelMailboxRegistry::default();
+        let handle = registry.handle(channel_id);
+        let persistence = QueuePersistenceContext::new(&provider, token_hash, None);
+        let now = Instant::now();
+
+        assert!(
+            handle
+                .enqueue(
+                    make_mergeable_intervention(40, "first", now),
+                    persistence.clone(),
+                )
+                .await
+                .enqueued
+        );
+        assert!(
+            handle
+                .enqueue(
+                    make_mergeable_intervention(41, "second", now + Duration::from_secs(1)),
+                    persistence.clone(),
+                )
+                .await
+                .enqueued
+        );
+
+        let removed = handle
+            .cancel_queued_message(MessageId::new(40), persistence.clone())
+            .await;
+        assert_eq!(removed.queue_exit_events.len(), 1);
+        assert_eq!(removed.queue_exit_events[0].kind, QueueExitKind::Cancelled);
+        let removed = removed
+            .removed
+            .expect("merged item should be removable by original source id");
+        assert_eq!(removed.message_id.get(), 41);
+        assert_eq!(
+            removed
+                .source_message_ids
+                .iter()
+                .map(|id| id.get())
+                .collect::<Vec<_>>(),
+            vec![40, 41]
+        );
+
+        let snapshot = handle.snapshot().await;
+        assert!(snapshot.intervention_queue.is_empty());
+        let path = queue_file_path(tmp.path(), &provider, token_hash, channel_id);
+        assert!(!path.exists());
+
+        unsafe { std::env::remove_var(AGENTDESK_ROOT_DIR_ENV) };
     }
 
     #[tokio::test]


### PR DESCRIPTION
Automated fallback PR after direct merge into `main` hit a cherry-pick conflict.

Card: `e875a023-4c65-4d28-868f-947418c60249`
Issue: https://github.com/itismyfield/AgentDesk/issues/517

Conflict summary:
error: could not apply e342ac7... #517 merge consecutive auto-queue messages hint: After resolving the conflicts, mark them with hint: "git add/rm <pathspec>", then run hint: "g...