### PR TITLE
fix(discord): enforce auth in phase2 catch-up recovery

### DIFF
--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -1143,6 +1143,14 @@ async fn catch_up_missed_messages(
             ) {
                 continue;
             }
+            let is_allowed_bot =
+                msg.author.bot && allowed_bot_ids_phase2.contains(&msg.author.id.get());
+            if !is_allowed_bot {
+                let settings = shared.settings.read().await;
+                if !discord_io::user_is_authorized(&settings, msg.author.id.get()) {
+                    continue;
+                }
+            }
             if !should_phase2_recover_message(mid, phase2_checkpoint, &existing_ids) {
                 continue;
             }


### PR DESCRIPTION
### Motivation

- Prevent unauthorized Discord users from being recovered and enqueued by the phase2 catch-up path after a bot restart, which previously bypassed the normal `check_auth`/allowlist gate.

### Description

- Add an authorization gate in the phase2 recovery loop in `src/services/discord/mod.rs` so recovered messages are only enqueued if they are from an allowed bot (`allowed_bot_ids`) or the author passes `discord_io::user_is_authorized`, while preserving existing dedup, ordering, and `is_allowed_turn_sender` logic.

### Testing

- Ran `cargo test -p agentdesk services::discord::tests:: --quiet`, which completed successfully (`8 passed, 0 failed`), and built the package with `cargo build -p agentdesk` which succeeded with warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e06c8b92d4833390e4fc02794300fe)