### PR TITLE
#545 api-friction: /api/kanban-cards/{id}/force-transition — undocumented-header

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -308,6 +308,9 @@ pub(crate) enum Commands {
         path: String,
         /// Optional JSON body
         body: Option<String>,
+        /// Repeatable custom header, e.g. --header 'X-Channel-Id:1234567890'
+        #[arg(long = "header", value_name = "NAME:VALUE")]
+        headers: Vec<String>,
     },
     /// List session termination events
     Terminations {

--- a/src/cli/client.rs
+++ b/src/cli/client.rs
@@ -45,7 +45,33 @@ fn parse_error_message(body: &str) -> Option<String> {
         })
 }
 
+fn parse_header_arg(raw: &str) -> Result<(String, String), String> {
+    let (name, value) = raw
+        .split_once(':')
+        .or_else(|| raw.split_once('='))
+        .ok_or_else(|| {
+            format!("Invalid header '{raw}'. Use --header 'Name:Value' or --header 'Name=Value'.")
+        })?;
+    let name = name.trim();
+    let value = value.trim();
+    if name.is_empty() || value.is_empty() {
+        return Err(format!(
+            "Invalid header '{raw}'. Both header name and value are required."
+        ));
+    }
+    Ok((name.to_string(), value.to_string()))
+}
+
 fn request_json(method: &str, path: &str, body: Option<&str>) -> Result<Value, String> {
+    request_json_with_headers(method, path, body, &[])
+}
+
+fn request_json_with_headers(
+    method: &str,
+    path: &str,
+    body: Option<&str>,
+    headers: &[String],
+) -> Result<Value, String> {
     let url = if path.starts_with('/') {
         format!("{}{}", api_base(), path)
     } else {
@@ -63,6 +89,10 @@ fn request_json(method: &str, path: &str, body: Option<&str>) -> Result<Value, S
     };
     if let Some(token) = auth_token() {
         req = req.set("Authorization", &format!("Bearer {token}"));
+    }
+    for raw in headers {
+        let (name, value) = parse_header_arg(raw)?;
+        req = req.set(&name, &value);
     }
 
     let method_upper = method.to_ascii_uppercase();
@@ -185,8 +215,13 @@ fn find_active_dispatch_by_type<'a>(
     })
 }
 
