### PR TITLE
fix(kanban): restrict GitHub auto-sync to registered card repo

### DIFF
--- a/src/kanban.rs
+++ b/src/kanban.rs
@@ -587,44 +587,76 @@ fn github_sync_on_transition(
         return;
     }
 
-    let info: Option<(String, Option<i64>)> = db
-        .lock()
-        .ok()
-        .and_then(|conn| {
-            conn.query_row(
-                "SELECT COALESCE(github_issue_url, ''), github_issue_number FROM kanban_cards WHERE id = ?1",
-                [card_id],
-                |row| Ok((row.get(0)?, row.get(1)?)),
-            )
-            .ok()
-        });
-
-    let Some((issue_url, issue_number)) = info else {
+    let Some((repo_id, num)) = github_sync_target_for_card(db, card_id) else {
         return;
     };
-    if issue_url.is_empty() {
-        return;
-    }
-
-    let repo = match issue_url
-        .strip_prefix("https://github.com/")
-        .and_then(|s| s.find("/issues/").map(|i| &s[..i]))
-    {
-        Some(r) => r.to_string(),
-        None => return,
-    };
-    let Some(num) = issue_number else { return };
 
     if is_terminal {
-        if let Err(error) = crate::github::close_issue(&repo, num) {
+        if let Err(error) = crate::github::close_issue(&repo_id, num) {
             tracing::warn!(
-                "[kanban] failed to close issue {repo}#{num} for terminal card {card_id}: {error}"
+                "[kanban] failed to close issue {repo_id}#{num} for terminal card {card_id}: {error}"
             );
         }
     } else if is_review_enter {
         let comment = "🔍 칸반 상태: **review** (카운터모델 리뷰 진행 중)";
-        let _ = crate::github::comment_issue(&repo, num, comment);
+        let _ = crate::github::comment_issue(&repo_id, num, comment);
     }
+}
+
+fn github_sync_target_for_card(db: &Db, card_id: &str) -> Option<(String, i64)> {
+    let info: Option<(String, String, Option<i64>)> = db
+        .lock()
+        .ok()
+        .and_then(|conn| {
+            conn.query_row(
+                "SELECT COALESCE(repo_id, ''), COALESCE(github_issue_url, ''), github_issue_number FROM kanban_cards WHERE id = ?1",
+                [card_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .ok()
+        });
+
+    let Some((repo_id, issue_url, issue_number)) = info else {
+        return None;
+    };
+    if repo_id.is_empty() || issue_url.is_empty() {
+        return None;
+    }
+
+    let issue_repo = match issue_url
+        .strip_prefix("https://github.com/")
+        .and_then(|s| s.find("/issues/").map(|i| &s[..i]))
+    {
+        Some(r) => r,
+        None => return None,
+    };
+    if issue_repo != repo_id {
+        tracing::warn!(
+            "[kanban] skip GitHub sync for card {card_id}: issue URL repo {issue_repo} does not match card repo_id {repo_id}"
+        );
+        return None;
+    }
+
+    let repo_registered = db
+        .lock()
+        .ok()
+        .and_then(|conn| {
+            conn.query_row(
+                "SELECT EXISTS(SELECT 1 FROM github_repos WHERE id = ?1 AND COALESCE(sync_enabled, 1) = 1)",
+                [&repo_id],
+                |row| row.get::<_, bool>(0),
+            )
+            .ok()
+        })
+        .unwrap_or(false);
+    if !repo_registered {
+        tracing::warn!(
+            "[kanban] skip GitHub sync for card {card_id}: repo_id {repo_id} is not a registered sync-enabled repo"
+        );
+        return None;
+    }
+
+    issue_number.map(|num| (repo_id, num))
 }
 
 /// Log a kanban state transition to audit_logs table.
@@ -1954,6 +1986,53 @@ mod tests {
             age_seconds < 60,
             "started_at should be set to now on first entry, but was {} seconds ago",
             age_seconds
+        );
+    }
+
+    #[test]
+    fn github_sync_target_requires_registered_repo_and_matching_issue_repo() {
+        let db = test_db();
+        seed_card(&db, "card-github-sync-guard", "review");
+        {
+            let conn = db.lock().unwrap();
+            conn.execute(
+                "UPDATE kanban_cards
+                 SET repo_id = 'owner/allowed',
+                     github_issue_url = 'https://github.com/owner/other/issues/101',
+                     github_issue_number = 101
+                 WHERE id = 'card-github-sync-guard'",
+                [],
+            )
+            .unwrap();
+        }
+
+        // Mismatched URL repo must be rejected.
+        assert_eq!(github_sync_target_for_card(&db, "card-github-sync-guard"), None);
+
+        {
+            let conn = db.lock().unwrap();
+            conn.execute(
+                "UPDATE kanban_cards
+                 SET github_issue_url = 'https://github.com/owner/allowed/issues/101'
+                 WHERE id = 'card-github-sync-guard'",
+                [],
+            )
+            .unwrap();
+        }
+        // Matching repo but not registered must still be rejected.
+        assert_eq!(github_sync_target_for_card(&db, "card-github-sync-guard"), None);
+
+        {
+            let conn = db.lock().unwrap();
+            conn.execute(
+                "INSERT INTO github_repos (id, display_name, sync_enabled) VALUES ('owner/allowed', 'Allowed Repo', 1)",
+                [],
+            )
+            .unwrap();
+        }
+        assert_eq!(
+            github_sync_target_for_card(&db, "card-github-sync-guard"),
+            Some(("owner/allowed".to_string(), 101))
         );
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent confused-deputy writes where attacker-controlled `github_issue_url`/`github_issue_number` on a kanban card could cause the server to close/comment issues in arbitrary repos accessible to the server's `gh` credentials.
- Ensure GitHub write actions only target an allowlisted, sync-enabled repository associated with the card rather than trusting an unvalidated URL supplied via the API.

### Description
- Introduced `github_sync_target_for_card(db, card_id)` which resolves and validates a safe sync target by requiring a non-empty `repo_id`, a parseable `github_issue_url` that matches `repo_id`, and that `repo_id` exists in `github_repos` with `sync_enabled` true.
- Refactored `github_sync_on_transition` to call the helper and to run `close_issue`/`comment_issue` only with the validated `repo_id` and issue number.
- Replaced ad-hoc repo parsing/trust of `github_issue_url` with the validated guard to avoid cross-repo actions driven by attacker-controlled metadata.
- Added a unit test `github_sync_target_requires_registered_repo_and_matching_issue_repo` that exercises rejection of mismatched/unregistered targets and acceptance of registered+matching targets.

### Testing
- Ran `cargo check` which completed successfully.
- Added a focused unit test covering the guard behavior and attempted `cargo test github_sync_target_requires_registered_repo_and_matching_issue_repo -- --nocapture`, but test compilation was blocked by a pre-existing duplicate test name elsewhere in the test suite (unrelated to these changes).
- The change is minimal and confined to `src/kanban.rs` and its tests; the guard logic is covered by the new unit test and `cargo check` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e099a27e148333b084b6b4424fcd0b)