### PR TITLE
fix: restore PMD channel auth gate for kanban admin endpoints

### DIFF
--- a/src/server/routes/kanban.rs
+++ b/src/server/routes/kanban.rs
@@ -2180,6 +2180,22 @@ pub(super) fn require_explicit_bearer_token(
         }
     }
 
+    if let Some(expected_channel_id) = config
+        .kanban
+        .manager_channel_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let provided_channel_id = trimmed_header_value(headers, "x-channel-id");
+        if provided_channel_id != Some(expected_channel_id) {
+            return Err((
+                StatusCode::UNAUTHORIZED,
+                Json(json!({"error": format!("{operation} requires PMD channel authorization")})),
+            ));
+        }
+    }
+
     Ok(())
 }
 

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -4217,6 +4217,45 @@ async fn force_transition_succeeds_with_correct_channel() {
 }
 
 #[tokio::test]
+async fn force_transition_rejects_mismatched_channel_when_pmd_channel_is_configured() {
+    let _lock = env_lock();
+    let db = test_db();
+    let engine = test_engine(&db);
+    seed_card_with_status(&db, "card-ft4", "requested");
+
+    let config_dir = tempfile::tempdir().unwrap();
+    let mut config = crate::config::Config::default();
+    config.kanban.manager_channel_id = Some("pmd-chan-123".to_string());
+    let config_path = config_dir.path().join("agentdesk.yaml");
+    crate::config::save_to_path(&config_path, &config).unwrap();
+    let _config_guard = EnvVarGuard::set_path("AGENTDESK_CONFIG", &config_path);
+
+    let app = test_api_router(db, engine, None);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/kanban-cards/card-ft4/force-transition")
+                .header("content-type", "application/json")
+                .header("x-channel-id", "wrong-channel")
+                .body(Body::from(r#"{"status":"done"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        json["error"],
+        "force-transition requires PMD channel authorization"
+    );
+}
+
+#[tokio::test]
 async fn force_transition_to_done_merges_from_live_work_dispatch_and_cleans_it_up() {
     crate::pipeline::ensure_loaded();
     let (repo, _repo_override) = setup_test_repo();


### PR DESCRIPTION
### Motivation
- A recent change removed the PMD `X-Channel-Id` gate from several kanban administrative endpoints, leaving them authenticated only by an optional `server.auth_token` and thus effectively unauthenticated in deployments where `auth_token` is unset.
- The intent is to reinstate the channel-based PMD authorization when a PMD manager channel is configured, while preserving existing bearer-token behavior for deployments that use it.

### Description
- Restored PMD channel verification in the shared auth helper `require_explicit_bearer_token` so that when `config.kanban.manager_channel_id` is set and non-empty, the request must include a matching `X-Channel-Id` header or the call returns `401 Unauthorized` with a descriptive error.
- Kept the existing explicit Bearer token check unchanged so environments using `server.auth_token` continue to require a correct `Authorization: Bearer <token>` header.
- Added a regression test `force_transition_rejects_mismatched_channel_when_pmd_channel_is_configured` that sets `kanban.manager_channel_id` via a temporary config file and asserts `401` and the expected error when `X-Channel-Id` is mismatched.
- Modified files: `src/server/routes/kanban.rs` and `src/server/routes/routes_tests.rs`.

### Testing
- Ran `cargo fmt` to format the changes and it completed successfully.
- Ran the new unit test with `cargo test force_transition_rejects_mismatched_channel_when_pmd_channel_is_configured -- --nocapture`; after adjusting the test to set the config via a temp `AGENTDESK_CONFIG`, the test passed.
- The added test verified that `force-transition` returns `401 Unauthorized` and the expected error string when the configured PMD channel and `X-Channel-Id` header do not match.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e04b37d6648333b6635e94e0626092)