### PR TITLE
Run high-risk recovery lane serially to fix PG admin pool starvation (#974)

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -183,7 +183,7 @@ jobs:
             ${{ runner.os }}-cargo-recovery-main-
 
       - name: High-risk recovery lane
-        run: "cargo test --bin agentdesk high_risk_recovery::"
+        run: "cargo test --bin agentdesk high_risk_recovery:: -- --test-threads=1"
 
   scripts:
     name: Script checks

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -181,7 +181,7 @@ jobs:
             ${{ runner.os }}-cargo-recovery-nightly-
 
       - name: High-risk recovery lane
-        run: "cargo test --bin agentdesk high_risk_recovery::"
+        run: "cargo test --bin agentdesk high_risk_recovery:: -- --test-threads=1"
 
   scripts:
     name: Script checks nightly

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -210,7 +210,7 @@ jobs:
             ${{ runner.os }}-cargo-recovery-
 
       - name: High-risk recovery lane
-        run: "cargo test --bin agentdesk high_risk_recovery::"
+        run: "cargo test --bin agentdesk high_risk_recovery:: -- --test-threads=1"
 
   lint:
     name: Lint


### PR DESCRIPTION
## Summary

`high_risk_recovery::` 테스트 시나리오는 각 시나리오마다 admin PG 커넥션으로 fresh DB 를 provision 한다. 기본 병렬 test executor 에서 admin pool 이 소진되어 `"pool timed out while waiting for an open connection"` 으로 실패.

`--test-threads=1` 로 serialize 해서 admin 커넥션을 순차적으로 재사용. 이는 workaround 가 아니라 시나리오 테스트 설계(per-test DB provision)에 맞는 실행 모드.

## 변경 파일

- `.github/workflows/ci-main.yml`
- `.github/workflows/ci-nightly.yml`
- `.github/workflows/ci-pr.yml`

세 워크플로 모두 같은 `cargo test --bin agentdesk high_risk_recovery::` 커맨드를 사용하므로 일괄 적용.

## Test plan

- [x] 로컬에서 `--test-threads=1` 으로 `high_risk_recovery::` 수행 시 PG 풀 timeout 발생하지 않음 확인
- [ ] main 머지 후 CI 에서 High-risk recovery lane 녹색 확인

Closes #974.

🤖 Generated with [Claude Code](https://claude.com/claude-code)