### PR TITLE
fix(security): validate worktree provenance before auto-merge operations

### DIFF
--- a/policies/merge-automation.js
+++ b/policies/merge-automation.js
@@ -372,6 +372,49 @@ function resolveTerminalMergeCandidate(cardId, tracking) {
     return null;
   }
 
+  var session = findLatestSessionForWorktree(worktreePath);
+  if (!session) {
+    agentdesk.log.warn(
+      "[merge] Card " + cardId + " terminal merge skipped: untrusted worktree_path (no session match): " +
+      worktreePath
+    );
+    return null;
+  }
+
+  if (
+    card.assigned_agent_id &&
+    session.agent_id &&
+    String(session.agent_id) !== String(card.assigned_agent_id)
+  ) {
+    agentdesk.log.warn(
+      "[merge] Card " + cardId + " terminal merge skipped: worktree owner mismatch (" +
+      session.agent_id + " != " + card.assigned_agent_id + ")"
+    );
+    return null;
+  }
+
+  // Resolve branch from the trusted worktree session path; ignore dispatch-provided
+  // branch values if they disagree.
+  var canonicalBranchResult = agentdesk.exec("git", ["-C", worktreePath, "branch", "--show-current"]);
+  if (
+    !canonicalBranchResult ||
+    canonicalBranchResult.indexOf("ERROR") === 0 ||
+    !canonicalBranchResult.trim()
+  ) {
+    agentdesk.log.warn(
+      "[merge] Card " + cardId + " terminal merge skipped: failed to resolve branch from trusted worktree"
+    );
+    return null;
+  }
+  var canonicalBranch = canonicalBranchResult.trim();
+  if (branch && branch !== canonicalBranch) {
+    agentdesk.log.warn(
+      "[merge] Card " + cardId + " terminal merge: dispatch branch mismatch (" +
+      branch + " -> " + canonicalBranch + "); using canonical branch"
+    );
+  }
+  branch = canonicalBranch;
+
   return {
     card: card,
     repo_id: repoId,


### PR DESCRIPTION
### Motivation
- An auto-merge path used dispatch-provided `worktree_path` and branch data to run `git`/`gh` commands, allowing attacker-controlled dispatch results to drive privileged repository operations.
- The merge flow in `merge-automation` could still be triggered from untrusted dispatch data even though `kanban-rules` no longer contained the direct auto-merge code, so a provenance check was required to close the trust gap.

### Description
- Hardened `resolveTerminalMergeCandidate` in `policies/merge-automation.js` to require that the candidate `worktree_path` maps to a known session by calling `findLatestSessionForWorktree(worktreePath)`. 
- Added an ownership check that skips terminal merge when a card has an `assigned_agent_id` that does not match the session's `agent_id` to prevent cross-agent or arbitrary worktree abuse. 
- Resolved the branch from the trusted worktree using `git -C <worktree_path> branch --show-current` and override any dispatch-provided branch when they disagree, skipping the merge if the branch cannot be determined. 
- The changes preserve the existing merge flow for cases where a trusted session and canonical branch can be resolved while eliminating the ability for untrusted `result` fields to control repo/branch choices. 

### Testing
- Ran `node --check policies/merge-automation.js` to validate the updated policy file syntax and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e05f07dd7083339ed14f7b029a3819)