### PR TITLE
Use policy DB facade for card alert context

### DIFF
--- a/policies/__tests__/kanban-rules.test.js
+++ b/policies/__tests__/kanban-rules.test.js
@@ -208,3 +208,36 @@ test("kanban-rules marks DoD-only gate failures as awaiting_dod instead of escal
     }
   ]);
 });
+
+test("kanban-rules _loadCardAlertContext uses typed facade agentdesk.cards.get", () => {
+  const { module } = loadPolicy("policies/kanban-rules.js", {
+    dbQuery: createSqlRouter([]),
+    cards: {
+      "card-minimal": { id: "card-minimal" },
+      "card-full": {
+        id: "card-full",
+        assigned_agent_id: "agent-123",
+        title: "My Full Title",
+        github_issue_number: 456
+      }
+    }
+  });
+
+  const loadAlertContext = module._loadCardAlertContext;
+
+  assert.equal(loadAlertContext("card-missing"), null);
+
+  assert.deepEqual(Object.assign({}, loadAlertContext("card-minimal")), {
+    card_id: "card-minimal",
+    assigned_agent_id: null,
+    title: "card-minimal",
+    github_issue_number: null
+  });
+
+  assert.deepEqual(Object.assign({}, loadAlertContext("card-full")), {
+    card_id: "card-full",
+    assigned_agent_id: "agent-123",
+    title: "My Full Title",
+    github_issue_number: 456
+  });
+});

--- a/policies/kanban-rules.js
+++ b/policies/kanban-rules.js
@@ -23,17 +23,13 @@ function emitQualityEvent(event) {
 }
 
 function _loadCardAlertContext(cardId) {
-  var rows = agentdesk.db.query(
-    "SELECT assigned_agent_id, COALESCE(title, id) as title, github_issue_number " +
-    "FROM kanban_cards WHERE id = ?",
-    [cardId]
-  );
-  if (rows.length === 0) return null;
+  var card = agentdesk.cards.get(cardId);
+  if (!card) return null;
   return {
     card_id: cardId,
-    assigned_agent_id: rows[0].assigned_agent_id || null,
-    title: rows[0].title || cardId,
-    github_issue_number: rows[0].github_issue_number || null
+    assigned_agent_id: card.assigned_agent_id || null,
+    title: card.title || cardId,
+    github_issue_number: card.github_issue_number || null
   };
 }
 
@@ -793,8 +789,10 @@ if (typeof agentdesk !== "undefined" && agentdesk && typeof agentdesk.registerPo
 if (typeof module !== "undefined" && module.exports) {
   module.exports = {
     policy: rules,
+    _loadCardAlertContext: _loadCardAlertContext,
     __test: {
-      runPreflight: _runPreflight
+      runPreflight: _runPreflight,
+      _loadCardAlertContext: _loadCardAlertContext
     }
   };
 }


### PR DESCRIPTION
## 목표
카드 alert context 로딩 경로에서 raw policy DB 접근을 facade 경유 접근으로 정리합니다.

## 쉬운 설명
정책 코드가 DB 세부 구현에 직접 묶이지 않도록 경계를 정리합니다. 이후 DB contract 변경 시 영향 범위를 줄입니다.

## 개선되는 것
### Fix 1
`_loadCardAlertContext`의 raw DB 접근을 facade 경유로 대체합니다.

### Fix 2
해당 경로가 facade를 사용하는지 회귀 테스트를 추가합니다.

## Before → After
| 시나리오 | Before | After |
|---|---|---|
| card alert context 조회 | raw DB 접근에 의존 | facade 경유 |
| DB contract 변경 | 정책 코드 영향 확대 가능 | facade 경계로 완충 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
|---|---|---|
| 기존 데이터 조회 | 같은 context 반환 의도 | 호환 유지 |
| facade mock/test | 접근 경로 검증 | 회귀 방지 |

## 해결한 내용
`policies/kanban-rules.js`, `policies/__tests__/kanban-rules.test.js`를 갱신했습니다.

## 검증
`git apply --check --3way`로 upstream/main 적용 가능성을 확인했습니다. 로컬 테스트는 이 PR 생성 패스에서 추가 실행하지 않았습니다.
