### PR TITLE
Reuse shared user path expansion in voice utils

### DIFF
--- a/src/voice/utils.rs
+++ b/src/voice/utils.rs
@@ -12,12 +12,18 @@ use std::path::{Component, Path, PathBuf};
 /// directory. Returns the input untouched when the path doesn't start with
 /// `~` or when the home directory cannot be resolved.
 pub(crate) fn expand_tilde(path: &Path) -> PathBuf {
-    if !matches!(path.components().next(), Some(Component::Normal(first)) if first == "~") {
+    let mut components = path.components();
+    if !matches!(components.next(), Some(Component::Normal(first)) if first == "~") {
         return path.to_path_buf();
     }
 
-    let raw = path.to_string_lossy();
-    crate::runtime_layout::expand_user_path(&raw).unwrap_or_else(|| path.to_path_buf())
+    let Some(mut expanded) = crate::runtime_layout::expand_user_path("~") else {
+        return path.to_path_buf();
+    };
+    for component in components {
+        expanded.push(component.as_os_str());
+    }
+    expanded
 }
 
 #[cfg(test)]
@@ -59,5 +65,13 @@ mod tests {
             expand_tilde(Path::new("~/.adk/voice/tmp")),
             home.join(".adk/voice/tmp"),
         );
+    }
+
+    #[test]
+    fn preserves_tilde_path_component_trailing_space() {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        assert_eq!(expand_tilde(Path::new("~/voice ")), home.join("voice "));
     }
 }

--- a/src/voice/utils.rs
+++ b/src/voice/utils.rs
@@ -6,22 +6,18 @@
 //! this helper; consolidating it here removes the drift risk noted by the
 //! voice module audit (#2046 follow-up).
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 /// Expand a leading `~` or `~/` in `path` to the current user's home
 /// directory. Returns the input untouched when the path doesn't start with
 /// `~` or when the home directory cannot be resolved.
 pub(crate) fn expand_tilde(path: &Path) -> PathBuf {
+    if !matches!(path.components().next(), Some(Component::Normal(first)) if first == "~") {
+        return path.to_path_buf();
+    }
+
     let raw = path.to_string_lossy();
-    if raw == "~" {
-        return dirs::home_dir().unwrap_or_else(|| path.to_path_buf());
-    }
-    if let Some(rest) = raw.strip_prefix("~/")
-        && let Some(home) = dirs::home_dir()
-    {
-        return home.join(rest);
-    }
-    path.to_path_buf()
+    crate::runtime_layout::expand_user_path(&raw).unwrap_or_else(|| path.to_path_buf())
 }
 
 #[cfg(test)]
@@ -37,6 +33,12 @@ mod tests {
     #[test]
     fn passes_through_relative_paths_without_tilde() {
         let input = PathBuf::from("relative/path");
+        assert_eq!(expand_tilde(&input), input);
+    }
+
+    #[test]
+    fn preserves_non_tilde_path_text_exactly() {
+        let input = PathBuf::from(" relative/path ");
         assert_eq!(expand_tilde(&input), input);
     }
 


### PR DESCRIPTION
## 목표
voice module의 `expand_tilde`가 공통 runtime layout의 home 해석을 재사용하면서도, `~/...` 뒤쪽 path component의 의도적 공백을 보존하도록 한다. 목표는 helper 중복을 줄이되 파일시스템에서 의미 있는 trailing space 경로를 깨지 않는 것이다.

## 쉬운 설명
기존 업데이트는 `runtime_layout::expand_user_path`를 그대로 호출하면서 `~/voice ` 같은 입력의 trailing space를 trim할 수 있었다. 리뷰 코멘트에 맞춰 home lookup만 공통 helper에 맡기고, 나머지 component는 `Path` 그대로 이어 붙이도록 수정했다. 일반 비-tilde 경로는 계속 원문 그대로 반환된다.

## 개선되는 것
### Fix 1
`~`로 시작하지 않는 경로는 `PathBuf` 원문을 그대로 반환한다.

### Fix 2
`~` / `~/...`는 `expand_user_path("~")`로 home만 해석한 뒤, 나머지 `Path` component를 `as_os_str()`로 push해 공백을 보존한다.

### Fix 3
`~/voice ` trailing-space 보존 회귀 테스트를 추가했다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| `Path::new("~")` | home으로 확장 | home으로 확장 |
| `Path::new("~/.adk/voice/tmp")` | home 아래 경로로 확장 | home 아래 경로로 확장 |
| `Path::new("~/voice ")` | `$HOME/voice`로 trim될 수 있음 | `$HOME/voice `로 trailing space 보존 |
| `PathBuf::from(" relative/path ")` | 입력 그대로 반환 | 입력 그대로 반환 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| home directory 조회 실패 | 기존 path를 그대로 반환 | 기존 fallback 의미 유지 |
| 경로 component 내부 공백 | `Path` component를 그대로 push | 파일명 공백 보존 |
| 비-tilde 경로 | 공통 helper를 호출하지 않음 | trim/rebuild 회귀 없음 |

## 해결한 내용
- `src/voice/utils.rs`: `expand_user_path("~")`로 home만 resolve하고, 나머지 component는 raw `OsStr`로 보존.
- `src/voice/utils.rs`: `preserves_tilde_path_component_trailing_space` 테스트 추가.
- 리뷰 코멘트 `Preserve whitespace in ~/... paths`에 답변 완료.

## 검증
- `cargo fmt --all --check` 통과.
- `cargo test voice::utils` 통과: 6 passed.
- `git diff --check origin/main...HEAD` 통과.
- GitHub 원격 체크는 `Changed paths`, `Script checks`, `Fast targeted tests (ubuntu-latest)` 성공, 확인 시점 기준 macOS/Windows fast check 진행 중.