-fn api_call(method: &str, path: &str, body: Option<&str>) -> Result<Value, String> {
-    request_json(method, path, body)
+fn api_call(
+    method: &str,
+    path: &str,
+    body: Option<&str>,
+    headers: &[String],
+) -> Result<Value, String> {
+    request_json_with_headers(method, path, body, headers)
 }
 
 fn truncate_cell(value: &str, width: usize) -> String {
@@ -700,9 +735,14 @@ pub fn cmd_config_audit(dry_run: bool) -> Result<(), String> {
     Ok(())
 }
 
-/// `agentdesk api <method> <path> [body]`
-pub fn cmd_api(method: &str, path: &str, body: Option<&str>) -> Result<(), String> {
-    let value = api_call(method, path, body)?;
+/// `agentdesk api <method> <path> [body] [--header Name:Value]`
+pub fn cmd_api(
+    method: &str,
+    path: &str,
+    body: Option<&str>,
+    headers: &[String],
+) -> Result<(), String> {
+    let value = api_call(method, path, body, headers)?;
     print_json(&value);
     Ok(())
 }
@@ -962,13 +1002,15 @@ pub fn cmd_terminations(
 mod tests {
     use super::{
         build_cli_advance_completion_result, cmd_advance, cmd_dispatch,
-        parse_github_repo_from_remote, render_cards_table, render_queue_thread_links,
-        runtime_config_payload,
+        parse_github_repo_from_remote, parse_header_arg, render_cards_table,
+        render_queue_thread_links, request_json_with_headers, runtime_config_payload,
     };
     use axum::extract::{Path, Query, State};
+    use axum::http::HeaderMap;
     use axum::routing::{get, patch, post};
     use axum::{Json, Router};
     use serde_json::json;
+    use std::collections::BTreeMap;
     use std::ffi::OsString;
     use std::process::Command;
     use std::sync::MutexGuard;
@@ -1135,6 +1177,19 @@ mod tests {
             axum::http::StatusCode::CONFLICT,
             Json(json!({"error": "should not be called"})),
         )
+    }
+
+    async fn api_header_echo_handler(
+        State(headers_seen): State<Arc<Mutex<BTreeMap<String, String>>>>,
+        headers: HeaderMap,
+    ) -> Json<serde_json::Value> {
+        let mut seen = headers_seen.lock().unwrap();
+        for name in ["x-channel-id", "x-force-reason"] {
+            if let Some(value) = headers.get(name).and_then(|value| value.to_str().ok()) {
+                seen.insert(name.to_string(), value.to_string());
+            }
+        }
+        Json(json!({"ok": true}))
     }
 
     fn run_cmd_advance_against_mock_server(
@@ -1324,6 +1379,64 @@ mod tests {
             assert_eq!(payload["groups"][0]["sequential"], true);
             assert_eq!(payload["groups"][1]["issues"], json!([407]));
             assert_eq!(payload["groups"][1]["sequential"], false);
+        });
+    }
+
+    #[test]
+    fn parse_header_arg_accepts_colon_and_equals_forms() {
+        assert_eq!(
+            parse_header_arg("X-Channel-Id: 123").unwrap(),
+            ("X-Channel-Id".to_string(), "123".to_string())
+        );
+        assert_eq!(
+            parse_header_arg("X-Force-Reason=test").unwrap(),
+            ("X-Force-Reason".to_string(), "test".to_string())
+        );
+    }
+
+    #[test]
+    fn request_json_with_headers_applies_custom_headers() {
+        let _lock = env_lock();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async move {
+            let headers_seen = Arc::new(Mutex::new(BTreeMap::new()));
+            let app = Router::new()
+                .route("/api/header-echo", get(api_header_echo_handler))
+                .with_state(headers_seen.clone());
+
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            let server = tokio::spawn(async move {
+                axum::serve(listener, app).await.unwrap();
+            });
+
+            let _api_url = EnvVarGuard::set("AGENTDESK_API_URL", &format!("http://{addr}"));
+
+            let result = request_json_with_headers(
+                "GET",
+                "/api/header-echo",
+                None,
+                &[
+                    "X-Channel-Id: pmd-chan-123".to_string(),
+                    "X-Force-Reason=test".to_string(),
+                ],
+            );
+
+            server.abort();
+            assert!(
+                result.is_ok(),
+                "request_json_with_headers failed: {result:?}"
+            );
+
+            let headers_seen = headers_seen.lock().unwrap();
+            assert_eq!(
+                headers_seen.get("x-channel-id").map(String::as_str),
+                Some("pmd-chan-123")
+            );
+            assert_eq!(
+                headers_seen.get("x-force-reason").map(String::as_str),
+                Some("test")
+            );
         });
     }
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -320,9 +320,17 @@ pub(crate) fn execute(command: Commands) -> Result<()> {
             ConfigAction::Set { json } => super::client::cmd_config_set(&json),
             ConfigAction::Audit { dry_run } => super::client::cmd_config_audit(dry_run),
         }),
-        Commands::Api { method, path, body } => {
-            exit_for_cli(super::client::cmd_api(&method, &path, body.as_deref()))
-        }
+        Commands::Api {
+            method,
+            path,
+            body,
+            headers,
+        } => exit_for_cli(super::client::cmd_api(
+            &method,
+            &path,
+            body.as_deref(),
+            &headers,
+        )),
         Commands::Terminations {
             card_id,
             dispatch_id,

--- a/src/server/routes/docs.rs
+++ b/src/server/routes/docs.rs
@@ -126,6 +126,31 @@ fn body_param(kind: &'static str, required: bool, description: &'static str) -> 
     }
 }
 
