### PR TITLE
fix: sanitize PM escalation announce payloads

### DIFF
--- a/policies/00-escalation.js
+++ b/policies/00-escalation.js
@@ -128,14 +128,14 @@ function escalationApiUrl(path) {
 
 function escalationCardTitle(cardId) {
   var cards = agentdesk.db.query(
-    "SELECT title, github_issue_number FROM kanban_cards WHERE id = ?",
+    "SELECT github_issue_number FROM kanban_cards WHERE id = ?",
     [cardId]
   );
   if (cards.length === 0) return cardId;
   if (cards[0].github_issue_number) {
-    return "#" + cards[0].github_issue_number + " " + cards[0].title;
+    return "#" + cards[0].github_issue_number + " (" + cardId + ")";
   }
-  return cards[0].title || cardId;
+  return cardId;
 }
 
 function parseCooldownRecord(raw) {

--- a/policies/review-automation.js
+++ b/policies/review-automation.js
@@ -112,7 +112,7 @@ var reviewAutomation = {
       notifyDeadlockManager(
         "⚠️ [Review Deadlock] " +
           (card.github_issue_number ? ("#" + card.github_issue_number + " ") : "") +
-          (card.title || card.id) + "\n" +
+          card.id + "\n" +
           "card_id: " + card.id + "\n" +
           "agent: " + card.assigned_agent_id + "\n" +
           "review round " + newRound + " exceeded max " + maxRounds,

--- a/src/server/routes/escalation.rs
+++ b/src/server/routes/escalation.rs
@@ -697,19 +697,22 @@ fn build_user_message(
 }
 
 fn build_pm_message(
+    card_id: &str,
     summary: &CardEscalationSummary,
-    context: Option<&CardContext>,
     reasons: &[String],
     fallback_note: Option<&str>,
 ) -> String {
-    let mut lines = vec![format!("⚠️ [PM 결정 요청] {}", format_card_label(summary))];
+    let mut lines = vec![format!("⚠️ [PM 결정 요청] card_id: {card_id}")];
+    if let Some(issue_number) = summary.issue_number {
+        lines.push(format!("issue: #{issue_number}"));
+    }
     if let Some(note) = fallback_note {
         lines.push(format!("fallback: {note}"));
     }
     lines.push("카드에 수동 판단이 필요합니다. 다음 조치를 결정해주세요.".to_string());
     compose_escalation_message(
         lines,
-        context,
+        None,
         vec![
             "사유:".to_string(),
             format_reason_lines(reasons),
@@ -1033,9 +1036,9 @@ async fn emit_escalation_with_base_url(
                                 &client,
                                 base_url,
                                 &announce_token,
+                                &card_id,
                                 &settings,
                                 &summary,
-                                context.as_ref(),
                                 &reasons,
                                 fallback_note,
                                 requested_mode,
@@ -1091,9 +1094,9 @@ async fn emit_escalation_with_base_url(
             &client,
             base_url,
             &announce_token,
+            &card_id,
             &settings,
             &summary,
-            context.as_ref(),
             &reasons,
             "owner routing unavailable",
             requested_mode,
@@ -1106,9 +1109,9 @@ async fn emit_escalation_with_base_url(
         &client,
         base_url,
         &announce_token,
+        &card_id,
         &settings,
         &summary,
-        context.as_ref(),
         &reasons,
         None,
         requested_mode,
@@ -1121,9 +1124,9 @@ async fn deliver_pm_fallback(
     client: &reqwest::Client,
     base_url: &str,
     announce_token: &str,
+    card_id: &str,
     settings: &EscalationSettings,
     summary: &CardEscalationSummary,
-    context: Option<&CardContext>,
     reasons: &[String],
     fallback_note: impl Into<Option<&'static str>>,
     requested_mode: EscalationMode,
@@ -1142,7 +1145,7 @@ async fn deliver_pm_fallback(
     };
     let pm_channel_id = pm_channel_id.to_string();
 
-    let message = build_pm_message(summary, context, reasons, fallback_note);
+    let message = build_pm_message(card_id, summary, reasons, fallback_note);
     match send_channel_message(client, base_url, announce_token, &pm_channel_id, &message).await {
         Ok(()) => (
             StatusCode::OK,


### PR DESCRIPTION
### Motivation
- Announce-bot messages are processed by agents, and previously PM escalation messages included attacker-controlled card titles/context (sourced from GitHub issue data), creating a prompt-injection/automation risk.

### Description
- Stop embedding untrusted card titles in PM escalation labels by changing `escalationCardTitle` to return only an identifier (use `cardId` and optional `#issue_number`) in `policies/00-escalation.js`.
- Prevent review deadlock announce messages from including `card.title` by using the stable `card.id` (and optional issue number) in `policies/review-automation.js`.
- Harden the PM fallback message path in the Rust escalation handler by changing `build_pm_message` to accept `card_id`, drop the free-form `context` for PM announce messages, and only include `card_id` + optional issue number in `src/server/routes/escalation.rs`; update call sites accordingly to avoid sending untrusted summaries to the announce bot.

### Testing
- Ran `node --check policies/00-escalation.js && node --check policies/review-automation.js` and both succeeded.
- Ran `cargo fmt --all -- --check` and it succeeded.
- Attempted full `cargo check -q` but the build exceeded the command timeout in this environment (no successful full Rust type-check completed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0944a5c6483339a6789566d5f280f)