### PR TITLE
fix: machine-status PostgreSQL 설정 소스 사용

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -130,7 +130,7 @@
 | `server::routes::agents` | `src/server/routes/agents.rs` | 1818 | giant-file |
 | `server::routes::agents_crud` | `src/server/routes/agents_crud.rs` | 2573 | giant-file |
 | `server::routes::agents_setup` | `src/server/routes/agents_setup.rs` | 1419 | giant-file |
-| `server::routes::analytics` | `src/server/routes/analytics.rs` | 1389 | giant-file |
+| `server::routes::analytics` | `src/server/routes/analytics.rs` | 1570 | giant-file |
 | `server::routes::auth` | `src/server/routes/auth.rs` | 92 |  |
 | `server::routes::auto_queue` | `src/server/routes/auto_queue.rs` | 11596 | giant-file |
 | `server::routes::cron_api` | `src/server/routes/cron_api.rs` | 168 |  |
@@ -250,7 +250,7 @@
 | `services::discord::settings::validation` | `src/services/discord/settings/validation.rs` | 213 |  |
 | `services::discord::settings::write` | `src/services/discord/settings/write.rs` | 356 |  |
 | `services::discord::shared_memory` | `src/services/discord/shared_memory.rs` | 59 |  |
-| `services::discord::tmux` | `src/services/discord/tmux.rs` | 7575 | giant-file |
+| `services::discord::tmux` | `src/services/discord/tmux.rs` | 7905 | giant-file |
 | `services::discord::tmux_error_detect` | `src/services/discord/tmux_error_detect.rs` | 309 |  |
 | `services::discord::tmux_lifecycle` | `src/services/discord/tmux_lifecycle.rs` | 708 |  |
 | `services::discord::tmux_overload_retry` | `src/services/discord/tmux_overload_retry.rs` | 271 |  |

--- a/docs/generated/route-inventory.md
+++ b/docs/generated/route-inventory.md
@@ -136,7 +136,7 @@
 | `PATCH` | `/api/kanban-repos/{owner}/{repo}` | `kanban_repos::update_repo` | `src/server/routes/kanban_repos.rs:258` | `src/server/routes/domains/kanban.rs:69` |
 | `PATCH` | `/api/kanban-reviews/{id}/decisions` | `reviews::update_decisions` | `src/server/routes/reviews.rs:136` | `src/server/routes/domains/reviews.rs:18` |
 | `POST` | `/api/kanban-reviews/{id}/trigger-rework` | `reviews::trigger_rework` | `src/server/routes/reviews.rs:233` | `src/server/routes/domains/reviews.rs:22` |
-| `GET` | `/api/machine-status` | `analytics::machine_status` | `src/server/routes/analytics.rs:664` | `src/server/routes/domains/admin.rs:75` |
+| `GET` | `/api/machine-status` | `analytics::machine_status` | `src/server/routes/analytics.rs:725` | `src/server/routes/domains/admin.rs:75` |
 | `GET` | `/api/maintenance/jobs` | `maintenance::list_jobs` | `src/server/routes/maintenance.rs:7` | `src/server/routes/domains/ops.rs:127` |
 | `GET` | `/api/messages` | `messages::list_messages` | `src/server/routes/messages.rs:41` | `src/server/routes/domains/ops.rs:119` |
 | `POST` | `/api/messages` | `messages::create_message` | `src/server/routes/messages.rs:128` | `src/server/routes/domains/ops.rs:119` |
@@ -175,7 +175,7 @@
 | `POST` | `/api/pm-decision` | `kanban::pm_decision` | `src/server/routes/kanban.rs:2430` | `src/server/routes/domains/kanban.rs:73` |
 | `GET` | `/api/policies` | `agents_crud::list_policies` | `src/server/routes/agents_crud.rs:2558` | `src/server/routes/domains/agents.rs:48` |
 | `GET` | `/api/quality/events` | `analytics::quality_events` | `src/server/routes/analytics.rs:95` | `src/server/routes/domains/admin.rs:70` |
-| `GET` | `/api/rate-limits` | `analytics::rate_limits` | `src/server/routes/analytics.rs:720` | `src/server/routes/domains/admin.rs:76` |
+| `GET` | `/api/rate-limits` | `analytics::rate_limits` | `src/server/routes/analytics.rs:750` | `src/server/routes/domains/admin.rs:76` |
 | `POST` | `/api/re-review` | `deprecated_batch_rereview` | `src/server/routes/domains/kanban.rs:77` | `src/server/routes/domains/kanban.rs:34` |
 | `GET` | `/api/receipt` | `receipt::get_receipt` | `src/server/routes/receipt.rs:22` | `src/server/routes/domains/admin.rs:77` |
 | `POST` | `/api/review-decision` | `deprecated_submit_review_decision` | `src/server/routes/domains/reviews.rs:52` | `src/server/routes/domains/reviews.rs:32` |
