### PR TITLE
deploy: harden release drift preflight metadata

### DIFF
--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -30,6 +30,7 @@ DEPLOY_LOCK_TIMEOUT_SECS="${AGENTDESK_DEPLOY_LOCK_TIMEOUT_SECS:-1800}"
 DEPLOY_MKDIR_LOCK_DIR=""
 CODESIGN_IDENTITY="${AGENTDESK_CODESIGN_IDENTITY:-Developer ID Application: Wonchang Oh (A7LJY7HNGA)}"
 ALLOW_ADHOC_RELEASE_SIGN="${AGENTDESK_ALLOW_ADHOC_RELEASE_SIGN:-0}"
+RESOLVED_RELEASE_SIGNING_MODE=""
 DASHBOARD_SOURCE=""
 STAGED_BINARY=""
 POLICIES_STAGED=""
@@ -91,6 +92,7 @@ sign_binary_with_fallback() {
         else
             current_authority=$(printf '%s\n' "$signature_details" | grep "^Authority=" | head -1 || true)
             if printf '%s\n' "$current_authority" | grep -qF "$identity" 2>/dev/null; then
+                RESOLVED_RELEASE_SIGNING_MODE="developer-id"
                 echo "✓ Already signed with matching identity — skipping re-sign (TCC preserved)"
                 return 0
             fi
@@ -98,8 +100,10 @@ sign_binary_with_fallback() {
     fi
 
     if [ "$identity" = "-" ]; then
+        RESOLVED_RELEASE_SIGNING_MODE="adhoc"
         codesign -f -s "$identity" --identifier "com.itismyfield.agentdesk" "$target"
     else
+        RESOLVED_RELEASE_SIGNING_MODE="developer-id"
         codesign -f -s "$identity" --options runtime --identifier "com.itismyfield.agentdesk" "$target"
     fi
 
@@ -191,6 +195,108 @@ _resolve_default_release_binary() {
         *) target_dir="$REPO/$target_dir" ;;
     esac
     printf '%s/release/agentdesk\n' "$target_dir"
+}
+
+_latest_postgres_migration_path() {
+    local migrations_dir="$REPO/migrations/postgres"
+    if [ ! -d "$migrations_dir" ]; then
+        return 0
+    fi
+    find "$migrations_dir" -maxdepth 1 -type f -name '[0-9][0-9][0-9][0-9]_*.sql' 2>/dev/null \
+        | sort \
+        | tail -n 1
+}
+
+_sha256_file() {
+    local path="$1"
+    if [ -z "$path" ] || [ ! -f "$path" ]; then
+        return 0
+    fi
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$path" | awk '{print $1}'
+    elif command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$path" | awk '{print $1}'
+    fi
+}
+
+_write_release_source_manifest() {
+    mkdir -p "$ADK_REL/runtime"
+
+    local manifest_tmp="$ADK_REL/runtime/release-source.json.new"
+    local manifest_path="$ADK_REL/runtime/release-source.json"
+    local generated_at repo_head repo_branch repo_upstream repo_upstream_sha repo_dirty latest_migration latest_migration_name latest_migration_sha
+
+    generated_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    repo_head="$(git -C "$REPO" rev-parse HEAD 2>/dev/null || true)"
+    repo_branch="$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+    repo_upstream="$(git -C "$REPO" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
+    repo_upstream_sha=""
+    if [ -n "$repo_upstream" ]; then
+        repo_upstream_sha="$(git -C "$REPO" rev-parse "$repo_upstream" 2>/dev/null || true)"
+    fi
+    repo_dirty="unknown"
+    if git -C "$REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        if [ -n "$(git -C "$REPO" status --porcelain 2>/dev/null)" ]; then
+            repo_dirty="true"
+        else
+            repo_dirty="false"
+        fi
+    fi
+
+    latest_migration="$(_latest_postgres_migration_path)"
+    latest_migration_name=""
+    latest_migration_sha=""
+    if [ -n "$latest_migration" ]; then
+        latest_migration_name="$(basename "$latest_migration")"
+        latest_migration_sha="$(_sha256_file "$latest_migration")"
+    fi
+
+    AGENTDESK_MANIFEST_GENERATED_AT="$generated_at" \
+    AGENTDESK_MANIFEST_REPO="$REPO" \
+    AGENTDESK_MANIFEST_REPO_BRANCH="$repo_branch" \
+    AGENTDESK_MANIFEST_REPO_HEAD="$repo_head" \
+    AGENTDESK_MANIFEST_REPO_UPSTREAM="$repo_upstream" \
+    AGENTDESK_MANIFEST_REPO_UPSTREAM_SHA="$repo_upstream_sha" \
+    AGENTDESK_MANIFEST_REPO_DIRTY="$repo_dirty" \
+    AGENTDESK_MANIFEST_SOURCE_BINARY="${SOURCE_BINARY:-}" \
+    AGENTDESK_MANIFEST_LATEST_MIGRATION="$latest_migration_name" \
+    AGENTDESK_MANIFEST_LATEST_MIGRATION_SHA="$latest_migration_sha" \
+    AGENTDESK_MANIFEST_SIGNING_MODE="${RESOLVED_RELEASE_SIGNING_MODE:-unknown}" \
+    AGENTDESK_MANIFEST_CODESIGN_IDENTITY="$CODESIGN_IDENTITY" \
+    AGENTDESK_MANIFEST_ALLOW_ADHOC_RELEASE_SIGN="$ALLOW_ADHOC_RELEASE_SIGN" \
+    AGENTDESK_MANIFEST_SKIP_TURN_DRAIN="${AGENTDESK_SKIP_TURN_DRAIN:-1}" \
+    AGENTDESK_MANIFEST_SKIP_FRESHNESS="${AGENTDESK_DEPLOY_SKIP_FRESHNESS:-0}" \
+    AGENTDESK_MANIFEST_SKIP_REMOTE_FRESHNESS="${AGENTDESK_DEPLOY_SKIP_REMOTE_FRESHNESS:-0}" \
+    python3 - "$manifest_tmp" <<PY
+import json
+import os
+import sys
+
+path = sys.argv[1]
+payload = {
+    "generated_at": os.environ.get("AGENTDESK_MANIFEST_GENERATED_AT", ""),
+    "repo_path": os.environ.get("AGENTDESK_MANIFEST_REPO", ""),
+    "repo_branch": os.environ.get("AGENTDESK_MANIFEST_REPO_BRANCH", ""),
+    "repo_head": os.environ.get("AGENTDESK_MANIFEST_REPO_HEAD", ""),
+    "repo_upstream": os.environ.get("AGENTDESK_MANIFEST_REPO_UPSTREAM", ""),
+    "repo_upstream_sha": os.environ.get("AGENTDESK_MANIFEST_REPO_UPSTREAM_SHA", ""),
+    "repo_dirty": os.environ.get("AGENTDESK_MANIFEST_REPO_DIRTY", "unknown"),
+    "source_binary": os.environ.get("AGENTDESK_MANIFEST_SOURCE_BINARY", ""),
+    "latest_postgres_migration": os.environ.get("AGENTDESK_MANIFEST_LATEST_MIGRATION", ""),
+    "latest_postgres_migration_sha256": os.environ.get("AGENTDESK_MANIFEST_LATEST_MIGRATION_SHA", ""),
+    "signing_mode": os.environ.get("AGENTDESK_MANIFEST_SIGNING_MODE", ""),
+    "codesign_identity": os.environ.get("AGENTDESK_MANIFEST_CODESIGN_IDENTITY", ""),
+    "allow_adhoc_release_sign": os.environ.get("AGENTDESK_MANIFEST_ALLOW_ADHOC_RELEASE_SIGN", ""),
+    "skip_turn_drain": os.environ.get("AGENTDESK_MANIFEST_SKIP_TURN_DRAIN", "1"),
+    "skip_freshness": os.environ.get("AGENTDESK_MANIFEST_SKIP_FRESHNESS", "0"),
+    "skip_remote_freshness": os.environ.get("AGENTDESK_MANIFEST_SKIP_REMOTE_FRESHNESS", "0"),
+}
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+    handle.write("\n")
+PY
+    mv -f "$manifest_tmp" "$manifest_path"
+    echo "▸ Release source manifest: $manifest_path"
 }
 
 _clean_release_build_cache_after_staging() {
@@ -620,12 +726,22 @@ if not postgres:
     raise SystemExit(1)
 
 status = str(postgres.get("status", "")).lower()
-if status in {"pass", "ok", "info"}:
+evidence = postgres.get("evidence") or {}
+drift_fields = {
+    "missing_from_resolved": evidence.get("missing_from_resolved") or [],
+    "unsuccessful_versions": evidence.get("unsuccessful_versions") or [],
+    "checksum_mismatches": evidence.get("checksum_mismatches") or [],
+}
+drift = {key: value for key, value in drift_fields.items() if value}
+if status in {"pass", "ok", "info"} and not drift:
     raise SystemExit(0)
 
 detail = postgres.get("detail") or "no detail"
 actual = postgres.get("actual") or "unknown"
-print(f"✗ Doctor postgres preflight failed: status={status}, detail={detail}, actual={actual}")
+if drift:
+    print(f"✗ Doctor postgres preflight failed: status={status}, drift={drift}, detail={detail}, actual={actual}")
+else:
+    print(f"✗ Doctor postgres preflight failed: status={status}, detail={detail}, actual={actual}")
 raise SystemExit(1)
 PY
 then
@@ -760,5 +876,7 @@ elif _health_json_reconcile_only "${WAIT_FOR_HTTP_SERVICE_LAST_HEALTH_JSON:-}"; 
 else
     echo "✓ Release is healthy on :${REL_PORT}"
 fi
+
+_write_release_source_manifest
 
 echo "═══ Deploy Complete ═══"


### PR DESCRIPTION
## 목표

release deploy가 임시 체크아웃이나 다른 서명 정책으로 진행됐을 때, 실제 배포 소스와 Postgres migration 상태를 나중에 추적할 수 있게 하고 migration drift preflight를 더 명확히 실패시키는 것이 목표입니다.

## 쉬운 설명

배포가 끝나면 어떤 repo 경로, branch, commit, 최신 Postgres migration, signing mode로 올라갔는지 runtime manifest에 남깁니다. 다음 장애 분석 때 현재 checkout과 운영 DB가 왜 다르게 보이는지 바로 확인할 수 있습니다. Postgres doctor preflight도 drift evidence가 있으면 상태 문자열만 믿지 않고 promotion 전에 중단합니다. migration 디렉터리가 없는 부분 checkout에서도 manifest 작성이 배포 후 false failure를 만들지 않게 했습니다.

## 개선되는 것

### Fix 1
release 성공 후 `runtime/release-source.json`에 배포 소스 manifest를 기록합니다. repo path, branch, HEAD, upstream ref/SHA, dirty 여부, source binary, 최신 migration 파일명/sha256, signing mode, ad-hoc override 여부, turn-drain/freshness override 값을 포함합니다.

### Fix 2
Doctor Postgres preflight가 `missing_from_resolved`, `unsuccessful_versions`, `checksum_mismatches` evidence를 직접 검사합니다. drift evidence가 있으면 detail과 actual만 출력하던 기존 메시지보다 명확하게 어떤 drift가 promotion을 막았는지 보여줍니다.

### Fix 3
codesign fallback 경로에서 실제 signing mode를 `developer-id` 또는 `adhoc`으로 기록합니다. Developer ID 부재로 ad-hoc override를 쓴 배포와 정상 Developer ID 배포를 후속 분석에서 구분할 수 있습니다.

### Fix 4
`migrations/postgres` 디렉터리가 없는 partial/older checkout에서도 최신 migration helper가 빈 값으로 성공합니다. `AGENTDESK_DEPLOY_BINARY` 같은 binary-only 배포 흐름에서 release health 성공 뒤 manifest 작성 때문에 실패로 뒤집히는 일을 막습니다.

## Before → After

| 시나리오 | Before | After |
|---|---|---|
| 임시 checkout에서 release 성공 | 로그를 잃으면 source path/commit 추적이 어려움 | `runtime/release-source.json`으로 실제 배포 source/HEAD/migration 확인 |
| DB에 적용된 migration이 binary resolved set에 없음 | doctor detail을 해석해야 함 | preflight 출력에 drift evidence가 직접 표시됨 |
| Developer ID 없음 + ad-hoc override | 로그에서만 fallback 확인 | manifest에 `signing_mode=adhoc` 기록 |
| migration dir 없는 partial checkout | health 성공 뒤 manifest helper가 false failure 가능 | 최신 migration 값만 비우고 manifest 작성 계속 진행 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
|---|---|---|
| 정상 Developer ID 배포 | manifest에 `developer-id` 기록 | 기존 signing 흐름 유지 |
| ad-hoc override 배포 | 기존처럼 명시 override가 있어야 진행, manifest에 `adhoc` 기록 | 재현성 개선 |
| pending migration 존재 | 기존 정책대로 pending 자체는 실패로 보지 않음 | 신규 migration rollout 방해 없음 |
| migration dir 없음 | `latest_postgres_migration`/sha만 빈 값으로 기록 | binary-only/partial checkout 배포 보호 |

## 해결한 내용

- `scripts/deploy-release.sh`: release source manifest 작성 함수를 추가하고, 성공 health check 뒤 manifest를 atomically 기록합니다.
- `scripts/deploy-release.sh`: Postgres preflight Python 검사에서 drift evidence를 직접 확인하도록 보강했습니다.
- `scripts/deploy-release.sh`: signing fallback 결과를 manifest에 기록할 수 있도록 실제 signing mode를 추적합니다.
- `scripts/deploy-release.sh`: migration 디렉터리 부재를 정상적인 empty manifest field로 처리합니다.

## 검증

- `bash -n scripts/deploy-release.sh`
- `shellcheck -P scripts -x scripts/deploy-release.sh`
- missing `migrations/postgres` directory helper reproduction under `set -euo pipefail`
- `git diff --check`