### PR TITLE
fix(dashboard): improve accessibility and update dependencies

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -27,7 +27,7 @@
         "happy-dom": "^20.9.0",
         "tailwindcss": "^4.1.0",
         "typescript": "^5.8.0",
-        "vite": "^6.3.0",
+        "vite": "^6.4.2",
         "vitest": "^4.1.1"
       },
       "engines": {
@@ -1833,9 +1833,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -3814,9 +3814,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {
@@ -4416,9 +4416,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -31,7 +31,7 @@
     "happy-dom": "^20.9.0",
     "tailwindcss": "^4.1.0",
     "typescript": "^5.8.0",
-    "vite": "^6.3.0",
+    "vite": "^6.4.2",
     "vitest": "^4.1.1"
   },
   "engines": {

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
         version: 1.59.1
       '@tailwindcss/vite':
         specifier: ^4.1.0
-        version: 4.2.2(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0))
+        version: 4.2.2(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0))
       '@types/node':
         specifier: ^22.15.0
         version: 22.19.15
@@ -47,7 +47,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.5.2
-        version: 4.7.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0))
+        version: 4.7.0(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0))
       happy-dom:
         specifier: ^20.9.0
         version: 20.9.0
@@ -58,11 +58,11 @@ importers:
         specifier: ^5.8.0
         version: 5.9.3
       vite:
-        specifier: ^6.3.0
-        version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)
+        specifier: ^6.4.2
+        version: 6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)
       vitest:
         specifier: ^4.1.1
-        version: 4.1.1(@types/node@22.19.15)(happy-dom@20.9.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0))
+        version: 4.1.1(@types/node@22.19.15)(happy-dom@20.9.0)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0))
 
 packages:
 
@@ -1307,8 +1307,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@6.4.1:
-    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -1766,12 +1766,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@tailwindcss/vite@4.2.2(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -1847,7 +1847,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -1855,7 +1855,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -1868,13 +1868,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.1(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@vitest/mocker@4.1.1(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@vitest/spy': 4.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)
 
   '@vitest/pretty-format@4.1.1':
     dependencies:
@@ -2770,7 +2770,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0):
+  vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2784,10 +2784,10 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
 
-  vitest@4.1.1(@types/node@22.19.15)(happy-dom@20.9.0)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)):
+  vitest@4.1.1(@types/node@22.19.15)(happy-dom@20.9.0)(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)):
     dependencies:
       '@vitest/expect': 4.1.1
