### PR TITLE
refactor(policies): use card facade in queue labels and pipeline transitions

### DIFF
--- a/policies/__tests__/auto-queue-facade.test.js
+++ b/policies/__tests__/auto-queue-facade.test.js
@@ -1,0 +1,84 @@
+var test = require("node:test");
+var assert = require("node:assert");
+
+// Set up mock agentdesk
+global.agentdesk = {
+  db: {
+    query: function(sql, params) {
+      throw new Error("agentdesk.db.query should not be called in typed-facade test");
+    }
+  },
+  cards: {
+    get: function(id) {
+      if (id === "card-123") {
+        return {
+          id: "card-123",
+          title: "Fix bug",
+          github_issue_number: "42"
+        };
+      }
+      if (id === "card-456") {
+        return {
+          id: "card-456",
+          title: "Refactor code"
+        };
+      }
+      return null;
+    }
+  },
+  kv: {
+    set: function() {},
+    delete: function() {}
+  }
+};
+
+test("auto-queue loadPhaseGateCardLabel uses typed facade agentdesk.cards.get", () => {
+  // We need to load auto-queue.js to test it, but it might execute some top-level stuff.
+  // The simplest way to test the function is to eval the file content and extract the function.
+  var fs = require("fs");
+  var content = fs.readFileSync(__dirname + "/../auto-queue.js", "utf8");
+
+  // Create a function from the file content, returning loadPhaseGateCardLabel
+  var getFunc = new Function(
+    "require", "module", "agentdesk",
+    content + "; return loadPhaseGateCardLabel;"
+  );
+
+  // Create dummy require for the internal dependencies
+  var dummyRequire = function(path) {
+    return {
+      hasValue: function() {},
+      logContextKeys: [],
+      mergeLogContext: function() {},
+      loadEntryLogContext: function() {},
+      loadDispatchLogContext: function() {},
+      normalizeLogContext: function() {},
+      formatLogContext: function() {},
+      autoQueueLog: function() {},
+      maxEntryRetries: 3,
+      staleDispatchedGraceMinutes: 30,
+      staleDispatchedTerminalStatuses: [],
+      staleDispatchedRecoverNullDispatch: false,
+      staleDispatchedRecoverMissingDispatch: false,
+      staleDispatchedRecoveryConditionsSql: ""
+    };
+  };
+
+  var loadPhaseGateCardLabel = getFunc(dummyRequire, {}, global.agentdesk);
+
+  // Test 1: Full card
+  var label1 = loadPhaseGateCardLabel("card-123");
+  assert.strictEqual(label1, "#42 Fix bug");
+
+  // Test 2: Card without issue number
+  var label2 = loadPhaseGateCardLabel("card-456");
+  assert.strictEqual(label2, "Refactor code");
+
+  // Test 3: Missing card
+  var label3 = loadPhaseGateCardLabel("missing-card");
+  assert.strictEqual(label3, "missing-card");
+
+  // Test 4: Empty cardId
+  var label4 = loadPhaseGateCardLabel(null);
+  assert.strictEqual(label4, "unknown card");
+});

--- a/policies/__tests__/pipeline-transition.test.js
+++ b/policies/__tests__/pipeline-transition.test.js
@@ -1,0 +1,65 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const fs = require("fs");
+
+function createSqlRouter(routes) {
+  return function dbQuery(sql, params) {
+    for (let r of routes) {
+      if (typeof r.match === "string" && sql.includes(r.match)) {
+        return typeof r.result === "function" ? r.result(params) : r.result || [];
+      }
+      if (r.match instanceof RegExp && r.match.test(sql)) {
+        return typeof r.result === "function" ? r.result(params) : r.result || [];
+      }
+    }
+    return [];
+  };
+}
+
+function loadPolicy(path, mockContext) {
+  const code = fs.readFileSync(path, "utf8");
+  let registered = null;
+  const agentdesk = {
+    registerPolicy: (p) => { registered = p; },
+    log: { info: () => {}, warn: () => {}, error: () => {} },
+    ...mockContext
+  };
+  const fn = new Function("agentdesk", code);
+  fn(agentdesk);
+  return { module: registered, agentdesk };
+}
+
+test("pipeline onCardTransition uses typed facade agentdesk.cards.get", () => {
+  let executeCalls = [];
+  const { module } = loadPolicy("policies/pipeline.js", {
+    db: {
+      query: createSqlRouter([
+        {
+          match: "SELECT id, stage_name, agent_override_id FROM pipeline_stages",
+          result: [{ id: "stage-1", stage_name: "deploy", agent_override_id: null }]
+        }
+      ]),
+      execute: (sql, params) => { executeCalls.push({ sql, params }); }
+    },
+    pipeline: {
+      resolveForCard: (cardId) => ({
+        states: [{ id: "ready", terminal: false }],
+        transitions: [{ from: "ready", type: "gated" }]
+      })
+    },
+    cards: {
+      get: (cardId) => {
+        if (cardId === "card-missing") return null;
+        if (cardId === "card-1") return { id: "card-1", repo_id: "repo-1" };
+        return null;
+      }
+    }
+  });
+
+  module.onCardTransition({ card_id: "card-missing", to: "ready" });
+  assert.equal(executeCalls.length, 0);
+
+  module.onCardTransition({ card_id: "card-1", to: "ready" });
+  assert.equal(executeCalls.length, 1);
+  assert.ok(executeCalls[0].sql.includes("UPDATE kanban_cards SET pipeline_stage_id"));
+});

