### PR TITLE
#680 fix: direct-first 자동머지가 병렬 디스패치 시 push 경합으로 실패

### DIFF
--- a/policies/merge-automation.js
+++ b/policies/merge-automation.js
@@ -334,8 +334,79 @@ function maybeResetDirectMergeHead(mainWorktreePath, originalHead) {
   return "main worktree reset to pre-merge HEAD";
 }
 
+function maybeAbortDirectMergeRebase(mainWorktreePath) {
+  var output = agentdesk.exec("git", ["-C", mainWorktreePath, "rebase", "--abort"]);
+  if (typeof output === "string" && output.indexOf("ERROR") === 0) {
+    var err = output.replace(/^ERROR:\s*/, "").trim();
+    return err
+      ? "rebase abort failed: " + err
+      : "rebase abort failed";
+  }
+  return "rebase aborted";
+}
+
 function isCherryPickConflict(errorText) {
   return /CONFLICT|could not apply|after resolving the conflicts|merge conflict/i.test(String(errorText || ""));
+}
+
+function isPushRejected(errorText) {
+  return /rejected|fetch first|non-fast-forward|failed to push some refs/i.test(String(errorText || ""));
+}
+
+function retryDirectMergePush(mainWorktreePath, mainBranch) {
+  var maxRetries = 3;
+  var attempts = 0;
+  var lastError = null;
+
+  while (attempts <= maxRetries) {
+    var pushOutput = agentdesk.exec("git", ["-C", mainWorktreePath, "push", "origin", mainBranch]);
+    if (!(typeof pushOutput === "string" && pushOutput.indexOf("ERROR") === 0)) {
+      return {
+        ok: true,
+        attempts: attempts + 1
+      };
+    }
+
+    lastError = pushOutput.replace(/^ERROR:\s*/, "");
+    if (!isPushRejected(lastError) || attempts === maxRetries) {
+      return {
+        ok: false,
+        conflict: false,
+        error: lastError,
+        attempts: attempts + 1
+      };
+    }
+
+    attempts += 1;
+
+    var fetchOutput = agentdesk.exec("git", ["-C", mainWorktreePath, "fetch", "origin", mainBranch]);
+    if (typeof fetchOutput === "string" && fetchOutput.indexOf("ERROR") === 0) {
+      return {
+        ok: false,
+        conflict: false,
+        error: fetchOutput.replace(/^ERROR:\s*/, ""),
+        attempts: attempts
+      };
+    }
+
+    var rebaseOutput = agentdesk.exec("git", ["-C", mainWorktreePath, "rebase", "origin/" + mainBranch]);
+    if (typeof rebaseOutput === "string" && rebaseOutput.indexOf("ERROR") === 0) {
+      return {
+        ok: false,
+        conflict: isCherryPickConflict(rebaseOutput),
+        error: rebaseOutput.replace(/^ERROR:\s*/, ""),
+        attempts: attempts,
+        rebase_failed: true
+      };
+    }
+  }
+
+  return {
+    ok: false,
+    conflict: false,
+    error: lastError || "direct merge push failed",
+    attempts: attempts
+  };
 }
 
 function parsePrNumberFromOutput(output) {
@@ -481,20 +552,23 @@ function attemptDirectMerge(candidate) {
     };
   }
 
