### PR TITLE
docs(pr): add duplicate-boundary checklist guard

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,3 +13,12 @@
 
 ## Closes
 <!-- e.g. Closes #1234 -->
+
+## Boundary fingerprint
+
+- Agent:
+- Boundary:
+- Primary files:
+- Queue hygiene invariant:
+- Related PRs/issues checked:
+- Why this is non-overlapping:


### PR DESCRIPTION
## 목표
PR 작성 단계에서 중복 PR·범위 충돌을 먼저 확인하도록 템플릿 체크리스트를 보강합니다.

## 쉬운 설명
비슷한 변경이 여러 PR로 올라오면 reviewer가 실제 차이를 다시 추적해야 합니다. PR 템플릿에 중복/경계 확인 항목을 추가해, 작성자가 먼저 관련 PR과 범위를 명확히 남기게 합니다.

## Before → After
| Before | After |
| --- | --- |
| PR 설명만으로 기존 PR과의 중복 여부를 놓칠 수 있었습니다. | 작성자가 중복 후보와 범위 차이를 체크리스트에서 확인합니다. |
| reviewer가 나중에 범위 충돌을 발견하는 구조였습니다. | PR 작성 시점에 duplicate boundary를 먼저 드러냅니다. |

## 해결한 내용
- `.github/PULL_REQUEST_TEMPLATE.md`: duplicate-boundary guard 체크리스트를 추가했습니다.

## 검증
- GitHub Actions: `Changed paths`, `Fast check + non-PG tests` 3개 OS, `PostgreSQL tests`, `Lint`, `Script checks`, `Fast check`, `Fast targeted tests` 성공 확인.
