### PR TITLE
fix(installer): harden one-click installer default network exposure

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -34,8 +34,11 @@ _read_default() {
 # During install, defaults.json may exist in the extracted tarball or cloned repo
 _DEFAULTS_SRC="${TMPDIR_BUILD:-${TMPDIR_DL:-}}/defaults.json"
 DEFAULT_PORT=$(_read_default port 8791 "$_DEFAULTS_SRC")
-DEFAULT_HOST=$(_read_default host "0.0.0.0" "$_DEFAULTS_SRC")
+DEFAULT_HOST=$(_read_default host "127.0.0.1" "$_DEFAULTS_SRC")
 DEFAULT_LOOPBACK=$(_read_default loopback "127.0.0.1" "$_DEFAULTS_SRC")
+if [ "$DEFAULT_HOST" = "0.0.0.0" ]; then
+  DEFAULT_HOST="$DEFAULT_LOOPBACK"
+fi
 
 # ── Colors ────────────────────────────────────────────────────────────────────
 RED='\033[0;31m'
@@ -335,7 +338,6 @@ if [ "$OS" = "darwin" ]; then
   FW=/usr/libexec/ApplicationFirewall/socketfilterfw
   if [ -f "$FW" ]; then
     sudo "$FW" --add "$INSTALL_DIR/bin/agentdesk" 2>/dev/null || true
-    sudo "$FW" --unblockapp "$INSTALL_DIR/bin/agentdesk" 2>/dev/null || true
   fi
 fi
 


### PR DESCRIPTION
### Motivation
- The macOS one-click installer previously wrote a default config binding the HTTP API to `0.0.0.0` with no auth and also unblocked the app in the firewall, causing immediate unauthenticated network exposure on first run.
- The goal is to make first-run installer behavior local-only by default while preserving onboarding and auto-start semantics.

### Description
- Changed the installer default host to `127.0.0.1` by default and added a safety override that rewrites any `0.0.0.0` value read from `defaults.json` to the loopback address in `scripts/install.sh`.
- Removed the automatic macOS firewall `--unblockapp` call so the installer no longer explicitly opens network access during setup.
- All changes are implemented in `scripts/install.sh` and are intentionally minimal to avoid altering runtime auth behavior.

### Testing
- Ran a shell syntax check with `bash -n scripts/install.sh` which succeeded. 
- Reviewed the installer output template and verified the firewall unblocking call was removed and the generated config now uses loopback for the host by default.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e09331d3948333a3a8d3daf8cb210d)