### PR TITLE
#766 fix: align PostgreSQL pr_tracking reseed with single-tx cancel/update semantics

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -71,7 +71,7 @@
 | `db::session_agent_resolution` | `src/db/session_agent_resolution.rs` | 262 |  |
 | `db::session_transcripts` | `src/db/session_transcripts.rs` | 1130 | giant-file |
 | `db::turns` | `src/db/turns.rs` | 451 |  |
-| `dispatch` | `src/dispatch/mod.rs` | 4628 | giant-file |
+| `dispatch` | `src/dispatch/mod.rs` | 4642 | giant-file |
 | `dispatch::dispatch_channel` | `src/dispatch/dispatch_channel.rs` | 23 |  |
 | `dispatch::dispatch_context` | `src/dispatch/dispatch_context.rs` | 1926 | giant-file |
 | `dispatch::dispatch_create` | `src/dispatch/dispatch_create.rs` | 719 |  |
@@ -97,7 +97,7 @@
 | `engine::ops::message_ops` | `src/engine/ops/message_ops.rs` | 275 |  |
 | `engine::ops::pipeline_ops` | `src/engine/ops/pipeline_ops.rs` | 206 |  |
 | `engine::ops::queue_ops` | `src/engine/ops/queue_ops.rs` | 105 |  |
-| `engine::ops::review_automation_ops` | `src/engine/ops/review_automation_ops.rs` | 1389 | giant-file |
+| `engine::ops::review_automation_ops` | `src/engine/ops/review_automation_ops.rs` | 1559 | giant-file |
 | `engine::ops::review_ops` | `src/engine/ops/review_ops.rs` | 338 |  |
 | `engine::ops::runtime_ops` | `src/engine/ops/runtime_ops.rs` | 106 |  |
 | `engine::sql_guard` | `src/engine/sql_guard.rs` | 230 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -97,7 +97,7 @@
 | `engine::ops::message_ops` | `src/engine/ops/message_ops.rs` | 275 |  |
 | `engine::ops::pipeline_ops` | `src/engine/ops/pipeline_ops.rs` | 206 |  |
 | `engine::ops::queue_ops` | `src/engine/ops/queue_ops.rs` | 105 |  |
