### PR TITLE
feat(dawn): add shared LaunchDaemon manager entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,39 @@ cargo build --release
 ./target/release/agentdesk --init
 ```
 
+### Dawn LaunchDaemon Operations (macOS)
+
+If you also install observability skills such as `memory-dream`, `service-monitoring`, `version-watch`, and `hardware-audit`, use `scripts/manage_dawn_launchdaemons.py` to manage their dawn `LaunchDaemon` jobs from a single entrypoint.
+
+The script automatically searches common skill install roots in this order:
+- `$AGENTDESK_SKILLS_ROOT`
+- `$CODEX_HOME/skills`
+- `~/.codex/skills`
+- `~/.adk/release/skills`
+- `<repo>/skills`
+
+First-time bootstrap:
+
+```bash
+sudo /opt/homebrew/bin/python3 ./scripts/manage_dawn_launchdaemons.py bootstrap
+```
+
+What that one command does:
+- installs the `agentdesk-dawn-manager` sudoers drop-in
+- installs or refreshes the selected dawn `LaunchDaemon` plists
+- keeps later `status` checks on the non-root path by default
+
+Useful follow-ups:
+
+```bash
+python3 ./scripts/manage_dawn_launchdaemons.py preflight
+python3 ./scripts/manage_dawn_launchdaemons.py status
+python3 ./scripts/manage_dawn_launchdaemons.py install
+python3 ./scripts/manage_dawn_launchdaemons.py uninstall
+```
+
+If your skills live outside the default roots, pass one or more `--skills-root <path>` flags.
+
 ## Onboarding
 
 After installation, the web dashboard opens automatically at `http://127.0.0.1:8791`. The onboarding wizard walks you through:

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -221,7 +221,7 @@
 | `services::discord::metrics` | `src/services/discord/metrics.rs` | 148 |  |
 | `services::discord::model_catalog` | `src/services/discord/model_catalog.rs` | 1081 | giant-file |
 | `services::discord::model_picker_interaction` | `src/services/discord/model_picker_interaction.rs` | 424 |  |
-| `services::discord::org_schema` | `src/services/discord/org_schema.rs` | 984 |  |
+| `services::discord::org_schema` | `src/services/discord/org_schema.rs` | 987 |  |
 | `services::discord::org_writer` | `src/services/discord/org_writer.rs` | 239 |  |
 | `services::discord::prompt_builder` | `src/services/discord/prompt_builder.rs` | 1407 | giant-file |
 | `services::discord::queue_io` | `src/services/discord/queue_io.rs` | 565 |  |

--- a/scripts/manage_dawn_launchdaemons.py
+++ b/scripts/manage_dawn_launchdaemons.py
@@ -477,14 +477,27 @@ def resolve_job_artifacts(
     )
 
 
+class ScheduleOverrideError(RuntimeError):
+    """Raised when a temporary launchd plist override cannot be built safely."""
+
+
 def build_schedule_override(source_plist: Path, *, hour: int, minute: int) -> Path:
-    with source_plist.open("rb") as handle:
-        plist = plistlib.load(handle)
+    try:
+        with source_plist.open("rb") as handle:
+            plist = plistlib.load(handle)
+    except (OSError, plistlib.InvalidFileException) as exc:
+        raise ScheduleOverrideError(
+            f"failed to build schedule override from `{source_plist}`: {exc}"
+        ) from exc
     plist["StartCalendarInterval"] = {"Hour": hour, "Minute": minute}
     tmp = tempfile.NamedTemporaryFile(prefix="dawn-launchd-", suffix=".plist", delete=False)
     try:
         with open(tmp.name, "wb") as handle:
             plistlib.dump(plist, handle)
+    except OSError as exc:
+        raise ScheduleOverrideError(
+            f"failed to write schedule override for `{source_plist}`: {exc}"
+        ) from exc
     finally:
         tmp.close()
     return Path(tmp.name)
