### PR TITLE
DomainKeeper: move monitoring routes to ops domain

### DIFF
--- a/src/server/routes/domains/ops.rs
+++ b/src/server/routes/domains/ops.rs
@@ -286,6 +286,15 @@ pub(crate) fn router(state: AppState) -> ApiRouter {
                 post(health_api::relay_recovery_handler),
             )
             .route(
+                "/channels/{channel_id}/monitoring",
+                post(super::super::monitoring::upsert_monitoring)
+                    .get(super::super::monitoring::list_monitoring),
+            )
+            .route(
+                "/channels/{channel_id}/monitoring/{key}",
+                delete(super::super::monitoring::remove_monitoring),
+            )
+            .route(
                 "/dispatches/pending",
                 get(queue_api::list_pending_dispatches),
             )

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -261,7 +261,6 @@ fn compose_api_router(state: AppState) -> ApiRouter {
         .merge(domains::reviews::router(state.clone()))
         .merge(domains::ops::router(state.clone()))
         .merge(domains::integrations::router(state.clone()))
-        .merge(monitoring::router(state.clone()))
         .merge(v1::router(state.clone()))
         .merge(domains::admin::router(state))
 }

--- a/src/server/routes/monitoring.rs
+++ b/src/server/routes/monitoring.rs
@@ -1,14 +1,13 @@
 use axum::{
-    Json, Router,
+    Json,
     extract::{Path, State},
     http::StatusCode,
-    routing::{delete, post},
 };
 use poise::serenity_prelude::ChannelId;
 use serde::Deserialize;
 use serde_json::json;
 
-use super::{ApiRouter, AppState, protected_api_domain, state};
+use super::{AppState, state};
 
 // Category: ops
 
@@ -16,21 +15,6 @@ use super::{ApiRouter, AppState, protected_api_domain, state};
 pub(crate) struct UpsertMonitoringBody {
     key: String,
     description: String,
-}
-
-pub(crate) fn router(state: AppState) -> ApiRouter {
-    protected_api_domain(
-        Router::new()
-            .route(
-                "/channels/{channel_id}/monitoring",
-                post(upsert_monitoring).get(list_monitoring),
-            )
-            .route(
-                "/channels/{channel_id}/monitoring/{key}",
-                delete(remove_monitoring),
-            ),
-        state,
-    )
 }
 
 pub async fn upsert_monitoring(


### PR DESCRIPTION
## 목표

monitoring API 라우트를 독립 top-level merge에서 ops domain 라우터로 옮겨, API 라우트 소유권 지도를 `src/server/routes/domains/*` 기준으로 정리합니다. 외부 API 경로, HTTP 메서드, 핸들러 동작은 그대로 유지하는 구조 정리 PR입니다.

## 쉬운 설명

monitoring 엔드포인트는 운영/채널 관리 성격인데, 기존에는 `compose_api_router`에서 별도로 merge되고 있었습니다. 이 PR은 같은 엔드포인트를 `domains::ops` 안으로 옮깁니다. 사용자가 호출하는 URL과 응답 동작은 바뀌지 않습니다.

## 개선되는 것

### Fix 1

`/api/channels/{channel_id}/monitoring` 계열 라우트 등록 위치를 `src/server/routes/domains/ops.rs`로 이동합니다.

### Fix 2

`src/server/routes/mod.rs`의 별도 `monitoring::router(state.clone())` merge를 제거해서 top-level router 구성을 단순화합니다.

### Fix 3

`src/server/routes/monitoring.rs`에서 라우터 생성 함수와 불필요한 `Router`, `routing`, `protected_api_domain`, `ApiRouter` import를 제거하고 핸들러 모듈로만 남깁니다.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| `GET /api/channels/{channel_id}/monitoring` | monitoring 모듈의 별도 router merge에서 등록 | ops domain router에서 같은 핸들러 등록 |
| `POST /api/channels/{channel_id}/monitoring` | monitoring 모듈 router가 등록 | ops domain router가 같은 핸들러 등록 |
| route ownership 추적 | monitoring만 domains map 밖에 있음 | channel-scoped ops route와 같은 위치에서 관리 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 기존 dashboard/API 클라이언트 호출 | 경로와 메서드가 동일 | 호환성 유지 |
| auth/domain guard | ops domain router의 보호 경로 아래에서 등록 | 보호 의도 유지 |
| generated inventory | 이 PR에서는 재생성하지 않음 | 순수 구조 이동으로 범위 제한 |

## 해결한 내용

- `src/server/routes/domains/ops.rs`: monitoring의 `GET`, `POST`, `DELETE` 라우트를 ops domain에 추가했습니다.
- `src/server/routes/mod.rs`: `monitoring::router(state.clone())` top-level merge를 제거했습니다.
- `src/server/routes/monitoring.rs`: 핸들러는 유지하고, router 생성 함수와 미사용 import를 제거했습니다.

## 검증

- GitHub CI `Changed paths`: pass
- GitHub CI `Script checks`: pass
- GitHub CI `Lint`: pass
- GitHub CI `High-risk recovery`: pass
- GitHub CI `Fast targeted tests (ubuntu-latest)`: pass
- GitHub CI `Dashboard (Node 22)`, `PostgreSQL tests (ubuntu-postgres)`: path filter로 skipped
- 진행 중: GitHub CI `Fast check + non-PG tests` matrix (`ubuntu-latest`, `macos-latest`, `windows-latest`)