### PR TITLE
fix(timeouts): cap idle force-kill fanout

### DIFF
--- a/policies/timeouts/idle-kill.js
+++ b/policies/timeouts/idle-kill.js
@@ -59,8 +59,14 @@ module.exports = function attachIdleKill(timeouts, helpers) {
       var now = Date.now();
       var processed = {};
 
-      function forceKillIdleSessions(sessions, minimumIdleMinutes, reasonLabel) {
+      function forceKillIdleSessions(sessions, minimumIdleMinutes, reasonLabel, maxKills) {
+        var killedCount = 0;
         for (var i = 0; i < sessions.length; i++) {
+          if (killedCount >= maxKills) {
+            agentdesk.log.info("[idle-kill] Reached max " + maxKills + " kills for this category. Breaking early.");
+            break;
+          }
+
           var s = sessions[i];
           if (!s.session_key || processed[s.session_key]) continue;
           processed[s.session_key] = true;
@@ -85,6 +91,8 @@ module.exports = function attachIdleKill(timeouts, helpers) {
             continue;
           }
 
+          killedCount++;
+
           if (!forceKillResp.tmux_killed) {
             agentdesk.log.warn("[idle-kill] force-kill API succeeded but tmux was already gone for " + s.session_key);
             continue;
@@ -99,7 +107,7 @@ module.exports = function attachIdleKill(timeouts, helpers) {
         }
       }
 
-      forceKillIdleSessions(idleSessions, 60, "idle 60분 경과 (active_dispatch_id 없음)");
-      forceKillIdleSessions(safetySessions, 180, "idle 180분 경과 (safety TTL)");
+      forceKillIdleSessions(safetySessions, 180, "idle 180분 경과 (safety TTL)", 2);
+      forceKillIdleSessions(idleSessions, 60, "idle 60분 경과 (active_dispatch_id 없음)", 3);
     };
 };


### PR DESCRIPTION
## 목표
idle session force-kill policy가 한 번의 tick에서 과도한 loopback force-kill 요청을 보내지 않도록 category별 처리량을 제한합니다.

## 쉬운 설명
오래 idle 상태인 세션이 많이 쌓여도 한 번에 모두 죽이려 하지 않습니다. safety TTL 세션과 일반 idle 세션을 나눠 작은 batch로 처리합니다. 실패한 force-kill 응답은 처리량 카운트에 포함하지 않아 다음 후보를 계속 확인합니다.

## 개선되는 것
### Fix 1
Before: idle-kill tick이 조회된 후보를 제한 없이 순회했습니다.
After: safety TTL은 tick당 2개, 일반 idle은 tick당 3개까지만 성공 응답 기준으로 처리합니다.

## Before → After
| 시나리오 | Before | After |
|---|---|---|
| idle 후보 다수 | 한 tick에서 연속 force-kill 요청 | category별 작은 batch로 제한 |
| force-kill 실패 | 실패 후보도 처리 흐름을 소모할 수 있음 | 성공 응답 이후에만 kill count 증가 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
|---|---|---|
| tmux가 이미 사라진 세션 | API 성공 후 warn 로그 유지 | 기존 처리 보존 |
| API 실패 | error 로그 후 다음 후보 진행 | 실패로 batch count를 낭비하지 않음 |

## 해결한 내용
- `policies/timeouts/idle-kill.js`: `forceKillIdleSessions`에 `maxKills` 인자를 추가하고 safety/general idle 순서와 limit을 명시했습니다.

## 검증
- `npm run test:policies` 통과: 88 pass.