### PR TITLE
WorkerRegistry: standardize lifecycle tracing metadata

### DIFF
--- a/src/server/worker_registry.rs
+++ b/src/server/worker_registry.rs
@@ -38,6 +38,7 @@ fn record_leader_only_worker_started(spec: WorkerSpec) {
     tracing::info!(
         worker = spec.name,
         target = spec.target,
+        kind = spec.kind.as_doc_str(),
         execution_scope = spec.execution_scope.as_doc_str(),
         "leader-only worker epoch started"
     );
@@ -52,6 +53,8 @@ fn record_leader_only_worker_stopped(spec: WorkerSpec, reason: &str) {
     tracing::warn!(
         worker = spec.name,
         target = spec.target,
+        kind = spec.kind.as_doc_str(),
+        execution_scope = spec.execution_scope.as_doc_str(),
         reason,
         "leader-only worker epoch stopped"
     );
@@ -849,18 +852,32 @@ impl SupervisedWorkerRegistry {
             tokio::pin!(future);
             tokio::select! {
                 _ = &mut future => {
-                    tracing::warn!(worker = spec.name, target = spec.target, "leader-only worker future exited");
+                    tracing::warn!(
+                        worker = spec.name,
+                        target = spec.target,
+                        kind = spec.kind.as_doc_str(),
+                        execution_scope = spec.execution_scope.as_doc_str(),
+                        "leader-only worker future exited"
+                    );
                 }
                 _ = cluster_runtime.wait_until_not_leader() => {
                     tracing::warn!(
                         worker = spec.name,
                         target = spec.target,
+                        kind = spec.kind.as_doc_str(),
+                        execution_scope = spec.execution_scope.as_doc_str(),
                         instance_id = cluster_runtime.instance_id(),
                         "leader-only worker self-fenced after cluster leadership was lost"
                     );
                 }
                 _ = wait_until_shutdown(shutdown.clone()) => {
-                    tracing::info!(worker = spec.name, target = spec.target, "leader-only worker supervisor shutting down");
+                    tracing::info!(
+                        worker = spec.name,
+                        target = spec.target,
+                        kind = spec.kind.as_doc_str(),
+                        execution_scope = spec.execution_scope.as_doc_str(),
+                        "leader-only worker supervisor shutting down"
+                    );
                     break;
                 }
             }
@@ -913,6 +930,7 @@ impl SupervisedWorkerRegistry {
         tracing::info!(
             worker = spec.name,
             target = spec.target,
+            kind = spec.kind.as_doc_str(),
             stage = spec.start_stage.as_doc_str(),
             execution_scope = spec.execution_scope.as_doc_str(),
             reason,


### PR DESCRIPTION
## 목표
WorkerRegistry의 leader-only worker lifecycle 로그에 worker kind와 execution scope 메타데이터를 일관되게 포함해 운영 관측성을 높입니다.

## 쉬운 설명
worker가 시작, 중단, self-fence, shutdown 되는 로그를 볼 때 어떤 종류의 worker인지 더 쉽게 식별할 수 있습니다.
로그 메시지 자체의 흐름은 유지하고 structured field만 보강합니다.
문제가 생긴 worker를 추적할 때 이름과 target만으로 부족했던 정보를 보완합니다.

## 개선되는 것
### Fix 1
leader-only worker started/stopped 로그에 `kind`와 `execution_scope`를 포함합니다.

### Fix 2
worker future exit, leadership loss self-fence, supervisor shutdown 로그에도 같은 structured fields를 맞춥니다.

### Fix 3
worker restart 로그에 `kind`를 추가해 start stage/execution scope와 함께 필터링할 수 있게 합니다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| leader-only worker 중단 | worker/target 중심 로그 | worker/target/kind/execution_scope 포함 |
| leadership loss self-fence | instance_id와 worker 중심 | kind와 execution_scope까지 함께 기록 |
| restart 추적 | start stage만으로 분류 | kind 기반 필터링 가능 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 정상 worker lifecycle | 로그 field만 추가 | 런타임 동작 변경 없음 |
| structured log consumer | 기존 field 유지, field 추가 | 후방 호환 위험 낮음 |
| generated inventory docs | 이번 PR에서 제외 | 코드 diff만 유지 |

## 해결한 내용
`src/server/worker_registry.rs`의 lifecycle tracing 호출에 `kind`와 `execution_scope` 메타데이터를 보강했습니다. 같은 묶음의 다른 커밋들은 최신 upstream에 이미 반영되어 있거나 generated docs만 남아 제외했습니다.

## 검증
- `cargo fmt --all --check`
- `cargo test supervisor_respawns_worker_after_lease_takeover --all-targets`
- `cargo check --all-targets`
