### PR TITLE
#682 fix: stale review worktree — remove issue-less bypass, exact HEAD match, target_repo injection

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -68,9 +68,9 @@
 | `db::session_agent_resolution` | `src/db/session_agent_resolution.rs` | 262 |  |
 | `db::session_transcripts` | `src/db/session_transcripts.rs` | 788 |  |
 | `db::turns` | `src/db/turns.rs` | 451 |  |
-| `dispatch` | `src/dispatch/mod.rs` | 3390 | giant-file |
+| `dispatch` | `src/dispatch/mod.rs` | 3774 | giant-file |
 | `dispatch::dispatch_channel` | `src/dispatch/dispatch_channel.rs` | 23 |  |
-| `dispatch::dispatch_context` | `src/dispatch/dispatch_context.rs` | 1375 | giant-file |
+| `dispatch::dispatch_context` | `src/dispatch/dispatch_context.rs` | 1486 | giant-file |
 | `dispatch::dispatch_create` | `src/dispatch/dispatch_create.rs` | 695 |  |
 | `dispatch::dispatch_status` | `src/dispatch/dispatch_status.rs` | 571 |  |
 | `engine` | `src/engine/mod.rs` | 1548 | giant-file |

--- a/src/dispatch/dispatch_context.rs
+++ b/src/dispatch/dispatch_context.rs
@@ -342,6 +342,21 @@ fn git_commit_exists(dir: &str, commit_sha: &str) -> bool {
         .is_some_and(|output| output.status.success())
 }
 
