### PR TITLE
refine(qwen): address stream watchdog review feedback

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -99,7 +99,7 @@
 | `engine::ops::runtime_ops` | `src/engine/ops/runtime_ops.rs` | 260 |  |
 | `engine::sql_guard` | `src/engine/sql_guard.rs` | 230 |  |
 | `engine::transition` | `src/engine/transition.rs` | 1618 | giant-file |
-| `engine::transition_executor_pg` | `src/engine/transition_executor_pg.rs` | 662 |  |
+| `engine::transition_executor_pg` | `src/engine/transition_executor_pg.rs` | 690 |  |
 | `error` | `src/error.rs` | 188 |  |
 | `github` | `src/github/mod.rs` | 833 |  |
 | `github::dod` | `src/github/dod.rs` | 395 |  |
@@ -136,7 +136,7 @@
 | `server::routes::dispatches` | `src/server/routes/dispatches/mod.rs` | 102 |  |
 | `server::routes::dispatches::crud` | `src/server/routes/dispatches/crud.rs` | 97 |  |
 | `server::routes::dispatches::discord_delivery` | `src/server/routes/dispatches/discord_delivery.rs` | 5433 | giant-file |
-| `server::routes::dispatches::outbox` | `src/server/routes/dispatches/outbox.rs` | 2478 | giant-file |
+| `server::routes::dispatches::outbox` | `src/server/routes/dispatches/outbox.rs` | 2481 | giant-file |
 | `server::routes::dispatches::thread_reuse` | `src/server/routes/dispatches/thread_reuse.rs` | 1235 | giant-file |
 | `server::routes::dm_reply` | `src/server/routes/dm_reply.rs` | 61 |  |
 | `server::routes::docs` | `src/server/routes/docs.rs` | 2259 | giant-file |
@@ -169,7 +169,7 @@
 | `server::routes::review_verdict::review_state_repo` | `src/server/routes/review_verdict/review_state_repo.rs` | 22 |  |
 | `server::routes::review_verdict::tuning_aggregate` | `src/server/routes/review_verdict/tuning_aggregate.rs` | 893 |  |
 | `server::routes::review_verdict::verdict_route` | `src/server/routes/review_verdict/verdict_route.rs` | 577 |  |
-| `server::routes::reviews` | `src/server/routes/reviews.rs` | 645 |  |
+| `server::routes::reviews` | `src/server/routes/reviews.rs` | 648 |  |
 | `server::routes::session_activity` | `src/server/routes/session_activity.rs` | 371 |  |
 | `server::routes::settings` | `src/server/routes/settings.rs` | 1126 | giant-file |
 | `server::routes::skill_usage_analytics` | `src/server/routes/skill_usage_analytics.rs` | 512 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -99,7 +99,7 @@
 | `engine::ops::runtime_ops` | `src/engine/ops/runtime_ops.rs` | 260 |  |
 | `engine::sql_guard` | `src/engine/sql_guard.rs` | 230 |  |
 | `engine::transition` | `src/engine/transition.rs` | 1618 | giant-file |
-| `engine::transition_executor_pg` | `src/engine/transition_executor_pg.rs` | 687 |  |
+| `engine::transition_executor_pg` | `src/engine/transition_executor_pg.rs` | 690 |  |
 | `error` | `src/error.rs` | 188 |  |
 | `github` | `src/github/mod.rs` | 833 |  |
 | `github::dod` | `src/github/dod.rs` | 395 |  |
@@ -136,7 +136,7 @@
 | `server::routes::dispatches` | `src/server/routes/dispatches/mod.rs` | 102 |  |
 | `server::routes::dispatches::crud` | `src/server/routes/dispatches/crud.rs` | 97 |  |
 | `server::routes::dispatches::discord_delivery` | `src/server/routes/dispatches/discord_delivery.rs` | 5433 | giant-file |
-| `server::routes::dispatches::outbox` | `src/server/routes/dispatches/outbox.rs` | 2478 | giant-file |
+| `server::routes::dispatches::outbox` | `src/server/routes/dispatches/outbox.rs` | 2481 | giant-file |
 | `server::routes::dispatches::thread_reuse` | `src/server/routes/dispatches/thread_reuse.rs` | 1235 | giant-file |
 | `server::routes::dm_reply` | `src/server/routes/dm_reply.rs` | 61 |  |
 | `server::routes::docs` | `src/server/routes/docs.rs` | 2259 | giant-file |
@@ -169,7 +169,7 @@
 | `server::routes::review_verdict::review_state_repo` | `src/server/routes/review_verdict/review_state_repo.rs` | 22 |  |
 | `server::routes::review_verdict::tuning_aggregate` | `src/server/routes/review_verdict/tuning_aggregate.rs` | 893 |  |
 | `server::routes::review_verdict::verdict_route` | `src/server/routes/review_verdict/verdict_route.rs` | 577 |  |
-| `server::routes::reviews` | `src/server/routes/reviews.rs` | 645 |  |
+| `server::routes::reviews` | `src/server/routes/reviews.rs` | 648 |  |
 | `server::routes::session_activity` | `src/server/routes/session_activity.rs` | 371 |  |
 | `server::routes::settings` | `src/server/routes/settings.rs` | 1126 | giant-file |
 | `server::routes::skill_usage_analytics` | `src/server/routes/skill_usage_analytics.rs` | 512 |  |
@@ -281,7 +281,7 @@
 | `services::provider_runtime` | `src/services/provider_runtime.rs` | 122 |  |
 | `services::queue` | `src/services/queue.rs` | 247 |  |
 | `services::qwen` | `src/services/qwen.rs` | 2446 | giant-file |
-| `services::qwen_tmux_wrapper` | `src/services/qwen_tmux_wrapper.rs` | 1138 | giant-file |
+| `services::qwen_tmux_wrapper` | `src/services/qwen_tmux_wrapper.rs` | 1176 | giant-file |
 | `services::remote_stub` | `src/services/remote_stub.rs` | 45 |  |
 | `services::retrospectives` | `src/services/retrospectives.rs` | 1160 | giant-file |
 | `services::service_error` | `src/services/service_error.rs` | 1 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -64,7 +64,7 @@
 | `db::auto_queue` | `src/db/auto_queue.rs` | 6147 | giant-file |
 | `db::kanban` | `src/db/kanban.rs` | 165 |  |
 | `db::memento_feedback_stats` | `src/db/memento_feedback_stats.rs` | 255 |  |
-| `db::postgres` | `src/db/postgres.rs` | 844 |  |
+| `db::postgres` | `src/db/postgres.rs` | 852 |  |
 | `db::schema` | `src/db/schema.rs` | 2892 | giant-file |
 | `db::session_agent_resolution` | `src/db/session_agent_resolution.rs` | 485 |  |
 | `db::session_transcripts` | `src/db/session_transcripts.rs` | 1246 | giant-file |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -99,7 +99,7 @@
 | `engine::ops::runtime_ops` | `src/engine/ops/runtime_ops.rs` | 260 |  |
 | `engine::sql_guard` | `src/engine/sql_guard.rs` | 230 |  |
 | `engine::transition` | `src/engine/transition.rs` | 1618 | giant-file |
-| `engine::transition_executor_pg` | `src/engine/transition_executor_pg.rs` | 690 |  |
+| `engine::transition_executor_pg` | `src/engine/transition_executor_pg.rs` | 687 |  |
 | `error` | `src/error.rs` | 188 |  |
 | `github` | `src/github/mod.rs` | 833 |  |
 | `github::dod` | `src/github/dod.rs` | 395 |  |
