### PR TITLE
#497 refactor: phase gate 정식 도메인 엔티티화 — kv_meta JSON에서 테이블로

### DIFF
--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -588,31 +588,167 @@ function _freePathToDispatchable(from, cfg) {
   return null;
 }
 
-function phaseGateKey(runId, phase) {
-  return "aq_phase_gate:" + runId + ":" + phase;
-}
-
 function loadPhaseGateState(runId, phase) {
   var rows = agentdesk.db.query(
-    "SELECT value FROM kv_meta WHERE key = ?",
-    [phaseGateKey(runId, phase)]
+    "SELECT dispatch_id, status, verdict, pass_verdict, next_phase, final_phase, " +
+    "anchor_card_id, failure_reason, created_at " +
+    "FROM auto_queue_phase_gates " +
+    "WHERE run_id = ? AND phase = ? " +
+    "ORDER BY CASE WHEN dispatch_id IS NULL THEN 0 ELSE 1 END ASC, created_at ASC, dispatch_id ASC",
+    [runId, phase]
   );
-  if (rows.length === 0 || !rows[0].value) return null;
-  try { return JSON.parse(rows[0].value); } catch (e) { return null; }
+  if (rows.length === 0) return null;
+
+  var dispatchIds = [];
+  var status = "pending";
+  var failedRow = null;
+  var hasPassedRows = false;
+
+  for (var i = 0; i < rows.length; i++) {
+    var row = rows[i];
+    if (row.dispatch_id) {
+      dispatchIds.push(row.dispatch_id);
+    }
+    if (row.status === "failed" && !failedRow) {
+      failedRow = row;
+      status = "failed";
+    } else if (row.status === "passed") {
+      hasPassedRows = true;
+    }
+  }
+
+  if (!failedRow && dispatchIds.length > 0 && hasPassedRows && rows.every(function(row) { return row.status === "passed"; })) {
+    status = "passed";
+  } else if (!failedRow) {
+    status = rows[0].status || "pending";
+  }
+
+  var state = {
+    run_id: runId,
+    batch_phase: phase,
+    next_phase: rows[0].next_phase,
+    final_phase: !!rows[0].final_phase,
+    anchor_card_id: rows[0].anchor_card_id || null,
+    status: status,
+    dispatch_ids: dispatchIds,
+    gates: [],
+    created_at: rows[0].created_at || null
+  };
+
+  if (failedRow) {
+    state.failed_dispatch_id = failedRow.dispatch_id || null;
+    state.failed_verdict = failedRow.verdict || null;
+    state.failed_reason = failedRow.failure_reason || null;
+  }
+
+  return state;
+}
+
+function _dedupePhaseGateDispatchIds(dispatchIds) {
+  var seen = {};
+  var deduped = [];
+  for (var i = 0; i < dispatchIds.length; i++) {
+    var dispatchId = dispatchIds[i];
+    if (!dispatchId || seen[dispatchId]) continue;
+    seen[dispatchId] = true;
+    deduped.push(dispatchId);
+  }
+  return deduped;
+}
+
+function _loadValidPhaseGateDispatchIds(dispatchIds) {
+  var valid = [];
+  for (var i = 0; i < dispatchIds.length; i++) {
+    var dispatchId = dispatchIds[i];
+    var rows = agentdesk.db.query(
+      "SELECT 1 FROM task_dispatches WHERE id = ? LIMIT 1",
+      [dispatchId]
+    );
+    if (rows.length > 0) {
+      valid.push(dispatchId);
+    }
+  }
+  return valid;
+}
+
+function _deleteStalePhaseGateRows(runId, phase, dispatchIds) {
+  if (dispatchIds.length === 0) {
+    agentdesk.db.execute(
+      "DELETE FROM auto_queue_phase_gates WHERE run_id = ? AND phase = ?",
+      [runId, phase]
+    );
+    return;
+  }
+
+  var placeholders = dispatchIds.map(function() { return "?"; }).join(",");
+  agentdesk.db.execute(
+    "DELETE FROM auto_queue_phase_gates " +
+    "WHERE run_id = ? AND phase = ? " +
+    "AND (dispatch_id IS NULL OR dispatch_id NOT IN (" + placeholders + "))",
+    [runId, phase].concat(dispatchIds)
+  );
 }
 
 function savePhaseGateState(runId, phase, state) {
   if (!state) return;
-  agentdesk.db.execute(
-    "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?, ?)",
-    [phaseGateKey(runId, phase), JSON.stringify(state)]
-  );
+  var dispatchIds = [];
+  if (Array.isArray(state.dispatch_ids)) {
+    dispatchIds = state.dispatch_ids.filter(function(dispatchId) {
+      return !!dispatchId;
+    });
+  }
+  dispatchIds = _loadValidPhaseGateDispatchIds(_dedupePhaseGateDispatchIds(dispatchIds));
+  var status = state.status || "pending";
+  var verdict = state.failed_verdict || state.verdict || null;
+  var passVerdict = state.pass_verdict ||
+    (state.gates && state.gates[0] && state.gates[0].pass_verdict) ||
+    "phase_gate_passed";
+  var nextPhase = state.next_phase !== undefined ? state.next_phase : null;
+  var finalPhase = !!state.final_phase;
+  var anchorCardId = state.anchor_card_id || null;
+  var failureReason = state.failed_reason || null;
+  var createdAt = state.created_at || null;
+
+  _deleteStalePhaseGateRows(runId, phase, dispatchIds);
+
+  if (dispatchIds.length === 0) {
+    agentdesk.db.execute(
+      "INSERT INTO auto_queue_phase_gates (" +
+      "run_id, phase, status, verdict, dispatch_id, pass_verdict, next_phase, " +
+      "final_phase, anchor_card_id, failure_reason, created_at, updated_at" +
+      ") VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, COALESCE(?, CURRENT_TIMESTAMP), datetime('now'))",
+      [runId, phase, status, verdict, passVerdict, nextPhase, finalPhase ? 1 : 0, anchorCardId, failureReason, createdAt]
+    );
+    return;
+  }
+
+  for (var i = 0; i < dispatchIds.length; i++) {
+    var dispatchId = dispatchIds[i];
+    agentdesk.db.execute(
+      "INSERT INTO auto_queue_phase_gates (" +
+      "run_id, phase, status, verdict, dispatch_id, pass_verdict, next_phase, " +
+      "final_phase, anchor_card_id, failure_reason, created_at, updated_at" +
+      ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, CURRENT_TIMESTAMP), datetime('now')) " +
+      "ON CONFLICT(dispatch_id) DO UPDATE SET " +
+      "run_id = excluded.run_id, " +
+      "phase = excluded.phase, " +
+      "status = excluded.status, " +
+      "verdict = excluded.verdict, " +
+      "pass_verdict = excluded.pass_verdict, " +
+      "next_phase = excluded.next_phase, " +
+      "final_phase = excluded.final_phase, " +
+      "anchor_card_id = excluded.anchor_card_id, " +
+      "failure_reason = excluded.failure_reason, " +
+      "updated_at = datetime('now')",
+      [runId, phase, status, verdict, dispatchId, passVerdict, nextPhase, finalPhase ? 1 : 0, anchorCardId, failureReason, createdAt]
+    );
+  }
 }
 
 function clearPhaseGateState(runId, phase) {
   agentdesk.db.execute(
-    "DELETE FROM kv_meta WHERE key = ?",
-    [phaseGateKey(runId, phase)]
+    "DELETE FROM auto_queue_phase_gates WHERE run_id = ? AND phase = ?",
+    [runId, phase]
   );
 }
 