@@ -590,13 +603,20 @@ def render_batch_summary(args: argparse.Namespace, jobs: Sequence[tuple[str, Daw
                     if index != len(jobs) - 1:
                         summary_lines.append("")
                     continue
-            result = run_manager(
-                resolved,
-                args.action,
-                python_bin=manager_python,
-                hour=args.hour,
-                minute=args.minute,
-            )
+            try:
+                result = run_manager(
+                    resolved,
+                    args.action,
+                    python_bin=manager_python,
+                    hour=args.hour,
+                    minute=args.minute,
+                )
+            except ScheduleOverrideError as exc:
+                all_ok = False
+                summary_lines.extend(summarize_resolution_error(job_name, exc))
+                if index != len(jobs) - 1:
+                    summary_lines.append("")
+                continue
             if result.returncode != 0:
                 all_ok = False
             summary_lines.extend(summarize_result(job_name, result))

--- a/scripts/manage_dawn_launchdaemons.py
+++ b/scripts/manage_dawn_launchdaemons.py
@@ -489,6 +489,11 @@ def build_schedule_override(source_plist: Path, *, hour: int, minute: int) -> Pa
         raise ScheduleOverrideError(
             f"failed to build schedule override from `{source_plist}`: {exc}"
         ) from exc
+    if not isinstance(plist, dict):
+        raise ScheduleOverrideError(
+            "failed to build schedule override from "
+            f"`{source_plist}`: expected plist dictionary root, got {type(plist).__name__}"
+        )
     plist["StartCalendarInterval"] = {"Hour": hour, "Minute": minute}
     tmp = tempfile.NamedTemporaryFile(prefix="dawn-launchd-", suffix=".plist", delete=False)
     try:

--- a/scripts/manage_dawn_launchdaemons.py
+++ b/scripts/manage_dawn_launchdaemons.py
@@ -191,11 +191,28 @@ def trusted_root_python_bin() -> Path:
 
 
 def path_is_root_owned_and_locked(path: Path) -> bool:
-    try:
-        st = path.stat()
-    except OSError:
-        return False
-    return st.st_uid == 0 and not (st.st_mode & (stat.S_IWGRP | stat.S_IWOTH))
+    current = path.expanduser()
+    seen: set[Path] = set()
+
+    while True:
+        if current in seen:
+            return False
+        seen.add(current)
+
+        try:
+            if current.is_symlink():
+                return False
+            st = current.stat()
+        except OSError:
+            return False
+
+        if st.st_uid != 0 or (st.st_mode & (stat.S_IWGRP | stat.S_IWOTH)):
+            return False
+
+        parent = current.parent
+        if parent == current:
+            return True
+        current = parent
 
 
 def path_is_executable(path: Path) -> bool:

--- a/scripts/manage_dawn_launchdaemons.py
+++ b/scripts/manage_dawn_launchdaemons.py
@@ -13,6 +13,7 @@ import argparse
 import os
 import plistlib
 import pwd
+import re
 import shutil
 import stat
 import subprocess
@@ -99,6 +100,18 @@ def current_user_name() -> str:
         return pwd.getpwuid(os.getuid()).pw_name
     except Exception:
         return "agentdesk"
+
+
+SAFE_SUDOERS_USER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.-]*$")
+
+
+def validate_sudoers_user_name(user_name: str) -> str:
+    if not SAFE_SUDOERS_USER_RE.fullmatch(user_name):
+        raise SystemExit(
+            "--sudoers-user must be a single POSIX-style account name "
+            "containing only letters, digits, underscores, dots, or hyphens"
+        )
+    return user_name
 
 
 def home_for_user(user_name: str) -> Optional[Path]:
@@ -288,6 +301,7 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
 
 
 def validate_schedule_args(args: argparse.Namespace) -> None:
+    args.sudoers_user = validate_sudoers_user_name(args.sudoers_user)
     if (args.hour is None) != (args.minute is None):
         raise SystemExit("--hour and --minute must be provided together")
     if args.hour is None:
@@ -533,12 +547,13 @@ def plist_valid(path: Path) -> bool:
 
 
 def sudoers_text(*, user_name: str, python_bin: Path, script_path: Path) -> str:
+    safe_user_name = validate_sudoers_user_name(user_name)
     return "\n".join(
         [
             "# /etc/sudoers.d/agentdesk-dawn-manager",
             "# Install with: sudo visudo -f /etc/sudoers.d/agentdesk-dawn-manager",
             "",
-            f"User_Alias AGENTDESK_RUNTIME = {user_name}",
+            f"User_Alias AGENTDESK_RUNTIME = {safe_user_name}",
             "",
             "Cmnd_Alias AGENTDESK_DAWN_MANAGER = \\",
             f"    {python_bin} {script_path} *",
@@ -598,7 +613,7 @@ def access_denied(stderr: str) -> bool:
 def render_preflight(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJobSpec]]) -> int:
     python_bin = Path(args.python_bin).expanduser()
     skills_roots = candidate_skills_roots(args)
-    manager_python = effective_manager_python(args)
+    manager_python = trusted_root_python_bin()
     if python_bin.exists():
         version_result = run_command([str(python_bin), "--version"])
         invocation_python_version = version_result.stdout.strip() or version_result.stderr.strip() or "unknown"

--- a/scripts/manage_dawn_launchdaemons.py
+++ b/scripts/manage_dawn_launchdaemons.py
@@ -1,0 +1,630 @@
+#!/usr/bin/env python3
+"""Manage dawn LaunchDaemon jobs for observability skills on a macOS host.
+
+Typical flow:
+1. `preflight` to verify python path, skill roots, and sudo readiness.
+2. `bootstrap` once under sudo to install the sudoers drop-in and the plists.
+3. `status` later as an unprivileged operator command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import plistlib
+import pwd
+import shutil
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Optional, Sequence
+
+
+SCRIPT_PATH = Path(__file__).resolve()
+REPO_ROOT = SCRIPT_PATH.parents[1]
+SUDOERS_TARGET = Path("/etc/sudoers.d/agentdesk-dawn-manager")
+
+
+@dataclass(frozen=True)
+class DawnJobSpec:
+    skill_name: str
+    manager_relpath: Path
+    daemon_plist_relpath: Path
+
+
+@dataclass(frozen=True)
+class ResolvedDawnJob:
+    name: str
+    skill_root: Path
+    manager_script: Path
+    daemon_plist: Path
+
+    @property
+    def installed_target(self) -> Path:
+        return Path("/Library/LaunchDaemons") / self.daemon_plist.name
+
+
+JOB_SPECS = {
+    "memory-dream": DawnJobSpec(
+        skill_name="memory-dream",
+        manager_relpath=Path("scripts/manage_memory_dream_launchd.py"),
+        daemon_plist_relpath=Path("launchd/com.agentdesk.memory-dream-dawn.plist"),
+    ),
+    "service-monitoring": DawnJobSpec(
+        skill_name="service-monitoring",
+        manager_relpath=Path("scripts/manage_service_monitoring_launchd.py"),
+        daemon_plist_relpath=Path("launchd/com.agentdesk.service-monitoring-dawn.plist"),
+    ),
+    "version-watch": DawnJobSpec(
+        skill_name="version-watch",
+        manager_relpath=Path("scripts/manage_version_watch_launchd.py"),
+        daemon_plist_relpath=Path("launchd/com.agentdesk.version-watch-dawn.plist"),
+    ),
+    "hardware-audit": DawnJobSpec(
+        skill_name="hardware-audit",
+        manager_relpath=Path("scripts/manage_hardware_audit_launchd.py"),
+        daemon_plist_relpath=Path("launchd/com.agentdesk.hardware-audit-dawn.plist"),
+    ),
+}
+
+
+def run_command(command: Sequence[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        list(command),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def preferred_python_bin() -> Path:
+    homebrew_python = Path("/opt/homebrew/bin/python3")
+    if homebrew_python.exists():
+        return homebrew_python
+    python3_path = shutil.which("python3")
+    if python3_path:
+        return Path(python3_path)
+    return Path(sys.executable)
+
+
+def current_user_name() -> str:
+    sudo_user = os.environ.get("SUDO_USER")
+    if sudo_user:
+        return sudo_user
+    try:
+        return pwd.getpwuid(os.getuid()).pw_name
+    except Exception:
+        return "agentdesk"
+
+
+def split_env_roots(raw: str | None) -> list[Path]:
+    if not raw:
+        return []
+    roots: list[Path] = []
+    for item in raw.split(os.pathsep):
+        item = item.strip()
+        if item:
+            roots.append(Path(item).expanduser())
+    return roots
+
+
+def unique_paths(paths: Sequence[Path]) -> list[Path]:
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for path in paths:
+        resolved = path.expanduser()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        unique.append(resolved)
+    return unique
+
+
+def default_skills_roots() -> list[Path]:
+    # Search the most common local runtime layouts before falling back to repo-local skills.
+    roots: list[Path] = []
+    roots.extend(split_env_roots(os.environ.get("AGENTDESK_SKILLS_ROOT")))
+    codex_home = os.environ.get("CODEX_HOME")
+    if codex_home:
+        roots.append(Path(codex_home).expanduser() / "skills")
+    roots.append(Path.home() / ".codex/skills")
+    roots.append(Path.home() / ".adk/release/skills")
+    roots.append(REPO_ROOT / "skills")
+    return unique_paths(roots)
+
+
+def candidate_skills_roots(args: argparse.Namespace) -> list[Path]:
+    if args.skills_root:
+        return unique_paths([Path(item).expanduser() for item in args.skills_root])
+    return default_skills_roots()
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Single entrypoint for dawn LaunchDaemon install/status/bootstrap operations.",
+        epilog=(
+            "Examples:\n"
+            "  python3 scripts/manage_dawn_launchdaemons.py preflight\n"
+            "  sudo python3 scripts/manage_dawn_launchdaemons.py bootstrap\n"
+            "  python3 scripts/manage_dawn_launchdaemons.py status --job memory-dream\n"
+            "  python3 scripts/manage_dawn_launchdaemons.py install --hour 5 --minute 30\n"
+            "  python3 scripts/manage_dawn_launchdaemons.py preflight --skills-root ~/.codex/skills\n"
+            "  python3 scripts/manage_dawn_launchdaemons.py sudoers\n\n"
+            "Action summary:\n"
+            "  bootstrap  install sudoers drop-in and run install for the selected jobs\n"
+            "  install    install or refresh LaunchDaemon plists\n"
+            "  status     inspect configured jobs without requiring root by default\n"
+            "  uninstall  remove installed LaunchDaemon plists\n"
+            "  preflight  verify python path, skill roots, plist validity, and sudo readiness\n"
+            "  sudoers    print the exact sudoers drop-in content for manual review"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "action",
+        choices=["bootstrap", "install", "status", "uninstall", "preflight", "sudoers"],
+        help="operation to run for the selected dawn jobs",
+    )
+    parser.add_argument(
+        "--job",
+        action="append",
+        choices=sorted(JOB_SPECS),
+        help="limit to one or more named jobs; defaults to all supported dawn jobs",
+    )
+    parser.add_argument(
+        "--hour",
+        type=int,
+        help="override install schedule hour (0-23); requires --minute and only works with install/bootstrap",
+    )
+    parser.add_argument(
+        "--minute",
+        type=int,
+        help="override install schedule minute (0-59); requires --hour and only works with install/bootstrap",
+    )
+    parser.add_argument(
+        "--python-bin",
+        default=str(preferred_python_bin()),
+        help="python binary used for sudo re-exec and downstream manager scripts",
+    )
+    parser.add_argument(
+        "--sudoers-user",
+        default=current_user_name(),
+        help="user name to emit in the sudoers example and bootstrap drop-in",
+    )
+    parser.add_argument(
+        "--skills-root",
+        action="append",
+        help="explicit skills root to search; pass multiple times to search more than one location",
+    )
+    parser.add_argument("--as-root", action="store_true", help=argparse.SUPPRESS)
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    validate_schedule_args(args)
+    return args
+
+
+def validate_schedule_args(args: argparse.Namespace) -> None:
+    if (args.hour is None) != (args.minute is None):
+        raise SystemExit("--hour and --minute must be provided together")
+    if args.hour is None:
+        return
+    if args.action not in {"install", "bootstrap"}:
+        raise SystemExit("schedule override is only supported for install/bootstrap")
+    if not 0 <= args.hour <= 23:
+        raise SystemExit("--hour must be between 0 and 23")
+    if not 0 <= args.minute <= 59:
+        raise SystemExit("--minute must be between 0 and 59")
+
+
+def action_needs_privileged_reexec(action: str) -> bool:
+    return action in {"bootstrap", "install", "uninstall"}
+
+
+def selected_job_specs(names: Optional[Sequence[str]]) -> list[tuple[str, DawnJobSpec]]:
+    if not names:
+        return list(JOB_SPECS.items())
+    return [(name, JOB_SPECS[name]) for name in names]
+
+
+def resolve_job_artifacts(
+    job_name: str,
+    spec: DawnJobSpec,
+    *,
+    skills_roots: Sequence[Path],
+) -> ResolvedDawnJob:
+    searched: list[str] = []
+    for root in skills_roots:
+        skill_root = root / spec.skill_name
+        manager_script = skill_root / spec.manager_relpath
+        daemon_plist = skill_root / spec.daemon_plist_relpath
+        searched.append(str(skill_root))
+        if manager_script.exists() and daemon_plist.exists():
+            return ResolvedDawnJob(
+                name=job_name,
+                skill_root=skill_root,
+                manager_script=manager_script,
+                daemon_plist=daemon_plist,
+            )
+    raise FileNotFoundError(
+        f"could not resolve `{job_name}` under any skills root: {', '.join(searched) or '(none)'}"
+    )
+
+
+def build_schedule_override(source_plist: Path, *, hour: int, minute: int) -> Path:
+    with source_plist.open("rb") as handle:
+        plist = plistlib.load(handle)
+    plist["StartCalendarInterval"] = {"Hour": hour, "Minute": minute}
+    tmp = tempfile.NamedTemporaryFile(prefix="dawn-launchd-", suffix=".plist", delete=False)
+    try:
+        with open(tmp.name, "wb") as handle:
+            plistlib.dump(plist, handle)
+    finally:
+        tmp.close()
+    return Path(tmp.name)
+
+
+@contextmanager
+def schedule_override_path(
+    daemon_plist: Path,
+    *,
+    hour: Optional[int],
+    minute: Optional[int],
+) -> Iterator[Optional[Path]]:
+    if hour is None or minute is None:
+        yield None
+        return
+
+    override_path = build_schedule_override(daemon_plist, hour=hour, minute=minute)
+    try:
+        yield override_path
+    finally:
+        override_path.unlink(missing_ok=True)
+
+
+def run_manager(
+    job: ResolvedDawnJob,
+    action: str,
+    *,
+    python_bin: Path,
+    hour: Optional[int],
+    minute: Optional[int],
+) -> subprocess.CompletedProcess:
+    command = [str(python_bin), str(job.manager_script), action, "--scope", "daemon"]
+    with schedule_override_path(job.daemon_plist, hour=hour, minute=minute) as override_path:
+        if override_path is not None:
+            command.extend(["--source", str(override_path)])
+        return run_command(command)
+
+
+def summarize_result(job_name: str, result: subprocess.CompletedProcess) -> list[str]:
+    lines = [f"## {job_name}"]
+    status = "ok" if result.returncode == 0 else "needs-attention"
+    lines.append(f"- status: `{status}`")
+    lines.append(f"- exit_code: `{result.returncode}`")
+    stdout = (result.stdout or "").strip()
+    stderr = (result.stderr or "").strip()
+    if stdout:
+        for line in stdout.splitlines()[:14]:
+            lines.append(f"- output: `{line}`")
+    if stderr:
+        for line in stderr.splitlines()[:8]:
+            lines.append(f"- stderr: `{line}`")
+    return lines
+
+
+def summarize_resolution_error(job_name: str, exc: Exception) -> list[str]:
+    return [
+        f"## {job_name}",
+        "- status: `needs-attention`",
+        "- exit_code: `1`",
+        f"- stderr: `{str(exc)}`",
+    ]
+
+
+def render_batch_summary(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJobSpec]]) -> int:
+    all_ok = True
+    skills_roots = candidate_skills_roots(args)
+    summary_lines = [
+        "# Dawn LaunchDaemons",
+        "",
+        f"- action: `{args.action}`",
+        f"- job_count: `{len(jobs)}`",
+        f"- execution_user: `{current_user_name()}`",
+        f"- execution_uid: `{os.geteuid()}`",
+        f"- python: `{sys.executable}`",
+        f"- manager_python: `{Path(args.python_bin)}`",
+        f"- schedule: `{args.hour:02d}:{args.minute:02d}`" if args.hour is not None else "- schedule: `default`",
+        f"- skills_roots: `{', '.join(str(path) for path in skills_roots) or '(none)'}`",
+        "",
+    ]
+
+    for index, (job_name, spec) in enumerate(jobs):
+        try:
+            resolved = resolve_job_artifacts(job_name, spec, skills_roots=skills_roots)
+        except FileNotFoundError as exc:
+            all_ok = False
+            summary_lines.extend(summarize_resolution_error(job_name, exc))
+        else:
+            result = run_manager(
+                resolved,
+                args.action,
+                python_bin=Path(args.python_bin),
+                hour=args.hour,
+                minute=args.minute,
+            )
+            if result.returncode != 0:
+                all_ok = False
+            summary_lines.extend(summarize_result(job_name, result))
+        if index != len(jobs) - 1:
+            summary_lines.append("")
+
+    print("\n".join(summary_lines))
+    return 0 if all_ok else 1
+
+
+def build_self_command(
+    args: argparse.Namespace,
+    *,
+    action: Optional[str] = None,
+    as_root: bool = False,
+    job_names: Optional[Sequence[str]] = None,
+) -> list[str]:
+    command = [str(Path(args.python_bin)), str(SCRIPT_PATH)]
+    if as_root:
+        command.append("--as-root")
+    command.append(action or args.action)
+    for job_name in (job_names if job_names is not None else args.job or []):
+        command.extend(["--job", job_name])
+    if args.hour is not None:
+        command.extend(["--hour", str(args.hour), "--minute", str(args.minute)])
+    command.extend(["--python-bin", str(Path(args.python_bin))])
+    for skills_root in args.skills_root or []:
+        command.extend(["--skills-root", skills_root])
+    return command
+
+
+def print_subprocess_output(result: subprocess.CompletedProcess) -> None:
+    stdout = (result.stdout or "").strip()
+    stderr = (result.stderr or "").strip()
+    if stdout:
+        print(stdout)
+    if stderr:
+        print(stderr, file=sys.stderr)
+
+
+def run_via_sudo(args: argparse.Namespace) -> int:
+    # Keep the public operator entrypoint stable; privilege escalation only re-enters this script.
+    command = ["sudo", "-n"] + build_self_command(args, as_root=True)
+    result = run_command(command)
+    print_subprocess_output(result)
+    return result.returncode
+
+
+def plist_valid(path: Path) -> bool:
+    if not path.exists():
+        return False
+    return run_command(["plutil", "-lint", str(path)]).returncode == 0
+
+
+def sudoers_text(*, user_name: str, python_bin: Path, script_path: Path) -> str:
+    return "\n".join(
+        [
+            "# /etc/sudoers.d/agentdesk-dawn-manager",
+            "# Install with: sudo visudo -f /etc/sudoers.d/agentdesk-dawn-manager",
+            "",
+            f"User_Alias AGENTDESK_RUNTIME = {user_name}",
+            "",
+            "Cmnd_Alias AGENTDESK_DAWN_MANAGER = \\",
+            f"    {python_bin} {script_path} *",
+            "",
+            "AGENTDESK_RUNTIME ALL = (root) NOPASSWD: AGENTDESK_DAWN_MANAGER",
+        ]
+    )
+
+
+def visudo_bin() -> Path:
+    candidate = shutil.which("visudo")
+    if candidate:
+        return Path(candidate)
+    return Path("/usr/sbin/visudo")
+
+
+def install_sudoers_dropin(*, user_name: str, python_bin: Path, script_path: Path) -> tuple[bool, str]:
+    target_dir = SUDOERS_TARGET.parent
+    target_dir.mkdir(parents=True, exist_ok=True)
+    tmp = tempfile.NamedTemporaryFile(prefix="agentdesk-dawn-sudoers-", dir=target_dir, delete=False)
+    tmp_path = Path(tmp.name)
+    tmp.close()
+
+    try:
+        tmp_path.write_text(
+            sudoers_text(user_name=user_name, python_bin=python_bin, script_path=script_path) + "\n",
+            encoding="utf-8",
+        )
+        os.chmod(tmp_path, 0o440)
+
+        validator = visudo_bin()
+        validation = run_command([str(validator), "-cf", str(tmp_path)])
+        if validation.returncode != 0:
+            detail = (validation.stderr or validation.stdout or "visudo validation failed").strip()
+            return False, detail
+
+        tmp_path.replace(SUDOERS_TARGET)
+        os.chmod(SUDOERS_TARGET, 0o440)
+        return True, f"installed sudoers drop-in: {SUDOERS_TARGET}"
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+
+
+def access_denied(stderr: str) -> bool:
+    lowered = stderr.lower()
+    fragments = [
+        "a password is required",
+        "is not in the sudoers file",
+        "not allowed to run sudo",
+        "may not run sudo",
+        "user is not allowed",
+    ]
+    return any(fragment in lowered for fragment in fragments)
+
+
+def render_preflight(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJobSpec]]) -> int:
+    python_bin = Path(args.python_bin)
+    skills_roots = candidate_skills_roots(args)
+    if python_bin.exists():
+        version_result = run_command([str(python_bin), "--version"])
+        invocation_python_version = version_result.stdout.strip() or version_result.stderr.strip() or "unknown"
+    else:
+        invocation_python_version = "missing"
+    lines = [
+        "# Dawn LaunchDaemon Preflight",
+        "",
+        f"- script_path: `{SCRIPT_PATH}`",
+        f"- invocation_python: `{python_bin}`",
+        f"- runtime_python: `{sys.executable}`",
+        f"- invocation_python_exists: `{python_bin.exists()}`",
+        f"- invocation_python_version: `{invocation_python_version}`",
+        f"- sudoers_user: `{args.sudoers_user}`",
+        f"- skills_roots: `{', '.join(str(path) for path in skills_roots) or '(none)'}`",
+        "",
+    ]
+
+    all_ok = python_bin.exists()
+    for job_name, spec in jobs:
+        try:
+            resolved = resolve_job_artifacts(job_name, spec, skills_roots=skills_roots)
+        except FileNotFoundError as exc:
+            lines.extend(
+                [
+                    f"## {job_name}",
+                    "- manager_exists: `False`",
+                    "- source_exists: `False`",
+                    f"- detail: `{str(exc)}`",
+                    "",
+                ]
+            )
+            all_ok = False
+            continue
+
+        manager_exists = resolved.manager_script.exists()
+        source_exists = resolved.daemon_plist.exists()
+        source_valid = plist_valid(resolved.daemon_plist) if source_exists else False
+        target_exists = resolved.installed_target.exists()
+        lines.extend(
+            [
+                f"## {job_name}",
+                f"- skill_root: `{resolved.skill_root}`",
+                f"- manager_exists: `{manager_exists}`",
+                f"- manager_path: `{resolved.manager_script}`",
+                f"- source_exists: `{source_exists}`",
+                f"- source_valid: `{source_valid}`",
+                f"- source_path: `{resolved.daemon_plist}`",
+                f"- installed_target_exists: `{target_exists}`",
+                f"- installed_target_path: `{resolved.installed_target}`",
+                "",
+            ]
+        )
+        all_ok = all_ok and manager_exists and source_exists and source_valid
+
+    probe_job_name = jobs[0][0]
+    probe_command = ["sudo", "-n"] + build_self_command(args, action="status", as_root=False, job_names=[probe_job_name])
+    probe_result = run_command(probe_command)
+    probe_access = not access_denied(probe_result.stderr or "")
+    lines.extend(
+        [
+            "## sudo_probe",
+            f"- command: `{' '.join(probe_command)}`",
+            f"- access_ready: `{probe_access}`",
+            f"- exit_code: `{probe_result.returncode}`",
+        ]
+    )
+    if probe_result.stderr:
+        for line in probe_result.stderr.strip().splitlines()[:8]:
+            lines.append(f"- stderr: `{line}`")
+    if probe_result.stdout:
+        for line in probe_result.stdout.strip().splitlines()[:8]:
+            lines.append(f"- stdout: `{line}`")
+
+    lines.extend(
+        [
+            "",
+            "## next_steps",
+            f"- install sudoers file with `python3 {SCRIPT_PATH} sudoers` output",
+            f"- or run `sudo {python_bin} {SCRIPT_PATH} bootstrap` once",
+            f"- status can be checked with `python3 {SCRIPT_PATH} status`",
+        ]
+    )
+    print("\n".join(lines))
+    return 0 if (all_ok and probe_access) else 1
+
+
+def namespace_for_action(args: argparse.Namespace, action: str) -> argparse.Namespace:
+    return argparse.Namespace(
+        action=action,
+        job=args.job,
+        hour=args.hour,
+        minute=args.minute,
+        python_bin=args.python_bin,
+        sudoers_user=args.sudoers_user,
+        skills_root=args.skills_root,
+        as_root=True,
+    )
+
+
+def run_bootstrap(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJobSpec]]) -> int:
+    python_bin = Path(args.python_bin)
+    # Bootstrap is the one-time setup path: install sudoers, then install the selected plists.
+    sudoers_ok, sudoers_message = install_sudoers_dropin(
+        user_name=args.sudoers_user,
+        python_bin=python_bin,
+        script_path=SCRIPT_PATH,
+    )
+
+    lines = [
+        "# Dawn LaunchDaemon Bootstrap",
+        "",
+        f"- sudoers_target: `{SUDOERS_TARGET}`",
+        f"- sudoers_user: `{args.sudoers_user}`",
+        f"- invocation_python: `{python_bin}`",
+        f"- sudoers_installed: `{sudoers_ok}`",
+        f"- detail: `{sudoers_message}`",
+        "",
+    ]
+    print("\n".join(lines))
+    if not sudoers_ok:
+        return 1
+
+    return render_batch_summary(namespace_for_action(args, "install"), jobs)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    jobs = selected_job_specs(args.job)
+
+    if args.action == "sudoers":
+        print(
+            sudoers_text(
+                user_name=args.sudoers_user,
+                python_bin=Path(args.python_bin),
+                script_path=SCRIPT_PATH,
+            )
+        )
+        return 0
+
+    if args.action == "preflight":
+        return render_preflight(args, jobs)
+
+    if action_needs_privileged_reexec(args.action) and not args.as_root and os.geteuid() != 0:
+        return run_via_sudo(args)
+
+    if args.action == "bootstrap":
+        return run_bootstrap(args, jobs)
+
+    return render_batch_summary(args, jobs)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/manage_dawn_launchdaemons.py
+++ b/scripts/manage_dawn_launchdaemons.py
@@ -215,6 +215,20 @@ def path_is_root_owned_and_locked(path: Path) -> bool:
         current = parent
 
 
+def ensure_locked_directory_chain(path: Path, *, anchor: Path, mode: int = 0o755) -> None:
+    path = path.expanduser()
+    anchor = anchor.expanduser()
+    if anchor != path and anchor not in path.parents:
+        raise ValueError(f"{path} must stay under managed anchor {anchor}")
+    path.mkdir(parents=True, exist_ok=True)
+    current = path
+    while True:
+        os.chmod(current, mode)
+        if current == anchor:
+            break
+        current = current.parent
+
+
 def path_is_executable(path: Path) -> bool:
     return path.exists() and os.access(path, os.X_OK)
 
@@ -267,8 +281,7 @@ def resolve_managed_job_artifacts(job_name: str, spec: DawnJobSpec) -> ResolvedD
 
 
 def copy_locked_file(source: Path, target: Path, *, mode: int) -> Path:
-    target.parent.mkdir(parents=True, exist_ok=True)
-    os.chmod(target.parent, 0o755)
+    ensure_locked_directory_chain(target.parent, anchor=MANAGED_ENTRYPOINT_DIR)
     tmp = tempfile.NamedTemporaryFile(prefix=f"{target.name}-", dir=target.parent, delete=False)
     tmp_path = Path(tmp.name)
     tmp.close()
@@ -305,8 +318,7 @@ def install_managed_job_artifacts(source_job: ResolvedDawnJob, spec: DawnJobSpec
 
 def install_managed_entrypoint(source_path: Path = SCRIPT_PATH) -> Path:
     target = managed_entrypoint_target()
-    target.parent.mkdir(parents=True, exist_ok=True)
-    os.chmod(target.parent, 0o755)
+    ensure_locked_directory_chain(target.parent, anchor=MANAGED_ENTRYPOINT_DIR)
     tmp = tempfile.NamedTemporaryFile(prefix="agentdesk-dawn-manager-", dir=target.parent, delete=False)
     tmp_path = Path(tmp.name)
     tmp.close()
@@ -759,6 +771,7 @@ def render_preflight(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJob
     manager_python = trusted_root_python_bin()
     managed_script = managed_entrypoint_target()
     managed_script_exists = managed_script.exists()
+    prefer_managed_artifacts = privileged_root_requested(args) or managed_script_exists
     if path_is_executable(python_bin):
         try:
             version_result = run_command([str(python_bin), "--version"])
@@ -795,7 +808,7 @@ def render_preflight(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJob
         try:
             resolved = (
                 resolve_managed_job_artifacts(job_name, spec)
-                if privileged_root_requested(args)
+                if prefer_managed_artifacts
                 else resolve_job_artifacts(job_name, spec, skills_roots=skills_roots)
             )
         except FileNotFoundError as exc:

--- a/scripts/manage_dawn_launchdaemons.py
+++ b/scripts/manage_dawn_launchdaemons.py
@@ -14,6 +14,7 @@ import os
 import plistlib
 import pwd
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -100,6 +101,22 @@ def current_user_name() -> str:
         return "agentdesk"
 
 
+def home_for_user(user_name: str) -> Optional[Path]:
+    try:
+        return Path(pwd.getpwnam(user_name).pw_dir)
+    except Exception:
+        return None
+
+
+def invoking_home() -> Path:
+    sudo_user = os.environ.get("SUDO_USER")
+    if sudo_user:
+        home = home_for_user(sudo_user)
+        if home is not None:
+            return home
+    return Path.home()
+
+
 def split_env_roots(raw: str | None) -> list[Path]:
     if not raw:
         return []
@@ -130,10 +147,57 @@ def default_skills_roots() -> list[Path]:
     codex_home = os.environ.get("CODEX_HOME")
     if codex_home:
         roots.append(Path(codex_home).expanduser() / "skills")
-    roots.append(Path.home() / ".codex/skills")
-    roots.append(Path.home() / ".adk/release/skills")
+    home = invoking_home()
+    roots.append(home / ".codex/skills")
+    roots.append(home / ".adk/release/skills")
     roots.append(REPO_ROOT / "skills")
     return unique_paths(roots)
+
+
+def trusted_root_python_bin() -> Path:
+    return preferred_python_bin().expanduser().resolve()
+
+
+def path_is_root_owned_and_locked(path: Path) -> bool:
+    try:
+        st = path.stat()
+    except OSError:
+        return False
+    return st.st_uid == 0 and not (st.st_mode & (stat.S_IWGRP | stat.S_IWOTH))
+
+
+def privileged_root_requested(args: argparse.Namespace) -> bool:
+    return action_needs_privileged_reexec(args.action) and (args.as_root or os.geteuid() == 0)
+
+
+def effective_manager_python(args: argparse.Namespace) -> Path:
+    if privileged_root_requested(args):
+        return trusted_root_python_bin()
+    return Path(args.python_bin).expanduser()
+
+
+def validate_privileged_entrypoint(python_bin: Path) -> None:
+    for label, path in (
+        ("manager_python", python_bin),
+        ("script_path", SCRIPT_PATH),
+    ):
+        if not path_is_root_owned_and_locked(path):
+            raise PermissionError(
+                f"{label} must be root-owned and not group/other-writable for privileged actions: {path}"
+            )
+
+
+def validate_privileged_job_artifacts(job: ResolvedDawnJob, python_bin: Path) -> None:
+    validate_privileged_entrypoint(python_bin)
+    for label, path in (
+        ("skill_root", job.skill_root),
+        ("manager_script", job.manager_script),
+        ("daemon_plist", job.daemon_plist),
+    ):
+        if not path_is_root_owned_and_locked(path):
+            raise PermissionError(
+                f"{job.name} {label} must be root-owned and not group/other-writable for privileged actions: {path}"
+            )
 
 
 def candidate_skills_roots(args: argparse.Namespace) -> list[Path]:
@@ -326,6 +390,7 @@ def summarize_resolution_error(job_name: str, exc: Exception) -> list[str]:
 def render_batch_summary(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJobSpec]]) -> int:
     all_ok = True
     skills_roots = candidate_skills_roots(args)
+    manager_python = effective_manager_python(args)
     summary_lines = [
         "# Dawn LaunchDaemons",
         "",
@@ -334,7 +399,7 @@ def render_batch_summary(args: argparse.Namespace, jobs: Sequence[tuple[str, Daw
         f"- execution_user: `{current_user_name()}`",
         f"- execution_uid: `{os.geteuid()}`",
         f"- python: `{sys.executable}`",
-        f"- manager_python: `{Path(args.python_bin)}`",
+        f"- manager_python: `{manager_python}`",
         f"- schedule: `{args.hour:02d}:{args.minute:02d}`" if args.hour is not None else "- schedule: `default`",
         f"- skills_roots: `{', '.join(str(path) for path in skills_roots) or '(none)'}`",
         "",
@@ -347,10 +412,19 @@ def render_batch_summary(args: argparse.Namespace, jobs: Sequence[tuple[str, Daw
             all_ok = False
             summary_lines.extend(summarize_resolution_error(job_name, exc))
         else:
+            if privileged_root_requested(args):
+                try:
+                    validate_privileged_job_artifacts(resolved, manager_python)
+                except PermissionError as exc:
+                    all_ok = False
+                    summary_lines.extend(summarize_resolution_error(job_name, exc))
+                    if index != len(jobs) - 1:
+                        summary_lines.append("")
+                    continue
             result = run_manager(
                 resolved,
                 args.action,
-                python_bin=Path(args.python_bin),
+                python_bin=manager_python,
                 hour=args.hour,
                 minute=args.minute,
             )
@@ -380,6 +454,7 @@ def build_self_command(
     if args.hour is not None:
         command.extend(["--hour", str(args.hour), "--minute", str(args.minute)])
     command.extend(["--python-bin", str(Path(args.python_bin))])
+    command.extend(["--sudoers-user", args.sudoers_user])
     for skills_root in args.skills_root or []:
         command.extend(["--skills-root", skills_root])
     return command
@@ -396,7 +471,18 @@ def print_subprocess_output(result: subprocess.CompletedProcess) -> None:
 
 def run_via_sudo(args: argparse.Namespace) -> int:
     # Keep the public operator entrypoint stable; privilege escalation only re-enters this script.
-    command = ["sudo", "-n"] + build_self_command(args, as_root=True)
+    forwarded = build_self_command(args, as_root=True)
+    forwarded[0] = str(trusted_root_python_bin())
+    for index, token in enumerate(forwarded[:-1]):
+        if token == "--python-bin":
+            forwarded[index + 1] = str(trusted_root_python_bin())
+    if not args.skills_root:
+        forwarded.extend(
+            token
+            for path in candidate_skills_roots(args)
+            for token in ("--skills-root", str(path))
+        )
+    command = ["sudo", "-n"] + forwarded
     result = run_command(command)
     print_subprocess_output(result)
     return result.returncode
@@ -472,8 +558,9 @@ def access_denied(stderr: str) -> bool:
 
 
 def render_preflight(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJobSpec]]) -> int:
-    python_bin = Path(args.python_bin)
+    python_bin = Path(args.python_bin).expanduser()
     skills_roots = candidate_skills_roots(args)
+    manager_python = effective_manager_python(args)
     if python_bin.exists():
         version_result = run_command([str(python_bin), "--version"])
         invocation_python_version = version_result.stdout.strip() or version_result.stderr.strip() or "unknown"
@@ -484,6 +571,7 @@ def render_preflight(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJob
         "",
         f"- script_path: `{SCRIPT_PATH}`",
         f"- invocation_python: `{python_bin}`",
+        f"- manager_python: `{manager_python}`",
         f"- runtime_python: `{sys.executable}`",
         f"- invocation_python_exists: `{python_bin.exists()}`",
         f"- invocation_python_version: `{invocation_python_version}`",
@@ -513,6 +601,12 @@ def render_preflight(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJob
         source_exists = resolved.daemon_plist.exists()
         source_valid = plist_valid(resolved.daemon_plist) if source_exists else False
         target_exists = resolved.installed_target.exists()
+        trusted_for_privileged_actions = True
+        if action_needs_privileged_reexec("install"):
+            try:
+                validate_privileged_job_artifacts(resolved, manager_python)
+            except PermissionError:
+                trusted_for_privileged_actions = False
         lines.extend(
             [
                 f"## {job_name}",
@@ -524,15 +618,30 @@ def render_preflight(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJob
                 f"- source_path: `{resolved.daemon_plist}`",
                 f"- installed_target_exists: `{target_exists}`",
                 f"- installed_target_path: `{resolved.installed_target}`",
+                f"- privileged_trusted: `{trusted_for_privileged_actions}`",
                 "",
             ]
         )
-        all_ok = all_ok and manager_exists and source_exists and source_valid
+        all_ok = all_ok and manager_exists and source_exists and source_valid and trusted_for_privileged_actions
 
     probe_job_name = jobs[0][0]
-    probe_command = ["sudo", "-n"] + build_self_command(args, action="status", as_root=False, job_names=[probe_job_name])
+    probe_command = [
+        "sudo",
+        "-n",
+        str(trusted_root_python_bin()),
+        str(SCRIPT_PATH),
+        "status",
+        "--python-bin",
+        str(trusted_root_python_bin()),
+        "--sudoers-user",
+        args.sudoers_user,
+        "--job",
+        probe_job_name,
+    ]
+    for path in candidate_skills_roots(args):
+        probe_command.extend(["--skills-root", str(path)])
     probe_result = run_command(probe_command)
-    probe_access = not access_denied(probe_result.stderr or "")
+    probe_access = probe_result.returncode == 0 and not access_denied(probe_result.stderr or "")
     lines.extend(
         [
             "## sudo_probe",
@@ -575,8 +684,25 @@ def namespace_for_action(args: argparse.Namespace, action: str) -> argparse.Name
 
 
 def run_bootstrap(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJobSpec]]) -> int:
-    python_bin = Path(args.python_bin)
+    python_bin = effective_manager_python(args)
     # Bootstrap is the one-time setup path: install sudoers, then install the selected plists.
+    try:
+        validate_privileged_entrypoint(python_bin)
+    except PermissionError as exc:
+        print(
+            "\n".join(
+                [
+                    "# Dawn LaunchDaemon Bootstrap",
+                    "",
+                    f"- sudoers_target: `{SUDOERS_TARGET}`",
+                    f"- sudoers_user: `{args.sudoers_user}`",
+                    f"- invocation_python: `{python_bin}`",
+                    "- sudoers_installed: `False`",
+                    f"- detail: `{str(exc)}`",
+                ]
+            )
+        )
+        return 1
     sudoers_ok, sudoers_message = install_sudoers_dropin(
         user_name=args.sudoers_user,
         python_bin=python_bin,
@@ -608,7 +734,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print(
             sudoers_text(
                 user_name=args.sudoers_user,
-                python_bin=Path(args.python_bin),
+                python_bin=effective_manager_python(args),
                 script_path=SCRIPT_PATH,
             )
         )

--- a/scripts/manage_dawn_launchdaemons.py
+++ b/scripts/manage_dawn_launchdaemons.py
@@ -611,7 +611,7 @@ def render_batch_summary(args: argparse.Namespace, jobs: Sequence[tuple[str, Daw
                     hour=args.hour,
                     minute=args.minute,
                 )
-            except ScheduleOverrideError as exc:
+            except (OSError, ScheduleOverrideError) as exc:
                 all_ok = False
                 summary_lines.extend(summarize_resolution_error(job_name, exc))
                 if index != len(jobs) - 1:

--- a/scripts/manage_dawn_launchdaemons.py
+++ b/scripts/manage_dawn_launchdaemons.py
@@ -196,7 +196,7 @@ def path_is_root_owned_and_locked(path: Path) -> bool:
 
 
 def privileged_root_requested(args: argparse.Namespace) -> bool:
-    if args.action == "status" and args.as_root and os.geteuid() == 0:
+    if args.action == "status" and os.geteuid() == 0:
         return True
     return action_needs_privileged_reexec(args.action) and (args.as_root or os.geteuid() == 0)
 

--- a/scripts/manage_dawn_launchdaemons.py
+++ b/scripts/manage_dawn_launchdaemons.py
@@ -28,6 +28,8 @@ from typing import Iterator, Optional, Sequence
 SCRIPT_PATH = Path(__file__).resolve()
 REPO_ROOT = SCRIPT_PATH.parents[1]
 SUDOERS_TARGET = Path("/etc/sudoers.d/agentdesk-dawn-manager")
+MANAGED_ENTRYPOINT_DIR = Path("/usr/local/libexec/agentdesk")
+MANAGED_ENTRYPOINT = MANAGED_ENTRYPOINT_DIR / SCRIPT_PATH.name
 
 
 @dataclass(frozen=True)
@@ -207,19 +209,50 @@ def effective_manager_python(args: argparse.Namespace) -> Path:
     return Path(args.python_bin).expanduser()
 
 
-def validate_privileged_entrypoint(python_bin: Path) -> None:
-    for label, path in (
-        ("manager_python", python_bin),
-        ("script_path", SCRIPT_PATH),
-    ):
+def managed_entrypoint_target() -> Path:
+    return MANAGED_ENTRYPOINT
+
+
+def privileged_reexec_script_path() -> Path:
+    target = managed_entrypoint_target()
+    return target if target.exists() else SCRIPT_PATH
+
+
+def install_managed_entrypoint(source_path: Path = SCRIPT_PATH) -> Path:
+    target = managed_entrypoint_target()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    os.chmod(target.parent, 0o755)
+    tmp = tempfile.NamedTemporaryFile(prefix="agentdesk-dawn-manager-", dir=target.parent, delete=False)
+    tmp_path = Path(tmp.name)
+    tmp.close()
+    try:
+        shutil.copyfile(source_path, tmp_path)
+        os.chmod(tmp_path, 0o755)
+        tmp_path.replace(target)
+        os.chmod(target, 0o755)
+        return target
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+
+
+def validate_privileged_entrypoint(python_bin: Path, script_path: Optional[Path] = None) -> None:
+    paths: list[tuple[str, Path]] = [("manager_python", python_bin)]
+    if script_path is not None:
+        paths.append(("script_path", script_path))
+    for label, path in paths:
         if not path_is_root_owned_and_locked(path):
             raise PermissionError(
                 f"{label} must be root-owned and not group/other-writable for privileged actions: {path}"
             )
 
 
-def validate_privileged_job_artifacts(job: ResolvedDawnJob, python_bin: Path) -> None:
-    validate_privileged_entrypoint(python_bin)
+def validate_privileged_job_artifacts(
+    job: ResolvedDawnJob,
+    python_bin: Path,
+    script_path: Optional[Path] = None,
+) -> None:
+    validate_privileged_entrypoint(python_bin, script_path)
     for label, path in (
         ("skill_root", job.skill_root),
         ("manager_script", job.manager_script),
@@ -446,7 +479,11 @@ def render_batch_summary(args: argparse.Namespace, jobs: Sequence[tuple[str, Daw
         else:
             if privileged_root_requested(args):
                 try:
-                    validate_privileged_job_artifacts(resolved, manager_python)
+                    validate_privileged_job_artifacts(
+                        resolved,
+                        manager_python,
+                        privileged_reexec_script_path(),
+                    )
                 except PermissionError as exc:
                     all_ok = False
                     summary_lines.extend(summarize_resolution_error(job_name, exc))
@@ -505,6 +542,7 @@ def run_via_sudo(args: argparse.Namespace) -> int:
     # Keep the public operator entrypoint stable; privilege escalation only re-enters this script.
     forwarded = build_self_command(args, as_root=True)
     forwarded[0] = str(trusted_root_python_bin())
+    forwarded[1] = str(privileged_reexec_script_path())
     for index, token in enumerate(forwarded[:-1]):
         if token == "--python-bin":
             forwarded[index + 1] = str(trusted_root_python_bin())
@@ -525,7 +563,7 @@ def build_preflight_probe_command(args: argparse.Namespace, probe_job_name: str)
         "sudo",
         "-n",
         str(trusted_root_python_bin()),
-        str(SCRIPT_PATH),
+        str(privileged_reexec_script_path()),
         "--as-root",
         "status",
         "--python-bin",
@@ -614,6 +652,8 @@ def render_preflight(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJob
     python_bin = Path(args.python_bin).expanduser()
     skills_roots = candidate_skills_roots(args)
     manager_python = trusted_root_python_bin()
+    managed_script = managed_entrypoint_target()
+    managed_script_exists = managed_script.exists()
     if python_bin.exists():
         version_result = run_command([str(python_bin), "--version"])
         invocation_python_version = version_result.stdout.strip() or version_result.stderr.strip() or "unknown"
@@ -625,6 +665,8 @@ def render_preflight(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJob
         f"- script_path: `{SCRIPT_PATH}`",
         f"- invocation_python: `{python_bin}`",
         f"- manager_python: `{manager_python}`",
+        f"- managed_entrypoint: `{managed_script}`",
+        f"- managed_entrypoint_exists: `{managed_script_exists}`",
         f"- runtime_python: `{sys.executable}`",
         f"- invocation_python_exists: `{python_bin.exists()}`",
         f"- invocation_python_version: `{invocation_python_version}`",
@@ -657,7 +699,11 @@ def render_preflight(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJob
         trusted_for_privileged_actions = True
         if action_needs_privileged_reexec("install"):
             try:
-                validate_privileged_job_artifacts(resolved, manager_python)
+                validate_privileged_job_artifacts(
+                    resolved,
+                    manager_python,
+                    managed_script if managed_script_exists else None,
+                )
             except PermissionError:
                 trusted_for_privileged_actions = False
         lines.extend(
@@ -726,14 +772,16 @@ def run_bootstrap(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJobSpe
     python_bin = effective_manager_python(args)
     # Bootstrap is the one-time setup path: install sudoers, then install the selected plists.
     try:
-        validate_privileged_entrypoint(python_bin)
-    except PermissionError as exc:
+        managed_script_path = install_managed_entrypoint()
+        validate_privileged_entrypoint(python_bin, managed_script_path)
+    except (OSError, PermissionError) as exc:
         print(
             "\n".join(
                 [
                     "# Dawn LaunchDaemon Bootstrap",
                     "",
                     f"- sudoers_target: `{SUDOERS_TARGET}`",
+                    f"- managed_entrypoint: `{managed_entrypoint_target()}`",
                     f"- sudoers_user: `{args.sudoers_user}`",
                     f"- invocation_python: `{python_bin}`",
                     "- sudoers_installed: `False`",
@@ -745,13 +793,14 @@ def run_bootstrap(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJobSpe
     sudoers_ok, sudoers_message = install_sudoers_dropin(
         user_name=args.sudoers_user,
         python_bin=python_bin,
-        script_path=SCRIPT_PATH,
+        script_path=managed_script_path,
     )
 
     lines = [
         "# Dawn LaunchDaemon Bootstrap",
         "",
         f"- sudoers_target: `{SUDOERS_TARGET}`",
+        f"- managed_entrypoint: `{managed_script_path}`",
         f"- sudoers_user: `{args.sudoers_user}`",
         f"- invocation_python: `{python_bin}`",
         f"- sudoers_installed: `{sudoers_ok}`",
@@ -774,7 +823,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             sudoers_text(
                 user_name=args.sudoers_user,
                 python_bin=effective_manager_python(args),
-                script_path=SCRIPT_PATH,
+                script_path=managed_entrypoint_target(),
             )
         )
         return 0

--- a/scripts/manage_dawn_launchdaemons.py
+++ b/scripts/manage_dawn_launchdaemons.py
@@ -155,7 +155,23 @@ def default_skills_roots() -> list[Path]:
 
 
 def trusted_root_python_bin() -> Path:
-    return preferred_python_bin().expanduser().resolve()
+    candidates = unique_paths(
+        [
+            preferred_python_bin().expanduser().resolve(),
+            Path("/usr/bin/python3"),
+            Path("/usr/bin/python"),
+            Path(sys.executable).expanduser().resolve(),
+        ]
+        + [
+            Path(candidate).expanduser().resolve()
+            for candidate in (shutil.which("python3"), shutil.which("python"))
+            if candidate
+        ]
+    )
+    for candidate in candidates:
+        if path_is_root_owned_and_locked(candidate):
+            return candidate
+    return candidates[0]
 
 
 def path_is_root_owned_and_locked(path: Path) -> bool:

--- a/scripts/manage_dawn_launchdaemons.py
+++ b/scripts/manage_dawn_launchdaemons.py
@@ -167,6 +167,8 @@ def path_is_root_owned_and_locked(path: Path) -> bool:
 
 
 def privileged_root_requested(args: argparse.Namespace) -> bool:
+    if args.action == "status" and args.as_root and os.geteuid() == 0:
+        return True
     return action_needs_privileged_reexec(args.action) and (args.as_root or os.geteuid() == 0)
 
 
@@ -488,6 +490,26 @@ def run_via_sudo(args: argparse.Namespace) -> int:
     return result.returncode
 
 
+def build_preflight_probe_command(args: argparse.Namespace, probe_job_name: str) -> list[str]:
+    command = [
+        "sudo",
+        "-n",
+        str(trusted_root_python_bin()),
+        str(SCRIPT_PATH),
+        "--as-root",
+        "status",
+        "--python-bin",
+        str(trusted_root_python_bin()),
+        "--sudoers-user",
+        args.sudoers_user,
+        "--job",
+        probe_job_name,
+    ]
+    for path in candidate_skills_roots(args):
+        command.extend(["--skills-root", str(path)])
+    return command
+
+
 def plist_valid(path: Path) -> bool:
     if not path.exists():
         return False
@@ -625,21 +647,7 @@ def render_preflight(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJob
         all_ok = all_ok and manager_exists and source_exists and source_valid and trusted_for_privileged_actions
 
     probe_job_name = jobs[0][0]
-    probe_command = [
-        "sudo",
-        "-n",
-        str(trusted_root_python_bin()),
-        str(SCRIPT_PATH),
-        "status",
-        "--python-bin",
-        str(trusted_root_python_bin()),
-        "--sudoers-user",
-        args.sudoers_user,
-        "--job",
-        probe_job_name,
-    ]
-    for path in candidate_skills_roots(args):
-        probe_command.extend(["--skills-root", str(path)])
+    probe_command = build_preflight_probe_command(args, probe_job_name)
     probe_result = run_command(probe_command)
     probe_access = probe_result.returncode == 0 and not access_denied(probe_result.stderr or "")
     lines.extend(

--- a/scripts/manage_dawn_launchdaemons.py
+++ b/scripts/manage_dawn_launchdaemons.py
@@ -588,12 +588,24 @@ def plist_valid(path: Path) -> bool:
     return run_command(["plutil", "-lint", str(path)]).returncode == 0
 
 
-def sudoers_text(*, user_name: str, python_bin: Path, script_path: Path) -> str:
+def sudoers_text(
+    *,
+    user_name: str,
+    python_bin: Path,
+    script_path: Path,
+    bootstrap_required: bool = False,
+) -> str:
     safe_user_name = validate_sudoers_user_name(user_name)
-    return "\n".join(
+    lines = [
+        "# /etc/sudoers.d/agentdesk-dawn-manager",
+        "# Install with: sudo visudo -f /etc/sudoers.d/agentdesk-dawn-manager",
+    ]
+    if bootstrap_required:
+        lines.append(
+            "# First-time setup still requires `sudo ... manage_dawn_launchdaemons.py bootstrap`"
+        )
+    lines.extend(
         [
-            "# /etc/sudoers.d/agentdesk-dawn-manager",
-            "# Install with: sudo visudo -f /etc/sudoers.d/agentdesk-dawn-manager",
             "",
             f"User_Alias AGENTDESK_RUNTIME = {safe_user_name}",
             "",
@@ -603,6 +615,7 @@ def sudoers_text(*, user_name: str, python_bin: Path, script_path: Path) -> str:
             "AGENTDESK_RUNTIME ALL = (root) NOPASSWD: AGENTDESK_DAWN_MANAGER",
         ]
     )
+    return "\n".join(lines)
 
 
 def visudo_bin() -> Path:
@@ -839,6 +852,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 user_name=args.sudoers_user,
                 python_bin=trusted_root_python_bin(),
                 script_path=managed_entrypoint_target(),
+                bootstrap_required=not managed_entrypoint_target().exists(),
             )
         )
         return 0

--- a/scripts/manage_dawn_launchdaemons.py
+++ b/scripts/manage_dawn_launchdaemons.py
@@ -30,6 +30,7 @@ REPO_ROOT = SCRIPT_PATH.parents[1]
 SUDOERS_TARGET = Path("/etc/sudoers.d/agentdesk-dawn-manager")
 MANAGED_ENTRYPOINT_DIR = Path("/usr/local/libexec/agentdesk")
 MANAGED_ENTRYPOINT = MANAGED_ENTRYPOINT_DIR / SCRIPT_PATH.name
+MANAGED_SKILLS_DIR = MANAGED_ENTRYPOINT_DIR / "skills"
 
 
 @dataclass(frozen=True)
@@ -222,6 +223,69 @@ def privileged_reexec_script_path() -> Path:
     return target if target.exists() else SCRIPT_PATH
 
 
+def managed_skill_root(spec: DawnJobSpec) -> Path:
+    return MANAGED_SKILLS_DIR / spec.skill_name
+
+
+def resolve_managed_job_artifacts(job_name: str, spec: DawnJobSpec) -> ResolvedDawnJob:
+    skill_root = managed_skill_root(spec)
+    manager_script = skill_root / spec.manager_relpath
+    daemon_plist = skill_root / spec.daemon_plist_relpath
+    missing: list[str] = []
+    if not manager_script.exists():
+        missing.append(str(manager_script))
+    if not daemon_plist.exists():
+        missing.append(str(daemon_plist))
+    if missing:
+        raise FileNotFoundError(
+            f"managed artifacts for `{job_name}` are missing: {', '.join(missing)}; "
+            "run `sudo ... manage_dawn_launchdaemons.py bootstrap` to install trusted copies"
+        )
+    return ResolvedDawnJob(
+        name=job_name,
+        skill_root=skill_root,
+        manager_script=manager_script,
+        daemon_plist=daemon_plist,
+    )
+
+
+def copy_locked_file(source: Path, target: Path, *, mode: int) -> Path:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    os.chmod(target.parent, 0o755)
+    tmp = tempfile.NamedTemporaryFile(prefix=f"{target.name}-", dir=target.parent, delete=False)
+    tmp_path = Path(tmp.name)
+    tmp.close()
+    try:
+        shutil.copyfile(source, tmp_path)
+        os.chmod(tmp_path, mode)
+        tmp_path.replace(target)
+        os.chmod(target, mode)
+        return target
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+
+
+def install_managed_job_artifacts(source_job: ResolvedDawnJob, spec: DawnJobSpec) -> ResolvedDawnJob:
+    skill_root = managed_skill_root(spec)
+    manager_script = copy_locked_file(
+        source_job.manager_script,
+        skill_root / spec.manager_relpath,
+        mode=0o755,
+    )
+    daemon_plist = copy_locked_file(
+        source_job.daemon_plist,
+        skill_root / spec.daemon_plist_relpath,
+        mode=0o644,
+    )
+    return ResolvedDawnJob(
+        name=source_job.name,
+        skill_root=skill_root,
+        manager_script=manager_script,
+        daemon_plist=daemon_plist,
+    )
+
+
 def install_managed_entrypoint(source_path: Path = SCRIPT_PATH) -> Path:
     target = managed_entrypoint_target()
     target.parent.mkdir(parents=True, exist_ok=True)
@@ -258,7 +322,6 @@ def validate_privileged_job_artifacts(
 ) -> None:
     validate_privileged_entrypoint(python_bin, script_path)
     for label, path in (
-        ("skill_root", job.skill_root),
         ("manager_script", job.manager_script),
         ("daemon_plist", job.daemon_plist),
     ):
@@ -291,7 +354,7 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
             "  status     inspect configured jobs without requiring root by default\n"
             "  uninstall  remove installed LaunchDaemon plists\n"
             "  preflight  verify python path, skill roots, plist validity, and sudo readiness\n"
-            "  sudoers    print the managed-entrypoint sudoers drop-in for manual review"
+            "  sudoers    print the post-bootstrap managed-entrypoint sudoers drop-in for manual review"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -476,7 +539,11 @@ def render_batch_summary(args: argparse.Namespace, jobs: Sequence[tuple[str, Daw
 
     for index, (job_name, spec) in enumerate(jobs):
         try:
-            resolved = resolve_job_artifacts(job_name, spec, skills_roots=skills_roots)
+            resolved = (
+                resolve_managed_job_artifacts(job_name, spec)
+                if privileged_root_requested(args)
+                else resolve_job_artifacts(job_name, spec, skills_roots=skills_roots)
+            )
         except FileNotFoundError as exc:
             all_ok = False
             summary_lines.extend(summarize_resolution_error(job_name, exc))
@@ -604,6 +671,9 @@ def sudoers_text(
         lines.append(
             "# First-time setup still requires `sudo ... manage_dawn_launchdaemons.py bootstrap`"
         )
+        lines.append(
+            "# This sudoers stanza targets the managed root-owned entrypoint installed by bootstrap."
+        )
     lines.extend(
         [
             "",
@@ -706,7 +776,11 @@ def render_preflight(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJob
     all_ok = path_is_executable(python_bin)
     for job_name, spec in jobs:
         try:
-            resolved = resolve_job_artifacts(job_name, spec, skills_roots=skills_roots)
+            resolved = (
+                resolve_managed_job_artifacts(job_name, spec)
+                if privileged_root_requested(args)
+                else resolve_job_artifacts(job_name, spec, skills_roots=skills_roots)
+            )
         except FileNotFoundError as exc:
             lines.extend(
                 [
@@ -802,7 +876,11 @@ def run_bootstrap(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJobSpe
     try:
         managed_script_path = install_managed_entrypoint()
         validate_privileged_entrypoint(python_bin, managed_script_path)
-    except (OSError, PermissionError) as exc:
+        source_roots = candidate_skills_roots(args)
+        for job_name, spec in jobs:
+            source_job = resolve_job_artifacts(job_name, spec, skills_roots=source_roots)
+            install_managed_job_artifacts(source_job, spec)
+    except (OSError, PermissionError, FileNotFoundError) as exc:
         print(
             "\n".join(
                 [

--- a/scripts/manage_dawn_launchdaemons.py
+++ b/scripts/manage_dawn_launchdaemons.py
@@ -197,6 +197,10 @@ def path_is_root_owned_and_locked(path: Path) -> bool:
     return st.st_uid == 0 and not (st.st_mode & (stat.S_IWGRP | stat.S_IWOTH))
 
 
+def path_is_executable(path: Path) -> bool:
+    return path.exists() and os.access(path, os.X_OK)
+
+
 def privileged_root_requested(args: argparse.Namespace) -> bool:
     if args.action == "status" and os.geteuid() == 0:
         return True
@@ -287,7 +291,7 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
             "  status     inspect configured jobs without requiring root by default\n"
             "  uninstall  remove installed LaunchDaemon plists\n"
             "  preflight  verify python path, skill roots, plist validity, and sudo readiness\n"
-            "  sudoers    print the exact sudoers drop-in content for manual review"
+            "  sudoers    print the managed-entrypoint sudoers drop-in for manual review"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -649,14 +653,23 @@ def access_denied(stderr: str) -> bool:
 
 
 def render_preflight(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJobSpec]]) -> int:
-    python_bin = Path(args.python_bin).expanduser()
+    requested_python_bin = Path(args.python_bin).expanduser()
+    python_bin = trusted_root_python_bin() if os.geteuid() == 0 else requested_python_bin
     skills_roots = candidate_skills_roots(args)
     manager_python = trusted_root_python_bin()
     managed_script = managed_entrypoint_target()
     managed_script_exists = managed_script.exists()
-    if python_bin.exists():
-        version_result = run_command([str(python_bin), "--version"])
-        invocation_python_version = version_result.stdout.strip() or version_result.stderr.strip() or "unknown"
+    if path_is_executable(python_bin):
+        try:
+            version_result = run_command([str(python_bin), "--version"])
+        except OSError as exc:
+            invocation_python_version = str(exc)
+        else:
+            invocation_python_version = (
+                version_result.stdout.strip() or version_result.stderr.strip() or "unknown"
+            )
+    elif python_bin.exists():
+        invocation_python_version = "not executable"
     else:
         invocation_python_version = "missing"
     lines = [
@@ -664,18 +677,20 @@ def render_preflight(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJob
         "",
         f"- script_path: `{SCRIPT_PATH}`",
         f"- invocation_python: `{python_bin}`",
+        f"- requested_python: `{requested_python_bin}`",
         f"- manager_python: `{manager_python}`",
         f"- managed_entrypoint: `{managed_script}`",
         f"- managed_entrypoint_exists: `{managed_script_exists}`",
         f"- runtime_python: `{sys.executable}`",
         f"- invocation_python_exists: `{python_bin.exists()}`",
+        f"- invocation_python_executable: `{path_is_executable(python_bin)}`",
         f"- invocation_python_version: `{invocation_python_version}`",
         f"- sudoers_user: `{args.sudoers_user}`",
         f"- skills_roots: `{', '.join(str(path) for path in skills_roots) or '(none)'}`",
         "",
     ]
 
-    all_ok = python_bin.exists()
+    all_ok = path_is_executable(python_bin)
     for job_name, spec in jobs:
         try:
             resolved = resolve_job_artifacts(job_name, spec, skills_roots=skills_roots)
@@ -746,8 +761,8 @@ def render_preflight(args: argparse.Namespace, jobs: Sequence[tuple[str, DawnJob
         [
             "",
             "## next_steps",
-            f"- install sudoers file with `python3 {SCRIPT_PATH} sudoers` output",
-            f"- or run `sudo {python_bin} {SCRIPT_PATH} bootstrap` once",
+            f"- first bootstrap with `sudo {manager_python} {SCRIPT_PATH} bootstrap`",
+            f"- after bootstrap, review or refresh the sudoers drop-in with `python3 {SCRIPT_PATH} sudoers`",
             f"- status can be checked with `python3 {SCRIPT_PATH} status`",
         ]
     )
@@ -822,7 +837,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print(
             sudoers_text(
                 user_name=args.sudoers_user,
-                python_bin=effective_manager_python(args),
+                python_bin=trusted_root_python_bin(),
                 script_path=managed_entrypoint_target(),
             )
         )

--- a/src/services/discord/org_schema.rs
+++ b/src/services/discord/org_schema.rs
@@ -634,11 +634,9 @@ channels:
 
     #[test]
     fn test_channel_binding_memory_overrides_agent_memory_defaults() {
-        with_temp_root(|temp_home: &TempDir| {
-            let _mem0_env = Mem0EnvGuard::install();
-            write_org_yaml(
-                temp_home.path(),
-                r#"
+        let _mem0_env = Mem0EnvGuard::install();
+        let schema: OrgSchema = serde_yaml::from_str(
+            r#"
 version: 1
 agents:
   spark:
@@ -663,22 +661,27 @@ channels:
           ingestion:
             custom_instructions: "Prefer high-confidence facts"
 "#,
-            );
+        )
+        .expect("parse org schema");
 
-            let binding = resolve_role_binding(ChannelId::new(1488022491992424448), None).unwrap();
-            assert_eq!(
-                binding.memory.backend,
-                super::super::settings::MemoryBackendKind::Mem0
-            );
-            assert_eq!(binding.memory.recall_timeout_ms, 100);
-            assert_eq!(binding.memory.capture_timeout_ms, 7000);
-            assert_eq!(binding.memory.mem0.profile, "strict");
-            assert_eq!(binding.memory.mem0.ingestion.infer, Some(false));
-            assert_eq!(
-                binding.memory.mem0.ingestion.custom_instructions.as_deref(),
-                Some("Prefer high-confidence facts")
-            );
-        });
+        let (channel_binding, agent_def) =
+            resolve_channel_binding(&schema, ChannelId::new(1488022491992424448), None)
+                .expect("resolve channel binding");
+        let memory =
+            resolve_memory_settings(agent_def.memory.as_ref(), channel_binding.memory.as_ref());
+
+        assert_eq!(
+            memory.backend,
+            super::super::settings::MemoryBackendKind::Mem0
+        );
+        assert_eq!(memory.recall_timeout_ms, 100);
+        assert_eq!(memory.capture_timeout_ms, 7000);
+        assert_eq!(memory.mem0.profile, "strict");
+        assert_eq!(memory.mem0.ingestion.infer, Some(false));
+        assert_eq!(
+            memory.mem0.ingestion.custom_instructions.as_deref(),
+            Some("Prefer high-confidence facts")
+        );
     }
 
     #[test]

--- a/tests/test_manage_dawn_launchdaemons.py
+++ b/tests/test_manage_dawn_launchdaemons.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from types import SimpleNamespace
 from pathlib import Path
 from unittest import mock
 
@@ -227,6 +228,32 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
                 Path("/usr/bin/python3"),
                 Path("/usr/local/libexec/agentdesk/manage_dawn_launchdaemons.py"),
             )
+
+    def test_path_is_root_owned_and_locked_rejects_group_writable_parent(self) -> None:
+        target = Path("/usr/local/libexec/agentdesk/manage_dawn_launchdaemons.py")
+        stats = {
+            target: SimpleNamespace(st_uid=0, st_mode=0o100755),
+            target.parent: SimpleNamespace(st_uid=0, st_mode=0o040755),
+            target.parent.parent: SimpleNamespace(st_uid=0, st_mode=0o040755),
+            target.parent.parent.parent: SimpleNamespace(st_uid=0, st_mode=0o040775),
+            Path("/usr"): SimpleNamespace(st_uid=0, st_mode=0o040755),
+            Path("/"): SimpleNamespace(st_uid=0, st_mode=0o040755),
+        }
+        path_type = type(Path("/"))
+
+        with mock.patch.object(
+            path_type,
+            "is_symlink",
+            autospec=True,
+            side_effect=lambda self: False,
+        ):
+            with mock.patch.object(
+                path_type,
+                "stat",
+                autospec=True,
+                side_effect=lambda self: stats[Path(str(self))],
+            ):
+                self.assertFalse(MODULE.path_is_root_owned_and_locked(target))
 
     def test_resolve_job_artifacts_prefers_existing_skills_root(self) -> None:
         spec = MODULE.JOB_SPECS["memory-dream"]

--- a/tests/test_manage_dawn_launchdaemons.py
+++ b/tests/test_manage_dawn_launchdaemons.py
@@ -638,6 +638,63 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
         run_manager.assert_called_once()
         self.assertEqual(run_manager.call_args.args[0], managed_job)
 
+    def test_render_batch_summary_reports_schedule_override_error_per_job(self) -> None:
+        args = argparse.Namespace(
+            action="install",
+            job=["memory-dream", "service-monitoring"],
+            hour=5,
+            minute=30,
+            python_bin="/usr/bin/python3",
+            sudoers_user="agentdesk-runtime",
+            skills_root=None,
+            as_root=False,
+        )
+        first_job = MODULE.ResolvedDawnJob(
+            name="memory-dream",
+            skill_root=Path("/Users/agentdesk/.codex/skills/memory-dream"),
+            manager_script=Path("/Users/agentdesk/.codex/skills/memory-dream/scripts/manage_memory_dream_launchd.py"),
+            daemon_plist=Path("/Users/agentdesk/.codex/skills/memory-dream/launchd/com.agentdesk.memory-dream-dawn.plist"),
+        )
+        second_job = MODULE.ResolvedDawnJob(
+            name="service-monitoring",
+            skill_root=Path("/Users/agentdesk/.codex/skills/service-monitoring"),
+            manager_script=Path("/Users/agentdesk/.codex/skills/service-monitoring/scripts/manage_service_monitoring_launchd.py"),
+            daemon_plist=Path("/Users/agentdesk/.codex/skills/service-monitoring/launchd/com.agentdesk.service-monitoring-dawn.plist"),
+        )
+        run_result = subprocess.CompletedProcess(["python3"], 0, stdout="ok", stderr="")
+
+        with mock.patch.object(MODULE, "candidate_skills_roots", return_value=[Path("/Users/agentdesk/.codex/skills")]):
+            with mock.patch.object(MODULE, "effective_manager_python", return_value=Path("/usr/bin/python3")):
+                with mock.patch.object(
+                    MODULE,
+                    "resolve_job_artifacts",
+                    side_effect=[first_job, second_job],
+                ):
+                    with mock.patch.object(
+                        MODULE,
+                        "run_manager",
+                        side_effect=[
+                            MODULE.ScheduleOverrideError("failed to build schedule override from `/tmp/bad.plist`: malformed"),
+                            run_result,
+                        ],
+                    ) as run_manager:
+                        with mock.patch("builtins.print") as print_mock:
+                            rc = MODULE.render_batch_summary(
+                                args,
+                                [
+                                    ("memory-dream", MODULE.JOB_SPECS["memory-dream"]),
+                                    ("service-monitoring", MODULE.JOB_SPECS["service-monitoring"]),
+                                ],
+                            )
+
+        self.assertEqual(rc, 1)
+        self.assertEqual(run_manager.call_count, 2)
+        rendered = print_mock.call_args.args[0]
+        self.assertIn("## memory-dream", rendered)
+        self.assertIn("failed to build schedule override", rendered)
+        self.assertIn("## service-monitoring", rendered)
+        self.assertIn("- output: `ok`", rendered)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_manage_dawn_launchdaemons.py
+++ b/tests/test_manage_dawn_launchdaemons.py
@@ -4,9 +4,10 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
-SCRIPT_PATH = Path("/Users/kunkun/kunkunGames/agentdesk/scripts/manage_dawn_launchdaemons.py")
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts/manage_dawn_launchdaemons.py"
 SPEC = importlib.util.spec_from_file_location("manage_dawn_launchdaemons", SCRIPT_PATH)
 MODULE = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
@@ -33,6 +34,7 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
             hour=5,
             minute=30,
             python_bin="/opt/homebrew/bin/python3",
+            sudoers_user="agentdesk-runtime",
             skills_root=["/tmp/skills-a", "/tmp/skills-b"],
         )
 
@@ -42,8 +44,10 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
         self.assertIn("--job", command)
         self.assertIn("memory-dream", command)
         self.assertIn("service-monitoring", command)
+        self.assertIn("--sudoers-user", command)
+        self.assertIn("agentdesk-runtime", command)
         self.assertEqual(
-            command[-10:],
+            command[-12:],
             [
                 "--hour",
                 "5",
@@ -51,6 +55,8 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
                 "30",
                 "--python-bin",
                 "/opt/homebrew/bin/python3",
+                "--sudoers-user",
+                "agentdesk-runtime",
                 "--skills-root",
                 "/tmp/skills-a",
                 "--skills-root",
@@ -86,6 +92,14 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
             self.assertEqual(resolved.skill_root, skill_root)
             self.assertEqual(resolved.manager_script, skill_root / spec.manager_relpath)
             self.assertEqual(resolved.daemon_plist, skill_root / spec.daemon_plist_relpath)
+
+    def test_default_skills_roots_prefers_sudo_user_home(self) -> None:
+        with mock.patch.dict(MODULE.os.environ, {"SUDO_USER": "agentdesk"}, clear=False):
+            with mock.patch.object(MODULE, "home_for_user", return_value=Path("/Users/agentdesk")):
+                roots = MODULE.default_skills_roots()
+
+        self.assertIn(Path("/Users/agentdesk/.codex/skills"), roots)
+        self.assertIn(Path("/Users/agentdesk/.adk/release/skills"), roots)
 
 
 if __name__ == "__main__":

--- a/tests/test_manage_dawn_launchdaemons.py
+++ b/tests/test_manage_dawn_launchdaemons.py
@@ -126,7 +126,7 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
         )
 
     def test_status_as_root_is_treated_as_privileged_probe(self) -> None:
-        args = argparse.Namespace(action="status", as_root=True)
+        args = argparse.Namespace(action="status", as_root=False)
 
         with mock.patch.object(MODULE.os, "geteuid", return_value=0):
             self.assertTrue(MODULE.privileged_root_requested(args))

--- a/tests/test_manage_dawn_launchdaemons.py
+++ b/tests/test_manage_dawn_launchdaemons.py
@@ -125,6 +125,49 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
             ],
         )
 
+    def test_run_via_sudo_prefers_managed_entrypoint_when_present(self) -> None:
+        args = argparse.Namespace(
+            action="install",
+            job=["memory-dream"],
+            hour=None,
+            minute=None,
+            python_bin="/opt/homebrew/bin/python3",
+            sudoers_user="agentdesk-runtime",
+            skills_root=None,
+            as_root=False,
+        )
+
+        run_result = subprocess.CompletedProcess(["sudo"], 0, stdout="", stderr="")
+        with mock.patch.object(MODULE, "trusted_root_python_bin", return_value=Path("/usr/bin/python3")):
+            with mock.patch.object(
+                MODULE,
+                "privileged_reexec_script_path",
+                return_value=Path("/usr/local/libexec/agentdesk/manage_dawn_launchdaemons.py"),
+            ):
+                with mock.patch.object(MODULE, "candidate_skills_roots", return_value=[]):
+                    with mock.patch.object(MODULE, "run_command", return_value=run_result) as run_command:
+                        MODULE.run_via_sudo(args)
+
+        command = run_command.call_args.args[0]
+        self.assertEqual(command[:6], [
+            "sudo",
+            "-n",
+            "/usr/bin/python3",
+            "/usr/local/libexec/agentdesk/manage_dawn_launchdaemons.py",
+            "--as-root",
+            "install",
+        ])
+
+    def test_install_managed_entrypoint_copies_script_to_target(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "libexec/agentdesk/manage_dawn_launchdaemons.py"
+
+            with mock.patch.object(MODULE, "managed_entrypoint_target", return_value=target):
+                installed = MODULE.install_managed_entrypoint(SCRIPT_PATH)
+                self.assertEqual(installed, target)
+                self.assertTrue(target.exists())
+                self.assertEqual(target.read_text(encoding="utf-8"), SCRIPT_PATH.read_text(encoding="utf-8"))
+
     def test_status_as_root_is_treated_as_privileged_probe(self) -> None:
         args = argparse.Namespace(action="status", as_root=False)
 
@@ -199,9 +242,14 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
         )
         seen: dict[str, Path] = {}
 
-        def fake_validate(job: MODULE.ResolvedDawnJob, python_bin: Path) -> None:
+        def fake_validate(
+            job: MODULE.ResolvedDawnJob,
+            python_bin: Path,
+            script_path: Path | None = None,
+        ) -> None:
             self.assertEqual(job, resolved)
             seen["python_bin"] = python_bin
+            seen["script_path"] = script_path
 
         def fake_run(command: list[str]) -> subprocess.CompletedProcess[str]:
             if command == ["/opt/homebrew/bin/python3", "--version"]:
@@ -226,6 +274,7 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
                                         )
 
         self.assertEqual(seen["python_bin"], Path("/usr/bin/python3"))
+        self.assertIsNone(seen["script_path"])
 
 
 if __name__ == "__main__":

--- a/tests/test_manage_dawn_launchdaemons.py
+++ b/tests/test_manage_dawn_launchdaemons.py
@@ -1,5 +1,6 @@
 import argparse
 import importlib.util
+import os
 import subprocess
 import sys
 import tempfile
@@ -175,10 +176,27 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
             target = Path(tmpdir) / "libexec/agentdesk/manage_dawn_launchdaemons.py"
 
             with mock.patch.object(MODULE, "managed_entrypoint_target", return_value=target):
-                installed = MODULE.install_managed_entrypoint(SCRIPT_PATH)
-                self.assertEqual(installed, target)
-                self.assertTrue(target.exists())
-                self.assertEqual(target.read_text(encoding="utf-8"), SCRIPT_PATH.read_text(encoding="utf-8"))
+                with mock.patch.object(MODULE, "MANAGED_ENTRYPOINT_DIR", target.parent):
+                    installed = MODULE.install_managed_entrypoint(SCRIPT_PATH)
+                    self.assertEqual(installed, target)
+                    self.assertTrue(target.exists())
+                    self.assertEqual(
+                        target.read_text(encoding="utf-8"),
+                        SCRIPT_PATH.read_text(encoding="utf-8"),
+                    )
+
+    def test_ensure_locked_directory_chain_normalizes_existing_managed_dirs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            anchor = Path(tmpdir) / "agentdesk"
+            nested = anchor / "skills/memory-dream/scripts"
+            nested.mkdir(parents=True, exist_ok=True)
+            for path in [anchor, anchor / "skills", anchor / "skills/memory-dream", nested]:
+                os.chmod(path, 0o775)
+
+            MODULE.ensure_locked_directory_chain(nested, anchor=anchor)
+
+            for path in [anchor, anchor / "skills", anchor / "skills/memory-dream", nested]:
+                self.assertEqual(path.stat().st_mode & 0o777, 0o755)
 
     def test_status_as_root_is_treated_as_privileged_probe(self) -> None:
         args = argparse.Namespace(action="status", as_root=False)
@@ -338,6 +356,80 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
 
         self.assertEqual(seen["python_bin"], Path("/usr/bin/python3"))
         self.assertIsNone(seen["script_path"])
+
+    def test_preflight_prefers_managed_artifacts_when_managed_entrypoint_exists(self) -> None:
+        args = argparse.Namespace(
+            action="preflight",
+            job=None,
+            hour=None,
+            minute=None,
+            python_bin="/opt/homebrew/bin/python3",
+            sudoers_user="agentdesk",
+            skills_root=None,
+            as_root=False,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            managed_script = tmpdir_path / "manage_dawn_launchdaemons.py"
+            managed_script.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+            managed_job = MODULE.ResolvedDawnJob(
+                name="memory-dream",
+                skill_root=tmpdir_path / "skills/memory-dream",
+                manager_script=tmpdir_path / "skills/memory-dream/scripts/manage_memory_dream_launchd.py",
+                daemon_plist=tmpdir_path / "skills/memory-dream/launchd/com.agentdesk.memory-dream-dawn.plist",
+            )
+            managed_job.manager_script.parent.mkdir(parents=True, exist_ok=True)
+            managed_job.manager_script.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+            managed_job.daemon_plist.parent.mkdir(parents=True, exist_ok=True)
+            managed_job.daemon_plist.write_text(
+                "<?xml version=\"1.0\"?>\n<plist version=\"1.0\"></plist>\n",
+                encoding="utf-8",
+            )
+            seen: dict[str, Path] = {}
+
+            def fake_validate(
+                job: MODULE.ResolvedDawnJob,
+                python_bin: Path,
+                script_path: Path | None = None,
+            ) -> None:
+                self.assertEqual(job, managed_job)
+                seen["python_bin"] = python_bin
+                seen["script_path"] = script_path
+
+            def fake_run(command: list[str]) -> subprocess.CompletedProcess[str]:
+                if command == ["/opt/homebrew/bin/python3", "--version"]:
+                    return subprocess.CompletedProcess(command, 0, stdout="Python 3.12.0\n", stderr="")
+                return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+            with mock.patch.object(MODULE, "candidate_skills_roots", return_value=[Path("/tmp/skills")]):
+                with mock.patch.object(MODULE, "managed_entrypoint_target", return_value=managed_script):
+                    with mock.patch.object(MODULE, "trusted_root_python_bin", return_value=Path("/usr/bin/python3")):
+                        with mock.patch.object(MODULE, "resolve_managed_job_artifacts", return_value=managed_job):
+                            with mock.patch.object(
+                                MODULE,
+                                "resolve_job_artifacts",
+                                side_effect=AssertionError("preflight should use managed artifacts once bootstrap installed them"),
+                            ):
+                                with mock.patch.object(MODULE, "plist_valid", return_value=True):
+                                    with mock.patch.object(
+                                        MODULE,
+                                        "validate_privileged_job_artifacts",
+                                        side_effect=fake_validate,
+                                    ):
+                                        with mock.patch.object(
+                                            MODULE,
+                                            "build_preflight_probe_command",
+                                            return_value=["sudo", "-n", "/usr/bin/python3", str(managed_script), "status"],
+                                        ):
+                                            with mock.patch.object(MODULE, "run_command", side_effect=fake_run):
+                                                with mock.patch("builtins.print"):
+                                                    MODULE.render_preflight(
+                                                        args,
+                                                        [("memory-dream", MODULE.JOB_SPECS["memory-dream"])],
+                                                    )
+
+            self.assertEqual(seen["python_bin"], Path("/usr/bin/python3"))
+            self.assertEqual(seen["script_path"], managed_script)
 
     def test_root_preflight_uses_trusted_python_for_version_probe(self) -> None:
         args = argparse.Namespace(

--- a/tests/test_manage_dawn_launchdaemons.py
+++ b/tests/test_manage_dawn_launchdaemons.py
@@ -670,28 +670,87 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
                     "resolve_job_artifacts",
                     side_effect=[first_job, second_job],
                 ):
-                    with mock.patch.object(
-                        MODULE,
-                        "run_manager",
-                        side_effect=[
-                            MODULE.ScheduleOverrideError("failed to build schedule override from `/tmp/bad.plist`: malformed"),
-                            run_result,
-                        ],
-                    ) as run_manager:
-                        with mock.patch("builtins.print") as print_mock:
-                            rc = MODULE.render_batch_summary(
-                                args,
-                                [
-                                    ("memory-dream", MODULE.JOB_SPECS["memory-dream"]),
-                                    ("service-monitoring", MODULE.JOB_SPECS["service-monitoring"]),
-                                ],
-                            )
+                    with mock.patch("os.geteuid", return_value=501):
+                        with mock.patch.object(
+                            MODULE,
+                            "run_manager",
+                            side_effect=[
+                                MODULE.ScheduleOverrideError("failed to build schedule override from `/tmp/bad.plist`: malformed"),
+                                run_result,
+                            ],
+                        ) as run_manager:
+                            with mock.patch("builtins.print") as print_mock:
+                                rc = MODULE.render_batch_summary(
+                                    args,
+                                    [
+                                        ("memory-dream", MODULE.JOB_SPECS["memory-dream"]),
+                                        ("service-monitoring", MODULE.JOB_SPECS["service-monitoring"]),
+                                    ],
+                                )
 
         self.assertEqual(rc, 1)
         self.assertEqual(run_manager.call_count, 2)
         rendered = print_mock.call_args.args[0]
         self.assertIn("## memory-dream", rendered)
         self.assertIn("failed to build schedule override", rendered)
+        self.assertIn("## service-monitoring", rendered)
+        self.assertIn("- output: `ok`", rendered)
+
+    def test_render_batch_summary_reports_manager_launch_failure_per_job(self) -> None:
+        args = argparse.Namespace(
+            action="status",
+            job=["memory-dream", "service-monitoring"],
+            hour=None,
+            minute=None,
+            python_bin="/usr/bin/python3",
+            sudoers_user="agentdesk-runtime",
+            skills_root=None,
+            as_root=False,
+        )
+        first_job = MODULE.ResolvedDawnJob(
+            name="memory-dream",
+            skill_root=Path("/Users/agentdesk/.codex/skills/memory-dream"),
+            manager_script=Path("/Users/agentdesk/.codex/skills/memory-dream/scripts/manage_memory_dream_launchd.py"),
+            daemon_plist=Path("/Users/agentdesk/.codex/skills/memory-dream/launchd/com.agentdesk.memory-dream-dawn.plist"),
+        )
+        second_job = MODULE.ResolvedDawnJob(
+            name="service-monitoring",
+            skill_root=Path("/Users/agentdesk/.codex/skills/service-monitoring"),
+            manager_script=Path("/Users/agentdesk/.codex/skills/service-monitoring/scripts/manage_service_monitoring_launchd.py"),
+            daemon_plist=Path("/Users/agentdesk/.codex/skills/service-monitoring/launchd/com.agentdesk.service-monitoring-dawn.plist"),
+        )
+        run_result = subprocess.CompletedProcess(["python3"], 0, stdout="ok", stderr="")
+
+        with mock.patch.object(MODULE, "candidate_skills_roots", return_value=[Path("/Users/agentdesk/.codex/skills")]):
+            with mock.patch.object(MODULE, "effective_manager_python", return_value=Path("/usr/bin/python3")):
+                with mock.patch.object(
+                    MODULE,
+                    "resolve_job_artifacts",
+                    side_effect=[first_job, second_job],
+                ):
+                    with mock.patch("os.geteuid", return_value=501):
+                        with mock.patch.object(
+                            MODULE,
+                            "run_manager",
+                            side_effect=[
+                                FileNotFoundError(2, "No such file or directory", "/bad/python"),
+                                run_result,
+                            ],
+                        ) as run_manager:
+                            with mock.patch("builtins.print") as print_mock:
+                                rc = MODULE.render_batch_summary(
+                                    args,
+                                    [
+                                        ("memory-dream", MODULE.JOB_SPECS["memory-dream"]),
+                                        ("service-monitoring", MODULE.JOB_SPECS["service-monitoring"]),
+                                    ],
+                                )
+
+        self.assertEqual(rc, 1)
+        self.assertEqual(run_manager.call_count, 2)
+        rendered = print_mock.call_args.args[0]
+        self.assertIn("## memory-dream", rendered)
+        self.assertIn("No such file or directory", rendered)
         self.assertIn("## service-monitoring", rendered)
         self.assertIn("- output: `ok`", rendered)
 

--- a/tests/test_manage_dawn_launchdaemons.py
+++ b/tests/test_manage_dawn_launchdaemons.py
@@ -122,6 +122,24 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
         with mock.patch.object(MODULE.os, "geteuid", return_value=0):
             self.assertTrue(MODULE.privileged_root_requested(args))
 
+    def test_trusted_root_python_bin_prefers_root_owned_fallback(self) -> None:
+        with mock.patch.object(
+            MODULE, "preferred_python_bin", return_value=Path("/opt/homebrew/bin/python3")
+        ):
+            with mock.patch.object(
+                MODULE.shutil,
+                "which",
+                side_effect=lambda name: "/opt/homebrew/bin/python3" if name == "python3" else None,
+            ):
+                with mock.patch.object(
+                    MODULE,
+                    "path_is_root_owned_and_locked",
+                    side_effect=lambda path: Path(path) == Path("/usr/bin/python3"),
+                ):
+                    trusted = MODULE.trusted_root_python_bin()
+
+        self.assertEqual(trusted, Path("/usr/bin/python3"))
+
     def test_resolve_job_artifacts_prefers_existing_skills_root(self) -> None:
         spec = MODULE.JOB_SPECS["memory-dream"]
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_manage_dawn_launchdaemons.py
+++ b/tests/test_manage_dawn_launchdaemons.py
@@ -1,5 +1,6 @@
 import argparse
 import importlib.util
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -26,6 +27,14 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
         self.assertIn("User_Alias AGENTDESK_RUNTIME = agentdesk", text)
         self.assertIn("/opt/homebrew/bin/python3 " + str(SCRIPT_PATH) + " *", text)
         self.assertIn("NOPASSWD: AGENTDESK_DAWN_MANAGER", text)
+
+    def test_sudoers_text_rejects_unsafe_user_name(self) -> None:
+        with self.assertRaises(SystemExit):
+            MODULE.sudoers_text(
+                user_name="agentdesk\nALL ALL=(ALL) NOPASSWD: ALL",
+                python_bin=Path("/usr/bin/python3"),
+                script_path=SCRIPT_PATH,
+            )
 
     def test_build_self_command_keeps_jobs_and_schedule(self) -> None:
         args = argparse.Namespace(
@@ -166,6 +175,57 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
 
         self.assertIn(Path("/Users/agentdesk/.codex/skills"), roots)
         self.assertIn(Path("/Users/agentdesk/.adk/release/skills"), roots)
+
+    def test_parse_args_rejects_unsafe_sudoers_user(self) -> None:
+        with self.assertRaises(SystemExit):
+            MODULE.parse_args(["sudoers", "--sudoers-user", "agentdesk\nroot ALL=(ALL) NOPASSWD: ALL"])
+
+    def test_preflight_validates_artifacts_with_trusted_root_python(self) -> None:
+        args = argparse.Namespace(
+            action="preflight",
+            job=None,
+            hour=None,
+            minute=None,
+            python_bin="/opt/homebrew/bin/python3",
+            sudoers_user="agentdesk",
+            skills_root=None,
+            as_root=False,
+        )
+        resolved = MODULE.ResolvedDawnJob(
+            name="memory-dream",
+            skill_root=Path("/tmp/skills/memory-dream"),
+            manager_script=Path("/tmp/skills/memory-dream/scripts/manage_memory_dream_launchd.py"),
+            daemon_plist=Path("/tmp/skills/memory-dream/launchd/com.agentdesk.memory-dream-dawn.plist"),
+        )
+        seen: dict[str, Path] = {}
+
+        def fake_validate(job: MODULE.ResolvedDawnJob, python_bin: Path) -> None:
+            self.assertEqual(job, resolved)
+            seen["python_bin"] = python_bin
+
+        def fake_run(command: list[str]) -> subprocess.CompletedProcess[str]:
+            if command == ["/opt/homebrew/bin/python3", "--version"]:
+                return subprocess.CompletedProcess(command, 0, stdout="Python 3.12.0\n", stderr="")
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+        with mock.patch.object(MODULE, "candidate_skills_roots", return_value=[Path("/tmp/skills")]):
+            with mock.patch.object(MODULE, "trusted_root_python_bin", return_value=Path("/usr/bin/python3")):
+                with mock.patch.object(MODULE, "resolve_job_artifacts", return_value=resolved):
+                    with mock.patch.object(MODULE, "plist_valid", return_value=True):
+                        with mock.patch.object(MODULE, "validate_privileged_job_artifacts", side_effect=fake_validate):
+                            with mock.patch.object(
+                                MODULE,
+                                "build_preflight_probe_command",
+                                return_value=["sudo", "-n", "/usr/bin/python3", str(SCRIPT_PATH), "status"],
+                            ):
+                                with mock.patch.object(MODULE, "run_command", side_effect=fake_run):
+                                    with mock.patch("builtins.print"):
+                                        MODULE.render_preflight(
+                                            args,
+                                            [("memory-dream", MODULE.JOB_SPECS["memory-dream"])],
+                                        )
+
+        self.assertEqual(seen["python_bin"], Path("/usr/bin/python3"))
 
 
 if __name__ == "__main__":

--- a/tests/test_manage_dawn_launchdaemons.py
+++ b/tests/test_manage_dawn_launchdaemons.py
@@ -1,6 +1,7 @@
 import argparse
 import importlib.util
 import os
+import plistlib
 import subprocess
 import sys
 import tempfile
@@ -85,6 +86,19 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
                 "/tmp/skills-b",
             ],
         )
+
+    def test_build_schedule_override_rejects_non_dict_plist_root(self) -> None:
+        with tempfile.NamedTemporaryFile("wb", suffix=".plist", delete=False) as handle:
+            plistlib.dump(["not", "a", "dict"], handle)
+            source_plist = Path(handle.name)
+
+        try:
+            with self.assertRaises(MODULE.ScheduleOverrideError) as ctx:
+                MODULE.build_schedule_override(source_plist, hour=5, minute=30)
+        finally:
+            source_plist.unlink(missing_ok=True)
+
+        self.assertIn("expected plist dictionary root", str(ctx.exception))
 
     def test_access_denied_matches_sudo_password_message(self) -> None:
         self.assertTrue(MODULE.access_denied("sudo: a password is required"))

--- a/tests/test_manage_dawn_launchdaemons.py
+++ b/tests/test_manage_dawn_launchdaemons.py
@@ -1,0 +1,92 @@
+import argparse
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path("/Users/kunkun/kunkunGames/agentdesk/scripts/manage_dawn_launchdaemons.py")
+SPEC = importlib.util.spec_from_file_location("manage_dawn_launchdaemons", SCRIPT_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class ManageDawnLaunchdaemonsTests(unittest.TestCase):
+    def test_sudoers_text_contains_expected_allowlist(self) -> None:
+        text = MODULE.sudoers_text(
+            user_name="agentdesk",
+            python_bin=Path("/opt/homebrew/bin/python3"),
+            script_path=SCRIPT_PATH,
+        )
+
+        self.assertIn("User_Alias AGENTDESK_RUNTIME = agentdesk", text)
+        self.assertIn("/opt/homebrew/bin/python3 " + str(SCRIPT_PATH) + " *", text)
+        self.assertIn("NOPASSWD: AGENTDESK_DAWN_MANAGER", text)
+
+    def test_build_self_command_keeps_jobs_and_schedule(self) -> None:
+        args = argparse.Namespace(
+            action="install",
+            job=["memory-dream", "service-monitoring"],
+            hour=5,
+            minute=30,
+            python_bin="/opt/homebrew/bin/python3",
+            skills_root=["/tmp/skills-a", "/tmp/skills-b"],
+        )
+
+        command = MODULE.build_self_command(args, as_root=True)
+
+        self.assertEqual(command[:3], ["/opt/homebrew/bin/python3", str(SCRIPT_PATH), "--as-root"])
+        self.assertIn("--job", command)
+        self.assertIn("memory-dream", command)
+        self.assertIn("service-monitoring", command)
+        self.assertEqual(
+            command[-10:],
+            [
+                "--hour",
+                "5",
+                "--minute",
+                "30",
+                "--python-bin",
+                "/opt/homebrew/bin/python3",
+                "--skills-root",
+                "/tmp/skills-a",
+                "--skills-root",
+                "/tmp/skills-b",
+            ],
+        )
+
+    def test_access_denied_matches_sudo_password_message(self) -> None:
+        self.assertTrue(MODULE.access_denied("sudo: a password is required"))
+        self.assertFalse(MODULE.access_denied("launchd status requires attention"))
+
+    def test_status_is_not_forced_through_sudo(self) -> None:
+        self.assertFalse(MODULE.action_needs_privileged_reexec("status"))
+        self.assertTrue(MODULE.action_needs_privileged_reexec("bootstrap"))
+        self.assertTrue(MODULE.action_needs_privileged_reexec("install"))
+        self.assertTrue(MODULE.action_needs_privileged_reexec("uninstall"))
+
+    def test_resolve_job_artifacts_prefers_existing_skills_root(self) -> None:
+        spec = MODULE.JOB_SPECS["memory-dream"]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skills_root = Path(tmpdir)
+            skill_root = skills_root / spec.skill_name
+            (skill_root / spec.manager_relpath).parent.mkdir(parents=True, exist_ok=True)
+            (skill_root / spec.daemon_plist_relpath).parent.mkdir(parents=True, exist_ok=True)
+            (skill_root / spec.manager_relpath).write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+            (skill_root / spec.daemon_plist_relpath).write_text(
+                "<?xml version=\"1.0\"?>\n<plist version=\"1.0\"></plist>\n",
+                encoding="utf-8",
+            )
+
+            resolved = MODULE.resolve_job_artifacts("memory-dream", spec, skills_roots=[skills_root])
+
+            self.assertEqual(resolved.skill_root, skill_root)
+            self.assertEqual(resolved.manager_script, skill_root / spec.manager_relpath)
+            self.assertEqual(resolved.daemon_plist, skill_root / spec.daemon_plist_relpath)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_manage_dawn_launchdaemons.py
+++ b/tests/test_manage_dawn_launchdaemons.py
@@ -276,6 +276,144 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
         self.assertEqual(seen["python_bin"], Path("/usr/bin/python3"))
         self.assertIsNone(seen["script_path"])
 
+    def test_root_preflight_uses_trusted_python_for_version_probe(self) -> None:
+        args = argparse.Namespace(
+            action="preflight",
+            job=None,
+            hour=None,
+            minute=None,
+            python_bin="/opt/homebrew/bin/python3",
+            sudoers_user="agentdesk",
+            skills_root=None,
+            as_root=False,
+        )
+        resolved = MODULE.ResolvedDawnJob(
+            name="memory-dream",
+            skill_root=Path("/tmp/skills/memory-dream"),
+            manager_script=Path("/tmp/skills/memory-dream/scripts/manage_memory_dream_launchd.py"),
+            daemon_plist=Path("/tmp/skills/memory-dream/launchd/com.agentdesk.memory-dream-dawn.plist"),
+        )
+        seen_commands: list[list[str]] = []
+
+        def fake_run(command: list[str]) -> subprocess.CompletedProcess[str]:
+            seen_commands.append(command)
+            return subprocess.CompletedProcess(command, 0, stdout="Python 3.12.0\n", stderr="")
+
+        with mock.patch.object(MODULE.os, "geteuid", return_value=0):
+            with mock.patch.object(MODULE, "candidate_skills_roots", return_value=[Path("/tmp/skills")]):
+                with mock.patch.object(
+                    MODULE, "trusted_root_python_bin", return_value=Path("/usr/bin/python3")
+                ):
+                    with mock.patch.object(MODULE, "resolve_job_artifacts", return_value=resolved):
+                        with mock.patch.object(MODULE, "plist_valid", return_value=True):
+                            with mock.patch.object(
+                                MODULE,
+                                "validate_privileged_job_artifacts",
+                                return_value=None,
+                            ):
+                                with mock.patch.object(
+                                    MODULE,
+                                    "build_preflight_probe_command",
+                                    return_value=["sudo", "-n", "/usr/bin/python3", str(SCRIPT_PATH), "status"],
+                                ):
+                                    with mock.patch.object(MODULE, "run_command", side_effect=fake_run):
+                                        with mock.patch("builtins.print"):
+                                            MODULE.render_preflight(
+                                                args,
+                                                [("memory-dream", MODULE.JOB_SPECS["memory-dream"])],
+                                            )
+
+        self.assertEqual(seen_commands[0], ["/usr/bin/python3", "--version"])
+
+    def test_preflight_reports_non_executable_python_without_crashing(self) -> None:
+        args = argparse.Namespace(
+            action="preflight",
+            job=None,
+            hour=None,
+            minute=None,
+            python_bin="/tmp/custom-python",
+            sudoers_user="agentdesk",
+            skills_root=None,
+            as_root=False,
+        )
+        resolved = MODULE.ResolvedDawnJob(
+            name="memory-dream",
+            skill_root=Path("/tmp/skills/memory-dream"),
+            manager_script=Path("/tmp/skills/memory-dream/scripts/manage_memory_dream_launchd.py"),
+            daemon_plist=Path("/tmp/skills/memory-dream/launchd/com.agentdesk.memory-dream-dawn.plist"),
+        )
+
+        def fake_run(command: list[str]) -> subprocess.CompletedProcess[str]:
+            if command and command[0] == "sudo":
+                return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+            raise AssertionError(f"unexpected command: {command}")
+
+        with mock.patch.object(MODULE, "candidate_skills_roots", return_value=[Path("/tmp/skills")]):
+            with mock.patch.object(MODULE, "resolve_job_artifacts", return_value=resolved):
+                with mock.patch.object(MODULE, "plist_valid", return_value=True):
+                    with mock.patch.object(
+                        MODULE,
+                        "validate_privileged_job_artifacts",
+                        return_value=None,
+                    ):
+                        with mock.patch.object(
+                            MODULE.Path,
+                            "exists",
+                            return_value=True,
+                        ):
+                            with mock.patch.object(
+                                MODULE,
+                                "path_is_executable",
+                                side_effect=lambda path: False,
+                            ):
+                                with mock.patch.object(
+                                    MODULE,
+                                    "build_preflight_probe_command",
+                                    return_value=["sudo", "-n", "/usr/bin/python3", str(SCRIPT_PATH), "status"],
+                                ):
+                                    with mock.patch.object(MODULE, "run_command", side_effect=fake_run):
+                                        with mock.patch("builtins.print") as printer:
+                                            rc = MODULE.render_preflight(
+                                                args,
+                                                [("memory-dream", MODULE.JOB_SPECS["memory-dream"])],
+                                            )
+
+        self.assertEqual(rc, 1)
+        rendered = "\n".join(call.args[0] for call in printer.call_args_list)
+        self.assertIn("- invocation_python_executable: `False`", rendered)
+        self.assertIn("- invocation_python_version: `not executable`", rendered)
+
+    def test_run_bootstrap_validates_installed_entrypoint_not_repo_checkout(self) -> None:
+        args = argparse.Namespace(
+            action="bootstrap",
+            job=["memory-dream"],
+            hour=None,
+            minute=None,
+            python_bin="/opt/homebrew/bin/python3",
+            sudoers_user="agentdesk-runtime",
+            skills_root=None,
+            as_root=True,
+        )
+
+        with mock.patch.object(MODULE, "effective_manager_python", return_value=Path("/usr/bin/python3")):
+            with mock.patch.object(
+                MODULE,
+                "install_managed_entrypoint",
+                return_value=Path("/usr/local/libexec/agentdesk/manage_dawn_launchdaemons.py"),
+            ):
+                with mock.patch.object(MODULE, "validate_privileged_entrypoint") as validate_entrypoint:
+                    with mock.patch.object(
+                        MODULE,
+                        "install_sudoers_dropin",
+                        return_value=(False, "skip install"),
+                    ):
+                        MODULE.run_bootstrap(args, [("memory-dream", MODULE.JOB_SPECS["memory-dream"])])
+
+        validate_entrypoint.assert_called_once_with(
+            Path("/usr/bin/python3"),
+            Path("/usr/local/libexec/agentdesk/manage_dawn_launchdaemons.py"),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_manage_dawn_launchdaemons.py
+++ b/tests/test_manage_dawn_launchdaemons.py
@@ -36,6 +36,16 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
                 script_path=SCRIPT_PATH,
             )
 
+    def test_sudoers_text_can_include_bootstrap_notice(self) -> None:
+        text = MODULE.sudoers_text(
+            user_name="agentdesk",
+            python_bin=Path("/usr/bin/python3"),
+            script_path=Path("/usr/local/libexec/agentdesk/manage_dawn_launchdaemons.py"),
+            bootstrap_required=True,
+        )
+
+        self.assertIn("First-time setup still requires", text)
+
     def test_build_self_command_keeps_jobs_and_schedule(self) -> None:
         args = argparse.Namespace(
             action="install",

--- a/tests/test_manage_dawn_launchdaemons.py
+++ b/tests/test_manage_dawn_launchdaemons.py
@@ -74,6 +74,54 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
         self.assertTrue(MODULE.action_needs_privileged_reexec("install"))
         self.assertTrue(MODULE.action_needs_privileged_reexec("uninstall"))
 
+    def test_preflight_probe_command_reenters_status_as_root(self) -> None:
+        args = argparse.Namespace(
+            action="preflight",
+            job=["memory-dream"],
+            hour=None,
+            minute=None,
+            python_bin="/opt/homebrew/bin/python3",
+            sudoers_user="agentdesk-runtime",
+            skills_root=["/tmp/skills-a", "/tmp/skills-b"],
+            as_root=False,
+        )
+
+        with mock.patch.object(MODULE, "trusted_root_python_bin", return_value=Path("/usr/bin/python3")):
+            command = MODULE.build_preflight_probe_command(args, "memory-dream")
+
+        self.assertEqual(
+            command[:8],
+            [
+                "sudo",
+                "-n",
+                "/usr/bin/python3",
+                str(SCRIPT_PATH),
+                "--as-root",
+                "status",
+                "--python-bin",
+                "/usr/bin/python3",
+            ],
+        )
+        self.assertIn("--sudoers-user", command)
+        self.assertIn("agentdesk-runtime", command)
+        self.assertEqual(
+            command[-6:],
+            [
+                "--job",
+                "memory-dream",
+                "--skills-root",
+                "/tmp/skills-a",
+                "--skills-root",
+                "/tmp/skills-b",
+            ],
+        )
+
+    def test_status_as_root_is_treated_as_privileged_probe(self) -> None:
+        args = argparse.Namespace(action="status", as_root=True)
+
+        with mock.patch.object(MODULE.os, "geteuid", return_value=0):
+            self.assertTrue(MODULE.privileged_root_requested(args))
+
     def test_resolve_job_artifacts_prefers_existing_skills_root(self) -> None:
         spec = MODULE.JOB_SPECS["memory-dream"]
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_manage_dawn_launchdaemons.py
+++ b/tests/test_manage_dawn_launchdaemons.py
@@ -45,6 +45,7 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
         )
 
         self.assertIn("First-time setup still requires", text)
+        self.assertIn("managed root-owned entrypoint", text)
 
     def test_build_self_command_keeps_jobs_and_schedule(self) -> None:
         args = argparse.Namespace(
@@ -202,6 +203,31 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
 
         self.assertEqual(trusted, Path("/usr/bin/python3"))
 
+    def test_validate_privileged_job_artifacts_ignores_source_skill_root(self) -> None:
+        job = MODULE.ResolvedDawnJob(
+            name="memory-dream",
+            skill_root=Path("/Users/agentdesk/.codex/skills/memory-dream"),
+            manager_script=Path("/usr/local/libexec/agentdesk/skills/memory-dream/scripts/manage_memory_dream_launchd.py"),
+            daemon_plist=Path("/usr/local/libexec/agentdesk/skills/memory-dream/launchd/com.agentdesk.memory-dream-dawn.plist"),
+        )
+
+        trusted_paths = {
+            Path("/usr/bin/python3"),
+            Path("/usr/local/libexec/agentdesk/manage_dawn_launchdaemons.py"),
+            job.manager_script,
+            job.daemon_plist,
+        }
+        with mock.patch.object(
+            MODULE,
+            "path_is_root_owned_and_locked",
+            side_effect=lambda path: Path(path) in trusted_paths,
+        ):
+            MODULE.validate_privileged_job_artifacts(
+                job,
+                Path("/usr/bin/python3"),
+                Path("/usr/local/libexec/agentdesk/manage_dawn_launchdaemons.py"),
+            )
+
     def test_resolve_job_artifacts_prefers_existing_skills_root(self) -> None:
         spec = MODULE.JOB_SPECS["memory-dream"]
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -314,7 +340,7 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
                 with mock.patch.object(
                     MODULE, "trusted_root_python_bin", return_value=Path("/usr/bin/python3")
                 ):
-                    with mock.patch.object(MODULE, "resolve_job_artifacts", return_value=resolved):
+                    with mock.patch.object(MODULE, "resolve_managed_job_artifacts", return_value=resolved):
                         with mock.patch.object(MODULE, "plist_valid", return_value=True):
                             with mock.patch.object(
                                 MODULE,
@@ -404,6 +430,18 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
             skills_root=None,
             as_root=True,
         )
+        source_job = MODULE.ResolvedDawnJob(
+            name="memory-dream",
+            skill_root=Path("/Users/agentdesk/.codex/skills/memory-dream"),
+            manager_script=Path("/Users/agentdesk/.codex/skills/memory-dream/scripts/manage_memory_dream_launchd.py"),
+            daemon_plist=Path("/Users/agentdesk/.codex/skills/memory-dream/launchd/com.agentdesk.memory-dream-dawn.plist"),
+        )
+        staged_job = MODULE.ResolvedDawnJob(
+            name="memory-dream",
+            skill_root=Path("/usr/local/libexec/agentdesk/skills/memory-dream"),
+            manager_script=Path("/usr/local/libexec/agentdesk/skills/memory-dream/scripts/manage_memory_dream_launchd.py"),
+            daemon_plist=Path("/usr/local/libexec/agentdesk/skills/memory-dream/launchd/com.agentdesk.memory-dream-dawn.plist"),
+        )
 
         with mock.patch.object(MODULE, "effective_manager_python", return_value=Path("/usr/bin/python3")):
             with mock.patch.object(
@@ -411,18 +449,75 @@ class ManageDawnLaunchdaemonsTests(unittest.TestCase):
                 "install_managed_entrypoint",
                 return_value=Path("/usr/local/libexec/agentdesk/manage_dawn_launchdaemons.py"),
             ):
-                with mock.patch.object(MODULE, "validate_privileged_entrypoint") as validate_entrypoint:
-                    with mock.patch.object(
-                        MODULE,
-                        "install_sudoers_dropin",
-                        return_value=(False, "skip install"),
-                    ):
-                        MODULE.run_bootstrap(args, [("memory-dream", MODULE.JOB_SPECS["memory-dream"])])
+                with mock.patch.object(MODULE, "candidate_skills_roots", return_value=[Path("/Users/agentdesk/.codex/skills")]):
+                    with mock.patch.object(MODULE, "resolve_job_artifacts", return_value=source_job):
+                        with mock.patch.object(
+                            MODULE,
+                            "install_managed_job_artifacts",
+                            return_value=staged_job,
+                        ) as install_managed_job_artifacts:
+                            with mock.patch.object(MODULE, "validate_privileged_entrypoint") as validate_entrypoint:
+                                with mock.patch.object(
+                                    MODULE,
+                                    "install_sudoers_dropin",
+                                    return_value=(False, "skip install"),
+                                ):
+                                    MODULE.run_bootstrap(
+                                        args,
+                                        [("memory-dream", MODULE.JOB_SPECS["memory-dream"])],
+                                    )
 
         validate_entrypoint.assert_called_once_with(
             Path("/usr/bin/python3"),
             Path("/usr/local/libexec/agentdesk/manage_dawn_launchdaemons.py"),
         )
+        install_managed_job_artifacts.assert_called_once_with(
+            source_job,
+            MODULE.JOB_SPECS["memory-dream"],
+        )
+
+    def test_render_batch_summary_privileged_uses_managed_job_artifacts(self) -> None:
+        args = argparse.Namespace(
+            action="install",
+            job=["memory-dream"],
+            hour=None,
+            minute=None,
+            python_bin="/usr/bin/python3",
+            sudoers_user="agentdesk-runtime",
+            skills_root=None,
+            as_root=True,
+        )
+        managed_job = MODULE.ResolvedDawnJob(
+            name="memory-dream",
+            skill_root=Path("/usr/local/libexec/agentdesk/skills/memory-dream"),
+            manager_script=Path("/usr/local/libexec/agentdesk/skills/memory-dream/scripts/manage_memory_dream_launchd.py"),
+            daemon_plist=Path("/usr/local/libexec/agentdesk/skills/memory-dream/launchd/com.agentdesk.memory-dream-dawn.plist"),
+        )
+        run_result = subprocess.CompletedProcess(["python3"], 0, stdout="ok", stderr="")
+
+        with mock.patch.object(MODULE, "candidate_skills_roots", return_value=[Path("/Users/agentdesk/.codex/skills")]):
+            with mock.patch.object(MODULE, "effective_manager_python", return_value=Path("/usr/bin/python3")):
+                with mock.patch.object(MODULE, "resolve_managed_job_artifacts", return_value=managed_job):
+                    with mock.patch.object(
+                        MODULE,
+                        "resolve_job_artifacts",
+                        side_effect=AssertionError("should not resolve user-owned skill roots in privileged mode"),
+                    ):
+                        with mock.patch.object(
+                            MODULE,
+                            "validate_privileged_job_artifacts",
+                            return_value=None,
+                        ):
+                            with mock.patch.object(MODULE, "run_manager", return_value=run_result) as run_manager:
+                                with mock.patch("builtins.print"):
+                                    rc = MODULE.render_batch_summary(
+                                        args,
+                                        [("memory-dream", MODULE.JOB_SPECS["memory-dream"])],
+                                    )
+
+        self.assertEqual(rc, 0)
+        run_manager.assert_called_once()
+        self.assertEqual(run_manager.call_args.args[0], managed_job)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 목표
- Dawn LaunchDaemon의 privileged 관리 경로가 bootstrap 이후 managed root-owned artifact 기준으로 일관되게 동작하도록 정리합니다.

## 해결한 내용
- `scripts/manage_dawn_launchdaemons.py`: managed skill 트리의 전체 디렉터리 체인을 잠금 권한으로 정규화하고, managed entrypoint가 설치된 뒤 `preflight`가 user skill root가 아니라 managed artifact 기준으로 privileged readiness를 평가하도록 수정했습니다.
- `scripts/manage_dawn_launchdaemons.py`: schedule override용 plist를 읽거나 쓰는 과정에서 `plistlib.InvalidFileException` / `OSError`가 발생하면 job 단위의 구조화된 실패로 기록하고, 나머지 job 실행은 계속 진행하도록 보강했습니다.
- `scripts/manage_dawn_launchdaemons.py`: `run_manager(...)` 실행 자체가 `FileNotFoundError` / `OSError`로 실패해도 batch summary가 traceback 없이 job 단위 실패로 요약되고 다음 job을 계속 처리하도록 보강했습니다.
- `tests/test_manage_dawn_launchdaemons.py`: managed 디렉터리 체인 권한 정규화와 bootstrap 이후 managed artifact 기준 `preflight` 동작을 검증하는 회귀 테스트를 추가했고, malformed plist와 manager launch failure가 있어도 batch summary가 다음 job까지 계속 진행되는 케이스를 검증하도록 보강했습니다.
- `docs/generated/module-inventory.md`: 최신 `upstream/main` 기준 generated inventory를 다시 동기화했습니다.

## 검증
- `python3 -m pytest tests/test_manage_dawn_launchdaemons.py -q` : Dawn LaunchDaemon Python 회귀 테스트 25개 통과를 확인했습니다.
- `cargo fmt --all --check` : 저장소 포맷 규칙 영향이 없음을 확인했습니다.
- `cargo check --all-targets` : 최신 base 위에서 Rust 빌드가 깨지지 않음을 확인했습니다.
- `python3 scripts/generate_inventory_docs.py` : generated inventory를 최신 코드 기준으로 갱신했습니다.