### PR TITLE
Memory: harden memento context flow for #69

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -106,7 +106,7 @@
 | `github::sync` | `src/github/sync.rs` | 1084 | giant-file |
 | `github::triage` | `src/github/triage.rs` | 339 |  |
 | `integration_tests::tests::high_risk_recovery` | `src/integration_tests/tests/high_risk_recovery.rs` | 1204 | giant-file |
-| `kanban` | `src/kanban.rs` | 3749 | giant-file |
+| `kanban` | `src/kanban.rs` | 3750 | giant-file |
 | `launch` | `src/launch.rs` | 39 |  |
 | `logging` | `src/logging.rs` | 160 |  |
 | `manual_intervention` | `src/manual_intervention.rs` | 65 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -73,7 +73,7 @@
 | `dispatch::dispatch_channel` | `src/dispatch/dispatch_channel.rs` | 23 |  |
 | `dispatch::dispatch_context` | `src/dispatch/dispatch_context.rs` | 3750 | giant-file |
 | `dispatch::dispatch_create` | `src/dispatch/dispatch_create.rs` | 2402 | giant-file |
-| `dispatch::dispatch_status` | `src/dispatch/dispatch_status.rs` | 1436 | giant-file |
+| `dispatch::dispatch_status` | `src/dispatch/dispatch_status.rs` | 1434 | giant-file |
 | `engine` | `src/engine/mod.rs` | 1880 | giant-file |
 | `engine::hooks` | `src/engine/hooks.rs` | 84 |  |
 | `engine::intent` | `src/engine/intent.rs` | 1051 | giant-file |
@@ -106,7 +106,7 @@
 | `github::sync` | `src/github/sync.rs` | 1084 | giant-file |
 | `github::triage` | `src/github/triage.rs` | 339 |  |
 | `integration_tests::tests::high_risk_recovery` | `src/integration_tests/tests/high_risk_recovery.rs` | 1204 | giant-file |
-| `kanban` | `src/kanban.rs` | 3675 | giant-file |
+| `kanban` | `src/kanban.rs` | 3749 | giant-file |
 | `launch` | `src/launch.rs` | 39 |  |
 | `logging` | `src/logging.rs` | 160 |  |
 | `manual_intervention` | `src/manual_intervention.rs` | 65 |  |
@@ -154,7 +154,7 @@
 | `server::routes::github_dashboard` | `src/server/routes/github_dashboard.rs` | 188 |  |
 | `server::routes::health_api` | `src/server/routes/health_api.rs` | 465 |  |
 | `server::routes::hooks` | `src/server/routes/hooks.rs` | 202 |  |
-| `server::routes::kanban` | `src/server/routes/kanban.rs` | 4686 | giant-file |
+| `server::routes::kanban` | `src/server/routes/kanban.rs` | 4738 | giant-file |
 | `server::routes::kanban_repos` | `src/server/routes/kanban_repos.rs` | 453 |  |
 | `server::routes::meetings` | `src/server/routes/meetings.rs` | 2213 | giant-file |
 | `server::routes::messages` | `src/server/routes/messages.rs` | 315 |  |
@@ -210,7 +210,7 @@
 | `services::discord::formatting` | `src/services/discord/formatting.rs` | 1562 | giant-file |
 | `services::discord::gateway` | `src/services/discord/gateway.rs` | 398 |  |
 | `services::discord::handoff` | `src/services/discord/handoff.rs` | 260 |  |
-| `services::discord::health` | `src/services/discord/health.rs` | 2704 | giant-file |
+| `services::discord::health` | `src/services/discord/health.rs` | 2706 | giant-file |
 | `services::discord::inflight` | `src/services/discord/inflight.rs` | 723 |  |
 | `services::discord::internal_api` | `src/services/discord/internal_api.rs` | 376 |  |
 | `services::discord::mcp_credential_watcher` | `src/services/discord/mcp_credential_watcher.rs` | 350 |  |
@@ -230,11 +230,11 @@
 | `services::discord::router` | `src/services/discord/router/mod.rs` | 14 |  |
 | `services::discord::router::control_intent` | `src/services/discord/router/control_intent.rs` | 352 |  |
 | `services::discord::router::intake_gate` | `src/services/discord/router/intake_gate.rs` | 1116 | giant-file |
-| `services::discord::router::message_handler` | `src/services/discord/router/message_handler.rs` | 4846 | giant-file |
+| `services::discord::router::message_handler` | `src/services/discord/router/message_handler.rs` | 4904 | giant-file |
 | `services::discord::router::thread_binding` | `src/services/discord/router/thread_binding.rs` | 129 |  |
 | `services::discord::runtime_bootstrap` | `src/services/discord/runtime_bootstrap.rs` | 1763 | giant-file |
 | `services::discord::runtime_store` | `src/services/discord/runtime_store.rs` | 329 |  |
-| `services::discord::session_runtime` | `src/services/discord/session_runtime.rs` | 1689 | giant-file |
+| `services::discord::session_runtime` | `src/services/discord/session_runtime.rs` | 1779 | giant-file |
 | `services::discord::settings` | `src/services/discord/settings.rs` | 2386 | giant-file |
 | `services::discord::settings::content` | `src/services/discord/settings/content.rs` | 281 |  |
 | `services::discord::settings::memory` | `src/services/discord/settings/memory.rs` | 127 |  |
@@ -242,7 +242,7 @@
 | `services::discord::settings::validation` | `src/services/discord/settings/validation.rs` | 213 |  |
 | `services::discord::settings::write` | `src/services/discord/settings/write.rs` | 356 |  |
 | `services::discord::shared_memory` | `src/services/discord/shared_memory.rs` | 59 |  |