-| `engine::ops::review_automation_ops` | `src/engine/ops/review_automation_ops.rs` | 1559 | giant-file |
+| `engine::ops::review_automation_ops` | `src/engine/ops/review_automation_ops.rs` | 1628 | giant-file |
 | `engine::ops::review_ops` | `src/engine/ops/review_ops.rs` | 338 |  |
 | `engine::ops::runtime_ops` | `src/engine/ops/runtime_ops.rs` | 106 |  |
 | `engine::sql_guard` | `src/engine/sql_guard.rs` | 230 |  |

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -137,11 +137,38 @@ pub async fn cancel_dispatch_and_reset_auto_queue_on_pg(
     dispatch_id: &str,
     reason: Option<&str>,
 ) -> Result<usize, String> {
-    let cancel_payload = reason.map(|value| json!({ "reason": value }));
     let mut tx = pool
         .begin()
         .await
         .map_err(|error| format!("begin postgres dispatch cancel transaction: {error}"))?;
+
+    // On error the Transaction's Drop runs an implicit rollback, so any
+    // partial writes from the helper are discarded automatically.
+    let changed =
+        cancel_dispatch_and_reset_auto_queue_on_pg_tx(&mut tx, dispatch_id, reason).await?;
+
+    tx.commit()
+        .await
+        .map_err(|error| format!("commit postgres dispatch cancel {dispatch_id}: {error}"))?;
+
+    Ok(changed)
+}
+
+/// Cancel a live dispatch and reset linked auto-queue entries inside a caller-owned
+/// PostgreSQL transaction.
+///
+/// Mirrors `cancel_dispatch_and_reset_auto_queue_on_pg` semantics (stale guard on
+/// `pending`/`dispatched`, dispatch_events insert, status_reaction outbox,
+/// auto_queue_entries reset to `pending`) but does not begin or commit the
+/// transaction. The caller composes this into a wider atomic operation. On
+/// stale-guard / missing-row paths this returns `Ok(0)` without writing — the
+/// caller decides whether to commit or rollback the surrounding work.
+pub async fn cancel_dispatch_and_reset_auto_queue_on_pg_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    dispatch_id: &str,
+    reason: Option<&str>,
+) -> Result<usize, String> {
+    let cancel_payload = reason.map(|value| json!({ "reason": value }));
 
     let current = sqlx::query(
         "SELECT status, kanban_card_id, dispatch_type
@@ -149,13 +176,10 @@ pub async fn cancel_dispatch_and_reset_auto_queue_on_pg(
          WHERE id = $1",
     )
     .bind(dispatch_id)
-    .fetch_optional(&mut *tx)
+    .fetch_optional(&mut **tx)
     .await
     .map_err(|error| format!("load postgres dispatch {dispatch_id}: {error}"))?;
     let Some(current) = current else {
-        tx.rollback().await.map_err(|error| {
-            format!("rollback missing postgres dispatch {dispatch_id}: {error}")
-        })?;
         return Ok(0);
     };
 
@@ -165,9 +189,6 @@ pub async fn cancel_dispatch_and_reset_auto_queue_on_pg(
         .flatten()
         .unwrap_or_default();
     if !matches!(current_status.as_str(), "pending" | "dispatched") {
-        tx.rollback()
-            .await
-            .map_err(|error| format!("rollback postgres dispatch {dispatch_id}: {error}"))?;
         return Ok(0);
     }
 
@@ -183,7 +204,7 @@ pub async fn cancel_dispatch_and_reset_auto_queue_on_pg(
         .bind(payload.to_string())
         .bind(dispatch_id)
         .bind(&current_status)
-        .execute(&mut *tx)
+        .execute(&mut **tx)
         .await
         .map_err(|error| format!("cancel postgres dispatch {dispatch_id}: {error}"))?
         .rows_affected() as usize,
@@ -196,16 +217,13 @@ pub async fn cancel_dispatch_and_reset_auto_queue_on_pg(
         )
         .bind(dispatch_id)
         .bind(&current_status)
-        .execute(&mut *tx)
+        .execute(&mut **tx)
         .await
         .map_err(|error| format!("cancel postgres dispatch {dispatch_id}: {error}"))?
         .rows_affected() as usize,
     };
 
     if changed == 0 {
-        tx.rollback().await.map_err(|error| {
-            format!("rollback unchanged postgres dispatch {dispatch_id}: {error}")
-        })?;
         return Ok(0);
     }
 
@@ -235,7 +253,7 @@ pub async fn cancel_dispatch_and_reset_auto_queue_on_pg(
     )
     .bind(&current_status)
     .bind(cancel_payload.clone())
-    .execute(&mut *tx)
+    .execute(&mut **tx)
     .await;
 
     let _ = sqlx::query(
@@ -250,7 +268,7 @@ pub async fn cancel_dispatch_and_reset_auto_queue_on_pg(
          )",
     )
     .bind(dispatch_id)
-    .execute(&mut *tx)
+    .execute(&mut **tx)
     .await;
 
     let entry_rows = sqlx::query(
@@ -260,7 +278,7 @@ pub async fn cancel_dispatch_and_reset_auto_queue_on_pg(
            AND status IN ('pending', 'dispatched')",
     )
     .bind(dispatch_id)
-    .fetch_all(&mut *tx)
+    .fetch_all(&mut **tx)
     .await
     .map_err(|error| format!("load postgres queue entries for dispatch {dispatch_id}: {error}"))?;
 
@@ -283,7 +301,7 @@ pub async fn cancel_dispatch_and_reset_auto_queue_on_pg(
         )
         .bind(&entry_id)
         .bind(&from_status)
-        .execute(&mut *tx)
+        .execute(&mut **tx)
         .await
         .map_err(|error| format!("reset postgres queue entry {entry_id}: {error}"))?
         .rows_affected() as usize;
@@ -298,14 +316,10 @@ pub async fn cancel_dispatch_and_reset_auto_queue_on_pg(
             )
             .bind(&entry_id)
             .bind(&from_status)
-            .execute(&mut *tx)
+            .execute(&mut **tx)
             .await;
         }
     }
-
-    tx.commit()
-        .await
-        .map_err(|error| format!("commit postgres dispatch cancel {dispatch_id}: {error}"))?;
 
     Ok(changed)
 }

--- a/src/engine/ops/review_automation_ops.rs
+++ b/src/engine/ops/review_automation_ops.rs
@@ -758,6 +758,15 @@ fn reseed_pr_tracking_raw(db: &Db, pg_pool: Option<&PgPool>, card_id: &str) -> S
 }
 
 async fn reseed_pr_tracking_pg(pool: &PgPool, card_id: &str) -> Result<serde_json::Value, String> {
+    // Run cancel/reset + pr_tracking generation/head/review_round update in a
+    // single transaction so a crash mid-flight cannot leave the dispatch
+    // cancelled while pr_tracking still points at the previous generation.
+    // This matches the SQLite `reseed_pr_tracking_tx` semantics (see below).
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| format!("begin postgres pr_tracking reseed transaction: {e}"))?;
+
     let active_id = sqlx::query_scalar::<_, String>(
         "SELECT id
          FROM task_dispatches
@@ -768,23 +777,18 @@ async fn reseed_pr_tracking_pg(pool: &PgPool, card_id: &str) -> Result<serde_jso
          LIMIT 1",
     )
     .bind(card_id)