-      '@vitest/mocker': 4.1.1(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@vitest/mocker': 4.1.1(vite@6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0))
       '@vitest/pretty-format': 4.1.1
       '@vitest/runner': 4.1.1
       '@vitest/snapshot': 4.1.1
@@ -2804,7 +2804,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 6.4.2(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.15

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -670,8 +670,8 @@ packages:
   '@webgpu/types@0.1.69':
     resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
 
-  '@xmldom/xmldom@0.8.11':
-    resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
 
   assertion-error@2.0.1:
@@ -1142,8 +1142,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   property-information@7.1.0:
@@ -1902,7 +1902,7 @@ snapshots:
 
   '@webgpu/types@0.1.69': {}
 
-  '@xmldom/xmldom@0.8.11': {}
+  '@xmldom/xmldom@0.8.13': {}
 
   assertion-error@2.0.1: {}
 
@@ -2537,7 +2537,7 @@ snapshots:
       '@pixi/colord': 2.9.6
       '@types/earcut': 3.0.0
       '@webgpu/types': 0.1.69
-      '@xmldom/xmldom': 0.8.11
+      '@xmldom/xmldom': 0.8.13
       earcut: 3.0.2
       eventemitter3: 5.0.4
       gifuct-js: 2.1.2
@@ -2553,7 +2553,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss@8.5.8:
+  postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -2775,7 +2775,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-      postcss: 8.5.8
+      postcss: 8.5.14
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:

--- a/dashboard/src/components/OfficeManagerModal.tsx
+++ b/dashboard/src/components/OfficeManagerModal.tsx
@@ -383,6 +383,9 @@ export default function OfficeManagerModal({
                       {OFFICE_COLORS.map((c) => (
                         <button
                           key={c}
+                          type="button"
+                          aria-label={`Color ${c}`}
+                          aria-pressed={formColor === c}
                           onClick={() => setFormColor(c)}
                           className={`w-7 h-7 rounded-full transition-all ${
                             formColor === c

--- a/dashboard/src/components/OfficeManagerView.tsx
+++ b/dashboard/src/components/OfficeManagerView.tsx
@@ -501,6 +501,9 @@ export default function OfficeManagerView({
                       {OFFICE_COLORS.map((color) => (
                         <button
                           key={color}
+                          type="button"
+                          aria-label={`Color ${color}`}
+                          aria-pressed={draft.color === color}
                           onClick={() => setDraft((prev) => ({ ...prev, color }))}
                           className="h-9 w-9 rounded-full border-2 transition-transform hover:scale-105"
                           style={{

--- a/dashboard/src/components/agent-manager/KanbanBoard.tsx
+++ b/dashboard/src/components/agent-manager/KanbanBoard.tsx
@@ -215,6 +215,7 @@ export default function KanbanBoard({
         return (
           <section className="rounded-2xl border px-4 py-3" style={{ borderColor: "var(--th-border-subtle)", background: "rgba(34,197,94,0.04)" }}>
             <button
+              type="button"
               onClick={() => setRecentDoneOpen((v) => !v)}
               className="flex w-full items-center gap-2 text-left"
             >
@@ -235,6 +236,7 @@ export default function KanbanBoard({
                   return (
                     <button
                       key={card.id}
+                      type="button"
                       onClick={() => onCardClick(card.id)}
                       className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm transition-colors hover:brightness-125"
                       style={{ background: "rgba(148,163,184,0.06)" }}
@@ -261,6 +263,7 @@ export default function KanbanBoard({
                 {totalPages > 1 && (
                   <div className="flex items-center justify-center gap-3 pt-1">
                     <button
+                      type="button"
                       disabled={page === 0}
                       onClick={() => setRecentDonePage((p) => Math.max(0, p - 1))}
                       className="rounded px-2 py-0.5 text-xs disabled:opacity-30"
@@ -272,6 +275,7 @@ export default function KanbanBoard({
                       {page + 1} / {totalPages}
                     </span>
                     <button
+                      type="button"
                       disabled={page >= totalPages - 1}
                       onClick={() => setRecentDonePage((p) => Math.min(totalPages - 1, p + 1))}
                       className="rounded px-2 py-0.5 text-xs disabled:opacity-30"
@@ -410,6 +414,7 @@ export default function KanbanBoard({
                   return (
                     <button
                       key={column.status}
+                      type="button"
                       onClick={() => setMobileColumnStatus(column.status)}
                       className="shrink-0 rounded-full px-3 py-1.5 text-xs font-medium border"
                       style={{


### PR DESCRIPTION
## 목표
Dashboard 접근성 문제를 줄이고, dashboard 의존성 lockfile을 npm/pnpm 모두에서 보안성 갱신과 일치시킵니다.

## 쉬운 설명
UI 컴포넌트는 키보드/보조기술 환경에서도 예측 가능해야 합니다. 또한 npm과 pnpm lockfile이 다르면 설치 도구에 따라 취약한 전이 의존성이 남을 수 있으므로 두 lock 경로를 함께 정리했습니다.

## Before → After
| Before | After |
| --- | --- |
| 일부 버튼/색상 선택 UI가 접근성 기본값을 명확히 보장하지 못했습니다. | KanbanBoard와 OfficeManager 관련 UI의 접근성 기본값을 보강했습니다. |
| npm lock은 감사 대상 의존성을 올렸지만 pnpm lock은 일부 전이 의존성이 뒤처졌습니다. | `vite`, `@xmldom/xmldom`, `postcss` 경로가 pnpm lock에서도 최신 허용 버전으로 갱신됐습니다. |

## 해결한 내용
- `dashboard/src/components/agent-manager/KanbanBoard.tsx`: 버튼 타입 접근성 기본값을 보강했습니다.
- `dashboard/src/components/OfficeManagerModal.tsx`, `dashboard/src/components/OfficeManagerView.tsx`: color picker 접근성 처리를 개선했습니다.
- `dashboard/package.json`, `dashboard/package-lock.json`, `dashboard/pnpm-lock.yaml`: dashboard 의존성과 lockfile을 동기화했습니다.

## 검증
- `corepack pnpm install --lockfile-only --frozen-lockfile --ignore-scripts` 통과.
- `git diff --check -- dashboard/pnpm-lock.yaml` 통과.
- GitHub Actions: `Changed paths`, `Fast check + non-PG tests` 3개 OS, `PostgreSQL tests`, `Lint`, `Script checks`, `Dashboard (Node 22)`, `Fast targeted tests` 성공 확인.
