### PR TITLE
test(#821): lock cancel/terminal/done/reactivate invariants with regression tests

### DIFF
--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -519,6 +519,10 @@ var autoQueue = {
       "AND NOT EXISTS (" +
       "  SELECT 1 FROM auto_queue_entries e " +
       "  WHERE e.run_id = r.id AND e.status IN ('pending', 'dispatched')" +
+      ") " +
+      "AND NOT EXISTS (" +
+      "  SELECT 1 FROM auto_queue_entries e " +
+      "  WHERE e.run_id = r.id AND e.status = 'user_cancelled'" +
       ")",
       []
     );
@@ -802,6 +806,16 @@ function finalizeRunWithoutPhaseGate(runId) {
 
   if (runHasBlockingPhaseGate(runId)) return false;
   if (remainingRunnableEntryCount(runId) > 0) return false;
+  // #815 P1: `user_cancelled` entries are operator-held terminal state.
+  // They are intentionally non-runnable, but they must still block the
+  // tick-side backstop from auto-completing the run; otherwise the next
+  // minute tick would strand a user-stopped run in `completed`.
+  if (runHasUserCancelledEntry(runId)) {
+    autoQueueLog("info", "Deferring finalize for run " + runId + " — user_cancelled entry still present", {
+      run_id: runId
+    });
+    return false;
+  }
   // Phase-gate race guard: the main engine's `onCardTerminal` may still be
   // in the middle of creating gate dispatches. Respect the grace window so
   // we never mark a run completed before phase gates get registered.
@@ -899,6 +913,15 @@ function remainingRunnableEntryCount(runId, phase) {
   }
   var rows = agentdesk.db.query(sql, params);
   return (rows.length > 0) ? rows[0].cnt : 0;
+}
+
+function runHasUserCancelledEntry(runId) {
+  var rows = agentdesk.db.query(
+    "SELECT COUNT(*) as cnt FROM auto_queue_entries " +
+    "WHERE run_id = ? AND status = 'user_cancelled'",
+    [runId]
+  );
+  return (rows.length > 0) && rows[0].cnt > 0;
 }
 
 function _deployGateTitle(phase) {

--- a/src/db/auto_queue.rs
+++ b/src/db/auto_queue.rs
@@ -5712,4 +5712,122 @@ mod tests {
         assert_eq!(phase_two_count, 0);
         assert_eq!(phase_three_count, 1);
     }
+
+    /// #821 (4): `done` entries must not reactivate without an explicit
+    /// operator rerun. The shared `update_entry_status_on_conn` helper gates
+    /// `done -> dispatched` behind the `pmd_reopen` / `rereview_dispatch`
+    /// trigger sources (see `is_allowed_entry_transition`), and `done ->
+    /// pending` is simply not in the allowlist. The only authorized entry
+    /// point that can legally flip a `done` row back to `dispatched` is
+    /// `reactivate_done_entry_on_conn` itself, invoked from the PMD reopen
+    /// route in `src/server/routes/kanban.rs` (the `pmd_reopen` /
+    /// `rereview_dispatch` call sites). The auto-queue tick and the
+    /// kanban-rules / auto-queue policy hooks do NOT call it.
+    ///
+    /// Authorized callers of `reactivate_done_entry_on_conn` at the time of
+    /// writing (audit via grep — update this list if call sites move):
+    ///   - `src/server/routes/kanban.rs` (PMD reopen fall-through from a
+    ///     failed `update_entry_status_on_conn(done -> dispatched)`).
+    ///   - this test module (regression coverage).
+    ///
+    /// The test below locks the invariant by proving the tick-style trigger
+    /// sources cannot sneak through: `auto_queue_tick` and `tick` attempts
+    /// on a `done` entry are rejected as invalid transitions, and a follow-up
+    /// explicit `reactivate_done_entry_on_conn` call from the operator path
+    /// succeeds. If anyone adds a non-operator caller of
+    /// `reactivate_done_entry_on_conn`, the grep audit above should flag it.
+    #[test]
+    fn done_entry_cannot_reactivate_without_explicit_operator_rerun() {
+        let conn = setup_conn();
+        conn.execute(
+            "INSERT INTO auto_queue_runs (id, repo, agent_id, status)
+             VALUES ('run-821-rea', 'repo-1', 'agent-1', 'completed')",
+            [],
+        )
+        .expect("seed completed run");
+        conn.execute(
+            "INSERT INTO auto_queue_entries (
+                 id, run_id, kanban_card_id, agent_id, status, thread_group, completed_at
+             ) VALUES (
+                 'entry-821-rea', 'run-821-rea', 'card-821-rea', 'agent-1',
+                 'done', 0, datetime('now')
+             )",
+            [],
+        )
+        .expect("seed done entry");
+
+        // Any non-operator trigger source attempting `done -> dispatched` via
+        // the shared helper must be rejected. This is what protects against
+        // the tick or a policy hook silently re-opening completed work.
+        for bogus_source in &[
+            "auto_queue_tick",
+            "tick",
+            "policy_hook",
+            "onDispatchCompleted",
+            "review_automation",
+        ] {
+            let err = update_entry_status_on_conn(
+                &conn,
+                "entry-821-rea",
+                ENTRY_STATUS_DISPATCHED,
+                bogus_source,
+                &EntryStatusUpdateOptions {
+                    dispatch_id: Some("dispatch-sneak".to_string()),
+                    slot_index: Some(0),
+                },
+            )
+            .expect_err("non-operator source must not resurrect a done entry");
+            assert!(
+                matches!(err, EntryStatusUpdateError::InvalidTransition { .. }),
+                "source `{bogus_source}` unexpectedly permitted done -> dispatched (got {:?})",
+                err
+            );
+        }
+
+        // `done -> pending` is not in the transition allowlist at all — no
+        // trigger source may perform it via the shared helper.
+        let err = update_entry_status_on_conn(
+            &conn,
+            "entry-821-rea",
+            ENTRY_STATUS_PENDING,
+            "pmd_reopen",
+            &EntryStatusUpdateOptions::default(),
+        )
+        .expect_err("done -> pending must not be a valid transition at all");
+        assert!(matches!(
+            err,
+            EntryStatusUpdateError::InvalidTransition { .. }
+        ));
+
+        // Sanity: the entry is still `done` and the run is still `completed`.
+        let entry_status: String = conn
+            .query_row(
+                "SELECT status FROM auto_queue_entries WHERE id = 'entry-821-rea'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("entry row");
+        assert_eq!(entry_status, "done");
+        let run_status: String = conn
+            .query_row(
+                "SELECT status FROM auto_queue_runs WHERE id = 'run-821-rea'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("run row");
+        assert_eq!(run_status, "completed");
+
+        // Only the explicit operator-rerun entry point (authorized caller in
+        // `server/routes/kanban.rs`) can reactivate a done entry.
+        let restored = reactivate_done_entry_on_conn(
+            &conn,
+            "entry-821-rea",
+            "pmd_reopen",
+            &EntryStatusUpdateOptions::default(),
+        )
+        .expect("operator-authorized reactivate must succeed");
+        assert!(restored.changed);
+        assert_eq!(restored.from_status, ENTRY_STATUS_DONE);
+        assert_eq!(restored.to_status, ENTRY_STATUS_DISPATCHED);
+    }
 }

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -4973,4 +4973,164 @@ mod tests {
         );
         assert_eq!(dispatch["result"]["decision"], "accept");
     }
+
+    // ── #821 invariants: cancel / terminal / done / reactivate ───────────
+    //
+    // These tests lock the runtime invariants protected by #815 (user cancel
+    // intent preservation) and related prior work. They are intentionally
+    // narrow regression guards that can be audited quickly rather than full
+    // integration tests. See `docs/FEATURES.md` for the broader state flow.
+
+    /// #821 (1): A user stop (reason `turn_bridge_cancelled`) must move the
+    /// linked auto-queue entry to `user_cancelled`, NOT reset it to `pending`.
+    /// The next auto-queue tick query (active run + pending entry) must not
+    /// find this entry, so no re-dispatch can fire.
+    #[test]
+    fn user_stop_does_not_redispatch() {
+        let db = test_db();
+        seed_user_cancel_fixture(&db, "card-821-nore", "dispatch-821-nore", "entry-821-nore");
+
+        let conn = db.separate_conn().unwrap();
+        cancel_dispatch_and_reset_auto_queue_on_conn(
+            &conn,
+            "dispatch-821-nore",
+            Some("turn_bridge_cancelled"),
+        )
+        .unwrap();
+
+        let entry_status: String = conn
+            .query_row(
+                "SELECT status FROM auto_queue_entries WHERE id = 'entry-821-nore'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            entry_status, "user_cancelled",
+            "user stop must mark the entry non-dispatchable"
+        );
+
+        // Model the auto-queue tick's pick query: `active` run + `pending`
+        // entry. A re-dispatch would require the entry to surface here.
+        let pending_visible: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM auto_queue_entries e \
+                 JOIN auto_queue_runs r ON e.run_id = r.id \
+                 WHERE r.status = 'active' AND e.status = 'pending' \
+                   AND e.id = 'entry-821-nore'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            pending_visible, 0,
+            "user-cancelled entries must not be seen by the next auto-queue tick"
+        );
+        assert!(
+            !crate::db::auto_queue::is_dispatchable_entry_status("user_cancelled"),
+            "user_cancelled must be a non-dispatchable terminal status"
+        );
+    }
+
+    /// #821 (2): A user stop must leave the card's kanban status as-is
+    /// (`in_progress`). The cancel path must NOT force-transition the card
+    /// into `done` — that would bypass review and strand the user's explicit
+    /// stop as a silent auto-completion.
+    #[test]
+    fn user_stop_does_not_mark_done() {
+        let db = test_db();
+        seed_user_cancel_fixture(&db, "card-821-nd", "dispatch-821-nd", "entry-821-nd");
+
+        let conn = db.separate_conn().unwrap();
+        cancel_dispatch_and_reset_auto_queue_on_conn(
+            &conn,
+            "dispatch-821-nd",
+            Some("turn_bridge_cancelled"),
+        )
+        .unwrap();
+
+        let card_status: String = conn
+            .query_row(
+                "SELECT status FROM kanban_cards WHERE id = 'card-821-nd'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            card_status, "in_progress",
+            "user cancel must NOT force the card into a terminal status"
+        );
+        assert_ne!(card_status, "done");
+        assert_ne!(card_status, "review");
+    }
+
+    /// #821 (3): When a PMD/admin force-transitions a card back to a
+    /// non-terminal state (or terminal, via a different path), live dispatches
+    /// for that card must be cancelled WITHOUT resetting the linked auto-queue
+    /// entry to `pending`. `cancel_active_dispatches_for_card_on_conn` is the
+    /// helper that enforces this: it cancels dispatches in bulk but never
+    /// touches `auto_queue_entries`. A re-queue on terminal transition would
+    /// cause the run to redispatch work the operator just abandoned.
+    #[test]
+    fn terminal_card_cancels_live_dispatch_without_requeue() {
+        let db = test_db();
+        seed_user_cancel_fixture(&db, "card-821-tc", "dispatch-821-tc", "entry-821-tc");
+
+        let conn = db.separate_conn().unwrap();
+        let cancelled = cancel_active_dispatches_for_card_on_conn(
+            &conn,
+            "card-821-tc",
+            Some("auto_cancelled_on_terminal_card"),
+        )
+        .unwrap();
+        assert_eq!(cancelled, 1, "live dispatch must be cancelled");
+
+        // Live dispatch moves to cancelled.
+        let dispatch_status: String = conn
+            .query_row(
+                "SELECT status FROM task_dispatches WHERE id = 'dispatch-821-tc'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(dispatch_status, "cancelled");
+
+        // The auto-queue entry must NOT have been reset to `pending` by the
+        // terminal-cancel helper. It remains in its prior state (`dispatched`)
+        // with its dispatch_id pointer intact. Re-queueing here would let the
+        // next auto-queue tick re-pick the abandoned work.
+        let (entry_status, entry_dispatch_id): (String, Option<String>) = conn
+            .query_row(
+                "SELECT status, dispatch_id FROM auto_queue_entries WHERE id = 'entry-821-tc'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            entry_status, "dispatched",
+            "terminal cancel must NOT reset the auto-queue entry to pending"
+        );
+        assert_eq!(
+            entry_dispatch_id.as_deref(),
+            Some("dispatch-821-tc"),
+            "terminal cancel must leave the entry's dispatch pointer intact"
+        );
+
+        // Modeled tick query: the run is still active but no pending entry
+        // surfaces, so nothing re-dispatches.
+        let pending_visible: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM auto_queue_entries e \
+                 JOIN auto_queue_runs r ON e.run_id = r.id \
+                 WHERE r.status = 'active' AND e.status = 'pending' \
+                   AND e.kanban_card_id = 'card-821-tc'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            pending_visible, 0,
+            "terminal cancel must not make the entry pick-able by the tick"
+        );
+    }
 }

