### PR TITLE
fix(security): avoid untrusted card metadata in PM announce escalation payloads

### DIFF
--- a/src/server/routes/escalation.rs
+++ b/src/server/routes/escalation.rs
@@ -71,6 +71,7 @@ pub struct EmitEscalationBody {
 
 #[derive(Debug)]
 struct CardEscalationSummary {
+    card_id: String,
     title: String,
     issue_number: Option<i64>,
     assigned_agent_id: Option<String>,
@@ -256,6 +257,7 @@ fn load_card_summary(
         [card_id],
         |row| {
             Ok(CardEscalationSummary {
+                card_id: card_id.to_string(),
                 title: row.get(0)?,
                 issue_number: row.get(1)?,
                 assigned_agent_id: row.get(2)?,
@@ -702,7 +704,14 @@ fn build_pm_message(
     reasons: &[String],
     fallback_note: Option<&str>,
 ) -> String {
-    let mut lines = vec![format!("⚠️ [PM 결정 요청] {}", format_card_label(summary))];
+    let mut lines = vec![format!(
+        "⚠️ [PM 결정 요청] card:{}{}",
+        summary.card_id,
+        summary
+            .issue_number
+            .map(|number| format!(" (#{number})"))
+            .unwrap_or_default()
+    )];
     if let Some(note) = fallback_note {
         lines.push(format!("fallback: {note}"));
     }
@@ -1108,7 +1117,7 @@ async fn emit_escalation_with_base_url(
         &announce_token,
         &settings,
         &summary,
-        context.as_ref(),
+        None,
         &reasons,
         None,
         requested_mode,


### PR DESCRIPTION
### Motivation
- The PM escalation path delivered attacker-controlled card `title`/URL into announce-bot messages (trusted by agents), creating a prompt-injection surface. 
- Provide a minimal, targeted hardening that removes untrusted metadata from announce-bot PM requests while preserving the escalation flow.

### Description
- Added `card_id` to `CardEscalationSummary` and populate it in `load_card_summary` so messages can reference a stable identifier (`card:<id>`). 
- Replaced the PM-mode escalation header that previously used the card title with a stable header built from `card_id` and an optional issue number in `build_pm_message`. 
- For PM-mode delivery fallback, stopped including rich card context by passing `None` for `context` when delivering to the announce bot, removing title/description/URL content from the trusted announce-bot channel. 
- Changes are localized to `src/server/routes/escalation.rs` and are intentionally minimal to mitigate injection without altering timeout policy logic.

### Testing
- Ran `cargo fmt` which completed successfully. 
- Attempted to run the targeted test `cargo test escalation::tests::build_pm_message_drops_low_priority_context_sections_to_fit_discord_limit -- --nocapture`, but the build failed due to a pre-existing duplicate test name in `src/server/routes/dispatches/discord_delivery.rs` (`reused_thread_probe_error_falls_back_to_creating_new_thread` defined twice), which is unrelated to this patch and prevented the test from completing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e096760a1c8333b67b8dac5e44eec4)