### PR TITLE
FacadePilot: complete _runPreflight typed-facade migration in kanban-rules.js

### DIFF
--- a/policies/__tests__/kanban-rules.test.js
+++ b/policies/__tests__/kanban-rules.test.js
@@ -19,7 +19,7 @@ function assertMetadataObjectParam(execution) {
 }
 
 test("kanban-rules preflight uses typed facade agentdesk.cards.get", () => {
-  const { module } = loadPolicy("policies/kanban-rules.js", {
+  const { module, state } = loadPolicy("policies/kanban-rules.js", {
     dbQuery: createSqlRouter([
       {
         match: "SELECT id FROM task_dispatches WHERE kanban_card_id = ? AND dispatch_type = 'implementation' AND status = 'completed'",
@@ -37,6 +37,22 @@ test("kanban-rules preflight uses typed facade agentdesk.cards.get", () => {
 
   const result = toPlain(module.__test.runPreflight("card-facade"));
   assert.equal(result.status, "assumption_ok");
+  assert.equal(state.queries.length, 1);
+  assert.match(state.queries[0].sql, /FROM task_dispatches/);
+  assert.doesNotMatch(state.queries[0].sql, /FROM kanban_cards/);
+});
+
+test("kanban-rules preflight missing facade card returns invalid without fallback side effects", () => {
+  const { module, state } = loadPolicy("policies/kanban-rules.js", {
+    dbQuery: createSqlRouter([]),
+    exec: createExecRouter([]),
+    cards: {}
+  });
+
+  const result = toPlain(module.__test.runPreflight("missing-card"));
+  assert.deepEqual(result, { status: "invalid", summary: "Card not found" });
+  assert.deepEqual(state.queries, []);
+  assert.deepEqual(state.execCalls, []);
 });
 
 test("kanban-rules preflight returns already_applied when the linked GitHub issue is closed", () => {

--- a/policies/__tests__/kanban-rules.test.js
+++ b/policies/__tests__/kanban-rules.test.js
@@ -18,26 +18,43 @@ function assertMetadataObjectParam(execution) {
   return written;
 }
 
-test("kanban-rules preflight returns already_applied when the linked GitHub issue is closed", () => {
+test("kanban-rules preflight uses typed facade agentdesk.cards.get", () => {
   const { module } = loadPolicy("policies/kanban-rules.js", {
     dbQuery: createSqlRouter([
       {
-        match: "FROM kanban_cards kc WHERE kc.id = ?",
-        result: [
-          {
-            id: "card-1",
-            title: "Closed issue card",
-            github_issue_number: 925,
-            github_issue_url: "https://github.com/itismyfield/AgentDesk/issues/925",
-            status: "requested",
-            description: "This issue body is comfortably longer than thirty characters.",
-            assigned_agent_id: "agent-1",
-            metadata: "{}",
-            blocked_reason: null
-          }
-        ]
+        match: "SELECT id FROM task_dispatches WHERE kanban_card_id = ? AND dispatch_type = 'implementation' AND status = 'completed'",
+        result: []
       }
     ]),
+    cards: {
+      "card-facade": {
+        id: "card-facade",
+        description: "A description that is long enough to pass the length check.",
+        metadata: "{}",
+      }
+    }
+  });
+
+  const result = toPlain(module.__test.runPreflight("card-facade"));
+  assert.equal(result.status, "assumption_ok");
+});
+
+test("kanban-rules preflight returns already_applied when the linked GitHub issue is closed", () => {
+  const { module } = loadPolicy("policies/kanban-rules.js", {
+    dbQuery: createSqlRouter([]),
+    cards: {
+      "card-1": {
+        id: "card-1",
+        title: "Closed issue card",
+        github_issue_number: 925,
+        github_issue_url: "https://github.com/itismyfield/AgentDesk/issues/925",
+        status: "requested",
+        description: "This issue body is comfortably longer than thirty characters.",
+        assigned_agent_id: "agent-1",
+        metadata: "{}",
+        blocked_reason: null
+      }
+    },
     exec: createExecRouter([
       {
         match: (cmd, args) =>
@@ -245,24 +262,21 @@ test("kanban-rules writes noop work-resolution metadata as a JSON object param",
 
 test("kanban-rules preflight already_applied transitions the card to done and skips pending queue entries", () => {
   const { policy, state } = loadPolicy("policies/kanban-rules.js", {
+    cards: {
+      "card-2": {
+        id: "card-2",
+        title: "Already implemented",
+        github_issue_number: null,
+        github_issue_url: null,
+        status: "requested",
+        description: "This body is long enough to pass the description length gate.",
+        assigned_agent_id: "agent-1",
+        metadata: null,
+        blocked_reason: null
+      }
+    },
     dbQuery: createSqlRouter([
       { match: "SELECT metadata FROM kanban_cards WHERE id = ?", result: [] },
-      {
-        match: "FROM kanban_cards kc WHERE kc.id = ?",
-        result: [
-          {
-            id: "card-2",
-            title: "Already implemented",
-            github_issue_number: null,
-            github_issue_url: null,
-            status: "requested",
-            description: "This body is long enough to pass the description length gate.",
-            assigned_agent_id: "agent-1",
-            metadata: null,
-            blocked_reason: null
-          }
-        ]
-      },
       {
         match: "SELECT id FROM task_dispatches WHERE kanban_card_id = ? AND dispatch_type = 'implementation' AND status = 'completed'",
         result: [{ id: "dispatch-1" }]

--- a/policies/kanban-rules.js
+++ b/policies/kanban-rules.js
@@ -276,14 +276,8 @@ function _findAutoQueueEntriesByDispatch(dispatchId, liveOnly) {
 }
 
 function _runPreflight(cardId) {
-  var card = agentdesk.db.query(
-    "SELECT kc.id, kc.title, kc.github_issue_number, kc.github_issue_url, kc.status, kc.description, " +
-    "kc.assigned_agent_id, kc.metadata, kc.blocked_reason " +
-    "FROM kanban_cards kc WHERE kc.id = ?",
-    [cardId]
-  );
-  if (card.length === 0) return { status: "invalid", summary: "Card not found" };
-  var c = card[0];
+  var c = agentdesk.cards.get(cardId);
+  if (!c) return { status: "invalid", summary: "Card not found" };
 
   // Check 1: GitHub issue closed? (uses gh CLI since no bridge exists)
   if (c.github_issue_number && c.github_issue_url) {


### PR DESCRIPTION
## 목표
`policies/kanban-rules.js`의 `_runPreflight`가 kanban card를 raw SQL로 직접 조회하지 않고 typed facade인 `agentdesk.cards.get(cardId)`를 사용하도록 마이그레이션한다. 기존 preflight 판정을 유지하면서 정책 코드의 DB 접근 경계를 줄이는 것이 목표다.

## 쉬운 설명
Kanban preflight가 카드 정보를 가져오는 방식이 더 안전한 내부 API로 바뀐다. 운영자가 보는 결과는 동일해야 한다. 카드가 없으면 기존처럼 invalid로 처리되고, 닫힌 GitHub issue나 이미 완료된 dispatch 처리도 유지된다.

## 개선되는 것
### Fix 1
Before: `_runPreflight`가 `kanban_cards` 테이블을 raw SQL로 직접 조회했다.
After: `agentdesk.cards.get(cardId)`를 통해 typed facade에서 card를 읽는다.

### Fix 2
Before: 일부 테스트가 raw SQL 카드 조회 mock에 의존했다.
After: 테스트 harness의 `cards` config block으로 card fixture를 주입하고, facade 경로를 명시적으로 검증한다.

### Fix 3
Before: facade migration의 "부작용 없음" 주장이 암묵적으로만 검증됐다.
After: missing-card 경로가 `invalid`로 즉시 반환되고 SQL fallback/gh 호출을 만들지 않는지, facade 조회 이후 남는 DB query가 terminal dispatch 확인뿐인지 테스트로 고정했다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| card preflight 조회 | raw `agentdesk.db.query`로 `kanban_cards` SELECT | `agentdesk.cards.get(cardId)` 사용 |
| card 없음 | 빈 SQL 결과를 보고 `invalid` | facade가 null/undefined면 `invalid` |
| 테스트 fixture | SQL 문자열 match 기반 mock | typed `cards` fixture 기반 mock |

## 사이드 이펙트 재검토
| 시나리오 | 확인 내용 | 결론 |
| --- | --- | --- |
| 닫힌 GitHub issue가 연결된 card | card 조회 방식만 바뀌며 gh issue state 확인 로직은 유지 | 기존 `already_applied` 판정 보존 |
| 이미 completed implementation dispatch가 있는 card | facade 조회 후 terminal dispatch SQL 확인은 그대로 수행 | 기존 already-applied 전환 보존 |
| card 없음 | 새 테스트가 SQL fallback과 gh 호출 없이 `invalid` 반환을 확인 | 불필요한 추가 side effect 없음 |
| card metadata 형식 차이 | facade는 metadata를 parsed JSON으로 줄 수 있지만 `_runPreflight`는 metadata를 소비하지 않음 | preflight 판정 입력에는 영향 없음 |
| facade backend failure | raw SQL failure와 마찬가지로 read failure가 전파될 수 있음 | 실패 모드는 읽기 실패 범주이며 silent fallback은 의도하지 않음 |

## 해결한 내용
- `policies/kanban-rules.js`: `_runPreflight`의 card 조회를 raw SQL에서 `agentdesk.cards.get`으로 교체했다.
- `policies/__tests__/kanban-rules.test.js`: preflight 테스트가 typed facade fixture를 사용하도록 정리하고 facade 사용 회귀 테스트를 추가했다.
- `policies/__tests__/kanban-rules.test.js`: missing-card side effect guard와 no-raw-kanban-card-query assertion을 추가했다.

## 검증
- `node --test policies/__tests__/kanban-rules.test.js`
- GitHub Checks 확인: `Changed paths`, `Script checks`, `Fast check + non-PG tests` Linux/macOS/Windows, `High-risk recovery`, `Lint`, `Fast check`, `Fast targeted tests` 모두 성공.
- `Dashboard (Node 22)`, `PostgreSQL tests`는 변경 경로 기준으로 skip됨.
