### PR TITLE
chore: port low-risk docs and helper cleanups

### DIFF
--- a/dashboard/src/app/AppShell.tsx
+++ b/dashboard/src/app/AppShell.tsx
@@ -937,6 +937,7 @@ export default function AppShell({
                         type="button"
                         onClick={() => setShowNotificationPanel(false)}
                         className="flex h-8 w-8 items-center justify-center rounded-xl text-[var(--th-text-muted)]"
+                        aria-label={tr("알림 창 닫기", "Close notification panel")}
                       >
                         <X size={14} />
                       </button>
@@ -1002,6 +1003,7 @@ export default function AppShell({
                                 type="button"
                                 onClick={() => dismissNotification(notification.id)}
                                 className="flex h-8 w-8 items-center justify-center rounded-xl text-[var(--th-text-muted)]"
+                                aria-label={tr("알림 지우기", "Dismiss notification")}
                               >
                                 <X size={12} />
                               </button>

--- a/dashboard/src/components/MeetingDetailModal.tsx
+++ b/dashboard/src/components/MeetingDetailModal.tsx
@@ -146,6 +146,7 @@ export default function MeetingDetailModal({ meeting, onClose }: Props) {
             tone="neutral"
             className="shrink-0"
             style={{ minWidth: 44, minHeight: 44 }}
+            aria-label={t({ ko: "닫기", en: "Close" })}
           >
             ✕
           </SurfaceActionButton>

--- a/docs/policy-typed-facade.md
+++ b/docs/policy-typed-facade.md
@@ -24,7 +24,11 @@ Current typed facade entrypoints:
 | `agentdesk.review` | `getVerdict(card_id)` | Returns canonical review verdict state from `card_review_state` with fallback to the latest completed review dispatch result. |
 | `agentdesk.review` | `entryContext(card_id)` | Returns review-entry planning data: current round, completed implementation/rework count, and the next round decision without exposing `task_dispatches` SQL. |
 | `agentdesk.review` | `recordEntry(card_id, opts)` | Updates `kanban_cards.review_round` and `updated_at` for the review-entry flow with an optional terminal-state guard. |
+| `agentdesk.reviewState` | `sync(card_id, state, opts)` | Synchronizes the canonical review verdict state in `card_review_state`. |
+| `agentdesk.kanban` | `setStatus(card_id, new_status, force?)` | Updates the card status without raw `kanban_cards.status` UPDATEs. |
+| `agentdesk.kanban` | `setReviewStatus(card_id, status, opts)` | Updates the review status without raw `kanban_cards.review_status` UPDATEs. |
 | `agentdesk.queue` | `status()` | Returns typed queue and outbox counts without exposing raw queue tables to JS. |
+| `agentdesk.autoQueue` | `updateEntryStatus(entry_id, status, source, opts)` | Updates `auto_queue_entries` status cleanly, logging the transition. |
 | `agentdesk.dispatch` | `create(...)` | Existing typed command, retained as-is. |
 | `agentdesk.kv` | `get/set/delete(...)` | Existing typed KV facade, preferred over `kv_meta` SQL. |
 

--- a/src/runtime_layout/mod.rs
+++ b/src/runtime_layout/mod.rs
@@ -27,8 +27,8 @@ use skill_sync::ensure_managed_skill_dir;
 pub(crate) use config_merge::preview_role_map_merge;
 #[allow(unused_imports)]
 pub use paths::{
-    config_dir, config_file_path, credential_dir, credential_token_path, legacy_config_file_path,
-    legacy_credential_dir, managed_agents_root, managed_memories_root,
+    config_dir, config_file_path, credential_dir, credential_token_path, expand_user_path,
+    legacy_config_file_path, legacy_credential_dir, managed_agents_root, managed_memories_root,
     managed_skills_manifest_path, managed_skills_root, memories_archive_root, memory_backend_path,
     org_schema_path, resolve_memory_path, role_map_path, shared_agent_knowledge_dir,
     shared_prompt_path,

--- a/src/runtime_layout/paths.rs
+++ b/src/runtime_layout/paths.rs
@@ -118,7 +118,7 @@ pub fn resolve_memory_path(root: &Path, raw: &str) -> PathBuf {
     }
 }
 
-pub(super) fn expand_user_path(raw: &str) -> Option<PathBuf> {
+pub fn expand_user_path(raw: &str) -> Option<PathBuf> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return None;

--- a/src/services/platform/binary_resolver.rs
+++ b/src/services/platform/binary_resolver.rs
@@ -14,6 +14,8 @@ use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
+use crate::runtime_layout::expand_user_path;
+
 const LOGIN_SHELL_TIMEOUT: Duration = Duration::from_secs(3);
 const VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 const VERSION_PROBE_MAX_OUTPUT_BYTES: usize = 8 * 1024;
@@ -114,7 +116,8 @@ fn resolve_provider_binary_legacy(provider: &str) -> BinaryResolution {
 
     match std::env::var_os(&override_var).filter(|value| !os_value_is_empty(value)) {
         Some(raw_override) => {
-            let expanded = expand_user_path(&raw_override);
+            let expanded = expand_user_path(&raw_override.to_string_lossy())
+                .unwrap_or_else(|| PathBuf::from(&raw_override));
             match resolve_candidate_path(&expanded, &cwd) {
                 Ok(path) => {
                     attempts.push(format!(
@@ -718,19 +721,6 @@ fn os_value_is_empty(value: &OsStr) -> bool {
     value.to_string_lossy().trim().is_empty()
 }
 
-fn expand_user_path(raw: &OsStr) -> PathBuf {
-    let raw = raw.to_string_lossy();
-    if raw == "~" {
-        return dirs::home_dir().unwrap_or_else(|| PathBuf::from(raw.as_ref()));
-    }
-    if let Some(rest) = raw.strip_prefix("~/") {
-        if let Some(home) = dirs::home_dir() {
-            return home.join(rest);
-        }
-    }
-    PathBuf::from(raw.as_ref())
-}
-
 fn push_env_dir(
     env_name: &str,
     suffix: Option<&str>,
@@ -740,7 +730,8 @@ fn push_env_dir(
     let Some(value) = std::env::var_os(env_name).filter(|value| !os_value_is_empty(value)) else {
         return;
     };
-    let mut path = expand_user_path(&value);
+    let mut path =
+        expand_user_path(&value.to_string_lossy()).unwrap_or_else(|| PathBuf::from(&value));
     if let Some(suffix) = suffix {
         path = path.join(suffix);
     }
@@ -833,7 +824,7 @@ fn registry_channel_resolution(
     channel: &crate::services::provider_cli::ProviderCliChannel,
 ) -> Option<BinaryResolution> {
     let cwd = current_dir_fallback();
-    let expanded = expand_user_path(OsStr::new(&channel.path));
+    let expanded = expand_user_path(&channel.path).unwrap_or_else(|| PathBuf::from(&channel.path));
     let resolved_path = resolve_candidate_path(&expanded, &cwd).ok()?;
     let resolution = finalize_resolution(
         requested_binary.to_string(),

--- a/tests/TEST_PLAN.md
+++ b/tests/TEST_PLAN.md
@@ -166,6 +166,9 @@
 
 ## P1: Settings & Config
 
+### Config Domains
+- `patch_config_entries_rejects_readonly_metadata` — read-only runtime metadata like server_port cannot be written
+
 ### bot_settings.json
 - `token_hash_sha256_correct` — SHA256 해시 계산 정확
 - `token_hash_reproducible` — 같은 토큰 → 같은 해시


### PR DESCRIPTION
## 목표
작고 독립적인 저위험 개선을 한 PR로 묶어 문서 계약, path helper 재사용, dashboard 접근성 라벨을 정리합니다.

## 쉬운 설명
typed facade 문서와 config test plan을 보강합니다. provider binary resolver는 이미 있는 `expand_user_path` helper를 재사용합니다. notification panel과 meeting detail modal의 icon-only close button에는 screen reader label을 추가합니다.

## 개선되는 것
### Fix 1
Before: 일부 typed facade entrypoint가 `docs/policy-typed-facade.md`의 current surface 표에 빠져 있었습니다.
After: reviewState, kanban status, autoQueue status update facade를 명시합니다.

### Fix 2
Before: provider binary resolver가 자체 `~` expansion helper를 중복 보유했습니다.
After: `runtime_layout::expand_user_path`를 public helper로 재사용합니다.

### Fix 3
Before: notification close/dismiss 및 MeetingDetailModal close icon button에 명시적 aria-label이 부족했습니다.
After: 한국어/영어 label을 추가합니다.

## Before → After
| 시나리오 | Before | After |
|---|---|---|
| policy facade docs | 일부 entrypoint 누락 | current surface 표에 추가 |
| provider path override | local helper 중복 | runtime_layout helper 재사용 |
| dashboard close icon button | screen reader label 부족 | aria-label 제공 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
|---|---|---|
| 빈 path override | helper가 None이면 기존 fallback PathBuf 사용 | 기존 fallback 유지 |
| dashboard build | React/Vite production build 통과 | UI compile 영향 없음 |

## 해결한 내용
- `docs/policy-typed-facade.md`, `tests/TEST_PLAN.md`: low-risk contract docs 보강.
- `src/runtime_layout/mod.rs`, `src/runtime_layout/paths.rs`, `src/services/platform/binary_resolver.rs`: `expand_user_path` 재사용.
- `dashboard/src/app/AppShell.tsx`: notification close/dismiss aria-label 추가.
- `dashboard/src/components/MeetingDetailModal.tsx`: close button aria-label 추가.

## 검증
- `cargo check --all-targets --config 'build.rustc-wrapper=""'` 통과.
- `cd dashboard && npm run build --silent` 통과.