### PR TITLE
fix(deploy): harden release preflight checks

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,22 @@
+use std::{fs, path::Path};
+
+fn main() {
+    rerun_if_changed_recursively(Path::new("migrations/postgres"));
+}
+
+fn rerun_if_changed_recursively(path: &Path) {
+    println!("cargo:rerun-if-changed={}", path.display());
+
+    let Ok(entries) = fs::read_dir(path) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let child_path = entry.path();
+        if child_path.is_dir() {
+            rerun_if_changed_recursively(&child_path);
+        } else {
+            println!("cargo:rerun-if-changed={}", child_path.display());
+        }
+    }
+}

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -234,8 +234,10 @@
 The remaining giant-file modules under `src/services/` not covered above:
 
 - `src/services/api_friction.rs` (1808).
-- `src/services/auto_queue.rs` (1047); auto-queue route behavior is split
-  across `src/services/auto_queue/*` slices, each currently below 1000 lines.
+- `src/services/auto_queue.rs` (1047) and
+  `src/services/auto_queue/activate_command.rs` (1012); auto-queue route
+  behavior is split across `src/services/auto_queue/*` slices, with
+  `activate_command.rs` now giant-file territory.
 - `src/services/claude.rs` (2477), `src/services/gemini.rs` (2565),
   `src/services/qwen.rs` (2466), `src/services/codex.rs` (1665),
   `src/services/opencode.rs` (2133), `src/services/provider.rs` (2177) —

