### PR TITLE
feat(codex): split chained and fresh goal sessions

### DIFF
--- a/src/services/codex.rs
+++ b/src/services/codex.rs
@@ -21,7 +21,7 @@ use crate::services::remote::RemoteProfile;
 use crate::services::session_backend::{
     insert_process_session, process_session_is_alive, process_session_probe,
     read_output_file_until_result, read_output_file_until_result_tracked, remove_process_session,
-    send_process_session_input,
+    send_process_session_input, terminate_process_handle,
 };
 #[cfg(unix)]
 use crate::services::tmux_diagnostics::{
@@ -108,6 +108,13 @@ fn render_goals_wrapper_arg(goals_override: Option<bool>) -> String {
         Some(false) => " \\\n  --goals-state disabled".to_string(),
         None => String::new(),
     }
+}
+
+fn should_reuse_existing_provider_session(
+    existing_session_usable: bool,
+    force_fresh_provider_session: bool,
+) -> bool {
+    existing_session_usable && !force_fresh_provider_session
 }
 
 #[cfg(unix)]
@@ -230,6 +237,7 @@ pub fn execute_command_streaming(
     fast_mode_enabled: Option<bool>,
     goals_enabled: Option<bool>,
     compact_token_limit: Option<u64>,
+    force_fresh_provider_session: bool,
 ) -> Result<(), String> {
     let readonly_mode = is_readonly_tool_policy(allowed_tools);
     let prompt = compose_codex_prompt(prompt, system_prompt, allowed_tools);
@@ -290,6 +298,7 @@ pub fn execute_command_streaming(
                 report_channel_id,
                 report_provider,
                 compact_token_limit,
+                force_fresh_provider_session,
             );
         }
         // ProcessBackend fallback for Codex (no tmux or non-unix)
@@ -304,6 +313,7 @@ pub fn execute_command_streaming(
             cancel_token,
             tmux_name,
             compact_token_limit,
+            force_fresh_provider_session,
         );
     }
 
