### PR TITLE
#776 feat: Silkscreen font + 8×8 pixel avatar procedure

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -7,6 +7,9 @@
   <meta http-equiv="Expires" content="0" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <title>AgentDesk</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&family=Press+Start+2P&family=Silkscreen:wght@400;700&display=swap" rel="stylesheet" />
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🐾</text></svg>" />
 </head>
 <body>

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -14,6 +14,7 @@ import type {
   SkillCatalogEntry,
   TaskDispatch,
 } from "../types";
+import { resolveAvatarSeed } from "../lib/pixel-avatar";
 
 export type { AuditLogEntry, KanbanCard, KanbanRepoSource, TokenAnalyticsResponse } from "../types";
 
@@ -162,6 +163,7 @@ function normalizeAgent(agent: Agent): Agent {
     ...agent,
     name_ko: agent.name_ko ?? agent.name,
     avatar_emoji: agent.avatar_emoji ?? "",
+    avatar_seed: resolveAvatarSeed(agent),
     department_name: agent.department_name ?? null,
     department_name_ko: agent.department_name_ko ?? agent.department_name ?? null,
   };
@@ -1166,6 +1168,7 @@ export interface Achievement {
   agent_name: string;
   agent_name_ko: string;
   avatar_emoji: string;
+  avatar_seed?: number | null;
 }
 
 export async function getAchievements(

--- a/dashboard/src/components/AgentAvatar.tsx
+++ b/dashboard/src/components/AgentAvatar.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from "react";
 import type { CSSProperties } from "react";
 import type { Agent } from "../types";
+import { resolveAvatarSeed } from "../lib/pixel-avatar";
+import PixelAvatar from "./PixelAvatar";
 
 /** Map agent IDs to sprite numbers (stable order, same as OfficeView) */
 export function buildSpriteMap(agents: Agent[]): Map<string, number> {
@@ -28,23 +30,6 @@ export function getSpriteNum(agents: Agent[], agentId: string): number | undefin
   return buildSpriteMap(agents).get(agentId);
 }
 
-function hashIdToSprite(id: string): number {
-  let hash = 0;
-  for (let i = 0; i < id.length; i += 1) {
-    hash = (hash * 31 + id.charCodeAt(i)) >>> 0;
-  }
-  return (hash % 12) + 1;
-}
-
-function resolveSpriteNum(agent: Agent | undefined, spriteMap: Map<string, number>): number | undefined {
-  if (!agent) return undefined;
-  if (agent.sprite_number != null && agent.sprite_number > 0) return agent.sprite_number;
-  const mapped = spriteMap.get(agent.id);
-  if (mapped != null && mapped > 0) return mapped;
-  if (agent.name === "DORO") return 13;
-  return hashIdToSprite(agent.id);
-}
-
 interface AgentAvatarProps {
   agent: Agent | undefined;
   agents?: Agent[];
@@ -56,7 +41,7 @@ interface AgentAvatarProps {
   imagePosition?: CSSProperties["objectPosition"];
 }
 
-/** Sprite-based avatar — pass either `agents` or `spriteMap` */
+/** Procedural 8x8 avatar — sprite maps remain reserved for the Pixi office scene. */
 export default function AgentAvatar({
   agent,
   agents,
@@ -67,34 +52,17 @@ export default function AgentAvatar({
   imageFit = "cover",
   imagePosition = "center",
 }: AgentAvatarProps) {
-  const map = spriteMap ?? (agents ? buildSpriteMap(agents) : new Map());
-  const spriteNum = resolveSpriteNum(agent, map);
-
-  const roundedClass = rounded === "full" ? "rounded-full" : rounded === "xl" ? "rounded-xl" : "rounded-2xl";
-
-  if (spriteNum) {
-    return (
-      <div
-        className={`${roundedClass} overflow-hidden bg-th-bg-surface flex-shrink-0 ${className}`}
-        style={{ width: size, height: size }}
-      >
-        <img
-          src={`/sprites/${spriteNum}-D-1.png`}
-          alt={agent?.name ?? ""}
-          className={`w-full h-full ${imageFit === "contain" ? "object-contain" : "object-cover"}`}
-          draggable={false}
-          onDragStart={(e) => e.preventDefault()}
-          style={{ imageRendering: "pixelated", objectPosition: imagePosition, userSelect: "none" }}
-        />
-      </div>
-    );
-  }
+  void agents;
+  void spriteMap;
+  void imageFit;
+  void imagePosition;
   return (
-    <div
-      className={`${roundedClass} bg-th-bg-surface flex items-center justify-center flex-shrink-0 ${className}`}
-      style={{ width: size, height: size, fontSize: size * 0.6 }}
-    >
-      {agent?.avatar_emoji ?? "🤖"}
-    </div>
+    <PixelAvatar
+      seed={resolveAvatarSeed(agent)}
+      size={size}
+      className={className}
+      rounded={rounded}
+      label={agent?.name ?? "Agent"}
+    />
   );
 }

--- a/dashboard/src/components/PixelAvatar.tsx
+++ b/dashboard/src/components/PixelAvatar.tsx
@@ -1,0 +1,56 @@
+import { buildPixelAvatarModel, normalizeAvatarSeed } from "../lib/pixel-avatar";
+
+interface PixelAvatarProps {
+  seed: number;
+  size?: number;
+  className?: string;
+  rounded?: "full" | "xl" | "2xl";
+  label?: string;
+}
+
+export default function PixelAvatar({
+  seed,
+  size = 28,
+  className = "",
+  rounded = "full",
+  label,
+}: PixelAvatarProps) {
+  const model = buildPixelAvatarModel(normalizeAvatarSeed(seed));
+  const roundedClass =
+    rounded === "full"
+      ? "rounded-full"
+      : rounded === "xl"
+        ? "rounded-xl"
+        : "rounded-2xl";
+
+  return (
+    <div
+      className={`${roundedClass} overflow-hidden bg-th-bg-surface flex-shrink-0 ${className}`}
+      style={{ width: size, height: size }}
+    >
+      <svg
+        viewBox="0 0 8 8"
+        width={size}
+        height={size}
+        role="img"
+        aria-label={label ?? "Pixel avatar"}
+        shapeRendering="crispEdges"
+        className="block h-full w-full"
+        style={{ imageRendering: "pixelated" }}
+      >
+        <title>{label ?? "Pixel avatar"}</title>
+        <rect width="8" height="8" fill={model.palette.background} />
+        {model.pixels.map((pixel) => (
+          <rect
+            key={`${pixel.x}-${pixel.y}`}
+            x={pixel.x}
+            y={pixel.y}
+            width="1"
+            height="1"
+            fill={pixel.color}
+          />
+        ))}
+      </svg>
+    </div>
+  );
+}

--- a/dashboard/src/components/agent-manager/AgentCard.tsx
+++ b/dashboard/src/components/agent-manager/AgentCard.tsx
@@ -1,5 +1,6 @@
 import type { Agent, Department } from "../../types";
 import { localeName } from "../../i18n";
+import { getFontFamilyForText } from "../../lib/fonts";
 import AgentAvatar from "../AgentAvatar";
 import { SurfaceActionButton, SurfaceCard } from "../common/SurfacePrimitives";
 import { STATUS_DOT } from "./constants";
@@ -36,6 +37,7 @@ export default function AgentCard({
 }: AgentCardProps) {
   const isDeleting = confirmDeleteId === agent.id;
   const dept = departments.find((d) => d.id === agent.department_id);
+  const primaryLabel = localeName(locale, agent);
 
   return (
     <SurfaceCard
@@ -60,12 +62,18 @@ export default function AgentCard({
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-1.5">
-            <span className="font-semibold text-sm truncate" style={{ color: "var(--th-text-heading)" }}>
-              {localeName(locale, agent)}
+            <span
+              className="font-pixel truncate text-sm font-semibold"
+              style={{
+                color: "var(--th-text-heading)",
+                fontFamily: getFontFamilyForText(primaryLabel, "pixel"),
+              }}
+            >
+              {primaryLabel}
             </span>
             <span className="text-xs shrink-0" style={{ color: "var(--th-text-muted)" }}>
               {(() => {
-                const primary = localeName(locale, agent);
+                const primary = primaryLabel;
                 const sub = locale === "en" ? agent.name_ko || "" : agent.name;
                 return primary !== sub ? sub : "";
               })()}

--- a/dashboard/src/components/dashboard/ExtraWidgets.tsx
+++ b/dashboard/src/components/dashboard/ExtraWidgets.tsx
@@ -6,6 +6,7 @@ import {
   readLocalStorageValue,
   writeLocalStorageValue,
 } from "../../lib/useLocalStorage";
+import { getFontFamilyForText } from "../../lib/fonts";
 import type { TFunction } from "./model";
 import AgentAvatar from "../AgentAvatar";
 import { cx, dashboardBadge, dashboardCard } from "./ui";
@@ -941,12 +942,22 @@ export function AchievementWidget({ t, agents }: AchievementWidgetProps) {
       className={dashboardCard.accentStandard}
       style={{ borderColor: "var(--th-border)", background: "linear-gradient(145deg, color-mix(in srgb, var(--th-surface) 90%, #eab308 10%), var(--th-surface))" }}
     >
-      <h3 className="text-sm font-semibold mb-3" style={{ color: "var(--th-text)" }}>
+      <h3
+        className="font-pixel mb-3 text-sm font-semibold"
+        style={{
+          color: "var(--th-text)",
+          fontFamily: getFontFamilyForText(
+            t({ ko: "업적", en: "Achievements", ja: "実績", zh: "成就" }),
+            "pixel",
+          ),
+        }}
+      >
         🏆 {t({ ko: "업적", en: "Achievements", ja: "実績", zh: "成就" })}
       </h3>
       <div className="space-y-1.5 max-h-48 overflow-y-auto">
         {achievements.slice(0, 15).map((ach) => {
           const agent = agentMap.get(ach.agent_id) ?? fallbackAgentFromAchievement(ach);
+          const agentLabel = ach.agent_name_ko || ach.agent_name;
           return (
             <div
               key={ach.id}
@@ -963,10 +974,22 @@ export function AchievementWidget({ t, agents }: AchievementWidgetProps) {
                 </span>
               </div>
               <div className="flex-1 min-w-0">
-                <div className="text-xs font-medium truncate" style={{ color: "var(--th-text)" }}>
-                  {ach.agent_name_ko || ach.agent_name}
+                <div
+                  className="font-pixel truncate text-xs font-medium"
+                  style={{
+                    color: "var(--th-text)",
+                    fontFamily: getFontFamilyForText(agentLabel, "pixel"),
+                  }}
+                >
+                  {agentLabel}
                 </div>
-                <div className="text-xs" style={{ color: "var(--th-text-muted)" }}>
+                <div
+                  className="font-pixel text-xs"
+                  style={{
+                    color: "var(--th-text-muted)",
+                    fontFamily: getFontFamilyForText(ach.name, "pixel"),
+                  }}
+                >
                   {ach.name} — {ach.description}
                 </div>
               </div>

--- a/dashboard/src/components/dashboard/HeroSections.tsx
+++ b/dashboard/src/components/dashboard/HeroSections.tsx
@@ -1,5 +1,6 @@
 import AgentAvatar from "../AgentAvatar";
 import type { Agent } from "../../types";
+import { getFontFamilyForText } from "../../lib/fonts";
 import { getRankTier, RankBadge, XpBar, type TFunction } from "./model";
 import { cx, dashboardBadge, dashboardCard, dashboardText } from "./ui";
 
@@ -256,8 +257,12 @@ export function DashboardRankingBoard({
                           <AgentAvatar agent={selectedAgent} agents={agents} size={avatarSize} rounded="2xl" />
                         </div>
                         <span
-                          className={`max-w-[80px] truncate text-center font-bold ${isFirst ? "text-sm" : "text-xs"}`}
-                          style={{ color: tier.color, textShadow: isFirst ? `0 0 8px ${tier.glow}` : "none" }}
+                          className={`font-pixel max-w-[80px] truncate text-center font-bold ${isFirst ? "text-sm" : "text-xs"}`}
+                          style={{
+                            color: tier.color,
+                            textShadow: isFirst ? `0 0 8px ${tier.glow}` : "none",
+                            fontFamily: getFontFamilyForText(agent.name, "pixel"),
+                          }}
                         >
                           {agent.name}
                         </span>
@@ -277,8 +282,12 @@ export function DashboardRankingBoard({
                         </div>
 
                         <span
-                          className={`max-w-[80px] truncate text-center font-bold ${isFirst ? "text-sm" : "text-xs"}`}
-                          style={{ color: tier.color, textShadow: isFirst ? `0 0 8px ${tier.glow}` : "none" }}
+                          className={`font-pixel max-w-[80px] truncate text-center font-bold ${isFirst ? "text-sm" : "text-xs"}`}
+                          style={{
+                            color: tier.color,
+                            textShadow: isFirst ? `0 0 8px ${tier.glow}` : "none",
+                            fontFamily: getFontFamilyForText(agent.name, "pixel"),
+                          }}
                         >
                           {agent.name}
                         </span>
@@ -343,7 +352,13 @@ export function DashboardRankingBoard({
                           <AgentAvatar agent={selectedAgent} agents={agents} size={36} rounded="xl" />
                         </div>
                         <div className="min-w-0 flex-1">
-                          <p className="truncate text-sm font-bold" style={{ color: "var(--th-text-primary)" }}>
+                          <p
+                            className="font-pixel truncate text-sm font-bold"
+                            style={{
+                              color: "var(--th-text-primary)",
+                              fontFamily: getFontFamilyForText(agent.name, "pixel"),
+                            }}
+                          >
                             {agent.name}
                           </p>
                           <p className="text-xs" style={{ color: "var(--th-text-muted)" }}>
@@ -360,7 +375,13 @@ export function DashboardRankingBoard({
                           <AgentAvatar agent={selectedAgent} agents={agents} size={36} rounded="xl" />
                         </div>
                         <div className="min-w-0 flex-1">
-                          <p className="truncate text-sm font-bold" style={{ color: "var(--th-text-primary)" }}>
+                          <p
+                            className="font-pixel truncate text-sm font-bold"
+                            style={{
+                              color: "var(--th-text-primary)",
+                              fontFamily: getFontFamilyForText(agent.name, "pixel"),
+                            }}
+                          >
                             {agent.name}
                           </p>
                           <p className="text-xs" style={{ color: "var(--th-text-muted)" }}>
@@ -415,7 +436,13 @@ export function DashboardRankingBoard({
                         <AgentAvatar agent={selectedAgent} agents={agents} size={52} rounded="2xl" />
                       </div>
                       <div className="min-w-0 flex-1">
-                        <p className="text-base font-black" style={{ color: tier.color }}>
+                        <p
+                          className="font-pixel text-base font-black"
+                          style={{
+                            color: tier.color,
+                            fontFamily: getFontFamilyForText(agent.name, "pixel"),
+                          }}
+                        >
                           {agent.name}
                         </p>
                         <p className="text-xs" style={{ color: "var(--th-text-muted)" }}>
@@ -432,7 +459,13 @@ export function DashboardRankingBoard({
                         <AgentAvatar agent={selectedAgent} agents={agents} size={52} rounded="2xl" />
                       </div>
                       <div className="min-w-0 flex-1">
-                        <p className="text-base font-black" style={{ color: tier.color }}>
+                        <p
+                          className="font-pixel text-base font-black"
+                          style={{
+                            color: tier.color,
+                            fontFamily: getFontFamilyForText(agent.name, "pixel"),
+                          }}
+                        >
                           {agent.name}
                         </p>
                         <p className="text-xs" style={{ color: "var(--th-text-muted)" }}>

--- a/dashboard/src/components/office-view/OfficeInsightPanel.tsx
+++ b/dashboard/src/components/office-view/OfficeInsightPanel.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, type ReactNode } from "react";
 import type { Notification } from "../NotificationCenter";
 import type { Agent, AuditLogEntry, KanbanCard } from "../../types";
 import { getAgentWarnings } from "../../agent-insights";
+import { getFontFamilyForText } from "../../lib/fonts";
+import AgentAvatar from "../AgentAvatar";
 import {
   SurfaceActionButton,
   SurfaceCard,
@@ -424,8 +426,20 @@ function WarningList({
                 className="p-3"
                 trailing={<span className="text-xs" style={{ color: "var(--th-accent-warn)" }}>⚠</span>}
               >
-                <div className="text-xs font-medium" style={{ color: "var(--th-text)" }}>
-                  {agent.avatar_emoji} {agent.alias || agent.name_ko || agent.name}
+                <div className="flex items-center gap-2">
+                  <AgentAvatar agent={agent} size={22} rounded="xl" />
+                  <div
+                    className="font-pixel min-w-0 truncate text-xs font-medium"
+                    style={{
+                      color: "var(--th-text)",
+                      fontFamily: getFontFamilyForText(
+                        agent.alias || agent.name_ko || agent.name,
+                        "pixel",
+                      ),
+                    }}
+                  >
+                    {agent.alias || agent.name_ko || agent.name}
+                  </div>
                 </div>
                 <div className="mt-0.5 text-xs" style={{ color: "var(--th-text-muted)" }}>
                   {(isKo ? warnings.map((warning) => warning.ko) : warnings.map((warning) => warning.en)).join(", ")}

--- a/dashboard/src/components/office-view/buildScene-break-room.ts
+++ b/dashboard/src/components/office-view/buildScene-break-room.ts
@@ -2,6 +2,7 @@ import type { MutableRefObject } from "react";
 import { Container, Graphics, Sprite, Text, TextStyle, type Application, type Texture } from "pixi.js";
 import type { Agent } from "../../types";
 import { localeName } from "../../i18n";
+import { getFontFamilyForText } from "../../lib/fonts";
 import type { CallbackSnapshot, BreakAnimItem } from "./buildScene-types";
 import { BREAK_ROOM_H, TARGET_CHAR_H, type RoomTheme, type WallClockVisual } from "./model";
 import { BREAK_CHAT_MESSAGES, BREAK_SPOTS, LOCALE_TEXT, type SupportedLocale, pickLocale } from "./themes-locale";
@@ -118,13 +119,14 @@ export function buildBreakRoom({
   brSignBg.roundRect(brx + brw / 2 - brSignW / 2, bry - 4, brSignW, 18, 4).fill(breakTheme.accent);
   breakRoom.addChild(brSignBg);
   const breakSignTextColor = isDark ? 0xffffff : contrastTextColor(breakTheme.accent);
+  const breakRoomLabel = pickLocale(activeLocale, LOCALE_TEXT.breakRoom);
   const brSignTxt = new Text({
-    text: pickLocale(activeLocale, LOCALE_TEXT.breakRoom),
+    text: breakRoomLabel,
     style: new TextStyle({
       fontSize: 9,
       fill: breakSignTextColor,
       fontWeight: "bold",
-      fontFamily: "system-ui, sans-serif",
+      fontFamily: getFontFamilyForText(breakRoomLabel, "pixel"),
       dropShadow: isDark ? { alpha: 0.6, blur: 2, distance: 1, color: 0x000000 } : undefined,
     }),
   });
@@ -201,9 +203,10 @@ export function buildBreakRoom({
     coffeeEmoji.position.set(spotX + 14, spotY - 10);
     breakRoom.addChild(coffeeEmoji);
 
+    const nameLabel = localeName(activeLocale, agent);
     const nameTag = new Text({
-      text: localeName(activeLocale, agent),
-      style: new TextStyle({ fontSize: 6, fill: 0x4a3a2a, fontFamily: "system-ui, sans-serif" }),
+      text: nameLabel,
+      style: new TextStyle({ fontSize: 6, fill: 0x4a3a2a, fontFamily: getFontFamilyForText(nameLabel, "pixel") }),
     });
     nameTag.anchor.set(0.5, 0);
     const ntW = nameTag.width + 4;
@@ -227,7 +230,7 @@ export function buildBreakRoom({
       const msg = chatPool[(seed + phase) % chatPool.length];
       const bubbleText = new Text({
         text: msg,
-        style: new TextStyle({ fontSize: 7, fill: 0x333333, fontFamily: "system-ui, sans-serif" }),
+        style: new TextStyle({ fontSize: 7, fill: 0x333333, fontFamily: getFontFamilyForText(msg, "pixel") }),
       });
       bubbleText.anchor.set(0.5, 1);
       const bw = bubbleText.width + 10;

--- a/dashboard/src/components/office-view/buildScene-department-agent.ts
+++ b/dashboard/src/components/office-view/buildScene-department-agent.ts
@@ -2,6 +2,7 @@ import type { MutableRefObject } from "react";
 import { AnimatedSprite, Container, Graphics, Text, TextStyle, type Texture } from "pixi.js";
 import { getAgentWarnings, getAgentWorkSummary } from "../../agent-insights";
 import type { Agent, SubAgent, Task } from "../../types";
+import { FONT_STACK_MONO, getFontFamilyForText } from "../../lib/fonts";
 import type { ActiveIssueInfo, AnimItem, CallbackSnapshot, SubCloneAnimItem } from "./buildScene-types";
 import {
   DESK_W,
@@ -184,7 +185,7 @@ export function renderDeskAgentAndSubClones({
       style: new TextStyle({
         fontSize: 6.5,
         fill: 0x333333,
-        fontFamily: "system-ui, sans-serif",
+        fontFamily: getFontFamilyForText(bubbleBody, "pixel"),
         wordWrap: true,
         wordWrapWidth: 85,
       }),
@@ -233,7 +234,7 @@ export function renderDeskAgentAndSubClones({
     room.addChild(badgeBg);
     const badgeText = new Text({
       text: warning.code === "missing_work_detail" ? "?" : "!",
-      style: new TextStyle({ fontSize: 8, fill: 0xffffff, fontWeight: "bold", fontFamily: "monospace" }),
+      style: new TextStyle({ fontSize: 8, fill: 0xffffff, fontWeight: "bold", fontFamily: FONT_STACK_MONO }),
     });
     badgeText.anchor.set(0.5, 0.5);
     badgeText.position.set(badgeX, badgeY);
@@ -246,7 +247,7 @@ export function renderDeskAgentAndSubClones({
     room.addChild(countBg);
     const countTxt = new Text({
       text: `x${workingSubs.length}`,
-      style: new TextStyle({ fontSize: 6.5, fill: 0xe2e8f8, fontWeight: "bold", fontFamily: "monospace" }),
+      style: new TextStyle({ fontSize: 6.5, fill: 0xe2e8f8, fontWeight: "bold", fontFamily: FONT_STACK_MONO }),
     });
     countTxt.anchor.set(0.5, 0.5);
     countTxt.position.set(ax + 26, deskY - 13);

--- a/dashboard/src/components/office-view/buildScene-departments.ts
+++ b/dashboard/src/components/office-view/buildScene-departments.ts
@@ -2,6 +2,7 @@ import type { MutableRefObject } from "react";
 import { Container, Graphics, Text, TextStyle, type Application, type Texture } from "pixi.js";
 import type { Agent, Department, SubAgent, Task } from "../../types";
 import { localeName } from "../../i18n";
+import { FONT_STACK_MONO, getFontFamilyForText } from "../../lib/fonts";
 import type { CallbackSnapshot, AnimItem, SubCloneAnimItem } from "./buildScene-types";
 import {
   COLS_PER_ROW,
@@ -124,13 +125,14 @@ export function buildDepartmentRooms({
     signBg.cursor = "pointer";
     signBg.on("pointerup", () => cbRef.current.onSelectDepartment(dept));
     room.addChild(signBg);
+    const signLabel = `${dept.icon || "🏢"} ${localeName(activeLocale, dept)}`;
     const signTxt = new Text({
-      text: `${dept.icon || "🏢"} ${localeName(activeLocale, dept)}`,
+      text: signLabel,
       style: new TextStyle({
         fontSize: 9,
         fill: 0xffffff,
         fontWeight: "bold",
-        fontFamily: "system-ui, sans-serif",
+        fontFamily: getFontFamilyForText(signLabel, "pixel"),
         dropShadow: { alpha: 0.2, distance: 1, color: 0x000000 },
       }),
     });
@@ -157,7 +159,7 @@ export function buildDepartmentRooms({
       room.addChild(barG);
       const ratioTxt = new Text({
         text: `${workingCount}/${totalCount}`,
-        style: new TextStyle({ fontSize: 6, fill: 0xffffff, fontFamily: "monospace", dropShadow: { alpha: 0.3, distance: 1, color: 0x000000 } }),
+        style: new TextStyle({ fontSize: 6, fill: 0xffffff, fontFamily: FONT_STACK_MONO, dropShadow: { alpha: 0.3, distance: 1, color: 0x000000 } }),
       });
       ratioTxt.anchor.set(0.5, 0);
       ratioTxt.position.set(rx + roomW / 2, barY + barH + 1);
@@ -178,9 +180,10 @@ export function buildDepartmentRooms({
     }
 
     if (deptAgents.length === 0) {
+      const emptyLabel = pickLocale(activeLocale, LOCALE_TEXT.noAssignedAgent);
       const emptyText = new Text({
-        text: pickLocale(activeLocale, LOCALE_TEXT.noAssignedAgent),
-        style: new TextStyle({ fontSize: 10, fill: 0x9a8a7a, fontFamily: "system-ui, sans-serif" }),
+        text: emptyLabel,
+        style: new TextStyle({ fontSize: 10, fill: 0x9a8a7a, fontFamily: getFontFamilyForText(emptyLabel, "pixel") }),
       });
       emptyText.anchor.set(0.5, 0.5);
       emptyText.position.set(rx + roomW / 2, ry + roomH / 2);
@@ -293,13 +296,14 @@ function renderAgentHeader(
   unread: Set<string> | undefined,
   activeLocale: SupportedLocale,
 ): void {
+  const label = localeName(activeLocale, agent);
   const nameText = new Text({
-    text: localeName(activeLocale, agent),
+    text: label,
     style: new TextStyle({
       fontSize: 7,
       fill: 0x3a3a4a,
       fontWeight: "bold",
-      fontFamily: "system-ui, sans-serif",
+      fontFamily: getFontFamilyForText(label, "pixel"),
     }),
   });
   nameText.anchor.set(0.5, 0);
@@ -318,7 +322,7 @@ function renderAgentHeader(
     room.addChild(bangBg);
     const bangTxt = new Text({
       text: "!",
-      style: new TextStyle({ fontSize: 8, fill: 0xffffff, fontWeight: "bold", fontFamily: "monospace" }),
+      style: new TextStyle({ fontSize: 8, fill: 0xffffff, fontWeight: "bold", fontFamily: FONT_STACK_MONO }),
     });
     bangTxt.anchor.set(0.5, 0.5);
     bangTxt.position.set(bangX, nameY + 6);
@@ -338,13 +342,14 @@ function drawBreakAwayTag(
   drawDesk(room, ax - DESK_W / 2, deskY, false);
   const awayTagY = charFeetY - TARGET_CHAR_H / 2;
   const awayTagBgColor = blendColor(accent, 0x101826, 0.78);
+  const awayLabel = pickLocale(activeLocale, LOCALE_TEXT.breakRoom);
   const awayTag = new Text({
-    text: pickLocale(activeLocale, LOCALE_TEXT.breakRoom),
+    text: awayLabel,
     style: new TextStyle({
       fontSize: 8,
       fill: contrastTextColor(awayTagBgColor),
       fontWeight: "bold",
-      fontFamily: "system-ui, sans-serif",
+      fontFamily: getFontFamilyForText(awayLabel, "pixel"),
     }),
   });
   awayTag.anchor.set(0.5, 0.5);

--- a/dashboard/src/components/office-view/buildScene-meeting-room.ts
+++ b/dashboard/src/components/office-view/buildScene-meeting-room.ts
@@ -2,6 +2,7 @@ import type { MutableRefObject } from "react";
 import { Container, Graphics, Sprite, Text, TextStyle, type Application, type Texture } from "pixi.js";
 import type { Agent, RoundTableMeeting } from "../../types";
 import { localeName } from "../../i18n";
+import { FONT_STACK_MONO, getFontFamilyForText } from "../../lib/fonts";
 import type { CallbackSnapshot } from "./buildScene-types";
 import { MEETING_ROOM_H, TARGET_CHAR_H, type RoomTheme, type WallClockVisual } from "./model";
 import { LOCALE_TEXT, type SupportedLocale, pickLocale } from "./themes-locale";
@@ -144,7 +145,7 @@ export function buildMeetingRoom({
       fontSize: 9,
       fill: signTextColor,
       fontWeight: "bold",
-      fontFamily: "system-ui, sans-serif",
+      fontFamily: getFontFamilyForText(signLabel, "pixel"),
       dropShadow: isDark ? { alpha: 0.6, blur: 2, distance: 1, color: 0x000000 } : undefined,
     }),
   });
@@ -240,9 +241,10 @@ export function buildMeetingRoom({
     agentPosRef.current.set(agent.id, { x: sx, y: sy - 6 });
 
     // Name tag
+    const nameLabel = localeName(activeLocale, agent);
     const nameTag = new Text({
-      text: localeName(activeLocale, agent),
-      style: new TextStyle({ fontSize: 5.5, fill: isDark ? 0xd0d8e8 : 0x4a3a2a, fontFamily: "system-ui, sans-serif" }),
+      text: nameLabel,
+      style: new TextStyle({ fontSize: 5.5, fill: isDark ? 0xd0d8e8 : 0x4a3a2a, fontFamily: getFontFamilyForText(nameLabel, "pixel") }),
     });
     nameTag.anchor.set(0.5, 0);
     const ntW = nameTag.width + 4;
@@ -287,7 +289,7 @@ export function buildMeetingRoom({
           fontSize: 7,
           fill: isDark ? 0xc8d0e0 : 0x4a5568,
           fontWeight: "bold",
-          fontFamily: "monospace",
+          fontFamily: FONT_STACK_MONO,
         }),
       });
       roundTxt.anchor.set(0.5, 0);
@@ -306,7 +308,7 @@ export function buildMeetingRoom({
       style: new TextStyle({
         fontSize: 6,
         fill: isDark ? 0x8899aa : 0x6b7c94,
-        fontFamily: "system-ui, sans-serif",
+        fontFamily: getFontFamilyForText(agendaText, "pixel"),
         wordWrap: true,
         wordWrapWidth: rw * 0.6,
       }),

--- a/dashboard/src/components/office-view/model.ts
+++ b/dashboard/src/components/office-view/model.ts
@@ -9,6 +9,7 @@ import type {
   CrossDeptDelivery,
   CeoOfficeCall,
 } from "../../types";
+import { getFontFamilyForText } from "../../lib/fonts";
 
 interface OfficeViewProps {
   departments: Department[];
@@ -214,7 +215,7 @@ function emitSubCloneSmokeBurst(
       fontSize: 7,
       fill: mode === "spawn" ? 0xeff4ff : 0xdde4f5,
       fontWeight: "bold",
-      fontFamily: "system-ui, sans-serif",
+      fontFamily: getFontFamilyForText("펑", "pixel"),
       stroke: { color: 0x1f2838, width: 2 },
     }),
   });

--- a/dashboard/src/components/office-view/officeTicker.ts
+++ b/dashboard/src/components/office-view/officeTicker.ts
@@ -1,6 +1,7 @@
 import type { MutableRefObject } from "react";
 import { Container, Graphics, Text, TextStyle, type AnimatedSprite, type Sprite } from "pixi.js";
 import type { MeetingPresence } from "../../types";
+import { FONT_STACK_MONO, getFontFamilyForText } from "../../lib/fonts";
 import {
   type Delivery,
   type RoomRect,
@@ -238,7 +239,7 @@ export function runOfficeTickerStep(ctx: OfficeTickerContext): void {
         if (tick % 80 === 0) {
           const sleepy = new Text({
             text: "z",
-            style: new TextStyle({ fontSize: 7 + Math.random() * 3, fill: 0xaaaacc, fontFamily: "monospace" }),
+            style: new TextStyle({ fontSize: 7 + Math.random() * 3, fill: 0xaaaacc, fontFamily: FONT_STACK_MONO }),
           });
           sleepy.anchor.set(0.5, 0.5);
           sleepy.position.set(headX + 6, bedCenterY - 18);
@@ -410,7 +411,7 @@ export function runOfficeTickerStep(ctx: OfficeTickerContext): void {
       const label = `${item.emoji} ${item.text}`;
       const bubbleText = new Text({
         text: label,
-        style: new TextStyle({ fontSize: 7, fill: 0xffffff, fontFamily: "system-ui, sans-serif" }),
+        style: new TextStyle({ fontSize: 7, fill: 0xffffff, fontFamily: getFontFamilyForText(label, "pixel") }),
       });
       bubbleText.anchor.set(0.5, 0.5);
       const bubbleWidth = bubbleText.width + 10;

--- a/dashboard/src/components/office-view/useOfficeDeliveryEffects.ts
+++ b/dashboard/src/components/office-view/useOfficeDeliveryEffects.ts
@@ -1,6 +1,7 @@
 import { useEffect, type MutableRefObject } from "react";
 import { AnimatedSprite, Container, Graphics, Text, TextStyle, type Texture } from "pixi.js";
 import type { Agent, CeoOfficeCall, CrossDeptDelivery, MeetingPresence } from "../../types";
+import { FONT_STACK_PIXEL, getFontFamilyForText } from "../../lib/fonts";
 import { hashStr } from "./drawing-core";
 import { type Delivery, destroyNode, trackProcessedId } from "./model";
 import {
@@ -94,7 +95,7 @@ export function useMeetingPresenceSync({
       actor.addChild(badge);
       const badgeText = new Text({
         text: "",
-        style: new TextStyle({ fontSize: 7, fill: 0x111111, fontWeight: "bold", fontFamily: "system-ui, sans-serif" }),
+        style: new TextStyle({ fontSize: 7, fill: 0x111111, fontWeight: "bold", fontFamily: FONT_STACK_PIXEL }),
       });
       badgeText.anchor.set(0.5, 0.5);
       badgeText.position.set(0, 10.5);
@@ -219,7 +220,15 @@ export function useCrossDeptDeliveryAnimations({
 
       const badgeText = new Text({
         text: pickLocale(language, LOCALE_TEXT.collabBadge),
-        style: new TextStyle({ fontSize: 7, fill: 0x000000, fontWeight: "bold", fontFamily: "system-ui, sans-serif" }),
+        style: new TextStyle({
+          fontSize: 7,
+          fill: 0x000000,
+          fontWeight: "bold",
+          fontFamily: getFontFamilyForText(
+            pickLocale(language, LOCALE_TEXT.collabBadge),
+            "pixel",
+          ),
+        }),
       });
       badgeText.anchor.set(0.5, 0.5);
       badgeText.position.set(0, 9.5);
@@ -304,7 +313,7 @@ export function useCeoOfficeCallAnimations({
         style: new TextStyle({
           fontSize: 7,
           fill: 0x2b2b2b,
-          fontFamily: "system-ui, sans-serif",
+          fontFamily: getFontFamilyForText(line, "pixel"),
           wordWrap: true,
           wordWrapWidth: 120,
           breakWords: true,
@@ -411,7 +420,7 @@ export function useCeoOfficeCallAnimations({
       const decision = resolveMeetingDecision(call.phase, call.decision, call.line);
       const badgeText = new Text({
         text: "",
-        style: new TextStyle({ fontSize: 7, fill: 0x111111, fontWeight: "bold", fontFamily: "system-ui, sans-serif" }),
+        style: new TextStyle({ fontSize: 7, fill: 0x111111, fontWeight: "bold", fontFamily: FONT_STACK_PIXEL }),
       });
       badgeText.anchor.set(0.5, 0.5);
       badgeText.position.set(0, 10.5);

--- a/dashboard/src/lib/fonts.ts
+++ b/dashboard/src/lib/fonts.ts
@@ -1,0 +1,20 @@
+export const FONT_STACK_SANS =
+  '"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+export const FONT_STACK_MONO =
+  '"JetBrains Mono", "SFMono-Regular", "SF Mono", Menlo, Consolas, monospace';
+export const FONT_STACK_PIXEL =
+  '"Silkscreen", "Press Start 2P", "Inter", "Segoe UI", sans-serif';
+
+const CJK_GLYPH_RE =
+  /[\u1100-\u11ff\u3040-\u30ff\u3130-\u318f\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uac00-\ud7af]/;
+
+export function getFontFamilyForText(
+  text: string | null | undefined,
+  variant: "sans" | "mono" | "pixel" = "pixel",
+): string {
+  if (variant === "sans") return FONT_STACK_SANS;
+  if (variant === "mono") return FONT_STACK_MONO;
+  return text && CJK_GLYPH_RE.test(text)
+    ? FONT_STACK_SANS
+    : FONT_STACK_PIXEL;
+}

--- a/dashboard/src/lib/pixel-avatar.test.ts
+++ b/dashboard/src/lib/pixel-avatar.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  PIXEL_AVATAR_PALETTES,
+  buildPixelAvatarModel,
+  hashAvatarSeed,
+  resolveAvatarSeed,
+} from "./pixel-avatar";
+import { FONT_STACK_PIXEL, FONT_STACK_SANS, getFontFamilyForText } from "./fonts";
+
+describe("pixel avatar seed helpers", () => {
+  it("prefers explicit avatar_seed when present", () => {
+    expect(resolveAvatarSeed({ avatar_seed: 42, id: "agent-1" })).toBe(42);
+  });
+
+  it("hashes fallback identity deterministically", () => {
+    expect(hashAvatarSeed("agent-1")).toBe(hashAvatarSeed("agent-1"));
+    expect(hashAvatarSeed("agent-1")).not.toBe(hashAvatarSeed("agent-2"));
+  });
+});
+
+describe("buildPixelAvatarModel", () => {
+  it("returns stable pixel output for the same seed", () => {
+    const first = buildPixelAvatarModel(1337);
+    const second = buildPixelAvatarModel(1337);
+    expect(second).toEqual(first);
+  });
+
+  it("maps seeds into the 7-palette set", () => {
+    const model = buildPixelAvatarModel(2026);
+    expect(model.paletteIndex).toBeGreaterThanOrEqual(0);
+    expect(model.paletteIndex).toBeLessThan(PIXEL_AVATAR_PALETTES.length);
+    expect(model.pixels.length).toBeGreaterThan(20);
+  });
+});
+
+describe("font fallback", () => {
+  it("keeps pixel font for latin-only labels", () => {
+    expect(getFontFamilyForText("DORO", "pixel")).toBe(FONT_STACK_PIXEL);
+  });
+
+  it("falls back to sans for Korean labels", () => {
+    expect(getFontFamilyForText("도로롱", "pixel")).toBe(FONT_STACK_SANS);
+  });
+});

--- a/dashboard/src/lib/pixel-avatar.ts
+++ b/dashboard/src/lib/pixel-avatar.ts
@@ -1,0 +1,260 @@
+export interface AvatarSeedSource {
+  avatar_seed?: number | null;
+  id?: string | null;
+  name?: string | null;
+  name_ko?: string | null;
+  avatar_emoji?: string | null;
+}
+
+export interface PixelAvatarPalette {
+  background: string;
+  skin: string;
+  hair: string;
+  outfit: string;
+  accent: string;
+  shadow: string;
+  eye: string;
+}
+
+export interface PixelAvatarPixel {
+  x: number;
+  y: number;
+  color: string;
+}
+
+export interface PixelAvatarModel {
+  paletteIndex: number;
+  palette: PixelAvatarPalette;
+  pixels: PixelAvatarPixel[];
+}
+
+export const PIXEL_AVATAR_SIZE = 8;
+
+export const PIXEL_AVATAR_PALETTES: PixelAvatarPalette[] = [
+  {
+    background: "#1f2331",
+    skin: "#f1c8a5",
+    hair: "#6f4f3d",
+    outfit: "#4fd1a5",
+    accent: "#f8f0c7",
+    shadow: "#132238",
+    eye: "#101419",
+  },
+  {
+    background: "#2b1f35",
+    skin: "#e8b894",
+    hair: "#2d314a",
+    outfit: "#6ea8ff",
+    accent: "#ffd166",
+    shadow: "#151121",
+    eye: "#0d1016",
+  },
+  {
+    background: "#162229",
+    skin: "#f0d0b1",
+    hair: "#205f6b",
+    outfit: "#f97316",
+    accent: "#fef08a",
+    shadow: "#0f161c",
+    eye: "#11151b",
+  },
+  {
+    background: "#2d2219",
+    skin: "#cfa580",
+    hair: "#7b2c2c",
+    outfit: "#c084fc",
+    accent: "#fde68a",
+    shadow: "#17110c",
+    eye: "#0f1014",
+  },
+  {
+    background: "#13252e",
+    skin: "#e6bc96",
+    hair: "#0f766e",
+    outfit: "#ef4444",
+    accent: "#fde68a",
+    shadow: "#0b1418",
+    eye: "#0b0f14",
+  },
+  {
+    background: "#2c2f36",
+    skin: "#f5cfb5",
+    hair: "#3f3f46",
+    outfit: "#84cc16",
+    accent: "#fb7185",
+    shadow: "#171a20",
+    eye: "#0f1218",
+  },
+  {
+    background: "#1f2a22",
+    skin: "#ddb38a",
+    hair: "#92400e",
+    outfit: "#38bdf8",
+    accent: "#facc15",
+    shadow: "#101612",
+    eye: "#0d1014",
+  },
+];
+
+export function normalizeAvatarSeed(seed: number | null | undefined): number {
+  const numeric = Number.isFinite(seed) ? Math.trunc(seed ?? 0) : 0;
+  const normalized = numeric >>> 0;
+  return normalized === 0 ? 0x9e3779b9 : normalized;
+}
+
+export function hashAvatarSeed(
+  value: string | number | null | undefined,
+): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return normalizeAvatarSeed(value);
+  }
+  const source = `${value ?? "agentdesk"}`;
+  let hash = 2166136261;
+  for (let i = 0; i < source.length; i += 1) {
+    hash ^= source.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return normalizeAvatarSeed(hash);
+}
+
+export function resolveAvatarSeed(source: AvatarSeedSource | undefined): number {
+  if (!source) return normalizeAvatarSeed(0);
+  if (source.avatar_seed != null && Number.isFinite(source.avatar_seed)) {
+    return normalizeAvatarSeed(source.avatar_seed);
+  }
+  return hashAvatarSeed(
+    source.id ??
+      source.name ??
+      source.name_ko ??
+      source.avatar_emoji ??
+      "agentdesk",
+  );
+}
+
+function createPrng(seed: number): () => number {
+  let state = normalizeAvatarSeed(seed);
+  return () => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    return (state >>> 0) / 0xffffffff;
+  };
+}
+
+function randInt(prng: () => number, maxExclusive: number): number {
+  return Math.floor(prng() * maxExclusive);
+}
+
+function setPixel(grid: string[][], x: number, y: number, color: string): void {
+  if (x < 0 || x >= PIXEL_AVATAR_SIZE || y < 0 || y >= PIXEL_AVATAR_SIZE) return;
+  grid[y][x] = color;
+}
+
+function setMirrorPixel(
+  grid: string[][],
+  x: number,
+  y: number,
+  color: string,
+  mirror = true,
+): void {
+  setPixel(grid, x, y, color);
+  if (mirror) setPixel(grid, PIXEL_AVATAR_SIZE - 1 - x, y, color);
+}
+
+function fillMirrorBand(
+  grid: string[][],
+  y: number,
+  colors: Array<string | null>,
+): void {
+  colors.forEach((color, x) => {
+    if (!color) return;
+    setMirrorPixel(grid, x, y, color);
+  });
+}
+
+export function buildPixelAvatarModel(seed: number): PixelAvatarModel {
+  const safeSeed = normalizeAvatarSeed(seed);
+  const prng = createPrng(safeSeed);
+  const paletteIndex = safeSeed % PIXEL_AVATAR_PALETTES.length;
+  const palette = PIXEL_AVATAR_PALETTES[paletteIndex];
+  const grid = Array.from({ length: PIXEL_AVATAR_SIZE }, () =>
+    Array.from({ length: PIXEL_AVATAR_SIZE }, () => palette.background),
+  );
+
+  const hairline = 1 + randInt(prng, 2);
+  const fringePatterns: Array<Array<string | null>> = [
+    [null, palette.hair, palette.hair, null],
+    [palette.hair, null, palette.hair, null],
+    [null, palette.hair, null, palette.hair],
+    [palette.hair, palette.hair, null, null],
+  ];
+  const browPatterns: Array<Array<string | null>> = [
+    [null, palette.hair, palette.hair, null],
+    [palette.hair, null, null, palette.hair],
+    [null, palette.hair, null, palette.hair],
+  ];
+  const shoulderPatterns: Array<Array<string | null>> = [
+    [null, palette.outfit, palette.outfit, palette.outfit],
+    [palette.outfit, palette.outfit, palette.outfit, null],
+    [null, palette.outfit, palette.accent, palette.outfit],
+  ];
+  const collarPatterns: Array<Array<string | null>> = [
+    [null, null, palette.accent, null],
+    [null, palette.accent, palette.accent, null],
+    [null, palette.accent, null, palette.outfit],
+  ];
+
+  fillMirrorBand(grid, 0, [null, palette.hair, palette.hair, palette.hair]);
+  fillMirrorBand(grid, 1, hairline === 2 ? [palette.hair, palette.hair, palette.hair, palette.hair] : fringePatterns[randInt(prng, fringePatterns.length)]);
+  fillMirrorBand(grid, 2, [palette.hair, palette.skin, palette.skin, palette.skin]);
+  fillMirrorBand(grid, 3, [palette.hair, palette.skin, palette.skin, palette.skin]);
+  fillMirrorBand(grid, 4, [null, palette.skin, palette.skin, palette.skin]);
+  fillMirrorBand(grid, 5, shoulderPatterns[randInt(prng, shoulderPatterns.length)]);
+  fillMirrorBand(grid, 6, [palette.outfit, palette.outfit, palette.outfit, palette.outfit]);
+  fillMirrorBand(grid, 7, [null, palette.outfit, palette.outfit, palette.outfit]);
+
+  fillMirrorBand(grid, 2 + hairline, browPatterns[randInt(prng, browPatterns.length)]);
+  fillMirrorBand(grid, 5, collarPatterns[randInt(prng, collarPatterns.length)]);
+
+  const eyeRow = 3;
+  setMirrorPixel(grid, 2, eyeRow, palette.eye);
+  setMirrorPixel(grid, 2, eyeRow + (randInt(prng, 3) === 0 ? 1 : 0), palette.eye);
+
+  const mouthType = randInt(prng, 3);
+  if (mouthType === 0) {
+    setPixel(grid, 3, 4, palette.shadow);
+    setPixel(grid, 4, 4, palette.shadow);
+  } else if (mouthType === 1) {
+    setPixel(grid, 3, 4, palette.shadow);
+  } else {
+    setPixel(grid, 4, 4, palette.shadow);
+  }
+
+  const accentType = randInt(prng, 4);
+  if (accentType === 0) {
+    setMirrorPixel(grid, 1, 1, palette.accent);
+  } else if (accentType === 1) {
+    setMirrorPixel(grid, 0, 3, palette.accent);
+  } else if (accentType === 2) {
+    setPixel(grid, 3, 6, palette.accent);
+    setPixel(grid, 4, 6, palette.accent);
+  } else {
+    setMirrorPixel(grid, 1, 5, palette.accent);
+  }
+
+  const shadowRow = randInt(prng, 2) === 0 ? 7 : 6;
+  setMirrorPixel(grid, 0, shadowRow, palette.shadow);
+  setMirrorPixel(grid, 1, shadowRow, palette.shadow, false);
+  setMirrorPixel(grid, 6, shadowRow, palette.shadow, false);
+
+  const pixels: PixelAvatarPixel[] = [];
+  for (let y = 0; y < grid.length; y += 1) {
+    for (let x = 0; x < grid[y].length; x += 1) {
+      const color = grid[y][x];
+      if (color === palette.background) continue;
+      pixels.push({ x, y, color });
+    }
+  }
+
+  return { paletteIndex, palette, pixels };
+}

--- a/dashboard/src/styles/main.css
+++ b/dashboard/src/styles/main.css
@@ -23,6 +23,9 @@
 
 :root {
   --color-primary: #6ef2a3;
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono", "SFMono-Regular", "SF Mono", Menlo, Consolas, monospace;
+  --font-pixel: "Silkscreen", "Press Start 2P", "Inter", "Segoe UI", sans-serif;
 }
 
 /* ── CE Theme Variables (dark) ── */
@@ -114,11 +117,15 @@
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family: var(--font-sans);
   background: var(--th-bg-primary);
   color: var(--th-text-primary);
   overflow: hidden;
   padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+}
+
+.font-pixel {
+  font-family: var(--font-pixel);
 }
 
 @media (max-width: 639px) {

--- a/dashboard/src/types/index.ts
+++ b/dashboard/src/types/index.ts
@@ -68,6 +68,7 @@ export interface Agent {
   department_name_ko?: string | null;
   department_color?: string | null;
   avatar_emoji: string;
+  avatar_seed?: number | null;
   sprite_number?: number | null;
   personality: string | null;
   status: AgentStatus;


### PR DESCRIPTION
Closes #776

P1-6 카드 자동큐 작업 결과. dashboard 변경 (Silkscreen 폰트 적용 + 8×8 pixel avatar 프로시저).

원작자: adk-dashboard (codex provider)
새 main(fa445fe3) 기준 clean rebase 후 PR 생성.