### PR TITLE
#747 fix: isolate tick hooks from main PolicyEngineActor + phase-gate grace window

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -64,7 +64,7 @@
 | `db::cron_history` | `src/db/cron_history.rs` | 74 |  |
 | `db::kanban` | `src/db/kanban.rs` | 162 |  |
 | `db::memento_feedback_stats` | `src/db/memento_feedback_stats.rs` | 255 |  |
-| `db::schema` | `src/db/schema.rs` | 3055 | giant-file |
+| `db::schema` | `src/db/schema.rs` | 3068 | giant-file |
 | `db::session_agent_resolution` | `src/db/session_agent_resolution.rs` | 262 |  |
 | `db::session_transcripts` | `src/db/session_transcripts.rs` | 788 |  |
 | `db::turns` | `src/db/turns.rs` | 451 |  |
@@ -73,7 +73,7 @@
 | `dispatch::dispatch_context` | `src/dispatch/dispatch_context.rs` | 1533 | giant-file |
 | `dispatch::dispatch_create` | `src/dispatch/dispatch_create.rs` | 695 |  |
 | `dispatch::dispatch_status` | `src/dispatch/dispatch_status.rs` | 608 |  |
-| `engine` | `src/engine/mod.rs` | 1555 | giant-file |
+| `engine` | `src/engine/mod.rs` | 1646 | giant-file |
 | `engine::hooks` | `src/engine/hooks.rs` | 84 |  |
 | `engine::intent` | `src/engine/intent.rs` | 812 |  |
 | `engine::loader` | `src/engine/loader.rs` | 281 |  |
@@ -118,7 +118,7 @@
 | `runtime_layout::legacy_migration` | `src/runtime_layout/legacy_migration.rs` | 396 |  |
 | `runtime_layout::paths` | `src/runtime_layout/paths.rs` | 134 |  |
 | `runtime_layout::skill_sync` | `src/runtime_layout/skill_sync.rs` | 685 |  |
-| `server` | `src/server/mod.rs` | 2175 | giant-file |
+| `server` | `src/server/mod.rs` | 2636 | giant-file |
 | `server::background` | `src/server/background.rs` | 535 |  |
 | `server::boot` | `src/server/boot.rs` | 141 |  |
 | `server::cron_catalog` | `src/server/cron_catalog.rs` | 71 |  |
@@ -176,7 +176,7 @@
 | `server::routes::stats` | `src/server/routes/stats.rs` | 428 |  |
 | `server::routes::termination_events` | `src/server/routes/termination_events.rs` | 117 |  |
 | `server::tick` | `src/server/tick.rs` | 230 |  |
-| `server::worker_registry` | `src/server/worker_registry.rs` | 542 |  |
+| `server::worker_registry` | `src/server/worker_registry.rs` | 550 |  |
 | `server::ws` | `src/server/ws.rs` | 141 |  |
 | `services` | `src/services/mod.rs` | 38 |  |
 | `services::agent_protocol` | `src/services/agent_protocol.rs` | 160 |  |

--- a/docs/generated/route-inventory.md
+++ b/docs/generated/route-inventory.md
@@ -186,4 +186,4 @@
 | `GET` | `/api/token-analytics` | `receipt::get_token_analytics` | `src/server/routes/receipt.rs:102` | `src/server/routes/domains/admin.rs:72` |
 | `POST` | `/api/turns/{channel_id}/cancel` | `queue_api::cancel_turn` | `src/server/routes/queue_api.rs:152` | `src/server/routes/domains/ops.rs:156` |
 | `POST` | `/api/turns/{channel_id}/extend-timeout` | `queue_api::extend_turn_timeout` | `src/server/routes/queue_api.rs:181` | `src/server/routes/domains/ops.rs:157` |
-| `GET` | `/ws` | `ws::ws_handler` | `src/server/ws.rs:65` | `src/server/mod.rs:361` |
+| `GET` | `/ws` | `ws::ws_handler` | `src/server/ws.rs:65` | `src/server/mod.rs:383` |

--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -746,11 +746,68 @@ function runHasBlockingPhaseGate(runId) {
   return rows.length > 0 && rows[0].cnt > 0;
 }
 
