### PR TITLE
feat(dashboard): add oklch theme tokens and accent switcher (#771)

### DIFF
--- a/dashboard/src/app/AppShell.tsx
+++ b/dashboard/src/app/AppShell.tsx
@@ -9,11 +9,9 @@ import {
   Home,
   LayoutDashboard,
   Menu,
-  Moon,
   Search,
   Settings,
   Sparkles,
-  SunMedium,
   Trophy,
   Users,
   Wifi,
@@ -59,6 +57,19 @@ import {
   type AppRouteId,
 } from "./routes";
 import type { DashboardTab } from "./dashboardTabs";
+import {
+  DEFAULT_ACCENT_PRESET,
+  THEME_STORAGE_KEY,
+  applyThemeAccentDataset,
+  persistAccentPreset,
+  persistThemePreference,
+  readStoredAccentPreset,
+  readStoredThemePreference,
+  readThemePreferenceFromPatch,
+  resolveThemePreference,
+  type AccentPreset,
+  type ThemePreference,
+} from "./themePreferences";
 
 const OfficeView = lazy(() => import("../components/OfficeView"));
 const DashboardPageView = lazy(() => import("../components/DashboardPageView"));
@@ -86,6 +97,29 @@ type AgentsPageTab = "agents" | "departments" | "dispatch";
 type KanbanSignalFocus = "review" | "blocked" | "requested" | "stalled";
 
 const SIDEBAR_COLLAPSED_STORAGE_KEY = "agentdesk.sidebar.collapsed";
+
+const THEME_OPTIONS: Array<{
+  id: ThemePreference;
+  labelKo: string;
+  labelEn: string;
+}> = [
+  { id: "auto", labelKo: "자동", labelEn: "Auto" },
+  { id: "dark", labelKo: "다크", labelEn: "Dark" },
+  { id: "light", labelKo: "라이트", labelEn: "Light" },
+];
+
+const ACCENT_OPTIONS: Array<{
+  id: AccentPreset;
+  label: string;
+  token: string;
+}> = [
+  { id: "indigo", label: "Indigo", token: "--accent-indigo" },
+  { id: "violet", label: "Violet", token: "--accent-violet" },
+  { id: "amber", label: "Amber", token: "--accent-amber" },
+  { id: "rose", label: "Rose", token: "--accent-rose" },
+  { id: "cyan", label: "Cyan", token: "--accent-cyan" },
+  { id: "lime", label: "Lime", token: "--accent-lime" },
+];
 
 export default function AppShell({
   wsConnected,
@@ -141,6 +175,15 @@ export default function AppShell({
       window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === "true"
     );
   });
+  const [themePreference, setThemePreference] = useState<ThemePreference>(() =>
+    readStoredThemePreference(window.localStorage, settings.theme),
+  );
+  const [accentPreset, setAccentPreset] = useState<AccentPreset>(() =>
+    readStoredAccentPreset(window.localStorage, DEFAULT_ACCENT_PRESET),
+  );
+  const [prefersDarkScheme, setPrefersDarkScheme] = useState(() =>
+    window.matchMedia("(prefers-color-scheme: dark)").matches,
+  );
 
   const spriteMap = useSpriteMap(agents);
   const unresolvedMeetingsCount = roundTableMeetings.filter(
@@ -150,7 +193,10 @@ export default function AppShell({
     (notification) => Date.now() - notification.ts < 60_000,
   ).length;
   const notificationBadgeCount = unresolvedMeetingsCount + unreadCount;
-  const resolvedTheme = getResolvedTheme(settings.theme);
+  const resolvedTheme = useMemo(
+    () => resolveThemePreference(themePreference, prefersDarkScheme),
+    [prefersDarkScheme, themePreference],
+  );
   const recentNotifications = notifications.slice(0, 6);
 
   useEffect(() => {
@@ -159,6 +205,38 @@ export default function AppShell({
       String(sidebarCollapsed),
     );
   }, [sidebarCollapsed]);
+
+  useEffect(() => {
+    const query = window.matchMedia("(prefers-color-scheme: dark)");
+    const sync = (matches: boolean) => setPrefersDarkScheme(matches);
+
+    sync(query.matches);
+
+    const listener = (event: MediaQueryListEvent) => sync(event.matches);
+    if (typeof query.addEventListener === "function") {
+      query.addEventListener("change", listener);
+      return () => query.removeEventListener("change", listener);
+    }
+
+    query.addListener(listener);
+    return () => query.removeListener(listener);
+  }, []);
+
+  useEffect(() => {
+    if (window.localStorage.getItem(THEME_STORAGE_KEY) == null) {
+      setThemePreference(settings.theme);
+    }
+  }, [settings.theme]);
+
+  useEffect(() => {
+    persistThemePreference(window.localStorage, themePreference);
+    persistAccentPreset(window.localStorage, accentPreset);
+    applyThemeAccentDataset(
+      document.documentElement,
+      resolvedTheme,
+      accentPreset,
+    );
+  }, [accentPreset, resolvedTheme, themePreference]);
 
   useEffect(() => {
     setMobileSidebarOpen(false);
@@ -198,21 +276,16 @@ export default function AppShell({
     [navigate],
   );
 
-  const toggleTheme = useCallback(async () => {
-    const nextTheme = resolvedTheme === "dark" ? "light" : "dark";
-    try {
-      await persistSettingsPatch({ theme: nextTheme });
-      pushNotification(
-        tr("테마가 변경되었습니다.", "Theme updated."),
-        "success",
-      );
-    } catch {
-      pushNotification(
-        tr("테마를 저장하지 못했습니다.", "Failed to save theme."),
-        "error",
-      );
-    }
-  }, [persistSettingsPatch, pushNotification, resolvedTheme, tr]);
+  const handleSettingsSave = useCallback(
+    async (patch: Record<string, unknown>) => {
+      const requestedThemePreference = readThemePreferenceFromPatch(patch);
+      await persistSettingsPatch(patch);
+      if (requestedThemePreference) {
+        setThemePreference(requestedThemePreference);
+      }
+    },
+    [persistSettingsPatch],
+  );
 
   const handleOfficeChanged = useCallback(() => {
     refreshOffices();
@@ -530,21 +603,6 @@ export default function AppShell({
             </label>
 
             <div className="ml-auto flex items-center gap-2 sm:ml-0">
-              <button
-                type="button"
-                onClick={() => void toggleTheme()}
-                className="flex h-10 w-10 items-center justify-center rounded-xl border transition-colors hover:bg-white/5"
-                style={{ borderColor: "var(--th-border-subtle)" }}
-                aria-label={tr("테마 전환", "Toggle theme")}
-                title={tr("테마 전환", "Toggle theme")}
-              >
-                {resolvedTheme === "dark" ? (
-                  <SunMedium size={18} />
-                ) : (
-                  <Moon size={18} />
-                )}
-              </button>
-
               <div className="relative">
                 <button
                   type="button"
@@ -699,6 +757,101 @@ export default function AppShell({
               >
                 <Settings size={18} />
               </button>
+            </div>
+          </div>
+
+          <div
+            className="mt-3 flex flex-col gap-3 rounded-2xl border px-3 py-3 xl:flex-row xl:items-center xl:justify-between"
+            style={{
+              borderColor: "var(--th-border-subtle)",
+              background:
+                "linear-gradient(180deg, color-mix(in oklch, var(--bg-1) 94%, transparent) 0%, color-mix(in oklch, var(--bg-2) 98%, transparent) 100%)",
+            }}
+          >
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              <span
+                className="font-display text-[11px] font-semibold uppercase tracking-[0.18em]"
+                style={{ color: "var(--fg-faint)" }}
+              >
+                Theme
+              </span>
+              <div
+                className="flex items-center gap-1 rounded-full p-1"
+                style={{
+                  background:
+                    "color-mix(in oklch, var(--bg-3) 72%, transparent)",
+                }}
+              >
+                {THEME_OPTIONS.map((option) => {
+                  const active = themePreference === option.id;
+                  return (
+                    <button
+                      key={option.id}
+                      type="button"
+                      onClick={() => setThemePreference(option.id)}
+                      aria-pressed={active}
+                      className="rounded-full px-3 py-1 text-xs font-medium transition-colors"
+                      style={
+                        active
+                          ? {
+                              background: "var(--accent-soft)",
+                              color: "var(--accent)",
+                            }
+                          : { color: "var(--fg-muted)" }
+                      }
+                    >
+                      {isKo ? option.labelKo : option.labelEn}
+                    </button>
+                  );
+                })}
+              </div>
+              <span
+                className="rounded-full px-2 py-1 text-[11px]"
+                style={{
+                  background: "var(--th-overlay-medium)",
+                  color: "var(--fg-muted)",
+                }}
+              >
+                {isKo ? `현재 ${resolvedTheme}` : `Live ${resolvedTheme}`}
+              </span>
+            </div>
+
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              <span
+                className="font-display text-[11px] font-semibold uppercase tracking-[0.18em]"
+                style={{ color: "var(--fg-faint)" }}
+              >
+                Accent
+              </span>
+              <div className="flex items-center gap-1.5">
+                {ACCENT_OPTIONS.map((option) => {
+                  const active = accentPreset === option.id;
+                  return (
+                    <button
+                      key={option.id}
+                      type="button"
+                      title={option.label}
+                      aria-label={option.label}
+                      aria-pressed={active}
+                      onClick={() => setAccentPreset(option.id)}
+                      className="flex h-8 w-8 items-center justify-center rounded-full transition-transform"
+                      style={{
+                        border: active
+                          ? "2px solid var(--fg)"
+                          : "1px solid color-mix(in oklch, var(--line) 74%, transparent)",
+                        background:
+                          "color-mix(in oklch, var(--bg-2) 92%, transparent)",
+                        transform: active ? "translateY(-1px)" : undefined,
+                      }}
+                    >
+                      <span
+                        className="h-4 w-4 rounded-full"
+                        style={{ background: `var(${option.token})` }}
+                      />
+                    </button>
+                  );
+                })}
+              </div>
             </div>
           </div>
         </header>
@@ -940,7 +1093,7 @@ export default function AppShell({
                 element={
                   <SettingsView
                     settings={settings}
-                    onSave={persistSettingsPatch}
+                    onSave={handleSettingsSave}
                     isKo={isKo}
                   />
                 }
@@ -1489,14 +1642,6 @@ function hasUnresolvedMeetingIssues(meeting: RoundTableMeeting): boolean {
   const pending = Math.max(totalIssues - created - failed - discarded, 0);
 
   return pending > 0 || failed > 0;
-}
-
-function getResolvedTheme(theme: CompanySettings["theme"]): "dark" | "light" {
-  if (theme !== "auto") return theme;
-  if (typeof window === "undefined") return "dark";
-  return window.matchMedia("(prefers-color-scheme: dark)").matches
-    ? "dark"
-    : "light";
 }
 
 function notificationColor(type: Notification["type"]): string {

--- a/dashboard/src/app/providerTheme.ts
+++ b/dashboard/src/app/providerTheme.ts
@@ -1,0 +1,110 @@
+type ProviderLevel = "normal" | "warning" | "danger";
+
+const PROVIDER_LABELS: Record<string, string> = {
+  claude: "Claude",
+  codex: "Codex",
+  gemini: "Gemini",
+  qwen: "Qwen",
+  opencode: "OpenCode",
+  copilot: "Copilot",
+  antigravity: "Antigravity",
+  api: "API",
+};
+
+const PROVIDER_ACCENTS: Record<string, string> = {
+  claude: "var(--claude)",
+  codex: "var(--codex)",
+  gemini: "var(--gemini)",
+  qwen: "var(--qwen)",
+  opencode: "var(--opencode)",
+  copilot: "var(--copilot)",
+  antigravity: "var(--antigravity)",
+  api: "var(--api)",
+};
+
+const PROVIDER_SOFTS: Record<string, string> = {
+  claude: "var(--claude-soft)",
+  codex: "var(--codex-soft)",
+  gemini: "var(--gemini-soft)",
+  qwen: "var(--qwen-soft)",
+  opencode: "var(--opencode-soft)",
+  copilot: "var(--copilot-soft)",
+  antigravity: "var(--antigravity-soft)",
+  api: "var(--api-soft)",
+};
+
+export interface ProviderMeta {
+  id: string | null;
+  label: string;
+  bg: string;
+  color: string;
+  border: string;
+}
+
+function normalizeProviderId(provider: string | null | undefined): string | null {
+  if (!provider) return null;
+  const normalized = provider.trim().toLowerCase();
+  return normalized || null;
+}
+
+export function getProviderLabel(provider: string | null | undefined): string {
+  const normalized = normalizeProviderId(provider);
+  if (!normalized) return "Unknown";
+  return PROVIDER_LABELS[normalized] ?? provider!.toUpperCase();
+}
+
+export function getProviderAccent(provider: string | null | undefined): string {
+  const normalized = normalizeProviderId(provider);
+  if (!normalized) return "var(--fg-faint)";
+  return PROVIDER_ACCENTS[normalized] ?? "var(--fg-faint)";
+}
+
+export function getProviderSoft(provider: string | null | undefined): string {
+  const normalized = normalizeProviderId(provider);
+  if (!normalized) {
+    return "color-mix(in oklch, var(--fg-faint) 18%, var(--bg-2) 82%)";
+  }
+  return PROVIDER_SOFTS[normalized] ?? "color-mix(in oklch, var(--fg-faint) 18%, var(--bg-2) 82%)";
+}
+
+export function getProviderBorder(provider: string | null | undefined): string {
+  return `color-mix(in oklch, ${getProviderAccent(provider)} 34%, var(--line) 66%)`;
+}
+
+export function getProviderMeta(provider: string | null | undefined): ProviderMeta {
+  return {
+    id: normalizeProviderId(provider),
+    label: getProviderLabel(provider),
+    bg: getProviderSoft(provider),
+    color: getProviderAccent(provider),
+    border: getProviderBorder(provider),
+  };
+}
+
+export function getProviderSeries(provider: string | null | undefined): string[] {
+  const accent = getProviderAccent(provider);
+  return [
+    accent,
+    `color-mix(in oklch, ${accent} 82%, var(--fg) 18%)`,
+    `color-mix(in oklch, ${accent} 70%, var(--bg-3) 30%)`,
+    `color-mix(in oklch, ${accent} 58%, var(--accent) 42%)`,
+  ];
+}
+
+export function getProviderLevelColors(
+  provider: string | null | undefined,
+  level: ProviderLevel,
+): { bar: string; text: string; glow: string } {
+  const bar =
+    level === "danger"
+      ? "var(--err)"
+      : level === "warning"
+        ? "var(--warn)"
+        : getProviderAccent(provider);
+
+  return {
+    bar,
+    text: `color-mix(in oklch, ${bar} 78%, var(--fg) 22%)`,
+    glow: `color-mix(in oklch, ${bar} 36%, transparent)`,
+  };
+}

--- a/dashboard/src/app/themePreferences.test.ts
+++ b/dashboard/src/app/themePreferences.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_ACCENT_PRESET,
+  applyThemeAccentDataset,
+  readStoredAccentPreset,
+  readThemePreferenceFromPatch,
+  readStoredThemePreference,
+  resolveThemePreference,
+} from "./themePreferences";
+
+function createStorage(seed: Record<string, string> = {}): Storage {
+  const data = new Map(Object.entries(seed));
+  return {
+    length: data.size,
+    clear() {
+      data.clear();
+      this.length = 0;
+    },
+    getItem(key) {
+      return data.get(key) ?? null;
+    },
+    key(index) {
+      return Array.from(data.keys())[index] ?? null;
+    },
+    removeItem(key) {
+      data.delete(key);
+      this.length = data.size;
+    },
+    setItem(key, value) {
+      data.set(key, value);
+      this.length = data.size;
+    },
+  };
+}
+
+describe("themePreferences", () => {
+  it("reads stored values when valid", () => {
+    const storage = createStorage({
+      "agentdesk.theme": "light",
+      "agentdesk.accent": "rose",
+    });
+
+    expect(readStoredThemePreference(storage, "dark")).toBe("light");
+    expect(readStoredAccentPreset(storage, DEFAULT_ACCENT_PRESET)).toBe("rose");
+  });
+
+  it("falls back when stored values are invalid", () => {
+    const storage = createStorage({
+      "agentdesk.theme": "sepia",
+      "agentdesk.accent": "mint",
+    });
+
+    expect(readStoredThemePreference(storage, "auto")).toBe("auto");
+    expect(readStoredAccentPreset(storage, DEFAULT_ACCENT_PRESET)).toBe(DEFAULT_ACCENT_PRESET);
+  });
+
+  it("resolves auto theme against system preference", () => {
+    expect(resolveThemePreference("auto", true)).toBe("dark");
+    expect(resolveThemePreference("auto", false)).toBe("light");
+    expect(resolveThemePreference("light", true)).toBe("light");
+  });
+
+  it("applies theme and accent to the document dataset", () => {
+    const element = { dataset: {} } as HTMLElement;
+
+    applyThemeAccentDataset(element, "light", "cyan");
+
+    expect(element.dataset.theme).toBe("light");
+    expect(element.dataset.accent).toBe("cyan");
+  });
+
+  it("reads a valid theme preference from settings patches", () => {
+    expect(readThemePreferenceFromPatch({ theme: "light" })).toBe("light");
+    expect(readThemePreferenceFromPatch({ theme: "auto" })).toBe("auto");
+    expect(readThemePreferenceFromPatch({ theme: "sepia" })).toBeNull();
+    expect(readThemePreferenceFromPatch({ theme: 1 })).toBeNull();
+    expect(readThemePreferenceFromPatch({})).toBeNull();
+  });
+});

--- a/dashboard/src/app/themePreferences.ts
+++ b/dashboard/src/app/themePreferences.ts
@@ -1,0 +1,86 @@
+export type ThemePreference = "auto" | "dark" | "light";
+export type AccentPreset =
+  | "indigo"
+  | "violet"
+  | "amber"
+  | "rose"
+  | "cyan"
+  | "lime";
+
+export const THEME_STORAGE_KEY = "agentdesk.theme";
+export const ACCENT_STORAGE_KEY = "agentdesk.accent";
+export const DEFAULT_ACCENT_PRESET: AccentPreset = "indigo";
+
+const THEME_PREFERENCES = new Set<ThemePreference>(["auto", "dark", "light"]);
+const ACCENT_PRESETS = new Set<AccentPreset>([
+  "indigo",
+  "violet",
+  "amber",
+  "rose",
+  "cyan",
+  "lime",
+]);
+
+export function isThemePreference(value: string | null): value is ThemePreference {
+  return value !== null && THEME_PREFERENCES.has(value as ThemePreference);
+}
+
+export function isAccentPreset(value: string | null): value is AccentPreset {
+  return value !== null && ACCENT_PRESETS.has(value as AccentPreset);
+}
+
+export function readStoredThemePreference(
+  storage: Storage | null | undefined,
+  fallback: ThemePreference,
+): ThemePreference {
+  const stored = storage?.getItem(THEME_STORAGE_KEY) ?? null;
+  return isThemePreference(stored) ? stored : fallback;
+}
+
+export function readStoredAccentPreset(
+  storage: Storage | null | undefined,
+  fallback: AccentPreset = DEFAULT_ACCENT_PRESET,
+): AccentPreset {
+  const stored = storage?.getItem(ACCENT_STORAGE_KEY) ?? null;
+  return isAccentPreset(stored) ? stored : fallback;
+}
+
+export function resolveThemePreference(
+  preference: ThemePreference,
+  prefersDarkScheme: boolean,
+): "dark" | "light" {
+  if (preference === "auto") {
+    return prefersDarkScheme ? "dark" : "light";
+  }
+  return preference;
+}
+
+export function persistThemePreference(
+  storage: Storage | null | undefined,
+  preference: ThemePreference,
+): void {
+  storage?.setItem(THEME_STORAGE_KEY, preference);
+}
+
+export function persistAccentPreset(
+  storage: Storage | null | undefined,
+  accent: AccentPreset,
+): void {
+  storage?.setItem(ACCENT_STORAGE_KEY, accent);
+}
+
+export function readThemePreferenceFromPatch(
+  patch: Record<string, unknown>,
+): ThemePreference | null {
+  const value = patch.theme;
+  return typeof value === "string" && isThemePreference(value) ? value : null;
+}
+
+export function applyThemeAccentDataset(
+  element: HTMLElement,
+  theme: "dark" | "light",
+  accent: AccentPreset,
+): void {
+  element.dataset.theme = theme;
+  element.dataset.accent = accent;
+}

--- a/dashboard/src/components/MeetingProviderFlow.tsx
+++ b/dashboard/src/components/MeetingProviderFlow.tsx
@@ -1,72 +1,7 @@
 import { useI18n } from "../i18n";
+import { getProviderMeta } from "../app/providerTheme";
 
-export const PROVIDER_META: Record<string, { label: string; bg: string; color: string; border: string }> = {
-  claude: {
-    label: "Claude",
-    bg: "rgba(245,158,11,0.12)",
-    color: "#fbbf24",
-    border: "rgba(245,158,11,0.25)",
-  },
-  codex: {
-    label: "Codex",
-    bg: "rgba(56,189,248,0.12)",
-    color: "#7dd3fc",
-    border: "rgba(56,189,248,0.24)",
-  },
-  gemini: {
-    label: "Gemini",
-    bg: "rgba(59,130,246,0.12)",
-    color: "#60a5fa",
-    border: "rgba(59,130,246,0.25)",
-  },
-  qwen: {
-    label: "Qwen",
-    bg: "rgba(34,197,94,0.12)",
-    color: "#86efac",
-    border: "rgba(34,197,94,0.25)",
-  },
-  opencode: {
-    label: "OpenCode",
-    bg: "rgba(6,182,212,0.12)",
-    color: "#22d3ee",
-    border: "rgba(6,182,212,0.25)",
-  },
-  copilot: {
-    label: "Copilot",
-    bg: "rgba(16,185,129,0.12)",
-    color: "#6ee7b7",
-    border: "rgba(16,185,129,0.25)",
-  },
-  antigravity: {
-    label: "Antigravity",
-    bg: "rgba(249,115,22,0.12)",
-    color: "#fdba74",
-    border: "rgba(249,115,22,0.25)",
-  },
-  api: {
-    label: "API",
-    bg: "rgba(148,163,184,0.12)",
-    color: "#cbd5e1",
-    border: "rgba(148,163,184,0.25)",
-  },
-};
-
-export function getProviderMeta(provider: string | null) {
-  if (!provider) {
-    return {
-      label: "Unknown",
-      bg: "rgba(148,163,184,0.1)",
-      color: "#cbd5e1",
-      border: "rgba(148,163,184,0.18)",
-    };
-  }
-  return PROVIDER_META[provider.toLowerCase()] ?? {
-    label: provider.toUpperCase(),
-    bg: "rgba(148,163,184,0.1)",
-    color: "#cbd5e1",
-    border: "rgba(148,163,184,0.18)",
-  };
-}
+export { getProviderMeta };
 
 export function formatProviderFlow(
   primaryProvider: string | null,

--- a/dashboard/src/components/agent-manager/AgentInfoCard.tsx
+++ b/dashboard/src/components/agent-manager/AgentInfoCard.tsx
@@ -31,6 +31,7 @@ import type {
   DiscordBinding,
   AgentOfficeMembership,
 } from "../../api/client";
+import { getProviderMeta } from "../../app/providerTheme";
 import {
   describeDiscordBinding,
   describeDiscordTarget,
@@ -1089,6 +1090,7 @@ export default function AgentInfoCard({
               ) : (
                 <div className="space-y-1.5">
                   {claudeSessions.map((s) => {
+                    const providerMeta = getProviderMeta(s.provider);
                     const sessionChannelInfo = resolveDiscordChannelInfo(
                       s.thread_channel_id ?? null,
                     );
@@ -1116,25 +1118,12 @@ export default function AgentInfoCard({
                           <span
                             className="rounded px-1.5 py-0.5 text-xs"
                             style={{
-                              background:
-                                s.provider === "codex"
-                                  ? "rgba(56,189,248,0.18)"
-                                  : s.provider === "gemini"
-                                    ? "rgba(250,204,21,0.18)"
-                                    : s.provider === "qwen"
-                                      ? "rgba(34,197,94,0.18)"
-                                      : "color-mix(in srgb, var(--th-accent-primary-soft) 80%, transparent)",
-                              color:
-                                s.provider === "codex"
-                                  ? "#38bdf8"
-                                  : s.provider === "gemini"
-                                    ? "#facc15"
-                                    : s.provider === "qwen"
-                                      ? "#86efac"
-                                      : "var(--th-accent-primary)",
+                              background: providerMeta.bg,
+                              color: providerMeta.color,
+                              border: `1px solid ${providerMeta.border}`,
                             }}
                           >
-                            {s.provider === "codex" ? "Codex" : s.provider === "gemini" ? "Gemini" : s.provider === "qwen" ? "Qwen" : "Claude"}
+                            {providerMeta.label}
                           </span>
                           <span
                             className="rounded px-1.5 py-0.5 text-xs"

--- a/dashboard/src/components/agent-manager/KanbanBoard.tsx
+++ b/dashboard/src/components/agent-manager/KanbanBoard.tsx
@@ -26,6 +26,7 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const noop = (() => {}) as any;
 const noopGetAgentLabel = (_id: string | null | undefined) => "—";
+const noopGetAgentProvider = () => null;
 const noopResolveAgent = (_labels: Array<{ name: string; color: string }>) => null;
 
 // ---------------------------------------------------------------------------
@@ -451,6 +452,7 @@ export default function KanbanBoard({
                     closingIssueNumber={null}
                     assigningIssue={false}
                     getAgentLabel={noopGetAgentLabel}
+                    getAgentProvider={noopGetAgentProvider}
                     resolveAgentFromLabels={noopResolveAgent}
                     onCardClick={onCardClick}
                     onBacklogIssueClick={onBacklogIssueClick}

--- a/dashboard/src/components/agent-manager/KanbanColumn.tsx
+++ b/dashboard/src/components/agent-manager/KanbanColumn.tsx
@@ -4,6 +4,7 @@ import type {
   KanbanCard,
   KanbanCardStatus,
 } from "../../types";
+import { getProviderMeta } from "../../app/providerTheme";
 import {
   STATUS_TRANSITIONS,
   TRANSITION_STYLE,
@@ -34,6 +35,9 @@ export interface KanbanColumnProps {
   closingIssueNumber: number | null;
   assigningIssue: boolean;
   getAgentLabel: (agentId: string | null | undefined) => string;
+  getAgentProvider: (
+    agentId: string | null | undefined,
+  ) => Agent["cli_provider"] | null | undefined;
   resolveAgentFromLabels: (labels: Array<{ name: string; color: string }>) => Agent | null;
   onCardClick: (cardId: string) => void;
   onBacklogIssueClick: (issue: GitHubIssue) => void;
@@ -56,6 +60,7 @@ export default function KanbanColumn({
   closingIssueNumber,
   assigningIssue,
   getAgentLabel,
+  getAgentProvider,
   resolveAgentFromLabels,
   onCardClick,
   onBacklogIssueClick,
@@ -131,6 +136,7 @@ export default function KanbanColumn({
             key={card.id}
             card={card}
             tr={tr}
+            getAgentProvider={getAgentProvider}
             onCardClick={onCardClick}
             onUpdateCardStatus={onUpdateCardStatus}
             onSetActionError={onSetActionError}
@@ -238,6 +244,9 @@ function BacklogIssueCard({
 interface KanbanCardArticleProps {
   card: KanbanCard;
   tr: (ko: string, en: string) => string;
+  getAgentProvider: (
+    agentId: string | null | undefined,
+  ) => Agent["cli_provider"] | null | undefined;
   onCardClick: (cardId: string) => void;
   onUpdateCardStatus: (cardId: string, targetStatus: KanbanCardStatus) => void;
   onSetActionError: (error: string | null) => void;
@@ -246,10 +255,14 @@ interface KanbanCardArticleProps {
 function KanbanCardArticle({
   card,
   tr,
+  getAgentProvider,
   onCardClick,
   onUpdateCardStatus,
   onSetActionError,
 }: KanbanCardArticleProps) {
+  const provider = getAgentProvider(card.assignee_agent_id);
+  const providerMeta = provider ? getProviderMeta(provider) : null;
+
   return (
     <article
       onClick={() => onCardClick(card.id)}
@@ -257,19 +270,35 @@ function KanbanCardArticle({
       style={{
         borderColor: "rgba(148,163,184,0.2)",
         background: isReviewCard(card)
-          ? "linear-gradient(180deg, color-mix(in srgb, rgba(16,185,129,0.16) 78%, var(--th-card-bg) 22%) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)"
+          ? "linear-gradient(180deg, color-mix(in oklch, var(--ok) 14%, var(--th-card-bg) 86%) 0%, color-mix(in oklch, var(--th-bg-surface) 96%, transparent) 100%)"
           : "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 95%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
-        borderLeft: isReviewCard(card) ? "3px solid rgba(16,185,129,0.6)" : undefined,
+        borderLeft: isReviewCard(card)
+          ? "3px solid color-mix(in oklch, var(--ok) 62%, transparent)"
+          : undefined,
       }}
     >
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
-          <span
-            className="rounded-full px-2 py-0.5 text-xs bg-surface-medium"
-            style={{ color: "var(--th-text-secondary)" }}
-          >
-            {card.github_issue_number ? `#${card.github_issue_number}` : `#${card.id.slice(0, 6)}`}
-          </span>
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span
+              className="rounded-full px-2 py-0.5 text-xs bg-surface-medium"
+              style={{ color: "var(--th-text-secondary)" }}
+            >
+              {card.github_issue_number ? `#${card.github_issue_number}` : `#${card.id.slice(0, 6)}`}
+            </span>
+            {providerMeta ? (
+              <span
+                className="rounded-full border px-2 py-0.5 text-[11px] font-semibold"
+                style={{
+                  color: providerMeta.color,
+                  background: providerMeta.bg,
+                  borderColor: providerMeta.border,
+                }}
+              >
+                {providerMeta.label}
+              </span>
+            ) : null}
+          </div>
           <h4 className="mt-2 text-sm font-semibold leading-snug" style={{ color: "var(--th-text-heading)" }}>
             {card.title}
           </h4>
@@ -280,7 +309,7 @@ function KanbanCardArticle({
             target="_blank"
             rel="noreferrer"
             className="text-xs hover:underline"
-            style={{ color: "#93c5fd" }}
+            style={{ color: "var(--info)" }}
             onClick={(event) => event.stopPropagation()}
           >
             GH

--- a/dashboard/src/components/agent-manager/KanbanTab.tsx
+++ b/dashboard/src/components/agent-manager/KanbanTab.tsx
@@ -482,6 +482,11 @@ export default function KanbanTab({
     return localeName(locale, agent);
   };
 
+  const getAgentProvider = (agentId: string | null | undefined) => {
+    if (!agentId) return null;
+    return agentMap.get(agentId)?.cli_provider ?? null;
+  };
+
   const getTimelineKindLabel = (kind: "review" | "pm" | "work" | "general") => {
     switch (kind) {
       case "review":
@@ -2093,6 +2098,7 @@ export default function KanbanTab({
                           closingIssueNumber={closingIssueNumber}
                           assigningIssue={assigningIssue}
                           getAgentLabel={getAgentLabel}
+                          getAgentProvider={getAgentProvider}
                           resolveAgentFromLabels={resolveAgentFromLabels}
                           onCardClick={setSelectedCardId}
                           onBacklogIssueClick={setSelectedBacklogIssue}

--- a/dashboard/src/components/dashboard/RateLimitWidget.tsx
+++ b/dashboard/src/components/dashboard/RateLimitWidget.tsx
@@ -8,6 +8,10 @@ import {
   SurfaceNotice,
   SurfaceSection,
 } from "../common/SurfacePrimitives";
+import {
+  getProviderLevelColors,
+  getProviderMeta,
+} from "../../app/providerTheme";
 
 interface RateLimitBucket {
   id: string;
@@ -114,58 +118,12 @@ export function transformRawData(
   };
 }
 
-interface ProviderPalette {
-  accent: string;
-  normal: { bar: string; text: string; glow: string };
-  warning: { bar: string; text: string; glow: string };
-  danger: { bar: string; text: string; glow: string };
-}
-
-const PROVIDER_PALETTES: Record<string, ProviderPalette> = {
-  Claude: {
-    accent: "#f59e0b",
-    normal: { bar: "#f59e0b", text: "#fbbf24", glow: "rgba(245,158,11,0.3)" },
-    warning: { bar: "#ea580c", text: "#fb923c", glow: "rgba(234,88,12,0.4)" },
-    danger: { bar: "#ef4444", text: "#fca5a5", glow: "rgba(239,68,68,0.5)" },
-  },
-  Codex: {
-    accent: "#34d399",
-    normal: { bar: "#34d399", text: "#6ee7b7", glow: "rgba(52,211,153,0.3)" },
-    warning: { bar: "#fbbf24", text: "#fcd34d", glow: "rgba(251,191,36,0.4)" },
-    danger: { bar: "#f87171", text: "#fca5a5", glow: "rgba(248,113,113,0.5)" },
-  },
-  Gemini: {
-    accent: "#3b82f6",
-    normal: { bar: "#3b82f6", text: "#60a5fa", glow: "rgba(59,130,246,0.3)" },
-    warning: { bar: "#f59e0b", text: "#fbbf24", glow: "rgba(245,158,11,0.4)" },
-    danger: { bar: "#ef4444", text: "#fca5a5", glow: "rgba(239,68,68,0.5)" },
-  },
-  Qwen: {
-    accent: "#8b5cf6",
-    normal: { bar: "#8b5cf6", text: "#a78bfa", glow: "rgba(139,92,246,0.3)" },
-    warning: { bar: "#f59e0b", text: "#fbbf24", glow: "rgba(245,158,11,0.4)" },
-    danger: { bar: "#ef4444", text: "#fca5a5", glow: "rgba(239,68,68,0.5)" },
-  },
-};
-
-const DEFAULT_PALETTE: ProviderPalette = PROVIDER_PALETTES.Codex;
 const PROVIDER_ICONS: Record<string, string> = {
   Claude: "🤖",
   Codex: "⚡",
   Gemini: "🔮",
   Qwen: "🧠",
 };
-
-function getColors(provider: string, level: string) {
-  const palette = PROVIDER_PALETTES[provider] || DEFAULT_PALETTE;
-  if (level === "danger") return palette.danger;
-  if (level === "warning") return palette.warning;
-  return palette.normal;
-}
-
-function getAccent(provider: string) {
-  return (PROVIDER_PALETTES[provider] || DEFAULT_PALETTE).accent;
-}
 
 function formatTimeRemaining(resetsAt: string | null): string {
   if (!resetsAt) return "";
@@ -346,7 +304,8 @@ export default function RateLimitWidget({ t, onOpenSettings }: RateLimitWidgetPr
       ) : (
         <div className="mt-4 grid gap-4 xl:grid-cols-3">
           {providers.map((provider) => {
-            const accent = getAccent(provider.provider);
+            const providerMeta = getProviderMeta(provider.provider);
+            const accent = providerMeta.color;
             const statusLabel = provider.unsupported
               ? t({ ko: "미지원", en: "N/A", ja: "未対応", zh: "未支持" })
               : provider.stale
@@ -358,8 +317,8 @@ export default function RateLimitWidget({ t, onOpenSettings }: RateLimitWidgetPr
                 key={provider.provider}
                 className="rounded-3xl p-5"
                 style={{
-                  borderColor: `color-mix(in srgb, ${accent} 22%, var(--th-border) 78%)`,
-                  background: "color-mix(in srgb, var(--th-card-bg) 92%, transparent)",
+                  borderColor: providerMeta.border,
+                  background: providerMeta.bg,
                 }}
               >
                 <div className="flex items-start justify-between gap-3">
@@ -396,13 +355,23 @@ export default function RateLimitWidget({ t, onOpenSettings }: RateLimitWidgetPr
                   <span
                     className="rounded-full px-2 py-1 text-[10px] font-medium"
                     style={{
-                      color: provider.unsupported ? "#cbd5f5" : provider.stale ? "#fbbf24" : accent,
-                      border: `1px solid ${provider.unsupported ? "rgba(203,213,225,0.24)" : provider.stale ? "rgba(251,191,36,0.3)" : `color-mix(in srgb, ${accent} 24%, var(--th-border) 76%)`}`,
-                      background: provider.unsupported
-                        ? "rgba(148,163,184,0.12)"
+                      color: provider.unsupported
+                        ? "var(--fg-dim)"
                         : provider.stale
-                          ? "rgba(251,191,36,0.1)"
-                          : `color-mix(in srgb, ${accent} 10%, var(--th-bg-surface) 90%)`,
+                          ? "var(--warn)"
+                          : accent,
+                      border: `1px solid ${
+                        provider.unsupported
+                          ? "color-mix(in oklch, var(--fg-faint) 24%, var(--line) 76%)"
+                          : provider.stale
+                            ? "color-mix(in oklch, var(--warn) 28%, var(--line) 72%)"
+                            : providerMeta.border
+                      }`,
+                      background: provider.unsupported
+                        ? "color-mix(in oklch, var(--fg-faint) 10%, var(--bg-2) 90%)"
+                        : provider.stale
+                          ? "color-mix(in oklch, var(--warn) 12%, var(--bg-2) 88%)"
+                          : providerMeta.bg,
                     }}
                   >
                     {statusLabel}
@@ -413,9 +382,8 @@ export default function RateLimitWidget({ t, onOpenSettings }: RateLimitWidgetPr
                   <div
                     className="mt-4 rounded-2xl border px-3 py-3"
                     style={{
-                      borderColor: "rgba(148,163,184,0.16)",
-                      background:
-                        "color-mix(in srgb, var(--th-bg-surface) 94%, rgba(148,163,184,0.12) 6%)",
+                      borderColor: "color-mix(in oklch, var(--fg-faint) 20%, var(--line) 80%)",
+                      background: "color-mix(in oklch, var(--fg-faint) 6%, var(--th-bg-surface) 94%)",
                     }}
                   >
                     <div className="text-xs font-semibold" style={{ color: "var(--th-text)" }}>
@@ -442,7 +410,7 @@ export default function RateLimitWidget({ t, onOpenSettings }: RateLimitWidgetPr
                 ) : (
                   <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
                     {provider.buckets.map((bucket) => {
-                      const colors = getColors(provider.provider, bucket.level);
+                      const colors = getProviderLevelColors(provider.provider, bucket.level);
                       const remaining = formatTimeRemaining(bucket.resets_at);
                       return (
                         <div key={bucket.id} className="relative">
@@ -471,8 +439,8 @@ export default function RateLimitWidget({ t, onOpenSettings }: RateLimitWidgetPr
                               className="relative overflow-hidden rounded-full"
                               style={{
                                 height: 10,
-                                background: "rgba(255,255,255,0.12)",
-                                border: "1px solid rgba(255,255,255,0.08)",
+                                background: "var(--line-soft)",
+                                border: "1px solid color-mix(in oklch, var(--line) 60%, transparent)",
                               }}
                             >
                               <div

--- a/dashboard/src/components/dashboard/TokenAnalyticsSection.tsx
+++ b/dashboard/src/components/dashboard/TokenAnalyticsSection.tsx
@@ -13,6 +13,7 @@ import type { TFunction } from "./model";
 import { cx, dashboardBadge, dashboardButton, dashboardCard } from "./ui";
 import TooltipLabel from "../common/TooltipLabel";
 import { buildAgentRoiRows } from "./dashboardInsights";
+import { getProviderSeries } from "../../app/providerTheme";
 
 type Period = "7d" | "30d" | "90d";
 
@@ -70,13 +71,6 @@ const analyticsCache = new Map<Period, CachedAnalyticsEntry>();
 const ANALYTICS_CACHE_TTL = 5 * 60_000;
 const PERIOD_OPTIONS: Period[] = ["7d", "30d", "90d"];
 const TREND_PLOT_HEIGHT_PX = 144;
-const MODEL_PALETTES: Record<string, string[]> = {
-  Claude: ["#f59e0b", "#fbbf24", "#fb7185", "#f97316"],
-  Codex: ["#22c55e", "#14b8a6", "#06b6d4", "#0ea5e9"],
-  Gemini: ["#60a5fa", "#818cf8", "#a855f7", "#38bdf8"],
-  Qwen: ["#8b5cf6", "#a78bfa", "#c084fc", "#7c3aed"],
-  default: ["#94a3b8", "#c084fc", "#fb7185", "#2dd4bf"],
-};
 const HEATMAP_COLORS = [
   "rgba(148,163,184,0.08)",
   "rgba(14,165,233,0.24)",
@@ -186,7 +180,7 @@ export function normalizeModelProviderLabel(provider: string): string {
 }
 
 function modelColor(provider: string, index: number): string {
-  const palette = MODEL_PALETTES[normalizeModelProviderLabel(provider)] ?? MODEL_PALETTES.default;
+  const palette = getProviderSeries(provider);
   return palette[index % palette.length];
 }
 

--- a/dashboard/src/components/office-view/OfficeInsightPanel.tsx
+++ b/dashboard/src/components/office-view/OfficeInsightPanel.tsx
@@ -5,6 +5,10 @@ import { getAgentWarnings } from "../../agent-insights";
 import { getFontFamilyForText } from "../../lib/fonts";
 import AgentAvatar from "../AgentAvatar";
 import {
+  getProviderLevelColors,
+  getProviderMeta,
+} from "../../app/providerTheme";
+import {
   SurfaceActionButton,
   SurfaceCard,
   SurfaceListItem,
@@ -33,6 +37,19 @@ function timeAgo(ts: number, isKo: boolean): string {
   if (hrs < 24) return isKo ? `${hrs}시간 전` : `${hrs}h ago`;
   const days = Math.floor(hrs / 24);
   return isKo ? `${days}일 전` : `${days}d ago`;
+}
+
+function eventAccent(type: Notification["type"]): string {
+  switch (type) {
+    case "success":
+      return "var(--ok)";
+    case "warning":
+      return "var(--warn)";
+    case "error":
+      return "var(--err)";
+    default:
+      return "var(--info)";
+  }
 }
 
 export default function OfficeInsightPanel({
@@ -216,15 +233,7 @@ export default function OfficeInsightPanel({
                       title={item.message}
                       ts={item.ts}
                       isKo={isKo}
-                      accent={
-                        item.type === "success"
-                          ? "#34d399"
-                          : item.type === "warning"
-                            ? "#fbbf24"
-                            : item.type === "error"
-                              ? "#f87171"
-                              : "#60a5fa"
-                      }
+                      accent={eventAccent(item.type)}
                     />
                   ))}
                 </div>
@@ -244,7 +253,7 @@ export default function OfficeInsightPanel({
                       title={item.summary}
                       ts={item.created_at}
                       isKo={isKo}
-                      accent="#f59e0b"
+                      accent="var(--warn)"
                       subtitle={`${item.entity_type}:${item.entity_id}`}
                     />
                   ))}
@@ -292,15 +301,7 @@ export default function OfficeInsightPanel({
                   title={item.message}
                   ts={item.ts}
                   isKo={isKo}
-                  accent={
-                    item.type === "success"
-                      ? "#34d399"
-                      : item.type === "warning"
-                        ? "#fbbf24"
-                        : item.type === "error"
-                          ? "#f87171"
-                          : "#60a5fa"
-                  }
+                  accent={eventAccent(item.type)}
                 />
               ))}
             </div>
@@ -320,7 +321,7 @@ export default function OfficeInsightPanel({
                   title={item.summary}
                   ts={item.created_at}
                   isKo={isKo}
-                  accent="#f59e0b"
+                  accent="var(--warn)"
                   subtitle={`${item.entity_type}:${item.entity_id}`}
                 />
               ))}
@@ -636,16 +637,6 @@ export function transformRLProviders(raw: RawRLProvider[]): RLProvider[] {
     }));
 }
 
-const RL_COLORS: Record<string, { normal: string; warning: string; danger: string; accent: string }> = {
-  Claude: { accent: "#f59e0b", normal: "#f59e0b", warning: "#ea580c", danger: "#ef4444" },
-  Codex: { accent: "#34d399", normal: "#34d399", warning: "#fbbf24", danger: "#f87171" },
-  Gemini: { accent: "#3b82f6", normal: "#3b82f6", warning: "#f59e0b", danger: "#ef4444" },
-  Qwen: { accent: "#8b5cf6", normal: "#8b5cf6", warning: "#f59e0b", danger: "#ef4444" },
-  OpenCode: { accent: "#06b6d4", normal: "#06b6d4", warning: "#f59e0b", danger: "#ef4444" },
-  Copilot: { accent: "#10b981", normal: "#10b981", warning: "#f59e0b", danger: "#ef4444" },
-  Antigravity: { accent: "#f97316", normal: "#f97316", warning: "#f59e0b", danger: "#ef4444" },
-  API: { accent: "#94a3b8", normal: "#94a3b8", warning: "#f59e0b", danger: "#ef4444" },
-};
 const RL_ICONS: Record<string, string> = {
   Claude: "🤖",
   Codex: "⚡",
@@ -656,13 +647,6 @@ const RL_ICONS: Record<string, string> = {
   Antigravity: "🌀",
   API: "🔌",
 };
-
-function barColor(provider: string, level: string) {
-  const p = RL_COLORS[provider] || RL_COLORS.Codex;
-  if (level === "danger") return p.danger;
-  if (level === "warning") return p.warning;
-  return p.normal;
-}
 
 function MiniRateLimitBar({ isKo }: { isKo: boolean }) {
   const [providers, setProviders] = useState<RLProvider[]>([]);
@@ -687,19 +671,28 @@ function MiniRateLimitBar({ isKo }: { isKo: boolean }) {
   return (
     <div className="mt-2 space-y-1">
       {providers.map((p) => {
-        const accent = (RL_COLORS[p.provider] || RL_COLORS.Codex).accent;
+        const providerMeta = getProviderMeta(p.provider);
         const visible = p.buckets;
         return (
           <div key={p.provider} className="flex items-center gap-0">
             {/* Fixed-width left: provider + stale placeholder */}
             <div className="flex items-center gap-1 shrink-0" style={{ width: 96 }}>
-              <span className="text-xs font-bold uppercase truncate" style={{ color: accent }}>
+              <span
+                className="text-xs font-bold uppercase truncate"
+                style={{ color: providerMeta.color }}
+              >
                 {(RL_ICONS[p.provider] ?? "•")} {p.provider}
               </span>
               {p.stale ? (
                 <span
                   className="rounded px-0.5 text-[7px] font-medium shrink-0"
-                  style={{ color: "#fbbf24", background: "rgba(251,191,36,0.1)", border: "1px solid rgba(251,191,36,0.2)" }}
+                  style={{
+                    color: "var(--warn)",
+                    background:
+                      "color-mix(in oklch, var(--warn) 14%, var(--bg-2) 86%)",
+                    border:
+                      "1px solid color-mix(in oklch, var(--warn) 28%, var(--line) 72%)",
+                  }}
                 >
                   {isKo ? "지연" : "STALE"}
                 </span>
@@ -711,9 +704,11 @@ function MiniRateLimitBar({ isKo }: { isKo: boolean }) {
                   <span
                     className="rounded px-1.5 py-0.5 text-[9px] font-semibold shrink-0"
                     style={{
-                      color: "#cbd5f5",
-                      background: "rgba(148,163,184,0.12)",
-                      border: "1px solid rgba(148,163,184,0.2)",
+                      color: "var(--fg-dim)",
+                      background:
+                        "color-mix(in oklch, var(--fg-faint) 10%, var(--bg-2) 90%)",
+                      border:
+                        "1px solid color-mix(in oklch, var(--fg-faint) 20%, var(--line) 80%)",
                     }}
                   >
                     {p.unsupported ? "N/A" : (isKo ? "비어있음" : "EMPTY")}
@@ -729,17 +724,25 @@ function MiniRateLimitBar({ isKo }: { isKo: boolean }) {
               <div className="flex-1 grid grid-cols-2 gap-x-2">
                 {visible.map((b) => (
                   <div key={b.id} className="flex items-center gap-1">
-                    <span className="text-xs font-bold shrink-0 w-[14px]" style={{ color: barColor(p.provider, b.level) }}>
+                    <span
+                      className="text-xs font-bold shrink-0 w-[14px]"
+                      style={{ color: getProviderLevelColors(p.provider, b.level).text }}
+                    >
                       {b.label}
                     </span>
                     <div className="flex-1 min-w-0">
-                      <div className="relative h-[3px] rounded-full overflow-hidden" style={{ background: "rgba(255,255,255,0.08)" }}>
+                      <div
+                        className="relative h-[3px] rounded-full overflow-hidden"
+                        style={{ background: "var(--line-soft)" }}
+                      >
                         <div
                           className="absolute inset-y-0 left-0 rounded-full"
                           style={{
                             width: b.utilization === null ? "0%" : `${Math.min(b.utilization, 100)}%`,
                             background:
-                              b.utilization === null ? "transparent" : barColor(p.provider, b.level),
+                              b.utilization === null
+                                ? "transparent"
+                                : getProviderLevelColors(p.provider, b.level).bar,
                           }}
                         />
                       </div>
@@ -750,7 +753,7 @@ function MiniRateLimitBar({ isKo }: { isKo: boolean }) {
                         color:
                           b.utilization === null
                             ? "var(--th-text-muted)"
-                            : barColor(p.provider, b.level),
+                            : getProviderLevelColors(p.provider, b.level).text,
                       }}
                     >
                       {b.utilization === null ? "N/A" : `${b.utilization}%`}

--- a/dashboard/src/contexts/SettingsContext.tsx
+++ b/dashboard/src/contexts/SettingsContext.tsx
@@ -2,8 +2,6 @@ import { createContext, useCallback, useContext, useEffect, useRef, useState, ty
 import type { CompanySettings, DashboardStats, WSEvent } from "../types";
 import type { UiLanguage } from "../i18n";
 import * as api from "../api/client";
-import { STORAGE_KEYS } from "../lib/storageKeys";
-import { writeLocalStorageValue } from "../lib/useLocalStorage";
 import { useOffice } from "./OfficeContext";
 
 // ── Context value ──
@@ -70,25 +68,6 @@ export function SettingsProvider({ initialSettings, initialStats, children }: Se
     window.addEventListener("pcd-ws-event", handleWs);
     return () => window.removeEventListener("pcd-ws-event", handleWs);
   }, [refreshStats]);
-
-  // Apply theme to DOM — handles auto (system preference) and explicit dark/light
-  useEffect(() => {
-    const applyTheme = (nextTheme: "dark" | "light") => {
-      document.documentElement.dataset.theme = nextTheme;
-      writeLocalStorageValue(STORAGE_KEYS.theme, nextTheme);
-    };
-    if (settings.theme !== "auto") {
-      applyTheme(settings.theme);
-      return;
-    }
-    const mq = window.matchMedia("(prefers-color-scheme: dark)");
-    const apply = () => {
-      applyTheme(mq.matches ? "dark" : "light");
-    };
-    apply();
-    mq.addEventListener("change", apply);
-    return () => mq.removeEventListener("change", apply);
-  }, [settings.theme]);
 
   const isKo = settings.language === "ko";
   const locale = settings.language;

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -3,7 +3,24 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import { OverlayProvider } from "./components/common/overlay";
+import {
+  DEFAULT_ACCENT_PRESET,
+  applyThemeAccentDataset,
+  readStoredAccentPreset,
+  readStoredThemePreference,
+  resolveThemePreference,
+} from "./app/themePreferences";
 import "./styles/main.css";
+
+const prefersDarkScheme = window.matchMedia("(prefers-color-scheme: dark)").matches;
+const initialThemePreference = readStoredThemePreference(window.localStorage, "dark");
+const initialAccentPreset = readStoredAccentPreset(window.localStorage, DEFAULT_ACCENT_PRESET);
+
+applyThemeAccentDataset(
+  document.documentElement,
+  resolveThemePreference(initialThemePreference, prefersDarkScheme),
+  initialAccentPreset,
+);
 
 // Recover from stale lazy chunks after deploy: detect load failures and reload once
 window.addEventListener("error", (e) => {

--- a/dashboard/src/styles/main.css
+++ b/dashboard/src/styles/main.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&family=Silkscreen:wght@400;700&display=swap");
 @import "tailwindcss";
 
 /* ── Tailwind v4 semantic color tokens ── */
@@ -6,6 +7,9 @@
   --color-surface-light: var(--th-overlay-light);
   --color-surface-medium: var(--th-overlay-medium);
   --color-surface-hover: var(--th-overlay-strong);
+  --color-accent: var(--accent);
+  --color-claude: var(--claude);
+  --color-codex: var(--codex);
   --color-th-bg-primary: var(--th-bg-primary);
   --color-th-bg-surface: var(--th-bg-surface);
   --color-th-card-bg: var(--th-card-bg);
@@ -22,91 +26,141 @@
 }
 
 :root {
-  --color-primary: #6ef2a3;
-  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --font-display: "Inter", "Avenir Next", "Segoe UI", system-ui, sans-serif;
   --font-mono: "JetBrains Mono", "SFMono-Regular", "SF Mono", Menlo, Consolas, monospace;
   --font-pixel: "Silkscreen", "Press Start 2P", "Inter", "Segoe UI", sans-serif;
+  --r-sm: 0.625rem;
+  --r-md: 0.875rem;
+  --r-lg: 1rem;
+  --r-xl: 1.25rem;
+  --shadow-sm: 0 10px 24px color-mix(in oklch, black 16%, transparent);
+  --shadow-md: 0 18px 40px color-mix(in oklch, black 24%, transparent);
+  --accent-indigo: oklch(0.63 0.19 274);
+  --accent-violet: oklch(0.67 0.21 307);
+  --accent-amber: oklch(0.8 0.16 83);
+  --accent-rose: oklch(0.67 0.22 18);
+  --accent-cyan: oklch(0.77 0.13 220);
+  --accent-lime: oklch(0.83 0.19 131);
+  --accent: var(--accent-indigo);
+  --color-primary: var(--accent);
 }
 
-/* ── CE Theme Variables (dark) ── */
-[data-theme="dark"], :root {
-  --th-bg-primary: #121313;
-  --th-bg-surface: #17191a;
-  --th-bg-surface-hover: #23272a;
-  --th-surface: var(--th-bg-surface);
-  --th-card-bg: #1d2022;
-  --th-card-border: #2a2f33;
-  --th-border: #3a4147;
-  --th-border-subtle: rgba(58, 65, 71, 0.58);
-  --th-input-bg: #161819;
-  --th-input-border: #3a4147;
-  --th-text: var(--th-text-primary);
-  --th-text-primary: #f3f5f7;
-  --th-text-secondary: #b8c0c7;
-  --th-text-muted: #7f8a94;
-  --th-text-heading: #fbfcfc;
-  --th-modal-overlay: rgba(7, 8, 9, 0.72);
-  --th-nav-bg: #111213;
-  --th-text: #f3f5f7;
-  --th-surface: #17191a;
-  --th-bg-card: #1d2022;
-  --th-overlay-subtle: rgba(255, 255, 255, 0.04);
-  --th-overlay-light: rgba(255, 255, 255, 0.055);
-  --th-overlay-medium: rgba(255, 255, 255, 0.075);
-  --th-overlay-strong: rgba(255, 255, 255, 0.1);
-  --th-accent-primary: #6ef2a3;
-  --th-accent-primary-soft: #173126;
-  --th-accent-info: #66b3ff;
-  --th-accent-warn: #f5bd47;
-  --th-accent-danger: #ff6b6b;
-  --th-badge-sky-bg: rgba(102, 179, 255, 0.16);
-  --th-badge-sky-text: #9dcfff;
-  --th-badge-blue-bg: rgba(126, 163, 255, 0.16);
-  --th-badge-blue-text: #b8ceff;
-  --th-badge-emerald-bg: rgba(110, 242, 163, 0.16);
-  --th-badge-emerald-text: #96f7bf;
-  --th-badge-amber-bg: rgba(245, 189, 71, 0.16);
-  --th-badge-amber-text: #f8d27d;
+/* Policy: raw OKLCH is the source of truth. Unsupported browsers are out of scope for our current Chromium/WebKit targets, so no sRGB fallback is intentionally shipped here. */
+:root,
+[data-theme="dark"] {
+  color-scheme: dark;
+  --bg: oklch(0.16 0.006 250);
+  --bg-1: oklch(0.2 0.007 250);
+  --bg-2: oklch(0.24 0.008 250);
+  --bg-3: oklch(0.29 0.01 250);
+  --fg: oklch(0.96 0.004 250);
+  --fg-dim: oklch(0.82 0.01 250);
+  --fg-muted: oklch(0.68 0.009 250);
+  --fg-faint: oklch(0.55 0.008 250);
+  --line: oklch(0.37 0.01 250);
+  --line-soft: color-mix(in oklch, var(--line) 60%, transparent);
+  --accent-soft: color-mix(in oklch, var(--accent) 24%, var(--bg-2) 76%);
+  --ok: oklch(0.78 0.17 150);
+  --warn: oklch(0.81 0.16 85);
+  --err: oklch(0.67 0.22 22);
+  --info: oklch(0.76 0.12 230);
+  --claude: oklch(0.77 0.16 71);
+  --claude-soft: color-mix(in oklch, var(--claude) 22%, var(--bg-2) 78%);
+  --codex: oklch(0.77 0.12 214);
+  --codex-soft: color-mix(in oklch, var(--codex) 22%, var(--bg-2) 78%);
+  --gemini: oklch(0.72 0.16 258);
+  --gemini-soft: color-mix(in oklch, var(--gemini) 22%, var(--bg-2) 78%);
+  --qwen: oklch(0.74 0.18 319);
+  --qwen-soft: color-mix(in oklch, var(--qwen) 22%, var(--bg-2) 78%);
+  --opencode: oklch(0.76 0.11 195);
+  --opencode-soft: color-mix(in oklch, var(--opencode) 22%, var(--bg-2) 78%);
+  --copilot: oklch(0.75 0.14 160);
+  --copilot-soft: color-mix(in oklch, var(--copilot) 22%, var(--bg-2) 78%);
+  --antigravity: oklch(0.74 0.17 45);
+  --antigravity-soft: color-mix(in oklch, var(--antigravity) 22%, var(--bg-2) 78%);
+  --api: oklch(0.72 0.02 250);
+  --api-soft: color-mix(in oklch, var(--api) 18%, var(--bg-2) 82%);
+  --th-bg-primary: var(--bg);
+  --th-bg-surface: var(--bg-1);
+  --th-bg-surface-hover: var(--bg-3);
+  --th-surface: var(--bg-1);
+  --th-card-bg: var(--bg-2);
+  --th-bg-card: var(--bg-2);
+  --th-card-border: var(--line-soft);
+  --th-border: var(--line);
+  --th-border-subtle: var(--line-soft);
+  --th-input-bg: var(--bg-2);
+  --th-input-border: var(--line);
+  --th-text: var(--fg);
+  --th-text-primary: var(--fg);
+  --th-text-secondary: var(--fg-dim);
+  --th-text-muted: var(--fg-muted);
+  --th-text-heading: var(--fg);
+  --th-modal-overlay: color-mix(in oklch, var(--bg) 78%, transparent);
+  --th-nav-bg: color-mix(in oklch, var(--bg-1) 90%, black 10%);
+  --th-overlay-subtle: color-mix(in oklch, white 4%, transparent);
+  --th-overlay-light: color-mix(in oklch, white 6%, transparent);
+  --th-overlay-medium: color-mix(in oklch, white 8%, transparent);
+  --th-overlay-strong: color-mix(in oklch, white 11%, transparent);
+  --th-accent-primary: var(--accent);
+  --th-accent-primary-soft: var(--accent-soft);
+  --th-accent-info: var(--info);
+  --th-accent-warn: var(--warn);
+  --th-accent-danger: var(--err);
+  --th-badge-sky-bg: color-mix(in oklch, var(--info) 16%, var(--bg-2) 84%);
+  --th-badge-sky-text: color-mix(in oklch, var(--info) 74%, var(--fg) 26%);
+  --th-badge-blue-bg: color-mix(in oklch, var(--accent) 18%, var(--bg-2) 82%);
+  --th-badge-blue-text: color-mix(in oklch, var(--accent) 72%, var(--fg) 28%);
+  --th-badge-emerald-bg: color-mix(in oklch, var(--ok) 16%, var(--bg-2) 84%);
+  --th-badge-emerald-text: color-mix(in oklch, var(--ok) 74%, var(--fg) 26%);
+  --th-badge-amber-bg: color-mix(in oklch, var(--warn) 16%, var(--bg-2) 84%);
+  --th-badge-amber-text: color-mix(in oklch, var(--warn) 76%, var(--fg) 24%);
 }
 
 [data-theme="light"] {
-  --th-bg-primary: #f5f6f6;
-  --th-bg-surface: #ecefed;
-  --th-bg-surface-hover: #dde3df;
-  --th-surface: var(--th-bg-surface);
-  --th-card-bg: #ffffff;
-  --th-card-border: #d7dcda;
-  --th-border: #c4cbc8;
-  --th-border-subtle: rgba(81, 96, 90, 0.18);
-  --th-input-bg: #ffffff;
-  --th-input-border: #c4cbc8;
-  --th-text: var(--th-text-primary);
-  --th-text-primary: #151b18;
-  --th-text-secondary: #51605a;
-  --th-text-muted: #74817b;
-  --th-text-heading: #0f1412;
-  --th-modal-overlay: rgba(15, 17, 18, 0.34);
-  --th-nav-bg: #e5eae7;
-  --th-text: #151b18;
-  --th-surface: #ecefed;
-  --th-bg-card: #ffffff;
-  --th-overlay-subtle: rgba(0, 0, 0, 0.04);
-  --th-overlay-light: rgba(0, 0, 0, 0.05);
-  --th-overlay-medium: rgba(0, 0, 0, 0.06);
-  --th-overlay-strong: rgba(0, 0, 0, 0.08);
-  --th-accent-primary: #2e9f63;
-  --th-accent-primary-soft: #dff4e8;
-  --th-accent-info: #2e78c7;
-  --th-accent-warn: #b88112;
-  --th-accent-danger: #cf4e4e;
-  --th-badge-sky-bg: rgba(102, 179, 255, 0.12);
-  --th-badge-sky-text: #235f99;
-  --th-badge-blue-bg: rgba(126, 163, 255, 0.12);
-  --th-badge-blue-text: #3559b0;
-  --th-badge-emerald-bg: rgba(46, 159, 99, 0.12);
-  --th-badge-emerald-text: #236f48;
-  --th-badge-amber-bg: rgba(245, 189, 71, 0.14);
-  --th-badge-amber-text: #9a6d12;
+  color-scheme: light;
+  --bg: oklch(0.98 0.003 250);
+  --bg-1: oklch(0.95 0.004 250);
+  --bg-2: oklch(1 0 0);
+  --bg-3: oklch(0.92 0.006 250);
+  --fg: oklch(0.21 0.01 250);
+  --fg-dim: oklch(0.36 0.01 250);
+  --fg-muted: oklch(0.49 0.012 250);
+  --fg-faint: oklch(0.62 0.01 250);
+  --line: oklch(0.83 0.008 250);
+  --line-soft: color-mix(in oklch, var(--line) 74%, transparent);
+  --accent-soft: color-mix(in oklch, var(--accent) 15%, var(--bg-2) 85%);
+  --th-modal-overlay: color-mix(in oklch, black 22%, transparent);
+  --th-nav-bg: color-mix(in oklch, var(--bg-1) 88%, white 12%);
+  --th-overlay-subtle: color-mix(in oklch, black 4%, transparent);
+  --th-overlay-light: color-mix(in oklch, black 5%, transparent);
+  --th-overlay-medium: color-mix(in oklch, black 7%, transparent);
+  --th-overlay-strong: color-mix(in oklch, black 10%, transparent);
+}
+
+[data-accent="indigo"] {
+  --accent: var(--accent-indigo);
+}
+
+[data-accent="violet"] {
+  --accent: var(--accent-violet);
+}
+
+[data-accent="amber"] {
+  --accent: var(--accent-amber);
+}
+
+[data-accent="rose"] {
+  --accent: var(--accent-rose);
+}
+
+[data-accent="cyan"] {
+  --accent: var(--accent-cyan);
+}
+
+[data-accent="lime"] {
+  --accent: var(--accent-lime);
 }
 
 *,
@@ -128,6 +182,13 @@ body {
   font-family: var(--font-pixel);
 }
 
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
 @media (max-width: 639px) {
   body { overflow-x: hidden; overflow-y: auto; }
 }
@@ -140,6 +201,14 @@ body {
   overflow-x: hidden;
 }
 
+.font-display {
+  font-family: var(--font-display);
+}
+
+.font-pixel {
+  font-family: var(--font-pixel);
+}
+
 /* Scrollbar */
 ::-webkit-scrollbar { width: 6px; }
 ::-webkit-scrollbar-track { background: transparent; }
@@ -150,15 +219,15 @@ body {
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 94%, white) 0%, var(--th-card-bg) 100%);
   border: 1px solid color-mix(in srgb, var(--th-card-border) 84%, var(--th-border) 16%);
-  border-radius: 0.875rem;
+  border-radius: var(--r-md);
   box-shadow:
     inset 0 1px 0 var(--th-overlay-subtle),
-    0 10px 24px rgba(0, 0, 0, 0.12);
+    var(--shadow-sm);
 }
 
 .dash-card {
   border: 1px solid var(--th-border);
-  border-radius: 1rem;
+  border-radius: var(--r-lg);
   background: var(--th-surface);
   min-width: 0;
   max-width: 100%;
@@ -170,7 +239,7 @@ body {
 }
 
 .dash-card-nested {
-  border-radius: 0.75rem;
+  border-radius: var(--r-md);
 }
 
 .dash-card-surface-muted {
@@ -187,7 +256,7 @@ body {
 }
 
 .dash-card-small {
-  border-radius: 0.5rem;
+  border-radius: var(--r-sm);
 }
 
 .dash-card-pad-standard {
@@ -225,7 +294,7 @@ body {
   justify-content: center;
   min-height: 2.75rem;
   gap: 0.5rem;
-  border-radius: 0.75rem;
+  border-radius: var(--r-md);
   border: 1px solid var(--dash-btn-border, transparent);
   background: var(--dash-btn-bg, transparent);
   color: var(--dash-btn-color, var(--th-text-secondary));
@@ -301,10 +370,10 @@ body {
   max-width: min(16rem, calc(100vw - 2rem));
   transform: translate(-50%, 0.25rem);
   border: 1px solid rgba(148, 163, 184, 0.24);
-  border-radius: 0.75rem;
+  border-radius: var(--r-md);
   background: color-mix(in srgb, var(--th-card-bg) 92%, black 8%);
   color: var(--th-text-primary);
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-md);
   opacity: 0;
   pointer-events: none;
   transition: opacity 140ms ease, transform 140ms ease;
@@ -510,12 +579,12 @@ body {
   padding: 0.65rem 0.85rem;
   border-left: 3px solid color-mix(in srgb, var(--th-accent-primary) 72%, transparent);
   background: color-mix(in srgb, var(--th-accent-primary-soft) 78%, transparent);
-  border-radius: 0 0.75rem 0.75rem 0;
+  border-radius: 0 var(--r-md) var(--r-md) 0;
   color: var(--th-text-secondary);
 }
 
 .pcd-markdown code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-family: var(--font-mono);
   font-size: 0.92em;
   padding: 0.12rem 0.38rem;
   border-radius: 0.4rem;
@@ -528,7 +597,7 @@ body {
   max-width: 100%;
   overflow-x: auto;
   padding: 0.85rem 0.95rem;
-  border-radius: 0.9rem;
+  border-radius: var(--r-md);
   background: color-mix(in srgb, var(--th-bg-primary) 92%, black 8%);
   border: 1px solid color-mix(in srgb, var(--th-border) 70%, transparent);
 }


### PR DESCRIPTION
## Summary
- port the dashboard theme foundation to `oklch` tokens while keeping legacy `--th-*` aliases
- add provider color utilities and wire them into kanban, meetings, office insights, and analytics surfaces
- add persistent topbar theme/accent controls backed by `localStorage` and `document.documentElement.dataset`

## Verification
- `npm --prefix dashboard test -- --run src/app/themePreferences.test.ts`
- `npm --prefix dashboard run build`

## Notes
- rebased `#771` onto the current `origin/main` app-shell layout (`#772`) so the topbar controls live in `dashboard/src/app/AppShell.tsx`