@@ -627,10 +763,9 @@ function loadRunInfo(runId) {
 
 function runHasBlockingPhaseGate(runId) {
   var rows = agentdesk.db.query(
-    "SELECT COUNT(*) as cnt FROM kv_meta " +
-    "WHERE key LIKE ? " +
-    "AND json_extract(COALESCE(value, '{}'), '$.status') IN ('pending', 'failed')",
-    ["aq_phase_gate:" + runId + ":%"]
+    "SELECT COUNT(*) as cnt FROM auto_queue_phase_gates " +
+    "WHERE run_id = ? AND status IN ('pending', 'failed')",
+    [runId]
   );
   return rows.length > 0 && rows[0].cnt > 0;
 }

--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -657,14 +657,22 @@ function _dedupePhaseGateDispatchIds(dispatchIds) {
 }
 
 function _loadValidPhaseGateDispatchIds(dispatchIds) {
+  if (dispatchIds.length === 0) return [];
+
+  var placeholders = dispatchIds.map(function() { return "?"; }).join(",");
+  var rows = agentdesk.db.query(
+    "SELECT id FROM task_dispatches WHERE id IN (" + placeholders + ")",
+    dispatchIds
+  );
+  var validIds = {};
+  for (var i = 0; i < rows.length; i++) {
+    validIds[rows[i].id] = true;
+  }
+
   var valid = [];
-  for (var i = 0; i < dispatchIds.length; i++) {
-    var dispatchId = dispatchIds[i];
-    var rows = agentdesk.db.query(
-      "SELECT 1 FROM task_dispatches WHERE id = ? LIMIT 1",
-      [dispatchId]
-    );
-    if (rows.length > 0) {
+  for (var j = 0; j < dispatchIds.length; j++) {
+    var dispatchId = dispatchIds[j];
+    if (validIds[dispatchId]) {
       valid.push(dispatchId);
     }
   }

--- a/src/db/auto_queue.rs
+++ b/src/db/auto_queue.rs
@@ -708,13 +708,12 @@ pub fn batch_phase_is_eligible(batch_phase: i64, current_phase: Option<i64>) -> 
 }
 
 pub fn run_has_blocking_phase_gate(conn: &Connection, run_id: &str) -> bool {
-    let key_pattern = format!("aq_phase_gate:{run_id}:%");
     conn.query_row(
         "SELECT COUNT(*) > 0
-         FROM kv_meta
-         WHERE key LIKE ?1
-           AND json_extract(COALESCE(value, '{}'), '$.status') IN ('pending', 'failed')",
-        [key_pattern],
+         FROM auto_queue_phase_gates
+         WHERE run_id = ?1
+           AND status IN ('pending', 'failed')",
+        [run_id],
         |row| row.get(0),
     )
     .unwrap_or(false)

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
-use rusqlite::Connection;
+use rusqlite::{Connection, params_from_iter};
+use std::collections::HashSet;
 
 const AGENTDESK_REPO_ID: &str = "itismyfield/AgentDesk";
 const SESSION_AGENT_ID_BACKFILL_META_KEY: &str = "session_agent_id_backfill:v1";
@@ -844,11 +845,13 @@ pub(crate) fn ensure_auto_queue_schema(conn: &Connection) -> Result<()> {
             UNIQUE(entry_id, dispatch_id)
         );
         CREATE TABLE IF NOT EXISTS auto_queue_phase_gates (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
             run_id          TEXT NOT NULL REFERENCES auto_queue_runs(id) ON DELETE CASCADE,
             phase           INTEGER NOT NULL,
             status          TEXT NOT NULL DEFAULT 'pending',
             verdict         TEXT,
-            dispatch_id     TEXT UNIQUE REFERENCES task_dispatches(id) ON DELETE CASCADE,
+            dispatch_id     TEXT REFERENCES task_dispatches(id) ON DELETE CASCADE
+                                CHECK(dispatch_id IS NULL OR TRIM(dispatch_id) <> ''),
             pass_verdict    TEXT NOT NULL DEFAULT 'phase_gate_passed',
             next_phase      INTEGER,
             final_phase     INTEGER NOT NULL DEFAULT 0,
@@ -866,14 +869,9 @@ pub(crate) fn ensure_auto_queue_schema(conn: &Connection) -> Result<()> {
         CREATE INDEX IF NOT EXISTS idx_aq_entry_dispatch_history_dispatch
             ON auto_queue_entry_dispatch_history(dispatch_id);
         CREATE INDEX IF NOT EXISTS idx_aq_entry_dispatch_history_created
-            ON auto_queue_entry_dispatch_history(created_at);
-        CREATE INDEX IF NOT EXISTS idx_aq_phase_gates_run_phase
-            ON auto_queue_phase_gates(run_id, phase);
-        CREATE INDEX IF NOT EXISTS idx_aq_phase_gates_run_status
-            ON auto_queue_phase_gates(run_id, status);
-        CREATE INDEX IF NOT EXISTS idx_aq_phase_gates_phase_dispatch
-            ON auto_queue_phase_gates(phase, dispatch_id);",
+            ON auto_queue_entry_dispatch_history(created_at);",
     )?;
+    ensure_auto_queue_phase_gate_table_shape(conn)?;
 
     ensure_auto_queue_column(
         conn,
@@ -1009,6 +1007,350 @@ fn auto_queue_has_column(conn: &Connection, table: &str, column: &str) -> bool {
         |row| row.get(0),
     )
     .unwrap_or(false)
+}
+
+fn auto_queue_index_exists(conn: &Connection, index_name: &str) -> bool {
+    conn.query_row(
+        "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type = 'index' AND name = ?1",
+        [index_name],
+        |row| row.get(0),
+    )
+    .unwrap_or(false)
+}
+
+#[derive(Debug)]
+struct LegacyAutoQueuePhaseGateRow {
+    rowid: i64,
+    run_id: String,
+    phase: i64,
+    status: String,
+    verdict: Option<String>,
+    dispatch_id: Option<String>,
+    pass_verdict: String,
+    next_phase: Option<i64>,
+    final_phase: i64,
+    anchor_card_id: Option<String>,
+    failure_reason: Option<String>,
+    created_at: Option<String>,
+    updated_at: Option<String>,
+}
+
+fn ensure_auto_queue_phase_gate_table_shape(conn: &Connection) -> Result<()> {
+    let needs_rebuild = !auto_queue_has_column(conn, "auto_queue_phase_gates", "id");
+    if needs_rebuild {
+        rebuild_auto_queue_phase_gates_table(conn)?;
+    } else {
+        ensure_auto_queue_phase_gate_indexes(conn)?;
+    }
+    Ok(())
+}
+
+fn ensure_auto_queue_phase_gate_indexes(conn: &Connection) -> Result<()> {
+    if auto_queue_index_exists(conn, "uq_aq_phase_gates_run_phase_dispatch_key")
+        && auto_queue_index_exists(conn, "uq_aq_phase_gates_dispatch_id")
+        && auto_queue_index_exists(conn, "idx_aq_phase_gates_run_phase")
+        && auto_queue_index_exists(conn, "idx_aq_phase_gates_run_status")
+        && auto_queue_index_exists(conn, "idx_aq_phase_gates_phase_dispatch")
+    {
+        return Ok(());
+    }
+
+    conn.execute_batch(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_aq_phase_gates_run_phase_dispatch_key
+            ON auto_queue_phase_gates(run_id, phase, COALESCE(dispatch_id, ''));
+         CREATE UNIQUE INDEX IF NOT EXISTS uq_aq_phase_gates_dispatch_id
+            ON auto_queue_phase_gates(dispatch_id);
+         CREATE INDEX IF NOT EXISTS idx_aq_phase_gates_run_phase
+            ON auto_queue_phase_gates(run_id, phase);
+         CREATE INDEX IF NOT EXISTS idx_aq_phase_gates_run_status
+            ON auto_queue_phase_gates(run_id, status);
+         CREATE INDEX IF NOT EXISTS idx_aq_phase_gates_phase_dispatch
+            ON auto_queue_phase_gates(phase, dispatch_id);",
+    )?;
+    Ok(())
+}
+
+fn rebuild_auto_queue_phase_gates_table(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "DROP INDEX IF EXISTS idx_aq_phase_gates_run_phase;
+         DROP INDEX IF EXISTS idx_aq_phase_gates_run_status;
+         DROP INDEX IF EXISTS idx_aq_phase_gates_phase_dispatch;
+         DROP INDEX IF EXISTS uq_aq_phase_gates_run_phase_dispatch_key;
+         DROP INDEX IF EXISTS uq_aq_phase_gates_dispatch_id;
+         ALTER TABLE auto_queue_phase_gates RENAME TO auto_queue_phase_gates_legacy;
+         CREATE TABLE auto_queue_phase_gates (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id          TEXT NOT NULL REFERENCES auto_queue_runs(id) ON DELETE CASCADE,
+            phase           INTEGER NOT NULL,
+            status          TEXT NOT NULL DEFAULT 'pending',
+            verdict         TEXT,
+            dispatch_id     TEXT REFERENCES task_dispatches(id) ON DELETE CASCADE
+                                CHECK(dispatch_id IS NULL OR TRIM(dispatch_id) <> ''),
+            pass_verdict    TEXT NOT NULL DEFAULT 'phase_gate_passed',
+            next_phase      INTEGER,
+            final_phase     INTEGER NOT NULL DEFAULT 0,
+            anchor_card_id  TEXT REFERENCES kanban_cards(id) ON DELETE SET NULL,
+            failure_reason  TEXT,
+            created_at      DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at      DATETIME DEFAULT CURRENT_TIMESTAMP
+         );",
+    )?;
+
+    let mut rows = conn
+        .prepare(
+            "SELECT
+                rowid,
+                run_id,
+                phase,
+                status,
+                verdict,
+                dispatch_id,
+                COALESCE(NULLIF(TRIM(pass_verdict), ''), 'phase_gate_passed') AS pass_verdict,
+                next_phase,
+                CASE
+                    WHEN LOWER(TRIM(CAST(COALESCE(final_phase, 0) AS TEXT))) IN ('1', 'true')
+                        THEN 1
+                    ELSE 0
+                END AS final_phase,
+                anchor_card_id,
+                failure_reason,
+                CAST(created_at AS TEXT),
+                CAST(updated_at AS TEXT)
+             FROM auto_queue_phase_gates_legacy",
+        )?
+        .query_map([], |row| {
+            Ok(LegacyAutoQueuePhaseGateRow {
+                rowid: row.get(0)?,
+                run_id: row.get(1)?,
+                phase: row.get(2)?,
+                status: row.get(3)?,
+                verdict: row.get(4)?,
+                dispatch_id: row.get(5)?,
+                pass_verdict: row.get(6)?,
+                next_phase: row.get(7)?,
+                final_phase: row.get(8)?,
+                anchor_card_id: row.get(9)?,
+                failure_reason: row.get(10)?,
+                created_at: row.get(11)?,
+                updated_at: row.get(12)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let valid_run_ids = load_existing_ids(
+        conn,
+        "auto_queue_runs",
+        &rows
+            .iter()
+            .map(|row| row.run_id.clone())
+            .collect::<Vec<_>>(),
+    )?;
+    let valid_dispatch_ids = load_existing_ids(
+        conn,
+        "task_dispatches",
+        &rows
+            .iter()
+            .filter_map(|row| row.dispatch_id.clone())
+            .collect::<Vec<_>>(),
+    )?;
+    let valid_anchor_card_ids = load_existing_ids(
+        conn,
+        "kanban_cards",
+        &rows
+            .iter()
+            .filter_map(|row| row.anchor_card_id.clone())
+            .collect::<Vec<_>>(),
+    )?;
+
+    let mut normalized_rows = Vec::new();
+    for mut row in rows.drain(..) {
+        row.run_id = row.run_id.trim().to_string();
+        if row.run_id.is_empty() || !valid_run_ids.contains(row.run_id.as_str()) {
+            continue;
+        }
+
+        row.status = if row.status.trim().is_empty() {
+            "pending".to_string()
+        } else {
+            row.status.trim().to_string()
+        };
+        row.verdict = row
+            .verdict
+            .take()
+            .and_then(|value| (!value.trim().is_empty()).then(|| value.trim().to_string()));
+        row.dispatch_id = row.dispatch_id.take().and_then(|value| {
+            let value = value.trim();
+            if value.is_empty() || !valid_dispatch_ids.contains(value) {
+                None
+            } else {
+                Some(value.to_string())
+            }
+        });
+        row.anchor_card_id = row.anchor_card_id.take().and_then(|value| {
+            let value = value.trim();
+            if value.is_empty() || !valid_anchor_card_ids.contains(value) {
+                None
+            } else {
+                Some(value.to_string())
+            }
+        });
+        row.failure_reason = row
+            .failure_reason
+            .take()
+            .and_then(|value| (!value.trim().is_empty()).then(|| value.trim().to_string()));
+        row.created_at = row
+            .created_at
+            .take()
+            .and_then(|value| (!value.trim().is_empty()).then(|| value.trim().to_string()));
+        row.updated_at = row
+            .updated_at
+            .take()
+            .and_then(|value| (!value.trim().is_empty()).then(|| value.trim().to_string()));
+        row.final_phase = if row.final_phase != 0 { 1 } else { 0 };
+
+        normalized_rows.push(row);
+    }
+
+    let groups_with_dispatch = normalized_rows
+        .iter()
+        .filter(|row| row.dispatch_id.is_some())
+        .map(|row| (row.run_id.clone(), row.phase))
+        .collect::<HashSet<_>>();
+
+    normalized_rows.retain(|row| {
+        row.dispatch_id.is_some()
+            || !groups_with_dispatch.contains(&(row.run_id.clone(), row.phase))
+    });
+
+    normalized_rows.sort_by(|left, right| {
+        phase_gate_status_priority(&left.status)
+            .cmp(&phase_gate_status_priority(&right.status))
+            .then_with(|| right.updated_at.cmp(&left.updated_at))
+            .then_with(|| right.created_at.cmp(&left.created_at))
+            .then_with(|| right.rowid.cmp(&left.rowid))
+    });
+
+    let mut seen_dispatch_ids = HashSet::new();
+    let mut seen_group_dispatch_keys = HashSet::new();
+    for row in normalized_rows {
+        if let Some(dispatch_id) = row.dispatch_id.as_ref() {
+            if !seen_dispatch_ids.insert(dispatch_id.clone()) {
+                continue;
+            }
+        }
+
+        let group_dispatch_key = (
+            row.run_id.clone(),
+            row.phase,
+            row.dispatch_id.clone().unwrap_or_default(),
+        );
+        if !seen_group_dispatch_keys.insert(group_dispatch_key) {
+            continue;
+        }
+
+        conn.execute(
+            "INSERT INTO auto_queue_phase_gates (
+                run_id,
+                phase,
+                status,
+                verdict,
+                dispatch_id,
+                pass_verdict,
+                next_phase,
+                final_phase,
+                anchor_card_id,
+                failure_reason,
+                created_at,
+                updated_at
+            ) VALUES (
+                ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
+                COALESCE(?11, CURRENT_TIMESTAMP),
+                COALESCE(?12, COALESCE(?11, CURRENT_TIMESTAMP))
+            )",
+            rusqlite::params![
+                row.run_id,
+                row.phase,
+                row.status,
+                row.verdict,
+                row.dispatch_id,
+                row.pass_verdict,
+                row.next_phase,
+                row.final_phase,
+                row.anchor_card_id,
+                row.failure_reason,
+                row.created_at,
+                row.updated_at,
+            ],
+        )?;
+    }
+
+    ensure_auto_queue_phase_gate_indexes(conn)?;
+    conn.execute_batch("DROP TABLE auto_queue_phase_gates_legacy;")?;
+    Ok(())
+}
+
+fn phase_gate_status_priority(status: &str) -> i32 {
+    match status {
+        "failed" => 0,
+        "pending" => 1,
+        "passed" => 2,
+        _ => 3,
+    }
+}
+
+fn load_existing_ids(conn: &Connection, table: &str, ids: &[String]) -> Result<HashSet<String>> {
+    let mut normalized_ids = Vec::new();
+    let mut seen = HashSet::new();
+    for id in ids {
+        let trimmed = id.trim();
+        if trimmed.is_empty() || !seen.insert(trimmed.to_string()) {
+            continue;
+        }
+        normalized_ids.push(trimmed.to_string());
+    }
+
+    if normalized_ids.is_empty() {
+        return Ok(HashSet::new());
+    }
+
+    let placeholders = (0..normalized_ids.len())
+        .map(|_| "?")
+        .collect::<Vec<_>>()
+        .join(",");
+    let sql = match table {
+        "auto_queue_runs" | "task_dispatches" | "kanban_cards" => {
+            format!("SELECT id FROM {table} WHERE id IN ({placeholders})")
+        }
+        _ => unreachable!("unexpected id lookup table"),
+    };
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_from_iter(normalized_ids.iter()), |row| {
+        row.get::<_, String>(0)
+    })?;
+
+    let mut existing = HashSet::new();
+    for row in rows {
+        existing.insert(row?);
+    }
+    Ok(existing)
+}
+
+fn filter_existing_dispatch_ids(conn: &Connection, dispatch_ids: &[String]) -> Result<Vec<String>> {
+    let existing_dispatch_ids = load_existing_ids(conn, "task_dispatches", dispatch_ids)?;
+    let mut filtered = Vec::new();
+    let mut seen = HashSet::new();
+    for dispatch_id in dispatch_ids {
+        let trimmed = dispatch_id.trim();
+        if trimmed.is_empty()
+            || !existing_dispatch_ids.contains(trimmed)
+            || !seen.insert(trimmed.to_string())
+        {
+            continue;
+        }
+        filtered.push(trimmed.to_string());
+    }
+    Ok(filtered)
 }
 
 fn backfill_auto_queue_dispatch_ids(conn: &Connection) -> Result<()> {
@@ -1176,17 +1518,8 @@ fn backfill_auto_queue_phase_gates(conn: &Connection) -> Result<()> {
             })
             .unwrap_or_default();
 
-        let valid_dispatch_ids = dispatch_ids
-            .into_iter()
-            .filter(|dispatch_id| {
-                conn.query_row(
-                    "SELECT COUNT(*) > 0 FROM task_dispatches WHERE id = ?1",
-                    [dispatch_id],
-                    |row| row.get::<_, bool>(0),
-                )
-                .unwrap_or(false)
-            })
-            .collect::<Vec<_>>();
+        let valid_dispatch_ids = filter_existing_dispatch_ids(conn, &dispatch_ids)?;
+        let final_phase = if final_phase { 1 } else { 0 };
 
         if valid_dispatch_ids.is_empty() {
             conn.execute(
@@ -1992,5 +2325,179 @@ mod tests {
             )
             .unwrap();
         assert!(!legacy_key_exists);
+    }
+
+    #[test]
+    fn auto_queue_phase_gates_enforce_foreign_keys_and_uniqueness() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        migrate(&conn).unwrap();
+
+        conn.execute(
+            "INSERT INTO kanban_cards (id, title, status, created_at, updated_at)
+             VALUES ('card-phase-fk', 'Phase Gate FK', 'ready', datetime('now'), datetime('now'))",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO auto_queue_runs (id, repo, agent_id, status)
+             VALUES ('run-phase-fk', 'test/repo', 'agent-1', 'paused')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO task_dispatches (
+                id, kanban_card_id, to_agent_id, dispatch_type, status, title, created_at, updated_at, context
+             ) VALUES (
+                'dispatch-phase-fk',
+                'card-phase-fk',
+                'agent-1',
+                'phase-gate',
+                'pending',
+                'Phase Gate FK',
+                datetime('now'),
+                datetime('now'),
+                '{}'
+             )",
+            [],
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO auto_queue_phase_gates (
+                run_id, phase, status, dispatch_id, pass_verdict
+             ) VALUES ('run-phase-fk', 1, 'pending', NULL, 'phase_gate_passed')",
+            [],
+        )
+        .unwrap();
+        assert!(
+            conn.execute(
+                "INSERT INTO auto_queue_phase_gates (
+                    run_id, phase, status, dispatch_id, pass_verdict
+                 ) VALUES ('run-phase-fk', 1, 'pending', NULL, 'phase_gate_passed')",
+                [],
+            )
+            .is_err()
+        );
+
+        conn.execute(
+            "INSERT INTO auto_queue_phase_gates (
+                run_id, phase, status, dispatch_id, pass_verdict
+             ) VALUES ('run-phase-fk', 2, 'pending', 'dispatch-phase-fk', 'phase_gate_passed')",
+            [],
+        )
+        .unwrap();
+        assert!(
+            conn.execute(
+                "INSERT INTO auto_queue_phase_gates (
+                    run_id, phase, status, dispatch_id, pass_verdict
+                 ) VALUES ('run-phase-fk', 3, 'pending', 'dispatch-phase-fk', 'phase_gate_passed')",
+                [],
+            )
+            .is_err()
+        );
+        assert!(
+            conn.execute(
+                "INSERT INTO auto_queue_phase_gates (
+                    run_id, phase, status, dispatch_id, pass_verdict
+                 ) VALUES ('run-phase-fk', 4, 'pending', 'dispatch-missing', 'phase_gate_passed')",
+                [],
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn migrate_rebuilds_legacy_auto_queue_phase_gates_table() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        conn.execute_batch(
+            "CREATE TABLE kv_meta (
+                key   TEXT PRIMARY KEY,
+                value TEXT
+            );",
+        )
+        .unwrap();
+        conn.execute_batch(include_str!("../../migrations/001_initial.sql"))
+            .unwrap();
+        conn.execute(
+            "INSERT INTO kv_meta (key, value) VALUES ('schema_version', '1')",
+            [],
+        )
+        .unwrap();
+        conn.execute_batch(
+            "CREATE TABLE auto_queue_runs (
+                id          TEXT PRIMARY KEY,
+                repo        TEXT,
+                agent_id    TEXT,
+                status      TEXT DEFAULT 'active',
+                created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+                completed_at DATETIME
+            );
+            CREATE TABLE auto_queue_phase_gates (
+                run_id          TEXT NOT NULL REFERENCES auto_queue_runs(id) ON DELETE CASCADE,
+                phase           INTEGER NOT NULL,
+                status          TEXT NOT NULL DEFAULT 'pending',
+                verdict         TEXT,
+                dispatch_id     TEXT UNIQUE REFERENCES task_dispatches(id) ON DELETE CASCADE,
+                pass_verdict    TEXT NOT NULL DEFAULT 'phase_gate_passed',
+                next_phase      INTEGER,
+                final_phase     INTEGER NOT NULL DEFAULT 0,
+                anchor_card_id  TEXT REFERENCES kanban_cards(id) ON DELETE SET NULL,
+                failure_reason  TEXT,
+                created_at      DATETIME DEFAULT CURRENT_TIMESTAMP,
+                updated_at      DATETIME DEFAULT CURRENT_TIMESTAMP
+            );",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO kanban_cards (id, title, status, created_at, updated_at)
+             VALUES ('card-phase-legacy', 'Legacy Gate', 'ready', datetime('now'), datetime('now'))",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO auto_queue_runs (id, repo, agent_id, status)
+             VALUES ('run-phase-legacy', 'test/repo', 'agent-1', 'paused')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO auto_queue_phase_gates (
+                run_id, phase, status, dispatch_id, anchor_card_id, pass_verdict
+             ) VALUES ('run-phase-legacy', 1, 'pending', NULL, 'card-phase-legacy', 'phase_gate_passed')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO auto_queue_phase_gates (
+                run_id, phase, status, dispatch_id, anchor_card_id, pass_verdict
+             ) VALUES ('run-phase-legacy', 1, 'failed', NULL, 'card-phase-legacy', 'phase_gate_passed')",
+            [],
+        )
+        .unwrap();
+
+        migrate(&conn).unwrap();
+
+        assert!(auto_queue_has_column(&conn, "auto_queue_phase_gates", "id"));
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM auto_queue_phase_gates
+                 WHERE run_id = 'run-phase-legacy' AND phase = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+
+        let status: String = conn
+            .query_row(
+                "SELECT status FROM auto_queue_phase_gates
+                 WHERE run_id = 'run-phase-legacy' AND phase = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(status, "failed");
     }
 }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -5,6 +5,7 @@ const AGENTDESK_REPO_ID: &str = "itismyfield/AgentDesk";
 const SESSION_AGENT_ID_BACKFILL_META_KEY: &str = "session_agent_id_backfill:v1";
 const SESSION_TRANSCRIPT_AGENT_ID_BACKFILL_META_KEY: &str =
     "session_transcript_agent_id_backfill:v1";
+const AUTO_QUEUE_PHASE_GATE_BACKFILL_META_KEY: &str = "auto_queue_phase_gate_backfill:v1";
 
 pub fn migrate(conn: &Connection) -> Result<()> {
     conn.execute_batch(
@@ -160,6 +161,11 @@ pub fn migrate(conn: &Connection) -> Result<()> {
          UPDATE kanban_cards SET awaiting_dod_at = updated_at WHERE status = 'review' AND review_status = 'awaiting_dod' AND awaiting_dod_at IS NULL;",
     );
     ensure_auto_queue_schema(conn)?;
+    run_migration_once(
+        conn,
+        AUTO_QUEUE_PHASE_GATE_BACKFILL_META_KEY,
+        backfill_auto_queue_phase_gates,
+    )?;
     ensure_api_friction_schema(conn)?;
 
     // Unique constraint: one kanban card per GitHub issue per repo.
@@ -837,6 +843,20 @@ pub(crate) fn ensure_auto_queue_schema(conn: &Connection) -> Result<()> {
             created_at      DATETIME DEFAULT CURRENT_TIMESTAMP,
             UNIQUE(entry_id, dispatch_id)
         );
+        CREATE TABLE IF NOT EXISTS auto_queue_phase_gates (
+            run_id          TEXT NOT NULL REFERENCES auto_queue_runs(id) ON DELETE CASCADE,
+            phase           INTEGER NOT NULL,
+            status          TEXT NOT NULL DEFAULT 'pending',
+            verdict         TEXT,
+            dispatch_id     TEXT UNIQUE REFERENCES task_dispatches(id) ON DELETE CASCADE,
+            pass_verdict    TEXT NOT NULL DEFAULT 'phase_gate_passed',
+            next_phase      INTEGER,
+            final_phase     INTEGER NOT NULL DEFAULT 0,
+            anchor_card_id  TEXT REFERENCES kanban_cards(id) ON DELETE SET NULL,
+            failure_reason  TEXT,
+            created_at      DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at      DATETIME DEFAULT CURRENT_TIMESTAMP
+        );
         CREATE INDEX IF NOT EXISTS idx_aq_entry_transitions_entry
             ON auto_queue_entry_transitions(entry_id);
         CREATE INDEX IF NOT EXISTS idx_aq_entry_transitions_created
@@ -846,7 +866,13 @@ pub(crate) fn ensure_auto_queue_schema(conn: &Connection) -> Result<()> {
         CREATE INDEX IF NOT EXISTS idx_aq_entry_dispatch_history_dispatch
             ON auto_queue_entry_dispatch_history(dispatch_id);
         CREATE INDEX IF NOT EXISTS idx_aq_entry_dispatch_history_created
-            ON auto_queue_entry_dispatch_history(created_at);",
+            ON auto_queue_entry_dispatch_history(created_at);
+        CREATE INDEX IF NOT EXISTS idx_aq_phase_gates_run_phase
+            ON auto_queue_phase_gates(run_id, phase);
+        CREATE INDEX IF NOT EXISTS idx_aq_phase_gates_run_status
+            ON auto_queue_phase_gates(run_id, status);
+        CREATE INDEX IF NOT EXISTS idx_aq_phase_gates_phase_dispatch
+            ON auto_queue_phase_gates(phase, dispatch_id);",
     )?;
 
     ensure_auto_queue_column(
@@ -1065,6 +1091,180 @@ fn backfill_auto_queue_dispatch_history(conn: &Connection) -> Result<()> {
         )?;
     }
 
+    Ok(())
+}
+
+fn backfill_auto_queue_phase_gates(conn: &Connection) -> Result<()> {
+    let rows = conn
+        .prepare(
+            "SELECT key, value
+             FROM kv_meta
+             WHERE key LIKE 'aq_phase_gate:%'",
+        )?
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    for (key, raw_value) in &rows {
+        let suffix = key.strip_prefix("aq_phase_gate:").unwrap_or(key);
+        let mut parts = suffix.rsplitn(2, ':');
+        let phase = parts
+            .next()
+            .and_then(|value| value.parse::<i64>().ok())
+            .unwrap_or(0);
+        let run_id_from_key = parts.next().unwrap_or_default().to_string();
+        let Ok(state) = serde_json::from_str::<serde_json::Value>(raw_value) else {
+            continue;
+        };
+
+        let run_id = state
+            .get("run_id")
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or(run_id_from_key.as_str())
+            .to_string();
+        let status = state
+            .get("status")
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or("pending")
+            .to_string();
+        let verdict = state
+            .get("failed_verdict")
+            .and_then(|value| value.as_str())
+            .map(str::to_string);
+        let next_phase = state.get("next_phase").and_then(|value| value.as_i64());
+        let final_phase = state
+            .get("final_phase")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        let anchor_card_id = state
+            .get("anchor_card_id")
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.trim().is_empty())
+            .map(str::to_string);
+        let failure_reason = state
+            .get("failed_reason")
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.trim().is_empty())
+            .map(str::to_string);
+        let created_at = state
+            .get("created_at")
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.trim().is_empty())
+            .map(str::to_string);
+        let pass_verdict = state
+            .get("gates")
+            .and_then(|value| value.as_array())
+            .and_then(|items| items.first())
+            .and_then(|item| item.get("pass_verdict"))
+            .and_then(|value| value.as_str())
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or("phase_gate_passed")
+            .to_string();
+        let dispatch_ids = state
+            .get("dispatch_ids")
+            .and_then(|value| value.as_array())
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(|item| item.as_str())
+                    .filter(|value| !value.trim().is_empty())
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        let valid_dispatch_ids = dispatch_ids
+            .into_iter()
+            .filter(|dispatch_id| {
+                conn.query_row(
+                    "SELECT COUNT(*) > 0 FROM task_dispatches WHERE id = ?1",
+                    [dispatch_id],
+                    |row| row.get::<_, bool>(0),
+                )
+                .unwrap_or(false)
+            })
+            .collect::<Vec<_>>();
+
+        if valid_dispatch_ids.is_empty() {
+            conn.execute(
+                "INSERT INTO auto_queue_phase_gates (
+                    run_id,
+                    phase,
+                    status,
+                    verdict,
+                    dispatch_id,
+                    pass_verdict,
+                    next_phase,
+                    final_phase,
+                    anchor_card_id,
+                    failure_reason,
+                    created_at,
+                    updated_at
+                ) VALUES (?1, ?2, ?3, ?4, NULL, ?5, ?6, ?7, ?8, ?9, COALESCE(?10, CURRENT_TIMESTAMP), datetime('now'))",
+                rusqlite::params![
+                    run_id,
+                    phase,
+                    status,
+                    verdict,
+                    pass_verdict,
+                    next_phase,
+                    final_phase,
+                    anchor_card_id,
+                    failure_reason,
+                    created_at,
+                ],
+            )?;
+            continue;
+        }
+
+        for dispatch_id in valid_dispatch_ids {
+            conn.execute(
+                "INSERT INTO auto_queue_phase_gates (
+                    run_id,
+                    phase,
+                    status,
+                    verdict,
+                    dispatch_id,
+                    pass_verdict,
+                    next_phase,
+                    final_phase,
+                    anchor_card_id,
+                    failure_reason,
+                    created_at,
+                    updated_at
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, COALESCE(?11, CURRENT_TIMESTAMP), datetime('now'))
+                ON CONFLICT(dispatch_id) DO UPDATE SET
+                    run_id = excluded.run_id,
+                    phase = excluded.phase,
+                    status = excluded.status,
+                    verdict = excluded.verdict,
+                    pass_verdict = excluded.pass_verdict,
+                    next_phase = excluded.next_phase,
+                    final_phase = excluded.final_phase,
+                    anchor_card_id = excluded.anchor_card_id,
+                    failure_reason = excluded.failure_reason,
+                    updated_at = datetime('now')",
+                rusqlite::params![
+                    run_id,
+                    phase,
+                    status,
+                    verdict,
+                    dispatch_id,
+                    pass_verdict,
+                    next_phase,
+                    final_phase,
+                    anchor_card_id,
+                    failure_reason,
+                    created_at,
+                ],
+            )?;
+        }
+    }
+
+    conn.execute("DELETE FROM kv_meta WHERE key LIKE 'aq_phase_gate:%'", [])?;
     Ok(())
 }
 
