### PR TITLE
fix(discord): block natural-language review bypass dismissal

### DIFF
--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -1,8 +1,5 @@
 use super::super::gateway::{DiscordGateway, LiveDiscordTurnContext};
 use super::super::*;
-use super::control_intent::{
-    build_control_intent_system_reminder, detect_natural_language_control_intent,
-};
 use crate::services::memory::{
     RecallRequest, RecallResponse, build_memory_backend, resolve_memory_role_id,
     resolve_memory_session_id,
@@ -987,9 +984,6 @@ pub(in crate::services::discord) async fn handle_text_message(
     }
     if let Some(external_recall) = memory_injection_plan.external_recall_for_context {
         context_chunks.push(external_recall.to_string());
-    }
-    if let Some(control_intent) = detect_natural_language_control_intent(user_text) {
-        context_chunks.push(build_control_intent_system_reminder(&control_intent));
     }
     context_chunks.push(sanitized_input);
     let context_prompt = context_chunks.join("\n\n");

--- a/src/services/discord/turn_bridge/completion_guard.rs
+++ b/src/services/discord/turn_bridge/completion_guard.rs
@@ -98,28 +98,6 @@ fn classify_review_decision_phrase(text: &str) -> Option<&'static str> {
         return Some("dismiss");
     }
 
-    const DISMISS_PHRASES: &[&str] = &[
-        "리뷰 우회",
-        "리뷰 무시",
-        "리뷰 스킵",
-        "직접 머지",
-        "직접 merge",
-        "머지 가능하게",
-        "머지가능하게",
-        "merge 가능하게",
-        "merge가능하게",
-        "기여자가 직접 머지",
-        "contributor can merge",
-        "author can merge",
-        "direct merge",
-    ];
-    if DISMISS_PHRASES
-        .iter()
-        .any(|phrase| normalized.contains(phrase))
-    {
-        return Some("dismiss");
-    }
-
     None
 }
 
@@ -150,7 +128,7 @@ pub(in crate::services::discord) fn extract_review_decision(
         }
         found = Some(candidate);
     }
-    found.or_else(|| classify_review_decision_phrase(tail))
+    found
 }
 
 async fn submit_review_decision_fallback(

--- a/src/services/discord/turn_bridge/tests.rs
+++ b/src/services/discord/turn_bridge/tests.rs
@@ -1006,25 +1006,22 @@ fn review_decision_parser_accepts_keyword_in_tail() {
     );
     assert_eq!(
         extract_review_decision("기여자가 직접 머지 가능하게 처리하겠습니다."),
-        Some("dismiss")
+        None
     );
 }
 
 #[test]
-fn review_decision_parser_accepts_korean_dismiss_synonyms() {
+fn review_decision_parser_rejects_korean_dismiss_synonyms_without_explicit_dismiss() {
     assert_eq!(
         extract_review_decision("결정: 리뷰 우회\n직접 머지로 진행합니다."),
-        Some("dismiss")
+        None
     );
     assert_eq!(
         extract_review_decision("결정: 기여자가 직접 머지\n리뷰는 여기서 닫겠습니다."),
-        Some("dismiss")
+        None
     );
-    assert_eq!(extract_review_decision("결정: 리뷰 스킵"), Some("dismiss"));
-    assert_eq!(
-        extract_review_decision("결정: direct merge"),
-        Some("dismiss")
-    );
+    assert_eq!(extract_review_decision("결정: 리뷰 스킵"), None);
+    assert_eq!(extract_review_decision("결정: direct merge"), None);
 }
 
 #[test]


### PR DESCRIPTION
### Motivation

- Prevent untrusted Discord or echoed model text from injecting a synthetic `review_decision: dismiss` system reminder or from being parsed as an automatic dismiss decision, which allowed bypassing review gates.

### Description

- Stop injecting the control-intent system reminder built from free-form user text by removing the `detect_natural_language_control_intent`/`build_control_intent_system_reminder` insertion from `handle_text_message` in `src/services/discord/router/message_handler.rs`.
- Remove the heuristic mapping of direct-merge/review-bypass phrases to `dismiss` by deleting the dismiss-phrase list from `classify_review_decision_phrase` in `src/services/discord/turn_bridge/completion_guard.rs` and prevent fallback classification of free-form tail text.
- Tighten `extract_review_decision` to only return explicit `accept|dispute|dismiss` matches or explicit `DECISION:`-style markers and not map natural-language bypass phrases to `dismiss`.
- Update unit tests in `src/services/discord/turn_bridge/tests.rs` to assert that direct-merge/review-bypass synonym phrases no longer produce a dismissal decision without an explicit `dismiss` marker.

### Testing

- Ran `cargo test -q review_decision_parser` and the targeted test suite completed successfully (`running 7 tests` -> `test result: ok. 7 passed; 0 failed`).
- All modified unit tests in `src/services/discord/turn_bridge/tests.rs` pass under the updated logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e067dbf7108333ae5ae980da22e338)