### PR TITLE
#750 chore: single-source dispatch lifecycle reactions (announce→command bot)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -68,11 +68,11 @@
 | `db::session_agent_resolution` | `src/db/session_agent_resolution.rs` | 262 |  |
 | `db::session_transcripts` | `src/db/session_transcripts.rs` | 788 |  |
 | `db::turns` | `src/db/turns.rs` | 451 |  |
-| `dispatch` | `src/dispatch/mod.rs` | 3816 | giant-file |
+| `dispatch` | `src/dispatch/mod.rs` | 3908 | giant-file |
 | `dispatch::dispatch_channel` | `src/dispatch/dispatch_channel.rs` | 23 |  |
 | `dispatch::dispatch_context` | `src/dispatch/dispatch_context.rs` | 1533 | giant-file |
 | `dispatch::dispatch_create` | `src/dispatch/dispatch_create.rs` | 695 |  |
-| `dispatch::dispatch_status` | `src/dispatch/dispatch_status.rs` | 571 |  |
+| `dispatch::dispatch_status` | `src/dispatch/dispatch_status.rs` | 608 |  |
 | `engine` | `src/engine/mod.rs` | 1555 | giant-file |
 | `engine::hooks` | `src/engine/hooks.rs` | 84 |  |
 | `engine::intent` | `src/engine/intent.rs` | 812 |  |
@@ -104,7 +104,7 @@
 | `github::dod` | `src/github/dod.rs` | 395 |  |
 | `github::sync` | `src/github/sync.rs` | 496 |  |
 | `github::triage` | `src/github/triage.rs` | 247 |  |
-| `integration_tests::tests::high_risk_recovery` | `src/integration_tests/tests/high_risk_recovery.rs` | 1218 | giant-file |
+| `integration_tests::tests::high_risk_recovery` | `src/integration_tests/tests/high_risk_recovery.rs` | 1189 | giant-file |
 | `kanban` | `src/kanban.rs` | 2143 | giant-file |
 | `launch` | `src/launch.rs` | 32 |  |
 | `logging` | `src/logging.rs` | 160 |  |
@@ -134,8 +134,8 @@
 | `server::routes::dispatched_sessions` | `src/server/routes/dispatched_sessions.rs` | 3357 | giant-file |
 | `server::routes::dispatches` | `src/server/routes/dispatches/mod.rs` | 99 |  |
 | `server::routes::dispatches::crud` | `src/server/routes/dispatches/crud.rs` | 97 |  |
-| `server::routes::dispatches::discord_delivery` | `src/server/routes/dispatches/discord_delivery.rs` | 3898 | giant-file |
-| `server::routes::dispatches::outbox` | `src/server/routes/dispatches/outbox.rs` | 1377 | giant-file |
+| `server::routes::dispatches::discord_delivery` | `src/server/routes/dispatches/discord_delivery.rs` | 3907 | giant-file |
+| `server::routes::dispatches::outbox` | `src/server/routes/dispatches/outbox.rs` | 1386 | giant-file |
 | `server::routes::dispatches::thread_reuse` | `src/server/routes/dispatches/thread_reuse.rs` | 901 |  |
 | `server::routes::dm_reply` | `src/server/routes/dm_reply.rs` | 67 |  |
 | `server::routes::docs` | `src/server/routes/docs.rs` | 2053 | giant-file |
@@ -225,7 +225,7 @@
 | `services::discord::router` | `src/services/discord/router/mod.rs` | 13 |  |
 | `services::discord::router::control_intent` | `src/services/discord/router/control_intent.rs` | 352 |  |
 | `services::discord::router::intake_gate` | `src/services/discord/router/intake_gate.rs` | 1085 | giant-file |
-| `services::discord::router::message_handler` | `src/services/discord/router/message_handler.rs` | 3498 | giant-file |
+| `services::discord::router::message_handler` | `src/services/discord/router/message_handler.rs` | 3508 | giant-file |
 | `services::discord::router::thread_binding` | `src/services/discord/router/thread_binding.rs` | 129 |  |
 | `services::discord::runtime_bootstrap` | `src/services/discord/runtime_bootstrap.rs` | 1346 | giant-file |
 | `services::discord::runtime_store` | `src/services/discord/runtime_store.rs` | 329 |  |

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -63,18 +63,35 @@ pub(crate) fn ensure_dispatch_notify_outbox_on_conn(
 /// Once an older row is already `done` or `failed`, a later transition should
 /// enqueue a fresh row.
 ///
-/// #750: announce bot no longer writes lifecycle emoji reactions — the
-/// command bot's turn-lifecycle emojis are the single source of truth. The
-/// enqueue is preserved as a no-op sink so schema/test harness assumptions
-/// about outbox row counts continue to hold, but no new status_reaction rows
-/// are created. Existing rows in the wild are drained by the outbox worker's
-/// no-op handler.
-#[allow(dead_code)]
+/// #750: announce bot no longer writes ✅ on completed dispatches (command
+/// bot's turn-lifecycle ✅ is the single source of truth for success). The
+/// announce-bot path is preserved ONLY to write ❌ on failed/cancelled
+/// dispatches, because command bot's turn_bridge unconditionally adds ✅ when
+/// a response was delivered (see turn_bridge/mod.rs:1537) — a failed dispatch
+/// that returned any text would otherwise show a false green check. This
+/// enqueue is also the only repair path for status transitions that bypass
+/// turn_bridge entirely (queue/API cancellation, orphan recovery).
 pub(crate) fn ensure_dispatch_status_reaction_outbox_on_conn(
-    _conn: &rusqlite::Connection,
-    _dispatch_id: &str,
+    conn: &rusqlite::Connection,
+    dispatch_id: &str,
 ) -> rusqlite::Result<bool> {
-    Ok(false)
+    let existing: Option<String> = conn
+        .query_row(
+            "SELECT status FROM dispatch_outbox \
+             WHERE dispatch_id = ?1 AND action = 'status_reaction' \
+             ORDER BY id DESC LIMIT 1",
+            [dispatch_id],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if matches!(existing.as_deref(), Some("pending")) {
+        return Ok(false);
+    }
+    conn.execute(
+        "INSERT INTO dispatch_outbox (dispatch_id, action, status) VALUES (?1, 'status_reaction', 'pending')",
+        [dispatch_id],
+    )?;
+    Ok(true)
 }
 
 pub(crate) fn record_dispatch_status_event_on_conn(
@@ -199,10 +216,17 @@ pub(crate) fn set_dispatch_status_on_conn(
                 result,
             )?;
 
-            // #750: status_reaction outbox enqueue removed — announce bot no
-            // longer writes dispatch-lifecycle emoji reactions. The outbox
-            // handler itself is a no-op for pre-existing rows (see
-            // src/server/routes/dispatches/outbox.rs).
+            // #750: only enqueue for failure/cancel transitions.
+            // - 'completed' → skip: command bot's turn_bridge already adds ✅.
+            // - 'failed' / 'cancelled' → enqueue: command bot unconditionally
+            //   adds ✅ if a response was delivered, so failed dispatches that
+            //   returned any text would otherwise show a false green check.
+            //   The announce-bot sync path writes ❌ to correct this, and is
+            //   also the only repair signal for status transitions that bypass
+            //   turn_bridge entirely (queue/API cancellation, orphan recovery).
+            if matches!(to_status, "failed" | "cancelled") {
+                ensure_dispatch_status_reaction_outbox_on_conn(conn, dispatch_id)?;
+            }
         }
         Ok(changed)
     })();

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -62,28 +62,19 @@ pub(crate) fn ensure_dispatch_notify_outbox_on_conn(
 /// Discord side-effect reads the latest dispatch status from `task_dispatches`.
 /// Once an older row is already `done` or `failed`, a later transition should
 /// enqueue a fresh row.
+///
+/// #750: announce bot no longer writes lifecycle emoji reactions — the
+/// command bot's turn-lifecycle emojis are the single source of truth. The
+/// enqueue is preserved as a no-op sink so schema/test harness assumptions
+/// about outbox row counts continue to hold, but no new status_reaction rows
+/// are created. Existing rows in the wild are drained by the outbox worker's
+/// no-op handler.
+#[allow(dead_code)]
 pub(crate) fn ensure_dispatch_status_reaction_outbox_on_conn(
-    conn: &rusqlite::Connection,
-    dispatch_id: &str,
+    _conn: &rusqlite::Connection,
+    _dispatch_id: &str,
 ) -> rusqlite::Result<bool> {
-    let exists: bool = conn.query_row(
-        "SELECT COUNT(*) > 0
-         FROM dispatch_outbox
-         WHERE dispatch_id = ?1
-           AND action = 'status_reaction'
-           AND status IN ('pending', 'processing')",
-        [dispatch_id],
-        |row| row.get(0),
-    )?;
-    if exists {
-        return Ok(false);
-    }
-
-    conn.execute(
-        "INSERT INTO dispatch_outbox (dispatch_id, action) VALUES (?1, 'status_reaction')",
-        [dispatch_id],
-    )?;
-    Ok(true)
+    Ok(false)
 }
 
 pub(crate) fn record_dispatch_status_event_on_conn(
@@ -208,12 +199,10 @@ pub(crate) fn set_dispatch_status_on_conn(
                 result,
             )?;
 
-            if matches!(
-                to_status,
-                "dispatched" | "completed" | "failed" | "cancelled"
-            ) {
-                ensure_dispatch_status_reaction_outbox_on_conn(conn, dispatch_id)?;
-            }
+            // #750: status_reaction outbox enqueue removed — announce bot no
+            // longer writes dispatch-lifecycle emoji reactions. The outbox
+            // handler itself is a no-op for pre-existing rows (see
+            // src/server/routes/dispatches/outbox.rs).
         }
         Ok(changed)
     })();

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -8,6 +8,18 @@ use crate::engine::PolicyEngine;
 use super::dispatch_context::validate_dispatch_completion_evidence_on_conn;
 use super::query_dispatch_row;
 
+/// #750: Sources whose completion path already writes ✅ to the Discord
+/// message via the command bot (turn_bridge / tmux watcher). For those, the
+/// announce-bot sync would only bump the reaction count; skip the enqueue.
+///
+/// Non-live paths (api, recovery_*, supervisor_*, test_*, cli, etc.) bypass
+/// the command bot entirely and need the announce-bot ✅ as the only
+/// terminal-state signal on the original dispatch message.
+fn transition_source_is_live_command_bot(transition_source: &str) -> bool {
+    let src = transition_source.trim();
+    src.starts_with("turn_bridge") || src.starts_with("watcher")
+}
+
 /// Ensure a durable notify outbox row exists for a dispatch.
 ///
 /// Used both by the authoritative dispatch creation transaction and by
