### PR TITLE
Harden dispatch repo resolution against issue description injection

### DIFF
--- a/src/dispatch/dispatch_context.rs
+++ b/src/dispatch/dispatch_context.rs
@@ -20,7 +20,6 @@ struct DispatchExecutionTarget {
 struct CardDispatchInfo {
     issue_number: Option<i64>,
     repo_id: Option<String>,
-    description: Option<String>,
 }
 
 fn execution_target_from_dir(dir: &str) -> Option<DispatchExecutionTarget> {
@@ -164,13 +163,12 @@ fn is_card_scoped_worktree_path(path: &str, branch: Option<&str>) -> bool {
 fn load_card_dispatch_info(db: &Db, card_id: &str) -> Option<CardDispatchInfo> {
     db.separate_conn().ok().and_then(|conn| {
         conn.query_row(
-            "SELECT github_issue_number, repo_id, description FROM kanban_cards WHERE id = ?1",
+            "SELECT github_issue_number, repo_id FROM kanban_cards WHERE id = ?1",
             [card_id],
             |row| {
                 Ok(CardDispatchInfo {
                     issue_number: row.get(0)?,
                     repo_id: row.get(1)?,
-                    description: row.get(2)?,
                 })
             },
         )
@@ -233,50 +231,6 @@ pub(crate) fn inject_review_dispatch_identifiers(
         _ => {}
     }
 }
-
-fn normalize_target_repo_token(raw: &str) -> Option<String> {
-    let trimmed = raw
-        .trim_matches(|ch: char| matches!(ch, '`' | '"' | '\'' | '(' | ')' | '[' | ']' | '{' | '}'))
-        .trim_end_matches(|ch: char| matches!(ch, '.' | ',' | ':' | ';'));
-    if trimmed.is_empty() {
-        return None;
-    }
-    Some(trimmed.to_string())
-}
-
-fn resolve_target_repo_path_candidate(raw: &str) -> Option<String> {
-    let candidate = normalize_target_repo_token(raw)?;
-    if !crate::services::platform::shell::looks_like_explicit_repo_path(&candidate) {
-        return None;
-    }
-    crate::services::platform::shell::resolve_repo_dir_for_target(Some(&candidate))
-        .ok()
-        .flatten()
-}
-
-fn extract_target_repo_from_description(description: &str) -> Option<String> {
-    static RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
-    let labeled = RE.get_or_init(|| {
-        regex::Regex::new(
-            r"(?i)(?:target_repo|target repo|repo_path|repo path|repo dir|external repo(?: path)?)\s*[:=]\s*([^\s]+)",
-        )
-        .expect("target repo description regex must compile")
-    });
-    for caps in labeled.captures_iter(description) {
-        if let Some(resolved) = caps
-            .get(1)
-            .and_then(|value| resolve_target_repo_path_candidate(value.as_str()))
-        {
-            return Some(resolved);
-        }
-    }
-
-    description
-        .split_whitespace()
-        .filter_map(resolve_target_repo_path_candidate)
-        .next()
-}
-
 pub(super) fn resolve_card_target_repo_ref(
     db: &Db,
     card_id: &str,
@@ -298,10 +252,7 @@ pub(super) fn resolve_card_target_repo_ref(
     }
 
     let info = load_card_dispatch_info(db, card_id)?;
-    info.description
-        .as_deref()
-        .and_then(extract_target_repo_from_description)
-        .or(info.repo_id)
+    info.repo_id
 }
 
 fn resolve_card_repo_dir_with_context(

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -2037,7 +2037,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_card_worktree_uses_target_repo_from_card_description() {
+    fn resolve_card_worktree_ignores_target_repo_from_card_description() {
         let default_repo = init_test_repo();
         let default_repo_dir = default_repo.path().to_str().unwrap();
         let _env = DispatchEnvOverride::new(Some(default_repo_dir), None);
@@ -2050,7 +2050,7 @@ mod tests {
             external_repo_dir,
             &["worktree", "add", external_wt_path, "-b", "wt/external-627"],
         );
-        let external_commit = git_commit(external_wt_path, "fix: external target repo (#627)");
+        git_commit(external_wt_path, "fix: external target repo (#627)");
 
         let db = test_db();
         seed_card(&db, "card-desc-target-repo", "ready");
@@ -2062,22 +2062,13 @@ mod tests {
             &format!("target_repo: {}", external_repo_dir),
         );
 
-        let result = resolve_card_worktree(&db, "card-desc-target-repo", None)
-            .unwrap()
-            .expect("external repo worktree should resolve from card description");
-
-        let actual_path = std::fs::canonicalize(&result.0)
-            .unwrap()
-            .to_string_lossy()
-            .into_owned();
-        let expected_path = std::fs::canonicalize(external_wt_path)
-            .unwrap()
-            .to_string_lossy()
-            .into_owned();
-
-        assert_eq!(actual_path, expected_path);
-        assert_eq!(result.1, "wt/external-627");
-        assert_eq!(result.2, external_commit);
+        let err = resolve_card_worktree(&db, "card-desc-target-repo", None)
+            .expect_err("description target_repo must not bypass missing repo mapping");
+        assert!(
+            err.to_string()
+                .contains("No local repo mapping for 'owner/missing'"),
+            "unexpected error: {err:#}"
+        );
     }
 
     #[test]
@@ -2223,7 +2214,7 @@ mod tests {
     }
 
     #[test]
-    fn create_dispatch_injects_target_repo_from_card_description() {
+    fn create_dispatch_rejects_target_repo_from_card_description() {
         let default_repo = init_test_repo();
         let default_repo_dir = default_repo.path().to_str().unwrap();
         let _env = DispatchEnvOverride::new(Some(default_repo_dir), None);
@@ -2236,7 +2227,7 @@ mod tests {
             external_repo_dir,
             &["worktree", "add", external_wt_path, "-b", "wt/target-627"],
         );
-        let _external_commit = git_commit(external_wt_path, "fix: dispatch target repo (#627)");
+        git_commit(external_wt_path, "fix: dispatch target repo (#627)");
 
         let db = test_db();
         let engine = test_engine(&db);
@@ -2249,7 +2240,7 @@ mod tests {
             &format!("external repo path: {}", external_repo_dir),
         );
 
-        let dispatch = create_dispatch(
+        let err = create_dispatch(
             &db,
             &engine,
             "card-dispatch-target-repo",
@@ -2258,29 +2249,12 @@ mod tests {
             "Implement external repo task",
             &json!({}),
         )
-        .expect("description target_repo should bypass missing repo mapping");
-
-        let ctx = &dispatch["context"];
-        let actual_target_repo = std::fs::canonicalize(ctx["target_repo"].as_str().unwrap())
-            .unwrap()
-            .to_string_lossy()
-            .into_owned();
-        let expected_target_repo = std::fs::canonicalize(external_repo_dir)
-            .unwrap()
-            .to_string_lossy()
-            .into_owned();
-        let actual_worktree = std::fs::canonicalize(ctx["worktree_path"].as_str().unwrap())
-            .unwrap()
-            .to_string_lossy()
-            .into_owned();
-        let expected_worktree = std::fs::canonicalize(external_wt_path)
-            .unwrap()
-            .to_string_lossy()
-            .into_owned();
-
-        assert_eq!(actual_target_repo, expected_target_repo);
-        assert_eq!(actual_worktree, expected_worktree);
-        assert_eq!(ctx["worktree_branch"], "wt/target-627");
+        .expect_err("description target_repo must not bypass missing repo mapping");
+        assert!(
+            err.to_string()
+                .contains("No local repo mapping for 'owner/missing'"),
+            "unexpected error: {err:#}"
+        );
     }
 
     #[test]
@@ -2817,7 +2791,7 @@ mod tests {
     }
 
     #[test]
-    fn review_context_accepts_external_work_target_when_card_target_repo_is_known() {
+    fn review_context_accepts_external_work_target_when_target_repo_is_in_context() {
         let db = test_db();
         seed_card(&db, "card-review-external-accept", "review");
         set_card_issue_number(&db, "card-review-external-accept", 627);
@@ -2831,12 +2805,6 @@ mod tests {
         let external_dir = external_repo.path().to_str().unwrap();
         run_git(external_dir, &["checkout", "-b", "codex/627-target-repo"]);
         let external_commit = git_commit(external_dir, "fix: cross repo review target (#627)");
-        set_card_description(
-            &db,
-            "card-review-external-accept",
-            &format!("target_repo: {}", external_dir),
-        );
-
         let conn = db.separate_conn().unwrap();
         conn.execute(
             "INSERT INTO task_dispatches (
@@ -2859,8 +2827,13 @@ mod tests {
         drop(conn);
 
         let context =
-            build_review_context(&db, "card-review-external-accept", "agent-1", &json!({}))
-                .unwrap();
+            build_review_context(
+                &db,
+                "card-review-external-accept",
+                "agent-1",
+                &json!({ "target_repo": external_dir }),
+            )
+            .unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&context).unwrap();
         let actual_worktree = std::fs::canonicalize(parsed["worktree_path"].as_str().unwrap())
             .unwrap()


### PR DESCRIPTION
### Motivation

- Prevent attacker-controlled GitHub issue bodies (synced into kanban card descriptions) from steering dispatch/review flows to arbitrary local git worktrees.  
- Close the trust-boundary bypass where description-derived paths could bypass configured `github.repo_dirs` mappings.  

### Description

- Removed description-derived `target_repo` extraction and resolution from dispatch path selection by deleting the description parsing helpers and no longer reading `description` from `kanban_cards`.  
- Restricted `resolve_card_target_repo_ref` to only trust explicit, authenticated overrides present in the dispatch `context` (e.g., `target_repo` or `worktree_path`) and then fall back to the card's stored `repo_id`.  
- Updated tests to assert that description-embedded repo path tokens are ignored and no longer bypass missing repo mappings, and adjusted the review test to provide a trusted `target_repo` via the dispatch context.  
- Key files changed: `src/dispatch/dispatch_context.rs` and `src/dispatch/mod.rs`.

### Testing

- Ran the targeted unit tests `resolve_card_worktree_ignores_target_repo_from_card_description`, `create_dispatch_rejects_target_repo_from_card_description`, and `review_context_accepts_external_work_target_when_target_repo_is_in_context` with `cargo test --locked`, and each test passed.  
- The crate compiled and the focused unit tests completed successfully (warnings only); the updated tests validated that description-derived repo tokens no longer influence repo/worktree resolution.  
- No other automated test failures were observed while running the focused test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e04972868883339da7d0d72d6c9115)