### PR TITLE
#933 GitHub Issue → kanban_card sync (PG-first + idempotent)

### DIFF
--- a/migrations/postgres/0010_issue_card_unique_upsert.sql
+++ b/migrations/postgres/0010_issue_card_unique_upsert.sql
@@ -1,0 +1,180 @@
+CREATE TEMP TABLE github_issue_card_dedupe_map AS
+WITH ranked AS (
+    SELECT
+        id,
+        FIRST_VALUE(id) OVER (
+            PARTITION BY repo_id, github_issue_number
+            ORDER BY created_at ASC NULLS LAST, id ASC
+        ) AS canonical_id,
+        ROW_NUMBER() OVER (
+            PARTITION BY repo_id, github_issue_number
+            ORDER BY created_at ASC NULLS LAST, id ASC
+        ) AS row_num
+    FROM kanban_cards
+    WHERE repo_id IS NOT NULL
+      AND github_issue_number IS NOT NULL
+)
+SELECT id AS duplicate_id, canonical_id
+FROM ranked
+WHERE row_num > 1;
+
+UPDATE task_dispatches td
+SET kanban_card_id = map.canonical_id
+FROM github_issue_card_dedupe_map map
+WHERE td.kanban_card_id = map.duplicate_id;
+
+UPDATE dispatch_queue dq
+SET kanban_card_id = map.canonical_id
+FROM github_issue_card_dedupe_map map
+WHERE dq.kanban_card_id = map.duplicate_id;
+
+UPDATE review_decisions rd
+SET kanban_card_id = map.canonical_id
+FROM github_issue_card_dedupe_map map
+WHERE rd.kanban_card_id = map.duplicate_id;
+
+UPDATE dispatch_events de
+SET kanban_card_id = map.canonical_id
+FROM github_issue_card_dedupe_map map
+WHERE de.kanban_card_id = map.duplicate_id;
+
+UPDATE auto_queue_entries aqe
+SET kanban_card_id = map.canonical_id
+FROM github_issue_card_dedupe_map map
+WHERE aqe.kanban_card_id = map.duplicate_id;
+
+UPDATE auto_queue_phase_gates aqpg
+SET anchor_card_id = map.canonical_id
+FROM github_issue_card_dedupe_map map
+WHERE aqpg.anchor_card_id = map.duplicate_id;
+
+UPDATE kanban_cards kc
+SET parent_card_id = map.canonical_id
+FROM github_issue_card_dedupe_map map
+WHERE kc.parent_card_id = map.duplicate_id;
+
+UPDATE dispatch_outbox dox
+SET card_id = map.canonical_id
+FROM github_issue_card_dedupe_map map
+WHERE dox.card_id = map.duplicate_id;
+
+UPDATE kanban_audit_logs kal
+SET card_id = map.canonical_id
+FROM github_issue_card_dedupe_map map
+WHERE kal.card_id = map.duplicate_id;
+
+UPDATE review_tuning_outcomes rto
+SET card_id = map.canonical_id
+FROM github_issue_card_dedupe_map map
+WHERE rto.card_id = map.duplicate_id;
+
+UPDATE api_friction_events afe
+SET card_id = map.canonical_id
+FROM github_issue_card_dedupe_map map
+WHERE afe.card_id = map.duplicate_id;
+
+INSERT INTO pr_tracking (
+    card_id,
+    repo_id,
+    worktree_path,
+    branch,
+    pr_number,
+    head_sha,
+    state,
+    last_error,
+    dispatch_generation,
+    review_round,
+    retry_count,
+    created_at,
+    updated_at
+)
+SELECT
+    map.canonical_id,
+    pt.repo_id,
+    pt.worktree_path,
+    pt.branch,
+    pt.pr_number,
+    pt.head_sha,
+    pt.state,
+    pt.last_error,
+    pt.dispatch_generation,
+    pt.review_round,
+    pt.retry_count,
+    pt.created_at,
+    pt.updated_at
+FROM pr_tracking pt
+JOIN github_issue_card_dedupe_map map ON map.duplicate_id = pt.card_id
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM pr_tracking existing
+    WHERE existing.card_id = map.canonical_id
+);
+
+DELETE FROM pr_tracking pt
+USING github_issue_card_dedupe_map map
+WHERE pt.card_id = map.duplicate_id;
+
+INSERT INTO card_review_state (
+    card_id,
+    review_round,
+    state,
+    pending_dispatch_id,
+    last_verdict,
+    last_decision,
+    decided_by,
+    decided_at,
+    approach_change_round,
+    session_reset_round,
+    review_entered_at,
+    updated_at
+)
+SELECT
+    map.canonical_id,
+    crs.review_round,
+    crs.state,
+    crs.pending_dispatch_id,
+    crs.last_verdict,
+    crs.last_decision,
+    crs.decided_by,
+    crs.decided_at,
+    crs.approach_change_round,
+    crs.session_reset_round,
+    crs.review_entered_at,
+    crs.updated_at
+FROM card_review_state crs
+JOIN github_issue_card_dedupe_map map ON map.duplicate_id = crs.card_id
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM card_review_state existing
+    WHERE existing.card_id = map.canonical_id
+);
+
+DELETE FROM card_review_state crs
+USING github_issue_card_dedupe_map map
+WHERE crs.card_id = map.duplicate_id;
+
+UPDATE card_retrospectives cr
+SET card_id = map.canonical_id
+FROM github_issue_card_dedupe_map map
+WHERE cr.card_id = map.duplicate_id
+  AND NOT EXISTS (
+      SELECT 1
+      FROM card_retrospectives existing
+      WHERE existing.card_id = map.canonical_id
+        AND existing.dispatch_id = cr.dispatch_id
+        AND existing.terminal_status = cr.terminal_status
+  );
+
+DELETE FROM card_retrospectives cr
+USING github_issue_card_dedupe_map map
+WHERE cr.card_id = map.duplicate_id;
+
+DELETE FROM kanban_cards kc
+USING github_issue_card_dedupe_map map
+WHERE kc.id = map.duplicate_id;
+
+DROP TABLE github_issue_card_dedupe_map;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_kanban_cards_repo_issue_unique
+    ON kanban_cards (repo_id, github_issue_number)
+    WHERE repo_id IS NOT NULL AND github_issue_number IS NOT NULL;

