### PR TITLE
[codex] fix PG thread reuse JSONB decoding

### DIFF
--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -155,6 +155,13 @@ pub fn migrate(conn: &Connection) -> Result<()> {
     let _ = conn.execute_batch("ALTER TABLE kanban_cards ADD COLUMN sort_order INTEGER DEFAULT 0;");
     let _ = conn.execute_batch("ALTER TABLE kanban_cards ADD COLUMN description TEXT;");
     let _ = conn.execute_batch("ALTER TABLE kanban_cards ADD COLUMN active_thread_id TEXT;");
+    // Postgres keeps several sibling columns as JSONB while SQLite stores raw JSON text.
+    // Any PG SELECT that decodes these as `String` / `Option<String>` must cast with `::text`
+    // first, or sqlx will raise a JSONB-vs-string decode error.
+    // High-risk regression points:
+    // - kanban_cards.metadata
+    // - kanban_cards.channel_thread_map
+    // - auto_queue_slots.thread_id_map
     let _ = conn.execute_batch("ALTER TABLE kanban_cards ADD COLUMN channel_thread_map TEXT;");
     let _ = conn.execute_batch("ALTER TABLE kanban_cards ADD COLUMN suggestion_pending_at TEXT;");
     let _ = conn.execute_batch("ALTER TABLE kanban_cards ADD COLUMN review_entered_at TEXT;");
@@ -904,6 +911,8 @@ pub fn migrate(conn: &Connection) -> Result<()> {
 }
 
 pub(crate) fn ensure_auto_queue_schema(conn: &Connection) -> Result<()> {
+    // SQLite stores thread maps as TEXT, but the Postgres schema uses JSONB for
+    // `auto_queue_slots.thread_id_map`. Keep PG raw-string readers on `::text`.
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS auto_queue_runs (
             id          TEXT PRIMARY KEY,

--- a/src/dispatch/dispatch_create.rs
+++ b/src/dispatch/dispatch_create.rs
@@ -97,7 +97,7 @@ async fn load_existing_thread_for_channel_pg(
     card_id: &str,
     channel_id: u64,
 ) -> Result<Option<String>> {
-    let row = sqlx::query_as::<_, (Option<String>, Option<String>)>(
+    let row = match sqlx::query_as::<_, (Option<String>, Option<String>)>(
         "SELECT channel_thread_map::text, active_thread_id
          FROM kanban_cards
          WHERE id = $1",
@@ -105,8 +105,18 @@ async fn load_existing_thread_for_channel_pg(
     .bind(card_id)
     .fetch_optional(pool)
     .await
-    .ok()
-    .flatten();
+    {
+        Ok(row) => row,
+        Err(error) => {
+            tracing::warn!(
+                card_id,
+                channel_id,
+                %error,
+                "[dispatch] failed to load postgres channel_thread_map; creating a new thread"
+            );
+            return Ok(None);
+        }
+    };
 
     let Some((map_json, active_thread_id)) = row else {
         return Ok(None);
@@ -138,7 +148,7 @@ async fn load_existing_thread_for_channel_pg(
         return Ok(None);
     }
 
-    Ok(active_thread_id)
+    Ok(active_thread_id.filter(|value| !value.trim().is_empty()))
 }
 
 #[cfg(test)]

--- a/src/server/routes/auto_queue.rs
+++ b/src/server/routes/auto_queue.rs
@@ -259,6 +259,17 @@ fn slot_requires_thread_reset_before_reuse(
             || slot_has_dispatch_thread_history(conn, agent_id, slot_index))
 }
 
+fn json_value_kind(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
 async fn slot_thread_map_has_bindings_pg(
     pool: &sqlx::PgPool,
     agent_id: &str,
@@ -277,19 +288,37 @@ async fn slot_thread_map_has_bindings_pg(
     .flatten()
     .unwrap_or_else(|| "{}".to_string());
 
-    Ok(serde_json::from_str::<serde_json::Value>(&raw_map)
-        .ok()
-        .and_then(|value| value.as_object().cloned())
-        .map(|map| {
-            map.values().any(|value| {
-                value
-                    .as_str()
-                    .map(|raw| !raw.trim().is_empty())
-                    .or_else(|| value.as_u64().map(|_| true))
-                    .unwrap_or(false)
-            })
-        })
-        .unwrap_or(false))
+    let thread_map = match serde_json::from_str::<serde_json::Value>(&raw_map) {
+        Ok(value) => value,
+        Err(error) => {
+            tracing::warn!(
+                agent_id,
+                slot_index,
+                %error,
+                "[auto-queue] invalid postgres slot thread_id_map JSON while checking thread reuse"
+            );
+            return Ok(false);
+        }
+    };
+    let Some(thread_map) = thread_map.as_object() else {
+        if raw_map.trim() != "{}" && raw_map.trim() != "null" {
+            tracing::warn!(
+                agent_id,
+                slot_index,
+                json_type = json_value_kind(&thread_map),
+                "[auto-queue] postgres slot thread_id_map is not an object while checking thread reuse"
+            );
+        }
+        return Ok(false);
+    };
+
+    Ok(thread_map.values().any(|value| {
+        value
+            .as_str()
+            .map(|raw| !raw.trim().is_empty())
+            .or_else(|| value.as_u64().map(|_| true))
+            .unwrap_or(false)
+    }))
 }
 
 async fn slot_has_dispatch_thread_history_pg(
@@ -298,7 +327,7 @@ async fn slot_has_dispatch_thread_history_pg(
     slot_index: i64,
 ) -> Result<bool, String> {
     let rows = sqlx::query(
-        "SELECT thread_id, context
+        "SELECT id, thread_id, context
          FROM task_dispatches
          WHERE to_agent_id = $1
            AND thread_id IS NOT NULL
@@ -312,11 +341,50 @@ async fn slot_has_dispatch_thread_history_pg(
     })?;
 
     for row in rows {
-        let context: Option<String> = row.try_get("context").ok().flatten();
-        let Some(context) = context else {
+        let dispatch_id: String = row.try_get("id").map_err(|error| {
+            format!("read postgres dispatch id for {agent_id}:{slot_index}: {error}")
+        })?;
+        let context: Option<String> = match row.try_get("context") {
+            Ok(context) => context,
+            Err(error) => {
+                tracing::warn!(
+                    dispatch_id,
+                    agent_id,
+                    slot_index,
+                    %error,
+                    "[auto-queue] failed to decode postgres dispatch context while checking slot thread history"
+                );
+                continue;
+            }
+        };
+        let Some(context) = context
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
             continue;
         };
-        let Some(context_json) = serde_json::from_str::<serde_json::Value>(&context).ok() else {
+        let context_json = match serde_json::from_str::<serde_json::Value>(context) {
+            Ok(value) => value,
+            Err(error) => {
+                tracing::warn!(
+                    dispatch_id,
+                    agent_id,
+                    slot_index,
+                    %error,
+                    "[auto-queue] invalid postgres dispatch context JSON while checking slot thread history"
+                );
+                continue;
+            }
+        };
+        let Some(context_json) = context_json.as_object() else {
+            tracing::warn!(
+                dispatch_id,
+                agent_id,
+                slot_index,
+                json_type = json_value_kind(&context_json),
+                "[auto-queue] postgres dispatch context is not an object while checking slot thread history"
+            );
             continue;
         };
         if context_json

--- a/src/server/routes/dispatches/discord_delivery.rs
+++ b/src/server/routes/dispatches/discord_delivery.rs
@@ -63,6 +63,49 @@ fn dispatch_context_value(dispatch_context: Option<&str>) -> Option<serde_json::
     dispatch_context.and_then(|ctx| serde_json::from_str::<serde_json::Value>(ctx).ok())
 }
 
+fn json_value_kind(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
+fn parse_pg_dispatch_context(
+    dispatch_id: &str,
+    raw_context: Option<&str>,
+    warn_reason: &'static str,
+) -> Option<serde_json::Value> {
+    let raw_context = raw_context
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    let value = match serde_json::from_str::<serde_json::Value>(raw_context) {
+        Ok(value) => value,
+        Err(error) => {
+            tracing::warn!(
+                dispatch_id,
+                %error,
+                warn_reason,
+                "[dispatch] invalid postgres dispatch context JSON"
+            );
+            return None;
+        }
+    };
+    if !value.is_object() {
+        tracing::warn!(
+            dispatch_id,
+            json_type = json_value_kind(&value),
+            warn_reason,
+            "[dispatch] postgres dispatch context is not an object"
+        );
+        return None;
+    }
+    Some(value)
+}
+
 fn context_slot_index(dispatch_context: Option<&serde_json::Value>) -> Option<i64> {
     dispatch_context
         .and_then(|ctx| ctx.get("slot_index"))
@@ -931,7 +974,7 @@ async fn recent_slot_thread_history_pg(
     slot_index: i64,
 ) -> Result<Vec<String>, String> {
     let rows = sqlx::query(
-        "SELECT thread_id, context
+        "SELECT id, thread_id, context
          FROM task_dispatches
          WHERE to_agent_id = $1
            AND thread_id IS NOT NULL
@@ -945,12 +988,41 @@ async fn recent_slot_thread_history_pg(
 
     let mut candidates = Vec::new();
     for row in rows {
-        let thread_id: Option<String> = row.try_get("thread_id").ok().flatten();
-        let context: Option<String> = row.try_get("context").ok().flatten();
-        let matches_slot = context
-            .as_deref()
-            .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
-            .and_then(|value| value.get("slot_index").and_then(|value| value.as_i64()))
+        let dispatch_id: String = row.try_get("id").map_err(|error| {
+            format!("read postgres dispatch id for {agent_id}:{slot_index}: {error}")
+        })?;
+        let thread_id: Option<String> = match row.try_get("thread_id") {
+            Ok(thread_id) => thread_id,
+            Err(error) => {
+                tracing::warn!(
+                    dispatch_id,
+                    agent_id,
+                    slot_index,
+                    %error,
+                    "[dispatch] failed to decode postgres thread_id while checking recent slot history"
+                );
+                continue;
+            }
+        };
+        let context: Option<String> = match row.try_get("context") {
+            Ok(context) => context,
+            Err(error) => {
+                tracing::warn!(
+                    dispatch_id,
+                    agent_id,
+                    slot_index,
+                    %error,
+                    "[dispatch] failed to decode postgres dispatch context while checking recent slot history"
+                );
+                continue;
+            }
+        };
+        let matches_slot = parse_pg_dispatch_context(
+            &dispatch_id,
+            context.as_deref(),
+            "recent_slot_thread_history_pg",
+        )
+        .and_then(|value| value.get("slot_index").and_then(|value| value.as_i64()))
             == Some(slot_index);
         if matches_slot {
             push_unique_thread_candidate(&mut candidates, thread_id.as_deref());
@@ -1741,7 +1813,7 @@ async fn latest_completed_review_provider_pg(
     card_id: &str,
 ) -> Result<Option<String>, String> {
     let rows = sqlx::query(
-        "SELECT context
+        "SELECT id, context
          FROM task_dispatches
          WHERE kanban_card_id = $1
            AND dispatch_type = 'review'
@@ -1754,10 +1826,37 @@ async fn latest_completed_review_provider_pg(
     .await
     .map_err(|error| format!("load postgres review provider for {card_id}: {error}"))?;
 
-    Ok(rows.into_iter().find_map(|row| {
-        let context: Option<String> = row.try_get("context").ok().flatten();
-        review_source_provider_from_context(context.as_deref())
-    }))
+    for row in rows {
+        let dispatch_id: String = row
+            .try_get("id")
+            .map_err(|error| format!("read postgres review dispatch id for {card_id}: {error}"))?;
+        let context: Option<String> = match row.try_get("context") {
+            Ok(context) => context,
+            Err(error) => {
+                tracing::warn!(
+                    dispatch_id,
+                    card_id,
+                    %error,
+                    "[dispatch] failed to decode postgres review context while loading provider"
+                );
+                continue;
+            }
+        };
+        if let Some(provider) = parse_pg_dispatch_context(
+            &dispatch_id,
+            context.as_deref(),
+            "latest_completed_review_provider_pg",
+        )
+        .and_then(|ctx| {
+            ctx.get("from_provider")
+                .and_then(|value| value.as_str())
+                .map(str::to_string)
+        }) {
+            return Ok(Some(provider));
+        }
+    }
+
+    Ok(None)
 }
 
 fn latest_work_dispatch_thread_on_conn(
@@ -1794,7 +1893,7 @@ async fn latest_work_dispatch_thread_pg(
     card_id: &str,
 ) -> Result<Option<String>, String> {
     let rows = sqlx::query(
-        "SELECT thread_id, context
+        "SELECT id, thread_id, context
          FROM task_dispatches
          WHERE kanban_card_id = $1
            AND dispatch_type IN ('implementation', 'rework')
@@ -1813,25 +1912,52 @@ async fn latest_work_dispatch_thread_pg(
     .map_err(|error| format!("load postgres work dispatch thread for {card_id}: {error}"))?;
 
     for row in rows {
-        let thread_id: Option<String> = row.try_get("thread_id").ok().flatten();
+        let dispatch_id: String = row
+            .try_get("id")
+            .map_err(|error| format!("read postgres work dispatch id for {card_id}: {error}"))?;
+        let thread_id: Option<String> = match row.try_get("thread_id") {
+            Ok(thread_id) => thread_id,
+            Err(error) => {
+                tracing::warn!(
+                    dispatch_id,
+                    card_id,
+                    %error,
+                    "[dispatch] failed to decode postgres work thread_id while loading reusable thread"
+                );
+                continue;
+            }
+        };
         if let Some(thread_id) = thread_id
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty())
         {
             return Ok(Some(thread_id));
         }
-        let context: Option<String> = row.try_get("context").ok().flatten();
-        if let Some(thread_id) = context
-            .as_deref()
-            .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
-            .and_then(|value| {
-                value
-                    .get("thread_id")
-                    .and_then(|value| value.as_str())
-                    .map(std::string::ToString::to_string)
-            })
-            .map(|value| value.trim().to_string())
-            .filter(|value| !value.is_empty())
+        let context: Option<String> = match row.try_get("context") {
+            Ok(context) => context,
+            Err(error) => {
+                tracing::warn!(
+                    dispatch_id,
+                    card_id,
+                    %error,
+                    "[dispatch] failed to decode postgres work context while loading reusable thread"
+                );
+                continue;
+            }
+        };
+        if let Some(thread_id) = parse_pg_dispatch_context(
+            &dispatch_id,
+            context.as_deref(),
+            "latest_work_dispatch_thread_pg",
+        )
+        .and_then(|value| {
+            value
+                .get("thread_id")
+                .and_then(|value| value.as_str())
+                .map(std::string::ToString::to_string)
+        })
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
         {
             return Ok(Some(thread_id));
         }

--- a/src/server/routes/dispatches/thread_reuse.rs
+++ b/src/server/routes/dispatches/thread_reuse.rs
@@ -41,6 +41,67 @@ fn lookup_thread_for_channel_from_map(map_json: Option<&str>, channel_id: u64) -
     })
 }
 
+fn json_value_kind(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
+fn lookup_thread_for_channel_from_map_pg(
+    map_json: Option<&str>,
+    card_id: &str,
+    channel_id: u64,
+) -> Option<String> {
+    let Some(raw) = map_json
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && *value != "null")
+    else {
+        return None;
+    };
+
+    let value = match serde_json::from_str::<serde_json::Value>(raw) {
+        Ok(value) => value,
+        Err(error) => {
+            tracing::warn!(
+                card_id,
+                channel_id,
+                %error,
+                "[dispatch] invalid postgres channel_thread_map JSON; skipping thread reuse"
+            );
+            return None;
+        }
+    };
+
+    let Some(map) = value.as_object() else {
+        tracing::warn!(
+            card_id,
+            channel_id,
+            json_type = json_value_kind(&value),
+            "[dispatch] postgres channel_thread_map is not an object; skipping thread reuse"
+        );
+        return None;
+    };
+
+    match map.get(&channel_id.to_string()) {
+        Some(serde_json::Value::String(thread_id)) => Some(thread_id.to_string()),
+        Some(other) => {
+            tracing::warn!(
+                card_id,
+                channel_id,
+                json_type = json_value_kind(other),
+                "[dispatch] postgres channel_thread_map entry is not a string; skipping thread reuse"
+            );
+            None
+        }
+        None => None,
+    }
+}
+
 /// Look up the thread_id for a specific channel from channel_thread_map.
 /// Falls back to active_thread_id for backward compatibility.
 pub(super) fn get_thread_for_channel(
@@ -106,7 +167,9 @@ pub(super) async fn get_thread_for_channel_pg(
         .try_get("active_thread_id")
         .map_err(|error| format!("read postgres active_thread_id for {card_id}: {error}"))?;
 
-    if let Some(thread_id) = lookup_thread_for_channel_from_map(map_json.as_deref(), channel_id) {
+    if let Some(thread_id) =
+        lookup_thread_for_channel_from_map_pg(map_json.as_deref(), card_id, channel_id)
+    {
         return Ok(Some(thread_id));
     }
 
@@ -892,12 +955,170 @@ mod tests {
         Json, Router, extract::Path, http::StatusCode, response::IntoResponse, routing::get,
     };
     use serde_json::json;
+    use std::{
+        future::Future,
+        io::{self, Write},
+        sync::{Arc, Mutex},
+    };
+
+    struct TestLogWriter {
+        buffer: Arc<Mutex<Vec<u8>>>,
+    }
 
     fn test_db() -> crate::db::Db {
         let conn = libsql_rusqlite::Connection::open_in_memory().unwrap();
         conn.execute_batch("PRAGMA foreign_keys=ON;").unwrap();
         crate::db::schema::migrate(&conn).unwrap();
         crate::db::wrap_conn(conn)
+    }
+
+    impl Write for TestLogWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.buffer.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    async fn capture_logs_async<T, F>(run: impl FnOnce() -> F) -> (T, String)
+    where
+        F: Future<Output = T>,
+    {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let log_buffer = buffer.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::WARN)
+            .with_ansi(false)
+            .without_time()
+            .with_writer(move || TestLogWriter {
+                buffer: log_buffer.clone(),
+            })
+            .finish();
+        let _guard = tracing::subscriber::set_default(subscriber);
+        let result = run().await;
+        let captured = buffer.lock().unwrap().clone();
+        (result, String::from_utf8_lossy(&captured).to_string())
+    }
+
+    struct TestPostgresDb {
+        admin_url: String,
+        database_name: String,
+        database_url: String,
+    }
+
+    impl TestPostgresDb {
+        async fn create() -> Option<Self> {
+            let admin_url = postgres_admin_database_url();
+            let database_name = format!("agentdesk_thread_reuse_{}", uuid::Uuid::new_v4().simple());
+            let database_url = format!("{}/{}", postgres_base_database_url(), database_name);
+            let admin_pool = match sqlx::PgPool::connect(&admin_url).await {
+                Ok(pool) => pool,
+                Err(error) => {
+                    eprintln!("skipping postgres thread_reuse test: admin connect failed: {error}");
+                    return None;
+                }
+            };
+            if let Err(error) = sqlx::query(&format!("CREATE DATABASE \"{database_name}\""))
+                .execute(&admin_pool)
+                .await
+            {
+                eprintln!("skipping postgres thread_reuse test: create database failed: {error}");
+                admin_pool.close().await;
+                return None;
+            }
+            admin_pool.close().await;
+            Some(Self {
+                admin_url,
+                database_name,
+                database_url,
+            })
+        }
+
+        async fn migrate(&self) -> Option<sqlx::PgPool> {
+            let pool = match sqlx::PgPool::connect(&self.database_url).await {
+                Ok(pool) => pool,
+                Err(error) => {
+                    eprintln!("skipping postgres thread_reuse test: db connect failed: {error}");
+                    return None;
+                }
+            };
+            if let Err(error) = crate::db::postgres::migrate(&pool).await {
+                eprintln!("skipping postgres thread_reuse test: migrate failed: {error}");
+                pool.close().await;
+                return None;
+            }
+            Some(pool)
+        }
+
+        async fn drop(self) {
+            let Ok(admin_pool) = sqlx::PgPool::connect(&self.admin_url).await else {
+                return;
+            };
+            let _ = sqlx::query(
+                "SELECT pg_terminate_backend(pid)
+                 FROM pg_stat_activity
+                 WHERE datname = $1
+                   AND pid <> pg_backend_pid()",
+            )
+            .bind(&self.database_name)
+            .execute(&admin_pool)
+            .await;
+            let _ = sqlx::query(&format!(
+                "DROP DATABASE IF EXISTS \"{}\"",
+                self.database_name
+            ))
+            .execute(&admin_pool)
+            .await;
+            admin_pool.close().await;
+        }
+    }
+
+    fn postgres_base_database_url() -> String {
+        if let Ok(base) = std::env::var("POSTGRES_TEST_DATABASE_URL_BASE") {
+            let trimmed = base.trim();
+            if !trimmed.is_empty() {
+                return trimmed.trim_end_matches('/').to_string();
+            }
+        }
+
+        let user = std::env::var("PGUSER")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .or_else(|| {
+                std::env::var("USER")
+                    .ok()
+                    .filter(|value| !value.trim().is_empty())
+            })
+            .unwrap_or_else(|| "postgres".to_string());
+        let password = std::env::var("PGPASSWORD")
+            .ok()
+            .filter(|value| !value.trim().is_empty());
+        let host = std::env::var("PGHOST")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| "127.0.0.1".to_string());
+        let port = std::env::var("PGPORT")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| "5432".to_string());
+
+        match password {
+            Some(password) => format!("postgres://{user}:{password}@{host}:{port}"),
+            None => format!("postgres://{user}@{host}:{port}"),
+        }
+    }
+
+    fn postgres_admin_database_url() -> String {
+        if let Ok(url) = std::env::var("POSTGRES_TEST_ADMIN_URL") {
+            let trimmed = url.trim();
+            if !trimmed.is_empty() {
+                return trimmed.to_string();
+            }
+        }
+        format!("{}/postgres", postgres_base_database_url())
     }
 
     async fn spawn_thread_info_server() -> (String, tokio::task::JoinHandle<()>) {
@@ -977,6 +1198,41 @@ mod tests {
         assert!(map.get("222").is_none());
         assert!(map.get("333").is_none());
         assert_eq!(active_thread_id.as_deref(), Some("thread-valid"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn get_thread_for_channel_pg_warns_on_non_object_thread_map() {
+        let Some(pg_db) = TestPostgresDb::create().await else {
+            return;
+        };
+        let Some(pool) = pg_db.migrate().await else {
+            pg_db.drop().await;
+            return;
+        };
+
+        sqlx::query(
+            "INSERT INTO kanban_cards (id, title, status, channel_thread_map)
+             VALUES ($1, 'Test Card', 'review', $2::jsonb)",
+        )
+        .bind("card-bad-thread-map")
+        .bind("\"bad-thread-map\"")
+        .execute(&pool)
+        .await
+        .expect("seed malformed thread map");
+
+        let (result, logs) = capture_logs_async(|| async {
+            get_thread_for_channel_pg(&pool, "card-bad-thread-map", 111).await
+        })
+        .await;
+
+        assert_eq!(result.expect("thread lookup should not fail"), None);
+        assert!(
+            logs.contains("postgres channel_thread_map is not an object"),
+            "expected warn log for malformed channel_thread_map, got: {logs}"
+        );
+
+        pool.close().await;
+        pg_db.drop().await;
     }
 }
 


### PR DESCRIPTION
## Summary
- fix Postgres thread-reuse lookups that were silently swallowing JSONB decode / parse failures
- cast JSONB-backed thread map reads to `::text` where the code expects string decoding and warn on malformed PG payloads instead of silently falling back
- document the high-risk JSONB columns in `src/db/schema.rs` to prevent future regressions

## Root Cause
Postgres stores `kanban_cards.channel_thread_map` and `auto_queue_slots.thread_id_map` as JSONB, but several reuse paths either decoded them as `Option<String>` without enough visibility on failure or silently ignored malformed JSON/object shapes. That made thread reuse fall back to fresh thread creation even when reusable history existed.

## Validation
- `cargo build --bin agentdesk`
- `cargo test server::routes::dispatches::thread_reuse::tests::get_thread_for_channel_pg_warns_on_non_object_thread_map -- --exact --nocapture`
- `cargo test -p agentdesk` currently remains red due to pre-existing unrelated failures in other PG/auto-queue/review automation areas (reproduced during this work)

## Scope
- limited to PG thread reuse / slot history / dispatch context parsing paths for issue #937
- excludes #606, unified thread redesign, and unrelated SQLite behavior
