### PR TITLE
#692 refactor: make review and review-decision dispatch context self-contained

### DIFF
--- a/src/dispatch/dispatch_context.rs
+++ b/src/dispatch/dispatch_context.rs
@@ -182,6 +182,58 @@ fn load_card_issue_repo(db: &Db, card_id: &str) -> Option<(Option<i64>, Option<S
     load_card_dispatch_info(db, card_id).map(|info| (info.issue_number, info.repo_id))
 }
 
+fn load_card_pr_number(db: &Db, card_id: &str) -> Option<i64> {
+    db.separate_conn().ok().and_then(|conn| {
+        conn.query_row(
+            "SELECT pr_number FROM pr_tracking WHERE card_id = ?1",
+            [card_id],
+            |row| row.get::<_, Option<i64>>(0),
+        )
+        .optional()
+        .ok()
+        .flatten()
+        .flatten()
+    })
+}
+
+pub(crate) fn inject_review_dispatch_identifiers(
+    db: &Db,
+    card_id: &str,
+    dispatch_type: &str,
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+) {
+    let snapshot = serde_json::Value::Object(obj.clone());
+    let repo = json_string_field(&snapshot, "repo")
+        .or_else(|| json_string_field(&snapshot, "target_repo"))
+        .map(str::to_string)
+        .or_else(|| resolve_card_target_repo_ref(db, card_id, Some(&snapshot)));
+    if let Some(repo) = repo {
+        obj.entry("repo".to_string()).or_insert_with(|| json!(repo));
+    }
+
+    if let Some(issue_number) = load_card_issue_repo(db, card_id).and_then(|(issue, _)| issue) {
+        obj.entry("issue_number".to_string())
+            .or_insert_with(|| json!(issue_number));
+    }
+
+    if let Some(pr_number) = load_card_pr_number(db, card_id) {
+        obj.entry("pr_number".to_string())
+            .or_insert_with(|| json!(pr_number));
+    }
+
+    match dispatch_type {
+        "review" => {
+            obj.entry("verdict_endpoint".to_string())
+                .or_insert_with(|| json!("POST /api/review-verdict"));
+        }
+        "review-decision" => {
+            obj.entry("decision_endpoint".to_string())
+                .or_insert_with(|| json!("POST /api/review-decision"));
+        }
+        _ => {}
+    }
+}
+
 fn normalize_target_repo_token(raw: &str) -> Option<String> {
     let trimmed = raw
         .trim_matches(|ch: char| matches!(ch, '`' | '"' | '\'' | '(' | ')' | '[' | ']' | '{' | '}'))
@@ -998,6 +1050,7 @@ pub(super) fn build_review_context(
 
         inject_review_merge_base_context(obj);
         inject_review_quality_context(obj);
+        inject_review_dispatch_identifiers(db, kanban_card_id, "review", obj);
 
         if !obj.contains_key("from_provider") || !obj.contains_key("target_provider") {
             if let Ok(conn) = db.separate_conn() {
@@ -1140,6 +1193,15 @@ mod tests {
                 ?1, 'Test Card', ?2, ?3, datetime('now'), datetime('now')
              )",
             rusqlite::params![card_id, status, issue_number],
+        )
+        .unwrap();
+    }
+
+    fn set_card_repo_id(db: &Db, card_id: &str, repo_id: &str) {
+        let conn = db.separate_conn().unwrap();
+        conn.execute(
+            "UPDATE kanban_cards SET repo_id = ?1 WHERE id = ?2",
+            rusqlite::params![repo_id, card_id],
         )
         .unwrap();
     }
@@ -1305,5 +1367,51 @@ mod tests {
             refreshed.is_none(),
             "refresh must report failure when neither worktree nor repo dir has the commit"
         );
+    }
+
+    #[test]
+    fn review_context_injects_review_identifiers() {
+        let db = test_db();
+        seed_card(&db, "card-review-identifiers", 692, "review");
+
+        let (repo, _repo_override) = setup_test_repo();
+        let repo_dir = repo.path().to_str().unwrap();
+        let reviewed_commit = git_commit(repo_dir, "fix: review identifiers (#692)");
+        set_card_repo_id(&db, "card-review-identifiers", repo_dir);
+
+        let conn = db.separate_conn().unwrap();
+        conn.execute(
+            "INSERT INTO pr_tracking (
+                card_id, repo_id, worktree_path, branch, pr_number, head_sha, state, created_at, updated_at
+             ) VALUES (
+                'card-review-identifiers', ?1, ?2, 'wt/692-review', 901, ?3, 'review',
+                datetime('now'), datetime('now')
+             )",
+            rusqlite::params![repo_dir, repo_dir, reviewed_commit],
+        )
+        .unwrap();
+        drop(conn);
+
+        let context = build_review_context(
+            &db,
+            "card-review-identifiers",
+            "agent-1",
+            &json!({
+                "worktree_path": repo_dir,
+                "branch": "wt/692-review",
+                "reviewed_commit": reviewed_commit,
+            }),
+        )
+        .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&context).unwrap();
+
+        assert_eq!(
+            canonicalize_path(parsed["repo"].as_str().unwrap()),
+            canonicalize_path(repo_dir)
+        );
+        assert_eq!(parsed["issue_number"], 692);
+        assert_eq!(parsed["pr_number"], 901);
+        assert_eq!(parsed["reviewed_commit"], reviewed_commit);
+        assert_eq!(parsed["verdict_endpoint"], "POST /api/review-verdict");
     }
 }