+fn header_param(required: bool, description: &'static str) -> ParamDoc {
+    ParamDoc {
+        location: "header",
+        kind: "string",
+        required,
+        description,
+        enum_values: None,
+        default: None,
+    }
+}
+
+fn explicit_bearer_header_param() -> ParamDoc {
+    header_param(
+        true,
+        "Explicit Authorization: Bearer <token> header. Same-origin auth bypass is not accepted for this PMD-only endpoint.",
+    )
+}
+
+fn kanban_manager_channel_header_param() -> ParamDoc {
+    header_param(
+        true,
+        "X-Channel-Id must match the current kanban_manager_channel_id. Discover that value via GET /api/settings/config before calling this endpoint.",
+    )
+}
+
 fn category_description(category: &str) -> &'static str {
     match category {
         "api-friction" => {
@@ -492,6 +517,8 @@ fn all_endpoints() -> Vec<EndpointDoc> {
         )
         .with_params([
             ("id", path_param("Kanban card ID")),
+            ("authorization", explicit_bearer_header_param()),
+            ("x-channel-id", kanban_manager_channel_header_param()),
             (
                 "reason",
                 body_param("string", false, "Why the rereview is needed"),
@@ -508,6 +535,8 @@ fn all_endpoints() -> Vec<EndpointDoc> {
             "Batch rereview by GitHub issue number",
         )
         .with_params([
+            ("authorization", explicit_bearer_header_param()),
+            ("x-channel-id", kanban_manager_channel_header_param()),
             (
                 "issues",
                 body_param("number[]", true, "GitHub issue numbers to rereview"),
@@ -528,6 +557,8 @@ fn all_endpoints() -> Vec<EndpointDoc> {
             "Force-transition multiple cards",
         )
         .with_params([
+            ("authorization", explicit_bearer_header_param()),
+            ("x-channel-id", kanban_manager_channel_header_param()),
             (
                 "issue_numbers",
                 body_param("number[]", false, "GitHub issue numbers to resolve into cards"),
@@ -559,6 +590,8 @@ fn all_endpoints() -> Vec<EndpointDoc> {
         )
         .with_params([
             ("id", path_param("Kanban card ID")),
+            ("authorization", explicit_bearer_header_param()),
+            ("x-channel-id", kanban_manager_channel_header_param()),
             (
                 "review_status",
                 body_param("string", false, "Optional review status to set after reopen"),
@@ -590,6 +623,8 @@ fn all_endpoints() -> Vec<EndpointDoc> {
         )
         .with_params([
             ("id", path_param("Kanban card ID")),
+            ("authorization", explicit_bearer_header_param()),
+            ("x-channel-id", kanban_manager_channel_header_param()),
             ("status", body_param("string", true, "Target pipeline status")),
             (
                 "cancel_dispatches",

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -2442,6 +2442,28 @@ async fn api_docs_category_exposes_kanban_params_and_examples() {
         resume["example"]["response"]["action"]["type"],
         "new_implementation_dispatch"
     );
+
+    let force_transition = endpoints
+        .iter()
+        .find(|ep| {
+            ep["method"] == "POST" && ep["path"] == "/api/kanban-cards/{id}/force-transition"
+        })
+        .expect("kanban force-transition endpoint must be present");
+    assert_eq!(
+        force_transition["params"]["authorization"]["location"],
+        "header"
+    );
+    assert_eq!(
+        force_transition["params"]["x-channel-id"]["location"],
+        "header"
+    );
+    assert!(
+        force_transition["params"]["x-channel-id"]["description"]
+            .as_str()
+            .unwrap_or("")
+            .contains("kanban_manager_channel_id"),
+        "force-transition docs must explain where X-Channel-Id comes from"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## 요약
- PMD kanban force-transition 관련 문서에 `authorization`/`x-channel-id` 헤더 요구사항과 값 출처를 명시합니다.
- `agentdesk api` CLI에 반복 가능한 `--header` 옵션을 추가해 커스텀 헤더를 직접 전달할 수 있게 합니다.
- docs/CLI 동작을 검증하는 회귀 테스트를 추가합니다.

## 테스트
- `cargo test api_docs_category_exposes_kanban_params_and_examples -- --nocapture`
- `cargo test request_json_with_headers_applies_custom_headers -- --nocapture`
- `cargo test parse_header_arg_accepts_colon_and_equals_forms -- --nocapture`

Closes #545