### PR TITLE
Tighten terminal-success watcher stop + cancel watcher policy + fallback escalation (partial #964)

### DIFF
--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -2186,6 +2186,7 @@ async fn cancel_turn_preserves_pending_queue_via_mailbox_fallback_cleanup() {
         .seed_queue(channel_num, &[(2_001, "preserve cancel queue")])
         .await;
     harness.insert_dispatch_role_override(channel_num, 1485506232256168998);
+    let watcher_cancel = harness.seed_watcher(channel_num);
 
     let app = test_api_router(db.clone(), engine, Some(harness.registry()));
     let response = app
@@ -2207,6 +2208,7 @@ async fn cancel_turn_preserves_pending_queue_via_mailbox_fallback_cleanup() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(json["session_key"], session_key);
     assert_eq!(json["lifecycle_path"], "runtime-fallback");
+    assert_eq!(json["tmux_killed"], false);
     assert_eq!(json["queue_preserved"], true);
     assert!(json["dispatch_cancelled"].is_null());
 
@@ -2215,6 +2217,14 @@ async fn cancel_turn_preserves_pending_queue_via_mailbox_fallback_cleanup() {
     assert_eq!(queue_depth, 1);
     assert_eq!(session_id, None);
     assert!(harness.has_dispatch_role_override(channel_num));
+    assert!(
+        harness.has_watcher(channel_num),
+        "cancel with tmux_killed=false must keep watcher attached"
+    );
+    assert!(
+        !watcher_cancel.load(std::sync::atomic::Ordering::Relaxed),
+        "cancel with tmux_killed=false must not signal watcher cancellation"
+    );
 
     let conn = db.lock().unwrap();
     let session_status: String = conn

--- a/src/services/discord/health.rs
+++ b/src/services/discord/health.rs
@@ -312,6 +312,7 @@ pub(crate) async fn stop_provider_channel_runtime_with_policy(
         channel_id,
         &finish,
         "runtime_stop_fallback",
+        cleanup_requested,
     )
     .await;
     let queue_depth = shared
@@ -488,6 +489,7 @@ async fn apply_runtime_hard_stop_cleanup(
     channel_id: ChannelId,
     finish: &super::FinishTurnResult,
     stop_source: &'static str,
+    stop_watcher: bool,
 ) -> bool {
     if let Some(token) = finish.removed_token.as_ref() {
         token.cancelled.store(true, Ordering::Relaxed);
@@ -505,7 +507,7 @@ async fn apply_runtime_hard_stop_cleanup(
         shared.dispatch_role_overrides.remove(&channel_id);
     }
 
-    if let Some((_, watcher)) = shared.tmux_watchers.remove(&channel_id) {
+    if stop_watcher && let Some((_, watcher)) = shared.tmux_watchers.remove(&channel_id) {
         watcher.cancel.store(true, Ordering::Relaxed);
     }
 
@@ -568,6 +570,7 @@ pub async fn hard_stop_runtime_turn(
             runtime.channel_id,
             &finish,
             stop_source,
+            true,
         )
         .await;
         return HardStopRuntimeResult {
@@ -1127,6 +1130,27 @@ impl TestHealthHarness {
             ChannelId::new(channel_id),
             ChannelId::new(override_channel_id),
         );
+    }
+
+    pub(crate) fn seed_watcher(&self, channel_id: u64) -> Arc<std::sync::atomic::AtomicBool> {
+        let cancel = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        self.shared.tmux_watchers.insert(
+            ChannelId::new(channel_id),
+            super::TmuxWatcherHandle {
+                paused: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                resume_offset: Arc::new(std::sync::Mutex::new(None)),
+                cancel: cancel.clone(),
+                pause_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                turn_delivered: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            },
+        );
+        cancel
+    }
+
+    pub(crate) fn has_watcher(&self, channel_id: u64) -> bool {
+        self.shared
+            .tmux_watchers
+            .contains_key(&ChannelId::new(channel_id))
     }
 }
 

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -226,6 +226,26 @@ fn recovery_dispatch_id(state: &inflight::InflightTurnState) -> Option<&str> {
         .filter(|dispatch_id| !dispatch_id.is_empty())
 }
 
+fn recovery_tmux_session_name(
+    provider: &ProviderKind,
+    state: &inflight::InflightTurnState,
+) -> Option<String> {
+    state
+        .tmux_session_name
+        .as_deref()
+        .or_else(|| state.channel_name.as_deref())
+        .map(|name| {
+            if name.starts_with(&format!(
+                "{}-",
+                crate::services::provider::TMUX_SESSION_PREFIX
+            )) {
+                name.to_string()
+            } else {
+                provider.build_tmux_session_name(name)
+            }
+        })
+}
+
 fn recovery_requires_worktree_context(state: &inflight::InflightTurnState) -> bool {
     recovery_worktree_branch(state).is_some()
         || state
@@ -600,32 +620,42 @@ fn detect_live_tmux_output_path(
 /// Check whether a **successful** result record exists after the given offset.
 /// Error results are not considered completion — they should not trigger the
 /// recovery completed-turn path (✅ reaction, idle dispatch, etc.).
-fn output_has_result_after_offset(output_path: &str, start_offset: u64) -> bool {
+fn success_result_end_offset_after_offset(output_path: &str, start_offset: u64) -> Option<u64> {
     let Ok(bytes) = std::fs::read(output_path) else {
-        return false;
+        return None;
     };
     let start = usize::try_from(start_offset)
         .ok()
         .map(|offset| offset.min(bytes.len()))
         .unwrap_or(bytes.len());
 
-    String::from_utf8_lossy(&bytes[start..])
-        .lines()
-        .any(|line| {
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                return false;
-            }
-            let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) else {
-                return false;
-            };
-            let is_result = value.get("type").and_then(|v| v.as_str()) == Some("result");
-            let is_error = value
-                .get("is_error")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false);
-            is_result && !is_error
-        })
+    let mut absolute_end = start as u64;
+    for segment in bytes[start..].split_inclusive(|byte| *byte == b'\n') {
+        absolute_end = absolute_end.saturating_add(segment.len() as u64);
+        let line = String::from_utf8_lossy(segment);
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+            continue;
+        };
+        let is_result = value.get("type").and_then(|v| v.as_str()) == Some("result");
+        let is_error = value
+            .get("is_error")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if is_result && !is_error {
+            return Some(absolute_end);
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+fn output_has_result_after_offset(output_path: &str, start_offset: u64) -> bool {
+    success_result_end_offset_after_offset(output_path, start_offset).is_some()
 }
 
 /// Extract accumulated assistant text from output JSONL after the given offset.
@@ -784,6 +814,57 @@ fn output_has_bytes_after_offset(output_path: &str, start_offset: u64) -> bool {
         .unwrap_or(false)
 }
 
+const TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD: std::time::Duration = std::time::Duration::from_secs(2);
+
+fn terminal_success_watcher_stop_allowed(
+    confirmed_end: u64,
+    tmux_tail_offset: u64,
+    quiet_for: std::time::Duration,
+) -> bool {
+    confirmed_end >= tmux_tail_offset && quiet_for >= TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD
+}
+
+async fn terminal_success_output_drained_for_recovery(
+    output_path: &str,
+    confirmed_end: u64,
+    tmux_session_name: Option<&str>,
+) -> bool {
+    let Ok(before_meta) = std::fs::metadata(output_path) else {
+        return false;
+    };
+    let tmux_alive = tmux_session_name
+        .map(crate::services::platform::tmux::has_session)
+        .unwrap_or(false);
+
+    if !tmux_alive {
+        return terminal_success_watcher_stop_allowed(
+            confirmed_end,
+            before_meta.len(),
+            TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD,
+        );
+    }
+
+    if !terminal_success_watcher_stop_allowed(
+        confirmed_end,
+        before_meta.len(),
+        TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD,
+    ) {
+        return false;
+    }
+
+    tokio::time::sleep(TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD).await;
+
+    let tail_after = std::fs::metadata(output_path)
+        .map(|meta| meta.len())
+        .unwrap_or(confirmed_end.saturating_add(1));
+    tail_after == confirmed_end
+        && terminal_success_watcher_stop_allowed(
+            confirmed_end,
+            tail_after,
+            TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD,
+        )
+}
+
 fn recovery_watcher_start_offset(output_path: &str, saved_last_offset: u64) -> (u64, u64, bool) {
     let current_len = std::fs::metadata(output_path).map(|m| m.len()).unwrap_or(0);
     if current_len >= saved_last_offset {
@@ -866,12 +947,36 @@ pub(super) async fn restore_inflight_turns(
                         .as_ref()
                         .map(|name| tmux_runtime_paths(&provider.build_tmux_session_name(name)).0)
                 });
-            let completed_during_downtime = output_path_for_check
+            let restart_tmux_name = recovery_tmux_session_name(provider, &state);
+            let completed_during_downtime_end = output_path_for_check
                 .as_deref()
-                .map(|path| output_has_result_after_offset(path, state.last_offset))
-                .unwrap_or(false);
+                .and_then(|path| success_result_end_offset_after_offset(path, state.last_offset));
+            let completed_during_downtime = completed_during_downtime_end.is_some();
+            let completed_during_downtime_drained = match (
+                output_path_for_check.as_deref(),
+                completed_during_downtime_end,
+            ) {
+                (Some(path), Some(confirmed_end)) => {
+                    terminal_success_output_drained_for_recovery(
+                        path,
+                        confirmed_end,
+                        restart_tmux_name.as_deref(),
+                    )
+                    .await
+                }
+                (None, Some(_)) => true,
+                _ => false,
+            };
 
-            if completed_during_downtime {
+            if completed_during_downtime && !completed_during_downtime_drained {
+                let ts = chrono::Local::now().format("%H:%M:%S");
+                tracing::warn!(
+                    "  [{ts}] ⚠ recovery: terminal success observed for channel {} but tmux output has not stayed drained; reattaching watcher",
+                    state.channel_id
+                );
+            }
+
+            if completed_during_downtime_drained {
                 let ts = chrono::Local::now().format("%H:%M:%S");
                 tracing::info!(
                     "  [{ts}] ✓ recovering completed turn for channel {} (restart report exists but output has result)",
@@ -1115,20 +1220,7 @@ pub(super) async fn restore_inflight_turns(
             // the restart report and fall through to normal recovery (which
             // re-attaches a watcher to pick up the remaining output).
             // If the session is dead, delegate to the flush loop for fallback.
-            let tmux_name = state
-                .tmux_session_name
-                .as_deref()
-                .or_else(|| state.channel_name.as_deref())
-                .map(|name| {
-                    if name.starts_with(&format!(
-                        "{}-",
-                        crate::services::provider::TMUX_SESSION_PREFIX
-                    )) {
-                        name.to_string()
-                    } else {
-                        provider.build_tmux_session_name(name)
-                    }
-                });
+            let tmux_name = restart_tmux_name;
             let session_alive = tmux_name
                 .as_deref()
                 .map_or(false, tmux_session_alive_with_retry);
@@ -1421,16 +1513,35 @@ pub(super) async fn restore_inflight_turns(
             }
         }
 
-        let output_already_completed = output_path
+        let terminal_success_end = output_path
             .as_deref()
-            .map(|path| output_has_result_after_offset(path, state.last_offset))
-            .unwrap_or(false);
+            .and_then(|path| success_result_end_offset_after_offset(path, state.last_offset));
+        let output_already_completed = terminal_success_end.is_some();
+        let terminal_success_drained = match (output_path.as_deref(), terminal_success_end) {
+            (Some(path), Some(confirmed_end)) => {
+                terminal_success_output_drained_for_recovery(
+                    path,
+                    confirmed_end,
+                    tmux_session_name.as_deref(),
+                )
+                .await
+            }
+            (None, Some(_)) => true,
+            _ => false,
+        };
+        if output_already_completed && !terminal_success_drained {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            tracing::warn!(
+                "  [{ts}] ⚠ recovery: terminal success observed for channel {} but tmux output has not stayed drained; reattaching watcher",
+                state.channel_id
+            );
+        }
         let output_has_new_bytes = output_path
             .as_deref()
             .map(|path| output_has_bytes_after_offset(path, state.last_offset))
             .unwrap_or(false);
 
-        if can_fast_path_captured_full_response(&state, output_already_completed) {
+        if can_fast_path_captured_full_response(&state, terminal_success_drained) {
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::info!(
                 "  [{ts}] ↻ recovery fast-path: delivering captured full_response for channel {}",
@@ -1632,7 +1743,7 @@ pub(super) async fn restore_inflight_turns(
             continue;
         }
         if matches!(
-            recovery_phase_after_output_scan(output_already_completed, false),
+            recovery_phase_after_output_scan(terminal_success_drained, false),
             RecoveryPhase::Done
         ) {
             let ts = chrono::Local::now().format("%H:%M:%S");
@@ -3188,6 +3299,27 @@ mod tests {
     }
 
     #[test]
+    fn success_result_end_offset_stops_at_result_line_before_followup_output() {
+        let file = write_jsonl(&[
+            r#"{"type":"result","subtype":"success","result":"done"}"#,
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"next"}]}}"#,
+        ]);
+        let full_len = file.as_file().metadata().unwrap().len();
+        let result_end =
+            success_result_end_offset_after_offset(file.path().to_str().unwrap(), 0).unwrap();
+
+        assert!(
+            result_end < full_len,
+            "confirmed end must not jump past follow-up output"
+        );
+        assert!(!terminal_success_watcher_stop_allowed(
+            result_end,
+            full_len,
+            TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD
+        ));
+    }
+
+    #[test]
     fn ignores_result_before_offset() {
         let mut file = tempfile::NamedTempFile::new().unwrap();
         writeln!(
@@ -3230,6 +3362,25 @@ mod tests {
         assert!(!output_has_bytes_after_offset(
             file.path().to_str().unwrap(),
             offset
+        ));
+    }
+
+    #[test]
+    fn terminal_success_stop_requires_drained_tail_and_quiet_period() {
+        assert!(terminal_success_watcher_stop_allowed(
+            256,
+            256,
+            TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD
+        ));
+        assert!(!terminal_success_watcher_stop_allowed(
+            128,
+            256,
+            TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD
+        ));
+        assert!(!terminal_success_watcher_stop_allowed(
+            256,
+            256,
+            TERMINAL_SUCCESS_DRAIN_QUIET_PERIOD - std::time::Duration::from_millis(1)
         ));
     }
 

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -1767,6 +1767,169 @@ async fn resolve_watcher_dispatch_id(
         })
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MissingInflightFallbackPlan {
+    warn: bool,
+    trigger_reattach: bool,
+}
+
+fn missing_inflight_fallback_plan(
+    inflight_missing: bool,
+    dispatch_resolved: bool,
+    terminal_output_committed: bool,
+) -> MissingInflightFallbackPlan {
+    MissingInflightFallbackPlan {
+        warn: inflight_missing,
+        trigger_reattach: inflight_missing && !dispatch_resolved && terminal_output_committed,
+    }
+}
+
+fn trigger_missing_inflight_reattach(
+    http: &Arc<serenity::Http>,
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    tmux_session_name: &str,
+) {
+    let ts = chrono::Local::now().format("%H:%M:%S");
+    tracing::warn!(
+        "  [{ts}] ⚠ watcher: DB dispatch fallback unresolved for channel {} — triggering explicit reattach to {}",
+        channel_id.get(),
+        tmux_session_name
+    );
+
+    if !tmux_session_has_live_pane(tmux_session_name) {
+        let ts = chrono::Local::now().format("%H:%M:%S");
+        tracing::warn!(
+            "  [{ts}] ⚠ watcher: explicit reattach skipped for channel {} — tmux session is not live ({})",
+            channel_id.get(),
+            tmux_session_name
+        );
+        return;
+    }
+
+    let (output_path, input_fifo_path) = super::turn_bridge::tmux_runtime_paths(tmux_session_name);
+    let initial_offset = std::fs::metadata(&output_path)
+        .map(|meta| meta.len())
+        .unwrap_or(0);
+    let channel_name =
+        parse_provider_and_channel_from_tmux_name(tmux_session_name).map(|(_, name)| name);
+
+    let mut state = super::inflight::InflightTurnState::new(
+        provider.clone(),
+        channel_id.get(),
+        channel_name.clone(),
+        0,
+        0,
+        0,
+        "watcher missing-inflight reattach".to_string(),
+        None,
+        Some(tmux_session_name.to_string()),
+        Some(output_path.clone()),
+        Some(input_fifo_path),
+        initial_offset,
+    );
+    state.rebind_origin = true;
+
+    match super::inflight::save_inflight_state_create_new(&state) {
+        Ok(()) => {}
+        Err(super::inflight::CreateNewInflightError::AlreadyExists) => {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            tracing::warn!(
+                "  [{ts}] ⚠ watcher: explicit reattach skipped for channel {} — inflight state already exists",
+                channel_id.get()
+            );
+            return;
+        }
+        Err(super::inflight::CreateNewInflightError::Internal(error)) => {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            tracing::error!(
+                "  [{ts}] ❌ watcher: explicit reattach failed for channel {} / {} after DB fallback miss: {}",
+                channel_id.get(),
+                tmux_session_name,
+                error
+            );
+            return;
+        }
+    }
+
+    if let Ok(mut data) = shared.core.try_lock() {
+        let session = data
+            .sessions
+            .entry(channel_id)
+            .or_insert_with(|| super::DiscordSession {
+                session_id: None,
+                memento_context_loaded: false,
+                memento_reflected: false,
+                current_path: None,
+                history: Vec::new(),
+                pending_uploads: Vec::new(),
+                cleared: false,
+                remote_profile_name: None,
+                channel_id: Some(channel_id.get()),
+                channel_name: channel_name.clone(),
+                category_name: None,
+                last_active: tokio::time::Instant::now(),
+                worktree: None,
+                born_generation: super::runtime_store::load_generation(),
+                assistant_turns: 0,
+            });
+        session.channel_id = Some(channel_id.get());
+        session.last_active = tokio::time::Instant::now();
+        if session.channel_name.is_none() {
+            session.channel_name = channel_name.clone();
+        }
+    } else {
+        let ts = chrono::Local::now().format("%H:%M:%S");
+        tracing::warn!(
+            "  [{ts}] ⚠ watcher: explicit reattach could not refresh in-memory session for channel {} because core state was busy",
+            channel_id.get()
+        );
+    }
+
+    let cancel = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let paused = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let resume_offset = Arc::new(std::sync::Mutex::new(None::<u64>));
+    let pause_epoch = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let turn_delivered = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let handle = TmuxWatcherHandle {
+        paused: paused.clone(),
+        resume_offset: resume_offset.clone(),
+        cancel: cancel.clone(),
+        pause_epoch: pause_epoch.clone(),
+        turn_delivered: turn_delivered.clone(),
+    };
+    let fresh = claim_or_replace_watcher(
+        &shared.tmux_watchers,
+        channel_id,
+        handle,
+        provider,
+        "watcher_missing_inflight_fallback",
+    );
+    tokio::spawn(tmux_output_watcher(
+        channel_id,
+        http.clone(),
+        shared.clone(),
+        output_path,
+        tmux_session_name.to_string(),
+        initial_offset,
+        cancel,
+        paused,
+        resume_offset,
+        pause_epoch,
+        turn_delivered,
+    ));
+
+    let ts = chrono::Local::now().format("%H:%M:%S");
+    tracing::warn!(
+        "  [{ts}] ↻ watcher: reattach triggered for channel {} (tmux={}, offset={}, replaced={})",
+        channel_id.get(),
+        tmux_session_name,
+        initial_offset,
+        !fresh
+    );
+}
+
 /// #226: Atomically claim a channel for watcher creation using DashMap::entry().
 /// Returns true if the claim succeeded (caller should spawn the watcher).
 /// Returns false if a watcher already exists (caller should skip).
@@ -3894,6 +4057,21 @@ pub(super) async fn tmux_output_watcher_with_restore(
             tracing::warn!("  [{ts}] ⚠ watcher: relay failed — preserving inflight for retry");
         }
 
+        let missing_inflight_plan = missing_inflight_fallback_plan(
+            inflight_state.is_none(),
+            resolved_did.is_some(),
+            relay_ok || relay_suppressed,
+        );
+        if missing_inflight_plan.trigger_reattach {
+            trigger_missing_inflight_reattach(
+                &http,
+                &shared,
+                &provider_kind,
+                channel_id,
+                &tmux_session_name,
+            );
+        }
+
         // Update session tokens from result event and auto-compact if threshold exceeded
         if let Some(tokens) = result_usage.map(|usage| usage.total_input_tokens()) {
             let provider = shared.settings.read().await.provider.clone();
@@ -5238,14 +5416,14 @@ mod tests {
         enqueue_background_trigger_response_to_notify_outbox,
         enqueue_monitor_auto_turn_suppressed_notification, fail_dispatch_for_ready_for_input_stall,
         finish_monitor_auto_turn, lifecycle_reason_code_for_tmux_exit,
-        load_restored_provider_session_id, notify_path_offset_advance_decision,
-        orphan_suppressed_placeholder_action, parse_bg_trigger_offset_from_session_key,
-        process_watcher_lines, refresh_session_heartbeat_from_tmux_output,
-        restored_watcher_turn_from_inflight, rollback_enqueued_offset_for_reconciled_failures,
-        start_monitor_auto_turn_when_available, strip_inprogress_indicators,
-        suppressed_placeholder_action, terminal_relay_decision, tmux_death_is_normal_completion,
-        watcher_ready_for_input_turn_completed, watcher_should_yield_to_inflight_state,
-        watcher_stream_seed,
+        load_restored_provider_session_id, missing_inflight_fallback_plan,
+        notify_path_offset_advance_decision, orphan_suppressed_placeholder_action,
+        parse_bg_trigger_offset_from_session_key, process_watcher_lines,
+        refresh_session_heartbeat_from_tmux_output, restored_watcher_turn_from_inflight,
+        rollback_enqueued_offset_for_reconciled_failures, start_monitor_auto_turn_when_available,
+        strip_inprogress_indicators, suppressed_placeholder_action, terminal_relay_decision,
+        tmux_death_is_normal_completion, watcher_ready_for_input_turn_completed,
+        watcher_should_yield_to_inflight_state, watcher_stream_seed,
     };
     use crate::services::agent_protocol::TaskNotificationKind;
     use crate::services::discord::inflight::InflightTurnState;
@@ -5403,6 +5581,21 @@ mod tests {
 
         let watcher = watchers.get(&channel_id).expect("watcher should exist");
         assert!(watcher.paused.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn missing_inflight_fallback_warns_and_triggers_reattach_on_db_miss() {
+        let plan = missing_inflight_fallback_plan(true, false, true);
+        assert!(plan.warn);
+        assert!(plan.trigger_reattach);
+
+        let resolved = missing_inflight_fallback_plan(true, true, true);
+        assert!(resolved.warn);
+        assert!(!resolved.trigger_reattach);
+
+        let uncommitted = missing_inflight_fallback_plan(true, false, false);
+        assert!(uncommitted.warn);
+        assert!(!uncommitted.trigger_reattach);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Scoped partial on #964 — 3 of 5 structural directions. Remaining (watcher-to-tmux direct binding, cross-watcher dedupe) stays in #964.

A. Terminal-success watcher stop strict: requires drained tail + 2s quiet period, double-checks tail after sleep
B. Cancel policy aligned: hard_stop takes stop_watcher flag; kill=false preserves watcher
C. Missing-inflight fallback escalation: warn + explicit reattach when pane alive, warn-only when pane dead

## Test plan

- [x] `cargo check --bin agentdesk` 0 errors
- [x] `terminal_success_stop_requires_drained_tail_and_quiet_period` passes
- [x] `missing_inflight_fallback_plan` passes
- [x] `cancel_turn_preserves_pending_queue_via_mailbox_fallback_cleanup` passes
- [ ] Post-deploy: observe adk-cdx during active turn for false-positive watcher stops

Partial progress on #964; issue remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)