### PR TITLE
Hooks: resolve Python runner portably

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+scripts/** text eol=lf
+.githooks/** text eol=lf
+.github/workflows/*.yml text eol=lf

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -5,6 +5,8 @@ HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$HOOK_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
 
+source "$PROJECT_ROOT/scripts/resolve-python-runner.sh"
+
 EMPTY_TREE="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 regen_needed=0
 
@@ -29,7 +31,7 @@ done
 
 [ "$regen_needed" -eq 1 ] || exit 0
 
-if ! regen_output=$(python3 scripts/generate_inventory_docs.py 2>&1); then
+if ! regen_output=$(agentdesk_run_python scripts/generate_inventory_docs.py 2>&1); then
   printf '%s\n' "$regen_output" >&2
   exit 1
 fi

--- a/scripts/resolve-python-runner.sh
+++ b/scripts/resolve-python-runner.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Shared Python runner resolution for local git hooks and shell checks.
+
+agentdesk_run_python() {
+  if [ -n "${PYTHON:-}" ]; then
+    if command -v "$PYTHON" >/dev/null 2>&1 || [ -x "$PYTHON" ]; then
+      "$PYTHON" "$@"
+      return $?
+    fi
+    printf 'Configured PYTHON runner not found or not executable: %s\n' "$PYTHON" >&2
+    return 127
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 "$@"
+    return $?
+  fi
+
+  if command -v uv >/dev/null 2>&1; then
+    uv run python "$@"
+    return $?
+  fi
+
+  if command -v py >/dev/null 2>&1; then
+    py "$@"
+    return $?
+  fi
+
+  cat >&2 <<'EOF'
+No Python runner found for AgentDesk git hooks.
+Install python3, install uv, install the Windows Python launcher, or set PYTHON=/path/to/python.
+EOF
+  return 127
+}

--- a/tests/test_git_hook_python_resolution.py
+++ b/tests/test_git_hook_python_resolution.py
@@ -1,0 +1,30 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class GitHookPythonResolutionTests(unittest.TestCase):
+    def test_pre_push_uses_portable_python_runner_helper(self):
+        text = (ROOT / ".githooks" / "pre-push").read_text(encoding="utf-8")
+
+        self.assertIn('source "$PROJECT_ROOT/scripts/resolve-python-runner.sh"', text)
+        self.assertIn("agentdesk_run_python scripts/generate_inventory_docs.py", text)
+        self.assertNotIn("python3 scripts/generate_inventory_docs.py", text)
+
+    def test_python_runner_resolution_order_is_documented_in_helper(self):
+        text = (ROOT / "scripts" / "resolve-python-runner.sh").read_text(encoding="utf-8")
+
+        order = [
+            text.index("${PYTHON:-}"),
+            text.index("command -v python3"),
+            text.index("command -v uv"),
+            text.index("command -v py "),
+        ]
+        self.assertEqual(order, sorted(order))
+        self.assertIn("set PYTHON=/path/to/python", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목표
local git hook이 `python3` 고정 호출에 묶이지 않고 `PYTHON`, `python3`, `uv`, Windows `py` 순서로 Python runner를 찾도록 합니다.

## 쉬운 설명
개발자 환경마다 Python 실행 파일 이름이 다를 수 있습니다.
pre-push docs regen hook은 이제 공용 helper를 source해서 사용합니다.
macOS/Linux/Windows 계열 개발 환경에서 hook 실패 가능성을 줄입니다.

## 개선되는 것
### Fix 1
`.githooks/pre-push`가 `scripts/resolve-python-runner.sh`를 통해 Python runner를 실행합니다.

### Fix 2
runner 탐색 순서를 테스트로 고정하고, scripts/hooks/workflow 파일의 LF line ending 정책을 추가합니다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| `python3`가 없는 환경 | pre-push hook 실패 | `PYTHON`, `uv`, `py` fallback 확인 |
| 명시적 Python 경로 필요 | hook 수정 필요 | `PYTHON=/path/to/python`으로 지정 가능 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 기존 macOS/Linux `python3` 환경 | 기존처럼 python3 사용 | 동작 유지 |
| `PYTHON`이 잘못 설정됨 | 명확한 오류와 127 반환 | 실패 원인 식별 가능 |
| hook이 regen 불필요한 push | 기존 early exit 유지 | 영향 없음 |

## 해결한 내용
공용 Python runner helper를 추가하고 pre-push hook의 inventory docs regen 실행 경로만 바꿨습니다. portable operator scaffold의 다른 대형 변경은 포함하지 않았습니다.

## 검증
- `python3 -m unittest tests.test_git_hook_python_resolution`
- `bash -n .githooks/pre-push scripts/resolve-python-runner.sh`
