### PR TITLE
[codex] Bound auto-queue finished-run finalization sweep

### DIFF
--- a/policies/__tests__/auto-queue.test.js
+++ b/policies/__tests__/auto-queue.test.js
@@ -220,6 +220,66 @@ test("auto-queue terminal cleanup uses pipeline terminal states", () => {
   ]);
 });
 
+test("auto-queue finalization sweep filters blocked runs before LIMIT", () => {
+  const { policy, state } = loadPolicy("policies/auto-queue.js", {
+    dbQuery: createSqlRouter([
+      {
+        match: "JOIN kanban_cards kc ON kc.id = e.kanban_card_id",
+        result: []
+      },
+      {
+        match(sql) {
+          return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
+            sql.includes("auto_queue_phase_gates") &&
+            sql.includes("phase_gate_grace_until") &&
+            sql.includes("ORDER BY r.id ASC LIMIT 50");
+        },
+        result: [{ id: "run-eligible" }]
+      },
+      {
+        match: "SELECT COUNT(*) as cnt FROM auto_queue_phase_gates",
+        result: [{ cnt: 0 }]
+      },
+      {
+        match: "SELECT COUNT(*) as cnt FROM auto_queue_entries WHERE run_id = ? AND status IN ('pending', 'dispatched')",
+        result: [{ cnt: 0 }]
+      },
+      {
+        match: "SELECT COUNT(*) as cnt FROM auto_queue_entries WHERE run_id = ? AND status = 'user_cancelled'",
+        result: [{ cnt: 0 }]
+      },
+      {
+        match: "SELECT phase_gate_grace_until FROM auto_queue_runs WHERE id = ?",
+        result: [{ phase_gate_grace_until: null }]
+      },
+      {
+        match(sql) {
+          return sql.includes("SELECT r.id FROM auto_queue_runs r") &&
+            sql.includes("JOIN auto_queue_entries e ON e.run_id = r.id") &&
+            sql.includes("GROUP BY r.id");
+        },
+        result: []
+      },
+      {
+        match: "e.status = 'dispatched'",
+        result: []
+      }
+    ])
+  });
+
+  policy.onTick1min();
+
+  const finishedRunQuery = state.queries.find((query) =>
+    query.sql.includes("SELECT r.id FROM auto_queue_runs r") &&
+    query.sql.includes("auto_queue_phase_gates")
+  );
+  assert.match(finishedRunQuery.sql, /NOT EXISTS \(  SELECT 1 FROM auto_queue_phase_gates pg/);
+  assert.match(finishedRunQuery.sql, /datetime\(r\.phase_gate_grace_until\) <= datetime\('now'\)/);
+  assert.deepEqual(state.autoQueueCompletes, [
+    { runId: "run-eligible", reason: "finalize_without_phase_gate", options: { releaseSlots: true } }
+  ]);
+});
+
 test("auto-queue rotates saturated active runs in bounded tick sweep", () => {
   const { policy, state } = loadPolicy("policies/auto-queue.js", {
     dbQuery: createSqlRouter([

--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -447,7 +447,7 @@ var autoQueue = {
       "AND NOT EXISTS (" +
       "  SELECT 1 FROM auto_queue_entries e " +
       "  WHERE e.run_id = r.id AND e.status = 'user_cancelled'" +
-      ")",
+      ") LIMIT 50",
       []
     );
     for (var fr = 0; fr < finishedRuns.length; fr++) {

--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -447,7 +447,7 @@ var autoQueue = {
       "AND NOT EXISTS (" +
       "  SELECT 1 FROM auto_queue_entries e " +
       "  WHERE e.run_id = r.id AND e.status = 'user_cancelled'" +
-      ") LIMIT 50",
+      ") ORDER BY r.id ASC LIMIT 50",
       []
     );
     for (var fr = 0; fr < finishedRuns.length; fr++) {

--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -447,6 +447,15 @@ var autoQueue = {
       "AND NOT EXISTS (" +
       "  SELECT 1 FROM auto_queue_entries e " +
       "  WHERE e.run_id = r.id AND e.status = 'user_cancelled'" +
+      ") " +
+      "AND NOT EXISTS (" +
+      "  SELECT 1 FROM auto_queue_phase_gates pg " +
+      "  WHERE pg.run_id = r.id AND pg.status IN ('pending', 'failed')" +
+      ") " +
+      "AND (" +
+      "  r.phase_gate_grace_until IS NULL " +
+      "  OR datetime(r.phase_gate_grace_until) IS NULL " +
+      "  OR datetime(r.phase_gate_grace_until) <= datetime('now')" +
       ") ORDER BY r.id ASC LIMIT 50",
       []
     );


### PR DESCRIPTION
## 목표
이 PR은 `Bound auto-queue finished-run finalization sweep` 범위를 `main`에 반영해 `policies`의 큐/자동화 반복 범위 제한 상태를 최신화합니다. 본문은 live PR의 커밋, 변경 파일, 원격 체크를 기준으로 갱신했습니다.

## 쉬운 설명
- 이 변경은 `policies`에 집중되어 있습니다.
- 리뷰어는 `큐/자동화 반복 범위 제한` 관점에서 변경 파일과 실행 경로를 확인하면 됩니다.
- 이 PR은 draft 해제 후 ready/open 리뷰 상태로 전환했습니다.
- diff 규모는 `+70 / -1`이며 head SHA는 `97e575b4e056`입니다.

## 개선되는 것
### Fix 1
- `Bound auto-queue finished-run finalization sweep` 변경을 PR head 기준으로 정리했습니다.
- 대상 범위: `policies`

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| `Bound auto-queue finished-run finalization sweep` | `main` 기준에서 해당 방어/정리/게이트가 부족하거나 최신 의도와 어긋날 수 있음 | head `codex/upstream-auto-queue-finalization-sweep`의 큐/자동화 반복 범위 제한 변경 반영 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 변경 파일 범위 | `policies` 중심으로 제한 | 인접 모듈 영향은 변경 파일과 호출 경로 중심으로 리뷰 필요 |
| PR 상태 | draft에서 ready/open 리뷰 상태로 전환 | 리뷰와 CI 판정이 외부에서 명확히 보임 |
| 병합 대상 | `main` 기준 PR | base branch로 직접 푸시하지 않음 |

## 해결한 내용
- `policies/__tests__/auto-queue.test.js`
- `policies/auto-queue.js`

커밋 근거:
- ⚡ Bolt: [auto-queue] cap unbounded finished run finalization sweep
- fix: order bounded finished run sweep
- fix: filter finalizable runs before sweep limit

## 검증
- 원격 체크 요약: `SUCCESS` 4개, `FAILURE` 3개, `SKIPPED` 2개, `IN_PROGRESS` 1개.
- 실패 체크: `Script checks`, `Fast check + non-PG tests (macos-latest)`, `Lint`.
- 진행 중 체크: `Fast check + non-PG tests (windows-latest)`.
- 별도 로컬 빌드/테스트 명령은 이번 PR 상태/본문 갱신 작업에서 실행하지 않았습니다.

## 메타
- PR: `2057`
- Head: `codex/upstream-auto-queue-finalization-sweep` @ `97e575b4e056`
- 변경량: `+70 / -1`, 파일 `2`개