-    .fetch_optional(pool)
+    .fetch_optional(&mut *tx)
     .await
     .map_err(|e| format!("load active postgres create-pr dispatch for {card_id}: {e}"))?;
     if let Some(dispatch_id) = active_id {
-        let _ = crate::dispatch::cancel_dispatch_and_reset_auto_queue_on_pg(
-            pool,
+        let _ = crate::dispatch::cancel_dispatch_and_reset_auto_queue_on_pg_tx(
+            &mut tx,
             &dispatch_id,
             Some("superseded_by_reseed"),
         )
         .await
         .map_err(|e| format!("cancel active postgres create-pr dispatch {dispatch_id}: {e}"))?;
     }
-
-    let mut tx = pool
-        .begin()
-        .await
-        .map_err(|e| format!("begin postgres pr_tracking reseed transaction: {e}"))?;
 
     let latest_head = sqlx::query_scalar::<_, String>(
         "SELECT COALESCE(
@@ -1382,6 +1386,165 @@ mod tests {
         .await
         .expect("count status reaction outbox");
         assert_eq!(status_reaction_count, 1);
+
+        pool.close().await;
+        test_db.drop().await;
+    }
+
+    // Helper used by the atomicity-focused tests below. Seeds a card + active
+    // create-pr dispatch + pr_tracking row so `reseed_pr_tracking_pg` has
+    // state to cancel and rewrite. Returns the dispatch id and the original
+    // generation string on pr_tracking.
+    async fn seed_reseed_fixture(pool: &sqlx::PgPool, card_id: &str) -> (String, String) {
+        sqlx::query(
+            "INSERT INTO kanban_cards (id, title, status, repo_id)
+             VALUES ($1, $2, 'review', 'repo-1')",
+        )
+        .bind(card_id)
+        .bind("Atomicity fixture")
+        .execute(pool)
+        .await
+        .expect("insert kanban card");
+
+        sqlx::query(
+            "INSERT INTO card_review_state (card_id, review_round, state)
+             VALUES ($1, 1, 'in_review')",
+        )
+        .bind(card_id)
+        .execute(pool)
+        .await
+        .expect("insert card review state");
+
+        let dispatch_id = format!("dispatch-{}", uuid::Uuid::new_v4().simple());
+        sqlx::query(
+            "INSERT INTO task_dispatches (
+                id, kanban_card_id, dispatch_type, status, created_at, updated_at
+             ) VALUES ($1, $2, 'create-pr', 'pending', NOW(), NOW())",
+        )
+        .bind(&dispatch_id)
+        .bind(card_id)
+        .execute(pool)
+        .await
+        .expect("insert pending create-pr dispatch");
+
+        let original_generation = "gen-original".to_string();
+        sqlx::query(
+            "INSERT INTO pr_tracking (
+                card_id, state, dispatch_generation, review_round, retry_count,
+                created_at, updated_at
+             ) VALUES ($1, 'create-pr', $2, 0, 0, NOW(), NOW())",
+        )
+        .bind(card_id)
+        .bind(&original_generation)
+        .execute(pool)
+        .await
+        .expect("insert initial pr_tracking row");
+
+        (dispatch_id, original_generation)
+    }
+
+    // Regression guard for #766: a successful reseed leaves dispatch cancelled
+    // AND pr_tracking rewritten with the new generation inside the same
+    // observable state. Before the fix the two mutations lived in separate
+    // transactions, creating a crash window where only one half applied.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reseed_pr_tracking_pg_is_atomic_on_success() {
+        let test_db = TestDatabase::create().await;
+        let pool = test_db.migrate().await;
+
+        let card_id = "card-reseed-atomic-ok";
+        let (dispatch_id, original_generation) = seed_reseed_fixture(&pool, card_id).await;
+
+        let reseed = reseed_pr_tracking_pg(&pool, card_id)
+            .await
+            .expect("reseed pr tracking");
+        assert_eq!(reseed["ok"], true);
+        let new_generation = reseed["generation"]
+            .as_str()
+            .expect("new generation")
+            .to_string();
+        assert_ne!(new_generation, original_generation);
+
+        let dispatch_status: String =
+            sqlx::query_scalar("SELECT status FROM task_dispatches WHERE id = $1")
+                .bind(&dispatch_id)
+                .fetch_one(&pool)
+                .await
+                .expect("load dispatch status");
+        assert_eq!(dispatch_status, "cancelled");
+
+        let tracking_generation: String =
+            sqlx::query_scalar("SELECT dispatch_generation FROM pr_tracking WHERE card_id = $1")
+                .bind(card_id)
+                .fetch_one(&pool)
+                .await
+                .expect("load pr_tracking generation");
+        assert_eq!(tracking_generation, new_generation);
+
+        pool.close().await;
+        test_db.drop().await;
+    }
+
+    // Atomicity guard: when the cancel/reset helper runs inside a caller-owned
+    // transaction that subsequently rolls back, NEITHER the dispatch cancel
+    // NOR the auto-queue reset must persist. This is the exact contract
+    // `reseed_pr_tracking_pg` relies on to stay atomic across both mutations.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancel_dispatch_and_reset_auto_queue_on_pg_tx_rolls_back_with_caller() {
+        let test_db = TestDatabase::create().await;
+        let pool = test_db.migrate().await;
+
+        let card_id = "card-reseed-atomic-rollback";
+        let (dispatch_id, original_generation) = seed_reseed_fixture(&pool, card_id).await;
+
+        let mut tx = pool.begin().await.expect("begin outer tx");
+        let changed = crate::dispatch::cancel_dispatch_and_reset_auto_queue_on_pg_tx(
+            &mut tx,
+            &dispatch_id,
+            Some("superseded_by_reseed"),
+        )
+        .await
+        .expect("cancel dispatch inside caller tx");
+        assert_eq!(changed, 1, "cancel should mark exactly one dispatch");
+
+        // Caller decides to abort the wider unit of work. The dispatch cancel
+        // must be rolled back atomically.
+        tx.rollback().await.expect("rollback outer tx");
+
+        let dispatch_status: String =
+            sqlx::query_scalar("SELECT status FROM task_dispatches WHERE id = $1")
+                .bind(&dispatch_id)
+                .fetch_one(&pool)
+                .await
+                .expect("load dispatch status after rollback");
+        assert_eq!(
+            dispatch_status, "pending",
+            "rollback must revert the dispatch cancel"
+        );
+
+        let tracking_generation: String =
+            sqlx::query_scalar("SELECT dispatch_generation FROM pr_tracking WHERE card_id = $1")
+                .bind(card_id)
+                .fetch_one(&pool)
+                .await
+                .expect("load pr_tracking generation after rollback");
+        assert_eq!(
+            tracking_generation, original_generation,
+            "pr_tracking must remain at the original generation when the outer tx rolls back"
+        );
+
+        let cancel_event_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM dispatch_events
+             WHERE dispatch_id = $1 AND to_status = 'cancelled'",
+        )
+        .bind(&dispatch_id)
+        .fetch_one(&pool)
+        .await
+        .expect("count cancel events after rollback");
+        assert_eq!(
+            cancel_event_count, 0,
+            "rollback must also discard the dispatch_events audit row"
+        );
 
         pool.close().await;
         test_db.drop().await;