@@ -1682,5 +1882,115 @@ mod tests {
             )
             .unwrap();
         assert_eq!(transcript_backfill_flag, "1");
+    }
+
+    #[test]
+    fn backfill_auto_queue_phase_gates_moves_kv_json_into_table() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
+        migrate(&conn).unwrap();
+
+        conn.execute(
+            "INSERT INTO kanban_cards (id, title, status, created_at, updated_at)
+             VALUES ('card-phase-backfill', 'Phase Gate', 'done', datetime('now'), datetime('now'))",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO auto_queue_runs (id, repo, agent_id, status)
+             VALUES ('run-phase-backfill', 'test/repo', 'agent-1', 'paused')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO task_dispatches (
+                id, kanban_card_id, to_agent_id, dispatch_type, status, title, created_at, updated_at, context
+             ) VALUES (
+                'dispatch-phase-backfill',
+                'card-phase-backfill',
+                'agent-1',
+                'phase-gate',
+                'pending',
+                'Phase Gate',
+                datetime('now'),
+                datetime('now'),
+                '{}'
+             )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO kv_meta (key, value)
+             VALUES ('aq_phase_gate:run-phase-backfill:2', ?1)",
+            [serde_json::json!({
+                "run_id": "run-phase-backfill",
+                "batch_phase": 2,
+                "next_phase": 3,
+                "final_phase": false,
+                "anchor_card_id": "card-phase-backfill",
+                "status": "failed",
+                "dispatch_ids": ["dispatch-phase-backfill"],
+                "failed_verdict": "reject",
+                "failed_reason": "needs follow-up",
+                "created_at": "2026-04-13T00:00:00Z",
+                "gates": [
+                    { "pass_verdict": "phase_gate_passed" }
+                ]
+            })
+            .to_string()],
+        )
+        .unwrap();
+
+        backfill_auto_queue_phase_gates(&conn).unwrap();
+
+        let row: (
+            String,
+            i64,
+            String,
+            Option<String>,
+            Option<String>,
+            Option<i64>,
+            i64,
+            Option<String>,
+            Option<String>,
+        ) = conn
+            .query_row(
+                "SELECT run_id, phase, status, verdict, dispatch_id, next_phase, final_phase, anchor_card_id, failure_reason
+                 FROM auto_queue_phase_gates
+                 WHERE run_id = 'run-phase-backfill' AND phase = 2",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                        row.get(6)?,
+                        row.get(7)?,
+                        row.get(8)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(row.0, "run-phase-backfill");
+        assert_eq!(row.1, 2);
+        assert_eq!(row.2, "failed");
+        assert_eq!(row.3.as_deref(), Some("reject"));
+        assert_eq!(row.4.as_deref(), Some("dispatch-phase-backfill"));
+        assert_eq!(row.5, Some(3));
+        assert_eq!(row.6, 0);
+        assert_eq!(row.7.as_deref(), Some("card-phase-backfill"));
+        assert_eq!(row.8.as_deref(), Some("needs follow-up"));
+
+        let legacy_key_exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM kv_meta WHERE key = 'aq_phase_gate:run-phase-backfill:2'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(!legacy_key_exists);
     }
 }

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -584,6 +584,125 @@ mod tests {
         (result, String::from_utf8_lossy(&captured).to_string())
     }
 
