### PR TITLE
fix(routines): scope automation candidate card observations to executor

### DIFF
--- a/src/services/routines/store.rs
+++ b/src/services/routines/store.rs
@@ -140,6 +140,13 @@ fn default_observation_source(source_kind: &str) -> &'static str {
     }
 }
 
+fn include_automation_candidate_card_observations(current_script_ref: Option<&str>) -> bool {
+    matches!(
+        current_script_ref.map(str::trim),
+        Some("monitoring/automation-executor-v2.js" | "monitoring/automation-executor.js")
+    )
+}
+
 /// Build one observation item from a `kv_meta` precomputed digest row.
 ///
 /// # kv_meta digest ingestion surface contract
@@ -1344,9 +1351,11 @@ impl RoutineStore {
             kanban_obs.into(),
             dispatch_obs.into(),
             session_obs.into(),
-            kanban_ready_obs.into(),
-            kanban_dispatched_obs.into(),
         ];
+        if include_automation_candidate_card_observations(current_script_ref) {
+            sources.push(kanban_ready_obs.into());
+            sources.push(kanban_dispatched_obs.into());
+        }
         let mut observations = Vec::with_capacity(max_items.min(100));
         let mut total_bytes: usize = 0;
         'merge: loop {
@@ -2514,8 +2523,9 @@ struct CloseRun<'a> {
 #[cfg(test)]
 mod tests {
     use super::{
-        next_due_after, next_due_after_anchor, parse_schedule_interval,
-        precomputed_observation_from_kv, truncate_chars, validate_routine_schedule,
+        include_automation_candidate_card_observations, next_due_after, next_due_after_anchor,
+        parse_schedule_interval, precomputed_observation_from_kv, truncate_chars,
+        validate_routine_schedule,
     };
     use chrono::{TimeZone, Timelike, Utc};
     use serde_json::Value;
@@ -2525,6 +2535,20 @@ mod tests {
     // The store SQL is compiled by `cargo check`; concurrent claim/recovery
     // behavior should be covered by PG integration tests once the runtime
     // harness starts executing routines.
+
+    #[test]
+    fn automation_candidate_card_observations_are_executor_only() {
+        assert!(include_automation_candidate_card_observations(Some(
+            "monitoring/automation-executor-v2.js"
+        )));
+        assert!(include_automation_candidate_card_observations(Some(
+            " monitoring/automation-executor.js "
+        )));
+        assert!(!include_automation_candidate_card_observations(Some(
+            "monitoring/automation-candidate-recommender.js"
+        )));
+        assert!(!include_automation_candidate_card_observations(None));
+    }
 
     #[test]
     fn parses_supported_interval_schedules() {


### PR DESCRIPTION
## 목표

PR #2064 머지 직후 남은 P1 리뷰를 닫습니다. `kanban_ready` / `kanban_dispatched` 관측 신호는 automation executor 전용 입력으로만 전달하고, recommender에는 노출하지 않아 기존 automation card가 다시 automation 후보로 추천되는 자기증폭 루프를 막습니다.

## 쉬운 설명

자동화 후보 카드가 준비되면 executor는 계속 볼 수 있습니다. 하지만 recommender는 이 카드를 새 자동화 후보 증거로 다시 점수화하지 않습니다. 그래서 이미 만들어진 자동화 카드가 또 다른 자동화 후보를 만드는 churn을 줄입니다.

## 개선되는 것

### Fix 1

Before: 모든 routine의 `ctx.observations`에 `kanban_ready` / `kanban_dispatched`가 섞여 들어갔습니다.

After: `monitoring/automation-executor-v2.js` 및 legacy `monitoring/automation-executor.js` 실행 때만 해당 observation source가 포함됩니다.

## Before → After

| 시나리오 | Before | After |
|---|---|---|
| recommender tick | ready automation card를 scoring evidence로 볼 수 있음 | automation card observation을 받지 않음 |
| executor tick | ready/dispatched card를 소비 | 동일하게 소비 |
| 일반 routine tick | automation card observation이 섞일 수 있음 | 제외됨 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
|---|---|---|
| automation executor v2 | `kanban_ready` / `kanban_dispatched` 유지 | 기존 실행 경로 보존 |
| automation-candidate-recommender | automation card source 제외 | 자기증폭 추천 방지 |
| script_ref 없음 | automation card source 제외 | 보수적 기본값 |

## 해결한 내용

- `src/services/routines/store.rs`: 현재 routine script ref를 기준으로 automation candidate card observation source를 executor 전용으로 gate했습니다.
- `src/services/routines/store.rs`: recommender와 nil script ref가 해당 source를 받지 않는 단위 테스트를 추가했습니다.

## 검증

- `cargo fmt --all --check`
- `cargo test automation_candidate_card_observations_are_executor_only -- --nocapture`
- `cargo check --all-targets`
- `git diff --check`

Follow-up for #2064 / discussion_r3225541971.