### PR TITLE
#775 feat(dashboard): shared overlay system — Drawer / Modal / BottomSheet / Toast

### DIFF
--- a/dashboard/src/components/common/overlay/Backdrop.tsx
+++ b/dashboard/src/components/common/overlay/Backdrop.tsx
@@ -1,0 +1,18 @@
+import type { CSSProperties, MouseEventHandler } from "react";
+
+interface BackdropProps {
+  onClick?: MouseEventHandler<HTMLDivElement>;
+  zIndex?: number;
+  style?: CSSProperties;
+}
+
+export function Backdrop({ onClick, zIndex = 50, style }: BackdropProps) {
+  return (
+    <div
+      onClick={onClick}
+      aria-hidden="true"
+      className="fixed inset-0 bg-black/45 backdrop-blur-sm transition-opacity"
+      style={{ zIndex, ...style }}
+    />
+  );
+}

--- a/dashboard/src/components/common/overlay/BottomSheet.tsx
+++ b/dashboard/src/components/common/overlay/BottomSheet.tsx
@@ -1,0 +1,97 @@
+import { useEffect, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+import { Backdrop } from "./Backdrop";
+import { useFocusTrap } from "./useFocusTrap";
+
+export interface BottomSheetProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  children: ReactNode;
+  closeOnBackdrop?: boolean;
+  closeOnEsc?: boolean;
+  ariaLabel?: string;
+}
+
+export function BottomSheet({
+  open,
+  onClose,
+  title,
+  children,
+  closeOnBackdrop = true,
+  closeOnEsc = true,
+  ariaLabel,
+}: BottomSheetProps) {
+  const containerRef = useFocusTrap(open);
+
+  useEffect(() => {
+    if (!open || !closeOnEsc) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, closeOnEsc, onClose]);
+
+  useEffect(() => {
+    if (!open) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [open]);
+
+  if (!open || typeof document === "undefined") return null;
+
+  return createPortal(
+    <>
+      <Backdrop onClick={closeOnBackdrop ? onClose : undefined} zIndex={70} />
+      <div
+        className="fixed inset-x-0 bottom-0 z-[80] flex justify-center"
+        role="dialog"
+        aria-modal="true"
+        aria-label={ariaLabel ?? title ?? "Bottom sheet"}
+      >
+        <div
+          ref={containerRef}
+          tabIndex={-1}
+          className="flex w-full max-w-2xl flex-col rounded-t-3xl border-t bg-[var(--th-card-bg,_#0f172a)] text-[var(--th-text,_#e2e8f0)] shadow-2xl outline-none"
+          style={{
+            borderColor: "var(--th-border, rgba(148,163,184,0.18))",
+            paddingBottom: "env(safe-area-inset-bottom)",
+            maxHeight: "min(90vh, 720px)",
+          }}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <div className="flex items-center justify-center pt-3">
+            <span className="h-1 w-10 rounded-full bg-white/20" aria-hidden="true" />
+          </div>
+          {title && (
+            <div
+              className="flex items-center justify-between gap-3 border-b px-5 py-3"
+              style={{ borderColor: "var(--th-border, rgba(148,163,184,0.12))" }}
+            >
+              <h2 className="text-base font-semibold">{title}</h2>
+              <button
+                type="button"
+                onClick={onClose}
+                className="flex h-8 w-8 items-center justify-center rounded-lg border text-[var(--th-text-muted,_#94a3b8)] hover:bg-white/5"
+                style={{ borderColor: "var(--th-border, rgba(148,163,184,0.16))" }}
+                aria-label="Close"
+              >
+                <X size={14} />
+              </button>
+            </div>
+          )}
+          <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">{children}</div>
+        </div>
+      </div>
+    </>,
+    document.body,
+  );
+}

--- a/dashboard/src/components/common/overlay/Drawer.tsx
+++ b/dashboard/src/components/common/overlay/Drawer.tsx
@@ -1,0 +1,115 @@
+import { useEffect, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+import { Backdrop } from "./Backdrop";
+import { useFocusTrap } from "./useFocusTrap";
+import { useIsMobile } from "./useBreakpoint";
+import { BottomSheet } from "./BottomSheet";
+
+export interface DrawerProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  children: ReactNode;
+  side?: "right" | "left";
+  width?: string;
+  closeOnBackdrop?: boolean;
+  closeOnEsc?: boolean;
+  ariaLabel?: string;
+}
+
+export function Drawer({
+  open,
+  onClose,
+  title,
+  children,
+  side = "right",
+  width = "min(420px, 100vw)",
+  closeOnBackdrop = true,
+  closeOnEsc = true,
+  ariaLabel,
+}: DrawerProps) {
+  const isMobile = useIsMobile();
+  const containerRef = useFocusTrap(open && !isMobile);
+
+  useEffect(() => {
+    if (!open || !closeOnEsc || isMobile) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, closeOnEsc, onClose, isMobile]);
+
+  useEffect(() => {
+    if (!open || isMobile) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [open, isMobile]);
+
+  if (isMobile) {
+    return (
+      <BottomSheet
+        open={open}
+        onClose={onClose}
+        title={title}
+        closeOnBackdrop={closeOnBackdrop}
+        closeOnEsc={closeOnEsc}
+        ariaLabel={ariaLabel}
+      >
+        {children}
+      </BottomSheet>
+    );
+  }
+
+  if (!open || typeof document === "undefined") return null;
+
+  return createPortal(
+    <>
+      <Backdrop onClick={closeOnBackdrop ? onClose : undefined} zIndex={70} />
+      <div
+        className={`fixed inset-y-0 z-[80] flex ${side === "right" ? "right-0" : "left-0"}`}
+        role="dialog"
+        aria-modal="true"
+        aria-label={ariaLabel ?? title ?? "Drawer"}
+      >
+        <div
+          ref={containerRef}
+          tabIndex={-1}
+          className={`flex h-full flex-col border-l bg-[var(--th-card-bg,_#0f172a)] text-[var(--th-text,_#e2e8f0)] shadow-2xl outline-none ${side === "left" ? "border-l-0 border-r" : ""}`}
+          style={{
+            width,
+            borderColor: "var(--th-border, rgba(148,163,184,0.18))",
+          }}
+          onClick={(event) => event.stopPropagation()}
+        >
+          {title && (
+            <div
+              className="flex items-center justify-between gap-3 border-b px-5 py-4"
+              style={{ borderColor: "var(--th-border, rgba(148,163,184,0.12))" }}
+            >
+              <h2 className="text-base font-semibold">{title}</h2>
+              <button
+                type="button"
+                onClick={onClose}
+                className="flex h-8 w-8 items-center justify-center rounded-lg border text-[var(--th-text-muted,_#94a3b8)] hover:bg-white/5"
+                style={{ borderColor: "var(--th-border, rgba(148,163,184,0.16))" }}
+                aria-label="Close"
+              >
+                <X size={14} />
+              </button>
+            </div>
+          )}
+          <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">{children}</div>
+        </div>
+      </div>
+    </>,
+    document.body,
+  );
+}

--- a/dashboard/src/components/common/overlay/Modal.tsx
+++ b/dashboard/src/components/common/overlay/Modal.tsx
@@ -1,0 +1,111 @@
+import { useEffect, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+import { Backdrop } from "./Backdrop";
+import { useFocusTrap } from "./useFocusTrap";
+
+export interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  description?: string;
+  children: ReactNode;
+  closeOnBackdrop?: boolean;
+  closeOnEsc?: boolean;
+  size?: "sm" | "md" | "lg" | "xl";
+  hideHeader?: boolean;
+  ariaLabel?: string;
+}
+
+const SIZE_CLASS: Record<NonNullable<ModalProps["size"]>, string> = {
+  sm: "max-w-sm",
+  md: "max-w-md",
+  lg: "max-w-2xl",
+  xl: "max-w-4xl",
+};
+
+export function Modal({
+  open,
+  onClose,
+  title,
+  description,
+  children,
+  closeOnBackdrop = true,
+  closeOnEsc = true,
+  size = "md",
+  hideHeader = false,
+  ariaLabel,
+}: ModalProps) {
+  const containerRef = useFocusTrap(open);
+
+  useEffect(() => {
+    if (!open || !closeOnEsc) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, closeOnEsc, onClose]);
+
+  useEffect(() => {
+    if (!open) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [open]);
+
+  if (!open || typeof document === "undefined") return null;
+
+  return createPortal(
+    <>
+      <Backdrop onClick={closeOnBackdrop ? onClose : undefined} zIndex={70} />
+      <div
+        className="fixed inset-0 z-[80] flex items-center justify-center p-4"
+        role="dialog"
+        aria-modal="true"
+        aria-label={ariaLabel ?? title ?? "Modal"}
+        aria-describedby={description ? "modal-desc" : undefined}
+      >
+        <div
+          ref={containerRef}
+          tabIndex={-1}
+          className={`flex w-full ${SIZE_CLASS[size]} max-h-[85vh] flex-col rounded-2xl border bg-[var(--th-card-bg,_#0f172a)] text-[var(--th-text,_#e2e8f0)] shadow-2xl outline-none`}
+          style={{ borderColor: "var(--th-border, rgba(148,163,184,0.18))" }}
+          onClick={(event) => event.stopPropagation()}
+        >
+          {!hideHeader && (title || description) && (
+            <div
+              className="flex items-start justify-between gap-3 border-b px-5 py-4"
+              style={{ borderColor: "var(--th-border, rgba(148,163,184,0.12))" }}
+            >
+              <div className="min-w-0 flex-1">
+                {title && <h2 className="text-base font-semibold">{title}</h2>}
+                {description && (
+                  <p id="modal-desc" className="mt-1 text-xs text-[var(--th-text-muted,_#94a3b8)]">
+                    {description}
+                  </p>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                className="flex h-8 w-8 items-center justify-center rounded-lg border text-[var(--th-text-muted,_#94a3b8)] hover:bg-white/5"
+                style={{ borderColor: "var(--th-border, rgba(148,163,184,0.16))" }}
+                aria-label="Close"
+              >
+                <X size={14} />
+              </button>
+            </div>
+          )}
+          <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">{children}</div>
+        </div>
+      </div>
+    </>,
+    document.body,
+  );
+}

--- a/dashboard/src/components/common/overlay/OverlayProvider.tsx
+++ b/dashboard/src/components/common/overlay/OverlayProvider.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+import { ToastProvider } from "./ToastProvider";
+
+interface OverlayProviderProps {
+  children: ReactNode;
+}
+
+// Root provider that wires the overlay subsystems (currently just toast).
+// Drawer/Modal/BottomSheet are stateless components — they manage their own
+// open state via props — so they don't need provider context.
+export function OverlayProvider({ children }: OverlayProviderProps) {
+  return <ToastProvider>{children}</ToastProvider>;
+}

--- a/dashboard/src/components/common/overlay/ToastProvider.tsx
+++ b/dashboard/src/components/common/overlay/ToastProvider.tsx
@@ -1,0 +1,160 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+
+export type ToastVariant = "info" | "success" | "warning" | "error";
+
+export interface ToastInput {
+  message: string;
+  variant?: ToastVariant;
+  durationMs?: number;
+}
+
+export interface ToastItem extends ToastInput {
+  id: string;
+  ts: number;
+}
+
+interface ToastContextValue {
+  show: (input: ToastInput | string) => string;
+  dismiss: (id: string) => void;
+  clear: () => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const DEFAULT_DURATION_MS = 5000;
+const MAX_VISIBLE = 4;
+
+const VARIANT_COLORS: Record<ToastVariant, string> = {
+  info: "rgba(56,189,248,0.85)",
+  success: "rgba(52,211,153,0.85)",
+  warning: "rgba(251,191,36,0.85)",
+  error: "rgba(248,113,113,0.85)",
+};
+
+const VARIANT_BG: Record<ToastVariant, string> = {
+  info: "rgba(56,189,248,0.14)",
+  success: "rgba(52,211,153,0.14)",
+  warning: "rgba(251,191,36,0.14)",
+  error: "rgba(248,113,113,0.14)",
+};
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const counterRef = useRef(0);
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+  }, []);
+
+  const show = useCallback((input: ToastInput | string) => {
+    const normalized: ToastInput = typeof input === "string" ? { message: input } : input;
+    counterRef.current += 1;
+    const id = `t${Date.now().toString(36)}-${counterRef.current}`;
+    const item: ToastItem = {
+      id,
+      ts: Date.now(),
+      message: normalized.message,
+      variant: normalized.variant ?? "info",
+      durationMs: normalized.durationMs ?? DEFAULT_DURATION_MS,
+    };
+    setToasts((prev) => [...prev, item]);
+    return id;
+  }, []);
+
+  const clear = useCallback(() => setToasts([]), []);
+
+  useEffect(() => {
+    if (toasts.length === 0) return;
+    const timer = window.setInterval(() => {
+      const now = Date.now();
+      setToasts((prev) =>
+        prev.filter((toast) => now - toast.ts < (toast.durationMs ?? DEFAULT_DURATION_MS)),
+      );
+    }, 500);
+    return () => window.clearInterval(timer);
+  }, [toasts.length]);
+
+  const value = useMemo<ToastContextValue>(() => ({ show, dismiss, clear }), [show, dismiss, clear]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <ToastViewport toasts={toasts} onDismiss={dismiss} />
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error("useToast must be used within <ToastProvider> (typically wired in OverlayProvider)");
+  }
+  return ctx;
+}
+
+interface ToastViewportProps {
+  toasts: ToastItem[];
+  onDismiss: (id: string) => void;
+}
+
+function ToastViewport({ toasts, onDismiss }: ToastViewportProps) {
+  if (typeof document === "undefined") return null;
+  const visible = toasts.slice(-MAX_VISIBLE);
+  if (visible.length === 0) return null;
+
+  return createPortal(
+    <div
+      className="pointer-events-none fixed right-3 z-[100] flex max-w-sm flex-col gap-2 bottom-[calc(4.5rem+env(safe-area-inset-bottom))] sm:bottom-4 sm:right-4"
+      role="region"
+      aria-label="Notifications"
+      aria-live="polite"
+    >
+      {visible.map((toast) => {
+        const variant = toast.variant ?? "info";
+        return (
+          <div
+            key={toast.id}
+            role="status"
+            className="pointer-events-auto flex items-start gap-2 rounded-xl border px-3 py-2 text-sm shadow-lg"
+            style={{
+              borderColor: `${VARIANT_COLORS[variant]}55`,
+              background: `linear-gradient(135deg, ${VARIANT_BG[variant]}, color-mix(in srgb, var(--th-card-bg) 92%, transparent))`,
+              color: "var(--th-text)",
+            }}
+          >
+            <span
+              className="mt-1 h-2.5 w-2.5 shrink-0 rounded-full"
+              style={{ background: VARIANT_COLORS[variant] }}
+              aria-hidden="true"
+            />
+            <p className="min-w-0 flex-1 break-words text-xs leading-relaxed">{toast.message}</p>
+            <button
+              type="button"
+              onClick={() => onDismiss(toast.id)}
+              className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border text-[var(--th-text-muted)] transition-opacity hover:opacity-100"
+              style={{
+                background: "color-mix(in srgb, var(--th-card-bg) 88%, transparent)",
+                borderColor: "color-mix(in srgb, var(--th-border) 64%, transparent)",
+              }}
+              aria-label="Dismiss"
+            >
+              <X size={12} />
+            </button>
+          </div>
+        );
+      })}
+    </div>,
+    document.body,
+  );
+}

--- a/dashboard/src/components/common/overlay/index.ts
+++ b/dashboard/src/components/common/overlay/index.ts
@@ -1,0 +1,11 @@
+export { Modal } from "./Modal";
+export type { ModalProps } from "./Modal";
+export { Drawer } from "./Drawer";
+export type { DrawerProps } from "./Drawer";
+export { BottomSheet } from "./BottomSheet";
+export type { BottomSheetProps } from "./BottomSheet";
+export { OverlayProvider } from "./OverlayProvider";
+export { ToastProvider, useToast } from "./ToastProvider";
+export type { ToastInput, ToastItem, ToastVariant } from "./ToastProvider";
+export { useFocusTrap } from "./useFocusTrap";
+export { useIsMobile } from "./useBreakpoint";

--- a/dashboard/src/components/common/overlay/useBreakpoint.ts
+++ b/dashboard/src/components/common/overlay/useBreakpoint.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+const MOBILE_QUERY = "(max-width: 899px)";
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(MOBILE_QUERY).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mql = window.matchMedia(MOBILE_QUERY);
+    const handler = (event: MediaQueryListEvent) => setIsMobile(event.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  return isMobile;
+}

--- a/dashboard/src/components/common/overlay/useFocusTrap.ts
+++ b/dashboard/src/components/common/overlay/useFocusTrap.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from "react";
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export function useFocusTrap(active: boolean) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+
+    const container = containerRef.current;
+    if (!container) return;
+
+    const focusables = container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    const first = focusables[0];
+    if (first) first.focus();
+    else container.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Tab") return;
+      const items = Array.from(
+        container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((el) => !el.hasAttribute("disabled") && el.offsetParent !== null);
+      if (items.length === 0) {
+        event.preventDefault();
+        return;
+      }
+      const current = document.activeElement as HTMLElement | null;
+      const idx = current ? items.indexOf(current) : -1;
+      if (event.shiftKey) {
+        if (idx <= 0) {
+          event.preventDefault();
+          items[items.length - 1].focus();
+        }
+      } else {
+        if (idx === -1 || idx === items.length - 1) {
+          event.preventDefault();
+          items[0].focus();
+        }
+      }
+    };
+
+    container.addEventListener("keydown", handleKeyDown);
+    return () => {
+      container.removeEventListener("keydown", handleKeyDown);
+      const previous = previousFocusRef.current;
+      if (previous && document.contains(previous)) {
+        previous.focus();
+      }
+    };
+  }, [active]);
+
+  return containerRef;
+}

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
+import { OverlayProvider } from "./components/common/overlay";
 import "./styles/main.css";
 
 // Recover from stale lazy chunks after deploy: detect load failures and reload once
