### PR TITLE
#698 fix: process phase-gate completion when batch_phase is 0

### DIFF
--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -227,11 +227,25 @@ var autoQueue = {
     var result = {};
     try { result = JSON.parse(dispatch.result || "{}"); } catch (e) { result = {}; }
     var gate = context.phase_gate;
-    if (!gate || !gate.run_id || !gate.batch_phase) {
+    if (!gate || !gate.run_id || gate.batch_phase == null) {
       return;
     }
 
-    var phase = gate.batch_phase || 0;
+    var phase = null;
+    if (typeof gate.batch_phase === "number") {
+      phase = gate.batch_phase;
+    } else if (typeof gate.batch_phase === "string" && gate.batch_phase.trim() !== "") {
+      phase = Number(gate.batch_phase);
+    }
+    if (!Number.isFinite(phase) || Math.floor(phase) !== phase || phase < 0) {
+      autoQueueLog("warn", "Ignoring phase gate completion with invalid batch_phase", {
+        run_id: gate.run_id,
+        dispatch_id: dispatch.id,
+        card_id: dispatch.kanban_card_id,
+        batch_phase: gate.batch_phase
+      });
+      return;
+    }
     var state = loadPhaseGateState(gate.run_id, phase);
     if (!state || !Array.isArray(state.dispatch_ids) || state.dispatch_ids.indexOf(dispatch.id) < 0) {
       return;

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -4444,6 +4444,98 @@ mod tests {
         );
     }
 
+    // #698: phase 0 is the default starting phase per default-pipeline.yaml.
+    // A falsy guard on `gate.batch_phase` (the pre-fix behavior) would ignore
+    // phase-0 gate completions, stranding the run as `paused` forever.
+    #[tokio::test]
+    async fn auto_queue_phase_gate_completes_for_batch_phase_zero() {
+        let db = test_db();
+        let engine = test_engine(&db);
+        seed_agent(&db);
+        ensure_auto_queue_tables(&db);
+        seed_card(&db, "card-phase-zero", "done");
+
+        {
+            let conn = db.lock().unwrap();
+            conn.execute(
+                "INSERT INTO auto_queue_runs (id, repo, agent_id, status, created_at) \
+                 VALUES ('run-phase-zero', 'test/repo', 'agent-1', 'paused', datetime('now'))",
+                [],
+            )
+            .unwrap();
+        }
+
+        let phase_gate_dispatch = dispatch::create_dispatch(
+            &db,
+            &engine,
+            "card-phase-zero",
+            "agent-1",
+            "phase-gate",
+            "[phase-gate P0] Default start",
+            &json!({
+                "auto_queue": true,
+                "sidecar_dispatch": true,
+                "phase_gate": {
+                    "run_id": "run-phase-zero",
+                    "batch_phase": 0,
+                    "next_phase": 1,
+                    "final_phase": false,
+                    "pass_verdict": "phase_gate_passed",
+                    "expected_gate_count": 1
+                }
+            }),
+        )
+        .expect("phase 0 gate dispatch should be created");
+        let phase_gate_dispatch_id = phase_gate_dispatch["id"].as_str().unwrap().to_string();
+        set_phase_gate_state(
+            &db,
+            "run-phase-zero",
+            0,
+            "pending",
+            &[phase_gate_dispatch_id.as_str()],
+            Some(1),
+            false,
+            Some("card-phase-zero"),
+            None,
+            None,
+        );
+
+        assert!(
+            phase_gate_state(&db, "run-phase-zero", 0).is_some(),
+            "seeded phase 0 gate state must exist before completion"
+        );
+
+        let completed = dispatch::complete_dispatch(
+            &db,
+            &engine,
+            &phase_gate_dispatch_id,
+            &json!({
+                "verdict": "phase_gate_passed",
+                "summary": "phase 0 gate approved"
+            }),
+        )
+        .expect("phase 0 gate completion should succeed");
+        assert_eq!(completed["status"], "completed");
+
+        let run_status: String = {
+            let conn = db.lock().unwrap();
+            conn.query_row(
+                "SELECT status FROM auto_queue_runs WHERE id = 'run-phase-zero'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+        assert_ne!(
+            run_status, "paused",
+            "phase 0 gate pass must not leave the run paused (#698)"
+        );
+        assert!(
+            phase_gate_state(&db, "run-phase-zero", 0).is_none(),
+            "phase 0 gate completion must clear the persisted phase gate state (#698)"
+        );
+    }
+
     #[test]
     fn auto_queue_cancel_releases_slots_and_clears_linked_sessions() {
         let db = test_db();


### PR DESCRIPTION
## Summary
- Fix falsy guard in `policies/auto-queue.js` `onDispatchCompleted` that rejected P0 phase-gate completions (`batch_phase === 0` was treated as falsy). Since `default-pipeline.yaml` starts runs at `batch_phase = 0`, every P0 gate completion was silently ignored and the run stayed `paused` forever.
- Replace with explicit `== null` guard and a `typeof`-safe numeric coercion so `batch_phase = 0` is a valid phase.
- Add regression integration test `auto_queue_phase_gate_completes_for_batch_phase_zero` that seeds a phase-0 gate, completes the dispatch with `phase_gate_passed`, and asserts the run is no longer `paused` and the persisted `auto_queue_phase_gates` row is cleared.

## Root cause
```js
// before — phase 0 treated as falsy, returns early
if (!gate || !gate.run_id || !gate.batch_phase) return;

// after
if (!gate || !gate.run_id || gate.batch_phase == null) return;
var phase = typeof gate.batch_phase === "number"
  ? gate.batch_phase
  : Number(gate.batch_phase) || 0;
```

## Test plan
- [x] `cargo check --bin agentdesk --tests` (clean)
- [x] `cargo test --bin agentdesk auto_queue` — 123 passed
- [x] `cargo test --bin agentdesk phase_gate` — 22 passed
- [x] `cargo test --bin agentdesk batch_phase_zero` — 1 passed (new regression)

Closes #698

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>