### PR TITLE
Route Background task_notification turns through direct_send when user-facing content exists (#1058)

### DIFF
--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -332,14 +332,25 @@ fn terminal_relay_decision(
             should_enqueue_notify_outbox: false,
             suppressed: !has_assistant_response,
         },
-        Some(TaskNotificationKind::Subagent | TaskNotificationKind::Background) => {
-            TerminalRelayDecision {
-                should_direct_send: false,
-                should_tag_monitor_origin: false,
-                should_enqueue_notify_outbox: false,
-                suppressed: true,
-            }
-        }
+        Some(TaskNotificationKind::Background) => TerminalRelayDecision {
+            // Background task_notification marks that a background event (Monitor
+            // completion, task_complete, etc.) fired during the turn. The response
+            // after that event is user-facing content and must reach Discord.
+            // Historical behavior suppressed the whole terminal relay, which
+            // caused #1044 A→C: user messages streamed after the tag were lost.
+            should_direct_send: has_assistant_response,
+            should_tag_monitor_origin: false,
+            should_enqueue_notify_outbox: false,
+            suppressed: !has_assistant_response,
+        },
+        Some(TaskNotificationKind::Subagent) => TerminalRelayDecision {
+            // Subagent turn = internal sub-agent reporting to parent. Not routed
+            // to the user-facing channel.
+            should_direct_send: false,
+            should_tag_monitor_origin: false,
+            should_enqueue_notify_outbox: false,
+            suppressed: true,
+        },
         None => TerminalRelayDecision {
             should_direct_send: has_assistant_response,
             should_tag_monitor_origin: false,
@@ -6921,8 +6932,21 @@ mod tests {
                 suppressed: true,
             }
         );
+        // Background kind with assistant response = user-facing content after a
+        // mid-turn background event (e.g. Monitor completion). Must relay (#1058).
         assert_eq!(
             terminal_relay_decision(true, Some(TaskNotificationKind::Background)),
+            super::TerminalRelayDecision {
+                should_direct_send: true,
+                should_tag_monitor_origin: false,
+                should_enqueue_notify_outbox: false,
+                suppressed: false,
+            }
+        );
+        // Background kind without any assistant response = only the tag arrived,
+        // nothing to show user. Suppress.
+        assert_eq!(
+            terminal_relay_decision(false, Some(TaskNotificationKind::Background)),
             super::TerminalRelayDecision {
                 should_direct_send: false,
                 should_tag_monitor_origin: false,


### PR DESCRIPTION
## Summary

Formal fix for #1058 (root cause of #1044 핫픽스 4회 반복). Replaces the A/B/C band-aid chain with a semantic change at the true source — `terminal_relay_decision`.

**Diagnosis** (2026-04-24 17:37 KST 실측 기반):
- User sent a turn. Claude started streaming user-facing response.
- Mid-turn, a background `<task-notification>` tag appeared (Monitor completion event).
- The turn's `task_notification_kind` got merged to `Background` via `merge_task_notification_kind`.
- At turn terminal, `terminal_relay_decision` returned `suppressed=true` for Background → the entire terminal relay was dropped.
- Claude's actual user-facing content (e.g., "PR 2개 준비 완료 A/B/C 선택") never reached Discord.
- Subsequent watcher reattach + bridge guard paths could only preserve the partial placeholder body (previous patches #1048/#1050/#1054), not recover the lost content.

**Fix**: split the merged arm in `terminal_relay_decision`:
- `Subagent` → keep suppressed (genuinely internal).
- `Background` → if `has_assistant_response` = true, route through direct_send (normal user-facing flow). If false, still suppress (only the tag was in the turn).

This allows mid-turn background markers without silently swallowing user-visible content.

## Diff
- `src/services/discord/tmux.rs`: +32 / -8

## Guardrails preserved
- `Subagent` suppression unchanged
- `MonitorAutoTurn` tagged relay unchanged
- `None` (normal turn) unchanged
- #987 / #992 placeholder preserve-on-suppress still applies to the remaining suppressed cases
- #1039 heartbeat unchanged
- #1044 A (PR #1048) grace window, B (PR #1050) bridge-guard offset match, C (PR #1054) task-notification suppress placeholder preserve all remain — they still help for non-Background paths and for `has_response=false` Background edge cases

## Test plan
- [x] `cargo check --bin agentdesk --tests` — 0 errors
- [x] `cargo test services::discord::tmux -- --test-threads=1` — 100/100 pass
- [x] Updated `terminal_relay_decision_suppresses_internal_task_notifications_without_notify_outbox` to assert new Background behavior (true → direct_send, false → suppressed)
- [ ] Post-deploy observation: 채널 `1479671298497183835`에서 내가 Monitor task_complete 받고 응답하는 플로우에서 메시지 누락 0건 (A/B/C 선택지 포함)

## Follow-up
- #1055 DRY consolidation of the 3 placeholder suppression call sites — separate PR after this lands and symptom verified

## Related
- Closes #1058
- Supersedes the iterative hotfix chain #1044 A/B/C (which remains in place as defense-in-depth for edge cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)