### PR TITLE
Fix Full tests lane PG filter and brittle assertion (#973)

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -76,7 +76,7 @@ jobs:
             ${{ runner.os }}-cargo-main-full-
 
       - name: cargo test (non-PG)
-        run: cargo test --all-targets -- --skip _pg_ --skip postgres_
+        run: cargo test --all-targets -- --skip _pg --skip pg_ --skip postgres
         env:
           RUST_BACKTRACE: 1
 
@@ -130,7 +130,12 @@ jobs:
 
       - name: cargo test (PG routes)
         timeout-minutes: 15
-        run: cargo test _pg_ -- --nocapture --test-threads=1
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo test _pg -- --nocapture --test-threads=1
+          cargo test pg_ -- --nocapture --test-threads=1
+          cargo test postgres -- --nocapture --test-threads=1
 
   high-risk-recovery:
     name: High-risk recovery

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -2260,7 +2260,7 @@ mod tests {
             .find("✓ Reconcile complete — intake open")
             .expect("reconcile completion log missing");
         let background_validation = startup_block
-            .find("spawn_startup_thread_map_validation(db, token_for_kickoff.clone());")
+            .find("spawn_startup_thread_map_validation(")
             .expect("background thread-map validation spawn missing");
 
         assert!(


### PR DESCRIPTION
## Summary

Two root causes of the Full tests (ubuntu-latest) lane red:

1. Non-PG lane skip filter `_pg_` + `postgres_` missed tests named with `*_pg` suffix, `pg_*` prefix, or `*postgres` suffix. Those PG tests then failed in the non-PG lane due to missing PostgreSQL. Filter widened; PG routes lane split into three sequential cargo test invocations.
2. `startup_recovery_source_prioritizes_catch_up_and_backgrounds_thread_map_validation` assertion used exact-match substring including specific argument names, brittle to upstream wiring changes. Relaxed to match the function identifier only.

## Test plan

- [x] `cargo check --bin agentdesk` 0 errors
- [x] `startup_recovery_source_*` test passes locally after relaxation
- [ ] Post-merge: CI Full tests (ubuntu-latest) lane green on main

Closes #973.

🤖 Generated with [Claude Code](https://claude.com/claude-code)