### PR TITLE
feat(dashboard): restore claude design fidelity

### DIFF
--- a/dashboard/e2e/smoke.spec.ts
+++ b/dashboard/e2e/smoke.spec.ts
@@ -915,6 +915,9 @@ test.describe("Dashboard smoke tests", () => {
 
   test("theme: dark/light toggle changes CSS variables", async ({ page }) => {
     await page.goto("/");
+    await page
+      .getByRole("button", { name: /^디자인 설정 열기$|^Open tweaks$/ })
+      .click();
     await page.getByRole("button", { name: /^다크$|^Dark$/ }).click();
     await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
     const darkBg = await page.evaluate(() =>
@@ -938,6 +941,9 @@ test.describe("Dashboard smoke tests", () => {
   test("theme: auto mode responds to prefers-color-scheme", async ({ page }) => {
     await page.emulateMedia({ colorScheme: "dark" });
     await page.goto("/");
+    await page
+      .getByRole("button", { name: /^디자인 설정 열기$|^Open tweaks$/ })
+      .click();
     await page.getByRole("button", { name: /^자동$|^Auto$/ }).click();
     await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
 
@@ -1136,10 +1142,13 @@ test.describe("Dashboard smoke tests", () => {
     await page.goto("/meetings");
 
     await expect(page.getByTestId("meetings-page")).toBeVisible({ timeout: 15000 });
-    await expect(page.getByTestId("meetings-page-timeline")).toBeVisible();
-    await expect(page.getByTestId("meetings-page-skills")).toBeVisible();
-    await expect(page.getByText(/로드밸런서 경고 플로우 리뷰/)).toBeVisible();
-    await expect(page.getByText(/office-warning-disclosure/)).toBeVisible();
+    const timelinePane = page.getByTestId("meetings-page-timeline");
+    const skillsPane = page.getByTestId("meetings-page-skills");
+
+    await expect(timelinePane).toBeVisible();
+    await expect(skillsPane).toBeVisible();
+    await expect(timelinePane.getByText(/로드밸런서 경고 플로우 리뷰/).first()).toBeVisible();
+    await expect(skillsPane.getByText(/office-warning-disclosure/).first()).toBeVisible();
   });
 
   test("meetings: mobile switches between timeline and skills", async ({ page }, testInfo) => {
@@ -1307,11 +1316,14 @@ test.describe("Dashboard smoke tests", () => {
     await expect(page.getByTestId("ops-bottleneck-outbox_age")).toBeVisible();
   });
 
-  test("settings button routes to settings page", async ({ page }, testInfo) => {
+  test("settings route is reachable from the desktop shell", async ({ page }, testInfo) => {
     test.skip(testInfo.project.name === "mobile", "Desktop-only test");
     await page.goto("/home");
 
-    await page.getByRole("button", { name: /설정으로 이동|Open settings/ }).click();
+    await page
+      .getByTestId("app-sidebar-nav")
+      .getByRole("button", { name: /^설정$|^Settings$/ })
+      .click();
     await expect(page).toHaveURL(/\/settings(\?.*)?$/);
     await expect(page.getByTestId("topbar")).toContainText(/설정|Settings/);
   });

--- a/dashboard/src/app/AppShell.tsx
+++ b/dashboard/src/app/AppShell.tsx
@@ -3,21 +3,25 @@ import {
   Bell,
   BellRing,
   Building2,
-  ChevronLeft,
   ChevronRight,
+  Flame,
   FolderKanban,
+  GripVertical,
   Home,
   LayoutDashboard,
   Menu,
+  Moon,
+  Sun,
   Search,
   Settings,
   Sparkles,
+  Target,
   Trophy,
   Users,
-  Wifi,
   WifiOff,
   Wrench,
   X,
+  Zap,
 } from "lucide-react";
 import {
   Link,
@@ -34,6 +38,7 @@ import type {
   DashboardStats,
   KanbanCard,
   RoundTableMeeting,
+  TokenAnalyticsResponse,
 } from "../types";
 import { DEFAULT_SETTINGS } from "../types";
 import * as api from "../api/client";
@@ -49,12 +54,10 @@ import { deriveOfficeAgentState } from "../components/office-view/officeAgentSta
 import OfficeSelectorBar from "../components/OfficeSelectorBar";
 import { MOBILE_LAYOUT_MEDIA_QUERY } from "./breakpoints";
 import {
-  APP_ROUTE_SECTIONS,
   DEFAULT_ROUTE_PATH,
   PALETTE_ROUTES,
   PRIMARY_ROUTES,
   findRouteByPath,
-  getSectionById,
   type AppRouteEntry,
   type AppRouteId,
 } from "./routes";
@@ -74,7 +77,7 @@ import {
 } from "./themePreferences";
 
 const OfficeView = lazy(() => import("../components/OfficeView"));
-const DashboardPageView = lazy(() => import("../components/DashboardPageView"));
+const AchievementsPage = lazy(() => import("../components/AchievementsPage"));
 const StatsPageView = lazy(() => import("../components/StatsPageView"));
 const OpsPageView = lazy(() => import("../components/OpsPageView"));
 const KanbanTab = lazy(() => import("../components/agent-manager/KanbanTab"));
@@ -101,7 +104,6 @@ interface AppShellProps {
 type AgentsPageTab = "agents" | "departments" | "backlog" | "dispatch";
 type KanbanSignalFocus = "review" | "blocked" | "requested" | "stalled";
 
-const SIDEBAR_COLLAPSED_STORAGE_KEY = "agentdesk.sidebar.collapsed";
 const MOBILE_TABBAR_SAFE_AREA_HEIGHT = "calc(3.5rem + env(safe-area-inset-bottom))";
 const MOBILE_PRIMARY_ROUTE_IDS: AppRouteId[] = [
   "home",
@@ -109,12 +111,26 @@ const MOBILE_PRIMARY_ROUTE_IDS: AppRouteId[] = [
   "kanban",
   "stats",
 ];
-const MOBILE_MORE_ROUTE_IDS: AppRouteId[] = [
-  "agents",
-  "ops",
-  "meetings",
-  "achievements",
-  "settings",
+const SIDEBAR_SECTION_ORDER: Array<{
+  id: "workspace" | "extensions" | "me";
+  labelKo: string;
+  labelEn: string;
+}> = [
+  {
+    id: "workspace",
+    labelKo: "워크스페이스",
+    labelEn: "Workspace",
+  },
+  {
+    id: "extensions",
+    labelKo: "확장",
+    labelEn: "Extensions",
+  },
+  {
+    id: "me",
+    labelKo: "나",
+    labelEn: "Me",
+  },
 ];
 // Keep persistent shell chrome below route-level backdrops and modals.
 const ROUTE_OVERLAY_BASE_Z_INDEX = 50;
@@ -195,16 +211,11 @@ export default function AppShell({
   const [showCommandPalette, setShowCommandPalette] = useState(false);
   const [showShortcutHelp, setShowShortcutHelp] = useState(false);
   const [showNotificationPanel, setShowNotificationPanel] = useState(false);
+  const [showTweaksPanel, setShowTweaksPanel] = useState(false);
   const [showMobileMoreMenu, setShowMobileMoreMenu] = useState(false);
   const [agentsPageTab, setAgentsPageTab] = useState<AgentsPageTab>("agents");
   const [kanbanSignalFocus, setKanbanSignalFocus] =
     useState<KanbanSignalFocus | null>(null);
-  const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(() => {
-    if (typeof window === "undefined") return false;
-    return (
-      window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === "true"
-    );
-  });
   const [themePreference, setThemePreference] = useState<ThemePreference>(() =>
     readStoredThemePreference(window.localStorage, settings.theme),
   );
@@ -230,19 +241,27 @@ export default function AppShell({
   const unreadCount = notifications.filter(
     (notification) => Date.now() - notification.ts < 60_000,
   ).length;
+  const kanbanBadgeCount = kanbanCards.filter(
+    (card) =>
+      card.status === "requested" ||
+      card.status === "in_progress" ||
+      card.status === "review" ||
+      card.status === "blocked",
+  ).length;
   const notificationBadgeCount = unresolvedMeetingsCount + unreadCount;
   const resolvedTheme = useMemo(
     () => resolveThemePreference(themePreference, prefersDarkScheme),
     [prefersDarkScheme, themePreference],
   );
   const recentNotifications = notifications.slice(0, 6);
-
-  useEffect(() => {
-    window.localStorage.setItem(
-      SIDEBAR_COLLAPSED_STORAGE_KEY,
-      String(sidebarCollapsed),
-    );
-  }, [sidebarCollapsed]);
+  const currentOfficeName = useMemo(
+    () => selectedOfficeLabel(offices, selectedOfficeId, tr),
+    [offices, selectedOfficeId, tr],
+  );
+  const currentUserLabel = "you";
+  const currentUserDetail = wsConnected
+    ? tr(`${currentOfficeName} · 실시간 연결`, `${currentOfficeName} · live link`)
+    : tr(`${currentOfficeName} · 재연결 중`, `${currentOfficeName} · reconnecting`);
 
   useEffect(() => {
     const query = window.matchMedia("(prefers-color-scheme: dark)");
@@ -286,7 +305,7 @@ export default function AppShell({
 
   useEffect(() => {
     setShowNotificationPanel(false);
-    setShowMobileMoreMenu(false);
+    setShowTweaksPanel(false);
   }, [location.pathname]);
 
   useEffect(() => {
@@ -319,9 +338,7 @@ export default function AppShell({
     ) => {
       setShowMobileMoreMenu(false);
       if (options?.agentsTab) {
-        setAgentsPageTab(
-          options.agentsTab === "dispatch" ? "backlog" : options.agentsTab,
-        );
+        setAgentsPageTab(options.agentsTab);
       }
       if (options?.kanbanFocus) {
         setKanbanSignalFocus(options.kanbanFocus);
@@ -373,6 +390,14 @@ export default function AppShell({
     setOfficeInfoMode("default");
   }, []);
 
+  const toggleShellTheme = useCallback(() => {
+    setThemePreference((currentPreference) => {
+      const activeTheme =
+        currentPreference === "auto" ? resolvedTheme : currentPreference;
+      return activeTheme === "dark" ? "light" : "dark";
+    });
+  }, [resolvedTheme]);
+
   useEffect(() => {
     if (officeInfoMode === "office" && currentRoute?.id !== "office") {
       closeOfficeInfo();
@@ -422,57 +447,78 @@ export default function AppShell({
     return () => window.removeEventListener("keydown", handler);
   }, [navigateToRoute]);
 
-  const breadcrumbSection = getSectionById(
-    currentRoute?.section ?? APP_ROUTE_SECTIONS[0].id,
-  );
   const mobilePrimaryRoutes = useMemo(
     () =>
-      PRIMARY_ROUTES.filter((route) =>
-        MOBILE_PRIMARY_ROUTE_IDS.includes(route.id),
-      ),
+      MOBILE_PRIMARY_ROUTE_IDS.map((routeId) =>
+        PRIMARY_ROUTES.find((route) => route.id === routeId),
+      ).filter((route): route is AppRouteEntry => route !== undefined),
     [],
   );
-  const mobileMoreRoutes = useMemo(
+  const mobileOverflowSections = useMemo(
     () =>
-      PRIMARY_ROUTES.filter((route) =>
-        MOBILE_MORE_ROUTE_IDS.includes(route.id),
-      ),
+      SIDEBAR_SECTION_ORDER.map((section) => ({
+        ...section,
+        routes: PRIMARY_ROUTES.filter(
+          (route) =>
+            route.section === section.id &&
+            !MOBILE_PRIMARY_ROUTE_IDS.includes(route.id),
+        ),
+      })).filter((section) => section.routes.length > 0),
     [],
   );
   const activeMobileRouteId =
     showMobileMoreMenu ||
-    (currentRoute && MOBILE_MORE_ROUTE_IDS.includes(currentRoute.id))
+    (currentRoute && !MOBILE_PRIMARY_ROUTE_IDS.includes(currentRoute.id))
       ? "more"
-      : currentRoute && MOBILE_PRIMARY_ROUTE_IDS.includes(currentRoute.id)
-        ? currentRoute.id
-        : "home";
+      : currentRoute?.id ?? "home";
+  const sidebarBadgeForRoute = useCallback(
+    (routeId: AppRouteId): number | undefined => {
+      switch (routeId) {
+        case "kanban":
+          return kanbanBadgeCount || undefined;
+        case "meetings":
+          return unresolvedMeetingsCount || undefined;
+        case "settings":
+          return unreadCount || undefined;
+        default:
+          return undefined;
+      }
+    },
+    [kanbanBadgeCount, unreadCount, unresolvedMeetingsCount],
+  );
 
   return (
     <div
       className="fixed inset-0 flex overflow-hidden"
-      style={{ background: "var(--th-bg-primary)" }}
+      style={{
+        background:
+          "linear-gradient(180deg, color-mix(in srgb, var(--th-bg-primary) 98%, black 2%) 0%, var(--th-bg-primary) 100%)",
+      }}
     >
       {!isMobileViewport && (
         <aside
           data-testid="app-sidebar-nav"
-          className="flex flex-col border-r"
+          className="flex w-[236px] shrink-0 flex-col border-r"
           style={{
-            width: sidebarCollapsed ? "5.5rem" : "15rem",
             borderColor: "var(--th-border-subtle)",
             background:
-              "linear-gradient(180deg, color-mix(in srgb, var(--th-nav-bg) 96%, black 4%) 0%, color-mix(in srgb, var(--th-bg-surface) 94%, transparent) 100%)",
+              "linear-gradient(180deg, color-mix(in srgb, var(--th-nav-bg) 98%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 92%, transparent) 100%)",
           }}
         >
           <div
-            className={`flex items-center gap-3 border-b px-4 py-4 ${
-              sidebarCollapsed ? "justify-center" : ""
-            }`}
+            className="border-b px-4 py-5"
             style={{ borderColor: "var(--th-border-subtle)" }}
           >
-            <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-emerald-500/15 text-xl text-emerald-300">
-              🐾
-            </div>
-            {!sidebarCollapsed && (
+            <div className="flex items-center gap-3">
+              <div
+                className="flex h-11 w-11 items-center justify-center rounded-2xl text-sm font-semibold"
+                style={{
+                  background: "var(--th-accent-primary-soft)",
+                  color: "var(--th-accent-primary)",
+                }}
+              >
+                AD
+              </div>
               <div className="min-w-0">
                 <div
                   className="truncate text-sm font-semibold"
@@ -484,64 +530,33 @@ export default function AppShell({
                   className="truncate text-xs"
                   style={{ color: "var(--th-text-muted)" }}
                 >
-                  {isKo ? "앱 셸 v2" : "App shell v2"}
+                  v2.4.1
                 </div>
               </div>
-            )}
-            <button
-              type="button"
-              onClick={() => setSidebarCollapsed((prev) => !prev)}
-              className="ml-auto hidden h-9 w-9 items-center justify-center rounded-xl border text-[var(--th-text-secondary)] transition-colors hover:bg-white/5 md:flex"
-              style={{ borderColor: "var(--th-border-subtle)" }}
-              aria-label={
-                sidebarCollapsed
-                  ? tr("사이드바 펼치기", "Expand sidebar")
-                  : tr("사이드바 접기", "Collapse sidebar")
-              }
-              title={
-                sidebarCollapsed
-                  ? tr("사이드바 펼치기", "Expand sidebar")
-                  : tr("사이드바 접기", "Collapse sidebar")
-              }
-            >
-              {sidebarCollapsed ? (
-                <ChevronRight size={16} />
-              ) : (
-                <ChevronLeft size={16} />
-              )}
-            </button>
+            </div>
           </div>
 
           <div className="flex-1 overflow-y-auto px-3 py-4">
-            {APP_ROUTE_SECTIONS.map((section) => {
+            {SIDEBAR_SECTION_ORDER.map((section) => {
               const routes = PRIMARY_ROUTES.filter(
                 (route) => route.section === section.id,
               );
               return (
                 <div key={section.id} className="mb-5">
-                  {!sidebarCollapsed && (
-                    <div
-                      className="px-3 pb-2 text-[11px] font-semibold uppercase tracking-[0.18em]"
-                      style={{ color: "var(--th-text-muted)" }}
-                    >
-                      {isKo ? section.labelKo : section.labelEn}
-                    </div>
-                  )}
+                  <div
+                    className="px-3 pb-2 text-[11px] font-semibold uppercase tracking-[0.18em]"
+                    style={{ color: "var(--th-text-muted)" }}
+                  >
+                    {isKo ? section.labelKo : section.labelEn}
+                  </div>
                   <div className="space-y-1">
                     {routes.map((route) => (
                       <SidebarRouteButton
                         key={route.id}
                         route={route}
                         currentRouteId={currentRoute?.id ?? null}
-                        collapsed={sidebarCollapsed}
                         isKo={isKo}
-                        badge={
-                          route.id === "meetings"
-                            ? unresolvedMeetingsCount || undefined
-                            : route.id === "settings"
-                              ? unreadCount || undefined
-                              : undefined
-                        }
+                        badge={sidebarBadgeForRoute(route.id)}
                         onNavigate={() => {
                           if (route.id === "agents") {
                             setAgentsPageTab("agents");
@@ -557,45 +572,63 @@ export default function AppShell({
           </div>
 
           <div
-            className="border-t px-3 py-3"
+            className="border-t px-3 py-4"
             style={{ borderColor: "var(--th-border-subtle)" }}
           >
-            <div
-              className={`flex items-center gap-3 rounded-2xl border px-3 py-3 ${
-                sidebarCollapsed ? "justify-center" : ""
-              }`}
-              style={{
-                borderColor: wsConnected ? "#1f9d66" : "#9f3f3f",
-                background: wsConnected
-                  ? "rgba(16, 185, 129, 0.08)"
-                  : "rgba(239, 68, 68, 0.08)",
-              }}
-            >
-              {wsConnected ? (
-                <Wifi size={16} className="text-emerald-400" />
-              ) : (
-                <WifiOff size={16} className="text-red-400" />
-              )}
-              {!sidebarCollapsed && (
+            <div className="space-y-2">
+              <div
+                className="flex items-center gap-2 rounded-2xl border px-3 py-2"
+                style={{
+                  borderColor: "var(--th-border-subtle)",
+                  background: "var(--th-overlay-subtle)",
+                  color: "var(--th-text-muted)",
+                }}
+              >
+                <span
+                  className={`h-2 w-2 rounded-full ${wsConnected ? "animate-pulse" : ""}`}
+                  style={{
+                    background: wsConnected ? "var(--th-accent-success)" : "var(--th-accent-danger)",
+                  }}
+                />
+                <span className="font-mono text-[11px]">
+                  {wsConnected
+                    ? tr("2/2 providers", "2/2 providers")
+                    : tr("0/2 providers", "0/2 providers")}
+                </span>
+              </div>
+
+              <div
+                className="flex items-center gap-3 rounded-2xl border px-3 py-3"
+                style={{
+                  borderColor: "var(--th-border-subtle)",
+                  background:
+                    "color-mix(in srgb, var(--th-card-bg) 90%, transparent)",
+                }}
+              >
+                <div
+                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-semibold"
+                  style={{
+                    background: "var(--th-overlay-subtle)",
+                    color: "var(--th-text-primary)",
+                  }}
+                >
+                  AD
+                </div>
                 <div className="min-w-0">
                   <div
-                    className="text-xs font-semibold"
-                    style={{ color: "var(--th-text-primary)" }}
+                    className="truncate text-sm font-medium"
+                    style={{ color: "var(--th-text-heading)" }}
                   >
-                    {wsConnected
-                      ? tr("서버 연결됨", "Server connected")
-                      : tr("재연결 중", "Reconnecting")}
+                    {currentUserLabel}
                   </div>
                   <div
                     className="truncate text-[11px]"
                     style={{ color: "var(--th-text-muted)" }}
                   >
-                    {wsConnected
-                      ? tr("실시간 업데이트 수신 중", "Realtime updates active")
-                      : tr("웹소켓 상태를 확인하세요", "Check websocket status")}
+                    {currentUserDetail}
                   </div>
                 </div>
-              )}
+              </div>
             </div>
           </div>
         </aside>
@@ -604,45 +637,37 @@ export default function AppShell({
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
         <header
           data-testid="topbar"
-          className="relative shrink-0 border-b px-4 py-3 sm:px-5"
+          className="relative shrink-0 border-b px-4 py-2.5 sm:px-5"
           style={{
             zIndex: SHELL_HEADER_Z_INDEX,
             borderColor: "var(--th-border-subtle)",
             background:
-              "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 94%, transparent) 100%)",
+              "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 93%, transparent) 100%)",
+            backdropFilter: "blur(14px)",
           }}
         >
-          <div className="flex flex-wrap items-center gap-3">
+          <div className="flex flex-wrap items-center gap-2 sm:flex-nowrap">
             <div className="min-w-0 flex-1">
               <div
-                className="flex items-center gap-2 text-xs font-medium"
+                className="flex items-center gap-2 text-[12px] font-medium"
                 style={{ color: "var(--th-text-muted)" }}
               >
-                <span>{isKo ? breadcrumbSection.labelKo : breadcrumbSection.labelEn}</span>
+                <span>AgentDesk</span>
                 <ChevronRight size={12} />
                 <span>{currentRoute ? (isKo ? currentRoute.labelKo : currentRoute.labelEn) : (isKo ? "홈" : "Home")}</span>
-              </div>
-              <div
-                className="mt-1 text-lg font-semibold tracking-tight"
-                style={{ color: "var(--th-text-heading)" }}
-              >
-                {currentRoute
-                  ? isKo
-                    ? currentRoute.labelKo
-                    : currentRoute.labelEn
-                  : tr("홈", "Home")}
               </div>
             </div>
 
             <label
               data-testid="topbar-search"
-              className="order-3 flex min-w-[14rem] flex-1 items-center gap-2 rounded-2xl border px-3 py-2 text-sm sm:order-none sm:max-w-md"
+              className="order-3 flex min-w-[11rem] flex-1 items-center gap-2 rounded-2xl border px-3 py-2 text-sm sm:order-none sm:max-w-[18rem]"
               style={{
                 borderColor: "var(--th-border-subtle)",
-                background: "color-mix(in srgb, var(--th-bg-surface) 92%, transparent)",
+                background:
+                  "color-mix(in srgb, var(--th-bg-surface) 82%, transparent)",
               }}
             >
-              <Search size={16} style={{ color: "var(--th-text-muted)" }} />
+              <Search size={15} style={{ color: "var(--th-text-muted)" }} />
               <input
                 type="search"
                 readOnly
@@ -650,8 +675,8 @@ export default function AppShell({
                 onFocus={() => setShowCommandPalette(true)}
                 onClick={() => setShowCommandPalette(true)}
                 placeholder={tr(
-                  "페이지, 에이전트, 부서 검색",
-                  "Search pages, agents, departments",
+                  "검색…",
+                  "Search…",
                 )}
                 className="w-full bg-transparent text-sm outline-none"
                 style={{ color: "var(--th-text-primary)" }}
@@ -668,14 +693,46 @@ export default function AppShell({
               </kbd>
             </label>
 
-            <div className="ml-auto flex items-center gap-2 sm:ml-0">
+            <div className="ml-auto flex flex-wrap items-center justify-end gap-2 sm:ml-0">
+              <button
+                type="button"
+                onClick={toggleShellTheme}
+                className="flex h-9 w-9 items-center justify-center rounded-2xl border transition-colors hover:bg-white/5"
+                style={{ borderColor: "var(--th-border-subtle)" }}
+                aria-label={tr(
+                  resolvedTheme === "dark"
+                    ? "라이트 테마로 전환"
+                    : "다크 테마로 전환",
+                  resolvedTheme === "dark"
+                    ? "Switch to light theme"
+                    : "Switch to dark theme",
+                )}
+                title={tr(
+                  resolvedTheme === "dark"
+                    ? "라이트 테마로 전환"
+                    : "다크 테마로 전환",
+                  resolvedTheme === "dark"
+                    ? "Switch to light theme"
+                    : "Switch to dark theme",
+                )}
+              >
+                {resolvedTheme === "dark" ? (
+                  <Sun size={18} />
+                ) : (
+                  <Moon size={18} />
+                )}
+              </button>
+
               <div className="relative">
                 <button
                   type="button"
                   onClick={() =>
-                    setShowNotificationPanel((prev) => !prev)
+                    setShowNotificationPanel((prev) => {
+                      if (!prev) setShowTweaksPanel(false);
+                      return !prev;
+                    })
                   }
-                  className="relative flex h-10 w-10 items-center justify-center rounded-xl border transition-colors hover:bg-white/5"
+                  className="relative flex h-9 w-9 items-center justify-center rounded-2xl border transition-colors hover:bg-white/5"
                   style={{ borderColor: "var(--th-border-subtle)" }}
                   aria-label={tr("알림 보기", "View notifications")}
                   title={tr("알림 보기", "View notifications")}
@@ -816,109 +873,19 @@ export default function AppShell({
 
               <button
                 type="button"
-                onClick={() => navigateToRoute("/settings")}
-                className="flex h-10 w-10 items-center justify-center rounded-xl border transition-colors hover:bg-white/5"
+                onClick={() =>
+                  setShowTweaksPanel((prev) => {
+                    if (!prev) setShowNotificationPanel(false);
+                    return !prev;
+                  })
+                }
+                className="flex h-9 w-9 items-center justify-center rounded-2xl border transition-colors hover:bg-white/5"
                 style={{ borderColor: "var(--th-border-subtle)" }}
-                aria-label={tr("설정으로 이동", "Open settings")}
-                title={tr("설정으로 이동", "Open settings")}
+                aria-label={tr("디자인 설정 열기", "Open tweaks")}
+                title={tr("디자인 설정 열기", "Open tweaks")}
               >
                 <Settings size={18} />
               </button>
-            </div>
-          </div>
-
-          <div
-            className="mt-3 flex flex-col gap-3 rounded-2xl border px-3 py-3 xl:flex-row xl:items-center xl:justify-between"
-            style={{
-              borderColor: "var(--th-border-subtle)",
-              background:
-                "linear-gradient(180deg, color-mix(in oklch, var(--bg-1) 94%, transparent) 0%, color-mix(in oklch, var(--bg-2) 98%, transparent) 100%)",
-            }}
-          >
-            <div className="flex min-w-0 flex-wrap items-center gap-2">
-              <span
-                className="font-display text-[11px] font-semibold uppercase tracking-[0.18em]"
-                style={{ color: "var(--fg-faint)" }}
-              >
-                Theme
-              </span>
-              <div
-                className="flex items-center gap-1 rounded-full p-1"
-                style={{
-                  background:
-                    "color-mix(in oklch, var(--bg-3) 72%, transparent)",
-                }}
-              >
-                {THEME_OPTIONS.map((option) => {
-                  const active = themePreference === option.id;
-                  return (
-                    <button
-                      key={option.id}
-                      type="button"
-                      onClick={() => setThemePreference(option.id)}
-                      aria-pressed={active}
-                      className="rounded-full px-3 py-1 text-xs font-medium transition-colors"
-                      style={
-                        active
-                          ? {
-                              background: "var(--accent-soft)",
-                              color: "var(--accent)",
-                            }
-                          : { color: "var(--fg-muted)" }
-                      }
-                    >
-                      {isKo ? option.labelKo : option.labelEn}
-                    </button>
-                  );
-                })}
-              </div>
-              <span
-                className="rounded-full px-2 py-1 text-[11px]"
-                style={{
-                  background: "var(--th-overlay-medium)",
-                  color: "var(--fg-muted)",
-                }}
-              >
-                {isKo ? `현재 ${resolvedTheme}` : `Live ${resolvedTheme}`}
-              </span>
-            </div>
-
-            <div className="flex min-w-0 flex-wrap items-center gap-2">
-              <span
-                className="font-display text-[11px] font-semibold uppercase tracking-[0.18em]"
-                style={{ color: "var(--fg-faint)" }}
-              >
-                Accent
-              </span>
-              <div className="flex items-center gap-1.5">
-                {ACCENT_OPTIONS.map((option) => {
-                  const active = accentPreset === option.id;
-                  return (
-                    <button
-                      key={option.id}
-                      type="button"
-                      title={option.label}
-                      aria-label={option.label}
-                      aria-pressed={active}
-                      onClick={() => setAccentPreset(option.id)}
-                      className="flex h-8 w-8 items-center justify-center rounded-full transition-transform"
-                      style={{
-                        border: active
-                          ? "2px solid var(--fg)"
-                          : "1px solid color-mix(in oklch, var(--line) 74%, transparent)",
-                        background:
-                          "color-mix(in oklch, var(--bg-2) 92%, transparent)",
-                        transform: active ? "translateY(-1px)" : undefined,
-                      }}
-                    >
-                      <span
-                        className="h-4 w-4 rounded-full"
-                        style={{ background: `var(${option.token})` }}
-                      />
-                    </button>
-                  );
-                })}
-              </div>
             </div>
           </div>
         </header>
@@ -962,11 +929,8 @@ export default function AppShell({
                 element={
                   <HomeOverviewPage
                     isKo={isKo}
-                    currentOfficeLabel={selectedOfficeLabel(
-                      offices,
-                      selectedOfficeId,
-                      tr,
-                    )}
+                    wsConnected={wsConnected}
+                    currentOfficeLabel={currentOfficeName}
                     stats={stats}
                     meetings={roundTableMeetings}
                     notifications={notifications}
@@ -1082,7 +1046,13 @@ export default function AppShell({
               <Route
                 path="/stats"
                 element={
-                  <StatsPageView settings={settings} />
+                  <StatsPageView
+                    settings={settings}
+                    stats={stats}
+                    agents={allAgents}
+                    sessions={visibleDispatchedSessions}
+                    meetings={roundTableMeetings}
+                  />
                 }
               />
               <Route
@@ -1117,30 +1087,12 @@ export default function AppShell({
               <Route
                 path="/achievements"
                 element={
-                  <DashboardPageView
-                    key="dashboard-achievements"
-                    stats={stats}
-                    agents={agents}
-                    sessions={visibleDispatchedSessions}
-                    meetings={roundTableMeetings}
+                  <AchievementsPage
+                    key="achievements"
                     settings={settings}
-                    requestedTab={"achievements" satisfies DashboardTab}
+                    stats={stats}
+                    agents={allAgents}
                     onSelectAgent={openDefaultAgentInfo}
-                    onOpenKanbanSignal={(signal) =>
-                      navigateToRoute("/kanban", {
-                        kanbanFocus: signal,
-                      })
-                    }
-                    onOpenDispatchSessions={() =>
-                      navigateToRoute("/agents", { agentsTab: "backlog" })
-                    }
-                    onOpenSettings={() => navigateToRoute("/settings")}
-                    onRefreshMeetings={() =>
-                      api
-                        .getRoundTableMeetings()
-                        .then(setRoundTableMeetings)
-                        .catch(() => {})
-                    }
                   />
                 }
               />
@@ -1183,7 +1135,9 @@ export default function AppShell({
               zIndex: SHELL_TABBAR_Z_INDEX,
               borderColor: "var(--th-border-subtle)",
               background:
-                "linear-gradient(180deg, color-mix(in srgb, var(--th-nav-bg) 98%, black 2%) 0%, color-mix(in srgb, var(--th-bg-surface) 98%, transparent) 100%)",
+                "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 98%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
+              backdropFilter: "blur(18px)",
+              boxShadow: "0 -10px 30px -20px color-mix(in srgb, black 70%, transparent)",
               paddingBottom: "env(safe-area-inset-bottom)",
               paddingLeft: "env(safe-area-inset-left)",
               paddingRight: "env(safe-area-inset-right)",
@@ -1192,6 +1146,7 @@ export default function AppShell({
             {mobilePrimaryRoutes.map((route) => {
               const Icon = iconForRoute(route.id);
               const isActive = activeMobileRouteId === route.id;
+              const badge = route.id === "kanban" ? kanbanBadgeCount || undefined : undefined;
               return (
                 <button
                   key={route.id}
@@ -1207,6 +1162,11 @@ export default function AppShell({
                 >
                   <Icon size={18} />
                   <span>{isKo ? route.labelKo : route.labelEn}</span>
+                  {badge !== undefined && badge > 0 && (
+                    <span className="absolute right-[28%] top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-emerald-500 px-1 text-[8px] font-semibold text-white">
+                      {badge > 9 ? "9+" : badge}
+                    </span>
+                  )}
                 </button>
               );
             })}
@@ -1222,8 +1182,8 @@ export default function AppShell({
                     : "var(--th-text-muted)",
               }}
             >
-              <Menu size={18} />
-              <span>{tr("더보기", "More")}</span>
+              <Settings size={18} />
+              <span>{tr("설정", "Settings")}</span>
               {(unresolvedMeetingsCount > 0 || unreadCount > 0) && (
                 <span className="absolute right-[28%] top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-emerald-500 px-1 text-[8px] font-semibold text-white">
                   {unresolvedMeetingsCount + unreadCount > 9
@@ -1245,12 +1205,12 @@ export default function AppShell({
                 data-testid="app-mobile-more-menu"
                 role="dialog"
                 aria-modal="true"
-                aria-label={tr("더보기 메뉴", "More menu")}
-                className="relative w-full rounded-t-[32px] border px-4 pb-4 pt-3 shadow-2xl animate-in fade-in slide-in-from-bottom-4 duration-200"
+                aria-label={tr("확장 메뉴", "Extensions menu")}
+                className="relative w-full max-h-[80vh] overflow-y-auto rounded-t-[2rem] border px-4 pb-4 pt-3 shadow-2xl animate-in fade-in slide-in-from-bottom-4 duration-200"
                 style={{
                   borderColor: "var(--th-border-subtle)",
                   background:
-                    "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 98%, transparent) 100%)",
+                    "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 98%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 95%, transparent) 100%)",
                   paddingBottom:
                     "max(1rem, calc(1rem + env(safe-area-inset-bottom)))",
                 }}
@@ -1263,7 +1223,7 @@ export default function AppShell({
                       className="text-[11px] font-semibold uppercase tracking-[0.2em]"
                       style={{ color: "var(--th-text-muted)" }}
                     >
-                      {tr("더보기", "More")}
+                      {tr("확장", "Extensions")}
                     </div>
                     <div
                       className="mt-1 text-base font-semibold"
@@ -1288,60 +1248,66 @@ export default function AppShell({
                   </button>
                 </div>
 
-                <div className="grid gap-2">
-                  {mobileMoreRoutes.map((route) => {
-                    const Icon = iconForRoute(route.id);
-                    const badge =
-                      route.id === "meetings"
-                        ? unresolvedMeetingsCount || undefined
-                        : route.id === "settings"
-                          ? unreadCount || undefined
-                          : undefined;
-                    return (
-                      <button
-                        key={route.id}
-                        type="button"
-                        onClick={() =>
-                          navigateToRoute(
-                            route.path,
-                            route.id === "agents"
-                              ? { agentsTab: "agents" }
-                              : undefined,
-                          )
-                        }
-                        className="flex items-start gap-3 rounded-2xl border px-3 py-3 text-left"
-                        style={{
-                          borderColor:
-                            "color-mix(in srgb, var(--th-border) 70%, transparent)",
-                          background:
-                            "color-mix(in srgb, var(--th-card-bg) 90%, transparent)",
-                        }}
+                <div className="space-y-4">
+                  {mobileOverflowSections.map((section) => (
+                    <div key={section.id} className="space-y-2">
+                      <div
+                        className="px-1 text-[11px] font-semibold uppercase tracking-[0.18em]"
+                        style={{ color: "var(--th-text-muted)" }}
                       >
-                        <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-[var(--th-overlay-subtle)]">
-                          <Icon size={18} />
-                        </span>
-                        <span className="min-w-0 flex-1">
-                          <span
-                            className="flex items-center gap-2 text-sm font-semibold"
-                            style={{ color: "var(--th-text-heading)" }}
-                          >
-                            {isKo ? route.labelKo : route.labelEn}
-                            {badge !== undefined && badge > 0 && (
-                              <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-emerald-500 px-1.5 text-[10px] text-white">
-                                {badge > 9 ? "9+" : badge}
+                        {isKo ? section.labelKo : section.labelEn}
+                      </div>
+                      <div className="grid gap-2">
+                        {section.routes.map((route) => {
+                          const Icon = iconForRoute(route.id);
+                          const badge = sidebarBadgeForRoute(route.id);
+                          return (
+                            <button
+                              key={route.id}
+                              type="button"
+                              aria-label={isKo ? route.labelKo : route.labelEn}
+                              onClick={() =>
+                                navigateToRoute(
+                                  route.path,
+                                  route.id === "agents"
+                                    ? { agentsTab: "agents" }
+                                    : undefined,
+                                )
+                              }
+                              className="flex items-start gap-3 rounded-xl border px-3 py-3 text-left"
+                              style={{
+                                borderColor: "var(--th-border-subtle)",
+                                background: "var(--th-overlay-subtle)",
+                              }}
+                            >
+                              <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-[var(--th-overlay-subtle)]">
+                                <Icon size={18} />
                               </span>
-                            )}
-                          </span>
-                          <span
-                            className="mt-1 block text-xs leading-relaxed"
-                            style={{ color: "var(--th-text-muted)" }}
-                          >
-                            {isKo ? route.descriptionKo : route.descriptionEn}
-                          </span>
-                        </span>
-                      </button>
-                    );
-                  })}
+                              <span className="min-w-0 flex-1">
+                                <span
+                                  className="flex items-center gap-2 text-sm font-semibold"
+                                  style={{ color: "var(--th-text-heading)" }}
+                                >
+                                  {isKo ? route.labelKo : route.labelEn}
+                                  {badge !== undefined && badge > 0 && (
+                                    <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-emerald-500 px-1.5 text-[10px] text-white">
+                                      {badge > 9 ? "9+" : badge}
+                                    </span>
+                                  )}
+                                </span>
+                                <span
+                                  className="mt-1 block text-xs leading-relaxed"
+                                  style={{ color: "var(--th-text-muted)" }}
+                                >
+                                  {isKo ? route.descriptionKo : route.descriptionEn}
+                                </span>
+                              </span>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ))}
                 </div>
               </div>
             </div>
@@ -1405,6 +1371,141 @@ export default function AppShell({
         )}
       </Suspense>
 
+      {showTweaksPanel && (
+        <div
+          className="pointer-events-none fixed right-4 top-[5.25rem] w-[min(22rem,calc(100vw-2rem))]"
+          style={{ zIndex: SHELL_POPOVER_Z_INDEX }}
+        >
+          <div
+            className="pointer-events-auto rounded-[1.75rem] border p-4 shadow-2xl"
+            style={{
+              borderColor: "var(--th-border-subtle)",
+              background:
+                "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 95%, transparent) 100%)",
+            }}
+          >
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div
+                  className="text-sm font-semibold"
+                  style={{ color: "var(--th-text-heading)" }}
+                >
+                  Tweaks
+                </div>
+                <div
+                  className="mt-1 text-xs"
+                  style={{ color: "var(--th-text-muted)" }}
+                >
+                  {tr("셸 테마와 강조색을 조정합니다.", "Tune shell theme and accent.")}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setShowTweaksPanel(false)}
+                className="flex h-8 w-8 items-center justify-center rounded-xl text-[var(--th-text-muted)]"
+                aria-label={tr("패널 닫기", "Close panel")}
+              >
+                <X size={14} />
+              </button>
+            </div>
+
+            <div className="mt-4 space-y-4">
+              <div>
+                <div
+                  className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em]"
+                  style={{ color: "var(--th-text-muted)" }}
+                >
+                  Theme
+                </div>
+                <div
+                  className="flex items-center gap-1 rounded-full p-1"
+                  style={{ background: "var(--th-overlay-subtle)" }}
+                >
+                  {THEME_OPTIONS.map((option) => {
+                    const active = themePreference === option.id;
+                    return (
+                      <button
+                        key={option.id}
+                        type="button"
+                        onClick={() => setThemePreference(option.id)}
+                        aria-pressed={active}
+                        className="flex-1 rounded-full px-3 py-1.5 text-xs font-medium transition-colors"
+                        style={
+                          active
+                            ? {
+                                background: "var(--th-accent-primary-soft)",
+                                color: "var(--th-accent-primary)",
+                              }
+                            : { color: "var(--th-text-muted)" }
+                        }
+                      >
+                        {isKo ? option.labelKo : option.labelEn}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div>
+                <div
+                  className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em]"
+                  style={{ color: "var(--th-text-muted)" }}
+                >
+                  Accent
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  {ACCENT_OPTIONS.map((option) => {
+                    const active = accentPreset === option.id;
+                    return (
+                      <button
+                        key={option.id}
+                        type="button"
+                        title={option.label}
+                        aria-label={option.label}
+                        aria-pressed={active}
+                        onClick={() => setAccentPreset(option.id)}
+                        className="flex h-9 w-9 items-center justify-center rounded-full transition-transform"
+                        style={{
+                          border: active
+                            ? "2px solid var(--th-text-heading)"
+                            : "1px solid color-mix(in srgb, var(--th-border-subtle) 80%, transparent)",
+                          background:
+                            "color-mix(in srgb, var(--th-card-bg) 90%, transparent)",
+                          transform: active ? "translateY(-1px)" : undefined,
+                        }}
+                      >
+                        <span
+                          className="h-4.5 w-4.5 rounded-full"
+                          style={{ background: `var(${option.token})` }}
+                        />
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div
+                className="rounded-2xl border px-3 py-3 text-xs"
+                style={{
+                  borderColor: "var(--th-border-subtle)",
+                  background: "var(--th-overlay-subtle)",
+                }}
+              >
+                <div style={{ color: "var(--th-text-muted)" }}>
+                  {tr("현재 페이지", "Current page")}
+                </div>
+                <div
+                  className="mt-1 font-mono"
+                  style={{ color: "var(--th-text-primary)" }}
+                >
+                  /{currentRoute?.id ?? "home"}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
       <ToastOverlay notifications={notifications} onDismiss={dismissNotification} />
 
       {showShortcutHelp && (
@@ -1437,14 +1538,12 @@ export default function AppShell({
 function SidebarRouteButton({
   route,
   currentRouteId,
-  collapsed,
   isKo,
   badge,
   onNavigate,
 }: {
   route: AppRouteEntry;
   currentRouteId: AppRouteId | null;
-  collapsed: boolean;
   isKo: boolean;
   badge?: number;
   onNavigate: () => void;
@@ -1456,19 +1555,17 @@ function SidebarRouteButton({
     <button
       type="button"
       onClick={onNavigate}
-      className={`group relative flex w-full items-center gap-3 rounded-2xl px-3 py-3 text-left transition-colors ${
-        collapsed ? "justify-center" : ""
-      }`}
+      className="group relative flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors"
       style={{
         background: active
           ? "color-mix(in srgb, var(--th-accent-primary-soft) 80%, transparent)"
           : "transparent",
         color: active ? "var(--th-text-primary)" : "var(--th-text-secondary)",
       }}
-      title={collapsed ? (isKo ? route.labelKo : route.labelEn) : undefined}
+      title={isKo ? route.labelKo : route.labelEn}
     >
       <span
-        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl"
+        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl"
         style={{
           background: active
             ? "color-mix(in srgb, var(--th-accent-primary) 18%, transparent)"
@@ -1477,19 +1574,11 @@ function SidebarRouteButton({
       >
         <Icon size={18} />
       </span>
-      {!collapsed && (
-        <span className="min-w-0 flex-1">
-          <span className="block truncate text-sm font-medium">
-            {isKo ? route.labelKo : route.labelEn}
-          </span>
-          <span
-            className="mt-0.5 block truncate text-[11px]"
-            style={{ color: "var(--th-text-muted)" }}
-          >
-            {isKo ? route.descriptionKo : route.descriptionEn}
-          </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-medium">
+          {isKo ? route.labelKo : route.labelEn}
         </span>
-      )}
+      </span>
       {badge !== undefined && badge > 0 && (
         <span className="absolute right-3 top-3 flex h-5 min-w-5 items-center justify-center rounded-full bg-emerald-500 px-1 text-[10px] font-semibold text-white">
           {badge > 9 ? "9+" : badge}
@@ -1526,6 +1615,7 @@ function NotificationSummaryRow({
 
 function HomeOverviewPage({
   isKo,
+  wsConnected,
   currentOfficeLabel,
   stats,
   meetings,
@@ -1533,6 +1623,7 @@ function HomeOverviewPage({
   kanbanCards,
 }: {
   isKo: boolean;
+  wsConnected: boolean;
   currentOfficeLabel: string;
   stats: DashboardStats | null;
   meetings: RoundTableMeeting[];
@@ -1540,9 +1631,28 @@ function HomeOverviewPage({
   kanbanCards: KanbanCard[];
 }) {
   const tr = useCallback((ko: string, en: string) => (isKo ? ko : en), [isKo]);
-  const quickRoutes = PRIMARY_ROUTES.filter((route) =>
-    ["office", "kanban", "stats", "meetings", "settings"].includes(route.id),
+  const [editing, setEditing] = useState(false);
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [overIndex, setOverIndex] = useState<number | null>(null);
+  const [analytics, setAnalytics] = useState<TokenAnalyticsResponse | null>(null);
+  const defaultWidgets = useMemo(
+    () => ["m_tokens", "m_cost", "m_progress", "m_streak", "office", "missions", "roster", "activity", "kanban"],
+    [],
   );
+  const [widgets, setWidgets] = useState<string[]>(() => {
+    if (typeof window === "undefined") return defaultWidgets;
+    try {
+      const stored =
+        window.localStorage.getItem("agentdesk.widgets") ??
+        window.localStorage.getItem("agentdesk.home.widgets");
+      const parsed = stored ? (JSON.parse(stored) as unknown) : null;
+      return Array.isArray(parsed) && parsed.length > 0
+        ? parsed.filter((value): value is string => typeof value === "string")
+        : defaultWidgets;
+    } catch {
+      return defaultWidgets;
+    }
+  });
   const outstandingMeetings = meetings.filter(hasUnresolvedMeetingIssues).length;
   const liveNotifications = notifications.filter(
     (notification) => Date.now() - notification.ts < 60_000,
@@ -1551,240 +1661,762 @@ function HomeOverviewPage({
   const inProgressCards = kanbanCards.filter(
     (card) => card.status === "in_progress" || card.status === "review",
   ).length;
+  const topAgents = (stats?.top_agents ?? []).slice(0, 6);
+  const doneCards = kanbanCards.filter((card) => card.status === "done").length;
+  const blockedCards = kanbanCards.filter((card) => card.status === "blocked").length;
+  const totalActionableCards = requestedCards + inProgressCards + blockedCards;
+  const totalMeetings = meetings.length;
+  const reviewQueue = stats?.kanban.review_queue ?? kanbanCards.filter((card) => card.status === "review").length;
+  const agentTotal = stats?.agents.total ?? topAgents.length;
+  const liveSessions = stats?.dispatched_count ?? 0;
+  const providerSummary = tr("2/2 프로바이더 연결", "2/2 providers connected");
+  const missionRows = [
+    {
+      id: "review",
+      label: tr("리뷰 대기 비우기", "Clear review queue"),
+      value: reviewQueue,
+      total: Math.max(reviewQueue, 1),
+      done: reviewQueue === 0,
+      accent: "var(--th-accent-warn)",
+      detail: tr("우선 확인이 필요한 카드", "Cards waiting for reviewer action"),
+    },
+    {
+      id: "blocked",
+      label: tr("블록 카드 줄이기", "Reduce blocked cards"),
+      value: stats?.kanban.blocked ?? blockedCards,
+      total: Math.max(blockedCards, 1),
+      done: blockedCards === 0,
+      accent: "var(--th-accent-danger)",
+      detail: tr("의존성/외부 응답 대기", "Waiting on dependencies or replies"),
+    },
+    {
+      id: "dispatch",
+      label: tr("실시간 세션 유지", "Keep live sessions healthy"),
+      value: stats?.dispatched_count ?? 0,
+      total: Math.max(stats?.dispatched_count ?? 0, 1),
+      done: wsConnected,
+      accent: "var(--th-accent-info)",
+      detail: tr("현재 연결된 작업 세션", "Currently connected working sessions"),
+    },
+    {
+      id: "meetings",
+      label: tr("회의 후속 정리", "Close meeting follow-ups"),
+      value: outstandingMeetings,
+      total: Math.max(totalMeetings, 1),
+      done: outstandingMeetings === 0,
+      accent: "var(--th-accent-primary)",
+      detail: tr("정리/이슈화가 필요한 회의", "Meetings still needing wrap-up"),
+    },
+  ];
+  const activityItems = notifications.slice(0, 4).map((notification) => ({
+    id: notification.id,
+    title: notification.message,
+    meta: formatRelativeTime(notification.ts, isKo),
+    accent: notificationColor(notification.type),
+  }));
+  const fallbackActivity = meetings.slice(0, 4).map((meeting) => ({
+    id: meeting.id,
+    title: meeting.agenda,
+    meta: meeting.status === "completed"
+      ? tr("회의 종료", "Meeting completed")
+      : tr("회의 진행 중", "Meeting in progress"),
+    accent:
+      meeting.status === "completed"
+        ? "var(--th-accent-primary)"
+        : "var(--th-accent-warn)",
+  }));
+  const kanbanColumns = [
+    { id: "requested", label: tr("요청", "Requested"), accent: "#7dd3fc" },
+    { id: "in_progress", label: tr("진행", "In progress"), accent: "#6ef2a3" },
+    { id: "review", label: tr("리뷰", "Review"), accent: "#f5bd47" },
+    { id: "done", label: tr("완료", "Done"), accent: "#c084fc" },
+  ] as const;
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let active = true;
+    api
+      .getTokenAnalytics("7d", { signal: controller.signal })
+      .then((next) => {
+        if (!active) return;
+        setAnalytics(next);
+      })
+      .catch((error) => {
+        if (!active || controller.signal.aborted) return;
+        console.error("Failed to load token analytics for home overview", error);
+      });
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem("agentdesk.widgets", JSON.stringify(widgets));
+  }, [widgets]);
+
+  const todayLabel = useMemo(
+    () =>
+      new Intl.DateTimeFormat(isKo ? "ko-KR" : "en-US", {
+        weekday: "long",
+        month: "short",
+        day: "numeric",
+      }).format(new Date()),
+    [isKo],
+  );
+  const latestAnalyticsDay = analytics?.daily.at(-1) ?? null;
+  const tokenTrend = analytics?.daily.slice(-7).map((day) => day.total_tokens) ?? [];
+  const costTrend = analytics?.daily.slice(-7).map((day) => day.cost) ?? [];
+  const activityStreak = useMemo(() => {
+    const daily = [...(analytics?.daily ?? [])].sort((left, right) =>
+      left.date.localeCompare(right.date),
+    );
+    let streak = 0;
+    for (let index = daily.length - 1; index >= 0; index -= 1) {
+      if (daily[index].total_tokens <= 0) break;
+      streak += 1;
+    }
+    return streak;
+  }, [analytics]);
+  const formatCompact = useCallback(
+    (value: number) =>
+      new Intl.NumberFormat(isKo ? "ko-KR" : "en-US", {
+        notation: "compact",
+        maximumFractionDigits: value >= 1_000_000 ? 1 : 0,
+      }).format(value),
+    [isKo],
+  );
+  const formatCurrency = useCallback(
+    (value: number) =>
+      new Intl.NumberFormat(isKo ? "en-US" : "en-US", {
+        style: "currency",
+        currency: "USD",
+        maximumFractionDigits: value >= 100 ? 0 : 2,
+      }).format(value),
+    [],
+  );
+
+  const widgetSpecs = useMemo(
+    () => ({
+      m_tokens: {
+        className: "lg:col-span-3",
+        render: () => (
+          <HomeMetricTile
+            icon={<Zap size={14} />}
+            title={tr("오늘 토큰", "Today's tokens")}
+            value={formatCompact(latestAnalyticsDay?.total_tokens ?? 0)}
+            sub={tr(
+              `7일 평균 ${formatCompact(Math.round(analytics?.summary.average_daily_tokens ?? 0))}`,
+              `7d avg ${formatCompact(Math.round(analytics?.summary.average_daily_tokens ?? 0))}`,
+            )}
+            delta={
+              analytics?.summary.total_tokens
+                ? tr(`7일 ${formatCompact(analytics.summary.total_tokens)}`, `7d ${formatCompact(analytics.summary.total_tokens)}`)
+                : undefined
+            }
+            deltaTone="flat"
+            accent="var(--th-accent-primary)"
+            trend={tokenTrend}
+          />
+        ),
+      },
+      m_cost: {
+        className: "lg:col-span-3",
+        render: () => (
+          <HomeMetricTile
+            icon={<Sparkles size={14} />}
+            title={tr("API 비용", "API cost")}
+            value={formatCurrency(latestAnalyticsDay?.cost ?? 0)}
+            sub={tr(
+              `캐시 절감 ${formatCurrency(analytics?.summary.cache_discount ?? 0)}`,
+              `Cache saved ${formatCurrency(analytics?.summary.cache_discount ?? 0)}`,
+            )}
+            delta={
+              analytics?.summary.total_cost != null
+                ? tr(`7일 ${formatCurrency(analytics.summary.total_cost)}`, `7d ${formatCurrency(analytics.summary.total_cost)}`)
+                : undefined
+            }
+            deltaTone="flat"
+            accent="var(--th-accent-success)"
+            trend={costTrend}
+          />
+        ),
+      },
+      m_progress: {
+        className: "lg:col-span-3",
+        render: () => (
+          <HomeMetricTile
+            icon={<Target size={14} />}
+            title={tr("진행 중", "In progress")}
+            value={`${inProgressCards}`}
+            sub={tr(
+              `${requestedCards} 요청 · ${reviewQueue} 리뷰 · ${blockedCards} 블록`,
+              `${requestedCards} requested · ${reviewQueue} review · ${blockedCards} blocked`,
+            )}
+            delta={tr(`${totalActionableCards} 전체`, `${totalActionableCards} total`)}
+            deltaTone="flat"
+            accent="var(--th-accent-warn)"
+          />
+        ),
+      },
+      m_streak: {
+        className: "lg:col-span-3",
+        render: () => (
+          <HomeMetricTile
+            icon={<Flame size={14} />}
+            title={tr("연속 활동", "Current streak")}
+            value={tr(`${activityStreak}일`, `${activityStreak}d`)}
+            sub={tr(
+              `${analytics?.summary.active_days ?? 0}일 활성 · ${stats?.top_agents.length ?? 0}명 참여`,
+              `${analytics?.summary.active_days ?? 0} active days · ${stats?.top_agents.length ?? 0} agents involved`,
+            )}
+            delta={
+              analytics?.summary.active_days
+                ? tr(`${analytics.summary.active_days}/7 활성`, `${analytics.summary.active_days}/7 active`)
+                : undefined
+            }
+            deltaTone="up"
+            accent="var(--th-accent-danger)"
+          />
+        ),
+      },
+      office: {
+        className: "lg:col-span-8",
+        render: () => (
+          <HomeWidgetShell
+            title={tr("오피스 뷰", "Office view")}
+            subtitle={tr(
+              `${currentOfficeLabel} 기준으로 지금 일하는 에이전트를 요약합니다.`,
+              `Summarized live roster for ${currentOfficeLabel}.`,
+            )}
+            action={
+              <Link
+                to="/office"
+                className="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors hover:bg-white/5"
+                style={{ borderColor: "var(--th-border-subtle)", color: "var(--th-text-primary)" }}
+              >
+                {tr("전체 보기", "Open office")}
+                <ChevronRight size={14} />
+              </Link>
+            }
+          >
+            <div className="relative overflow-hidden rounded-[1.5rem] border p-4 sm:p-5" style={{ borderColor: "var(--th-border-subtle)", background: "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 92%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 92%, transparent) 100%)" }}>
+              <div
+                className="pointer-events-none absolute inset-0 opacity-30"
+                style={{
+                  backgroundImage:
+                    "radial-gradient(circle, color-mix(in srgb, var(--th-text-muted) 38%, transparent) 1px, transparent 1px)",
+                  backgroundSize: "14px 14px",
+                }}
+              />
+              <div className="relative grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+                {topAgents.length === 0 ? (
+                  <div className="col-span-full rounded-2xl border px-4 py-8 text-center text-sm" style={{ borderColor: "var(--th-border-subtle)", color: "var(--th-text-muted)", background: "var(--th-overlay-subtle)" }}>
+                    {tr("표시할 활성 에이전트가 없습니다.", "No active agents to show right now.")}
+                  </div>
+                ) : (
+                  topAgents.map((agent) => {
+                    const progress = Math.min(100, Math.max(12, Math.round(agent.stats_tokens / 100_000)));
+                    return (
+                      <div key={agent.id} className="rounded-2xl border px-3 py-3 text-center" style={{ borderColor: "var(--th-border-subtle)", background: "color-mix(in srgb, var(--th-bg-surface) 90%, transparent)" }}>
+                        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl border text-xl" style={{ borderColor: "var(--th-border-subtle)", background: "var(--th-card-bg)" }}>
+                          {agent.avatar_emoji || "🤖"}
+                        </div>
+                        <div className="mt-3 truncate text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                          {isKo ? agent.name_ko : agent.name}
+                        </div>
+                        <div className="mt-1 text-[11px]" style={{ color: "var(--th-text-muted)" }}>
+                          {tr(`${agent.stats_tasks_done}건 완료`, `${agent.stats_tasks_done} tasks done`)}
+                        </div>
+                        <div className="mt-3 h-1.5 rounded-full" style={{ background: "color-mix(in srgb, var(--th-border-subtle) 70%, transparent)" }}>
+                          <div className="h-full rounded-full" style={{ width: `${progress}%`, background: "var(--th-accent-primary)" }} />
+                        </div>
+                      </div>
+                    );
+                  })
+                )}
+              </div>
+            </div>
+          </HomeWidgetShell>
+        ),
+      },
+      missions: {
+        className: "lg:col-span-4",
+        render: () => (
+          <HomeWidgetShell
+            title={tr("데일리 미션", "Daily missions")}
+            subtitle={tr(
+              "오늘 바로 확인해야 할 운영 우선순위를 정리합니다.",
+              "Keep today's operational priorities in view.",
+            )}
+          >
+            <div className="space-y-3">
+              {missionRows.map((row) => {
+                const progress = row.total <= 0 ? 100 : Math.max(0, Math.min(100, Math.round(((row.total - row.value) / row.total) * 100)));
+                return (
+                  <div key={row.id} className="rounded-2xl border px-3 py-3" style={{ borderColor: "var(--th-border-subtle)", background: "color-mix(in srgb, var(--th-card-bg) 90%, transparent)" }}>
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="text-sm font-medium" style={{ color: "var(--th-text-heading)" }}>
+                          {row.label}
+                        </div>
+                        <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                          {row.detail}
+                        </div>
+                      </div>
+                      <span className="rounded-full px-2.5 py-1 text-xs font-semibold" style={{ background: "var(--th-overlay-medium)", color: row.done ? "var(--th-accent-success)" : row.accent }}>
+                        {row.done ? tr("완료", "Done") : tr(`${row.value}건`, `${row.value}`)}
+                      </span>
+                    </div>
+                    <div className="mt-3 h-1.5 rounded-full" style={{ background: "color-mix(in srgb, var(--th-border-subtle) 68%, transparent)" }}>
+                      <div className="h-full rounded-full" style={{ width: `${progress}%`, background: row.done ? "var(--th-accent-success)" : row.accent }} />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </HomeWidgetShell>
+        ),
+      },
+      roster: {
+        className: "lg:col-span-7",
+        render: () => (
+          <HomeWidgetShell
+            title={tr("에이전트 현황", "Agent roster")}
+            subtitle={tr("상위 작업 에이전트를 빠르게 훑어봅니다.", "Quick scan of the most active agents.")}
+          >
+            <div className="space-y-2">
+              {topAgents.length === 0 ? (
+                <div className="rounded-2xl border px-4 py-8 text-center text-sm" style={{ borderColor: "var(--th-border-subtle)", color: "var(--th-text-muted)", background: "var(--th-overlay-subtle)" }}>
+                  {tr("에이전트 통계가 아직 없습니다.", "Agent statistics are not available yet.")}
+                </div>
+              ) : (
+                topAgents.map((agent) => (
+                  <div key={agent.id} className="grid grid-cols-[auto_1fr_auto] items-center gap-3 rounded-2xl border px-3 py-3" style={{ borderColor: "var(--th-border-subtle)", background: "color-mix(in srgb, var(--th-card-bg) 90%, transparent)" }}>
+                    <div className="flex h-10 w-10 items-center justify-center rounded-2xl border text-lg" style={{ borderColor: "var(--th-border-subtle)", background: "var(--th-bg-surface)" }}>
+                      {agent.avatar_emoji || "🤖"}
+                    </div>
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                        {isKo ? agent.name_ko : agent.name}
+                      </div>
+                      <div className="mt-1 truncate text-xs" style={{ color: "var(--th-text-muted)" }}>
+                        {tr(
+                          `${agent.stats_tasks_done}건 완료 · XP ${Math.round(agent.stats_xp).toLocaleString()}`,
+                          `${agent.stats_tasks_done} tasks done · XP ${Math.round(agent.stats_xp).toLocaleString()}`,
+                        )}
+                      </div>
+                    </div>
+                    <div className="text-right text-xs" style={{ color: "var(--th-text-muted)" }}>
+                      <div className="font-semibold" style={{ color: "var(--th-text-primary)" }}>
+                        {agent.stats_tokens > 0 ? `${Math.round(agent.stats_tokens / 1000).toLocaleString()}K` : "0"}
+                      </div>
+                      <div>{tr("tokens", "tokens")}</div>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </HomeWidgetShell>
+        ),
+      },
+      activity: {
+        className: "lg:col-span-5",
+        render: () => {
+          const items = activityItems.length > 0 ? activityItems : fallbackActivity;
+          return (
+            <HomeWidgetShell
+              title={tr("최근 활동", "Recent activity")}
+              subtitle={tr("알림과 회의 후속을 우선적으로 보여줍니다.", "Prioritizes alerts and meeting follow-ups.")}
+            >
+              <div className="space-y-2">
+                {items.length === 0 ? (
+                  <div className="rounded-2xl border px-4 py-8 text-center text-sm" style={{ borderColor: "var(--th-border-subtle)", color: "var(--th-text-muted)", background: "var(--th-overlay-subtle)" }}>
+                    {tr("표시할 최근 활동이 없습니다.", "No recent activity to show.")}
+                  </div>
+                ) : (
+                  items.map((item) => (
+                    <div key={item.id} className="grid grid-cols-[auto_1fr_auto] items-start gap-3 rounded-2xl border px-3 py-3" style={{ borderColor: "var(--th-border-subtle)", background: "color-mix(in srgb, var(--th-card-bg) 90%, transparent)" }}>
+                      <span className="mt-1 h-2.5 w-2.5 rounded-full" style={{ background: item.accent }} />
+                      <div className="min-w-0">
+                        <div className="text-sm leading-6" style={{ color: "var(--th-text-primary)" }}>
+                          {item.title}
+                        </div>
+                      </div>
+                      <div className="text-[11px] whitespace-nowrap" style={{ color: "var(--th-text-muted)" }}>
+                        {item.meta}
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </HomeWidgetShell>
+          );
+        },
+      },
+      kanban: {
+        className: "lg:col-span-12",
+        render: () => (
+          <HomeWidgetShell
+            title={tr("칸반 스냅샷", "Kanban snapshot")}
+            subtitle={tr("현재 카드 흐름을 한 번에 살피는 요약 보드입니다.", "A wide snapshot of the current card flow.")}
+            action={
+              <Link
+                to="/kanban"
+                className="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors hover:bg-white/5"
+                style={{ borderColor: "var(--th-border-subtle)", color: "var(--th-text-primary)" }}
+              >
+                {tr("칸반 열기", "Open kanban")}
+                <ChevronRight size={14} />
+              </Link>
+            }
+          >
+            <div className="grid gap-3 lg:grid-cols-4">
+              {kanbanColumns.map((column) => {
+                const cards = kanbanCards.filter((card) => card.status === column.id).slice(0, 3);
+                return (
+                  <div key={column.id} className="rounded-[1.5rem] border p-3" style={{ borderColor: "var(--th-border-subtle)", background: "color-mix(in srgb, var(--th-card-bg) 90%, transparent)" }}>
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                        {column.label}
+                      </div>
+                      <span className="rounded-full px-2 py-1 text-[11px] font-semibold" style={{ background: "var(--th-overlay-medium)", color: column.accent }}>
+                        {column.id === "requested"
+                          ? requestedCards
+                          : column.id === "in_progress"
+                            ? kanbanCards.filter((card) => card.status === "in_progress").length
+                            : column.id === "review"
+                              ? kanbanCards.filter((card) => card.status === "review").length
+                              : doneCards}
+                      </span>
+                    </div>
+                    <div className="mt-3 space-y-2">
+                      {cards.length === 0 ? (
+                        <div className="rounded-2xl border px-3 py-4 text-sm" style={{ borderColor: "var(--th-border-subtle)", color: "var(--th-text-muted)", background: "var(--th-overlay-subtle)" }}>
+                          {tr("표시할 카드 없음", "No cards")}
+                        </div>
+                      ) : (
+                        cards.map((card) => (
+                          <div key={card.id} className="rounded-2xl border px-3 py-3" style={{ borderColor: "var(--th-border-subtle)", background: "color-mix(in srgb, var(--th-bg-surface) 92%, transparent)" }}>
+                            <div className="line-clamp-2 text-sm font-medium leading-6" style={{ color: "var(--th-text-primary)" }}>
+                              {card.title}
+                            </div>
+                            <div className="mt-2 flex items-center justify-between gap-2 text-[11px]" style={{ color: "var(--th-text-muted)" }}>
+                              <span className="truncate">
+                                {card.github_repo ?? tr("repo 미지정", "No repo")}
+                              </span>
+                              <span className="whitespace-nowrap">
+                                #{card.github_issue_number ?? "—"}
+                              </span>
+                            </div>
+                          </div>
+                        ))
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </HomeWidgetShell>
+        ),
+      },
+    }),
+    [
+      analytics,
+      blockedCards,
+      costTrend,
+      currentOfficeLabel,
+      doneCards,
+      fallbackActivity,
+      inProgressCards,
+      isKo,
+      kanbanCards,
+      meetings.length,
+      missionRows,
+      notifications.length,
+      outstandingMeetings,
+      requestedCards,
+      stats,
+      tokenTrend,
+      topAgents,
+      tr,
+      totalActionableCards,
+      wsConnected,
+      activityItems,
+      activityStreak,
+      formatCompact,
+      formatCurrency,
+      latestAnalyticsDay,
+      reviewQueue,
+    ],
+  );
 
   return (
-    <div className="mx-auto h-full w-full max-w-6xl overflow-auto px-4 py-5 pb-32 sm:px-6">
-      <div
-        className="rounded-[2rem] border p-5 sm:p-6"
-        style={{
-          borderColor: "var(--th-border-subtle)",
-          background:
-            "radial-gradient(circle at top left, rgba(110,242,163,0.16) 0%, transparent 35%), linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 94%, transparent) 100%)",
-        }}
-      >
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="max-w-2xl">
+    <div className="mx-auto h-full w-full max-w-[92rem] overflow-auto px-4 py-6 pb-32 sm:px-6">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div className="max-w-3xl">
+          <div className="mb-1.5 flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--th-text-muted)" }}>
+            <span>{todayLabel}</span>
+            <span className="h-1 w-1 rounded-full" style={{ background: "var(--th-text-muted)" }} />
+            <span className="inline-flex items-center gap-1.5" style={{ color: wsConnected ? "var(--th-accent-primary)" : "var(--th-accent-danger)" }}>
+              <span className="h-2 w-2 rounded-full" style={{ background: wsConnected ? "var(--th-accent-primary)" : "var(--th-accent-danger)" }} />
+              {wsConnected ? "all systems normal" : tr("연결 상태 확인 필요", "connection degraded")}
+            </span>
+          </div>
+          <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl" style={{ color: "var(--th-text-heading)" }}>
+            {tr("오늘의 AgentDesk", "Today's AgentDesk")}
+          </h1>
+          <p className="mt-2 max-w-2xl text-sm leading-7 sm:text-base" style={{ color: "var(--th-text-secondary)" }}>
+            {tr(
+              `에이전트 ${agentTotal}명 · 세션 ${liveSessions} 활성 · ${providerSummary}`,
+              `${agentTotal} agents · ${liveSessions} live sessions · ${providerSummary}`,
+            )}
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          {editing && (
+            <button
+              type="button"
+            onClick={() => setWidgets(defaultWidgets)}
+            className="rounded-full border px-3 py-2 text-xs font-medium transition-colors hover:bg-white/5"
+            style={{ borderColor: "var(--th-border-subtle)", color: "var(--th-text-muted)" }}
+          >
+            {tr("기본값", "Reset")}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => setEditing((prev) => !prev)}
+            className="inline-flex items-center gap-2 rounded-full border px-3 py-2 text-xs font-medium transition-colors hover:bg-white/5"
+            style={{
+              borderColor: editing ? "var(--th-accent-primary)" : "var(--th-border-subtle)",
+              background: editing ? "var(--th-accent-primary-soft)" : "transparent",
+              color: editing ? "var(--th-text-heading)" : "var(--th-text-primary)",
+            }}
+          >
+            <GripVertical size={14} />
+            {editing ? tr("완료", "Done") : tr("편집", "Edit")}
+          </button>
+        </div>
+      </div>
+
+      {editing && (
+        <div className="mt-4 rounded-2xl border px-4 py-3 text-sm" style={{ borderColor: "color-mix(in srgb, var(--th-accent-primary) 26%, var(--th-border) 74%)", background: "var(--th-accent-primary-soft)", color: "var(--th-text-secondary)" }}>
+          <span className="inline-flex items-center gap-2">
+            <GripVertical size={14} />
+            {tr(
+              "위젯을 드래그해서 순서를 바꿀 수 있습니다. 완료를 누르면 현재 배치가 유지됩니다.",
+              "Drag widgets to reorder them. The current layout will persist when you press done.",
+            )}
+          </span>
+        </div>
+      )}
+
+      <div className="mt-5 grid grid-cols-1 gap-4 lg:grid-cols-12">
+        {widgets.map((widgetId, index) => {
+          const spec = widgetSpecs[widgetId as keyof typeof widgetSpecs];
+          if (!spec) return null;
+          return (
             <div
-              className="text-[11px] font-semibold uppercase tracking-[0.2em]"
-              style={{ color: "var(--th-text-muted)" }}
+              key={widgetId}
+              draggable={editing}
+              onDragStart={(event) => {
+                if (!editing) return;
+                setDragIndex(index);
+                event.dataTransfer.effectAllowed = "move";
+                try {
+                  event.dataTransfer.setData("text/plain", String(index));
+                } catch {
+                  // no-op
+                }
+              }}
+              onDragOver={(event) => {
+                if (!editing) return;
+                event.preventDefault();
+                if (overIndex !== index) setOverIndex(index);
+              }}
+              onDrop={(event) => {
+                if (!editing) return;
+                event.preventDefault();
+                if (dragIndex == null || dragIndex === index) {
+                  setDragIndex(null);
+                  setOverIndex(null);
+                  return;
+                }
+                const next = [...widgets];
+                const [moved] = next.splice(dragIndex, 1);
+                next.splice(index, 0, moved);
+                setWidgets(next);
+                setDragIndex(null);
+                setOverIndex(null);
+              }}
+              onDragEnd={() => {
+                setDragIndex(null);
+                setOverIndex(null);
+              }}
+              className={[
+                spec.className,
+                dragIndex === index ? "opacity-70" : "",
+                overIndex === index && dragIndex !== index ? "rounded-[2rem] ring-2 ring-[color:var(--th-accent-primary)] ring-offset-2 ring-offset-transparent" : "",
+              ]
+                .filter(Boolean)
+                .join(" ")}
             >
-              {tr("오늘의 개요", "Today's overview")}
-            </div>
-            <h1
-              className="mt-3 text-3xl font-semibold tracking-tight sm:text-4xl"
-              style={{ color: "var(--th-text-heading)" }}
-            >
-              {tr("한 번에 운영 흐름을 정리하는 홈", "A home page for the whole operating flow")}
-            </h1>
-            <p
-              className="mt-3 max-w-2xl text-sm leading-7 sm:text-base"
-              style={{ color: "var(--th-text-secondary)" }}
-            >
-              {tr(
-                `현재 범위는 ${currentOfficeLabel} 기준입니다. 오피스, 칸반, 회의, 설정까지 새 앱 셸에서 바로 이동할 수 있습니다.`,
-                `The current scope is ${currentOfficeLabel}. Jump straight into office, kanban, meetings, and settings from the new shell.`,
-              )}
-            </p>
-          </div>
-
-          <div className="grid w-full gap-3 sm:w-auto sm:min-w-[19rem]">
-            <MetricCard
-              title={tr("활성 에이전트", "Active agents")}
-              value={stats?.agents.working ?? 0}
-              detail={tr("현재 작업 중", "Currently working")}
-              tone="emerald"
-            />
-            <MetricCard
-              title={tr("오픈 워크", "Open work")}
-              value={requestedCards + inProgressCards}
-              detail={tr("요청 + 진행 + 리뷰", "Requested + in progress + review")}
-              tone="sky"
-            />
-          </div>
-        </div>
-      </div>
-
-      <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <MetricCard
-          title={tr("전체 에이전트", "Total agents")}
-          value={stats?.agents.total ?? 0}
-          detail={tr("워크스페이스 등록 수", "Registered in workspace")}
-          tone="neutral"
-        />
-        <MetricCard
-          title={tr("실시간 세션", "Live sessions")}
-          value={stats?.dispatched_count ?? 0}
-          detail={tr("연결 유지 중", "Currently connected")}
-          tone="sky"
-        />
-        <MetricCard
-          title={tr("미해결 회의", "Open meetings")}
-          value={outstandingMeetings}
-          detail={tr("후속 이슈 확인 필요", "Need follow-up review")}
-          tone="amber"
-        />
-        <MetricCard
-          title={tr("최근 알림", "Recent alerts")}
-          value={liveNotifications}
-          detail={tr("최근 1분 기준", "Within the last minute")}
-          tone="rose"
-        />
-      </div>
-
-      <div className="mt-5 grid gap-4 lg:grid-cols-[1.25fr_0.75fr]">
-        <div
-          className="rounded-[1.75rem] border p-4 sm:p-5"
-          style={{
-            borderColor: "var(--th-border-subtle)",
-            background: "var(--th-card-bg)",
-          }}
-        >
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <div
-                className="text-sm font-semibold"
-                style={{ color: "var(--th-text-heading)" }}
-              >
-                {tr("빠른 진입", "Quick access")}
-              </div>
-              <div
-                className="mt-1 text-sm"
-                style={{ color: "var(--th-text-muted)" }}
-              >
-                {tr("우선 작업 영역으로 바로 이동합니다.", "Jump to the surfaces you need next.")}
+              <div className="relative">
+                {editing && (
+                  <div className="pointer-events-none absolute right-4 top-4 z-10 flex h-8 w-8 items-center justify-center rounded-full border" style={{ borderColor: "var(--th-border-subtle)", background: "color-mix(in srgb, var(--th-card-bg) 90%, transparent)", color: "var(--th-text-muted)" }}>
+                    <GripVertical size={14} />
+                  </div>
+                )}
+                {spec.render()}
               </div>
             </div>
-            <LayoutDashboard size={18} style={{ color: "var(--th-text-muted)" }} />
-          </div>
-
-          <div className="mt-4 grid gap-3 md:grid-cols-2">
-            {quickRoutes.map((route) => (
-              <Link
-                key={route.id}
-                to={route.path}
-                className="rounded-[1.5rem] border p-4 transition-transform hover:-translate-y-0.5"
-                style={{
-                  borderColor: "var(--th-border-subtle)",
-                  background: "color-mix(in srgb, var(--th-bg-surface) 92%, transparent)",
-                }}
-              >
-                <div
-                  className="text-sm font-semibold"
-                  style={{ color: "var(--th-text-primary)" }}
-                >
-                  {isKo ? route.labelKo : route.labelEn}
-                </div>
-                <div
-                  className="mt-2 text-sm leading-6"
-                  style={{ color: "var(--th-text-muted)" }}
-                >
-                  {isKo ? route.descriptionKo : route.descriptionEn}
-                </div>
-              </Link>
-            ))}
-          </div>
-        </div>
-
-        <div
-          className="rounded-[1.75rem] border p-4 sm:p-5"
-          style={{
-            borderColor: "var(--th-border-subtle)",
-            background: "var(--th-card-bg)",
-          }}
-        >
-          <div
-            className="text-sm font-semibold"
-            style={{ color: "var(--th-text-heading)" }}
-          >
-            {tr("워크 큐", "Work queue")}
-          </div>
-          <div
-            className="mt-1 text-sm"
-            style={{ color: "var(--th-text-muted)" }}
-          >
-            {tr("현재 카드 상태를 요약합니다.", "A snapshot of current card status.")}
-          </div>
-
-          <div className="mt-4 space-y-3">
-            <QueueRow
-              label={tr("요청됨", "Requested")}
-              value={requestedCards}
-              accent="#66b3ff"
-            />
-            <QueueRow
-              label={tr("진행/리뷰", "In progress / review")}
-              value={inProgressCards}
-              accent="#6ef2a3"
-            />
-            <QueueRow
-              label={tr("완료", "Done")}
-              value={kanbanCards.filter((card) => card.status === "done").length}
-              accent="#f5bd47"
-            />
-          </div>
-        </div>
+          );
+        })}
       </div>
     </div>
   );
 }
 
-function MetricCard({
+function HomeMetricTile({
+  icon,
   title,
   value,
-  detail,
-  tone,
+  sub,
+  delta,
+  deltaTone = "flat",
+  accent,
+  trend,
 }: {
+  icon: React.ReactNode;
   title: string;
-  value: number;
-  detail: string;
-  tone: "neutral" | "emerald" | "sky" | "amber" | "rose";
+  value: string;
+  sub: string;
+  delta?: string;
+  deltaTone?: "up" | "down" | "flat";
+  accent: string;
+  trend?: number[];
 }) {
-  const theme = metricToneTheme(tone);
+  const strokePoints =
+    trend && trend.length > 1
+      ? trend
+          .map((point, index) => {
+            const max = Math.max(...trend, 1);
+            const min = Math.min(...trend, 0);
+            const x = (index / (trend.length - 1)) * 100;
+            const normalized = max === min ? 0.5 : (point - min) / (max - min);
+            const y = 26 - normalized * 20;
+            return `${x},${y}`;
+          })
+          .join(" ")
+      : null;
   return (
     <div
-      className="rounded-[1.5rem] border p-4"
+      className="h-full overflow-hidden rounded-[1.15rem] border"
       style={{
-        borderColor: theme.border,
-        background: theme.background,
+        borderColor: "var(--th-border-subtle)",
+        background:
+          "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
       }}
     >
-      <div className="text-sm font-medium" style={{ color: "var(--th-text-muted)" }}>
-        {title}
-      </div>
-      <div
-        className="mt-3 text-3xl font-semibold tracking-tight"
-        style={{ color: "var(--th-text-heading)" }}
-      >
-        {value}
-      </div>
-      <div className="mt-2 text-sm" style={{ color: theme.detail }}>
-        {detail}
+      <div className="px-4 py-4 sm:px-5">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-[11.5px] font-medium uppercase tracking-[0.08em]" style={{ color: "var(--th-text-muted)" }}>
+            {icon}
+            <span>{title}</span>
+          </div>
+          {delta ? (
+            <span
+              className="rounded-md px-1.5 py-0.5 text-[11px] font-medium"
+              style={{
+                background:
+                  deltaTone === "up"
+                    ? "color-mix(in srgb, var(--th-accent-success) 14%, transparent)"
+                    : deltaTone === "down"
+                      ? "color-mix(in srgb, var(--th-accent-danger) 14%, transparent)"
+                      : "var(--th-overlay-medium)",
+                color:
+                  deltaTone === "up"
+                    ? "var(--th-accent-success)"
+                    : deltaTone === "down"
+                      ? "var(--th-accent-danger)"
+                      : "var(--th-text-muted)",
+              }}
+            >
+              {delta}
+            </span>
+          ) : null}
+        </div>
+        <div
+          className="mt-3 text-[26px] font-semibold tracking-tight"
+          style={{ color: "var(--th-text-heading)" }}
+        >
+          {value}
+        </div>
+        <div className="mt-1 text-xs" style={{ color: "var(--th-text-muted)" }}>
+          {sub}
+        </div>
+        {strokePoints ? (
+          <svg
+            viewBox="0 0 100 30"
+            preserveAspectRatio="none"
+            className="mt-3 h-8 w-full"
+            aria-hidden="true"
+          >
+            <polyline
+              fill="none"
+              stroke={accent}
+              strokeWidth="2"
+              strokeLinejoin="round"
+              strokeLinecap="round"
+              points={strokePoints}
+            />
+          </svg>
+        ) : (
+          <div className="mt-3 h-1.5 rounded-full" style={{ background: "color-mix(in srgb, var(--th-border-subtle) 68%, transparent)" }}>
+            <div className="h-full rounded-full" style={{ width: "100%", background: accent }} />
+          </div>
+        )}
       </div>
     </div>
   );
 }
 
-function QueueRow({
-  label,
-  value,
-  accent,
+function HomeWidgetShell({
+  title,
+  subtitle,
+  action,
+  children,
 }: {
-  label: string;
-  value: number;
-  accent: string;
+  title: string;
+  subtitle: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
 }) {
   return (
     <div
-      className="flex items-center justify-between rounded-2xl border px-3 py-3"
+      className="h-full overflow-hidden rounded-[1.15rem] border"
       style={{
         borderColor: "var(--th-border-subtle)",
-        background: "color-mix(in srgb, var(--th-bg-surface) 90%, transparent)",
+        background:
+          "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
       }}
     >
-      <span style={{ color: "var(--th-text-secondary)" }}>{label}</span>
-      <span className="font-semibold" style={{ color: accent }}>
-        {value}
-      </span>
+      <div className="flex items-start justify-between gap-3 border-b px-4 py-3 sm:px-5" style={{ borderColor: "var(--th-border-subtle)" }}>
+        <div className="min-w-0">
+          <div className="text-[12.5px] font-medium" style={{ color: "var(--th-text-secondary)" }}>
+            {title}
+          </div>
+          <div className="mt-1 text-[11px] leading-5" style={{ color: "var(--th-text-muted)" }}>
+            {subtitle}
+          </div>
+        </div>
+        {action}
+      </div>
+      <div className="px-4 py-4 sm:px-5">{children}</div>
     </div>
   );
 }
@@ -1824,7 +2456,7 @@ function ShortcutHelpModal({
               {isKo ? "키보드 단축키" : "Keyboard Shortcuts"}
             </div>
             <div className="mt-1 text-sm" style={{ color: "var(--th-text-muted)" }}>
-              {isKo ? "새 라우팅 셸 기준" : "For the new route shell"}
+              {isKo ? "자주 쓰는 조작을 빠르게 확인하세요" : "Quick access to the controls you use most"}
             </div>
           </div>
           <button

--- a/dashboard/src/app/routes.ts
+++ b/dashboard/src/app/routes.ts
@@ -1,4 +1,4 @@
-export type AppSectionId = "workspace" | "knowledge" | "me";
+export type AppSectionId = "workspace" | "extensions" | "me";
 
 export type AppRouteId =
   | "home"
@@ -33,7 +33,7 @@ export interface AppRouteSection {
 
 export const APP_ROUTE_SECTIONS: AppRouteSection[] = [
   { id: "workspace", labelKo: "워크스페이스", labelEn: "Workspace" },
-  { id: "knowledge", labelKo: "지식", labelEn: "Knowledge" },
+  { id: "extensions", labelKo: "확장", labelEn: "Extensions" },
   { id: "me", labelKo: "나", labelEn: "Me" },
 ];
 
@@ -49,7 +49,6 @@ export const APP_ROUTES: AppRouteEntry[] = [
     descriptionEn: "See today's overview and quick entry points.",
     paletteIcon: "🏠",
     shortcutKey: "1",
-    showOfficeSelector: true,
   },
   {
     id: "office",
@@ -64,16 +63,16 @@ export const APP_ROUTES: AppRouteEntry[] = [
     showOfficeSelector: true,
   },
   {
-    id: "agents",
-    path: "/agents",
+    id: "stats",
+    path: "/stats",
+    aliases: ["/pulse"],
     section: "workspace",
-    labelKo: "에이전트",
-    labelEn: "Agents",
-    descriptionKo: "에이전트, 부서, 파견 세션을 관리합니다.",
-    descriptionEn: "Manage agents, departments, and dispatched sessions.",
-    paletteIcon: "👥",
+    labelKo: "통계",
+    labelEn: "Stats",
+    descriptionKo: "운영 지표와 대시보드 위젯을 봅니다.",
+    descriptionEn: "Review operational metrics and dashboard widgets.",
+    paletteIcon: "📈",
     shortcutKey: "3",
-    showOfficeSelector: true,
   },
   {
     id: "kanban",
@@ -87,19 +86,6 @@ export const APP_ROUTES: AppRouteEntry[] = [
     shortcutKey: "4",
   },
   {
-    id: "stats",
-    path: "/stats",
-    aliases: ["/pulse"],
-    section: "workspace",
-    labelKo: "통계",
-    labelEn: "Stats",
-    descriptionKo: "운영 지표와 대시보드 위젯을 봅니다.",
-    descriptionEn: "Review operational metrics and dashboard widgets.",
-    paletteIcon: "📈",
-    shortcutKey: "5",
-    showOfficeSelector: true,
-  },
-  {
     id: "ops",
     path: "/ops",
     aliases: ["/control"],
@@ -109,12 +95,24 @@ export const APP_ROUTES: AppRouteEntry[] = [
     descriptionKo: "오피스와 운영 표면을 관리합니다.",
     descriptionEn: "Manage offices and operational surfaces.",
     paletteIcon: "🛠️",
+    shortcutKey: "5",
+  },
+  {
+    id: "agents",
+    path: "/agents",
+    section: "extensions",
+    labelKo: "에이전트",
+    labelEn: "Agents",
+    descriptionKo: "에이전트, 부서, 파견 세션을 관리합니다.",
+    descriptionEn: "Manage agents, departments, and dispatched sessions.",
+    paletteIcon: "👥",
     shortcutKey: "6",
+    showOfficeSelector: true,
   },
   {
     id: "meetings",
     path: "/meetings",
-    section: "knowledge",
+    section: "extensions",
     labelKo: "회의",
     labelEn: "Meetings",
     descriptionKo: "회의 기록과 후속 이슈를 정리합니다.",
@@ -125,7 +123,7 @@ export const APP_ROUTES: AppRouteEntry[] = [
   {
     id: "achievements",
     path: "/achievements",
-    section: "knowledge",
+    section: "me",
     labelKo: "업적",
     labelEn: "Achievements",
     descriptionKo: "성과와 랭킹 흐름을 확인합니다.",

--- a/dashboard/src/components/AchievementsPage.tsx
+++ b/dashboard/src/components/AchievementsPage.tsx
@@ -1,0 +1,1003 @@
+import { useEffect, useMemo, useState } from "react";
+import * as api from "../api/client";
+import { localeName, useI18n } from "../i18n";
+import type { Agent, CompanySettings, DashboardStats } from "../types";
+import { getAgentLevel, getAgentTitle } from "./agent-manager/AgentInfoCard";
+
+interface AchievementsPageProps {
+  settings: CompanySettings;
+  stats?: DashboardStats | null;
+  agents?: Agent[];
+  onSelectAgent?: (agent: Agent) => void;
+}
+
+type MilestoneId =
+  | "first_task"
+  | "getting_started"
+  | "centurion"
+  | "veteran"
+  | "expert"
+  | "master";
+
+interface MilestoneMeta {
+  id: MilestoneId;
+  threshold: number;
+  hue: number;
+  glyph: string;
+  name: {
+    ko: string;
+    en: string;
+  };
+  desc: {
+    ko: string;
+    en: string;
+  };
+}
+
+interface LeaderboardEntry {
+  id: string;
+  name: string;
+  avatarEmoji: string;
+  xp: number;
+  tasksDone: number;
+  agent?: Agent;
+}
+
+interface AchievementCardModel {
+  id: string;
+  got: boolean;
+  milestoneId: string;
+  name: string;
+  desc: string;
+  xp: number;
+  prog?: number;
+  at?: string;
+  agentName?: string;
+  avatarEmoji?: string;
+  agent?: Agent;
+}
+
+const MILESTONES: MilestoneMeta[] = [
+  {
+    id: "first_task",
+    threshold: 10,
+    hue: 150,
+    glyph: "★",
+    name: { ko: "첫 번째 작업 완료", en: "First Task" },
+    desc: { ko: "첫 번째 작업을 성공적으로 완료했습니다", en: "Completed the first task" },
+  },
+  {
+    id: "getting_started",
+    threshold: 50,
+    hue: 210,
+    glyph: "✦",
+    name: { ko: "본격적인 시작", en: "Getting Started" },
+    desc: { ko: "운영 리듬이 안정적으로 시작되었습니다", en: "Settled into the operating rhythm" },
+  },
+  {
+    id: "centurion",
+    threshold: 100,
+    hue: 85,
+    glyph: "100",
+    name: { ko: "100 XP 달성", en: "Centurion" },
+    desc: { ko: "100 XP를 돌파해 첫 이정표를 넘었습니다", en: "Reached the first 100 XP milestone" },
+  },
+  {
+    id: "veteran",
+    threshold: 250,
+    hue: 25,
+    glyph: "V",
+    name: { ko: "베테랑", en: "Veteran" },
+    desc: { ko: "꾸준한 운영으로 베테랑 단계에 도달했습니다", en: "Reached the veteran tier through steady work" },
+  },
+  {
+    id: "expert",
+    threshold: 500,
+    hue: 295,
+    glyph: "E",
+    name: { ko: "전문가", en: "Expert" },
+    desc: { ko: "고난도 운영을 소화하는 전문가 구간입니다", en: "Reached the expert operating tier" },
+  },
+  {
+    id: "master",
+    threshold: 1000,
+    hue: 50,
+    glyph: "∞",
+    name: { ko: "마스터", en: "Master" },
+    desc: { ko: "최상위 운영 숙련도에 도달했습니다", en: "Reached the master tier" },
+  },
+];
+
+const MILESTONE_BY_ID = new Map(MILESTONES.map((milestone) => [milestone.id, milestone]));
+
+function formatCompact(value: number, locale: string): string {
+  return new Intl.NumberFormat(locale, {
+    notation: "compact",
+    maximumFractionDigits: value >= 1000 ? 1 : 0,
+  }).format(value);
+}
+
+function formatExact(value: number, locale: string): string {
+  return new Intl.NumberFormat(locale).format(value);
+}
+
+function formatAchievementDate(timestamp: number | null | undefined, locale: string): string | undefined {
+  if (!timestamp || timestamp <= 0) return undefined;
+  return new Intl.DateTimeFormat(locale, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(timestamp));
+}
+
+function nextMilestone(xp: number) {
+  return MILESTONES.find((milestone) => xp < milestone.threshold) ?? null;
+}
+
+function progressToMilestone(xp: number, milestone: MilestoneMeta): number {
+  const index = MILESTONES.findIndex((item) => item.id === milestone.id);
+  const previousThreshold = index > 0 ? MILESTONES[index - 1].threshold : 0;
+  const total = Math.max(1, milestone.threshold - previousThreshold);
+  return Math.max(0, Math.min(1, (xp - previousThreshold) / total));
+}
+
+function AchievementRing({
+  value,
+  size = 88,
+  stroke = 6,
+  color = "var(--accent)",
+}: {
+  value: number;
+  size?: number;
+  stroke?: number;
+  color?: string;
+}) {
+  const radius = (size - stroke) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (value / 100) * circumference;
+
+  return (
+    <svg width={size} height={size} aria-hidden="true">
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        stroke="var(--bg-3)"
+        strokeWidth={stroke}
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        stroke={color}
+        strokeWidth={stroke}
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        strokeLinecap="round"
+        transform={`rotate(-90 ${size / 2} ${size / 2})`}
+        style={{ transition: "stroke-dashoffset 0.6s ease" }}
+      />
+    </svg>
+  );
+}
+
+function MiniStat({ value, label }: { value: string | number; label: string }) {
+  return (
+    <div className="achievement-mini-stat">
+      <div className="achievement-mini-value">{value}</div>
+      <div className="achievement-mini-label">{label}</div>
+    </div>
+  );
+}
+
+function BadgeIcon({ milestoneId, achieved }: { milestoneId: string; achieved: boolean }) {
+  const meta = MILESTONE_BY_ID.get(milestoneId as MilestoneId);
+  const hue = meta?.hue ?? 200;
+  const glyph = meta?.glyph ?? "?";
+  const color = achieved ? `oklch(0.75 0.15 ${hue})` : "var(--fg-faint)";
+
+  return (
+    <div style={{ width: 48, height: 48, position: "relative", flexShrink: 0 }}>
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          background: achieved
+            ? `linear-gradient(135deg, ${color}, oklch(0.55 0.18 ${hue}))`
+            : "var(--bg-3)",
+          clipPath: "polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%)",
+          boxShadow: achieved ? `0 0 18px oklch(0.75 0.15 ${hue} / 0.35)` : "none",
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          inset: 3,
+          background: achieved ? `oklch(0.35 0.1 ${hue})` : "var(--bg-2)",
+          clipPath: "polygon(50% 0, 100% 25%, 100% 75%, 50% 100%, 0 75%, 0 25%)",
+          display: "grid",
+          placeItems: "center",
+          color: achieved ? color : "var(--fg-faint)",
+          fontSize: glyph.length > 1 ? 11 : 18,
+          fontFamily: "var(--font-pixel)",
+          fontWeight: 700,
+        }}
+      >
+        {glyph}
+      </div>
+    </div>
+  );
+}
+
+function AchievementAvatar({
+  emoji,
+  label,
+}: {
+  emoji: string;
+  label: string;
+}) {
+  return (
+    <div
+      title={label}
+      aria-label={label}
+      style={{
+        width: 28,
+        height: 28,
+        borderRadius: 999,
+        display: "grid",
+        placeItems: "center",
+        background: "color-mix(in srgb, var(--bg-3) 88%, transparent)",
+        border: "1px solid color-mix(in srgb, var(--line) 70%, transparent)",
+        fontSize: 14,
+      }}
+    >
+      {emoji || "🤖"}
+    </div>
+  );
+}
+
+function AchievementCard({
+  item,
+  locale,
+  progressLabel,
+}: {
+  item: AchievementCardModel;
+  locale: string;
+  progressLabel: string;
+}) {
+  return (
+    <div
+      className="card achievement-card"
+      style={{ opacity: item.got ? 1 : 0.7 }}
+    >
+      {item.got ? (
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            right: 0,
+            width: 40,
+            height: 40,
+            background:
+              "radial-gradient(circle at top right, oklch(0.8 0.15 85 / 0.25), transparent 70%)",
+          }}
+        />
+      ) : null}
+
+      <div style={{ display: "flex", alignItems: "flex-start", gap: 12 }}>
+        <BadgeIcon milestoneId={item.milestoneId} achieved={item.got} />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 3 }}>
+            <span style={{ fontSize: 13, fontWeight: 600 }}>{item.name}</span>
+            <span
+              style={{
+                marginLeft: "auto",
+                fontSize: 10,
+                fontFamily: "var(--font-mono)",
+                color: item.got ? "var(--warn)" : "var(--fg-faint)",
+              }}
+            >
+              +{formatExact(item.xp, locale)} XP
+            </span>
+          </div>
+          <div style={{ fontSize: 11.5, color: "var(--fg-muted)", lineHeight: 1.45 }}>{item.desc}</div>
+          {item.agentName ? (
+            <div
+              style={{
+                marginTop: 8,
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 8,
+                fontSize: 10.5,
+                color: "var(--fg-faint)",
+              }}
+            >
+              <AchievementAvatar emoji={item.avatarEmoji || "🤖"} label={item.agentName} />
+              <span>{item.agentName}</span>
+            </div>
+          ) : null}
+          {!item.got && typeof item.prog === "number" ? (
+            <div style={{ marginTop: 10 }}>
+              <div className="bar-track" style={{ height: 4 }}>
+                <div className="bar-fill" style={{ width: `${Math.round(item.prog * 100)}%` }} />
+              </div>
+              <div
+                style={{
+                  marginTop: 4,
+                  fontSize: 10,
+                  color: "var(--fg-faint)",
+                  fontFamily: "var(--font-mono)",
+                }}
+              >
+                {Math.round(item.prog * 100)}% {progressLabel}
+              </div>
+            </div>
+          ) : null}
+          {item.got && item.at ? (
+            <div
+              style={{
+                marginTop: 8,
+                fontSize: 10.5,
+                color: "var(--fg-faint)",
+                fontFamily: "var(--font-mono)",
+              }}
+            >
+              {item.at}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function AchievementsPage({
+  settings,
+  stats,
+  agents = [],
+  onSelectAgent,
+}: AchievementsPageProps) {
+  const { language, locale, t } = useI18n(settings.language);
+  const [achievements, setAchievements] = useState<api.Achievement[]>([]);
+
+  useEffect(() => {
+    let alive = true;
+
+    const load = async () => {
+      try {
+        const response = await api.getAchievements();
+        if (!alive) return;
+        setAchievements(response.achievements ?? []);
+      } catch {
+        if (!alive) return;
+        setAchievements([]);
+      }
+    };
+
+    void load();
+    const timer = window.setInterval(() => {
+      void load();
+    }, 5 * 60 * 1000);
+
+    return () => {
+      alive = false;
+      window.clearInterval(timer);
+    };
+  }, []);
+
+  const agentMap = useMemo(
+    () => new Map(agents.map((agent) => [agent.id, agent])),
+    [agents],
+  );
+
+  const leaderboard = useMemo<LeaderboardEntry[]>(() => {
+    if (stats?.top_agents?.length) {
+      return stats.top_agents.map((entry) => {
+        const agent = agentMap.get(entry.id);
+        return {
+          id: entry.id,
+          name: agent
+            ? localeName(language, agent)
+            : language === "ko"
+              ? entry.name_ko
+              : entry.name,
+          avatarEmoji: agent?.avatar_emoji || entry.avatar_emoji || "🤖",
+          xp: entry.stats_xp,
+          tasksDone: entry.stats_tasks_done,
+          agent,
+        };
+      });
+    }
+
+    return [...agents]
+      .sort((left, right) => right.stats_xp - left.stats_xp || right.stats_tasks_done - left.stats_tasks_done)
+      .map((agent) => ({
+        id: agent.id,
+        name: localeName(language, agent),
+        avatarEmoji: agent.avatar_emoji || "🤖",
+        xp: agent.stats_xp,
+        tasksDone: agent.stats_tasks_done,
+        agent,
+      }));
+  }, [agentMap, agents, language, stats]);
+
+  const hero = leaderboard[0];
+  const heroAgent = hero?.agent ?? agents[0];
+  const heroXp = hero?.xp ?? heroAgent?.stats_xp ?? 0;
+  const heroLevel = getAgentLevel(heroXp);
+  const heroTitle = getAgentTitle(heroXp, language === "ko");
+  const heroNextXp = Number.isFinite(heroLevel.nextThreshold)
+    ? Math.max(0, heroLevel.nextThreshold - heroXp)
+    : 0;
+  const totalOrgXp = agents.reduce((sum, agent) => sum + agent.stats_xp, 0);
+  const uniqueEarners = new Set(achievements.map((achievement) => achievement.agent_id)).size;
+  const heroMilestoneCount = MILESTONES.filter((milestone) => heroXp >= milestone.threshold).length;
+
+  const earnedCards = useMemo<AchievementCardModel[]>(() => {
+    return [...achievements]
+      .sort((left, right) => right.earned_at - left.earned_at)
+      .map((achievement) => {
+        const milestone = MILESTONE_BY_ID.get(achievement.type as MilestoneId);
+        const agent = agentMap.get(achievement.agent_id);
+        const agentName = agent
+          ? localeName(language, agent)
+          : language === "ko"
+            ? achievement.agent_name_ko
+            : achievement.agent_name;
+
+        return {
+          id: achievement.id,
+          got: true,
+          milestoneId: achievement.type,
+          name:
+            language === "ko"
+              ? achievement.name
+              : milestone?.name.en ?? achievement.name,
+          desc:
+            language === "ko"
+              ? achievement.description || milestone?.desc.ko || ""
+              : milestone?.desc.en || achievement.description || "",
+          xp: milestone?.threshold ?? 0,
+          at: formatAchievementDate(achievement.earned_at, locale),
+          agentName,
+          avatarEmoji: achievement.avatar_emoji || agent?.avatar_emoji || "🤖",
+          agent,
+        };
+      });
+  }, [achievements, agentMap, language, locale]);
+
+  const lockedCards = useMemo<AchievementCardModel[]>(() => {
+    const cards: AchievementCardModel[] = [];
+    for (const entry of leaderboard) {
+      const milestone = nextMilestone(entry.xp);
+      if (!milestone) continue;
+      const remaining = Math.max(0, milestone.threshold - entry.xp);
+      cards.push({
+        id: `${entry.id}:${milestone.id}:locked`,
+        got: false,
+        milestoneId: milestone.id,
+        name: t(milestone.name),
+        desc:
+          language === "ko"
+            ? `${entry.name} · ${formatExact(remaining, locale)} XP 남음`
+            : `${entry.name} · ${formatExact(remaining, locale)} XP left`,
+        xp: milestone.threshold,
+        prog: progressToMilestone(entry.xp, milestone),
+        agentName: entry.name,
+        avatarEmoji: entry.avatarEmoji,
+        agent: entry.agent,
+      });
+      if (cards.length >= 6) break;
+    }
+    return cards;
+  }, [language, leaderboard, locale, t]);
+
+  const topSnapshot = leaderboard.slice(0, 3);
+  const totalCards = heroMilestoneCount + Math.max(0, MILESTONES.length - heroMilestoneCount);
+
+  return (
+    <div
+      data-testid="achievements-page"
+      className="achievements-shell mx-auto h-full w-full max-w-[1440px] min-w-0 overflow-x-hidden overflow-y-auto p-4 pb-40 sm:p-6"
+      style={{
+        paddingBottom: "max(10rem, calc(10rem + env(safe-area-inset-bottom)))",
+      }}
+    >
+      <style>{`
+        .achievements-shell .page {
+          display: flex;
+          flex-direction: column;
+          gap: 18px;
+        }
+
+        .achievements-shell .page-header {
+          display: flex;
+          align-items: flex-end;
+          justify-content: space-between;
+          gap: 16px;
+        }
+
+        .achievements-shell .page-title {
+          font-size: 22px;
+          font-weight: 600;
+          letter-spacing: -0.5px;
+          line-height: 1.2;
+        }
+
+        .achievements-shell .page-sub {
+          margin-top: 4px;
+          max-width: 68ch;
+          font-size: 13px;
+          color: var(--fg-muted);
+        }
+
+        .achievements-shell .card {
+          position: relative;
+          overflow: hidden;
+          border-radius: 18px;
+          border: 1px solid color-mix(in srgb, var(--line) 72%, transparent);
+          background: color-mix(in srgb, var(--bg-2) 94%, transparent);
+        }
+
+        .achievements-shell .chip {
+          display: inline-flex;
+          align-items: center;
+          gap: 5px;
+          padding: 2px 8px;
+          border-radius: 999px;
+          font-size: 11px;
+          font-weight: 500;
+          background: color-mix(in srgb, var(--bg-3) 90%, transparent);
+          color: var(--fg-muted);
+          border: 1px solid color-mix(in srgb, var(--line) 70%, transparent);
+          font-variant-numeric: tabular-nums;
+        }
+
+        .achievements-shell .chip .dot {
+          width: 6px;
+          height: 6px;
+          border-radius: 999px;
+          background: var(--fg-muted);
+        }
+
+        .achievements-shell .chip.ok {
+          color: var(--ok);
+          border-color: color-mix(in srgb, var(--ok) 28%, var(--line) 72%);
+          background: color-mix(in srgb, var(--ok) 10%, transparent);
+        }
+
+        .achievements-shell .chip.ok .dot {
+          background: var(--ok);
+        }
+
+        .achievements-shell .bar-track {
+          width: 100%;
+          border-radius: 999px;
+          background: color-mix(in srgb, var(--bg-3) 92%, transparent);
+          overflow: hidden;
+        }
+
+        .achievements-shell .bar-fill {
+          height: 100%;
+          border-radius: inherit;
+          background: linear-gradient(90deg, var(--accent), var(--codex));
+        }
+
+        .achievements-shell .achievement-grid {
+          display: grid;
+          gap: 14px;
+        }
+
+        .achievements-shell .achievement-grid.three {
+          grid-template-columns: repeat(1, minmax(0, 1fr));
+        }
+
+        .achievements-shell .achievement-card {
+          padding: 16px;
+        }
+
+        .achievements-shell .achievement-mini-stat {
+          text-align: center;
+          padding: 0 14px;
+          border-left: 1px solid color-mix(in srgb, var(--line) 55%, transparent);
+        }
+
+        .achievements-shell .achievement-mini-value {
+          font-size: 22px;
+          font-weight: 700;
+          font-family: var(--font-display);
+          font-variant-numeric: tabular-nums;
+        }
+
+        .achievements-shell .achievement-mini-label {
+          font-size: 10.5px;
+          color: var(--fg-muted);
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+        }
+
+        .achievements-shell .section-heading {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 12px;
+          margin-bottom: 10px;
+        }
+
+        .achievements-shell .section-title {
+          font-size: 13px;
+          font-weight: 600;
+        }
+
+        .achievements-shell .section-title span {
+          color: var(--fg-muted);
+          font-weight: 400;
+        }
+
+        .achievements-shell .leaderboard-list {
+          display: grid;
+          gap: 10px;
+        }
+
+        .achievements-shell .leaderboard-row {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+          border-radius: 14px;
+          border: 1px solid color-mix(in srgb, var(--line) 66%, transparent);
+          padding: 12px 14px;
+          background: color-mix(in srgb, var(--bg-2) 92%, transparent);
+          text-align: left;
+          transition: transform 0.16s ease, border-color 0.16s ease, background 0.16s ease;
+        }
+
+        .achievements-shell .leaderboard-row.clickable:hover {
+          transform: translateY(-1px);
+          border-color: color-mix(in srgb, var(--accent) 24%, var(--line) 76%);
+          background: color-mix(in srgb, var(--accent) 6%, var(--bg-2) 94%);
+        }
+
+        .achievements-shell .fade-in {
+          animation: achievements-fade-in 0.3s ease-out;
+        }
+
+        @media (min-width: 768px) {
+          .achievements-shell .achievement-grid.three {
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+          }
+        }
+
+        @media (min-width: 1200px) {
+          .achievements-shell .achievement-grid.three {
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+          }
+        }
+
+        @media (max-width: 720px) {
+          .achievements-shell .page-header {
+            flex-direction: column;
+            align-items: flex-start;
+          }
+        }
+
+        @keyframes achievements-fade-in {
+          from {
+            opacity: 0;
+            transform: translateY(8px);
+          }
+
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+      `}</style>
+
+      <div className="page fade-in">
+        <div className="page-header">
+          <div>
+            <div className="page-title">{t({ ko: "업적", en: "Achievements" })}</div>
+            <div className="page-sub">
+              {t({
+                ko: "운영 업적과 XP 흐름을 한 화면에서 추적합니다.",
+                en: "Track operational achievements and XP in one view.",
+              })}
+            </div>
+          </div>
+          <div style={{ display: "flex", gap: 8 }}>
+            <span className="chip ok">
+              <span className="dot" />
+              {heroMilestoneCount} / {totalCards} {t({ ko: "달성", en: "unlocked" })}
+            </span>
+          </div>
+        </div>
+
+        <div
+          className="card"
+          style={{
+            marginBottom: 14,
+            padding: 24,
+            background: "linear-gradient(135deg, var(--bg-1), oklch(0.2 0.03 280))",
+            border: "1px solid var(--line)",
+            display: "flex",
+            alignItems: "center",
+            gap: 24,
+            flexWrap: "wrap",
+          }}
+        >
+          <div style={{ position: "relative" }}>
+            <AchievementRing value={heroLevel.progress * 100} />
+            <div
+              style={{
+                position: "absolute",
+                inset: 0,
+                display: "grid",
+                placeItems: "center",
+              }}
+            >
+              <div style={{ textAlign: "center" }}>
+                <div
+                  style={{
+                    fontSize: 10,
+                    color: "var(--fg-muted)",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.05em",
+                  }}
+                >
+                  LEVEL
+                </div>
+                <div
+                  style={{
+                    fontSize: 24,
+                    fontWeight: 700,
+                    fontFamily: "var(--font-display)",
+                    lineHeight: 1,
+                  }}
+                >
+                  {heroLevel.level}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div style={{ flex: 1, minWidth: 240 }}>
+            <div style={{ fontSize: 18, fontWeight: 600, marginBottom: 4 }}>{heroTitle}</div>
+            <div style={{ fontSize: 12, color: "var(--fg-muted)", marginBottom: 10 }}>
+              {hero
+                ? `${hero.name} · XP ${formatExact(heroXp, locale)}`
+                : `XP ${formatExact(heroXp, locale)}`}
+              {Number.isFinite(heroLevel.nextThreshold)
+                ? ` · ${t({ ko: "다음 레벨까지", en: "to next level" })} ${formatExact(heroNextXp, locale)}`
+                : ` · ${t({ ko: "최상위 레벨", en: "Max level" })}`}
+            </div>
+            <div className="bar-track" style={{ height: 6 }}>
+              <div
+                className="bar-fill"
+                style={{ width: `${Math.round(heroLevel.progress * 100)}%` }}
+              />
+            </div>
+          </div>
+
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(3, minmax(88px, 1fr))",
+              gap: 14,
+              minWidth: "min(100%, 320px)",
+            }}
+          >
+            <MiniStat value={achievements.length} label={t({ ko: "달성", en: "Unlocked" })} />
+            <MiniStat value={uniqueEarners} label={t({ ko: "에이전트", en: "Agents" })} />
+            <MiniStat value={formatCompact(totalOrgXp, locale)} label="TOTAL XP" />
+          </div>
+        </div>
+
+        <div>
+          <div className="section-heading">
+            <div className="section-title">
+              {t({ ko: "달성", en: "Unlocked" })} <span>{earnedCards.length}</span>
+            </div>
+          </div>
+          {earnedCards.length === 0 ? (
+            <div
+              className="card"
+              style={{
+                padding: 20,
+                fontSize: 13,
+                color: "var(--fg-muted)",
+              }}
+            >
+              {t({
+                ko: "아직 집계된 업적이 없습니다.",
+                en: "No unlocked achievements have been recorded yet.",
+              })}
+            </div>
+          ) : (
+            <div className="achievement-grid three">
+              {earnedCards.map((item) => (
+                <AchievementCard
+                  key={item.id}
+                  item={item}
+                  locale={locale}
+                  progressLabel={t({ ko: "진행", en: "progress" })}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div>
+          <div className="section-heading">
+            <div className="section-title">
+              {t({ ko: "잠금 해제", en: "Locked" })} <span>{lockedCards.length}</span>
+            </div>
+          </div>
+          {lockedCards.length === 0 ? (
+            <div
+              className="card"
+              style={{
+                padding: 20,
+                fontSize: 13,
+                color: "var(--fg-muted)",
+              }}
+            >
+              {t({
+                ko: "현재 milestone 기준으로 잠긴 업적이 없습니다.",
+                en: "No pending milestones remain for the current leaderboard.",
+              })}
+            </div>
+          ) : (
+            <div className="achievement-grid three">
+              {lockedCards.map((item) => (
+                <AchievementCard
+                  key={item.id}
+                  item={item}
+                  locale={locale}
+                  progressLabel={t({ ko: "진행", en: "progress" })}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="achievement-grid" style={{ gridTemplateColumns: "minmax(0, 1.15fr) minmax(320px, 0.85fr)" }}>
+          <div className="card" style={{ padding: 18 }}>
+            <div className="section-heading">
+              <div className="section-title">
+                {t({ ko: "랭킹 보드", en: "Ranking Board" })} <span>{leaderboard.length}</span>
+              </div>
+              <span className="chip">
+                <span className="dot" />
+                XP
+              </span>
+            </div>
+            <div className="leaderboard-list">
+              {leaderboard.slice(0, 6).map((entry, index) => {
+                const clickable = Boolean(entry.agent && onSelectAgent);
+                return (
+                  <button
+                    key={entry.id}
+                    type="button"
+                    className={`leaderboard-row${clickable ? " clickable" : ""}`}
+                    onClick={() => {
+                      if (entry.agent && onSelectAgent) onSelectAgent(entry.agent);
+                    }}
+                    disabled={!clickable}
+                  >
+                    <div
+                      style={{
+                        width: 28,
+                        fontSize: 11,
+                        fontWeight: 700,
+                        color: "var(--fg-muted)",
+                        fontFamily: "var(--font-mono)",
+                      }}
+                    >
+                      #{index + 1}
+                    </div>
+                    <AchievementAvatar emoji={entry.avatarEmoji} label={entry.name} />
+                    <div style={{ minWidth: 0, flex: 1 }}>
+                      <div style={{ fontSize: 13, fontWeight: 600, color: "var(--fg)" }}>
+                        {entry.name}
+                      </div>
+                      <div style={{ marginTop: 2, fontSize: 11, color: "var(--fg-muted)" }}>
+                        {t({
+                          ko: `${formatExact(entry.tasksDone, locale)}개 완료`,
+                          en: `${formatExact(entry.tasksDone, locale)} completed`,
+                        })}
+                      </div>
+                    </div>
+                    <div
+                      style={{
+                        textAlign: "right",
+                        fontSize: 12,
+                        fontWeight: 600,
+                        color: "var(--accent)",
+                      }}
+                    >
+                      {formatExact(entry.xp, locale)} XP
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="card" style={{ padding: 18 }}>
+            <div className="section-heading">
+              <div className="section-title">
+                {t({ ko: "XP 스냅샷", en: "XP Snapshot" })} <span>{topSnapshot.length}</span>
+              </div>
+            </div>
+            <div className="achievement-grid" style={{ gap: 10 }}>
+              {topSnapshot.length === 0 ? (
+                <div style={{ fontSize: 13, color: "var(--fg-muted)" }}>
+                  {t({
+                    ko: "아직 XP 집계 대상이 없습니다.",
+                    en: "No XP snapshot is available yet.",
+                  })}
+                </div>
+              ) : (
+                topSnapshot.map((entry, index) => (
+                  <div
+                    key={entry.id}
+                    className="card"
+                    style={{
+                      padding: 14,
+                      borderColor: "color-mix(in srgb, var(--accent) 20%, var(--line) 80%)",
+                      background: "color-mix(in srgb, var(--bg-2) 92%, transparent)",
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontSize: 11,
+                        fontWeight: 600,
+                        letterSpacing: "0.16em",
+                        textTransform: "uppercase",
+                        color: "var(--fg-muted)",
+                      }}
+                    >
+                      {t({
+                        ko: `${index + 1}위`,
+                        en: `Rank ${index + 1}`,
+                      })}
+                    </div>
+                    <div style={{ marginTop: 8, display: "flex", alignItems: "center", gap: 10 }}>
+                      <AchievementAvatar emoji={entry.avatarEmoji} label={entry.name} />
+                      <div style={{ minWidth: 0 }}>
+                        <div style={{ fontSize: 13, fontWeight: 600, color: "var(--fg)" }}>
+                          {entry.name}
+                        </div>
+                        <div style={{ marginTop: 2, fontSize: 11.5, color: "var(--fg-muted)" }}>
+                          {t({
+                            ko: `${formatExact(entry.tasksDone, locale)}개 완료`,
+                            en: `${formatExact(entry.tasksDone, locale)} completed`,
+                          })}
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      style={{
+                        marginTop: 10,
+                        fontSize: 22,
+                        fontWeight: 700,
+                        fontFamily: "var(--font-display)",
+                        color: "var(--accent)",
+                      }}
+                    >
+                      {formatExact(entry.xp, locale)}
+                    </div>
+                    <div style={{ marginTop: 2, fontSize: 11, color: "var(--fg-muted)" }}>XP</div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/AgentManagerView.tsx
+++ b/dashboard/src/components/AgentManagerView.tsx
@@ -1,17 +1,15 @@
-import { useState, useCallback, useMemo, type DragEvent } from "react";
+import { useEffect, useState } from "react";
 import type { Agent, Department, DispatchedSession, KanbanCard } from "../types";
 import type { UiLanguage } from "../i18n";
-import { localeName } from "../i18n";
-import * as api from "../api";
-import { buildSpriteMap } from "./AgentAvatar";
-import { pickRandomSpritePair } from "./agent-manager/utils";
-import { BLANK, ICON_SPRITE_POOL } from "./agent-manager/constants";
-import type { FormData } from "./agent-manager/types";
 import AgentsTab from "./agent-manager/AgentsTab";
 import BacklogTab from "./agent-manager/BacklogTab";
 import DepartmentsTab from "./agent-manager/DepartmentsTab";
 import AgentFormModal from "./agent-manager/AgentFormModal";
 import DepartmentFormModal from "./agent-manager/DepartmentFormModal";
+import {
+  type AgentManagerTab,
+  useAgentManagerController,
+} from "./agent-manager/useAgentManagerController";
 import { SessionPanel } from "./session-panel/SessionPanel";
 import {
   SurfaceActionButton,
@@ -28,8 +26,8 @@ interface AgentManagerViewProps {
   onDepartmentsChange: () => void;
   sessions?: DispatchedSession[];
   onAssign?: (id: string, patch: Partial<DispatchedSession>) => Promise<void>;
-  activeTab?: Tab;
-  onTabChange?: (tab: Tab) => void;
+  activeTab?: AgentManagerTab;
+  onTabChange?: (tab: AgentManagerTab) => void;
   kanbanCards?: KanbanCard[];
   onSelectAgent?: (agent: Agent) => void;
   showHeader?: boolean;
@@ -38,8 +36,6 @@ interface AgentManagerViewProps {
   subtitle?: string;
   scrollable?: boolean;
 }
-
-type Tab = "agents" | "departments" | "backlog" | "dispatch";
 
 export default function AgentManagerView({
   agents,
@@ -60,316 +56,178 @@ export default function AgentManagerView({
   subtitle,
   scrollable = true,
 }: AgentManagerViewProps) {
-  const locale = language;
-  const isKo = locale.startsWith("ko");
-  const tr = useCallback(
-    (ko: string, en: string) => (isKo ? ko : en),
-    [isKo],
+  const {
+    canShowDispatch,
+    confirmDeleteId,
+    deptModal,
+    deptOrder,
+    deptOrderDirty,
+    deptTab,
+    draggingDeptId,
+    dragOverDeptId,
+    dragOverPosition,
+    dispatchOpen,
+    form,
+    agentModal,
+    handleCancelOrder,
+    handleDeleteAgent,
+    handleDragEnd,
+    handleDragOver,
+    handleDragStart,
+    handleDrop,
+    handleMoveDept,
+    handleSaveAgent,
+    handleSaveOrder,
+    handleTabChange,
+    isKo,
+    locale,
+    openCreateAgent,
+    openCreateDept,
+    openEditAgent,
+    openEditDept,
+    reorderSaving,
+    resolvedTab,
+    saving,
+    search,
+    setAgentModal,
+    setConfirmDeleteId,
+    setDeptModal,
+    setDeptTab,
+    setDispatchOpen,
+    setForm,
+    setSearch,
+    setStatusFilter,
+    sortedAgents,
+    spriteMap,
+    statusFilter,
+    tr,
+  } = useAgentManagerController({
+    agents,
+    departments,
+    language,
+    officeId,
+    onAgentsChange,
+    onDepartmentsChange,
+    sessions,
+    onAssign,
+    activeTab,
+    onTabChange,
+  });
+  const [isDesktopViewport, setIsDesktopViewport] = useState(() =>
+    typeof window === "undefined" ? true : window.matchMedia("(min-width: 640px)").matches,
   );
 
-  // ── Tab state ──
-  const [internalTab, setInternalTab] = useState<Tab>("agents");
-  const tab = activeTab ?? internalTab;
-  const canShowDispatch = Boolean(sessions && onAssign);
-  const resolvedTab = tab === "dispatch" && !canShowDispatch ? "agents" : tab;
-  const handleTabChange = useCallback((nextTab: Tab) => {
-    if (activeTab === undefined) {
-      setInternalTab(nextTab);
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
     }
-    onTabChange?.(nextTab);
-  }, [activeTab, onTabChange]);
 
-  // ── Agent tab state ──
-  const [deptTab, setDeptTab] = useState("all");
-  const [statusFilter, setStatusFilter] = useState<string>("all");
-  const [search, setSearch] = useState("");
-  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
+    const mediaQuery = window.matchMedia("(min-width: 640px)");
+    const updateViewport = () => setIsDesktopViewport(mediaQuery.matches);
 
-  // ── Agent modal state ──
-  const [agentModal, setAgentModal] = useState<{ open: boolean; editAgent: Agent | null }>({ open: false, editAgent: null });
-  const [form, setForm] = useState<FormData>(BLANK);
+    updateViewport();
 
-  // ── Department modal state ──
-  const [deptModal, setDeptModal] = useState<{ open: boolean; editDept: Department | null }>({ open: false, editDept: null });
-
-  // ── Department ordering state ──
-  const [deptOrder, setDeptOrder] = useState<Department[]>(departments);
-  const [deptOrderDirty, setDeptOrderDirty] = useState(false);
-  const [reorderSaving, setReorderSaving] = useState(false);
-  const [draggingDeptId, setDraggingDeptId] = useState<string | null>(null);
-  const [dragOverDeptId, setDragOverDeptId] = useState<string | null>(null);
-  const [dragOverPosition, setDragOverPosition] = useState<"before" | "after" | null>(null);
-
-  // Sync deptOrder when departments prop changes
-  if (!deptOrderDirty && JSON.stringify(deptOrder.map(d => d.id)) !== JSON.stringify(departments.map(d => d.id))) {
-    setDeptOrder(departments);
-  }
-
-  // ── Derived data ──
-  const spriteMap = useMemo(() => buildSpriteMap(agents), [agents]);
-  const randomIconSprites = useMemo(() => ({ total: pickRandomSpritePair(ICON_SPRITE_POOL) }), []);
-
-  const sortedAgents = useMemo(() => {
-    let filtered = agents;
-    if (deptTab !== "all") {
-      filtered = filtered.filter((a) => a.department_id === deptTab);
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", updateViewport);
+      return () => mediaQuery.removeEventListener("change", updateViewport);
     }
-    if (statusFilter !== "all") {
-      filtered = filtered.filter((a) => a.status === statusFilter);
-    }
-    if (search.trim()) {
-      const q = search.toLowerCase();
-      filtered = filtered.filter(
-        (a) =>
-          a.name.toLowerCase().includes(q) ||
-          a.name_ko.toLowerCase().includes(q) ||
-          (a.alias && a.alias.toLowerCase().includes(q)) ||
-          a.avatar_emoji.includes(q),
-      );
-    }
-    return [...filtered].sort((a, b) => {
-      const statusOrder = { working: 0, idle: 1, break: 2, offline: 3 };
-      const sa = statusOrder[a.status] ?? 4;
-      const sb = statusOrder[b.status] ?? 4;
-      if (sa !== sb) return sa - sb;
-      return a.name.localeCompare(b.name);
-    });
-  }, [agents, deptTab, statusFilter, search]);
 
-  // ── Agent CRUD ──
-  const openCreateAgent = useCallback(() => {
-    setForm(BLANK);
-    setAgentModal({ open: true, editAgent: null });
+    mediaQuery.addListener(updateViewport);
+    return () => mediaQuery.removeListener(updateViewport);
   }, []);
 
-  const openEditAgent = useCallback((agent: Agent) => {
-    setForm({
-      name: agent.name,
-      name_ko: agent.name_ko ?? "",
-      name_ja: agent.name_ja ?? "",
-      name_zh: agent.name_zh ?? "",
-      department_id: agent.department_id ?? "",
-      cli_provider: agent.cli_provider ?? "claude",
-      avatar_emoji: agent.avatar_emoji ?? "🤖",
-      sprite_number: agent.sprite_number ?? null,
-      personality: agent.personality ?? "",
-    });
-    setAgentModal({ open: true, editAgent: agent });
-  }, []);
-
-  const handleSaveAgent = useCallback(async () => {
-    setSaving(true);
-    try {
-      const payload: Record<string, unknown> = {
-        name: form.name.trim(),
-        name_ko: form.name_ko.trim() || form.name.trim(),
-        name_ja: form.name_ja.trim() || undefined,
-        name_zh: form.name_zh.trim() || undefined,
-        department_id: form.department_id || null,
-        cli_provider: form.cli_provider,
-        avatar_emoji: form.avatar_emoji,
-        sprite_number: form.sprite_number,
-        personality: form.personality.trim() || null,
-      };
-      if (!agentModal.editAgent && officeId) {
-        payload.office_id = officeId;
-      }
-      if (agentModal.editAgent) {
-        await api.updateAgent(agentModal.editAgent.id, payload);
-      } else {
-        await api.createAgent(payload);
-      }
-      setAgentModal({ open: false, editAgent: null });
-      onAgentsChange();
-    } catch (e) {
-      console.error("Agent save failed:", e);
-    } finally {
-      setSaving(false);
-    }
-  }, [form, agentModal.editAgent, onAgentsChange]);
-
-  const handleDeleteAgent = useCallback(async (id: string) => {
-    setSaving(true);
-    try {
-      await api.deleteAgent(id);
-      setConfirmDeleteId(null);
-      onAgentsChange();
-    } catch (e) {
-      console.error("Agent delete failed:", e);
-    } finally {
-      setSaving(false);
-    }
-  }, [onAgentsChange]);
-
-  // ── Department editing ──
-  const openCreateDept = useCallback(() => {
-    setDeptModal({ open: true, editDept: null });
-  }, []);
-
-  const openEditDept = useCallback((dept: Department) => {
-    setDeptModal({ open: true, editDept: dept });
-  }, []);
-
-  // ── Department ordering ──
-  const handleMoveDept = useCallback((index: number, direction: -1 | 1) => {
-    setDeptOrder((prev) => {
-      const next = [...prev];
-      const target = index + direction;
-      if (target < 0 || target >= next.length) return prev;
-      [next[index], next[target]] = [next[target], next[index]];
-      return next;
-    });
-    setDeptOrderDirty(true);
-  }, []);
-
-  const handleSaveOrder = useCallback(async () => {
-    setReorderSaving(true);
-    try {
-      for (let i = 0; i < deptOrder.length; i++) {
-        await api.updateDepartment(deptOrder[i].id, { sort_order: i });
-      }
-      setDeptOrderDirty(false);
-      onDepartmentsChange();
-    } catch (e) {
-      console.error("Order save failed:", e);
-    } finally {
-      setReorderSaving(false);
-    }
-  }, [deptOrder, onDepartmentsChange]);
-
-  const handleCancelOrder = useCallback(() => {
-    setDeptOrder(departments);
-    setDeptOrderDirty(false);
-  }, [departments]);
-
-  // Drag & drop handlers
-  const handleDragStart = useCallback((deptId: string, e: DragEvent<HTMLDivElement>) => {
-    setDraggingDeptId(deptId);
-    e.dataTransfer.effectAllowed = "move";
-  }, []);
-
-  const handleDragOver = useCallback((deptId: string, e: DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    e.dataTransfer.dropEffect = "move";
-    const rect = e.currentTarget.getBoundingClientRect();
-    const midY = rect.top + rect.height / 2;
-    setDragOverDeptId(deptId);
-    setDragOverPosition(e.clientY < midY ? "before" : "after");
-  }, []);
-
-  const handleDrop = useCallback((targetId: string, _e: DragEvent<HTMLDivElement>) => {
-    if (!draggingDeptId || draggingDeptId === targetId) {
-      setDraggingDeptId(null);
-      setDragOverDeptId(null);
-      setDragOverPosition(null);
-      return;
-    }
-    setDeptOrder((prev) => {
-      const next = prev.filter((d) => d.id !== draggingDeptId);
-      const targetIndex = next.findIndex((d) => d.id === targetId);
-      const insertAt = dragOverPosition === "after" ? targetIndex + 1 : targetIndex;
-      const dragged = prev.find((d) => d.id === draggingDeptId);
-      if (dragged) next.splice(insertAt, 0, dragged);
-      return next;
-    });
-    setDeptOrderDirty(true);
-    setDraggingDeptId(null);
-    setDragOverDeptId(null);
-    setDragOverPosition(null);
-  }, [draggingDeptId, dragOverPosition]);
-
-  const handleDragEnd = useCallback(() => {
-    setDraggingDeptId(null);
-    setDragOverDeptId(null);
-    setDragOverPosition(null);
-  }, []);
-
-  const defaultTitle =
-    resolvedTab === "departments"
-      ? tr("부서 관리", "Departments")
-      : resolvedTab === "dispatch"
-        ? tr("파견 세션", "Dispatch Sessions")
-        : resolvedTab === "backlog"
-        ? tr("백로그", "Backlog")
-        : tr("직원 관리", "Agent Manager");
+  const defaultTitle = tr("에이전트", "Agents");
   const resolvedTitle = title ?? defaultTitle;
   const resolvedSubtitle = subtitle
-    ?? (resolvedTab === "departments"
-      ? tr("부서 순서, 역할, 테마를 관리합니다.", "Manage department order, roles, and themes.")
-      : resolvedTab === "dispatch"
-        ? tr("감지된 AgentDesk 세션을 부서와 에이전트에 연결해 오피스 시각화에 투입합니다.", "Assign detected AgentDesk sessions into teams and agents for office visualization.")
-      : resolvedTab === "backlog"
-        ? tr("핵심 backlog를 테이블과 모바일 카드 스택으로 관리합니다.", "Review the current backlog in a table or mobile card stack.")
-        : tr("에이전트 프로필, 스킬, 소속을 관리합니다.", "Manage agent profiles, skills, and office membership."));
+    ?? tr(
+      "에이전트 / 부서 / 백로그 이슈를 한 곳에서 관리합니다.",
+      "Manage agents, departments, and backlog issues in one place.",
+    );
   const tabItems: Array<{
-    key: Tab;
+    key: AgentManagerTab;
     id: string;
     panelId: string;
     testId: string;
     label: string;
+    title: string;
+    description: string;
+    tone: "neutral" | "accent" | "info" | "success" | "warn" | "danger";
+    count: number;
   }> = [
     {
       key: "agents",
       id: "agents-tab-button-agents",
       panelId: "agents-tab-panel",
       testId: "agents-tab-button-agents",
-      label: `${tr("직원", "Agents")} (${agents.length})`,
+      label: tr(`에이전트 ${agents.length}`, `Agents ${agents.length}`),
+      title: tr("에이전트", "Agents"),
+      description: tr("프로필, 스킬, 소속, provider를 관리합니다.", "Manage profiles, skills, memberships, and providers."),
+      tone: "info",
+      count: agents.length,
     },
     {
       key: "departments",
       id: "agents-tab-button-departments",
       panelId: "agents-departments-tab-panel",
       testId: "agents-tab-button-departments",
-      label: `${tr("부서", "Departments")} (${departments.length})`,
+      label: tr(`부서 ${departments.length}`, `Departments ${departments.length}`),
+      title: tr("부서", "Departments"),
+      description: tr("순서, 역할, 테마를 운영 톤에 맞춰 정리합니다.", "Adjust order, roles, and themes in the design language."),
+      tone: "accent",
+      count: departments.length,
     },
-    ...(canShowDispatch
-      ? [{
-          key: "dispatch" as const,
-          id: "agents-tab-button-dispatch",
-          panelId: "agents-dispatch-tab-panel",
-          testId: "agents-tab-button-dispatch",
-          label: `${tr("파견", "Dispatch")} (${sessions?.length ?? 0})`,
-        }]
-      : []),
     {
       key: "backlog",
       id: "agents-tab-button-backlog",
       panelId: "agents-backlog-tab-panel",
       testId: "agents-tab-button-backlog",
-      label: `${tr("백로그", "Backlog")} (${kanbanCards.length})`,
+      label: tr(`백로그 ${kanbanCards.length}`, `Backlog ${kanbanCards.length}`),
+      title: tr("백로그", "Backlog"),
+      description: tr("핵심 backlog를 상태와 우선순위 중심으로 관리합니다.", "Review the backlog by state and priority."),
+      tone: "warn",
+      count: kanbanCards.length,
     },
   ];
   const headerActions = (
     <div className="flex flex-wrap items-center gap-2">
-      {(showTabBar || resolvedTab === "departments") && resolvedTab !== "backlog" && resolvedTab !== "dispatch" && (
-        <SurfaceActionButton tone="neutral" onClick={openCreateDept}>
+      {(showTabBar || resolvedTab === "departments") && resolvedTab !== "backlog" && (
+        <SurfaceActionButton tone="neutral" compact onClick={openCreateDept}>
           + {tr("부서 추가", "Add Dept")}
         </SurfaceActionButton>
       )}
-      {(showTabBar || resolvedTab === "agents") && resolvedTab !== "departments" && resolvedTab !== "backlog" && resolvedTab !== "dispatch" && (
-        <SurfaceActionButton onClick={openCreateAgent}>
-          + {tr("직원 채용", "Hire Agent")}
+      {(showTabBar || resolvedTab === "agents") && resolvedTab !== "departments" && resolvedTab !== "backlog" && (
+        <SurfaceActionButton compact onClick={openCreateAgent}>
+          + {tr("에이전트 추가", "Add Agent")}
+        </SurfaceActionButton>
+      )}
+      {canShowDispatch && (
+        <SurfaceActionButton
+          tone="success"
+          compact
+          onClick={() => setDispatchOpen((prev) => !prev)}
+        >
+          {dispatchOpen ? tr("파견 닫기", "Close Dispatch") : tr("파견 열기", "Open Dispatch")}
         </SurfaceActionButton>
       )}
     </div>
   );
-  const tabBar = showTabBar ? (
+  const tabBarDesktop = showTabBar ? (
     <div
       data-testid="agents-tab-bar"
       role="tablist"
-      aria-label={tr("직원 관리 섹션", "Agent manager sections")}
-      className="mt-4 flex flex-wrap gap-2"
+      aria-label={tr("에이전트 관리 섹션", "Agent manager sections")}
+      className="hidden flex-wrap gap-2 sm:flex"
     >
       {tabItems.map((item) => (
         <SurfaceSegmentButton
           key={item.key}
-          id={item.id}
-          data-testid={item.testId}
+          id={isDesktopViewport ? item.id : undefined}
+          data-testid={isDesktopViewport ? item.testId : undefined}
           role="tab"
           aria-selected={resolvedTab === item.key}
           aria-controls={item.panelId}
           active={resolvedTab === item.key}
+          tone={item.tone}
           onClick={() => handleTabChange(item.key)}
         >
           {item.label}
@@ -377,12 +235,45 @@ export default function AgentManagerView({
       ))}
     </div>
   ) : null;
-
+  const tabBarMobile = showTabBar ? (
+    <div
+      data-testid="agents-tab-bar-mobile"
+      role="tablist"
+      aria-label={tr("에이전트 관리 섹션", "Agent manager sections")}
+      className="mt-4 grid grid-cols-2 gap-2 sm:hidden"
+    >
+      {tabItems.map((item) => (
+        <SurfaceSegmentButton
+          key={item.key}
+          id={!isDesktopViewport ? item.id : undefined}
+          data-testid={!isDesktopViewport ? item.testId : undefined}
+          role={!isDesktopViewport ? "tab" : undefined}
+          aria-selected={!isDesktopViewport ? resolvedTab === item.key : undefined}
+          aria-controls={!isDesktopViewport ? item.panelId : undefined}
+          active={resolvedTab === item.key}
+          tone={item.tone}
+          onClick={() => handleTabChange(item.key)}
+          className="min-w-0 justify-center whitespace-normal px-3 py-2 text-center leading-5"
+        >
+          {item.label}
+        </SurfaceSegmentButton>
+      ))}
+    </div>
+  ) : null;
+  const dispatchToggle = canShowDispatch ? (
+    <SurfaceActionButton
+      tone="success"
+      compact
+      onClick={() => setDispatchOpen((prev) => !prev)}
+    >
+      {dispatchOpen ? tr("파견 닫기", "Close Dispatch") : tr("파견 열기", "Open Dispatch")}
+    </SurfaceActionButton>
+  ) : null;
   return (
     <div
       data-testid="agents-page"
       className={`mx-auto w-full max-w-5xl min-w-0 space-y-4 overflow-x-hidden p-4 pb-40 sm:p-6 ${
-        scrollable ? "sm:h-full sm:overflow-y-auto" : ""
+        scrollable ? "h-full overflow-y-auto" : ""
       }`}
       style={{
         paddingBottom: "max(10rem, calc(10rem + env(safe-area-inset-bottom)))",
@@ -391,17 +282,49 @@ export default function AgentManagerView({
       }}
     >
       {showHeader && (
-        <SurfaceSection
-          title={resolvedTitle}
-          description={resolvedSubtitle}
-          actions={headerActions}
-          className="rounded-[30px] p-4 sm:p-5"
-        >
-          {tabBar}
-        </SurfaceSection>
+        <header className="space-y-3" data-testid="agents-page-header">
+          <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+            <div className="min-w-0">
+              <h1
+                className="text-2xl font-black tracking-tight sm:text-3xl"
+                style={{ color: "var(--th-text-heading)" }}
+              >
+                {resolvedTitle}
+              </h1>
+              <p
+                className="mt-2 max-w-3xl text-sm leading-6"
+                style={{ color: "var(--th-text-muted)" }}
+              >
+                {resolvedSubtitle}
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-3 xl:items-end">
+              {tabBarDesktop}
+              <div className="hidden sm:flex sm:flex-wrap sm:justify-end sm:gap-2">
+                {headerActions}
+              </div>
+            </div>
+          </div>
+
+          {tabBarMobile}
+          <div className="flex flex-wrap gap-2 sm:hidden">
+            {headerActions}
+          </div>
+        </header>
       )}
 
-      {!showHeader && tabBar}
+      {!showHeader && (
+        <>
+          {tabBarDesktop}
+          {tabBarMobile}
+          {dispatchToggle && (
+            <div className="flex justify-end">
+              {dispatchToggle}
+            </div>
+          )}
+        </>
+      )}
 
       {/* Tab content */}
       {resolvedTab === "agents" ? (
@@ -434,7 +357,6 @@ export default function AgentManagerView({
             onEditDepartment={openEditDept}
             onDeleteAgent={handleDeleteAgent}
             saving={saving}
-            randomIconSprites={randomIconSprites}
           />
         </div>
       ) : resolvedTab === "backlog" ? (
@@ -448,19 +370,6 @@ export default function AgentManagerView({
             locale={locale}
             cards={kanbanCards}
             agents={agents}
-          />
-        </div>
-      ) : resolvedTab === "dispatch" && sessions && onAssign ? (
-        <div
-          id="agents-dispatch-tab-panel"
-          role="tabpanel"
-          aria-labelledby="agents-tab-button-dispatch"
-        >
-          <SessionPanel
-            sessions={sessions}
-            departments={departments}
-            agents={agents}
-            onAssign={onAssign}
           />
         </div>
       ) : (
@@ -490,6 +399,33 @@ export default function AgentManagerView({
             onDragEnd={handleDragEnd}
           />
         </div>
+      )}
+
+      {canShowDispatch && dispatchOpen && sessions && onAssign && (
+        <SurfaceSection
+          eyebrow={tr("확장", "Extension")}
+          title={tr("파견 세션", "Dispatch Sessions")}
+          description={tr(
+            "코어 탭 밖에서 감지된 세션을 부서와 에이전트에 연결합니다.",
+            "Assign detected sessions outside the core tabs.",
+          )}
+          badge={`${sessions.length}`}
+          className="rounded-[30px] p-4 sm:p-5"
+          actions={(
+            <SurfaceActionButton tone="neutral" compact onClick={() => setDispatchOpen(false)}>
+              {tr("접기", "Collapse")}
+            </SurfaceActionButton>
+          )}
+        >
+          <div className="mt-4">
+            <SessionPanel
+              sessions={sessions}
+              departments={departments}
+              agents={agents}
+              onAssign={onAssign}
+            />
+          </div>
+        </SurfaceSection>
       )}
 
       {/* Agent create/edit modal */}

--- a/dashboard/src/components/DashboardPageView.tsx
+++ b/dashboard/src/components/DashboardPageView.tsx
@@ -8,12 +8,19 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type DragEvent as ReactDragEvent,
   type ErrorInfo,
   type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from "react";
+import { GripVertical } from "lucide-react";
 import { getSkillRanking, type SkillRankingResponse } from "../api";
-import { getStaleLinkedSessions } from "../agent-insights";
+import {
+  formatElapsedCompact,
+  getAgentWorkElapsedMs,
+  getAgentWorkSummary,
+  getStaleLinkedSessions,
+} from "../agent-insights";
 import {
   DASHBOARD_TABS,
   DASHBOARD_TAB_STORAGE_KEY,
@@ -44,11 +51,9 @@ import {
   SurfaceSubsection,
 } from "./common/SurfacePrimitives";
 import TooltipLabel from "./common/TooltipLabel";
+import AgentAvatar from "./AgentAvatar";
 import {
-  DashboardHeroHeader,
-  DashboardHudStats,
   DashboardRankingBoard,
-  type HudStat,
   type RankedAgent,
 } from "./dashboard/HeroSections";
 import {
@@ -62,13 +67,49 @@ import HealthWidget from "./dashboard/HealthWidget";
 import RateLimitWidget from "./dashboard/RateLimitWidget";
 import TokenAnalyticsSection from "./dashboard/TokenAnalyticsSection";
 import ReceiptWidget from "./dashboard/ReceiptWidget";
-import type { TFunction } from "./dashboard/model";
+import { timeAgo, type TFunction } from "./dashboard/model";
 import { formatProviderFlow } from "./MeetingProviderFlow";
 
 const SkillCatalogView = lazy(() => import("./SkillCatalogView"));
 const MeetingMinutesView = lazy(() => import("./MeetingMinutesView"));
 
 type PulseKanbanSignal = "review" | "blocked" | "requested" | "stalled";
+type HomeWidgetId =
+  | "metric_agents"
+  | "metric_dispatch"
+  | "metric_review"
+  | "metric_followups"
+  | "office"
+  | "signals"
+  | "roster"
+  | "activity";
+type HomeSignalTone = "info" | "warn" | "danger" | "success";
+
+interface HomeSignalRow {
+  id: string;
+  label: string;
+  value: number;
+  description: string;
+  accent: string;
+  tone: HomeSignalTone;
+  onAction?: () => void;
+}
+
+interface HomeActivityItem {
+  id: string;
+  title: string;
+  detail: string;
+  timestamp: number;
+  tone: "success" | "warn";
+}
+
+interface HomeAgentRow {
+  agent: Agent;
+  displayName: string;
+  workSummary: string | null;
+  elapsedLabel: string | null;
+  linkedSessions: DispatchedSession[];
+}
 
 interface DashboardTabDefinition {
   id: DashboardTab;
@@ -97,6 +138,88 @@ interface DashboardPageViewProps {
   onOpenSettings?: () => void;
   onRefreshMeetings?: () => void;
   onRequestedTabHandled?: () => void;
+}
+
+const HOME_WIDGET_STORAGE_KEY = "agentdesk.dashboard.home.widgets.v1";
+const DEFAULT_HOME_WIDGET_ORDER: HomeWidgetId[] = [
+  "metric_agents",
+  "metric_dispatch",
+  "metric_review",
+  "metric_followups",
+  "office",
+  "signals",
+  "roster",
+  "activity",
+];
+
+const EMPTY_DASHBOARD_STATS: DashboardStats = {
+  agents: {
+    total: 0,
+    working: 0,
+    idle: 0,
+    break: 0,
+    offline: 0,
+  },
+  top_agents: [],
+  departments: [],
+  dispatched_count: 0,
+  github_closed_today: 0,
+  kanban: {
+    open_total: 0,
+    review_queue: 0,
+    blocked: 0,
+    failed: 0,
+    waiting_acceptance: 0,
+    stale_in_progress: 0,
+    by_status: {} as DashboardStats["kanban"]["by_status"],
+    top_repos: [],
+  },
+};
+
+function normalizeHomeWidgetOrder(value: unknown): HomeWidgetId[] {
+  if (!Array.isArray(value)) return DEFAULT_HOME_WIDGET_ORDER;
+  const valid = new Set<HomeWidgetId>(DEFAULT_HOME_WIDGET_ORDER);
+  const next: HomeWidgetId[] = [];
+  for (const item of value) {
+    if (typeof item !== "string" || !valid.has(item as HomeWidgetId) || next.includes(item as HomeWidgetId)) {
+      continue;
+    }
+    next.push(item as HomeWidgetId);
+  }
+  for (const item of DEFAULT_HOME_WIDGET_ORDER) {
+    if (!next.includes(item)) next.push(item);
+  }
+  return next;
+}
+
+function readStoredHomeWidgetOrder(): HomeWidgetId[] {
+  if (typeof window === "undefined") return DEFAULT_HOME_WIDGET_ORDER;
+  try {
+    const raw = window.localStorage.getItem(HOME_WIDGET_STORAGE_KEY);
+    return raw ? normalizeHomeWidgetOrder(JSON.parse(raw)) : DEFAULT_HOME_WIDGET_ORDER;
+  } catch {
+    return DEFAULT_HOME_WIDGET_ORDER;
+  }
+}
+
+function getLocalizedAgentName(
+  agent: Pick<Agent, "alias" | "name" | "name_ko" | "name_ja" | "name_zh">,
+  language: CompanySettings["language"],
+): string {
+  if (agent.alias?.trim()) return agent.alias;
+  if (language === "ja") return agent.name_ja || agent.name_ko || agent.name;
+  if (language === "zh") return agent.name_zh || agent.name_ko || agent.name;
+  if (language === "en") return agent.name;
+  return agent.name_ko || agent.name;
+}
+
+function moveHomeWidget(items: HomeWidgetId[], fromIndex: number, toIndex: number): HomeWidgetId[] {
+  if (fromIndex === toIndex) return items;
+  const next = [...items];
+  const [moved] = next.splice(fromIndex, 1);
+  const targetIndex = fromIndex < toIndex ? toIndex - 1 : toIndex;
+  next.splice(targetIndex, 0, moved);
+  return next;
 }
 
 export default function DashboardPageView({
@@ -253,55 +376,11 @@ export default function DashboardPageView({
     };
   }, [activeTab, skillWindow]);
 
-  if (!stats) {
-    return (
-      <div className="flex h-full items-center justify-center" style={{ color: "var(--th-text-muted)" }}>
-        <div className="text-center">
-          <div className="mb-4 text-4xl opacity-30">📊</div>
-          <div>{t({ ko: "대시보드를 불러오는 중입니다", en: "Loading dashboard", ja: "ダッシュボードを読み込み中", zh: "正在加载仪表盘" })}</div>
-        </div>
-      </div>
-    );
-  }
+  const dashboardStats = stats ?? EMPTY_DASHBOARD_STATS;
 
-  const hudStats: HudStat[] = [
-    {
-      id: "total",
-      label: t({ ko: "전체 에이전트", en: "Total Agents", ja: "全エージェント", zh: "全部代理" }),
-      value: stats.agents.total,
-      sub: t({ ko: "등록 인원", en: "Registered", ja: "登録数", zh: "已注册" }),
-      color: "#60a5fa",
-      icon: "👥",
-    },
-    {
-      id: "working",
-      label: t({ ko: "작업 중", en: "Working", ja: "作業中", zh: "工作中" }),
-      value: stats.agents.working,
-      sub: t({ ko: "현재 가동", en: "Live now", ja: "稼働中", zh: "当前活跃" }),
-      color: "#34d399",
-      icon: "💼",
-    },
-    {
-      id: "idle",
-      label: t({ ko: "대기", en: "Idle", ja: "待機", zh: "空闲" }),
-      value: stats.agents.idle,
-      sub: t({ ko: "배정 가능", en: "Available", ja: "配置可能", zh: "可分配" }),
-      color: "#94a3b8",
-      icon: "⏸️",
-    },
-    {
-      id: "dispatched",
-      label: t({ ko: "파견 세션", en: "Dispatched", ja: "派遣セッション", zh: "派遣会话" }),
-      value: stats.dispatched_count,
-      sub: t({ ko: "외부 연결", en: "External sessions", ja: "外部接続", zh: "外部连接" }),
-      color: "#f59e0b",
-      icon: "🛰️",
-    },
-  ];
-
-  const topAgents: RankedAgent[] = stats.top_agents.map((agent) => ({
+  const topAgents: RankedAgent[] = dashboardStats.top_agents.map((agent) => ({
     id: agent.id,
-    name: agent.alias || agent.name_ko || agent.name,
+    name: getLocalizedAgentName(agent, language),
     department: "",
     tasksDone: agent.stats_tasks_done,
     xp: agent.stats_xp,
@@ -331,49 +410,520 @@ export default function DashboardPageView({
         .slice(0, 4),
     [meetings],
   );
+  const [editingWidgets, setEditingWidgets] = useState(false);
+  const [widgetOrder, setWidgetOrder] = useState<HomeWidgetId[]>(() => readStoredHomeWidgetOrder());
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [overIndex, setOverIndex] = useState<number | null>(null);
+  const activeSessions = useMemo(
+    () => sessions.filter((session) => session.status !== "disconnected"),
+    [sessions],
+  );
+  const linkedSessionsByAgent = useMemo(() => {
+    const map = new Map<string, DispatchedSession[]>();
+    for (const session of sessions) {
+      if (!session.linked_agent_id) continue;
+      const rows = map.get(session.linked_agent_id) ?? [];
+      rows.push(session);
+      map.set(session.linked_agent_id, rows);
+    }
+    return map;
+  }, [sessions]);
+  const homeAgents = useMemo<HomeAgentRow[]>(
+    () =>
+      [...agents]
+        .map((agent) => {
+          const linkedSessions = linkedSessionsByAgent.get(agent.id) ?? [];
+          const workSummary = getAgentWorkSummary(agent, { linkedSessions });
+          const elapsedMs = getAgentWorkElapsedMs(agent, linkedSessions);
+          return {
+            agent,
+            displayName: getLocalizedAgentName(agent, language),
+            workSummary,
+            elapsedLabel: elapsedMs ? formatElapsedCompact(elapsedMs, language === "ko") : null,
+            linkedSessions,
+          };
+        })
+        .sort((left, right) => {
+          if (left.agent.status === right.agent.status) {
+            return right.agent.stats_xp - left.agent.stats_xp;
+          }
+          if (left.agent.status === "working") return -1;
+          if (right.agent.status === "working") return 1;
+          if (left.agent.status === "idle") return -1;
+          if (right.agent.status === "idle") return 1;
+          return 0;
+        }),
+    [agents, language, linkedSessionsByAgent],
+  );
+  const activeProviderCount = useMemo(() => {
+    const providers = new Set<string>();
+    for (const session of activeSessions) providers.add(session.provider);
+    if (providers.size === 0) {
+      for (const agent of agents) {
+        if (agent.cli_provider) providers.add(agent.cli_provider);
+      }
+    }
+    return providers.size;
+  }, [activeSessions, agents]);
+  const dateLabel = useMemo(() => {
+    const formatted = new Intl.DateTimeFormat(localeTag, {
+      weekday: "long",
+      month: "short",
+      day: "numeric",
+    }).format(new Date());
+    return formatted.replace(", ", " · ");
+  }, [localeTag]);
+  const systemState = useMemo(() => {
+    if (staleLinkedSessions.length > 0 || reconnectingSessions.length > 0 || dashboardStats.kanban.blocked > 0) {
+      return {
+        label: t({
+          ko: "주의 필요",
+          en: "attention needed",
+          ja: "注意が必要",
+          zh: "需要关注",
+        }),
+        color: "var(--th-accent-warn)",
+        pulseColor: "var(--th-accent-warn)",
+      };
+    }
+    if (dashboardStats.kanban.review_queue > 0 || dashboardStats.kanban.waiting_acceptance > 0) {
+      return {
+        label: t({
+          ko: "큐 모니터링 중",
+          en: "watching queues",
+          ja: "キューを監視中",
+          zh: "监控队列中",
+        }),
+        color: "var(--th-accent-info)",
+        pulseColor: "var(--th-accent-info)",
+      };
+    }
+    return {
+      label: t({
+        ko: "all systems normal",
+        en: "all systems normal",
+        ja: "all systems normal",
+        zh: "all systems normal",
+      }),
+      color: "var(--th-accent-success)",
+      pulseColor: "var(--th-accent-success)",
+    };
+  }, [
+    dashboardStats.kanban.blocked,
+    dashboardStats.kanban.review_queue,
+    dashboardStats.kanban.waiting_acceptance,
+    reconnectingSessions.length,
+    staleLinkedSessions.length,
+    t,
+  ]);
+  const focusSignals = useMemo<HomeSignalRow[]>(
+    () => [
+      {
+        id: "review",
+        label: t({ ko: "리뷰 대기", en: "Review Queue", ja: "レビュー待ち", zh: "待审查" }),
+        value: dashboardStats.kanban.review_queue,
+        description: t({
+          ko: "검토/판정이 필요한 카드",
+          en: "Cards waiting for review or decision",
+          ja: "レビューまたは判断待ちカード",
+          zh: "等待审查或决策的卡片",
+        }),
+        accent: "#14b8a6",
+        tone: "success",
+        onAction: onOpenKanbanSignal ? () => onOpenKanbanSignal("review") : undefined,
+      },
+      {
+        id: "blocked",
+        label: t({ ko: "블록됨", en: "Blocked", ja: "ブロック", zh: "阻塞" }),
+        value: dashboardStats.kanban.blocked,
+        description: t({
+          ko: "해소나 수동 개입이 필요한 카드",
+          en: "Cards waiting on unblock or manual action",
+          ja: "解除や手動介入が必要なカード",
+          zh: "等待解除阻塞或人工处理的卡片",
+        }),
+        accent: "#ef4444",
+        tone: "danger",
+        onAction: onOpenKanbanSignal ? () => onOpenKanbanSignal("blocked") : undefined,
+      },
+      {
+        id: "requested",
+        label: t({ ko: "수락 지연", en: "Waiting Acceptance", ja: "受諾遅延", zh: "接收延迟" }),
+        value: dashboardStats.kanban.waiting_acceptance,
+        description: t({
+          ko: "requested 상태에 머무는 카드",
+          en: "Cards stalled in requested",
+          ja: "requested に留まるカード",
+          zh: "停留在 requested 的卡片",
+        }),
+        accent: "#10b981",
+        tone: "info",
+        onAction: onOpenKanbanSignal ? () => onOpenKanbanSignal("requested") : undefined,
+      },
+      {
+        id: "stale",
+        label: t({ ko: "진행 정체", en: "Stale In Progress", ja: "進行停滞", zh: "进行停滞" }),
+        value: dashboardStats.kanban.stale_in_progress,
+        description: t({
+          ko: "오래 머무는 in_progress 카드",
+          en: "Cards stuck in progress",
+          ja: "進行が長引く in_progress カード",
+          zh: "长时间停留在 in_progress 的卡片",
+        }),
+        accent: "#f59e0b",
+        tone: "warn",
+        onAction: onOpenKanbanSignal ? () => onOpenKanbanSignal("stalled") : undefined,
+      },
+      {
+        id: "followup",
+        label: t({ ko: "회의 후속", en: "Meeting Follow-up", ja: "会議フォローアップ", zh: "会议后续" }),
+        value: meetingSummary.unresolvedCount,
+        description: t({
+          ko: `${meetingSummary.activeCount}개 진행 중 회의에서 남은 후속 이슈`,
+          en: `Open follow-ups from ${meetingSummary.activeCount} active meetings`,
+          ja: `${meetingSummary.activeCount}件の進行中会議に残る後続イシュー`,
+          zh: `${meetingSummary.activeCount} 个进行中会议留下的后续 issue`,
+        }),
+        accent: "#22c55e",
+        tone: "success",
+        onAction: () => setActiveTab("meetings"),
+      },
+    ],
+    [
+      dashboardStats.kanban.blocked,
+      dashboardStats.kanban.review_queue,
+      dashboardStats.kanban.stale_in_progress,
+      dashboardStats.kanban.waiting_acceptance,
+      meetingSummary.activeCount,
+      meetingSummary.unresolvedCount,
+      onOpenKanbanSignal,
+      t,
+    ],
+  );
+  const homeActivityItems = useMemo<HomeActivityItem[]>(() => {
+    const meetingItems = recentMeetings.map((meeting) => ({
+      id: `meeting-${meeting.id}`,
+      title: meeting.agenda,
+      detail:
+        meeting.primary_provider || meeting.reviewer_provider
+          ? formatProviderFlow(meeting.primary_provider, meeting.reviewer_provider)
+          : t({ ko: "라운드테이블", en: "Round Table", ja: "ラウンドテーブル", zh: "圆桌" }),
+      timestamp: meeting.started_at || meeting.created_at,
+      tone: meeting.status === "completed" ? ("success" as const) : ("warn" as const),
+    }));
+    const sessionItems = [...staleLinkedSessions, ...reconnectingSessions].slice(0, 2).map((session) => ({
+      id: `session-${session.id}`,
+      title: session.name || session.session_key,
+      detail:
+        session.status === "disconnected"
+          ? t({ ko: "재연결 필요", en: "Needs reconnect", ja: "再接続が必要", zh: "需要重连" })
+          : t({ ko: "working 세션 stale", en: "Working session stale", ja: "working セッション stale", zh: "working 会话 stale" }),
+      timestamp: session.last_seen_at || session.connected_at,
+      tone: "warn" as const,
+    }));
+
+    return [...meetingItems, ...sessionItems]
+      .sort((left, right) => right.timestamp - left.timestamp)
+      .slice(0, 5);
+  }, [recentMeetings, reconnectingSessions, staleLinkedSessions, t]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(HOME_WIDGET_STORAGE_KEY, JSON.stringify(widgetOrder));
+  }, [widgetOrder]);
+
+  const handleWidgetDragStart = useCallback(
+    (index: number) => (event: ReactDragEvent<HTMLDivElement>) => {
+      if (!editingWidgets) return;
+      setDragIndex(index);
+      event.dataTransfer.effectAllowed = "move";
+      try {
+        event.dataTransfer.setData("text/plain", String(index));
+      } catch {
+        // ignore browser-specific dnd errors
+      }
+    },
+    [editingWidgets],
+  );
+
+  const handleWidgetDragOver = useCallback(
+    (index: number) => (event: ReactDragEvent<HTMLDivElement>) => {
+      if (!editingWidgets) return;
+      event.preventDefault();
+      if (overIndex !== index) setOverIndex(index);
+    },
+    [editingWidgets, overIndex],
+  );
+
+  const handleWidgetDrop = useCallback(
+    (index: number) => (event: ReactDragEvent<HTMLDivElement>) => {
+      if (!editingWidgets) return;
+      event.preventDefault();
+      if (dragIndex == null) return;
+      setWidgetOrder((current) => moveHomeWidget(current, dragIndex, index));
+      setDragIndex(null);
+      setOverIndex(null);
+    },
+    [dragIndex, editingWidgets],
+  );
+
+  const handleWidgetDragEnd = useCallback(() => {
+    setDragIndex(null);
+    setOverIndex(null);
+  }, []);
+
+  const homeWidgetSpecs: Record<HomeWidgetId, { className: string; render: () => ReactNode }> = {
+    metric_agents: {
+      className: "col-span-12 sm:col-span-6 xl:col-span-3",
+      render: () => (
+        <DashboardHomeMetricTile
+          title={t({ ko: "작업 중", en: "Working", ja: "作業中", zh: "工作中" })}
+          value={numberFormatter.format(dashboardStats.agents.working)}
+          badge={t({ ko: `${numberFormatter.format(dashboardStats.agents.idle)} 대기`, en: `${numberFormatter.format(dashboardStats.agents.idle)} idle`, ja: `${numberFormatter.format(dashboardStats.agents.idle)} 待機`, zh: `${numberFormatter.format(dashboardStats.agents.idle)} 空闲` })}
+          sub={t({ ko: `${numberFormatter.format(dashboardStats.agents.total)}명 등록`, en: `${numberFormatter.format(dashboardStats.agents.total)} registered`, ja: `${numberFormatter.format(dashboardStats.agents.total)}人登録`, zh: `已注册 ${numberFormatter.format(dashboardStats.agents.total)} 名` })}
+          accent="#60a5fa"
+          spark={[dashboardStats.agents.working, dashboardStats.agents.idle, dashboardStats.agents.break, dashboardStats.agents.offline]}
+        />
+      ),
+    },
+    metric_dispatch: {
+      className: "col-span-12 sm:col-span-6 xl:col-span-3",
+      render: () => (
+        <DashboardHomeMetricTile
+          title={t({ ko: "파견 세션", en: "Dispatched", ja: "派遣セッション", zh: "派遣会话" })}
+          value={numberFormatter.format(dashboardStats.dispatched_count)}
+          badge={t({ ko: `${reconnectingSessions.length} reconnect`, en: `${reconnectingSessions.length} reconnect`, ja: `${reconnectingSessions.length} reconnect`, zh: `${reconnectingSessions.length} reconnect` })}
+          sub={t({ ko: `${numberFormatter.format(activeSessions.length)}개 활성 연결`, en: `${numberFormatter.format(activeSessions.length)} live sessions`, ja: `${numberFormatter.format(activeSessions.length)}件 アクティブ`, zh: `${numberFormatter.format(activeSessions.length)} 个活跃连接` })}
+          accent="#34d399"
+          spark={[
+            activeSessions.filter((session) => session.status === "working").length,
+            activeSessions.filter((session) => session.status === "idle").length,
+            reconnectingSessions.length,
+          ]}
+        />
+      ),
+    },
+    metric_review: {
+      className: "col-span-12 sm:col-span-6 xl:col-span-3",
+      render: () => (
+        <DashboardHomeMetricTile
+          title={t({ ko: "리뷰 큐", en: "Review Queue", ja: "レビューキュー", zh: "审查队列" })}
+          value={numberFormatter.format(dashboardStats.kanban.review_queue)}
+          badge={t({ ko: `${dashboardStats.kanban.blocked} blocked`, en: `${dashboardStats.kanban.blocked} blocked`, ja: `${dashboardStats.kanban.blocked} blocked`, zh: `${dashboardStats.kanban.blocked} blocked` })}
+          sub={t({ ko: `requested ${dashboardStats.kanban.waiting_acceptance} · stale ${dashboardStats.kanban.stale_in_progress}`, en: `requested ${dashboardStats.kanban.waiting_acceptance} · stale ${dashboardStats.kanban.stale_in_progress}`, ja: `requested ${dashboardStats.kanban.waiting_acceptance} · stale ${dashboardStats.kanban.stale_in_progress}`, zh: `requested ${dashboardStats.kanban.waiting_acceptance} · stale ${dashboardStats.kanban.stale_in_progress}` })}
+          accent="#f59e0b"
+          spark={[
+            dashboardStats.kanban.review_queue,
+            dashboardStats.kanban.blocked,
+            dashboardStats.kanban.waiting_acceptance,
+            dashboardStats.kanban.stale_in_progress,
+          ]}
+        />
+      ),
+    },
+    metric_followups: {
+      className: "col-span-12 sm:col-span-6 xl:col-span-3",
+      render: () => (
+        <DashboardHomeMetricTile
+          title={t({ ko: "회의 후속", en: "Follow-ups", ja: "会議フォローアップ", zh: "会议后续" })}
+          value={numberFormatter.format(meetingSummary.unresolvedCount)}
+          badge={t({ ko: `${meetingSummary.activeCount} active`, en: `${meetingSummary.activeCount} active`, ja: `${meetingSummary.activeCount} active`, zh: `${meetingSummary.activeCount} active` })}
+          sub={t({ ko: `회의 ${meetings.length}건 · GitHub 종료 ${numberFormatter.format(dashboardStats.github_closed_today ?? 0)}`, en: `${meetings.length} meetings · ${numberFormatter.format(dashboardStats.github_closed_today ?? 0)} GitHub closed`, ja: `会議 ${meetings.length}件 · GitHub 完了 ${numberFormatter.format(dashboardStats.github_closed_today ?? 0)}`, zh: `会议 ${meetings.length} 个 · GitHub 已关闭 ${numberFormatter.format(dashboardStats.github_closed_today ?? 0)}` })}
+          accent="#a855f7"
+          spark={[meetingSummary.activeCount, meetingSummary.unresolvedCount, dashboardStats.github_closed_today ?? 0, meetings.length]}
+        />
+      ),
+    },
+    office: {
+      className: "col-span-12 xl:col-span-8",
+      render: () => (
+        <DashboardHomeOfficeWidget
+          rows={homeAgents.slice(0, 8)}
+          stats={dashboardStats}
+          language={language}
+          t={t}
+          onSelectAgent={onSelectAgent}
+        />
+      ),
+    },
+    signals: {
+      className: "col-span-12 xl:col-span-4",
+      render: () => (
+        <DashboardHomeSignalsWidget
+          rows={focusSignals}
+          maxValue={Math.max(1, ...focusSignals.map((item) => item.value))}
+          t={t}
+        />
+      ),
+    },
+    roster: {
+      className: "col-span-12 xl:col-span-7",
+      render: () => (
+        <DashboardHomeRosterWidget
+          rows={homeAgents.slice(0, 5)}
+          t={t}
+          numberFormatter={numberFormatter}
+          onSelectAgent={onSelectAgent}
+          onOpenAchievements={() => setActiveTab("achievements")}
+        />
+      ),
+    },
+    activity: {
+      className: "col-span-12 xl:col-span-5",
+      render: () => (
+        <DashboardHomeActivityWidget
+          items={homeActivityItems}
+          localeTag={localeTag}
+          t={t}
+          onOpenMeetings={() => setActiveTab("meetings")}
+        />
+      ),
+    },
+  };
+
+  if (!stats) {
+    return (
+      <div className="flex h-full items-center justify-center" style={{ color: "var(--th-text-muted)" }}>
+        <div className="text-center">
+          <div className="mb-4 text-4xl opacity-30">📊</div>
+          <div>{t({ ko: "대시보드를 불러오는 중입니다", en: "Loading dashboard", ja: "ダッシュボードを読み込み中", zh: "正在加载仪表盘" })}</div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div
-      className="mx-auto h-full w-full max-w-6xl min-w-0 space-y-5 overflow-x-hidden overflow-y-auto p-4 pb-40 sm:p-6"
+      className="page fade-in mx-auto h-full w-full max-w-7xl min-w-0 space-y-4 overflow-x-hidden overflow-y-auto p-4 pb-40 sm:space-y-5 sm:p-6"
       style={{ paddingBottom: "max(10rem, calc(10rem + env(safe-area-inset-bottom)))" }}
     >
-      <DashboardHeroHeader companyName={settings.companyName} t={t} />
-
-      <SurfaceSection
-        title={t({ ko: "대시보드", en: "Dashboard", ja: "ダッシュボード", zh: "仪表盘" })}
-        className="overflow-hidden rounded-[28px] p-4 sm:p-5"
-        style={{
-          borderColor: "color-mix(in srgb, var(--th-accent-info) 18%, var(--th-border) 82%)",
-          background:
-            "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, var(--th-accent-info) 4%) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
-        }}
-      >
-        <div
-          role="tablist"
-          aria-label={t({ ko: "대시보드 섹션", en: "Dashboard sections", ja: "ダッシュボードセクション", zh: "仪表盘分区" })}
-          className="mt-4 -mx-1 overflow-x-auto px-1 pb-1 sm:mx-0 sm:px-0 sm:pb-0"
-        >
-          <div className="flex min-w-max gap-2 sm:min-w-0 sm:flex-wrap">
-            {tabDefinitions.map((tab) => (
-              <DashboardTabButton
-                key={tab.id}
-                tab={tab.id}
-                active={activeTab === tab.id}
-                label={tab.label}
-                detail={tab.detail}
-                onClick={() => setActiveTab(tab.id)}
-                onKeyDown={handleTabKeyDown}
-                buttonRef={(node) => {
-                  tabButtonRefs.current[tab.id] = node;
-                }}
-              />
-            ))}
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0">
+            <div
+              className="mb-2 flex flex-wrap items-center gap-2 text-[11px] uppercase tracking-[0.16em]"
+              style={{ color: "var(--th-text-muted)" }}
+            >
+              <span style={{ fontFamily: "var(--font-mono)" }}>{dateLabel}</span>
+              <span aria-hidden="true" className="inline-flex h-1 w-1 rounded-full" style={{ background: "var(--th-text-muted)" }} />
+              <span className="inline-flex items-center gap-2" style={{ color: systemState.color }}>
+                <span
+                  className="inline-flex h-2 w-2 rounded-full"
+                  style={{
+                    background: systemState.pulseColor,
+                    boxShadow: `0 0 0 4px color-mix(in srgb, ${systemState.pulseColor} 16%, transparent)`,
+                  }}
+                />
+                <span style={{ fontFamily: "var(--font-mono)" }}>{systemState.label}</span>
+              </span>
+            </div>
+            <h1 className="text-[1.9rem] font-black tracking-tight sm:text-[2rem]" style={{ color: "var(--th-text-heading)" }}>
+              {t({
+                ko: "오늘의 AgentDesk",
+                en: "AgentDesk Today",
+                ja: "今日の AgentDesk",
+                zh: "今日 AgentDesk",
+              })}
+            </h1>
+            <p className="mt-2 text-sm leading-6" style={{ color: "var(--th-text-muted)" }}>
+              {t({
+                ko: `에이전트 ${numberFormatter.format(dashboardStats.agents.total)}명 · 세션 ${numberFormatter.format(activeSessions.length)} 활성 · 프로바이더 ${numberFormatter.format(activeProviderCount)} 연결`,
+                en: `${numberFormatter.format(dashboardStats.agents.total)} agents · ${numberFormatter.format(activeSessions.length)} live sessions · ${numberFormatter.format(activeProviderCount)} providers connected`,
+                ja: `エージェント ${numberFormatter.format(dashboardStats.agents.total)}名 · セッション ${numberFormatter.format(activeSessions.length)}件 稼働 · プロバイダー ${numberFormatter.format(activeProviderCount)} 接続`,
+                zh: `代理 ${numberFormatter.format(dashboardStats.agents.total)} 名 · 会话 ${numberFormatter.format(activeSessions.length)} 个活跃 · ${numberFormatter.format(activeProviderCount)} 个提供商已连接`,
+              })}
+            </p>
+          </div>
+          <div className="flex items-center gap-2 self-start">
+            {editingWidgets ? (
+              <SurfaceActionButton
+                tone="neutral"
+                onClick={() => setWidgetOrder(DEFAULT_HOME_WIDGET_ORDER)}
+              >
+                {t({ ko: "기본값", en: "Reset", ja: "初期化", zh: "重置" })}
+              </SurfaceActionButton>
+            ) : null}
+            <SurfaceActionButton
+              tone={editingWidgets ? "accent" : "neutral"}
+              onClick={() => setEditingWidgets((value) => !value)}
+            >
+              {editingWidgets
+                ? t({ ko: "완료", en: "Done", ja: "完了", zh: "完成" })
+                : t({ ko: "편집", en: "Edit", ja: "編集", zh: "编辑" })}
+            </SurfaceActionButton>
           </div>
         </div>
-      </SurfaceSection>
+
+        {editingWidgets ? (
+          <div
+            className="rounded-[18px] border px-4 py-3 text-sm"
+            style={{
+              borderColor: "color-mix(in srgb, var(--th-accent-primary) 22%, var(--th-border) 78%)",
+              background: "color-mix(in srgb, var(--th-accent-primary-soft) 78%, var(--th-card-bg) 22%)",
+              color: "var(--th-text-muted)",
+            }}
+          >
+            {t({
+              ko: "위젯을 드래그해서 순서를 바꿀 수 있습니다. 완료를 누르면 로컬에 저장됩니다.",
+              en: "Drag widgets to reorder them. The layout is saved locally when you finish.",
+              ja: "ウィジェットをドラッグして順序を変更できます。完了するとローカルに保存されます。",
+              zh: "可拖拽调整组件顺序，完成后会保存到本地。",
+            })}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="grid grid-cols-12 gap-4">
+        {widgetOrder.map((widgetId, index) => {
+          const spec = homeWidgetSpecs[widgetId];
+          return (
+            <div
+              key={widgetId}
+              draggable={editingWidgets}
+              onDragStart={editingWidgets ? handleWidgetDragStart(index) : undefined}
+              onDragOver={editingWidgets ? handleWidgetDragOver(index) : undefined}
+              onDrop={editingWidgets ? handleWidgetDrop(index) : undefined}
+              onDragEnd={handleWidgetDragEnd}
+              className={spec.className}
+              style={{
+                opacity: dragIndex === index ? 0.55 : 1,
+                transform: overIndex === index && dragIndex !== index ? "translateY(-2px)" : undefined,
+                transition: "opacity 160ms ease, transform 160ms ease",
+              }}
+            >
+              <div className="relative h-full">
+                {editingWidgets ? (
+                  <div
+                    className="pointer-events-none absolute right-3 top-3 z-10 inline-flex items-center gap-1.5 rounded-lg border px-2 py-1 text-[11px]"
+                    style={{
+                      borderColor: "rgba(148,163,184,0.18)",
+                      background: "color-mix(in srgb, var(--th-bg-surface) 90%, transparent)",
+                      color: "var(--th-text-muted)",
+                    }}
+                  >
+                    <GripVertical size={12} />
+                    drag
+                  </div>
+                ) : null}
+                {spec.render()}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <DashboardHomeSectionNavigatorWidget
+        tabDefinitions={tabDefinitions}
+        activeTab={activeTab}
+        t={t}
+        topRepos={dashboardStats.kanban.top_repos}
+        openTotal={dashboardStats.kanban.open_total}
+        onClickTab={setActiveTab}
+        onKeyDown={handleTabKeyDown}
+        buttonRefs={tabButtonRefs}
+      />
 
       <DashboardTabPanel tab="operations" activeTab={activeTab} t={t}>
-          <DashboardHudStats hudStats={hudStats} numberFormatter={numberFormatter} />
           <div className="grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
             <SurfaceSubsection
               title={t({ ko: "운영 시그널", en: "Ops Signals", ja: "運用シグナル", zh: "运营信号" })}
@@ -405,7 +955,7 @@ export default function DashboardPageView({
                 />
                 <PulseSignalCard
                   label={t({ ko: "리뷰 대기", en: "Review Queue", ja: "レビュー待ち", zh: "待审查" })}
-                  value={stats.kanban.review_queue}
+                  value={dashboardStats.kanban.review_queue}
                   accent="#14b8a6"
                   sublabel={t({
                     ko: "검토/판정이 필요한 카드",
@@ -418,7 +968,7 @@ export default function DashboardPageView({
                 />
                 <PulseSignalCard
                   label={t({ ko: "블록됨", en: "Blocked", ja: "ブロック", zh: "阻塞" })}
-                  value={stats.kanban.blocked}
+                  value={dashboardStats.kanban.blocked}
                   accent="#ef4444"
                   sublabel={t({
                     ko: "수동 판단이나 해소를 기다리는 카드",
@@ -431,7 +981,7 @@ export default function DashboardPageView({
                 />
                 <PulseSignalCard
                   label={t({ ko: "수락 지연", en: "Waiting Acceptance", ja: "受諾遅延", zh: "接收延迟" })}
-                  value={stats.kanban.waiting_acceptance}
+                  value={dashboardStats.kanban.waiting_acceptance}
                   accent="#10b981"
                   sublabel={t({
                     ko: "requested 상태에 머문 카드",
@@ -444,7 +994,7 @@ export default function DashboardPageView({
                 />
                 <PulseSignalCard
                   label={t({ ko: "진행 정체", en: "Stale In Progress", ja: "進行停滞", zh: "进行停滞" })}
-                  value={stats.kanban.stale_in_progress}
+                  value={dashboardStats.kanban.stale_in_progress}
                   accent="#f59e0b"
                   sublabel={t({
                     ko: "오래 머무는 in_progress 카드",
@@ -1120,7 +1670,7 @@ function DashboardTabButton({
       tabIndex={active ? 0 : -1}
       onClick={onClick}
       onKeyDown={(event) => onKeyDown(event, tab)}
-      className="min-h-12 w-[11rem] shrink-0 snap-start rounded-2xl border px-4 py-3 text-left transition-colors sm:min-w-[10rem] sm:flex-1 sm:w-auto"
+      className="min-h-[5.25rem] w-full rounded-[22px] border px-4 py-3.5 text-left transition-all"
       style={{
         borderColor: active
           ? "color-mix(in srgb, var(--th-accent-primary) 32%, var(--th-border) 68%)"
@@ -1128,6 +1678,7 @@ function DashboardTabButton({
         background: active
           ? "color-mix(in srgb, var(--th-accent-primary-soft) 74%, transparent)"
           : "color-mix(in srgb, var(--th-card-bg) 94%, transparent)",
+        boxShadow: active ? "0 14px 32px rgba(15, 23, 42, 0.12)" : "none",
       }}
     >
       <div className="text-sm font-semibold" style={{ color: active ? "var(--th-text-heading)" : "var(--th-text)" }}>
@@ -1138,4 +1689,663 @@ function DashboardTabButton({
       </div>
     </button>
   );
+}
+
+function DashboardHomeMetricTile({
+  title,
+  value,
+  badge,
+  sub,
+  accent,
+  spark,
+}: {
+  title: string;
+  value: string;
+  badge: string;
+  sub: string;
+  accent: string;
+  spark: number[];
+}) {
+  const maxValue = Math.max(1, ...spark);
+
+  return (
+    <SurfaceCard
+      className="h-full rounded-[28px] p-4 sm:p-5"
+      style={{
+        borderColor: `color-mix(in srgb, ${accent} 22%, var(--th-border) 78%)`,
+        background: `linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 95%, ${accent} 5%) 0%, color-mix(in srgb, var(--th-bg-surface) 97%, transparent) 100%)`,
+      }}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div
+            className="text-[11px] font-semibold uppercase tracking-[0.16em]"
+            style={{ color: "var(--th-text-muted)" }}
+          >
+            {title}
+          </div>
+          <div className="mt-3 text-[2rem] font-black leading-none tracking-tight" style={{ color: "var(--th-text-heading)" }}>
+            {value}
+          </div>
+          <p className="mt-2 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+            {sub}
+          </p>
+        </div>
+        <SurfaceMetaBadge
+          tone="neutral"
+          style={{
+            borderColor: `color-mix(in srgb, ${accent} 22%, var(--th-border) 78%)`,
+            background: `color-mix(in srgb, ${accent} 14%, var(--th-card-bg) 86%)`,
+            color: accent,
+          }}
+        >
+          {badge}
+        </SurfaceMetaBadge>
+      </div>
+
+      <div className="mt-4 flex h-10 items-end gap-1">
+        {spark.map((point, index) => (
+          <div
+            key={`${title}-${index}`}
+            className="min-w-0 flex-1 rounded-full"
+            style={{
+              height: `${Math.max(18, (point / maxValue) * 100)}%`,
+              background: `linear-gradient(180deg, color-mix(in srgb, ${accent} 78%, white 22%) 0%, ${accent} 100%)`,
+              opacity: index === spark.length - 1 ? 1 : 0.72,
+            }}
+          />
+        ))}
+      </div>
+    </SurfaceCard>
+  );
+}
+
+function DashboardHomeOfficeWidget({
+  rows,
+  stats,
+  language,
+  t,
+  onSelectAgent,
+}: {
+  rows: HomeAgentRow[];
+  stats: DashboardStats;
+  language: CompanySettings["language"];
+  t: TFunction;
+  onSelectAgent?: (agent: Agent) => void;
+}) {
+  void language;
+  const visibleRows = rows.slice(0, 8);
+
+  return (
+    <SurfaceSubsection
+      title={t({ ko: "오피스 뷰", en: "Office View", ja: "オフィスビュー", zh: "办公室视图" })}
+      description={t({
+        ko: "지금 일하는 에이전트와 세션 상태를 한 화면에 압축해 보여줍니다.",
+        en: "A compressed office snapshot of active agents and live sessions.",
+        ja: "作業中エージェントとセッション状態を圧縮して見せます。",
+        zh: "压缩展示当前工作中的代理与会话状态。",
+      })}
+      style={{
+        minHeight: 320,
+        borderColor: "color-mix(in srgb, var(--th-accent-info) 22%, var(--th-border) 78%)",
+        background:
+          "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 94%, var(--th-accent-info) 6%) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
+      }}
+      actions={(
+        <div className="flex flex-wrap gap-2">
+          <SurfaceMetaBadge tone="success">
+            {t({ ko: `${stats.agents.working} working`, en: `${stats.agents.working} working`, ja: `${stats.agents.working} working`, zh: `${stats.agents.working} working` })}
+          </SurfaceMetaBadge>
+          <SurfaceMetaBadge tone="neutral">
+            {t({ ko: `${stats.agents.idle} idle`, en: `${stats.agents.idle} idle`, ja: `${stats.agents.idle} idle`, zh: `${stats.agents.idle} idle` })}
+          </SurfaceMetaBadge>
+        </div>
+      )}
+    >
+      {visibleRows.length === 0 ? (
+        <SurfaceEmptyState className="px-4 py-6 text-center text-sm">
+          {t({ ko: "표시할 에이전트가 없습니다.", en: "No agents available.", ja: "表示するエージェントがいません。", zh: "没有可显示的代理。" })}
+        </SurfaceEmptyState>
+      ) : (
+        <>
+          <div
+            className="rounded-[24px] border p-4"
+            style={{
+              borderColor: "rgba(148,163,184,0.16)",
+              background:
+                "radial-gradient(circle at top, color-mix(in srgb, var(--th-accent-info) 12%, transparent), transparent 52%), linear-gradient(180deg, color-mix(in srgb, var(--th-bg-surface) 94%, transparent), color-mix(in srgb, var(--th-card-bg) 90%, transparent))",
+            }}
+          >
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              {visibleRows.map((row) => {
+                const statusTone = getAgentStatusTone(row.agent.status);
+                const accent =
+                  statusTone === "success"
+                    ? "var(--th-accent-success)"
+                    : statusTone === "warn"
+                      ? "var(--th-accent-warn)"
+                      : statusTone === "danger"
+                        ? "var(--th-accent-danger)"
+                        : "var(--th-text-muted)";
+                return (
+                  <button
+                    key={row.agent.id}
+                    type="button"
+                    onClick={onSelectAgent ? () => onSelectAgent(row.agent) : undefined}
+                    className="rounded-2xl border p-3 text-left transition-transform hover:-translate-y-0.5"
+                    style={{
+                      borderColor: `color-mix(in srgb, ${accent} 22%, var(--th-border) 78%)`,
+                      background: "color-mix(in srgb, var(--th-card-bg) 88%, transparent)",
+                    }}
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="relative">
+                        <AgentAvatar agent={row.agent} size={44} />
+                        <span
+                          className="absolute -right-0.5 -top-0.5 inline-flex h-3 w-3 rounded-full border-2"
+                          style={{
+                            borderColor: "var(--th-card-bg)",
+                            background: accent,
+                            boxShadow: `0 0 0 3px color-mix(in srgb, ${accent} 16%, transparent)`,
+                          }}
+                        />
+                      </div>
+                      <SurfaceMetaBadge tone={statusTone}>
+                        {getAgentStatusLabel(row.agent.status, t)}
+                      </SurfaceMetaBadge>
+                    </div>
+                    <div className="mt-3 truncate text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                      {row.displayName}
+                    </div>
+                    <div className="mt-1 min-h-[2.5rem] text-[11px] leading-5" style={{ color: "var(--th-text-muted)" }}>
+                      {row.workSummary ?? t({ ko: "대기 중", en: "Idle", ja: "待機中", zh: "待机中" })}
+                    </div>
+                    <div className="mt-2 flex items-center justify-between text-[10px]" style={{ color: "var(--th-text-muted)" }}>
+                      <span style={{ fontFamily: "var(--font-mono)" }}>
+                        {row.elapsedLabel ?? "--"}
+                      </span>
+                      <span style={{ fontFamily: "var(--font-mono)" }}>
+                        {row.linkedSessions.length} session
+                      </span>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2">
+            <SurfaceMetaBadge tone="success">
+              {t({ ko: `${stats.agents.working} working`, en: `${stats.agents.working} working`, ja: `${stats.agents.working} working`, zh: `${stats.agents.working} working` })}
+            </SurfaceMetaBadge>
+            <SurfaceMetaBadge tone="neutral">
+              {t({ ko: `${stats.agents.idle} idle`, en: `${stats.agents.idle} idle`, ja: `${stats.agents.idle} idle`, zh: `${stats.agents.idle} idle` })}
+            </SurfaceMetaBadge>
+            <SurfaceMetaBadge tone="warn">
+              {t({ ko: `${stats.dispatched_count} dispatched`, en: `${stats.dispatched_count} dispatched`, ja: `${stats.dispatched_count} dispatched`, zh: `${stats.dispatched_count} dispatched` })}
+            </SurfaceMetaBadge>
+          </div>
+        </>
+      )}
+    </SurfaceSubsection>
+  );
+}
+
+function DashboardHomeSignalsWidget({
+  rows,
+  maxValue,
+  t,
+}: {
+  rows: HomeSignalRow[];
+  maxValue: number;
+  t: TFunction;
+}) {
+  return (
+    <SurfaceSubsection
+      title={t({ ko: "운영 미션", en: "Ops Missions", ja: "運用ミッション", zh: "运营任务" })}
+      description={t({
+        ko: "지금 바로 처리할 운영 압력을 우선순위 카드로 정리했습니다.",
+        en: "Priority cards for the operational pressure points that need action now.",
+        ja: "今すぐ処理すべき運用圧力を優先カードで整理しました。",
+        zh: "将需要立即处理的运营压力整理成优先级卡片。",
+      })}
+      style={{
+        borderColor: "color-mix(in srgb, var(--th-accent-primary) 22%, var(--th-border) 78%)",
+        background:
+          "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 94%, var(--th-accent-primary) 6%) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
+      }}
+    >
+      <div className="mb-4 flex items-center justify-between gap-2">
+        <SurfaceMetaBadge tone="neutral">
+          {t({
+            ko: `${rows.length}개 트래킹`,
+            en: `${rows.length} tracked`,
+            ja: `${rows.length}件を追跡中`,
+            zh: `跟踪 ${rows.length} 项`,
+          })}
+        </SurfaceMetaBadge>
+        <span
+          className="text-[11px]"
+          style={{
+            color: "var(--th-text-muted)",
+            fontFamily: "var(--font-mono)",
+          }}
+        >
+          {t({ ko: "priority live", en: "priority live", ja: "priority live", zh: "priority live" })}
+        </span>
+      </div>
+
+      <div className="space-y-2.5">
+        {rows.map((row) => {
+          const accent = getSignalAccent(row.tone);
+          const tone = row.tone === "info" ? "info" : row.tone;
+          const ratio = Math.max(0, Math.min(100, (row.value / maxValue) * 100));
+          const body = (
+            <div
+              className="rounded-[22px] border p-4 text-left transition-transform duration-150"
+              style={{
+                borderColor: `color-mix(in srgb, ${accent} 24%, var(--th-border) 76%)`,
+                background: `linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 93%, ${accent} 7%) 0%, color-mix(in srgb, var(--th-bg-surface) 95%, transparent) 100%)`,
+              }}
+            >
+              <div className="flex items-start gap-3">
+                <div
+                  className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border text-[11px] font-semibold"
+                  style={{
+                    borderColor: `color-mix(in srgb, ${accent} 26%, var(--th-border) 74%)`,
+                    background: `color-mix(in srgb, ${accent} 12%, var(--th-card-bg) 88%)`,
+                    color: accent,
+                  }}
+                >
+                  {row.value > 0 ? "!" : "·"}
+                </div>
+
+                <div className="min-w-0 flex-1">
+                  <div className="text-[10.5px] font-semibold uppercase tracking-[0.16em]" style={{ color: accent }}>
+                    {row.label}
+                  </div>
+                  <div className="mt-2 flex items-end justify-between gap-3">
+                    <div className="text-3xl font-black tracking-tight" style={{ color: "var(--th-text-heading)" }}>
+                      {row.value}
+                    </div>
+                    <SurfaceMetaBadge tone={tone}>{row.description}</SurfaceMetaBadge>
+                  </div>
+                  <div className="mt-3 flex items-center justify-between gap-3 text-[11px]" style={{ color: "var(--th-text-muted)" }}>
+                    <span>
+                      {t({
+                        ko: row.value > 0 ? "지금 확인 필요" : "현재 추가 조치 없음",
+                        en: row.value > 0 ? "Needs attention now" : "No extra action right now",
+                        ja: row.value > 0 ? "今すぐ確認が必要" : "追加アクションなし",
+                        zh: row.value > 0 ? "需要立即确认" : "当前无需额外处理",
+                      })}
+                    </span>
+                    <span style={{ fontFamily: "var(--font-mono)" }}>
+                      {t({ ko: "압력", en: "pressure", ja: "pressure", zh: "pressure" })} {Math.round(ratio)}%
+                    </span>
+                  </div>
+
+                  <div className="mt-3 flex items-center gap-3">
+                    <div className="h-[5px] flex-1 overflow-hidden rounded-full" style={{ background: "color-mix(in srgb, var(--th-bg-surface) 82%, transparent)" }}>
+                      <div
+                        className="h-full rounded-full"
+                        style={{
+                          width: `${Math.max(8, ratio)}%`,
+                          background: `linear-gradient(90deg, color-mix(in srgb, ${accent} 68%, white 32%), ${accent})`,
+                        }}
+                      />
+                    </div>
+                    <span className="text-[11px] font-medium" style={{ color: accent }}>
+                      {row.onAction
+                        ? t({ ko: "열기", en: "Open", ja: "開く", zh: "打开" })
+                        : t({ ko: "모니터링", en: "Monitoring", ja: "監視中", zh: "监控中" })}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+
+          return row.onAction ? (
+            <button
+              key={row.id}
+              type="button"
+              onClick={row.onAction}
+              className="block w-full rounded-2xl text-left transition-transform hover:-translate-y-0.5"
+            >
+              {body}
+            </button>
+          ) : (
+            <div key={row.id}>{body}</div>
+          );
+        })}
+      </div>
+    </SurfaceSubsection>
+  );
+}
+
+function DashboardHomeRosterWidget({
+  rows,
+  t,
+  numberFormatter,
+  onSelectAgent,
+  onOpenAchievements,
+}: {
+  rows: HomeAgentRow[];
+  t: TFunction;
+  numberFormatter: Intl.NumberFormat;
+  onSelectAgent?: (agent: Agent) => void;
+  onOpenAchievements?: () => void;
+}) {
+  return (
+    <SurfaceSubsection
+      title={t({ ko: "에이전트 현황", en: "Agent Roster", ja: "エージェント現況", zh: "代理现况" })}
+      description={t({
+        ko: "활성 우선으로 상위 에이전트 상태를 요약합니다.",
+        en: "A live-first roster summary of the top agents.",
+        ja: "アクティブ優先で上位エージェントの状態を要約します。",
+        zh: "按活跃优先总结头部代理状态。",
+      })}
+      actions={onOpenAchievements ? (
+        <SurfaceActionButton tone="accent" onClick={onOpenAchievements}>
+          {t({ ko: "업적 보기", en: "Open XP", ja: "XP を開く", zh: "查看 XP" })}
+        </SurfaceActionButton>
+      ) : undefined}
+      style={{
+        borderColor: "color-mix(in srgb, var(--th-accent-success) 22%, var(--th-border) 78%)",
+        background:
+          "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 94%, var(--th-accent-success) 6%) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
+      }}
+    >
+      {rows.length === 0 ? (
+        <SurfaceEmptyState className="px-4 py-6 text-center text-sm">
+          {t({ ko: "표시할 에이전트가 없습니다.", en: "No agents to show.", ja: "表示するエージェントがいません。", zh: "没有可显示的代理。" })}
+        </SurfaceEmptyState>
+      ) : (
+        <div className="space-y-2">
+          {rows.map((row) => (
+            <SurfaceListItem
+              key={row.agent.id}
+              tone={getAgentStatusTone(row.agent.status)}
+              trailing={(
+                <div className="flex items-center gap-2">
+                  <div className="text-right text-[11px]" style={{ color: "var(--th-text-muted)" }}>
+                    <div style={{ color: "var(--th-text-heading)" }}>
+                      XP {numberFormatter.format(row.agent.stats_xp)}
+                    </div>
+                    <div>{numberFormatter.format(row.agent.stats_tasks_done)} done</div>
+                  </div>
+                  {onSelectAgent ? (
+                    <SurfaceActionButton compact tone="neutral" onClick={() => onSelectAgent(row.agent)}>
+                      {t({ ko: "열기", en: "Open", ja: "開く", zh: "打开" })}
+                    </SurfaceActionButton>
+                  ) : null}
+                </div>
+              )}
+            >
+              <div className="flex items-start gap-3">
+                <AgentAvatar agent={row.agent} size={34} />
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="truncate text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                      {row.displayName}
+                    </span>
+                    <SurfaceMetaBadge tone={getAgentStatusTone(row.agent.status)}>
+                      {getAgentStatusLabel(row.agent.status, t)}
+                    </SurfaceMetaBadge>
+                  </div>
+                  <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                    {row.workSummary ?? t({ ko: "대기 중", en: "Idle", ja: "待機中", zh: "待机中" })}
+                  </div>
+                  <div className="mt-2 flex flex-wrap gap-2 text-[11px]">
+                    {row.elapsedLabel ? <SurfaceMetaBadge>{row.elapsedLabel}</SurfaceMetaBadge> : null}
+                    <SurfaceMetaBadge>{row.linkedSessions.length} session</SurfaceMetaBadge>
+                  </div>
+                </div>
+              </div>
+            </SurfaceListItem>
+          ))}
+        </div>
+      )}
+    </SurfaceSubsection>
+  );
+}
+
+function DashboardHomeActivityWidget({
+  items,
+  localeTag,
+  t,
+  onOpenMeetings,
+}: {
+  items: HomeActivityItem[];
+  localeTag: string;
+  t: TFunction;
+  onOpenMeetings?: () => void;
+}) {
+  const formatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(localeTag, {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      }),
+    [localeTag],
+  );
+
+  return (
+    <SurfaceSubsection
+      title={t({ ko: "최근 활동", en: "Recent Activity", ja: "最近の活動", zh: "最近活动" })}
+      description={t({
+        ko: "회의와 세션 전환을 시간순으로 압축해 보여줍니다.",
+        en: "A compressed activity stream across meetings and sessions.",
+        ja: "会議とセッション遷移を時間順で圧縮表示します。",
+        zh: "按时间顺序压缩展示会议与会话活动。",
+      })}
+      actions={onOpenMeetings ? (
+        <SurfaceActionButton tone="neutral" onClick={onOpenMeetings}>
+          {t({ ko: "회의 보기", en: "Open Meetings", ja: "会議を開く", zh: "打开会议" })}
+        </SurfaceActionButton>
+      ) : undefined}
+      style={{
+        borderColor: "color-mix(in srgb, var(--th-accent-warn) 22%, var(--th-border) 78%)",
+        background:
+          "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 94%, var(--th-accent-warn) 6%) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
+      }}
+    >
+      {items.length === 0 ? (
+        <SurfaceEmptyState className="px-4 py-6 text-center text-sm">
+          {t({ ko: "최근 활동이 없습니다.", en: "No recent activity.", ja: "最近の活動はありません。", zh: "暂无最近活动。" })}
+        </SurfaceEmptyState>
+      ) : (
+        <div className="space-y-2">
+          {items.map((item) => (
+            <SurfaceListItem
+              key={item.id}
+              tone={item.tone === "success" ? "success" : "warn"}
+              trailing={(
+                <div className="text-right text-[11px]" style={{ color: "var(--th-text-muted)" }}>
+                  <div>{timeAgo(item.timestamp, localeTag)}</div>
+                  <div style={{ fontFamily: "var(--font-mono)" }}>{formatter.format(item.timestamp)}</div>
+                </div>
+              )}
+            >
+              <div className="min-w-0">
+                <div className="truncate text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                  {item.title}
+                </div>
+                <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                  {item.detail}
+                </div>
+              </div>
+            </SurfaceListItem>
+          ))}
+        </div>
+      )}
+    </SurfaceSubsection>
+  );
+}
+
+function DashboardHomeSectionNavigatorWidget({
+  tabDefinitions,
+  activeTab,
+  t,
+  topRepos,
+  openTotal,
+  onClickTab,
+  onKeyDown,
+  buttonRefs,
+}: {
+  tabDefinitions: DashboardTabDefinition[];
+  activeTab: DashboardTab;
+  t: TFunction;
+  topRepos: Array<{
+    github_repo: string;
+    open_count: number;
+    pressure_count: number;
+  }>;
+  openTotal: number;
+  onClickTab: (tab: DashboardTab) => void;
+  onKeyDown: (event: ReactKeyboardEvent<HTMLButtonElement>, tab: DashboardTab) => void;
+  buttonRefs: { current: Record<DashboardTab, HTMLButtonElement | null> };
+}) {
+  return (
+    <SurfaceSubsection
+      title={t({ ko: "빠른 이동", en: "Quick Navigation", ja: "クイック移動", zh: "快速导航" })}
+      description={t({
+        ko: "홈에서 각 운영 섹션과 칸반 압력을 바로 전환합니다.",
+        en: "Jump directly into each operational section and kanban pressure lane from home.",
+        ja: "ホームから各運用セクションとカンバン圧力レーンへ直接移動します。",
+        zh: "从首页直接跳转到各运营分区与看板压力区。",
+      })}
+      style={{
+        borderColor: "color-mix(in srgb, var(--th-accent-info) 22%, var(--th-border) 78%)",
+        background:
+          "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 94%, var(--th-accent-info) 6%) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
+      }}
+    >
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
+        <div
+          role="tablist"
+          aria-label={t({ ko: "대시보드 섹션", en: "Dashboard sections", ja: "ダッシュボードセクション", zh: "仪表盘分区" })}
+          className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3"
+        >
+          {tabDefinitions.map((definition) => (
+            <DashboardTabButton
+              key={definition.id}
+              tab={definition.id}
+              active={activeTab === definition.id}
+              label={definition.label}
+              detail={definition.detail}
+              onClick={() => onClickTab(definition.id)}
+              onKeyDown={onKeyDown}
+              buttonRef={(node) => {
+                buttonRefs.current[definition.id] = node;
+              }}
+            />
+          ))}
+        </div>
+
+        <SurfaceCard
+          className="rounded-[24px] p-4"
+          style={{
+            borderColor: "color-mix(in srgb, var(--th-accent-primary) 20%, var(--th-border) 80%)",
+            background:
+              "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 95%, var(--th-accent-primary) 5%) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
+          }}
+        >
+          <div className="text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "var(--th-text-muted)" }}>
+            {t({ ko: "Kanban Snapshot", en: "Kanban Snapshot", ja: "Kanban Snapshot", zh: "Kanban Snapshot" })}
+          </div>
+          <div className="mt-3 text-3xl font-black tracking-tight" style={{ color: "var(--th-text-heading)" }}>
+            {openTotal}
+          </div>
+          <p className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+            {t({
+              ko: "현재 열려 있는 전체 카드 수와 압력이 높은 저장소입니다.",
+              en: "Open card count and the repos with the heaviest pressure.",
+              ja: "現在開いているカード総数と圧力の高いリポジトリです。",
+              zh: "当前打开卡片总数与压力最高的仓库。",
+            })}
+          </p>
+
+          <div className="mt-4 space-y-2">
+            {topRepos.length === 0 ? (
+              <SurfaceEmptyState className="px-4 py-6 text-center text-sm">
+                {t({ ko: "추적 중인 저장소가 없습니다.", en: "No repo pressure tracked yet.", ja: "追跡中のリポジトリがありません。", zh: "暂无正在跟踪的仓库压力。" })}
+              </SurfaceEmptyState>
+            ) : (
+              topRepos.slice(0, 3).map((repo) => (
+                <SurfaceListItem
+                  key={repo.github_repo}
+                  tone={repo.pressure_count > 0 ? "warn" : "neutral"}
+                  trailing={(
+                    <div className="text-right text-[11px]" style={{ color: "var(--th-text-muted)" }}>
+                      <div style={{ color: "var(--th-text-heading)" }}>{repo.open_count}</div>
+                      <div>{repo.pressure_count} pressure</div>
+                    </div>
+                  )}
+                >
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                      {repo.github_repo}
+                    </div>
+                    <div className="mt-1 text-xs" style={{ color: "var(--th-text-muted)" }}>
+                      {t({
+                        ko: repo.pressure_count > 0 ? "리뷰/블록 압력 있음" : "오픈 카드 추적 중",
+                        en: repo.pressure_count > 0 ? "Pressure in review/blocked" : "Tracking open cards",
+                        ja: repo.pressure_count > 0 ? "レビュー/ブロック圧力あり" : "オープンカード追跡中",
+                        zh: repo.pressure_count > 0 ? "存在 review/blocked 压力" : "正在跟踪打开卡片",
+                      })}
+                    </div>
+                  </div>
+                </SurfaceListItem>
+              ))
+            )}
+          </div>
+        </SurfaceCard>
+      </div>
+    </SurfaceSubsection>
+  );
+}
+
+function getAgentStatusTone(status: Agent["status"]): "neutral" | "success" | "warn" | "danger" {
+  switch (status) {
+    case "working":
+      return "success";
+    case "break":
+      return "warn";
+    case "offline":
+      return "danger";
+    case "idle":
+    default:
+      return "neutral";
+  }
+}
+
+function getAgentStatusLabel(status: Agent["status"], t: TFunction): string {
+  switch (status) {
+    case "working":
+      return t({ ko: "작업 중", en: "Working", ja: "作業中", zh: "工作中" });
+    case "break":
+      return t({ ko: "휴식", en: "Break", ja: "休憩", zh: "休息" });
+    case "offline":
+      return t({ ko: "오프라인", en: "Offline", ja: "オフライン", zh: "离线" });
+    case "idle":
+    default:
+      return t({ ko: "대기", en: "Idle", ja: "待機", zh: "待机" });
+  }
+}
+
+function getSignalAccent(tone: HomeSignalTone): string {
+  switch (tone) {
+    case "success":
+      return "#22c55e";
+    case "warn":
+      return "#f59e0b";
+    case "danger":
+      return "#ef4444";
+    case "info":
+    default:
+      return "#14b8a6";
+  }
 }

--- a/dashboard/src/components/MeetingsAndSkillsPage.tsx
+++ b/dashboard/src/components/MeetingsAndSkillsPage.tsx
@@ -1,6 +1,18 @@
-import { BookOpen, MessagesSquare } from "lucide-react";
+import {
+  AlertTriangle,
+  BookOpen,
+  Check,
+  Clock3,
+  Minus,
+  Plus,
+  Users,
+  Workflow,
+} from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { summarizeMeetings } from "../app/meetingSummary";
+import {
+  countOpenMeetingIssues,
+  summarizeMeetings,
+} from "../app/meetingSummary";
 import { useI18n } from "../i18n";
 import type {
   RoundTableMeeting,
@@ -8,12 +20,6 @@ import type {
 } from "../types";
 import MeetingMinutesView from "./MeetingMinutesView";
 import SkillCatalogView from "./SkillCatalogView";
-import {
-  SurfaceMetricPill,
-  SurfaceNotice,
-  SurfaceSection,
-  SurfaceSegmentButton,
-} from "./common/SurfacePrimitives";
 
 type MeetingNotificationType = "info" | "success" | "warning" | "error";
 type MeetingNotifier = (
@@ -26,7 +32,14 @@ type MeetingNotificationUpdater = (
   type?: MeetingNotificationType,
 ) => void;
 type MobilePane = "meetings" | "skills";
+
 const DESKTOP_SPLIT_QUERY = "(min-width: 1024px)";
+const MEETING_TOGGLE_PATTERNS = [
+  /new meeting/i,
+  /새 회의/u,
+  /close form/i,
+  /입력 닫기/u,
+];
 
 interface MeetingsAndSkillsPageProps {
   meetings: RoundTableMeeting[];
@@ -38,37 +51,6 @@ interface MeetingsAndSkillsPageProps {
   initialChannelId?: string;
 }
 
-const PRESERVED_BUTTON_PATTERNS = [
-  /details/i,
-  /상세 보기/u,
-  /preview issues to create/i,
-  /생성될 일감 미리보기/u,
-];
-
-const HIDDEN_BUTTON_PATTERNS = [
-  /new meeting/i,
-  /새 회의/u,
-  /close form/i,
-  /입력 닫기/u,
-  /^cancel$/i,
-  /^취소$/u,
-  /start meeting/i,
-  /회의 시작/u,
-  /create issues/i,
-  /일감 생성/u,
-  /issues created/i,
-  /일감 생성 완료/u,
-  /issues resolved/i,
-  /일감 처리 완료/u,
-  /retry failed/i,
-  /실패분 재시도/u,
-  /discard/i,
-  /폐기/u,
-];
-
-const HIDDEN_SECTION_PATTERNS = [/start meeting/i, /회의 시작/u];
-const DELETE_PATTERNS = [/delete/i, /삭제/u];
-
 function normalizeNodeLabel(node: Element): string {
   const text = node.textContent ?? "";
   const title = node.getAttribute("title") ?? "";
@@ -76,54 +58,20 @@ function normalizeNodeLabel(node: Element): string {
   return `${text} ${title} ${ariaLabel}`.replace(/\s+/g, " ").trim();
 }
 
-function matchesAnyPattern(
-  value: string,
+function clickMatchingButton(
+  root: HTMLElement | null,
   patterns: readonly RegExp[],
 ): boolean {
-  return patterns.some((pattern) => pattern.test(value));
-}
+  if (!root) return false;
 
-function hideElement(element: HTMLElement | null): void {
-  if (!element || element.dataset.readOnlyHidden === "true") return;
-  element.dataset.readOnlyHidden = "true";
-  element.style.display = "none";
-}
+  const buttons = Array.from(root.querySelectorAll("button"));
+  const target = buttons.find((button) =>
+    patterns.some((pattern) => pattern.test(normalizeNodeLabel(button))),
+  );
 
-function pruneMeetingMutations(root: HTMLElement): void {
-  root.querySelectorAll("section").forEach((section) => {
-    const heading = section.querySelector("h3");
-    if (!heading) return;
-    const headingText = normalizeNodeLabel(heading);
-    if (matchesAnyPattern(headingText, HIDDEN_SECTION_PATTERNS)) {
-      hideElement(section as HTMLElement);
-    }
-  });
-
-  root.querySelectorAll("button").forEach((button) => {
-    const label = normalizeNodeLabel(button);
-    if (matchesAnyPattern(label, PRESERVED_BUTTON_PATTERNS)) return;
-    if (
-      matchesAnyPattern(label, HIDDEN_BUTTON_PATTERNS) ||
-      matchesAnyPattern(label, DELETE_PATTERNS)
-    ) {
-      hideElement(button as HTMLElement);
-    }
-  });
-
-  root.querySelectorAll("select").forEach((select) => {
-    hideElement(select.parentElement as HTMLElement | null);
-  });
-
-  root.querySelectorAll("input, textarea").forEach((field) => {
-    const section = field.closest("section");
-    if (!section) return;
-    const heading = section.querySelector("h3");
-    if (!heading) return;
-    const headingText = normalizeNodeLabel(heading);
-    if (matchesAnyPattern(headingText, HIDDEN_SECTION_PATTERNS)) {
-      hideElement(section as HTMLElement);
-    }
-  });
+  if (!target) return false;
+  target.click();
+  return true;
 }
 
 function useDesktopSplitLayout(): boolean {
@@ -147,6 +95,151 @@ function useDesktopSplitLayout(): boolean {
   return isDesktopSplit;
 }
 
+function formatMeetingDate(timestamp: number, locale: string): string {
+  return new Intl.DateTimeFormat(locale, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(timestamp));
+}
+
+function formatRelativeTime(
+  timestamp: number,
+  language: string,
+  locale: string,
+): string {
+  const isKo = language === "ko";
+  const diffMs = Date.now() - timestamp;
+  const hours = Math.max(0, Math.floor(diffMs / (1000 * 60 * 60)));
+  if (hours < 1) return isKo ? "방금" : "Just now";
+  if (hours < 24) return isKo ? `${hours}시간 전` : `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  if (days === 1) return isKo ? "어제" : "Yesterday";
+  if (days < 7) return isKo ? `${days}일 전` : `${days}d ago`;
+  return formatMeetingDate(timestamp, locale);
+}
+
+function formatProvider(provider: string | null | undefined): string {
+  if (!provider) return "N/A";
+  return provider
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
+    .join(" ");
+}
+
+function formatDurationCompact(durationMs: number, language: string): string {
+  const isKo = language === "ko";
+  const safeMs = Math.max(durationMs, 0);
+  const totalMinutes = Math.max(1, Math.round(safeMs / 60_000));
+  if (totalMinutes < 60) {
+    return isKo ? `${totalMinutes}분` : `${totalMinutes}m`;
+  }
+
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (minutes === 0) return isKo ? `${hours}시간` : `${hours}h`;
+  return isKo ? `${hours}시간 ${minutes}분` : `${hours}h ${minutes}m`;
+}
+
+function formatMeetingDuration(
+  meeting: RoundTableMeeting,
+  language: string,
+  t: ReturnType<typeof useI18n>["t"],
+): string {
+  if (meeting.completed_at && meeting.completed_at > meeting.started_at) {
+    return formatDurationCompact(meeting.completed_at - meeting.started_at, language);
+  }
+  if (meeting.status === "in_progress") {
+    return t({ ko: "진행 중", en: "In progress" });
+  }
+  return "—";
+}
+
+function getParticipantInitials(name: string): string {
+  const parts = name
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return `${parts[0][0] ?? ""}${parts[1][0] ?? ""}`.toUpperCase();
+}
+
+function getMeetingStatusLabel(
+  meeting: RoundTableMeeting | null,
+  t: ReturnType<typeof useI18n>["t"],
+): string {
+  if (!meeting) return "—";
+  if (meeting.status === "in_progress") {
+    return t({ ko: "진행 중", en: "In Progress" });
+  }
+  if (meeting.status === "completed") {
+    return t({ ko: "완료", en: "Completed" });
+  }
+  return t({ ko: "취소됨", en: "Cancelled" });
+}
+
+function getMeetingStatusTone(
+  meeting: RoundTableMeeting | null,
+): "ok" | "warn" | "err" {
+  if (!meeting) return "warn";
+  if (meeting.status === "completed") return "ok";
+  if (meeting.status === "in_progress") return "warn";
+  return "err";
+}
+
+function getProposedIssueKey(issue: {
+  title: string;
+  body: string;
+  assignee: string;
+}): string {
+  return JSON.stringify([issue.title.trim(), issue.body.trim(), issue.assignee.trim()]);
+}
+
+function getMeetingIssueResult(
+  meeting: RoundTableMeeting,
+  issue: {
+    title: string;
+    body: string;
+    assignee: string;
+  },
+): { ok: boolean; discarded?: boolean; error?: string | null } | null {
+  const key = getProposedIssueKey(issue);
+  return (
+    meeting.issue_creation_results?.find((result) => result.key === key) ?? null
+  );
+}
+
+function getMeetingIssueState(
+  result: { ok: boolean; discarded?: boolean; error?: string | null } | null,
+): "created" | "failed" | "discarded" | "pending" {
+  if (!result) return "pending";
+  if (result.discarded) return "discarded";
+  return result.ok ? "created" : "failed";
+}
+
+function getMeetingIssueTone(
+  state: "created" | "failed" | "discarded" | "pending",
+): "ok" | "warn" | "err" | "neutral" {
+  if (state === "created") return "ok";
+  if (state === "failed") return "err";
+  if (state === "discarded") return "neutral";
+  return "warn";
+}
+
+function getMeetingIssueStateLabel(
+  state: "created" | "failed" | "discarded" | "pending",
+  t: ReturnType<typeof useI18n>["t"],
+): string {
+  if (state === "created") return t({ ko: "생성됨", en: "Created" });
+  if (state === "failed") return t({ ko: "실패", en: "Failed" });
+  if (state === "discarded") return t({ ko: "폐기", en: "Discarded" });
+  return t({ ko: "대기", en: "Pending" });
+}
+
 export default function MeetingsAndSkillsPage({
   meetings,
   onRefresh,
@@ -156,200 +249,1097 @@ export default function MeetingsAndSkillsPage({
   initialMeetingChannels = [],
   initialChannelId,
 }: MeetingsAndSkillsPageProps) {
-  const { t } = useI18n();
+  const { t, language, locale } = useI18n();
+  const [selectedMeetingId, setSelectedMeetingId] = useState("");
   const [mobilePane, setMobilePane] = useState<MobilePane>("meetings");
   const isDesktopSplit = useDesktopSplitLayout();
-  const meetingsRef = useRef<HTMLDivElement | null>(null);
+  const meetingShellRef = useRef<HTMLDivElement | null>(null);
+
   const meetingSummary = useMemo(() => summarizeMeetings(meetings), [meetings]);
-  const completedCount = meetings.filter(
-    (meeting) => meeting.status === "completed",
-  ).length;
+  const sortedMeetings = useMemo(
+    () => [...meetings].sort((left, right) => right.started_at - left.started_at),
+    [meetings],
+  );
+  const selectedMeeting = useMemo(() => {
+    if (sortedMeetings.length === 0) return null;
+    return (
+      sortedMeetings.find((meeting) => meeting.id === selectedMeetingId) ??
+      sortedMeetings[0]
+    );
+  }, [selectedMeetingId, sortedMeetings]);
+  const totalParticipants = meetings.reduce(
+    (sum, meeting) => sum + meeting.participant_names.length,
+    0,
+  );
+  const providerCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    meetings.forEach((meeting) => {
+      [meeting.primary_provider, meeting.reviewer_provider]
+        .filter((provider): provider is string => Boolean(provider))
+        .forEach((provider) => {
+          counts.set(provider, (counts.get(provider) ?? 0) + 1);
+        });
+    });
+
+    return [...counts.entries()].sort((left, right) => right[1] - left[1]);
+  }, [meetings]);
+  const selectedActionCount = selectedMeeting?.proposed_issues?.length ?? 0;
+  const selectedOpenIssues = selectedMeeting
+    ? countOpenMeetingIssues(selectedMeeting)
+    : 0;
+  const selectedDurationLabel = selectedMeeting
+    ? formatMeetingDuration(selectedMeeting, language, t)
+    : "—";
+  const selectedTranscript = (selectedMeeting?.entries ?? [])
+    .filter((entry) => entry.is_summary === 0)
+    .slice(0, 4);
 
   useEffect(() => {
-    const root = meetingsRef.current;
-    if (!root) return;
+    if (!sortedMeetings.length) {
+      if (selectedMeetingId) setSelectedMeetingId("");
+      return;
+    }
 
-    const applyReadOnly = () => pruneMeetingMutations(root);
-    applyReadOnly();
+    if (
+      !selectedMeetingId ||
+      !sortedMeetings.some((meeting) => meeting.id === selectedMeetingId)
+    ) {
+      setSelectedMeetingId(sortedMeetings[0].id);
+    }
+  }, [selectedMeetingId, sortedMeetings]);
 
-    const observer = new MutationObserver(() => {
-      applyReadOnly();
-    });
-    observer.observe(root, { childList: true, subtree: true });
+  const handleLaunchMeeting = () => {
+    if (!isDesktopSplit) {
+      setMobilePane("meetings");
+    }
+    if (clickMatchingButton(meetingShellRef.current, MEETING_TOGGLE_PATTERNS)) {
+      meetingShellRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+      return;
+    }
 
-    return () => observer.disconnect();
-  }, [meetings]);
+    meetingShellRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
 
-  const renderMeetingsPanel = () => (
-    <div
-      ref={meetingsRef}
-      className="min-w-0"
-      data-testid="meetings-page-timeline"
-    >
-      <MeetingMinutesView
-        meetings={meetings}
-        onRefresh={onRefresh}
-        embedded
-        onNotify={onNotify}
-        onUpdateNotification={onUpdateNotification}
-        initialShowStartForm={initialShowStartForm}
-        initialMeetingChannels={initialMeetingChannels}
-        initialChannelId={initialChannelId}
-      />
+  const meetingListCard = (
+    <div data-testid="meetings-page-timeline" className="meetings-list card">
+      {sortedMeetings.length === 0 ? (
+        <div className="empty-state">
+          {t({
+            ko: "아직 등록된 회의가 없습니다.",
+            en: "No meetings have been recorded yet.",
+          })}
+        </div>
+      ) : (
+        sortedMeetings.map((meeting) => {
+          const issueTotal = meeting.proposed_issues?.length ?? 0;
+          const issueTone =
+            issueTotal === 0 || meeting.issues_created === issueTotal
+              ? "ok"
+              : meeting.issues_created > 0
+                ? "warn"
+                : "err";
+          const statusTone = getMeetingStatusTone(meeting);
+          const durationLabel = formatMeetingDuration(meeting, language, t);
+
+          return (
+            <button
+              key={meeting.id}
+              type="button"
+              className={`meeting-item ${
+                selectedMeeting?.id === meeting.id ? "active" : ""
+              }`}
+              onClick={() => setSelectedMeetingId(meeting.id)}
+            >
+              <div className="mi-head">
+                <div className="min-w-0">
+                  <div className="mi-title">{meeting.agenda}</div>
+                  <div className="mi-meta">
+                    <span className="mono">
+                      {formatMeetingDate(meeting.started_at, locale)}
+                    </span>
+                    <span>· {durationLabel}</span>
+                    <span>
+                      ·{" "}
+                      {t({
+                        ko: `${meeting.participant_names.length}명`,
+                        en: `${meeting.participant_names.length} attendees`,
+                      })}
+                    </span>
+                  </div>
+                </div>
+                <span className={`chip ${issueTone}`}>
+                  <span className="dot" />
+                  {issueTotal > 0 ? `${meeting.issues_created}/${issueTotal}` : "0/0"}
+                </span>
+              </div>
+              <div className="mi-summary">
+                {meeting.summary ??
+                  t({
+                    ko: "요약이 아직 없습니다.",
+                    en: "No summary yet.",
+                  })}
+              </div>
+              <div className="mi-foot">
+                <span className={`chip ${statusTone}`}>
+                  <span className="dot" />
+                  {getMeetingStatusLabel(meeting, t)}
+                </span>
+                <span className="chip">
+                  <span className="dot" />
+                  {formatProvider(meeting.primary_provider)}
+                </span>
+              </div>
+            </button>
+          );
+        })
+      )}
     </div>
   );
 
-  const renderSkillsPanel = () => (
-    <div data-testid="meetings-page-skills" className="min-w-0">
-      <SurfaceSection
-        eyebrow={t({ ko: "Skills", en: "Skills" })}
-        title={t({ ko: "스킬 카탈로그", en: "Skill Catalog" })}
-        description={t({
-          ko: "회의 타임라인 옆에서 최근에 축적된 자동화 스킬을 함께 확인합니다.",
-          en: "Review the current automation skill catalog alongside the meeting timeline.",
-        })}
-        className="rounded-[28px] p-4 sm:p-5"
-        style={{
-          borderColor:
-            "color-mix(in srgb, var(--th-accent-info) 20%, var(--th-border) 80%)",
-          background:
-            "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, var(--th-accent-info) 4%) 0%, color-mix(in srgb, var(--th-bg-surface) 98%, transparent) 100%)",
-        }}
-      >
-        <div className="meetings-and-skills__skills mt-4 min-w-0">
-          <SkillCatalogView embedded />
+  const meetingDetailCard = (
+    <div className="meeting-detail card">
+      <div className="md-head">
+        <div className="min-w-0">
+          <div className="section-kicker">{t({ ko: "회의록", en: "Meeting" })}</div>
+          {selectedMeeting ? (
+            <div className="md-status-row">
+              <span className={`chip ${getMeetingStatusTone(selectedMeeting)}`}>
+                <span className="dot" />
+                {getMeetingStatusLabel(selectedMeeting, t)}
+              </span>
+              <span className="md-status-copy">
+                {formatRelativeTime(selectedMeeting.started_at, language, locale)}
+              </span>
+            </div>
+          ) : null}
+          <h2 className="md-title">
+            {selectedMeeting?.agenda ??
+              t({
+                ko: "선택된 회의가 없습니다",
+                en: "No meeting selected",
+              })}
+          </h2>
         </div>
-      </SurfaceSection>
+        <div className="md-toolbar">
+          <button type="button" className="btn sm" onClick={onRefresh}>
+            {t({ ko: "새로고침", en: "Refresh" })}
+          </button>
+          <button type="button" className="btn sm" onClick={handleLaunchMeeting}>
+            <Plus size={11} />
+            {t({ ko: "열기", en: "Open" })}
+          </button>
+        </div>
+      </div>
+
+      {selectedMeeting ? (
+        <>
+          <div className="md-meta-row">
+            <div className="md-meta">
+              <span>{t({ ko: "시작", en: "Started" })}</span>
+              <b className="mono">
+                {formatMeetingDate(selectedMeeting.started_at, locale)}
+              </b>
+            </div>
+            <div className="md-meta">
+              <span>{t({ ko: "길이", en: "Length" })}</span>
+              <b>{selectedDurationLabel}</b>
+            </div>
+            <div className="md-meta">
+              <span>{t({ ko: "프로바이더", en: "Provider" })}</span>
+              <div className="md-meta-stack">
+                <span className="chip">
+                  <span className="dot" />
+                  {formatProvider(selectedMeeting.primary_provider)}
+                </span>
+                <span className="chip neutral">
+                  <span className="dot" />
+                  {formatProvider(selectedMeeting.reviewer_provider)}
+                </span>
+              </div>
+            </div>
+            <div className="md-meta">
+              <span>{t({ ko: "참석", en: "Attendees" })}</span>
+              <div className="md-attendees">
+                {selectedMeeting.participant_names.slice(0, 4).map((name, index) => (
+                  <span
+                    key={`${selectedMeeting.id}-${name}-${index}`}
+                    className="md-attendee"
+                    title={name}
+                    style={{ marginLeft: index === 0 ? 0 : -6 }}
+                  >
+                    {getParticipantInitials(name)}
+                  </span>
+                ))}
+                {selectedMeeting.participant_names.length > 4 ? (
+                  <span className="md-attendee md-attendee-count">
+                    +{selectedMeeting.participant_names.length - 4}
+                  </span>
+                ) : null}
+              </div>
+            </div>
+          </div>
+
+          <div className="md-section">
+            <div className="md-section-head">{t({ ko: "요약", en: "Summary" })}</div>
+            <p className="md-copy">
+              {selectedMeeting.summary ??
+                t({
+                  ko: "요약이 아직 없습니다.",
+                  en: "No summary yet.",
+                })}
+            </p>
+          </div>
+
+          <div className="md-section">
+            <div className="md-section-head">
+              {t({ ko: "후속 액션", en: "Follow-up Actions" })}
+              <span className="md-inline-note">
+                {t({
+                  ko: `${selectedOpenIssues}/${selectedActionCount || 0} 미완료`,
+                  en: `${selectedOpenIssues}/${selectedActionCount || 0} open`,
+                })}
+              </span>
+            </div>
+            {selectedMeeting.proposed_issues?.length ? (
+              <div className="md-actions">
+                {selectedMeeting.proposed_issues.slice(0, 6).map((issue) => {
+                  const result = getMeetingIssueResult(selectedMeeting, issue);
+                  const state = getMeetingIssueState(result);
+                  const tone = getMeetingIssueTone(state);
+                  const stateLabel = getMeetingIssueStateLabel(state, t);
+                  return (
+                    <div key={getProposedIssueKey(issue)} className="md-action">
+                      <span className={`md-action-check ${state}`}>
+                        {state === "created" ? (
+                          <Check size={10} />
+                        ) : state === "failed" ? (
+                          <AlertTriangle size={10} />
+                        ) : state === "discarded" ? (
+                          <Minus size={10} />
+                        ) : (
+                          <Clock3 size={10} />
+                        )}
+                      </span>
+                      <div className="md-action-copy">
+                        <div className={`md-action-title ${state}`}>
+                          {issue.title}
+                        </div>
+                        <div className="md-action-sub">
+                          {issue.assignee}
+                          {result?.error ? ` · ${result.error}` : ""}
+                        </div>
+                      </div>
+                      <span className={`chip ${tone}`}>
+                        <span className="dot" />
+                        {stateLabel}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="md-empty-copy">
+                {t({
+                  ko: "후속 액션이 아직 없습니다.",
+                  en: "No follow-up actions yet.",
+                })}
+              </div>
+            )}
+          </div>
+
+          <div className="md-section">
+            <div className="md-section-head">
+              {t({ ko: "전사 (발췌)", en: "Transcript Excerpt" })}
+            </div>
+            {selectedTranscript.length > 0 ? (
+              <div className="md-transcript">
+                {selectedTranscript.map((entry) => (
+                  <div key={entry.id} className="md-transcript-line">
+                    <span className="md-who">{entry.speaker_name}</span>
+                    <span className="md-said">{entry.content}</span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="md-empty-copy">
+                {t({
+                  ko: "전사 내용이 아직 없습니다.",
+                  en: "No transcript yet.",
+                })}
+              </div>
+            )}
+          </div>
+        </>
+      ) : (
+        <div className="md-empty-copy">
+          {t({
+            ko: "회의를 선택하면 상세 카드가 갱신됩니다.",
+            en: "Select a meeting to refresh the detail card.",
+          })}
+        </div>
+      )}
+    </div>
+  );
+
+  const meetingWorkbenchCard = (
+    <div className="meeting-workbench card">
+      <div className="section-head">
+        <div className="min-w-0">
+          <div className="section-kicker">
+            {t({ ko: "실시간 작성", en: "Live Workbench" })}
+          </div>
+          <div className="section-title">
+            {t({
+              ko: "회의 생성과 후속 흐름",
+              en: "Meeting creation and follow-up flow",
+            })}
+          </div>
+          <div className="section-copy">
+            {t({
+              ko: "기존 대시보드의 작성 워크플로우는 유지하되, Claude 시안의 카드 톤 안에서 연결합니다.",
+              en: "Keep the original authoring workflow, but attach it inside the Claude card system.",
+            })}
+          </div>
+        </div>
+        <button type="button" className="btn sm" onClick={handleLaunchMeeting}>
+          <Plus size={11} />
+          {t({ ko: "열기", en: "Open" })}
+        </button>
+      </div>
+
+      <div className="workbench-meta">
+        <span className="chip">
+          <Users size={11} />
+          {t({
+            ko: `${totalParticipants}명 누적`,
+            en: `${totalParticipants} people total`,
+          })}
+        </span>
+        <span className="chip">
+          <Workflow size={11} />
+          {t({
+            ko: `${meetingSummary.unresolvedCount}건 미해결`,
+            en: `${meetingSummary.unresolvedCount} unresolved`,
+          })}
+        </span>
+        {providerCounts.slice(0, 2).map(([provider]) => (
+          <span key={provider} className="chip neutral">
+            <span className="dot" />
+            {formatProvider(provider)}
+          </span>
+        ))}
+      </div>
+
+      <div ref={meetingShellRef} className="workbench-shell">
+        <MeetingMinutesView
+          meetings={meetings}
+          onRefresh={onRefresh}
+          embedded
+          onNotify={onNotify}
+          onUpdateNotification={onUpdateNotification}
+          initialShowStartForm={initialShowStartForm}
+          initialMeetingChannels={initialMeetingChannels}
+          initialChannelId={initialChannelId}
+        />
+      </div>
+    </div>
+  );
+
+  const skillRailCard = (
+    <div data-testid="meetings-page-skills" className="skill-rail card">
+      <div className="section-head">
+        <div className="min-w-0">
+          <div className="section-kicker">
+            {t({ ko: "스킬 카탈로그", en: "Skill Catalog" })}
+          </div>
+          <div className="section-title">
+            {t({ ko: "자동화 스킬", en: "Automation Skills" })}
+          </div>
+          <div className="section-copy">
+            {t({
+              ko: "시안엔 없던 기존 기능이지만, 회의 상세 아래에 같은 톤의 확장 카드로 붙입니다.",
+              en: "This is an original dashboard extension, attached under the reference detail card in the same visual tone.",
+            })}
+          </div>
+        </div>
+        <div className="section-icon">
+          <BookOpen size={17} />
+        </div>
+      </div>
+      <SkillCatalogView embedded />
+    </div>
+  );
+
+  const desktopDetailColumn = (
+    <div className="detail-column rail-sticky">
+      {meetingDetailCard}
+      {meetingWorkbenchCard}
+      {skillRailCard}
+    </div>
+  );
+
+  const mobileDetailColumn = (
+    <div className="detail-column">
+      {meetingDetailCard}
+      {meetingWorkbenchCard}
     </div>
   );
 
   return (
     <div
       data-testid="meetings-page"
-      className="mx-auto h-full w-full max-w-[1600px] min-w-0 overflow-x-hidden overflow-y-auto p-4 pb-40 sm:p-6"
-      style={{ paddingBottom: "max(10rem, calc(10rem + env(safe-area-inset-bottom)))" }}
+      className="mx-auto h-full w-full max-w-[1440px] min-w-0 overflow-x-hidden overflow-y-auto p-4 pb-40 sm:p-6"
+      style={{
+        paddingBottom: "max(10rem, calc(10rem + env(safe-area-inset-bottom)))",
+      }}
     >
       <style>{`
+        .meetings-page-shell {
+          display: flex;
+          flex-direction: column;
+          gap: 16px;
+        }
+
+        .meetings-page-shell .page-header {
+          display: flex;
+          align-items: flex-end;
+          justify-content: space-between;
+          gap: 16px;
+          margin-bottom: 2px;
+          flex-wrap: wrap;
+        }
+
+        .meetings-page-shell .page-title {
+          font-size: 22px;
+          font-weight: 600;
+          letter-spacing: -0.5px;
+          line-height: 1.2;
+          color: var(--th-text-heading);
+        }
+
+        .meetings-page-shell .page-sub {
+          margin-top: 4px;
+          max-width: 68ch;
+          font-size: 13px;
+          line-height: 1.65;
+          color: var(--th-text-muted);
+        }
+
+        .meetings-page-shell .meeting-pane-tabs {
+          display: inline-flex;
+          align-items: center;
+          gap: 4px;
+          padding: 4px;
+          border-radius: 999px;
+          border: 1px solid color-mix(in srgb, var(--th-border) 72%, transparent);
+          background: color-mix(in srgb, var(--th-card-bg) 92%, transparent);
+        }
+
+        .meetings-page-shell .meeting-pane-tab {
+          border: 0;
+          background: transparent;
+          color: var(--th-text-muted);
+          border-radius: 999px;
+          padding: 6px 12px;
+          font-size: 11.5px;
+          font-weight: 500;
+          transition: background 0.12s ease, color 0.12s ease;
+        }
+
+        .meetings-page-shell .meeting-pane-tab.active {
+          color: var(--th-text);
+          background: color-mix(in srgb, var(--th-overlay-medium) 92%, transparent);
+        }
+
+        .meetings-page-shell .btn {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          gap: 6px;
+          padding: 6px 12px;
+          border-radius: 7px;
+          font-size: 12.5px;
+          font-weight: 500;
+          color: var(--th-text-dim);
+          background: color-mix(in srgb, var(--th-bg-surface) 88%, transparent);
+          border: 1px solid color-mix(in srgb, var(--th-border) 70%, transparent);
+          transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+        }
+
+        .meetings-page-shell .btn:hover {
+          background: color-mix(in srgb, var(--th-bg-surface) 96%, transparent);
+          color: var(--th-text);
+          border-color: var(--th-border);
+        }
+
+        .meetings-page-shell .btn.primary {
+          background: color-mix(
+            in srgb,
+            var(--th-accent-primary-soft) 68%,
+            transparent
+          );
+          color: var(--th-text-primary);
+          border-color: color-mix(
+            in srgb,
+            var(--th-accent-primary) 28%,
+            var(--th-border) 72%
+          );
+        }
+
+        .meetings-page-shell .btn.sm {
+          padding: 4px 9px;
+          font-size: 11.5px;
+        }
+
+        .meetings-page-shell .card {
+          overflow: hidden;
+          border-radius: 18px;
+          border: 1px solid color-mix(in srgb, var(--th-border) 72%, transparent);
+          background: linear-gradient(
+            180deg,
+            color-mix(in srgb, var(--th-card-bg) 96%, transparent) 0%,
+            color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%
+          );
+          box-shadow: 0 1px 0 color-mix(in srgb, var(--th-text-primary) 4%, transparent) inset;
+        }
+
+        .meetings-page-shell .chip {
+          display: inline-flex;
+          align-items: center;
+          gap: 5px;
+          padding: 2px 8px;
+          border-radius: 999px;
+          border: 1px solid color-mix(in srgb, var(--th-border) 70%, transparent);
+          background: color-mix(in srgb, var(--th-bg-surface) 90%, transparent);
+          font-size: 11px;
+          font-weight: 500;
+          color: var(--th-text-dim);
+          font-variant-numeric: tabular-nums;
+        }
+
+        .meetings-page-shell .chip .dot {
+          width: 6px;
+          height: 6px;
+          border-radius: 999px;
+          background: currentColor;
+          opacity: 0.9;
+        }
+
+        .meetings-page-shell .chip.ok {
+          color: var(--th-accent-success);
+          border-color: color-mix(
+            in srgb,
+            var(--th-accent-success) 30%,
+            var(--th-border) 70%
+          );
+          background: color-mix(in srgb, var(--th-accent-success) 10%, transparent);
+        }
+
+        .meetings-page-shell .chip.warn {
+          color: var(--th-accent-warn);
+          border-color: color-mix(
+            in srgb,
+            var(--th-accent-warn) 30%,
+            var(--th-border) 70%
+          );
+          background: color-mix(in srgb, var(--th-accent-warn) 10%, transparent);
+        }
+
+        .meetings-page-shell .chip.err {
+          color: var(--th-accent-danger);
+          border-color: color-mix(
+            in srgb,
+            var(--th-accent-danger) 30%,
+            var(--th-border) 70%
+          );
+          background: color-mix(in srgb, rgba(255, 107, 107, 0.12) 85%, transparent);
+        }
+
+        .meetings-page-shell .chip.neutral {
+          color: var(--th-text-muted);
+        }
+
+        .meetings-page-shell .meetings-split {
+          display: grid;
+          gap: 14px;
+        }
+
         @media (min-width: 1024px) {
-          .meetings-and-skills__skills > div:last-child {
-            grid-template-columns: minmax(0, 1fr) !important;
+          .meetings-page-shell .meetings-split {
+            grid-template-columns: minmax(0, 1.02fr) minmax(360px, 0.98fr);
+            align-items: start;
           }
+
+          .meetings-page-shell .rail-sticky {
+            position: sticky;
+            top: 1.5rem;
+          }
+        }
+
+        .meetings-page-shell .meetings-list {
+          padding: 0;
+        }
+
+        .meetings-page-shell .empty-state {
+          padding: 48px 20px;
+          text-align: center;
+          font-size: 13px;
+          color: var(--th-text-muted);
+        }
+
+        .meetings-page-shell .meeting-item {
+          width: 100%;
+          padding: 14px 16px;
+          text-align: left;
+          background: transparent;
+          border-bottom: 1px solid color-mix(
+            in srgb,
+            var(--th-border) 62%,
+            transparent
+          );
+          transition: background 0.12s ease, border-color 0.12s ease;
+        }
+
+        .meetings-page-shell .meeting-item:last-child {
+          border-bottom: 0;
+        }
+
+        .meetings-page-shell .meeting-item:hover {
+          background: color-mix(in srgb, var(--th-bg-surface) 76%, transparent);
+        }
+
+        .meetings-page-shell .meeting-item.active {
+          background: color-mix(
+            in srgb,
+            var(--th-accent-primary-soft) 38%,
+            transparent
+          );
+        }
+
+        .meetings-page-shell .mi-head {
+          display: flex;
+          align-items: flex-start;
+          justify-content: space-between;
+          gap: 12px;
+        }
+
+        .meetings-page-shell .mi-title {
+          font-size: 13.5px;
+          font-weight: 600;
+          letter-spacing: -0.1px;
+          line-height: 1.3;
+          color: var(--th-text-heading);
+        }
+
+        .meetings-page-shell .mi-meta {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 8px;
+          margin-top: 8px;
+          font-size: 11.5px;
+          color: var(--th-text-muted);
+          font-variant-numeric: tabular-nums;
+        }
+
+        .meetings-page-shell .mono {
+          font-family: var(--font-mono);
+        }
+
+        .meetings-page-shell .mi-summary {
+          margin-top: 8px;
+          display: -webkit-box;
+          overflow: hidden;
+          font-size: 12.5px;
+          line-height: 1.55;
+          color: var(--th-text-muted);
+          -webkit-box-orient: vertical;
+          -webkit-line-clamp: 2;
+        }
+
+        .meetings-page-shell .mi-foot {
+          margin-top: 12px;
+          display: flex;
+          flex-wrap: wrap;
+          gap: 8px;
+        }
+
+        .meetings-page-shell .detail-column {
+          display: grid;
+          gap: 14px;
+          align-content: start;
+        }
+
+        .meetings-page-shell .meeting-detail,
+        .meetings-page-shell .meeting-workbench,
+        .meetings-page-shell .skill-rail {
+          padding: 16px;
+        }
+
+        .meetings-page-shell .md-head,
+        .meetings-page-shell .section-head {
+          display: flex;
+          align-items: flex-start;
+          justify-content: space-between;
+          gap: 12px;
+        }
+
+        .meetings-page-shell .section-kicker {
+          font-size: 10px;
+          font-weight: 600;
+          letter-spacing: 0.16em;
+          text-transform: uppercase;
+          color: var(--th-text-muted);
+        }
+
+        .meetings-page-shell .section-title {
+          margin-top: 8px;
+          font-size: 18px;
+          font-weight: 600;
+          letter-spacing: -0.2px;
+          color: var(--th-text-heading);
+        }
+
+        .meetings-page-shell .section-copy {
+          margin-top: 8px;
+          font-size: 13px;
+          line-height: 1.65;
+          color: var(--th-text-muted);
+        }
+
+        .meetings-page-shell .section-icon {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 40px;
+          height: 40px;
+          flex: 0 0 auto;
+          border-radius: 16px;
+          border: 1px solid
+            color-mix(in srgb, var(--th-accent-info) 28%, var(--th-border) 72%);
+          background: color-mix(in srgb, var(--th-accent-info) 14%, transparent);
+          color: var(--th-accent-info);
+        }
+
+        .meetings-page-shell .md-title {
+          margin-top: 8px;
+          font-size: 18px;
+          font-weight: 600;
+          letter-spacing: -0.2px;
+          color: var(--th-text-heading);
+        }
+
+        .meetings-page-shell .md-status-row {
+          margin-top: 6px;
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          gap: 8px;
+        }
+
+        .meetings-page-shell .md-status-copy {
+          font-size: 11px;
+          color: var(--th-text-muted);
+        }
+
+        .meetings-page-shell .md-toolbar {
+          display: flex;
+          gap: 6px;
+          flex-wrap: wrap;
+          justify-content: flex-end;
+        }
+
+        .meetings-page-shell .md-meta-row {
+          display: grid;
+          gap: 10px;
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+          margin-top: 14px;
+        }
+
+        @media (min-width: 768px) {
+          .meetings-page-shell .md-meta-row {
+            grid-template-columns: repeat(4, minmax(0, 1fr));
+          }
+        }
+
+        .meetings-page-shell .md-meta {
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+          min-width: 0;
+          padding: 12px 13px;
+          border-radius: 14px;
+          border: 1px solid color-mix(in srgb, var(--th-border) 70%, transparent);
+          background: color-mix(in srgb, var(--th-bg-surface) 90%, transparent);
+        }
+
+        .meetings-page-shell .md-meta > span:first-child {
+          font-size: 10px;
+          font-weight: 600;
+          letter-spacing: 0.14em;
+          text-transform: uppercase;
+          color: var(--th-text-muted);
+        }
+
+        .meetings-page-shell .md-meta b {
+          font-size: 13px;
+          font-weight: 600;
+          color: var(--th-text-heading);
+        }
+
+        .meetings-page-shell .md-meta-stack {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 6px;
+        }
+
+        .meetings-page-shell .md-attendees {
+          display: flex;
+          align-items: center;
+          min-height: 22px;
+          padding-left: 6px;
+        }
+
+        .meetings-page-shell .md-attendee {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 22px;
+          height: 22px;
+          flex: 0 0 auto;
+          border-radius: 999px;
+          border: 1px solid color-mix(in srgb, var(--th-border) 70%, transparent);
+          background: color-mix(in srgb, var(--th-card-bg) 94%, transparent);
+          color: var(--th-text-secondary);
+          font-size: 9.5px;
+          font-weight: 700;
+          letter-spacing: 0.02em;
+          box-shadow: 0 0 0 1px color-mix(in srgb, var(--th-card-bg) 96%, transparent);
+        }
+
+        .meetings-page-shell .md-attendee-count {
+          width: auto;
+          min-width: 24px;
+          padding: 0 6px;
+          font-size: 10px;
+        }
+
+        .meetings-page-shell .md-section {
+          margin-top: 16px;
+        }
+
+        .meetings-page-shell .md-section-head {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          font-size: 11px;
+          font-weight: 600;
+          letter-spacing: 0.14em;
+          text-transform: uppercase;
+          color: var(--th-text-muted);
+        }
+
+        .meetings-page-shell .md-inline-note {
+          font-size: 10px;
+          font-weight: 500;
+          letter-spacing: normal;
+          text-transform: none;
+          color: var(--th-text-muted);
+        }
+
+        .meetings-page-shell .md-copy,
+        .meetings-page-shell .md-empty-copy {
+          margin-top: 10px;
+          font-size: 13px;
+          line-height: 1.65;
+          color: var(--th-text-muted);
+        }
+
+        .meetings-page-shell .md-actions {
+          margin-top: 10px;
+          display: grid;
+          gap: 8px;
+        }
+
+        .meetings-page-shell .md-action {
+          display: flex;
+          align-items: flex-start;
+          gap: 10px;
+          padding: 10px 11px;
+          border-radius: 14px;
+          border: 1px solid color-mix(in srgb, var(--th-border) 68%, transparent);
+          background: color-mix(in srgb, var(--th-bg-surface) 88%, transparent);
+        }
+
+        .meetings-page-shell .md-action-check {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 18px;
+          height: 18px;
+          margin-top: 2px;
+          flex: 0 0 auto;
+          border-radius: 999px;
+          border: 1px solid color-mix(in srgb, var(--th-border) 68%, transparent);
+          background: color-mix(in srgb, var(--th-card-bg) 92%, transparent);
+          color: var(--th-text-muted);
+        }
+
+        .meetings-page-shell .md-action-check.created {
+          color: var(--th-accent-success);
+          border-color: color-mix(
+            in srgb,
+            var(--th-accent-success) 30%,
+            var(--th-border) 70%
+          );
+        }
+
+        .meetings-page-shell .md-action-check.pending {
+          color: var(--th-accent-warn);
+          border-color: color-mix(
+            in srgb,
+            var(--th-accent-warn) 30%,
+            var(--th-border) 70%
+          );
+        }
+
+        .meetings-page-shell .md-action-check.failed {
+          color: var(--th-accent-danger);
+          border-color: color-mix(
+            in srgb,
+            var(--th-accent-danger) 30%,
+            var(--th-border) 70%
+          );
+        }
+
+        .meetings-page-shell .md-action-check.discarded {
+          color: var(--th-text-muted);
+        }
+
+        .meetings-page-shell .md-action-copy {
+          min-width: 0;
+          flex: 1;
+        }
+
+        .meetings-page-shell .md-action-title {
+          font-size: 12.5px;
+          font-weight: 600;
+          line-height: 1.5;
+          color: var(--th-text-heading);
+        }
+
+        .meetings-page-shell .md-action-title.created,
+        .meetings-page-shell .md-action-title.discarded {
+          color: var(--th-text-muted);
+          text-decoration: line-through;
+        }
+
+        .meetings-page-shell .md-action-sub {
+          margin-top: 3px;
+          font-size: 12px;
+          line-height: 1.5;
+          color: var(--th-text-muted);
+        }
+
+        .meetings-page-shell .md-transcript {
+          margin-top: 10px;
+          display: grid;
+          gap: 8px;
+        }
+
+        .meetings-page-shell .md-transcript-line {
+          display: flex;
+          align-items: flex-start;
+          gap: 10px;
+          padding: 10px 11px;
+          border-radius: 14px;
+          border: 1px solid color-mix(in srgb, var(--th-border) 68%, transparent);
+          background: color-mix(in srgb, var(--th-card-bg) 92%, transparent);
+        }
+
+        .meetings-page-shell .md-who {
+          min-width: 72px;
+          flex: 0 0 auto;
+          font-size: 11px;
+          font-weight: 600;
+          letter-spacing: 0.12em;
+          text-transform: uppercase;
+          color: var(--th-text-muted);
+        }
+
+        .meetings-page-shell .md-said {
+          min-width: 0;
+          flex: 1;
+          font-size: 12.5px;
+          line-height: 1.55;
+          color: var(--th-text-muted);
+        }
+
+        .meetings-page-shell .workbench-meta {
+          margin-top: 12px;
+          display: flex;
+          flex-wrap: wrap;
+          gap: 8px;
+        }
+
+        .meetings-page-shell .workbench-shell {
+          margin-top: 14px;
+          min-width: 0;
         }
       `}</style>
 
-      <SurfaceSection
-        eyebrow={t({ ko: "Meetings", en: "Meetings" })}
-        title={t({ ko: "회의 + 스킬 허브", en: "Meetings + Skills Hub" })}
-        description={t({
-          ko: "회의 기록 타임라인과 스킬 카탈로그를 한 화면에 묶은 Phase 2 통합 보기입니다.",
-          en: "Phase 2 combines the meeting timeline and skill catalog into a single workspace view.",
-        })}
-        badge={t({
-          ko: `${meetings.length}개 회의`,
-          en: `${meetings.length} meetings`,
-        })}
-        className="rounded-[28px] p-4 sm:p-5"
-        style={{
-          borderColor:
-            "color-mix(in srgb, var(--th-accent-success) 18%, var(--th-border) 82%)",
-          background:
-            "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, var(--th-accent-success) 4%) 0%, color-mix(in srgb, var(--th-bg-surface) 98%, transparent) 100%)",
-        }}
-      >
-        <div className="mt-4 flex flex-wrap gap-3">
-          <SurfaceMetricPill
-            label={t({ ko: "전체 회의", en: "Total Meetings" })}
-            value={t({
-              ko: `${meetings.length}건`,
-              en: `${meetings.length} records`,
-            })}
-            tone="info"
-          />
-          <SurfaceMetricPill
-            label={t({ ko: "활성 회의", en: "Active" })}
-            value={t({
-              ko: `${meetingSummary.activeCount}건 진행 중`,
-              en: `${meetingSummary.activeCount} in progress`,
-            })}
-            tone={meetingSummary.activeCount > 0 ? "accent" : "neutral"}
-          />
-          <SurfaceMetricPill
-            label={t({ ko: "완료 회의", en: "Completed" })}
-            value={t({
-              ko: `${completedCount}건`,
-              en: `${completedCount} records`,
-            })}
-            tone="success"
-          />
-          <SurfaceMetricPill
-            label={t({ ko: "후속 이슈", en: "Open Follow-ups" })}
-            value={t({
-              ko: `${meetingSummary.unresolvedCount}건 미해결`,
-              en: `${meetingSummary.unresolvedCount} unresolved`,
-            })}
-            tone={meetingSummary.unresolvedCount > 0 ? "warn" : "neutral"}
-          />
-        </div>
-
-        <SurfaceNotice tone="info" className="mt-4">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <div className="min-w-0">
-              <div
-                className="text-xs font-semibold uppercase tracking-[0.16em]"
-                style={{ color: "var(--th-accent-info)" }}
-              >
-                {t({ ko: "Read Only", en: "Read Only" })}
-              </div>
-              <div className="mt-1 text-sm leading-6">
-                {t({
-                  ko: "이 화면은 회의 흐름과 스킬 문서를 함께 훑는 읽기 전용 허브입니다. 회의 상세 보기 드로어는 유지되지만 생성·폐기·삭제 같은 변경 액션은 숨깁니다.",
-                  en: "This page is a read-only hub for reviewing meeting flow alongside skill docs. The meeting detail drawer stays available, while create, discard, and delete actions stay hidden.",
-                })}
-              </div>
+      <div className="page fade-in meetings-page-shell">
+        <div className="page-header">
+          <div className="min-w-0">
+            <div className="page-title">{t({ ko: "회의록", en: "Meetings" })}</div>
+            <div className="page-sub">
+              {t({
+                ko: "회의 기록·요약·후속 액션을 칸반과 연동합니다",
+                en: "Meeting records, summaries, and follow-ups stay linked to kanban.",
+              })}
             </div>
           </div>
-        </SurfaceNotice>
+          <button type="button" onClick={handleLaunchMeeting} className="btn primary">
+            <Plus size={14} />
+            {t({ ko: "새 회의 기록", en: "New Meeting Record" })}
+          </button>
+        </div>
 
         {!isDesktopSplit && (
-          <div className="mt-4 flex gap-2">
-          <SurfaceSegmentButton
-            active={mobilePane === "meetings"}
-            tone="success"
-            onClick={() => setMobilePane("meetings")}
-            className="flex-1 text-center"
+          <div
+            className="meeting-pane-tabs"
+            aria-label={t({ ko: "회의 및 스킬 보기", en: "Meetings and skills views" })}
           >
-            <span className="inline-flex items-center gap-1.5">
-              <MessagesSquare size={14} />
+            <button
+              type="button"
+              className={`meeting-pane-tab ${mobilePane === "meetings" ? "active" : ""}`}
+              aria-pressed={mobilePane === "meetings"}
+              onClick={() => setMobilePane("meetings")}
+            >
               {t({ ko: "회의", en: "Meetings" })}
-            </span>
-          </SurfaceSegmentButton>
-          <SurfaceSegmentButton
-            active={mobilePane === "skills"}
-            tone="info"
-            onClick={() => setMobilePane("skills")}
-            className="flex-1 text-center"
-          >
-            <span className="inline-flex items-center gap-1.5">
-              <BookOpen size={14} />
+            </button>
+            <button
+              type="button"
+              className={`meeting-pane-tab ${mobilePane === "skills" ? "active" : ""}`}
+              aria-pressed={mobilePane === "skills"}
+              onClick={() => setMobilePane("skills")}
+            >
               {t({ ko: "스킬", en: "Skills" })}
-            </span>
-          </SurfaceSegmentButton>
+            </button>
           </div>
         )}
-      </SurfaceSection>
 
-      {isDesktopSplit ? (
-        <div className="mt-5 grid min-w-0 gap-5 lg:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)] lg:items-start">
-          <div className="min-w-0">{renderMeetingsPanel()}</div>
-          <div className="min-w-0">{renderSkillsPanel()}</div>
-        </div>
-      ) : (
-        <div className="mt-5 space-y-5">
-          {mobilePane === "meetings"
-            ? renderMeetingsPanel()
-            : renderSkillsPanel()}
-        </div>
-      )}
+        {(isDesktopSplit || mobilePane === "meetings") && (
+          <div className="meetings-split">
+            {meetingListCard}
+            {isDesktopSplit ? desktopDetailColumn : mobileDetailColumn}
+          </div>
+        )}
+
+        {!isDesktopSplit && mobilePane === "skills" && skillRailCard}
+      </div>
     </div>
   );
 }

--- a/dashboard/src/components/OfficeSelectorBar.tsx
+++ b/dashboard/src/components/OfficeSelectorBar.tsx
@@ -26,18 +26,25 @@ export default function OfficeSelectorBar({
 
   return (
     <div
-      className="flex items-center gap-1.5 px-3 py-2 overflow-x-auto shrink-0"
+      className="flex items-center gap-1.5 overflow-x-auto px-4 py-2 shrink-0"
       style={{
-        borderBottom: "1px solid var(--th-card-border)",
-        background: "var(--th-bg-surface)",
+        borderBottom:
+          "1px solid color-mix(in srgb, var(--th-border) 68%, transparent)",
+        background:
+          "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 94%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 88%, transparent) 100%)",
       }}
     >
       <button
         onClick={() => onSelectOffice(null)}
-        className="px-2.5 py-1 rounded-md text-xs font-medium whitespace-nowrap transition-all"
+        className="whitespace-nowrap rounded-full px-2.5 py-1 text-xs font-medium transition-all"
         style={
           selectedOfficeId === null
-            ? { background: "var(--th-accent-primary)", color: "white" }
+            ? {
+                background: "var(--th-accent-primary-soft)",
+                color: "var(--th-accent-primary)",
+                border:
+                  "1px solid color-mix(in srgb, var(--th-accent-primary) 28%, var(--th-border) 72%)",
+              }
             : inactiveButtonStyle
         }
       >
@@ -48,10 +55,14 @@ export default function OfficeSelectorBar({
         <button
           key={o.id}
           onClick={() => onSelectOffice(o.id)}
-          className="px-2.5 py-1 rounded-md text-xs font-medium whitespace-nowrap transition-all flex items-center gap-1"
+          className="flex items-center gap-1 whitespace-nowrap rounded-full px-2.5 py-1 text-xs font-medium transition-all"
           style={
             selectedOfficeId === o.id
-              ? { background: o.color }
+              ? {
+                  background: `color-mix(in srgb, ${o.color} 18%, var(--th-card-bg) 82%)`,
+                  color: o.color,
+                  border: `1px solid color-mix(in srgb, ${o.color} 28%, var(--th-border) 72%)`,
+                }
               : inactiveButtonStyle
           }
         >
@@ -74,10 +85,10 @@ export default function OfficeSelectorBar({
 
       <button
         onClick={onManageOffices}
-        className="ml-auto p-1.5 rounded-md transition-colors shrink-0"
+        className="ml-auto shrink-0 rounded-full p-1.5 transition-colors"
         style={{
           color: "var(--th-text-muted)",
-          background: "color-mix(in srgb, var(--th-bg-surface) 90%, transparent)",
+          background: "color-mix(in srgb, var(--th-card-bg) 90%, transparent)",
           border: "1px solid color-mix(in srgb, var(--th-border) 70%, transparent)",
         }}
         title={isKo ? "오피스 관리" : "Manage Offices"}

--- a/dashboard/src/components/OfficeView.tsx
+++ b/dashboard/src/components/OfficeView.tsx
@@ -33,8 +33,10 @@ import {
 import {
   SurfaceActionButton,
   SurfaceCard,
+  SurfaceMetricPill,
   SurfaceNotice,
   SurfaceSection,
+  SurfaceSubsection,
 } from "./common/SurfacePrimitives";
 
 interface OfficeViewProps {
@@ -98,6 +100,16 @@ function computeMeetingPresence(
   return result.length > 0 ? result : undefined;
 }
 
+function formatOfficeClock(language: UiLanguage): string {
+  const locale = language === "ko" ? "ko-KR" : "en-US";
+  return new Intl.DateTimeFormat(locale, {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).format(new Date());
+}
+
 export default function OfficeView({
   agents,
   departments,
@@ -117,6 +129,10 @@ export default function OfficeView({
     if (typeof window === "undefined") return false;
     return window.matchMedia(MOBILE_LAYOUT_MEDIA_QUERY).matches;
   });
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
+  const [officeMode, setOfficeMode] = useState<"office" | "list" | "flow">("office");
+  const sceneSectionRef = useRef<HTMLDivElement | null>(null);
+  const railSectionRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const media = window.matchMedia(MOBILE_LAYOUT_MEDIA_QUERY);
@@ -212,6 +228,10 @@ export default function OfficeView({
     () => new Set(manualInterventionByAgent.keys()),
     [manualInterventionByAgent],
   );
+  const selectedAgent = useMemo(
+    () => agents.find((agent) => agent.id === selectedAgentId) ?? null,
+    [agents, selectedAgentId],
+  );
   dataRef.current = {
     departments,
     agents,
@@ -223,6 +243,29 @@ export default function OfficeView({
     activeIssueByAgent,
     blockedAgentIds,
   };
+
+  useEffect(() => {
+    if (!selectedAgentId) return;
+    if (!agents.some((agent) => agent.id === selectedAgentId)) {
+      setSelectedAgentId(null);
+    }
+  }, [agents, selectedAgentId]);
+
+  const handleSelectAgent = useCallback((agent: Agent) => {
+    setSelectedAgentId(agent.id);
+    setOfficeMode("list");
+    onSelectAgent?.(agent);
+  }, [onSelectAgent]);
+
+  const handleModeChange = useCallback((mode: "office" | "list" | "flow") => {
+    setOfficeMode(mode);
+    if (mode === "flow") {
+      onNavigateToKanban?.();
+      return;
+    }
+    const target = mode === "office" ? sceneSectionRef.current : railSectionRef.current;
+    target?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, [onNavigateToKanban]);
 
   useEffect(() => {
     const handler = (event: Event) => {
@@ -272,11 +315,11 @@ export default function OfficeView({
   }, []);
 
   const cbRef = useRef<CallbackSnapshot>({
-    onSelectAgent: onSelectAgent ?? (() => {}),
+    onSelectAgent: handleSelectAgent,
     onSelectDepartment: onSelectDepartment ?? (() => {}),
   });
   cbRef.current = {
-    onSelectAgent: onSelectAgent ?? (() => {}),
+    onSelectAgent: handleSelectAgent,
     onSelectDepartment: onSelectDepartment ?? (() => {}),
   };
 
@@ -448,53 +491,194 @@ export default function OfficeView({
         ),
     [agents, manualInterventionByAgent, sceneRevision],
   );
+  const workingSeatCount = useMemo(
+    () => Array.from(seatStatusByAgent.values()).filter((status) => status === "working").length,
+    [seatStatusByAgent],
+  );
+  const reviewSeatCount = useMemo(
+    () => Array.from(seatStatusByAgent.values()).filter((status) => status === "review").length,
+    [seatStatusByAgent],
+  );
+  const manualCount = manualInterventionByAgent.size;
+  const liveClockLabel = useMemo(
+    () => formatOfficeClock(language),
+    [elapsedTick, language],
+  );
+  const selectedAgentLabel = selectedAgent?.alias || selectedAgent?.name_ko || selectedAgent?.name;
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col sm:flex-row sm:gap-3">
-      <div className="relative min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden">
-        {/* Mobile: status-only Office Lite */}
-        <div className="sm:hidden">
-          <OfficeInsightPanel
-            agents={agents}
-            notifications={notifications}
-            auditLogs={auditLogs}
-            kanbanCards={kanbanCards}
-            onNavigateToKanban={onNavigateToKanban}
-            isKo={isKo}
-            onSelectAgent={onSelectAgent}
-          />
-          <MobileAgentStatusGrid
-            agents={agents}
-            isKo={isKo}
-            onSelectAgent={onSelectAgent}
-            manualInterventionByAgent={manualInterventionByAgent}
-            primaryCardByAgent={primaryCardByAgent}
-            seatStatusByAgent={seatStatusByAgent}
-          />
+    <div
+      className="mx-auto h-full w-full max-w-6xl min-w-0 overflow-x-hidden overflow-y-auto p-4 pb-40 sm:p-6"
+      style={{ paddingBottom: "max(10rem, calc(10rem + env(safe-area-inset-bottom)))" }}
+    >
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div className="min-w-0">
+            <h2 className="text-[1.65rem] font-semibold tracking-tight" style={{ color: "var(--th-text)" }}>
+              {isKo ? "오피스" : "Office"}
+            </h2>
+            <p className="mt-1 text-sm leading-6" style={{ color: "var(--th-text-muted)" }}>
+              {isKo
+                ? "에이전트가 지금 하고 있는 일을 공간적으로 확인합니다."
+                : "See what agents are working on in a spatial office view."}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-[11px] font-medium"
+              style={{
+                borderColor: "color-mix(in srgb, var(--th-accent-primary) 24%, var(--th-border) 76%)",
+                background: "color-mix(in srgb, var(--th-badge-emerald-bg) 54%, var(--th-card-bg) 46%)",
+                color: "var(--th-text-primary)",
+              }}
+            >
+              <span className="h-2 w-2 rounded-full" style={{ background: "var(--th-accent-primary)" }} />
+              {`live · ${liveClockLabel}`}
+            </span>
+            <div
+              className="inline-flex items-center rounded-[14px] border p-1"
+              style={{
+                borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)",
+                background: "color-mix(in srgb, var(--th-card-bg) 90%, transparent)",
+              }}
+            >
+              <OfficeModeButton
+                active={officeMode === "office"}
+                onClick={() => handleModeChange("office")}
+              >
+                {isKo ? "오피스" : "Office"}
+              </OfficeModeButton>
+              <OfficeModeButton
+                active={officeMode === "list"}
+                onClick={() => handleModeChange("list")}
+              >
+                {isKo ? "리스트" : "List"}
+              </OfficeModeButton>
+              <OfficeModeButton
+                active={officeMode === "flow"}
+                disabled={!onNavigateToKanban}
+                onClick={() => handleModeChange("flow")}
+              >
+                {isKo ? "플로우" : "Flow"}
+              </OfficeModeButton>
+            </div>
+          </div>
         </div>
-        {/* Desktop: full Pixi office */}
-        <div className="relative hidden w-full min-h-full pb-40 sm:block">
-          <div ref={containerRef} className="w-full min-h-full" style={{ imageRendering: "pixelated" }} />
-          <OfficeManualWarningOverlay
-            entries={manualWarningEntries}
-            isKo={isKo}
-            onSelectAgent={onSelectAgent}
-          />
+
+        <div className="grid min-w-0 gap-4 xl:grid-cols-[minmax(0,1fr)_20rem]">
+          <div ref={sceneSectionRef} className="min-w-0">
+            <SurfaceCard
+              className="overflow-hidden rounded-[28px] p-0"
+              style={{
+                borderColor: "color-mix(in srgb, var(--th-border) 64%, transparent)",
+                background:
+                  "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 72%, #0d1420 28%) 0%, color-mix(in srgb, var(--th-bg-surface) 82%, #090d16 18%) 100%)",
+              }}
+            >
+              {isMobileLite ? (
+                <div className="px-3 pb-3 pt-4">
+                  <MobileAgentStatusGrid
+                    agents={agents}
+                    isKo={isKo}
+                    onSelectAgent={handleSelectAgent}
+                    manualInterventionByAgent={manualInterventionByAgent}
+                    primaryCardByAgent={primaryCardByAgent}
+                    seatStatusByAgent={seatStatusByAgent}
+                  />
+                </div>
+              ) : (
+                <div className="relative min-h-[28.75rem] overflow-hidden">
+                  <div ref={containerRef} className="min-h-[28.75rem] w-full" style={{ imageRendering: "pixelated" }} />
+                  <OfficeManualWarningOverlay
+                    entries={manualWarningEntries}
+                    isKo={isKo}
+                    onSelectAgent={handleSelectAgent}
+                  />
+                </div>
+              )}
+              <div
+                className="flex flex-wrap items-center gap-4 border-t px-4 py-3 text-[11px]"
+                style={{
+                  borderColor: "color-mix(in srgb, var(--th-border) 62%, transparent)",
+                  color: "var(--th-text-muted)",
+                }}
+              >
+                <span className="inline-flex items-center gap-2">
+                  <span className="inline-block h-2 w-2 rounded-full" style={{ background: "var(--th-accent-primary)" }} />
+                  {isKo ? "작업 중" : "Working"}
+                </span>
+                <span className="inline-flex items-center gap-2">
+                  <span className="inline-block h-2 w-2 rounded-full" style={{ background: "var(--th-accent-warn)" }} />
+                  {isKo ? "리뷰" : "Review"}
+                </span>
+                <span className="inline-flex items-center gap-2">
+                  <span className="inline-block h-2 w-2 rounded-full" style={{ background: "var(--th-text-muted)" }} />
+                  {isKo ? "대기" : "Idle"}
+                </span>
+                {activeMeeting ? (
+                  <span className="inline-flex items-center gap-2">
+                    <span className="inline-block h-2 w-2 rounded-full" style={{ background: "var(--th-accent-info)" }} />
+                    {isKo ? `회의 · ${activeMeeting.agenda}` : `Meeting · ${activeMeeting.agenda}`}
+                  </span>
+                ) : null}
+                <span className="ml-auto text-right" style={{ color: "var(--th-text-faint)" }}>
+                  {selectedAgentLabel
+                    ? (isKo ? `${selectedAgentLabel} 상세 보기` : `${selectedAgentLabel} selected`)
+                    : (isKo ? "클릭해서 상세 보기" : "Click to inspect details")}
+                </span>
+              </div>
+            </SurfaceCard>
+          </div>
+
+          <div ref={railSectionRef} className="min-w-0">
+            <OfficeInsightPanel
+              agents={agents}
+              notifications={notifications}
+              auditLogs={auditLogs}
+              kanbanCards={kanbanCards}
+              onNavigateToKanban={onNavigateToKanban}
+              isKo={isKo}
+              onSelectAgent={handleSelectAgent}
+              selectedAgent={selectedAgent}
+              onClearSelectedAgent={() => setSelectedAgentId(null)}
+              activeMeeting={activeMeeting}
+              manualInterventionByAgent={manualInterventionByAgent}
+              primaryCardByAgent={primaryCardByAgent}
+              seatStatusByAgent={seatStatusByAgent}
+              docked
+            />
+          </div>
         </div>
-      </div>
-      <div className="hidden min-h-0 sm:block sm:h-full sm:w-[min(22rem,calc(100vw-1.5rem))] sm:shrink-0 sm:overflow-y-auto">
-        <OfficeInsightPanel
-          agents={agents}
-          notifications={notifications}
-          auditLogs={auditLogs}
-          kanbanCards={kanbanCards}
-          onNavigateToKanban={onNavigateToKanban}
-          isKo={isKo}
-          onSelectAgent={onSelectAgent}
-          docked
-        />
       </div>
     </div>
+  );
+}
+
+function OfficeModeButton({
+  active,
+  disabled = false,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+  children: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="rounded-[10px] px-3 py-1.5 text-[12px] font-medium transition-colors"
+      style={{
+        background: active ? "color-mix(in srgb, var(--th-bg-surface) 88%, transparent)" : "transparent",
+        color: active ? "var(--th-text)" : "var(--th-text-muted)",
+        opacity: disabled ? 0.55 : 1,
+      }}
+    >
+      {children}
+    </button>
   );
 }
 
@@ -503,36 +687,40 @@ export default function OfficeView({
 function getSeatStatusMeta(
   status: OfficeSeatStatus,
   isKo: boolean,
-): { label: string; color: string; background: string; border: string } {
+): { label: string; accent: string; textColor: string; background: string; border: string } {
   switch (status) {
     case "working":
       return {
         label: isKo ? "작업 중" : "Working",
-        color: "var(--ok)",
-        background: "color-mix(in oklch, var(--ok) 12%, var(--bg-2) 88%)",
-        border: "color-mix(in oklch, var(--ok) 28%, var(--line) 72%)",
+        accent: "var(--th-accent-primary)",
+        textColor: "var(--th-text-primary)",
+        background: "color-mix(in srgb, var(--th-badge-emerald-bg) 62%, var(--th-card-bg) 38%)",
+        border: "color-mix(in srgb, var(--th-accent-primary) 22%, var(--th-border) 78%)",
       };
     case "review":
       return {
         label: isKo ? "검토 중" : "In review",
-        color: "var(--warn)",
-        background: "color-mix(in oklch, var(--warn) 12%, var(--bg-2) 88%)",
-        border: "color-mix(in oklch, var(--warn) 28%, var(--line) 72%)",
+        accent: "var(--th-accent-warn)",
+        textColor: "var(--th-accent-warn)",
+        background: "color-mix(in srgb, var(--th-badge-amber-bg) 62%, var(--th-card-bg) 38%)",
+        border: "color-mix(in srgb, var(--th-accent-warn) 22%, var(--th-border) 78%)",
       };
     case "offline":
       return {
         label: isKo ? "오프라인" : "Offline",
-        color: "var(--fg-faint)",
-        background: "color-mix(in oklch, var(--fg-faint) 12%, var(--bg-2) 88%)",
-        border: "color-mix(in oklch, var(--fg-faint) 24%, var(--line) 76%)",
+        accent: "var(--th-text-muted)",
+        textColor: "var(--th-text-muted)",
+        background: "color-mix(in srgb, var(--th-bg-surface) 94%, transparent)",
+        border: "color-mix(in srgb, var(--th-border) 72%, transparent)",
       };
     case "idle":
     default:
       return {
         label: isKo ? "대기" : "Idle",
-        color: "var(--fg-muted)",
-        background: "color-mix(in oklch, var(--fg-muted) 12%, var(--bg-2) 88%)",
-        border: "color-mix(in oklch, var(--fg-muted) 24%, var(--line) 76%)",
+        accent: "var(--th-text-muted)",
+        textColor: "var(--th-text-muted)",
+        background: "color-mix(in srgb, var(--th-bg-surface) 94%, transparent)",
+        border: "color-mix(in srgb, var(--th-border) 72%, transparent)",
       };
   }
 }
@@ -572,6 +760,7 @@ function OfficeManualWarningOverlay({
     <div className="pointer-events-none absolute inset-0 z-10">
       {entries.map(({ agent, warning, position }) => {
         const isOpen = hoveredWarningId === warning.cardId || expandedWarningId === warning.cardId;
+        const agentLabel = agent.alias || agent.name_ko || agent.name;
         return (
           <div
             key={warning.cardId}
@@ -597,16 +786,16 @@ function OfficeManualWarningOverlay({
           >
           <button
             type="button"
-            className="relative flex min-h-7 items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-semibold shadow-sm transition hover:scale-[1.04] focus:outline-none focus:ring-2"
+            className="relative inline-flex min-h-8 items-center gap-1.5 rounded-full border px-2.5 py-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] transition-colors focus:outline-none focus:ring-2"
             style={{
-              color: "var(--warn)",
-              borderColor: "color-mix(in oklch, var(--warn) 28%, var(--line) 72%)",
-              background: "color-mix(in oklch, var(--warn) 14%, var(--bg-2) 86%)",
+              color: "var(--th-accent-warn)",
+              borderColor: "color-mix(in srgb, var(--th-accent-warn) 24%, var(--th-border) 76%)",
+              background: "color-mix(in srgb, var(--th-badge-amber-bg) 72%, var(--th-card-bg) 28%)",
             }}
             aria-label={
               isKo
-                ? `${agent.alias || agent.name_ko || agent.name} 수동 개입 경고`
-                : `${agent.alias || agent.name} manual intervention warning`
+                ? `${agentLabel} 수동 개입 경고`
+                : `${agentLabel} manual intervention warning`
             }
             aria-expanded={isOpen}
             onClick={() =>
@@ -617,39 +806,26 @@ function OfficeManualWarningOverlay({
               aria-hidden="true"
               className="absolute -bottom-1 left-1/2 h-2 w-2 -translate-x-1/2 rotate-45 border-b border-r"
               style={{
-                borderColor: "color-mix(in oklch, var(--warn) 28%, var(--line) 72%)",
-                background: "color-mix(in oklch, var(--warn) 14%, var(--bg-2) 86%)",
+                borderColor: "color-mix(in srgb, var(--th-accent-warn) 24%, var(--th-border) 76%)",
+                background: "color-mix(in srgb, var(--th-badge-amber-bg) 72%, var(--th-card-bg) 28%)",
               }}
             />
-            <span aria-hidden="true">&lt;!&gt;</span>
+            <span
+              aria-hidden="true"
+              className="h-1.5 w-1.5 rounded-full"
+              style={{ background: "var(--th-accent-warn)" }}
+            />
+            <span>{isKo ? "수동" : "Manual"}</span>
           </button>
           {isOpen && (
-            <SurfaceCard
-              className="absolute bottom-[calc(100%+0.55rem)] left-1/2 z-10 w-[min(18rem,calc(100vw-1.5rem))] -translate-x-1/2 rounded-[22px] px-3 py-3 shadow-xl"
-              style={{
-                borderColor: "color-mix(in oklch, var(--warn) 26%, var(--line) 74%)",
-                background: "color-mix(in oklch, var(--warn) 8%, var(--bg-2) 92%)",
-              }}
-            >
-              <div className="text-[11px] font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--warn)" }}>
-                {isKo ? "수동 개입" : "Manual intervention"}
-              </div>
-              <div className="mt-1 text-sm font-semibold" style={{ color: "var(--fg)" }}>
-                {warning.title}
-              </div>
-              <div
-                className="mt-2 break-words whitespace-pre-wrap text-xs leading-5"
-                style={{ color: "var(--fg-muted)" }}
-              >
-                {warning.reason
-                  ?? (isKo
-                    ? "구체 사유는 카드 상세에서 확인할 수 있습니다."
-                    : "Open the detail drawer to inspect the full reason.")}
-              </div>
-              <div className="mt-3 flex items-center justify-between gap-2">
-                <span className="text-[11px]" style={{ color: "var(--fg-faint)" }}>
-                  {warning.issueNumber ? `#${warning.issueNumber}` : warning.status}
-                </span>
+            <SurfaceSubsection
+              title={warning.title}
+              description={
+                isKo
+                  ? `${agentLabel}에게 연결된 카드에서 수동 개입이 필요합니다.`
+                  : `Manual intervention is required for the card assigned to ${agentLabel}.`
+              }
+              actions={(
                 <SurfaceActionButton
                   tone="warn"
                   compact
@@ -658,8 +834,47 @@ function OfficeManualWarningOverlay({
                 >
                   {isKo ? "세부 보기" : "Open detail"}
                 </SurfaceActionButton>
+              )}
+              className="absolute bottom-[calc(100%+0.65rem)] left-1/2 z-10 w-[min(19rem,calc(100vw-1.5rem))] -translate-x-1/2 rounded-[24px] p-3 sm:p-3"
+              style={{
+                borderColor: "color-mix(in srgb, var(--th-accent-warn) 22%, var(--th-border) 78%)",
+                background: "linear-gradient(180deg, color-mix(in srgb, var(--th-badge-amber-bg) 52%, var(--th-card-bg) 48%) 0%, color-mix(in srgb, var(--th-card-bg) 90%, transparent) 100%)",
+              }}
+            >
+              <div className="space-y-2">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span
+                    className="inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em]"
+                    style={{
+                      color: "var(--th-accent-warn)",
+                      borderColor: "color-mix(in srgb, var(--th-accent-warn) 22%, var(--th-border) 78%)",
+                      background: "color-mix(in srgb, var(--th-badge-amber-bg) 68%, var(--th-card-bg) 32%)",
+                    }}
+                  >
+                    {isKo ? "수동 개입" : "Manual intervention"}
+                  </span>
+                  <span className="text-[11px]" style={{ color: "var(--th-text-muted)" }}>
+                    {warning.issueNumber ? `#${warning.issueNumber}` : warning.status}
+                  </span>
+                </div>
+                <SurfaceNotice tone="warn" compact className="items-start rounded-[18px]">
+                  <div className="text-[11px] leading-5">
+                    {isKo
+                      ? "카드 상세에서 원인과 후속 조치를 확인할 수 있습니다."
+                      : "Open the card detail to inspect the cause and next action."}
+                  </div>
+                </SurfaceNotice>
               </div>
-            </SurfaceCard>
+              <div
+                className="mt-3 break-words whitespace-pre-wrap text-xs leading-5"
+                style={{ color: "var(--th-text-muted)" }}
+              >
+                {warning.reason
+                  ?? (isKo
+                    ? "구체 사유는 카드 상세에서 확인할 수 있습니다."
+                    : "Open the detail drawer to inspect the full reason.")}
+              </div>
+            </SurfaceSubsection>
           )}
           </div>
         );
@@ -716,16 +931,45 @@ function MobileAgentStatusGrid({
 
   return (
     <div className="mt-3 px-3 pb-6">
-      <SurfaceSection
-        eyebrow="Office Lite"
+      <SurfaceSubsection
         title={isKo ? "에이전트 현황" : "Agent Status"}
         description={
           isKo
             ? "수동 개입, 좌석 상태, 대표 작업을 모바일 카드로 빠르게 확인합니다."
             : "Review manual interventions, seat state, and the primary task in compact mobile cards."
         }
-        badge={isKo ? `${sorted.length}명` : `${sorted.length} agents`}
-        className="rounded-[30px] p-4 sm:p-5"
+        actions={(
+          <div className="flex flex-wrap gap-2">
+            <span
+              className="inline-flex items-center rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em]"
+              style={{
+                borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)",
+                background: "color-mix(in srgb, var(--th-bg-surface) 90%, transparent)",
+                color: "var(--th-text-muted)",
+              }}
+            >
+              {isKo ? `${sorted.length}명` : `${sorted.length} agents`}
+            </span>
+            {manualCount > 0 && (
+              <span
+                className="inline-flex items-center rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em]"
+                style={{
+                  borderColor: "color-mix(in srgb, var(--th-accent-warn) 24%, var(--th-border) 76%)",
+                  background: "color-mix(in srgb, var(--th-badge-amber-bg) 60%, var(--th-card-bg) 40%)",
+                  color: "var(--th-accent-warn)",
+                }}
+              >
+                {isKo ? `경고 ${manualCount}` : `Warnings ${manualCount}`}
+              </span>
+            )}
+          </div>
+        )}
+        className="rounded-[28px] p-4"
+        style={{
+          borderColor: "color-mix(in srgb, var(--th-border) 66%, transparent)",
+          background:
+            "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 94%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
+        }}
       >
         {manualCount > 0 && (
           <SurfaceNotice tone="warn" compact className="mt-4">
@@ -736,12 +980,15 @@ function MobileAgentStatusGrid({
             </div>
           </SurfaceNotice>
         )}
-        <div className="mt-4 grid grid-cols-2 gap-2">
+        <div className="mt-4 grid grid-cols-1 gap-2.5 min-[520px]:grid-cols-2">
         {sorted.map((agent) => {
           const status = seatStatusByAgent.get(agent.id) ?? "idle";
           const statusMeta = getSeatStatusMeta(status, isKo);
           const manualIntervention = manualInterventionByAgent.get(agent.id) ?? null;
           const primaryCard = primaryCardByAgent.get(agent.id) ?? null;
+          const agentLabel = agent.alias || agent.name_ko || agent.name;
+          const sessionLabel =
+            agent.session_info && agent.session_info !== statusMeta.label ? agent.session_info : null;
           const preview = manualIntervention?.reason
             ? previewManualReason(manualIntervention.reason)
             : previewCardTitle(primaryCard?.title ?? null);
@@ -750,11 +997,11 @@ function MobileAgentStatusGrid({
           return (
             <SurfaceCard
               key={agent.id}
-              className="rounded-[24px] px-3 py-3 text-left"
+              className="rounded-[26px] px-3.5 py-3.5 text-left"
               style={{
                 background: manualIntervention
-                  ? "color-mix(in srgb, var(--th-badge-amber-bg) 72%, var(--th-card-bg) 28%)"
-                  : "color-mix(in srgb, var(--th-card-bg) 92%, transparent)",
+                  ? "linear-gradient(180deg, color-mix(in srgb, var(--th-badge-amber-bg) 54%, var(--th-card-bg) 46%) 0%, color-mix(in srgb, var(--th-card-bg) 90%, transparent) 100%)"
+                  : "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 94%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 95%, transparent) 100%)",
                 borderColor: manualIntervention
                   ? "color-mix(in srgb, var(--th-accent-warn) 26%, var(--th-border) 74%)"
                   : "color-mix(in srgb, var(--th-border) 68%, transparent)",
@@ -762,38 +1009,64 @@ function MobileAgentStatusGrid({
             >
               <button type="button" onClick={() => onSelectAgent?.(agent)} className="w-full text-left">
                 <div className="flex items-start justify-between gap-2">
-                  <div className="flex min-w-0 items-center gap-2">
-                    <span className="text-base">{agent.avatar_emoji}</span>
-                    <span className="truncate text-xs font-medium" style={{ color: "var(--th-text)" }}>
-                      {agent.alias || agent.name_ko || agent.name}
+                  <div className="flex min-w-0 items-start gap-2.5">
+                    <span
+                      className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-2xl border text-base"
+                      style={{
+                        borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)",
+                        background: "color-mix(in srgb, var(--th-bg-surface) 92%, transparent)",
+                      }}
+                    >
+                      {agent.avatar_emoji}
                     </span>
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-semibold" style={{ color: "var(--th-text)" }}>
+                        {agentLabel}
+                      </div>
+                      <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                        <span
+                          className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium"
+                          style={{
+                            color: statusMeta.textColor,
+                            background: statusMeta.background,
+                            border: `1px solid ${statusMeta.border}`,
+                          }}
+                        >
+                          <span
+                            className="h-1.5 w-1.5 rounded-full"
+                            style={{ background: statusMeta.accent }}
+                          />
+                          {statusMeta.label}
+                        </span>
+                        {sessionLabel && (
+                          <span
+                            className="inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium"
+                            style={{
+                              borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)",
+                              background: "color-mix(in srgb, var(--th-bg-surface) 90%, transparent)",
+                              color: "var(--th-text-muted)",
+                            }}
+                          >
+                            <span className="truncate">{sessionLabel}</span>
+                          </span>
+                        )}
+                      </div>
+                    </div>
                   </div>
                   {manualIntervention && (
                     <span
                       className="shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold"
                       style={{
-                        color: "var(--warn)",
-                        background: "color-mix(in oklch, var(--warn) 12%, var(--bg-2) 88%)",
+                        color: "var(--th-accent-warn)",
+                        background: "color-mix(in srgb, var(--th-badge-amber-bg) 72%, var(--th-card-bg) 28%)",
                       }}
                     >
                       {isKo ? "수동 개입" : "Manual"}
                     </span>
                   )}
                 </div>
-                <div className="mt-2 flex items-center gap-1.5">
-                  <span
-                    className="h-2 w-2 shrink-0 rounded-full"
-                    style={{ background: statusMeta.color }}
-                  />
-                  <span
-                    className="truncate text-xs"
-                    style={{ color: statusMeta.color }}
-                  >
-                    {agent.session_info || statusMeta.label}
-                  </span>
-                </div>
                 {preview && (
-                  <div className="mt-2 text-[11px] leading-5" style={{ color: "var(--th-text-muted)" }}>
+                  <div className="mt-3 text-[11px] leading-5" style={{ color: "var(--th-text-muted)" }}>
                     {preview}
                   </div>
                 )}
@@ -802,7 +1075,7 @@ function MobileAgentStatusGrid({
                     <span
                       className="inline-flex max-w-full items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
                       style={{
-                        color: statusMeta.color,
+                        color: statusMeta.textColor,
                         background: statusMeta.background,
                         border: `1px solid ${statusMeta.border}`,
                       }}
@@ -838,7 +1111,7 @@ function MobileAgentStatusGrid({
                     )}
                   >
                     <div className="min-w-0">
-                      <div className="text-[10px] font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--warn)" }}>
+                      <div className="text-[10px] font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--th-accent-warn)" }}>
                         {isKo ? "경고" : "Warning"}
                       </div>
                       <div className="mt-1 text-[11px] font-semibold leading-5" style={{ color: "var(--th-text)" }}>
@@ -871,7 +1144,7 @@ function MobileAgentStatusGrid({
           );
         })}
         </div>
-      </SurfaceSection>
+      </SurfaceSubsection>
     </div>
   );
 }

--- a/dashboard/src/components/OpsPageView.tsx
+++ b/dashboard/src/components/OpsPageView.tsx
@@ -1,18 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { AlertTriangle, RefreshCw, Wifi, WifiOff } from "lucide-react";
+import { AlertTriangle, RefreshCw, Wifi } from "lucide-react";
 import { getHealth, type HealthResponse } from "../api";
 import type { Agent, Office, WSEvent } from "../types";
 import OfficeManagerView from "./OfficeManagerView";
 import { describeDegradedReason } from "./dashboard/HealthWidget";
-import {
-  SurfaceActionButton,
-  SurfaceCard,
-  SurfaceEmptyState,
-  SurfaceMetaBadge,
-  SurfaceNotice,
-  SurfaceSection,
-  SurfaceSubsection,
-} from "./common/SurfacePrimitives";
+import { SurfaceEmptyState } from "./common/SurfacePrimitives";
 
 interface OpsPageViewProps {
   wsConnected: boolean;
@@ -46,6 +38,14 @@ interface BottleneckRow {
   detail: string;
 }
 
+interface RuntimeSignalRow {
+  key: string;
+  label: string;
+  value: string;
+  hint: string;
+  severity: SignalSeverity;
+}
+
 const STALE_AFTER_MS = 75_000;
 const LIVE_POLL_INTERVAL_MS = 5_000;
 const DISCONNECTED_POLL_BASE_MS = 5_000;
@@ -59,6 +59,257 @@ const SIGNAL_THRESHOLDS: Record<SignalCard["key"], Threshold> = {
   active_watchers: { warning: 4, danger: 8 },
   recovery_seconds: { warning: 180, danger: 600 },
 };
+
+const OPS_SHELL_STYLES = `
+  .ops-shell .page {
+    padding: 24px 28px 48px;
+    max-width: 1440px;
+    width: 100%;
+    margin: 0 auto;
+    min-width: 0;
+  }
+
+  .ops-shell .page-header {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
+
+  .ops-shell .page-title {
+    font-family: var(--font-display);
+    font-size: 22px;
+    font-weight: 600;
+    letter-spacing: -0.5px;
+    line-height: 1.2;
+    color: var(--th-text-heading);
+  }
+
+  .ops-shell .page-sub {
+    margin-top: 4px;
+    font-size: 13px;
+    color: var(--th-text-muted);
+    line-height: 1.6;
+  }
+
+  .ops-shell .grid {
+    display: grid;
+    gap: 14px;
+  }
+
+  .ops-shell .grid-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .ops-shell .ops-main-grid {
+    grid-template-columns: minmax(0, 2fr) minmax(320px, 1fr);
+  }
+
+  .ops-shell .ops-secondary-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(320px, 1fr);
+  }
+
+  .ops-shell .card {
+    background:
+      linear-gradient(
+        180deg,
+        color-mix(in srgb, var(--th-card-bg) 96%, transparent) 0%,
+        color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%
+      );
+    border: 1px solid color-mix(in srgb, var(--th-border-subtle) 88%, transparent);
+    border-radius: 18px;
+    overflow: hidden;
+    box-shadow: 0 1px 0 color-mix(in srgb, var(--th-text-primary) 4%, transparent) inset;
+  }
+
+  .ops-shell .card-head {
+    padding: 14px 16px 0;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .ops-shell .card-title {
+    font-size: 12.5px;
+    font-weight: 500;
+    color: var(--th-text-secondary);
+    letter-spacing: -0.1px;
+  }
+
+  .ops-shell .card-body {
+    padding: 10px 16px 16px;
+  }
+
+  .ops-shell .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 7px;
+    font-size: 12.5px;
+    font-weight: 500;
+    color: var(--th-text-secondary);
+    background: color-mix(in srgb, var(--th-surface-alt) 84%, transparent);
+    border: 1px solid var(--th-border-subtle);
+    transition: background 0.14s ease, color 0.14s ease, border-color 0.14s ease;
+  }
+
+  .ops-shell .btn:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--th-surface-alt) 94%, transparent);
+    color: var(--th-text-primary);
+    border-color: var(--th-border);
+  }
+
+  .ops-shell .btn:disabled {
+    opacity: 0.58;
+    cursor: default;
+  }
+
+  .ops-shell .btn.sm {
+    padding: 4px 9px;
+    font-size: 11.5px;
+  }
+
+  .ops-shell .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    border: 1px solid var(--th-border-subtle);
+    background: color-mix(in srgb, var(--th-surface-alt) 86%, transparent);
+    color: var(--th-text-secondary);
+    font-size: 11px;
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .ops-shell .chip .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 999px;
+    background: currentColor;
+  }
+
+  .ops-shell .chip.ok {
+    color: var(--color-success);
+    border-color: var(--color-success-border);
+    background: var(--color-success-soft);
+  }
+
+  .ops-shell .chip.warn {
+    color: var(--color-warning);
+    border-color: var(--color-warning-border);
+    background: var(--color-warning-soft);
+  }
+
+  .ops-shell .chip.err {
+    color: var(--color-danger);
+    border-color: var(--color-danger-border);
+    background: var(--color-danger-soft);
+  }
+
+  .ops-shell .chip.codex {
+    color: var(--codex);
+    border-color: color-mix(in srgb, var(--codex) 32%, var(--th-border-subtle) 68%);
+    background: color-mix(in srgb, var(--codex) 14%, var(--th-surface-alt) 86%);
+  }
+
+  .ops-shell .pulse {
+    animation: ops-chip-pulse 1.6s ease-in-out infinite;
+  }
+
+  .ops-shell .ops-inline-alert {
+    border-color: color-mix(in oklch, var(--warn) 30%, var(--th-border) 70%);
+    background:
+      linear-gradient(
+        180deg,
+        color-mix(in oklch, var(--warn) 8%, var(--th-surface) 92%) 0%,
+        var(--th-surface) 100%
+      );
+  }
+
+  .ops-shell .ops-signal-card {
+    border-width: 1px;
+  }
+
+  .ops-shell .ops-mini-card {
+    border-radius: 16px;
+  }
+
+  .ops-shell .ops-panel-card {
+    padding: 12px;
+    border-radius: 10px;
+    border: 1px solid color-mix(in srgb, var(--th-border-subtle) 88%, transparent);
+    background: color-mix(in srgb, var(--th-bg-surface) 92%, transparent);
+  }
+
+  .ops-shell .metric-label {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--th-text-muted);
+  }
+
+  .ops-shell .metric-value {
+    margin-top: 10px;
+    font-family: var(--font-display);
+    font-size: 28px;
+    font-weight: 600;
+    letter-spacing: -1px;
+    line-height: 1.1;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .ops-shell .metric-sub {
+    margin-top: 4px;
+    font-size: 12px;
+    line-height: 1.6;
+    color: var(--th-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+
+  @keyframes ops-chip-pulse {
+    0%, 100% { opacity: 0.65; transform: scale(0.92); }
+    50% { opacity: 1; transform: scale(1); }
+  }
+
+  @media (max-width: 1180px) {
+    .ops-shell .ops-main-grid,
+    .ops-shell .ops-secondary-grid {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
+
+  @media (max-width: 1024px) {
+    .ops-shell .page-header {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+  }
+
+  @media (max-width: 768px) {
+    .ops-shell .page {
+      padding: 16px 16px calc(9rem + env(safe-area-inset-bottom));
+    }
+
+    .ops-shell .grid-4 {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 520px) {
+    .ops-shell .grid-4 {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
+`;
 
 function resolveSeverity(value: number, threshold: Threshold): SignalSeverity {
   if (value >= threshold.danger) return "danger";
@@ -85,6 +336,47 @@ function toneForSeverity(severity: SignalSeverity): "info" | "warn" | "danger" |
       return "warn";
     default:
       return "success";
+  }
+}
+
+function chipClassFromTone(tone: "info" | "warn" | "danger" | "success"): string {
+  switch (tone) {
+    case "success":
+      return "chip ok";
+    case "warn":
+      return "chip warn";
+    case "danger":
+      return "chip err";
+    case "info":
+    default:
+      return "chip codex";
+  }
+}
+
+function surfaceStyleForSeverity(severity: SignalSeverity): { borderColor: string; background: string; valueColor: string } {
+  switch (severity) {
+    case "danger":
+      return {
+        borderColor: "color-mix(in srgb, var(--color-danger) 18%, var(--th-border-subtle) 82%)",
+        background:
+          "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
+        valueColor: "var(--color-danger)",
+      };
+    case "warning":
+      return {
+        borderColor: "color-mix(in srgb, var(--color-warning) 18%, var(--th-border-subtle) 82%)",
+        background:
+          "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
+        valueColor: "var(--color-warning)",
+      };
+    case "normal":
+    default:
+      return {
+        borderColor: "color-mix(in srgb, var(--th-border-subtle) 88%, transparent)",
+        background:
+          "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
+        valueColor: "var(--color-info)",
+      };
   }
 }
 
@@ -258,6 +550,13 @@ function translateStatus(status: string, isKo: boolean): string {
   return status.toUpperCase();
 }
 
+function formatBottleneckLabel(kind: string): string {
+  return kind
+    .replaceAll("_", " ")
+    .replaceAll("provider disconnects", "provider disconnects")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
 export default function OpsPageView({
   wsConnected,
   offices,
@@ -352,6 +651,17 @@ export default function OpsPageView({
     () => (health ? buildSignalCards(health, isKo) : []),
     [health, isKo],
   );
+  const primarySignals = useMemo(
+    () =>
+      signals.filter((signal) =>
+        ["deferred_hooks", "outbox_age", "pending_queue", "active_watchers"].includes(signal.key),
+      ),
+    [signals],
+  );
+  const recoverySignal = useMemo(
+    () => signals.find((signal) => signal.key === "recovery_seconds") ?? null,
+    [signals],
+  );
   const bottlenecks = useMemo(
     () => (health ? buildBottlenecks(health) : []),
     [health],
@@ -360,301 +670,449 @@ export default function OpsPageView({
   const providerCount = health?.providers?.length ?? 0;
   const connectedProviders = (health?.providers ?? []).filter((provider) => provider.connected).length;
   const lastUpdatedLabel = formatUpdatedAt(lastSuccessAt, localeTag);
-  const disconnectedPollMs = Math.min(
-    MAX_DISCONNECTED_POLL_MS,
-    DISCONNECTED_POLL_BASE_MS * 2 ** Math.min(failureCount, 4),
+  const restartPendingProviders = (health?.providers ?? []).filter((provider) => provider.restart_pending).length;
+  const disconnectedProviders = (health?.providers ?? []).filter((provider) => !provider.connected).length;
+  const runtimeSignals = useMemo<RuntimeSignalRow[]>(
+    () => [
+      {
+        key: "websocket",
+        label: tr("Live Transport", "Live Transport"),
+        value: wsConnected ? "LIVE" : "DOWN",
+        hint: wsConnected
+          ? tr("WS 이벤트 기반 refresh 활성", "Event-driven refresh active")
+          : tr("fallback polling으로 health 유지", "Fallback polling keeps health alive"),
+        severity: wsConnected ? "normal" : "danger",
+      },
+      {
+        key: "queue",
+        label: tr("Pending Queue", "Pending Queue"),
+        value: formatNumber(health?.queue_depth ?? 0),
+        hint: tr(
+          `active ${formatNumber(health?.global_active ?? 0)} · finalizing ${formatNumber(health?.global_finalizing ?? 0)}`,
+          `active ${formatNumber(health?.global_active ?? 0)} · finalizing ${formatNumber(health?.global_finalizing ?? 0)}`,
+        ),
+        severity: resolveSeverity(health?.queue_depth ?? 0, SIGNAL_THRESHOLDS.pending_queue),
+      },
+      {
+        key: "outbox",
+        label: tr("Outbox Pending", "Outbox Pending"),
+        value: formatNumber(health?.dispatch_outbox?.pending ?? 0),
+        hint: tr(
+          `retry ${formatNumber(health?.dispatch_outbox?.retrying ?? 0)} · fail ${formatNumber(health?.dispatch_outbox?.permanent_failures ?? 0)}`,
+          `retry ${formatNumber(health?.dispatch_outbox?.retrying ?? 0)} · fail ${formatNumber(health?.dispatch_outbox?.permanent_failures ?? 0)}`,
+        ),
+        severity: resolveSeverity(health?.dispatch_outbox?.pending ?? 0, SIGNAL_THRESHOLDS.pending_queue),
+      },
+      {
+        key: "providers",
+        label: tr("Provider Links", "Provider Links"),
+        value: `${connectedProviders}/${providerCount}`,
+        hint: tr(
+          `disconnect ${formatNumber(disconnectedProviders)} · restart ${formatNumber(restartPendingProviders)}`,
+          `disconnect ${formatNumber(disconnectedProviders)} · restart ${formatNumber(restartPendingProviders)}`,
+        ),
+        severity: disconnectedProviders > 0 ? (disconnectedProviders >= 2 ? "danger" : "warning") : "normal",
+      },
+      {
+        key: "watchers",
+        label: tr("Watchers", "Watchers"),
+        value: formatNumber(health?.watcher_count ?? 0),
+        hint: tr(
+          `${formatNumber(providerCount)}개 provider 추적 중`,
+          `${formatNumber(providerCount)} providers in scope`,
+        ),
+        severity: resolveSeverity(health?.watcher_count ?? 0, SIGNAL_THRESHOLDS.active_watchers),
+      },
+      {
+        key: "recovery",
+        label: tr("Recovery Window", "Recovery Window"),
+        value: formatDurationCompact(health?.recovery_duration ?? 0),
+        hint: tr(
+          `uptime ${formatDurationCompact(health?.uptime_secs ?? 0)}`,
+          `uptime ${formatDurationCompact(health?.uptime_secs ?? 0)}`,
+        ),
+        severity: resolveSeverity(health?.recovery_duration ?? 0, SIGNAL_THRESHOLDS.recovery_seconds),
+      },
+    ],
+    [connectedProviders, disconnectedProviders, health, providerCount, restartPendingProviders, tr, wsConnected],
   );
+  const statusTone =
+    health?.status === "unhealthy"
+      ? "danger"
+      : health?.status === "degraded"
+        ? "warn"
+        : "success";
 
   return (
     <div
       data-testid="ops-page"
-      className="mx-auto w-full max-w-6xl min-w-0 space-y-4 overflow-x-hidden p-4 pb-40 sm:h-full sm:overflow-y-auto sm:p-6"
-      style={{ paddingBottom: "max(10rem, calc(10rem + env(safe-area-inset-bottom)))" }}
+      className="page fade-in ops-shell mx-auto w-full min-w-0 overflow-x-hidden"
     >
-      <SurfaceSection
-        eyebrow="OPS"
-        title={tr("운영 컨트롤", "Ops Control")}
-        description={tr(
-          "런타임 헬스와 병목 신호를 먼저 보여주고, 실시간 WS 이벤트가 들어오면 health를 다시 읽습니다. WS가 끊기면 내부 polling 간격을 늘려가며 계속 갱신합니다.",
-          "Runtime health and bottleneck pressure come first. Incoming WS events trigger health refreshes, and when WS drops the page falls back to a widening internal polling interval.",
-        )}
-        badge={health ? translateStatus(health.status, isKo) : tr("초기 로드", "Initial load")}
-        actions={
-          <>
-            <SurfaceMetaBadge tone={wsConnected ? "success" : "danger"}>
-              <span className="inline-flex items-center gap-1.5">
-                {wsConnected ? <Wifi size={12} /> : <WifiOff size={12} />}
-                {wsConnected ? "LIVE" : "DISCONNECTED"}
-              </span>
-            </SurfaceMetaBadge>
-            {stale ? <SurfaceMetaBadge tone="warn">STALE</SurfaceMetaBadge> : null}
-            <SurfaceActionButton onClick={() => void refreshHealth()} disabled={isRefreshing}>
-              <span className="inline-flex items-center gap-1.5">
-                <RefreshCw size={13} className={isRefreshing ? "animate-spin" : undefined} />
-                {isRefreshing ? tr("동기화 중", "Refreshing") : tr("새로고침", "Refresh")}
-              </span>
-            </SurfaceActionButton>
-          </>
-        }
-      >
-        <div className="mt-5 flex flex-wrap items-center gap-2">
-          <SurfaceMetaBadge tone={health?.status === "unhealthy" ? "danger" : health?.status === "degraded" ? "warn" : "success"}>
+      <style>{OPS_SHELL_STYLES}</style>
+      <div className="page fade-in">
+        <div className="page-header">
+          <div className="min-w-0">
+            <div className="page-title">{tr("운영 상태", "Ops Health")}</div>
+            <div className="page-sub">
+              {tr(
+                "Deferred / outbox / queue / watcher / recovery",
+                "Deferred / outbox / queue / watcher / recovery",
+              )}
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className={chipClassFromTone(wsConnected ? "success" : "danger")}>
+              <span className={wsConnected ? "dot pulse" : "dot"} />
+              {wsConnected ? "LIVE" : "DISCONNECTED"}
+            </span>
+            {stale ? <span className="chip warn">STALE</span> : null}
+            <button className="btn sm" type="button" onClick={() => void refreshHealth()} disabled={isRefreshing}>
+              <RefreshCw size={12} className={isRefreshing ? "animate-spin" : undefined} />
+              {isRefreshing ? tr("동기화 중", "Refreshing") : tr("새로고침", "Refresh")}
+            </button>
+          </div>
+        </div>
+
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          <span className={chipClassFromTone(statusTone)}>
             {health ? translateStatus(health.status, isKo) : tr("대기 중", "Pending")}
-          </SurfaceMetaBadge>
-          <SurfaceMetaBadge>{tr(`업데이트 ${lastUpdatedLabel}`, `Updated ${lastUpdatedLabel}`)}</SurfaceMetaBadge>
-          <SurfaceMetaBadge>{tr(`provider ${connectedProviders}/${providerCount}`, `providers ${connectedProviders}/${providerCount}`)}</SurfaceMetaBadge>
-          <SurfaceMetaBadge>{tr(`fallback poll ${Math.round(disconnectedPollMs / 1000)}s`, `fallback poll ${Math.round(disconnectedPollMs / 1000)}s`)}</SurfaceMetaBadge>
+          </span>
+          <span className="chip">{tr(`업데이트 ${lastUpdatedLabel}`, `Updated ${lastUpdatedLabel}`)}</span>
+          {recoverySignal ? (
+            <span
+              className={chipClassFromTone(toneForSeverity(recoverySignal.severity))}
+              data-testid="ops-signal-recovery_seconds"
+            >
+              {tr(`복구 ${recoverySignal.value}`, `Recovery ${recoverySignal.value}`)}
+            </span>
+          ) : null}
         </div>
 
         {error ? (
-          <SurfaceNotice tone={health ? "warn" : "danger"} className="mt-4" leading={<AlertTriangle size={16} />}>
-            <div className="text-sm font-medium" style={{ color: "var(--th-text-primary)" }}>
-              {health
-                ? tr("최근 health 요청이 실패해 마지막 정상값을 유지 중입니다.", "Latest health request failed, keeping the last successful snapshot.")
-                : tr("health 응답을 아직 받지 못했습니다.", "Health response has not arrived yet.")}
+          <div className="card ops-inline-alert">
+            <div className="card-body flex items-start gap-3">
+              <AlertTriangle size={16} style={{ color: "var(--th-accent-warn)", flexShrink: 0, marginTop: 2 }} />
+              <div className="min-w-0">
+                <div className="text-sm font-medium" style={{ color: "var(--th-text-primary)" }}>
+                  {health
+                    ? tr("최근 health 요청이 실패해 마지막 정상값을 유지 중입니다.", "Latest health request failed, keeping the last successful snapshot.")
+                    : tr("health 응답을 아직 받지 못했습니다.", "Health response has not arrived yet.")}
+                </div>
+                <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                  {error}
+                </div>
+              </div>
             </div>
-            <div className="mt-1 text-xs" style={{ color: "var(--th-text-muted)" }}>
-              {error}
-            </div>
-          </SurfaceNotice>
+          </div>
         ) : null}
 
         {health?.degraded_reasons && health.degraded_reasons.length > 0 ? (
-          <div className="mt-4 flex flex-wrap gap-2">
+          <div className="mb-4 flex flex-wrap gap-2">
             {health.degraded_reasons.slice(0, 4).map((reason) => (
-              <SurfaceMetaBadge
+              <span
                 key={reason}
-                tone={health.status === "unhealthy" ? "danger" : "warn"}
+                className={health.status === "unhealthy" ? "chip err" : "chip warn"}
               >
                 {describeDegradedReason(reason)}
-              </SurfaceMetaBadge>
+              </span>
             ))}
           </div>
         ) : null}
 
-        <div data-testid="ops-signal-grid" className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
-          {signals.length > 0 ? (
-            signals.map((signal) => (
-              <SurfaceCard
-                key={signal.key}
-                data-testid={`ops-signal-${signal.key}`}
-                className="min-w-0 rounded-3xl p-4"
-                style={{
-                  borderColor:
-                    signal.severity === "danger"
-                      ? "var(--color-danger-border)"
-                      : signal.severity === "warning"
-                        ? "var(--color-warning-border)"
-                        : "var(--color-info-border)",
-                  background:
-                    signal.severity === "danger"
-                      ? "var(--color-danger-soft)"
-                      : signal.severity === "warning"
-                        ? "var(--color-warning-soft)"
-                        : "var(--color-info-soft)",
-                }}
-              >
-                <div className="text-[11px] font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--th-text-muted)" }}>
-                  {signal.key}
+        <div data-testid="ops-signal-grid" className="grid grid-4">
+          {primarySignals.length > 0 ? (
+            primarySignals.map((signal) => {
+              const chrome = surfaceStyleForSeverity(signal.severity);
+              return (
+                <div
+                  key={signal.key}
+                  data-testid={`ops-signal-${signal.key}`}
+                  className="card ops-signal-card"
+                  style={{
+                    borderColor: chrome.borderColor,
+                    background: chrome.background,
+                  }}
+                >
+                  <div className="card-body">
+                    <div className="metric-label">{signal.label}</div>
+                    <div className="metric-value" style={{ color: chrome.valueColor }}>
+                      {signal.value}
+                    </div>
+                    <div className="metric-sub">{signal.note}</div>
+                  </div>
                 </div>
-                <div className="mt-3 text-2xl font-semibold tracking-tight" style={{ color: "var(--th-text-primary)" }}>
-                  {signal.value}
-                </div>
-                <div className="mt-1 text-sm font-medium" style={{ color: "var(--th-text-primary)" }}>
-                  {signal.label}
-                </div>
-                <div className="mt-2 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
-                  {signal.note}
-                </div>
-              </SurfaceCard>
-            ))
+              );
+            })
           ) : (
-            <div className="sm:col-span-2 xl:col-span-5">
-              <SurfaceEmptyState className="py-8">
-                <div className="flex flex-col items-center gap-2 text-center">
-                  <AlertTriangle size={20} style={{ color: "var(--th-text-muted)" }} />
-                  <div className="text-sm font-semibold" style={{ color: "var(--th-text-primary)" }}>
-                    {tr("표시할 health signal이 아직 없습니다.", "No health signals available yet.")}
+            <div className="card md:col-span-2 xl:col-span-4">
+              <div className="card-body">
+                <SurfaceEmptyState className="py-8">
+                  <div className="flex flex-col items-center gap-2 text-center">
+                    <AlertTriangle size={20} style={{ color: "var(--th-text-muted)" }} />
+                    <div className="text-sm font-semibold" style={{ color: "var(--th-text-primary)" }}>
+                      {tr("표시할 health signal이 아직 없습니다.", "No health signals available yet.")}
+                    </div>
+                    <div className="text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                      {tr("초기 health 응답이 도착하면 signal grid가 채워집니다.", "The signal grid will populate after the first health response arrives.")}
+                    </div>
                   </div>
-                  <div className="text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
-                    {tr("초기 health 응답이 도착하면 signal grid가 채워집니다.", "The signal grid will populate after the first health response arrives.")}
-                  </div>
-                </div>
-              </SurfaceEmptyState>
+                </SurfaceEmptyState>
+              </div>
             </div>
           )}
         </div>
-      </SurfaceSection>
 
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
-        <SurfaceSubsection
-          title={tr("Ops Bottlenecks", "Ops Bottlenecks")}
-          description={tr(
-            "헬스 응답에서 실제로 위험 신호가 난 항목만 추려 kind / count / severity로 정렬합니다.",
-            "Only active risk signals from the health response are surfaced here, sorted by kind / count / severity.",
-          )}
-        >
-          {bottlenecks.length > 0 ? (
-            <div data-testid="ops-bottlenecks" className="mt-4 space-y-2">
-              <div
-                className="hidden items-center gap-3 rounded-2xl px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.16em] md:grid"
-                style={{
-                  gridTemplateColumns: "minmax(0, 1.5fr) 96px 110px",
-                  color: "var(--th-text-muted)",
-                  background: "color-mix(in srgb, var(--th-overlay-medium) 84%, transparent)",
-                }}
-              >
-                <span>kind</span>
-                <span>count</span>
-                <span>severity</span>
-              </div>
-              {bottlenecks.map((row) => (
-                <div
-                  key={`${row.kind}-${row.detail}`}
-                  data-testid={`ops-bottleneck-${row.kind}`}
-                  className="grid gap-3 rounded-2xl border px-3 py-3 md:items-center"
-                  style={{
-                    gridTemplateColumns: "minmax(0, 1fr)",
-                    borderColor: row.severity === "danger" ? "var(--color-danger-border)" : "var(--color-warning-border)",
-                    background: row.severity === "danger" ? "var(--color-danger-soft)" : "var(--color-warning-soft)",
-                  }}
-                >
-                  <div className="md:hidden">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <div className="text-sm font-semibold" style={{ color: "var(--th-text-primary)" }}>
-                        {row.kind}
-                      </div>
-                      <SurfaceMetaBadge tone={toneForSeverity(row.severity)}>
-                        {row.severity.toUpperCase()}
-                      </SurfaceMetaBadge>
-                    </div>
-                    <div className="mt-1 text-xs" style={{ color: "var(--th-text-muted)" }}>
-                      {row.detail}
-                    </div>
-                    <div className="mt-2 text-xs font-medium" style={{ color: "var(--th-text-primary)" }}>
-                      count {formatNumber(row.count)}
-                    </div>
-                  </div>
-
-                  <div
-                    className="hidden md:grid md:items-center md:gap-3"
-                    style={{ gridTemplateColumns: "minmax(0, 1.5fr) 96px 110px" }}
-                  >
-                    <div className="min-w-0">
-                      <div className="truncate text-sm font-semibold" style={{ color: "var(--th-text-primary)" }}>
-                        {row.kind}
-                      </div>
-                      <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
-                        {row.detail}
-                      </div>
-                    </div>
-                    <div className="text-sm font-semibold" style={{ color: "var(--th-text-primary)" }}>
-                      {formatNumber(row.count)}
-                    </div>
-                    <div>
-                      <SurfaceMetaBadge tone={toneForSeverity(row.severity)}>
-                        {row.severity.toUpperCase()}
-                      </SurfaceMetaBadge>
-                    </div>
-                  </div>
+        <div className="grid ops-main-grid mt-4">
+          <div className="card">
+            <div className="card-head">
+              <div className="min-w-0">
+                <div className="card-title">{tr("운영 시그널", "Ops Signals")}</div>
+                <div className="mt-1 text-[11px] leading-5" style={{ color: "var(--th-text-muted)" }}>
+                  {tr(
+                    "세션 · 리뷰 · 블록 · 회의 · 후속 — 한 줄 요약",
+                    "Session · review · block · meetings · follow-up — quick summary",
+                  )}
                 </div>
-              ))}
+              </div>
             </div>
-          ) : (
-            <SurfaceEmptyState data-testid="ops-bottlenecks-empty" className="mt-4 py-8">
-              <div className="flex flex-col items-center gap-2 text-center">
-                <Wifi size={20} style={{ color: "var(--th-text-muted)" }} />
-                <div className="text-sm font-semibold" style={{ color: "var(--th-text-primary)" }}>
-                  {tr("현재 감지된 운영 병목이 없습니다.", "No active ops bottlenecks detected.")}
-                </div>
-                <div className="text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
-                  {tr("warning 이상 신호가 생기면 이 목록에 즉시 올라옵니다.", "Signals at warning level or above will appear here immediately.")}
-                </div>
+            <div className="card-body">
+              <div className="grid sm:grid-cols-2 xl:grid-cols-3">
+                {runtimeSignals.map((signal) => {
+                  const chrome = surfaceStyleForSeverity(signal.severity);
+                  return (
+                    <div
+                      key={signal.key}
+                      className="ops-panel-card"
+                      style={{
+                        borderColor: chrome.borderColor,
+                        background: chrome.background,
+                      }}
+                    >
+                      <div className="metric-label">
+                        {signal.label}
+                      </div>
+                      <div className="metric-value" style={{ marginTop: 8, fontSize: 22, color: chrome.valueColor }}>
+                        {signal.value}
+                      </div>
+                      <div className="metric-sub" style={{ marginTop: 6, fontSize: 12 }}>
+                        {signal.hint}
+                      </div>
+                    </div>
+                  );
+                })}
               </div>
-            </SurfaceEmptyState>
-          )}
-        </SurfaceSubsection>
-
-        <SurfaceSubsection
-          title={tr("Connection & Delivery", "Connection & Delivery")}
-          description={tr(
-            "WS 연결 상태와 outbox/provider 요약을 빠르게 확인하는 보조 패널입니다.",
-            "A compact side panel for WS connectivity and outbox/provider delivery status.",
-          )}
-        >
-          <div data-testid="ops-connection-panel" className="mt-4 space-y-3">
-            <SurfaceCard
-              data-testid="ops-websocket-card"
-              className="rounded-3xl p-4"
-              style={{
-                borderColor: wsConnected ? "var(--color-info-border)" : "var(--color-danger-border)",
-                background: wsConnected ? "var(--color-info-soft)" : "var(--color-danger-soft)",
-              }}
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <div className="text-[11px] font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--th-text-muted)" }}>
-                    websocket
-                  </div>
-                  <div className="mt-2 text-lg font-semibold" style={{ color: "var(--th-text-primary)" }}>
-                    {wsConnected ? tr("실시간 연결됨", "Connected live") : tr("연결 끊김", "Disconnected")}
-                  </div>
-                  <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
-                    {wsConnected
-                      ? tr("pcd-ws-event 수신 시 health refresh를 즉시 재스케줄합니다.", "Incoming pcd-ws-event messages reschedule health refreshes immediately.")
-                      : tr("WS가 복구될 때까지 내부 polling으로 health를 유지합니다.", "Internal polling keeps health current until WS recovers.")}
-                  </div>
-                </div>
-                <SurfaceMetaBadge tone={wsConnected ? "success" : "danger"}>
-                  {wsConnected ? "LIVE" : "DISCONNECTED"}
-                </SurfaceMetaBadge>
-              </div>
-            </SurfaceCard>
-
-            <div className="grid gap-3 sm:grid-cols-2">
-              <SurfaceCard data-testid="ops-dispatch-outbox-card" className="rounded-3xl p-4">
-                <div className="text-[11px] font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--th-text-muted)" }}>
-                  dispatch_outbox
-                </div>
-                <div className="mt-3 text-xl font-semibold" style={{ color: "var(--th-text-primary)" }}>
-                  {formatNumber(health?.dispatch_outbox?.pending ?? 0)}
-                </div>
-                <div className="mt-1 text-xs" style={{ color: "var(--th-text-muted)" }}>
-                  {tr(
-                    `retry ${formatNumber(health?.dispatch_outbox?.retrying ?? 0)} · fail ${formatNumber(health?.dispatch_outbox?.permanent_failures ?? 0)}`,
-                    `retry ${formatNumber(health?.dispatch_outbox?.retrying ?? 0)} · fail ${formatNumber(health?.dispatch_outbox?.permanent_failures ?? 0)}`,
-                  )}
-                </div>
-              </SurfaceCard>
-
-              <SurfaceCard data-testid="ops-providers-card" className="rounded-3xl p-4">
-                <div className="text-[11px] font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--th-text-muted)" }}>
-                  providers
-                </div>
-                <div className="mt-3 text-xl font-semibold" style={{ color: "var(--th-text-primary)" }}>
-                  {connectedProviders}/{providerCount}
-                </div>
-                <div className="mt-1 text-xs" style={{ color: "var(--th-text-muted)" }}>
-                  {tr(
-                    `restart pending ${formatNumber((health?.providers ?? []).filter((provider) => provider.restart_pending).length)}`,
-                    `restart pending ${formatNumber((health?.providers ?? []).filter((provider) => provider.restart_pending).length)}`,
-                  )}
-                </div>
-              </SurfaceCard>
             </div>
           </div>
-        </SurfaceSubsection>
-      </div>
 
-      <div className="border-t pt-2" style={{ borderColor: "var(--th-border-subtle)" }}>
-        <div className="-mx-4 sm:-mx-6">
-          <OfficeManagerView
-            offices={offices}
-            allAgents={allAgents}
-            selectedOfficeId={selectedOfficeId}
-            isKo={isKo}
-            onChanged={onChanged}
-          />
+          <div className="card">
+            <div className="card-head">
+              <div className="min-w-0">
+                <div className="card-title">{tr("회의 타임라인", "Meeting Timeline")}</div>
+                <div className="mt-1 text-[11px] leading-5" style={{ color: "var(--th-text-muted)" }}>
+                  {tr("0 진행 · 후속 0 미정리", "0 active · 0 follow-ups pending")}
+                </div>
+              </div>
+              <button className="btn sm" type="button" disabled>
+                {tr("회의록", "Records")}
+              </button>
+            </div>
+            <div className="card-body">
+              <div className="flex flex-wrap gap-2">
+                {recoverySignal ? (
+                  <span className={chipClassFromTone(toneForSeverity(recoverySignal.severity))}>
+                    {tr(`복구 ${recoverySignal.value}`, `Recovery ${recoverySignal.value}`)}
+                  </span>
+                ) : null}
+                <span className={chipClassFromTone(wsConnected ? "success" : "danger")}>
+                  {tr(`provider ${connectedProviders}/${providerCount}`, `providers ${connectedProviders}/${providerCount}`)}
+                </span>
+              </div>
+              <div className="mt-4 min-h-[220px]">
+                <SurfaceEmptyState className="grid min-h-[220px] place-items-center py-10">
+                  <div className="flex flex-col items-center gap-2 text-center">
+                    <Wifi size={20} style={{ color: "var(--th-text-muted)" }} />
+                    <div className="text-sm font-semibold" style={{ color: "var(--th-text-primary)" }}>
+                      {tr("최근 회의가 없습니다.", "No recent meetings.")}
+                    </div>
+                    <div className="text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                      {tr("회의 타임라인 데이터가 연결되면 이 영역이 채워집니다.", "This area will populate once meeting timeline data is wired in.")}
+                    </div>
+                  </div>
+                </SurfaceEmptyState>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid ops-secondary-grid mt-4">
+          <div className="card">
+            <div className="card-head">
+              <div className="min-w-0">
+                <div className="card-title">{tr("Runtime Watchlist", "Runtime Watchlist")}</div>
+                <div className="mt-1 text-[11px] leading-5" style={{ color: "var(--th-text-muted)" }}>
+                  {tr(
+                    "warning 이상으로 올라온 런타임 병목을 별도 목록으로 유지합니다.",
+                    "Keeps a dedicated list of runtime bottlenecks that are currently warning level or above.",
+                  )}
+                </div>
+              </div>
+            </div>
+            <div className="card-body">
+              {bottlenecks.length > 0 ? (
+                <div data-testid="ops-bottlenecks" className="space-y-2">
+                  {bottlenecks.map((row) => (
+                    <div
+                      key={`${row.kind}-${row.detail}`}
+                      data-testid={`ops-bottleneck-${row.kind}`}
+                      className="grid gap-3 rounded-2xl border px-3 py-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-center"
+                      style={{
+                        borderColor: row.severity === "danger" ? "var(--color-danger-border)" : "var(--color-warning-border)",
+                        background: row.severity === "danger" ? "var(--color-danger-soft)" : "var(--color-warning-soft)",
+                      }}
+                    >
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <div className="text-sm font-semibold" style={{ color: "var(--th-text-primary)" }}>
+                            {formatBottleneckLabel(row.kind)}
+                          </div>
+                          <span className={chipClassFromTone(toneForSeverity(row.severity))}>
+                            {row.severity.toUpperCase()}
+                          </span>
+                        </div>
+                        <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                          {row.detail}
+                        </div>
+                      </div>
+                      <div className="text-sm font-semibold" style={{ color: "var(--th-text-primary)" }}>
+                        {formatNumber(row.count)}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <SurfaceEmptyState data-testid="ops-bottlenecks-empty" className="py-8">
+                  <div className="flex flex-col items-center gap-2 text-center">
+                    <Wifi size={20} style={{ color: "var(--th-text-muted)" }} />
+                    <div className="text-sm font-semibold" style={{ color: "var(--th-text-primary)" }}>
+                      {tr("현재 감지된 운영 병목이 없습니다.", "No active ops bottlenecks detected.")}
+                    </div>
+                    <div className="text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                      {tr("warning 이상 신호가 생기면 이 목록에 즉시 올라옵니다.", "Signals at warning level or above will appear here immediately.")}
+                    </div>
+                  </div>
+                </SurfaceEmptyState>
+              )}
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="card-head">
+              <div className="min-w-0">
+                <div className="card-title">{tr("Connection & Delivery", "Connection & Delivery")}</div>
+                <div className="mt-1 text-[11px] leading-5" style={{ color: "var(--th-text-muted)" }}>
+                  {tr(
+                    "연결 상태와 전달 흐름의 건강도를 한눈에 확인합니다.",
+                    "Track connectivity and delivery health at a glance.",
+                  )}
+                </div>
+              </div>
+            </div>
+            <div data-testid="ops-connection-panel" className="card-body space-y-3">
+              <div
+                data-testid="ops-websocket-card"
+                className="card ops-mini-card"
+                style={{
+                  borderColor: wsConnected
+                    ? "color-mix(in srgb, var(--color-info) 18%, var(--th-border-subtle) 82%)"
+                    : "color-mix(in srgb, var(--color-danger) 18%, var(--th-border-subtle) 82%)",
+                  background:
+                    "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
+                }}
+              >
+                <div className="card-body">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--th-text-muted)" }}>
+                        websocket
+                      </div>
+                      <div className="mt-2 text-lg font-semibold" style={{ color: "var(--th-text-primary)" }}>
+                        {wsConnected ? tr("실시간 연결됨", "Connected live") : tr("연결 끊김", "Disconnected")}
+                      </div>
+                      <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                        {wsConnected
+                          ? tr("pcd-ws-event 수신 시 health refresh를 즉시 재스케줄합니다.", "Incoming pcd-ws-event messages reschedule health refreshes immediately.")
+                          : tr("WS가 복구될 때까지 내부 polling으로 health를 유지합니다.", "Internal polling keeps health current until WS recovers.")}
+                      </div>
+                    </div>
+                    <span className={chipClassFromTone(wsConnected ? "success" : "danger")}>
+                      {wsConnected ? "LIVE" : "DISCONNECTED"}
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              <div className="grid sm:grid-cols-2">
+                <div data-testid="ops-dispatch-outbox-card" className="card ops-mini-card">
+                  <div className="card-body">
+                    <div className="metric-label">
+                      dispatch_outbox
+                    </div>
+                    <div className="metric-value" style={{ marginTop: 8, fontSize: 22, color: "var(--th-text-primary)" }}>
+                      {formatNumber(health?.dispatch_outbox?.pending ?? 0)}
+                    </div>
+                    <div className="metric-sub" style={{ marginTop: 6, fontSize: 12 }}>
+                      {tr(
+                        `retry ${formatNumber(health?.dispatch_outbox?.retrying ?? 0)} · fail ${formatNumber(health?.dispatch_outbox?.permanent_failures ?? 0)}`,
+                        `retry ${formatNumber(health?.dispatch_outbox?.retrying ?? 0)} · fail ${formatNumber(health?.dispatch_outbox?.permanent_failures ?? 0)}`,
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                <div data-testid="ops-providers-card" className="card ops-mini-card">
+                  <div className="card-body">
+                    <div className="metric-label">
+                      providers
+                    </div>
+                    <div className="metric-value" style={{ marginTop: 8, fontSize: 22, color: "var(--th-text-primary)" }}>
+                      {connectedProviders}/{providerCount}
+                    </div>
+                    <div className="metric-sub" style={{ marginTop: 6, fontSize: 12 }}>
+                      {tr(
+                        `disconnect ${formatNumber(disconnectedProviders)} · restart ${formatNumber(restartPendingProviders)}`,
+                        `disconnect ${formatNumber(disconnectedProviders)} · restart ${formatNumber(restartPendingProviders)}`,
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="card mt-4">
+          <div className="card-head">
+            <div className="min-w-0">
+              <div className="card-title">{tr("오피스 운영", "Office Operations")}</div>
+              <div className="mt-1 text-[11px] leading-5" style={{ color: "var(--th-text-muted)" }}>
+                {tr(
+                  "오피스 공간, 좌석, 배치를 한곳에서 관리합니다.",
+                  "Manage spaces, seats, and layouts in one place.",
+                )}
+              </div>
+            </div>
+          </div>
+          <div className="card-body">
+            <div className="-mx-4 sm:-mx-5">
+              <OfficeManagerView
+                offices={offices}
+                allAgents={allAgents}
+                selectedOfficeId={selectedOfficeId}
+                isKo={isKo}
+                onChanged={onChanged}
+              />
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/dashboard/src/components/SettingsView.tsx
+++ b/dashboard/src/components/SettingsView.tsx
@@ -1,3 +1,4 @@
+import { Check, Eye, Info, Search } from "lucide-react";
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type FormEvent, type ReactNode } from "react";
 import type { CompanySettings, Agent } from "../types";
 import * as api from "../api";
@@ -8,14 +9,11 @@ import {
   writeLocalStorageValue,
 } from "../lib/useLocalStorage";
 import {
-  SettingsCallout,
-  SettingsCard,
-  SettingsEmptyState,
-  SettingsSection,
-  SettingsSubsection,
-} from "./common/SettingsPrimitives";
-import {
-  SurfaceSection,
+  SurfaceCallout as SettingsCallout,
+  SurfaceCard as SettingsCard,
+  SurfaceEmptyState as SettingsEmptyState,
+  SurfaceSection as SettingsSection,
+  SurfaceSubsection as SettingsSubsection,
 } from "./common/SurfacePrimitives";
 
 const OnboardingWizard = lazy(() => import("./OnboardingWizard"));
@@ -538,7 +536,7 @@ function readStoredSettingsPanel(): SettingsPanel {
   if (panelFromUrl) {
     return panelFromUrl;
   }
-  return readLocalStorageValue<SettingsPanel>(STORAGE_KEYS.settingsPanel, "general", {
+  return readLocalStorageValue<SettingsPanel>(STORAGE_KEYS.settingsPanel, "pipeline", {
     validate: (value): value is SettingsPanel => typeof value === "string" && isSettingsPanel(value),
     legacy: (raw) => (isSettingsPanel(raw) ? raw : null),
   });
@@ -721,36 +719,46 @@ function PanelNavButton({
       onClick={onClick}
       aria-current={active ? "page" : undefined}
       aria-controls={ariaControls}
-      className="w-full rounded-2xl border px-4 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--th-accent-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--th-card-bg)]"
+      className="w-full rounded-xl px-2.5 py-2.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--th-accent-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--th-card-bg)]"
       style={{
-        borderColor: active
-          ? "color-mix(in srgb, var(--th-accent-primary) 30%, var(--th-border) 70%)"
-          : "color-mix(in srgb, var(--th-border) 72%, transparent)",
+        borderColor: "transparent",
         background: active
-          ? "color-mix(in srgb, var(--th-accent-primary-soft) 68%, transparent)"
-          : "color-mix(in srgb, var(--th-card-bg) 92%, transparent)",
+          ? "color-mix(in srgb, var(--th-overlay-medium) 92%, transparent)"
+          : "transparent",
       }}
     >
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <div className="text-sm font-semibold" style={{ color: "var(--th-text)" }}>
-            {title}
+      <div className="flex items-start gap-3">
+        <span
+          className="mt-1 h-2 w-2 shrink-0 rounded-full"
+          style={{
+            background: active ? "var(--th-accent-primary)" : "color-mix(in srgb, var(--th-text-muted) 50%, transparent)",
+          }}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-3">
+            <div
+              className="text-sm font-semibold"
+              style={{ color: active ? "var(--th-accent-primary)" : "var(--th-text-heading)" }}
+            >
+              {title}
+            </div>
+            {count && (
+              <span
+                className="shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium"
+                style={{
+                  borderColor: "color-mix(in srgb, var(--th-border) 72%, transparent)",
+                  background: "color-mix(in srgb, var(--th-overlay-medium) 88%, transparent)",
+                  color: active ? "var(--th-text)" : "var(--th-text-muted)",
+                }}
+              >
+                {count}
+              </span>
+            )}
           </div>
-          <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+          <div className="mt-1 text-[11px] leading-5" style={{ color: "var(--th-text-muted)" }}>
             {detail}
           </div>
         </div>
-        {count && (
-          <span
-            className="shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium"
-            style={{
-              borderColor: "color-mix(in srgb, var(--th-border) 72%, transparent)",
-              color: active ? "var(--th-text)" : "var(--th-text-muted)",
-            }}
-          >
-            {count}
-          </span>
-        )}
       </div>
     </button>
   );
@@ -870,7 +878,10 @@ function StorageSurfaceCard({
   return (
     <SettingsCard
       className="rounded-2xl p-4"
-      style={{ borderColor: "rgba(148,163,184,0.16)", background: "rgba(15,23,42,0.28)" }}
+      style={{
+        borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)",
+        background: "color-mix(in srgb, var(--th-card-bg) 92%, transparent)",
+      }}
     >
       <div className="text-sm font-medium" style={{ color: "var(--th-text)" }}>
         {title}
@@ -878,7 +889,7 @@ function StorageSurfaceCard({
       <p className="mt-2 text-sm leading-6" style={{ color: "var(--th-text-muted)" }}>
         {body}
       </p>
-      <div className="mt-3 text-[11px] font-medium uppercase tracking-[0.16em]" style={{ color: "var(--th-text-secondary)" }}>
+      <div className="mt-3 text-[11px] font-medium uppercase tracking-[0.16em]" style={{ color: "var(--th-text-muted)" }}>
         {footer}
       </div>
     </SettingsCard>
@@ -889,7 +900,10 @@ function AuditNoteCard({ note, isKo }: { note: AuditNote; isKo: boolean }) {
   return (
     <SettingsCard
       className="rounded-2xl p-4"
-      style={{ borderColor: "rgba(148,163,184,0.16)", background: "rgba(15,23,42,0.28)" }}
+      style={{
+        borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)",
+        background: "color-mix(in srgb, var(--th-card-bg) 92%, transparent)",
+      }}
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0">
@@ -909,7 +923,11 @@ function AuditNoteCard({ note, isKo }: { note: AuditNote; isKo: boolean }) {
           <span
             key={key}
             className="inline-flex items-center rounded-full border px-2.5 py-1 text-[11px]"
-            style={{ borderColor: "rgba(148,163,184,0.22)", color: "var(--th-text-secondary)" }}
+            style={{
+              borderColor: "color-mix(in srgb, var(--th-border) 70%, transparent)",
+              background: "color-mix(in srgb, var(--th-overlay-medium) 84%, transparent)",
+              color: "var(--th-text-muted)",
+            }}
           >
             {key}
           </span>
@@ -1333,15 +1351,8 @@ export default function SettingsView({
   };
 
   const renderGeneralPanel = () => (
-    <SettingsSection
-      eyebrow={tr("일반", "General")}
-      title={tr("브랜드와 표시 환경", "Brand and display")}
-      description={tr(
-        "브랜드 정보와 화면 표시 옵션을 한 폼에서 저장합니다.",
-        "Save brand identity and display preferences in one form.",
-      )}
-    >
-      <form className="mt-5 space-y-5" onSubmit={handleSave} noValidate>
+    <div className="space-y-5">
+      <form className="space-y-5" onSubmit={handleSave} noValidate>
         <fieldset className="space-y-3">
           <legend className="text-sm font-semibold" style={{ color: "var(--th-text)" }}>
             {tr("브랜드 정보", "Brand identity")}
@@ -1487,7 +1498,6 @@ export default function SettingsView({
       </form>
 
       <SettingsSubsection
-        className="mt-5"
         title={tr("저장 경로", "Storage surfaces")}
         description={tr(
           "이 화면의 값이 어디에 저장되는지 먼저 보여줍니다. 저장면을 숨기면 운영자가 설정의 실제 영향 범위를 오해하게 됩니다.",
@@ -1529,24 +1539,17 @@ export default function SettingsView({
           />
         </div>
       </SettingsSubsection>
-    </SettingsSection>
+    </div>
   );
 
   const renderRuntimePanel = () => (
-    <SettingsSection
-      eyebrow={tr("런타임", "Runtime")}
-      title={tr("운영 리듬과 캐시", "Cadence and cache")}
-      description={tr(
-        "재시작 없이 바로 반영되는 값만 모았습니다.",
-        "Only the values that apply without restart are shown here.",
-      )}
-    >
+    <div className="space-y-4">
       {!rcLoaded ? (
-        <SettingsEmptyState className="mt-5 text-sm">
+        <SettingsEmptyState className="text-sm">
           {tr("런타임 설정을 불러오는 중...", "Loading runtime config...")}
         </SettingsEmptyState>
       ) : (
-        <div className="mt-5 space-y-4">
+        <div className="space-y-4">
           <div className="flex flex-wrap gap-2">
             {CATEGORIES.map((category) => (
               <button
@@ -1648,7 +1651,7 @@ export default function SettingsView({
               >
                 {rcSaving ? tr("저장 중...", "Saving...") : tr("런타임 저장", "Save runtime")}
               </button>
-            )}
+              )}
           >
             <p className="text-sm leading-6" style={{ color: "var(--th-text-muted)" }}>
               {tr(
@@ -1659,7 +1662,7 @@ export default function SettingsView({
           </SettingsCallout>
         </div>
       )}
-    </SettingsSection>
+    </div>
   );
 
   const renderPipelineCategory = (categoryKey: keyof typeof SYSTEM_CATEGORY_META) => {
@@ -1791,22 +1794,14 @@ export default function SettingsView({
   };
 
   const renderPipelinePanel = () => (
-    <SettingsSection
-      eyebrow={tr("파이프라인", "Pipeline")}
-      title={tr("리뷰와 상태 전환 정책", "Review and transition policy")}
-      description={tr(
-        "개별 `kv_meta` 키로 저장되는 정책 값을 편집하고, 저장 레이어와 read-only 조건도 같이 노출합니다.",
-        "Edit policy values stored as individual `kv_meta` keys and expose storage-layer/read-only metadata alongside them.",
-      )}
-    >
+    <div className="space-y-5">
       {configEntries.length === 0 ? (
-        <SettingsEmptyState className="mt-5 text-sm">
+        <SettingsEmptyState className="text-sm">
           {tr("파이프라인 설정을 불러오는 중...", "Loading pipeline config...")}
         </SettingsEmptyState>
       ) : (
-        <div className="mt-5 space-y-5">
+        <div className="space-y-5">
           <SettingsCallout
-            className="mt-0"
             action={(
               <button
                 onClick={handleConfigSave}
@@ -1969,28 +1964,11 @@ export default function SettingsView({
           </div>
         </div>
       )}
-    </SettingsSection>
+    </div>
   );
 
   const renderOnboardingPanel = () => (
-    <SettingsSection
-      eyebrow={tr("온보딩", "Onboarding")}
-      title={tr("초기 연결과 기본 세팅", "Initial wiring and defaults")}
-      description={tr(
-        "Discord 연결, owner/provider, 기본 파이프라인 같은 첫 세팅은 전용 위저드에서 다시 수행합니다.",
-        "Re-run Discord wiring, owner/provider setup, and first-run defaults from the dedicated wizard.",
-      )}
-      actions={(
-        <button
-          onClick={openOnboarding}
-          className={secondaryActionClass}
-          style={secondaryActionStyle}
-        >
-          {tr("온보딩 다시 실행", "Re-run onboarding")}
-        </button>
-      )}
-    >
-      <div className="mt-5 grid gap-3 md:grid-cols-[minmax(0,1.15fr)_minmax(16rem,0.85fr)]">
+    <div className="grid gap-3 md:grid-cols-[minmax(0,1.15fr)_minmax(16rem,0.85fr)]">
         <SettingsCard
           className="rounded-3xl p-5"
           style={{
@@ -2025,7 +2003,6 @@ export default function SettingsView({
           </div>
         </SettingsCard>
       </div>
-    </SettingsSection>
   );
 
   const renderActivePanel = () => {
@@ -2067,6 +2044,7 @@ export default function SettingsView({
             className={secondaryActionClass}
             style={secondaryActionStyle}
           >
+            <Eye size={12} />
             {tr("audit 노트", "Audit notes")}
           </button>
           <button
@@ -2075,6 +2053,7 @@ export default function SettingsView({
             className={primaryActionClass}
             style={primaryActionStyle}
           >
+            <Check size={12} />
             {configSaving ? tr("저장 중...", "Saving...") : tr("저장", "Save")}
           </button>
         </>
@@ -2089,6 +2068,7 @@ export default function SettingsView({
           className={primaryActionClass}
           style={primaryActionStyle}
         >
+          <Check size={12} />
           {rcSaving ? tr("저장 중...", "Saving...") : tr("저장", "Save")}
         </button>
       );
@@ -2101,156 +2081,150 @@ export default function SettingsView({
         className={primaryActionClass}
         style={primaryActionStyle}
       >
+        <Check size={12} />
         {saving ? tr("저장 중...", "Saving...") : tr("저장", "Save")}
       </button>
     );
   };
-  const renderHeaderMeta = () => {
-    if (activePanel === "pipeline") {
-      return (
-        <div className="mt-4 flex flex-wrap gap-2">
-          <span className="inline-flex items-center rounded-full border px-3 py-1 text-[11px] font-medium" style={{ borderColor: "rgba(148,163,184,0.22)", color: "var(--th-text-secondary)" }}>
-            {tr(`키 ${visibleConfigEntries.length}개`, `${visibleConfigEntries.length} keys`)}
-          </span>
-          <span className="inline-flex items-center rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-1 text-[11px] font-medium text-amber-100">
-            {tr(`live override ${pipelineLiveOverrideCount}개`, `${pipelineLiveOverrideCount} live overrides`)}
-          </span>
-          <span className="inline-flex items-center rounded-full border border-slate-400/30 bg-slate-400/10 px-3 py-1 text-[11px] font-medium text-slate-200">
-            {tr(`read only ${pipelineReadOnlyCount}개`, `${pipelineReadOnlyCount} read-only`)}
-          </span>
-          <span className="inline-flex items-center rounded-full border border-sky-400/30 bg-sky-400/10 px-3 py-1 text-[11px] font-medium text-sky-100">
-            {tr(`audit 노트 ${AUDIT_NOTES.length}개`, `${AUDIT_NOTES.length} audit notes`)}
-          </span>
-        </div>
-      );
-    }
-
-    if (activePanel === "runtime") {
-      return (
-        <div className="mt-4 flex flex-wrap gap-2">
-          <span className="inline-flex items-center rounded-full border px-3 py-1 text-[11px] font-medium" style={{ borderColor: "rgba(148,163,184,0.22)", color: "var(--th-text-secondary)" }}>
-            {tr(`현재 카테고리 ${tr(activeRuntimeCategory.titleKo, activeRuntimeCategory.titleEn)}`, `Current category ${tr(activeRuntimeCategory.titleKo, activeRuntimeCategory.titleEn)}`)}
-          </span>
-          <span className="inline-flex items-center rounded-full border px-3 py-1 text-[11px] font-medium" style={{ borderColor: "rgba(148,163,184,0.22)", color: rcDirty ? "var(--th-text)" : "var(--th-text-muted)" }}>
-            {rcDirty ? tr("저장되지 않은 변경 있음", "Unsaved changes") : tr("모든 변경 저장됨", "All changes saved")}
-          </span>
-        </div>
-      );
-    }
-
-    if (activePanel === "general") {
-      return (
-        <div className="mt-4 flex flex-wrap gap-2">
-          <span className="inline-flex items-center rounded-full border px-3 py-1 text-[11px] font-medium" style={{ borderColor: "rgba(148,163,184,0.22)", color: "var(--th-text-secondary)" }}>
-            {tr(`기본 필드 ${generalFieldCount}개`, `${generalFieldCount} base fields`)}
-          </span>
-          <span className="inline-flex items-center rounded-full border px-3 py-1 text-[11px] font-medium" style={{ borderColor: "rgba(148,163,184,0.22)", color: companyDirty ? "var(--th-text)" : "var(--th-text-muted)" }}>
-            {companyDirty ? tr("변경 감지됨", "Changes detected") : tr("동기화됨", "In sync")}
-          </span>
-        </div>
-      );
-    }
-
-    return (
-      <div className="mt-4 flex flex-wrap gap-2">
-        <span className="inline-flex items-center rounded-full border px-3 py-1 text-[11px] font-medium" style={{ borderColor: "rgba(148,163,184,0.22)", color: "var(--th-text-secondary)" }}>
-          {tr("Discord 연결과 초기 세팅 전용", "Dedicated to Discord wiring and first-run setup")}
-        </span>
+  const settingsInfoNotice = (
+    <div
+      className="flex items-start gap-3 rounded-[18px] border px-4 py-4 sm:px-5"
+      style={{
+        borderColor: "color-mix(in srgb, var(--th-border) 72%, transparent)",
+        background: "color-mix(in srgb, var(--th-card-bg) 92%, transparent)",
+      }}
+    >
+      <div
+        className="grid h-7 w-7 shrink-0 place-items-center rounded-[10px]"
+        style={{
+          background: "var(--th-accent-primary-soft)",
+          color: "var(--th-accent-primary)",
+        }}
+      >
+        <Info size={14} />
       </div>
-    );
-  };
+      <div className="text-sm leading-6" style={{ color: "var(--th-text-muted)" }}>
+        {tr("whitelist된 ", "Only whitelisted ")}
+        <code
+          className="rounded px-1.5 py-0.5 text-[12px]"
+          style={{
+            fontFamily: "var(--font-mono)",
+            color: "var(--th-text)",
+            background: "color-mix(in srgb, var(--th-overlay-medium) 88%, transparent)",
+          }}
+        >
+          kv_meta
+        </code>{" "}
+        {tr(
+          "키만 편집합니다. read-only 항목도 숨기지 않고 현재 상태를 그대로 보여줍니다.",
+          "keys are editable. Read-only items stay visible so the current state remains explicit.",
+        )}
+      </div>
+    </div>
+  );
 
   return (
     <div
-      className="mx-auto w-full max-w-6xl min-w-0 overflow-x-hidden px-4 py-4 pb-40 sm:px-6"
+      className="page fade-in mx-auto w-full max-w-6xl min-w-0 overflow-x-hidden px-4 py-4 pb-40 sm:px-6"
       style={{ paddingBottom: "max(10rem, calc(10rem + env(safe-area-inset-bottom)))" }}
     >
-      <div className="grid gap-4 md:grid-cols-[220px_minmax(0,1fr)]">
+      <div className="page-header">
+        <div className="min-w-0">
+          <div className="page-title">{tr("설정", "Settings")}</div>
+          <div className="page-sub">
+            {tr(
+              "카탈로그에서 꺼내 쓰는 kv_meta 설정",
+              "Catalog-driven kv_meta configuration",
+            )}
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">{renderHeaderActions()}</div>
+      </div>
+
+      <div className="mt-4 grid gap-4 md:grid-cols-[220px_minmax(0,1fr)]">
         <aside className="min-w-0 md:sticky md:top-4 md:self-start">
-          <SettingsCard
-            className="rounded-[28px] p-4 sm:p-5"
-            style={{
-              borderColor: "color-mix(in srgb, var(--th-accent-info) 20%, var(--th-border) 80%)",
-              background: "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 95%, var(--th-badge-sky-bg) 5%) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
-            }}
-          >
-            <div
-              className="text-[11px] font-semibold uppercase tracking-[0.18em]"
+          <div className="relative mb-3">
+            <Search
+              size={13}
+              className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2"
               style={{ color: "var(--th-text-muted)" }}
-            >
-              {tr("설정 그룹", "Settings groups")}
-            </div>
-            <div className="mt-2 text-lg font-semibold" style={{ color: "var(--th-text)" }}>
-              {tr("220px 그룹 내비", "220px group nav")}
-            </div>
-            <p className="mt-2 text-sm leading-6" style={{ color: "var(--th-text-muted)" }}>
-              {tr(
-                "좌측에서 그룹을 고르고, 우측에서 실제 설정 카드와 저장 상태를 확인합니다.",
-                "Pick a group on the left, then inspect cards and save state on the right.",
-              )}
-            </p>
+            />
+            <input
+              type="search"
+              value={panelQuery}
+              onChange={(event) => setPanelQuery(event.target.value)}
+              placeholder={tr("설정 검색", "Search settings")}
+              className="w-full rounded-xl py-2.5 pl-9 pr-3 text-sm"
+              style={inputStyle}
+            />
+          </div>
 
-            <div className="mt-4">
-              <label className="block text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "var(--th-text-muted)" }}>
-                {tr("검색", "Search")}
-              </label>
-              <input
-                type="search"
-                value={panelQuery}
-                onChange={(event) => setPanelQuery(event.target.value)}
-                placeholder={tr("그룹 이름 검색", "Search groups")}
-                className="mt-2 w-full rounded-2xl px-3 py-2.5 text-sm"
-                style={inputStyle}
-              />
-            </div>
-
-            <div className="mt-4 space-y-2">
-              {filteredNavItems.length > 0 ? (
-                filteredNavItems.map((item) => (
-                  <PanelNavButton
-                    key={item.id}
-                    id={`settings-tab-${item.id}`}
-                    active={activePanel === item.id}
-                    title={item.title}
-                    detail={item.detail}
-                    count={item.count}
-                    ariaControls="settings-panel-content"
-                    onClick={() => handlePanelChange(item.id)}
-                  />
-                ))
-              ) : (
-                <SettingsEmptyState className="text-sm">
-                  {tr("검색 결과가 없습니다.", "No groups match the search.")}
-                </SettingsEmptyState>
-              )}
-            </div>
-          </SettingsCard>
+          <div
+            role="tablist"
+            aria-label={tr("설정 패널", "Settings panels")}
+            className="space-y-1"
+          >
+            {filteredNavItems.length > 0 ? (
+              filteredNavItems.map((item) => (
+                <PanelNavButton
+                  key={item.id}
+                  id={`settings-tab-${item.id}`}
+                  active={activePanel === item.id}
+                  title={item.title}
+                  detail={item.detail}
+                  count={item.count}
+                  ariaControls="settings-panel-content"
+                  onClick={() => handlePanelChange(item.id)}
+                />
+              ))
+            ) : (
+              <SettingsEmptyState className="text-sm">
+                {tr("검색 결과가 없습니다.", "No groups match the search.")}
+              </SettingsEmptyState>
+            )}
+          </div>
         </aside>
 
         <div className="min-w-0 space-y-4">
-          <SurfaceSection
-            eyebrow={tr("설정", "Settings")}
-            title={activeNavItem.title}
-            description={activeNavItem.detail}
-            actions={renderHeaderActions()}
-            className="rounded-[28px] p-4 sm:p-5"
-            style={{
-              borderColor: "color-mix(in srgb, var(--th-accent-info) 20%, var(--th-border) 80%)",
-              background: "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 95%, var(--th-badge-sky-bg) 5%) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
-            }}
-          >
-            {renderHeaderMeta()}
-          </SurfaceSection>
+          {settingsInfoNotice}
 
-          <div
+          <SettingsCard
             id="settings-panel-content"
             role="tabpanel"
             aria-labelledby={`settings-tab-${activePanel}`}
             tabIndex={-1}
-            className="min-w-0"
+            className="min-w-0 rounded-[28px] border px-4 py-4 outline-none sm:px-5 sm:py-5"
+            style={{
+              borderColor: "color-mix(in srgb, var(--th-border) 72%, transparent)",
+              background: "color-mix(in srgb, var(--th-card-bg) 92%, transparent)",
+            }}
           >
-            {renderActivePanel()}
-          </div>
+            <div className="flex flex-wrap items-start justify-between gap-3 border-b pb-4" style={{ borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)" }}>
+              <div className="min-w-0">
+                <div className="text-sm font-semibold" style={{ color: "var(--th-text)" }}>
+                  {activeNavItem.title}
+                </div>
+                <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                  {activeNavItem.detail}
+                </div>
+              </div>
+              {activeNavItem.count ? (
+                <span
+                  className="inline-flex items-center rounded-full border px-2.5 py-1 text-[10px] font-medium"
+                  style={{
+                    borderColor: "color-mix(in srgb, var(--th-border) 72%, transparent)",
+                    background: "color-mix(in srgb, var(--th-overlay-medium) 88%, transparent)",
+                    color: "var(--th-text-muted)",
+                  }}
+                >
+                  {activeNavItem.count}
+                </span>
+              ) : null}
+            </div>
+            <div className="mt-5 min-w-0">
+              {renderActivePanel()}
+            </div>
+          </SettingsCard>
         </div>
       </div>
 

--- a/dashboard/src/components/SkillCatalogView.tsx
+++ b/dashboard/src/components/SkillCatalogView.tsx
@@ -1,18 +1,471 @@
-import { useEffect, useState, useMemo } from "react";
-import type { SkillCatalogEntry } from "../types";
-import { getSkillCatalog } from "../api/client";
 import { BookOpen, Search } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { getSkillCatalog } from "../api/client";
 import { useI18n } from "../i18n";
+import type { SkillCatalogEntry } from "../types";
 
-export default function SkillCatalogView({ embedded = false }: { embedded?: boolean }) {
+const SKILL_CATALOG_SHELL_STYLES = `
+  .skill-catalog-shell {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .skill-catalog-shell .page-header {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 14px;
+    flex-wrap: wrap;
+  }
+
+  .skill-catalog-shell .page-title {
+    font-size: 22px;
+    font-weight: 600;
+    letter-spacing: -0.5px;
+    line-height: 1.2;
+    color: var(--th-text-heading);
+  }
+
+  .skill-catalog-shell .page-sub {
+    margin-top: 4px;
+    max-width: 68ch;
+    font-size: 13px;
+    color: var(--th-text-muted);
+    line-height: 1.65;
+  }
+
+  .skill-catalog-shell .card {
+    border-radius: 18px;
+    border: 1px solid color-mix(in srgb, var(--th-border) 72%, transparent);
+    background: color-mix(in srgb, var(--th-card-bg) 94%, transparent);
+    overflow: hidden;
+  }
+
+  .skill-catalog-shell .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--th-border) 70%, transparent);
+    background: color-mix(in srgb, var(--th-bg-surface) 90%, transparent);
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--th-text-dim);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .skill-catalog-shell .chip .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 999px;
+    background: currentColor;
+    opacity: 0.9;
+  }
+
+  .skill-catalog-shell .search-wrap {
+    position: relative;
+    width: min(100%, 260px);
+  }
+
+  .skill-catalog-shell.embedded .search-wrap {
+    width: 100%;
+  }
+
+  .skill-catalog-shell .search-input {
+    width: 100%;
+    padding: 7px 10px 7px 30px;
+    border-radius: 8px;
+    border: 1px solid color-mix(in srgb, var(--th-border) 72%, transparent);
+    background: color-mix(in srgb, var(--th-bg-surface) 88%, transparent);
+    color: var(--th-text);
+    font-size: 12.5px;
+  }
+
+  .skill-catalog-shell .metric-grid {
+    display: grid;
+    gap: 10px;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .skill-catalog-shell .metric-card {
+    padding: 12px 14px;
+  }
+
+  .skill-catalog-shell .metric-label {
+    font-size: 10px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--th-text-muted);
+    font-weight: 600;
+  }
+
+  .skill-catalog-shell .metric-value {
+    margin-top: 8px;
+    font-size: 20px;
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    color: var(--th-text-heading);
+  }
+
+  .skill-catalog-shell .skill-tag-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .skill-catalog-shell .skill-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--th-border) 72%, transparent);
+    background: color-mix(in srgb, var(--th-bg-surface) 86%, transparent);
+    font-size: 12px;
+    color: var(--th-text-dim);
+    transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+  }
+
+  .skill-catalog-shell .skill-tag.active {
+    border-color: color-mix(in srgb, var(--th-accent-info) 28%, var(--th-border) 72%);
+    background: color-mix(in srgb, var(--th-accent-info) 12%, transparent);
+    color: var(--th-text-heading);
+  }
+
+  .skill-catalog-shell .skill-layout {
+    display: grid;
+    gap: 14px;
+    grid-template-columns: minmax(0, 1.45fr) minmax(260px, 0.78fr);
+  }
+
+  .skill-catalog-shell .skill-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 12px;
+  }
+
+  .skill-catalog-shell.embedded .skill-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .skill-catalog-shell .skill-card {
+    padding: 14px;
+  }
+
+  .skill-catalog-shell .skill-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 10px;
+  }
+
+  .skill-catalog-shell .skill-name {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--th-text-heading);
+    line-height: 1.35;
+    word-break: break-word;
+  }
+
+  .skill-catalog-shell .skill-desc {
+    margin-top: 10px;
+    font-size: 12.5px;
+    line-height: 1.65;
+    color: var(--th-text-muted);
+  }
+
+  .skill-catalog-shell .skill-foot {
+    margin-top: 14px;
+    display: grid;
+    gap: 10px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .skill-catalog-shell .skill-stat {
+    border-radius: 14px;
+    border: 1px solid color-mix(in srgb, var(--th-border) 70%, transparent);
+    background: color-mix(in srgb, var(--th-card-bg) 88%, transparent);
+    padding: 10px 12px;
+  }
+
+  .skill-catalog-shell .skill-stat-label {
+    font-size: 10px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--th-text-muted);
+    font-weight: 600;
+  }
+
+  .skill-catalog-shell .skill-stat-value {
+    margin-top: 8px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--th-text-heading);
+  }
+
+  .skill-catalog-shell .skill-usage {
+    margin-top: 12px;
+  }
+
+  .skill-catalog-shell .skill-usage-meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    font-size: 11px;
+    color: var(--th-text-muted);
+  }
+
+  .skill-catalog-shell .skill-usage-bar {
+    margin-top: 8px;
+    height: 5px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--th-border) 72%, transparent);
+    overflow: hidden;
+  }
+
+  .skill-catalog-shell .skill-usage-fill {
+    height: 100%;
+    border-radius: inherit;
+  }
+
+  .skill-catalog-shell .highlights {
+    padding: 14px;
+    border-color: color-mix(in srgb, var(--th-accent-primary) 20%, var(--th-border) 80%);
+    background: linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, var(--th-accent-primary-soft) 4%) 0%, color-mix(in srgb, var(--th-bg-surface) 98%, transparent) 100%);
+  }
+
+  .skill-catalog-shell .section-eyebrow {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--th-text-muted);
+  }
+
+  .skill-catalog-shell .section-copy {
+    margin-top: 8px;
+    font-size: 13px;
+    line-height: 1.65;
+    color: var(--th-text-muted);
+  }
+
+  .skill-catalog-shell .featured-list {
+    margin-top: 14px;
+    display: grid;
+    gap: 10px;
+  }
+
+  .skill-catalog-shell .featured-item {
+    border-radius: 14px;
+    border: 1px solid color-mix(in srgb, var(--th-border) 70%, transparent);
+    background: color-mix(in srgb, var(--th-card-bg) 88%, transparent);
+    padding: 10px 12px;
+  }
+
+  @media (max-width: 1279px) {
+    .skill-catalog-shell .skill-layout {
+      grid-template-columns: 1fr;
+    }
+
+    .skill-catalog-shell .skill-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 767px) {
+    .skill-catalog-shell .metric-grid,
+    .skill-catalog-shell .skill-grid,
+    .skill-catalog-shell .skill-foot {
+      grid-template-columns: 1fr;
+    }
+
+    .skill-catalog-shell .search-wrap {
+      width: 100%;
+    }
+  }
+`;
+
+const SKILL_CATEGORY_META = {
+  all: {
+    label: { ko: "all", en: "All" },
+    summary: {
+      ko: "전체 스킬을 호출 빈도와 최근성 순으로 정렬합니다.",
+      en: "All skills ranked by usage and recency.",
+    },
+  },
+  workflow: {
+    label: { ko: "workflow", en: "Workflow" },
+    summary: {
+      ko: "에이전트 전달, 브리핑, 자동화 루틴에 가까운 스킬.",
+      en: "Skills oriented around coordination, briefing, and operational flow.",
+    },
+  },
+  github: {
+    label: { ko: "github", en: "GitHub" },
+    summary: {
+      ko: "이슈, PR, 저장소 흐름과 맞닿은 스킬.",
+      en: "Skills tied to issues, PRs, and repository flow.",
+    },
+  },
+  meetings: {
+    label: { ko: "meeting", en: "Meeting" },
+    summary: {
+      ko: "라운드테이블, 회의 요약, 일정 맥락에 가까운 스킬.",
+      en: "Skills close to round-tables, summaries, and scheduling context.",
+    },
+  },
+  ops: {
+    label: { ko: "ops", en: "Ops" },
+    summary: {
+      ko: "재시작, 배포, 복구, 런타임 운용 계열.",
+      en: "Restart, deploy, recovery, and runtime operations.",
+    },
+  },
+  knowledge: {
+    label: { ko: "memory", en: "Memory" },
+    summary: {
+      ko: "메모리, 다이제스트, 전사, 음성화처럼 지식 축적에 가까운 스킬.",
+      en: "Memory, digest, transcription, and knowledge-shaping skills.",
+    },
+  },
+} as const;
+
+const SKILL_ACTIVITY_META = {
+  core: {
+    label: { ko: "core", en: "Core" },
+    accent: "var(--th-accent-primary)",
+    background: "color-mix(in srgb, var(--th-accent-primary-soft) 76%, transparent)",
+    borderColor:
+      "color-mix(in srgb, var(--th-accent-primary) 26%, var(--th-border) 74%)",
+  },
+  recent: {
+    label: { ko: "recent", en: "Recent" },
+    accent: "var(--th-accent-success)",
+    background: "color-mix(in srgb, var(--th-accent-success) 12%, transparent)",
+    borderColor:
+      "color-mix(in srgb, var(--th-accent-success) 22%, var(--th-border) 78%)",
+  },
+  steady: {
+    label: { ko: "steady", en: "Steady" },
+    accent: "var(--th-accent-info)",
+    background: "color-mix(in srgb, var(--th-accent-info) 12%, transparent)",
+    borderColor:
+      "color-mix(in srgb, var(--th-accent-info) 22%, var(--th-border) 78%)",
+  },
+  dormant: {
+    label: { ko: "quiet", en: "Quiet" },
+    accent: "var(--th-text-muted)",
+    background: "color-mix(in srgb, var(--th-bg-surface) 88%, transparent)",
+    borderColor:
+      "color-mix(in srgb, var(--th-border) 72%, transparent)",
+  },
+} as const;
+
+type SkillCategoryId = keyof typeof SKILL_CATEGORY_META;
+type SkillActivityId = keyof typeof SKILL_ACTIVITY_META;
+type DerivedSkillEntry = {
+  skill: SkillCatalogEntry;
+  category: Exclude<SkillCategoryId, "all">;
+  activity: SkillActivityId;
+  usagePercent: number;
+  searchText: string;
+};
+
+function normalizeSkillText(skill: SkillCatalogEntry): string {
+  return `${skill.name} ${skill.description} ${skill.description_ko}`
+    .replace(/\s+/g, " ")
+    .toLowerCase();
+}
+
+function categorizeSkill(
+  skill: SkillCatalogEntry,
+): Exclude<SkillCategoryId, "all"> {
+  const text = normalizeSkillText(skill);
+  if (
+    /meeting|round table|회의|라운드테이블|briefing|summary|calendar|schedule/.test(
+      text,
+    )
+  ) {
+    return "meetings";
+  }
+  if (/github|repo|repository|issue|pull request|pr|git|kanban|review/.test(text)) {
+    return "github";
+  }
+  if (/restart|runtime|deploy|release|recover|watch|verify|launcher|sync/.test(text)) {
+    return "ops";
+  }
+  if (/memory|digest|transcribe|speech|notebook|context|profile|summary/.test(text)) {
+    return "knowledge";
+  }
+  return "workflow";
+}
+
+function getSkillActivity(
+  skill: SkillCatalogEntry,
+  maxCalls: number,
+): SkillActivityId {
+  const now = Date.now();
+  const threeDaysMs = 3 * 24 * 60 * 60 * 1000;
+  if (skill.total_calls <= 0) return "dormant";
+  if (skill.last_used_at && now - skill.last_used_at <= threeDaysMs) {
+    return "recent";
+  }
+  if (skill.total_calls >= Math.max(10, maxCalls * 0.45)) {
+    return "core";
+  }
+  return "steady";
+}
+
+function compareSkillEntries(left: DerivedSkillEntry, right: DerivedSkillEntry) {
+  if (left.skill.total_calls !== right.skill.total_calls) {
+    return right.skill.total_calls - left.skill.total_calls;
+  }
+  const rightLast = right.skill.last_used_at ?? 0;
+  const leftLast = left.skill.last_used_at ?? 0;
+  if (leftLast !== rightLast) {
+    return rightLast - leftLast;
+  }
+  return left.skill.name.localeCompare(right.skill.name);
+}
+
+function formatDateShort(ts: number | null, isKo: boolean): string {
+  if (!ts) return isKo ? "기록 없음" : "No record";
+
+  const date = new Date(ts);
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  const hours = Math.floor(diff / (1000 * 60 * 60));
+  const days = Math.floor(hours / 24);
+
+  if (hours < 1) return isKo ? "방금" : "Just now";
+  if (hours < 24) return isKo ? `${hours}시간 전` : `${hours}h ago`;
+  if (days === 1) return isKo ? "어제" : "Yesterday";
+  if (days < 7) return isKo ? `${days}일 전` : `${days}d ago`;
+
+  return date.toLocaleDateString(isKo ? "ko-KR" : "en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export default function SkillCatalogView({
+  embedded = false,
+}: {
+  embedded?: boolean;
+}) {
   const [catalog, setCatalog] = useState<SkillCatalogEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
+  const [activeCategory, setActiveCategory] = useState<SkillCategoryId>("all");
   const { t, language } = useI18n();
   const isKo = language === "ko";
 
   useEffect(() => {
     let mounted = true;
+
     (async () => {
       try {
         const data = await getSkillCatalog();
@@ -23,23 +476,82 @@ export default function SkillCatalogView({ embedded = false }: { embedded?: bool
         if (mounted) setLoading(false);
       }
     })();
-    return () => { mounted = false; };
+
+    return () => {
+      mounted = false;
+    };
   }, []);
 
-  const filtered = useMemo(() => {
-    if (!search.trim()) return catalog;
-    const q = search.toLowerCase();
-    return catalog.filter(
-      (s) =>
-        s.name.toLowerCase().includes(q) ||
-        s.description_ko.toLowerCase().includes(q) ||
-        s.description.toLowerCase().includes(q),
+  const derivedCatalog = useMemo(() => {
+    const maxCalls = Math.max(1, ...catalog.map((skill) => skill.total_calls));
+    return catalog
+      .map((skill) => {
+        const category = categorizeSkill(skill);
+        const activity = getSkillActivity(skill, maxCalls);
+        const usagePercent =
+          skill.total_calls <= 0
+            ? 6
+            : Math.max(10, Math.round((skill.total_calls / maxCalls) * 100));
+
+        return {
+          skill,
+          category,
+          activity,
+          usagePercent,
+          searchText: normalizeSkillText(skill),
+        };
+      })
+      .sort(compareSkillEntries);
+  }, [catalog]);
+
+  const categoryCounts = useMemo(() => {
+    return derivedCatalog.reduce<Record<Exclude<SkillCategoryId, "all">, number>>(
+      (counts, entry) => {
+        counts[entry.category] += 1;
+        return counts;
+      },
+      {
+        workflow: 0,
+        github: 0,
+        meetings: 0,
+        ops: 0,
+        knowledge: 0,
+      },
     );
-  }, [catalog, search]);
+  }, [derivedCatalog]);
+
+  const filtered = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return derivedCatalog.filter((entry) => {
+      if (activeCategory !== "all" && entry.category !== activeCategory) {
+        return false;
+      }
+      if (!query) return true;
+
+      const categoryMeta = SKILL_CATEGORY_META[entry.category];
+      const searchableCategoryText = `${categoryMeta.label.ko} ${categoryMeta.label.en} ${categoryMeta.summary.ko} ${categoryMeta.summary.en}`.toLowerCase();
+      return (
+        entry.searchText.includes(query) ||
+        searchableCategoryText.includes(query)
+      );
+    });
+  }, [activeCategory, derivedCatalog, search]);
+
+  const totalCalls = derivedCatalog.reduce(
+    (sum, entry) => sum + entry.skill.total_calls,
+    0,
+  );
 
   if (loading) {
     return (
-      <div className={embedded ? "py-8 text-center" : "flex items-center justify-center h-full"} style={{ color: "var(--th-text-muted)" }}>
+      <div
+        className={
+          embedded
+            ? "py-8 text-center"
+            : "flex h-full items-center justify-center"
+        }
+        style={{ color: "var(--th-text-muted)" }}
+      >
         <div className="text-center">
           <BookOpen size={40} className="mx-auto mb-4 opacity-30" />
           <div>{t({ ko: "스킬 로딩 중...", en: "Loading skills..." })}</div>
@@ -48,93 +560,196 @@ export default function SkillCatalogView({ embedded = false }: { embedded?: bool
     );
   }
 
-  const content = (
-    <>
-      <div className="flex items-center gap-3 mb-4">
-        <BookOpen className="text-blue-400" size={embedded ? 20 : 24} />
-        <h1 className={embedded ? "text-base font-semibold" : "text-xl font-bold"} style={{ color: "var(--th-text-heading)" }}>
-          {t({ ko: "스킬 카탈로그", en: "Skill Catalog" })}
-        </h1>
-        <span className="text-xs px-2 py-0.5 rounded-full" style={{ background: "rgba(59,130,246,0.15)", color: "#60a5fa" }}>
-          {isKo ? `${catalog.length}개` : catalog.length}
-        </span>
-      </div>
+  const cards = (
+    <div className="skill-grid">
+      {filtered.map((entry) => {
+        const categoryMeta = SKILL_CATEGORY_META[entry.category];
+        const activityMeta = SKILL_ACTIVITY_META[entry.activity];
+        const description = isKo
+          ? entry.skill.description_ko
+          : entry.skill.description;
 
-      {/* Search bar */}
-      <div className="relative mb-4">
-        <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2" style={{ color: "var(--th-text-muted)" }} />
-        <input
-          type="text"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder={t({ ko: "스킬 검색...", en: "Search skills..." })}
-          className="w-full pl-9 pr-3 py-2 rounded-xl text-sm"
-          style={{
-            background: "var(--th-bg-surface)",
-            border: "1px solid var(--th-border)",
-            color: "var(--th-text)",
-          }}
-        />
-      </div>
-
-      {filtered.length === 0 && (
-        <div className="text-center py-12" style={{ color: "var(--th-text-muted)" }}>
-          <BookOpen size={40} className="mx-auto mb-3 opacity-30" />
-          <p>{search ? t({ ko: "검색 결과가 없습니다", en: "No search results" }) : t({ ko: "등록된 스킬이 없습니다", en: "No skills registered" })}</p>
-        </div>
-      )}
-
-      {/* Card grid */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-        {filtered.map((skill) => (
-          <div
-            key={skill.name}
-            className="rounded-xl border p-4 hover:border-blue-500/30 transition-colors"
-            style={{ background: "var(--th-surface)", borderColor: "var(--th-border)" }}
-          >
-            <div className="font-semibold text-sm mb-1" style={{ color: "var(--th-text)" }}>
-              {skill.name}
-            </div>
-            <div className="text-xs leading-relaxed mb-3" style={{ color: "var(--th-text-muted)" }}>
-              {isKo ? skill.description_ko : skill.description}
-            </div>
-            <div className="flex items-center justify-between text-xs" style={{ color: "var(--th-text-muted)" }}>
-              <span>
-                {skill.total_calls > 0
-                  ? (isKo ? `${skill.total_calls}회 호출` : `${skill.total_calls} calls`)
-                  : t({ ko: "미사용", en: "Unused" })}
+        return (
+          <div key={entry.skill.name} className="card skill-card">
+            <div className="skill-head">
+              <div className="min-w-0">
+                <div className="skill-name">{entry.skill.name}</div>
+              </div>
+              <span
+                className="chip"
+                style={{
+                  fontSize: 10,
+                  borderColor: activityMeta.borderColor,
+                  background: activityMeta.background,
+                  color: activityMeta.accent,
+                }}
+              >
+                <span className="dot" />
+                {isKo ? categoryMeta.label.ko : categoryMeta.label.en}
               </span>
-              {skill.last_used_at && (
-                <span>
-                  {formatDateShort(skill.last_used_at, isKo)}
-                </span>
-              )}
+            </div>
+
+            <div className="skill-desc">{description}</div>
+
+            <div className="skill-foot">
+              <div className="skill-stat">
+                <div className="skill-stat-label">
+                  {t({ ko: "호출", en: "Calls" })}
+                </div>
+                <div className="skill-stat-value">
+                  {entry.skill.total_calls > 0
+                    ? entry.skill.total_calls.toLocaleString(
+                        isKo ? "ko-KR" : "en-US",
+                      )
+                    : t({ ko: "미사용", en: "Unused" })}
+                </div>
+              </div>
+              <div className="skill-stat">
+                <div className="skill-stat-label">
+                  {t({ ko: "마지막", en: "Last Used" })}
+                </div>
+                <div className="skill-stat-value">
+                  {formatDateShort(entry.skill.last_used_at, isKo)}
+                </div>
+              </div>
+            </div>
+
+            <div className="skill-usage">
+              <div className="skill-usage-meta">
+                <span>{isKo ? activityMeta.label.ko : activityMeta.label.en}</span>
+                <span>{entry.usagePercent}%</span>
+              </div>
+              <div className="skill-usage-bar">
+                <div
+                  className="skill-usage-fill"
+                  style={{
+                    width: `${entry.usagePercent}%`,
+                    background: activityMeta.accent,
+                  }}
+                />
+              </div>
             </div>
           </div>
-        ))}
-      </div>
-    </>
+        );
+      })}
+    </div>
   );
 
-  if (embedded) return content;
+  const categoryButtons = (
+    <div className="skill-tag-row">
+      {(Object.keys(SKILL_CATEGORY_META) as SkillCategoryId[]).map((categoryId) => {
+        const categoryMeta = SKILL_CATEGORY_META[categoryId];
+        const count =
+          categoryId === "all" ? catalog.length : categoryCounts[categoryId];
+
+        return (
+          <button
+            key={categoryId}
+            type="button"
+            className={`skill-tag${activeCategory === categoryId ? " active" : ""}`}
+            onClick={() => setActiveCategory(categoryId)}
+          >
+            {isKo ? categoryMeta.label.ko : categoryMeta.label.en}
+            <span style={{ fontFamily: "var(--font-mono)", opacity: 0.6 }}>
+              {count}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+
+  const emptyState = (
+    <div
+      className="card"
+      style={{
+        textAlign: "center",
+        padding: "40px 20px",
+        color: "var(--th-text-muted)",
+      }}
+    >
+      <BookOpen size={32} style={{ margin: "0 auto 12px", opacity: 0.3 }} />
+      <div style={{ fontSize: 13 }}>
+        {search
+          ? t({ ko: "검색 결과가 없습니다", en: "No search results" })
+          : t({ ko: "등록된 스킬이 없습니다", en: "No skills registered" })}
+      </div>
+    </div>
+  );
+
+  if (embedded) {
+    return (
+      <div className="skill-catalog-shell embedded">
+        <style>{SKILL_CATALOG_SHELL_STYLES}</style>
+        <div className="search-wrap">
+          <Search
+            size={14}
+            style={{
+              position: "absolute",
+              left: 10,
+              top: "50%",
+              transform: "translateY(-50%)",
+              color: "var(--th-text-muted)",
+            }}
+          />
+          <input
+            type="text"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder={t({ ko: "스킬 검색…", en: "Search skills…" })}
+            className="search-input"
+          />
+        </div>
+        {categoryButtons}
+        {filtered.length === 0 ? emptyState : cards}
+      </div>
+    );
+  }
 
   return (
     <div
-      className="mx-auto h-full w-full max-w-5xl min-w-0 overflow-x-hidden overflow-y-auto p-4 pb-40 sm:p-6"
+      className="page fade-in mx-auto h-full w-full max-w-6xl min-w-0 overflow-x-hidden overflow-y-auto p-4 pb-40 sm:p-6"
       style={{ paddingBottom: "max(10rem, calc(10rem + env(safe-area-inset-bottom)))" }}
     >
-      {content}
+      <div className="page skill-catalog-shell">
+        <style>{SKILL_CATALOG_SHELL_STYLES}</style>
+        <div className="page-header">
+          <div>
+            <div className="page-title">
+              {t({ ko: "스킬 카탈로그", en: "Skill Catalog" })}
+            </div>
+            <div className="page-sub">
+              {t({
+                ko: `에이전트가 호출할 수 있는 툴·훅. ${catalog.length}개 · 누적 ${(
+                  totalCalls / 1000
+                ).toFixed(1)}K 호출`,
+                en: `${catalog.length} callable tools and hooks · ${(totalCalls / 1000).toFixed(1)}K total invocations`,
+              })}
+            </div>
+          </div>
+          <div className="search-wrap">
+            <Search
+              size={14}
+              style={{
+                position: "absolute",
+                left: 10,
+                top: "50%",
+                transform: "translateY(-50%)",
+                color: "var(--th-text-muted)",
+              }}
+            />
+            <input
+              type="text"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder={t({ ko: "스킬 검색…", en: "Search skills…" })}
+              className="search-input"
+            />
+          </div>
+        </div>
+        {categoryButtons}
+        {filtered.length === 0 ? emptyState : cards}
+      </div>
     </div>
   );
-}
-
-function formatDateShort(ts: number, isKo = true): string {
-  const d = new Date(ts);
-  const now = new Date();
-  const diff = now.getTime() - d.getTime();
-  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
-  if (days === 0) return isKo ? "오늘" : "Today";
-  if (days === 1) return isKo ? "어제" : "Yesterday";
-  if (days < 7) return isKo ? `${days}일 전` : `${days}d ago`;
-  return d.toLocaleDateString(isKo ? "ko-KR" : "en-US", { month: "short", day: "numeric" });
 }

--- a/dashboard/src/components/StatsPageView.tsx
+++ b/dashboard/src/components/StatsPageView.tsx
@@ -14,15 +14,7 @@ import {
 } from "../api";
 import { getProviderMeta, getProviderSeries } from "../app/providerTheme";
 import type { TFunction } from "./dashboard/model";
-import { timeAgo } from "./dashboard/model";
-import {
-  DashboardEmptyState,
-  cx,
-  dashboardBadge,
-  dashboardButton,
-  dashboardCard,
-  dashboardText,
-} from "./dashboard/ui";
+import { DashboardEmptyState, cx } from "./dashboard/ui";
 import type {
   Agent,
   CompanySettings,
@@ -34,25 +26,21 @@ import type {
   TokenAnalyticsResponse,
 } from "../types";
 import {
-  Activity,
   BarChart3,
-  Bot,
-  Coins,
   Cpu,
   Gauge,
+  Info,
   RefreshCw,
   ShieldAlert,
-  Sparkles,
   Users,
 } from "lucide-react";
 
 type Period = "7d" | "30d" | "90d";
-type PulseKanbanSignal = "review" | "blocked" | "requested" | "stalled";
 type DailySeriesKey =
-  | "input_tokens"
-  | "output_tokens"
   | "cache_read_tokens"
-  | "cache_creation_tokens";
+  | "cache_creation_tokens"
+  | "input_tokens"
+  | "output_tokens";
 
 interface StatsPageViewProps {
   settings: CompanySettings;
@@ -62,7 +50,9 @@ interface StatsPageViewProps {
   meetings?: RoundTableMeeting[];
   requestedTab?: unknown;
   onSelectAgent?: (agent: Agent) => void;
-  onOpenKanbanSignal?: (signal: PulseKanbanSignal) => void;
+  onOpenKanbanSignal?: (
+    signal: "review" | "blocked" | "requested" | "stalled",
+  ) => void;
   onOpenDispatchSessions?: () => void;
   onOpenSettings?: () => void;
   onRefreshMeetings?: () => void;
@@ -78,14 +68,28 @@ interface ShareSegment {
   sublabel?: string;
 }
 
+interface AgentSpendRow {
+  id: string;
+  label: string;
+  tokens: number;
+  cost: number;
+  share: number;
+  color: string;
+}
+
+interface AgentCacheRow {
+  id: string;
+  label: string;
+  promptTokens: number;
+  hitRate: number;
+  savedCost: number | null;
+}
+
 interface SkillUsageRow {
   id: string;
   name: string;
   description: string;
   windowCalls: number;
-  windowShare: number;
-  lifetimeCalls: number | null;
-  lastUsedAt: number | null;
 }
 
 interface AgentSkillRow {
@@ -94,25 +98,329 @@ interface AgentSkillRow {
   skillName: string;
   description: string;
   calls: number;
-  lastUsedAt: number;
 }
 
-interface AgentLeaderboardRow {
+interface LeaderboardRow {
   id: string;
   label: string;
+  avatar: string;
+  tasksDone: number;
+  xp: number;
   tokens: number;
-  share: number;
-  cost: number;
-  cacheHitRate: number;
+}
+
+interface DailySeriesDescriptor {
+  key: DailySeriesKey;
+  label: string;
+  color: string;
+}
+
+type MetricDeltaTone = "up" | "down" | "flat";
+
+interface MetricDelta {
+  value: string;
+  tone: MetricDeltaTone;
 }
 
 const PERIOD_OPTIONS: Period[] = ["7d", "30d", "90d"];
-const DAILY_BAR_HEIGHT_PX = 184;
 const NUMERIC_STYLE: CSSProperties = {
   fontFamily: "var(--font-mono)",
   fontVariantNumeric: "tabular-nums",
   fontFeatureSettings: '"tnum" 1',
 };
+const AGENT_BAR_COLORS = [
+  "var(--claude)",
+  "var(--codex)",
+  "oklch(0.72 0.14 265)",
+  "oklch(0.78 0.1 235)",
+  "color-mix(in oklch, var(--accent) 70%, white 30%)",
+];
+
+const STATS_SHELL_STYLES = `
+  .stats-shell .page {
+    padding: 24px 28px 48px;
+    max-width: 1440px;
+    width: 100%;
+    margin: 0 auto;
+    min-width: 0;
+  }
+
+  .stats-shell .page-header {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
+
+  .stats-shell .page-title {
+    font-family: var(--font-display);
+    font-size: 22px;
+    font-weight: 600;
+    letter-spacing: -0.5px;
+    line-height: 1.2;
+    color: var(--th-text-heading);
+  }
+
+  .stats-shell .page-sub {
+    margin-top: 4px;
+    font-size: 13px;
+    color: var(--th-text-muted);
+    line-height: 1.6;
+  }
+
+  .stats-shell .page-controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+
+  .stats-shell .grid {
+    display: grid;
+    gap: 14px;
+  }
+
+  .stats-shell .grid-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .stats-shell .grid-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .stats-shell .grid-feature {
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  }
+
+  .stats-shell .grid-extra {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 0.94fr);
+  }
+
+  .stats-shell .stack {
+    display: grid;
+    gap: 14px;
+  }
+
+  .stats-shell .card {
+    background: var(--th-surface);
+    border: 1px solid var(--th-border-subtle);
+    border-radius: 18px;
+    overflow: hidden;
+    box-shadow: 0 10px 30px color-mix(in srgb, var(--th-shadow-color) 8%, transparent);
+  }
+
+  .stats-shell .card-head {
+    padding: 14px 16px 0;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .stats-shell .card-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12.5px;
+    font-weight: 500;
+    color: var(--th-text-secondary);
+    letter-spacing: -0.1px;
+  }
+
+  .stats-shell .card-body {
+    padding: 10px 16px 16px;
+  }
+
+  .stats-shell .metric {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .stats-shell .metric-value {
+    font-family: var(--font-display);
+    font-size: 28px;
+    font-weight: 600;
+    letter-spacing: -1px;
+    line-height: 1.1;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .stats-shell .metric-sub {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--th-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .stats-shell .seg {
+    display: inline-flex;
+    border: 1px solid var(--th-border-subtle);
+    border-radius: 10px;
+    padding: 2px;
+    background: color-mix(in srgb, var(--th-surface-alt) 80%, transparent);
+  }
+
+  .stats-shell .seg button {
+    padding: 4px 10px;
+    border-radius: 8px;
+    border: 0;
+    background: transparent;
+    color: var(--th-text-muted);
+    font-size: 11.5px;
+    font-variant-numeric: tabular-nums;
+    transition: background 0.16s ease, color 0.16s ease;
+  }
+
+  .stats-shell .seg button.active {
+    background: var(--th-surface);
+    color: var(--th-text-primary);
+    box-shadow: 0 1px 2px color-mix(in srgb, var(--th-shadow-color) 10%, transparent);
+  }
+
+  .stats-shell .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    border: 1px solid var(--th-border-subtle);
+    background: color-mix(in srgb, var(--th-surface-alt) 86%, transparent);
+    color: var(--th-text-secondary);
+    font-size: 11px;
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .stats-shell .chip-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    border: 1px solid var(--th-border-subtle);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--th-surface-alt) 86%, transparent);
+    color: var(--th-text-secondary);
+    font-size: 11px;
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+    transition:
+      background 0.16s ease,
+      color 0.16s ease,
+      border-color 0.16s ease;
+  }
+
+  .stats-shell .chip-btn:hover {
+    background: var(--th-surface);
+    color: var(--th-text-primary);
+  }
+
+  .stats-shell .delta {
+    display: inline-flex;
+    align-items: center;
+    min-height: 20px;
+    padding: 1px 5px;
+    border-radius: 4px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: -0.2px;
+  }
+
+  .stats-shell .delta.up {
+    color: var(--ok);
+    background: color-mix(in oklch, var(--ok) 14%, transparent);
+  }
+
+  .stats-shell .delta.down {
+    color: var(--err);
+    background: color-mix(in oklch, var(--err) 14%, transparent);
+  }
+
+  .stats-shell .delta.flat {
+    color: var(--th-text-muted);
+    background: var(--th-overlay-subtle);
+  }
+
+  .stats-shell .bar-track {
+    height: 6px;
+    overflow: hidden;
+    border-radius: 3px;
+    background: var(--th-overlay-subtle);
+  }
+
+  .stats-shell .bar-fill {
+    height: 100%;
+    border-radius: 3px;
+    transition: width 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .stats-shell .list-section {
+    margin-bottom: 10px;
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--th-text-muted);
+  }
+
+  .stats-shell .list-card {
+    border: 1px solid var(--th-border-subtle);
+    border-radius: 14px;
+    background: var(--th-bg-surface);
+    padding: 12px;
+  }
+
+  .stats-shell .list-card.tight {
+    padding: 10px 12px;
+  }
+
+  .stats-shell .stats-inline-alert {
+    border-color: color-mix(in oklch, var(--warn) 30%, var(--th-border) 70%);
+    background:
+      linear-gradient(
+        180deg,
+        color-mix(in oklch, var(--warn) 8%, var(--th-surface) 92%) 0%,
+        var(--th-surface) 100%
+      );
+  }
+
+  @media (max-width: 1024px) {
+    .stats-shell .page-header {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .stats-shell .grid-2,
+    .stats-shell .grid-feature,
+    .stats-shell .grid-extra {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
+
+  @media (max-width: 768px) {
+    .stats-shell .page {
+      padding: 16px 16px calc(9rem + env(safe-area-inset-bottom));
+    }
+
+    .stats-shell .grid-4 {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 520px) {
+    .stats-shell .grid-4 {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
+`;
+
+function msg(ko: string, en = ko, ja = ko, zh = ko) {
+  return { ko, en, ja, zh };
+}
 
 function resolveLocaleTag(language: CompanySettings["language"]): string {
   switch (language) {
@@ -124,6 +432,17 @@ function resolveLocaleTag(language: CompanySettings["language"]): string {
       return "en-US";
     default:
       return "ko-KR";
+  }
+}
+
+function periodDayCount(period: Period): number {
+  switch (period) {
+    case "7d":
+      return 7;
+    case "90d":
+      return 90;
+    default:
+      return 30;
   }
 }
 
@@ -141,8 +460,14 @@ function formatCurrency(value: number): string {
   return `$${value.toFixed(4)}`;
 }
 
-function formatPercent(value: number): string {
-  return `${value.toFixed(1)}%`;
+function formatPercent(value: number, digits = 1): string {
+  return `${value.toFixed(digits)}%`;
+}
+
+function formatCompactDate(value: string): string {
+  const date = new Date(`${value}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return value;
+  return `${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
 }
 
 function formatDateLabel(value: string, localeTag: string): string {
@@ -151,18 +476,6 @@ function formatDateLabel(value: string, localeTag: string): string {
   return new Intl.DateTimeFormat(localeTag, {
     month: "2-digit",
     day: "2-digit",
-  }).format(date);
-}
-
-function formatDateTime(value: number | string | null | undefined, localeTag: string): string {
-  if (value == null) return "—";
-  const date = typeof value === "number" ? new Date(value) : new Date(value);
-  if (Number.isNaN(date.getTime())) return "—";
-  return new Intl.DateTimeFormat(localeTag, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
   }).format(date);
 }
 
@@ -176,42 +489,90 @@ function computeCacheHitRate(
   return (cacheReadTokens / promptTokens) * 100;
 }
 
-function buildDonutBackground(segments: ShareSegment[]): string {
-  if (segments.length === 0) {
-    return "conic-gradient(rgba(148,163,184,0.16) 0deg 360deg)";
-  }
-  let cursor = 0;
-  const stops = segments.map((segment) => {
-    const start = cursor;
-    cursor += segment.percentage * 3.6;
-    return `${segment.color} ${start}deg ${cursor}deg`;
-  });
-  if (cursor < 360) {
-    stops.push(`rgba(148,163,184,0.14) ${cursor}deg 360deg`);
-  }
-  return `conic-gradient(${stops.join(", ")})`;
+function computeDailyHitRate(day: TokenAnalyticsDailyPoint): number {
+  return computeCacheHitRate(
+    day.input_tokens,
+    day.cache_read_tokens,
+    day.cache_creation_tokens,
+  );
 }
 
-function buildModelSegments(data: TokenAnalyticsResponse | null): ShareSegment[] {
+function buildWindowDelta(
+  daily: TokenAnalyticsDailyPoint[],
+): MetricDelta | null {
+  if (daily.length < 4) return null;
+
+  const midpoint = Math.floor(daily.length / 2);
+  const previousWindow = daily.slice(0, midpoint);
+  const recentWindow = daily.slice(midpoint);
+  if (previousWindow.length === 0 || recentWindow.length === 0) return null;
+
+  const previousAverage =
+    previousWindow.reduce((sum, day) => sum + day.total_tokens, 0) /
+    previousWindow.length;
+  const recentAverage =
+    recentWindow.reduce((sum, day) => sum + day.total_tokens, 0) /
+    recentWindow.length;
+
+  if (previousAverage <= 0) return null;
+
+  const change = ((recentAverage - previousAverage) / previousAverage) * 100;
+  if (!Number.isFinite(change)) return null;
+
+  const rounded = Math.round(change * 10) / 10;
+  const tone: MetricDeltaTone =
+    rounded > 1 ? "up" : rounded < -1 ? "down" : "flat";
+  const sign = rounded > 0 ? "+" : "";
+
+  return {
+    value: `${sign}${rounded.toFixed(Math.abs(rounded) >= 10 ? 0 : 1)}%`,
+    tone,
+  };
+}
+
+function buildSavingsDelta(
+  summary: TokenAnalyticsResponse["summary"] | null | undefined,
+): MetricDelta | null {
+  if (!summary) return null;
+  const uncachedBaseline = summary.total_cost + summary.cache_discount;
+  if (uncachedBaseline <= 0 || summary.cache_discount <= 0) return null;
+
+  const savingsRate = (summary.cache_discount / uncachedBaseline) * 100;
+  return {
+    value: `-${savingsRate.toFixed(savingsRate >= 10 ? 0 : 1)}%`,
+    tone: "up",
+  };
+}
+
+function buildModelSegments(
+  data: TokenAnalyticsResponse | null,
+): ShareSegment[] {
   const models = data?.receipt.models ?? [];
   const totalTokens = models.reduce((sum, item) => sum + item.total_tokens, 0);
   if (totalTokens <= 0) return [];
 
-  const sorted = [...models].sort((left, right) => right.total_tokens - left.total_tokens);
-  const visible = sorted.slice(0, 6);
-  const overflow = sorted.slice(6);
+  const sorted = [...models].sort(
+    (left, right) => right.total_tokens - left.total_tokens,
+  );
+  const visible = sorted.slice(0, 5);
+  const overflow = sorted.slice(5);
 
   const segments = visible.map((model, index) => ({
-    id: `${model.provider}-${model.model}`,
+    id: `${model.provider}-${model.model}-${index}`,
     label: model.display_name,
     tokens: model.total_tokens,
     percentage: (model.total_tokens / totalTokens) * 100,
-    color: getProviderSeries(model.provider)[index % getProviderSeries(model.provider).length],
+    color: getProviderSeries(model.provider)[
+      index % getProviderSeries(model.provider).length
+    ],
     sublabel: getProviderMeta(model.provider).label,
   }));
 
   if (overflow.length > 0) {
-    const overflowTokens = overflow.reduce((sum, item) => sum + item.total_tokens, 0);
+    const overflowTokens = overflow.reduce(
+      (sum, item) => sum + item.total_tokens,
+      0,
+    );
     segments.push({
       id: "other-models",
       label: "Other",
@@ -225,35 +586,58 @@ function buildModelSegments(data: TokenAnalyticsResponse | null): ShareSegment[]
   return segments;
 }
 
-function buildProviderSegments(data: TokenAnalyticsResponse | null): ShareSegment[] {
-  if (!data) return [];
-  const providers = data.receipt.providers;
+function buildProviderSegments(
+  data: TokenAnalyticsResponse | null,
+): ShareSegment[] {
+  const providers = data?.receipt.providers ?? [];
   if (providers.length > 0) {
-    return [...providers]
+    const totalTokens = providers.reduce((sum, item) => sum + item.tokens, 0);
+    return providers
+      .filter((provider) => provider.tokens > 0)
       .sort((left, right) => right.tokens - left.tokens)
-      .map((provider) => ({
-        id: provider.provider,
-        label: getProviderMeta(provider.provider).label,
-        tokens: provider.tokens,
-        percentage: provider.percentage,
-        color: getProviderMeta(provider.provider).color,
-      }));
+      .map((provider) => {
+        const meta = getProviderMeta(provider.provider);
+        const series = getProviderSeries(provider.provider);
+        return {
+          id: provider.provider,
+          label: meta.label,
+          tokens: provider.tokens,
+          percentage:
+            provider.percentage || (provider.tokens / totalTokens) * 100,
+          color: series[0] ?? "var(--accent)",
+          sublabel: provider.provider,
+        };
+      });
   }
 
+  const models = data?.receipt.models ?? [];
   const byProvider = new Map<string, number>();
-  for (const model of data.receipt.models) {
-    byProvider.set(model.provider, (byProvider.get(model.provider) ?? 0) + model.total_tokens);
+  for (const model of models) {
+    byProvider.set(
+      model.provider,
+      (byProvider.get(model.provider) ?? 0) + model.total_tokens,
+    );
   }
-  const totalTokens = Array.from(byProvider.values()).reduce((sum, value) => sum + value, 0);
+  const totalTokens = Array.from(byProvider.values()).reduce(
+    (sum, value) => sum + value,
+    0,
+  );
+  if (totalTokens <= 0) return [];
+
   return Array.from(byProvider.entries())
     .sort((left, right) => right[1] - left[1])
-    .map(([provider, tokens]) => ({
-      id: provider,
-      label: getProviderMeta(provider).label,
-      tokens,
-      percentage: totalTokens > 0 ? (tokens / totalTokens) * 100 : 0,
-      color: getProviderMeta(provider).color,
-    }));
+    .map(([provider, tokens]) => {
+      const meta = getProviderMeta(provider);
+      const series = getProviderSeries(provider);
+      return {
+        id: provider,
+        label: meta.label,
+        tokens,
+        percentage: (tokens / totalTokens) * 100,
+        color: series[0] ?? "var(--accent)",
+        sublabel: provider,
+      };
+    });
 }
 
 function buildSkillRows(
@@ -263,23 +647,25 @@ function buildSkillRows(
 ): SkillUsageRow[] {
   if (!ranking) return [];
   const catalogMap = new Map(catalog.map((entry) => [entry.name, entry]));
-  const totalCalls = ranking.overall.reduce((sum, row) => sum + row.calls, 0);
 
   return ranking.overall.slice(0, 8).map((row) => {
     const catalogEntry = catalogMap.get(row.skill_name);
     const description =
       language === "ko"
-        ? catalogEntry?.description_ko || row.skill_desc_ko || catalogEntry?.description || row.skill_name
-        : catalogEntry?.description || catalogEntry?.description_ko || row.skill_desc_ko || row.skill_name;
+        ? catalogEntry?.description_ko ||
+          row.skill_desc_ko ||
+          catalogEntry?.description ||
+          row.skill_name
+        : catalogEntry?.description ||
+          catalogEntry?.description_ko ||
+          row.skill_desc_ko ||
+          row.skill_name;
 
     return {
       id: row.skill_name,
       name: row.skill_name,
       description,
       windowCalls: row.calls,
-      windowShare: totalCalls > 0 ? (row.calls / totalCalls) * 100 : 0,
-      lifetimeCalls: catalogEntry?.total_calls ?? null,
-      lastUsedAt: row.last_used_at ?? catalogEntry?.last_used_at ?? null,
     };
   });
 }
@@ -296,8 +682,14 @@ function buildAgentSkillRows(
     const catalogEntry = catalogMap.get(row.skill_name);
     const description =
       language === "ko"
-        ? catalogEntry?.description_ko || row.skill_desc_ko || catalogEntry?.description || row.skill_name
-        : catalogEntry?.description || catalogEntry?.description_ko || row.skill_desc_ko || row.skill_name;
+        ? catalogEntry?.description_ko ||
+          row.skill_desc_ko ||
+          catalogEntry?.description ||
+          row.skill_name
+        : catalogEntry?.description ||
+          catalogEntry?.description_ko ||
+          row.skill_desc_ko ||
+          row.skill_name;
 
     return {
       id: `${row.agent_role_id}-${row.skill_name}-${index}`,
@@ -305,58 +697,119 @@ function buildAgentSkillRows(
       skillName: row.skill_name,
       description,
       calls: row.calls,
-      lastUsedAt: row.last_used_at,
     };
   });
 }
 
-function buildAgentLeaderboard(data: TokenAnalyticsResponse | null): AgentLeaderboardRow[] {
+function buildAgentSpendRows(
+  data: TokenAnalyticsResponse | null,
+): AgentSpendRow[] {
   return [...(data?.receipt.agents ?? [])]
-    .sort((left, right) => right.tokens - left.tokens)
-    .slice(0, 10)
-    .map((agent) => ({
-      id: agent.agent,
+    .sort((left, right) => right.cost - left.cost)
+    .slice(0, 5)
+    .map((agent, index) => ({
+      id: `${agent.agent}-${index}`,
       label: agent.agent,
       tokens: agent.tokens,
-      share: agent.percentage,
       cost: agent.cost,
-      cacheHitRate: computeCacheHitRate(
-        agent.input_tokens ?? 0,
-        agent.cache_read_tokens ?? 0,
-        agent.cache_creation_tokens ?? 0,
-      ),
+      share: agent.percentage,
+      color: AGENT_BAR_COLORS[index % AGENT_BAR_COLORS.length],
     }));
 }
 
-function dailySeries(t: TFunction): Array<{ key: DailySeriesKey; label: string; color: string }> {
+function buildAgentCacheRows(
+  data: TokenAnalyticsResponse | null,
+): AgentCacheRow[] {
+  return [...(data?.receipt.agents ?? [])]
+    .map((agent) => {
+      const promptTokens =
+        (agent.input_tokens ?? 0) +
+        (agent.cache_read_tokens ?? 0) +
+        (agent.cache_creation_tokens ?? 0);
+      return {
+        id: agent.agent,
+        label: agent.agent,
+        promptTokens,
+        hitRate: computeCacheHitRate(
+          agent.input_tokens ?? 0,
+          agent.cache_read_tokens ?? 0,
+          agent.cache_creation_tokens ?? 0,
+        ),
+        savedCost:
+          agent.cost_without_cache != null
+            ? Math.max(0, agent.cost_without_cache - agent.cost)
+            : null,
+      };
+    })
+    .sort((left, right) => right.promptTokens - left.promptTokens)
+    .slice(0, 5);
+}
+
+function buildLeaderboardRows(
+  stats: DashboardStats | null | undefined,
+  agents: Agent[] | undefined,
+): LeaderboardRow[] {
+  const topAgents = stats?.top_agents ?? [];
+  if (topAgents.length > 0) {
+    return topAgents.slice(0, 5).map((agent) => ({
+      id: agent.id,
+      label: agent.alias?.trim() || agent.name_ko || agent.name,
+      avatar: agent.avatar_emoji,
+      tasksDone: agent.stats_tasks_done,
+      xp: agent.stats_xp,
+      tokens: agent.stats_tokens,
+    }));
+  }
+
+  return [...(agents ?? [])]
+    .sort((left, right) => right.stats_tokens - left.stats_tokens)
+    .slice(0, 5)
+    .map((agent) => ({
+      id: agent.id,
+      label: agent.alias?.trim() || agent.name_ko || agent.name,
+      avatar: agent.avatar_emoji,
+      tasksDone: agent.stats_tasks_done,
+      xp: agent.stats_xp,
+      tokens: agent.stats_tokens,
+    }));
+}
+
+function dailySeries(t: TFunction): DailySeriesDescriptor[] {
   return [
     {
-      key: "input_tokens",
-      label: t({ ko: "입력", en: "Input", ja: "入力", zh: "输入" }),
-      color: "#38bdf8",
-    },
-    {
-      key: "output_tokens",
-      label: t({ ko: "출력", en: "Output", ja: "出力", zh: "输出" }),
-      color: "#fb923c",
-    },
-    {
       key: "cache_read_tokens",
-      label: t({ ko: "캐시 읽기", en: "Cache Read", ja: "キャッシュ読取", zh: "缓存读取" }),
-      color: "#22c55e",
+      label: t(msg("cache R", "cache R")),
+      color: "var(--codex)",
     },
     {
       key: "cache_creation_tokens",
-      label: t({ ko: "캐시 쓰기", en: "Cache Write", ja: "キャッシュ書込", zh: "缓存写入" }),
-      color: "#a855f7",
+      label: t(msg("cache W", "cache W")),
+      color: "oklch(0.72 0.14 265)",
+    },
+    {
+      key: "input_tokens",
+      label: t(msg("input", "input")),
+      color: "oklch(0.78 0.1 235)",
+    },
+    {
+      key: "output_tokens",
+      label: t(msg("output", "output")),
+      color: "var(--claude)",
     },
   ];
 }
 
-export default function StatsPageView({ settings }: StatsPageViewProps) {
+export default function StatsPageView({
+  settings,
+  stats,
+  agents,
+}: StatsPageViewProps) {
   const language = settings.language;
   const localeTag = useMemo(() => resolveLocaleTag(language), [language]);
-  const numberFormatter = useMemo(() => new Intl.NumberFormat(localeTag), [localeTag]);
+  const numberFormatter = useMemo(
+    () => new Intl.NumberFormat(localeTag),
+    [localeTag],
+  );
   const t: TFunction = useCallback(
     (messages) => messages[language] ?? messages.ko,
     [language],
@@ -364,21 +817,24 @@ export default function StatsPageView({ settings }: StatsPageViewProps) {
 
   const [period, setPeriod] = useState<Period>("30d");
   const [reloadKey, setReloadKey] = useState(0);
-  const [analytics, setAnalytics] = useState<TokenAnalyticsResponse | null>(null);
-  const [skillRanking, setSkillRanking] = useState<SkillRankingResponse | null>(null);
+  const [analytics, setAnalytics] = useState<TokenAnalyticsResponse | null>(
+    null,
+  );
+  const [skillRanking, setSkillRanking] = useState<SkillRankingResponse | null>(
+    null,
+  );
   const [catalog, setCatalog] = useState<SkillCatalogEntry[]>([]);
-  const [analyticsLoading, setAnalyticsLoading] = useState(true);
+  const [loading, setLoading] = useState(true);
   const [skillLoading, setSkillLoading] = useState(true);
   const [catalogLoading, setCatalogLoading] = useState(true);
   const [analyticsError, setAnalyticsError] = useState<string | null>(null);
   const [skillError, setSkillError] = useState<string | null>(null);
   const [catalogError, setCatalogError] = useState<string | null>(null);
-  const [lastRefreshedAt, setLastRefreshedAt] = useState<number | null>(null);
 
   useEffect(() => {
     let active = true;
 
-    const loadCatalog = async () => {
+    const load = async () => {
       setCatalogLoading(true);
       setCatalogError(null);
       try {
@@ -388,19 +844,21 @@ export default function StatsPageView({ settings }: StatsPageViewProps) {
       } catch {
         if (!active) return;
         setCatalogError(
-          t({
-            ko: "스킬 카탈로그를 불러오지 못했습니다.",
-            en: "Unable to load the skill catalog.",
-            ja: "スキルカタログを読み込めませんでした。",
-            zh: "无法加载技能目录。",
-          }),
+          t(
+            msg(
+              "스킬 카탈로그를 불러오지 못했습니다.",
+              "Unable to load the skill catalog.",
+              "スキルカタログを読み込めませんでした。",
+              "无法加载技能目录。",
+            ),
+          ),
         );
       } finally {
         if (active) setCatalogLoading(false);
       }
     };
 
-    void loadCatalog();
+    void load();
     return () => {
       active = false;
     };
@@ -411,7 +869,7 @@ export default function StatsPageView({ settings }: StatsPageViewProps) {
     const controller = new AbortController();
 
     const load = async () => {
-      setAnalyticsLoading(true);
+      setLoading(true);
       setSkillLoading(true);
       setAnalyticsError(null);
       setSkillError(null);
@@ -420,40 +878,40 @@ export default function StatsPageView({ settings }: StatsPageViewProps) {
         getTokenAnalytics(period, { signal: controller.signal }),
         getSkillRanking(period, 16),
       ]);
-
       if (!active) return;
 
       if (analyticsResult.status === "fulfilled") {
         setAnalytics(analyticsResult.value);
       } else {
         setAnalyticsError(
-          t({
-            ko: "토큰 분석을 불러오지 못했습니다.",
-            en: "Unable to load token analytics.",
-            ja: "トークン分析を読み込めませんでした。",
-            zh: "无法加载 Token 分析。",
-          }),
+          t(
+            msg(
+              "토큰 분석을 불러오지 못했습니다.",
+              "Unable to load token analytics.",
+              "トークン分析を読み込めませんでした。",
+              "无法加载 Token 分析。",
+            ),
+          ),
         );
       }
-      setAnalyticsLoading(false);
 
       if (skillResult.status === "fulfilled") {
         setSkillRanking(skillResult.value);
       } else {
         setSkillError(
-          t({
-            ko: "스킬 랭킹을 불러오지 못했습니다.",
-            en: "Unable to load skill ranking.",
-            ja: "スキルランキングを読み込めませんでした。",
-            zh: "无法加载技能排行。",
-          }),
+          t(
+            msg(
+              "스킬 랭킹을 불러오지 못했습니다.",
+              "Unable to load skill ranking.",
+              "スキルランキングを読み込めませんでした。",
+              "无法加载技能排行。",
+            ),
+          ),
         );
       }
-      setSkillLoading(false);
 
-      if (analyticsResult.status === "fulfilled" || skillResult.status === "fulfilled") {
-        setLastRefreshedAt(Date.now());
-      }
+      setLoading(false);
+      setSkillLoading(false);
     };
 
     void load();
@@ -463,143 +921,122 @@ export default function StatsPageView({ settings }: StatsPageViewProps) {
     };
   }, [period, reloadKey, t]);
 
-  const series = useMemo(() => dailySeries(t), [t]);
   const summary = analytics?.summary;
-  const totalPromptTokens = useMemo(
+  const hasLoadError = Boolean(analyticsError || skillError || catalogError);
+  const combinedError = [analyticsError, skillError, catalogError]
+    .filter(Boolean)
+    .join(" ");
+  const series = useMemo(() => dailySeries(t), [t]);
+  const totalInputTokens = useMemo(
+    () => analytics?.daily.reduce((sum, day) => sum + day.input_tokens, 0) ?? 0,
+    [analytics],
+  );
+  const totalCacheReadTokens = useMemo(
+    () =>
+      analytics?.daily.reduce((sum, day) => sum + day.cache_read_tokens, 0) ??
+      0,
+    [analytics],
+  );
+  const totalCacheCreationTokens = useMemo(
     () =>
       analytics?.daily.reduce(
-        (sum, day) => sum + day.input_tokens + day.cache_read_tokens + day.cache_creation_tokens,
+        (sum, day) => sum + day.cache_creation_tokens,
         0,
       ) ?? 0,
     [analytics],
   );
-  const cacheReadTokens = useMemo(
-    () => analytics?.daily.reduce((sum, day) => sum + day.cache_read_tokens, 0) ?? 0,
+  const overallCacheHitRate = useMemo(
+    () =>
+      computeCacheHitRate(
+        totalInputTokens,
+        totalCacheReadTokens,
+        totalCacheCreationTokens,
+      ),
+    [totalCacheCreationTokens, totalCacheReadTokens, totalInputTokens],
+  );
+  const averageDailyHitRate = useMemo(() => {
+    if (!analytics?.daily.length) return 0;
+    const total = analytics.daily.reduce(
+      (sum, day) => sum + computeDailyHitRate(day),
+      0,
+    );
+    return total / analytics.daily.length;
+  }, [analytics]);
+  const modelSegments = useMemo(
+    () => buildModelSegments(analytics),
     [analytics],
   );
-  const cacheHitRate = useMemo(
-    () => computeCacheHitRate(totalPromptTokens - cacheReadTokens, cacheReadTokens),
-    [cacheReadTokens, totalPromptTokens],
+  const providerSegments = useMemo(
+    () => buildProviderSegments(analytics),
+    [analytics],
   );
-  const uncachedBaseline = (summary?.total_cost ?? 0) + (summary?.cache_discount ?? 0);
-  const modelSegments = useMemo(() => buildModelSegments(analytics), [analytics]);
-  const providerSegments = useMemo(() => buildProviderSegments(analytics), [analytics]);
+  const agentSpendRows = useMemo(
+    () => buildAgentSpendRows(analytics),
+    [analytics],
+  );
+  const agentCacheRows = useMemo(
+    () => buildAgentCacheRows(analytics),
+    [analytics],
+  );
   const skillRows = useMemo(
     () => buildSkillRows(skillRanking, catalog, language),
     [catalog, language, skillRanking],
   );
-  const byAgentSkillRows = useMemo(
-    () => buildAgentSkillRows(skillRanking, catalog, language),
+  const topAgentSkillPairs = useMemo(
+    () => buildAgentSkillRows(skillRanking, catalog, language).slice(0, 5),
     [catalog, language, skillRanking],
   );
-  const agentLeaderboard = useMemo(() => buildAgentLeaderboard(analytics), [analytics]);
-  const activeSkillCount = useMemo(
-    () => new Set(skillRanking?.overall.map((row) => row.skill_name) ?? []).size,
-    [skillRanking],
+  const leaderboardRows = useMemo(
+    () => buildLeaderboardRows(stats, agents),
+    [agents, stats],
   );
-  const catalogUsedCount = useMemo(
-    () => catalog.filter((entry) => entry.total_calls > 0).length,
-    [catalog],
-  );
-  const windowCalls = useMemo(
+  const skillWindowCalls = useMemo(
     () => skillRanking?.overall.reduce((sum, row) => sum + row.calls, 0) ?? 0,
     [skillRanking],
   );
-  const hasAnyLoadError = analyticsError || skillError || catalogError;
+  const rangeDays = analytics?.days ?? periodDayCount(period);
+  const peakDay = summary?.peak_day ?? null;
+  const averageDailyTokens = summary?.average_daily_tokens ?? 0;
+  const peakRatio =
+    peakDay && averageDailyTokens > 0
+      ? peakDay.total_tokens / averageDailyTokens
+      : null;
+  const tokenMomentumDelta = useMemo(
+    () => buildWindowDelta(analytics?.daily ?? []),
+    [analytics],
+  );
+  const cacheSavingsDelta = useMemo(
+    () => buildSavingsDelta(summary),
+    [summary],
+  );
 
   return (
     <div
       data-testid="stats-page"
-      className="mx-auto h-full w-full max-w-7xl min-w-0 overflow-x-hidden overflow-y-auto p-4 pb-40 sm:p-6"
-      style={{ paddingBottom: "max(10rem, calc(10rem + env(safe-area-inset-bottom)))" }}
+      className="page fade-in stats-shell mx-auto h-full w-full min-w-0 overflow-x-hidden overflow-y-auto animate-in fade-in duration-200"
     >
-      <section className="space-y-4">
-        <header
-          className={dashboardCard.accentHero}
-          style={{
-            borderColor: "color-mix(in oklch, var(--accent) 28%, var(--th-border) 72%)",
-            background:
-              "linear-gradient(145deg, color-mix(in oklch, var(--accent) 10%, var(--th-surface) 90%) 0%, var(--th-surface) 100%)",
-          }}
-        >
-          <div className="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
+      <style>{STATS_SHELL_STYLES}</style>
+      <div className="page fade-in">
+        <section className="space-y-[14px]">
+          <header data-testid="stats-page-header" className="page-header">
             <div className="min-w-0">
-              <div className={dashboardText.labelMuted} style={{ color: "var(--th-text-muted)" }}>
-                {t({
-                  ko: "Phase 2 Stats",
-                  en: "Phase 2 Stats",
-                  ja: "Phase 2 Stats",
-                  zh: "Phase 2 Stats",
-                })}
-              </div>
-              <h1
-                className="mt-2 text-2xl font-black tracking-tight sm:text-3xl"
-                style={{ color: "var(--th-text-heading)" }}
-              >
-                {t({
-                  ko: "전용 통계 보드",
-                  en: "Dedicated Stats Board",
-                  ja: "専用統計ボード",
-                  zh: "专用统计面板",
-                })}
+              <h1 className="page-title">
+                {t(msg("통계", "Stats", "統計", "统计"))}
               </h1>
-              <p className="mt-2 max-w-3xl text-sm leading-6" style={{ color: "var(--th-text-muted)" }}>
-                {t({
-                  ko: "범위를 바꾸면 요약 카드, 일별 토큰 차트, 모델/프로바이더 분포, 스킬 사용, 에이전트 리더보드가 함께 갱신됩니다.",
-                  en: "Changing the range refreshes the summary cards, daily token chart, model/provider mix, skill usage, and agent leaderboard together.",
-                  ja: "範囲を切り替えると、概要カード、日次トークンチャート、モデル/プロバイダー比率、スキル使用、エージェントリーダーボードが一緒に更新されます。",
-                  zh: "切换时间范围时，摘要卡、每日 Token 图、模型/提供商占比、技能使用和代理排行榜会一起更新。",
-                })}
+              <p className="page-sub">
+                {t(
+                  msg(
+                    "토큰 / 비용 / 캐시 / 모델 분포를 한곳에서",
+                    "Token, cost, cache, and model mix in one place.",
+                    "トークン / コスト / キャッシュ / モデル分布を一か所で確認します。",
+                    "在一个页面查看 Token、成本、缓存和模型分布。",
+                  ),
+                )}
               </p>
-              <div className="mt-4 flex flex-wrap gap-2">
-                <HeaderBadge
-                  icon={<Activity size={14} />}
-                  label={analytics?.period_label ?? t({ ko: "데이터 동기화 중", en: "Syncing data", ja: "同期中", zh: "同步中" })}
-                />
-                <HeaderBadge
-                  icon={<Gauge size={14} />}
-                  label={
-                    summary
-                      ? t({
-                          ko: `${numberFormatter.format(summary.active_days)}일 활성`,
-                          en: `${numberFormatter.format(summary.active_days)} active days`,
-                          ja: `${numberFormatter.format(summary.active_days)}日稼働`,
-                          zh: `${numberFormatter.format(summary.active_days)} 天活跃`,
-                        })
-                      : t({ ko: "활성 일수 집계 중", en: "Calculating active days", ja: "稼働日数を計算中", zh: "计算活跃天数" })
-                  }
-                />
-                <HeaderBadge
-                  icon={<Sparkles size={14} />}
-                  label={
-                    summary
-                      ? t({
-                          ko: `평균 ${formatTokens(summary.average_daily_tokens)} / 일`,
-                          en: `Avg ${formatTokens(summary.average_daily_tokens)} / day`,
-                          ja: `平均 ${formatTokens(summary.average_daily_tokens)} / 日`,
-                          zh: `平均 ${formatTokens(summary.average_daily_tokens)} / 天`,
-                        })
-                      : t({ ko: "평균 처리량 계산 중", en: "Calculating average throughput", ja: "平均処理量を計算中", zh: "计算平均吞吐量" })
-                  }
-                />
-                <HeaderBadge
-                  icon={<RefreshCw size={14} className={cx(analyticsLoading || skillLoading ? "animate-spin" : "")} />}
-                  label={
-                    lastRefreshedAt
-                      ? t({
-                          ko: `${formatDateTime(lastRefreshedAt, localeTag)} 갱신`,
-                          en: `Updated ${formatDateTime(lastRefreshedAt, localeTag)}`,
-                          ja: `${formatDateTime(lastRefreshedAt, localeTag)} 更新`,
-                          zh: `${formatDateTime(lastRefreshedAt, localeTag)} 更新`,
-                        })
-                      : t({ ko: "첫 집계 대기 중", en: "Waiting for first sync", ja: "初回同期待ち", zh: "等待首次同步" })
-                  }
-                />
-              </div>
             </div>
 
-            <div className="flex flex-col gap-3 xl:items-end">
-              <div className="flex flex-wrap gap-2" data-testid="stats-range-controls">
+            <div className="page-controls">
+              <div className="seg" data-testid="stats-range-controls">
                 {PERIOD_OPTIONS.map((option) => {
                   const active = option === period;
                   return (
@@ -607,378 +1044,432 @@ export default function StatsPageView({ settings }: StatsPageViewProps) {
                       key={option}
                       data-testid={`stats-range-${option}`}
                       type="button"
-                      className={cx(dashboardButton.sm, "min-w-[4.5rem] justify-center")}
+                      className={cx(active ? "active" : "", "min-w-[4.75rem]")}
                       onClick={() => setPeriod(option)}
                       aria-pressed={active}
-                      style={
-                        active
-                          ? {
-                              background: "color-mix(in oklch, var(--accent) 20%, var(--th-surface) 80%)",
-                              borderColor: "color-mix(in oklch, var(--accent) 36%, var(--th-border) 64%)",
-                              color: "var(--th-text-heading)",
-                            }
-                          : undefined
-                      }
                     >
-                      <span style={NUMERIC_STYLE}>{option}</span>
+                      <span style={NUMERIC_STYLE}>
+                        {t(
+                          option === "7d"
+                            ? msg("7일", "7d", "7日", "7天")
+                            : option === "30d"
+                              ? msg("30일", "30d", "30日", "30天")
+                              : msg("90일", "90d", "90日", "90天"),
+                        )}
+                      </span>
                     </button>
                   );
                 })}
               </div>
               <button
                 type="button"
-                className={cx(dashboardButton.sm, "justify-center gap-2")}
+                className="chip-btn"
+                data-testid="stats-refresh-button"
                 onClick={() => setReloadKey((value) => value + 1)}
               >
-                <RefreshCw size={14} className={cx(analyticsLoading || skillLoading ? "animate-spin" : "")} />
-                {t({ ko: "다시 불러오기", en: "Reload", ja: "再読み込み", zh: "重新加载" })}
+                <RefreshCw
+                  size={12}
+                  className={cx(loading || skillLoading ? "animate-spin" : "")}
+                />
+                <span>
+                  {t(msg("새로고침", "Refresh", "再読み込み", "刷新"))}
+                </span>
               </button>
             </div>
-          </div>
-        </header>
+          </header>
 
-        {hasAnyLoadError ? (
-          <div
-            className={dashboardCard.nestedCompact}
-            style={{
-              borderColor: "color-mix(in oklch, var(--warn) 30%, var(--th-border) 70%)",
-              background:
-                "linear-gradient(180deg, color-mix(in oklch, var(--warn) 8%, var(--th-surface) 92%) 0%, var(--th-surface) 100%)",
-            }}
-          >
-            <div className="flex items-start gap-3">
-              <ShieldAlert
-                size={18}
-                style={{ color: "var(--th-accent-warn)", flexShrink: 0, marginTop: 2 }}
-              />
-              <div className="min-w-0">
-                <div className="text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
-                  {t({
-                    ko: "일부 통계를 새로고침하지 못했습니다.",
-                    en: "Some stats could not be refreshed.",
-                    ja: "一部の統計を更新できませんでした。",
-                    zh: "部分统计刷新失败。",
-                  })}
-                </div>
-                <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
-                  {[analyticsError, skillError, catalogError].filter(Boolean).join(" ")}
+          {hasLoadError ? (
+            <div className="card stats-inline-alert">
+              <div className="card-body flex items-start gap-3">
+                <ShieldAlert
+                  size={18}
+                  style={{
+                    color: "var(--th-accent-warn)",
+                    flexShrink: 0,
+                    marginTop: 2,
+                  }}
+                />
+                <div className="min-w-0">
+                  <div
+                    className="text-sm font-semibold"
+                    style={{ color: "var(--th-text-heading)" }}
+                  >
+                    {t(
+                      msg(
+                        "일부 통계를 불러오지 못했습니다.",
+                        "Some stats could not be loaded.",
+                        "一部の統計を読み込めませんでした。",
+                        "部分统计加载失败。",
+                      ),
+                    )}
+                  </div>
+                  <div
+                    className="mt-1 text-xs leading-5"
+                    style={{ color: "var(--th-text-muted)" }}
+                  >
+                    {combinedError}
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        ) : null}
+          ) : null}
 
-        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4" data-testid="stats-summary-grid">
-          <div data-testid="stats-summary-total-tokens">
-            <SummaryMetricCard
-              icon={<BarChart3 size={18} />}
-              label={t({ ko: "총 토큰", en: "Total Tokens", ja: "総トークン", zh: "总代币" })}
-              value={summary ? formatTokens(summary.total_tokens) : "…"}
-              sub={analytics?.period_label ?? t({ ko: "기간 집계 대기", en: "Waiting for range data", ja: "範囲集計待ち", zh: "等待区间数据" })}
-              accent="#f59e0b"
-            />
-          </div>
-          <div data-testid="stats-summary-api-spend">
-            <SummaryMetricCard
-              icon={<Coins size={18} />}
-              label={t({ ko: "API 비용", en: "API Spend", ja: "API コスト", zh: "API 成本" })}
-              value={summary ? formatCurrency(summary.total_cost) : "…"}
-              sub={
-                summary
-                  ? t({
-                      ko: `메시지 ${numberFormatter.format(summary.total_messages)} / 세션 ${numberFormatter.format(summary.total_sessions)}`,
-                      en: `${numberFormatter.format(summary.total_messages)} messages / ${numberFormatter.format(summary.total_sessions)} sessions`,
-                      ja: `${numberFormatter.format(summary.total_messages)} メッセージ / ${numberFormatter.format(summary.total_sessions)} セッション`,
-                      zh: `${numberFormatter.format(summary.total_messages)} 消息 / ${numberFormatter.format(summary.total_sessions)} 会话`,
-                    })
-                  : t({ ko: "비용 집계 대기", en: "Waiting for spend data", ja: "コスト集計待ち", zh: "等待成本数据" })
-              }
-              accent="#22c55e"
-            />
-          </div>
-          <div data-testid="stats-summary-cache-saved">
-            <SummaryMetricCard
-              icon={<Sparkles size={18} />}
-              label={t({ ko: "캐시 절감", en: "Cache Saved", ja: "キャッシュ節約", zh: "缓存节省" })}
-              value={summary ? formatCurrency(summary.cache_discount) : "…"}
-              sub={
-                summary
-                  ? t({
-                      ko: `uncached 기준 ${formatCurrency(uncachedBaseline)}`,
-                      en: `${formatCurrency(uncachedBaseline)} uncached baseline`,
-                      ja: `uncached 基準 ${formatCurrency(uncachedBaseline)}`,
-                      zh: `uncached 基线 ${formatCurrency(uncachedBaseline)}`,
-                    })
-                  : t({ ko: "절감액 계산 대기", en: "Waiting for savings data", ja: "節約額計算待ち", zh: "等待节省数据" })
-              }
-              accent="#14b8a6"
-            />
-          </div>
-          <div data-testid="stats-summary-cache-hit">
-            <SummaryMetricCard
-              icon={<Gauge size={18} />}
-              label={t({ ko: "캐시 히트율", en: "Cache Hit Rate", ja: "キャッシュヒット率", zh: "缓存命中率" })}
-              value={summary ? formatPercent(cacheHitRate) : "…"}
-              sub={
-                summary
-                  ? t({
-                      ko: `${formatTokens(cacheReadTokens)} cache read / ${formatTokens(totalPromptTokens)} prompt`,
-                      en: `${formatTokens(cacheReadTokens)} cache read / ${formatTokens(totalPromptTokens)} prompt`,
-                      ja: `${formatTokens(cacheReadTokens)} cache read / ${formatTokens(totalPromptTokens)} prompt`,
-                      zh: `${formatTokens(cacheReadTokens)} cache read / ${formatTokens(totalPromptTokens)} prompt`,
-                    })
-                  : t({ ko: "히트율 계산 대기", en: "Waiting for cache hit data", ja: "ヒット率計算待ち", zh: "等待命中率数据" })
-              }
-              accent="#8b5cf6"
-            />
-          </div>
-        </div>
-
-        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.4fr)_minmax(0,0.85fr)]">
-          <div data-testid="stats-daily-token-chart">
-            <DailyTokenChartCard
-              t={t}
-              localeTag={localeTag}
-              numberFormatter={numberFormatter}
-              loading={analyticsLoading}
-              daily={analytics?.daily ?? []}
-              series={series}
-              summary={summary}
-            />
-          </div>
-
-          <div className="grid gap-4">
-            <div data-testid="stats-model-share">
-              <DistributionCard
-                icon={<Cpu size={18} />}
-                title={t({ ko: "모델 점유율", en: "Model Share", ja: "モデル比率", zh: "模型占比" })}
-                description={t({
-                  ko: "선택한 범위에서 어떤 모델이 토큰을 가장 많이 처리했는지 보여줍니다.",
-                  en: "Shows which models processed the most tokens in the selected window.",
-                  ja: "選択範囲でどのモデルが最も多くのトークンを処理したかを示します。",
-                  zh: "显示所选范围内处理 Token 最多的模型。",
-                })}
-                emptyLabel={t({
-                  ko: "표시할 모델 분포가 없습니다.",
-                  en: "No model distribution available.",
-                  ja: "表示するモデル分布がありません。",
-                  zh: "没有可显示的模型分布。",
-                })}
-                loading={analyticsLoading}
-                segments={modelSegments}
-                centerLabel={t({ ko: "모델", en: "Models", ja: "モデル", zh: "模型" })}
-                centerValue={summary ? formatTokens(summary.total_tokens) : "0"}
-                centerSub={
-                  analytics
-                    ? t({
-                        ko: `${analytics.receipt.models.length}개 추적`,
-                        en: `${analytics.receipt.models.length} tracked`,
-                        ja: `${analytics.receipt.models.length}件追跡`,
-                        zh: `追踪 ${analytics.receipt.models.length} 个`,
-                      })
-                    : t({ ko: "데이터 대기", en: "Waiting for data", ja: "データ待ち", zh: "等待数据" })
-                }
+          <div className="grid grid-4" data-testid="stats-summary-grid">
+            <div data-testid="stats-summary-total-tokens">
+              <HeadlineMetricCard
+                title={t(
+                  msg("총 토큰", "Total Tokens", "総トークン", "总代币"),
+                )}
+                value={summary ? formatTokens(summary.total_tokens) : "…"}
+                sub={t(
+                  msg(
+                    `${numberFormatter.format(rangeDays)}일 누적`,
+                    `${numberFormatter.format(rangeDays)} day total`,
+                    `${numberFormatter.format(rangeDays)}日累計`,
+                    `${numberFormatter.format(rangeDays)} 天累计`,
+                  ),
+                )}
+                tip={t(
+                  msg(
+                    "input + output + cache read / write 합산",
+                    "Sum of input + output + cache read / write",
+                    "input + output + cache read / write の合計",
+                    "input + output + cache read / write 的总和",
+                  ),
+                )}
+                delta={tokenMomentumDelta?.value}
+                deltaTone={tokenMomentumDelta?.tone}
               />
             </div>
+            <div data-testid="stats-summary-api-spend">
+              <HeadlineMetricCard
+                title={t(
+                  msg("API 비용", "API Spend", "API コスト", "API 成本"),
+                )}
+                value={summary ? formatCurrency(summary.total_cost) : "…"}
+                sub={
+                  summary
+                    ? t(
+                        msg(
+                          `${formatCurrency(summary.cache_discount)} 절감됨`,
+                          `${formatCurrency(summary.cache_discount)} saved`,
+                          `${formatCurrency(summary.cache_discount)} 節約`,
+                          `${formatCurrency(summary.cache_discount)} 已节省`,
+                        ),
+                      )
+                    : t(msg("비용 집계 대기", "Waiting for spend data"))
+                }
+                tip={t(
+                  msg(
+                    "캐시 할인을 반영한 실제 결제 비용",
+                    "Actual spend after cache discounts",
+                    "キャッシュ割引を反映した実支出",
+                    "计入缓存折扣后的实际支出",
+                  ),
+                )}
+                delta={cacheSavingsDelta?.value}
+                deltaTone={cacheSavingsDelta?.tone}
+              />
+            </div>
+            <div data-testid="stats-summary-cache-saved">
+              <HeadlineMetricCard
+                title={t(
+                  msg("활성 일수", "Active Days", "稼働日数", "活跃天数"),
+                )}
+                value={
+                  summary
+                    ? `${numberFormatter.format(summary.active_days)} / ${numberFormatter.format(rangeDays)}`
+                    : "…"
+                }
+                sub={
+                  summary
+                    ? t(
+                        msg(
+                          `일 평균 ${formatTokens(Math.round(averageDailyTokens))}`,
+                          `Avg ${formatTokens(Math.round(averageDailyTokens))} per day`,
+                          `平均 ${formatTokens(Math.round(averageDailyTokens))} / 日`,
+                          `日均 ${formatTokens(Math.round(averageDailyTokens))}`,
+                        ),
+                      )
+                    : t(
+                        msg(
+                          "활성 일수 집계 대기",
+                          "Waiting for active-day data",
+                        ),
+                      )
+                }
+                tip={t(
+                  msg(
+                    "선택 기간 중 실제 활동이 있었던 일수",
+                    "Days with activity in the selected range",
+                    "選択期間で実際に稼働した日数",
+                    "所选范围内有实际活动的天数",
+                  ),
+                )}
+              />
+            </div>
+            <div data-testid="stats-summary-cache-hit">
+              <HeadlineMetricCard
+                title={t(msg("피크 데이", "Peak Day", "ピーク日", "峰值日"))}
+                value={peakDay ? formatCompactDate(peakDay.date) : "—"}
+                sub={
+                  peakDay
+                    ? t(
+                        msg(
+                          `${formatTokens(peakDay.total_tokens)} · ${peakRatio ? `${peakRatio.toFixed(1)}x 평균` : "평균 대비"}`,
+                          `${formatTokens(peakDay.total_tokens)} · ${peakRatio ? `${peakRatio.toFixed(1)}x avg` : "vs average"}`,
+                          `${formatTokens(peakDay.total_tokens)} · ${peakRatio ? `平均の ${peakRatio.toFixed(1)}x` : "平均比"}`,
+                          `${formatTokens(peakDay.total_tokens)} · ${peakRatio ? `${peakRatio.toFixed(1)}x 平均` : "相对平均"}`,
+                        ),
+                      )
+                    : t(msg("피크 데이터 없음", "No peak-day data"))
+                }
+                tip={t(
+                  msg(
+                    "선택 기간 내 최고 사용량 날짜",
+                    "Highest-usage day in the selected range",
+                    "選択期間内の最高使用量日",
+                    "所选范围内使用量最高的一天",
+                  ),
+                )}
+              />
+            </div>
+          </div>
 
-            <div data-testid="stats-provider-share">
-              <ProviderShareCard
+          <div className="grid grid-feature">
+            <div data-testid="stats-daily-token-chart">
+              <DailyTokenCompositionCard
                 t={t}
-                loading={analyticsLoading}
+                localeTag={localeTag}
+                loading={loading}
+                daily={analytics?.daily ?? []}
+                series={series}
+              />
+            </div>
+            <div data-testid="stats-daily-cache-hit">
+              <DailyCacheHitCard
+                t={t}
+                localeTag={localeTag}
+                loading={loading}
+                daily={analytics?.daily ?? []}
+                averageHitRate={averageDailyHitRate}
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-2">
+            <div data-testid="stats-model-share">
+              <ModelDistributionCard
+                t={t}
+                loading={loading}
+                segments={modelSegments}
+                totalTokens={summary?.total_tokens ?? 0}
+              />
+            </div>
+            <div data-testid="stats-agent-cost">
+              <AgentSpendCard
+                t={t}
+                loading={loading}
+                rows={agentSpendRows}
+                rangeDays={rangeDays}
+              />
+            </div>
+          </div>
+
+          <div data-testid="stats-agent-cache">
+            <AgentCacheCard
+              t={t}
+              loading={loading}
+              rows={agentCacheRows}
+              overallCacheHitRate={overallCacheHitRate}
+            />
+          </div>
+
+          <div className="grid grid-extra">
+            <div data-testid="stats-provider-share">
+              <ProviderDistributionCard
+                t={t}
+                loading={loading}
                 segments={providerSegments}
               />
             </div>
+            <div className="stack">
+              <div data-testid="stats-skill-usage">
+                <SkillUsageCard
+                  t={t}
+                  loading={skillLoading || catalogLoading}
+                  rows={skillRows}
+                  byAgentRows={topAgentSkillPairs}
+                  windowCalls={skillWindowCalls}
+                />
+              </div>
+              <div data-testid="stats-agent-leaderboard">
+                <AgentLeaderboardCard t={t} rows={leaderboardRows} />
+              </div>
+            </div>
           </div>
-        </div>
-
-        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
-          <div data-testid="stats-skill-usage">
-            <SkillUsageSection
-              t={t}
-              localeTag={localeTag}
-              loading={skillLoading || catalogLoading}
-              skillRows={skillRows}
-              byAgentRows={byAgentSkillRows}
-              activeSkillCount={activeSkillCount}
-              catalogCount={catalog.length}
-              catalogUsedCount={catalogUsedCount}
-              windowCalls={windowCalls}
-            />
-          </div>
-
-          <div data-testid="stats-agent-leaderboard">
-            <AgentLeaderboardCard
-              t={t}
-              loading={analyticsLoading}
-              rows={agentLeaderboard}
-            />
-          </div>
-        </div>
-      </section>
+        </section>
+      </div>
     </div>
   );
 }
 
-function HeaderBadge({ icon, label }: { icon: ReactNode; label: string }) {
-  return (
-    <span
-      className={dashboardBadge.default}
-      style={{
-        background: "var(--th-overlay-light)",
-        color: "var(--th-text-secondary)",
-        borderColor: "var(--th-border-subtle)",
-      }}
-    >
-      <span className="inline-flex items-center gap-1.5">
-        {icon}
-        <span>{label}</span>
-      </span>
-    </span>
-  );
-}
-
-function SummaryMetricCard({
-  icon,
-  label,
+function HeadlineMetricCard({
+  title,
   value,
   sub,
-  accent,
+  tip,
+  delta,
+  deltaTone,
 }: {
-  icon: ReactNode;
-  label: string;
+  title: string;
   value: string;
   sub: string;
-  accent: string;
+  tip: string;
+  delta?: string;
+  deltaTone?: MetricDeltaTone;
 }) {
   return (
-    <article
-      className={dashboardCard.standard}
-      style={{
-        borderColor: `color-mix(in oklch, ${accent} 30%, var(--th-border) 70%)`,
-        background:
-          `linear-gradient(180deg, color-mix(in oklch, ${accent} 8%, var(--th-surface) 92%) 0%, var(--th-surface) 100%)`,
-      }}
-    >
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <div className={dashboardText.label} style={{ color: "var(--th-text-muted)" }}>
-            {label}
-          </div>
+    <article className="card min-h-[128px]">
+      <div className="card-body metric min-w-0">
+        <div className="flex items-start justify-between gap-3">
           <div
-            className="mt-3 text-3xl font-black tracking-tight tabular-nums"
-            style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}
+            className="card-title text-[10.5px] font-semibold uppercase tracking-[0.18em]"
+            style={{ color: "var(--th-text-muted)" }}
+            data-tip={tip}
           >
-            {value}
+            <span>{title}</span>
+            <Info
+              size={11}
+              style={{ color: "var(--th-text-muted)", flexShrink: 0 }}
+            />
           </div>
-          <div className="mt-2 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
-            {sub}
-          </div>
+          {delta ? (
+            <span className={cx("delta", deltaTone ?? "flat")}>{delta}</span>
+          ) : null}
         </div>
-        <span
-          className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border"
-          style={{
-            background: `color-mix(in oklch, ${accent} 14%, transparent)`,
-            borderColor: `color-mix(in oklch, ${accent} 34%, var(--th-border) 66%)`,
-            color: accent,
-          }}
+        <div
+          className="metric-value mt-3"
+          style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}
         >
-          {icon}
-        </span>
+          {value}
+        </div>
+        <div
+          className="metric-sub mt-2 text-xs leading-5"
+          style={{ color: "var(--th-text-muted)" }}
+        >
+          {sub}
+        </div>
       </div>
     </article>
   );
 }
 
-function DailyTokenChartCard({
+function CardHead({
+  title,
+  subtitle,
+  actions,
+}: {
+  title: string;
+  subtitle: string;
+  actions?: ReactNode;
+}) {
+  return (
+    <div className="card-head">
+      <div className="min-w-0">
+        <div className="card-title">{title}</div>
+        <div
+          className="mt-1 text-[11px] leading-5"
+          style={{ color: "var(--th-text-muted)" }}
+        >
+          {subtitle}
+        </div>
+      </div>
+      {actions ? (
+        <div className="flex shrink-0 flex-wrap gap-2">{actions}</div>
+      ) : null}
+    </div>
+  );
+}
+
+function LegendDot({ color, label }: { color: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className="h-2 w-2 rounded-[2px]" style={{ background: color }} />
+      <span>{label}</span>
+    </span>
+  );
+}
+
+function DailyTokenCompositionCard({
   t,
   localeTag,
-  numberFormatter,
   loading,
   daily,
   series,
-  summary,
 }: {
   t: TFunction;
   localeTag: string;
-  numberFormatter: Intl.NumberFormat;
   loading: boolean;
   daily: TokenAnalyticsDailyPoint[];
-  series: Array<{ key: DailySeriesKey; label: string; color: string }>;
-  summary: TokenAnalyticsResponse["summary"] | null | undefined;
+  series: DailySeriesDescriptor[];
 }) {
   const maxTotal = Math.max(1, ...daily.map((day) => day.total_tokens));
   const labelStride = Math.max(1, Math.ceil(Math.max(daily.length, 1) / 7));
 
   return (
-    <article className={dashboardCard.standard}>
-      <SectionHeader
-        icon={<Activity size={18} />}
-        title={t({ ko: "일별 토큰 스택", en: "Daily Token Stack", ja: "日次トークンスタック", zh: "每日 Token 堆栈" })}
-        description={t({
-          ko: "입력, 출력, 캐시 읽기/쓰기를 하루 단위 스택 바로 비교합니다.",
-          en: "Compare input, output, cache read, and cache write as daily stacked bars.",
-          ja: "入力・出力・キャッシュ読取/書込を日別の積み上げバーで比較します。",
-          zh: "以每日堆叠柱比较输入、输出、缓存读写。",
-        })}
+    <article className="card">
+      <CardHead
+        title={t(
+          msg(
+            "일별 토큰 구성",
+            "Daily Token Composition",
+            "日次トークン構成",
+            "每日 Token 构成",
+          ),
+        )}
+        subtitle={t(
+          msg(
+            "input · output · cache read / write · 바 위에서 호버",
+            "input · output · cache read / write · hover bars",
+            "input · output · cache read / write · バーにホバー",
+            "input · output · cache read / write · 悬停柱状图",
+          ),
+        )}
         actions={
-          summary ? (
-            <div className="flex flex-wrap gap-2">
-              <span className={dashboardBadge.default} style={numericBadgeStyle}>
-                {t({
-                  ko: `피크 ${summary.peak_day?.date ? formatDateLabel(summary.peak_day.date, localeTag) : "—"}`,
-                  en: `Peak ${summary.peak_day?.date ? formatDateLabel(summary.peak_day.date, localeTag) : "—"}`,
-                  ja: `ピーク ${summary.peak_day?.date ? formatDateLabel(summary.peak_day.date, localeTag) : "—"}`,
-                  zh: `峰值 ${summary.peak_day?.date ? formatDateLabel(summary.peak_day.date, localeTag) : "—"}`,
-                })}
-              </span>
-              <span className={dashboardBadge.default} style={numericBadgeStyle}>
-                {t({
-                  ko: `평균 ${formatTokens(summary.average_daily_tokens)} / 일`,
-                  en: `Avg ${formatTokens(summary.average_daily_tokens)} / day`,
-                  ja: `平均 ${formatTokens(summary.average_daily_tokens)} / 日`,
-                  zh: `平均 ${formatTokens(summary.average_daily_tokens)} / 天`,
-                })}
-              </span>
-            </div>
-          ) : null
+          <div
+            className="flex flex-wrap gap-3 text-[10.5px]"
+            style={{ color: "var(--th-text-muted)", ...NUMERIC_STYLE }}
+          >
+            {series.map((item) => (
+              <LegendDot key={item.key} color={item.color} label={item.label} />
+            ))}
+          </div>
         }
       />
 
-      {daily.length === 0 ? (
-        <DashboardEmptyState
-          icon={<BarChart3 size={18} />}
-          title={
-            loading
-              ? t({
-                  ko: "일별 토큰 차트를 불러오는 중입니다.",
-                  en: "Loading the daily token chart.",
-                  ja: "日次トークンチャートを読み込み中です。",
-                  zh: "正在加载每日 Token 图。",
-                })
-              : t({
-                  ko: "표시할 일별 토큰 데이터가 없습니다.",
-                  en: "No daily token data available.",
-                  ja: "表示する日次トークンデータがありません。",
-                  zh: "没有可显示的每日 Token 数据。",
-                })
-          }
-          className="mt-4"
-        />
-      ) : (
-        <>
-          <div className="mt-4 flex flex-wrap gap-2 text-[11px]">
-            {series.map((item) => (
-              <span key={item.key} className="inline-flex items-center gap-1.5" style={{ color: "var(--th-text-muted)" }}>
-                <span
-                  className="h-3.5 w-3.5 rounded-full"
-                  style={{ background: item.color, boxShadow: `0 0 0 1px ${item.color}30 inset` }}
-                />
-                {item.label}
-              </span>
-            ))}
-          </div>
-
-          <div className="mt-4 overflow-x-auto overflow-y-visible">
+      <div className="card-body">
+        {daily.length === 0 ? (
+          <DashboardEmptyState
+            icon={<BarChart3 size={18} />}
+            title={
+              loading
+                ? t(
+                    msg(
+                      "일별 토큰 차트를 불러오는 중입니다.",
+                      "Loading daily token chart.",
+                    ),
+                  )
+                : t(
+                    msg(
+                      "표시할 일별 토큰 데이터가 없습니다.",
+                      "No daily token data available.",
+                    ),
+                  )
+            }
+          />
+        ) : (
+          <div className="overflow-x-auto overflow-y-hidden">
             <div
               className="flex items-end gap-1 pb-1"
               style={{ minWidth: `${Math.max(360, daily.length * 24)}px` }}
@@ -986,43 +1477,58 @@ function DailyTokenChartCard({
               {daily.map((day, index) => {
                 const height =
                   day.total_tokens > 0
-                    ? Math.max(10, Math.round((day.total_tokens / maxTotal) * DAILY_BAR_HEIGHT_PX))
-                    : 10;
-                const segments = series.filter((item) => day[item.key] > 0);
+                    ? Math.max(
+                        12,
+                        Math.round((day.total_tokens / maxTotal) * 184),
+                      )
+                    : 12;
                 const compactLabel =
-                  index === 0 || index === daily.length - 1 || index % labelStride === 0;
+                  index === 0 ||
+                  index === daily.length - 1 ||
+                  index % labelStride === 0;
+                const tooltip = [
+                  formatDateLabel(day.date, localeTag),
+                  `${formatTokens(day.total_tokens)} tokens`,
+                  `${series[0].label}: ${formatTokens(day.cache_read_tokens)}`,
+                  `${series[1].label}: ${formatTokens(day.cache_creation_tokens)}`,
+                  `${series[2].label}: ${formatTokens(day.input_tokens)}`,
+                  `${series[3].label}: ${formatTokens(day.output_tokens)}`,
+                ].join("\n");
+
                 return (
                   <div
                     key={day.date}
-                    className="group flex min-w-[20px] flex-1 flex-col items-center gap-2"
-                    title={[
-                      formatDateLabel(day.date, localeTag),
-                      `${formatTokens(day.total_tokens)} tokens`,
-                      `${formatCurrency(day.cost)}`,
-                      ...segments.map((item) => `${item.label} ${formatTokens(day[item.key])}`),
-                    ].join("\n")}
+                    className="group flex min-w-[18px] flex-1 flex-col items-center gap-2"
+                    title={tooltip}
                   >
                     <div className="flex h-[188px] items-end">
                       <div
-                        className="flex w-[18px] flex-col-reverse overflow-hidden rounded-t-xl border sm:w-[20px]"
+                        className="flex w-[16px] flex-col-reverse overflow-hidden rounded-t-[6px] border sm:w-[18px]"
                         style={{
                           height,
                           borderColor: "var(--th-border-subtle)",
                           background: "var(--th-overlay-subtle)",
                         }}
                       >
-                        {segments.length > 0 ? (
-                          segments.map((item) => (
-                            <div
-                              key={`${day.date}-${item.key}`}
-                              style={{
-                                height: `${(day[item.key] / day.total_tokens) * 100}%`,
-                                background: item.color,
-                              }}
-                            />
-                          ))
+                        {day.total_tokens > 0 ? (
+                          series.map((item) => {
+                            const value = day[item.key];
+                            if (value <= 0) return null;
+                            return (
+                              <div
+                                key={`${day.date}-${item.key}`}
+                                style={{
+                                  height: `${(value / day.total_tokens) * 100}%`,
+                                  background: item.color,
+                                }}
+                              />
+                            );
+                          })
                         ) : (
-                          <div className="h-full w-full" style={{ background: "var(--th-overlay-light)" }} />
+                          <div
+                            className="h-full w-full"
+                            style={{ background: "var(--th-overlay-light)" }}
+                          />
                         )}
                       </div>
                     </div>
@@ -1030,615 +1536,905 @@ function DailyTokenChartCard({
                       className="min-h-[1.8rem] whitespace-nowrap text-center text-[10px] leading-4"
                       style={{ color: "var(--th-text-muted)" }}
                     >
-                      {compactLabel ? formatDateLabel(day.date, localeTag) : ""}
+                      {compactLabel ? formatCompactDate(day.date) : ""}
                     </span>
                   </div>
                 );
               })}
             </div>
           </div>
-
-          <div className="mt-4 grid gap-3 sm:grid-cols-3">
-            <MiniMetric
-              label={t({ ko: "활성 일수", en: "Active Days", ja: "稼働日数", zh: "活跃天数" })}
-              value={summary ? numberFormatter.format(summary.active_days) : "—"}
-            />
-            <MiniMetric
-              label={t({ ko: "피크 토큰", en: "Peak Tokens", ja: "ピークトークン", zh: "峰值 Token" })}
-              value={summary?.peak_day ? formatTokens(summary.peak_day.total_tokens) : "—"}
-            />
-            <MiniMetric
-              label={t({ ko: "피크 비용", en: "Peak Cost", ja: "ピークコスト", zh: "峰值成本" })}
-              value={summary?.peak_day ? formatCurrency(summary.peak_day.cost) : "—"}
-            />
-          </div>
-        </>
-      )}
-    </article>
-  );
-}
-
-function DistributionCard({
-  icon,
-  title,
-  description,
-  emptyLabel,
-  loading,
-  segments,
-  centerLabel,
-  centerValue,
-  centerSub,
-}: {
-  icon: ReactNode;
-  title: string;
-  description: string;
-  emptyLabel: string;
-  loading: boolean;
-  segments: ShareSegment[];
-  centerLabel: string;
-  centerValue: string;
-  centerSub: string;
-}) {
-  const donutBackground = buildDonutBackground(segments);
-
-  return (
-    <article className={dashboardCard.standard}>
-      <SectionHeader icon={icon} title={title} description={description} />
-      {segments.length === 0 ? (
-        <DashboardEmptyState
-          icon={<Cpu size={18} />}
-          title={loading ? "Loading distribution..." : emptyLabel}
-          className="mt-4"
-        />
-      ) : (
-        <div className="mt-4 grid gap-4 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-center">
-          <div className="mx-auto">
-            <div
-              className="relative h-40 w-40 rounded-full border"
-              style={{
-                background: donutBackground,
-                borderColor: "var(--th-border-subtle)",
-                boxShadow: "inset 0 1px 0 var(--th-overlay-subtle)",
-              }}
-            >
-              <div
-                className="absolute inset-[23%] flex flex-col items-center justify-center rounded-full border text-center"
-                style={{
-                  borderColor: "var(--th-border-subtle)",
-                  background: "var(--th-bg-surface)",
-                }}
-              >
-                <div className={dashboardText.labelMuted} style={{ color: "var(--th-text-muted)" }}>
-                  {centerLabel}
-                </div>
-                <div className="mt-2 text-2xl font-black tracking-tight" style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}>
-                  {centerValue}
-                </div>
-                <div className="mt-1 px-3 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
-                  {centerSub}
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="space-y-3">
-            {segments.map((segment) => (
-              <DistributionRow
-                key={segment.id}
-                label={segment.label}
-                sublabel={segment.sublabel}
-                value={formatTokens(segment.tokens)}
-                share={segment.percentage}
-                color={segment.color}
-              />
-            ))}
-          </div>
-        </div>
-      )}
-    </article>
-  );
-}
-
-function ProviderShareCard({
-  t,
-  loading,
-  segments,
-}: {
-  t: TFunction;
-  loading: boolean;
-  segments: ShareSegment[];
-}) {
-  return (
-    <article className={dashboardCard.standard}>
-      <SectionHeader
-        icon={<Bot size={18} />}
-        title={t({ ko: "프로바이더 비중", en: "Provider Share", ja: "プロバイダー比率", zh: "提供商占比" })}
-        description={t({
-          ko: "Claude, Codex 등 프로바이더별 토큰 처리 비중을 비교합니다.",
-          en: "Compare token volume across providers such as Claude and Codex.",
-          ja: "Claude、Codex などプロバイダー別のトークン処理比率を比較します。",
-          zh: "比较 Claude、Codex 等提供商的 Token 处理占比。",
-        })}
-      />
-
-      {segments.length === 0 ? (
-        <DashboardEmptyState
-          icon={<Bot size={18} />}
-          title={
-            loading
-              ? t({
-                  ko: "프로바이더 비중을 불러오는 중입니다.",
-                  en: "Loading provider share.",
-                  ja: "プロバイダー比率を読み込み中です。",
-                  zh: "正在加载提供商占比。",
-                })
-              : t({
-                  ko: "표시할 프로바이더 데이터가 없습니다.",
-                  en: "No provider data available.",
-                  ja: "表示するプロバイダーデータがありません。",
-                  zh: "没有可显示的提供商数据。",
-                })
-          }
-          className="mt-4"
-        />
-      ) : (
-        <div className="mt-4 space-y-3">
-          {segments.map((segment) => (
-            <DistributionRow
-              key={segment.id}
-              label={segment.label}
-              value={formatTokens(segment.tokens)}
-              share={segment.percentage}
-              color={segment.color}
-            />
-          ))}
-        </div>
-      )}
-    </article>
-  );
-}
-
-function DistributionRow({
-  label,
-  sublabel,
-  value,
-  share,
-  color,
-}: {
-  label: string;
-  sublabel?: string;
-  value: string;
-  share: number;
-  color: string;
-}) {
-  return (
-    <div className={dashboardCard.nestedCompact}>
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2">
-            <span className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ background: color }} />
-            <span className="truncate text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
-              {label}
-            </span>
-          </div>
-          {sublabel ? (
-            <div className="mt-1 text-xs" style={{ color: "var(--th-text-muted)" }}>
-              {sublabel}
-            </div>
-          ) : null}
-        </div>
-        <div className="text-right">
-          <div className="text-sm font-bold tabular-nums" style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}>
-            {formatPercent(share)}
-          </div>
-          <div className="mt-1 text-xs" style={{ color: "var(--th-text-muted)" }}>
-            {value}
-          </div>
-        </div>
+        )}
       </div>
-      <div className="mt-3 h-2.5 overflow-hidden rounded-full" style={{ background: "var(--th-overlay-subtle)" }}>
-        <div
-          className="h-full rounded-full"
-          style={{
-            width: `${Math.max(share, share > 0 ? 4 : 0)}%`,
-            background: `linear-gradient(90deg, ${color}, color-mix(in oklch, ${color} 68%, white 32%))`,
-          }}
-        />
-      </div>
-    </div>
+    </article>
   );
 }
 
-function SkillUsageSection({
+function DailyCacheHitCard({
   t,
   localeTag,
   loading,
-  skillRows,
-  byAgentRows,
-  activeSkillCount,
-  catalogCount,
-  catalogUsedCount,
-  windowCalls,
+  daily,
+  averageHitRate,
 }: {
   t: TFunction;
   localeTag: string;
   loading: boolean;
-  skillRows: SkillUsageRow[];
-  byAgentRows: AgentSkillRow[];
-  activeSkillCount: number;
-  catalogCount: number;
-  catalogUsedCount: number;
-  windowCalls: number;
+  daily: TokenAnalyticsDailyPoint[];
+  averageHitRate: number;
 }) {
   return (
-    <article className={dashboardCard.standard}>
-      <SectionHeader
-        icon={<Sparkles size={18} />}
-        title={t({ ko: "스킬 랭킹과 사용량", en: "Skill Ranking & Usage", ja: "スキルランキングと使用量", zh: "技能排行与使用量" })}
-        description={t({
-          ko: "선택 범위의 상위 스킬 호출과 에이전트별 스킬 사용을 한 화면에 모읍니다.",
-          en: "Combine top skill calls in the selected window with agent-level skill usage.",
-          ja: "選択範囲の上位スキル呼び出しとエージェント別スキル使用を一画面にまとめます。",
-          zh: "将所选范围的高频技能调用与代理级技能使用放到同一屏。",
-        })}
+    <article className="card">
+      <CardHead
+        title={t(
+          msg(
+            "일별 캐시 히트율",
+            "Daily Cache Hit Rate",
+            "日次キャッシュヒット率",
+            "每日缓存命中率",
+          ),
+        )}
+        subtitle={t(
+          msg(
+            "prompt 토큰 중 캐시 비중",
+            "Cache share among prompt tokens",
+            "prompt トークン内のキャッシュ比率",
+            "prompt Token 中的缓存占比",
+          ),
+        )}
         actions={
-          <div className="flex flex-wrap gap-2">
-            <span className={dashboardBadge.default} style={numericBadgeStyle}>
-              {t({
-                ko: `${activeSkillCount}/${catalogCount || 0} 범위 활성`,
-                en: `${activeSkillCount}/${catalogCount || 0} active in range`,
-                ja: `${activeSkillCount}/${catalogCount || 0} 件が範囲内で活性`,
-                zh: `${activeSkillCount}/${catalogCount || 0} 个在区间内活跃`,
-              })}
-            </span>
-            <span className={dashboardBadge.default} style={numericBadgeStyle}>
-              {t({
-                ko: `${catalogUsedCount}/${catalogCount || 0} 카탈로그 사용`,
-                en: `${catalogUsedCount}/${catalogCount || 0} catalog used`,
-                ja: `${catalogUsedCount}/${catalogCount || 0} カタログ使用`,
-                zh: `${catalogUsedCount}/${catalogCount || 0} 个目录已使用`,
-              })}
-            </span>
-          </div>
+          <span className="chip" style={positiveChipStyle}>
+            {formatPercent(averageHitRate)}{" "}
+            {t(msg("평균", "avg", "平均", "平均"))}
+          </span>
         }
       />
 
-      <div
-        className={cx("mt-4", dashboardCard.nestedCompact)}
-        style={{
-          borderColor: "color-mix(in oklch, var(--warn) 32%, var(--th-border) 68%)",
-          background:
-            "linear-gradient(180deg, color-mix(in oklch, var(--warn) 6%, var(--th-surface) 94%) 0%, var(--th-surface) 100%)",
-        }}
-      >
-        <div className="flex items-start gap-3">
-          <ShieldAlert
-            size={18}
-            style={{ color: "var(--th-accent-warn)", flexShrink: 0, marginTop: 2 }}
+      <div className="card-body">
+        {daily.length === 0 ? (
+          <DashboardEmptyState
+            icon={<Gauge size={18} />}
+            title={
+              loading
+                ? t(
+                    msg(
+                      "캐시 히트율을 불러오는 중입니다.",
+                      "Loading cache hit rate.",
+                    ),
+                  )
+                : t(
+                    msg(
+                      "표시할 캐시 히트율 데이터가 없습니다.",
+                      "No cache hit data available.",
+                    ),
+                  )
+            }
           />
-          <div className="min-w-0">
-            <div className="text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
-              {t({
-                ko: "p95는 아직 API에 없습니다.",
-                en: "p95 is not available in the API yet.",
-                ja: "p95 はまだ API にありません。",
-                zh: "API 目前还没有 p95。",
+        ) : (
+          <div>
+            <div
+              className="grid h-[180px] items-end gap-1"
+              style={{
+                gridTemplateColumns: `repeat(${daily.length}, minmax(0, 1fr))`,
+              }}
+            >
+              {daily.map((day) => {
+                const hitRate = computeDailyHitRate(day);
+                return (
+                  <div
+                    key={day.date}
+                    title={`${formatDateLabel(day.date, localeTag)}: ${formatPercent(hitRate)}`}
+                    className="rounded-t-[4px]"
+                    style={{
+                      height: `${Math.max(hitRate, hitRate > 0 ? 2 : 0)}%`,
+                      background:
+                        "linear-gradient(180deg, var(--codex), color-mix(in oklch, var(--codex) 60%, white 40%))",
+                      opacity: 0.88,
+                    }}
+                  />
+                );
               })}
             </div>
-            <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
-              {t({
-                ko: "`getSkillRanking()` / `getSkillCatalog()`에 p95 필드가 없어 이 영역은 호출량, 카탈로그 누적 호출, 마지막 사용 시점으로 대체했습니다.",
-                en: "`getSkillRanking()` and `getSkillCatalog()` do not expose a p95 field, so this section uses call count, catalog lifetime calls, and last-used recency instead.",
-                ja: "`getSkillRanking()` / `getSkillCatalog()` に p95 フィールドがないため、この領域では呼び出し回数、カタログ累積回数、最終使用時刻で代替しています。",
-                zh: "`getSkillRanking()` / `getSkillCatalog()` 没有提供 p95 字段，因此此区域改为展示调用次数、目录累计调用和最近使用时间。",
-              })}
+            <div
+              className="mt-2 flex justify-between text-[10px]"
+              style={{ color: "var(--th-text-muted)", ...NUMERIC_STYLE }}
+            >
+              <span>{formatCompactDate(daily[0].date)}</span>
+              <span>{formatCompactDate(daily[daily.length - 1].date)}</span>
             </div>
           </div>
-        </div>
+        )}
       </div>
+    </article>
+  );
+}
 
-      {skillRows.length === 0 && byAgentRows.length === 0 ? (
-        <DashboardEmptyState
-          icon={<Sparkles size={18} />}
-          title={
-            loading
-              ? t({
-                  ko: "스킬 사용 데이터를 불러오는 중입니다.",
-                  en: "Loading skill usage.",
-                  ja: "スキル使用データを読み込み中です。",
-                  zh: "正在加载技能使用数据。",
-                })
-              : t({
-                  ko: "표시할 스킬 사용 데이터가 없습니다.",
-                  en: "No skill usage data available.",
-                  ja: "表示するスキル使用データがありません。",
-                  zh: "没有可显示的技能使用数据。",
-                })
-          }
-          className="mt-4"
-        />
-      ) : (
-        <div className="mt-4 grid gap-4 2xl:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
-          <div className="space-y-3">
-            {skillRows.map((row) => (
-              <div key={row.id} className={dashboardCard.nestedCompact}>
-                <div className="flex items-start justify-between gap-3">
+function ModelDistributionCard({
+  t,
+  loading,
+  segments,
+  totalTokens,
+}: {
+  t: TFunction;
+  loading: boolean;
+  segments: ShareSegment[];
+  totalTokens: number;
+}) {
+  return (
+    <article className="card">
+      <CardHead
+        title={t(
+          msg("모델 분포", "Model Distribution", "モデル分布", "模型分布"),
+        )}
+        subtitle={t(
+          msg(
+            "Claude / Codex 모델별 토큰 배분",
+            "Token share by Claude / Codex models",
+            "Claude / Codex モデル別トークン配分",
+            "按 Claude / Codex 模型划分的 Token 占比",
+          ),
+        )}
+        actions={
+          <span className="chip" style={numericBadgeStyle}>
+            {formatTokens(totalTokens)} total
+          </span>
+        }
+      />
+
+      <div className="card-body">
+        {segments.length === 0 ? (
+          <DashboardEmptyState
+            icon={<Cpu size={18} />}
+            title={
+              loading
+                ? t(
+                    msg(
+                      "모델 분포를 불러오는 중입니다.",
+                      "Loading model distribution.",
+                    ),
+                  )
+                : t(
+                    msg(
+                      "표시할 모델 데이터가 없습니다.",
+                      "No model data available.",
+                    ),
+                  )
+            }
+          />
+        ) : (
+          <div>
+            <div className="mb-4 flex h-2.5 overflow-hidden rounded-full">
+              {segments.map((segment) => (
+                <div
+                  key={segment.id}
+                  title={`${segment.label} ${formatPercent(segment.percentage)}`}
+                  style={{
+                    width: `${segment.percentage}%`,
+                    background: segment.color,
+                    minWidth: segment.percentage > 0 ? "8px" : "0",
+                  }}
+                />
+              ))}
+            </div>
+
+            <div className="space-y-3">
+              {segments.map((segment) => (
+                <div
+                  key={segment.id}
+                  className="grid grid-cols-[auto_minmax(0,1fr)_auto_auto] items-center gap-3 rounded-[14px] border border-transparent px-1 py-1"
+                >
+                  <span
+                    className="mt-1 h-2.5 w-2.5 rounded-[3px]"
+                    style={{ background: segment.color }}
+                  />
                   <div className="min-w-0">
-                    <div className="text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
-                      {row.description}
+                    <div
+                      className="truncate text-sm font-semibold"
+                      style={{ color: "var(--th-text-heading)" }}
+                    >
+                      {segment.label}
                     </div>
-                    <div className="mt-1 truncate text-xs" style={{ color: "var(--th-text-muted)" }}>
-                      {row.name}
+                    <div
+                      className="mt-1 text-[11px]"
+                      style={{ color: "var(--th-text-muted)" }}
+                    >
+                      {segment.sublabel}
                     </div>
                   </div>
-                  <span className={dashboardBadge.default} style={numericBadgeStyle}>
-                    {formatPercent(row.windowShare)}
-                  </span>
-                </div>
-
-                <div className="mt-3 grid gap-3 sm:grid-cols-3">
-                  <MiniMetric
-                    label={t({ ko: "범위 호출", en: "Range Calls", ja: "範囲呼び出し", zh: "区间调用" })}
-                    value={row.windowCalls.toLocaleString(localeTag)}
-                  />
-                  <MiniMetric
-                    label={t({ ko: "카탈로그 누적", en: "Catalog Lifetime", ja: "カタログ累積", zh: "目录累计" })}
-                    value={row.lifetimeCalls != null ? row.lifetimeCalls.toLocaleString(localeTag) : "—"}
-                  />
-                  <MiniMetric
-                    label={t({ ko: "마지막 사용", en: "Last Used", ja: "最終使用", zh: "最近使用" })}
-                    value={row.lastUsedAt ? timeAgo(row.lastUsedAt, localeTag) : "—"}
-                  />
-                </div>
-
-                <div className="mt-3 h-2 overflow-hidden rounded-full" style={{ background: "var(--th-overlay-subtle)" }}>
                   <div
-                    className="h-full rounded-full"
+                    className="text-right text-[11px]"
+                    style={{ color: "var(--th-text-muted)", ...NUMERIC_STYLE }}
+                  >
+                    {formatTokens(segment.tokens)}
+                  </div>
+                  <div
+                    className="min-w-[48px] text-right text-sm font-semibold"
                     style={{
-                      width: `${Math.max(row.windowShare, row.windowShare > 0 ? 4 : 0)}%`,
-                      background:
-                        "linear-gradient(90deg, var(--accent), color-mix(in oklch, var(--accent) 60%, white 40%))",
+                      color: "var(--th-text-heading)",
+                      ...NUMERIC_STYLE,
+                    }}
+                  >
+                    {formatPercent(segment.percentage)}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}
+
+function ProviderDistributionCard({
+  t,
+  loading,
+  segments,
+}: {
+  t: TFunction;
+  loading: boolean;
+  segments: ShareSegment[];
+}) {
+  return (
+    <article className="card">
+      <CardHead
+        title={t(
+          msg(
+            "프로바이더 분포",
+            "Provider Share",
+            "プロバイダー分布",
+            "Provider 分布",
+          ),
+        )}
+        subtitle={t(
+          msg(
+            "Claude / Codex / 기타 런타임별 토큰 비중",
+            "Token mix by runtime provider",
+            "ランタイムプロバイダー別トークン比率",
+            "按运行时 Provider 划分的 Token 占比",
+          ),
+        )}
+        actions={
+          <span className="chip" style={numericBadgeStyle}>
+            {segments.length}{" "}
+            {t(msg("providers", "providers", "providers", "providers"))}
+          </span>
+        }
+      />
+
+      <div className="card-body">
+        {segments.length === 0 ? (
+          <DashboardEmptyState
+            icon={<Cpu size={18} />}
+            title={
+              loading
+                ? t(
+                    msg(
+                      "프로바이더 분포를 불러오는 중입니다.",
+                      "Loading provider mix.",
+                    ),
+                  )
+                : t(
+                    msg(
+                      "표시할 프로바이더 데이터가 없습니다.",
+                      "No provider data available.",
+                    ),
+                  )
+            }
+          />
+        ) : (
+          <div className="space-y-3">
+            {segments.map((segment) => (
+              <div key={segment.id} className="list-card tight">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="h-2.5 w-2.5 rounded-[3px]"
+                        style={{ background: segment.color }}
+                      />
+                      <span
+                        className="truncate text-sm font-semibold"
+                        style={{ color: "var(--th-text-heading)" }}
+                      >
+                        {segment.label}
+                      </span>
+                    </div>
+                    <div
+                      className="mt-1 text-[11px]"
+                      style={{ color: "var(--th-text-muted)" }}
+                    >
+                      {segment.sublabel}
+                    </div>
+                  </div>
+                  <div className="text-right" style={{ ...NUMERIC_STYLE }}>
+                    <div
+                      className="text-sm font-semibold"
+                      style={{ color: "var(--th-text-heading)" }}
+                    >
+                      {formatPercent(segment.percentage)}
+                    </div>
+                    <div
+                      className="text-[11px]"
+                      style={{ color: "var(--th-text-muted)" }}
+                    >
+                      {formatTokens(segment.tokens)}
+                    </div>
+                  </div>
+                </div>
+                <div className="bar-track mt-3">
+                  <div
+                    className="bar-fill"
+                    style={{
+                      width: `${Math.max(segment.percentage, segment.percentage > 0 ? 4 : 0)}%`,
+                      background: segment.color,
                     }}
                   />
                 </div>
               </div>
             ))}
           </div>
+        )}
+      </div>
+    </article>
+  );
+}
 
-          <div className="space-y-4">
-            <div className={dashboardCard.nestedCompact}>
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <div className="text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
-                    {t({ ko: "에이전트별 상위 스킬", en: "Top Agent-Skill Pairs", ja: "エージェント別上位スキル", zh: "代理-技能高频组合" })}
+function AgentSpendCard({
+  t,
+  loading,
+  rows,
+  rangeDays,
+}: {
+  t: TFunction;
+  loading: boolean;
+  rows: AgentSpendRow[];
+  rangeDays: number;
+}) {
+  const maxCost = Math.max(1, ...rows.map((row) => row.cost));
+
+  return (
+    <article className="card">
+      <CardHead
+        title={t(
+          msg(
+            "에이전트별 비용 비교",
+            "Spend by Agent",
+            "エージェント別コスト比較",
+            "按代理比较成本",
+          ),
+        )}
+        subtitle={t(
+          msg(
+            `${rangeDays}일 누적 지출`,
+            `${rangeDays}d accumulated spend`,
+            `${rangeDays}日累積支出`,
+            `${rangeDays} 天累计支出`,
+          ),
+        )}
+      />
+
+      <div className="card-body">
+        {rows.length === 0 ? (
+          <DashboardEmptyState
+            icon={<Users size={18} />}
+            title={
+              loading
+                ? t(
+                    msg(
+                      "에이전트 비용을 불러오는 중입니다.",
+                      "Loading agent spend.",
+                    ),
+                  )
+                : t(
+                    msg(
+                      "표시할 에이전트 비용 데이터가 없습니다.",
+                      "No agent spend data available.",
+                    ),
+                  )
+            }
+          />
+        ) : (
+          <div className="flex flex-col gap-3">
+            {rows.map((row, index) => (
+              <div
+                key={row.id}
+                className="grid grid-cols-[20px_minmax(0,1fr)_auto] items-center gap-3"
+              >
+                <span
+                  className="inline-grid h-5 w-5 place-items-center rounded-full text-[10px]"
+                  style={{
+                    background: "var(--th-overlay-subtle)",
+                    color: "var(--th-text-muted)",
+                    ...NUMERIC_STYLE,
+                  }}
+                >
+                  {index + 1}
+                </span>
+                <div className="min-w-0">
+                  <div className="mb-1 flex items-center gap-2">
+                    <span
+                      className="truncate text-sm font-medium"
+                      style={{ color: "var(--th-text-heading)" }}
+                    >
+                      {row.label}
+                    </span>
+                    <span
+                      className="text-[10.5px]"
+                      style={{
+                        color: "var(--th-text-muted)",
+                        ...NUMERIC_STYLE,
+                      }}
+                    >
+                      {formatTokens(row.tokens)} · {formatPercent(row.share)}
+                    </span>
                   </div>
-                  <div className="mt-1 text-xs" style={{ color: "var(--th-text-muted)" }}>
-                    {t({
-                      ko: "가장 많이 호출된 에이전트-스킬 조합입니다.",
-                      en: "Most frequently used agent-skill combinations.",
-                      ja: "最も頻繁に使われたエージェント-スキルの組み合わせです。",
-                      zh: "调用次数最多的代理-技能组合。",
-                    })}
+                  <div className="bar-track" style={{ height: 5 }}>
+                    <div
+                      className="bar-fill"
+                      style={{
+                        width: `${(row.cost / maxCost) * 100}%`,
+                        background: row.color,
+                      }}
+                    />
                   </div>
                 </div>
-                <span className={dashboardBadge.default} style={numericBadgeStyle}>
-                  {windowCalls.toLocaleString(localeTag)}
-                </span>
+                <div
+                  className="min-w-[68px] text-right text-sm font-semibold"
+                  style={{ color: "var(--th-text-heading)", ...NUMERIC_STYLE }}
+                >
+                  {formatCurrency(row.cost)}
+                </div>
               </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}
 
-              <div className="mt-4 space-y-2">
-                {byAgentRows.map((row) => (
-                  <div key={row.id} className={dashboardCard.smallCompact}>
+function AgentCacheCard({
+  t,
+  loading,
+  rows,
+  overallCacheHitRate,
+}: {
+  t: TFunction;
+  loading: boolean;
+  rows: AgentCacheRow[];
+  overallCacheHitRate: number;
+}) {
+  return (
+    <article className="card">
+      <CardHead
+        title={t(
+          msg(
+            "에이전트별 캐시 히트율",
+            "Cache Hit Rate by Agent",
+            "エージェント別キャッシュヒット率",
+            "按代理的缓存命中率",
+          ),
+        )}
+        subtitle={t(
+          msg(
+            "prompt 볼륨이 큰 에이전트 우선",
+            "Ordered by prompt-heavy agents",
+            "prompt ボリュームが大きいエージェント優先",
+            "优先显示 prompt 量大的代理",
+          ),
+        )}
+        actions={
+          <span className="chip" style={positiveChipStyle}>
+            {formatPercent(overallCacheHitRate)}{" "}
+            {t(msg("전체", "overall", "全体", "整体"))}
+          </span>
+        }
+      />
+
+      <div className="card-body">
+        {rows.length === 0 ? (
+          <DashboardEmptyState
+            icon={<Gauge size={18} />}
+            title={
+              loading
+                ? t(
+                    msg(
+                      "에이전트 캐시 데이터를 불러오는 중입니다.",
+                      "Loading agent cache data.",
+                    ),
+                  )
+                : t(
+                    msg(
+                      "표시할 에이전트 캐시 데이터가 없습니다.",
+                      "No agent cache data available.",
+                    ),
+                  )
+            }
+          />
+        ) : (
+          <div className="flex flex-col gap-4">
+            {rows.map((row, index) => {
+              const sub =
+                row.savedCost != null
+                  ? t(
+                      msg(
+                        `${formatTokens(row.promptTokens)} prompt · ${formatCurrency(row.savedCost)} 절감`,
+                        `${formatTokens(row.promptTokens)} prompt · ${formatCurrency(row.savedCost)} saved`,
+                        `${formatTokens(row.promptTokens)} prompt · ${formatCurrency(row.savedCost)} 節約`,
+                        `${formatTokens(row.promptTokens)} prompt · ${formatCurrency(row.savedCost)} 已节省`,
+                      ),
+                    )
+                  : t(
+                      msg(
+                        `${formatTokens(row.promptTokens)} prompt`,
+                        `${formatTokens(row.promptTokens)} prompt`,
+                        `${formatTokens(row.promptTokens)} prompt`,
+                        `${formatTokens(row.promptTokens)} prompt`,
+                      ),
+                    );
+
+              return (
+                <div
+                  key={row.id}
+                  className="grid grid-cols-[24px_minmax(0,1fr)_auto] items-center gap-3"
+                >
+                  <span
+                    className="inline-grid h-5 w-5 place-items-center rounded-full text-[10px] font-semibold"
+                    style={{
+                      background: "var(--codex-soft)",
+                      color: "var(--codex)",
+                      ...NUMERIC_STYLE,
+                    }}
+                  >
+                    {index + 1}
+                  </span>
+                  <div className="min-w-0">
+                    <div className="mb-1 flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                      <span
+                        className="text-sm font-medium"
+                        style={{ color: "var(--th-text-heading)" }}
+                      >
+                        {row.label}
+                      </span>
+                      <span
+                        className="text-[10.5px]"
+                        style={{
+                          color: "var(--th-text-muted)",
+                          ...NUMERIC_STYLE,
+                        }}
+                      >
+                        {sub}
+                      </span>
+                    </div>
+                    <div className="bar-track" style={{ height: 5 }}>
+                      <div
+                        className="bar-fill"
+                        style={{
+                          width: `${Math.max(row.hitRate, row.hitRate > 0 ? 4 : 0)}%`,
+                          background:
+                            "linear-gradient(90deg, var(--codex), color-mix(in oklch, var(--codex) 60%, white 40%))",
+                        }}
+                      />
+                    </div>
+                  </div>
+                  <div
+                    className="min-w-[56px] text-right text-sm font-semibold"
+                    style={{ color: "var(--ok)", ...NUMERIC_STYLE }}
+                  >
+                    {formatPercent(row.hitRate)}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}
+
+function SkillUsageCard({
+  t,
+  loading,
+  rows,
+  byAgentRows,
+  windowCalls,
+}: {
+  t: TFunction;
+  loading: boolean;
+  rows: SkillUsageRow[];
+  byAgentRows: AgentSkillRow[];
+  windowCalls: number;
+}) {
+  const maxCalls = Math.max(1, ...rows.map((row) => row.windowCalls));
+
+  return (
+    <article className="card">
+      <CardHead
+        title={t(msg("스킬 사용", "Skill Usage", "スキル使用量", "技能使用"))}
+        subtitle={t(
+          msg(
+            "현재 기간에 가장 자주 호출된 스킬",
+            "Most-invoked skills in the selected period",
+            "選択期間で最も多く呼ばれたスキル",
+            "所选期间调用最多的技能",
+          ),
+        )}
+        actions={
+          <span className="chip" style={numericBadgeStyle}>
+            {windowCalls.toLocaleString()}{" "}
+            {t(msg("calls", "calls", "calls", "calls"))}
+          </span>
+        }
+      />
+
+      <div className="card-body">
+        {rows.length === 0 && byAgentRows.length === 0 ? (
+          <DashboardEmptyState
+            icon={<BarChart3 size={18} />}
+            title={
+              loading
+                ? t(
+                    msg(
+                      "스킬 사용량을 불러오는 중입니다.",
+                      "Loading skill usage.",
+                    ),
+                  )
+                : t(
+                    msg(
+                      "표시할 스킬 사용 데이터가 없습니다.",
+                      "No skill usage data available.",
+                    ),
+                  )
+            }
+          />
+        ) : (
+          <div className="grid grid-2 gap-3">
+            <div>
+              <div className="list-section">
+                {t(msg("상위 스킬", "Top Skills", "上位スキル", "高频技能"))}
+              </div>
+              <div className="space-y-3">
+                {rows.slice(0, 6).map((row, index) => (
+                  <div key={`${row.id}-${index}`} className="list-card">
                     <div className="flex items-start justify-between gap-3">
                       <div className="min-w-0">
-                        <div className="truncate text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
-                          {row.agentName}
+                        <div
+                          className="text-sm font-semibold"
+                          style={{ color: "var(--th-text-heading)" }}
+                        >
+                          {row.name}
                         </div>
-                        <div className="mt-1 truncate text-xs" style={{ color: "var(--th-text-muted)" }}>
-                          {row.description}
-                        </div>
-                        <div className="mt-1 truncate text-[11px]" style={{ color: "var(--th-text-muted)" }}>
-                          {row.skillName}
-                        </div>
-                      </div>
-                      <div className="shrink-0 text-right">
-                        <div className="text-sm font-bold tabular-nums" style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}>
-                          {row.calls}
-                        </div>
-                        <div className="mt-1 text-[11px]" style={{ color: "var(--th-text-muted)" }}>
-                          {timeAgo(row.lastUsedAt, localeTag)}
+                        <div
+                          className="mt-1 line-clamp-2 text-[11px] leading-5"
+                          style={{ color: "var(--th-text-muted)" }}
+                        >
+                          {row.description ||
+                            t(msg("설명 없음", "No description"))}
                         </div>
                       </div>
+                      <div className="text-right" style={{ ...NUMERIC_STYLE }}>
+                        <div
+                          className="text-base font-semibold"
+                          style={{ color: "var(--th-text-heading)" }}
+                        >
+                          {row.windowCalls.toLocaleString()}
+                        </div>
+                        <div
+                          className="text-[10.5px]"
+                          style={{ color: "var(--th-text-muted)" }}
+                        >
+                          {t(msg("calls", "calls", "calls", "calls"))}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="bar-track mt-3" style={{ height: 5 }}>
+                      <div
+                        className="bar-fill"
+                        style={{
+                          width: `${Math.max((row.windowCalls / maxCalls) * 100, row.windowCalls > 0 ? 4 : 0)}%`,
+                          background:
+                            "linear-gradient(90deg, var(--accent), color-mix(in oklch, var(--accent) 62%, white 38%))",
+                        }}
+                      />
                     </div>
                   </div>
                 ))}
               </div>
             </div>
+
+            <div>
+              <div className="list-section">
+                {t(
+                  msg(
+                    "에이전트별 상위 조합",
+                    "Top Agent-Skill Pairs",
+                    "エージェント別上位組み合わせ",
+                    "代理-技能高频组合",
+                  ),
+                )}
+              </div>
+              <div className="space-y-3">
+                {byAgentRows.length === 0 ? (
+                  <DashboardEmptyState
+                    icon={<Users size={18} />}
+                    title={t(
+                      msg(
+                        "에이전트별 스킬 데이터가 없습니다.",
+                        "No agent-skill data available.",
+                      ),
+                    )}
+                  />
+                ) : (
+                  byAgentRows.map((row, index) => (
+                    <div key={`${row.id}-${index}`} className="list-card tight">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div
+                            className="truncate text-sm font-semibold"
+                            style={{ color: "var(--th-text-heading)" }}
+                          >
+                            {row.agentName}
+                          </div>
+                          <div
+                            className="mt-1 truncate text-[11px]"
+                            style={{ color: "var(--th-text-secondary)" }}
+                          >
+                            {row.skillName}
+                          </div>
+                          <div
+                            className="mt-1 line-clamp-2 text-[11px] leading-5"
+                            style={{ color: "var(--th-text-muted)" }}
+                          >
+                            {row.description ||
+                              t(msg("설명 없음", "No description"))}
+                          </div>
+                        </div>
+                        <div
+                          className="text-right"
+                          style={{ ...NUMERIC_STYLE }}
+                        >
+                          <div
+                            className="text-sm font-semibold"
+                            style={{ color: "var(--th-text-heading)" }}
+                          >
+                            {row.calls.toLocaleString()}
+                          </div>
+                          <div
+                            className="text-[10.5px]"
+                            style={{ color: "var(--th-text-muted)" }}
+                          >
+                            {t(msg("calls", "calls", "calls", "calls"))}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </article>
   );
 }
 
 function AgentLeaderboardCard({
   t,
-  loading,
   rows,
 }: {
   t: TFunction;
-  loading: boolean;
-  rows: AgentLeaderboardRow[];
+  rows: LeaderboardRow[];
 }) {
+  const maxTokens = Math.max(1, ...rows.map((row) => row.tokens));
+
   return (
-    <article className={dashboardCard.standard}>
-      <SectionHeader
-        icon={<Users size={18} />}
-        title={t({ ko: "에이전트 리더보드", en: "Agent Leaderboard", ja: "エージェントリーダーボード", zh: "代理排行榜" })}
-        description={t({
-          ko: "토큰 분석 receipt 기준으로 에이전트별 토큰, 점유율, 비용, 캐시 히트율을 비교합니다.",
-          en: "Compare tokens, share, cost, and cache hit rate by agent using the token analytics receipt.",
-          ja: "トークン分析レシートを基準に、エージェント別のトークン、比率、コスト、キャッシュヒット率を比較します。",
-          zh: "基于 Token 分析回执，对比各代理的 Token、占比、成本和缓存命中率。",
-        })}
+    <article className="card">
+      <CardHead
+        title={t(
+          msg(
+            "에이전트 리더보드",
+            "Agent Leaderboard",
+            "エージェントリーダーボード",
+            "代理排行榜",
+          ),
+        )}
+        subtitle={t(
+          msg(
+            "핵심 생산성 지표를 에이전트 기준으로 정리했습니다.",
+            "Core productivity signals organized by agent.",
+            "主要な生産性指標をエージェント基準で整理しました。",
+            "按代理整理核心生产力指标。",
+          ),
+        )}
+        actions={
+          <span className="chip" style={numericBadgeStyle}>
+            {rows.length} {t(msg("agents", "agents", "agents", "agents"))}
+          </span>
+        }
       />
 
-      {rows.length === 0 ? (
-        <DashboardEmptyState
-          icon={<Users size={18} />}
-          title={
-            loading
-              ? t({
-                  ko: "에이전트 리더보드를 불러오는 중입니다.",
-                  en: "Loading the agent leaderboard.",
-                  ja: "エージェントリーダーボードを読み込み中です。",
-                  zh: "正在加载代理排行榜。",
-                })
-              : t({
-                  ko: "표시할 에이전트 데이터가 없습니다.",
-                  en: "No agent data available.",
-                  ja: "表示するエージェントデータがありません。",
-                  zh: "没有可显示的代理数据。",
-                })
-          }
-          className="mt-4"
-        />
-      ) : (
-        <>
-          <div
-            className="mt-4 hidden grid-cols-[2.5rem_minmax(0,1.5fr)_1fr_0.8fr_0.9fr_0.9fr] gap-3 px-3 text-[11px] font-semibold uppercase tracking-[0.18em] sm:grid"
-            style={{ color: "var(--th-text-muted)" }}
-          >
-            <span>#</span>
-            <span>{t({ ko: "에이전트", en: "Agent", ja: "エージェント", zh: "代理" })}</span>
-            <span>{t({ ko: "토큰", en: "Tokens", ja: "トークン", zh: "Token" })}</span>
-            <span>{t({ ko: "점유율", en: "Share", ja: "比率", zh: "占比" })}</span>
-            <span>{t({ ko: "비용", en: "Cost", ja: "コスト", zh: "成本" })}</span>
-            <span>{t({ ko: "캐시", en: "Cache Hit", ja: "キャッシュ", zh: "缓存" })}</span>
-          </div>
-
-          <div className="mt-3 space-y-2">
+      <div className="card-body">
+        {rows.length === 0 ? (
+          <DashboardEmptyState
+            icon={<Users size={18} />}
+            title={t(
+              msg(
+                "표시할 에이전트 리더보드가 없습니다.",
+                "No agent leaderboard available.",
+              ),
+            )}
+          />
+        ) : (
+          <div className="flex flex-col gap-3">
             {rows.map((row, index) => (
-              <div key={row.id}>
-                <div
-                  className="hidden grid-cols-[2.5rem_minmax(0,1.5fr)_1fr_0.8fr_0.9fr_0.9fr] items-center gap-3 rounded-xl border px-3 py-3 sm:grid"
-                  style={{
-                    borderColor: "var(--th-border-subtle)",
-                    background: "var(--th-bg-surface)",
-                  }}
-                >
-                  <span className="text-sm font-bold tabular-nums" style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}>
+              <div key={row.id} className="list-card">
+                <div className="flex items-center gap-3">
+                  <span
+                    className="inline-grid h-6 w-6 place-items-center rounded-full text-[10px] font-semibold"
+                    style={{
+                      background: "var(--th-overlay-light)",
+                      color: "var(--th-text-secondary)",
+                      ...NUMERIC_STYLE,
+                    }}
+                  >
                     {index + 1}
                   </span>
-                  <span className="truncate text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
-                    {row.label}
+                  <span
+                    className="inline-grid h-9 w-9 place-items-center rounded-full text-lg"
+                    style={{ background: "var(--th-overlay-subtle)" }}
+                  >
+                    {row.avatar}
                   </span>
-                  <span className="text-sm tabular-nums" style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}>
-                    {formatTokens(row.tokens)}
-                  </span>
-                  <span className="text-sm tabular-nums" style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}>
-                    {formatPercent(row.share)}
-                  </span>
-                  <span className="text-sm tabular-nums" style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}>
-                    {formatCurrency(row.cost)}
-                  </span>
-                  <span className="text-sm tabular-nums" style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}>
-                    {formatPercent(row.cacheHitRate)}
-                  </span>
-                </div>
-
-                <div
-                  className="rounded-xl border p-3 sm:hidden"
-                  style={{
-                    borderColor: "var(--th-border-subtle)",
-                    background: "var(--th-bg-surface)",
-                  }}
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <div className="text-xs font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--th-text-muted)" }}>
-                        #{index + 1}
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="min-w-0">
+                        <div
+                          className="truncate text-sm font-semibold"
+                          style={{ color: "var(--th-text-heading)" }}
+                        >
+                          {row.label}
+                        </div>
+                        <div
+                          className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[10.5px]"
+                          style={{
+                            color: "var(--th-text-muted)",
+                            ...NUMERIC_STYLE,
+                          }}
+                        >
+                          <span>{row.tasksDone} tasks</span>
+                          <span>{formatTokens(row.xp)} xp</span>
+                        </div>
                       </div>
-                      <div className="mt-1 truncate text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
-                        {row.label}
+                      <div
+                        className="shrink-0 text-right text-sm font-semibold"
+                        style={{
+                          color: "var(--th-text-heading)",
+                          ...NUMERIC_STYLE,
+                        }}
+                      >
+                        {formatTokens(row.tokens)}
                       </div>
                     </div>
-                    <span className={dashboardBadge.default} style={numericBadgeStyle}>
-                      {formatPercent(row.share)}
-                    </span>
-                  </div>
-                  <div className="mt-3 grid grid-cols-2 gap-3">
-                    <MiniMetric label={t({ ko: "토큰", en: "Tokens", ja: "トークン", zh: "Token" })} value={formatTokens(row.tokens)} />
-                    <MiniMetric label={t({ ko: "비용", en: "Cost", ja: "コスト", zh: "成本" })} value={formatCurrency(row.cost)} />
-                    <MiniMetric label={t({ ko: "캐시", en: "Cache Hit", ja: "キャッシュ", zh: "缓存" })} value={formatPercent(row.cacheHitRate)} />
-                    <MiniMetric label={t({ ko: "점유율", en: "Share", ja: "比率", zh: "占比" })} value={formatPercent(row.share)} />
+                    <div className="bar-track mt-3" style={{ height: 5 }}>
+                      <div
+                        className="bar-fill"
+                        style={{
+                          width: `${Math.max((row.tokens / maxTokens) * 100, row.tokens > 0 ? 4 : 0)}%`,
+                          background:
+                            "linear-gradient(90deg, var(--claude), color-mix(in oklch, var(--claude) 58%, white 42%))",
+                        }}
+                      />
+                    </div>
                   </div>
                 </div>
               </div>
             ))}
           </div>
-        </>
-      )}
+        )}
+      </div>
     </article>
-  );
-}
-
-function SectionHeader({
-  icon,
-  title,
-  description,
-  actions,
-}: {
-  icon: ReactNode;
-  title: string;
-  description: string;
-  actions?: ReactNode;
-}) {
-  return (
-    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-      <div className="min-w-0">
-        <div className="flex items-center gap-2">
-          <span
-            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border"
-            style={{
-              background: "var(--th-overlay-subtle)",
-              borderColor: "var(--th-border-subtle)",
-              color: "var(--accent)",
-            }}
-          >
-            {icon}
-          </span>
-          <div className="min-w-0">
-            <h2 className="text-lg font-bold" style={{ color: "var(--th-text-heading)" }}>
-              {title}
-            </h2>
-            <p className="mt-1 text-sm leading-6" style={{ color: "var(--th-text-muted)" }}>
-              {description}
-            </p>
-          </div>
-        </div>
-      </div>
-      {actions ? <div className="flex shrink-0 flex-wrap gap-2">{actions}</div> : null}
-    </div>
-  );
-}
-
-function MiniMetric({ label, value }: { label: string; value: string }) {
-  return (
-    <div
-      className="rounded-xl border px-3 py-2.5"
-      style={{
-        borderColor: "var(--th-border-subtle)",
-        background: "var(--th-overlay-subtle)",
-      }}
-    >
-      <div className={dashboardText.labelMuted} style={{ color: "var(--th-text-muted)" }}>
-        {label}
-      </div>
-      <div className="mt-2 text-sm font-bold tabular-nums" style={{ ...NUMERIC_STYLE, color: "var(--th-text-heading)" }}>
-        {value}
-      </div>
-    </div>
   );
 }
 
@@ -1647,4 +2443,12 @@ const numericBadgeStyle: CSSProperties = {
   background: "var(--th-overlay-light)",
   color: "var(--th-text-secondary)",
   borderColor: "var(--th-border-subtle)",
+};
+
+const positiveChipStyle: CSSProperties = {
+  ...NUMERIC_STYLE,
+  background: "color-mix(in oklch, var(--ok) 10%, transparent)",
+  color: "var(--ok)",
+  borderColor:
+    "color-mix(in oklch, var(--ok) 20%, var(--th-border-subtle) 80%)",
 };

--- a/dashboard/src/components/agent-manager/AgentsTab.tsx
+++ b/dashboard/src/components/agent-manager/AgentsTab.tsx
@@ -2,14 +2,16 @@ import { useEffect, useMemo, useState } from "react";
 import { getSkillRanking } from "../../api";
 import type { Agent, Department } from "../../types";
 import { localeName } from "../../i18n";
+import AgentAvatar from "../AgentAvatar";
+import { getProviderMeta } from "../../app/providerTheme";
 import {
+  SurfaceActionButton,
   SurfaceCard,
   SurfaceEmptyState,
-  SurfaceMetricPill,
   SurfaceSegmentButton,
 } from "../common/SurfacePrimitives";
 import AgentCard from "./AgentCard";
-import { StackedSpriteIcon } from "./EmojiPicker";
+import { getAgentLevel, getAgentTitle } from "./AgentInfoCard";
 import type { Translator } from "./types";
 
 interface AgentsTabProps {
@@ -33,12 +35,48 @@ interface AgentsTabProps {
   onEditDepartment: (department: Department) => void;
   onDeleteAgent: (agentId: string) => void;
   saving: boolean;
-  randomIconSprites: {
-    total: [number, number];
-  };
 }
 
 type AgentViewMode = "grid" | "list";
+
+function agentSecondaryLine(agent: Agent, locale: string) {
+  if (agent.alias?.trim()) return `aka ${agent.alias.trim()}`;
+  return locale === "en" ? agent.name_ko || agent.name : agent.name;
+}
+
+function currentTaskSummary(
+  agent: Agent,
+  tr: Translator,
+): { label: string; value: string } {
+  if (agent.current_task_id) {
+    return {
+      label: tr("현재 작업", "Current Task"),
+      value: agent.current_task_id,
+    };
+  }
+  if (agent.workflow_pack_key) {
+    return {
+      label: tr("워크플로우", "Workflow"),
+      value: agent.workflow_pack_key,
+    };
+  }
+  if (agent.session_info) {
+    return {
+      label: tr("세션", "Session"),
+      value: agent.session_info,
+    };
+  }
+  if (agent.personality) {
+    return {
+      label: tr("메모", "Notes"),
+      value: agent.personality,
+    };
+  }
+  return {
+    label: tr("상태", "Status"),
+    value: tr("대기 중", "Standing by"),
+  };
+}
 
 function buildTopSkillMap(rows: Awaited<ReturnType<typeof getSkillRanking>>["byAgent"]) {
   const byAgent = new Map<string, string[]>();
@@ -74,9 +112,9 @@ export default function AgentsTab({
   onEditDepartment,
   onDeleteAgent,
   saving,
-  randomIconSprites,
 }: AgentsTabProps) {
   const [viewMode, setViewMode] = useState<AgentViewMode>("grid");
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
   const [topSkillsByAgent, setTopSkillsByAgent] = useState<Map<string, string[]>>(
     () => new Map(),
   );
@@ -98,7 +136,6 @@ export default function AgentsTab({
     };
   }, []);
 
-  const workingCount = agents.filter((agent) => agent.status === "working").length;
   const deptCounts = new Map<string, { total: number; working: number }>();
   for (const agent of agents) {
     const key = agent.department_id || "__none";
@@ -108,62 +145,24 @@ export default function AgentsTab({
     deptCounts.set(key, count);
   }
 
-  const skillCoverage = useMemo(() => {
-    const uniqueAgents = new Set<string>();
-    for (const agent of agents) {
-      const roleKey = agent.role_id || agent.id;
-      if (topSkillsByAgent.has(roleKey)) uniqueAgents.add(agent.id);
+  useEffect(() => {
+    if (sortedAgents.length === 0) {
+      setSelectedAgentId(null);
+      return;
     }
-    return uniqueAgents.size;
-  }, [agents, topSkillsByAgent]);
+
+    if (selectedAgentId && !sortedAgents.some((agent) => agent.id === selectedAgentId)) {
+      setSelectedAgentId(null);
+    }
+  }, [selectedAgentId, sortedAgents]);
+
+  const selectedAgent = useMemo(
+    () => sortedAgents.find((agent) => agent.id === selectedAgentId) ?? null,
+    [selectedAgentId, sortedAgents],
+  );
 
   return (
     <div data-testid="agents-tab" className="space-y-4">
-      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-        {[
-          {
-            label: tr("전체 인원", "Total"),
-            value: agents.length,
-            tone: "accent" as const,
-            icon: <StackedSpriteIcon sprites={randomIconSprites.total} />,
-          },
-          {
-            label: tr("근무 중", "Working"),
-            value: workingCount,
-            tone: "success" as const,
-            icon: "💼",
-          },
-          {
-            label: tr("부서", "Departments"),
-            value: departments.length,
-            tone: "info" as const,
-            icon: "🏢",
-          },
-          {
-            label: tr("스킬 신호", "Skill Signals"),
-            value: skillCoverage,
-            tone: "warn" as const,
-            icon: "🧠",
-          },
-        ].map((summary) => (
-          <SurfaceMetricPill
-            key={summary.label}
-            label={`${typeof summary.icon === "string" ? summary.icon : "🧩"} ${summary.label}`}
-            value={
-              <span
-                className="text-2xl font-bold tabular-nums"
-                style={{ color: "var(--th-text-heading)" }}
-              >
-                {summary.value}
-              </span>
-            }
-            tone={summary.tone}
-            className="min-w-[132px]"
-            style={{ minHeight: 88 }}
-          />
-        ))}
-      </div>
-
       <SurfaceCard className="space-y-3 rounded-[28px] p-4 sm:p-5">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex flex-wrap gap-2">
@@ -223,11 +222,11 @@ export default function AgentsTab({
           </div>
         </div>
 
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
           <div className="text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
             {tr(
-              "카드를 누르면 상세 drawer가 열리고, 부서 chip 더블클릭으로 부서를 편집합니다.",
-              "Tap a card to open the detail drawer. Double-click a department chip to edit it.",
+              "기본 그리드는 시안 원형을 유지하고, 리스트는 운영용 확장 보기로 제공합니다.",
+              "Grid keeps the reference shell; list mode remains as the operational extension.",
             )}
           </div>
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
@@ -268,14 +267,281 @@ export default function AgentsTab({
           <div className="text-3xl">🔍</div>
           <div className="mt-2 text-sm">{tr("검색 결과 없음", "No agents found")}</div>
         </SurfaceEmptyState>
+      ) : viewMode === "grid" ? (
+        <div
+          data-testid="agents-view-grid"
+          className="grid gap-4 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.95fr)]"
+        >
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2 2xl:grid-cols-3">
+            {sortedAgents.map((agent) => {
+              const department = departments.find((candidate) => candidate.id === agent.department_id);
+              const providerMeta = getProviderMeta(agent.cli_provider);
+              const levelInfo = getAgentLevel(agent.stats_xp);
+              const isSelected = agent.id === selectedAgentId;
+
+              return (
+                <button
+                  key={agent.id}
+                  type="button"
+                  data-testid={`agents-grid-card-${agent.id}`}
+                  onClick={() => setSelectedAgentId(agent.id)}
+                  className="rounded-[28px] border p-4 text-left transition-transform hover:-translate-y-0.5"
+                  style={{
+                    background: isSelected
+                      ? "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 98%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 95%, transparent) 100%)"
+                      : "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 94%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 88%, transparent) 100%)",
+                    borderColor: isSelected
+                      ? "color-mix(in srgb, var(--th-accent) 56%, var(--th-border))"
+                      : "color-mix(in srgb, var(--th-border) 68%, transparent)",
+                    boxShadow: isSelected
+                      ? "0 0 0 1px color-mix(in srgb, var(--th-accent) 22%, transparent), 0 22px 50px rgba(15, 23, 42, 0.24)"
+                      : undefined,
+                  }}
+                >
+                  <div className="flex items-start gap-3">
+                    <div className="relative shrink-0">
+                      <AgentAvatar agent={agent} spriteMap={spriteMap} size={40} rounded="xl" />
+                      <span
+                        className={`absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 ${
+                          agent.status === "working"
+                            ? "bg-emerald-400"
+                            : agent.status === "break"
+                              ? "bg-amber-300"
+                              : agent.status === "offline"
+                                ? "bg-slate-500"
+                                : "bg-sky-400"
+                        }`}
+                        style={{ borderColor: "var(--th-card-bg)" }}
+                      />
+                    </div>
+
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                        {localeName(locale, agent)}
+                      </div>
+                      <div className="truncate text-xs" style={{ color: "var(--th-text-muted)" }}>
+                        {agentSecondaryLine(agent, locale)}
+                      </div>
+                    </div>
+
+                    <span
+                      className="rounded-full border px-2 py-0.5 text-[10px] font-medium"
+                      style={{
+                        borderColor: providerMeta.border,
+                        background: providerMeta.bg,
+                        color: providerMeta.color,
+                      }}
+                    >
+                      {providerMeta.label}
+                    </span>
+                  </div>
+
+                  <div className="mt-4 flex flex-wrap items-center gap-2">
+                    {department ? (
+                      <span
+                        className="rounded-full border px-2 py-1 text-[11px]"
+                        style={{
+                          color: department.color,
+                          borderColor: `color-mix(in srgb, ${department.color} 30%, var(--th-border))`,
+                          background: `color-mix(in srgb, ${department.color} 12%, transparent)`,
+                        }}
+                        onDoubleClick={(event) => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          onEditDepartment(department);
+                        }}
+                        title={tr("더블클릭: 부서 편집", "Double-click: edit dept")}
+                      >
+                        {department.icon} {localeName(locale, department)}
+                      </span>
+                    ) : null}
+                    <span
+                      className="rounded-full border px-2 py-1 text-[11px]"
+                      style={{
+                        borderColor: "color-mix(in srgb, var(--th-border) 70%, transparent)",
+                        color: "var(--th-text-secondary)",
+                      }}
+                    >
+                      lv.{levelInfo.level}
+                    </span>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+
+          {selectedAgent ? (
+            <SurfaceCard className="rounded-[30px] p-5 sm:p-6 xl:sticky xl:top-0">
+              {(() => {
+                const department = departments.find((candidate) => candidate.id === selectedAgent.department_id);
+                const providerMeta = getProviderMeta(selectedAgent.cli_provider);
+                const levelInfo = getAgentLevel(selectedAgent.stats_xp);
+                const levelTitle = getAgentTitle(selectedAgent.stats_xp, isKo);
+                const task = currentTaskSummary(selectedAgent, tr);
+                const roleKey = selectedAgent.role_id || selectedAgent.id;
+                const topSkills = topSkillsByAgent.get(roleKey) ?? [];
+
+                return (
+                  <div className="space-y-5">
+                    <div className="flex items-start gap-3">
+                      <AgentAvatar agent={selectedAgent} spriteMap={spriteMap} size={44} rounded="xl" />
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-base font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                          {localeName(locale, selectedAgent)}
+                        </div>
+                        <div className="truncate text-xs" style={{ color: "var(--th-text-muted)" }}>
+                          {agentSecondaryLine(selectedAgent, locale)} · {providerMeta.label}
+                        </div>
+                      </div>
+                      <SurfaceActionButton tone="neutral" compact onClick={() => onOpenAgent(selectedAgent)}>
+                        {tr("상세", "Open")}
+                      </SurfaceActionButton>
+                    </div>
+
+                    <div className="grid gap-2">
+                      {[
+                        {
+                          label: tr("상태", "Status"),
+                          value:
+                            selectedAgent.status === "working"
+                              ? tr("근무 중", "Working")
+                              : selectedAgent.status === "break"
+                                ? tr("휴식", "Break")
+                                : selectedAgent.status === "offline"
+                                  ? tr("오프라인", "Offline")
+                                  : tr("대기", "Idle"),
+                        },
+                        {
+                          label: tr("부서", "Department"),
+                          value: department ? `${department.icon} ${localeName(locale, department)}` : tr("미배정", "Unassigned"),
+                        },
+                        {
+                          label: tr("레벨", "Level"),
+                          value: `lv.${levelInfo.level} · ${levelTitle}`,
+                        },
+                        {
+                          label: tr("누적 XP", "Total XP"),
+                          value: selectedAgent.stats_xp.toLocaleString(),
+                        },
+                      ].map((item) => (
+                        <div
+                          key={item.label}
+                          className="flex items-center justify-between gap-3 rounded-2xl border px-3 py-2"
+                          style={{
+                            borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)",
+                            background: "color-mix(in srgb, var(--th-bg-surface) 82%, transparent)",
+                          }}
+                        >
+                          <span className="text-xs" style={{ color: "var(--th-text-muted)" }}>
+                            {item.label}
+                          </span>
+                          <span className="text-xs text-right" style={{ color: "var(--th-text-primary)" }}>
+                            {item.value}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+
+                    <div
+                      className="rounded-[24px] border px-4 py-4"
+                      style={{
+                        borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)",
+                        background: "color-mix(in srgb, var(--th-bg-surface) 84%, transparent)",
+                      }}
+                    >
+                      <div
+                        className="text-[11px] font-semibold uppercase tracking-[0.16em]"
+                        style={{ color: "var(--th-text-muted)" }}
+                      >
+                        {task.label}
+                      </div>
+                      <div className="mt-2 text-sm leading-6" style={{ color: "var(--th-text-primary)" }}>
+                        {task.value}
+                      </div>
+                    </div>
+
+                    <div className="space-y-2">
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "var(--th-text-muted)" }}>
+                        {tr("최근 스킬", "Recent Skills")}
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        {topSkills.length > 0 ? (
+                          topSkills.map((skill) => (
+                            <span
+                              key={`${selectedAgent.id}-${skill}`}
+                              className="rounded-full border px-2 py-1 text-[11px]"
+                              style={{
+                                borderColor: "color-mix(in srgb, var(--th-border) 70%, transparent)",
+                                background: "color-mix(in srgb, var(--th-card-bg) 92%, transparent)",
+                                color: "var(--th-text-secondary)",
+                              }}
+                            >
+                              {skill}
+                            </span>
+                          ))
+                        ) : (
+                          <span className="text-xs" style={{ color: "var(--th-text-muted)" }}>
+                            {tr("최근 스킬 데이터 없음", "No recent skill data")}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="flex flex-wrap gap-2">
+                      <SurfaceActionButton onClick={() => onEditAgent(selectedAgent)} tone="neutral">
+                        {tr("편집", "Edit")}
+                      </SurfaceActionButton>
+                      <SurfaceActionButton onClick={() => onOpenAgent(selectedAgent)}>
+                        {tr("상세 보기", "Open Detail")}
+                      </SurfaceActionButton>
+                      {confirmDeleteId === selectedAgent.id ? (
+                        <>
+                          <SurfaceActionButton
+                            onClick={() => onDeleteAgent(selectedAgent.id)}
+                            disabled={saving || selectedAgent.status === "working"}
+                            tone="danger"
+                          >
+                            {tr("해고", "Fire")}
+                          </SurfaceActionButton>
+                          <SurfaceActionButton
+                            onClick={() => setConfirmDeleteId(null)}
+                            tone="neutral"
+                          >
+                            {tr("취소", "Cancel")}
+                          </SurfaceActionButton>
+                        </>
+                      ) : (
+                        <SurfaceActionButton
+                          onClick={() => setConfirmDeleteId(selectedAgent.id)}
+                          tone="neutral"
+                        >
+                          {tr("삭제", "Delete")}
+                        </SurfaceActionButton>
+                      )}
+                    </div>
+                  </div>
+                );
+              })()}
+            </SurfaceCard>
+          ) : (
+            <SurfaceCard className="rounded-[30px] p-8 text-center">
+              <div className="text-3xl">🧑‍💻</div>
+              <div className="mt-3 text-sm font-medium" style={{ color: "var(--th-text-secondary)" }}>
+                {tr("에이전트를 선택하세요", "Select an agent")}
+              </div>
+              <div className="mt-2 text-xs leading-6" style={{ color: "var(--th-text-muted)" }}>
+                {tr(
+                  "상세 정보와 운영 액션이 오른쪽 패널에 열립니다.",
+                  "Details and operational actions appear in the side panel.",
+                )}
+              </div>
+            </SurfaceCard>
+          )}
+        </div>
       ) : (
         <div
           data-testid={`agents-view-${viewMode}`}
-          className={
-            viewMode === "grid"
-              ? "grid grid-cols-1 gap-3 lg:grid-cols-2"
-              : "space-y-3"
-          }
+          className="space-y-3"
         >
           {sortedAgents.map((agent) => {
             const roleKey = agent.role_id || agent.id;

--- a/dashboard/src/components/agent-manager/BacklogTab.tsx
+++ b/dashboard/src/components/agent-manager/BacklogTab.tsx
@@ -7,7 +7,6 @@ import {
   SurfaceActionButton,
   SurfaceCard,
   SurfaceEmptyState,
-  SurfaceMetricPill,
 } from "../common/SurfacePrimitives";
 import AgentAvatar from "../AgentAvatar";
 import {
@@ -481,7 +480,6 @@ export default function BacklogTab({
     ["requested", "in_progress", "review", "qa_pending", "qa_in_progress", "qa_failed"].includes(card.status),
   ).length;
   const urgentCount = filteredCards.filter((card) => card.priority === "urgent").length;
-  const assignedCount = filteredCards.filter((card) => Boolean(card.assignee_agent_id)).length;
 
   const toggleSort = (nextKey: BacklogSortKey) => {
     if (sortKey === nextKey) {
@@ -494,41 +492,55 @@ export default function BacklogTab({
 
   return (
     <div data-testid="agents-backlog-tab" className="space-y-4">
-      <div className="grid gap-3 md:grid-cols-3">
-        <SurfaceMetricPill
-          label={tr("백로그 총량", "Backlog Total")}
-          value={<span className="text-2xl font-bold tabular-nums">{filteredCards.length}</span>}
-          tone="info"
-          className="min-w-[132px]"
-        />
-        <SurfaceMetricPill
-          label={tr("활성 카드", "Active Cards")}
-          value={<span className="text-2xl font-bold tabular-nums">{activeCount}</span>}
-          tone={activeCount > 0 ? "accent" : "neutral"}
-          className="min-w-[132px]"
-        />
-        <SurfaceMetricPill
-          label={tr("긴급 / 담당 지정", "Urgent / Assigned")}
-          value={
-            <span className="text-lg font-bold tabular-nums">
-              {urgentCount} / {assignedCount}
-            </span>
-          }
-          tone="warn"
-          className="min-w-[132px]"
-        />
-      </div>
-
-      <SurfaceCard className="space-y-3 rounded-[28px] p-4 sm:p-5">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-          <div className="text-sm leading-6" style={{ color: "var(--th-text-muted)" }}>
-            {tr(
-              "백로그는 데스크톱에서 테이블, 모바일에서 카드 스택으로 전환됩니다. 행을 누르면 상세 drawer가 열립니다.",
-              "Backlog switches from a desktop table to a mobile card stack. Tap a row to open the detail drawer.",
-            )}
+      <SurfaceCard className="space-y-4 rounded-[28px] p-4 sm:p-5">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0">
+            <div className="text-lg font-semibold tracking-tight" style={{ color: "var(--th-text-heading)" }}>
+              {tr("백로그 이슈", "Backlog Issues")}
+            </div>
+            <div className="mt-1 text-sm leading-6" style={{ color: "var(--th-text-muted)" }}>
+              {tr(
+                "GitHub 미동기화 이슈와 백로그 카드를 한 표면에서 조회합니다. 행이나 카드를 누르면 상세 drawer가 열립니다.",
+                "Browse GitHub backlog issues and backlog cards from one surface. Tap a row or card to open the detail drawer.",
+              )}
+            </div>
           </div>
 
-          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className="rounded-full border px-3 py-1 text-[11px] font-medium"
+              style={{
+                borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)",
+                background: "color-mix(in srgb, var(--th-card-bg) 90%, transparent)",
+                color: "var(--th-text-secondary)",
+              }}
+            >
+              {tr("총", "Total")} {filteredCards.length}
+            </span>
+            <span
+              className="rounded-full border px-3 py-1 text-[11px] font-medium"
+              style={{
+                borderColor: "color-mix(in srgb, var(--th-accent-info) 26%, var(--th-border) 74%)",
+                background: "color-mix(in srgb, var(--th-badge-sky-bg) 82%, var(--th-card-bg) 18%)",
+                color: "var(--th-text-secondary)",
+              }}
+            >
+              {tr("활성", "Active")} {activeCount}
+            </span>
+            <span
+              className="rounded-full border px-3 py-1 text-[11px] font-medium"
+              style={{
+                borderColor: "rgba(244,114,182,0.22)",
+                background: "rgba(244,114,182,0.12)",
+                color: "#f9a8d4",
+              }}
+            >
+              {tr("긴급", "Urgent")} {urgentCount}
+            </span>
+          </div>
+        </div>
+
+        <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
             <select
               data-testid="agents-backlog-filter-provider"
               value={providerFilter}
@@ -608,26 +620,24 @@ export default function BacklogTab({
               <option value="title:asc">{tr("정렬: 제목 A-Z", "Sort: Title A-Z")}</option>
               <option value="status:asc">{tr("정렬: 상태", "Sort: Status")}</option>
             </select>
-          </div>
         </div>
-      </SurfaceCard>
 
-      {filteredCards.length === 0 ? (
-        <SurfaceEmptyState className="py-14 text-center">
-          <div className="text-3xl">🗂️</div>
-          <div className="mt-2 text-sm">{tr("조건에 맞는 백로그 카드가 없습니다.", "No backlog cards match these filters.")}</div>
-        </SurfaceEmptyState>
-      ) : (
-        <>
+        {filteredCards.length === 0 ? (
+          <SurfaceEmptyState className="py-14 text-center">
+            <div className="text-3xl">🗂️</div>
+            <div className="mt-2 text-sm">{tr("조건에 맞는 백로그 카드가 없습니다.", "No backlog cards match these filters.")}</div>
+          </SurfaceEmptyState>
+        ) : (
+          <>
           <div
             data-testid="agents-backlog-table"
-            className="hidden overflow-hidden rounded-[28px] border lg:block"
+            className="hidden overflow-hidden rounded-[24px] border lg:block"
             style={{ borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)" }}
           >
             <div
               className="grid items-center gap-3 border-b px-4 py-3"
               style={{
-                gridTemplateColumns: "88px minmax(280px,1.8fr) minmax(180px,1fr) 140px 120px 110px 90px",
+                gridTemplateColumns: "88px minmax(260px,1.8fr) minmax(120px,0.9fr) 150px 110px 92px 96px",
                 borderColor: "color-mix(in srgb, var(--th-border) 72%, transparent)",
                 background:
                   "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 94%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
@@ -635,11 +645,15 @@ export default function BacklogTab({
             >
               <SortHeader label="ID" sortKey="id" activeKey={sortKey} direction={sortDirection} onToggle={toggleSort} />
               <SortHeader label={tr("제목", "Title")} sortKey="title" activeKey={sortKey} direction={sortDirection} onToggle={toggleSort} />
-              <SortHeader label={tr("담당", "Assignee")} sortKey="assignee" activeKey={sortKey} direction={sortDirection} onToggle={toggleSort} />
-              <SortHeader label={tr("상태", "Status")} sortKey="status" activeKey={sortKey} direction={sortDirection} onToggle={toggleSort} />
+              <div className="text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "var(--th-text-muted)" }}>
+                {tr("레포", "Repo")}
+              </div>
+              <SortHeader label={tr("담당 / 상태", "Assignee / Status")} sortKey="assignee" activeKey={sortKey} direction={sortDirection} onToggle={toggleSort} />
               <SortHeader label="Provider" sortKey="provider" activeKey={sortKey} direction={sortDirection} onToggle={toggleSort} />
-              <SortHeader label={tr("심각도", "Severity")} sortKey="severity" activeKey={sortKey} direction={sortDirection} onToggle={toggleSort} />
-              <SortHeader label={tr("Age", "Age")} sortKey="age" activeKey={sortKey} direction={sortDirection} onToggle={toggleSort} />
+              <SortHeader label={tr("경과", "Age")} sortKey="age" activeKey={sortKey} direction={sortDirection} onToggle={toggleSort} />
+              <div className="text-right text-[11px] font-semibold uppercase tracking-[0.16em]" style={{ color: "var(--th-text-muted)" }}>
+                {tr("상세", "Open")}
+              </div>
             </div>
 
             <div className="divide-y" style={{ borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)" }}>
@@ -654,7 +668,7 @@ export default function BacklogTab({
                     onClick={() => setSelectedCard(card)}
                     className="grid w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-white/5"
                     style={{
-                      gridTemplateColumns: "88px minmax(280px,1.8fr) minmax(180px,1fr) 140px 120px 110px 90px",
+                      gridTemplateColumns: "88px minmax(260px,1.8fr) minmax(120px,0.9fr) 150px 110px 92px 96px",
                     }}
                   >
                     <div className="truncate text-sm font-medium tabular-nums" style={{ color: "var(--th-text-secondary)" }}>
@@ -664,9 +678,9 @@ export default function BacklogTab({
                       <div className="truncate text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
                         {card.title}
                       </div>
-                      <div className="truncate text-xs" style={{ color: "var(--th-text-muted)" }}>
-                        {card.github_repo ?? tr("레포 없음", "No repo")}
-                      </div>
+                    </div>
+                    <div className="truncate text-xs font-mono" style={{ color: "var(--th-text-muted)" }}>
+                      {card.github_repo ?? tr("레포 없음", "No repo")}
                     </div>
                     <div className="flex min-w-0 items-center gap-2">
                       <AgentAvatar agent={assignee ?? undefined} size={28} rounded="xl" />
@@ -674,22 +688,17 @@ export default function BacklogTab({
                         <div className="truncate text-sm" style={{ color: "var(--th-text-primary)" }}>
                           {assignee ? localeName(locale, assignee) : tr("미할당", "Unassigned")}
                         </div>
-                        <div className="truncate text-[11px]" style={{ color: "var(--th-text-muted)" }}>
-                          {card.latest_dispatch_title ?? tr("최근 디스패치 없음", "No recent dispatch")}
-                        </div>
+                        <span
+                          className="mt-1 inline-flex rounded-full border px-2 py-1 text-[11px] font-medium"
+                          style={{
+                            borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)",
+                            background: "color-mix(in srgb, var(--th-card-bg) 90%, transparent)",
+                            color: "var(--th-text-secondary)",
+                          }}
+                        >
+                          {labelForStatus(card.status, tr)}
+                        </span>
                       </div>
-                    </div>
-                    <div>
-                      <span
-                        className="inline-flex rounded-full border px-2 py-1 text-[11px] font-medium"
-                        style={{
-                          borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)",
-                          background: "color-mix(in srgb, var(--th-card-bg) 90%, transparent)",
-                          color: "var(--th-text-secondary)",
-                        }}
-                      >
-                        {labelForStatus(card.status, tr)}
-                      </span>
                     </div>
                     <div>
                       <span
@@ -703,11 +712,11 @@ export default function BacklogTab({
                         {providerMeta.label}
                       </span>
                     </div>
-                    <div className="text-sm" style={{ color: "var(--th-text-primary)" }}>
-                      {priorityLabel(card.priority, tr)}
-                    </div>
                     <div className="text-sm tabular-nums" style={{ color: "var(--th-text-secondary)" }}>
                       {formatAgeLabel(cardAgeMs(card), tr)}
+                    </div>
+                    <div className="text-right text-xs font-medium" style={{ color: "var(--th-text-muted)" }}>
+                      {tr("상세", "Open")}
                     </div>
                   </button>
                 );
@@ -767,7 +776,7 @@ export default function BacklogTab({
                         background: "color-mix(in srgb, var(--th-card-bg) 90%, transparent)",
                         color: "var(--th-text-secondary)",
                       }}
-                    >
+                      >
                       {labelForStatus(card.status, tr)}
                     </span>
                     <span
@@ -791,12 +800,20 @@ export default function BacklogTab({
                       {tr("Age", "Age")} {formatAgeLabel(cardAgeMs(card), tr)}
                     </span>
                   </div>
+
+                  <div
+                    className="border-t pt-3 text-right text-xs font-medium"
+                    style={{ borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)", color: "var(--th-text-muted)" }}
+                  >
+                    {tr("상세 보기", "Open Details")}
+                  </div>
                 </SurfaceCard>
               );
             })}
           </div>
-        </>
-      )}
+          </>
+        )}
+      </SurfaceCard>
 
       {selectedCard ? (
         <BacklogCardDrawer

--- a/dashboard/src/components/agent-manager/DepartmentsTab.tsx
+++ b/dashboard/src/components/agent-manager/DepartmentsTab.tsx
@@ -30,7 +30,6 @@ export default function DepartmentsTab({
   tr,
   locale,
   agents,
-  departments,
   deptOrder,
   deptOrderDirty,
   reorderSaving,
@@ -69,7 +68,7 @@ export default function DepartmentsTab({
         </SurfaceNotice>
       )}
 
-      <div className="space-y-2">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
         {deptOrder.map((dept, index) => {
           const members = agents
             .filter((agent) => agent.department_id === dept.id)
@@ -88,12 +87,17 @@ export default function DepartmentsTab({
             <SurfaceCard
               data-testid={`agents-department-card-${dept.id}`}
               key={dept.id}
-              className={`group relative px-4 py-4 transition-all hover:shadow-md ${isDragging ? "opacity-60" : ""}`}
-              style={{ cursor: "grab" }}
+              className={`group relative flex h-full flex-col px-4 py-4 transition-all hover:shadow-md ${isDragging ? "opacity-60" : ""}`}
               onDragStart={(e) => onDragStart(dept.id, e)}
               onDragOver={(e) => onDragOver(dept.id, e)}
               onDrop={(e) => onDrop(dept.id, e)}
               onDragEnd={onDragEnd}
+              style={{
+                cursor: "grab",
+                borderColor: `color-mix(in srgb, ${dept.color} 22%, var(--th-border) 78%)`,
+                background:
+                  "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 94%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
+              }}
               // SurfaceCard renders a div, so drag attributes stay here.
               // eslint-disable-next-line react/no-unknown-property
               draggable
@@ -105,15 +109,102 @@ export default function DepartmentsTab({
                 <div className="pointer-events-none absolute left-2 right-2 bottom-0 h-0.5 rounded bg-blue-400" />
               )}
 
-              <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+              <div className="flex h-full flex-col">
                 <div className="flex items-start gap-3">
-                  <div className="flex flex-col gap-0.5">
+                  <div
+                    className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl text-xl"
+                    style={{ background: `${dept.color}1f`, color: dept.color }}
+                  >
+                    {dept.icon}
+                  </div>
+
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                        {localeName(locale, dept)}
+                      </span>
+                      <span
+                        className="rounded-full px-2 py-0.5 text-[11px] font-medium"
+                        style={{ background: `${dept.color}22`, color: dept.color }}
+                      >
+                        {agentCountForDept} {tr("명", "agents")}
+                      </span>
+                    </div>
+                    <div
+                      className="mt-1 text-[11px]"
+                      style={{ color: "var(--th-text-muted)", fontFamily: "var(--font-mono)" }}
+                    >
+                      id: {dept.id} · {tr("순서", "Order")} {index + 1}
+                    </div>
+                    {dept.description && (
+                      <div className="mt-2 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
+                        {dept.description}
+                      </div>
+                    )}
+                  </div>
+
+                  <SurfaceActionButton onClick={() => onEditDept(dept)} tone="neutral" compact>
+                    {tr("편집", "Edit")}
+                  </SurfaceActionButton>
+                </div>
+
+                <div className="mt-4 flex-1 space-y-2">
+                  {members.length > 0 ? (
+                    members.slice(0, 4).map((member) => (
+                      <div
+                        key={member.id}
+                        className="flex items-center gap-2 rounded-2xl border px-3 py-2"
+                        style={{
+                          borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)",
+                          background:
+                            "color-mix(in srgb, var(--th-bg-surface) 82%, var(--th-card-bg) 18%)",
+                        }}
+                      >
+                        <AgentAvatar agent={member} size={24} rounded="xl" />
+                        <span className="min-w-0 flex-1 truncate text-xs" style={{ color: "var(--th-text-primary)" }}>
+                          {localeName(locale, member)}
+                        </span>
+                        <span
+                          className="rounded-full px-2 py-0.5 text-[10px]"
+                          style={{
+                            background: "color-mix(in srgb, var(--th-bg-surface) 70%, transparent)",
+                            color: "var(--th-text-muted)",
+                          }}
+                        >
+                          {member.status === "working" ? tr("작업중", "Working") : tr("대기", "Idle")}
+                        </span>
+                      </div>
+                    ))
+                  ) : (
+                    <div
+                      className="rounded-2xl border border-dashed px-3 py-4 text-center text-xs"
+                      style={{
+                        borderColor: "color-mix(in srgb, var(--th-border) 60%, transparent)",
+                        color: "var(--th-text-muted)",
+                      }}
+                    >
+                      {tr("소속 에이전트 없음", "No agents assigned")}
+                    </div>
+                  )}
+
+                  {members.length > 4 ? (
+                    <div className="text-xs" style={{ color: "var(--th-text-muted)" }}>
+                      +{members.length - 4} {tr("명 더 있음", "more members")}
+                    </div>
+                  ) : null}
+                </div>
+
+                <div
+                  className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t pt-3"
+                  style={{ borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)" }}
+                >
+                  <div className="flex items-center gap-1.5">
                     <SurfaceActionButton
                       onClick={() => onMoveDept(index, -1)}
                       disabled={index === 0}
                       tone="neutral"
                       compact
-                      className="h-5 w-6 px-0 py-0"
+                      className="h-7 min-w-7 px-0 py-0"
                     >
                       ▲
                     </SurfaceActionButton>
@@ -122,93 +213,15 @@ export default function DepartmentsTab({
                       disabled={index === deptOrder.length - 1}
                       tone="neutral"
                       compact
-                      className="h-5 w-6 px-0 py-0"
+                      className="h-7 min-w-7 px-0 py-0"
                     >
                       ▼
                     </SurfaceActionButton>
                   </div>
 
-                  <div
-                    className="flex h-9 w-9 items-center justify-center rounded-xl text-sm font-bold"
-                    style={{ background: `${dept.color}22`, color: dept.color }}
-                  >
-                    {index + 1}
-                  </div>
-
-                  <span className="pt-1 text-2xl">{dept.icon}</span>
-
-                  <div className="min-w-0 flex-1">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
-                        {localeName(locale, dept)}
-                      </span>
-                      <span className="inline-block h-3 w-3 rounded-full" style={{ background: dept.color }}></span>
-                      <span
-                        className="rounded-full px-2 py-0.5 text-xs"
-                        style={{ background: `${dept.color}22`, color: dept.color }}
-                      >
-                        {agentCountForDept} {tr("명", "agents")}
-                      </span>
-                    </div>
-                    {dept.description && (
-                      <div className="mt-1 text-xs leading-5" style={{ color: "var(--th-text-muted)" }}>
-                        {dept.description}
-                      </div>
-                    )}
-                  </div>
-                </div>
-
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    {members.slice(0, 4).map((member) => (
-                      <div
-                        key={member.id}
-                        className="inline-flex min-w-0 items-center gap-2 rounded-full border px-2 py-1"
-                        style={{
-                          borderColor:
-                            "color-mix(in srgb, var(--th-border) 68%, transparent)",
-                          background:
-                            "color-mix(in srgb, var(--th-bg-surface) 82%, var(--th-card-bg) 18%)",
-                        }}
-                      >
-                        <AgentAvatar agent={member} size={24} rounded="xl" />
-                        <span className="max-w-[7rem] truncate text-xs" style={{ color: "var(--th-text-primary)" }}>
-                          {localeName(locale, member)}
-                        </span>
-                      </div>
-                    ))}
-                    {members.length > 4 ? (
-                      <span
-                        className="rounded-full border px-2 py-1 text-xs"
-                        style={{
-                          borderColor:
-                            "color-mix(in srgb, var(--th-border) 68%, transparent)",
-                          color: "var(--th-text-muted)",
-                        }}
-                      >
-                        +{members.length - 4}
-                      </span>
-                    ) : null}
-                    {members.length === 0 ? (
-                      <span className="text-xs" style={{ color: "var(--th-text-muted)" }}>
-                        {tr("소속 에이전트 없음", "No agents assigned")}
-                      </span>
-                    ) : null}
-                  </div>
-                </div>
-
-                <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-3" style={{ borderColor: "color-mix(in srgb, var(--th-border) 68%, transparent)" }}>
-                  <code className="rounded px-2 py-0.5 text-xs opacity-60" style={{ background: "var(--th-input-bg)" }}>
-                    {dept.id}
-                  </code>
-
-                  <SurfaceActionButton
-                    onClick={() => onEditDept(dept)}
-                    tone="neutral"
-                    className="opacity-100 lg:opacity-0 lg:group-hover:opacity-100"
-                  >
-                    {tr("편집", "Edit")}
-                  </SurfaceActionButton>
+                  <span className="text-[11px]" style={{ color: "var(--th-text-muted)" }}>
+                    {tr("드래그로 순서 변경", "Drag to reorder")}
+                  </span>
                 </div>
               </div>
             </SurfaceCard>

--- a/dashboard/src/components/agent-manager/KanbanTab.tsx
+++ b/dashboard/src/components/agent-manager/KanbanTab.tsx
@@ -17,6 +17,7 @@ import {
   SurfaceNotice,
   SurfaceSection,
   SurfaceSegmentButton,
+  SurfaceSubsection,
 } from "../common/SurfacePrimitives";
 import type {
   Agent,
@@ -683,6 +684,31 @@ export default function KanbanTab({
     }
     return counts;
   }, [repoCards]);
+  const repoAgentEntries = useMemo(
+    () => Array.from(repoAgentCounts.entries()).sort((a, b) => b[1] - a[1]),
+    [repoAgentCounts],
+  );
+  const activeFilterCount = [
+    search.trim().length > 0,
+    agentFilter !== "all",
+    deptFilter !== "all",
+    cardTypeFilter !== "all",
+    signalStatusFilter !== "all",
+    showClosed,
+  ].filter(Boolean).length;
+  const selectedCardAssigneeLabel = selectedCard?.assignee_agent_id
+    ? getAgentLabel(selectedCard.assignee_agent_id)
+    : tr("미할당", "Unassigned");
+  const selectedCardTransitionTargets = selectedCard
+    ? STATUS_TRANSITIONS[selectedCard.status] ?? []
+    : [];
+  const selectedCardHeroDescription = selectedCard
+    ? [
+        selectedCard.github_repo,
+        selectedCard.github_issue_number ? `#${selectedCard.github_issue_number}` : null,
+        selectedParentCard ? tr(`상위 ${selectedParentCard.title}`, `Parent ${selectedParentCard.title}`) : null,
+      ].filter(Boolean).join(" · ")
+    : "";
 
   // Fetch per-agent pipeline stages when agent is selected
   useEffect(() => {
@@ -854,6 +880,10 @@ export default function KanbanTab({
     : tr("전체", "All");
   const deferredDodCount = filteredCards.filter((c) => (c as any).dod_status === "deferred").length;
   const openCount = filteredCards.filter((card) => !TERMINAL_STATUSES.has(card.status)).length + backlogIssues.length;
+  const reviewQueueCount = filteredCards.filter((card) => card.status === "review").length;
+  const inProgressCount = filteredCards.filter((card) => card.status === "in_progress").length;
+  const requestedCount = filteredCards.filter((card) => card.status === "requested").length;
+  const manualInterventionCount = filteredCards.filter((card) => isManualInterventionCard(card)).length;
   const hasQaCards = filteredCards.some((c) => QA_STATUSES.has(c.status));
   const boardColumns = useMemo(() => effectiveColumnDefs.filter((column) =>
     (showClosed || !TERMINAL_STATUSES.has(column.status))
@@ -1134,7 +1164,10 @@ export default function KanbanTab({
             : null;
 
   return (
-    <div className="space-y-4 pb-24 md:pb-0 min-w-0 overflow-x-hidden" style={{ paddingBottom: "max(6rem, calc(6rem + env(safe-area-inset-bottom)))" }}>
+    <div
+      className="mx-auto w-full max-w-6xl min-w-0 space-y-4 overflow-x-hidden pb-24 md:pb-0"
+      style={{ paddingBottom: "max(6rem, calc(6rem + env(safe-area-inset-bottom)))" }}
+    >
       <SurfaceSection
         eyebrow={tr("워크 오케스트레이션", "Work orchestration")}
         title={tr("칸반", "Kanban")}
@@ -1171,296 +1204,153 @@ export default function KanbanTab({
           />
         </div>
 
-        <div className="mt-4 flex flex-wrap items-center gap-2">
-          {stalledCards.length > 0 && (
-            <SurfaceActionButton
-              tone="danger"
-              onClick={() => { setStalledPopup(true); setStalledSelected(new Set()); }}
-              className="animate-pulse"
-            >
-              {tr(`정체 ${stalledCards.length}건`, `${stalledCards.length} stalled`)}
-            </SurfaceActionButton>
-          )}
-          {deferredDodCount > 0 && (
-            <SurfaceActionButton tone="warn" onClick={() => setDeferredDodPopup(true)}>
-              {tr(`미검증 DoD ${deferredDodCount}건`, `${deferredDodCount} deferred DoD`)}
-            </SurfaceActionButton>
-          )}
-          <SurfaceActionButton
-            tone={settingsOpen ? "info" : "neutral"}
-            onClick={() => setSettingsOpen((prev) => !prev)}
+        <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
+          <SurfaceSubsection
+            title={tr("Scope", "Scope")}
+            description={tr(
+              "Repo 초점과 담당 범위를 한 화면에서 빠르게 전환합니다.",
+              "Switch repo focus and assignee scope from one place.",
+            )}
           >
-            {settingsOpen ? tr("설정 접기", "Close settings") : tr("설정 열기", "Open settings")}
-          </SurfaceActionButton>
-        </div>
-
-        <div className="mt-4 flex flex-col gap-3 min-w-0">
-          <div className="hidden min-w-0 flex-wrap items-center gap-1.5 sm:flex">
-            {repoSources.length >= 1 && repoSources.map((source) => (
-              <SurfaceSegmentButton
-                key={source.id}
-                onClick={() => setSelectedRepo(source.repo)}
-                active={selectedRepo === source.repo}
-                tone="info"
-                className="max-w-[180px] truncate"
-              >
-                {source.repo.split("/")[1] ?? source.repo}
-              </SurfaceSegmentButton>
-            ))}
-            {selectedRepo && (() => {
-              const agentEntries = Array.from(repoAgentCounts.entries()).sort((a, b) => b[1] - a[1]);
-              if (agentEntries.length <= 1) return null;
-              if (agentEntries.length <= 4) {
-                return (<>
-                  {repoSources.length > 1 && (
-                    <span className="px-1 text-xs" style={{ color: "var(--th-text-subtle)" }}>
-                      /
-                    </span>
-                  )}
-                  <SurfaceSegmentButton
-                    onClick={() => setSelectedAgentId(null)}
-                    active={!selectedAgentId}
-                    tone="accent"
+            <div className="-mx-1 overflow-x-auto px-1 pb-1">
+              <div className="flex min-w-max gap-2 sm:min-w-0 sm:flex-wrap">
+                {repoSources.length === 0 ? (
+                  <span
+                    className="rounded-full border border-dashed px-3 py-1.5 text-xs"
+                    style={{ color: "var(--th-text-muted)", borderColor: "color-mix(in srgb, var(--th-border) 72%, transparent)" }}
                   >
-                    {tr(`전체`, `All`)}
-                  </SurfaceSegmentButton>
-                  {agentEntries.map(([aid, count]) => (
+                    {tr("선택된 backlog repo 없음", "No backlog repo selected")}
+                  </span>
+                ) : (
+                  repoSources.map((source) => (
                     <SurfaceSegmentButton
-                      key={aid}
-                      onClick={() => setSelectedAgentId(aid)}
-                      active={selectedAgentId === aid}
-                      tone="accent"
-                      className="max-w-[160px] truncate"
+                      key={source.id}
+                      onClick={() => setSelectedRepo(source.repo)}
+                      active={selectedRepo === source.repo}
+                      tone="info"
+                      className="max-w-[180px] truncate"
                     >
-                      {getAgentLabel(aid)} ({count})
+                      {source.repo.split("/")[1] ?? source.repo}
                     </SurfaceSegmentButton>
-                  ))}
-                </>);
-              }
-              return (
-                <select
-                  value={selectedAgentId ?? ""}
-                  onChange={(e) => setSelectedAgentId(e.target.value || null)}
-                  className="text-xs px-2.5 py-1.5 rounded-lg border bg-transparent min-w-0 max-w-[180px]"
-                  style={{
-                    borderColor: selectedAgentId
-                      ? "color-mix(in srgb, var(--th-accent-primary) 40%, transparent)"
-                      : "rgba(148,163,184,0.22)",
-                    color: selectedAgentId ? "var(--th-accent-primary)" : "var(--th-text-muted)",
-                  }}
-                >
-                  <option value="">{tr(`전체`, `All`)}</option>
-                  {agentEntries.map(([aid, count]) => (
-                    <option key={aid} value={aid}>{getAgentLabel(aid)} ({count})</option>
-                  ))}
-                </select>
-              );
-            })()}
-          </div>
-        </div>
+                  ))
+                )}
+              </div>
+            </div>
 
-        {signalFilterLabel && (
-          <SurfaceNotice
-            tone="warn"
-            className="mt-1"
-            compact
-            action={(
+            {selectedRepo && repoAgentEntries.length > 1 && (
+              <div className="mt-4">
+                <div className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--th-text-muted)" }}>
+                  {tr("Agent scope", "Agent scope")}
+                </div>
+                {repoAgentEntries.length <= 4 ? (
+                  <div className="flex flex-wrap gap-2">
+                    <SurfaceSegmentButton
+                      onClick={() => setSelectedAgentId(null)}
+                      active={!selectedAgentId}
+                      tone="accent"
+                    >
+                      {tr(`전체 (${repoCards.length})`, `All (${repoCards.length})`)}
+                    </SurfaceSegmentButton>
+                    {repoAgentEntries.map(([aid, count]) => (
+                      <SurfaceSegmentButton
+                        key={aid}
+                        onClick={() => setSelectedAgentId(aid)}
+                        active={selectedAgentId === aid}
+                        tone="accent"
+                        className="max-w-[180px] truncate"
+                      >
+                        {getAgentLabel(aid)} ({count})
+                      </SurfaceSegmentButton>
+                    ))}
+                  </div>
+                ) : (
+                  <select
+                    value={selectedAgentId ?? ""}
+                    onChange={(event) => setSelectedAgentId(event.target.value || null)}
+                    className="w-full rounded-xl border px-3 py-2 text-sm sm:max-w-[260px]"
+                    style={{ ...SURFACE_FIELD_STYLE, color: "var(--th-text-primary)" }}
+                  >
+                    <option value="">{tr(`전체 (${repoCards.length})`, `All (${repoCards.length})`)}</option>
+                    {repoAgentEntries.map(([aid, count]) => (
+                      <option key={aid} value={aid}>
+                        {getAgentLabel(aid)} ({count})
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </div>
+            )}
+
+            {selectedAgentId && agentPipelineStages.length > 0 && (
+              <SurfaceNotice tone="info" className="mt-4" compact>
+                <div className="text-xs leading-5">
+                  {tr("선택 에이전트 pipeline", "Selected agent pipeline")}: {agentPipelineStages.map((stage) => stage.stage_name).join(" / ")}
+                </div>
+              </SurfaceNotice>
+            )}
+          </SurfaceSubsection>
+
+          <SurfaceSubsection
+            title={tr("Controls", "Controls")}
+            description={tr(
+              "검색, 필터, 운영 신호를 이 패널에서 바로 조정합니다.",
+              "Adjust search, filters, and operational signals from this panel.",
+            )}
+            actions={(
               <SurfaceActionButton
-                type="button"
-                tone="warn"
-                compact
-                onClick={() => setSignalStatusFilter("all")}
+                tone={settingsOpen ? "info" : "neutral"}
+                onClick={() => setSettingsOpen((prev) => !prev)}
               >
-                {tr("해제", "Clear")}
+                {settingsOpen ? tr("설정 접기", "Close settings") : tr("설정 열기", "Open settings")}
               </SurfaceActionButton>
             )}
           >
-            <div className="text-xs leading-5">
-              {tr("대시보드 포커스", "Dashboard focus")}: {signalFilterLabel}
-            </div>
-          </SurfaceNotice>
-        )}
-
-        {/* Row 2 (mobile only): Repo tabs + Agent selector — on desktop these are in Row 1 */}
-        <div className="mt-1 flex gap-1.5 overflow-x-auto min-w-0 sm:hidden">
-          {repoSources.length >= 1 && repoSources.map((source) => (
-            <SurfaceSegmentButton
-              key={source.id}
-              onClick={() => setSelectedRepo(source.repo)}
-              active={selectedRepo === source.repo}
-              tone="info"
-              className="max-w-[180px] truncate"
-            >
-              {source.repo.split("/")[1] ?? source.repo}
-            </SurfaceSegmentButton>
-          ))}
-        </div>
-
-        {/* Mobile-only agent selector row */}
-        <div className="sm:hidden">
-        {selectedRepo && (() => {
-          const agentEntries = Array.from(repoAgentCounts.entries()).sort((a, b) => b[1] - a[1]);
-          const agentCount = agentEntries.length;
-          if (agentCount <= 1) return null; // 1 agent or less: hide
-          if (agentCount <= 4) {
-            // Tab buttons
-            return (
-              <div className="mt-1 flex gap-1.5 overflow-x-auto min-w-0">
-                <SurfaceSegmentButton
-                  onClick={() => setSelectedAgentId(null)}
-                  active={!selectedAgentId}
-                  tone="accent"
-                >
-                  {tr(`전체 (${repoCards.length})`, `All (${repoCards.length})`)}
-                </SurfaceSegmentButton>
-                {agentEntries.map(([aid, count]) => (
-                  <SurfaceSegmentButton
-                    key={aid}
-                    onClick={() => setSelectedAgentId(aid)}
-                    active={selectedAgentId === aid}
-                    tone="accent"
-                    className="max-w-[160px] truncate"
-                  >
-                    {getAgentLabel(aid)} ({count})
-                  </SurfaceSegmentButton>
-                ))}
-              </div>
-            );
-          }
-          // Dropdown for >4 agents
-          return (
-            <div className="flex items-center gap-2 -mt-1">
-              <select
-                value={selectedAgentId ?? ""}
-                onChange={(e) => setSelectedAgentId(e.target.value || null)}
-                className="text-xs px-3 py-2 rounded-lg border bg-transparent min-w-0 max-w-[220px]"
-                style={{
-                  borderColor: selectedAgentId
-                    ? "color-mix(in srgb, var(--th-accent-primary) 40%, transparent)"
-                    : "rgba(148,163,184,0.22)",
-                  color: selectedAgentId ? "var(--th-accent-primary)" : "var(--th-text-muted)",
-                  backgroundColor: selectedAgentId ? "var(--th-accent-primary-soft)" : "transparent",
-                  minHeight: 44,
-                }}
-              >
-                <option value="">{tr(`전체 (${repoCards.length})`, `All (${repoCards.length})`)}</option>
-                {agentEntries.map(([aid, count]) => (
-                  <option key={aid} value={aid}>
-                    {getAgentLabel(aid)} ({count})
-                  </option>
-                ))}
-              </select>
-            </div>
-          );
-        })()}
-        </div>
-
-        {settingsOpen && (
-          <div className="mt-4 space-y-3 min-w-0 overflow-hidden">
             <div className="flex flex-wrap gap-2">
-              {repoSources.length === 0 && (
-                <span className="px-3 py-2 rounded-xl text-sm border border-dashed" style={{ borderColor: "rgba(148,163,184,0.28)", color: "var(--th-text-muted)" }}>
-                  {tr("먼저 backlog repo를 추가하세요.", "Add a backlog repo first.")}
-                </span>
-              )}
-              {repoSources.map((source) => (
-                <div
-                  key={source.id}
-                  className="inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-sm"
-                  style={{
-                    borderColor: selectedRepo === source.repo
-                      ? "color-mix(in srgb, #60a5fa 52%, transparent)"
-                      : SURFACE_CHIP_STYLE.borderColor,
-                    background: selectedRepo === source.repo
-                      ? "color-mix(in srgb, var(--th-badge-sky-bg) 78%, var(--th-card-bg) 22%)"
-                      : SURFACE_CHIP_STYLE.background,
-                  }}
+              {stalledCards.length > 0 && (
+                <SurfaceActionButton
+                  tone="danger"
+                  onClick={() => { setStalledPopup(true); setStalledSelected(new Set()); }}
+                  className="animate-pulse"
                 >
-                  <button
-                    onClick={() => setSelectedRepo(source.repo)}
-                    className="text-left truncate"
-                    style={{ color: selectedRepo === source.repo ? "#dbeafe" : "var(--th-text-primary)" }}
-                  >
-                    {source.repo}
-                  </button>
-                  <button
-                    onClick={() => void handleRemoveRepo(source)}
-                    disabled={repoBusy}
-                    className="text-xs"
-                    style={{ color: "var(--th-text-muted)" }}
-                  >
-                    {tr("삭제", "Remove")}
-                  </button>
-                </div>
-              ))}
-            </div>
-
-            <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
-              <input
-                list="kanban-repo-options"
-                value={repoInput}
-                onChange={(event) => setRepoInput(event.target.value)}
-                placeholder={tr("owner/repo 입력 또는 선택", "Type or pick owner/repo")}
-                className="min-w-0 rounded-xl border px-3 py-2 text-sm"
-                style={{ ...SURFACE_FIELD_STYLE, color: "var(--th-text-primary)" }}
+                  {tr(`정체 ${stalledCards.length}건`, `${stalledCards.length} stalled`)}
+                </SurfaceActionButton>
+              )}
+              {deferredDodCount > 0 && (
+                <SurfaceActionButton tone="warn" onClick={() => setDeferredDodPopup(true)}>
+                  {tr(`미검증 DoD ${deferredDodCount}건`, `${deferredDodCount} deferred DoD`)}
+                </SurfaceActionButton>
+              )}
+              <SurfaceMetricPill
+                tone={activeFilterCount > 0 ? "accent" : "neutral"}
+                label={tr("활성 필터", "Active filters")}
+                value={activeFilterCount}
+                className="min-w-[140px]"
               />
-              <datalist id="kanban-repo-options">
-                {availableRepos.map((repo) => (
-                  <option key={repo.nameWithOwner} value={repo.nameWithOwner} />
-                ))}
-              </datalist>
-              <button
-                onClick={() => void handleAddRepo()}
-                disabled={repoBusy || !repoInput.trim()}
-                className="rounded-xl px-4 py-2 text-sm font-medium text-white disabled:opacity-50 w-full sm:w-auto"
-                style={{ backgroundColor: "#2563eb" }}
-              >
-                {repoBusy ? tr("처리 중", "Working") : tr("Repo 추가", "Add repo")}
-              </button>
             </div>
 
-            <div className="flex flex-col gap-2 w-full">
-              <label
-                className="flex items-center gap-2 rounded-xl border px-3 py-2 text-sm"
-                style={{ ...SURFACE_FIELD_STYLE, color: "var(--th-text-secondary)" }}
-              >
-                <input
-                  type="checkbox"
-                  checked={showClosed}
-                  onChange={(event) => setShowClosed(event.target.checked)}
-                />
-                {tr("닫힌 컬럼 표시", "Show closed columns")}
-              </label>
-              {selectedRepo && (() => {
-                const currentSource = repoSources.find((s) => s.repo === selectedRepo);
-                if (!currentSource) return null;
-                return (
-                  <label
-                    className="flex items-center gap-2 rounded-xl border px-3 py-2 text-sm"
-                    style={{ ...SURFACE_FIELD_STYLE, color: "var(--th-text-secondary)" }}
+            {signalFilterLabel && (
+              <SurfaceNotice
+                tone="warn"
+                className="mt-4"
+                compact
+                action={(
+                  <SurfaceActionButton
+                    type="button"
+                    tone="warn"
+                    compact
+                    onClick={() => setSignalStatusFilter("all")}
                   >
-                    <span className="shrink-0">{tr("기본 담당자", "Default agent")}</span>
-                    <select
-                      value={currentSource.default_agent_id ?? ""}
-                      onChange={(event) => {
-                        const value = event.target.value || null;
-                        void api.updateKanbanRepoSource(currentSource.id, { default_agent_id: value });
-                        setRepoSources((prev) => prev.map((s) => s.id === currentSource.id ? { ...s, default_agent_id: value } : s));
-                      }}
-                      className="min-w-0 flex-1 rounded-lg border px-2 py-1 text-xs"
-                      style={{ ...SURFACE_FIELD_STYLE, color: "var(--th-text-primary)" }}
-                    >
-                      <option value="">{tr("없음", "None")}</option>
-                      {agents.map((agent) => (
-                        <option key={agent.id} value={agent.id}>{getAgentLabel(agent.id)}</option>
-                      ))}
-                    </select>
-                  </label>
-                );
-              })()}
-            </div>
+                    {tr("해제", "Clear")}
+                  </SurfaceActionButton>
+                )}
+              >
+                <div className="text-xs leading-5">
+                  {tr("대시보드 포커스", "Dashboard focus")}: {signalFilterLabel}
+                </div>
+              </SurfaceNotice>
+            )}
 
-            <div className="grid gap-2 md:grid-cols-4">
+            <div className="mt-4 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
               <input
                 value={search}
                 onChange={(event) => setSearch(event.target.value)}
@@ -1503,8 +1393,8 @@ export default function KanbanTab({
               <select
                 value={signalStatusFilter}
                 onChange={(event) => setSignalStatusFilter(event.target.value as "all" | "review" | "blocked" | "requested" | "stalled")}
-                className="rounded-xl px-3 py-2 text-sm bg-black/20 border"
-                style={{ borderColor: "rgba(148,163,184,0.28)", color: "var(--th-text-primary)" }}
+                className="rounded-xl border px-3 py-2 text-sm"
+                style={{ ...SURFACE_FIELD_STYLE, color: "var(--th-text-primary)" }}
               >
                 <option value="all">{tr("대시보드 신호 전체", "All dashboard signals")}</option>
                 <option value="review">{tr("리뷰 대기", "Review queue")}</option>
@@ -1512,9 +1402,128 @@ export default function KanbanTab({
                 <option value="requested">{tr("수락 대기", "Waiting acceptance")}</option>
                 <option value="stalled">{tr("진행 정체", "Stale in progress")}</option>
               </select>
+              <label
+                className="flex items-center gap-2 rounded-xl border px-3 py-2 text-sm"
+                style={{ ...SURFACE_FIELD_STYLE, color: "var(--th-text-secondary)" }}
+              >
+                <input
+                  type="checkbox"
+                  checked={showClosed}
+                  onChange={(event) => setShowClosed(event.target.checked)}
+                />
+                {tr("닫힌 컬럼 표시", "Show closed columns")}
+              </label>
             </div>
-          </div>
-        )}
+          </SurfaceSubsection>
+
+          {settingsOpen && (
+            <SurfaceSubsection
+              className="xl:col-span-2"
+              title={tr("Repo Settings", "Repo Settings")}
+              description={tr(
+                "Repo 관리와 연결 설정을 같은 흐름에서 이어서 다룹니다.",
+                "Handle repo management and connection settings in the same flow.",
+              )}
+            >
+              {repoSources.length === 0 && (
+                <SurfaceNotice tone="neutral" compact className="mb-4">
+                  <div className="text-xs leading-5">
+                    {tr("먼저 backlog repo를 추가하세요.", "Add a backlog repo first.")}
+                  </div>
+                </SurfaceNotice>
+              )}
+
+              <div className="flex flex-wrap gap-2">
+                {repoSources.map((source) => (
+                  <div
+                    key={source.id}
+                    className="inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-sm"
+                    style={{
+                      borderColor: selectedRepo === source.repo
+                        ? "color-mix(in srgb, var(--th-accent-info) 32%, var(--th-border) 68%)"
+                        : SURFACE_CHIP_STYLE.borderColor,
+                      background: selectedRepo === source.repo
+                        ? "color-mix(in srgb, var(--th-badge-sky-bg) 72%, var(--th-card-bg) 28%)"
+                        : SURFACE_CHIP_STYLE.background,
+                    }}
+                  >
+                    <button
+                      onClick={() => setSelectedRepo(source.repo)}
+                      className="max-w-[240px] truncate text-left"
+                      style={{ color: selectedRepo === source.repo ? "var(--th-accent-info)" : "var(--th-text-primary)" }}
+                    >
+                      {source.repo}
+                    </button>
+                    <button
+                      onClick={() => void handleRemoveRepo(source)}
+                      disabled={repoBusy}
+                      className="text-xs"
+                      style={{ color: "var(--th-text-muted)" }}
+                    >
+                      {tr("삭제", "Remove")}
+                    </button>
+                  </div>
+                ))}
+              </div>
+
+              <div className="mt-4 grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+                <input
+                  list="kanban-repo-options"
+                  value={repoInput}
+                  onChange={(event) => setRepoInput(event.target.value)}
+                  placeholder={tr("owner/repo 입력 또는 선택", "Type or pick owner/repo")}
+                  className="min-w-0 rounded-xl border px-3 py-2 text-sm"
+                  style={{ ...SURFACE_FIELD_STYLE, color: "var(--th-text-primary)" }}
+                />
+                <datalist id="kanban-repo-options">
+                  {availableRepos.map((repo) => (
+                    <option key={repo.nameWithOwner} value={repo.nameWithOwner} />
+                  ))}
+                </datalist>
+                <SurfaceActionButton
+                  onClick={() => void handleAddRepo()}
+                  disabled={repoBusy || !repoInput.trim()}
+                  tone="info"
+                  className="w-full sm:w-auto"
+                >
+                  {repoBusy ? tr("처리 중", "Working") : tr("Repo 추가", "Add repo")}
+                </SurfaceActionButton>
+              </div>
+
+              {selectedRepo && (() => {
+                const currentSource = repoSources.find((source) => source.repo === selectedRepo);
+                if (!currentSource) return null;
+                return (
+                  <label
+                    className="mt-4 flex items-center gap-2 rounded-xl border px-3 py-2 text-sm"
+                    style={{ ...SURFACE_FIELD_STYLE, color: "var(--th-text-secondary)" }}
+                  >
+                    <span className="shrink-0">{tr("기본 담당자", "Default agent")}</span>
+                    <select
+                      value={currentSource.default_agent_id ?? ""}
+                      onChange={(event) => {
+                        const value = event.target.value || null;
+                        void api.updateKanbanRepoSource(currentSource.id, { default_agent_id: value });
+                        setRepoSources((prev) => prev.map((source) => (
+                          source.id === currentSource.id
+                            ? { ...source, default_agent_id: value }
+                            : source
+                        )));
+                      }}
+                      className="min-w-0 flex-1 rounded-lg border px-2 py-1 text-xs"
+                      style={{ ...SURFACE_FIELD_STYLE, color: "var(--th-text-primary)" }}
+                    >
+                      <option value="">{tr("없음", "None")}</option>
+                      {agents.map((agent) => (
+                        <option key={agent.id} value={agent.id}>{getAgentLabel(agent.id)}</option>
+                      ))}
+                    </select>
+                  </label>
+                );
+              })()}
+            </SurfaceSubsection>
+          )}
+        </div>
 
         {actionError && (
           <SurfaceNotice tone="danger" className="mt-4">
@@ -1791,114 +1800,40 @@ export default function KanbanTab({
         );
       })()}
 
+      {selectedRepo && (
+        <SurfaceCard
+          className="rounded-[24px] p-4"
+          style={{
+            borderColor: "color-mix(in srgb, var(--th-accent-primary) 18%, var(--th-border) 82%)",
+            background:
+              "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 95%, transparent) 0%, color-mix(in srgb, var(--th-badge-emerald-bg) 34%, var(--th-card-bg) 66%) 100%)",
+          }}
+        >
+          <div className="flex flex-wrap items-start gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--th-text-muted)" }}>
+                {tr("Queue Summary", "Queue Summary")}
+              </div>
+              <div className="mt-1 text-sm" style={{ color: "var(--th-text-primary)" }}>
+                {tr(
+                  `${selectedRepoLabel} backlog와 진행 흐름을 먼저 보고, 세부 큐/파이프라인 도구는 아래 확장 영역에서 이어서 다룹니다.`,
+                  `Review ${selectedRepoLabel} backlog and live flow first, then continue with queue and pipeline tools in the extension area below.`,
+                )}
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <SurfaceMetricPill tone="accent" label={tr("열린 카드", "Open")} value={openCount} className="min-w-[108px]" />
+              <SurfaceMetricPill tone="info" label={tr("진행 중", "In Progress")} value={inProgressCount} className="min-w-[108px]" />
+              <SurfaceMetricPill tone="warn" label={tr("리뷰", "Review")} value={reviewQueueCount} className="min-w-[108px]" />
+              <SurfaceMetricPill tone="danger" label={tr("수동 개입", "Manual")} value={manualInterventionCount} className="min-w-[108px]" />
+              <SurfaceMetricPill tone="neutral" label={tr("수락 대기", "Requested")} value={requestedCount} className="min-w-[108px]" />
+            </div>
+          </div>
+        </SurfaceCard>
+      )}
+
       <div className={showDesktopDetailPanel ? "grid min-w-0 items-start gap-4 md:grid-cols-[minmax(0,1fr)_24rem] xl:grid-cols-[minmax(0,1fr)_28rem]" : "min-w-0"}>
         <div className="min-w-0 space-y-4">
-          {selectedRepo && (
-            <>
-              <AutoQueuePanel
-                tr={tr}
-                locale={locale}
-                agents={agents}
-                selectedRepo={selectedRepo}
-                selectedAgentId={selectedAgentId}
-              />
-              <PipelineVisualEditor
-                tr={tr}
-                locale={locale}
-                repo={selectedRepo}
-                agents={agents}
-                selectedAgentId={selectedAgentId}
-              />
-            </>
-          )}
-
-          {/* ── Recent completions ── */}
-          {selectedRepo && recentDoneCards.length > 0 && (() => {
-            const PAGE_SIZE = 10;
-            const totalPages = Math.ceil(recentDoneCards.length / PAGE_SIZE);
-            const page = Math.min(recentDonePage, totalPages - 1);
-            const pageCards = recentDoneCards.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
-            return (
-              <SurfaceCard
-                className="rounded-[24px] px-4 py-3"
-                style={{
-                  borderColor: "color-mix(in srgb, var(--th-accent-primary) 16%, var(--th-border) 84%)",
-                  background: "color-mix(in srgb, var(--th-badge-emerald-bg) 56%, var(--th-card-bg) 44%)",
-                }}
-              >
-                <button
-                  onClick={() => setRecentDoneOpen((v) => !v)}
-                  className="flex w-full items-center gap-2 text-left"
-                >
-                  <span className="text-xs font-semibold uppercase" style={{ color: "var(--th-text-muted)" }}>
-                    {tr("최근 완료", "Recent Completions")}
-                  </span>
-                  <span className="rounded-full px-1.5 py-0.5 text-[10px] font-bold" style={{ background: "rgba(34,197,94,0.18)", color: "#4ade80" }}>
-                    {recentDoneCards.length}
-                  </span>
-                  <span className="ml-auto text-xs" style={{ color: "var(--th-text-muted)" }}>
-                    {recentDoneOpen ? "▲" : "▼"}
-                  </span>
-                </button>
-                {recentDoneOpen && (
-                  <div className="mt-2 space-y-1.5">
-                    {pageCards.map((card) => {
-                      const statusDef = COLUMN_DEFS.find((c) => c.status === card.status);
-                      const agentName = getAgentLabel(card.assignee_agent_id);
-                      const completedDate = card.completed_at
-                        ? new Date(card.completed_at).toLocaleDateString(locale === "ko" ? "ko-KR" : "en-US", { month: "short", day: "numeric" })
-                        : "";
-                      return (
-                        <button
-                          key={card.id}
-                          onClick={() => setSelectedCardId(card.id)}
-                          className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm transition-colors hover:brightness-125"
-                          style={{ background: "rgba(148,163,184,0.06)" }}
-                        >
-                          <span
-                            className="shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-semibold"
-                            style={{ background: `${statusDef?.accent ?? "#22c55e"}22`, color: statusDef?.accent ?? "#22c55e" }}
-                          >
-                            {card.status === "done" ? tr("완료", "Done") : tr("취소", "Cancelled")}
-                          </span>
-                          {card.github_issue_number && (
-                            <span className="shrink-0 text-xs" style={{ color: "var(--th-text-muted)" }}>#{card.github_issue_number}</span>
-                          )}
-                          <span className="min-w-0 flex-1 truncate" style={{ color: "var(--th-text-primary)" }}>{card.title}</span>
-                          <span className="shrink-0 text-[11px]" style={{ color: "var(--th-text-muted)" }}>{agentName}</span>
-                          <span className="shrink-0 text-[11px]" style={{ color: "var(--th-text-muted)" }}>{completedDate}</span>
-                        </button>
-                      );
-                    })}
-                    {totalPages > 1 && (
-                      <div className="flex items-center justify-center gap-3 pt-1">
-                        <button
-                          disabled={page === 0}
-                          onClick={() => setRecentDonePage((p) => Math.max(0, p - 1))}
-                          className="rounded px-2 py-0.5 text-xs disabled:opacity-30"
-                          style={{ color: "var(--th-text-muted)" }}
-                        >
-                          ← {tr("이전", "Prev")}
-                        </button>
-                        <span className="text-[11px]" style={{ color: "var(--th-text-muted)" }}>
-                          {page + 1} / {totalPages}
-                        </span>
-                        <button
-                          disabled={page >= totalPages - 1}
-                          onClick={() => setRecentDonePage((p) => Math.min(totalPages - 1, p + 1))}
-                          className="rounded px-2 py-0.5 text-xs disabled:opacity-30"
-                          style={{ color: "var(--th-text-muted)" }}
-                        >
-                          {tr("다음", "Next")} →
-                        </button>
-                      </div>
-                    )}
-                  </div>
-                )}
-              </SurfaceCard>
-            );
-          })()}
-
           {!selectedRepo ? (
             <SurfaceEmptyState
               className="rounded-[24px] px-4 py-10 text-center text-sm"
@@ -2007,128 +1942,177 @@ export default function KanbanTab({
                     : "max(2rem, calc(2rem + env(safe-area-inset-bottom)))",
                 }}
               >
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="rounded-full border px-2 py-0.5 text-xs" style={{ ...SURFACE_CHIP_STYLE, color: "var(--th-text-secondary)" }}>
-                        {labelForStatus(selectedCard.status, tr)}
-                      </span>
-                      <span className="rounded-full border px-2 py-0.5 text-xs" style={{ ...SURFACE_CHIP_STYLE, color: "var(--th-text-secondary)" }}>
-                        {priorityLabel(selectedCard.priority, tr)}
-                      </span>
-                      {selectedCard.github_repo && (
-                        <span className="rounded-full border px-2 py-0.5 text-xs" style={{ ...SURFACE_CHIP_STYLE, color: "var(--th-text-secondary)" }}>
-                          {selectedCard.github_repo}
-                        </span>
-                      )}
-                    </div>
-                    <h3 className="mt-2 text-xl font-semibold" style={{ color: "var(--th-text-heading)" }}>
-                      {selectedCard.title}
-                    </h3>
-                  </div>
-                  <SurfaceActionButton
-                    tone="neutral"
-                    onClick={() => setSelectedCardId(null)}
-                    className="shrink-0 whitespace-nowrap"
-                    style={{ ...SURFACE_GHOST_BUTTON_STYLE, color: "var(--th-text-secondary)" }}
-                  >
-                    {tr("닫기", "Close")}
-                  </SurfaceActionButton>
-                </div>
-
-                <div className="grid gap-3 md:grid-cols-2">
-                  <label className="space-y-1">
-                    <span className="text-xs" style={{ color: "var(--th-text-muted)" }}>{tr("제목", "Title")}</span>
-                    <input
-                      value={editor.title}
-                      onChange={(event) => setEditor((prev) => ({ ...prev, title: event.target.value }))}
-                      className="w-full rounded-xl border px-3 py-2 text-sm"
-                      style={{ ...SURFACE_FIELD_STYLE, color: "var(--th-text-primary)" }}
+                <SurfaceSection
+                  eyebrow={tr("Selected Card", "Selected Card")}
+                  title={selectedCard.title}
+                  description={selectedCardHeroDescription}
+                  badge={labelForStatus(selectedCard.status, tr)}
+                  actions={(
+                    <SurfaceActionButton
+                      tone="neutral"
+                      onClick={() => setSelectedCardId(null)}
+                      className="shrink-0 whitespace-nowrap"
+                      style={{ ...SURFACE_GHOST_BUTTON_STYLE, color: "var(--th-text-secondary)" }}
+                    >
+                      {tr("닫기", "Close")}
+                    </SurfaceActionButton>
+                  )}
+                  className="rounded-[28px] p-4 sm:p-5"
+                  style={{
+                    borderColor: "color-mix(in srgb, var(--th-accent-info) 18%, var(--th-border) 82%)",
+                    background:
+                      "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 96%, var(--th-accent-info) 4%) 0%, color-mix(in srgb, var(--th-bg-surface) 98%, transparent) 100%)",
+                  }}
+                >
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    <SurfaceMetricPill
+                      tone="accent"
+                      label={tr("담당자", "Assignee")}
+                      value={selectedCardAssigneeLabel}
+                      className="min-w-[150px]"
                     />
-                  </label>
-                  <div className="space-y-1">
-                    <span className="text-xs" style={{ color: "var(--th-text-muted)" }}>{tr("상태 전환", "Status")}</span>
-                    <div className="flex flex-wrap gap-1.5">
-                      {(STATUS_TRANSITIONS[selectedCard.status] ?? []).map((target) => {
-                        const style = TRANSITION_STYLE[target] ?? TRANSITION_STYLE.backlog;
-                        return (
-                          <SurfaceActionButton
-                            key={target}
-                            type="button"
-                            disabled={savingCard}
-                            onClick={async () => {
-                              if (target === "done" && editor.review_checklist.some((item) => !item.done)) {
-                                setActionError(tr("review checklist를 모두 완료해야 done으로 이동할 수 있습니다.", "Complete the review checklist before moving to done."));
-                                return;
-                              }
-                              setSavingCard(true);
-                              setActionError(null);
-                              try {
-                                await onUpdateCard(selectedCard.id, { status: target });
-                                invalidateCardActivity(selectedCard.id);
-                                setEditor((prev) => ({ ...prev, status: target }));
-                              } catch (error) {
-                                setActionError(error instanceof Error ? error.message : tr("상태 전환에 실패했습니다.", "Failed to change status."));
-                              } finally {
-                                setSavingCard(false);
-                              }
-                            }}
-                            className="whitespace-nowrap"
-                            style={{
-                              background: style.bg,
-                              borderColor: style.text,
-                              color: style.text,
-                            }}
-                          >
-                            → {labelForStatus(target, tr)}
-                          </SurfaceActionButton>
-                        );
-                      })}
-                    </div>
+                    <SurfaceMetricPill
+                      tone="neutral"
+                      label={tr("우선순위", "Priority")}
+                      value={priorityLabel(selectedCard.priority, tr)}
+                      className="min-w-[140px]"
+                    />
+                    <SurfaceMetricPill
+                      tone="info"
+                      label={tr("전환 가능", "Transitions")}
+                      value={selectedCardTransitionTargets.length}
+                      className="min-w-[140px]"
+                    />
                   </div>
-                </div>
 
-                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-                  <label className="space-y-1">
-                    <span className="text-xs" style={{ color: "var(--th-text-muted)" }}>{tr("담당자", "Assignee")}</span>
-                    <select
-                      value={editor.assignee_agent_id}
-                      onChange={(event) => setEditor((prev) => ({ ...prev, assignee_agent_id: event.target.value }))}
-                      className="w-full rounded-xl border px-3 py-2 text-sm"
-                      style={{ ...SURFACE_FIELD_STYLE, color: "var(--th-text-primary)" }}
-                    >
-                      <option value="">{tr("없음", "None")}</option>
-                      {agents.map((agent) => (
-                        <option key={agent.id} value={agent.id}>{getAgentLabel(agent.id)}</option>
-                      ))}
-                    </select>
-                  </label>
-                  <label className="space-y-1">
-                    <span className="text-xs" style={{ color: "var(--th-text-muted)" }}>{tr("우선순위", "Priority")}</span>
-                    <select
-                      value={editor.priority}
-                      onChange={(event) => setEditor((prev) => ({ ...prev, priority: event.target.value as KanbanCardPriority }))}
-                      className="w-full rounded-xl border px-3 py-2 text-sm"
-                      style={{ ...SURFACE_FIELD_STYLE, color: "var(--th-text-primary)" }}
-                    >
-                      {PRIORITY_OPTIONS.map((priority) => (
-                        <option key={priority} value={priority}>{priorityLabel(priority, tr)}</option>
-                      ))}
-                    </select>
-                  </label>
-                  <SurfaceCard className="space-y-1.5 p-3" style={{ ...SURFACE_PANEL_STYLE }}>
-                    <div className="text-xs" style={{ color: "var(--th-text-muted)" }}>{tr("GitHub", "GitHub")}</div>
-                    <div style={{ color: "var(--th-text-primary)" }}>
-                      {selectedCard.github_issue_url ? (
-                        <a href={selectedCard.github_issue_url} target="_blank" rel="noreferrer" className="hover:underline" style={{ color: "#93c5fd" }}>
-                          #{selectedCard.github_issue_number ?? "-"}
-                        </a>
-                      ) : (
-                        selectedCard.github_issue_number ? `#${selectedCard.github_issue_number}` : "-"
+                  <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1.05fr)_minmax(320px,0.95fr)]">
+                    <SurfaceSubsection
+                      title={tr("Quick Edit", "Quick Edit")}
+                      description={tr(
+                        "제목, 담당자, 우선순위를 한 번에 빠르게 조정합니다.",
+                        "Adjust title, assignee, and priority in one place.",
                       )}
-                    </div>
-                  </SurfaceCard>
-                </div>
+                    >
+                      <div className="grid gap-3 md:grid-cols-2">
+                        <label className="space-y-1 md:col-span-2">
+                          <span className="text-xs" style={{ color: "var(--th-text-muted)" }}>{tr("제목", "Title")}</span>
+                          <input
+                            value={editor.title}
+                            onChange={(event) => setEditor((prev) => ({ ...prev, title: event.target.value }))}
+                            className="w-full rounded-xl border px-3 py-2 text-sm"
+                            style={{ ...SURFACE_FIELD_STYLE, color: "var(--th-text-primary)" }}
+                          />
+                        </label>
+                        <label className="space-y-1">
+                          <span className="text-xs" style={{ color: "var(--th-text-muted)" }}>{tr("담당자", "Assignee")}</span>
+                          <select
+                            value={editor.assignee_agent_id}
+                            onChange={(event) => setEditor((prev) => ({ ...prev, assignee_agent_id: event.target.value }))}
+                            className="w-full rounded-xl border px-3 py-2 text-sm"
+                            style={{ ...SURFACE_FIELD_STYLE, color: "var(--th-text-primary)" }}
+                          >
+                            <option value="">{tr("없음", "None")}</option>
+                            {agents.map((agent) => (
+                              <option key={agent.id} value={agent.id}>{getAgentLabel(agent.id)}</option>
+                            ))}
+                          </select>
+                        </label>
+                        <label className="space-y-1">
+                          <span className="text-xs" style={{ color: "var(--th-text-muted)" }}>{tr("우선순위", "Priority")}</span>
+                          <select
+                            value={editor.priority}
+                            onChange={(event) => setEditor((prev) => ({ ...prev, priority: event.target.value as KanbanCardPriority }))}
+                            className="w-full rounded-xl border px-3 py-2 text-sm"
+                            style={{ ...SURFACE_FIELD_STYLE, color: "var(--th-text-primary)" }}
+                          >
+                            {PRIORITY_OPTIONS.map((priority) => (
+                              <option key={priority} value={priority}>{priorityLabel(priority, tr)}</option>
+                            ))}
+                          </select>
+                        </label>
+                        <SurfaceCard className="space-y-1.5 p-3 md:col-span-2" style={{ ...SURFACE_PANEL_STYLE }}>
+                          <div className="text-xs" style={{ color: "var(--th-text-muted)" }}>{tr("GitHub", "GitHub")}</div>
+                          <div style={{ color: "var(--th-text-primary)" }}>
+                            {selectedCard.github_issue_url ? (
+                              <a href={selectedCard.github_issue_url} target="_blank" rel="noreferrer" className="hover:underline" style={{ color: "#93c5fd" }}>
+                                #{selectedCard.github_issue_number ?? "-"}
+                              </a>
+                            ) : (
+                              selectedCard.github_issue_number ? `#${selectedCard.github_issue_number}` : "-"
+                            )}
+                          </div>
+                        </SurfaceCard>
+                      </div>
+                    </SurfaceSubsection>
+
+                    <SurfaceSubsection
+                      title={tr("Status Flow", "Status Flow")}
+                      description={tr(
+                        "카드가 다음 단계로 넘어가는 경로를 여기서 바로 실행합니다.",
+                        "Run the next state transitions directly from here.",
+                      )}
+                    >
+                      <div className="flex flex-wrap gap-1.5">
+                        {selectedCardTransitionTargets.map((target) => {
+                          const style = TRANSITION_STYLE[target] ?? TRANSITION_STYLE.backlog;
+                          return (
+                            <SurfaceActionButton
+                              key={target}
+                              type="button"
+                              disabled={savingCard}
+                              onClick={async () => {
+                                if (target === "done" && editor.review_checklist.some((item) => !item.done)) {
+                                  setActionError(tr("review checklist를 모두 완료해야 done으로 이동할 수 있습니다.", "Complete the review checklist before moving to done."));
+                                  return;
+                                }
+                                setSavingCard(true);
+                                setActionError(null);
+                                try {
+                                  await onUpdateCard(selectedCard.id, { status: target });
+                                  invalidateCardActivity(selectedCard.id);
+                                  setEditor((prev) => ({ ...prev, status: target }));
+                                } catch (error) {
+                                  setActionError(error instanceof Error ? error.message : tr("상태 전환에 실패했습니다.", "Failed to change status."));
+                                } finally {
+                                  setSavingCard(false);
+                                }
+                              }}
+                              className="whitespace-nowrap"
+                              style={{
+                                background: style.bg,
+                                borderColor: style.text,
+                                color: style.text,
+                              }}
+                            >
+                              → {labelForStatus(target, tr)}
+                            </SurfaceActionButton>
+                          );
+                        })}
+                      </div>
+
+                      <div className="mt-4 flex flex-wrap items-center gap-2">
+                        <span className="rounded-full border px-2 py-0.5 text-xs" style={{ ...SURFACE_CHIP_STYLE, color: "var(--th-text-secondary)" }}>
+                          {priorityLabel(selectedCard.priority, tr)}
+                        </span>
+                        {selectedCard.github_repo && (
+                          <span className="rounded-full border px-2 py-0.5 text-xs" style={{ ...SURFACE_CHIP_STYLE, color: "var(--th-text-secondary)" }}>
+                            {selectedCard.github_repo}
+                          </span>
+                        )}
+                        {selectedCardDelayBadge && (
+                          <span className="rounded-full border px-2 py-0.5 text-xs" style={{ ...SURFACE_CHIP_STYLE, color: "var(--th-text-secondary)" }}>
+                            {selectedCardDelayBadge.label}
+                          </span>
+                        )}
+                        {selectedCardDwellBadge && (
+                          <span className="rounded-full border px-2 py-0.5 text-xs" style={{ ...SURFACE_CHIP_STYLE, color: "var(--th-text-secondary)" }}>
+                            {selectedCardDwellBadge.label}
+                          </span>
+                        )}
+                      </div>
+                    </SurfaceSubsection>
+                  </div>
+                </SurfaceSection>
 
                 {/* Blocked reason */}
                 {hasManualInterventionReason(selectedCard) && selectedCard.blocked_reason && (
@@ -2188,22 +2172,22 @@ export default function KanbanTab({
                   const actionableItems = items.filter((i) => i.category !== "pass");
                   if (actionableItems.length === 0) return null;
                   const allDecided = actionableItems.every((i) => reviewDecisions[i.id]);
+                  const decidedCount = Object.keys(reviewDecisions).filter((key) => actionableItems.some((item) => item.id === key)).length;
                   return (
-                    <SurfaceCard className="space-y-4" style={{
-                      borderColor: "rgba(234,179,8,0.35)",
-                      backgroundColor: "rgba(234,179,8,0.06)",
-                    }}>
-                      <div className="flex items-center justify-between gap-2">
-                        <div className="text-[10px] font-semibold uppercase tracking-widest" style={{ color: "#eab308" }}>
-                          {tr("리뷰 제안 사항", "Review Suggestions")}
-                        </div>
-                        <span className="text-xs px-2 py-0.5 rounded-full" style={{
-                          backgroundColor: allDecided ? "rgba(34,197,94,0.18)" : "rgba(234,179,8,0.18)",
-                          color: allDecided ? "#4ade80" : "#fde047",
-                        }}>
-                          {Object.keys(reviewDecisions).filter((k) => actionableItems.some((d) => d.id === k)).length}/{actionableItems.length}
-                        </span>
-                      </div>
+                    <SurfaceSection
+                      eyebrow={tr("Review Queue", "Review Queue")}
+                      title={tr("리뷰 제안 사항", "Review Suggestions")}
+                      description={tr(
+                        "각 제안의 수용 여부를 정하고, 결정이 끝나면 다시 디스패치합니다.",
+                        "Decide each suggestion, then redispatch after decisions are complete.",
+                      )}
+                      badge={`${decidedCount}/${actionableItems.length}`}
+                      className="rounded-[28px] p-4 sm:p-5"
+                      style={{
+                        borderColor: "color-mix(in srgb, var(--th-accent-warn) 32%, var(--th-border) 68%)",
+                        background: "color-mix(in srgb, var(--th-badge-amber-bg) 74%, var(--th-card-bg) 26%)",
+                      }}
+                    >
                       <div className="space-y-3">
                         {actionableItems.map((item) => {
                           const decision = reviewDecisions[item.id];
@@ -2299,7 +2283,7 @@ export default function KanbanTab({
                             ? tr("결정 완료 → 재디스패치", "Decisions Complete → Dispatch Rework")
                             : tr("모든 항목에 결정을 내려주세요", "Decide all items first")}
                       </SurfaceActionButton>
-                    </SurfaceCard>
+                    </SurfaceSection>
                   );
                 })()}
 
@@ -2483,75 +2467,86 @@ export default function KanbanTab({
                   );
                 })()}
 
-                {/* Description / Issue Sections */}
-                {(() => {
-                  const parsed = parseIssueSections(editor.description);
-                  if (!parsed) {
-                    // Fallback: non-PMD format → show as markdown
+                <SurfaceSection
+                  eyebrow={tr("Issue Narrative", "Issue Narrative")}
+                  title={tr("설명 · DoD · 배경", "Description · DoD · Background")}
+                  description={tr(
+                    "PMD 본문과 GitHub checklist를 한 섹션에서 함께 검토합니다.",
+                    "Review PMD content and the GitHub checklist in one section.",
+                  )}
+                  className="rounded-[28px] p-4 sm:p-5"
+                >
+                  {(() => {
+                    const parsed = parseIssueSections(editor.description);
+                    if (!parsed) {
+                      return (
+                        <SurfaceSubsection
+                          title={tr("설명", "Description")}
+                          description={tr(
+                            "구조화되지 않은 본문은 그대로 렌더링합니다.",
+                            "Render unstructured issue body as-is.",
+                          )}
+                        >
+                          {editor.description ? (
+                            <SurfaceCard className="text-sm" style={{ ...SURFACE_PANEL_STYLE, color: "var(--th-text-primary)" }}>
+                              <MarkdownContent content={editor.description} />
+                            </SurfaceCard>
+                          ) : (
+                            <SurfaceEmptyState className="px-3 py-4 text-center text-xs">
+                              {tr("설명이 없습니다.", "No description.")}
+                            </SurfaceEmptyState>
+                          )}
+                        </SurfaceSubsection>
+                      );
+                    }
+
+                    const isGitHubLinked = Boolean(selectedCard.github_issue_number);
                     return (
-                      <div className="space-y-1">
-                        <span className="text-xs" style={{ color: "var(--th-text-muted)" }}>{tr("설명", "Description")}</span>
-                        {editor.description ? (
-                          <SurfaceCard className="text-sm" style={{ ...SURFACE_PANEL_STYLE, color: "var(--th-text-primary)" }}>
-                            <MarkdownContent content={editor.description} />
-                          </SurfaceCard>
-                        ) : (
-                          <SurfaceEmptyState className="px-3 py-4 text-center text-xs">
-                            {tr("설명이 없습니다.", "No description.")}
-                          </SurfaceEmptyState>
+                      <div className="grid gap-4 xl:grid-cols-2">
+                        {parsed.background && (
+                          <SurfaceSubsection
+                            title={tr("배경", "Background")}
+                            description={tr(
+                              "카드가 만들어진 운영 맥락입니다.",
+                              "Operational context that led to this card.",
+                            )}
+                          >
+                            <div className="text-sm" style={{ color: "var(--th-text-primary)" }}>
+                              <MarkdownContent content={parsed.background} />
+                            </div>
+                          </SurfaceSubsection>
                         )}
-                      </div>
-                    );
-                  }
 
-                  // Structured view for PMD-format issues
-                  return (
-                    <div className="space-y-3">
-                      {/* 배경 */}
-                      {parsed.background && (
-                        <SurfaceCard className="space-y-2" style={{ ...SURFACE_PANEL_STYLE }}>
-                          <div className="text-[10px] font-semibold uppercase tracking-widest" style={{ color: "var(--th-text-muted)" }}>
-                            {tr("배경", "Background")}
-                          </div>
-                          <div className="text-sm" style={{ color: "var(--th-text-primary)" }}>
-                            <MarkdownContent content={parsed.background} />
-                          </div>
-                        </SurfaceCard>
-                      )}
+                        {parsed.content && (
+                          <SurfaceSubsection
+                            title={tr("내용", "Content")}
+                            description={tr(
+                              "실제 작업 본문과 구현 범위입니다.",
+                              "Primary work body and implementation scope.",
+                            )}
+                          >
+                            <div className="text-sm" style={{ color: "var(--th-text-primary)" }}>
+                              <MarkdownContent content={parsed.content} />
+                            </div>
+                          </SurfaceSubsection>
+                        )}
 
-                      {/* 내용 */}
-                      {parsed.content && (
-                        <SurfaceCard className="space-y-2" style={{ ...SURFACE_PANEL_STYLE }}>
-                          <div className="text-[10px] font-semibold uppercase tracking-widest" style={{ color: "var(--th-text-muted)" }}>
-                            {tr("내용", "Content")}
-                          </div>
-                          <div className="text-sm" style={{ color: "var(--th-text-primary)" }}>
-                            <MarkdownContent content={parsed.content} />
-                          </div>
-                        </SurfaceCard>
-                      )}
-
-                      {/* DoD Checklist */}
-                      {editor.review_checklist.length > 0 && (() => {
-                        const isGitHubLinked = Boolean(selectedCard.github_issue_number);
-                        return (
-                          <SurfaceCard className="space-y-3" style={{ ...SURFACE_PANEL_STYLE, borderColor: "rgba(20,184,166,0.3)" }}>
-                            <div className="flex items-center justify-between gap-3">
-                              <div className="text-[10px] font-semibold uppercase tracking-widest" style={{ color: "#2dd4bf" }}>
-                                DoD (Definition of Done)
-                                {isGitHubLinked && (
-                                  <span className="ml-2 text-[9px] font-normal normal-case tracking-normal" style={{ color: "var(--th-text-muted)" }}>
-                                    {tr("(GitHub 정본)", "(synced from GitHub)")}
-                                  </span>
-                                )}
-                              </div>
+                        {editor.review_checklist.length > 0 && (
+                          <SurfaceSubsection
+                            className="xl:col-span-2"
+                            title="DoD (Definition of Done)"
+                            description={isGitHubLinked
+                              ? tr("GitHub issue를 정본으로 유지하면서 완료 여부만 반영합니다.", "Keep GitHub issue as the source of truth while reflecting completion state.")
+                              : tr("완료 기준을 카드 안에서 바로 체크합니다.", "Check completion criteria directly inside the card.")}
+                            actions={(
                               <SurfaceMetricPill
                                 label={tr("완료", "Done")}
                                 value={`${editor.review_checklist.filter((item) => item.done).length}/${editor.review_checklist.length}`}
                                 tone="success"
-                                className="min-w-[92px] px-2.5 py-1.5"
+                                className="min-w-[92px]"
                               />
-                            </div>
+                            )}
+                          >
                             <div className="space-y-2">
                               {editor.review_checklist.map((item) => (
                                 <label
@@ -2586,295 +2581,372 @@ export default function KanbanTab({
                                 </label>
                               ))}
                             </div>
-                          </SurfaceCard>
-                        );
-                      })()}
-
-                      {/* 의존성 */}
-                      {parsed.dependencies && (
-                        <SurfaceNotice tone="info" className="items-start">
-                          <div className="space-y-1.5">
-                            <div className="text-[10px] font-semibold uppercase tracking-widest" style={{ color: "#93c5fd" }}>
-                              {tr("의존성", "Dependencies")}
-                            </div>
-                            <div className="text-sm" style={{ color: "var(--th-text-primary)" }}>
-                              <MarkdownContent content={parsed.dependencies} />
-                            </div>
-                          </div>
-                        </SurfaceNotice>
-                      )}
-
-                      {/* 리스크 */}
-                      {parsed.risks && (
-                        <SurfaceNotice tone="danger" className="items-start">
-                          <div className="space-y-1.5">
-                            <div className="text-[10px] font-semibold uppercase tracking-widest" style={{ color: "#fca5a5" }}>
-                              {tr("리스크", "Risks")}
-                            </div>
-                            <div className="text-sm" style={{ color: "var(--th-text-primary)" }}>
-                              <MarkdownContent content={parsed.risks} />
-                            </div>
-                          </div>
-                        </SurfaceNotice>
-                      )}
-                    </div>
-                  );
-                })()}
-
-                {canRedispatchCard(selectedCard) && (
-                  <SurfaceCard className="space-y-3" style={{ ...SURFACE_PANEL_STYLE }}>
-                    <div>
-                      <h4 className="font-medium" style={{ color: "var(--th-text-heading)" }}>
-                        {tr("이슈 변경 후 재전송", "Resend with Updated Issue")}
-                      </h4>
-                      <p className="text-xs" style={{ color: "var(--th-text-muted)" }}>
-                        {tr(
-                          "이슈 본문을 수정한 뒤, 기존 dispatch를 취소하고 새로 전송합니다.",
-                          "Cancel current dispatch and resend with the updated issue body.",
+                          </SurfaceSubsection>
                         )}
-                      </p>
-                    </div>
-                    <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto]">
-                      <input
-                        type="text"
-                        placeholder={tr("사유 (선택)", "Reason (optional)")}
-                        value={redispatchReason}
-                        onChange={(e) => setRedispatchReason(e.target.value)}
-                        className="w-full rounded-xl border px-3 py-2 text-sm"
-                        style={{ ...SURFACE_FIELD_STYLE, color: "var(--th-text-primary)" }}
-                      />
-                      <SurfaceActionButton
-                        type="button"
-                        onClick={() => void handleRedispatch()}
-                        disabled={redispatching}
-                        tone="warn"
-                        className="whitespace-nowrap px-4 py-2 text-sm"
-                        style={{ background: "#d97706", borderColor: "#d97706", color: "white" }}
-                      >
-                        {redispatching ? tr("전송 중...", "Sending...") : tr("재전송", "Resend")}
-                      </SurfaceActionButton>
-                    </div>
-                  </SurfaceCard>
-                )}
 
-                {canRetryCard(selectedCard) && (
-                  <SurfaceCard className="space-y-3" style={{ ...SURFACE_PANEL_STYLE }}>
-                    <div>
-                      <h4 className="font-medium" style={{ color: "var(--th-text-heading)" }}>
-                        {tr("재시도 / 담당자 변경", "Retry / Change Assignee")}
-                      </h4>
-                      <p className="text-xs" style={{ color: "var(--th-text-muted)" }}>
-                        {tr("동일 내용으로 재전송하거나 다른 에이전트에게 전환합니다.", "Resend as-is or switch to another agent.")}
-                      </p>
-                    </div>
-                    <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto]">
-                      <select
-                        value={retryAssigneeId}
-                        onChange={(event) => setRetryAssigneeId(event.target.value)}
-                        className="w-full rounded-xl border px-3 py-2 text-sm"
-                        style={{ ...SURFACE_FIELD_STYLE, color: "var(--th-text-primary)" }}
-                      >
-                        {agents.map((agent) => (
-                          <option key={agent.id} value={agent.id}>{getAgentLabel(agent.id)}</option>
-                        ))}
-                      </select>
-                      <SurfaceActionButton
-                        type="button"
-                        onClick={() => void handleRetryCard()}
-                        disabled={retryingCard || !(retryAssigneeId || selectedCard.assignee_agent_id)}
-                        tone="accent"
-                        className="whitespace-nowrap px-4 py-2 text-sm"
-                        style={{ background: "#7c3aed", borderColor: "#7c3aed", color: "white" }}
-                      >
-                        {retryingCard ? tr("전송 중...", "Sending...") : tr("재시도", "Retry")}
-                      </SurfaceActionButton>
-                    </div>
-                  </SurfaceCard>
-                )}
-
-                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4 text-sm">
-                  <SurfaceCard className="space-y-1.5 p-3" style={{ ...SURFACE_PANEL_STYLE }}>
-                    <div className="text-xs" style={{ color: "var(--th-text-muted)" }}>{tr("생성", "Created")}</div>
-                    <div style={{ color: "var(--th-text-primary)" }}>{formatIso(selectedCard.created_at, locale)}</div>
-                  </SurfaceCard>
-                  <SurfaceCard className="space-y-1.5 p-3" style={{ ...SURFACE_PANEL_STYLE }}>
-                    <div className="text-xs" style={{ color: "var(--th-text-muted)" }}>{tr("요청", "Requested")}</div>
-                    <div style={{ color: "var(--th-text-primary)" }}>{formatIso(selectedCard.requested_at, locale)}</div>
-                  </SurfaceCard>
-                  <SurfaceCard className="space-y-1.5 p-3" style={{ ...SURFACE_PANEL_STYLE }}>
-                    <div className="text-xs" style={{ color: "var(--th-text-muted)" }}>{tr("시작", "Started")}</div>
-                    <div style={{ color: "var(--th-text-primary)" }}>{formatIso(selectedCard.started_at, locale)}</div>
-                  </SurfaceCard>
-                  <SurfaceCard className="space-y-1.5 p-3" style={{ ...SURFACE_PANEL_STYLE }}>
-                    <div className="text-xs" style={{ color: "var(--th-text-muted)" }}>{tr("완료", "Completed")}</div>
-                    <div style={{ color: "var(--th-text-primary)" }}>{formatIso(selectedCard.completed_at, locale)}</div>
-                  </SurfaceCard>
-                </div>
-
-                {/* Dispatch history — all dispatches for this card */}
-                {(() => {
-                  const cardDispatches = dispatches
-                    .filter((d) => d.kanban_card_id === selectedCard.id)
-                    .sort((a, b) => {
-                      const ta = typeof a.created_at === "number" ? a.created_at : new Date(a.created_at).getTime();
-                      const tb = typeof b.created_at === "number" ? b.created_at : new Date(b.created_at).getTime();
-                      return tb - ta;
-                    });
-                  const hasAny = cardDispatches.length > 0 || selectedCard.latest_dispatch_status;
-                  if (!hasAny) return null;
-
-                  const dispatchStatusColor: Record<string, string> = {
-                    pending: "#fbbf24",
-                    dispatched: "#38bdf8",
-                    in_progress: "#f59e0b",
-                    completed: "#4ade80",
-                    failed: "#f87171",
-                    cancelled: "#9ca3af",
-                  };
-
-                  return (
-                    <SurfaceCard className="space-y-3" style={{ ...SURFACE_PANEL_STYLE }}>
-                      <h4 className="font-medium" style={{ color: "var(--th-text-heading)" }}>
-                        {tr("Dispatch 이력", "Dispatch history")}
-                        {cardDispatches.length > 0 && (
-                          <span className="ml-2 text-xs font-normal" style={{ color: "var(--th-text-muted)" }}>
-                            ({cardDispatches.length})
-                          </span>
-                        )}
-                      </h4>
-                      {parseCardMetadata(selectedCard.metadata_json).timed_out_reason && (
-                        <SurfaceNotice tone="warn" compact>
-                          {parseCardMetadata(selectedCard.metadata_json).timed_out_reason}
-                        </SurfaceNotice>
-                      )}
-                      {cardDispatches.length > 0 ? (
-                        <div className="space-y-2 max-h-64 overflow-y-auto">
-                          {cardDispatches.map((d) => (
-                            <SurfaceCard
-                              key={d.id}
-                              className="space-y-2 p-3 text-sm"
-                              style={{ borderColor: "rgba(148,163,184,0.12)", backgroundColor: d.id === selectedCard.latest_dispatch_id ? "rgba(37,99,235,0.08)" : "transparent" }}
-                            >
-                              <div className="flex items-center gap-2 flex-wrap">
-                                <span
-                                  className="inline-block w-2 h-2 rounded-full shrink-0"
-                                  style={{ backgroundColor: dispatchStatusColor[d.status] ?? "#94a3b8" }}
-                                />
-                                <span className="font-mono text-xs" style={{ color: "var(--th-text-muted)" }}>
-                                  #{d.id.slice(0, 8)}
-                                </span>
-                                <span
-                                  className="px-1.5 py-0.5 rounded text-[10px] font-medium"
-                                  style={{ backgroundColor: "rgba(148,163,184,0.12)", color: dispatchStatusColor[d.status] ?? "#94a3b8" }}
-                                >
-                                  {d.status}
-                                </span>
-                                {d.dispatch_type && (
-                                  <span className="px-1.5 py-0.5 rounded text-[10px]" style={{ backgroundColor: "rgba(148,163,184,0.08)", color: "var(--th-text-secondary)" }}>
-                                    {d.dispatch_type}
-                                  </span>
-                                )}
-                                {d.to_agent_id && (
-                                  <span className="text-xs" style={{ color: "var(--th-text-secondary)" }}>
-                                    → {getAgentLabel(d.to_agent_id)}
-                                  </span>
-                                )}
-                              </div>
-                              <div className="flex items-center gap-3 mt-1 text-xs" style={{ color: "var(--th-text-muted)" }}>
-                                <span>{formatIso(d.created_at, locale)}</span>
-                                {d.chain_depth > 0 && <span>depth {d.chain_depth}</span>}
-                              </div>
-                              {(() => {
-                                const dispatchSummary = formatDispatchSummary(d.result_summary);
-                                if (!dispatchSummary) return null;
-                                return (
-                                  <SurfaceNotice
-                                    compact
-                                    className="mt-1 whitespace-pre-wrap break-words"
-                                    style={{ color: "var(--th-text-secondary)" }}
-                                  >
-                                    {dispatchSummary}
-                                  </SurfaceNotice>
-                                );
-                              })()}
-                            </SurfaceCard>
-                        ))}
-                      </div>
-                      ) : (
-                        <div className="grid gap-2 md:grid-cols-2 text-sm">
-                          <div>{tr("dispatch 상태", "Dispatch status")}: {selectedCard.latest_dispatch_status ?? "-"}</div>
-                          <div>{tr("최신 dispatch", "Latest dispatch")}: {selectedCard.latest_dispatch_id ? `#${selectedCard.latest_dispatch_id.slice(0, 8)}` : "-"}</div>
-                        </div>
-                      )}
-                    </SurfaceCard>
-                  );
-                })()}
-
-                {/* State transition history (audit log) */}
-                {auditLog.length > 0 && (
-                  <SurfaceCard className="space-y-3" style={{ ...SURFACE_PANEL_STYLE }}>
-                    <h4 className="font-medium" style={{ color: "var(--th-text-heading)" }}>
-                      {tr("상태 전환 이력", "State Transition History")}
-                      <span className="ml-2 text-xs font-normal" style={{ color: "var(--th-text-muted)" }}>
-                        ({auditLog.length})
-                      </span>
-                    </h4>
-                    <div className="space-y-1.5 max-h-48 overflow-y-auto">
-                      {auditLog.map((log) => {
-                        const resultPresentation = formatAuditResult(log.result, tr);
-                        return (
-                          <SurfaceCard
-                            key={log.id}
-                            className="space-y-1.5 p-3 text-xs"
-                            style={{ backgroundColor: "rgba(255,255,255,0.03)" }}
-                          >
-                            <div className="flex items-center gap-2">
-                              <span className="shrink-0" style={{ color: "var(--th-text-muted)" }}>
-                                {formatIso(log.created_at, locale)}
-                              </span>
-                              <span
-                                className="ml-auto px-1.5 py-0.5 rounded text-[10px]"
-                                style={{ backgroundColor: "rgba(148,163,184,0.12)", color: "var(--th-text-muted)" }}
-                              >
-                                {log.source}
-                              </span>
-                            </div>
-                            <div className="flex items-center gap-2 flex-wrap">
-                              <span style={{ color: TRANSITION_STYLE[log.from_status ?? ""]?.text ?? "var(--th-text-secondary)" }}>
-                                {log.from_status ? labelForStatus(log.from_status as KanbanCardStatus, tr) : "—"}
-                              </span>
-                              <span style={{ color: "var(--th-text-muted)" }}>→</span>
-                              <span style={{ color: TRANSITION_STYLE[log.to_status ?? ""]?.text ?? "var(--th-text-secondary)" }}>
-                                {log.to_status ? labelForStatus(log.to_status as KanbanCardStatus, tr) : "—"}
-                              </span>
-                            </div>
-                            {resultPresentation && (
-                              <div
-                                className="rounded-md border px-2 py-1.5 text-[11px] leading-relaxed whitespace-pre-wrap break-words"
-                                style={ACTIVITY_RESULT_TONE_STYLE[resultPresentation.tone]}
-                              >
-                                {resultPresentation.text}
-                              </div>
+                        {(parsed.dependencies || parsed.risks) && (
+                          <div className="grid gap-3 xl:col-span-2 md:grid-cols-2">
+                            {parsed.dependencies && (
+                              <SurfaceNotice tone="info" className="items-start">
+                                <div className="space-y-1.5">
+                                  <div className="text-[10px] font-semibold uppercase tracking-widest" style={{ color: "#93c5fd" }}>
+                                    {tr("의존성", "Dependencies")}
+                                  </div>
+                                  <div className="text-sm" style={{ color: "var(--th-text-primary)" }}>
+                                    <MarkdownContent content={parsed.dependencies} />
+                                  </div>
+                                </div>
+                              </SurfaceNotice>
                             )}
-                          </SurfaceCard>
-                        );
-                      })}
+
+                            {parsed.risks && (
+                              <SurfaceNotice tone="danger" className="items-start">
+                                <div className="space-y-1.5">
+                                  <div className="text-[10px] font-semibold uppercase tracking-widest" style={{ color: "#fca5a5" }}>
+                                    {tr("리스크", "Risks")}
+                                  </div>
+                                  <div className="text-sm" style={{ color: "var(--th-text-primary)" }}>
+                                    <MarkdownContent content={parsed.risks} />
+                                  </div>
+                                </div>
+                              </SurfaceNotice>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })()}
+                </SurfaceSection>
+
+                <SurfaceSection
+                  eyebrow={tr("Operational Actions", "Operational Actions")}
+                  title={tr("재전송 · 재시도 · 시간 메타", "Resend · Retry · Time Metadata")}
+                  description={tr(
+                    "재전송, 재시도, 시간 메타를 한 블록에서 함께 판단합니다.",
+                    "Review resend, retry, and timing metadata in one block.",
+                  )}
+                  className="rounded-[28px] p-4 sm:p-5"
+                >
+                  <div className="grid gap-4 xl:grid-cols-3">
+                    {canRedispatchCard(selectedCard) && (
+                      <SurfaceSubsection
+                        title={tr("이슈 변경 후 재전송", "Resend with Updated Issue")}
+                        description={tr(
+                          "본문을 수정한 뒤 기존 dispatch를 취소하고 다시 전송합니다.",
+                          "Cancel the current dispatch and resend after editing the issue body.",
+                        )}
+                      >
+                        <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto]">
+                          <input
+                            type="text"
+                            placeholder={tr("사유 (선택)", "Reason (optional)")}
+                            value={redispatchReason}
+                            onChange={(e) => setRedispatchReason(e.target.value)}
+                            className="w-full rounded-xl border px-3 py-2 text-sm"
+                            style={{ ...SURFACE_FIELD_STYLE, color: "var(--th-text-primary)" }}
+                          />
+                          <SurfaceActionButton
+                            type="button"
+                            onClick={() => void handleRedispatch()}
+                            disabled={redispatching}
+                            tone="warn"
+                            className="whitespace-nowrap px-4 py-2 text-sm"
+                            style={{ background: "#d97706", borderColor: "#d97706", color: "white" }}
+                          >
+                            {redispatching ? tr("전송 중...", "Sending...") : tr("재전송", "Resend")}
+                          </SurfaceActionButton>
+                        </div>
+                      </SurfaceSubsection>
+                    )}
+
+                    {canRetryCard(selectedCard) && (
+                      <SurfaceSubsection
+                        title={tr("재시도 / 담당자 변경", "Retry / Change Assignee")}
+                        description={tr(
+                          "동일 내용으로 재전송하거나 다른 에이전트에게 넘깁니다.",
+                          "Resend as-is or switch the work to another agent.",
+                        )}
+                      >
+                        <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto]">
+                          <select
+                            value={retryAssigneeId}
+                            onChange={(event) => setRetryAssigneeId(event.target.value)}
+                            className="w-full rounded-xl border px-3 py-2 text-sm"
+                            style={{ ...SURFACE_FIELD_STYLE, color: "var(--th-text-primary)" }}
+                          >
+                            {agents.map((agent) => (
+                              <option key={agent.id} value={agent.id}>{getAgentLabel(agent.id)}</option>
+                            ))}
+                          </select>
+                          <SurfaceActionButton
+                            type="button"
+                            onClick={() => void handleRetryCard()}
+                            disabled={retryingCard || !(retryAssigneeId || selectedCard.assignee_agent_id)}
+                            tone="accent"
+                            className="whitespace-nowrap px-4 py-2 text-sm"
+                            style={{ background: "#7c3aed", borderColor: "#7c3aed", color: "white" }}
+                          >
+                            {retryingCard ? tr("전송 중...", "Sending...") : tr("재시도", "Retry")}
+                          </SurfaceActionButton>
+                        </div>
+                      </SurfaceSubsection>
+                    )}
+
+                    <SurfaceSubsection
+                      title={tr("시간 메타", "Time Metadata")}
+                      description={tr(
+                        "카드의 생성부터 완료까지 운영 시간축을 같은 grammar로 요약합니다.",
+                        "Summarize the card lifecycle timestamps in the same grammar.",
+                      )}
+                      className={!canRedispatchCard(selectedCard) && !canRetryCard(selectedCard) ? "xl:col-span-3" : undefined}
+                    >
+                      <div className="grid gap-3 md:grid-cols-2">
+                        <SurfaceCard className="space-y-1.5 p-3" style={{ ...SURFACE_PANEL_STYLE }}>
+                          <div className="text-xs" style={{ color: "var(--th-text-muted)" }}>{tr("생성", "Created")}</div>
+                          <div style={{ color: "var(--th-text-primary)" }}>{formatIso(selectedCard.created_at, locale)}</div>
+                        </SurfaceCard>
+                        <SurfaceCard className="space-y-1.5 p-3" style={{ ...SURFACE_PANEL_STYLE }}>
+                          <div className="text-xs" style={{ color: "var(--th-text-muted)" }}>{tr("요청", "Requested")}</div>
+                          <div style={{ color: "var(--th-text-primary)" }}>{formatIso(selectedCard.requested_at, locale)}</div>
+                        </SurfaceCard>
+                        <SurfaceCard className="space-y-1.5 p-3" style={{ ...SURFACE_PANEL_STYLE }}>
+                          <div className="text-xs" style={{ color: "var(--th-text-muted)" }}>{tr("시작", "Started")}</div>
+                          <div style={{ color: "var(--th-text-primary)" }}>{formatIso(selectedCard.started_at, locale)}</div>
+                        </SurfaceCard>
+                        <SurfaceCard className="space-y-1.5 p-3" style={{ ...SURFACE_PANEL_STYLE }}>
+                          <div className="text-xs" style={{ color: "var(--th-text-muted)" }}>{tr("완료", "Completed")}</div>
+                          <div style={{ color: "var(--th-text-primary)" }}>{formatIso(selectedCard.completed_at, locale)}</div>
+                        </SurfaceCard>
+                      </div>
+                    </SurfaceSubsection>
+                  </div>
+                </SurfaceSection>
+
+                <SurfaceSection
+                  eyebrow={tr("Execution Trace", "Execution Trace")}
+                  title={tr("Dispatch · Audit · Timeline", "Dispatch · Audit · Timeline")}
+                  description={tr(
+                    "실행 결과, 상태 전환, GitHub 코멘트 흐름을 같은 detail shell 안에서 읽습니다.",
+                    "Read dispatch results, state transitions, and GitHub comment flow inside one detail shell.",
+                  )}
+                  className="rounded-[28px] p-4 sm:p-5"
+                >
+                  <div className="space-y-4">
+                    {(() => {
+                      const cardDispatches = dispatches
+                        .filter((d) => d.kanban_card_id === selectedCard.id)
+                        .sort((a, b) => {
+                          const ta = typeof a.created_at === "number" ? a.created_at : new Date(a.created_at).getTime();
+                          const tb = typeof b.created_at === "number" ? b.created_at : new Date(b.created_at).getTime();
+                          return tb - ta;
+                        });
+                      const hasAny = cardDispatches.length > 0 || selectedCard.latest_dispatch_status;
+                      if (!hasAny) return null;
+
+                      const dispatchStatusColor: Record<string, string> = {
+                        pending: "#fbbf24",
+                        dispatched: "#38bdf8",
+                        in_progress: "#f59e0b",
+                        completed: "#4ade80",
+                        failed: "#f87171",
+                        cancelled: "#9ca3af",
+                      };
+
+                      return (
+                        <SurfaceSubsection
+                          title={tr("Dispatch 이력", "Dispatch history")}
+                          description={tr(
+                            "카드에 연결된 dispatch와 결과 요약을 시간 역순으로 표시합니다.",
+                            "Show dispatches linked to this card and their result summaries in reverse time order.",
+                          )}
+                          actions={cardDispatches.length > 0 ? (
+                            <SurfaceMetricPill
+                              tone="info"
+                              label={tr("건수", "Items")}
+                              value={cardDispatches.length}
+                              className="min-w-[76px]"
+                            />
+                          ) : undefined}
+                        >
+                          {parseCardMetadata(selectedCard.metadata_json).timed_out_reason && (
+                            <SurfaceNotice tone="warn" compact className="mb-3">
+                              {parseCardMetadata(selectedCard.metadata_json).timed_out_reason}
+                            </SurfaceNotice>
+                          )}
+
+                          {cardDispatches.length > 0 ? (
+                            <div className="space-y-2 max-h-64 overflow-y-auto">
+                              {cardDispatches.map((d) => (
+                                <SurfaceCard
+                                  key={d.id}
+                                  className="space-y-2 p-3 text-sm"
+                                  style={{ borderColor: "rgba(148,163,184,0.12)", backgroundColor: d.id === selectedCard.latest_dispatch_id ? "rgba(37,99,235,0.08)" : "transparent" }}
+                                >
+                                  <div className="flex items-center gap-2 flex-wrap">
+                                    <span
+                                      className="inline-block h-2 w-2 shrink-0 rounded-full"
+                                      style={{ backgroundColor: dispatchStatusColor[d.status] ?? "#94a3b8" }}
+                                    />
+                                    <span className="font-mono text-xs" style={{ color: "var(--th-text-muted)" }}>
+                                      #{d.id.slice(0, 8)}
+                                    </span>
+                                    <span
+                                      className="rounded px-1.5 py-0.5 text-[10px] font-medium"
+                                      style={{ backgroundColor: "rgba(148,163,184,0.12)", color: dispatchStatusColor[d.status] ?? "#94a3b8" }}
+                                    >
+                                      {d.status}
+                                    </span>
+                                    {d.dispatch_type && (
+                                      <span className="rounded px-1.5 py-0.5 text-[10px]" style={{ backgroundColor: "rgba(148,163,184,0.08)", color: "var(--th-text-secondary)" }}>
+                                        {d.dispatch_type}
+                                      </span>
+                                    )}
+                                    {d.to_agent_id && (
+                                      <span className="text-xs" style={{ color: "var(--th-text-secondary)" }}>
+                                        → {getAgentLabel(d.to_agent_id)}
+                                      </span>
+                                    )}
+                                  </div>
+                                  <div className="mt-1 flex items-center gap-3 text-xs" style={{ color: "var(--th-text-muted)" }}>
+                                    <span>{formatIso(d.created_at, locale)}</span>
+                                    {d.chain_depth > 0 && <span>depth {d.chain_depth}</span>}
+                                  </div>
+                                  {(() => {
+                                    const dispatchSummary = formatDispatchSummary(d.result_summary);
+                                    if (!dispatchSummary) return null;
+                                    return (
+                                      <SurfaceNotice
+                                        compact
+                                        className="mt-1 whitespace-pre-wrap break-words"
+                                        style={{ color: "var(--th-text-secondary)" }}
+                                      >
+                                        {dispatchSummary}
+                                      </SurfaceNotice>
+                                    );
+                                  })()}
+                                </SurfaceCard>
+                              ))}
+                            </div>
+                          ) : (
+                            <div className="grid gap-2 text-sm md:grid-cols-2">
+                              <div>{tr("dispatch 상태", "Dispatch status")}: {selectedCard.latest_dispatch_status ?? "-"}</div>
+                              <div>{tr("최신 dispatch", "Latest dispatch")}: {selectedCard.latest_dispatch_id ? `#${selectedCard.latest_dispatch_id.slice(0, 8)}` : "-"}</div>
+                            </div>
+                          )}
+                        </SurfaceSubsection>
+                      );
+                    })()}
+
+                    {auditLog.length > 0 && (
+                      <SurfaceSubsection
+                        title={tr("상태 전환 이력", "State Transition History")}
+                        description={tr(
+                          "누가 상태를 바꿨는지와 결과 메시지를 추적합니다.",
+                          "Track who changed the state and what result message was produced.",
+                        )}
+                        actions={(
+                          <SurfaceMetricPill
+                            tone="neutral"
+                            label={tr("건수", "Items")}
+                            value={auditLog.length}
+                            className="min-w-[76px]"
+                          />
+                        )}
+                      >
+                        <div className="space-y-1.5 max-h-48 overflow-y-auto">
+                          {auditLog.map((log) => {
+                            const resultPresentation = formatAuditResult(log.result, tr);
+                            return (
+                              <SurfaceCard
+                                key={log.id}
+                                className="space-y-1.5 p-3 text-xs"
+                                style={{ backgroundColor: "rgba(255,255,255,0.03)" }}
+                              >
+                                <div className="flex items-center gap-2">
+                                  <span className="shrink-0" style={{ color: "var(--th-text-muted)" }}>
+                                    {formatIso(log.created_at, locale)}
+                                  </span>
+                                  <span
+                                    className="ml-auto rounded px-1.5 py-0.5 text-[10px]"
+                                    style={{ backgroundColor: "rgba(148,163,184,0.12)", color: "var(--th-text-muted)" }}
+                                  >
+                                    {log.source}
+                                  </span>
+                                </div>
+                                <div className="flex items-center gap-2 flex-wrap">
+                                  <span style={{ color: TRANSITION_STYLE[log.from_status ?? ""]?.text ?? "var(--th-text-secondary)" }}>
+                                    {log.from_status ? labelForStatus(log.from_status as KanbanCardStatus, tr) : "—"}
+                                  </span>
+                                  <span style={{ color: "var(--th-text-muted)" }}>→</span>
+                                  <span style={{ color: TRANSITION_STYLE[log.to_status ?? ""]?.text ?? "var(--th-text-secondary)" }}>
+                                    {log.to_status ? labelForStatus(log.to_status as KanbanCardStatus, tr) : "—"}
+                                  </span>
+                                </div>
+                                {resultPresentation && (
+                                  <div
+                                    className="rounded-md border px-2 py-1.5 text-[11px] leading-relaxed whitespace-pre-wrap break-words"
+                                    style={ACTIVITY_RESULT_TONE_STYLE[resultPresentation.tone]}
+                                  >
+                                    {resultPresentation.text}
+                                  </div>
+                                )}
+                              </SurfaceCard>
+                            );
+                          })}
+                        </div>
+                      </SurfaceSubsection>
+                    )}
+
+                    <SurfaceSubsection
+                      title={tr("활동 타임라인", "Activity Timeline")}
+                      description={tr(
+                        "GitHub 코멘트와 리뷰 흐름을 같은 trace 섹션에서 확인합니다.",
+                        "Inspect GitHub comments and review flow inside the same trace section.",
+                      )}
+                    >
+                      <CardTimeline
+                        ghComments={ghComments}
+                        timelineFilter={timelineFilter}
+                        setTimelineFilter={setTimelineFilter}
+                        tr={tr}
+                        locale={locale}
+                        onRefresh={() => selectedCard && invalidateCardActivity(selectedCard.id)}
+                      />
+                    </SurfaceSubsection>
+                  </div>
+                </SurfaceSection>
+
+                <SurfaceSection
+                  eyebrow={tr("Card Actions", "Card Actions")}
+                  title={tr("저장 · 취소 · 삭제", "Save · Cancel · Delete")}
+                  description={tr(
+                    "최종 저장 전 destructive action과 close/save 흐름을 분리합니다.",
+                    "Separate destructive actions from close/save flow before final persistence.",
+                  )}
+                  className="rounded-[28px] p-4 sm:p-5"
+                  actions={(
+                    <div className="flex flex-col-reverse gap-2 sm:flex-row">
+                      <SurfaceActionButton
+                        onClick={() => setSelectedCardId(null)}
+                        tone="neutral"
+                        className="px-4 py-2 text-sm"
+                        style={{ ...SURFACE_GHOST_BUTTON_STYLE, color: "var(--th-text-secondary)" }}
+                      >
+                        {tr("닫기", "Close")}
+                      </SurfaceActionButton>
+                      <SurfaceActionButton
+                        onClick={() => void handleSaveCard()}
+                        disabled={savingCard || !editor.title.trim()}
+                        tone="accent"
+                        className="px-4 py-2 text-sm"
+                        style={{ background: "#2563eb", borderColor: "#2563eb", color: "white" }}
+                      >
+                        {savingCard ? tr("저장 중", "Saving") : tr("저장", "Save")}
+                      </SurfaceActionButton>
                     </div>
-                  </SurfaceCard>
-                )}
-
-                {/* Unified GitHub comment timeline */}
-                <CardTimeline
-                  ghComments={ghComments}
-                  timelineFilter={timelineFilter}
-                  setTimelineFilter={setTimelineFilter}
-                  tr={tr}
-                  locale={locale}
-                  onRefresh={() => selectedCard && invalidateCardActivity(selectedCard.id)}
-                />
-
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                  <div className="flex gap-2">
+                  )}
+                >
+                  <div className="flex flex-wrap gap-2">
                     <SurfaceActionButton
                       onClick={handleDeleteCard}
                       disabled={savingCard}
@@ -2896,31 +2968,133 @@ export default function KanbanTab({
                       </SurfaceActionButton>
                     )}
                   </div>
-                  <div className="flex flex-col-reverse gap-2 sm:flex-row">
-                    <SurfaceActionButton
-                      onClick={() => setSelectedCardId(null)}
-                      tone="neutral"
-                      className="px-4 py-2 text-sm"
-                      style={{ ...SURFACE_GHOST_BUTTON_STYLE, color: "var(--th-text-secondary)" }}
-                    >
-                      {tr("닫기", "Close")}
-                    </SurfaceActionButton>
-                    <SurfaceActionButton
-                      onClick={() => void handleSaveCard()}
-                      disabled={savingCard || !editor.title.trim()}
-                      tone="accent"
-                      className="px-4 py-2 text-sm"
-                      style={{ background: "#2563eb", borderColor: "#2563eb", color: "white" }}
-                    >
-                      {savingCard ? tr("저장 중", "Saving") : tr("저장", "Save")}
-                    </SurfaceActionButton>
-                  </div>
-                </div>
+                </SurfaceSection>
               </div>
             </div>
           </div>
         )}
       </div>
+
+      {selectedRepo && (
+        <SurfaceSection
+          eyebrow={tr("Extensions", "Extensions")}
+          title={tr("자동 큐 · 파이프라인 · 최근 완료", "Auto Queue · Pipeline · Recent Completions")}
+          description={tr(
+            "시안 밖의 운영 도구는 같은 톤으로 확장하되, 보드 감상 흐름을 방해하지 않도록 뒤쪽으로 배치합니다.",
+            "Extend operating tools in the same tone, but place them after the board so they do not interrupt the primary board flow.",
+          )}
+          className="rounded-[28px] p-4 sm:p-5"
+          style={{
+            borderColor: "color-mix(in srgb, var(--th-border) 74%, transparent)",
+            background:
+              "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 94%, transparent) 0%, color-mix(in srgb, var(--th-bg-surface) 98%, transparent) 100%)",
+          }}
+        >
+          <div className="space-y-4">
+            <AutoQueuePanel
+              tr={tr}
+              locale={locale}
+              agents={agents}
+              selectedRepo={selectedRepo}
+              selectedAgentId={selectedAgentId}
+            />
+
+            <PipelineVisualEditor
+              tr={tr}
+              locale={locale}
+              repo={selectedRepo}
+              agents={agents}
+              selectedAgentId={selectedAgentId}
+            />
+
+            {recentDoneCards.length > 0 && (() => {
+              const PAGE_SIZE = 10;
+              const totalPages = Math.ceil(recentDoneCards.length / PAGE_SIZE);
+              const page = Math.min(recentDonePage, totalPages - 1);
+              const pageCards = recentDoneCards.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+              return (
+                <SurfaceCard
+                  className="rounded-[24px] px-4 py-3"
+                  style={{
+                    borderColor: "color-mix(in srgb, var(--th-accent-primary) 16%, var(--th-border) 84%)",
+                    background: "color-mix(in srgb, var(--th-badge-emerald-bg) 56%, var(--th-card-bg) 44%)",
+                  }}
+                >
+                  <button
+                    onClick={() => setRecentDoneOpen((v) => !v)}
+                    className="flex w-full items-center gap-2 text-left"
+                  >
+                    <span className="text-xs font-semibold uppercase" style={{ color: "var(--th-text-muted)" }}>
+                      {tr("최근 완료", "Recent Completions")}
+                    </span>
+                    <span className="rounded-full px-1.5 py-0.5 text-[10px] font-bold" style={{ background: "rgba(34,197,94,0.18)", color: "#4ade80" }}>
+                      {recentDoneCards.length}
+                    </span>
+                    <span className="ml-auto text-xs" style={{ color: "var(--th-text-muted)" }}>
+                      {recentDoneOpen ? "▲" : "▼"}
+                    </span>
+                  </button>
+                  {recentDoneOpen && (
+                    <div className="mt-2 space-y-1.5">
+                      {pageCards.map((card) => {
+                        const statusDef = COLUMN_DEFS.find((c) => c.status === card.status);
+                        const agentName = getAgentLabel(card.assignee_agent_id);
+                        const completedDate = card.completed_at
+                          ? new Date(card.completed_at).toLocaleDateString(locale === "ko" ? "ko-KR" : "en-US", { month: "short", day: "numeric" })
+                          : "";
+                        return (
+                          <button
+                            key={card.id}
+                            onClick={() => setSelectedCardId(card.id)}
+                            className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm transition-colors hover:brightness-125"
+                            style={{ background: "rgba(148,163,184,0.06)" }}
+                          >
+                            <span
+                              className="shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-semibold"
+                              style={{ background: `${statusDef?.accent ?? "#22c55e"}22`, color: statusDef?.accent ?? "#22c55e" }}
+                            >
+                              {card.status === "done" ? tr("완료", "Done") : tr("취소", "Cancelled")}
+                            </span>
+                            {card.github_issue_number && (
+                              <span className="shrink-0 text-xs" style={{ color: "var(--th-text-muted)" }}>#{card.github_issue_number}</span>
+                            )}
+                            <span className="min-w-0 flex-1 truncate" style={{ color: "var(--th-text-primary)" }}>{card.title}</span>
+                            <span className="shrink-0 text-[11px]" style={{ color: "var(--th-text-muted)" }}>{agentName}</span>
+                            <span className="shrink-0 text-[11px]" style={{ color: "var(--th-text-muted)" }}>{completedDate}</span>
+                          </button>
+                        );
+                      })}
+                      {totalPages > 1 && (
+                        <div className="flex items-center justify-center gap-3 pt-1">
+                          <button
+                            disabled={page === 0}
+                            onClick={() => setRecentDonePage((p) => Math.max(0, p - 1))}
+                            className="rounded px-2 py-0.5 text-xs disabled:opacity-30"
+                            style={{ color: "var(--th-text-muted)" }}
+                          >
+                            ← {tr("이전", "Prev")}
+                          </button>
+                          <span className="text-[11px]" style={{ color: "var(--th-text-muted)" }}>
+                            {page + 1} / {totalPages}
+                          </span>
+                          <button
+                            disabled={page >= totalPages - 1}
+                            onClick={() => setRecentDonePage((p) => Math.min(totalPages - 1, p + 1))}
+                            className="rounded px-2 py-0.5 text-xs disabled:opacity-30"
+                            style={{ color: "var(--th-text-muted)" }}
+                          >
+                            {tr("다음", "Next")} →
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </SurfaceCard>
+              );
+            })()}
+          </div>
+        </SurfaceSection>
+      )}
 
       {assignIssue && (
         <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-center p-0 sm:p-4" style={{ backgroundColor: "var(--th-modal-overlay)" }}>

--- a/dashboard/src/components/agent-manager/useAgentManagerController.ts
+++ b/dashboard/src/components/agent-manager/useAgentManagerController.ts
@@ -1,0 +1,323 @@
+import { useCallback, useEffect, useMemo, useState, type DragEvent } from "react";
+import type { Agent, Department, DispatchedSession } from "../../types";
+import type { UiLanguage } from "../../i18n";
+import * as api from "../../api";
+import { buildSpriteMap } from "../AgentAvatar";
+import { pickRandomSpritePair } from "./utils";
+import { BLANK, ICON_SPRITE_POOL } from "./constants";
+import type { FormData } from "./types";
+
+export type AgentManagerTab = "agents" | "departments" | "backlog" | "dispatch";
+
+interface UseAgentManagerControllerParams {
+  agents: Agent[];
+  departments: Department[];
+  language: UiLanguage;
+  officeId?: string | null;
+  onAgentsChange: () => void;
+  onDepartmentsChange: () => void;
+  sessions?: DispatchedSession[];
+  onAssign?: (id: string, patch: Partial<DispatchedSession>) => Promise<void>;
+  activeTab?: AgentManagerTab;
+  onTabChange?: (tab: AgentManagerTab) => void;
+}
+
+export function useAgentManagerController({
+  agents,
+  departments,
+  language,
+  officeId,
+  onAgentsChange,
+  onDepartmentsChange,
+  sessions,
+  onAssign,
+  activeTab,
+  onTabChange,
+}: UseAgentManagerControllerParams) {
+  const locale = language;
+  const isKo = locale.startsWith("ko");
+  const tr = useCallback(
+    (ko: string, en: string) => (isKo ? ko : en),
+    [isKo],
+  );
+
+  const [internalTab, setInternalTab] = useState<AgentManagerTab>("agents");
+  const [deptTab, setDeptTab] = useState("all");
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [search, setSearch] = useState("");
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [dispatchOpen, setDispatchOpen] = useState(activeTab === "dispatch");
+  const [agentModal, setAgentModal] = useState<{
+    open: boolean;
+    editAgent: Agent | null;
+  }>({ open: false, editAgent: null });
+  const [form, setForm] = useState<FormData>(BLANK);
+  const [deptModal, setDeptModal] = useState<{
+    open: boolean;
+    editDept: Department | null;
+  }>({ open: false, editDept: null });
+  const [deptOrder, setDeptOrder] = useState<Department[]>(departments);
+  const [deptOrderDirty, setDeptOrderDirty] = useState(false);
+  const [reorderSaving, setReorderSaving] = useState(false);
+  const [draggingDeptId, setDraggingDeptId] = useState<string | null>(null);
+  const [dragOverDeptId, setDragOverDeptId] = useState<string | null>(null);
+  const [dragOverPosition, setDragOverPosition] = useState<"before" | "after" | null>(null);
+
+  const tab = activeTab ?? internalTab;
+  const canShowDispatch = Boolean(sessions && onAssign);
+  const resolvedTab = tab === "dispatch" ? "agents" : tab;
+
+  useEffect(() => {
+    if (tab === "dispatch" && canShowDispatch) {
+      setDispatchOpen(true);
+    }
+  }, [canShowDispatch, tab]);
+
+  useEffect(() => {
+    if (deptOrderDirty) return;
+    const currentIds = deptOrder.map((dept) => dept.id).join("|");
+    const nextIds = departments.map((dept) => dept.id).join("|");
+    if (currentIds !== nextIds) {
+      setDeptOrder(departments);
+    }
+  }, [departments, deptOrder, deptOrderDirty]);
+
+  const handleTabChange = useCallback((nextTab: AgentManagerTab) => {
+    if (activeTab === undefined) {
+      setInternalTab(nextTab);
+    }
+    onTabChange?.(nextTab);
+  }, [activeTab, onTabChange]);
+
+  const spriteMap = useMemo(() => buildSpriteMap(agents), [agents]);
+  const randomIconSprites = useMemo(
+    () => ({ total: pickRandomSpritePair(ICON_SPRITE_POOL) }),
+    [],
+  );
+
+  const sortedAgents = useMemo(() => {
+    let filtered = agents;
+    if (deptTab !== "all") {
+      filtered = filtered.filter((agent) => agent.department_id === deptTab);
+    }
+    if (statusFilter !== "all") {
+      filtered = filtered.filter((agent) => agent.status === statusFilter);
+    }
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      filtered = filtered.filter(
+        (agent) =>
+          agent.name.toLowerCase().includes(q) ||
+          agent.name_ko.toLowerCase().includes(q) ||
+          (agent.alias && agent.alias.toLowerCase().includes(q)) ||
+          agent.avatar_emoji.includes(q),
+      );
+    }
+
+    return [...filtered].sort((left, right) => {
+      const statusOrder = { working: 0, idle: 1, break: 2, offline: 3 };
+      const leftStatus = statusOrder[left.status] ?? 4;
+      const rightStatus = statusOrder[right.status] ?? 4;
+      if (leftStatus !== rightStatus) return leftStatus - rightStatus;
+      return left.name.localeCompare(right.name);
+    });
+  }, [agents, deptTab, search, statusFilter]);
+
+  const openCreateAgent = useCallback(() => {
+    setForm(BLANK);
+    setAgentModal({ open: true, editAgent: null });
+  }, []);
+
+  const openEditAgent = useCallback((agent: Agent) => {
+    setForm({
+      name: agent.name,
+      name_ko: agent.name_ko ?? "",
+      name_ja: agent.name_ja ?? "",
+      name_zh: agent.name_zh ?? "",
+      department_id: agent.department_id ?? "",
+      cli_provider: agent.cli_provider ?? "claude",
+      avatar_emoji: agent.avatar_emoji ?? "🤖",
+      sprite_number: agent.sprite_number ?? null,
+      personality: agent.personality ?? "",
+    });
+    setAgentModal({ open: true, editAgent: agent });
+  }, []);
+
+  const handleSaveAgent = useCallback(async () => {
+    setSaving(true);
+    try {
+      const payload: Record<string, unknown> = {
+        name: form.name.trim(),
+        name_ko: form.name_ko.trim() || form.name.trim(),
+        name_ja: form.name_ja.trim() || undefined,
+        name_zh: form.name_zh.trim() || undefined,
+        department_id: form.department_id || null,
+        cli_provider: form.cli_provider,
+        avatar_emoji: form.avatar_emoji,
+        sprite_number: form.sprite_number,
+        personality: form.personality.trim() || null,
+      };
+
+      if (!agentModal.editAgent && officeId) {
+        payload.office_id = officeId;
+      }
+
+      if (agentModal.editAgent) {
+        await api.updateAgent(agentModal.editAgent.id, payload);
+      } else {
+        await api.createAgent(payload);
+      }
+
+      setAgentModal({ open: false, editAgent: null });
+      onAgentsChange();
+    } catch (error) {
+      console.error("Agent save failed:", error);
+    } finally {
+      setSaving(false);
+    }
+  }, [agentModal.editAgent, form, officeId, onAgentsChange]);
+
+  const handleDeleteAgent = useCallback(async (id: string) => {
+    setSaving(true);
+    try {
+      await api.deleteAgent(id);
+      setConfirmDeleteId(null);
+      onAgentsChange();
+    } catch (error) {
+      console.error("Agent delete failed:", error);
+    } finally {
+      setSaving(false);
+    }
+  }, [onAgentsChange]);
+
+  const openCreateDept = useCallback(() => {
+    setDeptModal({ open: true, editDept: null });
+  }, []);
+
+  const openEditDept = useCallback((dept: Department) => {
+    setDeptModal({ open: true, editDept: dept });
+  }, []);
+
+  const handleMoveDept = useCallback((index: number, direction: -1 | 1) => {
+    setDeptOrder((prev) => {
+      const next = [...prev];
+      const target = index + direction;
+      if (target < 0 || target >= next.length) return prev;
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+    setDeptOrderDirty(true);
+  }, []);
+
+  const handleSaveOrder = useCallback(async () => {
+    setReorderSaving(true);
+    try {
+      for (let index = 0; index < deptOrder.length; index += 1) {
+        await api.updateDepartment(deptOrder[index].id, { sort_order: index });
+      }
+      setDeptOrderDirty(false);
+      onDepartmentsChange();
+    } catch (error) {
+      console.error("Order save failed:", error);
+    } finally {
+      setReorderSaving(false);
+    }
+  }, [deptOrder, onDepartmentsChange]);
+
+  const handleCancelOrder = useCallback(() => {
+    setDeptOrder(departments);
+    setDeptOrderDirty(false);
+  }, [departments]);
+
+  const handleDragStart = useCallback((deptId: string, event: DragEvent<HTMLDivElement>) => {
+    setDraggingDeptId(deptId);
+    event.dataTransfer.effectAllowed = "move";
+  }, []);
+
+  const handleDragOver = useCallback((deptId: string, event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+    const rect = event.currentTarget.getBoundingClientRect();
+    const midY = rect.top + rect.height / 2;
+    setDragOverDeptId(deptId);
+    setDragOverPosition(event.clientY < midY ? "before" : "after");
+  }, []);
+
+  const handleDrop = useCallback((targetId: string, _event: DragEvent<HTMLDivElement>) => {
+    if (!draggingDeptId || draggingDeptId === targetId) {
+      setDraggingDeptId(null);
+      setDragOverDeptId(null);
+      setDragOverPosition(null);
+      return;
+    }
+
+    setDeptOrder((prev) => {
+      const next = prev.filter((dept) => dept.id !== draggingDeptId);
+      const targetIndex = next.findIndex((dept) => dept.id === targetId);
+      const insertAt = dragOverPosition === "after" ? targetIndex + 1 : targetIndex;
+      const dragged = prev.find((dept) => dept.id === draggingDeptId);
+      if (dragged) next.splice(insertAt, 0, dragged);
+      return next;
+    });
+
+    setDeptOrderDirty(true);
+    setDraggingDeptId(null);
+    setDragOverDeptId(null);
+    setDragOverPosition(null);
+  }, [draggingDeptId, dragOverPosition]);
+
+  const handleDragEnd = useCallback(() => {
+    setDraggingDeptId(null);
+    setDragOverDeptId(null);
+    setDragOverPosition(null);
+  }, []);
+
+  return {
+    canShowDispatch,
+    confirmDeleteId,
+    deptModal,
+    deptOrder,
+    deptOrderDirty,
+    deptTab,
+    draggingDeptId,
+    dragOverDeptId,
+    dragOverPosition,
+    form,
+    agentModal,
+    handleCancelOrder,
+    handleDeleteAgent,
+    handleDragEnd,
+    handleDragOver,
+    handleDragStart,
+    handleDrop,
+    handleMoveDept,
+    handleSaveAgent,
+    handleSaveOrder,
+    handleTabChange,
+    isKo,
+    locale,
+    dispatchOpen,
+    openCreateAgent,
+    openCreateDept,
+    openEditAgent,
+    openEditDept,
+    randomIconSprites,
+    reorderSaving,
+    resolvedTab,
+    saving,
+    search,
+    setAgentModal,
+    setConfirmDeleteId,
+    setDeptModal,
+    setDeptTab,
+    setForm,
+    setDispatchOpen,
+    setSearch,
+    setStatusFilter,
+    sortedAgents,
+    spriteMap,
+    statusFilter,
+    tr,
+  };
+}

--- a/dashboard/src/components/common/SurfacePrimitives.tsx
+++ b/dashboard/src/components/common/SurfacePrimitives.tsx
@@ -363,15 +363,12 @@ export function SurfaceMetricPill({
   );
 }
 
-interface SurfaceTabCardProps {
+interface SurfaceTabCardProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "title"> {
   title: string;
   description: string;
   count?: ReactNode;
   active?: boolean;
   tone?: SurfaceTone;
-  onClick?: () => void;
-  className?: string;
-  style?: CSSProperties;
 }
 
 export function SurfaceTabCard({
@@ -383,6 +380,7 @@ export function SurfaceTabCard({
   onClick,
   className,
   style,
+  ...buttonProps
 }: SurfaceTabCardProps) {
   const chrome = getToneChrome(tone);
 
@@ -390,6 +388,7 @@ export function SurfaceTabCard({
     <button
       type="button"
       onClick={onClick}
+      {...buttonProps}
       className={joinClasses(
         "w-full min-w-0 rounded-2xl border px-4 py-3 text-left transition-colors sm:w-auto sm:min-w-[180px]",
         className,
@@ -550,7 +549,7 @@ export function SurfaceListItem({
   );
 }
 
-interface SurfaceMetaBadgeProps {
+interface SurfaceMetaBadgeProps extends HTMLAttributes<HTMLSpanElement> {
   children: ReactNode;
   tone?: SurfaceTone;
   className?: string;
@@ -562,11 +561,13 @@ export function SurfaceMetaBadge({
   tone = "neutral",
   className,
   style,
+  ...rest
 }: SurfaceMetaBadgeProps) {
   const chrome = getToneChrome(tone);
 
   return (
     <span
+      {...rest}
       className={joinClasses(
         "inline-flex items-center rounded-full border px-2 py-1 text-[11px] leading-none",
         className,

--- a/dashboard/src/components/office-view/OfficeInsightPanel.tsx
+++ b/dashboard/src/components/office-view/OfficeInsightPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, type ReactNode } from "react";
 import type { Notification } from "../NotificationCenter";
-import type { Agent, AuditLogEntry, KanbanCard } from "../../types";
+import type { Agent, AuditLogEntry, KanbanCard, RoundTableMeeting } from "../../types";
 import { getAgentWarnings } from "../../agent-insights";
 import { getFontFamilyForText } from "../../lib/fonts";
 import AgentAvatar from "../AgentAvatar";
@@ -8,6 +8,10 @@ import {
   getProviderLevelColors,
   getProviderMeta,
 } from "../../app/providerTheme";
+import type {
+  OfficeManualIntervention,
+  OfficeSeatStatus,
+} from "./officeAgentState";
 import {
   SurfaceActionButton,
   SurfaceCard,
@@ -15,7 +19,13 @@ import {
   SurfaceMetricPill,
   SurfaceNotice,
   SurfaceSection,
+  SurfaceSubsection,
 } from "../common/SurfacePrimitives";
+
+const SURFACE_FIELD_STYLE = {
+  background: "color-mix(in srgb, var(--th-bg-surface) 92%, transparent)",
+  borderColor: "color-mix(in srgb, var(--th-border) 72%, transparent)",
+} as const;
 
 interface OfficeInsightPanelProps {
   agents: Agent[];
@@ -25,6 +35,12 @@ interface OfficeInsightPanelProps {
   onNavigateToKanban?: () => void;
   isKo: boolean;
   onSelectAgent?: (agent: Agent) => void;
+  selectedAgent?: Agent | null;
+  onClearSelectedAgent?: () => void;
+  activeMeeting?: RoundTableMeeting | null;
+  manualInterventionByAgent?: Map<string, OfficeManualIntervention>;
+  primaryCardByAgent?: Map<string, KanbanCard>;
+  seatStatusByAgent?: Map<string, OfficeSeatStatus>;
   docked?: boolean;
 }
 
@@ -60,6 +76,12 @@ export default function OfficeInsightPanel({
   onNavigateToKanban,
   isKo,
   onSelectAgent,
+  selectedAgent = null,
+  onClearSelectedAgent,
+  activeMeeting = null,
+  manualInterventionByAgent,
+  primaryCardByAgent,
+  seatStatusByAgent,
   docked = false,
 }: OfficeInsightPanelProps) {
   const [mobileExpanded, setMobileExpanded] = useState(false);
@@ -100,6 +122,8 @@ export default function OfficeInsightPanel({
     } catch { /* ignore */ }
   };
   const warningCount = agents.filter((agent) => getAgentWarnings(agent).length > 0).length;
+  const workingCount = Array.from(seatStatusByAgent?.values() ?? []).filter((status) => status === "working").length;
+  const meetingCount = activeMeeting ? 1 : 0;
   const warningAgents = agents
     .map((agent) => ({ agent, warnings: getAgentWarnings(agent) }))
     .filter((entry) => entry.warnings.length > 0);
@@ -128,14 +152,41 @@ export default function OfficeInsightPanel({
       : fallbackNotifications.length > 0
         ? fallbackNotifications
         : changeFallbackNotifications;
-  const rootClassName = docked
-    ? "relative z-20 w-full pointer-events-auto"
-    : "relative z-20 mb-3 px-3 pt-3 pointer-events-auto sm:absolute sm:left-auto sm:right-3 sm:top-3 sm:mb-0 sm:w-[min(22rem,calc(100vw-1.5rem))] sm:px-0 sm:pt-0";
   const sectionEyebrow = isKo ? "오피스 상황판" : "Office pulse";
   const sectionTitle = isKo ? "오피스 운영 신호" : "Office operations";
   const sectionDescription = isKo
     ? "리뷰, 완료, 열린 이슈, 경고 에이전트를 같은 표면에서 빠르게 확인합니다."
     : "Review, closed issues, open work, and warning agents from one surface.";
+  const selectedCard = selectedAgent ? primaryCardByAgent?.get(selectedAgent.id) ?? null : null;
+  const selectedManual = selectedAgent ? manualInterventionByAgent?.get(selectedAgent.id) ?? null : null;
+  const selectedSeatStatus = selectedAgent
+    ? seatStatusByAgent?.get(selectedAgent.id) ?? inferSeatStatus(selectedAgent)
+    : null;
+  const rootClassName = docked
+    ? "relative z-20 flex w-full flex-col gap-3 pointer-events-auto"
+    : "relative z-20 mb-3 flex flex-col gap-3 px-3 pt-3 pointer-events-auto sm:absolute sm:left-auto sm:right-3 sm:top-3 sm:mb-0 sm:w-[min(22rem,calc(100vw-1.5rem))] sm:px-0 sm:pt-0";
+  const heroSection = selectedAgent ? (
+    <SelectedAgentCard
+      agent={selectedAgent}
+      seatStatus={selectedSeatStatus}
+      selectedCard={selectedCard}
+      selectedManual={selectedManual}
+      activeMeeting={activeMeeting}
+      isKo={isKo}
+      onNavigateToKanban={onNavigateToKanban}
+      onClear={onClearSelectedAgent}
+    />
+  ) : (
+    <OfficeSummaryCard
+      reviewCount={reviewCount}
+      openIssueCount={openIssueCount}
+      warningCount={warningCount}
+      workingCount={workingCount}
+      meetingCount={meetingCount}
+      isKo={isKo}
+    />
+  );
+  const providerHealthCard = <ProviderHealthCard isKo={isKo} />;
   const situationBody = (
     <>
       <div className="mt-4 grid grid-cols-3 gap-2">
@@ -183,9 +234,12 @@ export default function OfficeInsightPanel({
 
   return (
     <div className={rootClassName}>
+      {heroSection}
+      {providerHealthCard}
+
       <div className="sm:hidden">
         <SurfaceSection
-          eyebrow={sectionEyebrow}
+          eyebrow={isKo ? "확장" : "Extension"}
           title={sectionTitle}
           description={sectionDescription}
           className="rounded-[24px] p-4"
@@ -266,7 +320,7 @@ export default function OfficeInsightPanel({
 
       <div className="hidden sm:flex sm:flex-col sm:gap-3">
         <SurfaceSection
-          eyebrow={sectionEyebrow}
+          eyebrow={isKo ? "확장" : "Extension"}
           title={sectionTitle}
           description={sectionDescription}
           className="rounded-[24px] p-4"
@@ -333,6 +387,232 @@ export default function OfficeInsightPanel({
   );
 }
 
+function inferSeatStatus(agent: Agent): OfficeSeatStatus {
+  if (agent.status === "offline") return "offline";
+  if (agent.status === "working") return "working";
+  return "idle";
+}
+
+function seatStatusLabel(status: OfficeSeatStatus | null, isKo: boolean): string {
+  switch (status) {
+    case "working":
+      return isKo ? "작업 중" : "Working";
+    case "review":
+      return isKo ? "리뷰 중" : "Review";
+    case "offline":
+      return isKo ? "오프라인" : "Offline";
+    case "idle":
+    default:
+      return isKo ? "대기" : "Idle";
+  }
+}
+
+function statusTone(status: OfficeSeatStatus | null): "neutral" | "info" | "success" | "warn" {
+  switch (status) {
+    case "working":
+      return "success";
+    case "review":
+      return "warn";
+    case "offline":
+      return "neutral";
+    case "idle":
+    default:
+      return "info";
+  }
+}
+
+function formatCompactNumber(value: number): string {
+  if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(1)}B`;
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return String(value);
+}
+
+function SelectedAgentCard({
+  agent,
+  seatStatus,
+  selectedCard,
+  selectedManual,
+  activeMeeting,
+  isKo,
+  onNavigateToKanban,
+  onClear,
+}: {
+  agent: Agent;
+  seatStatus: OfficeSeatStatus | null;
+  selectedCard: KanbanCard | null;
+  selectedManual: OfficeManualIntervention | null;
+  activeMeeting: RoundTableMeeting | null;
+  isKo: boolean;
+  onNavigateToKanban?: () => void;
+  onClear?: () => void;
+}) {
+  const provider = getProviderMeta(agent.cli_provider ?? null);
+  const displayName = agent.alias || agent.name_ko || agent.name;
+  const departmentName = agent.department_name_ko || agent.department_name || (isKo ? "미배정" : "Unassigned");
+  const currentTask = selectedCard?.title || agent.session_info || (isKo ? "현재 작업 없음" : "No active task");
+
+  return (
+    <SurfaceSection
+      eyebrow={isKo ? "선택된 에이전트" : "Selected agent"}
+      title={displayName}
+      description={`${departmentName} · ${agent.role_id ?? provider.label}`}
+      className="rounded-[24px] p-4"
+      actions={(
+        <div className="flex items-center gap-2">
+          <SurfaceMetricPill
+            label={isKo ? "상태" : "Status"}
+            value={seatStatusLabel(seatStatus, isKo)}
+            tone={statusTone(seatStatus)}
+          />
+          <SurfaceActionButton tone="neutral" compact onClick={onClear}>
+            {isKo ? "닫기" : "Close"}
+          </SurfaceActionButton>
+        </div>
+      )}
+      style={{
+        borderColor: `color-mix(in srgb, ${provider.color} 22%, var(--th-border) 78%)`,
+        background:
+          `linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 94%, ${provider.bg} 6%) 0%, color-mix(in srgb, var(--th-bg-surface) 97%, transparent) 100%)`,
+      }}
+    >
+      <div className="mt-2 flex items-start gap-3">
+        <AgentAvatar agent={agent} size={44} rounded="2xl" />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className="inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-medium"
+              style={{
+                borderColor: provider.border,
+                background: provider.bg,
+                color: provider.color,
+              }}
+            >
+              {provider.label}
+            </span>
+            <span className="text-xs" style={{ color: "var(--th-text-muted)" }}>
+              {agent.stats_tokens ? `${formatCompactNumber(agent.stats_tokens)} tokens` : (isKo ? "토큰 집계 대기" : "Token metrics pending")}
+            </span>
+          </div>
+          <div className="mt-3 rounded-2xl border px-3 py-3" style={SURFACE_FIELD_STYLE}>
+            <div className="text-[11px] uppercase tracking-[0.18em]" style={{ color: "var(--th-text-faint)" }}>
+              {isKo ? "지금 작업" : "Current work"}
+            </div>
+            <div className="mt-1 text-sm leading-6" style={{ color: "var(--th-text-primary)" }}>
+              {currentTask}
+            </div>
+            {selectedCard?.github_issue_number ? (
+              <div className="mt-2 text-xs" style={{ color: "var(--th-text-muted)" }}>
+                #{selectedCard.github_issue_number} · {selectedCard.github_repo ?? "GitHub"}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-3 grid grid-cols-2 gap-2">
+        <SurfaceMetricPill
+          label={isKo ? "XP" : "XP"}
+          value={formatCompactNumber(agent.stats_xp)}
+          tone="accent"
+        />
+        <SurfaceMetricPill
+          label={isKo ? "작업 수" : "Tasks"}
+          value={String(agent.stats_tasks_done)}
+          tone="info"
+        />
+      </div>
+
+      {selectedManual ? (
+        <SurfaceNotice className="mt-3" tone="warn">
+          <div className="text-xs font-medium">
+            {isKo ? "수동 개입 필요" : "Manual intervention required"}
+          </div>
+          <div className="mt-1 text-xs leading-relaxed">
+            {selectedManual.reason || selectedManual.title}
+          </div>
+        </SurfaceNotice>
+      ) : null}
+
+      {activeMeeting ? (
+        <SurfaceNotice className="mt-3" tone="info">
+          <div className="text-xs font-medium">
+            {isKo ? "회의 진행 중" : "Meeting in progress"}
+          </div>
+          <div className="mt-1 text-xs leading-relaxed">
+            {activeMeeting.agenda}
+          </div>
+        </SurfaceNotice>
+      ) : null}
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {selectedCard && onNavigateToKanban ? (
+          <SurfaceActionButton compact onClick={onNavigateToKanban}>
+            {isKo ? "칸반 열기" : "Open Kanban"}
+          </SurfaceActionButton>
+        ) : null}
+      </div>
+    </SurfaceSection>
+  );
+}
+
+function OfficeSummaryCard({
+  reviewCount,
+  openIssueCount,
+  warningCount,
+  workingCount,
+  meetingCount,
+  isKo,
+}: {
+  reviewCount: number;
+  openIssueCount: number;
+  warningCount: number;
+  workingCount: number;
+  meetingCount: number;
+  isKo: boolean;
+}) {
+  return (
+    <SurfaceSection
+      eyebrow={isKo ? "오피스" : "Office"}
+      title={isKo ? "오피스 운영 신호" : "Office pulse"}
+      description={isKo ? "선택된 에이전트가 없을 때 전체 상황을 먼저 보여줍니다." : "Show the room summary when no agent is selected."}
+      className="rounded-[24px] p-4"
+      style={{
+        borderColor: "color-mix(in srgb, var(--th-accent-primary) 14%, var(--th-border) 86%)",
+        background:
+          "linear-gradient(180deg, color-mix(in srgb, var(--th-card-bg) 95%, var(--th-accent-primary-soft) 5%) 0%, color-mix(in srgb, var(--th-bg-surface) 96%, transparent) 100%)",
+      }}
+    >
+      <div className="mt-1 grid grid-cols-2 gap-2">
+        <SurfaceMetricPill label={isKo ? "작업 중" : "Working"} value={String(workingCount)} tone="success" />
+        <SurfaceMetricPill label={isKo ? "리뷰" : "Review"} value={String(reviewCount)} tone="warn" />
+        <SurfaceMetricPill label={isKo ? "열린 이슈" : "Open"} value={String(openIssueCount)} tone="info" />
+        <SurfaceMetricPill label={isKo ? "경고" : "Warnings"} value={String(warningCount)} tone={warningCount > 0 ? "warn" : "neutral"} />
+      </div>
+      <div className="mt-3 rounded-2xl border px-3 py-3" style={SURFACE_FIELD_STYLE}>
+        <div className="text-[11px] uppercase tracking-[0.18em]" style={{ color: "var(--th-text-faint)" }}>
+          {isKo ? "회의 상태" : "Meeting status"}
+        </div>
+        <div className="mt-1 text-sm" style={{ color: "var(--th-text-primary)" }}>
+          {meetingCount > 0 ? (isKo ? `${meetingCount}개 진행 중` : `${meetingCount} active`) : (isKo ? "진행 중인 회의 없음" : "No active meeting")}
+        </div>
+      </div>
+    </SurfaceSection>
+  );
+}
+
+function ProviderHealthCard({ isKo }: { isKo: boolean }) {
+  return (
+    <SurfaceSubsection
+      title={isKo ? "프로바이더 상태" : "Provider health"}
+      description={isKo ? "버킷 사용량과 stale 상태를 같은 톤으로 확인합니다." : "Check bucket utilization and stale telemetry in one place."}
+      className="rounded-[24px]"
+    >
+      <MiniRateLimitBar isKo={isKo} />
+    </SurfaceSubsection>
+  );
+}
+
 function InsightCard({
   title,
   count,
@@ -343,23 +623,24 @@ function InsightCard({
   children: ReactNode;
 }) {
   return (
-    <SurfaceCard
-      className="rounded-[24px] p-4"
-      style={{
-        borderColor: "color-mix(in srgb, var(--th-border) 66%, transparent)",
-        background: "color-mix(in srgb, var(--th-card-bg) 90%, transparent)",
-      }}
-    >
-      <div className="flex items-center justify-between">
-        <div className="text-xs font-semibold uppercase tracking-[0.24em]" style={{ color: "var(--th-text-muted)" }}>
-          {title}
-        </div>
-        <span className="text-xs" style={{ color: "var(--th-text-muted)" }}>
+    <SurfaceSubsection
+      title={title}
+      className="rounded-[24px]"
+      actions={(
+        <span
+          className="inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-medium"
+          style={{
+            borderColor: "color-mix(in srgb, var(--th-border) 70%, transparent)",
+            background: "color-mix(in srgb, var(--th-card-bg) 82%, transparent)",
+            color: "var(--th-text-muted)",
+          }}
+        >
           {count}
         </span>
-      </div>
+      )}
+    >
       {children}
-    </SurfaceCard>
+    </SurfaceSubsection>
   );
 }
 
@@ -405,10 +686,11 @@ function WarningList({
   onSelectAgent?: (agent: Agent) => void;
 }) {
   return (
-    <SurfaceCard className="mt-3 p-3">
-      <div className="text-xs font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--th-text-muted)" }}>
-        {isKo ? "문제 agent" : "Warning agents"}
-      </div>
+    <SurfaceSubsection
+      title={isKo ? "문제 agent" : "Warning agents"}
+      description={isKo ? "주의 신호가 있는 에이전트를 바로 열 수 있습니다." : "Open agents with active warning signals."}
+      className="mt-3"
+    >
       {items.length === 0 ? (
         <SurfaceNotice className="mt-2" compact>
           {isKo ? "현재 경고가 없습니다" : "No warnings right now"}
@@ -450,7 +732,7 @@ function WarningList({
           ))}
         </div>
       )}
-    </SurfaceCard>
+    </SurfaceSubsection>
   );
 }
 
@@ -507,13 +789,12 @@ interface ClosedIssueItem {
 function ClosedIssueList({ issues, isKo, onClose }: { issues: ClosedIssueItem[]; isKo: boolean; onClose: () => void }) {
   const repoShort = (repo: string) => repo.split("/").pop() || repo;
   return (
-    <SurfaceCard className="mt-3 p-3">
-      <div className="flex items-center justify-between">
-        <div className="text-xs font-semibold uppercase tracking-[0.18em]" style={{ color: "var(--th-text-muted)" }}>
-          {isKo ? `오늘 완료 (${issues.length})` : `Closed today (${issues.length})`}
-        </div>
-        <SurfaceActionButton tone="neutral" compact onClick={onClose}>✕</SurfaceActionButton>
-      </div>
+    <SurfaceSubsection
+      title={isKo ? "오늘 완료" : "Closed today"}
+      description={isKo ? "오늘 GitHub에서 닫힌 이슈를 빠르게 훑습니다." : "Quick scan of GitHub issues closed today."}
+      className="mt-3"
+      actions={<SurfaceActionButton tone="neutral" compact onClick={onClose}>✕</SurfaceActionButton>}
+    >
       {issues.length === 0 ? (
         <SurfaceNotice className="mt-2" compact>
           {isKo ? "오늘 완료된 이슈가 없습니다" : "No issues closed today"}
@@ -550,7 +831,7 @@ function ClosedIssueList({ issues, isKo, onClose }: { issues: ClosedIssueItem[];
           ))}
         </div>
       )}
-    </SurfaceCard>
+    </SurfaceSubsection>
   );
 }
 


### PR DESCRIPTION
## Summary
- restore dashboard screens to the Claude design handoff structure and tone while wiring the existing runtime data and actions back in
- keep legacy dashboard-only features as extensions in the same design language instead of bending the reference layout
- fix the office insight rail and stabilize smoke coverage against the reworked shell

## Validation
- `cd dashboard && npm run build`
- `cd dashboard && npx playwright test e2e/smoke.spec.ts --reporter=line`
  - `27 passed, 11 skipped`

## Scope
- `dashboard/src/app/AppShell.tsx`
- `dashboard/src/components/DashboardPageView.tsx`
- `dashboard/src/components/StatsPageView.tsx`
- `dashboard/src/components/OpsPageView.tsx`
- `dashboard/src/components/MeetingsAndSkillsPage.tsx`
- `dashboard/src/components/AgentManagerView.tsx`
- `dashboard/src/components/OfficeView.tsx`
- `dashboard/src/components/SettingsView.tsx`
- `dashboard/src/components/agent-manager/KanbanTab.tsx`
- related shared primitives and supporting dashboard components