--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -100,15 +100,12 @@ function resetPhaseGateFailureCount(cardId, phase) {
 
 function loadPhaseGateCardLabel(cardId) {
   if (!cardId) return "unknown card";
-  var rows = agentdesk.db.query(
-    "SELECT COALESCE(title, id) as title, github_issue_number FROM kanban_cards WHERE id = ?",
-    [cardId]
-  );
-  if (rows.length === 0) return cardId;
-  if (rows[0].github_issue_number) {
-    return "#" + rows[0].github_issue_number + " " + rows[0].title;
+  var card = agentdesk.cards.get(cardId);
+  if (!card) return cardId;
+  if (card.github_issue_number) {
+    return "#" + card.github_issue_number + " " + (card.title || card.id);
   }
-  return rows[0].title || cardId;
+  return card.title || card.id;
 }
 
 function handlePhaseGateFailure(cardId, phase, reason, context) {

--- a/policies/pipeline.js
+++ b/policies/pipeline.js
@@ -22,15 +22,12 @@ var pipeline = {
     if (!isDispatchable) return;
 
     // Check if repo has pipeline stages triggered on this dispatchable state
-    var cards = agentdesk.db.query(
-      "SELECT repo_id FROM kanban_cards WHERE id = ?",
-      [payload.card_id]
-    );
-    if (cards.length === 0) return;
+    var card = agentdesk.cards.get(payload.card_id);
+    if (!card) return;
 
     var stages = agentdesk.db.query(
       "SELECT id, stage_name, agent_override_id FROM pipeline_stages WHERE repo_id = ? AND trigger_after = ? ORDER BY stage_order ASC LIMIT 1",
-      [cards[0].repo_id, payload.to]
+      [card.repo_id, payload.to]
     );
     if (stages.length > 0) {
       agentdesk.db.execute(


### PR DESCRIPTION
## 목표
JS policy에서 `kanban_cards`를 직접 조회하던 두 경로를 typed `agentdesk.cards.get` facade로 이동해 policy/schema 결합을 줄입니다.

## 쉬운 설명
auto-queue phase gate label과 pipeline transition hook이 카드 정보를 가져올 때 raw SQL 대신 공식 card facade를 사용합니다. 동작은 유지하면서 테스트로 facade 경계를 고정했습니다.

## 개선되는 것
### Fix 1
Before: `policies/auto-queue.js`가 phase gate label 생성을 위해 `kanban_cards`를 직접 SELECT했습니다.
After: `agentdesk.cards.get` 결과로 title/issue number label을 구성합니다.

### Fix 2
Before: `policies/pipeline.js`가 transition 처리 중 card repo_id를 raw SQL로 읽었습니다.
After: `agentdesk.cards.get`로 card를 읽고 repo_id를 사용합니다.

## Before → After
| 시나리오 | Before | After |
|---|---|---|
| phase gate card label | raw `kanban_cards` SELECT | typed card facade |
| pipeline transition | raw repo_id lookup | facade card lookup |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
|---|---|---|
| card 없음 | 기존처럼 fallback id/return 유지 | 동작 보존 |
| issue number 있음 | `#번호 제목` format 유지 | 표시 보존 |

## 해결한 내용
- `policies/auto-queue.js`: `loadPhaseGateCardLabel` raw DB read 제거.
- `policies/pipeline.js`: transition hook의 card repo lookup을 facade로 교체.
- `policies/__tests__/auto-queue-facade.test.js`, `policies/__tests__/pipeline-transition.test.js`: facade 사용 회귀 테스트 추가.

## 검증
- `npm run test:policies` 통과: 90 pass.