+    fn set_phase_gate_state(
+        db: &db::Db,
+        run_id: &str,
+        phase: i64,
+        status: &str,
+        dispatch_ids: &[&str],
+        next_phase: Option<i64>,
+        final_phase: bool,
+        anchor_card_id: Option<&str>,
+        verdict: Option<&str>,
+        failure_reason: Option<&str>,
+    ) {
+        let conn = db.lock().unwrap();
+        let final_phase = if final_phase { 1 } else { 0 };
+        if dispatch_ids.is_empty() {
+            conn.execute(
+                "INSERT INTO auto_queue_phase_gates (
+                    run_id, phase, status, verdict, dispatch_id, pass_verdict,
+                    next_phase, final_phase, anchor_card_id, failure_reason
+                ) VALUES (?1, ?2, ?3, ?4, NULL, 'phase_gate_passed', ?5, ?6, ?7, ?8)",
+                rusqlite::params![
+                    run_id,
+                    phase,
+                    status,
+                    verdict,
+                    next_phase,
+                    final_phase,
+                    anchor_card_id,
+                    failure_reason,
+                ],
+            )
+            .unwrap();
+            return;
+        }
+
+        for dispatch_id in dispatch_ids {
+            conn.execute(
+                "INSERT INTO auto_queue_phase_gates (
+                    run_id, phase, status, verdict, dispatch_id, pass_verdict,
+                    next_phase, final_phase, anchor_card_id, failure_reason
+                ) VALUES (?1, ?2, ?3, ?4, ?5, 'phase_gate_passed', ?6, ?7, ?8, ?9)",
+                rusqlite::params![
+                    run_id,
+                    phase,
+                    status,
+                    verdict,
+                    dispatch_id,
+                    next_phase,
+                    final_phase,
+                    anchor_card_id,
+                    failure_reason,
+                ],
+            )
+            .unwrap();
+        }
+    }
+
+    fn phase_gate_state(db: &db::Db, run_id: &str, phase: i64) -> Option<serde_json::Value> {
+        let conn = db.lock().unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT dispatch_id, status, verdict, next_phase, final_phase, anchor_card_id, failure_reason
+                 FROM auto_queue_phase_gates
+                 WHERE run_id = ?1 AND phase = ?2
+                 ORDER BY dispatch_id ASC",
+            )
+            .unwrap();
+        let rows = stmt
+            .query_map(rusqlite::params![run_id, phase], |row| {
+                Ok((
+                    row.get::<_, Option<String>>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, Option<i64>>(3)?,
+                    row.get::<_, i64>(4)?,
+                    row.get::<_, Option<String>>(5)?,
+                    row.get::<_, Option<String>>(6)?,
+                ))
+            })
+            .unwrap()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap();
+        drop(stmt);
+        drop(conn);
+
+        if rows.is_empty() {
+            return None;
+        }
+
+        let failed = rows.iter().find(|row| row.1 == "failed");
+        let dispatch_ids = rows
+            .iter()
+            .filter_map(|row| row.0.clone())
+            .collect::<Vec<_>>();
+        let status = if failed.is_some() {
+            "failed"
+        } else if !dispatch_ids.is_empty() && rows.iter().all(|row| row.1 == "passed") {
+            "passed"
+        } else {
+            rows[0].1.as_str()
+        };
+
+        let mut value = serde_json::json!({
+            "run_id": run_id,
+            "batch_phase": phase,
+            "next_phase": rows[0].3,
+            "final_phase": rows[0].4 != 0,
+            "anchor_card_id": rows[0].5,
+            "status": status,
+            "dispatch_ids": dispatch_ids,
+        });
+        if let Some(failed_row) = failed {
+            value["failed_dispatch_id"] = serde_json::json!(failed_row.0);
+            value["failed_verdict"] = serde_json::json!(failed_row.2);
+            value["failed_reason"] = serde_json::json!(failed_row.6);
+        }
+        Some(value)
+    }
+
     fn escalation_pending_reasons(db: &db::Db, card_id: &str) -> Vec<String> {
         kv_value(db, &format!("pm_pending:{card_id}"))
             .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
@@ -1129,6 +1248,20 @@ mod tests {
                 trigger_source  TEXT,
                 created_at      DATETIME DEFAULT CURRENT_TIMESTAMP,
                 UNIQUE(entry_id, dispatch_id)
+            );
+            CREATE TABLE IF NOT EXISTS auto_queue_phase_gates (
+                run_id          TEXT NOT NULL,
+                phase           INTEGER NOT NULL,
+                status          TEXT NOT NULL DEFAULT 'pending',
+                verdict         TEXT,
+                dispatch_id     TEXT UNIQUE,
+                pass_verdict    TEXT NOT NULL DEFAULT 'phase_gate_passed',
+                next_phase      INTEGER,
+                final_phase     INTEGER NOT NULL DEFAULT 0,
+                anchor_card_id  TEXT,
+                failure_reason  TEXT,
+                created_at      DATETIME DEFAULT CURRENT_TIMESTAMP,
+                updated_at      DATETIME DEFAULT CURRENT_TIMESTAMP
             );",
         )
         .unwrap();
