### PR TITLE
fix(ci): repair nightly workflow and add dashboard lane

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Rust multinode invariants
         timeout-minutes: 15
-        run: cargo test --bin agentdesk multinode_regression:: -- --nocapture --test-threads=1
+        run: "cargo test --bin agentdesk multinode_regression:: -- --nocapture --test-threads=1"
 
       - name: Merge gate policy invariants
         run: node --test policies/__tests__/merge-automation.test.js

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -16,6 +16,22 @@ env:
   SCCACHE_GHA_ENABLED: "true"
 
 jobs:
+  dashboard:
+    name: Dashboard (Node 22)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: dashboard/package-lock.json
+
+      - name: dashboard build/test
+        run: ./scripts/verify-dashboard.sh
+
   full_macos:
     name: Full tests (macos-latest)
     runs-on: macos-latest


### PR DESCRIPTION
## 목표
nightly CI가 쉘 인용 문제로 깨지지 않게 고치고, 무거운 정기 검증에 dashboard 검증 레인을 포함합니다.

## 쉬운 설명
정기 CI는 사람이 PR에서 바로 보지 못하는 장기 회귀를 잡는 역할입니다. 이번 변경은 nightly workflow의 cargo 명령 실행을 안전하게 만들고, dashboard 쪽 의존성/빌드 회귀도 정기 검증 대상에 넣습니다.

## Before → After
| Before | After |
| --- | --- |
| nightly workflow의 긴 cargo 명령이 쉘 파싱에 취약했습니다. | 명령을 안전하게 인용해 동일한 cargo 검증이 안정적으로 실행됩니다. |
| dashboard 변경은 nightly 정기 검증 범위에서 빠질 수 있었습니다. | dashboard Node 22 검증 job이 nightly workflow에 포함됩니다. |

## 해결한 내용
- `.github/workflows/ci-nightly.yml`: multinode cargo command 인용을 보강했습니다.
- `.github/workflows/ci-nightly.yml`: dashboard nightly job을 추가했습니다.

## 검증
- GitHub Actions: `Changed paths`, `Fast check + non-PG tests` 3개 OS, `PostgreSQL tests`, `Lint`, `Script checks`, `High-risk recovery`, `Fast check`, `Fast targeted tests` 성공 확인.
