### PR TITLE
#671 fix: dispatch 메시지 길이 제한 및 ci-recovery title에서 로그 제거

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -4,7 +4,7 @@
 
 - Production Rust modules: `249`
 - Giant-file threshold: `>= 1000` lines
-- Giant files: `60`
+- Giant files: `61`
 
 ## Namespace Summary
 
@@ -133,9 +133,9 @@
 | `server::routes::dispatched_sessions` | `src/server/routes/dispatched_sessions.rs` | 3304 | giant-file |
 | `server::routes::dispatches` | `src/server/routes/dispatches/mod.rs` | 99 |  |
 | `server::routes::dispatches::crud` | `src/server/routes/dispatches/crud.rs` | 97 |  |
-| `server::routes::dispatches::discord_delivery` | `src/server/routes/dispatches/discord_delivery.rs` | 3307 | giant-file |
-| `server::routes::dispatches::outbox` | `src/server/routes/dispatches/outbox.rs` | 1297 | giant-file |
-| `server::routes::dispatches::thread_reuse` | `src/server/routes/dispatches/thread_reuse.rs` | 876 |  |
+| `server::routes::dispatches::discord_delivery` | `src/server/routes/dispatches/discord_delivery.rs` | 3691 | giant-file |
+| `server::routes::dispatches::outbox` | `src/server/routes/dispatches/outbox.rs` | 1267 | giant-file |
+| `server::routes::dispatches::thread_reuse` | `src/server/routes/dispatches/thread_reuse.rs` | 901 |  |
 | `server::routes::dm_reply` | `src/server/routes/dm_reply.rs` | 67 |  |
 | `server::routes::docs` | `src/server/routes/docs.rs` | 2042 | giant-file |
 | `server::routes::domains` | `src/server/routes/domains/mod.rs` | 8 |  |
@@ -215,7 +215,7 @@
 | `services::discord::model_picker_interaction` | `src/services/discord/model_picker_interaction.rs` | 424 |  |
 | `services::discord::org_schema` | `src/services/discord/org_schema.rs` | 984 |  |
 | `services::discord::org_writer` | `src/services/discord/org_writer.rs` | 239 |  |
-| `services::discord::prompt_builder` | `src/services/discord/prompt_builder.rs` | 963 |  |
+| `services::discord::prompt_builder` | `src/services/discord/prompt_builder.rs` | 1390 | giant-file |
 | `services::discord::queue_io` | `src/services/discord/queue_io.rs` | 565 |  |
 | `services::discord::recovery_engine` | `src/services/discord/recovery_engine.rs` | 1939 | giant-file |
 | `services::discord::restart_ctrl` | `src/services/discord/restart_ctrl.rs` | 113 |  |
@@ -223,9 +223,9 @@
 | `services::discord::role_map` | `src/services/discord/role_map.rs` | 908 |  |
 | `services::discord::router` | `src/services/discord/router/mod.rs` | 13 |  |
 | `services::discord::router::control_intent` | `src/services/discord/router/control_intent.rs` | 352 |  |
-| `services::discord::router::intake_gate` | `src/services/discord/router/intake_gate.rs` | 1032 | giant-file |
-| `services::discord::router::message_handler` | `src/services/discord/router/message_handler.rs` | 2209 | giant-file |
-| `services::discord::router::thread_binding` | `src/services/discord/router/thread_binding.rs` | 124 |  |
+| `services::discord::router::intake_gate` | `src/services/discord/router/intake_gate.rs` | 1041 | giant-file |
+| `services::discord::router::message_handler` | `src/services/discord/router/message_handler.rs` | 2213 | giant-file |
+| `services::discord::router::thread_binding` | `src/services/discord/router/thread_binding.rs` | 129 |  |
 | `services::discord::runtime_bootstrap` | `src/services/discord/runtime_bootstrap.rs` | 1336 | giant-file |
 | `services::discord::runtime_store` | `src/services/discord/runtime_store.rs` | 329 |  |
 | `services::discord::session_runtime` | `src/services/discord/session_runtime.rs` | 1239 | giant-file |

--- a/docs/generated/route-inventory.md
+++ b/docs/generated/route-inventory.md
@@ -81,10 +81,10 @@
 | `GET` | `/api/help` | `docs::api_help` | `src/server/routes/docs.rs:1988` | `src/server/routes/domains/ops.rs:161` |
 | `DELETE` | `/api/hook/session` | `dispatched_sessions::delete_session` | `src/server/routes/dispatched_sessions.rs:544` | `src/server/routes/domains/ops.rs:79` |
 | `POST` | `/api/hook/session` | `dispatched_sessions::hook_session` | `src/server/routes/dispatched_sessions.rs:262` | `src/server/routes/domains/ops.rs:79` |
-| `GET` | `/api/internal/card-thread` | `dispatches::get_card_thread` | `src/server/routes/dispatches/thread_reuse.rs:691` | `src/server/routes/domains/ops.rs:26` |
+| `GET` | `/api/internal/card-thread` | `dispatches::get_card_thread` | `src/server/routes/dispatches/thread_reuse.rs:706` | `src/server/routes/domains/ops.rs:26` |
 | `POST` | `/api/internal/escalation/emit` | `escalation::emit_escalation` | `src/server/routes/escalation.rs:1248` | `src/server/routes/domains/admin.rs:61` |
-| `POST` | `/api/internal/link-dispatch-thread` | `dispatches::link_dispatch_thread` | `src/server/routes/dispatches/thread_reuse.rs:631` | `src/server/routes/domains/ops.rs:22` |
-| `GET` | `/api/internal/pending-dispatch-for-thread` | `dispatches::get_pending_dispatch_for_thread` | `src/server/routes/dispatches/thread_reuse.rs:820` | `src/server/routes/domains/ops.rs:27` |
+| `POST` | `/api/internal/link-dispatch-thread` | `dispatches::link_dispatch_thread` | `src/server/routes/dispatches/thread_reuse.rs:646` | `src/server/routes/domains/ops.rs:22` |
+| `GET` | `/api/internal/pending-dispatch-for-thread` | `dispatches::get_pending_dispatch_for_thread` | `src/server/routes/dispatches/thread_reuse.rs:845` | `src/server/routes/domains/ops.rs:27` |
 | `GET` | `/api/kanban-cards` | `kanban::list_cards` | `src/server/routes/kanban.rs:276` | `src/server/routes/domains/kanban.rs:11` |
 | `POST` | `/api/kanban-cards` | `kanban::create_card` | `src/server/routes/kanban.rs:323` | `src/server/routes/domains/kanban.rs:11` |
 | `POST` | `/api/kanban-cards/assign-issue` | `kanban::assign_issue` | `src/server/routes/kanban.rs:1444` | `src/server/routes/domains/kanban.rs:17` |

--- a/policies/ci-recovery.js
+++ b/policies/ci-recovery.js
@@ -19,6 +19,22 @@ var prTracking = agentdesk.prTracking;
 
 var CI_MAX_RETRIES = 3;
 var CI_LOG_MAX_LINES = 50;
+var CI_DISPATCH_CARD_TITLE_MAX_CHARS = 120;
+var CI_DISPATCH_JOB_NAME_MAX_CHARS = 60;
+
+function truncateText(text, maxChars) {
+  var normalized = String(text || "");
+  if (maxChars <= 0) {
+    return "";
+  }
+  if (normalized.length <= maxChars) {
+    return normalized;
+  }
+  if (maxChars === 1) {
+    return "…";
+  }
+  return normalized.substring(0, maxChars - 1) + "…";
+}
 
 // Transient failure patterns in CI logs
 var TRANSIENT_PATTERNS = [
@@ -359,18 +375,32 @@ function processWaitingCard(cardId, blockedReason) {
     var card = cards[0];
     var issueNum = card.github_issue_number || "?";
     var runUrl = "https://github.com/" + repo + "/actions/runs/" + runId;
+    var failedJobName = (classification.failedJobs && classification.failedJobs.length > 0)
+      ? classification.failedJobs[0]
+      : "unknown job";
+    var compactCardTitle = truncateText(card.title || "Untitled card", CI_DISPATCH_CARD_TITLE_MAX_CHARS);
+    var compactFailedJobName = truncateText(failedJobName, CI_DISPATCH_JOB_NAME_MAX_CHARS);
 
-    // CI log goes into dispatch context, NOT the title
-    var failedJobs = classification.reason || "unknown";
+    // Keep log excerpt in dispatch context, not in the Discord-visible title.
+    var logSnippet = classification.logExcerpt || "";
+    if (logSnippet.length > 1200) {
+      logSnippet = logSnippet.substring(logSnippet.length - 1200);
+    }
 
     try {
       agentdesk.dispatch.create(
         cardId,
         card.assigned_agent_id,
         "rework",
-        "[CI Fix] #" + issueNum + " " + card.title +
-        "\n\nCI failed: " + failedJobs +
-        "\nRun: " + runUrl
+        "[CI Fix] #" + issueNum + " " + compactCardTitle + " — " + compactFailedJobName,
+        {
+          ci_recovery: {
+            job_name: compactFailedJobName,
+            reason: classification.reason,
+            run_url: runUrl,
+            log_excerpt: logSnippet
+          }
+        }
       );
       agentdesk.log.info("[ci-recovery] Rework dispatch created for card " + cardId);
     } catch (e) {

--- a/src/server/routes/dispatches/discord_delivery.rs
+++ b/src/server/routes/dispatches/discord_delivery.rs
@@ -1671,7 +1671,12 @@ async fn send_dispatch_to_discord_inner_with_context(
                 }
             }
             Ok(None) => {}
-            Err(error) => return Err(error.to_string()),
+            Err(error) if error.is_length_error() => return Err(error.to_string()),
+            Err(error) => {
+                tracing::warn!(
+                    "[dispatch] Reusable thread probe failed for {existing_tid}: {error}; falling back to new thread"
+                );
+            }
         }
     }
 
@@ -2370,7 +2375,18 @@ mod tests {
         async fn get_channel(
             State(state): State<Arc<Mutex<MockDiscordState>>>,
             Path(thread_id): Path<String>,
-        ) -> impl IntoResponse {
+        ) -> axum::response::Response {
+            if thread_id == "thread-invalid-json" {
+                let mut state = state.lock().unwrap();
+                state.calls.push(format!("GET /channels/{thread_id}"));
+                return (
+                    axum::http::StatusCode::OK,
+                    [("content-type", "application/json")],
+                    "not-json",
+                )
+                    .into_response();
+            }
+
             let (archived, thread_name, parent_id) = {
                 let mut state = state.lock().unwrap();
                 state.calls.push(format!("GET /channels/{thread_id}"));
@@ -2399,6 +2415,7 @@ mod tests {
                     }
                 })),
             )
