### PR TITLE
#685 feat: always require auto-queue phase gates (default phase gate)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -60,7 +60,7 @@
 | `credential` | `src/credential.rs` | 24 |  |
 | `db` | `src/db/mod.rs` | 127 |  |
 | `db::agents` | `src/db/agents.rs` | 539 |  |
-| `db::auto_queue` | `src/db/auto_queue.rs` | 3423 | giant-file |
+| `db::auto_queue` | `src/db/auto_queue.rs` | 3419 | giant-file |
 | `db::cron_history` | `src/db/cron_history.rs` | 74 |  |
 | `db::kanban` | `src/db/kanban.rs` | 162 |  |
 | `db::memento_feedback_stats` | `src/db/memento_feedback_stats.rs` | 255 |  |
@@ -68,10 +68,10 @@
 | `db::session_agent_resolution` | `src/db/session_agent_resolution.rs` | 262 |  |
 | `db::session_transcripts` | `src/db/session_transcripts.rs` | 788 |  |
 | `db::turns` | `src/db/turns.rs` | 451 |  |
-| `dispatch` | `src/dispatch/mod.rs` | 3343 | giant-file |
+| `dispatch` | `src/dispatch/mod.rs` | 3388 | giant-file |
 | `dispatch::dispatch_channel` | `src/dispatch/dispatch_channel.rs` | 23 |  |
 | `dispatch::dispatch_context` | `src/dispatch/dispatch_context.rs` | 1375 | giant-file |
-| `dispatch::dispatch_create` | `src/dispatch/dispatch_create.rs` | 632 |  |
+| `dispatch::dispatch_create` | `src/dispatch/dispatch_create.rs` | 640 |  |
 | `dispatch::dispatch_status` | `src/dispatch/dispatch_status.rs` | 571 |  |
 | `engine` | `src/engine/mod.rs` | 1492 | giant-file |
 | `engine::hooks` | `src/engine/hooks.rs` | 84 |  |
@@ -104,7 +104,7 @@
 | `github::sync` | `src/github/sync.rs` | 496 |  |
 | `github::triage` | `src/github/triage.rs` | 247 |  |
 | `integration_tests::tests::high_risk_recovery` | `src/integration_tests/tests/high_risk_recovery.rs` | 1218 | giant-file |
-| `kanban` | `src/kanban.rs` | 2123 | giant-file |
+| `kanban` | `src/kanban.rs` | 2143 | giant-file |
 | `launch` | `src/launch.rs` | 32 |  |
 | `logging` | `src/logging.rs` | 160 |  |
 | `manual_intervention` | `src/manual_intervention.rs` | 34 |  |

--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -223,7 +223,8 @@ var autoQueue = {
   // ── Authoritative auto-queue continuation (#110, #140) ──────────────
   // This is the SINGLE path for done → next queued item.
   // Rust transition_status() already marks auto_queue_entries as 'done'
-  // before firing OnCardTerminal, so we don't re-mark here.
+  // before firing OnCardTerminal and now defers final run completion here so
+  // single-phase runs can still create a phase gate before they finish.
   // kanban-rules.js does NOT touch auto_queue_entries (removed in #110).
   // #140: Group-aware continuation — dispatches next entry in same group,
   //       and starts new groups when slots become available.

--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -777,15 +777,6 @@ function loadPhaseGateDispatches(dispatchIds) {
   );
 }
 
