### PR TITLE
fix(doctor): tmux FD pressure vs inherited plist limit; restore nofile target (follow-up to #2484)

### DIFF
--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -55,7 +55,7 @@
 | `cli::doctor::contract` | `src/cli/doctor/contract.rs` | 100 |  |
 | `cli::doctor::health` | `src/cli/doctor/health.rs` | 164 |  |
 | `cli::doctor::mailbox` | `src/cli/doctor/mailbox.rs` | 256 |  |
-| `cli::doctor::orchestrator` | `src/cli/doctor/orchestrator.rs` | 5042 | giant-file |
+| `cli::doctor::orchestrator` | `src/cli/doctor/orchestrator.rs` | 5115 | giant-file |
 | `cli::doctor::startup` | `src/cli/doctor/startup.rs` | 375 |  |
 | `cli::init` | `src/cli/init.rs` | 1671 | giant-file |
 | `cli::migrate` | `src/cli/migrate.rs` | 348 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -55,7 +55,7 @@
 | `cli::doctor::contract` | `src/cli/doctor/contract.rs` | 100 |  |
 | `cli::doctor::health` | `src/cli/doctor/health.rs` | 164 |  |
 | `cli::doctor::mailbox` | `src/cli/doctor/mailbox.rs` | 256 |  |
-| `cli::doctor::orchestrator` | `src/cli/doctor/orchestrator.rs` | 5036 | giant-file |
+| `cli::doctor::orchestrator` | `src/cli/doctor/orchestrator.rs` | 5042 | giant-file |
 | `cli::doctor::startup` | `src/cli/doctor/startup.rs` | 375 |  |
 | `cli::init` | `src/cli/init.rs` | 1671 | giant-file |
 | `cli::migrate` | `src/cli/migrate.rs` | 348 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -55,7 +55,7 @@
 | `cli::doctor::contract` | `src/cli/doctor/contract.rs` | 100 |  |
 | `cli::doctor::health` | `src/cli/doctor/health.rs` | 164 |  |
 | `cli::doctor::mailbox` | `src/cli/doctor/mailbox.rs` | 256 |  |
-| `cli::doctor::orchestrator` | `src/cli/doctor/orchestrator.rs` | 5115 | giant-file |
+| `cli::doctor::orchestrator` | `src/cli/doctor/orchestrator.rs` | 5040 | giant-file |
 | `cli::doctor::startup` | `src/cli/doctor/startup.rs` | 375 |  |
 | `cli::init` | `src/cli/init.rs` | 1671 | giant-file |
 | `cli::migrate` | `src/cli/migrate.rs` | 348 |  |
@@ -573,7 +573,7 @@
 | `services::platform::binary_resolver` | `src/services/platform/binary_resolver.rs` | 1368 | giant-file |
 | `services::platform::dump_tool` | `src/services/platform/dump_tool.rs` | 111 |  |
 | `services::platform::shell` | `src/services/platform/shell.rs` | 129 |  |
-| `services::platform::tmux` | `src/services/platform/tmux.rs` | 674 |  |
+| `services::platform::tmux` | `src/services/platform/tmux.rs` | 747 |  |
 | `services::process` | `src/services/process.rs` | 1442 | giant-file |
 | `services::provider` | `src/services/provider.rs` | 2621 | giant-file |
 | `services::provider_cli` | `src/services/provider_cli/mod.rs` | 21 |  |

--- a/docs/generated/module-inventory.md
+++ b/docs/generated/module-inventory.md
@@ -573,7 +573,7 @@
 | `services::platform::binary_resolver` | `src/services/platform/binary_resolver.rs` | 1368 | giant-file |
 | `services::platform::dump_tool` | `src/services/platform/dump_tool.rs` | 111 |  |
 | `services::platform::shell` | `src/services/platform/shell.rs` | 129 |  |
-| `services::platform::tmux` | `src/services/platform/tmux.rs` | 747 |  |
+| `services::platform::tmux` | `src/services/platform/tmux.rs` | 749 |  |
 | `services::process` | `src/services/process.rs` | 1442 | giant-file |
 | `services::provider` | `src/services/provider.rs` | 2621 | giant-file |
 | `services::provider_cli` | `src/services/provider_cli/mod.rs` | 21 |  |

--- a/src/cli/doctor/orchestrator.rs
+++ b/src/cli/doctor/orchestrator.rs
@@ -3299,6 +3299,16 @@ fn check_file_descriptor_headroom() -> Check {
     } else {
         launchd_soft_limit
     };
+    // tmux servers are spawned as children of the launchd-managed dcserver
+    // process, so they inherit its per-job SoftResourceLimits:NumberOfFiles
+    // (the plist value) — not the global `launchctl limit maxfiles`. Evaluate
+    // dcserver and tmux against the same resolved soft limit / source so a
+    // raised plist limit does not produce spurious EMFILE warnings for tmux.
+    let resolved_limit_source = if launchd_job_loaded && plist_nofile_limit.is_some() {
+        "launchd_plist"
+    } else {
+        "launchctl_maxfiles"
+    };
 
     let mut samples = Vec::new();
     for pid in dcserver::dcserver_instance_pids() {
@@ -3308,11 +3318,7 @@ fn check_file_descriptor_headroom() -> Check {
                 pid,
                 open_files,
                 soft_limit: dcserver_soft_limit,
-                limit_source: if launchd_job_loaded && plist_nofile_limit.is_some() {
-                    "launchd_plist"
-                } else {
-                    "launchctl_maxfiles"
-                },
+                limit_source: resolved_limit_source,
             });
         }
     }
