### PR TITLE
Document runtime invariants + emit violations via observability (#1036)

### DIFF
--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -1,0 +1,46 @@
+# Runtime Invariants
+
+This document records runtime invariants that must hold across the AgentDesk
+Discord runtime. Violations should surface through `debug_assert!` in dev/test
+when the condition is expected to be certain, or through `tracing::error!` plus
+the observability invariant counter when a transient runtime race is possible.
+
+Invariant violations are emitted as `observability_events.event_type =
+invariant_violation`, counted through the existing observability guard counter
+path, and exposed at `GET /api/analytics/invariants`.
+
+## Core Invariants
+
+| Invariant | Rule | Authoritative code | Runtime guard |
+| --- | --- | --- | --- |
+| `watcher_one_per_channel` | A Discord channel may have at most one live tmux watcher handle. Replacement must cancel the stale handle before installing the new one. | `src/services/discord/tmux.rs:1986`, `src/services/discord/tmux.rs:2023` | `debug_assert!` and invariant counter at `src/services/discord/tmux.rs:2004`, `src/services/discord/tmux.rs:2081`. |
+| `inflight_tmux_one_to_one` | One tmux session name must not be owned by multiple inflight state files, and one channel's inflight file must not drift to a different tmux session mid-turn. | `src/services/discord/inflight.rs:254`, `src/services/discord/inflight.rs:575` | Soft invariant counter at `src/services/discord/inflight.rs:312` and duplicate-owner detection at `src/services/discord/inflight.rs:635`. |
+| `response_sent_offset_monotonic` | `response_sent_offset` only advances within a turn. It must not move backwards when the turn bridge or restored watcher persists delivery progress. | `src/services/discord/turn_bridge/mod.rs:244`, `src/services/discord/tmux.rs:2152`, `src/services/discord/inflight.rs:254` | `debug_assert!` and invariant counter at `src/services/discord/turn_bridge/mod.rs:263`, `src/services/discord/tmux.rs:2181`, `src/services/discord/inflight.rs:292`. |
+| `response_sent_offset_in_bounds` | `response_sent_offset` must stay on a UTF-8 boundary within `full_response`. | `src/services/discord/turn_bridge/mod.rs:244`, `src/services/discord/tmux.rs:2152`, `src/services/discord/inflight.rs:254` | `debug_assert!` and invariant counter at `src/services/discord/turn_bridge/mod.rs:285`, `src/services/discord/tmux.rs:2200`, `src/services/discord/inflight.rs:267`. |
+| `tmux_confirmed_end_monotonic` | The tmux relay `confirmed_end_offset` watermark only advances and must reach the committed tmux output end after a direct delivery or bridge handoff. This is the tmux-output counterpart to `response_sent_offset`; the two are different units and must not be compared directly. | `src/services/discord/turn_bridge/mod.rs:299`, `src/services/discord/tmux.rs:3870` | `debug_assert!` and invariant counter at `src/services/discord/turn_bridge/mod.rs:337`, `src/services/discord/tmux.rs:3870`. |
+| `mailbox_active_turn_matches_dispatch` | While a foreground Discord turn is active, the channel mailbox owns exactly one active turn token. Turn finalization must remove that token before queue follow-up dispatch starts. | `src/services/turn_orchestrator.rs:675`, `src/services/turn_orchestrator.rs:1102`, `src/services/discord/mod.rs:1025`, `src/services/discord/turn_bridge/mod.rs:1541` | Soft invariant counter at `src/services/discord/turn_bridge/mod.rs:1549`. |
+| `turn_id_unique_within_session` | A persisted turn id is `discord:{channel_id}:{user_msg_id}`. Discord message ids are unique within the channel/session scope, and zero ids are reserved for synthetic rebind state that must not create real turn rows. | `src/services/discord/turn_bridge/mod.rs:213`, `src/services/discord/recovery_engine.rs:409` | `debug_assert!` and invariant counter at `src/services/discord/turn_bridge/mod.rs:228`. |
+
+## Lifecycle Invariants
+
+| Invariant | Rule | Authoritative code | Runtime guard |
+| --- | --- | --- | --- |
+| `recovery_phase_valid` | Recovery phase values are restricted to `pending`, `watcher_reattach`, `inflight_restore`, and `done`; transition helpers must canonicalize persisted values through that enum. | `src/services/discord/recovery_engine.rs:30`, `src/services/discord/recovery_engine.rs:186`, `src/services/discord/recovery_engine.rs:214`, `src/services/discord/recovery_engine.rs:225` | Existing unit tests cover phase parsing and transition helpers. Recovery fires remain observable through `emit_recovery_fired` at `src/services/discord/recovery_engine.rs:2359`. |
+| `recovery_mailbox_reregister_idempotent` | Restart recovery may re-register an active mailbox turn from inflight state, but repeated attempts must not create parallel active turns. | `src/services/discord/recovery_engine.rs:409`, `src/services/discord/recovery_engine.rs:419` | Covered by the mailbox single-token invariant and `reregister_active_turn_from_inflight` tests. |
+| `dispatch_completion_single_authority` | All dispatch completion paths route through `finalize_dispatch` / `complete_dispatch_inner_with_backends` so evidence validation, DB status transition, hooks, and follow-ups share one lifecycle. | `src/dispatch/dispatch_status.rs:1077`, `src/dispatch/dispatch_status.rs:1342`, `src/dispatch/dispatch_status.rs:1345` | Existing dispatch result observability is emitted by the shared status transition path; this change does not rewrite the dispatch state machine. |
+| `dispatch_outbox_single_delivery_worker` | Discord side effects for dispatch outbox rows originate from the outbox worker; other paths enqueue durable outbox rows and return. | `src/server/routes/dispatches/outbox.rs:334`, `src/server/routes/dispatches/outbox.rs:1662`, `src/server/routes/dispatches/outbox.rs:1697` | Existing outbox retry/backoff tests cover the lifecycle. No new runtime panic is introduced here. |
+
+## Observability Contract
+
+- Emit invariant violations through `record_invariant_check` at `src/services/observability.rs:461`.
+- Store the invariant key in `observability_events.status` with payload fields
+  `invariant`, `code_location`, `message`, and `details`.
+- Query counts and recent events through `query_invariant_analytics` at
+  `src/services/observability.rs:884`.
+- Expose the API via `GET /api/analytics/invariants` at
+  `src/server/routes/analytics.rs:125`.
+
+Release builds must not gain new panic paths from invariant checks. Use
+`debug_assert!` only beside checks that are expected to be impossible in normal
+execution; use `record_invariant_check` alone for lifecycle races or stale
+runtime files that can temporarily exist during restart/recovery.

--- a/src/server/routes/analytics.rs
+++ b/src/server/routes/analytics.rs
@@ -48,6 +48,15 @@ pub struct QualityEventsQuery {
     pub limit: Option<usize>,
 }
 
+#[derive(Debug, Default, Deserialize)]
+pub struct InvariantsQuery {
+    pub provider: Option<String>,
+    #[serde(rename = "channelId")]
+    pub channel_id: Option<String>,
+    pub invariant: Option<String>,
+    pub limit: Option<usize>,
+}
+
 /// GET /api/analytics
 pub async fn analytics(
     State(state): State<AppState>,
@@ -109,6 +118,39 @@ pub async fn quality_events(
         Err(error) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({"error": format!("query agent quality events: {error}")})),
+        ),
+    }
+}
+
+/// GET /api/analytics/invariants
+pub async fn invariants(
+    State(state): State<AppState>,
+    Query(params): Query<InvariantsQuery>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let filters = crate::services::observability::InvariantAnalyticsFilters {
+        provider: params.provider,
+        channel_id: params.channel_id,
+        invariant: params.invariant,
+        limit: params.limit.unwrap_or(50),
+    };
+
+    match crate::services::observability::query_invariant_analytics(
+        state.sqlite_db(),
+        state.pg_pool_ref(),
+        &filters,
+    )
+    .await
+    {
+        Ok(response) => match serde_json::to_value(response) {
+            Ok(value) => (StatusCode::OK, Json(value)),
+            Err(error) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("serialize invariant analytics response: {error}")})),
+            ),
+        },
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": format!("query invariant analytics: {error}")})),
         ),
     }
 }
