### PR TITLE
Courier: collapse notify outbox requeue into atomic UPSERT

### DIFF
--- a/src/db/dispatches/outbox/notify.rs
+++ b/src/db/dispatches/outbox/notify.rs
@@ -42,69 +42,24 @@ pub(crate) async fn requeue_dispatch_notify_pg(
         .map_err(|error| format!("read postgres dispatch title for {dispatch_id}: {error}"))?
         .ok_or_else(|| format!("postgres dispatch {dispatch_id} missing title"))?;
 
-    let updated = sqlx::query(
-        "UPDATE dispatch_outbox
-            SET agent_id = $2,
-                card_id = $3,
-                title = $4,
-                status = 'pending',
-                retry_count = 0,
-                next_attempt_at = NULL,
-                processed_at = NULL,
-                error = NULL,
-                delivery_status = NULL,
-                delivery_result = NULL,
-                claimed_at = NULL,
-                claim_owner = NULL
-          WHERE dispatch_id = $1
-            AND action = 'notify'",
-    )
-    .bind(dispatch_id)
-    .bind(&agent_id)
-    .bind(&card_id)
-    .bind(&title)
-    .execute(pool)
-    .await
-    .map_err(|error| format!("reset postgres notify outbox for {dispatch_id}: {error}"))?
-    .rows_affected();
-    if updated > 0 {
-        return Ok(true);
-    }
-
-    let inserted = sqlx::query(
+    let rearmed = sqlx::query(
         "INSERT INTO dispatch_outbox (
             dispatch_id, action, agent_id, card_id, title, status, retry_count
          ) VALUES ($1, 'notify', $2, $3, $4, 'pending', 0)
-         ON CONFLICT DO NOTHING",
-    )
-    .bind(dispatch_id)
-    .bind(&agent_id)
-    .bind(&card_id)
-    .bind(&title)
-    .execute(pool)
-    .await
-    .map_err(|error| format!("insert postgres notify outbox for {dispatch_id}: {error}"))?
-    .rows_affected();
-    if inserted > 0 {
-        return Ok(true);
-    }
-
-    let rearmed = sqlx::query(
-        "UPDATE dispatch_outbox
-            SET agent_id = $2,
-                card_id = $3,
-                title = $4,
-                status = 'pending',
-                retry_count = 0,
-                next_attempt_at = NULL,
-                processed_at = NULL,
-                error = NULL,
-                delivery_status = NULL,
-                delivery_result = NULL,
-                claimed_at = NULL,
-                claim_owner = NULL
-          WHERE dispatch_id = $1
-            AND action = 'notify'",
+         ON CONFLICT (dispatch_id, action) WHERE action IN ('notify', 'followup')
+         DO UPDATE SET
+            agent_id = EXCLUDED.agent_id,
+            card_id = EXCLUDED.card_id,
+            title = EXCLUDED.title,
+            status = 'pending',
+            retry_count = 0,
+            next_attempt_at = NULL,
+            processed_at = NULL,
+            error = NULL,
+            delivery_status = NULL,
+            delivery_result = NULL,
+            claimed_at = NULL,
+            claim_owner = NULL",
     )
     .bind(dispatch_id)
     .bind(&agent_id)


### PR DESCRIPTION
## 목표

PostgreSQL `dispatch_outbox`의 notify 재큐잉을 하나의 atomic UPSERT로 바꿔, 동시 재큐잉 상황에서 이미 claim된 행을 다시 덮어쓰는 경쟁 가능성을 줄입니다. 기존 반환 의미는 유지하면서 `notify` one-shot outbox 행을 항상 `pending` 상태로 안전하게 재무장하는 것이 목표입니다.

## 쉬운 설명

이전 코드는 notify outbox를 다시 살릴 때 `UPDATE`, `INSERT`, 다시 `UPDATE`를 순서대로 실행했습니다. 두 작업이 동시에 들어오면 중간 상태를 서로 밟을 여지가 있었습니다. 이 PR은 그 과정을 DB의 `INSERT ... ON CONFLICT DO UPDATE` 한 문장으로 합쳐서 같은 dispatch/action 행을 원자적으로 갱신합니다.

## 개선되는 것

### Fix 1

`requeue_dispatch_notify_pg`의 3단계 재큐잉 절차를 단일 UPSERT로 축소합니다.

### Fix 2

UPSERT conflict target을 기존 partial unique index `uq_dispatch_outbox_one_shot_action`과 동일하게 `dispatch_id, action WHERE action IN ('notify', 'followup')`로 맞춥니다.

### Fix 3

재무장 시 `status='pending'`, `retry_count=0`, 처리/전송/claim 관련 컬럼 초기화를 유지해서 기존 재시도 의미를 보존합니다.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| 기존 notify 행 있음 | 먼저 `UPDATE`로 pending 재설정 | UPSERT conflict update로 pending 재설정 |
| notify 행 없음 | `UPDATE` 실패 후 `INSERT`, 충돌 시 후속 `UPDATE` | `INSERT`, 충돌하면 같은 문장 안에서 update |
| 동시 재큐잉 | 두 실행이 INSERT/후속 UPDATE 사이에서 경쟁 가능 | unique index 기준의 단일 UPSERT로 원자 처리 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| dispatch가 없음 | 기존처럼 `Ok(false)` | 의미 유지 |
| dispatch 상태가 terminal | 기존처럼 재큐잉하지 않고 `Ok(false)` | completed/failed/cancelled 보호 유지 |
| 기존 행이 처리/claim 중 | UPSERT update가 pending 재무장 필드를 한 번에 세팅 | 단계 사이 경합 창 감소 |

## 해결한 내용

- `src/db/dispatches/outbox/notify.rs`: `requeue_dispatch_notify_pg`의 `UPDATE → INSERT DO NOTHING → UPDATE` 흐름을 `INSERT ... ON CONFLICT ... DO UPDATE`로 교체했습니다.
- `migrations/postgres/0001_initial_schema.sql`: 기존 `uq_dispatch_outbox_one_shot_action` partial unique index가 새 conflict target과 일치함을 확인했습니다. 스키마 변경은 없습니다.

## 검증

- GitHub CI `Changed paths`: pass
- GitHub CI `Script checks`: pass
- GitHub CI `Lint`: pass
- GitHub CI `High-risk recovery`: pass
- GitHub CI `PostgreSQL tests (ubuntu-postgres)`: pass
- GitHub CI `Fast targeted tests (ubuntu-latest)`: pass
- GitHub CI `Dashboard (Node 22)`: path filter로 skipped
- 진행 중: GitHub CI `Fast check + non-PG tests` matrix (`ubuntu-latest`, `macos-latest`, `windows-latest`)