### PR TITLE
Accessor: improve Office manager icon picker accessibility

### DIFF
--- a/dashboard/src/components/OfficeManagerIconPicker.test.tsx
+++ b/dashboard/src/components/OfficeManagerIconPicker.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Office } from "../types";
+import OfficeManagerModal from "./OfficeManagerModal";
+import OfficeManagerView from "./OfficeManagerView";
+
+vi.mock("../api/client", () => ({
+  addAgentToOffice: vi.fn().mockResolvedValue(undefined),
+  createOffice: vi.fn().mockResolvedValue({ id: "office-created" }),
+  deleteOffice: vi.fn().mockResolvedValue(undefined),
+  getAgents: vi.fn().mockResolvedValue([]),
+  removeAgentFromOffice: vi.fn().mockResolvedValue(undefined),
+  updateOffice: vi.fn().mockResolvedValue(undefined),
+}));
+
+const office: Office = {
+  id: "office-1",
+  name: "Studio",
+  name_ko: "스튜디오",
+  icon: "🎮",
+  color: "#3b82f6",
+  description: null,
+  sort_order: 0,
+  created_at: 1710000000000,
+};
+
+function queryIconButton(container: HTMLElement, label: string): HTMLButtonElement {
+  const button = container.querySelector<HTMLButtonElement>(
+    `button[aria-label="${label}"]`,
+  );
+  expect(button).not.toBeNull();
+  return button as HTMLButtonElement;
+}
+
+describe("Office manager icon picker accessibility", () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  async function render(element: ReactNode) {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(element);
+    });
+    return container;
+  }
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+      root = null;
+    }
+    container?.remove();
+    container = null;
+    vi.clearAllMocks();
+  });
+
+  it("renders view icon buttons as non-submit toggle buttons with localized labels", async () => {
+    const target = await render(
+      <OfficeManagerView
+        offices={[office]}
+        allAgents={[]}
+        selectedOfficeId={office.id}
+        isKo={false}
+        onChanged={() => {}}
+      />,
+    );
+
+    const selectedIcon = queryIconButton(target, "Icon 🎮");
+    expect(selectedIcon.getAttribute("type")).toBe("button");
+    expect(selectedIcon.getAttribute("aria-pressed")).toBe("true");
+
+    const unselectedIcon = queryIconButton(target, "Icon 🏢");
+    expect(unselectedIcon.getAttribute("type")).toBe("button");
+    expect(unselectedIcon.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("renders modal create icon buttons as non-submit toggle buttons with Korean labels", async () => {
+    const target = await render(
+      <OfficeManagerModal
+        offices={[]}
+        allAgents={[]}
+        isKo
+        onClose={() => {}}
+        onChanged={() => {}}
+      />,
+    );
+
+    const addButton = Array.from(target.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("오피스 추가"),
+    );
+    expect(addButton).toBeDefined();
+
+    await act(async () => {
+      addButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const defaultIcon = queryIconButton(target, "아이콘 🏢");
+    expect(defaultIcon.getAttribute("type")).toBe("button");
+    expect(defaultIcon.getAttribute("aria-pressed")).toBe("true");
+  });
+});

--- a/dashboard/src/components/OfficeManagerModal.tsx
+++ b/dashboard/src/components/OfficeManagerModal.tsx
@@ -354,6 +354,9 @@ export default function OfficeManagerModal({
                       {OFFICE_ICONS.map((ic) => (
                         <button
                           key={ic}
+                          type="button"
+                          aria-label={tr(`아이콘 ${ic}`, `Icon ${ic}`)}
+                          aria-pressed={formIcon === ic}
                           onClick={() => setFormIcon(ic)}
                           className="flex h-8 w-8 items-center justify-center rounded text-base transition-all"
                           style={{

--- a/dashboard/src/components/OfficeManagerView.tsx
+++ b/dashboard/src/components/OfficeManagerView.tsx
@@ -476,6 +476,9 @@ export default function OfficeManagerView({
                       {OFFICE_ICONS.map((icon) => (
                         <button
                           key={icon}
+                          type="button"
+                          aria-label={tr(`아이콘 ${icon}`, `Icon ${icon}`)}
+                          aria-pressed={draft.icon === icon}
                           onClick={() => setDraft((prev) => ({ ...prev, icon }))}
                           className="flex h-10 w-10 items-center justify-center rounded-xl text-lg transition-colors"
                           style={{


### PR DESCRIPTION
## 목표
Office manager의 icon picker 버튼이 스크린리더와 폼 동작에서 더 명확하게 동작하도록 접근성 속성을 보강한다. 시각적 UI는 유지하면서 버튼의 이름과 선택 상태를 보조 기술에 전달하는 것이 목표다.

## 쉬운 설명
아이콘 버튼이 더 이상 이름 없는 버튼으로 읽히지 않는다. 선택된 아이콘인지도 `aria-pressed`로 전달된다. 폼 안에서 클릭해도 의도치 않은 submit이 발생하지 않도록 `type="button"`도 명시했다.

## 개선되는 것
### Fix 1
Before: 아이콘 picker 버튼이 시각적으로는 보이지만 screen reader에는 의미가 부족했다.
After: 기존 `tr(ko, en)` helper로 localized `aria-label`을 제공한다.

### Fix 2
Before: 현재 선택된 아이콘 상태가 보조 기술에 전달되지 않았다.
After: `aria-pressed`로 선택 상태를 전달한다.

### Fix 3
Before: 폼 내부 기본 button 동작이 submit으로 해석될 여지가 있었다.
After: `type="button"`을 명시해 icon 선택만 수행한다.

### Fix 4
Before: 접근성 속성이 실제 Office manager view와 modal 양쪽에서 렌더링되는지 PR 본문만으로는 확인해야 했다.
After: DOM 테스트가 view와 modal의 icon picker 버튼에 대해 `type="button"`, localized `aria-label`, selected/unselected `aria-pressed` 값을 고정한다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| screen reader로 아이콘 이동 | 이름 없는 버튼처럼 들릴 수 있음 | `아이콘 {icon}` / `Icon {icon}` label 제공 |
| 선택 상태 확인 | 현재 선택 여부를 알기 어려움 | `aria-pressed`로 선택 상태 전달 |
| 폼 내부 클릭 | 기본 submit 가능성 존재 | `type="button"`으로 submit 방지 |

## 사이드 이펙트 재검토
| 시나리오 | 확인 내용 | 결론 |
| --- | --- | --- |
| 기존 마우스 클릭 | `onClick` handler와 state update 로직은 변경하지 않음 | 시각/클릭 동작 보존 |
| 키보드 탐색 | native button은 그대로 유지하고 속성만 추가 | focus/activation 모델 보존 |
| 폼 내부 클릭 | `type="button"` 추가로 submit default를 차단 | 의도된 안전한 동작 변화 |
| 보조 기술 출력 | accessible name과 pressed state가 새로 노출됨 | 의도된 접근성 트리 변화 |
| 한국어/영어 UI | `tr()` helper 기반 label을 DOM 테스트로 확인 | locale별 label 계약 보강 |

## 해결한 내용
- `dashboard/src/components/OfficeManagerModal.tsx`: modal의 office icon 버튼에 `type`, `aria-label`, `aria-pressed`를 추가했다.
- `dashboard/src/components/OfficeManagerView.tsx`: view의 office icon 버튼에도 같은 접근성 속성을 추가했다.
- `dashboard/src/components/OfficeManagerIconPicker.test.tsx`: view/modal icon picker 접근성 속성 렌더링을 검증한다.

## 검증
- `npm --prefix dashboard ci`
- `npm --prefix dashboard run test -- OfficeManagerIconPicker`
- GitHub Checks 확인: `Changed paths`, `Script checks`, `Dashboard (Node 22)`, `High-risk recovery`, `Fast check`, `Fast targeted tests` 모두 성공.
- `Fast check + non-PG tests`, `PostgreSQL tests`, `Lint`는 변경 경로 기준으로 skip됨.
