### PR TITLE
Remove stale direct Discord send allowlist entries

### DIFF
--- a/scripts/audit_allowlist.toml
+++ b/scripts/audit_allowlist.toml
@@ -47,7 +47,6 @@ direct_discord_sends = [
   "src/services/discord/monitoring_status.rs#direct_discord_sends:9ea6e87eaf2dcfcb",
   "src/services/discord/placeholder_controller.rs#direct_discord_sends:94892504c53d1b42",
   "src/services/discord/router/intake_gate.rs#direct_discord_sends:0a2beaabe9619b4f",
-  "src/services/discord/router/intake_gate.rs#direct_discord_sends:596126752fe9a5d2",
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:f377b5c8a89499a2",
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:9016a6940938ce84",
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:2bf7e5b93d0fda6b",
@@ -58,7 +57,6 @@ direct_discord_sends = [
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:b4849c24f5cb7d09",
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:590c5cd6bb3b93f8",
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:1c3d5094762f23e4",
-  "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:9de857dea13386a4",
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:26d4f3ea346a4c7b",
 ]
 


### PR DESCRIPTION
## 목표
`direct_discord_sends` maintainability hard gate의 allowlist에서 더 이상 현재 코드에 대응하지 않는 stale baseline key 2개를 제거한다. 목표는 실제로 남아 있는 예외만 allowlist에 유지하고, 사라진 direct Discord send callsite가 다시 들어오면 CI가 새 regression으로 잡게 하는 것이다.

## 쉬운 설명
`scripts/audit_allowlist.toml`은 현재 HEAD에서 허용 중인 예외만 담아야 한다. 오래된 key가 남아 있으면 audit baseline이 실제 코드보다 느슨해진다. 이 PR은 `intake_gate`와 `turn_bridge`에서 더 이상 필요하지 않은 direct send key 2개를 삭제한다. 런타임 코드는 바꾸지 않는다.

## 개선되는 것
### Fix 1
`src/services/discord/router/intake_gate.rs#direct_discord_sends:596126752fe9a5d2` allowlist entry를 제거한다.

### Fix 2
`src/services/discord/turn_bridge/mod.rs#direct_discord_sends:9de857dea13386a4` allowlist entry를 제거한다.

### Fix 3
`direct_discord_sends` allowlist entry 수를 30개에서 28개로 줄여, hard-gated baseline을 현재 코드 상태에 맞춘다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| audit allowlist 조회 | stale direct send key 2개가 남아 있음 | 현재 필요한 baseline key만 유지 |
| 제거된 callsite가 다시 생김 | 기존 stale key와 맞으면 regression을 놓칠 수 있음 | 새 finding으로 잡혀 script check가 실패해야 함 |
| 런타임 Discord 전송 | 코드 변경 없음 | 동작 변화 없음 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 삭제한 key가 실제 코드에 아직 존재 | `direct_discord_sends` hard gate가 실패 | 원격 `Script checks` 성공으로 현재 branch에서는 stale 제거로 확인 |
| 다른 allowlisted direct send callsite | 기존 entry 유지 | 현재 baseline 외 범위 영향 없음 |
| 문서/생성 리포트 | allowlist만 변경 | generated audit 문서는 별도 regen 대상일 수 있음 |

## 해결한 내용
- `scripts/audit_allowlist.toml`: stale direct Discord send allowlist entry 2개 삭제.

## 검증
- `git diff --check upstream/main...origin/codex/upstream-direct-discord-allowlist-cleanup -- scripts/audit_allowlist.toml` 통과.
- base/head의 `#direct_discord_sends` entry 수를 확인해 30개에서 28개로 줄어든 것을 확인.
- GitHub 원격 체크 확인: `Changed paths`, `Script checks`, `Fast check + non-PG tests (ubuntu-latest/macos-latest/windows-latest)`, `Fast check (ubuntu-latest)`, `High-risk recovery`, `Lint`, `Fast targeted tests (ubuntu-latest)` 성공.
- `Dashboard (Node 22)`, `PostgreSQL tests`는 변경 경로상 skipped.