### PR TITLE
#765 fix: allow loopback peer for /api/send and /api/senddm without auth_token

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -154,7 +154,7 @@
 | `server::routes::escalation` | `src/server/routes/escalation.rs` | 1700 | giant-file |
 | `server::routes::github` | `src/server/routes/github.rs` | 264 |  |
 | `server::routes::github_dashboard` | `src/server/routes/github_dashboard.rs` | 188 |  |
-| `server::routes::health_api` | `src/server/routes/health_api.rs` | 293 |  |
+| `server::routes::health_api` | `src/server/routes/health_api.rs` | 303 |  |
 | `server::routes::hooks` | `src/server/routes/hooks.rs` | 123 |  |
 | `server::routes::kanban` | `src/server/routes/kanban.rs` | 3841 | giant-file |
 | `server::routes::kanban_repos` | `src/server/routes/kanban_repos.rs` | 461 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -121,9 +121,9 @@
 | `runtime_layout::legacy_migration` | `src/runtime_layout/legacy_migration.rs` | 396 |  |
 | `runtime_layout::paths` | `src/runtime_layout/paths.rs` | 134 |  |
 | `runtime_layout::skill_sync` | `src/runtime_layout/skill_sync.rs` | 685 |  |
-| `server` | `src/server/mod.rs` | 3181 | giant-file |
+| `server` | `src/server/mod.rs` | 3185 | giant-file |
 | `server::background` | `src/server/background.rs` | 535 |  |
-| `server::boot` | `src/server/boot.rs` | 152 |  |
+| `server::boot` | `src/server/boot.rs` | 153 |  |
 | `server::cron_catalog` | `src/server/cron_catalog.rs` | 71 |  |
 | `server::routes` | `src/server/routes/mod.rs` | 200 |  |
 | `server::routes::agents` | `src/server/routes/agents.rs` | 1389 | giant-file |
@@ -154,7 +154,7 @@
 | `server::routes::escalation` | `src/server/routes/escalation.rs` | 1700 | giant-file |
 | `server::routes::github` | `src/server/routes/github.rs` | 264 |  |
 | `server::routes::github_dashboard` | `src/server/routes/github_dashboard.rs` | 188 |  |
-| `server::routes::health_api` | `src/server/routes/health_api.rs` | 243 |  |
+| `server::routes::health_api` | `src/server/routes/health_api.rs` | 293 |  |
 | `server::routes::hooks` | `src/server/routes/hooks.rs` | 123 |  |
 | `server::routes::kanban` | `src/server/routes/kanban.rs` | 3841 | giant-file |
 | `server::routes::kanban_repos` | `src/server/routes/kanban_repos.rs` | 461 |  |

--- a/docs/generated/route-inventory.md
+++ b/docs/generated/route-inventory.md
@@ -165,8 +165,8 @@
 | `POST` | `/api/round-table-meetings/{id}/issues` | `meetings::create_issues` | `src/server/routes/meetings.rs:793` | `src/server/routes/domains/integrations.rs:50` |
 | `POST` | `/api/round-table-meetings/{id}/issues/discard` | `meetings::discard_issue` | `src/server/routes/meetings.rs:977` | `src/server/routes/domains/integrations.rs:54` |
 | `POST` | `/api/round-table-meetings/{id}/issues/discard-all` | `meetings::discard_all_issues` | `src/server/routes/meetings.rs:1027` | `src/server/routes/domains/integrations.rs:58` |
-| `POST` | `/api/send` | `health_api::send_handler` | `src/server/routes/health_api.rs:149` | `src/server/routes/domains/access.rs:12` |
-| `POST` | `/api/senddm` | `health_api::senddm_handler` | `src/server/routes/health_api.rs:179` | `src/server/routes/domains/access.rs:13` |
+| `POST` | `/api/send` | `health_api::send_handler` | `src/server/routes/health_api.rs:156` | `src/server/routes/domains/access.rs:12` |
+| `POST` | `/api/senddm` | `health_api::senddm_handler` | `src/server/routes/health_api.rs:189` | `src/server/routes/domains/access.rs:13` |
 | `GET` | `/api/session-termination-events` | `termination_events::list_termination_events` | `src/server/routes/termination_events.rs:23` | `src/server/routes/domains/ops.rs:99` |
 | `GET` | `/api/sessions` | `agents_crud::list_sessions` | `src/server/routes/agents_crud.rs:1022` | `src/server/routes/domains/agents.rs:33` |
 | `POST` | `/api/sessions/{session_key}/force-kill` | `dispatched_sessions::force_kill_session` | `src/server/routes/dispatched_sessions.rs:1908` | `src/server/routes/domains/ops.rs:95` |

