### PR TITLE
Codex: avoid reusing legacy wrapper sessions

### DIFF
--- a/src/services/codex.rs
+++ b/src/services/codex.rs
@@ -645,6 +645,25 @@ fn should_reuse_existing_provider_session(
 }
 
 #[cfg(unix)]
+fn codex_wrapper_script_uses_pipe_input(script: &str) -> bool {
+    script
+        .lines()
+        .any(|line| line.trim() == "--input-mode pipe \\" || line.trim() == "--input-mode pipe")
+}
+
+#[cfg(unix)]
+fn codex_tmux_wrapper_session_uses_pipe_input(tmux_session_name: &str) -> bool {
+    let Some(script_path) =
+        crate::services::tmux_common::resolve_session_temp_path(tmux_session_name, "sh")
+    else {
+        return false;
+    };
+    std::fs::read_to_string(script_path)
+        .map(|script| codex_wrapper_script_uses_pipe_input(&script))
+        .unwrap_or(false)
+}
+
+#[cfg(unix)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct CodexTmuxTerminationReason {
     reason_code: &'static str,
@@ -1948,7 +1967,8 @@ fn execute_streaming_local_tmux(
         crate::services::tmux_common::resolve_session_temp_path(tmux_session_name, "input");
     let session_usable = tmux_session_has_live_pane(tmux_session_name)
         && resolved_output.is_some()
-        && resolved_input.is_some();
+        && resolved_input.is_some()
+        && codex_tmux_wrapper_session_uses_pipe_input(tmux_session_name);
 
     if should_reuse_existing_provider_session(session_usable, force_fresh_provider_session) {
         let output_path = resolved_output
@@ -2756,7 +2776,7 @@ mod tui_hosting_tests {
     #[cfg(unix)]
     use super::{
         codex_tui_existing_session_termination_reason,
-        codex_wrapper_existing_session_termination_reason,
+        codex_wrapper_existing_session_termination_reason, codex_wrapper_script_uses_pipe_input,
     };
     use crate::services::discord::restart_report::{
         RESTART_REPORT_CHANNEL_ENV, RESTART_REPORT_PROVIDER_ENV,
@@ -3073,6 +3093,16 @@ mod tui_hosting_tests {
         assert!(script.contains("--input-mode pipe"));
         assert!(!script.contains("mkfifo"));
         assert!(!script.contains("exec '/opt/bin/codex' "));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_wrapper_pipe_input_detector_rejects_legacy_scripts() {
+        let pipe_script = "exec agentdesk codex-tmux-wrapper \\\n  --input-mode pipe \\\n";
+        let legacy_script = "exec agentdesk codex-tmux-wrapper \\\n  --input-fifo /tmp/in \\\n";
+
+        assert!(codex_wrapper_script_uses_pipe_input(pipe_script));
+        assert!(!codex_wrapper_script_uses_pipe_input(legacy_script));
     }
 
     #[test]


### PR DESCRIPTION
## 목표
Codex tmux wrapper follow-up 재사용 시 새 pipe-input wrapper session인지 확인해, legacy FIFO wrapper session을 잘못 재사용하지 않도록 합니다.

## 쉬운 설명
이전 wrapper script와 새 wrapper script의 input 방식이 다를 수 있습니다.
기존 tmux pane이 살아 있어도 wrapper script가 `--input-mode pipe`를 사용하지 않으면 fresh session으로 재생성합니다.
follow-up 전달 실패나 stale wrapper 재사용 가능성을 줄입니다.

## 개선되는 것
### Fix 1
기존 Codex tmux wrapper session의 script를 읽어 `--input-mode pipe` 사용 여부를 검사합니다.

### Fix 2
output/input temp path가 있어도 legacy FIFO wrapper로 판단되면 session reuse 대상에서 제외합니다.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| legacy FIFO wrapper pane 생존 | follow-up 재사용 시도 가능 | fresh session으로 재생성 |
| 새 pipe wrapper pane 생존 | output/input path 기준 재사용 | pipe marker 확인 후 재사용 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 정상 pipe wrapper | 기존 reuse 유지 | 정상 경로 영향 낮음 |
| script 파일 없음 | reuse하지 않음 | stale session 안전 처리 |
| legacy wrapper | 새 세션 생성 | 호환성 오류 감소 |

## 해결한 내용
`src/services/codex.rs`에 wrapper script detector를 추가하고, tmux wrapper session reuse 조건에 pipe-input marker 확인을 포함했습니다. 이 변경은 installer PR에서 분리한 runtime recovery 성격의 hunk입니다.

## 검증
- `cargo fmt --all --check`
- `cargo test codex_wrapper_pipe_input_detector_rejects_legacy_scripts --all-targets`
- `cargo check --all-targets`
