### PR TITLE
pg-port: dispatch_create leaf helpers (lookup / validate / pipeline) (#846)

### DIFF
--- a/dashboard/src/app/AppShell.tsx
+++ b/dashboard/src/app/AppShell.tsx
@@ -45,6 +45,7 @@ import {
   ToastOverlay,
   type Notification,
 } from "../components/NotificationCenter";
+import { deriveOfficeAgentState } from "../components/office-view/officeAgentState";
 import OfficeSelectorBar from "../components/OfficeSelectorBar";
 import { MOBILE_LAYOUT_MEDIA_QUERY } from "./breakpoints";
 import {
@@ -81,6 +82,7 @@ const OfficeManagerView = lazy(() => import("../components/OfficeManagerView"));
 const MeetingsAndSkillsPage = lazy(() => import("../components/MeetingsAndSkillsPage"));
 const SettingsView = lazy(() => import("../components/SettingsView"));
 const AgentInfoCard = lazy(() => import("../components/agent-manager/AgentInfoCard"));
+const OfficeAgentDrawer = lazy(() => import("../components/office-view/OfficeAgentDrawer"));
 const CommandPalette = lazy(() => import("../components/CommandPalette"));
 
 interface AppShellProps {
@@ -186,6 +188,9 @@ export default function AppShell({
     useKanban();
 
   const [officeInfoAgent, setOfficeInfoAgent] = useState<Agent | null>(null);
+  const [officeInfoMode, setOfficeInfoMode] = useState<"default" | "office">(
+    "default",
+  );
   const [showCommandPalette, setShowCommandPalette] = useState(false);
   const [showShortcutHelp, setShowShortcutHelp] = useState(false);
   const [showNotificationPanel, setShowNotificationPanel] = useState(false);
@@ -214,6 +219,10 @@ export default function AppShell({
   });
 
   const spriteMap = useSpriteMap(agents);
+  const officeAgentState = useMemo(
+    () => deriveOfficeAgentState(agentsWithDispatched, kanbanCards),
+    [agentsWithDispatched, kanbanCards],
+  );
   const unresolvedMeetingsCount = roundTableMeetings.filter(
     hasUnresolvedMeetingIssues,
   ).length;
@@ -347,6 +356,27 @@ export default function AppShell({
     refreshDepartments,
     refreshOffices,
   ]);
+
+  const openDefaultAgentInfo = useCallback((agent: Agent) => {
+    setOfficeInfoMode("default");
+    setOfficeInfoAgent(agent);
+  }, []);
+
+  const openOfficeAgentInfo = useCallback((agent: Agent) => {
+    setOfficeInfoMode("office");
+    setOfficeInfoAgent(agent);
+  }, []);
+
+  const closeOfficeInfo = useCallback(() => {
+    setOfficeInfoAgent(null);
+    setOfficeInfoMode("default");
+  }, []);
+
+  useEffect(() => {
+    if (officeInfoMode === "office" && currentRoute?.id !== "office") {
+      closeOfficeInfo();
+    }
+  }, [closeOfficeInfo, currentRoute?.id, officeInfoMode]);
 
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
@@ -961,7 +991,7 @@ export default function AppShell({
                     }
                     kanbanCards={kanbanCards}
                     onNavigateToKanban={() => navigateToRoute("/kanban")}
-                    onSelectAgent={(agent) => setOfficeInfoAgent(agent)}
+                    onSelectAgent={openOfficeAgentInfo}
                     onSelectDepartment={() =>
                       navigateToRoute("/agents", { agentsTab: "departments" })
                     }
@@ -997,7 +1027,7 @@ export default function AppShell({
                         ),
                       );
                     }}
-                    onSelectAgent={(agent) => setOfficeInfoAgent(agent)}
+                    onSelectAgent={openDefaultAgentInfo}
                     activeTab={agentsPageTab}
                     onTabChange={setAgentsPageTab}
                   />
@@ -1093,7 +1123,7 @@ export default function AppShell({
                     meetings={roundTableMeetings}
                     settings={settings}
                     requestedTab={"achievements" satisfies DashboardTab}
-                    onSelectAgent={(agent) => setOfficeInfoAgent(agent)}
+                    onSelectAgent={openDefaultAgentInfo}
                     onOpenKanbanSignal={(signal) =>
                       navigateToRoute("/kanban", {
                         kanbanFocus: signal,
@@ -1319,21 +1349,42 @@ export default function AppShell({
 
       <Suspense fallback={null}>
         {officeInfoAgent && (
-          <AgentInfoCard
-            agent={officeInfoAgent}
-            spriteMap={spriteMap}
-            isKo={isKo}
-            locale={locale}
-            tr={tr}
-            departments={departments}
-            onClose={() => setOfficeInfoAgent(null)}
-            onAgentUpdated={() => {
-              refreshAgents();
-              refreshAllAgents();
-              refreshOffices();
-              refreshAuditLogs();
-            }}
-          />
+          officeInfoMode === "office" ? (
+            <OfficeAgentDrawer
+              open
+              agent={officeInfoAgent}
+              departments={departments}
+              locale={locale}
+              isKo={isKo}
+              spriteMap={spriteMap}
+              currentCard={
+                officeAgentState.primaryCardByAgent.get(officeInfoAgent.id) ??
+                null
+              }
+              manualIntervention={
+                officeAgentState.manualInterventionByAgent.get(
+                  officeInfoAgent.id,
+                ) ?? null
+              }
+              onClose={closeOfficeInfo}
+            />
+          ) : (
+            <AgentInfoCard
+              agent={officeInfoAgent}
+              spriteMap={spriteMap}
+              isKo={isKo}
+              locale={locale}
+              tr={tr}
+              departments={departments}
+              onClose={closeOfficeInfo}
+              onAgentUpdated={() => {
+                refreshAgents();
+                refreshAllAgents();
+                refreshOffices();
+                refreshAuditLogs();
+              }}
+            />
+          )
         )}
       </Suspense>
 
@@ -1343,7 +1394,7 @@ export default function AppShell({
             agents={allAgents}
             departments={departments}
             isKo={isKo}
-            onSelectAgent={(agent) => setOfficeInfoAgent(agent)}
+            onSelectAgent={openDefaultAgentInfo}
             onNavigate={(path) => navigateToRoute(path)}
             onClose={() => setShowCommandPalette(false)}
             routes={PALETTE_ROUTES}

--- a/dashboard/src/app/AppShell.tsx
+++ b/dashboard/src/app/AppShell.tsx
@@ -74,6 +74,7 @@ import {
 
 const OfficeView = lazy(() => import("../components/OfficeView"));
 const DashboardPageView = lazy(() => import("../components/DashboardPageView"));
+const StatsPageView = lazy(() => import("../components/StatsPageView"));
 const KanbanTab = lazy(() => import("../components/agent-manager/KanbanTab"));
 const AgentManagerView = lazy(() => import("../components/AgentManagerView"));
 const OfficeManagerView = lazy(() => import("../components/OfficeManagerView"));
@@ -1050,29 +1051,7 @@ export default function AppShell({
               <Route
                 path="/stats"
                 element={
-                  <DashboardPageView
-                    stats={stats}
-                    agents={agents}
-                    sessions={visibleDispatchedSessions}
-                    meetings={roundTableMeetings}
-                    settings={settings}
-                    onSelectAgent={(agent) => setOfficeInfoAgent(agent)}
-                    onOpenKanbanSignal={(signal) =>
-                      navigateToRoute("/kanban", {
-                        kanbanFocus: signal,
-                      })
-                    }
-                    onOpenDispatchSessions={() =>
-                      navigateToRoute("/agents", { agentsTab: "backlog" })
-                    }
-                    onOpenSettings={() => navigateToRoute("/settings")}
-                    onRefreshMeetings={() =>
-                      api
-                        .getRoundTableMeetings()
-                        .then(setRoundTableMeetings)
-                        .catch(() => {})
-                    }
-                  />
+                  <StatsPageView settings={settings} />
                 }
               />
               <Route

--- a/dashboard/src/app/AppShell.tsx
+++ b/dashboard/src/app/AppShell.tsx
@@ -78,7 +78,7 @@ const StatsPageView = lazy(() => import("../components/StatsPageView"));
 const KanbanTab = lazy(() => import("../components/agent-manager/KanbanTab"));
 const AgentManagerView = lazy(() => import("../components/AgentManagerView"));
 const OfficeManagerView = lazy(() => import("../components/OfficeManagerView"));
-const MeetingMinutesView = lazy(() => import("../components/MeetingMinutesView"));
+const MeetingsAndSkillsPage = lazy(() => import("../components/MeetingsAndSkillsPage"));
 const SettingsView = lazy(() => import("../components/SettingsView"));
 const AgentInfoCard = lazy(() => import("../components/agent-manager/AgentInfoCard"));
 const CommandPalette = lazy(() => import("../components/CommandPalette"));
@@ -1069,7 +1069,7 @@ export default function AppShell({
               <Route
                 path="/meetings"
                 element={
-                  <MeetingMinutesView
+                  <MeetingsAndSkillsPage
                     meetings={roundTableMeetings}
                     onRefresh={() =>
                       api

--- a/dashboard/src/app/AppShell.tsx
+++ b/dashboard/src/app/AppShell.tsx
@@ -94,7 +94,7 @@ interface AppShellProps {
   dismissNotification: (id: string) => void;
 }
 
-type AgentsPageTab = "agents" | "departments" | "dispatch";
+type AgentsPageTab = "agents" | "departments" | "backlog" | "dispatch";
 type KanbanSignalFocus = "review" | "blocked" | "requested" | "stalled";
 
 const SIDEBAR_COLLAPSED_STORAGE_KEY = "agentdesk.sidebar.collapsed";
@@ -308,7 +308,9 @@ export default function AppShell({
     ) => {
       setShowMobileMoreMenu(false);
       if (options?.agentsTab) {
-        setAgentsPageTab(options.agentsTab);
+        setAgentsPageTab(
+          options.agentsTab === "dispatch" ? "backlog" : options.agentsTab,
+        );
       }
       if (options?.kanbanFocus) {
         setKanbanSignalFocus(options.kanbanFocus);
@@ -972,6 +974,7 @@ export default function AppShell({
                   <AgentManagerView
                     agents={agents}
                     departments={departments}
+                    kanbanCards={kanbanCards}
                     language={settings.language}
                     officeId={selectedOfficeId}
                     onAgentsChange={() => {
@@ -993,6 +996,7 @@ export default function AppShell({
                         ),
                       );
                     }}
+                    onSelectAgent={(agent) => setOfficeInfoAgent(agent)}
                     activeTab={agentsPageTab}
                     onTabChange={setAgentsPageTab}
                   />
@@ -1059,7 +1063,7 @@ export default function AppShell({
                       })
                     }
                     onOpenDispatchSessions={() =>
-                      navigateToRoute("/agents", { agentsTab: "dispatch" })
+                      navigateToRoute("/agents", { agentsTab: "backlog" })
                     }
                     onOpenSettings={() => navigateToRoute("/settings")}
                     onRefreshMeetings={() =>
@@ -1117,7 +1121,7 @@ export default function AppShell({
                       })
                     }
                     onOpenDispatchSessions={() =>
-                      navigateToRoute("/agents", { agentsTab: "dispatch" })
+                      navigateToRoute("/agents", { agentsTab: "backlog" })
                     }
                     onOpenSettings={() => navigateToRoute("/settings")}
                     onRefreshMeetings={() =>

--- a/dashboard/src/components/AgentManagerView.tsx
+++ b/dashboard/src/components/AgentManagerView.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo, type DragEvent } from "react";
-import type { Agent, Department, DispatchedSession } from "../types";
+import type { Agent, Department, DispatchedSession, KanbanCard } from "../types";
 import type { UiLanguage } from "../i18n";
 import { localeName } from "../i18n";
 import * as api from "../api";
@@ -8,10 +8,10 @@ import { pickRandomSpritePair } from "./agent-manager/utils";
 import { BLANK, ICON_SPRITE_POOL } from "./agent-manager/constants";
 import type { FormData } from "./agent-manager/types";
 import AgentsTab from "./agent-manager/AgentsTab";
+import BacklogTab from "./agent-manager/BacklogTab";
 import DepartmentsTab from "./agent-manager/DepartmentsTab";
 import AgentFormModal from "./agent-manager/AgentFormModal";
 import DepartmentFormModal from "./agent-manager/DepartmentFormModal";
-import { SessionPanel } from "./session-panel/SessionPanel";
 
 interface AgentManagerViewProps {
   agents: Agent[];
@@ -24,6 +24,8 @@ interface AgentManagerViewProps {
   onAssign?: (id: string, patch: Partial<DispatchedSession>) => Promise<void>;
   activeTab?: Tab;
   onTabChange?: (tab: Tab) => void;
+  kanbanCards?: KanbanCard[];
+  onSelectAgent?: (agent: Agent) => void;
   showHeader?: boolean;
   showTabBar?: boolean;
   title?: string;
@@ -31,7 +33,7 @@ interface AgentManagerViewProps {
   scrollable?: boolean;
 }
 
-type Tab = "agents" | "departments" | "dispatch";
+type Tab = "agents" | "departments" | "backlog" | "dispatch";
 
 export default function AgentManagerView({
   agents,
@@ -44,6 +46,8 @@ export default function AgentManagerView({
   onAssign,
   activeTab,
   onTabChange,
+  kanbanCards = [],
+  onSelectAgent,
   showHeader = true,
   showTabBar = true,
   title,
@@ -60,6 +64,7 @@ export default function AgentManagerView({
   // ── Tab state ──
   const [internalTab, setInternalTab] = useState<Tab>("agents");
   const tab = activeTab ?? internalTab;
+  const resolvedTab = tab === "dispatch" ? "backlog" : tab;
   const handleTabChange = useCallback((nextTab: Tab) => {
     if (activeTab === undefined) {
       setInternalTab(nextTab);
@@ -274,17 +279,17 @@ export default function AgentManagerView({
   }, []);
 
   const defaultTitle =
-    tab === "departments"
+    resolvedTab === "departments"
       ? tr("부서 관리", "Departments")
-      : tab === "dispatch"
-        ? tr("파견 세션", "Dispatch Sessions")
+      : resolvedTab === "backlog"
+        ? tr("백로그", "Backlog")
         : tr("직원 관리", "Agent Manager");
   const resolvedTitle = title ?? defaultTitle;
   const resolvedSubtitle = subtitle
-    ?? (tab === "departments"
+    ?? (resolvedTab === "departments"
       ? tr("부서 순서, 역할, 테마를 관리합니다.", "Manage department order, roles, and themes.")
-      : tab === "dispatch"
-        ? tr("감지된 AgentDesk 세션을 오피스에 배치합니다.", "Assign detected AgentDesk sessions into the office.")
+      : resolvedTab === "backlog"
+        ? tr("핵심 backlog를 테이블과 모바일 카드 스택으로 관리합니다.", "Review the current backlog in a table or mobile card stack.")
         : tr("에이전트 프로필, 스킬, 소속을 관리합니다.", "Manage agent profiles, skills, and office membership."));
 
   return (
@@ -311,7 +316,7 @@ export default function AgentManagerView({
             )}
           </div>
           <div className="flex items-center gap-2">
-            {(showTabBar || tab === "departments") && tab !== "dispatch" && (
+            {(showTabBar || resolvedTab === "departments") && resolvedTab !== "backlog" && (
               <button
                 onClick={openCreateDept}
                 className="rounded-lg border px-3 py-1.5 text-xs font-medium transition-opacity hover:opacity-100"
@@ -324,7 +329,7 @@ export default function AgentManagerView({
                 + {tr("부서 추가", "Add Dept")}
               </button>
             )}
-            {(showTabBar || tab === "agents") && tab !== "departments" && tab !== "dispatch" && (
+            {(showTabBar || resolvedTab === "agents") && resolvedTab !== "departments" && resolvedTab !== "backlog" && (
               <button
                 onClick={openCreateAgent}
                 className="px-3 py-1.5 rounded-lg text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white transition-all"
@@ -341,44 +346,35 @@ export default function AgentManagerView({
           <button
             onClick={() => handleTabChange("agents")}
             className={`px-4 py-2 text-sm font-medium transition-colors ${
-              tab === "agents" ? "text-blue-400 border-b-2 border-blue-400" : ""
+              resolvedTab === "agents" ? "text-blue-400 border-b-2 border-blue-400" : ""
             }`}
-            style={tab !== "agents" ? { color: "var(--th-text-muted)" } : undefined}
+            style={resolvedTab !== "agents" ? { color: "var(--th-text-muted)" } : undefined}
           >
             {tr("직원", "Agents")} ({agents.length})
           </button>
           <button
             onClick={() => handleTabChange("departments")}
             className={`px-4 py-2 text-sm font-medium transition-colors ${
-              tab === "departments" ? "text-blue-400 border-b-2 border-blue-400" : ""
+              resolvedTab === "departments" ? "text-blue-400 border-b-2 border-blue-400" : ""
             }`}
-            style={tab !== "departments" ? { color: "var(--th-text-muted)" } : undefined}
+            style={resolvedTab !== "departments" ? { color: "var(--th-text-muted)" } : undefined}
           >
             {tr("부서", "Departments")} ({departments.length})
           </button>
-          {sessions && onAssign && (
-            <button
-              onClick={() => handleTabChange("dispatch")}
-              className={`px-4 py-2 text-sm font-medium transition-colors ${
-                tab === "dispatch" ? "text-blue-400 border-b-2 border-blue-400" : ""
-              }`}
-              style={tab !== "dispatch" ? { color: "var(--th-text-muted)" } : undefined}
-            >
-              {tr("파견", "Dispatch")} ({sessions.length})
-            </button>
-          )}
+          <button
+            onClick={() => handleTabChange("backlog")}
+            className={`px-4 py-2 text-sm font-medium transition-colors ${
+              resolvedTab === "backlog" ? "text-blue-400 border-b-2 border-blue-400" : ""
+            }`}
+            style={resolvedTab !== "backlog" ? { color: "var(--th-text-muted)" } : undefined}
+          >
+            {tr("백로그", "Backlog")} ({kanbanCards.length})
+          </button>
         </div>
       )}
 
       {/* Tab content */}
-      {tab === "dispatch" && sessions && onAssign ? (
-        <SessionPanel
-          sessions={sessions}
-          departments={departments}
-          agents={agents}
-          onAssign={onAssign}
-        />
-      ) : tab === "agents" ? (
+      {resolvedTab === "agents" ? (
         <div className="space-y-4">
           <AgentsTab
             tr={tr}
@@ -396,6 +392,9 @@ export default function AgentManagerView({
             spriteMap={spriteMap}
             confirmDeleteId={confirmDeleteId}
             setConfirmDeleteId={setConfirmDeleteId}
+            onOpenAgent={(agent) =>
+              onSelectAgent ? onSelectAgent(agent) : openEditAgent(agent)
+            }
             onEditAgent={openEditAgent}
             onEditDepartment={openEditDept}
             onDeleteAgent={handleDeleteAgent}
@@ -403,6 +402,13 @@ export default function AgentManagerView({
             randomIconSprites={randomIconSprites}
           />
         </div>
+      ) : resolvedTab === "backlog" ? (
+        <BacklogTab
+          tr={tr}
+          locale={locale}
+          cards={kanbanCards}
+          agents={agents}
+        />
       ) : (
         <DepartmentsTab
           tr={tr}

--- a/dashboard/src/components/MeetingsAndSkillsPage.tsx
+++ b/dashboard/src/components/MeetingsAndSkillsPage.tsx
@@ -1,0 +1,348 @@
+import { BookOpen, MessagesSquare } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { summarizeMeetings } from "../app/meetingSummary";
+import { useI18n } from "../i18n";
+import type {
+  RoundTableMeeting,
+  RoundTableMeetingChannelOption,
+} from "../types";
+import MeetingMinutesView from "./MeetingMinutesView";
+import SkillCatalogView from "./SkillCatalogView";
+import {
+  SurfaceMetricPill,
+  SurfaceNotice,
+  SurfaceSection,
+  SurfaceSegmentButton,
+} from "./common/SurfacePrimitives";
+
+type MeetingNotificationType = "info" | "success" | "warning" | "error";
+type MeetingNotifier = (
+  message: string,
+  type?: MeetingNotificationType,
+) => string | void;
+type MeetingNotificationUpdater = (
+  id: string,
+  message: string,
+  type?: MeetingNotificationType,
+) => void;
+type MobilePane = "meetings" | "skills";
+const DESKTOP_SPLIT_QUERY = "(min-width: 1024px)";
+
+interface MeetingsAndSkillsPageProps {
+  meetings: RoundTableMeeting[];
+  onRefresh: () => void;
+  onNotify?: MeetingNotifier;
+  onUpdateNotification?: MeetingNotificationUpdater;
+  initialShowStartForm?: boolean;
+  initialMeetingChannels?: RoundTableMeetingChannelOption[];
+  initialChannelId?: string;
+}
+
+const PRESERVED_BUTTON_PATTERNS = [
+  /details/i,
+  /상세 보기/u,
+  /preview issues to create/i,
+  /생성될 일감 미리보기/u,
+];
+
+const HIDDEN_BUTTON_PATTERNS = [
+  /new meeting/i,
+  /새 회의/u,
+  /close form/i,
+  /입력 닫기/u,
+  /^cancel$/i,
+  /^취소$/u,
+  /start meeting/i,
+  /회의 시작/u,
+  /create issues/i,
+  /일감 생성/u,
+  /issues created/i,
+  /일감 생성 완료/u,
+  /issues resolved/i,
+  /일감 처리 완료/u,
+  /retry failed/i,
+  /실패분 재시도/u,
+  /discard/i,
+  /폐기/u,
+];
+
+const HIDDEN_SECTION_PATTERNS = [/start meeting/i, /회의 시작/u];
+const DELETE_PATTERNS = [/delete/i, /삭제/u];
+
+function normalizeNodeLabel(node: Element): string {
+  const text = node.textContent ?? "";
+  const title = node.getAttribute("title") ?? "";
+  const ariaLabel = node.getAttribute("aria-label") ?? "";
+  return `${text} ${title} ${ariaLabel}`.replace(/\s+/g, " ").trim();
+}
+
+function matchesAnyPattern(
+  value: string,
+  patterns: readonly RegExp[],
+): boolean {
+  return patterns.some((pattern) => pattern.test(value));
+}
+
+function hideElement(element: HTMLElement | null): void {
+  if (!element || element.dataset.readOnlyHidden === "true") return;
+  element.dataset.readOnlyHidden = "true";
+  element.style.display = "none";
+}
+
+function pruneMeetingMutations(root: HTMLElement): void {
+  root.querySelectorAll("section").forEach((section) => {
+    const heading = section.querySelector("h3");
+    if (!heading) return;
+    const headingText = normalizeNodeLabel(heading);
+    if (matchesAnyPattern(headingText, HIDDEN_SECTION_PATTERNS)) {
+      hideElement(section as HTMLElement);
+    }
+  });
+
+  root.querySelectorAll("button").forEach((button) => {
+    const label = normalizeNodeLabel(button);
+    if (matchesAnyPattern(label, PRESERVED_BUTTON_PATTERNS)) return;
+    if (
+      matchesAnyPattern(label, HIDDEN_BUTTON_PATTERNS) ||
+      matchesAnyPattern(label, DELETE_PATTERNS)
+    ) {
+      hideElement(button as HTMLElement);
+    }
+  });
+
+  root.querySelectorAll("select").forEach((select) => {
+    hideElement(select.parentElement as HTMLElement | null);
+  });
+
+  root.querySelectorAll("input, textarea").forEach((field) => {
+    const section = field.closest("section");
+    if (!section) return;
+    const heading = section.querySelector("h3");
+    if (!heading) return;
+    const headingText = normalizeNodeLabel(heading);
+    if (matchesAnyPattern(headingText, HIDDEN_SECTION_PATTERNS)) {
+      hideElement(section as HTMLElement);
+    }
+  });
+}
+
+function useDesktopSplitLayout(): boolean {
+  const [isDesktopSplit, setIsDesktopSplit] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(DESKTOP_SPLIT_QUERY).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mediaQuery = window.matchMedia(DESKTOP_SPLIT_QUERY);
+    const handleChange = (event: MediaQueryListEvent) => {
+      setIsDesktopSplit(event.matches);
+    };
+
+    setIsDesktopSplit(mediaQuery.matches);
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, []);
+
+  return isDesktopSplit;
+}
+
+export default function MeetingsAndSkillsPage({
+  meetings,
+  onRefresh,
+  onNotify,
+  onUpdateNotification,
+  initialShowStartForm = false,
+  initialMeetingChannels = [],
+  initialChannelId,
+}: MeetingsAndSkillsPageProps) {
+  const { t } = useI18n();
+  const [mobilePane, setMobilePane] = useState<MobilePane>("meetings");
+  const isDesktopSplit = useDesktopSplitLayout();
+  const meetingsRef = useRef<HTMLDivElement | null>(null);
+  const meetingSummary = useMemo(() => summarizeMeetings(meetings), [meetings]);
+  const completedCount = meetings.filter(
+    (meeting) => meeting.status === "completed",
+  ).length;
+
+  useEffect(() => {
+    const root = meetingsRef.current;
+    if (!root) return;
+
+    const applyReadOnly = () => pruneMeetingMutations(root);
+    applyReadOnly();
+
+    const observer = new MutationObserver(() => {
+      applyReadOnly();
+    });
+    observer.observe(root, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
+  }, [meetings]);
+
+  const renderMeetingsPanel = () => (
+    <div ref={meetingsRef} className="min-w-0">
+      <MeetingMinutesView
+        meetings={meetings}
+        onRefresh={onRefresh}
+        embedded
+        onNotify={onNotify}
+        onUpdateNotification={onUpdateNotification}
+        initialShowStartForm={initialShowStartForm}
+        initialMeetingChannels={initialMeetingChannels}
+        initialChannelId={initialChannelId}
+      />
+    </div>
+  );
+
+  const renderSkillsPanel = () => (
+    <SurfaceSection
+      eyebrow={t({ ko: "Skills", en: "Skills" })}
+      title={t({ ko: "스킬 카탈로그", en: "Skill Catalog" })}
+      description={t({
+        ko: "회의 타임라인 옆에서 최근에 축적된 자동화 스킬을 함께 확인합니다.",
+        en: "Review the current automation skill catalog alongside the meeting timeline.",
+      })}
+      className="rounded-[28px] p-4 sm:p-5"
+      style={{
+        borderColor:
+          "color-mix(in srgb, var(--th-accent-info) 20%, var(--th-border) 80%)",
+        background:
+          "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, var(--th-accent-info) 4%) 0%, color-mix(in srgb, var(--th-bg-surface) 98%, transparent) 100%)",
+      }}
+    >
+      <div className="meetings-and-skills__skills mt-4 min-w-0">
+        <SkillCatalogView embedded />
+      </div>
+    </SurfaceSection>
+  );
+
+  return (
+    <div
+      className="mx-auto h-full w-full max-w-[1600px] min-w-0 overflow-x-hidden overflow-y-auto p-4 pb-40 sm:p-6"
+      style={{ paddingBottom: "max(10rem, calc(10rem + env(safe-area-inset-bottom)))" }}
+    >
+      <style>{`
+        @media (min-width: 1024px) {
+          .meetings-and-skills__skills > div:last-child {
+            grid-template-columns: minmax(0, 1fr) !important;
+          }
+        }
+      `}</style>
+
+      <SurfaceSection
+        eyebrow={t({ ko: "Meetings", en: "Meetings" })}
+        title={t({ ko: "회의 + 스킬 허브", en: "Meetings + Skills Hub" })}
+        description={t({
+          ko: "회의 기록 타임라인과 스킬 카탈로그를 한 화면에 묶은 Phase 2 통합 보기입니다.",
+          en: "Phase 2 combines the meeting timeline and skill catalog into a single workspace view.",
+        })}
+        badge={t({
+          ko: `${meetings.length}개 회의`,
+          en: `${meetings.length} meetings`,
+        })}
+        className="rounded-[28px] p-4 sm:p-5"
+        style={{
+          borderColor:
+            "color-mix(in srgb, var(--th-accent-success) 18%, var(--th-border) 82%)",
+          background:
+            "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, var(--th-accent-success) 4%) 0%, color-mix(in srgb, var(--th-bg-surface) 98%, transparent) 100%)",
+        }}
+      >
+        <div className="mt-4 flex flex-wrap gap-3">
+          <SurfaceMetricPill
+            label={t({ ko: "전체 회의", en: "Total Meetings" })}
+            value={t({
+              ko: `${meetings.length}건`,
+              en: `${meetings.length} records`,
+            })}
+            tone="info"
+          />
+          <SurfaceMetricPill
+            label={t({ ko: "활성 회의", en: "Active" })}
+            value={t({
+              ko: `${meetingSummary.activeCount}건 진행 중`,
+              en: `${meetingSummary.activeCount} in progress`,
+            })}
+            tone={meetingSummary.activeCount > 0 ? "accent" : "neutral"}
+          />
+          <SurfaceMetricPill
+            label={t({ ko: "완료 회의", en: "Completed" })}
+            value={t({
+              ko: `${completedCount}건`,
+              en: `${completedCount} records`,
+            })}
+            tone="success"
+          />
+          <SurfaceMetricPill
+            label={t({ ko: "후속 이슈", en: "Open Follow-ups" })}
+            value={t({
+              ko: `${meetingSummary.unresolvedCount}건 미해결`,
+              en: `${meetingSummary.unresolvedCount} unresolved`,
+            })}
+            tone={meetingSummary.unresolvedCount > 0 ? "warn" : "neutral"}
+          />
+        </div>
+
+        <SurfaceNotice tone="info" className="mt-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div className="min-w-0">
+              <div
+                className="text-xs font-semibold uppercase tracking-[0.16em]"
+                style={{ color: "var(--th-accent-info)" }}
+              >
+                {t({ ko: "Read Only", en: "Read Only" })}
+              </div>
+              <div className="mt-1 text-sm leading-6">
+                {t({
+                  ko: "이 화면은 회의 흐름과 스킬 문서를 함께 훑는 읽기 전용 허브입니다. 회의 상세 보기 드로어는 유지되지만 생성·폐기·삭제 같은 변경 액션은 숨깁니다.",
+                  en: "This page is a read-only hub for reviewing meeting flow alongside skill docs. The meeting detail drawer stays available, while create, discard, and delete actions stay hidden.",
+                })}
+              </div>
+            </div>
+          </div>
+        </SurfaceNotice>
+
+        {!isDesktopSplit && (
+          <div className="mt-4 flex gap-2">
+          <SurfaceSegmentButton
+            active={mobilePane === "meetings"}
+            tone="success"
+            onClick={() => setMobilePane("meetings")}
+            className="flex-1 text-center"
+          >
+            <span className="inline-flex items-center gap-1.5">
+              <MessagesSquare size={14} />
+              {t({ ko: "회의", en: "Meetings" })}
+            </span>
+          </SurfaceSegmentButton>
+          <SurfaceSegmentButton
+            active={mobilePane === "skills"}
+            tone="info"
+            onClick={() => setMobilePane("skills")}
+            className="flex-1 text-center"
+          >
+            <span className="inline-flex items-center gap-1.5">
+              <BookOpen size={14} />
+              {t({ ko: "스킬", en: "Skills" })}
+            </span>
+          </SurfaceSegmentButton>
+          </div>
+        )}
+      </SurfaceSection>
+
+      {isDesktopSplit ? (
+        <div className="mt-5 grid min-w-0 gap-5 lg:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)] lg:items-start">
+          <div className="min-w-0">{renderMeetingsPanel()}</div>
+          <div className="min-w-0">{renderSkillsPanel()}</div>
+        </div>
+      ) : (
+        <div className="mt-5 space-y-5">
+          {mobilePane === "meetings"
+            ? renderMeetingsPanel()
+            : renderSkillsPanel()}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/OfficeView.tsx
+++ b/dashboard/src/components/OfficeView.tsx
@@ -25,7 +25,11 @@ import type { OfficeTickerContext } from "./office-view/officeTicker";
 import OfficeInsightPanel from "./office-view/OfficeInsightPanel";
 import { useOfficePixiRuntime } from "./office-view/useOfficePixiRuntime";
 import type { SupportedLocale } from "./office-view/themes-locale";
-import { isManualInterventionCard } from "./agent-manager/kanban-utils";
+import {
+  deriveOfficeAgentState,
+  type OfficeManualIntervention,
+  type OfficeSeatStatus,
+} from "./office-view/officeAgentState";
 
 interface OfficeViewProps {
   agents: Agent[];
@@ -175,31 +179,33 @@ export default function OfficeView({
     activeMeeting,
     meetingPresence,
   });
-  // Build active issue lookup map from kanban cards
+  const officeAgentState = useMemo(
+    () => deriveOfficeAgentState(agents, kanbanCards),
+    [agents, kanbanCards],
+  );
+  const {
+    activeIssueByAgent: officeActiveIssueByAgent,
+    manualInterventionByAgent,
+    primaryCardByAgent,
+    seatStatusByAgent,
+  } = officeAgentState;
   const activeIssueByAgent = useMemo(() => {
     const map = new Map<string, { number: number; url: string; startedAt?: number; title?: string }>();
-    if (!kanbanCards) return map;
-    for (const card of kanbanCards) {
-      if (!card.assignee_agent_id || !card.github_issue_number) continue;
-      if (card.status !== "in_progress" && card.status !== "review") continue;
-      if (map.has(card.assignee_agent_id)) continue; // first match wins
-      map.set(card.assignee_agent_id, {
-        number: card.github_issue_number,
-        url: card.github_issue_url || `https://github.com/${card.github_repo}/issues/${card.github_issue_number}`,
-        startedAt: card.started_at != null ? (card.started_at < 1e12 ? card.started_at * 1000 : card.started_at) : undefined,
-        title: card.title,
+    for (const [agentId, issue] of officeActiveIssueByAgent) {
+      if (issue.number == null || !issue.url) continue;
+      map.set(agentId, {
+        number: issue.number,
+        url: issue.url,
+        startedAt: issue.startedAt ?? undefined,
+        title: issue.title,
       });
     }
     return map;
-  }, [kanbanCards]);
-  const blockedAgentIds = useMemo(() => {
-    const set = new Set<string>();
-    if (!kanbanCards) return set;
-    for (const card of kanbanCards) {
-      if (isManualInterventionCard(card) && card.assignee_agent_id) set.add(card.assignee_agent_id);
-    }
-    return set;
-  }, [kanbanCards]);
+  }, [officeActiveIssueByAgent]);
+  const blockedAgentIds = useMemo(
+    () => new Set(manualInterventionByAgent.keys()),
+    [manualInterventionByAgent],
+  );
   dataRef.current = {
     departments,
     agents,
@@ -269,7 +275,7 @@ export default function OfficeView({
   };
 
   // ── Scene revision state (triggers re-render after scene build) ──
-  const [, setSceneRevision] = useState(0);
+  const [sceneRevision, setSceneRevision] = useState(0);
 
   // ── Build scene context ──
   const sceneContext = useMemo<BuildOfficeSceneContext>(
@@ -419,6 +425,23 @@ export default function OfficeView({
   });
 
   const isKo = language === "ko";
+  const manualWarningEntries = useMemo(
+    () =>
+      agents
+        .map((agent) => {
+          const warning = manualInterventionByAgent.get(agent.id);
+          const position = agentPosRef.current.get(agent.id);
+          if (!warning || !position) return null;
+          return { agent, warning, position };
+        })
+        .filter(
+          (
+            entry,
+          ): entry is { agent: Agent; warning: OfficeManualIntervention; position: { x: number; y: number } } =>
+            entry !== null,
+        ),
+    [agents, manualInterventionByAgent, sceneRevision],
+  );
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col sm:flex-row sm:gap-3">
@@ -434,10 +457,24 @@ export default function OfficeView({
             isKo={isKo}
             onSelectAgent={onSelectAgent}
           />
-          <MobileAgentStatusGrid agents={agents} isKo={isKo} onSelectAgent={onSelectAgent} />
+          <MobileAgentStatusGrid
+            agents={agents}
+            isKo={isKo}
+            onSelectAgent={onSelectAgent}
+            manualInterventionByAgent={manualInterventionByAgent}
+            primaryCardByAgent={primaryCardByAgent}
+            seatStatusByAgent={seatStatusByAgent}
+          />
         </div>
         {/* Desktop: full Pixi office */}
-        <div ref={containerRef} className="hidden w-full min-h-full pb-40 sm:block" style={{ imageRendering: "pixelated" }} />
+        <div className="relative hidden w-full min-h-full pb-40 sm:block">
+          <div ref={containerRef} className="w-full min-h-full" style={{ imageRendering: "pixelated" }} />
+          <OfficeManualWarningOverlay
+            entries={manualWarningEntries}
+            isKo={isKo}
+            onSelectAgent={onSelectAgent}
+          />
+        </div>
       </div>
       <div className="hidden min-h-0 sm:block sm:h-full sm:w-[min(22rem,calc(100vw-1.5rem))] sm:shrink-0 sm:overflow-y-auto">
         <OfficeInsightPanel
@@ -457,68 +494,253 @@ export default function OfficeView({
 
 // ── Mobile Office Lite: agent status cards ──
 
-const STATUS_COLORS: Record<string, string> = {
-  working: "#34d399",
-  idle: "#94a3b8",
-  break: "#fbbf24",
-  offline: "#64748b",
-};
+function getSeatStatusMeta(
+  status: OfficeSeatStatus,
+  isKo: boolean,
+): { label: string; color: string; background: string; border: string } {
+  switch (status) {
+    case "working":
+      return {
+        label: isKo ? "작업 중" : "Working",
+        color: "var(--ok)",
+        background: "color-mix(in oklch, var(--ok) 12%, var(--bg-2) 88%)",
+        border: "color-mix(in oklch, var(--ok) 28%, var(--line) 72%)",
+      };
+    case "review":
+      return {
+        label: isKo ? "검토 중" : "In review",
+        color: "var(--warn)",
+        background: "color-mix(in oklch, var(--warn) 12%, var(--bg-2) 88%)",
+        border: "color-mix(in oklch, var(--warn) 28%, var(--line) 72%)",
+      };
+    case "offline":
+      return {
+        label: isKo ? "오프라인" : "Offline",
+        color: "var(--fg-faint)",
+        background: "color-mix(in oklch, var(--fg-faint) 12%, var(--bg-2) 88%)",
+        border: "color-mix(in oklch, var(--fg-faint) 24%, var(--line) 76%)",
+      };
+    case "idle":
+    default:
+      return {
+        label: isKo ? "대기" : "Idle",
+        color: "var(--fg-muted)",
+        background: "color-mix(in oklch, var(--fg-muted) 12%, var(--bg-2) 88%)",
+        border: "color-mix(in oklch, var(--fg-muted) 24%, var(--line) 76%)",
+      };
+  }
+}
+
+function previewManualReason(reason: string | null | undefined): string {
+  if (!reason) return "";
+  return reason.length > 72 ? `${reason.slice(0, 72)}…` : reason;
+}
+
+function previewCardTitle(title: string | null | undefined): string {
+  if (!title) return "";
+  return title.length > 52 ? `${title.slice(0, 52)}…` : title;
+}
+
+function OfficeManualWarningOverlay({
+  entries,
+  isKo,
+  onSelectAgent,
+}: {
+  entries: Array<{ agent: Agent; warning: OfficeManualIntervention; position: { x: number; y: number } }>;
+  isKo: boolean;
+  onSelectAgent?: (agent: Agent) => void;
+}) {
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-10">
+      {entries.map(({ agent, warning, position }) => (
+        <div
+          key={warning.cardId}
+          className="group absolute pointer-events-auto"
+          style={{
+            left: position.x + 16,
+            top: position.y - 28,
+            transform: "translate(-50%, -50%)",
+          }}
+        >
+          <button
+            type="button"
+            className="flex h-7 min-w-7 items-center justify-center rounded-full border text-xs font-semibold shadow-sm transition hover:scale-[1.04] focus:outline-none focus:ring-2"
+            style={{
+              color: "var(--warn)",
+              borderColor: "color-mix(in oklch, var(--warn) 28%, var(--line) 72%)",
+              background: "color-mix(in oklch, var(--warn) 14%, var(--bg-2) 86%)",
+            }}
+            aria-label={
+              isKo
+                ? `${agent.alias || agent.name_ko || agent.name} 수동 개입 경고`
+                : `${agent.alias || agent.name} manual intervention warning`
+            }
+          >
+            !
+          </button>
+          <div
+            className="pointer-events-none absolute bottom-[calc(100%+0.55rem)] left-1/2 hidden w-64 -translate-x-1/2 rounded-2xl border px-3 py-3 shadow-xl group-hover:block group-focus-within:block"
+            style={{
+              borderColor: "color-mix(in oklch, var(--warn) 26%, var(--line) 74%)",
+              background: "color-mix(in oklch, var(--warn) 8%, var(--bg-2) 92%)",
+            }}
+          >
+            <div className="text-[11px] font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--warn)" }}>
+              {isKo ? "수동 개입" : "Manual intervention"}
+            </div>
+            <div className="mt-1 text-sm font-semibold" style={{ color: "var(--fg)" }}>
+              {warning.title}
+            </div>
+            <div className="mt-2 text-xs leading-5" style={{ color: "var(--fg-muted)" }}>
+              {warning.reason
+                ?? (isKo
+                  ? "구체 사유는 카드 상세에서 확인할 수 있습니다."
+                  : "Open the detail drawer to inspect the full reason.")}
+            </div>
+            <div className="mt-3 flex items-center justify-between gap-2">
+              <span className="text-[11px]" style={{ color: "var(--fg-faint)" }}>
+                {warning.issueNumber ? `#${warning.issueNumber}` : warning.status}
+              </span>
+              <button
+                type="button"
+                className="pointer-events-auto rounded-full border px-2.5 py-1 text-[11px] font-semibold transition hover:opacity-90"
+                onClick={() => onSelectAgent?.(agent)}
+                style={{
+                  color: "var(--warn)",
+                  borderColor: "color-mix(in oklch, var(--warn) 30%, var(--line) 70%)",
+                  background: "color-mix(in oklch, var(--warn) 12%, var(--bg-2) 88%)",
+                }}
+              >
+                {isKo ? "세부 보기" : "Open detail"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 function MobileAgentStatusGrid({
   agents,
   isKo,
   onSelectAgent,
+  manualInterventionByAgent,
+  primaryCardByAgent,
+  seatStatusByAgent,
 }: {
   agents: Agent[];
   isKo: boolean;
   onSelectAgent?: (agent: Agent) => void;
+  manualInterventionByAgent: Map<string, OfficeManualIntervention>;
+  primaryCardByAgent: Map<string, KanbanCard>;
+  seatStatusByAgent: Map<string, OfficeSeatStatus>;
 }) {
   const sorted = [...agents].sort((a, b) => {
-    const order: Record<string, number> = { working: 0, break: 1, idle: 2, offline: 3 };
-    return (order[a.status] ?? 9) - (order[b.status] ?? 9);
+    const leftManual = manualInterventionByAgent.has(a.id) ? 0 : 1;
+    const rightManual = manualInterventionByAgent.has(b.id) ? 0 : 1;
+    if (leftManual !== rightManual) return leftManual - rightManual;
+
+    const order: Record<OfficeSeatStatus, number> = {
+      review: 0,
+      working: 1,
+      idle: 2,
+      offline: 3,
+    };
+    const leftStatus = seatStatusByAgent.get(a.id) ?? "idle";
+    const rightStatus = seatStatusByAgent.get(b.id) ?? "idle";
+    const statusDiff = (order[leftStatus] ?? 9) - (order[rightStatus] ?? 9);
+    if (statusDiff !== 0) return statusDiff;
+    return (a.alias || a.name_ko || a.name).localeCompare(b.alias || b.name_ko || b.name);
   });
 
   return (
-    <div className="px-3 pb-6 mt-3">
+    <div className="mt-3 px-3 pb-6">
       <div className="text-xs font-semibold uppercase tracking-[0.24em] mb-2 px-1" style={{ color: "var(--th-text-muted)" }}>
         {isKo ? "에이전트 현황" : "Agent Status"}
       </div>
       <div className="grid grid-cols-2 gap-2">
-        {sorted.map((agent) => (
-          <button
-            key={agent.id}
-            type="button"
-            onClick={() => onSelectAgent?.(agent)}
-            className="rounded-xl px-3 py-2.5 text-left"
-            style={{
-              background: "color-mix(in srgb, var(--th-card-bg) 86%, transparent)",
-              border: "1px solid var(--th-card-border)",
-            }}
-          >
-            <div className="flex items-center gap-2">
-              <span className="text-base">{agent.avatar_emoji}</span>
-              <span className="text-xs font-medium truncate" style={{ color: "var(--th-text-primary)" }}>
-                {agent.alias || agent.name_ko || agent.name}
-              </span>
-            </div>
-            <div className="flex items-center gap-1.5 mt-1.5">
-              <span
-                className="w-2 h-2 rounded-full shrink-0"
-                style={{ background: STATUS_COLORS[agent.status] ?? STATUS_COLORS.offline }}
-              />
-              <span className="text-xs truncate" style={{ color: STATUS_COLORS[agent.status] ?? STATUS_COLORS.offline }}>
-                {agent.session_info || (isKo
-                  ? (agent.status === "working" ? "작업 중" : agent.status === "idle" ? "대기" : agent.status === "break" ? "휴식" : "오프라인")
-                  : agent.status.charAt(0).toUpperCase() + agent.status.slice(1))}
-              </span>
-            </div>
-            {agent.department_name_ko && (
-              <div className="text-xs mt-1 truncate" style={{ color: "var(--th-text-muted)" }}>
-                {isKo ? agent.department_name_ko : (agent.department_name || agent.department_name_ko)}
+        {sorted.map((agent) => {
+          const status = seatStatusByAgent.get(agent.id) ?? "idle";
+          const statusMeta = getSeatStatusMeta(status, isKo);
+          const manualIntervention = manualInterventionByAgent.get(agent.id) ?? null;
+          const primaryCard = primaryCardByAgent.get(agent.id) ?? null;
+          const preview = manualIntervention?.reason
+            ? previewManualReason(manualIntervention.reason)
+            : previewCardTitle(primaryCard?.title ?? null);
+
+          return (
+            <button
+              key={agent.id}
+              type="button"
+              onClick={() => onSelectAgent?.(agent)}
+              className="rounded-2xl px-3 py-3 text-left"
+              style={{
+                background: manualIntervention
+                  ? "color-mix(in oklch, var(--warn) 8%, var(--bg-2) 92%)"
+                  : "color-mix(in oklch, var(--fg-faint) 6%, var(--bg-2) 94%)",
+                border: manualIntervention
+                  ? "1px solid color-mix(in oklch, var(--warn) 28%, var(--line) 72%)"
+                  : "1px solid var(--th-card-border)",
+              }}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex min-w-0 items-center gap-2">
+                  <span className="text-base">{agent.avatar_emoji}</span>
+                  <span className="truncate text-xs font-medium" style={{ color: "var(--th-text-primary)" }}>
+                    {agent.alias || agent.name_ko || agent.name}
+                  </span>
+                </div>
+                {manualIntervention && (
+                  <span
+                    className="shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold"
+                    style={{
+                      color: "var(--warn)",
+                      background: "color-mix(in oklch, var(--warn) 12%, var(--bg-2) 88%)",
+                    }}
+                  >
+                    {isKo ? "수동 개입" : "Manual"}
+                  </span>
+                )}
               </div>
-            )}
-          </button>
-        ))}
+              <div className="mt-2 flex items-center gap-1.5">
+                <span
+                  className="h-2 w-2 shrink-0 rounded-full"
+                  style={{ background: statusMeta.color }}
+                />
+                <span
+                  className="truncate text-xs"
+                  style={{ color: statusMeta.color }}
+                >
+                  {agent.session_info || statusMeta.label}
+                </span>
+              </div>
+              {preview && (
+                <div className="mt-2 text-[11px] leading-5" style={{ color: "var(--th-text-muted)" }}>
+                  {preview}
+                </div>
+              )}
+              {agent.department_name_ko && (
+                <div className="mt-2">
+                  <span
+                    className="inline-flex max-w-full items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
+                    style={{
+                      color: statusMeta.color,
+                      background: statusMeta.background,
+                      border: `1px solid ${statusMeta.border}`,
+                    }}
+                  >
+                    <span className="truncate">
+                      {isKo ? agent.department_name_ko : (agent.department_name || agent.department_name_ko)}
+                    </span>
+                  </span>
+                </div>
+              )}
+            </button>
+          );
+        })}
       </div>
     </div>
   );

--- a/dashboard/src/components/OpsPageView.tsx
+++ b/dashboard/src/components/OpsPageView.tsx
@@ -1,0 +1,658 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { AlertTriangle, RefreshCw, Wifi, WifiOff } from "lucide-react";
+import { getHealth, type HealthResponse } from "../api";
+import type { Agent, Office, WSEvent } from "../types";
+import OfficeManagerView from "./OfficeManagerView";
+import { describeDegradedReason } from "./dashboard/HealthWidget";
+import {
+  SurfaceActionButton,
+  SurfaceCard,
+  SurfaceEmptyState,
+  SurfaceMetaBadge,
+  SurfaceNotice,
+  SurfaceSection,
+  SurfaceSubsection,
+} from "./common/SurfacePrimitives";
+
+interface OpsPageViewProps {
+  wsConnected: boolean;
+  offices: Office[];
+  allAgents: Agent[];
+  selectedOfficeId?: string | null;
+  isKo: boolean;
+  onChanged: () => void;
+}
+
+type SignalSeverity = "normal" | "warning" | "danger";
+
+interface Threshold {
+  warning: number;
+  danger: number;
+}
+
+interface SignalCard {
+  key: "deferred_hooks" | "outbox_age" | "pending_queue" | "active_watchers" | "recovery_seconds";
+  label: string;
+  value: string;
+  rawValue: number;
+  severity: SignalSeverity;
+  note: string;
+}
+
+interface BottleneckRow {
+  kind: string;
+  count: number;
+  severity: Exclude<SignalSeverity, "normal">;
+  detail: string;
+}
+
+const STALE_AFTER_MS = 75_000;
+const LIVE_POLL_INTERVAL_MS = 5_000;
+const DISCONNECTED_POLL_BASE_MS = 5_000;
+const MAX_DISCONNECTED_POLL_MS = 30_000;
+const WS_REFRESH_DEBOUNCE_MS = 800;
+
+const SIGNAL_THRESHOLDS: Record<SignalCard["key"], Threshold> = {
+  deferred_hooks: { warning: 1, danger: 3 },
+  outbox_age: { warning: 30, danger: 60 },
+  pending_queue: { warning: 1, danger: 3 },
+  active_watchers: { warning: 4, danger: 8 },
+  recovery_seconds: { warning: 180, danger: 600 },
+};
+
+function resolveSeverity(value: number, threshold: Threshold): SignalSeverity {
+  if (value >= threshold.danger) return "danger";
+  if (value >= threshold.warning) return "warning";
+  return "normal";
+}
+
+function severityRank(severity: SignalSeverity): number {
+  switch (severity) {
+    case "danger":
+      return 2;
+    case "warning":
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+function toneForSeverity(severity: SignalSeverity): "info" | "warn" | "danger" | "success" {
+  switch (severity) {
+    case "danger":
+      return "danger";
+    case "warning":
+      return "warn";
+    default:
+      return "success";
+  }
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+function formatDurationCompact(seconds: number): string {
+  const safe = Math.max(0, Math.round(seconds));
+  if (safe >= 3600) {
+    const hours = Math.floor(safe / 3600);
+    const minutes = Math.floor((safe % 3600) / 60);
+    return `${hours}h ${minutes}m`;
+  }
+  if (safe >= 60) {
+    const minutes = Math.floor(safe / 60);
+    const remainSeconds = safe % 60;
+    return `${minutes}m ${remainSeconds}s`;
+  }
+  return `${safe}s`;
+}
+
+function formatUpdatedAt(timestamp: number | null, localeTag: string): string {
+  if (!timestamp) return "n/a";
+  return new Date(timestamp).toLocaleTimeString(localeTag, {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+}
+
+function buildSignalCards(data: HealthResponse, isKo: boolean): SignalCard[] {
+  const deferredHooks = data.deferred_hooks ?? 0;
+  const outboxAge = data.outbox_age ?? data.dispatch_outbox?.oldest_pending_age ?? 0;
+  const pendingQueue = data.queue_depth ?? 0;
+  const activeWatchers = data.watcher_count ?? 0;
+  const recoverySeconds = data.recovery_duration ?? 0;
+  const providerCount = data.providers?.length ?? 0;
+
+  return [
+    {
+      key: "deferred_hooks",
+      label: "Deferred Hooks",
+      value: formatNumber(deferredHooks),
+      rawValue: deferredHooks,
+      severity: resolveSeverity(deferredHooks, SIGNAL_THRESHOLDS.deferred_hooks),
+      note: isKo
+        ? `후처리 대기 ${formatNumber(deferredHooks)}건`
+        : `${formatNumber(deferredHooks)} waiting for post-processing`,
+    },
+    {
+      key: "outbox_age",
+      label: "Outbox Age",
+      value: formatDurationCompact(outboxAge),
+      rawValue: outboxAge,
+      severity: resolveSeverity(outboxAge, SIGNAL_THRESHOLDS.outbox_age),
+      note: isKo
+        ? `pending ${formatNumber(data.dispatch_outbox?.pending ?? 0)} · retry ${formatNumber(data.dispatch_outbox?.retrying ?? 0)}`
+        : `pending ${formatNumber(data.dispatch_outbox?.pending ?? 0)} · retry ${formatNumber(data.dispatch_outbox?.retrying ?? 0)}`,
+    },
+    {
+      key: "pending_queue",
+      label: "Pending Queue",
+      value: formatNumber(pendingQueue),
+      rawValue: pendingQueue,
+      severity: resolveSeverity(pendingQueue, SIGNAL_THRESHOLDS.pending_queue),
+      note: isKo
+        ? `active ${formatNumber(data.global_active ?? 0)} · finalizing ${formatNumber(data.global_finalizing ?? 0)}`
+        : `active ${formatNumber(data.global_active ?? 0)} · finalizing ${formatNumber(data.global_finalizing ?? 0)}`,
+    },
+    {
+      key: "active_watchers",
+      label: "Active Watchers",
+      value: formatNumber(activeWatchers),
+      rawValue: activeWatchers,
+      severity: resolveSeverity(activeWatchers, SIGNAL_THRESHOLDS.active_watchers),
+      note: isKo
+        ? `${formatNumber(providerCount)}개 provider 추적 중`
+        : `${formatNumber(providerCount)} providers in scope`,
+    },
+    {
+      key: "recovery_seconds",
+      label: "Recovery",
+      value: formatDurationCompact(recoverySeconds),
+      rawValue: recoverySeconds,
+      severity: resolveSeverity(recoverySeconds, SIGNAL_THRESHOLDS.recovery_seconds),
+      note: isKo
+        ? `uptime ${formatDurationCompact(data.uptime_secs ?? 0)}`
+        : `uptime ${formatDurationCompact(data.uptime_secs ?? 0)}`,
+    },
+  ];
+}
+
+function buildBottlenecks(data: HealthResponse): BottleneckRow[] {
+  const rows: BottleneckRow[] = [];
+  const outboxAge = data.outbox_age ?? data.dispatch_outbox?.oldest_pending_age ?? 0;
+  const disconnectedProviders = (data.providers ?? []).filter((provider) => !provider.connected).length;
+  const restartPendingProviders = (data.providers ?? []).filter((provider) => provider.restart_pending).length;
+  const providerQueueDepth = (data.providers ?? []).reduce(
+    (sum, provider) => sum + Math.max(provider.queue_depth ?? 0, 0),
+    0,
+  );
+
+  const addMetricBottleneck = (
+    kind: string,
+    count: number,
+    key: SignalCard["key"],
+    detail: string,
+  ) => {
+    const severity = resolveSeverity(count, SIGNAL_THRESHOLDS[key]);
+    if (severity === "normal" || count <= 0) return;
+    rows.push({ kind, count, severity, detail });
+  };
+
+  addMetricBottleneck("deferred_hooks", data.deferred_hooks ?? 0, "deferred_hooks", "deferred hook backlog");
+  addMetricBottleneck("outbox_age", outboxAge, "outbox_age", "oldest outbox item age (seconds)");
+  addMetricBottleneck("pending_queue", data.queue_depth ?? 0, "pending_queue", "global pending queue depth");
+  addMetricBottleneck("recovery_seconds", data.recovery_duration ?? 0, "recovery_seconds", "long-running recovery window");
+  addMetricBottleneck("active_watchers", data.watcher_count ?? 0, "active_watchers", "watcher load");
+
+  if (disconnectedProviders > 0) {
+    rows.push({
+      kind: "provider_disconnects",
+      count: disconnectedProviders,
+      severity: disconnectedProviders >= 2 ? "danger" : "warning",
+      detail: "providers disconnected",
+    });
+  }
+
+  if (restartPendingProviders > 0) {
+    rows.push({
+      kind: "restart_pending",
+      count: restartPendingProviders,
+      severity: restartPendingProviders >= 2 ? "danger" : "warning",
+      detail: "providers waiting for restart",
+    });
+  }
+
+  if (providerQueueDepth > 0) {
+    rows.push({
+      kind: "provider_queue",
+      count: providerQueueDepth,
+      severity: resolveSeverity(providerQueueDepth, SIGNAL_THRESHOLDS.pending_queue) === "danger" ? "danger" : "warning",
+      detail: "aggregate provider queue depth",
+    });
+  }
+
+  if (rows.length === 0 && (data.degraded_reasons?.length ?? 0) > 0) {
+    for (const reason of data.degraded_reasons ?? []) {
+      rows.push({
+        kind: reason,
+        count: 1,
+        severity: data.status === "unhealthy" ? "danger" : "warning",
+        detail: describeDegradedReason(reason),
+      });
+    }
+  }
+
+  return rows.sort((left, right) => {
+    const severityDelta = severityRank(right.severity) - severityRank(left.severity);
+    if (severityDelta !== 0) return severityDelta;
+    return right.count - left.count || left.kind.localeCompare(right.kind);
+  });
+}
+
+function translateStatus(status: string, isKo: boolean): string {
+  if (status === "healthy") return isKo ? "정상" : "Healthy";
+  if (status === "degraded") return isKo ? "주의" : "Degraded";
+  if (status === "unhealthy") return isKo ? "장애" : "Unhealthy";
+  return status.toUpperCase();
+}
+
+export default function OpsPageView({
+  wsConnected,
+  offices,
+  allAgents,
+  selectedOfficeId,
+  isKo,
+  onChanged,
+}: OpsPageViewProps) {
+  const tr = useCallback((ko: string, en: string) => (isKo ? ko : en), [isKo]);
+  const localeTag = isKo ? "ko-KR" : "en-US";
+
+  const [health, setHealth] = useState<HealthResponse | null>(null);
+  const [lastSuccessAt, setLastSuccessAt] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [failureCount, setFailureCount] = useState(0);
+  const [now, setNow] = useState(() => Date.now());
+  const refreshInFlightRef = useRef(false);
+
+  const refreshHealth = useCallback(async () => {
+    if (refreshInFlightRef.current) return;
+    refreshInFlightRef.current = true;
+    setIsRefreshing(true);
+    try {
+      const next = await getHealth();
+      setHealth(next);
+      setLastSuccessAt(Date.now());
+      setError(null);
+      setFailureCount(0);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : String(nextError));
+      setFailureCount((current) => current + 1);
+    } finally {
+      refreshInFlightRef.current = false;
+      setIsRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshHealth();
+  }, [refreshHealth]);
+
+  useEffect(() => {
+    if (!wsConnected) return;
+    void refreshHealth();
+  }, [refreshHealth, wsConnected]);
+
+  useEffect(() => {
+    const intervalMs = wsConnected
+      ? LIVE_POLL_INTERVAL_MS
+      : Math.min(MAX_DISCONNECTED_POLL_MS, DISCONNECTED_POLL_BASE_MS * 2 ** Math.min(failureCount, 4));
+
+    const timer = window.setInterval(() => {
+      void refreshHealth();
+    }, intervalMs);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [failureCount, refreshHealth, wsConnected]);
+
+  useEffect(() => {
+    const staleTimer = window.setInterval(() => {
+      setNow(Date.now());
+    }, 15_000);
+
+    return () => {
+      window.clearInterval(staleTimer);
+    };
+  }, []);
+
+  useEffect(() => {
+    let timer: number | null = null;
+
+    const handleWsEvent = (event: Event) => {
+      const detail = (event as CustomEvent<WSEvent>).detail;
+      if (!detail?.type) return;
+      if (timer != null) window.clearTimeout(timer);
+      timer = window.setTimeout(() => {
+        void refreshHealth();
+      }, WS_REFRESH_DEBOUNCE_MS);
+    };
+
+    window.addEventListener("pcd-ws-event", handleWsEvent);
+    return () => {
+      if (timer != null) window.clearTimeout(timer);
+      window.removeEventListener("pcd-ws-event", handleWsEvent);
+    };
+  }, [refreshHealth]);
+
+  const signals = useMemo(
+    () => (health ? buildSignalCards(health, isKo) : []),
+    [health, isKo],
+  );
+  const bottlenecks = useMemo(
+    () => (health ? buildBottlenecks(health) : []),
+    [health],
+  );
+  const stale = lastSuccessAt != null && now - lastSuccessAt > STALE_AFTER_MS;
+  const providerCount = health?.providers?.length ?? 0;
+  const connectedProviders = (health?.providers ?? []).filter((provider) => provider.connected).length;
+  const lastUpdatedLabel = formatUpdatedAt(lastSuccessAt, localeTag);
+  const disconnectedPollMs = Math.min(
+    MAX_DISCONNECTED_POLL_MS,
+    DISCONNECTED_POLL_BASE_MS * 2 ** Math.min(failureCount, 4),
+  );
+
+  return (
+    <div
+      className="mx-auto w-full max-w-6xl min-w-0 space-y-4 overflow-x-hidden p-4 pb-40 sm:h-full sm:overflow-y-auto sm:p-6"
+      style={{ paddingBottom: "max(10rem, calc(10rem + env(safe-area-inset-bottom)))" }}
+    >
+      <SurfaceSection
+        eyebrow="OPS"
+        title={tr("운영 컨트롤", "Ops Control")}
+        description={tr(
+          "런타임 헬스와 병목 신호를 먼저 보여주고, 실시간 WS 이벤트가 들어오면 health를 다시 읽습니다. WS가 끊기면 내부 polling 간격을 늘려가며 계속 갱신합니다.",
+          "Runtime health and bottleneck pressure come first. Incoming WS events trigger health refreshes, and when WS drops the page falls back to a widening internal polling interval.",
+        )}
+        badge={health ? translateStatus(health.status, isKo) : tr("초기 로드", "Initial load")}
+        actions={
+          <>
+            <SurfaceMetaBadge tone={wsConnected ? "success" : "danger"}>
+              <span className="inline-flex items-center gap-1.5">
+                {wsConnected ? <Wifi size={12} /> : <WifiOff size={12} />}
+                {wsConnected ? "LIVE" : "DISCONNECTED"}
+              </span>
+            </SurfaceMetaBadge>
+            {stale ? <SurfaceMetaBadge tone="warn">STALE</SurfaceMetaBadge> : null}
+            <SurfaceActionButton onClick={() => void refreshHealth()} disabled={isRefreshing}>
+              <span className="inline-flex items-center gap-1.5">
+                <RefreshCw size={13} className={isRefreshing ? "animate-spin" : undefined} />
+                {isRefreshing ? tr("동기화 중", "Refreshing") : tr("새로고침", "Refresh")}
+              </span>
+            </SurfaceActionButton>
+          </>
+        }
+      >
+        <div className="mt-5 flex flex-wrap items-center gap-2">
+          <SurfaceMetaBadge tone={health?.status === "unhealthy" ? "danger" : health?.status === "degraded" ? "warn" : "success"}>
+            {health ? translateStatus(health.status, isKo) : tr("대기 중", "Pending")}
+          </SurfaceMetaBadge>
+          <SurfaceMetaBadge>{tr(`업데이트 ${lastUpdatedLabel}`, `Updated ${lastUpdatedLabel}`)}</SurfaceMetaBadge>
+          <SurfaceMetaBadge>{tr(`provider ${connectedProviders}/${providerCount}`, `providers ${connectedProviders}/${providerCount}`)}</SurfaceMetaBadge>
+          <SurfaceMetaBadge>{tr(`fallback poll ${Math.round(disconnectedPollMs / 1000)}s`, `fallback poll ${Math.round(disconnectedPollMs / 1000)}s`)}</SurfaceMetaBadge>
+        </div>
+
+        {error ? (
+          <SurfaceNotice tone={health ? "warn" : "danger"} className="mt-4" leading={<AlertTriangle size={16} />}>
+            <div className="text-sm font-medium" style={{ color: "var(--th-text-primary)" }}>
+              {health
+                ? tr("최근 health 요청이 실패해 마지막 정상값을 유지 중입니다.", "Latest health request failed, keeping the last successful snapshot.")
+                : tr("health 응답을 아직 받지 못했습니다.", "Health response has not arrived yet.")}
+            </div>
+            <div className="mt-1 text-xs" style={{ color: "var(--th-text-muted)" }}>
+              {error}
+            </div>
+          </SurfaceNotice>
+        ) : null}
+
+        {health?.degraded_reasons && health.degraded_reasons.length > 0 ? (
+          <div className="mt-4 flex flex-wrap gap-2">
+            {health.degraded_reasons.slice(0, 4).map((reason) => (
+              <SurfaceMetaBadge
+                key={reason}
+                tone={health.status === "unhealthy" ? "danger" : "warn"}
+              >
+                {describeDegradedReason(reason)}
+              </SurfaceMetaBadge>
+            ))}
+          </div>
+        ) : null}
+
+        <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+          {signals.length > 0 ? (
+            signals.map((signal) => (
+              <SurfaceCard
+                key={signal.key}
+                className="min-w-0 rounded-3xl p-4"
+                style={{
+                  borderColor:
+                    signal.severity === "danger"
+                      ? "var(--color-danger-border)"
+                      : signal.severity === "warning"
+                        ? "var(--color-warning-border)"
+                        : "var(--color-info-border)",
+                  background:
+                    signal.severity === "danger"
+                      ? "var(--color-danger-soft)"
+                      : signal.severity === "warning"
+                        ? "var(--color-warning-soft)"
+                        : "var(--color-info-soft)",
+                }}
+              >
+                <div className="text-[11px] font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--th-text-muted)" }}>
+                  {signal.key}
+                </div>
+                <div className="mt-3 text-2xl font-semibold tracking-tight" style={{ color: "var(--th-text-primary)" }}>
+                  {signal.value}
+                </div>
+                <div className="mt-1 text-sm font-medium" style={{ color: "var(--th-text-primary)" }}>
+                  {signal.label}
+                </div>
+                <div className="mt-2 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                  {signal.note}
+                </div>
+              </SurfaceCard>
+            ))
+          ) : (
+            <div className="sm:col-span-2 xl:col-span-5">
+              <SurfaceEmptyState className="py-8">
+                <div className="flex flex-col items-center gap-2 text-center">
+                  <AlertTriangle size={20} style={{ color: "var(--th-text-muted)" }} />
+                  <div className="text-sm font-semibold" style={{ color: "var(--th-text-primary)" }}>
+                    {tr("표시할 health signal이 아직 없습니다.", "No health signals available yet.")}
+                  </div>
+                  <div className="text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                    {tr("초기 health 응답이 도착하면 signal grid가 채워집니다.", "The signal grid will populate after the first health response arrives.")}
+                  </div>
+                </div>
+              </SurfaceEmptyState>
+            </div>
+          )}
+        </div>
+      </SurfaceSection>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
+        <SurfaceSubsection
+          title={tr("Ops Bottlenecks", "Ops Bottlenecks")}
+          description={tr(
+            "헬스 응답에서 실제로 위험 신호가 난 항목만 추려 kind / count / severity로 정렬합니다.",
+            "Only active risk signals from the health response are surfaced here, sorted by kind / count / severity.",
+          )}
+        >
+          {bottlenecks.length > 0 ? (
+            <div className="mt-4 space-y-2">
+              <div
+                className="hidden items-center gap-3 rounded-2xl px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.16em] md:grid"
+                style={{
+                  gridTemplateColumns: "minmax(0, 1.5fr) 96px 110px",
+                  color: "var(--th-text-muted)",
+                  background: "color-mix(in srgb, var(--th-overlay-medium) 84%, transparent)",
+                }}
+              >
+                <span>kind</span>
+                <span>count</span>
+                <span>severity</span>
+              </div>
+              {bottlenecks.map((row) => (
+                <div
+                  key={`${row.kind}-${row.detail}`}
+                  className="grid gap-3 rounded-2xl border px-3 py-3 md:items-center"
+                  style={{
+                    gridTemplateColumns: "minmax(0, 1fr)",
+                    borderColor: row.severity === "danger" ? "var(--color-danger-border)" : "var(--color-warning-border)",
+                    background: row.severity === "danger" ? "var(--color-danger-soft)" : "var(--color-warning-soft)",
+                  }}
+                >
+                  <div className="md:hidden">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <div className="text-sm font-semibold" style={{ color: "var(--th-text-primary)" }}>
+                        {row.kind}
+                      </div>
+                      <SurfaceMetaBadge tone={toneForSeverity(row.severity)}>
+                        {row.severity.toUpperCase()}
+                      </SurfaceMetaBadge>
+                    </div>
+                    <div className="mt-1 text-xs" style={{ color: "var(--th-text-muted)" }}>
+                      {row.detail}
+                    </div>
+                    <div className="mt-2 text-xs font-medium" style={{ color: "var(--th-text-primary)" }}>
+                      count {formatNumber(row.count)}
+                    </div>
+                  </div>
+
+                  <div
+                    className="hidden md:grid md:items-center md:gap-3"
+                    style={{ gridTemplateColumns: "minmax(0, 1.5fr) 96px 110px" }}
+                  >
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-semibold" style={{ color: "var(--th-text-primary)" }}>
+                        {row.kind}
+                      </div>
+                      <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                        {row.detail}
+                      </div>
+                    </div>
+                    <div className="text-sm font-semibold" style={{ color: "var(--th-text-primary)" }}>
+                      {formatNumber(row.count)}
+                    </div>
+                    <div>
+                      <SurfaceMetaBadge tone={toneForSeverity(row.severity)}>
+                        {row.severity.toUpperCase()}
+                      </SurfaceMetaBadge>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <SurfaceEmptyState className="mt-4 py-8">
+              <div className="flex flex-col items-center gap-2 text-center">
+                <Wifi size={20} style={{ color: "var(--th-text-muted)" }} />
+                <div className="text-sm font-semibold" style={{ color: "var(--th-text-primary)" }}>
+                  {tr("현재 감지된 운영 병목이 없습니다.", "No active ops bottlenecks detected.")}
+                </div>
+                <div className="text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                  {tr("warning 이상 신호가 생기면 이 목록에 즉시 올라옵니다.", "Signals at warning level or above will appear here immediately.")}
+                </div>
+              </div>
+            </SurfaceEmptyState>
+          )}
+        </SurfaceSubsection>
+
+        <SurfaceSubsection
+          title={tr("Connection & Delivery", "Connection & Delivery")}
+          description={tr(
+            "WS 연결 상태와 outbox/provider 요약을 빠르게 확인하는 보조 패널입니다.",
+            "A compact side panel for WS connectivity and outbox/provider delivery status.",
+          )}
+        >
+          <div className="mt-4 space-y-3">
+            <SurfaceCard
+              className="rounded-3xl p-4"
+              style={{
+                borderColor: wsConnected ? "var(--color-info-border)" : "var(--color-danger-border)",
+                background: wsConnected ? "var(--color-info-soft)" : "var(--color-danger-soft)",
+              }}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--th-text-muted)" }}>
+                    websocket
+                  </div>
+                  <div className="mt-2 text-lg font-semibold" style={{ color: "var(--th-text-primary)" }}>
+                    {wsConnected ? tr("실시간 연결됨", "Connected live") : tr("연결 끊김", "Disconnected")}
+                  </div>
+                  <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                    {wsConnected
+                      ? tr("pcd-ws-event 수신 시 health refresh를 즉시 재스케줄합니다.", "Incoming pcd-ws-event messages reschedule health refreshes immediately.")
+                      : tr("WS가 복구될 때까지 내부 polling으로 health를 유지합니다.", "Internal polling keeps health current until WS recovers.")}
+                  </div>
+                </div>
+                <SurfaceMetaBadge tone={wsConnected ? "success" : "danger"}>
+                  {wsConnected ? "LIVE" : "DISCONNECTED"}
+                </SurfaceMetaBadge>
+              </div>
+            </SurfaceCard>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <SurfaceCard className="rounded-3xl p-4">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--th-text-muted)" }}>
+                  dispatch_outbox
+                </div>
+                <div className="mt-3 text-xl font-semibold" style={{ color: "var(--th-text-primary)" }}>
+                  {formatNumber(health?.dispatch_outbox?.pending ?? 0)}
+                </div>
+                <div className="mt-1 text-xs" style={{ color: "var(--th-text-muted)" }}>
+                  {tr(
+                    `retry ${formatNumber(health?.dispatch_outbox?.retrying ?? 0)} · fail ${formatNumber(health?.dispatch_outbox?.permanent_failures ?? 0)}`,
+                    `retry ${formatNumber(health?.dispatch_outbox?.retrying ?? 0)} · fail ${formatNumber(health?.dispatch_outbox?.permanent_failures ?? 0)}`,
+                  )}
+                </div>
+              </SurfaceCard>
+
+              <SurfaceCard className="rounded-3xl p-4">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--th-text-muted)" }}>
+                  providers
+                </div>
+                <div className="mt-3 text-xl font-semibold" style={{ color: "var(--th-text-primary)" }}>
+                  {connectedProviders}/{providerCount}
+                </div>
+                <div className="mt-1 text-xs" style={{ color: "var(--th-text-muted)" }}>
+                  {tr(
+                    `restart pending ${formatNumber((health?.providers ?? []).filter((provider) => provider.restart_pending).length)}`,
+                    `restart pending ${formatNumber((health?.providers ?? []).filter((provider) => provider.restart_pending).length)}`,
+                  )}
+                </div>
+              </SurfaceCard>
+            </div>
+          </div>
+        </SurfaceSubsection>
+      </div>
+
+      <div className="border-t pt-2" style={{ borderColor: "var(--th-border-subtle)" }}>
+        <div className="-mx-4 sm:-mx-6">
+          <OfficeManagerView
+            offices={offices}
+            allAgents={allAgents}
+            selectedOfficeId={selectedOfficeId}
+            isKo={isKo}
+            onChanged={onChanged}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/StatsPageView.tsx
+++ b/dashboard/src/components/StatsPageView.tsx
@@ -1,0 +1,1630 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+import {
+  getSkillCatalog,
+  getSkillRanking,
+  getTokenAnalytics,
+  type SkillRankingResponse,
+} from "../api";
+import { getProviderMeta, getProviderSeries } from "../app/providerTheme";
+import type { TFunction } from "./dashboard/model";
+import { timeAgo } from "./dashboard/model";
+import {
+  DashboardEmptyState,
+  cx,
+  dashboardBadge,
+  dashboardButton,
+  dashboardCard,
+  dashboardText,
+} from "./dashboard/ui";
+import type {
+  Agent,
+  CompanySettings,
+  DashboardStats,
+  DispatchedSession,
+  RoundTableMeeting,
+  SkillCatalogEntry,
+  TokenAnalyticsDailyPoint,
+  TokenAnalyticsResponse,
+} from "../types";
+import {
+  Activity,
+  BarChart3,
+  Bot,
+  Coins,
+  Cpu,
+  Gauge,
+  RefreshCw,
+  ShieldAlert,
+  Sparkles,
+  Users,
+} from "lucide-react";
+
+type Period = "7d" | "30d" | "90d";
+type PulseKanbanSignal = "review" | "blocked" | "requested" | "stalled";
+type DailySeriesKey =
+  | "input_tokens"
+  | "output_tokens"
+  | "cache_read_tokens"
+  | "cache_creation_tokens";
+
+interface StatsPageViewProps {
+  settings: CompanySettings;
+  stats?: DashboardStats | null;
+  agents?: Agent[];
+  sessions?: DispatchedSession[];
+  meetings?: RoundTableMeeting[];
+  requestedTab?: unknown;
+  onSelectAgent?: (agent: Agent) => void;
+  onOpenKanbanSignal?: (signal: PulseKanbanSignal) => void;
+  onOpenDispatchSessions?: () => void;
+  onOpenSettings?: () => void;
+  onRefreshMeetings?: () => void;
+  onRequestedTabHandled?: () => void;
+}
+
+interface ShareSegment {
+  id: string;
+  label: string;
+  tokens: number;
+  percentage: number;
+  color: string;
+  sublabel?: string;
+}
+
+interface SkillUsageRow {
+  id: string;
+  name: string;
+  description: string;
+  windowCalls: number;
+  windowShare: number;
+  lifetimeCalls: number | null;
+  lastUsedAt: number | null;
+}
+
+interface AgentSkillRow {
+  id: string;
+  agentName: string;
+  skillName: string;
+  description: string;
+  calls: number;
+  lastUsedAt: number;
+}
+
+interface AgentLeaderboardRow {
+  id: string;
+  label: string;
+  tokens: number;
+  share: number;
+  cost: number;
+  cacheHitRate: number;
+}
+
+const PERIOD_OPTIONS: Period[] = ["7d", "30d", "90d"];
+const DAILY_BAR_HEIGHT_PX = 184;
+const NUMERIC_STYLE: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontVariantNumeric: "tabular-nums",
+  fontFeatureSettings: '"tnum" 1',
+};
+
+function resolveLocaleTag(language: CompanySettings["language"]): string {
+  switch (language) {
+    case "ja":
+      return "ja-JP";
+    case "zh":
+      return "zh-CN";
+    case "en":
+      return "en-US";
+    default:
+      return "ko-KR";
+  }
+}
+
+function formatTokens(value: number): string {
+  if (value >= 1e9) return `${(value / 1e9).toFixed(1)}B`;
+  if (value >= 1e6) return `${(value / 1e6).toFixed(1)}M`;
+  if (value >= 1e3) return `${(value / 1e3).toFixed(1)}K`;
+  return Math.round(value).toString();
+}
+
+function formatCurrency(value: number): string {
+  if (value >= 100) return `$${value.toFixed(0)}`;
+  if (value >= 1) return `$${value.toFixed(2)}`;
+  if (value >= 0.01) return `$${value.toFixed(3)}`;
+  return `$${value.toFixed(4)}`;
+}
+
+function formatPercent(value: number): string {
+  return `${value.toFixed(1)}%`;
+}
+
+function formatDateLabel(value: string, localeTag: string): string {
+  const date = new Date(`${value}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(localeTag, {
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date);
+}
+
+function formatDateTime(value: number | string | null | undefined, localeTag: string): string {
+  if (value == null) return "—";
+  const date = typeof value === "number" ? new Date(value) : new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return new Intl.DateTimeFormat(localeTag, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function computeCacheHitRate(
+  inputTokens: number,
+  cacheReadTokens: number,
+  cacheCreationTokens = 0,
+): number {
+  const promptTokens = inputTokens + cacheReadTokens + cacheCreationTokens;
+  if (promptTokens <= 0) return 0;
+  return (cacheReadTokens / promptTokens) * 100;
+}
+
+function buildDonutBackground(segments: ShareSegment[]): string {
+  if (segments.length === 0) {
+    return "conic-gradient(rgba(148,163,184,0.16) 0deg 360deg)";
+  }
+  let cursor = 0;
+  const stops = segments.map((segment) => {
+    const start = cursor;
+    cursor += segment.percentage * 3.6;
+    return `${segment.color} ${start}deg ${cursor}deg`;
+  });
+  if (cursor < 360) {
+    stops.push(`rgba(148,163,184,0.14) ${cursor}deg 360deg`);
+  }
+  return `conic-gradient(${stops.join(", ")})`;
+}
+
+function buildModelSegments(data: TokenAnalyticsResponse | null): ShareSegment[] {
+  const models = data?.receipt.models ?? [];
+  const totalTokens = models.reduce((sum, item) => sum + item.total_tokens, 0);
+  if (totalTokens <= 0) return [];
+
+  const sorted = [...models].sort((left, right) => right.total_tokens - left.total_tokens);
+  const visible = sorted.slice(0, 6);
+  const overflow = sorted.slice(6);
+
+  const segments = visible.map((model, index) => ({
+    id: `${model.provider}-${model.model}`,
+    label: model.display_name,
+    tokens: model.total_tokens,
+    percentage: (model.total_tokens / totalTokens) * 100,
+    color: getProviderSeries(model.provider)[index % getProviderSeries(model.provider).length],
+    sublabel: getProviderMeta(model.provider).label,
+  }));
+
+  if (overflow.length > 0) {
+    const overflowTokens = overflow.reduce((sum, item) => sum + item.total_tokens, 0);
+    segments.push({
+      id: "other-models",
+      label: "Other",
+      tokens: overflowTokens,
+      percentage: (overflowTokens / totalTokens) * 100,
+      color: "var(--fg-muted)",
+      sublabel: `${overflow.length} models`,
+    });
+  }
+
+  return segments;
+}
+
+function buildProviderSegments(data: TokenAnalyticsResponse | null): ShareSegment[] {
+  if (!data) return [];
+  const providers = data.receipt.providers;
+  if (providers.length > 0) {
+    return [...providers]
+      .sort((left, right) => right.tokens - left.tokens)
+      .map((provider) => ({
+        id: provider.provider,
+        label: getProviderMeta(provider.provider).label,
+        tokens: provider.tokens,
+        percentage: provider.percentage,
+        color: getProviderMeta(provider.provider).color,
+      }));
+  }
+
+  const byProvider = new Map<string, number>();
+  for (const model of data.receipt.models) {
+    byProvider.set(model.provider, (byProvider.get(model.provider) ?? 0) + model.total_tokens);
+  }
+  const totalTokens = Array.from(byProvider.values()).reduce((sum, value) => sum + value, 0);
+  return Array.from(byProvider.entries())
+    .sort((left, right) => right[1] - left[1])
+    .map(([provider, tokens]) => ({
+      id: provider,
+      label: getProviderMeta(provider).label,
+      tokens,
+      percentage: totalTokens > 0 ? (tokens / totalTokens) * 100 : 0,
+      color: getProviderMeta(provider).color,
+    }));
+}
+
+function buildSkillRows(
+  ranking: SkillRankingResponse | null,
+  catalog: SkillCatalogEntry[],
+  language: CompanySettings["language"],
+): SkillUsageRow[] {
+  if (!ranking) return [];
+  const catalogMap = new Map(catalog.map((entry) => [entry.name, entry]));
+  const totalCalls = ranking.overall.reduce((sum, row) => sum + row.calls, 0);
+
+  return ranking.overall.slice(0, 8).map((row) => {
+    const catalogEntry = catalogMap.get(row.skill_name);
+    const description =
+      language === "ko"
+        ? catalogEntry?.description_ko || row.skill_desc_ko || catalogEntry?.description || row.skill_name
+        : catalogEntry?.description || catalogEntry?.description_ko || row.skill_desc_ko || row.skill_name;
+
+    return {
+      id: row.skill_name,
+      name: row.skill_name,
+      description,
+      windowCalls: row.calls,
+      windowShare: totalCalls > 0 ? (row.calls / totalCalls) * 100 : 0,
+      lifetimeCalls: catalogEntry?.total_calls ?? null,
+      lastUsedAt: row.last_used_at ?? catalogEntry?.last_used_at ?? null,
+    };
+  });
+}
+
+function buildAgentSkillRows(
+  ranking: SkillRankingResponse | null,
+  catalog: SkillCatalogEntry[],
+  language: CompanySettings["language"],
+): AgentSkillRow[] {
+  if (!ranking) return [];
+  const catalogMap = new Map(catalog.map((entry) => [entry.name, entry]));
+
+  return ranking.byAgent.slice(0, 8).map((row, index) => {
+    const catalogEntry = catalogMap.get(row.skill_name);
+    const description =
+      language === "ko"
+        ? catalogEntry?.description_ko || row.skill_desc_ko || catalogEntry?.description || row.skill_name
+        : catalogEntry?.description || catalogEntry?.description_ko || row.skill_desc_ko || row.skill_name;
+
+    return {
+      id: `${row.agent_role_id}-${row.skill_name}-${index}`,
+      agentName: row.agent_name,
+      skillName: row.skill_name,
+      description,
+      calls: row.calls,
+      lastUsedAt: row.last_used_at,
+    };
+  });
+}
+
+function buildAgentLeaderboard(data: TokenAnalyticsResponse | null): AgentLeaderboardRow[] {
+  return [...(data?.receipt.agents ?? [])]
+    .sort((left, right) => right.tokens - left.tokens)
+    .slice(0, 10)
+    .map((agent) => ({
+      id: agent.agent,
+      label: agent.agent,
+      tokens: agent.tokens,
+      share: agent.percentage,
+      cost: agent.cost,
+      cacheHitRate: computeCacheHitRate(
+        agent.input_tokens ?? 0,
+        agent.cache_read_tokens ?? 0,
+        agent.cache_creation_tokens ?? 0,
+      ),
+    }));
+}
+
+function dailySeries(t: TFunction): Array<{ key: DailySeriesKey; label: string; color: string }> {
+  return [
+    {
+      key: "input_tokens",
+      label: t({ ko: "입력", en: "Input", ja: "入力", zh: "输入" }),
+      color: "#38bdf8",
+    },
+    {
+      key: "output_tokens",
+      label: t({ ko: "출력", en: "Output", ja: "出力", zh: "输出" }),
+      color: "#fb923c",
+    },
+    {
+      key: "cache_read_tokens",
+      label: t({ ko: "캐시 읽기", en: "Cache Read", ja: "キャッシュ読取", zh: "缓存读取" }),
+      color: "#22c55e",
+    },
+    {
+      key: "cache_creation_tokens",
+      label: t({ ko: "캐시 쓰기", en: "Cache Write", ja: "キャッシュ書込", zh: "缓存写入" }),
+      color: "#a855f7",
+    },
+  ];
+}
+
+export default function StatsPageView({ settings }: StatsPageViewProps) {
+  const language = settings.language;
+  const localeTag = useMemo(() => resolveLocaleTag(language), [language]);
+  const numberFormatter = useMemo(() => new Intl.NumberFormat(localeTag), [localeTag]);
+  const t: TFunction = useCallback(
+    (messages) => messages[language] ?? messages.ko,
+    [language],
+  );
+
+  const [period, setPeriod] = useState<Period>("30d");
+  const [reloadKey, setReloadKey] = useState(0);
+  const [analytics, setAnalytics] = useState<TokenAnalyticsResponse | null>(null);
+  const [skillRanking, setSkillRanking] = useState<SkillRankingResponse | null>(null);
+  const [catalog, setCatalog] = useState<SkillCatalogEntry[]>([]);
+  const [analyticsLoading, setAnalyticsLoading] = useState(true);
+  const [skillLoading, setSkillLoading] = useState(true);
+  const [catalogLoading, setCatalogLoading] = useState(true);
+  const [analyticsError, setAnalyticsError] = useState<string | null>(null);
+  const [skillError, setSkillError] = useState<string | null>(null);
+  const [catalogError, setCatalogError] = useState<string | null>(null);
+  const [lastRefreshedAt, setLastRefreshedAt] = useState<number | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    const loadCatalog = async () => {
+      setCatalogLoading(true);
+      setCatalogError(null);
+      try {
+        const next = await getSkillCatalog();
+        if (!active) return;
+        setCatalog(next);
+      } catch {
+        if (!active) return;
+        setCatalogError(
+          t({
+            ko: "스킬 카탈로그를 불러오지 못했습니다.",
+            en: "Unable to load the skill catalog.",
+            ja: "スキルカタログを読み込めませんでした。",
+            zh: "无法加载技能目录。",
+          }),
+        );
+      } finally {
+        if (active) setCatalogLoading(false);
+      }
+    };
+
+    void loadCatalog();
+    return () => {
+      active = false;
+    };
+  }, [t]);
+
+  useEffect(() => {
+    let active = true;
+    const controller = new AbortController();
+
+    const load = async () => {
+      setAnalyticsLoading(true);
+      setSkillLoading(true);
+      setAnalyticsError(null);
+      setSkillError(null);
+
+      const [analyticsResult, skillResult] = await Promise.allSettled([
+        getTokenAnalytics(period, { signal: controller.signal }),
+        getSkillRanking(period, 16),
+      ]);
+
+      if (!active) return;
+
+      if (analyticsResult.status === "fulfilled") {
+        setAnalytics(analyticsResult.value);
+      } else {
+        setAnalyticsError(
+          t({
+            ko: "토큰 분석을 불러오지 못했습니다.",
+            en: "Unable to load token analytics.",
+            ja: "トークン分析を読み込めませんでした。",
+            zh: "无法加载 Token 分析。",
+          }),
+        );
+      }
+      setAnalyticsLoading(false);
+
+      if (skillResult.status === "fulfilled") {
+        setSkillRanking(skillResult.value);
+      } else {
+        setSkillError(
+          t({
+            ko: "스킬 랭킹을 불러오지 못했습니다.",
+            en: "Unable to load skill ranking.",
+            ja: "スキルランキングを読み込めませんでした。",
+            zh: "无法加载技能排行。",
+          }),
+        );
+      }
+      setSkillLoading(false);
+
+      if (analyticsResult.status === "fulfilled" || skillResult.status === "fulfilled") {
+        setLastRefreshedAt(Date.now());
+      }
+    };
+
+    void load();
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [period, reloadKey, t]);
+
+  const series = useMemo(() => dailySeries(t), [t]);
+  const summary = analytics?.summary;
+  const totalPromptTokens = useMemo(
+    () =>
+      analytics?.daily.reduce(
+        (sum, day) => sum + day.input_tokens + day.cache_read_tokens + day.cache_creation_tokens,
+        0,
+      ) ?? 0,
+    [analytics],
+  );
+  const cacheReadTokens = useMemo(
+    () => analytics?.daily.reduce((sum, day) => sum + day.cache_read_tokens, 0) ?? 0,
+    [analytics],
+  );
+  const cacheHitRate = useMemo(
+    () => computeCacheHitRate(totalPromptTokens - cacheReadTokens, cacheReadTokens),
+    [cacheReadTokens, totalPromptTokens],
+  );
+  const uncachedBaseline = (summary?.total_cost ?? 0) + (summary?.cache_discount ?? 0);
+  const modelSegments = useMemo(() => buildModelSegments(analytics), [analytics]);
+  const providerSegments = useMemo(() => buildProviderSegments(analytics), [analytics]);
+  const skillRows = useMemo(
+    () => buildSkillRows(skillRanking, catalog, language),
+    [catalog, language, skillRanking],
+  );
+  const byAgentSkillRows = useMemo(
+    () => buildAgentSkillRows(skillRanking, catalog, language),
+    [catalog, language, skillRanking],
+  );
+  const agentLeaderboard = useMemo(() => buildAgentLeaderboard(analytics), [analytics]);
+  const activeSkillCount = useMemo(
+    () => new Set(skillRanking?.overall.map((row) => row.skill_name) ?? []).size,
+    [skillRanking],
+  );
+  const catalogUsedCount = useMemo(
+    () => catalog.filter((entry) => entry.total_calls > 0).length,
+    [catalog],
+  );
+  const windowCalls = useMemo(
+    () => skillRanking?.overall.reduce((sum, row) => sum + row.calls, 0) ?? 0,
+    [skillRanking],
+  );
+  const hasAnyLoadError = analyticsError || skillError || catalogError;
+
+  return (
+    <div
+      className="mx-auto h-full w-full max-w-7xl min-w-0 overflow-x-hidden overflow-y-auto p-4 pb-40 sm:p-6"
+      style={{ paddingBottom: "max(10rem, calc(10rem + env(safe-area-inset-bottom)))" }}
+    >
+      <section className="space-y-4">
+        <header
+          className={dashboardCard.accentHero}
+          style={{
+            borderColor: "color-mix(in oklch, var(--accent) 28%, var(--th-border) 72%)",
+            background:
+              "linear-gradient(145deg, color-mix(in oklch, var(--accent) 10%, var(--th-surface) 90%) 0%, var(--th-surface) 100%)",
+          }}
+        >
+          <div className="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
+            <div className="min-w-0">
+              <div className={dashboardText.labelMuted} style={{ color: "var(--th-text-muted)" }}>
+                {t({
+                  ko: "Phase 2 Stats",
+                  en: "Phase 2 Stats",
+                  ja: "Phase 2 Stats",
+                  zh: "Phase 2 Stats",
+                })}
+              </div>
+              <h1
+                className="mt-2 text-2xl font-black tracking-tight sm:text-3xl"
+                style={{ color: "var(--th-text-heading)" }}
+              >
+                {t({
+                  ko: "전용 통계 보드",
+                  en: "Dedicated Stats Board",
+                  ja: "専用統計ボード",
+                  zh: "专用统计面板",
+                })}
+              </h1>
+              <p className="mt-2 max-w-3xl text-sm leading-6" style={{ color: "var(--th-text-muted)" }}>
+                {t({
+                  ko: "범위를 바꾸면 요약 카드, 일별 토큰 차트, 모델/프로바이더 분포, 스킬 사용, 에이전트 리더보드가 함께 갱신됩니다.",
+                  en: "Changing the range refreshes the summary cards, daily token chart, model/provider mix, skill usage, and agent leaderboard together.",
+                  ja: "範囲を切り替えると、概要カード、日次トークンチャート、モデル/プロバイダー比率、スキル使用、エージェントリーダーボードが一緒に更新されます。",
+                  zh: "切换时间范围时，摘要卡、每日 Token 图、模型/提供商占比、技能使用和代理排行榜会一起更新。",
+                })}
+              </p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                <HeaderBadge
+                  icon={<Activity size={14} />}
+                  label={analytics?.period_label ?? t({ ko: "데이터 동기화 중", en: "Syncing data", ja: "同期中", zh: "同步中" })}
+                />
+                <HeaderBadge
+                  icon={<Gauge size={14} />}
+                  label={
+                    summary
+                      ? t({
+                          ko: `${numberFormatter.format(summary.active_days)}일 활성`,
+                          en: `${numberFormatter.format(summary.active_days)} active days`,
+                          ja: `${numberFormatter.format(summary.active_days)}日稼働`,
+                          zh: `${numberFormatter.format(summary.active_days)} 天活跃`,
+                        })
+                      : t({ ko: "활성 일수 집계 중", en: "Calculating active days", ja: "稼働日数を計算中", zh: "计算活跃天数" })
+                  }
+                />
+                <HeaderBadge
+                  icon={<Sparkles size={14} />}
+                  label={
+                    summary
+                      ? t({
+                          ko: `평균 ${formatTokens(summary.average_daily_tokens)} / 일`,
+                          en: `Avg ${formatTokens(summary.average_daily_tokens)} / day`,
+                          ja: `平均 ${formatTokens(summary.average_daily_tokens)} / 日`,
+                          zh: `平均 ${formatTokens(summary.average_daily_tokens)} / 天`,
+                        })
+                      : t({ ko: "평균 처리량 계산 중", en: "Calculating average throughput", ja: "平均処理量を計算中", zh: "计算平均吞吐量" })
+                  }
+                />
+                <HeaderBadge
+                  icon={<RefreshCw size={14} className={cx(analyticsLoading || skillLoading ? "animate-spin" : "")} />}
+                  label={
+                    lastRefreshedAt
+                      ? t({
+                          ko: `${formatDateTime(lastRefreshedAt, localeTag)} 갱신`,
+                          en: `Updated ${formatDateTime(lastRefreshedAt, localeTag)}`,
+                          ja: `${formatDateTime(lastRefreshedAt, localeTag)} 更新`,
+                          zh: `${formatDateTime(lastRefreshedAt, localeTag)} 更新`,
+                        })
+                      : t({ ko: "첫 집계 대기 중", en: "Waiting for first sync", ja: "初回同期待ち", zh: "等待首次同步" })
+                  }
+                />
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-3 xl:items-end">
+              <div className="flex flex-wrap gap-2">
+                {PERIOD_OPTIONS.map((option) => {
+                  const active = option === period;
+                  return (
+                    <button
+                      key={option}
+                      type="button"
+                      className={cx(dashboardButton.sm, "min-w-[4.5rem] justify-center")}
+                      onClick={() => setPeriod(option)}
+                      aria-pressed={active}
+                      style={
+                        active
+                          ? {
+                              background: "color-mix(in oklch, var(--accent) 20%, var(--th-surface) 80%)",
+                              borderColor: "color-mix(in oklch, var(--accent) 36%, var(--th-border) 64%)",
+                              color: "var(--th-text-heading)",
+                            }
+                          : undefined
+                      }
+                    >
+                      <span style={NUMERIC_STYLE}>{option}</span>
+                    </button>
+                  );
+                })}
+              </div>
+              <button
+                type="button"
+                className={cx(dashboardButton.sm, "justify-center gap-2")}
+                onClick={() => setReloadKey((value) => value + 1)}
+              >
+                <RefreshCw size={14} className={cx(analyticsLoading || skillLoading ? "animate-spin" : "")} />
+                {t({ ko: "다시 불러오기", en: "Reload", ja: "再読み込み", zh: "重新加载" })}
+              </button>
+            </div>
+          </div>
+        </header>
+
+        {hasAnyLoadError ? (
+          <div
+            className={dashboardCard.nestedCompact}
+            style={{
+              borderColor: "color-mix(in oklch, var(--warn) 30%, var(--th-border) 70%)",
+              background:
+                "linear-gradient(180deg, color-mix(in oklch, var(--warn) 8%, var(--th-surface) 92%) 0%, var(--th-surface) 100%)",
+            }}
+          >
+            <div className="flex items-start gap-3">
+              <ShieldAlert
+                size={18}
+                style={{ color: "var(--th-accent-warn)", flexShrink: 0, marginTop: 2 }}
+              />
+              <div className="min-w-0">
+                <div className="text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                  {t({
+                    ko: "일부 통계를 새로고침하지 못했습니다.",
+                    en: "Some stats could not be refreshed.",
+                    ja: "一部の統計を更新できませんでした。",
+                    zh: "部分统计刷新失败。",
+                  })}
+                </div>
+                <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                  {[analyticsError, skillError, catalogError].filter(Boolean).join(" ")}
+                </div>
+              </div>
+            </div>
+          </div>
+        ) : null}
+
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <SummaryMetricCard
+            icon={<BarChart3 size={18} />}
+            label={t({ ko: "총 토큰", en: "Total Tokens", ja: "総トークン", zh: "总代币" })}
+            value={summary ? formatTokens(summary.total_tokens) : "…"}
+            sub={analytics?.period_label ?? t({ ko: "기간 집계 대기", en: "Waiting for range data", ja: "範囲集計待ち", zh: "等待区间数据" })}
+            accent="#f59e0b"
+          />
+          <SummaryMetricCard
+            icon={<Coins size={18} />}
+            label={t({ ko: "API 비용", en: "API Spend", ja: "API コスト", zh: "API 成本" })}
+            value={summary ? formatCurrency(summary.total_cost) : "…"}
+            sub={
+              summary
+                ? t({
+                    ko: `메시지 ${numberFormatter.format(summary.total_messages)} / 세션 ${numberFormatter.format(summary.total_sessions)}`,
+                    en: `${numberFormatter.format(summary.total_messages)} messages / ${numberFormatter.format(summary.total_sessions)} sessions`,
+                    ja: `${numberFormatter.format(summary.total_messages)} メッセージ / ${numberFormatter.format(summary.total_sessions)} セッション`,
+                    zh: `${numberFormatter.format(summary.total_messages)} 消息 / ${numberFormatter.format(summary.total_sessions)} 会话`,
+                  })
+                : t({ ko: "비용 집계 대기", en: "Waiting for spend data", ja: "コスト集計待ち", zh: "等待成本数据" })
+            }
+            accent="#22c55e"
+          />
+          <SummaryMetricCard
+            icon={<Sparkles size={18} />}
+            label={t({ ko: "캐시 절감", en: "Cache Saved", ja: "キャッシュ節約", zh: "缓存节省" })}
+            value={summary ? formatCurrency(summary.cache_discount) : "…"}
+            sub={
+              summary
+                ? t({
+                    ko: `uncached 기준 ${formatCurrency(uncachedBaseline)}`,
+                    en: `${formatCurrency(uncachedBaseline)} uncached baseline`,
+                    ja: `uncached 基準 ${formatCurrency(uncachedBaseline)}`,
+                    zh: `uncached 基线 ${formatCurrency(uncachedBaseline)}`,
+                  })
+                : t({ ko: "절감액 계산 대기", en: "Waiting for savings data", ja: "節約額計算待ち", zh: "等待节省数据" })
+            }
+            accent="#14b8a6"
+          />
+          <SummaryMetricCard
+            icon={<Gauge size={18} />}
+            label={t({ ko: "캐시 히트율", en: "Cache Hit Rate", ja: "キャッシュヒット率", zh: "缓存命中率" })}
+            value={summary ? formatPercent(cacheHitRate) : "…"}
+            sub={
+              summary
+                ? t({
+                    ko: `${formatTokens(cacheReadTokens)} cache read / ${formatTokens(totalPromptTokens)} prompt`,
+                    en: `${formatTokens(cacheReadTokens)} cache read / ${formatTokens(totalPromptTokens)} prompt`,
+                    ja: `${formatTokens(cacheReadTokens)} cache read / ${formatTokens(totalPromptTokens)} prompt`,
+                    zh: `${formatTokens(cacheReadTokens)} cache read / ${formatTokens(totalPromptTokens)} prompt`,
+                  })
+                : t({ ko: "히트율 계산 대기", en: "Waiting for cache hit data", ja: "ヒット率計算待ち", zh: "等待命中率数据" })
+            }
+            accent="#8b5cf6"
+          />
+        </div>
+
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.4fr)_minmax(0,0.85fr)]">
+          <DailyTokenChartCard
+            t={t}
+            localeTag={localeTag}
+            numberFormatter={numberFormatter}
+            loading={analyticsLoading}
+            daily={analytics?.daily ?? []}
+            series={series}
+            summary={summary}
+          />
+
+          <div className="grid gap-4">
+            <DistributionCard
+              icon={<Cpu size={18} />}
+              title={t({ ko: "모델 점유율", en: "Model Share", ja: "モデル比率", zh: "模型占比" })}
+              description={t({
+                ko: "선택한 범위에서 어떤 모델이 토큰을 가장 많이 처리했는지 보여줍니다.",
+                en: "Shows which models processed the most tokens in the selected window.",
+                ja: "選択範囲でどのモデルが最も多くのトークンを処理したかを示します。",
+                zh: "显示所选范围内处理 Token 最多的模型。",
+              })}
+              emptyLabel={t({
+                ko: "표시할 모델 분포가 없습니다.",
+                en: "No model distribution available.",
+                ja: "表示するモデル分布がありません。",
+                zh: "没有可显示的模型分布。",
+              })}
+              loading={analyticsLoading}
+              segments={modelSegments}
+              centerLabel={t({ ko: "모델", en: "Models", ja: "モデル", zh: "模型" })}
+              centerValue={summary ? formatTokens(summary.total_tokens) : "0"}
+              centerSub={
+                analytics
+                  ? t({
+                      ko: `${analytics.receipt.models.length}개 추적`,
+                      en: `${analytics.receipt.models.length} tracked`,
+                      ja: `${analytics.receipt.models.length}件追跡`,
+                      zh: `追踪 ${analytics.receipt.models.length} 个`,
+                    })
+                  : t({ ko: "데이터 대기", en: "Waiting for data", ja: "データ待ち", zh: "等待数据" })
+              }
+            />
+
+            <ProviderShareCard
+              t={t}
+              loading={analyticsLoading}
+              segments={providerSegments}
+            />
+          </div>
+        </div>
+
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
+          <SkillUsageSection
+            t={t}
+            localeTag={localeTag}
+            loading={skillLoading || catalogLoading}
+            skillRows={skillRows}
+            byAgentRows={byAgentSkillRows}
+            activeSkillCount={activeSkillCount}
+            catalogCount={catalog.length}
+            catalogUsedCount={catalogUsedCount}
+            windowCalls={windowCalls}
+          />
+
+          <AgentLeaderboardCard
+            t={t}
+            loading={analyticsLoading}
+            rows={agentLeaderboard}
+          />
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function HeaderBadge({ icon, label }: { icon: ReactNode; label: string }) {
+  return (
+    <span
+      className={dashboardBadge.default}
+      style={{
+        background: "var(--th-overlay-light)",
+        color: "var(--th-text-secondary)",
+        borderColor: "var(--th-border-subtle)",
+      }}
+    >
+      <span className="inline-flex items-center gap-1.5">
+        {icon}
+        <span>{label}</span>
+      </span>
+    </span>
+  );
+}
+
+function SummaryMetricCard({
+  icon,
+  label,
+  value,
+  sub,
+  accent,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  sub: string;
+  accent: string;
+}) {
+  return (
+    <article
+      className={dashboardCard.standard}
+      style={{
+        borderColor: `color-mix(in oklch, ${accent} 30%, var(--th-border) 70%)`,
+        background:
+          `linear-gradient(180deg, color-mix(in oklch, ${accent} 8%, var(--th-surface) 92%) 0%, var(--th-surface) 100%)`,
+      }}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className={dashboardText.label} style={{ color: "var(--th-text-muted)" }}>
+            {label}
+          </div>
+          <div
+            className="mt-3 text-3xl font-black tracking-tight tabular-nums"
+            style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}
+          >
+            {value}
+          </div>
+          <div className="mt-2 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+            {sub}
+          </div>
+        </div>
+        <span
+          className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border"
+          style={{
+            background: `color-mix(in oklch, ${accent} 14%, transparent)`,
+            borderColor: `color-mix(in oklch, ${accent} 34%, var(--th-border) 66%)`,
+            color: accent,
+          }}
+        >
+          {icon}
+        </span>
+      </div>
+    </article>
+  );
+}
+
+function DailyTokenChartCard({
+  t,
+  localeTag,
+  numberFormatter,
+  loading,
+  daily,
+  series,
+  summary,
+}: {
+  t: TFunction;
+  localeTag: string;
+  numberFormatter: Intl.NumberFormat;
+  loading: boolean;
+  daily: TokenAnalyticsDailyPoint[];
+  series: Array<{ key: DailySeriesKey; label: string; color: string }>;
+  summary: TokenAnalyticsResponse["summary"] | null | undefined;
+}) {
+  const maxTotal = Math.max(1, ...daily.map((day) => day.total_tokens));
+  const labelStride = Math.max(1, Math.ceil(Math.max(daily.length, 1) / 7));
+
+  return (
+    <article className={dashboardCard.standard}>
+      <SectionHeader
+        icon={<Activity size={18} />}
+        title={t({ ko: "일별 토큰 스택", en: "Daily Token Stack", ja: "日次トークンスタック", zh: "每日 Token 堆栈" })}
+        description={t({
+          ko: "입력, 출력, 캐시 읽기/쓰기를 하루 단위 스택 바로 비교합니다.",
+          en: "Compare input, output, cache read, and cache write as daily stacked bars.",
+          ja: "入力・出力・キャッシュ読取/書込を日別の積み上げバーで比較します。",
+          zh: "以每日堆叠柱比较输入、输出、缓存读写。",
+        })}
+        actions={
+          summary ? (
+            <div className="flex flex-wrap gap-2">
+              <span className={dashboardBadge.default} style={numericBadgeStyle}>
+                {t({
+                  ko: `피크 ${summary.peak_day?.date ? formatDateLabel(summary.peak_day.date, localeTag) : "—"}`,
+                  en: `Peak ${summary.peak_day?.date ? formatDateLabel(summary.peak_day.date, localeTag) : "—"}`,
+                  ja: `ピーク ${summary.peak_day?.date ? formatDateLabel(summary.peak_day.date, localeTag) : "—"}`,
+                  zh: `峰值 ${summary.peak_day?.date ? formatDateLabel(summary.peak_day.date, localeTag) : "—"}`,
+                })}
+              </span>
+              <span className={dashboardBadge.default} style={numericBadgeStyle}>
+                {t({
+                  ko: `평균 ${formatTokens(summary.average_daily_tokens)} / 일`,
+                  en: `Avg ${formatTokens(summary.average_daily_tokens)} / day`,
+                  ja: `平均 ${formatTokens(summary.average_daily_tokens)} / 日`,
+                  zh: `平均 ${formatTokens(summary.average_daily_tokens)} / 天`,
+                })}
+              </span>
+            </div>
+          ) : null
+        }
+      />
+
+      {daily.length === 0 ? (
+        <DashboardEmptyState
+          icon={<BarChart3 size={18} />}
+          title={
+            loading
+              ? t({
+                  ko: "일별 토큰 차트를 불러오는 중입니다.",
+                  en: "Loading the daily token chart.",
+                  ja: "日次トークンチャートを読み込み中です。",
+                  zh: "正在加载每日 Token 图。",
+                })
+              : t({
+                  ko: "표시할 일별 토큰 데이터가 없습니다.",
+                  en: "No daily token data available.",
+                  ja: "表示する日次トークンデータがありません。",
+                  zh: "没有可显示的每日 Token 数据。",
+                })
+          }
+          className="mt-4"
+        />
+      ) : (
+        <>
+          <div className="mt-4 flex flex-wrap gap-2 text-[11px]">
+            {series.map((item) => (
+              <span key={item.key} className="inline-flex items-center gap-1.5" style={{ color: "var(--th-text-muted)" }}>
+                <span
+                  className="h-3.5 w-3.5 rounded-full"
+                  style={{ background: item.color, boxShadow: `0 0 0 1px ${item.color}30 inset` }}
+                />
+                {item.label}
+              </span>
+            ))}
+          </div>
+
+          <div className="mt-4 overflow-x-auto overflow-y-visible">
+            <div
+              className="flex items-end gap-1 pb-1"
+              style={{ minWidth: `${Math.max(360, daily.length * 24)}px` }}
+            >
+              {daily.map((day, index) => {
+                const height =
+                  day.total_tokens > 0
+                    ? Math.max(10, Math.round((day.total_tokens / maxTotal) * DAILY_BAR_HEIGHT_PX))
+                    : 10;
+                const segments = series.filter((item) => day[item.key] > 0);
+                const compactLabel =
+                  index === 0 || index === daily.length - 1 || index % labelStride === 0;
+                return (
+                  <div
+                    key={day.date}
+                    className="group flex min-w-[20px] flex-1 flex-col items-center gap-2"
+                    title={[
+                      formatDateLabel(day.date, localeTag),
+                      `${formatTokens(day.total_tokens)} tokens`,
+                      `${formatCurrency(day.cost)}`,
+                      ...segments.map((item) => `${item.label} ${formatTokens(day[item.key])}`),
+                    ].join("\n")}
+                  >
+                    <div className="flex h-[188px] items-end">
+                      <div
+                        className="flex w-[18px] flex-col-reverse overflow-hidden rounded-t-xl border sm:w-[20px]"
+                        style={{
+                          height,
+                          borderColor: "var(--th-border-subtle)",
+                          background: "var(--th-overlay-subtle)",
+                        }}
+                      >
+                        {segments.length > 0 ? (
+                          segments.map((item) => (
+                            <div
+                              key={`${day.date}-${item.key}`}
+                              style={{
+                                height: `${(day[item.key] / day.total_tokens) * 100}%`,
+                                background: item.color,
+                              }}
+                            />
+                          ))
+                        ) : (
+                          <div className="h-full w-full" style={{ background: "var(--th-overlay-light)" }} />
+                        )}
+                      </div>
+                    </div>
+                    <span
+                      className="min-h-[1.8rem] whitespace-nowrap text-center text-[10px] leading-4"
+                      style={{ color: "var(--th-text-muted)" }}
+                    >
+                      {compactLabel ? formatDateLabel(day.date, localeTag) : ""}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="mt-4 grid gap-3 sm:grid-cols-3">
+            <MiniMetric
+              label={t({ ko: "활성 일수", en: "Active Days", ja: "稼働日数", zh: "活跃天数" })}
+              value={summary ? numberFormatter.format(summary.active_days) : "—"}
+            />
+            <MiniMetric
+              label={t({ ko: "피크 토큰", en: "Peak Tokens", ja: "ピークトークン", zh: "峰值 Token" })}
+              value={summary?.peak_day ? formatTokens(summary.peak_day.total_tokens) : "—"}
+            />
+            <MiniMetric
+              label={t({ ko: "피크 비용", en: "Peak Cost", ja: "ピークコスト", zh: "峰值成本" })}
+              value={summary?.peak_day ? formatCurrency(summary.peak_day.cost) : "—"}
+            />
+          </div>
+        </>
+      )}
+    </article>
+  );
+}
+
+function DistributionCard({
+  icon,
+  title,
+  description,
+  emptyLabel,
+  loading,
+  segments,
+  centerLabel,
+  centerValue,
+  centerSub,
+}: {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  emptyLabel: string;
+  loading: boolean;
+  segments: ShareSegment[];
+  centerLabel: string;
+  centerValue: string;
+  centerSub: string;
+}) {
+  const donutBackground = buildDonutBackground(segments);
+
+  return (
+    <article className={dashboardCard.standard}>
+      <SectionHeader icon={icon} title={title} description={description} />
+      {segments.length === 0 ? (
+        <DashboardEmptyState
+          icon={<Cpu size={18} />}
+          title={loading ? "Loading distribution..." : emptyLabel}
+          className="mt-4"
+        />
+      ) : (
+        <div className="mt-4 grid gap-4 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-center">
+          <div className="mx-auto">
+            <div
+              className="relative h-40 w-40 rounded-full border"
+              style={{
+                background: donutBackground,
+                borderColor: "var(--th-border-subtle)",
+                boxShadow: "inset 0 1px 0 var(--th-overlay-subtle)",
+              }}
+            >
+              <div
+                className="absolute inset-[23%] flex flex-col items-center justify-center rounded-full border text-center"
+                style={{
+                  borderColor: "var(--th-border-subtle)",
+                  background: "var(--th-bg-surface)",
+                }}
+              >
+                <div className={dashboardText.labelMuted} style={{ color: "var(--th-text-muted)" }}>
+                  {centerLabel}
+                </div>
+                <div className="mt-2 text-2xl font-black tracking-tight" style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}>
+                  {centerValue}
+                </div>
+                <div className="mt-1 px-3 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                  {centerSub}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            {segments.map((segment) => (
+              <DistributionRow
+                key={segment.id}
+                label={segment.label}
+                sublabel={segment.sublabel}
+                value={formatTokens(segment.tokens)}
+                share={segment.percentage}
+                color={segment.color}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </article>
+  );
+}
+
+function ProviderShareCard({
+  t,
+  loading,
+  segments,
+}: {
+  t: TFunction;
+  loading: boolean;
+  segments: ShareSegment[];
+}) {
+  return (
+    <article className={dashboardCard.standard}>
+      <SectionHeader
+        icon={<Bot size={18} />}
+        title={t({ ko: "프로바이더 비중", en: "Provider Share", ja: "プロバイダー比率", zh: "提供商占比" })}
+        description={t({
+          ko: "Claude, Codex 등 프로바이더별 토큰 처리 비중을 비교합니다.",
+          en: "Compare token volume across providers such as Claude and Codex.",
+          ja: "Claude、Codex などプロバイダー別のトークン処理比率を比較します。",
+          zh: "比较 Claude、Codex 等提供商的 Token 处理占比。",
+        })}
+      />
+
+      {segments.length === 0 ? (
+        <DashboardEmptyState
+          icon={<Bot size={18} />}
+          title={
+            loading
+              ? t({
+                  ko: "프로바이더 비중을 불러오는 중입니다.",
+                  en: "Loading provider share.",
+                  ja: "プロバイダー比率を読み込み中です。",
+                  zh: "正在加载提供商占比。",
+                })
+              : t({
+                  ko: "표시할 프로바이더 데이터가 없습니다.",
+                  en: "No provider data available.",
+                  ja: "表示するプロバイダーデータがありません。",
+                  zh: "没有可显示的提供商数据。",
+                })
+          }
+          className="mt-4"
+        />
+      ) : (
+        <div className="mt-4 space-y-3">
+          {segments.map((segment) => (
+            <DistributionRow
+              key={segment.id}
+              label={segment.label}
+              value={formatTokens(segment.tokens)}
+              share={segment.percentage}
+              color={segment.color}
+            />
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}
+
+function DistributionRow({
+  label,
+  sublabel,
+  value,
+  share,
+  color,
+}: {
+  label: string;
+  sublabel?: string;
+  value: string;
+  share: number;
+  color: string;
+}) {
+  return (
+    <div className={dashboardCard.nestedCompact}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ background: color }} />
+            <span className="truncate text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+              {label}
+            </span>
+          </div>
+          {sublabel ? (
+            <div className="mt-1 text-xs" style={{ color: "var(--th-text-muted)" }}>
+              {sublabel}
+            </div>
+          ) : null}
+        </div>
+        <div className="text-right">
+          <div className="text-sm font-bold tabular-nums" style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}>
+            {formatPercent(share)}
+          </div>
+          <div className="mt-1 text-xs" style={{ color: "var(--th-text-muted)" }}>
+            {value}
+          </div>
+        </div>
+      </div>
+      <div className="mt-3 h-2.5 overflow-hidden rounded-full" style={{ background: "var(--th-overlay-subtle)" }}>
+        <div
+          className="h-full rounded-full"
+          style={{
+            width: `${Math.max(share, share > 0 ? 4 : 0)}%`,
+            background: `linear-gradient(90deg, ${color}, color-mix(in oklch, ${color} 68%, white 32%))`,
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function SkillUsageSection({
+  t,
+  localeTag,
+  loading,
+  skillRows,
+  byAgentRows,
+  activeSkillCount,
+  catalogCount,
+  catalogUsedCount,
+  windowCalls,
+}: {
+  t: TFunction;
+  localeTag: string;
+  loading: boolean;
+  skillRows: SkillUsageRow[];
+  byAgentRows: AgentSkillRow[];
+  activeSkillCount: number;
+  catalogCount: number;
+  catalogUsedCount: number;
+  windowCalls: number;
+}) {
+  return (
+    <article className={dashboardCard.standard}>
+      <SectionHeader
+        icon={<Sparkles size={18} />}
+        title={t({ ko: "스킬 랭킹과 사용량", en: "Skill Ranking & Usage", ja: "スキルランキングと使用量", zh: "技能排行与使用量" })}
+        description={t({
+          ko: "선택 범위의 상위 스킬 호출과 에이전트별 스킬 사용을 한 화면에 모읍니다.",
+          en: "Combine top skill calls in the selected window with agent-level skill usage.",
+          ja: "選択範囲の上位スキル呼び出しとエージェント別スキル使用を一画面にまとめます。",
+          zh: "将所选范围的高频技能调用与代理级技能使用放到同一屏。",
+        })}
+        actions={
+          <div className="flex flex-wrap gap-2">
+            <span className={dashboardBadge.default} style={numericBadgeStyle}>
+              {t({
+                ko: `${activeSkillCount}/${catalogCount || 0} 범위 활성`,
+                en: `${activeSkillCount}/${catalogCount || 0} active in range`,
+                ja: `${activeSkillCount}/${catalogCount || 0} 件が範囲内で活性`,
+                zh: `${activeSkillCount}/${catalogCount || 0} 个在区间内活跃`,
+              })}
+            </span>
+            <span className={dashboardBadge.default} style={numericBadgeStyle}>
+              {t({
+                ko: `${catalogUsedCount}/${catalogCount || 0} 카탈로그 사용`,
+                en: `${catalogUsedCount}/${catalogCount || 0} catalog used`,
+                ja: `${catalogUsedCount}/${catalogCount || 0} カタログ使用`,
+                zh: `${catalogUsedCount}/${catalogCount || 0} 个目录已使用`,
+              })}
+            </span>
+          </div>
+        }
+      />
+
+      <div
+        className={cx("mt-4", dashboardCard.nestedCompact)}
+        style={{
+          borderColor: "color-mix(in oklch, var(--warn) 32%, var(--th-border) 68%)",
+          background:
+            "linear-gradient(180deg, color-mix(in oklch, var(--warn) 6%, var(--th-surface) 94%) 0%, var(--th-surface) 100%)",
+        }}
+      >
+        <div className="flex items-start gap-3">
+          <ShieldAlert
+            size={18}
+            style={{ color: "var(--th-accent-warn)", flexShrink: 0, marginTop: 2 }}
+          />
+          <div className="min-w-0">
+            <div className="text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+              {t({
+                ko: "p95는 아직 API에 없습니다.",
+                en: "p95 is not available in the API yet.",
+                ja: "p95 はまだ API にありません。",
+                zh: "API 目前还没有 p95。",
+              })}
+            </div>
+            <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+              {t({
+                ko: "`getSkillRanking()` / `getSkillCatalog()`에 p95 필드가 없어 이 영역은 호출량, 카탈로그 누적 호출, 마지막 사용 시점으로 대체했습니다.",
+                en: "`getSkillRanking()` and `getSkillCatalog()` do not expose a p95 field, so this section uses call count, catalog lifetime calls, and last-used recency instead.",
+                ja: "`getSkillRanking()` / `getSkillCatalog()` に p95 フィールドがないため、この領域では呼び出し回数、カタログ累積回数、最終使用時刻で代替しています。",
+                zh: "`getSkillRanking()` / `getSkillCatalog()` 没有提供 p95 字段，因此此区域改为展示调用次数、目录累计调用和最近使用时间。",
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {skillRows.length === 0 && byAgentRows.length === 0 ? (
+        <DashboardEmptyState
+          icon={<Sparkles size={18} />}
+          title={
+            loading
+              ? t({
+                  ko: "스킬 사용 데이터를 불러오는 중입니다.",
+                  en: "Loading skill usage.",
+                  ja: "スキル使用データを読み込み中です。",
+                  zh: "正在加载技能使用数据。",
+                })
+              : t({
+                  ko: "표시할 스킬 사용 데이터가 없습니다.",
+                  en: "No skill usage data available.",
+                  ja: "表示するスキル使用データがありません。",
+                  zh: "没有可显示的技能使用数据。",
+                })
+          }
+          className="mt-4"
+        />
+      ) : (
+        <div className="mt-4 grid gap-4 2xl:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
+          <div className="space-y-3">
+            {skillRows.map((row) => (
+              <div key={row.id} className={dashboardCard.nestedCompact}>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                      {row.description}
+                    </div>
+                    <div className="mt-1 truncate text-xs" style={{ color: "var(--th-text-muted)" }}>
+                      {row.name}
+                    </div>
+                  </div>
+                  <span className={dashboardBadge.default} style={numericBadgeStyle}>
+                    {formatPercent(row.windowShare)}
+                  </span>
+                </div>
+
+                <div className="mt-3 grid gap-3 sm:grid-cols-3">
+                  <MiniMetric
+                    label={t({ ko: "범위 호출", en: "Range Calls", ja: "範囲呼び出し", zh: "区间调用" })}
+                    value={row.windowCalls.toLocaleString(localeTag)}
+                  />
+                  <MiniMetric
+                    label={t({ ko: "카탈로그 누적", en: "Catalog Lifetime", ja: "カタログ累積", zh: "目录累计" })}
+                    value={row.lifetimeCalls != null ? row.lifetimeCalls.toLocaleString(localeTag) : "—"}
+                  />
+                  <MiniMetric
+                    label={t({ ko: "마지막 사용", en: "Last Used", ja: "最終使用", zh: "最近使用" })}
+                    value={row.lastUsedAt ? timeAgo(row.lastUsedAt, localeTag) : "—"}
+                  />
+                </div>
+
+                <div className="mt-3 h-2 overflow-hidden rounded-full" style={{ background: "var(--th-overlay-subtle)" }}>
+                  <div
+                    className="h-full rounded-full"
+                    style={{
+                      width: `${Math.max(row.windowShare, row.windowShare > 0 ? 4 : 0)}%`,
+                      background:
+                        "linear-gradient(90deg, var(--accent), color-mix(in oklch, var(--accent) 60%, white 40%))",
+                    }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="space-y-4">
+            <div className={dashboardCard.nestedCompact}>
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                    {t({ ko: "에이전트별 상위 스킬", en: "Top Agent-Skill Pairs", ja: "エージェント別上位スキル", zh: "代理-技能高频组合" })}
+                  </div>
+                  <div className="mt-1 text-xs" style={{ color: "var(--th-text-muted)" }}>
+                    {t({
+                      ko: "가장 많이 호출된 에이전트-스킬 조합입니다.",
+                      en: "Most frequently used agent-skill combinations.",
+                      ja: "最も頻繁に使われたエージェント-スキルの組み合わせです。",
+                      zh: "调用次数最多的代理-技能组合。",
+                    })}
+                  </div>
+                </div>
+                <span className={dashboardBadge.default} style={numericBadgeStyle}>
+                  {windowCalls.toLocaleString(localeTag)}
+                </span>
+              </div>
+
+              <div className="mt-4 space-y-2">
+                {byAgentRows.map((row) => (
+                  <div key={row.id} className={dashboardCard.smallCompact}>
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                          {row.agentName}
+                        </div>
+                        <div className="mt-1 truncate text-xs" style={{ color: "var(--th-text-muted)" }}>
+                          {row.description}
+                        </div>
+                        <div className="mt-1 truncate text-[11px]" style={{ color: "var(--th-text-muted)" }}>
+                          {row.skillName}
+                        </div>
+                      </div>
+                      <div className="shrink-0 text-right">
+                        <div className="text-sm font-bold tabular-nums" style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}>
+                          {row.calls}
+                        </div>
+                        <div className="mt-1 text-[11px]" style={{ color: "var(--th-text-muted)" }}>
+                          {timeAgo(row.lastUsedAt, localeTag)}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </article>
+  );
+}
+
+function AgentLeaderboardCard({
+  t,
+  loading,
+  rows,
+}: {
+  t: TFunction;
+  loading: boolean;
+  rows: AgentLeaderboardRow[];
+}) {
+  return (
+    <article className={dashboardCard.standard}>
+      <SectionHeader
+        icon={<Users size={18} />}
+        title={t({ ko: "에이전트 리더보드", en: "Agent Leaderboard", ja: "エージェントリーダーボード", zh: "代理排行榜" })}
+        description={t({
+          ko: "토큰 분석 receipt 기준으로 에이전트별 토큰, 점유율, 비용, 캐시 히트율을 비교합니다.",
+          en: "Compare tokens, share, cost, and cache hit rate by agent using the token analytics receipt.",
+          ja: "トークン分析レシートを基準に、エージェント別のトークン、比率、コスト、キャッシュヒット率を比較します。",
+          zh: "基于 Token 分析回执，对比各代理的 Token、占比、成本和缓存命中率。",
+        })}
+      />
+
+      {rows.length === 0 ? (
+        <DashboardEmptyState
+          icon={<Users size={18} />}
+          title={
+            loading
+              ? t({
+                  ko: "에이전트 리더보드를 불러오는 중입니다.",
+                  en: "Loading the agent leaderboard.",
+                  ja: "エージェントリーダーボードを読み込み中です。",
+                  zh: "正在加载代理排行榜。",
+                })
+              : t({
+                  ko: "표시할 에이전트 데이터가 없습니다.",
+                  en: "No agent data available.",
+                  ja: "表示するエージェントデータがありません。",
+                  zh: "没有可显示的代理数据。",
+                })
+          }
+          className="mt-4"
+        />
+      ) : (
+        <>
+          <div
+            className="mt-4 hidden grid-cols-[2.5rem_minmax(0,1.5fr)_1fr_0.8fr_0.9fr_0.9fr] gap-3 px-3 text-[11px] font-semibold uppercase tracking-[0.18em] sm:grid"
+            style={{ color: "var(--th-text-muted)" }}
+          >
+            <span>#</span>
+            <span>{t({ ko: "에이전트", en: "Agent", ja: "エージェント", zh: "代理" })}</span>
+            <span>{t({ ko: "토큰", en: "Tokens", ja: "トークン", zh: "Token" })}</span>
+            <span>{t({ ko: "점유율", en: "Share", ja: "比率", zh: "占比" })}</span>
+            <span>{t({ ko: "비용", en: "Cost", ja: "コスト", zh: "成本" })}</span>
+            <span>{t({ ko: "캐시", en: "Cache Hit", ja: "キャッシュ", zh: "缓存" })}</span>
+          </div>
+
+          <div className="mt-3 space-y-2">
+            {rows.map((row, index) => (
+              <div key={row.id}>
+                <div
+                  className="hidden grid-cols-[2.5rem_minmax(0,1.5fr)_1fr_0.8fr_0.9fr_0.9fr] items-center gap-3 rounded-xl border px-3 py-3 sm:grid"
+                  style={{
+                    borderColor: "var(--th-border-subtle)",
+                    background: "var(--th-bg-surface)",
+                  }}
+                >
+                  <span className="text-sm font-bold tabular-nums" style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}>
+                    {index + 1}
+                  </span>
+                  <span className="truncate text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                    {row.label}
+                  </span>
+                  <span className="text-sm tabular-nums" style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}>
+                    {formatTokens(row.tokens)}
+                  </span>
+                  <span className="text-sm tabular-nums" style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}>
+                    {formatPercent(row.share)}
+                  </span>
+                  <span className="text-sm tabular-nums" style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}>
+                    {formatCurrency(row.cost)}
+                  </span>
+                  <span className="text-sm tabular-nums" style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}>
+                    {formatPercent(row.cacheHitRate)}
+                  </span>
+                </div>
+
+                <div
+                  className="rounded-xl border p-3 sm:hidden"
+                  style={{
+                    borderColor: "var(--th-border-subtle)",
+                    background: "var(--th-bg-surface)",
+                  }}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="text-xs font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--th-text-muted)" }}>
+                        #{index + 1}
+                      </div>
+                      <div className="mt-1 truncate text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                        {row.label}
+                      </div>
+                    </div>
+                    <span className={dashboardBadge.default} style={numericBadgeStyle}>
+                      {formatPercent(row.share)}
+                    </span>
+                  </div>
+                  <div className="mt-3 grid grid-cols-2 gap-3">
+                    <MiniMetric label={t({ ko: "토큰", en: "Tokens", ja: "トークン", zh: "Token" })} value={formatTokens(row.tokens)} />
+                    <MiniMetric label={t({ ko: "비용", en: "Cost", ja: "コスト", zh: "成本" })} value={formatCurrency(row.cost)} />
+                    <MiniMetric label={t({ ko: "캐시", en: "Cache Hit", ja: "キャッシュ", zh: "缓存" })} value={formatPercent(row.cacheHitRate)} />
+                    <MiniMetric label={t({ ko: "점유율", en: "Share", ja: "比率", zh: "占比" })} value={formatPercent(row.share)} />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </article>
+  );
+}
+
+function SectionHeader({
+  icon,
+  title,
+  description,
+  actions,
+}: {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  actions?: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <span
+            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border"
+            style={{
+              background: "var(--th-overlay-subtle)",
+              borderColor: "var(--th-border-subtle)",
+              color: "var(--accent)",
+            }}
+          >
+            {icon}
+          </span>
+          <div className="min-w-0">
+            <h2 className="text-lg font-bold" style={{ color: "var(--th-text-heading)" }}>
+              {title}
+            </h2>
+            <p className="mt-1 text-sm leading-6" style={{ color: "var(--th-text-muted)" }}>
+              {description}
+            </p>
+          </div>
+        </div>
+      </div>
+      {actions ? <div className="flex shrink-0 flex-wrap gap-2">{actions}</div> : null}
+    </div>
+  );
+}
+
+function MiniMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div
+      className="rounded-xl border px-3 py-2.5"
+      style={{
+        borderColor: "var(--th-border-subtle)",
+        background: "var(--th-overlay-subtle)",
+      }}
+    >
+      <div className={dashboardText.labelMuted} style={{ color: "var(--th-text-muted)" }}>
+        {label}
+      </div>
+      <div className="mt-2 text-sm font-bold tabular-nums" style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+const numericBadgeStyle: CSSProperties = {
+  ...NUMERIC_STYLE,
+  background: "var(--th-overlay-light)",
+  color: "var(--th-text-secondary)",
+  borderColor: "var(--th-border-subtle)",
+};

--- a/dashboard/src/components/agent-manager/AgentCard.tsx
+++ b/dashboard/src/components/agent-manager/AgentCard.tsx
@@ -1,10 +1,14 @@
 import type { Agent, Department } from "../../types";
 import { localeName } from "../../i18n";
 import { getFontFamilyForText } from "../../lib/fonts";
+import { getProviderMeta } from "../../app/providerTheme";
 import AgentAvatar from "../AgentAvatar";
 import { SurfaceActionButton, SurfaceCard } from "../common/SurfacePrimitives";
 import { STATUS_DOT } from "./constants";
+import { getAgentLevel, getAgentTitle } from "./AgentInfoCard";
 import type { Translator } from "./types";
+
+type AgentCardViewMode = "grid" | "list";
 
 interface AgentCardProps {
   agent: Agent;
@@ -13,12 +17,49 @@ interface AgentCardProps {
   locale: string;
   tr: Translator;
   departments: Department[];
+  onOpen: () => void;
   onEdit: () => void;
   confirmDeleteId: string | null;
   onDeleteClick: () => void;
   onDeleteConfirm: () => void;
   onDeleteCancel: () => void;
   saving: boolean;
+  topSkills: string[];
+  viewMode: AgentCardViewMode;
+}
+
+function currentTaskSummary(
+  agent: Agent,
+  tr: Translator,
+): { label: string; value: string } {
+  if (agent.current_task_id) {
+    return {
+      label: tr("현재 작업", "Current Task"),
+      value: agent.current_task_id,
+    };
+  }
+  if (agent.workflow_pack_key) {
+    return {
+      label: tr("워크플로우", "Workflow"),
+      value: agent.workflow_pack_key,
+    };
+  }
+  if (agent.session_info) {
+    return {
+      label: tr("세션", "Session"),
+      value: agent.session_info,
+    };
+  }
+  if (agent.personality) {
+    return {
+      label: tr("메모", "Notes"),
+      value: agent.personality,
+    };
+  }
+  return {
+    label: tr("상태", "Status"),
+    value: tr("대기 중", "Standing by"),
+  };
 }
 
 export default function AgentCard({
@@ -28,122 +69,224 @@ export default function AgentCard({
   locale,
   tr,
   departments,
+  onOpen,
   onEdit,
   confirmDeleteId,
   onDeleteClick,
   onDeleteConfirm,
   onDeleteCancel,
   saving,
+  topSkills,
+  viewMode,
 }: AgentCardProps) {
   const isDeleting = confirmDeleteId === agent.id;
   const dept = departments.find((d) => d.id === agent.department_id);
   const primaryLabel = localeName(locale, agent);
+  const providerMeta = getProviderMeta(agent.cli_provider);
+  const levelInfo = getAgentLevel(agent.stats_xp);
+  const levelTitle = getAgentTitle(agent.stats_xp, isKo);
+  const task = currentTaskSummary(agent, tr);
+  const contentFont = getFontFamilyForText(task.value, "sans");
 
   return (
     <SurfaceCard
-      onClick={onEdit}
-      className="group cursor-pointer rounded-3xl p-4 transition-all hover:-translate-y-0.5"
+      onClick={onOpen}
+      className={`group cursor-pointer rounded-[28px] p-4 transition-all hover:-translate-y-0.5 ${
+        viewMode === "list" ? "flex flex-col gap-4 md:flex-row md:items-center" : ""
+      }`}
       draggable={false}
-      onDragStart={(e) => e.preventDefault()}
+      onDragStart={(event) => event.preventDefault()}
       style={{
-        background: "color-mix(in srgb, var(--th-card-bg) 94%, transparent)",
+        background:
+          "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 92%, transparent) 100%)",
         borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)",
         touchAction: "pan-y",
         userSelect: "none",
       }}
     >
-      <div className="flex items-start gap-3">
-        <div className="relative shrink-0">
-          <AgentAvatar agent={agent} spriteMap={spriteMap} size={44} rounded="xl" />
-          <div
-            className={`absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full border-2 ${STATUS_DOT[agent.status] ?? STATUS_DOT.idle}`}
-            style={{ borderColor: "var(--th-card-bg)" }}
-          />
-        </div>
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-1.5">
-            <span
-              className="font-pixel truncate text-sm font-semibold"
-              style={{
-                color: "var(--th-text-heading)",
-                fontFamily: getFontFamilyForText(primaryLabel, "pixel"),
-              }}
-            >
-              {primaryLabel}
-            </span>
-            <span className="text-xs shrink-0" style={{ color: "var(--th-text-muted)" }}>
-              {(() => {
-                const primary = primaryLabel;
-                const sub = locale === "en" ? agent.name_ko || "" : agent.name;
-                return primary !== sub ? sub : "";
-              })()}
-            </span>
+      <div
+        className={`min-w-0 ${
+          viewMode === "list"
+            ? "flex flex-1 flex-col gap-4 md:flex-row md:items-start"
+            : "space-y-4"
+        }`}
+      >
+        <div className="flex items-start gap-3">
+          <div className="relative shrink-0">
+            <AgentAvatar
+              agent={agent}
+              spriteMap={spriteMap}
+              size={viewMode === "list" ? 56 : 52}
+              rounded="xl"
+            />
+            <div
+              className={`absolute -bottom-0.5 -right-0.5 h-3.5 w-3.5 rounded-full border-2 ${
+                STATUS_DOT[agent.status] ?? STATUS_DOT.idle
+              }`}
+              style={{ borderColor: "var(--th-card-bg)" }}
+            />
           </div>
-          {dept && (
-            <div className="flex items-center gap-1.5 mt-1 flex-wrap">
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
               <span
-                className="rounded-full px-2 py-1 text-[11px]"
+                className="truncate text-sm font-semibold"
                 style={{
-                  background: "color-mix(in srgb, var(--th-bg-surface) 92%, transparent)",
-                  color: "var(--th-text-muted)",
-                  border: "1px solid color-mix(in srgb, var(--th-border) 72%, transparent)",
+                  color: "var(--th-text-heading)",
+                  fontFamily: getFontFamilyForText(primaryLabel, "pixel"),
                 }}
               >
-                {dept.icon} {localeName(locale, dept)}
+                {primaryLabel}
+              </span>
+              <span
+                className="rounded-full border px-2 py-0.5 text-[11px] font-medium"
+                style={{
+                  borderColor: "rgba(250,204,21,0.32)",
+                  background: "rgba(250,204,21,0.12)",
+                  color: "#fde68a",
+                }}
+              >
+                Lv.{levelInfo.level} {levelTitle}
+              </span>
+              <span
+                className="rounded-full border px-2 py-0.5 text-[11px] font-medium"
+                style={{
+                  borderColor: providerMeta.border,
+                  background: providerMeta.bg,
+                  color: providerMeta.color,
+                }}
+              >
+                {providerMeta.label}
               </span>
             </div>
-          )}
+            <div
+              className="mt-1 text-xs"
+              style={{ color: "var(--th-text-muted)" }}
+            >
+              {locale === "en" ? agent.name_ko || agent.name : agent.name}
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-1.5">
+              {dept ? (
+                <span
+                  className="rounded-full border px-2 py-1 text-[11px]"
+                  style={{
+                    background:
+                      "color-mix(in srgb, var(--th-bg-surface) 92%, transparent)",
+                    color: "var(--th-text-muted)",
+                    border:
+                      "1px solid color-mix(in srgb, var(--th-border) 72%, transparent)",
+                  }}
+                >
+                  {dept.icon} {localeName(locale, dept)}
+                </span>
+              ) : null}
+              <span
+                className="rounded-full border px-2 py-1 text-[11px] font-medium"
+                style={{
+                  background: "rgba(59,130,246,0.12)",
+                  borderColor: "rgba(59,130,246,0.22)",
+                  color: "#93c5fd",
+                }}
+              >
+                XP {agent.stats_xp.toLocaleString()}
+              </span>
+              <span
+                className="rounded-full border px-2 py-1 text-[11px] font-medium"
+                style={{
+                  background: "rgba(16,185,129,0.12)",
+                  borderColor: "rgba(16,185,129,0.22)",
+                  color: "#6ee7b7",
+                }}
+              >
+                {tr("완료", "Done")} {agent.stats_tasks_done.toLocaleString()}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div
+            className="rounded-2xl border px-3 py-3"
+            style={{
+              background:
+                "color-mix(in srgb, var(--th-bg-surface) 84%, transparent)",
+              borderColor:
+                "color-mix(in srgb, var(--th-border) 68%, transparent)",
+            }}
+          >
+            <div
+              className="text-[11px] font-semibold uppercase tracking-[0.18em]"
+              style={{ color: "var(--th-text-muted)" }}
+            >
+              {task.label}
+            </div>
+            <div
+              className="mt-2 line-clamp-2 text-sm"
+              style={{
+                color: "var(--th-text-primary)",
+                fontFamily: contentFont,
+              }}
+            >
+              {task.value}
+            </div>
+          </div>
+
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            {topSkills.length > 0 ? (
+              topSkills.map((skill) => (
+                <span
+                  key={`${agent.id}-${skill}`}
+                  className="rounded-full border px-2 py-1 text-[11px]"
+                  style={{
+                    borderColor:
+                      "color-mix(in srgb, var(--th-border) 70%, transparent)",
+                    background:
+                      "color-mix(in srgb, var(--th-card-bg) 92%, transparent)",
+                    color: "var(--th-text-secondary)",
+                  }}
+                >
+                  {skill}
+                </span>
+              ))
+            ) : (
+              <span
+                className="text-xs"
+                style={{ color: "var(--th-text-muted)" }}
+              >
+                {tr("최근 스킬 데이터 없음", "No recent skill data")}
+              </span>
+            )}
+          </div>
         </div>
       </div>
 
       <div
-        className="mt-3 flex flex-wrap items-center justify-between gap-2 pt-2.5"
-        style={{ borderTop: "1px solid color-mix(in srgb, var(--th-border) 70%, transparent)" }}
+        className={`flex shrink-0 items-center gap-1.5 ${
+          viewMode === "list" ? "justify-end" : "justify-between pt-2"
+        }`}
+        onClick={(event) => event.stopPropagation()}
       >
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          {agent.personality && (
-            <span
-              className="max-w-[180px] truncate text-xs"
-              style={{ color: "var(--th-text-muted)" }}
-              title={agent.personality}
-            >
-              {agent.personality}
-            </span>
-          )}
-        </div>
-        <div
-          className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100"
-          onClick={(e) => e.stopPropagation()}
-        >
-          {isDeleting ? (
-            <>
-              <SurfaceActionButton
-                onClick={onDeleteConfirm}
-                disabled={saving || agent.status === "working"}
-                tone="danger"
-                compact
-              >
-                {tr("해고", "Fire")}
-              </SurfaceActionButton>
-              <SurfaceActionButton
-                onClick={onDeleteCancel}
-                tone="neutral"
-                compact
-              >
-                {tr("취소", "No")}
-              </SurfaceActionButton>
-            </>
-          ) : (
+        <SurfaceActionButton onClick={onEdit} tone="neutral" compact>
+          {tr("편집", "Edit")}
+        </SurfaceActionButton>
+        {isDeleting ? (
+          <>
             <SurfaceActionButton
-              onClick={onDeleteClick}
-              tone="neutral"
+              onClick={onDeleteConfirm}
+              disabled={saving || agent.status === "working"}
+              tone="danger"
               compact
-              style={{ minWidth: 28 }}
             >
-              ✕
+              {tr("해고", "Fire")}
             </SurfaceActionButton>
-          )}
-        </div>
+            <SurfaceActionButton onClick={onDeleteCancel} tone="neutral" compact>
+              {tr("취소", "No")}
+            </SurfaceActionButton>
+          </>
+        ) : (
+          <SurfaceActionButton onClick={onDeleteClick} tone="neutral" compact>
+            {tr("삭제", "Delete")}
+          </SurfaceActionButton>
+        )}
       </div>
     </SurfaceCard>
   );

--- a/dashboard/src/components/agent-manager/AgentsTab.tsx
+++ b/dashboard/src/components/agent-manager/AgentsTab.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useMemo, useState } from "react";
+import { getSkillRanking } from "../../api";
 import type { Agent, Department } from "../../types";
 import { localeName } from "../../i18n";
 import {
@@ -26,6 +28,7 @@ interface AgentsTabProps {
   spriteMap: Map<string, number>;
   confirmDeleteId: string | null;
   setConfirmDeleteId: (id: string | null) => void;
+  onOpenAgent: (agent: Agent) => void;
   onEditAgent: (agent: Agent) => void;
   onEditDepartment: (department: Department) => void;
   onDeleteAgent: (agentId: string) => void;
@@ -33,6 +36,21 @@ interface AgentsTabProps {
   randomIconSprites: {
     total: [number, number];
   };
+}
+
+type AgentViewMode = "grid" | "list";
+
+function buildTopSkillMap(rows: Awaited<ReturnType<typeof getSkillRanking>>["byAgent"]) {
+  const byAgent = new Map<string, string[]>();
+  for (const row of rows) {
+    const key = row.agent_role_id;
+    const existing = byAgent.get(key) ?? [];
+    if (!existing.includes(row.skill_desc_ko)) {
+      existing.push(row.skill_desc_ko);
+      byAgent.set(key, existing.slice(0, 3));
+    }
+  }
+  return byAgent;
 }
 
 export default function AgentsTab({
@@ -51,12 +69,35 @@ export default function AgentsTab({
   spriteMap,
   confirmDeleteId,
   setConfirmDeleteId,
+  onOpenAgent,
   onEditAgent,
   onEditDepartment,
   onDeleteAgent,
   saving,
   randomIconSprites,
 }: AgentsTabProps) {
+  const [viewMode, setViewMode] = useState<AgentViewMode>("grid");
+  const [topSkillsByAgent, setTopSkillsByAgent] = useState<Map<string, string[]>>(
+    () => new Map(),
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getSkillRanking("30d", 120)
+      .then((ranking) => {
+        if (cancelled) return;
+        setTopSkillsByAgent(buildTopSkillMap(ranking.byAgent));
+      })
+      .catch(() => {
+        if (!cancelled) setTopSkillsByAgent(new Map());
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const workingCount = agents.filter((agent) => agent.status === "working").length;
   const deptCounts = new Map<string, { total: number; working: number }>();
   for (const agent of agents) {
@@ -67,9 +108,18 @@ export default function AgentsTab({
     deptCounts.set(key, count);
   }
 
+  const skillCoverage = useMemo(() => {
+    const uniqueAgents = new Set<string>();
+    for (const agent of agents) {
+      const roleKey = agent.role_id || agent.id;
+      if (topSkillsByAgent.has(roleKey)) uniqueAgents.add(agent.id);
+    }
+    return uniqueAgents.size;
+  }, [agents, topSkillsByAgent]);
+
   return (
     <>
-      <div className="flex flex-wrap gap-3">
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
         {[
           {
             label: tr("전체 인원", "Total"),
@@ -89,64 +139,101 @@ export default function AgentsTab({
             tone: "info" as const,
             icon: "🏢",
           },
+          {
+            label: tr("스킬 신호", "Skill Signals"),
+            value: skillCoverage,
+            tone: "warn" as const,
+            icon: "🧠",
+          },
         ].map((summary) => (
           <SurfaceMetricPill
             key={summary.label}
             label={`${typeof summary.icon === "string" ? summary.icon : "🧩"} ${summary.label}`}
             value={
-              <span className="text-2xl font-bold tabular-nums" style={{ color: "var(--th-text-heading)" }}>
+              <span
+                className="text-2xl font-bold tabular-nums"
+                style={{ color: "var(--th-text-heading)" }}
+              >
                 {summary.value}
               </span>
             }
             tone={summary.tone}
-            className="min-w-[132px] flex-1 sm:flex-none"
-            style={{ minHeight: 76 }}
+            className="min-w-[132px]"
+            style={{ minHeight: 88 }}
           />
         ))}
       </div>
 
-      <SurfaceCard className="space-y-3 rounded-3xl p-4 sm:p-5">
-        <div className="flex flex-wrap items-center gap-2">
-          <SurfaceSegmentButton active={deptTab === "all"} onClick={() => setDeptTab("all")} tone="accent">
-            {tr("전체", "All")} <span className="opacity-60">{agents.length}</span>
-          </SurfaceSegmentButton>
-          {departments.map((department) => {
-            const count = deptCounts.get(department.id);
-            return (
-              <SurfaceSegmentButton
-                key={department.id}
-                active={deptTab === department.id}
-                onClick={() => setDeptTab(department.id)}
-                tone="info"
-                className="flex items-center gap-1"
-                style={{ maxWidth: "100%" }}
-              >
-                <span
-                  onDoubleClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    onEditDepartment(department);
-                  }}
-                  title={tr("더블클릭: 부서 편집", "Double-click: edit dept")}
-                  className="inline-flex items-center gap-1"
+      <SurfaceCard className="space-y-3 rounded-[28px] p-4 sm:p-5">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-wrap gap-2">
+            <SurfaceSegmentButton
+              active={deptTab === "all"}
+              onClick={() => setDeptTab("all")}
+              tone="accent"
+            >
+              {tr("전체", "All")} <span className="opacity-60">{agents.length}</span>
+            </SurfaceSegmentButton>
+            {departments.map((department) => {
+              const count = deptCounts.get(department.id);
+              return (
+                <SurfaceSegmentButton
+                  key={department.id}
+                  active={deptTab === department.id}
+                  onClick={() => setDeptTab(department.id)}
+                  tone="info"
+                  className="flex items-center gap-1"
+                  style={{ maxWidth: "100%" }}
                 >
-                  <span>{department.icon}</span>
-                  <span className="hidden sm:inline">{localeName(locale, department)}</span>
-                  <span className="opacity-60">{count?.total ?? 0}</span>
-                </span>
-              </SurfaceSegmentButton>
-            );
-          })}
+                  <span
+                    onDoubleClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      onEditDepartment(department);
+                    }}
+                    title={tr("더블클릭: 부서 편집", "Double-click: edit dept")}
+                    className="inline-flex items-center gap-1"
+                  >
+                    <span>{department.icon}</span>
+                    <span className="hidden sm:inline">
+                      {localeName(locale, department)}
+                    </span>
+                    <span className="opacity-60">{count?.total ?? 0}</span>
+                  </span>
+                </SurfaceSegmentButton>
+              );
+            })}
+          </div>
+
+          <div className="flex items-center gap-2">
+            <SurfaceSegmentButton
+              active={viewMode === "grid"}
+              onClick={() => setViewMode("grid")}
+              tone="warn"
+            >
+              {tr("그리드", "Grid")}
+            </SurfaceSegmentButton>
+            <SurfaceSegmentButton
+              active={viewMode === "list"}
+              onClick={() => setViewMode("list")}
+              tone="warn"
+            >
+              {tr("리스트", "List")}
+            </SurfaceSegmentButton>
+          </div>
         </div>
 
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div className="text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
-            {tr("부서 chip 더블클릭으로 편집할 수 있습니다.", "Double-click a department chip to edit it.")}
+            {tr(
+              "카드를 누르면 상세 drawer가 열리고, 부서 chip 더블클릭으로 부서를 편집합니다.",
+              "Tap a card to open the detail drawer. Double-click a department chip to edit it.",
+            )}
           </div>
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
             <select
               value={statusFilter}
-              onChange={(e) => setStatusFilter(e.target.value)}
+              onChange={(event) => setStatusFilter(event.target.value)}
               className="rounded-xl px-3 py-2 text-xs outline-none"
               style={{
                 background: "var(--th-input-bg)",
@@ -164,8 +251,8 @@ export default function AgentsTab({
               type="text"
               placeholder={`${tr("검색", "Search")}...`}
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="w-full rounded-xl px-3 py-2 text-xs outline-none transition-shadow sm:w-40"
+              onChange={(event) => setSearch(event.target.value)}
+              className="w-full rounded-xl px-3 py-2 text-xs outline-none transition-shadow sm:w-48"
               style={{
                 background: "var(--th-input-bg)",
                 border: "1px solid var(--th-input-border)",
@@ -182,24 +269,38 @@ export default function AgentsTab({
           <div className="mt-2 text-sm">{tr("검색 결과 없음", "No agents found")}</div>
         </SurfaceEmptyState>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-          {sortedAgents.map((agent) => (
-            <AgentCard
-              key={agent.id}
-              agent={agent}
-              spriteMap={spriteMap}
-              isKo={isKo}
-              locale={locale}
-              tr={tr}
-              departments={departments}
-              onEdit={() => onEditAgent(agent)}
-              confirmDeleteId={confirmDeleteId}
-              onDeleteClick={() => setConfirmDeleteId(agent.id)}
-              onDeleteConfirm={() => onDeleteAgent(agent.id)}
-              onDeleteCancel={() => setConfirmDeleteId(null)}
-              saving={saving}
-            />
-          ))}
+        <div
+          className={
+            viewMode === "grid"
+              ? "grid grid-cols-1 gap-3 lg:grid-cols-2"
+              : "space-y-3"
+          }
+        >
+          {sortedAgents.map((agent) => {
+            const roleKey = agent.role_id || agent.id;
+            const topSkills = topSkillsByAgent.get(roleKey) ?? [];
+
+            return (
+              <AgentCard
+                key={agent.id}
+                agent={agent}
+                spriteMap={spriteMap}
+                isKo={isKo}
+                locale={locale}
+                tr={tr}
+                departments={departments}
+                onOpen={() => onOpenAgent(agent)}
+                onEdit={() => onEditAgent(agent)}
+                confirmDeleteId={confirmDeleteId}
+                onDeleteClick={() => setConfirmDeleteId(agent.id)}
+                onDeleteConfirm={() => onDeleteAgent(agent.id)}
+                onDeleteCancel={() => setConfirmDeleteId(null)}
+                saving={saving}
+                topSkills={topSkills}
+                viewMode={viewMode}
+              />
+            );
+          })}
         </div>
       )}
     </>

--- a/dashboard/src/components/agent-manager/BacklogTab.tsx
+++ b/dashboard/src/components/agent-manager/BacklogTab.tsx
@@ -1,0 +1,801 @@
+import { useMemo, useState } from "react";
+import type { Agent, KanbanCard, KanbanCardPriority, KanbanCardStatus, UiLanguage } from "../../types";
+import { localeName } from "../../i18n";
+import { getProviderMeta } from "../../app/providerTheme";
+import MarkdownContent from "../common/MarkdownContent";
+import {
+  SurfaceActionButton,
+  SurfaceCard,
+  SurfaceEmptyState,
+  SurfaceMetricPill,
+} from "../common/SurfacePrimitives";
+import AgentAvatar from "../AgentAvatar";
+import {
+  formatAgeLabel,
+  formatIso,
+  getCardStateEnteredAt,
+  labelForStatus,
+  parseCardMetadata,
+  priorityLabel,
+} from "./kanban-utils";
+import type { Translator } from "./types";
+
+type ProviderFilter = "all" | string;
+type SeverityFilter = "all" | KanbanCardPriority;
+type StatusFilter = "all" | KanbanCardStatus;
+type BacklogSortKey =
+  | "id"
+  | "title"
+  | "assignee"
+  | "status"
+  | "provider"
+  | "severity"
+  | "age";
+type SortDirection = "asc" | "desc";
+
+interface BacklogTabProps {
+  tr: Translator;
+  locale: UiLanguage;
+  cards: KanbanCard[];
+  agents: Agent[];
+}
+
+function cardAgeMs(card: KanbanCard): number {
+  const enteredAt = getCardStateEnteredAt(card);
+  if (enteredAt == null) return 0;
+  return Math.max(0, Date.now() - enteredAt);
+}
+
+function priorityRank(priority: KanbanCardPriority): number {
+  switch (priority) {
+    case "urgent":
+      return 0;
+    case "high":
+      return 1;
+    case "medium":
+      return 2;
+    case "low":
+    default:
+      return 3;
+  }
+}
+
+function resolveCardAgent(card: KanbanCard, agentMap: Map<string, Agent>): Agent | null {
+  return (
+    (card.assignee_agent_id ? agentMap.get(card.assignee_agent_id) : undefined) ??
+    (card.owner_agent_id ? agentMap.get(card.owner_agent_id) : undefined) ??
+    (card.requester_agent_id ? agentMap.get(card.requester_agent_id) : undefined) ??
+    null
+  );
+}
+
+function compareStrings(left: string, right: string): number {
+  return left.localeCompare(right, undefined, { numeric: true, sensitivity: "base" });
+}
+
+function compareCards(
+  left: KanbanCard,
+  right: KanbanCard,
+  sortKey: BacklogSortKey,
+  direction: SortDirection,
+  locale: UiLanguage,
+  tr: Translator,
+  agentMap: Map<string, Agent>,
+): number {
+  const providerMetaLeft = getProviderMeta(resolveCardAgent(left, agentMap)?.cli_provider);
+  const providerMetaRight = getProviderMeta(resolveCardAgent(right, agentMap)?.cli_provider);
+  const assigneeLeft = resolveCardAgent(left, agentMap);
+  const assigneeRight = resolveCardAgent(right, agentMap);
+
+  let result = 0;
+  switch (sortKey) {
+    case "id":
+      result = compareStrings(
+        left.github_issue_number ? `${left.github_issue_number}` : left.id,
+        right.github_issue_number ? `${right.github_issue_number}` : right.id,
+      );
+      break;
+    case "title":
+      result = compareStrings(left.title, right.title);
+      break;
+    case "assignee":
+      result = compareStrings(
+        assigneeLeft ? localeName(locale, assigneeLeft) : "",
+        assigneeRight ? localeName(locale, assigneeRight) : "",
+      );
+      break;
+    case "status":
+      result = compareStrings(
+        labelForStatus(left.status, tr),
+        labelForStatus(right.status, tr),
+      );
+      break;
+    case "provider":
+      result = compareStrings(providerMetaLeft.label, providerMetaRight.label);
+      break;
+    case "severity":
+      result = priorityRank(left.priority) - priorityRank(right.priority);
+      break;
+    case "age":
+    default:
+      result = cardAgeMs(left) - cardAgeMs(right);
+      break;
+  }
+
+  if (result === 0) {
+    result = right.updated_at - left.updated_at;
+  }
+  return direction === "asc" ? result : -result;
+}
+
+function SortHeader({
+  label,
+  sortKey,
+  activeKey,
+  direction,
+  onToggle,
+}: {
+  label: string;
+  sortKey: BacklogSortKey;
+  activeKey: BacklogSortKey;
+  direction: SortDirection;
+  onToggle: (key: BacklogSortKey) => void;
+}) {
+  const isActive = sortKey === activeKey;
+  return (
+    <button
+      type="button"
+      onClick={() => onToggle(sortKey)}
+      className="inline-flex items-center gap-1 rounded-full px-2 py-1 text-left text-[11px] font-semibold uppercase tracking-[0.16em] transition-opacity hover:opacity-100"
+      style={{
+        color: isActive ? "var(--th-text-heading)" : "var(--th-text-muted)",
+        opacity: isActive ? 1 : 0.86,
+      }}
+    >
+      {label}
+      <span className="text-[10px]">{isActive ? (direction === "asc" ? "↑" : "↓") : "↕"}</span>
+    </button>
+  );
+}
+
+function BacklogCardDrawer({
+  card,
+  locale,
+  tr,
+  agentMap,
+  onClose,
+}: {
+  card: KanbanCard;
+  locale: UiLanguage;
+  tr: Translator;
+  agentMap: Map<string, Agent>;
+  onClose: () => void;
+}) {
+  const assignee = card.assignee_agent_id ? agentMap.get(card.assignee_agent_id) : null;
+  const owner = card.owner_agent_id ? agentMap.get(card.owner_agent_id) : null;
+  const requester = card.requester_agent_id ? agentMap.get(card.requester_agent_id) : null;
+  const providerMeta = getProviderMeta(resolveCardAgent(card, agentMap)?.cli_provider);
+  const metadata = parseCardMetadata(card.metadata_json);
+  const ageLabel = formatAgeLabel(cardAgeMs(card), tr);
+
+  const infoItems = [
+    {
+      label: tr("상태", "Status"),
+      value: labelForStatus(card.status, tr),
+    },
+    {
+      label: tr("심각도", "Severity"),
+      value: priorityLabel(card.priority, tr),
+    },
+    {
+      label: tr("담당", "Assignee"),
+      value: assignee ? localeName(locale, assignee) : tr("미할당", "Unassigned"),
+    },
+    {
+      label: tr("Provider", "Provider"),
+      value: providerMeta.label,
+    },
+    {
+      label: tr("Stage Age", "Stage Age"),
+      value: ageLabel,
+    },
+    {
+      label: tr("업데이트", "Updated"),
+      value: formatIso(card.updated_at, locale),
+    },
+  ];
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/60 p-0 sm:items-center sm:p-4"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={card.title}
+        onClick={(event) => event.stopPropagation()}
+        className="max-h-[88svh] w-full max-w-4xl overflow-y-auto rounded-t-[32px] border p-5 sm:max-h-[90vh] sm:rounded-[32px] sm:p-6"
+        style={{
+          background:
+            "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 95%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
+          borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)",
+          paddingBottom: "max(6rem, calc(6rem + env(safe-area-inset-bottom)))",
+        }}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <span
+                className="rounded-full border px-2 py-1 text-[11px] font-medium"
+                style={{
+                  borderColor: "color-mix(in srgb, var(--th-border) 72%, transparent)",
+                  background: "color-mix(in srgb, var(--th-card-bg) 88%, transparent)",
+                  color: "var(--th-text-secondary)",
+                }}
+              >
+                {card.github_issue_number ? `#${card.github_issue_number}` : card.id.slice(0, 8)}
+              </span>
+              <span
+                className="rounded-full border px-2 py-1 text-[11px] font-medium"
+                style={{
+                  borderColor: "rgba(244,114,182,0.22)",
+                  background: "rgba(244,114,182,0.12)",
+                  color: "#f9a8d4",
+                }}
+              >
+                {priorityLabel(card.priority, tr)}
+              </span>
+              <span
+                className="rounded-full border px-2 py-1 text-[11px] font-medium"
+                style={{
+                  borderColor: providerMeta.border,
+                  background: providerMeta.bg,
+                  color: providerMeta.color,
+                }}
+              >
+                {providerMeta.label}
+              </span>
+            </div>
+            <h3
+              className="mt-3 text-xl font-semibold tracking-tight"
+              style={{ color: "var(--th-text-heading)" }}
+            >
+              {card.title}
+            </h3>
+          </div>
+          <SurfaceActionButton onClick={onClose} tone="neutral">
+            {tr("닫기", "Close")}
+          </SurfaceActionButton>
+        </div>
+
+        <div className="mt-5 grid gap-3 md:grid-cols-3">
+          {infoItems.map((item) => (
+            <SurfaceCard
+              key={item.label}
+              className="space-y-1.5 p-3"
+              style={{
+                background:
+                  "color-mix(in srgb, var(--th-bg-surface) 84%, var(--th-card-bg) 16%)",
+              }}
+            >
+              <div className="text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "var(--th-text-muted)" }}>
+                {item.label}
+              </div>
+              <div className="text-sm" style={{ color: "var(--th-text-primary)" }}>
+                {item.value}
+              </div>
+            </SurfaceCard>
+          ))}
+        </div>
+
+        <div className="mt-5 grid gap-4 xl:grid-cols-[minmax(0,1.3fr)_minmax(280px,0.7fr)]">
+          <SurfaceCard className="min-w-0 space-y-3">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "var(--th-text-muted)" }}>
+              {tr("설명", "Description")}
+            </div>
+            {card.description ? (
+              <div className="text-sm leading-6" style={{ color: "var(--th-text-primary)" }}>
+                <MarkdownContent content={card.description} />
+              </div>
+            ) : (
+              <div className="text-sm" style={{ color: "var(--th-text-muted)" }}>
+                {tr("설명이 없습니다.", "No description provided.")}
+              </div>
+            )}
+
+            {card.review_notes ? (
+              <SurfaceCard
+                className="space-y-2 p-3"
+                style={{
+                  background:
+                    "color-mix(in srgb, var(--th-badge-sky-bg) 82%, var(--th-card-bg) 18%)",
+                  borderColor:
+                    "color-mix(in srgb, var(--th-accent-info) 26%, var(--th-border) 74%)",
+                }}
+              >
+                <div className="text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "var(--th-accent-info)" }}>
+                  {tr("Review Notes", "Review Notes")}
+                </div>
+                <div className="text-sm leading-6" style={{ color: "var(--th-text-primary)" }}>
+                  {card.review_notes}
+                </div>
+              </SurfaceCard>
+            ) : null}
+
+            {card.blocked_reason ? (
+              <SurfaceCard
+                className="space-y-2 p-3"
+                style={{
+                  background:
+                    "color-mix(in srgb, rgba(248,113,113,0.16) 82%, var(--th-card-bg) 18%)",
+                  borderColor: "rgba(248,113,113,0.24)",
+                }}
+              >
+                <div className="text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "#fca5a5" }}>
+                  {tr("Blocked Reason", "Blocked Reason")}
+                </div>
+                <div className="text-sm leading-6" style={{ color: "var(--th-text-primary)" }}>
+                  {card.blocked_reason}
+                </div>
+              </SurfaceCard>
+            ) : null}
+          </SurfaceCard>
+
+          <div className="space-y-4">
+            <SurfaceCard className="space-y-3">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "var(--th-text-muted)" }}>
+                {tr("참여 에이전트", "Agents")}
+              </div>
+              {[
+                { label: tr("담당", "Assignee"), agent: assignee },
+                { label: tr("오너", "Owner"), agent: owner },
+                { label: tr("요청자", "Requester"), agent: requester },
+              ].map((item) => (
+                <div
+                  key={item.label}
+                  className="flex items-center gap-3 rounded-2xl border px-3 py-2"
+                  style={{
+                    borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)",
+                    background:
+                      "color-mix(in srgb, var(--th-bg-surface) 84%, var(--th-card-bg) 16%)",
+                  }}
+                >
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.12em]" style={{ color: "var(--th-text-muted)" }}>
+                    {item.label}
+                  </div>
+                  {item.agent ? (
+                    <div className="ml-auto flex min-w-0 items-center gap-2">
+                      <AgentAvatar agent={item.agent} size={28} rounded="xl" />
+                      <div className="min-w-0">
+                        <div className="truncate text-sm" style={{ color: "var(--th-text-primary)" }}>
+                          {localeName(locale, item.agent)}
+                        </div>
+                        <div className="truncate text-[11px]" style={{ color: "var(--th-text-muted)" }}>
+                          {getProviderMeta(item.agent.cli_provider).label}
+                        </div>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="ml-auto text-sm" style={{ color: "var(--th-text-muted)" }}>
+                      {tr("없음", "None")}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </SurfaceCard>
+
+            <SurfaceCard className="space-y-3">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "var(--th-text-muted)" }}>
+                {tr("메타", "Metadata")}
+              </div>
+              <div className="grid gap-2">
+                {[
+                  { label: tr("생성", "Created"), value: formatIso(card.created_at, locale) },
+                  { label: tr("진행 시작", "Started"), value: formatIso(card.started_at, locale) },
+                  { label: tr("요청 시각", "Requested"), value: formatIso(card.requested_at, locale) },
+                  { label: tr("재시도", "Retries"), value: `${metadata.retry_count ?? 0}` },
+                  { label: tr("재디스패치", "Redispatch"), value: `${metadata.redispatch_count ?? 0}` },
+                  { label: tr("Failover", "Failover"), value: `${metadata.failover_count ?? 0}` },
+                ].map((item) => (
+                  <div key={item.label} className="flex items-center justify-between gap-3 text-sm">
+                    <span style={{ color: "var(--th-text-muted)" }}>{item.label}</span>
+                    <span className="text-right tabular-nums" style={{ color: "var(--th-text-primary)" }}>
+                      {item.value}
+                    </span>
+                  </div>
+                ))}
+              </div>
+
+              {card.github_issue_url ? (
+                <a
+                  href={card.github_issue_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center rounded-full px-3 py-2 text-sm font-medium hover:underline"
+                  style={{ color: "#93c5fd" }}
+                >
+                  {tr("GitHub 이슈 열기", "Open GitHub Issue")}
+                </a>
+              ) : null}
+            </SurfaceCard>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function BacklogTab({
+  tr,
+  locale,
+  cards,
+  agents,
+}: BacklogTabProps) {
+  const agentMap = useMemo(
+    () => new Map(agents.map((agent) => [agent.id, agent])),
+    [agents],
+  );
+  const [providerFilter, setProviderFilter] = useState<ProviderFilter>("all");
+  const [severityFilter, setSeverityFilter] = useState<SeverityFilter>("all");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [sortKey, setSortKey] = useState<BacklogSortKey>("age");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+  const [selectedCard, setSelectedCard] = useState<KanbanCard | null>(null);
+
+  const providerOptions = useMemo(() => {
+    const providers = new Set<string>();
+    for (const card of cards) {
+      const provider = resolveCardAgent(card, agentMap)?.cli_provider;
+      if (provider) providers.add(provider);
+    }
+    return [...providers].sort((left, right) => compareStrings(left, right));
+  }, [agentMap, cards]);
+
+  const filteredCards = useMemo(() => {
+    const next = cards.filter((card) => {
+      const provider = resolveCardAgent(card, agentMap)?.cli_provider ?? "";
+      if (providerFilter !== "all" && provider !== providerFilter) return false;
+      if (severityFilter !== "all" && card.priority !== severityFilter) return false;
+      if (statusFilter !== "all" && card.status !== statusFilter) return false;
+      return true;
+    });
+    next.sort((left, right) =>
+      compareCards(left, right, sortKey, sortDirection, locale, tr, agentMap),
+    );
+    return next;
+  }, [
+    agentMap,
+    cards,
+    locale,
+    providerFilter,
+    severityFilter,
+    sortDirection,
+    sortKey,
+    statusFilter,
+    tr,
+  ]);
+
+  const activeCount = filteredCards.filter((card) =>
+    ["requested", "in_progress", "review", "qa_pending", "qa_in_progress", "qa_failed"].includes(card.status),
+  ).length;
+  const urgentCount = filteredCards.filter((card) => card.priority === "urgent").length;
+  const assignedCount = filteredCards.filter((card) => Boolean(card.assignee_agent_id)).length;
+
+  const toggleSort = (nextKey: BacklogSortKey) => {
+    if (sortKey === nextKey) {
+      setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
+      return;
+    }
+    setSortKey(nextKey);
+    setSortDirection(nextKey === "title" || nextKey === "assignee" ? "asc" : "desc");
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 md:grid-cols-3">
+        <SurfaceMetricPill
+          label={tr("백로그 총량", "Backlog Total")}
+          value={<span className="text-2xl font-bold tabular-nums">{filteredCards.length}</span>}
+          tone="info"
+          className="min-w-[132px]"
+        />
+        <SurfaceMetricPill
+          label={tr("활성 카드", "Active Cards")}
+          value={<span className="text-2xl font-bold tabular-nums">{activeCount}</span>}
+          tone={activeCount > 0 ? "accent" : "neutral"}
+          className="min-w-[132px]"
+        />
+        <SurfaceMetricPill
+          label={tr("긴급 / 담당 지정", "Urgent / Assigned")}
+          value={
+            <span className="text-lg font-bold tabular-nums">
+              {urgentCount} / {assignedCount}
+            </span>
+          }
+          tone="warn"
+          className="min-w-[132px]"
+        />
+      </div>
+
+      <SurfaceCard className="space-y-3 rounded-[28px] p-4 sm:p-5">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div className="text-sm leading-6" style={{ color: "var(--th-text-muted)" }}>
+            {tr(
+              "백로그는 데스크톱에서 테이블, 모바일에서 카드 스택으로 전환됩니다. 행을 누르면 상세 drawer가 열립니다.",
+              "Backlog switches from a desktop table to a mobile card stack. Tap a row to open the detail drawer.",
+            )}
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+            <select
+              value={providerFilter}
+              onChange={(event) => setProviderFilter(event.target.value)}
+              className="rounded-xl px-3 py-2 text-xs outline-none"
+              style={{
+                background: "var(--th-input-bg)",
+                border: "1px solid var(--th-input-border)",
+                color: "var(--th-text-primary)",
+              }}
+            >
+              <option value="all">{tr("Provider: 전체", "Provider: All")}</option>
+              {providerOptions.map((provider) => (
+                <option key={provider} value={provider}>
+                  {getProviderMeta(provider).label}
+                </option>
+              ))}
+            </select>
+
+            <select
+              value={severityFilter}
+              onChange={(event) => setSeverityFilter(event.target.value as SeverityFilter)}
+              className="rounded-xl px-3 py-2 text-xs outline-none"
+              style={{
+                background: "var(--th-input-bg)",
+                border: "1px solid var(--th-input-border)",
+                color: "var(--th-text-primary)",
+              }}
+            >
+              <option value="all">{tr("심각도: 전체", "Severity: All")}</option>
+              {(["urgent", "high", "medium", "low"] as KanbanCardPriority[]).map((priority) => (
+                <option key={priority} value={priority}>
+                  {priorityLabel(priority, tr)}
+                </option>
+              ))}
+            </select>
+
+            <select
+              value={statusFilter}
+              onChange={(event) => setStatusFilter(event.target.value as StatusFilter)}
+              className="rounded-xl px-3 py-2 text-xs outline-none"
+              style={{
+                background: "var(--th-input-bg)",
+                border: "1px solid var(--th-input-border)",
+                color: "var(--th-text-primary)",
+              }}
+            >
+              <option value="all">{tr("상태: 전체", "Status: All")}</option>
+              {(["backlog", "ready", "requested", "in_progress", "review", "qa_pending", "qa_in_progress", "qa_failed", "done"] as KanbanCardStatus[]).map((status) => (
+                <option key={status} value={status}>
+                  {labelForStatus(status, tr)}
+                </option>
+              ))}
+            </select>
+
+            <select
+              value={`${sortKey}:${sortDirection}`}
+              onChange={(event) => {
+                const [nextKey, nextDirection] = event.target.value.split(":") as [BacklogSortKey, SortDirection];
+                setSortKey(nextKey);
+                setSortDirection(nextDirection);
+              }}
+              className="rounded-xl px-3 py-2 text-xs outline-none"
+              style={{
+                background: "var(--th-input-bg)",
+                border: "1px solid var(--th-input-border)",
+                color: "var(--th-text-primary)",
+              }}
+            >
+              <option value="age:desc">{tr("정렬: Age ↓", "Sort: Age ↓")}</option>
+              <option value="age:asc">{tr("정렬: Age ↑", "Sort: Age ↑")}</option>
+              <option value="severity:asc">{tr("정렬: Severity ↑", "Sort: Severity ↑")}</option>
+              <option value="severity:desc">{tr("정렬: Severity ↓", "Sort: Severity ↓")}</option>
+              <option value="title:asc">{tr("정렬: 제목 A-Z", "Sort: Title A-Z")}</option>
+              <option value="status:asc">{tr("정렬: 상태", "Sort: Status")}</option>
+            </select>
+          </div>
+        </div>
+      </SurfaceCard>
+
+      {filteredCards.length === 0 ? (
+        <SurfaceEmptyState className="py-14 text-center">
+          <div className="text-3xl">🗂️</div>
+          <div className="mt-2 text-sm">{tr("조건에 맞는 백로그 카드가 없습니다.", "No backlog cards match these filters.")}</div>
+        </SurfaceEmptyState>
+      ) : (
+        <>
+          <div className="hidden overflow-hidden rounded-[28px] border lg:block" style={{ borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)" }}>
+            <div
+              className="grid items-center gap-3 border-b px-4 py-3"
+              style={{
+                gridTemplateColumns: "88px minmax(280px,1.8fr) minmax(180px,1fr) 140px 120px 110px 90px",
+                borderColor: "color-mix(in srgb, var(--th-border) 72%, transparent)",
+                background:
+                  "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 94%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
+              }}
+            >
+              <SortHeader label="ID" sortKey="id" activeKey={sortKey} direction={sortDirection} onToggle={toggleSort} />
+              <SortHeader label={tr("제목", "Title")} sortKey="title" activeKey={sortKey} direction={sortDirection} onToggle={toggleSort} />
+              <SortHeader label={tr("담당", "Assignee")} sortKey="assignee" activeKey={sortKey} direction={sortDirection} onToggle={toggleSort} />
+              <SortHeader label={tr("상태", "Status")} sortKey="status" activeKey={sortKey} direction={sortDirection} onToggle={toggleSort} />
+              <SortHeader label="Provider" sortKey="provider" activeKey={sortKey} direction={sortDirection} onToggle={toggleSort} />
+              <SortHeader label={tr("심각도", "Severity")} sortKey="severity" activeKey={sortKey} direction={sortDirection} onToggle={toggleSort} />
+              <SortHeader label={tr("Age", "Age")} sortKey="age" activeKey={sortKey} direction={sortDirection} onToggle={toggleSort} />
+            </div>
+
+            <div className="divide-y" style={{ borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)" }}>
+              {filteredCards.map((card) => {
+                const assignee = card.assignee_agent_id ? agentMap.get(card.assignee_agent_id) : null;
+                const providerMeta = getProviderMeta(resolveCardAgent(card, agentMap)?.cli_provider);
+                return (
+                  <button
+                    key={card.id}
+                    type="button"
+                    onClick={() => setSelectedCard(card)}
+                    className="grid w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-white/5"
+                    style={{
+                      gridTemplateColumns: "88px minmax(280px,1.8fr) minmax(180px,1fr) 140px 120px 110px 90px",
+                    }}
+                  >
+                    <div className="truncate text-sm font-medium tabular-nums" style={{ color: "var(--th-text-secondary)" }}>
+                      {card.github_issue_number ? `#${card.github_issue_number}` : card.id.slice(0, 8)}
+                    </div>
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                        {card.title}
+                      </div>
+                      <div className="truncate text-xs" style={{ color: "var(--th-text-muted)" }}>
+                        {card.github_repo ?? tr("레포 없음", "No repo")}
+                      </div>
+                    </div>
+                    <div className="flex min-w-0 items-center gap-2">
+                      <AgentAvatar agent={assignee ?? undefined} size={28} rounded="xl" />
+                      <div className="min-w-0">
+                        <div className="truncate text-sm" style={{ color: "var(--th-text-primary)" }}>
+                          {assignee ? localeName(locale, assignee) : tr("미할당", "Unassigned")}
+                        </div>
+                        <div className="truncate text-[11px]" style={{ color: "var(--th-text-muted)" }}>
+                          {card.latest_dispatch_title ?? tr("최근 디스패치 없음", "No recent dispatch")}
+                        </div>
+                      </div>
+                    </div>
+                    <div>
+                      <span
+                        className="inline-flex rounded-full border px-2 py-1 text-[11px] font-medium"
+                        style={{
+                          borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)",
+                          background: "color-mix(in srgb, var(--th-card-bg) 90%, transparent)",
+                          color: "var(--th-text-secondary)",
+                        }}
+                      >
+                        {labelForStatus(card.status, tr)}
+                      </span>
+                    </div>
+                    <div>
+                      <span
+                        className="inline-flex rounded-full border px-2 py-1 text-[11px] font-medium"
+                        style={{
+                          borderColor: providerMeta.border,
+                          background: providerMeta.bg,
+                          color: providerMeta.color,
+                        }}
+                      >
+                        {providerMeta.label}
+                      </span>
+                    </div>
+                    <div className="text-sm" style={{ color: "var(--th-text-primary)" }}>
+                      {priorityLabel(card.priority, tr)}
+                    </div>
+                    <div className="text-sm tabular-nums" style={{ color: "var(--th-text-secondary)" }}>
+                      {formatAgeLabel(cardAgeMs(card), tr)}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="space-y-3 lg:hidden">
+            {filteredCards.map((card) => {
+              const assignee = card.assignee_agent_id ? agentMap.get(card.assignee_agent_id) : null;
+              const providerMeta = getProviderMeta(resolveCardAgent(card, agentMap)?.cli_provider);
+              return (
+                <SurfaceCard
+                  key={card.id}
+                  onClick={() => setSelectedCard(card)}
+                  className="cursor-pointer space-y-3 rounded-[28px] p-4 transition-transform hover:-translate-y-0.5"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="text-xs tabular-nums" style={{ color: "var(--th-text-muted)" }}>
+                        {card.github_issue_number ? `#${card.github_issue_number}` : card.id.slice(0, 8)}
+                      </div>
+                      <div className="mt-1 line-clamp-2 text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                        {card.title}
+                      </div>
+                    </div>
+                    <span
+                      className="rounded-full border px-2 py-1 text-[11px] font-medium"
+                      style={{
+                        borderColor: providerMeta.border,
+                        background: providerMeta.bg,
+                        color: providerMeta.color,
+                      }}
+                    >
+                      {providerMeta.label}
+                    </span>
+                  </div>
+
+                  <div className="flex items-center gap-2">
+                    <AgentAvatar agent={assignee ?? undefined} size={30} rounded="xl" />
+                    <div className="min-w-0">
+                      <div className="truncate text-sm" style={{ color: "var(--th-text-primary)" }}>
+                        {assignee ? localeName(locale, assignee) : tr("미할당", "Unassigned")}
+                      </div>
+                      <div className="truncate text-[11px]" style={{ color: "var(--th-text-muted)" }}>
+                        {card.github_repo ?? tr("레포 없음", "No repo")}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    <span
+                      className="rounded-full border px-2 py-1 text-[11px] font-medium"
+                      style={{
+                        borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)",
+                        background: "color-mix(in srgb, var(--th-card-bg) 90%, transparent)",
+                        color: "var(--th-text-secondary)",
+                      }}
+                    >
+                      {labelForStatus(card.status, tr)}
+                    </span>
+                    <span
+                      className="rounded-full border px-2 py-1 text-[11px] font-medium"
+                      style={{
+                        borderColor: "rgba(244,114,182,0.22)",
+                        background: "rgba(244,114,182,0.12)",
+                        color: "#f9a8d4",
+                      }}
+                    >
+                      {priorityLabel(card.priority, tr)}
+                    </span>
+                    <span
+                      className="rounded-full border px-2 py-1 text-[11px] font-medium"
+                      style={{
+                        borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)",
+                        background: "color-mix(in srgb, var(--th-bg-surface) 86%, var(--th-card-bg) 14%)",
+                        color: "var(--th-text-muted)",
+                      }}
+                    >
+                      {tr("Age", "Age")} {formatAgeLabel(cardAgeMs(card), tr)}
+                    </span>
+                  </div>
+                </SurfaceCard>
+              );
+            })}
+          </div>
+        </>
+      )}
+
+      {selectedCard ? (
+        <BacklogCardDrawer
+          card={selectedCard}
+          locale={locale}
+          tr={tr}
+          agentMap={agentMap}
+          onClose={() => setSelectedCard(null)}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/dashboard/src/components/agent-manager/DepartmentsTab.tsx
+++ b/dashboard/src/components/agent-manager/DepartmentsTab.tsx
@@ -1,6 +1,7 @@
 import type { DragEvent } from "react";
 import type { Agent, Department } from "../../types";
 import { localeName } from "../../i18n";
+import AgentAvatar from "../AgentAvatar";
 import { SurfaceActionButton, SurfaceCard, SurfaceEmptyState, SurfaceNotice } from "../common/SurfacePrimitives";
 import type { Translator } from "./types";
 
@@ -70,7 +71,15 @@ export default function DepartmentsTab({
 
       <div className="space-y-2">
         {deptOrder.map((dept, index) => {
-          const agentCountForDept = agents.filter((agent) => agent.department_id === dept.id).length;
+          const members = agents
+            .filter((agent) => agent.department_id === dept.id)
+            .sort((left, right) => {
+              const leftWorking = left.status === "working" ? 0 : 1;
+              const rightWorking = right.status === "working" ? 0 : 1;
+              if (leftWorking !== rightWorking) return leftWorking - rightWorking;
+              return left.name.localeCompare(right.name);
+            });
+          const agentCountForDept = members.length;
           const isDragging = draggingDeptId === dept.id;
           const isDragTarget = dragOverDeptId === dept.id && draggingDeptId !== dept.id;
           const showDropBefore = isDragTarget && dragOverPosition === "before";
@@ -78,7 +87,7 @@ export default function DepartmentsTab({
           return (
             <SurfaceCard
               key={dept.id}
-              className={`group relative flex items-center gap-3 px-4 py-3 transition-all hover:shadow-md ${isDragging ? "opacity-60" : ""}`}
+              className={`group relative px-4 py-4 transition-all hover:shadow-md ${isDragging ? "opacity-60" : ""}`}
               style={{ cursor: "grab" }}
               onDragStart={(e) => onDragStart(dept.id, e)}
               onDragOver={(e) => onDragOver(dept.id, e)}
@@ -95,67 +104,112 @@ export default function DepartmentsTab({
                 <div className="pointer-events-none absolute left-2 right-2 bottom-0 h-0.5 rounded bg-blue-400" />
               )}
 
-              <div className="flex flex-col gap-0.5">
-                <SurfaceActionButton
-                  onClick={() => onMoveDept(index, -1)}
-                  disabled={index === 0}
-                  tone="neutral"
-                  compact
-                  className="h-5 w-6 px-0 py-0"
-                >
-                  ▲
-                </SurfaceActionButton>
-                <SurfaceActionButton
-                  onClick={() => onMoveDept(index, 1)}
-                  disabled={index === deptOrder.length - 1}
-                  tone="neutral"
-                  compact
-                  className="h-5 w-6 px-0 py-0"
-                >
-                  ▼
-                </SurfaceActionButton>
-              </div>
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+                <div className="flex items-start gap-3">
+                  <div className="flex flex-col gap-0.5">
+                    <SurfaceActionButton
+                      onClick={() => onMoveDept(index, -1)}
+                      disabled={index === 0}
+                      tone="neutral"
+                      compact
+                      className="h-5 w-6 px-0 py-0"
+                    >
+                      ▲
+                    </SurfaceActionButton>
+                    <SurfaceActionButton
+                      onClick={() => onMoveDept(index, 1)}
+                      disabled={index === deptOrder.length - 1}
+                      tone="neutral"
+                      compact
+                      className="h-5 w-6 px-0 py-0"
+                    >
+                      ▼
+                    </SurfaceActionButton>
+                  </div>
 
-              <div
-                className="w-8 h-8 rounded-lg flex items-center justify-center text-sm font-bold"
-                style={{ background: `${dept.color}22`, color: dept.color }}
-              >
-                {index + 1}
-              </div>
-
-              <span className="text-2xl">{dept.icon}</span>
-
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                  <span className="font-semibold text-sm" style={{ color: "var(--th-text-heading)" }}>
-                    {localeName(locale, dept)}
-                  </span>
-                  <span className="w-3 h-3 rounded-full inline-block" style={{ background: dept.color }}></span>
-                  <span
-                    className="text-xs px-2 py-0.5 rounded-full"
+                  <div
+                    className="flex h-9 w-9 items-center justify-center rounded-xl text-sm font-bold"
                     style={{ background: `${dept.color}22`, color: dept.color }}
                   >
-                    {agentCountForDept} {tr("명", "agents")}
-                  </span>
-                </div>
-                {dept.description && (
-                  <div className="text-xs mt-0.5 truncate" style={{ color: "var(--th-text-muted)" }}>
-                    {dept.description}
+                    {index + 1}
                   </div>
-                )}
+
+                  <span className="pt-1 text-2xl">{dept.icon}</span>
+
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                        {localeName(locale, dept)}
+                      </span>
+                      <span className="inline-block h-3 w-3 rounded-full" style={{ background: dept.color }}></span>
+                      <span
+                        className="rounded-full px-2 py-0.5 text-xs"
+                        style={{ background: `${dept.color}22`, color: dept.color }}
+                      >
+                        {agentCountForDept} {tr("명", "agents")}
+                      </span>
+                    </div>
+                    {dept.description && (
+                      <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                        {dept.description}
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    {members.slice(0, 4).map((member) => (
+                      <div
+                        key={member.id}
+                        className="inline-flex min-w-0 items-center gap-2 rounded-full border px-2 py-1"
+                        style={{
+                          borderColor:
+                            "color-mix(in srgb, var(--th-border) 68%, transparent)",
+                          background:
+                            "color-mix(in srgb, var(--th-bg-surface) 82%, var(--th-card-bg) 18%)",
+                        }}
+                      >
+                        <AgentAvatar agent={member} size={24} rounded="xl" />
+                        <span className="max-w-[7rem] truncate text-xs" style={{ color: "var(--th-text-primary)" }}>
+                          {localeName(locale, member)}
+                        </span>
+                      </div>
+                    ))}
+                    {members.length > 4 ? (
+                      <span
+                        className="rounded-full border px-2 py-1 text-xs"
+                        style={{
+                          borderColor:
+                            "color-mix(in srgb, var(--th-border) 68%, transparent)",
+                          color: "var(--th-text-muted)",
+                        }}
+                      >
+                        +{members.length - 4}
+                      </span>
+                    ) : null}
+                    {members.length === 0 ? (
+                      <span className="text-xs" style={{ color: "var(--th-text-muted)" }}>
+                        {tr("소속 에이전트 없음", "No agents assigned")}
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-3" style={{ borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)" }}>
+                  <code className="rounded px-2 py-0.5 text-xs opacity-60" style={{ background: "var(--th-input-bg)" }}>
+                    {dept.id}
+                  </code>
+
+                  <SurfaceActionButton
+                    onClick={() => onEditDept(dept)}
+                    tone="neutral"
+                    className="opacity-100 lg:opacity-0 lg:group-hover:opacity-100"
+                  >
+                    {tr("편집", "Edit")}
+                  </SurfaceActionButton>
+                </div>
               </div>
-
-              <code className="text-xs px-2 py-0.5 rounded opacity-50" style={{ background: "var(--th-input-bg)" }}>
-                {dept.id}
-              </code>
-
-              <SurfaceActionButton
-                onClick={() => onEditDept(dept)}
-                tone="neutral"
-                className="opacity-0 group-hover:opacity-100"
-              >
-                {tr("편집", "Edit")}
-              </SurfaceActionButton>
             </SurfaceCard>
           );
         })}

--- a/dashboard/src/components/office-view/OfficeAgentDrawer.tsx
+++ b/dashboard/src/components/office-view/OfficeAgentDrawer.tsx
@@ -1,0 +1,654 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  getAgentDispatchedSessions,
+  getAgentTranscripts,
+  getDiscordChannelInfo,
+  getSkillRanking,
+  type DiscordChannelInfo,
+  type SessionTranscript,
+  type SkillRankingByAgentRow,
+} from "../../api";
+import { getProviderMeta } from "../../app/providerTheme";
+import { localeName } from "../../i18n";
+import type { Agent, Department, DispatchedSession, KanbanCard, UiLanguage } from "../../types";
+import AgentAvatar from "../AgentAvatar";
+import {
+  SurfaceActionButton,
+  SurfaceCard,
+  SurfaceEmptyState,
+  SurfaceMetricPill,
+  SurfaceNotice,
+  SurfaceSection,
+  SurfaceSubsection,
+} from "../common/SurfacePrimitives";
+import { Drawer } from "../common/overlay";
+import {
+  describeDispatchedSession,
+  formatDiscordSummary,
+} from "../agent-manager/discord-routing";
+import { getAgentLevel, getAgentTitle } from "../agent-manager/AgentInfoCard";
+import type { OfficeManualIntervention } from "./officeAgentState";
+
+interface OfficeAgentDrawerProps {
+  open: boolean;
+  agent: Agent;
+  departments: Department[];
+  locale: UiLanguage;
+  isKo: boolean;
+  spriteMap?: Map<string, number>;
+  currentCard?: KanbanCard | null;
+  manualIntervention?: OfficeManualIntervention | null;
+  onClose: () => void;
+}
+
+interface OfficeSkillRow {
+  skillName: string;
+  description: string | null;
+  calls: number;
+  lastUsedAt: number | null;
+}
+
+const SKILL_MARKDOWN_RE = /([A-Za-z0-9][A-Za-z0-9._-]*)\/SKILL\.md/g;
+const SKILL_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+function t(isKo: boolean, ko: string, en: string): string {
+  return isKo ? ko : en;
+}
+
+function formatDateTime(value: number | null, locale: UiLanguage): string {
+  if (!value) return "-";
+  return new Intl.DateTimeFormat(locale, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(value);
+}
+
+function formatElapsed(value: number | null, isKo: boolean): string | null {
+  if (!value) return null;
+  const diff = Math.max(0, Date.now() - value);
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return t(isKo, "방금 시작", "Started just now");
+  if (mins < 60) return t(isKo, `${mins}분째`, `${mins}m running`);
+  const hours = Math.floor(mins / 60);
+  const remainMins = mins % 60;
+  if (hours < 24) {
+    return remainMins > 0
+      ? t(isKo, `${hours}시간 ${remainMins}분째`, `${hours}h ${remainMins}m running`)
+      : t(isKo, `${hours}시간째`, `${hours}h running`);
+  }
+  const days = Math.floor(hours / 24);
+  return t(isKo, `${days}일째`, `${days}d running`);
+}
+
+function normalizeTimestampMs(value: number | string | null | undefined): number | null {
+  if (value == null || value === "") return null;
+  if (typeof value === "number") {
+    return value < 1e12 ? value * 1000 : value;
+  }
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    return numeric < 1e12 ? numeric * 1000 : numeric;
+  }
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function extractSkillNameFromEventContent(content: string): string | null {
+  try {
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    for (const key of ["skill", "name", "command"]) {
+      const value = parsed[key];
+      if (typeof value === "string" && value.trim()) {
+        return value.trim().replace(/^\/+/, "");
+      }
+    }
+  } catch {
+    // Ignore malformed payloads and fall back to regex scanning.
+  }
+  return null;
+}
+
+function deriveFallbackSkillRows(transcripts: SessionTranscript[]): OfficeSkillRow[] {
+  const cutoff = Date.now() - SKILL_WINDOW_MS;
+  const aggregates = new Map<string, OfficeSkillRow>();
+
+  for (const transcript of transcripts) {
+    const usedAt = normalizeTimestampMs(transcript.created_at);
+    if (!usedAt || usedAt < cutoff) continue;
+
+    const used = new Set<string>();
+    const searchableChunks = [transcript.assistant_message];
+
+    for (const event of transcript.events) {
+      searchableChunks.push(event.summary ?? "");
+      searchableChunks.push(event.content);
+      if (
+        event.kind === "tool_use"
+        && event.tool_name?.toLowerCase() === "skill"
+      ) {
+        const skillName = extractSkillNameFromEventContent(event.content);
+        if (skillName) used.add(skillName);
+      }
+    }
+
+    const searchable = searchableChunks.join("\n");
+    for (const match of searchable.matchAll(SKILL_MARKDOWN_RE)) {
+      if (match[1]) used.add(match[1]);
+    }
+
+    for (const skillName of used) {
+      const current = aggregates.get(skillName);
+      if (current) {
+        current.calls += 1;
+        current.lastUsedAt = current.lastUsedAt == null ? usedAt : Math.max(current.lastUsedAt, usedAt);
+        continue;
+      }
+      aggregates.set(skillName, {
+        skillName,
+        description: null,
+        calls: 1,
+        lastUsedAt: usedAt,
+      });
+    }
+  }
+
+  return Array.from(aggregates.values())
+    .sort((left, right) => {
+      if (right.calls !== left.calls) return right.calls - left.calls;
+      return (right.lastUsedAt ?? 0) - (left.lastUsedAt ?? 0);
+    })
+    .slice(0, 5);
+}
+
+function buildSkillLookupKeys(agent: Agent): Set<string> {
+  return new Set(
+    [
+      agent.id,
+      agent.role_id,
+      agent.name,
+      agent.name_ko,
+      agent.alias,
+    ]
+      .filter((value): value is string => Boolean(value?.trim()))
+      .map((value) => value.trim().toLowerCase()),
+  );
+}
+
+function buildSkillRows(agent: Agent, rankingRows: SkillRankingByAgentRow[], transcripts: SessionTranscript[]): OfficeSkillRow[] {
+  const lookupKeys = buildSkillLookupKeys(agent);
+  const agentRows = rankingRows
+    .filter((row) => {
+      const roleId = row.agent_role_id.trim().toLowerCase();
+      const agentName = row.agent_name.trim().toLowerCase();
+      return lookupKeys.has(roleId) || lookupKeys.has(agentName);
+    })
+    .slice(0, 5)
+    .map((row) => ({
+      skillName: row.skill_name,
+      description: row.skill_desc_ko || null,
+      calls: row.calls,
+      lastUsedAt: row.last_used_at ?? null,
+    }));
+
+  if (agentRows.length > 0) return agentRows;
+  return deriveFallbackSkillRows(transcripts);
+}
+
+function hydrateSession(raw: DispatchedSession, agent: Agent): DispatchedSession {
+  return {
+    ...raw,
+    session_key: raw.session_key ?? `agent:${agent.id}`,
+    name: raw.name ?? agent.alias ?? agent.name_ko ?? agent.name,
+    department_id: raw.department_id ?? agent.department_id ?? null,
+    linked_agent_id: raw.linked_agent_id ?? agent.id,
+    provider: raw.provider ?? agent.cli_provider ?? "claude",
+    model: raw.model ?? null,
+    status: raw.status ?? (agent.status === "working" ? "working" : "idle"),
+    session_info: raw.session_info ?? agent.session_info ?? null,
+    sprite_number: raw.sprite_number ?? agent.sprite_number ?? null,
+    avatar_emoji: raw.avatar_emoji ?? agent.avatar_emoji,
+    stats_xp: raw.stats_xp ?? agent.stats_xp,
+    tokens: raw.tokens ?? 0,
+    connected_at: raw.connected_at ?? agent.created_at,
+    last_seen_at: raw.last_seen_at ?? null,
+    department_name: raw.department_name ?? agent.department_name ?? null,
+    department_name_ko: raw.department_name_ko ?? agent.department_name_ko ?? null,
+    department_color: raw.department_color ?? agent.department_color ?? null,
+    thread_channel_id: raw.thread_channel_id ?? agent.current_thread_channel_id ?? null,
+  };
+}
+
+function ensurePrimarySession(agent: Agent, sessions: DispatchedSession[]): DispatchedSession[] {
+  if (!agent.current_thread_channel_id) return sessions;
+  if (sessions.some((session) => session.thread_channel_id === agent.current_thread_channel_id)) {
+    return sessions;
+  }
+  return [
+    {
+      id: `office-primary:${agent.id}`,
+      session_key: `office:${agent.id}`,
+      name: agent.alias ?? agent.name_ko ?? agent.name,
+      department_id: agent.department_id ?? null,
+      linked_agent_id: agent.id,
+      provider: agent.cli_provider ?? "claude",
+      model: null,
+      status: agent.status === "working" ? "working" : "idle",
+      session_info: agent.session_info ?? null,
+      sprite_number: agent.sprite_number ?? null,
+      avatar_emoji: agent.avatar_emoji,
+      stats_xp: agent.stats_xp,
+      tokens: 0,
+      connected_at: agent.created_at,
+      last_seen_at: null,
+      department_name: agent.department_name ?? null,
+      department_name_ko: agent.department_name_ko ?? null,
+      department_color: agent.department_color ?? null,
+      thread_channel_id: agent.current_thread_channel_id,
+    },
+    ...sessions,
+  ];
+}
+
+function sessionSortValue(session: DispatchedSession): number {
+  return session.last_seen_at ?? session.connected_at ?? 0;
+}
+
+function buildCardIssueUrl(card: KanbanCard): string | null {
+  if (card.github_issue_url) return card.github_issue_url;
+  if (card.github_repo && card.github_issue_number) {
+    return `https://github.com/${card.github_repo}/issues/${card.github_issue_number}`;
+  }
+  return null;
+}
+
+export default function OfficeAgentDrawer({
+  open,
+  agent,
+  departments,
+  locale,
+  isKo,
+  spriteMap,
+  currentCard,
+  manualIntervention,
+  onClose,
+}: OfficeAgentDrawerProps) {
+  const [loading, setLoading] = useState(true);
+  const [sessions, setSessions] = useState<DispatchedSession[]>([]);
+  const [sessionChannelsById, setSessionChannelsById] = useState<Record<string, DiscordChannelInfo>>({});
+  const [skillRows, setSkillRows] = useState<OfficeSkillRow[]>([]);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoading(true);
+
+    void (async () => {
+      const [sessionsResult, rankingResult, transcriptsResult] = await Promise.allSettled([
+        getAgentDispatchedSessions(agent.id),
+        getSkillRanking("7d", 100),
+        getAgentTranscripts(agent.id, 80),
+      ]);
+
+      if (cancelled) return;
+
+      const loadedSessions =
+        sessionsResult.status === "fulfilled"
+          ? ensurePrimarySession(
+              agent,
+              sessionsResult.value
+                .map((session) => hydrateSession(session, agent))
+                .sort((left, right) => {
+                  const leftWorking = left.status === "working" ? 0 : 1;
+                  const rightWorking = right.status === "working" ? 0 : 1;
+                  if (leftWorking !== rightWorking) return leftWorking - rightWorking;
+                  return sessionSortValue(right) - sessionSortValue(left);
+                }),
+            )
+          : ensurePrimarySession(agent, []);
+
+      const rankingRows =
+        rankingResult.status === "fulfilled" ? rankingResult.value.byAgent : [];
+      const transcriptRows =
+        transcriptsResult.status === "fulfilled" ? transcriptsResult.value : [];
+
+      const channelIds = Array.from(
+        new Set(
+          loadedSessions
+            .map((session) => session.thread_channel_id ?? null)
+            .filter((value): value is string => Boolean(value)),
+        ),
+      );
+
+      const channelEntries = await Promise.all(
+        channelIds.map(async (channelId) => {
+          try {
+            return [channelId, await getDiscordChannelInfo(channelId)] as const;
+          } catch {
+            return null;
+          }
+        }),
+      );
+
+      if (cancelled) return;
+
+      setSessions(loadedSessions);
+      setSessionChannelsById(
+        Object.fromEntries(
+          channelEntries.filter(
+            (entry): entry is readonly [string, DiscordChannelInfo] => entry !== null,
+          ),
+        ),
+      );
+      setSkillRows(buildSkillRows(agent, rankingRows, transcriptRows));
+      setLoading(false);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [agent, open]);
+
+  const department = departments.find((item) => item.id === agent.department_id) ?? null;
+  const providerMeta = getProviderMeta(agent.cli_provider);
+  const level = getAgentLevel(agent.stats_xp);
+  const levelTitle = getAgentTitle(agent.stats_xp, isKo);
+  const currentTaskStartedAt = useMemo(
+    () => normalizeTimestampMs(currentCard?.started_at ?? currentCard?.requested_at ?? null),
+    [currentCard],
+  );
+  const currentTaskIssueUrl = currentCard ? buildCardIssueUrl(currentCard) : null;
+
+  return (
+    <Drawer
+      open={open}
+      onClose={onClose}
+      title={localeName(locale, agent)}
+      width="min(440px, 100vw)"
+      ariaLabel={`${localeName(locale, agent)} ${t(isKo, "오피스 상세", "Office details")}`}
+    >
+      <div className="space-y-4" data-testid="office-agent-drawer">
+        <SurfaceSection
+          eyebrow={t(isKo, "오피스 에이전트", "Office agent")}
+          title={localeName(locale, agent)}
+          description={agent.alias ? `aka ${agent.alias}` : undefined}
+          actions={(
+            <div className="flex flex-wrap items-center gap-2">
+              <span
+                className="rounded-full px-2.5 py-1 text-xs font-semibold"
+                style={{
+                  background: providerMeta.bg,
+                  color: providerMeta.color,
+                  border: `1px solid ${providerMeta.border}`,
+                }}
+              >
+                {providerMeta.label}
+              </span>
+              {manualIntervention && (
+                <span
+                  className="rounded-full px-2.5 py-1 text-xs font-semibold"
+                  style={{
+                    background: "color-mix(in srgb, var(--warn) 14%, var(--th-card-bg) 86%)",
+                    color: "var(--warn)",
+                    border: "1px solid color-mix(in srgb, var(--warn) 24%, var(--th-border) 76%)",
+                  }}
+                >
+                  {t(isKo, "수동 개입", "Manual intervention")}
+                </span>
+              )}
+            </div>
+          )}
+        >
+          <div className="mt-4 flex items-start gap-3">
+            <AgentAvatar agent={agent} spriteMap={spriteMap} size={56} rounded="2xl" />
+            <div className="min-w-0 flex-1 space-y-3">
+              <div className="flex flex-wrap gap-2">
+                <SurfaceMetricPill
+                  label={t(isKo, "레벨", "Level")}
+                  tone="accent"
+                  value={`Lv.${level.level} ${levelTitle}`}
+                />
+                <SurfaceMetricPill
+                  label="XP"
+                  tone="info"
+                  value={agent.stats_xp.toLocaleString(locale)}
+                />
+                <SurfaceMetricPill
+                  label={t(isKo, "완료", "Done")}
+                  tone="success"
+                  value={`${agent.stats_tasks_done}`}
+                />
+              </div>
+              <div className="grid gap-2 sm:grid-cols-2">
+                <SummaryRow
+                  label={t(isKo, "상태", "Status")}
+                  value={t(
+                    isKo,
+                    agent.status === "working"
+                      ? "작업 중"
+                      : agent.status === "offline"
+                        ? "오프라인"
+                        : agent.status === "break"
+                          ? "휴식"
+                          : "대기",
+                    agent.status === "working"
+                      ? "Working"
+                      : agent.status === "offline"
+                        ? "Offline"
+                        : agent.status === "break"
+                          ? "Break"
+                          : "Idle",
+                  )}
+                />
+                <SummaryRow
+                  label={t(isKo, "부서", "Department")}
+                  value={department ? `${department.icon} ${localeName(locale, department)}` : t(isKo, "미배정", "Unassigned")}
+                />
+              </div>
+              {agent.session_info && (
+                <div className="text-sm leading-6" style={{ color: "var(--th-text-muted)" }}>
+                  {agent.session_info}
+                </div>
+              )}
+            </div>
+          </div>
+        </SurfaceSection>
+
+        <SurfaceSubsection
+          title={t(isKo, "현재 작업", "Current task")}
+          description={t(isKo, "칸반 카드와 수동 개입 상태를 함께 보여줍니다.", "Shows the active card and any manual intervention state together.")}
+        >
+          {currentCard ? (
+            <div className="space-y-3">
+              <SurfaceCard className="p-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                      {currentCard.title}
+                    </div>
+                    <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                      {t(isKo, "상태", "Status")}: {currentCard.status}
+                      {currentTaskStartedAt
+                        ? ` · ${formatElapsed(currentTaskStartedAt, isKo) ?? formatDateTime(currentTaskStartedAt, locale)}`
+                        : ""}
+                    </div>
+                  </div>
+                  {currentCard.github_issue_number && currentTaskIssueUrl ? (
+                    <a
+                      href={currentTaskIssueUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="rounded-full border px-2.5 py-1 text-xs font-semibold transition hover:opacity-90"
+                      style={{
+                        borderColor: "color-mix(in srgb, var(--th-accent-info) 30%, var(--th-border) 70%)",
+                        color: "var(--th-accent-info)",
+                      }}
+                    >
+                      #{currentCard.github_issue_number}
+                    </a>
+                  ) : null}
+                </div>
+              </SurfaceCard>
+              {manualIntervention && (
+                <SurfaceCard
+                  className="p-3"
+                  style={{
+                    borderColor: "color-mix(in srgb, var(--warn) 28%, var(--th-border) 72%)",
+                    background: "color-mix(in srgb, var(--warn) 10%, var(--th-card-bg) 90%)",
+                  }}
+                >
+                  <div className="text-xs font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--warn)" }}>
+                    {t(isKo, "경고 사유", "Warning")}
+                  </div>
+                  <div className="mt-2 text-sm leading-6" style={{ color: "var(--th-text-primary)" }}>
+                    {manualIntervention.reason
+                      ?? t(
+                        isKo,
+                        "수동 개입 상태지만 구체 사유는 아직 기록되지 않았습니다.",
+                        "Manual intervention is active, but no explicit reason was recorded yet.",
+                      )}
+                  </div>
+                </SurfaceCard>
+              )}
+            </div>
+          ) : (
+            <SurfaceEmptyState className="text-sm">
+              {t(isKo, "열린 작업 카드가 없습니다.", "No active card is assigned right now.")}
+            </SurfaceEmptyState>
+          )}
+        </SurfaceSubsection>
+
+        <SurfaceSubsection
+          title={t(isKo, "최근 7일 Top 스킬", "Top skills in the last 7 days")}
+          description={t(isKo, "에이전트별 스킬 호출 집계 기준입니다.", "Based on per-agent skill usage aggregation.")}
+        >
+          {loading ? (
+            <SurfaceNotice compact>{t(isKo, "스킬 사용량을 불러오는 중...", "Loading skill usage...")}</SurfaceNotice>
+          ) : skillRows.length === 0 ? (
+            <SurfaceEmptyState className="text-sm">
+              {t(isKo, "최근 7일 스킬 호출이 없습니다.", "No skill calls in the last 7 days.")}
+            </SurfaceEmptyState>
+          ) : (
+            <div className="space-y-2">
+              {skillRows.map((row) => (
+                <SurfaceCard key={row.skillName} className="flex items-start justify-between gap-3 p-3">
+                  <div className="min-w-0">
+                    <div className="text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                      {row.skillName}
+                    </div>
+                    <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                      {row.description || t(isKo, "설명 없음", "No description")}
+                    </div>
+                  </div>
+                  <div className="shrink-0 text-right">
+                    <div className="text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                      {row.calls}
+                    </div>
+                    <div className="mt-1 text-[11px]" style={{ color: "var(--th-text-muted)" }}>
+                      {formatDateTime(row.lastUsedAt, locale)}
+                    </div>
+                  </div>
+                </SurfaceCard>
+              ))}
+            </div>
+          )}
+        </SurfaceSubsection>
+
+        <SurfaceSubsection
+          title={t(isKo, "세션 링크", "Session links")}
+          description={t(isKo, "현재 연결된 AgentDesk 세션과 Discord thread 링크입니다.", "Linked AgentDesk sessions and Discord thread links.")}
+        >
+          {loading ? (
+            <SurfaceNotice compact>{t(isKo, "세션 정보를 불러오는 중...", "Loading sessions...")}</SurfaceNotice>
+          ) : sessions.length === 0 ? (
+            <SurfaceEmptyState className="text-sm">
+              {t(isKo, "연결된 세션이 없습니다.", "No linked sessions.")}
+            </SurfaceEmptyState>
+          ) : (
+            <div className="space-y-2">
+              {sessions.map((session) => {
+                const provider = getProviderMeta(session.provider);
+                const channelInfo = session.thread_channel_id
+                  ? sessionChannelsById[session.thread_channel_id] ?? null
+                  : null;
+                const parentInfo = channelInfo?.parent_id
+                  ? sessionChannelsById[channelInfo.parent_id] ?? null
+                  : null;
+                const summary = describeDispatchedSession(session, channelInfo, parentInfo);
+                return (
+                  <SurfaceCard key={session.id} className="p-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                          {formatDiscordSummary(summary)}
+                        </div>
+                        <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                          {session.session_info || session.model || t(isKo, "세션 정보 없음", "No session detail")}
+                        </div>
+                      </div>
+                      <div className="flex shrink-0 flex-wrap gap-2">
+                        <span
+                          className="rounded-full px-2.5 py-1 text-[11px] font-semibold"
+                          style={{
+                            background: provider.bg,
+                            color: provider.color,
+                            border: `1px solid ${provider.border}`,
+                          }}
+                        >
+                          {provider.label}
+                        </span>
+                        <span
+                          className="rounded-full px-2.5 py-1 text-[11px] font-semibold"
+                          style={{
+                            background: session.status === "working"
+                              ? "color-mix(in srgb, var(--ok) 14%, var(--th-card-bg) 86%)"
+                              : "color-mix(in srgb, var(--fg-muted) 14%, var(--th-card-bg) 86%)",
+                            color: session.status === "working" ? "var(--ok)" : "var(--fg-muted)",
+                          }}
+                        >
+                          {session.status === "working" ? t(isKo, "작업중", "Working") : t(isKo, "대기", "Idle")}
+                        </span>
+                      </div>
+                    </div>
+                    {(summary.webUrl || summary.deepLink) && (
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        {summary.webUrl && (
+                          <a href={summary.webUrl} target="_blank" rel="noreferrer">
+                            <SurfaceActionButton tone="info" compact>
+                              {t(isKo, "웹에서 열기", "Open web")}
+                            </SurfaceActionButton>
+                          </a>
+                        )}
+                        {summary.deepLink && (
+                          <a href={summary.deepLink}>
+                            <SurfaceActionButton tone="neutral" compact>
+                              {t(isKo, "Discord 앱", "Discord app")}
+                            </SurfaceActionButton>
+                          </a>
+                        )}
+                      </div>
+                    )}
+                  </SurfaceCard>
+                );
+              })}
+            </div>
+          )}
+        </SurfaceSubsection>
+      </div>
+    </Drawer>
+  );
+}
+
+function SummaryRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border px-3 py-2" style={{ borderColor: "color-mix(in srgb, var(--th-border) 66%, transparent)" }}>
+      <div className="text-[11px] font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--th-text-muted)" }}>
+        {label}
+      </div>
+      <div className="mt-1 text-sm" style={{ color: "var(--th-text-primary)" }}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/office-view/buildScene-department-agent.ts
+++ b/dashboard/src/components/office-view/buildScene-department-agent.ts
@@ -153,10 +153,6 @@ export function renderDeskAgentAndSubClones({
     haloG.circle(ax, charFeetY - TARGET_CHAR_H / 2, 22).fill({ color: 0xef4444, alpha: 0.08 });
     haloG.circle(ax, charFeetY - TARGET_CHAR_H / 2, 22).stroke({ width: 1.5, color: 0xef4444, alpha: 0.5 });
     room.addChild(haloG);
-    const blockedBadge = new Text({ text: "🚫", style: new TextStyle({ fontSize: 9 }) });
-    blockedBadge.anchor.set(0.5, 0.5);
-    blockedBadge.position.set(ax - 18, charFeetY - TARGET_CHAR_H + 8);
-    room.addChild(blockedBadge);
   }
 
   const activeTask = tasks.find((task) => task.assigned_agent_id === agent.id && task.status === "in_progress");

--- a/dashboard/src/components/office-view/officeAgentState.test.ts
+++ b/dashboard/src/components/office-view/officeAgentState.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import type { Agent, KanbanCard } from "../../types";
+import { deriveOfficeAgentState } from "./officeAgentState";
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "agent-1",
+    name: "Alpha",
+    alias: "alpha",
+    name_ko: "알파",
+    department_id: "dept-1",
+    avatar_emoji: "🤖",
+    personality: null,
+    status: "working",
+    stats_tasks_done: 3,
+    stats_xp: 120,
+    stats_tokens: 0,
+    created_at: 1_710_000_000_000,
+    ...overrides,
+  };
+}
+
+function makeCard(overrides: Partial<KanbanCard> = {}): KanbanCard {
+  return {
+    id: "card-1",
+    title: "Test card",
+    description: null,
+    status: "in_progress",
+    github_repo: "itismyfield/AgentDesk",
+    owner_agent_id: null,
+    requester_agent_id: null,
+    assignee_agent_id: "agent-1",
+    parent_card_id: null,
+    latest_dispatch_id: "dispatch-1",
+    sort_order: 10,
+    priority: "medium",
+    depth: 0,
+    blocked_reason: null,
+    review_notes: null,
+    github_issue_number: 777,
+    github_issue_url: null,
+    metadata_json: null,
+    pipeline_stage_id: null,
+    review_status: null,
+    created_at: 1_710_000_000_000,
+    updated_at: 1_710_000_100_000,
+    started_at: 1_710_000_050_000,
+    requested_at: 1_710_000_000_000,
+    review_entered_at: null,
+    completed_at: null,
+    latest_dispatch_status: "in_progress",
+    latest_dispatch_title: "dispatch",
+    latest_dispatch_type: "implementation",
+    latest_dispatch_result_summary: null,
+    latest_dispatch_chain_depth: 0,
+    child_count: 0,
+    ...overrides,
+  };
+}
+
+describe("deriveOfficeAgentState", () => {
+  it("prefers review cards for active issue and seat status", () => {
+    const agent = makeAgent();
+
+    const state = deriveOfficeAgentState([agent], [
+      makeCard({
+        id: "card-in-progress",
+        title: "Implement widget",
+        status: "in_progress",
+        github_issue_number: 780,
+        updated_at: 1_710_000_100_000,
+      }),
+      makeCard({
+        id: "card-review",
+        title: "Review widget",
+        status: "review",
+        github_issue_number: 781,
+        updated_at: 1_710_000_200_000,
+      }),
+    ]);
+
+    expect(state.activeIssueByAgent.get(agent.id)).toMatchObject({
+      cardId: "card-review",
+      status: "review",
+      number: 781,
+    });
+    expect(state.primaryCardByAgent.get(agent.id)?.id).toBe("card-review");
+    expect(state.seatStatusByAgent.get(agent.id)).toBe("review");
+  });
+
+  it("keeps benign blocked reasons out of manual intervention and prefers explicit reasons", () => {
+    const agent = makeAgent();
+    const idleAgent = makeAgent({
+      id: "agent-2",
+      name: "Beta",
+      alias: "beta",
+      name_ko: "베타",
+      status: "idle",
+    });
+
+    const state = deriveOfficeAgentState([agent, idleAgent], [
+      makeCard({
+        id: "card-benign",
+        assignee_agent_id: agent.id,
+        status: "requested",
+        blocked_reason: "ci:waiting for checks",
+        updated_at: 1_710_000_100_000,
+      }),
+      makeCard({
+        id: "card-manual",
+        assignee_agent_id: agent.id,
+        status: "requested",
+        blocked_reason: "maintainer approval required before deploy",
+        github_issue_number: 785,
+        updated_at: 1_710_000_200_000,
+      }),
+      makeCard({
+        id: "card-dilemma",
+        assignee_agent_id: idleAgent.id,
+        status: "requested",
+        review_status: "dilemma_pending",
+        blocked_reason: "ci:waiting for reviewer",
+        updated_at: 1_710_000_300_000,
+      }),
+    ]);
+
+    expect(state.manualInterventionByAgent.get(agent.id)).toMatchObject({
+      cardId: "card-manual",
+      reason: "maintainer approval required before deploy",
+      issueNumber: 785,
+    });
+    expect(state.manualInterventionByAgent.get(idleAgent.id)).toMatchObject({
+      cardId: "card-dilemma",
+      reason: null,
+    });
+  });
+});

--- a/dashboard/src/components/office-view/officeAgentState.ts
+++ b/dashboard/src/components/office-view/officeAgentState.ts
@@ -1,0 +1,202 @@
+import type { Agent, KanbanCard, KanbanCardStatus } from "../../types";
+import {
+  hasManualInterventionReason,
+  isManualInterventionCard,
+} from "../agent-manager/kanban-utils";
+
+export type OfficeSeatStatus = "working" | "idle" | "review" | "offline";
+
+export interface OfficeActiveIssue {
+  cardId: string;
+  title: string;
+  status: KanbanCardStatus;
+  number: number | null;
+  url: string | null;
+  startedAt: number | null;
+  updatedAt: number;
+}
+
+export interface OfficeManualIntervention {
+  cardId: string;
+  title: string;
+  status: KanbanCardStatus;
+  reviewStatus: string | null;
+  reason: string | null;
+  issueNumber: number | null;
+  issueUrl: string | null;
+  updatedAt: number;
+}
+
+export interface OfficeAgentState {
+  activeIssueByAgent: Map<string, OfficeActiveIssue>;
+  manualInterventionByAgent: Map<string, OfficeManualIntervention>;
+  primaryCardByAgent: Map<string, KanbanCard>;
+  seatStatusByAgent: Map<string, OfficeSeatStatus>;
+}
+
+const TERMINAL_CARD_STATUSES = new Set<KanbanCardStatus>(["done"]);
+
+const PRIMARY_CARD_PRIORITY: Record<KanbanCardStatus, number> = {
+  review: 0,
+  in_progress: 1,
+  requested: 2,
+  blocked: 3,
+  qa_in_progress: 4,
+  qa_pending: 5,
+  qa_failed: 6,
+  ready: 7,
+  backlog: 8,
+  done: 9,
+};
+
+const ACTIVE_ISSUE_PRIORITY: Record<KanbanCardStatus, number> = {
+  review: 0,
+  in_progress: 1,
+  requested: 2,
+  blocked: 3,
+  qa_in_progress: 4,
+  qa_pending: 5,
+  qa_failed: 6,
+  ready: 7,
+  backlog: 8,
+  done: 9,
+};
+
+function normalizeTimestampMs(value: number | string | null | undefined): number | null {
+  if (value == null || value === "") return null;
+  if (typeof value === "number") {
+    return value < 1e12 ? value * 1000 : value;
+  }
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    return numeric < 1e12 ? numeric * 1000 : numeric;
+  }
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function compareCards(left: KanbanCard, right: KanbanCard, priority: Record<KanbanCardStatus, number>): number {
+  const leftPriority = priority[left.status] ?? 99;
+  const rightPriority = priority[right.status] ?? 99;
+  if (leftPriority !== rightPriority) {
+    return leftPriority - rightPriority;
+  }
+  return right.updated_at - left.updated_at;
+}
+
+function selectPreferredCard(current: KanbanCard | undefined, next: KanbanCard): KanbanCard {
+  if (!current) return next;
+  return compareCards(next, current, PRIMARY_CARD_PRIORITY) < 0 ? next : current;
+}
+
+function selectPreferredIssue(current: OfficeActiveIssue | undefined, next: OfficeActiveIssue): OfficeActiveIssue {
+  if (!current) return next;
+  const currentPriority = ACTIVE_ISSUE_PRIORITY[current.status] ?? 99;
+  const nextPriority = ACTIVE_ISSUE_PRIORITY[next.status] ?? 99;
+  if (nextPriority !== currentPriority) {
+    return nextPriority < currentPriority ? next : current;
+  }
+  return next.updatedAt > current.updatedAt ? next : current;
+}
+
+function selectPreferredManualIntervention(
+  current: OfficeManualIntervention | undefined,
+  next: OfficeManualIntervention,
+): OfficeManualIntervention {
+  if (!current) return next;
+
+  const nextHasReason = Boolean(next.reason?.trim());
+  const currentHasReason = Boolean(current.reason?.trim());
+  if (nextHasReason !== currentHasReason) {
+    return nextHasReason ? next : current;
+  }
+
+  const currentPriority = ACTIVE_ISSUE_PRIORITY[current.status] ?? 99;
+  const nextPriority = ACTIVE_ISSUE_PRIORITY[next.status] ?? 99;
+  if (nextPriority !== currentPriority) {
+    return nextPriority < currentPriority ? next : current;
+  }
+
+  return next.updatedAt > current.updatedAt ? next : current;
+}
+
+function buildIssueUrl(card: KanbanCard): string | null {
+  if (card.github_issue_url) return card.github_issue_url;
+  if (card.github_repo && card.github_issue_number) {
+    return `https://github.com/${card.github_repo}/issues/${card.github_issue_number}`;
+  }
+  return null;
+}
+
+export function deriveOfficeAgentState(
+  agents: Agent[],
+  kanbanCards?: KanbanCard[],
+): OfficeAgentState {
+  const activeIssueByAgent = new Map<string, OfficeActiveIssue>();
+  const manualInterventionByAgent = new Map<string, OfficeManualIntervention>();
+  const primaryCardByAgent = new Map<string, KanbanCard>();
+
+  for (const card of kanbanCards ?? []) {
+    const agentId = card.assignee_agent_id;
+    if (!agentId) continue;
+    if (!TERMINAL_CARD_STATUSES.has(card.status)) {
+      primaryCardByAgent.set(agentId, selectPreferredCard(primaryCardByAgent.get(agentId), card));
+    }
+
+    if (card.status === "review" || card.status === "in_progress") {
+      activeIssueByAgent.set(
+        agentId,
+        selectPreferredIssue(activeIssueByAgent.get(agentId), {
+          cardId: card.id,
+          title: card.title,
+          status: card.status,
+          number: card.github_issue_number ?? null,
+          url: buildIssueUrl(card),
+          startedAt: normalizeTimestampMs(card.started_at),
+          updatedAt: card.updated_at,
+        }),
+      );
+    }
+
+    if (isManualInterventionCard(card)) {
+      manualInterventionByAgent.set(
+        agentId,
+        selectPreferredManualIntervention(manualInterventionByAgent.get(agentId), {
+          cardId: card.id,
+          title: card.title,
+          status: card.status,
+          reviewStatus: card.review_status ?? null,
+          reason: hasManualInterventionReason(card) ? card.blocked_reason?.trim() ?? null : null,
+          issueNumber: card.github_issue_number ?? null,
+          issueUrl: buildIssueUrl(card),
+          updatedAt: card.updated_at,
+        }),
+      );
+    }
+  }
+
+  const seatStatusByAgent = new Map<string, OfficeSeatStatus>();
+  for (const agent of agents) {
+    if (agent.status === "offline") {
+      seatStatusByAgent.set(agent.id, "offline");
+      continue;
+    }
+    const activeIssue = activeIssueByAgent.get(agent.id);
+    if (activeIssue?.status === "review") {
+      seatStatusByAgent.set(agent.id, "review");
+      continue;
+    }
+    if (agent.status === "working") {
+      seatStatusByAgent.set(agent.id, "working");
+      continue;
+    }
+    seatStatusByAgent.set(agent.id, "idle");
+  }
+
+  return {
+    activeIssueByAgent,
+    manualInterventionByAgent,
+    primaryCardByAgent,
+    seatStatusByAgent,
+  };
+}

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -210,7 +210,7 @@
 | `services::discord::config_audit` | `src/services/discord/config_audit.rs` | 1145 | giant-file |
 | `services::discord::discord_io` | `src/services/discord/discord_io.rs` | 528 |  |
 | `services::discord::dm_reply_store` | `src/services/discord/dm_reply_store.rs` | 463 |  |
-| `services::discord::formatting` | `src/services/discord/formatting.rs` | 1530 | giant-file |
+| `services::discord::formatting` | `src/services/discord/formatting.rs` | 1568 | giant-file |
 | `services::discord::gateway` | `src/services/discord/gateway.rs` | 398 |  |
 | `services::discord::handoff` | `src/services/discord/handoff.rs` | 260 |  |
 | `services::discord::health` | `src/services/discord/health.rs` | 2201 | giant-file |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -4,7 +4,7 @@
 
 - Production Rust modules: `260`
 - Giant-file threshold: `>= 1000` lines
-- Giant files: `75`
+- Giant files: `76`
 
 ## Namespace Summary
 
@@ -73,20 +73,20 @@
 | `dispatch` | `src/dispatch/mod.rs` | 4642 | giant-file |
 | `dispatch::dispatch_channel` | `src/dispatch/dispatch_channel.rs` | 23 |  |
 | `dispatch::dispatch_context` | `src/dispatch/dispatch_context.rs` | 2657 | giant-file |
-| `dispatch::dispatch_create` | `src/dispatch/dispatch_create.rs` | 719 |  |
+| `dispatch::dispatch_create` | `src/dispatch/dispatch_create.rs` | 1260 | giant-file |
 | `dispatch::dispatch_status` | `src/dispatch/dispatch_status.rs` | 624 |  |
 | `engine` | `src/engine/mod.rs` | 1709 | giant-file |
 | `engine::hooks` | `src/engine/hooks.rs` | 84 |  |
 | `engine::intent` | `src/engine/intent.rs` | 819 |  |
 | `engine::loader` | `src/engine/loader.rs` | 281 |  |
-| `engine::ops` | `src/engine/ops.rs` | 177 |  |
+| `engine::ops` | `src/engine/ops.rs` | 178 |  |
 | `engine::ops::agent_ops` | `src/engine/ops/agent_ops.rs` | 335 |  |
 | `engine::ops::auto_queue_ops` | `src/engine/ops/auto_queue_ops.rs` | 791 |  |
 | `engine::ops::cards_ops` | `src/engine/ops/cards_ops.rs` | 626 |  |
 | `engine::ops::config_ops` | `src/engine/ops/config_ops.rs` | 46 |  |
 | `engine::ops::db_ops` | `src/engine/ops/db_ops.rs` | 1055 | giant-file |
 | `engine::ops::deploy_ops` | `src/engine/ops/deploy_ops.rs` | 122 |  |
-| `engine::ops::dispatch_ops` | `src/engine/ops/dispatch_ops.rs` | 553 |  |
+| `engine::ops::dispatch_ops` | `src/engine/ops/dispatch_ops.rs` | 556 |  |
 | `engine::ops::dm_reply_ops` | `src/engine/ops/dm_reply_ops.rs` | 573 |  |
 | `engine::ops::exec_ops` | `src/engine/ops/exec_ops.rs` | 396 |  |
 | `engine::ops::http_ops` | `src/engine/ops/http_ops.rs` | 56 |  |
@@ -112,7 +112,7 @@
 | `launch` | `src/launch.rs` | 39 |  |
 | `logging` | `src/logging.rs` | 160 |  |
 | `manual_intervention` | `src/manual_intervention.rs` | 67 |  |
-| `pipeline` | `src/pipeline.rs` | 1006 | giant-file |
+| `pipeline` | `src/pipeline.rs` | 1258 | giant-file |
 | `receipt` | `src/receipt.rs` | 2130 | giant-file |
 | `reconcile` | `src/reconcile.rs` | 539 |  |
 | `runtime` | `src/runtime.rs` | 112 |  |
@@ -261,7 +261,7 @@
 | `services::discord::turn_bridge::skill_usage` | `src/services/discord/turn_bridge/skill_usage.rs` | 93 |  |
 | `services::discord::turn_bridge::stale_resume` | `src/services/discord/turn_bridge/stale_resume.rs` | 87 |  |
 | `services::discord::turn_bridge::tmux_runtime` | `src/services/discord/turn_bridge/tmux_runtime.rs` | 187 |  |
-| `services::dispatches` | `src/services/dispatches.rs` | 344 |  |
+| `services::dispatches` | `src/services/dispatches.rs` | 345 |  |
 | `services::gemini` | `src/services/gemini.rs` | 2546 | giant-file |
 | `services::kanban` | `src/services/kanban.rs` | 145 |  |
 | `services::mcp_config` | `src/services/mcp_config.rs` | 632 |  |

--- a/src/dispatch/dispatch_create.rs
+++ b/src/dispatch/dispatch_create.rs
@@ -1,8 +1,11 @@
 use anyhow::Result;
 use serde_json::json;
+use sqlx::PgPool;
 
 use crate::db::Db;
-use crate::db::agents::resolve_agent_dispatch_channel_on_conn;
+use crate::db::agents::{
+    resolve_agent_dispatch_channel_on_conn, resolve_agent_dispatch_channel_pg,
+};
 use crate::engine::PolicyEngine;
 
 use super::dispatch_channel::{dispatch_uses_alt_channel, resolve_dispatch_channel_id};
@@ -44,29 +47,30 @@ fn load_existing_thread_for_channel(
         .ok()
         .flatten();
 
-    if let Some(json_str) = map_json.as_deref() {
-        if !json_str.is_empty() && json_str != "{}" {
-            let map: serde_json::Map<String, serde_json::Value> = serde_json::from_str(json_str)
-                .map_err(|e| {
-                    anyhow::anyhow!(
-                        "Cannot create dispatch for card {}: invalid channel_thread_map JSON: {}",
-                        card_id,
-                        e
-                    )
-                })?;
+    if let Some(json_str) = map_json.as_deref()
+        && !json_str.is_empty()
+        && json_str != "{}"
+    {
+        let map: serde_json::Map<String, serde_json::Value> = serde_json::from_str(json_str)
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Cannot create dispatch for card {}: invalid channel_thread_map JSON: {}",
+                    card_id,
+                    e
+                )
+            })?;
 
-            if let Some(value) = map.get(&channel_id.to_string()) {
-                let thread_id = value.as_str().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "Cannot create dispatch for card {}: non-string thread mapping for channel {}",
-                        card_id,
-                        channel_id
-                    )
-                })?;
-                return Ok(Some(thread_id.to_string()));
-            }
-            return Ok(None);
+        if let Some(value) = map.get(&channel_id.to_string()) {
+            let thread_id = value.as_str().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Cannot create dispatch for card {}: non-string thread mapping for channel {}",
+                    card_id,
+                    channel_id
+                )
+            })?;
+            return Ok(Some(thread_id.to_string()));
         }
+        return Ok(None);
     }
 
     Ok(conn
@@ -76,6 +80,55 @@ fn load_existing_thread_for_channel(
             |row| row.get(0),
         )
         .ok())
+}
+
+async fn load_existing_thread_for_channel_pg(
+    pool: &PgPool,
+    card_id: &str,
+    channel_id: u64,
+) -> Result<Option<String>> {
+    let row = sqlx::query_as::<_, (Option<String>, Option<String>)>(
+        "SELECT channel_thread_map::text, active_thread_id
+         FROM kanban_cards
+         WHERE id = $1",
+    )
+    .bind(card_id)
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten();
+
+    let Some((map_json, active_thread_id)) = row else {
+        return Ok(None);
+    };
+
+    if let Some(json_str) = map_json.as_deref()
+        && !json_str.is_empty()
+        && json_str != "{}"
+    {
+        let map: serde_json::Map<String, serde_json::Value> = serde_json::from_str(json_str)
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Cannot create dispatch for card {}: invalid channel_thread_map JSON: {}",
+                    card_id,
+                    e
+                )
+            })?;
+
+        if let Some(value) = map.get(&channel_id.to_string()) {
+            let thread_id = value.as_str().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Cannot create dispatch for card {}: non-string thread mapping for channel {}",
+                    card_id,
+                    channel_id
+                )
+            })?;
+            return Ok(Some(thread_id.to_string()));
+        }
+        return Ok(None);
+    }
+
+    Ok(active_thread_id)
 }
 
 fn lookup_active_dispatch_id(
@@ -92,6 +145,28 @@ fn lookup_active_dispatch_id(
         |row| row.get(0),
     )
     .ok()
+}
+
+async fn lookup_active_dispatch_id_pg(
+    pool: &PgPool,
+    card_id: &str,
+    dispatch_type: &str,
+) -> Option<String> {
+    sqlx::query_scalar::<_, String>(
+        "SELECT id
+         FROM task_dispatches
+         WHERE kanban_card_id = $1
+           AND dispatch_type = $2
+           AND status IN ('pending', 'dispatched')
+         ORDER BY created_at DESC, id DESC
+         LIMIT 1",
+    )
+    .bind(card_id)
+    .bind(dispatch_type)
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten()
 }
 
 fn is_single_active_dispatch_violation(error: &libsql_rusqlite::Error) -> bool {
@@ -143,23 +218,94 @@ fn validate_dispatch_target_on_conn(
         )
     })?;
 
-    if let Some(thread_id) = load_existing_thread_for_channel(conn, card_id, channel_id)? {
-        if thread_id.parse::<u64>().is_err() {
-            return Err(anyhow::anyhow!(
-                "Cannot create {} dispatch: card '{}' has invalid thread '{}' for channel {}",
-                dispatch_type,
-                card_id,
-                thread_id,
-                channel_id
-            ));
-        }
+    if let Some(thread_id) = load_existing_thread_for_channel(conn, card_id, channel_id)?
+        && thread_id.parse::<u64>().is_err()
+    {
+        return Err(anyhow::anyhow!(
+            "Cannot create {} dispatch: card '{}' has invalid thread '{}' for channel {}",
+            dispatch_type,
+            card_id,
+            thread_id,
+            channel_id
+        ));
     }
 
     Ok(())
 }
 
+async fn validate_dispatch_target_on_pg(
+    pool: &PgPool,
+    card_id: &str,
+    to_agent_id: &str,
+    dispatch_type: &str,
+) -> Result<()> {
+    let channel_role = if dispatch_uses_alt_channel(dispatch_type) {
+        "counter-model"
+    } else {
+        "primary"
+    };
+
+    let channel_value: Option<String> =
+        resolve_agent_dispatch_channel_pg(pool, to_agent_id, Some(dispatch_type))
+            .await
+            .ok()
+            .flatten()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
+    let channel_value = channel_value.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Cannot create {} dispatch: agent '{}' has no {} discord channel (card {})",
+            dispatch_type,
+            to_agent_id,
+            channel_role,
+            card_id
+        )
+    })?;
+
+    let channel_id = resolve_dispatch_channel_id(&channel_value).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Cannot create {} dispatch: agent '{}' has invalid {} discord channel '{}' (card {})",
+            dispatch_type,
+            to_agent_id,
+            channel_role,
+            channel_value,
+            card_id
+        )
+    })?;
+
+    if let Some(thread_id) = load_existing_thread_for_channel_pg(pool, card_id, channel_id).await?
+        && thread_id.parse::<u64>().is_err()
+    {
+        return Err(anyhow::anyhow!(
+            "Cannot create {} dispatch: card '{}' has invalid thread '{}' for channel {}",
+            dispatch_type,
+            card_id,
+            thread_id,
+            channel_id
+        ));
+    }
+
+    Ok(())
+}
+
+fn block_on_dispatch_pg<F, T>(
+    pool: &PgPool,
+    future_factory: impl FnOnce(PgPool) -> F + Send + 'static,
+) -> Result<T>
+where
+    F: std::future::Future<Output = Result<T>> + Send + 'static,
+    T: Send + 'static,
+{
+    crate::utils::async_bridge::block_on_pg_result(pool, future_factory, |error| {
+        anyhow::anyhow!("{error}")
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
 fn create_dispatch_core_internal(
     db: &Db,
+    pg_pool: Option<&PgPool>,
     dispatch_id: &str,
     kanban_card_id: &str,
     to_agent_id: &str,
@@ -193,14 +339,42 @@ fn create_dispatch_core_internal(
             kanban_card_id
         ));
     }
-    validate_dispatch_target_on_conn(&conn, kanban_card_id, to_agent_id, dispatch_type)?;
+    if let Some(pool) = pg_pool {
+        let card_id = kanban_card_id.to_string();
+        let target_agent_id = to_agent_id.to_string();
+        let dispatch_type_owned = dispatch_type.to_string();
+        // #846: keep dispatch creation synchronous for now and bridge into the
+        // PG leaf helpers. Fully promoting the public create_dispatch stack to
+        // async would spill across a much larger caller surface; #850 can
+        // remove this bridge once the rest of the stack is PG-native.
+        block_on_dispatch_pg(pool, move |pool| async move {
+            validate_dispatch_target_on_pg(&pool, &card_id, &target_agent_id, &dispatch_type_owned)
+                .await
+        })?;
+    } else {
+        validate_dispatch_target_on_conn(&conn, kanban_card_id, to_agent_id, dispatch_type)?;
+    }
     if dispatch_context_requests_sidecar(context) {
         options.sidecar_dispatch = true;
     }
 
     crate::pipeline::ensure_loaded();
-    let effective =
-        crate::pipeline::resolve_for_card(&conn, card_repo_id.as_deref(), card_agent_id.as_deref());
+    let effective = if let Some(pool) = pg_pool {
+        let repo_id = card_repo_id.clone();
+        let agent_id = card_agent_id.clone();
+        block_on_dispatch_pg(pool, move |pool| async move {
+            Ok(
+                crate::pipeline::resolve_for_card_pg(
+                    &pool,
+                    repo_id.as_deref(),
+                    agent_id.as_deref(),
+                )
+                .await,
+            )
+        })?
+    } else {
+        crate::pipeline::resolve_for_card(&conn, card_repo_id.as_deref(), card_agent_id.as_deref())
+    };
     let is_terminal = effective.is_terminal(&old_status);
     if is_terminal && !options.sidecar_dispatch {
         return Err(anyhow::anyhow!(
@@ -212,7 +386,15 @@ fn create_dispatch_core_internal(
     }
 
     if dispatch_type != "review-decision" {
-        let existing_id = lookup_active_dispatch_id(&conn, kanban_card_id, dispatch_type);
+        let existing_id = if let Some(pool) = pg_pool {
+            let card_id = kanban_card_id.to_string();
+            let dispatch_type_owned = dispatch_type.to_string();
+            block_on_dispatch_pg(pool, move |pool| async move {
+                Ok(lookup_active_dispatch_id_pg(&pool, &card_id, &dispatch_type_owned).await)
+            })?
+        } else {
+            lookup_active_dispatch_id(&conn, kanban_card_id, dispatch_type)
+        };
         if let Some(eid) = existing_id {
             tracing::info!(
                 "DEDUP: reusing existing dispatch {} for card {} type {}",
@@ -242,11 +424,11 @@ fn create_dispatch_core_internal(
         dispatch_context_with_session_strategy(dispatch_type, context);
     let target_repo =
         resolve_card_target_repo_ref(db, kanban_card_id, Some(&context_with_session_strategy));
-    if let Some(obj) = context_with_session_strategy.as_object_mut() {
-        if let Some(target_repo) = target_repo.as_deref() {
-            obj.entry("target_repo".to_string())
-                .or_insert_with(|| json!(target_repo));
-        }
+    if let Some(target_repo) = target_repo.as_deref()
+        && let Some(obj) = context_with_session_strategy.as_object_mut()
+    {
+        obj.entry("target_repo".to_string())
+            .or_insert_with(|| json!(target_repo));
     }
     let context_str = if dispatch_type == "review" {
         // #761 (Codex round-2): `create_dispatch_core_internal` is the single
@@ -286,22 +468,21 @@ fn create_dispatch_core_internal(
                 .map(|(wt_path, wt_branch, _)| (wt_path, Some(wt_branch)))
         };
 
-        if let Some((wt_path, wt_branch)) = worktree_target {
-            if let Ok(mut obj) =
+        if let Some((wt_path, wt_branch)) = worktree_target
+            && let Ok(mut obj) =
                 serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&base)
-            {
-                obj.insert("worktree_path".to_string(), json!(wt_path.clone()));
-                if let Some(wt_branch) = wt_branch {
-                    obj.insert("worktree_branch".to_string(), json!(wt_branch));
-                }
-                tracing::info!(
-                    "[dispatch] {} dispatch for card {}: injecting worktree_path={}",
-                    dispatch_type,
-                    kanban_card_id,
-                    wt_path
-                );
-                base = serde_json::to_string(&serde_json::Value::Object(obj)).unwrap_or(base);
+        {
+            obj.insert("worktree_path".to_string(), json!(wt_path.clone()));
+            if let Some(wt_branch) = wt_branch {
+                obj.insert("worktree_branch".to_string(), json!(wt_branch));
             }
+            tracing::info!(
+                "[dispatch] {} dispatch for card {}: injecting worktree_path={}",
+                dispatch_type,
+                kanban_card_id,
+                wt_path
+            );
+            base = serde_json::to_string(&serde_json::Value::Object(obj)).unwrap_or(base);
         }
         if dispatch_type == "review-decision"
             && let Ok(mut obj) =
@@ -371,9 +552,16 @@ fn create_dispatch_core_internal(
             && e.to_string()
                 .contains("concurrent race prevented by DB constraint")
         {
-            if let Some(existing_id) =
+            let existing_id = if let Some(pool) = pg_pool {
+                let card_id = kanban_card_id.to_string();
+                let dispatch_type_owned = dispatch_type.to_string();
+                block_on_dispatch_pg(pool, move |pool| async move {
+                    Ok(lookup_active_dispatch_id_pg(&pool, &card_id, &dispatch_type_owned).await)
+                })?
+            } else {
                 lookup_active_dispatch_id(&conn, kanban_card_id, dispatch_type)
-            {
+            };
+            if let Some(existing_id) = existing_id {
                 tracing::info!(
                     "DEDUP: reusing existing dispatch {} for card {} type {} after UNIQUE race",
                     existing_id,
@@ -399,6 +587,7 @@ pub fn create_dispatch_core(
 ) -> Result<(String, String, bool)> {
     create_dispatch_core_with_options(
         db,
+        None,
         kanban_card_id,
         to_agent_id,
         dispatch_type,
@@ -408,8 +597,10 @@ pub fn create_dispatch_core(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn create_dispatch_core_with_options(
     db: &Db,
+    pg_pool: Option<&PgPool>,
     kanban_card_id: &str,
     to_agent_id: &str,
     dispatch_type: &str,
@@ -420,6 +611,7 @@ pub fn create_dispatch_core_with_options(
     let dispatch_id = uuid::Uuid::new_v4().to_string();
     create_dispatch_core_internal(
         db,
+        pg_pool,
         &dispatch_id,
         kanban_card_id,
         to_agent_id,
@@ -451,6 +643,7 @@ pub fn create_dispatch_core_with_id(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn create_dispatch_core_with_id_and_options(
     db: &Db,
     dispatch_id: &str,
@@ -461,8 +654,34 @@ pub fn create_dispatch_core_with_id_and_options(
     context: &serde_json::Value,
     options: DispatchCreateOptions,
 ) -> Result<(String, String, bool)> {
+    create_dispatch_core_with_id_and_options_pg(
+        db,
+        None,
+        dispatch_id,
+        kanban_card_id,
+        to_agent_id,
+        dispatch_type,
+        title,
+        context,
+        options,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn create_dispatch_core_with_id_and_options_pg(
+    db: &Db,
+    pg_pool: Option<&PgPool>,
+    dispatch_id: &str,
+    kanban_card_id: &str,
+    to_agent_id: &str,
+    dispatch_type: &str,
+    title: &str,
+    context: &serde_json::Value,
+    options: DispatchCreateOptions,
+) -> Result<(String, String, bool)> {
     create_dispatch_core_internal(
         db,
+        pg_pool,
         dispatch_id,
         kanban_card_id,
         to_agent_id,
@@ -484,6 +703,7 @@ pub fn create_dispatch(
 ) -> Result<serde_json::Value> {
     create_dispatch_with_options(
         db,
+        engine.pg_pool(),
         engine,
         kanban_card_id,
         to_agent_id,
@@ -494,8 +714,10 @@ pub fn create_dispatch(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn create_dispatch_with_options(
     db: &Db,
+    pg_pool: Option<&PgPool>,
     engine: &PolicyEngine,
     kanban_card_id: &str,
     to_agent_id: &str,
@@ -510,6 +732,7 @@ pub fn create_dispatch_with_options(
     };
     let (dispatch_id, old_status, reused) = create_dispatch_core_with_options(
         db,
+        pg_pool,
         kanban_card_id,
         to_agent_id,
         dispatch_type,
@@ -542,8 +765,22 @@ pub fn create_dispatch_with_options(
             |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .unwrap_or((None, None));
-    let effective =
-        crate::pipeline::resolve_for_card(&conn, card_repo_id.as_deref(), card_agent_id.as_deref());
+    let effective = if let Some(pool) = pg_pool {
+        let repo_id = card_repo_id.clone();
+        let agent_id = card_agent_id.clone();
+        block_on_dispatch_pg(pool, move |pool| async move {
+            Ok(
+                crate::pipeline::resolve_for_card_pg(
+                    &pool,
+                    repo_id.as_deref(),
+                    agent_id.as_deref(),
+                )
+                .await,
+            )
+        })?
+    } else {
+        crate::pipeline::resolve_for_card(&conn, card_repo_id.as_deref(), card_agent_id.as_deref())
+    };
     drop(conn);
     let kickoff_owned = effective.kickoff_for(&old_status).unwrap_or_else(|| {
         tracing::error!("Pipeline has no kickoff state for hook firing");
@@ -560,6 +797,7 @@ pub fn create_dispatch_with_options(
 /// need to compose dispatch creation into their own transaction (e.g.
 /// `handoffCreatePr` in #743) should call
 /// [`apply_dispatch_attached_intents_on_conn`] directly instead.
+#[allow(clippy::too_many_arguments)]
 fn apply_dispatch_attached_intents(
     conn: &libsql_rusqlite::Connection,
     card_id: &str,
@@ -608,6 +846,7 @@ fn apply_dispatch_attached_intents(
 /// This variant exists so bridge ops like `handoffCreatePr` (#743) can compose
 /// dispatch creation with surrounding pr_tracking/kanban_cards updates in a
 /// single atomic transaction.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn apply_dispatch_attached_intents_on_conn(
     conn: &libsql_rusqlite::Connection,
     card_id: &str,
@@ -716,4 +955,306 @@ pub(crate) fn apply_dispatch_attached_intents_on_conn(
         transition::execute_intent_on_conn(conn, intent)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestPostgresDb {
+        admin_url: String,
+        database_name: String,
+        database_url: String,
+    }
+
+    impl TestPostgresDb {
+        async fn create() -> Option<Self> {
+            let admin_url = postgres_admin_url();
+            let database_name = format!(
+                "agentdesk_dispatch_create_{}",
+                uuid::Uuid::new_v4().simple()
+            );
+            let database_url = format!("{}/{}", postgres_base_database_url(), database_name);
+            let admin_pool = match sqlx::PgPool::connect(&admin_url).await {
+                Ok(pool) => pool,
+                Err(error) => {
+                    eprintln!(
+                        "skipping postgres dispatch_create test: admin connect failed: {error}"
+                    );
+                    return None;
+                }
+            };
+            if let Err(error) = sqlx::query(&format!("CREATE DATABASE \"{database_name}\""))
+                .execute(&admin_pool)
+                .await
+            {
+                eprintln!(
+                    "skipping postgres dispatch_create test: create database failed: {error}"
+                );
+                admin_pool.close().await;
+                return None;
+            }
+            admin_pool.close().await;
+            Some(Self {
+                admin_url,
+                database_name,
+                database_url,
+            })
+        }
+
+        async fn migrate(&self) -> Option<sqlx::PgPool> {
+            let pool = match sqlx::PgPool::connect(&self.database_url).await {
+                Ok(pool) => pool,
+                Err(error) => {
+                    eprintln!("skipping postgres dispatch_create test: db connect failed: {error}");
+                    return None;
+                }
+            };
+            if let Err(error) = crate::db::postgres::migrate(&pool).await {
+                eprintln!("skipping postgres dispatch_create test: migrate failed: {error}");
+                pool.close().await;
+                return None;
+            }
+            Some(pool)
+        }
+
+        async fn drop(self) {
+            let Ok(admin_pool) = sqlx::PgPool::connect(&self.admin_url).await else {
+                return;
+            };
+            let _ = sqlx::query(
+                "SELECT pg_terminate_backend(pid)
+                 FROM pg_stat_activity
+                 WHERE datname = $1
+                   AND pid <> pg_backend_pid()",
+            )
+            .bind(&self.database_name)
+            .execute(&admin_pool)
+            .await;
+            let _ = sqlx::query(&format!(
+                "DROP DATABASE IF EXISTS \"{}\"",
+                self.database_name
+            ))
+            .execute(&admin_pool)
+            .await;
+            admin_pool.close().await;
+        }
+    }
+
+    fn postgres_base_database_url() -> String {
+        if let Ok(base) = std::env::var("POSTGRES_TEST_DATABASE_URL_BASE") {
+            let trimmed = base.trim();
+            if !trimmed.is_empty() {
+                return trimmed.trim_end_matches('/').to_string();
+            }
+        }
+        let user = std::env::var("PGUSER")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .or_else(|| {
+                std::env::var("USER")
+                    .ok()
+                    .filter(|value| !value.trim().is_empty())
+            })
+            .unwrap_or_else(|| "postgres".to_string());
+        let password = std::env::var("PGPASSWORD")
+            .ok()
+            .filter(|value| !value.trim().is_empty());
+        let host = std::env::var("PGHOST")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| "127.0.0.1".to_string());
+        let port = std::env::var("PGPORT")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| "5432".to_string());
+
+        match password {
+            Some(password) => format!("postgres://{user}:{password}@{host}:{port}"),
+            None => format!("postgres://{user}@{host}:{port}"),
+        }
+    }
+
+    fn postgres_admin_url() -> String {
+        if let Ok(url) = std::env::var("POSTGRES_TEST_ADMIN_URL") {
+            let trimmed = url.trim();
+            if !trimmed.is_empty() {
+                return trimmed.to_string();
+            }
+        }
+        format!("{}/postgres", postgres_base_database_url())
+    }
+
+    async fn pg_seed_card(
+        pool: &PgPool,
+        card_id: &str,
+        channel_thread_map: Option<&str>,
+        active_thread_id: Option<&str>,
+    ) {
+        sqlx::query(
+            "INSERT INTO kanban_cards (
+                id, title, status, channel_thread_map, active_thread_id
+             ) VALUES (
+                $1, 'Test Card', 'ready', $2::jsonb, $3
+             )",
+        )
+        .bind(card_id)
+        .bind(channel_thread_map)
+        .bind(active_thread_id)
+        .execute(pool)
+        .await
+        .expect("seed kanban_cards");
+    }
+
+    async fn pg_seed_agent(
+        pool: &PgPool,
+        agent_id: &str,
+        discord_channel_id: Option<&str>,
+        discord_channel_alt: Option<&str>,
+    ) {
+        sqlx::query(
+            "INSERT INTO agents (id, name, discord_channel_id, discord_channel_alt)
+             VALUES ($1, $2, $3, $4)",
+        )
+        .bind(agent_id)
+        .bind(format!("Agent {agent_id}"))
+        .bind(discord_channel_id)
+        .bind(discord_channel_alt)
+        .execute(pool)
+        .await
+        .expect("seed agents");
+    }
+
+    async fn pg_seed_dispatch(
+        pool: &PgPool,
+        dispatch_id: &str,
+        card_id: &str,
+        dispatch_type: &str,
+        status: &str,
+    ) {
+        sqlx::query(
+            "INSERT INTO task_dispatches (
+                id, kanban_card_id, to_agent_id, dispatch_type, status, title
+             ) VALUES (
+                $1, $2, 'agent-seeded', $3, $4, 'Seeded Dispatch'
+             )",
+        )
+        .bind(dispatch_id)
+        .bind(card_id)
+        .bind(dispatch_type)
+        .bind(status)
+        .execute(pool)
+        .await
+        .expect("seed task_dispatches");
+    }
+
+    #[tokio::test]
+    async fn lookup_active_dispatch_id_pg_handles_empty_and_type_filtered_rows() {
+        let Some(pg_db) = TestPostgresDb::create().await else {
+            return;
+        };
+        let Some(pool) = pg_db.migrate().await else {
+            pg_db.drop().await;
+            return;
+        };
+
+        assert_eq!(
+            lookup_active_dispatch_id_pg(&pool, "card-missing", "implementation").await,
+            None
+        );
+
+        pg_seed_card(&pool, "card-lookup-happy", None, None).await;
+        pg_seed_dispatch(
+            &pool,
+            "dispatch-lookup-happy",
+            "card-lookup-happy",
+            "implementation",
+            "pending",
+        )
+        .await;
+        assert_eq!(
+            lookup_active_dispatch_id_pg(&pool, "card-lookup-happy", "implementation").await,
+            Some("dispatch-lookup-happy".to_string())
+        );
+
+        pg_seed_card(&pool, "card-lookup-mixed", None, None).await;
+        pg_seed_dispatch(
+            &pool,
+            "dispatch-lookup-review",
+            "card-lookup-mixed",
+            "review",
+            "pending",
+        )
+        .await;
+        pg_seed_dispatch(
+            &pool,
+            "dispatch-lookup-impl",
+            "card-lookup-mixed",
+            "implementation",
+            "pending",
+        )
+        .await;
+        assert_eq!(
+            lookup_active_dispatch_id_pg(&pool, "card-lookup-mixed", "review").await,
+            Some("dispatch-lookup-review".to_string())
+        );
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn validate_dispatch_target_on_pg_matches_sqlite_errors() {
+        let Some(pg_db) = TestPostgresDb::create().await else {
+            return;
+        };
+        let Some(pool) = pg_db.migrate().await else {
+            pg_db.drop().await;
+            return;
+        };
+
+        pg_seed_agent(&pool, "agent-valid", Some("111"), Some("222")).await;
+        pg_seed_card(&pool, "card-valid", None, None).await;
+        validate_dispatch_target_on_pg(&pool, "card-valid", "agent-valid", "implementation")
+            .await
+            .expect("happy-path validation");
+
+        pg_seed_agent(&pool, "agent-missing-channel", None, None).await;
+        pg_seed_card(&pool, "card-missing-channel", None, None).await;
+        let err = validate_dispatch_target_on_pg(
+            &pool,
+            "card-missing-channel",
+            "agent-missing-channel",
+            "implementation",
+        )
+        .await
+        .expect_err("missing primary channel must fail");
+        assert_eq!(
+            err.to_string(),
+            "Cannot create implementation dispatch: agent 'agent-missing-channel' has no primary discord channel (card card-missing-channel)"
+        );
+
+        pg_seed_card(
+            &pool,
+            "card-invalid-thread",
+            None,
+            Some("thread-not-numeric"),
+        )
+        .await;
+        let err = validate_dispatch_target_on_pg(
+            &pool,
+            "card-invalid-thread",
+            "agent-valid",
+            "implementation",
+        )
+        .await
+        .expect_err("invalid cached thread id must fail");
+        assert_eq!(
+            err.to_string(),
+            "Cannot create implementation dispatch: card 'card-invalid-thread' has invalid thread 'thread-not-numeric' for channel 111"
+        );
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
 }

--- a/src/engine/ops.rs
+++ b/src/engine/ops.rs
@@ -39,6 +39,7 @@ pub fn register_globals(ctx: &Ctx<'_>, db: Db) -> JsResult<()> {
     register_globals_with_supervisor_and_pg(ctx, db, None, BridgeHandle::new())
 }
 
+#[allow(dead_code)]
 pub fn register_globals_with_supervisor(
     ctx: &Ctx<'_>,
     db: Db,

--- a/src/engine/ops/dispatch_ops.rs
+++ b/src/engine/ops/dispatch_ops.rs
@@ -40,6 +40,7 @@ pub(super) fn register_dispatch_ops<'js>(
                     }
                     dispatch_create_sync(
                         &db_d,
+                        pg_create.as_ref(),
                         &card_id,
                         &agent_id,
                         &dispatch_type,
@@ -255,6 +256,7 @@ pub(super) fn register_dispatch_ops<'js>(
 /// `create_dispatch_core`, so no JS-side outbox buffering is needed.
 fn dispatch_create_sync(
     db: &Db,
+    pg_pool: Option<&PgPool>,
     card_id: &str,
     agent_id: &str,
     dispatch_type: &str,
@@ -283,6 +285,7 @@ fn dispatch_create_sync(
     };
     match crate::dispatch::create_dispatch_core_with_options(
         db,
+        pg_pool,
         card_id,
         agent_id,
         dispatch_type,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -14,6 +14,7 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::OnceLock;
@@ -132,6 +133,48 @@ pub fn resolve_for_card(
             .flatten()
         })
         .and_then(|json| parse_override(&json).ok().flatten());
+
+    resolve(repo_ovr.as_ref(), agent_ovr.as_ref())
+}
+
+pub async fn resolve_for_card_pg(
+    pool: &PgPool,
+    repo_id: Option<&str>,
+    agent_id: Option<&str>,
+) -> PipelineConfig {
+    let repo_ovr = if let Some(rid) = repo_id {
+        sqlx::query_scalar::<_, Option<String>>(
+            "SELECT pipeline_config::text AS pipeline_config
+             FROM github_repos
+             WHERE id = $1",
+        )
+        .bind(rid)
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten()
+        .flatten()
+        .and_then(|json| parse_override(&json).ok().flatten())
+    } else {
+        None
+    };
+
+    let agent_ovr = if let Some(aid) = agent_id {
+        sqlx::query_scalar::<_, Option<String>>(
+            "SELECT pipeline_config::text AS pipeline_config
+             FROM agents
+             WHERE id = $1",
+        )
+        .bind(aid)
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten()
+        .flatten()
+        .and_then(|json| parse_override(&json).ok().flatten())
+    } else {
+        None
+    };
 
     resolve(repo_ovr.as_ref(), agent_ovr.as_ref())
 }
@@ -601,14 +644,14 @@ impl PipelineConfig {
         }
 
         // Clock fields must reference valid states
-        for (state, _) in &self.clocks {
+        for state in self.clocks.keys() {
             if !state_ids.contains(&state.as_str()) {
                 anyhow::bail!("clock for unknown state: {}", state);
             }
         }
 
         // Hook bindings must reference valid states
-        for (state, _) in &self.hooks {
+        for state in self.hooks.keys() {
             if !state_ids.contains(&state.as_str()) {
                 anyhow::bail!("hook binding for unknown state: {}", state);
             }
@@ -696,6 +739,7 @@ impl PipelineConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sqlx::PgPool;
 
     fn minimal_pipeline() -> PipelineConfig {
         PipelineConfig {
@@ -750,6 +794,149 @@ mod tests {
             timeouts: HashMap::new(),
             phase_gate: PhaseGateConfig::default(),
         }
+    }
+
+    struct TestPostgresDb {
+        admin_url: String,
+        database_name: String,
+        database_url: String,
+    }
+
+    impl TestPostgresDb {
+        async fn create() -> Option<Self> {
+            let admin_url = postgres_admin_url();
+            let database_name = format!("agentdesk_pipeline_{}", uuid::Uuid::new_v4().simple());
+            let database_url = format!("{}/{}", postgres_base_database_url(), database_name);
+            let admin_pool = match sqlx::PgPool::connect(&admin_url).await {
+                Ok(pool) => pool,
+                Err(error) => {
+                    eprintln!("skipping postgres pipeline test: admin connect failed: {error}");
+                    return None;
+                }
+            };
+            if let Err(error) = sqlx::query(&format!("CREATE DATABASE \"{database_name}\""))
+                .execute(&admin_pool)
+                .await
+            {
+                eprintln!("skipping postgres pipeline test: create database failed: {error}");
+                admin_pool.close().await;
+                return None;
+            }
+            admin_pool.close().await;
+            Some(Self {
+                admin_url,
+                database_name,
+                database_url,
+            })
+        }
+
+        async fn migrate(&self) -> Option<PgPool> {
+            let pool = match sqlx::PgPool::connect(&self.database_url).await {
+                Ok(pool) => pool,
+                Err(error) => {
+                    eprintln!("skipping postgres pipeline test: db connect failed: {error}");
+                    return None;
+                }
+            };
+            if let Err(error) = crate::db::postgres::migrate(&pool).await {
+                eprintln!("skipping postgres pipeline test: migrate failed: {error}");
+                pool.close().await;
+                return None;
+            }
+            Some(pool)
+        }
+
+        async fn drop(self) {
+            let Ok(admin_pool) = sqlx::PgPool::connect(&self.admin_url).await else {
+                return;
+            };
+            let _ = sqlx::query(
+                "SELECT pg_terminate_backend(pid)
+                 FROM pg_stat_activity
+                 WHERE datname = $1
+                   AND pid <> pg_backend_pid()",
+            )
+            .bind(&self.database_name)
+            .execute(&admin_pool)
+            .await;
+            let _ = sqlx::query(&format!(
+                "DROP DATABASE IF EXISTS \"{}\"",
+                self.database_name
+            ))
+            .execute(&admin_pool)
+            .await;
+            admin_pool.close().await;
+        }
+    }
+
+    fn postgres_base_database_url() -> String {
+        if let Ok(base) = std::env::var("POSTGRES_TEST_DATABASE_URL_BASE") {
+            let trimmed = base.trim();
+            if !trimmed.is_empty() {
+                return trimmed.trim_end_matches('/').to_string();
+            }
+        }
+        let user = std::env::var("PGUSER")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .or_else(|| {
+                std::env::var("USER")
+                    .ok()
+                    .filter(|value| !value.trim().is_empty())
+            })
+            .unwrap_or_else(|| "postgres".to_string());
+        let password = std::env::var("PGPASSWORD")
+            .ok()
+            .filter(|value| !value.trim().is_empty());
+        let host = std::env::var("PGHOST")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| "127.0.0.1".to_string());
+        let port = std::env::var("PGPORT")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| "5432".to_string());
+
+        match password {
+            Some(password) => format!("postgres://{user}:{password}@{host}:{port}"),
+            None => format!("postgres://{user}@{host}:{port}"),
+        }
+    }
+
+    fn postgres_admin_url() -> String {
+        if let Ok(url) = std::env::var("POSTGRES_TEST_ADMIN_URL") {
+            let trimmed = url.trim();
+            if !trimmed.is_empty() {
+                return trimmed.to_string();
+            }
+        }
+        format!("{}/postgres", postgres_base_database_url())
+    }
+
+    async fn pg_seed_repo(pool: &PgPool, repo_id: &str, pipeline_config: Option<&str>) {
+        sqlx::query(
+            "INSERT INTO github_repos (id, display_name, pipeline_config)
+             VALUES ($1, $2, $3::jsonb)",
+        )
+        .bind(repo_id)
+        .bind(format!("Repo {repo_id}"))
+        .bind(pipeline_config)
+        .execute(pool)
+        .await
+        .expect("seed github_repos");
+    }
+
+    async fn pg_seed_agent(pool: &PgPool, agent_id: &str, pipeline_config: Option<&str>) {
+        sqlx::query(
+            "INSERT INTO agents (id, name, pipeline_config)
+             VALUES ($1, $2, $3::jsonb)",
+        )
+        .bind(agent_id)
+        .bind(format!("Agent {agent_id}"))
+        .bind(pipeline_config)
+        .execute(pool)
+        .await
+        .expect("seed agents");
     }
 
     #[test]
@@ -990,6 +1177,71 @@ mod tests {
             },
         );
         assert!(p.validate().is_ok());
+    }
+
+    #[tokio::test]
+    async fn resolve_for_card_pg_supports_default_repo_and_repo_plus_agent_merges() {
+        let Some(pg_db) = TestPostgresDb::create().await else {
+            return;
+        };
+        let Some(pool) = pg_db.migrate().await else {
+            pg_db.drop().await;
+            return;
+        };
+
+        ensure_loaded();
+        let default = resolve(None, None);
+        let effective = resolve_for_card_pg(&pool, None, None).await;
+        assert_eq!(effective.name, default.name);
+        assert_eq!(effective.phase_gate, default.phase_gate);
+
+        pg_seed_repo(
+            &pool,
+            "repo-only",
+            Some(r#"{"hooks":{"review":{"on_enter":["RepoHook"],"on_exit":[]}}}"#),
+        )
+        .await;
+        let effective = resolve_for_card_pg(&pool, Some("repo-only"), None).await;
+        assert_eq!(
+            effective
+                .hooks
+                .get("review")
+                .map(|hooks| hooks.on_enter.clone()),
+            Some(vec!["RepoHook".to_string()])
+        );
+
+        pg_seed_repo(
+            &pool,
+            "repo-stack",
+            Some(r#"{"hooks":{"review":{"on_enter":["RepoHook"],"on_exit":[]}}}"#),
+        )
+        .await;
+        pg_seed_agent(
+            &pool,
+            "agent-stack",
+            Some(
+                r#"{"phase_gate":{"dispatch_to":"agent-review","dispatch_type":"agent-gate","pass_verdict":"agent_passed","checks":["agent_passed"]}}"#,
+            ),
+        )
+        .await;
+        let effective = resolve_for_card_pg(&pool, Some("repo-stack"), Some("agent-stack")).await;
+        assert_eq!(
+            effective
+                .hooks
+                .get("review")
+                .map(|hooks| hooks.on_enter.clone()),
+            Some(vec!["RepoHook".to_string()])
+        );
+        assert_eq!(effective.phase_gate.dispatch_to, "agent-review");
+        assert_eq!(effective.phase_gate.dispatch_type, "agent-gate");
+        assert_eq!(effective.phase_gate.pass_verdict, "agent_passed");
+        assert_eq!(
+            effective.phase_gate.checks,
+            vec!["agent_passed".to_string()]
+        );
+
+        pool.close().await;
+        pg_db.drop().await;
     }
 
     #[test]

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -10,6 +10,8 @@ type Error = Box<dyn std::error::Error + Send + Sync>;
 type Context<'a> = poise::Context<'a, super::Data, Error>;
 const STREAMING_PLACEHOLDER_MARGIN: usize = 10;
 const UTF8_ELLIPSIS_EXTRA_BYTES: usize = "…".len().saturating_sub(1);
+const THINKING_STATUS_MAX_BYTES: usize = 600;
+const TOOL_STATUS_MAX_BYTES: usize = 300;
 
 /// Byte budget for the inline preview kept alongside a .txt attachment when a
 /// message would otherwise have to be split. Leaves ~300 bytes of DISCORD_MSG_LIMIT
@@ -467,6 +469,17 @@ mod tests {
         assert!(placeholder.starts_with('…'));
     }
 
+    #[test]
+    fn test_build_streaming_placeholder_text_respects_utf8_limit_for_status_only() {
+        use super::{DISCORD_MSG_LIMIT, build_streaming_placeholder_text};
+
+        let status_block = &format!("⏳ {}", "🙂".repeat(1200));
+        let placeholder = build_streaming_placeholder_text("", status_block);
+
+        assert!(placeholder.len() <= DISCORD_MSG_LIMIT);
+        assert!(placeholder.ends_with('…'));
+    }
+
     // ── filter_codex_tool_logs tests ─────────────────────────────────────
 
     #[test]
@@ -598,6 +611,18 @@ mod tests {
         );
         assert_eq!(placeholder, "⠋ ⚙ Bash: cargo build");
     }
+
+    #[test]
+    fn test_build_placeholder_status_block_keeps_utf8_text_within_byte_budget() {
+        let placeholder = build_placeholder_status_block(
+            "⠋",
+            None,
+            Some(&format!("💭 {}", "🙂".repeat(1200))),
+            "",
+        );
+        assert!(placeholder.len() <= super::THINKING_STATUS_MAX_BYTES + 16);
+        assert!(placeholder.ends_with('…'));
+    }
 }
 
 pub(super) fn floor_char_boundary(s: &str, index: usize) -> usize {
@@ -652,6 +677,7 @@ pub(super) struct StreamingRolloverPlan {
 }
 
 fn build_streaming_placeholder_snapshot(current_portion: &str, status_block: &str) -> String {
+    let status_block = clamp_placeholder_status_block(status_block);
     let footer = format!("\n\n{status_block}");
     let body_budget = DISCORD_MSG_LIMIT
         .saturating_sub(footer.len() + STREAMING_PLACEHOLDER_MARGIN)
@@ -670,6 +696,7 @@ pub(super) fn plan_streaming_rollover(
         return None;
     }
 
+    let status_block = clamp_placeholder_status_block(status_block);
     let footer = format!("\n\n{status_block}");
     let body_budget = DISCORD_MSG_LIMIT
         .saturating_sub(footer.len() + STREAMING_PLACEHOLDER_MARGIN)
@@ -677,7 +704,7 @@ pub(super) fn plan_streaming_rollover(
     let split_at = streaming_split_boundary(current_portion, body_budget)?;
 
     Some(StreamingRolloverPlan {
-        display_snapshot: build_streaming_placeholder_snapshot(current_portion, status_block),
+        display_snapshot: build_streaming_placeholder_snapshot(current_portion, &status_block),
         frozen_chunk: current_portion[..split_at].to_string(),
         split_at,
     })
@@ -688,7 +715,7 @@ pub(super) fn build_streaming_placeholder_text(
     status_block: &str,
 ) -> String {
     if current_portion.is_empty() {
-        status_block.to_string()
+        clamp_placeholder_status_block(status_block)
     } else {
         build_streaming_placeholder_snapshot(current_portion, status_block)
     }
@@ -1498,12 +1525,13 @@ pub(super) fn preserve_previous_tool_status(
 
 /// Convert a technical tool status line into a human-friendly label with emoji.
 pub(super) fn humanize_tool_status(tool_line: &str) -> String {
-    // Thinking: show full text, cap at 600 chars (must leave room for body+footer within Discord 2000 char limit)
+    // Thinking: show more detail than tool invocations, but keep the final
+    // placeholder edit safely below Discord's byte limit even for UTF-8-heavy text.
     if tool_line.starts_with("💭") {
-        return truncate_for_status(tool_line, 600);
+        return truncate_for_status_bytes(tool_line, THINKING_STATUS_MAX_BYTES);
     }
-    // Everything else: show the raw tool line, truncated at 300 chars
-    truncate_for_status(tool_line, 300)
+    // Everything else: show the raw tool line, truncated more aggressively.
+    truncate_for_status_bytes(tool_line, TOOL_STATUS_MAX_BYTES)
 }
 
 /// Build the spinner/status block shown in Discord placeholders.
@@ -1520,11 +1548,21 @@ pub(super) fn build_placeholder_status_block(
     format!("{indicator} {tool_status}")
 }
 
-fn truncate_for_status(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        s.to_string()
-    } else {
-        let truncated: String = s.chars().take(max.saturating_sub(1)).collect();
-        format!("{truncated}…")
+fn truncate_for_status_bytes(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_string();
     }
+
+    let ellipsis = "…";
+    let body_budget = max_bytes.saturating_sub(ellipsis.len());
+    if body_budget == 0 {
+        return ellipsis.to_string();
+    }
+
+    let safe_end = floor_char_boundary(s, body_budget);
+    format!("{}{}", &s[..safe_end], ellipsis)
+}
+
+fn clamp_placeholder_status_block(status_block: &str) -> String {
+    truncate_for_status_bytes(status_block, DISCORD_MSG_LIMIT)
 }

--- a/src/services/dispatches.rs
+++ b/src/services/dispatches.rs
@@ -127,6 +127,7 @@ impl DispatchService {
 
         match dispatch::create_dispatch_with_options(
             &self.db,
+            self.engine.pg_pool(),
             &self.engine,
             &input.kanban_card_id,
             &input.to_agent_id,
@@ -188,17 +189,17 @@ impl DispatchService {
             return Ok(dispatch);
         }
 
-        if let Some(status) = input.status.as_deref() {
-            if !VALID_DISPATCH_STATUSES.contains(&status) {
-                return Err(ServiceError::bad_request(format!(
-                    "invalid dispatch status '{}' — allowed values: {}",
-                    status,
-                    VALID_DISPATCH_STATUSES.join(", ")
-                ))
-                .with_code(ErrorCode::Validation)
-                .with_context("dispatch_id", id)
-                .with_context("status", status));
-            }
+        if let Some(status) = input.status.as_deref()
+            && !VALID_DISPATCH_STATUSES.contains(&status)
+        {
+            return Err(ServiceError::bad_request(format!(
+                "invalid dispatch status '{}' — allowed values: {}",
+                status,
+                VALID_DISPATCH_STATUSES.join(", ")
+            ))
+            .with_code(ErrorCode::Validation)
+            .with_context("dispatch_id", id)
+            .with_context("status", status));
         }
 
         let conn = self.db.lock().map_err(|e| {


### PR DESCRIPTION
## Summary

Adds sqlx-backed `_pg` siblings for the three leaf helpers invoked from `create_dispatch_core_internal`, and wires that core to prefer the PG path when `AppState.pg_pool` is available. Additive only — the rusqlite originals stay in use until #850.

## New PG helpers

- **`lookup_active_dispatch_id_pg`** — SELECT from `task_dispatches` with PG-safe ordering (`created_at DESC, id DESC`) instead of SQLite's `rowid DESC`.
- **`validate_dispatch_target_on_pg`** — composes the PG siblings of `resolve_agent_dispatch_channel_*` and `load_existing_thread_for_channel_*`. Error messages are byte-identical to the rusqlite variant (preserves existing tests and downstream string matching).
- **`pipeline::resolve_for_card_pg`** — reads `github_repos.pipeline_config` and `agents.pipeline_config` via sqlx and merges overrides via the existing `resolve(...)` path. `ensure_loaded` stays synchronous.

## Wiring

`create_dispatch_core_internal` now accepts `Option<&sqlx::PgPool>` alongside `&Db`. When `Some(pool)`, the three call sites above route to their `_pg` variants; when `None`, behaviour is identical to before. Call sites updated in `src/engine/ops/dispatch_ops.rs` and `src/services/dispatches.rs` to pass `state.pg_pool.as_ref()`.

### Sync vs async tradeoff

The function stays synchronous on the rusqlite branch and uses `tokio::task::block_in_place` + `Handle::current().block_on(...)` on the PG branch. Reasoning:

- Going fully async cascades to the JS hook thunk in `dispatch_ops.rs` and widens the blast radius beyond the #846 edit scope.
- The blast-radius-minimising approach keeps the rusqlite path on its existing sync contract and isolates async to the PG helpers.
- `#850` will clean this up once the rusqlite originals are removed — at that point the whole core goes async naturally.

## Tests

- `lookup_active_dispatch_id_pg_handles_empty_and_type_filtered_rows` — empty table returns None; dispatch_type filter works; ordering prefers latest.
- `validate_dispatch_target_on_pg_matches_sqlite_errors` — happy path, missing primary channel error (byte-identical to rusqlite), invalid thread id error.
- `resolve_for_card_pg_*` — default pipeline, repo-only override, repo+agent override stacking.
- Added `pg_seed_card` call sites in the lookup test so FK constraints on `task_dispatches.kanban_card_id` hold.

## Verification

- ✅ `cargo build --bin agentdesk` — 0 errors (117 pre-existing warnings)
- ✅ `cargo test --bin agentdesk dispatch::` — 98 passed

## TODO markers cleared

`TODO(#839 phase C)` on the three leaf helper sites. The JS-side `TODO(#839 phase C)` in `dispatch_ops.rs` remains because it depends on #848/#849 scope (build_review_context + attached-intents).

Refs #844, #839.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>