### PR TITLE
Strip in-progress spinner indicators on placeholder preserve (#1055 follow-up)

### DIFF
--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -488,9 +488,20 @@ struct PlaceholderSuppressContext<'a> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum PlaceholderSuppressDecision {
     None,
-    Preserve { reason: &'static str },
+    /// Keep the user-facing body already streamed to the placeholder; strip
+    /// the in-progress spinner/status-block suffix so the message is not
+    /// frozen mid-stream. `reason` feeds the observability log only.
+    /// `cleaned_body` is the stripped body that should be written back.
+    Preserve {
+        reason: &'static str,
+        cleaned_body: String,
+    },
     Edit(String),
     Delete,
+}
+
+fn strip_placeholder_indicators_for_preserve(text: &str) -> String {
+    strip_inprogress_indicators(text).trim_end().to_string()
 }
 
 fn decide_placeholder_suppression(
@@ -517,6 +528,7 @@ fn decide_placeholder_suppression(
             if ctx.reattach_offset_match {
                 return PlaceholderSuppressDecision::Preserve {
                     reason: "reattach-offset-match",
+                    cleaned_body: strip_placeholder_indicators_for_preserve(ctx.last_edit_text),
                 };
             }
             match suppressed_placeholder_action(
@@ -546,6 +558,7 @@ fn decide_placeholder_suppression(
                 SuppressedPlaceholderAction::Edit(_) if preserves_body => {
                     PlaceholderSuppressDecision::Preserve {
                         reason: "background-or-subagent-kind",
+                        cleaned_body: strip_placeholder_indicators_for_preserve(ctx.last_edit_text),
                     }
                 }
                 SuppressedPlaceholderAction::Edit(content) => {
@@ -567,13 +580,40 @@ async fn apply_placeholder_suppression(
 ) {
     match decision {
         PlaceholderSuppressDecision::None => {}
-        PlaceholderSuppressDecision::Preserve { reason } => {
+        PlaceholderSuppressDecision::Preserve {
+            reason,
+            cleaned_body,
+        } => {
             let ts = chrono::Local::now().format("%H:%M:%S");
             let detail_suffix = detail.map(|d| format!(" — {d}")).unwrap_or_default();
             tracing::info!(
                 "  [{ts}] 👁 {} preserved placeholder ({reason}){detail_suffix}",
                 origin.log_scope()
             );
+            if let Some(msg_id) = placeholder_msg_id {
+                if cleaned_body.is_empty() {
+                    let _ = channel_id.delete_message(http, msg_id).await;
+                } else {
+                    rate_limit_wait(shared, channel_id).await;
+                    if let Err(error) = channel_id
+                        .edit_message(
+                            http,
+                            msg_id,
+                            serenity::EditMessage::new().content(&cleaned_body),
+                        )
+                        .await
+                    {
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        tracing::warn!(
+                            "  [{ts}] ⚠ {} preserve finalize edit failed for channel {} msg {}: {}",
+                            origin.log_scope(),
+                            channel_id.get(),
+                            msg_id.get(),
+                            error
+                        );
+                    }
+                }
+            }
         }
         PlaceholderSuppressDecision::Delete => {
             if let Some(msg_id) = placeholder_msg_id {
@@ -7167,12 +7207,36 @@ mod tests {
             None,
             true,
         );
-        assert_eq!(
-            decide_placeholder_suppression(&ctx),
+        match decide_placeholder_suppression(&ctx) {
             PlaceholderSuppressDecision::Preserve {
-                reason: "reattach-offset-match"
+                reason: "reattach-offset-match",
+                cleaned_body,
+            } => {
+                assert_eq!(cleaned_body, "already delivered body");
             }
+            other => panic!("expected Preserve reattach-offset-match, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decide_placeholder_suppression_preserve_strips_inprogress_indicators() {
+        let ctx = test_placeholder_suppress_context(
+            PlaceholderSuppressOrigin::ActiveBridgeTurnGuard,
+            Some(MessageId::new(1)),
+            42,
+            "real body\n\n⠼ ⚙ TodoWrite: Todo: 1 pending, 0 in progress, 5 completed\n",
+            "AgentDesk-claude-adk-cc",
+            None,
+            true,
         );
+        match decide_placeholder_suppression(&ctx) {
+            PlaceholderSuppressDecision::Preserve { cleaned_body, .. } => {
+                assert_eq!(cleaned_body, "real body");
+                assert!(!cleaned_body.contains("⠼"));
+                assert!(!cleaned_body.contains("⚙"));
+            }
+            other => panic!("expected Preserve with stripped body, got {other:?}"),
+        }
     }
 
     #[test]
@@ -7205,12 +7269,15 @@ mod tests {
             Some(TaskNotificationKind::Background),
             false,
         );
-        assert_eq!(
-            decide_placeholder_suppression(&ctx),
+        match decide_placeholder_suppression(&ctx) {
             PlaceholderSuppressDecision::Preserve {
-                reason: "background-or-subagent-kind"
+                reason: "background-or-subagent-kind",
+                cleaned_body,
+            } => {
+                assert_eq!(cleaned_body, "live user-facing content");
             }
-        );
+            other => panic!("expected Preserve background-or-subagent-kind, got {other:?}"),
+        }
     }
 
     #[test]
@@ -7224,12 +7291,15 @@ mod tests {
             Some(TaskNotificationKind::Subagent),
             false,
         );
-        assert_eq!(
-            decide_placeholder_suppression(&ctx),
+        match decide_placeholder_suppression(&ctx) {
             PlaceholderSuppressDecision::Preserve {
-                reason: "background-or-subagent-kind"
+                reason: "background-or-subagent-kind",
+                cleaned_body,
+            } => {
+                assert_eq!(cleaned_body, "subagent body");
             }
-        );
+            other => panic!("expected Preserve background-or-subagent-kind, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Post-#1055 regression: Preserve decision left spinner/tool-status indicator lines stuck in the Discord placeholder when suppress fired mid-stream. User reported "플레이스홀더 정리가 안됐어" with a screenshot showing ⋰ spinner pinned to their actual response body.

**Root cause**: #1060 consolidated three sites to decide+apply, and implemented Preserve as a log-only no-op. Before #1060, bridge-guard reattach-match already did the same no-op (originated in #1044B). #1060 made it easier to see but also extended the behavior to task-notification Background/Subagent cases. The common flaw: `rewrite_placeholder_as_terminal_suppressed` (the old path before my #1044A→C hotfix chain) ran `strip_inprogress_indicators` before appending the label; Preserve cases skipped both the strip AND the label. So user content stayed (good) but the spinner indicator stayed too (bad).

**Fix**: Preserve decision carries a pre-stripped `cleaned_body` computed via `strip_inprogress_indicators + trim_end`. Applier edits the placeholder with that cleaned body. Empty → Delete. User content preservation semantics unchanged; only the spinner suffix is removed.

## Diff
- `src/services/discord/tmux.rs`: +83 / -13

## Test plan
- [x] `cargo check --bin agentdesk --tests` — 0 errors
- [x] `cargo test services::discord::tmux -- --test-threads=1` — 107/107 pass (106 existing + 1 new strip assertion)
- [x] Updated unit tests assert `cleaned_body` on bridge-guard reattach-match and task-notification Background/Subagent Preserve paths
- [ ] Post-deploy: screen observation in channel `1479671298497183835` — no ⋰ spinner pinned after message finalization

## Guardrails preserved
- #987 / #992 label replacement for the normal suppress case
- #1039 heartbeat
- #1044 A/B/C defense-in-depth
- #1058 / #1059 terminal_relay_decision Background split
- #1055 DRY consolidation structure (single decide+apply pair)

## Related
- Follow-up to #1055 (PR #1060)

🤖 Generated with [Claude Code](https://claude.com/claude-code)