--- a/src/dispatch/dispatch_create.rs
+++ b/src/dispatch/dispatch_create.rs
@@ -8,7 +8,8 @@ use crate::engine::PolicyEngine;
 use super::dispatch_channel::{dispatch_uses_alt_channel, resolve_dispatch_channel_id};
 use super::dispatch_context::{
     build_review_context, dispatch_context_with_session_strategy, dispatch_context_worktree_target,
-    resolve_card_target_repo_ref, resolve_card_worktree, resolve_parent_dispatch_context,
+    inject_review_dispatch_identifiers, resolve_card_target_repo_ref, resolve_card_worktree,
+    resolve_parent_dispatch_context,
 };
 use super::dispatch_status::{
     ensure_dispatch_notify_outbox_on_conn, record_dispatch_status_event_on_conn,
@@ -269,6 +270,13 @@ fn create_dispatch_core_internal(
                 );
                 base = serde_json::to_string(&serde_json::Value::Object(obj)).unwrap_or(base);
             }
+        }
+        if dispatch_type == "review-decision"
+            && let Ok(mut obj) =
+                serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&base)
+        {
+            inject_review_dispatch_identifiers(db, kanban_card_id, dispatch_type, &mut obj);
+            base = serde_json::to_string(&serde_json::Value::Object(obj)).unwrap_or(base);
         }
         base
     };

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -17,7 +17,7 @@ use dispatch_channel::provider_from_channel_suffix;
 pub(crate) use dispatch_context::{
     REVIEW_QUALITY_CHECKLIST, REVIEW_QUALITY_SCOPE_REMINDER, REVIEW_VERDICT_IMPROVE_GUIDANCE,
     commit_belongs_to_card_issue, dispatch_type_force_new_session_default,
-    dispatch_type_uses_thread_routing, resolve_card_worktree,
+    dispatch_type_uses_thread_routing, inject_review_dispatch_identifiers, resolve_card_worktree,
     validate_dispatch_completion_evidence,
 };
 #[cfg(test)]

--- a/src/server/routes/dispatches/discord_delivery.rs
+++ b/src/server/routes/dispatches/discord_delivery.rs
@@ -1,5 +1,6 @@
 use super::outbox::{
     build_minimal_dispatch_message, format_dispatch_message, prefix_dispatch_message,
+    review_submission_hint,
 };
 use super::resolve_channel_alias;
 use super::thread_reuse::{
@@ -2045,6 +2046,9 @@ async fn send_review_result_to_primary_with_context_and_transport<T: DispatchTra
         .ok()
         .flatten()
     };
+    let review_context_json = review_dispatch_context
+        .as_deref()
+        .and_then(|ctx| serde_json::from_str::<serde_json::Value>(ctx).ok());
 
     // For improve/rework/reject: create a review-decision dispatch via the
     // authoritative path and let the outbox worker deliver the message.
@@ -2074,9 +2078,6 @@ async fn send_review_result_to_primary_with_context_and_transport<T: DispatchTra
             }
         }
 
-        let review_context_json = review_dispatch_context
-            .as_deref()
-            .and_then(|ctx| serde_json::from_str::<serde_json::Value>(ctx).ok());
         let mut decision_context = serde_json::Map::new();
         decision_context.insert("verdict".to_string(), serde_json::json!(verdict));
         if let Some(provider) = review_context_json
@@ -2092,6 +2093,16 @@ async fn send_review_result_to_primary_with_context_and_transport<T: DispatchTra
             .and_then(|value| value.as_str())
         {
             decision_context.insert("target_provider".to_string(), serde_json::json!(provider));
+        }
+        if let Some(reviewed_commit) = review_context_json
+            .as_ref()
+            .and_then(|ctx| ctx.get("reviewed_commit"))
+            .and_then(|value| value.as_str())
+        {
+            decision_context.insert(
+                "reviewed_commit".to_string(),
+                serde_json::json!(reviewed_commit),
+            );
         }
 
         return match crate::dispatch::create_dispatch_core(
@@ -2162,6 +2173,16 @@ async fn send_review_result_to_primary_with_context_and_transport<T: DispatchTra
         )
     } else {
         let url_line = issue_url.map(|u| format!("\n{u}")).unwrap_or_default();
+        let review_locator = review_context_json
+            .as_ref()
+            .and_then(|ctx| super::outbox::review_target_hint(None, ctx))
+            .map(|value| format!("\n대상: {value}"))
+            .unwrap_or_default();
+        let submission_hint = review_context_json
+            .as_ref()
+            .and_then(|ctx| review_submission_hint(Some("review"), review_dispatch_id, ctx))
+            .map(|value| format!("\n누락된 verdict 제출 경로 참고: {value}"))
+            .unwrap_or_default();
         (
             ReviewFollowupKind::Unknown,
             prefix_dispatch_message(
@@ -2170,7 +2191,7 @@ async fn send_review_result_to_primary_with_context_and_transport<T: DispatchTra
                     "⚠️ [리뷰 verdict 미제출] {title}\n\
                      ⛔ 코드 리뷰 금지 — 이것은 리뷰 결과 확인 요청입니다\n\
                      카운터모델이 verdict를 제출하지 않고 세션이 종료됐습니다.\n\
-                     GitHub 이슈 코멘트를 확인하고 리뷰 내용이 있으면 반영해주세요.{url_line}"
+                     GitHub 이슈 코멘트를 확인하고 리뷰 내용이 있으면 반영해주세요.{review_locator}{submission_hint}{url_line}"
                 ),
             ),
         )