@@ -3420,16 +3553,10 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        let phase_gate_state: String = conn
-            .query_row(
-                "SELECT value FROM kv_meta WHERE key = 'aq_phase_gate:run-review-disabled-phase:1'",
-                [],
-                |row| row.get(0),
-            )
-            .unwrap();
         drop(conn);
 
-        let phase_gate_json: serde_json::Value = serde_json::from_str(&phase_gate_state).unwrap();
+        let phase_gate_json = phase_gate_state(&db, "run-review-disabled-phase", 1)
+            .expect("phase gate state must exist");
         assert_eq!(
             run_status, "paused",
             "multi-phase review-disabled terminal transition must pause the run for phase gate"
@@ -3483,20 +3610,17 @@ mod tests {
         )
         .expect("phase gate dispatch should be created");
         let phase_gate_dispatch_id = phase_gate_dispatch["id"].as_str().unwrap().to_string();
-        set_kv(
+        set_phase_gate_state(
             &db,
-            "aq_phase_gate:run-phase-final:2",
-            &json!({
-                "run_id": "run-phase-final",
-                "batch_phase": 2,
-                "next_phase": serde_json::Value::Null,
-                "final_phase": true,
-                "anchor_card_id": "card-phase-final",
-                "status": "pending",
-                "dispatch_ids": [phase_gate_dispatch_id.clone()],
-                "created_at": "2026-04-13T00:00:00Z"
-            })
-            .to_string(),
+            "run-phase-final",
+            2,
+            "pending",
+            &[phase_gate_dispatch_id.as_str()],
+            None,
+            true,
+            Some("card-phase-final"),
+            None,
+            None,
         );
 
         let state = AppState::test_state(db.clone(), engine.clone());
@@ -3506,7 +3630,7 @@ mod tests {
         assert_eq!(resume_body.0["resumed_runs"].as_u64(), Some(0));
         assert_eq!(resume_body.0["blocked_runs"].as_u64(), Some(1));
         assert_eq!(
-            kv_value(&db, "aq_phase_gate:run-phase-final:2").is_some(),
+            phase_gate_state(&db, "run-phase-final", 2).is_some(),
             true,
             "resume must leave the blocking phase gate untouched"
         );
@@ -3537,7 +3661,7 @@ mod tests {
             "final phase-gate pass should resume and complete the paused run"
         );
         assert!(
-            kv_value(&db, "aq_phase_gate:run-phase-final:2").is_none(),
+            phase_gate_state(&db, "run-phase-final", 2).is_none(),
             "successful gate completion must clear the persisted phase gate state"
         );
     }
@@ -4359,16 +4483,10 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        let phase_gate_state: String = conn
-            .query_row(
-                "SELECT value FROM kv_meta WHERE key = 'aq_phase_gate:run-547-phase:1'",
-                [],
-                |row| row.get(0),
-            )
-            .unwrap();
         drop(conn);
 
-        let phase_gate_json: serde_json::Value = serde_json::from_str(&phase_gate_state).unwrap();
+        let phase_gate_json =
+            phase_gate_state(&db, "run-547-phase", 1).expect("phase gate state must exist");
         assert_eq!(entry_status, "done");
         assert_eq!(
             run_status, "paused",

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -1250,19 +1250,26 @@ mod tests {
                 UNIQUE(entry_id, dispatch_id)
             );
             CREATE TABLE IF NOT EXISTS auto_queue_phase_gates (
-                run_id          TEXT NOT NULL,
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                run_id          TEXT NOT NULL REFERENCES auto_queue_runs(id) ON DELETE CASCADE,
                 phase           INTEGER NOT NULL,
                 status          TEXT NOT NULL DEFAULT 'pending',
                 verdict         TEXT,
-                dispatch_id     TEXT UNIQUE,
+                dispatch_id     TEXT REFERENCES task_dispatches(id) ON DELETE CASCADE
+                                    CHECK(dispatch_id IS NULL OR TRIM(dispatch_id) <> ''),
                 pass_verdict    TEXT NOT NULL DEFAULT 'phase_gate_passed',
                 next_phase      INTEGER,
                 final_phase     INTEGER NOT NULL DEFAULT 0,
-                anchor_card_id  TEXT,
+                anchor_card_id  TEXT REFERENCES kanban_cards(id) ON DELETE SET NULL,
                 failure_reason  TEXT,
                 created_at      DATETIME DEFAULT CURRENT_TIMESTAMP,
                 updated_at      DATETIME DEFAULT CURRENT_TIMESTAMP
-            );",
+            );
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_aq_phase_gates_run_phase_dispatch_key
+                ON auto_queue_phase_gates(run_id, phase, COALESCE(dispatch_id, ''));
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_aq_phase_gates_dispatch_id
+                ON auto_queue_phase_gates(dispatch_id);
+            ",
         )
         .unwrap();
     }