@@ -136,7 +136,7 @@
 | `server::routes::dispatches` | `src/server/routes/dispatches/mod.rs` | 102 |  |
 | `server::routes::dispatches::crud` | `src/server/routes/dispatches/crud.rs` | 97 |  |
 | `server::routes::dispatches::discord_delivery` | `src/server/routes/dispatches/discord_delivery.rs` | 5433 | giant-file |
-| `server::routes::dispatches::outbox` | `src/server/routes/dispatches/outbox.rs` | 2481 | giant-file |
+| `server::routes::dispatches::outbox` | `src/server/routes/dispatches/outbox.rs` | 2478 | giant-file |
 | `server::routes::dispatches::thread_reuse` | `src/server/routes/dispatches/thread_reuse.rs` | 1235 | giant-file |
 | `server::routes::dm_reply` | `src/server/routes/dm_reply.rs` | 61 |  |
 | `server::routes::docs` | `src/server/routes/docs.rs` | 2259 | giant-file |
@@ -169,7 +169,7 @@
 | `server::routes::review_verdict::review_state_repo` | `src/server/routes/review_verdict/review_state_repo.rs` | 22 |  |
 | `server::routes::review_verdict::tuning_aggregate` | `src/server/routes/review_verdict/tuning_aggregate.rs` | 893 |  |
 | `server::routes::review_verdict::verdict_route` | `src/server/routes/review_verdict/verdict_route.rs` | 577 |  |
-| `server::routes::reviews` | `src/server/routes/reviews.rs` | 648 |  |
+| `server::routes::reviews` | `src/server/routes/reviews.rs` | 645 |  |
 | `server::routes::session_activity` | `src/server/routes/session_activity.rs` | 371 |  |
 | `server::routes::settings` | `src/server/routes/settings.rs` | 1126 | giant-file |
 | `server::routes::skill_usage_analytics` | `src/server/routes/skill_usage_analytics.rs` | 512 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -280,8 +280,8 @@
 | `services::provider_exec` | `src/services/provider_exec.rs` | 357 |  |
 | `services::provider_runtime` | `src/services/provider_runtime.rs` | 122 |  |
 | `services::queue` | `src/services/queue.rs` | 247 |  |
-| `services::qwen` | `src/services/qwen.rs` | 2233 | giant-file |
-| `services::qwen_tmux_wrapper` | `src/services/qwen_tmux_wrapper.rs` | 1047 | giant-file |
+| `services::qwen` | `src/services/qwen.rs` | 2446 | giant-file |
+| `services::qwen_tmux_wrapper` | `src/services/qwen_tmux_wrapper.rs` | 1138 | giant-file |
 | `services::remote_stub` | `src/services/remote_stub.rs` | 45 |  |
 | `services::retrospectives` | `src/services/retrospectives.rs` | 1160 | giant-file |
 | `services::service_error` | `src/services/service_error.rs` | 1 |  |

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -1,19 +1,11 @@
 use std::collections::BTreeSet;
 use std::str::FromStr;
-#[cfg(test)]
-use std::sync::Arc;
-#[cfg(test)]
-use std::sync::OnceLock;
 use std::time::Duration;
 
 use sqlx::migrate::Migrator;
 use sqlx::pool::PoolConnection;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
-#[cfg(test)]
-use sqlx::{Connection, PgConnection};
 use sqlx::{PgPool, Postgres, Row};
-#[cfg(test)]
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::config::{AgentChannel, AgentDef, Config};
 use crate::server::routes::settings::{KvSeedAction, config_default_seed_actions};