@@ -208,7 +208,7 @@
 | `PUT` | `/api/settings/escalation` | `escalation::put_escalation_settings` | `src/server/routes/escalation.rs:1792` | `src/server/routes/domains/admin.rs:60` |
 | `GET` | `/api/settings/runtime-config` | `settings::get_runtime_config` | `src/server/routes/settings.rs:653` | `src/server/routes/domains/admin.rs:56` |
 | `PUT` | `/api/settings/runtime-config` | `settings::put_runtime_config` | `src/server/routes/settings.rs:663` | `src/server/routes/domains/admin.rs:56` |
-| `GET` | `/api/skills-trend` | `analytics::skills_trend` | `src/server/routes/analytics.rs:1037` | `src/server/routes/domains/admin.rs:79` |
+| `GET` | `/api/skills-trend` | `analytics::skills_trend` | `src/server/routes/analytics.rs:1067` | `src/server/routes/domains/admin.rs:79` |
 | `GET` | `/api/skills/catalog` | `skills_api::catalog` | `src/server/routes/skills_api.rs:370` | `src/server/routes/domains/ops.rs:123` |
 | `POST` | `/api/skills/prune` | `skills_api::prune` | `src/server/routes/skills_api.rs:651` | `src/server/routes/domains/ops.rs:125` |
 | `GET` | `/api/skills/ranking` | `skills_api::ranking` | `src/server/routes/skills_api.rs:477` | `src/server/routes/domains/ops.rs:124` |

--- a/src/server/routes/analytics.rs
+++ b/src/server/routes/analytics.rs
@@ -658,26 +658,9 @@ pub async fn audit_logs(
     (StatusCode::OK, Json(json!({ "logs": logs })))
 }
 
