### PR TITLE
Tighten promote-release gate semantics and binary freshness

### DIFF
--- a/scripts/_defaults.sh
+++ b/scripts/_defaults.sh
@@ -319,7 +319,10 @@ wait_for_live_turns_to_drain_or_fail() {
   local port="$3"
   local max_wait="${4:-120}"
   local poll_secs="${5:-2}"
-  local allow_cut="${AGENTDESK_ALLOW_LIVE_TURN_CUT:-0}"
+  # Turns themselves are preserved across restart via silent reattach (#43e3cacc);
+  # this flag only skips the drain wait, at the cost of possibly truncating a
+  # mid-stream Discord response during the SIGTERM window.
+  local skip_drain="${AGENTDESK_SKIP_TURN_DRAIN:-0}"
   local waited=0
   local active=0 finalizing=0 queue_depth=0 live_turns=0 job_state=""
 
@@ -332,13 +335,13 @@ EOF
       echo "▸ [gate] ${scope} launchd job already not running — skipping live-turn drain check"
       return 0
     fi
-    if [ "$allow_cut" = "1" ]; then
-      echo "⚠ [gate] Unable to read ${scope} health on :${port} (launchd state: ${job_state:-unknown}) — proceeding due to AGENTDESK_ALLOW_LIVE_TURN_CUT=1"
+    if [ "$skip_drain" = "1" ]; then
+      echo "⚠ [gate] Unable to read ${scope} health on :${port} (launchd state: ${job_state:-unknown}) — proceeding due to AGENTDESK_SKIP_TURN_DRAIN=1"
       return 0
     fi
     echo "✗ [gate] Unable to confirm ${scope} turn drain on :${port} (launchd state: ${job_state:-unknown})"
-    echo "  Refusing restart to avoid cutting active turns."
-    echo "  Override only if intentional: AGENTDESK_ALLOW_LIVE_TURN_CUT=1"
+    echo "  Refusing restart to avoid truncating mid-stream output."
+    echo "  Override only if stream hiccup is acceptable: AGENTDESK_SKIP_TURN_DRAIN=1"
     return 1
   fi
 
@@ -361,26 +364,26 @@ $(health_turn_snapshot "$port")
 EOF
     then
       job_state=$(_launchd_job_state "$label")
-      if [ "$allow_cut" = "1" ]; then
-        echo "⚠ [gate] Lost ${scope} health during drain wait after ${waited}s (launchd state: ${job_state:-unknown}) — proceeding due to AGENTDESK_ALLOW_LIVE_TURN_CUT=1"
+      if [ "$skip_drain" = "1" ]; then
+        echo "⚠ [gate] Lost ${scope} health during drain wait after ${waited}s (launchd state: ${job_state:-unknown}) — proceeding due to AGENTDESK_SKIP_TURN_DRAIN=1"
         return 0
       fi
       echo "✗ [gate] Lost ${scope} health during drain wait after ${waited}s (launchd state: ${job_state:-unknown})"
-      echo "  Refusing restart to avoid cutting active turns."
-      echo "  Override only if intentional: AGENTDESK_ALLOW_LIVE_TURN_CUT=1"
+      echo "  Refusing restart to avoid truncating mid-stream output."
+      echo "  Override only if stream hiccup is acceptable: AGENTDESK_SKIP_TURN_DRAIN=1"
       return 1
     fi
     live_turns=$(( active + finalizing ))
   done
 
   if [ "$live_turns" -gt 0 ]; then
-    if [ "$allow_cut" = "1" ]; then
-      echo "⚠ [gate] ${scope} still has ${live_turns} active/finalizing turn(s) after ${max_wait}s — proceeding due to AGENTDESK_ALLOW_LIVE_TURN_CUT=1 (queued=${queue_depth})"
+    if [ "$skip_drain" = "1" ]; then
+      echo "⚠ [gate] ${scope} still has ${live_turns} active/finalizing turn(s) after ${max_wait}s — proceeding due to AGENTDESK_SKIP_TURN_DRAIN=1 (queued=${queue_depth}); silent reattach will preserve turn state"
       return 0
     fi
     echo "✗ [gate] ${scope} still has ${live_turns} active/finalizing turn(s) after ${max_wait}s (queued=${queue_depth})"
-    echo "  Refusing restart to avoid cutting active turns."
-    echo "  Retry after work finishes, or override intentionally with AGENTDESK_ALLOW_LIVE_TURN_CUT=1"
+    echo "  Refusing restart to avoid truncating mid-stream output."
+    echo "  Retry after work finishes, or override with AGENTDESK_SKIP_TURN_DRAIN=1 when a brief stream hiccup is acceptable."
     return 1
   fi
 

--- a/scripts/promote-release.sh
+++ b/scripts/promote-release.sh
@@ -211,6 +211,9 @@ export AGENTDESK_REPO_DIR=$(printf '%q' "$REPO")
 export AGENTDESK_PROMOTE_DETACHED_CHILD=1
 export AGENTDESK_PROMOTE_LOG_PATH=$(printf '%q' "$log_path")
 export AGENTDESK_PROMOTE_TEST_MODE=$(printf '%q' "$PROMOTE_TEST_MODE")
+export AGENTDESK_SKIP_TURN_DRAIN=$(printf '%q' "${AGENTDESK_SKIP_TURN_DRAIN:-0}")
+export AGENTDESK_CODESIGN_IDENTITY=$(printf '%q' "${AGENTDESK_CODESIGN_IDENTITY:-}")
+export AGENTDESK_PROMOTE_BINARY=$(printf '%q' "${AGENTDESK_PROMOTE_BINARY:-}")
 cd $(printf '%q' "$REPO")
 exec $(printf '%q' "$SCRIPT_DIR/promote-release.sh")${quoted_args}
 EOF
@@ -305,7 +308,11 @@ mkdir -p "$SKILLS_STAGED"
 rsync -a --delete "$REPO/skills/" "$SKILLS_STAGED/"
 
 # Wait for active turns to finish before stopping the server.
-# Without this, the SIGTERM interrupts mid-response, cutting off output.
+# dcserver SIGTERM preserves turn state (#43e3cacc): tmux sessions stay alive
+# and the watcher silent-reattaches after restart. What the drain gate guards
+# against is mid-stream output truncation to Discord during the SIGTERM window.
+# Skip the wait with AGENTDESK_SKIP_TURN_DRAIN=1 when a brief stream hiccup is
+# acceptable for the planned restart.
 # REL_PORT already assigned earlier for the zero-inflight gate.
 if ! wait_for_live_turns_to_drain_or_fail "release" "$PLIST_REL" "$REL_PORT" 120 2; then
     exit 1
@@ -346,6 +353,28 @@ if [ ! -x "$SOURCE_BINARY" ]; then
     echo "  Run 'cargo build --release' or './scripts/build-release.sh' first."
     exit 1
 fi
+
+# Binary freshness check — reject promoting a binary built before the current HEAD.
+# An older binary may miss embedded migrations (sqlx::migrate! is a compile-time
+# macro) or code changes, leading to runtime migration-mismatch errors. Opt out
+# with AGENTDESK_PROMOTE_SKIP_FRESHNESS=1 when intentional (e.g. bisecting, or
+# when AGENTDESK_PROMOTE_BINARY points at a validated artifact from elsewhere).
+if [ "${AGENTDESK_PROMOTE_SKIP_FRESHNESS:-0}" != "1" ] && [ -z "${AGENTDESK_PROMOTE_BINARY:-}" ]; then
+    HEAD_EPOCH=$(git -C "$REPO" log -1 --format=%ct 2>/dev/null || echo 0)
+    BIN_EPOCH=$(stat -f %m "$SOURCE_BINARY" 2>/dev/null || stat -c %Y "$SOURCE_BINARY" 2>/dev/null || echo 0)
+    if [ "$BIN_EPOCH" -lt "$HEAD_EPOCH" ]; then
+        HEAD_SHORT=$(git -C "$REPO" log -1 --format=%h 2>/dev/null || echo "?")
+        BIN_MTIME_HUMAN=$(stat -f '%Sm' "$SOURCE_BINARY" 2>/dev/null || stat -c '%y' "$SOURCE_BINARY" 2>/dev/null || echo "?")
+        HEAD_HUMAN=$(git -C "$REPO" log -1 --format='%ai' 2>/dev/null || echo "?")
+        echo "✗ Binary is older than current HEAD (${HEAD_SHORT}):"
+        echo "    binary mtime: ${BIN_MTIME_HUMAN}"
+        echo "    HEAD commit:  ${HEAD_HUMAN}"
+        echo "  Rebuild with 'cargo build --release' before promoting, or override with"
+        echo "  AGENTDESK_PROMOTE_SKIP_FRESHNESS=1 when intentional."
+        exit 1
+    fi
+fi
+
 echo "▸ Copying binary from $SOURCE_BINARY..."
 STAGED_BINARY="$(_staged_promote_binary_path)"
 chflags nouchg "$ADK_REL/bin/agentdesk" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Two related hardening fixes for `scripts/promote-release.sh` after today's incident where an out-of-date `target/release/agentdesk` was promoted and tripped sqlx on a missing migration checksum.

### 1. Rename `AGENTDESK_ALLOW_LIVE_TURN_CUT` → `AGENTDESK_SKIP_TURN_DRAIN`

The old name was misleading. With the #43e3cacc inflight-turn preservation fix already in place, this flag does **not** actually cut turns — tmux sessions stay alive and the watcher silent-reattaches after restart. What the drain gate actually guards against is **mid-stream Discord output truncation** during the SIGTERM window.

- Renames the env var and every gate message
- Propagates the flag through the detached self-hosted helper (previously lost at helper re-exec)
- Also propagates `AGENTDESK_CODESIGN_IDENTITY` and `AGENTDESK_PROMOTE_BINARY` for the same reason

### 2. Add a binary freshness check

`promote-release.sh` only copies `$REPO/target/release/agentdesk` — it never builds. A stale binary (built before the current HEAD) can miss embedded migrations because `sqlx::migrate!("./migrations/postgres")` is a compile-time macro.

Today's specific failure: `promote-release.sh` copied the Apr 20 19:23 binary (pre-PR #889), which contained migration 5 but not 6. When the DB already had the new migration 6 applied, sqlx refused to start with:

```
migration 6 was previously applied but is missing in the resolved migrations
```

Fix: the script now refuses to promote if the binary's mtime is older than the current HEAD commit time. Override with `AGENTDESK_PROMOTE_SKIP_FRESHNESS=1` for bisect / `AGENTDESK_PROMOTE_BINARY` artifacts.

## What this does NOT fix (follow-up issues worth tracking)

- **`AGENTDESK_SKIP_TURN_DRAIN=1` still kills the user's session** after restart. Root cause: `src/services/claude.rs:1167-1170` `session_usable` requires the `/tmp/<session>.jsonl` output file to exist, but that file is removed somewhere during the dcserver restart cycle, so the next turn triggers "stale local session cleanup before recreate". Silent reattach is half-broken — watcher reattach works, but provider routing still kills the session when it tries to deliver a new turn. Separate issue warranted.
- **Mid-stream output loss with skip-drain** is documented but not fixed. Future work: flush Discord buffers before SIGTERM.

## Test plan

- [x] `bash -n` syntax check on both modified scripts
- [x] Visually verified every `AGENTDESK_ALLOW_LIVE_TURN_CUT` reference renamed
- [x] Helper env propagation block reviewed (added SKIP_TURN_DRAIN + CODESIGN_IDENTITY + PROMOTE_BINARY)
- [ ] Run `./scripts/promote-release.sh` once without `cargo build --release` to confirm the freshness check trips
- [ ] Run with `AGENTDESK_PROMOTE_SKIP_FRESHNESS=1` to confirm override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)