### PR TITLE
Sync MCP servers for Qwen and Gemini

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -51,6 +51,12 @@ pub(crate) fn initialize() -> Result<BootstrapState> {
     if let Err(error) = crate::services::mcp_config::sync_opencode_mcp_servers(&config) {
         tracing::warn!("  [mcp] Failed to sync OpenCode MCP servers: {error}");
     }
+    if let Err(error) = crate::services::mcp_config::sync_qwen_mcp_servers(&config) {
+        tracing::warn!("  [mcp] Failed to sync Qwen MCP servers: {error}");
+    }
+    if let Err(error) = crate::services::mcp_config::sync_gemini_mcp_servers(&config) {
+        tracing::warn!("  [mcp] Failed to sync Gemini MCP servers: {error}");
+    }
 
     // #1699: install the prompt-manifest retention snapshot so write-time
     // truncation in `db::prompt_manifests::save_prompt_manifest_pg` reflects

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -619,6 +619,8 @@ pub(crate) enum ConfigAction {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Sync runtime MCP servers into provider config files
+    SyncMcp,
 }
 
 #[derive(Clone, ValueEnum)]

--- a/src/cli/client.rs
+++ b/src/cli/client.rs
@@ -856,6 +856,63 @@ pub fn cmd_config_audit(dry_run: bool) -> Result<(), String> {
     Ok(())
 }
 
+/// `agentdesk config sync-mcp`
+pub fn cmd_config_sync_mcp() -> Result<(), String> {
+    let root = crate::config::runtime_root()
+        .ok_or_else(|| "Failed to resolve AGENTDESK_ROOT_DIR".to_string())?;
+    crate::runtime_layout::ensure_runtime_layout(&root)?;
+    let loaded = crate::services::discord_config_audit::load_runtime_config(&root)?;
+    let config = loaded.config;
+
+    let mut providers = Vec::new();
+    let mut failures = Vec::new();
+    for (provider, result) in [
+        (
+            "codex",
+            crate::services::mcp_config::sync_codex_mcp_servers(&config),
+        ),
+        (
+            "opencode",
+            crate::services::mcp_config::sync_opencode_mcp_servers(&config),
+        ),
+        (
+            "qwen",
+            crate::services::mcp_config::sync_qwen_mcp_servers(&config),
+        ),
+        (
+            "gemini",
+            crate::services::mcp_config::sync_gemini_mcp_servers(&config),
+        ),
+    ] {
+        match result {
+            Ok(()) => providers.push(serde_json::json!({
+                "provider": provider,
+                "ok": true,
+            })),
+            Err(error) => {
+                failures.push(provider.to_string());
+                providers.push(serde_json::json!({
+                    "provider": provider,
+                    "ok": false,
+                    "error": error,
+                }));
+            }
+        }
+    }
+
+    print_json(&serde_json::json!({
+        "ok": failures.is_empty(),
+        "config_path": loaded.path,
+        "providers": providers,
+    }));
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(format!("MCP sync failed for {}", failures.join(", ")))
+    }
+}
+
 /// `agentdesk api <method> <path> [body]`
 pub fn cmd_api(method: &str, path: &str, body: Option<&str>) -> Result<(), String> {
     let value = api_call(method, path, body)?;

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -373,6 +373,7 @@ pub(crate) fn execute(command: Commands) -> Result<()> {
             ConfigAction::Get => super::client::cmd_config_get(),
             ConfigAction::Set { json } => super::client::cmd_config_set(&json),
             ConfigAction::Audit { dry_run } => super::client::cmd_config_audit(dry_run),
+            ConfigAction::SyncMcp => super::client::cmd_config_sync_mcp(),
         }),
         Commands::Api { method, path, body } => {
             exit_for_cli(super::client::cmd_api(&method, &path, body.as_deref()))

--- a/src/services/mcp_config.rs
+++ b/src/services/mcp_config.rs
@@ -10,6 +10,8 @@ use crate::services::provider::ProviderKind;
 
 const CODEX_SYNC_STATE_FILE: &str = "codex-mcp-sync-state.json";
 const OPENCODE_SYNC_STATE_FILE: &str = "opencode-mcp-sync-state.json";
+const QWEN_SYNC_STATE_FILE: &str = "qwen-mcp-sync-state.json";
+const GEMINI_SYNC_STATE_FILE: &str = "gemini-mcp-sync-state.json";
 const MEMENTO_SERVER_NAME: &str = "memento";
 const REVIEW_MCP_ALLOWLIST_ENV: &str = "AGENTDESK_REVIEW_MCP_ALLOWLIST";
 const DEFAULT_REVIEW_MCP_ALLOWLIST: &[&str] = &[
@@ -50,6 +52,18 @@ struct OpenCodeMcpSyncState {
     managed_servers: Vec<String>,
 }
 
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct QwenMcpSyncState {
+    #[serde(default)]
+    managed_servers: Vec<String>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct GeminiMcpSyncState {
+    #[serde(default)]
+    managed_servers: Vec<String>,
+}
+
 pub(crate) fn provider_has_memento_mcp(provider: &ProviderKind) -> bool {
     provider_has_mcp_server(provider, MEMENTO_SERVER_NAME)
 }
@@ -71,6 +85,12 @@ pub(crate) fn provider_has_mcp_server(provider: &ProviderKind, server_name: &str
         ProviderKind::OpenCode => {
             runtime_config_contains_server(normalized)
                 || opencode_config_contains_server(normalized)
+        }
+        ProviderKind::Qwen => {
+            runtime_config_contains_server(normalized) || qwen_config_contains_server(normalized)
+        }
+        ProviderKind::Gemini => {
+            runtime_config_contains_server(normalized) || gemini_config_contains_server(normalized)
         }
         _ => false,
     }
@@ -199,6 +219,82 @@ pub(crate) fn sync_opencode_mcp_servers(config: &Config) -> Result<(), String> {
     };
     let serialized = serde_json::to_string_pretty(&next_state)
         .map_err(|error| format!("Failed to serialize OpenCode MCP sync state: {error}"))?;
+    atomic_write(&sync_state_path, &serialized)?;
+    Ok(())
+}
+
+pub(crate) fn sync_qwen_mcp_servers(config: &Config) -> Result<(), String> {
+    let runtime_root = crate::config::runtime_root()
+        .ok_or_else(|| "AGENTDESK_ROOT_DIR is unavailable".to_string())?;
+    let sync_state_path =
+        crate::runtime_layout::config_dir(&runtime_root).join(QWEN_SYNC_STATE_FILE);
+    let desired = resolved_mcp_servers(config, None);
+    let previous = load_qwen_sync_state_from_path(&sync_state_path);
+    let desired_names = desired.keys().cloned().collect::<BTreeSet<_>>();
+    let previous_names = previous
+        .managed_servers
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+
+    if desired_names.is_empty() && previous_names.is_empty() {
+        return Ok(());
+    }
+
+    let Some(config_path) = qwen_config_path() else {
+        return Err("Qwen config path unavailable".to_string());
+    };
+    sync_json_mcp_servers(
+        &config_path,
+        &desired,
+        &desired_names,
+        &previous_names,
+        qwen_mcp_entry,
+        "Qwen",
+    )?;
+
+    let next_state = QwenMcpSyncState {
+        managed_servers: desired_names.into_iter().collect(),
+    };
+    let serialized = serde_json::to_string_pretty(&next_state)
+        .map_err(|error| format!("Failed to serialize Qwen MCP sync state: {error}"))?;
+    atomic_write(&sync_state_path, &serialized)?;
+    Ok(())
+}
+
+pub(crate) fn sync_gemini_mcp_servers(config: &Config) -> Result<(), String> {
+    let runtime_root = crate::config::runtime_root()
+        .ok_or_else(|| "AGENTDESK_ROOT_DIR is unavailable".to_string())?;
+    let sync_state_path =
+        crate::runtime_layout::config_dir(&runtime_root).join(GEMINI_SYNC_STATE_FILE);
+    let desired = resolved_mcp_servers(config, None);
+    let previous = load_gemini_sync_state_from_path(&sync_state_path);
+    let desired_names = desired.keys().cloned().collect::<BTreeSet<_>>();
+    let previous_names = previous
+        .managed_servers
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+
+    if desired_names.is_empty() && previous_names.is_empty() {
+        return Ok(());
+    }
+
+    let Some(config_path) = gemini_config_path() else {
+        return Err("Gemini config path unavailable".to_string());
+    };
+    sync_json_mcp_servers(
+        &config_path,
+        &desired,
+        &desired_names,
+        &previous_names,
+        gemini_mcp_entry,
+        "Gemini",
+    )?;
+
+    let next_state = GeminiMcpSyncState {
+        managed_servers: desired_names.into_iter().collect(),
+    };
+    let serialized = serde_json::to_string_pretty(&next_state)
+        .map_err(|error| format!("Failed to serialize Gemini MCP sync state: {error}"))?;
     atomic_write(&sync_state_path, &serialized)?;
     Ok(())
 }
@@ -499,6 +595,20 @@ fn load_opencode_sync_state_from_path(path: &Path) -> OpenCodeMcpSyncState {
         .unwrap_or_default()
 }
 
+fn load_qwen_sync_state_from_path(path: &Path) -> QwenMcpSyncState {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<QwenMcpSyncState>(&raw).ok())
+        .unwrap_or_default()
+}
+
+fn load_gemini_sync_state_from_path(path: &Path) -> GeminiMcpSyncState {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<GeminiMcpSyncState>(&raw).ok())
+        .unwrap_or_default()
+}
+
 fn claude_global_mcp_config_contains_server(server_name: &str) -> bool {
     let Some(path) = current_home_dir().map(|home| home.join(".claude").join(".mcp.json")) else {
         return false;
@@ -531,21 +641,82 @@ fn opencode_config_path() -> Option<PathBuf> {
     current_home_dir().map(|home| home.join(".config").join("opencode").join("opencode.json"))
 }
 
+fn qwen_config_path() -> Option<PathBuf> {
+    std::env::var_os("QWEN_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(current_home_dir)
+        .map(|home| home.join(".qwen").join("settings.json"))
+}
+
+fn gemini_config_path() -> Option<PathBuf> {
+    std::env::var_os("GEMINI_CLI_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(current_home_dir)
+        .map(|home| home.join(".gemini").join("settings.json"))
+}
+
 fn load_opencode_config_value(path: &Path) -> Result<Value, String> {
+    load_json_object_config_value(path, "OpenCode")
+}
+
+fn load_json_object_config_value(path: &Path, label: &str) -> Result<Value, String> {
     match std::fs::read_to_string(path) {
         Ok(raw) if raw.trim().is_empty() => Ok(Value::Object(Map::new())),
-        Ok(raw) => serde_json::from_str::<Value>(&raw).map_err(|error| {
-            format!(
-                "Failed to parse OpenCode config {}: {error}",
-                path.display()
-            )
-        }),
+        Ok(raw) => serde_json::from_str::<Value>(&raw)
+            .map_err(|error| format!("Failed to parse {label} config {}: {error}", path.display())),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Value::Object(Map::new())),
         Err(error) => Err(format!(
-            "Failed to read OpenCode config {}: {error}",
+            "Failed to read {label} config {}: {error}",
             path.display()
         )),
     }
+}
+
+fn sync_json_mcp_servers(
+    config_path: &Path,
+    desired: &BTreeMap<String, ResolvedMcpServer>,
+    desired_names: &BTreeSet<String>,
+    previous_names: &BTreeSet<String>,
+    entry_fn: fn(&ResolvedMcpServer) -> Value,
+    label: &str,
+) -> Result<(), String> {
+    let mut root = load_json_object_config_value(config_path, label)?;
+    let root_object = root.as_object_mut().ok_or_else(|| {
+        format!(
+            "{label} config must be a JSON object: {}",
+            config_path.display()
+        )
+    })?;
+
+    let mcp_value = root_object
+        .entry("mcpServers".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    let mcp_servers = mcp_value
+        .as_object_mut()
+        .ok_or_else(|| format!("{label} config field `mcpServers` must be a JSON object"))?;
+
+    for removed in previous_names.difference(desired_names) {
+        mcp_servers.remove(removed);
+    }
+
+    for server in desired.values() {
+        mcp_servers.insert(server.name.clone(), entry_fn(server));
+    }
+
+    let serialized = serde_json::to_string_pretty(&root)
+        .map_err(|error| format!("Failed to serialize {label} config: {error}"))?;
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "Failed to create {label} config directory {}: {error}",
+                parent.display()
+            )
+        })?;
+    }
+    atomic_write(config_path, &serialized)?;
+    Ok(())
 }
 
 fn opencode_mcp_entry(server: &ResolvedMcpServer) -> Value {
@@ -569,6 +740,46 @@ fn opencode_mcp_entry(server: &ResolvedMcpServer) -> Value {
     Value::Object(entry)
 }
 
+fn qwen_mcp_entry(server: &ResolvedMcpServer) -> Value {
+    let mut entry = Map::new();
+    entry.insert("httpUrl".to_string(), Value::String(server.url.clone()));
+    entry.insert("trust".to_string(), Value::Bool(true));
+    if let Some(headers) = bearer_headers(server, "${", "}") {
+        entry.insert("headers".to_string(), Value::Object(headers));
+    }
+    Value::Object(entry)
+}
+
+fn gemini_mcp_entry(server: &ResolvedMcpServer) -> Value {
+    let mut entry = Map::new();
+    entry.insert("httpUrl".to_string(), Value::String(server.url.clone()));
+    entry.insert("trust".to_string(), Value::Bool(true));
+    if let Some(headers) = bearer_headers(server, "${", "}") {
+        entry.insert("headers".to_string(), Value::Object(headers));
+    }
+    Value::Object(entry)
+}
+
+fn bearer_headers(
+    server: &ResolvedMcpServer,
+    env_var_prefix: &str,
+    env_var_suffix: &str,
+) -> Option<Map<String, Value>> {
+    let token_env_var = server
+        .bearer_token_env_var
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    let mut headers = Map::new();
+    headers.insert(
+        "Authorization".to_string(),
+        Value::String(format!(
+            "Bearer {env_var_prefix}{token_env_var}{env_var_suffix}"
+        )),
+    );
+    Some(headers)
+}
+
 fn opencode_config_contains_server(server_name: &str) -> bool {
     let Some(path) = opencode_config_path() else {
         return false;
@@ -586,6 +797,33 @@ fn opencode_config_contains_server(server_name: &str) -> bool {
             .and_then(|servers| servers.get(server_name))
             .is_some_and(opencode_mcp_entry_enabled)
     })
+}
+
+fn qwen_config_contains_server(server_name: &str) -> bool {
+    let Some(path) = qwen_config_path() else {
+        return false;
+    };
+    json_mcp_config_contains_server(&path, server_name)
+}
+
+fn gemini_config_contains_server(server_name: &str) -> bool {
+    let Some(path) = gemini_config_path() else {
+        return false;
+    };
+    json_mcp_config_contains_server(&path, server_name)
+}
+
+fn json_mcp_config_contains_server(path: &Path, server_name: &str) -> bool {
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<Value>(&raw) else {
+        return false;
+    };
+    value
+        .get("mcpServers")
+        .and_then(Value::as_object)
+        .is_some_and(|servers| servers.contains_key(server_name))
 }
 
 fn opencode_mcp_entry_enabled(value: &Value) -> bool {
@@ -667,11 +905,15 @@ mod tests {
         let previous_userprofile = std::env::var_os("USERPROFILE");
         let previous_path = std::env::var_os("PATH");
         let previous_review_mcp_allowlist = std::env::var_os(REVIEW_MCP_ALLOWLIST_ENV);
+        let previous_qwen_home = std::env::var_os("QWEN_HOME");
+        let previous_gemini_cli_home = std::env::var_os("GEMINI_CLI_HOME");
         unsafe {
             std::env::set_var("AGENTDESK_ROOT_DIR", &runtime_root);
             std::env::set_var("HOME", temp.path());
             std::env::set_var("USERPROFILE", temp.path());
             std::env::remove_var(REVIEW_MCP_ALLOWLIST_ENV);
+            std::env::set_var("QWEN_HOME", temp.path());
+            std::env::set_var("GEMINI_CLI_HOME", temp.path());
         }
         f(temp.path());
         match previous_root {
@@ -693,6 +935,14 @@ mod tests {
         match previous_review_mcp_allowlist {
             Some(value) => unsafe { std::env::set_var(REVIEW_MCP_ALLOWLIST_ENV, value) },
             None => unsafe { std::env::remove_var(REVIEW_MCP_ALLOWLIST_ENV) },
+        }
+        match previous_qwen_home {
+            Some(value) => unsafe { std::env::set_var("QWEN_HOME", value) },
+            None => unsafe { std::env::remove_var("QWEN_HOME") },
+        }
+        match previous_gemini_cli_home {
+            Some(value) => unsafe { std::env::set_var("GEMINI_CLI_HOME", value) },
+            None => unsafe { std::env::remove_var("GEMINI_CLI_HOME") },
         }
     }
 
@@ -736,7 +986,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_has_memento_mcp_reflects_runtime_config_for_claude_codex_and_opencode() {
+    fn provider_has_memento_mcp_reflects_runtime_config_for_mcp_aware_providers() {
         with_test_env(|temp_root| {
             let runtime_root = temp_root.join(".adk").join("release");
             let config_path = crate::runtime_layout::config_file_path(&runtime_root);
@@ -753,6 +1003,8 @@ mod tests {
             assert!(provider_has_memento_mcp(&ProviderKind::Claude));
             assert!(provider_has_memento_mcp(&ProviderKind::Codex));
             assert!(provider_has_memento_mcp(&ProviderKind::OpenCode));
+            assert!(provider_has_memento_mcp(&ProviderKind::Qwen));
+            assert!(provider_has_memento_mcp(&ProviderKind::Gemini));
         });
     }
 
@@ -806,6 +1058,29 @@ mod tests {
                 &ProviderKind::OpenCode,
                 "disabled"
             ));
+        });
+    }
+
+    #[test]
+    fn provider_has_mcp_server_detects_manual_qwen_and_gemini_config() {
+        with_test_env(|temp_root| {
+            let qwen_dir = temp_root.join(".qwen");
+            let gemini_dir = temp_root.join(".gemini");
+            fs::create_dir_all(&qwen_dir).unwrap();
+            fs::create_dir_all(&gemini_dir).unwrap();
+            fs::write(
+                qwen_dir.join("settings.json"),
+                r#"{"mcpServers":{"manual":{"httpUrl":"http://manual.local/mcp"}}}"#,
+            )
+            .unwrap();
+            fs::write(
+                gemini_dir.join("settings.json"),
+                r#"{"mcpServers":{"manual":{"httpUrl":"http://manual.local/mcp"}}}"#,
+            )
+            .unwrap();
+
+            assert!(provider_has_mcp_server(&ProviderKind::Qwen, "manual"));
+            assert!(provider_has_mcp_server(&ProviderKind::Gemini, "manual"));
         });
     }
 
@@ -1067,6 +1342,144 @@ exit 1
             let err = sync_opencode_mcp_servers(&config).unwrap_err();
             assert!(err.contains("Failed to parse OpenCode config"));
             assert_eq!(fs::read_to_string(config_path).unwrap(), "{not-json");
+        });
+    }
+
+    #[test]
+    fn sync_qwen_mcp_servers_updates_managed_servers_without_touching_others() {
+        with_test_env(|temp_root| {
+            let runtime_root = temp_root.join(".adk").join("release");
+            let qwen_dir = temp_root.join(".qwen");
+            fs::create_dir_all(&qwen_dir).unwrap();
+            fs::write(
+                qwen_dir.join("settings.json"),
+                r#"{"mcpServers":{"serena":{"command":"serena","args":["start-mcp-server"]},"old":{"httpUrl":"http://old.local/mcp"}},"tools":{"approvalMode":"yolo"}}"#,
+            )
+            .unwrap();
+            let sync_state_path =
+                crate::runtime_layout::config_dir(&runtime_root).join(QWEN_SYNC_STATE_FILE);
+            fs::write(
+                &sync_state_path,
+                serde_json::to_string(&QwenMcpSyncState {
+                    managed_servers: vec!["old".to_string()],
+                })
+                .unwrap(),
+            )
+            .unwrap();
+
+            let mut config = Config::default();
+            config.mcp_servers.insert(
+                "memento".to_string(),
+                McpServerConfig {
+                    url: "http://localhost:57332/mcp".to_string(),
+                    auth: Some(crate::config::McpServerAuthConfig {
+                        auth_type: McpServerAuthType::Bearer,
+                        token_env_var: Some("MEMENTO_ACCESS_KEY".to_string()),
+                    }),
+                },
+            );
+            config.mcp_servers.insert(
+                "context7".to_string(),
+                McpServerConfig {
+                    url: "https://mcp.context7.com/mcp".to_string(),
+                    auth: Some(crate::config::McpServerAuthConfig {
+                        auth_type: McpServerAuthType::Bearer,
+                        token_env_var: Some("CONTEXT7_API_KEY".to_string()),
+                    }),
+                },
+            );
+
+            sync_qwen_mcp_servers(&config).unwrap();
+
+            let rendered = fs::read_to_string(qwen_dir.join("settings.json")).unwrap();
+            let value: Value = serde_json::from_str(&rendered).unwrap();
+            assert!(value["mcpServers"]["serena"].is_object());
+            assert!(value["mcpServers"]["old"].is_null());
+            assert_eq!(
+                value["mcpServers"]["memento"]["httpUrl"],
+                json!("http://localhost:57332/mcp")
+            );
+            assert_eq!(
+                value["mcpServers"]["context7"]["headers"]["Authorization"],
+                json!("Bearer ${CONTEXT7_API_KEY}")
+            );
+            assert_eq!(value["tools"]["approvalMode"], json!("yolo"));
+
+            let state = load_qwen_sync_state_from_path(&sync_state_path);
+            assert_eq!(
+                state.managed_servers,
+                vec!["context7".to_string(), "memento".to_string()]
+            );
+            assert!(provider_has_mcp_server(&ProviderKind::Qwen, "context7"));
+        });
+    }
+
+    #[test]
+    fn sync_gemini_mcp_servers_updates_managed_servers_without_touching_others() {
+        with_test_env(|temp_root| {
+            let runtime_root = temp_root.join(".adk").join("release");
+            let gemini_dir = temp_root.join(".gemini");
+            fs::create_dir_all(&gemini_dir).unwrap();
+            fs::write(
+                gemini_dir.join("settings.json"),
+                r#"{"mcpServers":{"serena":{"command":"serena","args":["start-mcp-server"]},"old":{"httpUrl":"http://old.local/mcp"}},"approvalMode":"yolo"}"#,
+            )
+            .unwrap();
+            let sync_state_path =
+                crate::runtime_layout::config_dir(&runtime_root).join(GEMINI_SYNC_STATE_FILE);
+            fs::write(
+                &sync_state_path,
+                serde_json::to_string(&GeminiMcpSyncState {
+                    managed_servers: vec!["old".to_string()],
+                })
+                .unwrap(),
+            )
+            .unwrap();
+
+            let mut config = Config::default();
+            config.mcp_servers.insert(
+                "memento".to_string(),
+                McpServerConfig {
+                    url: "http://localhost:57332/mcp".to_string(),
+                    auth: Some(crate::config::McpServerAuthConfig {
+                        auth_type: McpServerAuthType::Bearer,
+                        token_env_var: Some("MEMENTO_ACCESS_KEY".to_string()),
+                    }),
+                },
+            );
+            config.mcp_servers.insert(
+                "context7".to_string(),
+                McpServerConfig {
+                    url: "https://mcp.context7.com/mcp".to_string(),
+                    auth: Some(crate::config::McpServerAuthConfig {
+                        auth_type: McpServerAuthType::Bearer,
+                        token_env_var: Some("CONTEXT7_API_KEY".to_string()),
+                    }),
+                },
+            );
+
+            sync_gemini_mcp_servers(&config).unwrap();
+
+            let rendered = fs::read_to_string(gemini_dir.join("settings.json")).unwrap();
+            let value: Value = serde_json::from_str(&rendered).unwrap();
+            assert!(value["mcpServers"]["serena"].is_object());
+            assert!(value["mcpServers"]["old"].is_null());
+            assert_eq!(
+                value["mcpServers"]["memento"]["httpUrl"],
+                json!("http://localhost:57332/mcp")
+            );
+            assert_eq!(
+                value["mcpServers"]["context7"]["headers"]["Authorization"],
+                json!("Bearer ${CONTEXT7_API_KEY}")
+            );
+            assert_eq!(value["approvalMode"], json!("yolo"));
+
+            let state = load_gemini_sync_state_from_path(&sync_state_path);
+            assert_eq!(
+                state.managed_servers,
+                vec!["context7".to_string(), "memento".to_string()]
+            );
+            assert!(provider_has_mcp_server(&ProviderKind::Gemini, "context7"));
         });
     }
 }


