### PR TITLE
fix(#899): flip AGENTDESK_SKIP_TURN_DRAIN default to 1 (bypass)

### DIFF
--- a/scripts/_defaults.sh
+++ b/scripts/_defaults.sh
@@ -322,7 +322,13 @@ wait_for_live_turns_to_drain_or_fail() {
   # Turns themselves are preserved across restart via silent reattach (#43e3cacc);
   # this flag only skips the drain wait, at the cost of possibly truncating a
   # mid-stream Discord response during the SIGTERM window.
-  local skip_drain="${AGENTDESK_SKIP_TURN_DRAIN:-0}"
+  #
+  # #899: default is now `1` (bypass). In the self-hosted promote topology the
+  # operator agent running the promote IS a live turn on release, so drain
+  # would time out nearly always. The stream hiccup is acceptable and #826 /
+  # #896 guarantee recovery via watcher silent-reattach + inflight rebind.
+  # Set `AGENTDESK_SKIP_TURN_DRAIN=0` to force the classic drain-wait.
+  local skip_drain="${AGENTDESK_SKIP_TURN_DRAIN:-1}"
   local waited=0
   local active=0 finalizing=0 queue_depth=0 live_turns=0 job_state=""
 
@@ -341,7 +347,8 @@ EOF
     fi
     echo "✗ [gate] Unable to confirm ${scope} turn drain on :${port} (launchd state: ${job_state:-unknown})"
     echo "  Refusing restart to avoid truncating mid-stream output."
-    echo "  Override only if stream hiccup is acceptable: AGENTDESK_SKIP_TURN_DRAIN=1"
+    echo "  You opted into strict drain via AGENTDESK_SKIP_TURN_DRAIN=0;"
+    echo "  remove that override (default=1) if a brief stream hiccup is acceptable."
     return 1
   fi
 
@@ -370,7 +377,8 @@ EOF
       fi
       echo "✗ [gate] Lost ${scope} health during drain wait after ${waited}s (launchd state: ${job_state:-unknown})"
       echo "  Refusing restart to avoid truncating mid-stream output."
-      echo "  Override only if stream hiccup is acceptable: AGENTDESK_SKIP_TURN_DRAIN=1"
+      echo "  You opted into strict drain via AGENTDESK_SKIP_TURN_DRAIN=0;"
+      echo "  remove that override (default=1) if a brief stream hiccup is acceptable."
       return 1
     fi
     live_turns=$(( active + finalizing ))
@@ -383,7 +391,8 @@ EOF
     fi
     echo "✗ [gate] ${scope} still has ${live_turns} active/finalizing turn(s) after ${max_wait}s (queued=${queue_depth})"
     echo "  Refusing restart to avoid truncating mid-stream output."
-    echo "  Retry after work finishes, or override with AGENTDESK_SKIP_TURN_DRAIN=1 when a brief stream hiccup is acceptable."
+    echo "  You opted into strict drain via AGENTDESK_SKIP_TURN_DRAIN=0;"
+    echo "  retry after work finishes or remove that override (default=1) when a brief stream hiccup is acceptable."
     return 1
   fi
 

--- a/scripts/promote-release.sh
+++ b/scripts/promote-release.sh
@@ -211,7 +211,7 @@ export AGENTDESK_REPO_DIR=$(printf '%q' "$REPO")
 export AGENTDESK_PROMOTE_DETACHED_CHILD=1
 export AGENTDESK_PROMOTE_LOG_PATH=$(printf '%q' "$log_path")
 export AGENTDESK_PROMOTE_TEST_MODE=$(printf '%q' "$PROMOTE_TEST_MODE")
-export AGENTDESK_SKIP_TURN_DRAIN=$(printf '%q' "${AGENTDESK_SKIP_TURN_DRAIN:-0}")
+export AGENTDESK_SKIP_TURN_DRAIN=$(printf '%q' "${AGENTDESK_SKIP_TURN_DRAIN:-1}")
 export AGENTDESK_CODESIGN_IDENTITY=$(printf '%q' "${AGENTDESK_CODESIGN_IDENTITY:-}")
 export AGENTDESK_PROMOTE_BINARY=$(printf '%q' "${AGENTDESK_PROMOTE_BINARY:-}")
 cd $(printf '%q' "$REPO")
@@ -311,8 +311,12 @@ rsync -a --delete "$REPO/skills/" "$SKILLS_STAGED/"
 # dcserver SIGTERM preserves turn state (#43e3cacc): tmux sessions stay alive
 # and the watcher silent-reattaches after restart. What the drain gate guards
 # against is mid-stream output truncation to Discord during the SIGTERM window.
-# Skip the wait with AGENTDESK_SKIP_TURN_DRAIN=1 when a brief stream hiccup is
-# acceptable for the planned restart.
+# #899: the default is now AGENTDESK_SKIP_TURN_DRAIN=1 (bypass) — in practice
+# every self-hosted promotion carries a live turn (the operator agent's own
+# turn), so blocking on drain is a near-permanent false-negative; the brief
+# stream hiccup is acceptable and #826/#896 already guarantee recovery via
+# watcher silent-reattach + inflight rebind. Set AGENTDESK_SKIP_TURN_DRAIN=0
+# to force the classic drain-wait when a clean restart is genuinely required.
 # REL_PORT already assigned earlier for the zero-inflight gate.
 if ! wait_for_live_turns_to_drain_or_fail "release" "$PLIST_REL" "$REL_PORT" 120 2; then
     exit 1


### PR DESCRIPTION
## Summary
- Flip `AGENTDESK_SKIP_TURN_DRAIN` default from `0` → `1` in `promote-release.sh` (helper env export) and `_defaults.sh` (`wait_for_live_turns_to_drain_or_fail`). In the self-hosted promote topology the operator agent running the promote is itself a live turn on release, so drain gate always times out without manual override.
- Updated inline comment + three error messages: strict drain is now explicit opt-in via `AGENTDESK_SKIP_TURN_DRAIN=0`.
- Turn state is preserved by #826 watcher silent-reattach + #896 inflight rebind, so the stream hiccup the gate protects against is acceptable.

## Test plan
- [x] `bash -n scripts/_defaults.sh` / `bash -n scripts/promote-release.sh` clean
- [ ] Next promote-release run without `AGENTDESK_SKIP_TURN_DRAIN` set → bypasses drain, succeeds on self-hosted
- [ ] `AGENTDESK_SKIP_TURN_DRAIN=0 ./scripts/promote-release.sh` → classic drain-wait behaviour restored

Closes #899