### PR TITLE
fix(discord): ignore thread names for routing role binding

### DIFF
--- a/src/services/discord/settings.rs
+++ b/src/services/discord/settings.rs
@@ -2215,6 +2215,48 @@ channels:
     }
 
     #[test]
+    fn test_validate_bot_channel_routing_with_provider_channel_ignores_thread_name_binding() {
+        with_temp_home(|temp_home: &TempDir| {
+            let settings_dir = temp_home.path().join(".adk").join("config");
+            fs::create_dir_all(&settings_dir).unwrap();
+            fs::write(
+                settings_dir.join("org.yaml"),
+                r#"
+version: 1
+name: "Test Org"
+agents:
+  privileged-agent:
+    display_name: "Privileged"
+    provider: codex
+channels:
+  by_name:
+    enabled: true
+    mappings:
+      privileged-thread:
+        agent: privileged-agent
+"#,
+            )
+            .unwrap();
+
+            let mut settings = super::super::DiscordBotSettings::default();
+            settings.provider = ProviderKind::Codex;
+            settings.agent = Some("privileged-agent".to_string());
+            settings.allowed_channel_ids = vec![1470034105176424533];
+
+            let result = validate_bot_channel_routing_with_provider_channel(
+                &settings,
+                &ProviderKind::Codex,
+                ChannelId::new(1470034105176424533),
+                Some("privileged-thread"),
+                Some("team-general"),
+                false,
+            );
+
+            assert_eq!(result, Err(BotChannelRoutingGuardFailure::AgentMismatch));
+        });
+    }
+
+    #[test]
     fn test_cross_bot_skip_classification_only_hides_expected_misses() {
         assert!(BotChannelRoutingGuardFailure::ChannelNotAllowed.is_expected_cross_bot_skip());
         assert!(BotChannelRoutingGuardFailure::AgentMismatch.is_expected_cross_bot_skip());

--- a/src/services/discord/settings/validation.rs
+++ b/src/services/discord/settings/validation.rs
@@ -112,10 +112,10 @@ pub(crate) fn validate_bot_channel_routing_with_provider_channel(
     provider_channel_name: Option<&str>,
     is_dm: bool,
 ) -> Result<(), BotChannelRoutingGuardFailure> {
-    let role_binding = resolve_role_binding(
-        allowlist_channel_id,
-        binding_channel_name.or(provider_channel_name),
-    );
+    // Always resolve role binding against the same channel identity used for
+    // allowlist checks (parent for threads). Do not allow live thread names to
+    // influence agent binding resolution.
+    let role_binding = resolve_role_binding(allowlist_channel_id, provider_channel_name);
 
     if !bot_settings_allow_channel(settings, allowlist_channel_id, is_dm) {
         return Err(BotChannelRoutingGuardFailure::ChannelNotAllowed);


### PR DESCRIPTION
### Motivation
- Prevent an authorization bypass where user-controlled thread names could be used to resolve privileged role bindings while allowlisting used the parent channel ID.
- Ensure routing validation uses the channel identity that is actually allowlisted (parent channel) so threads cannot elevate privileges by naming.

### Description
- Change `validate_bot_channel_routing_with_provider_channel` to resolve role bindings with the `allowlist_channel_id` and `provider_channel_name` only, removing the live thread name from binding resolution (`src/services/discord/settings/validation.rs`).
- Add a regression test `test_validate_bot_channel_routing_with_provider_channel_ignores_thread_name_binding` that asserts a by-name privileged thread label no longer grants agent access when the parent/provider does not match (`src/services/discord/settings.rs`).
- Preserve existing behavior where appropriate (existing test `test_validate_bot_channel_routing_with_provider_channel_keeps_thread_binding` still passes).

### Testing
- Ran the focused unit tests: `cargo test -q keeps_thread_binding` and `cargo test -q ignores_thread_name_binding`, and both tests passed.
- Ran the singular exact test `test_validate_bot_channel_routing_with_provider_channel_keeps_thread_binding` which passed (1 test executed, 0 failed).
- No broader integration or system tests were run as part of this change; only the targeted unit tests described above were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0685085908333b7ac3dd24b60d06b)