@@ -216,15 +228,27 @@ pub(crate) fn set_dispatch_status_on_conn(
                 result,
             )?;
 
-            // #750: only enqueue for failure/cancel transitions.
-            // - 'completed' → skip: command bot's turn_bridge already adds ✅.
-            // - 'failed' / 'cancelled' → enqueue: command bot unconditionally
-            //   adds ✅ if a response was delivered, so failed dispatches that
-            //   returned any text would otherwise show a false green check.
-            //   The announce-bot sync path writes ❌ to correct this, and is
-            //   also the only repair signal for status transitions that bypass
-            //   turn_bridge entirely (queue/API cancellation, orphan recovery).
-            if matches!(to_status, "failed" | "cancelled") {
+            // #750: narrowed enqueue — the announce-bot reaction sync now runs
+            // only when it actually has something to write:
+            // - 'failed' / 'cancelled': always. Command bot's turn_bridge
+            //   unconditionally adds ✅ when a response is delivered, so the
+            //   announce-bot sync has to clean that ✅ and add ❌. Also covers
+            //   queue/API cancellation + orphan recovery which bypass
+            //   turn_bridge entirely.
+            // - 'completed': only when the completion path is NOT the command
+            //   bot's live reaction path. turn_bridge / tmux watcher already
+            //   added ✅ on response delivery; re-adding it via the announce
+            //   bot would just bump the reaction count. For non-live paths
+            //   (api, recovery, supervisor orphan) the announce-bot sync is
+            //   the ONLY source of the terminal ✅.
+            // - pending / dispatched: skipped. Command bot is now the single
+            //   source of ⏳ (see should_add_turn_pending_reaction).
+            let enqueue = match to_status {
+                "failed" | "cancelled" => true,
+                "completed" => !transition_source_is_live_command_bot(transition_source),
+                _ => false,
+            };
+            if enqueue {
                 ensure_dispatch_status_reaction_outbox_on_conn(conn, dispatch_id)?;
             }
         }

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -2077,8 +2077,14 @@ mod tests {
         );
     }
 
+    /// #750: announce bot no longer writes dispatch-lifecycle emoji
+    /// reactions. set_dispatch_status_on_conn previously enqueued a
+    /// status_reaction outbox row on every pending→dispatched / terminal
+    /// transition; that enqueue was removed because the only consumer
+    /// (announce-bot reaction writer) is disabled. Verify the transitions
+    /// still succeed but NO status_reaction row is created.
     #[test]
