### PR TITLE
Skip MCP broadcast when mcpServers diff is empty (#984)

### DIFF
--- a/src/services/discord/mcp_credential_watcher.rs
+++ b/src/services/discord/mcp_credential_watcher.rs
@@ -446,11 +446,20 @@ pub(super) fn spawn_watcher(
                 changes.push(change);
             }
 
-            tracing::info!("MCP credential change detected — notifying active Claude sessions");
-            let notification =
-                build_notification_from_changes(&changes, &mut snapshots, notify_message)
-                    .unwrap_or_else(|| notify_message.to_string());
-            broadcast_credential_change(&shared, &dedupe, dedupe_window, &notification).await;
+            match build_notification_from_changes(&changes, &mut snapshots, notify_message) {
+                Some(notification) => {
+                    tracing::info!(
+                        "MCP credential change detected — notifying active Claude sessions"
+                    );
+                    broadcast_credential_change(&shared, &dedupe, dedupe_window, &notification)
+                        .await;
+                }
+                None => {
+                    tracing::debug!(
+                        "MCP credential file touched but no mcpServers/credentials change — skipping broadcast"
+                    );
+                }
+            }
         }
     });
 }
@@ -503,7 +512,7 @@ async fn broadcast_credential_change(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use notify::event::{CreateKind, ModifyKind};
+    use notify::event::ModifyKind;
     use poise::serenity_prelude::ChannelId;
     use std::path::PathBuf;
     use std::time::{Duration, Instant, SystemTime};
@@ -575,5 +584,62 @@ mod tests {
         assert!(dedupe.try_record_at(ChannelId::new(2), window, t0));
         // First channel still inside its own window.
         assert!(!dedupe.try_record_at(ChannelId::new(1), window, t0 + Duration::from_secs(10)));
+    }
+
+    #[test]
+    fn build_notification_returns_none_when_mcp_servers_diff_empty() {
+        // Simulate .claude.json being modified without any mcpServers change
+        // (e.g. Claude CLI writing history / cwd tracking fields).
+        let tmp = tempdir().expect("tempdir");
+        let path = tmp.path().join(".claude.json");
+        let v1 = r#"{"mcpServers":{"memento":{"command":"memento"}},"history":[{"cwd":"/a"}]}"#;
+        let v2 = r#"{"mcpServers":{"memento":{"command":"memento"}},"history":[{"cwd":"/a"},{"cwd":"/b"}]}"#;
+        std::fs::write(&path, v1).expect("write v1");
+
+        let mut snapshots: HashMap<PathBuf, Option<FileSnapshot>> = HashMap::new();
+        snapshots.insert(path.clone(), snapshot_file(&path).unwrap_or(None));
+
+        std::fs::write(&path, v2).expect("write v2");
+        let changes = vec![CredentialChange {
+            path: path.clone(),
+            kind: notify::EventKind::Modify(ModifyKind::Any),
+            timestamp: SystemTime::now(),
+        }];
+
+        let out = build_notification_from_changes(&changes, &mut snapshots, "FALLBACK");
+        assert!(
+            out.is_none(),
+            "non-MCP field changes must not produce a notification, got: {out:?}"
+        );
+    }
+
+    #[test]
+    fn build_notification_returns_some_when_mcp_servers_actually_changes() {
+        let tmp = tempdir().expect("tempdir");
+        let path = tmp.path().join(".claude.json");
+        let v1 = r#"{"mcpServers":{"memento":{"command":"memento"}}}"#;
+        let v2 = r#"{"mcpServers":{"memento":{"command":"memento"},"brave":{"command":"brave"}}}"#;
+        std::fs::write(&path, v1).expect("write v1");
+
+        let mut snapshots: HashMap<PathBuf, Option<FileSnapshot>> = HashMap::new();
+        snapshots.insert(path.clone(), snapshot_file(&path).unwrap_or(None));
+
+        std::fs::write(&path, v2).expect("write v2");
+        let changes = vec![CredentialChange {
+            path: path.clone(),
+            kind: notify::EventKind::Modify(ModifyKind::Any),
+            timestamp: SystemTime::now(),
+        }];
+
+        let out = build_notification_from_changes(&changes, &mut snapshots, "FALLBACK");
+        let msg = out.expect("mcpServers diff should produce a notification");
+        assert!(
+            msg.contains("brave"),
+            "message should name the added server, got: {msg}"
+        );
+        assert!(
+            msg.starts_with("FALLBACK"),
+            "message should include the fallback prefix, got: {msg}"
+        );
     }
 }


### PR DESCRIPTION
Closes #984

## Summary

Completes #984 DoD: "mcpServers 섹션 diff 가 비어있으면 알림이 완전히 suppress 되어야 함".

Prior state: `spawn_watcher` 의 consumer 루프가 `build_notification_from_changes(...).unwrap_or_else(|| notify_message.to_string())` 로 None 을 static 메시지 fallback 으로 바꿔버려, **비-MCP 수정에도 계속 알림이 나가던 회귀**. Claude Code 가 `.claude.json` 의 history/cwd 등 비-MCP 필드를 갱신할 때마다 사용자 메인 채널에 `🔔 MCP credential 변화 감지됨` 알림이 발동.

## Fix

`src/services/discord/mcp_credential_watcher.rs:449-453` 의 호출부를 `match` 로 바꿔 **None 이면 broadcast 를 완전히 skip** 하고 debug 로그만 남긴다. Some 일 때만 알림 발송.

```rust
match build_notification_from_changes(&changes, &mut snapshots, notify_message) {
    Some(notification) => {
        tracing::info!("MCP credential change detected — notifying active Claude sessions");
        broadcast_credential_change(&shared, &dedupe, dedupe_window, &notification).await;
    }
    None => {
        tracing::debug!(
            "MCP credential file touched but no mcpServers/credentials change — skipping broadcast"
        );
    }
}
```

## Tests

- `build_notification_returns_none_when_mcp_servers_diff_empty` — 비-MCP 필드만 변경된 `.claude.json` 에 대해 `None` 반환 확인
- `build_notification_returns_some_when_mcp_servers_actually_changes` — 실제 mcpServers 추가 시 진단 문자열 포함 확인

두 테스트 모두 통과.

## DoD
- [x] `.claude.json` 의 mcpServers 와 무관한 필드 갱신 시 Discord 알림이 발생하지 않음 (단위 테스트로 보장)
- [x] mcpServers 추가/삭제/변경 시 구체 diff 알림은 정상 발송
- [x] `cargo check --bin agentdesk` 0 errors
- [ ] 실운영 로그에서 `MCP credential change detected` info 로그가 급격히 줄어드는지 24h 관측 (배포 후)