### PR TITLE
[codex] Handle TCP listener local_addr errors

### DIFF
--- a/src/services/opencode.rs
+++ b/src/services/opencode.rs
@@ -1498,7 +1498,10 @@ fn process_sse_event(
 fn allocate_port() -> Result<u16, String> {
     let listener = std::net::TcpListener::bind("127.0.0.1:0")
         .map_err(|e| format!("Failed to allocate a free port: {e}"))?;
-    Ok(listener.local_addr().unwrap().port())
+    let addr = listener
+        .local_addr()
+        .map_err(|e| format!("Failed to resolve local address: {e}"))?;
+    Ok(addr.port())
     // listener drops here, freeing the port with a brief race window
 }
 


### PR DESCRIPTION
## 목표
이 PR은 `Handle TCP listener local_addr errors` 범위를 `main`에 반영해 `src/services/opencode.rs`의 TCP listener 오류 처리 강화 상태를 최신화합니다. 본문은 live PR의 커밋, 변경 파일, 원격 체크를 기준으로 갱신했습니다.

## 쉬운 설명
- 이 변경은 `src/services/opencode.rs`에 집중되어 있습니다.
- 리뷰어는 `TCP listener 오류 처리 강화` 관점에서 변경 파일과 실행 경로를 확인하면 됩니다.
- 이 PR은 draft 해제 후 ready/open 리뷰 상태로 전환했습니다.
- diff 규모는 `+4 / -1`이며 head SHA는 `bd0d588d6f51`입니다.

## 개선되는 것
### Fix 1
- `Handle TCP listener local_addr errors` 변경을 PR head 기준으로 정리했습니다.
- 대상 범위: `src/services/opencode.rs`

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| `Handle TCP listener local_addr errors` | `main` 기준에서 해당 방어/정리/게이트가 부족하거나 최신 의도와 어긋날 수 있음 | head `codex/upstream-provider-local-addr`의 TCP listener 오류 처리 강화 변경 반영 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 변경 파일 범위 | `src/services/opencode.rs` 중심으로 제한 | 인접 모듈 영향은 변경 파일과 호출 경로 중심으로 리뷰 필요 |
| PR 상태 | draft에서 ready/open 리뷰 상태로 전환 | 리뷰와 CI 판정이 외부에서 명확히 보임 |
| 병합 대상 | `main` 기준 PR | base branch로 직접 푸시하지 않음 |

## 해결한 내용
- `src/services/opencode.rs`

커밋 근거:
- ProviderPilot: map unwrap error on TCP listener local_addr

## 검증
- 원격 체크 요약: `SUCCESS` 4개, `FAILURE` 3개, `SKIPPED` 2개, `IN_PROGRESS` 1개.
- 실패 체크: `Script checks`, `Fast check + non-PG tests (macos-latest)`, `Lint`.
- 진행 중 체크: `Fast check + non-PG tests (windows-latest)`.
- 별도 로컬 빌드/테스트 명령은 이번 PR 상태/본문 갱신 작업에서 실행하지 않았습니다.

## 메타
- PR: `2055`
- Head: `codex/upstream-provider-local-addr` @ `bd0d588d6f51`
- 변경량: `+4 / -1`, 파일 `1`개