-    fn dispatch_status_transitions_enqueue_status_reaction_outbox_entries() {
+    fn dispatch_status_transitions_do_not_enqueue_status_reaction_outbox_entries() {
         let db = test_db();
         let engine = test_engine(&db);
         seed_card(&db, "card-reaction-outbox", "ready");
@@ -2110,15 +2116,7 @@ mod tests {
         }
 
         let conn = db.separate_conn().unwrap();
-        assert_eq!(count_status_reaction_outbox(&conn, &dispatch_id), 1);
-
-        conn.execute(
-            "UPDATE dispatch_outbox
-             SET status = 'done', processed_at = datetime('now')
-             WHERE dispatch_id = ?1 AND action = 'status_reaction'",
-            [&dispatch_id],
-        )
-        .unwrap();
+        assert_eq!(count_status_reaction_outbox(&conn, &dispatch_id), 0);
 
         set_dispatch_status_on_conn(
             &conn,
@@ -2131,23 +2129,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(count_status_reaction_outbox(&conn, &dispatch_id), 2);
-
-        set_dispatch_status_on_conn(
-            &conn,
-            &dispatch_id,
-            "completed",
-            Some(&json!({"completion_source":"test_complete"})),
-            "test_complete_duplicate",
-            Some(&["completed"]),
-            true,
-        )
-        .unwrap();
-
         assert_eq!(
             count_status_reaction_outbox(&conn, &dispatch_id),
-            2,
-            "duplicate terminal transition must not enqueue extra status sync work"
+            0,
+            "#750: terminal transitions must not enqueue status_reaction rows"
         );
     }
 

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -2077,70 +2077,110 @@ mod tests {
         );
     }
 
-    /// #750: announce bot no longer writes ⏳ or ✅ (command bot owns those),
-    /// so pending→dispatched and dispatched→completed transitions skip the
-    /// status_reaction enqueue. Failed/cancelled transitions STILL enqueue —
-    /// command bot unconditionally adds ✅ on response delivery, so announce
-    /// bot is the only path that can correct the visual state to ❌.
+    /// #750: narrowed enqueue policy.
+    /// - pending → dispatched: no enqueue (command bot's ⏳ is the source).
+    /// - dispatched → completed from live command-bot paths
+    ///   (`transition_source` starts with "turn_bridge" or "watcher"): no
+    ///   enqueue. Command bot already added ✅ on response delivery.
+    /// - dispatched → completed from non-live paths (api, recovery,
+    ///   supervisor, test_*): enqueue. Announce bot's ✅ is the only
+    ///   terminal success signal on the original message.
+    /// - any → failed / cancelled: enqueue. Announce bot must clean
+    ///   command bot's stale ✅ and add ❌ to avoid false green checks.
     #[test]
-    fn dispatch_status_transitions_enqueue_only_for_failed_or_cancelled() {
+    fn dispatch_status_transitions_enqueue_narrowed_on_non_live_paths() {
         let db = test_db();
         let engine = test_engine(&db);
-        seed_card(&db, "card-reaction-outbox-success", "ready");
+        seed_card(&db, "card-outbox-turn-bridge", "ready");
 
-        let success = create_dispatch(
+        let live = create_dispatch(
             &db,
             &engine,
-            "card-reaction-outbox-success",
+            "card-outbox-turn-bridge",
             "agent-1",
             "implementation",
-            "Success trail",
+            "Live trail",
             &json!({}),
         )
         .unwrap();
-        let success_id = success["id"].as_str().unwrap().to_string();
+        let live_id = live["id"].as_str().unwrap().to_string();
 
-        {
-            let conn = db.separate_conn().unwrap();
-            set_dispatch_status_on_conn(
-                &conn,
-                &success_id,
-                "dispatched",
-                None,
-                "test_dispatch_outbox",
-                Some(&["pending"]),
-                false,
-            )
-            .unwrap();
-        }
         let conn = db.separate_conn().unwrap();
+        set_dispatch_status_on_conn(
+            &conn,
+            &live_id,
+            "dispatched",
+            None,
+            "turn_bridge_notify",
+            Some(&["pending"]),
+            false,
+        )
+        .unwrap();
         assert_eq!(
-            count_status_reaction_outbox(&conn, &success_id),
+            count_status_reaction_outbox(&conn, &live_id),
             0,
-            "#750: pending→dispatched must not enqueue (command bot owns ⏳)"
+            "#750: pending→dispatched must never enqueue (command bot owns ⏳)"
         );
 
         set_dispatch_status_on_conn(
             &conn,
-            &success_id,
+            &live_id,
             "completed",
-            Some(&json!({"completion_source":"test_complete"})),
-            "test_complete",
+            Some(&json!({"completion_source":"turn_bridge_explicit"})),
+            "turn_bridge_explicit",
             Some(&["dispatched"]),
             true,
         )
         .unwrap();
         assert_eq!(
-            count_status_reaction_outbox(&conn, &success_id),
+            count_status_reaction_outbox(&conn, &live_id),
             0,
-            "#750: dispatched→completed must not enqueue (command bot owns ✅)"
+            "#750: completed via turn_bridge must not enqueue (command bot already added ✅)"
         );
 
-        seed_card(&db, "card-reaction-outbox-failed", "ready");
+        seed_card(&db, "card-outbox-api", "ready");
+        let api = create_dispatch(
+            &db,
+            &engine,
+            "card-outbox-api",
+            "agent-1",
+            "implementation",
+            "API trail",
+            &json!({}),
+        )
+        .unwrap();
+        let api_id = api["id"].as_str().unwrap().to_string();
+        set_dispatch_status_on_conn(
+            &conn,
+            &api_id,
+            "dispatched",
+            None,
+            "turn_bridge_notify",
+            Some(&["pending"]),
+            false,
+        )
+        .unwrap();
+        set_dispatch_status_on_conn(
+            &conn,
+            &api_id,
+            "completed",
+            Some(&json!({"completion_source":"api"})),
+            "api",
+            Some(&["dispatched"]),
+            true,
+        )
+        .unwrap();
+        assert_eq!(
+            count_status_reaction_outbox(&conn, &api_id),
+            1,
+            "#750: completed via api/recovery/etc. must enqueue (no command-bot ✅ on message)"
+        );
+
+        seed_card(&db, "card-outbox-failed", "ready");
         let failed = create_dispatch(
             &db,
             &engine,
-            "card-reaction-outbox-failed",
+            "card-outbox-failed",
             "agent-1",
             "implementation",
             "Fail trail",
@@ -2153,7 +2193,7 @@ mod tests {
             &failed_id,
             "dispatched",
             None,
-            "test_dispatch_outbox",
+            "turn_bridge_notify",
             Some(&["pending"]),
             false,
         )
@@ -2162,8 +2202,8 @@ mod tests {
             &conn,
             &failed_id,
             "failed",
-            Some(&json!({"completion_source":"test_failed"})),
-            "test_failed",
+            Some(&json!({"completion_source":"turn_bridge_explicit"})),
+            "turn_bridge_explicit",
             Some(&["dispatched"]),
             true,
         )
@@ -2171,14 +2211,14 @@ mod tests {
         assert_eq!(
             count_status_reaction_outbox(&conn, &failed_id),
             1,
-            "#750: dispatched→failed must enqueue (announce bot writes ❌ to overwrite command bot's ✅)"
+            "#750: failed ALWAYS enqueues regardless of source (announce bot cleans ✅ and adds ❌)"
         );
 
-        seed_card(&db, "card-reaction-outbox-cancelled", "ready");
+        seed_card(&db, "card-outbox-cancelled", "ready");
         let cancelled = create_dispatch(
             &db,
             &engine,
-            "card-reaction-outbox-cancelled",
+            "card-outbox-cancelled",
             "agent-1",
             "implementation",
             "Cancel trail",
@@ -2190,8 +2230,8 @@ mod tests {
             &conn,
             &cancelled_id,
             "cancelled",
-            Some(&json!({"completion_source":"test_cancelled"})),
-            "test_cancelled",
+            Some(&json!({"completion_source":"cli"})),
+            "cli",
             Some(&["pending"]),
             true,
         )
@@ -2199,7 +2239,7 @@ mod tests {
         assert_eq!(
             count_status_reaction_outbox(&conn, &cancelled_id),
             1,
-            "#750: pending→cancelled must enqueue (covers queue/API cancel bypass paths)"
+            "#750: cancelled ALWAYS enqueues regardless of source"
         );
     }
 

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -2077,35 +2077,34 @@ mod tests {
         );
     }
 
-    /// #750: announce bot no longer writes dispatch-lifecycle emoji
-    /// reactions. set_dispatch_status_on_conn previously enqueued a
-    /// status_reaction outbox row on every pending→dispatched / terminal
-    /// transition; that enqueue was removed because the only consumer
-    /// (announce-bot reaction writer) is disabled. Verify the transitions
-    /// still succeed but NO status_reaction row is created.
+    /// #750: announce bot no longer writes ⏳ or ✅ (command bot owns those),
+    /// so pending→dispatched and dispatched→completed transitions skip the
+    /// status_reaction enqueue. Failed/cancelled transitions STILL enqueue —
+    /// command bot unconditionally adds ✅ on response delivery, so announce
+    /// bot is the only path that can correct the visual state to ❌.
     #[test]
-    fn dispatch_status_transitions_do_not_enqueue_status_reaction_outbox_entries() {
+    fn dispatch_status_transitions_enqueue_only_for_failed_or_cancelled() {
         let db = test_db();
         let engine = test_engine(&db);
-        seed_card(&db, "card-reaction-outbox", "ready");
+        seed_card(&db, "card-reaction-outbox-success", "ready");
 
-        let dispatch = create_dispatch(
+        let success = create_dispatch(
             &db,
             &engine,
-            "card-reaction-outbox",
+            "card-reaction-outbox-success",
             "agent-1",
             "implementation",
-            "Reaction trail",
+            "Success trail",
             &json!({}),
         )
         .unwrap();
-        let dispatch_id = dispatch["id"].as_str().unwrap().to_string();
+        let success_id = success["id"].as_str().unwrap().to_string();
 
         {
             let conn = db.separate_conn().unwrap();
             set_dispatch_status_on_conn(
                 &conn,
-                &dispatch_id,
+                &success_id,
                 "dispatched",
                 None,
                 "test_dispatch_outbox",
@@ -2114,13 +2113,16 @@ mod tests {
             )
             .unwrap();
         }
-
         let conn = db.separate_conn().unwrap();
-        assert_eq!(count_status_reaction_outbox(&conn, &dispatch_id), 0);
+        assert_eq!(
+            count_status_reaction_outbox(&conn, &success_id),
+            0,
+            "#750: pending→dispatched must not enqueue (command bot owns ⏳)"
+        );
 
         set_dispatch_status_on_conn(
             &conn,
-            &dispatch_id,
+            &success_id,
             "completed",
             Some(&json!({"completion_source":"test_complete"})),
             "test_complete",
@@ -2128,11 +2130,76 @@ mod tests {
             true,
         )
         .unwrap();
-
         assert_eq!(
-            count_status_reaction_outbox(&conn, &dispatch_id),
+            count_status_reaction_outbox(&conn, &success_id),
             0,
-            "#750: terminal transitions must not enqueue status_reaction rows"
+            "#750: dispatched→completed must not enqueue (command bot owns ✅)"
+        );
+
+        seed_card(&db, "card-reaction-outbox-failed", "ready");
+        let failed = create_dispatch(
+            &db,
+            &engine,
+            "card-reaction-outbox-failed",
+            "agent-1",
+            "implementation",
+            "Fail trail",
+            &json!({}),
+        )
+        .unwrap();
+        let failed_id = failed["id"].as_str().unwrap().to_string();
+        set_dispatch_status_on_conn(
+            &conn,
+            &failed_id,
+            "dispatched",
+            None,
+            "test_dispatch_outbox",
+            Some(&["pending"]),
+            false,
+        )
+        .unwrap();
+        set_dispatch_status_on_conn(
+            &conn,
+            &failed_id,
+            "failed",
+            Some(&json!({"completion_source":"test_failed"})),
+            "test_failed",
+            Some(&["dispatched"]),
+            true,
+        )
+        .unwrap();
+        assert_eq!(
+            count_status_reaction_outbox(&conn, &failed_id),
+            1,
+            "#750: dispatched→failed must enqueue (announce bot writes ❌ to overwrite command bot's ✅)"
+        );
+
+        seed_card(&db, "card-reaction-outbox-cancelled", "ready");
+        let cancelled = create_dispatch(
+            &db,
+            &engine,
+            "card-reaction-outbox-cancelled",
+            "agent-1",
+            "implementation",
+            "Cancel trail",
+            &json!({}),
+        )
+        .unwrap();
+        let cancelled_id = cancelled["id"].as_str().unwrap().to_string();
+        set_dispatch_status_on_conn(
+            &conn,
+            &cancelled_id,
+            "cancelled",
+            Some(&json!({"completion_source":"test_cancelled"})),
+            "test_cancelled",
+            Some(&["pending"]),
+            true,
+        )
+        .unwrap();
+        assert_eq!(
+            count_status_reaction_outbox(&conn, &cancelled_id),
+            1,
+            "#750: pending→cancelled must enqueue (covers queue/API cancel bypass paths)"
         );
     }
 

--- a/src/integration_tests/tests/high_risk_recovery.rs
+++ b/src/integration_tests/tests/high_risk_recovery.rs
@@ -384,9 +384,6 @@ mod outbox_boundary {
         Followup {
             dispatch_id: String,
         },
-        StatusReaction {
-            dispatch_id: String,
-        },
     }
 
     impl MockNotifier {
@@ -435,18 +432,6 @@ mod outbox_boundary {
                 .lock()
                 .unwrap()
                 .push(MockCall::Followup { dispatch_id });
-            Ok(())
-        }
-
-        async fn sync_status_reaction(
-            &self,
-            _db: crate::db::Db,
-            dispatch_id: String,
-        ) -> Result<(), String> {
-            self.calls
-                .lock()
-                .unwrap()
-                .push(MockCall::StatusReaction { dispatch_id });
             Ok(())
         }
     }
@@ -545,14 +530,15 @@ mod outbox_boundary {
             }]
         );
 
-        // Verify notify row is done and a follow-up status sync row is queued.
+        // #750: announce bot reaction writer retired — notify success no
+        // longer chain-enqueues a follow-up status_reaction outbox row.
         assert_eq!(
             outbox_status_for_action(&db, "d-160-1", "notify"),
             vec!["done"]
         );
-        assert_eq!(
-            outbox_status_for_action(&db, "d-160-1", "status_reaction"),
-            vec!["pending"]
+        assert!(
+            outbox_status_for_action(&db, "d-160-1", "status_reaction").is_empty(),
+            "#750: notify success must NOT chain-enqueue a status_reaction row"
         );
         assert_eq!(
             get_dispatch_status(&db, "d-160-1"),
@@ -560,31 +546,17 @@ mod outbox_boundary {
             "successful notify must transition pending dispatch to dispatched"
         );
 
-        // Second batch drains the queued status reaction.
+        // Second batch: nothing pending, no additional notifier calls.
         let processed2 = process_outbox_batch(&db, &mock).await;
         assert_eq!(
-            processed2, 1,
-            "status reaction should be processed on next drain"
+            processed2, 0,
+            "#750: no pending entries after single notify drain (no status_reaction chained)"
         );
         assert_eq!(
             mock.notify_count(),
             1,
             "No additional notify calls after dispatch"
         );
-        assert!(
-            mock.call_log().contains(&MockCall::StatusReaction {
-                dispatch_id: "d-160-1".into(),
-            }),
-            "status reaction must be queued after notify success"
-        );
-        assert_eq!(
-            outbox_status_for_action(&db, "d-160-1", "status_reaction"),
-            vec!["done"]
-        );
-
-        // Third batch should truly be empty after notify + status_reaction drain.
-        let processed3 = process_outbox_batch(&db, &mock).await;
-        assert_eq!(processed3, 0, "No pending entries after full drain");
     }
 
     /// Scenario 160-2: Recovery API failure → DB fallback completes dispatch
@@ -696,31 +668,15 @@ mod outbox_boundary {
             "Order reversal detected — outbox must process in id ASC (FIFO)"
         );
 
-        // Notify rows are done and each dispatch gets a queued status sync.
-        assert_eq!(
-            outbox_status_for_action(&db, "d-160o-a", "notify"),
-            vec!["done"]
-        );
-        assert_eq!(
-            outbox_status_for_action(&db, "d-160o-a", "status_reaction"),
-            vec!["pending"]
-        );
-        assert_eq!(
-            outbox_status_for_action(&db, "d-160o-b", "notify"),
-            vec!["done"]
-        );
-        assert_eq!(
-            outbox_status_for_action(&db, "d-160o-b", "status_reaction"),
-            vec!["pending"]
-        );
-        assert_eq!(
-            outbox_status_for_action(&db, "d-160o-c", "notify"),
-            vec!["done"]
-        );
-        assert_eq!(
-            outbox_status_for_action(&db, "d-160o-c", "status_reaction"),
-            vec!["pending"]
-        );
+        // #750: notify rows are done; no status_reaction chain row is
+        // enqueued since the announce-bot reaction writer is retired.
+        for id in ["d-160o-a", "d-160o-b", "d-160o-c"] {
+            assert_eq!(outbox_status_for_action(&db, id, "notify"), vec!["done"]);
+            assert!(
+                outbox_status_for_action(&db, id, "status_reaction").is_empty(),
+                "#750: notify success must not chain a status_reaction row"
+            );
+        }
         assert_eq!(get_dispatch_status(&db, "d-160o-a"), "dispatched");
         assert_eq!(get_dispatch_status(&db, "d-160o-b"), "dispatched");
         assert_eq!(get_dispatch_status(&db, "d-160o-c"), "dispatched");
@@ -771,14 +727,14 @@ mod outbox_boundary {
             "deduplicated notify rows must call the notifier only once"
         );
 
-        // The retained notify row is done; dispatch transition queues a single status sync.
+        // #750: the retained notify row is done; no status_reaction chain.
         assert_eq!(
             outbox_status_for_action(&db, "d-160d", "notify"),
             vec!["done"]
         );
-        assert_eq!(
-            outbox_status_for_action(&db, "d-160d", "status_reaction"),
-            vec!["pending"]
+        assert!(
+            outbox_status_for_action(&db, "d-160d", "status_reaction").is_empty(),
+            "#750: no status_reaction row chained after notify"
         );
     }
 

--- a/src/integration_tests/tests/high_risk_recovery.rs
+++ b/src/integration_tests/tests/high_risk_recovery.rs
@@ -384,6 +384,9 @@ mod outbox_boundary {
         Followup {
             dispatch_id: String,
         },
+        StatusReaction {
+            dispatch_id: String,
+        },
     }
 
     impl MockNotifier {
@@ -432,6 +435,18 @@ mod outbox_boundary {
                 .lock()
                 .unwrap()
                 .push(MockCall::Followup { dispatch_id });
+            Ok(())
+        }
+
+        async fn sync_status_reaction(
+            &self,
+            _db: crate::db::Db,
+            dispatch_id: String,
+        ) -> Result<(), String> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(MockCall::StatusReaction { dispatch_id });
             Ok(())
         }
     }

--- a/src/server/routes/dispatches/discord_delivery.rs
+++ b/src/server/routes/dispatches/discord_delivery.rs
@@ -71,11 +71,38 @@ fn context_reset_slot_thread_before_reuse(dispatch_context: Option<&serde_json::
         .unwrap_or(false)
 }
 
-// #750: removed — announce bot no longer writes dispatch-lifecycle emoji
-// reactions (see sync_dispatch_status_reaction for rationale). The
-// DispatchMessageTarget / DispatchStatusReactionState helpers that supported
-// the feature have no external callers; keeping them would just preserve
-// dead code paths that drift over time.
+/// #750: announce bot no longer writes ⏳ or ✅ (command bot handles those).
+/// The ❌ failure marker is still written because command bot unconditionally
+/// adds ✅ when a response is delivered — a failed dispatch that returned any
+/// text would otherwise show a false green check. `DispatchMessageTarget`
+/// locates the dispatch message for this narrow write path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct DispatchMessageTarget {
+    channel_id: String,
+    message_id: String,
+}
+
+fn dispatch_failure_emoji_path() -> &'static str {
+    "%E2%9D%8C" // ❌
+}
+
+fn parse_dispatch_message_target(dispatch_context: Option<&str>) -> Option<DispatchMessageTarget> {
+    let context = dispatch_context_value(dispatch_context)?;
+    let channel_id = context
+        .get("discord_message_channel_id")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    let message_id = context
+        .get("discord_message_id")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    Some(DispatchMessageTarget {
+        channel_id: channel_id.to_string(),
+        message_id: message_id.to_string(),
+    })
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ReviewFollowupKind {
@@ -405,17 +432,80 @@ pub(super) async fn persist_dispatch_message_target_and_add_pending_reaction(
     Ok(())
 }
 
-/// #750: announce bot lifecycle emoji reactions removed. The command bot
-/// (claudebot / codexbot) writes the authoritative turn-lifecycle emojis
-/// (`📬` / `⏳` / `✅`) onto the dispatch message; duplicating them from
-/// announce bot added no information and caused visual churn. This function
-/// is retained as a no-op so callers (outbox worker, direct callers in
-/// tests) keep compiling without an audit of every entry-point.
+/// #750: narrow-path status sync for announce bot.
+///
+/// Command bot (claudebot / codexbot) writes the ⏳ and ✅ reactions on the
+/// dispatch message — those two are no-ops here. The only status the
+/// announce-bot path still writes is ❌ for failed/cancelled dispatches,
+/// because `turn_bridge` unconditionally adds ✅ when a response is delivered
+/// (`services/discord/turn_bridge/mod.rs:1537`). Without this ❌ correction,
+/// a failed dispatch that returned any text would show a false green check.
+///
+/// This is also the only repair signal for status transitions that bypass
+/// turn_bridge entirely (queue/API cancellation, orphan recovery).
 pub(crate) async fn sync_dispatch_status_reaction(
-    _db: &crate::db::Db,
-    _dispatch_id: &str,
+    db: &crate::db::Db,
+    dispatch_id: &str,
 ) -> Result<(), String> {
-    Ok(())
+    let (status, target) = {
+        let conn = db
+            .lock()
+            .map_err(|_| format!("db lock failed for {dispatch_id} status reaction"))?;
+        let row: Option<(String, Option<String>)> = conn
+            .query_row(
+                "SELECT status, context FROM task_dispatches WHERE id = ?1",
+                [dispatch_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()
+            .map_err(|error| format!("lookup dispatch {dispatch_id}: {error}"))?;
+        let Some((status, context)) = row else {
+            return Ok(());
+        };
+        (status, parse_dispatch_message_target(context.as_deref()))
+    };
+
+    if !matches!(status.as_str(), "failed" | "cancelled") {
+        return Ok(());
+    }
+
+    let Some(target) = target else {
+        return Ok(());
+    };
+
+    let Some(token) = crate::credential::read_bot_token("announce") else {
+        return Err("no announce bot token".to_string());
+    };
+    let base_url = discord_api_base_url();
+    let url = discord_api_url(
+        &base_url,
+        &format!(
+            "/channels/{}/messages/{}/reactions/{}/@me",
+            target.channel_id,
+            target.message_id,
+            dispatch_failure_emoji_path()
+        ),
+    );
+    let response = shared_discord_http_client()
+        .put(&url)
+        .header("Authorization", format!("Bot {}", token))
+        .send()
+        .await
+        .map_err(|error| {
+            format!(
+                "failed to add ❌ to dispatch message {}: {error}",
+                target.message_id
+            )
+        })?;
+    if response.status().is_success() {
+        return Ok(());
+    }
+    let http_status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    Err(format!(
+        "failed to add ❌ for dispatch message {} (status={status}): {http_status} {body}",
+        target.message_id
+    ))
 }
 
 fn thread_id_from_slot_map(thread_id_map: Option<&str>, channel_id: u64) -> Option<String> {
@@ -3288,10 +3378,10 @@ mod tests {
         );
     }
 
-    /// #750: announce bot no longer writes dispatch-lifecycle emoji
-    /// reactions (command bot `📬`/`⏳`/`✅` is the single source of
-    /// truth). Verify that calling sync_dispatch_status_reaction for a
-    /// completed dispatch produces ZERO reaction HTTP calls.
+    /// #750: announce bot no longer writes ⏳ or ✅ (command bot `📬`/`⏳`/`✅`
+    /// is the single source of truth for normal lifecycle). Verify that
+    /// calling sync_dispatch_status_reaction for a **completed** dispatch
+    /// produces ZERO reaction HTTP calls.
     #[tokio::test]
     async fn sync_dispatch_status_reaction_does_not_write_reactions_for_completed_dispatch() {
         let _env_lock = env_lock();
@@ -3350,10 +3440,12 @@ mod tests {
         );
     }
 
-    /// #750: same as above but for failed dispatch — still zero reaction
-    /// HTTP calls.
+    /// #750: failed dispatches DO get ❌ from the announce bot because
+    /// command bot's turn_bridge unconditionally adds ✅ on response delivery
+    /// — without this correction a failed dispatch would show a false green
+    /// check. Only ❌ is written; no ⏳ remove / ✅ remove operations.
     #[tokio::test]
-    async fn sync_dispatch_status_reaction_does_not_write_reactions_for_failed_dispatch() {
+    async fn sync_dispatch_status_reaction_writes_failure_cross_for_failed_dispatch() {
         let _env_lock = env_lock();
         let (base_url, state, server_handle) = spawn_mock_discord_server(false).await;
         let _api_base = EnvVarGuard::set("AGENTDESK_DISCORD_API_BASE_URL", &base_url);
@@ -3404,9 +3496,10 @@ mod tests {
             .filter(|call| call.contains("/reactions/"))
             .cloned()
             .collect();
-        assert!(
-            reaction_calls.is_empty(),
-            "#750: failed dispatch must not trigger any reaction HTTP calls, got {reaction_calls:?}"
+        assert_eq!(
+            reaction_calls,
+            vec!["PUT /channels/123/messages/message-123/reactions/%E2%9D%8C/@me".to_string()],
+            "#750: failed dispatch must add exactly ❌ (no ⏳ or ✅ operations)"
         );
     }
 

--- a/src/server/routes/dispatches/discord_delivery.rs
+++ b/src/server/routes/dispatches/discord_delivery.rs
@@ -71,18 +71,11 @@ fn context_reset_slot_thread_before_reuse(dispatch_context: Option<&serde_json::
         .unwrap_or(false)
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) struct DispatchMessageTarget {
-    channel_id: String,
-    message_id: String,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum DispatchStatusReactionState {
-    InProgress,
-    Succeeded,
-    Failed,
-}
+// #750: removed — announce bot no longer writes dispatch-lifecycle emoji
+// reactions (see sync_dispatch_status_reaction for rationale). The
+// DispatchMessageTarget / DispatchStatusReactionState helpers that supported
+// the feature have no external callers; keeping them would just preserve
+// dead code paths that drift over time.
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ReviewFollowupKind {
@@ -233,32 +226,11 @@ impl DispatchTransport for HttpDispatchTransport {
     }
 }
 
-fn dispatch_reaction_emoji_path(emoji: char) -> Option<&'static str> {
-    match emoji {
-        '⏳' => Some("%E2%8F%B3"),
-        '✅' => Some("%E2%9C%85"),
-        '❌' => Some("%E2%9D%8C"),
-        _ => None,
-    }
-}
-
-fn parse_dispatch_message_target(dispatch_context: Option<&str>) -> Option<DispatchMessageTarget> {
-    let context = dispatch_context_value(dispatch_context)?;
-    let channel_id = context
-        .get("discord_message_channel_id")
-        .and_then(|value| value.as_str())
-        .map(str::trim)
-        .filter(|value| !value.is_empty())?;
-    let message_id = context
-        .get("discord_message_id")
-        .and_then(|value| value.as_str())
-        .map(str::trim)
-        .filter(|value| !value.is_empty())?;
-    Some(DispatchMessageTarget {
-        channel_id: channel_id.to_string(),
-        message_id: message_id.to_string(),
-    })
-}
+// #750: dispatch_reaction_emoji_path + parse_dispatch_message_target removed.
+// They fed the announce-bot lifecycle emoji writer that now no-ops. The
+// `discord_message_channel_id` / `discord_message_id` context fields are
+// still persisted by persist_dispatch_message_target_on_conn (used by the
+// message post path) — reading them is just no longer needed here.
 
 pub(super) fn persist_dispatch_message_target_on_conn(
     conn: &rusqlite::Connection,
@@ -291,87 +263,10 @@ pub(super) fn persist_dispatch_message_target_on_conn(
     Ok(())
 }
 
-async fn update_dispatch_reaction_presence(
-    client: &reqwest::Client,
-    token: &str,
-    base_url: &str,
-    target: &DispatchMessageTarget,
-    emoji: char,
-    present: bool,
-) -> Result<(), String> {
-    let encoded_emoji = dispatch_reaction_emoji_path(emoji)
-        .ok_or_else(|| format!("unsupported dispatch reaction emoji: {emoji}"))?;
-    let url = discord_api_url(
-        base_url,
-        &format!(
-            "/channels/{}/messages/{}/reactions/{}/@me",
-            target.channel_id, target.message_id, encoded_emoji
-        ),
-    );
-    let response = if present {
-        client
-            .put(&url)
-            .header("Authorization", format!("Bot {}", token))
-            .send()
-            .await
-            .map_err(|error| {
-                format!(
-                    "failed to add reaction {emoji} to dispatch message {}: {error}",
-                    target.message_id
-                )
-            })?
-    } else {
-        client
-            .delete(&url)
-            .header("Authorization", format!("Bot {}", token))
-            .send()
-            .await
-            .map_err(|error| {
-                format!(
-                    "failed to remove reaction {emoji} from dispatch message {}: {error}",
-                    target.message_id
-                )
-            })?
-    };
-
-    if response.status().is_success() || (!present && response.status().as_u16() == 404) {
-        return Ok(());
-    }
-
-    let status = response.status();
-    let body = response.text().await.unwrap_or_default();
-    let action = if present { "add" } else { "remove" };
-    Err(format!(
-        "failed to {action} reaction {emoji} for dispatch message {}: {status} {body}",
-        target.message_id
-    ))
-}
-
-async fn apply_dispatch_status_reaction_state(
-    client: &reqwest::Client,
-    token: &str,
-    base_url: &str,
-    target: &DispatchMessageTarget,
-    state: DispatchStatusReactionState,
-) -> Result<(), String> {
-    match state {
-        DispatchStatusReactionState::InProgress => {
-            update_dispatch_reaction_presence(client, token, base_url, target, '✅', false).await?;
-            update_dispatch_reaction_presence(client, token, base_url, target, '❌', false).await?;
-            update_dispatch_reaction_presence(client, token, base_url, target, '⏳', true).await
-        }
-        DispatchStatusReactionState::Succeeded => {
-            update_dispatch_reaction_presence(client, token, base_url, target, '⏳', false).await?;
-            update_dispatch_reaction_presence(client, token, base_url, target, '❌', false).await?;
-            update_dispatch_reaction_presence(client, token, base_url, target, '✅', true).await
-        }
-        DispatchStatusReactionState::Failed => {
-            update_dispatch_reaction_presence(client, token, base_url, target, '⏳', false).await?;
-            update_dispatch_reaction_presence(client, token, base_url, target, '✅', false).await?;
-            update_dispatch_reaction_presence(client, token, base_url, target, '❌', true).await
-        }
-    }
-}
+// #750: update_dispatch_reaction_presence + apply_dispatch_status_reaction_state
+// removed. They were the Discord REST wrappers used by the announce-bot
+// lifecycle emoji path; with sync_dispatch_status_reaction now a no-op they
+// have no callers.
 
 fn is_discord_length_error(status: reqwest::StatusCode, body: &str) -> bool {
     if status != reqwest::StatusCode::BAD_REQUEST {
@@ -487,95 +382,40 @@ pub(super) async fn post_dispatch_message_to_channel(
     }
 }
 
+/// #750: persists the posted dispatch message target (channel_id + message_id)
+/// so downstream consumers can locate the original dispatch post, but no
+/// longer adds the `⏳` pending emoji reaction. The announce bot reaction
+/// path was retired; the command bot's turn-lifecycle emojis remain the
+/// single source of truth. The helper signature is unchanged so callers
+/// don't need to re-thread http client/token availability through.
 pub(super) async fn persist_dispatch_message_target_and_add_pending_reaction(
     db: &crate::db::Db,
-    client: &reqwest::Client,
-    token: &str,
-    base_url: &str,
+    _client: &reqwest::Client,
+    _token: &str,
+    _base_url: &str,
     dispatch_id: &str,
     channel_id: &str,
     message_id: &str,
 ) -> Result<(), String> {
-    {
-        let conn = db
-            .lock()
-            .map_err(|_| format!("db lock failed while saving message target for {dispatch_id}"))?;
-        persist_dispatch_message_target_on_conn(&conn, dispatch_id, channel_id, message_id)
-            .map_err(|error| {
-                format!("persist dispatch message target for {dispatch_id}: {error}")
-            })?;
-    }
-
-    let target = DispatchMessageTarget {
-        channel_id: channel_id.to_string(),
-        message_id: message_id.to_string(),
-    };
-    if let Err(error) = apply_dispatch_status_reaction_state(
-        client,
-        token,
-        base_url,
-        &target,
-        DispatchStatusReactionState::InProgress,
-    )
-    .await
-    {
-        tracing::warn!(
-            "[dispatch] Failed to add pending reaction to message {} for dispatch {}: {}",
-            message_id,
-            dispatch_id,
-            error
-        );
-    }
-
+    let conn = db
+        .lock()
+        .map_err(|_| format!("db lock failed while saving message target for {dispatch_id}"))?;
+    persist_dispatch_message_target_on_conn(&conn, dispatch_id, channel_id, message_id)
+        .map_err(|error| format!("persist dispatch message target for {dispatch_id}: {error}"))?;
     Ok(())
 }
 
+/// #750: announce bot lifecycle emoji reactions removed. The command bot
+/// (claudebot / codexbot) writes the authoritative turn-lifecycle emojis
+/// (`📬` / `⏳` / `✅`) onto the dispatch message; duplicating them from
+/// announce bot added no information and caused visual churn. This function
+/// is retained as a no-op so callers (outbox worker, direct callers in
+/// tests) keep compiling without an audit of every entry-point.
 pub(crate) async fn sync_dispatch_status_reaction(
-    db: &crate::db::Db,
-    dispatch_id: &str,
+    _db: &crate::db::Db,
+    _dispatch_id: &str,
 ) -> Result<(), String> {
-    let (status, target) = {
-        let conn = db
-            .lock()
-            .map_err(|_| format!("db lock failed for dispatch reaction sync {dispatch_id}"))?;
-        let row: Option<(String, Option<String>)> = conn
-            .query_row(
-                "SELECT status, context FROM task_dispatches WHERE id = ?1",
-                [dispatch_id],
-                |row| Ok((row.get(0)?, row.get(1)?)),
-            )
-            .optional()
-            .map_err(|error| format!("load dispatch reaction target for {dispatch_id}: {error}"))?;
-        let Some((status, context)) = row else {
-            return Ok(());
-        };
-        (status, parse_dispatch_message_target(context.as_deref()))
-    };
-
-    let Some(target) = target else {
-        return Ok(());
-    };
-
-    let Some(state) = (match status.as_str() {
-        "pending" | "dispatched" => Some(DispatchStatusReactionState::InProgress),
-        "completed" => Some(DispatchStatusReactionState::Succeeded),
-        "failed" | "cancelled" => Some(DispatchStatusReactionState::Failed),
-        _ => None,
-    }) else {
-        return Ok(());
-    };
-
-    let token = crate::credential::read_bot_token("announce")
-        .ok_or_else(|| "no announce bot token".to_string())?;
-    let base_url = discord_api_base_url();
-    apply_dispatch_status_reaction_state(
-        shared_discord_http_client(),
-        &token,
-        &base_url,
-        &target,
-        state,
-    )
-    .await
+    Ok(())
 }
 
 fn thread_id_from_slot_map(thread_id_map: Option<&str>, channel_id: u64) -> Option<String> {
@@ -2815,18 +2655,17 @@ mod tests {
                 .calls
                 .contains(&"POST /channels/thread-created/messages".to_string())
         );
-        assert!(state.calls.contains(
-            &"DELETE /channels/thread-created/messages/message-thread-created/reactions/%E2%9C%85/@me"
-                .to_string()
-        ));
-        assert!(state.calls.contains(
-            &"DELETE /channels/thread-created/messages/message-thread-created/reactions/%E2%9D%8C/@me"
-                .to_string()
-        ));
-        assert!(state.calls.contains(
-            &"PUT /channels/thread-created/messages/message-thread-created/reactions/%E2%8F%B3/@me"
-                .to_string()
-        ));
+        // #750: announce bot no longer writes dispatch-lifecycle emoji
+        // reactions — no PUT/DELETE reaction calls should have been issued.
+        assert!(
+            !state.calls.iter().any(|call| call.contains("/reactions/")),
+            "#750: expected no emoji reaction HTTP calls, got {:?}",
+            state
+                .calls
+                .iter()
+                .filter(|c| c.contains("/reactions/"))
+                .collect::<Vec<_>>()
+        );
 
         let conn = db.lock().unwrap();
         let thread_id: Option<String> = conn
@@ -2896,18 +2735,11 @@ mod tests {
                 .calls
                 .contains(&"POST /channels/thread-created/messages".to_string())
         );
-        assert!(state.calls.contains(
-            &"DELETE /channels/thread-created/messages/message-thread-created/reactions/%E2%9C%85/@me"
-                .to_string()
-        ));
-        assert!(state.calls.contains(
-            &"DELETE /channels/thread-created/messages/message-thread-created/reactions/%E2%9D%8C/@me"
-                .to_string()
-        ));
-        assert!(state.calls.contains(
-            &"PUT /channels/thread-created/messages/message-thread-created/reactions/%E2%8F%B3/@me"
-                .to_string()
-        ));
+        // #750: no emoji reaction calls — see other tests in this file for rationale.
+        assert!(
+            !state.calls.iter().any(|call| call.contains("/reactions/")),
+            "#750: no emoji reaction HTTP calls expected"
+        );
         assert!(
             state
                 .calls
@@ -2990,15 +2822,9 @@ mod tests {
         server_handle.abort();
 
         let state = state.lock().unwrap();
-        assert_eq!(
-            state.calls,
-            vec![
-                "POST /channels/123/messages",
-                "DELETE /channels/123/messages/message-123/reactions/%E2%9C%85/@me",
-                "DELETE /channels/123/messages/message-123/reactions/%E2%9D%8C/@me",
-                "PUT /channels/123/messages/message-123/reactions/%E2%8F%B3/@me",
-            ]
-        );
+        // #750: phase-gate post → no emoji reaction calls (announce bot
+        // writer retired). Only the message POST should have hit Discord.
+        assert_eq!(state.calls, vec!["POST /channels/123/messages".to_string()]);
         assert!(
             !state.calls.iter().any(|call| call.contains("/threads")),
             "phase-gate dispatch must not create or reuse a Discord thread"
@@ -3096,18 +2922,11 @@ mod tests {
                 .calls
                 .contains(&"POST /channels/thread-created/messages".to_string())
         );
-        assert!(state.calls.contains(
-            &"DELETE /channels/thread-created/messages/message-thread-created/reactions/%E2%9C%85/@me"
-                .to_string()
-        ));
-        assert!(state.calls.contains(
-            &"DELETE /channels/thread-created/messages/message-thread-created/reactions/%E2%9D%8C/@me"
-                .to_string()
-        ));
-        assert!(state.calls.contains(
-            &"PUT /channels/thread-created/messages/message-thread-created/reactions/%E2%8F%B3/@me"
-                .to_string()
-        ));
+        assert!(
+            !state.calls.iter().any(|call| call.contains("/reactions/")),
+            "#750: announce bot must not write dispatch-lifecycle emoji reactions, got {:?}",
+            state.calls
+        );
 
         let conn = db.lock().unwrap();
         let thread_id: Option<String> = conn
@@ -3205,10 +3024,12 @@ mod tests {
                 "GET /channels/thread-history",
                 "PATCH /channels/thread-history",
                 "POST /channels/thread-history/messages",
-                "DELETE /channels/thread-history/messages/message-thread-history/reactions/%E2%9C%85/@me",
-                "DELETE /channels/thread-history/messages/message-thread-history/reactions/%E2%9D%8C/@me",
-                "PUT /channels/thread-history/messages/message-thread-history/reactions/%E2%8F%B3/@me",
             ]
+        );
+        assert!(
+            !state.calls.iter().any(|call| call.contains("/reactions/")),
+            "#750: announce bot must not write dispatch-lifecycle emoji reactions, got {:?}",
+            state.calls
         );
         assert_eq!(
             state.thread_names.get("thread-history").map(String::as_str),
@@ -3467,8 +3288,12 @@ mod tests {
         );
     }
 
+    /// #750: announce bot no longer writes dispatch-lifecycle emoji
+    /// reactions (command bot `📬`/`⏳`/`✅` is the single source of
+    /// truth). Verify that calling sync_dispatch_status_reaction for a
+    /// completed dispatch produces ZERO reaction HTTP calls.
     #[tokio::test]
-    async fn sync_dispatch_status_reaction_marks_completed_dispatch_success() {
+    async fn sync_dispatch_status_reaction_does_not_write_reactions_for_completed_dispatch() {
         let _env_lock = env_lock();
         let (base_url, state, server_handle) = spawn_mock_discord_server(false).await;
         let _api_base = EnvVarGuard::set("AGENTDESK_DISCORD_API_BASE_URL", &base_url);
@@ -3513,26 +3338,22 @@ mod tests {
 
         server_handle.abort();
         let state = state.lock().unwrap();
-        // Filter to reaction calls only: on some platforms (Windows) background
-        // thread/channel PATCH requests may also hit the mock server.
         let reaction_calls: Vec<String> = state
             .calls
             .iter()
-            .filter(|call| call.contains("/channels/123/messages/message-123/reactions/"))
+            .filter(|call| call.contains("/reactions/"))
             .cloned()
             .collect();
-        assert_eq!(
-            reaction_calls,
-            vec![
-                "DELETE /channels/123/messages/message-123/reactions/%E2%8F%B3/@me",
-                "DELETE /channels/123/messages/message-123/reactions/%E2%9D%8C/@me",
-                "PUT /channels/123/messages/message-123/reactions/%E2%9C%85/@me",
-            ]
+        assert!(
+            reaction_calls.is_empty(),
+            "#750: completed dispatch must not trigger any reaction HTTP calls, got {reaction_calls:?}"
         );
     }
 
+    /// #750: same as above but for failed dispatch — still zero reaction
+    /// HTTP calls.
     #[tokio::test]
-    async fn sync_dispatch_status_reaction_marks_failed_dispatch_error() {
+    async fn sync_dispatch_status_reaction_does_not_write_reactions_for_failed_dispatch() {
         let _env_lock = env_lock();
         let (base_url, state, server_handle) = spawn_mock_discord_server(false).await;
         let _api_base = EnvVarGuard::set("AGENTDESK_DISCORD_API_BASE_URL", &base_url);
@@ -3580,16 +3401,12 @@ mod tests {
         let reaction_calls: Vec<String> = state
             .calls
             .iter()
-            .filter(|call| call.contains("/channels/123/messages/message-123/reactions/"))
+            .filter(|call| call.contains("/reactions/"))
             .cloned()
             .collect();
-        assert_eq!(
-            reaction_calls,
-            vec![
-                "DELETE /channels/123/messages/message-123/reactions/%E2%8F%B3/@me",
-                "DELETE /channels/123/messages/message-123/reactions/%E2%9C%85/@me",
-                "PUT /channels/123/messages/message-123/reactions/%E2%9D%8C/@me",
-            ]
+        assert!(
+            reaction_calls.is_empty(),
+            "#750: failed dispatch must not trigger any reaction HTTP calls, got {reaction_calls:?}"
         );
     }
 

--- a/src/server/routes/dispatches/discord_delivery.rs
+++ b/src/server/routes/dispatches/discord_delivery.rs
@@ -71,19 +71,31 @@ fn context_reset_slot_thread_before_reuse(dispatch_context: Option<&serde_json::
         .unwrap_or(false)
 }
 
-/// #750: announce bot no longer writes ⏳ or ✅ (command bot handles those).
-/// The ❌ failure marker is still written because command bot unconditionally
-/// adds ✅ when a response is delivered — a failed dispatch that returned any
-/// text would otherwise show a false green check. `DispatchMessageTarget`
-/// locates the dispatch message for this narrow write path.
+/// #750: announce-bot reaction sync target. Command bot owns `⏳` (added at
+/// turn start, removed at turn end) and adds `✅` on response delivery; the
+/// announce-bot sync runs only for (a) failed/cancelled dispatches — to clean
+/// stale `✅`/`⏳` and add `❌` — and (b) completions that did not pass
+/// through the live command-bot path (api / recovery / supervisor), where
+/// the announce-bot `✅` is the only terminal-state signal.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct DispatchMessageTarget {
     channel_id: String,
     message_id: String,
 }
 
-fn dispatch_failure_emoji_path() -> &'static str {
-    "%E2%9D%8C" // ❌
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DispatchStatusReactionState {
+    Succeeded,
+    Failed,
+}
+
+fn dispatch_reaction_emoji_path(emoji: char) -> Option<&'static str> {
+    match emoji {
+        '⏳' => Some("%E2%8F%B3"),
+        '✅' => Some("%E2%9C%85"),
+        '❌' => Some("%E2%9D%8C"),
+        _ => None,
+    }
 }
 
 fn parse_dispatch_message_target(dispatch_context: Option<&str>) -> Option<DispatchMessageTarget> {
@@ -102,6 +114,94 @@ fn parse_dispatch_message_target(dispatch_context: Option<&str>) -> Option<Dispa
         channel_id: channel_id.to_string(),
         message_id: message_id.to_string(),
     })
+}
+
+async fn update_dispatch_reaction_presence(
+    client: &reqwest::Client,
+    token: &str,
+    base_url: &str,
+    target: &DispatchMessageTarget,
+    emoji: char,
+    present: bool,
+) -> Result<(), String> {
+    let encoded_emoji = dispatch_reaction_emoji_path(emoji)
+        .ok_or_else(|| format!("unsupported dispatch reaction emoji: {emoji}"))?;
+    let url = discord_api_url(
+        base_url,
+        &format!(
+            "/channels/{}/messages/{}/reactions/{}/@me",
+            target.channel_id, target.message_id, encoded_emoji
+        ),
+    );
+    let response = if present {
+        client
+            .put(&url)
+            .header("Authorization", format!("Bot {}", token))
+            .send()
+            .await
+            .map_err(|error| {
+                format!(
+                    "failed to add reaction {emoji} to dispatch message {}: {error}",
+                    target.message_id
+                )
+            })?
+    } else {
+        client
+            .delete(&url)
+            .header("Authorization", format!("Bot {}", token))
+            .send()
+            .await
+            .map_err(|error| {
+                format!(
+                    "failed to remove reaction {emoji} from dispatch message {}: {error}",
+                    target.message_id
+                )
+            })?
+    };
+
+    // Discord returns 404 when we try to remove a reaction that isn't present.
+    // That's expected when announce bot never added the emoji in the first
+    // place (the common case now that command bot owns ⏳), so treat
+    // 404-on-remove as success.
+    if response.status().is_success() || (!present && response.status().as_u16() == 404) {
+        return Ok(());
+    }
+
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    let action = if present { "add" } else { "remove" };
+    Err(format!(
+        "failed to {action} reaction {emoji} for dispatch message {}: {status} {body}",
+        target.message_id
+    ))
+}
+
+async fn apply_dispatch_status_reaction_state(
+    client: &reqwest::Client,
+    token: &str,
+    base_url: &str,
+    target: &DispatchMessageTarget,
+    state: DispatchStatusReactionState,
+) -> Result<(), String> {
+    match state {
+        DispatchStatusReactionState::Succeeded => {
+            // Clean announce-bot's own ⏳/❌ (404-tolerant) then add ✅.
+            // Command bot's separate ✅ (if any) is not touched.
+            update_dispatch_reaction_presence(client, token, base_url, target, '⏳', false).await?;
+            update_dispatch_reaction_presence(client, token, base_url, target, '❌', false).await?;
+            update_dispatch_reaction_presence(client, token, base_url, target, '✅', true).await
+        }
+        DispatchStatusReactionState::Failed => {
+            // Clean announce-bot's own ⏳/✅ (404-tolerant) then add ❌.
+            // Command bot's ✅ added on response delivery (turn_bridge:1537)
+            // is a separate @user reaction and will still render alongside
+            // ❌ — inevitable cross-bot collision on failed turns that
+            // returned text. ❌ remains the authoritative failure signal.
+            update_dispatch_reaction_presence(client, token, base_url, target, '⏳', false).await?;
+            update_dispatch_reaction_presence(client, token, base_url, target, '✅', false).await?;
+            update_dispatch_reaction_presence(client, token, base_url, target, '❌', true).await
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -432,17 +532,25 @@ pub(super) async fn persist_dispatch_message_target_and_add_pending_reaction(
     Ok(())
 }
 
-/// #750: narrow-path status sync for announce bot.
+/// #750: narrow-path dispatch-status reaction sync.
 ///
-/// Command bot (claudebot / codexbot) writes the ⏳ and ✅ reactions on the
-/// dispatch message — those two are no-ops here. The only status the
-/// announce-bot path still writes is ❌ for failed/cancelled dispatches,
-/// because `turn_bridge` unconditionally adds ✅ when a response is delivered
-/// (`services/discord/turn_bridge/mod.rs:1537`). Without this ❌ correction,
-/// a failed dispatch that returned any text would show a false green check.
+/// Command bot owns ⏳ (stop control) and ✅ on response delivery for live
+/// turns. This function runs only for terminal states where the announce-bot
+/// reaction is still meaningful:
 ///
-/// This is also the only repair signal for status transitions that bypass
-/// turn_bridge entirely (queue/API cancellation, orphan recovery).
+/// - `completed`: enqueue is gated on the transition source in
+///   `set_dispatch_status_on_conn`; only non-live paths (api, recovery,
+///   supervisor) reach this function, and they need the terminal ✅ here
+///   because command bot was never involved.
+/// - `failed` / `cancelled`: always reached. Command bot unconditionally
+///   adds ✅ whenever a response was delivered (turn_bridge:1537), so a
+///   failing dispatch that returned any text would otherwise show a false
+///   green check. The full-state reconcile (404-tolerant cleanup of
+///   announce-bot's own stale ⏳/✅ plus a fresh ❌) is the authoritative
+///   failure signal.
+///
+/// `pending` / `dispatched` are never enqueued — command bot's ⏳ is the
+/// single ⏳ source.
 pub(crate) async fn sync_dispatch_status_reaction(
     db: &crate::db::Db,
     dispatch_id: &str,
@@ -465,9 +573,11 @@ pub(crate) async fn sync_dispatch_status_reaction(
         (status, parse_dispatch_message_target(context.as_deref()))
     };
 
-    if !matches!(status.as_str(), "failed" | "cancelled") {
-        return Ok(());
-    }
+    let state = match status.as_str() {
+        "completed" => DispatchStatusReactionState::Succeeded,
+        "failed" | "cancelled" => DispatchStatusReactionState::Failed,
+        _ => return Ok(()),
+    };
 
     let Some(target) = target else {
         return Ok(());
@@ -477,35 +587,14 @@ pub(crate) async fn sync_dispatch_status_reaction(
         return Err("no announce bot token".to_string());
     };
     let base_url = discord_api_base_url();
-    let url = discord_api_url(
+    apply_dispatch_status_reaction_state(
+        shared_discord_http_client(),
+        &token,
         &base_url,
-        &format!(
-            "/channels/{}/messages/{}/reactions/{}/@me",
-            target.channel_id,
-            target.message_id,
-            dispatch_failure_emoji_path()
-        ),
-    );
-    let response = shared_discord_http_client()
-        .put(&url)
-        .header("Authorization", format!("Bot {}", token))
-        .send()
-        .await
-        .map_err(|error| {
-            format!(
-                "failed to add ❌ to dispatch message {}: {error}",
-                target.message_id
-            )
-        })?;
-    if response.status().is_success() {
-        return Ok(());
-    }
-    let http_status = response.status();
-    let body = response.text().await.unwrap_or_default();
-    Err(format!(
-        "failed to add ❌ for dispatch message {} (status={status}): {http_status} {body}",
-        target.message_id
-    ))
+        &target,
+        state,
+    )
+    .await
 }
 
 fn thread_id_from_slot_map(thread_id_map: Option<&str>, channel_id: u64) -> Option<String> {
@@ -3378,12 +3467,13 @@ mod tests {
         );
     }
 
-    /// #750: announce bot no longer writes ⏳ or ✅ (command bot `📬`/`⏳`/`✅`
-    /// is the single source of truth for normal lifecycle). Verify that
-    /// calling sync_dispatch_status_reaction for a **completed** dispatch
-    /// produces ZERO reaction HTTP calls.
+    /// #750: completed dispatches reach sync_dispatch_status_reaction only
+    /// for non-live completion paths (api/recovery/supervisor — gated by
+    /// `transition_source_is_live_command_bot` in set_dispatch_status_on_conn).
+    /// For those, the announce bot's ✅ is the only terminal signal, so the
+    /// sync runs the full reconcile: DELETE ⏳/❌ (@me, 404-tolerant), PUT ✅.
     #[tokio::test]
-    async fn sync_dispatch_status_reaction_does_not_write_reactions_for_completed_dispatch() {
+    async fn sync_dispatch_status_reaction_writes_success_cycle_for_completed_dispatch() {
         let _env_lock = env_lock();
         let (base_url, state, server_handle) = spawn_mock_discord_server(false).await;
         let _api_base = EnvVarGuard::set("AGENTDESK_DISCORD_API_BASE_URL", &base_url);
@@ -3434,18 +3524,23 @@ mod tests {
             .filter(|call| call.contains("/reactions/"))
             .cloned()
             .collect();
-        assert!(
-            reaction_calls.is_empty(),
-            "#750: completed dispatch must not trigger any reaction HTTP calls, got {reaction_calls:?}"
+        assert_eq!(
+            reaction_calls,
+            vec![
+                "DELETE /channels/123/messages/message-123/reactions/%E2%8F%B3/@me".to_string(),
+                "DELETE /channels/123/messages/message-123/reactions/%E2%9D%8C/@me".to_string(),
+                "PUT /channels/123/messages/message-123/reactions/%E2%9C%85/@me".to_string(),
+            ],
+            "#750: completed dispatch (non-live source) must DELETE announce-bot's own ⏳/❌ then PUT ✅"
         );
     }
 
-    /// #750: failed dispatches DO get ❌ from the announce bot because
-    /// command bot's turn_bridge unconditionally adds ✅ on response delivery
-    /// — without this correction a failed dispatch would show a false green
-    /// check. Only ❌ is written; no ⏳ remove / ✅ remove operations.
+    /// #750: failed dispatches get the full failure reconcile — DELETE
+    /// announce-bot's own ⏳/✅ (404-tolerant) then PUT ❌. Command bot's
+    /// own ✅ (if added via turn_bridge:1537) is untouched (@me-scoped
+    /// deletes), but ❌ is the authoritative failure signal.
     #[tokio::test]
-    async fn sync_dispatch_status_reaction_writes_failure_cross_for_failed_dispatch() {
+    async fn sync_dispatch_status_reaction_writes_failure_cycle_for_failed_dispatch() {
         let _env_lock = env_lock();
         let (base_url, state, server_handle) = spawn_mock_discord_server(false).await;
         let _api_base = EnvVarGuard::set("AGENTDESK_DISCORD_API_BASE_URL", &base_url);
@@ -3498,8 +3593,12 @@ mod tests {
             .collect();
         assert_eq!(
             reaction_calls,
-            vec!["PUT /channels/123/messages/message-123/reactions/%E2%9D%8C/@me".to_string()],
-            "#750: failed dispatch must add exactly ❌ (no ⏳ or ✅ operations)"
+            vec![
+                "DELETE /channels/123/messages/message-123/reactions/%E2%8F%B3/@me".to_string(),
+                "DELETE /channels/123/messages/message-123/reactions/%E2%9C%85/@me".to_string(),
+                "PUT /channels/123/messages/message-123/reactions/%E2%9D%8C/@me".to_string(),
+            ],
+            "#750: failed dispatch must DELETE announce-bot's own ⏳/✅ then PUT ❌ (clean signal, not mixed state)"
         );
     }
 

--- a/src/server/routes/dispatches/outbox.rs
+++ b/src/server/routes/dispatches/outbox.rs
@@ -76,6 +76,12 @@ pub(crate) trait OutboxNotifier: Send + Sync {
         db: crate::db::Db,
         dispatch_id: String,
     ) -> impl std::future::Future<Output = Result<(), String>> + Send;
+
+    fn sync_status_reaction(
+        &self,
+        db: crate::db::Db,
+        dispatch_id: String,
+    ) -> impl std::future::Future<Output = Result<(), String>> + Send;
 }
 
 /// Production notifier that calls the real Discord functions.
@@ -102,6 +108,14 @@ impl OutboxNotifier for RealOutboxNotifier {
 
     async fn handle_followup(&self, db: crate::db::Db, dispatch_id: String) -> Result<(), String> {
         handle_completed_dispatch_followups(&db, &dispatch_id).await
+    }
+
+    async fn sync_status_reaction(
+        &self,
+        db: crate::db::Db,
+        dispatch_id: String,
+    ) -> Result<(), String> {
+        super::discord_delivery::sync_dispatch_status_reaction(&db, &dispatch_id).await
     }
 }
 
@@ -228,17 +242,13 @@ pub(crate) async fn process_outbox_batch<N: OutboxNotifier>(
                     .await
             }
             "status_reaction" => {
-                // #750: announce bot no longer writes lifecycle emoji reactions.
-                // Command bot (turn_bridge) removes ⏳ on turn end and adds ✅
-                // on success, so the legacy announce-bot sync path is redundant.
-                // Any pre-existing status_reaction rows in the wild (from before
-                // this deploy) are drained as no-op — the command bot has
-                // already handled the ⏳→✅ transition on those turns, so no
-                // reaction state is actually lost.
-                tracing::debug!(
-                    "[dispatch-outbox] drop legacy status_reaction row (dispatch={dispatch_id}) — command bot handles reactions"
-                );
-                Ok(())
+                // #750: narrow-path sync — sync_dispatch_status_reaction only
+                // writes ❌ on failed/cancelled dispatches (command bot owns
+                // ⏳/✅). Drains legacy rows correctly and covers repair paths
+                // that bypass turn_bridge (queue/API cancel, orphan recovery).
+                notifier
+                    .sync_status_reaction(db.clone(), dispatch_id.clone())
+                    .await
             }
             other => {
                 tracing::warn!("[dispatch-outbox] Unknown action: {other}");
@@ -1323,14 +1333,26 @@ mod tests {
                 .push(format!("followup:{dispatch_id}"));
             Ok(())
         }
+
+        async fn sync_status_reaction(
+            &self,
+            _db: crate::db::Db,
+            dispatch_id: String,
+        ) -> Result<(), String> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("status_reaction:{dispatch_id}"));
+            Ok(())
+        }
     }
 
-    /// #750: status_reaction action is now a no-op inside the outbox worker
-    /// (announce bot lifecycle emoji path retired). The notifier is NOT
-    /// invoked for this action; the outbox row is still marked done so any
-    /// pre-existing status_reaction rows drain cleanly.
+    /// #750: status_reaction outbox rows route through notifier.sync_status_reaction.
+    /// The real notifier's sync is narrowed to write ❌ only for failed/cancelled
+    /// dispatches (command bot's ⏳/✅ covers normal lifecycle); mock captures
+    /// every invocation so we can assert the action is wired through.
     #[tokio::test]
-    async fn process_outbox_batch_drains_status_reaction_as_noop() {
+    async fn process_outbox_batch_routes_status_reaction_through_notifier() {
         let db = test_db();
         {
             let conn = db.lock().unwrap();
@@ -1344,9 +1366,10 @@ mod tests {
         let notifier = MockOutboxNotifier::default();
         let processed = process_outbox_batch(&db, &notifier).await;
         assert_eq!(processed, 1);
-        assert!(
-            notifier.calls.lock().unwrap().is_empty(),
-            "#750: notifier.sync_status_reaction must not be called; outbox handler is no-op"
+        assert_eq!(
+            *notifier.calls.lock().unwrap(),
+            vec!["status_reaction:dispatch-status".to_string()],
+            "#750: status_reaction action must flow through notifier.sync_status_reaction"
         );
 
         let conn = db.lock().unwrap();

--- a/src/server/routes/dispatches/outbox.rs
+++ b/src/server/routes/dispatches/outbox.rs
@@ -76,12 +76,6 @@ pub(crate) trait OutboxNotifier: Send + Sync {
         db: crate::db::Db,
         dispatch_id: String,
     ) -> impl std::future::Future<Output = Result<(), String>> + Send;
-
-    fn sync_status_reaction(
-        &self,
-        db: crate::db::Db,
-        dispatch_id: String,
-    ) -> impl std::future::Future<Output = Result<(), String>> + Send;
 }
 
 /// Production notifier that calls the real Discord functions.
@@ -108,14 +102,6 @@ impl OutboxNotifier for RealOutboxNotifier {
 
     async fn handle_followup(&self, db: crate::db::Db, dispatch_id: String) -> Result<(), String> {
         handle_completed_dispatch_followups(&db, &dispatch_id).await
-    }
-
-    async fn sync_status_reaction(
-        &self,
-        db: crate::db::Db,
-        dispatch_id: String,
-    ) -> Result<(), String> {
-        super::discord_delivery::sync_dispatch_status_reaction(&db, &dispatch_id).await
     }
 }
 
@@ -242,9 +228,11 @@ pub(crate) async fn process_outbox_batch<N: OutboxNotifier>(
                     .await
             }
             "status_reaction" => {
-                notifier
-                    .sync_status_reaction(db.clone(), dispatch_id.clone())
-                    .await
+                // #750: announce bot no longer writes lifecycle emoji reactions
+                // (command bot's turn-lifecycle emojis are the single source of
+                // truth). Any pre-existing status_reaction rows in the wild are
+                // drained as no-op so the outbox queue doesn't block.
+                Ok(())
             }
             other => {
                 tracing::warn!("[dispatch-outbox] Unknown action: {other}");
@@ -1329,22 +1317,14 @@ mod tests {
                 .push(format!("followup:{dispatch_id}"));
             Ok(())
         }
-
-        async fn sync_status_reaction(
-            &self,
-            _db: crate::db::Db,
-            dispatch_id: String,
-        ) -> Result<(), String> {
-            self.calls
-                .lock()
-                .unwrap()
-                .push(format!("status_reaction:{dispatch_id}"));
-            Ok(())
-        }
     }
 
+    /// #750: status_reaction action is now a no-op inside the outbox worker
+    /// (announce bot lifecycle emoji path retired). The notifier is NOT
+    /// invoked for this action; the outbox row is still marked done so any
+    /// pre-existing status_reaction rows drain cleanly.
     #[tokio::test]
-    async fn process_outbox_batch_handles_status_reaction_action() {
+    async fn process_outbox_batch_drains_status_reaction_as_noop() {
         let db = test_db();
         {
             let conn = db.lock().unwrap();
@@ -1358,9 +1338,9 @@ mod tests {
         let notifier = MockOutboxNotifier::default();
         let processed = process_outbox_batch(&db, &notifier).await;
         assert_eq!(processed, 1);
-        assert_eq!(
-            notifier.calls.lock().unwrap().as_slice(),
-            ["status_reaction:dispatch-status"]
+        assert!(
+            notifier.calls.lock().unwrap().is_empty(),
+            "#750: notifier.sync_status_reaction must not be called; outbox handler is no-op"
         );
 
         let conn = db.lock().unwrap();

--- a/src/server/routes/dispatches/outbox.rs
+++ b/src/server/routes/dispatches/outbox.rs
@@ -228,10 +228,16 @@ pub(crate) async fn process_outbox_batch<N: OutboxNotifier>(
                     .await
             }
             "status_reaction" => {
-                // #750: announce bot no longer writes lifecycle emoji reactions
-                // (command bot's turn-lifecycle emojis are the single source of
-                // truth). Any pre-existing status_reaction rows in the wild are
-                // drained as no-op so the outbox queue doesn't block.
+                // #750: announce bot no longer writes lifecycle emoji reactions.
+                // Command bot (turn_bridge) removes ⏳ on turn end and adds ✅
+                // on success, so the legacy announce-bot sync path is redundant.
+                // Any pre-existing status_reaction rows in the wild (from before
+                // this deploy) are drained as no-op — the command bot has
+                // already handled the ⏳→✅ transition on those turns, so no
+                // reaction state is actually lost.
+                tracing::debug!(
+                    "[dispatch-outbox] drop legacy status_reaction row (dispatch={dispatch_id}) — command bot handles reactions"
+                );
                 Ok(())
             }
             other => {

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -68,8 +68,15 @@ fn should_skip_memento_recall(
     memory_settings.backend == settings::MemoryBackendKind::Memento && memento_context_loaded
 }
 
-fn should_add_turn_pending_reaction(dispatch_id: Option<&str>) -> bool {
-    dispatch_id.is_none()
+fn should_add_turn_pending_reaction(_dispatch_id: Option<&str>) -> bool {
+    // #750: announce bot no longer writes lifecycle emojis, so the command bot
+    // is now the single source of ⏳ for both regular and dispatch turns.
+    // Users stop an active dispatch turn by removing this ⏳, which
+    // intake_gate's classify_removed_control_reaction catches.
+    // (#559 originally skipped this for dispatches to avoid duplicating the
+    // announce bot's ⏳. With the announce-bot path gone, we must re-add it
+    // here so the stop-via-reaction-removal path keeps working.)
+    true
 }
 
 fn session_reset_reason_for_turn(
@@ -3265,12 +3272,15 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_turns_skip_generic_pending_reaction() {
+    fn dispatch_turns_add_pending_reaction_as_single_source() {
+        // #750: announce bot no longer writes ⏳. Command bot must add it on
+        // dispatch turn start so the stop-via-reaction-removal path still
+        // works.
         let dispatch_id = crate::services::discord::adk_session::parse_dispatch_id(
             "DISPATCH:550e8400-e29b-41d4-a716-446655440000 - Fix login bug",
         );
 
-        assert!(!should_add_turn_pending_reaction(dispatch_id.as_deref()));
+        assert!(should_add_turn_pending_reaction(dispatch_id.as_deref()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #750. Drops the announce bot's initial `⏳` add on dispatch post so command bot becomes the single source of the pending/stop-control reaction (unifies with `#559`). Announce bot's lifecycle sync is narrowed to paths where command bot isn't the visible authority: failed/cancelled dispatches (always) and completed dispatches from non-live paths — API / recovery / supervisor / cli — where command bot was never involved.

## Changes

- `should_add_turn_pending_reaction`: flip to always-true. Command bot now adds `⏳` to dispatch messages at turn start; users stop the turn by removing it (`intake_gate::classify_removed_control_reaction`).
- `persist_dispatch_message_target_and_add_pending_reaction`: persists the message target only (no `⏳` add).
- `sync_dispatch_status_reaction`: full state machine retained (Succeeded / Failed) but routed through `transition_source_is_live_command_bot` gate on `completed`.
- `set_dispatch_status_on_conn`: enqueues status_reaction for ALL failed/cancelled, and for completed only when source is not `turn_bridge`/`watcher`.
- Full-state reconcile on terminal: DELETE announce-bot's own `⏳`/`❌`|`✅` (404-tolerant, @me-scoped), PUT the terminal emoji.

## Iteration history (Codex adversarial review)

| Round | Flagged | Resolution |
|-------|---------|------------|
| 1 | Stop control regression (removing `⏳` breaks stop-via-reaction-removal) + rollout drops legacy rows | Flipped `should_add_turn_pending_reaction` to command-bot-owns-⏳; documented legacy no-op |
| 2 | False `✅` on failed dispatches + non-turn-bridge completions lose terminal signal | Narrowed failure sync to add `❌`; kept OutboxNotifier trait method |
| 3 | Failed sync doesn't clean stale `✅`/`⏳` + non-live-path completions still silent | Restored full state-machine reconcile; added `transition_source_is_live_command_bot` gate |

## Known limitation / follow-up

Codex round 4 flagged that announce-bot `@me`-scoped DELETE cannot clean command-bot's own reactions from the same message. On a dispatch that delivered text and then transitioned to `failed`, the message will temporarily show both command-bot's `✅` (added on response delivery, turn_bridge:1537) and announce-bot's `❌`. The `❌` is the authoritative failure signal, but the mixed-reaction state can confuse operators.

Proper fix requires unifying reaction ownership (either command bot removes its own `✅` on failure, or use bulk-DELETE endpoints with Manage Messages permission). Filing follow-up to track.

## Test plan

- [x] `MEMENTO_ACCESS_KEY="" cargo test --bin agentdesk` — 1728 passed, 4 ignored
- [x] New tests:
  - `sync_dispatch_status_reaction_writes_success_cycle_for_completed_dispatch`
  - `sync_dispatch_status_reaction_writes_failure_cycle_for_failed_dispatch`
  - `dispatch_status_transitions_enqueue_narrowed_on_non_live_paths`
  - `process_outbox_batch_routes_status_reaction_through_notifier`
  - `dispatch_turns_add_pending_reaction_as_single_source` (flipped from skip)
- [ ] Post-deploy: manually verify a real dispatch → command bot's `⏳` appears; removing it stops the turn; terminal state shows `✅` (success) or `❌` (fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)