### PR TITLE
fix(dashboard): hide unsupported empty Qwen rows

### DIFF
--- a/dashboard/src/components/dashboard/RateLimitWidget.test.ts
+++ b/dashboard/src/components/dashboard/RateLimitWidget.test.ts
@@ -8,7 +8,7 @@ describe("RateLimitWidget helpers", () => {
     expect(normalizeRateLimitProviderLabel("qwen")).toBe("Qwen");
   });
 
-  it("preserves unsupported providers and computes visible bucket utilization", () => {
+  it("hides unsupported providers without measurable buckets and keeps measurable rows", () => {
     const data = transformRawData(
       {
         providers: [
@@ -28,6 +28,14 @@ describe("RateLimitWidget helpers", () => {
             fetched_at: 1_700_000_000,
             stale: false,
           },
+          {
+            provider: "qwen",
+            buckets: [{ name: "1h", limit: 120, used: 24, remaining: 96, reset: 1_700_000_600 }],
+            fetched_at: 1_700_000_000,
+            stale: true,
+            unsupported: true,
+            reason: "Rendering last known measurable bucket until live telemetry lands.",
+          },
         ],
       },
       80,
@@ -35,15 +43,21 @@ describe("RateLimitWidget helpers", () => {
     );
 
     expect(data.providers).toHaveLength(2);
-    expect(data.providers[0]).toMatchObject({
-      provider: "Qwen",
-      unsupported: true,
-      reason: "No Qwen rate-limit telemetry source is implemented yet.",
-    });
-    expect(data.providers[1]?.provider).toBe("Gemini");
-    expect(data.providers[1]?.buckets[0]).toMatchObject({
+    expect(data.providers[0]?.provider).toBe("Gemini");
+    expect(data.providers[0]?.buckets[0]).toMatchObject({
       label: "1h",
       utilization: 25,
+      level: "normal",
+    });
+    expect(data.providers[1]).toMatchObject({
+      provider: "Qwen",
+      stale: true,
+      unsupported: true,
+      reason: "Rendering last known measurable bucket until live telemetry lands.",
+    });
+    expect(data.providers[1]?.buckets[0]).toMatchObject({
+      label: "1h",
+      utilization: 20,
       level: "normal",
     });
   });

--- a/dashboard/src/components/dashboard/RateLimitWidget.tsx
+++ b/dashboard/src/components/dashboard/RateLimitWidget.tsx
@@ -87,13 +87,8 @@ export function transformRawData(
   return {
     providers: raw.providers
       .filter((rp) => !HIDDEN_PROVIDERS.has(rp.provider.toLowerCase()))
-      .map((rp) => ({
-        provider: normalizeRateLimitProviderLabel(rp.provider),
-        fetched_at: rp.fetched_at,
-        stale: rp.stale,
-        unsupported: Boolean(rp.unsupported),
-        reason: typeof rp.reason === "string" ? rp.reason : null,
-        buckets: rp.buckets
+      .flatMap((rp) => {
+        const buckets = rp.buckets
           .filter((b) => !HIDDEN_BUCKETS.has(b.name))
           .map((b) => {
             const utilization =
@@ -113,8 +108,21 @@ export function transformRawData(
               resets_at: b.reset > 0 ? new Date(b.reset * 1000).toISOString() : null,
               level,
             };
-          }),
-      })),
+          });
+        if (rp.unsupported && buckets.length === 0) {
+          return [];
+        }
+        return [
+          {
+            provider: normalizeRateLimitProviderLabel(rp.provider),
+            fetched_at: rp.fetched_at,
+            stale: rp.stale,
+            unsupported: Boolean(rp.unsupported),
+            reason: typeof rp.reason === "string" ? rp.reason : null,
+            buckets,
+          },
+        ];
+      }),
   };
 }
 

--- a/dashboard/src/components/office-view/OfficeInsightPanel.test.ts
+++ b/dashboard/src/components/office-view/OfficeInsightPanel.test.ts
@@ -10,7 +10,7 @@ describe("OfficeInsightPanel mini rate-limit helpers", () => {
     expect(normalizeMiniRateLimitProviderLabel("qwen")).toBe("Qwen");
   });
 
-  it("keeps unsupported providers visible instead of dropping them", () => {
+  it("drops unsupported providers without measurable buckets but keeps stale measurable rows", () => {
     const rows = transformRLProviders([
       {
         provider: "qwen",
@@ -24,17 +24,32 @@ describe("OfficeInsightPanel mini rate-limit helpers", () => {
         buckets: [{ name: "1h", limit: 100, used: 92, remaining: 8, reset: 1_700_000_600 }],
         stale: false,
       },
+      {
+        provider: "qwen",
+        buckets: [{ name: "1h", limit: 50, used: 10, remaining: 40, reset: 1_700_000_600 }],
+        stale: true,
+        unsupported: true,
+        reason: "Rendering last known measurable bucket until live telemetry lands.",
+      },
     ]);
 
-    expect(rows[0]).toMatchObject({
-      provider: "Qwen",
-      unsupported: true,
-      reason: "No Qwen rate-limit telemetry source is implemented yet.",
-    });
-    expect(rows[1]?.buckets[0]).toMatchObject({
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.provider).toBe("Gemini");
+    expect(rows[0]?.buckets[0]).toMatchObject({
       label: "1h",
       utilization: 92,
       level: "warning",
+    });
+    expect(rows[1]).toMatchObject({
+      provider: "Qwen",
+      stale: true,
+      unsupported: true,
+      reason: "Rendering last known measurable bucket until live telemetry lands.",
+    });
+    expect(rows[1]?.buckets[0]).toMatchObject({
+      label: "1h",
+      utilization: 20,
+      level: "normal",
     });
   });
 

--- a/dashboard/src/components/office-view/OfficeInsightPanel.tsx
+++ b/dashboard/src/components/office-view/OfficeInsightPanel.tsx
@@ -609,12 +609,8 @@ export function normalizeMiniRateLimitProviderLabel(provider: string): string {
 export function transformRLProviders(raw: RawRLProvider[]): RLProvider[] {
   return raw
     .filter((rp) => !RL_HIDDEN_PROVIDERS.has(rp.provider.toLowerCase()))
-    .map((rp) => ({
-      provider: normalizeMiniRateLimitProviderLabel(rp.provider),
-      stale: rp.stale,
-      unsupported: Boolean(rp.unsupported),
-      reason: typeof rp.reason === "string" ? rp.reason : null,
-      buckets: rp.buckets
+    .flatMap((rp) => {
+      const buckets = rp.buckets
         .filter((b) => !RL_HIDDEN_BUCKETS.has(b.name))
         .map((b) => {
           const utilization =
@@ -633,8 +629,20 @@ export function transformRLProviders(raw: RawRLProvider[]): RLProvider[] {
                   : "normal"
             ) as "normal" | "warning" | "danger",
           };
-        }),
-    }));
+        });
+      if (rp.unsupported && buckets.length === 0) {
+        return [];
+      }
+      return [
+        {
+          provider: normalizeMiniRateLimitProviderLabel(rp.provider),
+          stale: rp.stale,
+          unsupported: Boolean(rp.unsupported),
+          reason: typeof rp.reason === "string" ? rp.reason : null,
+          buckets,
+        },
+      ];
+    });
 }
 
 const RL_ICONS: Record<string, string> = {

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -96,7 +96,7 @@
 | `engine::ops::message_ops` | `src/engine/ops/message_ops.rs` | 275 |  |
 | `engine::ops::pipeline_ops` | `src/engine/ops/pipeline_ops.rs` | 206 |  |
 | `engine::ops::queue_ops` | `src/engine/ops/queue_ops.rs` | 195 |  |
-| `engine::ops::review_automation_ops` | `src/engine/ops/review_automation_ops.rs` | 1637 | giant-file |
+| `engine::ops::review_automation_ops` | `src/engine/ops/review_automation_ops.rs` | 2574 | giant-file |
 | `engine::ops::review_ops` | `src/engine/ops/review_ops.rs` | 676 |  |
 | `engine::ops::runtime_ops` | `src/engine/ops/runtime_ops.rs` | 106 |  |
 | `engine::sql_guard` | `src/engine/sql_guard.rs` | 230 |  |
@@ -225,7 +225,7 @@
 | `services::discord::org_writer` | `src/services/discord/org_writer.rs` | 239 |  |
 | `services::discord::prompt_builder` | `src/services/discord/prompt_builder.rs` | 1407 | giant-file |
 | `services::discord::queue_io` | `src/services/discord/queue_io.rs` | 565 |  |
-| `services::discord::recovery_engine` | `src/services/discord/recovery_engine.rs` | 2007 | giant-file |
+| `services::discord::recovery_engine` | `src/services/discord/recovery_engine.rs` | 2074 | giant-file |
 | `services::discord::restart_ctrl` | `src/services/discord/restart_ctrl.rs` | 113 |  |
 | `services::discord::restart_report` | `src/services/discord/restart_report.rs` | 488 |  |
 | `services::discord::role_map` | `src/services/discord/role_map.rs` | 908 |  |

--- a/policies/review-automation.js
+++ b/policies/review-automation.js
@@ -960,6 +960,14 @@ function markPrCreateFailed(cardId, reason, stampGen) {
     } catch (e) {
       agentdesk.log.warn("[review] escalateToManualIntervention failed: " + e);
     }
+    // Human escalation can overwrite blocked_reason with a readable message.
+    // Restore the machine-readable marker so merge automation stays in the
+    // create-pr failure lane.
+    agentdesk.db.execute(
+      "UPDATE kanban_cards SET blocked_reason = 'pr:create_failed_escalated:max_retries', " +
+      "updated_at = datetime('now') WHERE id = ?",
+      [cardId]
+    );
   } else {
     var blockedReason = "pr:create_failed:" + errorMsg;
     agentdesk.db.execute(

--- a/src/engine/ops/review_automation_ops.rs
+++ b/src/engine/ops/review_automation_ops.rs
@@ -312,7 +312,37 @@ async fn handoff_create_pr_pg(
             .await?
             .as_deref()
         {
-            Some("pending") | Some("dispatched") => {}
+            Some("pending") | Some("dispatched") => {
+                refresh_pg_pr_tracking_reuse_state(&mut tx, payload, &generation, current_round)
+                    .await?;
+                sqlx::query(
+                    "UPDATE kanban_cards
+                     SET blocked_reason = 'pr:creating',
+                         updated_at = NOW()
+                     WHERE id = $1",
+                )
+                .bind(&payload.card_id)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| {
+                    format!(
+                        "refresh postgres blocked_reason for {}: {e}",
+                        payload.card_id
+                    )
+                })?;
+                tx.commit().await.map_err(|e| {
+                    format!(
+                        "commit postgres create-pr reuse for {}: {e}",
+                        payload.card_id
+                    )
+                })?;
+                return Ok(json!({
+                    "ok": true,
+                    "reused": true,
+                    "dispatch_id": dispatch_id,
+                    "generation": generation,
+                }));
+            }
             Some("completed") => {
                 tx.commit().await.map_err(|e| {
                     format!(
@@ -333,34 +363,6 @@ async fn handoff_create_pr_pg(
                 // instead of rewinding terminal or failed state.
             }
         }
-        refresh_pg_pr_tracking_reuse_state(&mut tx, payload, &generation, current_round).await?;
-        sqlx::query(
-            "UPDATE kanban_cards
-             SET blocked_reason = 'pr:creating',
-                 updated_at = NOW()
-             WHERE id = $1",
-        )
-        .bind(&payload.card_id)
-        .execute(&mut *tx)
-        .await
-        .map_err(|e| {
-            format!(
-                "refresh postgres blocked_reason for {}: {e}",
-                payload.card_id
-            )
-        })?;
-        tx.commit().await.map_err(|e| {
-            format!(
-                "commit postgres create-pr reuse for {}: {e}",
-                payload.card_id
-            )
-        })?;
-        return Ok(json!({
-            "ok": true,
-            "reused": true,
-            "dispatch_id": dispatch_id,
-            "generation": generation,
-        }));
     }
 
     let card_exists = sqlx::query_scalar::<_, bool>(
@@ -616,7 +618,21 @@ fn handoff_create_pr_tx(db: &Db, payload: &HandoffPayload) -> anyhow::Result<ser
         lookup_active_create_pr_dispatch(&tx, &payload.card_id)?
     {
         match load_dispatch_status(&tx, &dispatch_id)?.as_deref() {
-            Some("pending") | Some("dispatched") => {}
+            Some("pending") | Some("dispatched") => {
+                refresh_pr_tracking_reuse_state(&tx, payload, &generation, current_round)?;
+                tx.execute(
+                    "UPDATE kanban_cards SET blocked_reason = 'pr:creating', updated_at = datetime('now') \
+                     WHERE id = ?1",
+                    [&payload.card_id],
+                )?;
+                tx.commit()?;
+                return Ok(json!({
+                    "ok": true,
+                    "reused": true,
+                    "dispatch_id": dispatch_id,
+                    "generation": generation,
+                }));
+            }
             Some("completed") => {
                 tx.commit()?;
                 return Ok(json!({
@@ -631,19 +647,6 @@ fn handoff_create_pr_tx(db: &Db, payload: &HandoffPayload) -> anyhow::Result<ser
                 // state back into create-pr reuse for a completed or failed lane.
             }
         }
-        refresh_pr_tracking_reuse_state(&tx, payload, &generation, current_round)?;
-        tx.execute(
-            "UPDATE kanban_cards SET blocked_reason = 'pr:creating', updated_at = datetime('now') \
-             WHERE id = ?1",
-            [&payload.card_id],
-        )?;
-        tx.commit()?;
-        return Ok(json!({
-            "ok": true,
-            "reused": true,
-            "dispatch_id": dispatch_id,
-            "generation": generation,
-        }));
     }
 
     // 3. Read card row for pipeline resolution + current status.

--- a/src/engine/ops/review_automation_ops.rs
+++ b/src/engine/ops/review_automation_ops.rs
@@ -235,6 +235,21 @@ async fn refresh_pg_pr_tracking_reuse_state(
     Ok(())
 }
 
+async fn load_pg_dispatch_status(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    dispatch_id: &str,
+) -> Result<Option<String>, String> {
+    sqlx::query_scalar::<_, String>(
+        "SELECT status
+         FROM task_dispatches
+         WHERE id = $1",
+    )
+    .bind(dispatch_id)
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(|e| format!("load postgres dispatch status for {dispatch_id}: {e}"))
+}
+
 async fn handoff_create_pr_pg(
     pool: &PgPool,
     payload: &HandoffPayload,
@@ -257,8 +272,20 @@ async fn handoff_create_pr_pg(
 
     let existing = sqlx::query(
         "SELECT td.id,
-                COALESCE((td.context::jsonb)->>'dispatch_generation', '') AS dispatch_generation
+                COALESCE(
+                    NULLIF(
+                        substring(
+                            COALESCE(td.context, '')
+                            FROM '\"dispatch_generation\"\\s*:\\s*\"([^\"]+)\"'
+                        ),
+                        ''
+                    ),
+                    pt.dispatch_generation,
+                    ''
+                ) AS dispatch_generation
          FROM task_dispatches td
+         LEFT JOIN pr_tracking pt
+                ON pt.card_id = td.kanban_card_id
          WHERE td.kanban_card_id = $1
            AND td.dispatch_type = 'create-pr'
            AND td.status IN ('pending', 'dispatched')
@@ -281,6 +308,31 @@ async fn handoff_create_pr_pg(
         let generation = existing
             .try_get::<String, _>("dispatch_generation")
             .map_err(|e| format!("decode active postgres create-pr generation: {e}"))?;
+        match load_pg_dispatch_status(&mut tx, &dispatch_id)
+            .await?
+            .as_deref()
+        {
+            Some("pending") | Some("dispatched") => {}
+            Some("completed") => {
+                tx.commit().await.map_err(|e| {
+                    format!(
+                        "commit postgres create-pr completed reuse for {}: {e}",
+                        payload.card_id
+                    )
+                })?;
+                return Ok(json!({
+                    "ok": true,
+                    "reused": true,
+                    "dispatch_id": dispatch_id,
+                    "generation": generation,
+                }));
+            }
+            _ => {
+                // The candidate dispatch stopped being active before we refreshed
+                // pr_tracking/blocked_reason. Fall through to the fresh handoff path
+                // instead of rewinding terminal or failed state.
+            }
+        }
         refresh_pg_pr_tracking_reuse_state(&mut tx, payload, &generation, current_round).await?;
         sqlx::query(
             "UPDATE kanban_cards
@@ -527,6 +579,21 @@ fn refresh_pr_tracking_reuse_state(
     Ok(())
 }
 
+fn load_dispatch_status(
+    tx: &libsql_rusqlite::Transaction<'_>,
+    dispatch_id: &str,
+) -> anyhow::Result<Option<String>> {
+    tx.query_row(
+        "SELECT status
+         FROM task_dispatches
+         WHERE id = ?1",
+        [dispatch_id],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(|e| anyhow::anyhow!("load dispatch status for {dispatch_id}: {e}"))
+}
+
 fn handoff_create_pr_tx(db: &Db, payload: &HandoffPayload) -> anyhow::Result<serde_json::Value> {
     let mut conn = db
         .separate_conn()
@@ -548,6 +615,22 @@ fn handoff_create_pr_tx(db: &Db, payload: &HandoffPayload) -> anyhow::Result<ser
     if let Some((dispatch_id, generation)) =
         lookup_active_create_pr_dispatch(&tx, &payload.card_id)?
     {
+        match load_dispatch_status(&tx, &dispatch_id)?.as_deref() {
+            Some("pending") | Some("dispatched") => {}
+            Some("completed") => {
+                tx.commit()?;
+                return Ok(json!({
+                    "ok": true,
+                    "reused": true,
+                    "dispatch_id": dispatch_id,
+                    "generation": generation,
+                }));
+            }
+            _ => {
+                // The dispatch is no longer active; do not rewind card/tracking
+                // state back into create-pr reuse for a completed or failed lane.
+            }
+        }
         refresh_pr_tracking_reuse_state(&tx, payload, &generation, current_round)?;
         tx.execute(
             "UPDATE kanban_cards SET blocked_reason = 'pr:creating', updated_at = datetime('now') \
@@ -1217,6 +1300,41 @@ mod tests {
     }
 
     #[test]
+    fn sqlite_lookup_active_create_pr_dispatch_surfaces_malformed_context_errors() {
+        let mut conn =
+            libsql_rusqlite::Connection::open_in_memory().expect("open sqlite memory db");
+        conn.execute_batch(
+            "CREATE TABLE task_dispatches (
+                id TEXT PRIMARY KEY,
+                kanban_card_id TEXT,
+                dispatch_type TEXT,
+                status TEXT,
+                context TEXT
+            );",
+        )
+        .expect("create task_dispatches table");
+
+        let tx = conn.transaction().expect("open sqlite transaction");
+        tx.execute(
+            "INSERT INTO task_dispatches (id, kanban_card_id, dispatch_type, status, context)
+             VALUES (?1, ?2, 'create-pr', 'pending', ?3)",
+            libsql_rusqlite::params![
+                "dispatch-sqlite-malformed",
+                "card-sqlite-malformed",
+                "{not-json",
+            ],
+        )
+        .expect("seed malformed sqlite dispatch context");
+
+        let err = lookup_active_create_pr_dispatch(&tx, "card-sqlite-malformed")
+            .expect_err("malformed context should surface lookup error");
+        assert!(
+            err.to_string().contains("lookup active create-pr dispatch"),
+            "unexpected malformed-context error: {err}"
+        );
+    }
+
+    #[test]
     fn sqlite_reuse_refresh_preserves_existing_tracking_target_fields() {
         let mut conn =
             libsql_rusqlite::Connection::open_in_memory().expect("open sqlite memory db");
@@ -1323,6 +1441,196 @@ mod tests {
         assert_eq!(tracked.6.as_deref(), Some("generation-new"));
         assert_eq!(tracked.7, 9);
         assert_eq!(tracked.8, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn review_automation_pg_handoff_reuses_dispatch_with_malformed_context() {
+        let test_db = TestDatabase::create().await;
+        let pool = test_db.migrate().await;
+
+        sqlx::query(
+            "INSERT INTO agents (id, name, provider, status)
+             VALUES ($1, $2, 'codex', 'idle')",
+        )
+        .bind("agent-reviewer")
+        .bind("Reviewer Agent")
+        .execute(&pool)
+        .await
+        .expect("insert reviewer agent");
+
+        sqlx::query(
+            "INSERT INTO kanban_cards (id, title, status, repo_id, assigned_agent_id)
+             VALUES ($1, $2, 'review', $3, $4)",
+        )
+        .bind("card-pg-malformed-context")
+        .bind("PG malformed create-pr context")
+        .bind("repo-tracked")
+        .bind("agent-reviewer")
+        .execute(&pool)
+        .await
+        .expect("insert kanban card");
+
+        sqlx::query(
+            "INSERT INTO card_review_state (card_id, review_round, state)
+             VALUES ($1, 7, 'in_review')",
+        )
+        .bind("card-pg-malformed-context")
+        .execute(&pool)
+        .await
+        .expect("insert card review state");
+
+        sqlx::query(
+            "INSERT INTO pr_tracking (
+                card_id,
+                repo_id,
+                worktree_path,
+                branch,
+                head_sha,
+                state,
+                last_error,
+                dispatch_generation,
+                review_round,
+                retry_count,
+                created_at,
+                updated_at
+             ) VALUES (
+                $1, $2, $3, $4, $5, 'escalated', 'stale error', $6, 2, 4, NOW(), NOW()
+             )",
+        )
+        .bind("card-pg-malformed-context")
+        .bind("repo-tracked")
+        .bind("/tracked/worktree")
+        .bind("tracked/branch")
+        .bind("tracked-head")
+        .bind("tracked-generation")
+        .execute(&pool)
+        .await
+        .expect("seed tracked pr_tracking row");
+
+        sqlx::query(
+            "INSERT INTO task_dispatches (
+                id,
+                kanban_card_id,
+                dispatch_type,
+                status,
+                context,
+                created_at,
+                updated_at
+             ) VALUES (
+                $1, $2, 'create-pr', 'pending', $3, NOW(), NOW()
+             )",
+        )
+        .bind("dispatch-pg-malformed-context")
+        .bind("card-pg-malformed-context")
+        .bind("{not-json")
+        .execute(&pool)
+        .await
+        .expect("seed pending dispatch with malformed context");
+
+        let payload = HandoffPayload {
+            card_id: "card-pg-malformed-context".to_string(),
+            repo_id: "repo-new".to_string(),
+            worktree_path: Some("/new/worktree".to_string()),
+            branch: "new/branch".to_string(),
+            head_sha: Some("new-head".to_string()),
+            agent_id: "agent-reviewer".to_string(),
+            title: "Create PR".to_string(),
+        };
+
+        let reused = handoff_create_pr_pg(&pool, &payload)
+            .await
+            .expect("reuse should tolerate malformed postgres context");
+        assert_eq!(reused["ok"], true);
+        assert_eq!(reused["reused"], true);
+        assert_eq!(reused["dispatch_id"], "dispatch-pg-malformed-context");
+        assert_eq!(reused["generation"], "tracked-generation");
+
+        let tracking = sqlx::query(
+            "SELECT pt.repo_id,
+                    pt.worktree_path,
+                    pt.branch,
+                    pt.head_sha,
+                    pt.state,
+                    pt.last_error,
+                    pt.dispatch_generation,
+                    pt.review_round,
+                    pt.retry_count,
+                    kc.blocked_reason
+             FROM pr_tracking pt
+             JOIN kanban_cards kc ON kc.id = pt.card_id
+             WHERE pt.card_id = $1",
+        )
+        .bind("card-pg-malformed-context")
+        .fetch_one(&pool)
+        .await
+        .expect("load refreshed tracking state");
+
+        assert_eq!(
+            tracking
+                .try_get::<String, _>("repo_id")
+                .expect("decode repo_id"),
+            "repo-tracked"
+        );
+        assert_eq!(
+            tracking
+                .try_get::<Option<String>, _>("worktree_path")
+                .expect("decode worktree_path")
+                .as_deref(),
+            Some("/tracked/worktree")
+        );
+        assert_eq!(
+            tracking
+                .try_get::<String, _>("branch")
+                .expect("decode branch"),
+            "tracked/branch"
+        );
+        assert_eq!(
+            tracking
+                .try_get::<Option<String>, _>("head_sha")
+                .expect("decode head_sha")
+                .as_deref(),
+            Some("tracked-head")
+        );
+        assert_eq!(
+            tracking
+                .try_get::<String, _>("state")
+                .expect("decode state"),
+            "create-pr"
+        );
+        assert_eq!(
+            tracking
+                .try_get::<Option<String>, _>("last_error")
+                .expect("decode last_error"),
+            None
+        );
+        assert_eq!(
+            tracking
+                .try_get::<String, _>("dispatch_generation")
+                .expect("decode generation"),
+            "tracked-generation"
+        );
+        assert_eq!(
+            tracking
+                .try_get::<i32, _>("review_round")
+                .expect("decode review_round"),
+            7
+        );
+        assert_eq!(
+            tracking
+                .try_get::<i32, _>("retry_count")
+                .expect("decode retry_count"),
+            0
+        );
+        assert_eq!(
+            tracking
+                .try_get::<Option<String>, _>("blocked_reason")
+                .expect("decode blocked_reason")
+                .as_deref(),
+            Some("pr:creating")
+        );
+
+        pool.close().await;
+        test_db.drop().await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/engine/ops/review_automation_ops.rs
+++ b/src/engine/ops/review_automation_ops.rs
@@ -507,8 +507,14 @@ fn lookup_active_create_pr_dispatch(
 ) -> anyhow::Result<Option<(String, String)>> {
     conn.query_row(
         "SELECT td.id,
-                COALESCE(json_extract(COALESCE(td.context, '{}'), '$.dispatch_generation'), '')
+                COALESCE(
+                    NULLIF(json_extract(COALESCE(td.context, '{}'), '$.dispatch_generation'), ''),
+                    pt.dispatch_generation,
+                    ''
+                )
          FROM task_dispatches td
+         LEFT JOIN pr_tracking pt
+                ON pt.card_id = td.kanban_card_id
          WHERE td.kanban_card_id = ?1
            AND td.dispatch_type = 'create-pr'
            AND td.status IN ('pending', 'dispatched')
@@ -1444,6 +1450,51 @@ mod tests {
         assert_eq!(tracked.6.as_deref(), Some("generation-new"));
         assert_eq!(tracked.7, 9);
         assert_eq!(tracked.8, 0);
+    }
+
+    #[test]
+    fn sqlite_lookup_active_create_pr_dispatch_falls_back_to_tracking_generation() {
+        let mut conn =
+            libsql_rusqlite::Connection::open_in_memory().expect("open sqlite memory db");
+        conn.execute_batch(
+            "CREATE TABLE task_dispatches (
+                id TEXT PRIMARY KEY,
+                kanban_card_id TEXT,
+                dispatch_type TEXT,
+                status TEXT,
+                context TEXT
+            );
+            CREATE TABLE pr_tracking (
+                card_id TEXT PRIMARY KEY,
+                dispatch_generation TEXT
+            );",
+        )
+        .expect("create sqlite tables");
+
+        let tx = conn.transaction().expect("open sqlite transaction");
+        tx.execute(
+            "INSERT INTO task_dispatches (id, kanban_card_id, dispatch_type, status, context)
+             VALUES (?1, ?2, 'create-pr', 'pending', ?3)",
+            libsql_rusqlite::params![
+                "dispatch-sqlite-fallback",
+                "card-sqlite-fallback",
+                "{\"note\":\"legacy-context-without-generation\"}",
+            ],
+        )
+        .expect("seed sqlite dispatch row");
+        tx.execute(
+            "INSERT INTO pr_tracking (card_id, dispatch_generation)
+             VALUES (?1, ?2)",
+            libsql_rusqlite::params!["card-sqlite-fallback", "tracked-generation-42"],
+        )
+        .expect("seed sqlite tracking row");
+
+        let active = lookup_active_create_pr_dispatch(&tx, "card-sqlite-fallback")
+            .expect("lookup sqlite active dispatch")
+            .expect("active dispatch should exist");
+
+        assert_eq!(active.0, "dispatch-sqlite-fallback");
+        assert_eq!(active.1, "tracked-generation-42");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/engine/ops/review_automation_ops.rs
+++ b/src/engine/ops/review_automation_ops.rs
@@ -151,7 +151,7 @@ fn handoff_create_pr_raw(db: &Db, pg_pool: Option<&PgPool>, payload_json: &str) 
     }
 }
 
-async fn upsert_pg_pr_tracking_handoff_state(
+async fn seed_pg_pr_tracking_handoff_state(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     payload: &HandoffPayload,
     generation: &str,
@@ -196,6 +196,41 @@ async fn upsert_pg_pr_tracking_handoff_state(
     .execute(&mut **tx)
     .await
     .map_err(|e| format!("upsert postgres pr_tracking for {}: {e}", payload.card_id))?;
+
+    Ok(())
+}
+
+async fn refresh_pg_pr_tracking_reuse_state(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    payload: &HandoffPayload,
+    generation: &str,
+    current_round: i64,
+) -> Result<(), String> {
+    let updated = sqlx::query(
+        "UPDATE pr_tracking
+         SET state = 'create-pr',
+             last_error = NULL,
+             dispatch_generation = $1,
+             review_round = $2,
+             retry_count = 0,
+             updated_at = NOW()
+         WHERE card_id = $3",
+    )
+    .bind(generation)
+    .bind(current_round)
+    .bind(&payload.card_id)
+    .execute(&mut **tx)
+    .await
+    .map_err(|e| {
+        format!(
+            "refresh postgres reused pr_tracking for {}: {e}",
+            payload.card_id
+        )
+    })?;
+
+    if updated.rows_affected() == 0 {
+        seed_pg_pr_tracking_handoff_state(tx, payload, generation, current_round).await?;
+    }
 
     Ok(())
 }
@@ -246,7 +281,7 @@ async fn handoff_create_pr_pg(
         let generation = existing
             .try_get::<String, _>("dispatch_generation")
             .map_err(|e| format!("decode active postgres create-pr generation: {e}"))?;
-        upsert_pg_pr_tracking_handoff_state(&mut tx, payload, &generation, current_round).await?;
+        refresh_pg_pr_tracking_reuse_state(&mut tx, payload, &generation, current_round).await?;
         sqlx::query(
             "UPDATE kanban_cards
              SET blocked_reason = 'pr:creating',
@@ -294,7 +329,7 @@ async fn handoff_create_pr_pg(
     let generation = Uuid::new_v4().to_string();
     let dispatch_id = Uuid::new_v4().to_string();
 
-    upsert_pg_pr_tracking_handoff_state(&mut tx, payload, &generation, current_round).await?;
+    seed_pg_pr_tracking_handoff_state(&mut tx, payload, &generation, current_round).await?;
 
     let context = json!({
         "dispatch_generation": generation,
@@ -415,7 +450,7 @@ async fn handoff_create_pr_pg(
 fn lookup_active_create_pr_dispatch(
     conn: &libsql_rusqlite::Transaction<'_>,
     card_id: &str,
-) -> Option<(String, String)> {
+) -> anyhow::Result<Option<(String, String)>> {
     conn.query_row(
         "SELECT td.id,
                 COALESCE(json_extract(COALESCE(td.context, '{}'), '$.dispatch_generation'), '')
@@ -427,10 +462,11 @@ fn lookup_active_create_pr_dispatch(
         [card_id],
         |row| Ok((row.get(0)?, row.get(1)?)),
     )
-    .ok()
+    .optional()
+    .map_err(|e| anyhow::anyhow!("lookup active create-pr dispatch for {card_id}: {e}"))
 }
 
-fn upsert_pr_tracking_handoff_state(
+fn seed_pr_tracking_handoff_state(
     tx: &libsql_rusqlite::Transaction<'_>,
     payload: &HandoffPayload,
     generation: &str,
@@ -466,6 +502,31 @@ fn upsert_pr_tracking_handoff_state(
     Ok(())
 }
 
+fn refresh_pr_tracking_reuse_state(
+    tx: &libsql_rusqlite::Transaction<'_>,
+    payload: &HandoffPayload,
+    generation: &str,
+    current_round: i64,
+) -> anyhow::Result<()> {
+    let updated = tx.execute(
+        "UPDATE pr_tracking SET \
+           state = 'create-pr', \
+           last_error = NULL, \
+           dispatch_generation = ?1, \
+           review_round = ?2, \
+           retry_count = 0, \
+           updated_at = CURRENT_TIMESTAMP \
+         WHERE card_id = ?3",
+        libsql_rusqlite::params![generation, current_round, payload.card_id],
+    )?;
+
+    if updated == 0 {
+        seed_pr_tracking_handoff_state(tx, payload, generation, current_round)?;
+    }
+
+    Ok(())
+}
+
 fn handoff_create_pr_tx(db: &Db, payload: &HandoffPayload) -> anyhow::Result<serde_json::Value> {
     let mut conn = db
         .separate_conn()
@@ -484,9 +545,10 @@ fn handoff_create_pr_tx(db: &Db, payload: &HandoffPayload) -> anyhow::Result<ser
 
     // 2. Idempotent reuse — refresh pr_tracking to the active dispatch stamp so
     //    stale generations do not leak into retry logic.
-    if let Some((dispatch_id, generation)) = lookup_active_create_pr_dispatch(&tx, &payload.card_id)
+    if let Some((dispatch_id, generation)) =
+        lookup_active_create_pr_dispatch(&tx, &payload.card_id)?
     {
-        upsert_pr_tracking_handoff_state(&tx, payload, &generation, current_round)?;
+        refresh_pr_tracking_reuse_state(&tx, payload, &generation, current_round)?;
         tx.execute(
             "UPDATE kanban_cards SET blocked_reason = 'pr:creating', updated_at = datetime('now') \
              WHERE id = ?1",
@@ -520,7 +582,7 @@ fn handoff_create_pr_tx(db: &Db, payload: &HandoffPayload) -> anyhow::Result<ser
     let dispatch_id = Uuid::new_v4().to_string();
 
     // 6. pr_tracking upsert with stamp.
-    upsert_pr_tracking_handoff_state(&tx, payload, &generation, current_round)?;
+    seed_pr_tracking_handoff_state(&tx, payload, &generation, current_round)?;
 
     // 7. Build dispatch context with stamps.
     let context = json!({
@@ -1140,6 +1202,129 @@ mod tests {
         format!("{}/{}", base_database_url(), admin_db)
     }
 
+    #[test]
+    fn sqlite_lookup_active_create_pr_dispatch_surfaces_query_errors() {
+        let mut conn =
+            libsql_rusqlite::Connection::open_in_memory().expect("open sqlite memory db");
+        let tx = conn.transaction().expect("open sqlite transaction");
+
+        let err = lookup_active_create_pr_dispatch(&tx, "card-sqlite-missing-table")
+            .expect_err("missing task_dispatches table should error");
+        assert!(
+            err.to_string().contains("lookup active create-pr dispatch"),
+            "unexpected lookup error: {err}"
+        );
+    }
+
+    #[test]
+    fn sqlite_reuse_refresh_preserves_existing_tracking_target_fields() {
+        let mut conn =
+            libsql_rusqlite::Connection::open_in_memory().expect("open sqlite memory db");
+        conn.execute_batch(
+            "CREATE TABLE pr_tracking (
+                card_id TEXT PRIMARY KEY,
+                repo_id TEXT,
+                worktree_path TEXT,
+                branch TEXT,
+                head_sha TEXT,
+                state TEXT,
+                last_error TEXT,
+                dispatch_generation TEXT,
+                review_round INTEGER,
+                retry_count INTEGER,
+                created_at TEXT,
+                updated_at TEXT
+            );",
+        )
+        .expect("create pr_tracking table");
+
+        let tx = conn.transaction().expect("open sqlite transaction");
+        tx.execute(
+            "INSERT INTO pr_tracking (
+                card_id,
+                repo_id,
+                worktree_path,
+                branch,
+                head_sha,
+                state,
+                last_error,
+                dispatch_generation,
+                review_round,
+                retry_count,
+                created_at,
+                updated_at
+             ) VALUES (
+                ?1, ?2, ?3, ?4, ?5, 'escalated', 'stale error', ?6, ?7, 3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+             )",
+            libsql_rusqlite::params![
+                "card-sqlite-reuse",
+                "repo-tracked",
+                "/tracked/worktree",
+                "tracked/branch",
+                "tracked-head",
+                "generation-old",
+                4_i64,
+            ],
+        )
+        .expect("seed tracked row");
+
+        let payload = HandoffPayload {
+            card_id: "card-sqlite-reuse".to_string(),
+            repo_id: "repo-new".to_string(),
+            worktree_path: Some("/new/worktree".to_string()),
+            branch: "new/branch".to_string(),
+            head_sha: Some("new-head".to_string()),
+            agent_id: "agent-reviewer".to_string(),
+            title: "Create PR".to_string(),
+        };
+
+        refresh_pr_tracking_reuse_state(&tx, &payload, "generation-new", 9)
+            .expect("refresh reused tracking row");
+
+        let tracked = tx
+            .query_row(
+                "SELECT
+                    repo_id,
+                    worktree_path,
+                    branch,
+                    head_sha,
+                    state,
+                    last_error,
+                    dispatch_generation,
+                    review_round,
+                    retry_count
+                 FROM pr_tracking
+                 WHERE card_id = ?1",
+                [&payload.card_id],
+                |row| {
+                    Ok((
+                        row.get::<_, Option<String>>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                        row.get::<_, Option<String>>(2)?,
+                        row.get::<_, Option<String>>(3)?,
+                        row.get::<_, Option<String>>(4)?,
+                        row.get::<_, Option<String>>(5)?,
+                        row.get::<_, Option<String>>(6)?,
+                        row.get::<_, i64>(7)?,
+                        row.get::<_, i64>(8)?,
+                    ))
+                },
+            )
+            .optional()
+            .expect("query refreshed tracking row")
+            .expect("tracking row should exist");
+
+        assert_eq!(tracked.0.as_deref(), Some("repo-tracked"));
+        assert_eq!(tracked.1.as_deref(), Some("/tracked/worktree"));
+        assert_eq!(tracked.2.as_deref(), Some("tracked/branch"));
+        assert_eq!(tracked.3.as_deref(), Some("tracked-head"));
+        assert_eq!(tracked.4.as_deref(), Some("create-pr"));
+        assert_eq!(tracked.5, None);
+        assert_eq!(tracked.6.as_deref(), Some("generation-new"));
+        assert_eq!(tracked.7, 9);
+        assert_eq!(tracked.8, 0);
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn review_automation_pg_handoff_failure_and_reseed_round_trip() {
         let test_db = TestDatabase::create().await;
@@ -1313,7 +1498,15 @@ mod tests {
         .await
         .expect("clear blocked reason before reuse");
 
-        let second_handoff = handoff_create_pr_pg(&pool, &payload)
+        let reused_payload = HandoffPayload {
+            repo_id: "repo-reused-override".to_string(),
+            worktree_path: Some("/tmp/worktree/reused-override".to_string()),
+            branch: "feature/reused-override".to_string(),
+            head_sha: Some("override-head-456".to_string()),
+            ..payload.clone()
+        };
+
+        let second_handoff = handoff_create_pr_pg(&pool, &reused_payload)
             .await
             .expect("second handoff create pr");
         assert_eq!(second_handoff["ok"], true);
@@ -1322,7 +1515,12 @@ mod tests {
         assert_eq!(second_handoff["generation"], generation);
 
         let reused_tracking = sqlx::query(
-            "SELECT dispatch_generation, blocked_reason
+            "SELECT pt.repo_id,
+                    pt.worktree_path,
+                    pt.branch,
+                    pt.head_sha,
+                    pt.dispatch_generation,
+                    kc.blocked_reason
              FROM pr_tracking pt
              JOIN kanban_cards kc ON kc.id = pt.card_id
              WHERE pt.card_id = $1",
@@ -1331,6 +1529,32 @@ mod tests {
         .fetch_one(&pool)
         .await
         .expect("load refreshed postgres reuse state");
+        assert_eq!(
+            reused_tracking
+                .try_get::<String, _>("repo_id")
+                .expect("decode refreshed postgres repo_id"),
+            payload.repo_id
+        );
+        assert_eq!(
+            reused_tracking
+                .try_get::<Option<String>, _>("worktree_path")
+                .expect("decode refreshed postgres worktree_path")
+                .as_deref(),
+            payload.worktree_path.as_deref()
+        );
+        assert_eq!(
+            reused_tracking
+                .try_get::<String, _>("branch")
+                .expect("decode refreshed postgres branch"),
+            payload.branch
+        );
+        assert_eq!(
+            reused_tracking
+                .try_get::<Option<String>, _>("head_sha")
+                .expect("decode refreshed postgres head_sha")
+                .as_deref(),
+            payload.head_sha.as_deref()
+        );
         assert_eq!(
             reused_tracking
                 .try_get::<String, _>("dispatch_generation")

--- a/src/engine/ops/review_automation_ops.rs
+++ b/src/engine/ops/review_automation_ops.rs
@@ -200,26 +200,81 @@ async fn seed_pg_pr_tracking_handoff_state(
     Ok(())
 }
 
-async fn refresh_pg_pr_tracking_reuse_state(
+async fn refresh_pg_pr_tracking_reuse_state_if_active(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     payload: &HandoffPayload,
+    dispatch_id: &str,
     generation: &str,
     current_round: i64,
-) -> Result<(), String> {
-    let updated = sqlx::query(
-        "UPDATE pr_tracking
-         SET state = 'create-pr',
-             last_error = NULL,
-             dispatch_generation = $1,
-             review_round = $2,
-             retry_count = 0,
-             updated_at = NOW()
-         WHERE card_id = $3",
+) -> Result<bool, String> {
+    let refreshed = sqlx::query(
+        "WITH active_dispatch AS (
+             SELECT id
+             FROM task_dispatches
+             WHERE id = $8
+               AND status IN ('pending', 'dispatched')
+             FOR UPDATE
+         ),
+         upsert_tracking AS (
+             INSERT INTO pr_tracking (
+                 card_id,
+                 repo_id,
+                 worktree_path,
+                 branch,
+                 head_sha,
+                 state,
+                 last_error,
+                 dispatch_generation,
+                 review_round,
+                 retry_count,
+                 created_at,
+                 updated_at
+             )
+             SELECT
+                 $1,
+                 $2,
+                 $3,
+                 $4,
+                 $5,
+                 'create-pr',
+                 NULL,
+                 $6,
+                 $7,
+                 0,
+                 NOW(),
+                 NOW()
+             FROM active_dispatch
+             ON CONFLICT (card_id) DO UPDATE
+             SET state = 'create-pr',
+                 last_error = NULL,
+                 dispatch_generation = EXCLUDED.dispatch_generation,
+                 review_round = EXCLUDED.review_round,
+                 retry_count = 0,
+                 updated_at = NOW()
+             RETURNING 1
+         ),
+         update_card AS (
+             UPDATE kanban_cards
+             SET blocked_reason = 'pr:creating',
+                 updated_at = NOW()
+             WHERE id = $1
+               AND EXISTS (SELECT 1 FROM active_dispatch)
+             RETURNING 1
+         )
+         SELECT
+             EXISTS (SELECT 1 FROM active_dispatch) AS dispatch_active,
+             EXISTS (SELECT 1 FROM upsert_tracking) AS tracking_updated,
+             EXISTS (SELECT 1 FROM update_card) AS card_updated",
     )
+    .bind(&payload.card_id)
+    .bind(&payload.repo_id)
+    .bind(payload.worktree_path.as_deref())
+    .bind(&payload.branch)
+    .bind(payload.head_sha.as_deref())
     .bind(generation)
     .bind(current_round)
-    .bind(&payload.card_id)
-    .execute(&mut **tx)
+    .bind(dispatch_id)
+    .fetch_one(&mut **tx)
     .await
     .map_err(|e| {
         format!(
@@ -228,11 +283,30 @@ async fn refresh_pg_pr_tracking_reuse_state(
         )
     })?;
 
-    if updated.rows_affected() == 0 {
-        seed_pg_pr_tracking_handoff_state(tx, payload, generation, current_round).await?;
-    }
+    let dispatch_active = refreshed
+        .try_get::<bool, _>("dispatch_active")
+        .map_err(|e| {
+            format!(
+                "decode postgres reuse dispatch_active for {}: {e}",
+                payload.card_id
+            )
+        })?;
+    let tracking_updated = refreshed
+        .try_get::<bool, _>("tracking_updated")
+        .map_err(|e| {
+            format!(
+                "decode postgres reuse tracking_updated for {}: {e}",
+                payload.card_id
+            )
+        })?;
+    let card_updated = refreshed.try_get::<bool, _>("card_updated").map_err(|e| {
+        format!(
+            "decode postgres reuse card_updated for {}: {e}",
+            payload.card_id
+        )
+    })?;
 
-    Ok(())
+    Ok(dispatch_active && tracking_updated && card_updated)
 }
 
 async fn load_pg_dispatch_status(
@@ -308,41 +382,33 @@ async fn handoff_create_pr_pg(
         let generation = existing
             .try_get::<String, _>("dispatch_generation")
             .map_err(|e| format!("decode active postgres create-pr generation: {e}"))?;
+        if refresh_pg_pr_tracking_reuse_state_if_active(
+            &mut tx,
+            payload,
+            &dispatch_id,
+            &generation,
+            current_round,
+        )
+        .await?
+        {
+            tx.commit().await.map_err(|e| {
+                format!(
+                    "commit postgres create-pr reuse for {}: {e}",
+                    payload.card_id
+                )
+            })?;
+            return Ok(json!({
+                "ok": true,
+                "reused": true,
+                "dispatch_id": dispatch_id,
+                "generation": generation,
+            }));
+        }
+
         match load_pg_dispatch_status(&mut tx, &dispatch_id)
             .await?
             .as_deref()
         {
-            Some("pending") | Some("dispatched") => {
-                refresh_pg_pr_tracking_reuse_state(&mut tx, payload, &generation, current_round)
-                    .await?;
-                sqlx::query(
-                    "UPDATE kanban_cards
-                     SET blocked_reason = 'pr:creating',
-                         updated_at = NOW()
-                     WHERE id = $1",
-                )
-                .bind(&payload.card_id)
-                .execute(&mut *tx)
-                .await
-                .map_err(|e| {
-                    format!(
-                        "refresh postgres blocked_reason for {}: {e}",
-                        payload.card_id
-                    )
-                })?;
-                tx.commit().await.map_err(|e| {
-                    format!(
-                        "commit postgres create-pr reuse for {}: {e}",
-                        payload.card_id
-                    )
-                })?;
-                return Ok(json!({
-                    "ok": true,
-                    "reused": true,
-                    "dispatch_id": dispatch_id,
-                    "generation": generation,
-                }));
-            }
             Some("completed") => {
                 tx.commit().await.map_err(|e| {
                     format!(
@@ -1681,6 +1747,193 @@ mod tests {
                 .expect("decode blocked_reason")
                 .as_deref(),
             Some("pr:creating")
+        );
+
+        pool.close().await;
+        test_db.drop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn review_automation_pg_reuse_state_guard_skips_inactive_dispatch() {
+        let test_db = TestDatabase::create().await;
+        let pool = test_db.migrate().await;
+
+        sqlx::query(
+            "INSERT INTO kanban_cards (id, title, status, repo_id)
+             VALUES ($1, $2, 'review', $3)",
+        )
+        .bind("card-pg-inactive-reuse")
+        .bind("PG inactive reuse guard")
+        .bind("repo-tracked")
+        .execute(&pool)
+        .await
+        .expect("insert kanban card");
+
+        sqlx::query(
+            "UPDATE kanban_cards
+             SET blocked_reason = 'pr:failed'
+             WHERE id = $1",
+        )
+        .bind("card-pg-inactive-reuse")
+        .execute(&pool)
+        .await
+        .expect("seed blocked_reason");
+
+        sqlx::query(
+            "INSERT INTO pr_tracking (
+                card_id,
+                repo_id,
+                worktree_path,
+                branch,
+                head_sha,
+                state,
+                last_error,
+                dispatch_generation,
+                review_round,
+                retry_count,
+                created_at,
+                updated_at
+             ) VALUES (
+                $1, $2, $3, $4, $5, 'wait-ci', 'dispatch failed', $6, 4, 2, NOW(), NOW()
+             )",
+        )
+        .bind("card-pg-inactive-reuse")
+        .bind("repo-tracked")
+        .bind("/tracked/worktree")
+        .bind("tracked/branch")
+        .bind("tracked-head")
+        .bind("tracked-generation")
+        .execute(&pool)
+        .await
+        .expect("seed tracked pr_tracking row");
+
+        sqlx::query(
+            "INSERT INTO task_dispatches (
+                id,
+                kanban_card_id,
+                dispatch_type,
+                status,
+                context,
+                created_at,
+                updated_at
+             ) VALUES (
+                $1, $2, 'create-pr', 'failed', $3, NOW(), NOW()
+             )",
+        )
+        .bind("dispatch-pg-inactive-reuse")
+        .bind("card-pg-inactive-reuse")
+        .bind("{\"dispatch_generation\":\"tracked-generation\"}")
+        .execute(&pool)
+        .await
+        .expect("seed failed dispatch");
+
+        let payload = HandoffPayload {
+            card_id: "card-pg-inactive-reuse".to_string(),
+            repo_id: "repo-new".to_string(),
+            worktree_path: Some("/new/worktree".to_string()),
+            branch: "new/branch".to_string(),
+            head_sha: Some("new-head".to_string()),
+            agent_id: "agent-reviewer".to_string(),
+            title: "Create PR".to_string(),
+        };
+
+        let mut tx = pool.begin().await.expect("begin tx");
+        let applied = refresh_pg_pr_tracking_reuse_state_if_active(
+            &mut tx,
+            &payload,
+            "dispatch-pg-inactive-reuse",
+            "generation-new",
+            8,
+        )
+        .await
+        .expect("inactive dispatch should skip reuse rewrites");
+        tx.commit().await.expect("commit tx");
+
+        assert!(!applied);
+
+        let tracking = sqlx::query(
+            "SELECT pt.repo_id,
+                    pt.worktree_path,
+                    pt.branch,
+                    pt.head_sha,
+                    pt.state,
+                    pt.last_error,
+                    pt.dispatch_generation,
+                    pt.review_round,
+                    pt.retry_count,
+                    kc.blocked_reason
+             FROM pr_tracking pt
+             JOIN kanban_cards kc ON kc.id = pt.card_id
+             WHERE pt.card_id = $1",
+        )
+        .bind("card-pg-inactive-reuse")
+        .fetch_one(&pool)
+        .await
+        .expect("load tracking after inactive reuse attempt");
+
+        assert_eq!(
+            tracking
+                .try_get::<String, _>("repo_id")
+                .expect("decode repo_id"),
+            "repo-tracked"
+        );
+        assert_eq!(
+            tracking
+                .try_get::<Option<String>, _>("worktree_path")
+                .expect("decode worktree_path")
+                .as_deref(),
+            Some("/tracked/worktree")
+        );
+        assert_eq!(
+            tracking
+                .try_get::<String, _>("branch")
+                .expect("decode branch"),
+            "tracked/branch"
+        );
+        assert_eq!(
+            tracking
+                .try_get::<Option<String>, _>("head_sha")
+                .expect("decode head_sha")
+                .as_deref(),
+            Some("tracked-head")
+        );
+        assert_eq!(
+            tracking
+                .try_get::<String, _>("state")
+                .expect("decode state"),
+            "wait-ci"
+        );
+        assert_eq!(
+            tracking
+                .try_get::<Option<String>, _>("last_error")
+                .expect("decode last_error")
+                .as_deref(),
+            Some("dispatch failed")
+        );
+        assert_eq!(
+            tracking
+                .try_get::<String, _>("dispatch_generation")
+                .expect("decode dispatch_generation"),
+            "tracked-generation"
+        );
+        assert_eq!(
+            tracking
+                .try_get::<i32, _>("review_round")
+                .expect("decode review_round"),
+            4
+        );
+        assert_eq!(
+            tracking
+                .try_get::<i32, _>("retry_count")
+                .expect("decode retry_count"),
+            2
+        );
+        assert_eq!(
+            tracking
+                .try_get::<Option<String>, _>("blocked_reason")
+                .expect("decode blocked_reason")
+                .as_deref(),
+            Some("pr:failed")
         );
 
         pool.close().await;

--- a/src/engine/ops/review_automation_ops.rs
+++ b/src/engine/ops/review_automation_ops.rs
@@ -151,80 +151,12 @@ fn handoff_create_pr_raw(db: &Db, pg_pool: Option<&PgPool>, payload_json: &str) 
     }
 }
 
-async fn handoff_create_pr_pg(
-    pool: &PgPool,
+async fn upsert_pg_pr_tracking_handoff_state(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     payload: &HandoffPayload,
-) -> Result<serde_json::Value, String> {
-    let mut tx = pool
-        .begin()
-        .await
-        .map_err(|e| format!("begin postgres review automation transaction: {e}"))?;
-
-    let existing = sqlx::query(
-        "SELECT td.id,
-                COALESCE(pt.dispatch_generation, '') AS dispatch_generation
-         FROM task_dispatches td
-         LEFT JOIN pr_tracking pt ON pt.card_id = td.kanban_card_id
-         WHERE td.kanban_card_id = $1
-           AND td.dispatch_type = 'create-pr'
-           AND td.status IN ('pending', 'dispatched')
-         ORDER BY td.created_at DESC
-         LIMIT 1",
-    )
-    .bind(&payload.card_id)
-    .fetch_optional(&mut *tx)
-    .await
-    .map_err(|e| {
-        format!(
-            "lookup active postgres create-pr dispatch for {}: {e}",
-            payload.card_id
-        )
-    })?;
-    if let Some(existing) = existing {
-        let dispatch_id = existing
-            .try_get::<String, _>("id")
-            .map_err(|e| format!("decode active postgres create-pr dispatch id: {e}"))?;
-        let generation = existing
-            .try_get::<String, _>("dispatch_generation")
-            .map_err(|e| format!("decode active postgres create-pr generation: {e}"))?;
-        tx.rollback().await.ok();
-        return Ok(json!({
-            "ok": true,
-            "reused": true,
-            "dispatch_id": dispatch_id,
-            "generation": generation,
-        }));
-    }
-
-    let card_exists = sqlx::query_scalar::<_, bool>(
-        "SELECT EXISTS (
-            SELECT 1
-            FROM kanban_cards
-            WHERE id = $1
-         )",
-    )
-    .bind(&payload.card_id)
-    .fetch_one(&mut *tx)
-    .await
-    .map_err(|e| format!("check postgres card {} existence: {e}", payload.card_id))?;
-    if !card_exists {
-        return Err(format!("card {} not found", payload.card_id));
-    }
-
-    let current_round = sqlx::query_scalar::<_, i64>(
-        "SELECT COALESCE(review_round, 0)::BIGINT
-         FROM card_review_state
-         WHERE card_id = $1",
-    )
-    .bind(&payload.card_id)
-    .fetch_optional(&mut *tx)
-    .await
-    .map_err(|e| format!("load postgres review_round for {}: {e}", payload.card_id))?
-    .unwrap_or(0);
-
-    let generation = Uuid::new_v4().to_string();
-    let dispatch_id = Uuid::new_v4().to_string();
-
+    generation: &str,
+    current_round: i64,
+) -> Result<(), String> {
     sqlx::query(
         "INSERT INTO pr_tracking (
             card_id,
@@ -259,11 +191,110 @@ async fn handoff_create_pr_pg(
     .bind(payload.worktree_path.as_deref())
     .bind(&payload.branch)
     .bind(payload.head_sha.as_deref())
-    .bind(&generation)
+    .bind(generation)
     .bind(current_round)
-    .execute(&mut *tx)
+    .execute(&mut **tx)
     .await
     .map_err(|e| format!("upsert postgres pr_tracking for {}: {e}", payload.card_id))?;
+
+    Ok(())
+}
+
+async fn handoff_create_pr_pg(
+    pool: &PgPool,
+    payload: &HandoffPayload,
+) -> Result<serde_json::Value, String> {
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| format!("begin postgres review automation transaction: {e}"))?;
+
+    let current_round = sqlx::query_scalar::<_, i64>(
+        "SELECT COALESCE(review_round, 0)::BIGINT
+         FROM card_review_state
+         WHERE card_id = $1",
+    )
+    .bind(&payload.card_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| format!("load postgres review_round for {}: {e}", payload.card_id))?
+    .unwrap_or(0);
+
+    let existing = sqlx::query(
+        "SELECT td.id,
+                COALESCE((td.context::jsonb)->>'dispatch_generation', '') AS dispatch_generation
+         FROM task_dispatches td
+         WHERE td.kanban_card_id = $1
+           AND td.dispatch_type = 'create-pr'
+           AND td.status IN ('pending', 'dispatched')
+         ORDER BY td.created_at DESC
+         LIMIT 1",
+    )
+    .bind(&payload.card_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| {
+        format!(
+            "lookup active postgres create-pr dispatch for {}: {e}",
+            payload.card_id
+        )
+    })?;
+    if let Some(existing) = existing {
+        let dispatch_id = existing
+            .try_get::<String, _>("id")
+            .map_err(|e| format!("decode active postgres create-pr dispatch id: {e}"))?;
+        let generation = existing
+            .try_get::<String, _>("dispatch_generation")
+            .map_err(|e| format!("decode active postgres create-pr generation: {e}"))?;
+        upsert_pg_pr_tracking_handoff_state(&mut tx, payload, &generation, current_round).await?;
+        sqlx::query(
+            "UPDATE kanban_cards
+             SET blocked_reason = 'pr:creating',
+                 updated_at = NOW()
+             WHERE id = $1",
+        )
+        .bind(&payload.card_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| {
+            format!(
+                "refresh postgres blocked_reason for {}: {e}",
+                payload.card_id
+            )
+        })?;
+        tx.commit().await.map_err(|e| {
+            format!(
+                "commit postgres create-pr reuse for {}: {e}",
+                payload.card_id
+            )
+        })?;
+        return Ok(json!({
+            "ok": true,
+            "reused": true,
+            "dispatch_id": dispatch_id,
+            "generation": generation,
+        }));
+    }
+
+    let card_exists = sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS (
+            SELECT 1
+            FROM kanban_cards
+            WHERE id = $1
+         )",
+    )
+    .bind(&payload.card_id)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| format!("check postgres card {} existence: {e}", payload.card_id))?;
+    if !card_exists {
+        return Err(format!("card {} not found", payload.card_id));
+    }
+
+    let generation = Uuid::new_v4().to_string();
+    let dispatch_id = Uuid::new_v4().to_string();
+
+    upsert_pg_pr_tracking_handoff_state(&mut tx, payload, &generation, current_round).await?;
 
     let context = json!({
         "dispatch_generation": generation,
@@ -381,65 +412,30 @@ async fn handoff_create_pr_pg(
     }))
 }
 
-fn handoff_create_pr_tx(db: &Db, payload: &HandoffPayload) -> anyhow::Result<serde_json::Value> {
-    let mut conn = db
-        .separate_conn()
-        .map_err(|e| anyhow::anyhow!("DB conn error: {e}"))?;
-    let tx = conn.transaction()?;
+fn lookup_active_create_pr_dispatch(
+    conn: &libsql_rusqlite::Transaction<'_>,
+    card_id: &str,
+) -> Option<(String, String)> {
+    conn.query_row(
+        "SELECT td.id,
+                COALESCE(json_extract(COALESCE(td.context, '{}'), '$.dispatch_generation'), '')
+         FROM task_dispatches td
+         WHERE td.kanban_card_id = ?1
+           AND td.dispatch_type = 'create-pr'
+           AND td.status IN ('pending', 'dispatched')
+         ORDER BY td.rowid DESC LIMIT 1",
+        [card_id],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )
+    .ok()
+}
 
-    // 1. Idempotent reuse — if an active create-pr dispatch already exists for
-    //    this card, return its id and the stored generation rather than erroring.
-    //    This preserves the existing dedupe contract (C5).
-    let existing: Option<(String, String)> = tx
-        .query_row(
-            "SELECT td.id, COALESCE(pt.dispatch_generation, '')
-             FROM task_dispatches td
-             LEFT JOIN pr_tracking pt ON pt.card_id = td.kanban_card_id
-             WHERE td.kanban_card_id = ?1
-               AND td.dispatch_type = 'create-pr'
-               AND td.status IN ('pending', 'dispatched')
-             ORDER BY td.rowid DESC LIMIT 1",
-            [&payload.card_id],
-            |row| Ok((row.get(0)?, row.get(1)?)),
-        )
-        .optional()?;
-    if let Some((dispatch_id, generation)) = existing {
-        return Ok(json!({
-            "ok": true,
-            "reused": true,
-            "dispatch_id": dispatch_id,
-            "generation": generation,
-        }));
-    }
-
-    // 2. Read card row for pipeline resolution + current status.
-    let (old_status, card_repo_id, card_agent_id): (String, Option<String>, Option<String>) = tx
-        .query_row(
-            "SELECT status, repo_id, assigned_agent_id FROM kanban_cards WHERE id = ?1",
-            [&payload.card_id],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-        )
-        .map_err(|e| anyhow::anyhow!("card not found: {e}"))?;
-
-    // 3. Read current review_round (observability stamp).
-    let current_round: i64 = tx
-        .query_row(
-            "SELECT review_round FROM card_review_state WHERE card_id = ?1",
-            [&payload.card_id],
-            |row| row.get(0),
-        )
-        .unwrap_or(0);
-
-    // 4. Resolve pipeline for TransitionContext.
-    crate::pipeline::ensure_loaded();
-    let effective =
-        crate::pipeline::resolve_for_card(&tx, card_repo_id.as_deref(), card_agent_id.as_deref());
-
-    // 5. Mint fresh generation + dispatch id.
-    let generation = Uuid::new_v4().to_string();
-    let dispatch_id = Uuid::new_v4().to_string();
-
-    // 6. pr_tracking upsert with stamp.
+fn upsert_pr_tracking_handoff_state(
+    tx: &libsql_rusqlite::Transaction<'_>,
+    payload: &HandoffPayload,
+    generation: &str,
+    current_round: i64,
+) -> anyhow::Result<()> {
     tx.execute(
         "INSERT INTO pr_tracking \
          (card_id, repo_id, worktree_path, branch, head_sha, state, last_error, \
@@ -466,6 +462,65 @@ fn handoff_create_pr_tx(db: &Db, payload: &HandoffPayload) -> anyhow::Result<ser
             current_round,
         ],
     )?;
+
+    Ok(())
+}
+
+fn handoff_create_pr_tx(db: &Db, payload: &HandoffPayload) -> anyhow::Result<serde_json::Value> {
+    let mut conn = db
+        .separate_conn()
+        .map_err(|e| anyhow::anyhow!("DB conn error: {e}"))?;
+    let tx = conn.transaction()?;
+
+    // 1. Read current review_round early so reuse and fresh handoff paths keep
+    //    pr_tracking aligned with the currently active dispatch.
+    let current_round: i64 = tx
+        .query_row(
+            "SELECT review_round FROM card_review_state WHERE card_id = ?1",
+            [&payload.card_id],
+            |row| row.get(0),
+        )
+        .unwrap_or(0);
+
+    // 2. Idempotent reuse — refresh pr_tracking to the active dispatch stamp so
+    //    stale generations do not leak into retry logic.
+    if let Some((dispatch_id, generation)) = lookup_active_create_pr_dispatch(&tx, &payload.card_id)
+    {
+        upsert_pr_tracking_handoff_state(&tx, payload, &generation, current_round)?;
+        tx.execute(
+            "UPDATE kanban_cards SET blocked_reason = 'pr:creating', updated_at = datetime('now') \
+             WHERE id = ?1",
+            [&payload.card_id],
+        )?;
+        tx.commit()?;
+        return Ok(json!({
+            "ok": true,
+            "reused": true,
+            "dispatch_id": dispatch_id,
+            "generation": generation,
+        }));
+    }
+
+    // 3. Read card row for pipeline resolution + current status.
+    let (old_status, card_repo_id, card_agent_id): (String, Option<String>, Option<String>) = tx
+        .query_row(
+            "SELECT status, repo_id, assigned_agent_id FROM kanban_cards WHERE id = ?1",
+            [&payload.card_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .map_err(|e| anyhow::anyhow!("card not found: {e}"))?;
+
+    // 4. Resolve pipeline for TransitionContext.
+    crate::pipeline::ensure_loaded();
+    let effective =
+        crate::pipeline::resolve_for_card(&tx, card_repo_id.as_deref(), card_agent_id.as_deref());
+
+    // 5. Mint fresh generation + dispatch id.
+    let generation = Uuid::new_v4().to_string();
+    let dispatch_id = Uuid::new_v4().to_string();
+
+    // 6. pr_tracking upsert with stamp.
+    upsert_pr_tracking_handoff_state(&tx, payload, &generation, current_round)?;
 
     // 7. Build dispatch context with stamps.
     let context = json!({
@@ -1239,6 +1294,25 @@ mod tests {
         .expect("count pending dispatch events");
         assert_eq!(pending_event_count, 1);
 
+        sqlx::query(
+            "UPDATE pr_tracking
+             SET dispatch_generation = '00000000-0000-0000-0000-stale0reuse01'
+             WHERE card_id = $1",
+        )
+        .bind(&payload.card_id)
+        .execute(&pool)
+        .await
+        .expect("force stale tracking generation before reuse");
+        sqlx::query(
+            "UPDATE kanban_cards
+             SET blocked_reason = NULL
+             WHERE id = $1",
+        )
+        .bind(&payload.card_id)
+        .execute(&pool)
+        .await
+        .expect("clear blocked reason before reuse");
+
         let second_handoff = handoff_create_pr_pg(&pool, &payload)
             .await
             .expect("second handoff create pr");
@@ -1246,6 +1320,30 @@ mod tests {
         assert_eq!(second_handoff["reused"], true);
         assert_eq!(second_handoff["dispatch_id"], dispatch_id);
         assert_eq!(second_handoff["generation"], generation);
+
+        let reused_tracking = sqlx::query(
+            "SELECT dispatch_generation, blocked_reason
+             FROM pr_tracking pt
+             JOIN kanban_cards kc ON kc.id = pt.card_id
+             WHERE pt.card_id = $1",
+        )
+        .bind(&payload.card_id)
+        .fetch_one(&pool)
+        .await
+        .expect("load refreshed postgres reuse state");
+        assert_eq!(
+            reused_tracking
+                .try_get::<String, _>("dispatch_generation")
+                .expect("decode refreshed postgres generation"),
+            generation
+        );
+        assert_eq!(
+            reused_tracking
+                .try_get::<Option<String>, _>("blocked_reason")
+                .expect("decode refreshed postgres blocked_reason")
+                .as_deref(),
+            Some("pr:creating")
+        );
 
         let first_failure =
             record_pr_create_failure_pg(&pool, &payload.card_id, "git push failed", &generation)

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -6625,6 +6625,88 @@ mod tests {
         );
     }
 
+    /// #743 regression: escalateToManualIntervention can overwrite the
+    /// machine-readable create-pr escalation marker with a human-readable
+    /// message. markPrCreateFailed must restore the machine marker afterward so
+    /// merge automation keeps the card in the create-pr failure lane.
+    #[cfg(unix)]
+    #[test]
+    fn scenario_743_mark_pr_create_failed_escalation_preserves_machine_marker() {
+        let (_repo, _repo_guard) = setup_test_repo();
+
+        let db = test_db();
+        let engine = test_engine(&db);
+        seed_agent(&db);
+        seed_repo(&db, "test/repo");
+        seed_card_with_repo(
+            &db,
+            "card-743-mark-escalated",
+            "review",
+            "test/repo",
+            1000,
+            None,
+        );
+        seed_pr_tracking(
+            &db,
+            "card-743-mark-escalated",
+            "test/repo",
+            Some("wt/card-743-mark-escalated"),
+            "feature/card-743-mark-escalated",
+            None,
+            Some("sha-743-mark-escalated"),
+            "create-pr",
+        );
+        {
+            let conn = db.lock().unwrap();
+            conn.execute(
+                "UPDATE pr_tracking SET retry_count = 2, last_error = 'previous_failure' \
+                 WHERE card_id = 'card-743-mark-escalated'",
+                [],
+            )
+            .unwrap();
+        }
+
+        engine
+            .eval_js::<String>(
+                r#"(() => {
+                    agentdesk.reviewAutomation.markPrCreateFailed(
+                        "card-743-mark-escalated",
+                        "handoff_crashed"
+                    );
+                    return "ok";
+                })()"#,
+            )
+            .unwrap();
+        kanban::drain_hook_side_effects(&db, &engine);
+
+        let conn = db.lock().unwrap();
+        let (card_status, blocked_reason, tracking_state, retry_count): (
+            String,
+            Option<String>,
+            String,
+            i64,
+        ) = conn
+            .query_row(
+                "SELECT kc.status, kc.blocked_reason, pt.state, pt.retry_count \
+                 FROM kanban_cards kc \
+                 JOIN pr_tracking pt ON pt.card_id = kc.id \
+                 WHERE kc.id = 'card-743-mark-escalated'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        drop(conn);
+
+        assert_eq!(card_status, "done");
+        assert_eq!(tracking_state, "escalated");
+        assert_eq!(retry_count, 3);
+        assert_eq!(
+            blocked_reason.as_deref(),
+            Some("pr:create_failed_escalated:max_retries"),
+            "#743: escalation must preserve the machine marker after human notification overwrites blocked_reason"
+        );
+    }
+
     /// #743: pr:create_failed card with NO pr_tracking row → escalate to
     /// manual intervention via blocked_reason='pr:create_failed_escalated:no_tracking'
     /// rather than silently deferring to processTrackedMergeQueue (which has
@@ -6794,6 +6876,105 @@ mod tests {
             Some("cancelled"),
             "#743: reseedPrTracking must cancel the active stale dispatch so the partial unique index does not block the next handoff"
         );
+    }
+
+    /// #743: if handoffCreatePr reuses an already-active create-pr dispatch, it
+    /// must refresh pr_tracking back to the active dispatch's generation so
+    /// stale loser generations do not leak into retry logic.
+    #[cfg(unix)]
+    #[test]
+    fn scenario_743_handoff_reuse_refreshes_tracking_generation_from_active_dispatch() {
+        let (_repo, _repo_guard) = setup_test_repo();
+
+        let db = test_db();
+        let engine = test_engine(&db);
+        seed_agent(&db);
+        seed_repo(&db, "test/repo");
+        seed_card_with_repo(
+            &db,
+            "card-743-handoff-reuse",
+            "review",
+            "test/repo",
+            1005,
+            None,
+        );
+
+        let active_generation = seed_stamped_create_pr_state(
+            &db,
+            "disp-743-existing",
+            "card-743-handoff-reuse",
+            "test/repo",
+            Some("wt/card-743-handoff-reuse"),
+            "feature/card-743-handoff-reuse",
+            None,
+            Some("sha-743-handoff-reuse"),
+            "create-pr",
+            "pending",
+        );
+        {
+            let conn = db.lock().unwrap();
+            conn.execute(
+                "UPDATE pr_tracking SET dispatch_generation = '00000000-0000-0000-0000-stale0reuse01' \
+                 WHERE card_id = 'card-743-handoff-reuse'",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "UPDATE kanban_cards SET blocked_reason = NULL WHERE id = 'card-743-handoff-reuse'",
+                [],
+            )
+            .unwrap();
+        }
+
+        let raw = engine
+            .eval_js::<String>(
+                r#"(() => JSON.stringify(agentdesk.reviewAutomation.handoffCreatePr(
+                    "card-743-handoff-reuse",
+                    {
+                        repo_id: "test/repo",
+                        worktree_path: "wt/card-743-handoff-reuse",
+                        branch: "feature/card-743-handoff-reuse",
+                        head_sha: "sha-743-handoff-reuse",
+                        agent_id: "agent-1",
+                        title: "Test Create PR Reuse"
+                    }
+                )))()"#,
+            )
+            .unwrap();
+        let result: serde_json::Value = serde_json::from_str(&raw).unwrap();
+
+        let conn = db.lock().unwrap();
+        let (dispatch_generation, blocked_reason, active_count): (
+            Option<String>,
+            Option<String>,
+            i64,
+        ) = conn
+            .query_row(
+                "SELECT pt.dispatch_generation, kc.blocked_reason, \
+                        (SELECT COUNT(*) FROM task_dispatches \
+                         WHERE kanban_card_id = 'card-743-handoff-reuse' \
+                           AND dispatch_type = 'create-pr' \
+                           AND status IN ('pending', 'dispatched')) \
+                 FROM pr_tracking pt \
+                 JOIN kanban_cards kc ON kc.id = pt.card_id \
+                 WHERE pt.card_id = 'card-743-handoff-reuse'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        drop(conn);
+
+        assert_eq!(result["ok"], true);
+        assert_eq!(result["reused"], true);
+        assert_eq!(result["dispatch_id"], "disp-743-existing");
+        assert_eq!(result["generation"], active_generation);
+        assert_eq!(
+            dispatch_generation.as_deref(),
+            Some(active_generation.as_str()),
+            "#743: handoffCreatePr reuse must refresh pr_tracking to the active dispatch generation"
+        );
+        assert_eq!(blocked_reason.as_deref(), Some("pr:creating"));
+        assert_eq!(active_count, 1);
     }
 
     /// #743: pr_tracking.head_sha divergence from the latest completed work

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -1179,6 +1179,7 @@ pub(super) async fn restore_inflight_turns(
                         shared,
                     )
                     .await;
+                    save_missing_session_handoff(provider, &state, &best_response);
                     clear_inflight_state(provider, state.channel_id);
                 }
                 continue;
@@ -1974,6 +1975,72 @@ mod tests {
                 .context
                 .contains("이어서 원인과 대응을 설명하겠습니다")
         );
+    }
+
+    #[test]
+    fn planned_restart_recovery_saves_handoff_for_non_unix_followup() {
+        let _lock = super::super::runtime_store::lock_test_env();
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = temp.path().join("agentdesk-root");
+        std::fs::create_dir_all(root.join("runtime")).unwrap();
+
+        struct EnvReset;
+        impl Drop for EnvReset {
+            fn drop(&mut self) {
+                unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") };
+            }
+        }
+
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", &root) };
+        let _reset = EnvReset;
+
+        let state = crate::services::discord::inflight::InflightTurnState {
+            version: 1,
+            provider: "codex".to_string(),
+            channel_id: 1486333430516945010,
+            channel_name: Some("adk-cdx-t1486333430516945010".to_string()),
+            logical_channel_id: Some(1479671301387059202),
+            thread_id: Some(1486333430516945010),
+            thread_title: Some("[AgentDesk] restart recovery".to_string()),
+            request_owner_user_id: 343742347365974026,
+            user_msg_id: 1487795113240559790,
+            current_msg_id: 1487799916758827140,
+            current_msg_len: 0,
+            user_text: "dcserver 재시작 후에도 이어서 마무리해줘.".to_string(),
+            session_id: Some("session-restart".to_string()),
+            tmux_session_name: Some("AgentDesk-codex-adk-cdx-t1486333430516945010".to_string()),
+            output_path: Some("/tmp/agentdesk-test-restart.jsonl".to_string()),
+            input_fifo_path: Some("/tmp/agentdesk-test-restart.input".to_string()),
+            last_offset: 77,
+            turn_start_offset: Some(77),
+            full_response: "재시작 전 답변을 정리하던 중이었습니다.".to_string(),
+            response_sent_offset: 0,
+            current_tool_line: None,
+            prev_tool_status: None,
+            started_at: "2026-03-29 22:10:34".to_string(),
+            updated_at: "2026-03-29 22:13:53".to_string(),
+            born_generation: 8,
+            any_tool_used: true,
+            has_post_tool_text: false,
+            session_key: None,
+            dispatch_id: None,
+            last_watcher_relayed_offset: None,
+            planned_restart: true,
+        };
+
+        save_missing_session_handoff(
+            &ProviderKind::Codex,
+            &state,
+            "새 dcserver가 올라오면 이어서 남은 설명을 마무리합니다.",
+        );
+
+        let handoffs = crate::services::discord::handoff::load_handoffs(&ProviderKind::Codex);
+        assert_eq!(handoffs.len(), 1);
+        assert_eq!(handoffs[0].channel_id, state.channel_id);
+        assert_eq!(handoffs[0].user_msg_id, Some(state.user_msg_id));
+        assert!(handoffs[0].intent.contains("중단된 응답"));
+        assert!(handoffs[0].context.contains("원래 사용자 요청"));
+        assert!(handoffs[0].context.contains("남은 설명을 마무리합니다"));
     }
 
     #[test]


### PR DESCRIPTION
## 목표
- unsupported 상태이면서 표시할 bucket이 없는 Qwen provider 행을 대시보드와 오피스 인사이트 패널에서 숨겨, 의미 없는 빈 상태가 노출되지 않도록 정리합니다.

## 해결한 내용
- `dashboard/src/components/dashboard/RateLimitWidget.tsx`: unsupported provider에 표시 가능한 bucket이 없으면 행 자체를 렌더링하지 않도록 바꿨습니다.
- `dashboard/src/components/office-view/OfficeInsightPanel.tsx`: 동일 조건을 mini rate-limit 패널에도 반영했습니다.
- `dashboard/src/components/dashboard/RateLimitWidget.test.ts` 및 `dashboard/src/components/office-view/OfficeInsightPanel.test.ts`: 숨김 동작 회귀를 막는 테스트를 추가/갱신했습니다.

## 검증
- `npm test -- --run src/components/dashboard/RateLimitWidget.test.ts src/components/office-view/OfficeInsightPanel.test.ts` : 관련 컴포넌트 테스트 2개 파일, 6개 테스트 통과를 확인했습니다.
- `npm run build` : dashboard 프로덕션 빌드가 통과함을 확인했습니다.

## 동기화 메모
- `#831` 공통 기반 위에 dashboard 커밋만 다시 얹고 stale generated inventory refresh commit은 제외했습니다.