### PR TITLE
docs(test-plan): document full-replace dashboard settings contract

### DIFF
--- a/tests/TEST_PLAN.md
+++ b/tests/TEST_PLAN.md
@@ -168,7 +168,7 @@
 
 ### Config Domains
 - `patch_config_entries_rejects_readonly_metadata` — read-only runtime metadata like server_port cannot be written
-- `put_settings_pg_is_full_replace_and_strips_retired_company_keys` — `kv_meta['settings']` is full-replace; callers must merge hidden/retired keys themselves or they will be dropped (see `src/server/routes/settings_tests.rs`)
+- `put_settings_pg_is_full_replace_and_strips_retired_company_keys` — `kv_meta['settings']` is full-replace; callers must merge any hidden keys they intend to preserve, while retired legacy keys are stripped server-side (see `src/server/routes/settings_tests.rs`)
 
 ### bot_settings.json
 - `token_hash_sha256_correct` — SHA256 해시 계산 정확

--- a/tests/TEST_PLAN.md
+++ b/tests/TEST_PLAN.md
@@ -168,6 +168,7 @@
 
 ### Config Domains
 - `patch_config_entries_rejects_readonly_metadata` — read-only runtime metadata like server_port cannot be written
+- `put_settings_pg_is_full_replace_and_strips_retired_company_keys` — `kv_meta['settings']` is full-replace; callers must merge hidden/retired keys themselves or they will be dropped (see `src/server/routes/settings_tests.rs`)
 
 ### bot_settings.json
 - `token_hash_sha256_correct` — SHA256 해시 계산 정확


### PR DESCRIPTION
## 목표
`tests/TEST_PLAN.md`의 Config Domains 섹션에 `kv_meta['settings']` full-replace 계약을 검증하는 기존 테스트 항목을 추가한다. 설정 API를 다루는 작업자가 현재 hidden key 보존 책임과 retired legacy key stripping 동작을 구분해서 볼 수 있게 하는 문서 보강이다.

## 쉬운 설명
설정 저장은 부분 업데이트가 아니라 전체 교체 방식이다. 호출자가 기존 값을 병합하지 않으면 현재 저장된 hidden key는 사라질 수 있다. 반대로 retired legacy key는 호출자가 보내도 서버가 strip한다. 이미 있는 테스트를 TEST_PLAN에서 찾을 수 있게 했다.

## 개선되는 것
### Fix 1
Before: `put_settings_pg_is_full_replace_and_strips_retired_company_keys` 테스트가 존재하지만 TEST_PLAN의 Config Domains 목록에 없었다.
After: TEST_PLAN에 해당 테스트와 계약 설명이 추가되어 설정 도메인 변경 시 검증 포인트가 드러난다.

### Fix 2
Before: PR 설명이 hidden key와 retired key를 같은 보존 책임처럼 읽힐 수 있었다.
After: hidden key는 caller merge가 필요하고, retired legacy key는 server-side strip 대상임을 분리해서 설명한다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| 설정 full-replace 계약 확인 | 테스트 파일을 직접 알아야 찾을 수 있음 | TEST_PLAN의 Config Domains에서 바로 확인 |
| hidden key 보존 책임 | 문서 breadcrumb 부족 | 호출자가 보존하려는 hidden key는 직접 merge해야 한다는 설명 추가 |
| retired legacy key 처리 | hidden key와 같은 보존 대상처럼 오해될 수 있음 | retired legacy key는 서버가 strip한다는 설명 추가 |

## 사이드 이펙트 재검토
| 시나리오 | 확인 내용 | 결론 |
| --- | --- | --- |
| 런타임 코드 | `tests/TEST_PLAN.md` 한 줄 문서 변경만 포함 | 동작 영향 없음 |
| 테스트 실행 범위 | 테스트 목록 문서만 갱신 | CI 비용 변화 없음 |
| 설정 API 작업자 | `src/server/routes/settings.rs` 주석과 기존 테스트 의미에 맞게 설명 | 회귀 방지에 도움 |
| retired key 보존 | retired key는 보존 대상이 아니라 server-side strip 대상 | 기존 본문 표현을 정정함 |

## 해결한 내용
- `tests/TEST_PLAN.md`: Config Domains 섹션에 `put_settings_pg_is_full_replace_and_strips_retired_company_keys` 항목을 추가했다.
- `tests/TEST_PLAN.md`: hidden key merge 책임과 retired legacy key stripping을 분리해 설명했다.

## 검증
- `rg -n "put_settings_pg_is_full_replace_and_strips_retired_company_keys|full-replace|retired legacy keys" tests/TEST_PLAN.md src/server/routes/settings.rs src/server/routes/docs.rs -S`
- GitHub Checks 확인: `Changed paths`, `Script checks`, `Fast check + non-PG tests` Linux/macOS/Windows, `High-risk recovery`, `Lint`, `Fast check`, `Fast targeted tests` 모두 성공.
- `Dashboard (Node 22)`, `PostgreSQL tests`는 변경 경로 기준으로 skip됨.
