### PR TITLE
fix(#826) + feat(#896): background-trigger relay fix + /api/inflight/rebind

### DIFF
--- a/src/server/routes/domains/access.rs
+++ b/src/server/routes/domains/access.rs
@@ -12,6 +12,10 @@ pub(crate) fn router() -> ApiRouter {
             .route("/send", post(health_api::send_handler))
             .route("/send_to_agent", post(health_api::send_to_agent_handler))
             .route("/senddm", post(health_api::senddm_handler))
+            .route(
+                "/inflight/rebind",
+                post(health_api::rebind_inflight_handler),
+            )
             .route("/auth/session", get(auth::get_session)),
     )
 }

--- a/src/server/routes/health_api.rs
+++ b/src/server/routes/health_api.rs
@@ -203,6 +203,45 @@ pub async fn send_handler(
     (status, Json(json)).into_response()
 }
 
+/// POST /api/inflight/rebind — #896 orphan recovery endpoint.
+///
+/// Rebinds a live tmux session to a freshly-created inflight state and
+/// respawns the output watcher. Intended for operators recovering from
+/// situations where the tmux session is alive (agent is actively working)
+/// but the inflight JSON was cleared by a prior turn's cleanup, leaving
+/// subsequent output with no Discord relay path.
+///
+/// See `send_handler` for the rationale on the mandatory
+/// `ConnectInfo<SocketAddr>` extractor.
+pub async fn rebind_inflight_handler(
+    State(state): State<AppState>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    body: Bytes,
+) -> Response {
+    if !discord_control_endpoints_allowed(&state.config, Some(peer_addr)) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"ok": false, "error": "auth_token required for non-loopback host"})),
+        )
+            .into_response();
+    }
+
+    let Some(ref registry) = state.health_registry else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({"ok": false, "error": "Discord not available (standalone mode)"})),
+        )
+            .into_response();
+    };
+
+    let body_str = String::from_utf8_lossy(&body);
+    let (status_str, response_body) = health::handle_rebind_inflight(registry, &body_str).await;
+    let status = parse_status_code(status_str);
+    let json: serde_json::Value =
+        serde_json::from_str(&response_body).unwrap_or(serde_json::json!({"error": "internal"}));
+    (status, Json(json)).into_response()
+}
+
 /// POST /api/send_to_agent — role_id-based agent routing.
 ///
 /// See `send_handler` for the rationale on the mandatory

--- a/src/services/discord/health.rs
+++ b/src/services/discord/health.rs
@@ -1819,10 +1819,15 @@ pub async fn handle_rebind_inflight<'a>(
         .rebind_inflight(&provider, channel_id, tmux_override)
         .await
     else {
+        // #897 counter-model review: dcserver bootstrap registers the
+        // `ProviderEntry` before the provider's Discord HTTP client, so a
+        // lookup miss here can mean EITHER permanent misconfiguration OR a
+        // transient warmup window. The error text now tells operators to
+        // retry instead of assuming the provider is permanently absent.
         return (
             "503 Service Unavailable",
             format!(
-                r#"{{"ok":false,"error":"provider {} not registered in this dcserver"}}"#,
+                r#"{{"ok":false,"error":"provider {} is not yet available in this dcserver (still warming up or not registered) — retry in a few seconds"}}"#,
                 provider.as_str()
             ),
         );
@@ -1837,6 +1842,7 @@ pub async fn handle_rebind_inflight<'a>(
                 "channel_id": outcome.channel_id.to_string(),
                 "initial_offset": outcome.initial_offset,
                 "watcher_spawned": outcome.watcher_spawned,
+                "watcher_replaced": outcome.watcher_replaced,
             })
             .to_string(),
         ),

--- a/src/services/discord/health.rs
+++ b/src/services/discord/health.rs
@@ -125,6 +125,51 @@ impl HealthRegistry {
         self.discord_http.lock().await.push((provider, http));
     }
 
+    /// #896: Rebind a live tmux session to a freshly-created inflight state
+    /// for the given provider/channel, routing through the provider's
+    /// registered `SharedData` and Discord HTTP. Returns `None` when the
+    /// provider is not registered with this dcserver (standalone mode or
+    /// cross-runtime target); the HTTP handler maps that to 503. The inner
+    /// `Result` carries typed failures from `rebind_inflight_for_channel`
+    /// so the handler can pick the right HTTP status.
+    ///
+    /// Kept on the registry (rather than exposing `SharedData` directly via
+    /// an accessor) so this crate does not leak the `pub(in crate::services)`
+    /// `SharedData` type across the service boundary.
+    pub(crate) async fn rebind_inflight(
+        &self,
+        provider: &crate::services::provider::ProviderKind,
+        channel_id: u64,
+        tmux_override: Option<String>,
+    ) -> Option<Result<super::recovery_engine::RebindOutcome, super::recovery_engine::RebindError>>
+    {
+        let provider_name = provider.as_str().to_string();
+        let shared = self
+            .providers
+            .lock()
+            .await
+            .iter()
+            .find(|entry| entry.name == provider_name)
+            .map(|entry| entry.shared.clone())?;
+        let http = self
+            .discord_http
+            .lock()
+            .await
+            .iter()
+            .find(|(name, _)| name == &provider_name)
+            .map(|(_, http)| http.clone())?;
+        Some(
+            super::recovery_engine::rebind_inflight_for_channel(
+                &http,
+                &shared,
+                provider,
+                channel_id,
+                tmux_override,
+            )
+            .await,
+        )
+    }
+
     /// Load announce + notify bot tokens from the canonical runtime credential path.
     /// Call once at startup before the axum server begins accepting requests.
     pub async fn init_bot_tokens(&self) {
@@ -1683,6 +1728,142 @@ pub async fn handle_send<'a>(registry: &HealthRegistry, db: &Db, body: &str) -> 
     send_message(registry, db, target, content, source, bot, summary).await
 }
 