--- a/src/engine/ops/review_automation_ops.rs
+++ b/src/engine/ops/review_automation_ops.rs
@@ -1392,10 +1392,12 @@ mod tests {
     }
 
     // Helper used by the atomicity-focused tests below. Seeds a card + active
-    // create-pr dispatch + pr_tracking row so `reseed_pr_tracking_pg` has
-    // state to cancel and rewrite. Returns the dispatch id and the original
-    // generation string on pr_tracking.
-    async fn seed_reseed_fixture(pool: &sqlx::PgPool, card_id: &str) -> (String, String) {
+    // create-pr dispatch + pr_tracking row + a dispatched auto_queue entry tied
+    // to that dispatch so `reseed_pr_tracking_pg` has state to cancel/reset and
+    // rewrite. Returns the dispatch id, the original pr_tracking generation,
+    // and the seeded auto_queue entry id (so the rollback test can verify the
+    // queue half also rolls back atomically).
+    async fn seed_reseed_fixture(pool: &sqlx::PgPool, card_id: &str) -> (String, String, String) {
         sqlx::query(
             "INSERT INTO kanban_cards (id, title, status, repo_id)
              VALUES ($1, $2, 'review', 'repo-1')",
@@ -1440,7 +1442,39 @@ mod tests {
         .await
         .expect("insert initial pr_tracking row");
 
-        (dispatch_id, original_generation)
+        // Seed an auto_queue run + entry tied to the dispatch so the cancel
+        // helper exercises its queue-reset half (it resets status and clears
+        // dispatch_id / slot_index, and inserts an auto_queue_entry_transitions
+        // row). The atomicity tests assert these mutations also roll back when
+        // the caller-owned tx is aborted.
+        let run_id = format!("run-{}", uuid::Uuid::new_v4().simple());
+        sqlx::query(
+            "INSERT INTO auto_queue_runs (
+                id, agent_id, status, total_entries, batch_phase_max,
+                created_at, updated_at
+             ) VALUES ($1, 'project-agentdesk', 'running', 1, 1, NOW(), NOW())",
+        )
+        .bind(&run_id)
+        .execute(pool)
+        .await
+        .expect("insert auto_queue run");
+
+        let entry_id = format!("entry-{}", uuid::Uuid::new_v4().simple());
+        sqlx::query(
+            "INSERT INTO auto_queue_entries (
+                id, run_id, kanban_card_id, status, dispatch_id, slot_index,
+                batch_phase, thread_group, dispatched_at, created_at, updated_at
+             ) VALUES ($1, $2, $3, 'dispatched', $4, 0, 1, 1, NOW(), NOW(), NOW())",
+        )
+        .bind(&entry_id)
+        .bind(&run_id)
+        .bind(card_id)
+        .bind(&dispatch_id)
+        .execute(pool)
+        .await
+        .expect("insert dispatched auto_queue entry");
+
+        (dispatch_id, original_generation, entry_id)
     }
 
     // Regression guard for #766: a successful reseed leaves dispatch cancelled
@@ -1453,7 +1487,9 @@ mod tests {
         let pool = test_db.migrate().await;
 
         let card_id = "card-reseed-atomic-ok";
-        let (dispatch_id, original_generation) = seed_reseed_fixture(&pool, card_id).await;
+        let (dispatch_id, original_generation, entry_id) =
+            seed_reseed_fixture(&pool, card_id).await;
+        let _ = entry_id; // success path doesn't assert per-entry — see rollback test
 
         let reseed = reseed_pr_tracking_pg(&pool, card_id)
             .await
@@ -1495,7 +1531,8 @@ mod tests {
         let pool = test_db.migrate().await;
 
         let card_id = "card-reseed-atomic-rollback";
-        let (dispatch_id, original_generation) = seed_reseed_fixture(&pool, card_id).await;
+        let (dispatch_id, original_generation, entry_id) =
+            seed_reseed_fixture(&pool, card_id).await;
 
         let mut tx = pool.begin().await.expect("begin outer tx");
         let changed = crate::dispatch::cancel_dispatch_and_reset_auto_queue_on_pg_tx(
@@ -1544,6 +1581,45 @@ mod tests {
         assert_eq!(
             cancel_event_count, 0,
             "rollback must also discard the dispatch_events audit row"
+        );
+
+        // Auto-queue half of the helper must roll back too: the entry stays
+        // 'dispatched' with its dispatch_id intact, and no
+        // auto_queue_entry_transitions row was persisted for the cancel.
+        let entry_status: String =
+            sqlx::query_scalar("SELECT status FROM auto_queue_entries WHERE id = $1")
+                .bind(&entry_id)
+                .fetch_one(&pool)
+                .await
+                .expect("load auto_queue entry status after rollback");
+        assert_eq!(
+            entry_status, "dispatched",
+            "rollback must revert the auto_queue entry status reset"
+        );
+
+        let entry_dispatch_id: Option<String> =
+            sqlx::query_scalar("SELECT dispatch_id FROM auto_queue_entries WHERE id = $1")
+                .bind(&entry_id)
+                .fetch_one(&pool)
+                .await
+                .expect("load auto_queue entry dispatch_id after rollback");
+        assert_eq!(
+            entry_dispatch_id.as_deref(),
+            Some(dispatch_id.as_str()),
+            "rollback must revert the auto_queue entry dispatch_id clear"
+        );
+
+        let queue_transition_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM auto_queue_entry_transitions
+             WHERE entry_id = $1 AND trigger_source = 'dispatch_cancel'",
+        )
+        .bind(&entry_id)
+        .fetch_one(&pool)
+        .await
+        .expect("count auto_queue_entry_transitions after rollback");
+        assert_eq!(
+            queue_transition_count, 0,
+            "rollback must also discard the auto_queue_entry_transitions row"
         );
 
         pool.close().await;


### PR DESCRIPTION
## Summary

Closes #766.

`reseed_pr_tracking_pg` (`src/engine/ops/review_automation_ops.rs`) used to commit the create-pr cancel + auto-queue reset in one transaction and then run the `pr_tracking` generation/head/review_round update in a separate transaction. A crash between the two left the dispatch cancelled while `pr_tracking` still pointed at the previous generation — divergent from the SQLite path (`reseed_pr_tracking_tx`), which performs all three mutations atomically.

The next handoff is self-healing, so this was not a runtime blocker, but the semantic divergence + crash window is wrong and worth closing.

## Changes

- `src/dispatch/mod.rs`
  - Extract new `cancel_dispatch_and_reset_auto_queue_on_pg_tx(&mut Transaction<'_, Postgres>, dispatch_id, reason)` helper that performs cancel/reset against a caller-owned transaction. On stale-guard / missing-row paths it returns `Ok(0)` without writing — the caller decides whether to commit or roll back the surrounding work.
  - Rewrite `cancel_dispatch_and_reset_auto_queue_on_pg(&PgPool, ...)` (the original public API used by `server/routes/auto_queue.rs`) to delegate to the helper inside its own `begin` / `commit`. External callers see no behavior change.
- `src/engine/ops/review_automation_ops.rs`
  - Rewrite `reseed_pr_tracking_pg` to begin one transaction, call the new helper to cancel any active create-pr dispatch + reset linked auto-queue entries, then read latest head + review_round + write the new `pr_tracking` row, then commit. Now atomic — matches the SQLite semantics.
  - Add two regression tests:
    - `reseed_pr_tracking_pg_is_atomic_on_success`: after `reseed_pr_tracking_pg` returns, both `task_dispatches.status='cancelled'` AND `pr_tracking.dispatch_generation = <new generation>` are observable in one state.
    - `cancel_dispatch_and_reset_auto_queue_on_pg_tx_rolls_back_with_caller`: exercises the new helper inside a caller-owned tx, then rolls back the outer tx and asserts neither the cancel, the `dispatch_events` audit row, nor any side-effects persist — proving the helper composes safely inside a wider atomic unit.
- `docs/generated/module-inventory.md`: regenerated by `scripts/generate_inventory_docs.py` (line counts only).

## Risk awareness

- Cancel logic semantics unchanged: stale guard on `pending` / `dispatched`, generation re-issuance via `Uuid::new_v4`, auto_queue reset to `pending` with `auto_queue_entry_transitions` audit, latest head re-query from completed work dispatches.
- Only the transaction boundary widened. The original `cancel_dispatch_and_reset_auto_queue_on_pg` is intact and still used by `server/routes/auto_queue.rs`.
- On error inside the wider tx, sqlx `Transaction::Drop` issues an implicit rollback, so partial writes from the helper are discarded automatically.

## Test plan

- [x] `cargo build --bin agentdesk --message-format=short` — clean.
- [x] `cargo build --tests --bin agentdesk --message-format=short` — clean.
- [x] `cargo test --bin agentdesk -- reseed_pr_tracking_pg_is_atomic_on_success cancel_dispatch_and_reset_auto_queue_on_pg_tx_rolls_back_with_caller --nocapture` — both new PG tests pass against local Postgres.
- [x] Existing `review_automation_pg_handoff_failure_and_reseed_round_trip` still passes (it already asserts the post-reseed end state; the new tests add the explicit atomicity guarantee).
- [x] Full `cargo test --bin agentdesk` — 1848 pass, 1 unrelated pre-existing failure (`services::discord::prompt_builder::tests::test_full_prompt_injects_memento_memory_guidance`, also fails on `main` with my changes stashed).
- [x] `python3 scripts/generate_inventory_docs.py` — only line-count diffs in `module-inventory.md`.

PG tests require a reachable local Postgres (`PGUSER` / `PGHOST` / `POSTGRES_TEST_DATABASE_URL_BASE`). Mirrors the env contract used by every other PG test in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)