### PR TITLE
Harden system prompt against task-context injection

### DIFF
--- a/src/services/discord/prompt_builder.rs
+++ b/src/services/discord/prompt_builder.rs
@@ -3,7 +3,6 @@ use super::settings::{
     load_role_prompt, load_shared_prompt, render_peer_agent_guidance,
 };
 use super::*;
-use crate::github::dod::{DodItem, parse_dod_from_body, render_dod_markdown};
 use crate::services::memory::{
     UNBOUND_MEMORY_ROLE_ID, resolve_memento_agent_id, resolve_memento_workspace,
     sanitize_memento_workspace_segment,
@@ -21,8 +20,6 @@ pub(crate) struct CurrentTaskContext<'a> {
     pub(crate) dispatch_context: Option<&'a str>,
     pub(crate) card_title: Option<&'a str>,
     pub(crate) github_issue_url: Option<&'a str>,
-    pub(crate) issue_body: Option<&'a str>,
-    pub(crate) deferred_dod: Option<&'a serde_json::Value>,
 }
 
 fn context_compression_guidance() -> String {
@@ -45,57 +42,6 @@ fn tool_output_efficiency_guidance() -> &'static str {
      - Read: Use offset/limit to read specific sections, not entire large files\n\
      - Grep: Set head_limit, use narrow glob/type filters, avoid broad patterns that match hundreds of lines\n\
      - Prefer targeted queries over exhaustive dumps"
-}
-
-fn strip_dod_section(issue_body: &str) -> Option<String> {
-    let mut lines = Vec::new();
-    let mut in_dod_section = false;
-
-    for line in issue_body.lines() {
-        let trimmed = line.trim();
-        if trimmed.starts_with("## ") {
-            let header = trimmed[3..].trim().to_lowercase();
-            if header == "dod" || header == "definition of done" {
-                in_dod_section = true;
-                continue;
-            }
-            if in_dod_section {
-                in_dod_section = false;
-            }
-        }
-
-        if in_dod_section {
-            continue;
-        }
-
-        lines.push(line);
-    }
-
-    let stripped = lines.join("\n").trim().to_string();
-    (!stripped.is_empty()).then_some(stripped)
-}
-
-fn deferred_dod_items(value: &serde_json::Value) -> Vec<DodItem> {
-    let verified: std::collections::HashSet<String> = value
-        .get("verified")
-        .and_then(|v| v.as_array())
-        .into_iter()
-        .flatten()
-        .filter_map(|item| item.as_str())
-        .map(str::to_string)
-        .collect();
-
-    value
-        .get("items")
-        .and_then(|v| v.as_array())
-        .into_iter()
-        .flatten()
-        .filter_map(|item| item.as_str())
-        .map(|text| DodItem {
-            text: text.to_string(),
-            checked: verified.contains(text),
-        })
-        .collect()
 }
 
 fn parse_dispatch_context(dispatch_context: Option<&str>) -> Option<serde_json::Value> {
@@ -472,24 +418,6 @@ fn render_current_task_section(
         .filter(|s| !s.is_empty())
     {
         sections.push(format!("GitHub URL: {url}"));
-    }
-    if let Some(issue_body) = current_task.issue_body.and_then(strip_dod_section) {
-        sections.push(format!("Issue Body:\n{issue_body}"));
-    }
-
-    let dod_items = current_task
-        .deferred_dod
-        .map(deferred_dod_items)
-        .filter(|items| !items.is_empty())
-        .or_else(|| {
-            current_task
-                .issue_body
-                .map(parse_dod_from_body)
-                .filter(|items| !items.is_empty())
-        });
-
-    if let Some(dod_items) = dod_items {
-        sections.push(format!("DoD:\n{}", render_dod_markdown(&dod_items)));
     }
 
     if let Some(dispatch_context_section) =
@@ -1310,10 +1238,6 @@ mod tests {
 
     #[test]
     fn test_build_system_prompt_appends_current_task_after_queued_turn_rules() {
-        let deferred_dod = serde_json::json!({
-            "items": ["ship tests"],
-            "verified": ["ship tests"]
-        });
         let current_task = CurrentTaskContext {
             dispatch_id: Some("dispatch-570"),
             card_id: Some("card-570"),
@@ -1321,8 +1245,6 @@ mod tests {
             dispatch_context: None,
             card_title: Some("fix: prompt context"),
             github_issue_url: Some("https://github.com/itismyfield/AgentDesk/issues/570"),
-            issue_body: Some("## 배경\n\ncompact에서 사라짐\n\n## DoD\n- [ ] old item"),
-            deferred_dod: Some(&deferred_dod),
         };
         let prompt = build_system_prompt(
             "ctx",
@@ -1350,9 +1272,9 @@ mod tests {
         assert!(prompt.contains("Dispatch Brief:\n[Rework] fix: prompt context"));
         assert!(prompt.contains("GitHub URL: https://github.com/itismyfield/AgentDesk/issues/570"));
         assert!(prompt.contains("Title: fix: prompt context"));
-        assert!(prompt.contains("- [x] ship tests"));
         assert!(prompt.contains("`OUTCOME: noop`"));
-        assert!(!prompt.contains("## DoD"));
+        assert!(!prompt.contains("Issue Body:"));
+        assert!(!prompt.contains("DoD:"));
     }
 
     #[test]
@@ -1383,8 +1305,6 @@ mod tests {
             dispatch_context: Some(&dispatch_context_raw),
             card_title: Some("fix: dispatch message"),
             github_issue_url: None,
-            issue_body: None,
-            deferred_dod: None,
         };
         let prompt = build_system_prompt(
             "ctx",
@@ -1436,8 +1356,6 @@ mod tests {
             dispatch_context: Some(&dispatch_context_raw),
             card_title: Some("refactor: self-contained review decision"),
             github_issue_url: Some("https://github.com/itismyfield/AgentDesk/issues/692"),
-            issue_body: None,
-            deferred_dod: None,
         };
         let binding = RoleBinding {
             role_id: "test-agent".to_string(),

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -1068,8 +1068,6 @@ pub(in crate::services::discord) async fn handle_text_message(
             dispatch_context: info.context.as_deref(),
             card_title: info.card_title.as_deref(),
             github_issue_url: info.github_issue_url.as_deref(),
-            issue_body: info.issue_body.as_deref(),
-            deferred_dod: info.deferred_dod.as_ref(),
         }
     });
     let memento_mcp_available = crate::services::mcp_config::provider_has_memento_mcp(&provider);


### PR DESCRIPTION
### Motivation

- Prevent untrusted GitHub issue text (issue body and deferred DoD) from being injected into the system prompt, which created a prompt-injection vector.
- Preserve useful, non-sensitive metadata (card title and GitHub URL) while removing attacker-controlled content from system-level instructions.

### Description

- Removed `issue_body` and `deferred_dod` fields from `CurrentTaskContext` and deleted the code that extracted/Rendered DoD and issue-body sections in `prompt_builder.rs`.
- Removed import of DoD parsing/rendering helpers and the `strip_dod_section` / `deferred_dod_items` helper logic to ensure no issue text is appended to the system prompt.
- Updated the Discord message handler mapping in `message_handler.rs` so `CurrentTaskContext` only forwards `card_title` and `github_issue_url` into `build_system_prompt`.
- Updated unit test expectations to assert that `Issue Body` and `DoD` content are no longer present in the system prompt while keeping `[Current Task]` placement and metadata intact.

### Testing

- Ran `cargo fmt --check` which completed successfully.
- Ran unit tests covering the prompt builder, including `test_build_system_prompt_appends_current_task_after_queued_turn_rules` and `test_build_system_prompt_omits_current_task_when_context_empty`, and both tests passed.
- Ran targeted `cargo test` for the prompt_builder suite and observed the test binary finish with the above tests passing and no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e04b9d34c483338c5327de8d562ba4)