### PR TITLE
Refactor PolicyEngine to remove direct Db dependency

### DIFF
--- a/policies/kanban-rules.js
+++ b/policies/kanban-rules.js
@@ -197,8 +197,17 @@ function _autoRefreshInventoryDocs(card, dispatch, dispatchContext, workResult) 
     return;
   }
 
-  if (!_dispatchTouchedSrcSinceCreated(worktreePath, dispatch.created_at)) {
-    agentdesk.log.info("[inventory] dispatch " + dispatch.id + " skipped: no src changes since dispatch start");
+  try {
+    if (!_dispatchTouchedSrcSinceCreated(worktreePath, dispatch.created_at)) {
+      agentdesk.log.info("[inventory] dispatch " + dispatch.id + " skipped: no src changes since dispatch start");
+      return;
+    }
+  } catch (e) {
+    var probeError = e && e.message ? e.message : String(e);
+    agentdesk.log.warn(
+      "[inventory] dispatch " + dispatch.id + " skipped: src-change probe failed for " +
+      worktreePath + ": " + probeError
+    );
     return;
   }
 

--- a/src/cli/dcserver.rs
+++ b/src/cli/dcserver.rs
@@ -1289,11 +1289,7 @@ pub fn handle_dcserver(token: Option<String>) {
                 // Start axum HTTP server (background task) — now serves all API
                 // endpoints including /api/send, /api/senddm, /api/health
                 let http_port = ad_config.server.port;
-                match PolicyEngine::new_with_pg(
-                    &ad_config,
-                    ad_db.clone(),
-                    discord_pg_pool.clone(),
-                ) {
+                match PolicyEngine::new_with_pg(&ad_config, discord_pg_pool.clone()) {
                     Ok(engine) => {
                         // Clone for Discord bot — direct finalize_dispatch access (#143)
                         discord_db = Some(ad_db.clone());

--- a/src/cli/direct.rs
+++ b/src/cli/direct.rs
@@ -201,7 +201,7 @@ async fn build_app_state(with_health_registry: bool) -> Result<AppState, String>
 
     let pg_pool = crate::db::postgres::connect_and_migrate(&config).await?;
     crate::services::termination_audit::init_audit_db(db.clone(), pg_pool.clone());
-    let engine = crate::engine::PolicyEngine::new_with_pg(&config, db.clone(), pg_pool.clone())
+    let engine = crate::engine::PolicyEngine::new_with_pg(&config, pg_pool.clone())
         .map_err(|e| format!("init policy engine: {e}"))?;
     let broadcast_tx = crate::server::ws::new_broadcast();
     let batch_buffer = crate::server::ws::spawn_batch_flusher(broadcast_tx.clone());

--- a/src/dispatch/dispatch_context.rs
+++ b/src/dispatch/dispatch_context.rs
@@ -2496,7 +2496,7 @@ mod tests {
 
     fn test_engine(db: &Db) -> PolicyEngine {
         let config = crate::config::Config::default();
-        PolicyEngine::new(&config, db.clone()).unwrap()
+        PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
     }
 
     fn run_git(dir: &str, args: &[&str]) {

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -850,7 +850,7 @@ mod tests {
 
     fn test_engine(db: &Db) -> PolicyEngine {
         let config = crate::config::Config::default();
-        PolicyEngine::new(&config, db.clone()).unwrap()
+        PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
     }
 
     fn run_git(repo_dir: &str, args: &[&str]) -> std::process::Output {

--- a/src/engine/intent.rs
+++ b/src/engine/intent.rs
@@ -95,6 +95,20 @@ pub fn execute_intents(
     engine: Option<&crate::engine::PolicyEngine>,
     intents: Vec<Intent>,
 ) -> IntentExecutionResult {
+    execute_intents_with_backends(
+        Some(db),
+        engine.and_then(|engine| engine.pg_pool()),
+        engine,
+        intents,
+    )
+}
+
+pub fn execute_intents_with_backends(
+    db: Option<&crate::db::Db>,
+    pg_pool: Option<&sqlx::PgPool>,
+    engine: Option<&crate::engine::PolicyEngine>,
+    intents: Vec<Intent>,
+) -> IntentExecutionResult {
     let mut result = IntentExecutionResult {
         transitions: Vec::new(),
         created_dispatches: Vec::new(),
@@ -113,7 +127,7 @@ pub fn execute_intents(
                 let intent_span =
                     crate::logging::dispatch_span("intent_transition", None, Some(&card_id), None);
                 let _guard = intent_span.enter();
-                if let Err(e) = execute_transition(db, &card_id, &from, &to) {
+                if let Err(e) = execute_transition(db, pg_pool, engine, &card_id, &from, &to) {
                     tracing::warn!(from, to, error = %e, "transition intent failed");
                     result.errors += 1;
                 } else {
@@ -136,6 +150,7 @@ pub fn execute_intents(
                 let _guard = intent_span.enter();
                 match execute_create_dispatch(
                     db,
+                    pg_pool,
                     engine,
                     &dispatch_id,
                     &card_id,
@@ -151,7 +166,7 @@ pub fn execute_intents(
                 }
             }
             Intent::ActivateAutoQueue { body } => {
-                match execute_activate_auto_queue(db, engine, body) {
+                match execute_activate_auto_queue(db, pg_pool, engine, body) {
                     Ok(_) => {}
                     Err(e) => {
                         tracing::warn!(error = %e, "auto-queue activate intent failed");
@@ -181,7 +196,9 @@ pub fn execute_intents(
                 signal_name,
                 evidence,
             } => {
-                if let Err(e) = execute_emit_supervisor_signal(db, engine, &signal_name, evidence) {
+                if let Err(e) =
+                    execute_emit_supervisor_signal(db, pg_pool, engine, &signal_name, evidence)
+                {
                     tracing::warn!(
                         signal_name,
                         error = %e,
@@ -195,13 +212,13 @@ pub fn execute_intents(
                 value,
                 ttl_seconds,
             } => {
-                if let Err(e) = execute_set_kv(db, &key, &value, ttl_seconds) {
+                if let Err(e) = execute_set_kv(db, pg_pool, &key, &value, ttl_seconds) {
                     tracing::warn!(key, ttl_seconds, error = %e, "set-kv intent failed");
                     result.errors += 1;
                 }
             }
             Intent::DeleteKV { key } => {
-                if let Err(e) = execute_delete_kv(db, &key) {
+                if let Err(e) = execute_delete_kv(db, pg_pool, &key) {
                     tracing::warn!(key, error = %e, "delete-kv intent failed");
                     result.errors += 1;
                 }
@@ -222,11 +239,44 @@ pub fn execute_intents(
 // ── Individual intent executors ─────────────────────────────────
 
 fn execute_transition(
-    db: &crate::db::Db,
+    db: Option<&crate::db::Db>,
+    pg_pool: Option<&sqlx::PgPool>,
+    engine: Option<&crate::engine::PolicyEngine>,
     card_id: &str,
     expected_from: &str,
     to: &str,
 ) -> anyhow::Result<()> {
+    if let (Some(pool), Some(engine)) = (pg_pool, engine) {
+        let result = crate::utils::async_bridge::block_on_pg_result(
+            pool,
+            {
+                let db = db.cloned();
+                let pool = pool.clone();
+                let engine = engine.clone();
+                let card_id = card_id.to_string();
+                let to = to.to_string();
+                move |_bridge_pool| async move {
+                    crate::kanban::transition_status_with_opts_pg(
+                        db.as_ref(),
+                        &pool,
+                        &engine,
+                        &card_id,
+                        &to,
+                        "intent_transition",
+                        crate::engine::transition::ForceIntent::None,
+                    )
+                    .await
+                    .map(|_| ())
+                    .map_err(|error| error.to_string())
+                }
+            },
+            |error| error,
+        );
+        return result.map_err(anyhow::Error::msg);
+    }
+    let Some(db) = db else {
+        anyhow::bail!("sqlite backend is unavailable");
+    };
     let transition_span =
         crate::logging::dispatch_span("execute_transition", None, Some(card_id), None);
     let _guard = transition_span.enter();
@@ -319,7 +369,8 @@ fn execute_transition(
 }
 
 fn execute_create_dispatch(
-    db: &crate::db::Db,
+    db: Option<&crate::db::Db>,
+    pg_pool: Option<&sqlx::PgPool>,
     engine: Option<&crate::engine::PolicyEngine>,
     pre_id: &str,
     card_id: &str,
@@ -334,36 +385,59 @@ fn execute_create_dispatch(
         Some(agent_id),
     );
     let _guard = dispatch_span.enter();
-    let Some(pg_pool) = engine.and_then(|value| value.pg_pool()) else {
-        anyhow::bail!("postgres pool required for create_dispatch intent");
-    };
     let context = serde_json::json!({});
-    let dispatch_id_input = pre_id.to_string();
-    let card_id_input = card_id.to_string();
-    let agent_id_input = agent_id.to_string();
-    let dispatch_type_input = dispatch_type.to_string();
-    let title_input = title.to_string();
-    let (dispatch_id, _old_status, _reused) = crate::utils::async_bridge::block_on_pg_result(
-        pg_pool,
-        move |bridge_pool| async move {
-            crate::dispatch::create_dispatch_core_with_id(
-                &bridge_pool,
-                &dispatch_id_input,
-                &card_id_input,
-                &agent_id_input,
-                &dispatch_type_input,
-                &title_input,
-                &context,
-            )
-            .await
-        },
-        |error| anyhow::anyhow!(error),
-    )?;
+    let dispatch_id = if let Some(pg_pool) =
+        pg_pool.or_else(|| engine.and_then(|value| value.pg_pool()))
+    {
+        let dispatch_id_input = pre_id.to_string();
+        let card_id_input = card_id.to_string();
+        let agent_id_input = agent_id.to_string();
+        let dispatch_type_input = dispatch_type.to_string();
+        let title_input = title.to_string();
+        let (dispatch_id, _old_status, _reused) = crate::utils::async_bridge::block_on_pg_result(
+            pg_pool,
+            move |bridge_pool| async move {
+                crate::dispatch::create_dispatch_core_with_id(
+                    &bridge_pool,
+                    &dispatch_id_input,
+                    &card_id_input,
+                    &agent_id_input,
+                    &dispatch_type_input,
+                    &title_input,
+                    &context,
+                )
+                .await
+            },
+            |error| anyhow::anyhow!(error),
+        )?;
+        dispatch_id
+    } else {
+        let Some(db) = db else {
+            anyhow::bail!("sqlite backend is unavailable for create_dispatch intent");
+        };
+        let engine =
+            engine.ok_or_else(|| anyhow::anyhow!("create_dispatch intent requires engine"))?;
+        let dispatch = crate::dispatch::create_dispatch(
+            db,
+            engine,
+            card_id,
+            agent_id,
+            dispatch_type,
+            title,
+            &context,
+        )?;
+        dispatch
+            .get("id")
+            .and_then(|value| value.as_str())
+            .map(str::to_string)
+            .ok_or_else(|| anyhow::anyhow!("sqlite create_dispatch did not return id"))?
+    };
 
     // #117/#158: Update card_review_state via unified entrypoint
     if dispatch_type == "review-decision" {
-        crate::engine::ops::review_state_sync(
+        crate::engine::ops::review_state_sync_with_backends(
             db,
+            pg_pool.or_else(|| engine.and_then(|value| value.pg_pool())),
             &serde_json::json!({
                 "card_id": card_id,
                 "state": "suggestion_pending",
@@ -374,15 +448,43 @@ fn execute_create_dispatch(
     }
 
     // Get issue URL for Discord notification
-    let issue_url: Option<String> = db.separate_conn().ok().and_then(|conn| {
-        conn.query_row(
-            "SELECT github_issue_url FROM kanban_cards WHERE id = ?1",
-            [card_id],
-            |row| row.get(0),
+    let issue_url: Option<String> = if let Some(db) = db {
+        db.separate_conn().ok().and_then(|conn| {
+            conn.query_row(
+                "SELECT github_issue_url FROM kanban_cards WHERE id = ?1",
+                [card_id],
+                |row| row.get(0),
+            )
+            .ok()
+            .flatten()
+        })
+    } else if let Some(pg_pool) = pg_pool.or_else(|| engine.and_then(|value| value.pg_pool())) {
+        crate::utils::async_bridge::block_on_pg_result(
+            pg_pool,
+            {
+                let card_id = card_id.to_string();
+                move |bridge_pool| async move {
+                    sqlx::query_scalar::<_, Option<String>>(
+                        "SELECT github_issue_url
+                         FROM kanban_cards
+                         WHERE id = $1",
+                    )
+                    .bind(&card_id)
+                    .fetch_optional(&bridge_pool)
+                    .await
+                    .map(|value| value.flatten())
+                    .map_err(|error| {
+                        format!("load postgres github_issue_url for {card_id}: {error}")
+                    })
+                }
+            },
+            |error| error,
         )
         .ok()
         .flatten()
-    });
+    } else {
+        None
+    };
 
     Ok(CreatedDispatch {
         dispatch_id,
@@ -394,13 +496,45 @@ fn execute_create_dispatch(
 }
 
 fn execute_activate_auto_queue(
-    db: &crate::db::Db,
+    db: Option<&crate::db::Db>,
+    pg_pool: Option<&sqlx::PgPool>,
     engine: Option<&crate::engine::PolicyEngine>,
     body: serde_json::Value,
 ) -> anyhow::Result<()> {
     let engine =
         engine.ok_or_else(|| anyhow::anyhow!("auto-queue activation intent requires engine"))?;
     let body: crate::server::routes::auto_queue::ActivateBody = serde_json::from_value(body)?;
+    if pg_pool.is_some() || engine.pg_pool().is_some() {
+        let pool = pg_pool
+            .or_else(|| engine.pg_pool())
+            .ok_or_else(|| anyhow::anyhow!("postgres pool is not configured"))?;
+        let (_status, response) = crate::utils::async_bridge::block_on_pg_result(
+            pool,
+            {
+                let engine = engine.clone();
+                let body = body.clone();
+                move |_bridge_pool| async move {
+                    Ok(
+                        crate::server::routes::auto_queue::activate_with_bridge_pg(engine, body)
+                            .await,
+                    )
+                }
+            },
+            |error| anyhow::anyhow!(error),
+        )?;
+        if response.0.get("error").is_some() {
+            return Err(anyhow::anyhow!(
+                "{}",
+                response.0["error"]
+                    .as_str()
+                    .unwrap_or("auto-queue activation failed")
+            ));
+        }
+        return Ok(());
+    }
+    let Some(db) = db else {
+        anyhow::bail!("sqlite backend is unavailable");
+    };
     let deps = crate::server::routes::auto_queue::AutoQueueActivateDeps::for_bridge(
         db.clone(),
         engine.clone(),
@@ -437,12 +571,19 @@ fn json_to_sqlite(val: &serde_json::Value) -> libsql_rusqlite::types::Value {
     }
 }
 
-fn execute_sql(db: &crate::db::Db, sql: &str, params: &[serde_json::Value]) -> anyhow::Result<()> {
+fn execute_sql(
+    db: Option<&crate::db::Db>,
+    sql: &str,
+    params: &[serde_json::Value],
+) -> anyhow::Result<()> {
     if let Some(violation) = crate::engine::sql_guard::detect_core_table_write(sql) {
         warn!("{}", violation.warning_message("ExecuteSQL intent", sql));
         return Err(anyhow::anyhow!(violation.error_message()));
     }
 
+    let Some(db) = db else {
+        anyhow::bail!("sqlite backend is unavailable");
+    };
     let conn = db.separate_conn()?;
     let bind: Vec<libsql_rusqlite::types::Value> = params.iter().map(json_to_sqlite).collect();
     let params_ref: Vec<&dyn libsql_rusqlite::types::ToSql> = bind
@@ -454,7 +595,7 @@ fn execute_sql(db: &crate::db::Db, sql: &str, params: &[serde_json::Value]) -> a
 }
 
 fn execute_queue_message(
-    db: &crate::db::Db,
+    db: Option<&crate::db::Db>,
     engine: Option<&crate::engine::PolicyEngine>,
     target: &str,
     content: &str,
@@ -481,7 +622,8 @@ fn execute_queue_message(
 }
 
 fn execute_emit_supervisor_signal(
-    db: &crate::db::Db,
+    db: Option<&crate::db::Db>,
+    pg_pool: Option<&sqlx::PgPool>,
     engine: Option<&crate::engine::PolicyEngine>,
     signal_name: &str,
     evidence: serde_json::Value,
@@ -490,7 +632,8 @@ fn execute_emit_supervisor_signal(
         engine.ok_or_else(|| anyhow::anyhow!("supervisor signal intent requires engine"))?;
     let signal =
         crate::supervisor::SupervisorSignal::try_from(signal_name).map_err(anyhow::Error::msg)?;
-    let supervisor = crate::supervisor::RuntimeSupervisor::new(db.clone(), engine.clone());
+    let supervisor =
+        crate::supervisor::RuntimeSupervisor::new(db.cloned(), pg_pool.cloned(), engine.clone());
     supervisor
         .emit_signal(signal, evidence)
         .map(|_| ())
@@ -498,11 +641,58 @@ fn execute_emit_supervisor_signal(
 }
 
 fn execute_set_kv(
-    db: &crate::db::Db,
+    db: Option<&crate::db::Db>,
+    pg_pool: Option<&sqlx::PgPool>,
     key: &str,
     value: &str,
     ttl_seconds: i64,
 ) -> anyhow::Result<()> {
+    if let Some(pool) = pg_pool {
+        crate::utils::async_bridge::block_on_pg_result(
+            pool,
+            {
+                let key = key.to_string();
+                let value = value.to_string();
+                move |bridge_pool| async move {
+                    let query = if ttl_seconds > 0 {
+                        sqlx::query(
+                            "INSERT INTO kv_meta (key, value, expires_at)
+                             VALUES ($1, $2, NOW() + ($3 * INTERVAL '1 second'))
+                             ON CONFLICT (key) DO UPDATE
+                             SET value = EXCLUDED.value,
+                                 expires_at = EXCLUDED.expires_at",
+                        )
+                        .bind(&key)
+                        .bind(&value)
+                        .bind(ttl_seconds)
+                        .execute(&bridge_pool)
+                        .await
+                    } else {
+                        sqlx::query(
+                            "INSERT INTO kv_meta (key, value, expires_at)
+                             VALUES ($1, $2, NULL)
+                             ON CONFLICT (key) DO UPDATE
+                             SET value = EXCLUDED.value,
+                                 expires_at = EXCLUDED.expires_at",
+                        )
+                        .bind(&key)
+                        .bind(&value)
+                        .execute(&bridge_pool)
+                        .await
+                    };
+                    query
+                        .map(|_| ())
+                        .map_err(|error| format!("upsert postgres kv_meta {key}: {error}"))
+                }
+            },
+            |error| error,
+        )
+        .map_err(anyhow::Error::msg)?;
+        return Ok(());
+    }
+    let Some(db) = db else {
+        anyhow::bail!("sqlite backend is unavailable");
+    };
     let conn = db.separate_conn()?;
     if ttl_seconds > 0 {
         conn.execute(
@@ -520,7 +710,33 @@ fn execute_set_kv(
     Ok(())
 }
 
-fn execute_delete_kv(db: &crate::db::Db, key: &str) -> anyhow::Result<()> {
+fn execute_delete_kv(
+    db: Option<&crate::db::Db>,
+    pg_pool: Option<&sqlx::PgPool>,
+    key: &str,
+) -> anyhow::Result<()> {
+    if let Some(pool) = pg_pool {
+        crate::utils::async_bridge::block_on_pg_result(
+            pool,
+            {
+                let key = key.to_string();
+                move |bridge_pool| async move {
+                    sqlx::query("DELETE FROM kv_meta WHERE key = $1")
+                        .bind(&key)
+                        .execute(&bridge_pool)
+                        .await
+                        .map(|_| ())
+                        .map_err(|error| format!("delete postgres kv_meta {key}: {error}"))
+                }
+            },
+            |error| error,
+        )
+        .map_err(anyhow::Error::msg)?;
+        return Ok(());
+    }
+    let Some(db) = db else {
+        anyhow::bail!("sqlite backend is unavailable");
+    };
     let conn = db.separate_conn()?;
     conn.execute("DELETE FROM kv_meta WHERE key = ?1", [key])?;
     Ok(())

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use rquickjs::{Context, Function, Persistent, Runtime};
+use sqlx::Row;
 
 use crate::config::Config;
 use crate::db::Db;
@@ -91,7 +92,7 @@ enum EngineCommand {
 impl PolicyEngineActor {
     fn spawn(
         inner: Arc<Mutex<PolicyEngineInner>>,
-        runtime_deps: Arc<PolicyEngineCompatDeps>,
+        runtime_deps: Arc<PolicyEngineRuntimeDeps>,
         tick_hook_in_flight: Arc<AtomicBool>,
         label: &'static str,
     ) -> Result<Arc<Self>> {
@@ -131,7 +132,7 @@ impl PolicyEngineActor {
     fn run_loop(
         actor_weak: Weak<Self>,
         inner: Arc<Mutex<PolicyEngineInner>>,
-        runtime_deps: Arc<PolicyEngineCompatDeps>,
+        runtime_deps: Arc<PolicyEngineRuntimeDeps>,
         tick_hook_in_flight: Arc<AtomicBool>,
         thread_id: Arc<OnceLock<ThreadId>>,
         queue_depth: Arc<AtomicUsize>,
@@ -235,8 +236,8 @@ impl Drop for PolicyEngineActor {
 }
 
 #[derive(Clone)]
-struct PolicyEngineCompatDeps {
-    sqlite_db: Db,
+struct PolicyEngineRuntimeDeps {
+    legacy_db: Option<Db>,
     pg_pool: Option<sqlx::PgPool>,
 }
 
@@ -246,7 +247,7 @@ pub struct PolicyEngine {
     inner: Arc<Mutex<PolicyEngineInner>>,
     actor: Arc<PolicyEngineActor>,
     /// Transitional runtime deps kept only while SQLite compatibility remains.
-    runtime_deps: Arc<PolicyEngineCompatDeps>,
+    runtime_deps: Arc<PolicyEngineRuntimeDeps>,
     tick_hook_in_flight: Arc<AtomicBool>,
 }
 
@@ -254,7 +255,7 @@ pub struct PolicyEngine {
 pub struct PolicyEngineHandle {
     inner: Weak<Mutex<PolicyEngineInner>>,
     actor: Weak<PolicyEngineActor>,
-    runtime_deps: Weak<PolicyEngineCompatDeps>,
+    runtime_deps: Weak<PolicyEngineRuntimeDeps>,
     tick_hook_in_flight: Arc<AtomicBool>,
 }
 
@@ -269,8 +270,8 @@ pub struct PolicyInfo {
 
 impl PolicyEngine {
     /// Create a new policy engine, initializing QuickJS and loading policies.
-    pub fn new(config: &Config, db: Db) -> Result<Self> {
-        Self::new_with_pg_and_label(config, db, None, "main")
+    pub fn new(config: &Config) -> Result<Self> {
+        Self::new_with_backends_and_label(config, None, None, "main")
     }
 
     /// Create a dedicated policy engine for the tick loop (#747).
@@ -282,22 +283,26 @@ impl PolicyEngine {
     ///
     /// Both engines load the same policies directory (so any policy that
     /// registers `onTick*` hooks is executed by this engine).
-    pub fn new_for_tick(config: &Config, db: Db) -> Result<Self> {
-        Self::new_with_pg_and_label(config, db, None, "tick")
+    pub fn new_for_tick(config: &Config, pg_pool: Option<sqlx::PgPool>) -> Result<Self> {
+        Self::new_with_backends_and_label(config, None, pg_pool, "tick")
     }
 
-    pub fn new_with_pg(config: &Config, db: Db, pg_pool: Option<sqlx::PgPool>) -> Result<Self> {
-        Self::new_with_pg_and_label(config, db, pg_pool, "main")
+    pub fn new_with_pg(config: &Config, pg_pool: Option<sqlx::PgPool>) -> Result<Self> {
+        Self::new_with_backends_and_label(config, None, pg_pool, "main")
     }
 
-    fn new_with_pg_and_label(
+    pub fn new_with_legacy_db(config: &Config, db: Db) -> Result<Self> {
+        Self::new_with_backends_and_label(config, Some(db), None, "main")
+    }
+
+    fn new_with_backends_and_label(
         config: &Config,
-        db: Db,
+        legacy_db: Option<Db>,
         pg_pool: Option<sqlx::PgPool>,
         label: &'static str,
     ) -> Result<Self> {
-        let runtime_deps = Arc::new(PolicyEngineCompatDeps {
-            sqlite_db: db.clone(),
+        let runtime_deps = Arc::new(PolicyEngineRuntimeDeps {
+            legacy_db: legacy_db.clone(),
             pg_pool: pg_pool.clone(),
         });
         let supervisor_bridge = crate::supervisor::BridgeHandle::new();
@@ -310,7 +315,7 @@ impl PolicyEngine {
         context.with(|ctx| {
             ops::register_globals_with_supervisor_and_pg(
                 &ctx,
-                runtime_deps.sqlite_db.clone(),
+                runtime_deps.legacy_db.clone(),
                 runtime_deps.pg_pool.clone(),
                 supervisor_bridge.clone(),
             )
@@ -334,7 +339,7 @@ impl PolicyEngine {
             reload_ctx.with(|ctx| {
                 ops::register_globals_with_supervisor_and_pg(
                     &ctx,
-                    runtime_deps.sqlite_db.clone(),
+                    runtime_deps.legacy_db.clone(),
                     runtime_deps.pg_pool.clone(),
                     supervisor_bridge.clone(),
                 )
@@ -428,8 +433,8 @@ impl PolicyEngine {
         self.runtime_deps.pg_pool.as_ref()
     }
 
-    fn sqlite_db(&self) -> &Db {
-        &self.runtime_deps.sqlite_db
+    pub(crate) fn legacy_db(&self) -> Option<&Db> {
+        self.runtime_deps.legacy_db.as_ref()
     }
 
     fn roundtrip<T>(&self, command: impl FnOnce(mpsc::Sender<T>) -> EngineCommand) -> Result<T> {
@@ -510,8 +515,17 @@ impl PolicyEngine {
     fn drain_startup_hooks_inline(&self) {
         tracing::info!("[startup] draining legacy deferred hooks from DB");
 
+        if let Some(pool) = self.pg_pool().cloned() {
+            self.drain_startup_hooks_inline_pg(pool);
+            return;
+        }
+
+        let Some(legacy_db) = self.legacy_db() else {
+            return;
+        };
+
         // Record server boot time for orphan recovery grace period
-        if let Ok(conn) = self.sqlite_db().separate_conn() {
+        if let Ok(conn) = legacy_db.separate_conn() {
             conn.execute(
                 "INSERT OR REPLACE INTO kv_meta (key, value) VALUES ('server_boot_at', datetime('now'))",
                 [],
@@ -521,7 +535,7 @@ impl PolicyEngine {
 
         loop {
             let hooks: Vec<(i64, String, String)> = {
-                let conn = match self.sqlite_db().separate_conn() {
+                let conn = match legacy_db.separate_conn() {
                     Ok(c) => c,
                     Err(_) => return,
                 };
@@ -566,7 +580,7 @@ impl PolicyEngine {
 
                 if let Err(e) = fire_result {
                     tracing::warn!("[startup] deferred hook {hook_name} failed: {e}");
-                    if let Ok(conn) = self.sqlite_db().separate_conn() {
+                    if let Ok(conn) = legacy_db.separate_conn() {
                         let _ = conn.execute(
                             "UPDATE deferred_hooks SET status = 'pending' WHERE id = ?1",
                             [id],
@@ -575,8 +589,159 @@ impl PolicyEngine {
                     continue;
                 }
                 // Success — delete from DB
-                if let Ok(conn) = self.sqlite_db().separate_conn() {
+                if let Ok(conn) = legacy_db.separate_conn() {
                     let _ = conn.execute("DELETE FROM deferred_hooks WHERE id = ?1", [id]);
+                }
+            }
+        }
+    }
+
+    fn drain_startup_hooks_inline_pg(&self, pool: sqlx::PgPool) {
+        let _ = crate::utils::async_bridge::block_on_pg_result(
+            &pool,
+            move |bridge_pool| async move {
+                sqlx::query(
+                    "INSERT INTO kv_meta (key, value)
+                     VALUES ('server_boot_at', NOW()::TEXT)
+                     ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value",
+                )
+                .execute(&bridge_pool)
+                .await
+                .map_err(|error| format!("upsert postgres server_boot_at: {error}"))?;
+                Ok::<(), String>(())
+            },
+            |error| {
+                tracing::warn!("failed to upsert postgres server_boot_at: {error}");
+                error
+            },
+        );
+
+        loop {
+            let fetch_result = crate::utils::async_bridge::block_on_pg_result(
+                &pool,
+                move |bridge_pool| async move {
+                    let rows = sqlx::query(
+                        "SELECT id, hook_name, payload
+                         FROM deferred_hooks
+                         WHERE status IN ('pending', 'processing')
+                         ORDER BY id ASC
+                         LIMIT 50",
+                    )
+                    .fetch_all(&bridge_pool)
+                    .await
+                    .map_err(|error| format!("load postgres deferred hooks: {error}"))?;
+                    let hooks = rows
+                        .into_iter()
+                        .map(|row| {
+                            Ok::<_, String>((
+                                row.try_get::<i64, _>("id")
+                                    .map_err(|error| format!("decode deferred hook id: {error}"))?,
+                                row.try_get::<String, _>("hook_name").map_err(|error| {
+                                    format!("decode deferred hook hook_name: {error}")
+                                })?,
+                                row.try_get::<String, _>("payload").map_err(|error| {
+                                    format!("decode deferred hook payload: {error}")
+                                })?,
+                            ))
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    for (id, _, _) in &hooks {
+                        sqlx::query(
+                            "UPDATE deferred_hooks SET status = 'processing' WHERE id = $1",
+                        )
+                        .bind(*id)
+                        .execute(&bridge_pool)
+                        .await
+                        .map_err(|error| {
+                            format!("mark postgres deferred hook {id} processing: {error}")
+                        })?;
+                    }
+                    Ok(hooks)
+                },
+                |error| error,
+            );
+            let hooks: Vec<(i64, String, String)> = match fetch_result {
+                Ok(hooks) => hooks,
+                Err(error) => {
+                    tracing::warn!("failed to load postgres deferred hooks: {error}");
+                    return;
+                }
+            };
+            if hooks.is_empty() {
+                return;
+            }
+
+            for (id, hook_name, payload_str) in &hooks {
+                let payload: serde_json::Value =
+                    serde_json::from_str(payload_str).unwrap_or(serde_json::json!({}));
+                let span = crate::logging::hook_span(hook_name, &payload);
+                let _guard = span.enter();
+                tracing::info!(deferred_hook_id = *id, "[startup] replaying deferred hook");
+
+                let fire_result = if let Some(hook) = Hook::from_str(hook_name) {
+                    self.fire_hook_inline(hook, payload)
+                } else {
+                    self.fire_hook_by_name_inline(hook_name, payload)
+                };
+
+                let update_result = if fire_result.is_err() {
+                    crate::utils::async_bridge::block_on_pg_result(
+                        &pool,
+                        {
+                            let id = *id;
+                            move |bridge_pool| async move {
+                                sqlx::query(
+                                    "UPDATE deferred_hooks SET status = 'pending' WHERE id = $1",
+                                )
+                                .bind(id)
+                                .execute(&bridge_pool)
+                                .await
+                                .map_err(|error| {
+                                    format!("mark postgres deferred hook {id} pending: {error}")
+                                })?;
+                                Ok(())
+                            }
+                        },
+                        |error| error,
+                    )
+                } else {
+                    crate::utils::async_bridge::block_on_pg_result(
+                        &pool,
+                        {
+                            let id = *id;
+                            move |bridge_pool| async move {
+                                sqlx::query("DELETE FROM deferred_hooks WHERE id = $1")
+                                    .bind(id)
+                                    .execute(&bridge_pool)
+                                    .await
+                                    .map_err(|error| {
+                                        format!("delete postgres deferred hook {id}: {error}")
+                                    })?;
+                                Ok(())
+                            }
+                        },
+                        |error| error,
+                    )
+                };
+
+                if let Err(error) = fire_result {
+                    tracing::warn!("[startup] deferred hook {hook_name} failed: {error}");
+                    if let Err(update_error) = update_result {
+                        tracing::warn!(
+                            "failed to restore postgres deferred hook {} after replay failure: {}",
+                            id,
+                            update_error
+                        );
+                    }
+                    continue;
+                }
+
+                if let Err(update_error) = update_result {
+                    tracing::warn!(
+                        "failed to delete postgres deferred hook {} after replay success: {}",
+                        id,
+                        update_error
+                    );
                 }
             }
         }
@@ -637,8 +802,9 @@ impl PolicyEngine {
             }
 
             for (card_id, old_status, new_status) in &transitions {
-                crate::kanban::fire_transition_hooks(
-                    self.sqlite_db(),
+                crate::kanban::fire_transition_hooks_with_backends(
+                    self.legacy_db(),
+                    self.pg_pool(),
                     self,
                     card_id,
                     old_status,
@@ -936,7 +1102,12 @@ impl PolicyEngine {
         if intents.is_empty() {
             Self::empty_intent_result()
         } else {
-            intent::execute_intents(self.sqlite_db(), Some(self), intents)
+            intent::execute_intents_with_backends(
+                self.legacy_db(),
+                self.pg_pool(),
+                Some(self),
+                intents,
+            )
         }
     }
 
@@ -1109,7 +1280,7 @@ mod tests {
     fn test_engine_creates_runtime() {
         let db = test_db();
         let config = test_config();
-        let engine = PolicyEngine::new(&config, db);
+        let engine = PolicyEngine::new_with_legacy_db(&config, db);
         assert!(engine.is_ok(), "Engine should initialize without error");
     }
 
@@ -1117,7 +1288,7 @@ mod tests {
     fn test_engine_evaluates_js() {
         let db = test_db();
         let config = test_config();
-        let engine = PolicyEngine::new(&config, db).unwrap();
+        let engine = PolicyEngine::new_with_legacy_db(&config, db).unwrap();
         let result: i32 = engine.eval_js("1 + 2").unwrap();
         assert_eq!(result, 3);
     }
@@ -1135,7 +1306,7 @@ mod tests {
         }
 
         let config = test_config();
-        let engine = PolicyEngine::new(&config, db).unwrap();
+        let engine = PolicyEngine::new_with_legacy_db(&config, db).unwrap();
         let handle = engine.downgrade();
         let upgraded = handle.upgrade().expect("policy engine upgrade");
 
@@ -1157,7 +1328,7 @@ mod tests {
         }
 
         let config = test_config();
-        let engine = PolicyEngine::new(&config, db).unwrap();
+        let engine = PolicyEngine::new_with_legacy_db(&config, db).unwrap();
         let xp: i32 = engine
             .eval_js(r#"agentdesk.db.query("SELECT xp FROM agents WHERE id = 'x1'")[0].xp"#)
             .unwrap();
@@ -1185,7 +1356,7 @@ mod tests {
 
         let db = test_db();
         let config = test_config_with_dir(dir.path());
-        let engine = PolicyEngine::new(&config, db).unwrap();
+        let engine = PolicyEngine::new_with_legacy_db(&config, db).unwrap();
 
         let policies = engine.list_policies();
         assert_eq!(policies.len(), 1);
@@ -1225,7 +1396,7 @@ mod tests {
 
         let db = test_db();
         let config = test_config_with_dir(dir.path());
-        let engine = PolicyEngine::new(&config, db.clone()).unwrap();
+        let engine = PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap();
 
         // Fire onTick
         engine
@@ -1271,7 +1442,7 @@ mod tests {
         }
 
         let config = test_config_with_dir(dir.path());
-        let engine = PolicyEngine::new(&config, db.clone()).unwrap();
+        let engine = PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap();
         engine
             .fire_hook(Hook::OnTick, serde_json::json!({}))
             .unwrap();
@@ -1312,7 +1483,7 @@ mod tests {
 
         let db = test_db();
         let config = test_config_with_dir(dir.path());
-        let engine = PolicyEngine::new(&config, db.clone()).unwrap();
+        let engine = PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap();
 
         engine
             .fire_hook(
@@ -1356,7 +1527,7 @@ mod tests {
 
         let db = test_db();
         let config = test_config_with_dir(dir.path());
-        let engine = PolicyEngine::new(&config, db.clone()).unwrap();
+        let engine = PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap();
 
         // Verify the dynamic hook was detected
         let policies = engine.list_policies();
@@ -1429,7 +1600,7 @@ mod tests {
 
         let db = test_db();
         let config = test_config_with_dir(dir.path());
-        let engine = PolicyEngine::new(&config, db.clone()).unwrap();
+        let engine = PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap();
 
         engine
             .try_fire_hook_by_name("onMyHook", serde_json::json!({}))
@@ -1491,7 +1662,7 @@ mod tests {
         }
 
         let config = test_config_with_dir(dir.path());
-        let engine = PolicyEngine::new(&config, db.clone()).unwrap();
+        let engine = PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap();
 
         engine
             .try_fire_hook_by_name(
@@ -1583,7 +1754,7 @@ mod tests {
         }
 
         let config = test_config_with_dir(dir.path());
-        let engine = PolicyEngine::new(&config, db.clone()).unwrap();
+        let engine = PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap();
 
         engine
             .try_fire_hook_by_name(
@@ -1650,7 +1821,7 @@ mod tests {
         }
 
         let config = test_config_with_dir(dir.path());
-        let engine = PolicyEngine::new(&config, db.clone()).unwrap();
+        let engine = PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap();
 
         let (entered_tx, entered_rx) = mpsc::channel();
         let (release_tx, release_rx) = mpsc::channel();

--- a/src/engine/ops.rs
+++ b/src/engine/ops.rs
@@ -36,7 +36,7 @@ use rquickjs::{Ctx, Function, Object, Result as JsResult};
 /// Register all `agentdesk.*` globals in the given JS context.
 #[cfg_attr(not(test), allow(dead_code))]
 pub fn register_globals(ctx: &Ctx<'_>, db: Db) -> JsResult<()> {
-    register_globals_with_supervisor_and_pg(ctx, db, None, BridgeHandle::new())
+    register_globals_with_supervisor_and_pg(ctx, Some(db), None, BridgeHandle::new())
 }
 
 #[allow(dead_code)]
@@ -45,12 +45,12 @@ pub fn register_globals_with_supervisor(
     db: Db,
     supervisor_bridge: BridgeHandle,
 ) -> JsResult<()> {
-    register_globals_with_supervisor_and_pg(ctx, db, None, supervisor_bridge)
+    register_globals_with_supervisor_and_pg(ctx, Some(db), None, supervisor_bridge)
 }
 
 pub fn register_globals_with_supervisor_and_pg(
     ctx: &Ctx<'_>,
-    db: Db,
+    db: Option<Db>,
     pg_pool: Option<sqlx::PgPool>,
     supervisor_bridge: BridgeHandle,
 ) -> JsResult<()> {
@@ -87,13 +87,13 @@ pub fn register_globals_with_supervisor_and_pg(
     log_ops::register_log_ops(ctx)?;
 
     // ── agentdesk.config ─────────────────────────────────────────
-    config_ops::register_config_ops(ctx, db.clone())?;
+    config_ops::register_config_ops(ctx, db.clone(), pg_pool.clone())?;
 
     // ── agentdesk.http ────────────────────────────────────────────
     http_ops::register_http_ops(ctx)?;
 
     // ── agentdesk.dispatch ────────────────────────────────────────
-    dispatch_ops::register_dispatch_ops(ctx, pg_pool.clone())?;
+    dispatch_ops::register_dispatch_ops(ctx, db.clone(), pg_pool.clone())?;
 
     // ── agentdesk.kanban ────────────────────────────────────────
     kanban_ops::register_kanban_ops(ctx, db.clone(), pg_pool.clone())?;
@@ -126,14 +126,14 @@ pub fn register_globals_with_supervisor_and_pg(
     let db_for_dm_reply = db.clone();
     let pg_for_dm_reply = pg_pool.clone();
     let db_for_agents = db.clone();
-    message_ops::register_message_ops(ctx, db, pg_pool.clone())?;
+    message_ops::register_message_ops(ctx, db.clone(), pg_pool.clone())?;
 
     // ── agentdesk.exec ──────────────────────────────────────────
     exec_ops::register_exec_ops(ctx)?;
     deploy_ops::register_deploy_ops(ctx)?;
 
     // ── agentdesk.pipeline ────────────────────────────────────────
-    pipeline_ops::register_pipeline_ops(ctx, db_for_pipeline)?;
+    pipeline_ops::register_pipeline_ops(ctx, db_for_pipeline, pg_pool.clone())?;
 
     // ── agentdesk.dmReply ────────────────────────────────────
     dm_reply_ops::register_dm_reply_ops(ctx, db_for_dm_reply, pg_for_dm_reply)?;
@@ -149,6 +149,14 @@ pub fn register_globals_with_supervisor_and_pg(
 /// Used by both the JS bridge and Rust route handlers.
 pub fn review_state_sync(db: &Db, json_str: &str) -> String {
     kanban_ops::review_state_sync(db, json_str)
+}
+
+pub fn review_state_sync_with_backends(
+    db: Option<&Db>,
+    pg_pool: Option<&sqlx::PgPool>,
+    json_str: &str,
+) -> String {
+    kanban_ops::review_state_sync_with_backends(db, pg_pool, json_str)
 }
 
 /// Best-effort auto-queue cleanup for terminal cards.

--- a/src/engine/ops/agent_ops.rs
+++ b/src/engine/ops/agent_ops.rs
@@ -11,7 +11,7 @@ use sqlx::{PgPool, Row as SqlxRow};
 
 pub(super) fn register_agent_ops<'js>(
     ctx: &Ctx<'js>,
-    db: Db,
+    db: Option<Db>,
     pg_pool: Option<PgPool>,
 ) -> JsResult<()> {
     let ad: Object<'js> = ctx.globals().get("agentdesk")?;
@@ -25,6 +25,9 @@ pub(super) fn register_agent_ops<'js>(
             if let Some(pool) = pg_get.as_ref() {
                 return agent_get_raw_pg(pool, &agent_id);
             }
+            let Some(db_get) = db_get.as_ref() else {
+                return json!({ "error": "sqlite backend is unavailable" }).to_string();
+            };
             let result = (|| -> anyhow::Result<serde_json::Value> {
                 let conn = db_get.read_conn()?;
                 let agent = conn
@@ -83,6 +86,9 @@ pub(super) fn register_agent_ops<'js>(
             if let Some(pool) = pg_primary.as_ref() {
                 return resolve_agent_primary_channel_pg_raw(pool, &agent_id);
             }
+            let Some(db_primary) = db_primary.as_ref() else {
+                return String::new();
+            };
             match db_primary.separate_conn() {
                 Ok(conn) => {
                     match crate::db::agents::resolve_agent_primary_channel_on_conn(&conn, &agent_id)
@@ -105,6 +111,9 @@ pub(super) fn register_agent_ops<'js>(
             if let Some(pool) = pg_counter.as_ref() {
                 return resolve_agent_counter_channel_pg_raw(pool, &agent_id);
             }
+            let Some(db_counter) = db_counter.as_ref() else {
+                return String::new();
+            };
             match db_counter.separate_conn() {
                 Ok(conn) => {
                     match crate::db::agents::resolve_agent_counter_model_channel_on_conn(
@@ -138,6 +147,9 @@ pub(super) fn register_agent_ops<'js>(
                         },
                     );
                 }
+                let Some(db_dispatch) = db_dispatch.as_ref() else {
+                    return String::new();
+                };
                 match db_dispatch.separate_conn() {
                     Ok(conn) => {
                         let dtype = if dispatch_type.is_empty() {

--- a/src/engine/ops/auto_queue_ops.rs
+++ b/src/engine/ops/auto_queue_ops.rs
@@ -6,7 +6,7 @@ use sqlx::PgPool;
 
 pub(super) fn register_auto_queue_ops<'js>(
     ctx: &Ctx<'js>,
-    db: Db,
+    db: Option<Db>,
     pg_pool: Option<PgPool>,
     bridge: BridgeHandle,
 ) -> JsResult<()> {
@@ -21,7 +21,7 @@ pub(super) fn register_auto_queue_ops<'js>(
             ctx.clone(),
             move |entry_id: String, status: String, source: String, opts_json: String| -> String {
                 update_entry_status_raw(
-                    &db_update,
+                    db_update.as_ref(),
                     pg_update.as_ref(),
                     &entry_id,
                     &status,
@@ -33,11 +33,17 @@ pub(super) fn register_auto_queue_ops<'js>(
     )?;
 
     let db_activate = db.clone();
+    let pg_activate = pg_pool.clone();
     let bridge_activate = bridge.clone();
     auto_queue_obj.set(
         "__activateRaw",
         Function::new(ctx.clone(), move |body_json: String| -> String {
-            activate_raw(&db_activate, &bridge_activate, &body_json)
+            activate_raw(
+                db_activate.as_ref(),
+                pg_activate.as_ref(),
+                &bridge_activate,
+                &body_json,
+            )
         })?,
     )?;
     let db_pause_run = db.clone();
@@ -47,7 +53,12 @@ pub(super) fn register_auto_queue_ops<'js>(
         Function::new(
             ctx.clone(),
             move |run_id: String, source: String| -> String {
-                pause_run_raw(&db_pause_run, pg_pause_run.as_ref(), &run_id, &source)
+                pause_run_raw(
+                    db_pause_run.as_ref(),
+                    pg_pause_run.as_ref(),
+                    &run_id,
+                    &source,
+                )
             },
         )?,
     )?;
@@ -58,7 +69,12 @@ pub(super) fn register_auto_queue_ops<'js>(
         Function::new(
             ctx.clone(),
             move |run_id: String, source: String| -> String {
-                resume_run_raw(&db_resume_run, pg_resume_run.as_ref(), &run_id, &source)
+                resume_run_raw(
+                    db_resume_run.as_ref(),
+                    pg_resume_run.as_ref(),
+                    &run_id,
+                    &source,
+                )
             },
         )?,
     )?;
@@ -70,7 +86,7 @@ pub(super) fn register_auto_queue_ops<'js>(
             ctx.clone(),
             move |run_id: String, source: String, opts_json: String| -> String {
                 complete_run_raw(
-                    &db_complete_run,
+                    db_complete_run.as_ref(),
                     pg_complete_run.as_ref(),
                     &run_id,
                     &source,
@@ -87,7 +103,7 @@ pub(super) fn register_auto_queue_ops<'js>(
             ctx.clone(),
             move |run_id: String, phase: i64, state_json: String| -> String {
                 save_phase_gate_state_raw(
-                    &db_save_phase_gate,
+                    db_save_phase_gate.as_ref(),
                     pg_save_phase_gate.as_ref(),
                     &run_id,
                     phase,
@@ -102,7 +118,7 @@ pub(super) fn register_auto_queue_ops<'js>(
         "__clearPhaseGateStateRaw",
         Function::new(ctx.clone(), move |run_id: String, phase: i64| -> String {
             clear_phase_gate_state_raw(
-                &db_clear_phase_gate,
+                db_clear_phase_gate.as_ref(),
                 pg_clear_phase_gate.as_ref(),
                 &run_id,
                 phase,
@@ -122,7 +138,7 @@ pub(super) fn register_auto_queue_ops<'js>(
                   metadata_json: String|
                   -> String {
                 record_consultation_dispatch_raw(
-                    &db_record_consultation,
+                    db_record_consultation.as_ref(),
                     pg_record_consultation.as_ref(),
                     &entry_id,
                     &card_id,
@@ -141,7 +157,7 @@ pub(super) fn register_auto_queue_ops<'js>(
             ctx.clone(),
             move |entry_id: String, max_retries: i64, source: String| -> String {
                 record_entry_dispatch_failure_raw(
-                    &db_record_dispatch_failure,
+                    db_record_dispatch_failure.as_ref(),
                     pg_record_dispatch_failure.as_ref(),
                     &entry_id,
                     max_retries,
@@ -281,7 +297,12 @@ pub(super) fn register_auto_queue_ops<'js>(
     Ok(())
 }
 
-fn activate_raw(db: &Db, bridge: &BridgeHandle, body_json: &str) -> String {
+fn activate_raw(
+    db: Option<&Db>,
+    pg_pool: Option<&PgPool>,
+    bridge: &BridgeHandle,
+    body_json: &str,
+) -> String {
     let body: crate::server::routes::auto_queue::ActivateBody =
         match serde_json::from_str(body_json) {
             Ok(body) => body,
@@ -303,6 +324,35 @@ fn activate_raw(db: &Db, bridge: &BridgeHandle, body_json: &str) -> String {
         }
     };
 
+    if pg_pool.is_some() || engine.pg_pool().is_some() {
+        let Some(pool) = pg_pool.or_else(|| engine.pg_pool()) else {
+            return serde_json::json!({"error": "postgres pool is not configured"}).to_string();
+        };
+        return match crate::utils::async_bridge::block_on_pg_result(
+            pool,
+            {
+                let body = body;
+                let engine = engine.clone();
+                move |_bridge_pool| async move {
+                    let (_status, response) =
+                        crate::server::routes::auto_queue::activate_with_bridge_pg(engine, body)
+                            .await;
+                    Ok(response.0.to_string())
+                }
+            },
+            |error| serde_json::json!({ "error": error }).to_string(),
+        ) {
+            Ok(json) => json,
+            Err(error_json) => error_json,
+        };
+    }
+
+    let Some(db) = db else {
+        return serde_json::json!({
+            "error": "sqlite backend is unavailable"
+        })
+        .to_string();
+    };
     let deps =
         crate::server::routes::auto_queue::AutoQueueActivateDeps::for_bridge(db.clone(), engine);
     let (_status, response) = crate::server::routes::auto_queue::activate_with_deps(&deps, body);
@@ -316,7 +366,7 @@ fn should_defer_activate(bridge: &BridgeHandle) -> bool {
         .unwrap_or(false)
 }
 
-fn pause_run_raw(db: &Db, pg_pool: Option<&PgPool>, run_id: &str, source: &str) -> String {
+fn pause_run_raw(db: Option<&Db>, pg_pool: Option<&PgPool>, run_id: &str, source: &str) -> String {
     if source.trim().is_empty() {
         return r#"{"error":"source is required"}"#.to_string();
     }
@@ -327,6 +377,9 @@ fn pause_run_raw(db: &Db, pg_pool: Option<&PgPool>, run_id: &str, source: &str) 
             crate::db::auto_queue::pause_run_on_pg(&pool, &run_id).await
         })
     } else {
+        let Some(db) = db else {
+            return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+        };
         let conn = match db.separate_conn() {
             Ok(conn) => conn,
             Err(error) => {
@@ -352,7 +405,7 @@ fn pause_run_raw(db: &Db, pg_pool: Option<&PgPool>, run_id: &str, source: &str) 
     }
 }
 
-fn resume_run_raw(db: &Db, pg_pool: Option<&PgPool>, run_id: &str, source: &str) -> String {
+fn resume_run_raw(db: Option<&Db>, pg_pool: Option<&PgPool>, run_id: &str, source: &str) -> String {
     if source.trim().is_empty() {
         return r#"{"error":"source is required"}"#.to_string();
     }
@@ -363,6 +416,9 @@ fn resume_run_raw(db: &Db, pg_pool: Option<&PgPool>, run_id: &str, source: &str)
             crate::db::auto_queue::resume_run_on_pg(&pool, &run_id).await
         })
     } else {
+        let Some(db) = db else {
+            return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+        };
         let conn = match db.separate_conn() {
             Ok(conn) => conn,
             Err(error) => {
@@ -389,7 +445,7 @@ fn resume_run_raw(db: &Db, pg_pool: Option<&PgPool>, run_id: &str, source: &str)
 }
 
 fn complete_run_raw(
-    db: &Db,
+    db: Option<&Db>,
     pg_pool: Option<&PgPool>,
     run_id: &str,
     source: &str,
@@ -424,6 +480,9 @@ fn complete_run_raw(
             crate::db::auto_queue::complete_run_on_pg(&pool, &run_id).await
         })
     } else {
+        let Some(db) = db else {
+            return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+        };
         let conn = match db.separate_conn() {
             Ok(conn) => conn,
             Err(error) => {
@@ -482,7 +541,7 @@ struct PhaseGateStatePayload {
 }
 
 fn save_phase_gate_state_raw(
-    db: &Db,
+    db: Option<&Db>,
     pg_pool: Option<&PgPool>,
     run_id: &str,
     phase: i64,
@@ -518,6 +577,9 @@ fn save_phase_gate_state_raw(
             crate::db::auto_queue::save_phase_gate_state_on_pg(&pool, &run_id, phase, &write).await
         })
     } else {
+        let Some(db) = db else {
+            return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+        };
         let conn = match db.separate_conn() {
             Ok(conn) => conn,
             Err(error) => {
@@ -546,7 +608,7 @@ fn save_phase_gate_state_raw(
 }
 
 fn clear_phase_gate_state_raw(
-    db: &Db,
+    db: Option<&Db>,
     pg_pool: Option<&PgPool>,
     run_id: &str,
     phase: i64,
@@ -557,6 +619,9 @@ fn clear_phase_gate_state_raw(
             crate::db::auto_queue::clear_phase_gate_state_on_pg(&pool, &run_id, phase).await
         })
     } else {
+        let Some(db) = db else {
+            return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+        };
         let conn = match db.separate_conn() {
             Ok(conn) => conn,
             Err(error) => {
@@ -584,7 +649,7 @@ fn clear_phase_gate_state_raw(
 }
 
 fn record_consultation_dispatch_raw(
-    db: &Db,
+    db: Option<&Db>,
     pg_pool: Option<&PgPool>,
     entry_id: &str,
     card_id: &str,
@@ -610,6 +675,9 @@ fn record_consultation_dispatch_raw(
             .await
         })
     } else {
+        let Some(db) = db else {
+            return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+        };
         let mut conn = match db.separate_conn() {
             Ok(conn) => conn,
             Err(error) => {
@@ -647,7 +715,7 @@ fn record_consultation_dispatch_raw(
 }
 
 fn record_entry_dispatch_failure_raw(
-    db: &Db,
+    db: Option<&Db>,
     pg_pool: Option<&PgPool>,
     entry_id: &str,
     max_retries: i64,
@@ -670,6 +738,9 @@ fn record_entry_dispatch_failure_raw(
             .await
         })
     } else {
+        let Some(db) = db else {
+            return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+        };
         let conn = match db.separate_conn() {
             Ok(conn) => conn,
             Err(error) => {
@@ -708,7 +779,7 @@ fn record_entry_dispatch_failure_raw(
 }
 
 fn update_entry_status_raw(
-    db: &Db,
+    db: Option<&Db>,
     pg_pool: Option<&PgPool>,
     entry_id: &str,
     status: &str,
@@ -748,6 +819,9 @@ fn update_entry_status_raw(
             .await
         })
     } else {
+        let Some(db) = db else {
+            return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+        };
         let conn = match db.separate_conn() {
             Ok(conn) => conn,
             Err(error) => {

--- a/src/engine/ops/cards_ops.rs
+++ b/src/engine/ops/cards_ops.rs
@@ -28,7 +28,7 @@ struct CardListFilter {
 
 pub(super) fn register_card_ops<'js>(
     ctx: &Ctx<'js>,
-    db: Db,
+    db: Option<Db>,
     pg_pool: Option<PgPool>,
 ) -> JsResult<()> {
     let ad: Object<'js> = ctx.globals().get("agentdesk")?;
@@ -42,7 +42,10 @@ pub(super) fn register_card_ops<'js>(
             if let Some(pool) = pg_get.as_ref() {
                 return card_get_raw_pg(pool, &card_id);
             }
-            card_get_raw(&db_get, &card_id)
+            db_get
+                .as_ref()
+                .map(|db| card_get_raw(db, &card_id))
+                .unwrap_or_else(|| json_result(Err(anyhow!("sqlite backend is unavailable"))))
         })?,
     )?;
 
@@ -54,7 +57,10 @@ pub(super) fn register_card_ops<'js>(
             if let Some(pool) = pg_list.as_ref() {
                 return card_list_raw_pg(pool, &filter_json);
             }
-            card_list_raw(&db_list, &filter_json)
+            db_list
+                .as_ref()
+                .map(|db| card_list_raw(db, &filter_json))
+                .unwrap_or_else(|| json_result(Err(anyhow!("sqlite backend is unavailable"))))
         })?,
     )?;
 
@@ -68,7 +74,10 @@ pub(super) fn register_card_ops<'js>(
                 if let Some(pool) = pg_assign.as_ref() {
                     return card_assign_raw_pg(pool, &card_id, &agent_id);
                 }
-                card_assign_raw(&db_assign, &card_id, &agent_id)
+                db_assign
+                    .as_ref()
+                    .map(|db| card_assign_raw(db, &card_id, &agent_id))
+                    .unwrap_or_else(|| json_result(Err(anyhow!("sqlite backend is unavailable"))))
             },
         )?,
     )?;
@@ -83,7 +92,10 @@ pub(super) fn register_card_ops<'js>(
                 if let Some(pool) = pg_priority.as_ref() {
                     return card_set_priority_raw_pg(pool, &card_id, &priority);
                 }
-                card_set_priority_raw(&db_priority, &card_id, &priority)
+                db_priority
+                    .as_ref()
+                    .map(|db| card_set_priority_raw(db, &card_id, &priority))
+                    .unwrap_or_else(|| json_result(Err(anyhow!("sqlite backend is unavailable"))))
             },
         )?,
     )?;

--- a/src/engine/ops/config_ops.rs
+++ b/src/engine/ops/config_ops.rs
@@ -1,29 +1,45 @@
 use crate::db::Db;
 use rquickjs::{Ctx, Function, Object, Result as JsResult};
+use sqlx::PgPool;
 
 // ── Config ops ───────────────────────────────────────────────────
 
-pub(super) fn register_config_ops<'js>(ctx: &Ctx<'js>, db: Db) -> JsResult<()> {
+pub(super) fn register_config_ops<'js>(
+    ctx: &Ctx<'js>,
+    db: Option<Db>,
+    pg_pool: Option<PgPool>,
+) -> JsResult<()> {
     let ad: Object<'js> = ctx.globals().get("agentdesk")?;
     let config_obj = Object::new(ctx.clone())?;
 
     // __config_get_raw(key) → JSON string: "null" or "\"value\""
     let db_c = db;
+    let pg_c = pg_pool;
     config_obj.set(
         "__get_raw",
         Function::new(
             ctx.clone(),
             rquickjs::function::MutFn::from(move |key: String| -> String {
-                let conn = match db_c.separate_conn() {
-                    Ok(c) => c,
-                    Err(_) => return "null".to_string(),
-                };
-                match conn.query_row("SELECT value FROM kv_meta WHERE key = ?1", [&key], |row| {
-                    row.get::<_, String>(0)
-                }) {
-                    Ok(val) => serde_json::to_string(&val).unwrap_or_else(|_| "null".to_string()),
-                    Err(_) => "null".to_string(),
+                if let Some(pool) = pg_c.as_ref() {
+                    return config_get_raw_pg(pool, &key);
                 }
+                if let Some(db_c) = db_c.as_ref() {
+                    let conn = match db_c.separate_conn() {
+                        Ok(c) => c,
+                        Err(_) => return "null".to_string(),
+                    };
+                    return match conn.query_row(
+                        "SELECT value FROM kv_meta WHERE key = ?1",
+                        [&key],
+                        |row| row.get::<_, String>(0),
+                    ) {
+                        Ok(val) => {
+                            serde_json::to_string(&val).unwrap_or_else(|_| "null".to_string())
+                        }
+                        Err(_) => "null".to_string(),
+                    };
+                }
+                "null".to_string()
             }),
         )?,
     )?;
@@ -43,4 +59,23 @@ pub(super) fn register_config_ops<'js>(ctx: &Ctx<'js>, db: Db) -> JsResult<()> {
     )?;
 
     Ok(())
+}
+
+fn config_get_raw_pg(pool: &PgPool, key: &str) -> String {
+    let key = key.to_string();
+    crate::utils::async_bridge::block_on_pg_result(
+        pool,
+        move |bridge_pool| async move {
+            let value = sqlx::query_scalar::<_, String>("SELECT value FROM kv_meta WHERE key = $1")
+                .bind(&key)
+                .fetch_optional(&bridge_pool)
+                .await
+                .map_err(|error| format!("load postgres kv_meta {key}: {error}"))?;
+            Ok(value
+                .and_then(|value| serde_json::to_string(&value).ok())
+                .unwrap_or_else(|| "null".to_string()))
+        },
+        |_error| "null".to_string(),
+    )
+    .unwrap_or_else(|value| value)
 }

--- a/src/engine/ops/db_ops.rs
+++ b/src/engine/ops/db_ops.rs
@@ -16,7 +16,7 @@ const POLICY_DB_WARN_THRESHOLD: Duration = Duration::from_millis(100);
 
 pub(super) fn register_db_ops<'js>(
     ctx: &Ctx<'js>,
-    db: Db,
+    db: Option<Db>,
     pg_pool: Option<PgPool>,
 ) -> JsResult<()> {
     let ad: Object<'js> = ctx.globals().get("agentdesk")?;
@@ -28,7 +28,7 @@ pub(super) fn register_db_ops<'js>(
     let query_raw = Function::new(
         ctx.clone(),
         rquickjs::function::MutFn::from(move |sql: String, params_json: String| -> String {
-            db_query_raw(&db_q, pg_q.clone(), &sql, &params_json)
+            db_query_raw(db_q.as_ref(), pg_q.clone(), &sql, &params_json)
         }),
     )?;
     db_obj.set("__query_raw", query_raw)?;
@@ -39,7 +39,7 @@ pub(super) fn register_db_ops<'js>(
     let execute_raw = Function::new(
         ctx.clone(),
         rquickjs::function::MutFn::from(move |sql: String, params_json: String| -> String {
-            db_execute_raw(&db_e, pg_e.clone(), &sql, &params_json)
+            db_execute_raw(db_e.as_ref(), pg_e.clone(), &sql, &params_json)
         }),
     )?;
     db_obj.set("__execute_raw", execute_raw)?;
@@ -98,7 +98,7 @@ fn db_guard_raw(sql: &str, origin: &str) -> String {
     }
 }
 
-fn db_query_raw(db: &Db, pg_pool: Option<PgPool>, sql: &str, params_json: &str) -> String {
+fn db_query_raw(db: Option<&Db>, pg_pool: Option<PgPool>, sql: &str, params_json: &str) -> String {
     let started = std::time::Instant::now();
     let params: Vec<serde_json::Value> =
         match parse_params_json(params_json, "agentdesk.db.query.parse_params", sql) {
@@ -109,6 +109,13 @@ fn db_query_raw(db: &Db, pg_pool: Option<PgPool>, sql: &str, params_json: &str) 
     if let Some(pg_pool) = pg_pool {
         return db_query_raw_pg(&pg_pool, sql, &params, started);
     }
+    let Some(db) = db else {
+        return policy_db_error_json(
+            "agentdesk.db.query.sqlite_backend",
+            sql,
+            "sqlite backend is unavailable".to_string(),
+        );
+    };
 
     let bind: Vec<libsql_rusqlite::types::Value> = params.iter().map(json_to_sqlite).collect(); // TODO(#839): sqlite compatibility retained for out-of-scope callers or legacy tests.
 
@@ -251,7 +258,12 @@ fn db_query_raw_pg(
     })
 }
 
-fn db_execute_raw(db: &Db, pg_pool: Option<PgPool>, sql: &str, params_json: &str) -> String {
+fn db_execute_raw(
+    db: Option<&Db>,
+    pg_pool: Option<PgPool>,
+    sql: &str,
+    params_json: &str,
+) -> String {
     let started = std::time::Instant::now();
     if let Some(violation) = detect_core_table_write(sql) {
         return serde_json::json!({ "error": violation.error_message() }).to_string();
@@ -266,6 +278,13 @@ fn db_execute_raw(db: &Db, pg_pool: Option<PgPool>, sql: &str, params_json: &str
     if let Some(pg_pool) = pg_pool {
         return db_execute_raw_pg(&pg_pool, sql, &params, started);
     }
+    let Some(db) = db else {
+        return policy_db_error_json(
+            "agentdesk.db.execute.sqlite_backend",
+            sql,
+            "sqlite backend is unavailable".to_string(),
+        );
+    };
 
     let bind: Vec<libsql_rusqlite::types::Value> = params.iter().map(json_to_sqlite).collect(); // TODO(#839): sqlite compatibility retained for out-of-scope callers or legacy tests.
 

--- a/src/engine/ops/dispatch_ops.rs
+++ b/src/engine/ops/dispatch_ops.rs
@@ -1,3 +1,4 @@
+use crate::db::Db;
 use rquickjs::{Ctx, Function, Object, Result as JsResult};
 use serde_json::json;
 use sqlx::{PgPool, Row as SqlxRow};
@@ -8,12 +9,17 @@ use sqlx::{PgPool, Row as SqlxRow};
 // Creates a task_dispatch row + updates kanban card to "requested".
 // Discord notification is handled by posting to the local /api/send endpoint.
 
-pub(super) fn register_dispatch_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>) -> JsResult<()> {
+pub(super) fn register_dispatch_ops<'js>(
+    ctx: &Ctx<'js>,
+    db: Option<Db>,
+    pg_pool: Option<PgPool>,
+) -> JsResult<()> {
     let ad: Object<'js> = ctx.globals().get("agentdesk")?;
     let dispatch_obj = Object::new(ctx.clone())?;
 
     // #248: __dispatch_create_raw(card_id, agent_id, dispatch_type, title, context_json)
     // -> json_string. Synchronous PG INSERT — no deferred intent.
+    let db_create = db.clone();
     let pg_create = pg_pool.clone();
     dispatch_obj.set(
         "__create_raw",
@@ -26,20 +32,15 @@ pub(super) fn register_dispatch_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>
                       title: String,
                       context_json: String|
                       -> String {
-                    match pg_create.as_ref() {
-                        Some(pool) => dispatch_create_raw_pg(
-                            pool,
-                            &card_id,
-                            &agent_id,
-                            &dispatch_type,
-                            &title,
-                            &context_json,
-                        ),
-                        None => {
-                            r#"{"error":"postgres pool required for dispatch.create in JS hook"}"#
-                                .to_string()
-                        }
-                    }
+                    dispatch_create_raw(
+                        db_create.as_ref(),
+                        pg_create.as_ref(),
+                        &card_id,
+                        &agent_id,
+                        &dispatch_type,
+                        &title,
+                        &context_json,
+                    )
                 },
             ),
         )?,
@@ -47,6 +48,7 @@ pub(super) fn register_dispatch_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>
 
     // __mark_failed_raw(dispatch_id, reason) → json_string
     // Marks a dispatch as failed. Used by timeout handlers.
+    let db_mf = db.clone();
     let pg_mf = pg_pool.clone();
     dispatch_obj.set(
         "__mark_failed_raw",
@@ -64,13 +66,25 @@ pub(super) fn register_dispatch_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>
                         false,
                     );
                 }
-                r#"{"error":"postgres pool required for dispatch.markFailed"}"#.to_string()
+                if let Some(db) = db_mf.as_ref() {
+                    let reason_json = json!({ "reason": reason });
+                    return dispatch_set_status_raw_sqlite_test(
+                        db,
+                        &dispatch_id,
+                        "failed",
+                        Some(reason_json),
+                        "js_dispatch_mark_failed_raw",
+                        false,
+                    );
+                }
+                r#"{"error":"backend unavailable for dispatch.markFailed"}"#.to_string()
             },
         )?,
     )?;
 
     // __mark_completed_raw(dispatch_id, result_json) → json_string
     // Marks a dispatch as completed. Used by orphan recovery.
+    let db_mc = db.clone();
     let pg_mc = pg_pool.clone();
     dispatch_obj.set(
         "__mark_completed_raw",
@@ -89,13 +103,26 @@ pub(super) fn register_dispatch_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>
                         true,
                     );
                 }
-                r#"{"error":"postgres pool required for dispatch.markCompleted"}"#.to_string()
+                if let Some(db) = db_mc.as_ref() {
+                    let parsed_result = serde_json::from_str::<serde_json::Value>(&result_json)
+                        .unwrap_or_else(|_| serde_json::json!({ "raw_result": result_json }));
+                    return dispatch_set_status_raw_sqlite_test(
+                        db,
+                        &dispatch_id,
+                        "completed",
+                        Some(parsed_result),
+                        "js_dispatch_mark_completed_raw",
+                        true,
+                    );
+                }
+                r#"{"error":"backend unavailable for dispatch.markCompleted"}"#.to_string()
             },
         )?,
     )?;
 
     // __has_active_work_raw(card_id) → json_string {"count":N}
     // Checks if a card has active implementation/rework dispatches.
+    let db_aw = db.clone();
     let pg_aw = pg_pool.clone();
     dispatch_obj.set(
         "__has_active_work_raw",
@@ -103,12 +130,16 @@ pub(super) fn register_dispatch_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>
             if let Some(pool) = pg_aw.as_ref() {
                 return dispatch_has_active_work_raw_pg(pool, &card_id);
             }
-            r#"{"error":"postgres pool required for dispatch.hasActiveWork"}"#.to_string()
+            if let Some(db) = db_aw.as_ref() {
+                return dispatch_has_active_work_raw_sqlite_test(db, &card_id);
+            }
+            r#"{"error":"backend unavailable for dispatch.hasActiveWork"}"#.to_string()
         })?,
     )?;
 
     // __set_retry_count_raw(dispatch_id, count) → json_string
     // Updates retry_count for auto-retry tracking.
+    let db_rc = db;
     let pg_rc = pg_pool;
     dispatch_obj.set(
         "__set_retry_count_raw",
@@ -118,7 +149,10 @@ pub(super) fn register_dispatch_ops<'js>(ctx: &Ctx<'js>, pg_pool: Option<PgPool>
                 if let Some(pool) = pg_rc.as_ref() {
                     return dispatch_set_retry_count_raw_pg(pool, &dispatch_id, count);
                 }
-                r#"{"error":"postgres pool required for dispatch.setRetryCount"}"#.to_string()
+                if let Some(db) = db_rc.as_ref() {
+                    return dispatch_set_retry_count_raw_sqlite_test(db, &dispatch_id, count);
+                }
+                r#"{"error":"backend unavailable for dispatch.setRetryCount"}"#.to_string()
             },
         )?,
     )?;
@@ -277,6 +311,119 @@ fn dispatch_create_raw_pg(
     }
 }
 
+fn dispatch_create_raw(
+    db: Option<&Db>,
+    pg_pool: Option<&PgPool>,
+    card_id: &str,
+    agent_id: &str,
+    dispatch_type: &str,
+    title: &str,
+    context_json: &str,
+) -> String {
+    if let Some(pool) = pg_pool {
+        return dispatch_create_raw_pg(pool, card_id, agent_id, dispatch_type, title, context_json);
+    }
+    if let Some(db) = db {
+        return dispatch_create_raw_sqlite_test(
+            db,
+            card_id,
+            agent_id,
+            dispatch_type,
+            title,
+            context_json,
+        );
+    }
+    r#"{"error":"backend unavailable for dispatch.create in JS hook"}"#.to_string()
+}
+
+#[cfg(test)]
+fn dispatch_create_raw_sqlite_test(
+    db: &Db,
+    card_id: &str,
+    agent_id: &str,
+    dispatch_type: &str,
+    title: &str,
+    context_json: &str,
+) -> String {
+    let context: serde_json::Value = match serde_json::from_str(context_json) {
+        Ok(value) => value,
+        Err(error) => {
+            return format!(
+                r#"{{"error":"invalid dispatch context JSON: {}"}}"#,
+                error.to_string().replace('"', "'")
+            );
+        }
+    };
+    let options = crate::dispatch::DispatchCreateOptions {
+        skip_outbox: false,
+        sidecar_dispatch: context
+            .get("sidecar_dispatch")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false)
+            || context
+                .get("phase_gate")
+                .and_then(|value| value.as_object())
+                .is_some(),
+    };
+    match crate::dispatch::create_dispatch_record_sqlite_test(
+        db,
+        card_id,
+        agent_id,
+        dispatch_type,
+        title,
+        &context,
+        options,
+    ) {
+        Ok((dispatch_id, _old_status, reused)) => {
+            if dispatch_type == "review-decision" {
+                let conn = match db.separate_conn() {
+                    Ok(conn) => conn,
+                    Err(error) => {
+                        return format!(
+                            r#"{{"error":"open sqlite connection for dispatch.create: {}"}}"#,
+                            error.to_string().replace('"', "'")
+                        );
+                    }
+                };
+                if let Err(error) = conn.execute(
+                    "INSERT INTO card_review_state (
+                        card_id,
+                        state,
+                        pending_dispatch_id,
+                        updated_at
+                     ) VALUES (?1, 'suggestion_pending', ?2, datetime('now'))
+                     ON CONFLICT(card_id) DO UPDATE
+                     SET state = 'suggestion_pending',
+                         pending_dispatch_id = excluded.pending_dispatch_id,
+                         updated_at = datetime('now')",
+                    libsql_rusqlite::params![card_id, dispatch_id],
+                ) {
+                    return format!(r#"{{"error":"{}"}}"#, error.to_string().replace('"', "'"));
+                }
+            }
+            if reused {
+                return format!(r#"{{"dispatch_id":"{dispatch_id}","reused":true}}"#);
+            }
+            format!(r#"{{"dispatch_id":"{dispatch_id}"}}"#)
+        }
+        Err(error) => {
+            format!(r#"{{"error":"{}"}}"#, error.to_string().replace('"', "'"))
+        }
+    }
+}
+
+#[cfg(not(test))]
+fn dispatch_create_raw_sqlite_test(
+    _db: &Db,
+    _card_id: &str,
+    _agent_id: &str,
+    _dispatch_type: &str,
+    _title: &str,
+    _context_json: &str,
+) -> String {
+    r#"{"error":"sqlite backend is unavailable for dispatch.create in production"}"#.to_string()
+}
+
 fn dispatch_has_active_work_raw_pg(pool: &PgPool, card_id: &str) -> String {
     let card_id = card_id.to_string();
     match crate::utils::async_bridge::block_on_pg_result(
@@ -301,6 +448,34 @@ fn dispatch_has_active_work_raw_pg(pool: &PgPool, card_id: &str) -> String {
     }
 }
 
+#[cfg(test)]
+fn dispatch_has_active_work_raw_sqlite_test(db: &Db, card_id: &str) -> String {
+    let conn = match db.separate_conn() {
+        Ok(conn) => conn,
+        Err(error) => {
+            return format!(r#"{{"error":"{}"}}"#, error.to_string().replace('"', "'"));
+        }
+    };
+    match conn.query_row(
+        "SELECT COUNT(*)
+         FROM task_dispatches
+         WHERE kanban_card_id = ?1
+           AND dispatch_type IN ('implementation', 'rework')
+           AND status IN ('pending', 'dispatched')",
+        [card_id],
+        |row| row.get::<_, i64>(0),
+    ) {
+        Ok(count) => format!(r#"{{"count":{count}}}"#),
+        Err(error) => format!(r#"{{"error":"{}"}}"#, error.to_string().replace('"', "'")),
+    }
+}
+
+#[cfg(not(test))]
+fn dispatch_has_active_work_raw_sqlite_test(_db: &Db, _card_id: &str) -> String {
+    r#"{"error":"sqlite backend is unavailable for dispatch.hasActiveWork in production"}"#
+        .to_string()
+}
+
 fn dispatch_set_retry_count_raw_pg(pool: &PgPool, dispatch_id: &str, count: i32) -> String {
     let dispatch_id = dispatch_id.to_string();
     match crate::utils::async_bridge::block_on_pg_result(
@@ -321,6 +496,29 @@ fn dispatch_set_retry_count_raw_pg(pool: &PgPool, dispatch_id: &str, count: i32)
         Ok(rows_affected) => format!(r#"{{"ok":true,"rows_affected":{rows_affected}}}"#),
         Err(error_json) => error_json,
     }
+}
+
+#[cfg(test)]
+fn dispatch_set_retry_count_raw_sqlite_test(db: &Db, dispatch_id: &str, count: i32) -> String {
+    let conn = match db.separate_conn() {
+        Ok(conn) => conn,
+        Err(error) => {
+            return format!(r#"{{"error":"{}"}}"#, error.to_string().replace('"', "'"));
+        }
+    };
+    match conn.execute(
+        "UPDATE task_dispatches SET retry_count = ?1 WHERE id = ?2",
+        libsql_rusqlite::params![count, dispatch_id],
+    ) {
+        Ok(rows_affected) => format!(r#"{{"ok":true,"rows_affected":{rows_affected}}}"#),
+        Err(error) => format!(r#"{{"error":"{}"}}"#, error.to_string().replace('"', "'")),
+    }
+}
+
+#[cfg(not(test))]
+fn dispatch_set_retry_count_raw_sqlite_test(_db: &Db, _dispatch_id: &str, _count: i32) -> String {
+    r#"{"error":"sqlite backend is unavailable for dispatch.setRetryCount in production"}"#
+        .to_string()
 }
 
 fn dispatch_set_status_raw_pg(
@@ -513,4 +711,46 @@ fn dispatch_set_status_raw_pg(
         Ok(rows_affected) => format!(r#"{{"ok":true,"rows_affected":{rows_affected}}}"#),
         Err(error_json) => error_json,
     }
+}
+
+#[cfg(test)]
+fn dispatch_set_status_raw_sqlite_test(
+    db: &Db,
+    dispatch_id: &str,
+    to_status: &str,
+    result: Option<serde_json::Value>,
+    transition_source: &str,
+    touch_completed_at: bool,
+) -> String {
+    let conn = match db.separate_conn() {
+        Ok(conn) => conn,
+        Err(error) => {
+            return format!(r#"{{"error":"{}"}}"#, error.to_string().replace('"', "'"));
+        }
+    };
+    match crate::dispatch::set_dispatch_status_on_conn(
+        &conn,
+        dispatch_id,
+        to_status,
+        result.as_ref(),
+        transition_source,
+        Some(&["pending", "dispatched"]),
+        touch_completed_at,
+    ) {
+        Ok(rows_affected) => format!(r#"{{"ok":true,"rows_affected":{rows_affected}}}"#),
+        Err(error) => format!(r#"{{"error":"{}"}}"#, error.to_string().replace('"', "'")),
+    }
+}
+
+#[cfg(not(test))]
+fn dispatch_set_status_raw_sqlite_test(
+    _db: &Db,
+    _dispatch_id: &str,
+    _to_status: &str,
+    _result: Option<serde_json::Value>,
+    _transition_source: &str,
+    _touch_completed_at: bool,
+) -> String {
+    r#"{"error":"sqlite backend is unavailable for dispatch status updates in production"}"#
+        .to_string()
 }

--- a/src/engine/ops/dm_reply_ops.rs
+++ b/src/engine/ops/dm_reply_ops.rs
@@ -14,7 +14,7 @@ use std::future::Future;
 
 pub(super) fn register_dm_reply_ops<'js>(
     ctx: &Ctx<'js>,
-    db: Db,
+    db: Option<Db>,
     pg_pool: Option<PgPool>,
 ) -> JsResult<()> {
     let ad: Object<'js> = ctx.globals().get("agentdesk")?;
@@ -35,7 +35,7 @@ pub(super) fn register_dm_reply_ops<'js>(
                       ttl_seconds: i64|
                       -> String {
                     dm_reply_register_raw(
-                        &db_reg,
+                        db_reg.as_ref(),
                         pg_reg.clone(),
                         &source_agent,
                         &user_id,
@@ -56,7 +56,7 @@ pub(super) fn register_dm_reply_ops<'js>(
         Function::new(
             ctx.clone(),
             rquickjs::function::MutFn::from(move |user_id: String| -> String {
-                dm_reply_consume_raw(&db_con, pg_con.clone(), &user_id)
+                dm_reply_consume_raw(db_con.as_ref(), pg_con.clone(), &user_id)
             }),
         )?,
     )?;
@@ -69,7 +69,7 @@ pub(super) fn register_dm_reply_ops<'js>(
         Function::new(
             ctx.clone(),
             rquickjs::function::MutFn::from(move |user_id: String| -> String {
-                dm_reply_pending_raw(&db_pend, pg_pend.clone(), &user_id)
+                dm_reply_pending_raw(db_pend.as_ref(), pg_pend.clone(), &user_id)
             }),
         )?,
     )?;
@@ -82,7 +82,7 @@ pub(super) fn register_dm_reply_ops<'js>(
         Function::new(
             ctx.clone(),
             rquickjs::function::MutFn::from(move |user_id: String| -> String {
-                dm_reply_read_consumed_raw(&db_read, pg_read.clone(), &user_id)
+                dm_reply_read_consumed_raw(db_read.as_ref(), pg_read.clone(), &user_id)
             }),
         )?,
     )?;
@@ -117,7 +117,7 @@ pub(super) fn register_dm_reply_ops<'js>(
 }
 
 fn dm_reply_register_raw(
-    db: &Db,
+    db: Option<&Db>,
     pg_pool: Option<PgPool>,
     source_agent: &str,
     user_id: &str,
@@ -127,6 +127,9 @@ fn dm_reply_register_raw(
 ) -> String {
     let ch = (!channel_id.is_empty()).then_some(channel_id);
     let result = if let Some(pg_pool) = pg_pool {
+        let Some(db) = db.cloned() else {
+            return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+        };
         let db = db.clone();
         let source_agent = source_agent.trim().to_string();
         let user_id = user_id.trim().to_string();
@@ -144,8 +147,10 @@ fn dm_reply_register_raw(
             )
             .await
         })
-    } else {
+    } else if let Some(db) = db {
         register_pending_dm_reply(db, source_agent, user_id, ch, context, ttl_seconds)
+    } else {
+        Err("sqlite backend is unavailable".to_string())
     };
 
     match result {
@@ -163,8 +168,11 @@ fn dm_reply_register_raw(
     }
 }
 
-fn dm_reply_consume_raw(db: &Db, pg_pool: Option<PgPool>, user_id: &str) -> String {
+fn dm_reply_consume_raw(db: Option<&Db>, pg_pool: Option<PgPool>, user_id: &str) -> String {
     if let Some(pg_pool) = pg_pool {
+        let Some(db) = db.cloned() else {
+            return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+        };
         let db = db.clone();
         let user_id = user_id.to_string();
         let log_user_id = user_id.clone();
@@ -191,6 +199,9 @@ fn dm_reply_consume_raw(db: &Db, pg_pool: Option<PgPool>, user_id: &str) -> Stri
         };
     }
 
+    let Some(db) = db else {
+        return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+    };
     let conn = match db.separate_conn() {
         Ok(c) => c,
         Err(e) => return format!(r#"{{"error":"db connection: {e}"}}"#),
@@ -249,8 +260,11 @@ fn dm_reply_consume_raw(db: &Db, pg_pool: Option<PgPool>, user_id: &str) -> Stri
     }
 }
 
-fn dm_reply_pending_raw(db: &Db, pg_pool: Option<PgPool>, user_id: &str) -> String {
+fn dm_reply_pending_raw(db: Option<&Db>, pg_pool: Option<PgPool>, user_id: &str) -> String {
     if let Some(pg_pool) = pg_pool {
+        let Some(db) = db.cloned() else {
+            return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+        };
         let db = db.clone();
         let user_id = user_id.to_string();
         return match run_async_bridge_pg(&pg_pool, move |pool| async move {
@@ -262,6 +276,9 @@ fn dm_reply_pending_raw(db: &Db, pg_pool: Option<PgPool>, user_id: &str) -> Stri
         };
     }
 
+    let Some(db) = db else {
+        return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+    };
     let conn = match db.separate_conn() {
         Ok(c) => c,
         Err(e) => return format!(r#"{{"error":"db connection: {e}"}}"#),
@@ -294,8 +311,11 @@ fn dm_reply_pending_raw(db: &Db, pg_pool: Option<PgPool>, user_id: &str) -> Stri
     }
 }
 
-fn dm_reply_read_consumed_raw(db: &Db, pg_pool: Option<PgPool>, user_id: &str) -> String {
+fn dm_reply_read_consumed_raw(db: Option<&Db>, pg_pool: Option<PgPool>, user_id: &str) -> String {
     if let Some(pg_pool) = pg_pool {
+        let Some(db) = db.cloned() else {
+            return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+        };
         let db = db.clone();
         let user_id = user_id.to_string();
         return match run_async_bridge_pg(&pg_pool, move |pool| async move {
@@ -307,6 +327,9 @@ fn dm_reply_read_consumed_raw(db: &Db, pg_pool: Option<PgPool>, user_id: &str) -
         };
     }
 
+    let Some(db) = db else {
+        return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+    };
     let conn = match db.separate_conn() {
         Ok(c) => c,
         Err(e) => return format!(r#"{{"error":"db connection: {e}"}}"#),
@@ -501,7 +524,7 @@ mod tests {
             let globals = ctx.globals();
             let ad = Object::new(ctx.clone()).expect("agentdesk object");
             globals.set("agentdesk", ad).expect("install agentdesk");
-            register_dm_reply_ops(&ctx, sqlite_db.clone(), Some(pg_pool.clone()))
+            register_dm_reply_ops(&ctx, Some(sqlite_db.clone()), Some(pg_pool.clone()))
                 .expect("register dmReply ops");
 
             let raw: String = ctx

--- a/src/engine/ops/kanban_ops.rs
+++ b/src/engine/ops/kanban_ops.rs
@@ -10,7 +10,7 @@ use sqlx::{PgPool, Postgres, QueryBuilder, Row as SqlxRow};
 
 pub(super) fn register_kanban_ops<'js>(
     ctx: &Ctx<'js>,
-    db: Db,
+    db: Option<Db>,
     pg_pool: Option<PgPool>,
 ) -> JsResult<()> {
     let ad: Object<'js> = ctx.globals().get("agentdesk")?;
@@ -26,6 +26,9 @@ pub(super) fn register_kanban_ops<'js>(
                 if let Some(pool) = pg_set.as_ref() {
                     return set_status_raw_pg(pool, &card_id, &new_status, force.unwrap_or(false));
                 }
+                let Some(db_set) = db_set.as_ref() else {
+                    return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+                };
                 let conn = match db_set.separate_conn() {
                     Ok(c) => c,
                     Err(e) => return format!(r#"{{"error":"DB lock: {}"}}"#, e),
@@ -233,6 +236,9 @@ pub(super) fn register_kanban_ops<'js>(
     kanban_obj.set(
         "__reopenRaw",
         Function::new(ctx.clone(), move |card_id: String, new_status: String| -> String {
+            let Some(db_reopen) = db_reopen.as_ref() else {
+                return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+            };
             let conn = match db_reopen.separate_conn() {
                 Ok(c) => c,
                 Err(e) => return format!(r#"{{"error":"DB lock: {}"}}"#, e),
@@ -322,7 +328,7 @@ pub(super) fn register_kanban_ops<'js>(
                 }
             }
 
-            crate::kanban::correct_tn_to_fn_on_reopen(&db_reopen, pg_reopen.as_ref(), &card_id);
+            crate::kanban::correct_tn_to_fn_on_reopen(db_reopen, pg_reopen.as_ref(), &card_id);
 
             let has_hooks = pipeline
                 .hooks_for_state(&new_status)
@@ -357,6 +363,9 @@ pub(super) fn register_kanban_ops<'js>(
             if let Some(pool) = pg_get.as_ref() {
                 return get_card_raw_pg(pool, &card_id);
             }
+            let Some(db_get) = db_get.as_ref() else {
+                return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+            };
             let conn = match db_get.separate_conn() {
                 Ok(c) => c,
                 Err(e) => return format!(r#"{{"error":"{}"}}"#, e),
@@ -396,6 +405,9 @@ pub(super) fn register_kanban_ops<'js>(
                         expected_dispatch_id.as_deref(),
                     );
                 }
+                let Some(db_clear_latest) = db_clear_latest.as_ref() else {
+                    return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+                };
                 let conn = match db_clear_latest.separate_conn() {
                     Ok(c) => c,
                     Err(e) => return format!(r#"{{"error":"{}"}}"#, e),
@@ -440,6 +452,9 @@ pub(super) fn register_kanban_ops<'js>(
                 let opts: serde_json::Value = match serde_json::from_str(&opts_json) {
                     Ok(v) => v,
                     Err(e) => return format!(r#"{{"error":"bad opts: {}"}}"#, e),
+                };
+                let Some(db_review) = db_review.as_ref() else {
+                    return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
                 };
                 let conn = match db_review.separate_conn() {
                     Ok(c) => c,
@@ -1054,6 +1069,20 @@ pub(super) fn review_state_sync(db: &Db, json_str: &str) -> String {
     review_state_sync_on_conn(&conn, json_str)
 }
 
+pub(super) fn review_state_sync_with_backends(
+    db: Option<&Db>,
+    pg_pool: Option<&PgPool>,
+    json_str: &str,
+) -> String {
+    if let Some(pool) = pg_pool {
+        return review_state_sync_pg(pool, json_str);
+    }
+    let Some(db) = db else {
+        return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+    };
+    review_state_sync(db, json_str)
+}
+
 /// Best-effort auto-queue cleanup for terminal cards.
 ///
 /// When a card finishes, its active dispatch entry should become `done` and any
@@ -1239,5 +1268,124 @@ pub(super) fn review_state_sync_on_conn(
     match result {
         Ok(n) => format!(r#"{{"ok":true,"rows_affected":{n}}}"#),
         Err(e) => format!(r#"{{"error":"sql error: {}"}}"#, e),
+    }
+}
+
+fn review_state_sync_pg(pool: &PgPool, json_str: &str) -> String {
+    let params: serde_json::Value = match serde_json::from_str(json_str) {
+        Ok(v) => v,
+        Err(e) => return format!(r#"{{"error":"invalid JSON: {}"}}"#, e),
+    };
+
+    let card_id = params["card_id"].as_str().unwrap_or("");
+    let state = params["state"].as_str().unwrap_or("");
+    if card_id.is_empty() || state.is_empty() {
+        return r#"{"error":"card_id and state are required"}"#.to_string();
+    }
+
+    let card_id = card_id.to_string();
+    let state = state.to_string();
+    let review_round = params["review_round"].as_i64();
+    let last_verdict = params["last_verdict"].as_str().map(str::to_string);
+    let last_decision = params["last_decision"].as_str().map(str::to_string);
+    let pending_dispatch_id = params["pending_dispatch_id"].as_str().map(str::to_string);
+    let approach_change_round = params["approach_change_round"].as_i64();
+    let session_reset_round = params["session_reset_round"].as_i64();
+    let review_entered_at = params["review_entered_at"].as_str().map(str::to_string);
+
+    let result = crate::utils::async_bridge::block_on_pg_result(
+        pool,
+        move |bridge_pool| async move {
+            if state == "clear_verdict" {
+                let rows_affected = sqlx::query(
+                    "UPDATE card_review_state
+                     SET last_verdict = NULL,
+                         updated_at = NOW()
+                     WHERE card_id = $1",
+                )
+                .bind(&card_id)
+                .execute(&bridge_pool)
+                .await
+                .map_err(|error| format!("clear postgres review verdict for {card_id}: {error}"))?
+                .rows_affected();
+                return Ok(format!(r#"{{"ok":true,"rows_affected":{rows_affected}}}"#));
+            }
+
+            let rows_affected = sqlx::query(
+                "INSERT INTO card_review_state (
+                    card_id,
+                    state,
+                    review_round,
+                    last_verdict,
+                    last_decision,
+                    pending_dispatch_id,
+                    approach_change_round,
+                    session_reset_round,
+                    review_entered_at,
+                    updated_at
+                 ) VALUES (
+                    $1,
+                    $2,
+                    COALESCE(
+                        $3,
+                        (SELECT COALESCE(review_round, 0)::BIGINT FROM kanban_cards WHERE id = $1),
+                        0
+                    ),
+                    $4,
+                    $5,
+                    $6,
+                    $7,
+                    $8,
+                    COALESCE($9, CASE WHEN $2 = 'reviewing' THEN NOW()::TEXT ELSE NULL END),
+                    NOW()
+                 )
+                 ON CONFLICT(card_id) DO UPDATE SET
+                    state = EXCLUDED.state,
+                    review_round = COALESCE(EXCLUDED.review_round, card_review_state.review_round),
+                    last_verdict = COALESCE(EXCLUDED.last_verdict, card_review_state.last_verdict),
+                    last_decision = COALESCE(EXCLUDED.last_decision, card_review_state.last_decision),
+                    pending_dispatch_id = CASE
+                        WHEN EXCLUDED.pending_dispatch_id IS NOT NULL THEN EXCLUDED.pending_dispatch_id
+                        WHEN EXCLUDED.state = 'suggestion_pending' THEN card_review_state.pending_dispatch_id
+                        ELSE NULL
+                    END,
+                    approach_change_round = COALESCE(
+                        EXCLUDED.approach_change_round,
+                        card_review_state.approach_change_round
+                    ),
+                    session_reset_round = COALESCE(
+                        EXCLUDED.session_reset_round,
+                        card_review_state.session_reset_round
+                    ),
+                    review_entered_at = COALESCE(
+                        EXCLUDED.review_entered_at,
+                        CASE
+                            WHEN EXCLUDED.state = 'reviewing' THEN NOW()::TEXT
+                            ELSE card_review_state.review_entered_at
+                        END
+                    ),
+                    updated_at = NOW()",
+            )
+            .bind(&card_id)
+            .bind(&state)
+            .bind(review_round)
+            .bind(last_verdict)
+            .bind(last_decision)
+            .bind(pending_dispatch_id)
+            .bind(approach_change_round)
+            .bind(session_reset_round)
+            .bind(review_entered_at)
+            .execute(&bridge_pool)
+            .await
+            .map_err(|error| format!("upsert postgres review state for {card_id}: {error}"))?
+            .rows_affected();
+            Ok(format!(r#"{{"ok":true,"rows_affected":{rows_affected}}}"#))
+        },
+        |error| format!(r#"{{"error":"{}"}}"#, error),
+    );
+
+    match result {
+        Ok(value) => value,
+        Err(error_json) => error_json,
     }
 }

--- a/src/engine/ops/kv_ops.rs
+++ b/src/engine/ops/kv_ops.rs
@@ -11,7 +11,7 @@ use sqlx::PgPool;
 
 pub(super) fn register_kv_ops<'js>(
     ctx: &Ctx<'js>,
-    db: Db,
+    db: Option<Db>,
     pg_pool: Option<PgPool>,
 ) -> JsResult<()> {
     let ad: Object<'js> = ctx.globals().get("agentdesk")?;
@@ -28,6 +28,9 @@ pub(super) fn register_kv_ops<'js>(
                 if let Some(pool) = pg_set.as_ref() {
                     return kv_set_raw_pg(pool, &key, &value, ttl_seconds);
                 }
+                let Some(db_set) = db_set.as_ref() else {
+                    return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+                };
                 let conn = match db_set.separate_conn() {
                     Ok(c) => c,
                     Err(e) => return format!(r#"{{"error":"{}"}}"#, e),
@@ -63,6 +66,9 @@ pub(super) fn register_kv_ops<'js>(
             if let Some(pool) = pg_get.as_ref() {
                 return kv_get_raw_pg(pool, &key);
             }
+            let Some(db_get) = db_get.as_ref() else {
+                return r#"{"found":false}"#.to_string();
+            };
             let conn = match db_get.separate_conn() {
                 Ok(c) => c,
                 Err(_) => return r#"{"found":false}"#.to_string(),
@@ -80,13 +86,16 @@ pub(super) fn register_kv_ops<'js>(
 
     // kv.delete(key)
     let db_del = db.clone();
-    let pg_del = pg_pool;
+    let pg_del = pg_pool.clone();
     kv_obj.set(
         "delete",
         Function::new(ctx.clone(), move |key: String| -> String {
             if let Some(pool) = pg_del.as_ref() {
                 return kv_delete_raw_pg(pool, &key);
             }
+            let Some(db_del) = db_del.as_ref() else {
+                return r#"{"error":"sqlite backend is unavailable"}"#.to_string();
+            };
             let conn = match db_del.separate_conn() {
                 Ok(c) => c,
                 Err(e) => return format!(r#"{{"error":"{}"}}"#, e),
@@ -120,8 +129,13 @@ pub(super) fn register_kv_ops<'js>(
     // All review-state mutations go through this single entrypoint.
     {
         let db_rs = db.clone();
+        let pg_rs = pg_pool.clone();
         let sync_raw = Function::new(ctx.clone(), move |json_str: String| -> String {
-            crate::engine::ops::review_state_sync(&db_rs, &json_str)
+            crate::engine::ops::review_state_sync_with_backends(
+                db_rs.as_ref(),
+                pg_rs.as_ref(),
+                &json_str,
+            )
         })?;
 
         let _: rquickjs::Value = ctx.eval(

--- a/src/engine/ops/message_ops.rs
+++ b/src/engine/ops/message_ops.rs
@@ -8,7 +8,7 @@ use sqlx::PgPool;
 
 pub(super) fn register_message_ops<'js>(
     ctx: &Ctx<'js>,
-    db: Db,
+    db: Option<Db>,
     pg_pool: Option<PgPool>,
 ) -> JsResult<()> {
     let ad: Object<'js> = ctx.globals().get("agentdesk")?;
@@ -22,7 +22,7 @@ pub(super) fn register_message_ops<'js>(
         rquickjs::function::MutFn::from(
             move |target: String, content: String, bot: String, source: String| -> String {
                 message_queue_raw(
-                    &db_clone,
+                    db_clone.as_ref(),
                     pg_clone.as_ref(),
                     &target,
                     &content,
@@ -54,7 +54,7 @@ pub(super) fn register_message_ops<'js>(
 }
 
 pub(crate) fn queue_message(
-    db: &Db,
+    db: Option<&Db>,
     pg_pool: Option<&PgPool>,
     target: &str,
     content: &str,
@@ -88,6 +88,9 @@ pub(crate) fn queue_message(
         );
     }
 
+    let Some(db) = db else {
+        return Err("sqlite backend is unavailable".to_string());
+    };
     let conn = db
         .separate_conn()
         .map_err(|e| format!("db connection: {e}"))?;
@@ -100,7 +103,7 @@ pub(crate) fn queue_message(
 }
 
 fn message_queue_raw(
-    db: &Db,
+    db: Option<&Db>,
     pg_pool: Option<&PgPool>,
     target: &str,
     content: &str,
@@ -222,7 +225,7 @@ mod tests {
         let sqlite_db = crate::db::test_db();
 
         let id = queue_message(
-            &sqlite_db,
+            Some(&sqlite_db),
             Some(&pool),
             "channel:alerts",
             "hello from pg",

--- a/src/engine/ops/pipeline_ops.rs
+++ b/src/engine/ops/pipeline_ops.rs
@@ -1,12 +1,17 @@
 use crate::db::Db;
 use rquickjs::{Ctx, Function, Object, Result as JsResult};
+use sqlx::{PgPool, Row as SqlxRow};
 
 // ── Pipeline ops ─────────────────────────────────────────────────
 //
 // Exposes pipeline config to JS policies so they can look up transitions,
 // terminal states, etc. instead of hardcoding state names.
 
-pub(super) fn register_pipeline_ops<'js>(ctx: &Ctx<'js>, db: Db) -> JsResult<()> {
+pub(super) fn register_pipeline_ops<'js>(
+    ctx: &Ctx<'js>,
+    db: Option<Db>,
+    pg_pool: Option<PgPool>,
+) -> JsResult<()> {
     let ad: Object<'js> = ctx.globals().get("agentdesk")?;
     let pipeline_obj = Object::new(ctx.clone())?;
 
@@ -26,10 +31,21 @@ pub(super) fn register_pipeline_ops<'js>(ctx: &Ctx<'js>, db: Db) -> JsResult<()>
 
     // __resolveForCardRaw(cardId): returns the effective pipeline for a card
     let db_resolve = db;
+    let pg_resolve = pg_pool;
     pipeline_obj.set(
         "__resolveForCardRaw",
         Function::new(ctx.clone(), move |card_id: String| -> String {
             crate::pipeline::ensure_loaded();
+            if let Some(pool) = pg_resolve.as_ref() {
+                return resolve_for_card_raw_pg(pool, &card_id);
+            }
+            let Some(db_resolve) = db_resolve.as_ref() else {
+                return crate::pipeline::try_get()
+                    .map(|p| {
+                        serde_json::to_string(&p.to_json()).unwrap_or_else(|_| "null".to_string())
+                    })
+                    .unwrap_or_else(|| "null".to_string());
+            };
             let conn = match db_resolve.lock() {
                 Ok(c) => c,
                 Err(_) => {
@@ -203,4 +219,47 @@ pub(super) fn register_pipeline_ops<'js>(ctx: &Ctx<'js>, db: Db) -> JsResult<()>
     "#)?;
 
     Ok(())
+}
+
+fn resolve_for_card_raw_pg(pool: &PgPool, card_id: &str) -> String {
+    let card_id = card_id.to_string();
+    match crate::utils::async_bridge::block_on_pg_result(
+        pool,
+        move |bridge_pool| async move {
+            let row = sqlx::query(
+                "SELECT repo_id, assigned_agent_id
+                 FROM kanban_cards
+                 WHERE id = $1",
+            )
+            .bind(&card_id)
+            .fetch_optional(&bridge_pool)
+            .await
+            .map_err(|error| format!("load postgres card pipeline context {card_id}: {error}"))?;
+            let (repo_id, agent_id) = if let Some(row) = row {
+                (
+                    row.try_get::<Option<String>, _>("repo_id")
+                        .map_err(|error| {
+                            format!("decode postgres repo_id for {card_id}: {error}")
+                        })?,
+                    row.try_get::<Option<String>, _>("assigned_agent_id")
+                        .map_err(|error| {
+                            format!("decode postgres assigned_agent_id for {card_id}: {error}")
+                        })?,
+                )
+            } else {
+                (None, None)
+            };
+            let effective = crate::pipeline::resolve_for_card_pg(
+                &bridge_pool,
+                repo_id.as_deref(),
+                agent_id.as_deref(),
+            )
+            .await;
+            Ok(serde_json::to_string(&effective.to_json()).unwrap_or_else(|_| "null".to_string()))
+        },
+        |_error| "null".to_string(),
+    ) {
+        Ok(result) => result,
+        Err(result) => result,
+    }
 }

--- a/src/engine/ops/queue_ops.rs
+++ b/src/engine/ops/queue_ops.rs
@@ -6,7 +6,7 @@ use sqlx::PgPool;
 
 pub(super) fn register_queue_ops<'js>(
     ctx: &Ctx<'js>,
-    db: Db,
+    db: Option<Db>,
     pg_pool: Option<PgPool>,
 ) -> JsResult<()> {
     let ad: Object<'js> = ctx.globals().get("agentdesk")?;
@@ -17,7 +17,7 @@ pub(super) fn register_queue_ops<'js>(
     queue_obj.set(
         "__statusRaw",
         Function::new(ctx.clone(), move || -> String {
-            queue_status_raw(&db_status, pg_status.as_ref())
+            queue_status_raw(db_status.as_ref(), pg_status.as_ref())
         })?,
     )?;
 
@@ -38,10 +38,13 @@ pub(super) fn register_queue_ops<'js>(
     Ok(())
 }
 
-fn queue_status_raw(db: &Db, pg_pool: Option<&PgPool>) -> String {
+fn queue_status_raw(db: Option<&Db>, pg_pool: Option<&PgPool>) -> String {
     if let Some(pool) = pg_pool {
         return queue_status_raw_pg(pool);
     }
+    let Some(db) = db else {
+        return json!({ "error": "sqlite backend is unavailable" }).to_string();
+    };
 
     let result = (|| -> anyhow::Result<serde_json::Value> {
         let conn = db.read_conn()?;

--- a/src/engine/ops/review_automation_ops.rs
+++ b/src/engine/ops/review_automation_ops.rs
@@ -26,17 +26,18 @@ use uuid::Uuid;
 
 pub(super) fn register_review_automation_ops<'js>(
     ctx: &Ctx<'js>,
-    db: Db,
+    db: Option<Db>,
     pg_pool: Option<PgPool>,
 ) -> JsResult<()> {
     let ad: Object<'js> = ctx.globals().get("agentdesk")?;
     let obj = Object::new(ctx.clone())?;
 
+    let db_handoff = db.clone();
     let pg_handoff = pg_pool.clone();
     obj.set(
         "__handoffCreatePrRaw",
         Function::new(ctx.clone(), move |payload_json: String| -> String {
-            handoff_create_pr_raw(pg_handoff.as_ref(), &payload_json)
+            handoff_create_pr_raw(db_handoff.as_ref(), pg_handoff.as_ref(), &payload_json)
         })?,
     )?;
 
@@ -48,7 +49,7 @@ pub(super) fn register_review_automation_ops<'js>(
             ctx.clone(),
             move |card_id: String, error: String, stamp_gen: String| -> String {
                 record_pr_create_failure_raw(
-                    &db_record,
+                    db_record.as_ref(),
                     pg_record.as_ref(),
                     &card_id,
                     &error,
@@ -63,7 +64,7 @@ pub(super) fn register_review_automation_ops<'js>(
     obj.set(
         "__reseedPrTrackingRaw",
         Function::new(ctx.clone(), move |card_id: String| -> String {
-            reseed_pr_tracking_raw(&db_reseed, pg_reseed.as_ref(), &card_id)
+            reseed_pr_tracking_raw(db_reseed.as_ref(), pg_reseed.as_ref(), &card_id)
         })?,
     )?;
 
@@ -118,7 +119,7 @@ struct HandoffPayload {
     title: String,
 }
 
-fn handoff_create_pr_raw(pg_pool: Option<&PgPool>, payload_json: &str) -> String {
+fn handoff_create_pr_raw(db: Option<&Db>, pg_pool: Option<&PgPool>, payload_json: &str) -> String {
     let payload: HandoffPayload = match serde_json::from_str(payload_json) {
         Ok(p) => p,
         Err(e) => return json!({"error": format!("invalid payload: {e}")}).to_string(),
@@ -132,18 +133,21 @@ fn handoff_create_pr_raw(pg_pool: Option<&PgPool>, payload_json: &str) -> String
     if payload.branch.trim().is_empty() {
         return json!({"error": "branch is required"}).to_string();
     }
-    let Some(pool) = pg_pool else {
-        return json!({"error": "postgres pool required for reviewAutomation.handoffCreatePr"})
-            .to_string();
+    let result = if let Some(pool) = pg_pool {
+        crate::utils::async_bridge::block_on_pg_result(
+            pool,
+            {
+                let payload = payload.clone();
+                move |bridge_pool| async move { handoff_create_pr_pg(&bridge_pool, &payload).await }
+            },
+            |error| error,
+        )
+    } else {
+        let Some(db) = db else {
+            return json!({"error": "sqlite backend is unavailable"}).to_string();
+        };
+        handoff_create_pr_sqlite_test(db, &payload).map_err(|error| error.to_string())
     };
-    let result = crate::utils::async_bridge::block_on_pg_result(
-        pool,
-        {
-            let payload = payload.clone();
-            move |bridge_pool| async move { handoff_create_pr_pg(&bridge_pool, &payload).await }
-        },
-        |error| error,
-    );
     match result {
         Ok(v) => v.to_string(),
         Err(e) => json!({"error": e}).to_string(),
@@ -539,6 +543,101 @@ async fn handoff_create_pr_pg(
 }
 
 #[cfg(test)]
+fn handoff_create_pr_sqlite_test(
+    db: &Db,
+    payload: &HandoffPayload,
+) -> anyhow::Result<serde_json::Value> {
+    let mut conn = db
+        .separate_conn()
+        .map_err(|e| anyhow::anyhow!("DB conn error: {e}"))?;
+    let tx = conn.transaction()?;
+
+    let current_round: i64 = tx
+        .query_row(
+            "SELECT review_round FROM card_review_state WHERE card_id = ?1",
+            [&payload.card_id],
+            |row| row.get(0),
+        )
+        .unwrap_or(0);
+
+    if let Some((dispatch_id, generation)) =
+        lookup_active_create_pr_dispatch(&tx, &payload.card_id)?
+    {
+        refresh_pr_tracking_reuse_state(&tx, payload, &generation, current_round)?;
+        tx.execute(
+            "UPDATE kanban_cards
+             SET blocked_reason = 'pr:creating',
+                 updated_at = CURRENT_TIMESTAMP
+             WHERE id = ?1",
+            [&payload.card_id],
+        )?;
+        tx.commit()?;
+        return Ok(json!({
+            "ok": true,
+            "reused": true,
+            "dispatch_id": dispatch_id,
+            "generation": generation,
+        }));
+    }
+
+    tx.commit()?;
+
+    let generation = Uuid::new_v4().to_string();
+    let dispatch_id = Uuid::new_v4().to_string();
+    let context = json!({
+        "dispatch_generation": generation,
+        "review_round_at_dispatch": current_round,
+        "sidecar_dispatch": true,
+        "worktree_path": payload.worktree_path,
+        "worktree_branch": payload.branch,
+        "branch": payload.branch,
+    });
+
+    crate::dispatch::create_dispatch_record_with_id_sqlite_test(
+        db,
+        &dispatch_id,
+        &payload.card_id,
+        &payload.agent_id,
+        "create-pr",
+        &payload.title,
+        &context,
+        DispatchCreateOptions {
+            sidecar_dispatch: true,
+            ..Default::default()
+        },
+    )?;
+
+    let mut conn = db
+        .separate_conn()
+        .map_err(|e| anyhow::anyhow!("DB conn error: {e}"))?;
+    let tx = conn.transaction()?;
+    seed_pr_tracking_handoff_state(&tx, payload, &generation, current_round)?;
+    tx.execute(
+        "UPDATE kanban_cards
+         SET blocked_reason = 'pr:creating',
+             updated_at = CURRENT_TIMESTAMP
+         WHERE id = ?1",
+        [&payload.card_id],
+    )?;
+    tx.commit()?;
+
+    Ok(json!({
+        "ok": true,
+        "reused": false,
+        "dispatch_id": dispatch_id,
+        "generation": generation,
+    }))
+}
+
+#[cfg(not(test))]
+fn handoff_create_pr_sqlite_test(
+    _db: &Db,
+    _payload: &HandoffPayload,
+) -> anyhow::Result<serde_json::Value> {
+    anyhow::bail!("postgres pool required for reviewAutomation.handoffCreatePr");
+}
+
+#[cfg(test)]
 fn lookup_active_create_pr_dispatch(
     conn: &libsql_rusqlite::Transaction<'_>,
     card_id: &str,
@@ -630,7 +729,7 @@ fn refresh_pr_tracking_reuse_state(
 // ── recordPrCreateFailure ──────────────────────────────────────────────
 
 fn record_pr_create_failure_raw(
-    db: &Db,
+    db: Option<&Db>,
     pg_pool: Option<&PgPool>,
     card_id: &str,
     error: &str,
@@ -651,6 +750,9 @@ fn record_pr_create_failure_raw(
             |runtime_error| runtime_error,
         )
     } else {
+        let Some(db) = db else {
+            return json!({"error": "sqlite backend is unavailable"}).to_string();
+        };
         record_pr_create_failure_tx(db, card_id, error, stamp_gen).map_err(|e| format!("{e}"))
     };
     match result {
@@ -846,7 +948,7 @@ fn record_pr_create_failure_tx(
 
 // ── reseedPrTracking ──────────────────────────────────────────────────
 
-fn reseed_pr_tracking_raw(db: &Db, pg_pool: Option<&PgPool>, card_id: &str) -> String {
+fn reseed_pr_tracking_raw(db: Option<&Db>, pg_pool: Option<&PgPool>, card_id: &str) -> String {
     if card_id.trim().is_empty() {
         return json!({"error": "card_id is required"}).to_string();
     }
@@ -858,6 +960,9 @@ fn reseed_pr_tracking_raw(db: &Db, pg_pool: Option<&PgPool>, card_id: &str) -> S
             |runtime_error| runtime_error,
         )
     } else {
+        let Some(db) = db else {
+            return json!({"error": "sqlite backend is unavailable"}).to_string();
+        };
         reseed_pr_tracking_tx(db, card_id).map_err(|e| format!("{e}"))
     };
     match result {

--- a/src/engine/ops/review_ops.rs
+++ b/src/engine/ops/review_ops.rs
@@ -8,7 +8,7 @@ pub(crate) const ADVANCE_REVIEW_ROUND_HINT_KEY: &str = "advance_review_round_on_
 
 pub(super) fn register_review_ops<'js>(
     ctx: &Ctx<'js>,
-    db: Db,
+    db: Option<Db>,
     pg_pool: Option<PgPool>,
 ) -> JsResult<()> {
     let ad: Object<'js> = ctx.globals().get("agentdesk")?;
@@ -22,7 +22,10 @@ pub(super) fn register_review_ops<'js>(
             if let Some(pool) = pg_verdict.as_ref() {
                 return review_get_verdict_raw_pg(pool, &card_id);
             }
-            review_get_verdict_raw(&db_verdict, &card_id)
+            db_verdict
+                .as_ref()
+                .map(|db| review_get_verdict_raw(db, &card_id))
+                .unwrap_or_else(|| json!({ "error": "sqlite backend is unavailable" }).to_string())
         })?,
     )?;
 
@@ -34,7 +37,10 @@ pub(super) fn register_review_ops<'js>(
             if let Some(pool) = pg_entry.as_ref() {
                 return review_entry_context_raw_pg(pool, &card_id);
             }
-            review_entry_context_raw(&db_entry, &card_id)
+            db_entry
+                .as_ref()
+                .map(|db| review_entry_context_raw(db, &card_id))
+                .unwrap_or_else(|| json!({ "error": "sqlite backend is unavailable" }).to_string())
         })?,
     )?;
 
@@ -48,7 +54,12 @@ pub(super) fn register_review_ops<'js>(
                 if let Some(pool) = pg_record.as_ref() {
                     return review_record_entry_raw_pg(pool, &card_id, &opts_json);
                 }
-                review_record_entry_raw(&db_record, &card_id, &opts_json)
+                db_record
+                    .as_ref()
+                    .map(|db| review_record_entry_raw(db, &card_id, &opts_json))
+                    .unwrap_or_else(|| {
+                        json!({ "error": "sqlite backend is unavailable" }).to_string()
+                    })
             },
         )?,
     )?;
@@ -61,7 +72,10 @@ pub(super) fn register_review_ops<'js>(
             if let Some(pool) = pg_active_work.as_ref() {
                 return review_has_active_work_raw_pg(pool, &card_id);
             }
-            review_has_active_work_raw(&db_active_work, &card_id)
+            db_active_work
+                .as_ref()
+                .map(|db| review_has_active_work_raw(db, &card_id))
+                .unwrap_or_else(|| json!({ "error": "sqlite backend is unavailable" }).to_string())
         })?,
     )?;
 

--- a/src/engine/ops/runtime_ops.rs
+++ b/src/engine/ops/runtime_ops.rs
@@ -1,4 +1,3 @@
-use crate::db::Db;
 use crate::services::process::{configure_child_process_group, wait_with_output_timeout};
 use crate::supervisor::BridgeHandle;
 use rquickjs::{Ctx, Function, Object, Result as JsResult};
@@ -130,13 +129,12 @@ fn refresh_inventory_docs_json(worktree_path: &str, timeout_ms: Option<u64>) -> 
 
 pub(super) fn register_runtime_ops<'js>(
     ctx: &Ctx<'js>,
-    db: Db,
+    db: Option<crate::db::Db>,
     pg_pool: Option<sqlx::PgPool>,
     bridge: BridgeHandle,
 ) -> JsResult<()> {
     let ad: Object<'js> = ctx.globals().get("agentdesk")?;
     let runtime_obj = Object::new(ctx.clone())?;
-    let db_for_signal = db.clone();
     let bridge_for_signal = bridge.clone();
 
     runtime_obj.set(
@@ -145,7 +143,6 @@ pub(super) fn register_runtime_ops<'js>(
             ctx.clone(),
             move |signal_name: String, evidence_json: String| -> String {
                 crate::supervisor::emit_signal_json(
-                    &db_for_signal,
                     &bridge_for_signal,
                     &signal_name,
                     &evidence_json,
@@ -168,7 +165,7 @@ pub(super) fn register_runtime_ops<'js>(
             ctx.clone(),
             move |card_id: String, terminal_status: String| -> String {
                 crate::services::retrospectives::record_card_retrospective_json(
-                    &db_for_retrospective,
+                    db_for_retrospective.as_ref(),
                     pg_for_retrospective.as_ref(),
                     &card_id,
                     &terminal_status,

--- a/src/engine/ops/tests.rs
+++ b/src/engine/ops/tests.rs
@@ -1068,8 +1068,11 @@ async fn test_auto_queue_activate_bridge_dispatches_without_server_port() {
         .unwrap();
     }
 
-    let engine =
-        crate::engine::PolicyEngine::new(&crate::config::Config::default(), db.clone()).unwrap();
+    let engine = crate::engine::PolicyEngine::new_with_legacy_db(
+        &crate::config::Config::default(),
+        db.clone(),
+    )
+    .unwrap();
     let bridge = crate::supervisor::BridgeHandle::new();
     bridge.attach_engine(&engine);
 
@@ -1158,8 +1161,11 @@ fn js_auto_queue_run_status_bridge_updates_run_and_releases_slots() {
         .unwrap();
     }
 
-    let engine =
-        crate::engine::PolicyEngine::new(&crate::config::Config::default(), db.clone()).unwrap();
+    let engine = crate::engine::PolicyEngine::new_with_legacy_db(
+        &crate::config::Config::default(),
+        db.clone(),
+    )
+    .unwrap();
     let bridge = crate::supervisor::BridgeHandle::new();
     bridge.attach_engine(&engine);
 
@@ -1289,8 +1295,11 @@ fn js_auto_queue_consultation_bridge_updates_card_metadata_and_entry_status() {
         .unwrap();
     }
 
-    let engine =
-        crate::engine::PolicyEngine::new(&crate::config::Config::default(), db.clone()).unwrap();
+    let engine = crate::engine::PolicyEngine::new_with_legacy_db(
+        &crate::config::Config::default(),
+        db.clone(),
+    )
+    .unwrap();
     let bridge = crate::supervisor::BridgeHandle::new();
     bridge.attach_engine(&engine);
 
@@ -1416,8 +1425,11 @@ fn js_auto_queue_phase_gate_bridge_saves_and_clears_rows() {
         .unwrap();
     }
 
-    let engine =
-        crate::engine::PolicyEngine::new(&crate::config::Config::default(), db.clone()).unwrap();
+    let engine = crate::engine::PolicyEngine::new_with_legacy_db(
+        &crate::config::Config::default(),
+        db.clone(),
+    )
+    .unwrap();
     let bridge = crate::supervisor::BridgeHandle::new();
     bridge.attach_engine(&engine);
 

--- a/src/github/sync.rs
+++ b/src/github/sync.rs
@@ -730,7 +730,7 @@ mod tests {
         let mut config = crate::config::Config::default();
         config.policies.dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("policies");
         config.policies.hot_reload = false;
-        crate::engine::PolicyEngine::new(&config, db.clone()).unwrap()
+        crate::engine::PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
     }
 
     #[test]

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -34,14 +34,14 @@ mod tests {
         let mut config = crate::config::Config::default();
         config.policies.dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("policies");
         config.policies.hot_reload = false;
-        PolicyEngine::new(&config, db.clone()).unwrap()
+        PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
     }
 
     fn test_engine_with_dir(db: &db::Db, dir: &std::path::Path) -> PolicyEngine {
         let mut config = crate::config::Config::default();
         config.policies.dir = dir.to_path_buf();
         config.policies.hot_reload = false;
-        PolicyEngine::new(&config, db.clone()).unwrap()
+        PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
     }
 
     struct WorktreeCommitOverrideGuard;

--- a/src/kanban.rs
+++ b/src/kanban.rs
@@ -545,7 +545,7 @@ where
 }
 
 pub async fn transition_status_with_opts_pg(
-    db: &Db,
+    db: Option<&Db>,
     pg_pool: &sqlx::PgPool,
     engine: &PolicyEngine,
     card_id: &str,
@@ -749,6 +749,7 @@ pub async fn transition_status_with_opts_pg(
     );
     if old_manual_intervention
         && !new_manual_intervention
+        && let Some(db) = db
         && let Ok(conn) = db.lock()
         && let Err(error) = clear_escalation_alert_state_on_conn(&conn, card_id)
     {
@@ -768,7 +769,8 @@ pub async fn transition_status_with_opts_pg(
     );
 
     if effective.is_terminal(new_status)
-        && record_true_negative_if_pass(db, engine.pg_pool(), card_id)
+        && record_true_negative_if_pass_with_backends(db, engine.pg_pool(), card_id)
+        && let Some(db) = db
     {
         crate::server::routes::review_verdict::spawn_aggregate_if_needed_with_pg(
             db,
@@ -1147,9 +1149,28 @@ pub fn fire_enter_hooks(db: &Db, engine: &PolicyEngine, card_id: &str, state: &s
 /// Fire hooks for a status transition that already happened in the DB.
 /// Use this when the DB UPDATE was done elsewhere (e.g., update_card with mixed fields).
 pub fn fire_transition_hooks(db: &Db, engine: &PolicyEngine, card_id: &str, from: &str, to: &str) {
+    fire_transition_hooks_with_backends(Some(db), engine.pg_pool(), engine, card_id, from, to);
+}
+
+pub fn fire_transition_hooks_with_backends(
+    db: Option<&Db>,
+    pg_pool: Option<&sqlx::PgPool>,
+    engine: &PolicyEngine,
+    card_id: &str,
+    from: &str,
+    to: &str,
+) {
     if from == to {
         return;
     }
+
+    if let Some(pg_pool) = pg_pool {
+        fire_transition_hooks_pg(db, pg_pool, engine, card_id, from, to);
+        return;
+    }
+    let Some(db) = db else {
+        return;
+    };
 
     // Audit log
     if let Ok(conn) = db.lock() {
@@ -1197,6 +1218,172 @@ pub fn fire_transition_hooks(db: &Db, engine: &PolicyEngine, card_id: &str, from
     }
 
     drain_hook_side_effects(db, engine);
+}
+
+fn fire_transition_hooks_pg(
+    db: Option<&Db>,
+    pg_pool: &sqlx::PgPool,
+    engine: &PolicyEngine,
+    card_id: &str,
+    from: &str,
+    to: &str,
+) {
+    let card_id_owned = card_id.to_string();
+    let from_owned = from.to_string();
+    let to_owned = to.to_string();
+    let effective = match crate::utils::async_bridge::block_on_pg_result(
+        pg_pool,
+        move |bridge_pool| async move {
+            sqlx::query(
+                "INSERT INTO kanban_audit_logs (card_id, from_status, to_status, source, result)
+                 VALUES ($1, $2, $3, 'hook', 'OK')",
+            )
+            .bind(&card_id_owned)
+            .bind(&from_owned)
+            .bind(&to_owned)
+            .execute(&bridge_pool)
+            .await
+            .map_err(|error| {
+                format!("insert postgres kanban audit for {card_id_owned}: {error}")
+            })?;
+            sqlx::query(
+                "INSERT INTO audit_logs (entity_type, entity_id, action, actor)
+                 VALUES ('kanban_card', $1, $2, 'hook')",
+            )
+            .bind(&card_id_owned)
+            .bind(format!("{from_owned}->{to_owned} (OK)"))
+            .execute(&bridge_pool)
+            .await
+            .map_err(|error| format!("insert postgres audit log for {card_id_owned}: {error}"))?;
+
+            crate::pipeline::ensure_loaded();
+            let row = sqlx::query(
+                "SELECT repo_id, assigned_agent_id
+                 FROM kanban_cards
+                 WHERE id = $1",
+            )
+            .bind(&card_id_owned)
+            .fetch_optional(&bridge_pool)
+            .await
+            .map_err(|error| {
+                format!("load postgres card transition context {card_id_owned}: {error}")
+            })?;
+            let (repo_id, agent_id) = if let Some(row) = row {
+                (
+                    row.try_get::<Option<String>, _>("repo_id")
+                        .map_err(|error| {
+                            format!("decode postgres repo_id for {card_id_owned}: {error}")
+                        })?,
+                    row.try_get::<Option<String>, _>("assigned_agent_id")
+                        .map_err(|error| {
+                            format!(
+                                "decode postgres assigned_agent_id for {card_id_owned}: {error}"
+                            )
+                        })?,
+                )
+            } else {
+                (None, None)
+            };
+            Ok(Some(
+                crate::pipeline::resolve_for_card_pg(
+                    &bridge_pool,
+                    repo_id.as_deref(),
+                    agent_id.as_deref(),
+                )
+                .await,
+            ))
+        },
+        |error| error,
+    ) {
+        Ok(value) => value,
+        Err(error) => {
+            tracing::warn!("failed to fire postgres transition hooks for {card_id}: {error}");
+            None
+        }
+    };
+
+    if let Some(ref pipeline) = effective {
+        if pipeline.is_terminal(to) {
+            let card_id_owned = card_id.to_string();
+            let terminal_followup = crate::utils::async_bridge::block_on_pg_result(
+                pg_pool,
+                move |bridge_pool| async move {
+                    let mut tx = bridge_pool.begin().await.map_err(|error| {
+                        format!("begin postgres terminal follow-up tx: {error}")
+                    })?;
+                    crate::github::sync::sync_auto_queue_terminal_on_pg(&mut tx, &card_id_owned)
+                        .await
+                        .map_err(|error| format!("{error}"))?;
+                    let dispatch_ids = sqlx::query_scalar::<_, String>(
+                        "SELECT id
+                         FROM task_dispatches
+                         WHERE kanban_card_id = $1
+                           AND dispatch_type IN ('review-decision', 'rework')
+                           AND status IN ('pending', 'dispatched')",
+                    )
+                    .bind(&card_id_owned)
+                    .fetch_all(&mut *tx)
+                    .await
+                    .map_err(|error| {
+                        format!(
+                            "load postgres terminal follow-up dispatches {card_id_owned}: {error}"
+                        )
+                    })?;
+                    for dispatch_id in dispatch_ids {
+                        crate::dispatch::cancel_dispatch_and_reset_auto_queue_on_pg_tx(
+                            &mut tx,
+                            &dispatch_id,
+                            Some(TERMINAL_DISPATCH_CLEANUP_REASON),
+                        )
+                        .await
+                        .map_err(|error| format!("{error}"))?;
+                    }
+                    tx.commit().await.map_err(|error| {
+                        format!("commit postgres terminal follow-up tx: {error}")
+                    })?;
+                    Ok(())
+                },
+                |error| error,
+            );
+            if let Err(error) = terminal_followup {
+                tracing::warn!(
+                    "[kanban] failed postgres terminal follow-up sync for {}: {}",
+                    card_id,
+                    error
+                );
+            }
+        }
+
+        let pg_pool_owned = pg_pool.clone();
+        let pipeline_owned = pipeline.clone();
+        let card_id_owned = card_id.to_string();
+        let to_owned = to.to_string();
+        let _ = crate::utils::async_bridge::block_on_pg_result(
+            pg_pool,
+            move |_bridge_pool| async move {
+                github_sync_on_transition_pg(
+                    &pg_pool_owned,
+                    &pipeline_owned,
+                    &card_id_owned,
+                    &to_owned,
+                )
+                .await;
+                Ok(())
+            },
+            |_error| (),
+        );
+        fire_dynamic_hooks(engine, pipeline, card_id, from, to, Some("hook"));
+
+        if pipeline.is_terminal(to)
+            && record_true_negative_if_pass_with_backends(db, Some(pg_pool), card_id)
+            && let Some(db) = db
+        {
+            crate::server::routes::review_verdict::spawn_aggregate_if_needed_with_pg(
+                db,
+                engine.pg_pool().cloned(),
+            );
+        }
+    }
 }
 
 /// Sync GitHub issue state when kanban card transitions (pipeline-driven).
@@ -1337,6 +1524,14 @@ fn log_audit(
 /// tuning outcome. This confirms the review was correct in not finding issues.
 /// Returns true if a TN was actually inserted.
 fn record_true_negative_if_pass(db: &Db, pg_pool: Option<&sqlx::PgPool>, card_id: &str) -> bool {
+    record_true_negative_if_pass_with_backends(Some(db), pg_pool, card_id)
+}
+
+fn record_true_negative_if_pass_with_backends(
+    db: Option<&Db>,
+    pg_pool: Option<&sqlx::PgPool>,
+    card_id: &str,
+) -> bool {
     if let Some(pool) = pg_pool {
         let card_id = card_id.to_string();
         return crate::utils::async_bridge::block_on_pg_result(
@@ -1433,7 +1628,9 @@ fn record_true_negative_if_pass(db: &Db, pg_pool: Option<&sqlx::PgPool>, card_id
         .unwrap_or(false);
     }
 
-    if let Ok(conn) = db.lock() {
+    if let Some(db) = db
+        && let Ok(conn) = db.lock()
+    {
         // Check if the card's last review verdict was "pass" or "approved"
         let last_verdict: Option<String> = conn
             .query_row(
@@ -1750,14 +1947,14 @@ mod tests {
         let mut config = crate::config::Config::default();
         config.policies.dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("policies");
         config.policies.hot_reload = false;
-        PolicyEngine::new(&config, db.clone()).unwrap()
+        PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
     }
 
     fn test_engine_with_dir(db: &Db, dir: &std::path::Path) -> PolicyEngine {
         let mut config = crate::config::Config::default();
         config.policies.dir = dir.to_path_buf();
         config.policies.hot_reload = false;
-        PolicyEngine::new(&config, db.clone()).unwrap()
+        PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
     }
 
     struct EnvVarGuard {

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -21,7 +21,7 @@ async fn launch_server(state: crate::bootstrap::BootstrapState) -> Result<()> {
         .map_err(anyhow::Error::msg)
         .context("Failed to init PostgreSQL")?;
 
-    let engine = crate::engine::PolicyEngine::new_with_pg(&config, db.clone(), pg_pool)
+    let engine = crate::engine::PolicyEngine::new_with_pg(&config, pg_pool)
         .context("Failed to init policy engine")?;
 
     tracing::info!(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -912,7 +912,7 @@ mod tests {
         let mut config = crate::config::Config::default();
         config.policies.dir = dir.to_path_buf();
         config.policies.hot_reload = false;
-        PolicyEngine::new(&config, db.clone()).unwrap()
+        PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
     }
 
     fn insert_agent(conn: &Connection, agent_id: &str) {

--- a/src/server/routes/agents.rs
+++ b/src/server/routes/agents.rs
@@ -1352,7 +1352,7 @@ mod tests {
 
     fn test_engine(db: &Db) -> PolicyEngine {
         let config = crate::config::Config::default();
-        PolicyEngine::new(&config, db.clone()).unwrap()
+        PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
     }
 
     #[tokio::test]

--- a/src/server/routes/auto_queue.rs
+++ b/src/server/routes/auto_queue.rs
@@ -42,7 +42,7 @@ pub struct GenerateBody {
     pub max_concurrent_per_agent: Option<i64>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ActivateBody {
     pub run_id: Option<String>,
     pub repo: Option<String>,
@@ -2497,8 +2497,28 @@ impl AutoQueueActivateDeps {
         }
     }
 
+    pub(crate) fn for_bridge_pg(engine: crate::engine::PolicyEngine) -> Self {
+        let db = engine.legacy_db().cloned().unwrap_or_else(|| {
+            let conn =
+                libsql_rusqlite::Connection::open_in_memory().expect("open sqlite bridge db");
+            crate::db::schema::migrate(&conn).expect("migrate sqlite bridge db");
+            crate::db::wrap_conn(conn)
+        });
+        Self {
+            db,
+            pg_pool: engine.pg_pool().cloned(),
+            engine,
+            config: Arc::new(crate::config::Config::default()),
+            health_registry: None,
+            guild_id: None,
+        }
+    }
+
     fn auto_queue_service(&self) -> crate::services::auto_queue::AutoQueueService {
-        crate::services::auto_queue::AutoQueueService::new(self.db.clone(), self.engine.clone())
+        crate::services::auto_queue::AutoQueueService::new(
+            Some(self.db.clone()),
+            self.engine.clone(),
+        )
     }
 
     fn entry_json(&self, entry_id: &str) -> serde_json::Value {
@@ -4781,6 +4801,24 @@ pub async fn activate(
     } else {
         activate_with_deps(&deps, body)
     }
+}
+
+pub(crate) async fn activate_with_bridge_pg(
+    engine: crate::engine::PolicyEngine,
+    body: ActivateBody,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let deps = AutoQueueActivateDeps::for_bridge_pg(engine);
+    let Some(pool) = deps.pg_pool.as_ref() else {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "postgres pool is not configured"})),
+        );
+    };
+    let body = match activate_preflight_with_pg(pool, body).await {
+        ActivatePgPreflight::Return(response) => return response,
+        ActivatePgPreflight::Continue(body) => body,
+    };
+    activate_with_deps_pg(&deps, body).await
 }
 
 enum ActivatePgPreflight {

--- a/src/server/routes/dispatched_sessions.rs
+++ b/src/server/routes/dispatched_sessions.rs
@@ -1944,7 +1944,7 @@ mod tests {
 
     fn test_engine(db: &Db) -> PolicyEngine {
         let config = crate::config::Config::default();
-        PolicyEngine::new(&config, db.clone()).unwrap()
+        PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
     }
 
     fn env_lock() -> MutexGuard<'static, ()> {

--- a/src/server/routes/dispatches/discord_delivery.rs
+++ b/src/server/routes/dispatches/discord_delivery.rs
@@ -3101,21 +3101,14 @@ async fn send_review_result_to_primary_with_context_and_transport<T: DispatchTra
             );
         }
 
-        let Some(pool) = transport.pg_pool() else {
-            return Err(
-                "Postgres pool required for review-decision follow-up dispatch".to_string(),
-            );
-        };
-        return match crate::dispatch::create_dispatch_core(
-            pool,
+        return match create_review_decision_followup_dispatch(
+            db,
+            transport.pg_pool(),
             card_id,
             &agent_id,
-            "review-decision",
             &format!("[리뷰 검토] {title}"),
             &serde_json::Value::Object(decision_context),
-        )
-        .await
-        {
+        ) {
             Ok((id, _old_status, _reused)) => {
                 if let Ok(conn) = db.lock() {
                     crate::engine::ops::review_state_sync_on_conn(
@@ -3209,6 +3202,72 @@ async fn send_review_result_to_primary_with_context_and_transport<T: DispatchTra
             kind,
         )
         .await
+}
+
+fn create_review_decision_followup_dispatch(
+    db: &crate::db::Db,
+    pg_pool: Option<&PgPool>,
+    card_id: &str,
+    agent_id: &str,
+    title: &str,
+    context: &serde_json::Value,
+) -> Result<(String, String, bool), String> {
+    if let Some(pool) = pg_pool {
+        return crate::utils::async_bridge::block_on_pg_result(
+            pool,
+            {
+                let card_id = card_id.to_string();
+                let agent_id = agent_id.to_string();
+                let title = title.to_string();
+                let context = context.clone();
+                move |bridge_pool| async move {
+                    crate::dispatch::create_dispatch_core(
+                        &bridge_pool,
+                        &card_id,
+                        &agent_id,
+                        "review-decision",
+                        &title,
+                        &context,
+                    )
+                    .await
+                    .map_err(|error| error.to_string())
+                }
+            },
+            |error| error,
+        );
+    }
+    create_review_decision_followup_dispatch_sqlite_test(db, card_id, agent_id, title, context)
+}
+
+#[cfg(test)]
+fn create_review_decision_followup_dispatch_sqlite_test(
+    db: &crate::db::Db,
+    card_id: &str,
+    agent_id: &str,
+    title: &str,
+    context: &serde_json::Value,
+) -> Result<(String, String, bool), String> {
+    crate::dispatch::create_dispatch_record_sqlite_test(
+        db,
+        card_id,
+        agent_id,
+        "review-decision",
+        title,
+        context,
+        crate::dispatch::DispatchCreateOptions::default(),
+    )
+    .map_err(|error| error.to_string())
+}
+
+#[cfg(not(test))]
+fn create_review_decision_followup_dispatch_sqlite_test(
+    _db: &crate::db::Db,
+    _card_id: &str,
+    _agent_id: &str,
+    _title: &str,
+    _context: &serde_json::Value,
+) -> Result<(String, String, bool), String> {
+    Err("Postgres pool required for review-decision follow-up dispatch".to_string())
 }
 
 async fn send_review_result_message_via_http(

--- a/src/server/routes/dispatches/tests.rs
+++ b/src/server/routes/dispatches/tests.rs
@@ -27,7 +27,7 @@ fn test_db() -> Db {
 
 fn test_engine(db: &Db) -> PolicyEngine {
     let config = crate::config::Config::default();
-    PolicyEngine::new(&config, db.clone()).unwrap()
+    PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
 }
 
 #[derive(Default)]

--- a/src/server/routes/escalation.rs
+++ b/src/server/routes/escalation.rs
@@ -1322,7 +1322,7 @@ mod tests {
         let mut config = crate::config::Config::default();
         config.policies.dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("policies");
         config.policies.hot_reload = false;
-        crate::engine::PolicyEngine::new(&config, db.clone()).unwrap()
+        crate::engine::PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
     }
 
     #[test]

--- a/src/server/routes/kanban.rs
+++ b/src/server/routes/kanban.rs
@@ -702,7 +702,7 @@ pub async fn assign_card(
             if let Some(path) = pipeline.free_path_to_dispatchable(&old_status) {
                 for step in &path {
                     if let Err(error) = crate::kanban::transition_status_with_opts_pg(
-                        &state.db,
+                        Some(&state.db),
                         pool,
                         &state.engine,
                         &id,
@@ -719,7 +719,7 @@ pub async fn assign_card(
                     }
                 }
             } else if let Err(error) = crate::kanban::transition_status_with_opts_pg(
-                &state.db,
+                Some(&state.db),
                 pool,
                 &state.engine,
                 &id,

--- a/src/server/routes/meetings.rs
+++ b/src/server/routes/meetings.rs
@@ -1782,7 +1782,7 @@ mod tests {
         let mut config = crate::config::Config::default();
         config.policies.dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("policies");
         config.policies.hot_reload = false;
-        PolicyEngine::new(&config, db.clone()).unwrap()
+        PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
     }
 
     fn transcript_counts(conn: &libsql_rusqlite::Connection, meeting_id: &str) -> (i64, i64) {

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -62,7 +62,10 @@ pub struct AppState {
 
 impl AppState {
     pub fn auto_queue_service(&self) -> crate::services::auto_queue::AutoQueueService {
-        crate::services::auto_queue::AutoQueueService::new(self.db.clone(), self.engine.clone())
+        crate::services::auto_queue::AutoQueueService::new(
+            Some(self.db.clone()),
+            self.engine.clone(),
+        )
     }
 
     pub fn dispatch_service(&self) -> crate::services::dispatches::DispatchService {

--- a/src/server/routes/onboarding.rs
+++ b/src/server/routes/onboarding.rs
@@ -3165,7 +3165,11 @@ mod tests {
     }
 
     fn test_engine(db: &crate::db::Db) -> crate::engine::PolicyEngine {
-        crate::engine::PolicyEngine::new(&crate::config::Config::default(), db.clone()).unwrap()
+        crate::engine::PolicyEngine::new_with_legacy_db(
+            &crate::config::Config::default(),
+            db.clone(),
+        )
+        .unwrap()
     }
 
     const VALID_OWNER_ID: &str = "123456789012345678";

--- a/src/server/routes/pipeline.rs
+++ b/src/server/routes/pipeline.rs
@@ -879,7 +879,7 @@ mod tests {
 
     fn test_engine(db: &Db) -> PolicyEngine {
         let config = crate::config::Config::default();
-        PolicyEngine::new(&config, db.clone()).unwrap()
+        PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
     }
 
     #[tokio::test]

--- a/src/server/routes/review_verdict/decision_route.rs
+++ b/src/server/routes/review_verdict/decision_route.rs
@@ -646,42 +646,36 @@ pub async fn submit_review_decision(
                             "[Rework] {}",
                             card_title.as_deref().unwrap_or(&body.card_id)
                         );
-                        if let Some(pg_pool) = state.engine.pg_pool() {
-                            match crate::dispatch::create_dispatch_core(
-                                pg_pool,
-                                &body.card_id,
-                                agent_id,
-                                "rework",
-                                &rework_title,
-                                &json!({}),
-                            )
-                            .await
-                            {
-                                Ok((dispatch_id, _, _reused)) => {
-                                    tracing::info!(
-                                        "[review-decision] #195 Rework dispatch created: card={} dispatch={}",
-                                        body.card_id,
-                                        dispatch_id
-                                    );
-                                }
-                                Err(e) => {
-                                    accept_failures
-                                        .push(format!("rework dispatch creation failed: {e}"));
-                                    tracing::warn!(
-                                        "[review-decision] #195 Rework dispatch creation failed for card {}: {e}",
-                                        body.card_id
-                                    );
-                                }
+                        match crate::dispatch::create_dispatch_with_options(
+                            &state.db,
+                            state.engine.pg_pool(),
+                            &state.engine,
+                            &body.card_id,
+                            agent_id,
+                            "rework",
+                            &rework_title,
+                            &json!({}),
+                            crate::dispatch::DispatchCreateOptions::default(),
+                        ) {
+                            Ok(dispatch) => {
+                                let dispatch_id = dispatch
+                                    .get("id")
+                                    .and_then(|value| value.as_str())
+                                    .unwrap_or("(unknown)");
+                                tracing::info!(
+                                    "[review-decision] #195 Rework dispatch created: card={} dispatch={}",
+                                    body.card_id,
+                                    dispatch_id
+                                );
                             }
-                        } else {
-                            accept_failures.push(
-                                "rework dispatch creation failed: postgres pool required"
-                                    .to_string(),
-                            );
-                            tracing::warn!(
-                                "[review-decision] #195 Rework dispatch creation failed for card {}: postgres pool required",
-                                body.card_id
-                            );
+                            Err(e) => {
+                                accept_failures
+                                    .push(format!("rework dispatch creation failed: {e}"));
+                                tracing::warn!(
+                                    "[review-decision] #195 Rework dispatch creation failed for card {}: {e}",
+                                    body.card_id
+                                );
+                            }
                         }
                     } else {
                         accept_failures.push(format!(

--- a/src/server/routes/review_verdict/tests.rs
+++ b/src/server/routes/review_verdict/tests.rs
@@ -20,7 +20,7 @@ fn test_engine(db: &Db) -> PolicyEngine {
     let mut config = crate::config::Config::default();
     config.policies.dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("policies");
     config.policies.hot_reload = false;
-    PolicyEngine::new(&config, db.clone()).unwrap()
+    PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
 }
 
 fn env_lock() -> MutexGuard<'static, ()> {
@@ -1251,7 +1251,7 @@ async fn duplicate_accept_returns_conflict() {
     let state = AppState::test_state(db.clone(), engine);
 
     // First accept should succeed
-    let (status1, _) = submit_review_decision(
+    let (status1, body1) = submit_review_decision(
         State(state.clone()),
         Json(ReviewDecisionBody {
             card_id: "card-dup".to_string(),
@@ -1261,7 +1261,12 @@ async fn duplicate_accept_returns_conflict() {
         }),
     )
     .await;
-    assert_eq!(status1, StatusCode::OK);
+    assert_eq!(
+        status1,
+        StatusCode::OK,
+        "unexpected first accept body: {}",
+        body1.0
+    );
 
     let conn = db.lock().unwrap();
     let latest_dispatch_id: String = conn

--- a/src/server/routes/reviews.rs
+++ b/src/server/routes/reviews.rs
@@ -256,7 +256,7 @@ pub async fn trigger_rework(
         };
 
         return match crate::kanban::transition_status_with_opts_pg(
-            &state.db,
+            Some(&state.db),
             pg_pool,
             &state.engine,
             &card_id,
@@ -348,7 +348,7 @@ mod tests {
 
     fn test_engine(db: &Db) -> PolicyEngine {
         let config = crate::config::Config::default();
-        PolicyEngine::new(&config, db.clone()).unwrap()
+        PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
     }
 
     fn test_state_with_pg(db: Db, engine: PolicyEngine, pg_pool: sqlx::PgPool) -> AppState {

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -30,12 +30,12 @@ fn seed_test_agents(db: &Db) {
 
 fn test_engine(db: &Db) -> PolicyEngine {
     let config = crate::config::Config::default();
-    PolicyEngine::new(&config, db.clone()).unwrap()
+    PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
 }
 
-fn test_engine_with_pg(db: &Db, pg_pool: sqlx::PgPool) -> PolicyEngine {
+fn test_engine_with_pg(_db: &Db, pg_pool: sqlx::PgPool) -> PolicyEngine {
     let config = crate::config::Config::default();
-    PolicyEngine::new_with_pg(&config, db.clone(), Some(pg_pool)).unwrap()
+    PolicyEngine::new_with_pg(&config, Some(pg_pool)).unwrap()
 }
 
 fn test_api_router(
@@ -5150,7 +5150,7 @@ async fn kanban_terminal_status_fires_hook() {
         },
         ..crate::config::Config::default()
     };
-    let engine = PolicyEngine::new(&config, db.clone()).unwrap();
+    let engine = PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap();
 
     {
         let conn = db.lock().unwrap();
@@ -7331,7 +7331,7 @@ async fn force_transition_to_done_tracks_pr_from_live_work_dispatch_and_cleans_i
     let db = test_db();
     let mut config = crate::config::Config::default();
     config.policies.dir = policy_dir.path().to_path_buf();
-    let engine = PolicyEngine::new(&config, db.clone()).unwrap();
+    let engine = PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap();
     seed_agent(&db, "agent-ft-terminal");
     seed_repo(&db, "test/repo");
     set_pmd_channel(&db, "pmd-chan-123");
@@ -8591,7 +8591,6 @@ async fn transition_to_done_records_true_negative_in_postgres_review_tuning() {
     let pg_pool = pg_db.connect_and_migrate().await;
     let engine = crate::engine::PolicyEngine::new_with_pg(
         &crate::config::Config::default(),
-        db.clone(),
         Some(pg_pool.clone()),
     )
     .unwrap();

--- a/src/server/routes/settings.rs
+++ b/src/server/routes/settings.rs
@@ -682,7 +682,7 @@ mod tests {
         let mut config = crate::config::Config::default();
         config.policies.dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("policies");
         config.policies.hot_reload = false;
-        PolicyEngine::new(&config, db.clone()).unwrap()
+        PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
     }
 
     #[tokio::test]

--- a/src/server/worker_registry.rs
+++ b/src/server/worker_registry.rs
@@ -371,8 +371,8 @@ impl SupervisedWorkerRegistry {
                 // cannot back up the main engine's actor queue and starve
                 // HTTP/Discord hook paths. The two engines share the same
                 // policies directory (each with its own hot-reload watcher)
-                // and the same SQLite DB.
-                let tick_engine = PolicyEngine::new_for_tick(&self.config, self.db.clone())
+                // and the same PostgreSQL backend.
+                let tick_engine = PolicyEngine::new_for_tick(&self.config, self.pg_pool.clone())
                     .map_err(|e| {
                         anyhow!("failed to initialize dedicated policy tick engine: {e}")
                     })?;

--- a/src/services/auto_queue.rs
+++ b/src/services/auto_queue.rs
@@ -143,7 +143,7 @@ macro_rules! auto_queue_log {
 
 #[derive(Clone)]
 pub struct AutoQueueService {
-    db: Db,
+    db: Option<Db>,
     engine: PolicyEngine,
 }
 
@@ -280,7 +280,7 @@ struct ThreadLinkCandidate {
 }
 
 impl AutoQueueService {
-    pub fn new(db: Db, engine: PolicyEngine) -> Self {
+    pub fn new(db: Option<Db>, engine: PolicyEngine) -> Self {
         Self { db, engine }
     }
 
@@ -316,11 +316,20 @@ impl AutoQueueService {
     ) -> ServiceResult<Vec<GenerateCandidate>> {
         if let Some(issue_numbers) = input.issue_numbers.as_ref().filter(|nums| !nums.is_empty()) {
             let transition_plan = {
-                let conn = self.db.read_conn().map_err(|error| {
-                    ServiceError::internal(format!("{error}"))
-                        .with_code(ErrorCode::Database)
-                        .with_operation("prepare_generate_cards.read_conn.transition_plan")
-                })?;
+                let conn = self
+                    .db
+                    .as_ref()
+                    .ok_or_else(|| {
+                        ServiceError::internal("sqlite backend is unavailable")
+                            .with_code(ErrorCode::Database)
+                            .with_operation("prepare_generate_cards.read_conn.transition_plan")
+                    })?
+                    .read_conn()
+                    .map_err(|error| {
+                        ServiceError::internal(format!("{error}"))
+                            .with_code(ErrorCode::Database)
+                            .with_operation("prepare_generate_cards.read_conn.transition_plan")
+                    })?;
                 crate::pipeline::ensure_loaded();
                 let backlog_cards = auto_queue::list_backlog_cards(
                     &conn,
@@ -365,8 +374,13 @@ impl AutoQueueService {
 
             for (card_id, path) in transition_plan {
                 for step in &path {
+                    let Some(db) = self.db.as_ref() else {
+                        return Err(ServiceError::internal("sqlite backend is unavailable")
+                            .with_code(ErrorCode::Database)
+                            .with_operation("prepare_generate_cards.transition_status"));
+                    };
                     crate::kanban::transition_status_with_opts(
-                        &self.db,
+                        db,
                         &self.engine,
                         &card_id,
                         step,
@@ -385,11 +399,20 @@ impl AutoQueueService {
             }
         }
 
-        let conn = self.db.read_conn().map_err(|error| {
-            ServiceError::internal(format!("{error}"))
-                .with_code(ErrorCode::Database)
-                .with_operation("prepare_generate_cards.read_conn.generate_candidates")
-        })?;
+        let conn = self
+            .db
+            .as_ref()
+            .ok_or_else(|| {
+                ServiceError::internal("sqlite backend is unavailable")
+                    .with_code(ErrorCode::Database)
+                    .with_operation("prepare_generate_cards.read_conn.generate_candidates")
+            })?
+            .read_conn()
+            .map_err(|error| {
+                ServiceError::internal(format!("{error}"))
+                    .with_code(ErrorCode::Database)
+                    .with_operation("prepare_generate_cards.read_conn.generate_candidates")
+            })?;
         crate::pipeline::ensure_loaded();
         let enqueueable_states = crate::pipeline::try_get()
             .map(enqueueable_states_for)
@@ -418,12 +441,22 @@ impl AutoQueueService {
         agent_id: Option<&str>,
         status: &str,
     ) -> ServiceResult<i64> {
-        let conn = self.db.read_conn().map_err(|error| {
-            ServiceError::internal(format!("{error}"))
-                .with_code(ErrorCode::Database)
-                .with_operation("count_cards_by_status.read_conn")
-                .with_context("status", status)
-        })?;
+        let conn = self
+            .db
+            .as_ref()
+            .ok_or_else(|| {
+                ServiceError::internal("sqlite backend is unavailable")
+                    .with_code(ErrorCode::Database)
+                    .with_operation("count_cards_by_status.read_conn")
+                    .with_context("status", status)
+            })?
+            .read_conn()
+            .map_err(|error| {
+                ServiceError::internal(format!("{error}"))
+                    .with_code(ErrorCode::Database)
+                    .with_operation("count_cards_by_status.read_conn")
+                    .with_context("status", status)
+            })?;
         auto_queue::count_cards_by_status(&conn, repo, agent_id, status).map_err(|error| {
             ServiceError::internal(format!("count cards: {error}"))
                 .with_code(ErrorCode::Database)
@@ -433,12 +466,22 @@ impl AutoQueueService {
     }
 
     pub fn run_view(&self, run_id: &str) -> ServiceResult<Option<AutoQueueRunView>> {
-        let conn = self.db.read_conn().map_err(|error| {
-            ServiceError::internal(format!("{error}"))
-                .with_code(ErrorCode::Database)
-                .with_operation("run_view.read_conn")
-                .with_context("run_id", run_id)
-        })?;
+        let conn = self
+            .db
+            .as_ref()
+            .ok_or_else(|| {
+                ServiceError::internal("sqlite backend is unavailable")
+                    .with_code(ErrorCode::Database)
+                    .with_operation("run_view.read_conn")
+                    .with_context("run_id", run_id)
+            })?
+            .read_conn()
+            .map_err(|error| {
+                ServiceError::internal(format!("{error}"))
+                    .with_code(ErrorCode::Database)
+                    .with_operation("run_view.read_conn")
+                    .with_context("run_id", run_id)
+            })?;
         auto_queue::get_run(&conn, run_id)
             .map(|record| record.map(AutoQueueRunView::from))
             .map_err(|error| {
@@ -461,12 +504,22 @@ impl AutoQueueService {
         entry_id: &str,
         guild_id: Option<&str>,
     ) -> ServiceResult<Option<AutoQueueStatusEntryView>> {
-        let conn = self.db.read_conn().map_err(|error| {
-            ServiceError::internal(format!("{error}"))
-                .with_code(ErrorCode::Database)
-                .with_operation("entry_view.read_conn")
-                .with_context("entry_id", entry_id)
-        })?;
+        let conn = self
+            .db
+            .as_ref()
+            .ok_or_else(|| {
+                ServiceError::internal("sqlite backend is unavailable")
+                    .with_code(ErrorCode::Database)
+                    .with_operation("entry_view.read_conn")
+                    .with_context("entry_id", entry_id)
+            })?
+            .read_conn()
+            .map_err(|error| {
+                ServiceError::internal(format!("{error}"))
+                    .with_code(ErrorCode::Database)
+                    .with_operation("entry_view.read_conn")
+                    .with_context("entry_id", entry_id)
+            })?;
         let Some(record) = auto_queue::get_status_entry(&conn, entry_id).map_err(|error| {
             ServiceError::internal(format!("load status entry: {error}"))
                 .with_code(ErrorCode::Database)
@@ -519,12 +572,22 @@ impl AutoQueueService {
         run_id: &str,
         input: StatusInput,
     ) -> ServiceResult<AutoQueueStatusResponse> {
-        let conn = self.db.read_conn().map_err(|error| {
-            ServiceError::internal(format!("{error}"))
-                .with_code(ErrorCode::Database)
-                .with_operation("status_for_run.read_conn")
-                .with_context("run_id", run_id)
-        })?;
+        let conn = self
+            .db
+            .as_ref()
+            .ok_or_else(|| {
+                ServiceError::internal("sqlite backend is unavailable")
+                    .with_code(ErrorCode::Database)
+                    .with_operation("status_for_run.read_conn")
+                    .with_context("run_id", run_id)
+            })?
+            .read_conn()
+            .map_err(|error| {
+                ServiceError::internal(format!("{error}"))
+                    .with_code(ErrorCode::Database)
+                    .with_operation("status_for_run.read_conn")
+                    .with_context("run_id", run_id)
+            })?;
         let Some(run) = auto_queue::get_run(&conn, run_id).map_err(|error| {
             ServiceError::internal(format!("load run: {error}"))
                 .with_code(ErrorCode::Database)
@@ -558,11 +621,20 @@ impl AutoQueueService {
 
     pub fn status(&self, input: StatusInput) -> ServiceResult<AutoQueueStatusResponse> {
         let run_id = {
-            let conn = self.db.read_conn().map_err(|error| {
-                ServiceError::internal(format!("{error}"))
-                    .with_code(ErrorCode::Database)
-                    .with_operation("status.read_conn")
-            })?;
+            let conn = self
+                .db
+                .as_ref()
+                .ok_or_else(|| {
+                    ServiceError::internal("sqlite backend is unavailable")
+                        .with_code(ErrorCode::Database)
+                        .with_operation("status.read_conn")
+                })?
+                .read_conn()
+                .map_err(|error| {
+                    ServiceError::internal(format!("{error}"))
+                        .with_code(ErrorCode::Database)
+                        .with_operation("status.read_conn")
+                })?;
             auto_queue::find_latest_run_id(
                 &conn,
                 &StatusFilter {

--- a/src/services/discord/router/tests.rs
+++ b/src/services/discord/router/tests.rs
@@ -191,7 +191,7 @@ fn intake_gate_enqueue_stays_responsive_while_policy_tick_times_out() {
         },
         ..Default::default()
     };
-    let engine = crate::engine::PolicyEngine::new(&config, db.clone()).unwrap();
+    let engine = crate::engine::PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap();
 
     let (entered_tx, entered_rx) = std::sync::mpsc::channel();
     let (release_tx, release_rx) = std::sync::mpsc::channel();

--- a/src/services/dispatches.rs
+++ b/src/services/dispatches.rs
@@ -1,5 +1,6 @@
 use axum::http::StatusCode;
 use serde_json::{Value, json};
+use sqlx::Row;
 
 use crate::db::Db;
 use crate::dispatch;
@@ -119,79 +120,43 @@ impl DispatchService {
         let dispatch_type = input
             .dispatch_type
             .unwrap_or_else(|| "implementation".to_string());
+        let to_agent_id = if let Some(pg_pool) = self.engine.pg_pool() {
+            resolve_dispatch_target_agent_id_with_pg(pg_pool, &input.to_agent_id)
+                .await
+                .unwrap_or_else(|| input.to_agent_id.clone())
+        } else {
+            self.db
+                .lock()
+                .ok()
+                .and_then(|conn| {
+                    resolve_dispatch_target_agent_id_on_conn(&conn, &input.to_agent_id)
+                })
+                .unwrap_or_else(|| input.to_agent_id.clone())
+        };
         let context = input.context.unwrap_or_else(|| json!({}));
-        let base_options = dispatch::DispatchCreateOptions {
-            skip_outbox: input.skip_outbox.unwrap_or(false),
-            ..Default::default()
-        };
-        let Some(pg_pool) = self.engine.pg_pool() else {
-            return Err(
-                ServiceError::internal("postgres pool required for dispatch.create")
-                    .with_code(ErrorCode::Dispatch),
-            );
-        };
         let options = dispatch::DispatchCreateOptions {
-            sidecar_dispatch: base_options.sidecar_dispatch
-                || context
-                    .get("sidecar_dispatch")
-                    .and_then(|value| value.as_bool())
-                    .unwrap_or(false)
+            skip_outbox: input.skip_outbox.unwrap_or(false),
+            sidecar_dispatch: context
+                .get("sidecar_dispatch")
+                .and_then(|value| value.as_bool())
+                .unwrap_or(false)
                 || context
                     .get("phase_gate")
                     .and_then(|value| value.as_object())
                     .is_some(),
-            ..base_options
         };
 
-        let result: anyhow::Result<serde_json::Value> = async {
-            let (dispatch_id, old_status, reused) = dispatch::create_dispatch_core_with_options(
-                pg_pool,
-                &input.kanban_card_id,
-                &input.to_agent_id,
-                &dispatch_type,
-                &input.title,
-                &context,
-                options,
-            )
-            .await?;
-            let mut dispatch = dispatch::query_dispatch_row_pg(pg_pool, &dispatch_id).await?;
-            if reused {
-                dispatch["__reused"] = json!(true);
-                return Ok(dispatch);
-            }
-            if !options.sidecar_dispatch {
-                crate::pipeline::ensure_loaded();
-                let (card_repo_id, card_agent_id) =
-                    sqlx::query_as::<_, (Option<String>, Option<String>)>(
-                        "SELECT repo_id, assigned_agent_id
-                         FROM kanban_cards
-                         WHERE id = $1",
-                    )
-                    .bind(&input.kanban_card_id)
-                    .fetch_optional(pg_pool)
-                    .await?
-                    .ok_or_else(|| anyhow::anyhow!("Card not found: {}", input.kanban_card_id))?;
-                let effective = crate::pipeline::resolve_for_card_pg(
-                    pg_pool,
-                    card_repo_id.as_deref(),
-                    card_agent_id.as_deref(),
-                )
-                .await;
-                let kickoff_owned = effective.kickoff_for(&old_status).unwrap_or_else(|| {
-                    tracing::error!("Pipeline has no kickoff state for hook firing");
-                    effective.initial_state().to_string()
-                });
-                crate::kanban::fire_state_hooks(
-                    &self.db,
-                    &self.engine,
-                    &input.kanban_card_id,
-                    &old_status,
-                    &kickoff_owned,
-                );
-            }
-            Ok(dispatch)
-        }
-        .await;
+        let result = dispatch::create_dispatch_with_options(
+            &self.db,
+            self.engine.pg_pool(),
+            &self.engine,
+            &input.kanban_card_id,
+            &to_agent_id,
+            &dispatch_type,
+            &input.title,
+            &context,
+            options,
+        );
 
         match result {
             Ok(dispatch) => {
@@ -335,6 +300,62 @@ impl DispatchService {
                 .with_context("dispatch_id", id)
         })
     }
+}
+
+fn resolve_dispatch_target_agent_id_on_conn(
+    conn: &libsql_rusqlite::Connection,
+    raw_target: &str,
+) -> Option<String> {
+    conn.query_row(
+        "SELECT id FROM agents WHERE id = ?1 LIMIT 1",
+        [raw_target],
+        |row| row.get(0),
+    )
+    .ok()
+    .or_else(|| {
+        conn.query_row(
+            "SELECT id FROM agents
+             WHERE discord_channel_id = ?1
+                OR discord_channel_alt = ?1
+                OR discord_channel_cc = ?1
+                OR discord_channel_cdx = ?1
+             LIMIT 1",
+            [raw_target],
+            |row| row.get(0),
+        )
+        .ok()
+    })
+}
+
+async fn resolve_dispatch_target_agent_id_with_pg(
+    pool: &sqlx::PgPool,
+    raw_target: &str,
+) -> Option<String> {
+    let exact_match = sqlx::query("SELECT id FROM agents WHERE id = $1 LIMIT 1")
+        .bind(raw_target)
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|row| row.try_get::<String, _>("id").ok());
+    if exact_match.is_some() {
+        return exact_match;
+    }
+
+    sqlx::query(
+        "SELECT id FROM agents
+         WHERE discord_channel_id = $1
+            OR discord_channel_alt = $1
+            OR discord_channel_cc = $1
+            OR discord_channel_cdx = $1
+         LIMIT 1",
+    )
+    .bind(raw_target)
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten()
+    .and_then(|row| row.try_get::<String, _>("id").ok())
 }
 
 fn dispatch_row_to_json(row: &libsql_rusqlite::Row) -> libsql_rusqlite::Result<Value> {

--- a/src/services/retrospectives.rs
+++ b/src/services/retrospectives.rs
@@ -56,7 +56,7 @@ struct RetrospectiveDraft {
 }
 
 pub(crate) fn record_card_retrospective_json(
-    db: &Db,
+    db: Option<&Db>,
     pg_pool: Option<&PgPool>,
     card_id: &str,
     terminal_status: &str,
@@ -72,12 +72,12 @@ pub(crate) fn record_card_retrospective_json(
 }
 
 fn record_card_retrospective(
-    db: &Db,
+    db: Option<&Db>,
     pg_pool: Option<&PgPool>,
     card_id: &str,
     terminal_status: &str,
 ) -> Result<Value, String> {
-    let db = db.clone();
+    let db = db.cloned();
     let card_id = card_id.trim().to_string();
     let terminal_status = terminal_status.trim().to_string();
 
@@ -90,10 +90,13 @@ fn record_card_retrospective(
 
     if let Some(pg_pool) = pg_pool.cloned() {
         return run_async_bridge_pg(&pg_pool, move |pool| async move {
-            record_card_retrospective_pg(&db, &pool, &card_id, &terminal_status).await
+            record_card_retrospective_pg(&pool, &card_id, &terminal_status).await
         });
     }
 
+    let Some(db) = db else {
+        return Err("sqlite backend is unavailable".to_string());
+    };
     record_card_retrospective_sqlite(&db, &card_id, &terminal_status)
 }
 
@@ -189,7 +192,7 @@ fn record_card_retrospective_sqlite(
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(async move {
                 sync_retrospective_to_memento(
-                    db_clone,
+                    Some(db_clone),
                     None,
                     retrospective_id_clone,
                     sync_settings,
@@ -211,7 +214,6 @@ fn record_card_retrospective_sqlite(
 }
 
 async fn record_card_retrospective_pg(
-    db: &Db,
     pg_pool: &PgPool,
     card_id: &str,
     terminal_status: &str,
@@ -282,7 +284,6 @@ async fn record_card_retrospective_pg(
     }
 
     if sync_settings.backend == MemoryBackendKind::Memento && has_runtime {
-        let db_clone = db.clone();
         let pg_pool_clone = pg_pool.clone();
         let retrospective_id_clone = retrospective_id.clone();
         let remember_request = MementoRememberRequest {
@@ -305,7 +306,7 @@ async fn record_card_retrospective_pg(
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(async move {
                 sync_retrospective_to_memento(
-                    db_clone,
+                    None,
                     Some(pg_pool_clone),
                     retrospective_id_clone,
                     sync_settings,
@@ -327,7 +328,7 @@ async fn record_card_retrospective_pg(
 }
 
 async fn sync_retrospective_to_memento(
-    db: Db,
+    db: Option<Db>,
     pg_pool: Option<PgPool>,
     retrospective_id: String,
     settings: ResolvedMemorySettings,
@@ -358,6 +359,9 @@ async fn sync_retrospective_to_memento(
         return;
     }
 
+    let Some(db) = db else {
+        return;
+    };
     let Ok(conn) = db.lock() else {
         return;
     };
@@ -985,7 +989,7 @@ mod tests {
         drop(conn);
 
         let payload = serde_json::from_str::<Value>(&record_card_retrospective_json(
-            &db,
+            Some(&db),
             None,
             "card-retro",
             "done",
@@ -1044,7 +1048,7 @@ mod tests {
         drop(conn);
 
         let payload = serde_json::from_str::<Value>(&record_card_retrospective_json(
-            &db,
+            Some(&db),
             None,
             "card-retro-skip",
             "done",
@@ -1126,7 +1130,7 @@ mod tests {
         .unwrap();
 
         let payload = serde_json::from_str::<Value>(&record_card_retrospective_json(
-            &sqlite_db,
+            Some(&sqlite_db),
             Some(&pg_pool),
             "card-retro-pg",
             "done",

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 use libsql_rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use sqlx::{PgPool, Row as SqlxRow};
 
 use crate::db::Db;
 use crate::engine::{PolicyEngine, PolicyEngineHandle};
@@ -69,18 +70,24 @@ impl BridgeHandle {
             .ok_or_else(|| "policy engine is no longer available".to_string())
     }
 
-    fn runtime_supervisor(&self, db: Db) -> Result<RuntimeSupervisor, String> {
+    fn runtime_supervisor(&self) -> Result<RuntimeSupervisor, String> {
         let engine = self.upgrade_engine()?;
-        Ok(RuntimeSupervisor::new(db, engine))
+        Ok(RuntimeSupervisor::new(
+            engine.legacy_db().cloned(),
+            engine.pg_pool().cloned(),
+            engine,
+        ))
     }
 }
 
 #[derive(Clone)]
 pub struct RuntimeSupervisor {
-    db: Db,
+    db: Option<Db>,
+    pg_pool: Option<PgPool>,
     engine: PolicyEngine,
 }
 
+#[derive(Clone)]
 struct OrphanCandidate {
     card_id: String,
     card_status: String,
@@ -97,8 +104,12 @@ struct OrphanConfirmMarker {
 }
 
 impl RuntimeSupervisor {
-    pub fn new(db: Db, engine: PolicyEngine) -> Self {
-        Self { db, engine }
+    pub fn new(db: Option<Db>, pg_pool: Option<PgPool>, engine: PolicyEngine) -> Self {
+        Self {
+            db,
+            pg_pool,
+            engine,
+        }
     }
 
     pub fn emit_signal(
@@ -163,22 +174,47 @@ impl RuntimeSupervisor {
 
                     // Return card to ready for re-dispatch instead of advancing to review
                     let ready_target = {
-                        let conn = self
-                            .db
-                            .separate_conn()
-                            .map_err(|e| format!("db connection: {e}"))?;
-                        crate::pipeline::ensure_loaded();
-                        let effective = crate::pipeline::resolve_for_card(
-                            &conn,
-                            candidate.repo_id.as_deref(),
-                            candidate.assigned_agent_id.as_deref(),
-                        );
-                        // Use the dispatchable state (ready) as target
-                        effective
-                            .dispatchable_states()
-                            .first()
-                            .map(|s| s.to_string())
-                            .unwrap_or_else(|| "ready".to_string())
+                        if let Some(db) = self.db.as_ref() {
+                            let conn = db
+                                .separate_conn()
+                                .map_err(|e| format!("db connection: {e}"))?;
+                            crate::pipeline::ensure_loaded();
+                            let effective = crate::pipeline::resolve_for_card(
+                                &conn,
+                                candidate.repo_id.as_deref(),
+                                candidate.assigned_agent_id.as_deref(),
+                            );
+                            effective
+                                .dispatchable_states()
+                                .first()
+                                .map(|s| s.to_string())
+                                .unwrap_or_else(|| "ready".to_string())
+                        } else if let Some(pool) = self.pg_pool.as_ref() {
+                            let repo_id = candidate.repo_id.clone();
+                            let agent_id = candidate.assigned_agent_id.clone();
+                            crate::utils::async_bridge::block_on_pg_result(
+                                pool,
+                                move |bridge_pool| async move {
+                                    crate::pipeline::ensure_loaded();
+                                    let effective = crate::pipeline::resolve_for_card_pg(
+                                        &bridge_pool,
+                                        repo_id.as_deref(),
+                                        agent_id.as_deref(),
+                                    )
+                                    .await;
+                                    Ok::<String, String>(
+                                        effective
+                                            .dispatchable_states()
+                                            .first()
+                                            .map(|s| s.to_string())
+                                            .unwrap_or_else(|| "ready".to_string()),
+                                    )
+                                },
+                                |error| error,
+                            )?
+                        } else {
+                            return Err("runtime supervisor backend is unavailable".to_string());
+                        }
                     };
 
                     let current = self.current_card_head(&candidate.card_id)?;
@@ -189,14 +225,43 @@ impl RuntimeSupervisor {
                                 && latest_dispatch_id.as_deref() == Some(dispatch_id.as_str())
                         })
                     {
-                        match crate::kanban::transition_status_with_opts(
-                            &self.db,
-                            &self.engine,
-                            &candidate.card_id,
-                            &ready_target,
-                            SUPERVISOR_ACTOR,
-                            crate::engine::transition::ForceIntent::SystemRecovery,
-                        ) {
+                        let transition_result = if let Some(db) = self.db.as_ref() {
+                            crate::kanban::transition_status_with_opts(
+                                db,
+                                &self.engine,
+                                &candidate.card_id,
+                                &ready_target,
+                                SUPERVISOR_ACTOR,
+                                crate::engine::transition::ForceIntent::SystemRecovery,
+                            )
+                            .map(|_| ())
+                            .map_err(|error| error.to_string())
+                        } else if let Some(pool) = self.pg_pool.as_ref() {
+                            let engine = self.engine.clone();
+                            let card_id = candidate.card_id.clone();
+                            let ready_target = ready_target.clone();
+                            crate::utils::async_bridge::block_on_pg_result(
+                                pool,
+                                move |bridge_pool| async move {
+                                    crate::kanban::transition_status_with_opts_pg(
+                                        None,
+                                        &bridge_pool,
+                                        &engine,
+                                        &card_id,
+                                        &ready_target,
+                                        SUPERVISOR_ACTOR,
+                                        crate::engine::transition::ForceIntent::SystemRecovery,
+                                    )
+                                    .await
+                                    .map(|_| ())
+                                    .map_err(|error| error.to_string())
+                                },
+                                |error| error,
+                            )
+                        } else {
+                            Err("runtime supervisor backend is unavailable".to_string())
+                        };
+                        match transition_result {
                             Ok(_) => {
                                 executed = true;
                                 self.notify_orphan_recovery(&candidate, &ready_target);
@@ -248,63 +313,149 @@ impl RuntimeSupervisor {
     }
 
     fn load_orphan_candidate(&self, dispatch_id: &str) -> Result<Option<OrphanCandidate>, String> {
-        let conn = self
-            .db
-            .separate_conn()
-            .map_err(|e| format!("db connection: {e}"))?;
-        conn.query_row(
-            "SELECT td.kanban_card_id,
-                    kc.status,
-                    kc.title,
-                    kc.assigned_agent_id,
-                    kc.repo_id
-             FROM task_dispatches td
-             JOIN kanban_cards kc ON kc.id = td.kanban_card_id
-             WHERE td.id = ?1
-               AND td.status = 'pending'
-               AND kc.latest_dispatch_id = td.id
-               AND td.dispatch_type IN ('implementation', 'rework')
-               AND td.created_at < datetime('now', '-5 minutes')
-               AND NOT EXISTS (
-                 SELECT 1 FROM sessions s
-                 WHERE s.active_dispatch_id = td.id AND s.status = 'working'
-               )",
-            [dispatch_id],
-            |row| {
-                Ok(OrphanCandidate {
-                    card_id: row.get(0)?,
-                    card_status: row.get(1)?,
-                    title: row.get(2)?,
-                    assigned_agent_id: row.get(3)?,
-                    repo_id: row.get(4)?,
-                })
+        if let Some(db) = self.db.as_ref() {
+            let conn = db
+                .separate_conn()
+                .map_err(|e| format!("db connection: {e}"))?;
+            return conn
+                .query_row(
+                    "SELECT td.kanban_card_id,
+                            kc.status,
+                            kc.title,
+                            kc.assigned_agent_id,
+                            kc.repo_id
+                     FROM task_dispatches td
+                     JOIN kanban_cards kc ON kc.id = td.kanban_card_id
+                     WHERE td.id = ?1
+                       AND td.status = 'pending'
+                       AND kc.latest_dispatch_id = td.id
+                       AND td.dispatch_type IN ('implementation', 'rework')
+                       AND td.created_at < datetime('now', '-5 minutes')
+                       AND NOT EXISTS (
+                         SELECT 1 FROM sessions s
+                         WHERE s.active_dispatch_id = td.id AND s.status = 'working'
+                       )",
+                    [dispatch_id],
+                    |row| {
+                        Ok(OrphanCandidate {
+                            card_id: row.get(0)?,
+                            card_status: row.get(1)?,
+                            title: row.get(2)?,
+                            assigned_agent_id: row.get(3)?,
+                            repo_id: row.get(4)?,
+                        })
+                    },
+                )
+                .optional()
+                .map_err(|e| format!("load orphan candidate: {e}"));
+        }
+        let Some(pool) = self.pg_pool.as_ref() else {
+            return Err("runtime supervisor backend is unavailable".to_string());
+        };
+        let dispatch_id = dispatch_id.to_string();
+        crate::utils::async_bridge::block_on_pg_result(
+            pool,
+            move |bridge_pool| async move {
+                let row = sqlx::query(
+                    "SELECT td.kanban_card_id,
+                            kc.status,
+                            kc.title,
+                            kc.assigned_agent_id,
+                            kc.repo_id
+                     FROM task_dispatches td
+                     JOIN kanban_cards kc ON kc.id = td.kanban_card_id
+                     WHERE td.id = $1
+                       AND td.status = 'pending'
+                       AND kc.latest_dispatch_id = td.id
+                       AND td.dispatch_type IN ('implementation', 'rework')
+                       AND td.created_at < NOW() - INTERVAL '5 minutes'
+                       AND NOT EXISTS (
+                         SELECT 1 FROM sessions s
+                         WHERE s.active_dispatch_id = td.id AND s.status = 'working'
+                       )",
+                )
+                .bind(&dispatch_id)
+                .fetch_optional(&bridge_pool)
+                .await
+                .map_err(|error| format!("load orphan candidate {dispatch_id}: {error}"))?;
+                Ok(row.map(|row| OrphanCandidate {
+                    card_id: row.try_get("kanban_card_id").unwrap_or_default(),
+                    card_status: row.try_get("status").unwrap_or_default(),
+                    title: row.try_get("title").unwrap_or_default(),
+                    assigned_agent_id: row.try_get("assigned_agent_id").ok().flatten(),
+                    repo_id: row.try_get("repo_id").ok().flatten(),
+                }))
             },
+            |error| error,
         )
-        .optional()
-        .map_err(|e| format!("load orphan candidate: {e}"))
     }
 
     fn clear_orphan_confirmation(&self, dispatch_id: &str) {
-        let Ok(conn) = self.db.separate_conn() else {
+        if let Some(db) = self.db.as_ref() {
+            let Ok(conn) = db.separate_conn() else {
+                return;
+            };
+            let _ = conn.execute(
+                "DELETE FROM kv_meta WHERE key = ?1",
+                [format!("{ORPHAN_CONFIRM_KEY_PREFIX}{dispatch_id}")],
+            );
             return;
-        };
-        let _ = conn.execute(
-            "DELETE FROM kv_meta WHERE key = ?1",
-            [format!("{ORPHAN_CONFIRM_KEY_PREFIX}{dispatch_id}")],
-        );
+        }
+        if let Some(pool) = self.pg_pool.as_ref() {
+            let dispatch_id = dispatch_id.to_string();
+            let _ = crate::utils::async_bridge::block_on_pg_result(
+                pool,
+                move |bridge_pool| async move {
+                    sqlx::query("DELETE FROM kv_meta WHERE key = $1")
+                        .bind(format!("{ORPHAN_CONFIRM_KEY_PREFIX}{dispatch_id}"))
+                        .execute(&bridge_pool)
+                        .await
+                        .map(|_| ())
+                        .map_err(|error| {
+                            format!("clear orphan confirmation {dispatch_id}: {error}")
+                        })
+                },
+                |error| error,
+            );
+        }
     }
 
     fn load_orphan_confirmation(&self, dispatch_id: &str) -> Option<OrphanConfirmMarker> {
-        let conn = self.db.separate_conn().ok()?;
-        let key = format!("{ORPHAN_CONFIRM_KEY_PREFIX}{dispatch_id}");
-        let raw: Option<String> = conn
-            .query_row("SELECT value FROM kv_meta WHERE key = ?1", [key], |row| {
-                row.get(0)
-            })
-            .optional()
-            .ok()
-            .flatten();
-        raw.and_then(|value| serde_json::from_str::<OrphanConfirmMarker>(&value).ok())
+        if let Some(db) = self.db.as_ref() {
+            let conn = db.separate_conn().ok()?;
+            let key = format!("{ORPHAN_CONFIRM_KEY_PREFIX}{dispatch_id}");
+            let raw: Option<String> = conn
+                .query_row("SELECT value FROM kv_meta WHERE key = ?1", [key], |row| {
+                    row.get(0)
+                })
+                .optional()
+                .ok()
+                .flatten();
+            return raw.and_then(|value| serde_json::from_str::<OrphanConfirmMarker>(&value).ok());
+        }
+        let pool = self.pg_pool.as_ref()?;
+        let dispatch_id = dispatch_id.to_string();
+        match crate::utils::async_bridge::block_on_pg_result(
+            pool,
+            move |bridge_pool| async move {
+                let raw =
+                    sqlx::query_scalar::<_, String>("SELECT value FROM kv_meta WHERE key = $1")
+                        .bind(format!("{ORPHAN_CONFIRM_KEY_PREFIX}{dispatch_id}"))
+                        .fetch_optional(&bridge_pool)
+                        .await
+                        .map_err(|error| {
+                            format!("load orphan confirmation {dispatch_id}: {error}")
+                        })?;
+                Ok(raw.and_then(|value| serde_json::from_str::<OrphanConfirmMarker>(&value).ok()))
+            },
+            |error| error,
+        ) {
+            Ok(value) => value,
+            Err(error) => {
+                tracing::warn!("failed to load orphan confirmation: {error}");
+                None
+            }
+        }
     }
 
     fn confirm_orphan_candidate(
@@ -323,26 +474,50 @@ impl RuntimeSupervisor {
             return Ok(true);
         }
 
-        let conn = self
-            .db
-            .separate_conn()
-            .map_err(|e| format!("db connection: {e}"))?;
         let key = format!("{ORPHAN_CONFIRM_KEY_PREFIX}{dispatch_id}");
         let marker_json =
             serde_json::to_string(&marker).map_err(|e| format!("serialize orphan marker: {e}"))?;
-
-        conn.execute(
-            "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?1, ?2)",
-            libsql_rusqlite::params![key, marker_json],
+        if let Some(db) = self.db.as_ref() {
+            let conn = db
+                .separate_conn()
+                .map_err(|e| format!("db connection: {e}"))?;
+            conn.execute(
+                "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?1, ?2)",
+                libsql_rusqlite::params![key, marker_json],
+            )
+            .map_err(|e| format!("store orphan marker: {e}"))?;
+            return Ok(false);
+        }
+        let Some(pool) = self.pg_pool.as_ref() else {
+            return Err("runtime supervisor backend is unavailable".to_string());
+        };
+        let dispatch_id = dispatch_id.to_string();
+        crate::utils::async_bridge::block_on_pg_result(
+            pool,
+            move |bridge_pool| async move {
+                sqlx::query(
+                    "INSERT INTO kv_meta (key, value)
+                     VALUES ($1, $2)
+                     ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value",
+                )
+                .bind(&key)
+                .bind(&marker_json)
+                .execute(&bridge_pool)
+                .await
+                .map(|_| false)
+                .map_err(|error| format!("store orphan marker {dispatch_id}: {error}"))
+            },
+            |error| error,
         )
-        .map_err(|e| format!("store orphan marker: {e}"))?;
-        Ok(false)
     }
 
     #[allow(dead_code)]
     fn mark_dispatch_completed(&self, dispatch_id: &str) -> Result<usize, String> {
-        let conn = self
+        let db = self
             .db
+            .as_ref()
+            .ok_or_else(|| "sqlite backend is unavailable".to_string())?;
+        let conn = db
             .separate_conn()
             .map_err(|e| format!("db connection: {e}"))?;
         crate::dispatch::set_dispatch_status_on_conn(
@@ -361,37 +536,161 @@ impl RuntimeSupervisor {
     }
 
     fn mark_dispatch_failed(&self, dispatch_id: &str) -> Result<usize, String> {
-        let conn = self
-            .db
-            .separate_conn()
-            .map_err(|e| format!("db connection: {e}"))?;
-        crate::dispatch::set_dispatch_status_on_conn(
-            &conn,
-            dispatch_id,
-            "failed",
-            Some(&json!({
-                "orphan_failed": true,
-                "completion_source": "orphan_recovery_rollback"
-            })),
-            "orphan_recovery_rollback",
-            Some(&["pending", "dispatched"]),
-            false,
+        if let Some(db) = self.db.as_ref() {
+            let conn = db
+                .separate_conn()
+                .map_err(|e| format!("db connection: {e}"))?;
+            return crate::dispatch::set_dispatch_status_on_conn(
+                &conn,
+                dispatch_id,
+                "failed",
+                Some(&json!({
+                    "orphan_failed": true,
+                    "completion_source": "orphan_recovery_rollback"
+                })),
+                "orphan_recovery_rollback",
+                Some(&["pending", "dispatched"]),
+                false,
+            )
+            .map_err(|e| format!("mark dispatch failed: {e}"));
+        }
+        let Some(pool) = self.pg_pool.as_ref() else {
+            return Err("runtime supervisor backend is unavailable".to_string());
+        };
+        let dispatch_id = dispatch_id.to_string();
+        crate::utils::async_bridge::block_on_pg_result(
+            pool,
+            move |bridge_pool| async move {
+                let payload = json!({
+                    "orphan_failed": true,
+                    "completion_source": "orphan_recovery_rollback"
+                })
+                .to_string();
+                let current = sqlx::query(
+                    "SELECT status, kanban_card_id, dispatch_type
+                     FROM task_dispatches
+                     WHERE id = $1",
+                )
+                .bind(&dispatch_id)
+                .fetch_optional(&bridge_pool)
+                .await
+                .map_err(|error| format!("load dispatch {dispatch_id}: {error}"))?;
+                let Some(current) = current else {
+                    return Ok(0);
+                };
+                let status = current
+                    .try_get::<Option<String>, _>("status")
+                    .ok()
+                    .flatten()
+                    .unwrap_or_default();
+                if !matches!(status.as_str(), "pending" | "dispatched") {
+                    return Ok(0);
+                }
+                let changed = sqlx::query(
+                    "UPDATE task_dispatches
+                     SET status = 'failed',
+                         result = $1,
+                         updated_at = NOW()
+                     WHERE id = $2
+                       AND status = $3",
+                )
+                .bind(&payload)
+                .bind(&dispatch_id)
+                .bind(&status)
+                .execute(&bridge_pool)
+                .await
+                .map_err(|error| format!("mark dispatch failed {dispatch_id}: {error}"))?
+                .rows_affected() as usize;
+                if changed == 0 {
+                    return Ok(0);
+                }
+                let _ = sqlx::query(
+                    "INSERT INTO dispatch_events (
+                        dispatch_id,
+                        kanban_card_id,
+                        dispatch_type,
+                        from_status,
+                        to_status,
+                        transition_source,
+                        payload_json
+                     ) VALUES ($1, $2, $3, $4, 'failed', 'orphan_recovery_rollback', $5)",
+                )
+                .bind(&dispatch_id)
+                .bind(
+                    current
+                        .try_get::<Option<String>, _>("kanban_card_id")
+                        .ok()
+                        .flatten(),
+                )
+                .bind(
+                    current
+                        .try_get::<Option<String>, _>("dispatch_type")
+                        .ok()
+                        .flatten(),
+                )
+                .bind(&status)
+                .bind(&payload)
+                .execute(&bridge_pool)
+                .await;
+                let _ = sqlx::query(
+                    "INSERT INTO dispatch_outbox (dispatch_id, action)
+                     SELECT $1, 'status_reaction'
+                     WHERE NOT EXISTS (
+                         SELECT 1
+                         FROM dispatch_outbox
+                         WHERE dispatch_id = $1
+                           AND action = 'status_reaction'
+                           AND status IN ('pending', 'processing')
+                     )",
+                )
+                .bind(&dispatch_id)
+                .execute(&bridge_pool)
+                .await;
+                Ok(changed)
+            },
+            |error| error,
         )
-        .map_err(|e| format!("mark dispatch failed: {e}"))
     }
 
     fn current_card_head(&self, card_id: &str) -> Result<Option<(String, Option<String>)>, String> {
-        let conn = self
-            .db
-            .separate_conn()
-            .map_err(|e| format!("db connection: {e}"))?;
-        conn.query_row(
-            "SELECT status, latest_dispatch_id FROM kanban_cards WHERE id = ?1",
-            [card_id],
-            |row| Ok((row.get(0)?, row.get(1)?)),
+        if let Some(db) = self.db.as_ref() {
+            let conn = db
+                .separate_conn()
+                .map_err(|e| format!("db connection: {e}"))?;
+            return conn
+                .query_row(
+                    "SELECT status, latest_dispatch_id FROM kanban_cards WHERE id = ?1",
+                    [card_id],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .optional()
+                .map_err(|e| format!("current card head: {e}"));
+        }
+        let Some(pool) = self.pg_pool.as_ref() else {
+            return Err("runtime supervisor backend is unavailable".to_string());
+        };
+        let card_id = card_id.to_string();
+        crate::utils::async_bridge::block_on_pg_result(
+            pool,
+            move |bridge_pool| async move {
+                let row = sqlx::query(
+                    "SELECT status, latest_dispatch_id FROM kanban_cards WHERE id = $1",
+                )
+                .bind(&card_id)
+                .fetch_optional(&bridge_pool)
+                .await
+                .map_err(|error| format!("current card head {card_id}: {error}"))?;
+                Ok(row.map(|row| {
+                    (
+                        row.try_get::<String, _>("status").unwrap_or_default(),
+                        row.try_get::<Option<String>, _>("latest_dispatch_id")
+                            .ok()
+                            .flatten(),
+                    )
+                }))
+            },
+            |error| error,
         )
-        .optional()
-        .map_err(|e| format!("current card head: {e}"))
     }
 
     fn record_decision(
@@ -402,38 +701,90 @@ impl RuntimeSupervisor {
         session_key: Option<&str>,
         dispatch_id: Option<&str>,
     ) -> Result<(), String> {
-        let conn = self
-            .db
-            .separate_conn()
-            .map_err(|e| format!("db connection: {e}"))?;
-        conn.execute(
-            "INSERT INTO runtime_decisions
-             (signal, evidence_json, chosen_action, actor, session_key, dispatch_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            libsql_rusqlite::params![
-                signal.to_string(),
-                evidence.to_string(),
-                chosen_action.to_string(),
-                SUPERVISOR_ACTOR,
-                session_key,
-                dispatch_id,
-            ],
+        if let Some(db) = self.db.as_ref() {
+            let conn = db
+                .separate_conn()
+                .map_err(|e| format!("db connection: {e}"))?;
+            conn.execute(
+                "INSERT INTO runtime_decisions
+                 (signal, evidence_json, chosen_action, actor, session_key, dispatch_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                libsql_rusqlite::params![
+                    signal.to_string(),
+                    evidence.to_string(),
+                    chosen_action.to_string(),
+                    SUPERVISOR_ACTOR,
+                    session_key,
+                    dispatch_id,
+                ],
+            )
+            .map_err(|e| format!("record runtime decision: {e}"))?;
+            return Ok(());
+        }
+        let Some(pool) = self.pg_pool.as_ref() else {
+            return Err("runtime supervisor backend is unavailable".to_string());
+        };
+        let evidence_json = evidence.to_string();
+        let signal = signal.to_string();
+        let chosen_action = chosen_action.to_string();
+        let session_key = session_key.map(str::to_string);
+        let dispatch_id = dispatch_id.map(str::to_string);
+        crate::utils::async_bridge::block_on_pg_result(
+            pool,
+            move |bridge_pool| async move {
+                sqlx::query(
+                    "INSERT INTO runtime_decisions
+                     (signal, evidence_json, chosen_action, actor, session_key, dispatch_id)
+                     VALUES ($1, $2, $3, $4, $5, $6)",
+                )
+                .bind(&signal)
+                .bind(&evidence_json)
+                .bind(&chosen_action)
+                .bind(SUPERVISOR_ACTOR)
+                .bind(session_key.as_deref())
+                .bind(dispatch_id.as_deref())
+                .execute(&bridge_pool)
+                .await
+                .map(|_| ())
+                .map_err(|error| format!("record runtime decision: {error}"))
+            },
+            |error| error,
         )
-        .map_err(|e| format!("record runtime decision: {e}"))?;
-        Ok(())
     }
 
     fn notify_orphan_recovery(&self, candidate: &OrphanCandidate, review_target: &str) {
-        let Ok(conn) = self.db.separate_conn() else {
-            return;
-        };
-        let channel_id: Option<String> = conn
-            .query_row(
+        let channel_id: Option<String> = if let Some(db) = self.db.as_ref() {
+            let Ok(conn) = db.separate_conn() else {
+                return;
+            };
+            conn.query_row(
                 "SELECT value FROM kv_meta WHERE key = 'kanban_manager_channel_id'",
                 [],
                 |row| row.get(0),
             )
-            .ok();
+            .ok()
+        } else if let Some(pool) = self.pg_pool.as_ref() {
+            match crate::utils::async_bridge::block_on_pg_result(
+                pool,
+                move |bridge_pool| async move {
+                    sqlx::query_scalar::<_, String>(
+                        "SELECT value FROM kv_meta WHERE key = 'kanban_manager_channel_id'",
+                    )
+                    .fetch_optional(&bridge_pool)
+                    .await
+                    .map_err(|error| format!("load kanban_manager_channel_id: {error}"))
+                },
+                |error| error,
+            ) {
+                Ok(value) => value,
+                Err(error) => {
+                    tracing::warn!("failed to load orphan recovery channel id: {error}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
         let Some(channel_id) = channel_id.filter(|id| !id.trim().is_empty()) else {
             return;
         };
@@ -446,22 +797,51 @@ impl RuntimeSupervisor {
             "🔄 [고아 디스패치 복구] {} — {}\n사유: pending 디스패치 5분 경과 + 활성 세션 없음 → {} 전이",
             agent, candidate.title, review_target
         );
-        let _ = enqueue(
-            &conn,
-            crate::services::message_outbox::OutboxMessage {
-                target: &format!("channel:{channel_id}"),
-                content: &content,
-                bot: "announce",
-                source: "system",
-                reason_code: Some("lifecycle.orphan_recovery"),
-                session_key: Some(&candidate.card_id),
-            },
-        );
+        if let Some(db) = self.db.as_ref() {
+            if let Ok(conn) = db.separate_conn() {
+                let _ = enqueue(
+                    &conn,
+                    crate::services::message_outbox::OutboxMessage {
+                        target: &format!("channel:{channel_id}"),
+                        content: &content,
+                        bot: "announce",
+                        source: "system",
+                        reason_code: Some("lifecycle.orphan_recovery"),
+                        session_key: Some(&candidate.card_id),
+                    },
+                );
+            }
+            return;
+        }
+        if let Some(pool) = self.pg_pool.as_ref() {
+            let channel_id = channel_id.clone();
+            let content = content.clone();
+            let card_id = candidate.card_id.clone();
+            let _ = crate::utils::async_bridge::block_on_pg_result(
+                pool,
+                move |bridge_pool| async move {
+                    crate::services::message_outbox::enqueue_lifecycle_notification_pg(
+                        &bridge_pool,
+                        &format!("channel:{channel_id}"),
+                        Some(&card_id),
+                        "lifecycle.orphan_recovery",
+                        &content,
+                    )
+                    .await
+                    .map(|_| ())
+                    .map_err(|error| format!("enqueue orphan recovery notification: {error}"))
+                },
+                |error| error,
+            );
+        }
     }
 
     #[cfg(test)]
     fn apply_orphan_fault_injection(&self, dispatch_id: &str, card_id: &str) {
-        let Ok(conn) = self.db.separate_conn() else {
+        let Some(db) = self.db.as_ref() else {
+            return;
+        };
+        let Ok(conn) = db.separate_conn() else {
             return;
         };
         let key = format!("test:runtime_supervisor:orphan_post_complete_override:{dispatch_id}");
@@ -485,12 +865,7 @@ impl RuntimeSupervisor {
     }
 }
 
-pub fn emit_signal_json(
-    db: &Db,
-    bridge: &BridgeHandle,
-    signal_name: &str,
-    evidence_json: &str,
-) -> String {
+pub fn emit_signal_json(bridge: &BridgeHandle, signal_name: &str, evidence_json: &str) -> String {
     let signal = match SupervisorSignal::try_from(signal_name) {
         Ok(signal) => signal,
         Err(err) => {
@@ -511,7 +886,7 @@ pub fn emit_signal_json(
                 .into_policy_json_string();
         }
     };
-    let supervisor = match bridge.runtime_supervisor(db.clone()) {
+    let supervisor = match bridge.runtime_supervisor() {
         Ok(supervisor) => supervisor,
         Err(err) => {
             return AppError::internal(err)
@@ -628,7 +1003,7 @@ mod tests {
         let bridge = BridgeHandle::new();
 
         let value: Value =
-            serde_json::from_str(&emit_signal_json(&db, &bridge, "Nope", r#"{}"#)).unwrap();
+            serde_json::from_str(&emit_signal_json(&bridge, "Nope", r#"{}"#)).unwrap();
 
         assert_eq!(value["ok"], false);
         assert_eq!(value["code"], "policy");


### PR DESCRIPTION
## Summary
- make `PolicyEngine`/runtime/supervisor/intent-drain paths backend-aware so PG is primary and sqlite is only retained for legacy/test-only callers
- update dispatch/review automation raw ops plus review-decision follow-up flows to work without a mandatory sqlite handle
- harden the remaining tail cases found while landing #864, including `/dispatches` target-agent canonicalization and fail-soft inventory probe handling in `kanban-rules.js`

## Verification
- `cargo test -q --bin agentdesk` (`1977 passed, 2 failed, 5 ignored`; remaining failures are pre-existing host/fixture issues documented in #864)
- `cargo build -q --bin agentdesk`
- `cargo test -q --bin agentdesk server::routes::routes_tests::dispatch_create_and_get -- --exact --nocapture`
- `cargo test -q --bin agentdesk server::routes::review_verdict::tests::duplicate_accept_returns_conflict -- --exact --nocapture --test-threads=1`
- `cargo test -q --bin agentdesk integration_tests::tests::scenario_690_code_failure_duplicate_run_is_suppressed_after_review_reentry -- --exact --nocapture --test-threads=1`

Closes #864