### PR TITLE
#635 fix: auto-queue restore가 비원자적 — 크래시 시 반절 복원 상태 고아화

### DIFF
--- a/src/server/routes/auto_queue.rs
+++ b/src/server/routes/auto_queue.rs
@@ -685,6 +685,8 @@ struct RestoreRunCounts {
     unbound_dispatches: usize,
 }
 
+const RUN_STATUS_RESTORING: &str = "restoring";
+
 #[derive(Debug, Clone)]
 enum RestoreEntryDecision {
     Pending,
@@ -4539,7 +4541,7 @@ pub async fn restore_run(
                 Json(json!({"error": format!("auto-queue run '{run_id}' not found")})),
             );
         }
-        Some("cancelled") => {}
+        Some("cancelled") | Some(RUN_STATUS_RESTORING) => {}
         Some("active") => {
             return (
                 StatusCode::BAD_REQUEST,
@@ -4550,7 +4552,9 @@ pub async fn restore_run(
             return (
                 StatusCode::BAD_REQUEST,
                 Json(json!({
-                    "error": format!("only cancelled runs can be restored (status={status})"),
+                    "error": format!(
+                        "only cancelled or restoring runs can be restored (status={status})"
+                    ),
                     "run_id": run_id,
                     "status": status,
                 })),
@@ -4567,21 +4571,25 @@ pub async fn restore_run(
             );
         }
     };
-    let restored_run = conn
-        .execute(
-            "UPDATE auto_queue_runs
-             SET status = 'active',
-                 completed_at = NULL
-             WHERE id = ?1
-               AND status = 'cancelled'",
-            [&run_id],
-        )
-        .unwrap_or(0);
-    if restored_run == 0 {
-        return (
-            StatusCode::CONFLICT,
-            Json(json!({"error": format!("failed to restore cancelled run '{run_id}'")})),
-        );
+    if run_status.as_deref() == Some("cancelled") {
+        let restored_run = conn
+            .execute(
+                "UPDATE auto_queue_runs
+                 SET status = ?2,
+                     completed_at = NULL
+                 WHERE id = ?1
+                   AND status = 'cancelled'",
+                rusqlite::params![&run_id, RUN_STATUS_RESTORING],
+            )
+            .unwrap_or(0);
+        if restored_run == 0 {
+            return (
+                StatusCode::CONFLICT,
+                Json(
+                    json!({"error": format!("failed to start restore for cancelled run '{run_id}'")}),
+                ),
+            );
+        }
     }
     drop(conn);
 
@@ -4934,6 +4942,38 @@ pub async fn restore_run(
             );
         }
     };
+    if errors.is_empty() {
+        let finalized = conn
+            .execute(
+                "UPDATE auto_queue_runs
+                 SET status = 'active',
+                     completed_at = NULL
+                 WHERE id = ?1
+                   AND status = ?2",
+                rusqlite::params![&run_id, RUN_STATUS_RESTORING],
+            )
+            .unwrap_or(0);
+        if finalized == 0 {
+            let current_status: Option<String> = conn
+                .query_row(
+                    "SELECT status
+                     FROM auto_queue_runs
+                     WHERE id = ?1",
+                    [&run_id],
+                    |row| row.get(0),
+                )
+                .ok();
+            match current_status.as_deref() {
+                Some("active") => {}
+                Some(status) => errors.push(format!(
+                    "failed to finalize restore for run '{run_id}' (status={status})"
+                )),
+                None => errors.push(format!(
+                    "failed to finalize restore for missing run '{run_id}'"
+                )),
+            }
+        }
+    }
     let final_run_status = conn
         .query_row(
             "SELECT status

--- a/src/server/routes/auto_queue.rs
+++ b/src/server/routes/auto_queue.rs
@@ -473,7 +473,9 @@ pub(crate) fn cancel_with_conn(
     health_registry: Option<Arc<crate::services::discord::health::HealthRegistry>>,
     conn: &rusqlite::Connection,
 ) -> serde_json::Value {
-    let target_run_ids = load_run_ids_with_status(conn, &["active", "paused"]).unwrap_or_default();
+    let target_run_ids =
+        load_run_ids_with_status(conn, &["active", "paused", RUN_STATUS_RESTORING])
+            .unwrap_or_default();
     cancel_selected_runs_with_conn(health_registry, conn, &target_run_ids, "auto_queue_cancel")
 }
 
@@ -496,7 +498,7 @@ fn cancel_selected_runs_with_conn(
         let sql = format!(
             "UPDATE auto_queue_runs
              SET status = 'cancelled', completed_at = datetime('now')
-             WHERE id IN ({placeholders}) AND status IN ('active', 'paused')"
+             WHERE id IN ({placeholders}) AND status IN ('active', 'paused', '{RUN_STATUS_RESTORING}')"
         );
         conn.execute(&sql, rusqlite::params_from_iter(target_run_ids.iter()))
             .unwrap_or(0)
@@ -2709,6 +2711,12 @@ pub(crate) fn activate_with_deps(
                 return (
                     StatusCode::OK,
                     Json(json!({ "dispatched": [], "count": 0, "message": message })),
+                );
+            }
+            Some(RUN_STATUS_RESTORING) => {
+                return (
+                    StatusCode::OK,
+                    Json(json!({ "dispatched": [], "count": 0, "message": "Run is restoring" })),
                 );
             }
             Some(status) if active_only && status != "active" => {
@@ -5558,7 +5566,7 @@ pub async fn cancel(
             )
             .ok();
         match run_status.as_deref() {
-            Some("active") | Some("paused") => {
+            Some("active") | Some("paused") | Some(RUN_STATUS_RESTORING) => {
                 let payload = cancel_selected_runs_with_conn(
                     state.health_registry.clone(),
                     &conn,

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -7201,6 +7201,193 @@ async fn auto_queue_restore_run_rejects_active_run() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn auto_queue_restore_run_retries_from_restoring_after_partial_failure() {
+    crate::pipeline::ensure_loaded();
+    let (_repo, _repo_guard) = setup_test_repo();
+    let db = test_db();
+    let engine = test_engine(&db);
+    seed_agent(&db, "agent-restore-retry");
+    ensure_auto_queue_tables(&db);
+    seed_auto_queue_card(
+        &db,
+        "card-restore-retry-ok",
+        1811,
+        "ready",
+        "agent-restore-retry",
+    );
+    seed_auto_queue_card(
+        &db,
+        "card-restore-retry-fail",
+        1812,
+        "ready",
+        "agent-restore-retry",
+    );
+
+    {
+        let conn = db.lock().unwrap();
+        conn.execute(
+            "INSERT INTO auto_queue_runs (
+                id, repo, agent_id, status, max_concurrent_threads, thread_group_count
+            ) VALUES (
+                'run-restore-retry', 'test-repo', 'agent-restore-retry', 'cancelled', 2, 2
+            )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO auto_queue_entries (
+                id, run_id, kanban_card_id, agent_id, status, priority_rank, thread_group
+            ) VALUES (
+                'entry-restore-retry-ok', 'run-restore-retry', 'card-restore-retry-ok',
+                'agent-restore-retry', 'skipped', 0, 0
+            )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO auto_queue_entries (
+                id, run_id, kanban_card_id, agent_id, status, priority_rank, thread_group
+            ) VALUES (
+                'entry-restore-retry-fail', 'run-restore-retry', 'card-restore-retry-fail',
+                'agent-restore-retry', 'skipped', 1, 1
+            )",
+            [],
+        )
+        .unwrap();
+        conn.execute_batch(
+            "CREATE TRIGGER fail_restore_retry_entry
+             BEFORE UPDATE OF status ON auto_queue_entries
+             WHEN OLD.id = 'entry-restore-retry-fail'
+               AND NEW.status != OLD.status
+             BEGIN
+                 SELECT RAISE(ABORT, 'restore retry blocked');
+             END;",
+        )
+        .unwrap();
+    }
+
+    let app = test_api_router(db.clone(), engine, None);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auto-queue/runs/run-restore-retry/restore")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["run_status"], "restoring");
+    assert_eq!(json["restored_pending"], 1);
+    assert!(
+        json["errors"]
+            .as_array()
+            .unwrap_or(&Vec::new())
+            .iter()
+            .any(|value| value
+                .as_str()
+                .unwrap_or_default()
+                .contains("entry-restore-retry-fail")),
+        "restore response must surface the skipped entry that still needs recovery"
+    );
+
+    {
+        let conn = db.lock().unwrap();
+        let run_status: String = conn
+            .query_row(
+                "SELECT status FROM auto_queue_runs WHERE id = 'run-restore-retry'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(run_status, "restoring");
+
+        let restored_status: String = conn
+            .query_row(
+                "SELECT status FROM auto_queue_entries WHERE id = 'entry-restore-retry-ok'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(restored_status, "pending");
+
+        let missing_status: String = conn
+            .query_row(
+                "SELECT status FROM auto_queue_entries WHERE id = 'entry-restore-retry-fail'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(missing_status, "skipped");
+        conn.execute("DROP TRIGGER fail_restore_retry_entry", [])
+            .unwrap();
+    }
+
+    let retry_app = test_api_router(db.clone(), test_engine(&db), None);
+    let retry_response = retry_app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auto-queue/runs/run-restore-retry/restore")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(retry_response.status(), StatusCode::OK);
+    let retry_body = axum::body::to_bytes(retry_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let retry_json: serde_json::Value = serde_json::from_slice(&retry_body).unwrap();
+    assert_eq!(retry_json["ok"], true);
+    assert_eq!(retry_json["run_status"], "active");
+    assert_eq!(retry_json["restored_pending"], 1);
+
+    let conn = db.lock().unwrap();
+    let final_run_status: String = conn
+        .query_row(
+            "SELECT status FROM auto_queue_runs WHERE id = 'run-restore-retry'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(final_run_status, "active");
+
+    let entry_states: Vec<(String, String)> = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, status
+                 FROM auto_queue_entries
+                 WHERE run_id = 'run-restore-retry'
+                 ORDER BY id ASC",
+            )
+            .unwrap();
+        stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    };
+    assert_eq!(
+        entry_states,
+        vec![
+            (
+                "entry-restore-retry-fail".to_string(),
+                "pending".to_string(),
+            ),
+            ("entry-restore-retry-ok".to_string(), "pending".to_string()),
+        ]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn auto_queue_activate_active_only_does_not_promote_generated_runs() {
     crate::pipeline::ensure_loaded();
     let (_repo, _repo_guard) = setup_test_repo();

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -7388,6 +7388,80 @@ async fn auto_queue_restore_run_retries_from_restoring_after_partial_failure() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn auto_queue_activate_run_id_does_not_dispatch_restoring_runs() {
+    crate::pipeline::ensure_loaded();
+    let (_repo, _repo_guard) = setup_test_repo();
+    let db = test_db();
+    let engine = test_engine(&db);
+    seed_agent(&db, "agent-restoring-activate");
+    ensure_auto_queue_tables(&db);
+    seed_auto_queue_card(
+        &db,
+        "card-restoring-activate",
+        1700,
+        "ready",
+        "agent-restoring-activate",
+    );
+
+    {
+        let conn = db.lock().unwrap();
+        conn.execute(
+            "INSERT INTO auto_queue_runs (id, repo, agent_id, status, created_at) \
+             VALUES ('run-restoring-activate', 'test-repo', 'agent-restoring-activate', 'restoring', datetime('now'))",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO auto_queue_entries (id, run_id, kanban_card_id, agent_id, status, priority_rank) \
+             VALUES ('entry-restoring-activate', 'run-restoring-activate', 'card-restoring-activate', 'agent-restoring-activate', 'pending', 0)",
+            [],
+        )
+        .unwrap();
+    }
+
+    let app = test_api_router(db.clone(), engine, None);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auto-queue/activate")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_string(&serde_json::json!({
+                        "run_id": "run-restoring-activate",
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["count"], 0);
+    assert_eq!(json["message"], "Run is restoring");
+
+    let conn = db.lock().unwrap();
+    let entry_status: String = conn
+        .query_row(
+            "SELECT status FROM auto_queue_entries WHERE id = 'entry-restoring-activate'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(entry_status, "pending");
+
+    let dispatch_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM task_dispatches", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(dispatch_count, 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn auto_queue_activate_active_only_does_not_promote_generated_runs() {
     crate::pipeline::ensure_loaded();
     let (_repo, _repo_guard) = setup_test_repo();
@@ -11397,6 +11471,119 @@ async fn auto_queue_cancel_cancels_live_dispatches_skips_entries_and_releases_sl
     assert_eq!(session.1, None);
     assert_eq!(session.2, 0);
     assert_eq!(session.3, None);
+}
+
+#[tokio::test]
+async fn auto_queue_cancel_includes_restoring_runs() {
+    let db = test_db();
+    let engine = test_engine(&db);
+    ensure_auto_queue_tables(&db);
+    seed_agent(&db, "agent-cancel-restoring");
+    seed_auto_queue_card(
+        &db,
+        "card-cancel-restoring-pending",
+        4598,
+        "ready",
+        "agent-cancel-restoring",
+    );
+    seed_auto_queue_card(
+        &db,
+        "card-cancel-restoring-skipped",
+        4599,
+        "ready",
+        "agent-cancel-restoring",
+    );
+
+    {
+        let conn = db.lock().unwrap();
+        conn.execute(
+            "INSERT INTO auto_queue_runs (
+                id, repo, agent_id, status, created_at
+            ) VALUES (
+                'run-cancel-restoring', 'test-repo', 'agent-cancel-restoring', 'restoring', datetime('now')
+            )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO auto_queue_entries (
+                id, run_id, kanban_card_id, agent_id, status, priority_rank, thread_group
+            ) VALUES (
+                'entry-cancel-restoring-pending', 'run-cancel-restoring', 'card-cancel-restoring-pending',
+                'agent-cancel-restoring', 'pending', 0, 0
+            )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO auto_queue_entries (
+                id, run_id, kanban_card_id, agent_id, status, priority_rank, thread_group
+            ) VALUES (
+                'entry-cancel-restoring-skipped', 'run-cancel-restoring', 'card-cancel-restoring-skipped',
+                'agent-cancel-restoring', 'skipped', 1, 1
+            )",
+            [],
+        )
+        .unwrap();
+    }
+
+    let app = test_api_router(db.clone(), engine, None);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auto-queue/cancel")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["cancelled_runs"], 1);
+    assert_eq!(json["cancelled_entries"], 1);
+
+    let conn = db.lock().unwrap();
+    let run_status: String = conn
+        .query_row(
+            "SELECT status FROM auto_queue_runs WHERE id = 'run-cancel-restoring'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(run_status, "cancelled");
+
+    let entry_states: Vec<(String, String)> = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, status
+                 FROM auto_queue_entries
+                 WHERE run_id = 'run-cancel-restoring'
+                 ORDER BY id ASC",
+            )
+            .unwrap();
+        stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    };
+    assert_eq!(
+        entry_states,
+        vec![
+            (
+                "entry-cancel-restoring-pending".to_string(),
+                "skipped".to_string(),
+            ),
+            (
+                "entry-cancel-restoring-skipped".to_string(),
+                "skipped".to_string(),
+            ),
+        ]
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Automated fallback PR after direct merge into `main` hit a cherry-pick conflict.

Card: `994c90a7-049a-48ec-85e7-b8a960406333`
Issue: https://github.com/itismyfield/AgentDesk/issues/635

Conflict summary:
error: could not apply ea160091... #635 Make auto-queue restore resumable hint: After resolving the conflicts, mark them with hint: "git add/rm <pathspec>", then run hint: "git ...