### PR TITLE
Prevent YAML owner overwrite from unconfigured Discord bots

### DIFF
--- a/src/services/discord/settings.rs
+++ b/src/services/discord/settings.rs
@@ -1420,6 +1420,35 @@ agents:
     }
 
     #[test]
+    fn test_save_bot_settings_does_not_overwrite_yaml_owner_for_unconfigured_bot() {
+        with_temp_home(|temp_home: &TempDir| {
+            let configured_token = "configured-token";
+            let unconfigured_token = "unconfigured-token";
+            write_agentdesk_yaml(
+                temp_home,
+                &format!(
+                    "server:\n  port: 8791\ndiscord:\n  owner_id: 7\n  bots:\n    command:\n      token: \"{configured_token}\"\n"
+                ),
+            );
+
+            let mut settings = super::super::DiscordBotSettings::default();
+            settings.owner_user_id = Some(42);
+            save_bot_settings(unconfigured_token, &settings);
+
+            let yaml_after = fs::read_to_string(
+                temp_home
+                    .path()
+                    .join(".adk")
+                    .join("config")
+                    .join("agentdesk.yaml"),
+            )
+            .unwrap();
+            assert!(yaml_after.contains("owner_id: 7"));
+            assert!(!yaml_after.contains("owner_id: 42"));
+        });
+    }
+
+    #[test]
     fn test_save_bot_settings_rolls_back_yaml_and_json_when_runtime_write_fails() {
         with_temp_home(|temp_home: &TempDir| {
             struct ResetRuntimeWriteFailureFlag;

--- a/src/services/discord/settings/write.rs
+++ b/src/services/discord/settings/write.rs
@@ -68,12 +68,14 @@ fn persist_bot_auth_to_yaml_checked(
         crate::config::Config::default()
     };
 
-    config.discord.owner_id = settings.owner_user_id;
-
     let Some(bot_name) = super::resolved_config_bot_name(&config, token) else {
-        let rendered = serde_yaml::to_string(&config).map_err(|err| config_io_error(&path, err))?;
-        return write_bytes_atomically(&path, rendered.as_bytes());
+        // Do not mutate YAML for tokens that are not managed by agentdesk.yaml.
+        // This prevents owner imprinting from an unconfigured bot from overwriting
+        // the shared discord.owner_id used by configured bots.
+        return Ok(());
     };
+
+    config.discord.owner_id = settings.owner_user_id;
 
     if let Some(bot) = config.discord.bots.get_mut(&bot_name) {
         bot.provider = Some(settings.provider.as_str().to_string());


### PR DESCRIPTION
### Motivation
- An unconfigured Discord bot (started with a raw token) could imprint the first user as owner and `persist_bot_auth_to_yaml` would unconditionally write `config.discord.owner_id` to `agentdesk.yaml`, enabling a cross-bot owner takeover.

### Description
- Change `persist_bot_auth_to_yaml_checked` in `src/services/discord/settings/write.rs` to return early for tokens that are not mapped to a configured `discord.bots.*` entry, avoiding any YAML mutation for unconfigured tokens.
- Move the `config.discord.owner_id = settings.owner_user_id;` assignment to occur only after the token resolves to a configured bot name so the global owner field is not overwritten by unconfigured bots.
- Add a regression test `test_save_bot_settings_does_not_overwrite_yaml_owner_for_unconfigured_bot` in `src/services/discord/settings.rs` to verify that saving settings for an unconfigured token does not change `discord.owner_id` in `agentdesk.yaml`.

### Testing
- Ran `cargo test -q test_save_bot_settings_does_not_overwrite_yaml_owner_for_unconfigured_bot`, which passed.
- Ran `cargo test -q test_save_bot_settings_rolls_back_yaml_and_json_when_runtime_write_fails`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0607c9a4083338ddc4714853b3034)