--- a/src/engine/ops/review_automation_ops.rs
+++ b/src/engine/ops/review_automation_ops.rs
@@ -2573,4 +2573,150 @@ mod tests {
         pool.close().await;
         test_db.drop().await;
     }
+
+    /// #821 (1+2, PG variant): the PostgreSQL `cancel_dispatch_and_reset_*`
+    /// path must honour the same user-cancel invariants as the SQLite path
+    /// (src/dispatch/mod.rs tests):
+    ///   - entry transitions to `user_cancelled` (NOT `pending`).
+    ///   - card status stays `in_progress` (NOT forced into `done`).
+    ///   - the next auto-queue tick query (`active` run + `pending` entry)
+    ///     does not surface this entry, so no re-dispatch can fire.
+    ///
+    /// This locks the behaviour that #815 P2 landed for the PG branch
+    /// (routing through `update_entry_status_on_pg_tx` with the
+    /// `ENTRY_STATUS_USER_CANCELLED` target).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn user_stop_does_not_redispatch_or_mark_done_pg() {
+        let test_db = TestDatabase::create().await;
+        let pool = test_db.migrate().await;
+
+        let card_id = "card-821-user-pg";
+        let dispatch_id = format!("dispatch-{}", uuid::Uuid::new_v4().simple());
+        let run_id = format!("run-{}", uuid::Uuid::new_v4().simple());
+        let entry_id = format!("entry-{}", uuid::Uuid::new_v4().simple());
+
+        sqlx::query(
+            "INSERT INTO kanban_cards (id, title, status, repo_id)
+             VALUES ($1, 'User cancel PG', 'in_progress', 'repo-1')",
+        )
+        .bind(card_id)
+        .execute(&pool)
+        .await
+        .expect("seed kanban card");
+
+        sqlx::query(
+            "INSERT INTO task_dispatches (
+                id, kanban_card_id, dispatch_type, status, created_at, updated_at
+             ) VALUES ($1, $2, 'implementation', 'dispatched', NOW(), NOW())",
+        )
+        .bind(&dispatch_id)
+        .bind(card_id)
+        .execute(&pool)
+        .await
+        .expect("seed dispatched task dispatch");
+
+        sqlx::query(
+            "INSERT INTO auto_queue_runs (
+                id, repo, agent_id, status, max_concurrent_threads, thread_group_count,
+                created_at
+             ) VALUES ($1, 'itismyfield/AgentDesk', 'project-agentdesk', 'active', 1, 1, NOW())",
+        )
+        .bind(&run_id)
+        .execute(&pool)
+        .await
+        .expect("seed active auto_queue run");
+
+        sqlx::query(
+            "INSERT INTO auto_queue_entries (
+                id, run_id, kanban_card_id, status, dispatch_id, slot_index,
+                batch_phase, thread_group, dispatched_at, created_at
+             ) VALUES ($1, $2, $3, 'dispatched', $4, 0, 0, 0, NOW(), NOW())",
+        )
+        .bind(&entry_id)
+        .bind(&run_id)
+        .bind(card_id)
+        .bind(&dispatch_id)
+        .execute(&pool)
+        .await
+        .expect("seed dispatched auto_queue entry");
+
+        // User stop via the PG cancel path with the canonical reaction-stop
+        // reason. Uses the pool-scoped helper so the test exercises the
+        // commit path (not the rollback path that the sibling test covers).
+        let changed = crate::dispatch::cancel_dispatch_and_reset_auto_queue_on_pg(
+            &pool,
+            &dispatch_id,
+            Some("turn_bridge_cancelled"),
+        )
+        .await
+        .expect("PG cancel with user reason must succeed");
+        assert_eq!(changed, 1);
+
+        // (1) Entry must be `user_cancelled`, dispatch pointer cleared,
+        // completed_at stamped — and the next tick query must NOT see it.
+        let entry_status: String =
+            sqlx::query_scalar("SELECT status FROM auto_queue_entries WHERE id = $1")
+                .bind(&entry_id)
+                .fetch_one(&pool)
+                .await
+                .expect("load entry status");
+        assert_eq!(
+            entry_status, "user_cancelled",
+            "PG user cancel must move the entry to user_cancelled (not pending)"
+        );
+        let entry_dispatch_id: Option<String> =
+            sqlx::query_scalar("SELECT dispatch_id FROM auto_queue_entries WHERE id = $1")
+                .bind(&entry_id)
+                .fetch_one(&pool)
+                .await
+                .expect("load entry dispatch_id");
+        assert!(
+            entry_dispatch_id.is_none(),
+            "PG user cancel must detach the entry from its dispatch"
+        );
+
+        let tick_visible: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM auto_queue_entries e
+             JOIN auto_queue_runs r ON e.run_id = r.id
+             WHERE r.status = 'active' AND e.status = 'pending' AND e.id = $1",
+        )
+        .bind(&entry_id)
+        .fetch_one(&pool)
+        .await
+        .expect("tick-visibility query");
+        assert_eq!(
+            tick_visible, 0,
+            "user-cancelled entry must not be visible to the PG tick"
+        );
+
+        // Run must stay active so the operator can flip the entry back to
+        // pending if they want to restart — see the SQLite
+        // `user_cancelled_entry_can_be_restarted_via_pending_flip` test.
+        let run_status: String =
+            sqlx::query_scalar("SELECT status FROM auto_queue_runs WHERE id = $1")
+                .bind(&run_id)
+                .fetch_one(&pool)
+                .await
+                .expect("load run status");
+        assert_eq!(
+            run_status, "active",
+            "PG user cancel must leave the run active for operator restart"
+        );
+
+        // (2) Card must remain `in_progress` — the cancel path must NOT
+        // force-transition it into `done` / `review` / any terminal state.
+        let card_status: String =
+            sqlx::query_scalar("SELECT status FROM kanban_cards WHERE id = $1")
+                .bind(card_id)
+                .fetch_one(&pool)
+                .await
+                .expect("load card status");
+        assert_eq!(
+            card_status, "in_progress",
+            "PG user cancel must not mark the card done"
+        );
+
+        pool.close().await;
+        test_db.drop().await;
+    }
 }

