### PR TITLE
fix(security): require DISPATCH prefix for allowed bot turns

### DIFF
--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -134,12 +134,8 @@ pub(super) fn session_retry_context_key(channel_id: ChannelId) -> String {
     format!("session_retry_context:{}", channel_id.get())
 }
 
-pub(super) fn should_process_allowed_bot_turn_text(_text: &str) -> bool {
-    // All announce bot messages trigger turns — dispatches, agent-to-agent
-    // communication, review instructions, and deadlock alerts all need
-    // processing.  "검토 전용" / "작업 착수 금지" are instructions for the
-    // agent's behavior during the turn, not reasons to skip the turn.
-    true
+pub(super) fn should_process_allowed_bot_turn_text(text: &str) -> bool {
+    text.trim_start().starts_with("DISPATCH:")
 }
 
 pub(in crate::services::discord) fn is_allowed_turn_sender(
@@ -1870,21 +1866,19 @@ mod tests {
     }
 
     #[test]
-    fn allowed_bot_all_messages_accepted() {
+    fn allowed_bot_turns_require_dispatch_prefix() {
         let allowed_bot_ids = vec![123];
-        let review_only = "⚠️ 검토 전용 — 작업 착수 금지";
         let dispatch = "DISPATCH: abc123\n작업 시작";
         let agent_msg = "completion_guard 수정해줘";
 
-        // All announce bot messages trigger turns
-        assert!(should_process_allowed_bot_turn_text(review_only));
+        assert!(!should_process_allowed_bot_turn_text("⚠️ 검토 전용 — 작업 착수 금지"));
         assert!(should_process_allowed_bot_turn_text(dispatch));
-        assert!(should_process_allowed_bot_turn_text(agent_msg));
-        assert!(is_allowed_turn_sender(
+        assert!(!should_process_allowed_bot_turn_text(agent_msg));
+        assert!(!is_allowed_turn_sender(
             &allowed_bot_ids,
             123,
             false,
-            review_only
+            "⚠️ 검토 전용 — 작업 착수 금지"
         ));
         assert!(is_allowed_turn_sender(
             &allowed_bot_ids,
@@ -1892,7 +1886,7 @@ mod tests {
             false,
             dispatch
         ));
-        assert!(is_allowed_turn_sender(
+        assert!(!is_allowed_turn_sender(
             &allowed_bot_ids,
             123,
             false,

--- a/src/services/discord/router/tests.rs
+++ b/src/services/discord/router/tests.rs
@@ -72,19 +72,17 @@ fn unregistered_human_slash_messages_fall_through() {
 }
 
 #[test]
-fn allowed_bot_turn_text_accepts_all_messages() {
+fn allowed_bot_turn_text_requires_dispatch_prefix() {
     assert!(should_process_allowed_bot_turn_text(
         "DISPATCH:550e8400-e29b-41d4-a716-446655440000 [implementation] - Fix login bug"
     ));
     assert!(should_process_allowed_bot_turn_text(
         "DISPATCH:550e8400-e29b-41d4-a716-446655440000 [review-decision] - Feedback follow-up\n⛔ 코드 리뷰 금지"
     ));
-    // Review dispatches must also trigger turns — the agent reads and judges
     assert!(should_process_allowed_bot_turn_text(
         "DISPATCH:550e8400-e29b-41d4-a716-446655440000 [review] - Review this\n⚠️ 검토 전용 — 작업 착수 금지"
     ));
-    // Agent-to-agent messages without DISPATCH: also trigger turns
-    assert!(should_process_allowed_bot_turn_text(
+    assert!(!should_process_allowed_bot_turn_text(
         "completion_guard 수정에 OUTCOME: noop 처리도 포함해줘."
     ));
 }


### PR DESCRIPTION
### Motivation

- Restore the original gate that prevents arbitrary allowed-bot messages from starting agent turns so unauthenticated `/api/send` requests cannot trigger turns via the announce bot.

### Description

- Reintroduce a dispatch-prefix check by changing `should_process_allowed_bot_turn_text` to `text.trim_start().starts_with("DISPATCH:")` so only messages that begin with `DISPATCH:` are processed as turns.
- Keep the existing allowed-bot bypass behavior but route it through the restored `DISPATCH:` predicate so allowed bots no longer trigger turns for arbitrary content.
- Update unit tests in `src/services/discord/mod.rs` and `src/services/discord/router/tests.rs` to assert the `DISPATCH:` requirement and to ensure non-dispatch messages are rejected.
- Make a minimal, focused change to remediate the security regression without altering other logic.

### Testing

- Ran `cargo test allowed_bot_turns_require_dispatch_prefix -- --nocapture` and the unit test `services::discord::tests::allowed_bot_turns_require_dispatch_prefix` passed.
- Ran `cargo test allowed_bot_turn_text_requires_dispatch_prefix -- --nocapture` and the router test `services::discord::router::tests::allowed_bot_turn_text_requires_dispatch_prefix` passed.
- Automated test runs completed successfully (tests passed) with compiler warnings only and no test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0591f97988333bd7674b9afd2e6bf)