### PR TITLE
fix(release): add PATH + HOME to launchd plist template

### DIFF
--- a/scripts/com.agentdesk.release.plist
+++ b/scripts/com.agentdesk.release.plist
@@ -15,6 +15,10 @@
     <dict>
         <key>AGENTDESK_ROOT_DIR</key>
         <string>AGENTDESK_HOME</string>
+        <key>HOME</key>
+        <string>USER_HOME</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:USER_HOME/.cargo/bin:USER_HOME/bin:USER_HOME/.local/bin</string>
     </dict>
 
     <key>WorkingDirectory</key>

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -536,6 +536,7 @@ install_launchd() {
   sed \
     -e "s|AGENTDESK_BIN|$BIN_DIR/agentdesk|g" \
     -e "s|AGENTDESK_HOME|$AD_HOME|g" \
+    -e "s|USER_HOME|$HOME|g" \
     "$PLIST_SRC" > "$PLIST_DST"
 
   if [ -f "$LAUNCHD_ENV_FILE" ]; then


### PR DESCRIPTION
## Problem

`scripts/com.agentdesk.release.plist` has been missing a `PATH` env var since it was created (`d56b7cd4`, 2026-03-19). When `deploy.sh::install_launchd` installs the plist from this template into `~/Library/LaunchAgents/`, launchd spawns `dcserver` with the minimal default PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) — no `/opt/homebrew/bin`.

`src/services/platform/tmux.rs::is_available()` runs `Command::new("tmux").arg("-V")`, which fails binary lookup, so `claude::is_tmux_available()` returns `false`. The fallback at `services/claude.rs:571-583` ("Local without tmux → ProcessBackend") activates on macOS even though tmux IS installed.

ProcessBackend was intended as a Windows-only path. On macOS it silently disables `tmux ls` / `tmux attach` visibility into agent sessions.

Contrast: `~/Library/LaunchAgents/com.agentdesk.dev.plist` (created by `install.sh` or `init.rs`, both of which inline-inject PATH) has always had `/opt/homebrew/bin` in PATH, so dev ran tmux correctly. Only the release template drifted.

## Fix

- `scripts/com.agentdesk.release.plist`: add `PATH` and `HOME` under `EnvironmentVariables`. Introduce a new `USER_HOME` placeholder for `$HOME`-relative paths.
- `scripts/deploy.sh::install_launchd`: add `-e "s|USER_HOME|$HOME|g"` to the sed substitution block.

## Follow-up

The 3-way drift that allowed this to happen (static plist template / `install.sh` heredoc / `src/cli/init.rs` Rust generator) is tracked as a separate refactor — see #TBD (issue opened alongside this PR).

## Verification

- Next `deploy.sh` run regenerates `~/Library/LaunchAgents/com.agentdesk.release.plist` with PATH.
- After `launchctl bootout` + `bootstrap`, `is_tmux_available()` returns true → `execute_streaming_local_tmux` used → `tmux ls` shows agent sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)