### PR TITLE
[codex] Improve EmojiPicker accessibility labels

### DIFF
--- a/dashboard/src/components/agent-manager/EmojiPicker.test.tsx
+++ b/dashboard/src/components/agent-manager/EmojiPicker.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment happy-dom
+
+import React, { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import EmojiPicker from "./EmojiPicker";
+
+describe("EmojiPicker", () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  async function render(element: ReactNode) {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(element);
+    });
+    return container;
+  }
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+      root = null;
+    }
+    container?.remove();
+    container = null;
+    vi.clearAllMocks();
+  });
+
+  it("renders with aria-expanded and aria-label", async () => {
+    const target = await render(<EmojiPicker value="🤖" onChange={() => {}} />);
+    const button = target.querySelector("button");
+    expect(button).not.toBeNull();
+    expect(button?.getAttribute("aria-expanded")).toBe("false");
+    expect(button?.getAttribute("aria-label")).toBeTruthy();
+    expect(button?.getAttribute("aria-haspopup")).toBe("dialog");
+  });
+});

--- a/dashboard/src/components/agent-manager/EmojiPicker.tsx
+++ b/dashboard/src/components/agent-manager/EmojiPicker.tsx
@@ -60,11 +60,16 @@ export default function EmojiPicker({
         onClick={() => setOpen(!open)}
         className={`${btnSize} rounded-lg border flex items-center justify-center transition-all hover:scale-105 hover:shadow-md`}
         style={{ background: "var(--th-input-bg)", borderColor: "var(--th-input-border)" }}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label={value ? `Change emoji (current: ${value})` : "Open emoji picker"}
       >
         {value || "❓"}
       </button>
       {open && (
         <div
+          role="dialog"
+          aria-label="Choose an emoji"
           className="absolute z-[60] top-full mt-1 left-0 rounded-xl shadow-2xl p-3 w-72 max-h-[60vh] overflow-y-auto overscroll-contain"
           style={{
             background:
@@ -97,6 +102,7 @@ export default function EmojiPicker({
                         ? "rgba(59,130,246,0.15)"
                         : "transparent",
                     }}
+                    aria-label={emoji}
                   >
                     {emoji}
                   </button>


### PR DESCRIPTION
## 목표
이 PR은 `Improve EmojiPicker accessibility labels` 범위를 `main`에 반영해 `dashboard`의 접근성/라벨링 개선 상태를 최신화합니다. 본문은 live PR의 커밋, 변경 파일, 원격 체크를 기준으로 갱신했습니다.

## 쉬운 설명
- 이 변경은 `dashboard`에 집중되어 있습니다.
- 리뷰어는 `접근성/라벨링 개선` 관점에서 변경 파일과 실행 경로를 확인하면 됩니다.
- 이 PR은 draft 해제 후 ready/open 리뷰 상태로 전환했습니다.
- diff 규모는 `+48 / -0`이며 head SHA는 `ee0edbe0eac7`입니다.

## 개선되는 것
### Fix 1
- `Improve EmojiPicker accessibility labels` 변경을 PR head 기준으로 정리했습니다.
- 대상 범위: `dashboard`

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| `Improve EmojiPicker accessibility labels` | `main` 기준에서 해당 방어/정리/게이트가 부족하거나 최신 의도와 어긋날 수 있음 | head `codex/upstream-emoji-picker-a11y`의 접근성/라벨링 개선 변경 반영 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 변경 파일 범위 | `dashboard` 중심으로 제한 | 인접 모듈 영향은 변경 파일과 호출 경로 중심으로 리뷰 필요 |
| PR 상태 | draft에서 ready/open 리뷰 상태로 전환 | 리뷰와 CI 판정이 외부에서 명확히 보임 |
| 병합 대상 | `main` 기준 PR | base branch로 직접 푸시하지 않음 |

## 해결한 내용
- `dashboard/src/components/agent-manager/EmojiPicker.test.tsx`
- `dashboard/src/components/agent-manager/EmojiPicker.tsx`

커밋 근거:
- fix(a11y): improve emoji picker keyboard labels

## 검증
- 원격 체크 요약: `SUCCESS` 5개, `FAILURE` 1개, `SKIPPED` 3개.
- 실패 체크: `Script checks`.
- 별도 로컬 빌드/테스트 명령은 이번 PR 상태/본문 갱신 작업에서 실행하지 않았습니다.

## 메타
- PR: `2060`
- Head: `codex/upstream-emoji-picker-a11y` @ `ee0edbe0eac7`
- 변경량: `+48 / -0`, 파일 `2`개