-  try {
-    execGitOrThrow(["-C", mainWorktree.path, "push", "origin", mainBranch]);
-  } catch (e) {
+  var pushResult = retryDirectMergePush(mainWorktree.path, mainBranch);
+  if (!pushResult.ok) {
     var cleanupNotes = [];
+    if (pushResult.rebase_failed) {
+      var abortStatus = maybeAbortDirectMergeRebase(mainWorktree.path);
+      if (abortStatus) cleanupNotes.push(abortStatus);
+    }
     var resetStatus = maybeResetDirectMergeHead(mainWorktree.path, originalHead);
     if (resetStatus) cleanupNotes.push(resetStatus);
     var stashStatus = maybeRestoreMergeStash(mainWorktree.path, stashCreated);
     if (stashStatus) cleanupNotes.push(stashStatus);
     return {
       ok: false,
-      conflict: false,
+      conflict: !!pushResult.conflict,
       branch: candidate.branch,
       main_branch: mainBranch,
-      error: String(e),
+      error: pushResult.error,
       stash: cleanupNotes.length > 0 ? cleanupNotes.join("; ") : null
     };
   }

--- a/policies/merge-automation.js
+++ b/policies/merge-automation.js
@@ -322,6 +322,18 @@ function maybeRestoreMergeStash(mainWorktreePath, stashCreated) {
   return "stash restored";
 }
 
+function maybeResetDirectMergeHead(mainWorktreePath, originalHead) {
+  if (!originalHead) return null;
+  var output = agentdesk.exec("git", ["-C", mainWorktreePath, "reset", "--hard", originalHead]);
+  if (typeof output === "string" && output.indexOf("ERROR") === 0) {
+    var err = output.replace(/^ERROR:\s*/, "").trim();
+    return err
+      ? "reset to original main HEAD failed: " + err
+      : "reset to original main HEAD failed";
+  }
+  return "main worktree reset to pre-merge HEAD";
+}
+
 function isCherryPickConflict(errorText) {
   return /CONFLICT|could not apply|after resolving the conflicts|merge conflict/i.test(String(errorText || ""));
 }
@@ -417,6 +429,7 @@ function attemptDirectMerge(candidate) {
   var mainWorktree = resolveMainWorktree(repoDir);
   var mainBranch = mainWorktree.branch || "main";
   var branchRange = mainBranch + ".." + candidate.branch;
+  var originalHead = execGitOrThrow(["-C", mainWorktree.path, "rev-parse", "HEAD"]).trim();
   var commitsOutput = execGitOrThrow([
     "-C",
     mainWorktree.path,
@@ -471,13 +484,18 @@ function attemptDirectMerge(candidate) {
   try {
     execGitOrThrow(["-C", mainWorktree.path, "push", "origin", mainBranch]);
   } catch (e) {
+    var cleanupNotes = [];
+    var resetStatus = maybeResetDirectMergeHead(mainWorktree.path, originalHead);
+    if (resetStatus) cleanupNotes.push(resetStatus);
+    var stashStatus = maybeRestoreMergeStash(mainWorktree.path, stashCreated);
+    if (stashStatus) cleanupNotes.push(stashStatus);
     return {
       ok: false,
       conflict: false,
       branch: candidate.branch,
       main_branch: mainBranch,
       error: String(e),
-      stash: maybeRestoreMergeStash(mainWorktree.path, stashCreated)
+      stash: cleanupNotes.length > 0 ? cleanupNotes.join("; ") : null
     };
   }
 
@@ -504,10 +522,12 @@ function buildTrackedPrBody(card, options) {
 
   if (mode === "pr-always") {
     lines.push("Automated PR created because `merge_strategy_mode` is set to `pr-always`.");
-  } else {
+  } else if (mergeResult && mergeResult.conflict) {
     lines.push(
       "Automated fallback PR after direct merge into `" + mainBranch + "` hit a cherry-pick conflict."
     );
+  } else {
+    lines.push("Automated fallback PR after direct merge into `" + mainBranch + "` could not be completed safely.");
   }
   lines.push("");
   lines.push("Card: `" + card.id + "`");
@@ -519,10 +539,71 @@ function buildTrackedPrBody(card, options) {
     lines.push("Merge path: wait for CI + Codex review approval before auto-merge.");
   } else if (mergeResult && mergeResult.error) {
     lines.push("");
-    lines.push("Conflict summary:");
+    lines.push(mergeResult.conflict ? "Conflict summary:" : "Direct-merge failure summary:");
     lines.push(summarizeInlineText(mergeResult.error));
   }
   return lines.join("\n");
+}
+
+function resolveTrackedPrBaseBranch(candidate, fallbackBranch) {
+  try {
+    return resolveMainBranchForCandidate(candidate);
+  } catch (e) {
+    return fallbackBranch || "main";
+  }
+}
+
+function markTrackedPrWaitingForCi(cardId, candidate, pr, headSha) {
+  upsertPrTracking(
+    cardId,
+    candidate.repo_id,
+    candidate.worktree_path,
+    pr.branch || candidate.branch,
+    pr.number,
+    headSha,
+    "wait-ci",
+    null
+  );
+  agentdesk.db.execute(
+    "UPDATE kanban_cards SET blocked_reason = 'ci:waiting' WHERE id = ?",
+    [cardId]
+  );
+}
+
+function tryCreateTrackedPr(cardId, tracking, candidate, options) {
+  try {
+    var trackedPr = createOrLocateTrackedPr(candidate, options || {});
+    if (!trackedPr || !trackedPr.number) {
+      throw new Error("no open PR found for branch " + candidate.branch);
+    }
+
+    var trackedHeadSha = getCurrentPrHeadSha(trackedPr.number, candidate.repo_id) || trackedPr.sha || candidate.head_sha;
+    markTrackedPrWaitingForCi(cardId, candidate, trackedPr, trackedHeadSha);
+    return {
+      ok: true,
+      pr: trackedPr,
+      head_sha: trackedHeadSha
+    };
+  } catch (e) {
+    upsertPrTracking(
+      cardId,
+      candidate.repo_id,
+      candidate.worktree_path,
+      candidate.branch,
+      tracking ? tracking.pr_number : null,
+      candidate.head_sha,
+      "create-pr",
+      String(e)
+    );
+    agentdesk.db.execute(
+      "UPDATE kanban_cards SET blocked_reason = 'pr:create_failed' WHERE id = ?",
+      [cardId]
+    );
+    return {
+      ok: false,
+      error: String(e)
+    };
+  }
 }
 
 function createOrLocateTrackedPr(candidate, options) {
@@ -572,47 +653,14 @@ function tryDirectMergeOrTrackPr(cardId, tracking) {
   persistTrackedMergeStrategyMode(cardId, mergeMode);
 
   if (mergeMode === "pr-always") {
-    try {
-      var trackedPr = createOrLocateTrackedPr(candidate, {
-        mode: mergeMode,
-        main_branch: resolveMainBranchForCandidate(candidate)
-      });
-      if (!trackedPr || !trackedPr.number) {
-        throw new Error("no open PR found for branch " + candidate.branch);
-      }
-
-      var trackedHeadSha = getCurrentPrHeadSha(trackedPr.number, candidate.repo_id) || trackedPr.sha || candidate.head_sha;
-      upsertPrTracking(
-        cardId,
-        candidate.repo_id,
-        candidate.worktree_path,
-        trackedPr.branch || candidate.branch,
-        trackedPr.number,
-        trackedHeadSha,
-        "wait-ci",
-        null
-      );
-      agentdesk.db.execute(
-        "UPDATE kanban_cards SET blocked_reason = 'ci:waiting' WHERE id = ?",
-        [cardId]
-      );
-      agentdesk.log.info("[merge] Card " + cardId + " is in pr-always mode — PR #" + trackedPr.number + " is now tracked for CI");
-    } catch (e) {
-      agentdesk.log.warn("[merge] PR creation failed for pr-always card " + cardId + ": " + e);
-      upsertPrTracking(
-        cardId,
-        candidate.repo_id,
-        candidate.worktree_path,
-        candidate.branch,
-        tracking ? tracking.pr_number : null,
-        candidate.head_sha,
-        "create-pr",
-        String(e)
-      );
-      agentdesk.db.execute(
-        "UPDATE kanban_cards SET blocked_reason = 'pr:create_failed' WHERE id = ?",
-        [cardId]
-      );
+    var trackedPrResult = tryCreateTrackedPr(cardId, tracking, candidate, {
+      mode: mergeMode,
+      main_branch: resolveTrackedPrBaseBranch(candidate)
+    });
+    if (trackedPrResult.ok) {
+      agentdesk.log.info("[merge] Card " + cardId + " is in pr-always mode — PR #" + trackedPrResult.pr.number + " is now tracked for CI");
+    } else {
+      agentdesk.log.warn("[merge] PR creation failed for pr-always card " + cardId + ": " + trackedPrResult.error);
     }
     return;
   }
@@ -622,16 +670,18 @@ function tryDirectMergeOrTrackPr(cardId, tracking) {
     mergeResult = attemptDirectMerge(candidate);
   } catch (e) {
     agentdesk.log.warn("[merge] Direct merge setup failed for card " + cardId + ": " + e);
-    upsertPrTracking(
-      cardId,
-      candidate.repo_id,
-      candidate.worktree_path,
-      candidate.branch,
-      tracking ? tracking.pr_number : null,
-      candidate.head_sha,
-      tracking && tracking.state ? tracking.state : "create-pr",
-      String(e)
-    );
+    var setupFallback = tryCreateTrackedPr(cardId, tracking, candidate, {
+      mode: mergeMode,
+      main_branch: resolveTrackedPrBaseBranch(candidate),
+      merge_result: { error: String(e), conflict: false }
+    });
+    if (setupFallback.ok) {
+      agentdesk.log.info(
+        "[merge] Card " + cardId + " fell back to PR #" + setupFallback.pr.number + " after direct-merge setup failure"
+      );
+    } else {
+      agentdesk.log.warn("[merge] Direct merge setup fallback PR creation failed for card " + cardId + ": " + setupFallback.error);
+    }
     return;
   }
 
@@ -655,63 +705,18 @@ function tryDirectMergeOrTrackPr(cardId, tracking) {
     return;
   }
 
-  if (!mergeResult.conflict) {
-    agentdesk.log.warn("[merge] Direct merge failed for card " + cardId + ": " + mergeResult.error);
-    upsertPrTracking(
-      cardId,
-      candidate.repo_id,
-      candidate.worktree_path,
-      candidate.branch,
-      tracking ? tracking.pr_number : null,
-      candidate.head_sha,
-      tracking && tracking.state ? tracking.state : "create-pr",
-      mergeResult.error
+  agentdesk.log.warn("[merge] Direct merge failed for card " + cardId + ": " + mergeResult.error);
+  var fallbackPr = tryCreateTrackedPr(cardId, tracking, candidate, {
+    mode: mergeMode,
+    main_branch: mergeResult.main_branch || resolveTrackedPrBaseBranch(candidate),
+    merge_result: mergeResult
+  });
+  if (fallbackPr.ok) {
+    agentdesk.log.info(
+      "[merge] Card " + cardId + " fell back to PR #" + fallbackPr.pr.number + " after direct-merge failure"
     );
-    return;
-  }
-
-  try {
-    var pr = createOrLocateTrackedPr(candidate, {
-      mode: mergeMode,
-      main_branch: mergeResult.main_branch,
-      merge_result: mergeResult
-    });
-    if (!pr || !pr.number) {
-      throw new Error("no open PR found after conflict fallback for branch " + candidate.branch);
-    }
-
-    var headSha = getCurrentPrHeadSha(pr.number, candidate.repo_id) || pr.sha || candidate.head_sha;
-    upsertPrTracking(
-      cardId,
-      candidate.repo_id,
-      candidate.worktree_path,
-      pr.branch || candidate.branch,
-      pr.number,
-      headSha,
-      "wait-ci",
-      null
-    );
-    agentdesk.db.execute(
-      "UPDATE kanban_cards SET blocked_reason = 'ci:waiting' WHERE id = ?",
-      [cardId]
-    );
-    agentdesk.log.info("[merge] Card " + cardId + " hit direct-merge conflict — PR #" + pr.number + " is now tracked for CI");
-  } catch (e) {
-    agentdesk.log.warn("[merge] Conflict fallback PR creation failed for card " + cardId + ": " + e);
-    upsertPrTracking(
-      cardId,
-      candidate.repo_id,
-      candidate.worktree_path,
-      candidate.branch,
-      tracking ? tracking.pr_number : null,
-      candidate.head_sha,
-      "create-pr",
-      String(e)
-    );
-    agentdesk.db.execute(
-      "UPDATE kanban_cards SET blocked_reason = 'pr:create_failed' WHERE id = ?",
-      [cardId]
-    );
+  } else {
+    agentdesk.log.warn("[merge] Direct merge fallback PR creation failed for card " + cardId + ": " + fallbackPr.error);
   }
 }
 
@@ -1566,10 +1571,7 @@ function processManualMergeRequests() {
 }
 
 function processTrackedMergeQueue() {
-  var tracked = listTrackedPrRows(
-    "state = 'merge' AND pr_number IS NOT NULL AND repo_id IS NOT NULL",
-    []
-  );
+  var tracked = listTrackedPrRows("state IN ('create-pr', 'merge')", []);
   for (var i = 0; i < tracked.length; i++) {
     var row = tracked[i];
     var card = loadCardContext(row.card_id);
@@ -1577,6 +1579,27 @@ function processTrackedMergeQueue() {
     var cfg = agentdesk.pipeline.resolveForCard(card.id);
     if (!agentdesk.pipeline.isTerminal(card.status, cfg)) continue;
 
+    if (row.state === "create-pr") {
+      var candidate = resolveTerminalMergeCandidate(row.card_id, row);
+      if (!candidate) continue;
+      var trackedMode = resolveTrackedMergeStrategyMode(row.card_id);
+      persistTrackedMergeStrategyMode(row.card_id, trackedMode);
+      var retriedPr = tryCreateTrackedPr(row.card_id, row, candidate, {
+        mode: trackedMode,
+        main_branch: resolveTrackedPrBaseBranch(candidate),
+        merge_result: row.last_error ? { error: row.last_error, conflict: false } : null
+      });
+      if (retriedPr.ok) {
+        agentdesk.log.info(
+          "[merge] Card " + row.card_id + " retried create-pr — PR #" + retriedPr.pr.number + " is now tracked for CI"
+        );
+      } else {
+        agentdesk.log.warn("[merge] Create-pr retry failed for card " + row.card_id + ": " + retriedPr.error);
+      }
+      continue;
+    }
+
+    if (!row.pr_number || !row.repo_id) continue;
     var author = getPrAuthor(row.pr_number, row.repo_id);
     if (!isAllowedAuthor(author)) continue;
     enableAutoMerge(row.pr_number, row.repo_id, row.card_id);

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -6004,6 +6004,150 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn scenario_211_terminal_direct_merge_push_rejected_falls_back_to_pr_and_resets_main() {
+        let (repo, remote, gh) = setup_test_repo_with_origin_and_mock_gh(&[
+            MockGhReply {
+                key: "pr:create",
+                contains: Some("--head wt/card-211-push-rejected"),
+                stdout: "https://github.com/test/repo/pull/904",
+            },
+            MockGhReply {
+                key: "pr:view",
+                contains: Some("--json headRefOid"),
+                stdout: "feature-sha-211-push-rejected",
+            },
+        ]);
+        let worktrees_dir = repo.path().join("worktrees");
+        fs::create_dir_all(&worktrees_dir).unwrap();
+        run_git(repo.path(), &["branch", "wt/card-211-push-rejected"]);
+
+        let worktree_path = worktrees_dir.join("card-211-push-rejected");
+        run_git(
+            repo.path(),
+            &[
+                "worktree",
+                "add",
+                worktree_path.to_str().unwrap(),
+                "wt/card-211-push-rejected",
+            ],
+        );
+        fs::write(worktree_path.join("feature.txt"), "feature\n").unwrap();
+        run_git(worktree_path.as_path(), &["add", "feature.txt"]);
+        run_git(
+            worktree_path.as_path(),
+            &["commit", "-m", "feat: push rejected fallback #211"],
+        );
+        let feature_commit = run_git_output(worktree_path.as_path(), &["rev-parse", "HEAD"]);
+
+        let remote_clone = tempfile::tempdir().unwrap();
+        let clone_output = Command::new("git")
+            .args([
+                "clone",
+                remote.path().to_str().unwrap(),
+                remote_clone.path().to_str().unwrap(),
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            clone_output.status.success(),
+            "git clone failed: {}",
+            String::from_utf8_lossy(&clone_output.stderr)
+        );
+        run_git(
+            remote_clone.path(),
+            &["config", "user.email", "test@test.com"],
+        );
+        run_git(remote_clone.path(), &["config", "user.name", "Remote Test"]);
+        fs::write(remote_clone.path().join("remote-only.txt"), "remote\n").unwrap();
+        run_git(remote_clone.path(), &["add", "remote-only.txt"]);
+        run_git(
+            remote_clone.path(),
+            &["commit", "-m", "remote main advance"],
+        );
+        run_git(remote_clone.path(), &["push", "origin", "main"]);
+
+        let db = test_db();
+        let engine = test_engine(&db);
+        seed_agent(&db);
+        seed_repo(&db, "test/repo");
+        seed_card_with_repo(
+            &db,
+            "card-211-push-rejected",
+            "done",
+            "test/repo",
+            217,
+            None,
+        );
+        set_kv(&db, "merge_automation_enabled", "true");
+        seed_completed_work_dispatch_target(
+            &db,
+            "impl-211-push-rejected",
+            "card-211-push-rejected",
+            "implementation",
+            worktree_path.to_str().unwrap(),
+            "wt/card-211-push-rejected",
+            &feature_commit,
+        );
+
+        engine
+            .try_fire_hook_by_name(
+                "OnCardTerminal",
+                serde_json::json!({"card_id": "card-211-push-rejected"}),
+            )
+            .unwrap();
+        kanban::drain_hook_side_effects(&db, &engine);
+
+        assert_eq!(get_card_status(&db, "card-211-push-rejected"), "done");
+        assert_eq!(
+            pr_tracking_state(&db, "card-211-push-rejected").as_deref(),
+            Some("wait-ci")
+        );
+        assert_eq!(
+            pr_tracking_pr_number(&db, "card-211-push-rejected"),
+            Some(904)
+        );
+
+        let conn = db.lock().unwrap();
+        let blocked_reason: Option<String> = conn
+            .query_row(
+                "SELECT blocked_reason FROM kanban_cards WHERE id = 'card-211-push-rejected'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(blocked_reason.as_deref(), Some("ci:waiting"));
+        drop(conn);
+
+        run_git(repo.path(), &["fetch", "origin", "main"]);
+        let merged = Command::new("git")
+            .args([
+                "merge-base",
+                "--is-ancestor",
+                &feature_commit,
+                "origin/main",
+            ])
+            .current_dir(repo.path())
+            .status()
+            .unwrap();
+        assert!(
+            !merged.success(),
+            "push-rejected fallback must leave the feature commit out of origin/main"
+        );
+        assert_eq!(
+            run_git_output(repo.path(), &["rev-list", "--count", "origin/main..main"]),
+            "0",
+            "local main must be reset after a rejected direct push"
+        );
+
+        let log = gh_log(&gh._gh);
+        assert!(
+            log.contains("pr create --repo test/repo --base main --head wt/card-211-push-rejected"),
+            "push-rejected direct merge must fall back to PR creation"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn scenario_211_pr_always_creates_pr_without_direct_merge_and_waits_for_codex_approval() {
         let (repo, _remote, gh) = setup_test_repo_with_origin_and_mock_gh(&[
             MockGhReply {
@@ -6359,6 +6503,119 @@ mod tests {
         assert!(
             log.contains("pr create --repo test/repo --base main --head wt/card-211-conflict"),
             "conflict fallback must create a PR for the tracked branch"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scenario_211_tick5min_retries_create_pr_rows_until_wait_ci() {
+        let (repo, _remote, gh) = setup_test_repo_with_origin_and_mock_gh(&[
+            MockGhReply {
+                key: "pr:create",
+                contains: Some("--head wt/card-211-create-pr-retry"),
+                stdout: "https://github.com/test/repo/pull/905",
+            },
+            MockGhReply {
+                key: "pr:view",
+                contains: Some("--json headRefOid"),
+                stdout: "feature-sha-211-create-pr-retry",
+            },
+        ]);
+        let worktrees_dir = repo.path().join("worktrees");
+        fs::create_dir_all(&worktrees_dir).unwrap();
+        run_git(repo.path(), &["branch", "wt/card-211-create-pr-retry"]);
+
+        let worktree_path = worktrees_dir.join("card-211-create-pr-retry");
+        run_git(
+            repo.path(),
+            &[
+                "worktree",
+                "add",
+                worktree_path.to_str().unwrap(),
+                "wt/card-211-create-pr-retry",
+            ],
+        );
+        fs::write(worktree_path.join("feature.txt"), "retry\n").unwrap();
+        run_git(worktree_path.as_path(), &["add", "feature.txt"]);
+        run_git(
+            worktree_path.as_path(),
+            &["commit", "-m", "feat: create-pr retry path #211"],
+        );
+        let feature_commit = run_git_output(worktree_path.as_path(), &["rev-parse", "HEAD"]);
+
+        let db = test_db();
+        let engine = test_engine(&db);
+        seed_agent(&db);
+        seed_repo(&db, "test/repo");
+        seed_card_with_repo(
+            &db,
+            "card-211-create-pr-retry",
+            "done",
+            "test/repo",
+            218,
+            None,
+        );
+        set_kv(&db, "merge_automation_enabled", "true");
+        seed_completed_work_dispatch_target(
+            &db,
+            "impl-211-create-pr-retry",
+            "card-211-create-pr-retry",
+            "implementation",
+            worktree_path.to_str().unwrap(),
+            "wt/card-211-create-pr-retry",
+            &feature_commit,
+        );
+        seed_pr_tracking(
+            &db,
+            "card-211-create-pr-retry",
+            "test/repo",
+            Some(worktree_path.to_str().unwrap()),
+            "wt/card-211-create-pr-retry",
+            None,
+            Some(feature_commit.as_str()),
+            "create-pr",
+        );
+        {
+            let conn = db.lock().unwrap();
+            conn.execute(
+                "UPDATE kanban_cards SET blocked_reason = 'pr:create_failed' WHERE id = 'card-211-create-pr-retry'",
+                [],
+            )
+            .unwrap();
+        }
+
+        engine
+            .try_fire_hook_by_name("OnTick5min", serde_json::json!({}))
+            .unwrap();
+        kanban::drain_hook_side_effects(&db, &engine);
+
+        assert_eq!(get_card_status(&db, "card-211-create-pr-retry"), "done");
+        assert_eq!(
+            pr_tracking_state(&db, "card-211-create-pr-retry").as_deref(),
+            Some("wait-ci")
+        );
+        assert_eq!(
+            pr_tracking_pr_number(&db, "card-211-create-pr-retry"),
+            Some(905)
+        );
+
+        let conn = db.lock().unwrap();
+        let blocked_reason: Option<String> = conn
+            .query_row(
+                "SELECT blocked_reason FROM kanban_cards WHERE id = 'card-211-create-pr-retry'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(blocked_reason.as_deref(), Some("ci:waiting"));
+        drop(conn);
+
+        let log = gh_log(&gh._gh);
+        assert!(
+            log.contains(
+                "pr create --repo test/repo --base main --head wt/card-211-create-pr-retry"
+            ),
+            "create-pr rows must be retried on OnTick5min"
         );
     }
 

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -6004,19 +6004,8 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn scenario_211_terminal_direct_merge_push_rejected_falls_back_to_pr_and_resets_main() {
-        let (repo, remote, gh) = setup_test_repo_with_origin_and_mock_gh(&[
-            MockGhReply {
-                key: "pr:create",
-                contains: Some("--head wt/card-211-push-rejected"),
-                stdout: "https://github.com/test/repo/pull/904",
-            },
-            MockGhReply {
-                key: "pr:view",
-                contains: Some("--json headRefOid"),
-                stdout: "feature-sha-211-push-rejected",
-            },
-        ]);
+    fn scenario_211_terminal_direct_merge_push_rejected_rebases_and_retries_push() {
+        let (repo, remote, gh) = setup_test_repo_with_origin_and_mock_gh(&[]);
         let worktrees_dir = repo.path().join("worktrees");
         fs::create_dir_all(&worktrees_dir).unwrap();
         run_git(repo.path(), &["branch", "wt/card-211-push-rejected"]);
@@ -6100,12 +6089,9 @@ mod tests {
         assert_eq!(get_card_status(&db, "card-211-push-rejected"), "done");
         assert_eq!(
             pr_tracking_state(&db, "card-211-push-rejected").as_deref(),
-            Some("wait-ci")
+            Some("closed")
         );
-        assert_eq!(
-            pr_tracking_pr_number(&db, "card-211-push-rejected"),
-            Some(904)
-        );
+        assert_eq!(pr_tracking_pr_number(&db, "card-211-push-rejected"), None);
 
         let conn = db.lock().unwrap();
         let blocked_reason: Option<String> = conn
@@ -6115,34 +6101,35 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(blocked_reason.as_deref(), Some("ci:waiting"));
+        assert_eq!(blocked_reason, None);
         drop(conn);
 
         run_git(repo.path(), &["fetch", "origin", "main"]);
-        let merged = Command::new("git")
-            .args([
-                "merge-base",
-                "--is-ancestor",
-                &feature_commit,
-                "origin/main",
-            ])
-            .current_dir(repo.path())
-            .status()
-            .unwrap();
         assert!(
-            !merged.success(),
-            "push-rejected fallback must leave the feature commit out of origin/main"
+            run_git_output(repo.path(), &["show", "origin/main:feature.txt"]) == "feature",
+            "feature commit must reach origin/main after retrying rejected pushes"
+        );
+        assert!(
+            run_git_output(repo.path(), &["show", "origin/main:remote-only.txt"]) == "remote",
+            "retry must preserve the remote main advance after rebasing"
         );
         assert_eq!(
             run_git_output(repo.path(), &["rev-list", "--count", "origin/main..main"]),
             "0",
-            "local main must be reset after a rejected direct push"
+            "local main must not diverge from origin/main after the retried push succeeds"
+        );
+        assert_eq!(
+            run_git_output(repo.path(), &["rev-list", "--count", "main..origin/main"]),
+            "0",
+            "origin/main must not diverge from local main after the retried push succeeds"
         );
 
         let log = gh_log(&gh._gh);
         assert!(
-            log.contains("pr create --repo test/repo --base main --head wt/card-211-push-rejected"),
-            "push-rejected direct merge must fall back to PR creation"
+            !log.contains(
+                "pr create --repo test/repo --base main --head wt/card-211-push-rejected"
+            ),
+            "successful rebase retries must not fall back to PR creation"
         );
     }
 
@@ -6407,6 +6394,148 @@ mod tests {
         assert!(
             log.contains("pr merge 903 --auto --squash --repo test/repo"),
             "approved pr-always cards must enable auto-merge even after the global mode toggles"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scenario_211_terminal_direct_merge_rebase_conflict_falls_back_to_pr() {
+        let (repo, remote, gh) = setup_test_repo_with_origin_and_mock_gh(&[
+            MockGhReply {
+                key: "pr:create",
+                contains: Some("--head wt/card-211-rebase-conflict"),
+                stdout: "https://github.com/test/repo/pull/906",
+            },
+            MockGhReply {
+                key: "pr:view",
+                contains: Some("--json headRefOid"),
+                stdout: "feature-sha-211-rebase-conflict",
+            },
+        ]);
+        fs::write(repo.path().join("shared.txt"), "base\n").unwrap();
+        run_git(repo.path(), &["add", "shared.txt"]);
+        run_git(repo.path(), &["commit", "-m", "base shared file"]);
+        run_git(repo.path(), &["push", "origin", "main"]);
+
+        let worktrees_dir = repo.path().join("worktrees");
+        fs::create_dir_all(&worktrees_dir).unwrap();
+        run_git(repo.path(), &["branch", "wt/card-211-rebase-conflict"]);
+
+        let worktree_path = worktrees_dir.join("card-211-rebase-conflict");
+        run_git(
+            repo.path(),
+            &[
+                "worktree",
+                "add",
+                worktree_path.to_str().unwrap(),
+                "wt/card-211-rebase-conflict",
+            ],
+        );
+        fs::write(worktree_path.join("shared.txt"), "feature version\n").unwrap();
+        run_git(worktree_path.as_path(), &["add", "shared.txt"]);
+        run_git(
+            worktree_path.as_path(),
+            &["commit", "-m", "feature rebase conflict change #211"],
+        );
+        let feature_commit = run_git_output(worktree_path.as_path(), &["rev-parse", "HEAD"]);
+
+        let remote_clone = tempfile::tempdir().unwrap();
+        let clone_output = Command::new("git")
+            .args([
+                "clone",
+                remote.path().to_str().unwrap(),
+                remote_clone.path().to_str().unwrap(),
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            clone_output.status.success(),
+            "git clone failed: {}",
+            String::from_utf8_lossy(&clone_output.stderr)
+        );
+        run_git(
+            remote_clone.path(),
+            &["config", "user.email", "test@test.com"],
+        );
+        run_git(remote_clone.path(), &["config", "user.name", "Remote Test"]);
+        fs::write(remote_clone.path().join("shared.txt"), "main version\n").unwrap();
+        run_git(remote_clone.path(), &["add", "shared.txt"]);
+        run_git(
+            remote_clone.path(),
+            &["commit", "-m", "remote main conflicting advance"],
+        );
+        run_git(remote_clone.path(), &["push", "origin", "main"]);
+
+        let db = test_db();
+        let engine = test_engine(&db);
+        seed_agent(&db);
+        seed_repo(&db, "test/repo");
+        seed_card_with_repo(
+            &db,
+            "card-211-rebase-conflict",
+            "done",
+            "test/repo",
+            219,
+            None,
+        );
+        set_kv(&db, "merge_automation_enabled", "true");
+        seed_completed_work_dispatch_target(
+            &db,
+            "impl-211-rebase-conflict",
+            "card-211-rebase-conflict",
+            "implementation",
+            worktree_path.to_str().unwrap(),
+            "wt/card-211-rebase-conflict",
+            &feature_commit,
+        );
+
+        engine
+            .try_fire_hook_by_name(
+                "OnCardTerminal",
+                serde_json::json!({"card_id": "card-211-rebase-conflict"}),
+            )
+            .unwrap();
+        kanban::drain_hook_side_effects(&db, &engine);
+
+        assert_eq!(get_card_status(&db, "card-211-rebase-conflict"), "done");
+        assert_eq!(
+            pr_tracking_state(&db, "card-211-rebase-conflict").as_deref(),
+            Some("wait-ci")
+        );
+        assert_eq!(
+            pr_tracking_pr_number(&db, "card-211-rebase-conflict"),
+            Some(906)
+        );
+
+        let conn = db.lock().unwrap();
+        let blocked_reason: Option<String> = conn
+            .query_row(
+                "SELECT blocked_reason FROM kanban_cards WHERE id = 'card-211-rebase-conflict'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(blocked_reason.as_deref(), Some("ci:waiting"));
+        drop(conn);
+
+        run_git(repo.path(), &["fetch", "origin", "main"]);
+        assert_eq!(
+            run_git_output(repo.path(), &["show", "origin/main:shared.txt"]),
+            "main version",
+            "rebase-conflict fallback must keep origin/main on the remote-advanced contents"
+        );
+        assert_eq!(
+            run_git_output(repo.path(), &["show", "main:shared.txt"]),
+            "base",
+            "local main must reset to the pre-merge HEAD after rebase conflict fallback"
+        );
+
+        let log = gh_log(&gh._gh);
+        assert!(
+            log.contains(
+                "pr create --repo test/repo --base main --head wt/card-211-rebase-conflict"
+            ),
+            "rebase conflicts must fall back to PR creation"
         );
     }
 


### PR DESCRIPTION
Automated fallback PR after direct merge into `main` hit a cherry-pick conflict.

Card: `0df41239-ca36-4b51-97b3-2211f8e960d1`
Issue: https://github.com/itismyfield/AgentDesk/issues/680

Conflict summary:
error: could not apply b333723d... #680 retry direct-first push rejection before PR fallback hint: After resolving the conflicts, mark them with hint: "git add/rm <pathspec>", t...