--- a/src/server/routes/dispatches/outbox.rs
+++ b/src/server/routes/dispatches/outbox.rs
@@ -967,35 +967,145 @@ fn dispatch_reason_suffix(context_json: &serde_json::Value) -> String {
         .unwrap_or_default()
 }
 
-fn dispatch_instruction_line(dispatch_type: Option<&str>) -> &'static str {
+fn trim_context_string<'a>(context_json: &'a serde_json::Value, key: &str) -> Option<&'a str> {
+    context_json
+        .get(key)
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+pub(super) fn review_target_hint(
+    issue_number: Option<i64>,
+    context_json: &serde_json::Value,
+) -> Option<String> {
+    let mut parts = Vec::new();
+
+    if let Some(repo) = trim_context_string(context_json, "repo")
+        .or_else(|| trim_context_string(context_json, "target_repo"))
+    {
+        parts.push(format!("repo={repo}"));
+    }
+    if let Some(issue_number) = context_json
+        .get("issue_number")
+        .and_then(|value| value.as_i64())
+        .or(issue_number)
+    {
+        parts.push(format!("issue=#{issue_number}"));
+    }
+    if let Some(pr_number) = context_json
+        .get("pr_number")
+        .and_then(|value| value.as_i64())
+    {
+        parts.push(format!("pr=#{pr_number}"));
+    }
+    if let Some(commit) = trim_context_string(context_json, "reviewed_commit") {
+        parts.push(format!("commit={}", truncate_chars(commit, 12)));
+    }
+
+    (!parts.is_empty()).then(|| parts.join(", "))
+}
+
+pub(super) fn review_submission_hint(
+    dispatch_type: Option<&str>,
+    dispatch_id: &str,
+    context_json: &serde_json::Value,
+) -> Option<String> {
     match dispatch_type {
-        Some("review") => {
-            "한 줄 지시: 코드 리뷰만 수행하고 상세 범위와 verdict 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
-        }
-        Some("review-decision") => {
-            "한 줄 지시: GitHub 리뷰 피드백을 확인하고 accept/dispute/dismiss 중 하나를 제출하세요."
-        }
-        Some("implementation") => {
-            "한 줄 지시: 이 이슈를 구현하고 상세 요구사항과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
-        }
-        Some("rework") => {
-            "한 줄 지시: 기존 결과를 수정하고 상세 요구사항과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
-        }
-        Some("e2e-test") => {
-            "한 줄 지시: 검증만 수행하고 상세 기준과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
-        }
-        Some("consultation") => {
-            "한 줄 지시: 필요한 조사/판단만 수행하고 상세 기준과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
-        }
-        Some("phase-gate") => {
-            "한 줄 지시: phase gate 판정만 수행하고 체크 항목과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
-        }
-        _ => "한 줄 지시: 상세 요구사항은 시스템 프롬프트의 [Current Task]를 따르세요.",
+        Some("review") => Some(format!(
+            "제출: `{}` (`dispatch_id={dispatch_id}`)",
+            trim_context_string(context_json, "verdict_endpoint")
+                .unwrap_or("POST /api/review-verdict")
+        )),
+        Some("review-decision") => Some(format!(
+            "제출: `{}`",
+            trim_context_string(context_json, "decision_endpoint")
+                .unwrap_or("POST /api/review-decision")
+        )),
+        _ => None,
     }
 }
 