--- a/src/config.rs
+++ b/src/config.rs
@@ -506,7 +506,7 @@ pub struct MeetingAgentDef {
     pub provider_hint: Option<String>,
 }
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GitHubConfig {
     #[serde(default)]
     pub repos: Vec<String>,
@@ -514,6 +514,16 @@ pub struct GitHubConfig {
     pub repo_dirs: std::collections::BTreeMap<String, String>,
     #[serde(default = "default_sync_interval")]
     pub sync_interval_minutes: u64,
+}
+
+impl Default for GitHubConfig {
+    fn default() -> Self {
+        Self {
+            repos: Vec::new(),
+            repo_dirs: std::collections::BTreeMap::new(),
+            sync_interval_minutes: default_sync_interval(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -814,7 +824,7 @@ fn normalized_channel_value(value: Option<String>) -> Option<String> {
 }
 
 fn default_sync_interval() -> u64 {
-    10
+    5
 }
 fn default_policies_dir() -> PathBuf {
     PathBuf::from("./policies")

--- a/src/db/kanban.rs
+++ b/src/db/kanban.rs
@@ -77,6 +77,154 @@ pub async fn list_registered_repo_ids_pg(pool: &PgPool) -> Result<Vec<String>, S
         .map_err(|error| format!("list registered repos from postgres: {error}"))
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct IssueCardUpsert {
+    pub repo_id: String,
+    pub issue_number: i64,
+    pub issue_url: Option<String>,
+    pub title: String,
+    pub description: Option<String>,
+    pub priority: Option<String>,
+    pub assigned_agent_id: Option<String>,
+    pub metadata_json: Option<String>,
+    pub status_on_create: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssueCardUpsertResult {
+    pub card_id: String,
+    pub created: bool,
+}
+
+fn normalize_optional_text(value: Option<String>) -> Option<String> {
+    value
+        .map(|raw| raw.trim().to_string())
+        .filter(|raw| !raw.is_empty())
+}
+
+fn normalize_optional_description(value: Option<String>) -> Option<String> {
+    value
+        .map(|raw| raw.trim_end().to_string())
+        .filter(|raw| !raw.trim().is_empty())
+}
+
+pub async fn upsert_card_from_issue_pg(
+    pool: &PgPool,
+    params: IssueCardUpsert,
+) -> Result<IssueCardUpsertResult, String> {
+    let repo_id = params.repo_id.trim().to_string();
+    if repo_id.is_empty() {
+        return Err("upsert issue card: repo_id is required".to_string());
+    }
+
+    let title = params.title.trim().to_string();
+    if title.is_empty() {
+        return Err("upsert issue card: title is required".to_string());
+    }
+
+    let issue_url = normalize_optional_text(params.issue_url);
+    let description = normalize_optional_description(params.description);
+    let priority = normalize_optional_text(params.priority);
+    let assigned_agent_id = normalize_optional_text(params.assigned_agent_id);
+    let metadata_json = normalize_optional_text(params.metadata_json);
+    let status_on_create =
+        normalize_optional_text(params.status_on_create).unwrap_or_else(|| "backlog".to_string());
+
+    let inserted_id = sqlx::query_scalar::<_, String>(
+        "INSERT INTO kanban_cards (
+            id,
+            repo_id,
+            title,
+            status,
+            priority,
+            assigned_agent_id,
+            github_issue_url,
+            github_issue_number,
+            description,
+            metadata,
+            created_at,
+            updated_at
+         ) VALUES (
+            $1,
+            $2,
+            $3,
+            $4,
+            COALESCE($5, 'medium'),
+            $6,
+            $7,
+            $8,
+            $9,
+            CAST($10 AS jsonb),
+            NOW(),
+            NOW()
+         )
+         ON CONFLICT (repo_id, github_issue_number)
+         WHERE repo_id IS NOT NULL AND github_issue_number IS NOT NULL
+         DO NOTHING
+         RETURNING id",
+    )
+    .bind(uuid::Uuid::new_v4().to_string())
+    .bind(&repo_id)
+    .bind(&title)
+    .bind(&status_on_create)
+    .bind(priority.as_deref())
+    .bind(assigned_agent_id.as_deref())
+    .bind(issue_url.as_deref())
+    .bind(params.issue_number)
+    .bind(description.as_deref())
+    .bind(metadata_json.as_deref())
+    .fetch_optional(pool)
+    .await
+    .map_err(|error| {
+        format!(
+            "insert postgres issue card {repo_id}#{}: {error}",
+            params.issue_number
+        )
+    })?;
+
+    if let Some(card_id) = inserted_id {
+        return Ok(IssueCardUpsertResult {
+            card_id,
+            created: true,
+        });
+    }
+
+    let updated_id = sqlx::query_scalar::<_, String>(
+        "UPDATE kanban_cards
+         SET title = $1,
+             priority = COALESCE($2, kanban_cards.priority),
+             assigned_agent_id = COALESCE($3, kanban_cards.assigned_agent_id),
+             github_issue_url = COALESCE($4, kanban_cards.github_issue_url),
+             description = COALESCE($5, kanban_cards.description),
+             metadata = COALESCE(CAST($6 AS jsonb), kanban_cards.metadata),
+             updated_at = NOW()
+         WHERE repo_id = $7
+           AND github_issue_number = $8
+         RETURNING id",
+    )
+    .bind(&title)
+    .bind(priority.as_deref())
+    .bind(assigned_agent_id.as_deref())
+    .bind(issue_url.as_deref())
+    .bind(description.as_deref())
+    .bind(metadata_json.as_deref())
+    .bind(&repo_id)
+    .bind(params.issue_number)
+    .fetch_one(pool)
+    .await
+    .map_err(|error| {
+        format!(
+            "update postgres issue card {repo_id}#{}: {error}",
+            params.issue_number
+        )
+    })?;
+
+    Ok(IssueCardUpsertResult {
+        card_id: updated_id,
+        created: false,
+    })
+}
+
 pub fn list_cards(
     conn: &Connection,
     filter: &ListCardsFilter,

--- a/src/github/triage.rs
+++ b/src/github/triage.rs
@@ -1,6 +1,7 @@
 //! Issue auto-triage: create kanban backlog cards for new GitHub issues.
 
 use crate::db::Db;
+use crate::db::kanban::{IssueCardUpsert, upsert_card_from_issue_pg};
 use sqlx::PgPool;
 
 use super::sync::GhIssue;
@@ -88,62 +89,81 @@ pub async fn triage_new_issues_pg(
             continue;
         }
 
-        let exists = sqlx::query_scalar::<_, i64>(
-            "SELECT COUNT(*) FROM kanban_cards WHERE github_issue_number = $1 AND repo_id = $2",
-        )
-        .bind(issue.number)
-        .bind(repo)
-        .fetch_one(pool)
-        .await
-        .map_err(|error| format!("check existing card: {error}"))?;
-
-        if exists > 0 {
-            continue;
-        }
-
-        let card_id = uuid::Uuid::new_v4().to_string();
-        let labels_str = issue
-            .labels
-            .iter()
-            .map(|label| label.name.as_str())
-            .collect::<Vec<_>>()
-            .join(",");
-        let metadata = if labels_str.is_empty() {
-            None
-        } else {
-            Some(serde_json::json!({ "labels": labels_str }).to_string())
-        };
+        let metadata = labels_metadata_json(issue);
+        let assigned_agent_id = resolve_agent_label_pg(pool, issue).await?;
         let github_url = format!("https://github.com/{repo}/issues/{}", issue.number);
-        let priority = infer_priority(&issue.labels);
-
-        sqlx::query(
-            "INSERT INTO kanban_cards (
-                id, repo_id, title, status, priority, github_issue_url,
-                github_issue_number, description, metadata, created_at, updated_at
-             )
-             VALUES ($1, $2, $3, 'backlog', $4, $5, $6, $7, CAST($8 AS jsonb), NOW(), NOW())",
+        let upserted = upsert_card_from_issue_pg(
+            pool,
+            IssueCardUpsert {
+                repo_id: repo.to_string(),
+                issue_number: issue.number,
+                issue_url: Some(github_url),
+                title: issue.title.clone(),
+                description: issue.body.clone(),
+                priority: Some(infer_priority(&issue.labels).to_string()),
+                assigned_agent_id,
+                metadata_json: metadata,
+                status_on_create: Some("backlog".to_string()),
+            },
         )
-        .bind(&card_id)
-        .bind(repo)
-        .bind(&issue.title)
-        .bind(priority)
-        .bind(&github_url)
-        .bind(issue.number)
-        .bind(issue.body.as_deref())
-        .bind(metadata.as_deref())
-        .execute(pool)
-        .await
-        .map_err(|error| format!("insert card: {error}"))?;
+        .await?;
 
-        tracing::info!(
-            "[triage] Created backlog card for {repo}#{}: {}",
-            issue.number,
-            issue.title
-        );
-        created += 1;
+        if upserted.created {
+            tracing::info!(
+                "[triage] Created backlog card for {repo}#{}: {}",
+                issue.number,
+                issue.title
+            );
+            created += 1;
+        }
     }
 
     Ok(created)
+}
+
+fn labels_metadata_json(issue: &GhIssue) -> Option<String> {
+    let labels = issue
+        .labels
+        .iter()
+        .map(|label| label.name.trim())
+        .filter(|label| !label.is_empty())
+        .collect::<Vec<_>>();
+
+    if labels.is_empty() {
+        None
+    } else {
+        Some(serde_json::json!({ "labels": labels.join(",") }).to_string())
+    }
+}
+
+async fn resolve_agent_label_pg(pool: &PgPool, issue: &GhIssue) -> Result<Option<String>, String> {
+    let agent_id = issue.labels.iter().find_map(|label| {
+        let raw = label.name.trim();
+        raw.strip_prefix("agent:")
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|value| value.to_string())
+    });
+
+    let Some(agent_id) = agent_id else {
+        return Ok(None);
+    };
+
+    let exists = sqlx::query_scalar::<_, String>("SELECT id FROM agents WHERE id = $1")
+        .bind(&agent_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|error| format!("resolve agent label {agent_id}: {error}"))?;
+
+    if exists.is_none() {
+        tracing::warn!(
+            "[triage] Ignoring unknown agent label '{}' for issue #{}",
+            agent_id,
+            issue.number
+        );
+    }
+
+    Ok(exists)
 }
 
 /// Simple priority inference from labels.

--- a/src/server/cron_catalog.rs
+++ b/src/server/cron_catalog.rs
@@ -69,3 +69,12 @@ pub fn legacy_policy_descriptors(engine: &PolicyEngine) -> Vec<CronJobDescriptor
         })
         .collect()
 }
+
+pub fn github_issue_sync_descriptor(interval_minutes: u64) -> Option<CronJobDescriptor> {
+    (interval_minutes > 0).then(|| CronJobDescriptor {
+        job_id: "github_issue_card_sync".to_string(),
+        name: "github issue card sync — reconcile GitHub issues into kanban cards".to_string(),
+        every_ms: (interval_minutes as i64) * 60_000,
+        kv_label: "github_sync".to_string(),
+    })
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod cron_catalog;
 pub mod routes;
 mod worker_registry;
 pub mod ws;
@@ -686,6 +687,36 @@ pub(crate) async fn fire_tick_hook_by_name_for_test(
         fire_tick_hook_by_name_with_timeout(engine, hook_name, label, hook_timeout).await;
     record_tick_hook_execution(db, label, &execution);
     execution.outcome
+}
+
+async fn upsert_kv_meta_pg_ignore(pg_pool: &PgPool, key: &str, value: &str) {
+    sqlx::query(
+        "INSERT INTO kv_meta (key, value)
+         VALUES ($1, $2)
+         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value",
+    )
+    .bind(key)
+    .bind(value)
+    .execute(pg_pool)
+    .await
+    .ok();
+}
+
+async fn record_periodic_job_execution_pg(
+    pg_pool: &PgPool,
+    label: &str,
+    status: &str,
+    elapsed: std::time::Duration,
+) {
+    let now_ms = chrono::Utc::now().timestamp_millis().to_string();
+    let elapsed_ms = elapsed.as_millis().to_string();
+    let key_ms = format!("last_tick_{}_ms", label);
+    let key_status = format!("last_tick_{}_status", label);
+    let key_duration = format!("last_tick_{}_duration_ms", label);
+
+    upsert_kv_meta_pg_ignore(pg_pool, &key_ms, &now_ms).await;
+    upsert_kv_meta_pg_ignore(pg_pool, &key_status, status).await;
+    upsert_kv_meta_pg_ignore(pg_pool, &key_duration, &elapsed_ms).await;
 }
 
 /// Background task that periodically fetches rate-limit data from external providers
@@ -2564,6 +2595,7 @@ async fn github_sync_loop(pg_pool: Arc<PgPool>, interval_minutes: u64) {
 
     loop {
         tokio::time::sleep(interval).await;
+        let sync_start = std::time::Instant::now();
 
         let mut advisory_lock = match try_acquire_pg_singleton_lock(
             &pg_pool,
@@ -2589,6 +2621,13 @@ async fn github_sync_loop(pg_pool: Arc<PgPool>, interval_minutes: u64) {
             Ok(repos) => repos,
             Err(error) => {
                 tracing::error!("[github-sync] Failed to list repos from PG: {error}");
+                record_periodic_job_execution_pg(
+                    &pg_pool,
+                    "github_sync",
+                    "error",
+                    sync_start.elapsed(),
+                )
+                .await;
                 if let Some(conn) = advisory_lock.take() {
                     release_pg_singleton_lock(conn, GITHUB_SYNC_ADVISORY_LOCK_ID, "github-sync")
                         .await;
@@ -2597,6 +2636,7 @@ async fn github_sync_loop(pg_pool: Arc<PgPool>, interval_minutes: u64) {
             }
         };
 
+        let mut had_errors = false;
         for repo in &repos {
             if !repo.sync_enabled {
                 continue;
@@ -2606,6 +2646,7 @@ async fn github_sync_loop(pg_pool: Arc<PgPool>, interval_minutes: u64) {
                 Ok(i) => i,
                 Err(e) => {
                     tracing::warn!("[github-sync] Fetch failed for {}: {e}", repo.id);
+                    had_errors = true;
                     continue;
                 }
             };
@@ -2616,6 +2657,7 @@ async fn github_sync_loop(pg_pool: Arc<PgPool>, interval_minutes: u64) {
                 }
                 Err(error) => {
                     tracing::warn!("[github-sync] Triage failed for {}: {error}", repo.id);
+                    had_errors = true;
                 }
                 _ => {}
             }
@@ -2635,9 +2677,18 @@ async fn github_sync_loop(pg_pool: Arc<PgPool>, interval_minutes: u64) {
                 }
                 Err(error) => {
                     tracing::error!("[github-sync] Sync failed for {}: {error}", repo.id);
+                    had_errors = true;
                 }
             }
         }
+
+        record_periodic_job_execution_pg(
+            &pg_pool,
+            "github_sync",
+            if had_errors { "error" } else { "ok" },
+            sync_start.elapsed(),
+        )
+        .await;
 
         if let Some(conn) = advisory_lock.take() {
             release_pg_singleton_lock(conn, GITHUB_SYNC_ADVISORY_LOCK_ID, "github-sync").await;

--- a/src/server/routes/cron_api.rs
+++ b/src/server/routes/cron_api.rs
@@ -1,26 +1,38 @@
 use axum::{Json, extract::State, http::StatusCode};
 use serde_json::json;
+use sqlx::Row;
 
 use super::AppState;
 
 /// Read a kv_meta value as i64.
-fn read_kv_i64(state: &AppState, key: &str) -> i64 {
-    state
-        .db
-        .lock()
-        .ok()
-        .and_then(|conn| {
-            conn.query_row("SELECT value FROM kv_meta WHERE key = ?1", [key], |row| {
-                row.get::<_, String>(0)
-            })
-            .ok()
-        })
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(0)
+async fn read_kv_i64(state: &AppState, key: &str) -> i64 {
+    read_kv_str(state, key).await.parse().ok().unwrap_or(0)
 }
 
 /// Read a kv_meta value as String.
-fn read_kv_str(state: &AppState, key: &str) -> String {
+async fn read_kv_str(state: &AppState, key: &str) -> String {
+    if let Some(pool) = state.pg_pool.as_ref() {
+        match sqlx::query("SELECT value FROM kv_meta WHERE key = $1")
+            .bind(key)
+            .fetch_optional(pool)
+            .await
+        {
+            Ok(Some(row)) => {
+                if let Ok(value) = row.try_get::<Option<String>, _>("value") {
+                    return value.unwrap_or_else(|| "unknown".to_string());
+                }
+            }
+            Ok(None) => {}
+            Err(error) => {
+                tracing::warn!(
+                    "[cron_api] read kv_meta {} from postgres failed: {}",
+                    key,
+                    error
+                );
+            }
+        }
+    }
+
     state
         .db
         .lock()
@@ -35,43 +47,25 @@ fn read_kv_str(state: &AppState, key: &str) -> String {
 }
 
 /// Build cron job list — 3-tier tick jobs (#127) + legacy per-policy entries.
-fn build_cron_jobs(state: &AppState, _agent_filter: Option<&str>) -> Vec<serde_json::Value> {
+async fn build_cron_jobs(state: &AppState, _agent_filter: Option<&str>) -> Vec<serde_json::Value> {
     let mut jobs = Vec::new();
 
-    // 3-tier tick jobs
-    let tiers: &[(&str, &str, i64, &str)] = &[
-        (
-            "tick:30s",
-            "onTick30s — [J] retry, [I-0] notification recovery, [I] deadlock, [K] orphan",
-            30_000,
-            "30s",
-        ),
-        (
-            "tick:1min",
-            "onTick1min — [A][C][D][E][L] non-critical timeouts",
-            60_000,
-            "1min",
-        ),
-        (
-            "tick:5min",
-            "onTick5min — [R][B][F][G][H][M][O] non-critical reconciliation + idle session cleanup",
-            300_000,
-            "5min",
-        ),
-    ];
-
-    for &(id, desc, every_ms, label) in tiers {
-        let last_ms = read_kv_i64(state, &format!("last_tick_{}_ms", label));
-        let status = read_kv_str(state, &format!("last_tick_{}_status", label));
-        let next_ms = if last_ms == 0 { 0 } else { last_ms + every_ms };
+    for descriptor in crate::server::cron_catalog::tier_descriptors() {
+        let last_ms = read_kv_i64(state, &format!("last_tick_{}_ms", descriptor.kv_label)).await;
+        let status = read_kv_str(state, &format!("last_tick_{}_status", descriptor.kv_label)).await;
+        let next_ms = if last_ms == 0 {
+            0
+        } else {
+            last_ms + descriptor.every_ms
+        };
 
         jobs.push(json!({
-            "id": id,
-            "name": desc,
+            "id": descriptor.job_id,
+            "name": descriptor.name,
             "enabled": true,
             "schedule": {
                 "kind": "every",
-                "everyMs": every_ms,
+                "everyMs": descriptor.every_ms,
             },
             "state": {
                 "status": "active",
@@ -82,27 +76,54 @@ fn build_cron_jobs(state: &AppState, _agent_filter: Option<&str>) -> Vec<serde_j
         }));
     }
 
-    // Legacy per-policy entries for non-tiered onTick handlers (auto-queue, triage-rules)
-    let policies = state.engine.list_policies();
-    let legacy_ms = read_kv_i64(state, "last_tick_legacy_ms");
-    let legacy_status = read_kv_str(state, "last_tick_legacy_status");
+    if state.pg_pool.is_some() {
+        if let Some(descriptor) = crate::server::cron_catalog::github_issue_sync_descriptor(
+            state.config.github.sync_interval_minutes,
+        ) {
+            let last_ms =
+                read_kv_i64(state, &format!("last_tick_{}_ms", descriptor.kv_label)).await;
+            let status =
+                read_kv_str(state, &format!("last_tick_{}_status", descriptor.kv_label)).await;
+            let next_ms = if last_ms == 0 {
+                0
+            } else {
+                last_ms + descriptor.every_ms
+            };
 
-    for p in policies
-        .iter()
-        .filter(|p| p.hooks.iter().any(|h| h == "onTick") && p.name != "timeouts")
-    {
+            jobs.push(json!({
+                "id": descriptor.job_id,
+                "name": descriptor.name,
+                "enabled": true,
+                "schedule": {
+                    "kind": "every",
+                    "everyMs": descriptor.every_ms,
+                },
+                "state": {
+                    "status": "active",
+                    "lastStatus": status,
+                    "lastRunAtMs": if last_ms == 0 { serde_json::Value::Null } else { json!(last_ms) },
+                    "nextRunAtMs": if next_ms == 0 { serde_json::Value::Null } else { json!(next_ms) },
+                },
+            }));
+        }
+    }
+
+    for descriptor in crate::server::cron_catalog::legacy_policy_descriptors(&state.engine) {
+        let legacy_ms = read_kv_i64(state, "last_tick_legacy_ms").await;
+        let legacy_status = read_kv_str(state, "last_tick_legacy_status").await;
         let next = if legacy_ms == 0 {
             0
         } else {
-            legacy_ms + 300_000
+            legacy_ms + descriptor.every_ms
         };
+
         jobs.push(json!({
-            "id": format!("policy:{}", p.name),
-            "name": format!("policy/{} → onTick (5min legacy)", p.name),
+            "id": descriptor.job_id,
+            "name": descriptor.name,
             "enabled": true,
             "schedule": {
                 "kind": "every",
-                "everyMs": 300_000,
+                "everyMs": descriptor.every_ms,
             },
             "state": {
                 "status": "active",
@@ -120,7 +141,7 @@ fn build_cron_jobs(state: &AppState, _agent_filter: Option<&str>) -> Vec<serde_j
 pub async fn list_cron_jobs(
     State(state): State<AppState>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let jobs = build_cron_jobs(&state, None);
+    let jobs = build_cron_jobs(&state, None).await;
     (StatusCode::OK, Json(json!({ "jobs": jobs })))
 }
 
@@ -129,6 +150,6 @@ pub async fn agent_cron_jobs(
     State(state): State<AppState>,
     axum::extract::Path(agent_id): axum::extract::Path<String>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let jobs = build_cron_jobs(&state, Some(&agent_id));
+    let jobs = build_cron_jobs(&state, Some(&agent_id)).await;
     (StatusCode::OK, Json(json!({ "jobs": jobs })))
 }

--- a/src/server/routes/github.rs
+++ b/src/server/routes/github.rs
@@ -3,11 +3,13 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
 };
+use libsql_rusqlite::Connection;
 use serde::Deserialize;
 use serde_json::json;
-use sqlx::Row;
+use sqlx::{PgPool, Row};
 
 use super::AppState;
+use crate::db::kanban::{IssueCardUpsert, upsert_card_from_issue_pg};
 use crate::github;
 
 // ── Body types ─────────────────────────────────────────────────
@@ -55,6 +57,55 @@ fn normalize_string_list(values: &[String]) -> Vec<String> {
         .iter()
         .filter_map(|value| trim_non_empty(value))
         .collect()
+}
+
+fn labels_metadata_json(labels: &[String]) -> Option<String> {
+    let labels = labels
+        .iter()
+        .filter_map(|label| trim_non_empty(label))
+        .collect::<Vec<_>>();
+
+    if labels.is_empty() {
+        None
+    } else {
+        Some(json!({ "labels": labels.join(",") }).to_string())
+    }
+}
+
+fn resolve_known_agent_id(conn: &Connection, agent_id: Option<&str>) -> Option<String> {
+    let agent_id = agent_id.and_then(trim_non_empty)?;
+    let exists = conn
+        .query_row(
+            "SELECT 1 FROM agents WHERE id = ?1 LIMIT 1",
+            [agent_id.as_str()],
+            |_| Ok(()),
+        )
+        .is_ok();
+    if !exists {
+        tracing::warn!("[issues] ignoring unknown assignee '{agent_id}' for linked kanban card");
+    }
+    exists.then_some(agent_id)
+}
+
+async fn resolve_known_agent_id_pg(
+    pool: &PgPool,
+    agent_id: Option<&str>,
+) -> Result<Option<String>, String> {
+    let Some(agent_id) = agent_id.and_then(trim_non_empty) else {
+        return Ok(None);
+    };
+
+    let exists = sqlx::query_scalar::<_, String>("SELECT id FROM agents WHERE id = $1 LIMIT 1")
+        .bind(&agent_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|error| format!("resolve agent {agent_id}: {error}"))?;
+
+    if exists.is_none() {
+        tracing::warn!("[issues] ignoring unknown assignee '{agent_id}' for linked kanban card");
+    }
+
+    Ok(exists)
 }
 
 fn resolve_issue_repo(input: &str) -> Result<String, String> {
@@ -174,7 +225,7 @@ fn build_pmd_issue_body(body: &CreateIssueBody) -> Result<String, String> {
 
 /// POST /api/issues
 pub async fn create_issue(
-    State(_state): State<AppState>,
+    State(state): State<AppState>,
     Json(body): Json<CreateIssueBody>,
 ) -> (StatusCode, Json<serde_json::Value>) {
     if body.auto_dispatch.unwrap_or(false) {
@@ -237,18 +288,143 @@ pub async fn create_issue(
         .unwrap_or_default();
 
     match github::create_issue_with_labels(&repo, &title, &issue_body, &applied_labels).await {
-        Ok(created) => (
-            StatusCode::CREATED,
-            Json(json!({
-                "issue": {
-                    "number": created.number,
-                    "url": created.url,
-                    "repo": repo,
-                },
-                "applied_labels": applied_labels,
-                "pmd_format_version": PMD_FORMAT_VERSION,
-            })),
-        ),
+        Ok(created) => {
+            let metadata_json = labels_metadata_json(&applied_labels);
+            let (kanban_card_id, kanban_card_sync_error) = if let Some(pool) =
+                state.pg_pool.as_ref()
+            {
+                let assigned_agent_id = match resolve_known_agent_id_pg(
+                    pool,
+                    body.agent_id.as_deref(),
+                )
+                .await
+                {
+                    Ok(agent_id) => agent_id,
+                    Err(error) => {
+                        tracing::error!(
+                            "[issues] created GitHub issue {}#{} but failed to resolve assignee: {}",
+                            repo,
+                            created.number,
+                            error
+                        );
+                        return (
+                            StatusCode::CREATED,
+                            Json(json!({
+                                "issue": {
+                                    "number": created.number,
+                                    "url": created.url,
+                                    "repo": repo,
+                                },
+                                "kanban_card_id": serde_json::Value::Null,
+                                "kanban_card_sync_error": error,
+                                "applied_labels": applied_labels,
+                                "pmd_format_version": PMD_FORMAT_VERSION,
+                            })),
+                        );
+                    }
+                };
+                match upsert_card_from_issue_pg(
+                    pool,
+                    IssueCardUpsert {
+                        repo_id: repo.clone(),
+                        issue_number: created.number,
+                        issue_url: Some(created.url.clone()),
+                        title: title.clone(),
+                        description: Some(issue_body.clone()),
+                        priority: None,
+                        assigned_agent_id,
+                        metadata_json: metadata_json.clone(),
+                        status_on_create: Some("backlog".to_string()),
+                    },
+                )
+                .await
+                {
+                    Ok(upserted) => (Some(upserted.card_id), None),
+                    Err(error) => {
+                        tracing::error!(
+                            "[issues] created GitHub issue {}#{} but failed to sync kanban card: {}",
+                            repo,
+                            created.number,
+                            error
+                        );
+                        (None, Some(error))
+                    }
+                }
+            } else {
+                let card_id = uuid::Uuid::new_v4().to_string();
+                match state.db.lock() {
+                    Ok(conn) => {
+                        let assigned_agent_id =
+                            resolve_known_agent_id(&conn, body.agent_id.as_deref());
+                        let metadata_json = metadata_json.as_deref();
+                        match conn.execute(
+                            "INSERT INTO kanban_cards (
+                            id,
+                            repo_id,
+                            title,
+                            status,
+                            priority,
+                            assigned_agent_id,
+                            github_issue_url,
+                            github_issue_number,
+                            description,
+                            metadata,
+                            created_at,
+                            updated_at
+                         ) VALUES (
+                            ?1,
+                            ?2,
+                            ?3,
+                            'backlog',
+                            'medium',
+                            ?4,
+                            ?5,
+                            ?6,
+                            ?7,
+                            ?8,
+                            datetime('now'),
+                            datetime('now')
+                         )",
+                            libsql_rusqlite::params![
+                                card_id,
+                                repo.clone(),
+                                title.clone(),
+                                assigned_agent_id.as_deref(),
+                                created.url.clone(),
+                                created.number,
+                                issue_body.clone(),
+                                metadata_json,
+                            ],
+                        ) {
+                            Ok(_) => (Some(card_id), None),
+                            Err(error) => (
+                                None,
+                                Some(format!(
+                                    "insert sqlite issue card {}#{}: {error}",
+                                    repo, created.number
+                                )),
+                            ),
+                        }
+                    }
+                    Err(error) => (None, Some(format!("db lock: {error}"))),
+                }
+            };
+
+            (
+                StatusCode::CREATED,
+                Json(json!({
+                    "issue": {
+                        "number": created.number,
+                        "url": created.url,
+                        "repo": repo,
+                    },
+                    "kanban_card_id": kanban_card_id,
+                    "kanban_card_sync_error": kanban_card_sync_error,
+                    "applied_labels": applied_labels,
+                    "pmd_format_version": PMD_FORMAT_VERSION,
+                })),
+            )
+        }
         Err(error) => (
             StatusCode::BAD_GATEWAY,
             Json(json!({"error": format!("gh issue create failed: {error}")})),

--- a/src/server/routes/kanban.rs
+++ b/src/server/routes/kanban.rs
@@ -9,6 +9,7 @@ use serde_json::json;
 use sqlx::Row as SqlxRow;
 
 use super::AppState;
+use crate::db::kanban::{IssueCardUpsert, upsert_card_from_issue_pg};
 use crate::services::provider::ProviderKind;
 use crate::services::turn_lifecycle::{TurnLifecycleTarget, force_kill_turn};
 
@@ -1824,6 +1825,136 @@ pub async fn assign_issue(
     State(state): State<AppState>,
     Json(body): Json<AssignIssueBody>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    if let Some(pool) = state.pg_pool.as_ref() {
+        let upserted = match upsert_card_from_issue_pg(
+            pool,
+            IssueCardUpsert {
+                repo_id: body.github_repo.clone(),
+                issue_number: body.github_issue_number,
+                issue_url: body.github_issue_url.clone(),
+                title: body.title.clone(),
+                description: body.description.clone(),
+                priority: None,
+                assigned_agent_id: Some(body.assignee_agent_id.clone()),
+                metadata_json: None,
+                status_on_create: Some("backlog".to_string()),
+            },
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(error) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": error})),
+                );
+            }
+        };
+
+        let old_status = if upserted.created {
+            "backlog".to_string()
+        } else {
+            match sqlx::query_scalar::<_, String>(
+                "SELECT status FROM kanban_cards WHERE id = $1 LIMIT 1",
+            )
+            .bind(&upserted.card_id)
+            .fetch_optional(pool)
+            .await
+            {
+                Ok(Some(status)) => status,
+                Ok(None) => {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({"error": "failed to reload card after upsert"})),
+                    );
+                }
+                Err(error) => {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({"error": format!("{error}")})),
+                    );
+                }
+            }
+        };
+
+        crate::pipeline::ensure_loaded();
+        let pipeline = crate::pipeline::get();
+        let ready_state = pipeline
+            .dispatchable_states()
+            .into_iter()
+            .next()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| {
+                tracing::warn!("Pipeline has no dispatchable states, using initial state");
+                pipeline.initial_state().to_string()
+            });
+
+        if old_status != ready_state {
+            if let Some(path) = pipeline.free_path_to_dispatchable(&old_status) {
+                for step in &path {
+                    if let Err(error) = crate::kanban::transition_status_with_opts_pg(
+                        Some(&state.db),
+                        pool,
+                        &state.engine,
+                        &upserted.card_id,
+                        step,
+                        "assign",
+                        crate::engine::transition::ForceIntent::None,
+                    )
+                    .await
+                    {
+                        tracing::warn!(
+                            "[assign_issue] postgres walk step to '{step}' failed: {error}"
+                        );
+                        break;
+                    }
+                }
+            } else if let Err(error) = crate::kanban::transition_status_with_opts_pg(
+                Some(&state.db),
+                pool,
+                &state.engine,
+                &upserted.card_id,
+                &ready_state,
+                "assign",
+                crate::engine::transition::ForceIntent::None,
+            )
+            .await
+            {
+                tracing::warn!("[assign_issue] postgres transition failed: {error}");
+            }
+        }
+
+        return match load_card_json_pg(pool, &upserted.card_id).await {
+            Ok(Some(card)) => {
+                let event_name = if upserted.created {
+                    "kanban_card_created"
+                } else {
+                    "kanban_card_updated"
+                };
+                crate::server::ws::emit_event(&state.broadcast_tx, event_name, card.clone());
+                (
+                    if upserted.created {
+                        StatusCode::CREATED
+                    } else {
+                        StatusCode::OK
+                    },
+                    Json(json!({
+                        "card": card,
+                        "deduplicated": !upserted.created,
+                    })),
+                )
+            }
+            Ok(None) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "failed to read card after assign"})),
+            ),
+            Err(error) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": error})),
+            ),
+        };
+    }
+
     let id = uuid::Uuid::new_v4().to_string();
 
     let conn = match state.db.lock() {

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -4483,6 +4483,106 @@ async fn kanban_assign_card_pg_only_without_sqlite_mirror() {
     pg_db.drop().await;
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn kanban_assign_issue_pg_upserts_without_duplicates() {
+    crate::pipeline::ensure_loaded();
+
+    let db = test_db();
+    let engine = test_engine(&db);
+    let pg_db = TestPostgresDb::create().await;
+    let pg_pool = pg_db.connect_and_migrate().await;
+
+    sqlx::query("INSERT INTO agents (id, name) VALUES ($1, $2)")
+        .bind("agent-issue")
+        .bind("Agent Issue")
+        .execute(&pg_pool)
+        .await
+        .unwrap();
+
+    let app = test_api_router_with_pg(
+        db,
+        engine,
+        crate::config::Config::default(),
+        None,
+        pg_pool.clone(),
+    );
+
+    let request_body = json!({
+        "github_repo": "owner/issue-sync",
+        "github_issue_number": 77,
+        "github_issue_url": "https://github.com/owner/issue-sync/issues/77",
+        "title": "Issue sync via assign route",
+        "description": "Assign route must reuse the same card for the same issue.",
+        "assignee_agent_id": "agent-issue"
+    })
+    .to_string();
+
+    let first_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/kanban-cards/assign-issue")
+                .header("content-type", "application/json")
+                .body(Body::from(request_body.clone()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first_response.status(), StatusCode::CREATED);
+    let first_body = axum::body::to_bytes(first_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let first_json: serde_json::Value = serde_json::from_slice(&first_body).unwrap();
+    assert_eq!(first_json["deduplicated"], false);
+    assert_eq!(first_json["card"]["assigned_agent_id"], "agent-issue");
+    assert_eq!(first_json["card"]["github_issue_number"], 77);
+    assert_eq!(first_json["card"]["status"], "requested");
+    let first_card_id = first_json["card"]["id"].as_str().unwrap().to_string();
+
+    let second_response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/kanban-cards/assign-issue")
+                .header("content-type", "application/json")
+                .body(Body::from(request_body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second_response.status(), StatusCode::OK);
+    let second_body = axum::body::to_bytes(second_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let second_json: serde_json::Value = serde_json::from_slice(&second_body).unwrap();
+    assert_eq!(second_json["deduplicated"], true);
+    assert_eq!(second_json["card"]["id"], first_card_id);
+
+    let row = sqlx::query(
+        "SELECT COUNT(*)::BIGINT AS card_count, MIN(id) AS card_id, MIN(status) AS status
+         FROM kanban_cards
+         WHERE repo_id = $1 AND github_issue_number = $2",
+    )
+    .bind("owner/issue-sync")
+    .bind(77_i64)
+    .fetch_one(&pg_pool)
+    .await
+    .unwrap();
+    assert_eq!(row.try_get::<i64, _>("card_count").unwrap(), 1);
+    assert_eq!(
+        row.try_get::<Option<String>, _>("card_id").unwrap(),
+        Some(first_card_id)
+    );
+    assert_eq!(
+        row.try_get::<Option<String>, _>("status").unwrap(),
+        Some("requested".to_string())
+    );
+
+    pg_pool.close().await;
+    pg_db.drop().await;
+}
+
 #[tokio::test]
 async fn kanban_assign_card_not_found() {
     let db = test_db();
@@ -5412,7 +5512,14 @@ async fn create_issue_route_builds_pmd_body_and_agent_label() {
     let gh = install_mock_gh_issue_create("itismyfield/AgentDesk", 819);
     let db = test_db();
     let engine = test_engine(&db);
-    let app = test_api_router(db, engine, None);
+    db.lock()
+        .unwrap()
+        .execute(
+            "INSERT INTO agents (id, name) VALUES (?1, ?2)",
+            libsql_rusqlite::params!["adk-backend", "ADK Backend"],
+        )
+        .unwrap();
+    let app = test_api_router(db.clone(), engine, None);
 
     let response = app
         .oneshot(
@@ -5453,8 +5560,45 @@ async fn create_issue_route_builds_pmd_body_and_agent_label() {
         "https://github.com/itismyfield/AgentDesk/issues/819"
     );
     assert_eq!(json["issue"]["repo"], "itismyfield/AgentDesk");
+    let card_id = json["kanban_card_id"]
+        .as_str()
+        .expect("sqlite issue route must create a linked kanban card")
+        .to_string();
+    assert!(json["kanban_card_sync_error"].is_null());
     assert_eq!(json["applied_labels"], json!(["agent:adk-backend"]));
     assert_eq!(json["pmd_format_version"], 1);
+
+    let conn = db.lock().unwrap();
+    let (repo_id, status, issue_number, assigned_agent_id, metadata_raw): (
+        Option<String>,
+        String,
+        Option<i64>,
+        Option<String>,
+        Option<String>,
+    ) = conn
+        .query_row(
+            "SELECT repo_id, status, github_issue_number, assigned_agent_id, metadata
+             FROM kanban_cards
+             WHERE id = ?1",
+            [card_id.as_str()],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
+            },
+        )
+        .unwrap();
+    assert_eq!(repo_id.as_deref(), Some("itismyfield/AgentDesk"));
+    assert_eq!(status, "backlog");
+    assert_eq!(issue_number, Some(819));
+    assert_eq!(assigned_agent_id.as_deref(), Some("adk-backend"));
+    let metadata_json: serde_json::Value =
+        serde_json::from_str(metadata_raw.as_deref().expect("metadata must exist")).unwrap();
+    assert_eq!(metadata_json["labels"], "agent:adk-backend");
 
     let args = fs::read_to_string(gh.path().join("issue-create-args.txt")).unwrap();
     let args: Vec<&str> = args.lines().collect();
@@ -5480,6 +5624,111 @@ async fn create_issue_route_builds_pmd_body_and_agent_label() {
     assert!(issue_body.contains("## DoD\n- [ ] 성공 시 issue URL과 번호를 반환한다\n- [ ] DoD 항목은 체크리스트로 렌더링된다"));
     assert!(!issue_body.contains("## 의존성"));
     assert!(!issue_body.contains("## 리스크"));
+}
+
+#[tokio::test]
+async fn create_issue_route_pg_returns_kanban_card_id() {
+    let _env_lock = env_lock();
+    let _gh = install_mock_gh_issue_create("itismyfield/AgentDesk", 820);
+    let pg_db = TestPostgresDb::create().await;
+    let pg_pool = pg_db.connect_and_migrate().await;
+    let db = test_db();
+    let engine = test_engine(&db);
+
+    sqlx::query("INSERT INTO agents (id, name) VALUES ($1, $2)")
+        .bind("adk-backend")
+        .bind("ADK Backend")
+        .execute(&pg_pool)
+        .await
+        .unwrap();
+
+    let app = test_api_router_with_pg(
+        db,
+        engine,
+        crate::config::Config::default(),
+        None,
+        pg_pool.clone(),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/issues")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "repo": "ADK",
+                        "title": "PG issue sync path",
+                        "background": "Postgres-backed issue creation must return the linked card id.",
+                        "content": [
+                            "GitHub issue create success should upsert a kanban backlog card.",
+                            "Response payload should expose the linked card id."
+                        ],
+                        "dod": [
+                            "kanban_card_id is returned",
+                            "card metadata keeps the applied agent label"
+                        ],
+                        "agent_id": "adk-backend"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let card_id = json["kanban_card_id"]
+        .as_str()
+        .expect("postgres issue route must return kanban_card_id")
+        .to_string();
+    assert!(json["kanban_card_sync_error"].is_null());
+
+    let row = sqlx::query(
+        "SELECT repo_id, status, github_issue_number, assigned_agent_id, description, metadata::text AS metadata
+         FROM kanban_cards
+         WHERE id = $1",
+    )
+    .bind(&card_id)
+    .fetch_one(&pg_pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        row.try_get::<Option<String>, _>("repo_id").unwrap(),
+        Some("itismyfield/AgentDesk".to_string())
+    );
+    assert_eq!(row.try_get::<String, _>("status").unwrap(), "backlog");
+    assert_eq!(
+        row.try_get::<Option<i64>, _>("github_issue_number")
+            .unwrap(),
+        Some(820)
+    );
+    assert_eq!(
+        row.try_get::<Option<String>, _>("assigned_agent_id")
+            .unwrap(),
+        Some("adk-backend".to_string())
+    );
+    let description = row
+        .try_get::<Option<String>, _>("description")
+        .unwrap()
+        .expect("description must contain issue body");
+    assert!(description.contains("## 배경"));
+    let metadata_json: serde_json::Value = serde_json::from_str(
+        row.try_get::<Option<String>, _>("metadata")
+            .unwrap()
+            .as_deref()
+            .expect("metadata must exist"),
+    )
+    .unwrap();
+    assert_eq!(metadata_json["labels"], "agent:adk-backend");
+
+    pg_pool.close().await;
+    pg_db.drop().await;
 }
 
 #[tokio::test]
@@ -6638,13 +6887,21 @@ async fn github_repos_pg_sync_triages_open_issue() {
     let _env_lock = env_lock();
     let _gh = install_mock_gh_issue_list(
         "owner/pg-repo",
-        r#"[{"number":101,"state":"OPEN","title":"PG route open","labels":[{"name":"bug"},{"name":"p1"}],"body":"Investigate route sync"}]"#,
+        r#"[{"number":101,"state":"OPEN","title":"PG route open","labels":[{"name":"bug"},{"name":"p1"},{"name":"agent:agent-sync"}],"body":"Investigate route sync"}]"#,
         "[]",
     );
     let pg_db = TestPostgresDb::create().await;
     let pg_pool = pg_db.connect_and_migrate().await;
     let db = test_db();
     let engine = test_engine(&db);
+
+    sqlx::query("INSERT INTO agents (id, name) VALUES ($1, $2)")
+        .bind("agent-sync")
+        .bind("Agent Sync")
+        .execute(&pg_pool)
+        .await
+        .unwrap();
+
     let app = test_api_router_with_pg(
         db,
         engine,
@@ -6668,6 +6925,7 @@ async fn github_repos_pg_sync_triages_open_issue() {
     assert_eq!(register_response.status(), StatusCode::CREATED);
 
     let sync_response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -6688,13 +6946,32 @@ async fn github_repos_pg_sync_triages_open_issue() {
     assert_eq!(sync_json["cards_created"], 1);
     assert_eq!(sync_json["cards_closed"], 0);
 
-    let (status, issue_number, description, metadata_text): (
+    let second_sync_response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/github/repos/owner/pg-repo/sync")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second_sync_response.status(), StatusCode::OK);
+    let second_sync_body = axum::body::to_bytes(second_sync_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let second_sync_json: serde_json::Value = serde_json::from_slice(&second_sync_body).unwrap();
+    assert_eq!(second_sync_json["cards_created"], 0);
+
+    let (status, priority, issue_number, description, assigned_agent_id, metadata_text): (
         String,
-        Option<i32>,
+        String,
+        Option<i64>,
+        Option<String>,
         Option<String>,
         Option<String>,
     ) = sqlx::query_as(
-        "SELECT status, github_issue_number, description, metadata::text
+        "SELECT status, priority, github_issue_number, description, assigned_agent_id, metadata::text
          FROM kanban_cards
          WHERE repo_id = $1
          ORDER BY github_issue_number",
@@ -6704,11 +6981,13 @@ async fn github_repos_pg_sync_triages_open_issue() {
     .await
     .unwrap();
     assert_eq!(status, "backlog");
+    assert_eq!(priority, "high");
     assert_eq!(issue_number, Some(101));
     assert_eq!(description.as_deref(), Some("Investigate route sync"));
+    assert_eq!(assigned_agent_id.as_deref(), Some("agent-sync"));
     let metadata_json: serde_json::Value =
         serde_json::from_str(metadata_text.as_deref().expect("metadata must exist")).unwrap();
-    assert_eq!(metadata_json["labels"], "bug,p1");
+    assert_eq!(metadata_json["labels"], "bug,p1,agent:agent-sync");
 
     let last_synced_at: Option<String> =
         sqlx::query_scalar("SELECT last_synced_at::text FROM github_repos WHERE id = $1")
@@ -6717,6 +6996,50 @@ async fn github_repos_pg_sync_triages_open_issue() {
             .await
             .unwrap();
     assert!(last_synced_at.is_some());
+
+    pg_pool.close().await;
+    pg_db.drop().await;
+}
+
+#[tokio::test]
+async fn cron_jobs_include_github_issue_card_sync_job() {
+    let pg_db = TestPostgresDb::create().await;
+    let pg_pool = pg_db.connect_and_migrate().await;
+    let db = test_db();
+    let engine = test_engine(&db);
+    let app = test_api_router_with_pg(
+        db,
+        engine,
+        crate::config::Config::default(),
+        None,
+        pg_pool.clone(),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/cron-jobs")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let jobs = json["jobs"]
+        .as_array()
+        .expect("cron jobs response must include jobs array");
+    let github_sync_job = jobs
+        .iter()
+        .find(|job| job["id"] == "github_issue_card_sync")
+        .expect("cron jobs must expose github issue card sync");
+    assert_eq!(github_sync_job["schedule"]["kind"], "every");
+    assert_eq!(github_sync_job["schedule"]["everyMs"], 300000);
+    assert_eq!(github_sync_job["enabled"], true);
 
     pg_pool.close().await;
     pg_db.drop().await;
@@ -6863,7 +7186,7 @@ async fn github_repos_pg_sync_closes_card_and_cleans_live_state() {
         String,
         Option<String>,
         Option<String>,
-        Option<i32>,
+        Option<i64>,
     ) = sqlx::query_as(
         "SELECT status, latest_dispatch_id, review_status, review_round
          FROM kanban_cards


### PR DESCRIPTION
## Summary

- PG-first, idempotent GitHub issue → kanban_card upsert (issue #933)
- unifies three previously-divergent entry points (`github/triage.rs`, `server/routes/github.rs`, `server/routes/kanban.rs`) on a single `upsert_card_from_issue_pg` path
- migration 0010 deduplicates pre-existing `(repo_id, github_issue_number)` duplicates and rewires 8 referencing tables (`task_dispatches`, `dispatch_queue`, `review_decisions`, `dispatch_events`, `auto_queue_entries`, `auto_queue_phase_gates`, `kanban_cards.parent_card_id`, `dispatch_outbox`) to the canonical card before applying the unique constraint
- scheduled reconciliation added via `github_issue_sync_descriptor` (default 5 min) + `record_periodic_job_execution_pg` bookkeeping

## Implementation notes

- `IssueCardUpsert` carries the input (repo_id, issue_number, title, description, priority, assigned_agent_id, metadata_json, status_on_create) with optional fields normalized (empty strings → None)
- `IssueCardUpsertResult { card_id, created }` lets callers tell insert from update
- `cron_api.rs`: `read_kv_*` converted to async + PG path so the new sync job records `last_tick_github_sync_*` without blocking on a mutex

## Tests

- `kanban_assign_issue_pg_upserts_without_duplicates` — repeated upsert returns the same `card_id` and does not create a duplicate row
- `create_issue_route_pg_returns_kanban_card_id` — HTTP path's response shape includes the kanban card id
- `cron_jobs_include_github_issue_card_sync_job` — the scheduled job is registered with the configured interval

## Provenance

Implementation was recovered from an orphaned worktree discovered during cleanup of the 9h+ auto-queue stuck incident (the originating dispatch slot was evicted before commit). Verified with a clean `cargo build --bin agentdesk` on top of `origin/main` in a dedicated worktree, then cherry-copied here.

Closes #933.