### PR TITLE
#772 feat: rebuild dashboard app shell with routed navigation

### DIFF
--- a/dashboard/e2e/smoke.spec.ts
+++ b/dashboard/e2e/smoke.spec.ts
@@ -1,44 +1,59 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+const ROUTES = [
+  { path: "/home", label: /홈|Home/ },
+  { path: "/office", label: /오피스|Office/ },
+  { path: "/agents", label: /에이전트|Agents/ },
+  { path: "/kanban", label: /칸반|Kanban/ },
+  { path: "/stats", label: /통계|Stats/ },
+  { path: "/ops", label: /운영|Ops/ },
+  { path: "/meetings", label: /회의|Meetings/ },
+  { path: "/achievements", label: /업적|Achievements/ },
+  { path: "/settings", label: /설정|Settings/ },
+];
 
 test.describe("Dashboard smoke tests", () => {
   test("page loads and renders root element", async ({ page }) => {
     await page.goto("/");
     await expect(page.locator("#root")).toBeAttached();
+    await expect(page.getByTestId("topbar")).toBeVisible();
   });
 
   test("theme: dark/light toggle changes CSS variables", async ({ page }) => {
     await page.goto("/");
-    // Set dark, verify CSS variable responds
-    await page.evaluate(() => { document.documentElement.dataset.theme = "dark"; });
+    await page.evaluate(() => {
+      document.documentElement.dataset.theme = "dark";
+    });
     await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
     const darkBg = await page.evaluate(() =>
-      getComputedStyle(document.documentElement).getPropertyValue("--th-bg-primary").trim(),
+      getComputedStyle(document.documentElement)
+        .getPropertyValue("--th-bg-primary")
+        .trim(),
     );
     expect(darkBg).toBeTruthy();
 
-    // Switch to light, verify CSS variable changes
-    await page.evaluate(() => { document.documentElement.dataset.theme = "light"; });
+    await page.evaluate(() => {
+      document.documentElement.dataset.theme = "light";
+    });
     await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
     const lightBg = await page.evaluate(() =>
-      getComputedStyle(document.documentElement).getPropertyValue("--th-bg-primary").trim(),
+      getComputedStyle(document.documentElement)
+        .getPropertyValue("--th-bg-primary")
+        .trim(),
     );
     expect(lightBg).toBeTruthy();
     expect(lightBg).not.toBe(darkBg);
   });
 
   test("theme: auto mode responds to prefers-color-scheme", async ({ page }) => {
-    // Emulate dark system preference
     await page.emulateMedia({ colorScheme: "dark" });
     await page.goto("/");
-    // The SettingsContext auto path uses matchMedia to set data-theme.
-    // Without backend, simulate the auto logic that the app would run:
     await page.evaluate(() => {
       const mq = window.matchMedia("(prefers-color-scheme: dark)");
       document.documentElement.dataset.theme = mq.matches ? "dark" : "light";
     });
     await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
 
-    // Switch to light system preference
     await page.emulateMedia({ colorScheme: "light" });
     await page.evaluate(() => {
       const mq = window.matchMedia("(prefers-color-scheme: dark)");
@@ -47,28 +62,51 @@ test.describe("Dashboard smoke tests", () => {
     await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
   });
 
-  test("responsive: desktop viewport shows sidebar nav", async ({ page }, testInfo) => {
+  test("desktop: sidebar renders at the full shell width", async ({ page }, testInfo) => {
     test.skip(testInfo.project.name === "mobile", "Desktop-only test");
-    await page.goto("/");
-    const sidebar = page.locator("nav").first();
-    await expect(sidebar).toBeVisible({ timeout: 5000 });
+    await page.goto("/home");
+
+    const sidebar = page.getByTestId("app-sidebar");
+    await expect(sidebar).toBeVisible();
+    const box = await sidebar.boundingBox();
+    expect(box?.width).toBeGreaterThan(230);
+    expect(box?.width).toBeLessThan(250);
   });
 
-  test("responsive: mobile viewport shows bottom tab bar", async ({ page }, testInfo) => {
+  test("desktop: sidebar navigation updates route and breadcrumb", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name === "mobile", "Desktop-only test");
+    await page.goto("/home");
+
+    await page.getByRole("button", { name: /칸반|Kanban/ }).click();
+    await expect(page).toHaveURL(/\/kanban$/);
+    await expect(page.getByTestId("topbar")).toContainText(/칸반|Kanban/);
+  });
+
+  test("mobile: menu button opens the sidebar drawer", async ({ page }, testInfo) => {
     test.skip(testInfo.project.name === "desktop", "Mobile-only test");
-    await page.goto("/");
-    const bottomNav = page.locator("nav").last();
-    await expect(bottomNav).toBeVisible({ timeout: 5000 });
+    await page.goto("/home");
+
+    const sidebar = page.getByTestId("app-sidebar");
+    await expect(sidebar).not.toBeVisible();
+
+    await page.getByRole("button", { name: /사이드바 열기|Open sidebar/ }).click();
+    await expect(sidebar).toBeVisible();
   });
 
-  test("settings: clicking settings button renders SettingsView", async ({ page }, testInfo) => {
+  test("settings button routes to settings page", async ({ page }, testInfo) => {
     test.skip(testInfo.project.name === "mobile", "Desktop-only test");
-    await page.goto("/");
-    const settingsBtn = page.locator('button[title*="Settings"], button[title*="설정"]').first();
-    await expect(settingsBtn).toBeVisible({ timeout: 5000 });
-    await settingsBtn.click();
-    // SettingsView renders a heading with "Settings" or "설정" text
-    const heading = page.locator('h2:has-text("Settings"), h2:has-text("설정")').first();
-    await expect(heading).toBeVisible({ timeout: 5000 });
+    await page.goto("/home");
+
+    await page.getByRole("button", { name: /설정으로 이동|Open settings/ }).click();
+    await expect(page).toHaveURL(/\/settings$/);
+    await expect(page.getByTestId("topbar")).toContainText(/설정|Settings/);
+  });
+
+  test("all app shell routes are directly reachable", async ({ page }) => {
+    for (const route of ROUTES) {
+      await page.goto(route.path);
+      await expect(page).toHaveURL(new RegExp(`${route.path.replace("/", "\\/")}$`));
+      await expect(page.getByTestId("topbar")).toContainText(route.label);
+    }
   });
 });

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, lazy, Suspense, useMemo } from "react";
+import { useEffect, useState } from "react";
 import type {
   Agent,
   AuditLogEntry,
@@ -15,92 +15,16 @@ import type {
 import { DEFAULT_SETTINGS } from "./types";
 import * as api from "./api/client";
 import { onApiError } from "./api/client";
-import { KanbanProvider, useKanban } from "./contexts/KanbanContext";
-import { OfficeProvider, useOffice } from "./contexts/OfficeContext";
-import { SettingsProvider, useSettings } from "./contexts/SettingsContext";
-
-const OfficeView = lazy(() => import("./components/OfficeView"));
-const DashboardPageView = lazy(() => import("./components/DashboardPageView"));
-const KanbanTab = lazy(() => import("./components/agent-manager/KanbanTab"));
-const ControlCenterView = lazy(() => import("./components/ControlCenterView"));
-import OfficeSelectorBar from "./components/OfficeSelectorBar";
-const AgentInfoCard = lazy(() => import("./components/agent-manager/AgentInfoCard"));
-import { useSpriteMap } from "./components/AgentAvatar";
-import { useI18n } from "./i18n";
+import { KanbanProvider } from "./contexts/KanbanContext";
+import { OfficeProvider } from "./contexts/OfficeContext";
+import { SettingsProvider } from "./contexts/SettingsContext";
 import {
-  ToastOverlay,
   type Notification,
   useNotifications,
 } from "./components/NotificationCenter";
 import { useDashboardSocket } from "./app/useDashboardSocket";
-import type { DashboardTab } from "./app/dashboardTabs";
-import { syncDashboardTabToUrl } from "./app/dashboardTabs";
-import {
-  Building2,
-  KanbanSquare,
-  LayoutDashboard,
-  SlidersHorizontal,
-  Wifi,
-  WifiOff,
-} from "lucide-react";
-const CommandPalette = lazy(() => import("./components/CommandPalette"));
-
-type ViewMode = "office" | "dashboard" | "kanban" | "more";
-type ControlTab = "agents" | "departments" | "offices" | "settings" | "meetings";
-type AgentsPane = "directory" | "dispatch";
-type KanbanSignalFocus = "review" | "blocked" | "requested" | "stalled";
-
-interface ShellRoute {
-  id: ViewMode;
-  labelKo: string;
-  labelEn: string;
-  shortcutKey: string;
-  loadingKo: string;
-  loadingEn: string;
-}
-
-interface PaletteRoute {
-  id: string;
-  labelKo: string;
-  labelEn: string;
-  icon: string;
-}
-
-const VIEW_ROUTES: ShellRoute[] = [
-  { id: "office", labelKo: "오피스", labelEn: "Office", shortcutKey: "o", loadingKo: "오피스 로딩 중...", loadingEn: "Loading Office..." },
-  { id: "dashboard", labelKo: "대시보드", labelEn: "Dashboard", shortcutKey: "d", loadingKo: "대시보드 로딩 중...", loadingEn: "Loading Dashboard..." },
-  { id: "kanban", labelKo: "칸반", labelEn: "Kanban", shortcutKey: "b", loadingKo: "칸반 로딩 중...", loadingEn: "Loading Kanban..." },
-  { id: "more", labelKo: "컨트롤", labelEn: "Control", shortcutKey: "m", loadingKo: "컨트롤 로딩 중...", loadingEn: "Loading Control..." },
-];
-
-const PALETTE_ROUTES: PaletteRoute[] = [
-  { id: "office", labelKo: "오피스", labelEn: "Office", icon: "🏢" },
-  { id: "dashboard", labelKo: "대시보드", labelEn: "Dashboard", icon: "📊" },
-  { id: "kanban", labelKo: "칸반", labelEn: "Kanban", icon: "📋" },
-  { id: "more", labelKo: "컨트롤", labelEn: "Control", icon: "🎛️" },
-  { id: "control_agents", labelKo: "에이전트", labelEn: "Agents", icon: "👥" },
-  { id: "control_departments", labelKo: "부서", labelEn: "Departments", icon: "🏢" },
-  { id: "control_offices", labelKo: "오피스 관리", labelEn: "Offices", icon: "🏬" },
-  { id: "control_meetings", labelKo: "회의 기록", labelEn: "Meeting Records", icon: "📝" },
-  { id: "control_settings", labelKo: "설정", labelEn: "Settings", icon: "⚙️" },
-];
-
-function hasUnresolvedMeetingIssues(meeting: RoundTableMeeting): boolean {
-  const totalIssues = meeting.proposed_issues?.length ?? 0;
-  if (meeting.status !== "completed" || totalIssues === 0) return false;
-
-  const results = meeting.issue_creation_results ?? [];
-  if (results.length === 0) {
-    return meeting.issues_created < totalIssues;
-  }
-
-  const created = results.filter((result) => result.ok && result.discarded !== true).length;
-  const failed = results.filter((result) => !result.ok && result.discarded !== true).length;
-  const discarded = results.filter((result) => result.discarded === true).length;
-  const pending = Math.max(totalIssues - created - failed - discarded, 0);
-
-  return pending > 0 || failed > 0;
-}
+import AppShell from "./app/AppShell";
+import { useI18n } from "./i18n";
 
 interface BootstrapData {
   offices: Office[];
@@ -120,10 +44,9 @@ interface BootstrapData {
 
 export default function App() {
   const [data, setData] = useState<BootstrapData | null>(null);
-  const [bootstrapError, setBootstrapError] = useState<string | null>(null);
-  const { notifications, pushNotification, updateNotification, dismissNotification } = useNotifications();
+  const { notifications, pushNotification, updateNotification, dismissNotification } =
+    useNotifications();
 
-  // Wire up API error → toast notifications (throttled: max 1 per 3s per endpoint)
   useEffect(() => {
     const lastFired = new Map<string, number>();
     onApiError((url, error) => {
@@ -139,26 +62,39 @@ export default function App() {
 
   useEffect(() => {
     (async () => {
-      const partial: string[] = [];
       try {
         await api.getSession();
         const offices = await api.getOffices();
         const defaultOfficeId = offices.length > 0 ? offices[0].id : undefined;
-        const [allAgents, agents, allDepartments, departments, sessions, stats, settings, meetings, logs, cards, dispatches] =
-          await Promise.all([
-            api.getAgents(),
-            api.getAgents(defaultOfficeId),
-            api.getDepartments(),
-            api.getDepartments(defaultOfficeId),
-            api.getDispatchedSessions(true),
-            api.getStats(defaultOfficeId),
-            api.getSettings(),
-            api.getRoundTableMeetings().catch(() => [] as RoundTableMeeting[]),
-            api.getAuditLogs(12).catch(() => [] as AuditLogEntry[]),
-            api.getKanbanCards().catch(() => [] as KanbanCard[]),
-            api.getTaskDispatches({ limit: 200 }).catch(() => [] as TaskDispatch[]),
-          ]);
-        const resolvedSettings = { ...DEFAULT_SETTINGS, ...settings } as CompanySettings;
+        const [
+          allAgents,
+          agents,
+          allDepartments,
+          departments,
+          sessions,
+          stats,
+          settings,
+          meetings,
+          logs,
+          cards,
+          dispatches,
+        ] = await Promise.all([
+          api.getAgents(),
+          api.getAgents(defaultOfficeId),
+          api.getDepartments(),
+          api.getDepartments(defaultOfficeId),
+          api.getDispatchedSessions(true),
+          api.getStats(defaultOfficeId),
+          api.getSettings(),
+          api.getRoundTableMeetings().catch(() => [] as RoundTableMeeting[]),
+          api.getAuditLogs(12).catch(() => [] as AuditLogEntry[]),
+          api.getKanbanCards().catch(() => [] as KanbanCard[]),
+          api.getTaskDispatches({ limit: 200 }).catch(() => [] as TaskDispatch[]),
+        ]);
+        const resolvedSettings = {
+          ...DEFAULT_SETTINGS,
+          ...settings,
+        } as CompanySettings;
         setData({
           offices,
           agents,
@@ -193,24 +129,16 @@ export default function App() {
         });
       }
     })();
-  }, [pushNotification]);
+  }, []);
 
-  const handleWsEvent = useCallback(
-    (event: WSEvent) => {
-      switch (event.type) {
-        case "kanban_card_created": {
-          const card = event.payload as KanbanCard;
-          if (card.status === "requested") {
-            pushNotification(`칸반 요청 발사: ${card.title}`, "info");
-          }
-          break;
-        }
-        case "kanban_card_updated":
-          break;
+  const handleWsEvent = (event: WSEvent) => {
+    if (event.type === "kanban_card_created") {
+      const card = event.payload as KanbanCard;
+      if (card.status === "requested") {
+        pushNotification(`칸반 요청 발사: ${card.title}`, "info");
       }
-    },
-    [pushNotification],
-  );
+    }
+  };
 
   const { wsConnected } = useDashboardSocket(handleWsEvent);
   const { t } = useI18n();
@@ -220,7 +148,12 @@ export default function App() {
       <div className="flex h-screen items-center justify-center bg-gray-900 text-gray-400">
         <div className="text-center">
           <div className="mb-4 text-4xl">🐾</div>
-          <div>{t({ ko: "AgentDesk 대시보드 로딩 중...", en: "Loading AgentDesk Dashboard..." })}</div>
+          <div>
+            {t({
+              ko: "AgentDesk 대시보드 로딩 중...",
+              en: "Loading AgentDesk Dashboard...",
+            })}
+          </div>
         </div>
       </div>
     );
@@ -239,8 +172,14 @@ export default function App() {
       initialSelectedOfficeId={data.selectedOfficeId}
       pushNotification={pushNotification}
     >
-      <SettingsProvider initialSettings={data.settings} initialStats={data.stats}>
-        <KanbanProvider initialCards={data.kanbanCards} initialDispatches={data.taskDispatches}>
+      <SettingsProvider
+        initialSettings={data.settings}
+        initialStats={data.stats}
+      >
+        <KanbanProvider
+          initialCards={data.kanbanCards}
+          initialDispatches={data.taskDispatches}
+        >
           <AppShell
             wsConnected={wsConnected}
             notifications={notifications}
@@ -251,518 +190,5 @@ export default function App() {
         </KanbanProvider>
       </SettingsProvider>
     </OfficeProvider>
-  );
-}
-
-interface AppShellProps {
-  wsConnected: boolean;
-  notifications: Notification[];
-  pushNotification: (message: string, type?: Notification["type"]) => string;
-  updateNotification: (id: string, message: string, type?: Notification["type"]) => void;
-  dismissNotification: (id: string) => void;
-}
-
-function AppShell({ wsConnected, notifications, pushNotification, updateNotification, dismissNotification }: AppShellProps) {
-  const [view, setView] = useState<ViewMode>("office");
-  const [controlTab, setControlTab] = useState<ControlTab>("agents");
-  const [agentsPane, setAgentsPane] = useState<AgentsPane>("directory");
-  const [kanbanSignalFocus, setKanbanSignalFocus] = useState<KanbanSignalFocus | null>(null);
-  const [dashboardRequestedTab, setDashboardRequestedTab] = useState<DashboardTab | null>(null);
-  const [officeInfoAgent, setOfficeInfoAgent] = useState<Agent | null>(null);
-  const [showCmdPalette, setShowCmdPalette] = useState(false);
-  const [showShortcutHelp, setShowShortcutHelp] = useState(false);
-
-  const { settings, setSettings, stats, refreshStats, refreshingStats, isKo, locale, tr } = useSettings();
-  const {
-    offices,
-    selectedOfficeId,
-    setSelectedOfficeId,
-    agents,
-    allAgents,
-    departments,
-    allDepartments,
-    setSessions,
-    roundTableMeetings,
-    setRoundTableMeetings,
-    auditLogs,
-    visibleDispatchedSessions,
-    subAgents,
-    agentsWithDispatched,
-    refreshOffices,
-    refreshAgents,
-    refreshAllAgents,
-    refreshDepartments,
-    refreshAllDepartments,
-    refreshAuditLogs,
-    refreshing,
-    datasetStates,
-  } = useOffice();
-  const { kanbanCards, taskDispatches, upsertKanbanCard, setKanbanCards } = useKanban();
-
-  const spriteMap = useSpriteMap(agents);
-  const unreadCount = notifications.filter((notification) => Date.now() - notification.ts < 60_000).length;
-  const unresolvedMeetingsCount = roundTableMeetings.filter(hasUnresolvedMeetingIssues).length;
-
-  const resolveTheme = useCallback(() => {
-    if (settings.theme !== "auto") return settings.theme;
-    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-  }, [settings.theme]);
-
-  const viewFallbackLabel = useMemo(
-    () =>
-      Object.fromEntries(
-        VIEW_ROUTES.map((route) => [route.id, isKo ? route.loadingKo : route.loadingEn]),
-      ) as Record<ViewMode, string>,
-    [isKo],
-  );
-
-  const moreBadge = unresolvedMeetingsCount > 0 ? unresolvedMeetingsCount : unreadCount || undefined;
-  const moreBadgeColor = unresolvedMeetingsCount > 0 ? "bg-amber-500" : unreadCount > 0 ? "bg-red-500" : undefined;
-
-  const navItems: Array<{ id: ViewMode; icon: React.ReactNode; label: string; badge?: number; badgeColor?: string }> = [
-    { id: "office", icon: <Building2 size={20} />, label: isKo ? "오피스" : "Office" },
-    { id: "dashboard", icon: <LayoutDashboard size={20} />, label: isKo ? "대시보드" : "Dashboard" },
-    { id: "kanban", icon: <KanbanSquare size={20} />, label: isKo ? "칸반" : "Kanban" },
-    { id: "more", icon: <SlidersHorizontal size={20} />, label: isKo ? "컨트롤" : "Control", badge: moreBadge, badgeColor: moreBadgeColor },
-  ];
-
-  const handleNavigate = useCallback(
-    (nextView: ViewMode) => {
-      setView(nextView);
-      if (nextView === "dashboard") refreshStats();
-    },
-    [refreshStats],
-  );
-
-  const handlePaletteNavigate = useCallback(
-    (routeId: string) => {
-      if (routeId === "office" || routeId === "dashboard" || routeId === "kanban" || routeId === "more") {
-        handleNavigate(routeId);
-        return;
-      }
-
-      if (routeId === "dashboard_meetings") {
-        syncDashboardTabToUrl("meetings");
-        setDashboardRequestedTab("meetings");
-        handleNavigate("dashboard");
-        return;
-      }
-
-      setView("more");
-      if (routeId === "control_departments") {
-        setControlTab("departments");
-      } else if (routeId === "control_offices") {
-        setControlTab("offices");
-      } else if (routeId === "control_settings") {
-        setControlTab("settings");
-      } else if (routeId === "control_meetings") {
-        setControlTab("meetings");
-      } else {
-        setControlTab("agents");
-        setAgentsPane("directory");
-      }
-    },
-    [handleNavigate],
-  );
-
-  const openKanbanSignalFocus = useCallback((signal: KanbanSignalFocus) => {
-    setKanbanSignalFocus(signal);
-    setView("kanban");
-  }, []);
-
-  const openDispatchSessions = useCallback(() => {
-    setControlTab("agents");
-    setAgentsPane("dispatch");
-    setView("more");
-  }, []);
-
-  const openMeetingsView = useCallback(() => {
-    setControlTab("meetings");
-    setView("more");
-  }, []);
-
-  const openSettingsView = useCallback(() => {
-    setControlTab("settings");
-    setView("more");
-  }, []);
-
-  const clearRequestedDashboardTab = useCallback(() => {
-    setDashboardRequestedTab(null);
-  }, []);
-
-  const openDashboardMeetings = useCallback(() => {
-    syncDashboardTabToUrl("meetings");
-    setDashboardRequestedTab("meetings");
-    handleNavigate("dashboard");
-  }, [handleNavigate]);
-
-  useEffect(() => {
-    const handler = (event: KeyboardEvent) => {
-      const tag = (event.target as HTMLElement | null)?.tagName;
-      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
-
-      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
-        event.preventDefault();
-        setShowCmdPalette((prev) => !prev);
-        return;
-      }
-
-      if (event.key === "?" && !event.metaKey && !event.ctrlKey && !event.altKey) {
-        event.preventDefault();
-        setShowShortcutHelp((prev) => !prev);
-        return;
-      }
-
-      if (event.altKey && !event.metaKey && !event.ctrlKey) {
-        const route = VIEW_ROUTES.find((item) => item.shortcutKey === event.key.toLowerCase());
-        if (!route) return;
-        event.preventDefault();
-        handleNavigate(route.id);
-      }
-    };
-
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [handleNavigate]);
-
-  const handleOfficeChanged = useCallback(() => {
-    refreshOffices();
-    refreshAgents();
-    refreshAllAgents();
-    refreshDepartments();
-    refreshAllDepartments();
-    refreshAuditLogs();
-  }, [refreshOffices, refreshAgents, refreshAllAgents, refreshDepartments, refreshAllDepartments, refreshAuditLogs]);
-
-  const showOfficeSelector =
-    offices.length > 0 && (view === "office" || view === "dashboard" || (view === "more" && controlTab !== "settings" && controlTab !== "meetings"));
-
-  return (
-    <div className="flex fixed inset-0 bg-gray-900">
-      <nav className="hidden w-[4.5rem] flex-col items-center gap-1 border-r border-gray-800 bg-gray-950 py-4 sm:flex">
-        <div className="mb-4 text-2xl">🐾</div>
-        {navItems.map((item) => (
-          <NavBtn
-            key={item.id}
-            icon={item.icon}
-            active={view === item.id}
-            badge={item.badge}
-            badgeColor={item.badgeColor}
-            onClick={() => handleNavigate(item.id)}
-            label={item.label}
-          />
-        ))}
-        <div className="flex-1" />
-        <div
-          className="flex h-10 w-10 items-center justify-center rounded-lg"
-          title={wsConnected ? (isKo ? "서버 연결됨" : "Server connected") : (isKo ? "서버 연결 끊김" : "Server disconnected")}
-        >
-          {wsConnected ? <Wifi size={16} className="text-emerald-500" /> : <WifiOff size={16} className="animate-pulse text-red-400" />}
-        </div>
-      </nav>
-
-      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-        {showOfficeSelector && (
-          <OfficeSelectorBar
-            offices={offices}
-            selectedOfficeId={selectedOfficeId}
-            onSelectOffice={setSelectedOfficeId}
-            onManageOffices={() => {
-              setView("more");
-              setControlTab("offices");
-            }}
-            isKo={isKo}
-          />
-        )}
-
-        <main className="mb-14 flex min-h-0 flex-1 flex-col overflow-x-hidden overflow-y-auto sm:mb-0 sm:overflow-hidden">
-          <Suspense fallback={<ViewSkeleton label={viewFallbackLabel[view]} />}>
-            {view === "office" && (
-              <OfficeView
-                agents={agentsWithDispatched}
-                departments={departments}
-                language={settings.language}
-                theme={resolveTheme()}
-                subAgents={subAgents}
-                notifications={notifications}
-                auditLogs={auditLogs}
-                activeMeeting={roundTableMeetings.find((meeting) => meeting.status === "in_progress") ?? null}
-                kanbanCards={kanbanCards}
-                onNavigateToKanban={() => handleNavigate("kanban")}
-                onSelectAgent={(agent) => setOfficeInfoAgent(agent)}
-                onSelectDepartment={() => {
-                  setView("more");
-                  setControlTab("departments");
-                }}
-                customDeptThemes={settings.roomThemes}
-              />
-            )}
-
-            {view === "dashboard" && (
-              <DashboardPageView
-                stats={stats}
-                agents={agents}
-                sessions={visibleDispatchedSessions}
-                meetings={roundTableMeetings}
-                settings={settings}
-                requestedTab={dashboardRequestedTab}
-                onRequestedTabHandled={clearRequestedDashboardTab}
-                onSelectAgent={(agent) => setOfficeInfoAgent(agent)}
-                onOpenKanbanSignal={openKanbanSignalFocus}
-                onOpenDispatchSessions={openDispatchSessions}
-                onOpenSettings={openSettingsView}
-                onRefreshMeetings={() => api.getRoundTableMeetings().then(setRoundTableMeetings).catch(() => {})}
-              />
-            )}
-
-            {view === "kanban" && (
-              <div className="h-full overflow-auto p-4 pb-40 sm:p-6">
-                <KanbanTab
-                  tr={(ko: string, en: string) => (settings.language === "ko" ? ko : en)}
-                  locale={settings.language}
-                  cards={kanbanCards}
-                  dispatches={taskDispatches}
-                  agents={allAgents}
-                  departments={allDepartments}
-                  onAssignIssue={async (payload: {
-                    github_repo: string;
-                    github_issue_number: number;
-                    github_issue_url?: string | null;
-                    title: string;
-                    description?: string | null;
-                    assignee_agent_id: string;
-                  }) => {
-                    const assigned = await api.assignKanbanIssue(payload);
-                    upsertKanbanCard(assigned);
-                  }}
-                  onUpdateCard={async (id: string, patch: Partial<KanbanCard> & { before_card_id?: string | null }) => {
-                    const updated = await api.updateKanbanCard(id, patch);
-                    upsertKanbanCard(updated);
-                  }}
-                  onRetryCard={async (id: string, payload?: { assignee_agent_id?: string | null; request_now?: boolean }) => {
-                    const updated = await api.retryKanbanCard(id, payload);
-                    upsertKanbanCard(updated);
-                  }}
-                  onRedispatchCard={async (id: string, payload?: { reason?: string | null }) => {
-                    const updated = await api.redispatchKanbanCard(id, payload);
-                    upsertKanbanCard(updated);
-                  }}
-                onDeleteCard={async (id: string) => {
-                  await api.deleteKanbanCard(id);
-                  setKanbanCards((prev) => prev.filter((card) => card.id !== id));
-                }}
-                onPatchDeferDod={async (id, payload) => {
-                  const updated = await api.patchKanbanDeferDod(id, payload);
-                  upsertKanbanCard(updated);
-                }}
-                externalStatusFocus={kanbanSignalFocus}
-                onClearSignalFocus={() => setKanbanSignalFocus(null)}
-              />
-            </div>
-            )}
-
-            {view === "more" && (
-              <ControlCenterView
-                controlTab={controlTab}
-                onControlTabChange={setControlTab}
-                agentsPane={agentsPane}
-                onAgentsPaneChange={setAgentsPane}
-                isKo={isKo}
-                language={settings.language}
-                officeId={selectedOfficeId}
-                offices={offices}
-                selectedOfficeId={selectedOfficeId}
-                allAgents={allAgents}
-                agents={agents}
-                departments={departments}
-                sessions={visibleDispatchedSessions}
-                meetings={roundTableMeetings}
-                onAssign={async (id, patch) => {
-                  const updated = await api.assignDispatchedSession(id, patch);
-                  setSessions((prev) => prev.map((session) => (session.id === updated.id ? updated : session)));
-                }}
-                onAgentsChange={() => {
-                  refreshAgents();
-                  refreshAllAgents();
-                  refreshOffices();
-                }}
-                onDepartmentsChange={() => {
-                  refreshDepartments();
-                  refreshAllDepartments();
-                  refreshOffices();
-                }}
-                onOfficesChange={handleOfficeChanged}
-                onRefreshMeetings={() => api.getRoundTableMeetings().then(setRoundTableMeetings).catch(() => {})}
-                settings={settings}
-                onSaveSettings={async (patch) => {
-                  const mergedSettings = { ...settings, ...patch } as CompanySettings;
-                  await api.saveSettings(mergedSettings);
-                  const refreshed = await api.getSettings();
-                  setSettings({ ...DEFAULT_SETTINGS, ...refreshed } as CompanySettings);
-                  refreshAuditLogs();
-                }}
-                notifications={notifications}
-                onNotify={pushNotification}
-                onUpdateNotification={updateNotification}
-                onDismissNotification={dismissNotification}
-                onOpenMeetings={openDashboardMeetings}
-              />
-            )}
-          </Suspense>
-        </main>
-      </div>
-
-      {!wsConnected && (
-        <div className="fixed left-0 right-0 top-0 z-[90] flex items-center justify-center gap-2 border-b border-red-500/20 bg-red-500/15 px-3 py-1.5 text-center text-xs text-red-400 sm:left-[4.5rem]">
-          <WifiOff size={12} className="animate-pulse" />
-          <span>{isKo ? "서버 연결 끊김 — 재연결 시도 중..." : "Server disconnected — reconnecting..."}</span>
-        </div>
-      )}
-
-      <nav className="fixed bottom-0 left-0 right-0 z-50 flex h-14 items-center justify-around border-t border-gray-800 bg-gray-950 sm:hidden">
-        {navItems.map((item) => (
-          <button
-            key={item.id}
-            onClick={() => handleNavigate(item.id)}
-            className={`relative flex h-full flex-1 flex-col items-center justify-center text-[10px] ${
-              view === item.id ? "text-emerald-300" : "text-gray-500"
-            }`}
-          >
-            {item.icon}
-            <span className="mt-0.5">{item.label}</span>
-            {item.badge !== undefined && item.badge > 0 && (
-              <span className={`absolute right-1/4 top-1 flex h-3.5 w-3.5 items-center justify-center rounded-full text-[8px] text-white ${item.badgeColor || "bg-emerald-500"}`}>
-                {item.badge > 9 ? "9+" : item.badge}
-              </span>
-            )}
-          </button>
-        ))}
-      </nav>
-
-      <Suspense fallback={null}>
-        {officeInfoAgent && (
-          <AgentInfoCard
-            agent={officeInfoAgent}
-            spriteMap={spriteMap}
-            isKo={isKo}
-            locale={locale}
-            tr={tr}
-            departments={departments}
-            onClose={() => setOfficeInfoAgent(null)}
-            onAgentUpdated={() => {
-              refreshAgents();
-              refreshAllAgents();
-              refreshOffices();
-              refreshAuditLogs();
-            }}
-          />
-        )}
-      </Suspense>
-
-      <Suspense fallback={null}>
-        {showCmdPalette && (
-          <CommandPalette
-            agents={allAgents}
-            departments={departments}
-            isKo={isKo}
-            onSelectAgent={(agent) => setOfficeInfoAgent(agent)}
-            onNavigate={handlePaletteNavigate}
-            onClose={() => setShowCmdPalette(false)}
-            routes={PALETTE_ROUTES}
-            departmentRouteId="control_departments"
-          />
-        )}
-      </Suspense>
-
-      <ToastOverlay notifications={notifications} onDismiss={dismissNotification} />
-
-      {showShortcutHelp && (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center" onClick={() => setShowShortcutHelp(false)}>
-          <div className="fixed inset-0 bg-black/50 backdrop-blur-sm" />
-          <div
-            role="dialog"
-            aria-modal="true"
-            aria-label="Keyboard shortcuts"
-            className="relative mx-4 w-full max-w-md space-y-4 rounded-2xl border border-[var(--th-border)] bg-[var(--th-surface)] p-6 shadow-2xl"
-            onClick={(event) => event.stopPropagation()}
-          >
-            <div className="flex items-center justify-between">
-              <h3 className="text-lg font-bold" style={{ color: "var(--th-text-heading)" }}>
-                {isKo ? "키보드 단축키" : "Keyboard Shortcuts"}
-              </h3>
-              <button
-                onClick={() => setShowShortcutHelp(false)}
-                className="flex h-11 w-11 items-center justify-center rounded-lg text-[var(--th-text-muted)] hover:bg-white/5"
-                aria-label="Close"
-              >
-                ✕
-              </button>
-            </div>
-            <div className="space-y-2 text-sm">
-              <div className="flex justify-between" style={{ color: "var(--th-text-muted)" }}>
-                <span>{isKo ? "명령 팔레트" : "Command Palette"}</span>
-                <kbd className="rounded bg-black/10 px-2 py-0.5 text-xs">⌘K</kbd>
-              </div>
-              <div className="flex justify-between" style={{ color: "var(--th-text-muted)" }}>
-                <span>{isKo ? "이 도움말" : "This help"}</span>
-                <kbd className="rounded bg-black/10 px-2 py-0.5 text-xs">?</kbd>
-              </div>
-              <hr style={{ borderColor: "var(--th-border)" }} />
-              <div className="text-xs font-semibold uppercase" style={{ color: "var(--th-text-muted)" }}>
-                {isKo ? "뷰 전환" : "View Navigation"}
-              </div>
-              {VIEW_ROUTES.map((route) => (
-                <div key={route.id} className="flex justify-between" style={{ color: "var(--th-text-muted)" }}>
-                  <span>{isKo ? route.labelKo : route.labelEn}</span>
-                  <kbd className="rounded bg-black/10 px-2 py-0.5 text-xs">Alt+{route.shortcutKey.toUpperCase()}</kbd>
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
-function NavBtn({
-  icon,
-  active,
-  badge,
-  badgeColor,
-  onClick,
-  label,
-}: {
-  icon: React.ReactNode;
-  active: boolean;
-  badge?: number;
-  badgeColor?: string;
-  onClick: () => void;
-  label: string;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      title={label}
-      className={`relative flex w-14 flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 transition-colors ${
-        active ? "bg-emerald-600 text-white" : "text-gray-500 hover:bg-gray-800 hover:text-gray-300"
-      }`}
-    >
-      {icon}
-      <span className="text-xs leading-tight">{label}</span>
-      {badge !== undefined && badge > 0 && (
-        <span className={`absolute -right-0.5 -top-1 flex h-4 w-4 items-center justify-center rounded-full text-[10px] text-white ${badgeColor || "bg-emerald-500"}`}>
-          {badge > 9 ? "9+" : badge}
-        </span>
-      )}
-    </button>
-  );
-}
-
-function ViewSkeleton({ label }: { label: string }) {
-  return (
-    <div className="flex h-full items-center justify-center text-gray-500">
-      {label}
-    </div>
   );
 }

--- a/dashboard/src/app/AppShell.tsx
+++ b/dashboard/src/app/AppShell.tsx
@@ -1,0 +1,1594 @@
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Bell,
+  BellRing,
+  Building2,
+  ChevronLeft,
+  ChevronRight,
+  FolderKanban,
+  Home,
+  LayoutDashboard,
+  Menu,
+  Moon,
+  Search,
+  Settings,
+  Sparkles,
+  SunMedium,
+  Trophy,
+  Users,
+  Wifi,
+  WifiOff,
+  Wrench,
+  X,
+} from "lucide-react";
+import {
+  Link,
+  NavLink,
+  Navigate,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+} from "react-router-dom";
+import type {
+  Agent,
+  CompanySettings,
+  DashboardStats,
+  KanbanCard,
+  RoundTableMeeting,
+} from "../types";
+import { DEFAULT_SETTINGS } from "../types";
+import * as api from "../api/client";
+import { useKanban } from "../contexts/KanbanContext";
+import { useOffice } from "../contexts/OfficeContext";
+import { useSettings } from "../contexts/SettingsContext";
+import { useSpriteMap } from "../components/AgentAvatar";
+import {
+  ToastOverlay,
+  type Notification,
+} from "../components/NotificationCenter";
+import OfficeSelectorBar from "../components/OfficeSelectorBar";
+import {
+  APP_ROUTE_SECTIONS,
+  DEFAULT_ROUTE_PATH,
+  PALETTE_ROUTES,
+  PRIMARY_ROUTES,
+  findRouteByPath,
+  getSectionById,
+  type AppRouteEntry,
+  type AppRouteId,
+} from "./routes";
+import type { DashboardTab } from "./dashboardTabs";
+
+const OfficeView = lazy(() => import("../components/OfficeView"));
+const DashboardPageView = lazy(() => import("../components/DashboardPageView"));
+const KanbanTab = lazy(() => import("../components/agent-manager/KanbanTab"));
+const AgentManagerView = lazy(() => import("../components/AgentManagerView"));
+const OfficeManagerView = lazy(() => import("../components/OfficeManagerView"));
+const MeetingMinutesView = lazy(() => import("../components/MeetingMinutesView"));
+const SettingsView = lazy(() => import("../components/SettingsView"));
+const AgentInfoCard = lazy(() => import("../components/agent-manager/AgentInfoCard"));
+const CommandPalette = lazy(() => import("../components/CommandPalette"));
+
+interface AppShellProps {
+  wsConnected: boolean;
+  notifications: Notification[];
+  pushNotification: (message: string, type?: Notification["type"]) => string;
+  updateNotification: (
+    id: string,
+    message: string,
+    type?: Notification["type"],
+  ) => void;
+  dismissNotification: (id: string) => void;
+}
+
+type AgentsPageTab = "agents" | "departments" | "dispatch";
+type KanbanSignalFocus = "review" | "blocked" | "requested" | "stalled";
+
+const SIDEBAR_COLLAPSED_STORAGE_KEY = "agentdesk.sidebar.collapsed";
+
+export default function AppShell({
+  wsConnected,
+  notifications,
+  pushNotification,
+  updateNotification,
+  dismissNotification,
+}: AppShellProps) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const currentRoute = useMemo(
+    () => findRouteByPath(location.pathname),
+    [location.pathname],
+  );
+  const { settings, setSettings, stats, refreshStats, isKo, locale, tr } =
+    useSettings();
+  const {
+    offices,
+    selectedOfficeId,
+    setSelectedOfficeId,
+    agents,
+    allAgents,
+    departments,
+    allDepartments,
+    setSessions,
+    roundTableMeetings,
+    setRoundTableMeetings,
+    auditLogs,
+    visibleDispatchedSessions,
+    subAgents,
+    agentsWithDispatched,
+    refreshOffices,
+    refreshAgents,
+    refreshAllAgents,
+    refreshDepartments,
+    refreshAllDepartments,
+    refreshAuditLogs,
+  } = useOffice();
+  const { kanbanCards, taskDispatches, upsertKanbanCard, setKanbanCards } =
+    useKanban();
+
+  const [officeInfoAgent, setOfficeInfoAgent] = useState<Agent | null>(null);
+  const [showCommandPalette, setShowCommandPalette] = useState(false);
+  const [showShortcutHelp, setShowShortcutHelp] = useState(false);
+  const [showNotificationPanel, setShowNotificationPanel] = useState(false);
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const [agentsPageTab, setAgentsPageTab] = useState<AgentsPageTab>("agents");
+  const [kanbanSignalFocus, setKanbanSignalFocus] =
+    useState<KanbanSignalFocus | null>(null);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return (
+      window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === "true"
+    );
+  });
+
+  const spriteMap = useSpriteMap(agents);
+  const unresolvedMeetingsCount = roundTableMeetings.filter(
+    hasUnresolvedMeetingIssues,
+  ).length;
+  const unreadCount = notifications.filter(
+    (notification) => Date.now() - notification.ts < 60_000,
+  ).length;
+  const notificationBadgeCount = unresolvedMeetingsCount + unreadCount;
+  const resolvedTheme = getResolvedTheme(settings.theme);
+  const recentNotifications = notifications.slice(0, 6);
+
+  useEffect(() => {
+    window.localStorage.setItem(
+      SIDEBAR_COLLAPSED_STORAGE_KEY,
+      String(sidebarCollapsed),
+    );
+  }, [sidebarCollapsed]);
+
+  useEffect(() => {
+    setMobileSidebarOpen(false);
+    setShowNotificationPanel(false);
+  }, [location.pathname]);
+
+  useEffect(() => {
+    if (currentRoute?.id === "home" || currentRoute?.id === "stats") {
+      refreshStats();
+    }
+  }, [currentRoute?.id, refreshStats]);
+
+  const persistSettingsPatch = useCallback(
+    async (patch: Record<string, unknown>) => {
+      const mergedSettings = { ...settings, ...patch } as CompanySettings;
+      await api.saveSettings(mergedSettings);
+      const refreshed = await api.getSettings();
+      setSettings({ ...DEFAULT_SETTINGS, ...refreshed } as CompanySettings);
+      refreshAuditLogs();
+    },
+    [refreshAuditLogs, setSettings, settings],
+  );
+
+  const navigateToRoute = useCallback(
+    (
+      path: string,
+      options?: { agentsTab?: AgentsPageTab; kanbanFocus?: KanbanSignalFocus },
+    ) => {
+      if (options?.agentsTab) {
+        setAgentsPageTab(options.agentsTab);
+      }
+      if (options?.kanbanFocus) {
+        setKanbanSignalFocus(options.kanbanFocus);
+      }
+      navigate(path);
+    },
+    [navigate],
+  );
+
+  const toggleTheme = useCallback(async () => {
+    const nextTheme = resolvedTheme === "dark" ? "light" : "dark";
+    try {
+      await persistSettingsPatch({ theme: nextTheme });
+      pushNotification(
+        tr("테마가 변경되었습니다.", "Theme updated."),
+        "success",
+      );
+    } catch {
+      pushNotification(
+        tr("테마를 저장하지 못했습니다.", "Failed to save theme."),
+        "error",
+      );
+    }
+  }, [persistSettingsPatch, pushNotification, resolvedTheme, tr]);
+
+  const handleOfficeChanged = useCallback(() => {
+    refreshOffices();
+    refreshAgents();
+    refreshAllAgents();
+    refreshDepartments();
+    refreshAllDepartments();
+    refreshAuditLogs();
+  }, [
+    refreshAgents,
+    refreshAllAgents,
+    refreshAllDepartments,
+    refreshAuditLogs,
+    refreshDepartments,
+    refreshOffices,
+  ]);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const tag = target?.tagName;
+      const isEditable = Boolean(
+        target?.isContentEditable ||
+          tag === "INPUT" ||
+          tag === "TEXTAREA" ||
+          tag === "SELECT",
+      );
+      if (isEditable) return;
+
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        setShowCommandPalette((prev) => !prev);
+        return;
+      }
+
+      if (
+        event.key === "?" &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey
+      ) {
+        event.preventDefault();
+        setShowShortcutHelp((prev) => !prev);
+        return;
+      }
+
+      if (event.altKey && !event.metaKey && !event.ctrlKey) {
+        const route = PRIMARY_ROUTES.find(
+          (item) => item.shortcutKey === event.key,
+        );
+        if (!route) return;
+        event.preventDefault();
+        navigateToRoute(route.path);
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [navigateToRoute]);
+
+  const breadcrumbSection = getSectionById(
+    currentRoute?.section ?? APP_ROUTE_SECTIONS[0].id,
+  );
+
+  return (
+    <div
+      className="fixed inset-0 flex overflow-hidden"
+      style={{ background: "var(--th-bg-primary)" }}
+    >
+      <div
+        className={`fixed inset-0 z-[70] bg-black/50 backdrop-blur-sm transition-opacity md:hidden ${
+          mobileSidebarOpen
+            ? "pointer-events-auto opacity-100"
+            : "pointer-events-none opacity-0"
+        }`}
+        onClick={() => setMobileSidebarOpen(false)}
+      />
+
+      <aside
+        data-testid="app-sidebar"
+        className={`fixed inset-y-0 left-0 z-[80] flex flex-col border-r transition-transform duration-200 md:static md:translate-x-0 ${
+          mobileSidebarOpen ? "translate-x-0" : "-translate-x-full"
+        }`}
+        style={{
+          width: sidebarCollapsed ? "5.5rem" : "15rem",
+          borderColor: "var(--th-border-subtle)",
+          background:
+            "linear-gradient(180deg, color-mix(in srgb, var(--th-nav-bg) 96%, black 4%) 0%, color-mix(in srgb, var(--th-bg-surface) 94%, transparent) 100%)",
+        }}
+      >
+        <div
+          className={`flex items-center gap-3 border-b px-4 py-4 ${
+            sidebarCollapsed ? "justify-center" : ""
+          }`}
+          style={{ borderColor: "var(--th-border-subtle)" }}
+        >
+          <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-emerald-500/15 text-xl text-emerald-300">
+            🐾
+          </div>
+          {!sidebarCollapsed && (
+            <div className="min-w-0">
+              <div
+                className="truncate text-sm font-semibold"
+                style={{ color: "var(--th-text-heading)" }}
+              >
+                AgentDesk
+              </div>
+              <div
+                className="truncate text-xs"
+                style={{ color: "var(--th-text-muted)" }}
+              >
+                {isKo ? "앱 셸 v2" : "App shell v2"}
+              </div>
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={() =>
+              window.innerWidth >= 768
+                ? setSidebarCollapsed((prev) => !prev)
+                : setMobileSidebarOpen(false)
+            }
+            className="ml-auto hidden h-9 w-9 items-center justify-center rounded-xl border text-[var(--th-text-secondary)] transition-colors hover:bg-white/5 md:flex"
+            style={{ borderColor: "var(--th-border-subtle)" }}
+            aria-label={
+              sidebarCollapsed
+                ? tr("사이드바 펼치기", "Expand sidebar")
+                : tr("사이드바 접기", "Collapse sidebar")
+            }
+            title={
+              sidebarCollapsed
+                ? tr("사이드바 펼치기", "Expand sidebar")
+                : tr("사이드바 접기", "Collapse sidebar")
+            }
+          >
+            {sidebarCollapsed ? (
+              <ChevronRight size={16} />
+            ) : (
+              <ChevronLeft size={16} />
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={() => setMobileSidebarOpen(false)}
+            className="ml-auto flex h-9 w-9 items-center justify-center rounded-xl border text-[var(--th-text-secondary)] md:hidden"
+            style={{ borderColor: "var(--th-border-subtle)" }}
+            aria-label={tr("사이드바 닫기", "Close sidebar")}
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-3 py-4">
+          {APP_ROUTE_SECTIONS.map((section) => {
+            const routes = PRIMARY_ROUTES.filter(
+              (route) => route.section === section.id,
+            );
+            return (
+              <div key={section.id} className="mb-5">
+                {!sidebarCollapsed && (
+                  <div
+                    className="px-3 pb-2 text-[11px] font-semibold uppercase tracking-[0.18em]"
+                    style={{ color: "var(--th-text-muted)" }}
+                  >
+                    {isKo ? section.labelKo : section.labelEn}
+                  </div>
+                )}
+                <div className="space-y-1">
+                  {routes.map((route) => (
+                    <SidebarRouteButton
+                      key={route.id}
+                      route={route}
+                      currentRouteId={currentRoute?.id ?? null}
+                      collapsed={sidebarCollapsed}
+                      isKo={isKo}
+                      badge={
+                        route.id === "meetings"
+                          ? unresolvedMeetingsCount || undefined
+                          : route.id === "settings"
+                            ? unreadCount || undefined
+                            : undefined
+                      }
+                      onNavigate={() => {
+                        if (route.id === "agents") {
+                          setAgentsPageTab("agents");
+                        }
+                        navigateToRoute(route.path);
+                      }}
+                    />
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div
+          className="border-t px-3 py-3"
+          style={{ borderColor: "var(--th-border-subtle)" }}
+        >
+          <div
+            className={`flex items-center gap-3 rounded-2xl border px-3 py-3 ${
+              sidebarCollapsed ? "justify-center" : ""
+            }`}
+            style={{
+              borderColor: wsConnected ? "#1f9d66" : "#9f3f3f",
+              background: wsConnected
+                ? "rgba(16, 185, 129, 0.08)"
+                : "rgba(239, 68, 68, 0.08)",
+            }}
+          >
+            {wsConnected ? (
+              <Wifi size={16} className="text-emerald-400" />
+            ) : (
+              <WifiOff size={16} className="text-red-400" />
+            )}
+            {!sidebarCollapsed && (
+              <div className="min-w-0">
+                <div
+                  className="text-xs font-semibold"
+                  style={{ color: "var(--th-text-primary)" }}
+                >
+                  {wsConnected
+                    ? tr("서버 연결됨", "Server connected")
+                    : tr("재연결 중", "Reconnecting")}
+                </div>
+                <div
+                  className="truncate text-[11px]"
+                  style={{ color: "var(--th-text-muted)" }}
+                >
+                  {wsConnected
+                    ? tr("실시간 업데이트 수신 중", "Realtime updates active")
+                    : tr("웹소켓 상태를 확인하세요", "Check websocket status")}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </aside>
+
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        <header
+          data-testid="topbar"
+          className="relative z-[60] shrink-0 border-b px-4 py-3 sm:px-5"
+          style={{
+            borderColor: "var(--th-border-subtle)",
+            background:
+              "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 94%, transparent) 100%)",
+          }}
+        >
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={() => setMobileSidebarOpen(true)}
+              className="flex h-10 w-10 items-center justify-center rounded-xl border md:hidden"
+              style={{ borderColor: "var(--th-border-subtle)" }}
+              aria-label={tr("사이드바 열기", "Open sidebar")}
+            >
+              <Menu size={18} />
+            </button>
+
+            <div className="min-w-0 flex-1">
+              <div
+                className="flex items-center gap-2 text-xs font-medium"
+                style={{ color: "var(--th-text-muted)" }}
+              >
+                <span>{isKo ? breadcrumbSection.labelKo : breadcrumbSection.labelEn}</span>
+                <ChevronRight size={12} />
+                <span>{currentRoute ? (isKo ? currentRoute.labelKo : currentRoute.labelEn) : (isKo ? "홈" : "Home")}</span>
+              </div>
+              <div
+                className="mt-1 text-lg font-semibold tracking-tight"
+                style={{ color: "var(--th-text-heading)" }}
+              >
+                {currentRoute
+                  ? isKo
+                    ? currentRoute.labelKo
+                    : currentRoute.labelEn
+                  : tr("홈", "Home")}
+              </div>
+            </div>
+
+            <label
+              data-testid="topbar-search"
+              className="order-3 flex min-w-[14rem] flex-1 items-center gap-2 rounded-2xl border px-3 py-2 text-sm sm:order-none sm:max-w-md"
+              style={{
+                borderColor: "var(--th-border-subtle)",
+                background: "color-mix(in srgb, var(--th-bg-surface) 92%, transparent)",
+              }}
+            >
+              <Search size={16} style={{ color: "var(--th-text-muted)" }} />
+              <input
+                type="search"
+                readOnly
+                value=""
+                onFocus={() => setShowCommandPalette(true)}
+                onClick={() => setShowCommandPalette(true)}
+                placeholder={tr(
+                  "페이지, 에이전트, 부서 검색",
+                  "Search pages, agents, departments",
+                )}
+                className="w-full bg-transparent text-sm outline-none"
+                style={{ color: "var(--th-text-primary)" }}
+                aria-label={tr("검색 열기", "Open search")}
+              />
+              <kbd
+                className="hidden rounded-lg px-2 py-1 text-[11px] sm:inline-flex"
+                style={{
+                  background: "var(--th-overlay-subtle)",
+                  color: "var(--th-text-muted)",
+                }}
+              >
+                ⌘K
+              </kbd>
+            </label>
+
+            <div className="ml-auto flex items-center gap-2 sm:ml-0">
+              <button
+                type="button"
+                onClick={() => void toggleTheme()}
+                className="flex h-10 w-10 items-center justify-center rounded-xl border transition-colors hover:bg-white/5"
+                style={{ borderColor: "var(--th-border-subtle)" }}
+                aria-label={tr("테마 전환", "Toggle theme")}
+                title={tr("테마 전환", "Toggle theme")}
+              >
+                {resolvedTheme === "dark" ? (
+                  <SunMedium size={18} />
+                ) : (
+                  <Moon size={18} />
+                )}
+              </button>
+
+              <div className="relative">
+                <button
+                  type="button"
+                  onClick={() =>
+                    setShowNotificationPanel((prev) => !prev)
+                  }
+                  className="relative flex h-10 w-10 items-center justify-center rounded-xl border transition-colors hover:bg-white/5"
+                  style={{ borderColor: "var(--th-border-subtle)" }}
+                  aria-label={tr("알림 보기", "View notifications")}
+                  title={tr("알림 보기", "View notifications")}
+                >
+                  {notificationBadgeCount > 0 ? (
+                    <BellRing size={18} />
+                  ) : (
+                    <Bell size={18} />
+                  )}
+                  {notificationBadgeCount > 0 && (
+                    <span className="absolute -right-1 -top-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-emerald-500 px-1 text-[10px] font-semibold text-white">
+                      {notificationBadgeCount > 9 ? "9+" : notificationBadgeCount}
+                    </span>
+                  )}
+                </button>
+
+                {showNotificationPanel && (
+                  <div
+                    className="absolute right-0 top-12 z-[90] w-[min(22rem,calc(100vw-2rem))] rounded-3xl border p-3 shadow-2xl"
+                    style={{
+                      borderColor: "var(--th-border-subtle)",
+                      background:
+                        "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 95%, transparent) 100%)",
+                    }}
+                  >
+                    <div className="flex items-center justify-between gap-3 px-1 pb-2">
+                      <div>
+                        <div
+                          className="text-sm font-semibold"
+                          style={{ color: "var(--th-text-heading)" }}
+                        >
+                          {tr("알림", "Notifications")}
+                        </div>
+                        <div
+                          className="text-xs"
+                          style={{ color: "var(--th-text-muted)" }}
+                        >
+                          {tr(
+                            "최근 이벤트와 회의 후속 상태",
+                            "Recent events and meeting follow-ups",
+                          )}
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => setShowNotificationPanel(false)}
+                        className="flex h-8 w-8 items-center justify-center rounded-xl text-[var(--th-text-muted)]"
+                      >
+                        <X size={14} />
+                      </button>
+                    </div>
+
+                    <div className="space-y-2">
+                      <NotificationSummaryRow
+                        label={tr("미해결 회의", "Open meetings")}
+                        value={unresolvedMeetingsCount}
+                        accent="var(--th-accent-warn)"
+                      />
+                      <NotificationSummaryRow
+                        label={tr("최근 토스트", "Recent toasts")}
+                        value={recentNotifications.length}
+                        accent="var(--th-accent-info)"
+                      />
+                    </div>
+
+                    <div className="mt-3 space-y-2">
+                      {recentNotifications.length === 0 ? (
+                        <div
+                          className="rounded-2xl border px-3 py-4 text-sm"
+                          style={{
+                            borderColor: "var(--th-border-subtle)",
+                            color: "var(--th-text-muted)",
+                            background: "var(--th-overlay-subtle)",
+                          }}
+                        >
+                          {tr("새 알림이 없습니다.", "No recent notifications.")}
+                        </div>
+                      ) : (
+                        recentNotifications.map((notification) => (
+                          <div
+                            key={notification.id}
+                            className="rounded-2xl border px-3 py-3"
+                            style={{
+                              borderColor: "var(--th-border-subtle)",
+                              background: "var(--th-overlay-subtle)",
+                            }}
+                          >
+                            <div className="flex items-start gap-3">
+                              <span
+                                className="mt-1 h-2.5 w-2.5 rounded-full"
+                                style={{
+                                  background: notificationColor(notification.type),
+                                }}
+                              />
+                              <div className="min-w-0 flex-1">
+                                <div
+                                  className="text-sm leading-relaxed"
+                                  style={{ color: "var(--th-text-primary)" }}
+                                >
+                                  {notification.message}
+                                </div>
+                                <div
+                                  className="mt-1 text-[11px]"
+                                  style={{ color: "var(--th-text-muted)" }}
+                                >
+                                  {formatRelativeTime(notification.ts, isKo)}
+                                </div>
+                              </div>
+                              <button
+                                type="button"
+                                onClick={() => dismissNotification(notification.id)}
+                                className="flex h-8 w-8 items-center justify-center rounded-xl text-[var(--th-text-muted)]"
+                              >
+                                <X size={12} />
+                              </button>
+                            </div>
+                          </div>
+                        ))
+                      )}
+                    </div>
+
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setShowNotificationPanel(false);
+                        navigateToRoute("/meetings");
+                      }}
+                      className="mt-3 flex w-full items-center justify-center gap-2 rounded-2xl border px-3 py-2 text-sm font-medium transition-colors hover:bg-white/5"
+                      style={{ borderColor: "var(--th-border-subtle)" }}
+                    >
+                      <Sparkles size={15} />
+                      {tr("회의 페이지로 이동", "Open meetings page")}
+                    </button>
+                  </div>
+                )}
+              </div>
+
+              <button
+                type="button"
+                onClick={() => navigateToRoute("/settings")}
+                className="flex h-10 w-10 items-center justify-center rounded-xl border transition-colors hover:bg-white/5"
+                style={{ borderColor: "var(--th-border-subtle)" }}
+                aria-label={tr("설정으로 이동", "Open settings")}
+                title={tr("설정으로 이동", "Open settings")}
+              >
+                <Settings size={18} />
+              </button>
+            </div>
+          </div>
+        </header>
+
+        {currentRoute?.showOfficeSelector && offices.length > 0 && (
+          <OfficeSelectorBar
+            offices={offices}
+            selectedOfficeId={selectedOfficeId}
+            onSelectOffice={setSelectedOfficeId}
+            onManageOffices={() => navigateToRoute("/ops")}
+            isKo={isKo}
+          />
+        )}
+
+        <main className="min-h-0 flex-1 overflow-hidden">
+          <Suspense
+            fallback={
+              <ViewSkeleton
+                label={
+                  currentRoute
+                    ? isKo
+                      ? currentRoute.labelKo
+                      : currentRoute.labelEn
+                    : tr("로딩 중...", "Loading...")
+                }
+              />
+            }
+          >
+            <Routes>
+              <Route path="/" element={<Navigate replace to={DEFAULT_ROUTE_PATH} />} />
+              <Route
+                path="/home"
+                element={
+                  <HomeOverviewPage
+                    isKo={isKo}
+                    currentOfficeLabel={selectedOfficeLabel(
+                      offices,
+                      selectedOfficeId,
+                      tr,
+                    )}
+                    stats={stats}
+                    meetings={roundTableMeetings}
+                    notifications={notifications}
+                    kanbanCards={kanbanCards}
+                  />
+                }
+              />
+              <Route
+                path="/office"
+                element={
+                  <OfficeView
+                    agents={agentsWithDispatched}
+                    departments={departments}
+                    language={settings.language}
+                    theme={resolvedTheme}
+                    subAgents={subAgents}
+                    notifications={notifications}
+                    auditLogs={auditLogs}
+                    activeMeeting={
+                      roundTableMeetings.find(
+                        (meeting) => meeting.status === "in_progress",
+                      ) ?? null
+                    }
+                    kanbanCards={kanbanCards}
+                    onNavigateToKanban={() => navigateToRoute("/kanban")}
+                    onSelectAgent={(agent) => setOfficeInfoAgent(agent)}
+                    onSelectDepartment={() =>
+                      navigateToRoute("/agents", { agentsTab: "departments" })
+                    }
+                    customDeptThemes={settings.roomThemes}
+                  />
+                }
+              />
+              <Route
+                path="/agents"
+                element={
+                  <AgentManagerView
+                    agents={agents}
+                    departments={departments}
+                    language={settings.language}
+                    officeId={selectedOfficeId}
+                    onAgentsChange={() => {
+                      refreshAgents();
+                      refreshAllAgents();
+                      refreshOffices();
+                    }}
+                    onDepartmentsChange={() => {
+                      refreshDepartments();
+                      refreshAllDepartments();
+                      refreshOffices();
+                    }}
+                    sessions={visibleDispatchedSessions}
+                    onAssign={async (id, patch) => {
+                      const updated = await api.assignDispatchedSession(id, patch);
+                      setSessions((prev) =>
+                        prev.map((session) =>
+                          session.id === updated.id ? updated : session,
+                        ),
+                      );
+                    }}
+                    activeTab={agentsPageTab}
+                    onTabChange={setAgentsPageTab}
+                  />
+                }
+              />
+              <Route
+                path="/kanban"
+                element={
+                  <div className="h-full overflow-auto p-4 pb-36 sm:p-6">
+                    <KanbanTab
+                      tr={(ko: string, en: string) =>
+                        settings.language === "ko" ? ko : en
+                      }
+                      locale={settings.language}
+                      cards={kanbanCards}
+                      dispatches={taskDispatches}
+                      agents={allAgents}
+                      departments={allDepartments}
+                      onAssignIssue={async (payload) => {
+                        const assigned = await api.assignKanbanIssue(payload);
+                        upsertKanbanCard(assigned);
+                      }}
+                      onUpdateCard={async (id, patch) => {
+                        const updated = await api.updateKanbanCard(id, patch);
+                        upsertKanbanCard(updated);
+                      }}
+                      onRetryCard={async (id, payload) => {
+                        const updated = await api.retryKanbanCard(id, payload);
+                        upsertKanbanCard(updated);
+                      }}
+                      onRedispatchCard={async (id, payload) => {
+                        const updated = await api.redispatchKanbanCard(id, payload);
+                        upsertKanbanCard(updated);
+                      }}
+                      onDeleteCard={async (id: string) => {
+                        await api.deleteKanbanCard(id);
+                        setKanbanCards((prev) =>
+                          prev.filter((card) => card.id !== id),
+                        );
+                      }}
+                      onPatchDeferDod={async (id, payload) => {
+                        const updated = await api.patchKanbanDeferDod(id, payload);
+                        upsertKanbanCard(updated);
+                      }}
+                      externalStatusFocus={kanbanSignalFocus}
+                      onClearSignalFocus={() => setKanbanSignalFocus(null)}
+                    />
+                  </div>
+                }
+              />
+              <Route
+                path="/stats"
+                element={
+                  <DashboardPageView
+                    stats={stats}
+                    agents={agents}
+                    sessions={visibleDispatchedSessions}
+                    meetings={roundTableMeetings}
+                    settings={settings}
+                    onSelectAgent={(agent) => setOfficeInfoAgent(agent)}
+                    onOpenKanbanSignal={(signal) =>
+                      navigateToRoute("/kanban", {
+                        kanbanFocus: signal,
+                      })
+                    }
+                    onOpenDispatchSessions={() =>
+                      navigateToRoute("/agents", { agentsTab: "dispatch" })
+                    }
+                    onOpenSettings={() => navigateToRoute("/settings")}
+                    onRefreshMeetings={() =>
+                      api
+                        .getRoundTableMeetings()
+                        .then(setRoundTableMeetings)
+                        .catch(() => {})
+                    }
+                  />
+                }
+              />
+              <Route
+                path="/ops"
+                element={
+                  <OfficeManagerView
+                    offices={offices}
+                    allAgents={allAgents}
+                    selectedOfficeId={selectedOfficeId}
+                    isKo={isKo}
+                    onChanged={handleOfficeChanged}
+                  />
+                }
+              />
+              <Route
+                path="/meetings"
+                element={
+                  <MeetingMinutesView
+                    meetings={roundTableMeetings}
+                    onRefresh={() =>
+                      api
+                        .getRoundTableMeetings()
+                        .then(setRoundTableMeetings)
+                        .catch(() => {})
+                    }
+                    onNotify={pushNotification}
+                    onUpdateNotification={updateNotification}
+                  />
+                }
+              />
+              <Route
+                path="/achievements"
+                element={
+                  <DashboardPageView
+                    key="dashboard-achievements"
+                    stats={stats}
+                    agents={agents}
+                    sessions={visibleDispatchedSessions}
+                    meetings={roundTableMeetings}
+                    settings={settings}
+                    requestedTab={"achievements" satisfies DashboardTab}
+                    onSelectAgent={(agent) => setOfficeInfoAgent(agent)}
+                    onOpenKanbanSignal={(signal) =>
+                      navigateToRoute("/kanban", {
+                        kanbanFocus: signal,
+                      })
+                    }
+                    onOpenDispatchSessions={() =>
+                      navigateToRoute("/agents", { agentsTab: "dispatch" })
+                    }
+                    onOpenSettings={() => navigateToRoute("/settings")}
+                    onRefreshMeetings={() =>
+                      api
+                        .getRoundTableMeetings()
+                        .then(setRoundTableMeetings)
+                        .catch(() => {})
+                    }
+                  />
+                }
+              />
+              <Route
+                path="/settings"
+                element={
+                  <SettingsView
+                    settings={settings}
+                    onSave={persistSettingsPatch}
+                    isKo={isKo}
+                  />
+                }
+              />
+              {PRIMARY_ROUTES.flatMap((route) =>
+                (route.aliases ?? []).map((alias) => (
+                  <Route
+                    key={`${route.id}:${alias}`}
+                    path={alias}
+                    element={<Navigate replace to={route.path} />}
+                  />
+                )),
+              )}
+              <Route
+                path="*"
+                element={<Navigate replace to={DEFAULT_ROUTE_PATH} />}
+              />
+            </Routes>
+          </Suspense>
+        </main>
+      </div>
+
+      <Suspense fallback={null}>
+        {officeInfoAgent && (
+          <AgentInfoCard
+            agent={officeInfoAgent}
+            spriteMap={spriteMap}
+            isKo={isKo}
+            locale={locale}
+            tr={tr}
+            departments={departments}
+            onClose={() => setOfficeInfoAgent(null)}
+            onAgentUpdated={() => {
+              refreshAgents();
+              refreshAllAgents();
+              refreshOffices();
+              refreshAuditLogs();
+            }}
+          />
+        )}
+      </Suspense>
+
+      <Suspense fallback={null}>
+        {showCommandPalette && (
+          <CommandPalette
+            agents={allAgents}
+            departments={departments}
+            isKo={isKo}
+            onSelectAgent={(agent) => setOfficeInfoAgent(agent)}
+            onNavigate={(path) => navigateToRoute(path)}
+            onClose={() => setShowCommandPalette(false)}
+            routes={PALETTE_ROUTES}
+            departmentRouteId="/agents"
+          />
+        )}
+      </Suspense>
+
+      <ToastOverlay notifications={notifications} onDismiss={dismissNotification} />
+
+      {showShortcutHelp && (
+        <ShortcutHelpModal
+          isKo={isKo}
+          onClose={() => setShowShortcutHelp(false)}
+        />
+      )}
+
+      {!wsConnected && (
+        <div className="pointer-events-none fixed left-4 right-4 top-4 z-[95] flex justify-center md:left-auto md:right-6">
+          <div className="flex items-center gap-2 rounded-full border border-red-500/30 bg-red-500/15 px-4 py-2 text-xs text-red-300 shadow-lg">
+            <WifiOff size={12} />
+            <span>
+              {tr(
+                "서버 연결 끊김, 재연결 중입니다.",
+                "Server disconnected, reconnecting.",
+              )}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SidebarRouteButton({
+  route,
+  currentRouteId,
+  collapsed,
+  isKo,
+  badge,
+  onNavigate,
+}: {
+  route: AppRouteEntry;
+  currentRouteId: AppRouteId | null;
+  collapsed: boolean;
+  isKo: boolean;
+  badge?: number;
+  onNavigate: () => void;
+}) {
+  const active = currentRouteId === route.id;
+  const Icon = iconForRoute(route.id);
+
+  return (
+    <button
+      type="button"
+      onClick={onNavigate}
+      className={`group relative flex w-full items-center gap-3 rounded-2xl px-3 py-3 text-left transition-colors ${
+        collapsed ? "justify-center" : ""
+      }`}
+      style={{
+        background: active
+          ? "color-mix(in srgb, var(--th-accent-primary-soft) 80%, transparent)"
+          : "transparent",
+        color: active ? "var(--th-text-primary)" : "var(--th-text-secondary)",
+      }}
+      title={collapsed ? (isKo ? route.labelKo : route.labelEn) : undefined}
+    >
+      <span
+        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl"
+        style={{
+          background: active
+            ? "color-mix(in srgb, var(--th-accent-primary) 18%, transparent)"
+            : "var(--th-overlay-subtle)",
+        }}
+      >
+        <Icon size={18} />
+      </span>
+      {!collapsed && (
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-sm font-medium">
+            {isKo ? route.labelKo : route.labelEn}
+          </span>
+          <span
+            className="mt-0.5 block truncate text-[11px]"
+            style={{ color: "var(--th-text-muted)" }}
+          >
+            {isKo ? route.descriptionKo : route.descriptionEn}
+          </span>
+        </span>
+      )}
+      {badge !== undefined && badge > 0 && (
+        <span className="absolute right-3 top-3 flex h-5 min-w-5 items-center justify-center rounded-full bg-emerald-500 px-1 text-[10px] font-semibold text-white">
+          {badge > 9 ? "9+" : badge}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function NotificationSummaryRow({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: number;
+  accent: string;
+}) {
+  return (
+    <div
+      className="flex items-center justify-between rounded-2xl border px-3 py-2 text-sm"
+      style={{
+        borderColor: "var(--th-border-subtle)",
+        background: "var(--th-overlay-subtle)",
+      }}
+    >
+      <span style={{ color: "var(--th-text-muted)" }}>{label}</span>
+      <span className="font-semibold" style={{ color: accent }}>
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function HomeOverviewPage({
+  isKo,
+  currentOfficeLabel,
+  stats,
+  meetings,
+  notifications,
+  kanbanCards,
+}: {
+  isKo: boolean;
+  currentOfficeLabel: string;
+  stats: DashboardStats | null;
+  meetings: RoundTableMeeting[];
+  notifications: Notification[];
+  kanbanCards: KanbanCard[];
+}) {
+  const tr = useCallback((ko: string, en: string) => (isKo ? ko : en), [isKo]);
+  const quickRoutes = PRIMARY_ROUTES.filter((route) =>
+    ["office", "kanban", "stats", "meetings", "settings"].includes(route.id),
+  );
+  const outstandingMeetings = meetings.filter(hasUnresolvedMeetingIssues).length;
+  const liveNotifications = notifications.filter(
+    (notification) => Date.now() - notification.ts < 60_000,
+  ).length;
+  const requestedCards = kanbanCards.filter((card) => card.status === "requested").length;
+  const inProgressCards = kanbanCards.filter(
+    (card) => card.status === "in_progress" || card.status === "review",
+  ).length;
+
+  return (
+    <div className="mx-auto h-full w-full max-w-6xl overflow-auto px-4 py-5 pb-32 sm:px-6">
+      <div
+        className="rounded-[2rem] border p-5 sm:p-6"
+        style={{
+          borderColor: "var(--th-border-subtle)",
+          background:
+            "radial-gradient(circle at top left, rgba(110,242,163,0.16) 0%, transparent 35%), linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 94%, transparent) 100%)",
+        }}
+      >
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="max-w-2xl">
+            <div
+              className="text-[11px] font-semibold uppercase tracking-[0.2em]"
+              style={{ color: "var(--th-text-muted)" }}
+            >
+              {tr("오늘의 개요", "Today's overview")}
+            </div>
+            <h1
+              className="mt-3 text-3xl font-semibold tracking-tight sm:text-4xl"
+              style={{ color: "var(--th-text-heading)" }}
+            >
+              {tr("한 번에 운영 흐름을 정리하는 홈", "A home page for the whole operating flow")}
+            </h1>
+            <p
+              className="mt-3 max-w-2xl text-sm leading-7 sm:text-base"
+              style={{ color: "var(--th-text-secondary)" }}
+            >
+              {tr(
+                `현재 범위는 ${currentOfficeLabel} 기준입니다. 오피스, 칸반, 회의, 설정까지 새 앱 셸에서 바로 이동할 수 있습니다.`,
+                `The current scope is ${currentOfficeLabel}. Jump straight into office, kanban, meetings, and settings from the new shell.`,
+              )}
+            </p>
+          </div>
+
+          <div className="grid w-full gap-3 sm:w-auto sm:min-w-[19rem]">
+            <MetricCard
+              title={tr("활성 에이전트", "Active agents")}
+              value={stats?.agents.working ?? 0}
+              detail={tr("현재 작업 중", "Currently working")}
+              tone="emerald"
+            />
+            <MetricCard
+              title={tr("오픈 워크", "Open work")}
+              value={requestedCards + inProgressCards}
+              detail={tr("요청 + 진행 + 리뷰", "Requested + in progress + review")}
+              tone="sky"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <MetricCard
+          title={tr("전체 에이전트", "Total agents")}
+          value={stats?.agents.total ?? 0}
+          detail={tr("워크스페이스 등록 수", "Registered in workspace")}
+          tone="neutral"
+        />
+        <MetricCard
+          title={tr("실시간 세션", "Live sessions")}
+          value={stats?.dispatched_count ?? 0}
+          detail={tr("연결 유지 중", "Currently connected")}
+          tone="sky"
+        />
+        <MetricCard
+          title={tr("미해결 회의", "Open meetings")}
+          value={outstandingMeetings}
+          detail={tr("후속 이슈 확인 필요", "Need follow-up review")}
+          tone="amber"
+        />
+        <MetricCard
+          title={tr("최근 알림", "Recent alerts")}
+          value={liveNotifications}
+          detail={tr("최근 1분 기준", "Within the last minute")}
+          tone="rose"
+        />
+      </div>
+
+      <div className="mt-5 grid gap-4 lg:grid-cols-[1.25fr_0.75fr]">
+        <div
+          className="rounded-[1.75rem] border p-4 sm:p-5"
+          style={{
+            borderColor: "var(--th-border-subtle)",
+            background: "var(--th-card-bg)",
+          }}
+        >
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <div
+                className="text-sm font-semibold"
+                style={{ color: "var(--th-text-heading)" }}
+              >
+                {tr("빠른 진입", "Quick access")}
+              </div>
+              <div
+                className="mt-1 text-sm"
+                style={{ color: "var(--th-text-muted)" }}
+              >
+                {tr("우선 작업 영역으로 바로 이동합니다.", "Jump to the surfaces you need next.")}
+              </div>
+            </div>
+            <LayoutDashboard size={18} style={{ color: "var(--th-text-muted)" }} />
+          </div>
+
+          <div className="mt-4 grid gap-3 md:grid-cols-2">
+            {quickRoutes.map((route) => (
+              <Link
+                key={route.id}
+                to={route.path}
+                className="rounded-[1.5rem] border p-4 transition-transform hover:-translate-y-0.5"
+                style={{
+                  borderColor: "var(--th-border-subtle)",
+                  background: "color-mix(in srgb, var(--th-bg-surface) 92%, transparent)",
+                }}
+              >
+                <div
+                  className="text-sm font-semibold"
+                  style={{ color: "var(--th-text-primary)" }}
+                >
+                  {isKo ? route.labelKo : route.labelEn}
+                </div>
+                <div
+                  className="mt-2 text-sm leading-6"
+                  style={{ color: "var(--th-text-muted)" }}
+                >
+                  {isKo ? route.descriptionKo : route.descriptionEn}
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+
+        <div
+          className="rounded-[1.75rem] border p-4 sm:p-5"
+          style={{
+            borderColor: "var(--th-border-subtle)",
+            background: "var(--th-card-bg)",
+          }}
+        >
+          <div
+            className="text-sm font-semibold"
+            style={{ color: "var(--th-text-heading)" }}
+          >
+            {tr("워크 큐", "Work queue")}
+          </div>
+          <div
+            className="mt-1 text-sm"
+            style={{ color: "var(--th-text-muted)" }}
+          >
+            {tr("현재 카드 상태를 요약합니다.", "A snapshot of current card status.")}
+          </div>
+
+          <div className="mt-4 space-y-3">
+            <QueueRow
+              label={tr("요청됨", "Requested")}
+              value={requestedCards}
+              accent="#66b3ff"
+            />
+            <QueueRow
+              label={tr("진행/리뷰", "In progress / review")}
+              value={inProgressCards}
+              accent="#6ef2a3"
+            />
+            <QueueRow
+              label={tr("완료", "Done")}
+              value={kanbanCards.filter((card) => card.status === "done").length}
+              accent="#f5bd47"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MetricCard({
+  title,
+  value,
+  detail,
+  tone,
+}: {
+  title: string;
+  value: number;
+  detail: string;
+  tone: "neutral" | "emerald" | "sky" | "amber" | "rose";
+}) {
+  const theme = metricToneTheme(tone);
+  return (
+    <div
+      className="rounded-[1.5rem] border p-4"
+      style={{
+        borderColor: theme.border,
+        background: theme.background,
+      }}
+    >
+      <div className="text-sm font-medium" style={{ color: "var(--th-text-muted)" }}>
+        {title}
+      </div>
+      <div
+        className="mt-3 text-3xl font-semibold tracking-tight"
+        style={{ color: "var(--th-text-heading)" }}
+      >
+        {value}
+      </div>
+      <div className="mt-2 text-sm" style={{ color: theme.detail }}>
+        {detail}
+      </div>
+    </div>
+  );
+}
+
+function QueueRow({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: number;
+  accent: string;
+}) {
+  return (
+    <div
+      className="flex items-center justify-between rounded-2xl border px-3 py-3"
+      style={{
+        borderColor: "var(--th-border-subtle)",
+        background: "color-mix(in srgb, var(--th-bg-surface) 90%, transparent)",
+      }}
+    >
+      <span style={{ color: "var(--th-text-secondary)" }}>{label}</span>
+      <span className="font-semibold" style={{ color: accent }}>
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function ShortcutHelpModal({
+  isKo,
+  onClose,
+}: {
+  isKo: boolean;
+  onClose: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center px-4" onClick={onClose}>
+      <div className="fixed inset-0 bg-black/50 backdrop-blur-sm" />
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="relative w-full max-w-md rounded-[2rem] border p-6 shadow-2xl"
+        style={{
+          borderColor: "var(--th-border-subtle)",
+          background:
+            "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 95%, transparent) 100%)",
+        }}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <div>
+            <div
+              className="text-lg font-semibold"
+              style={{ color: "var(--th-text-heading)" }}
+            >
+              {isKo ? "키보드 단축키" : "Keyboard Shortcuts"}
+            </div>
+            <div className="mt-1 text-sm" style={{ color: "var(--th-text-muted)" }}>
+              {isKo ? "새 라우팅 셸 기준" : "For the new route shell"}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex h-9 w-9 items-center justify-center rounded-xl text-[var(--th-text-muted)]"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="mt-5 space-y-3 text-sm">
+          <ShortcutRow
+            label={isKo ? "명령 팔레트" : "Command palette"}
+            combo="⌘K"
+          />
+          <ShortcutRow label={isKo ? "도움말" : "Help"} combo="?" />
+          {PRIMARY_ROUTES.map((route) => (
+            <ShortcutRow
+              key={route.id}
+              label={isKo ? route.labelKo : route.labelEn}
+              combo={`Alt+${route.shortcutKey}`}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ShortcutRow({ label, combo }: { label: string; combo: string }) {
+  return (
+    <div className="flex items-center justify-between rounded-2xl border px-3 py-2" style={{ borderColor: "var(--th-border-subtle)" }}>
+      <span style={{ color: "var(--th-text-secondary)" }}>{label}</span>
+      <kbd
+        className="rounded-lg px-2 py-1 text-xs"
+        style={{
+          background: "var(--th-overlay-subtle)",
+          color: "var(--th-text-primary)",
+        }}
+      >
+        {combo}
+      </kbd>
+    </div>
+  );
+}
+
+function ViewSkeleton({ label }: { label: string }) {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="text-center">
+        <div className="text-3xl opacity-40">🐾</div>
+        <div className="mt-3 text-sm" style={{ color: "var(--th-text-muted)" }}>
+          {label}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function hasUnresolvedMeetingIssues(meeting: RoundTableMeeting): boolean {
+  const totalIssues = meeting.proposed_issues?.length ?? 0;
+  if (meeting.status !== "completed" || totalIssues === 0) return false;
+
+  const results = meeting.issue_creation_results ?? [];
+  if (results.length === 0) {
+    return meeting.issues_created < totalIssues;
+  }
+
+  const created = results.filter(
+    (result) => result.ok && result.discarded !== true,
+  ).length;
+  const failed = results.filter(
+    (result) => !result.ok && result.discarded !== true,
+  ).length;
+  const discarded = results.filter((result) => result.discarded === true).length;
+  const pending = Math.max(totalIssues - created - failed - discarded, 0);
+
+  return pending > 0 || failed > 0;
+}
+
+function getResolvedTheme(theme: CompanySettings["theme"]): "dark" | "light" {
+  if (theme !== "auto") return theme;
+  if (typeof window === "undefined") return "dark";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+function notificationColor(type: Notification["type"]): string {
+  switch (type) {
+    case "success":
+      return "#34d399";
+    case "warning":
+      return "#fbbf24";
+    case "error":
+      return "#f87171";
+    default:
+      return "#60a5fa";
+  }
+}
+
+function formatRelativeTime(timestamp: number, isKo: boolean): string {
+  const diffMs = Date.now() - timestamp;
+  const seconds = Math.max(1, Math.floor(diffMs / 1000));
+  if (seconds < 60) return isKo ? `${seconds}초 전` : `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return isKo ? `${minutes}분 전` : `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return isKo ? `${hours}시간 전` : `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return isKo ? `${days}일 전` : `${days}d ago`;
+}
+
+function selectedOfficeLabel(
+  offices: { id: string; name: string; name_ko: string }[],
+  selectedOfficeId: string | null,
+  tr: (ko: string, en: string) => string,
+): string {
+  if (!selectedOfficeId) return tr("전체", "All");
+  const office = offices.find((candidate) => candidate.id === selectedOfficeId);
+  if (!office) return selectedOfficeId;
+  return office.name_ko || office.name;
+}
+
+function iconForRoute(routeId: AppRouteId) {
+  switch (routeId) {
+    case "home":
+      return Home;
+    case "office":
+      return Building2;
+    case "agents":
+      return Users;
+    case "kanban":
+      return FolderKanban;
+    case "stats":
+      return LayoutDashboard;
+    case "ops":
+      return Wrench;
+    case "meetings":
+      return Bell;
+    case "achievements":
+      return Trophy;
+    case "settings":
+      return Settings;
+  }
+}
+
+function metricToneTheme(tone: "neutral" | "emerald" | "sky" | "amber" | "rose") {
+  switch (tone) {
+    case "emerald":
+      return {
+        border: "rgba(16, 185, 129, 0.24)",
+        background: "rgba(16, 185, 129, 0.09)",
+        detail: "#6ef2a3",
+      };
+    case "sky":
+      return {
+        border: "rgba(96, 165, 250, 0.24)",
+        background: "rgba(96, 165, 250, 0.09)",
+        detail: "#93c5fd",
+      };
+    case "amber":
+      return {
+        border: "rgba(245, 189, 71, 0.24)",
+        background: "rgba(245, 189, 71, 0.08)",
+        detail: "#f5bd47",
+      };
+    case "rose":
+      return {
+        border: "rgba(244, 114, 182, 0.22)",
+        background: "rgba(244, 114, 182, 0.08)",
+        detail: "#f472b6",
+      };
+    default:
+      return {
+        border: "var(--th-border-subtle)",
+        background: "color-mix(in srgb, var(--th-bg-surface) 92%, transparent)",
+        detail: "var(--th-text-muted)",
+      };
+  }
+}

--- a/dashboard/src/app/routes.ts
+++ b/dashboard/src/app/routes.ts
@@ -1,28 +1,180 @@
-export type ViewMode = "office" | "dashboard" | "kanban" | "agents" | "meetings" | "skills" | "settings";
+export type AppSectionId = "workspace" | "knowledge" | "me";
 
-export interface RouteEntry {
-  id: ViewMode;
-  icon: string;
+export type AppRouteId =
+  | "home"
+  | "office"
+  | "agents"
+  | "kanban"
+  | "stats"
+  | "ops"
+  | "meetings"
+  | "achievements"
+  | "settings";
+
+export interface AppRouteEntry {
+  id: AppRouteId;
+  path: string;
+  aliases?: string[];
+  section: AppSectionId;
   labelKo: string;
   labelEn: string;
-  /** Show in sidebar/bottom nav */
-  nav: boolean;
-  /** Show in command palette */
-  palette: boolean;
-  /** Lazy loading fallback labels */
-  loadingKo: string;
-  loadingEn: string;
+  descriptionKo: string;
+  descriptionEn: string;
+  paletteIcon: string;
+  shortcutKey: string;
+  showOfficeSelector?: boolean;
 }
 
-export const VIEW_REGISTRY: RouteEntry[] = [
-  { id: "office", icon: "🏢", labelKo: "오피스", labelEn: "Office", nav: true, palette: true, loadingKo: "오피스 로딩 중...", loadingEn: "Loading Office..." },
-  { id: "dashboard", icon: "📊", labelKo: "대시보드", labelEn: "Dashboard", nav: true, palette: true, loadingKo: "대시보드 로딩 중...", loadingEn: "Loading Dashboard..." },
-  { id: "kanban", icon: "📋", labelKo: "칸반", labelEn: "Kanban", nav: true, palette: true, loadingKo: "칸반 로딩 중...", loadingEn: "Loading Kanban..." },
-  { id: "agents", icon: "👥", labelKo: "직원", labelEn: "Staff", nav: true, palette: true, loadingKo: "직원 로딩 중...", loadingEn: "Loading Agents..." },
-  { id: "meetings", icon: "📝", labelKo: "회의", labelEn: "Meetings", nav: true, palette: true, loadingKo: "회의 로딩 중...", loadingEn: "Loading Meetings..." },
-  { id: "skills", icon: "🧩", labelKo: "스킬", labelEn: "Skills", nav: true, palette: true, loadingKo: "스킬 로딩 중...", loadingEn: "Loading Skills..." },
-  { id: "settings", icon: "⚙️", labelKo: "설정", labelEn: "Settings", nav: true, palette: true, loadingKo: "설정 로딩 중...", loadingEn: "Loading Settings..." },
+export interface AppRouteSection {
+  id: AppSectionId;
+  labelKo: string;
+  labelEn: string;
+}
+
+export const APP_ROUTE_SECTIONS: AppRouteSection[] = [
+  { id: "workspace", labelKo: "워크스페이스", labelEn: "Workspace" },
+  { id: "knowledge", labelKo: "지식", labelEn: "Knowledge" },
+  { id: "me", labelKo: "나", labelEn: "Me" },
 ];
 
-export const NAV_ROUTES = VIEW_REGISTRY.filter((r) => r.nav);
-export const PALETTE_ROUTES = VIEW_REGISTRY.filter((r) => r.palette);
+export const APP_ROUTES: AppRouteEntry[] = [
+  {
+    id: "home",
+    path: "/home",
+    aliases: ["/dashboard"],
+    section: "workspace",
+    labelKo: "홈",
+    labelEn: "Home",
+    descriptionKo: "오늘의 상태와 빠른 진입점을 확인합니다.",
+    descriptionEn: "See today's overview and quick entry points.",
+    paletteIcon: "🏠",
+    shortcutKey: "1",
+    showOfficeSelector: true,
+  },
+  {
+    id: "office",
+    path: "/office",
+    section: "workspace",
+    labelKo: "오피스",
+    labelEn: "Office",
+    descriptionKo: "실시간 오피스 씬과 배치를 확인합니다.",
+    descriptionEn: "Inspect the live office scene and assignments.",
+    paletteIcon: "🏢",
+    shortcutKey: "2",
+    showOfficeSelector: true,
+  },
+  {
+    id: "agents",
+    path: "/agents",
+    section: "workspace",
+    labelKo: "에이전트",
+    labelEn: "Agents",
+    descriptionKo: "에이전트, 부서, 파견 세션을 관리합니다.",
+    descriptionEn: "Manage agents, departments, and dispatched sessions.",
+    paletteIcon: "👥",
+    shortcutKey: "3",
+    showOfficeSelector: true,
+  },
+  {
+    id: "kanban",
+    path: "/kanban",
+    section: "workspace",
+    labelKo: "칸반",
+    labelEn: "Kanban",
+    descriptionKo: "작업 상태와 디스패치를 추적합니다.",
+    descriptionEn: "Track work status and dispatches.",
+    paletteIcon: "📋",
+    shortcutKey: "4",
+  },
+  {
+    id: "stats",
+    path: "/stats",
+    aliases: ["/pulse"],
+    section: "workspace",
+    labelKo: "통계",
+    labelEn: "Stats",
+    descriptionKo: "운영 지표와 대시보드 위젯을 봅니다.",
+    descriptionEn: "Review operational metrics and dashboard widgets.",
+    paletteIcon: "📈",
+    shortcutKey: "5",
+    showOfficeSelector: true,
+  },
+  {
+    id: "ops",
+    path: "/ops",
+    aliases: ["/control"],
+    section: "workspace",
+    labelKo: "운영",
+    labelEn: "Ops",
+    descriptionKo: "오피스와 운영 표면을 관리합니다.",
+    descriptionEn: "Manage offices and operational surfaces.",
+    paletteIcon: "🛠️",
+    shortcutKey: "6",
+  },
+  {
+    id: "meetings",
+    path: "/meetings",
+    section: "knowledge",
+    labelKo: "회의",
+    labelEn: "Meetings",
+    descriptionKo: "회의 기록과 후속 이슈를 정리합니다.",
+    descriptionEn: "Review meeting records and follow-up issues.",
+    paletteIcon: "📝",
+    shortcutKey: "7",
+  },
+  {
+    id: "achievements",
+    path: "/achievements",
+    section: "knowledge",
+    labelKo: "업적",
+    labelEn: "Achievements",
+    descriptionKo: "성과와 랭킹 흐름을 확인합니다.",
+    descriptionEn: "Inspect achievements and ranking flow.",
+    paletteIcon: "🏆",
+    shortcutKey: "8",
+  },
+  {
+    id: "settings",
+    path: "/settings",
+    section: "me",
+    labelKo: "설정",
+    labelEn: "Settings",
+    descriptionKo: "개인 및 시스템 설정을 조정합니다.",
+    descriptionEn: "Adjust personal and system settings.",
+    paletteIcon: "⚙️",
+    shortcutKey: "9",
+  },
+];
+
+export const PRIMARY_ROUTES = APP_ROUTES;
+
+export const PALETTE_ROUTES = PRIMARY_ROUTES.map((route) => ({
+  id: route.path,
+  labelKo: route.labelKo,
+  labelEn: route.labelEn,
+  icon: route.paletteIcon,
+}));
+
+export const DEFAULT_ROUTE_PATH = "/home";
+
+export function normalizeRoutePath(pathname: string): string {
+  if (!pathname || pathname === "/") return "/";
+  return pathname.replace(/\/+$/, "");
+}
+
+export function findRouteByPath(pathname: string): AppRouteEntry | null {
+  const normalizedPath = normalizeRoutePath(pathname);
+  return (
+    PRIMARY_ROUTES.find(
+      (route) =>
+        route.path === normalizedPath || route.aliases?.includes(normalizedPath),
+    ) ?? null
+  );
+}
+
+export function getSectionById(sectionId: AppSectionId): AppRouteSection {
+  return (
+    APP_ROUTE_SECTIONS.find((section) => section.id === sectionId) ??
+    APP_ROUTE_SECTIONS[0]
+  );
+}

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./styles/main.css";
 
@@ -20,6 +21,8 @@ window.addEventListener("error", (e) => {
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
 );

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -121,9 +121,9 @@
 | `runtime_layout::legacy_migration` | `src/runtime_layout/legacy_migration.rs` | 396 |  |
 | `runtime_layout::paths` | `src/runtime_layout/paths.rs` | 134 |  |
 | `runtime_layout::skill_sync` | `src/runtime_layout/skill_sync.rs` | 685 |  |
-| `server` | `src/server/mod.rs` | 3178 | giant-file |
+| `server` | `src/server/mod.rs` | 3181 | giant-file |
 | `server::background` | `src/server/background.rs` | 535 |  |
-| `server::boot` | `src/server/boot.rs` | 148 |  |
+| `server::boot` | `src/server/boot.rs` | 152 |  |
 | `server::cron_catalog` | `src/server/cron_catalog.rs` | 71 |  |
 | `server::routes` | `src/server/routes/mod.rs` | 200 |  |
 | `server::routes::agents` | `src/server/routes/agents.rs` | 1389 | giant-file |

--- a/docs/generated/route-inventory.md
+++ b/docs/generated/route-inventory.md
@@ -186,4 +186,4 @@
 | `GET` | `/api/token-analytics` | `receipt::get_token_analytics` | `src/server/routes/receipt.rs:102` | `src/server/routes/domains/admin.rs:72` |
 | `POST` | `/api/turns/{channel_id}/cancel` | `queue_api::cancel_turn` | `src/server/routes/queue_api.rs:152` | `src/server/routes/domains/ops.rs:156` |
 | `POST` | `/api/turns/{channel_id}/extend-timeout` | `queue_api::extend_turn_timeout` | `src/server/routes/queue_api.rs:181` | `src/server/routes/domains/ops.rs:157` |
-| `GET` | `/ws` | `ws::ws_handler` | `src/server/ws.rs:65` | `src/server/mod.rs:428` |
+| `GET` | `/ws` | `ws::ws_handler` | `src/server/ws.rs:65` | `src/server/mod.rs:431` |

--- a/src/server/boot.rs
+++ b/src/server/boot.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use axum::Router;
 use axum::routing::get;
-use tower_http::services::ServeDir;
+use tower_http::services::{ServeDir, ServeFile};
 
 use crate::config::Config;
 use crate::db::Db;
@@ -113,6 +113,10 @@ fn build_app(
     health_registry: Option<Arc<HealthRegistry>>,
     pg_pool: Option<sqlx::PgPool>,
 ) -> Router {
+    let dashboard_service = ServeDir::new(dashboard_dir)
+        .append_index_html_on_directories(true)
+        .fallback(ServeFile::new(dashboard_dir.join("index.html")));
+
     Router::new()
         .route("/ws", get(ws::ws_handler).with_state(broadcast_tx.clone()))
         .nest(
@@ -127,7 +131,7 @@ fn build_app(
                 pg_pool,
             ),
         )
-        .fallback_service(ServeDir::new(dashboard_dir).append_index_html_on_directories(true))
+        .fallback_service(dashboard_service)
 }
 
 fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<usize> {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -13,7 +13,7 @@ use sqlx::pool::PoolConnection;
 use sqlx::{PgPool, Postgres, Row};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
-use tower_http::services::ServeDir;
+use tower_http::services::{ServeDir, ServeFile};
 
 use crate::config::Config;
 use crate::db::Db;
@@ -423,6 +423,9 @@ pub async fn run(
 
     let broadcast_tx = ws::new_broadcast();
     let batch_buffer = worker_registry.start_after_websocket_broadcast(broadcast_tx.clone())?;
+    let dashboard_service = ServeDir::new(&dashboard_dir)
+        .append_index_html_on_directories(true)
+        .fallback(ServeFile::new(dashboard_dir.join("index.html")));
 
     let app = Router::new()
         .route("/ws", get(ws::ws_handler).with_state(broadcast_tx.clone()))
@@ -438,7 +441,7 @@ pub async fn run(
                 pg_pool,
             ),
         )
-        .fallback_service(ServeDir::new(&dashboard_dir).append_index_html_on_directories(true));
+        .fallback_service(dashboard_service);
 
     let addr = format!("{}:{}", config.server.host, config.server.port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;


### PR DESCRIPTION
## Summary
- rebuild the dashboard shell around routed navigation with a 240px sidebar and topbar
- add 9 routes and map Office, Kanban, and Settings into the new shell while keeping placeholders for the remaining pages
- add server-side SPA fallback for direct route hits and expand smoke coverage for breadcrumbs and mobile drawer behavior

## Testing
- `./scripts/verify-dashboard.sh`
- `npm run test:e2e`
- `cargo build`
- `./scripts/deploy-dev.sh`

Closes #772