--- a/src/engine/transition.rs
+++ b/src/engine/transition.rs
@@ -1461,4 +1461,67 @@ mod tests {
             Some("pending")
         );
     }
+
+    /// #821 (6): `decide_pipeline_transition` must refuse a transition that
+    /// has no matching pipeline rule unless the caller passes the explicit
+    /// `force` flag. This locks the behaviour proven at
+    /// `decide_pipeline_transition` around the `None if force { ... }`
+    /// branch — without the flag, the `None` arm must return `Blocked` with
+    /// a `BLOCKED: no transition rule` audit entry. Companion to the
+    /// existing `no_rule_blocks_transition` and `force_bypasses_missing_rule`
+    /// tests: this one asserts the audit payload on the blocked path plus
+    /// the allowed-with-force symmetric case in a single guard, so a refactor
+    /// that relaxes the no-rule check without also flipping the audit must
+    /// break this test.
+    #[test]
+    fn force_transition_without_rule_requires_explicit_flag() {
+        // No transition rule exists from `backlog` to `done` in the test
+        // pipeline. Without force: blocked + audited as "no transition rule".
+        let ctx = test_ctx("backlog", false);
+        let blocked = decide_status_transition(&ctx, "done", "api", false);
+        assert!(
+            matches!(blocked.outcome, TransitionOutcome::Blocked(_)),
+            "no-rule transition must block without force (got {:?})",
+            blocked.outcome
+        );
+        let audited_no_rule = blocked.intents.iter().any(|intent| {
+            matches!(
+                intent,
+                TransitionIntent::AuditLog { message, .. }
+                    if message.contains("no transition rule")
+            )
+        });
+        assert!(
+            audited_no_rule,
+            "blocked no-rule transition must emit a `no transition rule` audit log entry \
+             (intents: {:?})",
+            blocked.intents
+        );
+        // Blocked decisions must not produce an UpdateStatus intent.
+        assert!(
+            !blocked
+                .intents
+                .iter()
+                .any(|intent| matches!(intent, TransitionIntent::UpdateStatus { .. })),
+            "blocked no-rule transition must not emit an UpdateStatus intent"
+        );
+
+        // With the explicit force flag: allowed, and at least one
+        // UpdateStatus intent is emitted. This mirrors the PMD/admin
+        // override path (the only legal way to move a card across a
+        // missing rule).
+        let allowed = decide_status_transition(&ctx, "done", "pmd", true);
+        assert_eq!(
+            allowed.outcome,
+            TransitionOutcome::Allowed,
+            "force flag must unblock the no-rule transition"
+        );
+        assert!(
+            allowed.intents.iter().any(|intent| matches!(
+                intent,
+                TransitionIntent::UpdateStatus { to, .. } if to == "done"
+            )),
+            "force-allowed no-rule transition must emit UpdateStatus to the target"
+        );
+    }
 }