--- a/src/server/routes/auto_queue.rs
+++ b/src/server/routes/auto_queue.rs
@@ -3724,9 +3724,9 @@ pub async fn resume_run(State(state): State<AppState>) -> (StatusCode, Json<serd
              WHERE r.status = 'paused'
                AND EXISTS (
                    SELECT 1
-                   FROM kv_meta km
-                   WHERE km.key LIKE 'aq_phase_gate:' || r.id || ':%'
-                     AND json_extract(COALESCE(km.value, '{}'), '$.status') IN ('pending', 'failed')
+                   FROM auto_queue_phase_gates pg
+                   WHERE pg.run_id = r.id
+                     AND pg.status IN ('pending', 'failed')
                )",
             [],
             |row| row.get(0),
@@ -3739,9 +3739,9 @@ pub async fn resume_run(State(state): State<AppState>) -> (StatusCode, Json<serd
              WHERE status = 'paused'
                AND NOT EXISTS (
                    SELECT 1
-                   FROM kv_meta km
-                   WHERE km.key LIKE 'aq_phase_gate:' || auto_queue_runs.id || ':%'
-                     AND json_extract(COALESCE(km.value, '{}'), '$.status') IN ('pending', 'failed')
+                   FROM auto_queue_phase_gates pg
+                   WHERE pg.run_id = auto_queue_runs.id
+                     AND pg.status IN ('pending', 'failed')
                )",
             [],
         )

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -3490,19 +3490,25 @@ fn ensure_auto_queue_tables(db: &Db) {
             PRIMARY KEY (agent_id, slot_index)
         );
         CREATE TABLE IF NOT EXISTS auto_queue_phase_gates (
-            run_id          TEXT NOT NULL,
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id          TEXT NOT NULL REFERENCES auto_queue_runs(id) ON DELETE CASCADE,
             phase           INTEGER NOT NULL,
             status          TEXT NOT NULL DEFAULT 'pending',
             verdict         TEXT,
-            dispatch_id     TEXT UNIQUE,
+            dispatch_id     TEXT REFERENCES task_dispatches(id) ON DELETE CASCADE
+                                CHECK(dispatch_id IS NULL OR TRIM(dispatch_id) <> ''),
             pass_verdict    TEXT NOT NULL DEFAULT 'phase_gate_passed',
             next_phase      INTEGER,
             final_phase     INTEGER NOT NULL DEFAULT 0,
-            anchor_card_id  TEXT,
+            anchor_card_id  TEXT REFERENCES kanban_cards(id) ON DELETE SET NULL,
             failure_reason  TEXT,
             created_at      DATETIME DEFAULT CURRENT_TIMESTAMP,
             updated_at      DATETIME DEFAULT CURRENT_TIMESTAMP
-        );",
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_aq_phase_gates_run_phase_dispatch_key
+            ON auto_queue_phase_gates(run_id, phase, COALESCE(dispatch_id, ''));
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_aq_phase_gates_dispatch_id
+            ON auto_queue_phase_gates(dispatch_id);",
     )
     .unwrap();
 }

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -3488,6 +3488,20 @@ fn ensure_auto_queue_tables(db: &Db) {
             created_at            DATETIME DEFAULT CURRENT_TIMESTAMP,
             updated_at            DATETIME DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY (agent_id, slot_index)
+        );
+        CREATE TABLE IF NOT EXISTS auto_queue_phase_gates (
+            run_id          TEXT NOT NULL,
+            phase           INTEGER NOT NULL,
+            status          TEXT NOT NULL DEFAULT 'pending',
+            verdict         TEXT,
+            dispatch_id     TEXT UNIQUE,
+            pass_verdict    TEXT NOT NULL DEFAULT 'phase_gate_passed',
+            next_phase      INTEGER,
+            final_phase     INTEGER NOT NULL DEFAULT 0,
+            anchor_card_id  TEXT,
+            failure_reason  TEXT,
+            created_at      DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at      DATETIME DEFAULT CURRENT_TIMESTAMP
         );",
     )
     .unwrap();