@@ -503,6 +513,7 @@ fn execute_streaming_local_tmux(
     report_channel_id: Option<u64>,
     report_provider: Option<ProviderKind>,
     compact_token_limit: Option<u64>,
+    force_fresh_provider_session: bool,
 ) -> Result<(), String> {
     let output_path = crate::services::tmux_common::session_temp_path(tmux_session_name, "jsonl");
     let input_fifo_path =
@@ -522,7 +533,7 @@ fn execute_streaming_local_tmux(
         && resolved_output.is_some()
         && resolved_input.is_some();
 
-    if session_usable {
+    if should_reuse_existing_provider_session(session_usable, force_fresh_provider_session) {
         let output_path = resolved_output
             .clone()
             .unwrap_or_else(|| output_path.clone());
@@ -551,13 +562,15 @@ fn execute_streaming_local_tmux(
             }
         }
     } else if session_exists {
-        record_tmux_exit_reason(
-            tmux_session_name,
-            "stale local session cleanup before recreate",
-        );
+        let cleanup_reason = if force_fresh_provider_session {
+            "codex fresh provider session requested"
+        } else {
+            "stale local session cleanup before recreate"
+        };
+        record_tmux_exit_reason(tmux_session_name, cleanup_reason);
         crate::services::platform::tmux::kill_session_with_reason(
             tmux_session_name,
-            "stale local session cleanup before recreate",
+            cleanup_reason,
         );
     }
 
@@ -838,6 +851,7 @@ fn execute_streaming_local_process_codex(
     cancel_token: Option<std::sync::Arc<CancelToken>>,
     session_name: &str,
     compact_token_limit: Option<u64>,
+    force_fresh_provider_session: bool,
 ) -> Result<(), String> {
     use crate::services::session_backend::{ProcessBackend, SessionBackend, SessionConfig};
 
@@ -853,7 +867,8 @@ fn execute_streaming_local_process_codex(
     );
 
     // Check for existing process session
-    if process_session_is_alive(session_name) {
+    let process_session_alive = process_session_is_alive(session_name);
+    if should_reuse_existing_provider_session(process_session_alive, force_fresh_provider_session) {
         // Snapshot file length BEFORE sending input to avoid race:
         // Codex wrapper appends JSONL immediately on stdin, so a fast
         // response could be written before we read the offset.
@@ -893,6 +908,12 @@ fn execute_streaming_local_process_codex(
             },
         );
         return Ok(());
+    }
+
+    if force_fresh_provider_session && process_session_alive {
+        if let Some(handle) = remove_process_session(session_name) {
+            terminate_process_handle(handle);
+        }
     }
 
     // Clean up and create new session
@@ -1285,7 +1306,7 @@ mod tests {
     use super::{
         CODEX_BACKGROUND_TASK_NOTIFICATION_ID, CODEX_BACKGROUND_TASK_NOTIFICATION_STATUS,
         TMUX_PROMPT_B64_PREFIX, base_exec_args, build_tmux_launch_env_lines, compose_codex_prompt,
-        handle_codex_json_line,
+        handle_codex_json_line, should_reuse_existing_provider_session,
     };
     use crate::services::agent_protocol::StreamMessage;
     use crate::services::discord::restart_report::{
@@ -1409,6 +1430,14 @@ mod tests {
     fn test_compose_codex_prompt_returns_plain_prompt_without_overrides() {
         let prompt = compose_codex_prompt("just answer", None, None);
         assert_eq!(prompt, "just answer");
+    }
+
+    #[test]
+    fn test_provider_session_reuse_decision_honors_explicit_fresh_flag() {
+        assert!(should_reuse_existing_provider_session(true, false));
+        assert!(!should_reuse_existing_provider_session(true, true));
+        assert!(!should_reuse_existing_provider_session(false, false));
+        assert!(!should_reuse_existing_provider_session(false, true));
     }
 
     #[test]

--- a/src/services/discord/router/message_handler.rs
+++ b/src/services/discord/router/message_handler.rs
@@ -640,25 +640,80 @@ fn codex_goals_override_for_turn(
     }
 }
 
-fn is_codex_goal_start_request(text: &str) -> bool {
+#[derive(Debug, PartialEq)]
+enum GoalCommandKind {
+    NotGoal,
+    ChainedStart,
+    FreshStart,
+    Lifecycle,
+}
+
+const GOAL_LIFECYCLE_SUBCOMMANDS: &[&str] = &["pause", "resume", "clear"];
+
+fn classify_codex_goal_command(text: &str) -> GoalCommandKind {
     let Some(first_line) = text.trim_start().lines().next() else {
-        return false;
+        return GoalCommandKind::NotGoal;
     };
     let first_line = first_line.trim_end();
     let Some(rest) = first_line.strip_prefix("/goal") else {
-        return false;
+        return GoalCommandKind::NotGoal;
     };
-    rest.is_empty() || rest.chars().next().is_some_and(char::is_whitespace)
+    if !rest.is_empty() && !rest.chars().next().is_some_and(char::is_whitespace) {
+        return GoalCommandKind::NotGoal;
+    }
+    let args = rest.trim_start();
+    if args.is_empty() {
+        return GoalCommandKind::ChainedStart;
+    }
+    for sub in GOAL_LIFECYCLE_SUBCOMMANDS {
+        let Some(after) = args.strip_prefix(sub) else {
+            continue;
+        };
+        if after.is_empty() || after.chars().next().is_some_and(char::is_whitespace) {
+            return GoalCommandKind::Lifecycle;
+        }
+    }
+    if let Some(after_fresh) = args.strip_prefix("--fresh") {
+        if after_fresh.is_empty() || after_fresh.chars().next().is_some_and(char::is_whitespace) {
+            return GoalCommandKind::FreshStart;
+        }
+    }
+    GoalCommandKind::ChainedStart
 }
 
-fn should_start_fresh_codex_goal_session(
+fn classify_codex_goal_command_for_provider(
     provider: &ProviderKind,
     text: &str,
     channel_codex_goals_setting: Option<bool>,
-) -> bool {
-    matches!(provider, ProviderKind::Codex)
-        && channel_codex_goals_setting.unwrap_or(true)
-        && is_codex_goal_start_request(text)
+) -> GoalCommandKind {
+    if matches!(provider, ProviderKind::Codex) && channel_codex_goals_setting.unwrap_or(true) {
+        classify_codex_goal_command(text)
+    } else {
+        GoalCommandKind::NotGoal
+    }
+}
+
+fn rewrite_fresh_goal_prompt(text: &str) -> String {
+    let trimmed = text.trim_start();
+    let prefix_len = text.len() - trimmed.len();
+    let leading = &text[..prefix_len];
+    let Some(rest) = trimmed.strip_prefix("/goal") else {
+        return text.to_string();
+    };
+    let after_goal = rest.trim_start_matches(|c: char| c == ' ' || c == '\t');
+    let Some(after_fresh) = after_goal.strip_prefix("--fresh") else {
+        return text.to_string();
+    };
+    let objective = after_fresh.trim_start_matches(|c: char| c == ' ' || c == '\t');
+    if objective.is_empty() {
+        format!("{}/goal", leading)
+    } else {
+        format!("{}/goal {}", leading, objective)
+    }
+}
+
+fn is_codex_goal_start_request(text: &str) -> bool {
+    !matches!(classify_codex_goal_command(text), GoalCommandKind::NotGoal)
 }
 
 async fn clear_codex_goal_start_provider_session(
@@ -947,12 +1002,14 @@ pub(in crate::services::discord) async fn start_reserved_headless_turn(
             let _ = super::super::internal_api::clear_stale_session_id(session_id_to_clear).await;
         }
     }
-    let fresh_codex_goal_session_requested = should_start_fresh_codex_goal_session(
+    let headless_goal_kind = classify_codex_goal_command_for_provider(
         &provider,
         prompt,
         super::super::commands::channel_codex_goals_setting(shared, fast_mode_channel_id).await,
     );
-    if fresh_codex_goal_session_requested {
+    let force_fresh_provider_session = matches!(headless_goal_kind, GoalCommandKind::FreshStart);
+    let fresh_codex_goal_session_requested = force_fresh_provider_session;
+    if force_fresh_provider_session {
         clear_codex_goal_start_provider_session(
             shared,
             channel_id,
@@ -963,6 +1020,11 @@ pub(in crate::services::discord) async fn start_reserved_headless_turn(
         )
         .await;
     }
+    let effective_prompt: std::borrow::Cow<str> = if force_fresh_provider_session {
+        std::borrow::Cow::Owned(rewrite_fresh_goal_prompt(prompt))
+    } else {
+        std::borrow::Cow::Borrowed(prompt)
+    };
     if session_id.is_none() {
         if fresh_codex_goal_session_requested {
             let ts = chrono::Local::now().format("%H:%M:%S");
@@ -1152,7 +1214,7 @@ pub(in crate::services::discord) async fn start_reserved_headless_turn(
     context_chunks.push(wrap_user_prompt_with_author(
         request_owner_name,
         request_owner,
-        ai_screen::sanitize_user_input(prompt),
+        ai_screen::sanitize_user_input(&effective_prompt),
     ));
     let context_prompt = context_chunks.join("\n\n");
 
@@ -1608,6 +1670,7 @@ pub(in crate::services::discord) async fn start_reserved_headless_turn(
                             native_fast_mode_override,
                             codex_goals_override,
                             compact_token_limit_for_codex,
+                            force_fresh_provider_session,
                         ),
                         ProviderKind::Gemini => gemini::execute_command_streaming(
                             &context_prompt,
@@ -2666,14 +2729,18 @@ pub(in crate::services::discord) async fn handle_text_message(
             let _ = super::super::internal_api::clear_stale_session_id(session_id_to_clear).await;
         }
     }
-    let fresh_codex_goal_session_requested = !dispatch_reset_provider_state
-        && !dispatch_recreate_tmux
-        && should_start_fresh_codex_goal_session(
+    let turn_goal_kind = if !dispatch_reset_provider_state && !dispatch_recreate_tmux {
+        classify_codex_goal_command_for_provider(
             &provider,
             user_text,
             super::super::commands::channel_codex_goals_setting(shared, fast_mode_channel_id).await,
-        );
-    if fresh_codex_goal_session_requested {
+        )
+    } else {
+        GoalCommandKind::NotGoal
+    };
+    let force_fresh_provider_session = matches!(turn_goal_kind, GoalCommandKind::FreshStart);
+    let fresh_codex_goal_session_requested = force_fresh_provider_session;
+    if force_fresh_provider_session {
         clear_codex_goal_start_provider_session(
             shared,
             channel_id,
@@ -2684,6 +2751,11 @@ pub(in crate::services::discord) async fn handle_text_message(
         )
         .await;
     }
+    let sanitized_input = if force_fresh_provider_session {
+        rewrite_fresh_goal_prompt(&sanitized_input)
+    } else {
+        sanitized_input
+    };
     if session_id.is_none() {
         if fresh_codex_goal_session_requested {
             let ts = chrono::Local::now().format("%H:%M:%S");
@@ -4106,6 +4178,7 @@ pub(in crate::services::discord) async fn handle_text_message(
                             native_fast_mode_override,
                             codex_goals_override,
                             compact_token_limit_for_codex,
+                            force_fresh_provider_session,
                         ),
                         ProviderKind::Gemini => gemini::execute_command_streaming(
                             &context_prompt,
@@ -6257,32 +6330,113 @@ mod tests {
     }
 
     #[test]
-    fn fresh_codex_goal_session_requires_codex_and_enabled_goals() {
-        assert!(should_start_fresh_codex_goal_session(
-            &ProviderKind::Codex,
-            "/goal 새 목표",
-            None
-        ));
-        assert!(should_start_fresh_codex_goal_session(
-            &ProviderKind::Codex,
-            "/goal 새 목표",
-            Some(true)
-        ));
-        assert!(!should_start_fresh_codex_goal_session(
-            &ProviderKind::Codex,
-            "/goal 새 목표",
-            Some(false)
-        ));
-        assert!(!should_start_fresh_codex_goal_session(
-            &ProviderKind::Claude,
-            "/goal 새 목표",
-            Some(true)
-        ));
-        assert!(!should_start_fresh_codex_goal_session(
-            &ProviderKind::Codex,
-            "/goals",
-            Some(true)
-        ));
+    fn classify_codex_goal_command_basic() {
+        // ChainedStart: plain /goal
+        assert_eq!(
+            classify_codex_goal_command("/goal 새 목표"),
+            GoalCommandKind::ChainedStart
+        );
+        assert_eq!(
+            classify_codex_goal_command("/goal\n다음 줄"),
+            GoalCommandKind::ChainedStart
+        );
+        assert_eq!(
+            classify_codex_goal_command("  /goal 탭 뒤"),
+            GoalCommandKind::ChainedStart
+        );
+
+        // FreshStart: /goal --fresh
+        assert_eq!(
+            classify_codex_goal_command("/goal --fresh 새 목표"),
+            GoalCommandKind::FreshStart
+        );
+        assert_eq!(
+            classify_codex_goal_command("/goal --fresh"),
+            GoalCommandKind::FreshStart
+        );
+
+        // Lifecycle
+        assert_eq!(
+            classify_codex_goal_command("/goal pause"),
+            GoalCommandKind::Lifecycle
+        );
+        assert_eq!(
+            classify_codex_goal_command("/goal resume"),
+            GoalCommandKind::Lifecycle
+        );
+        assert_eq!(
+            classify_codex_goal_command("/goal clear"),
+            GoalCommandKind::Lifecycle
+        );
+
+        // NotGoal
+        assert_eq!(
+            classify_codex_goal_command("/goals"),
+            GoalCommandKind::NotGoal
+        );
+        assert_eq!(
+            classify_codex_goal_command("/goalkeeper"),
+            GoalCommandKind::NotGoal
+        );
+        assert_eq!(
+            classify_codex_goal_command("질문 /goal"),
+            GoalCommandKind::NotGoal
+        );
+        assert_eq!(classify_codex_goal_command(""), GoalCommandKind::NotGoal);
+    }
+
+    #[test]
+    fn classify_codex_goal_command_for_provider_gates_non_codex() {
+        // Non-Codex provider → always NotGoal
+        assert_eq!(
+            classify_codex_goal_command_for_provider(&ProviderKind::Claude, "/goal 새 목표", None),
+            GoalCommandKind::NotGoal
+        );
+        // goals disabled → NotGoal
+        assert_eq!(
+            classify_codex_goal_command_for_provider(
+                &ProviderKind::Codex,
+                "/goal 새 목표",
+                Some(false)
+            ),
+            GoalCommandKind::NotGoal
+        );
+        // Codex + goals enabled (or unset) → classify
+        assert_eq!(
+            classify_codex_goal_command_for_provider(
+                &ProviderKind::Codex,
+                "/goal 새 목표",
+                Some(true)
+            ),
+            GoalCommandKind::ChainedStart
+        );
+        assert_eq!(
+            classify_codex_goal_command_for_provider(
+                &ProviderKind::Codex,
+                "/goal --fresh 새 목표",
+                None
+            ),
+            GoalCommandKind::FreshStart
+        );
+        assert_eq!(
+            classify_codex_goal_command_for_provider(
+                &ProviderKind::Codex,
+                "/goal pause",
+                Some(true)
+            ),
+            GoalCommandKind::Lifecycle
+        );
+    }
+
+    #[test]
+    fn rewrite_fresh_goal_prompt_strips_fresh_marker() {
+        assert_eq!(
+            rewrite_fresh_goal_prompt("/goal --fresh 새 목표"),
+            "/goal 새 목표"
+        );
+        assert_eq!(rewrite_fresh_goal_prompt("/goal --fresh"), "/goal");
+        // Non-fresh prompts are returned unchanged
+        assert_eq!(rewrite_fresh_goal_prompt("/goal 새 목표"), "/goal 새 목표");
     }
 
     #[test]

--- a/src/services/provider_exec.rs
+++ b/src/services/provider_exec.rs
@@ -211,6 +211,7 @@ pub async fn execute_structured_with_context(
                     None,
                     None,
                     None,
+                    false,
                 ),
                 ProviderKind::Gemini => gemini::execute_command_streaming(
                     &prompt,


### PR DESCRIPTION
## 목표

Codex goal 실행에서 기본 `/goal <objective>`는 같은 Discord 채널의 기존 wrapper/thread를 이어 쓰고, 명시적인 `/goal --fresh <objective>`만 새 provider session으로 격리되도록 session policy를 분리합니다.

## 쉬운 설명

이제 `goal A`가 끝난 뒤 같은 채널에서 `goal B`를 보내면 기존 Codex 세션 맥락을 이어갈 수 있습니다. 이전 작업과 분리하고 싶을 때만 `/goal --fresh B`를 쓰면 됩니다. `/goal pause`, `/goal resume`, `/goal clear`는 기존 thread에 그대로 전달됩니다.

## 개선되는 것

### Fix 1

`/goal` prefix를 단순 fresh-start로만 보지 않고 `ChainedStart`, `FreshStart`, `Lifecycle`, `NotGoal`로 분류합니다.

### Fix 2

`/goal --fresh <objective>`에서 AgentDesk가 `--fresh` marker를 소비하고 Codex에는 `/goal <objective>` 형태로 전달합니다.

### Fix 3

Codex local tmux/process wrapper 재사용 조건에 explicit fresh flag를 반영해, fresh 요청일 때만 기존 wrapper/thread를 재사용하지 않습니다.

## Before → After

| 시나리오 | Before | After |
|---|---|---|
| `/goal A` 후 `/goal B` | `/goal` fresh 처리 의도와 wrapper 재사용이 섞여 정책이 불명확 | 기본 chain으로 기존 wrapper/thread 재사용 |
| `/goal --fresh B` | marker가 없고 기존 wrapper/thread 재사용 가능 | marker 제거 후 새 provider session으로 실행 |
| `/goal pause/resume/clear` | `/goal` prefix라 fresh reset 대상이 될 수 있음 | lifecycle로 분류되어 기존 thread 유지 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
|---|---|---|
| dcserver 재시작 후 live tmux reattach | fresh flag가 없으면 기존 reattach 유지 | 기존 복구 동작 보존 |
| process fallback live + fresh flag | 기존 process handle 종료 후 새 process 시작 | tmux와 fallback 정책 일치 |
| non-Codex provider `/goal` | `NotGoal` 처리 | 다른 provider 영향 없음 |

## 해결한 내용

- `src/services/discord/router/message_handler.rs`: Codex goal command classifier, fresh marker rewrite, provider-gated fresh flag 전달을 추가했습니다.
- `src/services/codex.rs`: explicit fresh flag로 tmux/process wrapper 재사용을 제어하고, fresh process fallback에서는 기존 process handle을 종료하도록 했습니다.
- `src/services/provider_exec.rs`: structured Codex execution 호출부에 기본 `force_fresh_provider_session=false`를 전달했습니다.

## 계약 대응

- 기본 `/goal <objective>`는 chain mode입니다.
- `/goal --fresh <objective>`만 fresh isolation입니다.
- `session_id == None`만으로 fresh를 추론하지 않습니다.
- tmux와 process fallback의 reuse policy를 동일하게 유지합니다.

## 검증

- `cargo fmt --all --check`
- `cargo check --all-targets`
- `cargo test classify_codex_goal_command --features legacy-sqlite-tests`
- `cargo test rewrite_fresh_goal_prompt_strips_fresh_marker --features legacy-sqlite-tests`
- `cargo test test_provider_session_reuse_decision_honors_explicit_fresh_flag --features legacy-sqlite-tests`
