### PR TITLE
Retire SQLite fallback on termination_events route (slice of #843)

### DIFF
--- a/src/server/routes/termination_events.rs
+++ b/src/server/routes/termination_events.rs
@@ -27,101 +27,16 @@ pub async fn list_termination_events(
 ) -> Json<serde_json::Value> {
     let limit = params.limit.min(500);
 
-    if let Some(pool) = state.pg_pool.as_ref() {
-        return match list_termination_events_pg(pool, &params, limit).await {
-            Ok(events) => Json(json!({"events": events})),
-            Err(error) => Json(json!({"error": format!("Query error: {error}"), "events": []})),
-        };
-    }
-
-    let conn = match state.db.read_conn() {
-        Ok(c) => c,
-        Err(e) => {
-            return Json(json!({"error": format!("DB error: {e}"), "events": []}));
-        }
+    let Some(pool) = state.pg_pool_ref() else {
+        return Json(json!({
+            "error": "PostgreSQL pool unavailable for termination events",
+            "events": []
+        }));
     };
 
-    // Build query based on filters
-    let (sql, sql_params): (String, Vec<Box<dyn libsql_rusqlite::types::ToSql>>) =
-        if let Some(ref card_id) = params.card_id {
-            (
-                "SELECT ste.id, ste.session_key, ste.dispatch_id, ste.killer_component, \
-                 ste.reason_code, ste.reason_text, ste.probe_snapshot, ste.last_offset, \
-                 ste.tmux_alive, ste.created_at \
-                 FROM session_termination_events ste \
-                 LEFT JOIN task_dispatches td ON ste.dispatch_id = td.id \
-                 WHERE td.kanban_card_id = ?1 \
-                 ORDER BY ste.created_at DESC LIMIT ?2"
-                    .to_string(),
-                vec![
-                    Box::new(card_id.clone()) as Box<dyn libsql_rusqlite::types::ToSql>,
-                    Box::new(limit as i64),
-                ],
-            )
-        } else if let Some(ref dispatch_id) = params.dispatch_id {
-            (
-                "SELECT id, session_key, dispatch_id, killer_component, \
-                 reason_code, reason_text, probe_snapshot, last_offset, \
-                 tmux_alive, created_at \
-                 FROM session_termination_events \
-                 WHERE dispatch_id = ?1 \
-                 ORDER BY created_at DESC LIMIT ?2"
-                    .to_string(),
-                vec![
-                    Box::new(dispatch_id.clone()) as Box<dyn libsql_rusqlite::types::ToSql>,
-                    Box::new(limit as i64),
-                ],
-            )
-        } else if let Some(ref session_key) = params.session_key {
-            (
-                "SELECT id, session_key, dispatch_id, killer_component, \
-                 reason_code, reason_text, probe_snapshot, last_offset, \
-                 tmux_alive, created_at \
-                 FROM session_termination_events \
-                 WHERE session_key = ?1 \
-                 ORDER BY created_at DESC LIMIT ?2"
-                    .to_string(),
-                vec![
-                    Box::new(session_key.clone()) as Box<dyn libsql_rusqlite::types::ToSql>,
-                    Box::new(limit as i64),
-                ],
-            )
-        } else {
-            (
-                "SELECT id, session_key, dispatch_id, killer_component, \
-                 reason_code, reason_text, probe_snapshot, last_offset, \
-                 tmux_alive, created_at \
-                 FROM session_termination_events \
-                 ORDER BY created_at DESC LIMIT ?1"
-                    .to_string(),
-                vec![Box::new(limit as i64) as Box<dyn libsql_rusqlite::types::ToSql>],
-            )
-        };
-
-    let params_refs: Vec<&dyn libsql_rusqlite::types::ToSql> =
-        sql_params.iter().map(|p| &**p).collect();
-
-    let result = conn.prepare(&sql).and_then(|mut stmt| {
-        let rows = stmt.query_map(params_refs.as_slice(), |row| {
-            Ok(json!({
-                "id": row.get::<_, i64>(0)?,
-                "session_key": row.get::<_, String>(1)?,
-                "dispatch_id": row.get::<_, Option<String>>(2)?,
-                "killer_component": row.get::<_, String>(3)?,
-                "reason_code": row.get::<_, String>(4)?,
-                "reason_text": row.get::<_, Option<String>>(5)?,
-                "probe_snapshot": row.get::<_, Option<String>>(6)?,
-                "last_offset": row.get::<_, Option<i64>>(7)?,
-                "tmux_alive": row.get::<_, Option<i32>>(8)?.map(|v| v != 0),
-                "created_at": row.get::<_, Option<String>>(9)?,
-            }))
-        })?;
-        rows.collect::<Result<Vec<_>, _>>()
-    });
-
-    match result {
+    match list_termination_events_pg(pool, &params, limit).await {
         Ok(events) => Json(json!({"events": events})),
-        Err(e) => Json(json!({"error": format!("Query error: {e}"), "events": []})),
+        Err(error) => Json(json!({"error": format!("Query error: {error}"), "events": []})),
     }
 }
 


### PR DESCRIPTION
## Summary

Single-route Phase C slice. `src/server/routes/termination_events.rs` was the first pass:
- drop the AppState.db SQLite code path
- use `state.pg_pool_ref()` exclusively
- return explicit PG-unavailable error instead of silent fallback

Removes ~90 lines of SQLite query builder and `libsql_rusqlite::types::ToSql` box usage on this route.

## Scope context

The full Phase C (from #843) covers 60+ files / 159 coupling points across PolicyEngine, WorkerRegistry, Discord shared state, runtime loops. This PR is one slice; the rest tracks under #843 and will be decomposed during Wave 4 epic decomposition. #868 (Phase D — AppState.db field drop + launch.rs + Cargo.toml) is unchanged.

## Test plan

- [x] `cargo check --bin agentdesk` 0 errors
- [x] Route still returns JSON with the same shape (events array or error)
- [ ] Post-deploy manual: exercise `/api/session-termination-events` with card_id / dispatch_id / session_key filters

Partial progress on #843; issue stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)