### PR TITLE
Recover from poisoned runtime mutexes

### DIFF
--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -1621,7 +1621,8 @@ fn execute_streaming_local_tmux(
 
     // Store tmux session name in cancel token
     if let Some(ref token) = cancel_token {
-        *token.tmux_session.lock().unwrap() = Some(tmux_session_name.to_string());
+        *token.tmux_session.lock().unwrap_or_else(|e| e.into_inner()) =
+            Some(tmux_session_name.to_string());
     }
 
     emit_fresh_session_watcher_handoff(&sender, output_path, input_fifo_path, tmux_session_name);
@@ -1698,7 +1699,8 @@ fn send_followup_to_tmux(
 
     // Store tmux session name in cancel token
     if let Some(ref token) = cancel_token {
-        *token.tmux_session.lock().unwrap() = Some(tmux_session_name.to_string());
+        *token.tmux_session.lock().unwrap_or_else(|e| e.into_inner()) =
+            Some(tmux_session_name.to_string());
     }
 
     // Read output file from the offset
@@ -1849,7 +1851,7 @@ pub(crate) fn execute_streaming_local_process(
 
     // Store child PID in cancel token
     if let Some(ref token) = cancel_token {
-        *token.child_pid.lock().unwrap() = Some(handle.pid());
+        *token.child_pid.lock().unwrap_or_else(|e| e.into_inner()) = Some(handle.pid());
     }
 
     // Store handle for follow-up messages
@@ -1927,7 +1929,7 @@ fn send_followup_to_process(
     // Store session in cancel token
     if let Some(ref token) = cancel_token {
         if let Some(pid) = process_session_pid(session_name) {
-            *token.child_pid.lock().unwrap() = Some(pid);
+            *token.child_pid.lock().unwrap_or_else(|e| e.into_inner()) = Some(pid);
         }
     }
 

--- a/src/services/codex.rs
+++ b/src/services/codex.rs
@@ -679,7 +679,8 @@ fn execute_streaming_local_tmux(
     let _ = std::fs::write(&gen_marker_path, current_gen.to_string());
 
     if let Some(ref token) = cancel_token {
-        *token.tmux_session.lock().unwrap() = Some(tmux_session_name.to_string());
+        *token.tmux_session.lock().unwrap_or_else(|e| e.into_inner()) =
+            Some(tmux_session_name.to_string());
     }
 
     let read_result = read_output_file_until_result(
@@ -749,7 +750,8 @@ fn send_followup_to_tmux(
     }
 
     if let Some(ref token) = cancel_token {
-        *token.tmux_session.lock().unwrap() = Some(tmux_session_name.to_string());
+        *token.tmux_session.lock().unwrap_or_else(|e| e.into_inner()) =
+            Some(tmux_session_name.to_string());
     }
 
     let read_result = match read_output_file_until_result_tracked(
@@ -986,7 +988,7 @@ fn execute_streaming_local_process_codex(
     let handle = backend.create_session(&config)?;
 
     if let Some(ref token) = cancel_token {
-        *token.child_pid.lock().unwrap() = Some(handle.pid());
+        *token.child_pid.lock().unwrap_or_else(|e| e.into_inner()) = Some(handle.pid());
     }
 
     insert_process_session(session_name.to_string(), handle);

--- a/src/services/gemini.rs
+++ b/src/services/gemini.rs
@@ -2234,7 +2234,13 @@ Available sessions for this project (2):
 
         assert!(result.is_ok());
         assert!(rx.try_recv().is_err());
-        assert!(token.child_pid.lock().unwrap().is_none());
+        assert!(
+            token
+                .child_pid
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/services/provider.rs
+++ b/src/services/provider.rs
@@ -556,7 +556,12 @@ impl CancelToken {
     /// Cancel and clean up any associated tmux session.
     pub fn cancel_with_tmux_cleanup(&self) {
         self.cancelled.store(true, Ordering::Relaxed);
-        if let Some(name) = self.tmux_session.lock().unwrap().take() {
+        if let Some(name) = self
+            .tmux_session
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take()
+        {
             #[cfg(unix)]
             {
                 crate::services::tmux_diagnostics::record_tmux_exit_reason(
@@ -590,11 +595,14 @@ impl CancelToken {
     }
 
     pub fn set_cancel_source(&self, source: impl Into<String>) {
-        *self.cancel_source.lock().unwrap() = Some(source.into());
+        *self.cancel_source.lock().unwrap_or_else(|e| e.into_inner()) = Some(source.into());
     }
 
     pub fn cancel_source(&self) -> Option<String> {
-        self.cancel_source.lock().unwrap().clone()
+        self.cancel_source
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
     }
 }
 
@@ -604,7 +612,7 @@ pub fn cancel_requested(token: Option<&CancelToken>) -> bool {
 
 pub fn register_child_pid(token: Option<&CancelToken>, child_pid: u32) {
     if let Some(token) = token {
-        *token.child_pid.lock().unwrap() = Some(child_pid);
+        *token.child_pid.lock().unwrap_or_else(|e| e.into_inner()) = Some(child_pid);
     }
 }
 
@@ -1081,7 +1089,10 @@ mod cancel_token_tests {
         assert_eq!(token.cancel_source(), None);
 
         register_child_pid(Some(&token), 4242);
-        assert_eq!(*token.child_pid.lock().unwrap(), Some(4242));
+        assert_eq!(
+            *token.child_pid.lock().unwrap_or_else(|e| e.into_inner()),
+            Some(4242)
+        );
 
         token.set_cancel_source("watchdog_timeout");
         assert_eq!(token.cancel_source().as_deref(), Some("watchdog_timeout"));
@@ -1644,7 +1655,10 @@ mod tests {
         assert_eq!(token.cancel_source(), None);
 
         register_child_pid(Some(&token), 4242);
-        assert_eq!(*token.child_pid.lock().unwrap(), Some(4242));
+        assert_eq!(
+            *token.child_pid.lock().unwrap_or_else(|e| e.into_inner()),
+            Some(4242)
+        );
 
         token.set_cancel_source("watchdog_timeout");
         assert_eq!(token.cancel_source().as_deref(), Some("watchdog_timeout"));

--- a/src/services/qwen.rs
+++ b/src/services/qwen.rs
@@ -457,7 +457,7 @@ fn execute_qwen_streaming_attempt(
         .map_err(|e| format!("Failed to start Qwen: {}", e))?;
 
     if let Some(ref token) = cancel_token {
-        *token.child_pid.lock().unwrap() = Some(child.id());
+        *token.child_pid.lock().unwrap_or_else(|e| e.into_inner()) = Some(child.id());
     }
 
     let stdout = child
@@ -1211,7 +1211,8 @@ fn execute_streaming_local_tmux(
     let _ = std::fs::write(&gen_marker_path, current_gen.to_string());
 
     if let Some(ref token) = cancel_token {
-        *token.tmux_session.lock().unwrap() = Some(tmux_session_name.to_string());
+        *token.tmux_session.lock().unwrap_or_else(|e| e.into_inner()) =
+            Some(tmux_session_name.to_string());
     }
 
     let read_result = read_output_file_until_result(
@@ -1279,7 +1280,8 @@ fn send_followup_to_tmux(
     }
 
     if let Some(ref token) = cancel_token {
-        *token.tmux_session.lock().unwrap() = Some(tmux_session_name.to_string());
+        *token.tmux_session.lock().unwrap_or_else(|e| e.into_inner()) =
+            Some(tmux_session_name.to_string());
     }
 
     let read_result = match read_output_file_until_result_tracked(
@@ -1477,7 +1479,7 @@ fn execute_streaming_local_process(
     let handle = backend.create_session(&config)?;
 
     if let Some(ref token) = cancel_token {
-        *token.child_pid.lock().unwrap() = Some(handle.pid());
+        *token.child_pid.lock().unwrap_or_else(|e| e.into_inner()) = Some(handle.pid());
     }
 
     insert_process_session(session_name.to_string(), handle);

--- a/src/services/routines/loader.rs
+++ b/src/services/routines/loader.rs
@@ -139,7 +139,7 @@ impl RoutineScriptLoader {
         let script_ref = script.script_ref.clone();
         self.scripts
             .lock()
-            .map_err(|_| anyhow!("routine script store lock poisoned"))?
+            .unwrap_or_else(|e| e.into_inner())
             .insert(script_ref.clone(), script);
         Ok(script_ref)
     }
@@ -157,7 +157,7 @@ impl RoutineScriptLoader {
         let existing_scripts: HashMap<String, LoadedRoutineScript> = self
             .scripts
             .lock()
-            .map_err(|_| anyhow!("routine script store lock poisoned"))?
+            .unwrap_or_else(|e| e.into_inner())
             .clone();
 
         for (root_index, root) in roots.iter().enumerate() {
@@ -271,10 +271,7 @@ impl RoutineScriptLoader {
     }
 
     pub fn get_script(&self, script_ref: &str) -> Result<Option<LoadedRoutineScript>> {
-        let scripts = self
-            .scripts
-            .lock()
-            .map_err(|_| anyhow!("routine script store lock poisoned"))?;
+        let scripts = self.scripts.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(script) = scripts.get(script_ref).cloned() {
             return Ok(Some(script));
         }
@@ -303,7 +300,7 @@ impl RoutineScriptLoader {
         Ok(self
             .scripts
             .lock()
-            .map_err(|_| anyhow!("routine script store lock poisoned"))?
+            .unwrap_or_else(|e| e.into_inner())
             .contains_key(script_ref))
     }
 
@@ -311,7 +308,7 @@ impl RoutineScriptLoader {
         let mut refs: Vec<String> = self
             .scripts
             .lock()
-            .map_err(|_| anyhow!("routine script store lock poisoned"))?
+            .unwrap_or_else(|e| e.into_inner())
             .keys()
             .cloned()
             .collect();
@@ -324,10 +321,7 @@ impl RoutineScriptLoader {
         loaded_scripts: Vec<LoadedRoutineScript>,
         seen_refs: &HashSet<String>,
     ) -> Result<usize> {
-        let mut scripts = self
-            .scripts
-            .lock()
-            .map_err(|_| anyhow!("routine script store lock poisoned"))?;
+        let mut scripts = self.scripts.lock().unwrap_or_else(|e| e.into_inner());
         for script in loaded_scripts {
             scripts.insert(script.script_ref.clone(), script);
         }
@@ -339,9 +333,8 @@ impl RoutineScriptLoader {
 
 impl Drop for RoutineScriptLoader {
     fn drop(&mut self) {
-        if let Ok(mut scripts) = self.scripts.lock() {
-            scripts.clear();
-        }
+        let mut scripts = self.scripts.lock().unwrap_or_else(|e| e.into_inner());
+        scripts.clear();
     }
 }
 


### PR DESCRIPTION
## 목표
provider 런타임과 routine loader가 `Mutex` poison 상태에서도 즉시 panic/중단하지 않고, 보존된 내부 상태로 취소/정리/조회 작업을 계속 수행하도록 한다. 목표는 한 스레드의 panic 이후에도 tmux/process cancel token과 routine script registry 경로가 추가 장애로 번지지 않게 만드는 것이다.

## 쉬운 설명
Rust `Mutex`는 잠금을 잡은 스레드가 panic하면 이후 접근을 `poisoned`로 표시한다. 기존 코드는 이 상태에서 `unwrap()` 또는 명시적 에러로 흐름을 끊었다. 이 PR은 이미 보유한 내부 값을 꺼내서 cleanup, follow-up, routine reload를 계속 진행한다. 정상 lock 경로의 동작은 그대로 유지한다.

## 개선되는 것
### Fix 1
`CancelToken`의 `tmux_session`, `child_pid`, `cancel_source` 접근이 poisoned lock에서 panic하지 않도록 바꾼다. Claude/Codex/Qwen의 tmux/process 실행 및 follow-up 경로도 같은 방식으로 session name/PID를 기록한다.

### Fix 2
`RoutineScriptLoader`의 script store 접근이 poison 때문에 `routine script store lock poisoned` 에러로 끝나지 않게 한다. `load_script`, `load_dirs`, `get_script`, `has_script`, `script_refs`, `apply_dir_reload`, `Drop` 모두 기존 registry 값을 회복해서 계속 처리한다.

### Fix 3
테스트 코드의 lock 확인도 동일한 poison recovery 방식으로 맞춰, 운영 코드와 테스트가 같은 잠금 계약을 사용한다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| provider 실행 중 이전 panic으로 `child_pid` lock이 poisoned 됨 | 새 PID 기록 시 `unwrap()` panic 가능 | 내부 guard를 회복해 PID를 기록하고 output read 흐름 지속 |
| 취소 시 `tmux_session` lock이 poisoned 됨 | cleanup 전에 panic해 tmux kill/exit reason 기록이 누락될 수 있음 | 저장된 session name을 회복해 가능한 cleanup을 계속 수행 |
| routine script registry lock이 poisoned 됨 | load/get/script_refs가 lock poisoned 에러로 실패 | 기존 registry를 회복해 reload, 조회, prune을 계속 수행 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| lock이 정상인 일반 경로 | `unwrap_or_else`는 기존 guard를 그대로 사용 | 정상 동작 변화 없음 |
| lock 보유 중 panic 후 취소 요청 | poisoned 내부 값을 회복해 best-effort cleanup 진행 | 추가 panic보다 운영 복구성이 높음 |
| poisoned registry에 오래된 script가 남아 있음 | `load_dirs`가 기존 snapshot을 기준으로 fresh load/prune 수행 | 데이터 무결성은 기존 reload 로직에 맡기고 서비스 중단을 줄임 |

## 해결한 내용
- `src/services/provider.rs`: `CancelToken` cleanup/source/PID helper의 poison panic 제거.
- `src/services/claude.rs`: Claude tmux/process 신규 실행과 follow-up에서 cancel token 기록 회복.
- `src/services/codex.rs`: Codex tmux/process 경로의 session/PID 기록 회복.
- `src/services/qwen.rs`: Qwen direct/process/tmux 경로의 PID/session 기록 회복.
- `src/services/gemini.rs`: 관련 테스트의 lock 접근 계약 정렬.
- `src/services/routines/loader.rs`: routine script store load/read/reload/drop 경로의 poison 에러 제거.

## 검증
- `git diff --check upstream/main...origin/codex/upstream-mutex-poison-recovery -- src/services/claude.rs src/services/codex.rs src/services/gemini.rs src/services/provider.rs src/services/qwen.rs src/services/routines/loader.rs` 통과.
- GitHub 원격 체크 확인: `Changed paths`, `Script checks`, `Fast check + non-PG tests (ubuntu-latest/macos-latest/windows-latest)`, `Fast check (ubuntu-latest)`, `High-risk recovery`, `Lint`, `Fast targeted tests (ubuntu-latest)` 성공.
- `Dashboard (Node 22)`, `PostgreSQL tests`는 변경 경로상 skipped.