### PR TITLE
fix(discord): prevent reaction-remove owner imprint bypass

### DIFF
--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -240,19 +240,9 @@ async fn handle_reaction_remove(
         return Ok(());
     }
 
-    let (user_name, is_allowed_bot) = {
-        let cached_user = ctx.cache.user(user_id);
-        let user_name = cached_user
-            .as_ref()
-            .map(|user| user.name.clone())
-            .unwrap_or_else(|| format!("user:{}", user_id.get()));
-        let is_allowed_bot = cached_user
-            .as_ref()
-            .map(|user| user.bot && settings_snapshot.allowed_bot_ids.contains(&user_id.get()))
-            .unwrap_or(false);
-        (user_name, is_allowed_bot)
-    };
-    if !is_allowed_bot && !check_auth(user_id, &user_name, &data.shared, &data.token).await {
+    // Reaction-removal controls must never imprint owner state.
+    // Only already-authorized users may trigger queue cancel / turn stop.
+    if !super::super::discord_io::user_is_authorized(&settings_snapshot, user_id.get()) {
         return Ok(());
     }
 


### PR DESCRIPTION
### Motivation
- Reaction-removal handling previously called `check_auth`, which imprints the first caller as `owner_user_id`, allowing an untrusted account to capture owner privileges by removing the control emojis.
- The change aims to block owner imprint via reaction toggles while preserving the ability for already-authorized users to cancel queued turns or stop active turns.

### Description
- Replace the `check_auth` call in `handle_reaction_remove` with a pure authorization gate using `user_is_authorized` on the current `settings_snapshot` so reaction removals cannot register a new owner.
- Add a short comment explaining that reaction-removal controls must never imprint owner state and only already-authorized users may trigger them.
- The fix is narrowly scoped to `src/services/discord/router/intake_gate.rs` and does not alter `check_auth` or owner-imprinting behavior elsewhere.

### Testing
- Attempted to run `cargo test -q classify_removed_control_reaction_only_matches_queue_and_stop_emojis`, but the build/test process did not complete within the session and produced no pass/fail result.
- No other automated tests were executed in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0584ad27483339275bf3d97c54269)