### PR TITLE
fix(discord): enforce auth before consuming pending DM replies

### DIFF
--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -560,17 +560,7 @@ pub(in crate::services::discord) async fn handle_event(
             // Only skip channels that are explicitly bound to a different provider.
             // Unowned channels fall through to normal handling.
 
-            // #189: Generic DM reply tracking — consume pending entry if present.
-            // Consumed DM answers must stop here; falling through into normal
-            // message handling produces a bogus "No active session" error in DMs.
             let text = new_message.content.trim();
-            if !text.is_empty() {
-                if let Some(ref db) = data.shared.db {
-                    if try_handle_pending_dm_reply(db, new_message).await {
-                        return Ok(());
-                    }
-                }
-            }
 
             let is_allowed_bot_sender = settings_snapshot.allowed_bot_ids.contains(&user_id.get());
             if is_allowed_bot_sender
@@ -594,6 +584,19 @@ pub(in crate::services::discord) async fn handle_event(
             let is_allowed_bot = is_allowed_bot_sender;
             if !is_allowed_bot && !check_auth(user_id, user_name, &data.shared, &data.token).await {
                 return Ok(());
+            }
+
+            // #189: Generic DM reply tracking — consume pending entry if present.
+            // Keep this after auth so unauthorized DM senders cannot inject
+            // answers into pending workflows.
+            // Consumed DM answers must stop here; falling through into normal
+            // message handling produces a bogus "No active session" error in DMs.
+            if !text.is_empty() {
+                if let Some(ref db) = data.shared.db {
+                    if try_handle_pending_dm_reply(db, new_message).await {
+                        return Ok(());
+                    }
+                }
             }
 
             // Handle file attachments — download regardless of session state


### PR DESCRIPTION
### Motivation
- A pending DM reply consumer was running before the Discord auth check, allowing unauthorized users to have their DM content consumed into pending workflows and enabling an authentication bypass for `dmReply` flows. 

### Description
- Move the call to `try_handle_pending_dm_reply(...)` in `src/services/discord/router/intake_gate.rs` to run after the `check_auth(...)` gate so only authorized senders (or allowed bots) can consume pending replies. 
- Preserve the original short-circuit behavior where a consumed pending reply returns early and prevents further message handling. 
- Add an inline comment clarifying the security intent to prevent unauthorized DM reply injection.

### Testing
- Ran `cargo fmt --all -- --check`, which completed successfully. 
- Ran `timeout 90 cargo test -q --package agentdesk intake_gate -- --nocapture`, which executed the filtered test run with no failures (tests were filtered out by the pattern and no failing tests occurred).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e07399eb5c833398c56a72f1662787)