### PR TITLE
fix(auto-queue): reduce finished run exclusion subqueries

### DIFF
--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -484,11 +484,7 @@ var autoQueue = {
       "WHERE r.status IN ('active', 'paused') " +
       "AND NOT EXISTS (" +
       "  SELECT 1 FROM auto_queue_entries e " +
-      "  WHERE e.run_id = r.id AND e.status IN ('pending', 'dispatched')" +
-      ") " +
-      "AND NOT EXISTS (" +
-      "  SELECT 1 FROM auto_queue_entries e " +
-      "  WHERE e.run_id = r.id AND e.status = 'user_cancelled'" +
+      "  WHERE e.run_id = r.id AND e.status IN ('pending', 'dispatched', 'user_cancelled')" +
       ") " +
       "AND NOT EXISTS (" +
       "  SELECT 1 FROM auto_queue_phase_gates pg " +


### PR DESCRIPTION
## 목표

auto-queue tick에서 완료된 run을 수집할 때 중복 `NOT EXISTS` 조건을 줄여 query를 단순화하고, 기존 finalization sweep 동작은 유지합니다.

## 쉬운 설명

auto-queue가 완료된 run을 정리하는 쿼리가 더 가볍고 읽기 쉬워집니다. 같은 차단 조건을 반복해서 검사하던 부분을 줄였습니다. 사용자에게 보이는 큐 상태 변화는 없습니다.

## 개선되는 것

### Fix 1
`policies/auto-queue.js`의 `finishedRuns` query에서 중복된 blocked-run exclusion 조건을 제거합니다.

### Fix 2
기존 `LIMIT` 앞에서 blocked runs를 제외하는 동작은 유지해 finalization sweep의 의미를 바꾸지 않습니다.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| completed run sweep | 같은 exclusion 조건을 중복 평가 | 한 번만 평가 |
| blocked run 존재 | finalization 대상에서 제외 | 동일하게 제외 |
| visible queue state | 기존 상태 전환 | 동일 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| blocked run이 LIMIT 앞에 있음 | sweep 대상에서 제외 | 기존 테스트 유지 |
| active saturated runs | rotation 로직 영향 없음 | 안전 |
| policy 전체 테스트 | 126개 node policy tests 통과 | 회귀 없음 |

## 해결한 내용

- `policies/auto-queue.js`의 completed run finalization query를 더 짧고 덜 중복되게 정리했습니다.

## 검증

- `git diff --check upstream/main...HEAD`
- `node --test policies/__tests__/auto-queue.test.js`
- `npm run test:policies -- policies/__tests__/auto-queue.test.js`