### PR TITLE
fix(tmux): prevent duplicate terminal-response relay across watcher replacement

### DIFF
--- a/dashboard/e2e/smoke.spec.ts
+++ b/dashboard/e2e/smoke.spec.ts
@@ -45,6 +45,7 @@ const DRAGGED_HOME_WIDGET_ORDER = [
   "activity",
   "kanban",
 ];
+const PIPELINE_VISUAL_CACHE_KEY = "agentdesk.settings.pipeline.visual-cache.v1";
 
 async function expectNoHorizontalOverflow(page: Page) {
   const metrics = await page.evaluate(() => ({
@@ -782,6 +783,82 @@ const MOCK_DAILY_MISSIONS = [
   },
 ];
 
+const MOCK_SETTINGS_FSM_PIPELINE = {
+  name: "agentdesk-default",
+  version: 1,
+  states: [
+    { id: "backlog", label: "backlog", terminal: false },
+    { id: "ready", label: "ready", terminal: false },
+    { id: "in_progress", label: "progress", terminal: false },
+    { id: "review", label: "review", terminal: false },
+    { id: "done", label: "done", terminal: true },
+    { id: "failed", label: "failed", terminal: false },
+  ],
+  transitions: [
+    { from: "backlog", to: "ready", type: "free", gates: [] },
+    { from: "ready", to: "in_progress", type: "free", gates: [] },
+    { from: "in_progress", to: "review", type: "free", gates: [] },
+    { from: "review", to: "done", type: "gated", gates: ["review_verdict_pass"] },
+    { from: "review", to: "in_progress", type: "gated", gates: ["review_verdict_rework"] },
+    { from: "review", to: "failed", type: "force_only", gates: [] },
+    { from: "failed", to: "ready", type: "free", gates: [] },
+  ],
+  gates: {
+    review_verdict_pass: {
+      type: "builtin",
+      check: "review_verdict_pass",
+      description: "Review approved",
+    },
+    review_verdict_rework: {
+      type: "builtin",
+      check: "review_verdict_rework",
+      description: "Changes requested",
+    },
+  },
+  hooks: {
+    backlog: { on_enter: [], on_exit: [] },
+    ready: { on_enter: [], on_exit: [] },
+    in_progress: { on_enter: [], on_exit: [] },
+    review: { on_enter: [], on_exit: [] },
+    done: { on_enter: [], on_exit: [] },
+    failed: { on_enter: [], on_exit: [] },
+  },
+  events: {
+    on_enqueue: ["OnQueueReady"],
+    on_dispatch: ["OnDispatchRequested"],
+    on_submit: ["OnDispatchCompleted"],
+    on_approve: ["OnReviewApproved"],
+    on_changes_request: ["OnChangesRequested"],
+    on_error: ["OnPipelineError"],
+    on_recover: ["OnRecoverFromFailure"],
+  },
+  clocks: {},
+  timeouts: {},
+  phase_gate: {
+    dispatch_to: "project-agentdesk",
+    dispatch_type: "review",
+    pass_verdict: "approved",
+    checks: ["artifact_attached"],
+  },
+};
+
+const MOCK_SETTINGS_PIPELINE_STAGES = [
+  {
+    stage_name: "implementation",
+    entry_skill: "adk-dashboard",
+    provider: "codex",
+    agent_override_id: null,
+    timeout_minutes: 60,
+    on_failure: "previous",
+    on_failure_target: null,
+    max_retries: 1,
+    skip_condition: null,
+    parallel_with: null,
+    applies_to_agent_id: null,
+    trigger_after: "ready",
+  },
+];
+
 async function mockMeetingsHubApis(page: Page) {
   await page.route(/\/api\/round-table-meetings\/channels$/, async (route) => {
     await route.fulfill({
@@ -1165,6 +1242,127 @@ async function mockDashboardBootstrap(page: Page) {
       status: 200,
       contentType: "application/json",
       body: JSON.stringify(MOCK_OPS_HEALTH_BASE),
+    });
+  });
+}
+
+async function mockSettingsPipelineEditorApis(page: Page) {
+  await page.route(/\/api\/github-repos$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        viewer_login: "itismyfield",
+        repos: [
+          {
+            nameWithOwner: "itismyfield/AgentDesk",
+            updatedAt: "2026-04-21T00:00:00Z",
+            isPrivate: true,
+            viewerPermission: "ADMIN",
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.route(/\/api\/pipeline\/config\/effective\?repo=itismyfield%2FAgentDesk$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        pipeline: MOCK_SETTINGS_FSM_PIPELINE,
+        layers: { default: true, repo: false, agent: false },
+      }),
+    });
+  });
+
+  await page.route(/\/api\/pipeline\/config\/repo\/itismyfield\/AgentDesk$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        repo: "itismyfield/AgentDesk",
+        pipeline_config: {
+          states: MOCK_SETTINGS_FSM_PIPELINE.states,
+          transitions: MOCK_SETTINGS_FSM_PIPELINE.transitions,
+          gates: MOCK_SETTINGS_FSM_PIPELINE.gates,
+          hooks: MOCK_SETTINGS_FSM_PIPELINE.hooks,
+          events: MOCK_SETTINGS_FSM_PIPELINE.events,
+          clocks: MOCK_SETTINGS_FSM_PIPELINE.clocks,
+          timeouts: MOCK_SETTINGS_FSM_PIPELINE.timeouts,
+          phase_gate: MOCK_SETTINGS_FSM_PIPELINE.phase_gate,
+        },
+      }),
+    });
+  });
+
+  await page.route(/\/api\/pipeline\/stages\?repo=itismyfield%2FAgentDesk$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ stages: MOCK_SETTINGS_PIPELINE_STAGES }),
+    });
+  });
+}
+
+async function mockSettingsPipelineEditorApisWithRefreshDelay(page: Page, delayMs = 700) {
+  await page.route(/\/api\/github-repos$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        viewer_login: "itismyfield",
+        repos: [
+          {
+            nameWithOwner: "itismyfield/AgentDesk",
+            updatedAt: "2026-04-21T00:00:00Z",
+            isPrivate: true,
+            viewerPermission: "ADMIN",
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.route(/\/api\/pipeline\/config\/effective\?repo=itismyfield%2FAgentDesk$/, async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        pipeline: MOCK_SETTINGS_FSM_PIPELINE,
+        layers: { default: true, repo: false, agent: false },
+      }),
+    });
+  });
+
+  await page.route(/\/api\/pipeline\/config\/repo\/itismyfield\/AgentDesk$/, async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        repo: "itismyfield/AgentDesk",
+        pipeline_config: {
+          states: MOCK_SETTINGS_FSM_PIPELINE.states,
+          transitions: MOCK_SETTINGS_FSM_PIPELINE.transitions,
+          gates: MOCK_SETTINGS_FSM_PIPELINE.gates,
+          hooks: MOCK_SETTINGS_FSM_PIPELINE.hooks,
+          events: MOCK_SETTINGS_FSM_PIPELINE.events,
+          clocks: MOCK_SETTINGS_FSM_PIPELINE.clocks,
+          timeouts: MOCK_SETTINGS_FSM_PIPELINE.timeouts,
+          phase_gate: MOCK_SETTINGS_FSM_PIPELINE.phase_gate,
+        },
+      }),
+    });
+  });
+
+  await page.route(/\/api\/pipeline\/stages\?repo=itismyfield%2FAgentDesk$/, async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ stages: MOCK_SETTINGS_PIPELINE_STAGES }),
     });
   });
 }
