### PR TITLE
Reuse expand_user_path across path helpers

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -357,7 +357,7 @@
 | `services::cluster::watcher_supervisor` | `src/services/cluster/watcher_supervisor.rs` | 743 |  |
 | `services::codex` | `src/services/codex.rs` | 3276 | giant-file |
 | `services::codex_remote_policy` | `src/services/codex_remote_policy.rs` | 49 |  |
-| `services::codex_tmux_wrapper` | `src/services/codex_tmux_wrapper.rs` | 754 |  |
+| `services::codex_tmux_wrapper` | `src/services/codex_tmux_wrapper.rs` | 744 |  |
 | `services::codex_tui` | `src/services/codex_tui/mod.rs` | 3 |  |
 | `services::codex_tui::input` | `src/services/codex_tui/input.rs` | 1088 | giant-file |
 | `services::codex_tui::rollout_tail` | `src/services/codex_tui/rollout_tail.rs` | 2968 | giant-file |
@@ -529,7 +529,7 @@
 | `services::git::branch_resolver` | `src/services/git/branch_resolver.rs` | 197 |  |
 | `services::git::commit_resolver` | `src/services/git/commit_resolver.rs` | 575 |  |
 | `services::git::remote` | `src/services/git/remote.rs` | 49 |  |
-| `services::git::repo_resolver` | `src/services/git/repo_resolver.rs` | 257 |  |
+| `services::git::repo_resolver` | `src/services/git/repo_resolver.rs` | 254 |  |
 | `services::git::runner` | `src/services/git/runner.rs` | 420 |  |
 | `services::git::worktree_resolver` | `src/services/git/worktree_resolver.rs` | 640 |  |
 | `services::issue_announcements` | `src/services/issue_announcements.rs` | 483 |  |
@@ -594,7 +594,7 @@
 | `services::provider_runtime` | `src/services/provider_runtime.rs` | 122 |  |
 | `services::queue` | `src/services/queue.rs` | 782 |  |
 | `services::qwen` | `src/services/qwen.rs` | 2461 | giant-file |
-| `services::qwen_tmux_wrapper` | `src/services/qwen_tmux_wrapper.rs` | 1230 | giant-file |
+| `services::qwen_tmux_wrapper` | `src/services/qwen_tmux_wrapper.rs` | 1220 | giant-file |
 | `services::remote_stub` | `src/services/remote_stub.rs` | 45 |  |
 | `services::retrospectives` | `src/services/retrospectives.rs` | 882 |  |
 | `services::routines` | `src/services/routines/mod.rs` | 30 |  |
@@ -615,7 +615,7 @@
 | `services::termination_audit` | `src/services/termination_audit.rs` | 411 |  |
 | `services::tmux_common` | `src/services/tmux_common.rs` | 869 |  |
 | `services::tmux_diagnostics` | `src/services/tmux_diagnostics.rs` | 398 |  |
-| `services::tmux_wrapper` | `src/services/tmux_wrapper.rs` | 737 |  |
+| `services::tmux_wrapper` | `src/services/tmux_wrapper.rs` | 727 |  |
 | `services::tool_output_guard` | `src/services/tool_output_guard.rs` | 237 |  |
 | `services::tui_prompt_dedupe` | `src/services/tui_prompt_dedupe.rs` | 729 |  |
 | `services::turn_cancel_finalizer` | `src/services/turn_cancel_finalizer.rs` | 409 |  |
@@ -628,7 +628,7 @@
 | `utils::api` | `src/utils/api.rs` | 53 |  |
 | `utils::async_bridge` | `src/utils/async_bridge.rs` | 137 |  |
 | `utils::discord` | `src/utils/discord.rs` | 24 |  |
