### PR TITLE
fix(discord): restore unbound channel intake guard before auth

### DIFF
--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -547,9 +547,32 @@ pub(in crate::services::discord) async fn handle_event(
                 );
                 return Ok(());
             }
-            // Allow unbound channels for the owner (direct Claude Code usage).
-            // Only skip channels that are explicitly bound to a different provider.
-            // Unowned channels fall through to normal handling.
+            if !is_dm {
+                match resolve_runtime_channel_binding_status(&ctx.http, effective_channel_id).await
+                {
+                    RuntimeChannelBindingStatus::Owned => {}
+                    RuntimeChannelBindingStatus::Unowned => {
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        tracing::info!(
+                            "  [{ts}] ⏭ BINDING-GUARD: skipping message {} in unbound channel {} (effective {})",
+                            new_message.id,
+                            channel_id,
+                            effective_channel_id
+                        );
+                        return Ok(());
+                    }
+                    RuntimeChannelBindingStatus::Unknown => {
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        tracing::warn!(
+                            "  [{ts}] ⏭ BINDING-GUARD: skipping message {} because channel binding lookup failed for {} (effective {})",
+                            new_message.id,
+                            channel_id,
+                            effective_channel_id
+                        );
+                        return Ok(());
+                    }
+                }
+            }
 
             // #189: Generic DM reply tracking — consume pending entry if present.
             // Consumed DM answers must stop here; falling through into normal


### PR DESCRIPTION
### Motivation
- A recent change allowed messages in unbound guild channels to fall through to the auth path, enabling the first sender to be auto-registered as owner and creating a severe authorization regression. 
- The intent of this change is to reintroduce the intake-level binding guard so unconfigured (unowned) guild channels are skipped before reaching `check_auth`, while preserving DM behavior.

### Description
- Restored a binding guard in `src/services/discord/router/intake_gate.rs` that checks `resolve_runtime_channel_binding_status` for non-DM messages and skips processing for `Unowned` and `Unknown` channels. 
- The guard only runs for non-DM guild channels so DMs remain unaffected. 
- Added informative `tracing::info!`/`tracing::warn!` logs for `Unowned` and `Unknown` outcomes to aid diagnostics. 

### Testing
- Ran `cargo check -q`, which completed successfully. 
- Ran the full test suite with `cargo test -q`, which exposed many pre-existing unrelated test failures in the repository and is therefore not an indication of this change breaking behavior. 
- Ran a focused unit test `cargo test -q should_skip_for_missing_required_mention -- --nocapture`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e05c078d308333abb2e8d3735f5493)