--- a/src/kanban.rs
+++ b/src/kanban.rs
@@ -2973,4 +2973,50 @@ mod tests {
             Some(("owner/allowed".to_string(), 101))
         );
     }
+
+    /// #821 (5): `onDispatchCompleted` (kanban-rules.js) must skip cancelled
+    /// dispatches. A race can fire the hook after the user cancels a
+    /// dispatch; without the guard the policy would force-transition the
+    /// card to `review` and the terminal sweep would then push it to `done`,
+    /// overriding the user's explicit stop. #815 added the guard —
+    /// `if (dispatch.status === "cancelled") return;` — and this test locks
+    /// the behaviour.
+    #[test]
+    fn cancelled_dispatch_does_not_enter_review() {
+        let db = test_db();
+        let engine = test_engine(&db);
+
+        // Seed a card currently in `in_progress` with a cancelled
+        // implementation dispatch. Absent the #815 guard the policy would
+        // drive the card into `review` on hook fan-out.
+        seed_card(&db, "card-821-no-review", "in_progress");
+        let dispatch_id = "dispatch-821-no-review";
+        seed_dispatch_with_type(
+            &db,
+            dispatch_id,
+            "card-821-no-review",
+            "implementation",
+            "cancelled",
+        );
+
+        // Fire the hook the same way the real runtime would.
+        engine
+            .try_fire_hook_by_name("OnDispatchCompleted", json!({ "dispatch_id": dispatch_id }))
+            .expect("fire OnDispatchCompleted");
+
+        // The card must remain in its prior status — NOT `review`, NOT `done`.
+        let status: String = {
+            let conn = db.lock().unwrap();
+            conn.query_row(
+                "SELECT status FROM kanban_cards WHERE id = 'card-821-no-review'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(
+            status, "in_progress",
+            "kanban-rules.onDispatchCompleted must skip cancelled dispatches"
+        );
+    }
 }

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -18024,6 +18024,64 @@ fn auto_queue_recovery_completes_finished_non_phase_gate_runs_and_releases_slots
 }
 
 #[test]
