### PR TITLE
fix: re-protect /api/send and /api/senddm behind bearer auth

### DIFF
--- a/src/server/routes/auth.rs
+++ b/src/server/routes/auth.rs
@@ -36,8 +36,6 @@ pub async fn auth_middleware(
     let path = req.uri().path();
 
     if path == "/health"
-        || path == "/send"
-        || path == "/senddm"
         || path == "/auth/session"
         || path.starts_with("/hook/")
         || path.starts_with("/internal/")

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -157,7 +157,7 @@ fn git_commit(repo_dir: &std::path::Path, message: &str) -> String {
 }
 
 #[tokio::test]
-async fn protected_domain_router_keeps_internal_and_hook_auth_exemptions() {
+async fn protected_domain_router_only_keeps_expected_auth_exemptions() {
     let db = test_db();
     let engine = test_engine(&db);
     let mut config = crate::config::Config::default();
@@ -173,6 +173,8 @@ async fn protected_domain_router_keeps_internal_and_hook_auth_exemptions() {
                 "/hook/session",
                 axum::routing::post(|| async { StatusCode::CREATED }),
             )
+            .route("/send", axum::routing::post(|| async { StatusCode::OK }))
+            .route("/senddm", axum::routing::post(|| async { StatusCode::OK }))
             .route("/settings", axum::routing::get(|| async { StatusCode::OK })),
         state.clone(),
     )
@@ -204,6 +206,7 @@ async fn protected_domain_router_keeps_internal_and_hook_auth_exemptions() {
     assert_eq!(hook_response.status(), StatusCode::CREATED);
 
     let protected_response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .uri("/settings")
@@ -213,6 +216,31 @@ async fn protected_domain_router_keeps_internal_and_hook_auth_exemptions() {
         .await
         .unwrap();
     assert_eq!(protected_response.status(), StatusCode::UNAUTHORIZED);
+
+    let send_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/send")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(send_response.status(), StatusCode::UNAUTHORIZED);
+
+    let senddm_response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/senddm")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(senddm_response.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Motivation
- Restore bearer-token enforcement for state-changing Discord endpoints that were accidentally exempted, preventing unauthenticated clients from posting messages or mutating session state.
- Limit the auth middleware exemptions to only intended public/internal paths (`/health`, `/auth/session`, `/hook/*`, `/internal/*`).

### Description
- Removed `/send` and `/senddm` from the auth middleware skip list in `src/server/routes/auth.rs` so those routes now require the configured `server.auth_token` when present.
- Updated and renamed a route-level regression test in `src/server/routes/routes_tests.rs` to verify that `/internal/*` and `/hook/*` remain exempt while `/send` and `/senddm` return `401 Unauthorized` without credentials.
- Modified only the mentioned files to minimally remediate the auth bypass while preserving existing behavior for genuine exemptions.

### Testing
- Ran `cargo test protected_domain_router_only_keeps_expected_auth_exemptions --package agentdesk`, and the test passed (`1 passed; 0 failed`).
- The change was validated by the updated route-level unit test confirming `/send` and `/senddm` are now protected by bearer auth when `server.auth_token` is set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08d9d38d88333affa25ef2717bddc)