@@ -1236,6 +1278,49 @@ mod tests {
                 .iter()
                 .any(|event| event["event_type"] == json!("turn_finished"))
         );
+    }
+
+    #[tokio::test]
+    async fn invariants_route_returns_violation_payload() {
+        let _guard = crate::services::observability::test_runtime_lock();
+        crate::services::observability::reset_for_tests();
+        let db = crate::db::test_db();
+        crate::services::observability::init_observability(db.clone(), None);
+        crate::services::observability::record_invariant_check(
+            false,
+            crate::services::observability::InvariantViolation {
+                provider: Some("codex"),
+                channel_id: Some(5150),
+                dispatch_id: Some("dispatch-route"),
+                session_key: None,
+                turn_id: Some("discord:5150:1"),
+                invariant: "watcher_one_per_channel",
+                code_location: "src/services/discord/tmux.rs:test",
+                message: "route test violation",
+                details: json!({ "source": "test" }),
+            },
+        );
+        crate::services::observability::flush_for_tests().await;
+
+        let state = AppState::test_state(db.clone(), test_engine(&db));
+        let (status, Json(body)) = invariants(
+            State(state),
+            Query(InvariantsQuery {
+                provider: Some("codex".to_string()),
+                channel_id: Some("5150".to_string()),
+                invariant: Some("watcher_one_per_channel".to_string()),
+                limit: Some(10),
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["total_violations"], json!(1));
+        assert_eq!(
+            body["counts"][0]["invariant"],
+            json!("watcher_one_per_channel")
+        );
+        assert_eq!(body["recent"][0]["message"], json!("route test violation"));
     }
 
     #[tokio::test]

--- a/src/server/routes/docs.rs
+++ b/src/server/routes/docs.rs
@@ -2407,6 +2407,30 @@ fn all_endpoints() -> Vec<EndpointDoc> {
             ]),
         ep(
             "GET",
+            "/api/analytics/invariants",
+            "analytics",
+            "Runtime invariant violation counts and recent events",
+        )
+        .with_params([
+            (
+                "provider",
+                query_param("string", false, "Filter by provider id (claude/codex/gemini/qwen)"),
+            ),
+            (
+                "channelId",
+                query_param("string", false, "Filter by Discord channel id"),
+            ),
+            (
+                "invariant",
+                query_param("string", false, "Filter by invariant key"),
+            ),
+            (
+                "limit",
+                query_param("integer", false, "Maximum recent violations to return").with_default(50),
+            ),
+        ]),
+        ep(
+            "GET",
             "/api/quality/events",
             "analytics",
             "Agent quality raw event stream",

--- a/src/server/routes/domains/admin.rs
+++ b/src/server/routes/domains/admin.rs
@@ -66,6 +66,7 @@ pub(crate) fn router(state: AppState) -> ApiRouter {
                 post(escalation::emit_escalation),
             )
             .route("/analytics", get(analytics::analytics))
+            .route("/analytics/invariants", get(analytics::invariants))
             .route("/quality/events", get(analytics::quality_events))
             .route("/streaks", get(analytics::streaks))
             .route("/achievements", get(analytics::achievements))

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -221,6 +222,105 @@ fn now_string() -> String {
     chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string()
 }
 
+fn turn_id_for_state(state: &InflightTurnState) -> Option<String> {
+    (state.user_msg_id != 0).then(|| format!("discord:{}:{}", state.channel_id, state.user_msg_id))
+}
+
+fn record_inflight_invariant(
+    condition: bool,
+    state: &InflightTurnState,
+    invariant: &'static str,
+    code_location: &'static str,
+    message: &'static str,
+    details: serde_json::Value,
+) -> bool {
+    let turn_id = turn_id_for_state(state);
+    crate::services::observability::record_invariant_check(
+        condition,
+        crate::services::observability::InvariantViolation {
+            provider: Some(state.provider.as_str()),
+            channel_id: Some(state.channel_id),
+            dispatch_id: state.dispatch_id.as_deref(),
+            session_key: state.session_key.as_deref(),
+            turn_id: turn_id.as_deref(),
+            invariant,
+            code_location,
+            message,
+            details,
+        },
+    )
+}
+
+fn validate_inflight_state_for_save(
+    root: &Path,
+    path: &Path,
+    state: &InflightTurnState,
+    code_location: &'static str,
+) {
+    let offset_in_bounds = state.response_sent_offset <= state.full_response.len()
+        && state
+            .full_response
+            .is_char_boundary(state.response_sent_offset);
+    record_inflight_invariant(
+        offset_in_bounds,
+        state,
+        "response_sent_offset_in_bounds",
+        code_location,
+        "inflight response_sent_offset must stay within full_response",
+        serde_json::json!({
+            "response_sent_offset": state.response_sent_offset,
+            "full_response_len": state.full_response.len(),
+            "path": path.display().to_string(),
+        }),
+    );
+    debug_assert!(
+        offset_in_bounds,
+        "inflight response_sent_offset must stay within full_response"
+    );
+
+    let Ok(existing_content) = fs::read_to_string(path) else {
+        return;
+    };
+    let Ok(existing) = serde_json::from_str::<InflightTurnState>(&existing_content) else {
+        return;
+    };
+
+    let monotonic_offset = state.response_sent_offset >= existing.response_sent_offset;
+    record_inflight_invariant(
+        monotonic_offset,
+        state,
+        "response_sent_offset_monotonic",
+        code_location,
+        "inflight response_sent_offset must not move backwards",
+        serde_json::json!({
+            "previous": existing.response_sent_offset,
+            "next": state.response_sent_offset,
+            "path": path.display().to_string(),
+        }),
+    );
+    debug_assert!(
+        monotonic_offset,
+        "inflight response_sent_offset must not move backwards"
+    );
+
+    let same_tmux_owner = existing.tmux_session_name.is_none()
+        || state.tmux_session_name.is_none()
+        || existing.tmux_session_name == state.tmux_session_name;
+    record_inflight_invariant(
+        same_tmux_owner,
+        state,
+        "inflight_tmux_one_to_one",
+        code_location,
+        "inflight state for a channel must not drift between tmux sessions",
+        serde_json::json!({
+            "previous_tmux_session_name": existing.tmux_session_name.as_deref(),
+            "next_tmux_session_name": state.tmux_session_name.as_deref(),
+            "root": root.display().to_string(),
+            "path": path.display().to_string(),
+        }),
+    );
+}
+
 pub(super) fn save_inflight_state(state: &InflightTurnState) -> Result<(), String> {
     let Some(root) = inflight_runtime_root() else {
         return Err("Home directory not found".to_string());
@@ -282,6 +382,12 @@ fn save_inflight_state_create_new_in_root(
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| CreateNewInflightError::Internal(e.to_string()))?;
     }
+    validate_inflight_state_for_save(
+        root,
+        &path,
+        state,
+        "src/services/discord/inflight.rs:save_inflight_state_create_new_in_root",
+    );
     let mut updated = state.clone();
     updated.updated_at = now_string();
     let json = serde_json::to_string_pretty(&updated)
@@ -318,6 +424,12 @@ fn save_inflight_state_in_root(root: &Path, state: &InflightTurnState) -> Result
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
+    validate_inflight_state_for_save(
+        root,
+        &path,
+        state,
+        "src/services/discord/inflight.rs:save_inflight_state_in_root",
+    );
     let mut updated = state.clone();
     updated.updated_at = now_string();
     let json = serde_json::to_string_pretty(&updated).map_err(|e| e.to_string())?;
@@ -466,6 +578,7 @@ fn load_inflight_states_from_root(root: &Path, provider: &ProviderKind) -> Vec<I
         return Vec::new();
     };
     let mut states = Vec::new();
+    let mut tmux_owners: HashMap<String, u64> = HashMap::new();
     let current_generation = super::runtime_store::load_generation();
     for entry in entries.filter_map(|e| e.ok()) {
         let path = entry.path();
@@ -507,6 +620,29 @@ fn load_inflight_states_from_root(root: &Path, provider: &ProviderKind) -> Vec<I
             tracing::info!("  [{ts}] ⚠ {}: {}", reason, path.display());
             let _ = fs::remove_file(&path);
             continue;
+        }
+        if let Some(tmux_session_name) = state
+            .tmux_session_name
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            if let Some(previous_channel_id) =
+                tmux_owners.insert(tmux_session_name.to_string(), state.channel_id)
+            {
+                record_inflight_invariant(
+                    false,
+                    &state,
+                    "inflight_tmux_one_to_one",
+                    "src/services/discord/inflight.rs:load_inflight_states_from_root",
+                    "one tmux session must not be owned by multiple inflight channel files",
+                    serde_json::json!({
+                        "tmux_session_name": tmux_session_name,
+                        "previous_channel_id": previous_channel_id,
+                        "current_channel_id": state.channel_id,
+                        "path": path.display().to_string(),
+                    }),
+                );
+            }
         }
         states.push(state);
     }

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -94,6 +94,31 @@ fn normalize_response_sent_offset(full_response: &str, response_sent_offset: usi
     offset
 }
 
