### PR TITLE
Fix unauthenticated hook session agent spoofing

### DIFF
--- a/src/server/routes/dispatched_sessions.rs
+++ b/src/server/routes/dispatched_sessions.rs
@@ -290,9 +290,11 @@ pub async fn hook_session(
                 .and_then(|dispatch_id| load_dispatch_thread_id(&conn, dispatch_id))
         });
 
+    // /api/hook/session is intentionally auth-exempt, so never trust a client-supplied
+    // agent_id from this payload. Resolve ownership from session/channel/dispatch context only.
     let agent_id = resolve_session_agent_id(
         &conn,
-        body.agent_id.as_deref(),
+        None,
         Some(&body.session_key),
         body.name.as_deref(),
         thread_channel_id.as_deref(),
@@ -3047,20 +3049,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn direct_session_accepts_explicit_agent_id_for_namespaced_session_key() {
+    async fn direct_session_ignores_explicit_agent_id_without_other_resolution_context() {
         let db = test_db();
         let engine = test_engine(&db);
         let state = AppState::test_state(db.clone(), engine);
-        let long_channel = "project-skillmanager-extremely-verbose-channel-cdx";
-        let tmux_name = ProviderKind::Codex.build_tmux_session_name(long_channel);
+        let tmux_name = ProviderKind::Codex.build_tmux_session_name(
+            "project-skillmanager-extremely-verbose-channel-cdx",
+        );
         let session_key = format!("codex/hash123/mac-mini:{tmux_name}");
 
         {
             let conn = db.lock().unwrap();
             conn.execute(
                 "INSERT INTO agents (id, name, discord_channel_alt)
-                 VALUES ('project-skillmanager', 'SkillManager', ?1)",
-                [long_channel],
+                 VALUES ('project-spoofed', 'Spoofed Agent', 'spoofed-channel')",
+                [],
             )
             .unwrap();
         }
@@ -3069,7 +3072,7 @@ mod tests {
             State(state),
             Json(HookSessionBody {
                 session_key: session_key.clone(),
-                agent_id: Some("project-skillmanager".to_string()),
+                agent_id: Some("project-spoofed".to_string()),
                 status: Some("working".to_string()),
                 provider: Some("codex".to_string()),
                 session_info: Some("explicit agent".to_string()),
@@ -3094,7 +3097,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(agent_id.as_deref(), Some("project-skillmanager"));
+        assert_eq!(agent_id, None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- The auth-exempt `/api/hook/session` endpoint previously accepted a client-supplied `agent_id` and passed it into session resolution, enabling unauthenticated callers to spoof agent ownership and trigger hooks/auto-queue behavior.

### Description
- Stop trusting the webhook payload `agent_id` by passing `None` to `resolve_session_agent_id` in `hook_session`, forcing resolution from session/channel/dispatch context only.  
- Added an inline comment documenting why the webhook must not trust client-supplied `agent_id`.  
- Updated the regression test to reflect the new behavior by asserting an explicit spoofed `agent_id` is ignored when no other resolution context exists and renamed the test to `direct_session_ignores_explicit_agent_id_without_other_resolution_context`.

### Testing
- Ran the targeted test before and after fixes; the initial change produced a failing assertion, the test was adjusted, and then `cargo test direct_session_ignores_explicit_agent_id_without_other_resolution_context -- --nocapture` succeeded.  
- Verified the test binary ran and the single modified unit test passed (`ok`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e04d9eed3883339b8f03d0bcd0b073)