+/// #682: Stronger check than git_commit_exists — returns true only when
+/// `commit_sha` is reachable from the worktree's *current* HEAD. Git's
+/// object store is shared across worktrees of the same repo, so
+/// git_commit_exists is satisfied by any commit anywhere in the repo;
+/// that is insufficient when the worktree directory still exists but was
+/// recycled for a different checkout.
+fn worktree_head_reaches_commit(dir: &str, commit_sha: &str) -> bool {
+    std::process::Command::new("git")
+        .args(["merge-base", "--is-ancestor", commit_sha, "HEAD"])
+        .current_dir(dir)
+        .output()
+        .ok()
+        .is_some_and(|output| output.status.success())
+}
+
 fn resolve_review_target_branch(
     db: &Db,
     card_id: &str,
@@ -367,19 +382,30 @@ fn refresh_review_target_worktree(
     context: &serde_json::Value,
     target: &DispatchExecutionTarget,
 ) -> Result<Option<DispatchExecutionTarget>> {
-    if target
-        .worktree_path
-        .as_deref()
-        .is_some_and(|path| std::path::Path::new(path).is_dir())
-    {
-        return Ok(Some(target.clone()));
+    // #682 (Codex review, [medium]): the recorded worktree_path may still
+    // exist as a directory but point at a *different* checkout now (e.g. a
+    // later session recycled the path for another issue). Accept the
+    // recorded path only when the reviewed_commit is reachable from the
+    // worktree's current HEAD; otherwise fall through to recovery.
+    //
+    // git_commit_exists is insufficient here — git's object store is
+    // shared across worktrees of the same repo, so any commit anywhere
+    // in the repo satisfies it. worktree_head_reaches_commit confirms
+    // the reviewed state is actually what is checked out.
+    if let Some(recorded) = target.worktree_path.as_deref() {
+        if std::path::Path::new(recorded).is_dir()
+            && worktree_head_reaches_commit(recorded, &target.reviewed_commit)
+        {
+            return Ok(Some(target.clone()));
+        }
     }
 
     if let Some(stale_path) = target.worktree_path.as_deref() {
         tracing::warn!(
-            "[dispatch] Review dispatch for card {}: latest work target path '{}' no longer exists — attempting fallback",
+            "[dispatch] Review dispatch for card {}: latest work target path '{}' no longer holds commit {} — attempting fallback",
             card_id,
-            stale_path
+            stale_path,
+            &target.reviewed_commit[..8.min(target.reviewed_commit.len())]
         );
     }
 
@@ -416,12 +442,31 @@ fn refresh_review_target_worktree(
         );
     }
 
-    if let Some(repo_dir) = resolve_card_repo_dir_with_context(
-        db,
-        card_id,
-        Some(context),
-        "recover review target repo",
-    )? {
+    // #682 (Codex review, [high]): prefer the explicit target_repo recorded
+    // on the completion before falling back to card-scoped repo resolution.
+    // Issue-less cards that ran against an external repo (recorded as
+    // target_repo on the work dispatch) would otherwise lose the original
+    // repo when their worktree was cleaned up.
+    let fallback_repo_dir = target
+        .target_repo
+        .as_deref()
+        .and_then(|value| {
+            crate::services::platform::shell::resolve_repo_dir_for_target(Some(value))
+                .ok()
+                .flatten()
+        })
+        .or_else(|| {
+            resolve_card_repo_dir_with_context(
+                db,
+                card_id,
+                Some(context),
+                "recover review target repo",
+            )
+            .ok()
+            .flatten()
+        });
+
+    if let Some(repo_dir) = fallback_repo_dir {
         if git_commit_exists(&repo_dir, &target.reviewed_commit) {
             let branch = resolve_review_target_branch(
                 db,

--- a/src/dispatch/dispatch_context.rs
+++ b/src/dispatch/dispatch_context.rs
@@ -498,7 +498,13 @@ fn refresh_review_target_worktree(
         });
 
     if let Some(repo_dir) = fallback_repo_dir {
-        if git_commit_exists(&repo_dir, &target.reviewed_commit) {
+        // #682 (Codex round 3, [high]): require the repo_dir's HEAD to be
+        // exactly reviewed_commit before emitting it as worktree_path. The
+        // shared git object store makes git_commit_exists trivially pass
+        // for any commit anywhere in the repo — but if HEAD is checked out
+        // at something else, the reviewer sees unrelated filesystem state.
+        // Exact HEAD match guarantees the on-disk state is what was reviewed.
+        if worktree_head_matches_commit(&repo_dir, &target.reviewed_commit) {
             let branch = resolve_review_target_branch(
                 db,
                 card_id,
@@ -516,6 +522,31 @@ fn refresh_review_target_worktree(
                 reviewed_commit: target.reviewed_commit.clone(),
                 branch,
                 worktree_path: Some(repo_dir),
+                target_repo: target.target_repo.clone(),
+            }));
+        }
+
+        tracing::warn!(
+            "[dispatch] Review dispatch for card {}: repo_dir '{}' HEAD does not match reviewed commit {} — emitting reviewed_commit without worktree_path",
+            card_id,
+            repo_dir,
+            &target.reviewed_commit[..8.min(target.reviewed_commit.len())]
+        );
+        // We know the commit exists in this repo (cat-file via the earlier
+        // branch); hand back reviewed_commit and let the reviewer inspect
+        // it via git commands, without misleading worktree_path.
+        if git_commit_exists(&repo_dir, &target.reviewed_commit) {
+            let branch = resolve_review_target_branch(
+                db,
+                card_id,
+                &repo_dir,
+                &target.reviewed_commit,
+                target.branch.as_deref(),
+            );
+            return Ok(Some(DispatchExecutionTarget {
+                reviewed_commit: target.reviewed_commit.clone(),
+                branch,
+                worktree_path: None,
                 target_repo: target.target_repo.clone(),
             }));
         }

--- a/src/dispatch/dispatch_context.rs
+++ b/src/dispatch/dispatch_context.rs
@@ -342,19 +342,29 @@ fn git_commit_exists(dir: &str, commit_sha: &str) -> bool {
         .is_some_and(|output| output.status.success())
 }
 
-/// #682: Stronger check than git_commit_exists — returns true only when
-/// `commit_sha` is reachable from the worktree's *current* HEAD. Git's
-/// object store is shared across worktrees of the same repo, so
-/// git_commit_exists is satisfied by any commit anywhere in the repo;
-/// that is insufficient when the worktree directory still exists but was
-/// recycled for a different checkout.
-fn worktree_head_reaches_commit(dir: &str, commit_sha: &str) -> bool {
-    std::process::Command::new("git")
-        .args(["merge-base", "--is-ancestor", commit_sha, "HEAD"])
+/// #682: Exact-HEAD check — returns true only when the worktree's current
+/// HEAD resolves to `commit_sha`. Git's object store is shared across
+/// worktrees of the same repo, so `git cat-file -e` (git_commit_exists)
+/// is satisfied by any commit anywhere in the repo; `merge-base --is-ancestor`
+/// additionally accepts any descendant HEAD, which means a path that was
+/// recycled for follow-up work still passes — but the filesystem state the
+/// reviewer sees is the descendant, not the reviewed commit. Exact HEAD
+/// match is the only way to guarantee the on-disk state matches the
+/// reviewed commit.
+fn worktree_head_matches_commit(dir: &str, commit_sha: &str) -> bool {
+    let Some(output) = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
         .current_dir(dir)
         .output()
         .ok()
-        .is_some_and(|output| output.status.success())
+    else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let head = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    head == commit_sha
 }
 
 fn resolve_review_target_branch(
@@ -394,7 +404,7 @@ fn refresh_review_target_worktree(
     // the reviewed state is actually what is checked out.
     if let Some(recorded) = target.worktree_path.as_deref() {
         if std::path::Path::new(recorded).is_dir()
-            && worktree_head_reaches_commit(recorded, &target.reviewed_commit)
+            && worktree_head_matches_commit(recorded, &target.reviewed_commit)
         {
             return Ok(Some(target.clone()));
         }
@@ -409,10 +419,31 @@ fn refresh_review_target_worktree(
         );
     }
 
+    // #682 (Codex round 2, [high]): resolve_card_worktree picks the repo
+    // from the current card/context, not the historical completion's
+    // target_repo. For an external-repo completion whose card's canonical
+    // repo differs, this would miss the right worktree. Inject target_repo
+    // into a local context copy so resolve_card_worktree's repo lookup
+    // honors the completion's recorded repo before falling back to the
+    // card's default.
+    let resolve_context = if let Some(tr) = target.target_repo.as_deref() {
+        let mut merged = context.clone();
+        if let Some(obj) = merged.as_object_mut() {
+            obj.insert("target_repo".to_string(), json!(tr));
+        }
+        std::borrow::Cow::Owned(merged)
+    } else {
+        std::borrow::Cow::Borrowed(context)
+    };
+
     if let Some((wt_path, wt_branch, _wt_commit)) =
-        resolve_card_worktree(db, card_id, Some(context))?
+        resolve_card_worktree(db, card_id, Some(resolve_context.as_ref()))?
     {
-        if git_commit_exists(&wt_path, &target.reviewed_commit) {
+        // Use the exact-HEAD check here too — a worktree whose HEAD has
+        // advanced past reviewed_commit still satisfies git_commit_exists
+        // via the shared object store, but the files on disk are the
+        // descendant state, not what was reviewed.
+        if worktree_head_matches_commit(&wt_path, &target.reviewed_commit) {
             let branch = resolve_review_target_branch(
                 db,
                 card_id,
@@ -436,7 +467,7 @@ fn refresh_review_target_worktree(
         }
 
         tracing::warn!(
-            "[dispatch] Review dispatch for card {}: active issue worktree does not contain commit {} — skipping path refresh",
+            "[dispatch] Review dispatch for card {}: active issue worktree HEAD does not match reviewed commit {} — skipping path refresh",
             card_id,
             &target.reviewed_commit[..8.min(target.reviewed_commit.len())]
         );

--- a/src/dispatch/dispatch_context.rs
+++ b/src/dispatch/dispatch_context.rs
@@ -925,11 +925,15 @@ pub(super) fn build_review_context(
                     );
                 }
                 if valid {
-                    if card_issue_number.is_none() {
-                        Some(target.clone())
-                    } else {
-                        refresh_review_target_worktree(db, kanban_card_id, &ctx_snapshot, target)?
-                    }
+                    // #682: Always refresh to catch stale worktree_path even for
+                    // issue-less cards. refresh_review_target_worktree tries
+                    // resolve_card_worktree first (needs issue_number — returns
+                    // None here) and falls back to the card's repo_dir when the
+                    // reviewed_commit still lives there. Prior code returned the
+                    // recorded target unchanged when issue_number was None, which
+                    // meant a stale worktree_path propagated into the dispatch
+                    // context and failed `Path::exists()` at review execution.
+                    refresh_review_target_worktree(db, kanban_card_id, &ctx_snapshot, target)?
                 } else {
                     None
                 }

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -2738,6 +2738,63 @@ mod tests {
         assert_eq!(parsed["branch"], "main");
     }
 
+    /// #682: An issue-less card (no github_issue_number) whose completed-work
+    /// dispatch points at a worktree that has since been cleaned up must NOT
+    /// leak the stale path into the review dispatch context. The refresh path
+    /// should fall back to the card's repo_dir when the reviewed commit still
+    /// lives there — matching the behavior already covered for issue-bearing
+    /// cards (see review_context_falls_back_to_repo_dir_when_completed_worktree_was_deleted).
+    ///
+    /// Regression guard for the kunkunGames port (commit bad35a191) which
+    /// bypassed refresh_review_target_worktree for issue-less cards and
+    /// returned the recorded (stale) target unchanged.
+    #[test]
+    fn review_context_refreshes_stale_worktree_for_issueless_card() {
+        let db = test_db();
+        seed_card(&db, "card-review-no-issue", "review");
+        // Deliberately do NOT set_card_issue_number — this is the edge case.
+
+        let (repo, _repo_override) = setup_test_repo();
+        let repo_dir = repo.path().to_str().unwrap();
+        let reviewed_commit = git_commit(repo_dir, "fix: issueless repo fallback (#682)");
+        let stale_wt_path = repo.path().join("wt-682-deleted-no-issue");
+
+        let conn = db.separate_conn().unwrap();
+        conn.execute(
+            "INSERT INTO task_dispatches (
+                id, kanban_card_id, to_agent_id, dispatch_type, status, title, context, result, created_at, updated_at
+             ) VALUES (
+                'dispatch-review-no-issue', 'card-review-no-issue', 'agent-1', 'implementation', 'completed',
+                'Done', ?1, ?2, datetime('now'), datetime('now')
+             )",
+            rusqlite::params![
+                serde_json::json!({}).to_string(),
+                serde_json::json!({
+                    "completed_worktree_path": stale_wt_path,
+                    "completed_branch": "wt/682-deleted-no-issue",
+                    "completed_commit": reviewed_commit.clone(),
+                })
+                .to_string(),
+            ],
+        )
+        .unwrap();
+        drop(conn);
+
+        let context =
+            build_review_context(&db, "card-review-no-issue", "agent-1", &json!({})).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&context).unwrap();
+
+        assert_eq!(parsed["reviewed_commit"], reviewed_commit);
+        // Must NOT be the stale path — refresh should have dropped it in favor
+        // of the repo_dir fallback (where the reviewed_commit lives).
+        assert_ne!(
+            parsed["worktree_path"].as_str(),
+            Some(stale_wt_path.to_str().unwrap()),
+            "issue-less card must not propagate stale worktree_path into review context"
+        );
+        assert_eq!(parsed["worktree_path"], repo_dir);
+    }
+
     #[test]
     fn review_context_includes_merge_base_for_branch_review() {
         let db = test_db();

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -2592,15 +2592,14 @@ mod tests {
         let db = test_db();
         seed_card(&db, "card-review-target", "review");
 
-        let repo_dir = crate::services::platform::resolve_repo_dir()
-            .or_else(|| {
-                std::env::current_dir()
-                    .ok()
-                    .map(|path| path.display().to_string())
-            })
-            .unwrap();
-        let completed_commit = crate::services::platform::git_head_commit(&repo_dir)
-            .unwrap_or_else(|| "ci-detached-head".to_string());
+        // #682: Use a dedicated test repo instead of resolve_repo_dir() to
+        // avoid picking up another test's leaked RepoDirOverride (a tempdir
+        // that may have been dropped, which would fail the new exact-HEAD
+        // check in refresh_review_target_worktree). The test is exercising
+        // the "recorded worktree still exists with matching HEAD" reuse path.
+        let (repo, _repo_override) = setup_test_repo();
+        let repo_dir = repo.path().to_str().unwrap().to_string();
+        let completed_commit = crate::services::platform::git_head_commit(&repo_dir).unwrap();
         let completed_branch = crate::services::platform::shell::git_branch_name(&repo_dir);
 
         let conn = db.separate_conn().unwrap();
@@ -2936,11 +2935,14 @@ mod tests {
         assert_eq!(parsed["worktree_path"], repo_dir);
     }
 
-    /// #682 (Codex round 2, [high]): An issue-bearing card whose recorded
+    /// #682 (Codex round 2+3, [high]): An issue-bearing card whose recorded
     /// target_repo differs from the card's canonical repo must recover its
-    /// worktree via target_repo, not card-scoped repo resolution. The
-    /// historical completion dispatch carries the external target_repo
-    /// that must be honored during refresh.
+    /// worktree via target_repo, not card-scoped repo resolution. This test
+    /// specifically exercises the resolve_card_worktree path (not the
+    /// repo_dir fallback) by creating a LIVE issue worktree in the external
+    /// repo with reviewed_commit as HEAD. If resolve_card_worktree failed
+    /// to honor target_repo, recovery would fall through to the repo_dir
+    /// branch and the worktree-path + HEAD assertions would catch it.
     #[test]
     fn review_context_refreshes_issue_bearing_external_target_repo_stale_worktree() {
         let db = test_db();
@@ -2961,10 +2963,22 @@ mod tests {
             external_repo_dir,
             &["commit", "--allow-empty", "-m", "initial"],
         );
-        let reviewed_commit = git_commit(
+
+        // Live issue worktree in the external repo whose branch name
+        // encodes the issue (685) so find_worktree_for_issue picks it up.
+        let live_wt_dir = external_repo.path().join("wt-685-live");
+        let live_wt_path = live_wt_dir.to_str().unwrap();
+        run_git(
             external_repo_dir,
+            &["worktree", "add", "-b", "wt/685-live", live_wt_path],
+        );
+        let reviewed_commit = git_commit(
+            live_wt_path,
             "fix: external issue target_repo refresh (#685)",
         );
+
+        // Stale (deleted) worktree that the completion dispatch originally
+        // ran on — must NOT be returned.
         let stale_wt_path = external_repo.path().join("wt-685-external-deleted");
 
         let conn = db.separate_conn().unwrap();
@@ -2994,7 +3008,7 @@ mod tests {
 
         assert_eq!(parsed["reviewed_commit"], reviewed_commit);
         let actual_wt = parsed["worktree_path"].as_str().unwrap();
-        let canonical_external = std::fs::canonicalize(external_repo_dir)
+        let canonical_live = std::fs::canonicalize(live_wt_path)
             .unwrap()
             .to_string_lossy()
             .into_owned();
@@ -3003,8 +3017,24 @@ mod tests {
             .to_string_lossy()
             .into_owned();
         assert_eq!(
-            canonical_actual, canonical_external,
-            "issue-bearing external-repo review must honor historical target_repo during refresh"
+            canonical_actual, canonical_live,
+            "issue-bearing external-repo review must resolve to the live issue worktree via target_repo (not the repo root fallback)"
+        );
+        // Verify the returned path actually has reviewed_commit as HEAD —
+        // this is what makes the test bite even if target_repo injection
+        // silently misrouted to repo_dir (repo_dir HEAD is just the
+        // initial empty commit, not reviewed_commit).
+        let head_output = std::process::Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(actual_wt)
+            .output()
+            .unwrap();
+        let head = String::from_utf8_lossy(&head_output.stdout)
+            .trim()
+            .to_string();
+        assert_eq!(
+            head, reviewed_commit,
+            "returned worktree must have reviewed_commit as HEAD"
         );
     }
 
@@ -3061,13 +3091,35 @@ mod tests {
 
         assert_eq!(parsed["reviewed_commit"], reviewed_commit);
         // Recorded path must NOT be reused — HEAD advanced past the reviewed
-        // commit. Fallback should use repo_dir (where the reviewed commit
-        // is also reachable but the filesystem state is under our control).
+        // commit.
         assert_ne!(
             parsed["worktree_path"].as_str(),
             Some(wt_path),
             "recorded worktree with advanced HEAD must be rejected"
         );
+        // #682 (Codex round 3, [high]): when a worktree_path IS emitted, it
+        // must have HEAD==reviewed_commit. Otherwise the reviewer sees the
+        // wrong filesystem state. Acceptable outcomes:
+        //   (a) worktree_path is None (reviewer falls back to default repo)
+        //   (b) worktree_path is a path with HEAD exactly at reviewed_commit
+        // (c) worktree_path is the recorded wt_path — which is the failure
+        //     this test guards against.
+        if let Some(emitted) = parsed["worktree_path"].as_str() {
+            let head_output = std::process::Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(emitted)
+                .output()
+                .unwrap();
+            let head = String::from_utf8_lossy(&head_output.stdout)
+                .trim()
+                .to_string();
+            assert_eq!(
+                head, reviewed_commit,
+                "if worktree_path is emitted after rejecting the recorded path, HEAD must be exactly reviewed_commit (got {} at {})",
+                head, emitted
+            );
+        }
+        _ = repo_dir; // silence unused warning when worktree_path is None
     }
 
     #[test]

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -2795,6 +2795,147 @@ mod tests {
         assert_eq!(parsed["worktree_path"], repo_dir);
     }
 
+    /// #682 (Codex review, [high]): An issue-less card whose completed-work
+    /// dispatch recorded a `target_repo` pointing at an external repo must
+    /// recover via that repo (not the card-scoped default) when its worktree
+    /// is cleaned up. Prior refresh logic consulted only card-scoped repo
+    /// resolution, so issue-less external-repo runs would lose their
+    /// reviewed_commit after stale-worktree cleanup.
+    #[test]
+    fn review_context_refreshes_stale_worktree_for_issueless_card_via_target_repo() {
+        let db = test_db();
+        seed_card(&db, "card-review-no-issue-tr", "review");
+
+        // Two repos: the default (setup_test_repo) repo and a separate
+        // "external" repo that holds the reviewed commit. We deliberately do
+        // NOT commit the reviewed commit into the default repo so that the
+        // card-scoped fallback can't find it — only the target_repo path can.
+        let (_default_repo, _repo_override) = setup_test_repo();
+        let external_repo = tempfile::tempdir().unwrap();
+        let external_repo_dir = external_repo.path().to_str().unwrap();
+        run_git(external_repo_dir, &["init", "-b", "main"]);
+        run_git(
+            external_repo_dir,
+            &["config", "user.email", "test@test.com"],
+        );
+        run_git(external_repo_dir, &["config", "user.name", "Test"]);
+        run_git(
+            external_repo_dir,
+            &["commit", "--allow-empty", "-m", "initial"],
+        );
+        let reviewed_commit =
+            git_commit(external_repo_dir, "fix: external repo review target (#682)");
+        let stale_wt_path = external_repo.path().join("wt-682-external-deleted");
+
+        let conn = db.separate_conn().unwrap();
+        conn.execute(
+            "INSERT INTO task_dispatches (
+                id, kanban_card_id, to_agent_id, dispatch_type, status, title, context, result, created_at, updated_at
+             ) VALUES (
+                'dispatch-review-no-issue-tr', 'card-review-no-issue-tr', 'agent-1', 'implementation', 'completed',
+                'Done', ?1, ?2, datetime('now'), datetime('now')
+             )",
+            rusqlite::params![
+                serde_json::json!({ "target_repo": external_repo_dir }).to_string(),
+                serde_json::json!({
+                    "completed_worktree_path": stale_wt_path,
+                    "completed_branch": "wt/682-external-deleted",
+                    "completed_commit": reviewed_commit.clone(),
+                })
+                .to_string(),
+            ],
+        )
+        .unwrap();
+        drop(conn);
+
+        let context =
+            build_review_context(&db, "card-review-no-issue-tr", "agent-1", &json!({})).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&context).unwrap();
+
+        assert_eq!(parsed["reviewed_commit"], reviewed_commit);
+        // Must resolve via target_repo, not the card-scoped default.
+        // Compare after canonicalization — macOS canonicalizes /var/folders
+        // temp dirs to /private/var/folders.
+        let actual_wt = parsed["worktree_path"].as_str().unwrap();
+        let canonical_external = std::fs::canonicalize(external_repo_dir)
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let canonical_actual = std::fs::canonicalize(actual_wt)
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(canonical_actual, canonical_external);
+    }
+
+    /// #682 (Codex review, [medium]): If the recorded worktree_path still
+    /// exists as a directory but has been recycled for a different checkout
+    /// (so it no longer contains the reviewed_commit), refresh must drop it
+    /// and fall through to recovery. Prior code accepted any existing
+    /// directory without verifying the commit.
+    #[test]
+    fn review_context_drops_recycled_worktree_path_without_reviewed_commit() {
+        let db = test_db();
+        seed_card(&db, "card-review-recycled-wt", "review");
+        set_card_issue_number(&db, "card-review-recycled-wt", 684);
+
+        let (repo, _repo_override) = setup_test_repo();
+        let repo_dir = repo.path().to_str().unwrap();
+
+        // Build the "recycled" worktree path: it exists as a directory but
+        // tracks an unrelated branch (no reviewed_commit reachable from it).
+        let recycled_wt_dir = repo.path().join("wt-684-recycled");
+        let recycled_wt_path = recycled_wt_dir.to_str().unwrap();
+        run_git(
+            repo_dir,
+            &["worktree", "add", "-b", "wt/684-recycled", recycled_wt_path],
+        );
+        let _unrelated_commit = git_commit(recycled_wt_path, "feat: unrelated recycled tree work");
+
+        // The reviewed commit for *our* card only lives on the main repo dir
+        // (not in the recycled worktree's branch).
+        let reviewed_commit = git_commit(
+            repo_dir,
+            "fix: reviewed commit not in recycled worktree (#684)",
+        );
+
+        let conn = db.separate_conn().unwrap();
+        conn.execute(
+            "INSERT INTO task_dispatches (
+                id, kanban_card_id, to_agent_id, dispatch_type, status, title, context, result, created_at, updated_at
+             ) VALUES (
+                'dispatch-review-recycled', 'card-review-recycled-wt', 'agent-1', 'implementation', 'completed',
+                'Done', ?1, ?2, datetime('now'), datetime('now')
+             )",
+            rusqlite::params![
+                serde_json::json!({}).to_string(),
+                serde_json::json!({
+                    "completed_worktree_path": recycled_wt_path,
+                    "completed_branch": "wt/684-obsolete",
+                    "completed_commit": reviewed_commit.clone(),
+                })
+                .to_string(),
+            ],
+        )
+        .unwrap();
+        drop(conn);
+
+        let context =
+            build_review_context(&db, "card-review-recycled-wt", "agent-1", &json!({})).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&context).unwrap();
+
+        assert_eq!(parsed["reviewed_commit"], reviewed_commit);
+        // Must NOT accept the recycled worktree_path — it exists but does
+        // not contain the reviewed_commit.
+        assert_ne!(
+            parsed["worktree_path"].as_str(),
+            Some(recycled_wt_path),
+            "recycled worktree path (exists but missing reviewed_commit) must be dropped"
+        );
+        // Falls back to repo_dir where the reviewed_commit actually lives.
+        assert_eq!(parsed["worktree_path"], repo_dir);
+    }
+
     #[test]
     fn review_context_includes_merge_base_for_branch_review() {
         let db = test_db();

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -2936,6 +2936,140 @@ mod tests {
         assert_eq!(parsed["worktree_path"], repo_dir);
     }
 
+    /// #682 (Codex round 2, [high]): An issue-bearing card whose recorded
+    /// target_repo differs from the card's canonical repo must recover its
+    /// worktree via target_repo, not card-scoped repo resolution. The
+    /// historical completion dispatch carries the external target_repo
+    /// that must be honored during refresh.
+    #[test]
+    fn review_context_refreshes_issue_bearing_external_target_repo_stale_worktree() {
+        let db = test_db();
+        seed_card(&db, "card-review-external-tr", "review");
+        set_card_issue_number(&db, "card-review-external-tr", 685);
+
+        let (_card_default_repo, _repo_override) = setup_test_repo();
+        // Separate external repo — the completion actually ran here.
+        let external_repo = tempfile::tempdir().unwrap();
+        let external_repo_dir = external_repo.path().to_str().unwrap();
+        run_git(external_repo_dir, &["init", "-b", "main"]);
+        run_git(
+            external_repo_dir,
+            &["config", "user.email", "test@test.com"],
+        );
+        run_git(external_repo_dir, &["config", "user.name", "Test"]);
+        run_git(
+            external_repo_dir,
+            &["commit", "--allow-empty", "-m", "initial"],
+        );
+        let reviewed_commit = git_commit(
+            external_repo_dir,
+            "fix: external issue target_repo refresh (#685)",
+        );
+        let stale_wt_path = external_repo.path().join("wt-685-external-deleted");
+
+        let conn = db.separate_conn().unwrap();
+        conn.execute(
+            "INSERT INTO task_dispatches (
+                id, kanban_card_id, to_agent_id, dispatch_type, status, title, context, result, created_at, updated_at
+             ) VALUES (
+                'dispatch-review-external-tr', 'card-review-external-tr', 'agent-1', 'implementation', 'completed',
+                'Done', ?1, ?2, datetime('now'), datetime('now')
+             )",
+            rusqlite::params![
+                serde_json::json!({ "target_repo": external_repo_dir }).to_string(),
+                serde_json::json!({
+                    "completed_worktree_path": stale_wt_path,
+                    "completed_branch": "wt/685-external-deleted",
+                    "completed_commit": reviewed_commit.clone(),
+                })
+                .to_string(),
+            ],
+        )
+        .unwrap();
+        drop(conn);
+
+        let context =
+            build_review_context(&db, "card-review-external-tr", "agent-1", &json!({})).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&context).unwrap();
+
+        assert_eq!(parsed["reviewed_commit"], reviewed_commit);
+        let actual_wt = parsed["worktree_path"].as_str().unwrap();
+        let canonical_external = std::fs::canonicalize(external_repo_dir)
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        let canonical_actual = std::fs::canonicalize(actual_wt)
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(
+            canonical_actual, canonical_external,
+            "issue-bearing external-repo review must honor historical target_repo during refresh"
+        );
+    }
+
+    /// #682 (Codex round 2, [high]): A recorded worktree path that still
+    /// exists but whose HEAD has advanced past reviewed_commit (follow-up
+    /// work on the same branch) must NOT be reused as-is. The reviewer
+    /// would otherwise see the descendant filesystem state, not the
+    /// reviewed state. git_commit_exists and merge-base --is-ancestor both
+    /// accept this case — only exact HEAD match is safe.
+    #[test]
+    fn review_context_rejects_recorded_worktree_with_descendant_head() {
+        let db = test_db();
+        seed_card(&db, "card-review-descendant", "review");
+        set_card_issue_number(&db, "card-review-descendant", 686);
+
+        let (repo, _repo_override) = setup_test_repo();
+        let repo_dir = repo.path().to_str().unwrap();
+
+        let wt_dir = repo.path().join("wt-686-descendant");
+        let wt_path = wt_dir.to_str().unwrap();
+        run_git(
+            repo_dir,
+            &["worktree", "add", "-b", "wt/686-descendant", wt_path],
+        );
+        let reviewed_commit = git_commit(wt_path, "fix: reviewed commit on descendant wt (#686)");
+        // HEAD advances past the reviewed commit — follow-up commit on the
+        // same branch in the same worktree.
+        let _descendant_commit = git_commit(wt_path, "chore: follow-up work beyond reviewed");
+
+        let conn = db.separate_conn().unwrap();
+        conn.execute(
+            "INSERT INTO task_dispatches (
+                id, kanban_card_id, to_agent_id, dispatch_type, status, title, context, result, created_at, updated_at
+             ) VALUES (
+                'dispatch-review-descendant', 'card-review-descendant', 'agent-1', 'implementation', 'completed',
+                'Done', ?1, ?2, datetime('now'), datetime('now')
+             )",
+            rusqlite::params![
+                serde_json::json!({}).to_string(),
+                serde_json::json!({
+                    "completed_worktree_path": wt_path,
+                    "completed_branch": "wt/686-descendant",
+                    "completed_commit": reviewed_commit.clone(),
+                })
+                .to_string(),
+            ],
+        )
+        .unwrap();
+        drop(conn);
+
+        let context =
+            build_review_context(&db, "card-review-descendant", "agent-1", &json!({})).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&context).unwrap();
+
+        assert_eq!(parsed["reviewed_commit"], reviewed_commit);
+        // Recorded path must NOT be reused — HEAD advanced past the reviewed
+        // commit. Fallback should use repo_dir (where the reviewed commit
+        // is also reachable but the filesystem state is under our control).
+        assert_ne!(
+            parsed["worktree_path"].as_str(),
+            Some(wt_path),
+            "recorded worktree with advanced HEAD must be rejected"
+        );
+    }
+
     #[test]
     fn review_context_includes_merge_base_for_branch_review() {
         let db = test_db();


### PR DESCRIPTION
## Summary

Closes #682 — review dispatches failing with "Path X does not exist" when a worktree was cleaned up between completion and review.

The earlier fix (5251a727) added \`refresh_review_target_worktree\` but the kunkunGames port (bad35a191) bypassed it for cards without \`github_issue_number\`, so issue-less cards kept leaking stale paths. This PR removes the bypass and, after 4 rounds of Codex adversarial review, tightens the recovery semantics across 3 correctness dimensions.

## Changes

### Commit 1 — remove the issue-less bypass (primary #682 fix)
- \`build_review_context\` always calls \`refresh_review_target_worktree\`, regardless of \`card_issue_number\`. Issue-less cards with a stale worktree now fall back to repo_dir instead of propagating the stale path.
- +1 regression test: \`review_context_refreshes_stale_worktree_for_issueless_card\`

### Commit 2 — Codex round 1 ([high] target_repo, [medium] recycled dir)
- \`refresh_review_target_worktree\` prefers \`target.target_repo\` via \`resolve_repo_dir_for_target\` before card-scoped resolution. External-repo completions no longer lose their repo context after stale-worktree cleanup.
- Recorded \`worktree_path\` fast-path replaces \`git_commit_exists\` (shared object store ⇒ trivially true) with \`worktree_head_reaches_commit\`. Recycled directories that no longer contain the reviewed commit fall through to recovery.
- +2 tests: \`…_via_target_repo\`, \`…_drops_recycled_worktree_path\`

### Commit 3 — Codex round 2 ([high] exact HEAD, [high] target_repo in worktree recovery)
- Replaced \`merge-base --is-ancestor\` with strict \`git rev-parse HEAD == reviewed_commit\` (\`worktree_head_matches_commit\`). \`is-ancestor\` accepted descendants where HEAD advanced past the reviewed commit; the reviewer would then see the follow-up state, not the reviewed state.
- \`resolve_card_worktree\` is now called with a context that has \`target_repo\` injected from the historical completion, so worktree recovery honors the external target_repo before card-scoped defaults.
- +2 tests: \`…_issue_bearing_external_target_repo_stale_worktree\` (live worktree + HEAD assertion), \`…_rejects_recorded_worktree_with_descendant_head\`

### Commit 4 — Codex round 3 ([high] repo_dir fallback, [medium] test robustness)
- Repo-root fallback also requires exact HEAD match. When HEAD doesn't match but the commit is still in the object store, \`worktree_path\` is emitted as \`None\` (let bootstrap fall back to its default) while \`reviewed_commit\` is preserved.
- Strengthened the round-2 tests to create a live external worktree and assert HEAD equality, so the tests bite even if implementation silently misroutes.
- Fixed flaky pre-existing \`review_context_reuses_latest_completed_work_dispatch_target\` that relied on \`resolve_repo_dir()\` — now uses a dedicated \`setup_test_repo\`.

## Out of scope — filed as follow-ups

Codex round 4 surfaced 2 deeper concerns that exist **before** this PR too (this fix is a strict improvement). Both need dedicated design:

- **#761** — caller-supplied \`reviewed_commit\` / \`worktree_path\` via POST /api/dispatches context bypasses all validation (input-validation at API boundary)
- **#762** — \`target_repo\` doesn't survive the full fallback chain / dispatch bootstrap (when refresh returns None for an external completion, bootstrap can silently land in the card repo)

## Test plan

- [x] All 1719 bin tests pass (\`MEMENTO_ACCESS_KEY\` unset; 2 unrelated tests fail when the var is set — pre-existing pollution from #758 memento default, unrelated)
- [x] 22 \`review_context_*\` tests pass
- [ ] CI: macos/ubuntu/windows + dashboard + lint + script-checks + high-risk recovery

## Codex review trail

4 rounds of \`codex adversarial-review\`, each round's findings addressed in the next commit. The final two findings (repo-root resolve_repo_dir fallback not honoring target_repo, card-scoped silent redirect on refresh failure) are deferred to #761 / #762 because they require changes beyond the build_review_context boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)