--- a/docs/generated/route-inventory.md
+++ b/docs/generated/route-inventory.md
@@ -77,7 +77,7 @@
 | `GET` | `/api/github/repos` | `github::list_repos` | `src/server/routes/github.rs:23` | `src/server/routes/domains/integrations.rs:14` |
 | `POST` | `/api/github/repos` | `github::register_repo` | `src/server/routes/github.rs:75` | `src/server/routes/domains/integrations.rs:14` |
 | `POST` | `/api/github/repos/{owner}/{repo}/sync` | `github::sync_repo` | `src/server/routes/github.rs:138` | `src/server/routes/domains/integrations.rs:18` |
-| `GET` | `/api/health` | `health_api::health_handler` | `src/server/routes/health_api.rs:39` | `src/server/routes/domains/access.rs:11` |
+| `GET` | `/api/health` | `health_api::health_handler` | `src/server/routes/health_api.rs:47` | `src/server/routes/domains/access.rs:11` |
 | `GET` | `/api/help` | `docs::api_help` | `src/server/routes/docs.rs:1999` | `src/server/routes/domains/ops.rs:161` |
 | `DELETE` | `/api/hook/session` | `dispatched_sessions::delete_session` | `src/server/routes/dispatched_sessions.rs:829` | `src/server/routes/domains/ops.rs:79` |
 | `POST` | `/api/hook/session` | `dispatched_sessions::hook_session` | `src/server/routes/dispatched_sessions.rs:542` | `src/server/routes/domains/ops.rs:79` |
@@ -165,8 +165,8 @@
 | `POST` | `/api/round-table-meetings/{id}/issues` | `meetings::create_issues` | `src/server/routes/meetings.rs:793` | `src/server/routes/domains/integrations.rs:50` |
 | `POST` | `/api/round-table-meetings/{id}/issues/discard` | `meetings::discard_issue` | `src/server/routes/meetings.rs:977` | `src/server/routes/domains/integrations.rs:54` |
 | `POST` | `/api/round-table-meetings/{id}/issues/discard-all` | `meetings::discard_all_issues` | `src/server/routes/meetings.rs:1027` | `src/server/routes/domains/integrations.rs:58` |
-| `POST` | `/api/send` | `health_api::send_handler` | `src/server/routes/health_api.rs:141` | `src/server/routes/domains/access.rs:12` |
-| `POST` | `/api/senddm` | `health_api::senddm_handler` | `src/server/routes/health_api.rs:167` | `src/server/routes/domains/access.rs:13` |
+| `POST` | `/api/send` | `health_api::send_handler` | `src/server/routes/health_api.rs:149` | `src/server/routes/domains/access.rs:12` |
+| `POST` | `/api/senddm` | `health_api::senddm_handler` | `src/server/routes/health_api.rs:179` | `src/server/routes/domains/access.rs:13` |
 | `GET` | `/api/session-termination-events` | `termination_events::list_termination_events` | `src/server/routes/termination_events.rs:23` | `src/server/routes/domains/ops.rs:99` |
 | `GET` | `/api/sessions` | `agents_crud::list_sessions` | `src/server/routes/agents_crud.rs:1022` | `src/server/routes/domains/agents.rs:33` |
 | `POST` | `/api/sessions/{session_key}/force-kill` | `dispatched_sessions::force_kill_session` | `src/server/routes/dispatched_sessions.rs:1908` | `src/server/routes/domains/ops.rs:95` |

