### PR TITLE
Avoid reconcile cursor heap allocations

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -188,7 +188,7 @@
 | `manual_intervention` | `src/manual_intervention.rs` | 65 |  |
 | `pipeline` | `src/pipeline.rs` | 2125 | giant-file |
 | `receipt` | `src/receipt.rs` | 2133 | giant-file |
-| `reconcile` | `src/reconcile.rs` | 1867 | giant-file |
+| `reconcile` | `src/reconcile.rs` | 1869 | giant-file |
 | `runtime` | `src/runtime.rs` | 115 |  |
 | `runtime_layout` | `src/runtime_layout/mod.rs` | 1425 | giant-file |
 | `runtime_layout::config_merge` | `src/runtime_layout/config_merge.rs` | 601 |  |

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -379,10 +379,11 @@ pub(crate) async fn dispatch_delivery_event_reconcile_report_pg(
             stats.kv_notified_checked += row.notified_count.max(0) as usize;
             classify_delivery_kv_guard_mismatches(&mut stats, &mut mismatches, row);
         }
-        cursor = rows
-            .last()
-            .map(|row| row.dispatch_id.clone())
-            .unwrap_or_default();
+        if let Some(last_row) = rows.last() {
+            cursor.clone_from(&last_row.dispatch_id);
+        } else {
+            cursor.clear();
+        }
     }
 
     cursor.clear();
@@ -400,10 +401,11 @@ pub(crate) async fn dispatch_delivery_event_reconcile_report_pg(
             stats.typed_events_checked += 1;
             classify_delivery_typed_guard_mismatches(&mut stats, &mut mismatches, row);
         }
-        cursor = rows
-            .last()
-            .map(|row| row.dispatch_id.clone())
-            .unwrap_or_default();
+        if let Some(last_row) = rows.last() {
+            cursor.clone_from(&last_row.dispatch_id);
+        } else {
+            cursor.clear();
+        }
     }
 
     Ok(DispatchDeliveryEventReconcileReport { stats, mismatches })


### PR DESCRIPTION
## 목표

reconcile loop의 cursor 처리에서 불필요한 heap allocation을 줄여 반복 조정 루프의 작은 비용을 낮춥니다.

## 쉬운 설명

reconcile 루프가 같은 cursor 값을 반복해서 다룰 때 매번 새 문자열 할당을 만들 필요가 없습니다. 이 PR은 동작을 바꾸지 않고 내부 데이터 참조 방식을 더 가볍게 정리합니다. 이미 upstream에 반영된 유사한 작은 정리들은 제외하고 실제로 남은 변경만 올립니다.

## 개선되는 것

### Fix 1
`src/reconcile.rs`에서 cursor 값을 소유 문자열로 반복 복제하기보다 필요한 시점에 참조/변환하도록 정리했습니다.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| reconcile loop cursor 비교 | loop 안에서 불필요한 owned string 흐름 발생 | 참조 기반 흐름으로 allocation 감소 |
| cursor 없음 | 기존 none/empty 처리 유지 | 동작 변화 없음 |
| reconcile 결과 계산 | 상태 전이 로직 유지 | 내부 비용만 소폭 감소 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| cursor가 있는 실행 | 동일한 cursor 의미를 유지 | 결과 변화 없음 |
| cursor가 없는 실행 | 기존 fallback 경로 유지 | 결과 변화 없음 |
| 반복 루프 | heap allocation 감소 | 성능/메모리 측면의 작은 개선 |

## 해결한 내용

- `src/reconcile.rs`: loop cursor 값을 다루는 방식을 더 가볍게 정리했습니다.

## 포트 메모

- fork #266만 현재 upstream/main에 새 diff로 남았습니다.
- fork #223, #219는 upstream/main에 이미 같은 변경이 반영되어 empty cherry-pick으로 제외했습니다.

## 검증

- `git diff --check upstream/main...HEAD`
- `cargo fmt --all --check`
- `CMAKE_GENERATOR="Visual Studio 17 2022" CARGO_TARGET_DIR="D:\\AgentDesk-shared-target" cargo check --bin agentdesk` 시도
  - 실패 위치는 이 PR 변경 파일이 아니라 현재 upstream/main의 Windows baseline cfg 오류입니다: `src/services/discord/recovery_engine.rs` 및 `src/services/discord/turn_bridge/mod.rs`에서 `super::tmux`가 `#[cfg(unix)]`로 제외됨.
  - 해당 baseline 문제는 별도 upstream PR #2484에서 수정 대상으로 올렸습니다.