@@ -9534,18 +9548,10 @@ async fn activate_run_id_blocks_phase_gate_paused_runs() {
         )
         .unwrap();
         conn.execute(
-            "INSERT OR REPLACE INTO kv_meta (key, value)
-             VALUES (?1, ?2)",
-            rusqlite::params![
-                "aq_phase_gate:run-phase-gate-paused:1",
-                serde_json::json!({
-                    "run_id": "run-phase-gate-paused",
-                    "batch_phase": 1,
-                    "status": "pending",
-                    "dispatch_ids": ["dispatch-phase-gate-1"]
-                })
-                .to_string()
-            ],
+            "INSERT INTO auto_queue_phase_gates (
+                run_id, phase, status, dispatch_id, pass_verdict
+             ) VALUES (?1, ?2, ?3, NULL, 'phase_gate_passed')",
+            rusqlite::params!["run-phase-gate-paused", 1, "pending",],
         )
         .unwrap();
     }
@@ -9636,18 +9642,10 @@ async fn resume_run_skips_phase_gate_blocked_runs() {
         )
         .unwrap();
         conn.execute(
-            "INSERT OR REPLACE INTO kv_meta (key, value)
-             VALUES (?1, ?2)",
-            rusqlite::params![
-                "aq_phase_gate:run-resume-gate:1",
-                serde_json::json!({
-                    "run_id": "run-resume-gate",
-                    "batch_phase": 1,
-                    "status": "failed",
-                    "dispatch_ids": ["dispatch-phase-gate-failed"]
-                })
-                .to_string()
-            ],
+            "INSERT INTO auto_queue_phase_gates (
+                run_id, phase, status, dispatch_id, pass_verdict
+             ) VALUES (?1, ?2, ?3, NULL, 'phase_gate_passed')",
+            rusqlite::params!["run-resume-gate", 1, "failed",],
         )
         .unwrap();
     }
