### PR TITLE
#643 refactor: PMD 역할 축소 — 알림 라우팅 재분배 및 PMD 전용 API 개방

### DIFF
--- a/agentdesk.example.yaml
+++ b/agentdesk.example.yaml
@@ -74,6 +74,7 @@ data:
 kanban:
   manager_channel_id: "123456789012345678"
   deadlock_manager_channel_id: "223456789012345678"
+  human_alert_channel_id: "323456789012345678"
   pm_decision_gate_enabled: true
 
 review:

--- a/dashboard/src/components/SettingsView.tsx
+++ b/dashboard/src/components/SettingsView.tsx
@@ -292,6 +292,10 @@ const SYSTEM_CONFIG_DESCRIPTIONS: Record<string, { ko: string; en: string }> = {
     ko: "교착 상태나 멈춤 감지를 보고하는 Discord 채널입니다.",
     en: "Discord channel that receives deadlock and stalled-work alerts.",
   },
+  kanban_human_alert_channel_id: {
+    ko: "에이전트 fallback이나 수동 개입이 사람에게 라우팅될 Discord 채널입니다.",
+    en: "Discord channel used when alerts must be routed to a human instead of an agent.",
+  },
   review_enabled: {
     ko: "리뷰 단계를 전체 파이프라인에 적용할지 결정합니다.",
     en: "Controls whether the review step is enforced across the pipeline.",

--- a/policies/00-escalation.js
+++ b/policies/00-escalation.js
@@ -83,6 +83,39 @@ function escalateToManualIntervention(cardId, reason, options) {
   }
 }
 
+function getConfiguredChannelTarget(configKey, purpose) {
+  var ch = agentdesk.config.get(configKey);
+  if (!ch) {
+    agentdesk.log.warn("[notify] No " + configKey + " configured, skipping " + purpose);
+    return null;
+  }
+  return "channel:" + ch;
+}
+
+function getHumanAlertChannel() {
+  return getConfiguredChannelTarget("kanban_human_alert_channel_id", "human alert");
+}
+
+function notifyHumanAlert(message, source) {
+  var target = getHumanAlertChannel();
+  if (!target) return false;
+  agentdesk.message.queue(target, message, "notify", source || "system");
+  return true;
+}
+
+function getDeadlockManagerChannel() {
+  return getConfiguredChannelTarget("deadlock_manager_channel_id", "deadlock alert");
+}
+
+function notifyDeadlockManager(message, source) {
+  var target = getDeadlockManagerChannel();
+  if (target) {
+    agentdesk.message.queue(target, message, "announce", source || "system");
+    return true;
+  }
+  return notifyHumanAlert(message, source || "system");
+}
+
 function escalationServerPort() {
   return agentdesk.config.get("server_port");
 }

--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -90,6 +90,57 @@ function autoQueueLog(level, message, context) {
   agentdesk.log[level]("[auto-queue] " + message + _formatAutoQueueLogContext(merged));
 }
 