+fn auto_queue_recovery_keeps_user_cancelled_runs_active() {
+    crate::pipeline::ensure_loaded();
+    let db = test_db();
+    let engine = test_engine(&db);
+    ensure_auto_queue_tables(&db);
+
+    seed_agent(&db, "agent-user-cancelled-recovery");
+    seed_auto_queue_card(
+        &db,
+        "card-user-cancelled-recovery",
+        9017,
+        "in_progress",
+        "agent-user-cancelled-recovery",
+    );
+
+    {
+        let conn = db.lock().unwrap();
+        conn.execute(
+            "INSERT INTO auto_queue_runs (id, repo, agent_id, status)
+             VALUES ('run-user-cancelled-recovery', 'test-repo', 'agent-user-cancelled-recovery', 'active')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO auto_queue_entries (
+                id, run_id, kanban_card_id, agent_id, status, priority_rank, thread_group, completed_at
+            ) VALUES (
+                'entry-user-cancelled-recovery', 'run-user-cancelled-recovery',
+                'card-user-cancelled-recovery', 'agent-user-cancelled-recovery',
+                'user_cancelled', 0, 0, datetime('now')
+            )",
+            [],
+        )
+        .unwrap();
+    }
+
+    engine
+        .fire_hook(
+            crate::engine::hooks::Hook::OnTick1min,
+            serde_json::json!({}),
+        )
+        .unwrap();
+
+    let conn = db.lock().unwrap();
+    let run_status: String = conn
+        .query_row(
+            "SELECT status FROM auto_queue_runs WHERE id = 'run-user-cancelled-recovery'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        run_status, "active",
+        "user_cancelled entries must block onTick1min from auto-completing the run"
+    );
+}
+
+#[test]
 fn auto_queue_recovery_keeps_finished_phase_gate_runs_blocked_until_gate_resolves() {
     crate::pipeline::ensure_loaded();
     let db = test_db();


### PR DESCRIPTION
Closes #821
Stacks on PR #858 (#815). Rebase to main after #858 merges.

## Summary
- cancel → entry user_cancelled, no auto-redispatch
- cancelled dispatch → review 전환 차단
- card terminal/done/reactivate invariants 회귀 테스트 추가

## Test plan
- [x] `cargo build --release` 통과
- [x] PG 테스트 시나리오: cancel → 재dispatch 차단, 카드 done 마감 차단, terminal/reactivate invariant 잠금

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>