### PR TITLE
docs: add CLI review notes for Claude, Gemini, and Qwen

### DIFF
--- a/docs/claude-code-2.1.112-review-issue-34.md
+++ b/docs/claude-code-2.1.112-review-issue-34.md
@@ -1,0 +1,106 @@
+# Claude Code 2.1.104 -> 2.1.112 Review for AgentDesk
+
+Issue: `#34`  
+Date: `2026-04-18`
+
+## Executive summary
+
+Recommendation:
+
+- Apply now: none
+- Needs design: optional Claude reasoning-effort exposure if AgentDesk wants a first-class effort control
+- Hold: tool allow/deny help-text syntax changes
+
+The update from `2.1.104` to `2.1.112` does not force an AgentDesk compatibility change on the current execution path. The only directly observable CLI-level delta from local comparison is that Claude now advertises `xhigh` as an extra `--effort` level. AgentDesk does not currently expose or pass an effort flag, so there is no safe "just wire it in" patch without a separate UX and policy decision.
+
+## What changed in Claude Code 2.1.112
+
+Verified on `2026-04-18` with local CLI comparisons between:
+
+- `claude 2.1.112`
+- `npx -y @anthropic-ai/claude-code@2.1.104`
+
+Observed top-level CLI deltas:
+
+- `claude --help` now advertises `--effort <level>` values `low, medium, high, xhigh, max`.
+- The `--allowed-tools` and `--disallowed-tools` help examples changed from `Bash(git:*)` style wording to `Bash(git *)` example wording.
+
+Evidence:
+
+- local `claude --help`
+- local `npx -y @anthropic-ai/claude-code@2.1.104 --help`
+
+## Current AgentDesk integration shape
+
+AgentDesk's Claude execution path is still centered on model selection, system prompt composition, and streamed tool usage:
+
+- `src/services/discord/router/message_handler.rs:1481` calls `claude::execute_command_streaming(...)` per turn.
+- `src/services/claude.rs:501` through `src/services/claude.rs:505` only wire a `--model` override into the Claude CLI arguments.
+- `src/services/discord/model_picker_interaction.rs:211` through `src/services/discord/model_picker_interaction.rs:243` only validate and persist model-picker choices, not reasoning-effort controls.
+
+There is no existing AgentDesk surface for:
+
+- per-channel Claude effort level
+- per-dispatch Claude effort level
+- policy gating for `xhigh` cost and latency tradeoffs
+
+## Classification
+
+### Apply now
+
+None.
+
+Why:
+
+- The current Claude execution path remains valid after the update.
+- No required flag migration or resume behavior change was observed.
+- The observed tool-allow/deny help-text example change is documentation-level, not an integration contract change.
+
+### Needs design
+
+### 1. Expose Claude reasoning effort separately from model selection
+
+Value:
+
+- `xhigh` may be useful for expensive but high-value review or synthesis work where operators explicitly want more reasoning depth.
+
+Effort:
+
+- Medium to high.
+
+Risk:
+
+- Higher latency and cost without a clear Discord or dispatch UX can create confusing behavior and uneven operator expectations.
+
+Why this is not an apply-now patch:
+
+- AgentDesk currently stores only model override state, not effort state.
+- Reusing `/model` to smuggle effort would be semantically wrong and create configuration debt.
+
+Suggested follow-up:
+
+- Only create a separate implementation card if the team wants a dedicated effort control surface with explicit policy and cost semantics.
+
+### Hold
+
+### 1. Help-text example syntax changes for tool allow/deny patterns
+
+Value:
+
+- Low.
+
+Effort:
+
+- Low.
+
+Risk:
+
+- Low, but also low payoff.
+
+Reason:
+
+- The observed delta is in help examples, not a verified break in AgentDesk's current Claude invocation contract.
+
+## Conclusion
+
+The `2.1.104 -> 2.1.112` upgrade is safe to keep, but it does not justify an immediate AgentDesk compatibility patch. The only meaningful new candidate is `xhigh` effort exposure, and that requires a deliberate product and operator-control design rather than a silent transport-layer change.

