### PR TITLE
fix(dashboard): keep pipeline events in visual editor overrides

### DIFF
--- a/dashboard/src/components/agent-manager/pipeline-visual-editor-model.ts
+++ b/dashboard/src/components/agent-manager/pipeline-visual-editor-model.ts
@@ -69,6 +69,7 @@ const VISUAL_OVERRIDE_KEYS = new Set([
   "transitions",
   "gates",
   "hooks",
+  "events",
   "clocks",
   "timeouts",
   "phase_gate",
@@ -96,7 +97,7 @@ export function clonePipelineConfig(pipeline: PipelineConfigFull): PipelineConfi
       ]),
     ),
     events: Object.fromEntries(
-      Object.entries(pipeline.events).map(([key, names]) => [key, [...names]]),
+      Object.entries(pipeline.events).map(([key, hooks]) => [key, [...hooks]]),
     ),
     clocks: Object.fromEntries(
       Object.entries(pipeline.clocks).map(([key, clock]) => [key, { ...clock }]),
@@ -257,6 +258,9 @@ export function buildOverridePayload(
           on_exit: [...hook.on_exit],
         },
       ]),
+    ),
+    events: Object.fromEntries(
+      Object.entries(pipeline.events).map(([key, hooks]) => [key, [...hooks]]),
     ),
     clocks: Object.fromEntries(
       Object.entries(pipeline.clocks).map(([key, clock]) => [key, { ...clock }]),


### PR DESCRIPTION
## Summary
- keep `events` in the visual override key set for `dashboard/src/components/agent-manager/pipeline-visual-editor-model.ts`
- include `pipeline.events` in `buildOverridePayload` so editor overrides preserve event hooks
- align the remaining event-array clone with the shape already partially restored on `main`

## Why
`origin/main` already restored part of the pipeline event cloning in `#860`, but the dashboard visual editor still drops `events` from override payloads. This small follow-up keeps the pipeline model consistent for dashboard builds and editor saves.

## Verification
- `cd dashboard && npm run build`
