### PR TITLE
fix: restrict tokenless onboarding server to loopback

### DIFF
--- a/src/cli/dcserver.rs
+++ b/src/cli/dcserver.rs
@@ -1188,6 +1188,25 @@ pub fn handle_dcserver(token: Option<String>) {
         // Health registry (shared across all providers, passed to axum server)
         let health_registry = std::sync::Arc::new(services::discord::health::HealthRegistry::new());
         health_registry.init_bot_tokens().await;
+        let launch_configs = services::discord::load_discord_bot_launch_configs();
+        let onboarding_mode =
+            should_run_http_only_onboarding(token.as_deref(), launch_configs.len());
+        if onboarding_mode
+            && ad_config
+                .server
+                .auth_token
+                .as_deref()
+                .map(str::is_empty)
+                .unwrap_or(true)
+        {
+            let loopback = config::loopback();
+            if ad_config.server.host != loopback {
+                eprintln!(
+                    "  ⚠ No auth token configured during onboarding; restricting HTTP server to loopback ({loopback})"
+                );
+                ad_config.server.host = loopback;
+            }
+        }
 
         // Initialize SQLite DB — clone handles for Discord bot before moving into HTTP server (#143)
         let mut discord_db: Option<crate::db::Db> = None;
@@ -1311,8 +1330,8 @@ pub fn handle_dcserver(token: Option<String>) {
                 .await;
             }
             None => {
-                let configs = services::discord::load_discord_bot_launch_configs();
-                if should_run_http_only_onboarding(token.as_deref(), configs.len()) {
+                let configs = launch_configs;
+                if onboarding_mode {
                     let settings_display = settings_path
                         .as_deref()
                         .map(|p| p.display().to_string())


### PR DESCRIPTION
### Motivation

- The server previously continued running in HTTP-only onboarding with no Discord tokens, while default config binds to `0.0.0.0` and `auth_token` unset, exposing an unauthenticated API surface; the change intends to close that remote attack surface during tokenless onboarding.

### Description

- Preload Discord launch configs and compute an `onboarding_mode` flag before HTTP startup in `handle_dcserver` and reuse it in the tokenless branch to avoid reloading later.
- When `onboarding_mode` is active and `server.auth_token` is unset or empty, force `ad_config.server.host` to the loopback address from `config::loopback()` and log a warning, preventing remote binding during onboarding.
- Keep onboarding behavior intact (still waits for `/api/health`), only restricting bind address when unauthenticated.
- File changed: `src/cli/dcserver.rs`.

### Testing

- Ran the targeted unit tests in `src/cli/dcserver.rs` for `should_run_http_only_onboarding` using `cargo test` and the focused test invocation, and they completed successfully.
- Ran the repository test run (`cargo test`) which completed without failing tests (warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e071a872388333bbbd21bc2b8d5db9)