### PR TITLE
Gate memento recall on turn-signal + truncate oversized MCP output (#1035)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -226,7 +226,7 @@
 | `services::discord::monitoring_status` | `src/services/discord/monitoring_status.rs` | 294 |  |
 | `services::discord::org_schema` | `src/services/discord/org_schema.rs` | 937 |  |
 | `services::discord::org_writer` | `src/services/discord/org_writer.rs` | 239 |  |
-| `services::discord::prompt_builder` | `src/services/discord/prompt_builder.rs` | 1574 | giant-file |
+| `services::discord::prompt_builder` | `src/services/discord/prompt_builder.rs` | 1577 | giant-file |
 | `services::discord::queue_io` | `src/services/discord/queue_io.rs` | 565 |  |
 | `services::discord::recovery_engine` | `src/services/discord/recovery_engine.rs` | 4579 | giant-file |
 | `services::discord::restart_ctrl` | `src/services/discord/restart_ctrl.rs` | 113 |  |
@@ -236,7 +236,7 @@
 | `services::discord::router` | `src/services/discord/router/mod.rs` | 14 |  |
 | `services::discord::router::control_intent` | `src/services/discord/router/control_intent.rs` | 352 |  |
 | `services::discord::router::intake_gate` | `src/services/discord/router/intake_gate.rs` | 1116 | giant-file |
-| `services::discord::router::message_handler` | `src/services/discord/router/message_handler.rs` | 5209 | giant-file |
+| `services::discord::router::message_handler` | `src/services/discord/router/message_handler.rs` | 5347 | giant-file |
 | `services::discord::router::thread_binding` | `src/services/discord/router/thread_binding.rs` | 129 |  |
 | `services::discord::runtime_bootstrap` | `src/services/discord/runtime_bootstrap.rs` | 1765 | giant-file |
 | `services::discord::runtime_store` | `src/services/discord/runtime_store.rs` | 329 |  |
@@ -272,7 +272,7 @@
 | `services::mcp_config` | `src/services/mcp_config.rs` | 632 |  |
 | `services::memory` | `src/services/memory/mod.rs` | 345 |  |
 | `services::memory::local` | `src/services/memory/local.rs` | 114 |  |
-| `services::memory::memento` | `src/services/memory/memento.rs` | 2224 | giant-file |
+| `services::memory::memento` | `src/services/memory/memento.rs` | 2321 | giant-file |
 | `services::memory::memento_throttle` | `src/services/memory/memento_throttle.rs` | 274 |  |
 | `services::memory::runtime_state` | `src/services/memory/runtime_state.rs` | 434 |  |
 | `services::message_outbox` | `src/services/message_outbox.rs` | 515 |  |

--- a/src/services/discord/prompt_builder.rs
+++ b/src/services/discord/prompt_builder.rs
@@ -54,8 +54,9 @@ fn context_compression_guidance() -> String {
 fn tool_output_efficiency_guidance() -> &'static str {
     "[Tool Output Efficiency]\n\
      Large tool results persist in context and increase cost for every subsequent turn.\n\
+     - Bash/Read: If output would exceed 10 lines, summarize the result instead of pasting raw output\n\
      - Bash: Use LIMIT clauses for SQL, pipe to head/grep for filtering, avoid tail with large line counts\n\
-     - Read: Use offset/limit to read specific sections, not entire large files\n\
+     - Read: Use offset/limit to read specific sections; do not read entire files when a section is enough\n\
      - Grep: Set head_limit, use narrow glob/type filters, avoid broad patterns that match hundreds of lines\n\
      - Prefer targeted queries over exhaustive dumps"
 }
@@ -934,8 +935,10 @@ mod tests {
         let output = call_build("ctx", "/tmp", 1, "tok", false);
         assert!(output.contains("[Tool Output Efficiency]"));
         assert!(output.contains("Large tool results persist in context"));
+        assert!(output.contains("If output would exceed 10 lines"));
         assert!(output.contains("Use LIMIT clauses for SQL"));
         assert!(output.contains("Use offset/limit to read specific sections"));
+        assert!(output.contains("do not read entire files"));
         assert!(output.contains("Set head_limit"));
     }
 

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -18,6 +18,12 @@ struct MemoryInjectionPlan<'a> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MementoRecallGateDecision {
+    should_recall: bool,
+    reason: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SessionResetReason {
     IdleExpired,
     AssistantTurnCap,
@@ -62,11 +68,85 @@ fn build_memory_injection_plan<'a>(
     }
 }
 
