### PR TITLE
Add heartbeat refresh to turn_bridge active turn path (#982)

### DIFF
--- a/src/dispatch/dispatch_context.rs
+++ b/src/dispatch/dispatch_context.rs
@@ -99,6 +99,10 @@ pub(crate) fn dispatch_type_force_new_session_default(dispatch_type: Option<&str
         .map(|strategy| strategy.reset_provider_state)
 }
 
+pub(crate) fn dispatch_type_requires_fresh_worktree(dispatch_type: Option<&str>) -> bool {
+    matches!(dispatch_type, Some("implementation" | "rework"))
+}
+
 pub(crate) fn dispatch_type_uses_thread_routing(dispatch_type: Option<&str>) -> bool {
     !matches!(dispatch_type, Some("phase-gate"))
 }

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -21,8 +21,8 @@ pub(crate) use dispatch_context::{
     DispatchSessionStrategy, REVIEW_QUALITY_CHECKLIST, REVIEW_QUALITY_SCOPE_REMINDER,
     REVIEW_VERDICT_IMPROVE_GUIDANCE, commit_belongs_to_card_issue, commit_belongs_to_card_issue_pg,
     dispatch_session_strategy_from_context, dispatch_type_force_new_session_default,
-    dispatch_type_session_strategy_default, dispatch_type_uses_thread_routing,
-    inject_review_dispatch_identifiers, resolve_card_worktree,
+    dispatch_type_requires_fresh_worktree, dispatch_type_session_strategy_default,
+    dispatch_type_uses_thread_routing, inject_review_dispatch_identifiers, resolve_card_worktree,
     validate_dispatch_completion_evidence,
 };
 #[cfg(test)]

--- a/src/services/discord/commands/config.rs
+++ b/src/services/discord/commands/config.rs
@@ -1529,7 +1529,8 @@ agents:
 
     #[test]
     fn codex_catalog_includes_spark_preview_entry() {
-        let spark = known_models(&ProviderKind::Codex)
+        let codex_models = known_models(&ProviderKind::Codex);
+        let spark = codex_models
             .iter()
             .find(|entry| entry.value == "gpt-5.3-codex-spark")
             .expect("spark entry missing");

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -7,7 +7,7 @@ use super::InflightRestartMode;
 use super::runtime_store::{atomic_write, discord_inflight_root};
 use crate::services::provider::ProviderKind;
 
-const INFLIGHT_STATE_VERSION: u32 = 4;
+const INFLIGHT_STATE_VERSION: u32 = 5;
 const INFLIGHT_MAX_AGE_SECS: u64 = 300; // 5 minutes
 const DRAIN_RESTART_MAX_AGE_SECS: u64 = 1800; // 30 minutes
 const HOT_SWAP_HANDOFF_MAX_AGE_SECS: u64 = 900; // 15 minutes
@@ -33,6 +33,12 @@ pub(super) struct InflightTurnState {
     pub tmux_session_name: Option<String>,
     pub output_path: Option<String>,
     pub input_fifo_path: Option<String>,
+    #[serde(default)]
+    pub worktree_path: Option<String>,
+    #[serde(default)]
+    pub worktree_branch: Option<String>,
+    #[serde(default)]
+    pub base_commit: Option<String>,
     pub last_offset: u64,
     /// Stable start offset for the current turn's output JSONL slice.
     #[serde(default)]
@@ -119,6 +125,9 @@ impl InflightTurnState {
             tmux_session_name,
             output_path,
             input_fifo_path,
+            worktree_path: None,
+            worktree_branch: None,
+            base_commit: None,
             last_offset,
             turn_start_offset: Some(last_offset),
             full_response: String::new(),
@@ -151,6 +160,17 @@ impl InflightTurnState {
     pub fn clear_restart_mode(&mut self) {
         self.restart_mode = None;
         self.restart_generation = None;
+    }
+
+    pub fn set_worktree_context(
+        &mut self,
+        worktree_path: Option<String>,
+        worktree_branch: Option<String>,
+        base_commit: Option<String>,
+    ) {
+        self.worktree_path = worktree_path;
+        self.worktree_branch = worktree_branch;
+        self.base_commit = base_commit;
     }
 }
 
@@ -500,6 +520,41 @@ mod tests {
         assert_eq!(loaded[0].current_msg_id, 999);
         assert_eq!(loaded[0].last_offset, 42);
         assert_eq!(loaded[0].turn_start_offset, Some(42));
+    }
+
+    #[test]
+    fn test_save_and_load_inflight_state_preserves_worktree_metadata() {
+        let temp = TempDir::new().unwrap();
+
+        let mut state = InflightTurnState::new(
+            ProviderKind::Codex,
+            123,
+            Some("adk-cdx".to_string()),
+            456,
+            789,
+            999,
+            "hello".to_string(),
+            Some("session-1".to_string()),
+            Some("AgentDesk-codex-adk-cdx".to_string()),
+            Some("/tmp/out.jsonl".to_string()),
+            Some("/tmp/in.fifo".to_string()),
+            42,
+        );
+        state.set_worktree_context(
+            Some("/tmp/worktree".to_string()),
+            Some("agentdesk/codex/adk-cdx".to_string()),
+            Some("abc123".to_string()),
+        );
+        save_inflight_state_in_root(temp.path(), &state).unwrap();
+
+        let loaded = load_inflight_states_from_root(temp.path(), &ProviderKind::Codex);
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].worktree_path.as_deref(), Some("/tmp/worktree"));
+        assert_eq!(
+            loaded[0].worktree_branch.as_deref(),
+            Some("agentdesk/codex/adk-cdx")
+        );
+        assert_eq!(loaded[0].base_commit.as_deref(), Some("abc123"));
     }
 
     #[test]

--- a/src/services/discord/mcp_credential_watcher.rs
+++ b/src/services/discord/mcp_credential_watcher.rs
@@ -18,15 +18,225 @@
 //! do not persist this across restarts because the cooldown is short (5min default)
 //! and re-notification after a restart is harmless.
 
-use std::path::PathBuf;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use dashmap::DashMap;
+use notify::EventKind;
 use poise::serenity_prelude::ChannelId;
+use serde_json::Value;
 use tokio::sync::mpsc;
 
 use super::SharedData;
+
+#[derive(Debug, Clone)]
+struct CredentialChange {
+    path: PathBuf,
+    kind: EventKind,
+    timestamp: SystemTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FileSnapshot {
+    Config(String),
+    CredentialsPresent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct McpConfigDiff {
+    added: Vec<String>,
+    removed: Vec<String>,
+    changed: Vec<String>,
+}
+
+impl McpConfigDiff {
+    fn is_empty(&self) -> bool {
+        self.added.is_empty() && self.removed.is_empty() && self.changed.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FileChangeSummary {
+    Config { file: String, diff: McpConfigDiff },
+    Credentials { file: String, detail: &'static str },
+}
+
+impl FileChangeSummary {
+    fn render(&self) -> String {
+        match self {
+            Self::Config { file, diff } => {
+                let mut parts = Vec::new();
+                if !diff.added.is_empty() {
+                    parts.push(prefix_names("+", &diff.added));
+                }
+                if !diff.removed.is_empty() {
+                    parts.push(prefix_names("-", &diff.removed));
+                }
+                if !diff.changed.is_empty() {
+                    parts.push(prefix_names("변경 ", &diff.changed));
+                }
+                format!("{file}: {}", parts.join(", "))
+            }
+            Self::Credentials { file, detail } => format!("{file}: {detail}"),
+        }
+    }
+}
+
+fn prefix_names(prefix: &str, names: &[String]) -> String {
+    names
+        .iter()
+        .map(|name| format!("{prefix}{name}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn snapshot_existing_files(paths: &[PathBuf]) -> HashMap<PathBuf, Option<FileSnapshot>> {
+    paths
+        .iter()
+        .map(|path| (path.clone(), snapshot_file(path).unwrap_or(None)))
+        .collect()
+}
+
+fn snapshot_file(path: &Path) -> std::io::Result<Option<FileSnapshot>> {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => {
+            if is_credentials_file(path) {
+                Ok(Some(FileSnapshot::CredentialsPresent))
+            } else {
+                Ok(Some(FileSnapshot::Config(canonical_mcp_config(&contents))))
+            }
+        }
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn is_credentials_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == ".credentials.json")
+}
+
+fn canonical_mcp_config(contents: &str) -> String {
+    let Ok(value) = serde_json::from_str::<Value>(contents) else {
+        return "{}".to_string();
+    };
+    let entries = extract_mcp_server_entries(&value);
+    serde_json::to_string(&entries).unwrap_or_else(|_| "{}".to_string())
+}
+
+fn extract_mcp_server_entries(value: &Value) -> BTreeMap<String, String> {
+    let mut entries = BTreeMap::new();
+    for key in ["mcpServers", "mcp_servers"] {
+        let Some(servers) = value.get(key).and_then(Value::as_object) else {
+            continue;
+        };
+        for (name, server_config) in servers {
+            let rendered =
+                serde_json::to_string(server_config).unwrap_or_else(|_| "null".to_string());
+            entries.insert(name.clone(), rendered);
+        }
+    }
+    entries
+}
+
+fn parse_config_snapshot(snapshot: Option<&FileSnapshot>) -> BTreeMap<String, String> {
+    let Some(FileSnapshot::Config(config)) = snapshot else {
+        return BTreeMap::new();
+    };
+    serde_json::from_str::<BTreeMap<String, String>>(config).unwrap_or_default()
+}
+
+fn diff_mcp_config(
+    previous: Option<&FileSnapshot>,
+    current: Option<&FileSnapshot>,
+) -> McpConfigDiff {
+    let previous = parse_config_snapshot(previous);
+    let current = parse_config_snapshot(current);
+    let previous_names = previous.keys().cloned().collect::<BTreeSet<_>>();
+    let current_names = current.keys().cloned().collect::<BTreeSet<_>>();
+
+    let added = current_names
+        .difference(&previous_names)
+        .cloned()
+        .collect::<Vec<_>>();
+    let removed = previous_names
+        .difference(&current_names)
+        .cloned()
+        .collect::<Vec<_>>();
+    let changed = current_names
+        .intersection(&previous_names)
+        .filter(|name| previous.get(*name) != current.get(*name))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    McpConfigDiff {
+        added,
+        removed,
+        changed,
+    }
+}
+
+fn summarize_change(
+    path: &Path,
+    previous: Option<&FileSnapshot>,
+    current: Option<&FileSnapshot>,
+) -> Option<FileChangeSummary> {
+    let file = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("credential file")
+        .to_string();
+    if is_credentials_file(path) {
+        let detail = match (previous, current) {
+            (None, Some(FileSnapshot::CredentialsPresent)) => "created",
+            (Some(FileSnapshot::CredentialsPresent), None) => "removed",
+            (Some(FileSnapshot::CredentialsPresent), Some(FileSnapshot::CredentialsPresent)) => {
+                "updated"
+            }
+            _ => return None,
+        };
+        return Some(FileChangeSummary::Credentials { file, detail });
+    }
+
+    let diff = diff_mcp_config(previous, current);
+    if diff.is_empty() {
+        return None;
+    }
+    Some(FileChangeSummary::Config { file, diff })
+}
+
+fn build_notification_from_changes(
+    changes: &[CredentialChange],
+    snapshots: &mut HashMap<PathBuf, Option<FileSnapshot>>,
+    notify_message: &str,
+) -> Option<String> {
+    let mut changed_paths = BTreeSet::new();
+    for change in changes {
+        let _ = &change.kind;
+        let _ = change.timestamp;
+        changed_paths.insert(change.path.clone());
+    }
+
+    let mut summaries = Vec::new();
+    for path in changed_paths {
+        let previous = snapshots.get(&path).cloned().flatten();
+        let current = snapshot_file(&path).unwrap_or(None);
+        snapshots.insert(path.clone(), current.clone());
+        if let Some(summary) = summarize_change(&path, previous.as_ref(), current.as_ref()) {
+            summaries.push(summary.render());
+        }
+    }
+
+    if summaries.is_empty() {
+        None
+    } else {
+        Some(format!("{notify_message} ({})", summaries.join("; ")))
+    }
+}
 
 /// In-memory per-channel cooldown tracker — skip notifying a channel if it was
 /// notified within the dedupe window.
@@ -131,9 +341,10 @@ pub(super) fn spawn_watcher(
         return;
     }
 
-    let (tx, mut rx) = mpsc::unbounded_channel::<()>();
+    let (tx, mut rx) = mpsc::unbounded_channel::<CredentialChange>();
     let watch_dirs_for_thread = watch_dirs.clone();
     let paths_for_filter = paths.clone();
+    let paths_for_snapshots = paths.clone();
 
     // Notify watcher runs on its own OS thread (the notify crate uses sync callbacks).
     std::thread::Builder::new()
@@ -153,14 +364,23 @@ pub(super) fn spawn_watcher(
                     ) {
                         return;
                     }
-                    let touched_credential = event.paths.iter().any(|path| {
-                        paths_for_filter.iter().any(|target| {
-                            path.file_name() == target.file_name()
-                                && path.parent() == target.parent()
+                    let changed_paths = event
+                        .paths
+                        .iter()
+                        .filter_map(|path| {
+                            paths_for_filter.iter().find(|target| {
+                                path.file_name() == target.file_name()
+                                    && path.parent() == target.parent()
+                            })
                         })
-                    });
-                    if touched_credential {
-                        let _ = watcher_tx.send(());
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    for path in changed_paths {
+                        let _ = watcher_tx.send(CredentialChange {
+                            path,
+                            kind: event.kind.clone(),
+                            timestamp: SystemTime::now(),
+                        });
                     }
                 }) {
                     Ok(w) => w,
@@ -210,20 +430,27 @@ pub(super) fn spawn_watcher(
     // Async consumer: debounce + dispatch notifications.
     let dedupe = Arc::new(CredentialNotifyDedupe::new());
     tokio::spawn(async move {
+        let mut snapshots = snapshot_existing_files(&paths_for_snapshots);
         let debounce = Duration::from_millis(750);
         loop {
             // Wait for an event.
-            if rx.recv().await.is_none() {
+            let Some(first_change) = rx.recv().await else {
                 return;
-            }
+            };
             // Drain any backlog inside the debounce window so we send at most one
             // notification per burst of file events (e.g. credential rotation that
             // touches both files in quick succession).
             tokio::time::sleep(debounce).await;
-            while rx.try_recv().is_ok() {}
+            let mut changes = vec![first_change];
+            while let Ok(change) = rx.try_recv() {
+                changes.push(change);
+            }
 
             tracing::info!("MCP credential change detected — notifying active Claude sessions");
-            broadcast_credential_change(&shared, &dedupe, dedupe_window, notify_message).await;
+            let notification =
+                build_notification_from_changes(&changes, &mut snapshots, notify_message)
+                    .unwrap_or_else(|| notify_message.to_string());
+            broadcast_credential_change(&shared, &dedupe, dedupe_window, &notification).await;
         }
     });
 }
@@ -275,10 +502,12 @@ async fn broadcast_credential_change(
 
 #[cfg(test)]
 mod tests {
-    use super::{CredentialNotifyDedupe, credential_paths_with_overrides};
+    use super::*;
+    use notify::event::{CreateKind, ModifyKind};
     use poise::serenity_prelude::ChannelId;
     use std::path::PathBuf;
-    use std::time::{Duration, Instant};
+    use std::time::{Duration, Instant, SystemTime};
+    use tempfile::tempdir;
 
     #[test]
     fn credential_paths_covers_top_level_config_and_dot_claude_files() {

--- a/src/services/discord/model_catalog.rs
+++ b/src/services/discord/model_catalog.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
-use std::time::UNIX_EPOCH;
+use std::time::{Duration, UNIX_EPOCH};
 
 use regex::Regex;
 use serde::Deserialize;
@@ -84,6 +84,12 @@ const CLAUDE_MODEL_CATALOG: &[ModelCatalogEntry] = &[
 ];
 
 const CODEX_MODEL_CATALOG: &[ModelCatalogEntry] = &[
+    ModelCatalogEntry {
+        value: "gpt-5.5",
+        label: "GPT-5.5",
+        primary_summary: "Frontier complex work",
+        secondary_summary: "Local CLI catalog",
+    },
     ModelCatalogEntry {
         value: "gpt-5.4",
         label: "gpt-5.4",
@@ -191,10 +197,24 @@ const GEMINI_MODEL_CATALOG: &[ModelCatalogEntry] = &[
     },
 ];
 
-static CODEX_MODEL_CATALOG_DYNAMIC: OnceLock<Vec<ModelCatalogEntry>> = OnceLock::new();
-static GEMINI_MODEL_CATALOG_DYNAMIC: OnceLock<Vec<ModelCatalogEntry>> = OnceLock::new();
+static CODEX_MODEL_CATALOG_DYNAMIC: OnceLock<Mutex<FileBackedCatalogCache>> = OnceLock::new();
+static GEMINI_MODEL_CATALOG_DYNAMIC: OnceLock<Mutex<FileBackedCatalogCache>> = OnceLock::new();
 static QWEN_MODEL_CATALOG_CACHE: OnceLock<Mutex<HashMap<String, QwenResolvedCatalog>>> =
     OnceLock::new();
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct FileBackedCatalogCacheKey {
+    path: PathBuf,
+    modified_secs: u64,
+    modified_nanos: u32,
+    len: u64,
+}
+
+#[derive(Clone, Debug, Default)]
+struct FileBackedCatalogCache {
+    key: Option<FileBackedCatalogCacheKey>,
+    entries: Vec<ModelCatalogEntry>,
+}
 
 #[derive(Debug, Deserialize)]
 struct CodexModelsCache {
@@ -268,6 +288,10 @@ fn codex_catalog_summary(model: &str) -> CatalogSummary {
         "gpt-5.4" => CatalogSummary {
             primary: "Frontier coding baseline",
             secondary: "API $2.5/$15",
+        },
+        "gpt-5.5" => CatalogSummary {
+            primary: "Frontier complex work",
+            secondary: "Local CLI catalog",
         },
         "gpt-5.4-mini" => CatalogSummary {
             primary: "Fast strong mini",
@@ -360,14 +384,61 @@ fn gemini_catalog_summary(model: &str) -> CatalogSummary {
     }
 }
 
+fn file_backed_catalog_cache_key(path: PathBuf) -> Option<FileBackedCatalogCacheKey> {
+    let metadata = fs::metadata(&path).ok()?;
+    let modified = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .unwrap_or(Duration::ZERO);
+    Some(FileBackedCatalogCacheKey {
+        path,
+        modified_secs: modified.as_secs(),
+        modified_nanos: modified.subsec_nanos(),
+        len: metadata.len(),
+    })
+}
+
+fn build_file_backed_catalog(
+    cache: &'static OnceLock<Mutex<FileBackedCatalogCache>>,
+    path: Option<PathBuf>,
+    fallback: &[ModelCatalogEntry],
+    parse: fn(&str) -> Option<Vec<ModelCatalogEntry>>,
+) -> Vec<ModelCatalogEntry> {
+    let Some(path) = path else {
+        return fallback.to_vec();
+    };
+    let Some(cache_key) = file_backed_catalog_cache_key(path) else {
+        return fallback.to_vec();
+    };
+
+    let cache_cell = cache.get_or_init(|| Mutex::new(FileBackedCatalogCache::default()));
+    if let Ok(cached) = cache_cell.lock() {
+        if cached.key.as_ref() == Some(&cache_key) {
+            return cached.entries.clone();
+        }
+    }
+
+    let entries = fs::read_to_string(&cache_key.path)
+        .ok()
+        .and_then(|raw| parse(&raw))
+        .unwrap_or_else(|| fallback.to_vec());
+
+    if let Ok(mut cached) = cache_cell.lock() {
+        cached.key = Some(cache_key);
+        cached.entries = entries.clone();
+    }
+
+    entries
+}
+
 fn build_codex_model_catalog() -> Vec<ModelCatalogEntry> {
-    let Some(path) = codex_model_cache_path() else {
-        return CODEX_MODEL_CATALOG.to_vec();
-    };
-    let Ok(raw) = fs::read_to_string(path) else {
-        return CODEX_MODEL_CATALOG.to_vec();
-    };
-    build_codex_model_catalog_from_cache(&raw).unwrap_or_else(|| CODEX_MODEL_CATALOG.to_vec())
+    build_file_backed_catalog(
+        &CODEX_MODEL_CATALOG_DYNAMIC,
+        codex_model_cache_path(),
+        CODEX_MODEL_CATALOG,
+        build_codex_model_catalog_from_cache,
+    )
 }
 
 fn build_codex_model_catalog_from_cache(raw: &str) -> Option<Vec<ModelCatalogEntry>> {
@@ -449,13 +520,12 @@ fn gemini_display_label(model: &str) -> String {
 }
 
 fn build_gemini_model_catalog() -> Vec<ModelCatalogEntry> {
-    let Some(path) = gemini_models_js_path() else {
-        return GEMINI_MODEL_CATALOG.to_vec();
-    };
-    let Ok(raw) = fs::read_to_string(path) else {
-        return GEMINI_MODEL_CATALOG.to_vec();
-    };
-    build_gemini_model_catalog_from_models_js(&raw).unwrap_or_else(|| GEMINI_MODEL_CATALOG.to_vec())
+    build_file_backed_catalog(
+        &GEMINI_MODEL_CATALOG_DYNAMIC,
+        gemini_models_js_path(),
+        GEMINI_MODEL_CATALOG,
+        build_gemini_model_catalog_from_models_js,
+    )
 }
 
 fn build_gemini_model_catalog_from_models_js(raw: &str) -> Option<Vec<ModelCatalogEntry>> {
@@ -732,7 +802,7 @@ pub(crate) fn resolved_models(
 ) -> Vec<ModelCatalogEntry> {
     match provider {
         ProviderKind::Qwen => resolve_qwen_model_catalog(working_dir).entries,
-        _ => known_models(provider).to_vec(),
+        _ => known_models(provider),
     }
 }
 
@@ -751,8 +821,12 @@ pub(in crate::services::discord) fn model_hint(
 ) -> String {
     match provider {
         ProviderKind::Claude => "default + curated Claude models + custom model id".to_string(),
-        ProviderKind::Codex => "default + curated Codex models + custom model id".to_string(),
-        ProviderKind::Gemini => "default + curated Gemini models + custom model id".to_string(),
+        ProviderKind::Codex => {
+            "default + models resolved from local Codex catalog + custom model id".to_string()
+        }
+        ProviderKind::Gemini => {
+            "default + models resolved from local Gemini catalog + custom model id".to_string()
+        }
         ProviderKind::Qwen => {
             let catalog = resolve_qwen_model_catalog(working_dir);
             if catalog.entries.is_empty() {
@@ -765,17 +839,13 @@ pub(in crate::services::discord) fn model_hint(
     }
 }
 
-pub(crate) fn known_models(provider: &ProviderKind) -> &'static [ModelCatalogEntry] {
+pub(crate) fn known_models(provider: &ProviderKind) -> Vec<ModelCatalogEntry> {
     match provider {
-        ProviderKind::Claude => CLAUDE_MODEL_CATALOG,
-        ProviderKind::Codex => CODEX_MODEL_CATALOG_DYNAMIC
-            .get_or_init(build_codex_model_catalog)
-            .as_slice(),
-        ProviderKind::Gemini => GEMINI_MODEL_CATALOG_DYNAMIC
-            .get_or_init(build_gemini_model_catalog)
-            .as_slice(),
-        ProviderKind::Qwen => &[],
-        ProviderKind::Unsupported(_) => &[],
+        ProviderKind::Claude => CLAUDE_MODEL_CATALOG.to_vec(),
+        ProviderKind::Codex => build_codex_model_catalog(),
+        ProviderKind::Gemini => build_gemini_model_catalog(),
+        ProviderKind::Qwen => Vec::new(),
+        ProviderKind::Unsupported(_) => Vec::new(),
     }
 }
 
@@ -791,11 +861,10 @@ fn model_aliases(provider: &ProviderKind) -> &'static [(&'static str, &'static s
 
 fn canonical_known_model(provider: &ProviderKind, raw: &str) -> Option<&'static str> {
     let trimmed = raw.trim();
-    if let Some(entry) = known_models(provider)
-        .iter()
-        .find(|entry| entry.value.eq_ignore_ascii_case(trimmed))
-    {
-        return Some(entry.value);
+    for entry in known_models(provider) {
+        if entry.value.eq_ignore_ascii_case(trimmed) {
+            return Some(entry.value);
+        }
     }
 
     model_aliases(provider)
@@ -865,6 +934,45 @@ mod tests {
 
     use super::{build_codex_model_catalog_from_cache, build_gemini_model_catalog_from_models_js};
 
+    fn with_temp_model_catalog_home<F>(f: F)
+    where
+        F: FnOnce(&TempDir),
+    {
+        let _guard = super::super::runtime_store::lock_test_env();
+        let temp_home = TempDir::new().unwrap();
+
+        let prev_home = std::env::var_os("HOME");
+        let prev_userprofile = std::env::var_os("USERPROFILE");
+        let prev_test_home = std::env::var_os("AGENTDESK_TEST_HOME");
+
+        unsafe {
+            std::env::set_var("HOME", temp_home.path());
+            std::env::set_var("USERPROFILE", temp_home.path());
+            std::env::set_var("AGENTDESK_TEST_HOME", temp_home.path());
+        }
+
+        f(&temp_home);
+
+        match prev_home {
+            Some(value) => unsafe { std::env::set_var("HOME", value) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        match prev_userprofile {
+            Some(value) => unsafe { std::env::set_var("USERPROFILE", value) },
+            None => unsafe { std::env::remove_var("USERPROFILE") },
+        }
+        match prev_test_home {
+            Some(value) => unsafe { std::env::set_var("AGENTDESK_TEST_HOME", value) },
+            None => unsafe { std::env::remove_var("AGENTDESK_TEST_HOME") },
+        }
+    }
+
+    fn write_codex_models_cache(home: &TempDir, raw: &str) {
+        let codex_dir = home.path().join(".codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        fs::write(codex_dir.join("models_cache.json"), raw).unwrap();
+    }
+
     fn with_temp_qwen_env<F>(f: F)
     where
         F: FnOnce(&TempDir, &TempDir),
@@ -916,6 +1024,7 @@ mod tests {
         let raw = r#"{
           "models": [
             { "slug": "gpt-5.4", "display_name": "gpt-5.4", "visibility": "list" },
+            { "slug": "gpt-5.5", "display_name": "GPT-5.5", "visibility": "list" },
             { "slug": "gpt-5.4-mini", "display_name": "GPT-5.4-Mini", "visibility": "list" },
             { "slug": "gpt-5.1", "display_name": "gpt-5.1", "visibility": "hide" },
             { "slug": "gpt-5.3-codex-spark", "display_name": "GPT-5.3-Codex-Spark", "visibility": "list" }
@@ -925,12 +1034,46 @@ mod tests {
         let catalog = build_codex_model_catalog_from_cache(raw).expect("catalog");
         assert_eq!(catalog[0].value, "gpt-5.4");
         assert_eq!(catalog[0].label, "gpt-5.4");
-        assert_eq!(catalog[1].label, "GPT-5.4-Mini");
+        assert_eq!(catalog[1].value, "gpt-5.5");
+        assert_eq!(catalog[1].label, "GPT-5.5");
+        assert_eq!(catalog[2].label, "GPT-5.4-Mini");
         assert_eq!(
-            catalog[2].picker_description(),
+            catalog[3].picker_description(),
             "Text-only preview | No API"
         );
         assert!(!catalog.iter().any(|entry| entry.value == "gpt-5.1"));
+    }
+
+    #[test]
+    fn codex_known_models_reloads_when_local_cache_changes() {
+        with_temp_model_catalog_home(|home| {
+            write_codex_models_cache(
+                home,
+                r#"{
+                  "models": [
+                    { "slug": "gpt-5.4", "display_name": "gpt-5.4", "visibility": "list" }
+                  ]
+                }"#,
+            );
+            assert!(
+                super::known_models(&ProviderKind::Codex)
+                    .iter()
+                    .any(|entry| entry.value == "gpt-5.4")
+            );
+
+            write_codex_models_cache(
+                home,
+                r#"{
+                  "models": [
+                    { "slug": "gpt-5.5", "display_name": "GPT-5.5", "visibility": "list" },
+                    { "slug": "gpt-5.4-mini", "display_name": "GPT-5.4-Mini", "visibility": "list" }
+                  ]
+                }"#,
+            );
+            let catalog = super::known_models(&ProviderKind::Codex);
+            assert!(catalog.iter().any(|entry| entry.value == "gpt-5.5"));
+            assert!(!catalog.iter().any(|entry| entry.value == "gpt-5.4"));
+        });
     }
 
     #[test]

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -131,6 +131,125 @@ fn can_fast_path_captured_full_response(
         && state.last_watcher_relayed_offset.is_none()
 }
 
+fn recovery_worktree_path(state: &inflight::InflightTurnState) -> Option<&str> {
+    state
+        .worktree_path
+        .as_deref()
+        .filter(|path| !path.trim().is_empty())
+}
+
+fn recovery_worktree_branch(state: &inflight::InflightTurnState) -> Option<&str> {
+    state
+        .worktree_branch
+        .as_deref()
+        .map(str::trim)
+        .filter(|branch| !branch.is_empty())
+}
+
+fn recovery_dispatch_id(state: &inflight::InflightTurnState) -> Option<&str> {
+    state
+        .dispatch_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|dispatch_id| !dispatch_id.is_empty())
+}
+
+fn recovery_requires_worktree_context(state: &inflight::InflightTurnState) -> bool {
+    recovery_worktree_branch(state).is_some()
+        || state
+            .base_commit
+            .as_deref()
+            .is_some_and(|commit| !commit.trim().is_empty())
+}
+
+fn recovery_git_stdout(repo_path: &str, args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["-C", repo_path])
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if stdout.is_empty() {
+        return None;
+    }
+    Some(stdout)
+}
+
+fn recovery_worktree_original_path(worktree_path: &str) -> Option<String> {
+    let git_common_dir = recovery_git_stdout(worktree_path, &["rev-parse", "--git-common-dir"])?;
+    let common_dir = {
+        let candidate = std::path::PathBuf::from(&git_common_dir);
+        if candidate.is_absolute() {
+            candidate
+        } else {
+            std::path::Path::new(worktree_path).join(candidate)
+        }
+    };
+    let canonical = std::fs::canonicalize(common_dir).ok()?;
+    canonical.parent()?.to_str().map(str::to_string)
+}
+
+fn recovery_worktree_info(state: &inflight::InflightTurnState) -> Option<WorktreeInfo> {
+    let worktree_path = recovery_worktree_path(state)?;
+    if !std::path::Path::new(worktree_path).is_dir() {
+        return None;
+    }
+
+    let branch_name = recovery_worktree_branch(state)
+        .map(str::to_string)
+        .or_else(|| recovery_git_stdout(worktree_path, &["branch", "--show-current"]))?;
+    let original_path = recovery_worktree_original_path(worktree_path)?;
+
+    Some(WorktreeInfo {
+        original_path,
+        worktree_path: worktree_path.to_string(),
+        branch_name,
+    })
+}
+
+fn restore_recovered_session_worktree(
+    session: &mut DiscordSession,
+    state: &inflight::InflightTurnState,
+) {
+    if let Some(worktree) = recovery_worktree_info(state) {
+        if session.current_path.is_none() {
+            session.current_path = Some(worktree.worktree_path.clone());
+        }
+        session.worktree = Some(worktree);
+    }
+}
+
+fn recovery_spawn_adk_cwd(
+    state: &inflight::InflightTurnState,
+    persisted_session_path: Option<String>,
+) -> Result<Option<String>, String> {
+    if let Some(worktree_path) = recovery_worktree_path(state) {
+        if std::path::Path::new(worktree_path).is_dir() {
+            return Ok(Some(worktree_path.to_string()));
+        }
+        return Err(format!(
+            "recovery blocked: inflight worktree missing for channel {}: {}",
+            state.channel_id, worktree_path
+        ));
+    }
+
+    if recovery_requires_worktree_context(state) {
+        let dispatch_suffix = recovery_dispatch_id(state)
+            .map(|dispatch_id| format!(" (dispatch {dispatch_id})"))
+            .unwrap_or_default();
+        return Err(format!(
+            "recovery blocked: inflight worktree state missing for channel {}{}",
+            state.channel_id, dispatch_suffix
+        ));
+    }
+
+    Ok(persisted_session_path)
+}
+
 async fn finish_recovered_turn_mailbox(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
@@ -1034,6 +1153,7 @@ pub(super) async fn restore_inflight_turns(
                     if session.channel_name.is_none() {
                         session.channel_name = effective_channel_name;
                     }
+                    restore_recovered_session_worktree(session, &state);
                 }
 
                 // Immediately spawn a tmux watcher instead of deferring to
@@ -1810,12 +1930,48 @@ pub(super) async fn restore_inflight_turns(
                 } else {
                     shared.sqlite.as_ref()
                 };
-                let last_path = load_last_session_path(
+                let persisted_session_path = load_last_session_path(
                     sqlite_settings_db,
                     shared.pg_pool.as_ref(),
                     &shared.token_hash,
                     channel_id.get(),
                 );
+                let recovery_adk_cwd = match recovery_spawn_adk_cwd(&state, persisted_session_path)
+                {
+                    Ok(path) => path,
+                    Err(error) => {
+                        let dispatch_id = state
+                            .dispatch_id
+                            .clone()
+                            .or_else(|| parse_dispatch_id(&state.user_text));
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        tracing::error!("  [{ts}] {error}; main-workspace fallback blocked");
+                        crate::services::observability::emit_recovery_fired(
+                            provider.as_str(),
+                            state.channel_id,
+                            dispatch_id.as_deref(),
+                            state.session_key.as_deref(),
+                            "worktree_missing_main_fallback_blocked",
+                        );
+                        let _ = super::formatting::replace_long_message_raw(
+                            http,
+                            channel_id,
+                            current_msg_id,
+                            &format!("❌ {error}\nmain workspace fallback blocked."),
+                            shared,
+                        )
+                        .await;
+                        super::turn_bridge::fail_dispatch_with_retry(
+                            shared.api_port,
+                            dispatch_id.as_deref(),
+                            &error,
+                        )
+                        .await;
+                        super::restart_report::clear_restart_report(provider, state.channel_id);
+                        clear_inflight_state(provider, state.channel_id);
+                        continue;
+                    }
+                };
                 let saved_remote = load_last_remote_profile(
                     sqlite_settings_db,
                     shared.pg_pool.as_ref(),
@@ -1846,11 +2002,12 @@ pub(super) async fn restore_inflight_turns(
                 session.channel_id = Some(channel_id.get());
                 session.last_active = tokio::time::Instant::now();
                 if session.current_path.is_none() {
-                    session.current_path = last_path;
+                    session.current_path = recovery_adk_cwd;
                 }
                 if session.channel_name.is_none() {
                     session.channel_name = effective_channel_name;
                 }
+                restore_recovered_session_worktree(session, &state);
             }
 
             // Immediately spawn watcher to avoid race condition.
@@ -1945,12 +2102,47 @@ pub(super) async fn restore_inflight_turns(
         } else {
             shared.sqlite.as_ref()
         };
-        let last_path = load_last_session_path(
+        let persisted_session_path = load_last_session_path(
             sqlite_settings_db,
             shared.pg_pool.as_ref(),
             &shared.token_hash,
             channel_id.get(),
         );
+        let recovery_adk_cwd = match recovery_spawn_adk_cwd(&state, persisted_session_path) {
+            Ok(path) => path,
+            Err(error) => {
+                let dispatch_id = state
+                    .dispatch_id
+                    .clone()
+                    .or_else(|| parse_dispatch_id(&state.user_text));
+                let ts = chrono::Local::now().format("%H:%M:%S");
+                tracing::error!("  [{ts}] {error}; main-workspace fallback blocked");
+                crate::services::observability::emit_recovery_fired(
+                    provider.as_str(),
+                    state.channel_id,
+                    dispatch_id.as_deref(),
+                    state.session_key.as_deref(),
+                    "worktree_missing_main_fallback_blocked",
+                );
+                let _ = super::formatting::replace_long_message_raw(
+                    http,
+                    channel_id,
+                    current_msg_id,
+                    &format!("❌ {error}\nmain workspace fallback blocked."),
+                    shared,
+                )
+                .await;
+                super::turn_bridge::fail_dispatch_with_retry(
+                    shared.api_port,
+                    dispatch_id.as_deref(),
+                    &error,
+                )
+                .await;
+                super::restart_report::clear_restart_report(provider, state.channel_id);
+                clear_inflight_state(provider, state.channel_id);
+                continue;
+            }
+        };
         let saved_remote = load_last_remote_profile(
             sqlite_settings_db,
             shared.pg_pool.as_ref(),
@@ -1989,7 +2181,7 @@ pub(super) async fn restore_inflight_turns(
             session.channel_id = Some(channel_id.get());
             session.last_active = tokio::time::Instant::now();
             if session.current_path.is_none() {
-                session.current_path = last_path.clone();
+                session.current_path = recovery_adk_cwd.clone();
             }
             if session.channel_name.is_none() {
                 session.channel_name = channel_name.clone();
@@ -1997,6 +2189,7 @@ pub(super) async fn restore_inflight_turns(
             if session.remote_profile_name.is_none() {
                 session.remote_profile_name = saved_remote;
             }
+            restore_recovered_session_worktree(session, &state);
         }
 
         mailbox_recovery_kickoff(
@@ -2013,7 +2206,7 @@ pub(super) async fn restore_inflight_turns(
         let adk_session_info = derive_adk_session_info(
             Some(&state.user_text),
             channel_name.as_deref(),
-            last_path.as_deref(),
+            recovery_adk_cwd.as_deref(),
         );
         let role_binding = resolve_role_binding(channel_id, channel_name.as_deref());
         let adk_thread_channel_id = adk_session_name
@@ -2027,7 +2220,7 @@ pub(super) async fn restore_inflight_turns(
             provider,
             Some(&adk_session_info),
             None,
-            last_path.as_deref(),
+            recovery_adk_cwd.as_deref(),
             parse_dispatch_id(&state.user_text)
                 .or(lookup_pending_dispatch_for_thread(shared.api_port, channel_id.get()).await)
                 .as_deref(),
@@ -2133,7 +2326,7 @@ pub(super) async fn restore_inflight_turns(
                 adk_session_key,
                 adk_session_name,
                 adk_session_info: Some(adk_session_info),
-                adk_cwd: last_path.clone(),
+                adk_cwd: recovery_adk_cwd.clone(),
                 dispatch_id: recovery_dispatch_id,
                 memory_recall_usage: crate::services::memory::TokenUsage::default(),
                 current_msg_id,
@@ -2426,7 +2619,9 @@ pub(crate) async fn rebind_inflight_for_channel(
         synthetic_initial_offset
     };
 
-    if existing_inflight.is_none() {
+    let recovered_state_for_session = if let Some(existing) = existing_inflight.clone() {
+        existing
+    } else {
         // Build and persist the new inflight state. No request_owner / msg_ids
         // apply because this recovery has no originating Discord message.
         //
@@ -2466,7 +2661,8 @@ pub(crate) async fn rebind_inflight_for_channel(
                 return Err(RebindError::Internal(msg));
             }
         }
-    }
+        state
+    };
 
     // Register / refresh the in-memory session so downstream handlers can
     // locate this channel after the rebind.
@@ -2497,6 +2693,7 @@ pub(crate) async fn rebind_inflight_for_channel(
         if session.channel_name.is_none() {
             session.channel_name = channel_name.clone();
         }
+        restore_recovered_session_worktree(session, &recovered_state_for_session);
     }
 
     // #897 P2 #2: use `claim_or_replace_watcher` instead of
@@ -3245,6 +3442,9 @@ mod tests {
             tmux_session_name: Some("AgentDesk-codex-adk-cdx-t1486333430516945008".to_string()),
             output_path: Some("/tmp/agentdesk-test.jsonl".to_string()),
             input_fifo_path: Some("/tmp/agentdesk-test.input".to_string()),
+            worktree_path: None,
+            worktree_branch: None,
+            base_commit: None,
             last_offset: 123,
             turn_start_offset: Some(123),
             full_response: "중간까지 정리했습니다.".to_string(),
@@ -3356,6 +3556,9 @@ mod tests {
             tmux_session_name: Some("AgentDesk-codex-adk-cdx-t1486333430516945008".to_string()),
             output_path: Some("/tmp/agentdesk-test.jsonl".to_string()),
             input_fifo_path: Some("/tmp/agentdesk-test.input".to_string()),
+            worktree_path: None,
+            worktree_branch: None,
+            base_commit: None,
             last_offset: 123,
             turn_start_offset: Some(123),
             full_response: "중간까지 정리했습니다.".to_string(),
@@ -3439,6 +3642,222 @@ mod tests {
         assert_eq!(offset, 0);
         assert!(current_len < saved_offset);
         assert!(truncated);
+    }
+
+    #[test]
+    fn recovery_spawn_adk_cwd_prefers_inflight_worktree() {
+        let temp = tempfile::tempdir().unwrap();
+        let worktree_path = temp.path().join("wt");
+        std::fs::create_dir_all(&worktree_path).unwrap();
+
+        let mut state = crate::services::discord::inflight::InflightTurnState::new(
+            ProviderKind::Codex,
+            42,
+            Some("adk-cdx-t42".to_string()),
+            1,
+            2,
+            3,
+            "resume".to_string(),
+            Some("session-42".to_string()),
+            Some("AgentDesk-codex-adk-cdx-t42".to_string()),
+            Some("/tmp/out.jsonl".to_string()),
+            Some("/tmp/in.fifo".to_string()),
+            0,
+        );
+        state.worktree_path = Some(worktree_path.to_string_lossy().to_string());
+
+        let resolved = recovery_spawn_adk_cwd(&state, Some("/tmp/main-workspace".to_string()))
+            .expect("existing inflight worktree must win over persisted main workspace cwd");
+        assert_eq!(
+            resolved.as_deref(),
+            Some(worktree_path.to_string_lossy().as_ref())
+        );
+    }
+
+    #[test]
+    fn recovery_spawn_adk_cwd_uses_legacy_session_path_without_inflight_worktree() {
+        let state = crate::services::discord::inflight::InflightTurnState::new(
+            ProviderKind::Codex,
+            42,
+            Some("adk-cdx-t42".to_string()),
+            1,
+            2,
+            3,
+            "resume".to_string(),
+            Some("session-42".to_string()),
+            Some("AgentDesk-codex-adk-cdx-t42".to_string()),
+            Some("/tmp/out.jsonl".to_string()),
+            Some("/tmp/in.fifo".to_string()),
+            0,
+        );
+
+        let resolved = recovery_spawn_adk_cwd(&state, Some("/tmp/main-workspace".to_string()))
+            .expect("legacy recovery should preserve the persisted session cwd");
+        assert_eq!(resolved.as_deref(), Some("/tmp/main-workspace"));
+    }
+
+    #[test]
+    fn recovery_spawn_adk_cwd_blocks_missing_inflight_worktree() {
+        let mut state = crate::services::discord::inflight::InflightTurnState::new(
+            ProviderKind::Codex,
+            42,
+            Some("adk-cdx-t42".to_string()),
+            1,
+            2,
+            3,
+            "resume".to_string(),
+            Some("session-42".to_string()),
+            Some("AgentDesk-codex-adk-cdx-t42".to_string()),
+            Some("/tmp/out.jsonl".to_string()),
+            Some("/tmp/in.fifo".to_string()),
+            0,
+        );
+        state.worktree_path = Some("/tmp/missing-worktree".to_string());
+
+        let error = recovery_spawn_adk_cwd(&state, Some("/tmp/main-workspace".to_string()))
+            .expect_err("missing inflight worktree must block main-workspace fallback");
+        assert!(error.contains("missing-worktree"));
+        assert!(error.contains("recovery blocked"));
+    }
+
+    #[test]
+    fn recovery_spawn_adk_cwd_allows_dispatch_fallback_without_worktree_metadata() {
+        let mut state = crate::services::discord::inflight::InflightTurnState::new(
+            ProviderKind::Codex,
+            42,
+            Some("adk-cdx-t42".to_string()),
+            1,
+            2,
+            3,
+            "DISPATCH:dispatch-42 resume".to_string(),
+            Some("session-42".to_string()),
+            Some("AgentDesk-codex-adk-cdx-t42".to_string()),
+            Some("/tmp/out.jsonl".to_string()),
+            Some("/tmp/in.fifo".to_string()),
+            0,
+        );
+        state.dispatch_id = Some("dispatch-42".to_string());
+
+        let resolved = recovery_spawn_adk_cwd(&state, Some("/tmp/dispatch-target".to_string()))
+            .expect("dispatch fallback cwd must remain valid when no worktree was tracked");
+        assert_eq!(resolved.as_deref(), Some("/tmp/dispatch-target"));
+    }
+
+    #[test]
+    fn recovery_spawn_adk_cwd_blocks_missing_required_worktree_metadata_for_dispatch_turn() {
+        let mut state = crate::services::discord::inflight::InflightTurnState::new(
+            ProviderKind::Codex,
+            42,
+            Some("adk-cdx-t42".to_string()),
+            1,
+            2,
+            3,
+            "DISPATCH:dispatch-42 resume".to_string(),
+            Some("session-42".to_string()),
+            Some("AgentDesk-codex-adk-cdx-t42".to_string()),
+            Some("/tmp/out.jsonl".to_string()),
+            Some("/tmp/in.fifo".to_string()),
+            0,
+        );
+        state.dispatch_id = Some("dispatch-42".to_string());
+        state.worktree_branch = Some("agentdesk/codex/adk-cdx-t42".to_string());
+
+        let error = recovery_spawn_adk_cwd(&state, Some("/tmp/main-workspace".to_string()))
+            .expect_err("dispatch recovery without recorded worktree path must not fall back");
+        assert!(error.contains("dispatch-42"));
+        assert!(error.contains("worktree state missing"));
+    }
+
+    #[test]
+    fn recovery_restores_worktree_identity_into_session_state() {
+        fn run_git(repo_path: &std::path::Path, args: &[&str]) -> String {
+            let output = std::process::Command::new("git")
+                .args(["-C", repo_path.to_str().unwrap()])
+                .args(args)
+                .output()
+                .unwrap_or_else(|error| panic!("git {:?} failed to spawn: {error}", args));
+            assert!(
+                output.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&output.stderr)
+            );
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        }
+
+        let repo = tempfile::tempdir().unwrap();
+        run_git(repo.path(), &["init", "-b", "main"]);
+        run_git(repo.path(), &["config", "user.name", "AgentDesk"]);
+        run_git(
+            repo.path(),
+            &["config", "user.email", "agentdesk@example.com"],
+        );
+        std::fs::write(repo.path().join("README.md"), "seed\n").unwrap();
+        run_git(repo.path(), &["add", "README.md"]);
+        run_git(repo.path(), &["commit", "-m", "seed"]);
+
+        let worktree_path = repo.path().join("wt-recovery");
+        let branch = "wt/recovery-936";
+        run_git(
+            repo.path(),
+            &[
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                worktree_path.to_str().unwrap(),
+                "main",
+            ],
+        );
+
+        let mut state = crate::services::discord::inflight::InflightTurnState::new(
+            ProviderKind::Codex,
+            42,
+            Some("adk-cdx-t42".to_string()),
+            1,
+            2,
+            3,
+            "resume".to_string(),
+            Some("session-42".to_string()),
+            Some("AgentDesk-codex-adk-cdx-t42".to_string()),
+            Some("/tmp/out.jsonl".to_string()),
+            Some("/tmp/in.fifo".to_string()),
+            0,
+        );
+        state.worktree_path = Some(worktree_path.to_string_lossy().to_string());
+        state.worktree_branch = Some(branch.to_string());
+
+        let mut session = DiscordSession {
+            session_id: None,
+            memento_context_loaded: false,
+            memento_reflected: false,
+            current_path: Some(worktree_path.to_string_lossy().to_string()),
+            history: Vec::new(),
+            pending_uploads: Vec::new(),
+            cleared: false,
+            remote_profile_name: None,
+            channel_id: Some(42),
+            channel_name: Some("adk-cdx-t42".to_string()),
+            category_name: None,
+            last_active: tokio::time::Instant::now(),
+            worktree: None,
+            born_generation: 0,
+            assistant_turns: 0,
+        };
+
+        restore_recovered_session_worktree(&mut session, &state);
+
+        let restored = session
+            .worktree
+            .as_ref()
+            .expect("recovery should rebuild worktree identity from inflight metadata");
+        let canonical_repo_path = std::fs::canonicalize(repo.path()).unwrap();
+        assert_eq!(restored.worktree_path, worktree_path.to_string_lossy());
+        assert_eq!(restored.branch_name, branch);
+        assert_eq!(
+            restored.original_path,
+            canonical_repo_path.to_string_lossy()
+        );
     }
     #[test]
     fn fast_path_captured_full_response_requires_unsent_response() {

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -1204,17 +1204,109 @@ fn session_runtime_state_after_redirect(
 /// Returns `true` when the effective path should overwrite the session path.
 fn dispatch_session_path_should_update(
     has_dispatch: bool,
+    dispatch_type: Option<&str>,
     has_worktree_path: bool,
+    bootstrapped_fresh_thread_session: bool,
     current_path: &str,
     dispatch_effective_path: &str,
 ) -> bool {
     if !has_dispatch {
         return false;
     }
+    if crate::dispatch::dispatch_type_requires_fresh_worktree(dispatch_type)
+        && bootstrapped_fresh_thread_session
+    {
+        return false;
+    }
     if has_worktree_path {
         return true;
     }
     dispatch_effective_path != current_path
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DispatchCwdPolicyDecision {
+    log_main_workspace_error: bool,
+    reject_for_missing_fresh_worktree: bool,
+}
+
+#[cfg(test)]
+fn evaluate_dispatch_cwd_policy(
+    dispatch_type: Option<&str>,
+    current_path: &str,
+    main_workspace: Option<&std::path::Path>,
+    worktrees_root: Option<&std::path::Path>,
+) -> DispatchCwdPolicyDecision {
+    let requires_fresh_worktree =
+        crate::dispatch::dispatch_type_requires_fresh_worktree(dispatch_type);
+    let current_path = std::path::Path::new(current_path);
+    let is_main_workspace = main_workspace.is_some_and(|workspace| current_path == workspace);
+    let is_managed_worktree = worktrees_root.is_some_and(|root| current_path.starts_with(root));
+
+    DispatchCwdPolicyDecision {
+        log_main_workspace_error: requires_fresh_worktree && is_main_workspace,
+        reject_for_missing_fresh_worktree: requires_fresh_worktree
+            && worktrees_root.is_some()
+            && !is_managed_worktree,
+    }
+}
+
+#[cfg(test)]
+async fn enforce_dispatch_cwd_policy(
+    shared: &SharedData,
+    dispatch_id: Option<&str>,
+    dispatch_type: Option<&str>,
+    card_id: Option<&str>,
+    current_path: &str,
+) -> anyhow::Result<()> {
+    let main_workspace =
+        super::super::runtime_store::workspace_root().map(|root| root.join("agentdesk"));
+    let worktrees_root = super::super::runtime_store::worktrees_root();
+    let decision = evaluate_dispatch_cwd_policy(
+        dispatch_type,
+        current_path,
+        main_workspace.as_deref(),
+        worktrees_root.as_deref(),
+    );
+    if !decision.reject_for_missing_fresh_worktree {
+        return Ok(());
+    }
+
+    let dispatch_id = dispatch_id.ok_or_else(|| {
+        anyhow::anyhow!("implementation dispatch requires a fresh origin/main worktree")
+    })?;
+    let error = "implementation_requires_fresh_worktree";
+    let reason = format!("cowardly refusing cwd {current_path}");
+    let result = serde_json::json!({
+        "error": error,
+        "reason": reason,
+    })
+    .to_string();
+    let Some(db) = shared.sqlite.as_ref() else {
+        anyhow::bail!("implementation dispatch requires a fresh origin/main worktree");
+    };
+    {
+        let conn = db
+            .lock()
+            .map_err(|_| anyhow::anyhow!("sqlite lock poisoned"))?;
+        conn.execute(
+            "UPDATE task_dispatches \
+             SET status = 'failed', result = ?2, completed_at = datetime('now'), updated_at = datetime('now') \
+             WHERE id = ?1",
+            libsql_rusqlite::params![dispatch_id, result],
+        )?;
+        if let Some(card_id) = card_id {
+            conn.execute(
+                "UPDATE kanban_cards \
+                 SET blocked_reason = ?2, updated_at = datetime('now') \
+                 WHERE id = ?1",
+                libsql_rusqlite::params![card_id, format!("dispatch:{error}:{reason}")],
+            )?;
+        }
+    }
+
+    anyhow::bail!("implementation dispatch requires a fresh origin/main worktree: {reason}");
 }
 
 fn build_race_requeued_intervention(
@@ -1614,6 +1706,7 @@ pub(in crate::services::discord) async fn handle_text_message(
     }
     let dispatch_uses_thread_routing =
         crate::dispatch::dispatch_type_uses_thread_routing(dispatch_type_str.as_deref());
+    let mut bootstrapped_fresh_thread_session = false;
     let channel_id = if let Some(ref did) = dispatch_id_for_thread {
         if !dispatch_uses_thread_routing {
             let ts = chrono::Local::now().format("%H:%M:%S");
@@ -1682,7 +1775,7 @@ pub(in crate::services::discord) async fn handle_text_message(
                             tid,
                             did
                         );
-                        super::super::bootstrap_thread_session(
+                        bootstrapped_fresh_thread_session = super::super::bootstrap_thread_session(
                             shared,
                             tid,
                             &dispatch_effective_path,
@@ -1746,13 +1839,14 @@ pub(in crate::services::discord) async fn handle_text_message(
                                 thread.id,
                                 did
                             );
-                            super::super::bootstrap_thread_session(
-                                shared,
-                                thread.id,
-                                &dispatch_effective_path,
-                                ctx,
-                            )
-                            .await;
+                            bootstrapped_fresh_thread_session =
+                                super::super::bootstrap_thread_session(
+                                    shared,
+                                    thread.id,
+                                    &dispatch_effective_path,
+                                    ctx,
+                                )
+                                .await;
                             shared.dispatch_thread_parents.insert(channel_id, thread.id);
                             super::link_dispatch_thread(
                                 shared.api_port,
@@ -1819,7 +1913,9 @@ pub(in crate::services::discord) async fn handle_text_message(
     // whether `worktree_path` was supplied.
     let current_path = if dispatch_session_path_should_update(
         dispatch_id_for_thread.is_some(),
+        dispatch_type_str.as_deref(),
         dispatch_worktree_path.is_some(),
+        bootstrapped_fresh_thread_session,
         &current_path,
         &dispatch_effective_path,
     ) {
@@ -4730,8 +4826,10 @@ mod tests {
         // session's stale current_path. Must update.
         assert!(
             dispatch_session_path_should_update(
-                true,  // has_dispatch
+                true, // has_dispatch
+                Some("review"),
                 false, // has_worktree_path
+                false, // existing thread, no fresh bootstrap this turn
                 "/tmp/stale-impl-repo",
                 "/tmp/external-target-repo",
             ),
@@ -4744,11 +4842,25 @@ mod tests {
         // Classic #259 path: dispatch has worktree_path. Always update,
         // even when stale current_path already happens to match.
         assert!(
-            dispatch_session_path_should_update(true, true, "/tmp/impl-wt", "/tmp/impl-wt",),
+            dispatch_session_path_should_update(
+                true,
+                Some("review"),
+                true,
+                false,
+                "/tmp/impl-wt",
+                "/tmp/impl-wt",
+            ),
             "worktree_path dispatches must always update session CWD"
         );
         assert!(
-            dispatch_session_path_should_update(true, true, "/tmp/stale", "/tmp/fresh-wt",),
+            dispatch_session_path_should_update(
+                true,
+                Some("review"),
+                true,
+                false,
+                "/tmp/stale",
+                "/tmp/fresh-wt",
+            ),
             "worktree_path dispatches with divergent path must update"
         );
     }
@@ -4757,16 +4869,147 @@ mod tests {
     fn dispatch_session_path_should_update_skips_when_paths_match() {
         // No dispatch → leave alone.
         assert!(!dispatch_session_path_should_update(
-            false, false, "/tmp/a", "/tmp/b",
+            false, None, false, false, "/tmp/a", "/tmp/b",
         ));
         // Dispatch present but worktree_path absent AND effective path
         // matches current path → nothing to update.
         assert!(!dispatch_session_path_should_update(
             true,
+            Some("review"),
+            false,
             false,
             "/tmp/same",
             "/tmp/same",
         ));
+    }
+
+    #[test]
+    fn dispatch_session_path_should_not_override_fresh_bootstrap_for_implementation() {
+        assert!(!dispatch_session_path_should_update(
+            true,
+            Some("implementation"),
+            true,
+            true,
+            "/tmp/worktrees/dispatch-934",
+            "/tmp/workspaces/agentdesk",
+        ));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn enforce_dispatch_cwd_policy_marks_implementation_dispatch_failed() {
+        let db = crate::db::test_db();
+        {
+            let conn = db.lock().unwrap();
+            conn.execute(
+                "INSERT INTO agents (id, name, discord_channel_id, discord_channel_alt) \
+                 VALUES ('agent-1', 'Test Agent', '111', '222')",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO kanban_cards (id, title, status, assigned_agent_id, created_at, updated_at) \
+                 VALUES ('card-934-policy', '#934 policy fail', 'in_progress', 'agent-1', datetime('now'), datetime('now'))",
+                [],
+            )
+            .unwrap();
+        }
+
+        let (dispatch_id, _, _) = crate::dispatch::create_dispatch_record_sqlite_test(
+            &db,
+            "card-934-policy",
+            "agent-1",
+            "implementation",
+            "[Impl]",
+            &serde_json::json!({}),
+            crate::dispatch::DispatchCreateOptions::default(),
+        )
+        .unwrap();
+        let shared = make_shared_data_for_tests_with_storage(Some(db.clone()), None);
+
+        let error = enforce_dispatch_cwd_policy(
+            &shared,
+            Some(&dispatch_id),
+            Some("implementation"),
+            Some("card-934-policy"),
+            "/tmp/campaign-r3-934-main-workspace",
+        )
+        .await
+        .expect_err("implementation dispatch must fail closed outside managed worktrees");
+        assert!(
+            error
+                .to_string()
+                .contains("requires a fresh origin/main worktree")
+        );
+
+        let conn = db.lock().unwrap();
+        let (status, result_json): (String, Option<String>) = conn
+            .query_row(
+                "SELECT status, result FROM task_dispatches WHERE id = ?1",
+                [&dispatch_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(status, "failed");
+        let result: serde_json::Value =
+            serde_json::from_str(result_json.as_deref().unwrap_or("{}")).unwrap();
+        assert_eq!(
+            result["error"].as_str(),
+            Some("implementation_requires_fresh_worktree")
+        );
+
+        let blocked_reason: Option<String> = conn
+            .query_row(
+                "SELECT blocked_reason FROM kanban_cards WHERE id = 'card-934-policy'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            blocked_reason.as_deref(),
+            Some(
+                "dispatch:implementation_requires_fresh_worktree:cowardly refusing cwd /tmp/campaign-r3-934-main-workspace"
+            )
+        );
+    }
+
+    #[test]
+    fn evaluate_dispatch_cwd_policy_rejects_main_workspace_for_implementation() {
+        let root = tempfile::tempdir().unwrap();
+        let main_workspace = root.path().join("workspaces").join("agentdesk");
+        let worktrees_root = root.path().join("worktrees");
+        std::fs::create_dir_all(&main_workspace).unwrap();
+        std::fs::create_dir_all(worktrees_root.join("impl-934")).unwrap();
+
+        let decision = evaluate_dispatch_cwd_policy(
+            Some("implementation"),
+            main_workspace.to_str().unwrap(),
+            Some(main_workspace.as_path()),
+            Some(worktrees_root.as_path()),
+        );
+
+        assert!(decision.log_main_workspace_error);
+        assert!(decision.reject_for_missing_fresh_worktree);
+    }
+
+    #[test]
+    fn evaluate_dispatch_cwd_policy_allows_review_repo_root_fallback() {
+        let root = tempfile::tempdir().unwrap();
+        let main_workspace = root.path().join("workspaces").join("agentdesk");
+        let external_repo = root.path().join("external-review");
+        let worktrees_root = root.path().join("worktrees");
+        std::fs::create_dir_all(&main_workspace).unwrap();
+        std::fs::create_dir_all(&external_repo).unwrap();
+        std::fs::create_dir_all(&worktrees_root).unwrap();
+
+        let decision = evaluate_dispatch_cwd_policy(
+            Some("review"),
+            external_repo.to_str().unwrap(),
+            Some(main_workspace.as_path()),
+            Some(worktrees_root.as_path()),
+        );
+
+        assert!(!decision.log_main_workspace_error);
+        assert!(!decision.reject_for_missing_fresh_worktree);
     }
 
     #[test]

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -778,6 +778,21 @@ pub(in crate::services::discord) async fn start_headless_turn(
         inflight_input_fifo.clone(),
         inflight_offset,
     );
+    let (worktree_path, worktree_branch, base_commit) = {
+        let data = shared.core.lock().await;
+        data.sessions
+            .get(&channel_id)
+            .and_then(|session| session.worktree.as_ref())
+            .map(|wt| {
+                (
+                    Some(wt.worktree_path.clone()),
+                    Some(wt.branch_name.clone()),
+                    crate::services::platform::git_head_commit(&wt.original_path),
+                )
+            })
+            .unwrap_or((None, None, None))
+    };
+    inflight_state.set_worktree_context(worktree_path, worktree_branch, base_commit);
     inflight_state.logical_channel_id = Some(channel_id.get());
     inflight_state.session_key = adk_session_key.clone();
     if let Err(error) = save_inflight_state(&inflight_state) {
@@ -2573,6 +2588,21 @@ pub(in crate::services::discord) async fn handle_text_message(
         inflight_input_fifo.clone(),
         inflight_offset,
     );
+    let (worktree_path, worktree_branch, base_commit) = {
+        let data = shared.core.lock().await;
+        data.sessions
+            .get(&channel_id)
+            .and_then(|session| session.worktree.as_ref())
+            .map(|wt| {
+                (
+                    Some(wt.worktree_path.clone()),
+                    Some(wt.branch_name.clone()),
+                    crate::services::platform::git_head_commit(&wt.original_path),
+                )
+            })
+            .unwrap_or((None, None, None))
+    };
+    inflight_state.set_worktree_context(worktree_path, worktree_branch, base_commit);
     inflight_state.logical_channel_id = Some(logical_channel_id);
     inflight_state.thread_id = thread_id;
     inflight_state.thread_title = thread_title;

--- a/src/services/discord/session_runtime.rs
+++ b/src/services/discord/session_runtime.rs
@@ -885,6 +885,7 @@ pub(super) async fn bootstrap_thread_session(
     serenity_ctx: &serenity::prelude::Context,
 ) -> bool {
     let (thread_title, cat_name) = resolve_channel_category(serenity_ctx, thread_channel_id).await;
+    let provider_kind = shared.settings.read().await.provider.clone();
     // Build a short, stable channel_name: "{parent_channel}-t{thread_id}"
     let parent_info = resolve_thread_parent(&serenity_ctx.http, thread_channel_id).await;
     let ch_name = if let Some((parent_id, parent_name)) = parent_info {
@@ -926,6 +927,7 @@ pub(super) async fn bootstrap_thread_session(
         let provider_str = shared.settings.read().await.provider.as_str().to_string();
         match create_git_worktree(parent_path, ch, &provider_str) {
             Ok((wt_path, branch)) => {
+                let base_commit = crate::services::platform::git_head_commit(parent_path);
                 let ts = chrono::Local::now().format("%H:%M:%S");
                 tracing::info!(
                     "  [{ts}] 🌿 Thread worktree created: {} (branch: {})",
@@ -935,8 +937,15 @@ pub(super) async fn bootstrap_thread_session(
                 session.worktree = Some(WorktreeInfo {
                     original_path: parent_path.to_string(),
                     worktree_path: wt_path.clone(),
-                    branch_name: branch,
+                    branch_name: branch.clone(),
                 });
+                sync_inflight_worktree_context(
+                    &provider_kind,
+                    thread_channel_id.get(),
+                    Some(wt_path.clone()),
+                    Some(branch),
+                    base_commit,
+                );
                 wt_path
             }
             Err(e) => {
@@ -952,6 +961,19 @@ pub(super) async fn bootstrap_thread_session(
     let ts = chrono::Local::now().format("%H:%M:%S");
     tracing::info!("  [{ts}] ↻ Bootstrapped thread session: {effective_path}");
     true
+}
+
+fn sync_inflight_worktree_context(
+    provider: &crate::services::provider::ProviderKind,
+    channel_id: u64,
+    worktree_path: Option<String>,
+    worktree_branch: Option<String>,
+    base_commit: Option<String>,
+) {
+    if let Some(mut inflight) = super::inflight::load_inflight_state(provider, channel_id) {
+        inflight.set_worktree_context(worktree_path, worktree_branch, base_commit);
+        let _ = super::inflight::save_inflight_state(&inflight);
+    }
 }
 
 /// Resolve the channel name and parent category name for a Discord channel.
@@ -1776,5 +1798,56 @@ mod tests {
         assert_eq!(session.session_id.as_deref(), Some("session-2"));
         assert!(!session.memento_context_loaded);
         assert!(!session.memento_reflected);
+    }
+
+    #[test]
+    fn sync_inflight_worktree_context_persists_bootstrap_worktree_metadata() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("agentdesk-root");
+        std::fs::create_dir_all(root.join("runtime").join("state").join("discord")).unwrap();
+
+        struct EnvReset;
+        impl Drop for EnvReset {
+            fn drop(&mut self) {
+                unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") };
+            }
+        }
+
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", &root) };
+        let _reset = EnvReset;
+
+        let provider = crate::services::provider::ProviderKind::Codex;
+        let inflight = crate::services::discord::inflight::InflightTurnState::new(
+            provider.clone(),
+            4242,
+            Some("adk-cdx-t4242".to_string()),
+            1,
+            2,
+            3,
+            "resume".to_string(),
+            Some("session-4242".to_string()),
+            Some("AgentDesk-codex-adk-cdx-t4242".to_string()),
+            Some("/tmp/out.jsonl".to_string()),
+            Some("/tmp/in.fifo".to_string()),
+            0,
+        );
+        crate::services::discord::inflight::save_inflight_state(&inflight).unwrap();
+
+        sync_inflight_worktree_context(
+            &provider,
+            4242,
+            Some("/tmp/new-worktree".to_string()),
+            Some("agentdesk/codex/adk-cdx-t4242".to_string()),
+            Some("abc123".to_string()),
+        );
+
+        let saved = crate::services::discord::inflight::load_inflight_state(&provider, 4242)
+            .expect("bootstrap should update existing inflight state");
+        assert_eq!(saved.worktree_path.as_deref(), Some("/tmp/new-worktree"));
+        assert_eq!(
+            saved.worktree_branch.as_deref(),
+            Some("agentdesk/codex/adk-cdx-t4242")
+        );
+        assert_eq!(saved.base_commit.as_deref(), Some("abc123"));
     }
 }

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -40,7 +40,8 @@ use super::tmux_restart_handoff::{
 };
 use super::{SharedData, TmuxWatcherHandle, rate_limit_wait};
 const READY_FOR_INPUT_IDLE_PROBE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
-const WATCHER_ACTIVITY_HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+pub(super) const WATCHER_ACTIVITY_HEARTBEAT_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(30);
 const READY_FOR_INPUT_STUCK_LABEL: &str = "stuck_at_ready";
 const READY_FOR_INPUT_STUCK_REASON: &str = "agent ended at Ready for input without commit/push";
 
@@ -1234,7 +1235,7 @@ pub(super) async fn clear_recovery_handled_channels(shared: &SharedData) {
 
 // Tmux watcher output is activity, but reusing hook_session here would also
 // overwrite status/tokens defaults. Touch only last_heartbeat instead.
-fn refresh_session_heartbeat_from_tmux_output(
+pub(super) fn refresh_session_heartbeat_from_tmux_output(
     db: Option<&crate::db::Db>,
     pg_pool: Option<&sqlx::PgPool>,
     token_hash: &str,

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -160,6 +160,52 @@ fn advance_tmux_relay_confirmed_end(
     }
 }
 
+fn active_turn_thread_channel_id(
+    adk_session_name: Option<&str>,
+    inflight_state: &InflightTurnState,
+) -> Option<u64> {
+    adk_session_name
+        .and_then(crate::services::discord::adk_session::parse_thread_channel_id_from_name)
+        .or_else(|| {
+            inflight_state
+                .channel_name
+                .as_deref()
+                .and_then(crate::services::discord::adk_session::parse_thread_channel_id_from_name)
+        })
+        .or(inflight_state.thread_id)
+}
+
+fn maybe_refresh_active_turn_activity_heartbeat(
+    shared: &SharedData,
+    provider: &ProviderKind,
+    inflight_state: &InflightTurnState,
+    adk_session_name: Option<&str>,
+    last_heartbeat_at: &mut Option<std::time::Instant>,
+) {
+    let now = std::time::Instant::now();
+    if last_heartbeat_at.is_some_and(|last| {
+        now.duration_since(last) < super::tmux::WATCHER_ACTIVITY_HEARTBEAT_INTERVAL
+    }) {
+        return;
+    }
+
+    let Some(tmux_session_name) = inflight_state.tmux_session_name.as_deref() else {
+        return;
+    };
+    let thread_channel_id = active_turn_thread_channel_id(adk_session_name, inflight_state);
+
+    if super::tmux::refresh_session_heartbeat_from_tmux_output(
+        shared.sqlite.as_ref(),
+        shared.pg_pool.as_ref(),
+        &shared.token_hash,
+        provider,
+        tmux_session_name,
+        thread_channel_id,
+    ) {
+        *last_heartbeat_at = Some(now);
+    }
+}
+
 async fn enqueue_headless_delivery(
     shared: &Arc<SharedData>,
     channel_id: ChannelId,
@@ -475,6 +521,7 @@ pub(super) fn spawn_turn_bridge(
         let mut terminal_session_reset_required = false;
         let mut recovery_retry = false;
         let mut last_adk_heartbeat = std::time::Instant::now();
+        let mut last_activity_heartbeat_at: Option<std::time::Instant> = None;
         let mut current_msg_id = bridge.current_msg_id;
         let mut response_sent_offset = bridge.response_sent_offset;
         let mut tmux_last_offset = bridge.tmux_last_offset;
@@ -1015,6 +1062,13 @@ pub(super) fn spawn_turn_bridge(
                         StreamMessage::OutputOffset { offset } => {
                             tmux_last_offset = Some(offset);
                             inflight_state.last_offset = offset;
+                            maybe_refresh_active_turn_activity_heartbeat(
+                                shared_owned.as_ref(),
+                                &provider,
+                                &inflight_state,
+                                adk_session_name.as_deref(),
+                                &mut last_activity_heartbeat_at,
+                            );
                             state_dirty = true;
                         }
                     },

--- a/src/services/discord/turn_bridge/tests.rs
+++ b/src/services/discord/turn_bridge/tests.rs
@@ -26,17 +26,20 @@ use super::stale_resume::{
 };
 use super::tmux_runtime::should_resume_watcher_after_turn;
 use crate::db::turns::TurnTokenUsage;
+use crate::services::agent_protocol::StreamMessage;
 use crate::services::discord::ChannelId;
 use crate::services::discord::DiscordSession;
 use crate::services::discord::InflightTurnState;
 use crate::services::discord::MessageId;
+use crate::services::discord::gateway::HeadlessGateway;
 use crate::services::discord::make_shared_data_for_tests;
+use crate::services::discord::make_shared_data_for_tests_with_storage;
 use crate::services::discord::settings::{MemoryBackendKind, ResolvedMemorySettings};
 use crate::services::memory::{SessionEndReason, TokenUsage};
-use crate::services::provider::ProviderKind;
+use crate::services::provider::{CancelToken, ProviderKind};
 use crate::ui::ai_screen::{HistoryItem, HistoryType};
 use std::io::Write;
-use std::sync::atomic::Ordering;
+use std::sync::{Arc, atomic::Ordering};
 use std::time::{Duration, Instant};
 
 #[test]
@@ -115,6 +118,126 @@ fn advance_tmux_relay_confirmed_end_updates_shared_floor_monotonically() {
         relay_coord.confirmed_end_offset.load(Ordering::Acquire),
         128
     );
+}
+
+#[tokio::test]
+async fn active_turn_output_offset_refreshes_session_heartbeat_before_done() {
+    let db = crate::db::test_db();
+    let shared = make_shared_data_for_tests_with_storage(Some(db.clone()), None);
+    let provider = ProviderKind::Codex;
+    let channel_id = ChannelId::new(1485506232256168011);
+    let channel_name = format!("adk-cdx-t{}", channel_id.get());
+    let tmux_name = provider.build_tmux_session_name(&channel_name);
+    let session_key = crate::services::discord::adk_session::build_namespaced_session_key(
+        &shared.token_hash,
+        &provider,
+        &tmux_name,
+    );
+    let thread_channel_id = channel_id.get().to_string();
+
+    db.lock()
+        .expect("test db lock")
+        .execute(
+            "INSERT INTO sessions
+             (session_key, provider, status, thread_channel_id, last_heartbeat, created_at)
+             VALUES (?1, ?2, 'working', ?3, '2026-04-09 01:02:03', '2026-04-09 01:02:03')",
+            [
+                session_key.as_str(),
+                provider.as_str(),
+                thread_channel_id.as_str(),
+            ],
+        )
+        .expect("insert session row");
+
+    let (stream_tx, stream_rx) = std::sync::mpsc::channel();
+    let (completion_tx, completion_rx) = tokio::sync::oneshot::channel();
+    let mut inflight_state = InflightTurnState::new(
+        provider.clone(),
+        channel_id.get(),
+        Some(channel_name.clone()),
+        343742347365974026,
+        1487795113240559788,
+        1487799916758827138,
+        "ping".to_string(),
+        None,
+        Some(tmux_name),
+        Some("/tmp/agentdesk-test-output.jsonl".to_string()),
+        Some("/tmp/agentdesk-test-input.fifo".to_string()),
+        0,
+    );
+    inflight_state.session_key = Some(session_key.clone());
+
+    super::spawn_turn_bridge(
+        shared.clone(),
+        Arc::new(CancelToken::new()),
+        stream_rx,
+        super::TurnBridgeContext {
+            provider: provider.clone(),
+            gateway: Arc::new(HeadlessGateway),
+            channel_id,
+            user_msg_id: MessageId::new(1487795113240559788),
+            user_text_owned: "ping".to_string(),
+            request_owner_name: "tester".to_string(),
+            role_binding: None,
+            adk_session_key: Some(session_key.clone()),
+            adk_session_name: Some(channel_name),
+            adk_session_info: None,
+            adk_cwd: None,
+            dispatch_id: None,
+            memory_recall_usage: TokenUsage::default(),
+            current_msg_id: MessageId::new(1487799916758827138),
+            response_sent_offset: 0,
+            full_response: String::new(),
+            tmux_last_offset: Some(0),
+            new_session_id: None,
+            defer_watcher_resume: false,
+            completion_tx: Some(completion_tx),
+            inflight_state,
+        },
+    );
+
+    stream_tx
+        .send(StreamMessage::OutputOffset { offset: 128 })
+        .expect("send output offset");
+
+    let heartbeat_changed = async {
+        loop {
+            let last_heartbeat: String = db
+                .lock()
+                .expect("test db lock")
+                .query_row(
+                    "SELECT last_heartbeat FROM sessions WHERE session_key = ?1",
+                    [session_key.as_str()],
+                    |row| row.get(0),
+                )
+                .expect("select last heartbeat");
+            if last_heartbeat != "2026-04-09 01:02:03" {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(4), heartbeat_changed)
+        .await
+        .expect("active turn output offset should refresh last_heartbeat");
+
+    stream_tx
+        .send(StreamMessage::Text {
+            content: "done".to_string(),
+        })
+        .expect("send text");
+    stream_tx
+        .send(StreamMessage::Done {
+            result: String::new(),
+            session_id: None,
+        })
+        .expect("send done");
+    drop(stream_tx);
+
+    tokio::time::timeout(Duration::from_secs(5), completion_rx)
+        .await
+        .expect("turn bridge should finish")
+        .expect("completion sender should complete");
 }
 
 #[test]


### PR DESCRIPTION
Closes #982

## Summary

turn_bridge 가 active turn 을 처리하는 동안 watcher 가 `paused=true` 로 유지되어 `sessions.last_heartbeat` 가 갱신되지 않던 버그를 수정. turn_bridge 의 `StreamMessage::OutputOffset` 이벤트 처리 경로에 heartbeat refresh hook 을 추가.

## Changes
- `src/services/discord/tmux.rs`: `WATCHER_ACTIVITY_HEARTBEAT_INTERVAL` 와 `refresh_session_heartbeat_from_tmux_output` 를 `pub(super)` 로 격상 (turn_bridge 에서 재사용)
- `src/services/discord/turn_bridge/mod.rs`: `active_turn_thread_channel_id` helper + `maybe_refresh_active_turn_activity_heartbeat` helper 신설. `spawn_turn_bridge` 의 `OutputOffset` 핸들러에서 30s throttle 로 heartbeat 갱신
- `src/services/discord/turn_bridge/tests.rs`: 신규 회귀 테스트 `active_turn_output_offset_refreshes_session_heartbeat_before_done` — OutputOffset 이벤트가 `last_heartbeat` 를 실제로 갱신하는지 검증

## Validation
- `cargo check --bin agentdesk` — 0 errors
- 신규 테스트 통과 (`services::discord::turn_bridge::tests::active_turn_output_offset_refreshes_session_heartbeat_before_done`)

## DoD
- [x] turn_bridge 에 `refresh_session_heartbeat_from_tmux_output` 호출 추가
- [x] `WATCHER_ACTIVITY_HEARTBEAT_INTERVAL`(30s) throttle 공유
- [x] 회귀 테스트 추가
- [ ] 실운영 로그에서 활성 세션이 idle safety TTL 에 걸리지 않음을 24h 관측 (배포 후)