### PR DESCRIPTION
## 목표
Qwen/Gemini도 AgentDesk 중앙 `mcp_servers` 설정을 provider별 설정 파일에 동기화해서, 중앙 MCP 변경이 Codex/OpenCode뿐 아니라 Qwen/Gemini에도 같은 방식으로 반영되게 합니다.

## 쉬운 설명
운영자는 MCP 서버를 AgentDesk 중앙 설정에 한 번만 추가하면 됩니다. AgentDesk 시작 시 Qwen/Gemini 설정도 자동으로 맞춰지고, 필요하면 `agentdesk config sync-mcp`로 재시작 없이 수동 재동기화할 수 있습니다. 기존 수동 MCP 항목과 provider 고유 설정은 유지합니다.

## 개선되는 것
### Fix 1
Qwen/Gemini가 중앙 MCP 설정에서 빠지는 드리프트를 줄입니다. bootstrap 단계에서 Codex/OpenCode와 같은 경로로 Qwen/Gemini 동기화를 실행합니다.

### Fix 2
수동 복구와 QA preflight를 위한 `agentdesk config sync-mcp` CLI를 추가합니다. provider별 성공/실패를 JSON으로 확인할 수 있습니다.

### Fix 3
Qwen/Gemini `settings.json`의 `mcpServers`만 관리하고, 기존 수동 MCP 서버와 다른 설정 키는 건드리지 않도록 회귀 테스트를 추가했습니다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| 중앙 `mcp_servers`에 context7 추가 | Qwen/Gemini는 별도 수동 설정 필요 | Qwen/Gemini `mcpServers`에도 동기화 |
| 운영 중 MCP 재동기화 | AgentDesk 재시작이나 수동 편집 의존 | `agentdesk config sync-mcp`로 즉시 재적용 |
| 기존 수동 MCP 서버 | 자동 동기화가 덮어쓸 위험 | managed state 외 항목은 유지 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| Qwen/Gemini 설정 파일에 `serena` 수동 항목 존재 | `serena` 유지, 중앙 MCP만 추가/갱신 | 수동 설정 보존 |
| 이전 managed 항목이 중앙 설정에서 삭제됨 | sync state에 기록된 항목만 제거 | stale 중앙 MCP 정리 가능 |
| bearer token MCP 서버 | 실제 토큰 대신 env var 참조를 기록 | secret 직접 저장 회피 |

## 해결한 내용
- `src/bootstrap.rs`: bootstrap MCP 동기화 대상에 Qwen/Gemini 추가
- `src/cli/args.rs`, `src/cli/run.rs`, `src/cli/client.rs`: `agentdesk config sync-mcp` CLI 추가 및 provider별 결과 JSON 출력
- `src/services/mcp_config.rs`: Qwen/Gemini 설정 경로, managed sync state, JSON MCP entry 렌더링, provider MCP 감지, 회귀 테스트 추가

## 검증
- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo test services::mcp_config --features legacy-sqlite-tests -- --nocapture` (16 passed)