+                .into_response()
         }
 
         async fn patch_channel(
@@ -2704,6 +2721,96 @@ mod tests {
             )
             .unwrap();
         assert_eq!(thread_id, None);
+    }
+
+    #[tokio::test]
+    async fn reused_thread_probe_error_falls_back_to_creating_new_thread() {
+        let (base_url, state, server_handle) = spawn_mock_discord_server(false).await;
+        let db = test_db();
+        {
+            let conn = db.lock().unwrap();
+            conn.execute(
+                "INSERT INTO agents (id, name, discord_channel_id) VALUES ('agent-1', 'Agent 1', '123')",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO kanban_cards (
+                    id, title, status, assigned_agent_id, latest_dispatch_id, channel_thread_map, active_thread_id,
+                    created_at, updated_at
+                ) VALUES (
+                    'card-probe-error', 'Probe error card', 'requested', 'agent-1', 'dispatch-probe-error',
+                    '{\"123\":\"thread-invalid-json\"}', 'thread-invalid-json',
+                    datetime('now'), datetime('now')
+                )",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO task_dispatches (
+                    id, kanban_card_id, to_agent_id, dispatch_type, status, title,
+                    created_at, updated_at
+                ) VALUES (
+                    'dispatch-probe-error', 'card-probe-error', 'agent-1', 'implementation', 'pending', 'Probe error card',
+                    datetime('now'), datetime('now')
+                )",
+                [],
+            )
+            .unwrap();
+        }
+
+        send_dispatch_to_discord_inner_with_context(
+            &db,
+            "agent-1",
+            "Probe error card",
+            "card-probe-error",
+            "dispatch-probe-error",
+            "announce-token",
+            &base_url,
+            None,
+        )
+        .await
+        .expect("non-length reuse probe errors should fall back to new thread creation");
+
+        server_handle.abort();
+
+        let state = state.lock().unwrap();
+        assert_eq!(
+            state.calls.first().map(String::as_str),
+            Some("GET /channels/thread-invalid-json")
+        );
+        assert!(
+            state
+                .calls
+                .contains(&"POST /channels/123/threads".to_string())
+        );
+        assert!(
+            state
+                .calls
+                .contains(&"POST /channels/thread-created/messages".to_string())
+        );
+        assert!(state.calls.contains(
+            &"DELETE /channels/thread-created/messages/message-thread-created/reactions/%E2%9C%85/@me"
+                .to_string()
+        ));
+        assert!(state.calls.contains(
+            &"DELETE /channels/thread-created/messages/message-thread-created/reactions/%E2%9D%8C/@me"
+                .to_string()
+        ));
+        assert!(state.calls.contains(
+            &"PUT /channels/thread-created/messages/message-thread-created/reactions/%E2%8F%B3/@me"
+                .to_string()
+        ));
+
+        let conn = db.lock().unwrap();
+        let thread_id: Option<String> = conn
+            .query_row(
+                "SELECT thread_id FROM task_dispatches WHERE id = 'dispatch-probe-error'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(thread_id.as_deref(), Some("thread-created"));
     }
 
     #[tokio::test]

--- a/src/server/routes/dispatches/discord_delivery.rs
+++ b/src/server/routes/dispatches/discord_delivery.rs
@@ -1,4 +1,6 @@
-use super::outbox::{format_dispatch_message, prefix_dispatch_message, use_counter_model_channel};
+use super::outbox::{
+    build_minimal_dispatch_message, format_dispatch_message, prefix_dispatch_message,
+};
 use super::resolve_channel_alias;
 use super::thread_reuse::{
     clear_thread_for_channel, get_thread_for_channel, set_thread_for_channel, try_reuse_thread,
@@ -86,6 +88,36 @@ pub(crate) enum ReviewFollowupKind {
     Pass,
     Unknown,
 }
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum DispatchMessagePostErrorKind {
+    MessageTooLong,
+    Other,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct DispatchMessagePostError {
+    kind: DispatchMessagePostErrorKind,
+    detail: String,
+}
+
+impl DispatchMessagePostError {
+    pub(super) fn new(kind: DispatchMessagePostErrorKind, detail: String) -> Self {
+        Self { kind, detail }
+    }
+
+    pub(super) fn is_length_error(&self) -> bool {
+        self.kind == DispatchMessagePostErrorKind::MessageTooLong
+    }
+}
+
+impl std::fmt::Display for DispatchMessagePostError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.detail)
+    }
+}
+
+impl std::error::Error for DispatchMessagePostError {}
 
 /// Discord delivery side-effects boundary.
 /// Keep business rules local and swap transport behavior in tests.
@@ -340,13 +372,25 @@ async fn apply_dispatch_status_reaction_state(
     }
 }
 