-| `utils::format` | `src/utils/format.rs` | 324 |  |
+| `utils::format` | `src/utils/format.rs` | 320 |  |
 | `utils::github_links` | `src/utils/github_links.rs` | 154 |  |
 | `utils::loopback_url` | `src/utils/loopback_url.rs` | 58 |  |
 | `utils::wip_detect` | `src/utils/wip_detect.rs` | 244 |  |

--- a/src/services/codex_tmux_wrapper.rs
+++ b/src/services/codex_tmux_wrapper.rs
@@ -50,19 +50,9 @@ pub fn run(
     };
     let _ = std::fs::remove_file(prompt_file);
 
-    let expanded_dir = if working_dir.starts_with("~/") {
-        if let Some(home) = dirs::home_dir() {
-            home.join(&working_dir[2..]).to_string_lossy().to_string()
-        } else {
-            working_dir.to_string()
-        }
-    } else if working_dir == "~" {
-        dirs::home_dir()
-            .map(|h| h.to_string_lossy().to_string())
-            .unwrap_or_else(|| working_dir.to_string())
-    } else {
-        working_dir.to_string()
-    };
+    let expanded_dir = crate::runtime_layout::expand_user_path(working_dir)
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|| working_dir.to_string());
 
     let (prompt_tx, prompt_rx) = mpsc::channel::<String>();
 