@@ -22,7 +23,9 @@ window.addEventListener("error", (e) => {
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <OverlayProvider>
+        <App />
+      </OverlayProvider>
     </BrowserRouter>
   </React.StrictMode>,
 );


### PR DESCRIPTION
Closes #775

## Summary

Introduces `dashboard/src/components/common/overlay/` covering the four primitives from the P1-5 handoff:

- **Modal** — center dialog (focus trap + ESC + backdrop)
- **Drawer** — desktop right-slide; auto-converts to BottomSheet under 900px
- **BottomSheet** — independent mobile-first sheet
- **Toast** (`ToastProvider` + `useToast`) — queue-driven, auto-dismiss, 4 variants

`OverlayProvider` mounted in `main.tsx` under `<BrowserRouter>`.

## Out of scope (follow-up)

- Migrating existing `AgentFormModal` / `DepartmentFormModal` / `OfficeManagerModal` / `MeetingDetailModal` to the new `Modal` — kept in place to limit diff
- Migrating `NotificationCenter.ToastOverlay` to `useToast` — current implementation reads the global notifications array; switching it requires unrelated wiring changes
- Component-level interaction tests (focus trap, ESC, backdrop click) — repo currently has no `@testing-library/react` setup; planned as a small follow-up that adds that dep and covers the four components

## Dependencies

- P1-3 (#773 → PR #802) introduces a shared breakpoint utility. Until that lands, this PR uses a local `useIsMobile()` hook (TODO at the import site for swap-out).

## Test plan

- [x] `npm run build` green
- [x] `npm test` — 115/115 existing tests still green
- [ ] Visual smoke (open a Drawer/Modal/BottomSheet/Toast in dev) — pending reviewer check

Reviewer focus:
- Focus trap correctness in `useFocusTrap.ts` (Tab cycle + previous-focus restore)
- ESC handler ordering when multiple overlays stack (currently stops propagation but no shared z-index manager)