### PR TITLE
fix(test): extend Windows polling window for auto_queue_activate_concurrent_calls_dispatch_once

### DIFF
--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -2169,7 +2169,7 @@ mod tests {
         let mut dispatch_status: Option<String> = None;
         let mut entry_dispatch_id: Option<String> = None;
 
-        for attempt in 0..20 {
+        for attempt in 0..80 {
             kanban::drain_hook_side_effects(&db, &engine);
 
             let (
@@ -2246,8 +2246,8 @@ mod tests {
                 break;
             }
 
-            if attempt < 19 {
-                std::thread::sleep(std::time::Duration::from_millis(25));
+            if attempt < 79 {
+                std::thread::sleep(std::time::Duration::from_millis(50));
             }
         }
 


### PR DESCRIPTION
## Summary
Pre-existing Windows-only flake in `auto_queue_activate_concurrent_calls_dispatch_once`. SQLite locking + thread scheduling on Windows CI can exceed the 500ms polling budget, failing the final `dispatch_count == 1` assertion before the concurrent activate settles.

Blocks merges of #745, #748 and any PR that triggers a full-matrix rerun.

## Change
Extend polling: 20 attempts × 25ms → 80 attempts × 50ms (4s total). No change to test semantics.

## Test plan
- [ ] CI green on Windows / ubuntu / macOS
- [ ] No regression on fast platforms (total wall time < 4s when assertions converge early, which is the common case)