--- a/src/services/git/repo_resolver.rs
+++ b/src/services/git/repo_resolver.rs
@@ -58,12 +58,9 @@ pub fn resolve_repo_dir() -> Option<String> {
 }
 
 fn expand_tilde(path: &str) -> String {
-    if let Some(home) = dirs::home_dir() {
-        if path == "~" {
-            return home.display().to_string();
-        }
-        if let Some(rest) = path.strip_prefix("~/") {
-            return home.join(rest).display().to_string();
+    if path == "~" || path.starts_with("~/") {
+        if let Some(expanded) = crate::runtime_layout::expand_user_path(path) {
+            return expanded.to_string_lossy().into_owned();
         }
     }
     path.to_string()

--- a/src/services/qwen_tmux_wrapper.rs
+++ b/src/services/qwen_tmux_wrapper.rs
@@ -80,19 +80,9 @@ pub fn run(
     };
     let _ = std::fs::remove_file(prompt_file);
 
-    let expanded_dir = if working_dir.starts_with("~/") {
-        if let Some(home) = dirs::home_dir() {
-            home.join(&working_dir[2..]).to_string_lossy().to_string()
-        } else {
-            working_dir.to_string()
-        }
-    } else if working_dir == "~" {
-        dirs::home_dir()
-            .map(|h| h.to_string_lossy().to_string())
-            .unwrap_or_else(|| working_dir.to_string())
-    } else {
-        working_dir.to_string()
-    };
+    let expanded_dir = crate::runtime_layout::expand_user_path(working_dir)
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|| working_dir.to_string());
 
     let (prompt_tx, prompt_rx) = mpsc::channel::<String>();
 

--- a/src/services/tmux_wrapper.rs
+++ b/src/services/tmux_wrapper.rs
@@ -77,19 +77,9 @@ pub fn run(
     let claude_args = &claude_cmd[1..];
 
     // Expand ~ in working_dir (Rust's current_dir doesn't handle tilde)
-    let expanded_dir = if working_dir.starts_with("~/") {
-        if let Some(home) = dirs::home_dir() {
-            home.join(&working_dir[2..]).to_string_lossy().to_string()
-        } else {
-            working_dir.to_string()
-        }
-    } else if working_dir == "~" {
-        dirs::home_dir()
-            .map(|h| h.to_string_lossy().to_string())
-            .unwrap_or_else(|| working_dir.to_string())
-    } else {
-        working_dir.to_string()
-    };
+    let expanded_dir = crate::runtime_layout::expand_user_path(working_dir)
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|| working_dir.to_string());
 
     // Spawn Claude with piped stdin (kept open for multi-turn)
     let mut claude_command = Command::new(claude_bin);

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -214,13 +214,9 @@ pub fn tail_with_ellipsis_bytes(text: &str, max_bytes: usize) -> String {
 /// `~` 또는 `~/...` 경로를 홈 디렉토리로 확장한다.
 /// `~user/...` 형태는 확장하지 않고 그대로 반환한다.
 pub fn expand_tilde_path(path: &str) -> std::path::PathBuf {
-    if path == "~" {
-        if let Some(home) = dirs::home_dir() {
-            return home;
-        }
-    } else if let Some(rest) = path.strip_prefix("~/") {
-        if let Some(home) = dirs::home_dir() {
-            return home.join(rest);
+    if path == "~" || path.starts_with("~/") {
+        if let Some(expanded) = crate::runtime_layout::expand_user_path(path) {
+            return expanded;
         }
     }
     std::path::PathBuf::from(path)


### PR DESCRIPTION
## 목표

`~` 경로 확장 로직을 `runtime_layout::expand_user_path`로 모아 repo resolver, tmux wrapper, formatting utility의 중복 구현을 줄입니다.

## 쉬운 설명

사용자가 `~`가 들어간 경로를 넘겼을 때 여러 모듈이 각자 조금씩 다른 방식으로 처리하지 않게 합니다. 같은 helper를 재사용하므로 플랫폼별 home directory 처리 차이가 줄어듭니다. 동작을 새로 추가하기보다 이미 있는 계약으로 정리하는 refiner 성격의 변경입니다.

## 개선되는 것

### Fix 1
repo resolver의 직접 `HOME`/`USERPROFILE` 조립 코드를 공용 `expand_user_path` 호출로 대체했습니다.

### Fix 2
Codex/Qwen/Claude tmux wrapper의 반복된 `~` 확장 helper를 제거하고 runtime layout helper를 재사용합니다.

### Fix 3
format utility의 경로 축약/확장 보조 로직도 같은 helper를 사용해 drift 가능성을 줄였습니다.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| repo path에 `~/work` 입력 | resolver 내부 중복 로직으로 확장 | `runtime_layout::expand_user_path`로 확장 |
| tmux wrapper별 path handling | provider wrapper마다 유사 helper 보유 | 공용 helper 재사용 |
| format utils 경로 처리 | 별도 `~` 확장 구현 유지 | runtime layout helper와 동일 계약 사용 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| `~`가 없는 절대/상대 경로 | helper가 기존 path를 그대로 반환 | 기존 동작 유지 |
| home directory 미확정 환경 | 공용 helper의 기존 fallback 계약을 따름 | 모듈별 차이 감소 |
| provider wrapper path 전달 | 문자열 후처리만 정리 | 런타임 실행 흐름 변화 없음 |

## 해결한 내용

- `src/services/git/repo_resolver.rs`: repo path 확장을 공용 helper로 정리했습니다.
- `src/services/*_tmux_wrapper.rs`: provider wrapper별 중복 expand 함수와 import를 줄였습니다.
- `src/utils/format.rs`: format utility가 같은 경로 확장 계약을 쓰도록 조정했습니다.

## 포트 메모

- fork #225, #226, #276을 upstream/main 기준으로 순차 cherry-pick했습니다.
- 충돌 없이 적용됐습니다.

## 검증

- `git diff --check upstream/main...HEAD`
- `cargo fmt --all --check`
- `CMAKE_GENERATOR="Visual Studio 17 2022" CARGO_TARGET_DIR="D:\\AgentDesk-shared-target" cargo check --bin agentdesk` 시도
  - 실패 위치는 이 PR 변경 파일이 아니라 현재 upstream/main의 Windows baseline cfg 오류입니다: `src/services/discord/recovery_engine.rs` 및 `src/services/discord/turn_bridge/mod.rs`에서 `super::tmux`가 `#[cfg(unix)]`로 제외됨.
  - 해당 baseline 문제는 별도 upstream PR #2484에서 수정 대상으로 올렸습니다.