### PR TITLE
fix(discord): block Discord owner auto-imprint when owner is unset

### DIFF
--- a/src/services/discord/discord_io.rs
+++ b/src/services/discord/discord_io.rs
@@ -3,25 +3,22 @@ use poise::serenity_prelude::{CreateAttachment, CreateMessage};
 
 /// Check if a user is authorized (owner or allowed user)
 /// Returns true if authorized, false if rejected.
-/// On first use, registers the user as owner.
+/// Requires an explicitly configured owner unless allow-all mode is enabled.
 pub(super) async fn check_auth(
     user_id: UserId,
     user_name: &str,
     shared: &Arc<SharedData>,
-    token: &str,
+    _token: &str,
 ) -> bool {
-    let mut settings = shared.settings.write().await;
+    let settings = shared.settings.write().await;
     match settings.owner_user_id {
         None => {
-            // Imprint: register first user as owner
-            settings.owner_user_id = Some(user_id.get());
-            save_bot_settings(token, &settings);
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::info!(
-                "  [{ts}] ★ Owner registered: {user_name} (id:{})",
+                "  [{ts}] ✗ Rejected: {user_name} (id:{}) — owner_user_id is not configured",
                 user_id.get()
             );
-            true
+            false
         }
         Some(_) => {
             let uid = user_id.get();

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -318,7 +318,7 @@ pub(super) struct DiscordBotSettings {
     pub(super) require_mention_channel_ids: Vec<u64>,
     /// channel_id (string) → persisted model override
     pub(super) channel_model_overrides: std::collections::HashMap<String, String>,
-    /// Discord user ID of the registered owner (imprinting auth)
+    /// Discord user ID of the registered owner (must be configured explicitly)
     pub(super) owner_user_id: Option<u64>,
     /// Additional authorized user IDs (added by owner via /adduser)
     pub(super) allowed_user_ids: Vec<u64>,

--- a/src/services/discord/runtime_bootstrap.rs
+++ b/src/services/discord/runtime_bootstrap.rs
@@ -453,7 +453,9 @@ pub(crate) async fn run_bot(token: &str, provider: ProviderKind, context: RunBot
 
     match bot_settings.owner_user_id {
         Some(owner_id) => tracing::info!("  ✓ Owner: {owner_id}"),
-        None => tracing::info!("  ⚠ No owner registered — first user will be registered as owner"),
+        None => tracing::info!(
+            "  ⚠ No owner registered — configure discord.owner_id (or allow_all_users) before use"
+        ),
     }
 
     let initial_skills = scan_skills(&provider, None);

--- a/src/services/discord/shared_state.rs
+++ b/src/services/discord/shared_state.rs
@@ -114,7 +114,7 @@ pub(super) struct DiscordBotSettings {
     pub(super) last_remotes: std::collections::HashMap<String, String>,
     /// channel_id (string) → persisted model override
     pub(super) channel_model_overrides: std::collections::HashMap<String, String>,
-    /// Discord user ID of the registered owner (imprinting auth)
+    /// Discord user ID of the registered owner (must be configured explicitly)
     pub(super) owner_user_id: Option<u64>,
     /// Additional authorized user IDs (added by owner via /adduser)
     pub(super) allowed_user_ids: Vec<u64>,


### PR DESCRIPTION
### Motivation
- The Discord bot previously auto-registered the first user who messaged it as the owner when `owner_user_id` was unset, creating an authentication bypass that could lead to takeover of privileged command paths.
- The intent of this change is to require an explicitly configured owner (or deliberate `allow_all_users` mode) before any user is treated as authorized, removing the unsafe "imprinting" behavior.

### Description
- Removed the first-user owner imprint from `check_auth` in `src/services/discord/discord_io.rs` so the function now rejects requests when `owner_user_id` is `None` and logs a clear rejection message instead of assigning ownership.
- Stopped persisting owner state from the auth path and updated the `token` parameter to `_token`, and simplified the settings lock usage in `check_auth` to avoid unnecessary mutation.
- Updated startup logging in `src/services/discord/runtime_bootstrap.rs` to instruct operators to configure `discord.owner_id` (or enable `allow_all_users`) rather than implying automatic registration will occur.
- Clarified comments for the `owner_user_id` field in `src/services/discord/mod.rs` and `src/services/discord/shared_state.rs` to reflect that the owner must be configured explicitly.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo check -q` which completed successfully (the repository still emits unrelated pre-existing warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e09cd8cbcc83338e54bc6d91d53e13)