### PR TITLE
fix(security): require auth token for deploy_phases API

### DIFF
--- a/src/server/routes/auto_queue.rs
+++ b/src/server/routes/auto_queue.rs
@@ -156,6 +156,16 @@ struct DependencyParseResult {
     signals: Vec<String>,
 }
 
+fn deploy_phase_api_enabled(state: &AppState) -> bool {
+    state
+        .config
+        .server
+        .auth_token
+        .as_deref()
+        .map(|token| !token.trim().is_empty())
+        .unwrap_or(false)
+}
+
 fn load_run_ids_with_status(
     conn: &rusqlite::Connection,
     statuses: &[&str],
@@ -4256,6 +4266,20 @@ pub async fn dispatch(
     State(state): State<AppState>,
     Json(body): Json<DispatchBody>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    if body
+        .deploy_phases
+        .as_ref()
+        .is_some_and(|phases| !phases.is_empty())
+        && !deploy_phase_api_enabled(&state)
+    {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({
+                "error": "deploy_phases requires server.auth_token to be configured"
+            })),
+        );
+    }
+
     let force = body.force.unwrap_or(false);
     let requested_entries = match normalize_dispatch_entries(&body) {
         Ok(entries) => entries,
@@ -5250,6 +5274,20 @@ pub async fn update_run(
     Path(id): Path<String>,
     Json(body): Json<UpdateRunBody>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    if body
+        .deploy_phases
+        .as_ref()
+        .is_some_and(|phases| !phases.is_empty())
+        && !deploy_phase_api_enabled(&state)
+    {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({
+                "error": "deploy_phases requires server.auth_token to be configured"
+            })),
+        );
+    }
+
     let conn = match state.db.separate_conn() {
         Ok(c) => c,
         Err(e) => {

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -6167,6 +6167,54 @@ async fn auto_queue_dispatch_prepares_backlog_cards_and_auto_assigns_agent() {
 }
 
 #[tokio::test]
+async fn auto_queue_dispatch_rejects_deploy_phases_when_auth_token_is_not_configured() {
+    crate::pipeline::ensure_loaded();
+    let db = test_db();
+    let engine = test_engine(&db);
+    seed_agent(&db, "project-agentdesk");
+    ensure_auto_queue_tables(&db);
+    seed_auto_queue_card(
+        &db,
+        "card-dq-deploy-phase-reject",
+        7401,
+        "ready",
+        "project-agentdesk",
+    );
+
+    let app = test_api_router(db.clone(), engine, None);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auto-queue/dispatch")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_string(&serde_json::json!({
+                        "repo": "test-repo",
+                        "agent_id": "project-agentdesk",
+                        "groups": [{"issues": [7401]}],
+                        "deploy_phases": [1],
+                        "activate": false
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        json["error"],
+        "deploy_phases requires server.auth_token to be configured"
+    );
+}
+
+#[tokio::test]
 async fn auto_queue_dispatch_rejects_when_live_run_exists_without_force() {
     crate::pipeline::ensure_loaded();
     let db = test_db();
@@ -6610,6 +6658,41 @@ async fn auto_queue_add_run_entry_rejects_non_active_runs() {
             .unwrap_or("")
             .contains("status=cancelled"),
         "inactive runs must be rejected with status details: {json}"
+    );
+}
+
+#[tokio::test]
+async fn auto_queue_update_run_rejects_deploy_phases_when_auth_token_is_not_configured() {
+    let db = test_db();
+    let engine = test_engine(&db);
+    ensure_auto_queue_tables(&db);
+
+    let app = test_api_router(db, engine, None);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri("/auto-queue/runs/run-does-not-matter")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_string(&json!({
+                        "deploy_phases": [2]
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        json["error"],
+        "deploy_phases requires server.auth_token to be configured"
     );
 }
 


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated/default-mode API callers from persisting `deploy_phases` on auto-queue runs, which could later trigger server-side deployment scripts and escalate privileges.

### Description
- Add a helper `deploy_phase_api_enabled` and enforce it in the auto-queue ingress so `deploy_phases` can only be set when `server.auth_token` is configured and non-empty (applied to `POST /api/auto-queue/dispatch` and `PATCH /api/auto-queue/runs/{id}`).
- Return `403 Forbidden` with a clear message when `deploy_phases` is provided but `server.auth_token` is not set.
- Add regression tests that assert both endpoints reject `deploy_phases` when auth token is not configured.
- Files changed: `src/server/routes/auto_queue.rs` and `src/server/routes/routes_tests.rs`.

### Testing
- Ran `cargo fmt --all` to format changes successfully.
- Executed the new route tests (`auto_queue_dispatch_rejects_deploy_phases_when_auth_token_is_not_configured` and `auto_queue_update_run_rejects_deploy_phases_when_auth_token_is_not_configured`) via `cargo test`; both tests passed.
- No other automated tests were modified; existing test suite warnings were unchanged and unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e04cdbf0e88333943de136898a3a46)