+fn record_watcher_invariant(
+    condition: bool,
+    provider: Option<&ProviderKind>,
+    channel_id: ChannelId,
+    invariant: &'static str,
+    code_location: &'static str,
+    message: &'static str,
+    details: serde_json::Value,
+) -> bool {
+    crate::services::observability::record_invariant_check(
+        condition,
+        crate::services::observability::InvariantViolation {
+            provider: provider.map(ProviderKind::as_str),
+            channel_id: Some(channel_id.get()),
+            dispatch_id: None,
+            session_key: None,
+            turn_id: None,
+            invariant,
+            code_location,
+            message,
+            details,
+        },
+    )
+}
+
 pub(super) fn restored_watcher_turn_from_inflight(
     state: &super::inflight::InflightTurnState,
     tmux_session_name: &str,
@@ -1964,13 +1989,31 @@ pub(super) fn try_claim_watcher(
     handle: TmuxWatcherHandle,
 ) -> bool {
     use dashmap::mapref::entry::Entry;
-    match watchers.entry(channel_id) {
+    let claimed = match watchers.entry(channel_id) {
         Entry::Occupied(_) => false,
         Entry::Vacant(entry) => {
             entry.insert(handle);
             true
         }
-    }
+    };
+    let slot_present = watchers.contains_key(&channel_id);
+    record_watcher_invariant(
+        slot_present,
+        None,
+        channel_id,
+        "watcher_one_per_channel",
+        "src/services/discord/tmux.rs:try_claim_watcher",
+        "watcher claim must leave a single channel-owned watcher slot",
+        serde_json::json!({
+            "claimed": claimed,
+            "watcher_slots": watchers.len(),
+        }),
+    );
+    debug_assert!(
+        slot_present,
+        "watcher claim must leave a channel-owned watcher slot"
+    );
+    claimed
 }
 
 /// #243: Claim a channel for watcher creation, cancelling any existing watcher.
@@ -1985,7 +2028,7 @@ pub(super) fn claim_or_replace_watcher(
     source: &str,
 ) -> bool {
     use dashmap::mapref::entry::Entry;
-    match watchers.entry(channel_id) {
+    let fresh = match watchers.entry(channel_id) {
         Entry::Occupied(mut entry) => {
             // Cancel the existing watcher — it will exit on its next loop iteration
             // and skip DashMap removal (since cancel is set).
@@ -1993,6 +2036,25 @@ pub(super) fn claim_or_replace_watcher(
                 .get()
                 .cancel
                 .store(true, std::sync::atomic::Ordering::Relaxed);
+            let stale_cancelled = entry
+                .get()
+                .cancel
+                .load(std::sync::atomic::Ordering::Relaxed);
+            record_watcher_invariant(
+                stale_cancelled,
+                Some(provider),
+                channel_id,
+                "watcher_replacement_cancels_stale",
+                "src/services/discord/tmux.rs:claim_or_replace_watcher",
+                "replacing a watcher must cancel the stale watcher before installing the new handle",
+                serde_json::json!({
+                    "source": source,
+                }),
+            );
+            debug_assert!(
+                stale_cancelled,
+                "stale watcher must be cancelled before replacement"
+            );
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::info!(
                 "  [{ts}] ♻ watcher replaced for channel {} — cancelled stale watcher",
@@ -2010,7 +2072,26 @@ pub(super) fn claim_or_replace_watcher(
             entry.insert(handle);
             true
         }
-    }
+    };
+    let slot_present = watchers.contains_key(&channel_id);
+    record_watcher_invariant(
+        slot_present,
+        Some(provider),
+        channel_id,
+        "watcher_one_per_channel",
+        "src/services/discord/tmux.rs:claim_or_replace_watcher",
+        "watcher replacement must leave exactly one channel-owned watcher slot",
+        serde_json::json!({
+            "fresh": fresh,
+            "source": source,
+            "watcher_slots": watchers.len(),
+        }),
+    );
+    debug_assert!(
+        slot_present,
+        "watcher replacement must leave a channel-owned watcher slot"
+    );
+    fresh
 }
 
 use crate::services::tmux_common::{current_tmux_owner_marker, tmux_owner_path};
@@ -2090,9 +2171,47 @@ fn persist_watcher_stream_progress(
     if let Some(msg_id) = current_msg_id {
         inflight.current_msg_id = msg_id.get();
     }
-    inflight.full_response = full_response.to_string();
-    inflight.response_sent_offset =
+    let normalized_response_sent_offset =
         normalize_response_sent_offset(full_response, response_sent_offset);
+    let monotonic_offset = normalized_response_sent_offset >= inflight.response_sent_offset;
+    record_watcher_invariant(
+        monotonic_offset,
+        Some(provider),
+        channel_id,
+        "response_sent_offset_monotonic",
+        "src/services/discord/tmux.rs:persist_watcher_stream_progress",
+        "watcher response_sent_offset must not move backwards",
+        serde_json::json!({
+            "previous": inflight.response_sent_offset,
+            "next": normalized_response_sent_offset,
+            "tmux_session_name": tmux_session_name,
+        }),
+    );
+    debug_assert!(
+        monotonic_offset,
+        "watcher response_sent_offset must not move backwards"
+    );
+    let offset_in_bounds = normalized_response_sent_offset <= full_response.len()
+        && full_response.is_char_boundary(normalized_response_sent_offset);
+    record_watcher_invariant(
+        offset_in_bounds,
+        Some(provider),
+        channel_id,
+        "response_sent_offset_in_bounds",
+        "src/services/discord/tmux.rs:persist_watcher_stream_progress",
+        "watcher response_sent_offset must stay on a full_response boundary",
+        serde_json::json!({
+            "next": normalized_response_sent_offset,
+            "full_response_len": full_response.len(),
+            "tmux_session_name": tmux_session_name,
+        }),
+    );
+    debug_assert!(
+        offset_in_bounds,
+        "watcher response_sent_offset must stay on a full_response boundary"
+    );
+    inflight.full_response = full_response.to_string();
+    inflight.response_sent_offset = normalized_response_sent_offset;
     inflight.current_tool_line = current_tool_line.map(str::to_string);
     inflight.prev_tool_status = prev_tool_status.map(str::to_string);
     if task_notification_kind.is_some() {
@@ -3740,6 +3859,27 @@ pub(super) async fn tmux_output_watcher_with_restore(
                     Err(observed) => cur = observed,
                 }
             }
+            let confirmed_end = relay_coord
+                .confirmed_end_offset
+                .load(std::sync::atomic::Ordering::Acquire);
+            let confirmed_reached_current = confirmed_end >= current_offset;
+            record_watcher_invariant(
+                confirmed_reached_current,
+                Some(&watcher_provider),
+                channel_id,
+                "tmux_confirmed_end_monotonic",
+                "src/services/discord/tmux.rs:tmux_output_watcher_confirmed_end",
+                "watcher confirmed_end_offset must reach the committed tmux output end",
+                serde_json::json!({
+                    "current_offset": current_offset,
+                    "confirmed_end": confirmed_end,
+                    "tmux_session_name": tmux_session_name.as_str(),
+                }),
+            );
+            debug_assert!(
+                confirmed_reached_current,
+                "watcher confirmed_end_offset must reach committed output end"
+            );
         }
         // Release the emission slot regardless of success. If delivery failed
         // the local `last_relayed_offset` also stayed put, so the same watcher

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -182,6 +182,120 @@ fn response_portion_after_offset(full_response: &str, response_sent_offset: usiz
     full_response.get(response_sent_offset..).unwrap_or("")
 }
 
+fn record_turn_bridge_invariant(
+    condition: bool,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    dispatch_id: Option<&str>,
+    session_key: Option<&str>,
+    turn_id: Option<&str>,
+    invariant: &'static str,
+    code_location: &'static str,
+    message: &'static str,
+    details: serde_json::Value,
+) -> bool {
+    crate::services::observability::record_invariant_check(
+        condition,
+        crate::services::observability::InvariantViolation {
+            provider: Some(provider.as_str()),
+            channel_id: Some(channel_id.get()),
+            dispatch_id,
+            session_key,
+            turn_id,
+            invariant,
+            code_location,
+            message,
+            details,
+        },
+    )
+}
+
+fn discord_turn_id(
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    user_msg_id: MessageId,
+    session_key: Option<&str>,
+) -> String {
+    let turn_id = format!("discord:{}:{}", channel_id.get(), user_msg_id.get());
+    let nonzero_components = channel_id.get() != 0 && user_msg_id.get() != 0;
+    record_turn_bridge_invariant(
+        nonzero_components,
+        provider,
+        channel_id,
+        None,
+        session_key,
+        Some(turn_id.as_str()),
+        "turn_id_unique_within_session",
+        "src/services/discord/turn_bridge/mod.rs:discord_turn_id",
+        "turn_id must be built from non-zero Discord channel/message ids",
+        serde_json::json!({
+            "channel_id": channel_id.get(),
+            "user_msg_id": user_msg_id.get(),
+            "turn_id": turn_id.as_str(),
+        }),
+    );
+    debug_assert!(
+        nonzero_components,
+        "turn_id requires non-zero Discord channel/message ids"
+    );
+    turn_id
+}
+
+fn assert_response_sent_offset_progress(
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    dispatch_id: Option<&str>,
+    session_key: Option<&str>,
+    turn_id: &str,
+    previous: usize,
+    next: usize,
+    full_response: &str,
+    code_location: &'static str,
+) {
+    let monotonic = next >= previous;
+    record_turn_bridge_invariant(
+        monotonic,
+        provider,
+        channel_id,
+        dispatch_id,
+        session_key,
+        Some(turn_id),
+        "response_sent_offset_monotonic",
+        code_location,
+        "turn_bridge response_sent_offset must not move backwards",
+        serde_json::json!({
+            "previous": previous,
+            "next": next,
+            "full_response_len": full_response.len(),
+        }),
+    );
+    debug_assert!(
+        monotonic,
+        "turn_bridge response_sent_offset must not move backwards"
+    );
+
+    let in_bounds = next <= full_response.len() && full_response.is_char_boundary(next);
+    record_turn_bridge_invariant(
+        in_bounds,
+        provider,
+        channel_id,
+        dispatch_id,
+        session_key,
+        Some(turn_id),
+        "response_sent_offset_in_bounds",
+        code_location,
+        "turn_bridge response_sent_offset must stay on a full_response boundary",
+        serde_json::json!({
+            "next": next,
+            "full_response_len": full_response.len(),
+        }),
+    );
+    debug_assert!(
+        in_bounds,
+        "turn_bridge response_sent_offset must stay on a full_response boundary"
+    );
+}
+
 fn advance_tmux_relay_confirmed_end(
     shared: &SharedData,
     channel_id: ChannelId,
@@ -207,6 +321,32 @@ fn advance_tmux_relay_confirmed_end(
             Err(observed) => current = observed,
         }
     }
+
+    let confirmed_end = relay_coord
+        .confirmed_end_offset
+        .load(std::sync::atomic::Ordering::Acquire);
+    let confirmed_reached_target = confirmed_end >= target_end;
+    crate::services::observability::record_invariant_check(
+        confirmed_reached_target,
+        crate::services::observability::InvariantViolation {
+            provider: None,
+            channel_id: Some(channel_id.get()),
+            dispatch_id: None,
+            session_key: None,
+            turn_id: None,
+            invariant: "tmux_confirmed_end_monotonic",
+            code_location: "src/services/discord/turn_bridge/mod.rs:advance_tmux_relay_confirmed_end",
+            message: "tmux relay confirmed_end_offset must reach the delivered output end",
+            details: serde_json::json!({
+                "target_end": target_end,
+                "confirmed_end": confirmed_end,
+            }),
+        },
+    );
+    debug_assert!(
+        confirmed_reached_target,
+        "tmux relay confirmed_end_offset must reach target end"
+    );
 }
 
 fn active_turn_thread_channel_id(
@@ -447,7 +587,7 @@ pub(super) fn persist_turn_analytics_row_with_handles(
                 .and_then(crate::services::discord::adk_session::parse_thread_channel_id_from_name)
                 .map(|value| value.to_string())
         });
-    let turn_id = format!("discord:{}:{}", channel_id.get(), user_msg_id.get());
+    let turn_id = discord_turn_id(provider, channel_id, user_msg_id, session_key);
     let session_key = session_key.map(str::to_string);
     let thread_title = inflight_state.thread_title.clone();
     let persisted_channel_id = inflight_state
@@ -550,7 +690,12 @@ pub(super) fn spawn_turn_bridge(
         let provider = bridge.provider.clone();
         let gateway = bridge.gateway.clone();
         let user_msg_id = bridge.user_msg_id;
-        let turn_id = format!("discord:{}:{}", bridge.channel_id.get(), bridge.user_msg_id.get());
+        let turn_id = discord_turn_id(
+            &provider,
+            bridge.channel_id,
+            bridge.user_msg_id,
+            bridge.adk_session_key.as_deref(),
+        );
         let user_text_owned = bridge.user_text_owned.clone();
         let request_owner_name = bridge.request_owner_name.clone();
         let role_binding = bridge.role_binding.clone();
@@ -1192,7 +1337,19 @@ pub(super) fn spawn_turn_bridge(
                 {
                     Ok(()) => match gateway.send_message(channel_id, &status_block).await {
                         Ok(next_msg_id) => {
-                            response_sent_offset += plan.split_at;
+                            let next_response_sent_offset = response_sent_offset + plan.split_at;
+                            assert_response_sent_offset_progress(
+                                &provider,
+                                channel_id,
+                                dispatch_id.as_deref(),
+                                adk_session_key.as_deref(),
+                                &turn_id,
+                                response_sent_offset,
+                                next_response_sent_offset,
+                                &full_response,
+                                "src/services/discord/turn_bridge/mod.rs:rollover_response_sent_offset",
+                            );
+                            response_sent_offset = next_response_sent_offset;
                             current_msg_id = next_msg_id;
                             last_edit_text = status_block;
                             last_status_edit = tokio::time::Instant::now() - status_interval;
@@ -1382,6 +1539,21 @@ pub(super) fn spawn_turn_bridge(
             .global_finalizing
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let finish = super::mailbox_finish_turn(&shared_owned, &provider, channel_id).await;
+        record_turn_bridge_invariant(
+            finish.removed_token.is_some(),
+            &provider,
+            channel_id,
+            dispatch_id.as_deref(),
+            adk_session_key.as_deref(),
+            Some(turn_id.as_str()),
+            "mailbox_active_turn_matches_dispatch",
+            "src/services/discord/turn_bridge/mod.rs:mailbox_finish_turn",
+            "turn_bridge finalization expected exactly one active mailbox turn",
+            serde_json::json!({
+                "has_pending": finish.has_pending,
+                "mailbox_online": finish.mailbox_online,
+            }),
+        );
         if let Some(removed_token) = finish.removed_token {
             // Mark the token as cancelled so any lingering watchdog timer exits cleanly
             // instead of mistakenly firing on a newer turn's token.

--- a/src/services/observability.rs
+++ b/src/services/observability.rs
@@ -20,6 +20,8 @@ const DEFAULT_EVENT_LIMIT: usize = 100;
 const DEFAULT_COUNTER_LIMIT: usize = 200;
 const MAX_EVENT_LIMIT: usize = 500;
 const MAX_COUNTER_LIMIT: usize = 500;
+const DEFAULT_INVARIANT_LIMIT: usize = 50;
+const MAX_INVARIANT_LIMIT: usize = 500;
 const DEFAULT_QUALITY_LIMIT: usize = 200;
 const MAX_QUALITY_LIMIT: usize = 500;
 const DEFAULT_QUALITY_DAYS: i64 = 7;
@@ -227,6 +229,55 @@ pub struct AnalyticsResponse {
     pub events: Vec<AnalyticsEventRecord>,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct InvariantAnalyticsFilters {
+    pub provider: Option<String>,
+    pub channel_id: Option<String>,
+    pub invariant: Option<String>,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct InvariantViolationCount {
+    pub invariant: String,
+    pub count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct InvariantViolationRecord {
+    pub id: i64,
+    pub invariant: String,
+    pub provider: Option<String>,
+    pub channel_id: Option<String>,
+    pub dispatch_id: Option<String>,
+    pub session_key: Option<String>,
+    pub turn_id: Option<String>,
+    pub message: Option<String>,
+    pub code_location: Option<String>,
+    pub details: Value,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct InvariantAnalyticsResponse {
+    pub generated_at: String,
+    pub total_violations: u64,
+    pub counts: Vec<InvariantViolationCount>,
+    pub recent: Vec<InvariantViolationRecord>,
+}
+
+pub struct InvariantViolation<'a> {
+    pub provider: Option<&'a str>,
+    pub channel_id: Option<u64>,
+    pub dispatch_id: Option<&'a str>,
+    pub session_key: Option<&'a str>,
+    pub turn_id: Option<&'a str>,
+    pub invariant: &'a str,
+    pub code_location: &'static str,
+    pub message: &'a str,
+    pub details: Value,
+}
+
 #[derive(Debug, Clone)]
 pub struct AgentQualityEvent {
     pub source_event_id: Option<String>,
@@ -405,6 +456,46 @@ pub fn emit_recovery_fired(
             "reason": normalize_string(reason),
         }),
     );
+}
+
+pub fn record_invariant_check(condition: bool, violation: InvariantViolation<'_>) -> bool {
+    if condition {
+        return true;
+    }
+
+    let invariant = normalize_string(violation.invariant).unwrap_or_else(|| "unknown".to_string());
+    tracing::error!(
+        invariant = %invariant,
+        provider = violation.provider.unwrap_or_default(),
+        channel_id = violation.channel_id.unwrap_or_default(),
+        dispatch_id = violation.dispatch_id.unwrap_or_default(),
+        session_key = violation.session_key.unwrap_or_default(),
+        turn_id = violation.turn_id.unwrap_or_default(),
+        code_location = violation.code_location,
+        "[invariant] {}",
+        violation.message
+    );
+
+    emit_event(
+        "invariant_violation",
+        violation.provider,
+        violation.channel_id,
+        violation.dispatch_id,
+        violation.session_key,
+        violation.turn_id,
+        Some(invariant.as_str()),
+        CounterDelta {
+            guard_fires: 1,
+            ..CounterDelta::default()
+        },
+        json!({
+            "invariant": invariant,
+            "code_location": violation.code_location,
+            "message": violation.message,
+            "details": violation.details,
+        }),
+    );
+    false
 }
 
 pub fn emit_dispatch_result(
@@ -790,6 +881,65 @@ pub async fn query_agent_quality_events(
     query_agent_quality_events_sqlite(&conn, filters.agent_id.as_deref(), days, limit)
 }
 
+pub async fn query_invariant_analytics(
+    db: &Db,
+    pg_pool: Option<&PgPool>,
+    filters: &InvariantAnalyticsFilters,
+) -> Result<InvariantAnalyticsResponse> {
+    let limit = normalized_invariant_limit(filters.limit);
+    let counts = query_invariant_counts_db(db, pg_pool, filters).await?;
+    let total_violations = counts.iter().map(|count| count.count).sum();
+    let recent = query_invariant_events_db(db, pg_pool, filters, limit).await?;
+
+    Ok(InvariantAnalyticsResponse {
+        generated_at: now_kst(),
+        total_violations,
+        counts,
+        recent,
+    })
+}
+
+async fn query_invariant_counts_db(
+    db: &Db,
+    pg_pool: Option<&PgPool>,
+    filters: &InvariantAnalyticsFilters,
+) -> Result<Vec<InvariantViolationCount>> {
+    if let Some(pool) = pg_pool {
+        match query_invariant_counts_pg(pool, filters).await {
+            Ok(records) => return Ok(records),
+            Err(error) => {
+                tracing::warn!("[observability] postgres invariant count query failed: {error}");
+            }
+        }
+    }
+
+    let conn = db
+        .read_conn()
+        .map_err(|error| anyhow!("db read connection for invariant counts: {error}"))?;
+    query_invariant_counts_sqlite(&conn, filters)
+}
+
+async fn query_invariant_events_db(
+    db: &Db,
+    pg_pool: Option<&PgPool>,
+    filters: &InvariantAnalyticsFilters,
+    limit: usize,
+) -> Result<Vec<InvariantViolationRecord>> {
+    if let Some(pool) = pg_pool {
+        match query_invariant_events_pg(pool, filters, limit).await {
+            Ok(records) => return Ok(records),
+            Err(error) => {
+                tracing::warn!("[observability] postgres invariant event query failed: {error}");
+            }
+        }
+    }
+
+    let conn = db
+        .read_conn()
+        .map_err(|error| anyhow!("db read connection for invariant events: {error}"))?;
+    query_invariant_events_sqlite(&conn, filters, limit)
+}
+
 async fn query_events_db(
     db: &Db,
     pg_pool: Option<&PgPool>,
@@ -884,6 +1034,93 @@ fn query_events_sqlite(
     Ok(rows.collect::<libsql_rusqlite::Result<Vec<_>>>()?)
 }
 
+fn query_invariant_counts_sqlite(
+    conn: &Connection,
+    filters: &InvariantAnalyticsFilters,
+) -> Result<Vec<InvariantViolationCount>> {
+    let mut stmt = conn.prepare(
+        "SELECT COALESCE(status, 'unknown') AS invariant,
+                COUNT(*) AS violation_count
+         FROM observability_events
+         WHERE event_type = 'invariant_violation'
+           AND (?1 IS NULL OR provider = ?1)
+           AND (?2 IS NULL OR channel_id = ?2)
+           AND (?3 IS NULL OR status = ?3)
+         GROUP BY COALESCE(status, 'unknown')
+         ORDER BY violation_count DESC, invariant ASC",
+    )?;
+    let rows = stmt.query_map(
+        libsql_rusqlite::params![
+            filters.provider.as_deref(),
+            filters.channel_id.as_deref(),
+            filters.invariant.as_deref(),
+        ],
+        |row| {
+            Ok(InvariantViolationCount {
+                invariant: row.get(0)?,
+                count: row.get::<_, i64>(1)?.max(0) as u64,
+            })
+        },
+    )?;
+    Ok(rows.collect::<libsql_rusqlite::Result<Vec<_>>>()?)
+}
+
+fn query_invariant_events_sqlite(
+    conn: &Connection,
+    filters: &InvariantAnalyticsFilters,
+    limit: usize,
+) -> Result<Vec<InvariantViolationRecord>> {
+    let mut stmt = conn.prepare(
+        "SELECT id,
+                provider,
+                channel_id,
+                dispatch_id,
+                session_key,
+                turn_id,
+                status,
+                payload_json,
+                datetime(created_at, '+9 hours') AS created_at_kst
+         FROM observability_events
+         WHERE event_type = 'invariant_violation'
+           AND (?1 IS NULL OR provider = ?1)
+           AND (?2 IS NULL OR channel_id = ?2)
+           AND (?3 IS NULL OR status = ?3)
+         ORDER BY id DESC
+         LIMIT ?4",
+    )?;
+    let rows = stmt.query_map(
+        libsql_rusqlite::params![
+            filters.provider.as_deref(),
+            filters.channel_id.as_deref(),
+            filters.invariant.as_deref(),
+            limit as i64,
+        ],
+        |row| {
+            let payload_json: Option<String> = row.get(7)?;
+            let payload = payload_json
+                .as_deref()
+                .and_then(|value| serde_json::from_str::<Value>(value).ok())
+                .unwrap_or_else(|| json!({}));
+            let invariant = row
+                .get::<_, Option<String>>(6)?
+                .or_else(|| payload.get("invariant").and_then(value_as_string))
+                .unwrap_or_else(|| "unknown".to_string());
+            Ok(invariant_record_from_parts(
+                row.get(0)?,
+                invariant,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+                row.get(5)?,
+                payload,
+                row.get::<_, Option<String>>(8)?.unwrap_or_default(),
+            ))
+        },
+    )?;
+    Ok(rows.collect::<libsql_rusqlite::Result<Vec<_>>>()?)
+}
+
 async fn query_events_pg(
     pool: &PgPool,
     filters: &AnalyticsFilters,
@@ -953,6 +1190,110 @@ async fn query_events_pg(
                     .try_get("created_at_kst")
                     .map_err(|error| anyhow!("decode observability created_at: {error}"))?,
             })
+        })
+        .collect()
+}
+
+async fn query_invariant_counts_pg(
+    pool: &PgPool,
+    filters: &InvariantAnalyticsFilters,
+) -> Result<Vec<InvariantViolationCount>> {
+    let rows = sqlx::query(
+        "SELECT COALESCE(status, 'unknown') AS invariant,
+                COUNT(*) AS violation_count
+         FROM observability_events
+         WHERE event_type = 'invariant_violation'
+           AND ($1::text IS NULL OR provider = $1)
+           AND ($2::text IS NULL OR channel_id = $2)
+           AND ($3::text IS NULL OR status = $3)
+         GROUP BY COALESCE(status, 'unknown')
+         ORDER BY violation_count DESC, invariant ASC",
+    )
+    .bind(filters.provider.as_deref())
+    .bind(filters.channel_id.as_deref())
+    .bind(filters.invariant.as_deref())
+    .fetch_all(pool)
+    .await
+    .map_err(|error| anyhow!("query postgres invariant counts: {error}"))?;
+
+    rows.into_iter()
+        .map(|row| {
+            Ok(InvariantViolationCount {
+                invariant: row
+                    .try_get("invariant")
+                    .map_err(|error| anyhow!("decode invariant: {error}"))?,
+                count: row
+                    .try_get::<i64, _>("violation_count")
+                    .map_err(|error| anyhow!("decode violation_count: {error}"))?
+                    .max(0) as u64,
+            })
+        })
+        .collect()
+}
+
+async fn query_invariant_events_pg(
+    pool: &PgPool,
+    filters: &InvariantAnalyticsFilters,
+    limit: usize,
+) -> Result<Vec<InvariantViolationRecord>> {
+    let rows = sqlx::query(
+        "SELECT id,
+                provider,
+                channel_id,
+                dispatch_id,
+                session_key,
+                turn_id,
+                status,
+                payload_json::text AS payload_json,
+                to_char(created_at AT TIME ZONE 'Asia/Seoul', 'YYYY-MM-DD HH24:MI:SS') AS created_at_kst
+         FROM observability_events
+         WHERE event_type = 'invariant_violation'
+           AND ($1::text IS NULL OR provider = $1)
+           AND ($2::text IS NULL OR channel_id = $2)
+           AND ($3::text IS NULL OR status = $3)
+         ORDER BY id DESC
+         LIMIT $4",
+    )
+    .bind(filters.provider.as_deref())
+    .bind(filters.channel_id.as_deref())
+    .bind(filters.invariant.as_deref())
+    .bind(limit as i64)
+    .fetch_all(pool)
+    .await
+    .map_err(|error| anyhow!("query postgres invariant events: {error}"))?;
+
+    rows.into_iter()
+        .map(|row| {
+            let payload_json: Option<String> = row
+                .try_get("payload_json")
+                .map_err(|error| anyhow!("decode invariant payload_json: {error}"))?;
+            let payload = payload_json
+                .as_deref()
+                .and_then(|value| serde_json::from_str::<Value>(value).ok())
+                .unwrap_or_else(|| json!({}));
+            let invariant = row
+                .try_get::<Option<String>, _>("status")
+                .map_err(|error| anyhow!("decode invariant status: {error}"))?
+                .or_else(|| payload.get("invariant").and_then(value_as_string))
+                .unwrap_or_else(|| "unknown".to_string());
+            Ok(invariant_record_from_parts(
+                row.try_get("id")
+                    .map_err(|error| anyhow!("decode invariant event id: {error}"))?,
+                invariant,
+                row.try_get("provider")
+                    .map_err(|error| anyhow!("decode invariant provider: {error}"))?,
+                row.try_get("channel_id")
+                    .map_err(|error| anyhow!("decode invariant channel_id: {error}"))?,
+                row.try_get("dispatch_id")
+                    .map_err(|error| anyhow!("decode invariant dispatch_id: {error}"))?,
+                row.try_get("session_key")
+                    .map_err(|error| anyhow!("decode invariant session_key: {error}"))?,
+                row.try_get("turn_id")
+                    .map_err(|error| anyhow!("decode invariant turn_id: {error}"))?,
+                payload,
+                row.try_get("created_at_kst")
+                    .map_err(|error| anyhow!("decode invariant created_at: {error}"))?,
+            ))
         })
         .collect()
 }
@@ -1507,6 +1848,42 @@ fn normalize_quality_event_type(value: &str) -> Option<String> {
         .then_some(normalized)
 }
 
+fn value_as_string(value: &Value) -> Option<String> {
+    value
+        .as_str()
+        .map(str::to_string)
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn invariant_record_from_parts(
+    id: i64,
+    invariant: String,
+    provider: Option<String>,
+    channel_id: Option<String>,
+    dispatch_id: Option<String>,
+    session_key: Option<String>,
+    turn_id: Option<String>,
+    payload: Value,
+    created_at: String,
+) -> InvariantViolationRecord {
+    let message = payload.get("message").and_then(value_as_string);
+    let code_location = payload.get("code_location").and_then(value_as_string);
+    let details = payload.get("details").cloned().unwrap_or_else(|| json!({}));
+    InvariantViolationRecord {
+        id,
+        invariant,
+        provider,
+        channel_id,
+        dispatch_id,
+        session_key,
+        turn_id,
+        message,
+        code_location,
+        details,
+        created_at,
+    }
+}
+
 fn normalized_event_limit(limit: usize) -> usize {
     match limit {
         0 => DEFAULT_EVENT_LIMIT,
@@ -1518,6 +1895,13 @@ fn normalized_counter_limit(limit: usize) -> usize {
     match limit {
         0 => DEFAULT_COUNTER_LIMIT,
         value => value.min(MAX_COUNTER_LIMIT),
+    }
+}
+
+fn normalized_invariant_limit(limit: usize) -> usize {
+    match limit {
+        0 => DEFAULT_INVARIANT_LIMIT,
+        value => value.min(MAX_INVARIANT_LIMIT),
     }
 }
 
@@ -1645,6 +2029,102 @@ mod tests {
                 .events
                 .iter()
                 .any(|event| event.event_type == "turn_finished")
+        );
+    }
+
+    #[tokio::test]
+    async fn invariant_true_check_does_not_record_violation() {
+        let _guard = test_runtime_lock();
+        reset_for_tests();
+        let db = crate::db::test_db();
+        init_observability(db.clone(), None);
+
+        assert!(record_invariant_check(
+            true,
+            InvariantViolation {
+                provider: Some("codex"),
+                channel_id: Some(7),
+                dispatch_id: None,
+                session_key: None,
+                turn_id: Some("discord:7:70"),
+                invariant: "response_sent_offset_monotonic",
+                code_location: "src/services/discord/turn_bridge/mod.rs:test",
+                message: "known-true invariant check should not emit",
+                details: json!({
+                    "previous": 8,
+                    "next": 12,
+                }),
+            },
+        ));
+        flush_for_tests().await;
+
+        let response = query_invariant_analytics(
+            &db,
+            None,
+            &InvariantAnalyticsFilters {
+                provider: Some("codex".to_string()),
+                channel_id: Some("7".to_string()),
+                invariant: Some("response_sent_offset_monotonic".to_string()),
+                limit: 10,
+            },
+        )
+        .await
+        .expect("query invariant analytics");
+
+        assert_eq!(response.total_violations, 0);
+        assert!(response.counts.is_empty());
+        assert!(response.recent.is_empty());
+    }
+
+    #[tokio::test]
+    async fn invariant_violation_emit_and_query_round_trip() {
+        let _guard = test_runtime_lock();
+        reset_for_tests();
+        let db = crate::db::test_db();
+        init_observability(db.clone(), None);
+
+        assert!(!record_invariant_check(
+            false,
+            InvariantViolation {
+                provider: Some("claude"),
+                channel_id: Some(42),
+                dispatch_id: Some("dispatch-invariant"),
+                session_key: Some("host:session"),
+                turn_id: Some("discord:42:420"),
+                invariant: "inflight_tmux_one_to_one",
+                code_location: "src/services/discord/inflight.rs:test",
+                message: "test violation",
+                details: json!({
+                    "tmux_session_name": "AgentDesk-claude-test",
+                }),
+            },
+        ));
+        flush_for_tests().await;
+
+        let response = query_invariant_analytics(
+            &db,
+            None,
+            &InvariantAnalyticsFilters {
+                provider: Some("claude".to_string()),
+                channel_id: Some("42".to_string()),
+                invariant: Some("inflight_tmux_one_to_one".to_string()),
+                limit: 10,
+            },
+        )
+        .await
+        .expect("query invariant analytics");
+
+        assert_eq!(response.total_violations, 1);
+        assert_eq!(response.counts[0].invariant, "inflight_tmux_one_to_one");
+        assert_eq!(response.counts[0].count, 1);
+        assert_eq!(response.recent.len(), 1);
+        assert_eq!(
+            response.recent[0].message.as_deref(),
+            Some("test violation")
+        );
+        assert_eq!(
+            response.recent[0].details["tmux_session_name"],
+            "AgentDesk-claude-test"
         );
     }
 


### PR DESCRIPTION
## Summary

Wave 4B Batch 2 — adds `docs/invariants.md` with runtime invariant specs and code pointers. Adds `debug_assert` guards at critical invariant check points in inflight / tmux watcher / turn_bridge. Invariant violations emit via observability as structured events and surface through `GET /api/analytics/invariants` (admin-gated).

## Related
- Closes #1036
- Part of Wave 4B Batch 2 — parent epic #905

## Test plan
- [x] `cargo check --bin agentdesk --tests` — 0 errors
- [x] `cargo test invariant -- --test-threads=1` — 3/3 pass (true check / violation emit / route round-trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)