@@ -3322,8 +3328,8 @@ fn check_file_descriptor_headroom() -> Check {
                 process: "tmux",
                 pid,
                 open_files,
-                soft_limit: launchd_soft_limit,
-                limit_source: "launchctl_maxfiles",
+                soft_limit: dcserver_soft_limit,
+                limit_source: resolved_limit_source,
             });
         }
     }

--- a/src/cli/doctor/orchestrator.rs
+++ b/src/cli/doctor/orchestrator.rs
@@ -3128,62 +3128,26 @@ fn launchagent_plist_nofile_limit(label: &str) -> Option<u64> {
 }
 
 #[cfg(target_os = "macos")]
-fn pids_from_command_output(output: &[u8]) -> Vec<u32> {
+fn tmux_server_pids() -> Vec<u32> {
+    let owner_marker = crate::services::tmux_common::current_tmux_owner_marker();
+    let sessions = match crate::services::platform::tmux::list_sessions_with_server_pid() {
+        Ok(sessions) => sessions,
+        Err(_) => return Vec::new(),
+    };
     let mut pids = BTreeSet::new();
-    for line in String::from_utf8_lossy(output).lines() {
-        if let Ok(pid) = line.trim().parse::<u32>() {
-            pids.insert(pid);
+    for session in sessions {
+        if session.server_pid == 0 || !session.session_name.starts_with("AgentDesk-") {
+            continue;
+        }
+        let owner_path = crate::services::tmux_common::tmux_owner_path(&session.session_name);
+        let belongs_to_current_runtime = std::fs::read_to_string(owner_path)
+            .map(|value| value.trim() == owner_marker)
+            .unwrap_or(false);
+        if belongs_to_current_runtime {
+            pids.insert(session.server_pid);
         }
     }
     pids.into_iter().collect()
-}
-
-#[cfg(target_os = "macos")]
-fn tmux_server_pids() -> Vec<u32> {
-    let output = match std::process::Command::new("pgrep")
-        .args(["-x", "tmux"])
-        .output()
-    {
-        Ok(output) if output.status.success() => output,
-        _ => return Vec::new(),
-    };
-    pids_from_command_output(&output.stdout)
-}
-
-#[cfg(any(test, target_os = "macos"))]
-fn pid_has_ancestor_with(
-    mut pid: u32,
-    ancestors: &BTreeSet<u32>,
-    mut parent_pid_for: impl FnMut(u32) -> Option<u32>,
-) -> bool {
-    let mut seen = BTreeSet::new();
-    while let Some(parent_pid) = parent_pid_for(pid) {
-        if parent_pid == 0 || !seen.insert(parent_pid) {
-            return false;
-        }
-        if ancestors.contains(&parent_pid) {
-            return true;
-        }
-        pid = parent_pid;
-    }
-    false
-}
-
-#[cfg(target_os = "macos")]
-fn parent_pid_for_pid(pid: u32) -> Option<u32> {
-    let output = std::process::Command::new("ps")
-        .args(["-o", "ppid=", "-p", &pid.to_string()])
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    String::from_utf8_lossy(&output.stdout).trim().parse().ok()
-}
-
-#[cfg(target_os = "macos")]
-fn pid_has_ancestor(pid: u32, ancestors: &BTreeSet<u32>) -> bool {
-    pid_has_ancestor_with(pid, ancestors, parent_pid_for_pid)
 }
 
 #[cfg(target_os = "macos")]
@@ -3336,8 +3300,8 @@ fn check_file_descriptor_headroom() -> Check {
         launchd_soft_limit
     };
     // dcserver itself is the launchd job and inherits the per-job plist limit.
-    // tmux may be an unrelated user server from `pgrep -x tmux`, so only tmux
-    // processes in dcserver's process tree can safely use that same limit.
+    // tmux server PIDs are scoped to current-runtime AgentDesk sessions, not
+    // all user tmux daemons, so they can use the same resolved limit/source.
     let resolved_limit_source = if launchd_job_loaded && plist_nofile_limit.is_some() {
         "launchd_plist"
     } else {
@@ -3345,9 +3309,7 @@ fn check_file_descriptor_headroom() -> Check {
     };
 
     let mut samples = Vec::new();
-    let dcserver_pids = dcserver::dcserver_instance_pids();
-    let dcserver_pid_set: BTreeSet<u32> = dcserver_pids.iter().copied().collect();
-    for pid in dcserver_pids {
+    for pid in dcserver::dcserver_instance_pids() {
         if let Some(open_files) = open_file_count_for_pid(pid) {
             samples.push(FdUsageSample {
                 process: "dcserver",
@@ -3360,20 +3322,12 @@ fn check_file_descriptor_headroom() -> Check {
     }
     for pid in tmux_server_pids() {
         if let Some(open_files) = open_file_count_for_pid(pid) {
-            let tmux_uses_dcserver_limit = launchd_job_loaded
-                && plist_nofile_limit.is_some()
-                && pid_has_ancestor(pid, &dcserver_pid_set);
-            let (soft_limit, limit_source) = if tmux_uses_dcserver_limit {
-                (dcserver_soft_limit, resolved_limit_source)
-            } else {
-                (launchd_soft_limit, "launchctl_maxfiles")
-            };
             samples.push(FdUsageSample {
                 process: "tmux",
                 pid,
                 open_files,
-                soft_limit,
-                limit_source,
+                soft_limit: dcserver_soft_limit,
+                limit_source: resolved_limit_source,
             });
         }
     }
@@ -4202,35 +4156,6 @@ pub fn cmd_doctor(options: DoctorOptions) -> Result<(), String> {
         ))
     } else {
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod fd_process_tree_tests {
-    use super::pid_has_ancestor_with;
-    use std::collections::{BTreeMap, BTreeSet};
-
-    #[test]
-    fn pid_ancestor_lookup_walks_parent_chain() {
-        let parents = BTreeMap::from([(30, 20), (20, 10), (10, 1)]);
-        let ancestors = BTreeSet::from([10]);
-
-        assert!(pid_has_ancestor_with(30, &ancestors, |pid| parents
-            .get(&pid)
-            .copied()));
-        assert!(!pid_has_ancestor_with(30, &BTreeSet::from([40]), |pid| {
-            parents.get(&pid).copied()
-        }));
-    }
-
-    #[test]
-    fn pid_ancestor_lookup_stops_on_cycles() {
-        let parents = BTreeMap::from([(30, 20), (20, 30)]);
-        let ancestors = BTreeSet::from([10]);
-
-        assert!(!pid_has_ancestor_with(30, &ancestors, |pid| parents
-            .get(&pid)
-            .copied()));
     }
 }
 

--- a/src/cli/doctor/orchestrator.rs
+++ b/src/cli/doctor/orchestrator.rs
@@ -3150,6 +3150,42 @@ fn tmux_server_pids() -> Vec<u32> {
     pids_from_command_output(&output.stdout)
 }
 
+#[cfg(any(test, target_os = "macos"))]
+fn pid_has_ancestor_with(
+    mut pid: u32,
+    ancestors: &BTreeSet<u32>,
+    mut parent_pid_for: impl FnMut(u32) -> Option<u32>,
+) -> bool {
+    let mut seen = BTreeSet::new();
+    while let Some(parent_pid) = parent_pid_for(pid) {
+        if parent_pid == 0 || !seen.insert(parent_pid) {
+            return false;
+        }
+        if ancestors.contains(&parent_pid) {
+            return true;
+        }
+        pid = parent_pid;
+    }
+    false
+}
+
+#[cfg(target_os = "macos")]
+fn parent_pid_for_pid(pid: u32) -> Option<u32> {
+    let output = std::process::Command::new("ps")
+        .args(["-o", "ppid=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&output.stdout).trim().parse().ok()
+}
+
+#[cfg(target_os = "macos")]
+fn pid_has_ancestor(pid: u32, ancestors: &BTreeSet<u32>) -> bool {
+    pid_has_ancestor_with(pid, ancestors, parent_pid_for_pid)
+}
+
 #[cfg(target_os = "macos")]
 fn lsof_fd_column_counts_against_rlimit(fd: &str) -> bool {
     fd.chars()
@@ -3299,11 +3335,9 @@ fn check_file_descriptor_headroom() -> Check {
     } else {
         launchd_soft_limit
     };
-    // tmux servers are spawned as children of the launchd-managed dcserver
-    // process, so they inherit its per-job SoftResourceLimits:NumberOfFiles
-    // (the plist value) — not the global `launchctl limit maxfiles`. Evaluate
-    // dcserver and tmux against the same resolved soft limit / source so a
-    // raised plist limit does not produce spurious EMFILE warnings for tmux.
+    // dcserver itself is the launchd job and inherits the per-job plist limit.
+    // tmux may be an unrelated user server from `pgrep -x tmux`, so only tmux
+    // processes in dcserver's process tree can safely use that same limit.
     let resolved_limit_source = if launchd_job_loaded && plist_nofile_limit.is_some() {
         "launchd_plist"
     } else {
@@ -3311,7 +3345,9 @@ fn check_file_descriptor_headroom() -> Check {
     };
 
     let mut samples = Vec::new();
-    for pid in dcserver::dcserver_instance_pids() {
+    let dcserver_pids = dcserver::dcserver_instance_pids();
+    let dcserver_pid_set: BTreeSet<u32> = dcserver_pids.iter().copied().collect();
+    for pid in dcserver_pids {
         if let Some(open_files) = open_file_count_for_pid(pid) {
             samples.push(FdUsageSample {
                 process: "dcserver",
@@ -3324,12 +3360,20 @@ fn check_file_descriptor_headroom() -> Check {
     }
     for pid in tmux_server_pids() {
         if let Some(open_files) = open_file_count_for_pid(pid) {
+            let tmux_uses_dcserver_limit = launchd_job_loaded
+                && plist_nofile_limit.is_some()
+                && pid_has_ancestor(pid, &dcserver_pid_set);
+            let (soft_limit, limit_source) = if tmux_uses_dcserver_limit {
+                (dcserver_soft_limit, resolved_limit_source)
+            } else {
+                (launchd_soft_limit, "launchctl_maxfiles")
+            };
             samples.push(FdUsageSample {
                 process: "tmux",
                 pid,
                 open_files,
-                soft_limit: dcserver_soft_limit,
-                limit_source: resolved_limit_source,
+                soft_limit,
+                limit_source,
             });
         }
     }
@@ -4158,6 +4202,35 @@ pub fn cmd_doctor(options: DoctorOptions) -> Result<(), String> {
         ))
     } else {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod fd_process_tree_tests {
+    use super::pid_has_ancestor_with;
+    use std::collections::{BTreeMap, BTreeSet};
+
+    #[test]
+    fn pid_ancestor_lookup_walks_parent_chain() {
+        let parents = BTreeMap::from([(30, 20), (20, 10), (10, 1)]);
+        let ancestors = BTreeSet::from([10]);
+
+        assert!(pid_has_ancestor_with(30, &ancestors, |pid| parents
+            .get(&pid)
+            .copied()));
+        assert!(!pid_has_ancestor_with(30, &BTreeSet::from([40]), |pid| {
+            parents.get(&pid).copied()
+        }));
+    }
+
+    #[test]
+    fn pid_ancestor_lookup_stops_on_cycles() {
+        let parents = BTreeMap::from([(30, 20), (20, 30)]);
+        let ancestors = BTreeSet::from([10]);
+
+        assert!(!pid_has_ancestor_with(30, &ancestors, |pid| parents
+            .get(&pid)
+            .copied()));
     }
 }
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -393,7 +393,7 @@ fn default_launchd_root_dir(home: &Path, flavor: LaunchdPlistFlavorArg) -> PathB
 }
 
 #[cfg(target_os = "macos")]
-const LAUNCHD_NOFILE_SOFT_LIMIT_TARGET: u64 = 2_048;
+const LAUNCHD_NOFILE_SOFT_LIMIT_TARGET: u64 = 16_384;
 
 #[cfg(target_os = "macos")]
 fn clamp_launchd_nofile_soft_limit(hard_limit: u64) -> Option<u64> {

--- a/src/services/platform/tmux.rs
+++ b/src/services/platform/tmux.rs
@@ -439,7 +439,9 @@ pub fn list_sessions_with_pane_command() -> Result<Vec<EnumeratedSession>, Strin
 
 /// List every tmux session along with its owning tmux server PID.
 pub fn list_sessions_with_server_pid() -> Result<Vec<SessionServer>, String> {
-    let out = tmux_command()
+    let mut command = tmux_command();
+    command.env_remove("TMUX");
+    let out = command
         .args(["list-sessions", "-F", "#{session_name}|#{pid}"])
         .output()
         .map_err(|e| format!("tmux list-sessions failed: {e}"))?;

--- a/src/services/platform/tmux.rs
+++ b/src/services/platform/tmux.rs
@@ -379,6 +379,15 @@ pub struct EnumeratedSession {
     pub pane_pid: u32,
 }
 
+/// A tmux session and the PID of the tmux server that owns it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionServer {
+    pub session_name: String,
+    /// `#{pid}` is the tmux server PID. It is shared by every session on the
+    /// same socket and may be 0 if tmux cannot resolve it.
+    pub server_pid: u32,
+}
+
 /// List every tmux session along with its active pane's `pane_current_command`.
 /// Used by `SessionDiscovery` (Epic #2285 / E2) to feed the `SessionMatcher`
 /// with both the session name *and* the live provider fingerprint in a single
@@ -426,6 +435,45 @@ pub fn list_sessions_with_pane_command() -> Result<Vec<EnumeratedSession>, Strin
         });
     }
     Ok(sessions)
+}
+
+/// List every tmux session along with its owning tmux server PID.
+pub fn list_sessions_with_server_pid() -> Result<Vec<SessionServer>, String> {
+    let out = tmux_command()
+        .args(["list-sessions", "-F", "#{session_name}|#{pid}"])
+        .output()
+        .map_err(|e| format!("tmux list-sessions failed: {e}"))?;
+    if !out.status.success() {
+        return Err("tmux list-sessions returned non-zero".to_string());
+    }
+    Ok(parse_sessions_with_server_pid(&String::from_utf8_lossy(
+        &out.stdout,
+    )))
+}
+
+fn parse_sessions_with_server_pid(text: &str) -> Vec<SessionServer> {
+    let mut sessions = Vec::new();
+    for line in text.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.splitn(2, '|');
+        let session_name = parts.next().unwrap_or("").trim().to_string();
+        if session_name.is_empty() {
+            continue;
+        }
+        let server_pid = parts
+            .next()
+            .unwrap_or("")
+            .trim()
+            .parse::<u32>()
+            .unwrap_or(0);
+        sessions.push(SessionServer {
+            session_name,
+            server_pid,
+        });
+    }
+    sessions
 }
 
 /// Read the command line of a live process by PID, used as a fallback
@@ -562,6 +610,31 @@ mod paste_tests {
                 "agentdesk-buffer",
                 "-t",
                 "=AgentDesk-claude-adk-cc:"
+            ]
+        );
+    }
+}
+
+#[cfg(test)]
+mod session_server_tests {
+    use super::*;
+
+    #[test]
+    fn parse_sessions_with_server_pid_skips_empty_names_and_defaults_bad_pids() {
+        let sessions =
+            parse_sessions_with_server_pid("AgentDesk-a|123\n|456\noperator|not-a-pid\n");
+
+        assert_eq!(
+            sessions,
+            vec![
+                SessionServer {
+                    session_name: "AgentDesk-a".to_string(),
+                    server_pid: 123,
+                },
+                SessionServer {
+                    session_name: "operator".to_string(),
+                    server_pid: 0,
+                },
             ]
         );
     }


### PR DESCRIPTION
## 목표

PR #2484가 리뷰 반영 전 커밋(`deb437cd`)으로 squash-merge(`f3644879 ... (#2484)`)되어, 리뷰에서 합의된 두 수정이 upstream/main에 반영되지 못했습니다. 이 PR은 그 두 건만 현재 `upstream/main` 기준으로 다시 올립니다.

## 수정

### Fix 1 — tmux FD 압박을 상속된 plist 한도로 평가 (`src/cli/doctor/orchestrator.rs`)
`check_file_descriptor_headroom`에서 dcserver 샘플은 plist `SoftResourceLimits:NumberOfFiles`로 해석한 soft limit을 쓰지만, tmux 샘플은 전역 `launchctl limit maxfiles`(`launchd_soft_limit`)로 평가하고 있었습니다. tmux 서버는 launchd가 기동한 dcserver의 자식 프로세스로 dcserver의 per-job rlimit을 상속하므로, launchctl이 256을 보고하지만 plist가 상향된 환경에서 거짓 EMFILE 경고가 발생합니다(Codex P2). dcserver와 tmux가 동일한 resolved soft limit/source(`resolved_limit_source` 공용 바인딩)를 쓰도록 정리했습니다.

### Fix 2 — provisioned launchd soft FD 한도 복원 (`src/cli/init.rs`)
#2484는 FD 압박 경고를 추가하면서 동시에 `LAUNCHD_NOFILE_SOFT_LIMIT_TARGET`을 `16_384 → 2_048`로 8배 낮춰, `agentdesk init`이 새로 기록하는 plist soft FD 한도를 축소했습니다. 이는 같은 PR이 추가한 FD-압박 경고/EMFILE 방지 목표와 정면으로 모순됩니다. upstream 값 `16_384`로 복원합니다.

## Before → After

| 시나리오 | Before (#2484 merged) | After |
| --- | --- | --- |
| tmux FD 평가 | 전역 launchctl maxfiles 기준 → 거짓 EMFILE 경고 | dcserver와 동일 resolved limit/source |
| `agentdesk init` plist nofile soft | 2_048 (8× 축소) | 16_384 (복원) |
| dcserver FD 평가 | 변화 없음 | 변화 없음 |

## 검증

- `cargo fmt --all --check`
- `uv run python scripts/generate_inventory_docs.py --check`
- `CMAKE_GENERATOR='Visual Studio 17 2022' cargo check --bin agentdesk` (Windows, 0 errors)

generated `module-inventory.md`는 orchestrator.rs 라인 변화에 맞춰 재생성했습니다.