-fn should_skip_memento_recall(
+fn memento_recall_gate_decision(
     memory_settings: &settings::ResolvedMemorySettings,
     memento_context_loaded: bool,
-) -> bool {
-    memory_settings.backend == settings::MemoryBackendKind::Memento && memento_context_loaded
+    user_text: &str,
+) -> MementoRecallGateDecision {
+    if memory_settings.backend != settings::MemoryBackendKind::Memento {
+        return MementoRecallGateDecision {
+            should_recall: true,
+            reason: "non_memento_backend",
+        };
+    }
+
+    if !memento_context_loaded {
+        return MementoRecallGateDecision {
+            should_recall: true,
+            reason: "session_start_context",
+        };
+    }
+
+    let normalized = user_text.split_whitespace().collect::<Vec<_>>().join(" ");
+    let lower = normalized.to_lowercase();
+    let text = lower.as_str();
+
+    if ["이전에", "저번에", "전에"]
+        .iter()
+        .any(|keyword| text.contains(keyword))
+    {
+        return MementoRecallGateDecision {
+            should_recall: true,
+            reason: "previous_context_signal",
+        };
+    }
+
+    if ["에러", "실패", "오류", "안 됨", "안됨"]
+        .iter()
+        .any(|keyword| text.contains(keyword))
+    {
+        return MementoRecallGateDecision {
+            should_recall: true,
+            reason: "error_context_signal",
+        };
+    }
+
+    if [
+        "설정 변경",
+        "설정 바",
+        "설정 업데이트",
+        "config change",
+        "configuration change",
+        "settings change",
+    ]
+    .iter()
+    .any(|keyword| text.contains(keyword))
+    {
+        return MementoRecallGateDecision {
+            should_recall: true,
+            reason: "setting_change_signal",
+        };
+    }
+
+    let trimmed = text.trim_start();
+    if trimmed.starts_with("/recall")
+        || trimmed.starts_with("/memento")
+        || trimmed.starts_with("/memory-read")
+        || text.contains("[memento:recall]")
+        || text.contains("<memento:recall>")
+        || text.contains("memento_recall")
+        || text.contains("@memento recall")
+    {
+        return MementoRecallGateDecision {
+            should_recall: true,
+            reason: "explicit_recall_signal",
+        };
+    }
+
+    MementoRecallGateDecision {
+        should_recall: false,
+        reason: "no_turn_signal",
+    }
 }
 
 fn should_note_memento_context_loaded(
@@ -493,7 +573,9 @@ pub(in crate::services::discord) async fn start_headless_turn(
         .insert(channel_id, std::time::Instant::now());
 
     let (memory_settings, memory_backend) = build_memory_backend(role_binding.as_ref());
-    let memory_recall = if should_skip_memento_recall(&memory_settings, memento_context_loaded) {
+    let memento_recall_gate =
+        memento_recall_gate_decision(&memory_settings, memento_context_loaded, prompt);
+    let memory_recall = if !memento_recall_gate.should_recall {
         RecallResponse::default()
     } else {
         memory_backend
@@ -507,6 +589,22 @@ pub(in crate::services::discord) async fn start_headless_turn(
             })
             .await
     };
+    if memory_settings.backend == settings::MemoryBackendKind::Memento {
+        let ts = chrono::Local::now().format("%H:%M:%S");
+        tracing::info!(
+            "  [{ts}] [memory] memento recall gate for headless channel {}: decision={} reason={} context_loaded={} input_tokens={} output_tokens={}",
+            channel_id.get(),
+            if memento_recall_gate.should_recall {
+                "inject"
+            } else {
+                "skip"
+            },
+            memento_recall_gate.reason,
+            memento_context_loaded,
+            memory_recall.token_usage.input_tokens,
+            memory_recall.token_usage.output_tokens
+        );
+    }
     if should_note_memento_context_loaded(&memory_settings, memento_context_loaded, &memory_recall)
     {
         let mut data = shared.core.lock().await;
@@ -2205,7 +2303,9 @@ pub(in crate::services::discord) async fn handle_text_message(
         .insert(channel_id, std::time::Instant::now());
 
     let (memory_settings, memory_backend) = build_memory_backend(role_binding.as_ref());
-    let memory_recall = if should_skip_memento_recall(&memory_settings, memento_context_loaded) {
+    let memento_recall_gate =
+        memento_recall_gate_decision(&memory_settings, memento_context_loaded, user_text);
+    let memory_recall = if !memento_recall_gate.should_recall {
         RecallResponse::default()
     } else {
         memory_backend
@@ -2219,6 +2319,22 @@ pub(in crate::services::discord) async fn handle_text_message(
             })
             .await
     };
+    if memory_settings.backend == settings::MemoryBackendKind::Memento {
+        let ts = chrono::Local::now().format("%H:%M:%S");
+        tracing::info!(
+            "  [{ts}] [memory] memento recall gate for channel {}: decision={} reason={} context_loaded={} input_tokens={} output_tokens={}",
+            channel_id.get(),
+            if memento_recall_gate.should_recall {
+                "inject"
+            } else {
+                "skip"
+            },
+            memento_recall_gate.reason,
+            memento_context_loaded,
+            memory_recall.token_usage.input_tokens,
+            memory_recall.token_usage.output_tokens
+        );
+    }
     if should_note_memento_context_loaded(&memory_settings, memento_context_loaded, &memory_recall)
     {
         let mut data = shared.core.lock().await;
@@ -4481,16 +4597,35 @@ mod tests {
     }
 
     #[test]
-    fn memento_recall_skip_only_triggers_for_loaded_memento_sessions() {
+    fn memento_recall_gate_uses_session_start_and_turn_signals() {
         let memento = settings::ResolvedMemorySettings {
             backend: settings::MemoryBackendKind::Memento,
             ..settings::ResolvedMemorySettings::default()
         };
         let file = settings::ResolvedMemorySettings::default();
 
-        assert!(should_skip_memento_recall(&memento, true));
-        assert!(!should_skip_memento_recall(&memento, false));
-        assert!(!should_skip_memento_recall(&file, true));
+        assert_eq!(
+            memento_recall_gate_decision(&memento, false, "평범한 요청").reason,
+            "session_start_context"
+        );
+        assert!(!memento_recall_gate_decision(&memento, true, "평범한 요청").should_recall);
+        assert_eq!(
+            memento_recall_gate_decision(&memento, true, "이전에 하던 거 이어서 해줘").reason,
+            "previous_context_signal"
+        );
+        assert_eq!(
+            memento_recall_gate_decision(&memento, true, "빌드 실패 원인 찾아줘").reason,
+            "error_context_signal"
+        );
+        assert_eq!(
+            memento_recall_gate_decision(&memento, true, "설정 변경 내용 기억나?").reason,
+            "setting_change_signal"
+        );
+        assert_eq!(
+            memento_recall_gate_decision(&memento, true, "/recall deploy note").reason,
+            "explicit_recall_signal"
+        );
+        assert!(memento_recall_gate_decision(&file, true, "평범한 요청").should_recall);
     }
 
     #[test]
@@ -4565,16 +4700,16 @@ mod tests {
 
         session.restore_provider_session(Some("session-1".to_string()));
         session.note_memento_context_loaded();
-        assert!(should_skip_memento_recall(
-            &memento,
-            session.memento_context_loaded
-        ));
+        assert!(
+            !memento_recall_gate_decision(&memento, session.memento_context_loaded, "평범한 요청",)
+                .should_recall
+        );
 
         session.clear_provider_session();
-        assert!(!should_skip_memento_recall(
-            &memento,
-            session.memento_context_loaded
-        ));
+        assert!(
+            memento_recall_gate_decision(&memento, session.memento_context_loaded, "평범한 요청",)
+                .should_recall
+        );
     }
 
     #[test]
@@ -4587,14 +4722,17 @@ mod tests {
 
         session.restore_provider_session(Some("session-1".to_string()));
         let mut memento_context_loaded = session.memento_context_loaded;
-        assert!(!should_skip_memento_recall(
-            &memento,
-            memento_context_loaded
-        ));
+        assert!(
+            memento_recall_gate_decision(&memento, memento_context_loaded, "평범한 요청",)
+                .should_recall
+        );
 
         session.note_memento_context_loaded();
         memento_context_loaded = session.memento_context_loaded;
-        assert!(should_skip_memento_recall(&memento, memento_context_loaded));
+        assert!(
+            !memento_recall_gate_decision(&memento, memento_context_loaded, "평범한 요청")
+                .should_recall
+        );
     }
 
     #[test]

--- a/src/services/memory/memento.rs
+++ b/src/services/memory/memento.rs
@@ -23,6 +23,7 @@ const MEMENTO_PROTOCOL_VERSION: &str = "2025-11-25";
 const MAX_WORKING_MEMORY_LINES: usize = 6;
 const MAX_MEMORY_LINES: usize = 6;
 const MAX_SKIP_LINES: usize = 4;
+const MEMENTO_MODEL_OUTPUT_MAX_BYTES: usize = 16 * 1024;
 
 #[derive(Clone, Debug)]
 struct CachedMcpSession {
@@ -45,6 +46,14 @@ struct ToolCallResult {
 struct ContextFetchResult {
     external_recall: Option<String>,
     token_usage: TokenUsage,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ModelOutputGuardResult {
+    text: String,
+    truncated: bool,
+    original_bytes: usize,
+    limit_bytes: usize,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -696,6 +705,56 @@ fn truncate_text(value: &str, max_chars: usize) -> String {
     shortened
 }
 
+fn truncate_to_byte_boundary(value: &str, max_bytes: usize) -> &str {
+    let mut end = max_bytes.min(value.len());
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    &value[..end]
+}
+
+fn guard_mcp_output_for_model(value: String, max_bytes: usize) -> ModelOutputGuardResult {
+    let original_bytes = value.len();
+    if original_bytes <= max_bytes {
+        return ModelOutputGuardResult {
+            text: value,
+            truncated: false,
+            original_bytes,
+            limit_bytes: max_bytes,
+        };
+    }
+
+    if max_bytes == 0 {
+        return ModelOutputGuardResult {
+            text: String::new(),
+            truncated: true,
+            original_bytes,
+            limit_bytes: max_bytes,
+        };
+    }
+
+    let notice = format!(
+        "\n\n[truncated memento MCP output: original_bytes={original_bytes}, limit_bytes={max_bytes}]"
+    );
+    let text = if notice.len() >= max_bytes {
+        truncate_to_byte_boundary(&value, max_bytes).to_string()
+    } else {
+        let keep_bytes = max_bytes - notice.len();
+        format!(
+            "{}{}",
+            truncate_to_byte_boundary(&value, keep_bytes),
+            notice
+        )
+    };
+
+    ModelOutputGuardResult {
+        text,
+        truncated: true,
+        original_bytes,
+        limit_bytes: max_bytes,
+    }
+}
+
 fn summarize_transcript_line(line: &str) -> Option<String> {
     let line = line.trim();
     if line.is_empty() || line == "[Stopped]" || line.starts_with("[System]:") {
@@ -1111,7 +1170,16 @@ fn format_context_payload_for_external_recall(payload: &Value) -> Option<String>
     if sections.len() == 1 {
         None
     } else {
-        Some(sections.join("\n"))
+        let guarded =
+            guard_mcp_output_for_model(sections.join("\n"), MEMENTO_MODEL_OUTPUT_MAX_BYTES);
+        if guarded.truncated {
+            tracing::warn!(
+                "[memory] truncated memento MCP output before model injection: original_bytes={} limit_bytes={}",
+                guarded.original_bytes,
+                guarded.limit_bytes
+            );
+        }
+        Some(guarded.text)
     }
 }
 
@@ -1385,6 +1453,35 @@ mod tests {
     #[test]
     fn test_format_context_payload_for_external_recall_returns_none_when_empty() {
         assert!(format_context_payload_for_external_recall(&json!({})).is_none());
+    }
+
+    #[test]
+    fn test_mcp_output_guard_preserves_threshold_boundary() {
+        let exact = "x".repeat(MEMENTO_MODEL_OUTPUT_MAX_BYTES);
+        let exact_guarded =
+            guard_mcp_output_for_model(exact.clone(), MEMENTO_MODEL_OUTPUT_MAX_BYTES);
+        assert_eq!(exact_guarded.text, exact);
+        assert!(!exact_guarded.truncated);
+
+        let oversized = format!("{}y", "x".repeat(MEMENTO_MODEL_OUTPUT_MAX_BYTES));
+        let oversized_guarded =
+            guard_mcp_output_for_model(oversized, MEMENTO_MODEL_OUTPUT_MAX_BYTES);
+        assert!(oversized_guarded.truncated);
+        assert!(oversized_guarded.text.len() <= MEMENTO_MODEL_OUTPUT_MAX_BYTES);
+        assert!(
+            oversized_guarded
+                .text
+                .contains("truncated memento MCP output")
+        );
+    }
+
+    #[test]
+    fn test_mcp_output_guard_truncates_on_utf8_boundary() {
+        let guarded = guard_mcp_output_for_model("가나다라마바사".to_string(), 10);
+
+        assert!(guarded.truncated);
+        assert!(guarded.text.len() <= 10);
+        assert!(std::str::from_utf8(guarded.text.as_bytes()).is_ok());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Wave 4B Batch 1 — adds a per-turn gate predicate for memento `recall` injection (error/"이전에"/"전에"/setting-change signals or explicit recall), preserving the unconditional `context` load at session start. Adds a 16 KiB byte-boundary truncation guard for memento MCP output with char-boundary safety and a truncation notice. Audit logs record decision/reason/token usage for each gate evaluation.

## Related
- Closes #1035
- Part of Wave 4B Batch 1 — parent epic #908

## Test plan
- [x] `cargo check --bin agentdesk --tests` — 0 errors
- [x] `cargo test --bin agentdesk memento -- --test-threads=1` — 46/46 pass
- [x] Byte-boundary truncation preserves char boundaries at 16 KiB limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)