### PR TITLE
fix(doctor): propagate FixSafety escalation + clarify Qwen auth guidance

### DIFF
--- a/src/cli/doctor/orchestrator.rs
+++ b/src/cli/doctor/orchestrator.rs
@@ -853,6 +853,25 @@ fn highest_reason_severity(reasons: &[health::ClassifiedReason]) -> Severity {
     result
 }
 
+fn highest_reason_fix_safety(reasons: &[health::ClassifiedReason]) -> FixSafety {
+    let mut result = FixSafety::ReadOnly;
+    for reason in reasons {
+        result =
+            match (result, reason.fix_safety) {
+                (FixSafety::NotFixable, _) | (_, FixSafety::NotFixable) => FixSafety::NotFixable,
+                (FixSafety::ExplicitDbRepairRequired, _)
+                | (_, FixSafety::ExplicitDbRepairRequired) => FixSafety::ExplicitDbRepairRequired,
+                (FixSafety::ExplicitRestartRequired, _)
+                | (_, FixSafety::ExplicitRestartRequired) => FixSafety::ExplicitRestartRequired,
+                (FixSafety::SafeLocalRepair, _) | (_, FixSafety::SafeLocalRepair) => {
+                    FixSafety::SafeLocalRepair
+                }
+                _ => FixSafety::ReadOnly,
+            };
+    }
+    result
+}
+
 fn stale_zero_byte_db_candidates(
     runtime_root: &std::path::Path,
     canonical_db_path: &std::path::Path,
@@ -2324,7 +2343,7 @@ fn discord_bot_check_from_health(base: &str, body: &Value) -> Check {
             )
             .with_subsystem("provider_runtime")
             .with_severity(highest_reason_severity(&provider_reasons))
-            .with_fix_safety(FixSafety::ReadOnly)
+            .with_fix_safety(highest_reason_fix_safety(&provider_reasons))
             .with_security_exposure(SecurityExposure::OperationalMetadata)
             .with_evidence(health::reasons_evidence(&provider_reasons))
             .with_path(health_detail_endpoint(base))
@@ -2729,7 +2748,7 @@ fn check_server_running(snapshot: &HealthSnapshot) -> Check {
                 )
                 .with_subsystem("health")
                 .with_severity(highest_reason_severity(&reasons))
-                .with_fix_safety(FixSafety::ReadOnly)
+                .with_fix_safety(highest_reason_fix_safety(&reasons))
                 .with_security_exposure(SecurityExposure::OperationalMetadata)
                 .with_evidence(health::reasons_evidence(&reasons))
                 .with_path(health_endpoint(&snapshot.base))
@@ -2898,7 +2917,7 @@ fn check_degraded_reasons(snapshot: &HealthSnapshot) -> Check {
         .with_severity(highest_reason_severity(&reasons))
         .with_evidence(health::reasons_evidence(&reasons))
         .with_security_exposure(SecurityExposure::OperationalMetadata)
-        .with_fix_safety(FixSafety::ReadOnly)
+        .with_fix_safety(highest_reason_fix_safety(&reasons))
         .with_expected_actual("no degraded reasons", detail)
         .with_next_steps(next_steps);
     check
@@ -3957,7 +3976,7 @@ mod tests {
         assert_eq!(check.status, CheckStatus::Fail);
         assert_eq!(check.severity, Severity::Error);
         assert_eq!(check.subsystem, "provider_runtime");
-        assert_eq!(check.fix_safety, FixSafety::ReadOnly);
+        assert_eq!(check.fix_safety, FixSafety::ExplicitRestartRequired);
         assert!(check.detail.contains("provider codex is disconnected"));
         assert!(
             check

--- a/src/cli/doctor/orchestrator.rs
+++ b/src/cli/doctor/orchestrator.rs
@@ -642,11 +642,11 @@ fn check_qwen_auth_hints(configured: bool) -> Check {
         .with_expected_actual("cached auth or API-key hint visible", hints.join(", "))
         .with_next_steps(vec![
             "qwen auth status".to_string(),
-            "Open a Qwen CLI session and run /stats".to_string(),
+            "Check DashScope web console for usage limits".to_string(),
         ]);
     }
 
-    let guidance = "API key 경로는 project .qwen/.env 우선, 그다음 .env를 확인하세요. Qwen CLI는 env-file을 merge하지 않습니다. 사용량/제한은 숫자를 doctor에 고정하지 말고 Qwen CLI 세션의 /stats 또는 공식 문서를 확인하세요.";
+    let guidance = "API key 경로는 project .qwen/.env 우선, 그다음 .env를 확인하세요. Qwen CLI는 env-file을 merge하지 않습니다. 사용량/제한은 숫자를 doctor에 고정하지 말고 DashScope 웹 콘솔 또는 공식 문서를 확인하세요.";
     if configured {
         Check::warn(
             "provider_qwen_auth",


### PR DESCRIPTION
## 목표

`agentdesk doctor`가 health reason에서 계산된 실제 `FixSafety` 수준을 보존하고, Qwen 인증 진단 안내를 실제 운영 경로에 맞게 고칩니다. 진단 도구가 위험도를 낮게 표기하거나 존재하지 않는 Qwen CLI `/stats` 명령을 안내하지 않도록 합니다.

## 쉬운 설명

Doctor는 문제가 자동 복구 가능한지, 재시작이 필요한지, 수동 DB 수리가 필요한지를 구분해야 합니다. 기존 일부 경로는 더 높은 위험 신호가 있어도 `ReadOnly`로 고정했습니다. 이 PR은 reason 목록에서 가장 높은 `FixSafety`를 골라 반영하고, Qwen 사용량/제한 확인은 DashScope 웹 콘솔로 안내합니다.

## 개선되는 것

### Fix 1
`highest_reason_fix_safety`를 추가해 `ClassifiedReason` 목록의 가장 강한 fix safety를 선택합니다.

### Fix 2
provider runtime, server running, degraded reasons 체크가 더 이상 무조건 `FixSafety::ReadOnly`를 쓰지 않습니다.

### Fix 3
Qwen auth hint에서 존재하지 않는 `/stats` 안내를 제거하고 DashScope 웹 콘솔 확인으로 바꿉니다.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| provider disconnected reason이 restart 필요 | Doctor check는 `ReadOnly`로 표시 가능 | `ExplicitRestartRequired` 같은 실제 safety 반영 |
| degraded reason에 DB repair 필요 | 낮은 safety로 보일 수 있음 | reason 중 가장 높은 safety 채택 |
| Qwen auth troubleshooting | Qwen CLI `/stats` 안내 | DashScope 웹 콘솔/공식 문서 안내 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| reason이 모두 read-only | 결과는 `ReadOnly` 유지 | 기존 안전 경로 유지 |
| 하나라도 NotFixable 포함 | `NotFixable` 우선 | 자동 수리 오판 방지 |
| Qwen 미설정/설정 상태 | 안내 문구만 변경 | provider 동작 영향 없음 |

## 해결한 내용

- `src/cli/doctor/orchestrator.rs`: reason 목록에서 가장 높은 `FixSafety`를 계산하는 helper를 추가하고 관련 check에 적용했습니다.
- `src/cli/doctor/orchestrator.rs`: Qwen auth 안내 문구를 DashScope 웹 콘솔 기준으로 수정했습니다.
- provider/runtime 설정이나 DB schema 변경은 없습니다.

## 검증

- GitHub CI `Changed paths`: pass
- GitHub CI `Script checks`: pass
- GitHub CI `Lint`: pass
- GitHub CI `High-risk recovery`: pass
- GitHub CI `Fast check (ubuntu-latest)`: pass
- GitHub CI `Fast targeted tests (ubuntu-latest)`: pass
- GitHub CI `Fast check + non-PG tests` matrix: pass on ubuntu/macos/windows
- GitHub CI `Dashboard (Node 22)`, `PostgreSQL tests (ubuntu-postgres)`: path filter로 skipped
- review thread/top-level comment: 없음
- merge state: `CLEAN`
