### PR TITLE
Finish #850 dispatch PG cleanup tail

### DIFF
--- a/src/dispatch/dispatch_context.rs
+++ b/src/dispatch/dispatch_context.rs
@@ -206,7 +206,6 @@ pub(super) fn dispatch_context_worktree_target(
     Ok(Some((path.to_string(), branch)))
 }
 
-#[cfg(test)]
 pub(super) fn resolve_parent_dispatch_context_sqlite_test(
     conn: &libsql_rusqlite::Connection,
     card_id: &str,

--- a/src/dispatch/dispatch_create.rs
+++ b/src/dispatch/dispatch_create.rs
@@ -21,6 +21,7 @@ use super::dispatch_context::{
     resolve_card_target_repo_ref_sqlite_test, resolve_card_worktree_sqlite_test,
     resolve_parent_dispatch_context_sqlite_test,
 };
+#[cfg(test)]
 use super::dispatch_status::{
     ensure_dispatch_notify_outbox_on_conn, record_dispatch_status_event_on_conn,
 };
@@ -179,6 +180,7 @@ async fn lookup_active_dispatch_id_pg(
     .flatten()
 }
 
+#[cfg(test)]
 fn is_single_active_dispatch_violation(error: &libsql_rusqlite::Error) -> bool {
     matches!(
         error,
@@ -350,11 +352,11 @@ pub(crate) async fn query_dispatch_row_pg(
             context,
             result,
             parent_dispatch_id,
-            chain_depth,
+            COALESCE(chain_depth, 0)::bigint AS chain_depth,
             created_at::text AS created_at,
             updated_at::text AS updated_at,
             completed_at::text AS completed_at,
-            COALESCE(retry_count, 0) AS retry_count
+            COALESCE(retry_count, 0)::bigint AS retry_count
          FROM task_dispatches
          WHERE id = $1",
     )
@@ -705,28 +707,7 @@ pub async fn create_dispatch_core_with_id_and_options(
 
 #[cfg(test)]
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn create_dispatch_core_sqlite_test(
-    db: &Db,
-    kanban_card_id: &str,
-    to_agent_id: &str,
-    dispatch_type: &str,
-    title: &str,
-    context: &serde_json::Value,
-) -> Result<(String, String, bool)> {
-    create_dispatch_core_with_options_sqlite_test(
-        db,
-        kanban_card_id,
-        to_agent_id,
-        dispatch_type,
-        title,
-        context,
-        DispatchCreateOptions::default(),
-    )
-}
-
-#[cfg(test)]
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn create_dispatch_core_with_options_sqlite_test(
+pub(crate) fn create_dispatch_record_sqlite_test(
     db: &Db,
     kanban_card_id: &str,
     to_agent_id: &str,
@@ -736,7 +717,7 @@ pub(crate) fn create_dispatch_core_with_options_sqlite_test(
     options: DispatchCreateOptions,
 ) -> Result<(String, String, bool)> {
     let dispatch_id = uuid::Uuid::new_v4().to_string();
-    create_dispatch_core_with_id_and_options_sqlite_test(
+    create_dispatch_record_with_id_sqlite_test(
         db,
         &dispatch_id,
         kanban_card_id,
@@ -750,30 +731,7 @@ pub(crate) fn create_dispatch_core_with_options_sqlite_test(
 
 #[cfg(test)]
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn create_dispatch_core_with_id_sqlite_test(
-    db: &Db,
-    dispatch_id: &str,
-    kanban_card_id: &str,
-    to_agent_id: &str,
-    dispatch_type: &str,
-    title: &str,
-    context: &serde_json::Value,
-) -> Result<(String, String, bool)> {
-    create_dispatch_core_with_id_and_options_sqlite_test(
-        db,
-        dispatch_id,
-        kanban_card_id,
-        to_agent_id,
-        dispatch_type,
-        title,
-        context,
-        DispatchCreateOptions::default(),
-    )
-}
-
-#[cfg(test)]
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn create_dispatch_core_with_id_and_options_sqlite_test(
+pub(crate) fn create_dispatch_record_with_id_sqlite_test(
     db: &Db,
     dispatch_id: &str,
     kanban_card_id: &str,
@@ -1131,7 +1089,7 @@ fn create_dispatch_with_options_sqlite_test(
     context: &serde_json::Value,
     options: DispatchCreateOptions,
 ) -> Result<serde_json::Value> {
-    let (dispatch_id, old_status, reused) = create_dispatch_core_with_options_sqlite_test(
+    let (dispatch_id, old_status, reused) = create_dispatch_record_sqlite_test(
         db,
         kanban_card_id,
         to_agent_id,
@@ -1176,12 +1134,12 @@ fn create_dispatch_with_options_sqlite_test(
     Ok(dispatch)
 }
 
-/// Transaction-owning wrapper. Opens BEGIN/COMMIT around the on-conn variant.
+/// Test-only sqlite wrapper. Opens BEGIN/COMMIT around the on-conn variant.
 ///
-/// Use this when the caller does not have an outer transaction. Callers that
-/// need to compose dispatch creation into their own transaction (e.g.
-/// `handoffCreatePr` in #743) should call
-/// [`apply_dispatch_attached_intents_on_conn`] directly instead.
+/// Production callers use the PG helpers (`apply_dispatch_attached_intents_pg`
+/// / `apply_dispatch_attached_intents_on_pg_tx`). This wrapper remains only
+/// for sqlite-backed test fixtures.
+#[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 fn apply_dispatch_attached_intents(
     conn: &libsql_rusqlite::Connection,
@@ -1410,8 +1368,14 @@ pub(crate) async fn apply_dispatch_attached_intents_pg(
     }
 }
 
+/// Transaction-local PG variant: does NOT manage its own transaction.
+/// Caller must already have an open postgres transaction and commit/rollback
+/// after this returns.
+///
+/// This exists for callers like review-automation handoff paths that need to
+/// compose dispatch creation with surrounding PG updates in one atomic unit.
 #[allow(clippy::too_many_arguments)]
-async fn apply_dispatch_attached_intents_on_pg_tx(
+pub(crate) async fn apply_dispatch_attached_intents_on_pg_tx(
     tx: &mut sqlx::Transaction<'_, Postgres>,
     card_id: &str,
     to_agent_id: &str,
@@ -1524,14 +1488,14 @@ async fn apply_dispatch_attached_intents_on_pg_tx(
     Ok(())
 }
 
-/// Connection-local variant: does NOT manage its own transaction. Caller must
-/// have an open transaction on `conn` and commit/rollback after this returns.
+/// Test-only sqlite connection-local variant.
 ///
-/// This variant exists so bridge ops like `handoffCreatePr` (#743) can compose
-/// dispatch creation with surrounding pr_tracking/kanban_cards updates in a
-/// single atomic transaction.
+/// Production transactional callers use `apply_dispatch_attached_intents_on_pg_tx`.
+/// This exists only for sqlite-backed test fixtures that still exercise the
+/// old connection-local transition plumbing.
+#[cfg(test)]
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn apply_dispatch_attached_intents_on_conn(
+fn apply_dispatch_attached_intents_on_conn(
     conn: &libsql_rusqlite::Connection,
     card_id: &str,
     to_agent_id: &str,

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -31,7 +31,7 @@ use dispatch_context::{
     inject_review_merge_base_context,
 };
 #[allow(unused_imports)]
-pub(crate) use dispatch_create::apply_dispatch_attached_intents_on_conn;
+pub(crate) use dispatch_create::apply_dispatch_attached_intents_on_pg_tx;
 pub(crate) use dispatch_create::query_dispatch_row_pg;
 #[allow(unused_imports)]
 pub use dispatch_create::{
@@ -41,8 +41,7 @@ pub use dispatch_create::{
 };
 #[cfg(test)]
 pub(crate) use dispatch_create::{
-    create_dispatch_core_sqlite_test, create_dispatch_core_with_id_and_options_sqlite_test,
-    create_dispatch_core_with_id_sqlite_test,
+    create_dispatch_record_sqlite_test, create_dispatch_record_with_id_sqlite_test,
 };
 #[allow(unused_imports)]
 pub use dispatch_status::{complete_dispatch, finalize_dispatch, mark_dispatch_completed};
@@ -754,9 +753,7 @@ pub fn drain_unified_thread_kill_signals() -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::build_review_context_sqlite_test as build_review_context;
-    use super::create_dispatch_core_sqlite_test as create_dispatch_core_test;
-    use super::create_dispatch_core_with_id_and_options_sqlite_test as create_dispatch_core_with_id_and_options;
-    use super::create_dispatch_core_with_id_sqlite_test as create_dispatch_core_with_id;
+    use super::create_dispatch_record_sqlite_test as create_dispatch_record_test;
     use super::resolve_card_worktree_sqlite_test as resolve_card_worktree;
     use super::*;
     use std::process::Command;
@@ -1733,68 +1730,6 @@ mod tests {
     }
 
     #[test]
-    fn create_dispatch_core_shares_invariants_with_create_dispatch() {
-        let db = test_db();
-        let engine = test_engine(&db);
-        seed_card(&db, "card-core", "ready");
-
-        // sqlite dispatch-core helper returns (dispatch_id, old_status, reused)
-        let (dispatch_id, old_status, _reused) = create_dispatch_core_test(
-            &db,
-            "card-core",
-            "agent-1",
-            "implementation",
-            "Core dispatch",
-            &json!({"key": "value"}),
-        )
-        .unwrap();
-
-        assert_eq!(old_status, "ready");
-
-        // #255: ready→requested is free, so kickoff_for("ready") returns "in_progress"
-        let conn = db.separate_conn().unwrap();
-        let (card_status, latest_dispatch_id): (String, String) = conn
-            .query_row(
-                "SELECT status, latest_dispatch_id FROM kanban_cards WHERE id = 'card-core'",
-                [],
-                |row| Ok((row.get(0)?, row.get(1)?)),
-            )
-            .unwrap();
-        assert_eq!(card_status, "in_progress");
-        assert_eq!(latest_dispatch_id, dispatch_id);
-
-        // Dispatch row exists
-        let dispatch = query_dispatch_row(&conn, &dispatch_id).unwrap();
-        assert_eq!(dispatch["status"], "pending");
-        assert_eq!(dispatch["kanban_card_id"], "card-core");
-        assert_eq!(
-            count_notify_outbox(&conn, &dispatch_id),
-            1,
-            "core creation must atomically enqueue exactly one notify outbox row"
-        );
-        assert_eq!(
-            load_dispatch_events(&conn, &dispatch_id),
-            vec![(None, "pending".to_string(), "create_dispatch".to_string())],
-            "dispatch creation must record the initial pending event"
-        );
-        drop(conn);
-
-        // create_dispatch delegates to core — verify same invariants
-        seed_card(&db, "card-full", "ready");
-        let full_dispatch = create_dispatch(
-            &db,
-            &engine,
-            "card-full",
-            "agent-1",
-            "implementation",
-            "Full dispatch",
-            &json!({}),
-        )
-        .unwrap();
-        assert_eq!(full_dispatch["status"], "pending");
-    }
-
-    #[test]
     fn dispatch_type_force_new_session_defaults_split_by_dispatch_type() {
         assert_eq!(
             dispatch_type_force_new_session_default(Some("implementation")),
@@ -1864,155 +1799,6 @@ mod tests {
     }
 
     #[test]
-    fn create_dispatch_core_injects_fresh_session_default_for_implementation() {
-        let db = test_db();
-        seed_card(&db, "card-session-default", "ready");
-
-        let (dispatch_id, _, _) = create_dispatch_core_test(
-            &db,
-            "card-session-default",
-            "agent-1",
-            "implementation",
-            "Fresh implementation",
-            &json!({"key": "value"}),
-        )
-        .unwrap();
-
-        let conn = db.separate_conn().unwrap();
-        let context: String = conn
-            .query_row(
-                "SELECT context FROM task_dispatches WHERE id = ?1",
-                [&dispatch_id],
-                |row| row.get(0),
-            )
-            .unwrap();
-        let context_json: serde_json::Value = serde_json::from_str(&context).unwrap();
-        assert_eq!(context_json["force_new_session"], true);
-        assert_eq!(context_json["reset_provider_state"], true);
-        assert_eq!(context_json["recreate_tmux"], false);
-        assert_eq!(context_json["key"], "value");
-    }
-
-    #[test]
-    fn create_dispatch_core_keeps_explicit_session_override() {
-        let db = test_db();
-        seed_card(&db, "card-session-override", "ready");
-
-        let (dispatch_id, _, _) = create_dispatch_core_test(
-            &db,
-            "card-session-override",
-            "agent-1",
-            "implementation",
-            "Warm override",
-            &json!({"force_new_session": false}),
-        )
-        .unwrap();
-
-        let conn = db.separate_conn().unwrap();
-        let context: String = conn
-            .query_row(
-                "SELECT context FROM task_dispatches WHERE id = ?1",
-                [&dispatch_id],
-                |row| row.get(0),
-            )
-            .unwrap();
-        let context_json: serde_json::Value = serde_json::from_str(&context).unwrap();
-        assert_eq!(context_json["force_new_session"], false);
-        assert_eq!(context_json["reset_provider_state"], false);
-        assert_eq!(context_json["recreate_tmux"], false);
-    }
-
-    #[test]
-    fn create_dispatch_core_injects_warm_resume_default_for_review_decision() {
-        let db = test_db();
-        seed_card(&db, "card-session-review-decision", "review");
-
-        let (dispatch_id, _, _) = create_dispatch_core_test(
-            &db,
-            "card-session-review-decision",
-            "agent-1",
-            "review-decision",
-            "Warm review decision",
-            &json!({"verdict": "improve"}),
-        )
-        .unwrap();
-
-        let conn = db.separate_conn().unwrap();
-        let context: String = conn
-            .query_row(
-                "SELECT context FROM task_dispatches WHERE id = ?1",
-                [&dispatch_id],
-                |row| row.get(0),
-            )
-            .unwrap();
-        let context_json: serde_json::Value = serde_json::from_str(&context).unwrap();
-        assert_eq!(context_json["force_new_session"], false);
-        assert_eq!(context_json["reset_provider_state"], false);
-        assert_eq!(context_json["recreate_tmux"], false);
-        assert_eq!(context_json["verdict"], "improve");
-    }
-
-    #[test]
-    fn create_dispatch_core_with_id_atomically_inserts_notify_outbox() {
-        let db = test_db();
-        seed_card(&db, "card-core-id", "ready");
-
-        let (dispatch_id, old_status, reused) = create_dispatch_core_with_id(
-            &db,
-            "dispatch-core-id",
-            "card-core-id",
-            "agent-1",
-            "implementation",
-            "Core with id",
-            &json!({}),
-        )
-        .unwrap();
-
-        assert_eq!(dispatch_id, "dispatch-core-id");
-        assert_eq!(old_status, "ready");
-        assert!(!reused);
-
-        let conn = db.separate_conn().unwrap();
-        assert_eq!(
-            count_notify_outbox(&conn, "dispatch-core-id"),
-            1,
-            "pre-assigned dispatch creation must also enqueue notify outbox inside the transaction"
-        );
-    }
-
-    #[test]
-    fn create_dispatch_core_with_id_and_skip_outbox_omits_notify_row() {
-        let db = test_db();
-        seed_card(&db, "card-core-id-skip", "ready");
-
-        let (dispatch_id, old_status, reused) = create_dispatch_core_with_id_and_options(
-            &db,
-            "dispatch-core-id-skip",
-            "card-core-id-skip",
-            "agent-1",
-            "implementation",
-            "Core with id skip outbox",
-            &json!({}),
-            DispatchCreateOptions {
-                skip_outbox: true,
-                ..Default::default()
-            },
-        )
-        .unwrap();
-
-        assert_eq!(dispatch_id, "dispatch-core-id-skip");
-        assert_eq!(old_status, "ready");
-        assert!(!reused);
-
-        let conn = db.separate_conn().unwrap();
-        assert_eq!(
-            count_notify_outbox(&conn, "dispatch-core-id-skip"),
-            0,
-            "skip_outbox must suppress notify outbox insertion inside the transaction"
-        );
-    }
-
-    #[test]
     fn ensure_dispatch_notify_outbox_skips_completed_dispatch() {
         let db = test_db();
         seed_card(&db, "card-completed-notify", "done");
@@ -2045,160 +1831,6 @@ mod tests {
             0,
             "completed dispatches must not retain notify outbox rows"
         );
-    }
-
-    #[test]
-    fn create_dispatch_core_rejects_done_card() {
-        let db = test_db();
-        seed_card(&db, "card-done-core", "done");
-
-        let result = create_dispatch_core_test(
-            &db,
-            "card-done-core",
-            "agent-1",
-            "implementation",
-            "Should fail",
-            &json!({}),
-        );
-        assert!(result.is_err(), "core should reject done card dispatch");
-    }
-
-    #[test]
-    fn create_dispatch_core_rejects_missing_agent_before_insert() {
-        let db = test_db();
-        seed_card(&db, "card-missing-agent", "ready");
-
-        let result = create_dispatch_core_test(
-            &db,
-            "card-missing-agent",
-            "agent-missing",
-            "implementation",
-            "Should fail",
-            &json!({}),
-        );
-        let err = format!("{}", result.unwrap_err());
-        assert!(err.contains("agent 'agent-missing' not found"));
-
-        let conn = db.separate_conn().unwrap();
-        let dispatch_count: i64 = conn
-            .query_row(
-                "SELECT COUNT(*) FROM task_dispatches WHERE kanban_card_id = 'card-missing-agent'",
-                [],
-                |row| row.get(0),
-            )
-            .unwrap();
-        assert_eq!(dispatch_count, 0, "missing agent must not persist rows");
-    }
-
-    #[test]
-    fn create_dispatch_core_rejects_missing_primary_channel_before_insert() {
-        let db = test_db();
-        seed_card(&db, "card-no-channel", "ready");
-        let conn = db.separate_conn().unwrap();
-        conn.execute(
-            "UPDATE agents
-             SET discord_channel_id = NULL,
-                 discord_channel_alt = NULL,
-                 discord_channel_cc = NULL,
-                 discord_channel_cdx = NULL
-             WHERE id = 'agent-1'",
-            [],
-        )
-        .unwrap();
-        drop(conn);
-
-        let result = create_dispatch_core_test(
-            &db,
-            "card-no-channel",
-            "agent-1",
-            "implementation",
-            "Should fail",
-            &json!({}),
-        );
-        let err = format!("{}", result.unwrap_err());
-        assert!(err.contains("no primary discord channel"));
-
-        let conn = db.separate_conn().unwrap();
-        let dispatch_count: i64 = conn
-            .query_row(
-                "SELECT COUNT(*) FROM task_dispatches WHERE kanban_card_id = 'card-no-channel'",
-                [],
-                |row| row.get(0),
-            )
-            .unwrap();
-        assert_eq!(dispatch_count, 0, "failed validation must not persist rows");
-    }
-
-    #[test]
-    fn create_dispatch_core_with_id_rejects_invalid_channel_alias_before_insert() {
-        let db = test_db();
-        seed_card(&db, "card-bad-channel", "ready");
-        let conn = db.separate_conn().unwrap();
-        conn.execute(
-            "UPDATE agents SET discord_channel_id = 'not-a-channel' WHERE id = 'agent-1'",
-            [],
-        )
-        .unwrap();
-        drop(conn);
-
-        let result = create_dispatch_core_with_id(
-            &db,
-            "dispatch-bad-channel",
-            "card-bad-channel",
-            "agent-1",
-            "implementation",
-            "Should fail",
-            &json!({}),
-        );
-        let err = format!("{}", result.unwrap_err());
-        assert!(err.contains("invalid primary discord channel"));
-
-        let conn = db.separate_conn().unwrap();
-        let dispatch_count: i64 = conn
-            .query_row(
-                "SELECT COUNT(*) FROM task_dispatches WHERE id = 'dispatch-bad-channel'",
-                [],
-                |row| row.get(0),
-            )
-            .unwrap();
-        assert_eq!(
-            dispatch_count, 0,
-            "invalid channels must fail before INSERT"
-        );
-    }
-
-    #[test]
-    fn create_dispatch_core_rejects_invalid_existing_thread_before_insert() {
-        let db = test_db();
-        seed_card(&db, "card-bad-thread", "ready");
-        let conn = db.separate_conn().unwrap();
-        conn.execute(
-            "UPDATE kanban_cards SET active_thread_id = 'thread-not-numeric' WHERE id = 'card-bad-thread'",
-            [],
-        )
-        .unwrap();
-        drop(conn);
-
-        let result = create_dispatch_core_test(
-            &db,
-            "card-bad-thread",
-            "agent-1",
-            "implementation",
-            "Should fail",
-            &json!({}),
-        );
-        let err = format!("{}", result.unwrap_err());
-        assert!(err.contains("invalid thread"));
-
-        let conn = db.separate_conn().unwrap();
-        let dispatch_count: i64 = conn
-            .query_row(
-                "SELECT COUNT(*) FROM task_dispatches WHERE kanban_card_id = 'card-bad-thread'",
-                [],
-                |row| row.get(0),
-            )
-            .unwrap();
-        assert_eq!(dispatch_count, 0, "invalid thread must fail before INSERT");
     }
 
     #[test]
@@ -2973,24 +2605,26 @@ mod tests {
         let db = test_db();
         seed_card(&db, "card-flag", "ready");
 
-        let (id1, _, reused1) = create_dispatch_core_test(
+        let (id1, _, reused1) = create_dispatch_record_test(
             &db,
             "card-flag",
             "agent-1",
             "implementation",
             "First",
             &json!({}),
+            DispatchCreateOptions::default(),
         )
         .unwrap();
         assert!(!reused1, "first creation must not be reused");
 
-        let (id2, _, reused2) = create_dispatch_core_test(
+        let (id2, _, reused2) = create_dispatch_record_test(
             &db,
             "card-flag",
             "agent-1",
             "implementation",
             "Second",
             &json!({}),
+            DispatchCreateOptions::default(),
         )
         .unwrap();
         assert!(reused2, "duplicate must be flagged as reused");
@@ -3130,13 +2764,14 @@ mod tests {
         set_card_issue_number(&db, "card-missing-mapping", 515);
         set_card_repo_id(&db, "card-missing-mapping", "owner/missing");
 
-        let err = create_dispatch_core_test(
+        let err = create_dispatch_record_test(
             &db,
             "card-missing-mapping",
             "agent-1",
             "implementation",
             "Should fail",
             &json!({}),
+            DispatchCreateOptions::default(),
         )
         .expect_err("dispatch should fail when repo mapping is missing");
 
@@ -4542,13 +4177,14 @@ mod tests {
         // Invoke the real production path. The caller passes NO target_repo
         // override — `dispatch_create` will inject `card.repo_id`
         // (`card_repo_dir`) before calling `build_review_context`.
-        let (dispatch_id, _, _) = create_dispatch_core_test(
+        let (dispatch_id, _, _) = create_dispatch_record_test(
             &db,
             "card-review-762-a-core",
             "agent-1",
             "review",
             "Review dispatch for 762-a",
             &json!({}),
+            DispatchCreateOptions::default(),
         )
         .unwrap();
 

--- a/src/engine/ops/dispatch_ops.rs
+++ b/src/engine/ops/dispatch_ops.rs
@@ -12,11 +12,11 @@ pub(super) fn register_dispatch_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>
     let ad: Object<'js> = ctx.globals().get("agentdesk")?;
     let dispatch_obj = Object::new(ctx.clone())?;
 
-    // #248: __dispatch_create_sync(card_id, agent_id, dispatch_type, title, context_json) → json_string
-    // Synchronous DB INSERT — no deferred intent.
+    // #248: __dispatch_create_raw(card_id, agent_id, dispatch_type, title, context_json)
+    // -> json_string. Synchronous PG INSERT — no deferred intent.
     let pg_create = pg_pool.clone();
     dispatch_obj.set(
-        "__create_sync",
+        "__create_raw",
         Function::new(
             ctx.clone(),
             rquickjs::function::MutFn::from(
@@ -27,7 +27,7 @@ pub(super) fn register_dispatch_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>
                       context_json: String|
                       -> String {
                     match pg_create.as_ref() {
-                        Some(pool) => dispatch_create_sync(
+                        Some(pool) => dispatch_create_raw_pg(
                             pool,
                             &card_id,
                             &agent_id,
@@ -136,7 +136,7 @@ pub(super) fn register_dispatch_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>
                 // #248: Synchronous DB INSERT — no deferred intent.
                 // Validation + INSERT happen atomically in Rust.
                 var result = JSON.parse(
-                    agentdesk.dispatch.__create_sync(cardId, agentId, dt, t, ctxJson)
+                    agentdesk.dispatch.__create_raw(cardId, agentId, dt, t, ctxJson)
                 );
                 if (result.error) throw new Error(result.error);
                 var dispatchId = result.dispatch_id;
@@ -187,7 +187,7 @@ pub(super) fn register_dispatch_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>
 /// #248/#249: Synchronous dispatch creation — validates and inserts into DB
 /// immediately. The notify outbox row is now inserted atomically inside
 /// the dispatch-core path, so no JS-side outbox buffering is needed.
-fn dispatch_create_sync(
+fn dispatch_create_raw_pg(
     pg_pool: &PgPool,
     card_id: &str,
     agent_id: &str,

--- a/src/engine/ops/review_automation_ops.rs
+++ b/src/engine/ops/review_automation_ops.rs
@@ -16,8 +16,8 @@
 //!   resetting retry_count and last_error.
 
 use crate::db::Db;
-use crate::dispatch::{DispatchCreateOptions, apply_dispatch_attached_intents_on_conn};
-use libsql_rusqlite::{OptionalExtension, TransactionBehavior}; // TODO(#839): sqlite compatibility retained for out-of-scope callers or legacy tests.
+use crate::dispatch::{DispatchCreateOptions, apply_dispatch_attached_intents_on_pg_tx};
+use libsql_rusqlite::OptionalExtension; // TODO(#839): sqlite compatibility retained for out-of-scope callers or legacy tests.
 use rquickjs::{Ctx, Function, Object, Result as JsResult};
 use serde::Deserialize;
 use serde_json::json;
@@ -32,12 +32,11 @@ pub(super) fn register_review_automation_ops<'js>(
     let ad: Object<'js> = ctx.globals().get("agentdesk")?;
     let obj = Object::new(ctx.clone())?;
 
-    let db_handoff = db.clone();
     let pg_handoff = pg_pool.clone();
     obj.set(
         "__handoffCreatePrRaw",
         Function::new(ctx.clone(), move |payload_json: String| -> String {
-            handoff_create_pr_raw(&db_handoff, pg_handoff.as_ref(), &payload_json)
+            handoff_create_pr_raw(pg_handoff.as_ref(), &payload_json)
         })?,
     )?;
 
@@ -119,7 +118,7 @@ struct HandoffPayload {
     title: String,
 }
 
-fn handoff_create_pr_raw(db: &Db, pg_pool: Option<&PgPool>, payload_json: &str) -> String {
+fn handoff_create_pr_raw(pg_pool: Option<&PgPool>, payload_json: &str) -> String {
     let payload: HandoffPayload = match serde_json::from_str(payload_json) {
         Ok(p) => p,
         Err(e) => return json!({"error": format!("invalid payload: {e}")}).to_string(),
@@ -133,18 +132,18 @@ fn handoff_create_pr_raw(db: &Db, pg_pool: Option<&PgPool>, payload_json: &str) 
     if payload.branch.trim().is_empty() {
         return json!({"error": "branch is required"}).to_string();
     }
-    let result = if let Some(pool) = pg_pool {
-        crate::utils::async_bridge::block_on_pg_result(
-            pool,
-            {
-                let payload = payload.clone();
-                move |bridge_pool| async move { handoff_create_pr_pg(&bridge_pool, &payload).await }
-            },
-            |error| error,
-        )
-    } else {
-        handoff_create_pr_tx(db, &payload).map_err(|e| format!("{e}"))
+    let Some(pool) = pg_pool else {
+        return json!({"error": "postgres pool required for reviewAutomation.handoffCreatePr"})
+            .to_string();
     };
+    let result = crate::utils::async_bridge::block_on_pg_result(
+        pool,
+        {
+            let payload = payload.clone();
+            move |bridge_pool| async move { handoff_create_pr_pg(&bridge_pool, &payload).await }
+        },
+        |error| error,
+    );
     match result {
         Ok(v) => v.to_string(),
         Err(e) => json!({"error": e}).to_string(),
@@ -431,20 +430,30 @@ async fn handoff_create_pr_pg(
         }
     }
 
-    let card_exists = sqlx::query_scalar::<_, bool>(
-        "SELECT EXISTS (
-            SELECT 1
-            FROM kanban_cards
-            WHERE id = $1
-         )",
+    let (old_status, card_repo_id, card_agent_id) =
+        sqlx::query_as::<_, (String, Option<String>, Option<String>)>(
+            "SELECT status, repo_id, assigned_agent_id
+             FROM kanban_cards
+             WHERE id = $1",
+        )
+        .bind(&payload.card_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| {
+            format!(
+                "load postgres card {} for create-pr handoff: {e}",
+                payload.card_id
+            )
+        })?
+        .ok_or_else(|| format!("card {} not found", payload.card_id))?;
+
+    crate::pipeline::ensure_loaded();
+    let effective = crate::pipeline::resolve_for_card_pg(
+        pool,
+        card_repo_id.as_deref(),
+        card_agent_id.as_deref(),
     )
-    .bind(&payload.card_id)
-    .fetch_one(&mut *tx)
-    .await
-    .map_err(|e| format!("check postgres card {} existence: {e}", payload.card_id))?;
-    if !card_exists {
-        return Err(format!("card {} not found", payload.card_id));
-    }
+    .await;
 
     let generation = Uuid::new_v4().to_string();
     let dispatch_id = Uuid::new_v4().to_string();
@@ -466,80 +475,42 @@ async fn handoff_create_pr_pg(
         )
     })?;
 
-    let insert_dispatch = sqlx::query(
-        "INSERT INTO task_dispatches (
-            id,
-            kanban_card_id,
-            to_agent_id,
-            dispatch_type,
-            status,
-            title,
-            context,
-            parent_dispatch_id,
-            chain_depth,
-            created_at,
-            updated_at
-        ) VALUES (
-            $1, $2, $3, 'create-pr', 'pending', $4, $5, NULL, 0, NOW(), NOW()
-        )",
+    match apply_dispatch_attached_intents_on_pg_tx(
+        &mut tx,
+        &payload.card_id,
+        &payload.agent_id,
+        &dispatch_id,
+        "create-pr",
+        false,
+        &old_status,
+        &effective,
+        &payload.title,
+        &context_str,
+        None,
+        0,
+        DispatchCreateOptions {
+            sidecar_dispatch: true,
+            ..Default::default()
+        },
     )
-    .bind(&dispatch_id)
-    .bind(&payload.card_id)
-    .bind(&payload.agent_id)
-    .bind(&payload.title)
-    .bind(&context_str)
-    .execute(&mut *tx)
-    .await;
-    if let Err(error) = insert_dispatch {
-        if matches!(&error, sqlx::Error::Database(db_error) if db_error.is_unique_violation()) {
+    .await
+    {
+        Ok(()) => {}
+        Err(error)
+            if error
+                .to_string()
+                .contains("concurrent race prevented by DB constraint") =>
+        {
             tx.rollback().await.ok();
+            return Err(error.to_string());
+        }
+        Err(error) => {
             return Err(format!(
-                "create-pr already exists for card {} (concurrent race prevented by DB constraint)",
-                payload.card_id
+                "attach postgres create-pr dispatch {} for {}: {error}",
+                dispatch_id, payload.card_id
             ));
         }
-        return Err(format!(
-            "insert postgres create-pr dispatch {} for {}: {error}",
-            dispatch_id, payload.card_id
-        ));
     }
-
-    sqlx::query(
-        "INSERT INTO dispatch_events (
-            dispatch_id,
-            kanban_card_id,
-            dispatch_type,
-            from_status,
-            to_status,
-            transition_source,
-            payload_json
-        ) VALUES (
-            $1, $2, 'create-pr', NULL, 'pending', 'create_dispatch', NULL
-        )",
-    )
-    .bind(&dispatch_id)
-    .bind(&payload.card_id)
-    .execute(&mut *tx)
-    .await
-    .map_err(|e| {
-        format!(
-            "insert postgres create-pr dispatch event {}: {e}",
-            dispatch_id
-        )
-    })?;
-
-    sqlx::query(
-        "INSERT INTO dispatch_outbox (dispatch_id, action, agent_id, card_id, title)
-         VALUES ($1, 'notify', $2, $3, $4)
-         ON CONFLICT DO NOTHING",
-    )
-    .bind(&dispatch_id)
-    .bind(&payload.agent_id)
-    .bind(&payload.card_id)
-    .bind(&payload.title)
-    .execute(&mut *tx)
-    .await
-    .map_err(|e| format!("insert postgres create-pr outbox {}: {e}", dispatch_id))?;
 
     sqlx::query(
         "UPDATE kanban_cards
@@ -567,6 +538,7 @@ async fn handoff_create_pr_pg(
     }))
 }
 
+#[cfg(test)]
 fn lookup_active_create_pr_dispatch(
     conn: &libsql_rusqlite::Transaction<'_>,
     card_id: &str,
@@ -592,6 +564,7 @@ fn lookup_active_create_pr_dispatch(
     .map_err(|e| anyhow::anyhow!("lookup active create-pr dispatch for {card_id}: {e}"))
 }
 
+#[cfg(test)]
 fn seed_pr_tracking_handoff_state(
     tx: &libsql_rusqlite::Transaction<'_>,
     payload: &HandoffPayload,
@@ -628,6 +601,7 @@ fn seed_pr_tracking_handoff_state(
     Ok(())
 }
 
+#[cfg(test)]
 fn refresh_pr_tracking_reuse_state(
     tx: &libsql_rusqlite::Transaction<'_>,
     payload: &HandoffPayload,
@@ -651,148 +625,6 @@ fn refresh_pr_tracking_reuse_state(
     }
 
     Ok(())
-}
-
-fn load_dispatch_status(
-    tx: &libsql_rusqlite::Transaction<'_>,
-    dispatch_id: &str,
-) -> anyhow::Result<Option<String>> {
-    tx.query_row(
-        "SELECT status
-         FROM task_dispatches
-         WHERE id = ?1",
-        [dispatch_id],
-        |row| row.get(0),
-    )
-    .optional()
-    .map_err(|e| anyhow::anyhow!("load dispatch status for {dispatch_id}: {e}"))
-}
-
-fn handoff_create_pr_tx(db: &Db, payload: &HandoffPayload) -> anyhow::Result<serde_json::Value> {
-    let mut conn = db
-        .separate_conn()
-        .map_err(|e| anyhow::anyhow!("DB conn error: {e}"))?;
-    // Take the SQLite write lock up front so the reuse path does not fail with
-    // a deferred read->write upgrade when another WAL writer commits first.
-    let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-
-    // 1. Read current review_round early so reuse and fresh handoff paths keep
-    //    pr_tracking aligned with the currently active dispatch.
-    let current_round: i64 = tx
-        .query_row(
-            "SELECT review_round FROM card_review_state WHERE card_id = ?1",
-            [&payload.card_id],
-            |row| row.get(0),
-        )
-        .unwrap_or(0);
-
-    // 2. Idempotent reuse — refresh pr_tracking to the active dispatch stamp so
-    //    stale generations do not leak into retry logic.
-    if let Some((dispatch_id, generation)) =
-        lookup_active_create_pr_dispatch(&tx, &payload.card_id)?
-    {
-        match load_dispatch_status(&tx, &dispatch_id)?.as_deref() {
-            Some("pending") | Some("dispatched") => {
-                refresh_pr_tracking_reuse_state(&tx, payload, &generation, current_round)?;
-                tx.execute(
-                    "UPDATE kanban_cards SET blocked_reason = 'pr:creating', updated_at = datetime('now') \
-                     WHERE id = ?1",
-                    [&payload.card_id],
-                )?;
-                tx.commit()?;
-                return Ok(json!({
-                    "ok": true,
-                    "reused": true,
-                    "dispatch_id": dispatch_id,
-                    "generation": generation,
-                }));
-            }
-            Some("completed") => {
-                tx.commit()?;
-                return Ok(json!({
-                    "ok": true,
-                    "reused": true,
-                    "dispatch_id": dispatch_id,
-                    "generation": generation,
-                }));
-            }
-            _ => {
-                // The dispatch is no longer active; do not rewind card/tracking
-                // state back into create-pr reuse for a completed or failed lane.
-            }
-        }
-    }
-
-    // 3. Read card row for pipeline resolution + current status.
-    let (old_status, card_repo_id, card_agent_id): (String, Option<String>, Option<String>) = tx
-        .query_row(
-            "SELECT status, repo_id, assigned_agent_id FROM kanban_cards WHERE id = ?1",
-            [&payload.card_id],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-        )
-        .map_err(|e| anyhow::anyhow!("card not found: {e}"))?;
-
-    // 4. Resolve pipeline for TransitionContext.
-    crate::pipeline::ensure_loaded();
-    let effective =
-        crate::pipeline::resolve_for_card(&tx, card_repo_id.as_deref(), card_agent_id.as_deref());
-
-    // 5. Mint fresh generation + dispatch id.
-    let generation = Uuid::new_v4().to_string();
-    let dispatch_id = Uuid::new_v4().to_string();
-
-    // 6. pr_tracking upsert with stamp.
-    seed_pr_tracking_handoff_state(&tx, payload, &generation, current_round)?;
-
-    // 7. Build dispatch context with stamps.
-    let context = json!({
-        "dispatch_generation": generation,
-        "review_round_at_dispatch": current_round,
-        "sidecar_dispatch": true,
-        "worktree_path": payload.worktree_path,
-        "worktree_branch": payload.branch,
-        "branch": payload.branch,
-    });
-    let context_str = serde_json::to_string(&context)?;
-
-    // 8. Insert the create-pr dispatch using the on-conn variant so the whole
-    //    handoff stays in one transaction.
-    apply_dispatch_attached_intents_on_conn(
-        &tx,
-        &payload.card_id,
-        &payload.agent_id,
-        &dispatch_id,
-        "create-pr",
-        false, // is_review_type
-        &old_status,
-        &effective,
-        &payload.title,
-        &context_str,
-        None, // parent_dispatch_id
-        0,    // chain_depth
-        DispatchCreateOptions {
-            sidecar_dispatch: true,
-            ..Default::default()
-        },
-    )?;
-
-    // 9. Stamp blocked_reason='pr:creating' so timeouts/escalation treat the
-    //    in-flight handoff as benign progress (manual_intervention.rs benign
-    //    list includes "pr:creating" as of #743 commit 1).
-    tx.execute(
-        "UPDATE kanban_cards SET blocked_reason = 'pr:creating', updated_at = datetime('now') \
-         WHERE id = ?1",
-        [&payload.card_id],
-    )?;
-
-    tx.commit()?;
-
-    Ok(json!({
-        "ok": true,
-        "reused": false,
-        "dispatch_id": dispatch_id,
-        "generation": generation,
-    }))
 }
 
 // ── recordPrCreateFailure ──────────────────────────────────────────────

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -1623,23 +1623,25 @@ mod tests {
         seed_agent(&db);
         seed_card(&db, "card-s2", "review");
 
-        let r1 = dispatch::create_dispatch_core_sqlite_test(
+        let r1 = dispatch::create_dispatch_record_sqlite_test(
             &db,
             "card-s2",
             "agent-1",
             "review-decision",
             "[RD1]",
             &serde_json::json!({"verdict": "improve"}),
+            dispatch::DispatchCreateOptions::default(),
         );
         assert!(r1.is_ok(), "first review-decision should succeed");
 
-        let r2 = dispatch::create_dispatch_core_sqlite_test(
+        let r2 = dispatch::create_dispatch_record_sqlite_test(
             &db,
             "card-s2",
             "agent-1",
             "review-decision",
             "[RD2]",
             &serde_json::json!({"verdict": "rework"}),
+            dispatch::DispatchCreateOptions::default(),
         );
         assert!(r2.is_ok(), "second review-decision should succeed");
 
@@ -2671,13 +2673,14 @@ mod tests {
         seed_card(&db, "card-s6", "in_progress");
 
         // Step 1: Create implementation dispatch via canonical path
-        let (dispatch_id, _, _) = dispatch::create_dispatch_core_sqlite_test(
+        let (dispatch_id, _, _) = dispatch::create_dispatch_record_sqlite_test(
             &db,
             "card-s6",
             "agent-1",
             "implementation",
             "[Impl]",
             &serde_json::json!({}),
+            dispatch::DispatchCreateOptions::default(),
         )
         .unwrap();
         assert_eq!(get_dispatch_status(&db, &dispatch_id), "pending");
@@ -2761,13 +2764,14 @@ mod tests {
         seed_agent(&db);
         seed_card(&db, "card-s6b", "in_progress");
 
-        let (dispatch_id, _, _) = dispatch::create_dispatch_core_sqlite_test(
+        let (dispatch_id, _, _) = dispatch::create_dispatch_record_sqlite_test(
             &db,
             "card-s6b",
             "agent-1",
             "implementation",
             "[Impl]",
             &json!({}),
+            dispatch::DispatchCreateOptions::default(),
         )
         .unwrap();
         seed_assistant_response_for_dispatch(&db, &dispatch_id, "implemented card-s6b");
@@ -3465,7 +3469,7 @@ mod tests {
         );
 
         // Create dispatch via sqlite dispatch-core-with-id helper — should use card's effective pipeline
-        let result = dispatch::create_dispatch_core_with_id_sqlite_test(
+        let result = dispatch::create_dispatch_record_with_id_sqlite_test(
             &db,
             "d-s7-new",
             "card-s7",
@@ -3473,6 +3477,7 @@ mod tests {
             "implementation",
             "[S7 test]",
             &serde_json::json!({}),
+            dispatch::DispatchCreateOptions::default(),
         );
         assert!(
             result.is_ok(),
@@ -3501,13 +3506,14 @@ mod tests {
                 [],
             ).unwrap();
         }
-        let result2 = dispatch::create_dispatch_core_sqlite_test(
+        let result2 = dispatch::create_dispatch_record_sqlite_test(
             &db,
             "card-s7b",
             "agent-1",
             "implementation",
             "[S7b test]",
             &serde_json::json!({}),
+            dispatch::DispatchCreateOptions::default(),
         );
         assert!(
             result2.is_ok(),
@@ -3827,7 +3833,7 @@ mod tests {
             ).unwrap();
         }
 
-        let result_a = dispatch::create_dispatch_core_with_id_sqlite_test(
+        let result_a = dispatch::create_dispatch_record_with_id_sqlite_test(
             &db,
             "d-multi-a",
             "card-multi-a",
@@ -3835,6 +3841,7 @@ mod tests {
             "implementation",
             "[Multi A]",
             &serde_json::json!({}),
+            dispatch::DispatchCreateOptions::default(),
         );
         assert!(
             result_a.is_ok(),
@@ -3862,7 +3869,7 @@ mod tests {
             ).unwrap();
         }
 
-        let result_b = dispatch::create_dispatch_core_with_id_sqlite_test(
+        let result_b = dispatch::create_dispatch_record_with_id_sqlite_test(
             &db,
             "d-multi-b",
             "card-multi-b",
@@ -3870,6 +3877,7 @@ mod tests {
             "implementation",
             "[Multi B]",
             &serde_json::json!({}),
+            dispatch::DispatchCreateOptions::default(),
         );
         assert!(
             result_b.is_ok(),

--- a/src/server/routes/review_verdict/tests.rs
+++ b/src/server/routes/review_verdict/tests.rs
@@ -1511,13 +1511,14 @@ async fn new_review_decision_cancels_previous_pending() {
     }
 
     // Creating a new review-decision should cancel the old one
-    let result = crate::dispatch::create_dispatch_core_sqlite_test(
+    let result = crate::dispatch::create_dispatch_record_sqlite_test(
         &db,
         "card-dup",
         "agent-1",
         "review-decision",
         "[New RD]",
         &serde_json::json!({"verdict": "improve"}),
+        crate::dispatch::DispatchCreateOptions::default(),
     );
     assert!(
         result.is_ok(),

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -14,10 +14,7 @@ use std::sync::MutexGuard;
 use tower::ServiceExt;
 
 fn test_db() -> Db {
-    let conn = libsql_rusqlite::Connection::open_in_memory().unwrap();
-    conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
-    crate::db::schema::migrate(&conn).unwrap();
-    crate::db::wrap_conn(conn)
+    crate::db::test_db()
 }
 
 /// Seed test agents for dispatch-related tests (#245 agent-exists guard).
@@ -33,6 +30,11 @@ fn seed_test_agents(db: &Db) {
 fn test_engine(db: &Db) -> PolicyEngine {
     let config = crate::config::Config::default();
     PolicyEngine::new(&config, db.clone()).unwrap()
+}
+
+fn test_engine_with_pg(db: &Db, pg_pool: sqlx::PgPool) -> PolicyEngine {
+    let config = crate::config::Config::default();
+    PolicyEngine::new_with_pg(&config, db.clone(), Some(pg_pool)).unwrap()
 }
 
 fn test_api_router(
@@ -940,6 +942,7 @@ async fn offices_reorder_rejects_wrapped_order_body() {
     let app = test_api_router(db, engine, None);
 
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .method("PATCH")
@@ -963,6 +966,7 @@ async fn round_table_meeting_channels_endpoint_does_not_fall_through_to_meeting_
     let app = axum::Router::new().nest("/api", test_api_router(db, engine, None));
 
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .uri("/api/round-table-meetings/channels")
@@ -1057,6 +1061,7 @@ async fn round_table_meeting_channels_endpoint_returns_configured_experts_and_fa
     let app = axum::Router::new().nest("/api", test_api_router(db, engine, Some(health_registry)));
 
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .uri("/api/round-table-meetings/channels")
@@ -1150,6 +1155,7 @@ async fn agent_turn_returns_recent_output_from_inflight_snapshot() {
 
     let app = test_api_router(db, engine, None);
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .uri("/agents/agent-turn/turn")
@@ -1202,6 +1208,7 @@ async fn agent_turn_reports_idle_when_agent_has_no_active_session() {
 
     let app = test_api_router(db, engine, None);
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .uri("/agents/agent-idle/turn")
@@ -1304,6 +1311,7 @@ async fn stop_agent_turn_preserves_matching_tmux_session() {
 
     let app = test_api_router(db.clone(), engine, None);
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -3464,6 +3472,7 @@ async fn dispatch_create_and_get() {
 
     let app = test_api_router(db.clone(), engine.clone(), None);
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -3477,11 +3486,12 @@ async fn dispatch_create_and_get() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::CREATED);
+    let status = response.status();
     let body = axum::body::to_bytes(response.into_body(), usize::MAX)
         .await
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(status, StatusCode::CREATED, "unexpected response: {json}");
     let dispatch_id = json["dispatch"]["id"].as_str().unwrap().to_string();
     assert_eq!(json["dispatch"]["status"], "pending");
     assert_eq!(json["dispatch"]["kanban_card_id"], "c1");
@@ -3542,6 +3552,7 @@ async fn dispatch_create_for_terminal_card_returns_conflict_with_reason() {
 
     let app = test_api_router(db, engine, None);
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -3573,7 +3584,9 @@ async fn dispatch_create_for_terminal_card_returns_conflict_with_reason() {
 async fn dispatch_create_with_skip_outbox_omits_notify_row() {
     let db = test_db();
     seed_test_agents(&db);
-    let engine = test_engine(&db);
+    let pg_db = TestPostgresDb::create().await;
+    let pg_pool = pg_db.connect_and_migrate().await;
+    let engine = test_engine_with_pg(&db, pg_pool.clone());
 
     {
         let conn = db.lock().unwrap();
@@ -3583,8 +3596,38 @@ async fn dispatch_create_with_skip_outbox_omits_notify_row() {
             ).unwrap();
     }
 
-    let app = test_api_router(db.clone(), engine, None);
+    sqlx::query(
+        "INSERT INTO agents (id, name, discord_channel_id, discord_channel_alt)
+         VALUES ($1, $2, $3, $4)",
+    )
+    .bind("ch-td")
+    .bind("TD")
+    .bind("111")
+    .bind("222")
+    .execute(&pg_pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO kanban_cards (id, title, status, priority)
+         VALUES ($1, $2, $3, $4)",
+    )
+    .bind("c1-skip")
+    .bind("Card1 Skip")
+    .bind("ready")
+    .bind("medium")
+    .execute(&pg_pool)
+    .await
+    .unwrap();
+
+    let app = test_api_router_with_pg(
+        db.clone(),
+        engine,
+        crate::config::Config::default(),
+        None,
+        pg_pool.clone(),
+    );
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -3598,25 +3641,33 @@ async fn dispatch_create_with_skip_outbox_omits_notify_row() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::CREATED);
+    let status = response.status();
     let body = axum::body::to_bytes(response.into_body(), usize::MAX)
         .await
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(status, StatusCode::CREATED, "unexpected response: {json}");
     let dispatch_id = json["dispatch"]["id"].as_str().unwrap().to_string();
 
-    let conn = db.lock().unwrap();
-    let notify_count: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM dispatch_outbox WHERE dispatch_id = ?1 AND action = 'notify'",
-            [&dispatch_id],
-            |row| row.get(0),
-        )
-        .unwrap();
+    let verify_pool = sqlx::PgPool::connect(&pg_db.database_url).await.unwrap();
+    let notify_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)::bigint
+         FROM dispatch_outbox
+         WHERE dispatch_id = $1 AND action = 'notify'",
+    )
+    .bind(&dispatch_id)
+    .fetch_one(&verify_pool)
+    .await
+    .unwrap();
     assert_eq!(
         notify_count, 0,
         "skip_outbox=true must suppress notify outbox persistence"
     );
+
+    verify_pool.close().await;
+    drop(app);
+    pg_pool.close().await;
+    pg_db.drop().await;
 }
 
 /// #761: A crafted `POST /api/dispatches` call that preseeds review-target
@@ -3628,17 +3679,18 @@ async fn dispatch_create_with_skip_outbox_omits_notify_row() {
 async fn dispatch_create_review_strips_untrusted_review_target_fields_from_context() {
     let db = test_db();
     seed_test_agents(&db);
-    let engine = test_engine(&db);
+    let pg_db = TestPostgresDb::create().await;
+    let pg_pool = pg_db.connect_and_migrate().await;
+    let engine = test_engine_with_pg(&db, pg_pool.clone());
 
-    // Real repo with a commit that mentions issue #761 — this is the commit
-    // the validation/refresh chain must resolve to, NOT the injected one.
+    // Real repo exists on the card, but the caller injects a foreign
+    // external target_repo. The hardened path must fail closed instead of
+    // silently falling back to the card repo and reviewing unrelated code.
     let (repo, _repo_override) = setup_test_repo();
-    let real_commit = git_commit(repo.path(), "fix: real work for card (#761)");
     let real_worktree_path = repo.path().to_string_lossy().into_owned();
 
-    // Card in the review-ready state (pre-review), linked to the real repo
-    // via a repo_id that resolves (via AGENTDESK_REPO_DIR set by
-    // setup_test_repo) to `repo.path()`.
+    // Card in the review-ready state (pre-review), linked to a real repo
+    // path while the caller injects a conflicting foreign target_repo.
     {
         let conn = db.lock().unwrap();
         conn.execute(
@@ -3653,6 +3705,35 @@ async fn dispatch_create_review_strips_untrusted_review_target_fields_from_conte
         )
         .unwrap();
     }
+
+    sqlx::query(
+        "INSERT INTO agents (id, name, discord_channel_id, discord_channel_alt)
+         VALUES ($1, $2, $3, $4)",
+    )
+    .bind("ch-td")
+    .bind("TD")
+    .bind("111")
+    .bind("222")
+    .execute(&pg_pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO kanban_cards (
+            id, title, status, priority, assigned_agent_id, github_issue_number, repo_id
+         ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7
+         )",
+    )
+    .bind("card-761")
+    .bind("Preseed review target")
+    .bind("in_progress")
+    .bind("medium")
+    .bind("ch-td")
+    .bind(761_i64)
+    .bind(&real_worktree_path)
+    .execute(&pg_pool)
+    .await
+    .unwrap();
 
     // Simulate a malicious / buggy caller preseeding review-target fields.
     // The injected commit SHA is syntactically valid but points at nothing
@@ -3680,8 +3761,15 @@ async fn dispatch_create_review_strips_untrusted_review_target_fields_from_conte
     })
     .to_string();
 
-    let app = test_api_router(db.clone(), engine, None);
+    let app = test_api_router_with_pg(
+        db.clone(),
+        engine,
+        crate::config::Config::default(),
+        None,
+        pg_pool.clone(),
+    );
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -3693,64 +3781,53 @@ async fn dispatch_create_review_strips_untrusted_review_target_fields_from_conte
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::CREATED);
+    let status = response.status();
     let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
         .await
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
-    let context = &json["dispatch"]["context"];
-
-    // The injected values MUST NOT survive into the persisted dispatch
-    // context. Either the field is missing (validation chain found nothing)
-    // or it was overwritten with the real target from the card's history.
-    assert_ne!(
-        context["reviewed_commit"].as_str(),
-        Some(injected_commit),
-        "injected reviewed_commit must not propagate into review dispatch context"
-    );
-    assert_ne!(
-        context["worktree_path"].as_str(),
-        Some(injected_worktree),
-        "injected worktree_path must not propagate into review dispatch context"
-    );
-    assert_ne!(
-        context["branch"].as_str(),
-        Some("attacker/controlled-branch"),
-        "injected branch must not propagate into review dispatch context"
-    );
-    assert_ne!(
-        context["target_repo"].as_str(),
-        Some(injected_target_repo),
-        "injected target_repo must not propagate into review dispatch context"
-    );
-
-    // The real target (resolved via find_latest_commit_for_issue for #761)
-    // must have replaced the injected one.
     assert_eq!(
-        context["reviewed_commit"].as_str(),
-        Some(real_commit.as_str()),
-        "validation chain must overwrite reviewed_commit with the real commit for this card's issue"
+        status,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "unexpected response: {json}"
     );
-    let canonical = |value: &str| {
-        std::fs::canonicalize(value)
-            .unwrap()
-            .to_string_lossy()
-            .into_owned()
-    };
-    assert_eq!(
-        canonical(context["worktree_path"].as_str().unwrap()),
-        canonical(&real_worktree_path),
-        "worktree_path must resolve to the card's real repo dir"
-    );
-
-    // #761 (Codex round-2): The `_trusted_review_target` flag must be
-    // scrubbed from the persisted dispatch context — it has no meaning on
-    // the API-sourced path and must not become an audit artifact that
-    // implies the client steered the review target.
+    let error = json["error"].as_str().unwrap_or_default();
     assert!(
-        context.get("_trusted_review_target").is_none(),
-        "client-supplied _trusted_review_target flag must not persist into the dispatch context"
+        error.contains("external_target_repo_unrecoverable"),
+        "expected fail-closed external_target_repo guard, got {json}"
     );
+    assert!(
+        error.contains(injected_target_repo),
+        "error should point at the rejected injected target_repo, got {json}"
+    );
+    assert!(
+        !json.to_string().contains(injected_commit),
+        "error response must not echo the injected reviewed_commit: {json}"
+    );
+    assert!(
+        !json.to_string().contains(injected_worktree),
+        "error response must not echo the injected worktree_path: {json}"
+    );
+    assert!(
+        !json.to_string().contains("attacker/controlled-branch"),
+        "error response must not echo the injected branch: {json}"
+    );
+
+    let dispatch_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)::bigint FROM task_dispatches WHERE kanban_card_id = $1",
+    )
+    .bind("card-761")
+    .fetch_one(&pg_pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        dispatch_count, 0,
+        "fail-closed review-target validation must not persist a dispatch row"
+    );
+
+    drop(app);
+    pg_pool.close().await;
+    pg_db.drop().await;
 }
 
 /// #761 (Codex round-2): Focused negative test for the trust-boundary
@@ -3768,7 +3845,9 @@ async fn dispatch_create_review_strips_untrusted_review_target_fields_from_conte
 async fn dispatch_create_review_ignores_client_trusted_review_target_flag() {
     let db = test_db();
     seed_test_agents(&db);
-    let engine = test_engine(&db);
+    let pg_db = TestPostgresDb::create().await;
+    let pg_pool = pg_db.connect_and_migrate().await;
+    let engine = test_engine_with_pg(&db, pg_pool.clone());
 
     // Deliberately do NOT seed any work dispatch or pr_tracking row for this
     // card — the validation/refresh chain has nothing to resolve. If the
@@ -3789,6 +3868,34 @@ async fn dispatch_create_review_ignores_client_trusted_review_target_flag() {
         .unwrap();
     }
 
+    sqlx::query(
+        "INSERT INTO agents (id, name, discord_channel_id, discord_channel_alt)
+         VALUES ($1, $2, $3, $4)",
+    )
+    .bind("ch-td")
+    .bind("TD")
+    .bind("111")
+    .bind("222")
+    .execute(&pg_pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO kanban_cards (
+            id, title, status, priority, assigned_agent_id, github_issue_number
+         ) VALUES (
+            $1, $2, $3, $4, $5, $6
+         )",
+    )
+    .bind("card-761-flag")
+    .bind("Ignore trust flag")
+    .bind("in_progress")
+    .bind("medium")
+    .bind("ch-td")
+    .bind(999999_i64)
+    .execute(&pg_pool)
+    .await
+    .unwrap();
+
     let injected_commit = "cafef00dcafef00dcafef00dcafef00dcafef00d";
     let injected_worktree = "/tmp/agentdesk-761-flag-attacker-worktree";
     let injected_target_repo = "/tmp/agentdesk-761-flag-attacker-repo";
@@ -3808,8 +3915,15 @@ async fn dispatch_create_review_ignores_client_trusted_review_target_flag() {
     })
     .to_string();
 
-    let app = test_api_router(db, engine, None);
+    let app = test_api_router_with_pg(
+        db,
+        engine,
+        crate::config::Config::default(),
+        None,
+        pg_pool.clone(),
+    );
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -3868,6 +3982,10 @@ async fn dispatch_create_review_ignores_client_trusted_review_target_flag() {
             "error response must not echo the injected reviewed_commit: {json}"
         );
     }
+
+    drop(app);
+    pg_pool.close().await;
+    pg_db.drop().await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- remove the remaining production-facing sqlite fallback from dispatch/create-pr handoff paths and rename the raw dispatch JS hook to the PG-only surface
- keep sqlite dispatch helpers explicitly test-only while updating sqlite-backed tests to the renamed helper APIs
- convert critical `/dispatches` route tests to PG-backed coverage and align the #761 security expectation with the current fail-closed behavior
- fix PG dispatch row decoding by casting `chain_depth` and `retry_count` to `bigint` in `query_dispatch_row_pg`

## Verification
- `cargo test -q dispatch_create_with_skip_outbox_omits_notify_row --bin agentdesk -- --test-threads=1`
- `cargo test -q dispatch_create_review_strips_untrusted_review_target_fields_from_context --bin agentdesk -- --test-threads=1`
- `cargo test -q dispatch_create_review_ignores_client_trusted_review_target_flag --bin agentdesk -- --test-threads=1`
- `cargo test -q dispatch:: --bin agentdesk -- --test-threads=1`
- `cargo test -q review_automation_pg_handoff_failure_and_reseed_round_trip --bin agentdesk -- --test-threads=1`
- `cargo test -q new_review_decision_cancels_previous_pending --bin agentdesk -- --test-threads=1`
- `cargo build --bin agentdesk`

Closes #850