--- a/src/server/boot.rs
+++ b/src/server/boot.rs
@@ -50,7 +50,8 @@ pub(super) async fn serve_http(
     let addr = format!("{}:{}", config.server.host, config.server.port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     tracing::info!("HTTP server listening on {addr}");
-    axum::serve(listener, app).await?;
+    axum::serve(listener, app.into_make_service_with_connect_info::<std::net::SocketAddr>())
+        .await?;
     Ok(())
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -446,7 +446,11 @@ pub async fn run(
     let addr = format!("{}:{}", config.server.host, config.server.port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     tracing::info!("HTTP server listening on {addr}");
-    axum::serve(listener, app).await?;
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .await?;
     Ok(())
 }
 

--- a/src/server/routes/health_api.rs
+++ b/src/server/routes/health_api.rs
@@ -146,6 +146,13 @@ pub async fn health_handler(State(state): State<AppState>) -> Response {
 }
 
 /// POST /api/send — agent-to-agent native routing.
+///
+/// Requires `ConnectInfo<SocketAddr>` injected by the server bootstrap
+/// (see `boot.rs::run_with_state` and `mod.rs::launch_*` which both call
+/// `into_make_service_with_connect_info::<SocketAddr>`). The
+/// `discord_control_endpoints_allowed` helper supports `peer_addr: None`
+/// for internal callers / unit tests where the connection info isn't
+/// available; in production HTTP traffic the extractor is always present.
 pub async fn send_handler(
     State(state): State<AppState>,
     ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
@@ -176,6 +183,9 @@ pub async fn send_handler(
 }
 
 /// POST /api/senddm — send a DM to a Discord user.
+///
+/// See `send_handler` for the rationale on the mandatory
+/// `ConnectInfo<SocketAddr>` extractor.
 pub async fn senddm_handler(
     State(state): State<AppState>,
     ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,

--- a/src/server/routes/health_api.rs
+++ b/src/server/routes/health_api.rs
@@ -1,10 +1,11 @@
 use axum::{
     Json,
     body::Bytes,
-    extract::State,
+    extract::{ConnectInfo, State},
     http::StatusCode,
     response::{IntoResponse, Response},
 };
+use std::net::SocketAddr;
 
 use crate::services::discord::health;
 
@@ -19,7 +20,10 @@ struct DispatchOutboxStats {
     oldest_pending_age: i64,
 }
 
-fn discord_control_endpoints_allowed(config: &crate::config::Config) -> bool {
+fn discord_control_endpoints_allowed(
+    config: &crate::config::Config,
+    peer_addr: Option<SocketAddr>,
+) -> bool {
     if config
         .server
         .auth_token
@@ -27,6 +31,10 @@ fn discord_control_endpoints_allowed(config: &crate::config::Config) -> bool {
         .map(str::trim)
         .is_some_and(|token| !token.is_empty())
     {
+        return true;
+    }
+
+    if peer_addr.is_some_and(|addr| addr.ip().is_loopback()) {
         return true;
     }
 
@@ -138,8 +146,12 @@ pub async fn health_handler(State(state): State<AppState>) -> Response {
 }
 
 /// POST /api/send — agent-to-agent native routing.
-pub async fn send_handler(State(state): State<AppState>, body: Bytes) -> Response {
-    if !discord_control_endpoints_allowed(&state.config) {
+pub async fn send_handler(
+    State(state): State<AppState>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    body: Bytes,
+) -> Response {
+    if !discord_control_endpoints_allowed(&state.config, Some(peer_addr)) {
         return (
             StatusCode::FORBIDDEN,
             Json(serde_json::json!({"ok": false, "error": "auth_token required for non-loopback host"})),
@@ -164,8 +176,12 @@ pub async fn send_handler(State(state): State<AppState>, body: Bytes) -> Respons
 }
 
 /// POST /api/senddm — send a DM to a Discord user.
-pub async fn senddm_handler(State(state): State<AppState>, body: Bytes) -> Response {
-    if !discord_control_endpoints_allowed(&state.config) {
+pub async fn senddm_handler(
+    State(state): State<AppState>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    body: Bytes,
+) -> Response {
+    if !discord_control_endpoints_allowed(&state.config, Some(peer_addr)) {
         return (
             StatusCode::FORBIDDEN,
             Json(serde_json::json!({"ok": false, "error": "auth_token required for non-loopback host"})),
@@ -187,6 +203,40 @@ pub async fn senddm_handler(State(state): State<AppState>, body: Bytes) -> Respo
     let json: serde_json::Value =
         serde_json::from_str(&response_body).unwrap_or(serde_json::json!({"error": "internal"}));
     (status, Json(json)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::discord_control_endpoints_allowed;
+
+    #[test]
+    fn discord_control_endpoints_allow_loopback_peer_without_auth_token() {
+        let mut config = crate::config::Config::default();
+        config.server.host = "0.0.0.0".to_string();
+        config.server.auth_token = Some(String::new());
+
+        assert!(discord_control_endpoints_allowed(
+            &config,
+            Some("127.0.0.1:8791".parse().unwrap())
+        ));
+        assert!(discord_control_endpoints_allowed(
+            &config,
+            Some("[::1]:8791".parse().unwrap())
+        ));
+    }
+
+    #[test]
+    fn discord_control_endpoints_reject_non_loopback_without_auth_token() {
+        let mut config = crate::config::Config::default();
+        config.server.host = "0.0.0.0".to_string();
+        config.server.auth_token = Some(String::new());
+
+        assert!(!discord_control_endpoints_allowed(
+            &config,
+            Some("10.0.0.5:8791".parse().unwrap())
+        ));
+        assert!(!discord_control_endpoints_allowed(&config, None));
+    }
 }
 
 fn parse_status_code(s: &str) -> StatusCode {

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -501,16 +501,16 @@ async fn discord_control_endpoints_require_auth_token_on_non_loopback_host() {
     config.server.host = "0.0.0.0".to_string();
     let app = test_api_router_with_config(db, engine, config, None);
 
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/send")
-                .body(Body::from("{}"))
-                .unwrap(),
-        )
-        .await
+    let mut request = Request::builder()
+        .method("POST")
+        .uri("/send")
+        .body(Body::from("{}"))
         .unwrap();
+    request.extensions_mut().insert(axum::extract::ConnectInfo(
+        "10.0.0.5:8791".parse::<std::net::SocketAddr>().unwrap(),
+    ));
+
+    let response = app.oneshot(request).await.unwrap();
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
@@ -523,16 +523,16 @@ async fn discord_control_endpoints_allow_loopback_without_auth_token() {
     config.server.host = "127.0.0.1".to_string();
     let app = test_api_router_with_config(db, engine, config, None);
 
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/send")
-                .body(Body::from("{}"))
-                .unwrap(),
-        )
-        .await
+    let mut request = Request::builder()
+        .method("POST")
+        .uri("/send")
+        .body(Body::from("{}"))
         .unwrap();
+    request.extensions_mut().insert(axum::extract::ConnectInfo(
+        "127.0.0.1:8791".parse::<std::net::SocketAddr>().unwrap(),
+    ));
+
+    let response = app.oneshot(request).await.unwrap();
 
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
 }


### PR DESCRIPTION
## Summary
- `discord_control_endpoints_allowed()` previously only inspected `config.server.host`, so a server bound to `0.0.0.0` with no `auth_token` rejected loopback (127.0.0.1) clients with `auth_token required for non-loopback host`.
- Now inspects the actual peer connection address (`ConnectInfo<SocketAddr>`): loopback peers are allowed even when bind is not a loopback alias. Bind-address check remains as fallback.
- Eliminates the friction logged in api-friction marker (`/api/send` workaround via direct Discord bot API).

Closes #765.

## Changes
- `src/server/routes/health_api.rs` — both `send_handler` and `senddm_handler` now extract `ConnectInfo` and pass to `discord_control_endpoints_allowed(&config, peer_addr)`. Added unit tests for loopback-allow and non-loopback-reject cases.
- `src/server/mod.rs` + `src/server/boot.rs` — wire `ConnectInfo` extractor into the router.
- `src/server/routes/routes_tests.rs` — minor test signature updates.

## Test plan
- [x] `cargo build --bin agentdesk` clean.
- [x] `cargo test --bin agentdesk discord_control` 4 passed.
- [ ] After release promote, verify `agentdesk api POST /api/send '{"target":"channel:...", "content":"...", "source":"project-agentdesk", "bot":"announce"}'` succeeds from local CLI without falling back.