### PR TITLE
Silence test-build dead_code warnings on monitoring sweeper (#1000)

### DIFF
--- a/src/services/discord/monitoring_status.rs
+++ b/src/services/discord/monitoring_status.rs
@@ -10,9 +10,14 @@ use super::{SharedData, health, rate_limit_wait};
 use crate::server::routes::state::{MonitoringEntry, MonitoringStore, global_monitoring_store};
 
 const RENDER_DEBOUNCE: StdDuration = StdDuration::from_millis(300);
+
+#[cfg_attr(test, allow(dead_code))]
 const MONITORING_TTL: chrono::Duration = chrono::Duration::minutes(10);
+
+#[cfg_attr(test, allow(dead_code))]
 const SWEEP_INTERVAL: StdDuration = StdDuration::from_secs(60);
 
+#[cfg_attr(test, allow(dead_code))]
 static SWEEPER_STARTED: OnceLock<()> = OnceLock::new();
 
 pub(crate) fn schedule_render_channel(
@@ -53,6 +58,7 @@ pub(crate) fn schedule_render_channel(
     });
 }
 
+#[cfg_attr(test, allow(dead_code))]
 pub(crate) fn spawn_expiry_sweeper(
     monitoring: Arc<Mutex<MonitoringStore>>,
     health_registry: Option<Arc<health::HealthRegistry>>,


### PR DESCRIPTION
## Summary

Added `#[cfg_attr(test, allow(dead_code))]` to `MONITORING_TTL`, `SWEEP_INTERVAL`, `SWEEPER_STARTED`, and `spawn_expiry_sweeper`. These symbols are only referenced from a `#[cfg(not(test))]`-gated call site in `src/server/routes/mod.rs`, so test builds flagged them as never-used.

Runtime behavior unchanged — same pattern already used in `src/server/state.rs`.

## Test plan

- [x] `cargo check --bin agentdesk` 0 errors
- [x] `cargo check --bin agentdesk --tests` 0 warnings on the four symbols
- [x] No functional code touched

Closes #1000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)