--- a/docs/gemini-cli-0.38.1-review-issue-36.md
+++ b/docs/gemini-cli-0.38.1-review-issue-36.md
@@ -1,0 +1,87 @@
+# Gemini CLI 0.38.0 -> 0.38.1 Review for AgentDesk
+
+Issue: `#36`  
+Date: `2026-04-18`
+
+## Executive summary
+
+Recommendation:
+
+- Apply now: none
+- Needs design: none from this patch delta alone
+- Hold: keep the current exact-UUID resume prohibition intact
+
+The `0.38.0 -> 0.38.1` update does not expose a new AgentDesk-relevant feature candidate that should be merged immediately. Local CLI comparison did not show a top-level command-surface delta, and the current AgentDesk Gemini integration should keep its strict resume-selector guardrail.
+
+## What changed in Gemini CLI 0.38.1
+
+Verified on `2026-04-18` with local CLI comparisons between:
+
+- `gemini 0.38.1`
+- `npx -y @google/gemini-cli@0.38.0`
+
+Observed CLI delta:
+
+- No top-level `gemini --help` diff was observed from the local comparison.
+
+Evidence:
+
+- local `gemini --version`
+- local `npx -y @google/gemini-cli@0.38.0 --version`
+- local `gemini --help`
+- local `npx -y @google/gemini-cli@0.38.0 --help`
+
+## Current AgentDesk integration shape
+
+AgentDesk's Gemini path is intentionally conservative:
+
+- `src/services/discord/router/message_handler.rs:1511` through `src/services/discord/router/message_handler.rs:1524` call `gemini::execute_command_streaming(...)` with a model override only.
+- `src/services/gemini.rs:363` through `src/services/gemini.rs:365` explicitly reject remote-profile execution.
+- `src/services/gemini.rs:367` through `src/services/gemini.rs:382` normalize and log the runtime resume selector before execution.
+- `src/services/gemini.rs:1081` through `src/services/gemini.rs:1120` coerce UUID-like session identifiers to `latest` instead of passing them through as exact resume selectors.
+
+That last guardrail is important because Gemini CLI can silently fork history if a UUID-like selector is not actually resumable.
+
+## Classification
+
+### Apply now
+
+None.
+
+Why:
+
+- No new top-level CLI surface was observed in the patch comparison.
+- The current AgentDesk integration already constrains Gemini to the supported model-plus-streaming path.
+- There is no verified new feature from `0.38.1` that should change Discord UX, model selection, or session transport immediately.
+
+### Needs design
+
+None from this patch delta alone.
+
+Reason:
+
+- Any future Gemini session-management expansion should wait for a verified selector contract that is safe for automated resume behavior.
+
+### Hold
+
+### 1. Relaxing exact UUID resume behavior
+
+Value:
+
+- Potentially high if Gemini later exposes a reliable exact-resume contract.
+
+Effort:
+
+- Medium.
+
+Risk:
+
+- High. A mistaken selector can silently create a new session and break continuity expectations.
+
+Disposition:
+
+- Keep the current UUID-to-`latest` coercion and invalid-selector rejection logic intact.
+
+## Conclusion
+
+The `0.38.0 -> 0.38.1` patch is safe to keep, but it does not create an immediate AgentDesk implementation target. The important decision here is not to weaken the existing Gemini resume guardrail until upstream exposes a selector contract that can be verified safely.