--- a/scripts/audit_allowlist.toml
+++ b/scripts/audit_allowlist.toml
@@ -23,8 +23,8 @@ route_srp_violations = [
 # extraction. Entries are path:line so new callsites in the same file still
 # fail the hard gate. Line numbers for tmux.rs / turn_bridge / mod.rs /
 # health.rs were refreshed in #1440 after the #1435 tmux watcher-lifecycle
-# extraction shifted callsites (no logical regressions; the same callsites
-# moved with the surrounding functions).
+# extraction shifted callsites; #1450 refreshes the remaining drift detected
+# by CI with no logical regressions.
 direct_discord_sends = [
   "src/services/discord/commands/model_picker.rs:60",
   "src/services/discord/commands/skill.rs:286",

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -308,8 +308,8 @@ SOURCE_BINARY="${AGENTDESK_DEPLOY_BINARY:-$REPO/target/release/agentdesk}"
 if [ -z "${AGENTDESK_DEPLOY_BINARY:-}" ]; then
     echo "▸ Building release binary..."
     (cd "$REPO" && cargo build --release --bin agentdesk)
-    # The freshness gate below is mtime-based. A successful current-HEAD cargo
-    # build can still reuse an existing artifact, so align the mtime after build.
+    # Cargo tracks embedded migration inputs via build.rs. After a successful
+    # current-HEAD build, align the mtime so the freshness gate records it.
     [ -e "$SOURCE_BINARY" ] && touch "$SOURCE_BINARY"
 fi
 

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -151,6 +151,19 @@ _resolve_dashboard_source() {
     return 1
 }
 
+_resolve_default_release_binary() {
+    local target_dir
+    target_dir="$(cd "$REPO" && cargo metadata --format-version 1 --no-deps 2>/dev/null | jq -r '.target_directory // empty' 2>/dev/null || true)"
+    if [ -z "$target_dir" ]; then
+        target_dir="${CARGO_TARGET_DIR:-$REPO/target}"
+    fi
+    case "$target_dir" in
+        /*) ;;
+        *) target_dir="$REPO/$target_dir" ;;
+    esac
+    printf '%s/release/agentdesk\n' "$target_dir"
+}
+
 _finalize_detached_helper() {
     local status="${1:-0}"
     [ "$DEPLOY_DETACHED_CHILD" = "1" ] || return 0
@@ -304,7 +317,11 @@ fi
 # Build the release binary from the current workspace by default so deploy
 # always ships code compiled from the current HEAD. When a validated external
 # artifact is provided explicitly, keep the existing override behavior.
-SOURCE_BINARY="${AGENTDESK_DEPLOY_BINARY:-$REPO/target/release/agentdesk}"
+if [ -n "${AGENTDESK_DEPLOY_BINARY:-}" ]; then
+    SOURCE_BINARY="$AGENTDESK_DEPLOY_BINARY"
+else
+    SOURCE_BINARY="$(_resolve_default_release_binary)"
+fi
 if [ -z "${AGENTDESK_DEPLOY_BINARY:-}" ]; then
     echo "▸ Building release binary..."
     (cd "$REPO" && cargo build --release --bin agentdesk)

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -256,14 +256,12 @@ else
     echo "▸ [gate] Zero create-pr dispatches inflight on release — proceeding."
 fi
 
-if ! DASHBOARD_SOURCE=$(_resolve_dashboard_source); then
-    echo "✗ Dashboard dist not found in workspace — aborting deploy"
-    echo "  looked for:"
-    echo "    - $REPO/dashboard/dist/index.html"
-    echo "  Run 'cd $REPO/dashboard && npm run build' to generate it"
-    exit 1
+if DASHBOARD_SOURCE=$(_resolve_dashboard_source); then
+    echo "▸ Dashboard source: $DASHBOARD_SOURCE"
+else
+    echo "▸ Dashboard source missing — will build before staging"
+    echo "  looked for: $REPO/dashboard/dist/index.html"
 fi
-echo "▸ Dashboard source: $DASHBOARD_SOURCE"
 if [ ! -d "$REPO/skills" ]; then
     echo "✗ Managed skills not found in workspace — aborting deploy"
     echo "  expected: $REPO/skills"
@@ -310,6 +308,9 @@ SOURCE_BINARY="${AGENTDESK_DEPLOY_BINARY:-$REPO/target/release/agentdesk}"
 if [ -z "${AGENTDESK_DEPLOY_BINARY:-}" ]; then
     echo "▸ Building release binary..."
     (cd "$REPO" && cargo build --release --bin agentdesk)
+    # The freshness gate below is mtime-based. A successful current-HEAD cargo
+    # build can still reuse an existing artifact, so align the mtime after build.
+    [ -e "$SOURCE_BINARY" ] && touch "$SOURCE_BINARY"
 fi
 
 # Rebuild dashboard so deploy never ships a stale dist.


### PR DESCRIPTION
## 목표
릴리스 배포 스크립트의 preflight와 바이너리 freshness 검사를 더 정확하게 만들어, clean checkout이나 non-default Cargo target dir에서도 stale artifact를 배포하지 않게 합니다.

## 쉬운 설명
배포 스크립트가 `dashboard/dist/index.html`이 아직 없는 상태를 즉시 실패로 보지 않고, 먼저 대시보드를 다시 빌드한 뒤 최종 산출물을 확인합니다. AgentDesk 릴리스 바이너리는 Cargo가 실제로 쓰는 target directory를 기준으로 찾고, 성공적으로 빌드된 뒤에만 mtime을 정렬합니다. PostgreSQL migration만 바뀐 경우에도 Cargo가 rebuild하도록 `build.rs`에서 migration 파일 변화를 추적합니다.

## Before → After
| 상황 | Before | After |
| --- | --- | --- |
| clean checkout에서 dashboard dist가 없음 | `dashboard/dist/index.html`이 없으면 dashboard rebuild 전에 preflight가 실패할 수 있었습니다. | 먼저 dashboard를 rebuild하고, staging 직전에도 dist 산출물이 없을 때만 hard fail합니다. |
| PostgreSQL migration만 추가됨 | `sqlx::migrate!("./migrations/postgres")` 입력이 Cargo rebuild trigger로 잡히지 않아 stale binary가 통과할 수 있었습니다. | `build.rs`가 `migrations/postgres`를 재귀적으로 `rerun-if-changed`로 등록해 migration-only 변경도 rebuild 입력으로 잡습니다. |
| `CARGO_TARGET_DIR` 또는 Cargo target dir가 기본값이 아님 | `$REPO/target/release/agentdesk`의 mtime만 갱신해 Cargo가 실제로 만든 binary와 다른 artifact를 freshness-check할 수 있었습니다. | `cargo metadata`의 `target_directory`를 기준으로 실제 release binary 경로를 resolve하고, 그 경로만 touch/freshness-check합니다. |

## 해결한 내용
- `build.rs`: `migrations/postgres` 아래 파일과 디렉터리를 Cargo rebuild trigger로 재귀 등록합니다.
- `scripts/deploy-release.sh`: dashboard preflight 순서를 완화하되 build 이후 검증은 유지하고, 기본 release binary 경로를 Cargo metadata 기반으로 계산합니다.
- `scripts/deploy-release.sh`: 기본 빌드가 성공한 경우에만 source binary mtime을 현재 HEAD 이후로 정렬해 freshness gate의 false fail을 줄입니다.
- `docs/agent-maintenance/change-surfaces.md`: `src/services/auto_queue/activate_command.rs`를 giant-file surface로 문서화합니다.
- `scripts/audit_allowlist.toml`: direct Discord send allowlist의 설명 주석을 #1450의 CI drift refresh 맥락에 맞게 갱신합니다.

## 검증
- `bash -n scripts/deploy-release.sh`: deploy script 문법 확인.
- `git diff --check`: whitespace/error marker 확인.
- `cargo fmt --all --check`: Rust formatting 확인.
- `cargo check --all-targets`: 전체 Rust target typecheck 확인. 기존 warning만 남습니다.
- `python3 scripts/audit_maintainability.py --check`: maintainability audit allowlist/docs 정합성 확인.
- `cargo metadata --format-version 1 --no-deps | jq -r .target_directory`: 기본 target directory resolve 확인.
- `CARGO_TARGET_DIR=/tmp/agentdesk-target-check cargo metadata --format-version 1 --no-deps | jq -r .target_directory`: custom target dir resolve 확인.
- `shellcheck -x scripts/deploy-release.sh`: 기존 `_defaults.sh` source-follow SC1091 info warning만 확인.