### PR TITLE
Refiner: reuse expand_user_path for Gemini working dir

### DIFF
--- a/src/services/gemini.rs
+++ b/src/services/gemini.rs
@@ -885,15 +885,7 @@ fn expand_gemini_working_dir(raw: &str) -> PathBuf {
     if raw.is_empty() {
         return dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
     }
-    if raw == "~" {
-        return dirs::home_dir().unwrap_or_else(|| PathBuf::from(raw));
-    }
-    if let Some(stripped) = raw.strip_prefix("~/") {
-        return dirs::home_dir()
-            .map(|home| home.join(stripped))
-            .unwrap_or_else(|| PathBuf::from(raw));
-    }
-    PathBuf::from(raw)
+    crate::runtime_layout::expand_user_path(raw).unwrap_or_else(|| PathBuf::from(raw))
 }
 
 fn gemini_trust_rules() -> Vec<GeminiTrustRule> {
@@ -1409,6 +1401,38 @@ fn render_gemini_value(value: &Value) -> String {
         Value::Null => String::new(),
         Value::String(text) => text.to_string(),
         _ => value.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod path_expansion_tests {
+    use super::expand_gemini_working_dir;
+    use std::path::PathBuf;
+
+    #[test]
+    fn expand_gemini_working_dir_keeps_existing_trimmed_relative_behavior() {
+        assert_eq!(
+            expand_gemini_working_dir("  relative/project  "),
+            PathBuf::from("relative/project")
+        );
+    }
+
+    #[test]
+    fn expand_gemini_working_dir_reuses_runtime_tilde_expansion() {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+
+        assert_eq!(
+            expand_gemini_working_dir("~/agentdesk"),
+            home.join("agentdesk")
+        );
+
+        #[cfg(windows)]
+        assert_eq!(
+            expand_gemini_working_dir(r"~\agentdesk"),
+            home.join("agentdesk")
+        );
     }
 }
 


### PR DESCRIPTION
## 목표

Gemini provider의 working directory 확장에서 기존 직접 경로 처리 대신 공용 `expand_user_path` 흐름을 재사용해 `~`와 사용자 경로 해석을 일관되게 만듭니다.

## 쉬운 설명

Gemini 실행 경로가 다른 provider와 같은 방식으로 사용자 홈 경로를 해석합니다. 설정에 `~/...` 같은 경로가 들어와도 더 예측 가능하게 동작합니다.

## 개선되는 것

### Fix 1
Gemini working dir expansion이 공용 path expansion helper를 사용합니다. provider별 경로 처리 차이를 줄이고 설정 이식성을 높입니다.

## Before → After

| 시나리오 | Before | After |
|---|---|---|
| Gemini working dir에 user path 사용 | provider-local 처리에 의존 | 공용 `expand_user_path` 기준으로 처리 |
| 다른 provider와 경로 처리 비교 | 구현 차이 발생 가능 | helper 재사용으로 일관성 증가 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
|---|---|---|
| 절대 경로 입력 | 기존 경로 유지 | 영향 낮음 |
| `~` 포함 경로 입력 | 홈 경로로 확장 | 의도한 개선 |

## 해결한 내용

- `src/services/gemini.rs`: Gemini working directory expansion에서 공용 path helper를 재사용하도록 정리했습니다.

## 검증

- `cargo fmt --all --check` 통과
- `cargo check --all-targets` 통과