### PR TITLE
Finalize auto-queue run when github sync skips pending entry (#1017)

### DIFF
--- a/src/github/sync.rs
+++ b/src/github/sync.rs
@@ -617,24 +617,12 @@ pub(crate) async fn sync_auto_queue_terminal_on_pg(
         let entry_id: String = row
             .try_get("id")
             .map_err(|error| format!("read pending auto-queue entry id: {error}"))?;
-        sqlx::query(
-            "UPDATE auto_queue_entries
-             SET status = 'skipped',
-                 dispatch_id = NULL,
-                 dispatched_at = NULL,
-                 completed_at = NOW()
-             WHERE id = $1 AND status = 'pending'",
-        )
-        .bind(&entry_id)
-        .execute(&mut **tx)
-        .await
-        .map_err(|error| format!("skip pending auto-queue entry {entry_id}: {error}"))?;
-        record_auto_queue_transition_on_pg(
+        crate::db::auto_queue::update_entry_status_on_pg_tx(
             tx,
             &entry_id,
-            crate::db::auto_queue::ENTRY_STATUS_PENDING,
             crate::db::auto_queue::ENTRY_STATUS_SKIPPED,
             "card_terminal_pending_cleanup",
+            &crate::db::auto_queue::EntryStatusUpdateOptions::default(),
         )
         .await?;
     }

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -7932,12 +7932,14 @@ async fn github_repos_pg_sync_closes_card_and_cleans_live_state() {
     assert_eq!(entry_status, "skipped");
     assert!(entry_dispatch_id.is_none());
 
-    let run_status: String = sqlx::query_scalar("SELECT status FROM auto_queue_runs WHERE id = $1")
-        .bind("run-pg-sync")
-        .fetch_one(&pg_pool)
-        .await
-        .unwrap();
+    let (run_status, run_completed_at): (String, Option<chrono::DateTime<chrono::Utc>>) =
+        sqlx::query_as("SELECT status, completed_at FROM auto_queue_runs WHERE id = $1")
+            .bind("run-pg-sync")
+            .fetch_one(&pg_pool)
+            .await
+            .unwrap();
     assert_eq!(run_status, "completed");
+    assert!(run_completed_at.is_some());
 
     let (review_state, pending_dispatch_id): (String, Option<String>) = sqlx::query_as(
         "SELECT state, pending_dispatch_id


### PR DESCRIPTION
## Summary

Root cause: PG terminal sync used raw SQL to mark pending auto_queue_entry as skipped but bypassed transition recording + run finalization. Result: `auto_queue_runs.status` stuck at `active`, card not transitioning to `completed`.

Switched to `update_entry_status_on_pg_tx` helper which canonically handles transition + run finalization. Strengthened the assertion in routes_tests.rs to verify `completed_at` is set.

## Test plan

- [x] `cargo check --bin agentdesk` 0 errors on rebased main
- [ ] `github_repos_pg_sync_closes_card_and_cleans_live_state` passes in CI PG routes lane

Closes #1017.

🤖 Generated with [Claude Code](https://claude.com/claude-code)