-fn minimal_dispatch_instruction_line() -> &'static str {
-    "상세 요구사항과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
+fn dispatch_instruction_line(
+    dispatch_type: Option<&str>,
+    dispatch_id: &str,
+    issue_number: Option<i64>,
+    context_json: &serde_json::Value,
+) -> String {
+    match dispatch_type {
+        Some("review") => {
+            let mut line =
+                "한 줄 지시: 코드 리뷰만 수행하고 상세 범위와 verdict 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
+                    .to_string();
+            if let Some(target) = review_target_hint(issue_number, context_json) {
+                line.push_str(&format!(" 대상: {target}."));
+            }
+            if let Some(submission) = review_submission_hint(dispatch_type, dispatch_id, context_json)
+            {
+                line.push_str(&format!(" {submission}."));
+            }
+            line
+        }
+        Some("review-decision") => {
+            let mut line =
+                "한 줄 지시: GitHub 리뷰 피드백을 확인하고 accept/dispute/dismiss 중 하나를 제출하세요."
+                    .to_string();
+            if let Some(target) = review_target_hint(issue_number, context_json) {
+                line.push_str(&format!(" 대상: {target}."));
+            }
+            if let Some(submission) = review_submission_hint(dispatch_type, dispatch_id, context_json)
+            {
+                line.push_str(&format!(" {submission}."));
+            }
+            line
+        }
+        Some("implementation") => {
+            "한 줄 지시: 이 이슈를 구현하고 상세 요구사항과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
+                .to_string()
+        }
+        Some("rework") => {
+            "한 줄 지시: 기존 결과를 수정하고 상세 요구사항과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
+                .to_string()
+        }
+        Some("e2e-test") => {
+            "한 줄 지시: 검증만 수행하고 상세 기준과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
+                .to_string()
+        }
+        Some("consultation") => {
+            "한 줄 지시: 필요한 조사/판단만 수행하고 상세 기준과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
+                .to_string()
+        }
+        Some("phase-gate") => {
+            "한 줄 지시: phase gate 판정만 수행하고 체크 항목과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
+                .to_string()
+        }
+        _ => "한 줄 지시: 상세 요구사항은 시스템 프롬프트의 [Current Task]를 따르세요."
+            .to_string(),
+    }
+}
+
+fn minimal_dispatch_instruction_line(
+    dispatch_type: Option<&str>,
+    dispatch_id: &str,
+    issue_number: Option<i64>,
+    context_json: &serde_json::Value,
+) -> String {
+    match dispatch_type {
+        Some("review") | Some("review-decision") => {
+            let mut line =
+                "상세 요구사항은 시스템 프롬프트의 [Current Task]를 따르세요.".to_string();
+            if let Some(target) = review_target_hint(issue_number, context_json) {
+                line.push_str(&format!(" 대상: {target}."));
+            }
+            if let Some(submission) =
+                review_submission_hint(dispatch_type, dispatch_id, context_json)
+            {
+                line.push_str(&format!(" {submission}."));
+            }
+            line
+        }
+        _ => "상세 요구사항과 완료 규칙은 시스템 프롬프트의 [Current Task]를 따르세요.".to_string(),
+    }
 }
 
 fn render_dispatch_message(
@@ -1050,7 +1160,7 @@ pub(super) fn build_minimal_dispatch_message(
         &context_json,
         DISPATCH_TITLE_MINIMAL_LIMIT,
         false,
-        minimal_dispatch_instruction_line(),
+        &minimal_dispatch_instruction_line(dispatch_type, dispatch_id, issue_number, &context_json),
     );
     truncate_chars(&message, DISPATCH_MESSAGE_HARD_LIMIT)
 }
