### PR TITLE
Bound timeout policy HTTP fan-out

### DIFF
--- a/policies/__tests__/timeouts.test.js
+++ b/policies/__tests__/timeouts.test.js
@@ -168,6 +168,11 @@ test("timeouts review auto-accept module creates rework dispatches before transi
 
   policy._section_E();
 
+  const staleSuggestionQuery = state.queries.find((query) =>
+    query.sql.includes("review_status = 'suggestion_pending'")
+  );
+  assert.match(staleSuggestionQuery.sql, /assigned_agent_id IS NOT NULL/);
+
   assert.deepEqual(state.dispatchCreates, [
     {
       cardId: "card-review-1",

--- a/policies/timeouts/active-monitor.js
+++ b/policies/timeouts/active-monitor.js
@@ -120,7 +120,8 @@ module.exports = function attachActiveMonitor(timeouts, helpers) {
         "SELECT session_key, agent_id, active_dispatch_id, last_heartbeat " +
         "FROM sessions WHERE status IN ('turn_active', 'working') " +
         "AND session_key NOT LIKE '%deadlock-manager%' " +
-        "AND last_heartbeat < datetime('now', '-" + DEADLOCK_MINUTES + " minutes')"
+        "AND last_heartbeat < datetime('now', '-" + DEADLOCK_MINUTES + " minutes') " +
+        "ORDER BY last_heartbeat ASC LIMIT 50"
       );
       for (var dl = 0; dl < staleSessions.length; dl++) {
         var sess = staleSessions[dl];

--- a/policies/timeouts/review-auto-accept.js
+++ b/policies/timeouts/review-auto-accept.js
@@ -38,7 +38,9 @@ module.exports = function attachReviewAutoAccept(timeouts, helpers) {
       var staleSuggestions = agentdesk.db.query(
         "SELECT id, assigned_agent_id, title FROM kanban_cards " +
         "WHERE status = ? AND review_status = 'suggestion_pending' " +
-        "AND suggestion_pending_at IS NOT NULL AND suggestion_pending_at < datetime('now', '-15 minutes')",
+        "AND suggestion_pending_at IS NOT NULL AND suggestion_pending_at < datetime('now', '-15 minutes') " +
+        "AND assigned_agent_id IS NOT NULL " +
+        "ORDER BY suggestion_pending_at ASC LIMIT 50",
         [eReview]
       );
       for (var s = 0; s < staleSuggestions.length; s++) {


### PR DESCRIPTION
## 목표
정책 timeout 처리에서 한 tick당 HTTP fan-out이 과도하게 커지는 경로를 제한합니다.

## 쉬운 설명
active monitor와 review auto-accept 정책이 한 번에 너무 많은 외부 호출을 만들지 않도록 합니다. 운영 중 deadlock/latency 위험을 낮추는 안전장치입니다.

## 개선되는 것
### Fix 1
`active-monitor`의 deadlock fan-out 후보 수를 제한합니다.

### Fix 2
`review-auto-accept`의 stale suggestion 조회 범위를 제한하고 담당 agent가 없는 항목을 제외합니다.

## Before → After
| 시나리오 | Before | After |
|---|---|---|
| 대량 pending 항목 | 한 tick에서 fan-out 확대 가능 | 제한된 후보만 처리 |
| 담당 agent 없음 | 처리 후보에 섞일 수 있음 | 제외됨 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
|---|---|---|
| 정상 소량 queue | 기존처럼 처리 | 영향 낮음 |
| 대량 stale queue | 제한적으로 처리 | 운영 안정성 개선 |

## 해결한 내용
`policies/timeouts/active-monitor.js`, `policies/timeouts/review-auto-accept.js`, `policies/__tests__/timeouts.test.js`를 갱신했습니다.

## 검증
`git apply --check --3way`로 upstream/main 적용 가능성을 확인했습니다. 로컬 테스트는 이 PR 생성 패스에서 추가 실행하지 않았습니다.