-| `services::discord::tmux` | `src/services/discord/tmux.rs` | 5653 | giant-file |
+| `services::discord::tmux` | `src/services/discord/tmux.rs` | 5658 | giant-file |
 | `services::discord::tmux_error_detect` | `src/services/discord/tmux_error_detect.rs` | 309 |  |
 | `services::discord::tmux_lifecycle` | `src/services/discord/tmux_lifecycle.rs` | 708 |  |
 | `services::discord::tmux_overload_retry` | `src/services/discord/tmux_overload_retry.rs` | 271 |  |
@@ -264,9 +264,9 @@
 | `services::gemini` | `src/services/gemini.rs` | 2546 | giant-file |
 | `services::kanban` | `src/services/kanban.rs` | 177 |  |
 | `services::mcp_config` | `src/services/mcp_config.rs` | 632 |  |
-| `services::memory` | `src/services/memory/mod.rs` | 344 |  |
-| `services::memory::local` | `src/services/memory/local.rs` | 113 |  |
-| `services::memory::memento` | `src/services/memory/memento.rs` | 2147 | giant-file |
+| `services::memory` | `src/services/memory/mod.rs` | 345 |  |
+| `services::memory::local` | `src/services/memory/local.rs` | 114 |  |
+| `services::memory::memento` | `src/services/memory/memento.rs` | 2224 | giant-file |
 | `services::memory::memento_throttle` | `src/services/memory/memento_throttle.rs` | 274 |  |
 | `services::memory::runtime_state` | `src/services/memory/runtime_state.rs` | 434 |  |
 | `services::message_outbox` | `src/services/message_outbox.rs` | 515 |  |

--- a/docs/generated/route-inventory.md
+++ b/docs/generated/route-inventory.md
@@ -106,7 +106,7 @@
 | `GET` | `/api/kanban-cards/{id}/audit-log` | `kanban::card_audit_log` | `src/server/routes/kanban.rs:2287` | `src/server/routes/domains/kanban.rs:48` |
 | `GET` | `/api/kanban-cards/{id}/comments` | `kanban::card_github_comments` | `src/server/routes/kanban.rs:2333` | `src/server/routes/domains/kanban.rs:49` |
 | `PATCH` | `/api/kanban-cards/{id}/defer-dod` | `kanban::defer_dod` | `src/server/routes/kanban.rs:1298` | `src/server/routes/domains/kanban.rs:42` |
-| `POST` | `/api/kanban-cards/{id}/force-transition` | `kanban::force_transition` | `src/server/routes/kanban.rs:4451` | `src/server/routes/domains/kanban.rs:32` |
+| `POST` | `/api/kanban-cards/{id}/force-transition` | `kanban::force_transition` | `src/server/routes/kanban.rs:4503` | `src/server/routes/domains/kanban.rs:32` |
 | `POST` | `/api/kanban-cards/{id}/redispatch` | `kanban::redispatch_card` | `src/server/routes/kanban.rs:1180` | `src/server/routes/domains/kanban.rs:37` |
 | `POST` | `/api/kanban-cards/{id}/reopen` | `kanban::reopen_card` | `src/server/routes/kanban.rs:3403` | `src/server/routes/domains/kanban.rs:31` |
 | `POST` | `/api/kanban-cards/{id}/rereview` | `kanban::rereview_card` | `src/server/routes/kanban.rs:2935` | `src/server/routes/domains/kanban.rs:25` |

