### PR TITLE
Stabilize system prompt cache with per-turn author prefix (#907)

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -314,6 +314,7 @@ fn default_shared_prompt() -> &'static str {
 ## Communication
 - Respond in the user's language.
 - Be concise and direct.
+- Discord 발신자는 `[User: NAME (ID: N)]` prefix로 구분한다. 발신자가 바뀌어도 이전 요청자의 의도를 자동으로 무효화하지 않는다.
 
 ## Work Style
 - Plan before implementing.

--- a/src/services/discord/health.rs
+++ b/src/services/discord/health.rs
@@ -895,6 +895,7 @@ impl TestHealthHarness {
             dispatch_role_overrides: dashmap::DashMap::new(),
             last_message_ids: dashmap::DashMap::new(),
             turn_start_times: dashmap::DashMap::new(),
+            channel_rosters: dashmap::DashMap::new(),
             cached_serenity_ctx: tokio::sync::OnceCell::new(),
             cached_bot_token: tokio::sync::OnceCell::new(),
             token_hash: super::settings::discord_token_hash("test-token"),

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -504,6 +504,40 @@ pub(super) struct CoreState {
     active_meetings: HashMap<ChannelId, meeting::Meeting>,
 }
 
+const CHANNEL_ROSTER_MAX_USERS: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct UserRecord {
+    pub(super) id: UserId,
+    pub(super) name: String,
+}
+
+impl UserRecord {
+    pub(super) fn new(id: UserId, name: &str) -> Self {
+        let collapsed = name.split_whitespace().collect::<Vec<_>>().join(" ");
+        let base = if collapsed.is_empty() {
+            format!("user {}", id.get())
+        } else {
+            collapsed
+        };
+        let sanitized = base
+            .chars()
+            .map(|ch| match ch {
+                '\r' | '\n' => ' ',
+                _ => ch,
+            })
+            .collect::<String>();
+        Self {
+            id,
+            name: sanitized.split_whitespace().collect::<Vec<_>>().join(" "),
+        }
+    }
+
+    pub(super) fn label(&self) -> String {
+        format!("{} (ID: {})", self.name, self.id.get())
+    }
+}
+
 /// Shared state for the Discord bot — split into independently-lockable groups
 pub(super) struct SharedData {
     /// Core state (sessions + request lifecycle) — requires atomic access
@@ -599,6 +633,8 @@ pub(super) struct SharedData {
     pub(super) last_message_ids: dashmap::DashMap<ChannelId, u64>,
     /// Per-channel turn start time — used for metrics duration calculation.
     pub(super) turn_start_times: dashmap::DashMap<ChannelId, std::time::Instant>,
+    /// Per-channel known speakers collected lazily from incoming messages.
+    pub(super) channel_rosters: dashmap::DashMap<ChannelId, Vec<UserRecord>>,
     /// Cached serenity context for deferred queue drain (set once during ready event).
     pub(super) cached_serenity_ctx: tokio::sync::OnceCell<serenity::Context>,
     /// Cached bot token for deferred queue drain.
@@ -641,6 +677,47 @@ impl SharedData {
             .entry(channel_id)
             .or_insert_with(|| Arc::new(TmuxRelayCoord::new()))
             .clone()
+    }
+
+    pub(super) fn record_channel_speaker(
+        &self,
+        channel_id: ChannelId,
+        user_id: UserId,
+        user_name: &str,
+        is_dm: bool,
+    ) {
+        let record = UserRecord::new(user_id, user_name);
+        if is_dm {
+            self.channel_rosters.insert(channel_id, vec![record]);
+            return;
+        }
+
+        match self.channel_rosters.entry(channel_id) {
+            dashmap::mapref::entry::Entry::Occupied(mut entry) => {
+                let roster = entry.get_mut();
+                if let Some(existing) = roster.iter_mut().find(|user| user.id == user_id) {
+                    existing.name = record.name;
+                } else if roster.len() < CHANNEL_ROSTER_MAX_USERS {
+                    roster.push(record);
+                }
+            }
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                entry.insert(vec![record]);
+            }
+        }
+    }
+
+    pub(super) fn channel_roster(
+        &self,
+        channel_id: ChannelId,
+        fallback_user_id: UserId,
+        fallback_user_name: &str,
+    ) -> Vec<UserRecord> {
+        self.channel_rosters
+            .get(&channel_id)
+            .map(|entry| entry.clone())
+            .filter(|users| !users.is_empty())
+            .unwrap_or_else(|| vec![UserRecord::new(fallback_user_id, fallback_user_name)])
     }
 }
 
@@ -691,6 +768,7 @@ pub(super) fn make_shared_data_for_tests_with_storage(
         dispatch_role_overrides: dashmap::DashMap::new(),
         last_message_ids: dashmap::DashMap::new(),
         turn_start_times: dashmap::DashMap::new(),
+        channel_rosters: dashmap::DashMap::new(),
         cached_serenity_ctx: tokio::sync::OnceCell::new(),
         cached_bot_token: tokio::sync::OnceCell::new(),
         token_hash: "test-token-hash".to_string(),

--- a/src/services/discord/prompt_builder.rs
+++ b/src/services/discord/prompt_builder.rs
@@ -580,8 +580,30 @@ impl DispatchProfile {
     }
 }
 
+fn render_channel_participants(
+    discord_context: &str,
+    channel_participants: &[UserRecord],
+) -> String {
+    let is_dm_context = discord_context.trim() == "Discord context: DM";
+    let mut lines = vec!["Channel participants:".to_string()];
+    if channel_participants.is_empty() {
+        lines.push("- none recorded yet".to_string());
+        return lines.join("\n");
+    }
+
+    for (idx, user) in channel_participants.iter().enumerate() {
+        let mut line = format!("- {}", user.label());
+        if is_dm_context && channel_participants.len() == 1 && idx == 0 {
+            line.push_str(" [DM requester]");
+        }
+        lines.push(line);
+    }
+    lines.join("\n")
+}
+
 pub(super) fn build_system_prompt(
     discord_context: &str,
+    channel_participants: &[UserRecord],
     current_path: &str,
     channel_id: ChannelId,
     token: &str,
@@ -598,6 +620,7 @@ pub(super) fn build_system_prompt(
     let mut system_prompt_owned = format!(
         "You are chatting with a user through Discord.\n\
          {}\n\
+         {}\n\
          Current working directory: {}\n\n\
          When your work produces a file the user would want (generated code, reports, images, archives, etc.),\n\
          send it by running this bash command:\n\n\
@@ -612,9 +635,11 @@ pub(super) fn build_system_prompt(
          - Avoid decorative separators or long horizontal lines.\n\n\
          This Discord channel does not support interactive prompts. Do NOT call AskUserQuestion, EnterPlanMode, or ExitPlanMode. \
          Ask in plain text if you need clarification.\n\n\
+         Message author prefix: Direct user messages are prefixed as `[User: NAME (ID: N)]`; use that marker to distinguish speakers in shared channels.\n\n\
          Reply context: When a user message includes a [Reply context] tag, the user is responding to the **replied-to message**, \
          not necessarily your most recent message. Prioritize the reply target; ask if ambiguous.",
         discord_context,
+        render_channel_participants(discord_context, channel_participants),
         current_path,
         channel_id.get(),
         discord_token_hash(token),
@@ -781,6 +806,7 @@ mod tests {
     ) -> String {
         build_system_prompt(
             discord_context,
+            &[],
             current_path,
             ChannelId::new(channel_id),
             token,
@@ -809,6 +835,59 @@ mod tests {
             output.contains("Channel: #general (guild: TestServer)"),
             "System prompt should contain the discord_context string"
         );
+    }
+
+    #[test]
+    fn test_build_system_prompt_lists_channel_participants_without_inline_context_user() {
+        let participants = [UserRecord::new(UserId::new(77), "Alice")];
+        let output = build_system_prompt(
+            "Discord context: channel #general (ID: 42)",
+            &participants,
+            "/tmp/work",
+            ChannelId::new(42),
+            "fake-token",
+            None,
+            false,
+            DispatchProfile::Full,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+        );
+
+        assert!(output.contains("Channel participants:\n- Alice (ID: 77)"));
+        assert!(output.contains("[User: NAME (ID: N)]"));
+        let discord_context_line = output
+            .lines()
+            .find(|line| line.starts_with("Discord context:"))
+            .expect("discord context line");
+        assert!(!discord_context_line.contains("user: Alice"));
+        assert!(!discord_context_line.contains("ID: 77"));
+    }
+
+    #[test]
+    fn test_build_system_prompt_marks_dm_single_participant() {
+        let participants = [UserRecord::new(UserId::new(77), "Alice")];
+        let output = build_system_prompt(
+            "Discord context: DM",
+            &participants,
+            "/tmp/work",
+            ChannelId::new(42),
+            "fake-token",
+            None,
+            false,
+            DispatchProfile::Full,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+        );
+
+        assert!(output.contains("Channel participants:\n- Alice (ID: 77) [DM requester]"));
     }
 
     #[test]
@@ -905,6 +984,7 @@ mod tests {
     fn test_empty_skills_notice_omits_skills_for_full_profile() {
         let prompt = build_system_prompt(
             "ctx",
+            &[],
             "/tmp",
             ChannelId::new(1),
             "tok",
@@ -928,6 +1008,7 @@ mod tests {
     fn test_review_lite_omits_context_compression_guidance() {
         let prompt = build_system_prompt(
             "ctx",
+            &[],
             "/tmp",
             ChannelId::new(1),
             "tok",
@@ -951,6 +1032,7 @@ mod tests {
     fn test_review_lite_includes_tool_output_efficiency_guidance() {
         let prompt = build_system_prompt(
             "ctx",
+            &[],
             "/tmp",
             ChannelId::new(1),
             "tok",
@@ -983,6 +1065,7 @@ mod tests {
         };
         let review_prompt = build_system_prompt(
             "ctx",
+            &[],
             "/tmp",
             ChannelId::new(1),
             "tok",
@@ -998,6 +1081,7 @@ mod tests {
         );
         let decision_prompt = build_system_prompt(
             "ctx",
+            &[],
             "/tmp",
             ChannelId::new(1),
             "tok",
@@ -1036,6 +1120,7 @@ mod tests {
 
         let prompt = build_system_prompt(
             "ctx",
+            &[],
             "/tmp",
             ChannelId::new(1488022491992424448),
             "tok",
@@ -1069,6 +1154,7 @@ mod tests {
 
         let prompt = build_system_prompt(
             "ctx",
+            &[],
             "/tmp",
             ChannelId::new(1),
             "tok",
@@ -1102,6 +1188,7 @@ mod tests {
         };
         let prompt = build_system_prompt(
             "ctx",
+            &[],
             "/Users/test/.adk/release/workspaces/agentdesk",
             ChannelId::new(1),
             "tok",
@@ -1138,6 +1225,7 @@ mod tests {
     fn test_full_prompt_omits_memento_memory_guidance_without_mcp() {
         let prompt = build_system_prompt(
             "ctx",
+            &[],
             "/Users/test/.adk/release/workspaces/agentdesk",
             ChannelId::new(1),
             "tok",
@@ -1164,6 +1252,7 @@ mod tests {
     fn test_review_lite_omits_memory_guidance() {
         let prompt = build_system_prompt(
             "ctx",
+            &[],
             "/tmp",
             ChannelId::new(1),
             "tok",
@@ -1198,6 +1287,7 @@ mod tests {
         };
         let prompt = build_system_prompt(
             "ctx",
+            &[],
             "/tmp",
             ChannelId::new(1),
             "tok",
@@ -1256,6 +1346,7 @@ mod tests {
         };
         let prompt = build_system_prompt(
             "ctx",
+            &[],
             "/tmp",
             ChannelId::new(1),
             "tok",
@@ -1315,6 +1406,7 @@ mod tests {
 
         let prompt = build_system_prompt(
             "ctx",
+            &[],
             "/tmp",
             ChannelId::new(1),
             "tok",
@@ -1349,6 +1441,7 @@ mod tests {
         let current_task = CurrentTaskContext::default();
         let prompt = build_system_prompt(
             "ctx",
+            &[],
             "/tmp",
             ChannelId::new(1),
             "tok",
@@ -1385,6 +1478,7 @@ mod tests {
         };
         let prompt = build_system_prompt(
             "ctx",
+            &[],
             "/tmp",
             ChannelId::new(1),
             "tok",
@@ -1421,6 +1515,7 @@ mod tests {
         };
         let prompt = build_system_prompt(
             "ctx",
+            &[],
             "/tmp",
             ChannelId::new(1),
             "tok",
@@ -1452,6 +1547,7 @@ mod tests {
         };
         let prompt = build_system_prompt(
             "ctx",
+            &[],
             "/tmp",
             ChannelId::new(1),
             "tok",

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -242,9 +242,17 @@ fn normalize_turn_author_name(request_owner_name: &str, request_owner: UserId) -
     sanitized.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-fn build_turn_author_prefix(request_owner_name: &str, request_owner: UserId) -> String {
+fn wrap_user_prompt_with_author(
+    request_owner_name: &str,
+    request_owner: UserId,
+    sanitized_prompt: String,
+) -> String {
     let author = normalize_turn_author_name(request_owner_name, request_owner);
-    format!("[from {author}]\nauthor_id: {}", request_owner.get())
+    format!(
+        "[User: {author} (ID: {})]\n{}",
+        request_owner.get(),
+        sanitized_prompt
+    )
 }
 
 pub(in crate::services::discord) async fn start_headless_turn(
@@ -266,6 +274,7 @@ pub(in crate::services::discord) async fn start_headless_turn(
     }
 
     let request_owner = UserId::new(1);
+    shared.record_channel_speaker(channel_id, request_owner, request_owner_name, false);
     let user_msg_id = next_headless_turn_message_id();
     let placeholder_msg_id = next_headless_turn_message_id();
     let mut session_reset_reason = None;
@@ -521,7 +530,6 @@ pub(in crate::services::discord) async fn start_headless_turn(
         dispatch_profile,
         &memory_recall,
     );
-    context_chunks.push(build_turn_author_prefix(request_owner_name, request_owner));
     if !pending_uploads.is_empty() {
         context_chunks.push(pending_uploads.join("\n"));
     }
@@ -537,7 +545,11 @@ pub(in crate::services::discord) async fn start_headless_turn(
     if let Some(external_recall) = memory_injection_plan.external_recall_for_context {
         context_chunks.push(external_recall.to_string());
     }
-    context_chunks.push(ai_screen::sanitize_user_input(prompt));
+    context_chunks.push(wrap_user_prompt_with_author(
+        request_owner_name,
+        request_owner,
+        ai_screen::sanitize_user_input(prompt),
+    ));
     let context_prompt = context_chunks.join("\n\n");
 
     let discord_context = build_system_discord_context(
@@ -550,8 +562,10 @@ pub(in crate::services::discord) async fn start_headless_turn(
     let sak_for_system = memory_injection_plan.shared_knowledge_for_system_prompt;
     let longterm_catalog_for_prompt = memory_injection_plan.longterm_catalog_for_system_prompt;
     let memento_mcp_available = crate::services::mcp_config::provider_has_memento_mcp(&provider);
+    let channel_participants = shared.channel_roster(channel_id, request_owner, request_owner_name);
     let system_prompt_owned = build_system_prompt(
         &discord_context,
+        &channel_participants,
         &current_path,
         channel_id,
         token,
@@ -1460,6 +1474,7 @@ pub(in crate::services::discord) async fn handle_text_message(
         Some(serenity::Channel::Private(_))
     );
     let is_dm_channel = super::super::resolve_is_dm_channel(dm_hint, is_dm_channel);
+    shared.record_channel_speaker(channel_id, request_owner, request_owner_name, is_dm_channel);
     let dm_default_agent = if is_dm_channel {
         super::super::agentdesk_config::resolve_dm_default_agent(&provider)
     } else {
@@ -2228,7 +2243,6 @@ pub(in crate::services::discord) async fn handle_text_message(
         dispatch_profile,
         &memory_recall,
     );
-    context_chunks.push(build_turn_author_prefix(request_owner_name, request_owner));
     if !pending_uploads.is_empty() {
         context_chunks.push(pending_uploads.join("\n"));
     }
@@ -2241,7 +2255,11 @@ pub(in crate::services::discord) async fn handle_text_message(
     if let Some(external_recall) = memory_injection_plan.external_recall_for_context {
         context_chunks.push(external_recall.to_string());
     }
-    context_chunks.push(sanitized_input);
+    context_chunks.push(wrap_user_prompt_with_author(
+        request_owner_name,
+        request_owner,
+        sanitized_input,
+    ));
     let context_prompt = context_chunks.join("\n\n");
 
     // Build Discord context info
@@ -2271,9 +2289,11 @@ pub(in crate::services::discord) async fn handle_text_message(
         }
     });
     let memento_mcp_available = crate::services::mcp_config::provider_has_memento_mcp(&provider);
+    let channel_participants = shared.channel_roster(channel_id, request_owner, request_owner_name);
 
     let system_prompt_owned = build_system_prompt(
         &discord_context,
+        &channel_participants,
         &current_path,
         channel_id,
         token,
@@ -5111,10 +5131,26 @@ mod tests {
     }
 
     #[test]
-    fn build_turn_author_prefix_starts_with_from_header() {
-        let prefix = build_turn_author_prefix("  Alice [ops]\nteam  ", UserId::new(77));
+    fn wrap_user_prompt_with_author_adds_user_prefix() {
+        let prompt = wrap_user_prompt_with_author(
+            "  Alice [ops]\nteam  ",
+            UserId::new(77),
+            "deploy it".to_string(),
+        );
 
-        assert_eq!(prefix, "[from Alice (ops) team]\nauthor_id: 77");
+        assert_eq!(prompt, "[User: Alice (ops) team (ID: 77)]\ndeploy it");
+    }
+
+    #[test]
+    fn dm_channel_roster_keeps_single_requester() {
+        let shared = super::super::super::make_shared_data_for_tests();
+        let channel_id = ChannelId::new(42);
+        shared.record_channel_speaker(channel_id, UserId::new(101), "Alice", false);
+        shared.record_channel_speaker(channel_id, UserId::new(202), "Bob", false);
+        shared.record_channel_speaker(channel_id, UserId::new(101), "Alice", true);
+
+        let roster = shared.channel_roster(channel_id, UserId::new(999), "Fallback");
+        assert_eq!(roster, vec![UserRecord::new(UserId::new(101), "Alice")]);
     }
 
     #[test]
@@ -5128,6 +5164,7 @@ mod tests {
 
         let alice_system = prompt_builder::build_system_prompt(
             &discord_context,
+            &[],
             "/tmp/work",
             ChannelId::new(9001),
             "token",
@@ -5143,6 +5180,7 @@ mod tests {
         );
         let bob_system = prompt_builder::build_system_prompt(
             &discord_context,
+            &[],
             "/tmp/work",
             ChannelId::new(9001),
             "token",
@@ -5159,19 +5197,13 @@ mod tests {
 
         assert_eq!(alice_system.as_bytes(), bob_system.as_bytes());
 
-        let alice_user_prompt = [
-            build_turn_author_prefix("Alice", UserId::new(101)),
-            "same task".to_string(),
-        ]
-        .join("\n\n");
-        let bob_user_prompt = [
-            build_turn_author_prefix("Bob", UserId::new(202)),
-            "same task".to_string(),
-        ]
-        .join("\n\n");
+        let alice_user_prompt =
+            wrap_user_prompt_with_author("Alice", UserId::new(101), "same task".to_string());
+        let bob_user_prompt =
+            wrap_user_prompt_with_author("Bob", UserId::new(202), "same task".to_string());
 
-        assert!(alice_user_prompt.starts_with("[from Alice]\nauthor_id: 101"));
-        assert!(bob_user_prompt.starts_with("[from Bob]\nauthor_id: 202"));
+        assert!(alice_user_prompt.starts_with("[User: Alice (ID: 101)]"));
+        assert!(bob_user_prompt.starts_with("[User: Bob (ID: 202)]"));
         assert_ne!(alice_user_prompt, bob_user_prompt);
     }
 }

--- a/src/services/discord/runtime_bootstrap.rs
+++ b/src/services/discord/runtime_bootstrap.rs
@@ -600,6 +600,7 @@ pub(crate) async fn run_bot(token: &str, provider: ProviderKind, context: RunBot
         dispatch_role_overrides: dashmap::DashMap::new(),
         last_message_ids: dashmap::DashMap::new(),
         turn_start_times: dashmap::DashMap::new(),
+        channel_rosters: dashmap::DashMap::new(),
         cached_serenity_ctx: tokio::sync::OnceCell::new(),
         cached_bot_token: tokio::sync::OnceCell::new(),
         token_hash: token_hash.clone(),

--- a/src/services/discord/settings.rs
+++ b/src/services/discord/settings.rs
@@ -669,6 +669,7 @@ memory:
 
                     let prompt = super::super::prompt_builder::build_system_prompt(
                         "ctx",
+                        &[],
                         "/tmp",
                         ChannelId::new(1),
                         "tok",


### PR DESCRIPTION
## Summary

Multi-user channel fix covering two linked problems:

1. Agents couldn't distinguish past-turn senders (user input was un-prefixed)
2. The inline `user: X (ID: N)` line burst Claude prompt cache on each user switch

## Changes

- SharedData.channel_rosters (DashMap) with lazy population + DM single-entry + 64-user cap
- prompt_builder: inline user line removed, stable `Channel participants:` block + `[User: NAME (ID: N)]` guidance
- message_handler headless + normal turn: wrap direct user message with `[User: NAME (ID: N)]\n{sanitized}` prefix
- SAK addendum in src/cli/init.rs for per-turn author prefix rule
- Test fixtures + new unit tests for wrap helper and DM roster

## Test plan

- [x] `cargo check --bin agentdesk` 0 errors
- [x] `test_build_system_prompt_lists_channel_participants_without_inline_context_user` passes
- [x] `test_build_system_prompt_marks_dm_single_participant` passes
- [x] `wrap_user_prompt_with_author_adds_user_prefix` passes
- [x] `dm_channel_roster_keeps_single_requester` passes
- [ ] Manual: observe cache-miss behavior decrease on multi-user channel after deploy

Closes #907.

🤖 Generated with [Claude Code](https://claude.com/claude-code)