-pub(super) async fn post_dispatch_message_to_channel(
+fn is_discord_length_error(status: reqwest::StatusCode, body: &str) -> bool {
+    if status != reqwest::StatusCode::BAD_REQUEST {
+        return false;
+    }
+    let lowered = body.to_ascii_lowercase();
+    body.contains("BASE_TYPE_MAX_LENGTH")
+        || lowered.contains("2000 or fewer in length")
+        || lowered.contains("100 or fewer in length")
+        || lowered.contains("string value is too long")
+        || (body.contains("50035") && lowered.contains("length"))
+}
+
+async fn post_dispatch_message_once_to_channel(
     client: &reqwest::Client,
     token: &str,
     base_url: &str,
     channel_id: &str,
     message: &str,
-) -> Result<String, String> {
+) -> Result<String, DispatchMessagePostError> {
     // Hard-truncate to stay within Discord's 2000 Unicode character limit.
     // Discord counts chars (not bytes), so use .chars().count().
     let message = if message.chars().count() > 1900 {
@@ -369,26 +413,77 @@ pub(super) async fn post_dispatch_message_to_channel(
         .json(&serde_json::json!({"content": message}))
         .send()
         .await
-        .map_err(|error| format!("failed to post dispatch message to {channel_id}: {error}"))?;
+        .map_err(|error| {
+            DispatchMessagePostError::new(
+                DispatchMessagePostErrorKind::Other,
+                format!("failed to post dispatch message to {channel_id}: {error}"),
+            )
+        })?;
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
-        return Err(format!(
-            "failed to post dispatch message to {channel_id}: {status} {body}"
+        let kind = if is_discord_length_error(status, &body) {
+            DispatchMessagePostErrorKind::MessageTooLong
+        } else {
+            DispatchMessagePostErrorKind::Other
+        };
+        return Err(DispatchMessagePostError::new(
+            kind,
+            format!("failed to post dispatch message to {channel_id}: {status} {body}"),
         ));
     }
     let body = response
         .json::<serde_json::Value>()
         .await
         .map_err(|error| {
-            format!("failed to parse dispatch message response for {channel_id}: {error}")
+            DispatchMessagePostError::new(
+                DispatchMessagePostErrorKind::Other,
+                format!("failed to parse dispatch message response for {channel_id}: {error}"),
+            )
         })?;
     body.get("id")
         .and_then(|value| value.as_str())
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(|value| value.to_string())
-        .ok_or_else(|| format!("dispatch message response for {channel_id} omitted message id"))
+        .ok_or_else(|| {
+            DispatchMessagePostError::new(
+                DispatchMessagePostErrorKind::Other,
+                format!("dispatch message response for {channel_id} omitted message id"),
+            )
+        })
+}
+
+pub(super) async fn post_dispatch_message_to_channel(
+    client: &reqwest::Client,
+    token: &str,
+    base_url: &str,
+    channel_id: &str,
+    message: &str,
+    minimal_message: &str,
+) -> Result<String, DispatchMessagePostError> {
+    match post_dispatch_message_once_to_channel(client, token, base_url, channel_id, message).await
+    {
+        Ok(message_id) => Ok(message_id),
+        Err(error)
+            if error.is_length_error()
+                && !minimal_message.trim().is_empty()
+                && minimal_message != message =>
+        {
+            tracing::warn!(
+                "[dispatch] Message too long for channel {channel_id}; retrying with minimal fallback"
+            );
+            post_dispatch_message_once_to_channel(
+                client,
+                token,
+                base_url,
+                channel_id,
+                minimal_message,
+            )
+            .await
+        }
+        Err(error) => Err(error),
+    }
 }
 
 pub(super) async fn persist_dispatch_message_target_and_add_pending_reaction(
@@ -1340,9 +1435,6 @@ async fn send_dispatch_to_discord_inner_with_context(
         return Ok(());
     }
 
-    // For review dispatches, use the alternate channel (counter-model)
-    let use_alt = use_counter_model_channel(dispatch_type.as_deref());
-
     // Look up agent's discord channel
     let channel_id: Option<String> = {
         let conn = match db.lock() {
@@ -1406,49 +1498,25 @@ async fn send_dispatch_to_discord_inner_with_context(
     let dispatch_context_json = dispatch_context_value(dispatch_context.as_deref());
 
     // For review dispatches, look up reviewed commit SHA, branch, and target provider from context
-    let (reviewed_commit, target_provider, review_branch): (
-        Option<String>,
-        Option<String>,
-        Option<String>,
-    ) = if use_alt {
-        let ctx_val = dispatch_context_json
-            .clone()
-            .unwrap_or_else(|| serde_json::json!({}));
-        (
-            ctx_val
-                .get("reviewed_commit")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string()),
-            ctx_val
-                .get("target_provider")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string()),
-            ctx_val
-                .get("branch")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string()),
-        )
-    } else {
-        (None, None, None)
-    };
-
     let message = format_dispatch_message(
         dispatch_id,
         title,
         issue_url.as_deref(),
         issue_number,
-        use_alt,
-        reviewed_commit.as_deref(),
-        target_provider.as_deref(),
-        review_branch.as_deref(),
+        dispatch_type.as_deref(),
+        dispatch_context.as_deref(),
+    );
+    let minimal_message = build_minimal_dispatch_message(
+        dispatch_id,
+        title,
+        issue_url.as_deref(),
+        issue_number,
         dispatch_type.as_deref(),
         dispatch_context.as_deref(),
     );
 
     // ── Thread reuse: every dispatch now resolves into a slot thread ──
     let client = reqwest::Client::new();
-    let dispatch_type_label = dispatch_type.as_deref().unwrap_or("implementation");
-    let message = prefix_dispatch_message(dispatch_type_label, &message);
     if !crate::dispatch::dispatch_type_uses_thread_routing(dispatch_type.as_deref()) {
         let channel_id_text = channel_id_num.to_string();
         let message_id = post_dispatch_message_to_channel(
@@ -1457,8 +1525,10 @@ async fn send_dispatch_to_discord_inner_with_context(
             &discord_api_base,
             &channel_id_text,
             &message,
+            &minimal_message,
         )
-        .await?;
+        .await
+        .map_err(|error| error.to_string())?;
         persist_dispatch_message_target_and_add_pending_reaction(
             db,
             &client,
@@ -1550,7 +1620,7 @@ async fn send_dispatch_to_discord_inner_with_context(
         .unwrap_or_default();
 
     for existing_tid in &existing_thread_ids {
-        if let Some(reused) = try_reuse_thread(
+        match try_reuse_thread(
             &client,
             &token,
             discord_api_base,
@@ -1558,45 +1628,50 @@ async fn send_dispatch_to_discord_inner_with_context(
             channel_id_num,
             &thread_name,
             &message,
+            &minimal_message,
             dispatch_id,
             card_id,
             db,
         )
         .await
         {
-            if reused {
-                if let Ok(conn) = db.lock() {
-                    set_thread_for_channel(&conn, card_id, channel_id_num, existing_tid);
-                    if let Some(binding) = slot_binding.as_ref() {
-                        upsert_slot_thread_id(
-                            &conn,
-                            &binding.agent_id,
-                            binding.slot_index,
-                            channel_id_num,
-                            existing_tid,
-                        );
+            Ok(Some(reused)) => {
+                if reused {
+                    if let Ok(conn) = db.lock() {
+                        set_thread_for_channel(&conn, card_id, channel_id_num, existing_tid);
+                        if let Some(binding) = slot_binding.as_ref() {
+                            upsert_slot_thread_id(
+                                &conn,
+                                &binding.agent_id,
+                                binding.slot_index,
+                                channel_id_num,
+                                existing_tid,
+                            );
+                        }
                     }
+                    archive_duplicate_slot_threads(
+                        &client,
+                        &token,
+                        discord_api_base,
+                        channel_id_num,
+                        existing_tid,
+                        &existing_thread_ids,
+                    )
+                    .await;
+                    maybe_add_owner_to_dispatch_thread(
+                        &client,
+                        &token,
+                        &discord_api_base,
+                        existing_tid,
+                        dispatch_id,
+                        thread_owner_user_id,
+                    )
+                    .await;
+                    return Ok(());
                 }
-                archive_duplicate_slot_threads(
-                    &client,
-                    &token,
-                    discord_api_base,
-                    channel_id_num,
-                    existing_tid,
-                    &existing_thread_ids,
-                )
-                .await;
-                maybe_add_owner_to_dispatch_thread(
-                    &client,
-                    &token,
-                    &discord_api_base,
-                    existing_tid,
-                    dispatch_id,
-                    thread_owner_user_id,
-                )
-                .await;
-                return Ok(());
             }
+            Ok(None) => {}
+            Err(error) => return Err(error.to_string()),
         }
     }
 
@@ -1636,6 +1711,7 @@ async fn send_dispatch_to_discord_inner_with_context(
                         &discord_api_base,
                         thread_id,
                         &message,
+                        &minimal_message,
                     )
                     .await
                     {
@@ -1696,7 +1772,7 @@ async fn send_dispatch_to_discord_inner_with_context(
                                 "[dispatch] Thread message POST failed for dispatch {dispatch_id}: {}",
                                 error
                             );
-                            return Err(error);
+                            return Err(error.to_string());
                         }
                     }
                 }
@@ -1707,6 +1783,12 @@ async fn send_dispatch_to_discord_inner_with_context(
         Ok(tr) => {
             // Thread creation failed — fall back to sending directly to the channel
             let status = tr.status();
+            let body = tr.text().await.unwrap_or_default();
+            if is_discord_length_error(status, &body) {
+                return Err(format!(
+                    "thread creation rejected for dispatch {dispatch_id} due to Discord length limits: {status} {body}"
+                ));
+            }
             tracing::warn!(
                 "[dispatch] Thread creation failed ({status}), falling back to channel message"
             );
@@ -1717,6 +1799,7 @@ async fn send_dispatch_to_discord_inner_with_context(
                 &discord_api_base,
                 &channel_id_text,
                 &message,
+                &minimal_message,
             )
             .await
             {
@@ -1738,7 +1821,7 @@ async fn send_dispatch_to_discord_inner_with_context(
                 }
                 Err(e) => {
                     tracing::warn!("[dispatch] Fallback dispatch message failed: {e}");
-                    return Err(e);
+                    return Err(e.to_string());
                 }
             }
         }
@@ -2221,7 +2304,10 @@ mod tests {
     struct MockDiscordState {
         archived: bool,
         unarchive_failures_remaining: usize,
+        message_length_failures_remaining: usize,
+        message_length_failure_min_chars: Option<usize>,
         calls: Vec<String>,
+        posted_messages: Vec<(String, String)>,
         thread_names: HashMap<String, String>,
         thread_parents: HashMap<String, String>,
     }
@@ -2233,12 +2319,49 @@ mod tests {
         Arc<Mutex<MockDiscordState>>,
         tokio::task::JoinHandle<()>,
     ) {
-        spawn_mock_discord_server_with_failures(initial_archived, 0).await
+        spawn_mock_discord_server_with_config(initial_archived, 0, 0, None).await
     }
 
     async fn spawn_mock_discord_server_with_failures(
         initial_archived: bool,
         unarchive_failures_remaining: usize,
+    ) -> (
+        String,
+        Arc<Mutex<MockDiscordState>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        spawn_mock_discord_server_with_config(
+            initial_archived,
+            unarchive_failures_remaining,
+            0,
+            None,
+        )
+        .await
+    }
+
+    async fn spawn_mock_discord_server_with_message_length_failures(
+        initial_archived: bool,
+        message_length_failures_remaining: usize,
+        message_length_failure_min_chars: usize,
+    ) -> (
+        String,
+        Arc<Mutex<MockDiscordState>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        spawn_mock_discord_server_with_config(
+            initial_archived,
+            0,
+            message_length_failures_remaining,
+            Some(message_length_failure_min_chars),
+        )
+        .await
+    }
+
+    async fn spawn_mock_discord_server_with_config(
+        initial_archived: bool,
+        unarchive_failures_remaining: usize,
+        message_length_failures_remaining: usize,
+        message_length_failure_min_chars: Option<usize>,
     ) -> (
         String,
         Arc<Mutex<MockDiscordState>>,
@@ -2335,11 +2458,45 @@ mod tests {
         async fn post_message(
             State(state): State<Arc<Mutex<MockDiscordState>>>,
             Path(channel_id): Path<String>,
+            Json(body): Json<serde_json::Value>,
         ) -> impl IntoResponse {
             let mut state = state.lock().unwrap();
             state
                 .calls
                 .push(format!("POST /channels/{channel_id}/messages"));
+            let content = body
+                .get("content")
+                .and_then(|value| value.as_str())
+                .unwrap_or_default()
+                .to_string();
+            state
+                .posted_messages
+                .push((channel_id.clone(), content.clone()));
+            if state.message_length_failures_remaining > 0
+                && state
+                    .message_length_failure_min_chars
+                    .map(|limit| content.chars().count() >= limit)
+                    .unwrap_or(false)
+            {
+                state.message_length_failures_remaining -= 1;
+                return (
+                    axum::http::StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "code": 50035,
+                        "message": "Invalid Form Body",
+                        "errors": {
+                            "content": {
+                                "_errors": [
+                                    {
+                                        "code": "BASE_TYPE_MAX_LENGTH",
+                                        "message": "Must be 2000 or fewer in length."
+                                    }
+                                ]
+                            }
+                        }
+                    })),
+                );
+            }
             (
                 axum::http::StatusCode::OK,
                 Json(serde_json::json!({"id": format!("message-{channel_id}")})),
@@ -2380,7 +2537,10 @@ mod tests {
         let state = Arc::new(Mutex::new(MockDiscordState {
             archived: initial_archived,
             unarchive_failures_remaining,
+            message_length_failures_remaining,
+            message_length_failure_min_chars,
             calls: Vec::new(),
+            posted_messages: Vec::new(),
             thread_names: HashMap::new(),
             thread_parents: HashMap::new(),
         }));
@@ -2427,6 +2587,123 @@ mod tests {
                 "PUT /channels/thread-1/thread-members/42",
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn post_dispatch_message_retries_with_minimal_fallback_after_length_error() {
+        let (base_url, state, server_handle) =
+            spawn_mock_discord_server_with_message_length_failures(false, 1, 120).await;
+        let client = reqwest::Client::new();
+        let primary_message = "A".repeat(180);
+        let minimal_message = "minimal fallback message";
+
+        let message_id = post_dispatch_message_to_channel(
+            &client,
+            "announce-token",
+            &base_url,
+            "123",
+            &primary_message,
+            minimal_message,
+        )
+        .await
+        .unwrap();
+
+        server_handle.abort();
+        assert_eq!(message_id, "message-123");
+
+        let state = state.lock().unwrap();
+        assert_eq!(
+            state.calls,
+            vec!["POST /channels/123/messages", "POST /channels/123/messages",]
+        );
+        assert_eq!(
+            state.posted_messages,
+            vec![
+                ("123".to_string(), primary_message),
+                ("123".to_string(), minimal_message.to_string()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn reused_thread_length_error_does_not_fall_back_to_creating_new_thread() {
+        let (base_url, state, server_handle) =
+            spawn_mock_discord_server_with_message_length_failures(false, 2, 10).await;
+        let db = test_db();
+        {
+            let conn = db.lock().unwrap();
+            conn.execute(
+                "INSERT INTO agents (id, name, discord_channel_id) VALUES ('agent-1', 'Agent 1', '123')",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO kanban_cards (
+                    id, title, status, assigned_agent_id, latest_dispatch_id, channel_thread_map, active_thread_id,
+                    created_at, updated_at
+                ) VALUES (
+                    'card-length', 'Length card', 'requested', 'agent-1', 'dispatch-length',
+                    '{\"123\":\"thread-existing\"}', 'thread-existing',
+                    datetime('now'), datetime('now')
+                )",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO task_dispatches (
+                    id, kanban_card_id, to_agent_id, dispatch_type, status, title,
+                    created_at, updated_at
+                ) VALUES (
+                    'dispatch-length', 'card-length', 'agent-1', 'implementation', 'pending', 'Length card',
+                    datetime('now'), datetime('now')
+                )",
+                [],
+            )
+            .unwrap();
+        }
+
+        let error = send_dispatch_to_discord_inner_with_context(
+            &db,
+            "agent-1",
+            "Length card",
+            "card-length",
+            "dispatch-length",
+            "announce-token",
+            &base_url,
+            None,
+        )
+        .await
+        .expect_err("length error after minimal retry should fail closed");
+
+        server_handle.abort();
+        assert!(error.contains("BASE_TYPE_MAX_LENGTH"));
+
+        let state = state.lock().unwrap();
+        assert_eq!(
+            state.calls,
+            vec![
+                "GET /channels/thread-existing",
+                "PATCH /channels/thread-existing",
+                "POST /channels/thread-existing/messages",
+                "POST /channels/thread-existing/messages",
+            ]
+        );
+        assert!(
+            !state
+                .calls
+                .contains(&"POST /channels/123/threads".to_string()),
+            "length errors on a reused thread must not trigger new thread fallback"
+        );
+
+        let conn = db.lock().unwrap();
+        let thread_id: Option<String> = conn
+            .query_row(
+                "SELECT thread_id FROM task_dispatches WHERE id = 'dispatch-length'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(thread_id, None);
     }
 
     #[tokio::test]

--- a/src/server/routes/dispatches/outbox.rs
+++ b/src/server/routes/dispatches/outbox.rs
@@ -877,67 +877,57 @@ pub(crate) fn use_counter_model_channel(dispatch_type: Option<&str>) -> bool {
     )
 }
 
-fn review_quality_checklist(context_json: &serde_json::Value) -> Vec<String> {
-    let checklist = context_json
-        .get("review_quality_checklist")
-        .and_then(|value| value.as_array())
-        .map(|items| {
-            items
-                .iter()
-                .filter_map(|item| item.as_str())
-                .map(str::to_string)
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
+// ── Message formatting ──────────────────────────────────────────
 
-    if checklist.is_empty() {
-        crate::dispatch::REVIEW_QUALITY_CHECKLIST
-            .iter()
-            .map(|item| (*item).to_string())
-            .collect()
+const DISPATCH_MESSAGE_TARGET_LEN: usize = 500;
+pub(super) const DISPATCH_MESSAGE_HARD_LIMIT: usize = 1800;
+const DISPATCH_TITLE_PRIMARY_LIMIT: usize = 160;
+const DISPATCH_TITLE_COMPACT_LIMIT: usize = 96;
+const DISPATCH_TITLE_MINIMAL_LIMIT: usize = 72;
+
+fn truncate_chars(value: &str, limit: usize) -> String {
+    let total = value.chars().count();
+    if total <= limit {
+        return value.to_string();
+    }
+    if limit <= 1 {
+        return "…".chars().take(limit).collect();
+    }
+
+    let mut truncated: String = value.chars().take(limit - 1).collect();
+    truncated.push('…');
+    truncated
+}
+
+fn compact_dispatch_title(title: &str, limit: usize) -> String {
+    let first_line = title
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or(title);
+    let collapsed = first_line.split_whitespace().collect::<Vec<_>>().join(" ");
+    let trimmed = collapsed.trim();
+    if trimmed.is_empty() {
+        "Untitled dispatch".to_string()
     } else {
-        checklist
+        truncate_chars(trimmed, limit)
     }
 }
 
-// ── Message formatting ──────────────────────────────────────────
-
-pub(super) fn format_dispatch_message(
-    dispatch_id: &str,
-    title: &str,
-    issue_url: Option<&str>,
-    issue_number: Option<i64>,
-    use_alt: bool,
-    reviewed_commit: Option<&str>,
-    target_provider: Option<&str>,
-    review_branch: Option<&str>,
-    dispatch_type: Option<&str>,
-    dispatch_context: Option<&str>,
-) -> String {
-    let context_json = dispatch_context
-        .and_then(|ctx| serde_json::from_str::<serde_json::Value>(ctx).ok())
-        .unwrap_or_else(|| serde_json::json!({}));
-
-    // Format issue link as markdown hyperlink with angle brackets to suppress embed
-    let issue_link = match (issue_url, issue_number) {
-        (Some(url), Some(num)) => format!("[{title} #{num}](<{url}>)"),
-        (Some(url), None) => format!("[{title}](<{url}>)"),
-        _ => String::new(),
-    };
-
-    // Build dispatch type label and reason line
-    let type_label = match dispatch_type {
+fn dispatch_type_label(dispatch_type: Option<&str>) -> &'static str {
+    match dispatch_type {
         Some("implementation") => "📋 구현",
         Some("review") => "🔍 리뷰",
         Some("rework") => "🔧 리워크",
         Some("review-decision") => "⚖️ 리뷰 검토",
         Some("pm-decision") => "🎯 PM 판단",
         Some("e2e-test") => "🧪 E2E 테스트",
-        Some(other) => other,
-        None => "dispatch",
-    };
+        Some("consultation") => "💬 상담",
+        Some("phase-gate") => "🚦 Phase Gate",
+        _ => "dispatch",
+    }
+}
 
-    // Extract reason from context JSON
+fn dispatch_reason_suffix(context_json: &serde_json::Value) -> String {
     let reason = context_json
         .get("resumed_from")
         .and_then(|r| r.as_str())
@@ -972,169 +962,149 @@ pub(super) fn format_dispatch_message(
             }
         });
 
-    let reason_suffix = reason.map(|r| format!(" ({r})")).unwrap_or_default();
-    let review_verdict = context_json
-        .get("verdict")
-        .and_then(|v| v.as_str())
-        .unwrap_or("unknown");
-    let review_mode = context_json
-        .get("review_mode")
-        .and_then(|value| value.as_str());
-    let noop_verification = review_mode == Some("noop_verification");
+    reason
+        .map(|value| format!(" ({value})"))
+        .unwrap_or_default()
+}
 
-    if dispatch_type == Some("review") {
-        let mut message = format!(
-            "DISPATCH:{dispatch_id} [{type_label}] - {title}\n\
-             ⚠️ 검토 전용 — 작업 착수 금지\n\
-             코드 리뷰만 수행하고 GitHub 이슈에 코멘트로 피드백해주세요."
-        );
-        if !issue_link.is_empty() {
-            message.push('\n');
-            message.push_str(&issue_link);
+fn dispatch_instruction_line(dispatch_type: Option<&str>) -> &'static str {
+    match dispatch_type {
+        Some("review") => {
+            "한 줄 지시: 코드 리뷰만 수행하고 상세 범위와 verdict 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
         }
-        // #193: Include branch info so reviewer inspects the correct code
-        if let Some(branch) = review_branch {
-            let short_commit = reviewed_commit.map(|c| &c[..8.min(c.len())]).unwrap_or("?");
-            message.push_str(&format!(
-                "\n\n리뷰 대상 브랜치: `{branch}` (commit: `{short_commit}`)\n\
-                 반드시 해당 브랜치를 checkout하여 리뷰하세요. main 브랜치가 아닙니다."
-            ));
-            if !noop_verification {
-                if let (Some(merge_base), Some(reviewed_commit)) = (
-                    context_json
-                        .get("merge_base")
-                        .and_then(|value| value.as_str()),
-                    reviewed_commit,
-                ) {
-                    message.push_str(&format!(
-                        "\n\
-                         merge-base(main, `{branch}`): `{merge_base}`\n\
-                         정확한 변경 범위는 아래 명령으로 확인하세요:\n\
-                         ```bash\n\
-                         git diff {merge_base}..{reviewed_commit}\n\
-                         ```"
-                    ));
-                }
-            } else {
-                message.push_str(
-                    "\n\
-                     이번 리뷰는 diff 검토가 아니라 현재 브랜치 상태 검증입니다. 이슈 본문과 실제 코드 상태 대조를 우선하세요.",
-                );
-            }
+        Some("review-decision") => {
+            "한 줄 지시: GitHub 리뷰 피드백을 확인하고 accept/dispute/dismiss 중 하나를 제출하세요."
         }
-        if let Some(warning) = context_json
-            .get("review_target_warning")
-            .and_then(|value| value.as_str())
-        {
-            message.push_str(&format!("\n\n리뷰 타겟 안내: {warning}"));
+        Some("implementation") => {
+            "한 줄 지시: 이 이슈를 구현하고 상세 요구사항과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
         }
-        if noop_verification {
-            let noop_reason = context_json
-                .get("noop_reason")
-                .and_then(|value| value.as_str())
-                .or_else(|| {
-                    context_json
-                        .get("noop_result")
-                        .and_then(|value| value.get("notes"))
-                        .and_then(|value| value.as_str())
-                })
-                .unwrap_or("noop 사유가 제공되지 않았습니다.");
-            message.push_str(&format!(
-                "\n\n리뷰 모드: `noop_verification`\n\
-                 이번 리뷰는 코드 diff 대신 GitHub 이슈 본문과 현재 코드 상태를 대조하는 검증입니다.\n\
-                 noop 사유: {noop_reason}\n\
-                 반드시 아래 항목을 판정하세요:\n\
-                 - 이슈가 요구한 변경이 현재 코드에 이미 존재하는지\n\
-                 - noop 사유가 구체적이고 직접 검증 가능한지\n\
-                 둘 중 하나라도 아니면 `VERDICT: reject` 또는 `VERDICT: rework`로 판정하세요."
-            ));
+        Some("rework") => {
+            "한 줄 지시: 기존 결과를 수정하고 상세 요구사항과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
         }
-        let review_scope_reminder = context_json
-            .get("review_quality_scope_reminder")
-            .and_then(|value| value.as_str())
-            .unwrap_or(crate::dispatch::REVIEW_QUALITY_SCOPE_REMINDER);
-        let review_verdict_guidance = context_json
-            .get("review_verdict_guidance")
-            .and_then(|value| value.as_str())
-            .unwrap_or(crate::dispatch::REVIEW_VERDICT_IMPROVE_GUIDANCE);
-        let quality_checklist = review_quality_checklist(&context_json);
-        message.push_str(&format!("\n\n{review_scope_reminder}"));
-        for item in quality_checklist {
-            message.push_str(&format!("\n- {item}"));
+        Some("e2e-test") => {
+            "한 줄 지시: 검증만 수행하고 상세 기준과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
         }
-        message.push_str(&format!("\n{review_verdict_guidance}"));
-        // Append verdict API call instructions for the counter-model reviewer
-        let commit_arg = reviewed_commit
-            .map(|c| format!(r#","commit":"{}""#, c))
-            .unwrap_or_default();
-        let provider_arg = target_provider
-            .map(|p| format!(r#","provider":"{}""#, p))
-            .unwrap_or_default();
-        let base_url = crate::config::local_api_url(crate::config::load_graceful().server.port, "");
-        message.push_str(&format!(
-            "\n---\n\
-             응답 첫 줄에 반드시 `VERDICT: pass|improve|reject|rework` 중 하나를 적으세요.\n\
-             verdict API가 200 OK로 호출되기 전까지 리뷰는 완료로 간주되지 않습니다.\n\
-             `improve`/`reject`/`rework` 시 반드시 `notes`에 구체적 피드백을, `items`에 개별 지적 사항을 포함하세요.\n\
-             리뷰 완료 후 verdict API를 호출하세요:\n\
-             `curl -sf -X POST {base_url}/api/review-verdict \
-             -H \"Content-Type: application/json\" \
-             -d '{{\"dispatch_id\":\"{dispatch_id}\",\"overall\":\"pass|improve|reject|rework\",\
-             \"notes\":\"리뷰 피드백 요약\",\
-             \"items\":[{{\"category\":\"bug|style|perf|security|logic\",\"summary\":\"개별 지적 사항\"}}]\
-             {commit_arg}{provider_arg}}}'`"
-        ));
-        message
-    } else if dispatch_type == Some("review-decision") {
-        let mut message = format!(
-            "DISPATCH:{dispatch_id} [{type_label}] - {title}\n\
-             ⛔ 코드 리뷰 금지 — 이미 완료된 리뷰 결과를 검토하는 단계입니다\n\
-             📝 카운터모델 리뷰 결과: **{review_verdict}**\n\
-             GitHub 이슈 코멘트에서 피드백을 확인하고 다음 중 하나를 선택하세요:\n\
-             • **수용** → 피드백 반영 수정 후 review-decision API에 `accept` 호출\n\
-             • **반론** → GitHub 코멘트로 이의 제기 후 review-decision API에 `dispute` 호출\n\
-             • **무시** → review-decision API에 `dismiss` 호출"
-        );
-        if !issue_link.is_empty() {
-            message.push('\n');
-            message.push_str(&issue_link);
+        Some("consultation") => {
+            "한 줄 지시: 필요한 조사/판단만 수행하고 상세 기준과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
         }
-        message
-    } else if matches!(dispatch_type, Some("implementation") | Some("rework")) {
-        let mut message = if !issue_link.is_empty() {
-            format!("DISPATCH:{dispatch_id} [{type_label}] - {title}{reason_suffix}\n{issue_link}")
-        } else {
-            format!("DISPATCH:{dispatch_id} [{type_label}] - {title}{reason_suffix}")
-        };
-        message.push_str(
-            "\n\n구현이 불필요하고 현재 worktree에 tracked 변경이 전혀 없을 때만 응답 첫 줄에 반드시 `OUTCOME: noop`를 적고 근거를 설명하세요.\n\
-             tracked 변경이 남아 있으면 noop 완료가 거부되므로 먼저 commit 또는 정리를 해야 합니다.\n\
-             이 marker가 있으면 일반 완료 대신 non-implementation terminal path로 처리됩니다.\n\
-             \n\
-             커밋 메시지에 반드시 GitHub 이슈 번호를 포함하세요 (예: `#123 구현 내용`). 이슈-커밋 추적성을 위해 필수입니다.",
-        );
-        message
-    } else if use_alt {
-        let mut message = if !issue_link.is_empty() {
-            format!("DISPATCH:{dispatch_id} [{type_label}] - {title}{reason_suffix}\n{issue_link}")
-        } else {
-            format!("DISPATCH:{dispatch_id} [{type_label}] - {title}{reason_suffix}")
-        };
-        let base_url = crate::config::local_api_url(crate::config::load_graceful().server.port, "");
-        message.push_str(&format!(
-            "\n\n작업을 마치면 일반 dispatch 완료 API로 종료하세요.\n\
-             리뷰 전용 verdict 절차를 쓰지 말고 아래 완료 경로를 그대로 사용하세요.\n\
-             완료 예시:\n\
-             `curl -sf -X PATCH {base_url}/api/dispatches/{dispatch_id} \
-             -H \"Content-Type: application/json\" \
-             -d '{{\"status\":\"completed\",\"result\":{{\"summary\":\"결과 요약\"}}}}'`"
-        ));
-        message
-    } else if !issue_link.is_empty() {
-        format!("DISPATCH:{dispatch_id} [{type_label}] - {title}{reason_suffix}\n{issue_link}")
-    } else {
-        format!("DISPATCH:{dispatch_id} [{type_label}] - {title}{reason_suffix}")
+        Some("phase-gate") => {
+            "한 줄 지시: phase gate 판정만 수행하고 체크 항목과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
+        }
+        _ => "한 줄 지시: 상세 요구사항은 시스템 프롬프트의 [Current Task]를 따르세요.",
     }
+}
+
+fn minimal_dispatch_instruction_line() -> &'static str {
+    "상세 요구사항과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
+}
+
+fn render_dispatch_message(
+    dispatch_id: &str,
+    title: &str,
+    issue_url: Option<&str>,
+    issue_number: Option<i64>,
+    dispatch_type: Option<&str>,
+    context_json: &serde_json::Value,
+    title_limit: usize,
+    include_url: bool,
+    instruction_line: &str,
+) -> String {
+    let compact_title = compact_dispatch_title(title, title_limit);
+    let title_with_issue = match issue_number {
+        Some(number) if !compact_title.contains(&format!("#{number}")) => {
+            format!("#{number} {compact_title}")
+        }
+        _ => compact_title,
+    };
+    let mut lines = vec![format!(
+        "DISPATCH:{dispatch_id} [{}] - {}{}",
+        dispatch_type_label(dispatch_type),
+        title_with_issue,
+        dispatch_reason_suffix(context_json),
+    )];
+    if include_url && let Some(url) = issue_url.map(str::trim).filter(|value| !value.is_empty()) {
+        lines.push(format!("<{url}>"));
+    }
+    lines.push(instruction_line.to_string());
+
+    prefix_dispatch_message(dispatch_type.unwrap_or("dispatch"), &lines.join("\n"))
+}
+
+pub(super) fn build_minimal_dispatch_message(
+    dispatch_id: &str,
+    title: &str,
+    issue_url: Option<&str>,
+    issue_number: Option<i64>,
+    dispatch_type: Option<&str>,
+    dispatch_context: Option<&str>,
+) -> String {
+    let context_json = dispatch_context
+        .and_then(|ctx| serde_json::from_str::<serde_json::Value>(ctx).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+    let message = render_dispatch_message(
+        dispatch_id,
+        title,
+        issue_url,
+        issue_number,
+        dispatch_type,
+        &context_json,
+        DISPATCH_TITLE_MINIMAL_LIMIT,
+        false,
+        minimal_dispatch_instruction_line(),
+    );
+    truncate_chars(&message, DISPATCH_MESSAGE_HARD_LIMIT)
+}
+
+pub(super) fn format_dispatch_message(
+    dispatch_id: &str,
+    title: &str,
+    issue_url: Option<&str>,
+    issue_number: Option<i64>,
+    dispatch_type: Option<&str>,
+    dispatch_context: Option<&str>,
+) -> String {
+    let context_json = dispatch_context
+        .and_then(|ctx| serde_json::from_str::<serde_json::Value>(ctx).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+
+    let primary = render_dispatch_message(
+        dispatch_id,
+        title,
+        issue_url,
+        issue_number,
+        dispatch_type,
+        &context_json,
+        DISPATCH_TITLE_PRIMARY_LIMIT,
+        true,
+        dispatch_instruction_line(dispatch_type),
+    );
+    if primary.chars().count() <= DISPATCH_MESSAGE_TARGET_LEN {
+        return primary;
+    }
+
+    let compact = render_dispatch_message(
+        dispatch_id,
+        title,
+        issue_url,
+        issue_number,
+        dispatch_type,
+        &context_json,
+        DISPATCH_TITLE_COMPACT_LIMIT,
+        true,
+        minimal_dispatch_instruction_line(),
+    );
+    if compact.chars().count() <= DISPATCH_MESSAGE_HARD_LIMIT {
+        return compact;
+    }
+
+    build_minimal_dispatch_message(
+        dispatch_id,
+        title,
+        issue_url,
+        issue_number,
+        dispatch_type,
+        dispatch_context,
+    )
 }
 
 pub(super) fn prefix_dispatch_message(dispatch_type: &str, message: &str) -> String {

--- a/src/server/routes/dispatches/tests.rs
+++ b/src/server/routes/dispatches/tests.rs
@@ -286,68 +286,53 @@ fn review_dispatch_uses_counter_model_channel() {
 }
 
 #[test]
-fn review_dispatch_message_includes_review_only_banner() {
+fn review_dispatch_message_includes_compact_metadata_and_issue_url() {
     let message = format_dispatch_message(
         "dispatch-1",
         "[Review R1] card-1",
         Some("https://github.com/itismyfield/AgentDesk/issues/19"),
         Some(19),
-        true,
-        Some("abc123"),
-        Some("codex"),
-        None,
         Some("review"),
         None,
     );
 
-    assert!(message.starts_with("DISPATCH:dispatch-1 [🔍 리뷰] - [Review R1] card-1"));
-    assert!(message.contains("⚠️ 검토 전용"));
-    assert!(message.contains("코드 리뷰만 수행하고 GitHub 이슈에 코멘트로 피드백해주세요."));
-    assert!(
-        message.contains(
-            "[Review R1] card-1 #19](<https://github.com/itismyfield/AgentDesk/issues/19>)"
-        )
-    );
-    // Verdict API instructions must be present for counter-model reviewers
-    assert!(message.contains("review-verdict"));
-    assert!(message.contains("VERDICT: pass|improve|reject|rework"));
+    assert!(message.starts_with(
+        "── review dispatch ──\nDISPATCH:dispatch-1 [🔍 리뷰] - #19 [Review R1] card-1"
+    ));
+    assert!(message.contains("<https://github.com/itismyfield/AgentDesk/issues/19>"));
+    assert!(message.contains(
+        "한 줄 지시: 코드 리뷰만 수행하고 상세 범위와 verdict 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
+    ));
     assert!(message.contains("dispatch-1"));
-    assert!(message.contains("abc123"));
-    // Provider must be included in the curl example
-    assert!(message.contains(r#""provider":"codex""#));
+    assert!(!message.contains("review-verdict"));
+    assert!(!message.contains("VERDICT: pass|improve|reject|rework"));
+    assert!(message.chars().count() <= 500);
 }
 
 #[test]
-fn review_dispatch_message_with_branch() {
+fn review_dispatch_message_omits_branch_and_commit_details() {
     let message = format_dispatch_message(
         "dispatch-br",
         "[Review R1] card-1",
         Some("https://github.com/itismyfield/AgentDesk/issues/19"),
         Some(19),
-        true,
-        Some("abc12345deadbeef"),
-        Some("codex"),
-        Some("wt/feature-branch"),
         Some("review"),
         None,
     );
 
-    assert!(message.contains("리뷰 대상 브랜치: `wt/feature-branch`"));
-    assert!(message.contains("commit: `abc12345`"));
-    assert!(message.contains("main 브랜치가 아닙니다"));
+    assert!(message.contains("DISPATCH:dispatch-br [🔍 리뷰] - #19 [Review R1] card-1"));
+    assert!(!message.contains("wt/feature-branch"));
+    assert!(!message.contains("abc12345deadbeef"));
+    assert!(!message.contains("main 브랜치가 아닙니다"));
 }
 
 #[test]
-fn review_dispatch_message_includes_quality_checklist_and_improve_guidance() {
+fn review_dispatch_message_omits_verbose_quality_checklist_and_guidance() {
     let message = format_dispatch_message(
         "dispatch-quality",
         "[Review R1] card-1",
         Some("https://github.com/itismyfield/AgentDesk/issues/19"),
         Some(19),
-        true,
-        Some("abc12345deadbeef"),
-        Some("codex"),
-        Some("wt/feature-branch"),
         Some("review"),
         Some(
             &serde_json::json!({
@@ -359,33 +344,29 @@ fn review_dispatch_message_includes_quality_checklist_and_improve_guidance() {
         ),
     );
 
-    assert!(message.contains(crate::dispatch::REVIEW_QUALITY_SCOPE_REMINDER));
-    assert!(message.contains("race condition / 동시성 이슈"));
-    assert!(message.contains("에러 핸들링 누락"));
-    assert!(message.contains("리소스 정리 누락"));
-    assert!(message.contains(crate::dispatch::REVIEW_VERDICT_IMPROVE_GUIDANCE));
+    assert!(message.contains("DISPATCH:dispatch-quality [🔍 리뷰] - #19 [Review R1] card-1"));
+    assert!(!message.contains(crate::dispatch::REVIEW_QUALITY_SCOPE_REMINDER));
+    assert!(!message.contains("race condition / 동시성 이슈"));
+    assert!(!message.contains("에러 핸들링 누락"));
+    assert!(!message.contains("리소스 정리 누락"));
+    assert!(!message.contains(crate::dispatch::REVIEW_VERDICT_IMPROVE_GUIDANCE));
 }
 
 #[test]
-fn review_dispatch_message_with_merge_base_diff_instructions() {
+fn review_dispatch_message_omits_merge_base_diff_instructions() {
     let message = format_dispatch_message(
         "dispatch-merge-base",
         "[Review R1] card-1",
         Some("https://github.com/itismyfield/AgentDesk/issues/19"),
         Some(19),
-        true,
-        Some("abc12345deadbeef0011223344556677"),
-        Some("codex"),
-        Some("wt/feature-branch"),
         Some("review"),
         Some(r#"{"merge_base":"11223344556677889900aabbccddeeff00112233"}"#),
     );
 
-    assert!(message.contains("merge-base(main, `wt/feature-branch`)"));
-    assert!(message.contains("11223344556677889900aabbccddeeff00112233"));
-    assert!(message.contains(
-        "git diff 11223344556677889900aabbccddeeff00112233..abc12345deadbeef0011223344556677"
-    ));
+    assert!(message.contains("DISPATCH:dispatch-merge-base [🔍 리뷰] - #19 [Review R1] card-1"));
+    assert!(!message.contains("merge-base(main"));
+    assert!(!message.contains("11223344556677889900aabbccddeeff00112233"));
+    assert!(!message.contains("git diff"));
 }
 
 #[test]
@@ -395,31 +376,26 @@ fn review_dispatch_message_without_commit() {
         "[Review R1] card-1",
         None,
         None,
-        true,
-        None,
-        None,
-        None,
         Some("review"),
         None,
     );
 
-    assert!(message.contains("review-verdict"));
+    assert!(message.contains("DISPATCH:dispatch-no-commit [🔍 리뷰] - [Review R1] card-1"));
     assert!(message.contains("dispatch-no-commit"));
-    // No commit arg in the curl command
+    assert!(message.contains(
+        "한 줄 지시: 코드 리뷰만 수행하고 상세 범위와 verdict 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
+    ));
     assert!(!message.contains(r#""commit""#));
+    assert!(!message.contains(r#""provider""#));
 }
 
 #[test]
-fn review_dispatch_message_includes_noop_verification_guidance() {
+fn review_dispatch_message_omits_noop_verification_details() {
     let message = format_dispatch_message(
         "dispatch-noop-review",
         "[Review R1] card-655",
         Some("https://github.com/itismyfield/AgentDesk/issues/655"),
         Some(655),
-        true,
-        Some("abc12345deadbeef"),
-        Some("codex"),
-        Some("wt/655-noop"),
         Some("review"),
         Some(
             &serde_json::json!({
@@ -433,23 +409,21 @@ fn review_dispatch_message_includes_noop_verification_guidance() {
         ),
     );
 
-    assert!(message.contains("리뷰 모드: `noop_verification`"));
-    assert!(message.contains("GitHub 이슈 본문과 현재 코드 상태를 대조"));
-    assert!(message.contains("noop 사유: OUTCOME: noop\\nfeature already exists"));
-    assert!(message.contains("이슈가 요구한 변경이 현재 코드에 이미 존재하는지"));
+    assert!(
+        message.contains("DISPATCH:dispatch-noop-review [🔍 리뷰] - #655 [Review R1] card-655")
+    );
+    assert!(!message.contains("Review Mode"));
+    assert!(!message.contains("noop_verification"));
+    assert!(!message.contains("OUTCOME: noop"));
     assert!(!message.contains("git diff"));
 }
 
 #[test]
-fn review_dispatch_message_includes_manual_lookup_warning_when_branch_is_missing() {
+fn review_dispatch_message_omits_manual_lookup_warning_when_branch_is_missing() {
     let message = format_dispatch_message(
         "dispatch-manual-review-target",
         "[Review R1] card-1",
         None,
-        None,
-        true,
-        None,
-        Some("codex"),
         None,
         Some("review"),
         Some(
@@ -461,7 +435,10 @@ fn review_dispatch_message_includes_manual_lookup_warning_when_branch_is_missing
         ),
     );
 
-    assert!(message.contains("리뷰 타겟 안내: 브랜치 정보 없음"));
+    assert!(message.contains(
+        "한 줄 지시: 코드 리뷰만 수행하고 상세 범위와 verdict 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
+    ));
+    assert!(!message.contains("브랜치 정보 없음"));
     assert!(!message.contains("리뷰 대상 브랜치:"));
 }
 
@@ -472,69 +449,61 @@ fn implementation_dispatch_message_stays_compact() {
         "Implement feature",
         Some("https://github.com/itismyfield/AgentDesk/issues/24"),
         Some(24),
-        false,
-        None,
-        None,
-        None,
         Some("implementation"),
         None,
     );
 
-    assert!(message.contains("[📋 구현]"));
-    assert!(
-        message.contains(
-            "[Implement feature #24](<https://github.com/itismyfield/AgentDesk/issues/24>)"
-        )
-    );
-    assert!(message.contains("`OUTCOME: noop`"));
+    assert!(message.starts_with(
+        "── implementation dispatch ──\nDISPATCH:dispatch-2 [📋 구현] - #24 Implement feature"
+    ));
+    assert!(message.contains("<https://github.com/itismyfield/AgentDesk/issues/24>"));
+    assert!(message.contains(
+        "한 줄 지시: 이 이슈를 구현하고 상세 요구사항과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
+    ));
+    assert!(!message.contains("`OUTCOME: noop`"));
     assert!(!message.contains("검토 전용"));
-    // Implementation dispatches should NOT include verdict instructions
     assert!(!message.contains("review-verdict"));
+    assert!(message.chars().count() <= 500);
 }
 
 #[test]
-fn e2e_test_dispatch_message_uses_general_completion_contract() {
+fn e2e_test_dispatch_message_stays_compact() {
     let message = format_dispatch_message(
         "dispatch-e2e",
         "Run regression",
         Some("https://github.com/itismyfield/AgentDesk/issues/340"),
         Some(340),
-        true,
-        None,
-        Some("codex"),
-        None,
         Some("e2e-test"),
         None,
     );
 
     assert!(message.contains("[🧪 E2E 테스트]"));
-    assert!(message.contains("PATCH"));
-    assert!(message.contains("/api/dispatches/dispatch-e2e"));
-    assert!(!message.contains("검토 전용"));
+    assert!(message.contains(
+        "한 줄 지시: 검증만 수행하고 상세 기준과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
+    ));
+    assert!(!message.contains("/api/dispatches/"));
     assert!(!message.contains("review-verdict"));
-    assert!(!message.contains("VERDICT: pass|improve|reject|rework"));
+    assert!(message.chars().count() <= 500);
 }
 
 #[test]
-fn consultation_dispatch_message_uses_general_completion_contract() {
+fn consultation_dispatch_message_stays_compact() {
     let message = format_dispatch_message(
         "dispatch-consult",
         "Need investigation",
         Some("https://github.com/itismyfield/AgentDesk/issues/256"),
         Some(256),
-        true,
-        None,
-        Some("codex"),
-        None,
         Some("consultation"),
         None,
     );
 
-    assert!(message.contains("PATCH"));
-    assert!(message.contains("/api/dispatches/dispatch-consult"));
-    assert!(!message.contains("검토 전용"));
+    assert!(message.contains("[💬 상담]"));
+    assert!(message.contains(
+        "한 줄 지시: 필요한 조사/판단만 수행하고 상세 기준과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
+    ));
+    assert!(!message.contains("/api/dispatches/"));
     assert!(!message.contains("review-verdict"));
-    assert!(!message.contains("VERDICT: pass|improve|reject|rework"));
+    assert!(message.chars().count() <= 500);
 }
 
 #[test]
@@ -544,20 +513,16 @@ fn review_decision_primary_message_includes_action_instructions() {
         "[리뷰 검토] Test Card",
         Some("https://github.com/itismyfield/AgentDesk/issues/249"),
         Some(249),
-        false,
-        None,
-        None,
-        None,
         Some("review-decision"),
         Some(r#"{"verdict":"rework"}"#),
     );
 
     assert!(message.contains("[⚖️ 리뷰 검토]"));
-    assert!(message.contains("카운터모델 리뷰 결과: **rework**"));
-    assert!(message.contains("review-decision API에 `accept` 호출"));
-    assert!(message.contains("review-decision API에 `dispute` 호출"));
-    assert!(message.contains("review-decision API에 `dismiss` 호출"));
-    assert!(message.contains("#249](<https://github.com/itismyfield/AgentDesk/issues/249>)"));
+    assert!(message.contains(
+        "한 줄 지시: GitHub 리뷰 피드백을 확인하고 accept/dispute/dismiss 중 하나를 제출하세요."
+    ));
+    assert!(message.contains("<https://github.com/itismyfield/AgentDesk/issues/249>"));
+    assert!(!message.contains("카운터모델 리뷰 결과"));
     assert!(!message.contains("review-verdict"));
 }
 

--- a/src/server/routes/dispatches/thread_reuse.rs
+++ b/src/server/routes/dispatches/thread_reuse.rs
@@ -368,10 +368,11 @@ pub(super) async fn try_reuse_thread(
     expected_parent: u64,
     desired_thread_name: &str,
     message: &str,
+    minimal_message: &str,
     dispatch_id: &str,
     card_id: &str,
     db: &crate::db::Db,
-) -> Option<bool> {
+) -> Result<Option<bool>, super::discord_delivery::DispatchMessagePostError> {
     // 1. Fetch thread info to verify it exists and belongs to the right parent channel
     let thread_info_url = format!(
         "{}/channels/{}",
@@ -383,7 +384,12 @@ pub(super) async fn try_reuse_thread(
         .header("Authorization", format!("Bot {}", token))
         .send()
         .await
-        .ok()?;
+        .map_err(|error| {
+            super::discord_delivery::DispatchMessagePostError::new(
+                super::discord_delivery::DispatchMessagePostErrorKind::Other,
+                format!("failed to inspect reusable thread {thread_id}: {error}"),
+            )
+        })?;
 
     if !resp.status().is_success() {
         tracing::info!("[dispatch] Thread {thread_id} no longer accessible, will create new");
@@ -391,10 +397,15 @@ pub(super) async fn try_reuse_thread(
         if let Ok(conn) = db.lock() {
             clear_thread_for_channel(&conn, card_id, expected_parent);
         }
-        return None;
+        return Ok(None);
     }
 
-    let body: serde_json::Value = resp.json().await.ok()?;
+    let body: serde_json::Value = resp.json().await.map_err(|error| {
+        super::discord_delivery::DispatchMessagePostError::new(
+            super::discord_delivery::DispatchMessagePostErrorKind::Other,
+            format!("failed to parse reusable thread {thread_id}: {error}"),
+        )
+    })?;
 
     // Check parent_id — only reuse threads from the same channel.
     // Each channel independently manages its own thread per card.
@@ -420,7 +431,7 @@ pub(super) async fn try_reuse_thread(
             )
             .ok();
         }
-        return None;
+        return Ok(None);
     }
 
     // Check if thread is locked — locked threads cannot be reused
@@ -435,7 +446,7 @@ pub(super) async fn try_reuse_thread(
         if let Ok(conn) = db.lock() {
             clear_thread_for_channel(&conn, card_id, expected_parent);
         }
-        return Some(false);
+        return Ok(Some(false));
     }
 
     // Unarchive if needed
@@ -458,7 +469,7 @@ pub(super) async fn try_reuse_thread(
                 tracing::warn!(
                     "[dispatch] Failed to unarchive thread {thread_id}, will create new"
                 );
-                return None;
+                return Ok(None);
             }
         }
     }
@@ -480,6 +491,7 @@ pub(super) async fn try_reuse_thread(
         discord_api_base,
         thread_id,
         message,
+        minimal_message,
     )
     .await
     {
@@ -516,14 +528,17 @@ pub(super) async fn try_reuse_thread(
                 );
             }
             tracing::info!("[dispatch] Reused thread {thread_id} for dispatch {dispatch_id}");
-            Some(true)
+            Ok(Some(true))
         }
         Err(error) => {
             tracing::warn!(
                 "[dispatch] Failed to send message to reused thread {thread_id}: {}",
                 error
             );
-            None
+            if error.is_length_error() {
+                return Err(error);
+            }
+            Ok(None)
         }
     }
 }
@@ -721,31 +736,39 @@ pub async fn get_card_thread(
         Option<String>,
         Option<String>,
         Option<String>,
+        Option<String>,
         String,
         Option<String>,
     )> = conn
         .query_row(
-            "SELECT kc.id, kc.title, kc.github_issue_url, kc.github_issue_number, \
-                    kc.description, kc.deferred_dod_json, \
-                    kc.active_thread_id, td.dispatch_type, \
-                    td.to_agent_id, \
-                    td.context \
+            "SELECT kc.id AS card_id, \
+                    kc.title AS card_title, \
+                    kc.github_issue_url AS github_issue_url, \
+                    kc.github_issue_number AS github_issue_number, \
+                    kc.description AS issue_body, \
+                    kc.deferred_dod_json AS deferred_dod_json, \
+                    kc.active_thread_id AS legacy_thread_id, \
+                    td.dispatch_type AS dispatch_type, \
+                    td.title AS dispatch_title, \
+                    td.to_agent_id AS dispatch_agent_id, \
+                    td.context AS dispatch_context \
              FROM task_dispatches td \
              JOIN kanban_cards kc ON kc.id = td.kanban_card_id \
              WHERE td.id = ?1",
             [dispatch_id],
             |row| {
                 Ok((
-                    row.get(0)?,
-                    row.get(1)?,
-                    row.get(2)?,
-                    row.get(3)?,
-                    row.get(4)?,
-                    row.get(5)?,
-                    row.get(6)?,
-                    row.get(7)?,
-                    row.get(8)?,
-                    row.get(9)?,
+                    row.get("card_id")?,
+                    row.get("card_title")?,
+                    row.get("github_issue_url")?,
+                    row.get("github_issue_number")?,
+                    row.get("issue_body")?,
+                    row.get("deferred_dod_json")?,
+                    row.get("legacy_thread_id")?,
+                    row.get("dispatch_type")?,
+                    row.get("dispatch_title")?,
+                    row.get("dispatch_agent_id")?,
+                    row.get("dispatch_context")?,
                 ))
             },
         )
@@ -761,6 +784,7 @@ pub async fn get_card_thread(
             deferred_dod_json,
             _legacy_thread_id,
             dispatch_type,
+            dispatch_title,
             to_agent_id,
             dispatch_context,
         )) => {
@@ -797,6 +821,7 @@ pub async fn get_card_thread(
                     "deferred_dod": deferred_dod,
                     "active_thread_id": thread_id,
                     "dispatch_type": dispatch_type,
+                    "dispatch_title": dispatch_title,
                     "discord_channel_id": primary_channel,
                     "discord_channel_alt": counter_model_channel,
                     "discord_channel_target": target_channel,

--- a/src/services/discord/prompt_builder.rs
+++ b/src/services/discord/prompt_builder.rs
@@ -15,6 +15,10 @@ const STALE_TOOL_RESULT_PLACEHOLDER_EXAMPLE: &str =
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct CurrentTaskContext<'a> {
+    pub(crate) dispatch_id: Option<&'a str>,
+    pub(crate) card_id: Option<&'a str>,
+    pub(crate) dispatch_title: Option<&'a str>,
+    pub(crate) dispatch_context: Option<&'a str>,
     pub(crate) card_title: Option<&'a str>,
     pub(crate) github_issue_url: Option<&'a str>,
     pub(crate) issue_body: Option<&'a str>,
@@ -94,8 +98,324 @@ fn deferred_dod_items(value: &serde_json::Value) -> Vec<DodItem> {
         .collect()
 }
 
-fn render_current_task_section(current_task: &CurrentTaskContext<'_>) -> Option<String> {
+fn parse_dispatch_context(dispatch_context: Option<&str>) -> Option<serde_json::Value> {
+    dispatch_context.and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+}
+
+fn json_string_list(value: Option<&serde_json::Value>) -> Vec<String> {
+    value
+        .and_then(|items| items.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|item| item.as_str())
+        .map(str::trim)
+        .filter(|item| !item.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn render_string_list(label: &str, items: &[String], limit: usize) -> Option<String> {
+    if items.is_empty() {
+        return None;
+    }
+    let mut lines = items
+        .iter()
+        .take(limit)
+        .map(|item| format!("- {item}"))
+        .collect::<Vec<_>>();
+    if items.len() > limit {
+        lines.push(format!("- ... {} more", items.len() - limit));
+    }
+    Some(format!("{label}:\n{}", lines.join("\n")))
+}
+
+fn render_dispatch_context_section(
+    dispatch_type: Option<&str>,
+    dispatch_context: Option<&str>,
+) -> Option<String> {
+    let context = parse_dispatch_context(dispatch_context)?;
     let mut sections = Vec::new();
+
+    if let Some(value) = context.get("resumed_from").and_then(|value| value.as_str()) {
+        sections.push(format!("Dispatch Trigger: resume from {value}"));
+    } else if context
+        .get("retry")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false)
+    {
+        sections.push("Dispatch Trigger: retry".to_string());
+    } else if context
+        .get("redispatch")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false)
+    {
+        sections.push("Dispatch Trigger: redispatch".to_string());
+    } else if context
+        .get("auto_queue")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false)
+    {
+        sections.push("Dispatch Trigger: auto-queue".to_string());
+    }
+
+    if context
+        .get("force_new_session")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false)
+    {
+        sections.push("Session Strategy: force a fresh session before working".to_string());
+    }
+
+    let review_branch = context
+        .get("branch")
+        .and_then(|value| value.as_str())
+        .or_else(|| {
+            context
+                .get("worktree_branch")
+                .and_then(|value| value.as_str())
+        })
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let reviewed_commit = context
+        .get("reviewed_commit")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let merge_base = context
+        .get("merge_base")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    if dispatch_type == Some("review")
+        || review_branch.is_some()
+        || reviewed_commit.is_some()
+        || context.get("review_mode").is_some()
+    {
+        if let Some(review_mode) = context.get("review_mode").and_then(|value| value.as_str()) {
+            sections.push(format!("Review Mode: {review_mode}"));
+        }
+        if let Some(branch) = review_branch {
+            sections.push(format!("Review Branch: {branch}"));
+        }
+        if let Some(commit) = reviewed_commit {
+            sections.push(format!("Reviewed Commit: {commit}"));
+        }
+        if let Some(base) = merge_base {
+            sections.push(format!("Merge Base: {base}"));
+        }
+        if let Some(warning) = context
+            .get("review_target_warning")
+            .and_then(|value| value.as_str())
+        {
+            sections.push(format!("Review Target Warning: {warning}"));
+        }
+        if let Some(noop_reason) = context
+            .get("noop_reason")
+            .and_then(|value| value.as_str())
+            .or_else(|| {
+                context
+                    .get("noop_result")
+                    .and_then(|value| value.get("notes"))
+                    .and_then(|value| value.as_str())
+            })
+        {
+            sections.push(format!("Noop Reason:\n{noop_reason}"));
+        }
+        if let Some(scope_reminder) = context
+            .get("review_quality_scope_reminder")
+            .and_then(|value| value.as_str())
+        {
+            sections.push(format!("Review Scope Reminder: {scope_reminder}"));
+        }
+        let quality_checklist = json_string_list(context.get("review_quality_checklist"));
+        if let Some(rendered) =
+            render_string_list("Review Quality Checklist", &quality_checklist, 8)
+        {
+            sections.push(rendered);
+        }
+        if let Some(guidance) = context
+            .get("review_verdict_guidance")
+            .and_then(|value| value.as_str())
+        {
+            sections.push(format!("Review Verdict Guidance: {guidance}"));
+        }
+    }
+
+    if let Some(verdict) = context.get("verdict").and_then(|value| value.as_str()) {
+        sections.push(format!("Review Verdict: {verdict}"));
+    }
+
+    if let Some(phase_gate) = context
+        .get("phase_gate")
+        .and_then(|value| value.as_object())
+    {
+        if let Some(run_id) = phase_gate.get("run_id").and_then(|value| value.as_str()) {
+            sections.push(format!("Phase Gate Run: {run_id}"));
+        }
+        if let Some(batch_phase) = phase_gate
+            .get("batch_phase")
+            .and_then(|value| value.as_i64())
+        {
+            sections.push(format!("Phase Gate Batch Phase: {batch_phase}"));
+        }
+        if let Some(next_phase) = phase_gate
+            .get("next_phase")
+            .and_then(|value| value.as_i64())
+        {
+            sections.push(format!("Phase Gate Next Phase: {next_phase}"));
+        }
+        if phase_gate
+            .get("final_phase")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false)
+        {
+            sections.push("Phase Gate Final Phase: true".to_string());
+        }
+        if let Some(pass_verdict) = phase_gate
+            .get("pass_verdict")
+            .and_then(|value| value.as_str())
+        {
+            sections.push(format!("Phase Gate Pass Verdict: {pass_verdict}"));
+        }
+        let checks = json_string_list(phase_gate.get("checks"));
+        if let Some(rendered) = render_string_list("Phase Gate Checks", &checks, 8) {
+            sections.push(rendered);
+        }
+        let work_items = json_string_list(phase_gate.get("work_items"));
+        if let Some(rendered) = render_string_list("Phase Gate Work Items", &work_items, 8) {
+            sections.push(rendered);
+        }
+        let issues = phase_gate
+            .get("issue_numbers")
+            .and_then(|value| value.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|item| item.as_i64())
+            .map(|issue| format!("#{issue}"))
+            .collect::<Vec<_>>();
+        if !issues.is_empty() {
+            sections.push(format!("Phase Gate Issues: {}", issues.join(", ")));
+        }
+    }
+
+    if let Some(ci_recovery) = context
+        .get("ci_recovery")
+        .and_then(|value| value.as_object())
+    {
+        if let Some(job_name) = ci_recovery.get("job_name").and_then(|value| value.as_str()) {
+            sections.push(format!("CI Recovery Job: {job_name}"));
+        }
+        if let Some(reason) = ci_recovery.get("reason").and_then(|value| value.as_str()) {
+            sections.push(format!("CI Failure Reason: {reason}"));
+        }
+        if let Some(run_url) = ci_recovery.get("run_url").and_then(|value| value.as_str()) {
+            sections.push(format!("CI Run URL: {run_url}"));
+        }
+        if let Some(log_excerpt) = ci_recovery
+            .get("log_excerpt")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            sections.push(format!("CI Log Excerpt:\n{log_excerpt}"));
+        }
+    }
+
+    (!sections.is_empty()).then(|| format!("Dispatch Context:\n{}", sections.join("\n\n")))
+}
+
+fn render_dispatch_contract(
+    dispatch_type: Option<&str>,
+    current_task: &CurrentTaskContext<'_>,
+) -> Option<String> {
+    match dispatch_type {
+        Some("implementation") | Some("rework") => Some(
+            "[Dispatch Contract]\n\
+             - 구현이 불필요하고 현재 worktree에 tracked 변경이 전혀 없을 때만 응답 첫 줄에 `OUTCOME: noop`를 적고 근거를 설명한다.\n\
+             - tracked 변경이 남아 있으면 noop를 사용하지 않는다.\n\
+             - 커밋 메시지에 반드시 GitHub 이슈 번호를 포함한다.\n\
+             - 변경 후 관련 검증을 직접 실행하고 결과를 최종 응답에 포함한다."
+                .to_string(),
+        ),
+        Some("review") => {
+            let dispatch_id = current_task.dispatch_id?;
+            Some(format!(
+                "[Dispatch Contract]\n\
+                 - 응답 첫 줄에 반드시 `VERDICT: pass|improve|reject|rework` 중 하나를 적는다.\n\
+                 - 리뷰 결과는 GitHub issue 코멘트로 남긴다.\n\
+                 - verdict 제출 경로: `POST /api/review-verdict` (`dispatch_id={dispatch_id}`).\n\
+                 - `improve`/`reject`/`rework`면 구체적 `notes`와 `items`를 포함한다."
+            ))
+        }
+        Some("review-decision") => {
+            let card_id = current_task.card_id?;
+            Some(format!(
+                "[Dispatch Contract]\n\
+                 - 카운터 리뷰 피드백을 읽고 `accept|dispute|dismiss` 중 하나를 고른다.\n\
+                 - decision 제출 경로: `POST /api/review-decision` (`card_id={card_id}`).\n\
+                 - accept는 피드백 수용 후 rework, dispute는 반박 후 재리뷰, dismiss는 무시 후 done 경로다."
+            ))
+        }
+        Some("e2e-test") | Some("consultation") | Some("phase-gate") | Some("pm-decision") => {
+            let dispatch_id = current_task.dispatch_id?;
+            Some(format!(
+                "[Dispatch Contract]\n\
+                 - 완료 시 `PATCH /api/dispatches/{dispatch_id}`로 dispatch를 종료한다.\n\
+                 - 예시 body: `{{\"status\":\"completed\",\"result\":{{\"summary\":\"결과 요약\"}}}}`\n\
+                 - review verdict API는 사용하지 않는다."
+            ))
+        }
+        _ => Some(
+            current_task.dispatch_id.map_or_else(
+                || {
+                    "[Dispatch Contract]\n\
+                     - 작업 완료 후 해당 dispatch의 종료 경로를 확인하고 상태를 마무리한다.\n\
+                     - review verdict/review-decision 전용 dispatch가 아니라면 일반 dispatch 종료 경로를 사용한다."
+                        .to_string()
+                },
+                |dispatch_id| {
+                    format!(
+                        "[Dispatch Contract]\n\
+                         - 완료 시 `PATCH /api/dispatches/{dispatch_id}`로 dispatch를 종료한다.\n\
+                         - 예시 body: `{{\"status\":\"completed\",\"result\":{{\"summary\":\"결과 요약\"}}}}`\n\
+                         - 별도 review verdict/review-decision 규칙이 없으면 이 경로를 기본으로 사용한다."
+                    )
+                },
+            ),
+        ),
+    }
+}
+
+fn render_current_task_section(
+    current_task: &CurrentTaskContext<'_>,
+    dispatch_type: Option<&str>,
+) -> Option<String> {
+    let mut sections = Vec::new();
+
+    if let Some(dispatch_id) = current_task
+        .dispatch_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        sections.push(format!("Dispatch ID: {dispatch_id}"));
+    }
+    if let Some(card_id) = current_task
+        .card_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        sections.push(format!("Card ID: {card_id}"));
+    }
+
+    let card_title = current_task
+        .card_title
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let dispatch_title = current_task
+        .dispatch_title
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
 
     if let Some(title) = current_task
         .card_title
@@ -103,6 +423,9 @@ fn render_current_task_section(current_task: &CurrentTaskContext<'_>) -> Option<
         .filter(|s| !s.is_empty())
     {
         sections.push(format!("Title: {title}"));
+    }
+    if let Some(dispatch_title) = dispatch_title.filter(|title| Some(*title) != card_title) {
+        sections.push(format!("Dispatch Brief:\n{dispatch_title}"));
     }
     if let Some(url) = current_task
         .github_issue_url
@@ -128,6 +451,16 @@ fn render_current_task_section(current_task: &CurrentTaskContext<'_>) -> Option<
 
     if let Some(dod_items) = dod_items {
         sections.push(format!("DoD:\n{}", render_dod_markdown(&dod_items)));
+    }
+
+    if let Some(dispatch_context_section) =
+        render_dispatch_context_section(dispatch_type, current_task.dispatch_context)
+    {
+        sections.push(dispatch_context_section);
+    }
+
+    if let Some(dispatch_contract) = render_dispatch_contract(dispatch_type, current_task) {
+        sections.push(dispatch_contract);
     }
 
     (!sections.is_empty()).then(|| format!("[Current Task]\n{}", sections.join("\n\n")))
@@ -409,7 +742,9 @@ pub(super) fn build_system_prompt(
              If the latest user message asks for an exact literal output, return exactly that literal output and nothing else.",
         );
     }
-    if let Some(current_task_section) = current_task.and_then(render_current_task_section) {
+    if let Some(current_task_section) =
+        current_task.and_then(|task| render_current_task_section(task, dispatch_type))
+    {
         system_prompt_owned.push_str("\n\n");
         system_prompt_owned.push_str(&current_task_section);
     }
@@ -894,6 +1229,10 @@ mod tests {
             "verified": ["ship tests"]
         });
         let current_task = CurrentTaskContext {
+            dispatch_id: Some("dispatch-570"),
+            card_id: Some("card-570"),
+            dispatch_title: Some("[Rework] fix: prompt context"),
+            dispatch_context: None,
             card_title: Some("fix: prompt context"),
             github_issue_url: Some("https://github.com/itismyfield/AgentDesk/issues/570"),
             issue_body: Some("## 배경\n\ncompact에서 사라짐\n\n## DoD\n- [ ] old item"),
@@ -919,14 +1258,70 @@ mod tests {
         let queued_index = prompt.find("[Queued Turn Rules]").unwrap();
         let task_index = prompt.find("[Current Task]").unwrap();
         assert!(task_index > queued_index);
+        assert!(prompt.contains("Dispatch ID: dispatch-570"));
+        assert!(prompt.contains("Card ID: card-570"));
+        assert!(prompt.contains("Dispatch Brief:\n[Rework] fix: prompt context"));
         assert!(prompt.contains("GitHub URL: https://github.com/itismyfield/AgentDesk/issues/570"));
         assert!(prompt.contains("Title: fix: prompt context"));
         assert!(prompt.contains("- [x] ship tests"));
+        assert!(prompt.contains("`OUTCOME: noop`"));
         assert!(!prompt.contains("## DoD"));
     }
 
     #[test]
-    fn test_build_system_prompt_omits_current_task_when_context_empty() {
+    fn test_build_system_prompt_renders_dispatch_context_and_completion_contract() {
+        let dispatch_context = serde_json::json!({
+            "review_mode": "noop_verification",
+            "branch": "wt/671-dispatch",
+            "reviewed_commit": "abc12345deadbeef",
+            "merge_base": "1122334455667788",
+            "noop_reason": "feature already exists",
+            "review_quality_checklist": ["edge case", "error handling"],
+            "review_verdict_guidance": "quality issue가 보이면 improve",
+            "ci_recovery": {
+                "job_name": "dashboard-build",
+                "reason": "Code job failed: dashboard-build",
+                "run_url": "https://github.com/example/actions/runs/1"
+            }
+        });
+        let dispatch_context_raw = dispatch_context.to_string();
+        let current_task = CurrentTaskContext {
+            dispatch_id: Some("dispatch-review-671"),
+            card_id: Some("card-671"),
+            dispatch_title: Some("[Review R2] card-671"),
+            dispatch_context: Some(&dispatch_context_raw),
+            card_title: Some("fix: dispatch message"),
+            github_issue_url: None,
+            issue_body: None,
+            deferred_dod: None,
+        };
+        let prompt = build_system_prompt(
+            "ctx",
+            "/tmp",
+            ChannelId::new(1),
+            "tok",
+            "",
+            true,
+            None,
+            false,
+            DispatchProfile::ReviewLite,
+            Some("review"),
+            Some(&current_task),
+            None,
+            None,
+            None,
+        );
+
+        assert!(prompt.contains("Review Mode: noop_verification"));
+        assert!(prompt.contains("Review Branch: wt/671-dispatch"));
+        assert!(prompt.contains("Reviewed Commit: abc12345deadbeef"));
+        assert!(prompt.contains("CI Recovery Job: dashboard-build"));
+        assert!(prompt.contains("`POST /api/review-verdict` (`dispatch_id=dispatch-review-671`)"));
+        assert!(prompt.contains("Review Quality Checklist"));
+    }
+
+    #[test]
+    fn test_build_system_prompt_keeps_dispatch_contract_when_context_is_otherwise_empty() {
         let current_task = CurrentTaskContext::default();
         let prompt = build_system_prompt(
             "ctx",
@@ -945,7 +1340,39 @@ mod tests {
             None,
         );
 
-        assert!(!prompt.contains("[Current Task]"));
+        assert!(prompt.contains("[Current Task]"));
+        assert!(prompt.contains("[Dispatch Contract]"));
+        assert!(prompt.contains("`OUTCOME: noop`"));
+        assert!(!prompt.contains("Dispatch ID:"));
+        assert!(!prompt.contains("GitHub URL:"));
+    }
+
+    #[test]
+    fn test_build_system_prompt_uses_default_dispatch_contract_for_unknown_dispatch_type() {
+        let current_task = CurrentTaskContext {
+            dispatch_id: Some("dispatch-generic-1"),
+            ..CurrentTaskContext::default()
+        };
+        let prompt = build_system_prompt(
+            "ctx",
+            "/tmp",
+            ChannelId::new(1),
+            "tok",
+            "",
+            true,
+            None,
+            false,
+            DispatchProfile::Full,
+            None,
+            Some(&current_task),
+            None,
+            None,
+            None,
+        );
+
+        assert!(prompt.contains("[Dispatch Contract]"));
+        assert!(prompt.contains("PATCH /api/dispatches/dispatch-generic-1"));
+        assert!(prompt.contains("별도 review verdict/review-decision 규칙이 없으면"));
     }
 
     #[test]

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -1052,6 +1052,10 @@ pub(in crate::services::discord) async fn handle_text_message(
     let narrate_progress = settings::load_narrate_progress(shared.db.as_ref());
     let current_task_context = active_dispatch_info.as_ref().map(|info| {
         super::super::prompt_builder::CurrentTaskContext {
+            dispatch_id: active_dispatch_id_for_prompt.as_deref(),
+            card_id: info.card_id.as_deref(),
+            dispatch_title: info.dispatch_title.as_deref(),
+            dispatch_context: info.context.as_deref(),
             card_title: info.card_title.as_deref(),
             github_issue_url: info.github_issue_url.as_deref(),
             issue_body: info.issue_body.as_deref(),

--- a/src/services/discord/router/thread_binding.rs
+++ b/src/services/discord/router/thread_binding.rs
@@ -6,6 +6,7 @@ use serenity::ChannelId;
 pub(super) struct DispatchInfo {
     pub(super) card_id: Option<String>,
     pub(super) card_title: Option<String>,
+    pub(super) dispatch_title: Option<String>,
     pub(super) github_issue_url: Option<String>,
     pub(super) github_issue_number: Option<i64>,
     pub(super) issue_body: Option<String>,
@@ -35,6 +36,10 @@ pub(super) async fn lookup_dispatch_info(api_port: u16, dispatch_id: &str) -> Op
             .map(|s| s.to_string()),
         card_title: body
             .get("card_title")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        dispatch_title: body
+            .get("dispatch_title")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string()),
         github_issue_url: body


### PR DESCRIPTION
Automated fallback PR after direct merge into `main` hit a cherry-pick conflict.

Card: `93217d32-0ba0-4ce5-8ed8-fb0c7a7513c2`
Issue: https://github.com/itismyfield/AgentDesk/issues/671

Conflict summary:
The previous cherry-pick is now empty, possibly due to conflict resolution. If you wish to commit it anyway, use: git commit --allow-empty Otherwise, please use 'git cherry-pick...