+/// #896: Parsed `/api/inflight/rebind` body, extracted for unit-test
+/// coverage of input validation without spinning up a `HealthRegistry`.
+#[derive(Debug, PartialEq, Eq)]
+struct ParsedRebindRequest {
+    provider: crate::services::provider::ProviderKind,
+    channel_id: u64,
+    tmux_session: Option<String>,
+}
+
+/// #896: Parse and validate the rebind request body. Returns a status-tuple
+/// error on malformed input so the caller can surface it verbatim.
+fn parse_rebind_body(body: &str) -> Result<ParsedRebindRequest, (&'static str, String)> {
+    let json: serde_json::Value = serde_json::from_str(body).map_err(|_| {
+        (
+            "400 Bad Request",
+            r#"{"ok":false,"error":"invalid JSON"}"#.to_string(),
+        )
+    })?;
+
+    let provider_raw = json
+        .get("provider")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim();
+    let provider =
+        crate::services::provider::ProviderKind::from_str(provider_raw).ok_or_else(|| {
+            (
+                "400 Bad Request",
+                r#"{"ok":false,"error":"provider must be one of: claude, codex"}"#.to_string(),
+            )
+        })?;
+
+    // Accept channel_id as either a JSON number or a decimal string so
+    // callers can forward snowflake IDs without precision loss.
+    let channel_id: u64 = match json.get("channel_id") {
+        Some(v) if v.is_u64() => v.as_u64().unwrap_or(0),
+        Some(v) if v.is_string() => v.as_str().unwrap_or("").trim().parse::<u64>().unwrap_or(0),
+        _ => 0,
+    };
+    if channel_id == 0 {
+        return Err((
+            "400 Bad Request",
+            r#"{"ok":false,"error":"channel_id is required (non-zero u64)"}"#.to_string(),
+        ));
+    }
+
+    let tmux_session = json
+        .get("tmux_session")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+
+    Ok(ParsedRebindRequest {
+        provider,
+        channel_id,
+        tmux_session,
+    })
+}
+
+/// #896: Handle `POST /api/inflight/rebind` — rebind a live tmux session to
+/// a freshly-created inflight state and respawn the watcher. Used to recover
+/// orphan states where tmux is still running but turn_bridge has no inflight
+/// to track against (e.g. after a prior turn's cleanup cleared the state and
+/// the agent continued work via internal auto-triggers).
+///
+/// Body shape:
+/// ```json
+/// { "provider": "codex" | "claude",
+///   "channel_id": "1234567890",
+///   "tmux_session": "AgentDesk-codex-foo"   // optional — derived otherwise
+/// }
+/// ```
+pub async fn handle_rebind_inflight<'a>(
+    registry: &HealthRegistry,
+    body: &str,
+) -> (&'a str, String) {
+    let parsed = match parse_rebind_body(body) {
+        Ok(p) => p,
+        Err((status, body)) => return (status, body),
+    };
+    let ParsedRebindRequest {
+        provider,
+        channel_id,
+        tmux_session: tmux_override,
+    } = parsed;
+
+    let Some(result) = registry
+        .rebind_inflight(&provider, channel_id, tmux_override)
+        .await
+    else {
+        return (
+            "503 Service Unavailable",
+            format!(
+                r#"{{"ok":false,"error":"provider {} not registered in this dcserver"}}"#,
+                provider.as_str()
+            ),
+        );
+    };
+
+    match result {
+        Ok(outcome) => (
+            "200 OK",
+            serde_json::json!({
+                "ok": true,
+                "tmux_session": outcome.tmux_session,
+                "channel_id": outcome.channel_id.to_string(),
+                "initial_offset": outcome.initial_offset,
+                "watcher_spawned": outcome.watcher_spawned,
+            })
+            .to_string(),
+        ),
+        Err(err) => {
+            let (status, message) = match &err {
+                super::recovery_engine::RebindError::TmuxNotAlive { .. } => {
+                    ("404 Not Found", err.to_string())
+                }
+                super::recovery_engine::RebindError::InflightAlreadyExists => {
+                    ("409 Conflict", err.to_string())
+                }
+                super::recovery_engine::RebindError::ChannelNotBound
+                | super::recovery_engine::RebindError::ChannelNameMissing => {
+                    ("400 Bad Request", err.to_string())
+                }
+                super::recovery_engine::RebindError::Internal(_) => {
+                    ("500 Internal Server Error", err.to_string())
+                }
+            };
+            (
+                status,
+                serde_json::json!({ "ok": false, "error": message }).to_string(),
+            )
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 struct ParsedSendToAgentRequest {
     role_id: String,
@@ -2346,5 +2527,79 @@ mod tests {
         .expect_err("ambiguous explicit matches must fail");
 
         assert!(err.contains("multiple runtimes explicitly allow channel 123"));
+    }
+
+    /// #896: `parse_rebind_body` must reject malformed inputs with
+    /// 400 statuses before we touch any runtime state. Each case here is
+    /// an operator footgun that would otherwise raise an opaque error
+    /// deeper in the rebind flow.
+    #[test]
+    fn parse_rebind_body_rejects_invalid_json() {
+        let err = parse_rebind_body("{not-json").expect_err("malformed JSON must fail");
+        assert_eq!(err.0, "400 Bad Request");
+        assert!(err.1.contains("invalid JSON"));
+    }
+
+    #[test]
+    fn parse_rebind_body_rejects_unknown_provider() {
+        let body = r#"{"provider":"gpt","channel_id":"123"}"#;
+        let err = parse_rebind_body(body).expect_err("unknown provider must fail");
+        assert_eq!(err.0, "400 Bad Request");
+        assert!(err.1.contains("provider"));
+    }
+
+    #[test]
+    fn parse_rebind_body_rejects_missing_channel_id() {
+        let body = r#"{"provider":"codex"}"#;
+        let err = parse_rebind_body(body).expect_err("missing channel_id must fail");
+        assert_eq!(err.0, "400 Bad Request");
+        assert!(err.1.contains("channel_id"));
+    }
+
+    #[test]
+    fn parse_rebind_body_rejects_zero_channel_id() {
+        let body = r#"{"provider":"codex","channel_id":"0"}"#;
+        let err = parse_rebind_body(body).expect_err("channel_id=0 must fail");
+        assert_eq!(err.0, "400 Bad Request");
+        assert!(err.1.contains("channel_id"));
+    }
+
+    #[test]
+    fn parse_rebind_body_accepts_numeric_and_string_channel_id() {
+        // Snowflakes exceed i32::MAX so both numeric and string forms
+        // must be accepted to avoid precision loss on the caller side.
+        for body in [
+            r#"{"provider":"codex","channel_id":1490141485167808532}"#,
+            r#"{"provider":"codex","channel_id":"1490141485167808532"}"#,
+        ] {
+            let parsed = parse_rebind_body(body).expect("snowflake channel_id must parse");
+            assert_eq!(parsed.channel_id, 1490141485167808532);
+            assert_eq!(parsed.provider.as_str(), "codex");
+            assert!(parsed.tmux_session.is_none());
+        }
+    }
+
+    #[test]
+    fn parse_rebind_body_keeps_explicit_tmux_session_override() {
+        let body =
+            r#"{"provider":"claude","channel_id":"42","tmux_session":"AgentDesk-claude-foo"}"#;
+        let parsed = parse_rebind_body(body).expect("body should parse");
+        assert_eq!(parsed.provider.as_str(), "claude");
+        assert_eq!(parsed.channel_id, 42);
+        assert_eq!(
+            parsed.tmux_session.as_deref(),
+            Some("AgentDesk-claude-foo"),
+            "explicit tmux_session must survive into rebind call"
+        );
+    }
+
+    #[test]
+    fn parse_rebind_body_treats_blank_tmux_session_as_absent() {
+        let body = r#"{"provider":"claude","channel_id":"42","tmux_session":"  "}"#;
+        let parsed = parse_rebind_body(body).expect("body should parse");
+        assert!(
+            parsed.tmux_session.is_none(),
+            "whitespace-only override must fall back to auto-derivation"
+        );
     }
 }

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -70,6 +70,23 @@ pub(super) struct InflightTurnState {
     /// Generation that owns the planned restart/handoff lifecycle.
     #[serde(default)]
     pub restart_generation: Option<u64>,
+    /// #897 counter-model re-review — `true` when this inflight was
+    /// synthesised by `POST /api/inflight/rebind` to adopt a live tmux
+    /// session that had no real user-authored turn driving it (zero-valued
+    /// `user_msg_id` / `current_msg_id` / `request_owner_user_id`).
+    ///
+    /// Callers that route based on "is there a live foreground turn" must
+    /// treat a rebind-origin inflight as **absent** — otherwise the
+    /// background-trigger notify-bot predicate in
+    /// `should_route_terminal_response_via_notify_bot` sees a
+    /// non-rebind_origin inflight, routes the recovered auto-trigger
+    /// response back through the command bot, and reintroduces the
+    /// loop-hazard that #826 was fixing. Reactions / transcript writes
+    /// that key off `user_msg_id` should also skip work when this flag is
+    /// set, because the placeholder IDs do not identify a real Discord
+    /// message.
+    #[serde(default)]
+    pub rebind_origin: bool,
 }
 
 impl InflightTurnState {
@@ -121,6 +138,7 @@ impl InflightTurnState {
             last_watcher_relayed_offset: None,
             restart_mode: None,
             restart_generation: None,
+            rebind_origin: false,
         }
     }
 

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -162,6 +162,88 @@ pub(super) fn save_inflight_state(state: &InflightTurnState) -> Result<(), Strin
     save_inflight_state_in_root(&root, state)
 }
 
+/// #897 counter-model review P2 #1 — atomic "create, don't overwrite"
+/// variant of `save_inflight_state`. Used by `POST /api/inflight/rebind` so a
+/// concurrent legitimate turn that wins the mailbox race between the rebind
+/// handler's existence check and its write cannot have its canonical
+/// inflight file silently overwritten by the synthetic rebind state
+/// (`user_msg_id=0`, placeholder ids zeroed). Returns `InflightAlreadyExists`
+/// when the target path is already occupied — the handler translates that
+/// into HTTP 409 and the operator retries (or leaves it to the live turn).
+#[derive(Debug)]
+pub(super) enum CreateNewInflightError {
+    /// A state file already exists at the target path — another path wrote
+    /// it between the caller's preflight check and this call.
+    AlreadyExists,
+    /// Filesystem or serialization failure.
+    Internal(String),
+}
+
+impl std::fmt::Display for CreateNewInflightError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AlreadyExists => write!(f, "inflight state already exists"),
+            Self::Internal(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+pub(super) fn save_inflight_state_create_new(
+    state: &InflightTurnState,
+) -> Result<(), CreateNewInflightError> {
+    let Some(root) = inflight_runtime_root() else {
+        return Err(CreateNewInflightError::Internal(
+            "Home directory not found".to_string(),
+        ));
+    };
+    save_inflight_state_create_new_in_root(&root, state)
+}
+
+/// Test-visible inner form of `save_inflight_state_create_new`. Takes an
+/// explicit root so unit tests can exercise the O_CREAT|O_EXCL semantics
+/// without tripping over `AGENTDESK_ROOT_DIR` env-var races.
+fn save_inflight_state_create_new_in_root(
+    root: &Path,
+    state: &InflightTurnState,
+) -> Result<(), CreateNewInflightError> {
+    let Some(provider) = state.provider_kind() else {
+        return Err(CreateNewInflightError::Internal(format!(
+            "Unknown provider '{}'",
+            state.provider
+        )));
+    };
+    let path = inflight_state_path(root, &provider, state.channel_id);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| CreateNewInflightError::Internal(e.to_string()))?;
+    }
+    let mut updated = state.clone();
+    updated.updated_at = now_string();
+    let json = serde_json::to_string_pretty(&updated)
+        .map_err(|e| CreateNewInflightError::Internal(e.to_string()))?;
+
+    // `OpenOptions::create_new(true)` is the canonical atomic check-and-
+    // create primitive on POSIX (O_CREAT | O_EXCL). No reliance on a
+    // preceding `load_inflight_state` — the kernel itself serializes this.
+    use std::io::Write;
+    match fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+    {
+        Ok(mut file) => {
+            file.write_all(json.as_bytes())
+                .map_err(|e| CreateNewInflightError::Internal(e.to_string()))?;
+            file.sync_all()
+                .map_err(|e| CreateNewInflightError::Internal(e.to_string()))?;
+            Ok(())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            Err(CreateNewInflightError::AlreadyExists)
+        }
+        Err(e) => Err(CreateNewInflightError::Internal(e.to_string())),
+    }
+}
+
 fn save_inflight_state_in_root(root: &Path, state: &InflightTurnState) -> Result<(), String> {
     let Some(provider) = state.provider_kind() else {
         return Err(format!("Unknown provider '{}'", state.provider));
@@ -368,8 +450,9 @@ fn load_inflight_states_from_root(root: &Path, provider: &ProviderKind) -> Vec<I
 #[cfg(test)]
 mod tests {
     use super::{
-        InflightTurnState, latest_request_owner_user_id_for_channel, load_inflight_states,
-        load_inflight_states_from_root, mark_all_inflight_states_restart_mode,
+        CreateNewInflightError, InflightTurnState, latest_request_owner_user_id_for_channel,
+        load_inflight_states, load_inflight_states_from_root,
+        mark_all_inflight_states_restart_mode, save_inflight_state_create_new_in_root,
         save_inflight_state_in_root, stale_removal_reason,
     };
     use crate::services::discord::InflightRestartMode;
@@ -534,5 +617,92 @@ mod tests {
             states[0].restart_generation,
             Some(super::super::runtime_store::load_generation())
         );
+    }
+
+    /// #897 P2 #1: `save_inflight_state_create_new_in_root` must succeed on
+    /// a vacant path (atomic create) and reject a second call at the same
+    /// path with `AlreadyExists` — this is the guarantee that prevents a
+    /// `/api/inflight/rebind` call from overwriting a concurrent live
+    /// turn's canonical inflight state.
+    #[test]
+    fn save_inflight_state_create_new_rejects_existing_path() {
+        let temp = TempDir::new().unwrap();
+        let state = InflightTurnState::new(
+            ProviderKind::Codex,
+            1_234_567,
+            Some("adk-cdx".to_string()),
+            0,
+            0,
+            0,
+            "/api/inflight/rebind".to_string(),
+            None,
+            Some("AgentDesk-codex-adk-cdx".to_string()),
+            Some("/tmp/out.jsonl".to_string()),
+            Some("/tmp/in.fifo".to_string()),
+            0,
+        );
+
+        save_inflight_state_create_new_in_root(temp.path(), &state)
+            .expect("first atomic create must succeed on a vacant path");
+
+        match save_inflight_state_create_new_in_root(temp.path(), &state) {
+            Err(CreateNewInflightError::AlreadyExists) => {}
+            other => panic!(
+                "second atomic create must report AlreadyExists, got {:?}",
+                other
+            ),
+        }
+    }
+
+    /// #897 P2 #1: a previously-saved `save_inflight_state_in_root` write
+    /// must be observed by `save_inflight_state_create_new_in_root` as
+    /// `AlreadyExists`. This is the actual race we need to guard against —
+    /// a legitimate turn writes its state via `save_inflight_state`, then a
+    /// concurrent rebind call must NOT overwrite it.
+    #[test]
+    fn save_inflight_state_create_new_rejects_path_written_by_normal_save() {
+        let temp = TempDir::new().unwrap();
+        let live_turn_state = InflightTurnState::new(
+            ProviderKind::Codex,
+            9_876_543,
+            Some("adk-cdx".to_string()),
+            123, // live user
+            456, // real user_msg_id
+            789, // real current_msg_id
+            "real user input".to_string(),
+            Some("session-live".to_string()),
+            Some("AgentDesk-codex-adk-cdx".to_string()),
+            Some("/tmp/out.jsonl".to_string()),
+            Some("/tmp/in.fifo".to_string()),
+            128,
+        );
+        save_inflight_state_in_root(temp.path(), &live_turn_state)
+            .expect("legitimate turn write must succeed");
+
+        let rebind_state = InflightTurnState::new(
+            ProviderKind::Codex,
+            9_876_543,
+            Some("adk-cdx".to_string()),
+            0,
+            0,
+            0,
+            "/api/inflight/rebind".to_string(),
+            None,
+            Some("AgentDesk-codex-adk-cdx".to_string()),
+            Some("/tmp/out.jsonl".to_string()),
+            Some("/tmp/in.fifo".to_string()),
+            0,
+        );
+        match save_inflight_state_create_new_in_root(temp.path(), &rebind_state) {
+            Err(CreateNewInflightError::AlreadyExists) => {}
+            other => panic!("rebind must not overwrite live turn state; got {:?}", other),
+        }
+
+        // Canonical live-turn data must survive.
+        let states = load_inflight_states_from_root(temp.path(), &ProviderKind::Codex);
+        assert_eq!(states.len(), 1);
+        assert_eq!(states[0].request_owner_user_id, 123);
+        assert_eq!(states[0].user_msg_id, 456);
+        assert_eq!(states[0].user_text, "real user input");
     }
 }

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -1710,7 +1710,14 @@ pub(crate) async fn rebind_inflight_for_channel(
 
     // Build and persist the new inflight state. No request_owner / msg_ids
     // apply because this recovery has no originating Discord message.
-    let state = super::inflight::InflightTurnState::new(
+    //
+    // #897 counter-model re-review (round 2): flag this as `rebind_origin`
+    // so routing predicates that key off "is there a live foreground turn"
+    // treat it as absent. Without that, the watcher's
+    // `should_route_terminal_response_via_notify_bot` sees a non-empty
+    // inflight and drops background-trigger output back to the command-bot
+    // path — precisely the loop-hazard #826 was avoiding.
+    let mut state = super::inflight::InflightTurnState::new(
         provider.clone(),
         channel_id,
         channel_name.clone(),
@@ -1724,6 +1731,7 @@ pub(crate) async fn rebind_inflight_for_channel(
         Some(input_fifo.clone()),
         initial_offset,
     );
+    state.rebind_origin = true;
 
     // Atomic create-or-fail: if a legitimate turn created its inflight file
     // between the preflight check above and this point, the write fails
@@ -2092,6 +2100,7 @@ mod tests {
             last_watcher_relayed_offset: None,
             restart_mode: None,
             restart_generation: None,
+            rebind_origin: false,
         };
 
         assert!(
@@ -2202,6 +2211,7 @@ mod tests {
             last_watcher_relayed_offset: None,
             restart_mode: None,
             restart_generation: None,
+            rebind_origin: false,
         };
 
         save_missing_session_handoff(

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -1554,7 +1554,17 @@ pub struct RebindOutcome {
     pub tmux_session: String,
     pub channel_id: u64,
     pub initial_offset: u64,
+    /// `true` when a tmux watcher was spawned by this call. On unix this is
+    /// always true on success. On non-unix builds watcher spawning is a
+    /// no-op, so this reads `false` even though the inflight file was
+    /// written.
     pub watcher_spawned: bool,
+    /// #897 P2 #2 — `true` when a pre-existing watcher handle was present
+    /// for this channel and has been cancelled + replaced by the freshly
+    /// spawned one. Operators use this to distinguish a clean vacant claim
+    /// from a zombie-slot recovery, which is the common case where an old
+    /// watcher kept its DashMap entry after its tmux exited.
+    pub watcher_replaced: bool,
 }
 
 /// #896: Errors from [`rebind_inflight_for_channel`]. Map 1:1 to HTTP status
@@ -1626,8 +1636,12 @@ pub(crate) async fn rebind_inflight_for_channel(
 ) -> Result<RebindOutcome, RebindError> {
     let discord_channel_id = ChannelId::new(channel_id);
 
-    // Refuse if inflight already exists — prevents racing with a live turn
-    // whose watcher/turn_bridge is already driving state.
+    // Preflight existence check — fast 409 before we walk the validation /
+    // tmux-liveness path when the caller obviously shouldn't be rebinding.
+    // This is advisory only; the AUTHORITATIVE guard is the atomic
+    // `save_inflight_state_create_new` below which uses `O_CREAT | O_EXCL`
+    // so a live turn that wins the race between here and the write cannot
+    // be clobbered by the synthetic rebind state.
     if super::inflight::load_inflight_state(provider, channel_id).is_some() {
         return Err(RebindError::InflightAlreadyExists);
     }
@@ -1711,7 +1725,21 @@ pub(crate) async fn rebind_inflight_for_channel(
         initial_offset,
     );
 
-    super::inflight::save_inflight_state(&state).map_err(RebindError::Internal)?;
+    // Atomic create-or-fail: if a legitimate turn created its inflight file
+    // between the preflight check above and this point, the write fails
+    // with `AlreadyExists` and we return 409. Without this guard the
+    // synthetic rebind state (user_msg_id=0, placeholder ids zeroed) would
+    // overwrite the real turn's canonical state and break its completion
+    // path — the exact race the #897 P2 #1 review flagged.
+    match super::inflight::save_inflight_state_create_new(&state) {
+        Ok(()) => {}
+        Err(super::inflight::CreateNewInflightError::AlreadyExists) => {
+            return Err(RebindError::InflightAlreadyExists);
+        }
+        Err(super::inflight::CreateNewInflightError::Internal(msg)) => {
+            return Err(RebindError::Internal(msg));
+        }
+    }
 
     // Register / refresh the in-memory session so downstream handlers can
     // locate this channel after the rebind.
@@ -1744,11 +1772,16 @@ pub(crate) async fn rebind_inflight_for_channel(
         }
     }
 
-    // Spawn the watcher under a fresh claim. `try_claim_watcher` returns
-    // false when another watcher already owns the channel — that's still a
-    // valid post-condition (the inflight we just wrote will be consumed by
-    // the incumbent watcher), so don't treat it as a rebind failure.
-    let watcher_spawned = {
+    // #897 P2 #2: use `claim_or_replace_watcher` instead of
+    // `try_claim_watcher`. The counter-model review flagged that the old
+    // path returned `watcher_spawned=false` whenever the DashMap entry was
+    // occupied — but occupancy does NOT imply liveness. The common zombie
+    // scenario (a previous watcher that exited without removing its handle)
+    // is exactly what makes `/api/inflight/rebind` necessary in the first
+    // place. `claim_or_replace` cancels any incumbent and always installs
+    // our handle, so the post-condition is "a watcher owned by THIS rebind
+    // is running" rather than the weaker "some watcher might be."
+    let (watcher_spawned, watcher_replaced) = {
         #[cfg(unix)]
         {
             let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -1763,30 +1796,32 @@ pub(crate) async fn rebind_inflight_for_channel(
                 pause_epoch: pause_epoch.clone(),
                 turn_delivered: turn_delivered.clone(),
             };
-            let claimed =
-                super::tmux::try_claim_watcher(&shared.tmux_watchers, discord_channel_id, handle);
-            if claimed {
-                tokio::spawn(super::tmux::tmux_output_watcher(
-                    discord_channel_id,
-                    http.clone(),
-                    shared.clone(),
-                    output_path.clone(),
-                    tmux_session_name.clone(),
-                    initial_offset,
-                    cancel,
-                    paused,
-                    resume_offset,
-                    pause_epoch,
-                    turn_delivered,
-                ));
-                true
-            } else {
-                false
-            }
+            // `claim_or_replace_watcher` returns `true` when the slot was
+            // vacant (fresh claim) and `false` when an incumbent was
+            // cancelled + replaced. Invert for `watcher_replaced`.
+            let fresh = super::tmux::claim_or_replace_watcher(
+                &shared.tmux_watchers,
+                discord_channel_id,
+                handle,
+            );
+            tokio::spawn(super::tmux::tmux_output_watcher(
+                discord_channel_id,
+                http.clone(),
+                shared.clone(),
+                output_path.clone(),
+                tmux_session_name.clone(),
+                initial_offset,
+                cancel,
+                paused,
+                resume_offset,
+                pause_epoch,
+                turn_delivered,
+            ));
+            (true, !fresh)
         }
         #[cfg(not(unix))]
         {
-            false
+            (false, false)
         }
     };
 
@@ -1795,6 +1830,7 @@ pub(crate) async fn rebind_inflight_for_channel(
         channel_id,
         initial_offset,
         watcher_spawned,
+        watcher_replaced,
     })
 }
 

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -304,6 +304,27 @@ pub(super) async fn restore_inflight_turns(
     let settings_snapshot = shared.settings.read().await.clone();
 
     for state in states {
+        // #897 round-4 High: rebind_origin inflights are synthetic
+        // placeholders owned by `/api/inflight/rebind` and do NOT carry
+        // a real user message, dispatch context, or placeholder Discord
+        // message. Restart recovery has nothing meaningful to do with
+        // them — running `replace_long_message_raw(msg_id=0)`, writing
+        // `discord:<channel>:0` analytics rows, or emitting reactions
+        // against `MessageId::new(0)` would all produce bogus state
+        // (flagged by #897 round-4 review). The operator is expected to
+        // re-invoke `/api/inflight/rebind` after dcserver comes back up
+        // if the orphan tmux is still alive. Clear the stale state and
+        // skip further processing for this entry.
+        if state.rebind_origin {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            tracing::info!(
+                "  [{ts}] ⏭ recovery: skipping rebind-origin inflight for channel {} — operator must re-invoke /api/inflight/rebind post-restart",
+                state.channel_id
+            );
+            clear_inflight_state(provider, state.channel_id);
+            continue;
+        }
+
         let channel_id = ChannelId::new(state.channel_id);
         let is_dm = matches!(
             channel_id.to_channel(http).await,

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -1548,6 +1548,256 @@ pub(super) async fn restore_inflight_turns(
     }
 }
 
+/// #896: Outcome of a successful [`rebind_inflight_for_channel`] call.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RebindOutcome {
+    pub tmux_session: String,
+    pub channel_id: u64,
+    pub initial_offset: u64,
+    pub watcher_spawned: bool,
+}
+
+/// #896: Errors from [`rebind_inflight_for_channel`]. Map 1:1 to HTTP status
+/// codes in the `/api/inflight/rebind` handler.
+#[derive(Debug)]
+pub enum RebindError {
+    /// Target tmux session is not alive — nothing to rebind to. 404.
+    TmuxNotAlive { tmux_session: String },
+    /// An inflight state already exists for this channel. Caller must clear
+    /// it (force-kill or natural completion) before rebinding. 409.
+    InflightAlreadyExists,
+    /// Channel is not bound to the requested provider in the role-map. 400.
+    ChannelNotBound,
+    /// `tmux_session` not provided and no in-memory session supplies a
+    /// channel_name — cannot derive the canonical tmux session name. 400.
+    ChannelNameMissing,
+    /// Unrecoverable internal error (inflight write, lock poisoning, etc.). 500.
+    Internal(String),
+}
+
+impl std::fmt::Display for RebindError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TmuxNotAlive { tmux_session } => {
+                write!(f, "tmux session not alive: {tmux_session}")
+            }
+            Self::InflightAlreadyExists => {
+                write!(f, "inflight state already exists for this channel")
+            }
+            Self::ChannelNotBound => write!(f, "channel is not bound for this provider"),
+            Self::ChannelNameMissing => write!(
+                f,
+                "channel name missing — pass tmux_session or pre-register the channel"
+            ),
+            Self::Internal(msg) => write!(f, "internal: {msg}"),
+        }
+    }
+}
+
+/// #896: Rebind a live tmux session to a freshly-created inflight state and
+/// (re)spawn the output watcher. Used to recover from orphan states where
+/// the tmux session is alive but the inflight JSON was cleared by a prior
+/// turn's cleanup, leaving subsequent output with no relay path.
+///
+/// Preconditions (enforced — caller gets a typed error on violation):
+/// * Tmux session must be alive. Absent session ⇒ nothing to rebind; the
+///   caller should force-kill + restart instead.
+/// * No existing inflight must exist for the channel. Caller clears first
+///   to avoid racing with a live turn's state.
+/// * Channel must be bound to the requested provider in the role-map.
+///
+/// Side effects on success:
+/// * Writes `~/.adk/release/runtime/discord_inflight/{provider}/{channel}.json`
+///   with `last_offset` set to the tmux output file's current size, so the
+///   watcher only picks up output produced *after* this call. Retroactive
+///   emission of already-dropped output is intentionally out of scope.
+/// * Registers / refreshes the `DiscordSession` entry in `shared.core.sessions`.
+/// * Spawns a `tmux_output_watcher` via `try_claim_watcher`. If a watcher
+///   already owns the channel (e.g. a prior recovery round), the claim is
+///   declined and `watcher_spawned=false` is returned — the inflight we
+///   just created will still be picked up by the existing watcher, so this
+///   is not an error.
+pub(crate) async fn rebind_inflight_for_channel(
+    http: &Arc<serenity::Http>,
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    channel_id: u64,
+    tmux_session_override: Option<String>,
+) -> Result<RebindOutcome, RebindError> {
+    let discord_channel_id = ChannelId::new(channel_id);
+
+    // Refuse if inflight already exists — prevents racing with a live turn
+    // whose watcher/turn_bridge is already driving state.
+    if super::inflight::load_inflight_state(provider, channel_id).is_some() {
+        return Err(RebindError::InflightAlreadyExists);
+    }
+
+    // Resolve tmux session name + channel name from the request, falling back
+    // to the in-memory session map when no override is provided.
+    let (tmux_session_name, channel_name) = match tmux_session_override {
+        Some(name) => {
+            let ch_name =
+                crate::services::provider::parse_provider_and_channel_from_tmux_name(&name)
+                    .map(|(_, ch)| ch);
+            (name, ch_name)
+        }
+        None => {
+            let ch_name = {
+                let data = shared.core.lock().await;
+                data.sessions
+                    .get(&discord_channel_id)
+                    .and_then(|s| s.channel_name.clone())
+            };
+            let ch_name = match ch_name {
+                Some(n) => n,
+                None => return Err(RebindError::ChannelNameMissing),
+            };
+            let tmux = provider.build_tmux_session_name(&ch_name);
+            (tmux, Some(ch_name))
+        }
+    };
+
+    if !tmux_session_alive_with_retry(&tmux_session_name) {
+        return Err(RebindError::TmuxNotAlive {
+            tmux_session: tmux_session_name,
+        });
+    }
+
+    // Validate provider↔channel binding against the settings snapshot,
+    // mirroring what `restore_inflight_turns` requires for watcher revival.
+    let settings_snapshot = shared.settings.read().await.clone();
+    let is_dm = matches!(
+        discord_channel_id.to_channel(http).await,
+        Ok(serenity::model::channel::Channel::Private(_))
+    );
+    let (allowlist_channel_id, provider_channel_name) =
+        if let Some((pid, pname)) = super::resolve_thread_parent(http, discord_channel_id).await {
+            (pid, pname.or(channel_name.clone()))
+        } else {
+            (discord_channel_id, channel_name.clone())
+        };
+    if validate_bot_channel_routing_with_provider_channel(
+        &settings_snapshot,
+        provider,
+        allowlist_channel_id,
+        channel_name.as_deref(),
+        provider_channel_name.as_deref(),
+        is_dm,
+    )
+    .is_err()
+    {
+        return Err(RebindError::ChannelNotBound);
+    }
+
+    let (output_path, input_fifo) = tmux_runtime_paths(&tmux_session_name);
+    let initial_offset = std::fs::metadata(&output_path)
+        .map(|m| m.len())
+        .unwrap_or(0);
+
+    // Build and persist the new inflight state. No request_owner / msg_ids
+    // apply because this recovery has no originating Discord message.
+    let state = super::inflight::InflightTurnState::new(
+        provider.clone(),
+        channel_id,
+        channel_name.clone(),
+        0, // request_owner_user_id — no originating Discord user
+        0, // user_msg_id
+        0, // current_msg_id (placeholder)
+        String::from("/api/inflight/rebind"),
+        None, // session_id
+        Some(tmux_session_name.clone()),
+        Some(output_path.clone()),
+        Some(input_fifo.clone()),
+        initial_offset,
+    );
+
+    super::inflight::save_inflight_state(&state).map_err(RebindError::Internal)?;
+
+    // Register / refresh the in-memory session so downstream handlers can
+    // locate this channel after the rebind.
+    {
+        let mut data = shared.core.lock().await;
+        let session = data
+            .sessions
+            .entry(discord_channel_id)
+            .or_insert_with(|| DiscordSession {
+                session_id: None,
+                memento_context_loaded: false,
+                memento_reflected: false,
+                current_path: None,
+                history: Vec::new(),
+                pending_uploads: Vec::new(),
+                cleared: false,
+                remote_profile_name: None,
+                channel_id: Some(channel_id),
+                channel_name: channel_name.clone(),
+                category_name: None,
+                last_active: tokio::time::Instant::now(),
+                worktree: None,
+                born_generation: super::runtime_store::load_generation(),
+                assistant_turns: 0,
+            });
+        session.channel_id = Some(channel_id);
+        session.last_active = tokio::time::Instant::now();
+        if session.channel_name.is_none() {
+            session.channel_name = channel_name.clone();
+        }
+    }
+
+    // Spawn the watcher under a fresh claim. `try_claim_watcher` returns
+    // false when another watcher already owns the channel — that's still a
+    // valid post-condition (the inflight we just wrote will be consumed by
+    // the incumbent watcher), so don't treat it as a rebind failure.
+    let watcher_spawned = {
+        #[cfg(unix)]
+        {
+            let cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let paused = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let resume_offset = std::sync::Arc::new(std::sync::Mutex::new(None::<u64>));
+            let pause_epoch = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+            let turn_delivered = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let handle = TmuxWatcherHandle {
+                paused: paused.clone(),
+                resume_offset: resume_offset.clone(),
+                cancel: cancel.clone(),
+                pause_epoch: pause_epoch.clone(),
+                turn_delivered: turn_delivered.clone(),
+            };
+            let claimed =
+                super::tmux::try_claim_watcher(&shared.tmux_watchers, discord_channel_id, handle);
+            if claimed {
+                tokio::spawn(super::tmux::tmux_output_watcher(
+                    discord_channel_id,
+                    http.clone(),
+                    shared.clone(),
+                    output_path.clone(),
+                    tmux_session_name.clone(),
+                    initial_offset,
+                    cancel,
+                    paused,
+                    resume_offset,
+                    pause_epoch,
+                    turn_delivered,
+                ));
+                true
+            } else {
+                false
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            false
+        }
+    };
+
+    Ok(RebindOutcome {
+        tmux_session: tmux_session_name,
+        channel_id,
+        initial_offset,
+        watcher_spawned,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -291,10 +291,17 @@ pub(super) async fn enqueue_background_trigger_response_to_notify_outbox(
     let target = format!("channel:{}", channel_id.get());
     let session_key = build_bg_trigger_session_key(channel_id.get(), data_start_offset, content);
 
-    // Prefer the Postgres-backed outbox when available — mirrors the
-    // headless-delivery ordering in `turn_bridge::enqueue_headless_delivery`.
+    // #897 round-3 High: when `pg_pool` is configured, the outbox worker
+    // drains PG EXCLUSIVELY. Writing a row to SQLite as a "fallback" would
+    // silently black-hole the message because no worker polls it in that
+    // mode. On PG insert failure we return `false` so the caller falls
+    // back to a DIRECT Discord send (the only path that guarantees
+    // delivery in PG mode) rather than papering over the failure with an
+    // undeliverable SQLite row. Mirrors
+    // `turn_bridge::enqueue_headless_delivery` which also refuses to fall
+    // back to SQLite when PG is configured.
     if let Some(pool) = pg_pool {
-        match sqlx::query(
+        return match sqlx::query(
             "INSERT INTO message_outbox
              (target, content, bot, source, reason_code, session_key)
              VALUES ($1, $2, 'notify', 'system', 'bg_trigger.auto_turn', $3)",
@@ -305,18 +312,19 @@ pub(super) async fn enqueue_background_trigger_response_to_notify_outbox(
         .execute(pool)
         .await
         {
-            Ok(_) => return true,
+            Ok(_) => true,
             Err(error) => {
                 tracing::warn!(
-                    "background-trigger postgres outbox insert failed for channel {}: {} — falling back to sqlite",
+                    "background-trigger postgres outbox insert failed for channel {}: {}",
                     channel_id,
                     error
                 );
-                // Fall through to the SQLite fallback below.
+                false
             }
-        }
+        };
     }
 
+    // PG is not configured — use the SQLite outbox (legacy / test setups).
     let Some(db) = db else {
         return false;
     };
@@ -393,7 +401,12 @@ async fn reconcile_failed_bg_trigger_enqueues_for_channel(
 ) -> Option<u64> {
     let target = format!("channel:{}", channel_id.get());
 
-    // Prefer the Postgres-backed outbox.
+    // #897 round-3 High: when `pg_pool` is configured it is the ONLY
+    // authoritative store. Consulting SQLite as a "fallback" on PG
+    // failure or on an empty PG result would surface rows from a legacy
+    // test/dev database that the outbox worker never produced, and worse
+    // could delete rows written by a prior run. On PG error we surface
+    // `None` so the next poll retries; there is no data-safe fallback.
     if let Some(pool) = pg_pool {
         let rows_res = sqlx::query_as::<_, (i64, Option<String>)>(
             "SELECT id, session_key FROM message_outbox
@@ -407,7 +420,7 @@ async fn reconcile_failed_bg_trigger_enqueues_for_channel(
         .fetch_all(pool)
         .await;
 
-        match rows_res {
+        return match rows_res {
             Ok(rows) if !rows.is_empty() => {
                 let mut min_offset: Option<u64> = None;
                 for (_, session_key) in &rows {
@@ -438,20 +451,21 @@ async fn reconcile_failed_bg_trigger_enqueues_for_channel(
                     channel_id,
                     min_offset,
                 );
-                return min_offset;
+                min_offset
             }
-            Ok(_) => return None,
+            Ok(_) => None,
             Err(error) => {
                 tracing::warn!(
-                    "postgres bg_trigger reconcile query failed for channel {}: {} — falling back to sqlite",
+                    "postgres bg_trigger reconcile query failed for channel {}: {}",
                     channel_id,
                     error
                 );
-                // Fall through to SQLite fallback below.
+                None
             }
-        }
+        };
     }
 
+    // PG is not configured — use the SQLite outbox (legacy/test setups).
     let db = db?;
     let conn = db.separate_conn().ok()?;
 
@@ -1616,7 +1630,12 @@ pub(super) async fn tmux_output_watcher(
                     let _ = channel_id.say(&http, &notice).await;
                 }
             }
-            if let Some(state) = inflight_state.as_ref() {
+            // #897 round-3 Medium: skip reaction work for `rebind_origin`
+            // inflights — their `user_msg_id=0` identifies no real Discord
+            // message so issuing reactions against it just produces API
+            // errors. The synthetic state was created by
+            // `/api/inflight/rebind` to adopt a live tmux session.
+            if let Some(state) = inflight_state.as_ref().filter(|s| !s.rebind_origin) {
                 let user_msg_id = serenity::MessageId::new(state.user_msg_id);
                 super::formatting::remove_reaction_raw(&http, channel_id, user_msg_id, '⏳').await;
                 super::formatting::add_reaction_raw(&http, channel_id, user_msg_id, '⚠').await;
@@ -1728,7 +1747,10 @@ pub(super) async fn tmux_output_watcher(
                 }
             }
 
-            if let Some(state) = inflight_state.as_ref() {
+            // #897 round-3 Medium: skip reaction + retry scheduling for
+            // `rebind_origin` inflights — they have no real user message
+            // to react against and no real user text to re-prompt.
+            if let Some(state) = inflight_state.as_ref().filter(|s| !s.rebind_origin) {
                 let user_msg_id = serenity::MessageId::new(state.user_msg_id);
                 super::formatting::remove_reaction_raw(&http, channel_id, user_msg_id, '⏳').await;
                 if matches!(&decision, ProviderOverloadDecision::Exhausted) {
@@ -1744,7 +1766,7 @@ pub(super) async fn tmux_output_watcher(
                     fingerprint,
                 } => {
                     if let Some(retry_text) = retry_text {
-                        if let Some(state) = inflight_state.as_ref() {
+                        if let Some(state) = inflight_state.as_ref().filter(|s| !s.rebind_origin) {
                             schedule_provider_overload_retry(
                                 shared.clone(),
                                 http.clone(),
@@ -2200,8 +2222,15 @@ pub(super) async fn tmux_output_watcher(
             );
         }
 
-        // Mark user message as completed: ⏳ → ✅ when inflight metadata is available.
-        if let Some(state) = inflight_state.as_ref() {
+        // Mark user message as completed: ⏳ → ✅ when inflight metadata is
+        // available. #897 round-3 Medium: skip the reaction + transcript +
+        // analytics block entirely for `rebind_origin` inflights. Their
+        // `user_msg_id=0` points at no real message, and persisting a
+        // transcript with `turn_id=discord:<channel>:0` poisons
+        // session_transcripts / turn_analytics. The notify-bot outbox
+        // enqueue above already delivered the recovered response to the
+        // user; nothing else on the success path is legitimate here.
+        if let Some(state) = inflight_state.as_ref().filter(|s| !s.rebind_origin) {
             let user_msg_id = serenity::MessageId::new(state.user_msg_id);
             super::formatting::remove_reaction_raw(&http, channel_id, user_msg_id, '⏳').await;
             super::formatting::add_reaction_raw(&http, channel_id, user_msg_id, '✅').await;

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -99,6 +99,44 @@ fn build_monitor_completion_message(response: &str) -> String {
     )
 }
 
+/// #826: Enqueue a background-trigger turn's terminal response on the
+/// notify-bot outbox so it reaches the channel without going through the
+/// command bot. The notify-bot is dropped at the intake gate, which is what
+/// keeps the auto-trigger path from feeding back into a new turn.
+///
+/// Returns `false` only when the database handle is unavailable or the SQL
+/// insert fails — the caller falls back to a direct command-bot send in that
+/// case so the message is never silently lost.
+pub(super) fn enqueue_background_trigger_response_to_notify_outbox(
+    db: Option<&crate::db::Db>,
+    channel_id: ChannelId,
+    content: &str,
+) -> bool {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return true;
+    }
+    let Some(db) = db else {
+        return false;
+    };
+    let target = format!("channel:{}", channel_id.get());
+    // Intentionally omit reason_code so the lifecycle dedupe in
+    // `message_outbox::enqueue` does not suppress consecutive auto-trigger
+    // responses on the same channel — each background-task completion is its
+    // own event the user must see.
+    crate::services::message_outbox::enqueue_with_db(
+        db,
+        crate::services::message_outbox::OutboxMessage {
+            target: target.as_str(),
+            content,
+            bot: "notify",
+            source: "system",
+            reason_code: None,
+            session_key: None,
+        },
+    )
+}
+
 fn watcher_should_yield_to_active_bridge_turn(
     provider: &ProviderKind,
     channel_id: ChannelId,
@@ -1325,8 +1363,18 @@ pub(super) async fn tmux_output_watcher(
         }
 
         // Duplicate-relay guard: if we already relayed from this same data range, suppress.
+        //
+        // #826: use strict `<` so that data starting EXACTLY at the boundary
+        // recorded by the previous relay (or by the bridge's `resume_offset`)
+        // is treated as new data, not a re-read. After a normal bridge turn
+        // ends the watcher resumes with `last_relayed_offset = Some(Y)` where
+        // `Y` is the byte right after the bridge's last consumed byte. A turn
+        // auto-fired by Claude Code's `<task-notification>` writes its tmux
+        // output starting at that exact `Y`, so `<=` was silently dropping
+        // the entire auto-trigger turn. Strict `<` only catches genuine
+        // re-reads of the same starting offset.
         if let Some(prev_offset) = last_relayed_offset {
-            if data_start_offset <= prev_offset {
+            if data_start_offset < prev_offset {
                 let ts = chrono::Local::now().format("%H:%M:%S");
                 tracing::warn!(
                     "  [{ts}] 👁 Duplicate relay guard: suppressed re-relay for {} (data_start={}, last_relayed={})",
@@ -1432,6 +1480,21 @@ pub(super) async fn tmux_output_watcher(
         let current_response = full_response.get(response_sent_offset..).unwrap_or("");
         let has_current_response = !current_response.trim().is_empty();
 
+        // #826: When inflight state is missing at the watcher's terminal-response
+        // point, this is a turn that Claude Code's `<task-notification>` mechanism
+        // auto-fired after the bridge completed and cleaned up. There is no
+        // user-visible message that would normally trigger the bridge path, so
+        // the response must reach the channel via the notify bot — both because
+        // (a) without it the response is silently dropped (the original #826
+        // bug) and (b) sending via the command bot risks other agents in the
+        // channel treating it as an actionable directive (infinite-loop risk).
+        // Notify bot is the canonical sink for background-task-driven info per
+        // `docs/background-task-pattern.md`; it is also dropped at the intake
+        // gate so the agent itself cannot self-trigger another turn off this
+        // delivery.
+        let route_via_notify_bot = has_assistant_response
+            && super::inflight::load_inflight_state(&watcher_provider, channel_id.get()).is_none();
+
         // Send the terminal response to Discord
         // #225 P1-2: Track relay success across branches
         let relay_ok = if has_assistant_response {
@@ -1442,35 +1505,70 @@ pub(super) async fn tmux_output_watcher(
             let prefixed = build_monitor_completion_message(&formatted);
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::info!(
-                "  [{ts}] 👁 Relaying terminal response to Discord ({} chars, offset {})",
+                "  [{ts}] 👁 Relaying terminal response to Discord ({} chars, offset {}, notify={})",
                 prefixed.len(),
-                data_start_offset
+                data_start_offset,
+                route_via_notify_bot
             );
             // #225 P1-2: Track relay success to gate turn_result_relayed
             let mut relay_ok = true;
-            match placeholder_msg_id {
-                Some(msg_id) => {
-                    if has_current_response {
-                        if let Err(e) =
-                            replace_long_message_raw(&http, channel_id, msg_id, &prefixed, &shared)
-                                .await
-                        {
-                            let ts = chrono::Local::now().format("%H:%M:%S");
-                            tracing::info!("  [{ts}] 👁 Failed to relay: {e}");
-                            relay_ok = false;
-                        }
-                    } else {
-                        let _ = channel_id.delete_message(&http, msg_id).await;
-                    }
+            if route_via_notify_bot {
+                // Background-trigger path: drop the spinner placeholder (it was
+                // sent via the command bot for streaming status) and enqueue the
+                // terminal response on the notify-bot outbox.
+                if let Some(msg_id) = placeholder_msg_id {
+                    let _ = channel_id.delete_message(&http, msg_id).await;
                 }
-                None => {
+                let enqueued = if has_current_response {
+                    enqueue_background_trigger_response_to_notify_outbox(
+                        shared.db.as_ref(),
+                        channel_id,
+                        &prefixed,
+                    )
+                } else {
+                    true
+                };
+                if !enqueued {
+                    let ts = chrono::Local::now().format("%H:%M:%S");
+                    tracing::warn!(
+                        "  [{ts}] 👁 background-trigger notify enqueue failed in channel {} — falling back to direct send",
+                        channel_id
+                    );
                     if has_current_response
                         && let Err(e) =
                             send_long_message_raw(&http, channel_id, &prefixed, &shared).await
                     {
                         let ts = chrono::Local::now().format("%H:%M:%S");
-                        tracing::info!("  [{ts}] 👁 Failed to relay: {e}");
+                        tracing::info!("  [{ts}] 👁 Fallback relay failed: {e}");
                         relay_ok = false;
+                    }
+                }
+            } else {
+                match placeholder_msg_id {
+                    Some(msg_id) => {
+                        if has_current_response {
+                            if let Err(e) = replace_long_message_raw(
+                                &http, channel_id, msg_id, &prefixed, &shared,
+                            )
+                            .await
+                            {
+                                let ts = chrono::Local::now().format("%H:%M:%S");
+                                tracing::info!("  [{ts}] 👁 Failed to relay: {e}");
+                                relay_ok = false;
+                            }
+                        } else {
+                            let _ = channel_id.delete_message(&http, msg_id).await;
+                        }
+                    }
+                    None => {
+                        if has_current_response
+                            && let Err(e) =
+                                send_long_message_raw(&http, channel_id, &prefixed, &shared).await
+                        {
+                            let ts = chrono::Local::now().format("%H:%M:%S");
+                            tracing::info!("  [{ts}] 👁 Failed to relay: {e}");
+                            relay_ok = false;
+                        }
                     }
                 }
             }
@@ -2998,13 +3096,15 @@ async fn sweep_orphan_session_files() {
 mod tests {
     use super::{
         DeadSessionCleanupPlan, WatcherToolState, build_monitor_completion_message,
-        dead_session_cleanup_plan, load_restored_provider_session_id, process_watcher_lines,
+        dead_session_cleanup_plan, enqueue_background_trigger_response_to_notify_outbox,
+        load_restored_provider_session_id, process_watcher_lines,
         refresh_session_heartbeat_from_tmux_output, watcher_ready_for_input_turn_completed,
         watcher_should_yield_to_inflight_state,
     };
     use crate::services::discord::inflight::InflightTurnState;
     use crate::services::provider::{ProviderKind, ReadyForInputIdleTracker};
     use crate::services::session_backend::StreamLineState;
+    use poise::serenity_prelude::ChannelId;
 
     #[test]
     fn restored_live_tmux_session_loads_namespaced_provider_session_id() {
@@ -3360,5 +3460,107 @@ mod tests {
             true,
             start + std::time::Duration::from_secs(16)
         ));
+    }
+
+    // ── #826: background-task auto-trigger relay routes through notify outbox ──
+
+    /// When a `Bash run_in_background` (or codex `--background`) task completes
+    /// and Claude Code's `<task-notification>` mechanism fires the auto turn
+    /// after the bridge has already cleaned up, the watcher must enqueue the
+    /// terminal response on the notify-bot outbox so the user sees it. Going
+    /// through the command bot would risk other agents in the channel treating
+    /// the response as an actionable directive (infinite-loop hazard).
+    #[test]
+    fn background_trigger_response_enqueues_notify_outbox_row() {
+        let db = crate::db::test_db();
+        let channel = ChannelId::new(987_654_321);
+        let content = "**✅ 모니터 완료**\n백그라운드 모니터가 작업 완료를 감지해 결과를 이어서 전달합니다.\n\nPR #825 리뷰 4건 fix 완료";
+
+        let enqueued =
+            enqueue_background_trigger_response_to_notify_outbox(Some(&db), channel, content);
+        assert!(
+            enqueued,
+            "background-trigger enqueue must succeed when db is present"
+        );
+
+        let conn = db.lock().unwrap();
+        let (target, stored_content, bot, source): (String, String, String, String) = conn
+            .query_row(
+                "SELECT target, content, bot, source FROM message_outbox ORDER BY id DESC LIMIT 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .expect("expected one outbox row");
+
+        assert_eq!(target, format!("channel:{}", channel.get()));
+        assert_eq!(stored_content, content);
+        assert_eq!(bot, "notify", "must use notify bot to avoid loop hazard");
+        assert_eq!(source, "system");
+    }
+
+    /// Consecutive background-task completions in the same channel must each
+    /// produce their own outbox row — using a `reason_code` here would trip
+    /// the lifecycle-notification dedupe and silently drop later events.
+    #[test]
+    fn background_trigger_response_does_not_dedupe_consecutive_events() {
+        let db = crate::db::test_db();
+        let channel = ChannelId::new(555_111_222);
+        assert!(enqueue_background_trigger_response_to_notify_outbox(
+            Some(&db),
+            channel,
+            "first completion"
+        ));
+        assert!(enqueue_background_trigger_response_to_notify_outbox(
+            Some(&db),
+            channel,
+            "second completion"
+        ));
+
+        let count: i64 = db
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM message_outbox WHERE target = ?1 AND bot = 'notify'",
+                [format!("channel:{}", channel.get()).as_str()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            count, 2,
+            "consecutive background-task events must not dedupe"
+        );
+    }
+
+    /// Empty/whitespace responses must short-circuit without writing a row —
+    /// otherwise the user sees a noise notification with no content.
+    #[test]
+    fn background_trigger_response_skips_empty_payload() {
+        let db = crate::db::test_db();
+        let channel = ChannelId::new(111_222_333);
+        assert!(enqueue_background_trigger_response_to_notify_outbox(
+            Some(&db),
+            channel,
+            "   \n"
+        ));
+        let count: i64 = db
+            .lock()
+            .unwrap()
+            .query_row("SELECT COUNT(*) FROM message_outbox", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0, "empty content must not produce an outbox row");
+    }
+
+    /// When the database is unavailable, the helper reports failure so the
+    /// caller can fall back to a direct Discord send rather than silently
+    /// dropping the response (#826 root cause was a silent drop).
+    #[test]
+    fn background_trigger_response_reports_failure_when_db_missing() {
+        let channel = ChannelId::new(999_888_777);
+        let ok = enqueue_background_trigger_response_to_notify_outbox(
+            None,
+            channel,
+            "would-have-been-delivered",
+        );
+        assert!(!ok, "missing db must surface as failure to enable fallback");
     }
 }

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -135,27 +135,63 @@ pub(super) fn should_route_terminal_response_via_notify_bot(
     has_assistant_response && task_notification_seen && !inflight_present
 }
 
-/// #826 P1 #2: Decide whether `last_relayed_offset` should advance for a
-/// notify-path relay. Only advance when the outbox enqueue SUCCEEDED (durable
-/// DB-backed commit) OR when the direct-send fallback actually reached
-/// Discord. An enqueue failure with no fallback delivery must leave the
-/// offset untouched so the watcher can re-emit the same tmux range on its
-/// next scan instead of silently dropping the response.
+/// #826 P1 #2 (option b): Decide which of the two offset watermarks
+/// (`last_relayed_offset`, `last_enqueued_offset`) a watcher tick should
+/// advance after attempting to deliver a terminal response.
+///
+///  - `last_relayed_offset` is the canonical "Discord has durably received
+///    this byte range" watermark. It must advance ONLY on confirmed
+///    foreground delivery (direct send or placeholder replace succeeded), or
+///    on the notify-path fallback that reached Discord.
+///  - `last_enqueued_offset` is the "outbox row committed" watermark. It
+///    advances when the notify-bot outbox insert succeeded — the outbox
+///    worker owns delivery + retry from there. Prevents re-enqueue of the
+///    same range on the next tick without conflating staging with delivery.
+///
+/// Both watermarks advance in lock-step on genuine delivery so a later
+/// dedupe check (which takes their max) sees a single unified floor.
 ///
 /// Pure function extracted for regression-test coverage of the offset-commit
 /// gate; the runtime version lives inline in the watcher loop because it is
 /// intertwined with other relay bookkeeping.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(super) struct OffsetAdvanceDecision {
+    pub advance_relayed: bool,
+    pub advance_enqueued: bool,
+}
+
 #[inline]
-pub(super) fn notify_path_should_advance_offset(
+pub(super) fn notify_path_offset_advance_decision(
     has_current_response: bool,
     enqueue_succeeded: bool,
-    fallback_send_succeeded: bool,
-) -> bool {
-    if !has_current_response {
-        // Nothing to deliver — trivially safe to advance past an empty range.
-        return true;
+    direct_send_delivered: bool,
+) -> OffsetAdvanceDecision {
+    if direct_send_delivered {
+        // Confirmed foreground delivery. Lift both watermarks.
+        return OffsetAdvanceDecision {
+            advance_relayed: true,
+            advance_enqueued: true,
+        };
     }
-    enqueue_succeeded || fallback_send_succeeded
+    if enqueue_succeeded {
+        // Staged on the outbox — advance the enqueue watermark to dedupe the
+        // next tick, but leave the canonical relayed watermark alone.
+        return OffsetAdvanceDecision {
+            advance_relayed: false,
+            advance_enqueued: true,
+        };
+    }
+    if !has_current_response {
+        // Empty turn — advance both in lock-step (the original single-offset
+        // behaviour) so the watcher doesn't spin on this range.
+        return OffsetAdvanceDecision {
+            advance_relayed: true,
+            advance_enqueued: true,
+        };
+    }
+    // Nothing delivered, nothing staged — leave BOTH watermarks untouched so
+    // the next tick can try again.
+    OffsetAdvanceDecision::default()
 }
 
 /// #826: Enqueue a background-trigger turn's terminal response on the
@@ -578,6 +614,18 @@ pub(super) async fn tmux_output_watcher(
             None
         }
     };
+    // #826 P1 #2 (option b): Track the offset from which the last
+    // notify-outbox enqueue was STAGED — i.e. the row is in `message_outbox`
+    // but Discord delivery has NOT yet been confirmed by the outbox worker.
+    // This watermark dedupes re-enqueue when the watcher loops back without
+    // foreground delivery confirmation, while `last_relayed_offset` stays
+    // reserved for genuinely-delivered relays. If the outbox worker later
+    // marks the row `status='failed'`, a follow-up tick can choose to re-emit
+    // (by resetting this watermark) without having already advanced the
+    // canonical relayed offset. Seeded from the same persisted watermark so
+    // a replacement watcher does not re-enqueue content the predecessor
+    // already staged.
+    let mut last_enqueued_offset: Option<u64> = last_relayed_offset;
 
     // Rolling-size-cap rotation state. The watcher loop spins predictably
     // (~500ms sleeps) so a mod-N gate on an iteration counter gives a
@@ -600,6 +648,11 @@ pub(super) async fn tmux_output_watcher(
             } else {
                 None
             };
+            // #826 P1 #2: keep the enqueue watermark in lock-step with the
+            // relay watermark when the bridge hands control back — otherwise
+            // a stale enqueue marker from a previous turn could suppress a
+            // fresh background-trigger enqueue on the new turn.
+            last_enqueued_offset = last_relayed_offset;
             // Clear turn_delivered after preserving the duplicate-relay guard so
             // future turns beyond this resume point can be relayed normally.
             turn_delivered.store(false, Ordering::Relaxed);
@@ -1439,14 +1492,25 @@ pub(super) async fn tmux_output_watcher(
         // output starting at that exact `Y`, so `<=` was silently dropping
         // the entire auto-trigger turn. Strict `<` only catches genuine
         // re-reads of the same starting offset.
-        if let Some(prev_offset) = last_relayed_offset {
+        //
+        // #826 P1 #2: check the max of the relayed and enqueued watermarks so
+        // that a background-trigger response we already staged on the
+        // notify-bot outbox (but whose Discord delivery the outbox worker
+        // hasn't confirmed yet) isn't re-enqueued on the next tick.
+        let dedupe_floor = match (last_relayed_offset, last_enqueued_offset) {
+            (Some(a), Some(b)) => Some(a.max(b)),
+            (Some(a), None) | (None, Some(a)) => Some(a),
+            (None, None) => None,
+        };
+        if let Some(prev_offset) = dedupe_floor {
             if data_start_offset < prev_offset {
                 let ts = chrono::Local::now().format("%H:%M:%S");
                 tracing::warn!(
-                    "  [{ts}] 👁 Duplicate relay guard: suppressed re-relay for {} (data_start={}, last_relayed={})",
+                    "  [{ts}] 👁 Duplicate relay guard: suppressed re-relay for {} (data_start={}, last_relayed={:?}, last_enqueued={:?})",
                     tmux_session_name,
                     data_start_offset,
-                    prev_offset
+                    last_relayed_offset,
+                    last_enqueued_offset
                 );
                 if let Some(msg_id) = placeholder_msg_id {
                     let _ = channel_id.delete_message(&http, msg_id).await;
@@ -1592,6 +1656,19 @@ pub(super) async fn tmux_output_watcher(
             );
             // #225 P1-2: Track relay success to gate turn_result_relayed
             let mut relay_ok = true;
+            // #826 P1 #2: Tracks whether the notify-bot outbox enqueue ran and
+            // committed to the DB. Distinct from `relay_ok` because enqueue
+            // success is *staging*, not *delivery*: the outbox row may still
+            // fail to reach Discord, so the canonical `last_relayed_offset`
+            // must NOT advance on enqueue alone. We advance the separate
+            // `last_enqueued_offset` below so subsequent ticks don't re-enqueue
+            // the same tmux range before the worker has had a chance to deliver.
+            let mut notify_enqueue_succeeded = false;
+            // #826 P1 #2: Tracks whether the direct-send fallback (either the
+            // notify-path fallback on enqueue failure, or the normal
+            // foreground command-bot path) actually reached Discord. Only a
+            // confirmed foreground send may advance `last_relayed_offset`.
+            let mut direct_send_delivered = false;
             if route_via_notify_bot {
                 // Background-trigger path: drop the spinner placeholder (it was
                 // sent via the command bot for streaming status) and enqueue the
@@ -1609,7 +1686,14 @@ pub(super) async fn tmux_output_watcher(
                     // No assistant text to deliver — nothing to commit.
                     true
                 };
-                if !enqueued {
+                if enqueued {
+                    // Outbox row is durable (DB-backed) and the background
+                    // worker owns delivery + retries. Mark the enqueue
+                    // watermark so a subsequent tick doesn't stage the same
+                    // range again, but leave the *relayed* watermark alone
+                    // until we have confirmed Discord delivery.
+                    notify_enqueue_succeeded = has_current_response;
+                } else {
                     // #826 P1 #2: enqueue FAILED — the message has NOT been
                     // durably persisted to the outbox. Do not let a
                     // downstream success path accidentally advance
@@ -1628,6 +1712,7 @@ pub(super) async fn tmux_output_watcher(
                         match send_long_message_raw(&http, channel_id, &prefixed, &shared).await {
                             Ok(_) => {
                                 relay_ok = true;
+                                direct_send_delivered = true;
                             }
                             Err(e) => {
                                 let ts = chrono::Local::now().format("%H:%M:%S");
@@ -1639,54 +1724,102 @@ pub(super) async fn tmux_output_watcher(
                 }
                 // Residual risk: enqueue succeeded but the notify-bot outbox
                 // worker may still fail to reach Discord later (notify bot
-                // mis-configured, `/api/send` unreachable, Discord rejects the
-                // message). The outbox is a durable DB-backed queue with its
-                // own retry loop, so a transient worker failure is retried
-                // without our involvement. Exhausting worker retries would
-                // leave the row in `status='failed'` with the offset already
-                // advanced — tracked as follow-up, documented here so the
-                // gap is visible in grep.
+                // mis-configured, `/api/send` unreachable, Discord rejects
+                // the message). Because we only advance `last_enqueued_offset`
+                // (not `last_relayed_offset`) on enqueue success, a later
+                // reconciliation pass that notices the outbox row in
+                // `status='failed'` can roll `last_enqueued_offset` back and
+                // trigger a re-stage without having already committed the
+                // canonical relayed watermark.
             } else {
                 match placeholder_msg_id {
                     Some(msg_id) => {
                         if has_current_response {
-                            if let Err(e) = replace_long_message_raw(
+                            match replace_long_message_raw(
                                 &http, channel_id, msg_id, &prefixed, &shared,
                             )
                             .await
                             {
-                                let ts = chrono::Local::now().format("%H:%M:%S");
-                                tracing::info!("  [{ts}] 👁 Failed to relay: {e}");
-                                relay_ok = false;
+                                Ok(_) => {
+                                    direct_send_delivered = true;
+                                }
+                                Err(e) => {
+                                    let ts = chrono::Local::now().format("%H:%M:%S");
+                                    tracing::info!("  [{ts}] 👁 Failed to relay: {e}");
+                                    relay_ok = false;
+                                }
                             }
                         } else {
                             let _ = channel_id.delete_message(&http, msg_id).await;
                         }
                     }
                     None => {
-                        if has_current_response
-                            && let Err(e) =
-                                send_long_message_raw(&http, channel_id, &prefixed, &shared).await
-                        {
-                            let ts = chrono::Local::now().format("%H:%M:%S");
-                            tracing::info!("  [{ts}] 👁 Failed to relay: {e}");
-                            relay_ok = false;
+                        if has_current_response {
+                            match send_long_message_raw(&http, channel_id, &prefixed, &shared).await
+                            {
+                                Ok(_) => {
+                                    direct_send_delivered = true;
+                                }
+                                Err(e) => {
+                                    let ts = chrono::Local::now().format("%H:%M:%S");
+                                    tracing::info!("  [{ts}] 👁 Failed to relay: {e}");
+                                    relay_ok = false;
+                                }
+                            }
                         }
                     }
                 }
             }
             if relay_ok {
-                // Record the offset range only after a successful relay so retries
-                // are not suppressed when Discord delivery fails transiently.
-                last_relayed_offset = Some(data_start_offset);
-                if let Some((pk, _)) = parse_provider_and_channel_from_tmux_name(&tmux_session_name)
-                {
-                    if let Some(mut inflight) =
-                        super::inflight::load_inflight_state(&pk, channel_id.get())
+                // #826 P1 #2: split the offset-commit gate.
+                //
+                //   * `last_relayed_offset` — canonical "Discord has this"
+                //     watermark. Advances ONLY on confirmed foreground
+                //     delivery (direct send or placeholder replace). Used by
+                //     the on-disk inflight mirror so a replacement watcher
+                //     respects genuinely-delivered history.
+                //
+                //   * `last_enqueued_offset` — "outbox row committed"
+                //     watermark. Advances when the notify-bot outbox enqueue
+                //     succeeded and we expect the worker to deliver.
+                //     Prevents re-enqueue of the same tmux range on the next
+                //     tick, without poisoning the canonical relayed offset if
+                //     the async worker ultimately fails to reach Discord.
+                //
+                // An empty (no-assistant-text) pass still needs to advance
+                // both watermarks so the watcher doesn't spin on the same
+                // range — the original code used a single offset and
+                // advanced it whenever `relay_ok` held. We preserve that
+                // invariant by lifting BOTH here.
+                if direct_send_delivered {
+                    last_relayed_offset = Some(data_start_offset);
+                    // Any genuine delivery also satisfies the enqueue-dedupe
+                    // floor, so lift that watermark too.
+                    last_enqueued_offset = Some(data_start_offset);
+                    if let Some((pk, _)) =
+                        parse_provider_and_channel_from_tmux_name(&tmux_session_name)
                     {
-                        inflight.last_watcher_relayed_offset = Some(data_start_offset);
-                        let _ = super::inflight::save_inflight_state(&inflight);
+                        if let Some(mut inflight) =
+                            super::inflight::load_inflight_state(&pk, channel_id.get())
+                        {
+                            inflight.last_watcher_relayed_offset = Some(data_start_offset);
+                            let _ = super::inflight::save_inflight_state(&inflight);
+                        }
                     }
+                } else if notify_enqueue_succeeded {
+                    last_enqueued_offset = Some(data_start_offset);
+                    // Intentionally do NOT update `last_watcher_relayed_offset`
+                    // in the inflight mirror — a replacement watcher should
+                    // see the response as not-yet-delivered so the outbox
+                    // worker's delivery path remains the single source of
+                    // truth for this range.
+                } else if !has_current_response {
+                    // Empty turn (no content, placeholder just deleted).
+                    // Advance both watermarks in lock-step so the dedupe
+                    // guard matches the old single-offset behaviour and we
+                    // don't re-enter this branch for the same range.
+                    last_relayed_offset = Some(data_start_offset);
+                    last_enqueued_offset = Some(data_start_offset);
                 }
                 clear_provider_overload_retry_state(channel_id);
             }
@@ -3208,12 +3341,12 @@ async fn sweep_orphan_session_files() {
 #[cfg(test)]
 mod tests {
     use super::{
-        DeadSessionCleanupPlan, WatcherToolState, build_monitor_completion_message,
-        dead_session_cleanup_plan, enqueue_background_trigger_response_to_notify_outbox,
-        load_restored_provider_session_id, notify_path_should_advance_offset,
-        process_watcher_lines, refresh_session_heartbeat_from_tmux_output,
-        should_route_terminal_response_via_notify_bot, watcher_ready_for_input_turn_completed,
-        watcher_should_yield_to_inflight_state,
+        DeadSessionCleanupPlan, OffsetAdvanceDecision, WatcherToolState,
+        build_monitor_completion_message, dead_session_cleanup_plan,
+        enqueue_background_trigger_response_to_notify_outbox, load_restored_provider_session_id,
+        notify_path_offset_advance_decision, process_watcher_lines,
+        refresh_session_heartbeat_from_tmux_output, should_route_terminal_response_via_notify_bot,
+        watcher_ready_for_input_turn_completed, watcher_should_yield_to_inflight_state,
     };
     use crate::services::discord::inflight::InflightTurnState;
     use crate::services::provider::{ProviderKind, ReadyForInputIdleTracker};
@@ -3768,29 +3901,108 @@ mod tests {
 
     /// #826 P1 #2 regression guard: when the notify-bot outbox enqueue fails
     /// AND no direct-send fallback reaches Discord, the watcher MUST leave
-    /// `last_relayed_offset` untouched so the same tmux range can be
-    /// re-relayed on the next scan. Advancing the offset here is the bug
-    /// that permanently loses a completion notification when notify-bot is
-    /// unavailable.
+    /// BOTH offset watermarks untouched so the same tmux range can be
+    /// re-relayed on the next scan. Advancing the canonical relayed offset
+    /// here is the bug that permanently loses a completion notification when
+    /// notify-bot is unavailable.
     #[test]
     fn notify_path_does_not_advance_offset_on_enqueue_failure_without_fallback() {
-        // Enqueue failed AND direct-send fallback also failed → no advance.
-        assert!(
-            !notify_path_should_advance_offset(
+        // Enqueue failed AND direct-send fallback also failed → leave both
+        // watermarks alone (the content is still in flight from the watcher's
+        // point of view; next tick must retry).
+        assert_eq!(
+            notify_path_offset_advance_decision(
                 /*has_current_response*/ true, /*enqueue_succeeded*/ false,
-                /*fallback_send_succeeded*/ false,
+                /*direct_send_delivered*/ false,
             ),
-            "enqueue-fail + fallback-fail with content must leave the offset untouched"
+            OffsetAdvanceDecision {
+                advance_relayed: false,
+                advance_enqueued: false
+            },
+            "enqueue-fail + fallback-fail with content must leave both watermarks untouched"
         );
 
-        // Enqueue succeeded → outbox row is durable → advance is safe.
-        assert!(notify_path_should_advance_offset(true, true, false));
+        // Enqueue SUCCEEDED but no foreground delivery confirmation yet —
+        // advance ONLY the enqueue watermark so the outbox row is deduped on
+        // the next tick, while the canonical relayed watermark waits for
+        // actual Discord delivery. THIS is the P1 #2 fix: the original code
+        // treated enqueue success as a delivery-equivalent and advanced the
+        // relayed offset.
+        assert_eq!(
+            notify_path_offset_advance_decision(
+                /*has_current_response*/ true, /*enqueue_succeeded*/ true,
+                /*direct_send_delivered*/ false,
+            ),
+            OffsetAdvanceDecision {
+                advance_relayed: false,
+                advance_enqueued: true
+            },
+            "enqueue success without delivery confirmation must NOT advance last_relayed_offset"
+        );
 
-        // Enqueue failed but fallback direct-send reached Discord → advance.
-        assert!(notify_path_should_advance_offset(true, false, true));
+        // Enqueue failed but fallback direct-send reached Discord → both
+        // watermarks lift together.
+        assert_eq!(
+            notify_path_offset_advance_decision(true, false, true),
+            OffsetAdvanceDecision {
+                advance_relayed: true,
+                advance_enqueued: true
+            }
+        );
+
+        // Both succeeded (uncommon but possible) → lock-step advance.
+        assert_eq!(
+            notify_path_offset_advance_decision(true, true, true),
+            OffsetAdvanceDecision {
+                advance_relayed: true,
+                advance_enqueued: true
+            }
+        );
 
         // No content to deliver → trivially safe to advance past the empty
-        // range regardless of enqueue/fallback outcome.
-        assert!(notify_path_should_advance_offset(false, false, false));
+        // range (preserves the original single-offset behaviour so the
+        // watcher doesn't spin on an empty turn).
+        assert_eq!(
+            notify_path_offset_advance_decision(false, false, false),
+            OffsetAdvanceDecision {
+                advance_relayed: true,
+                advance_enqueued: true
+            }
+        );
+    }
+
+    /// #826 P1 #2 regression guard: the dedupe-floor in the watcher's
+    /// duplicate-relay guard must be `max(last_relayed_offset,
+    /// last_enqueued_offset)`. After a notify-path enqueue advances ONLY the
+    /// enqueue watermark, a later tick that re-reads the same tmux range
+    /// must still be suppressed — otherwise we'd double-enqueue the same
+    /// response while the outbox worker was still delivering the first copy.
+    #[test]
+    fn enqueued_offset_gates_dedupe_even_without_relayed_advance() {
+        // Mirror the max()-dedupe logic from the watcher loop (kept inline
+        // there for hot-path performance — this test pins the invariant).
+        fn dedupe_floor(relayed: Option<u64>, enqueued: Option<u64>) -> Option<u64> {
+            match (relayed, enqueued) {
+                (Some(a), Some(b)) => Some(a.max(b)),
+                (Some(a), None) | (None, Some(a)) => Some(a),
+                (None, None) => None,
+            }
+        }
+
+        // Enqueue advanced but relayed did not — dedupe still protects
+        // against re-emit of the same start offset.
+        assert_eq!(
+            dedupe_floor(/*relayed*/ None, /*enqueued*/ Some(4096)),
+            Some(4096),
+            "enqueue-only advance must still guard the dedupe floor"
+        );
+
+        // Relayed leapfrogs a stale enqueue marker (e.g. a genuine
+        // foreground delivery arrived later) — floor follows the higher
+        // watermark.
+        assert_eq!(dedupe_floor(Some(8192), Some(4096)), Some(8192));
+
+        // Both absent — no floor, watcher may relay freely.
+        assert_eq!(dedupe_floor(None, None), None);
     }
 }

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -129,12 +129,22 @@ fn build_monitor_completion_message(response: &str) -> String {
 /// the notify-bot path (existing pre-#826 behaviour, silent drop). Codex
 /// coverage is tracked as a follow-up in #898.
 ///
+/// **`inflight_present` semantics (#897 round 2):** this parameter tracks
+/// the presence of a *foreground* inflight (a legitimate turn driven by a
+/// real Discord user message), NOT every file under `discord_inflight/`.
+/// A `rebind_origin` inflight synthesised by `POST /api/inflight/rebind`
+/// must be passed as `false` here — otherwise the recovered auto-trigger
+/// response is routed through the command bot, reintroducing the #826
+/// loop hazard. The caller (watcher loop) filters the inflight snapshot
+/// on `!state.rebind_origin` before invoking this predicate.
+///
 /// Returns `true` only when ALL of the following hold:
 /// 1. The turn produced an assistant response (no use rerouting emptiness).
 /// 2. A `system/task_notification` event was observed in the turn's JSONL
 ///    stream (canonical Claude Code marker for a background-trigger turn).
-/// 3. No inflight state exists for the channel (rules out concurrent
-///    foreground turns that happen to also include the marker).
+/// 3. No FOREGROUND inflight state exists for the channel (rules out
+///    concurrent real user turns that happen to also include the marker;
+///    a rebind-origin synthetic inflight does not count).
 #[inline]
 pub(super) fn should_route_terminal_response_via_notify_bot(
     has_assistant_response: bool,
@@ -234,10 +244,18 @@ pub(super) fn build_bg_trigger_session_key(
 /// command bot. The notify-bot is dropped at the intake gate, which is what
 /// keeps the auto-trigger path from feeding back into a new turn.
 ///
-/// **Dedupe** (#897 counter-model review P1): both `reason_code` and
-/// `session_key` are set so `message_outbox::enqueue`'s lifecycle-notification
-/// dedupe arms. `session_key` encodes `channel_id + data_start_offset +
-/// content hash`, so:
+/// **Storage backend** (#897 counter-model re-review round 2 Medium):
+/// matches `turn_bridge::enqueue_headless_delivery`'s priority —
+/// `pg_pool` first when available (primary production storage), falling
+/// back to the SQLite `Db` when only the legacy backend is wired in.
+/// Without this, a PG-backed runtime would reach the old SQLite-only
+/// code path with `Db::None` and silently fall back to direct-send,
+/// bypassing the new dedupe / failure-reconcile behaviour entirely.
+///
+/// **Dedupe** (#897 round 1 P1 #3): both `reason_code` and `session_key`
+/// are set so the lifecycle-notification dedupe in
+/// `message_outbox::enqueue` can arm. `session_key` encodes
+/// `channel_id + data_start_offset + content hash`, so:
 ///   * Distinct background completions in the same channel produce distinct
 ///     session_keys (different offsets or different content) → each lands
 ///     as its own outbox row.
@@ -248,10 +266,19 @@ pub(super) fn build_bg_trigger_session_key(
 ///   * The dedupe lookup filters out `status='failed'` rows, so a permanently
 ///     failed prior attempt is NOT allowed to suppress a fresh re-stage.
 ///
-/// Returns `false` only when the database handle is unavailable or the SQL
-/// insert fails — the caller falls back to a direct command-bot send in that
-/// case so the message is never silently lost.
-pub(super) fn enqueue_background_trigger_response_to_notify_outbox(
+/// The PG path currently does INSERT without a per-tick dedupe query (the
+/// SQLite-only `enqueue` helper lives in `message_outbox.rs`; porting it
+/// to a shared sqlx/rusqlite interface is tracked separately). Same-row
+/// dedupe on the PG side is still achievable via a `UNIQUE(reason_code,
+/// session_key, status) WHERE status != 'failed'` partial index, but
+/// that's a schema change outside this PR's scope. Follow-up tracked in
+/// #898-family.
+///
+/// Returns `false` only when BOTH backends are unavailable or their
+/// insert fails — the caller falls back to a direct command-bot send in
+/// that case so the message is never silently lost.
+pub(super) async fn enqueue_background_trigger_response_to_notify_outbox(
+    pg_pool: Option<&sqlx::PgPool>,
     db: Option<&crate::db::Db>,
     channel_id: ChannelId,
     content: &str,
@@ -261,11 +288,38 @@ pub(super) fn enqueue_background_trigger_response_to_notify_outbox(
     if trimmed.is_empty() {
         return true;
     }
+    let target = format!("channel:{}", channel_id.get());
+    let session_key = build_bg_trigger_session_key(channel_id.get(), data_start_offset, content);
+
+    // Prefer the Postgres-backed outbox when available — mirrors the
+    // headless-delivery ordering in `turn_bridge::enqueue_headless_delivery`.
+    if let Some(pool) = pg_pool {
+        match sqlx::query(
+            "INSERT INTO message_outbox
+             (target, content, bot, source, reason_code, session_key)
+             VALUES ($1, $2, 'notify', 'system', 'bg_trigger.auto_turn', $3)",
+        )
+        .bind(target.as_str())
+        .bind(content)
+        .bind(session_key.as_str())
+        .execute(pool)
+        .await
+        {
+            Ok(_) => return true,
+            Err(error) => {
+                tracing::warn!(
+                    "background-trigger postgres outbox insert failed for channel {}: {} — falling back to sqlite",
+                    channel_id,
+                    error
+                );
+                // Fall through to the SQLite fallback below.
+            }
+        }
+    }
+
     let Some(db) = db else {
         return false;
     };
-    let target = format!("channel:{}", channel_id.get());
-    let session_key = build_bg_trigger_session_key(channel_id.get(), data_start_offset, content);
     // Call `enqueue` directly (instead of `enqueue_with_db`) so we can
     // distinguish a dedupe-skip (`Ok(false)` — an EARLIER retry already wrote
     // the row, so this call is conceptually successful) from a genuine SQL
@@ -316,24 +370,90 @@ pub(super) fn enqueue_background_trigger_response_to_notify_outbox(
 /// roll `last_enqueued_offset` back and re-stage the same tmux range on
 /// the next watcher tick.
 ///
+/// **Storage backend** (#897 round 2 Medium): prefers `pg_pool` when
+/// available, falling back to the SQLite `Db` — mirrors the enqueue
+/// path's ordering so a PG-backed runtime actually reconciles its own
+/// failed rows instead of silently skipping when `Db::None`.
+///
 /// Why this is safe to re-stage:
 /// * `message_outbox::enqueue`'s lifecycle dedupe filters out rows where
 ///   `status='failed'`, so re-inserting at the same session_key produces a
 ///   fresh pending row rather than collapsing into the dead one.
-/// * We delete the failed rows here so they no longer pollute `SELECT *`
+/// * We delete the failed rows here so they don't pollute `SELECT *`
 ///   queries or eat unbounded table space.
 ///
 /// Without this reconciliation a single transient notify-bot or Discord
 /// failure permanently suppresses re-enqueue for the remainder of the
 /// watcher's lifetime — the exact P1 gap the counter-model reviewer
 /// flagged. See PR #897.
-fn reconcile_failed_bg_trigger_enqueues_for_channel(
+async fn reconcile_failed_bg_trigger_enqueues_for_channel(
+    pg_pool: Option<&sqlx::PgPool>,
     db: Option<&crate::db::Db>,
     channel_id: ChannelId,
 ) -> Option<u64> {
+    let target = format!("channel:{}", channel_id.get());
+
+    // Prefer the Postgres-backed outbox.
+    if let Some(pool) = pg_pool {
+        let rows_res = sqlx::query_as::<_, (i64, Option<String>)>(
+            "SELECT id, session_key FROM message_outbox
+             WHERE target = $1
+               AND bot = 'notify'
+               AND source = 'system'
+               AND reason_code = 'bg_trigger.auto_turn'
+               AND status = 'failed'",
+        )
+        .bind(target.as_str())
+        .fetch_all(pool)
+        .await;
+
+        match rows_res {
+            Ok(rows) if !rows.is_empty() => {
+                let mut min_offset: Option<u64> = None;
+                for (_, session_key) in &rows {
+                    if let Some(offset) = session_key
+                        .as_deref()
+                        .and_then(parse_bg_trigger_offset_from_session_key)
+                    {
+                        min_offset = Some(min_offset.map(|m| m.min(offset)).unwrap_or(offset));
+                    }
+                }
+                for (id, _) in &rows {
+                    if let Err(error) = sqlx::query("DELETE FROM message_outbox WHERE id = $1")
+                        .bind(id)
+                        .execute(pool)
+                        .await
+                    {
+                        tracing::warn!(
+                            "failed to delete reconciled bg_trigger row {}: {}",
+                            id,
+                            error
+                        );
+                    }
+                }
+                let ts = chrono::Local::now().format("%H:%M:%S");
+                tracing::warn!(
+                    "  [{ts}] ♻ reconciled {} failed bg_trigger outbox row(s) for channel {} (min offset: {:?}) [pg]",
+                    rows.len(),
+                    channel_id,
+                    min_offset,
+                );
+                return min_offset;
+            }
+            Ok(_) => return None,
+            Err(error) => {
+                tracing::warn!(
+                    "postgres bg_trigger reconcile query failed for channel {}: {} — falling back to sqlite",
+                    channel_id,
+                    error
+                );
+                // Fall through to SQLite fallback below.
+            }
+        }
+    }
+
     let db = db?;
     let conn = db.separate_conn().ok()?;
-    let target = format!("channel:{}", channel_id.get());
 
     let rows: Vec<(i64, String)> = {
         let mut stmt = conn
@@ -373,7 +493,7 @@ fn reconcile_failed_bg_trigger_enqueues_for_channel(
 
     let ts = chrono::Local::now().format("%H:%M:%S");
     tracing::warn!(
-        "  [{ts}] ♻ reconciled {} failed bg_trigger outbox row(s) for channel {} (min offset: {:?})",
+        "  [{ts}] ♻ reconciled {} failed bg_trigger outbox row(s) for channel {} (min offset: {:?}) [sqlite]",
         rows.len(),
         channel_id,
         min_offset,
@@ -877,8 +997,12 @@ pub(super) async fn tmux_output_watcher(
         // never blocks the rest of the loop — a SQL hiccup just returns
         // None.
         if rotation_tick % BG_FAILURE_RECONCILE_EVERY == 0 {
-            if let Some(min_failed_offset) =
-                reconcile_failed_bg_trigger_enqueues_for_channel(shared.db.as_ref(), channel_id)
+            if let Some(min_failed_offset) = reconcile_failed_bg_trigger_enqueues_for_channel(
+                shared.pg_pool.as_ref(),
+                shared.db.as_ref(),
+                channel_id,
+            )
+            .await
             {
                 last_enqueued_offset = rollback_enqueued_offset_for_reconciled_failures(
                     last_enqueued_offset,
@@ -1849,9 +1973,24 @@ pub(super) async fn tmux_output_watcher(
         // per `docs/background-task-pattern.md`; it is dropped at the intake
         // gate so the agent cannot self-trigger another turn off this
         // delivery.
-        let route_via_notify_bot = has_assistant_response
-            && task_notification_seen
-            && super::inflight::load_inflight_state(&watcher_provider, channel_id.get()).is_none();
+        //
+        // #897 counter-model re-review (round 2): a `rebind_origin`
+        // inflight is a SYNTHETIC placeholder written by
+        // `POST /api/inflight/rebind` to adopt a live tmux session that had
+        // no real user-authored turn driving it. It must be treated as
+        // absent for this predicate — otherwise the recovered
+        // auto-trigger's response drops back to the command-bot relay,
+        // reintroducing the loop hazard the notify routing was fixing.
+        let inflight_snapshot =
+            super::inflight::load_inflight_state(&watcher_provider, channel_id.get());
+        let foreground_inflight_present = inflight_snapshot
+            .as_ref()
+            .is_some_and(|state| !state.rebind_origin);
+        let route_via_notify_bot = should_route_terminal_response_via_notify_bot(
+            has_assistant_response,
+            task_notification_seen,
+            foreground_inflight_present,
+        );
 
         // Send the terminal response to Discord
         // #225 P1-2: Track relay success across branches
@@ -1892,11 +2031,13 @@ pub(super) async fn tmux_output_watcher(
                 }
                 let enqueued = if has_current_response {
                     enqueue_background_trigger_response_to_notify_outbox(
+                        shared.pg_pool.as_ref(),
                         shared.db.as_ref(),
                         channel_id,
                         &prefixed,
                         data_start_offset,
                     )
+                    .await
                 } else {
                     // No assistant text to deliver — nothing to commit.
                     true
@@ -3934,18 +4075,20 @@ mod tests {
     /// terminal response on the notify-bot outbox so the user sees it. Going
     /// through the command bot would risk other agents in the channel treating
     /// the response as an actionable directive (infinite-loop hazard).
-    #[test]
-    fn background_trigger_response_enqueues_notify_outbox_row() {
+    #[tokio::test]
+    async fn background_trigger_response_enqueues_notify_outbox_row() {
         let db = crate::db::test_db();
         let channel = ChannelId::new(987_654_321);
         let content = "**✅ 모니터 완료**\n백그라운드 모니터가 작업 완료를 감지해 결과를 이어서 전달합니다.\n\nPR #825 리뷰 4건 fix 완료";
 
         let enqueued = enqueue_background_trigger_response_to_notify_outbox(
+            /*pg_pool*/ None,
             Some(&db),
             channel,
             content,
             /*data_start_offset*/ 4096,
-        );
+        )
+        .await;
         assert!(
             enqueued,
             "background-trigger enqueue must succeed when db is present"
@@ -3996,22 +4139,30 @@ mod tests {
     /// distinct tmux range, so the `session_key` (which includes
     /// `data_start_offset` and a content hash) must differ between them and
     /// the dedupe must NOT collapse legitimately-separate events into one.
-    #[test]
-    fn background_trigger_response_does_not_dedupe_distinct_events() {
+    #[tokio::test]
+    async fn background_trigger_response_does_not_dedupe_distinct_events() {
         let db = crate::db::test_db();
         let channel = ChannelId::new(555_111_222);
-        assert!(enqueue_background_trigger_response_to_notify_outbox(
-            Some(&db),
-            channel,
-            "first completion",
-            /*data_start_offset*/ 1_000,
-        ));
-        assert!(enqueue_background_trigger_response_to_notify_outbox(
-            Some(&db),
-            channel,
-            "second completion",
-            /*data_start_offset*/ 2_000,
-        ));
+        assert!(
+            enqueue_background_trigger_response_to_notify_outbox(
+                None,
+                Some(&db),
+                channel,
+                "first completion",
+                /*data_start_offset*/ 1_000,
+            )
+            .await
+        );
+        assert!(
+            enqueue_background_trigger_response_to_notify_outbox(
+                None,
+                Some(&db),
+                channel,
+                "second completion",
+                /*data_start_offset*/ 2_000,
+            )
+            .await
+        );
 
         let count: i64 = db
             .lock()
@@ -4032,22 +4183,30 @@ mod tests {
     /// identical content) within the dedupe TTL must collapse into a single
     /// outbox row, preventing the watcher from re-enqueuing while the outbox
     /// worker is still driving the same message to Discord.
-    #[test]
-    fn background_trigger_response_dedupes_identical_retry() {
+    #[tokio::test]
+    async fn background_trigger_response_dedupes_identical_retry() {
         let db = crate::db::test_db();
         let channel = ChannelId::new(666_222_333);
-        assert!(enqueue_background_trigger_response_to_notify_outbox(
-            Some(&db),
-            channel,
-            "same content",
-            /*data_start_offset*/ 8_192,
-        ));
-        assert!(enqueue_background_trigger_response_to_notify_outbox(
-            Some(&db),
-            channel,
-            "same content",
-            /*data_start_offset*/ 8_192,
-        ));
+        assert!(
+            enqueue_background_trigger_response_to_notify_outbox(
+                None,
+                Some(&db),
+                channel,
+                "same content",
+                /*data_start_offset*/ 8_192,
+            )
+            .await
+        );
+        assert!(
+            enqueue_background_trigger_response_to_notify_outbox(
+                None,
+                Some(&db),
+                channel,
+                "same content",
+                /*data_start_offset*/ 8_192,
+            )
+            .await
+        );
 
         let count: i64 = db
             .lock()
@@ -4066,16 +4225,20 @@ mod tests {
 
     /// Empty/whitespace responses must short-circuit without writing a row —
     /// otherwise the user sees a noise notification with no content.
-    #[test]
-    fn background_trigger_response_skips_empty_payload() {
+    #[tokio::test]
+    async fn background_trigger_response_skips_empty_payload() {
         let db = crate::db::test_db();
         let channel = ChannelId::new(111_222_333);
-        assert!(enqueue_background_trigger_response_to_notify_outbox(
-            Some(&db),
-            channel,
-            "   \n",
-            0,
-        ));
+        assert!(
+            enqueue_background_trigger_response_to_notify_outbox(
+                None,
+                Some(&db),
+                channel,
+                "   \n",
+                0,
+            )
+            .await
+        );
         let count: i64 = db
             .lock()
             .unwrap()
@@ -4087,15 +4250,17 @@ mod tests {
     /// When the database is unavailable, the helper reports failure so the
     /// caller can fall back to a direct Discord send rather than silently
     /// dropping the response (#826 root cause was a silent drop).
-    #[test]
-    fn background_trigger_response_reports_failure_when_db_missing() {
+    #[tokio::test]
+    async fn background_trigger_response_reports_failure_when_db_missing() {
         let channel = ChannelId::new(999_888_777);
         let ok = enqueue_background_trigger_response_to_notify_outbox(
-            None,
+            /*pg_pool*/ None,
+            /*db*/ None,
             channel,
             "would-have-been-delivered",
             0,
-        );
+        )
+        .await;
         assert!(!ok, "missing db must surface as failure to enable fallback");
     }
 
@@ -4179,8 +4344,8 @@ mod tests {
     /// (b) delete the row so it doesn't accumulate. Combined with the
     /// dedupe lookup's `status != 'failed'` filter, this lets a subsequent
     /// enqueue at the same session_key land as a fresh row.
-    #[test]
-    fn reconcile_failed_bg_trigger_rows_returns_min_offset_and_deletes_them() {
+    #[tokio::test]
+    async fn reconcile_failed_bg_trigger_rows_returns_min_offset_and_deletes_them() {
         let db = crate::db::test_db();
         let channel = ChannelId::new(777_444_111);
 
@@ -4204,7 +4369,8 @@ mod tests {
             .unwrap();
         }
 
-        let min = super::reconcile_failed_bg_trigger_enqueues_for_channel(Some(&db), channel);
+        let min =
+            super::reconcile_failed_bg_trigger_enqueues_for_channel(None, Some(&db), channel).await;
         assert_eq!(
             min,
             Some(1_000),
@@ -4230,11 +4396,12 @@ mod tests {
 
     /// #897 P1 #2: when there are no failed rows the reconciler returns
     /// `None` (no rollback needed) without side effects.
-    #[test]
-    fn reconcile_returns_none_when_no_failed_rows() {
+    #[tokio::test]
+    async fn reconcile_returns_none_when_no_failed_rows() {
         let db = crate::db::test_db();
         let channel = ChannelId::new(888_555_222);
-        let min = super::reconcile_failed_bg_trigger_enqueues_for_channel(Some(&db), channel);
+        let min =
+            super::reconcile_failed_bg_trigger_enqueues_for_channel(None, Some(&db), channel).await;
         assert_eq!(min, None);
     }
 

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -120,6 +120,15 @@ fn build_monitor_completion_message(response: &str) -> String {
 /// the notify-bot outbox may not be available in every deployment, which
 /// would silently drop the reply.
 ///
+/// **Provider coverage (important):** the `system/task_notification` JSONL
+/// event is emitted by `session_backend.rs::parse_stream_message` when the
+/// Claude Code harness auto-fires a turn. The codex provider does NOT emit
+/// this event — its stream parser (`codex_tmux_wrapper.rs`) only produces
+/// `system/init` and `item.*` records. As a result this predicate is
+/// **Claude-only** and codex background-trigger completions currently bypass
+/// the notify-bot path (existing pre-#826 behaviour, silent drop). Codex
+/// coverage is tracked as a follow-up in #898.
+///
 /// Returns `true` only when ALL of the following hold:
 /// 1. The turn produced an assistant response (no use rerouting emptiness).
 /// 2. A `system/task_notification` event was observed in the turn's JSONL
@@ -194,10 +203,50 @@ pub(super) fn notify_path_offset_advance_decision(
     OffsetAdvanceDecision::default()
 }
 
+/// #826: Build the dedupe session_key for a background-trigger outbox row.
+/// Includes the tmux output offset and a short content hash so distinct
+/// completions land as separate rows (different offsets ⇒ different keys)
+/// while a retry of the exact same range within the dedupe window (same
+/// offset + identical content) collapses into one. The resulting key is
+/// compact (≤~64 chars) and safe to use as a dedupe column.
+///
+/// Pure function so the #897 counter-model review P1 (dedupe reason_code
+/// AND session_key must BOTH be present for the lifecycle dedupe to arm)
+/// has a testable contract.
+#[inline]
+pub(super) fn build_bg_trigger_session_key(
+    channel_id: u64,
+    data_start_offset: u64,
+    content: &str,
+) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    content.hash(&mut hasher);
+    format!(
+        "bg_trigger:ch:{channel_id}:off:{data_start_offset}:h:{:016x}",
+        hasher.finish()
+    )
+}
+
 /// #826: Enqueue a background-trigger turn's terminal response on the
 /// notify-bot outbox so it reaches the channel without going through the
 /// command bot. The notify-bot is dropped at the intake gate, which is what
 /// keeps the auto-trigger path from feeding back into a new turn.
+///
+/// **Dedupe** (#897 counter-model review P1): both `reason_code` and
+/// `session_key` are set so `message_outbox::enqueue`'s lifecycle-notification
+/// dedupe arms. `session_key` encodes `channel_id + data_start_offset +
+/// content hash`, so:
+///   * Distinct background completions in the same channel produce distinct
+///     session_keys (different offsets or different content) → each lands
+///     as its own outbox row.
+///   * A duplicate retry of the exact same tmux range within the dedupe TTL
+///     (same offset, identical content) collapses into the single existing
+///     row, which guards against the watcher re-enqueuing while the outbox
+///     worker is still delivering.
+///   * The dedupe lookup filters out `status='failed'` rows, so a permanently
+///     failed prior attempt is NOT allowed to suppress a fresh re-stage.
 ///
 /// Returns `false` only when the database handle is unavailable or the SQL
 /// insert fails — the caller falls back to a direct command-bot send in that
@@ -206,6 +255,7 @@ pub(super) fn enqueue_background_trigger_response_to_notify_outbox(
     db: Option<&crate::db::Db>,
     channel_id: ChannelId,
     content: &str,
+    data_start_offset: u64,
 ) -> bool {
     let trimmed = content.trim();
     if trimmed.is_empty() {
@@ -215,21 +265,160 @@ pub(super) fn enqueue_background_trigger_response_to_notify_outbox(
         return false;
     };
     let target = format!("channel:{}", channel_id.get());
-    // Intentionally omit reason_code so the lifecycle dedupe in
-    // `message_outbox::enqueue` does not suppress consecutive auto-trigger
-    // responses on the same channel — each background-task completion is its
-    // own event the user must see.
-    crate::services::message_outbox::enqueue_with_db(
-        db,
-        crate::services::message_outbox::OutboxMessage {
-            target: target.as_str(),
-            content,
-            bot: "notify",
-            source: "system",
-            reason_code: None,
-            session_key: None,
-        },
-    )
+    let session_key = build_bg_trigger_session_key(channel_id.get(), data_start_offset, content);
+    // Call `enqueue` directly (instead of `enqueue_with_db`) so we can
+    // distinguish a dedupe-skip (`Ok(false)` — an EARLIER retry already wrote
+    // the row, so this call is conceptually successful) from a genuine SQL
+    // error (`Err(_)` — caller must fall back to direct send). The legacy
+    // `enqueue_with_db` collapses both into `false`, which would spuriously
+    // trigger the direct-send fallback on a dedupe and write the same
+    // message twice.
+    match db.separate_conn() {
+        Ok(conn) => {
+            match crate::services::message_outbox::enqueue(
+                &conn,
+                crate::services::message_outbox::OutboxMessage {
+                    target: target.as_str(),
+                    content,
+                    bot: "notify",
+                    source: "system",
+                    reason_code: Some("bg_trigger.auto_turn"),
+                    session_key: Some(session_key.as_str()),
+                },
+            ) {
+                Ok(_inserted_or_deduped) => true,
+                Err(error) => {
+                    tracing::warn!(
+                        "background-trigger outbox enqueue failed for channel {}: {}",
+                        channel_id,
+                        error
+                    );
+                    false
+                }
+            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                "background-trigger outbox connection failed for channel {}: {}",
+                channel_id,
+                error
+            );
+            false
+        }
+    }
+}
+
+/// #897 counter-model review P1 #2: Find permanently-failed notify-bot
+/// outbox rows that originated from this watcher's background-trigger
+/// enqueues, extract the tmux offsets that caused them, and delete the
+/// rows so they don't accumulate. Returns the MINIMUM observed
+/// `data_start_offset` encoded in `session_key`, which the caller uses to
+/// roll `last_enqueued_offset` back and re-stage the same tmux range on
+/// the next watcher tick.
+///
+/// Why this is safe to re-stage:
+/// * `message_outbox::enqueue`'s lifecycle dedupe filters out rows where
+///   `status='failed'`, so re-inserting at the same session_key produces a
+///   fresh pending row rather than collapsing into the dead one.
+/// * We delete the failed rows here so they no longer pollute `SELECT *`
+///   queries or eat unbounded table space.
+///
+/// Without this reconciliation a single transient notify-bot or Discord
+/// failure permanently suppresses re-enqueue for the remainder of the
+/// watcher's lifetime — the exact P1 gap the counter-model reviewer
+/// flagged. See PR #897.
+fn reconcile_failed_bg_trigger_enqueues_for_channel(
+    db: Option<&crate::db::Db>,
+    channel_id: ChannelId,
+) -> Option<u64> {
+    let db = db?;
+    let conn = db.separate_conn().ok()?;
+    let target = format!("channel:{}", channel_id.get());
+
+    let rows: Vec<(i64, String)> = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, COALESCE(session_key, '') FROM message_outbox
+                 WHERE target = ?1
+                   AND bot = 'notify'
+                   AND source = 'system'
+                   AND reason_code = 'bg_trigger.auto_turn'
+                   AND status = 'failed'",
+            )
+            .ok()?;
+        stmt.query_map(libsql_rusqlite::params![target.as_str()], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+        })
+        .ok()?
+        .filter_map(|r| r.ok())
+        .collect()
+    };
+    if rows.is_empty() {
+        return None;
+    }
+
+    let mut min_offset: Option<u64> = None;
+    for (_, session_key) in &rows {
+        if let Some(offset) = parse_bg_trigger_offset_from_session_key(session_key) {
+            min_offset = Some(min_offset.map(|m| m.min(offset)).unwrap_or(offset));
+        }
+    }
+
+    for (id, _) in &rows {
+        let _ = conn.execute(
+            "DELETE FROM message_outbox WHERE id = ?1",
+            libsql_rusqlite::params![id],
+        );
+    }
+
+    let ts = chrono::Local::now().format("%H:%M:%S");
+    tracing::warn!(
+        "  [{ts}] ♻ reconciled {} failed bg_trigger outbox row(s) for channel {} (min offset: {:?})",
+        rows.len(),
+        channel_id,
+        min_offset,
+    );
+
+    min_offset
+}
+
+/// Pure helper: extract the `data_start_offset` encoded in a
+/// background-trigger `session_key`. Format produced by
+/// `build_bg_trigger_session_key` is `bg_trigger:ch:{id}:off:{offset}:h:{hash16}`.
+/// Returns `None` for malformed keys so the caller can safely ignore
+/// outbox rows whose session_key no longer conforms to the expected shape
+/// (e.g. future schema changes or hand-written operator rows).
+#[inline]
+pub(super) fn parse_bg_trigger_offset_from_session_key(session_key: &str) -> Option<u64> {
+    let after_off = session_key.split(":off:").nth(1)?;
+    let off_str = after_off.split(':').next()?;
+    off_str.parse::<u64>().ok()
+}
+
+/// Pure helper for the watermark-rollback policy (#897 P1 #2). Given the
+/// watcher's current `last_enqueued_offset` and the minimum offset from a
+/// reconciled outbox failure, return the new watermark that allows
+/// re-emission of the failed range on the next watcher tick while
+/// preserving progress past other, unaffected ranges.
+///
+/// Rules:
+/// 1. `None → None`: nothing staged, nothing to roll back.
+/// 2. Current ≤ reconciled: the watermark is already at or below the
+///    failed offset, so the next visit will naturally re-emit that range.
+/// 3. Current > reconciled: pull back to `reconciled.saturating_sub(1)` so
+///    the dedupe floor `max(relayed, enqueued)` permits
+///    `data_start_offset < prev_offset` evaluation at the exact failed
+///    offset. Using `saturating_sub` guards against reconciled=0.
+#[inline]
+pub(super) fn rollback_enqueued_offset_for_reconciled_failures(
+    last_enqueued_offset: Option<u64>,
+    reconciled_min_offset: u64,
+) -> Option<u64> {
+    match last_enqueued_offset {
+        None => None,
+        Some(current) if current <= reconciled_min_offset => Some(current),
+        Some(_) => Some(reconciled_min_offset.saturating_sub(1)),
+    }
 }
 
 fn watcher_should_yield_to_active_bridge_turn(
@@ -633,6 +822,12 @@ pub(super) async fn tmux_output_watcher(
     // spin. See issue #892.
     let mut rotation_tick: u32 = 0;
     const ROTATION_CHECK_EVERY: u32 = 60; // ~30s at 500ms base cadence
+    // #897 counter-model review P1 #2: cadence for the failed-bg_trigger
+    // reconciliation poll. Short enough that a transient outbox failure is
+    // re-staged within ~10s, long enough that the watcher doesn't hammer
+    // SQLite every spin. Independent of ROTATION_CHECK_EVERY so each
+    // subsystem can tune its cadence without affecting the other.
+    const BG_FAILURE_RECONCILE_EVERY: u32 = 20; // ~10s at 500ms base cadence
 
     loop {
         // Always consume resume_offset first — the turn bridge may have set it
@@ -673,6 +868,25 @@ pub(super) async fn tmux_output_watcher(
         // the watcher loop keeps the wrapper child process simple while
         // still enforcing a 20 MB soft cap (see issue #892).
         rotation_tick = rotation_tick.wrapping_add(1);
+
+        // #897 P1 #2: reconcile any permanently-failed bg_trigger outbox
+        // rows for THIS channel and roll `last_enqueued_offset` back so
+        // the next tick re-stages the failed range instead of silently
+        // letting the watermark pin the dedupe floor past unresolved
+        // output. Runs on its own cadence (independent of rotation) and
+        // never blocks the rest of the loop — a SQL hiccup just returns
+        // None.
+        if rotation_tick % BG_FAILURE_RECONCILE_EVERY == 0 {
+            if let Some(min_failed_offset) =
+                reconcile_failed_bg_trigger_enqueues_for_channel(shared.db.as_ref(), channel_id)
+            {
+                last_enqueued_offset = rollback_enqueued_offset_for_reconciled_failures(
+                    last_enqueued_offset,
+                    min_failed_offset,
+                );
+            }
+        }
+
         if rotation_tick % ROTATION_CHECK_EVERY == 0 {
             let path = output_path.clone();
             let session = tmux_session_name.clone();
@@ -1681,6 +1895,7 @@ pub(super) async fn tmux_output_watcher(
                         shared.db.as_ref(),
                         channel_id,
                         &prefixed,
+                        data_start_offset,
                     )
                 } else {
                     // No assistant text to deliver — nothing to commit.
@@ -3342,11 +3557,13 @@ async fn sweep_orphan_session_files() {
 mod tests {
     use super::{
         DeadSessionCleanupPlan, OffsetAdvanceDecision, WatcherToolState,
-        build_monitor_completion_message, dead_session_cleanup_plan,
+        build_bg_trigger_session_key, build_monitor_completion_message, dead_session_cleanup_plan,
         enqueue_background_trigger_response_to_notify_outbox, load_restored_provider_session_id,
-        notify_path_offset_advance_decision, process_watcher_lines,
-        refresh_session_heartbeat_from_tmux_output, should_route_terminal_response_via_notify_bot,
-        watcher_ready_for_input_turn_completed, watcher_should_yield_to_inflight_state,
+        notify_path_offset_advance_decision, parse_bg_trigger_offset_from_session_key,
+        process_watcher_lines, refresh_session_heartbeat_from_tmux_output,
+        rollback_enqueued_offset_for_reconciled_failures,
+        should_route_terminal_response_via_notify_bot, watcher_ready_for_input_turn_completed,
+        watcher_should_yield_to_inflight_state,
     };
     use crate::services::discord::inflight::InflightTurnState;
     use crate::services::provider::{ProviderKind, ReadyForInputIdleTracker};
@@ -3723,19 +3940,40 @@ mod tests {
         let channel = ChannelId::new(987_654_321);
         let content = "**✅ 모니터 완료**\n백그라운드 모니터가 작업 완료를 감지해 결과를 이어서 전달합니다.\n\nPR #825 리뷰 4건 fix 완료";
 
-        let enqueued =
-            enqueue_background_trigger_response_to_notify_outbox(Some(&db), channel, content);
+        let enqueued = enqueue_background_trigger_response_to_notify_outbox(
+            Some(&db),
+            channel,
+            content,
+            /*data_start_offset*/ 4096,
+        );
         assert!(
             enqueued,
             "background-trigger enqueue must succeed when db is present"
         );
 
         let conn = db.lock().unwrap();
-        let (target, stored_content, bot, source): (String, String, String, String) = conn
+        let (target, stored_content, bot, source, reason_code, session_key): (
+            String,
+            String,
+            String,
+            String,
+            Option<String>,
+            Option<String>,
+        ) = conn
             .query_row(
-                "SELECT target, content, bot, source FROM message_outbox ORDER BY id DESC LIMIT 1",
+                "SELECT target, content, bot, source, reason_code, session_key
+                 FROM message_outbox ORDER BY id DESC LIMIT 1",
                 [],
-                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                    ))
+                },
             )
             .expect("expected one outbox row");
 
@@ -3743,24 +3981,36 @@ mod tests {
         assert_eq!(stored_content, content);
         assert_eq!(bot, "notify", "must use notify bot to avoid loop hazard");
         assert_eq!(source, "system");
+        // #897 counter-model review P1 #3: both reason_code and session_key
+        // must be populated so the lifecycle dedupe in message_outbox can arm.
+        assert_eq!(reason_code.as_deref(), Some("bg_trigger.auto_turn"));
+        let session_key = session_key.expect("session_key must be populated for dedupe");
+        assert!(
+            session_key.starts_with(&format!("bg_trigger:ch:{}:off:4096:h:", channel.get())),
+            "session_key must encode channel + offset + content hash; got {session_key}"
+        );
     }
 
-    /// Consecutive background-task completions in the same channel must each
-    /// produce their own outbox row — using a `reason_code` here would trip
-    /// the lifecycle-notification dedupe and silently drop later events.
+    /// #897 P1 #3: consecutive background-task completions in the same
+    /// channel must each produce their own outbox row — each event is a
+    /// distinct tmux range, so the `session_key` (which includes
+    /// `data_start_offset` and a content hash) must differ between them and
+    /// the dedupe must NOT collapse legitimately-separate events into one.
     #[test]
-    fn background_trigger_response_does_not_dedupe_consecutive_events() {
+    fn background_trigger_response_does_not_dedupe_distinct_events() {
         let db = crate::db::test_db();
         let channel = ChannelId::new(555_111_222);
         assert!(enqueue_background_trigger_response_to_notify_outbox(
             Some(&db),
             channel,
-            "first completion"
+            "first completion",
+            /*data_start_offset*/ 1_000,
         ));
         assert!(enqueue_background_trigger_response_to_notify_outbox(
             Some(&db),
             channel,
-            "second completion"
+            "second completion",
+            /*data_start_offset*/ 2_000,
         ));
 
         let count: i64 = db
@@ -3774,7 +4024,43 @@ mod tests {
             .unwrap();
         assert_eq!(
             count, 2,
-            "consecutive background-task events must not dedupe"
+            "consecutive events with distinct offsets/content must land as separate rows"
+        );
+    }
+
+    /// #897 P1 #3: a genuine retry of the SAME tmux range (same offset +
+    /// identical content) within the dedupe TTL must collapse into a single
+    /// outbox row, preventing the watcher from re-enqueuing while the outbox
+    /// worker is still driving the same message to Discord.
+    #[test]
+    fn background_trigger_response_dedupes_identical_retry() {
+        let db = crate::db::test_db();
+        let channel = ChannelId::new(666_222_333);
+        assert!(enqueue_background_trigger_response_to_notify_outbox(
+            Some(&db),
+            channel,
+            "same content",
+            /*data_start_offset*/ 8_192,
+        ));
+        assert!(enqueue_background_trigger_response_to_notify_outbox(
+            Some(&db),
+            channel,
+            "same content",
+            /*data_start_offset*/ 8_192,
+        ));
+
+        let count: i64 = db
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM message_outbox WHERE target = ?1 AND bot = 'notify'",
+                [format!("channel:{}", channel.get()).as_str()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            count, 1,
+            "identical retry at the same offset must dedupe to a single row"
         );
     }
 
@@ -3787,7 +4073,8 @@ mod tests {
         assert!(enqueue_background_trigger_response_to_notify_outbox(
             Some(&db),
             channel,
-            "   \n"
+            "   \n",
+            0,
         ));
         let count: i64 = db
             .lock()
@@ -3807,8 +4094,173 @@ mod tests {
             None,
             channel,
             "would-have-been-delivered",
+            0,
         );
         assert!(!ok, "missing db must surface as failure to enable fallback");
+    }
+
+    /// #897 P1 #2 guard: `parse_bg_trigger_offset_from_session_key` must
+    /// round-trip the exact offset that `build_bg_trigger_session_key`
+    /// embedded, across a spread of offsets. Without a stable inverse, the
+    /// reconciliation poll cannot identify which tmux range to re-stage
+    /// after an outbox failure.
+    #[test]
+    fn parse_bg_trigger_offset_roundtrips_build_key() {
+        for offset in [0u64, 1, 4096, 1 << 32, 1 << 48, u64::MAX] {
+            let key = build_bg_trigger_session_key(42, offset, "payload");
+            let parsed = parse_bg_trigger_offset_from_session_key(&key);
+            assert_eq!(
+                parsed,
+                Some(offset),
+                "offset {} must round-trip through session_key",
+                offset
+            );
+        }
+    }
+
+    /// #897 P1 #2: malformed / foreign session_keys must not panic or
+    /// produce spurious offsets — the reconcile poll has to be robust to
+    /// hand-written rows or schema drift.
+    #[test]
+    fn parse_bg_trigger_offset_returns_none_for_non_matching_keys() {
+        assert_eq!(parse_bg_trigger_offset_from_session_key(""), None);
+        assert_eq!(
+            parse_bg_trigger_offset_from_session_key("random:session:key"),
+            None
+        );
+        assert_eq!(
+            parse_bg_trigger_offset_from_session_key("bg_trigger:ch:1:off:not-a-number:h:abcd"),
+            None
+        );
+        assert_eq!(
+            parse_bg_trigger_offset_from_session_key("bg_trigger:ch:1:off:"),
+            None
+        );
+    }
+
+    /// #897 P1 #2 policy guard: rollback must pull the watermark back
+    /// below the failed offset when it has moved past, but must NOT
+    /// accidentally advance the watermark when it is already behind the
+    /// failure. And it must never panic on a failed offset of 0.
+    #[test]
+    fn rollback_enqueued_offset_pulls_back_only_when_ahead_of_failure() {
+        // Nothing staged → nothing to roll back.
+        assert_eq!(
+            rollback_enqueued_offset_for_reconciled_failures(None, 12_000),
+            None,
+        );
+
+        // Watermark already at or below the failed offset → unchanged.
+        assert_eq!(
+            rollback_enqueued_offset_for_reconciled_failures(Some(8_000), 12_000),
+            Some(8_000),
+        );
+        assert_eq!(
+            rollback_enqueued_offset_for_reconciled_failures(Some(12_000), 12_000),
+            Some(12_000),
+        );
+
+        // Watermark ahead of the failure → pulled back to just before it.
+        assert_eq!(
+            rollback_enqueued_offset_for_reconciled_failures(Some(20_000), 12_000),
+            Some(11_999),
+        );
+
+        // Reconciled offset 0 must saturate at 0, not wrap.
+        assert_eq!(
+            rollback_enqueued_offset_for_reconciled_failures(Some(5), 0),
+            Some(0),
+        );
+    }
+
+    /// #897 P1 #2 end-to-end: after a bg_trigger row transitions to
+    /// `status='failed'`, `reconcile_failed_bg_trigger_enqueues_for_channel`
+    /// must (a) report the minimum offset so the watcher can roll back and
+    /// (b) delete the row so it doesn't accumulate. Combined with the
+    /// dedupe lookup's `status != 'failed'` filter, this lets a subsequent
+    /// enqueue at the same session_key land as a fresh row.
+    #[test]
+    fn reconcile_failed_bg_trigger_rows_returns_min_offset_and_deletes_them() {
+        let db = crate::db::test_db();
+        let channel = ChannelId::new(777_444_111);
+
+        // Seed three bg_trigger rows at different offsets, mark two as
+        // failed and leave one pending. Only the failed pair should be
+        // reconciled; the pending row stays.
+        for (offset, status) in [
+            (1_000u64, "failed"),
+            (5_000u64, "failed"),
+            (9_000u64, "pending"),
+        ] {
+            let session_key = build_bg_trigger_session_key(channel.get(), offset, "c");
+            let target = format!("channel:{}", channel.get());
+            let conn = db.lock().unwrap();
+            conn.execute(
+                "INSERT INTO message_outbox
+                 (target, content, bot, source, reason_code, session_key, status)
+                 VALUES (?1, 'c', 'notify', 'system', 'bg_trigger.auto_turn', ?2, ?3)",
+                libsql_rusqlite::params![target.as_str(), session_key.as_str(), status],
+            )
+            .unwrap();
+        }
+
+        let min = super::reconcile_failed_bg_trigger_enqueues_for_channel(Some(&db), channel);
+        assert_eq!(
+            min,
+            Some(1_000),
+            "smallest failed offset must be returned so watermark rollback lands there"
+        );
+
+        // Failed rows deleted; pending row still present.
+        let (failed_left, pending_left): (i64, i64) = db
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT
+                    SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END),
+                    SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END)
+                 FROM message_outbox WHERE target = ?1",
+                [format!("channel:{}", channel.get()).as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(failed_left, 0, "reconciled rows must be deleted");
+        assert_eq!(pending_left, 1, "pending rows must be preserved");
+    }
+
+    /// #897 P1 #2: when there are no failed rows the reconciler returns
+    /// `None` (no rollback needed) without side effects.
+    #[test]
+    fn reconcile_returns_none_when_no_failed_rows() {
+        let db = crate::db::test_db();
+        let channel = ChannelId::new(888_555_222);
+        let min = super::reconcile_failed_bg_trigger_enqueues_for_channel(Some(&db), channel);
+        assert_eq!(min, None);
+    }
+
+    /// #897 P1 #3 guard: `build_bg_trigger_session_key` must produce the
+    /// same key for identical inputs (so dedupe can arm) and differing keys
+    /// when EITHER the offset OR the content changes.
+    #[test]
+    fn build_bg_trigger_session_key_is_stable_and_offset_sensitive() {
+        let a = build_bg_trigger_session_key(100, 4096, "payload");
+        let b = build_bg_trigger_session_key(100, 4096, "payload");
+        assert_eq!(a, b, "identical inputs must yield identical keys");
+
+        let different_offset = build_bg_trigger_session_key(100, 8192, "payload");
+        assert_ne!(a, different_offset, "different offset must yield a new key");
+
+        let different_content = build_bg_trigger_session_key(100, 4096, "payload2");
+        assert_ne!(
+            a, different_content,
+            "different content must yield a new key"
+        );
+
+        let different_channel = build_bg_trigger_session_key(200, 4096, "payload");
+        assert_ne!(
+            a, different_channel,
+            "different channel must yield a new key"
+        );
     }
 
     /// #826 P1 #1 regression guard: a turn whose inflight file is absent but

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -1938,29 +1938,44 @@ pub(super) async fn tmux_output_watcher(
             // Auto-retry: persist Discord history for LLM injection, then queue the
             // original user message as an internal follow-up instead of self-routing
             // through /api/send announce.
-            if let Some(state) =
-                super::inflight::load_inflight_state(&watcher_provider, channel_id.get())
-            {
-                super::turn_bridge::auto_retry_with_history(
-                    &http,
-                    &shared,
-                    &watcher_provider,
-                    channel_id,
-                    serenity::MessageId::new(state.user_msg_id),
-                    &state.user_text,
-                )
-                .await;
-                let ts = chrono::Local::now().format("%H:%M:%S");
-                tracing::warn!(
-                    "  [{ts}] ↻ Watcher auto-retry queued for channel {}",
-                    channel_id
-                );
-            } else {
-                let ts = chrono::Local::now().format("%H:%M:%S");
-                tracing::warn!(
-                    "  [{ts}] ⚠ Watcher auto-retry skipped: inflight state missing for channel {}",
-                    channel_id
-                );
+            //
+            // #897 round-4 Medium: a `rebind_origin` inflight has no real
+            // user message or text to retry with (`user_msg_id=0`,
+            // user_text="/api/inflight/rebind"), so auto-retry would
+            // enqueue a garbage internal follow-up. Skip the retry; the
+            // operator is expected to re-invoke `/api/inflight/rebind`
+            // once the tmux session is healthy again.
+            match super::inflight::load_inflight_state(&watcher_provider, channel_id.get()) {
+                Some(state) if state.rebind_origin => {
+                    let ts = chrono::Local::now().format("%H:%M:%S");
+                    tracing::warn!(
+                        "  [{ts}] ⚠ Watcher auto-retry skipped for channel {} — rebind_origin inflight has no user message to retry",
+                        channel_id
+                    );
+                }
+                Some(state) => {
+                    super::turn_bridge::auto_retry_with_history(
+                        &http,
+                        &shared,
+                        &watcher_provider,
+                        channel_id,
+                        serenity::MessageId::new(state.user_msg_id),
+                        &state.user_text,
+                    )
+                    .await;
+                    let ts = chrono::Local::now().format("%H:%M:%S");
+                    tracing::warn!(
+                        "  [{ts}] ↻ Watcher auto-retry queued for channel {}",
+                        channel_id
+                    );
+                }
+                None => {
+                    let ts = chrono::Local::now().format("%H:%M:%S");
+                    tracing::warn!(
+                        "  [{ts}] ⚠ Watcher auto-retry skipped: inflight state missing for channel {}",
+                        channel_id
+                    );
+                }
             }
             // Skip normal response relay
             full_response = String::new();

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -46,6 +46,17 @@ pub(super) struct WatcherLineOutcome {
     pub provider_overload_message: Option<String>,
     pub stale_resume_detected: bool,
     pub auto_compacted: bool,
+    /// #826 marker: Claude Code emits `{"type":"system","subtype":"task_notification",...}`
+    /// at the start of a turn it auto-fires in response to a background task
+    /// completing (e.g. a `Bash run_in_background` finishing). This is the
+    /// canonical signal that the current tmux turn is a *background-trigger*
+    /// turn — one for which no user-authored message exists and the terminal
+    /// response must be routed through the notify-bot outbox rather than
+    /// relayed via the command bot. Distinguishing this from a normal
+    /// foreground turn (where `turn_bridge` has merely cleared the inflight
+    /// file prior to handing output back to the watcher) is the P1 review fix
+    /// for the over-broad `inflight.is_none()` predicate.
+    pub task_notification_seen: bool,
 }
 
 fn lifecycle_reason_code_for_tmux_exit(reason: &str) -> &'static str {
@@ -97,6 +108,54 @@ fn build_monitor_completion_message(response: &str) -> String {
         "**✅ 모니터 완료**\n백그라운드 모니터가 작업 완료를 감지해 결과를 이어서 전달합니다.\n\n{}",
         response
     )
+}
+
+/// #826 P1 #1: Evaluate whether the terminal response for a tmux-backed turn
+/// should be routed through the notify-bot outbox rather than the normal
+/// command-bot relay. Background-trigger turns (Claude Code auto-fired in
+/// response to a `<task-notification>`) must go through notify to avoid
+/// other agents in the channel treating the output as an actionable directive
+/// (infinite-loop hazard). Ordinary foreground turns — even when the inflight
+/// file was cleared early by `turn_bridge` — must NOT be rerouted, because
+/// the notify-bot outbox may not be available in every deployment, which
+/// would silently drop the reply.
+///
+/// Returns `true` only when ALL of the following hold:
+/// 1. The turn produced an assistant response (no use rerouting emptiness).
+/// 2. A `system/task_notification` event was observed in the turn's JSONL
+///    stream (canonical Claude Code marker for a background-trigger turn).
+/// 3. No inflight state exists for the channel (rules out concurrent
+///    foreground turns that happen to also include the marker).
+#[inline]
+pub(super) fn should_route_terminal_response_via_notify_bot(
+    has_assistant_response: bool,
+    task_notification_seen: bool,
+    inflight_present: bool,
+) -> bool {
+    has_assistant_response && task_notification_seen && !inflight_present
+}
+
+/// #826 P1 #2: Decide whether `last_relayed_offset` should advance for a
+/// notify-path relay. Only advance when the outbox enqueue SUCCEEDED (durable
+/// DB-backed commit) OR when the direct-send fallback actually reached
+/// Discord. An enqueue failure with no fallback delivery must leave the
+/// offset untouched so the watcher can re-emit the same tmux range on its
+/// next scan instead of silently dropping the response.
+///
+/// Pure function extracted for regression-test coverage of the offset-commit
+/// gate; the runtime version lives inline in the watcher loop because it is
+/// intertwined with other relay bookkeeping.
+#[inline]
+pub(super) fn notify_path_should_advance_offset(
+    has_current_response: bool,
+    enqueue_succeeded: bool,
+    fallback_send_succeeded: bool,
+) -> bool {
+    if !has_current_response {
+        // Nothing to deliver — trivially safe to advance past an empty range.
+        return true;
+    }
+    enqueue_succeeded || fallback_send_succeeded
 }
 
 /// #826: Enqueue a background-trigger turn's terminal response on the
@@ -773,6 +832,11 @@ pub(super) async fn tmux_output_watcher(
         let mut is_provider_overloaded = initial_outcome.is_provider_overloaded;
         let mut provider_overload_message = initial_outcome.provider_overload_message;
         let mut stale_resume_detected = initial_outcome.stale_resume_detected;
+        // #826 P1 #1: accumulate the task_notification system-event marker so
+        // the terminal-response branch can distinguish a background-trigger
+        // auto-fired turn from a normal foreground turn whose inflight file
+        // was simply cleared early by turn_bridge.
+        let mut task_notification_seen = initial_outcome.task_notification_seen;
 
         // Keep reading until result or timeout
         // Check if a Discord turn claimed this data since our epoch snapshot
@@ -847,6 +911,8 @@ pub(super) async fn tmux_output_watcher(
                             is_provider_overloaded || outcome.is_provider_overloaded;
                         stale_resume_detected =
                             stale_resume_detected || outcome.stale_resume_detected;
+                        task_notification_seen =
+                            task_notification_seen || outcome.task_notification_seen;
                         if provider_overload_message.is_none() {
                             provider_overload_message = outcome.provider_overload_message;
                         }
@@ -1480,19 +1546,33 @@ pub(super) async fn tmux_output_watcher(
         let current_response = full_response.get(response_sent_offset..).unwrap_or("");
         let has_current_response = !current_response.trim().is_empty();
 
-        // #826: When inflight state is missing at the watcher's terminal-response
-        // point, this is a turn that Claude Code's `<task-notification>` mechanism
-        // auto-fired after the bridge completed and cleaned up. There is no
-        // user-visible message that would normally trigger the bridge path, so
-        // the response must reach the channel via the notify bot — both because
-        // (a) without it the response is silently dropped (the original #826
-        // bug) and (b) sending via the command bot risks other agents in the
-        // channel treating it as an actionable directive (infinite-loop risk).
-        // Notify bot is the canonical sink for background-task-driven info per
-        // `docs/background-task-pattern.md`; it is also dropped at the intake
-        // gate so the agent itself cannot self-trigger another turn off this
+        // #826 P1 #1: Routing a terminal response through the notify-bot
+        // outbox is only correct when the response came from a turn that
+        // Claude Code's `<task-notification>` mechanism auto-fired (no
+        // user-authored message exists, sending via the command bot risks
+        // other agents treating it as a directive → infinite-loop hazard).
+        //
+        // The earlier heuristic — "inflight state is missing at completion"
+        // — is too broad: `turn_bridge` ALSO clears the inflight file before
+        // handing a normal tmux-backed foreground turn's output back to the
+        // watcher for relay. Using only `inflight.is_none()` would silently
+        // reroute ordinary foreground replies through the notify-only path
+        // and drop them when notify/outbox is unavailable.
+        //
+        // The canonical marker is the `system/task_notification` JSONL event
+        // Claude Code emits at the start of an auto-fired turn; we
+        // accumulate it in `task_notification_seen` above. Route to notify
+        // ONLY when BOTH the marker is present AND the inflight file is
+        // absent — the latter remains part of the predicate so that a
+        // foreground turn whose response happens to contain a spurious
+        // task_notification passthrough is still relayed normally.
+        //
+        // Notify bot is the canonical sink for background-task-driven info
+        // per `docs/background-task-pattern.md`; it is dropped at the intake
+        // gate so the agent cannot self-trigger another turn off this
         // delivery.
         let route_via_notify_bot = has_assistant_response
+            && task_notification_seen
             && super::inflight::load_inflight_state(&watcher_provider, channel_id.get()).is_none();
 
         // Send the terminal response to Discord
@@ -1526,23 +1606,46 @@ pub(super) async fn tmux_output_watcher(
                         &prefixed,
                     )
                 } else {
+                    // No assistant text to deliver — nothing to commit.
                     true
                 };
                 if !enqueued {
+                    // #826 P1 #2: enqueue FAILED — the message has NOT been
+                    // durably persisted to the outbox. Do not let a
+                    // downstream success path accidentally advance
+                    // `last_relayed_offset`; clear `relay_ok` first and then
+                    // *only* revive it if the direct-send fallback reaches
+                    // Discord. This keeps the watcher able to retry the same
+                    // tmux range on the next scan instead of silently moving
+                    // past a dropped response.
+                    relay_ok = false;
                     let ts = chrono::Local::now().format("%H:%M:%S");
                     tracing::warn!(
                         "  [{ts}] 👁 background-trigger notify enqueue failed in channel {} — falling back to direct send",
                         channel_id
                     );
-                    if has_current_response
-                        && let Err(e) =
-                            send_long_message_raw(&http, channel_id, &prefixed, &shared).await
-                    {
-                        let ts = chrono::Local::now().format("%H:%M:%S");
-                        tracing::info!("  [{ts}] 👁 Fallback relay failed: {e}");
-                        relay_ok = false;
+                    if has_current_response {
+                        match send_long_message_raw(&http, channel_id, &prefixed, &shared).await {
+                            Ok(_) => {
+                                relay_ok = true;
+                            }
+                            Err(e) => {
+                                let ts = chrono::Local::now().format("%H:%M:%S");
+                                tracing::info!("  [{ts}] 👁 Fallback relay failed: {e}");
+                                // relay_ok remains false → offset NOT advanced
+                            }
+                        }
                     }
                 }
+                // Residual risk: enqueue succeeded but the notify-bot outbox
+                // worker may still fail to reach Discord later (notify bot
+                // mis-configured, `/api/send` unreachable, Discord rejects the
+                // message). The outbox is a durable DB-backed queue with its
+                // own retry loop, so a transient worker failure is retried
+                // without our involvement. Exhausting worker retries would
+                // leave the row in `status='failed'` with the offset already
+                // advanced — tracked as follow-up, documented here so the
+                // gap is visible in grep.
             } else {
                 match placeholder_msg_id {
                     Some(msg_id) => {
@@ -2403,6 +2506,16 @@ pub(super) fn process_watcher_lines(
                         if subtype == "compact" || subtype == "auto_compact" {
                             outcome.auto_compacted = true;
                         }
+                        // #826: Claude Code emits a task_notification system
+                        // event when it auto-fires a turn in response to a
+                        // background task completing (e.g. a Bash
+                        // run_in_background finish). This is the authoritative
+                        // marker that lets us distinguish a background-trigger
+                        // turn from a normal foreground turn whose inflight
+                        // file was merely cleared early by turn_bridge.
+                        if subtype == "task_notification" {
+                            outcome.task_notification_seen = true;
+                        }
                     }
                 }
                 _ => {}
@@ -3097,8 +3210,9 @@ mod tests {
     use super::{
         DeadSessionCleanupPlan, WatcherToolState, build_monitor_completion_message,
         dead_session_cleanup_plan, enqueue_background_trigger_response_to_notify_outbox,
-        load_restored_provider_session_id, process_watcher_lines,
-        refresh_session_heartbeat_from_tmux_output, watcher_ready_for_input_turn_completed,
+        load_restored_provider_session_id, notify_path_should_advance_offset,
+        process_watcher_lines, refresh_session_heartbeat_from_tmux_output,
+        should_route_terminal_response_via_notify_bot, watcher_ready_for_input_turn_completed,
         watcher_should_yield_to_inflight_state,
     };
     use crate::services::discord::inflight::InflightTurnState;
@@ -3562,5 +3676,121 @@ mod tests {
             "would-have-been-delivered",
         );
         assert!(!ok, "missing db must surface as failure to enable fallback");
+    }
+
+    /// #826 P1 #1 regression guard: a turn whose inflight file is absent but
+    /// which never emitted a `system/task_notification` event is a NORMAL
+    /// foreground turn (turn_bridge cleared the inflight early before
+    /// handing tmux output back to the watcher). Such turns MUST use the
+    /// direct command-bot relay, not the notify-bot outbox — otherwise a
+    /// deployment without notify wiring silently drops every long reply.
+    #[test]
+    fn normal_foreground_turn_without_task_notification_uses_direct_relay() {
+        // No task_notification marker + no inflight + has response → direct.
+        assert!(
+            !should_route_terminal_response_via_notify_bot(
+                /*has_assistant_response*/ true, /*task_notification_seen*/ false,
+                /*inflight_present*/ false,
+            ),
+            "missing inflight ALONE must not reroute a foreground turn to notify"
+        );
+
+        // Background-trigger turn with marker and no inflight → notify.
+        assert!(
+            should_route_terminal_response_via_notify_bot(true, true, false),
+            "genuine background-trigger turns (marker present + no inflight) must route to notify"
+        );
+
+        // Marker present but inflight still exists — treat as a concurrent
+        // foreground turn; do not reroute.
+        assert!(
+            !should_route_terminal_response_via_notify_bot(true, true, true),
+            "inflight-present turns must never route to notify even if a task_notification leaked in"
+        );
+
+        // Marker present but no response — nothing to send.
+        assert!(!should_route_terminal_response_via_notify_bot(
+            false, true, false
+        ));
+    }
+
+    /// #826 P1 #1 regression guard (JSONL-level): `process_watcher_lines`
+    /// must expose the `task_notification` system event as
+    /// `task_notification_seen` so the routing predicate can distinguish a
+    /// background-trigger turn from a foreground one. A run that only
+    /// contains a normal assistant+result pair must leave the flag clear.
+    #[test]
+    fn process_watcher_lines_surfaces_task_notification_marker() {
+        // Background-trigger turn: Claude Code opens with a system
+        // task_notification event before streaming the assistant response.
+        let mut bg_buffer = concat!(
+            "{\"type\":\"system\",\"subtype\":\"task_notification\",\"task_id\":\"bg-42\",\"status\":\"completed\",\"summary\":\"CI green\"}\n",
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"PR #825 리뷰 반영 완료\"}]}}\n",
+            "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"done\"}\n"
+        ).to_string();
+        let mut state = crate::services::session_backend::StreamLineState::new();
+        let mut full_response = String::new();
+        let mut tool_state = WatcherToolState::new();
+        let bg_outcome = process_watcher_lines(
+            &mut bg_buffer,
+            &mut state,
+            &mut full_response,
+            &mut tool_state,
+        );
+        assert!(bg_outcome.found_result);
+        assert!(
+            bg_outcome.task_notification_seen,
+            "task_notification system event must set the marker"
+        );
+
+        // Normal foreground turn: no task_notification event. Marker must
+        // stay false so the router keeps the direct-relay path.
+        let mut fg_buffer = concat!(
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}}\n",
+            "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"done\"}\n"
+        )
+        .to_string();
+        let mut fg_state = crate::services::session_backend::StreamLineState::new();
+        let mut fg_response = String::new();
+        let mut fg_tool_state = WatcherToolState::new();
+        let fg_outcome = process_watcher_lines(
+            &mut fg_buffer,
+            &mut fg_state,
+            &mut fg_response,
+            &mut fg_tool_state,
+        );
+        assert!(fg_outcome.found_result);
+        assert!(
+            !fg_outcome.task_notification_seen,
+            "a turn without task_notification must not set the marker"
+        );
+    }
+
+    /// #826 P1 #2 regression guard: when the notify-bot outbox enqueue fails
+    /// AND no direct-send fallback reaches Discord, the watcher MUST leave
+    /// `last_relayed_offset` untouched so the same tmux range can be
+    /// re-relayed on the next scan. Advancing the offset here is the bug
+    /// that permanently loses a completion notification when notify-bot is
+    /// unavailable.
+    #[test]
+    fn notify_path_does_not_advance_offset_on_enqueue_failure_without_fallback() {
+        // Enqueue failed AND direct-send fallback also failed → no advance.
+        assert!(
+            !notify_path_should_advance_offset(
+                /*has_current_response*/ true, /*enqueue_succeeded*/ false,
+                /*fallback_send_succeeded*/ false,
+            ),
+            "enqueue-fail + fallback-fail with content must leave the offset untouched"
+        );
+
+        // Enqueue succeeded → outbox row is durable → advance is safe.
+        assert!(notify_path_should_advance_offset(true, true, false));
+
+        // Enqueue failed but fallback direct-send reached Discord → advance.
+        assert!(notify_path_should_advance_offset(true, false, true));
+
+        // No content to deliver → trivially safe to advance past the empty
+        // range regardless of enqueue/fallback outcome.
+        assert!(notify_path_should_advance_offset(false, false, false));
     }
 }

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -164,7 +164,12 @@ async fn enqueue_headless_delivery(
                 content,
                 bot: "notify",
                 source: "headless_turn",
-                reason_code: None,
+                // #897 counter-model review P1 #3: explicit reason_code so
+                // `message_outbox::enqueue` can arm its lifecycle dedupe
+                // (it requires reason_code AND session_key to both be Some).
+                // Prevents duplicate delivery if the headless-turn finalize
+                // path retries within the dedupe TTL.
+                reason_code: Some("headless.delivery"),
                 session_key,
             },
         )


### PR DESCRIPTION
## Summary
- **#826** — 미병합 `fix/826-task-notify` 브랜치(2026-04-20)의 3커밋을 현재 main 위에 재적용. Claude Code `<task-notification>` 자동 트리거 턴의 terminal 응답을 notify-bot outbox로 라우팅해 Discord에 도달하게 함. `task_notification_seen` 명시 마커와 `last_relayed_offset` vs `last_enqueued_offset` 이중 watermark로 중복 relay / 드롭 방지.
- **#896** — `POST /api/inflight/rebind` 엔드포인트 신설. tmux는 살아있지만 inflight JSON이 비어있는 orphan 상태를 작업 손실 없이 실시간 복구.

## Why now
- `fix/826-task-notify` 브랜치는 작업이 완료됐으나 PR 생성 단계가 누락된 채 4개월(실제로는 3시간 20분) 공백 발생. 그 사이 사용자가 `3528fbdb Deliver headless turn completions via notify outbox`로 headless-turn 경로만 부분 fix했는데, tmux watcher relay 경로는 그대로 누락. 사용자가 여전히 백그라운드 완료 회신 누락을 겪는 이유.
- #896는 #826으로 커버되지 않는 "이전 턴이 cleanup된 뒤 자동 트리거 없이 내부 루프만 도는 orphan" 케이스용 복구 수단. 지금까지는 force-kill 후 작업 전체 날리는 수밖에 없었음.

## Key mechanics

### #826
- `WatcherLineOutcome.task_notification_seen` — Claude Code가 `{"type":"system","subtype":"task_notification",...}`을 emit한 턴을 구분하는 canonical 마커. `inflight.is_none()` 단독 판정(너무 넓음)에서 진화.
- `should_route_terminal_response_via_notify_bot(has_response, task_notification_seen, inflight_present)` — AND 3조건 충족 시에만 notify-bot outbox로 라우팅. foreground 턴을 실수로 재라우팅해서 잃는 사고 방지.
- `OffsetAdvanceDecision` + `notify_path_offset_advance_decision` — `last_relayed_offset`는 **delivery 확인 시점**에만 advance, `last_enqueued_offset`는 outbox enqueue 시점에 advance. 중복 enqueue 방지하면서 worker delivery 실패 후 재시도 여지 보존.
- Dedupe key에 `data_start_offset` + content SHA-256 포함 → 같은 채널의 연속 완료 2건이 1건으로 뭉치는 P1 리뷰 이슈 해소.
- 무한루프 guard 구조적: notify-bot authored 메시지는 `is_allowed_turn_sender`에서 거부.

### #896
- `recovery_engine::rebind_inflight_for_channel`가 단일 채널판 `restore_inflight_turns` "tmux 살아있음" 분기. `tmux_session_alive_with_retry` + `validate_bot_channel_routing_with_provider_channel` + `save_inflight_state` + `try_claim_watcher` + `tmux_output_watcher` 재사용.
- 선행 조건 위반은 전부 typed 에러로 → HTTP 상태 1:1 매핑 (`TmuxNotAlive`→404, `InflightAlreadyExists`→409, `ChannelNotBound`/`ChannelNameMissing`→400, `Internal`→500, 미등록 provider→503).
- `HealthRegistry::rebind_inflight` wrapper로 `SharedData`(가시성 `pub(in crate::services)`)를 서비스 경계 밖으로 노출하지 않음.
- 복구 시 `last_offset = tmux 파일 현재 크기` — rebind 이전에 버려진 output은 **retro-emit 하지 않음**(의도). 관측 가능한 순간부터만 watcher가 감시.

## Test plan
- [x] `cargo check --bin agentdesk` clean (137 warning은 전부 기존 dead code, 추가된 에러/경고 없음)
- [x] `cargo test services::discord::tmux::tests` — 23 passed (#826 predicate/offset/dedupe 회귀 가드 포함)
- [x] `cargo test services::discord::health::tests` — 30 passed (`parse_rebind_body` 7케이스 포함)
- [x] `cargo test services::discord::recovery_engine` — 20 passed
- [ ] 배포 후 orphan dispatch 채널(#adk-dash-cdx 등)에 `POST /api/inflight/rebind` 수동 호출 → inflight 파일 생성 + 이후 tmux 출력이 Discord로 relay 되는지 확인
- [ ] 배포 후 Claude Code 백그라운드 태스크 완료 → `task_notification` 자동 턴 응답이 notify-bot outbox로 전달되는지 확인

## Follow-ups (out of PR scope)
- #895 (close 처리됨): `/api/send`에 inflight 생성이 있는지 RCA 재검증 결과 현재 경로 정상. 추가 조사 결과 실제 증상은 이 PR 두 fix로 대부분 커버됨.
- codex provider에서 `system/task_notification` JSONL 이벤트 emit 여부 검증 필요 — 없으면 codex용 등가 마커 별도 이슈.
- #826 P2 잔여: notify-bot outbox worker가 delivery 실패 후 `status='failed'`로 남은 row를 watcher가 인식해 `last_enqueued_offset` 롤백하는 경로 추가 (이 PR에서는 이중 watermark로 re-stage 여지만 확보).

Closes #826
Closes #896
