### PR TITLE
Add SSE stream for /api/v1

### DIFF
--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use axum::body::Body;
+use axum::body::{Body, HttpBody as _};
 use axum::http::{Request, StatusCode};
 use libsql_rusqlite::OptionalExtension;
 use serde_json::json;
@@ -8,6 +8,7 @@ use std::ffi::OsString;
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+use std::pin::Pin;
 use std::process::Command;
 use std::sync::Arc;
 use std::sync::MutexGuard;
@@ -71,6 +72,28 @@ fn test_api_router_with_pg(
     let tx = crate::server::ws::new_broadcast();
     let buf = crate::server::ws::spawn_batch_flusher(tx.clone());
     api_router_with_pg(db, engine, config, tx, buf, health_registry, Some(pg_pool))
+}
+
+async fn read_sse_body_until(body: &mut Body, needles: &[&str]) -> String {
+    let mut output = String::new();
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
+
+    while !needles.iter().all(|needle| output.contains(needle)) {
+        let frame = tokio::time::timeout_at(
+            deadline,
+            futures::future::poll_fn(|cx| Pin::new(&mut *body).poll_frame(cx)),
+        )
+        .await
+        .expect("timed out waiting for SSE frame")
+        .expect("stream should still be open")
+        .expect("stream frame should be readable");
+
+        if let Ok(data) = frame.into_data() {
+            output.push_str(&String::from_utf8_lossy(&data));
+        }
+    }
+
+    output
 }
 
 struct TestPostgresDb {
@@ -20624,6 +20647,206 @@ async fn v1_routes_pg_surface_dashboard_contract() {
     assert_eq!(settings_patch_json["key"], json!("merge_strategy"));
     assert_eq!(settings_patch_json["value"], json!("rebase"));
     assert_eq!(settings_patch_json["live_override"]["active"], json!(true));
+
+    pg_pool.close().await;
+    pg_db.drop().await;
+}
+
+#[tokio::test]
+async fn v1_stream_pg_emits_snapshot_and_replays_shared_bus_events() {
+    let db = test_db();
+    let pg_db = TestPostgresDb::create().await;
+    let pg_pool = pg_db.connect_and_migrate().await;
+    let engine = test_engine_with_pg(&db, pg_pool.clone());
+
+    sqlx::query("INSERT INTO github_repos (id, display_name) VALUES ($1, $1)")
+        .bind("repo-v1-stream")
+        .execute(&pg_pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO agents (
+            id, name, provider, status, xp, avatar_emoji, discord_channel_id, discord_channel_alt
+         ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8
+         )",
+    )
+    .bind("agent-v1-stream")
+    .bind("V1 Stream Agent")
+    .bind("claude")
+    .bind("working")
+    .bind(60_i64)
+    .bind("🤖")
+    .bind("111")
+    .bind("222")
+    .execute(&pg_pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO kanban_cards (
+            id, repo_id, title, status, priority, assigned_agent_id, github_issue_number, created_at, updated_at
+         ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7, NOW(), NOW()
+         )",
+    )
+    .bind("card-v1-stream")
+    .bind("repo-v1-stream")
+    .bind("Stream Card")
+    .bind("in_progress")
+    .bind("high")
+    .bind("agent-v1-stream")
+    .bind(792_i64)
+    .execute(&pg_pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO task_dispatches (
+            id, kanban_card_id, to_agent_id, dispatch_type, status, title, created_at, updated_at
+         ) VALUES (
+            $1, $2, $3, $4, $5, $6, NOW(), NOW()
+         )",
+    )
+    .bind("dispatch-v1-stream")
+    .bind("card-v1-stream")
+    .bind("agent-v1-stream")
+    .bind("implementation")
+    .bind("dispatched")
+    .bind("Stream dispatch")
+    .execute(&pg_pool)
+    .await
+    .unwrap();
+    sqlx::query("UPDATE kanban_cards SET latest_dispatch_id = $1 WHERE id = $2")
+        .bind("dispatch-v1-stream")
+        .bind("card-v1-stream")
+        .execute(&pg_pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO sessions (
+            session_key, agent_id, provider, status, active_dispatch_id, session_info, tokens,
+            last_heartbeat, thread_channel_id, created_at
+         ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7, NOW(), $8, NOW()
+         )",
+    )
+    .bind("host:session-v1-stream")
+    .bind("agent-v1-stream")
+    .bind("claude")
+    .bind("working")
+    .bind("dispatch-v1-stream")
+    .bind("v1 stream session")
+    .bind(321_i64)
+    .bind("222000000000002")
+    .execute(&pg_pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO kanban_audit_logs (card_id, from_status, to_status, source, result, created_at)
+         VALUES ($1, $2, $3, $4, $5, NOW())",
+    )
+    .bind("card-v1-stream")
+    .bind("requested")
+    .bind("in_progress")
+    .bind("dispatch")
+    .bind("ok")
+    .execute(&pg_pool)
+    .await
+    .unwrap();
+
+    let tx = crate::server::ws::new_broadcast();
+    let buf = crate::server::ws::spawn_batch_flusher(tx.clone());
+    let app = axum::Router::new().nest(
+        "/api",
+        api_router_with_pg(
+            db,
+            engine,
+            crate::config::Config::default(),
+            tx.clone(),
+            buf,
+            None,
+            Some(pg_pool.clone()),
+        ),
+    );
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/stream")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value.starts_with("text/event-stream"))
+    );
+    assert_eq!(response.headers().get("cache-control").unwrap(), "no-store");
+
+    let mut body = response.into_body();
+    let snapshot = read_sse_body_until(
+        &mut body,
+        &[
+            "event: agent.status",
+            "event: token.tick",
+            "event: achievement.unlocked",
+            "event: kanban.transition",
+            "event: ops.health",
+        ],
+    )
+    .await;
+
+    assert!(snapshot.contains("\"agent_id\":\"agent-v1-stream\""));
+    assert!(snapshot.contains("\"delta_tokens\":321"));
+    assert!(snapshot.contains("\"achievement_id\""));
+    assert!(snapshot.contains("\"from\":\"requested\""));
+    assert!(snapshot.contains("\"status\":\"ok\""));
+    drop(body);
+
+    crate::server::ws::emit_event(
+        &tx,
+        "agent.status",
+        json!({
+            "agent_id": "agent-v1-stream",
+            "status": "idle",
+            "task": null,
+        }),
+    );
+    crate::server::ws::emit_event(
+        &tx,
+        "token.tick",
+        json!({
+            "agent_id": "agent-v1-stream",
+            "delta_tokens": 7,
+            "delta_cost_usd": "0.12",
+        }),
+    );
+
+    let replay_response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/stream")
+                .header("Last-Event-ID", "1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(replay_response.status(), StatusCode::OK);
+
+    let mut replay_body = replay_response.into_body();
+    let replay = read_sse_body_until(
+        &mut replay_body,
+        &["id: 2", "event: token.tick", "\"delta_tokens\":7"],
+    )
+    .await;
+    assert!(replay.contains("\"delta_cost_usd\":\"0.12\""));
 
     pg_pool.close().await;
     pg_db.drop().await;

--- a/src/server/routes/v1.rs
+++ b/src/server/routes/v1.rs
@@ -1,15 +1,19 @@
 use axum::{
     Json, Router, body,
     extract::{Path, Query, State},
-    http::{HeaderValue, StatusCode, header},
-    response::{IntoResponse, Response},
+    http::{HeaderMap, HeaderValue, StatusCode, header},
+    response::{
+        IntoResponse, Response,
+        sse::{Event, KeepAlive, Sse},
+    },
     routing::{get, patch},
 };
 use chrono::{DateTime, Duration, Local, NaiveDateTime, SecondsFormat, TimeZone, Utc};
+use futures::stream::{self, StreamExt};
 use serde::Deserialize;
 use serde_json::{Value, json};
 use sqlx::Row;
-use std::collections::HashMap;
+use std::{collections::HashMap, convert::Infallible, time::Duration as StdDuration};
 
 use super::{
     ApiRouter, AppState, health_api, protected_api_domain,
@@ -98,6 +102,13 @@ struct CursorMarker {
     cursor_id: String,
 }
 
+#[derive(Debug, Clone)]
+struct StreamEnvelope {
+    id: String,
+    event: String,
+    data: Value,
+}
+
 pub(crate) fn router(state: AppState) -> ApiRouter {
     protected_api_domain(
         Router::new()
@@ -106,6 +117,7 @@ pub(crate) fn router(state: AppState) -> ApiRouter {
             .route("/v1/tokens", get(tokens))
             .route("/v1/kanban", get(kanban))
             .route("/v1/ops/health", get(ops_health))
+            .route("/v1/stream", get(stream))
             .route("/v1/activity", get(activity))
             .route("/v1/achievements", get(achievements))
             .route("/v1/settings", get(get_settings))
@@ -214,6 +226,66 @@ async fn ops_health(State(state): State<AppState>) -> Response {
     };
     payload["bottlenecks"] = Value::Array(build_bottlenecks(&payload));
     json_response(status, CACHE_OPS, payload)
+}
+
+async fn stream(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    let last_event_id = headers
+        .get("last-event-id")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+
+    let replay = last_event_id
+        .as_deref()
+        .map(|last_id| state.broadcast_tx.replay_since(last_id))
+        .unwrap_or_default();
+    let snapshot = if last_event_id.is_some() && !replay.is_empty() {
+        Vec::new()
+    } else {
+        match build_stream_snapshot(state.clone()).await {
+            Ok(snapshot) => snapshot,
+            Err(response) => return response,
+        }
+    };
+    let live_stream = stream::unfold(state.broadcast_tx.subscribe(), |mut rx| async move {
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    if let Some(mapped) = map_live_stream_event(event) {
+                        break Some((Ok::<_, Infallible>(to_sse_event(mapped)), rx));
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    tracing::debug!(skipped, "sse stream lagged");
+                    continue;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break None,
+            }
+        }
+    });
+    let initial_stream = stream::iter(
+        snapshot
+            .into_iter()
+            .chain(
+                replay
+                    .into_iter()
+                    .filter_map(map_live_stream_event)
+                    .collect::<Vec<_>>(),
+            )
+            .map(|event| Ok::<_, Infallible>(to_sse_event(event))),
+    );
+    let sse = Sse::new(initial_stream.chain(live_stream)).keep_alive(
+        KeepAlive::new()
+            .interval(StdDuration::from_secs(15))
+            .text("keepalive"),
+    );
+
+    (
+        [(header::CACHE_CONTROL, HeaderValue::from_static("no-store"))],
+        sse,
+    )
+        .into_response()
 }
 
 async fn activity(State(state): State<AppState>, Query(query): Query<ActivityQuery>) -> Response {
@@ -367,6 +439,221 @@ async fn patch_setting(
     };
 
     json_response(StatusCode::OK, CACHE_SETTINGS, entry)
+}
+
+fn to_sse_event(event: StreamEnvelope) -> Event {
+    Event::default()
+        .id(event.id)
+        .event(event.event)
+        .data(event.data.to_string())
+}
+
+fn snapshot_envelope(
+    id: impl Into<String>,
+    event: impl Into<String>,
+    data: Value,
+) -> StreamEnvelope {
+    StreamEnvelope {
+        id: id.into(),
+        event: event.into(),
+        data,
+    }
+}
+
+async fn build_stream_snapshot(state: AppState) -> Result<Vec<StreamEnvelope>, Response> {
+    let mut events = Vec::new();
+    let generated_at = utc_now_iso();
+
+    let agents = if let Some(pool) = state.pg_pool.as_ref() {
+        load_agents_pg(pool, None)
+            .await
+            .map_err(|error| internal_error("stream_agents_pg", &error))?
+    } else {
+        load_agents_sqlite(&state, None)
+            .map_err(|error| internal_error("stream_agents_sqlite", &error))?
+    };
+    for agent in &agents {
+        if let Some(agent_id) = agent["id"].as_str() {
+            events.push(snapshot_envelope(
+                format!("snapshot:agent-status:{agent_id}"),
+                "agent.status",
+                json!({
+                    "agent_id": agent_id,
+                    "status": agent["status"].as_str().unwrap_or("idle"),
+                    "task": compact_agent_task(agent),
+                    "snapshot": true,
+                    "generated_at": generated_at,
+                }),
+            ));
+            events.push(snapshot_envelope(
+                format!("snapshot:token:{agent_id}"),
+                "token.tick",
+                json!({
+                    "agent_id": agent_id,
+                    "delta_tokens": agent["stats_tokens"].as_i64().unwrap_or(0),
+                    "delta_cost_usd": "0",
+                    "snapshot": true,
+                    "generated_at": generated_at,
+                }),
+            ));
+        }
+    }
+
+    let (health_status, health_payload) = load_health_payload(state.clone()).await?;
+    events.push(snapshot_envelope(
+        "snapshot:ops-health",
+        "ops.health",
+        compact_ops_health_event(health_status, &health_payload, &generated_at),
+    ));
+
+    let achievements = if let Some(pool) = state.pg_pool.as_ref() {
+        build_achievements_pg(pool, None)
+            .await
+            .map_err(|error| internal_error("stream_achievements_pg", &error))?
+    } else {
+        build_achievements_sqlite(&state, None)
+            .map_err(|error| internal_error("stream_achievements_sqlite", &error))?
+    };
+    for achievement in achievements.achievements.iter().take(8) {
+        if let Some(achievement_id) = achievement["id"].as_str() {
+            events.push(snapshot_envelope(
+                format!("snapshot:achievement:{achievement_id}"),
+                "achievement.unlocked",
+                json!({
+                    "achievement_id": achievement_id,
+                    "xp": achievement["progress"]["current"].as_i64().unwrap_or(0),
+                    "snapshot": true,
+                    "generated_at": generated_at,
+                }),
+            ));
+        }
+    }
+
+    let activity_items = if let Some(pool) = state.pg_pool.as_ref() {
+        load_activity_items_pg(pool)
+            .await
+            .map_err(|error| internal_error("stream_activity_pg", &error))?
+    } else {
+        load_activity_items_sqlite(&state)
+            .map_err(|error| internal_error("stream_activity_sqlite", &error))?
+    };
+    for item in activity_items
+        .into_iter()
+        .filter(|item| item.body["kind"] == "kanban_transition")
+        .take(8)
+    {
+        if let Some(event) = compact_kanban_transition_snapshot(&item.body, &generated_at) {
+            events.push(event);
+        }
+    }
+
+    Ok(events)
+}
+
+fn compact_agent_task(agent: &Value) -> Value {
+    let Some(current_task) = agent.get("current_task") else {
+        return Value::Null;
+    };
+    if current_task.is_null() {
+        return Value::Null;
+    }
+    json!({
+        "dispatch_id": current_task["dispatch_id"],
+        "card_id": current_task["card_id"],
+        "card_title": current_task["card_title"],
+    })
+}
+
+fn compact_ops_health_event(status: StatusCode, payload: &Value, generated_at: &str) -> Value {
+    let providers = payload["providers"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|provider| {
+            Some(json!({
+                "name": provider.get("name")?.as_str()?,
+                "healthy": provider.get("healthy").and_then(Value::as_bool).unwrap_or(false),
+            }))
+        })
+        .take(6)
+        .collect::<Vec<_>>();
+    let reasons = payload["reasons"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|reason| reason.as_str().map(str::to_string))
+        .take(6)
+        .collect::<Vec<_>>();
+    json!({
+        "status": if status.is_success() { "ok" } else { "degraded" },
+        "providers": providers,
+        "reasons": reasons,
+        "deferred_hooks": payload["deferred_hooks"].as_i64().unwrap_or(0),
+        "snapshot": true,
+        "generated_at": generated_at,
+    })
+}
+
+fn compact_kanban_transition_snapshot(body: &Value, generated_at: &str) -> Option<StreamEnvelope> {
+    let meta = body.get("meta")?;
+    let card_id = meta.get("card_id").and_then(Value::as_str)?;
+    Some(snapshot_envelope(
+        format!("snapshot:kanban:{card_id}"),
+        "kanban.transition",
+        json!({
+            "card_id": card_id,
+            "from": meta.get("from_status").and_then(Value::as_str).unwrap_or("unknown"),
+            "to": meta.get("to_status").and_then(Value::as_str).unwrap_or("unknown"),
+            "at": body["created_at"].as_str().unwrap_or(generated_at),
+            "snapshot": true,
+            "generated_at": generated_at,
+        }),
+    ))
+}
+
+fn map_live_stream_event(event: crate::server::ws::BroadcastEvent) -> Option<StreamEnvelope> {
+    let data = match event.event.as_str() {
+        "agent.status"
+        | "ops.health"
+        | "achievement.unlocked"
+        | "token.tick"
+        | "kanban.transition" => event.data,
+        "agent_status" => {
+            let agent_id = event.data["id"].as_str()?;
+            json!({
+                "agent_id": agent_id,
+                "status": event.data["status"].as_str().unwrap_or("idle"),
+                "task": {
+                    "dispatch_id": event.data["current_task_id"],
+                },
+            })
+        }
+        "dispatched_session_new" | "dispatched_session_update" => {
+            let agent_id = event.data["linked_agent_id"].as_str()?;
+            json!({
+                "agent_id": agent_id,
+                "status": event.data["status"].as_str().unwrap_or("idle"),
+                "task": {
+                    "dispatch_id": event.data["active_dispatch_id"],
+                    "session_key": event.data["session_key"],
+                },
+            })
+        }
+        _ => event.data,
+    };
+    let event_name = match event.event.as_str() {
+        "agent_status" | "dispatched_session_new" | "dispatched_session_update" => {
+            "agent.status".to_string()
+        }
+        other => other.to_string(),
+    };
+    Some(StreamEnvelope {
+        id: event.id,
+        event: event_name,
+        data,
+    })
 }
 
 fn json_response(status: StatusCode, cache_control: &str, body: Value) -> Response {
@@ -1400,6 +1687,8 @@ async fn load_activity_items_pg(pool: &sqlx::PgPool) -> Result<Vec<ActivityItem>
                 "meta": {
                     "card_id": row.try_get::<Option<String>, _>("card_id").ok().flatten(),
                     "card_title": card_title,
+                    "from_status": row.try_get::<Option<String>, _>("from_status").ok().flatten(),
+                    "to_status": row.try_get::<Option<String>, _>("to_status").ok().flatten(),
                     "source": row.try_get::<Option<String>, _>("source").ok().flatten(),
                     "result": row.try_get::<Option<String>, _>("result").ok().flatten(),
                 }
@@ -1533,6 +1822,8 @@ fn load_activity_items_sqlite(state: &AppState) -> Result<Vec<ActivityItem>, Str
                     .and_then(normalize_datetime_to_iso)
                     .unwrap_or_else(utc_now_iso);
                 let id = format!("kanban:{}", row.0);
+                let from_status = row.2.clone().unwrap_or_else(|| "unknown".to_string());
+                let to_status = row.3.clone().unwrap_or_else(|| "unknown".to_string());
                 items.push(ActivityItem {
                     timestamp_ms: iso_to_millis(&iso),
                     cursor_id: id.clone(),
@@ -1543,12 +1834,14 @@ fn load_activity_items_sqlite(state: &AppState) -> Result<Vec<ActivityItem>, Str
                         "summary": format!(
                             "{} {} -> {}",
                             row.8.map(|value| format!("#{value}")).unwrap_or_else(|| "card".to_string()),
-                            row.2.unwrap_or_else(|| "unknown".to_string()),
-                            row.3.unwrap_or_else(|| "unknown".to_string()),
+                            from_status,
+                            to_status,
                         ),
                         "meta": {
                             "card_id": row.1,
                             "card_title": row.7,
+                            "from_status": row.2,
+                            "to_status": row.3,
                             "source": row.4,
                             "result": row.5,
                         }

--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -7,25 +7,114 @@ use axum::{
 };
 use futures::{SinkExt, StreamExt};
 use serde_json::json;
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::collections::{HashMap, VecDeque};
+use std::sync::{
+    Arc, Mutex as StdMutex,
+    atomic::{AtomicU64, Ordering},
+};
 use tokio::sync::{Mutex, broadcast};
 
 /// Shared broadcast sender for pushing events to all connected WS clients.
-pub type BroadcastTx = Arc<broadcast::Sender<String>>;
+pub type BroadcastTx = Arc<BroadcastBus>;
 
 /// Buffer for batched events — groups events by key, flushes periodically.
-pub type BatchBuffer = Arc<Mutex<HashMap<String, serde_json::Value>>>;
+pub type BatchBuffer = Arc<Mutex<HashMap<String, PendingEvent>>>;
+
+const BROADCAST_HISTORY_LIMIT: usize = 256;
+
+#[derive(Clone, Debug)]
+pub struct BroadcastEvent {
+    pub id: String,
+    pub event: String,
+    pub data: serde_json::Value,
+}
+
+impl BroadcastEvent {
+    fn as_ws_message(&self) -> String {
+        json!({
+            "id": self.id,
+            "type": self.event,
+            "data": self.data,
+        })
+        .to_string()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PendingEvent {
+    event: String,
+    data: serde_json::Value,
+}
+
+pub struct BroadcastBus {
+    tx: broadcast::Sender<BroadcastEvent>,
+    history: StdMutex<VecDeque<BroadcastEvent>>,
+    next_event_id: AtomicU64,
+}
+
+impl BroadcastBus {
+    fn new() -> Self {
+        let (tx, _) = broadcast::channel::<BroadcastEvent>(256);
+        Self {
+            tx,
+            history: StdMutex::new(VecDeque::with_capacity(BROADCAST_HISTORY_LIMIT)),
+            next_event_id: AtomicU64::new(1),
+        }
+    }
+
+    fn send(&self, event: &str, data: serde_json::Value) -> BroadcastEvent {
+        let envelope = BroadcastEvent {
+            id: self
+                .next_event_id
+                .fetch_add(1, Ordering::Relaxed)
+                .to_string(),
+            event: event.to_string(),
+            data,
+        };
+        if let Ok(mut history) = self.history.lock() {
+            if history.len() >= BROADCAST_HISTORY_LIMIT {
+                history.pop_front();
+            }
+            history.push_back(envelope.clone());
+        }
+        let _ = self.tx.send(envelope.clone());
+        envelope
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<BroadcastEvent> {
+        self.tx.subscribe()
+    }
+
+    pub fn replay_since(&self, last_event_id: &str) -> Vec<BroadcastEvent> {
+        let Ok(last_seen) = last_event_id.parse::<u64>() else {
+            return Vec::new();
+        };
+        self.history
+            .lock()
+            .map(|history| {
+                history
+                    .iter()
+                    .filter(|event| {
+                        event
+                            .id
+                            .parse::<u64>()
+                            .ok()
+                            .is_some_and(|event_id| event_id > last_seen)
+                    })
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}
 
 pub fn new_broadcast() -> BroadcastTx {
-    let (tx, _) = broadcast::channel::<String>(256);
-    Arc::new(tx)
+    Arc::new(BroadcastBus::new())
 }
 
 /// Immediately emit an event to all connected WebSocket clients.
 pub fn emit_event(tx: &BroadcastTx, event_name: &str, payload: serde_json::Value) {
-    let msg = json!({"type": event_name, "data": payload}).to_string();
-    let _ = tx.send(msg);
+    tx.send(event_name, payload);
 }
 
 /// Queue a batched event — deduplicates by key, flushed periodically.
@@ -35,11 +124,17 @@ pub fn emit_batched_event(
     key: impl Into<String>,
     payload: serde_json::Value,
 ) {
-    let msg = json!({"type": event_name, "data": payload});
     let key = key.into();
+    let event_name = event_name.to_string();
     let buffer = buffer.clone();
     tokio::spawn(async move {
-        buffer.lock().await.insert(key, msg);
+        buffer.lock().await.insert(
+            key,
+            PendingEvent {
+                event: event_name,
+                data: payload,
+            },
+        );
     });
 }
 
@@ -55,8 +150,8 @@ pub fn spawn_batch_flusher(tx: BroadcastTx) -> BatchBuffer {
             if buf.is_empty() {
                 continue;
             }
-            for (_key, msg) in buf.drain() {
-                let _ = tx.send(msg.to_string());
+            for (_key, pending) in buf.drain() {
+                tx.send(&pending.event, pending.data);
             }
         }
     });
@@ -104,7 +199,7 @@ async fn handle_socket(socket: WebSocket, tx: BroadcastTx) {
                 result = rx.recv() => {
                     match result {
                         Ok(msg) => {
-                            if sender.send(Message::Text(msg.into())).await.is_err() {
+                            if sender.send(Message::Text(msg.as_ws_message().into())).await.is_err() {
                                 break;
                             }
                         }


### PR DESCRIPTION
## Summary
- add `/api/v1/stream` as an SSE surface on top of the existing shared broadcast bus
- add bounded event replay for `Last-Event-ID` and compact on-connect snapshot events for dashboard consumers
- keep `/ws` working while sharing the same event source and cover the stream contract with route tests

## Verification
- `cargo test -q v1_stream_pg_emits_snapshot_and_replays_shared_bus_events --bin agentdesk -- --test-threads=1`
- `cargo test -q v1_routes_pg_surface_dashboard_contract --bin agentdesk -- --test-threads=1`
- `cargo build -q --bin agentdesk`

Closes #792