+var PHASE_GATE_HUMAN_ESCALATION_THRESHOLD = 3;
+var PHASE_GATE_FAILURE_TTL_SEC = 7 * 24 * 60 * 60;
+
+function phaseGateFailureKey(cardId, phase) {
+  return "phase_gate_failure:" + cardId + ":" + phase;
+}
+
+function incrementPhaseGateFailureCount(cardId, phase) {
+  if (!cardId) return 0;
+  var key = phaseGateFailureKey(cardId, phase);
+  var current = parseInt(agentdesk.kv.get(key) || "0", 10);
+  if (!current || current < 0) current = 0;
+  var next = current + 1;
+  agentdesk.kv.set(key, String(next), PHASE_GATE_FAILURE_TTL_SEC);
+  return next;
+}
+
+function resetPhaseGateFailureCount(cardId, phase) {
+  if (!cardId) return;
+  agentdesk.kv.delete(phaseGateFailureKey(cardId, phase));
+}
+
+function loadPhaseGateCardLabel(cardId) {
+  if (!cardId) return "unknown card";
+  var rows = agentdesk.db.query(
+    "SELECT COALESCE(title, id) as title, github_issue_number FROM kanban_cards WHERE id = ?",
+    [cardId]
+  );
+  if (rows.length === 0) return cardId;
+  if (rows[0].github_issue_number) {
+    return "#" + rows[0].github_issue_number + " " + rows[0].title;
+  }
+  return rows[0].title || cardId;
+}
+
+function handlePhaseGateFailure(cardId, phase, reason, context) {
+  var failureCount = incrementPhaseGateFailureCount(cardId, phase);
+  notifyCardOwner(cardId, reason, "auto-queue");
+  if (failureCount >= PHASE_GATE_HUMAN_ESCALATION_THRESHOLD) {
+    notifyHumanAlert(
+      "⚠️ [Phase Gate] " + loadPhaseGateCardLabel(cardId) + "\n" +
+        "phase " + phase + " 실패가 " + failureCount + "회 누적되었습니다.\n" +
+        reason + "\n" +
+        "사람 확인이 필요합니다.",
+      "auto-queue"
+    );
+  }
+  autoQueueLog("warn", "Phase gate failure recorded for card " + (cardId || "unknown") + " phase " + phase + " count=" + failureCount, context);
+  return failureCount;
+}
+
 var autoQueue = {
   name: "auto-queue",
   priority: 500,
@@ -205,7 +256,17 @@ var autoQueue = {
       state.failed_reason = result.summary || result.reason || ("expected " + passVerdict + ", got " + (verdict || "none"));
       savePhaseGateState(gate.run_id, phase, state);
       pauseRun(gate.run_id);
-      notifyPMD(state.anchor_card_id || dispatch.kanban_card_id, "[phase-gate] phase " + phase + " failed: " + state.failed_reason);
+      handlePhaseGateFailure(
+        state.anchor_card_id || dispatch.kanban_card_id,
+        phase,
+        "[phase-gate] phase " + phase + " failed: " + state.failed_reason,
+        {
+          run_id: gate.run_id,
+          dispatch_id: dispatch.id,
+          card_id: state.anchor_card_id || dispatch.kanban_card_id,
+          batch_phase: phase
+        }
+      );
       autoQueueLog("warn", "Phase gate failed for run " + gate.run_id + " phase " + phase + ": " + state.failed_reason, {
         run_id: gate.run_id,
         dispatch_id: dispatch.id,
@@ -222,7 +283,17 @@ var autoQueue = {
       state.failed_reason = "missing phase gate dispatch rows";
       savePhaseGateState(gate.run_id, phase, state);
       pauseRun(gate.run_id);
-      notifyPMD(state.anchor_card_id || dispatch.kanban_card_id, "[phase-gate] phase " + phase + " failed: missing gate dispatch rows");
+      handlePhaseGateFailure(
+        state.anchor_card_id || dispatch.kanban_card_id,
+        phase,
+        "[phase-gate] phase " + phase + " failed: missing gate dispatch rows",
+        {
+          run_id: gate.run_id,
+          dispatch_id: dispatch.id,
+          card_id: state.anchor_card_id || dispatch.kanban_card_id,
+          batch_phase: phase
+        }
+      );
       return;
     }
 
@@ -246,7 +317,17 @@ var autoQueue = {
         state.failed_reason = gateResult.summary || gateResult.reason || ("gate verdict mismatch for dispatch " + gateDispatch.id);
         savePhaseGateState(gate.run_id, phase, state);
         pauseRun(gate.run_id);
-        notifyPMD(state.anchor_card_id || dispatch.kanban_card_id, "[phase-gate] phase " + phase + " failed: " + state.failed_reason);
+        handlePhaseGateFailure(
+          state.anchor_card_id || dispatch.kanban_card_id,
+          phase,
+          "[phase-gate] phase " + phase + " failed: " + state.failed_reason,
+          {
+            run_id: gate.run_id,
+            dispatch_id: gateDispatch.id,
+            card_id: state.anchor_card_id || dispatch.kanban_card_id,
+            batch_phase: phase
+          }
+        );
         return;
       }
     }
@@ -262,6 +343,7 @@ var autoQueue = {
     }
 
     clearPhaseGateState(gate.run_id, phase);
+    resetPhaseGateFailureCount(state.anchor_card_id || dispatch.kanban_card_id, phase);
     if (state.final_phase || gate.final_phase) {
       completeRunAndNotify(gate.run_id);
       autoQueueLog("info", "Phase gate passed, completed run " + gate.run_id + " at phase " + phase, {
@@ -904,7 +986,16 @@ function _createPhaseGateDispatches(runId, phase, nextPhase, finalPhase, anchorC
     state.status = "failed";
     state.failed_reason = "no phase gate targets found";
     savePhaseGateState(runId, phase, state);
-    notifyPMD(anchorCardId, "[phase-gate] run " + runId.substring(0, 8) + " phase " + phase + " has no gate targets");
+    handlePhaseGateFailure(
+      anchorCardId,
+      phase,
+      "[phase-gate] run " + runId.substring(0, 8) + " phase " + phase + " has no gate targets",
+      {
+        run_id: runId,
+        card_id: anchorCardId,
+        batch_phase: phase
+      }
+    );
     return state;
   }
 
@@ -956,7 +1047,16 @@ function _createPhaseGateDispatches(runId, phase, nextPhase, finalPhase, anchorC
     state.status = "failed";
     state.failed_reason = errors.join("; ") || "phase gate dispatch creation failed";
     savePhaseGateState(runId, phase, state);
-    notifyPMD(anchorCardId, "[phase-gate] run " + runId.substring(0, 8) + " phase " + phase + " setup failed: " + state.failed_reason);
+    handlePhaseGateFailure(
+      anchorCardId,
+      phase,
+      "[phase-gate] run " + runId.substring(0, 8) + " phase " + phase + " setup failed: " + state.failed_reason,
+      {
+        run_id: runId,
+        card_id: anchorCardId,
+        batch_phase: phase
+      }
+    );
     autoQueueLog("warn", "Phase gate setup failed for run " + runId + " phase " + phase + ": " + state.failed_reason, {
       run_id: runId,
       card_id: anchorCardId,

--- a/policies/kanban-rules.js
+++ b/policies/kanban-rules.js
@@ -15,8 +15,54 @@ function sendDiscordNotification(target, content, bot) {
   agentdesk.message.queue(target, content, bot || "announce", "system");
 }
 
-function notifyPMD(cardId, reason) {
-  escalate(cardId, reason);
+function _loadCardAlertContext(cardId) {
+  var rows = agentdesk.db.query(
+    "SELECT assigned_agent_id, COALESCE(title, id) as title, github_issue_number " +
+    "FROM kanban_cards WHERE id = ?",
+    [cardId]
+  );
+  if (rows.length === 0) return null;
+  return {
+    card_id: cardId,
+    assigned_agent_id: rows[0].assigned_agent_id || null,
+    title: rows[0].title || cardId,
+    github_issue_number: rows[0].github_issue_number || null
+  };
+}
+
+function _formatCardAlertLabel(card) {
+  if (!card) return null;
+  if (card.github_issue_number) {
+    return "#" + card.github_issue_number + " " + (card.title || card.card_id);
+  }
+  return card.title || card.card_id;
+}
+
+function notifyCardOwner(cardId, reason, source) {
+  var card = _loadCardAlertContext(cardId);
+  var src = source || "system";
+  if (!card) {
+    agentdesk.log.warn("[notify] Card not found for owner notification: " + cardId);
+    return notifyHumanAlert("⚠️ 카드 " + cardId + "\n" + reason, src);
+  }
+
+  var message = "⚠️ " + _formatCardAlertLabel(card) + "\n" + reason;
+  if (!card.assigned_agent_id) {
+    agentdesk.log.warn("[notify] Card " + cardId + " has no assigned agent — escalating to human");
+    return notifyHumanAlert(message + "\n담당 에이전트가 없어 사람이 확인해야 합니다.", src);
+  }
+
+  var target = agentdesk.agents.resolvePrimaryChannel(card.assigned_agent_id);
+  if (!target) {
+    agentdesk.log.warn(
+      "[notify] No primary channel for assigned agent " + card.assigned_agent_id +
+      " on card " + cardId + " — escalating to human"
+    );
+    return notifyHumanAlert(message + "\n담당 에이전트 채널을 찾지 못해 사람이 확인해야 합니다.", src);
+  }
+
+  agentdesk.message.queue(target, message, "announce", src);
+  return true;
 }
 
 // ── Preflight helpers (#256) ─────────────────────────────────
@@ -460,16 +506,19 @@ var rules = {
     // by auto-queue, which triggers DispatchAttached to advance requested → in_progress.
     if (payload.to === initialState && payload.from !== initialState) {
       var metaBeforePreflight = _loadCardMetadata(payload.card_id);
-      if (metaBeforePreflight.skip_preflight_once === "pmd_reopen") {
+      if (
+        metaBeforePreflight.skip_preflight_once === "api_reopen" ||
+        metaBeforePreflight.skip_preflight_once === "pmd_reopen"
+      ) {
         delete metaBeforePreflight.skip_preflight_once;
         metaBeforePreflight.preflight_status = "skipped";
-        metaBeforePreflight.preflight_summary = "Skipped for PMD reopen";
+        metaBeforePreflight.preflight_summary = "Skipped for API reopen";
         metaBeforePreflight.preflight_checked_at = new Date().toISOString();
         agentdesk.db.execute(
           "UPDATE kanban_cards SET metadata = ? WHERE id = ?",
           [JSON.stringify(metaBeforePreflight), payload.card_id]
         );
-        agentdesk.log.info("[preflight] Skipped for PMD reopen: " + payload.card_id);
+        agentdesk.log.info("[preflight] Skipped for API reopen: " + payload.card_id);
         return;
       }
 

--- a/policies/review-automation.js
+++ b/policies/review-automation.js
@@ -106,15 +106,24 @@ var reviewAutomation = {
     // #117: Update canonical card_review_state
     agentdesk.reviewState.sync(card.id, "reviewing", { review_round: newRound });
 
-    // Check review round limit — exceed → dilemma_pending with PMD notification
+    // Check review round limit — exceed → dilemma_pending with deadlock-manager notification
     var maxRounds = agentdesk.config.get("max_review_rounds") || 3;
     if (newRound > maxRounds) {
       escalateToManualIntervention(card.id, "Max review rounds (" + maxRounds + ") exceeded — PM decision needed", {
         review: true,
-        reviewStateSync: { review_round: newRound }
+        reviewStateSync: { review_round: newRound },
+        skipEscalate: true
       });
       agentdesk.log.warn("[review] Max review rounds (" + maxRounds + ") reached for " + card.id + " → dilemma_pending");
-      notifyPmdPendingDecision(card.id, "리뷰 라운드 상한(" + maxRounds + "회) 초과");
+      notifyDeadlockManager(
+        "⚠️ [Review Deadlock] " +
+          (card.github_issue_number ? ("#" + card.github_issue_number + " ") : "") +
+          (card.title || card.id) + "\n" +
+          "card_id: " + card.id + "\n" +
+          "agent: " + card.assigned_agent_id + "\n" +
+          "review round " + newRound + " exceeded max " + maxRounds,
+        "review-automation"
+      );
       return;
     }
     // Create review dispatch (targets same agent — counter channel picks it up)

--- a/policies/timeouts.js
+++ b/policies/timeouts.js
@@ -22,26 +22,8 @@
  * [O] Idle session TTL cleanup (5분) — idle 60분 tmux-backed 세션 force-kill
  */
 
-// Get PMD channel for alerts
-function getPMDChannel() {
-  var ch = agentdesk.config.get("kanban_manager_channel_id");
-  if (!ch) {
-    agentdesk.log.warn("[notify] No kanban_manager_channel_id configured, skipping");
-    return null;
-  }
-  return "channel:" + ch;
-}
-
-// Send deadlock alert via announce bot to deadlock-manager channel
 function sendDeadlockAlert(message) {
-  var ch = agentdesk.config.get("deadlock_manager_channel_id");
-  if (!ch) {
-    // Fallback to PMD channel via announce bot (actionable alert, not info-only)
-    var pmd = getPMDChannel();
-    if (pmd) agentdesk.message.queue(pmd, message, "announce", "system");
-    return;
-  }
-  agentdesk.message.queue("channel:" + ch, message, "announce", "system");
+  return notifyDeadlockManager(message, "timeouts");
 }
 
 // Shared constant used by sections [A] and [J]

--- a/src/config.rs
+++ b/src/config.rs
@@ -469,6 +469,8 @@ pub struct KanbanConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deadlock_manager_channel_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub human_alert_channel_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pm_decision_gate_enabled: Option<bool>,
 }
 
@@ -476,6 +478,7 @@ impl KanbanConfig {
     pub fn is_empty(&self) -> bool {
         self.manager_channel_id.is_none()
             && self.deadlock_manager_channel_id.is_none()
+            && self.human_alert_channel_id.is_none()
             && self.pm_decision_gate_enabled.is_none()
     }
 }
@@ -1230,6 +1233,7 @@ mod tests {
         config.kanban = KanbanConfig {
             manager_channel_id: Some("123456789012345678".to_string()),
             deadlock_manager_channel_id: Some("223456789012345678".to_string()),
+            human_alert_channel_id: Some("323456789012345678".to_string()),
             pm_decision_gate_enabled: Some(true),
         };
         config.review = ReviewConfig {
@@ -1355,6 +1359,10 @@ mod tests {
         assert_eq!(
             loaded.kanban.deadlock_manager_channel_id.as_deref(),
             Some("223456789012345678")
+        );
+        assert_eq!(
+            loaded.kanban.human_alert_channel_id.as_deref(),
+            Some("323456789012345678")
         );
         assert_eq!(loaded.kanban.pm_decision_gate_enabled, Some(true));
         assert_eq!(loaded.review.enabled, Some(true));

--- a/src/db/auto_queue.rs
+++ b/src/db/auto_queue.rs
@@ -105,6 +105,117 @@ pub fn update_entry_status_on_conn(
     )
 }
 
+pub fn reactivate_done_entry_on_conn(
+    conn: &Connection,
+    entry_id: &str,
+    trigger_source: &str,
+    options: &EntryStatusUpdateOptions,
+) -> Result<EntryStatusUpdateResult, EntryStatusUpdateError> {
+    let current = load_entry_status_row(conn, entry_id)?;
+    if current.status != ENTRY_STATUS_DONE {
+        return update_entry_status_with_current_on_conn(
+            conn,
+            entry_id,
+            ENTRY_STATUS_DISPATCHED,
+            trigger_source,
+            options,
+            current,
+        );
+    }
+
+    let effective_dispatch_id = options
+        .dispatch_id
+        .clone()
+        .or_else(|| current.dispatch_id.clone());
+    let effective_slot_index = options.slot_index.or(current.slot_index);
+
+    conn.execute_batch("SAVEPOINT auto_queue_entry_done_reactivate")?;
+    let restore_result = (|| -> rusqlite::Result<usize> {
+        let rows_affected = conn.execute(
+            "UPDATE auto_queue_entries
+                 SET status = 'dispatched',
+                     dispatch_id = ?1,
+                     slot_index = ?2,
+                     dispatched_at = datetime('now'),
+                     completed_at = NULL
+                 WHERE id = ?3
+                   AND status = 'done'",
+            rusqlite::params![effective_dispatch_id, effective_slot_index, entry_id,],
+        )?;
+
+        if rows_affected == 0 {
+            return Ok(0);
+        }
+
+        conn.execute(
+            "UPDATE auto_queue_runs
+                 SET status = 'active',
+                     completed_at = NULL
+                 WHERE id = ?1
+                   AND status = 'completed'",
+            [&current.run_id],
+        )?;
+
+        if let Some(dispatch_id) = effective_dispatch_id.as_deref() {
+            record_entry_dispatch_history_on_conn(conn, entry_id, dispatch_id, trigger_source)?;
+        }
+
+        record_entry_transition_on_conn(
+            conn,
+            entry_id,
+            ENTRY_STATUS_DONE,
+            ENTRY_STATUS_DISPATCHED,
+            trigger_source,
+        )?;
+
+        Ok(rows_affected)
+    })();
+
+    let rows_affected = match restore_result {
+        Ok(rows_affected) => {
+            conn.execute_batch("RELEASE SAVEPOINT auto_queue_entry_done_reactivate")?;
+            rows_affected
+        }
+        Err(error) => {
+            let _ = conn.execute_batch(
+                "ROLLBACK TO SAVEPOINT auto_queue_entry_done_reactivate; \
+                 RELEASE SAVEPOINT auto_queue_entry_done_reactivate",
+            );
+            return Err(EntryStatusUpdateError::Sql(error));
+        }
+    };
+
+    if rows_affected == 0 {
+        let latest = load_entry_status_row(conn, entry_id)?;
+        if entry_status_row_matches_target(
+            &latest,
+            ENTRY_STATUS_DISPATCHED,
+            effective_dispatch_id.as_deref(),
+            effective_slot_index,
+        ) {
+            return Ok(EntryStatusUpdateResult {
+                run_id: latest.run_id,
+                from_status: latest.status,
+                to_status: ENTRY_STATUS_DISPATCHED.to_string(),
+                changed: false,
+            });
+        }
+
+        return Err(EntryStatusUpdateError::InvalidTransition {
+            entry_id: entry_id.to_string(),
+            from_status: latest.status,
+            to_status: ENTRY_STATUS_DISPATCHED.to_string(),
+        });
+    }
+
+    Ok(EntryStatusUpdateResult {
+        run_id: current.run_id,
+        from_status: ENTRY_STATUS_DONE.to_string(),
+        to_status: ENTRY_STATUS_DISPATCHED.to_string(),
+        changed: true,
+    })
+}
+
 fn update_entry_status_with_current_on_conn(
     conn: &Connection,
     entry_id: &str,
@@ -1937,8 +2048,8 @@ mod tests {
         ENTRY_STATUS_PENDING, ENTRY_STATUS_SKIPPED, EntryStatusUpdateError,
         EntryStatusUpdateOptions, PhaseGateStateWrite, SlotAllocationError,
         allocate_slot_for_group_agent, clear_phase_gate_state_on_conn, list_entry_dispatch_history,
-        record_consultation_dispatch_on_conn, release_slot_for_group_agent,
-        save_phase_gate_state_on_conn, update_entry_status_on_conn,
+        reactivate_done_entry_on_conn, record_consultation_dispatch_on_conn,
+        release_slot_for_group_agent, save_phase_gate_state_on_conn, update_entry_status_on_conn,
     };
     use rusqlite::{Connection, OpenFlags};
     use std::sync::{Arc, Barrier};
@@ -2532,6 +2643,57 @@ mod tests {
             error,
             EntryStatusUpdateError::InvalidTransition { .. }
         ));
+    }
+
+    #[test]
+    fn reactivate_done_entry_allows_admin_restore_to_dispatched() {
+        let conn = setup_conn();
+        conn.execute(
+            "INSERT INTO auto_queue_runs (id, repo, agent_id, status)
+             VALUES ('run-reactivate', 'repo-1', 'agent-1', 'completed')",
+            [],
+        )
+        .expect("seed run");
+        conn.execute(
+            "INSERT INTO auto_queue_entries (
+                 id, run_id, kanban_card_id, agent_id, status, thread_group, completed_at
+             ) VALUES ('entry-reactivate', 'run-reactivate', 'card-reactivate', 'agent-1', 'done', 0, datetime('now'))",
+            [],
+        )
+        .expect("seed done entry");
+
+        let restored = reactivate_done_entry_on_conn(
+            &conn,
+            "entry-reactivate",
+            "test_reactivate_done",
+            &EntryStatusUpdateOptions::default(),
+        )
+        .expect("reactivate done entry");
+        assert!(restored.changed);
+        assert_eq!(restored.from_status, ENTRY_STATUS_DONE);
+        assert_eq!(restored.to_status, ENTRY_STATUS_DISPATCHED);
+
+        let (status, dispatch_id, completed_at): (String, Option<String>, Option<String>) = conn
+            .query_row(
+                "SELECT status, dispatch_id, completed_at
+                 FROM auto_queue_entries
+                 WHERE id = 'entry-reactivate'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("entry row");
+        assert_eq!(status, ENTRY_STATUS_DISPATCHED);
+        assert!(dispatch_id.is_none());
+        assert!(completed_at.is_none());
+
+        let run_status: String = conn
+            .query_row(
+                "SELECT status FROM auto_queue_runs WHERE id = 'run-reactivate'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("run row");
+        assert_eq!(run_status, "active");
     }
 
     #[test]

--- a/src/kanban.rs
+++ b/src/kanban.rs
@@ -29,8 +29,8 @@ use serde_json::json;
 /// 6. OnCardTerminal hook (when → done)
 /// 7. auto_queue_entries sync (when → done)
 ///
-/// `source`: who initiated the transition (e.g., "api", "policy", "pmd")
-/// `force`: PMD-only override to bypass dispatch validation
+/// `source`: who initiated the transition (e.g., "api", "policy", "agentdesk")
+/// `force`: administrative override to bypass dispatch validation
 pub fn transition_status(
     db: &Db,
     engine: &PolicyEngine,
@@ -194,7 +194,6 @@ where
             source,
             reason
         );
-        notify_pmd_violation(&conn, card_id, &old_status, new_status, source, reason);
         return Err(anyhow::anyhow!("{}", reason));
     }
 
@@ -625,111 +624,6 @@ fn github_sync_on_transition(
     } else if is_review_enter {
         let comment = "🔍 칸반 상태: **review** (카운터모델 리뷰 진행 중)";
         let _ = crate::github::comment_issue(&repo, num, comment);
-    }
-}
-
-/// Cooldown period for violation alerts (30 minutes).
-const VIOLATION_COOLDOWN_SECS: i64 = 1800;
-
-/// Send a violation alert to the PMD/kanban-manager channel via announce bot.
-/// Applies dedup cooldown (30 min per card+from+to) and suppresses API-source alerts.
-fn notify_pmd_violation(
-    conn: &rusqlite::Connection,
-    card_id: &str,
-    from: &str,
-    to: &str,
-    source: &str,
-    reason: &str,
-) {
-    // #200: API callers already receive error responses — no need to alert PMD.
-    if source == "api" {
-        tracing::debug!(
-            "[kanban] Suppressing violation alert for api source: {from} → {to} card {card_id}"
-        );
-        return;
-    }
-
-    // #200: Dedup cooldown — skip if same card+from+to was alerted within 30 min.
-    let cooldown_key = format!("violation_sent:{card_id}:{from}:{to}");
-    let recently_sent: bool = conn
-        .query_row(
-            "SELECT 1 FROM kv_meta WHERE key = ?1 \
-             AND (expires_at IS NULL OR expires_at > datetime('now'))",
-            [&cooldown_key],
-            |_| Ok(true),
-        )
-        .unwrap_or(false);
-    if recently_sent {
-        tracing::debug!(
-            "[kanban] Violation alert cooldown active for {from} → {to} card {card_id}"
-        );
-        return;
-    }
-    // Record cooldown with TTL
-    let _ = conn.execute(
-        "INSERT OR REPLACE INTO kv_meta (key, value, expires_at) \
-         VALUES (?1, ?2, datetime('now', '+' || ?3 || ' seconds'))",
-        rusqlite::params![cooldown_key, "1", VIOLATION_COOLDOWN_SECS.to_string()],
-    );
-
-    // Look up card title for the notification
-    let title: String = conn
-        .query_row(
-            "SELECT COALESCE(title, id) FROM kanban_cards WHERE id = ?1",
-            [card_id],
-            |row| row.get(0),
-        )
-        .unwrap_or_else(|_| card_id.to_string());
-
-    // Read kanban_manager_channel_id from kv_meta
-    let km_channel: Option<String> = conn
-        .query_row(
-            "SELECT value FROM kv_meta WHERE key = 'kanban_manager_channel_id'",
-            [],
-            |row| row.get(0),
-        )
-        .ok();
-
-    let Some(km_channel) = km_channel else {
-        tracing::debug!(
-            "[kanban] No kanban_manager_channel_id configured, skipping violation alert"
-        );
-        return;
-    };
-    let Some(channel_num) = km_channel.parse::<u64>().ok() else {
-        tracing::warn!("[kanban] Invalid kanban_manager_channel_id: {km_channel}");
-        return;
-    };
-
-    let message = format!(
-        "⚠️ **칸반 위반 감지**\n\n\
-         카드: {title}\n\
-         시도: {from} → {to}\n\
-         차단 사유: {reason}\n\
-         호출자: {source}\n\
-         카드 ID: {card_id}"
-    );
-
-    let token = match crate::credential::read_bot_token("announce") {
-        Some(t) => t,
-        None => {
-            tracing::debug!("[kanban] No announce bot token, skipping violation alert");
-            return;
-        }
-    };
-
-    if let Ok(handle) = tokio::runtime::Handle::try_current() {
-        handle.spawn(async move {
-            let client = reqwest::Client::new();
-            let _ = client
-                .post(format!(
-                    "https://discord.com/api/v10/channels/{channel_num}/messages"
-                ))
-                .header("Authorization", format!("Bot {}", token))
-                .json(&serde_json::json!({"content": message}))
-                .send()
-                .await;
-        });
     }
 }
 

--- a/src/server/routes/auto_queue.rs
+++ b/src/server/routes/auto_queue.rs
@@ -2,7 +2,7 @@ use axum::{
     Json,
     body::Bytes,
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -5653,7 +5653,7 @@ pub async fn reorder(
     (StatusCode::OK, Json(json!({ "ok": true })))
 }
 
-// ── PM-assisted callback ─────────────────────────────────────────────────────
+// ── Authenticated order submission callback ─────────────────────────────────
 
 #[derive(Debug, Deserialize)]
 pub struct OrderBody {
@@ -5665,12 +5665,19 @@ pub struct OrderBody {
 }
 
 /// POST /api/auto-queue/runs/:id/order
-/// Callback from PMD: provides the ordered card list for a pending run.
+/// Authenticated callback: provides the ordered card list for a pending run.
 pub async fn submit_order(
     State(state): State<AppState>,
     Path(run_id): Path<String>,
+    headers: HeaderMap,
     Json(body): Json<OrderBody>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    if let Err(response) =
+        crate::server::routes::kanban::require_explicit_bearer_token(&headers, "submit_order")
+    {
+        return response;
+    }
+
     let conn = match state.db.separate_conn() {
         Ok(c) => c,
         Err(e) => {
@@ -5680,6 +5687,8 @@ pub async fn submit_order(
             );
         }
     };
+    let caller_agent_id =
+        crate::server::routes::kanban::resolve_requesting_agent_id_on_conn(&conn, &headers);
     // Verify run exists and is pending, get repo for filtering
     let run_info: Option<(String, Option<String>)> = conn
         .query_row(
@@ -5773,9 +5782,14 @@ pub async fn submit_order(
     // to prevent the activate() fallback from filling the run with unintended cards
     let rationale = body
         .rationale
-        .as_deref()
-        .or(body.reasoning.as_deref())
-        .unwrap_or("PMD 분석 완료");
+        .clone()
+        .or(body.reasoning.clone())
+        .unwrap_or_else(|| {
+            caller_agent_id
+                .as_deref()
+                .map(|agent_id| format!("{agent_id} order submitted"))
+                .unwrap_or_else(|| "API order submitted".to_string())
+        });
     if created > 0 {
         conn.execute(
             "UPDATE auto_queue_runs SET status = 'active', ai_rationale = ?1 WHERE id = ?2",
@@ -5800,7 +5814,7 @@ pub async fn submit_order(
     }
 
     // Queue created and activated — dispatch is a separate step via POST /api/auto-queue/activate
-    // This allows PMD to review/adjust the order before dispatching begins.
+    // This allows the caller to review/adjust the order before dispatching begins.
     drop(conn);
 
     (

--- a/src/server/routes/docs.rs
+++ b/src/server/routes/docs.rs
@@ -147,7 +147,9 @@ fn category_description(category: &str) -> &'static str {
         "github-dashboard" => "Dashboard-oriented GitHub read models and issue actions.",
         "health" => "Health and liveness endpoints.",
         "internal" => "Internal-only thread reuse helpers used by the runtime.",
-        "kanban" => "Kanban cards, review recovery, PMD transitions, and DoD operations.",
+        "kanban" => {
+            "Kanban cards, review recovery, administrative transitions, and DoD operations."
+        }
         "kanban-repos" => "Kanban repository settings and ownership metadata.",
         "meetings" => "Round-table meeting lifecycle and issue generation.",
         "messages" => "Message log read/write APIs.",
@@ -579,8 +581,8 @@ fn all_endpoints() -> Vec<EndpointDoc> {
             ),
         ])
         .with_example(
-            json!({"path": {"id": "card-1"}, "body": {"reason": "pm reopen", "reset_full": true}}),
-            json!({"card": {"id": "card-1", "status": "ready"}, "reopened": true, "reset_full": true, "cancelled_dispatches": 1, "skipped_auto_queue_entries": 1, "from": "done", "to": "ready", "reason": "pm reopen"}),
+            json!({"path": {"id": "card-1"}, "body": {"reason": "manual reopen", "reset_full": true}}),
+            json!({"card": {"id": "card-1", "status": "ready"}, "reopened": true, "reset_full": true, "cancelled_dispatches": 1, "skipped_auto_queue_entries": 1, "from": "done", "to": "ready", "reason": "manual reopen"}),
         ),
         ep(
             "POST",
@@ -1775,7 +1777,7 @@ fn all_endpoints() -> Vec<EndpointDoc> {
             "POST",
             "/api/auto-queue/runs/{id}/order",
             "auto-queue",
-            "Submit ordered cards for a pending PM-assisted run",
+            "Submit ordered cards for a pending run",
         )
         .with_params([
             ("id", path_param("Auto-queue run ID")),
@@ -1789,7 +1791,7 @@ fn all_endpoints() -> Vec<EndpointDoc> {
             ),
             (
                 "rationale",
-                body_param("string", false, "PM rationale for this order"),
+                body_param("string", false, "Ordering rationale for this run"),
             ),
             (
                 "reasoning",

--- a/src/server/routes/escalation.rs
+++ b/src/server/routes/escalation.rs
@@ -120,7 +120,7 @@ fn escalation_defaults(config: &Config) -> EscalationSettings {
                 .escalation
                 .pm_channel_id
                 .clone()
-                .or_else(|| config.kanban.manager_channel_id.clone()),
+                .or_else(|| config.kanban.human_alert_channel_id.clone()),
         ),
         schedule: EscalationScheduleSettings {
             pm_hours: config

--- a/src/server/routes/kanban.rs
+++ b/src/server/routes/kanban.rs
@@ -2132,7 +2132,7 @@ pub async fn pm_decision(
     )
 }
 
-// ── PMD-only reopen (done → in_progress) ─────────────────────────
+// ── Administrative review recovery helpers ───────────────────────
 
 #[derive(Debug, Deserialize)]
 pub struct RereviewBody {
@@ -2153,6 +2153,72 @@ fn find_active_review_dispatch_id(conn: &rusqlite::Connection, card_id: &str) ->
     .ok()
 }
 
+fn trimmed_header_value<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+pub(super) fn require_explicit_bearer_token(
+    headers: &HeaderMap,
+    operation: &str,
+) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    let config = crate::config::load_graceful();
+    if let Some(expected_token) = config.server.auth_token.as_deref() {
+        if !expected_token.is_empty() {
+            let provided = trimmed_header_value(headers, "authorization")
+                .and_then(|value| value.strip_prefix("Bearer "))
+                .map(str::trim);
+            if provided != Some(expected_token) {
+                return Err((
+                    StatusCode::UNAUTHORIZED,
+                    Json(json!({"error": format!("{operation} requires explicit Bearer token")})),
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn resolve_agent_id_from_channel_id_on_conn(
+    conn: &rusqlite::Connection,
+    channel_id: &str,
+) -> Option<String> {
+    conn.query_row(
+        "SELECT id FROM agents
+         WHERE discord_channel_id = ?1
+            OR discord_channel_alt = ?1
+            OR discord_channel_cc = ?1
+            OR discord_channel_cdx = ?1
+         LIMIT 1",
+        [channel_id],
+        |row| row.get(0),
+    )
+    .ok()
+}
+
+pub(super) fn resolve_requesting_agent_id_on_conn(
+    conn: &rusqlite::Connection,
+    headers: &HeaderMap,
+) -> Option<String> {
+    if let Some(agent_id) = trimmed_header_value(headers, "x-agent-id") {
+        return conn
+            .query_row(
+                "SELECT id FROM agents WHERE id = ?1 LIMIT 1",
+                [agent_id],
+                |row| row.get(0),
+            )
+            .ok()
+            .or_else(|| Some(agent_id.to_string()));
+    }
+
+    trimmed_header_value(headers, "x-channel-id")
+        .and_then(|channel_id| resolve_agent_id_from_channel_id_on_conn(conn, channel_id))
+}
+
 /// POST /api/kanban-cards/:id/rereview
 ///
 /// Recovery endpoint. Forces a card back through counter-model review
@@ -2163,24 +2229,12 @@ pub async fn rereview_card(
     headers: HeaderMap,
     Json(body): Json<RereviewBody>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let config = crate::config::load_graceful();
-    if let Some(expected_token) = config.server.auth_token.as_deref() {
-        if !expected_token.is_empty() {
-            let provided = headers
-                .get("authorization")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|v| v.strip_prefix("Bearer "));
-            if provided != Some(expected_token) {
-                return (
-                    StatusCode::UNAUTHORIZED,
-                    Json(json!({"error": "rereview requires explicit Bearer token"})),
-                );
-            }
-        }
+    if let Err(response) = require_explicit_bearer_token(&headers, "rereview") {
+        return response;
     }
 
     let reason = body.reason.as_deref().unwrap_or("manual rereview");
-    let (current_status, assigned_agent_id, card_title, gh_url) = {
+    let (current_status, assigned_agent_id, card_title, gh_url, caller_source) = {
         let conn = match state.db.lock() {
             Ok(c) => c,
             Err(e) => {
@@ -2200,6 +2254,8 @@ pub async fn rereview_card(
                     row.get::<_, Option<String>>(1)?,
                     row.get::<_, String>(2)?,
                     row.get::<_, Option<String>>(3)?,
+                    resolve_requesting_agent_id_on_conn(&conn, &headers)
+                        .unwrap_or_else(|| "api".to_string()),
                 ))
             },
         ) {
@@ -2307,7 +2363,7 @@ pub async fn rereview_card(
             &state.engine,
             &id,
             "review",
-            &format!("pmd:rereview({reason})"),
+            &format!("{caller_source}:rereview({reason})"),
             true,
         ) {
             return (
@@ -2404,10 +2460,9 @@ pub async fn rereview_card(
             })
             .unwrap_or_default();
         for entry_id in entry_ids {
-            if let Err(error) = crate::db::auto_queue::update_entry_status_on_conn(
+            if let Err(error) = move_auto_queue_entry_to_dispatched_on_conn(
                 &conn,
                 &entry_id,
-                crate::db::auto_queue::ENTRY_STATUS_DISPATCHED,
                 "rereview_dispatch",
                 &crate::db::auto_queue::EntryStatusUpdateOptions {
                     dispatch_id: Some(review_dispatch_id.clone()),
@@ -2480,21 +2535,8 @@ pub async fn batch_rereview(
     headers: HeaderMap,
     Json(body): Json<BatchRereviewBody>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    // ── Auth: same two-factor check as single rereview ──
-    let config = crate::config::load_graceful();
-    if let Some(expected_token) = config.server.auth_token.as_deref() {
-        if !expected_token.is_empty() {
-            let provided = headers
-                .get("authorization")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|v| v.strip_prefix("Bearer "));
-            if provided != Some(expected_token) {
-                return (
-                    StatusCode::UNAUTHORIZED,
-                    Json(json!({"error": "batch rereview requires explicit Bearer token"})),
-                );
-            }
-        }
+    if let Err(response) = require_explicit_bearer_token(&headers, "batch rereview") {
+        return response;
     }
 
     let reason = body.reason.clone();
@@ -2571,7 +2613,7 @@ pub struct BatchTransitionBody {
 
 /// POST /api/kanban-cards/:id/reopen
 ///
-/// PMD-only endpoint. Reopens a done card by transitioning to in_progress,
+/// Administrative endpoint. Reopens a done card by transitioning to in_progress,
 /// clearing completed_at, and optionally resetting recovery fields.
 /// Same explicit Bearer auth as force-transition.
 pub async fn reopen_card(
@@ -2582,25 +2624,12 @@ pub async fn reopen_card(
 ) -> (StatusCode, Json<serde_json::Value>) {
     let reset_full = body.reset_full.unwrap_or(false);
 
-    // ── Auth: same explicit Bearer token check as force-transition ──
-    let config = crate::config::load_graceful();
-    if let Some(expected_token) = config.server.auth_token.as_deref() {
-        if !expected_token.is_empty() {
-            let provided = headers
-                .get("authorization")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|v| v.strip_prefix("Bearer "));
-            if provided != Some(expected_token) {
-                return (
-                    StatusCode::UNAUTHORIZED,
-                    Json(json!({"error": "reopen requires explicit Bearer token"})),
-                );
-            }
-        }
+    if let Err(response) = require_explicit_bearer_token(&headers, "reopen") {
+        return response;
     }
 
     // ── Pre-check: card must be in done state ──
-    let current_status: String = {
+    let (current_status, caller_source): (String, String) = {
         let conn = match state.db.lock() {
             Ok(c) => c,
             Err(e) => {
@@ -2613,7 +2642,13 @@ pub async fn reopen_card(
         match conn.query_row(
             "SELECT status FROM kanban_cards WHERE id = ?1",
             [&id],
-            |row| row.get(0),
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    resolve_requesting_agent_id_on_conn(&conn, &headers)
+                        .unwrap_or_else(|| "api".to_string()),
+                ))
+            },
         ) {
             Ok(s) => s,
             Err(_) => {
@@ -2659,10 +2694,10 @@ pub async fn reopen_card(
                 );
             }
         };
-        if let Err(e) = mark_pmd_reopen_skip_preflight_on_conn(&conn, &id) {
+        if let Err(e) = mark_api_reopen_skip_preflight_on_conn(&conn, &id) {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": format!("failed to stage PMD reopen preflight skip: {e}")})),
+                Json(json!({"error": format!("failed to stage API reopen preflight skip: {e}")})),
             );
         }
     }
@@ -2675,7 +2710,7 @@ pub async fn reopen_card(
             &state.engine,
             &id,
             &reopen_target,
-            &format!("pmd:reopen({})", reason),
+            &format!("{caller_source}:reopen({reason})"),
             true,
         );
         result.map(|result| (result.from, result.to))
@@ -2721,6 +2756,14 @@ pub async fn reopen_card(
                         }
                     }
                 } else {
+                    if let Err(e) = consume_api_reopen_preflight_skip_on_conn(&conn, &id) {
+                        return (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(
+                                json!({"error": format!("failed to persist API reopen preflight skip: {e}")}),
+                            ),
+                        );
+                    }
                     (0, 0)
                 };
 
@@ -2743,7 +2786,8 @@ pub async fn reopen_card(
                     .ok();
                 }
 
-                // Reactivate auto_queue_entries that were marked done
+                // Reopen reactivates completed auto-queue entries so the card can be
+                // redispatched after stale live reservations are cleaned up.
                 let entry_ids: Vec<String> = conn
                     .prepare(
                         "SELECT id FROM auto_queue_entries
@@ -2757,11 +2801,10 @@ pub async fn reopen_card(
                     })
                     .unwrap_or_default();
                 for entry_id in entry_ids {
-                    if let Err(error) = crate::db::auto_queue::update_entry_status_on_conn(
+                    if let Err(error) = move_auto_queue_entry_to_dispatched_on_conn(
                         &conn,
                         &entry_id,
-                        crate::db::auto_queue::ENTRY_STATUS_DISPATCHED,
-                        "pmd_reopen",
+                        "api_reopen",
                         &crate::db::auto_queue::EntryStatusUpdateOptions::default(),
                     ) {
                         return (
@@ -2829,7 +2872,7 @@ pub async fn reopen_card(
         }
         Err(e) => {
             if let Ok(conn) = state.db.lock() {
-                let _ = clear_pmd_reopen_skip_preflight_on_conn(&conn, &id);
+                let _ = clear_api_reopen_skip_preflight_on_conn(&conn, &id);
             }
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -2841,7 +2884,7 @@ pub async fn reopen_card(
 
 /// POST /api/kanban-cards/batch-transition
 ///
-/// PMD-only endpoint. Applies the same force semantics as force-transition to
+/// Administrative endpoint. Applies the same force semantics as force-transition to
 /// multiple cards, resolving targets by either explicit card IDs or GitHub
 /// issue numbers. Returns per-card success/failure details.
 pub async fn batch_transition(
@@ -2849,20 +2892,8 @@ pub async fn batch_transition(
     headers: HeaderMap,
     Json(body): Json<BatchTransitionBody>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let config = crate::config::load_graceful();
-    if let Some(expected_token) = config.server.auth_token.as_deref() {
-        if !expected_token.is_empty() {
-            let provided = headers
-                .get("authorization")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|v| v.strip_prefix("Bearer "));
-            if provided != Some(expected_token) {
-                return (
-                    StatusCode::UNAUTHORIZED,
-                    Json(json!({"error": "batch-transition requires explicit Bearer token"})),
-                );
-            }
-        }
+    if let Err(response) = require_explicit_bearer_token(&headers, "batch-transition") {
+        return response;
     }
 
     let has_issue_numbers = body
@@ -2877,6 +2908,19 @@ pub async fn batch_transition(
         );
     }
 
+    let caller_source = {
+        let conn = match state.db.lock() {
+            Ok(c) => c,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": format!("{e}")})),
+                );
+            }
+        };
+        resolve_requesting_agent_id_on_conn(&conn, &headers).unwrap_or_else(|| "api".to_string())
+    };
+    let batch_transition_source = format!("{caller_source}:batch-transition");
     let mut targets: Vec<(String, Option<i64>)> = Vec::new();
     let mut results = Vec::new();
 
@@ -2934,7 +2978,7 @@ pub async fn batch_transition(
             &state.engine,
             &card_id,
             &body.status,
-            "pmd:batch-transition",
+            &batch_transition_source,
             true,
         ) {
             Ok(result) => {
@@ -2993,7 +3037,7 @@ pub async fn batch_transition(
     (StatusCode::OK, Json(json!({ "results": results })))
 }
 
-// ── PMD-only force transition ────────────────────────────────────
+// ── Administrative force transition ──────────────────────────────
 
 #[derive(Debug, Deserialize)]
 pub struct ForceTransitionBody {
@@ -3085,6 +3129,38 @@ fn cleanup_force_transition_revert_on_conn(
     Ok((cancelled_dispatches, skipped_auto_queue_entries))
 }
 
+fn move_auto_queue_entry_to_dispatched_on_conn(
+    conn: &rusqlite::Connection,
+    entry_id: &str,
+    trigger_source: &str,
+    options: &crate::db::auto_queue::EntryStatusUpdateOptions,
+) -> Result<(), crate::db::auto_queue::EntryStatusUpdateError> {
+    match crate::db::auto_queue::update_entry_status_on_conn(
+        conn,
+        entry_id,
+        crate::db::auto_queue::ENTRY_STATUS_DISPATCHED,
+        trigger_source,
+        options,
+    ) {
+        Err(crate::db::auto_queue::EntryStatusUpdateError::InvalidTransition {
+            from_status,
+            to_status,
+            ..
+        }) if from_status == crate::db::auto_queue::ENTRY_STATUS_DONE
+            && to_status == crate::db::auto_queue::ENTRY_STATUS_DISPATCHED =>
+        {
+            crate::db::auto_queue::reactivate_done_entry_on_conn(
+                conn,
+                entry_id,
+                trigger_source,
+                options,
+            )
+            .map(|_| ())
+        }
+        other => other.map(|_| ()),
+    }
+}
+
 fn load_card_metadata_map_on_conn(
     conn: &rusqlite::Connection,
     card_id: &str,
@@ -3123,25 +3199,54 @@ fn save_card_metadata_map_on_conn(
     Ok(())
 }
 
-fn mark_pmd_reopen_skip_preflight_on_conn(
+fn mark_api_reopen_skip_preflight_on_conn(
     conn: &rusqlite::Connection,
     card_id: &str,
 ) -> anyhow::Result<()> {
     let mut metadata = load_card_metadata_map_on_conn(conn, card_id)?;
     metadata.insert(
         "skip_preflight_once".to_string(),
-        serde_json::Value::String("pmd_reopen".to_string()),
+        serde_json::Value::String("api_reopen".to_string()),
     );
     save_card_metadata_map_on_conn(conn, card_id, &metadata)
 }
 
-fn clear_pmd_reopen_skip_preflight_on_conn(
+fn clear_api_reopen_skip_preflight_on_conn(
     conn: &rusqlite::Connection,
     card_id: &str,
 ) -> anyhow::Result<()> {
     let mut metadata = load_card_metadata_map_on_conn(conn, card_id)?;
     metadata.remove("skip_preflight_once");
     save_card_metadata_map_on_conn(conn, card_id, &metadata)
+}
+
+fn consume_api_reopen_preflight_skip_on_conn(
+    conn: &rusqlite::Connection,
+    card_id: &str,
+) -> anyhow::Result<()> {
+    let mut metadata = load_card_metadata_map_on_conn(conn, card_id)?;
+    if matches!(
+        metadata
+            .get("skip_preflight_once")
+            .and_then(|value| value.as_str()),
+        Some("api_reopen") | Some("pmd_reopen")
+    ) {
+        metadata.remove("skip_preflight_once");
+        metadata.insert(
+            "preflight_status".to_string(),
+            serde_json::Value::String("skipped".to_string()),
+        );
+        metadata.insert(
+            "preflight_summary".to_string(),
+            serde_json::Value::String("Skipped for API reopen".to_string()),
+        );
+        metadata.insert(
+            "preflight_checked_at".to_string(),
+            serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
+        );
+        save_card_metadata_map_on_conn(conn, card_id, &metadata)?;
+    }
+    Ok(())
 }
 
 fn clear_reopen_preflight_cache_on_conn(
@@ -3172,27 +3277,14 @@ pub async fn force_transition(
     headers: HeaderMap,
     Json(body): Json<ForceTransitionBody>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    // 1. Explicit Bearer token check (bypasses same-origin exemption in auth middleware)
-    let config = crate::config::load_graceful();
-    if let Some(expected_token) = config.server.auth_token.as_deref() {
-        if !expected_token.is_empty() {
-            let provided = headers
-                .get("authorization")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|v| v.strip_prefix("Bearer "));
-            if provided != Some(expected_token) {
-                return (
-                    StatusCode::UNAUTHORIZED,
-                    Json(json!({"error": "force-transition requires explicit Bearer token"})),
-                );
-            }
-        }
+    if let Err(response) = require_explicit_bearer_token(&headers, "force-transition") {
+        return response;
     }
 
     let needs_cleanup = force_transition_needs_cleanup(&body.status, body.cancel_dispatches);
     let target_status = body.status;
     let mut cleanup_counts = (0, 0);
-    let terminal_cleanup = {
+    let (terminal_cleanup, caller_source) = {
         let conn = match state.db.lock() {
             Ok(c) => c,
             Err(e) => {
@@ -3215,7 +3307,11 @@ pub async fn force_transition(
             card_repo_id.as_deref(),
             card_agent_id.as_deref(),
         );
-        effective.is_terminal(&target_status) && body.cancel_dispatches.unwrap_or(true)
+        (
+            effective.is_terminal(&target_status) && body.cancel_dispatches.unwrap_or(true),
+            resolve_requesting_agent_id_on_conn(&conn, &headers)
+                .unwrap_or_else(|| "api".to_string()),
+        )
     };
 
     let transition_result = if needs_cleanup {
@@ -3224,7 +3320,7 @@ pub async fn force_transition(
             &state.engine,
             &id,
             &target_status,
-            "pmd",
+            &caller_source,
             true,
             |conn| {
                 cleanup_counts =
@@ -3238,7 +3334,7 @@ pub async fn force_transition(
             &state.engine,
             &id,
             &target_status,
-            "pmd",
+            &caller_source,
             true,
             |conn| {
                 cleanup_counts.0 =
@@ -3252,7 +3348,7 @@ pub async fn force_transition(
             &state.engine,
             &id,
             &target_status,
-            "pmd",
+            &caller_source,
             true,
         )
     };

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -2537,7 +2537,7 @@ async fn api_docs_flat_format_omits_removed_legacy_routes() {
         endpoints
             .iter()
             .any(|ep| ep["method"] == "POST" && ep["path"] == "/api/auto-queue/runs/{id}/order"),
-        "flat docs must keep the PM-assisted submit_order callback route"
+        "flat docs must keep the submit_order callback route"
     );
 }
 
@@ -5415,7 +5415,7 @@ async fn reopen_reactivates_done_card_without_deadlocking_review_tuning_fixup() 
 }
 
 #[tokio::test]
-async fn reopen_skips_preflight_already_applied_for_pmd_reopen() {
+async fn reopen_skips_preflight_already_applied_for_api_reopen() {
     crate::pipeline::ensure_loaded();
     let db = test_db();
     let engine = test_engine(&db);
@@ -5465,7 +5465,7 @@ async fn reopen_skips_preflight_already_applied_for_pmd_reopen() {
                 .uri("/kanban-cards/card-reopen-skip/reopen")
                 .header("content-type", "application/json")
                 .header("x-channel-id", "pmd-chan-123")
-                .body(Body::from(r#"{"reason":"skip preflight on PMD reopen"}"#))
+                .body(Body::from(r#"{"reason":"skip preflight on API reopen"}"#))
                 .unwrap(),
         )
         .await
@@ -5489,12 +5489,12 @@ async fn reopen_skips_preflight_already_applied_for_pmd_reopen() {
         .unwrap();
     assert_eq!(
         status, reopen_target,
-        "PMD reopen must skip already_applied preflight and keep card reopened"
+        "API reopen must skip already_applied preflight and keep card reopened"
     );
     let metadata: serde_json::Value =
         serde_json::from_str(metadata_raw.as_deref().unwrap_or("{}")).unwrap();
     assert_eq!(metadata["preflight_status"], "skipped");
-    assert_eq!(metadata["preflight_summary"], "Skipped for PMD reopen");
+    assert_eq!(metadata["preflight_summary"], "Skipped for API reopen");
     assert!(
         metadata.get("skip_preflight_once").is_none(),
         "skip_preflight_once must be consumed during reopen transition"
@@ -5619,6 +5619,12 @@ async fn reopen_reset_full_clears_review_thread_and_preflight_state() {
         )
         .unwrap();
         conn.execute(
+            "INSERT INTO auto_queue_runs (id, repo, agent_id, status)
+             VALUES ('run-reopen-reset-history', 'test-repo', 'agent-reopen-reset', 'completed')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
             "INSERT INTO auto_queue_entries (
                 id, run_id, kanban_card_id, agent_id, status, dispatch_id, dispatched_at
             ) VALUES (
@@ -5632,7 +5638,7 @@ async fn reopen_reset_full_clears_review_thread_and_preflight_state() {
             "INSERT INTO auto_queue_entries (
                 id, run_id, kanban_card_id, agent_id, status, completed_at
             ) VALUES (
-                'entry-reopen-done', 'run-reopen-reset', 'card-reopen-reset', 'agent-reopen-reset',
+                'entry-reopen-done', 'run-reopen-reset-history', 'card-reopen-reset', 'agent-reopen-reset',
                 'done', datetime('now', '-30 minutes')
             )",
             [],

--- a/src/server/routes/settings.rs
+++ b/src/server/routes/settings.rs
@@ -107,6 +107,13 @@ const CONFIG_KEYS: &[(&str, &str, &str, &str, Option<&str>)] = &[
         None,
     ),
     (
+        "kanban_human_alert_channel_id",
+        "pipeline",
+        "사람 알림 채널 ID",
+        "Human Alert Channel ID",
+        None,
+    ),
+    (
         "review_enabled",
         "review",
         "리뷰 활성화",
@@ -212,6 +219,7 @@ fn yaml_section_value(config: &crate::config::Config, key: &str) -> Option<Strin
     match key {
         "kanban_manager_channel_id" => config.kanban.manager_channel_id.clone(),
         "deadlock_manager_channel_id" => config.kanban.deadlock_manager_channel_id.clone(),
+        "kanban_human_alert_channel_id" => config.kanban.human_alert_channel_id.clone(),
         "review_enabled" => stringified_bool(config.review.enabled),
         "max_review_rounds" => stringified_number(config.review.max_rounds),
         "pm_decision_gate_enabled" => stringified_bool(config.kanban.pm_decision_gate_enabled),


### PR DESCRIPTION
Automated fallback PR after direct merge into `main` hit a cherry-pick conflict.

Card: `1b8332fb-c0f8-4dd1-a34c-2e1fa538f0d0`
Issue: https://github.com/itismyfield/AgentDesk/issues/643

Conflict summary:
error: could not apply dcfb4aae... #643 reroute PMD alerts and open PMD APIs hint: After resolving the conflicts, mark them with hint: "git add/rm <pathspec>", then run hint: "g...