### PR TITLE
Doctor: improve health degraded reasons and startup report endpoint

### DIFF
--- a/src/cli/doctor/health.rs
+++ b/src/cli/doctor/health.rs
@@ -88,6 +88,31 @@ pub(crate) fn classify_degraded_reason(raw: &str) -> ClassifiedReason {
             summary: format!("pipeline override warnings count is {count}"),
             next_step: "run config audit and inspect override report".to_string(),
         },
+        [
+            "global_active_counter_out_of_bounds",
+            raw_val,
+            prov_val,
+            fin_val,
+        ] => {
+            let raw_clean = raw_val.strip_prefix("raw=").unwrap_or(raw_val);
+            let prov_clean = prov_val
+                .strip_prefix("provider_active_turns=")
+                .unwrap_or(prov_val);
+            let fin_clean = fin_val
+                .strip_prefix("global_finalizing=")
+                .unwrap_or(fin_val);
+            ClassifiedReason {
+                raw: raw.to_string(),
+                subsystem: "health",
+                severity: Severity::Warning,
+                fix_safety: FixSafety::ReadOnly,
+                security_exposure: SecurityExposure::OperationalMetadata,
+                summary: format!(
+                    "global active counter out of bounds (raw: {raw_clean}, provider: {prov_clean}, finalizing: {fin_clean})"
+                ),
+                next_step: "inspect global active counter tracking in dcserver logs".to_string(),
+            }
+        }
         ["no_providers_registered"] => ClassifiedReason {
             raw: raw.to_string(),
             subsystem: "provider_registry",
@@ -173,6 +198,44 @@ pub(crate) fn reasons_evidence(reasons: &[ClassifiedReason]) -> Value {
 
 pub(crate) fn is_loopback_base_url(base: &str) -> bool {
     crate::utils::loopback_url::is_loopback_url(base, None)
+}
+
+#[cfg(test)]
+mod health_classification_tests {
+    use super::{LATEST_STARTUP_DOCTOR_ENDPOINT, classify_degraded_reason};
+
+    #[test]
+    fn startup_doctor_reasons_point_to_latest_report_endpoint() {
+        let expected_next_step =
+            format!("inspect the startup doctor report via {LATEST_STARTUP_DOCTOR_ENDPOINT}");
+
+        let failed = classify_degraded_reason("startup_doctor_failed:2");
+        assert_eq!(failed.subsystem, "startup_doctor");
+        assert_eq!(failed.summary, "startup doctor reported 2 failure(s)");
+        assert_eq!(failed.next_step.as_str(), expected_next_step.as_str());
+
+        let warned = classify_degraded_reason("startup_doctor_warned:3");
+        assert_eq!(warned.subsystem, "startup_doctor");
+        assert_eq!(warned.summary, "startup doctor reported 3 warning(s)");
+        assert_eq!(warned.next_step.as_str(), expected_next_step.as_str());
+    }
+
+    #[test]
+    fn global_active_counter_reason_is_actionable() {
+        let reason = classify_degraded_reason(
+            "global_active_counter_out_of_bounds:raw=4:provider_active_turns=2:global_finalizing=1",
+        );
+
+        assert_eq!(reason.subsystem, "health");
+        assert_eq!(
+            reason.summary,
+            "global active counter out of bounds (raw: 4, provider: 2, finalizing: 1)"
+        );
+        assert_eq!(
+            reason.next_step,
+            "inspect global active counter tracking in dcserver logs"
+        );
+    }
 }
 
 #[cfg(all(test, feature = "legacy-sqlite-tests"))]

--- a/src/cli/doctor/health.rs
+++ b/src/cli/doctor/health.rs
@@ -1,6 +1,7 @@
 use serde_json::{Value, json};
 
 use super::contract::{FixSafety, SecurityExposure, Severity};
+use super::startup::LATEST_STARTUP_DOCTOR_ENDPOINT;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ClassifiedReason {
@@ -11,6 +12,10 @@ pub(crate) struct ClassifiedReason {
     pub(crate) security_exposure: SecurityExposure,
     pub(crate) summary: String,
     pub(crate) next_step: String,
+}
+
+fn startup_doctor_report_next_step() -> String {
+    format!("inspect the startup doctor report via {LATEST_STARTUP_DOCTOR_ENDPOINT}")
 }
 
 pub(crate) fn classify_degraded_reason(raw: &str) -> ClassifiedReason {
@@ -129,7 +134,7 @@ pub(crate) fn classify_degraded_reason(raw: &str) -> ClassifiedReason {
             fix_safety: FixSafety::ReadOnly,
             security_exposure: SecurityExposure::OperationalMetadata,
             summary: format!("startup doctor reported {count} failure(s)"),
-            next_step: "inspect the startup doctor logs or report".to_string(),
+            next_step: startup_doctor_report_next_step(),
         },
         ["startup_doctor_warned", count] => ClassifiedReason {
             raw: raw.to_string(),
@@ -138,7 +143,7 @@ pub(crate) fn classify_degraded_reason(raw: &str) -> ClassifiedReason {
             fix_safety: FixSafety::ReadOnly,
             security_exposure: SecurityExposure::OperationalMetadata,
             summary: format!("startup doctor reported {count} warning(s)"),
-            next_step: "inspect the startup doctor logs or report".to_string(),
+            next_step: startup_doctor_report_next_step(),
         },
         ["disk_low_free_bytes", bytes] => ClassifiedReason {
             raw: raw.to_string(),


### PR DESCRIPTION
## 목표
Doctor health 진단에서 degraded 원인을 더 구체적으로 분류하고, startup doctor 리포트 안내가 실제 최신 엔드포인트를 기준으로 나오도록 맞춥니다.

## 쉬운 설명
Doctor가 문제가 있는 상태를 발견했을 때 다음에 무엇을 확인해야 하는지 더 명확하게 알려줍니다.
startup doctor 리포트 경로도 하드코딩된 문자열 대신 현재 코드의 엔드포인트 상수를 사용합니다.
운영자가 잘못된 안내를 따라가거나 원인을 다시 추적해야 하는 시간을 줄입니다.

## 개선되는 것
### Fix 1
Health degraded reason에 `global_active_counter_out_of_bounds` 케이스를 추가해 전역 active counter 불일치가 별도 원인으로 드러납니다.

### Fix 2
Startup doctor 리포트 next step이 `LATEST_STARTUP_DOCTOR_ENDPOINT`를 사용해 실제 최신 리포트 엔드포인트와 같은 값을 안내합니다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| 전역 active counter 이상 | 일반 degraded 원인으로 뭉개질 수 있음 | `global_active_counter_out_of_bounds`로 명확히 표시 |
| startup doctor 리포트 확인 안내 | 문자열이 코드 흐름과 어긋날 여지 있음 | 공유 상수 기반 엔드포인트를 안내 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 기존 health OK 상태 | 기존 OK 분류 유지 | 정상 경로 영향 낮음 |
| startup doctor 엔드포인트 변경 | 상수 변경을 next step이 따라감 | 안내 drift 감소 |
| 테스트 필터 실행 | 관련 health classification 테스트 통과 | 진단 분류 회귀 방지 |

## 해결한 내용
`src/cli/doctor/health.rs`에서 degraded reason 분류와 startup doctor next step 생성 로직을 보강했습니다. 관련 단위 테스트를 추가해 global active counter 원인과 startup doctor 리포트 엔드포인트 안내를 고정했습니다.

## 검증
- `cargo fmt --all --check`
- `cargo test health_classification_tests --all-targets`
- `cargo check --all-targets`