-/// GET /api/machine-status
-/// Machine list from kv_meta key 'machines' (JSON array of {name, host}).
-/// Falls back to current hostname if not configured.
-pub async fn machine_status(
-    State(state): State<AppState>,
-) -> (StatusCode, Json<serde_json::Value>) {
-    // Read machine list from config
-    let machines_config: Vec<(String, String)> = state
-        .db
-        .lock()
+fn parse_machine_config(value: &str) -> Option<Vec<(String, String)>> {
+    serde_json::from_str::<Vec<serde_json::Value>>(value)
         .ok()
-        .and_then(|conn| {
-            conn.query_row(
-                "SELECT value FROM kv_meta WHERE key = 'machines'",
-                [],
-                |row| row.get::<_, String>(0),
-            )
-            .ok()
-        })
-        .and_then(|v| serde_json::from_str::<Vec<serde_json::Value>>(&v).ok())
         .map(|arr| {
             arr.iter()
                 .filter_map(|m| {
@@ -691,11 +674,58 @@ pub async fn machine_status(
                 })
                 .collect()
         })
-        .unwrap_or_else(|| {
-            // Default: current hostname
-            let hostname = crate::services::platform::hostname_short();
-            vec![(hostname.clone(), hostname)]
-        });
+        .filter(|machines: &Vec<(String, String)>| !machines.is_empty())
+}
+
+fn default_machine_config() -> Vec<(String, String)> {
+    let hostname = crate::services::platform::hostname_short();
+    vec![(hostname.clone(), hostname)]
+}
+
+async fn load_machine_config_pg(pool: &sqlx::PgPool) -> Option<Vec<(String, String)>> {
+    sqlx::query_scalar::<_, String>("SELECT value FROM kv_meta WHERE key = $1")
+        .bind("machines")
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|value| parse_machine_config(&value))
+}
+
+fn load_machine_config_sqlite(db: &crate::db::Db) -> Option<Vec<(String, String)>> {
+    db.lock()
+        .ok()
+        .and_then(|conn| {
+            conn.query_row(
+                "SELECT value FROM kv_meta WHERE key = 'machines'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .ok()
+        })
+        .and_then(|value| parse_machine_config(&value))
+}
+
+async fn load_machine_config(
+    db: &crate::db::Db,
+    pg_pool: Option<&sqlx::PgPool>,
+) -> Vec<(String, String)> {
+    if let Some(pool) = pg_pool {
+        return load_machine_config_pg(pool)
+            .await
+            .unwrap_or_else(default_machine_config);
+    }
+
+    load_machine_config_sqlite(db).unwrap_or_else(default_machine_config)
+}
+
+/// GET /api/machine-status
+/// Machine list from kv_meta key 'machines' (JSON array of {name, host}).
+/// Falls back to current hostname if not configured.
+pub async fn machine_status(
+    State(state): State<AppState>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let machines_config = load_machine_config(state.sqlite_db(), state.pg_pool_ref()).await;
 
     let result = tokio::task::spawn_blocking(move || {
         let mut results = Vec::new();
@@ -1178,6 +1208,157 @@ mod tests {
     fn test_engine(db: &crate::db::Db) -> crate::engine::PolicyEngine {
         let config = crate::config::Config::default();
         crate::engine::PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn machine_status_machines_config_prefers_postgres_when_pool_exists() {
+        let sqlite_db = crate::db::test_db();
+        {
+            let conn = sqlite_db.lock().unwrap();
+            conn.execute(
+                "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?1, ?2)",
+                libsql_rusqlite::params![
+                    "machines",
+                    serde_json::json!([{ "name": "sqlite-machine", "host": "sqlite-host" }])
+                        .to_string()
+                ],
+            )
+            .unwrap();
+        }
+
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        sqlx::query(
+            "INSERT INTO kv_meta (key, value)
+             VALUES ($1, $2)
+             ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value",
+        )
+        .bind("machines")
+        .bind(serde_json::json!([{ "name": "pg-machine", "host": "pg-host" }]).to_string())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let machines = load_machine_config(&sqlite_db, Some(&pool)).await;
+
+        assert_eq!(
+            machines,
+            vec![("pg-machine".to_string(), "pg-host.local".to_string())]
+        );
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn machine_status_machines_config_uses_hostname_when_postgres_is_unconfigured() {
+        let sqlite_db = crate::db::test_db();
+        {
+            let conn = sqlite_db.lock().unwrap();
+            conn.execute(
+                "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?1, ?2)",
+                libsql_rusqlite::params![
+                    "machines",
+                    serde_json::json!([{ "name": "stale-sqlite-machine", "host": "stale-host" }])
+                        .to_string()
+                ],
+            )
+            .unwrap();
+        }
+
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        let hostname = crate::services::platform::hostname_short();
+
+        let machines = load_machine_config(&sqlite_db, Some(&pool)).await;
+
+        assert_eq!(machines, vec![(hostname.clone(), hostname)]);
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn machine_status_machines_config_uses_hostname_for_empty_postgres_config() {
+        let sqlite_db = crate::db::test_db();
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        sqlx::query(
+            "INSERT INTO kv_meta (key, value)
+             VALUES ($1, $2)
+             ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value",
+        )
+        .bind("machines")
+        .bind("[]")
+        .execute(&pool)
+        .await
+        .unwrap();
+        let hostname = crate::services::platform::hostname_short();
+
+        let machines = load_machine_config(&sqlite_db, Some(&pool)).await;
+
+        assert_eq!(machines, vec![(hostname.clone(), hostname)]);
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    #[tokio::test]
+    async fn machine_status_machines_config_uses_sqlite_without_pg_pool() {
+        let sqlite_db = crate::db::test_db();
+        {
+            let conn = sqlite_db.lock().unwrap();
+            conn.execute(
+                "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?1, ?2)",
+                libsql_rusqlite::params![
+                    "machines",
+                    serde_json::json!([{ "name": "sqlite-machine", "host": "sqlite-host" }])
+                        .to_string()
+                ],
+            )
+            .unwrap();
+        }
+
+        let machines = load_machine_config(&sqlite_db, None).await;
+
+        assert_eq!(
+            machines,
+            vec![(
+                "sqlite-machine".to_string(),
+                "sqlite-host.local".to_string()
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn machine_status_machines_config_uses_hostname_for_invalid_sqlite_entries() {
+        let sqlite_db = crate::db::test_db();
+        {
+            let conn = sqlite_db.lock().unwrap();
+            conn.execute(
+                "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?1, ?2)",
+                libsql_rusqlite::params![
+                    "machines",
+                    serde_json::json!([{ "host": "missing-name" }]).to_string()
+                ],
+            )
+            .unwrap();
+        }
+        let hostname = crate::services::platform::hostname_short();
+
+        let machines = load_machine_config(&sqlite_db, None).await;
+
+        assert_eq!(machines, vec![(hostname.clone(), hostname)]);
+    }
+
+    #[tokio::test]
+    async fn machine_status_machines_config_falls_back_to_hostname_when_unconfigured() {
+        let sqlite_db = crate::db::test_db();
+        let hostname = crate::services::platform::hostname_short();
+
+        let machines = load_machine_config(&sqlite_db, None).await;
+
+        assert_eq!(machines, vec![(hostname.clone(), hostname)]);
     }
 
     #[test]


### PR DESCRIPTION
## 목표

`/api/machine-status`가 PostgreSQL 런타임에서 stale SQLite `kv_meta.machines`를 읽지 않도록 origin PR #81의 수정사항을 upstream `main`에 반영합니다.

## 해결한 내용

- PostgreSQL pool이 있으면 PostgreSQL `kv_meta['machines']`를 우선 사용합니다.
- PostgreSQL 설정이 없거나 비어 있거나 유효한 machine entry가 없으면 hostname fallback을 사용합니다.
- SQLite-only 모드에서는 기존 SQLite `kv_meta['machines']` 경로를 유지합니다.
- 관련 generated inventory 문서를 갱신했습니다.

## 검증

- `cargo fmt --all --check`
- `python3 scripts/generate_inventory_docs.py --check`
- `cargo test machine_status_machines_config --bin agentdesk`
- `cargo check --all-targets`

## 포트 메모

- fork `kunkunGames/AgentDesk`의 merged PR #81 squash commit `e3edaa5d`를 upstream `main` 최신 commit `b368c559` 위에 cherry-pick했습니다.
- Cherry-pick conflict 없음.