--- a/docs/qwen-cli-0.14.5-review-issue-37.md
+++ b/docs/qwen-cli-0.14.5-review-issue-37.md
@@ -1,0 +1,92 @@
+# Qwen CLI 0.14.4 -> 0.14.5 Review for AgentDesk
+
+Issue: `#37`  
+Date: `2026-04-18`
+
+## Executive summary
+
+Recommendation:
+
+- Apply now: none
+- Needs design: only if AgentDesk later wants a dedicated non-turn telemetry/context surface for Qwen
+- Hold: additional Qwen telemetry surfaces beyond the current stream parsing path
+
+The `0.14.4 -> 0.14.5` update does not require an immediate AgentDesk patch. AgentDesk already parses usage-bearing stream events from Qwen's turn output, and local top-level CLI comparison did not show a command-surface delta that maps directly to a current AgentDesk feature gap.
+
+## What changed in Qwen CLI 0.14.5
+
+Verified on `2026-04-18` with local CLI comparisons between:
+
+- `qwen 0.14.5`
+- `npx -y @qwen-code/qwen-code@0.14.4`
+
+Observed CLI delta:
+
+- No top-level `qwen --help` diff was observed from the local comparison.
+
+Evidence:
+
+- local `qwen --version`
+- local `npx -y @qwen-code/qwen-code@0.14.4 --version`
+- local `qwen --help`
+- local `npx -y @qwen-code/qwen-code@0.14.4 --help`
+
+## Current AgentDesk integration shape
+
+AgentDesk already consumes the most relevant live signal from Qwen's streaming path:
+
+- `src/services/qwen.rs:238` through `src/services/qwen.rs:337` run Qwen in streaming mode with retry-aware session handling.
+- `src/services/qwen.rs:536` through `src/services/qwen.rs:589` inspect Qwen stream events and update status from usage-bearing payloads.
+- `src/services/qwen_tmux_wrapper.rs:328` through `src/services/qwen_tmux_wrapper.rs:371` retry stalled tmux-backed Qwen sessions instead of assuming the stream is healthy forever.
+- `src/services/discord/model_picker_interaction.rs:211` through `src/services/discord/model_picker_interaction.rs:243` remain model-only and do not expose separate Qwen telemetry controls.
+
+## Classification
+
+### Apply now
+
+None.
+
+Why:
+
+- AgentDesk already parses Qwen usage from live stream events.
+- No top-level CLI surface delta was observed that requires a transport or UX change.
+
+### Needs design
+
+### 1. Dedicated non-turn Qwen telemetry/context collection
+
+Value:
+
+- Medium if the product later wants provider-side context or usage inspection outside an active turn.
+
+Effort:
+
+- Medium.
+
+Risk:
+
+- Medium. A new polling or side-channel telemetry path would need provider-specific semantics and should not be inferred from turn-stream behavior alone.
+
+Reason this is not an apply-now patch:
+
+- The current AgentDesk product surface does not yet use a separate Qwen context/telemetry command path.
+
+### Hold
+
+### 1. Extra Qwen telemetry surfaces beyond stream-event parsing
+
+Value:
+
+- Unknown until there is a concrete product requirement.
+
+Effort:
+
+- Medium.
+
+Risk:
+
+- Medium, because it can create duplicated or inconsistent telemetry semantics across providers.
+
+## Conclusion
+
+The `0.14.4 -> 0.14.5` upgrade is safe to keep, but it does not justify an immediate AgentDesk code patch. AgentDesk already captures the main live usage signal it currently knows how to consume, and any additional Qwen-specific telemetry or context surface should be designed deliberately rather than attached opportunistically to this patch upgrade.


### PR DESCRIPTION
## 목표
- Claude Code, Gemini CLI, Qwen CLI 검토 노트를 문서로 추가해 운영 판단 근거와 후속 참고 문서를 남깁니다.

## 해결한 내용
- `docs/claude-code-2.1.112-review-issue-34.md`: Claude Code 2.1.112 검토 내용을 정리했습니다.
- `docs/gemini-cli-0.38.1-review-issue-36.md`: Gemini CLI 0.38.1 검토 내용을 정리했습니다.
- `docs/qwen-cli-0.14.5-review-issue-37.md`: Qwen CLI 0.14.5 검토 내용을 정리했습니다.

## 검증
- `cargo fmt --all --check` : 저장소 포맷 규칙 영향이 없음을 확인했습니다.

## 동기화 메모
- `#831` 공통 기반 위에 문서 커밋만 다시 얹고 stale generated inventory refresh commit은 제외했습니다.