+// #747 round-2: Phase-gate race protection.
+// Tick hooks now run on a separate `PolicyEngine` from `onCardTerminal`, so
+// `onTick1min.finalizeRunWithoutPhaseGate` can see a run with no
+// pending/dispatched entries AFTER Rust marks the last entry `done` but
+// BEFORE the main engine's `onCardTerminal` has finished creating phase-gate
+// dispatches. Mark a short grace window in the DB at the start of
+// `continueRunAfterEntry` and respect it in finalization.
+var PHASE_GATE_GRACE_WINDOW_MS = 30 * 1000; // 30s
+
+function beginPhaseGateGraceWindow(runId) {
+  if (!runId) return;
+  var until = new Date(Date.now() + PHASE_GATE_GRACE_WINDOW_MS).toISOString();
+  try {
+    agentdesk.db.execute(
+      "UPDATE auto_queue_runs SET phase_gate_grace_until = ? WHERE id = ?",
+      [until, runId]
+    );
+  } catch (e) {
+    autoQueueLog("warn", "Failed to begin phase-gate grace window for run " + runId + ": " + e, {
+      run_id: runId
+    });
+  }
+}
+
+function clearPhaseGateGraceWindow(runId) {
+  if (!runId) return;
+  try {
+    agentdesk.db.execute(
+      "UPDATE auto_queue_runs SET phase_gate_grace_until = NULL WHERE id = ?",
+      [runId]
+    );
+  } catch (e) {
+    // Non-fatal: grace window will naturally expire.
+  }
+}
+
+function runWithinPhaseGateGrace(runId) {
+  if (!runId) return false;
+  var rows = agentdesk.db.query(
+    "SELECT phase_gate_grace_until FROM auto_queue_runs WHERE id = ?",
+    [runId]
+  );
+  if (rows.length === 0 || !rows[0].phase_gate_grace_until) return false;
+  var until = Date.parse(rows[0].phase_gate_grace_until);
+  if (!isFinite(until)) return false;
+  return Date.now() < until;
+}
+
 function finalizeRunWithoutPhaseGate(runId) {
   if (!runId) return false;
 
   if (runHasBlockingPhaseGate(runId)) return false;
   if (remainingRunnableEntryCount(runId) > 0) return false;
+  // Phase-gate race guard: the main engine's `onCardTerminal` may still be
+  // in the middle of creating gate dispatches. Respect the grace window so
+  // we never mark a run completed before phase gates get registered.
+  if (runWithinPhaseGateGrace(runId)) {
+    autoQueueLog("info", "Deferring finalize for run " + runId + " — phase-gate grace window active", {
+      run_id: runId
+    });
+    return false;
+  }
 
   var completed = false;
   try {
@@ -848,6 +905,14 @@ function _deployGateTitle(phase) {
 function continueRunAfterEntry(runId, agentId, doneGroup, donePhase, anchorCardId) {
   if (!runId || !agentId) return;
 
+  // #747 round-2: Open the phase-gate grace window BEFORE we do any work so
+  // an overlapping `onTick1min.finalizeRunWithoutPhaseGate` on the tick
+  // engine cannot steal-complete the run. Cleared on all non-phase-gate
+  // exits below; `_createPhaseGateDispatches` leaves the gate in place (the
+  // pending phase-gate row itself now guards the run via
+  // `runHasBlockingPhaseGate`).
+  beginPhaseGateGraceWindow(runId);
+
   var remainingCount = remainingRunnableEntryCount(runId, null);
 
   var effectiveDonePhase = (donePhase !== null && donePhase !== undefined) ? donePhase : -1;
@@ -863,6 +928,8 @@ function continueRunAfterEntry(runId, agentId, doneGroup, donePhase, anchorCardI
       if (_phaseGateRequired(runId, donePhase)) {
         var finalPhase = remainingCount === 0;
         _createPhaseGateDispatches(runId, donePhase, nextPhase, finalPhase, anchorCardId);
+        // Intentionally leave grace window in place: the phase-gate row
+        // created above now guards the run; grace naturally expires.
         return;
       }
       if (nextPhase !== null && nextPhase !== undefined) {
@@ -873,6 +940,7 @@ function continueRunAfterEntry(runId, agentId, doneGroup, donePhase, anchorCardI
         );
         var nextPhaseCount = (nextPhaseCountRows.length > 0) ? nextPhaseCountRows[0].cnt : 0;
         agentdesk.log.info("[auto-queue] Phase " + donePhase + " 완료, Phase " + nextPhase + " 시작 (" + nextPhaseCount + " entries)");
+        clearPhaseGateGraceWindow(runId);
         activateRun(runId, null);
         return;
       }
@@ -880,6 +948,9 @@ function continueRunAfterEntry(runId, agentId, doneGroup, donePhase, anchorCardI
   }
 
   if (remainingCount === 0) {
+    // No more work AND no phase gate required → grace window no longer
+    // needed. Clear it so finalization can proceed immediately.
+    clearPhaseGateGraceWindow(runId);
     if (!finalizeRunWithoutPhaseGate(runId)) {
       completeRunAndNotify(runId);
     }
@@ -906,6 +977,12 @@ function continueRunAfterEntry(runId, agentId, doneGroup, donePhase, anchorCardI
     );
     agentBusy = active.length > 0 && active[0].cnt > 0;
   }
+
+  // Grace window no longer needed past this point — either we keep
+  // dispatching in the same group (no phase transition happened) or we
+  // move to the next group. Either way, there is no phase-gate dispatch
+  // window to protect.
+  clearPhaseGateGraceWindow(runId);
 
   if (!groupDone) {
     if (!agentBusy) {

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1068,6 +1068,19 @@ pub(crate) fn ensure_auto_queue_schema(conn: &Connection) -> Result<()> {
         "deploy_phases",
         "ALTER TABLE auto_queue_runs ADD COLUMN deploy_phases TEXT;",
     )?;
+    // #747 round-2: phase-gate grace window. Set by OnCardTerminal at the
+    // start of its continuation work; read by the tick-fired
+    // `finalizeRunWithoutPhaseGate` path so a tiered tick on the dedicated
+    // tick engine cannot race ahead and complete a run while the main engine
+    // is still preparing phase-gate dispatches. Value is an ISO-8601 UTC
+    // timestamp (string) representing the moment *after* which finalization
+    // is allowed to proceed again. NULL means no grace window is active.
+    ensure_auto_queue_column(
+        conn,
+        "auto_queue_runs",
+        "phase_gate_grace_until",
+        "ALTER TABLE auto_queue_runs ADD COLUMN phase_gate_grace_until TEXT;",
+    )?;
     ensure_auto_queue_column(
         conn,
         "auto_queue_entries",

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -5,7 +5,11 @@ pub mod ops;
 pub mod sql_guard;
 pub mod transition;
 
-use std::sync::{Arc, Mutex, OnceLock, Weak, atomic::AtomicBool, mpsc};
+use std::sync::{
+    Arc, Mutex, OnceLock, Weak,
+    atomic::{AtomicBool, AtomicUsize},
+    mpsc,
+};
 use std::thread::{self, JoinHandle, ThreadId};
 use std::time::Duration;
 
@@ -44,6 +48,11 @@ struct PolicyEngineActor {
     tx: mpsc::Sender<EngineCommand>,
     thread_id: Arc<OnceLock<ThreadId>>,
     join: Mutex<Option<JoinHandle<()>>>,
+    /// Approximate queue depth: incremented when a command is sent, decremented
+    /// when the actor pops one off the channel. Exposed for observability (#747).
+    queue_depth: Arc<AtomicUsize>,
+    /// Short name used in log messages (e.g. "main", "tick").
+    label: &'static str,
 }
 
 enum EngineCommand {
@@ -83,19 +92,32 @@ impl PolicyEngineActor {
         inner: Arc<Mutex<PolicyEngineInner>>,
         db: Db,
         tick_hook_in_flight: Arc<AtomicBool>,
+        label: &'static str,
     ) -> Result<Arc<Self>> {
         let (tx, rx) = mpsc::channel();
         let thread_id = Arc::new(OnceLock::new());
+        let queue_depth = Arc::new(AtomicUsize::new(0));
         let actor = Arc::new(Self {
             tx,
             thread_id: thread_id.clone(),
             join: Mutex::new(None),
+            queue_depth: queue_depth.clone(),
+            label,
         });
         let actor_weak = Arc::downgrade(&actor);
+        let thread_name = format!("policy-engine-actor-{label}");
         let handle = thread::Builder::new()
-            .name("policy-engine-actor".to_string())
+            .name(thread_name)
             .spawn(move || {
-                Self::run_loop(actor_weak, inner, db, tick_hook_in_flight, thread_id, rx)
+                Self::run_loop(
+                    actor_weak,
+                    inner,
+                    db,
+                    tick_hook_in_flight,
+                    thread_id,
+                    queue_depth,
+                    rx,
+                )
             })
             .map_err(|e| anyhow::anyhow!("failed to spawn policy engine actor: {e}"))?;
         *actor
@@ -111,6 +133,7 @@ impl PolicyEngineActor {
         db: Db,
         tick_hook_in_flight: Arc<AtomicBool>,
         thread_id: Arc<OnceLock<ThreadId>>,
+        queue_depth: Arc<AtomicUsize>,
         rx: mpsc::Receiver<EngineCommand>,
     ) {
         let _ = thread_id.set(thread::current().id());
@@ -122,6 +145,16 @@ impl PolicyEngineActor {
         let _runtime_guard = runtime.as_ref().map(|rt| rt.enter());
 
         while let Ok(command) = rx.recv() {
+            // We popped a command off the channel, so approximate queue depth
+            // should drop. saturating_sub guards against any accidental skew.
+            queue_depth
+                .fetch_update(
+                    std::sync::atomic::Ordering::AcqRel,
+                    std::sync::atomic::Ordering::Acquire,
+                    |d| Some(d.saturating_sub(1)),
+                )
+                .ok();
+
             if matches!(command, EngineCommand::Shutdown) {
                 break;
             }
@@ -230,6 +263,23 @@ pub struct PolicyInfo {
 impl PolicyEngine {
     /// Create a new policy engine, initializing QuickJS and loading policies.
     pub fn new(config: &Config, db: Db) -> Result<Self> {
+        Self::new_with_label(config, db, "main")
+    }
+
+    /// Create a dedicated policy engine for the tick loop (#747).
+    ///
+    /// The tick engine has its own QuickJS runtime, policy actor thread,
+    /// and hot-reload watcher — fully isolated from the main engine so that
+    /// a long-running or stuck tick hook cannot back up the main engine's
+    /// actor queue and starve HTTP/Discord hook paths.
+    ///
+    /// Both engines load the same policies directory (so any policy that
+    /// registers `onTick*` hooks is executed by this engine).
+    pub fn new_for_tick(config: &Config, db: Db) -> Result<Self> {
+        Self::new_with_label(config, db, "tick")
+    }
+
+    fn new_with_label(config: &Config, db: Db, label: &'static str) -> Result<Self> {
         let supervisor_bridge = crate::supervisor::BridgeHandle::new();
         let runtime =
             Runtime::new().map_err(|e| anyhow::anyhow!("QuickJS runtime creation failed: {e}"))?;
@@ -265,11 +315,18 @@ impl PolicyEngine {
 
             match loader::start_hot_reload(policies_dir.clone(), reload_ctx, store.clone()) {
                 Ok(w) => {
-                    tracing::info!("Policy hot-reload enabled for {}", policies_dir.display());
+                    tracing::info!(
+                        engine_label = label,
+                        "Policy hot-reload enabled for {}",
+                        policies_dir.display()
+                    );
                     Some(w)
                 }
                 Err(e) => {
-                    tracing::warn!("Failed to start policy hot-reload: {e}");
+                    tracing::warn!(
+                        engine_label = label,
+                        "Failed to start policy hot-reload: {e}"
+                    );
                     None
                 }
             }
@@ -278,6 +335,7 @@ impl PolicyEngine {
         };
 
         tracing::info!(
+            engine_label = label,
             "Policy engine initialized (policies_dir={}, loaded={policy_count})",
             policies_dir.display()
         );
@@ -289,8 +347,12 @@ impl PolicyEngine {
             _watcher: watcher,
         }));
         let tick_hook_in_flight = Arc::new(AtomicBool::new(false));
-        let actor =
-            PolicyEngineActor::spawn(inner.clone(), db.clone(), tick_hook_in_flight.clone())?;
+        let actor = PolicyEngineActor::spawn(
+            inner.clone(),
+            db.clone(),
+            tick_hook_in_flight.clone(),
+            label,
+        )?;
         let engine = Self {
             inner,
             actor,
@@ -300,6 +362,21 @@ impl PolicyEngine {
         supervisor_bridge.attach_engine(&engine);
 
         Ok(engine)
+    }
+
+    /// Approximate number of commands waiting in the actor queue (#747).
+    /// Zero when idle. Reported for observability when a tick hook times out
+    /// so operators can tell whether the stuck worker is also holding up
+    /// queued callers.
+    pub fn actor_queue_depth(&self) -> usize {
+        self.actor
+            .queue_depth
+            .load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    /// Short label identifying this engine instance (e.g. "main", "tick").
+    pub fn actor_label(&self) -> &'static str {
+        self.actor.label
     }
 
     pub fn downgrade(&self) -> PolicyEngineHandle {
@@ -321,10 +398,24 @@ impl PolicyEngine {
 
     fn roundtrip<T>(&self, command: impl FnOnce(mpsc::Sender<T>) -> EngineCommand) -> Result<T> {
         let (reply_tx, reply_rx) = mpsc::channel();
+        // Approximate queue depth is bumped before the send. The actor drops it
+        // back down when it pops the command off the channel (#747).
         self.actor
-            .tx
-            .send(command(reply_tx))
-            .map_err(|_| anyhow::anyhow!("policy engine actor is unavailable"))?;
+            .queue_depth
+            .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        if let Err(e) = self.actor.tx.send(command(reply_tx)) {
+            // Send failed — the actor is gone, undo our increment so the gauge
+            // does not drift upward forever.
+            self.actor
+                .queue_depth
+                .fetch_update(
+                    std::sync::atomic::Ordering::AcqRel,
+                    std::sync::atomic::Ordering::Acquire,
+                    |d| Some(d.saturating_sub(1)),
+                )
+                .ok();
+            return Err(anyhow::anyhow!("policy engine actor is unavailable: {e}"));
+        }
         reply_rx
             .recv()
             .map_err(|_| anyhow::anyhow!("policy engine actor response channel dropped"))

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -584,6 +584,13 @@ fn record_tick_hook_execution(db: &Db, label: &str, execution: &PolicyTickHookEx
     let key_ms = format!("last_tick_{}_ms", label);
     let key_status = format!("last_tick_{}_status", label);
     let key_duration = format!("last_tick_{}_duration_ms", label);
+    // #747 round-2: `*_skip_ms` tracks the last moment we *attempted* a tick
+    // that was rejected by the in-flight guard. It advances for every
+    // SkippedInFlight so operators have visibility into a wedged tick, but
+    // `last_tick_*_ms` only advances for hooks that actually ran (Ok / Error
+    // / JoinError / Timeout — the timed-out body continues in the
+    // background and therefore still counts as tick progress).
+    let key_skip_ms = format!("last_tick_{}_skip_ms", label);
     let status = execution.outcome.status();
 
     match execution.outcome {
@@ -620,30 +627,26 @@ fn record_tick_hook_execution(db: &Db, label: &str, execution: &PolicyTickHookEx
         PolicyTickHookOutcome::SkippedInFlight => {}
     }
 
+    let skipped_inflight = matches!(execution.outcome, PolicyTickHookOutcome::SkippedInFlight);
+
     if let Ok(conn) = db.lock() {
-        conn.execute(
-            "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?1, ?2)",
-            rusqlite::params![key_ms, now_ms],
-        )
-        .ok();
-        conn.execute(
-            "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?1, ?2)",
-            rusqlite::params![key_duration, execution.elapsed.as_millis().to_string()],
-        )
-        .ok();
+        // Always record the status + skip timestamp so dashboards can see
+        // a skipped invocation happened. Duration for SkippedInFlight is
+        // always ZERO, which is fine.
         conn.execute(
             "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?1, ?2)",
             rusqlite::params![key_status, status],
         )
         .ok();
         conn.execute(
-            "INSERT OR REPLACE INTO kv_meta (key, value) VALUES ('last_tick_ms', ?1)",
-            [&now_ms],
+            "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?1, ?2)",
+            rusqlite::params![key_skip_ms, now_ms],
         )
         .ok();
+        // The global last-skip marker is useful for at-a-glance health.
         conn.execute(
-            "INSERT OR REPLACE INTO kv_meta (key, value) VALUES ('last_tick_duration_ms', ?1)",
-            [execution.elapsed.as_millis().to_string()],
+            "INSERT OR REPLACE INTO kv_meta (key, value) VALUES ('last_tick_skip_ms', ?1)",
+            [&now_ms],
         )
         .ok();
         conn.execute(
@@ -651,6 +654,33 @@ fn record_tick_hook_execution(db: &Db, label: &str, execution: &PolicyTickHookEx
             [status],
         )
         .ok();
+
+        if !skipped_inflight {
+            // Only real hook executions (including Timeout, whose body
+            // continues running in the background) advance the freshness
+            // timestamps. This ensures a wedged tick becomes visibly
+            // overdue on `/api/cron-jobs` instead of looking "recent".
+            conn.execute(
+                "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?1, ?2)",
+                rusqlite::params![key_ms, now_ms],
+            )
+            .ok();
+            conn.execute(
+                "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?1, ?2)",
+                rusqlite::params![key_duration, execution.elapsed.as_millis().to_string()],
+            )
+            .ok();
+            conn.execute(
+                "INSERT OR REPLACE INTO kv_meta (key, value) VALUES ('last_tick_ms', ?1)",
+                [&now_ms],
+            )
+            .ok();
+            conn.execute(
+                "INSERT OR REPLACE INTO kv_meta (key, value) VALUES ('last_tick_duration_ms', ?1)",
+                [execution.elapsed.as_millis().to_string()],
+            )
+            .ok();
+        }
     }
 }
 
@@ -1482,6 +1512,216 @@ mod tests {
 
         release_tx.send(()).unwrap();
         blocker.join().unwrap();
+    }
+
+    /// Regression for #747 round-2 Finding 2: a `SkippedInFlight` tick must
+    /// NOT advance `last_tick_<tier>_ms` / `last_tick_ms`. Those fields are
+    /// exposed by `cron_api` as `lastRunAtMs` / `nextRunAtMs`; if they
+    /// advance on skip, a wedged tick shows "recent" on the dashboard while
+    /// no hook body is actually progressing. A skip must ONLY advance the
+    /// new `last_tick_<tier>_skip_ms` / `last_tick_skip_ms` fields.
+    #[tokio::test(flavor = "current_thread")]
+    async fn skipped_inflight_does_not_advance_last_tick_ms() {
+        let db = test_db();
+        let dir = tempfile::TempDir::new().unwrap();
+        let engine = test_engine_with_dir(&db, dir.path());
+
+        // Wedge the actor so the first hook times out and the second call
+        // hits SkippedInFlight.
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let blocker_engine = engine.clone();
+        let blocker = std::thread::spawn(move || {
+            blocker_engine
+                .block_actor_for_test(entered_tx, release_rx)
+                .unwrap();
+        });
+        entered_rx.recv().unwrap();
+
+        // First call: hook body runs past the deadline → Timeout. The body
+        // is still running in the background — this counts as "tick
+        // progress" for freshness purposes, so it SHOULD advance
+        // last_tick_1min_ms.
+        let timeout_outcome = fire_tick_hook_by_name_for_test(
+            &engine,
+            &db,
+            "OnTick1min",
+            "1min",
+            Duration::from_millis(50),
+        )
+        .await;
+        assert_eq!(timeout_outcome, PolicyTickHookOutcome::Timeout);
+        let tick_ms_after_timeout = kv_value(&db, "last_tick_1min_ms")
+            .and_then(|v| v.parse::<i64>().ok())
+            .expect("Timeout must advance last_tick_1min_ms");
+        let global_tick_ms_after_timeout = kv_value(&db, "last_tick_ms")
+            .and_then(|v| v.parse::<i64>().ok())
+            .expect("Timeout must advance last_tick_ms");
+
+        // Need strictly different millisecond reads; sleep just past 1ms.
+        tokio::time::sleep(Duration::from_millis(5)).await;
+
+        // Second call while the first is still holding the in-flight guard
+        // → SkippedInFlight. This must NOT touch last_tick_1min_ms or
+        // last_tick_ms, but MUST advance last_tick_1min_skip_ms /
+        // last_tick_skip_ms.
+        let skipped_outcome = fire_tick_hook_by_name_for_test(
+            &engine,
+            &db,
+            "OnTick1min",
+            "1min",
+            Duration::from_millis(50),
+        )
+        .await;
+        assert_eq!(skipped_outcome, PolicyTickHookOutcome::SkippedInFlight);
+
+        let tick_ms_after_skip = kv_value(&db, "last_tick_1min_ms")
+            .and_then(|v| v.parse::<i64>().ok())
+            .expect("last_tick_1min_ms must still be present after skip");
+        let global_tick_ms_after_skip = kv_value(&db, "last_tick_ms")
+            .and_then(|v| v.parse::<i64>().ok())
+            .expect("last_tick_ms must still be present after skip");
+        assert_eq!(
+            tick_ms_after_skip, tick_ms_after_timeout,
+            "SkippedInFlight must NOT advance last_tick_1min_ms"
+        );
+        assert_eq!(
+            global_tick_ms_after_skip, global_tick_ms_after_timeout,
+            "SkippedInFlight must NOT advance last_tick_ms"
+        );
+
+        // The new skip freshness markers should be populated.
+        let skip_ms = kv_value(&db, "last_tick_1min_skip_ms")
+            .and_then(|v| v.parse::<i64>().ok())
+            .expect("SkippedInFlight must populate last_tick_1min_skip_ms");
+        assert!(
+            skip_ms >= tick_ms_after_timeout,
+            "skip marker should be >= tick marker (skip={skip_ms}, tick={tick_ms_after_timeout})"
+        );
+        assert!(
+            kv_value(&db, "last_tick_skip_ms").is_some(),
+            "SkippedInFlight must populate global last_tick_skip_ms"
+        );
+
+        release_tx.send(()).unwrap();
+        blocker.join().unwrap();
+    }
+
+    /// Regression for #747 round-2 Finding 1: the auto-queue phase-gate
+    /// race between `onCardTerminal` (main engine) and `onTick1min`
+    /// (tick engine). After the last entry is marked `done`, a tick-side
+    /// `finalizeRunWithoutPhaseGate()` must NOT complete a run while its
+    /// owning `onCardTerminal` is still creating phase-gate dispatches.
+    ///
+    /// The grace window column `phase_gate_grace_until` is set by the
+    /// main engine's `onCardTerminal` path BEFORE it calls
+    /// `_createPhaseGateDispatches`, so the tick's finalize call refuses
+    /// to finalize the run until the grace window expires (or
+    /// `onCardTerminal` clears it on a non-phase-gate exit).
+    #[tokio::test(flavor = "current_thread")]
+    async fn phase_gate_grace_window_blocks_tick_finalize_race() {
+        let db = test_db();
+        // Install a minimal probe policy that exposes just the
+        // finalizeRunWithoutPhaseGate behavior we want to exercise. We
+        // re-implement the helper here mirroring the production policy so
+        // the test stays self-contained.
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("grace-window-probe.js"),
+            r#"
+            var PHASE_GATE_GRACE_WINDOW_MS = 30 * 1000;
+
+            function runWithinPhaseGateGrace(runId) {
+                var rows = agentdesk.db.query(
+                    "SELECT phase_gate_grace_until FROM auto_queue_runs WHERE id = ?",
+                    [runId]
+                );
+                if (rows.length === 0 || !rows[0].phase_gate_grace_until) return false;
+                var until = Date.parse(rows[0].phase_gate_grace_until);
+                if (!isFinite(until)) return false;
+                return Date.now() < until;
+            }
+
+            function finalizeRunWithoutPhaseGate(runId) {
+                if (runWithinPhaseGateGrace(runId)) {
+                    agentdesk.db.execute(
+                        "INSERT OR REPLACE INTO kv_meta (key, value) VALUES ('grace_probe_result', 'deferred')"
+                    );
+                    return false;
+                }
+                agentdesk.db.execute(
+                    "INSERT OR REPLACE INTO kv_meta (key, value) VALUES ('grace_probe_result', 'finalized')"
+                );
+                return true;
+            }
+
+            agentdesk.registerPolicy({
+                name: "grace-window-probe",
+                priority: 1,
+                onTick1min: function() {
+                    finalizeRunWithoutPhaseGate("run-race-1");
+                }
+            });
+            "#,
+        )
+        .unwrap();
+
+        // Seed the DB with an auto_queue_runs row and set the grace window
+        // into the future (simulating onCardTerminal having just started
+        // its continuation work on the main engine).
+        {
+            let conn = db.lock().unwrap();
+            conn.execute(
+                "INSERT INTO auto_queue_runs (id, repo, agent_id, status, phase_gate_grace_until)
+                 VALUES ('run-race-1', 'test/repo', 'agent-1', 'active',
+                         strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '+30 seconds'))",
+                [],
+            )
+            .unwrap();
+        }
+
+        let engine = test_engine_with_dir(&db, dir.path());
+        let outcome = fire_tick_hook_by_name_for_test(
+            &engine,
+            &db,
+            "OnTick1min",
+            "1min",
+            Duration::from_secs(2),
+        )
+        .await;
+        assert_eq!(outcome, PolicyTickHookOutcome::Ok);
+        assert_eq!(
+            kv_value(&db, "grace_probe_result").as_deref(),
+            Some("deferred"),
+            "tick-side finalize must defer while the grace window is active"
+        );
+
+        // Now clear the grace window (simulating onCardTerminal finishing
+        // without a phase-gate path) and re-fire: the tick should now be
+        // allowed to finalize.
+        {
+            let conn = db.lock().unwrap();
+            conn.execute(
+                "UPDATE auto_queue_runs SET phase_gate_grace_until = NULL WHERE id = 'run-race-1'",
+                [],
+            )
+            .unwrap();
+        }
+
+        let outcome2 = fire_tick_hook_by_name_for_test(
+            &engine,
+            &db,
+            "OnTick1min",
+            "1min",
+            Duration::from_secs(2),
+        )
+        .await;
+        assert_eq!(outcome2, PolicyTickHookOutcome::Ok);
+        assert_eq!(
+            kv_value(&db, "grace_probe_result").as_deref(),
+            Some("finalized"),
+            "once the grace window is cleared, finalize may proceed"
+        );
     }
 
     #[tokio::test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -9,7 +9,7 @@ use axum::Router;
 use axum::routing::get;
 use rusqlite::Connection;
 use serde_json::json;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 use tower_http::services::ServeDir;
 
@@ -26,6 +26,28 @@ const POLICY_TICK_WARN_MS: u128 = 500;
 const POLICY_TICK_HOOK_TIMEOUT: Duration = Duration::from_secs(5);
 
 static DEPLOY_GATE_RUNNING: AtomicBool = AtomicBool::new(false);
+
+/// Monotonically increasing count of policy tick hook timeouts (#747).
+/// Incremented each time `fire_tick_hook_by_name_with_timeout` returns
+/// because the wall-clock timeout elapsed before the spawn_blocking task
+/// finished. Observable via `policy_tick_timeout_count()` in tests or logs.
+static POLICY_TICK_TIMEOUT_COUNT: AtomicU64 = AtomicU64::new(0);
+
+/// Monotonically increasing count of tick hooks that *did* finish, but only
+/// after their owning call already timed out (#747). Helps operators notice
+/// when the tick actor is holding onto work well past the user-visible
+/// deadline, which is the failure mode this counter was added to track.
+static POLICY_TICK_POST_TIMEOUT_COMPLETIONS: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(test)]
+pub(crate) fn policy_tick_timeout_count() -> u64 {
+    POLICY_TICK_TIMEOUT_COUNT.load(Ordering::Acquire)
+}
+
+#[cfg(test)]
+pub(crate) fn policy_tick_post_timeout_completions() -> u64 {
+    POLICY_TICK_POST_TIMEOUT_COMPLETIONS.load(Ordering::Acquire)
+}
 
 struct PolicyTickHookGuard {
     in_flight: Arc<AtomicBool>,
@@ -496,19 +518,22 @@ async fn fire_tick_hook_by_name_with_timeout(
     };
 
     let start = std::time::Instant::now();
-    let engine = engine.clone();
-    let hook_name = hook_name.to_string();
-    let label = label.to_string();
+    let engine_for_task = engine.clone();
+    let hook_name_owned = hook_name.to_string();
+    let label_owned = label.to_string();
     let timed_out = std::sync::Arc::new(AtomicBool::new(false));
     let timed_out_for_task = timed_out.clone();
     let mut handle = tokio::task::spawn_blocking(move || {
         let _guard = in_flight_guard;
-        let result = engine.try_fire_hook_by_name(&hook_name, serde_json::json!({}));
+        let result = engine_for_task.try_fire_hook_by_name(&hook_name_owned, serde_json::json!({}));
         let elapsed = start.elapsed();
         if timed_out_for_task.load(Ordering::Acquire) {
+            POLICY_TICK_POST_TIMEOUT_COMPLETIONS.fetch_add(1, Ordering::AcqRel);
             tracing::warn!(
-                "[policy-tick] {} finished after timeout in {}ms",
-                label,
+                engine_label = engine_for_task.actor_label(),
+                queue_depth = engine_for_task.actor_queue_depth(),
+                "[policy-tick] {} finished after timeout in {}ms (post-timeout completion)",
+                label_owned,
                 elapsed.as_millis()
             );
         }
@@ -537,6 +562,14 @@ async fn fire_tick_hook_by_name_with_timeout(
         },
         _ = tokio::time::sleep(hook_timeout) => {
             timed_out.store(true, Ordering::Release);
+            POLICY_TICK_TIMEOUT_COUNT.fetch_add(1, Ordering::AcqRel);
+            tracing::warn!(
+                engine_label = engine.actor_label(),
+                queue_depth = engine.actor_queue_depth(),
+                timeout_ms = hook_timeout.as_millis() as u64,
+                "[policy-tick] {} hook timed out; tick actor continues running in background",
+                label
+            );
             PolicyTickHookExecution {
                 outcome: PolicyTickHookOutcome::Timeout,
                 elapsed: start.elapsed(),
@@ -1257,6 +1290,194 @@ mod tests {
         assert_eq!(
             kv_value(&free_db, "probe_engine_local").as_deref(),
             Some("hit")
+        );
+
+        release_tx.send(()).unwrap();
+        blocker.join().unwrap();
+    }
+
+    /// Regression for #747: when the tick engine's actor is stuck executing a
+    /// long-running hook, firing a regular hook on the *main* engine must not
+    /// be queued behind that tick hook. The two engines run on independent
+    /// actor threads, so the main engine's fire_hook should return promptly.
+    ///
+    /// Also verifies that the timeout + post-timeout observability counters
+    /// move as expected when the tick hook eventually finishes.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stuck_tick_hook_does_not_block_main_engine_hook_calls() {
+        use crate::engine::hooks::Hook;
+
+        let db = test_db();
+
+        // Main engine — this is what HTTP/Discord callers use.
+        let main_dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            main_dir.path().join("main-probe.js"),
+            r#"
+            agentdesk.registerPolicy({
+                name: "main-probe",
+                priority: 1,
+                onTick30s: function() {
+                    agentdesk.db.execute(
+                        "INSERT OR REPLACE INTO kv_meta (key, value) VALUES ('main_engine_hit', 'yes')"
+                    );
+                }
+            });
+            "#,
+        )
+        .unwrap();
+        let main_engine = test_engine_with_dir(&db, main_dir.path());
+
+        // Tick engine — has its own actor. Completely separate from `main_engine`.
+        let tick_dir = tempfile::TempDir::new().unwrap();
+        let tick_engine = test_engine_with_dir(&db, tick_dir.path());
+
+        let timeout_before = policy_tick_timeout_count();
+        let post_timeout_before = policy_tick_post_timeout_completions();
+
+        // Block the tick engine's actor so any tick hook send() sits in the
+        // actor queue until we release the blocker.
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let blocker_engine = tick_engine.clone();
+        let blocker = std::thread::spawn(move || {
+            blocker_engine
+                .block_actor_for_test(entered_tx, release_rx)
+                .unwrap();
+        });
+        entered_rx.recv().unwrap();
+
+        // Tick hook against the stuck tick engine — should time out quickly.
+        let tick_outcome = fire_tick_hook_by_name_for_test(
+            &tick_engine,
+            &db,
+            "OnTick30s",
+            "30s",
+            Duration::from_millis(50),
+        )
+        .await;
+        assert_eq!(tick_outcome, PolicyTickHookOutcome::Timeout);
+        // The counter is a global static; other tick tests may bump it in
+        // parallel. Assert monotonic growth instead of an exact delta.
+        assert!(
+            policy_tick_timeout_count() > timeout_before,
+            "timed-out tick should bump the timeout counter (before={} after={})",
+            timeout_before,
+            policy_tick_timeout_count()
+        );
+
+        // The tick actor is still holding the BlockActor command. Now fire a
+        // regular hook against the *main* engine — this must return promptly
+        // because the main engine has its own independent actor thread.
+        let main_start = std::time::Instant::now();
+        tokio::time::timeout(Duration::from_secs(2), async {
+            // Run the engine call on the current-thread runtime via
+            // spawn_blocking so fire_hook doesn't wedge the reactor.
+            tokio::task::spawn_blocking({
+                let main_engine = main_engine.clone();
+                move || {
+                    main_engine
+                        .fire_hook(Hook::OnTick30s, serde_json::json!({}))
+                        .unwrap()
+                }
+            })
+            .await
+            .unwrap();
+        })
+        .await
+        .expect("main engine fire_hook must complete while the tick engine is stuck");
+        let main_elapsed = main_start.elapsed();
+        assert!(
+            main_elapsed < Duration::from_millis(500),
+            "main engine hook should not wait on the blocked tick engine (elapsed={:?})",
+            main_elapsed
+        );
+        assert_eq!(
+            kv_value(&db, "main_engine_hit").as_deref(),
+            Some("yes"),
+            "main engine hook must have actually fired its side effect"
+        );
+
+        // Release the blocked tick actor so it drains the queued BlockActor
+        // command. Once the background fire_hook task finishes, it records a
+        // post-timeout completion log + counter bump.
+        release_tx.send(()).unwrap();
+        blocker.join().unwrap();
+
+        // Drain any remaining queued tick hook so the post-timeout counter
+        // reflects its completion. We loop until skipped_inflight clears.
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let outcome = fire_tick_hook_by_name_for_test(
+                    &tick_engine,
+                    &db,
+                    "OnTick30s",
+                    "30s",
+                    Duration::from_millis(200),
+                )
+                .await;
+                if outcome == PolicyTickHookOutcome::Ok {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("tick engine eventually drains once unblocked");
+
+        assert!(
+            policy_tick_post_timeout_completions() > post_timeout_before,
+            "post-timeout completion counter must record the late finish (before={} after={})",
+            post_timeout_before,
+            policy_tick_post_timeout_completions()
+        );
+    }
+
+    /// Regression for #747: a timed-out tick hook must NOT leak its in-flight
+    /// guard, so a later (non-concurrent) tick call on the same engine can
+    /// acquire it again once the stuck work finishes. Together with
+    /// `timed_out_tick_marks_status_and_skips_overlapping_runs`, this pins the
+    /// `skipped_inflight` contract in place across the engine split.
+    #[tokio::test(flavor = "current_thread")]
+    async fn tick_skipped_inflight_guard_still_blocks_overlap_on_tick_engine() {
+        let db = test_db();
+        let dir = tempfile::TempDir::new().unwrap();
+        let engine = test_engine_with_dir(&db, dir.path());
+
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let blocker_engine = engine.clone();
+        let blocker = std::thread::spawn(move || {
+            blocker_engine
+                .block_actor_for_test(entered_tx, release_rx)
+                .unwrap();
+        });
+        entered_rx.recv().unwrap();
+
+        let timed_out = fire_tick_hook_by_name_for_test(
+            &engine,
+            &db,
+            "OnTick30s",
+            "30s",
+            Duration::from_millis(50),
+        )
+        .await;
+        assert_eq!(timed_out, PolicyTickHookOutcome::Timeout);
+
+        // Second call while the previous hook is still running on the actor
+        // must hit the skipped_inflight guard.
+        let skipped = fire_tick_hook_by_name_for_test(
+            &engine,
+            &db,
+            "OnTick30s",
+            "30s",
+            Duration::from_millis(50),
+        )
+        .await;
+        assert_eq!(
+            skipped,
+            PolicyTickHookOutcome::SkippedInFlight,
+            "skipped_inflight contract must hold even with the split engines"
         );
 
         release_tx.send(()).unwrap();

--- a/src/server/worker_registry.rs
+++ b/src/server/worker_registry.rs
@@ -363,7 +363,15 @@ impl SupervisedWorkerRegistry {
                 Ok(None)
             }
             ServerWorkerId::PolicyTick => {
-                let tick_engine = self.engine.clone();
+                // #747: build a dedicated tick engine so a stuck tick hook
+                // cannot back up the main engine's actor queue and starve
+                // HTTP/Discord hook paths. The two engines share the same
+                // policies directory (each with its own hot-reload watcher)
+                // and the same SQLite DB.
+                let tick_engine = PolicyEngine::new_for_tick(&self.config, self.db.clone())
+                    .map_err(|e| {
+                        anyhow!("failed to initialize dedicated policy tick engine: {e}")
+                    })?;
                 let tick_db = self.db.clone();
                 self.register_thread(spec, "policy-tick", move || {
                     let rt = tokio::runtime::Builder::new_current_thread()


### PR DESCRIPTION
## Summary

Closes #747. Isolates `onTick*` hooks onto a dedicated `PolicyEngine` instance so a timed-out tick can no longer starve regular HTTP/Discord hook calls on the main engine. Plus a phase-gate grace window and narrowed skip telemetry to close gaps that Codex adversarial review surfaced in round 1.

## Changes

**Round 1 — engine isolation:**
- `PolicyEngine::new_for_tick()` — dedicated engine instance for `PolicyTick` worker
- `ServerWorkerId::PolicyTick` builds its own engine instead of cloning the main one
- Per-engine `actor_queue_depth()` + `actor_label()` observability helpers
- `POLICY_TICK_TIMEOUT_COUNT` / `POLICY_TICK_POST_TIMEOUT_COMPLETIONS` atomic counters + warn logs

**Round 2 — Codex pushback fixes:**
- **Phase-gate race**: new `auto_queue_runs.phase_gate_grace_until` column. `onCardTerminal` → `beginPhaseGateGraceWindow()` before creating gate dispatches; `onTick1min::finalizeRunWithoutPhaseGate()` defers while window is active. Prevents the tick from finalizing a run in the gap between "last entry `done`" and "`onCardTerminal` creates the phase gate".
- **Skip telemetry**: `SkippedInFlight` no longer advances `last_tick_<tier>_ms` / global `last_tick_ms` — writes `last_tick_<tier>_skip_ms` / `last_tick_skip_ms` instead. Wedged tick now becomes visibly overdue on dashboards.

## Tests

New:
- `stuck_tick_hook_does_not_block_main_engine_hook_calls`
- `tick_skipped_inflight_guard_still_blocks_overlap_on_tick_engine`
- `skipped_inflight_does_not_advance_last_tick_ms`
- `phase_gate_grace_window_blocks_tick_finalize_race`

`MEMENTO_ACCESS_KEY="" cargo test --bin agentdesk` — 1732 passed, 4 ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)