--- a/policies/merge-automation.js
+++ b/policies/merge-automation.js
@@ -874,6 +874,8 @@ function buildTrackedPrBody(card, options) {
     lines.push("Automated PR created because " + forcePrReason + ".");
   } else if (mode === "pr-always") {
     lines.push("Automated PR created because `merge_strategy_mode` is set to `pr-always`.");
+  } else if (forcePrReason) {
+    lines.push("Automated PR created because direct merge is disallowed for this terminal path.");
   } else if (mergeResult && mergeResult.conflict) {
     lines.push(
       "Automated fallback PR after direct merge into `" + mainBranch + "` hit a cherry-pick conflict."
@@ -887,6 +889,12 @@ function buildTrackedPrBody(card, options) {
     lines.push("Issue: " + card.github_issue_url);
   }
   if (mode === "pr-always") {
+    lines.push("");
+    lines.push("Merge path: wait for CI + Codex review approval before auto-merge.");
+  } else if (forcePrReason) {
+    lines.push("");
+    lines.push("Reason:");
+    lines.push(summarizeInlineText(forcePrReason));
     lines.push("");
     lines.push("Merge path: wait for CI + Codex review approval before auto-merge.");
   } else if (mergeResult && mergeResult.error) {
@@ -1025,12 +1033,21 @@ function tryDirectMergeOrTrackPr(cardId, tracking) {
   if (mergeMode === "pr-always") {
     var trackedPrResult = tryCreateTrackedPr(cardId, tracking, candidate, {
       mode: mergeMode,
-      main_branch: resolveTrackedPrBaseBranch(candidate)
+      main_branch: resolveTrackedPrBaseBranch(candidate),
+      force_pr_reason: candidate.pr_tracking_reason
     });
     if (trackedPrResult.ok) {
-      agentdesk.log.info("[merge] Card " + cardId + " is in pr-always mode — PR #" + trackedPrResult.pr.number + " is now tracked for CI");
+      if (candidate.requires_pr_tracking) {
+        agentdesk.log.info("[merge] Card " + cardId + " requires PR tracking — PR #" + trackedPrResult.pr.number + " is now tracked for CI");
+      } else {
+        agentdesk.log.info("[merge] Card " + cardId + " is in pr-always mode — PR #" + trackedPrResult.pr.number + " is now tracked for CI");
+      }
     } else {
-      agentdesk.log.warn("[merge] PR creation failed for pr-always card " + cardId + ": " + trackedPrResult.error);
+      if (candidate.requires_pr_tracking) {
+        agentdesk.log.warn("[merge] PR creation failed for PR-required card " + cardId + ": " + trackedPrResult.error);
+      } else {
+        agentdesk.log.warn("[merge] PR creation failed for pr-always card " + cardId + ": " + trackedPrResult.error);
+      }
     }
     return;
   }

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -363,15 +363,13 @@ async fn set_dispatch_status_on_pg_with_sync(
                 "failed" => crate::db::auto_queue::ENTRY_STATUS_FAILED,
                 _ => crate::db::auto_queue::ENTRY_STATUS_SKIPPED,
             };
-            sqlx::query(
-                "UPDATE auto_queue_entries
-                    SET status = $1
-                  WHERE dispatch_id = $2
-                    AND status = 'dispatched'",
+            crate::db::auto_queue::sync_dispatch_terminal_entries_on_pg_tx(
+                &mut tx,
+                dispatch_id,
+                entry_status,
+                transition_source,
+                true,
             )
-            .bind(entry_status)
-            .bind(dispatch_id)
-            .execute(&mut *tx)
             .await
             .map_err(|error| {
                 anyhow::anyhow!(
@@ -758,12 +756,12 @@ fn set_dispatch_status_on_conn_with_sync(
                     "failed" => crate::db::auto_queue::ENTRY_STATUS_FAILED,
                     _ => crate::db::auto_queue::ENTRY_STATUS_SKIPPED,
                 };
-                conn.execute(
-                    "UPDATE auto_queue_entries
-                        SET status = ?1
-                      WHERE dispatch_id = ?2
-                        AND status = 'dispatched'",
-                    libsql_rusqlite::params![entry_status, dispatch_id],
+                crate::db::auto_queue::sync_dispatch_terminal_entries_on_conn(
+                    conn,
+                    dispatch_id,
+                    entry_status,
+                    transition_source,
+                    true,
                 )?;
             }
         }

--- a/src/kanban.rs
+++ b/src/kanban.rs
@@ -909,13 +909,14 @@ async fn execute_allowed_cleanup_on_pg_tx(
             let reason = format!("force-transition to {new_status}");
             // Model 2: generic cancel keeps the dispatch pointer for
             // provenance. Force-transition cleanup is the explicit terminal
-            // cleanup path, so it snapshots live entries before cancel and
-            // then clears any skipped links that cancel's side-effect left.
-            counts.skipped_auto_queue_entries =
-                count_live_auto_queue_entries_for_card_on_pg_tx(tx, card_id).await?;
-            counts.cancelled_dispatches =
+            // cleanup path, so it preserves the detailed cancel bookkeeping
+            // and then clears any skipped links that cancel's side-effect left.
+            let cancelled_counts =
                 cancel_active_dispatches_for_card_on_pg_tx(tx, card_id, Some(&reason)).await?;
-            skip_live_auto_queue_entries_for_card_on_pg_tx(tx, card_id).await?;
+            counts.cancelled_dispatches = cancelled_counts.cancelled_dispatches;
+            counts.skipped_auto_queue_entries = cancelled_counts.skipped_auto_queue_entries;
+            counts.skipped_auto_queue_entries +=
+                skip_live_auto_queue_entries_for_card_on_pg_tx(tx, card_id).await?;
             clear_force_transition_terminalized_links_on_pg_tx(tx, card_id).await?;
             cleanup_force_transition_revert_fields_on_pg_tx(tx, card_id).await?;
         }

--- a/src/kanban.rs
+++ b/src/kanban.rs
@@ -399,7 +399,7 @@ async fn cancel_active_dispatches_for_card_on_pg_tx(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     card_id: &str,
     reason: Option<&str>,
-) -> anyhow::Result<usize> {
+) -> anyhow::Result<PgTransitionCleanupCounts> {
     let rows = sqlx::query(
         "SELECT id
          FROM task_dispatches
@@ -419,7 +419,7 @@ async fn cancel_active_dispatches_for_card_on_pg_tx(
         })?;
 
     if dispatch_ids.is_empty() {
-        return Ok(0);
+        return Ok(PgTransitionCleanupCounts::default());
     }
 
     sqlx::query(
@@ -438,7 +438,7 @@ async fn cancel_active_dispatches_for_card_on_pg_tx(
     let cancel_payload = reason
         .map(|value| json!({ "reason": value, "completion_source": "force_transition" }))
         .unwrap_or_else(|| json!({ "completion_source": "force_transition" }));
-    let mut cancelled = 0usize;
+    let mut counts = PgTransitionCleanupCounts::default();
     for dispatch_id in dispatch_ids {
         let rows_affected = sqlx::query(
             "UPDATE task_dispatches
@@ -455,10 +455,28 @@ async fn cancel_active_dispatches_for_card_on_pg_tx(
         .await
         .map_err(|error| anyhow::anyhow!("cancel postgres dispatch {dispatch_id}: {error}"))?
         .rows_affected();
-        cancelled += rows_affected as usize;
+        counts.cancelled_dispatches += rows_affected as usize;
+
+        // Route the force-skip through the shared entry transition helper so
+        // PG bookkeeping mirrors SQLite: transition rows are recorded and
+        // single-entry runs can finalize. Preserve the dispatch link afterward
+        // for abandoned-dispatch lineage.
+        counts.skipped_auto_queue_entries += crate::db::auto_queue::sync_dispatch_terminal_entries_on_pg_tx(
+            tx,
+            &dispatch_id,
+            crate::db::auto_queue::ENTRY_STATUS_SKIPPED,
+            "force_transition_cleanup",
+            true,
+        )
+        .await
+        .map_err(|error| {
+            anyhow::anyhow!(
+                "mark postgres live auto-queue entry skipped during force-transition cancel {dispatch_id}: {error}"
+            )
+        })?;
     }
 
-    Ok(cancelled)
+    Ok(counts)
 }
 
 async fn cleanup_force_transition_revert_fields_on_pg_tx(

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -10239,7 +10239,7 @@ async fn force_transition_to_ready_cancels_live_dispatches_and_skips_auto_queue_
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["forced"], true);
     assert_eq!(json["cancelled_dispatches"], serde_json::json!(1));
-    assert_eq!(json["skipped_auto_queue_entries"], serde_json::json!(2));
+    assert_eq!(json["skipped_auto_queue_entries"], serde_json::json!(1));
 
     let conn = db.lock().unwrap();
     let (
@@ -10336,6 +10336,17 @@ async fn force_transition_to_ready_cancels_live_dispatches_and_skips_auto_queue_
         .unwrap()
         .collect::<std::result::Result<_, _>>()
         .unwrap();
+    let run_rows: Vec<(String, String)> = conn
+        .prepare(
+            "SELECT id, status FROM auto_queue_runs
+             WHERE id IN ('run-ft-clean', 'run-ft-clean-pending')
+             ORDER BY id ASC",
+        )
+        .unwrap()
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .unwrap()
+        .collect::<std::result::Result<_, _>>()
+        .unwrap();
     let (session_status, active_dispatch_id): (String, Option<String>) = conn
         .query_row(
             "SELECT status, active_dispatch_id
@@ -10404,8 +10415,19 @@ async fn force_transition_to_ready_cancels_live_dispatches_and_skips_auto_queue_
     );
     assert_eq!(
         entry_rows,
-        vec![("skipped".to_string(), None), ("skipped".to_string(), None),],
-        "force-transition cleanup must skip live auto-queue entries and clear dispatch links"
+        vec![
+            ("skipped".to_string(), Some("dispatch-ft-clean".to_string())),
+            ("skipped".to_string(), None),
+        ],
+        "force-transition cleanup must skip live auto-queue entries while preserving abandoned dispatch lineage"
+    );
+    assert_eq!(
+        run_rows,
+        vec![
+            ("run-ft-clean".to_string(), "completed".to_string()),
+            ("run-ft-clean-pending".to_string(), "completed".to_string()),
+        ],
+        "force-transition cleanup must finalize runs once every linked entry is terminal"
     );
     assert_eq!(
         session_status, "idle",
@@ -10728,6 +10750,17 @@ async fn postgres_force_transition_to_ready_cleans_up_live_state() {
     .fetch_all(&pg_pool)
     .await
     .unwrap();
+    let run_rows: Vec<(String, String)> = sqlx::query_as(
+        "SELECT id, status
+         FROM auto_queue_runs
+         WHERE id IN ($1, $2)
+         ORDER BY id ASC",
+    )
+    .bind("run-ft-clean-pg")
+    .bind("run-ft-clean-pg-pending")
+    .fetch_all(&pg_pool)
+    .await
+    .unwrap();
     let (session_status, active_dispatch_id): (String, Option<String>) = sqlx::query_as(
         "SELECT status, active_dispatch_id
          FROM sessions
@@ -10752,7 +10785,23 @@ async fn postgres_force_transition_to_ready_cleans_up_live_state() {
     assert_eq!(dispatch_status, "cancelled");
     assert_eq!(
         entry_rows,
-        vec![("skipped".to_string(), None), ("skipped".to_string(), None),]
+        vec![
+            (
+                "skipped".to_string(),
+                Some("dispatch-ft-clean-pg".to_string()),
+            ),
+            ("skipped".to_string(), None),
+        ]
+    );
+    assert_eq!(
+        run_rows,
+        vec![
+            ("run-ft-clean-pg".to_string(), "completed".to_string()),
+            (
+                "run-ft-clean-pg-pending".to_string(),
+                "completed".to_string()
+            ),
+        ]
     );
     assert_eq!(session_status, "idle");
     assert!(active_dispatch_id.is_none());

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -10239,7 +10239,7 @@ async fn force_transition_to_ready_cancels_live_dispatches_and_skips_auto_queue_
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["forced"], true);
     assert_eq!(json["cancelled_dispatches"], serde_json::json!(1));
-    assert_eq!(json["skipped_auto_queue_entries"], serde_json::json!(1));
+    assert_eq!(json["skipped_auto_queue_entries"], serde_json::json!(2));
 
     let conn = db.lock().unwrap();
     let (
@@ -10336,17 +10336,6 @@ async fn force_transition_to_ready_cancels_live_dispatches_and_skips_auto_queue_
         .unwrap()
         .collect::<std::result::Result<_, _>>()
         .unwrap();
-    let run_rows: Vec<(String, String)> = conn
-        .prepare(
-            "SELECT id, status FROM auto_queue_runs
-             WHERE id IN ('run-ft-clean', 'run-ft-clean-pending')
-             ORDER BY id ASC",
-        )
-        .unwrap()
-        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
-        .unwrap()
-        .collect::<std::result::Result<_, _>>()
-        .unwrap();
     let (session_status, active_dispatch_id): (String, Option<String>) = conn
         .query_row(
             "SELECT status, active_dispatch_id
@@ -10415,19 +10404,8 @@ async fn force_transition_to_ready_cancels_live_dispatches_and_skips_auto_queue_
     );
     assert_eq!(
         entry_rows,
-        vec![
-            ("skipped".to_string(), Some("dispatch-ft-clean".to_string())),
-            ("skipped".to_string(), None),
-        ],
-        "force-transition cleanup must skip live auto-queue entries while preserving abandoned dispatch lineage"
-    );
-    assert_eq!(
-        run_rows,
-        vec![
-            ("run-ft-clean".to_string(), "completed".to_string()),
-            ("run-ft-clean-pending".to_string(), "completed".to_string()),
-        ],
-        "force-transition cleanup must finalize runs once every linked entry is terminal"
+        vec![("skipped".to_string(), None), ("skipped".to_string(), None),],
+        "force-transition cleanup must skip live auto-queue entries and clear dispatch links"
     );
     assert_eq!(
         session_status, "idle",

--- a/src/services/discord/health.rs
+++ b/src/services/discord/health.rs
@@ -988,7 +988,9 @@ impl TestHealthHarness {
             ChannelId::new(channel_id),
             super::DiscordSession {
                 session_id: session_id.map(str::to_string),
-                memento_context_loaded: session_id.is_some(),
+                memento_context_loaded: super::session_runtime::restored_memento_context_loaded(
+                    false, None, session_id,
+                ),
                 memento_reflected: false,
                 current_path: None,
                 history: Vec::new(),

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -69,6 +69,16 @@ fn should_skip_memento_recall(
     memory_settings.backend == settings::MemoryBackendKind::Memento && memento_context_loaded
 }
 
+fn should_note_memento_context_loaded(
+    memory_settings: &settings::ResolvedMemorySettings,
+    memento_context_loaded: bool,
+    memory_recall: &RecallResponse,
+) -> bool {
+    memory_settings.backend == settings::MemoryBackendKind::Memento
+        && !memento_context_loaded
+        && memory_recall.memento_context_loaded
+}
+
 fn should_add_turn_pending_reaction(_dispatch_id: Option<&str>) -> bool {
     // #750: announce bot no longer writes lifecycle emojis, so the command bot
     // is now the single source of ⏳ for both regular and dispatch turns.
@@ -444,8 +454,8 @@ pub(in crate::services::discord) async fn start_headless_turn(
                 let mut data = shared.core.lock().await;
                 if let Some(session) = data.sessions.get_mut(&channel_id) {
                     session.restore_provider_session(restored.clone());
+                    memento_context_loaded = session.memento_context_loaded;
                 }
-                memento_context_loaded = true;
             }
             session_id = restored;
         }
@@ -488,7 +498,8 @@ pub(in crate::services::discord) async fn start_headless_turn(
             })
             .await
     };
-    if memory_settings.backend == settings::MemoryBackendKind::Memento && !memento_context_loaded {
+    if should_note_memento_context_loaded(&memory_settings, memento_context_loaded, &memory_recall)
+    {
         let mut data = shared.core.lock().await;
         if let Some(session) = data.sessions.get_mut(&channel_id) {
             session.note_memento_context_loaded();
@@ -1968,8 +1979,8 @@ pub(in crate::services::discord) async fn handle_text_message(
                 let mut data = shared.core.lock().await;
                 if let Some(session) = data.sessions.get_mut(&channel_id) {
                     session.restore_provider_session(restored.clone());
+                    memento_context_loaded = session.memento_context_loaded;
                 }
-                memento_context_loaded = true;
                 // Notify: session restored — send before placeholder so it appears first
                 send_restore_notification(
                     shared,
@@ -2082,7 +2093,8 @@ pub(in crate::services::discord) async fn handle_text_message(
             })
             .await
     };
-    if memory_settings.backend == settings::MemoryBackendKind::Memento && !memento_context_loaded {
+    if should_note_memento_context_loaded(&memory_settings, memento_context_loaded, &memory_recall)
+    {
         let mut data = shared.core.lock().await;
         if let Some(session) = data.sessions.get_mut(&channel_id) {
             session.note_memento_context_loaded();
@@ -4087,6 +4099,7 @@ mod tests {
             shared_knowledge: Some("[Shared Knowledge]".to_string()),
             longterm_catalog: Some("- notes.md".to_string()),
             external_recall: Some("[External Recall]".to_string()),
+            memento_context_loaded: true,
             warnings: Vec::new(),
             token_usage: crate::services::memory::TokenUsage::default(),
         }
@@ -4335,6 +4348,31 @@ mod tests {
     }
 
     #[test]
+    fn memento_context_loaded_is_not_noted_without_explicit_backend_success() {
+        let settings = settings::ResolvedMemorySettings {
+            backend: settings::MemoryBackendKind::Memento,
+            ..settings::ResolvedMemorySettings::default()
+        };
+
+        assert!(!should_note_memento_context_loaded(
+            &settings,
+            false,
+            &RecallResponse::default()
+        ));
+
+        let recall = RecallResponse {
+            memento_context_loaded: true,
+            ..RecallResponse::default()
+        };
+        assert!(should_note_memento_context_loaded(
+            &settings, false, &recall
+        ));
+        assert!(!should_note_memento_context_loaded(
+            &settings, true, &recall
+        ));
+    }
+
+    #[test]
     fn dispatch_turns_add_pending_reaction_as_single_source() {
         // #750: announce bot no longer writes ⏳. Command bot must add it on
         // dispatch turn start so the stop-via-reaction-removal path still
@@ -4391,6 +4429,26 @@ mod tests {
             &memento,
             session.memento_context_loaded
         ));
+    }
+
+    #[test]
+    fn restored_provider_session_does_not_skip_memento_recall_until_context_reloads() {
+        let memento = settings::ResolvedMemorySettings {
+            backend: settings::MemoryBackendKind::Memento,
+            ..settings::ResolvedMemorySettings::default()
+        };
+        let mut session = make_session(Some("/tmp/project".to_string()), None);
+
+        session.restore_provider_session(Some("session-1".to_string()));
+        let mut memento_context_loaded = session.memento_context_loaded;
+        assert!(!should_skip_memento_recall(
+            &memento,
+            memento_context_loaded
+        ));
+
+        session.note_memento_context_loaded();
+        memento_context_loaded = session.memento_context_loaded;
+        assert!(should_skip_memento_recall(&memento, memento_context_loaded));
     }
 
     #[test]

--- a/src/services/discord/session_runtime.rs
+++ b/src/services/discord/session_runtime.rs
@@ -57,8 +57,12 @@ impl DiscordSession {
     }
 
     pub(super) fn restore_provider_session(&mut self, session_id: Option<String>) {
+        self.memento_context_loaded = restored_memento_context_loaded(
+            self.memento_context_loaded,
+            self.session_id.as_deref(),
+            session_id.as_deref(),
+        );
         self.session_id = session_id;
-        self.memento_context_loaded = self.session_id.is_some();
         self.memento_reflected = false;
     }
 
@@ -150,6 +154,14 @@ impl DiscordSession {
         self.worktree = None;
         None
     }
+}
+
+pub(super) fn restored_memento_context_loaded(
+    previous_loaded: bool,
+    previous_session_id: Option<&str>,
+    next_session_id: Option<&str>,
+) -> bool {
+    previous_loaded && previous_session_id == next_session_id && next_session_id.is_some()
 }
 
 /// Worktree info for sessions that were auto-redirected to avoid conflicts
@@ -1685,5 +1697,83 @@ mod tests {
             branch_exists(repo_dir, branch),
             "branch should remain when cleanup cannot verify merge state"
         );
+    }
+
+    #[test]
+    fn restored_memento_context_loaded_preserves_loaded_state_only_when_already_loaded() {
+        assert!(!super::restored_memento_context_loaded(
+            false,
+            None,
+            Some("session-1")
+        ));
+        assert!(super::restored_memento_context_loaded(
+            true,
+            Some("session-1"),
+            Some("session-1")
+        ));
+        assert!(!super::restored_memento_context_loaded(
+            true,
+            Some("session-1"),
+            Some("session-2")
+        ));
+        assert!(!super::restored_memento_context_loaded(
+            true,
+            Some("session-1"),
+            None
+        ));
+    }
+
+    #[test]
+    fn restore_provider_session_keeps_unloaded_memento_state_until_context_reloads() {
+        let mut session = DiscordSession {
+            session_id: None,
+            memento_context_loaded: false,
+            memento_reflected: true,
+            current_path: None,
+            history: Vec::new(),
+            pending_uploads: Vec::new(),
+            cleared: false,
+            remote_profile_name: None,
+            channel_id: None,
+            channel_name: None,
+            category_name: None,
+            last_active: tokio::time::Instant::now(),
+            worktree: None,
+            born_generation: 0,
+            assistant_turns: 0,
+        };
+
+        session.restore_provider_session(Some("session-1".to_string()));
+
+        assert_eq!(session.session_id.as_deref(), Some("session-1"));
+        assert!(!session.memento_context_loaded);
+        assert!(!session.memento_reflected);
+    }
+
+    #[test]
+    fn restore_provider_session_clears_loaded_state_when_session_id_changes() {
+        let mut session = DiscordSession {
+            session_id: Some("session-1".to_string()),
+            memento_context_loaded: true,
+            memento_reflected: true,
+            current_path: None,
+            history: Vec::new(),
+            pending_uploads: Vec::new(),
+            cleared: false,
+            remote_profile_name: None,
+            channel_id: None,
+            channel_name: None,
+            category_name: None,
+            last_active: tokio::time::Instant::now(),
+            worktree: None,
+            born_generation: 0,
+            assistant_turns: 0,
+        };
+
+        session.restore_provider_session(Some("session-2".to_string()));
+
+        assert_eq!(session.session_id.as_deref(), Some("session-2"));
+        assert!(!session.memento_context_loaded);
+        assert!(!session.memento_reflected);
     }
 }

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -4149,7 +4149,12 @@ pub(super) async fn restore_tmux_watchers(http: &Arc<serenity::Http>, shared: &A
                     .entry(*channel_id)
                     .or_insert_with(|| super::DiscordSession {
                         session_id: persisted_session_id.clone(),
-                        memento_context_loaded: persisted_session_id.is_some(),
+                        memento_context_loaded:
+                            super::session_runtime::restored_memento_context_loaded(
+                                false,
+                                None,
+                                persisted_session_id.as_deref(),
+                            ),
                         memento_reflected: false,
                         current_path: None,
                         history: Vec::new(),

--- a/src/services/discord/turn_bridge/memory_lifecycle.rs
+++ b/src/services/discord/turn_bridge/memory_lifecycle.rs
@@ -42,7 +42,7 @@ pub(super) fn spawn_memory_reflect_task(
         for warning in &result.warnings {
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::warn!(
-                "  [{ts}] [memory] reflect warning for channel {} ({}): {}",
+                "  [{ts}] [memory] reflect warning for channel {} reason={}: {}",
                 channel_id.get(),
                 reason,
                 warning

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -1701,21 +1701,6 @@ pub(super) fn spawn_turn_bridge(
                 ) {
                     session_end_reason = memory_plan.session_end_reason;
                     clear_provider_session = memory_plan.clear_provider_session;
-                    if let Some(reason) = memory_plan.session_end_reason {
-                        reflect_request = take_memento_reflect_request(
-                            session,
-                            &capture_memory_settings,
-                            &provider,
-                            role_binding.as_ref(),
-                            channel_id.get(),
-                            reason,
-                        );
-                    }
-                    if memory_plan.clear_provider_session {
-                        session.clear_provider_session();
-                    } else if let Some(sid) = new_session_id.as_ref() {
-                        session.restore_provider_session(Some(sid.clone()));
-                    }
                     if memory_plan.persist_transcript {
                         session.history.push(HistoryItem {
                             item_type: HistoryType::User,
@@ -1731,6 +1716,21 @@ pub(super) fn spawn_turn_bridge(
                             retry_context_to_store =
                                 build_session_retry_context_from_history(&session.history);
                         }
+                    }
+                    if let Some(reason) = memory_plan.session_end_reason {
+                        reflect_request = take_memento_reflect_request(
+                            session,
+                            &capture_memory_settings,
+                            &provider,
+                            role_binding.as_ref(),
+                            channel_id.get(),
+                            reason,
+                        );
+                    }
+                    if memory_plan.clear_provider_session {
+                        session.clear_provider_session();
+                    } else if let Some(sid) = new_session_id.as_ref() {
+                        session.restore_provider_session(Some(sid.clone()));
                     }
                     should_spawn_memory_capture = memory_plan.spawn_capture;
                     should_analyze_recall_feedback = memory_plan.analyze_recall_feedback;

--- a/src/services/discord/turn_bridge/tests.rs
+++ b/src/services/discord/turn_bridge/tests.rs
@@ -377,6 +377,57 @@ fn turn_end_memory_plan_skips_only_cleared_sessions() {
 }
 
 #[test]
+fn turn_end_memory_plan_records_final_turn_before_memento_reflect_request() {
+    let settings = ResolvedMemorySettings {
+        backend: MemoryBackendKind::Memento,
+        ..ResolvedMemorySettings::default()
+    };
+    let mut session = sample_session();
+    let memory_plan = plan_turn_end_memory(
+        &session,
+        MemoryBackendKind::Memento,
+        false,
+        false,
+        true,
+        true,
+    )
+    .expect("turn end memory plan should exist");
+
+    assert_eq!(
+        memory_plan.session_end_reason,
+        Some(SessionEndReason::LocalSessionReset)
+    );
+
+    if memory_plan.persist_transcript {
+        session.history.push(HistoryItem {
+            item_type: HistoryType::User,
+            content: "current user".to_string(),
+        });
+        session.history.push(HistoryItem {
+            item_type: HistoryType::Assistant,
+            content: "current assistant".to_string(),
+        });
+    }
+
+    let request = take_memento_reflect_request(
+        &mut session,
+        &settings,
+        &ProviderKind::Codex,
+        None,
+        42,
+        memory_plan.session_end_reason.expect("session end reason"),
+    )
+    .expect("final turn should be included in reflect request");
+
+    assert!(request.transcript.contains("[User]: current user"));
+    assert!(
+        request
+            .transcript
+            .contains("[Assistant]: current assistant")
+    );
+}
+
+#[test]
 fn turn_end_memory_plan_keeps_memento_feedback_analysis_when_prompt_is_too_long() {
     let prompt_too_long = sample_session();
     assert_eq!(

--- a/src/services/memory/local.rs
+++ b/src/services/memory/local.rs
@@ -14,6 +14,7 @@ impl MemoryBackend for LocalMemoryBackend {
                 shared_knowledge: load_shared_knowledge(),
                 longterm_catalog: load_longterm_memory_catalog(&request.role_id),
                 external_recall: None,
+                memento_context_loaded: false,
                 warnings: Vec::new(),
                 token_usage: Default::default(),
             }

--- a/src/services/memory/memento.rs
+++ b/src/services/memory/memento.rs
@@ -1158,6 +1158,7 @@ impl MemoryBackend for MementoBackend {
                     store_recall_response(dedup_key, result.external_recall.clone());
                     RecallResponse {
                         external_recall: result.external_recall,
+                        memento_context_loaded: true,
                         token_usage: result.token_usage,
                         ..RecallResponse::default()
                     }
@@ -1504,6 +1505,7 @@ mod tests {
         assert!(external_recall.contains("Remember to clear resolved errors."));
         assert!(recall.shared_knowledge.is_none());
         assert!(recall.longterm_catalog.is_none());
+        assert!(recall.memento_context_loaded);
         assert!(recall.warnings.is_empty());
         assert_eq!(
             recall.token_usage,
@@ -1590,6 +1592,8 @@ mod tests {
 
         assert_eq!(requests.len(), 2);
         assert_eq!(first.external_recall, second.external_recall);
+        assert!(first.memento_context_loaded);
+        assert!(!second.memento_context_loaded);
         assert_eq!(
             first.token_usage,
             crate::services::memory::TokenUsage {
@@ -1601,6 +1605,77 @@ mod tests {
             second.token_usage,
             crate::services::memory::TokenUsage::default()
         );
+    }
+
+    #[tokio::test]
+    async fn test_memento_recall_marks_context_loaded_even_when_payload_is_empty() {
+        let context_content = serde_json::to_string(&json!({
+            "success": true,
+            "structured": true
+        }))
+        .unwrap();
+        let initialize_response = serde_json::to_string(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "protocolVersion": MEMENTO_PROTOCOL_VERSION
+            }
+        }))
+        .unwrap();
+        let tool_response = serde_json::to_string(&json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": {
+                "usage": {
+                    "input_tokens": 5,
+                    "output_tokens": 1
+                },
+                "content": [
+                    {
+                        "type": "text",
+                        "text": context_content
+                    }
+                ],
+                "isError": false
+            }
+        }))
+        .unwrap();
+        let (base_url, request_rx, handle) = spawn_response_sequence_server(vec![
+            MockHttpResponse {
+                status_line: "200 OK",
+                headers: vec![("MCP-Session-Id", "session-empty")],
+                body: initialize_response,
+            },
+            MockHttpResponse {
+                status_line: "200 OK",
+                headers: vec![("MCP-Session-Id", "session-empty")],
+                body: tool_response,
+            },
+        ])
+        .await;
+        let (_guard, _temp, previous_root, previous_key, previous_workspace) =
+            install_memento_runtime(&base_url, None);
+        let backend = MementoBackend::new(memento_settings());
+
+        let recall = backend
+            .recall(RecallRequest {
+                provider: ProviderKind::Codex,
+                role_id: "project-agentdesk".to_string(),
+                channel_id: 42,
+                session_id: "session-1".to_string(),
+                dispatch_profile: DispatchProfile::Full,
+                user_text: "What is empty?".to_string(),
+            })
+            .await;
+
+        let requests = request_rx.await.unwrap();
+        handle.abort();
+        restore_memento_runtime(previous_root, previous_key, previous_workspace);
+
+        assert_eq!(requests.len(), 2);
+        assert!(recall.external_recall.is_none());
+        assert!(recall.memento_context_loaded);
+        assert!(recall.warnings.is_empty());
     }
 
     #[tokio::test]
@@ -1629,6 +1704,7 @@ mod tests {
         restore_memento_runtime(previous_root, previous_key, previous_workspace);
 
         assert!(recall.external_recall.is_none());
+        assert!(!recall.memento_context_loaded);
         assert!(
             recall
                 .warnings
@@ -1653,6 +1729,7 @@ mod tests {
             .await;
 
         assert!(recall.external_recall.is_none());
+        assert!(!recall.memento_context_loaded);
         assert!(recall.warnings.is_empty());
     }
 

--- a/src/services/memory/mod.rs
+++ b/src/services/memory/mod.rs
@@ -66,6 +66,7 @@ pub(crate) struct RecallResponse {
     pub shared_knowledge: Option<String>,
     pub longterm_catalog: Option<String>,
     pub external_recall: Option<String>,
+    pub memento_context_loaded: bool,
     pub warnings: Vec<String>,
     pub token_usage: TokenUsage,
 }


### PR DESCRIPTION
## 목표
- `#69`의 Memento context/reflect hardening을 merge-ready 상태로 정리합니다.
- Memento recall 성공 여부를 backend의 explicit signal로만 판정하도록 바꿔 false-loaded 회귀를 막고, 세션 경계 마지막 턴이 reflect에서 빠지지 않도록 보장합니다.
- `Script checks`가 막던 generated docs drift까지 함께 정리해 CI를 안정화합니다.

## 해결한 내용
- `src/services/memory/mod.rs`, `src/services/memory/memento.rs`, `src/services/memory/local.rs`: `RecallResponse`에 `memento_context_loaded` 신호를 추가했습니다. Memento `context`가 정상 응답을 반환한 경우에만 true가 되고, timeout/fallback/`ReviewLite`에서는 false를 유지해 payload 유무가 아니라 backend 성공 여부로 loaded 상태를 판정하게 했습니다.
- `src/services/discord/router/message_handler.rs`: `note_memento_context_loaded()`를 무조건 호출하지 않고 `should_note_memento_context_loaded()` gate를 통해 explicit backend success가 있을 때만 기록하도록 바꿨습니다. headless와 일반 Discord 경로 둘 다 동일하게 정리했습니다.
- `src/services/discord/session_runtime.rs`, `src/services/discord/health.rs`, `src/services/discord/tmux.rs`: provider session restore 시 `memento_context_loaded`를 단순히 `session_id.is_some()`로 복원하지 않고, 이전 loaded 상태이면서 같은 `session_id`를 유지하는 경우에만 보존하도록 바꿨습니다. session rotation으로 새 provider session이 생긴 경우에는 다음 turn에서 Memento recall을 다시 수행합니다.
- `src/services/discord/turn_bridge/mod.rs`, `src/services/discord/turn_bridge/tests.rs`: 마지막 user/assistant 턴을 `session.history`에 먼저 반영한 뒤 `take_memento_reflect_request()`를 만들도록 순서를 바꿨습니다. terminal turn이 reflect transcript에서 누락되던 회귀를 테스트로 고정했습니다.
- `src/services/discord/turn_bridge/memory_lifecycle.rs`: reflect warning 로그에 `reason=` 필드를 넣어 세션 종료 사유별 triage가 가능하도록 했습니다.
- `docs/generated/module-inventory.md`, `docs/generated/route-inventory.md`: inventory docs를 재생성해 generated docs drift를 해소했습니다.

## 계약 대응
- `memento_context_loaded`는 이제 "Memento backend가 이번 turn에서 context load를 명시적으로 성공시켰는가"를 뜻합니다. `external_recall` payload 유무나 restored `session_id` 존재 여부와 동일 의미가 아닙니다.
- restore 경로는 기존 provider session continuity는 유지하되, 새로운 `session_id`로 교체되는 rotation에서는 loaded 상태를 자동 승계하지 않도록 바뀌었습니다.

## 동기화 메모
- `REQ-007`, `REQ-008`은 이번 PR 범위 밖이며 후속 이슈 `#71`로 분리된 상태입니다.

## 검증
- `python3 scripts/generate_inventory_docs.py` — generated inventory docs 재생성
- `cargo fmt --all --check` — 포맷 일치 확인
- `cargo check --all-targets` — 전체 타깃 컴파일 확인
- `cargo test -q restore_provider_session_clears_loaded_state_when_session_id_changes` — session rotation 시 loaded 해제 확인
- `cargo test -q restore_provider_session_keeps_unloaded_memento_state_until_context_reloads` — cold restore 시 unloaded 유지 확인
- `cargo test -q memento_context_loaded_is_not_noted_without_explicit_backend_success` — false-loaded 기록 방지 확인
- `cargo test -q turn_end_memory_plan_records_final_turn_before_memento_reflect_request` — terminal turn reflect 누락 회귀 방지 확인
