### PR TITLE
chore: code quality rollup — dispatcher cleanup, audit guard fix, onboarding validation, a11y

### DIFF
--- a/dashboard/src/components/OnboardingWizard.tsx
+++ b/dashboard/src/components/OnboardingWizard.tsx
@@ -1282,7 +1282,7 @@ export default function OnboardingWizard({ isKo, onComplete }: Props) {
       label: tr("소유자 ID 형식", "Owner ID format"),
       ok: ownerIdValid,
       detail: ownerId.trim()
-        ? tr("18~19자리 Discord 사용자 ID 형식인지 확인했습니다.", "Checked that the value matches a Discord user ID format.")
+        ? tr("17~20자리 Discord 사용자 ID 형식인지 확인했습니다.", "Checked that the value matches a Discord user ID format.")
         : tr("비워두면 첫 메시지 발신자가 자동 소유자가 됩니다.", "Leave blank to make the first message sender the owner."),
     },
     {
@@ -2225,8 +2225,8 @@ export default function OnboardingWizard({ isKo, onComplete }: Props) {
               </ol>
               <div className="mt-1" style={{ color: "var(--th-text-muted)" }}>
                 {tr(
-                  "18~19자리 숫자입니다 (예: 123456789012345678)",
-                  "It's an 18-19 digit number (e.g., 123456789012345678)",
+                  "17~20자리 숫자입니다 (예: 123456789012345678)",
+                  "It's a 17-20 digit number (e.g., 123456789012345678)",
                 )}
               </div>
             </div>

--- a/dashboard/src/components/agent-manager/AgentFormModal.tsx
+++ b/dashboard/src/components/agent-manager/AgentFormModal.tsx
@@ -105,6 +105,7 @@ export default function AgentFormModal({
               <div className="flex flex-col items-center gap-1">
                 <button
                   type="button"
+                  aria-label={tr("다음 스프라이트", "Next Sprite")}
                   className="w-6 h-6 rounded flex items-center justify-center text-xs transition-colors"
                   style={{
                     color: "var(--th-text-muted)",
@@ -136,6 +137,7 @@ export default function AgentFormModal({
                 </div>
                 <button
                   type="button"
+                  aria-label={tr("이전 스프라이트", "Previous Sprite")}
                   className="w-6 h-6 rounded flex items-center justify-center text-xs transition-colors"
                   style={{
                     color: "var(--th-text-muted)",

--- a/dashboard/src/components/agent-manager/DepartmentFormModal.tsx
+++ b/dashboard/src/components/agent-manager/DepartmentFormModal.tsx
@@ -280,6 +280,8 @@ export default function DepartmentFormModal({
                     <button
                       key={c}
                       type="button"
+                      aria-label={`Color ${c}`}
+                      aria-pressed={form.color === c}
                       onClick={() => setForm({ ...form, color: c })}
                       className="w-11 h-11 rounded-full transition-all hover:scale-110"
                       style={{

--- a/dashboard/src/components/agent-manager/EmojiPicker.tsx
+++ b/dashboard/src/components/agent-manager/EmojiPicker.tsx
@@ -90,6 +90,7 @@ export default function EmojiPicker({
                   <button
                     key={emoji}
                     type="button"
+                    aria-pressed={value === emoji}
                     onClick={() => {
                       onChange(emoji);
                       setOpen(false);

--- a/scripts/audit_maintainability/checks/manual_json_mapping.py
+++ b/scripts/audit_maintainability/checks/manual_json_mapping.py
@@ -34,7 +34,7 @@ def _run(allowlist: set[str]) -> Iterable[Finding]:
             findings.append(
                 Finding(
                     rule="manual_json_row_mapping",
-                    severity="info",
+                    severity="warn",
                     file=rel,
                     line=line_of(text, match.start()),
                     message="manual row.try_get JSON mapping (use db::row helpers)",
@@ -51,6 +51,6 @@ CHECK = CheckSpec(
         "row.try_get::<serde_json::Value|Json<...>>(...) callsites that should "
         "use db::row typed helpers."
     ),
-    hard_gate=False,
+    hard_gate=True,
     runner=_run,
 )

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -538,16 +538,13 @@ async fn set_dispatch_status_on_pg_with_sync(
         })?
         .unwrap_or_default();
 
-    if let Some(allowed_from) = allowed_from {
-        if !allowed_from
-            .iter()
-            .any(|status| *status == current_status.as_str())
-        {
-            tx.rollback().await.map_err(|error| {
-                anyhow::anyhow!("rollback postgres dispatch status tx: {error}")
-            })?;
-            return Ok(0);
-        }
+    if let Some(allowed_from) = allowed_from
+        && !allowed_from.contains(&current_status.as_str())
+    {
+        tx.rollback()
+            .await
+            .map_err(|error| anyhow::anyhow!("rollback postgres dispatch status tx: {error}"))?;
+        return Ok(0);
     }
 
     // #2045 Finding 14 (P1): when a caller pushes a phase-gate dispatch into
@@ -1273,13 +1270,10 @@ fn set_dispatch_status_on_conn_with_sync(
         return Ok(0);
     };
 
-    if let Some(allowed_from) = allowed_from {
-        if !allowed_from
-            .iter()
-            .any(|status| *status == current_status.as_str())
-        {
-            return Ok(0);
-        }
+    if let Some(allowed_from) = allowed_from
+        && !allowed_from.contains(&current_status.as_str())
+    {
+        return Ok(0);
     }
 
     conn.execute_batch("SAVEPOINT dispatch_status_transition")?;
@@ -1682,9 +1676,7 @@ fn set_dispatch_status_sqlite_for_tests(
         return Ok(0);
     };
     if let Some(allowed_from) = allowed_from
-        && !allowed_from
-            .iter()
-            .any(|allowed| *allowed == current_status.as_str())
+        && !allowed_from.contains(&current_status.as_str())
     {
         return Ok(0);
     }


### PR DESCRIPTION
## 목표

작은 코드 품질 개선 4개를 하나의 rollup으로 묶어 dispatcher 가독성, maintainability audit guard, onboarding validation 안내, dashboard selector 접근성을 개선합니다. 기능 동작을 크게 바꾸지 않고 안전한 정리와 UI 접근성 보강을 반영합니다.

## 쉬운 설명

이 PR은 서로 충돌 위험이 낮은 작은 수정들을 모은 것입니다. dispatch status 조건문을 더 읽기 쉽게 만들고, manual JSON mapping audit을 hard gate로 올립니다. Onboarding의 Discord Owner ID 설명을 실제 17-20자리 기준에 맞추고, agent manager의 icon/color/emoji 선택 UI에 접근성 속성을 추가합니다.

## 개선되는 것

### Fix 1
`src/dispatch/dispatch_status.rs`에서 nested `if`와 `.iter().any(...)` 패턴을 `if let ... && !contains(...)` 형태로 단순화합니다.

### Fix 2
`scripts/audit_maintainability/checks/manual_json_mapping.py`에서 manual JSON row mapping rule을 `warn` severity와 `hard_gate=True`로 올려 guard로 동작하게 합니다.

### Fix 3
`dashboard/src/components/OnboardingWizard.tsx`의 Discord Owner ID 설명을 backend 기준인 17-20자리로 고칩니다.

### Fix 4
agent manager modal selector에 `aria-label`/`aria-pressed`를 추가해 icon, color, emoji 선택 UI의 접근성을 개선합니다.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| dispatch status transition guard | nested if + iterator comparison | `contains` 기반 간결 조건 |
| manual JSON mapping audit | info 수준, hard gate 아님 | warn + hard gate |
| owner ID 안내 | 18-19자리로 설명 | 17-20자리로 설명 |
| modal icon/color/emoji selector | 일부 버튼 접근성 이름/상태 부족 | aria label/pressed 보강 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 기존 dispatch status transition | 조건 의미 동일 | 동작 변화 낮음 |
| audit에서 manual row mapping 발견 | 이제 hard gate 실패 가능 | 품질 회귀 조기 차단 |
| dashboard screen reader 사용 | selector 이름/선택 상태 노출 개선 | 접근성 개선 |

## 해결한 내용

- `src/dispatch/dispatch_status.rs`: status guard 조건식을 단순화했습니다.
- `scripts/audit_maintainability/checks/manual_json_mapping.py`: rule severity와 hard gate 설정을 강화했습니다.
- `dashboard/src/components/OnboardingWizard.tsx`: Discord Owner ID 안내 문구를 17-20자리로 수정했습니다.
- `dashboard/src/components/agent-manager/{AgentFormModal.tsx,DepartmentFormModal.tsx,EmojiPicker.tsx}`: 선택 버튼 접근성 속성을 추가했습니다.
- 참고: WorkerRegistry observability 후보 commit은 upstream supervision refactor와 충돌해 포함하지 않았습니다.

## 검증

- GitHub CI `Changed paths`: pass
- GitHub CI `Script checks`: pass
- GitHub CI `Dashboard (Node 22)`: pass
- GitHub CI `Lint`: pass
- GitHub CI `High-risk recovery`: pass
- GitHub CI `PostgreSQL tests (ubuntu-postgres)`: pass
- GitHub CI `Fast check (ubuntu-latest)`: pass
- GitHub CI `Fast targeted tests (ubuntu-latest)`: pass
- GitHub CI `Fast check + non-PG tests` matrix: pass on ubuntu/macos/windows
- review thread/top-level comment: 없음
- merge state: `CLEAN`
