### PR TITLE
fix(security): redact onboarding tokens from status API

### DIFF
--- a/src/server/routes/onboarding.rs
+++ b/src/server/routes/onboarding.rs
@@ -321,20 +321,9 @@ pub async fn status(State(state): State<AppState>) -> (StatusCode, Json<serde_js
     let setup_mode = onboarding_setup_mode(completed);
     let resume_state = onboarding_resume_state(draft_available, completion_state.as_ref());
 
-    // Mask tokens after onboarding is complete to prevent unauthenticated leakage.
-    // Only show full tokens during initial setup (before completion).
-    let mask = |t: Option<String>| -> Option<String> {
-        if !completed {
-            return t;
-        }
-        t.map(|s| {
-            if s.len() > 8 {
-                format!("{}…{}", &s[..4], &s[s.len() - 4..])
-            } else {
-                "***".to_string()
-            }
-        })
-    };
+    // Never return raw onboarding tokens from status.
+    // This endpoint can be reachable without auth, so redact all token values.
+    let redact = |_t: Option<String>| -> Option<String> { None };
 
     (
         StatusCode::OK,
@@ -342,10 +331,10 @@ pub async fn status(State(state): State<AppState>) -> (StatusCode, Json<serde_js
             "completed": completed,
             "agent_count": agent_count,
             "bot_tokens": {
-                "command": mask(bot_token),
-                "announce": mask(announce_token),
-                "notify": mask(notify_token),
-                "command2": mask(command_token_2),
+                "command": redact(bot_token),
+                "announce": redact(announce_token),
+                "notify": redact(notify_token),
+                "command2": redact(command_token_2),
             },
             "bot_providers": {
                 "command": primary_provider,


### PR DESCRIPTION
### Motivation
- The `GET /api/onboarding/status` handler read onboarding bot tokens from `kv_meta` and could return them in the JSON response, exposing long‑lived Discord bot credentials to unauthenticated callers. 
- This change prevents credential disclosure while keeping the onboarding status API usable for the dashboard.

### Description
- Updated the `status` handler in `src/server/routes/onboarding.rs` to never return raw onboarding tokens and to redact the `bot_tokens` fields (`command`, `announce`, `notify`, `command2`) by returning `None` for those fields. 
- Preserved the existing JSON response shape (other fields such as `bot_providers`, `guild_id`, `owner_id`, `agents`, `draft_available`, `setup_mode`, and `resume_state` remain unchanged) to minimize API surface disruption.

### Testing
- Ran `cargo fmt --check`, which succeeded. 
- Attempted `cargo check -q --package agentdesk` and targeted package tests, but the build/test commands timed out in this environment so a full compile/test run could not be completed here (environment timeout/exit 124). 
- The change is minimal and localized to `status`, and it preserves response shape to avoid breaking callers while eliminating the credential disclosure risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e09661297883338ab5a50c112236d3)