@@ -343,31 +335,42 @@ fn database_url_override() -> Option<String> {
 #[cfg(test)]
 const TEST_POSTGRES_OP_TIMEOUT: Duration = Duration::from_secs(15);
 #[cfg(test)]
-const TEST_POSTGRES_POOL_MAX: u32 = 2;
+const TEST_POSTGRES_POOL_MAX_CONNECTIONS: u32 = 1;
 #[cfg(test)]
-const TEST_POSTGRES_SETUP_CONCURRENCY: usize = 4;
+const TEST_POSTGRES_ADMIN_POOL_MAX_CONNECTIONS: u32 = 1;
+#[cfg(test)]
+static POSTGRES_TEST_SETUP_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> =
+    std::sync::OnceLock::new();
+#[cfg(test)]
+static POSTGRES_TEST_LIFECYCLE_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> =
+    std::sync::OnceLock::new();
 
 #[cfg(test)]
-fn test_postgres_setup_semaphore() -> &'static Arc<Semaphore> {
-    static TEST_POSTGRES_SETUP_SEMAPHORE: OnceLock<Arc<Semaphore>> = OnceLock::new();
-    TEST_POSTGRES_SETUP_SEMAPHORE
-        .get_or_init(|| Arc::new(Semaphore::new(TEST_POSTGRES_SETUP_CONCURRENCY)))
+fn lock_test_setup() -> std::sync::MutexGuard<'static, ()> {
+    let mutex = POSTGRES_TEST_SETUP_LOCK.get_or_init(|| std::sync::Mutex::new(()));
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 #[cfg(test)]
-async fn acquire_test_postgres_setup_slot(label: &str) -> Result<OwnedSemaphorePermit, String> {
-    tokio::time::timeout(
-        TEST_POSTGRES_OP_TIMEOUT,
-        test_postgres_setup_semaphore().clone().acquire_owned(),
-    )
-    .await
-    .map_err(|_| {
-        format!(
-            "{label} wait for postgres test setup slot timed out after {}s",
-            TEST_POSTGRES_OP_TIMEOUT.as_secs()
-        )
-    })?
-    .map_err(|error| format!("{label} acquire postgres test setup slot: {error}"))
+fn lock_test_lifecycle_raw() -> std::sync::MutexGuard<'static, ()> {
+    let mutex = POSTGRES_TEST_LIFECYCLE_LOCK.get_or_init(|| std::sync::Mutex::new(()));
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+#[cfg(test)]
+pub(crate) struct PostgresTestLifecycleGuard {
+    _guard: std::sync::MutexGuard<'static, ()>,
+}
+
+#[cfg(test)]
+pub(crate) fn lock_test_lifecycle() -> PostgresTestLifecycleGuard {
+    PostgresTestLifecycleGuard {
+        _guard: lock_test_lifecycle_raw(),
+    }
 }
 
 #[cfg(test)]
@@ -394,28 +397,30 @@ where
 }
 
 #[cfg(test)]
-async fn connect_test_connection(database_url: &str, label: &str) -> Result<PgConnection, String> {
+async fn connect_test_pool_with_max_connections(
+    database_url: &str,
+    label: &str,
+    max_connections: u32,
+) -> Result<PgPool, String> {
+    let options = PgConnectOptions::from_str(database_url)
+        .map_err(|error| format!("{label} parse postgres url: {error}"))?;
     run_test_postgres_sqlx_op(
         &format!("{label} connect postgres"),
-        PgConnection::connect(database_url),
+        PgPoolOptions::new()
+            .max_connections(max_connections.max(1))
+            .acquire_timeout(TEST_POSTGRES_OP_TIMEOUT)
+            .connect_with(options),
     )
     .await
 }
 
 #[cfg(test)]
 pub(crate) async fn connect_test_pool(database_url: &str, label: &str) -> Result<PgPool, String> {
-    let options = PgConnectOptions::from_str(database_url)
-        .map_err(|error| format!("{label} parse postgres url: {error}"))?;
-    run_test_postgres_sqlx_op(
-        &format!("{label} connect postgres"),
-        PgPoolOptions::new()
-            // CI runs many PostgreSQL-backed tests in parallel; keeping the
-            // per-test pool lean prevents transient pool starvation.
-            .max_connections(TEST_POSTGRES_POOL_MAX)
-            .acquire_timeout(TEST_POSTGRES_OP_TIMEOUT)
-            .connect_with(options),
-    )
-    .await
+    // Test helpers frequently create many isolated pools in parallel on CI.
+    // Keep the default test pool lean so PG-backed route tests do not exhaust
+    // the shared runner database just by setting up fixtures.
+    connect_test_pool_with_max_connections(database_url, label, TEST_POSTGRES_POOL_MAX_CONNECTIONS)
+        .await
 }
 
 #[cfg(test)]
@@ -424,18 +429,22 @@ pub(crate) async fn create_test_database(
     database_name: &str,
     label: &str,
 ) -> Result<(), String> {
-    let _setup_slot = acquire_test_postgres_setup_slot(label).await?;
-    let mut admin_conn = connect_test_connection(admin_url, &format!("{label} admin")).await?;
+    // CI failures were caused by many PG-backed tests racing to create/drop
+    // isolated databases at the same time. Serialize setup/teardown at the
+    // shared helper boundary so every test module benefits from the guard.
+    let _guard = lock_test_setup();
+    let admin_pool = connect_test_pool_with_max_connections(
+        admin_url,
+        &format!("{label} admin"),
+        TEST_POSTGRES_ADMIN_POOL_MAX_CONNECTIONS,
+    )
+    .await?;
     run_test_postgres_sqlx_op(
         &format!("{label} create postgres test db {database_name}"),
-        sqlx::query(&format!("CREATE DATABASE \"{database_name}\"")).execute(&mut admin_conn),
+        sqlx::query(&format!("CREATE DATABASE \"{database_name}\"")).execute(&admin_pool),
     )
     .await?;
-    run_test_postgres_sqlx_op(
-        &format!("{label} admin close postgres connection"),
-        admin_conn.close(),
-    )
-    .await?;
+    close_test_pool(admin_pool, &format!("{label} admin")).await?;
     Ok(())
 }
 
@@ -444,7 +453,6 @@ pub(crate) async fn connect_test_pool_and_migrate(
     database_url: &str,
     label: &str,
 ) -> Result<PgPool, String> {
-    let _setup_slot = acquire_test_postgres_setup_slot(label).await?;
     let pool = connect_test_pool(database_url, label).await?;
     tokio::time::timeout(TEST_POSTGRES_OP_TIMEOUT, migrate(&pool))
         .await
@@ -463,8 +471,13 @@ pub(crate) async fn drop_test_database(
     database_name: &str,
     label: &str,
 ) -> Result<(), String> {
-    let _setup_slot = acquire_test_postgres_setup_slot(label).await?;
-    let mut admin_conn = connect_test_connection(admin_url, &format!("{label} admin")).await?;
+    let _guard = lock_test_setup();
+    let admin_pool = connect_test_pool_with_max_connections(
+        admin_url,
+        &format!("{label} admin"),
+        TEST_POSTGRES_ADMIN_POOL_MAX_CONNECTIONS,
+    )
+    .await?;
     run_test_postgres_sqlx_op(
         &format!("{label} terminate postgres test db sessions {database_name}"),
         sqlx::query(
@@ -474,20 +487,15 @@ pub(crate) async fn drop_test_database(
                AND pid <> pg_backend_pid()",
         )
         .bind(database_name)
-        .execute(&mut admin_conn),
+        .execute(&admin_pool),
     )
     .await?;
     run_test_postgres_sqlx_op(
         &format!("{label} drop postgres test db {database_name}"),
-        sqlx::query(&format!("DROP DATABASE IF EXISTS \"{database_name}\""))
-            .execute(&mut admin_conn),
+        sqlx::query(&format!("DROP DATABASE IF EXISTS \"{database_name}\"")).execute(&admin_pool),
     )
     .await?;
-    run_test_postgres_sqlx_op(
-        &format!("{label} admin close postgres connection"),
-        admin_conn.close(),
-    )
-    .await?;
+    close_test_pool(admin_pool, &format!("{label} admin")).await?;
     Ok(())
 }
 

--- a/src/engine/transition_executor_pg.rs
+++ b/src/engine/transition_executor_pg.rs
@@ -211,13 +211,41 @@ mod tests {
     use std::collections::HashMap;
 
     struct TestDatabase {
+        _lock: crate::db::postgres::PostgresTestLifecycleGuard,
         admin_url: String,
         database_name: String,
         database_url: String,
     }
 
+    async fn connect_test_pool(database_url: &str, max_connections: u32, context: &str) -> PgPool {
+        let mut last_error = None;
+
+        for attempt in 1..=3 {
+            match sqlx::postgres::PgPoolOptions::new()
+                .max_connections(max_connections)
+                .acquire_timeout(std::time::Duration::from_secs(30))
+                .connect(database_url)
+                .await
+            {
+                Ok(pool) => return pool,
+                Err(error) => {
+                    last_error = Some(error);
+                    if attempt < 3 {
+                        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                    }
+                }
+            }
+        }
+
+        panic!(
+            "{context} after retries: {}",
+            last_error.expect("postgres pool connect should capture final error")
+        );
+    }
+
     impl TestDatabase {
         async fn create() -> Self {
+            let lock = crate::db::postgres::lock_test_lifecycle();
             let admin_url = admin_database_url();
             let database_name = format!("agentdesk_pg_{}", uuid::Uuid::new_v4().simple());
             let database_url = format!("{}/{}", base_database_url(), database_name);
@@ -230,6 +258,7 @@ mod tests {
             .expect("create postgres test db");
 
             Self {
+                _lock: lock,
                 admin_url,
                 database_name,
                 database_url,
@@ -237,12 +266,11 @@ mod tests {
         }
 
         async fn migrate(&self) -> PgPool {
-            crate::db::postgres::connect_test_pool_and_migrate(
-                &self.database_url,
-                "transition executor pg tests",
-            )
-            .await
-            .expect("migrate postgres test db")
+            let pool = connect_test_pool(&self.database_url, 1, "connect postgres test db").await;
+            crate::db::postgres::migrate(&pool)
+                .await
+                .expect("migrate postgres test db");
+            pool
         }
 
         async fn drop(self) {

--- a/src/engine/transition_executor_pg.rs
+++ b/src/engine/transition_executor_pg.rs
@@ -211,6 +211,7 @@ mod tests {
     use std::collections::HashMap;
 
     struct TestDatabase {
+        _lock: crate::db::postgres::PostgresTestLifecycleGuard,
         admin_url: String,
         database_name: String,
         database_url: String,
@@ -244,6 +245,7 @@ mod tests {
 
     impl TestDatabase {
         async fn create() -> Self {
+            let lock = crate::db::postgres::lock_test_lifecycle();
             let admin_url = admin_database_url();
             let database_name = format!("agentdesk_pg_{}", uuid::Uuid::new_v4().simple());
             let database_url = format!("{}/{}", base_database_url(), database_name);
@@ -256,6 +258,7 @@ mod tests {
             .expect("create postgres test db");
 
             Self {
+                _lock: lock,
                 admin_url,
                 database_name,
                 database_url,

--- a/src/engine/transition_executor_pg.rs
+++ b/src/engine/transition_executor_pg.rs
@@ -211,7 +211,6 @@ mod tests {
     use std::collections::HashMap;
 
     struct TestDatabase {
-        _lock: crate::db::postgres::PostgresTestLifecycleGuard,
         admin_url: String,
         database_name: String,
         database_url: String,
@@ -245,7 +244,6 @@ mod tests {
 
     impl TestDatabase {
         async fn create() -> Self {
-            let lock = crate::db::postgres::lock_test_lifecycle();
             let admin_url = admin_database_url();
             let database_name = format!("agentdesk_pg_{}", uuid::Uuid::new_v4().simple());
             let database_url = format!("{}/{}", base_database_url(), database_name);
@@ -258,7 +256,6 @@ mod tests {
             .expect("create postgres test db");
 
             Self {
-                _lock: lock,
                 admin_url,
                 database_name,
                 database_url,

--- a/src/server/routes/dispatches/outbox.rs
+++ b/src/server/routes/dispatches/outbox.rs
@@ -1803,6 +1803,7 @@ mod tests {
     }
 
     struct TestPostgresDb {
+        _lock: crate::db::postgres::PostgresTestLifecycleGuard,
         admin_url: String,
         database_name: String,
         database_url: String,
@@ -1810,6 +1811,7 @@ mod tests {
 
     impl TestPostgresDb {
         async fn create() -> Self {
+            let lock = crate::db::postgres::lock_test_lifecycle();
             let admin_url = postgres_admin_database_url();
             let database_name = format!(
                 "agentdesk_dispatch_outbox_{}",
@@ -1825,6 +1827,7 @@ mod tests {
             .unwrap();
 
             Self {
+                _lock: lock,
                 admin_url,
                 database_name,
                 database_url,

--- a/src/server/routes/dispatches/outbox.rs
+++ b/src/server/routes/dispatches/outbox.rs
@@ -1803,7 +1803,6 @@ mod tests {
     }
 
     struct TestPostgresDb {
-        _lock: crate::db::postgres::PostgresTestLifecycleGuard,
         admin_url: String,
         database_name: String,
         database_url: String,
@@ -1811,7 +1810,6 @@ mod tests {
 
     impl TestPostgresDb {
         async fn create() -> Self {
-            let lock = crate::db::postgres::lock_test_lifecycle();
             let admin_url = postgres_admin_database_url();
             let database_name = format!(
                 "agentdesk_dispatch_outbox_{}",
@@ -1827,7 +1825,6 @@ mod tests {
             .unwrap();
 
             Self {
-                _lock: lock,
                 admin_url,
                 database_name,
                 database_url,

--- a/src/server/routes/reviews.rs
+++ b/src/server/routes/reviews.rs
@@ -366,6 +366,7 @@ mod tests {
     }
 
     struct TestPostgresDb {
+        _lock: crate::db::postgres::PostgresTestLifecycleGuard,
         admin_url: String,
         database_name: String,
         database_url: String,
@@ -373,6 +374,7 @@ mod tests {
 
     impl TestPostgresDb {
         async fn create() -> Self {
+            let lock = crate::db::postgres::lock_test_lifecycle();
             let admin_url = postgres_admin_database_url();
             let database_name = format!("agentdesk_reviews_{}", uuid::Uuid::new_v4().simple());
             let database_url = format!("{}/{}", postgres_base_database_url(), database_name);
@@ -380,6 +382,7 @@ mod tests {
                 .await
                 .unwrap();
             Self {
+                _lock: lock,
                 admin_url,
                 database_name,
                 database_url,

--- a/src/server/routes/reviews.rs
+++ b/src/server/routes/reviews.rs
@@ -366,7 +366,6 @@ mod tests {
     }
 
     struct TestPostgresDb {
-        _lock: crate::db::postgres::PostgresTestLifecycleGuard,
         admin_url: String,
         database_name: String,
         database_url: String,
@@ -374,7 +373,6 @@ mod tests {
 
     impl TestPostgresDb {
         async fn create() -> Self {
-            let lock = crate::db::postgres::lock_test_lifecycle();
             let admin_url = postgres_admin_database_url();
             let database_name = format!("agentdesk_reviews_{}", uuid::Uuid::new_v4().simple());
             let database_url = format!("{}/{}", postgres_base_database_url(), database_name);
@@ -382,7 +380,6 @@ mod tests {
                 .await
                 .unwrap();
             Self {
-                _lock: lock,
                 admin_url,
                 database_name,
                 database_url,

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -97,6 +97,7 @@ async fn read_sse_body_until(body: &mut Body, needles: &[&str]) -> String {
 }
 
 struct TestPostgresDb {
+    _lock: crate::db::postgres::PostgresTestLifecycleGuard,
     admin_url: String,
     database_name: String,
     database_url: String,
@@ -104,6 +105,7 @@ struct TestPostgresDb {
 
 impl TestPostgresDb {
     async fn create() -> Self {
+        let lock = crate::db::postgres::lock_test_lifecycle();
         let admin_url = postgres_admin_database_url();
         let database_name = format!("agentdesk_routes_{}", uuid::Uuid::new_v4().simple());
         let database_url = format!("{}/{}", postgres_base_database_url(), database_name);
@@ -112,6 +114,7 @@ impl TestPostgresDb {
             .unwrap();
 
         Self {
+            _lock: lock,
             admin_url,
             database_name,
             database_url,

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -97,7 +97,6 @@ async fn read_sse_body_until(body: &mut Body, needles: &[&str]) -> String {
 }
 
 struct TestPostgresDb {
-    _lock: crate::db::postgres::PostgresTestLifecycleGuard,
     admin_url: String,
     database_name: String,
     database_url: String,
@@ -105,7 +104,6 @@ struct TestPostgresDb {
 
 impl TestPostgresDb {
     async fn create() -> Self {
-        let lock = crate::db::postgres::lock_test_lifecycle();
         let admin_url = postgres_admin_database_url();
         let database_name = format!("agentdesk_routes_{}", uuid::Uuid::new_v4().simple());
         let database_url = format!("{}/{}", postgres_base_database_url(), database_name);
@@ -114,7 +112,6 @@ impl TestPostgresDb {
             .unwrap();
 
         Self {
-            _lock: lock,
             admin_url,
             database_name,
             database_url,

--- a/src/services/qwen.rs
+++ b/src/services/qwen.rs
@@ -2298,7 +2298,10 @@ mod tests {
                 message: expected_message,
             }
         );
-        assert!(!state.meaningful_progress_seen, "system event must not mark progress");
+        assert!(
+            !state.meaningful_progress_seen,
+            "system event must not mark progress"
+        );
     }
 
     #[test]

--- a/src/services/qwen.rs
+++ b/src/services/qwen.rs
@@ -42,8 +42,9 @@ use crate::services::tmux_diagnostics::{
 
 const QWEN_CANCELLED_MESSAGE: &str = "Qwen request cancelled";
 const QWEN_SESSION_DEAD_MESSAGE: &str = "Qwen stream ended without a terminal result";
-pub(crate) const QWEN_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
-pub(crate) const QWEN_STREAM_IDLE_TICKS_BEFORE_RETRY: u32 = 2;
+pub(crate) const QWEN_STREAM_POLL_TIMEOUT: Duration = Duration::from_secs(5);
+pub(crate) const QWEN_STREAM_STARTUP_WATCHDOG: Duration = Duration::from_secs(60);
+pub(crate) const QWEN_STREAM_IDLE_WATCHDOG: Duration = Duration::from_secs(120);
 pub(crate) const QWEN_MAX_SESSION_RETRIES: usize = 1;
 const TMUX_PROMPT_B64_PREFIX: &str = "__AGENTDESK_B64__:";
 pub(crate) const QWEN_CODE_SYSTEM_SETTINGS_ENV: &str = "QWEN_CODE_SYSTEM_SETTINGS_PATH";
@@ -69,6 +70,80 @@ pub(crate) const QWEN_SUPPORTED_ALLOWED_TOOLS: &[&str] = &[
     "EnterPlanMode",
     "ExitPlanMode",
 ];
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct QwenStreamWatchdog {
+    poll_timeout: Duration,
+    startup_watchdog: Duration,
+    idle_watchdog: Duration,
+    startup_silent_for: Duration,
+    idle_silent_for: Duration,
+}
+
+impl Default for QwenStreamWatchdog {
+    fn default() -> Self {
+        Self::new(
+            QWEN_STREAM_POLL_TIMEOUT,
+            QWEN_STREAM_STARTUP_WATCHDOG,
+            QWEN_STREAM_IDLE_WATCHDOG,
+        )
+    }
+}
+
+impl QwenStreamWatchdog {
+    pub(crate) const fn new(
+        poll_timeout: Duration,
+        startup_watchdog: Duration,
+        idle_watchdog: Duration,
+    ) -> Self {
+        Self {
+            poll_timeout,
+            startup_watchdog,
+            idle_watchdog,
+            startup_silent_for: Duration::ZERO,
+            idle_silent_for: Duration::ZERO,
+        }
+    }
+
+    pub(crate) const fn poll_timeout(&self) -> Duration {
+        self.poll_timeout
+    }
+
+    pub(crate) fn observe_line(&mut self) {
+        self.startup_silent_for = Duration::ZERO;
+        self.idle_silent_for = Duration::ZERO;
+    }
+
+    pub(crate) fn on_timeout(&mut self, meaningful_progress_seen: bool) -> Option<String> {
+        if !meaningful_progress_seen {
+            self.startup_silent_for += self.poll_timeout;
+            if self.startup_silent_for >= self.startup_watchdog {
+                return Some(self.startup_retry_message());
+            }
+            return None;
+        }
+
+        self.idle_silent_for += self.poll_timeout;
+        if self.idle_silent_for >= self.idle_watchdog {
+            return Some(self.idle_retry_message());
+        }
+        None
+    }
+
+    pub(crate) fn startup_retry_message(&self) -> String {
+        format!(
+            "Qwen stream produced no output for {} seconds before first progress",
+            self.startup_watchdog.as_secs()
+        )
+    }
+
+    pub(crate) fn idle_retry_message(&self) -> String {
+        format!(
+            "Qwen stream produced no output for {} seconds after progress",
+            self.idle_watchdog.as_secs()
+        )
+    }
+}
 
 #[derive(Debug)]
 pub(crate) struct QwenSystemSettingsOverride {
@@ -163,6 +238,7 @@ struct QwenAttemptState {
     current_model: Option<String>,
     last_error_message: Option<String>,
     terminal_result_seen: bool,
+    meaningful_progress_seen: bool,
     terminal_result_text: Option<String>,
     partial_stream_seen: bool,
     buffered_messages: Vec<StreamMessage>,
@@ -405,8 +481,7 @@ fn execute_qwen_streaming_attempt(
         &stdout_events,
         cancel_token.as_deref(),
         &mut state,
-        QWEN_STREAM_IDLE_TIMEOUT,
-        QWEN_STREAM_IDLE_TICKS_BEFORE_RETRY,
+        QwenStreamWatchdog::default(),
     ) {
         QwenStreamLoopResult::Cancelled => {
             kill_child_tree(&mut child);
@@ -476,19 +551,16 @@ fn collect_qwen_stream_events(
     stdout_events: &mpsc::Receiver<QwenStreamEvent>,
     cancel_token: Option<&CancelToken>,
     state: &mut QwenAttemptState,
-    idle_timeout: Duration,
-    idle_ticks_before_retry: u32,
+    mut watchdog: QwenStreamWatchdog,
 ) -> QwenStreamLoopResult {
-    let mut idle_ticks = 0;
-
     loop {
         if is_cancelled(cancel_token) {
             return QwenStreamLoopResult::Cancelled;
         }
 
-        match stdout_events.recv_timeout(idle_timeout) {
+        match stdout_events.recv_timeout(watchdog.poll_timeout()) {
             Ok(QwenStreamEvent::Line(line)) => {
-                idle_ticks = 0;
+                watchdog.observe_line();
                 process_qwen_stream_line(&line, state);
             }
             Ok(QwenStreamEvent::ReadError(message)) => {
@@ -504,14 +576,8 @@ fn collect_qwen_stream_events(
                 if state.terminal_result_seen {
                     return QwenStreamLoopResult::Eof;
                 }
-                idle_ticks += 1;
-                if idle_ticks >= idle_ticks_before_retry {
-                    return QwenStreamLoopResult::RetrySession {
-                        message: format!(
-                            "Qwen stream produced no output for {} seconds",
-                            idle_timeout.as_secs() * idle_ticks_before_retry as u64
-                        ),
-                    };
+                if let Some(message) = watchdog.on_timeout(state.meaningful_progress_seen) {
+                    return QwenStreamLoopResult::RetrySession { message };
                 }
             }
         }
@@ -642,6 +708,7 @@ fn process_qwen_partial_event(
                         .and_then(|v| v.as_str())
                         .unwrap_or("");
                     if !text.is_empty() {
+                        mark_meaningful_progress(state);
                         state.final_text.push_str(text);
                         state.buffered_messages.push(StreamMessage::Text {
                             content: text.to_string(),
@@ -659,10 +726,12 @@ fn process_qwen_partial_event(
                             .thinking_signature
                             .clone()
                             .or_else(|| Some("thinking".to_string()));
+                        block_state.thinking_emitted = true;
+                        let _ = block_state;
+                        mark_meaningful_progress(state);
                         state
                             .buffered_messages
                             .push(StreamMessage::Thinking { summary });
-                        block_state.thinking_emitted = true;
                     }
                 }
                 Some("signature_delta") => {
@@ -695,11 +764,13 @@ fn process_qwen_partial_event(
             let index = event.get("index").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
             if let Some(block_state) = state.partial_blocks.remove(&index) {
                 if block_state.kind == "tool_use" {
+                    mark_meaningful_progress(state);
                     state.buffered_messages.push(StreamMessage::ToolUse {
                         name: block_state.tool_name.unwrap_or_else(|| "tool".to_string()),
                         input: normalize_tool_input(block_state.input_json),
                     });
                 } else if block_state.kind == "thinking" && !block_state.thinking_emitted {
+                    mark_meaningful_progress(state);
                     state.buffered_messages.push(StreamMessage::Thinking {
                         summary: block_state.thinking_signature,
                     });
@@ -740,6 +811,7 @@ fn process_qwen_assistant_message(json: &Value, state: &mut QwenAttemptState) {
                 if text.is_empty() {
                     continue;
                 }
+                mark_meaningful_progress(state);
                 if !state.partial_stream_seen {
                     state.final_text.push_str(text);
                     state.buffered_messages.push(StreamMessage::Text {
@@ -750,6 +822,7 @@ fn process_qwen_assistant_message(json: &Value, state: &mut QwenAttemptState) {
                 }
             }
             Some("thinking") if !state.partial_stream_seen => {
+                mark_meaningful_progress(state);
                 let summary = block
                     .get("signature")
                     .and_then(|v| v.as_str())
@@ -767,6 +840,7 @@ fn process_qwen_assistant_message(json: &Value, state: &mut QwenAttemptState) {
                     .push(StreamMessage::Thinking { summary });
             }
             Some("tool_use") if !state.partial_stream_seen => {
+                mark_meaningful_progress(state);
                 let name = block
                     .get("name")
                     .and_then(|v| v.as_str())
@@ -808,6 +882,7 @@ fn process_qwen_user_message(json: &Value, state: &mut QwenAttemptState) {
             .get("is_error")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+        mark_meaningful_progress(state);
         state
             .buffered_messages
             .push(StreamMessage::ToolResult { content, is_error });
@@ -1744,6 +1819,10 @@ fn track_session_id(state: &mut QwenAttemptState, session_id: Option<&str>) {
     }
 }
 
+fn mark_meaningful_progress(state: &mut QwenAttemptState) {
+    state.meaningful_progress_seen = true;
+}
+
 fn update_status_from_usage(
     state: &mut QwenAttemptState,
     usage: Option<&Value>,
@@ -1788,19 +1867,28 @@ fn update_status_from_usage(
 }
 
 fn maybe_emit_partial_thinking(index: usize, state: &mut QwenAttemptState) {
-    let Some(block_state) = state.partial_blocks.get_mut(&index) else {
+    let Some(summary) = state
+        .partial_blocks
+        .get_mut(&index)
+        .and_then(|block_state| {
+            if block_state.kind != "thinking" || block_state.thinking_emitted {
+                return None;
+            }
+            block_state.thinking_emitted = true;
+            Some(
+                block_state
+                    .thinking_signature
+                    .clone()
+                    .or_else(|| Some("thinking".to_string())),
+            )
+        })
+    else {
         return;
     };
-    if block_state.kind != "thinking" || block_state.thinking_emitted {
-        return;
-    }
-    state.buffered_messages.push(StreamMessage::Thinking {
-        summary: block_state
-            .thinking_signature
-            .clone()
-            .or_else(|| Some("thinking".to_string())),
-    });
-    block_state.thinking_emitted = true;
+    mark_meaningful_progress(state);
+    state
+        .buffered_messages
+        .push(StreamMessage::Thinking { summary });
 }
 
 fn normalize_tool_input(raw: String) -> String {
@@ -1910,7 +1998,7 @@ fn render_qwen_value(value: &Value) -> String {
 mod tests {
     use super::{
         QWEN_CODE_SYSTEM_SETTINGS_ENV, QwenAttemptState, QwenResumeStrategy, QwenStreamEvent,
-        QwenStreamLoopResult, build_simple_exec_args, build_stream_exec_args,
+        QwenStreamLoopResult, QwenStreamWatchdog, build_simple_exec_args, build_stream_exec_args,
         collect_qwen_stream_events, compose_qwen_prompt, create_system_settings_override,
         extract_text_from_json_output, normalize_resume_strategy, process_qwen_json_event,
         qwen_project_cache_key, resolve_allowed_core_tools,
@@ -2082,13 +2170,98 @@ mod tests {
             &rx,
             Some(token.as_ref()),
             &mut state,
-            Duration::from_millis(100),
-            2,
+            QwenStreamWatchdog::new(
+                Duration::from_millis(100),
+                Duration::from_secs(1),
+                Duration::from_secs(1),
+            ),
         );
 
         assert_eq!(result, QwenStreamLoopResult::Cancelled);
         assert_eq!(state.final_text, "partial");
         assert!(!state.raw_stdout.is_empty());
+    }
+
+    #[test]
+    fn qwen_stream_watchdog_startup_timeout_fires_before_first_progress() {
+        let (_tx, rx) = mpsc::channel();
+        let mut state = QwenAttemptState::default();
+
+        let watchdog = QwenStreamWatchdog::new(
+            Duration::from_millis(200),
+            Duration::from_secs(1),
+            Duration::from_secs(2),
+        );
+        let expected_message = watchdog.startup_retry_message();
+
+        let result = collect_qwen_stream_events(&rx, None, &mut state, watchdog);
+
+        assert_eq!(
+            result,
+            QwenStreamLoopResult::RetrySession {
+                message: expected_message,
+            }
+        );
+        assert!(!state.meaningful_progress_seen);
+    }
+
+    #[test]
+    fn qwen_stream_watchdog_idle_timeout_fires_after_progress() {
+        let (tx, rx) = mpsc::channel();
+        let mut state = QwenAttemptState::default();
+        tx.send(QwenStreamEvent::Line(
+            r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"partial"}]}}"#
+                .to_string(),
+        ))
+        .unwrap();
+
+        let watchdog = QwenStreamWatchdog::new(
+            Duration::from_millis(200),
+            Duration::from_secs(1),
+            Duration::from_secs(2),
+        );
+        let expected_message = watchdog.idle_retry_message();
+
+        let result = collect_qwen_stream_events(&rx, None, &mut state, watchdog);
+
+        assert_eq!(
+            result,
+            QwenStreamLoopResult::RetrySession {
+                message: expected_message,
+            }
+        );
+        assert!(state.meaningful_progress_seen);
+        assert_eq!(state.final_text, "partial");
+    }
+
+    #[test]
+    fn qwen_stream_watchdog_ignores_timeout_after_terminal_result() {
+        let (tx, rx) = mpsc::channel();
+        let mut state = QwenAttemptState::default();
+        tx.send(QwenStreamEvent::Line(
+            r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"partial"}]}}"#
+                .to_string(),
+        ))
+        .unwrap();
+        tx.send(QwenStreamEvent::Line(
+            r#"{"type":"result","is_error":false,"result":"final"}"#.to_string(),
+        ))
+        .unwrap();
+
+        let result = collect_qwen_stream_events(
+            &rx,
+            None,
+            &mut state,
+            QwenStreamWatchdog::new(
+                Duration::from_millis(200),
+                Duration::from_secs(1),
+                Duration::from_secs(1),
+            ),
+        );
+
+        assert_eq!(result, QwenStreamLoopResult::Eof);
+        assert!(state.terminal_result_seen);
+        assert!(state.meaningful_progress_seen);
     }
 
     #[test]

--- a/src/services/qwen.rs
+++ b/src/services/qwen.rs
@@ -43,7 +43,11 @@ use crate::services::tmux_diagnostics::{
 const QWEN_CANCELLED_MESSAGE: &str = "Qwen request cancelled";
 const QWEN_SESSION_DEAD_MESSAGE: &str = "Qwen stream ended without a terminal result";
 pub(crate) const QWEN_STREAM_POLL_TIMEOUT: Duration = Duration::from_secs(5);
+// Allow up to 60 s for the first token: covers cold start, model loading, and upstream rate-limit
+// backoffs that happen before the session produces any meaningful output.
 pub(crate) const QWEN_STREAM_STARTUP_WATCHDOG: Duration = Duration::from_secs(60);
+// Allow up to 120 s of silence after progress has been seen: covers long-running tool calls
+// (e.g. cargo build, test suites) where the model is waiting for a tool result between turns.
 pub(crate) const QWEN_STREAM_IDLE_WATCHDOG: Duration = Duration::from_secs(120);
 pub(crate) const QWEN_MAX_SESSION_RETRIES: usize = 1;
 const TMUX_PROMPT_B64_PREFIX: &str = "__AGENTDESK_B64__:";
@@ -109,6 +113,10 @@ impl QwenStreamWatchdog {
         self.poll_timeout
     }
 
+    // Called on every received line, not just meaningful ones.  Any stream activity resets both
+    // accumulators so a session that is producing non-content output (init handshake, system
+    // events) does not get prematurely retried.  The startup-vs-idle threshold selection is made
+    // by `on_timeout` based on `meaningful_progress_seen`, not here.
     pub(crate) fn observe_line(&mut self) {
         self.startup_silent_for = Duration::ZERO;
         self.idle_silent_for = Duration::ZERO;
@@ -2235,7 +2243,7 @@ mod tests {
     }
 
     #[test]
-    fn qwen_stream_watchdog_ignores_timeout_after_terminal_result() {
+    fn qwen_stream_watchdog_eof_after_terminal_result() {
         let (tx, rx) = mpsc::channel();
         let mut state = QwenAttemptState::default();
         tx.send(QwenStreamEvent::Line(
@@ -2262,6 +2270,35 @@ mod tests {
         assert_eq!(result, QwenStreamLoopResult::Eof);
         assert!(state.terminal_result_seen);
         assert!(state.meaningful_progress_seen);
+    }
+
+    #[test]
+    fn qwen_stream_watchdog_non_meaningful_line_resets_timer_but_not_progress() {
+        // A system/session_start event resets idle timers (observe_line) but must not set
+        // meaningful_progress_seen, so the startup watchdog fires rather than the idle one.
+        let (tx, rx) = mpsc::channel();
+        let mut state = QwenAttemptState::default();
+        tx.send(QwenStreamEvent::Line(
+            r#"{"type":"system","subtype":"session_start","session_id":"s1"}"#.to_string(),
+        ))
+        .unwrap();
+
+        let watchdog = QwenStreamWatchdog::new(
+            Duration::from_millis(200),
+            Duration::from_secs(1),
+            Duration::from_secs(2),
+        );
+        let expected_message = watchdog.startup_retry_message();
+
+        let result = collect_qwen_stream_events(&rx, None, &mut state, watchdog);
+
+        assert_eq!(
+            result,
+            QwenStreamLoopResult::RetrySession {
+                message: expected_message,
+            }
+        );
+        assert!(!state.meaningful_progress_seen, "system event must not mark progress");
     }
 
     #[test]

--- a/src/services/qwen_tmux_wrapper.rs
+++ b/src/services/qwen_tmux_wrapper.rs
@@ -568,7 +568,7 @@ fn normalize_stream_event(json: &Value, state: &mut TurnNormalizationState) -> V
             state.partial_blocks.insert(
                 index,
                 PartialBlockState {
-                    kind: block_type,
+                    kind: block_type.clone(),
                     tool_name: block
                         .get("name")
                         .and_then(|v| v.as_str())
@@ -581,6 +581,11 @@ fn normalize_stream_event(json: &Value, state: &mut TurnNormalizationState) -> V
                     thinking_emitted: false,
                 },
             );
+            if block_type == "thinking" {
+                // Thinking-start is meaningful progress even though this wrapper does not emit
+                // a normalized output event until a later delta or stop arrives.
+                state.meaningful_progress_seen = true;
+            }
             Vec::new()
         }
         Some("content_block_delta") => {
@@ -1115,6 +1120,39 @@ mod tests {
             }
         }
         assert!(state.meaningful_progress_seen);
+
+        let mut watchdog = crate::services::qwen::QwenStreamWatchdog::new(
+            Duration::from_millis(200),
+            Duration::from_secs(1),
+            Duration::from_secs(2),
+        );
+        watchdog.observe_line();
+        let expected_message = watchdog.idle_retry_message();
+
+        loop {
+            match next_turn_watchdog_outcome(false, &state, &mut watchdog) {
+                TurnWatchdogOutcome::Continue => {}
+                TurnWatchdogOutcome::Retry { message } => {
+                    assert_eq!(message, expected_message);
+                    break;
+                }
+                TurnWatchdogOutcome::Break => panic!("idle watchdog should not break"),
+            }
+        }
+    }
+
+    #[test]
+    fn qwen_tmux_watchdog_treats_thinking_start_as_progress() {
+        let mut state = TurnNormalizationState::default();
+        let thinking_start = r#"{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"thinking","signature":"pondering"}}}"#;
+
+        let normalized = normalize_qwen_line(thinking_start, &mut state);
+
+        assert!(normalized.is_empty());
+        assert!(
+            state.meaningful_progress_seen,
+            "thinking start should count as progress even without a normalized output event"
+        );
 
         let mut watchdog = crate::services::qwen::QwenStreamWatchdog::new(
             Duration::from_millis(200),

--- a/src/services/qwen_tmux_wrapper.rs
+++ b/src/services/qwen_tmux_wrapper.rs
@@ -20,6 +20,7 @@ struct PartialBlockState {
 #[derive(Debug, Default)]
 struct TurnNormalizationState {
     partial_stream_seen: bool,
+    meaningful_progress_seen: bool,
     current_model: Option<String>,
     last_session_id: Option<String>,
     init_emitted_for_session: Option<String>,
@@ -37,6 +38,13 @@ enum TurnReadEvent {
 struct TurnFailure {
     message: String,
     retryable: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum TurnWatchdogOutcome {
+    Continue,
+    Break,
+    Retry { message: String },
 }
 
 pub fn run(
@@ -323,13 +331,16 @@ fn run_turn_once(
         ..TurnNormalizationState::default()
     };
     let mut saw_result = false;
-    let mut idle_ticks = 0;
+    let mut watchdog = crate::services::qwen::QwenStreamWatchdog::default();
 
     loop {
-        match stdout_events.recv_timeout(crate::services::qwen::QWEN_STREAM_IDLE_TIMEOUT) {
+        match stdout_events.recv_timeout(watchdog.poll_timeout()) {
             Ok(TurnReadEvent::Line(line)) => {
-                idle_ticks = 0;
+                watchdog.observe_line();
                 for normalized in normalize_qwen_line(&line, &mut state) {
+                    if is_meaningful_progress_event(&normalized) {
+                        state.meaningful_progress_seen = true;
+                    }
                     if let Some(id) = extract_init_session_id(&normalized) {
                         *session_id = Some(id);
                     }
@@ -353,22 +364,18 @@ fn run_turn_once(
             }
             Ok(TurnReadEvent::Eof) | Err(RecvTimeoutError::Disconnected) => break,
             Err(RecvTimeoutError::Timeout) => {
-                if saw_result {
-                    break;
-                }
-                idle_ticks += 1;
-                if idle_ticks >= crate::services::qwen::QWEN_STREAM_IDLE_TICKS_BEFORE_RETRY {
-                    crate::services::process::kill_pid_tree(child_pid);
-                    let _ = child.wait();
-                    let _ = stderr_handle.join().unwrap_or_default();
-                    return Err(TurnFailure {
-                        message: format!(
-                            "Qwen stream produced no output for {} seconds",
-                            crate::services::qwen::QWEN_STREAM_IDLE_TIMEOUT.as_secs()
-                                * crate::services::qwen::QWEN_STREAM_IDLE_TICKS_BEFORE_RETRY as u64
-                        ),
-                        retryable: true,
-                    });
+                match next_turn_watchdog_outcome(saw_result, &state, &mut watchdog) {
+                    TurnWatchdogOutcome::Continue => {}
+                    TurnWatchdogOutcome::Break => break,
+                    TurnWatchdogOutcome::Retry { message } => {
+                        crate::services::process::kill_pid_tree(child_pid);
+                        let _ = child.wait();
+                        let _ = stderr_handle.join().unwrap_or_default();
+                        return Err(TurnFailure {
+                            message,
+                            retryable: true,
+                        });
+                    }
                 }
             }
         }
@@ -469,6 +476,28 @@ fn normalize_qwen_line(line: &str, state: &mut TurnNormalizationState) -> Vec<Va
         Some("user") => normalize_user_message(&json),
         Some("result") => normalize_result_message(&json, state),
         _ => Vec::new(),
+    }
+}
+
+fn is_meaningful_progress_event(event: &Value) -> bool {
+    matches!(
+        event.get("type").and_then(|value| value.as_str()),
+        Some("assistant") | Some("user")
+    )
+}
+
+fn next_turn_watchdog_outcome(
+    saw_result: bool,
+    state: &TurnNormalizationState,
+    watchdog: &mut crate::services::qwen::QwenStreamWatchdog,
+) -> TurnWatchdogOutcome {
+    if saw_result {
+        return TurnWatchdogOutcome::Break;
+    }
+
+    match watchdog.on_timeout(state.meaningful_progress_seen) {
+        Some(message) => TurnWatchdogOutcome::Retry { message },
+        None => TurnWatchdogOutcome::Continue,
     }
 }
 
@@ -897,10 +926,14 @@ fn emit_json_line(output: &mut std::fs::File, value: Value) -> Result<(), String
 
 #[cfg(test)]
 mod tests {
-    use super::{build_turn_args, decode_external_prompt, normalize_qwen_line};
+    use super::{
+        TurnNormalizationState, TurnWatchdogOutcome, build_turn_args, decode_external_prompt,
+        next_turn_watchdog_outcome, normalize_qwen_line,
+    };
     use crate::services::qwen::qwen_project_cache_key;
     use std::fs;
     use std::io::Write;
+    use std::time::Duration;
     use tempfile::TempDir;
 
     fn with_temp_qwen_home<F>(f: F)
@@ -1043,5 +1076,59 @@ mod tests {
             std::fs::read_to_string(&path).unwrap(),
             "{\"type\":\"assistant\",\"message\":\"keep\"}\n"
         );
+    }
+
+    #[test]
+    fn qwen_tmux_watchdog_uses_startup_timeout_before_first_progress() {
+        let state = TurnNormalizationState::default();
+        let mut watchdog = crate::services::qwen::QwenStreamWatchdog::new(
+            Duration::from_millis(200),
+            Duration::from_secs(1),
+            Duration::from_secs(2),
+        );
+        let expected_message = watchdog.startup_retry_message();
+
+        loop {
+            match next_turn_watchdog_outcome(false, &state, &mut watchdog) {
+                TurnWatchdogOutcome::Continue => {}
+                TurnWatchdogOutcome::Retry { message } => {
+                    assert_eq!(message, expected_message);
+                    break;
+                }
+                TurnWatchdogOutcome::Break => panic!("startup watchdog should not break"),
+            }
+        }
+    }
+
+    #[test]
+    fn qwen_tmux_watchdog_uses_idle_timeout_after_progress() {
+        let mut state = TurnNormalizationState::default();
+        let assistant_line = r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"partial"}]}}"#;
+        let normalized = normalize_qwen_line(assistant_line, &mut state);
+        for event in normalized {
+            if super::is_meaningful_progress_event(&event) {
+                state.meaningful_progress_seen = true;
+            }
+        }
+        assert!(state.meaningful_progress_seen);
+
+        let mut watchdog = crate::services::qwen::QwenStreamWatchdog::new(
+            Duration::from_millis(200),
+            Duration::from_secs(1),
+            Duration::from_secs(2),
+        );
+        watchdog.observe_line();
+        let expected_message = watchdog.idle_retry_message();
+
+        loop {
+            match next_turn_watchdog_outcome(false, &state, &mut watchdog) {
+                TurnWatchdogOutcome::Continue => {}
+                TurnWatchdogOutcome::Retry { message } => {
+                    assert_eq!(message, expected_message);
+                    break;
+                }
+                TurnWatchdogOutcome::Break => panic!("idle watchdog should not break"),
+            }
+        }
     }
 }

--- a/src/services/qwen_tmux_wrapper.rs
+++ b/src/services/qwen_tmux_wrapper.rs
@@ -479,6 +479,10 @@ fn normalize_qwen_line(line: &str, state: &mut TurnNormalizationState) -> Vec<Va
     }
 }
 
+// After normalize_qwen_line expansion, LLM text/thinking/tool-use arrives as "assistant" events
+// and tool results arrive as "user" events.  "system" (session bookkeeping) and "result" (terminal
+// signal) represent protocol framing, not LLM progress, so they intentionally do not qualify.
+// This is consistent with qwen.rs where mark_meaningful_progress is called only on content events.
 fn is_meaningful_progress_event(event: &Value) -> bool {
     matches!(
         event.get("type").and_then(|value| value.as_str()),


### PR DESCRIPTION
## 목표

- upstream `main`에 Qwen direct stream / tmux wrapper의 watchdog semantics를 일관되게 맞춥니다.
- upstream CI의 `Fast targeted tests`를 막던 PostgreSQL test DB lifecycle 경합을 정리해 PR을 merge-ready 상태로 맞춥니다.

## 해결한 내용

- `src/services/qwen.rs`
  - direct stream 경로에서 startup silence와 progress 이후 idle silence를 구분하는 watchdog semantics를 유지했습니다.
  - timeout 메시지가 `before first progress`와 `after progress`를 구분하도록 upstream 코드에 맞게 정리했습니다.
- `src/services/qwen_tmux_wrapper.rs`
  - tmux wrapper 경로에도 같은 startup/idle watchdog semantics를 포트했습니다.
  - `thinking` block start도 progress로 간주하도록 보강해, 실제 진행이 시작된 턴이 startup watchdog에 의해 불필요하게 재시도되지 않도록 했습니다.
  - 관련 회귀 테스트를 upstream 기준으로 함께 정리했습니다.
- `src/db/postgres.rs`
  - PG-backed test database 생성/삭제 helper에서 lifecycle lock을 직접 잡도록 바꿔 create/drop 경쟁을 막았습니다.
  - lock poison이 다음 테스트까지 연쇄 실패로 번지지 않도록 poison recovery 경로를 추가했습니다.
- `src/engine/transition_executor_pg.rs`, `src/server/routes/dispatches/outbox.rs`, `src/server/routes/reviews.rs`, `src/server/routes/routes_tests.rs`
  - PostgreSQL fixture가 같은 serialization 경로를 타도록 정리해 `Fast targeted tests`의 admin pool timeout / teardown race를 줄였습니다.
- `docs/generated/module-inventory.md`
  - upstream 현재 소스 기준으로 재생성해 drift를 제거했습니다.

## 검증

- `cargo fmt --all --check`
- `python3 scripts/generate_inventory_docs.py --check`
- `cargo test qwen_stream_watchdog -- --nocapture`
- `cargo test qwen_tmux_watchdog -- --nocapture`
- `cargo test --all-targets transition`
- `cargo test --all-targets auto_queue`
- `cargo test --all-targets cancel`
- `cargo test --all-targets review_decision`
- `cargo test invariant --all-targets -- --skip _pg_ --skip postgres_`