-function countDistinctBatchPhases(runId) {
-  var rows = agentdesk.db.query(
-    "SELECT COUNT(DISTINCT COALESCE(batch_phase, 0)) as cnt " +
-    "FROM auto_queue_entries WHERE run_id = ?",
-    [runId]
-  );
-  return (rows.length > 0) ? (rows[0].cnt || 0) : 0;
-}
-
 function _isDeployPhase(runId, phase) {
   var rows = agentdesk.db.query(
     "SELECT deploy_phases FROM auto_queue_runs WHERE id = ?",
@@ -801,8 +792,9 @@ function _isDeployPhase(runId, phase) {
 }
 
 function _phaseGateRequired(runId, phase) {
-  if (_isDeployPhase(runId, phase)) return true;
-  return countDistinctBatchPhases(runId) > 1;
+  // General phase gates are always required after a phase completes.
+  // `deploy_phases` only selects the deploy/build gate implementation.
+  return true;
 }
 
 function completeRunAndNotify(runId) {

--- a/src/db/auto_queue.rs
+++ b/src/db/auto_queue.rs
@@ -1824,7 +1824,9 @@ fn maybe_finalize_run_after_terminal_entry(
     run_id: &str,
     new_status: &str,
 ) -> rusqlite::Result<bool> {
-    if new_status == ENTRY_STATUS_DONE && distinct_batch_phase_count(conn, run_id) > 1 {
+    // `done` completion is finalized by the policy-side OnCardTerminal flow so it
+    // can always create or pass through a phase gate, even for single-phase runs.
+    if new_status == ENTRY_STATUS_DONE {
         return Ok(false);
     }
     if run_has_blocking_phase_gate(conn, run_id) {
@@ -1971,17 +1973,6 @@ fn completion_notify_targets_on_conn(
     targets.sort();
     targets.dedup();
     targets
-}
-
-fn distinct_batch_phase_count(conn: &Connection, run_id: &str) -> i64 {
-    conn.query_row(
-        "SELECT COUNT(DISTINCT COALESCE(batch_phase, 0))
-         FROM auto_queue_entries
-         WHERE run_id = ?1",
-        [run_id],
-        |row| row.get::<_, i64>(0),
-    )
-    .unwrap_or(0)
 }
 
 fn record_entry_transition_on_conn(
@@ -2282,7 +2273,7 @@ mod tests {
     }
 
     #[test]
-    fn entry_transition_done_releases_slots_and_completes_run() {
+    fn entry_transition_done_defers_run_completion_until_policy_hook() {
         let conn = setup_conn();
         conn.execute(
             "INSERT INTO auto_queue_entries (
@@ -2333,7 +2324,7 @@ mod tests {
                 |row| row.get(0),
             )
             .expect("run status");
-        assert_eq!(run_status, "completed");
+        assert_eq!(run_status, "active");
 
         let slot_run: Option<String> = conn
             .query_row(
@@ -2342,7 +2333,7 @@ mod tests {
                 |row| row.get(0),
             )
             .expect("slot row");
-        assert!(slot_run.is_none());
+        assert_eq!(slot_run.as_deref(), Some("run-1"));
 
         let audit_rows: i64 = conn
             .query_row(
@@ -2353,16 +2344,13 @@ mod tests {
             .expect("audit count");
         assert_eq!(audit_rows, 2);
 
-        let (target, bot, content): (String, String, String) = conn
-            .query_row(
-                "SELECT target, bot, content FROM message_outbox ORDER BY id DESC LIMIT 1",
-                [],
-                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-            )
-            .expect("completion notify");
-        assert_eq!(target, "channel:123");
-        assert_eq!(bot, "notify");
-        assert!(content.contains("자동큐 완료: repo-1 / run run-1 / 1개"));
+        let outbox_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM message_outbox", [], |row| row.get(0))
+            .expect("outbox count");
+        assert_eq!(
+            outbox_count, 0,
+            "done transition must wait for policy-side completion before notifying"
+        );
     }
 
     #[test]
@@ -3094,7 +3082,7 @@ mod tests {
     }
 
     #[test]
-    fn terminal_transition_rolls_back_when_slot_release_fails() {
+    fn terminal_transition_done_defers_slot_release_failures_until_policy_hook() {
         let conn = setup_conn();
         conn.execute_batch(
             "CREATE TRIGGER fail_slot_release
@@ -3125,15 +3113,14 @@ mod tests {
         )
         .expect("dispatch transition");
 
-        let error = update_entry_status_on_conn(
+        update_entry_status_on_conn(
             &conn,
             "entry-rollback",
             ENTRY_STATUS_DONE,
             "test_done_rollback",
             &EntryStatusUpdateOptions::default(),
         )
-        .expect_err("slot release failure must roll back the terminal transition");
-        assert!(matches!(error, EntryStatusUpdateError::Sql(_)));
+        .expect("done transition should defer slot release until policy hook");
 
         let (status, dispatch_id, completed_at): (String, Option<String>, Option<String>) = conn
             .query_row(
@@ -3144,9 +3131,9 @@ mod tests {
                 |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
             )
             .expect("entry row");
-        assert_eq!(status, ENTRY_STATUS_DISPATCHED);
+        assert_eq!(status, ENTRY_STATUS_DONE);
         assert_eq!(dispatch_id.as_deref(), Some("dispatch-rollback"));
-        assert!(completed_at.is_none());
+        assert!(completed_at.is_some());
 
         let run_status: String = conn
             .query_row(
@@ -3157,6 +3144,15 @@ mod tests {
             .expect("run status");
         assert_eq!(run_status, "active");
 
+        let slot_run: Option<String> = conn
+            .query_row(
+                "SELECT assigned_run_id FROM auto_queue_slots WHERE agent_id = 'agent-1' AND slot_index = 0",
+                [],
+                |row| row.get(0),
+            )
+            .expect("slot row");
+        assert_eq!(slot_run.as_deref(), Some("run-1"));
+
         let audit_rows: i64 = conn
             .query_row(
                 "SELECT COUNT(*) FROM auto_queue_entry_transitions WHERE entry_id = 'entry-rollback'",
@@ -3165,8 +3161,8 @@ mod tests {
             )
             .expect("audit count");
         assert_eq!(
-            audit_rows, 1,
-            "done transition audit must roll back together"
+            audit_rows, 2,
+            "done transition audit must still be recorded"
         );
     }
 

--- a/src/dispatch/dispatch_create.rs
+++ b/src/dispatch/dispatch_create.rs
@@ -245,10 +245,18 @@ fn create_dispatch_core_internal(
         )?
     } else {
         let mut base = serde_json::to_string(&context_with_session_strategy)?;
+        let phase_gate_sidecar = context_with_session_strategy
+            .get("phase_gate")
+            .and_then(|value| value.as_object())
+            .is_some();
         let worktree_target = if let Some((wt_path, wt_branch)) =
             dispatch_context_worktree_target(&context_with_session_strategy)?
         {
             Some((wt_path, wt_branch))
+        } else if phase_gate_sidecar {
+            // Phase-gate sidecars can operate on the recorded gate context alone.
+            // Do not fail dispatch creation just because a repo_dir mapping is absent.
+            None
         } else {
             resolve_card_worktree(db, kanban_card_id, Some(&context_with_session_strategy))?
                 .map(|(wt_path, wt_branch, _)| (wt_path, Some(wt_branch)))

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -1135,6 +1135,51 @@ mod tests {
     }
 
     #[test]
+    fn create_sidecar_phase_gate_skips_repo_lookup_without_explicit_worktree() {
+        let db = test_db();
+        let engine = test_engine(&db);
+        seed_card(&db, "card-phase-gate-repo", "done");
+        set_card_issue_number(&db, "card-phase-gate-repo", 685);
+        set_card_repo_id(&db, "card-phase-gate-repo", "test/repo");
+
+        let dispatch = create_dispatch(
+            &db,
+            &engine,
+            "card-phase-gate-repo",
+            "agent-1",
+            "phase-gate",
+            "Phase Gate Repo",
+            &json!({
+                "phase_gate": {
+                    "run_id": "run-sidecar-repo",
+                    "batch_phase": 0,
+                    "pass_verdict": "phase_gate_passed"
+                }
+            }),
+        )
+        .expect("phase gate sidecar should not require repo_dirs mapping");
+
+        let dispatch_id = dispatch["id"].as_str().unwrap().to_string();
+        let conn = db.separate_conn().unwrap();
+        let context: String = conn
+            .query_row(
+                "SELECT context FROM task_dispatches WHERE id = ?1",
+                [&dispatch_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let context_json: serde_json::Value = serde_json::from_str(&context).unwrap();
+        assert!(
+            context_json.get("worktree_path").is_none(),
+            "phase gate sidecar should not synthesize a repo-derived worktree path"
+        );
+        assert_eq!(
+            context_json["phase_gate"]["run_id"], "run-sidecar-repo",
+            "phase gate payload must remain intact"
+        );
+    }
+
+    #[test]
     fn create_dispatch_core_shares_invariants_with_create_dispatch() {
         let db = test_db();
         let engine = test_engine(&db);

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -2663,7 +2663,8 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn scenario_6c_review_verdict_pass_closes_issue_and_completes_auto_queue_run() {
+    async fn scenario_6c_review_verdict_pass_closes_issue_and_creates_phase_gate_for_single_phase_run()
+     {
         let gh = install_mock_gh(&[MockGhReply {
             key: "issue:close",
             contains: Some("--repo test/repo"),
@@ -2741,6 +2742,16 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
+        let phase_gate_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM task_dispatches \
+                 WHERE kanban_card_id = 'card-s6c' \
+                   AND dispatch_type = 'phase-gate' \
+                   AND status IN ('pending', 'dispatched')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
         drop(conn);
 
         assert_eq!(card_status, "done");
@@ -2748,10 +2759,20 @@ mod tests {
             entry_status, "done",
             "pass verdict terminal transition must close the active auto-queue entry"
         );
+        let phase_gate_json =
+            phase_gate_state(&db, "run-s6c", 0).expect("single-phase run must persist gate state");
         assert_eq!(
-            run_status, "completed",
-            "pass verdict terminal transition must still fire OnCardTerminal auto-queue completion"
+            run_status, "paused",
+            "pass verdict terminal transition must pause for a single-phase gate"
         );
+        assert_eq!(
+            phase_gate_count, 1,
+            "pass verdict terminal transition must create a single-phase gate dispatch"
+        );
+        assert_eq!(phase_gate_json["status"], "pending");
+        assert_eq!(phase_gate_json["batch_phase"], 0);
+        assert_eq!(phase_gate_json["next_phase"], serde_json::Value::Null);
+        assert_eq!(phase_gate_json["final_phase"], true);
 
         let log = gh_log(&gh);
         assert!(
@@ -2877,7 +2898,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn scenario_655_noop_review_pass_skips_create_pr_and_closes_issue() {
+    async fn scenario_655_noop_review_pass_skips_create_pr_and_creates_phase_gate() {
         let gh = install_mock_gh(&[MockGhReply {
             key: "issue:close",
             contains: Some("--repo test/repo"),
@@ -3003,6 +3024,16 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
+        let phase_gate_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM task_dispatches \
+                 WHERE kanban_card_id = 'card-655-pass' \
+                   AND dispatch_type = 'phase-gate' \
+                   AND status IN ('pending', 'dispatched')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
         drop(conn);
 
         assert_eq!(card_status, "done");
@@ -3014,10 +3045,20 @@ mod tests {
             entry_status, "done",
             "#655: noop verification pass must still close the active auto-queue entry"
         );
+        let phase_gate_json = phase_gate_state(&db, "run-655-pass", 0)
+            .expect("#655: single-phase noop pass must persist gate state");
         assert_eq!(
-            run_status, "completed",
-            "#655: noop verification pass must still complete the auto-queue run via terminal review flow"
+            run_status, "paused",
+            "#655: noop verification pass must pause the run for the single-phase gate"
         );
+        assert_eq!(
+            phase_gate_count, 1,
+            "#655: noop verification pass must create a phase-gate dispatch after review passes"
+        );
+        assert_eq!(phase_gate_json["status"], "pending");
+        assert_eq!(phase_gate_json["batch_phase"], 0);
+        assert_eq!(phase_gate_json["next_phase"], serde_json::Value::Null);
+        assert_eq!(phase_gate_json["final_phase"], true);
 
         let log = gh_log(&gh);
         assert!(
@@ -4211,7 +4252,8 @@ mod tests {
     }
 
     #[test]
-    fn scenario_review_disabled_on_review_enter_closes_issue_and_completes_auto_queue_run() {
+    fn scenario_review_disabled_on_review_enter_closes_issue_and_creates_phase_gate_for_single_phase_run()
+     {
         let gh = install_mock_gh(&[MockGhReply {
             key: "issue:close",
             contains: Some("--repo test/repo"),
@@ -4261,6 +4303,16 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
+        let phase_gate_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM task_dispatches \
+                 WHERE kanban_card_id = 'card-review-disabled-gh' \
+                   AND dispatch_type = 'phase-gate' \
+                   AND status IN ('pending', 'dispatched')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
         let entry_status: String = conn
             .query_row(
                 "SELECT status FROM auto_queue_entries WHERE id = 'entry-review-disabled-gh'",
@@ -4274,10 +4326,20 @@ mod tests {
             entry_status, "done",
             "terminal review-disabled transition must close the active auto-queue entry"
         );
+        let phase_gate_json = phase_gate_state(&db, "run-review-disabled-gh", 0)
+            .expect("single-phase review-disabled run must persist gate state");
         assert_eq!(
-            run_status, "completed",
-            "review-disabled JS terminal path must still fire OnCardTerminal auto-queue completion"
+            run_status, "paused",
+            "review-disabled JS terminal path must pause the run for single-phase gate"
         );
+        assert_eq!(
+            phase_gate_count, 1,
+            "review-disabled single-phase terminal transition must create a phase-gate dispatch"
+        );
+        assert_eq!(phase_gate_json["status"], "pending");
+        assert_eq!(phase_gate_json["batch_phase"], 0);
+        assert_eq!(phase_gate_json["next_phase"], serde_json::Value::Null);
+        assert_eq!(phase_gate_json["final_phase"], true);
 
         let log = gh_log(&gh);
         assert!(

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -4357,6 +4357,75 @@ mod tests {
     }
 
     #[test]
+    fn continue_run_after_entry_creates_phase_gate_for_single_phase_run() {
+        let db = test_db();
+        let engine = test_engine(&db);
+        seed_agent(&db);
+        ensure_auto_queue_tables(&db);
+        seed_card(&db, "card-single-phase-gate", "done");
+
+        {
+            let conn = db.lock().unwrap();
+            conn.execute(
+                "INSERT INTO auto_queue_runs (id, repo, agent_id, status, created_at) \
+                 VALUES ('run-single-phase-gate', 'test/repo', 'agent-1', 'active', datetime('now'))",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO auto_queue_entries (id, run_id, kanban_card_id, agent_id, status, priority_rank, batch_phase, created_at, completed_at) \
+                 VALUES ('entry-single-phase-gate', 'run-single-phase-gate', 'card-single-phase-gate', 'agent-1', 'done', 0, 0, datetime('now'), datetime('now'))",
+                [],
+            )
+            .unwrap();
+        }
+
+        engine
+            .eval_js::<String>(
+                r#"(() => {
+                    continueRunAfterEntry("run-single-phase-gate", "agent-1", 0, 0, "card-single-phase-gate");
+                    return "ok";
+                })()"#,
+            )
+            .expect("single-phase continueRunAfterEntry should evaluate");
+
+        let conn = db.lock().unwrap();
+        let run_status: String = conn
+            .query_row(
+                "SELECT status FROM auto_queue_runs WHERE id = 'run-single-phase-gate'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let phase_gate_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM task_dispatches \
+                 WHERE kanban_card_id = 'card-single-phase-gate' \
+                   AND dispatch_type = 'phase-gate' \
+                   AND status IN ('pending', 'dispatched')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        drop(conn);
+
+        let phase_gate_json = phase_gate_state(&db, "run-single-phase-gate", 0)
+            .expect("phase gate state must exist for single-phase runs");
+        assert_eq!(
+            run_status, "paused",
+            "single-phase completion must pause the run for phase gate"
+        );
+        assert_eq!(
+            phase_gate_count, 1,
+            "single-phase completion must create a phase-gate dispatch"
+        );
+        assert_eq!(phase_gate_json["status"], "pending");
+        assert_eq!(phase_gate_json["batch_phase"], 0);
+        assert_eq!(phase_gate_json["next_phase"], serde_json::Value::Null);
+        assert_eq!(phase_gate_json["final_phase"], true);
+    }
+
+    #[test]
     fn deploy_gate_creation_skips_when_phase_still_has_live_entries() {
         let db = test_db();
         let engine = test_engine(&db);

--- a/src/kanban.rs
+++ b/src/kanban.rs
@@ -1837,7 +1837,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_completion_enqueues_notify_to_main_channel() {
+    async fn run_completion_waits_for_phase_gate_then_enqueues_notify_to_main_channel() {
         let db = test_db();
         ensure_auto_queue_tables(&db);
         let engine = test_engine(&db);
@@ -1878,31 +1878,51 @@ mod tests {
             transition_status_with_opts(&db, &engine, "card-notify", "done", "review", true);
         assert!(result.is_ok(), "transition to done should succeed");
 
-        // onCardTerminal completes the run by calling the authoritative activate API.
-        // In this unit harness no localhost Axum server is listening, so invoke the
-        // route directly before asserting the persisted run status.
-        let state = crate::server::routes::AppState {
-            db: db.clone(),
-            engine: engine.clone(),
-            config: std::sync::Arc::new(crate::config::Config::default()),
-            broadcast_tx: crate::server::ws::new_broadcast(),
-            batch_buffer: crate::server::ws::spawn_batch_flusher(crate::server::ws::new_broadcast()),
-            health_registry: None,
+        let phase_gate_dispatch_id = {
+            let conn = db.lock().unwrap();
+            let run_status: String = conn
+                .query_row(
+                    "SELECT status FROM auto_queue_runs WHERE id = 'run-notify'",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(
+                run_status, "paused",
+                "single-phase terminal completion must pause for a phase gate"
+            );
+
+            let phase_gate_dispatch_id: String = conn
+                .query_row(
+                    "SELECT id FROM task_dispatches
+                     WHERE kanban_card_id = 'card-notify' AND dispatch_type = 'phase-gate'
+                     ORDER BY created_at DESC, id DESC
+                     LIMIT 1",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            let queued_notifications: i64 = conn
+                .query_row("SELECT COUNT(*) FROM message_outbox", [], |row| row.get(0))
+                .unwrap();
+            assert_eq!(
+                queued_notifications, 0,
+                "completion notify must wait for the phase gate to pass"
+            );
+            phase_gate_dispatch_id
         };
-        let (status, body) = crate::server::routes::auto_queue::activate(
-            axum::extract::State(state),
-            axum::Json(crate::server::routes::auto_queue::ActivateBody {
-                run_id: Some("run-notify".to_string()),
-                repo: None,
-                agent_id: None,
-                thread_group: None,
-                unified_thread: None,
-                active_only: Some(true),
+
+        let completed = crate::dispatch::complete_dispatch(
+            &db,
+            &engine,
+            &phase_gate_dispatch_id,
+            &json!({
+                "verdict": "phase_gate_passed",
+                "summary": "phase gate approved"
             }),
         )
-        .await;
-        assert_eq!(status, axum::http::StatusCode::OK);
-        assert_eq!(body.0["count"].as_u64(), Some(0));
+        .expect("phase gate completion should succeed");
+        assert_eq!(completed["status"], "completed");
 
         let conn = db.lock().unwrap();
         let run_status: String = conn


### PR DESCRIPTION
Closes #685

## Summary
- Manual PR created from auto-queue g1 worktree because the automated create-pr step was skipped on review-pass.
- Three commits cherry-picked from `wt/codex-adk-cdx-t1494654377426948288-20260417-200304`:
  - `#685 Always require auto-queue phase gates`
  - `#685 Rework single-phase phase gate dispatch creation`
  - `#685 Fix phase-gate completion notify test`

## Background
Card `56b16016-f9e0-4502-98db-ac137be24a82` passed review at 13:13 JST (Review verdict: pass, R1 핵심 regression 해결, 3개 테스트 paused+phase-gate dispatch 단언 갱신) and transitioned to `done`, but no PR was created. Implementation commits exist locally; this PR promotes them to main.

The codex reviewer's note: "`src/db/auto_queue.rs:1979` `maybe_finalize_run_after_terminal_entry()` was closing single-phase runs to `completed` before JS phase gate path; fix routes all DONE transitions through policy `OnCardTerminal` with paused + phase-gate dispatch. phase-gate sidecar dispatch creation handles missing `repo_dirs` via `dispatch_create.rs` branch + unit test."

## Test plan
- [ ] CI green on cherry-picked branch
- [ ] Integration test: single-phase run flows `done → paused + phase-gate → completed`
- [ ] Regression: multi-phase runs still transition correctly
- [ ] No interference with in-flight auto-queue runs after merge