### PR TITLE
Add maintenance job scheduler infra + trivial seed job (#1038)

### DIFF
--- a/src/server/maintenance.rs
+++ b/src/server/maintenance.rs
@@ -1,0 +1,701 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, TimeZone, Utc};
+use libsql_rusqlite::OptionalExtension;
+use serde::Serialize;
+use sqlx::{PgPool, Row};
+
+use crate::db::Db;
+
+type MaintenanceFuture<'a> = Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
+type StoreFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, String>> + Send + 'a>>;
+
+const DEFAULT_SCHEDULER_TICK: Duration = Duration::from_secs(1);
+const EXTRA_STAGGER_PER_JOB: Duration = Duration::from_secs(15);
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct MaintenanceSchedule {
+    every: Duration,
+    startup_stagger: Duration,
+}
+
+impl MaintenanceSchedule {
+    pub(crate) const fn every(every: Duration, startup_stagger: Duration) -> Self {
+        Self {
+            every,
+            startup_stagger,
+        }
+    }
+
+    fn every_ms(self) -> i64 {
+        duration_millis_i64(self.every)
+    }
+
+    fn startup_stagger_ms(self) -> i64 {
+        duration_millis_i64(self.startup_stagger)
+    }
+}
+
+pub(crate) trait MaintenanceJob: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn schedule(&self) -> MaintenanceSchedule;
+    fn run<'a>(&'a self, pool: &'a PgPool) -> MaintenanceFuture<'a>;
+}
+
+#[derive(Clone)]
+pub(crate) struct MaintenanceJobRegistry {
+    jobs: Arc<Vec<Arc<dyn MaintenanceJob>>>,
+}
+
+impl MaintenanceJobRegistry {
+    pub(crate) fn new(jobs: Vec<Arc<dyn MaintenanceJob>>) -> Self {
+        Self {
+            jobs: Arc::new(jobs),
+        }
+    }
+
+    fn static_registry() -> Self {
+        Self::new(vec![Arc::new(NoopHeartbeatJob)])
+    }
+
+    fn jobs(&self) -> &[Arc<dyn MaintenanceJob>] {
+        self.jobs.as_ref().as_slice()
+    }
+}
+
+struct NoopHeartbeatJob;
+
+impl MaintenanceJob for NoopHeartbeatJob {
+    fn name(&self) -> &'static str {
+        "maintenance.noop_heartbeat"
+    }
+
+    fn schedule(&self) -> MaintenanceSchedule {
+        MaintenanceSchedule::every(Duration::from_secs(15 * 60), Duration::from_secs(10))
+    }
+
+    fn run<'a>(&'a self, pool: &'a PgPool) -> MaintenanceFuture<'a> {
+        Box::pin(async move {
+            let _ = pool;
+            tracing::info!(job = self.name(), "maintenance noop heartbeat fired");
+            Ok(())
+        })
+    }
+}
+
+trait MaintenanceJobStore: Send + Sync {
+    fn read<'a>(&'a self, key: &'a str) -> StoreFuture<'a, Option<String>>;
+    fn upsert<'a>(&'a self, key: &'a str, value: &'a str) -> StoreFuture<'a, ()>;
+}
+
+struct PgMaintenanceJobStore {
+    pool: PgPool,
+}
+
+impl PgMaintenanceJobStore {
+    fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+impl MaintenanceJobStore for PgMaintenanceJobStore {
+    fn read<'a>(&'a self, key: &'a str) -> StoreFuture<'a, Option<String>> {
+        Box::pin(async move {
+            let row = sqlx::query("SELECT value FROM kv_meta WHERE key = $1")
+                .bind(key)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|error| format!("read maintenance kv_meta {key}: {error}"))?;
+
+            match row {
+                Some(row) => row
+                    .try_get::<Option<String>, _>("value")
+                    .map_err(|error| format!("decode maintenance kv_meta {key}: {error}")),
+                None => Ok(None),
+            }
+        })
+    }
+
+    fn upsert<'a>(&'a self, key: &'a str, value: &'a str) -> StoreFuture<'a, ()> {
+        Box::pin(async move {
+            sqlx::query(
+                "INSERT INTO kv_meta (key, value)
+                 VALUES ($1, $2)
+                 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value",
+            )
+            .bind(key)
+            .bind(value)
+            .execute(&self.pool)
+            .await
+            .map(|_| ())
+            .map_err(|error| format!("upsert maintenance kv_meta {key}: {error}"))
+        })
+    }
+}
+
+struct SqliteMaintenanceJobStore {
+    db: Db,
+}
+
+impl SqliteMaintenanceJobStore {
+    fn new(db: Db) -> Self {
+        Self { db }
+    }
+}
+
+impl MaintenanceJobStore for SqliteMaintenanceJobStore {
+    fn read<'a>(&'a self, key: &'a str) -> StoreFuture<'a, Option<String>> {
+        Box::pin(async move {
+            let conn = self
+                .db
+                .lock()
+                .map_err(|error| format!("lock sqlite maintenance store: {error}"))?;
+            conn.query_row("SELECT value FROM kv_meta WHERE key = ?1", [key], |row| {
+                row.get::<_, Option<String>>(0)
+            })
+            .optional()
+            .map_err(|error| format!("read sqlite maintenance kv_meta {key}: {error}"))
+            .map(|value| value.flatten())
+        })
+    }
+
+    fn upsert<'a>(&'a self, key: &'a str, value: &'a str) -> StoreFuture<'a, ()> {
+        Box::pin(async move {
+            let conn = self
+                .db
+                .lock()
+                .map_err(|error| format!("lock sqlite maintenance store: {error}"))?;
+            conn.execute(
+                "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?1, ?2)",
+                libsql_rusqlite::params![key, value],
+            )
+            .map(|_| ())
+            .map_err(|error| format!("upsert sqlite maintenance kv_meta {key}: {error}"))
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct MaintenanceJobStatus {
+    id: String,
+    name: String,
+    enabled: bool,
+    schedule: MaintenanceScheduleStatus,
+    state: MaintenanceJobState,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MaintenanceScheduleStatus {
+    kind: &'static str,
+    every_ms: i64,
+    startup_stagger_ms: i64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MaintenanceJobState {
+    status: &'static str,
+    last_status: String,
+    last_run_at_ms: Option<i64>,
+    last_run_at: Option<String>,
+    next_run_at_ms: Option<i64>,
+    next_run_at: Option<String>,
+    last_duration_ms: Option<i64>,
+    last_error: Option<String>,
+    run_count: i64,
+    failure_count: i64,
+}
+
+pub(crate) async fn scheduler_loop(pg_pool: Arc<PgPool>) {
+    let registry = MaintenanceJobRegistry::static_registry();
+    let store: Arc<dyn MaintenanceJobStore> =
+        Arc::new(PgMaintenanceJobStore::new(pg_pool.as_ref().clone()));
+
+    tracing::info!(
+        job_count = registry.jobs().len(),
+        "maintenance scheduler started"
+    );
+    run_scheduler_loop(
+        pg_pool.as_ref().clone(),
+        registry,
+        store,
+        DEFAULT_SCHEDULER_TICK,
+        None,
+    )
+    .await;
+}
+
+pub(crate) async fn list_job_statuses_pg(pg_pool: PgPool) -> Vec<MaintenanceJobStatus> {
+    let store: Arc<dyn MaintenanceJobStore> = Arc::new(PgMaintenanceJobStore::new(pg_pool));
+    build_job_statuses(&MaintenanceJobRegistry::static_registry(), store).await
+}
+
+pub(crate) async fn list_job_statuses_sqlite(db: Db) -> Vec<MaintenanceJobStatus> {
+    let store: Arc<dyn MaintenanceJobStore> = Arc::new(SqliteMaintenanceJobStore::new(db));
+    build_job_statuses(&MaintenanceJobRegistry::static_registry(), store).await
+}
+
+async fn run_scheduler_loop(
+    pg_pool: PgPool,
+    registry: MaintenanceJobRegistry,
+    store: Arc<dyn MaintenanceJobStore>,
+    tick_interval: Duration,
+    max_completed_runs: Option<usize>,
+) {
+    let mut next_runs = initialize_next_runs(&registry, store.clone()).await;
+    let mut completed_runs = 0usize;
+
+    loop {
+        let now = Utc::now();
+        for (index, job) in registry.jobs().iter().enumerate() {
+            let job_name = job.name().to_string();
+            let next_run = match next_runs.get(&job_name).copied() {
+                Some(value) => value,
+                None => startup_next_run(job.schedule(), None, now, index),
+            };
+
+            if now < next_run {
+                continue;
+            }
+
+            run_job_once(pg_pool.clone(), job.clone(), store.clone()).await;
+            completed_runs = completed_runs.saturating_add(1);
+
+            let next = add_duration(Utc::now(), job.schedule().every);
+            next_runs.insert(job_name, next);
+            write_metric_ignore(
+                store.as_ref(),
+                &kv_key(job.name(), "next_run_ms"),
+                &datetime_to_millis(next).to_string(),
+            )
+            .await;
+
+            if max_completed_runs.is_some_and(|limit| completed_runs >= limit) {
+                return;
+            }
+        }
+
+        tokio::time::sleep(tick_interval).await;
+    }
+}
+
+async fn initialize_next_runs(
+    registry: &MaintenanceJobRegistry,
+    store: Arc<dyn MaintenanceJobStore>,
+) -> std::collections::HashMap<String, DateTime<Utc>> {
+    let now = Utc::now();
+    let mut next_runs = std::collections::HashMap::new();
+
+    for (index, job) in registry.jobs().iter().enumerate() {
+        let last_run_ms = read_i64(store.as_ref(), &kv_key(job.name(), "last_run_ms")).await;
+        let last_run = last_run_ms.and_then(datetime_from_millis);
+        let next_run = startup_next_run(job.schedule(), last_run, now, index);
+
+        write_metric_ignore(
+            store.as_ref(),
+            &kv_key(job.name(), "next_run_ms"),
+            &datetime_to_millis(next_run).to_string(),
+        )
+        .await;
+        next_runs.insert(job.name().to_string(), next_run);
+    }
+
+    next_runs
+}
+
+async fn run_job_once(
+    pg_pool: PgPool,
+    job: Arc<dyn MaintenanceJob>,
+    store: Arc<dyn MaintenanceJobStore>,
+) {
+    let started_at = Utc::now();
+    let start = Instant::now();
+    let job_name = job.name();
+    let started_ms = datetime_to_millis(started_at).to_string();
+
+    tracing::info!(
+        job = job_name,
+        every_ms = job.schedule().every_ms(),
+        "maintenance job started"
+    );
+
+    write_metric_ignore(store.as_ref(), &kv_key(job_name, "last_status"), "running").await;
+    write_metric_ignore(
+        store.as_ref(),
+        &kv_key(job_name, "last_started_ms"),
+        &started_ms,
+    )
+    .await;
+
+    let result = job.run(&pg_pool).await;
+    let elapsed = start.elapsed();
+    let elapsed_ms = duration_millis_i64(elapsed).to_string();
+    let finished_ms = datetime_to_millis(Utc::now()).to_string();
+
+    increment_counter(store.as_ref(), &kv_key(job_name, "run_count")).await;
+    write_metric_ignore(
+        store.as_ref(),
+        &kv_key(job_name, "last_run_ms"),
+        &finished_ms,
+    )
+    .await;
+    write_metric_ignore(
+        store.as_ref(),
+        &kv_key(job_name, "last_duration_ms"),
+        &elapsed_ms,
+    )
+    .await;
+
+    match result {
+        Ok(()) => {
+            write_metric_ignore(store.as_ref(), &kv_key(job_name, "last_status"), "ok").await;
+            write_metric_ignore(store.as_ref(), &kv_key(job_name, "last_error"), "").await;
+            tracing::info!(
+                job = job_name,
+                duration_ms = duration_millis_i64(elapsed),
+                outcome = "ok",
+                "maintenance job completed"
+            );
+        }
+        Err(error) => {
+            let message = error.to_string();
+            increment_counter(store.as_ref(), &kv_key(job_name, "failure_count")).await;
+            write_metric_ignore(store.as_ref(), &kv_key(job_name, "last_status"), "error").await;
+            write_metric_ignore(store.as_ref(), &kv_key(job_name, "last_error"), &message).await;
+            tracing::warn!(
+                job = job_name,
+                duration_ms = duration_millis_i64(elapsed),
+                outcome = "error",
+                error = %message,
+                "maintenance job completed"
+            );
+        }
+    }
+}
+
+async fn build_job_statuses(
+    registry: &MaintenanceJobRegistry,
+    store: Arc<dyn MaintenanceJobStore>,
+) -> Vec<MaintenanceJobStatus> {
+    let mut statuses = Vec::with_capacity(registry.jobs().len());
+    let now = Utc::now();
+
+    for (index, job) in registry.jobs().iter().enumerate() {
+        let last_run_ms = read_i64(store.as_ref(), &kv_key(job.name(), "last_run_ms")).await;
+        let persisted_next_ms = read_i64(store.as_ref(), &kv_key(job.name(), "next_run_ms")).await;
+        let last_duration_ms =
+            read_i64(store.as_ref(), &kv_key(job.name(), "last_duration_ms")).await;
+        let run_count = match read_i64(store.as_ref(), &kv_key(job.name(), "run_count")).await {
+            Some(value) => value,
+            None => 0,
+        };
+        let failure_count =
+            match read_i64(store.as_ref(), &kv_key(job.name(), "failure_count")).await {
+                Some(value) => value,
+                None => 0,
+            };
+        let last_status = match read_string(store.as_ref(), &kv_key(job.name(), "last_status"))
+            .await
+            .filter(|value| !value.trim().is_empty())
+        {
+            Some(value) => value,
+            None => "never".to_string(),
+        };
+        let last_error = read_string(store.as_ref(), &kv_key(job.name(), "last_error"))
+            .await
+            .filter(|value| !value.trim().is_empty());
+
+        let fallback_next = startup_next_run(
+            job.schedule(),
+            last_run_ms.and_then(datetime_from_millis),
+            now,
+            index,
+        );
+        let next_run_ms = persisted_next_ms.or_else(|| Some(datetime_to_millis(fallback_next)));
+
+        statuses.push(MaintenanceJobStatus {
+            id: job.name().to_string(),
+            name: job.name().to_string(),
+            enabled: true,
+            schedule: MaintenanceScheduleStatus {
+                kind: "every",
+                every_ms: job.schedule().every_ms(),
+                startup_stagger_ms: job.schedule().startup_stagger_ms(),
+            },
+            state: MaintenanceJobState {
+                status: "active",
+                last_status,
+                last_run_at_ms: last_run_ms,
+                last_run_at: last_run_ms.and_then(datetime_millis_to_rfc3339),
+                next_run_at_ms: next_run_ms,
+                next_run_at: next_run_ms.and_then(datetime_millis_to_rfc3339),
+                last_duration_ms,
+                last_error,
+                run_count,
+                failure_count,
+            },
+        });
+    }
+
+    statuses
+}
+
+async fn read_i64(store: &dyn MaintenanceJobStore, key: &str) -> Option<i64> {
+    match store.read(key).await {
+        Ok(Some(value)) => value.parse::<i64>().ok(),
+        Ok(None) => None,
+        Err(error) => {
+            tracing::warn!("[maintenance] failed to read {key}: {error}");
+            None
+        }
+    }
+}
+
+async fn read_string(store: &dyn MaintenanceJobStore, key: &str) -> Option<String> {
+    match store.read(key).await {
+        Ok(value) => value,
+        Err(error) => {
+            tracing::warn!("[maintenance] failed to read {key}: {error}");
+            None
+        }
+    }
+}
+
+async fn write_metric_ignore(store: &dyn MaintenanceJobStore, key: &str, value: &str) {
+    if let Err(error) = store.upsert(key, value).await {
+        tracing::warn!("[maintenance] failed to write {key}: {error}");
+    }
+}
+
+async fn increment_counter(store: &dyn MaintenanceJobStore, key: &str) {
+    let current = match read_i64(store, key).await {
+        Some(value) => value,
+        None => 0,
+    };
+    let next = current.saturating_add(1).to_string();
+    write_metric_ignore(store, key, &next).await;
+}
+
+fn startup_next_run(
+    schedule: MaintenanceSchedule,
+    last_run: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+    index: usize,
+) -> DateTime<Utc> {
+    if let Some(next_after_last) = last_run.map(|last| add_duration(last, schedule.every)) {
+        if next_after_last > now {
+            return next_after_last;
+        }
+    }
+
+    add_duration(
+        now,
+        startup_stagger_for_index(schedule.startup_stagger, index),
+    )
+}
+
+fn startup_stagger_for_index(base: Duration, index: usize) -> Duration {
+    let index_u32 = match u32::try_from(index) {
+        Ok(value) => value,
+        Err(_) => u32::MAX,
+    };
+    base.saturating_add(EXTRA_STAGGER_PER_JOB.saturating_mul(index_u32))
+}
+
+fn add_duration(at: DateTime<Utc>, duration: Duration) -> DateTime<Utc> {
+    let chrono_duration = chrono::Duration::milliseconds(duration_millis_i64(duration));
+    match at.checked_add_signed(chrono_duration) {
+        Some(value) => value,
+        None => at,
+    }
+}
+
+fn duration_millis_i64(duration: Duration) -> i64 {
+    match i64::try_from(duration.as_millis()) {
+        Ok(value) => value,
+        Err(_) => i64::MAX,
+    }
+}
+
+fn datetime_to_millis(value: DateTime<Utc>) -> i64 {
+    value.timestamp_millis()
+}
+
+fn datetime_from_millis(value: i64) -> Option<DateTime<Utc>> {
+    Utc.timestamp_millis_opt(value).single()
+}
+
+fn datetime_millis_to_rfc3339(value: i64) -> Option<String> {
+    datetime_from_millis(value).map(|datetime| datetime.to_rfc3339())
+}
+
+fn kv_key(job_name: &str, field: &str) -> String {
+    format!("maintenance_job:{job_name}:{field}")
+}
+
+#[cfg(test)]
+async fn run_scheduler_loop_for_test(
+    pg_pool: PgPool,
+    registry: MaintenanceJobRegistry,
+    store: Arc<dyn MaintenanceJobStore>,
+    tick_interval: Duration,
+    max_completed_runs: usize,
+) {
+    run_scheduler_loop(
+        pg_pool,
+        registry,
+        store,
+        tick_interval,
+        Some(max_completed_runs),
+    )
+    .await;
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct InMemoryMaintenanceJobStore {
+    values: tokio::sync::Mutex<std::collections::HashMap<String, String>>,
+}
+
+#[cfg(test)]
+impl MaintenanceJobStore for InMemoryMaintenanceJobStore {
+    fn read<'a>(&'a self, key: &'a str) -> StoreFuture<'a, Option<String>> {
+        Box::pin(async move {
+            let values = self.values.lock().await;
+            Ok(values.get(key).cloned())
+        })
+    }
+
+    fn upsert<'a>(&'a self, key: &'a str, value: &'a str) -> StoreFuture<'a, ()> {
+        Box::pin(async move {
+            let mut values = self.values.lock().await;
+            values.insert(key.to_string(), value.to_string());
+            Ok(())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
+    use std::io::{self, Write};
+    use std::sync::Mutex;
+
+    struct FastLogJob;
+
+    impl MaintenanceJob for FastLogJob {
+        fn name(&self) -> &'static str {
+            "test.fast_log"
+        }
+
+        fn schedule(&self) -> MaintenanceSchedule {
+            MaintenanceSchedule::every(Duration::from_secs(60), Duration::from_millis(1))
+        }
+
+        fn run<'a>(&'a self, pool: &'a PgPool) -> MaintenanceFuture<'a> {
+            Box::pin(async move {
+                let _ = pool;
+                tracing::info!(job = self.name(), "test maintenance job body ran");
+                Ok(())
+            })
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestLogWriter {
+        buffer: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl Write for TestLogWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            let mut buffer = self
+                .buffer
+                .lock()
+                .map_err(|_| io::Error::new(io::ErrorKind::Other, "log buffer poisoned"))?;
+            buffer.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn scheduler_loop_starts_fires_one_tick_and_logs_outcome() -> Result<(), String> {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let log_buffer = buffer.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .with_ansi(false)
+            .without_time()
+            .with_writer(move || TestLogWriter {
+                buffer: log_buffer.clone(),
+            })
+            .finish();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let pg_pool = PgPoolOptions::new().connect_lazy_with(
+            PgConnectOptions::new()
+                .host("localhost")
+                .username("agentdesk")
+                .database("agentdesk"),
+        );
+        let registry = MaintenanceJobRegistry::new(vec![Arc::new(FastLogJob)]);
+        let store: Arc<dyn MaintenanceJobStore> = Arc::new(InMemoryMaintenanceJobStore::default());
+
+        tokio::time::timeout(
+            Duration::from_millis(250),
+            run_scheduler_loop_for_test(pg_pool, registry, store, Duration::from_millis(1), 1),
+        )
+        .await
+        .map_err(|_| "maintenance scheduler test timed out".to_string())?;
+
+        let captured = {
+            let buffer = buffer
+                .lock()
+                .map_err(|_| "log buffer poisoned".to_string())?;
+            String::from_utf8_lossy(&buffer).to_string()
+        };
+
+        if !captured.contains("maintenance job started")
+            || !captured.contains("maintenance job completed")
+            || !captured.contains("test.fast_log")
+        {
+            return Err(format!(
+                "expected maintenance run logs, captured:\n{captured}"
+            ));
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn status_builder_uses_persisted_next_run() -> Result<(), String> {
+        let registry = MaintenanceJobRegistry::new(vec![Arc::new(FastLogJob)]);
+        let store: Arc<dyn MaintenanceJobStore> = Arc::new(InMemoryMaintenanceJobStore::default());
+        store
+            .upsert(&kv_key("test.fast_log", "next_run_ms"), "1700000000000")
+            .await?;
+
+        let statuses = build_job_statuses(&registry, store).await;
+        let status = statuses
+            .first()
+            .ok_or_else(|| "missing maintenance job status".to_string())?;
+
+        if status.state.next_run_at_ms != Some(1_700_000_000_000) {
+            return Err(format!(
+                "unexpected next run: {:?}",
+                status.state.next_run_at_ms
+            ));
+        }
+
+        Ok(())
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod cron_catalog;
+pub(crate) mod maintenance;
 pub mod routes;
 mod worker_registry;
 pub mod ws;

--- a/src/server/routes/cron_api.rs
+++ b/src/server/routes/cron_api.rs
@@ -134,6 +134,19 @@ async fn build_cron_jobs(state: &AppState, _agent_filter: Option<&str>) -> Vec<s
         }));
     }
 
+    let maintenance_jobs = match state.pg_pool_ref() {
+        Some(pool) => crate::server::maintenance::list_job_statuses_pg(pool.clone()).await,
+        None => crate::server::maintenance::list_job_statuses_sqlite(state.db.clone()).await,
+    };
+    for job in maintenance_jobs {
+        match serde_json::to_value(job) {
+            Ok(value) => jobs.push(value),
+            Err(error) => {
+                tracing::warn!("[cron_api] failed to encode maintenance job status: {error}");
+            }
+        }
+    }
+
     jobs
 }
 

--- a/src/server/routes/domains/ops.rs
+++ b/src/server/routes/domains/ops.rs
@@ -8,8 +8,8 @@ use serde_json::Value;
 
 use super::super::{
     ApiRouter, AppState, auto_queue, cron_api, dispatched_sessions, dispatches, docs, hooks,
-    log_deprecated_alias, messages, pipeline, protected_api_domain, queue_api, skills_api,
-    termination_events,
+    log_deprecated_alias, maintenance, messages, pipeline, protected_api_domain, queue_api,
+    skills_api, termination_events,
 };
 
 // Category: dispatches, queue, and ops
@@ -124,6 +124,7 @@ pub(crate) fn router(state: AppState) -> ApiRouter {
             .route("/skills/ranking", get(skills_api::ranking))
             .route("/skills/prune", post(skills_api::prune))
             .route("/cron-jobs", get(cron_api::list_cron_jobs))
+            .route("/maintenance/jobs", get(maintenance::list_jobs))
             .route("/auto-queue/generate", post(auto_queue::generate))
             .route("/auto-queue/dispatch", post(auto_queue::dispatch))
             .route("/auto-queue/dispatch-next", post(auto_queue::activate))

--- a/src/server/routes/maintenance.rs
+++ b/src/server/routes/maintenance.rs
@@ -1,0 +1,14 @@
+use axum::{Json, extract::State, http::StatusCode};
+use serde_json::json;
+
+use super::AppState;
+
+/// GET /api/maintenance/jobs
+pub async fn list_jobs(State(state): State<AppState>) -> (StatusCode, Json<serde_json::Value>) {
+    let jobs = match state.pg_pool_ref() {
+        Some(pool) => crate::server::maintenance::list_job_statuses_pg(pool.clone()).await,
+        None => crate::server::maintenance::list_job_statuses_sqlite(state.db.clone()).await,
+    };
+
+    (StatusCode::OK, Json(json!({ "jobs": jobs })))
+}

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -19,6 +19,7 @@ pub mod health_api;
 pub mod hooks;
 pub mod kanban;
 pub mod kanban_repos;
+mod maintenance;
 pub mod meetings;
 pub mod messages;
 pub mod monitoring;

--- a/src/server/routes/routes_tests.rs
+++ b/src/server/routes/routes_tests.rs
@@ -8144,6 +8144,83 @@ async fn cron_jobs_include_github_issue_card_sync_job() {
 }
 
 #[tokio::test]
+async fn maintenance_jobs_endpoint_lists_seed_job() -> Result<(), Box<dyn std::error::Error>> {
+    let db = test_db();
+    {
+        let conn = db.lock()?;
+        conn.execute(
+            "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?1, ?2)",
+            libsql_rusqlite::params![
+                "maintenance_job:maintenance.noop_heartbeat:next_run_ms",
+                "1700000000000"
+            ],
+        )?;
+    }
+    let engine = test_engine(&db);
+    let app = test_api_router(db, engine, None);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/maintenance/jobs")
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await?;
+    let json: serde_json::Value = serde_json::from_slice(&body)?;
+    let jobs = json["jobs"].as_array().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "maintenance response must include jobs array",
+        )
+    })?;
+    let noop_job = jobs
+        .iter()
+        .find(|job| job["id"] == "maintenance.noop_heartbeat")
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "maintenance response must include noop heartbeat job",
+            )
+        })?;
+
+    assert_eq!(noop_job["schedule"]["kind"], "every");
+    assert_eq!(noop_job["schedule"]["everyMs"], 900000);
+    assert_eq!(
+        noop_job["state"]["nextRunAtMs"],
+        json!(1_700_000_000_000i64)
+    );
+
+    let cron_response = app
+        .oneshot(Request::builder().uri("/cron-jobs").body(Body::empty())?)
+        .await?;
+    assert_eq!(cron_response.status(), StatusCode::OK);
+    let cron_body = axum::body::to_bytes(cron_response.into_body(), usize::MAX).await?;
+    let cron_json: serde_json::Value = serde_json::from_slice(&cron_body)?;
+    let cron_jobs = cron_json["jobs"].as_array().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "cron response must include jobs array",
+        )
+    })?;
+    let cron_maintenance_job = cron_jobs
+        .iter()
+        .find(|job| job["id"] == "maintenance.noop_heartbeat")
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "cron response must include noop maintenance job",
+            )
+        })?;
+    assert_eq!(cron_maintenance_job["state"]["status"], "active");
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn github_repos_pg_sync_closes_card_and_cleans_live_state() {
     crate::pipeline::ensure_loaded();
     let terminal = crate::pipeline::try_get()

--- a/src/server/worker_registry.rs
+++ b/src/server/worker_registry.rs
@@ -44,6 +44,7 @@ enum ServerWorkerId {
     GithubSync,
     PolicyTick,
     RateLimitSync,
+    MaintenanceScheduler,
     MessageOutbox,
     DispatchOutbox,
     DmReplyRetry,
@@ -130,7 +131,7 @@ pub(crate) struct WorkerSpec {
     pub(crate) notes: &'static str,
 }
 
-pub(crate) const WORKER_SPECS: [WorkerSpec; 7] = [
+pub(crate) const WORKER_SPECS: [WorkerSpec; 8] = [
     WorkerSpec {
         id: ServerWorkerId::GithubSync,
         name: "github_sync_loop",
@@ -172,6 +173,20 @@ pub(crate) const WORKER_SPECS: [WorkerSpec; 7] = [
         shutdown_policy: WorkerShutdownPolicy::RuntimeShutdown,
         health_owner: "rate_limit_cache freshness and tracing logs",
         notes: "Runs immediately on startup and then every 120 seconds",
+    },
+    WorkerSpec {
+        id: ServerWorkerId::MaintenanceScheduler,
+        name: "maintenance_scheduler_loop",
+        kind: WorkerKind::TokioTask,
+        target: "maintenance::scheduler_loop",
+        responsibility: "Run registered maintenance jobs on interval schedules",
+        owner: "server::worker_registry",
+        start_stage: WorkerStartStage::AfterBootReconcile,
+        start_order: 35,
+        restart_policy: WorkerRestartPolicy::LoopOwned,
+        shutdown_policy: WorkerShutdownPolicy::RuntimeShutdown,
+        health_owner: "kv_meta maintenance_job:* keys and tracing logs",
+        notes: "Static registry seeded with a noop heartbeat; first runs are staggered after startup",
     },
     WorkerSpec {
         id: ServerWorkerId::MessageOutbox,
@@ -391,6 +406,16 @@ impl SupervisedWorkerRegistry {
                 });
                 Ok(None)
             }
+            ServerWorkerId::MaintenanceScheduler => {
+                let Some(maintenance_pg_pool) = self.pg_pool.clone() else {
+                    self.log_skip(spec, "postgres pool unavailable");
+                    return Ok(None);
+                };
+                self.register_tokio(spec, async move {
+                    super::maintenance::scheduler_loop(maintenance_pg_pool).await;
+                });
+                Ok(None)
+            }
             ServerWorkerId::MessageOutbox => {
                 let Some(outbox_pg_pool) = self.pg_pool.clone() else {
                     self.log_skip(spec, "postgres pool unavailable");
@@ -514,7 +539,7 @@ mod tests {
 
     #[test]
     fn long_lived_workers_have_explicit_supervision_metadata() {
-        assert_eq!(WORKER_SPECS.len(), 7);
+        assert_eq!(WORKER_SPECS.len(), 8);
         assert!(
             WORKER_SPECS
                 .windows(2)
@@ -525,7 +550,7 @@ mod tests {
                 .iter()
                 .filter(|spec| spec.start_stage == WorkerStartStage::AfterBootReconcile)
                 .count(),
-            6
+            7
         );
         assert_eq!(
             WORKER_SPECS


### PR DESCRIPTION
## Summary

Wave 4B Batch 2 — adds `MaintenanceJob` trait, static registry, interval-based scheduler running inside dcserver tokio runtime, `kv_meta`-backed last/next run state with restart persistence, start/end/duration/status logs, startup staggering, and `GET /api/maintenance/jobs` endpoint listing next-run per job. Seeds the registry with a trivial noop to prove the infra works. Later phases (#1040 rollup, future log rotation / DB retention) will register their own jobs.

## Related
- Closes #1038
- Part of Wave 4B Batch 2 — parent epic #909 (P2)

## Test plan
- [x] `cargo check --bin agentdesk --tests` — 0 errors
- [x] `cargo test maintenance -- --test-threads=1` — 3/3 pass (scheduler loop / status builder / routes endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)