### PR TITLE
Preserve placeholder body in task-notification suppress for Background/Subagent kinds (#1044)

### DIFF
--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -3913,6 +3913,10 @@ pub(super) async fn tmux_output_watcher_with_restore(
                     tool_state.transcript_events.len(),
                 );
             }
+            let placeholder_preserves_content = matches!(
+                task_notification_kind,
+                Some(TaskNotificationKind::Background | TaskNotificationKind::Subagent)
+            );
             match suppressed_placeholder_action(
                 placeholder_msg_id.is_some(),
                 response_sent_offset,
@@ -3925,7 +3929,17 @@ pub(super) async fn tmux_output_watcher_with_restore(
                     }
                 }
                 SuppressedPlaceholderAction::Edit(content) => {
-                    if let Some(msg_id) = placeholder_msg_id {
+                    if placeholder_preserves_content {
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        tracing::info!(
+                            "  [{ts}] 👁 Task-notification suppress: preserved placeholder body for {} (kind={}, offset {})",
+                            tmux_session_name,
+                            task_notification_kind
+                                .map(TaskNotificationKind::as_str)
+                                .unwrap_or("none"),
+                            data_start_offset
+                        );
+                    } else if let Some(msg_id) = placeholder_msg_id {
                         rate_limit_wait(&shared, channel_id).await;
                         if let Err(error) = channel_id
                             .edit_message(


### PR DESCRIPTION
## Summary

Part C of #1044 — direct fix by maintainer after codex iterations on parts A (#1048 grace) and B (#1050 bridge-guard offset match) proved insufficient in production (marker still appeared).

**Real root cause found**: not the `Active bridge turn guard` path (part B scope). The label replacement actually fires at `src/services/discord/tmux.rs:3902-3957` — the `relay_decision.suppressed` branch for task-notification events.

Log evidence (2026-04-24 17:00:45 / 17:13:41 KST):
```
👁 Suppressed task-notification relay for AgentDesk-claude-adk-cc (kind=background, offset X)
⚠ watcher: inflight state missing
↻ watcher: reattach triggered
```
No `Active bridge turn guard: suppressed duplicate relay` log — so part B's offset-ring protection never ran. The label replacement happens inside the task-notification suppress branch directly.

**Mechanism**: when Claude's mid-turn output contains a `<task-notification>` tag (Background/Subagent kind from Monitor/codex events), `relay_decision.suppressed=true` fires. `suppressed_placeholder_action` then rewrites the placeholder with `SUPPRESSED_INTERNAL_LABEL`, destroying user-visible content already streamed in the same turn (often before any substantive tokens arrived, so the placeholder ends up showing only the label).

**Fix**: in the task-notification suppress branch, skip the Edit action for `Background`/`Subagent` kinds (they are mid-stream events, not terminal). `MonitorAutoTurn` kind keeps current behavior (intentional terminal semantic). `Delete` action for unexposed placeholders unchanged.

## Diff
- `src/services/discord/tmux.rs`: +15/-1

## Guardrails preserved
- #987 placeholder preserve-on-suppress
- #992 terminal-marker replacement for cases where it's genuinely needed (MonitorAutoTurn)
- #1039 heartbeat
- #1044 part A grace window (PR #1048)
- #1044 part B bridge-guard offset match (PR #1050)

## Test plan
- [x] `cargo check --bin agentdesk --tests` — 0 errors
- [x] `cargo test --tests -- services::discord::tmux --test-threads=1` — 100/100 pass
- [ ] Post-deploy observation: 채널 `1479671298497183835`에서 `SUPPRESSED_INTERNAL_LABEL` marker 30분 0건이면 회귀 해소 확인

## Related
- Continues #1044 after parts A (PR #1048) + B (PR #1050) proved narrow-scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)