### PR TITLE
fix(sentinel): case-insensitive prompt injection sanitization

### DIFF
--- a/src/ui/ai_screen.rs
+++ b/src/ui/ai_screen.rs
@@ -70,27 +70,23 @@ pub fn sanitize_user_input(input: &str) -> String {
         "---end",
     ];
 
-    let lower_input = sanitized.to_lowercase();
-    for pattern in dangerous_patterns {
-        if lower_input.contains(pattern) {
-            sanitized = sanitized.replace(pattern, "[filtered]");
-            let pattern_lower = pattern.to_lowercase();
-            let pattern_upper = pattern.to_uppercase();
-            let pattern_title: String = pattern
-                .chars()
-                .enumerate()
-                .map(|(i, c)| {
-                    if i == 0 {
-                        c.to_uppercase().next().unwrap_or(c)
-                    } else {
-                        c
-                    }
-                })
-                .collect();
-            sanitized = sanitized.replace(&pattern_lower, "[filtered]");
-            sanitized = sanitized.replace(&pattern_upper, "[filtered]");
-            sanitized = sanitized.replace(&pattern_title, "[filtered]");
-        }
+    // Optimization: compile regexes once statically to avoid per-call performance penalty
+    static SANITIZERS: std::sync::OnceLock<Vec<regex::Regex>> = std::sync::OnceLock::new();
+    let sanitizers = SANITIZERS.get_or_init(|| {
+        dangerous_patterns
+            .iter()
+            .filter_map(|pattern| {
+                let escaped = regex::escape(pattern);
+                regex::RegexBuilder::new(&escaped)
+                    .case_insensitive(true)
+                    .build()
+                    .ok()
+            })
+            .collect()
+    });
+
+    for re in sanitizers {
+        sanitized = re.replace_all(&sanitized, "[filtered]").to_string();
     }
 
     const MAX_INPUT_LENGTH: usize = 4000;


### PR DESCRIPTION
## 목표

`src/ui/ai_screen.rs`의 prompt injection sanitization이 대소문자 변형 입력도 차단하도록 보강합니다. 기존 blocklist 의미는 유지하면서 mixed-case 우회 문자열도 `[filtered]`로 치환합니다.

## 쉬운 설명

이전 로직은 lowercase, uppercase, title-case 중심으로 직접 치환했습니다. `IgNoRe PrEvIoUs...`처럼 중간 대소문자가 섞인 입력은 남을 수 있었습니다. 이 PR은 case-insensitive regex와 `OnceLock` 캐시로 같은 패턴을 한 번에 처리합니다.

## 개선되는 것

### Fix 1
manual casing replacement를 `RegexBuilder::case_insensitive(true)` 기반 치환으로 바꿔 mixed-case injection 문구를 차단합니다.

### Fix 2
`regex::escape(pattern)`를 사용해 blocklist 패턴 자체가 regex syntax로 해석되는 위험을 줄입니다.

### Fix 3
compiled regex 목록을 `std::sync::OnceLock`에 저장해 sanitization 호출마다 regex를 다시 만들지 않습니다.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| `ignore previous instructions` | `[filtered]` 처리 | `[filtered]` 처리 유지 |
| `IGNORE PREVIOUS INSTRUCTIONS` | `[filtered]` 처리 | `[filtered]` 처리 유지 |
| `IgNoRe PrEvIoUs InStRuCtIoNs` | 남을 수 있음 | `[filtered]` 처리 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 일반 사용자 입력 | blocklist와 매칭되지 않으면 그대로 통과 | 정상 입력 영향 낮음 |
| regex 특수문자가 포함된 패턴 | `regex::escape` 후 literal 매칭 | pattern injection 위험 낮음 |
| 반복 호출 | `OnceLock` 캐시 사용 | per-call compile 비용 방지 |

## 해결한 내용

- `src/ui/ai_screen.rs`: `sanitize_user_input`의 대소문자 수동 치환을 case-insensitive regex 치환으로 교체했습니다.
- 새 파일/스키마/런타임 설정 변경은 없습니다.

## 검증

- GitHub CI `Changed paths`: pass
- GitHub CI `Script checks`: pass
- GitHub CI `Lint`: pass
- GitHub CI `High-risk recovery`: pass
- GitHub CI `Fast targeted tests (ubuntu-latest)`: pass
- GitHub CI `Fast check + non-PG tests` matrix: pass on ubuntu/macos/windows
- GitHub CI `Dashboard (Node 22)`, `PostgreSQL tests (ubuntu-postgres)`: path filter로 skipped
- review thread/top-level comment: 없음
- merge state: `CLEAN`
