### PR TITLE
[codex] Harden markdown links without breaking anchors

### DIFF
--- a/dashboard/src/components/common/MarkdownContent.test.tsx
+++ b/dashboard/src/components/common/MarkdownContent.test.tsx
@@ -1,0 +1,26 @@
+/** @vitest-environment happy-dom */
+import { test, expect } from "vitest";
+import { createRoot } from "react-dom/client";
+import { act } from "react";
+import MarkdownContent from "./MarkdownContent";
+import React from "react";
+
+test("MarkdownContent renders links safely with target blank and noopener noreferrer", async () => {
+  const div = document.createElement("div");
+  const root = createRoot(div);
+
+  await act(async () => {
+    root.render(<MarkdownContent content={"[external](https://example.com) [evil](javascript:alert(1))"} />);
+  });
+
+  const links = div.querySelectorAll("a");
+
+  for (const link of links) {
+    if (link.getAttribute("href") === "https://example.com") {
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+    } else {
+      expect(link.getAttribute("href")).not.toBe("javascript:alert(1)");
+    }
+  }
+});

--- a/dashboard/src/components/common/MarkdownContent.test.tsx
+++ b/dashboard/src/components/common/MarkdownContent.test.tsx
@@ -10,7 +10,13 @@ test("MarkdownContent renders links safely with target blank and noopener norefe
   const root = createRoot(div);
 
   await act(async () => {
-    root.render(<MarkdownContent content={"[external](https://example.com) [anchor](#details) [evil](javascript:alert(1))"} />);
+    root.render(
+      <MarkdownContent
+        content={
+          "[external](https://example.com) [same-origin](http://localhost:3000/settings) [protocol-relative](//localhost:3000/help) [anchor](#details) [evil](javascript:alert(1))"
+        }
+      />
+    );
   });
 
   const links = div.querySelectorAll("a");
@@ -19,7 +25,11 @@ test("MarkdownContent renders links safely with target blank and noopener norefe
     if (link.getAttribute("href") === "https://example.com") {
       expect(link.getAttribute("target")).toBe("_blank");
       expect(link.getAttribute("rel")).toBe("noopener noreferrer");
-    } else if (link.getAttribute("href") === "#details") {
+    } else if (
+      link.getAttribute("href") === "http://localhost:3000/settings" ||
+      link.getAttribute("href") === "//localhost:3000/help" ||
+      link.getAttribute("href") === "#details"
+    ) {
       expect(link.hasAttribute("target")).toBe(false);
       expect(link.hasAttribute("rel")).toBe(false);
     } else {

--- a/dashboard/src/components/common/MarkdownContent.test.tsx
+++ b/dashboard/src/components/common/MarkdownContent.test.tsx
@@ -10,7 +10,7 @@ test("MarkdownContent renders links safely with target blank and noopener norefe
   const root = createRoot(div);
 
   await act(async () => {
-    root.render(<MarkdownContent content={"[external](https://example.com) [evil](javascript:alert(1))"} />);
+    root.render(<MarkdownContent content={"[external](https://example.com) [anchor](#details) [evil](javascript:alert(1))"} />);
   });
 
   const links = div.querySelectorAll("a");
@@ -19,6 +19,9 @@ test("MarkdownContent renders links safely with target blank and noopener norefe
     if (link.getAttribute("href") === "https://example.com") {
       expect(link.getAttribute("target")).toBe("_blank");
       expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+    } else if (link.getAttribute("href") === "#details") {
+      expect(link.hasAttribute("target")).toBe(false);
+      expect(link.hasAttribute("rel")).toBe(false);
     } else {
       expect(link.getAttribute("href")).not.toBe("javascript:alert(1)");
     }

--- a/dashboard/src/components/common/MarkdownContent.tsx
+++ b/dashboard/src/components/common/MarkdownContent.tsx
@@ -7,7 +7,19 @@ interface Props {
 }
 
 function isExternalHref(href?: string) {
-  return Boolean(href && /^(https?:)?\/\//i.test(href));
+  if (!href || !/^(https?:)?\/\//i.test(href)) {
+    return false;
+  }
+
+  if (typeof window === "undefined" || !window.location?.href) {
+    return true;
+  }
+
+  try {
+    return new URL(href, window.location.href).origin !== window.location.origin;
+  } catch {
+    return true;
+  }
 }
 
 export default function MarkdownContent({ content, className }: Props) {

--- a/dashboard/src/components/common/MarkdownContent.tsx
+++ b/dashboard/src/components/common/MarkdownContent.tsx
@@ -13,7 +13,14 @@ export default function MarkdownContent({ content, className }: Props) {
 
   return (
     <div className={classes}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          a: ({ node, ...props }) => (
+            <a {...props} target="_blank" rel="noopener noreferrer" />
+          )
+        }}
+      >
         {content.replace(/\r\n/g, "\n")}
       </ReactMarkdown>
     </div>

--- a/dashboard/src/components/common/MarkdownContent.tsx
+++ b/dashboard/src/components/common/MarkdownContent.tsx
@@ -6,6 +6,10 @@ interface Props {
   className?: string;
 }
 
+function isExternalHref(href?: string) {
+  return Boolean(href && /^(https?:)?\/\//i.test(href));
+}
+
 export default function MarkdownContent({ content, className }: Props) {
   if (!content.trim()) return null;
 
@@ -16,9 +20,13 @@ export default function MarkdownContent({ content, className }: Props) {
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
-          a: ({ node, ...props }) => (
-            <a {...props} target="_blank" rel="noopener noreferrer" />
-          )
+          a: ({ node, ...props }) => {
+            const externalProps = isExternalHref(props.href)
+              ? { target: "_blank", rel: "noopener noreferrer" }
+              : {};
+
+            return <a {...props} {...externalProps} />;
+          }
         }}
       >
         {content.replace(/\r\n/g, "\n")}


### PR DESCRIPTION
## 목표
이 PR은 `Harden markdown links without breaking anchors` 범위를 `main`에 반영해 `dashboard`의 Markdown 링크 처리 안전화 상태를 최신화합니다. 본문은 live PR의 커밋, 변경 파일, 원격 체크를 기준으로 갱신했습니다.

## 쉬운 설명
- 이 변경은 `dashboard`에 집중되어 있습니다.
- 리뷰어는 `Markdown 링크 처리 안전화` 관점에서 변경 파일과 실행 경로를 확인하면 됩니다.
- 이 PR은 draft 해제 후 ready/open 리뷰 상태로 전환했습니다.
- diff 규모는 `+45 / -1`이며 head SHA는 `f1869be840bf`입니다.

## 개선되는 것
### Fix 1
- `Harden markdown links without breaking anchors` 변경을 PR head 기준으로 정리했습니다.
- 대상 범위: `dashboard`

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| `Harden markdown links without breaking anchors` | `main` 기준에서 해당 방어/정리/게이트가 부족하거나 최신 의도와 어긋날 수 있음 | head `codex/upstream-markdown-safe-links`의 Markdown 링크 처리 안전화 변경 반영 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 변경 파일 범위 | `dashboard` 중심으로 제한 | 인접 모듈 영향은 변경 파일과 호출 경로 중심으로 리뷰 필요 |
| PR 상태 | draft에서 ready/open 리뷰 상태로 전환 | 리뷰와 CI 판정이 외부에서 명확히 보임 |
| 병합 대상 | `main` 기준 PR | base branch로 직접 푸시하지 않음 |

## 해결한 내용
- `dashboard/src/components/common/MarkdownContent.test.tsx`
- `dashboard/src/components/common/MarkdownContent.tsx`

커밋 근거:
- 🛡️ Sentinel: [HARDENING] enforce safe link targets in markdown
- fix: keep markdown anchor links in tab

## 검증
- 원격 체크 요약: `SUCCESS` 5개, `FAILURE` 1개, `SKIPPED` 3개.
- 실패 체크: `Script checks`.
- 별도 로컬 빌드/테스트 명령은 이번 PR 상태/본문 갱신 작업에서 실행하지 않았습니다.

## 메타
- PR: `2056`
- Head: `codex/upstream-markdown-safe-links` @ `f1869be840bf`
- 변경량: `+45 / -1`, 파일 `2`개