@@ -1076,7 +1186,7 @@ pub(super) fn format_dispatch_message(
         &context_json,
         DISPATCH_TITLE_PRIMARY_LIMIT,
         true,
-        dispatch_instruction_line(dispatch_type),
+        &dispatch_instruction_line(dispatch_type, dispatch_id, issue_number, &context_json),
     );
     if primary.chars().count() <= DISPATCH_MESSAGE_TARGET_LEN {
         return primary;
@@ -1091,7 +1201,7 @@ pub(super) fn format_dispatch_message(
         &context_json,
         DISPATCH_TITLE_COMPACT_LIMIT,
         true,
-        minimal_dispatch_instruction_line(),
+        &minimal_dispatch_instruction_line(dispatch_type, dispatch_id, issue_number, &context_json),
     );
     if compact.chars().count() <= DISPATCH_MESSAGE_HARD_LIMIT {
         return compact;

--- a/src/server/routes/dispatches/tests.rs
+++ b/src/server/routes/dispatches/tests.rs
@@ -42,6 +42,7 @@ struct MockDispatchSummaryState {
 struct MockDispatchTransportState {
     dispatch_calls: usize,
     review_followup_kinds: Vec<ReviewFollowupKind>,
+    review_followup_messages: Vec<String>,
 }
 
 #[derive(Clone, Default)]
@@ -85,13 +86,15 @@ impl DispatchTransport for MockDispatchTransport {
         _db: Db,
         _card_id: String,
         _channel_id_num: u64,
-        _message: String,
+        message: String,
         kind: ReviewFollowupKind,
     ) -> impl std::future::Future<Output = Result<(), String>> + Send {
         let state = self.state.clone();
         let error = self.review_followup_error.clone();
         async move {
-            state.lock().unwrap().review_followup_kinds.push(kind);
+            let mut guard = state.lock().unwrap();
+            guard.review_followup_kinds.push(kind);
+            guard.review_followup_messages.push(message);
             match error {
                 Some(error) => Err(error),
                 None => Ok(()),
@@ -304,7 +307,7 @@ fn review_dispatch_message_includes_compact_metadata_and_issue_url() {
         "한 줄 지시: 코드 리뷰만 수행하고 상세 범위와 verdict 규칙은 시스템 프롬프트의 [Current Task]를 따르세요."
     ));
     assert!(message.contains("dispatch-1"));
-    assert!(!message.contains("review-verdict"));
+    assert!(message.contains("`POST /api/review-verdict` (`dispatch_id=dispatch-1`)"));
     assert!(!message.contains("VERDICT: pass|improve|reject|rework"));
     assert!(message.chars().count() <= 500);
 }
@@ -514,13 +517,24 @@ fn review_decision_primary_message_includes_action_instructions() {
         Some("https://github.com/itismyfield/AgentDesk/issues/249"),
         Some(249),
         Some("review-decision"),
-        Some(r#"{"verdict":"rework"}"#),
+        Some(
+            r#"{
+                "verdict":"rework",
+                "repo":"owner/repo",
+                "issue_number":249,
+                "pr_number":366,
+                "reviewed_commit":"feedfacecafebeef",
+                "decision_endpoint":"POST /api/review-decision"
+            }"#,
+        ),
     );
 
     assert!(message.contains("[⚖️ 리뷰 검토]"));
     assert!(message.contains(
         "한 줄 지시: GitHub 리뷰 피드백을 확인하고 accept/dispute/dismiss 중 하나를 제출하세요."
     ));
+    assert!(message.contains("대상: repo=owner/repo, issue=#249, pr=#366, commit=feedfacecaf…"));
+    assert!(message.contains("제출: `POST /api/review-decision`"));
     assert!(message.contains("<https://github.com/itismyfield/AgentDesk/issues/249>"));
     assert!(!message.contains("카운터모델 리뷰 결과"));
     assert!(!message.contains("review-verdict"));
@@ -578,8 +592,26 @@ async fn completed_review_dispatch_with_explicit_verdict_creates_followup() {
         )
         .unwrap();
         conn.execute(
+            "UPDATE kanban_cards SET github_issue_number = 692, repo_id = ?1 WHERE id = 'card-1'",
+            [std::env::current_dir().unwrap().display().to_string()],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO pr_tracking (
+                card_id, repo_id, worktree_path, branch, pr_number, head_sha, state, created_at, updated_at
+             ) VALUES (
+                'card-1', ?1, ?1, 'wt/692-followup', 366, 'feedfacecafebeef', 'review',
+                datetime('now'), datetime('now')
+             )",
+            [std::env::current_dir()
+                .unwrap()
+                .display()
+                .to_string()],
+        )
+        .unwrap();
+        conn.execute(
             "INSERT INTO task_dispatches (id, kanban_card_id, to_agent_id, dispatch_type, status, title, result, context, created_at, updated_at)
-             VALUES ('dispatch-review', 'card-1', 'agent-1', 'review', 'completed', '[Review R1] card-1', '{\"verdict\":\"improve\"}', '{\"from_provider\":\"codex\",\"target_provider\":\"claude\"}', datetime('now'), datetime('now'))",
+             VALUES ('dispatch-review', 'card-1', 'agent-1', 'review', 'completed', '[Review R1] card-1', '{\"verdict\":\"improve\",\"notes\":\"missing null check\",\"items\":[\"handle null\"]}', '{\"from_provider\":\"codex\",\"target_provider\":\"claude\",\"reviewed_commit\":\"feedfacecafebeef\"}', datetime('now'), datetime('now'))",
             [],
         )
         .unwrap();
@@ -609,6 +641,77 @@ async fn completed_review_dispatch_with_explicit_verdict_creates_followup() {
     assert_eq!(dispatch_status, "pending");
     let context = context.expect("review-decision should persist provider routing context");
     assert!(context.contains("\"from_provider\":\"codex\""));
+    assert!(context.contains("\"reviewed_commit\":\"feedfacecafebeef\""));
+    assert!(context.contains("\"issue_number\":692"));
+    assert!(context.contains("\"pr_number\":366"));
+    assert!(context.contains("\"decision_endpoint\":\"POST /api/review-decision\""));
+    assert!(!context.contains("\"notes\""));
+    assert!(!context.contains("\"items\""));
+}
+
+#[tokio::test]
+async fn unknown_review_verdict_followup_includes_target_and_submission_hints() {
+    let db = test_db();
+    let transport = MockDispatchTransport::default();
+    {
+        let conn = db.lock().unwrap();
+        conn.execute(
+            "INSERT INTO agents (id, name, discord_channel_id, discord_channel_alt) VALUES ('agent-1', 'Agent 1', '123', '456')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO kanban_cards (
+                id, title, status, assigned_agent_id, github_issue_url, latest_dispatch_id, created_at, updated_at
+            ) VALUES (
+                'card-unknown', 'Unknown verdict', 'review', 'agent-1',
+                'https://github.com/itismyfield/AgentDesk/issues/692', 'dispatch-review',
+                datetime('now'), datetime('now')
+            )",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE kanban_cards SET github_issue_number = 692 WHERE id = 'card-unknown'",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO task_dispatches (
+                id, kanban_card_id, to_agent_id, dispatch_type, status, title, context, created_at, updated_at
+            ) VALUES (
+                'dispatch-review', 'card-unknown', 'agent-1', 'review', 'completed',
+                '[Review R1] card-unknown',
+                '{\"repo\":\"owner/repo\",\"issue_number\":692,\"pr_number\":366,\"reviewed_commit\":\"feedfacecafebeef\",\"verdict_endpoint\":\"POST /api/review-verdict\"}',
+                datetime('now'), datetime('now')
+            )",
+            [],
+        )
+        .unwrap();
+    }
+
+    super::discord_delivery::send_review_result_to_primary_with_transport(
+        &db,
+        "card-unknown",
+        "dispatch-review",
+        "unknown",
+        &transport,
+    )
+    .await
+    .expect("unknown verdict followup should be sent");
+
+    let transport_state = transport.state.lock().unwrap();
+    assert_eq!(
+        transport_state.review_followup_kinds,
+        vec![ReviewFollowupKind::Unknown]
+    );
+    let message = transport_state
+        .review_followup_messages
+        .first()
+        .expect("followup message should be captured");
+    assert!(message.contains("대상: repo=owner/repo, issue=#692, pr=#366, commit=feedfacecaf…"));
+    assert!(message.contains("누락된 verdict 제출 경로 참고: 제출: `POST /api/review-verdict` (`dispatch_id=dispatch-review`)"));
+    assert!(message.contains("https://github.com/itismyfield/AgentDesk/issues/692"));
 }
 
 #[test]

--- a/src/services/discord/prompt_builder.rs
+++ b/src/services/discord/prompt_builder.rs
@@ -769,13 +769,15 @@ pub(super) fn build_system_prompt(
 mod tests {
     use super::*;
 
-    /// Helper: call build_system_prompt with minimal/default arguments (Full profile).
+    /// Helper: call build_system_prompt with minimal/default arguments (Full profile),
+    /// while requiring each test to choose its own memento availability.
     fn call_build(
         discord_context: &str,
         current_path: &str,
         channel_id: u64,
         token: &str,
         disabled_notice: &str,
+        memento_mcp_available: bool,
     ) -> String {
         build_system_prompt(
             discord_context,
@@ -787,12 +789,12 @@ mod tests {
             None,  // role_binding
             false, // queued_turn
             DispatchProfile::Full,
-            None,  // dispatch_type
-            None,  // current_task
-            None,  // shared_knowledge
-            None,  // longterm_catalog
-            None,  // memory_settings
-            false, // memento_mcp_available
+            None, // dispatch_type
+            None, // current_task
+            None, // shared_knowledge
+            None, // longterm_catalog
+            None, // memory_settings
+            memento_mcp_available,
         )
     }
 
@@ -804,6 +806,7 @@ mod tests {
             123456789,
             "fake-token",
             "",
+            false,
         );
         assert!(
             output.contains("Channel: #general (guild: TestServer)"),
@@ -813,7 +816,7 @@ mod tests {
 
     #[test]
     fn test_build_system_prompt_includes_cwd() {
-        let output = call_build("ctx", "/home/user/projects", 1, "tok", "");
+        let output = call_build("ctx", "/home/user/projects", 1, "tok", "", false);
         assert!(
             output.contains("Current working directory: /home/user/projects"),
             "System prompt should contain the current working directory"
@@ -822,7 +825,7 @@ mod tests {
 
     #[test]
     fn test_build_system_prompt_includes_file_send_command() {
-        let output = call_build("ctx", "/tmp", 1, "tok", "");
+        let output = call_build("ctx", "/tmp", 1, "tok", "", false);
         assert!(
             output.contains("agentdesk discord-sendfile"),
             "System prompt should contain the agentdesk discord-sendfile command"
@@ -831,7 +834,7 @@ mod tests {
 
     #[test]
     fn test_build_system_prompt_disables_interactive_tools() {
-        let output = call_build("ctx", "/tmp", 1, "tok", "");
+        let output = call_build("ctx", "/tmp", 1, "tok", "", false);
         assert!(
             output.contains("CANNOT interact with any interactive prompts"),
             "System prompt should warn that interactive tools are disabled"
@@ -844,7 +847,7 @@ mod tests {
 
     #[test]
     fn test_build_system_prompt_includes_context_compression_guidance() {
-        let output = call_build("ctx", "/tmp", 1, "tok", "");
+        let output = call_build("ctx", "/tmp", 1, "tok", "", false);
         assert!(output.contains("[Context Compression]"));
         assert!(output.contains(CONTEXT_COMPRESSION_SECTION_ORDER));
         assert!(output.contains(STALE_TOOL_RESULT_PLACEHOLDER_EXAMPLE));
@@ -852,7 +855,7 @@ mod tests {
 
     #[test]
     fn test_build_system_prompt_includes_tool_output_efficiency_guidance() {
-        let output = call_build("ctx", "/tmp", 1, "tok", "");
+        let output = call_build("ctx", "/tmp", 1, "tok", "", false);
         assert!(output.contains("[Tool Output Efficiency]"));
         assert!(output.contains("Large tool results persist in context"));
         assert!(output.contains("Use LIMIT clauses for SQL"));
@@ -862,7 +865,7 @@ mod tests {
 
     #[test]
     fn test_build_system_prompt_includes_api_friction_guidance() {
-        let output = call_build("ctx", "/tmp", 1, "tok", "");
+        let output = call_build("ctx", "/tmp", 1, "tok", "", false);
         assert!(output.contains("[ADK API Usage]"));
         assert!(output.contains("GET /api/docs/{category}"));
         assert!(output.contains("API_FRICTION:"));
@@ -871,7 +874,7 @@ mod tests {
 
     #[test]
     fn test_build_system_prompt_includes_narration_when_enabled() {
-        let output = call_build("ctx", "/tmp", 1, "tok", "");
+        let output = call_build("ctx", "/tmp", 1, "tok", "", false);
         assert!(output.contains("Always keep the user informed about what you are doing."));
         assert!(!output.contains("The user cannot see your tool calls"));
     }

--- a/src/services/discord/prompt_builder.rs
+++ b/src/services/discord/prompt_builder.rs
@@ -176,6 +176,14 @@ fn render_dispatch_context_section(
         })
         .map(str::trim)
         .filter(|value| !value.is_empty());
+    let review_repo = context
+        .get("repo")
+        .or_else(|| context.get("target_repo"))
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let review_issue = context.get("issue_number").and_then(|value| value.as_i64());
+    let review_pr = context.get("pr_number").and_then(|value| value.as_i64());
     let reviewed_commit = context
         .get("reviewed_commit")
         .and_then(|value| value.as_str())
@@ -186,12 +194,37 @@ fn render_dispatch_context_section(
         .and_then(|value| value.as_str())
         .map(str::trim)
         .filter(|value| !value.is_empty());
+    let verdict_endpoint = context
+        .get("verdict_endpoint")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let decision_endpoint = context
+        .get("decision_endpoint")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
 
     if dispatch_type == Some("review")
+        || dispatch_type == Some("review-decision")
+        || review_repo.is_some()
+        || review_issue.is_some()
+        || review_pr.is_some()
         || review_branch.is_some()
         || reviewed_commit.is_some()
         || context.get("review_mode").is_some()
+        || verdict_endpoint.is_some()
+        || decision_endpoint.is_some()
     {
+        if let Some(repo) = review_repo {
+            sections.push(format!("Review Repo: {repo}"));
+        }
+        if let Some(issue_number) = review_issue {
+            sections.push(format!("Review Issue: #{issue_number}"));
+        }
+        if let Some(pr_number) = review_pr {
+            sections.push(format!("Review PR: #{pr_number}"));
+        }
         if let Some(review_mode) = context.get("review_mode").and_then(|value| value.as_str()) {
             sections.push(format!("Review Mode: {review_mode}"));
         }
@@ -239,6 +272,12 @@ fn render_dispatch_context_section(
             .and_then(|value| value.as_str())
         {
             sections.push(format!("Review Verdict Guidance: {guidance}"));
+        }
+        if let Some(endpoint) = verdict_endpoint {
+            sections.push(format!("Verdict Endpoint: {endpoint}"));
+        }
+        if let Some(endpoint) = decision_endpoint {
+            sections.push(format!("Decision Endpoint: {endpoint}"));
         }
     }
 
@@ -1319,6 +1358,9 @@ mod tests {
     #[test]
     fn test_build_system_prompt_renders_dispatch_context_and_completion_contract() {
         let dispatch_context = serde_json::json!({
+            "repo": "owner/repo",
+            "issue_number": 671,
+            "pr_number": 812,
             "review_mode": "noop_verification",
             "branch": "wt/671-dispatch",
             "reviewed_commit": "abc12345deadbeef",
@@ -1326,6 +1368,7 @@ mod tests {
             "noop_reason": "feature already exists",
             "review_quality_checklist": ["edge case", "error handling"],
             "review_verdict_guidance": "quality issue가 보이면 improve",
+            "verdict_endpoint": "POST /api/review-verdict",
             "ci_recovery": {
                 "job_name": "dashboard-build",
                 "reason": "Code job failed: dashboard-build",
@@ -1361,12 +1404,82 @@ mod tests {
             false,
         );
 
+        assert!(prompt.contains("Review Repo: owner/repo"));
+        assert!(prompt.contains("Review Issue: #671"));
+        assert!(prompt.contains("Review PR: #812"));
         assert!(prompt.contains("Review Mode: noop_verification"));
         assert!(prompt.contains("Review Branch: wt/671-dispatch"));
         assert!(prompt.contains("Reviewed Commit: abc12345deadbeef"));
+        assert!(prompt.contains("Verdict Endpoint: POST /api/review-verdict"));
         assert!(prompt.contains("CI Recovery Job: dashboard-build"));
         assert!(prompt.contains("`POST /api/review-verdict` (`dispatch_id=dispatch-review-671`)"));
         assert!(prompt.contains("Review Quality Checklist"));
+    }
+
+    #[test]
+    fn test_review_decision_identifiers_render_in_current_task_but_not_rules_section() {
+        use super::super::settings::RoleBinding;
+
+        let dispatch_context = serde_json::json!({
+            "repo": "owner/repo",
+            "issue_number": 692,
+            "pr_number": 366,
+            "reviewed_commit": "feedfacecafebeef",
+            "decision_endpoint": "POST /api/review-decision",
+            "verdict": "rework"
+        });
+        let dispatch_context_raw = dispatch_context.to_string();
+        let current_task = CurrentTaskContext {
+            dispatch_id: Some("dispatch-decision-692"),
+            card_id: Some("card-692"),
+            dispatch_title: Some("[리뷰 검토] card-692"),
+            dispatch_context: Some(&dispatch_context_raw),
+            card_title: Some("refactor: self-contained review decision"),
+            github_issue_url: Some("https://github.com/itismyfield/AgentDesk/issues/692"),
+            issue_body: None,
+            deferred_dod: None,
+        };
+        let binding = RoleBinding {
+            role_id: "test-agent".to_string(),
+            prompt_file: "/nonexistent".to_string(),
+            provider: None,
+            model: None,
+            reasoning_effort: None,
+            peer_agents_enabled: true,
+            memory: Default::default(),
+        };
+
+        let prompt = build_system_prompt(
+            "ctx",
+            "/tmp",
+            ChannelId::new(1),
+            "tok",
+            "",
+            true,
+            Some(&binding),
+            false,
+            DispatchProfile::ReviewLite,
+            Some("review-decision"),
+            Some(&current_task),
+            None,
+            None,
+            None,
+            false,
+        );
+
+        let rules_start = prompt.find("[Review Decision Rules]").unwrap();
+        let task_start = prompt.find("[Current Task]").unwrap();
+        let rules_section = &prompt[rules_start..task_start];
+
+        assert!(prompt.contains("Review Repo: owner/repo"));
+        assert!(prompt.contains("Review Issue: #692"));
+        assert!(prompt.contains("Review PR: #366"));
+        assert!(prompt.contains("Reviewed Commit: feedfacecafebeef"));
+        assert!(prompt.contains("Decision Endpoint: POST /api/review-decision"));
+        assert!(rules_section.contains("POST /api/review-decision {card_id, decision, comment}"));
+        assert!(!rules_section.contains("owner/repo"));
+        assert!(!rules_section.contains("#366"));
+        assert!(!rules_section.contains("feedfacecafebeef"));
     }
 
     #[test]

--- a/src/services/mcp_config.rs
+++ b/src/services/mcp_config.rs
@@ -36,10 +36,12 @@ pub(crate) fn provider_has_mcp_server(provider: &ProviderKind, server_name: &str
 
     match provider {
         ProviderKind::Claude => {
-            load_runtime_mcp_servers().contains_key(normalized)
+            runtime_config_contains_server(normalized)
                 || claude_global_mcp_config_contains_server(normalized)
         }
-        ProviderKind::Codex => codex_config_contains_server(normalized),
+        ProviderKind::Codex => {
+            runtime_config_contains_server(normalized) || codex_config_contains_server(normalized)
+        }
         _ => false,
     }
 }
@@ -183,6 +185,10 @@ fn load_runtime_mcp_servers() -> BTreeMap<String, ResolvedMcpServer> {
     load_runtime_config()
         .map(|config| resolved_mcp_servers(&config))
         .unwrap_or_default()
+}
+
+fn runtime_config_contains_server(server_name: &str) -> bool {
+    load_runtime_mcp_servers().contains_key(server_name)
 }
 
 fn load_runtime_config() -> Option<Config> {
@@ -368,7 +374,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_has_memento_mcp_reflects_runtime_config_for_claude() {
+    fn provider_has_memento_mcp_reflects_runtime_config_for_claude_and_codex() {
         with_test_env(|temp_root| {
             let runtime_root = temp_root.join(".adk").join("release");
             let config_path = crate::runtime_layout::config_file_path(&runtime_root);
@@ -383,7 +389,7 @@ mod tests {
             crate::config::save_to_path(&config_path, &config).unwrap();
 
             assert!(provider_has_memento_mcp(&ProviderKind::Claude));
-            assert!(!provider_has_memento_mcp(&ProviderKind::Codex));
+            assert!(provider_has_memento_mcp(&ProviderKind::Codex));
         });
     }
 
@@ -399,6 +405,52 @@ mod tests {
             .unwrap();
 
             assert!(provider_has_memento_mcp(&ProviderKind::Claude));
+        });
+    }
+
+    #[test]
+    fn provider_has_mcp_server_falls_back_to_runtime_config_for_codex() {
+        with_test_env(|temp_root| {
+            let runtime_root = temp_root.join(".adk").join("release");
+            let config_path = crate::runtime_layout::config_file_path(&runtime_root);
+            let mut config = Config::default();
+            config.mcp_servers.insert(
+                "manual".to_string(),
+                McpServerConfig {
+                    url: "http://manual.local/mcp".to_string(),
+                    auth: None,
+                },
+            );
+            crate::config::save_to_path(&config_path, &config).unwrap();
+
+            assert!(provider_has_mcp_server(&ProviderKind::Codex, "manual"));
+        });
+    }
+
+    #[test]
+    fn provider_has_memento_mcp_stays_false_for_codex_without_matching_config() {
+        with_test_env(|temp_root| {
+            let runtime_root = temp_root.join(".adk").join("release");
+            let config_path = crate::runtime_layout::config_file_path(&runtime_root);
+            let mut config = Config::default();
+            config.mcp_servers.insert(
+                "manual".to_string(),
+                McpServerConfig {
+                    url: "http://manual.local/mcp".to_string(),
+                    auth: None,
+                },
+            );
+            crate::config::save_to_path(&config_path, &config).unwrap();
+
+            let codex_dir = temp_root.join(".codex");
+            fs::create_dir_all(&codex_dir).unwrap();
+            fs::write(
+                codex_dir.join("config.toml"),
+                "[mcp_servers.other]\nurl = \"http://other.local/mcp\"\n",
+            )
+            .unwrap();
+
+            assert!(!provider_has_memento_mcp(&ProviderKind::Codex));
         });
     }
 


### PR DESCRIPTION
Automated fallback PR after direct merge into `main` hit a cherry-pick conflict.

Card: `9ba639be-21aa-4ff9-b652-6634441e13de`
Issue: https://github.com/itismyfield/AgentDesk/issues/692

Conflict summary:
The previous cherry-pick is now empty, possibly due to conflict resolution. If you wish to commit it anyway, use: git commit --allow-empty Otherwise, please use 'git cherry-pick...