### PR TITLE
fix: require auth token for Discord control endpoints on non-loopback hosts

### DIFF
--- a/src/server/routes/health_api.rs
+++ b/src/server/routes/health_api.rs
@@ -19,6 +19,20 @@ struct DispatchOutboxStats {
     oldest_pending_age: i64,
 }
 
+fn discord_control_endpoints_allowed(config: &crate::config::Config) -> bool {
+    if config
+        .server
+        .auth_token
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|token| !token.is_empty())
+    {
+        return true;
+    }
+
+    matches!(config.server.host.trim(), "127.0.0.1" | "localhost" | "::1")
+}
+
 /// GET /api/health — combined DB + Discord provider health.
 /// When HealthRegistry is present, returns Discord provider status.
 /// Always includes DB status and dashboard availability.
@@ -125,6 +139,14 @@ pub async fn health_handler(State(state): State<AppState>) -> Response {
 
 /// POST /api/send — agent-to-agent native routing.
 pub async fn send_handler(State(state): State<AppState>, body: Bytes) -> Response {
+    if !discord_control_endpoints_allowed(&state.config) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"ok": false, "error": "auth_token required for non-loopback host"})),
+        )
+            .into_response();
+    }
+
     let Some(ref registry) = state.health_registry else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
@@ -143,6 +165,14 @@ pub async fn send_handler(State(state): State<AppState>, body: Bytes) -> Respons
 
 /// POST /api/senddm — send a DM to a Discord user.
 pub async fn senddm_handler(State(state): State<AppState>, body: Bytes) -> Response {
+    if !discord_control_endpoints_allowed(&state.config) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"ok": false, "error": "auth_token required for non-loopback host"})),
+        )
+            .into_response();
+    }
+
     let Some(ref registry) = state.health_registry else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -216,6 +216,48 @@ async fn protected_domain_router_keeps_internal_and_hook_auth_exemptions() {
 }
 
 #[tokio::test]
+async fn discord_control_endpoints_require_auth_token_on_non_loopback_host() {
+    let db = test_db();
+    let engine = test_engine(&db);
+    let app = test_api_router(db, engine, None);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/send")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn discord_control_endpoints_allow_loopback_without_auth_token() {
+    let db = test_db();
+    let engine = test_engine(&db);
+    let mut config = crate::config::Config::default();
+    config.server.host = "127.0.0.1".to_string();
+    let app = test_api_router_with_config(db, engine, config, None);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/send")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
 async fn public_domain_router_wraps_plain_server_errors_in_app_error_json() {
     let db = test_db();
     let engine = test_engine(&db);


### PR DESCRIPTION
### Motivation
- The `/api/send` and `/api/senddm` Discord control endpoints were registered on the main public API router and became reachable when the server binds to `0.0.0.0` with `server.auth_token` unset, creating a remote unauthenticated attack surface.

### Description
- Add a guard function `discord_control_endpoints_allowed` in `src/server/routes/health_api.rs` that returns true only when `server.auth_token` is configured/non-empty or when the server host is loopback (`127.0.0.1`, `localhost`, `::1`).
- Gate the `send` and `senddm` handlers to return `403 Forbidden` with a clear JSON error when the guard denies access, preserving existing behavior when allowed.
- Add tests in `src/server/routes/routes_tests.rs` to assert non-loopback without `auth_token` is forbidden and loopback without `auth_token` still reaches the handler path.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test` targeting the new `discord_control_endpoints_` tests; compilation proceeded but the test run failed due to an unrelated duplicate test name error in `src/server/routes/dispatches/discord_delivery.rs`, causing the test suite to abort before full completion.
- New tests are present and exercise the intended gating behavior (they compiled as part of the test run), but the whole test suite did not finish due to the unrelated compile-time test name collision.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e090fc7ec88333a1e26d0e6479cfec)