### PR TITLE
[codex] Bound review auto-accept fan-out and aggregate retries

### DIFF
--- a/policies/__tests__/timeouts.test.js
+++ b/policies/__tests__/timeouts.test.js
@@ -225,6 +225,45 @@ test("timeouts review auto-accept triggers tuning aggregate once after batch ins
   assert.deepEqual(state.httpPosts, [
     { url: "http://127.0.0.1:8791/api/reviews/tuning/aggregate", body: {} }
   ]);
+  assert.equal(state.kv.has("review_tuning:auto_accept_aggregate_retry"), false);
+});
+
+test("timeouts review auto-accept retries pending tuning aggregate on later tick", () => {
+  const retryKey = "review_tuning:auto_accept_aggregate_retry";
+  let staleQueryCount = 0;
+  let postCount = 0;
+
+  const { policy, state } = loadPolicy("policies/timeouts.js", {
+    config: { server_port: 8791 },
+    dbQuery(sql) {
+      if (sql.includes("review_status = 'suggestion_pending'")) {
+        staleQueryCount += 1;
+        return staleQueryCount === 1
+          ? [{ id: "card-review-1", assigned_agent_id: "agent-review-1", title: "Review card 1" }]
+          : [];
+      }
+      if (sql.includes("SELECT review_round, last_verdict FROM card_review_state")) {
+        return [{ review_round: 2, last_verdict: "changes_requested" }];
+      }
+      if (sql.includes("FROM task_dispatches")) return [];
+      return [];
+    },
+    httpPost() {
+      postCount += 1;
+      if (postCount === 1) throw new Error("temporary API failure");
+      return { ok: true };
+    }
+  });
+
+  policy._section_E();
+
+  assert.equal(state.kv.get(retryKey), "pending");
+  assert.equal(state.httpPosts.length, 1);
+
+  policy._section_E();
+
+  assert.equal(state.kv.has(retryKey), false);
+  assert.equal(state.httpPosts.length, 2);
 });
 
 test("timeouts dispatch maintenance module re-enqueues unnotified pending dispatches", () => {

--- a/policies/__tests__/timeouts.test.js
+++ b/policies/__tests__/timeouts.test.js
@@ -266,6 +266,29 @@ test("timeouts review auto-accept retries pending tuning aggregate on later tick
   assert.equal(state.httpPosts.length, 2);
 });
 
+test("timeouts review auto-accept keeps aggregate retry when POST returns error payload", () => {
+  const retryKey = "review_tuning:auto_accept_aggregate_retry";
+  const { policy, state } = loadPolicy("policies/timeouts.js", {
+    config: { server_port: 8791 },
+    dbQuery: createSqlRouter([
+      {
+        match: "WHERE status = ? AND review_status = 'suggestion_pending'",
+        result: []
+      }
+    ]),
+    httpPost() {
+      return { error: "temporary API failure" };
+    }
+  });
+  state.kv.set(retryKey, "pending");
+
+  policy._section_E();
+
+  assert.equal(state.kv.get(retryKey), "pending");
+  assert.equal(state.httpPosts.length, 1);
+  assert.match(state.logs.warn.at(-1), /aggregate trigger returned error/);
+});
+
 test("timeouts dispatch maintenance module re-enqueues unnotified pending dispatches", () => {
   const { policy, state } = loadPolicy("policies/timeouts.js", {
     dbQuery: createSqlRouter([

--- a/policies/__tests__/timeouts.test.js
+++ b/policies/__tests__/timeouts.test.js
@@ -194,6 +194,39 @@ test("timeouts review auto-accept module creates rework dispatches before transi
   ]);
 });
 
+test("timeouts review auto-accept triggers tuning aggregate once after batch inserts", () => {
+  const staleCards = [
+    { id: "card-review-1", assigned_agent_id: "agent-review-1", title: "Review card 1" },
+    { id: "card-review-2", assigned_agent_id: "agent-review-2", title: "Review card 2" }
+  ];
+
+  const { policy, state } = loadPolicy("policies/timeouts.js", {
+    config: { server_port: 8791 },
+    dbQuery(sql) {
+      if (sql.includes("review_status = 'suggestion_pending'")) return staleCards;
+      if (sql.includes("SELECT review_round, last_verdict FROM card_review_state")) {
+        return [{ review_round: 2, last_verdict: "changes_requested" }];
+      }
+      if (sql.includes("FROM task_dispatches")) return [];
+      return [];
+    },
+    httpPost(url, body, currentState) {
+      assert.equal(currentState.executions.length, 2);
+      return { ok: true };
+    }
+  });
+
+  policy._section_E();
+
+  const outcomeInserts = state.executions.filter((execution) =>
+    execution.sql.includes("INSERT INTO review_tuning_outcomes")
+  );
+  assert.equal(outcomeInserts.length, 2);
+  assert.deepEqual(state.httpPosts, [
+    { url: "http://127.0.0.1:8791/api/reviews/tuning/aggregate", body: {} }
+  ]);
+});
+
 test("timeouts dispatch maintenance module re-enqueues unnotified pending dispatches", () => {
   const { policy, state } = loadPolicy("policies/timeouts.js", {
     dbQuery: createSqlRouter([

--- a/policies/timeouts/review-auto-accept.js
+++ b/policies/timeouts/review-auto-accept.js
@@ -43,6 +43,7 @@ module.exports = function attachReviewAutoAccept(timeouts, helpers) {
         "ORDER BY suggestion_pending_at ASC LIMIT 50",
         [eReview]
       );
+      var aggregateTriggered = false;
       for (var s = 0; s < staleSuggestions.length; s++) {
         var sc = staleSuggestions[s];
         if (sc.assigned_agent_id) {
@@ -86,13 +87,16 @@ module.exports = function attachReviewAutoAccept(timeouts, helpers) {
               agentdesk.log.info("[review-tuning] #119 recorded true_positive (auto-accept): card=" + sc.id);
               // #119: Trigger re-aggregation — other outcome paths (Rust) call
               // spawn_aggregate_if_needed directly; from JS we hit the HTTP API.
-              try {
-                var aggPort = agentdesk.config.get("server_port");
-                if (aggPort) {
-                  agentdesk.http.post("http://127.0.0.1:" + aggPort + "/api/reviews/tuning/aggregate", {});
+              if (!aggregateTriggered) {
+                try {
+                  var aggPort = agentdesk.config.get("server_port");
+                  if (aggPort) {
+                    agentdesk.http.post("http://127.0.0.1:" + aggPort + "/api/reviews/tuning/aggregate", {});
+                    aggregateTriggered = true;
+                  }
+                } catch (aggErr) {
+                  agentdesk.log.warn("[review-tuning] aggregate trigger failed (non-fatal): " + aggErr);
                 }
-              } catch (aggErr) {
-                agentdesk.log.warn("[review-tuning] aggregate trigger failed (non-fatal): " + aggErr);
               }
             }
             // #117: sync canonical review state

--- a/policies/timeouts/review-auto-accept.js
+++ b/policies/timeouts/review-auto-accept.js
@@ -43,7 +43,7 @@ module.exports = function attachReviewAutoAccept(timeouts, helpers) {
         "ORDER BY suggestion_pending_at ASC LIMIT 50",
         [eReview]
       );
-      var aggregateTriggered = false;
+      var aggregateNeeded = false;
       for (var s = 0; s < staleSuggestions.length; s++) {
         var sc = staleSuggestions[s];
         if (sc.assigned_agent_id) {
@@ -85,19 +85,7 @@ module.exports = function attachReviewAutoAccept(timeouts, helpers) {
                 [sc.id, rs.review_round || null, rs.last_verdict || "unknown", findingCats]
               );
               agentdesk.log.info("[review-tuning] #119 recorded true_positive (auto-accept): card=" + sc.id);
-              // #119: Trigger re-aggregation — other outcome paths (Rust) call
-              // spawn_aggregate_if_needed directly; from JS we hit the HTTP API.
-              if (!aggregateTriggered) {
-                aggregateTriggered = true;
-                try {
-                  var aggPort = agentdesk.config.get("server_port");
-                  if (aggPort) {
-                    agentdesk.http.post("http://127.0.0.1:" + aggPort + "/api/reviews/tuning/aggregate", {});
-                  }
-                } catch (aggErr) {
-                  agentdesk.log.warn("[review-tuning] aggregate trigger failed (non-fatal): " + aggErr);
-                }
-              }
+              aggregateNeeded = true;
             }
             // #117: sync canonical review state
             agentdesk.reviewState.sync(sc.id, "rework_pending", { last_decision: "auto_accept" });
@@ -109,6 +97,18 @@ module.exports = function attachReviewAutoAccept(timeouts, helpers) {
           }
         } else {
           agentdesk.log.warn("[timeout] Auto-accepted card " + sc.id + " but no agent assigned — no rework dispatch");
+        }
+      }
+      // #119: Trigger re-aggregation after the batch so all newly inserted
+      // outcomes are visible while still bounding this JS path to one POST.
+      if (aggregateNeeded) {
+        try {
+          var aggPort = agentdesk.config.get("server_port");
+          if (aggPort) {
+            agentdesk.http.post("http://127.0.0.1:" + aggPort + "/api/reviews/tuning/aggregate", {});
+          }
+        } catch (aggErr) {
+          agentdesk.log.warn("[review-tuning] aggregate trigger failed (non-fatal): " + aggErr);
         }
       }
     };

--- a/policies/timeouts/review-auto-accept.js
+++ b/policies/timeouts/review-auto-accept.js
@@ -106,8 +106,19 @@ module.exports = function attachReviewAutoAccept(timeouts, helpers) {
         try {
           var aggPort = agentdesk.config.get("server_port");
           if (aggPort) {
-            agentdesk.http.post("http://127.0.0.1:" + aggPort + "/api/reviews/tuning/aggregate", {});
-            agentdesk.kv.delete(reviewTuningAggregateRetryKey);
+            var aggregateResponse = agentdesk.http.post(
+              "http://127.0.0.1:" + aggPort + "/api/reviews/tuning/aggregate",
+              {}
+            );
+            if (aggregateResponse && aggregateResponse.error) {
+              agentdesk.kv.set(reviewTuningAggregateRetryKey, "pending");
+              agentdesk.log.warn(
+                "[review-tuning] aggregate trigger returned error (non-fatal): " +
+                (aggregateResponse.error.message || aggregateResponse.error)
+              );
+            } else {
+              agentdesk.kv.delete(reviewTuningAggregateRetryKey);
+            }
           } else {
             agentdesk.kv.set(reviewTuningAggregateRetryKey, "pending");
           }

--- a/policies/timeouts/review-auto-accept.js
+++ b/policies/timeouts/review-auto-accept.js
@@ -88,11 +88,11 @@ module.exports = function attachReviewAutoAccept(timeouts, helpers) {
               // #119: Trigger re-aggregation — other outcome paths (Rust) call
               // spawn_aggregate_if_needed directly; from JS we hit the HTTP API.
               if (!aggregateTriggered) {
+                aggregateTriggered = true;
                 try {
                   var aggPort = agentdesk.config.get("server_port");
                   if (aggPort) {
                     agentdesk.http.post("http://127.0.0.1:" + aggPort + "/api/reviews/tuning/aggregate", {});
-                    aggregateTriggered = true;
                   }
                 } catch (aggErr) {
                   agentdesk.log.warn("[review-tuning] aggregate trigger failed (non-fatal): " + aggErr);

--- a/policies/timeouts/review-auto-accept.js
+++ b/policies/timeouts/review-auto-accept.js
@@ -25,6 +25,7 @@ module.exports = function attachReviewAutoAccept(timeouts, helpers) {
   var requestTurnWatchdogExtension = helpers.requestTurnWatchdogExtension;
   var _queuePMDecision = helpers._queuePMDecision;
   var _flushPMDecisions = helpers._flushPMDecisions;
+  var reviewTuningAggregateRetryKey = "review_tuning:auto_accept_aggregate_retry";
 
   timeouts._section_E = function() {
       // ─── [E] 자동-수용 결정 타임아웃 (suggestion_pending 15분) ──
@@ -43,7 +44,7 @@ module.exports = function attachReviewAutoAccept(timeouts, helpers) {
         "ORDER BY suggestion_pending_at ASC LIMIT 50",
         [eReview]
       );
-      var aggregateNeeded = false;
+      var aggregateNeeded = agentdesk.kv.get(reviewTuningAggregateRetryKey) === "pending";
       for (var s = 0; s < staleSuggestions.length; s++) {
         var sc = staleSuggestions[s];
         if (sc.assigned_agent_id) {
@@ -106,8 +107,12 @@ module.exports = function attachReviewAutoAccept(timeouts, helpers) {
           var aggPort = agentdesk.config.get("server_port");
           if (aggPort) {
             agentdesk.http.post("http://127.0.0.1:" + aggPort + "/api/reviews/tuning/aggregate", {});
+            agentdesk.kv.delete(reviewTuningAggregateRetryKey);
+          } else {
+            agentdesk.kv.set(reviewTuningAggregateRetryKey, "pending");
           }
         } catch (aggErr) {
+          agentdesk.kv.set(reviewTuningAggregateRetryKey, "pending");
           agentdesk.log.warn("[review-tuning] aggregate trigger failed (non-fatal): " + aggErr);
         }
       }


### PR DESCRIPTION
## 목표
이 PR은 `Bound review auto-accept fan-out and aggregate retries` 범위를 `main`에 반영해 `policies`의 CI와 유지보수 게이트 안정화 상태를 최신화합니다. 본문은 live PR의 커밋, 변경 파일, 원격 체크를 기준으로 갱신했습니다.

## 쉬운 설명
- 이 변경은 `policies`에 집중되어 있습니다.
- 리뷰어는 `CI와 유지보수 게이트 안정화` 관점에서 변경 파일과 실행 경로를 확인하면 됩니다.
- 이 PR은 draft 해제 후 ready/open 리뷰 상태로 전환했습니다.
- diff 규모는 `+91 / -10`이며 head SHA는 `8071a07ef6b6`입니다.

## 개선되는 것
### Fix 1
- `Bound review auto-accept fan-out and aggregate retries` 변경을 PR head 기준으로 정리했습니다.
- 대상 범위: `policies`

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| `Bound review auto-accept fan-out and aggregate retries` | `main` 기준에서 해당 방어/정리/게이트가 부족하거나 최신 의도와 어긋날 수 있음 | head `codex/upstream-review-auto-accept-bounds`의 CI와 유지보수 게이트 안정화 변경 반영 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 변경 파일 범위 | `policies` 중심으로 제한 | 인접 모듈 영향은 변경 파일과 호출 경로 중심으로 리뷰 필요 |
| PR 상태 | draft에서 ready/open 리뷰 상태로 전환 | 리뷰와 CI 판정이 외부에서 명확히 보임 |
| 병합 대상 | `main` 기준 PR | base branch로 직접 푸시하지 않음 |

## 해결한 내용
- `policies/__tests__/timeouts.test.js`
- `policies/timeouts/review-auto-accept.js`

커밋 근거:
- ⚡ Bolt: [timeouts] bound review-auto-accept HTTP fan-out
- fix: bound review aggregate trigger attempts
- fix: aggregate review tuning after auto-accept batch
- fix: retry review tuning aggregate trigger

## 검증
- 원격 체크 요약: `SUCCESS` 4개, `FAILURE` 3개, `SKIPPED` 2개, `IN_PROGRESS` 1개.
- 실패 체크: `Script checks`, `Fast check + non-PG tests (macos-latest)`, `Lint`.
- 진행 중 체크: `Fast check + non-PG tests (windows-latest)`.
- 별도 로컬 빌드/테스트 명령은 이번 PR 상태/본문 갱신 작업에서 실행하지 않았습니다.

## 메타
- PR: `2058`
- Head: `codex/upstream-review-auto-accept-bounds` @ `8071a07ef6b6`
- 변경량: `+91 / -10`, 파일 `2`개
