### PR TITLE
Add agent monitoring status surface for Discord channels (#997)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -148,6 +148,11 @@ pub(crate) enum Commands {
         #[arg(long)]
         repo: Option<String>,
     },
+    /// Monitor status commands for Discord channels
+    Monitoring {
+        #[command(subcommand)]
+        action: MonitoringAction,
+    },
     /// Discord utility commands without HTTP server dependency
     Discord {
         #[command(subcommand)]
@@ -457,6 +462,31 @@ pub(crate) enum DiscordAction {
         /// Read messages after this message ID
         #[arg(long)]
         after: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub(crate) enum MonitoringAction {
+    /// Register or refresh a monitor status entry
+    Start {
+        /// Discord channel ID
+        #[arg(long)]
+        channel: u64,
+        /// Monitor key, stable across refreshes
+        #[arg(long)]
+        key: String,
+        /// Human-readable monitor description
+        #[arg(long)]
+        description: String,
+    },
+    /// Remove a monitor status entry
+    Stop {
+        /// Discord channel ID
+        #[arg(long)]
+        channel: u64,
+        /// Monitor key to remove
+        #[arg(long)]
+        key: String,
     },
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod discord;
 pub(crate) mod doctor;
 pub(crate) mod init;
 pub(crate) mod migrate;
+pub(crate) mod monitoring;
 pub(crate) mod run;
 pub(crate) mod utils;
 

--- a/src/cli/monitoring.rs
+++ b/src/cli/monitoring.rs
@@ -1,0 +1,141 @@
+use serde_json::Value;
+
+const DEFAULT_API_URL: &str = "http://127.0.0.1:8791";
+
+pub(crate) fn start(channel: u64, key: &str, description: &str) -> Result<(), String> {
+    let body = serde_json::json!({
+        "key": key,
+        "description": description,
+    });
+    let response = request_json(
+        "POST",
+        &format!("/api/channels/{channel}/monitoring"),
+        Some(body),
+    )?;
+    print_json(&response);
+    Ok(())
+}
+
+pub(crate) fn stop(channel: u64, key: &str) -> Result<(), String> {
+    let response = request_json(
+        "DELETE",
+        &format!(
+            "/api/channels/{channel}/monitoring/{}",
+            encode_path_segment(key)
+        ),
+        None,
+    )?;
+    print_json(&response);
+    Ok(())
+}
+
+fn api_base() -> String {
+    let raw = match std::env::var("ADK_API_URL") {
+        Ok(value) => value,
+        Err(_) => match std::env::var("AGENTDESK_API_URL") {
+            Ok(value) => value,
+            Err(_) => DEFAULT_API_URL.to_string(),
+        },
+    };
+    raw.trim_end_matches('/').to_string()
+}
+
+fn auth_token() -> Option<String> {
+    crate::config::load_graceful().server.auth_token
+}
+
+fn request_json(method: &str, path: &str, body: Option<Value>) -> Result<Value, String> {
+    let url = format!("{}{}", api_base(), path);
+    let agent = ureq::Agent::new();
+    let mut request = match method {
+        "POST" => agent.post(&url),
+        "DELETE" => agent.delete(&url),
+        other => return Err(format!("unsupported monitoring HTTP method: {other}")),
+    };
+
+    if let Some(token) = auth_token() {
+        request = request.set("Authorization", &format!("Bearer {token}"));
+    }
+
+    let response = match body {
+        Some(body) => request
+            .set("Content-Type", "application/json")
+            .send_string(&body.to_string()),
+        None => request.call(),
+    };
+
+    match response {
+        Ok(response) => response
+            .into_json()
+            .map_err(|error| format!("monitoring API response parse failed: {error}")),
+        Err(ureq::Error::Status(code, response)) => {
+            let body = match response.into_string() {
+                Ok(body) => body,
+                Err(_) => String::new(),
+            };
+            Err(format_monitoring_error(code, &body))
+        }
+        Err(ureq::Error::Transport(error)) => {
+            Err(format!("monitoring API request failed: {error}"))
+        }
+    }
+}
+
+fn format_monitoring_error(code: u16, body: &str) -> String {
+    let detail = match serde_json::from_str::<Value>(body).ok().and_then(|value| {
+        value
+            .get("error")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+    }) {
+        Some(error) => error.trim().to_string(),
+        None => body.trim().to_string(),
+    };
+
+    if detail.is_empty() {
+        format!("monitoring API request failed ({code})")
+    } else {
+        format!("monitoring API request failed ({code}): {detail}")
+    }
+}
+
+fn print_json(value: &Value) {
+    match serde_json::to_string_pretty(value) {
+        Ok(rendered) => println!("{rendered}"),
+        Err(_) => println!("{value}"),
+    }
+}
+
+fn encode_path_segment(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(byte as char);
+            }
+            _ => {
+                encoded.push('%');
+                encoded.push_str(&format!("{byte:02X}"));
+            }
+        }
+    }
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_path_segment_leaves_uuid_like_keys_readable() {
+        assert_eq!(encode_path_segment("monitor-123_abc"), "monitor-123_abc");
+    }
+
+    #[test]
+    fn encode_path_segment_escapes_slashes_and_spaces() {
+        assert_eq!(
+            encode_path_segment("agent one/monitor"),
+            "agent%20one%2Fmonitor"
+        );
+    }
+}

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 
 use super::args::{
     AutoQueueAction, CardAction, Commands, ConfigAction, DispatchAction, MigrateAction,
-    ReportProvider,
+    MonitoringAction, ReportProvider,
 };
 
 fn exit_for_cli(result: std::result::Result<(), String>) -> Result<()> {
@@ -158,6 +158,14 @@ pub(crate) fn execute(command: Commands) -> Result<()> {
         Commands::GithubSync { repo } => exit_for_cli(super::direct::run_async(
             super::direct::cmd_github_sync(repo.as_deref()),
         )),
+        Commands::Monitoring { action } => exit_for_cli(match action {
+            MonitoringAction::Start {
+                channel,
+                key,
+                description,
+            } => super::monitoring::start(channel, &key, &description),
+            MonitoringAction::Stop { channel, key } => super::monitoring::stop(channel, &key),
+        }),
         Commands::Discord { action } => exit_for_cli(match action {
             super::args::DiscordAction::Read {
                 channel_id,

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -20,6 +20,7 @@ pub mod kanban;
 pub mod kanban_repos;
 pub mod meetings;
 pub mod messages;
+pub mod monitoring;
 pub mod offices;
 pub mod onboarding;
 pub mod pipeline;
@@ -32,6 +33,8 @@ mod session_activity;
 pub mod settings;
 mod skill_usage_analytics;
 pub mod skills_api;
+#[path = "../state.rs"]
+pub mod state;
 pub mod stats;
 pub mod termination_events;
 pub mod v1;
@@ -163,6 +166,12 @@ pub fn api_router_with_pg(
         health_registry,
     };
 
+    #[cfg(not(test))]
+    crate::services::discord::monitoring_status::spawn_expiry_sweeper(
+        state::global_monitoring_store(),
+        state.health_registry.clone(),
+    );
+
     compose_api_router(state.clone()).with_state(state)
 }
 
@@ -175,6 +184,7 @@ fn compose_api_router(state: AppState) -> ApiRouter {
         .merge(domains::reviews::router(state.clone()))
         .merge(domains::ops::router(state.clone()))
         .merge(domains::integrations::router(state.clone()))
+        .merge(monitoring::router(state.clone()))
         .merge(v1::router(state.clone()))
         .merge(domains::admin::router(state))
 }

--- a/src/server/routes/monitoring.rs
+++ b/src/server/routes/monitoring.rs
@@ -1,0 +1,125 @@
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    http::StatusCode,
+    routing::{delete, post},
+};
+use poise::serenity_prelude::ChannelId;
+use serde::Deserialize;
+use serde_json::json;
+
+use super::{ApiRouter, AppState, protected_api_domain, state};
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct UpsertMonitoringBody {
+    key: String,
+    description: String,
+}
+
+pub(crate) fn router(state: AppState) -> ApiRouter {
+    protected_api_domain(
+        Router::new()
+            .route(
+                "/channels/{channel_id}/monitoring",
+                post(upsert_monitoring).get(list_monitoring),
+            )
+            .route(
+                "/channels/{channel_id}/monitoring/{key}",
+                delete(remove_monitoring),
+            ),
+        state,
+    )
+}
+
+pub async fn upsert_monitoring(
+    State(state): State<AppState>,
+    Path(channel_id): Path<u64>,
+    Json(body): Json<UpsertMonitoringBody>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let key = body.key.trim();
+    let description = body.description.trim();
+    if key.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"status": "error", "error": "key is required"})),
+        );
+    }
+    if description.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"status": "error", "error": "description is required"})),
+        );
+    }
+
+    let active_count = {
+        let monitoring = state::global_monitoring_store();
+        let mut store = monitoring.lock().await;
+        store.upsert(channel_id, key.to_string(), description.to_string())
+    };
+    schedule_render(&state, channel_id);
+
+    (
+        StatusCode::OK,
+        Json(json!({"status": "ok", "active_count": active_count})),
+    )
+}
+
+pub async fn remove_monitoring(
+    State(state): State<AppState>,
+    Path((channel_id, key)): Path<(u64, String)>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let active_count = {
+        let monitoring = state::global_monitoring_store();
+        let mut store = monitoring.lock().await;
+        store.remove(channel_id, &key)
+    };
+    schedule_render(&state, channel_id);
+
+    (
+        StatusCode::OK,
+        Json(json!({"status": "ok", "active_count": active_count})),
+    )
+}
+
+pub async fn list_monitoring(
+    State(_state): State<AppState>,
+    Path(channel_id): Path<u64>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let entries = {
+        let monitoring = state::global_monitoring_store();
+        let store = monitoring.lock().await;
+        store.list(channel_id)
+    };
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "status": "ok",
+            "active_count": entries.len(),
+            "entries": entries,
+        })),
+    )
+}
+
+fn schedule_render(state: &AppState, channel_id: u64) {
+    crate::services::discord::monitoring_status::schedule_render_channel(
+        state::global_monitoring_store(),
+        state.health_registry.clone(),
+        ChannelId::new(channel_id),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upsert_body_deserializes_payload_shape() -> Result<(), serde_json::Error> {
+        let body: UpsertMonitoringBody =
+            serde_json::from_str(r#"{"key":"m1","description":"waiting"}"#)?;
+
+        assert_eq!(body.key, "m1");
+        assert_eq!(body.description, "waiting");
+        Ok(())
+    }
+}

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -1,0 +1,227 @@
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+
+use chrono::{DateTime, Duration, Utc};
+use serde::Serialize;
+use tokio::sync::Mutex;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct MonitoringEntry {
+    pub key: String,
+    pub description: String,
+    pub started_at: DateTime<Utc>,
+    pub last_refresh: DateTime<Utc>,
+}
+
+#[derive(Debug, Default)]
+pub struct MonitoringStore {
+    entries: HashMap<u64, Vec<MonitoringEntry>>,
+    rendered: HashMap<u64, u64>,
+    render_versions: HashMap<u64, u64>,
+}
+
+impl MonitoringStore {
+    pub fn upsert(&mut self, channel_id: u64, key: String, description: String) -> usize {
+        let now = Utc::now();
+        let entries = self.entries.entry(channel_id).or_default();
+        if let Some(entry) = entries.iter_mut().find(|entry| entry.key == key) {
+            entry.description = description;
+            entry.last_refresh = now;
+        } else {
+            entries.push(MonitoringEntry {
+                key,
+                description,
+                started_at: now,
+                last_refresh: now,
+            });
+        }
+        entries.len()
+    }
+
+    pub fn remove(&mut self, channel_id: u64, key: &str) -> usize {
+        let Some(entries) = self.entries.get_mut(&channel_id) else {
+            return 0;
+        };
+        entries.retain(|entry| entry.key != key);
+        let active_count = entries.len();
+        if active_count == 0 {
+            self.entries.remove(&channel_id);
+        }
+        active_count
+    }
+
+    pub fn list(&self, channel_id: u64) -> Vec<MonitoringEntry> {
+        match self.entries.get(&channel_id) {
+            Some(entries) => entries.clone(),
+            None => Vec::new(),
+        }
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn sweep_expired(&mut self, ttl: Duration) -> Vec<u64> {
+        self.sweep_expired_inner(ttl).emptied_channels
+    }
+
+    pub(crate) fn sweep_expired_affected(&mut self, ttl: Duration) -> Vec<u64> {
+        self.sweep_expired_inner(ttl).affected_channels
+    }
+
+    pub fn set_rendered_msg(&mut self, channel_id: u64, msg_id: Option<u64>) {
+        match msg_id {
+            Some(msg_id) => {
+                self.rendered.insert(channel_id, msg_id);
+            }
+            None => {
+                self.rendered.remove(&channel_id);
+            }
+        }
+    }
+
+    pub fn get_rendered_msg(&self, channel_id: u64) -> Option<u64> {
+        self.rendered.get(&channel_id).copied()
+    }
+
+    pub(crate) fn next_render_version(&mut self, channel_id: u64) -> u64 {
+        let version = self.render_versions.entry(channel_id).or_insert(0);
+        *version = version.saturating_add(1);
+        *version
+    }
+
+    pub(crate) fn is_latest_render_version(&self, channel_id: u64, version: u64) -> bool {
+        self.render_versions
+            .get(&channel_id)
+            .copied()
+            .map_or(0, |value| value)
+            == version
+    }
+
+    fn sweep_expired_inner(&mut self, ttl: Duration) -> SweepResult {
+        let now = Utc::now();
+        let mut affected_channels = Vec::new();
+        let mut emptied_channels = Vec::new();
+        let channel_ids = self.entries.keys().copied().collect::<Vec<_>>();
+
+        for channel_id in channel_ids {
+            let Some(entries) = self.entries.get_mut(&channel_id) else {
+                continue;
+            };
+            let before = entries.len();
+            entries.retain(|entry| now.signed_duration_since(entry.last_refresh) <= ttl);
+            if entries.len() == before {
+                continue;
+            }
+
+            affected_channels.push(channel_id);
+            if entries.is_empty() {
+                self.entries.remove(&channel_id);
+                emptied_channels.push(channel_id);
+            }
+        }
+
+        SweepResult {
+            affected_channels,
+            emptied_channels,
+        }
+    }
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Debug)]
+struct SweepResult {
+    affected_channels: Vec<u64>,
+    emptied_channels: Vec<u64>,
+}
+
+static GLOBAL_MONITORING_STORE: OnceLock<Arc<Mutex<MonitoringStore>>> = OnceLock::new();
+
+pub fn global_monitoring_store() -> Arc<Mutex<MonitoringStore>> {
+    GLOBAL_MONITORING_STORE
+        .get_or_init(|| Arc::new(Mutex::new(MonitoringStore::default())))
+        .clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upsert_adds_and_refreshes_entries() {
+        let mut store = MonitoringStore::default();
+
+        assert_eq!(
+            store.upsert(10, "one".to_string(), "waiting".to_string()),
+            1
+        );
+        let first = store.list(10).remove(0);
+
+        assert_eq!(
+            store.upsert(10, "one".to_string(), "updated".to_string()),
+            1
+        );
+        let updated = store.list(10).remove(0);
+
+        assert_eq!(updated.description, "updated");
+        assert_eq!(updated.started_at, first.started_at);
+        assert!(updated.last_refresh >= first.last_refresh);
+    }
+
+    #[test]
+    fn remove_clears_entries_without_losing_rendered_message() {
+        let mut store = MonitoringStore::default();
+        store.upsert(10, "one".to_string(), "waiting".to_string());
+        store.set_rendered_msg(10, Some(99));
+
+        assert_eq!(store.remove(10, "one"), 0);
+        assert!(store.list(10).is_empty());
+        assert_eq!(store.get_rendered_msg(10), Some(99));
+    }
+
+    #[test]
+    fn rendered_message_can_be_set_and_cleared() {
+        let mut store = MonitoringStore::default();
+
+        assert_eq!(store.get_rendered_msg(10), None);
+        store.set_rendered_msg(10, Some(42));
+        assert_eq!(store.get_rendered_msg(10), Some(42));
+        store.set_rendered_msg(10, None);
+        assert_eq!(store.get_rendered_msg(10), None);
+    }
+
+    #[test]
+    fn sweep_expired_removes_old_entries_and_reports_empty_channels() -> Result<(), String> {
+        let mut store = MonitoringStore::default();
+        store.upsert(10, "old".to_string(), "old wait".to_string());
+        store.upsert(11, "fresh".to_string(), "fresh wait".to_string());
+        let entries = store
+            .entries
+            .get_mut(&10)
+            .ok_or_else(|| "missing channel 10 entry".to_string())?;
+        entries[0].last_refresh = Utc::now() - Duration::minutes(11);
+
+        let emptied = store.sweep_expired(Duration::minutes(10));
+
+        assert_eq!(emptied, vec![10]);
+        assert!(store.list(10).is_empty());
+        assert_eq!(store.list(11).len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn sweep_expired_affected_reports_partial_channel_updates() -> Result<(), String> {
+        let mut store = MonitoringStore::default();
+        store.upsert(10, "old".to_string(), "old wait".to_string());
+        store.upsert(10, "fresh".to_string(), "fresh wait".to_string());
+        let entries = store
+            .entries
+            .get_mut(&10)
+            .ok_or_else(|| "missing channel 10 entries".to_string())?;
+        entries[0].last_refresh = Utc::now() - Duration::minutes(11);
+
+        let affected = store.sweep_expired_affected(Duration::minutes(10));
+
+        assert_eq!(affected, vec![10]);
+        assert_eq!(store.list(10).len(), 1);
+        assert_eq!(store.list(10)[0].key, "fresh");
+        Ok(())
+    }
+}

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod meeting_orchestrator;
 mod metrics;
 mod model_catalog;
 mod model_picker_interaction;
+pub(crate) mod monitoring_status;
 mod org_schema;
 pub(crate) mod org_writer;
 mod prompt_builder;

--- a/src/services/discord/monitoring_status.rs
+++ b/src/services/discord/monitoring_status.rs
@@ -1,0 +1,288 @@
+use std::sync::{Arc, OnceLock};
+use std::time::Duration as StdDuration;
+
+use chrono::{DateTime, Utc};
+use poise::serenity_prelude as serenity;
+use serenity::{ChannelId, CreateMessage, EditMessage, MessageId};
+use tokio::sync::Mutex;
+
+use super::{SharedData, health, rate_limit_wait};
+use crate::server::routes::state::{MonitoringEntry, MonitoringStore, global_monitoring_store};
+
+const RENDER_DEBOUNCE: StdDuration = StdDuration::from_millis(300);
+const MONITORING_TTL: chrono::Duration = chrono::Duration::minutes(10);
+const SWEEP_INTERVAL: StdDuration = StdDuration::from_secs(60);
+
+static SWEEPER_STARTED: OnceLock<()> = OnceLock::new();
+
+pub(crate) fn schedule_render_channel(
+    monitoring: Arc<Mutex<MonitoringStore>>,
+    health_registry: Option<Arc<health::HealthRegistry>>,
+    channel_id: ChannelId,
+) {
+    tokio::spawn(async move {
+        let version = {
+            let mut store = monitoring.lock().await;
+            store.next_render_version(channel_id.get())
+        };
+
+        tokio::time::sleep(RENDER_DEBOUNCE).await;
+
+        let should_render = {
+            let store = monitoring.lock().await;
+            store.is_latest_render_version(channel_id.get(), version)
+        };
+        if !should_render {
+            return;
+        }
+
+        if let Err(error) = render_channel_monitoring_from_registry(
+            &monitoring,
+            health_registry.as_ref(),
+            channel_id,
+        )
+        .await
+        {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            tracing::warn!(
+                "  [{ts}] ⚠ monitoring status render failed for channel {}: {}",
+                channel_id.get(),
+                error
+            );
+        }
+    });
+}
+
+pub(crate) fn spawn_expiry_sweeper(
+    monitoring: Arc<Mutex<MonitoringStore>>,
+    health_registry: Option<Arc<health::HealthRegistry>>,
+) {
+    if SWEEPER_STARTED.set(()).is_err() {
+        return;
+    }
+
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(SWEEP_INTERVAL);
+        loop {
+            interval.tick().await;
+            let affected_channels = {
+                let mut store = monitoring.lock().await;
+                store.sweep_expired_affected(MONITORING_TTL)
+            };
+
+            for channel_id in affected_channels {
+                schedule_render_channel(
+                    monitoring.clone(),
+                    health_registry.clone(),
+                    ChannelId::new(channel_id),
+                );
+            }
+        }
+    });
+}
+
+#[allow(dead_code)]
+pub(in crate::services::discord) async fn render_channel_monitoring(
+    http: &Arc<serenity::Http>,
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+) {
+    let monitoring = global_monitoring_store();
+    if let Err(error) =
+        render_channel_monitoring_from_store(http, &monitoring, Some(shared), channel_id).await
+    {
+        let ts = chrono::Local::now().format("%H:%M:%S");
+        tracing::warn!(
+            "  [{ts}] ⚠ monitoring status render failed for channel {}: {}",
+            channel_id.get(),
+            error
+        );
+    }
+}
+
+async fn render_channel_monitoring_from_registry(
+    monitoring: &Arc<Mutex<MonitoringStore>>,
+    health_registry: Option<&Arc<health::HealthRegistry>>,
+    channel_id: ChannelId,
+) -> Result<(), String> {
+    let Some(registry) = health_registry else {
+        return Ok(());
+    };
+    let http = resolve_status_http(registry).await?;
+    render_channel_monitoring_from_store(&http, monitoring, None, channel_id).await
+}
+
+async fn resolve_status_http(
+    registry: &Arc<health::HealthRegistry>,
+) -> Result<Arc<serenity::Http>, String> {
+    if let Ok(http) = health::resolve_bot_http(registry, "notify").await {
+        return Ok(http);
+    }
+    health::resolve_bot_http(registry, "announce")
+        .await
+        .map_err(|(_, body)| body)
+}
+
+async fn render_channel_monitoring_from_store(
+    http: &Arc<serenity::Http>,
+    monitoring: &Arc<Mutex<MonitoringStore>>,
+    shared: Option<&Arc<SharedData>>,
+    channel_id: ChannelId,
+) -> Result<(), String> {
+    let (entries, rendered_msg_id) = {
+        let store = monitoring.lock().await;
+        (
+            store.list(channel_id.get()),
+            store.get_rendered_msg(channel_id.get()),
+        )
+    };
+
+    let Some(content) = format_monitoring_message(&entries) else {
+        if let Some(msg_id) = rendered_msg_id {
+            wait_if_shared(shared, channel_id).await;
+            if let Err(error) = channel_id
+                .delete_message(http, MessageId::new(msg_id))
+                .await
+            {
+                let ts = chrono::Local::now().format("%H:%M:%S");
+                tracing::warn!(
+                    "  [{ts}] ⚠ failed to delete monitoring status msg {} in channel {}: {}",
+                    msg_id,
+                    channel_id.get(),
+                    error
+                );
+            }
+            let mut store = monitoring.lock().await;
+            store.set_rendered_msg(channel_id.get(), None);
+        }
+        return Ok(());
+    };
+
+    if let Some(msg_id) = rendered_msg_id {
+        wait_if_shared(shared, channel_id).await;
+        match channel_id
+            .edit_message(
+                http,
+                MessageId::new(msg_id),
+                EditMessage::new().content(&content),
+            )
+            .await
+        {
+            Ok(_) => return Ok(()),
+            Err(error) => {
+                let ts = chrono::Local::now().format("%H:%M:%S");
+                tracing::warn!(
+                    "  [{ts}] ⚠ failed to edit monitoring status msg {} in channel {}: {}",
+                    msg_id,
+                    channel_id.get(),
+                    error
+                );
+                let mut store = monitoring.lock().await;
+                store.set_rendered_msg(channel_id.get(), None);
+            }
+        }
+    }
+
+    wait_if_shared(shared, channel_id).await;
+    let message = channel_id
+        .send_message(http, CreateMessage::new().content(content))
+        .await
+        .map_err(|error| {
+            format!(
+                "failed to send monitoring status message in channel {}: {}",
+                channel_id.get(),
+                error
+            )
+        })?;
+    let mut store = monitoring.lock().await;
+    store.set_rendered_msg(channel_id.get(), Some(message.id.get()));
+    Ok(())
+}
+
+async fn wait_if_shared(shared: Option<&Arc<SharedData>>, channel_id: ChannelId) {
+    if let Some(shared) = shared {
+        rate_limit_wait(shared, channel_id).await;
+    }
+}
+
+pub(crate) fn format_monitoring_message(entries: &[MonitoringEntry]) -> Option<String> {
+    match entries {
+        [] => None,
+        [entry] => Some(format!(
+            "👁️ 모니터링 중: {} (시작 {})",
+            entry.description,
+            format_kst_hhmm(entry.started_at)
+        )),
+        entries => {
+            let mut lines = Vec::with_capacity(entries.len() + 1);
+            lines.push(format!("👁️ 모니터링 중 ({}건):", entries.len()));
+            lines.extend(entries.iter().map(|entry| {
+                format!(
+                    "- {} ({})",
+                    entry.description,
+                    format_kst_hhmm(entry.started_at)
+                )
+            }));
+            Some(lines.join("\n"))
+        }
+    }
+}
+
+fn format_kst_hhmm(value: DateTime<Utc>) -> String {
+    value
+        .with_timezone(&chrono_tz::Asia::Seoul)
+        .format("%H:%M")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(
+        key: &str,
+        description: &str,
+        started_at: &str,
+    ) -> Result<MonitoringEntry, chrono::ParseError> {
+        let started_at = DateTime::parse_from_rfc3339(started_at)?.with_timezone(&Utc);
+        Ok(MonitoringEntry {
+            key: key.to_string(),
+            description: description.to_string(),
+            started_at,
+            last_refresh: started_at,
+        })
+    }
+
+    #[test]
+    fn format_empty_monitoring_message_returns_none() {
+        assert_eq!(format_monitoring_message(&[]), None);
+    }
+
+    #[test]
+    fn format_single_monitoring_message() -> Result<(), chrono::ParseError> {
+        let entries = vec![entry("one", "터미널 신호 대기", "2026-04-24T01:20:00Z")?];
+
+        assert_eq!(
+            format_monitoring_message(&entries),
+            Some("👁️ 모니터링 중: 터미널 신호 대기 (시작 10:20)".to_string())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn format_multiple_monitoring_messages() -> Result<(), chrono::ParseError> {
+        let entries = vec![
+            entry("one", "터미널 신호 대기", "2026-04-24T01:20:00Z")?,
+            entry("two", "CI 완료 대기", "2026-04-24T02:05:00Z")?,
+        ];
+
+        assert_eq!(
+            format_monitoring_message(&entries),
+            Some(
+                "👁️ 모니터링 중 (2건):\n- 터미널 신호 대기 (10:20)\n- CI 완료 대기 (11:05)"
+                    .to_string()
+            )
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

- `MonitoringStore` (in-memory) 와 API 3 엔드포인트로 agent 가 Monitor 대기 상태를 Discord 채널에 실시간 표시
- 채널당 상태 메시지 1 개 유지 (edit 우선, 신규 생성 fallback, 0 건 시 삭제)
- 10 분 TTL 자동 만료 + 60s sweep 태스크로 좀비 상태 정리
- CLI: `agentdesk monitoring start --channel <id> --key <key> --description "..."` / `agentdesk monitoring stop --channel <id> --key <key>`

## 추가 파일

- `src/server/state.rs` — `MonitoringStore` + 글로벌 `OnceLock`
- `src/server/routes/monitoring.rs` — axum 라우트
- `src/services/discord/monitoring_status.rs` — 렌더링 + debounce + sweeper
- `src/cli/monitoring.rs` — ureq 기반 CLI (기존 의존성 재사용)

## 턴 lifecycle 독립

- mailbox / turn_bridge / tmux watcher / idle TTL 로직 전부 미수정
- 상태 메시지는 placeholder 와 무관하며 edit rate-limit 은 기존 `rate_limit_wait` 재사용

## Test plan

- [x] `cargo check --bin agentdesk` 0 errors
- [x] `server::routes::state::tests::*` 5건 통과 (upsert, remove, sweep_expired variations, rendered set/clear)
- [x] `services::discord::monitoring_status::tests::format_*` 3건 통과 (empty/single/multi)
- [x] `cli::monitoring::tests::encode_path_segment_*` 2건 통과
- [x] `server::routes::monitoring::tests::upsert_body_deserializes_payload_shape` 통과
- [ ] 배포 후 실채널에서 CLI `start` → 상태 메시지 출현, `stop` → 자동 삭제 확인

Closes #997.

🤖 Generated with [Claude Code](https://claude.com/claude-code)