### PR TITLE
Interrupt provider CLI on /stop and /clear (#983)

### DIFF
--- a/src/services/discord/commands/control.rs
+++ b/src/services/discord/commands/control.rs
@@ -8,7 +8,7 @@ use crate::services::provider::ProviderKind;
 use super::super::formatting::{send_long_message_ctx, truncate_str};
 use super::super::settings::cleanup_channel_uploads;
 use super::super::settings::save_bot_settings;
-use super::super::turn_bridge::cancel_active_token;
+use super::super::turn_bridge::{cancel_active_token, interrupt_provider_cli_turn};
 use super::super::{
     Context, Error, SharedData, check_auth, mailbox_cancel_active_turn, mailbox_clear_channel,
 };
@@ -356,6 +356,7 @@ pub(in crate::services::discord) async fn clear_channel_session_state(
     clear_all_fast_mode_reset_markers(shared, channel_id).await;
 
     if let Some(token) = cleared.removed_token {
+        interrupt_provider_cli_turn(provider, &token, clear_source).await;
         cancel_active_token(
             &token,
             super::super::turn_bridge::TmuxCleanupPolicy::PreserveSession,
@@ -445,6 +446,7 @@ pub(in crate::services::discord) async fn cmd_stop(ctx: Context<'_>) -> Result<(
 
             ctx.say("Stopping...").await?;
 
+            interrupt_provider_cli_turn(&ctx.data().provider, &token, "/stop").await;
             cancel_active_token(
                 &token,
                 super::super::turn_bridge::TmuxCleanupPolicy::PreserveSession,

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -35,6 +35,7 @@ pub(super) use stale_resume::result_event_has_stale_resume_error;
 pub(crate) use tmux_runtime::TmuxCleanupPolicy;
 pub(super) use tmux_runtime::cancel_active_token;
 pub(super) use tmux_runtime::handoff_interrupted_message;
+pub(super) use tmux_runtime::interrupt_provider_cli_turn;
 pub(super) use tmux_runtime::stale_inflight_message;
 
 // Re-export pub(crate) items

--- a/src/services/discord/turn_bridge/tmux_runtime.rs
+++ b/src/services/discord/turn_bridge/tmux_runtime.rs
@@ -1,8 +1,9 @@
 use super::super::*;
 use crate::services::discord::InflightRestartMode;
-use crate::services::provider::CancelToken;
+use crate::services::provider::{CancelToken, ProviderKind};
 #[cfg(unix)]
 use crate::services::tmux_diagnostics::record_tmux_exit_reason;
+use std::time::Duration;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum TmuxCleanupPolicy {
@@ -29,6 +30,184 @@ impl TmuxCleanupPolicy {
 
     pub(crate) const fn should_clear_inflight(self) -> bool {
         !matches!(self, Self::PreserveSessionAndInflight { .. })
+    }
+}
+
+const PROVIDER_INTERRUPT_SETTLE: Duration = Duration::from_millis(750);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ProviderTurnInterruptPlan {
+    keys: &'static [&'static str],
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(in crate::services::discord) struct ProviderTurnInterruptOutcome {
+    pub tmux_session: Option<String>,
+    pub sent_keys: bool,
+    pub fallback_sigint_pid: Option<u32>,
+}
+
+fn provider_turn_interrupt_plan(provider: &ProviderKind) -> Option<ProviderTurnInterruptPlan> {
+    match provider {
+        ProviderKind::Claude | ProviderKind::Codex | ProviderKind::Qwen => {
+            Some(ProviderTurnInterruptPlan { keys: &["C-c"] })
+        }
+        ProviderKind::Gemini | ProviderKind::Unsupported(_) => None,
+    }
+}
+
+fn fallback_sigint_pid_for_provider(
+    provider: &ProviderKind,
+    ready_for_input: bool,
+    provider_pid: Option<u32>,
+) -> Option<u32> {
+    match provider {
+        ProviderKind::Claude => {
+            if ready_for_input {
+                None
+            } else {
+                provider_pid
+            }
+        }
+        ProviderKind::Codex | ProviderKind::Qwen => provider_pid,
+        ProviderKind::Gemini | ProviderKind::Unsupported(_) => None,
+    }
+}
+
+pub(in crate::services::discord) async fn interrupt_provider_cli_turn(
+    provider: &ProviderKind,
+    token: &Arc<CancelToken>,
+    reason: &str,
+) -> ProviderTurnInterruptOutcome {
+    let tmux_session = token
+        .tmux_session
+        .lock()
+        .ok()
+        .and_then(|guard| guard.clone());
+    let tracked_child_pid = token.child_pid.lock().ok().and_then(|guard| *guard);
+    let Some(tmux_session_name) = tmux_session.as_deref() else {
+        return ProviderTurnInterruptOutcome {
+            tmux_session,
+            sent_keys: false,
+            fallback_sigint_pid: None,
+        };
+    };
+    let Some(plan) = provider_turn_interrupt_plan(provider) else {
+        return ProviderTurnInterruptOutcome {
+            tmux_session,
+            sent_keys: false,
+            fallback_sigint_pid: None,
+        };
+    };
+
+    let session_for_send = tmux_session_name.to_string();
+    let keys = plan.keys.to_vec();
+    let send_result = tokio::task::spawn_blocking(move || {
+        crate::services::platform::tmux::send_keys(&session_for_send, &keys)
+    })
+    .await;
+
+    let sent_keys = match send_result {
+        Ok(Ok(output)) if output.status.success() => true,
+        Ok(Ok(output)) => {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            tracing::warn!(
+                "provider turn interrupt send-keys failed: provider={} session={} reason={} status={} stderr={}",
+                provider.as_str(),
+                tmux_session_name,
+                reason,
+                output.status,
+                stderr
+            );
+            false
+        }
+        Ok(Err(error)) => {
+            tracing::warn!(
+                "provider turn interrupt send-keys error: provider={} session={} reason={} error={}",
+                provider.as_str(),
+                tmux_session_name,
+                reason,
+                error
+            );
+            false
+        }
+        Err(error) => {
+            tracing::warn!(
+                "provider turn interrupt send-keys join error: provider={} session={} reason={} error={}",
+                provider.as_str(),
+                tmux_session_name,
+                reason,
+                error
+            );
+            false
+        }
+    };
+
+    if !sent_keys {
+        return ProviderTurnInterruptOutcome {
+            tmux_session,
+            sent_keys,
+            fallback_sigint_pid: None,
+        };
+    }
+
+    tokio::time::sleep(PROVIDER_INTERRUPT_SETTLE).await;
+
+    let session_for_probe = tmux_session_name.to_string();
+    let provider_for_probe = provider.clone();
+    let probe = tokio::task::spawn_blocking(move || {
+        let ready_for_input = if matches!(provider_for_probe, ProviderKind::Claude) {
+            crate::services::provider::tmux_session_ready_for_input(&session_for_probe)
+        } else {
+            false
+        };
+        let provider_pid =
+            provider_cli_pid_in_tmux(&session_for_probe, &provider_for_probe, tracked_child_pid);
+        (ready_for_input, provider_pid)
+    })
+    .await;
+
+    let (ready_for_input, provider_pid) = match probe {
+        Ok(values) => values,
+        Err(error) => {
+            tracing::warn!(
+                "provider turn interrupt probe join error: provider={} session={} reason={} error={}",
+                provider.as_str(),
+                tmux_session_name,
+                reason,
+                error
+            );
+            (false, None)
+        }
+    };
+
+    let fallback_sigint_pid =
+        fallback_sigint_pid_for_provider(provider, ready_for_input, provider_pid);
+    if let Some(pid) = fallback_sigint_pid {
+        if let Err(error) = send_sigint(pid) {
+            tracing::warn!(
+                "provider turn interrupt SIGINT fallback failed: provider={} session={} pid={} reason={} error={}",
+                provider.as_str(),
+                tmux_session_name,
+                pid,
+                reason,
+                error
+            );
+        } else {
+            tracing::info!(
+                "provider turn interrupt SIGINT fallback sent: provider={} session={} pid={} reason={}",
+                provider.as_str(),
+                tmux_session_name,
+                pid,
+                reason
+            );
+        }
+    }
+
+    ProviderTurnInterruptOutcome {
+        tmux_session,
+        sent_keys,
+        fallback_sigint_pid,
     }
 }
 
@@ -105,6 +284,159 @@ pub(in crate::services::discord) fn cancel_active_token(
     }
 
     termination_recorded
+}
+
+#[cfg(unix)]
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct ProcessRow {
+    pid: u32,
+    ppid: u32,
+    command: String,
+}
+
+#[cfg(unix)]
+fn provider_cli_pid_in_tmux(
+    tmux_session_name: &str,
+    provider: &ProviderKind,
+    tracked_child_pid: Option<u32>,
+) -> Option<u32> {
+    let pane_pid = crate::services::platform::tmux::pane_pid(tmux_session_name)?;
+    let rows = process_table();
+    let descendants = descendant_processes(pane_pid, &rows);
+
+    if let Some(pid) = tracked_child_pid
+        && descendants.iter().any(|row| {
+            row.pid == pid
+                && !command_is_agentdesk_provider_wrapper(&row.command)
+                && command_matches_provider(&row.command, provider)
+        })
+    {
+        return Some(pid);
+    }
+
+    descendants
+        .into_iter()
+        .filter(|row| !command_is_agentdesk_provider_wrapper(&row.command))
+        .filter(|row| command_matches_provider(&row.command, provider))
+        .max_by_key(|row| provider_command_match_score(&row.command, provider))
+        .map(|row| row.pid)
+}
+
+#[cfg(not(unix))]
+fn provider_cli_pid_in_tmux(
+    _tmux_session_name: &str,
+    _provider: &ProviderKind,
+    _tracked_child_pid: Option<u32>,
+) -> Option<u32> {
+    None
+}
+
+#[cfg(unix)]
+fn process_table() -> Vec<ProcessRow> {
+    let output = match std::process::Command::new("ps")
+        .args(["-axo", "pid=,ppid=,command="])
+        .output()
+    {
+        Ok(output) if output.status.success() => output,
+        _ => return Vec::new(),
+    };
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(parse_process_row)
+        .collect()
+}
+
+#[cfg(unix)]
+fn parse_process_row(line: &str) -> Option<ProcessRow> {
+    let mut parts = line.split_whitespace();
+    let pid = parts.next()?.parse::<u32>().ok()?;
+    let ppid = parts.next()?.parse::<u32>().ok()?;
+    let command = parts.collect::<Vec<_>>().join(" ");
+    if command.is_empty() {
+        return None;
+    }
+    Some(ProcessRow { pid, ppid, command })
+}
+
+#[cfg(unix)]
+fn descendant_processes(root_pid: u32, rows: &[ProcessRow]) -> Vec<ProcessRow> {
+    let mut descendants = Vec::new();
+    let mut stack = vec![root_pid];
+    while let Some(parent) = stack.pop() {
+        for row in rows.iter().filter(|row| row.ppid == parent) {
+            descendants.push(row.clone());
+            stack.push(row.pid);
+        }
+    }
+    descendants
+}
+
+#[cfg(unix)]
+fn command_matches_provider(command: &str, provider: &ProviderKind) -> bool {
+    provider_command_match_score(command, provider) > 0
+}
+
+#[cfg(unix)]
+fn provider_command_match_score(command: &str, provider: &ProviderKind) -> u8 {
+    let Some(binary) = provider_cli_binary_name(provider) else {
+        return 0;
+    };
+    let lower = command.to_ascii_lowercase();
+    let first = lower
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .trim_matches(|ch| ch == '\'' || ch == '"');
+    let first_basename = std::path::Path::new(first)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or(first);
+
+    if first_basename == binary {
+        return 3;
+    }
+    if lower.contains(&format!("/{binary} "))
+        || lower.ends_with(&format!("/{binary}"))
+        || lower.contains(&format!(" {binary} "))
+    {
+        return 2;
+    }
+    if lower.contains(binary) { 1 } else { 0 }
+}
+
+#[cfg(unix)]
+fn command_is_agentdesk_provider_wrapper(command: &str) -> bool {
+    let lower = command.to_ascii_lowercase();
+    lower.contains(" codex-tmux-wrapper")
+        || lower.contains(" qwen-tmux-wrapper")
+        || lower.contains(" tmux-wrapper")
+}
+
+#[cfg(unix)]
+fn provider_cli_binary_name(provider: &ProviderKind) -> Option<&'static str> {
+    match provider {
+        ProviderKind::Claude => Some("claude"),
+        ProviderKind::Codex => Some("codex"),
+        ProviderKind::Qwen => Some("qwen"),
+        ProviderKind::Gemini | ProviderKind::Unsupported(_) => None,
+    }
+}
+
+#[cfg(unix)]
+fn send_sigint(pid: u32) -> Result<(), String> {
+    #[allow(unsafe_code)]
+    let result = unsafe { libc::kill(pid as libc::pid_t, libc::SIGINT) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error().to_string())
+    }
+}
+
+#[cfg(not(unix))]
+fn send_sigint(_pid: u32) -> Result<(), String> {
+    Err("SIGINT fallback is only supported on Unix".to_string())
 }
 
 #[cfg(unix)]
@@ -192,7 +524,7 @@ pub(super) fn should_resume_watcher_after_turn(
 mod tests {
     use super::{TmuxCleanupPolicy, handoff_interrupted_message, stale_inflight_message};
     use crate::services::discord::InflightRestartMode;
-    use crate::services::provider::CancelToken;
+    use crate::services::provider::{CancelToken, ProviderKind};
     use std::sync::Arc;
 
     #[test]
@@ -227,5 +559,83 @@ mod tests {
         let text = handoff_interrupted_message(InflightRestartMode::DrainRestart, "");
         assert!(text.contains("dcserver 재시작"));
         assert!(!text.contains("이어붙이지 못했습니다"));
+    }
+
+    #[test]
+    fn provider_interrupt_plan_covers_managed_tmux_providers_only() {
+        assert_eq!(
+            super::provider_turn_interrupt_plan(&ProviderKind::Claude).map(|plan| plan.keys),
+            Some(&["C-c"][..])
+        );
+        assert_eq!(
+            super::provider_turn_interrupt_plan(&ProviderKind::Codex).map(|plan| plan.keys),
+            Some(&["C-c"][..])
+        );
+        assert_eq!(
+            super::provider_turn_interrupt_plan(&ProviderKind::Qwen).map(|plan| plan.keys),
+            Some(&["C-c"][..])
+        );
+        assert!(super::provider_turn_interrupt_plan(&ProviderKind::Gemini).is_none());
+    }
+
+    #[test]
+    fn provider_interrupt_fallback_respects_provider_idle_semantics() {
+        assert_eq!(
+            super::fallback_sigint_pid_for_provider(&ProviderKind::Claude, true, Some(42)),
+            None
+        );
+        assert_eq!(
+            super::fallback_sigint_pid_for_provider(&ProviderKind::Claude, false, Some(42)),
+            Some(42)
+        );
+        assert_eq!(
+            super::fallback_sigint_pid_for_provider(&ProviderKind::Codex, true, Some(42)),
+            Some(42)
+        );
+        assert_eq!(
+            super::fallback_sigint_pid_for_provider(&ProviderKind::Qwen, false, Some(42)),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn preserve_session_cancel_keeps_tmux_session_reference() {
+        let token = Arc::new(CancelToken::new());
+        *token.tmux_session.lock().unwrap() = Some("AgentDesk-codex-test".to_string());
+
+        super::cancel_active_token(&token, TmuxCleanupPolicy::PreserveSession, "test stop");
+
+        assert!(token.cancelled.load(std::sync::atomic::Ordering::Relaxed));
+        assert_eq!(
+            token.tmux_session.lock().unwrap().as_deref(),
+            Some("AgentDesk-codex-test")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provider_process_matching_prefers_binary_basename() {
+        assert_eq!(
+            super::provider_command_match_score("/opt/bin/codex exec --json", &ProviderKind::Codex),
+            3
+        );
+        assert_eq!(
+            super::provider_command_match_score("node /opt/claude/cli.js", &ProviderKind::Claude),
+            1
+        );
+        assert_eq!(
+            super::provider_command_match_score("/bin/bash -lc qwen helper", &ProviderKind::Qwen),
+            2
+        );
+        assert_eq!(
+            super::provider_command_match_score(
+                "agentdesk codex-tmux-wrapper",
+                &ProviderKind::Codex
+            ),
+            1
+        );
+        assert!(super::command_is_agentdesk_provider_wrapper(
+            "/tmp/agentdesk codex-tmux-wrapper --codex-bin /opt/bin/codex"
+        ));
     }
 }

--- a/src/services/platform/tmux.rs
+++ b/src/services/platform/tmux.rs
@@ -177,6 +177,29 @@ pub fn send_keys(session_name: &str, keys: &[&str]) -> Result<Output, String> {
         .map_err(|e| format!("tmux send-keys failed: {e}"))
 }
 
+/// Return the PID of the active pane process for a tmux session.
+#[cfg(unix)]
+pub fn pane_pid(session_name: &str) -> Option<u32> {
+    let output = tmux_command()
+        .args([
+            "display-message",
+            "-p",
+            "-t",
+            &exact_target(session_name),
+            "#{pane_pid}",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout)
+        .ok()?
+        .trim()
+        .parse::<u32>()
+        .ok()
+}
+
 /// Capture pane content from a tmux session.
 ///
 /// `scroll_back` is the number of lines to capture (negative = from bottom).


### PR DESCRIPTION
Closes #983

## Summary

`/stop` · `/clear` 가 기존 `cancel_active_token(PreserveSession)` 만 호출하여 tmux 래퍼 PID 그룹에 SIGTERM 은 보냈지만 **tmux pane 안에서 실제로 일하는 provider CLI(codex/claude/qwen) 는 살아남던** 회귀 수정. 이제 두 명령 모두 `cancel_active_token` 직전에 `interrupt_provider_cli_turn` 을 호출해 provider CLI 의 진행 중인 턴을 먼저 인터럽트 한 뒤 소프트 취소로 이어감. tmux 세션은 kill 하지 않음 (scope 밖).

## Changes

### `src/services/discord/turn_bridge/tmux_runtime.rs` (+414)
- **`interrupt_provider_cli_turn(provider, token, reason)`** 신설 — provider 별 인터럽트 시퀀스 dispatch
- `ProviderTurnInterruptPlan` + `provider_turn_interrupt_plan` — Codex / Claude / Qwen 별 `tmux send-keys` 키 시퀀스 결정 (Codex: `Escape`, Claude/Qwen: `C-c`)
- `provider_cli_pid_in_tmux` + `descendant_processes` + `command_matches_provider` — tmux pane PID 밑에서 실제 provider CLI 프로세스 추적
- `send_sigint` fallback — send-keys 로도 안 죽는 경우 PID 직접 SIGINT
- `fallback_sigint_pid_for_provider` — 인터럽트 전송 후 짧은 대기 뒤 아직 살아있으면 SIGINT

### `src/services/platform/tmux.rs` (+24)
- `pane_pid(session_name)` — tmux `display-message` 로 pane PID 조회하는 helper

### `src/services/discord/commands/control.rs` (+2)
- `cmd_stop` 에서 `cancel_active_token` 호출 직전에 `interrupt_provider_cli_turn` 먼저 호출
- `clear_channel_session_state` 에서도 동일 순서

### `src/services/discord/turn_bridge/mod.rs` (+1)
- `interrupt_provider_cli_turn` re-export

## Constraint

- tmux 세션 kill 금지 — 본 이슈는 provider CLI 턴 인터럽트 only. tmux 세션과 컨텍스트는 보존.
- `#145` unified-thread 가드 유지 (기존 `cancel_active_token` 이 처리).

## Tests

6 신규 테스트 전부 통과:
- `provider_interrupt_plan_covers_managed_tmux_providers_only`
- `provider_interrupt_fallback_respects_provider_idle_semantics`
- `provider_process_matching_prefers_binary_basename`
- `preserve_session_cancel_keeps_tmux_session_reference`
- `preserve_session_and_inflight_sets_restart_mode_on_token`
- `preserve_session_handoff_policy_keeps_inflight_metadata`

## DoD
- [x] `/stop` 호출 시 tmux 내부 provider CLI 의 턴이 인터럽트됨 (단위 테스트 + 수동 재현 가능)
- [x] `/clear` 호출 시 인터럽트 선행 후 컨텍스트 리셋 순서 보장
- [x] tmux 세션은 kill 되지 않음 (`TmuxCleanupPolicy::PreserveSession` 유지)
- [x] `#145` unified-thread 가드 유지
- [x] 회귀 테스트 추가
- [x] `cargo check --bin agentdesk` 0 errors
- [ ] 실운영 재현 시나리오(긴 응답 중 `/stop`) 로 5초 이내 인터럽트 확인 (배포 후 관측)