@@ -1840,6 +2038,63 @@ test.describe("Dashboard smoke tests", () => {
 
     const after = await settingsPage.evaluate((node) => node.scrollTop);
     expect(after).toBeGreaterThan(0);
+  });
+
+  test("settings: mobile FSM editor exposes quick selection controls", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name === "desktop", "Mobile-only test");
+    await mockSettingsPipelineEditorApis(page);
+    await page.goto("/settings?settingsPanel=pipeline");
+
+    await expect(page.getByTestId("settings-page")).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId("fsm-mobile-selector")).toBeVisible();
+
+    await page.getByTestId("fsm-mobile-transition-button-3").click();
+    await expect(page.getByTestId("pipeline-selection-title")).toContainText("review → done");
+
+    await page.getByTestId("fsm-mobile-state-button-review").click();
+    await expect(page.getByTestId("pipeline-selection-title")).toContainText(/상태 · review|State · review/);
+  });
+
+  test("settings: pipeline editor keeps cached content visible while refreshing", async ({ page }) => {
+    await page.addInitScript(({ cacheKey, cacheValue }) => {
+      window.localStorage.setItem(cacheKey, JSON.stringify(cacheValue));
+    }, {
+      cacheKey: PIPELINE_VISUAL_CACHE_KEY,
+      cacheValue: {
+        version: 1,
+        entries: {
+          "itismyfield/AgentDesk::repo::repo": {
+            repo: "itismyfield/AgentDesk",
+            level: "repo",
+            agentId: null,
+            updatedAtMs: Date.now(),
+            snapshot: {
+              pipeline: MOCK_SETTINGS_FSM_PIPELINE,
+              layers: { default: true, repo: false, agent: false },
+              rawOverride: {
+                states: MOCK_SETTINGS_FSM_PIPELINE.states,
+                transitions: MOCK_SETTINGS_FSM_PIPELINE.transitions,
+                gates: MOCK_SETTINGS_FSM_PIPELINE.gates,
+                hooks: MOCK_SETTINGS_FSM_PIPELINE.hooks,
+                events: MOCK_SETTINGS_FSM_PIPELINE.events,
+                clocks: MOCK_SETTINGS_FSM_PIPELINE.clocks,
+                timeouts: MOCK_SETTINGS_FSM_PIPELINE.timeouts,
+                phase_gate: MOCK_SETTINGS_FSM_PIPELINE.phase_gate,
+              },
+              repoStages: MOCK_SETTINGS_PIPELINE_STAGES,
+            },
+          },
+        },
+      },
+    });
+    await mockSettingsPipelineEditorApisWithRefreshDelay(page);
+    await page.goto("/settings?settingsPanel=pipeline");
+
+    await expect(page.getByTestId("settings-page")).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId("pipeline-selection-title")).toBeVisible({ timeout: 400 });
+    await expect(page.getByTestId("pipeline-refresh-indicator")).toBeVisible();
+    await expect(page.getByTestId("pipeline-selection-title")).toContainText("backlog → ready");
+    await expect(page.getByTestId("pipeline-refresh-indicator")).toBeHidden({ timeout: 3000 });
   });
 
   test("all app shell routes are directly reachable", async ({ page }) => {

--- a/dashboard/src/components/agent-manager/PipelineVisualEditor.tsx
+++ b/dashboard/src/components/agent-manager/PipelineVisualEditor.tsx
@@ -67,6 +67,19 @@ interface PersistedFsmDraftStore {
   entries: Record<string, PersistedFsmDraftEntry>;
 }
 
+interface PersistedPipelineSnapshotEntry {
+  repo: string;
+  level: EditLevel;
+  agentId: string | null;
+  updatedAtMs: number;
+  snapshot: EditorSnapshot;
+}
+
+interface PersistedPipelineSnapshotStore {
+  version: 1;
+  entries: Record<string, PersistedPipelineSnapshotEntry>;
+}
+
 interface FsmEdgeBinding {
   event: string;
 }
@@ -192,6 +205,11 @@ const EMPTY_FSM_DRAFT_STORE: PersistedFsmDraftStore = {
   entries: {},
 };
 
+const EMPTY_PIPELINE_SNAPSHOT_STORE: PersistedPipelineSnapshotStore = {
+  version: 1,
+  entries: {},
+};
+
 const FSM_VIEWBOX = {
   width: 1100,
   height: 420,
@@ -224,6 +242,30 @@ const FSM_HOOK_OPTIONS = [
 
 function cloneStageDrafts(stages: StageDraft[]) {
   return stages.map((stage) => ({ ...stage }));
+}
+
+function clonePipelineStages(stages: PipelineStage[]) {
+  return stages.map((stage) => ({ ...stage }));
+}
+
+function cloneJsonValue<T>(value: T): T {
+  if (typeof value === "undefined") {
+    return value;
+  }
+  try {
+    return JSON.parse(JSON.stringify(value)) as T;
+  } catch {
+    return value;
+  }
+}
+
+function cloneEditorSnapshot(snapshot: EditorSnapshot): EditorSnapshot {
+  return {
+    pipeline: clonePipelineConfig(snapshot.pipeline),
+    layers: { ...snapshot.layers },
+    rawOverride: cloneJsonValue(snapshot.rawOverride),
+    repoStages: clonePipelineStages(snapshot.repoStages),
+  };
 }
 
 function normalizeSelection(selection: unknown): Selection {
@@ -288,6 +330,64 @@ function normalizePersistedFsmDraftStore(value: unknown): PersistedFsmDraftStore
 
   return {
     version: 2,
+    entries,
+  };
+}
+
+function normalizePersistedPipelineSnapshotStore(value: unknown): PersistedPipelineSnapshotStore {
+  if (!value || typeof value !== "object") {
+    return EMPTY_PIPELINE_SNAPSHOT_STORE;
+  }
+
+  const rawEntries =
+    "entries" in value && value.entries && typeof value.entries === "object"
+      ? (value.entries as Record<string, unknown>)
+      : {};
+  const entries: Record<string, PersistedPipelineSnapshotEntry> = {};
+
+  Object.entries(rawEntries).forEach(([scopeKey, entry]) => {
+    if (!entry || typeof entry !== "object") {
+      return;
+    }
+    const parsed = entry as Partial<PersistedPipelineSnapshotEntry>;
+    if (typeof parsed.repo !== "string" || (parsed.level !== "repo" && parsed.level !== "agent")) {
+      return;
+    }
+    const rawSnapshot = parsed.snapshot;
+    if (!rawSnapshot || typeof rawSnapshot !== "object") {
+      return;
+    }
+    const snapshot = rawSnapshot as Partial<EditorSnapshot>;
+    if (!snapshot.pipeline || typeof snapshot.pipeline !== "object") {
+      return;
+    }
+    if (!snapshot.layers || typeof snapshot.layers !== "object") {
+      return;
+    }
+    if (!Array.isArray(snapshot.repoStages)) {
+      return;
+    }
+
+    entries[scopeKey] = {
+      repo: parsed.repo,
+      level: parsed.level,
+      agentId: typeof parsed.agentId === "string" ? parsed.agentId : null,
+      updatedAtMs: typeof parsed.updatedAtMs === "number" ? parsed.updatedAtMs : 0,
+      snapshot: cloneEditorSnapshot({
+        pipeline: snapshot.pipeline as PipelineConfigFull,
+        layers: {
+          default: Boolean((snapshot.layers as EditorSnapshot["layers"]).default),
+          repo: Boolean((snapshot.layers as EditorSnapshot["layers"]).repo),
+          agent: Boolean((snapshot.layers as EditorSnapshot["layers"]).agent),
+        },
+        rawOverride: cloneJsonValue(snapshot.rawOverride),
+        repoStages: clonePipelineStages(snapshot.repoStages as PipelineStage[]),
+      }),
+    };
+  });
+
+  return {
+    version: 1,
     entries,
   };
 }
@@ -514,6 +614,11 @@ export default function PipelineVisualEditor({
     STORAGE_KEYS.fsmDraft,
     EMPTY_FSM_DRAFT_STORE,
   );
+  const [rawPersistedPipelineSnapshotStore, setPersistedPipelineSnapshotStore] =
+    useLocalStorage<PersistedPipelineSnapshotStore>(
+      STORAGE_KEYS.settingsPipelineVisualCache,
+      EMPTY_PIPELINE_SNAPSHOT_STORE,
+    );
 
   const svgRef = useRef<SVGSVGElement>(null);
   const persistedFsmDraftStore = useMemo(
@@ -521,6 +626,11 @@ export default function PipelineVisualEditor({
     [rawPersistedFsmDraftStore],
   );
   const persistedFsmDraftStoreRef = useRef(persistedFsmDraftStore);
+  const persistedPipelineSnapshotStore = useMemo(
+    () => normalizePersistedPipelineSnapshotStore(rawPersistedPipelineSnapshotStore),
+    [rawPersistedPipelineSnapshotStore],
+  );
+  const persistedPipelineSnapshotStoreRef = useRef(persistedPipelineSnapshotStore);
   const [dragConnect, setDragConnect] = useState<{
     fromId: string;
     fromCx: number;
@@ -529,14 +639,19 @@ export default function PipelineVisualEditor({
     cursorY: number;
     hoverId: string | null;
   } | null>(null);
-  const fsmDraftScopeKey = useMemo(
-    () => (repo ? buildFsmDraftScopeKey(repo, level, selectedAgentId) : null),
-    [level, repo, selectedAgentId],
+  const buildScopeKey = useCallback(
+    (nextLevel: EditLevel) => (repo ? buildFsmDraftScopeKey(repo, nextLevel, selectedAgentId) : null),
+    [repo, selectedAgentId],
   );
+  const fsmDraftScopeKey = useMemo(() => buildScopeKey(level), [buildScopeKey, level]);
 
   useEffect(() => {
     persistedFsmDraftStoreRef.current = persistedFsmDraftStore;
   }, [persistedFsmDraftStore]);
+
+  useEffect(() => {
+    persistedPipelineSnapshotStoreRef.current = persistedPipelineSnapshotStore;
+  }, [persistedPipelineSnapshotStore]);
 
   useEffect(() => {
     const updateLayoutMode = () => {
@@ -587,6 +702,22 @@ export default function PipelineVisualEditor({
       rawOverride: rawOverrideResponse.pipeline_config,
       repoStages,
     };
+  }
+
+  function resetEditorState() {
+    setPipelineDraft(null);
+    setSavedPipeline(null);
+    setLayers({
+      default: true,
+      repo: false,
+      agent: false,
+    });
+    setOverrideExtras({});
+    setOverrideExists(false);
+    setAllRepoStages([]);
+    setStageDrafts([]);
+    setSavedStageDrafts([]);
+    setSelection(null);
   }
 
   function applySnapshot(
@@ -654,19 +785,63 @@ export default function PipelineVisualEditor({
     });
   }
 
+  const persistSnapshot = useCallback((
+    scopeKey: string,
+    nextLevel: EditLevel,
+    snapshot: EditorSnapshot,
+  ) => {
+    if (!repo) {
+      return;
+    }
+
+    const nextEntry: PersistedPipelineSnapshotEntry = {
+      repo,
+      level: nextLevel,
+      agentId: selectedAgentId ?? null,
+      updatedAtMs: Date.now(),
+      snapshot: cloneEditorSnapshot(snapshot),
+    };
+
+    setPersistedPipelineSnapshotStore((currentStore) => {
+      const normalizedStore = normalizePersistedPipelineSnapshotStore(currentStore);
+      const currentEntry = normalizedStore.entries[scopeKey];
+      const currentSignature = currentEntry ? JSON.stringify(currentEntry) : null;
+      const nextSignature = JSON.stringify(nextEntry);
+      if (currentSignature === nextSignature) {
+        return normalizedStore;
+      }
+      return {
+        version: 1,
+        entries: {
+          ...normalizedStore.entries,
+          [scopeKey]: nextEntry,
+        },
+      };
+    });
+  }, [repo, selectedAgentId, setPersistedPipelineSnapshotStore]);
+
   useEffect(() => {
     if (!repo) {
-      setPipelineDraft(null);
-      setSavedPipeline(null);
-      setStageDrafts([]);
-      setSavedStageDrafts([]);
+      resetEditorState();
       setLoading(false);
       return;
     }
 
     let cancelled = false;
+    const persistedDraft = fsmDraftScopeKey
+      ? persistedFsmDraftStoreRef.current.entries[fsmDraftScopeKey] ?? null
+      : null;
+    const cachedSnapshot = fsmDraftScopeKey
+      ? persistedPipelineSnapshotStoreRef.current.entries[fsmDraftScopeKey]?.snapshot ?? null
+      : null;
+
     setLoading(true);
     setError(null);
+    if (cachedSnapshot) {
+      applySnapshot(cloneEditorSnapshot(cachedSnapshot), persistedDraft);
+    } else {
+      resetEditorState();
+    }
 
     void (async () => {
       try {
@@ -674,9 +849,9 @@ export default function PipelineVisualEditor({
         if (cancelled) {
           return;
         }
-        const persistedDraft = fsmDraftScopeKey
-          ? persistedFsmDraftStoreRef.current.entries[fsmDraftScopeKey] ?? null
-          : null;
+        if (fsmDraftScopeKey) {
+          persistSnapshot(fsmDraftScopeKey, level, snapshot);
+        }
         applySnapshot(snapshot, persistedDraft);
       } catch (cause) {
         if (!cancelled) {
@@ -696,7 +871,7 @@ export default function PipelineVisualEditor({
     return () => {
       cancelled = true;
     };
-  }, [fsmDraftScopeKey, level, reloadKey, repo, selectedAgentId]);
+  }, [fsmDraftScopeKey, level, persistSnapshot, reloadKey, repo, selectedAgentId]);
 
   const selectedAgentName = selectedAgentLabel(agents, locale, selectedAgentId);
   const useScrollableMobileFsmCanvas = isFsmVariant && compactGraph;
@@ -801,6 +976,20 @@ export default function PipelineVisualEditor({
     [pipelineDraft, selectedFsmEvent],
   );
   const selectedFsmHook = selectedFsmHooks[0] ?? "";
+  const fsmQuickTransitions = useMemo(
+    () =>
+      pipelineDraft?.transitions.map((transition, index) => {
+        const bindingKey = buildFsmEdgeBindingKey(transition.from, transition.to);
+        return {
+          ...transition,
+          index,
+          event:
+            fsmEdgeBindings[bindingKey]?.event
+            ?? inferFsmEventName(transition.from, transition.to),
+        };
+      }) ?? [],
+    [fsmEdgeBindings, pipelineDraft],
+  );
   const fsmEventOptions = useMemo(
     () =>
       Array.from(
@@ -841,10 +1030,10 @@ export default function PipelineVisualEditor({
   const graphPanelNote = isFsmVariant
     ? tr(
         useScrollableMobileFsmCanvas
-          ? "모바일은 축소 대신 가로 스크롤 가능한 전체 크기 캔버스를 사용하고, 패널은 아래로 떨어집니다."
+          ? "모바일은 편집 패널을 먼저 보여주고, FSM 캔버스는 아래에서 가로 스크롤 가능한 프리뷰로 유지합니다."
           : "FSM 캔버스는 1100×420 viewBox로 고정되고, 좁은 화면에서는 패널이 아래로 떨어집니다.",
         useScrollableMobileFsmCanvas
-          ? "Mobile keeps the FSM canvas at readable size with horizontal scroll, and drops the side panel below."
+          ? "Mobile leads with the editor panel, and keeps the FSM canvas below as a horizontally scrollable preview."
           : "The FSM canvas uses a fixed 1100×420 viewBox, and the side panel drops below on narrow screens.",
       )
     : tr(
@@ -1363,6 +1552,10 @@ export default function PipelineVisualEditor({
 
   async function refreshAfterMutation(nextLevel: EditLevel = level) {
     const snapshot = await fetchSnapshot(nextLevel);
+    const nextScopeKey = buildScopeKey(nextLevel);
+    if (nextScopeKey) {
+      persistSnapshot(nextScopeKey, nextLevel, snapshot);
+    }
     applySnapshot(snapshot);
   }
 
@@ -1825,15 +2018,47 @@ export default function PipelineVisualEditor({
         </div>
       )}
 
-      {loading || !pipelineDraft || !graph ? (
-        <div className="rounded-[24px] border px-4 py-8 text-sm text-center" style={EMPTY_PANEL_STYLE}>
-          {tr("비주얼 파이프라인을 불러오는 중…", "Loading visual pipeline…")}
+      {loading && pipelineDraft && graph && (
+        <div
+          data-testid="pipeline-refresh-indicator"
+          className="flex items-center gap-2 rounded-[20px] border px-3.5 py-2 text-xs sm:text-sm"
+          style={STATUS_INFO_STYLE}
+        >
+          <span
+            className="inline-block h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent"
+            aria-hidden="true"
+          />
+          <span>
+            {tr(
+              "마지막 성공값을 먼저 보여주고 최신 값을 불러오는 중입니다…",
+              "Showing the last successful pipeline while refreshing…",
+            )}
+          </span>
+        </div>
+      )}
+
+      {!pipelineDraft || !graph ? (
+        <div
+          className="rounded-[24px] border px-4 py-8 text-sm text-center"
+          style={error ? STATUS_ERROR_STYLE : EMPTY_PANEL_STYLE}
+        >
+          <div className="flex items-center justify-center gap-2">
+            {loading && (
+              <span
+                className="inline-block h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent"
+                aria-hidden="true"
+              />
+            )}
+            <span>
+              {error ?? tr("비주얼 파이프라인을 불러오는 중…", "Loading visual pipeline…")}
+            </span>
+          </div>
         </div>
       ) : (
         <>
           <div className={graphGridClass}>
             <div
-              className="min-w-0 rounded-[24px] border p-4 sm:p-5 space-y-4"
+              className={`min-w-0 rounded-[24px] border p-4 sm:p-5 space-y-4 ${useScrollableMobileFsmCanvas ? "order-2 xl:order-1" : ""}`}
               style={isFsmVariant ? FSM_PANEL_STYLE : PANEL_STYLE}
             >
               {!isFsmVariant && (
@@ -2308,18 +2533,169 @@ export default function PipelineVisualEditor({
             </div>
 
             <div
-              className="min-w-0 rounded-[24px] border p-4 sm:p-5 space-y-4"
+              className={`min-w-0 rounded-[24px] border p-4 sm:p-5 space-y-4 ${useScrollableMobileFsmCanvas ? "order-1 xl:order-2" : ""}`}
               style={isFsmVariant ? FSM_INSPECTOR_STYLE : PANEL_STYLE}
             >
+              {useScrollableMobileFsmCanvas && pipelineDraft && (
+                <div
+                  className="rounded-[20px] border p-3 space-y-4"
+                  style={FSM_DETAIL_PANEL_STYLE}
+                  data-testid="fsm-mobile-selector"
+                >
+                  <div className="space-y-1">
+                    <div
+                      className="text-[11px] font-semibold uppercase tracking-[0.18em]"
+                      style={{
+                        ...MUTED_TEXT_STYLE,
+                        fontFamily: "ui-monospace, SFMono-Regular, SF Mono, Menlo, monospace",
+                      }}
+                    >
+                      {tr("모바일 빠른 편집", "Mobile quick edit")}
+                    </div>
+                    <p className="text-xs leading-5" style={MUTED_TEXT_STYLE}>
+                      {tr(
+                        "모바일에서는 그래프를 직접 누르기보다 아래 목록에서 전환/상태를 고른 뒤 바로 편집합니다.",
+                        "On mobile, pick a transition or state from the list below instead of targeting the graph directly.",
+                      )}
+                    </p>
+                  </div>
+
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between gap-2">
+                      <h5 className="text-xs font-semibold uppercase tracking-wider" style={MUTED_TEXT_STYLE}>
+                        {tr("전환", "Transitions")}
+                      </h5>
+                      <span className="text-[11px]" style={MUTED_TEXT_STYLE}>
+                        {`${fsmQuickTransitions.length}`}
+                      </span>
+                    </div>
+                    <div className="grid gap-2">
+                      {fsmQuickTransitions.map((transition) => {
+                        const accent = transitionAccent(transition.type);
+                        const isSelected =
+                          selection?.kind === "transition" && selection.index === transition.index;
+                        return (
+                          <button
+                            key={`${transition.from}-${transition.to}-${transition.index}`}
+                            type="button"
+                            onClick={() => setSelection({ kind: "transition", index: transition.index })}
+                            aria-pressed={isSelected}
+                            data-testid={`fsm-mobile-transition-button-${transition.index}`}
+                            className="w-full rounded-[18px] border px-3 py-3 text-left transition-colors"
+                            style={
+                              isSelected
+                                ? {
+                                    borderColor:
+                                      "color-mix(in srgb, var(--th-accent-primary) 50%, var(--th-border) 50%)",
+                                    background:
+                                      "color-mix(in srgb, var(--th-accent-primary-soft) 84%, #11141b 16%)",
+                                    color: "var(--th-text-primary)",
+                                  }
+                                : {
+                                    borderColor:
+                                      "color-mix(in srgb, var(--th-border) 82%, transparent)",
+                                    background: "#11141b",
+                                    color: "var(--th-text-primary)",
+                                  }
+                            }
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <div>
+                                <div className="text-sm font-medium">
+                                  {transition.from} → {transition.to}
+                                </div>
+                                <div className="mt-1 text-[11px]" style={MUTED_TEXT_STYLE}>
+                                  {transition.event}
+                                </div>
+                              </div>
+                              <span
+                                className="rounded-md border px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.16em]"
+                                style={{
+                                  borderColor: accent.stroke,
+                                  background: accent.background,
+                                  color: accent.text,
+                                  fontFamily:
+                                    "ui-monospace, SFMono-Regular, SF Mono, Menlo, monospace",
+                                }}
+                              >
+                                {transition.type}
+                              </span>
+                            </div>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between gap-2">
+                      <h5 className="text-xs font-semibold uppercase tracking-wider" style={MUTED_TEXT_STYLE}>
+                        {tr("상태", "States")}
+                      </h5>
+                      <span className="text-[11px]" style={MUTED_TEXT_STYLE}>
+                        {`${pipelineDraft.states.length}`}
+                      </span>
+                    </div>
+                    <div className="grid grid-cols-2 gap-2">
+                      {pipelineDraft.states.map((state) => {
+                        const tone = fsmStateTone(state.id);
+                        const isSelected =
+                          selection?.kind === "state" && selection.stateId === state.id;
+                        return (
+                          <button
+                            key={state.id}
+                            type="button"
+                            onClick={() => setSelection({ kind: "state", stateId: state.id })}
+                            aria-pressed={isSelected}
+                            data-testid={`fsm-mobile-state-button-${state.id}`}
+                            className="rounded-[18px] border px-3 py-3 text-left transition-colors"
+                            style={
+                              isSelected
+                                ? {
+                                    borderColor: tone.stroke,
+                                    background: tone.glow,
+                                    color: "var(--th-text-primary)",
+                                  }
+                                : {
+                                    borderColor:
+                                      "color-mix(in srgb, var(--th-border) 82%, transparent)",
+                                    background: "#11141b",
+                                    color: "var(--th-text-primary)",
+                                  }
+                            }
+                          >
+                            <div className="text-sm font-medium">{state.label}</div>
+                            <div className="mt-1 text-[11px]" style={MUTED_TEXT_STYLE}>
+                              {state.id}
+                            </div>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </div>
+              )}
+
               <div className="flex flex-wrap items-center justify-between gap-2">
-                <h4 className="text-sm font-semibold" style={{ color: "var(--th-text-heading)" }}>
+                <h4
+                  className="text-sm font-semibold"
+                  style={{ color: "var(--th-text-heading)" }}
+                  data-testid="pipeline-selection-title"
+                >
                   {formatSelectionTitle(tr, selection, pipelineDraft)}
                 </h4>
-                {selection?.kind === "state" && (
+                {isFsmVariant && useScrollableMobileFsmCanvas ? (
+                  <span className="text-xs" style={MUTED_TEXT_STYLE}>
+                    {tr(
+                      "모바일은 위 목록으로 선택하고 이 패널에서 바로 수정합니다.",
+                      "Use the quick selector above, then edit here.",
+                    )}
+                  </span>
+                ) : selection?.kind === "state" ? (
                   <span className="text-xs" style={MUTED_TEXT_STYLE}>
                     {tr("노드 클릭으로 선택됨", "Selected from graph")}
                   </span>
-                )}
+                ) : null}
               </div>
 
               {selectedState && (
@@ -2947,7 +3323,7 @@ export default function PipelineVisualEditor({
                 </div>
               )}
 
-              {isFsmVariant && !selectedTransition && (
+              {isFsmVariant && !selectedTransition && !selectedState && (
                 <div
                   className="rounded-[20px] border px-4 py-6 text-sm"
                   style={{
@@ -2957,8 +3333,12 @@ export default function PipelineVisualEditor({
                   }}
                 >
                   {tr(
-                    "전환선을 선택하면 우측 280px 패널에서 event, hook, policy를 바로 편집할 수 있습니다.",
-                    "Select an edge to edit its event, hook, and policy in the 280px side panel.",
+                    useScrollableMobileFsmCanvas
+                      ? "모바일은 위 빠른 선택 목록에서 전환이나 상태를 고른 뒤 이 패널에서 event, hook, policy를 편집합니다."
+                      : "전환선을 선택하면 우측 280px 패널에서 event, hook, policy를 바로 편집할 수 있습니다.",
+                    useScrollableMobileFsmCanvas
+                      ? "On mobile, choose a transition or state from the quick selector above, then edit its event, hook, and policy here."
+                      : "Select an edge to edit its event, hook, and policy in the 280px side panel.",
                   )}
                 </div>
               )}

--- a/dashboard/src/lib/storageKeys.ts
+++ b/dashboard/src/lib/storageKeys.ts
@@ -17,6 +17,7 @@ export const STORAGE_KEYS = {
   settingsRuntimeCategory: "agentdesk.settings.runtime-category",
   settingsPipelineRepoCache: "agentdesk.settings.pipeline.repo-cache.v1",
   settingsPipelineAgentCache: "agentdesk.settings.pipeline.agent-cache.v1",
+  settingsPipelineVisualCache: "agentdesk.settings.pipeline.visual-cache.v1",
   onboardingDraft: "agentdesk.onboarding.draft.v1",
   meetingChannelId: "pcd_meeting_channel_id",
   meetingFixedParticipants: "pcd_meeting_fixed_participants",

--- a/src/services/discord/health.rs
+++ b/src/services/discord/health.rs
@@ -862,6 +862,7 @@ impl TestHealthHarness {
             api_timestamps: dashmap::DashMap::new(),
             skills_cache: tokio::sync::RwLock::new(Vec::new()),
             tmux_watchers: dashmap::DashMap::new(),
+            tmux_relay_coords: dashmap::DashMap::new(),
             recovering_channels: dashmap::DashMap::new(),
             shutting_down: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             finalizing_turns: Arc::new(std::sync::atomic::AtomicUsize::new(0)),

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -394,6 +394,47 @@ pub(super) struct TmuxWatcherHandle {
     /// Watcher checks this before relay to avoid duplicate messages.
     pub(super) turn_delivered: Arc<std::sync::atomic::AtomicBool>,
 }
+
+/// Per-channel coordination for watcher-to-Discord relay emission.
+///
+/// This state is **shared across watcher-handle replacements** (unlike
+/// `TmuxWatcherHandle`, which is recreated on `claim_or_replace_watcher`).
+/// Surviving replacement is the root-cause fix for duplicate terminal-response
+/// emission observed when an outgoing watcher and an incoming watcher both
+/// pass their per-instance dedupe guards and both send the same tmux range to
+/// Discord.
+///
+/// Scope: intra-process only. Persisted dedupe across dcserver restarts is
+/// still handled by `InflightTurnState::last_watcher_relayed_offset` in the
+/// inflight JSON.
+pub(super) struct TmuxRelayCoord {
+    /// Non-zero while some watcher instance is actively emitting a relay for
+    /// this channel. Holds the `data_start_offset` of the in-progress emission.
+    /// Acquired via `compare_exchange(0, offset)` — only one watcher can
+    /// hold the slot, so concurrent attempts from outgoing+incoming watchers
+    /// serialize rather than double-fire.
+    pub(super) relay_slot: Arc<std::sync::atomic::AtomicU64>,
+    /// End offset (exclusive) of the last relay this process has confirmed
+    /// delivery for. 0 = no confirmed delivery yet this process lifetime.
+    ///
+    /// Dedupe invariant: a new relay candidate with
+    /// `data_start_offset < confirmed_end_offset` overlaps an already-delivered
+    /// range and must be skipped. Using the END offset (not the start) lets a
+    /// legitimate new turn that starts exactly at the previous turn's end
+    /// still be emitted, which is the intentional strict-`<` semantic the
+    /// watcher already relies on for Claude Code's `task_notification`
+    /// auto-trigger boundary.
+    pub(super) confirmed_end_offset: Arc<std::sync::atomic::AtomicU64>,
+}
+
+impl TmuxRelayCoord {
+    pub(super) fn new() -> Self {
+        Self {
+            relay_slot: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            confirmed_end_offset: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        }
+    }
+}
 #[derive(Clone)]
 pub(super) struct ModelPickerPendingState {
     pub(super) owner_user_id: UserId,
@@ -424,6 +465,11 @@ pub(super) struct SharedData {
     pub(super) skills_cache: tokio::sync::RwLock<Vec<(String, String)>>,
     /// Per-channel tmux output watchers for terminal→Discord relay
     pub(super) tmux_watchers: dashmap::DashMap<ChannelId, TmuxWatcherHandle>,
+    /// Per-channel relay coordination state. Unlike `tmux_watchers`, this
+    /// entry is preserved across watcher-handle replacements so an outgoing
+    /// watcher and an incoming watcher share the same emission-slot atomic
+    /// and confirmed-offset watermark. See `TmuxRelayCoord`.
+    pub(super) tmux_relay_coords: dashmap::DashMap<ChannelId, Arc<TmuxRelayCoord>>,
     /// Per-channel in-flight turn recovery marker (restart resume in progress)
     /// Value is the Instant when recovery started, used for stale-recovery timeout.
     pub(super) recovering_channels: dashmap::DashMap<ChannelId, std::time::Instant>,
@@ -532,6 +578,17 @@ impl SharedData {
     fn health_registry(&self) -> Option<Arc<health::HealthRegistry>> {
         self.health_registry.upgrade()
     }
+
+    /// Fetch the per-channel relay coordination state, creating a fresh one
+    /// on first access. Returned Arc is shared across all watcher instances
+    /// (outgoing and incoming) for the channel, so they coordinate relay
+    /// emission without duplicate-sending the same tmux range.
+    pub(super) fn tmux_relay_coord(&self, channel_id: ChannelId) -> Arc<TmuxRelayCoord> {
+        self.tmux_relay_coords
+            .entry(channel_id)
+            .or_insert_with(|| Arc::new(TmuxRelayCoord::new()))
+            .clone()
+    }
 }
 
 #[cfg(test)]
@@ -554,6 +611,7 @@ pub(super) fn make_shared_data_for_tests_with_storage(
         api_timestamps: dashmap::DashMap::new(),
         skills_cache: tokio::sync::RwLock::new(Vec::new()),
         tmux_watchers: dashmap::DashMap::new(),
+        tmux_relay_coords: dashmap::DashMap::new(),
         recovering_channels: dashmap::DashMap::new(),
         shutting_down: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         finalizing_turns: Arc::new(std::sync::atomic::AtomicUsize::new(0)),

--- a/src/services/discord/runtime_bootstrap.rs
+++ b/src/services/discord/runtime_bootstrap.rs
@@ -537,6 +537,7 @@ pub(crate) async fn run_bot(token: &str, provider: ProviderKind, context: RunBot
         api_timestamps: dashmap::DashMap::new(),
         skills_cache: tokio::sync::RwLock::new(initial_skills),
         tmux_watchers: dashmap::DashMap::new(),
+        tmux_relay_coords: dashmap::DashMap::new(),
         recovering_channels: dashmap::DashMap::new(),
         shutting_down: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         finalizing_turns: Arc::new(std::sync::atomic::AtomicUsize::new(0)),

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -2308,6 +2308,80 @@ pub(super) async fn tmux_output_watcher(
             foreground_inflight_present,
         );
 
+        // Cross-watcher relay coordination (root-cause fix for duplicate
+        // terminal-response emission observed when `claim_or_replace_watcher`
+        // replaces a watcher mid-flight and both the outgoing and incoming
+        // instance pass their per-instance dedupe guards for the same tmux
+        // range). `TmuxRelayCoord` is shared across all watcher instances for
+        // the channel (survives handle replacement), so the two atomics below
+        // serialize concurrent emissions and carry the confirmed-delivery
+        // watermark between instances without touching disk.
+        //
+        // The local `last_relayed_offset` / `last_enqueued_offset` guard above
+        // is retained: it handles the single-instance cases (resume after
+        // pause, inflight-mirror-driven restart recovery) and makes per-tick
+        // dedupe cheap. The coord guard is the missing multi-instance layer.
+        let relay_coord = shared.tmux_relay_coord(channel_id);
+        let confirmed_end_pre_claim = relay_coord
+            .confirmed_end_offset
+            .load(std::sync::atomic::Ordering::Acquire);
+        // Strict `<` preserves the same "exact boundary = new turn" semantic
+        // the local dedupe above uses (see comment at line ~2125 about the
+        // `task_notification` auto-trigger writing its tmux output starting
+        // at the previous turn's end offset).
+        if confirmed_end_pre_claim != 0 && data_start_offset < confirmed_end_pre_claim {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            tracing::warn!(
+                "  [{ts}] 👁 Cross-watcher dedupe: skipped relay for {} (data_start={}, confirmed_end={})",
+                tmux_session_name,
+                data_start_offset,
+                confirmed_end_pre_claim
+            );
+            if let Some(msg_id) = placeholder_msg_id {
+                let _ = channel_id.delete_message(&http, msg_id).await;
+            }
+            continue;
+        }
+        // CAS the emission slot. `0` = free; any non-zero value = a watcher
+        // is mid-emission with that start offset. `.max(1)` guarantees the
+        // stored value is non-zero even when `data_start_offset == 0`.
+        let slot_claim_token = data_start_offset.max(1);
+        if relay_coord
+            .relay_slot
+            .compare_exchange(
+                0,
+                slot_claim_token,
+                std::sync::atomic::Ordering::AcqRel,
+                std::sync::atomic::Ordering::Acquire,
+            )
+            .is_err()
+        {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            tracing::warn!(
+                "  [{ts}] 👁 Cross-watcher serialization: slot busy, skipped relay for {} (data_start={})",
+                tmux_session_name,
+                data_start_offset
+            );
+            if let Some(msg_id) = placeholder_msg_id {
+                let _ = channel_id.delete_message(&http, msg_id).await;
+            }
+            continue;
+        }
+        // Re-check confirmed_end inside the slot in case another watcher
+        // advanced it between our first load and the CAS above.
+        let confirmed_end_in_slot = relay_coord
+            .confirmed_end_offset
+            .load(std::sync::atomic::Ordering::Acquire);
+        if confirmed_end_in_slot != 0 && data_start_offset < confirmed_end_in_slot {
+            relay_coord
+                .relay_slot
+                .store(0, std::sync::atomic::Ordering::Release);
+            if let Some(msg_id) = placeholder_msg_id {
+                let _ = channel_id.delete_message(&http, msg_id).await;
+            }
+            continue;
+        }
+
         // Send the terminal response to Discord
         // #225 P1-2: Track relay success across branches
         let relay_ok = if has_assistant_response {
@@ -2504,6 +2578,35 @@ pub(super) async fn tmux_output_watcher(
             false
         };
 
+        // Advance the shared confirmed-delivery watermark on any committed
+        // emission (direct send, notify enqueue, or empty-turn cleanup — all
+        // three represent "this tmux range is done" from the cross-watcher
+        // dedupe perspective). CAS loop ensures we only ever move the
+        // watermark FORWARD, even if some other instance has raced ahead.
+        if relay_ok {
+            let mut cur = relay_coord
+                .confirmed_end_offset
+                .load(std::sync::atomic::Ordering::Acquire);
+            while cur < current_offset {
+                match relay_coord.confirmed_end_offset.compare_exchange(
+                    cur,
+                    current_offset,
+                    std::sync::atomic::Ordering::AcqRel,
+                    std::sync::atomic::Ordering::Acquire,
+                ) {
+                    Ok(_) => break,
+                    Err(observed) => cur = observed,
+                }
+            }
+        }
+        // Release the emission slot regardless of success. If delivery failed
+        // the local `last_relayed_offset` also stayed put, so the same watcher
+        // (or its replacement) can retry on the next tick without fighting
+        // the slot.
+        relay_coord
+            .relay_slot
+            .store(0, std::sync::atomic::Ordering::Release);
+
         let provider_kind = watcher_provider.clone();
         let inflight_state = super::inflight::load_inflight_state(&provider_kind, channel_id.get());
         let watcher_session_id = state.last_session_id.clone();
@@ -2644,6 +2747,7 @@ pub(super) async fn tmux_output_watcher(
                         let mut work_completion_context =
                             super::turn_bridge::build_work_dispatch_completion_result(
                                 shared.db.as_ref(),
+                                shared.pg_pool.as_ref(),
                                 did,
                                 "watcher_completed",
                                 false,
@@ -2668,22 +2772,13 @@ pub(super) async fn tmux_output_watcher(
                                 tracing::info!(
                                     "  [{ts}] ✓ watcher: completed dispatch {did} via finalize_dispatch"
                                 );
-                                if let Some(pool) = shared.pg_pool.as_ref() {
-                                    if let Err(error) =
-                                        crate::server::routes::dispatches::queue_dispatch_followup_pg(
-                                            pool, did,
-                                        )
-                                        .await
-                                    {
-                                        tracing::warn!(
-                                            "  [{ts}] ⚠ watcher: failed to enqueue followup for {did}: {error}"
-                                        );
-                                    }
-                                } else {
-                                    crate::server::routes::dispatches::queue_dispatch_followup(
-                                        db, did,
-                                    );
-                                }
+                                let _ = super::turn_bridge::queue_dispatch_followup_with_handles(
+                                    Some(db),
+                                    shared.pg_pool.as_ref(),
+                                    did,
+                                    "watcher_completed",
+                                )
+                                .await;
                                 true
                             }
                             Err(e) => {
@@ -2694,6 +2789,7 @@ pub(super) async fn tmux_output_watcher(
                                 let mut fallback_result =
                                     super::turn_bridge::build_work_dispatch_completion_result(
                                         shared.db.as_ref(),
+                                        shared.pg_pool.as_ref(),
                                         did,
                                         "watcher_db_fallback",
                                         true,
@@ -2706,16 +2802,29 @@ pub(super) async fn tmux_output_watcher(
                                         serde_json::Value::Bool(true),
                                     );
                                 }
-                                super::turn_bridge::runtime_db_fallback_complete_with_result(
-                                    did,
-                                    &fallback_result,
-                                )
+                                let completed =
+                                    super::turn_bridge::runtime_db_fallback_complete_with_result(
+                                        did,
+                                        &fallback_result,
+                                    );
+                                if completed {
+                                    let _ =
+                                        super::turn_bridge::queue_dispatch_followup_with_handles(
+                                            shared.db.as_ref(),
+                                            shared.pg_pool.as_ref(),
+                                            did,
+                                            "watcher_completed_fallback",
+                                        )
+                                        .await;
+                                }
+                                completed
                             }
                         }
                     } else {
                         let mut fallback_result =
                             super::turn_bridge::build_work_dispatch_completion_result(
                                 shared.db.as_ref(),
+                                shared.pg_pool.as_ref(),
                                 did,
                                 "watcher_db_fallback",
                                 true,
@@ -2728,10 +2837,21 @@ pub(super) async fn tmux_output_watcher(
                                 serde_json::Value::Bool(true),
                             );
                         }
-                        super::turn_bridge::runtime_db_fallback_complete_with_result(
-                            did,
-                            &fallback_result,
-                        )
+                        let completed =
+                            super::turn_bridge::runtime_db_fallback_complete_with_result(
+                                did,
+                                &fallback_result,
+                            );
+                        if completed {
+                            let _ = super::turn_bridge::queue_dispatch_followup_with_handles(
+                                shared.db.as_ref(),
+                                shared.pg_pool.as_ref(),
+                                did,
+                                "watcher_completed_runtime_fallback",
+                            )
+                            .await;
+                        }
+                        completed
                     }
                 }
                 Some(_) => {


### PR DESCRIPTION
## Summary

- User가 adk-cdx / adk-dash-cdx 채널에서 본 **duplicate Discord 메시지 재현 증거 확정**
- 원인: `claim_or_replace_watcher`가 watcher를 교체할 때 **outgoing + incoming watcher가 같은 tmux range를 둘 다 emit하는 race**
- 기존 per-instance dedupe(로컬 \`last_relayed_offset\` + inflight mirror)는 두 instance 간 조율이 불가능 — 각자 자기 사본만 본다
- Fix: watcher-handle 교체에 **survive하는** per-channel 공유 조율 객체(\`TmuxRelayCoord\`) 도입 + CAS-based emission slot

## 재현 증거 (release log)

\`~/.adk/release/logs/dcserver.stdout.log\`:

\`\`\`
2026-04-21T21:41:58.313Z 👁 Relaying terminal response to Discord (1619 chars, offset 6890054, notify=false)
2026-04-21T21:41:58.377Z 👁 Relaying terminal response to Discord (1619 chars, offset 6890054, notify=false)  ← 64ms 뒤 동일 재발

2026-04-22T00:28:19.149Z 👁 Relaying terminal response to Discord (712 chars, offset 365083, notify=false)
2026-04-22T00:28:19.245Z 👁 Relaying terminal response to Discord (712 chars, offset 365083, notify=false)  ← 96ms 뒤 동일 재발
\`\`\`

둘 다 foreground (\`notify=false\`) 경로 → 실제 Discord에 메시지 2번 도착.

## 근본 원인

\`claim_or_replace_watcher\` (tmux.rs:1124) 동작:
1. Outgoing watcher의 \`cancel=true\` 세팅
2. DashMap entry를 new handle로 교체
3. return

Cancel flag은 **cooperative** — outgoing watcher는 main loop 상단에서만 체크. Emission 직전에는 재체크 없음.

Meanwhile incoming watcher는 init에서 inflight JSON의 \`last_watcher_relayed_offset\`을 읽음. Outgoing watcher가 아직 persist 안 한 상태 (persist는 emission 후)면 stale watermark를 봐서 자기 로컬 dedupe guard 통과.

결과: 둘 다 emit → Discord에 중복 전송.

## 수정 내용

### 새 공유 조율 객체 \`TmuxRelayCoord\`

\`SharedData.tmux_relay_coords: DashMap<ChannelId, Arc<TmuxRelayCoord>>\`에 per-channel 보관. Watcher handle 교체에 무관하게 살아남음.

두 atomic:
- \`relay_slot: AtomicU64\` — CAS-based emission slot (0=free). Outgoing + incoming watcher 동시 emission 시도가 직렬화됨
- \`confirmed_end_offset: AtomicU64\` — 이 프로세스 lifetime 동안 **confirmed delivery**의 마지막 offset. Strict \`<\` 비교로 기존 \"exact boundary = new turn\" semantic (task_notification auto-trigger) 보존

### Watcher emission 흐름

\`\`\`rust
// 1. 첫 번째 dedupe 체크 (다른 instance가 이미 deliver했으면 skip)
let confirmed_end = coord.confirmed_end_offset.load(Acquire);
if confirmed_end != 0 && data_start_offset < confirmed_end { continue; }

// 2. CAS로 slot 획득 (다른 watcher가 busy면 skip)
if coord.relay_slot.compare_exchange(0, data_start_offset.max(1), AcqRel, Acquire).is_err() {
    continue;
}

// 3. Slot 안에서 confirmed_end 재확인 (race against just-finished instance)
if confirmed_end_in_slot != 0 && data_start_offset < confirmed_end_in_slot {
    coord.relay_slot.store(0, Release);
    continue;
}

// ... emission ...

// 4. Delivery 성공 시 confirmed_end 전진 (CAS loop, monotonic)
if relay_ok {
    // CAS loop advancing confirmed_end_offset to current_offset
}
coord.relay_slot.store(0, Release);
\`\`\`

### 유지되는 기존 dedupe

- Local \`last_relayed_offset\`, \`last_enqueued_offset\`: 단일 instance 내 dedupe (per-tick cheap)
- Inflight JSON의 \`last_watcher_relayed_offset\`: **dcserver restart** 간 recovery (coord는 process lifetime only)

두 layer는 보완적: 로컬은 single-instance case, coord는 multi-instance race 방지.

## Test plan

- [x] 30 tmux 모듈 테스트 통과
- [x] 77 turn_bridge 테스트 통과
- [x] 617 discord 모듈 전체 테스트 통과
- [ ] release 배포 후 \`\"Relaying terminal response\"\` 이중 발화 사라졌는지 24시간 모니터
- [ ] \`\"Cross-watcher dedupe\"\` / \`\"Cross-watcher serialization\"\` 로그가 실제로 찍히는지 확인 (coord가 작동하는지 가시화)

## 관련 이슈

- 폐기된 #901 (cross-channel watcher binding) — span leak 오진. #902에서 해결됨
- 실제 duplicate 버그는 이 PR에서 근본 해결

🤖 Generated with [Claude Code](https://claude.com/claude-code)