### PR TITLE
fix: block release when postgres migration checksum drift is detected

### DIFF
--- a/scripts/_defaults.sh
+++ b/scripts/_defaults.sh
@@ -122,6 +122,20 @@ sync_launchd_plist_environment_from_file() {
   done < "$env_file"
 }
 
+_apply_launchd_env_file_to_shell() {
+  local env_file="$1"
+  local raw_line parsed key value
+
+  [ -f "$env_file" ] || return 0
+
+  while IFS= read -r raw_line || [ -n "$raw_line" ]; do
+    parsed=$(_parse_launchd_env_line "$raw_line") || continue
+    key="${parsed%%$'\t'*}"
+    value="${parsed#*$'\t'}"
+    export "$key=$value"
+  done < "$env_file"
+}
+
 _launchd_job_state() {
   local label="$1"
   launchctl print "gui/$(id -u)/$label" 2>/dev/null \

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -7,6 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 ADK_REL="$HOME/.adk/release"
 PLIST_REL="com.agentdesk.release"
+REL_LAUNCHD_ENV_FILE="$ADK_REL/config/launchd.env"
 REPO="${AGENTDESK_REPO_DIR:-}"
 if [ -z "$REPO" ]; then
     REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -551,6 +552,11 @@ fi
 
 _assert_release_binary_runtime_surface
 
+if [ -f "$REL_LAUNCHD_ENV_FILE" ]; then
+    echo "▸ Applying release launchd env for doctor preflight..."
+    _apply_launchd_env_file_to_shell "$REL_LAUNCHD_ENV_FILE"
+fi
+
 echo "▸ Preflight PostgreSQL migration integrity via doctor..."
 DOCTOR_JSON_TMP=$(mktemp "${TMPDIR:-/tmp}/agentdesk-doctor.XXXXXX.json")
 set +e
@@ -685,7 +691,6 @@ echo "▸ Ensuring global agentdesk CLI..."
 
 # Postgres database is operator-managed; SQLite copy removed after #461 cutover.
 
-REL_LAUNCHD_ENV_FILE="$ADK_REL/config/launchd.env"
 if [ -f "$REL_LAUNCHD_ENV_FILE" ]; then
     echo "▸ Syncing release launchd env..."
     sync_launchd_plist_environment_from_file "$HOME/Library/LaunchAgents/$PLIST_REL.plist" "$REL_LAUNCHD_ENV_FILE"

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -551,6 +551,49 @@ fi
 
 _assert_release_binary_runtime_surface
 
+echo "▸ Preflight PostgreSQL migration integrity via doctor..."
+DOCTOR_JSON_TMP=$(mktemp "${TMPDIR:-/tmp}/agentdesk-doctor.XXXXXX.json")
+set +e
+"$SOURCE_BINARY" doctor --json >"$DOCTOR_JSON_TMP" 2>/dev/null
+DOCTOR_RC=$?
+set -e
+if [ ! -s "$DOCTOR_JSON_TMP" ]; then
+    echo "✗ Doctor preflight did not return JSON output."
+    rm -f "$DOCTOR_JSON_TMP"
+    exit 1
+fi
+if ! python3 - "$DOCTOR_JSON_TMP" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+checks = data.get("checks", [])
+postgres = next((c for c in checks if c.get("id") == "postgres_connection"), None)
+if not postgres:
+    print("✗ Doctor preflight missing postgres_connection check.")
+    raise SystemExit(1)
+
+status = str(postgres.get("status", "")).lower()
+if status in {"pass", "ok", "info"}:
+    raise SystemExit(0)
+
+detail = postgres.get("detail") or "no detail"
+actual = postgres.get("actual") or "unknown"
+print(f"✗ Doctor postgres preflight failed: status={status}, detail={detail}, actual={actual}")
+raise SystemExit(1)
+PY
+then
+    rm -f "$DOCTOR_JSON_TMP"
+    exit 1
+fi
+if [ "$DOCTOR_RC" -ne 0 ]; then
+    echo "⚠ doctor command returned non-zero ($DOCTOR_RC), but postgres preflight check passed."
+fi
+rm -f "$DOCTOR_JSON_TMP"
+
 # Copy and sign the binary before stopping release. This keeps a missing
 # certificate or failed codesign from taking down a healthy dcserver.
 echo "▸ Staging signed binary from $SOURCE_BINARY..."

--- a/src/cli/doctor/orchestrator.rs
+++ b/src/cli/doctor/orchestrator.rs
@@ -2989,8 +2989,9 @@ fn check_postgres_connection(cfg: &config::Config) -> Check {
     match runtime.block_on(crate::db::postgres::connect(cfg)) {
         Ok(Some(pool)) => {
             let migration_status = runtime.block_on(crate::db::postgres::migration_status(&pool));
-            let checksum_mismatches =
-                runtime.block_on(crate::db::postgres::applied_migration_checksum_mismatches(&pool));
+            let checksum_mismatches = runtime.block_on(
+                crate::db::postgres::applied_migration_checksum_mismatches(&pool),
+            );
             drop(pool);
             match (migration_status, checksum_mismatches) {
                 (Ok(status), Ok(checksum_mismatches))

--- a/src/cli/doctor/orchestrator.rs
+++ b/src/cli/doctor/orchestrator.rs
@@ -2989,9 +2989,13 @@ fn check_postgres_connection(cfg: &config::Config) -> Check {
     match runtime.block_on(crate::db::postgres::connect(cfg)) {
         Ok(Some(pool)) => {
             let migration_status = runtime.block_on(crate::db::postgres::migration_status(&pool));
+            let checksum_mismatches =
+                runtime.block_on(crate::db::postgres::applied_migration_checksum_mismatches(&pool));
             drop(pool);
-            match migration_status {
-                Ok(status) if postgres_migration_status_is_healthy(&status) => {
+            match (migration_status, checksum_mismatches) {
+                (Ok(status), Ok(checksum_mismatches))
+                    if postgres_migration_status_is_healthy(&status, &checksum_mismatches) =>
+                {
                     let pending = status.pending_versions.len();
                     Check::ok(
                         "postgres_connection",
@@ -3008,17 +3012,19 @@ fn check_postgres_connection(cfg: &config::Config) -> Check {
                         "applied_count": status.applied.len(),
                         "resolved_count": status.resolved_versions.len(),
                         "pending_versions": status.pending_versions,
+                        "checksum_mismatches": checksum_mismatches,
                     }))
                     .with_expected_actual("postgres connection and migration metadata readable", "ok")
                 }
-                Ok(status) => Check::fail(
+                (Ok(status), Ok(checksum_mismatches)) => Check::fail(
                     "postgres_connection",
                     CheckGroup::Core,
                     "PostgreSQL",
                     format!(
-                        "{summary} — migration drift: missing_from_resolved={:?} unsuccessful={:?}",
+                        "{summary} — migration drift: missing_from_resolved={:?} unsuccessful={:?} checksum_mismatches={:?}",
                         status.missing_from_resolved,
-                        unsuccessful_migration_versions(&status)
+                        unsuccessful_migration_versions(&status),
+                        checksum_mismatches
                     ),
                     "Postgres _sqlx_migrations contains drift or unsuccessful migration records.",
                 )
@@ -3031,12 +3037,13 @@ fn check_postgres_connection(cfg: &config::Config) -> Check {
                     "missing_from_resolved": status.missing_from_resolved,
                     "unsuccessful_versions": unsuccessful_migration_versions(&status),
                     "pending_versions": status.pending_versions,
+                    "checksum_mismatches": checksum_mismatches,
                 }))
                 .with_expected_actual(
-                    "applied migrations all exist in resolved migrations and succeeded",
-                    "migration drift or unsuccessful migration",
+                    "applied migrations all exist in resolved migrations, succeeded, and checksum-matched",
+                    "migration drift, checksum mismatch, or unsuccessful migration",
                 ),
-                Err(error) => Check::fail(
+                (Err(error), _) => Check::fail(
                     "postgres_connection",
                     CheckGroup::Core,
                     "PostgreSQL",
@@ -3047,6 +3054,17 @@ fn check_postgres_connection(cfg: &config::Config) -> Check {
                 .with_fix_safety(FixSafety::NotFixable)
                 .with_security_exposure(SecurityExposure::OperationalMetadata)
                 .with_expected_actual("read-only _sqlx_migrations query succeeds", error),
+                (_, Err(error)) => Check::fail(
+                    "postgres_connection",
+                    CheckGroup::Core,
+                    "PostgreSQL",
+                    format!("{summary} — migration checksum verification failed"),
+                    "Postgres connection succeeded but read-only migration checksum metadata could not be queried.",
+                )
+                .with_subsystem("postgres")
+                .with_fix_safety(FixSafety::NotFixable)
+                .with_security_exposure(SecurityExposure::OperationalMetadata)
+                .with_expected_actual("read-only _sqlx_migrations checksum query succeeds", error),
             }
         }
         Ok(None) => Check::ok(
@@ -3077,8 +3095,13 @@ fn unsuccessful_migration_versions(status: &crate::db::postgres::MigrationStatus
         .collect()
 }
 
-fn postgres_migration_status_is_healthy(status: &crate::db::postgres::MigrationStatus) -> bool {
-    status.missing_from_resolved.is_empty() && unsuccessful_migration_versions(status).is_empty()
+fn postgres_migration_status_is_healthy(
+    status: &crate::db::postgres::MigrationStatus,
+    checksum_mismatches: &[i64],
+) -> bool {
+    status.missing_from_resolved.is_empty()
+        && unsuccessful_migration_versions(status).is_empty()
+        && checksum_mismatches.is_empty()
 }
 
 fn check_stale_zero_byte_db_files(cfg: &config::Config) -> Check {
@@ -4263,8 +4286,27 @@ mod tests {
             pending_versions: vec![202604250001],
         };
 
-        assert!(!postgres_migration_status_is_healthy(&status));
+        assert!(!postgres_migration_status_is_healthy(&status, &[]));
         assert_eq!(unsuccessful_migration_versions(&status), vec![202604250001]);
+    }
+
+    #[test]
+    fn postgres_migration_status_is_unhealthy_when_checksum_mismatch_exists() {
+        let status = crate::db::postgres::MigrationStatus {
+            applied: vec![crate::db::postgres::AppliedMigrationInfo {
+                version: 202604250001,
+                description: "ok_migration".to_string(),
+                success: true,
+            }],
+            resolved_versions: vec![202604250001],
+            missing_from_resolved: Vec::new(),
+            pending_versions: Vec::new(),
+        };
+
+        assert!(!postgres_migration_status_is_healthy(
+            &status,
+            &[202604250001]
+        ));
     }
 
     #[test]

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -284,6 +284,40 @@ pub async fn migration_status(pool: &PgPool) -> Result<MigrationStatus, String> 
         missing_from_resolved,
         pending_versions,
     })
+}
+
+pub async fn applied_migration_checksum_mismatches(pool: &PgPool) -> Result<Vec<i64>, String> {
+    let rows = sqlx::query(
+        "SELECT version, checksum, success
+         FROM _sqlx_migrations
+         ORDER BY version",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|error| format!("query _sqlx_migrations checksums: {error}"))?;
+
+    let resolved_checksums = POSTGRES_MIGRATOR
+        .iter()
+        .map(|migration| (migration.version, migration.checksum.as_ref()))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut mismatches = Vec::new();
+    for row in rows {
+        let version = row.get::<i64, _>("version");
+        let success = row.get::<bool, _>("success");
+        if !success {
+            continue;
+        }
+        let Some(expected_checksum) = resolved_checksums.get(&version) else {
+            continue;
+        };
+        let applied_checksum = row.get::<Vec<u8>, _>("checksum");
+        if applied_checksum.as_slice() != *expected_checksum {
+            mismatches.push(version);
+        }
+    }
+
+    Ok(mismatches)
 }
 
 async fn apply_kv_seed_actions(pool: &PgPool, actions: &[KvSeedAction]) -> Result<(), String> {


### PR DESCRIPTION
## 목표

배포 스크립트에 `doctor --json` preflight 체크를 추가해, PostgreSQL migration checksum drift를 **기존 릴리즈를 내리기 전에** 감지합니다. 기존에는 새 프로세스가 부팅하다 실패한 뒤에야 문제를 알 수 있었습니다.

또한 `doctor` 출력에 `checksum_mismatches` 목록을 노출해, 어떤 migration 버전이 영향을 받는지 sqlx 로그를 뒤지지 않고도 바로 확인할 수 있습니다.

## 변경 내용

- **`src/db/postgres.rs`** — `applied_migration_checksum_mismatches()` 추가: `_sqlx_migrations` 테이블에 저장된 checksum과 컴파일된 migration set을 비교
- **`src/cli/doctor/orchestrator.rs`** — `postgres_connection` 체크에서 checksum mismatch를 fail 조건으로 포함; evidence에 `checksum_mismatches` 목록 추가
- **`scripts/deploy-release.sh`** — `doctor --json` preflight 추가; `postgres_connection`이 `pass`가 아니면 promote/stop 이전에 배포 중단

## Before → After

| 상황 | Before | After |
|---|---|---|
| 적용된 migration 파일이 수정됨 | 배포 진행 후 런타임 부팅 단계에서 실패 | Preflight에서 즉시 실패, promote/stop 이전 차단 |
| `doctor` postgres 점검 | drift/unsuccessful 중심, checksum mismatch 식별 약함 | `checksum_mismatches` 목록으로 영향 받는 버전 노출 |

## 배경

`migration XX was previously applied but has been modified` 류의 장애를 런타임에서 발견하기 전에 배포 단계에서 사전 차단하기 위한 변경입니다.

## 검증

- `bash -n scripts/deploy-release.sh` — 배포 스크립트 문법 정상 확인
- `cargo run --quiet -- doctor --json | jq '.checks[] | select(.id=="postgres_connection") | {status, detail, evidence}'` — `checksum_mismatches`가 evidence에 포함되는 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)