### PR TITLE
#699 fix: inject phase-gate verdict when all checks pass

### DIFF
--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -263,6 +263,41 @@ var autoQueue = {
     var verdict = result.verdict || result.decision || null;
     var passVerdict = gate.pass_verdict || "phase_gate_passed";
 
+    // #699 fallback: legacy/buggy callers may persist a phase-gate result with
+    // all `checks.*` entries passing but no explicit `verdict`. The server
+    // finalize path now injects the verdict, but this guard handles result
+    // rows stored before the fix shipped. Never infer "pass" when any check
+    // reports fail, and never override an explicit verdict/decision.
+    if (!verdict && result && result.checks && typeof result.checks === "object") {
+      var checkNames = Object.keys(result.checks);
+      if (checkNames.length > 0) {
+        var allPass = true;
+        for (var ci = 0; ci < checkNames.length; ci++) {
+          var entry = result.checks[checkNames[ci]];
+          var entryStatus = null;
+          if (entry && typeof entry === "object") {
+            entryStatus = entry.status || entry.result || null;
+          } else if (typeof entry === "string") {
+            entryStatus = entry;
+          }
+          var normalized = entryStatus ? String(entryStatus).toLowerCase() : null;
+          if (normalized !== "pass" && normalized !== "passed") {
+            allPass = false;
+            break;
+          }
+        }
+        if (allPass) {
+          verdict = passVerdict;
+          autoQueueLog("info", "Inferred phase gate verdict '" + passVerdict + "' for dispatch " + dispatch.id + " (all " + checkNames.length + " checks passed, no explicit verdict)", {
+            run_id: gate.run_id,
+            dispatch_id: dispatch.id,
+            card_id: dispatch.kanban_card_id,
+            batch_phase: phase
+          });
+        }
+      }
+    }
+
     if (verdict !== passVerdict) {
       state.status = "failed";
       state.failed_dispatch_id = dispatch.id;

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -316,12 +316,19 @@ fn complete_dispatch_inner(
 
     validate_dispatch_completion_evidence_on_conn(&conn, dispatch_id, result)?;
 
+    // #699: phase-gate callers occasionally omit `verdict` even when every
+    // declared `checks.*` entry passed. Auto-queue then reads the missing
+    // verdict as failure and pauses the run. Inject `verdict = pass_verdict`
+    // defensively so the run can progress.
+    let result_owned = maybe_inject_phase_gate_verdict(&conn, dispatch_id, result);
+    let result_ref = result_owned.as_ref().unwrap_or(result);
+
     let changed = set_dispatch_status_on_conn(
         &conn,
         dispatch_id,
         "completed",
-        Some(result),
-        result
+        Some(result_ref),
+        result_ref
             .get("completion_source")
             .and_then(|value| value.as_str())
             .unwrap_or("complete_dispatch"),
@@ -435,4 +442,116 @@ fn complete_dispatch_inner(
     }
 
     Ok(dispatch)
+}
+
+/// #699: inject `verdict = context.phase_gate.pass_verdict` into a phase-gate
+/// dispatch result when every declared `checks.*` entry passed but the caller
+/// forgot the explicit verdict field.
+///
+/// Returns `Some(enriched)` only when an injection happened — callers should
+/// fall back to the original `result` otherwise. Never overrides an explicit
+/// verdict/decision (even `"fail"`) and never injects when any check is not
+/// `pass`.
+pub(super) fn maybe_inject_phase_gate_verdict(
+    conn: &rusqlite::Connection,
+    dispatch_id: &str,
+    result: &serde_json::Value,
+) -> Option<serde_json::Value> {
+    // Only act on phase-gate dispatches.
+    let (dispatch_type, context_raw): (Option<String>, Option<String>) = conn
+        .query_row(
+            "SELECT dispatch_type, context FROM task_dispatches WHERE id = ?1",
+            [dispatch_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .ok()?;
+    if dispatch_type.as_deref() != Some("phase-gate") {
+        return None;
+    }
+
+    // Explicit verdict/decision already present — never override, even for
+    // explicit "fail" cases.
+    let has_verdict = result
+        .get("verdict")
+        .and_then(|v| v.as_str())
+        .map(|s| !s.is_empty())
+        .unwrap_or(false);
+    let has_decision = result
+        .get("decision")
+        .and_then(|v| v.as_str())
+        .map(|s| !s.is_empty())
+        .unwrap_or(false);
+    if has_verdict || has_decision {
+        return None;
+    }
+
+    // Require a `checks` object with at least one entry, and every entry's
+    // `status` (or equivalent) must be "pass".
+    let checks = result.get("checks").and_then(|v| v.as_object())?;
+    if checks.is_empty() {
+        return None;
+    }
+    for (_name, entry) in checks.iter() {
+        if !check_entry_is_pass(entry) {
+            return None;
+        }
+    }
+
+    // Resolve `pass_verdict`: prefer `context.phase_gate.pass_verdict` stored
+    // at dispatch creation; fall back to the system default.
+    let pass_verdict = context_raw
+        .as_deref()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+        .and_then(|ctx| {
+            ctx.get("phase_gate")
+                .and_then(|pg| pg.get("pass_verdict"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        })
+        .unwrap_or_else(|| "phase_gate_passed".to_string());
+
+    let mut enriched = result.clone();
+    if !enriched.is_object() {
+        enriched = serde_json::Value::Object(serde_json::Map::new());
+        if let Some(obj) = enriched.as_object_mut() {
+            if let Some(src) = result.as_object() {
+                for (k, v) in src.iter() {
+                    obj.insert(k.clone(), v.clone());
+                }
+            }
+        }
+    }
+    if let Some(obj) = enriched.as_object_mut() {
+        obj.insert(
+            "verdict".to_string(),
+            serde_json::Value::String(pass_verdict.clone()),
+        );
+        obj.insert(
+            "verdict_inferred".to_string(),
+            serde_json::Value::Bool(true),
+        );
+    }
+
+    tracing::info!(
+        "[dispatch] #699 inferring phase-gate verdict '{}' for dispatch {} (all {} checks passed)",
+        pass_verdict,
+        dispatch_id,
+        checks.len()
+    );
+
+    Some(enriched)
+}
+
+fn check_entry_is_pass(entry: &serde_json::Value) -> bool {
+    // Accept either `{"status": "pass"}` (canonical) or a bare string "pass".
+    if let Some(status) = entry.get("status").and_then(|v| v.as_str()) {
+        return status.eq_ignore_ascii_case("pass") || status.eq_ignore_ascii_case("passed");
+    }
+    if let Some(outcome) = entry.get("result").and_then(|v| v.as_str()) {
+        return outcome.eq_ignore_ascii_case("pass") || outcome.eq_ignore_ascii_case("passed");
+    }
+    if let Some(s) = entry.as_str() {
+        return s.eq_ignore_ascii_case("pass") || s.eq_ignore_ascii_case("passed");
+    }
+    false
 }

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -1683,6 +1683,159 @@ mod tests {
         assert_eq!(completed["result"]["auto_completed"], true);
     }
 
+    // #699 — phase-gate completion with all checks passing but no explicit
+    // `verdict` must inject `verdict = context.phase_gate.pass_verdict` into
+    // the persisted result so auto-queue does not pause the run.
+    #[test]
+    fn finalize_phase_gate_injects_verdict_when_all_checks_pass() {
+        let db = test_db();
+        let engine = test_engine(&db);
+        seed_card(&db, "card-pg-pass", "in_progress");
+
+        let context = json!({
+            "auto_queue": true,
+            "sidecar_dispatch": true,
+            "phase_gate": {
+                "run_id": "run-699",
+                "batch_phase": 1,
+                "next_phase": 2,
+                "final_phase": false,
+                "pass_verdict": "phase_gate_passed",
+                "checks": ["merge_verified", "issue_closed", "build_passed"],
+            }
+        });
+        let dispatch = create_dispatch(
+            &db,
+            &engine,
+            "card-pg-pass",
+            "agent-1",
+            "phase-gate",
+            "Phase gate test",
+            &context,
+        )
+        .unwrap();
+        let dispatch_id = dispatch["id"].as_str().unwrap().to_string();
+
+        // Simulate a caller that produced all-pass checks + summary but
+        // omitted the explicit verdict field entirely.
+        let result = json!({
+            "summary": "Phase gate passed",
+            "checks": {
+                "merge_verified": { "status": "pass" },
+                "issue_closed": { "status": "pass" },
+                "build_passed": { "status": "pass" },
+            }
+        });
+        let completed =
+            finalize_dispatch(&db, &engine, &dispatch_id, "api", Some(&result)).unwrap();
+
+        assert_eq!(completed["status"], "completed");
+        assert_eq!(
+            completed["result"]["verdict"], "phase_gate_passed",
+            "server must inject phase_gate_passed when verdict absent and checks all pass",
+        );
+        assert_eq!(completed["result"]["verdict_inferred"], true);
+    }
+
+    // #699 — never infer pass when any check fails. The verdict must remain
+    // absent so auto-queue can classify the gate as failed.
+    #[test]
+    fn finalize_phase_gate_preserves_absent_verdict_when_check_fails() {
+        let db = test_db();
+        let engine = test_engine(&db);
+        seed_card(&db, "card-pg-fail", "in_progress");
+
+        let context = json!({
+            "auto_queue": true,
+            "sidecar_dispatch": true,
+            "phase_gate": {
+                "run_id": "run-699b",
+                "batch_phase": 1,
+                "pass_verdict": "phase_gate_passed",
+                "checks": ["merge_verified", "issue_closed"],
+            }
+        });
+        let dispatch = create_dispatch(
+            &db,
+            &engine,
+            "card-pg-fail",
+            "agent-1",
+            "phase-gate",
+            "Phase gate test (fail)",
+            &context,
+        )
+        .unwrap();
+        let dispatch_id = dispatch["id"].as_str().unwrap().to_string();
+
+        let result = json!({
+            "checks": {
+                "merge_verified": { "status": "pass" },
+                "issue_closed": { "status": "fail" },
+            }
+        });
+        let completed =
+            finalize_dispatch(&db, &engine, &dispatch_id, "api", Some(&result)).unwrap();
+
+        assert_eq!(completed["status"], "completed");
+        assert!(
+            completed["result"].get("verdict").is_none()
+                || completed["result"]["verdict"].is_null(),
+            "verdict must not be inferred when any check is fail"
+        );
+        assert!(
+            completed["result"].get("verdict_inferred").is_none()
+                || completed["result"]["verdict_inferred"].is_null(),
+            "verdict_inferred flag must not be set on failed checks"
+        );
+    }
+
+    // #699 — explicit verdict="fail" must survive verbatim even when every
+    // check status happens to be "pass" in the same payload.
+    #[test]
+    fn finalize_phase_gate_preserves_explicit_verdict_fail() {
+        let db = test_db();
+        let engine = test_engine(&db);
+        seed_card(&db, "card-pg-explicit", "in_progress");
+
+        let context = json!({
+            "auto_queue": true,
+            "sidecar_dispatch": true,
+            "phase_gate": {
+                "run_id": "run-699c",
+                "batch_phase": 1,
+                "pass_verdict": "phase_gate_passed",
+            }
+        });
+        let dispatch = create_dispatch(
+            &db,
+            &engine,
+            "card-pg-explicit",
+            "agent-1",
+            "phase-gate",
+            "Phase gate test (explicit fail)",
+            &context,
+        )
+        .unwrap();
+        let dispatch_id = dispatch["id"].as_str().unwrap().to_string();
+
+        let result = json!({
+            "verdict": "fail",
+            "summary": "Operator-forced fail",
+            "checks": {
+                "merge_verified": { "status": "pass" },
+            }
+        });
+        let completed =
+            finalize_dispatch(&db, &engine, &dispatch_id, "api", Some(&result)).unwrap();
+
+        assert_eq!(completed["result"]["verdict"], "fail");
+        assert!(
+            completed["result"].get("verdict_inferred").is_none()
+                || completed["result"]["verdict_inferred"].is_null(),
+            "explicit verdict must not be flagged as inferred"
+        );
+    }
+
     #[test]
     fn dispatch_events_capture_dispatched_and_completed_transitions() {
         let db = test_db();


### PR DESCRIPTION
## Summary

- **Server-side (primary)**: `complete_dispatch_inner` now calls a new `maybe_inject_phase_gate_verdict` helper before persisting a phase-gate completion. When `dispatch_type = "phase-gate"`, no explicit `verdict`/`decision` is present, and every `checks.*` entry reports pass, it stamps `verdict = context.phase_gate.pass_verdict` (falling back to `phase_gate_passed`) plus `verdict_inferred: true` on the persisted result. Logged at INFO.
- **Policy fallback**: `policies/auto-queue.js` onDispatchCompleted mirrors the same inference so already-persisted legacy rows still recover.
- **Safety**: never infers `pass` when any check reports fail; never overrides an explicit `verdict` / `decision` (e.g. `verdict: "fail"` is preserved verbatim).

## Problem

`policies/auto-queue.js:249` reads `var verdict = result.verdict || result.decision || null;`. When the phase-gate caller forgot to inject `verdict` but persisted all-pass `checks`, verdict becomes `null !== "phase_gate_passed"`, the gate is judged failed, and the run is paused.

Real-world payload: every `checks.*.status = "pass"`, `summary = "Phase gate passed"`, but `verdict` key absent.

## Test plan

- [x] `cargo check --bin agentdesk --tests` (0 errors)
- [x] `cargo test --bin agentdesk finalize_phase_gate` — 3/3 pass
  - `finalize_phase_gate_injects_verdict_when_all_checks_pass`
  - `finalize_phase_gate_preserves_absent_verdict_when_check_fails`
  - `finalize_phase_gate_preserves_explicit_verdict_fail`
- [x] `cargo test --bin agentdesk dispatch` — 300 passed, 2 ignored
- [x] `node -c policies/auto-queue.js` — JS syntax OK

## Relation to sibling PRs

This is complementary to **#698** (`batch_phase=0` cleanup); both must land for the run to actually resume after a successful phase gate. Scope here is verdict injection only — no other behavior is touched.

Closes #699

Generated with [Claude Code](https://claude.com/claude-code)