@@ -10209,18 +10207,10 @@ fn auto_queue_recovery_keeps_finished_phase_gate_runs_blocked_until_gate_resolve
         )
         .unwrap();
         conn.execute(
-            "INSERT OR REPLACE INTO kv_meta (key, value)
-             VALUES (?1, ?2)",
-            rusqlite::params![
-                "aq_phase_gate:run-finished-gate:1",
-                serde_json::json!({
-                    "run_id": "run-finished-gate",
-                    "batch_phase": 1,
-                    "status": "pending",
-                    "dispatch_ids": ["dispatch-phase-gate-finished"]
-                })
-                .to_string()
-            ],
+            "INSERT INTO auto_queue_phase_gates (
+                run_id, phase, status, dispatch_id, pass_verdict
+             ) VALUES (?1, ?2, ?3, NULL, 'phase_gate_passed')",
+            rusqlite::params!["run-finished-gate", 1, "pending",],
         )
         .unwrap();
     }


### PR DESCRIPTION
Automated fallback PR after direct merge into `main` hit a cherry-pick conflict.

Card: `805e449e-a9fa-4bc2-97a6-028d9ec83aa7`
Issue: https://github.com/itismyfield/AgentDesk/issues/497

Conflict summary:
error: could not apply 7a100fe... #497 Refactor phase gates into auto_queue_phase_gates hint: After resolving the conflicts, mark them with hint: "git add/rm <pathspec>", then r...