### PR TITLE
Launchd: resolve migrated entrypoints portably

### DIFF
--- a/docs/launchd-to-routine-migration-plan.md
+++ b/docs/launchd-to-routine-migration-plan.md
@@ -10,7 +10,7 @@ de-duplicates by removing the launchd plist once parity is confirmed.
 All routine scripts live under `routines/migrated-launchd/`. Each routine's
 `tick()` returns `action: "agent"` with a prompt instructing the attached
 agent to invoke the repo-deployed entrypoint under
-`/Users/itismyfield/.adk/release/scripts/launchd-migrated/`. The entrypoints
+`${AGENTDESK_ROOT_DIR:-$HOME/.adk/release}/scripts/launchd-migrated/`. The entrypoints
 were copied from the original `~/.local/bin/*.sh` launchd targets and are
 deployed by `adk-release`, so leadership can move between eligible nodes
 without a manual script rsync.
@@ -52,7 +52,7 @@ hour shift is possible between launchd and the routine scheduler.
 Run on whichever node is the cluster leader. The workspace containing
 `routines/migrated-launchd/` must be deployed before the script loader
 will see the new files, and `scripts/launchd-migrated/` must be deployed
-under `/Users/itismyfield/.adk/release/scripts/launchd-migrated/`.
+under `${AGENTDESK_ROOT_DIR:-$HOME/.adk/release}/scripts/launchd-migrated/`.
 
 The attach commands are split into three groups: Group A
 (parallel-run-safe, attach with schedule), Group B (cutover via
@@ -227,7 +227,7 @@ curl -sf "$API/api/routines/$ID10/pause" -X POST
 ## Cross-leader prerequisite — script availability
 
 Jobs 1–11 now invoke scripts staged by `adk-release` at
-`/Users/itismyfield/.adk/release/scripts/launchd-migrated/*.sh`; the
+`${AGENTDESK_ROOT_DIR:-$HOME/.adk/release}/scripts/launchd-migrated/*.sh`; the
 helper `run-claude-message-job.sh` is staged in the same directory and
 called via the script's own directory. Cross-leader failover therefore
 uses the release artifact instead of host-local `~/.local/bin` state.
@@ -236,7 +236,7 @@ Before attaching any migrated job, deploy the release on every node
 eligible to hold the `routine-runtime` lease and verify the directory:
 
 ```bash
-ls -l /Users/itismyfield/.adk/release/scripts/launchd-migrated/*.sh | sort
+ls -l "${AGENTDESK_ROOT_DIR:-$HOME/.adk/release}/scripts/launchd-migrated/"*.sh | sort
 ```
 
 No supported `preferred-leader` / `execution_scope` knob currently exists

--- a/routines/migrated-launchd/agent-feedback-briefing.js
+++ b/routines/migrated-launchd/agent-feedback-briefing.js
@@ -30,8 +30,9 @@ agentdesk.routines.register({
       prompt: [
         "Run the migrated launchd job 'agent-feedback-briefing' for routine_id=" +
           ctx.routine.id,
-        "Invoke the existing shell pipeline exactly as launchd does:",
-        "  /Users/itismyfield/.adk/release/scripts/launchd-migrated/agent-feedback-briefing.sh",
+        "Resolve the release root from AGENTDESK_ROOT_DIR, or ~/.adk/release if unset.",
+        "Invoke this root-relative shell pipeline exactly as launchd does:",
+        "  scripts/launchd-migrated/agent-feedback-briefing.sh",
         "This preserves the original prompt body, target channel, and skill path.",
         "Return a one-line status summary (success | NO_REPLY | error: <msg>) for the routine result.",
       ].join("\n"),

--- a/routines/migrated-launchd/ai-integrated-briefing.js
+++ b/routines/migrated-launchd/ai-integrated-briefing.js
@@ -21,14 +21,21 @@
 // True parallel-running would duplicate the Discord message.
 agentdesk.routines.register({
   name: "ai-integrated-briefing",
+  metadata: {
+    migrated_launchd: {
+      entrypoint: "scripts/launchd-migrated/ai-integrated-briefing.sh",
+      required_connectors: ["obsidian_skill_root"],
+    },
+  },
   tick(ctx) {
     return {
       action: "agent",
       prompt: [
         "Run the migrated launchd job 'ai-integrated-briefing' for routine_id=" +
           ctx.routine.id,
-        "Invoke the existing shell pipeline exactly as launchd does:",
-        "  /Users/itismyfield/.adk/release/scripts/launchd-migrated/ai-integrated-briefing.sh",
+        "Resolve the release root from AGENTDESK_ROOT_DIR, or ~/.adk/release if unset.",
+        "Invoke this root-relative shell pipeline exactly as launchd does:",
+        "  scripts/launchd-migrated/ai-integrated-briefing.sh",
         "This preserves the original prompt body, target channel, and skill path.",
         "Return a one-line status summary (success | NO_REPLY | error: <msg>) for the routine result.",
       ].join("\n"),

--- a/routines/migrated-launchd/banchan-day-reminder-cook.js
+++ b/routines/migrated-launchd/banchan-day-reminder-cook.js
@@ -25,14 +25,21 @@
 // → cutover protocol above to avoid that risk.
 agentdesk.routines.register({
   name: "banchan-day-reminder-cook",
+  metadata: {
+    migrated_launchd: {
+      entrypoint: "scripts/launchd-migrated/banchan-day-reminder-cook.sh",
+      required_connectors: ["obsidian_skill_root"],
+    },
+  },
   tick(ctx) {
     return {
       action: "agent",
       prompt: [
         "Run the migrated launchd job 'banchan-day-reminder.cook' for routine_id=" +
           ctx.routine.id,
-        "Invoke the existing shell pipeline exactly as launchd does:",
-        "  /Users/itismyfield/.adk/release/scripts/launchd-migrated/banchan-day-reminder-cook.sh",
+        "Resolve the release root from AGENTDESK_ROOT_DIR, or ~/.adk/release if unset.",
+        "Invoke this root-relative shell pipeline exactly as launchd does:",
+        "  scripts/launchd-migrated/banchan-day-reminder-cook.sh",
         "The skill performs calendar lookup; NO_REPLY is the correct result on",
         "non-반찬데이 days. Do not second-guess the skill's calendar logic.",
         "Return a one-line status summary (success | NO_REPLY | error: <msg>).",

--- a/routines/migrated-launchd/banchan-day-reminder-prep.js
+++ b/routines/migrated-launchd/banchan-day-reminder-prep.js
@@ -27,14 +27,21 @@
 // → cutover protocol above to avoid that risk.
 agentdesk.routines.register({
   name: "banchan-day-reminder-prep",
+  metadata: {
+    migrated_launchd: {
+      entrypoint: "scripts/launchd-migrated/banchan-day-reminder-prep.sh",
+      required_connectors: ["obsidian_skill_root"],
+    },
+  },
   tick(ctx) {
     return {
       action: "agent",
       prompt: [
         "Run the migrated launchd job 'banchan-day-reminder.prep' for routine_id=" +
           ctx.routine.id,
-        "Invoke the existing shell pipeline exactly as launchd does:",
-        "  /Users/itismyfield/.adk/release/scripts/launchd-migrated/banchan-day-reminder-prep.sh",
+        "Resolve the release root from AGENTDESK_ROOT_DIR, or ~/.adk/release if unset.",
+        "Invoke this root-relative shell pipeline exactly as launchd does:",
+        "  scripts/launchd-migrated/banchan-day-reminder-prep.sh",
         "The skill performs calendar lookup; NO_REPLY is the correct result on",
         "non-반찬데이 days. Do not second-guess the skill's calendar logic.",
         "Return a one-line status summary (success | NO_REPLY | error: <msg>).",

--- a/routines/migrated-launchd/cookingheart-daily-briefing.js
+++ b/routines/migrated-launchd/cookingheart-daily-briefing.js
@@ -21,14 +21,21 @@
 // True parallel-running would duplicate the Discord message.
 agentdesk.routines.register({
   name: "cookingheart-daily-briefing",
+  metadata: {
+    migrated_launchd: {
+      entrypoint: "scripts/launchd-migrated/cookingheart-daily-briefing.sh",
+      required_connectors: ["obsidian_skill_root"],
+    },
+  },
   tick(ctx) {
     return {
       action: "agent",
       prompt: [
         "Run the migrated launchd job 'cookingheart-daily-briefing' for routine_id=" +
           ctx.routine.id,
-        "Invoke the existing shell pipeline exactly as launchd does:",
-        "  /Users/itismyfield/.adk/release/scripts/launchd-migrated/cookingheart-daily-briefing.sh",
+        "Resolve the release root from AGENTDESK_ROOT_DIR, or ~/.adk/release if unset.",
+        "Invoke this root-relative shell pipeline exactly as launchd does:",
+        "  scripts/launchd-migrated/cookingheart-daily-briefing.sh",
         "This preserves the original prompt body, target channel, and skill path.",
         "Return a one-line status summary (success | NO_REPLY | error: <msg>).",
       ].join("\n"),

--- a/routines/migrated-launchd/family-morning-briefing-obujang.js
+++ b/routines/migrated-launchd/family-morning-briefing-obujang.js
@@ -23,14 +23,21 @@
 // would deliver two briefings to the recipient every morning.
 agentdesk.routines.register({
   name: "family-morning-briefing-obujang",
+  metadata: {
+    migrated_launchd: {
+      entrypoint: "scripts/launchd-migrated/family-morning-briefing-obujang.sh",
+      required_connectors: ["obsidian_skill_root"],
+    },
+  },
   tick(ctx) {
     return {
       action: "agent",
       prompt: [
         "Run the migrated launchd job 'family-morning-briefing.obujang' for routine_id=" +
           ctx.routine.id,
-        "Invoke the existing shell pipeline exactly as launchd does:",
-        "  /Users/itismyfield/.adk/release/scripts/launchd-migrated/family-morning-briefing-obujang.sh",
+        "Resolve the release root from AGENTDESK_ROOT_DIR, or ~/.adk/release if unset.",
+        "Invoke this root-relative shell pipeline exactly as launchd does:",
+        "  scripts/launchd-migrated/family-morning-briefing-obujang.sh",
         "Preserve the original prompt body, target channel, weather/calendar/reminders",
         "skill path, and Discord destination unchanged.",
         "Return a one-line status summary (success | NO_REPLY | error: <msg>).",

--- a/routines/migrated-launchd/family-morning-briefing-yohoejang.js
+++ b/routines/migrated-launchd/family-morning-briefing-yohoejang.js
@@ -23,14 +23,21 @@
 // would deliver two briefings to the recipient every morning.
 agentdesk.routines.register({
   name: "family-morning-briefing-yohoejang",
+  metadata: {
+    migrated_launchd: {
+      entrypoint: "scripts/launchd-migrated/family-morning-briefing-yohoejang.sh",
+      required_connectors: ["obsidian_skill_root"],
+    },
+  },
   tick(ctx) {
     return {
       action: "agent",
       prompt: [
         "Run the migrated launchd job 'family-morning-briefing.yohoejang' for routine_id=" +
           ctx.routine.id,
-        "Invoke the existing shell pipeline exactly as launchd does:",
-        "  /Users/itismyfield/.adk/release/scripts/launchd-migrated/family-morning-briefing-yohoejang.sh",
+        "Resolve the release root from AGENTDESK_ROOT_DIR, or ~/.adk/release if unset.",
+        "Invoke this root-relative shell pipeline exactly as launchd does:",
+        "  scripts/launchd-migrated/family-morning-briefing-yohoejang.sh",
         "Preserve the original prompt body, target channel, weather/calendar/reminders",
         "skill path, and Discord destination unchanged.",
         "Return a one-line status summary (success | NO_REPLY | error: <msg>).",

--- a/routines/migrated-launchd/memento-daily-report.js
+++ b/routines/migrated-launchd/memento-daily-report.js
@@ -1,7 +1,7 @@
 // Migrated from launchd: com.itismyfield.memento-daily-report
 // Original shell script: ~/.local/bin/memento-daily-report.sh
 // Repo-deployed shell script:
-//   /Users/itismyfield/.adk/release/scripts/launchd-migrated/memento-daily-report.sh
+//   scripts/launchd-migrated/memento-daily-report.sh (below AGENTDESK_ROOT_DIR)
 // Schedule: 0 9 * * * (KST, 09:00 daily)
 // Agent: personal-obiseo
 //
@@ -29,10 +29,10 @@ agentdesk.routines.register({
       prompt: [
         "Run the migrated launchd job 'memento-daily-report' for routine_id=" +
           ctx.routine.id,
-        "Invoke the existing shell pipeline exactly as launchd does:",
-        "  /Users/itismyfield/.adk/release/scripts/launchd-migrated/memento-daily-report.sh",
-        "Working directory matches the original launchd job:",
-        "  /Users/itismyfield/.adk/release/workspaces/agentfactory",
+        "Resolve the release root from AGENTDESK_ROOT_DIR, or ~/.adk/release if unset.",
+        "Invoke this root-relative shell pipeline exactly as launchd does:",
+        "  scripts/launchd-migrated/memento-daily-report.sh",
+        "Use AGENTDESK_MIGRATED_AGENTFACTORY_WORKDIR when set; otherwise use AGENTDESK_ROOT_DIR + '/workspaces/agentfactory'.",
         "Return a one-line status summary (success | NO_REPLY | error: <msg>).",
       ].join("\n"),
     };

--- a/routines/migrated-launchd/memento-hygiene.js
+++ b/routines/migrated-launchd/memento-hygiene.js
@@ -1,7 +1,7 @@
 // Migrated from launchd: com.itismyfield.memento-hygiene
 // Original shell script: ~/.local/bin/memento-hygiene.sh
 // Repo-deployed shell script:
-//   /Users/itismyfield/.adk/release/scripts/launchd-migrated/memento-hygiene.sh
+//   scripts/launchd-migrated/memento-hygiene.sh (below AGENTDESK_ROOT_DIR)
 // Schedule: 0 6 * * * (KST, 06:00 daily)
 // Agent: personal-obiseo
 //
@@ -29,10 +29,10 @@ agentdesk.routines.register({
       prompt: [
         "Run the migrated launchd job 'memento-hygiene' for routine_id=" +
           ctx.routine.id,
-        "Invoke the existing shell pipeline exactly as launchd does:",
-        "  /Users/itismyfield/.adk/release/scripts/launchd-migrated/memento-hygiene.sh",
-        "Working directory matches the original launchd job:",
-        "  /Users/itismyfield/.adk/release/workspaces/agentfactory",
+        "Resolve the release root from AGENTDESK_ROOT_DIR, or ~/.adk/release if unset.",
+        "Invoke this root-relative shell pipeline exactly as launchd does:",
+        "  scripts/launchd-migrated/memento-hygiene.sh",
+        "Use AGENTDESK_MIGRATED_AGENTFACTORY_WORKDIR when set; otherwise use AGENTDESK_ROOT_DIR + '/workspaces/agentfactory'.",
         "Return a one-line status summary (success | NO_REPLY | error: <msg>).",
       ].join("\n"),
     };

--- a/routines/migrated-launchd/memory-merge.js
+++ b/routines/migrated-launchd/memory-merge.js
@@ -1,7 +1,7 @@
 // Migrated from launchd: com.itismyfield.memory-merge
 // Original shell script: ~/.local/bin/memory-merge.sh
 // Repo-deployed shell script:
-//   /Users/itismyfield/.adk/release/scripts/launchd-migrated/memory-merge.sh
+//   scripts/launchd-migrated/memory-merge.sh (below AGENTDESK_ROOT_DIR)
 // Schedule: 0 6 * * * (KST, 06:00 daily)
 // Agent: project-agentdesk
 //
@@ -18,7 +18,7 @@
 // Do NOT POST with "schedule" included on attach.
 //
 // The original launchd job sets AGENTDESK_MEMORY_MERGE_SKILL=
-//   /Users/itismyfield/.adk/release/skills/memory-merge/SKILL.md
+//   $AGENTDESK_ROOT_DIR/skills/memory-merge/SKILL.md
 // The shell script must read this env var or fall back to the default skill
 // path. Verify the script handles a missing env var before flipping the
 // routine to status=enabled. If the script requires the env var, set it via
@@ -36,12 +36,12 @@ agentdesk.routines.register({
       prompt: [
         "Run the migrated launchd job 'memory-merge' for routine_id=" +
           ctx.routine.id,
-        "Invoke the existing shell pipeline exactly as launchd does:",
-        "  /Users/itismyfield/.adk/release/scripts/launchd-migrated/memory-merge.sh",
-        "Working directory matches the original launchd job:",
-        "  /Users/itismyfield/.adk/release/workspaces/agentfactory",
+        "Resolve the release root from AGENTDESK_ROOT_DIR, or ~/.adk/release if unset.",
+        "Invoke this root-relative shell pipeline exactly as launchd does:",
+        "  scripts/launchd-migrated/memory-merge.sh",
+        "Use AGENTDESK_MIGRATED_AGENTFACTORY_WORKDIR when set; otherwise use AGENTDESK_ROOT_DIR + '/workspaces/agentfactory'.",
         "Ensure env var AGENTDESK_MEMORY_MERGE_SKILL points to the memory-merge",
-        "SKILL.md (default: /Users/itismyfield/.adk/release/skills/memory-merge/SKILL.md).",
+        "SKILL.md if the root-relative default is not correct.",
         "Return a one-line status summary (success | NO_REPLY | error: <msg>).",
       ].join("\n"),
     };

--- a/routines/migrated-launchd/queue-stability-batch.js
+++ b/routines/migrated-launchd/queue-stability-batch.js
@@ -22,14 +22,20 @@
 // PARALLEL-RUN SAFETY: launchd plist remains active during verification.
 agentdesk.routines.register({
   name: "queue-stability-batch",
+  metadata: {
+    migrated_launchd: {
+      entrypoint: "scripts/queue-stability-batch.sh",
+    },
+  },
   tick(ctx) {
     return {
       action: "agent",
       prompt: [
         "Run the migrated launchd job 'queue-stability-batch' for routine_id=" +
           ctx.routine.id,
-        "Invoke the existing shell entrypoint exactly as launchd does:",
-        "  /Users/itismyfield/.adk/release/workspaces/agentdesk/scripts/queue-stability-batch.sh",
+        "Resolve the AgentDesk workspace from AGENTDESK_QUEUE_STABILITY_WORKDIR,",
+        "or AGENTDESK_ROOT_DIR + '/workspaces/agentdesk' if unset.",
+        "Invoke scripts/queue-stability-batch.sh from that workspace exactly as launchd does.",
         "The script is idempotent (skips if a run is active/pending/paused);",
         "do not bypass that guard.",
         "Return a one-line status summary (success | skipped: <reason> | error: <msg>).",

--- a/routines/migrated-launchd/token-daily-report.js
+++ b/routines/migrated-launchd/token-daily-report.js
@@ -27,8 +27,9 @@ agentdesk.routines.register({
       prompt: [
         "Run the migrated launchd job 'token-daily-report' for routine_id=" +
           ctx.routine.id,
-        "Invoke the existing shell pipeline exactly as launchd does:",
-        "  /Users/itismyfield/.adk/release/scripts/launchd-migrated/token-daily-report.sh",
+        "Resolve the release root from AGENTDESK_ROOT_DIR, or ~/.adk/release if unset.",
+        "Invoke this root-relative shell pipeline exactly as launchd does:",
+        "  scripts/launchd-migrated/token-daily-report.sh",
         "Return a one-line status summary (success | NO_REPLY | error: <msg>).",
       ].join("\n"),
     };

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -188,6 +188,14 @@ if [ -d "scripts/launchd-migrated" ]; then
   fi
 fi
 
+# Root-level shell entrypoints referenced by bundled migrated routines.
+if [ -f "scripts/queue-stability-batch.sh" ]; then
+  mkdir -p "$STAGING/scripts"
+  cp "scripts/_defaults.sh" "$STAGING/scripts/_defaults.sh"
+  cp "scripts/queue-stability-batch.sh" "$STAGING/scripts/queue-stability-batch.sh"
+  chmod +x "$STAGING/scripts/queue-stability-batch.sh"
+fi
+
 # Managed skills
 if [ -d "skills" ]; then
   mkdir -p "$STAGING/skills"

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -65,6 +65,7 @@ DASHBOARD_SOURCE=""
 STAGED_BINARY=""
 POLICIES_STAGED=""
 LAUNCHD_MIGRATED_STAGED=""
+RELEASE_ROOT_SCRIPTS_STAGED=""
 DEPLOY_ALL_NODES="${AGENTDESK_DEPLOY_ALL_NODES:-0}"
 DEPLOY_PEERS_OVERRIDE=()
 DEPLOY_PEERS_FILE="${AGENTDESK_DEPLOY_PEERS_FILE:-$ADK_REL/config/deploy-peers.txt}"
@@ -565,6 +566,9 @@ _cleanup_on_exit() {
     if [ -n "${LAUNCHD_MIGRATED_STAGED:-}" ] && [ -d "$LAUNCHD_MIGRATED_STAGED" ]; then
         rm -rf "$LAUNCHD_MIGRATED_STAGED" 2>/dev/null || true
     fi
+    if [ -n "${RELEASE_ROOT_SCRIPTS_STAGED:-}" ] && [ -d "$RELEASE_ROOT_SCRIPTS_STAGED" ]; then
+        rm -rf "$RELEASE_ROOT_SCRIPTS_STAGED" 2>/dev/null || true
+    fi
     if [ -n "${DEPLOY_MKDIR_LOCK_DIR:-}" ] && [ -d "$DEPLOY_MKDIR_LOCK_DIR" ]; then
         rm -rf "$DEPLOY_MKDIR_LOCK_DIR" 2>/dev/null || true
     fi
@@ -932,7 +936,11 @@ cp -r "$DASHBOARD_SOURCE" "$DIST_STAGED"
 # Stage agent prompt files atomically (source-of-truth: Obsidian vault, private).
 # Agent prompts contain operator-specific content and are NOT tracked in this repo.
 # See docs/source-of-truth.md.
-OBSIDIAN_AGENTS_SRC="${AGENTDESK_OBSIDIAN_AGENTS_SRC:-${OBSIDIAN_VAULT_ROOT:-$HOME/ObsidianVault}/RemoteVault/adk-config/agents}"
+OBSIDIAN_DEFAULT_VAULT_ROOT="$HOME/ObsidianVault"
+if [ -d "$ADK_REL/ObsidianVault" ]; then
+    OBSIDIAN_DEFAULT_VAULT_ROOT="$ADK_REL/ObsidianVault"
+fi
+OBSIDIAN_AGENTS_SRC="${AGENTDESK_OBSIDIAN_AGENTS_SRC:-${OBSIDIAN_VAULT_ROOT:-$OBSIDIAN_DEFAULT_VAULT_ROOT}/RemoteVault/adk-config/agents}"
 if [ -d "$OBSIDIAN_AGENTS_SRC" ]; then
     echo "▸ Staging agent prompts from Obsidian vault..."
     PROMPTS_STAGED="$ADK_REL/config/agents.new"
@@ -940,8 +948,14 @@ if [ -d "$OBSIDIAN_AGENTS_SRC" ]; then
     mkdir -p "$PROMPTS_STAGED"
     rsync -a "$OBSIDIAN_AGENTS_SRC/" "$PROMPTS_STAGED/"
 else
-    echo "⚠ Obsidian agent prompt source missing: $OBSIDIAN_AGENTS_SRC"
-    echo "  Skipping prompt staging — existing $ADK_REL/config/agents/ will be retained."
+    if [ -n "${AGENTDESK_OBSIDIAN_AGENTS_SRC:-}" ]; then
+        echo "⚠ Optional connector obsidian_agent_prompts invalid: $OBSIDIAN_AGENTS_SRC"
+        echo "  state=missing_path reason=missing_path; core release deploy will continue."
+    else
+        echo "ℹ Optional connector obsidian_agent_prompts skipped: $OBSIDIAN_AGENTS_SRC"
+        echo "  state=missing_config reason=missing_config; core release deploy will continue."
+    fi
+    echo "  Existing $ADK_REL/config/agents/ will be retained."
 fi
 
 # Stage managed skills before stopping release so skill sync never sees partial content.
@@ -983,6 +997,22 @@ if [ -d "$REPO/scripts/launchd-migrated" ]; then
 else
     echo "⚠ Launchd-migrated entrypoint source missing: $REPO/scripts/launchd-migrated"
     echo "  Skipping launchd-migrated entrypoint staging — existing $ADK_REL/scripts/launchd-migrated/ will be retained."
+fi
+
+# Stage release-owned root shell entrypoints referenced by bundled migrated
+# routines. queue-stability-batch.sh sources _defaults.sh from the same
+# directory, so deploy both files together.
+if [ -f "$REPO/scripts/queue-stability-batch.sh" ]; then
+    echo "▸ Staging release root script entrypoints..."
+    RELEASE_ROOT_SCRIPTS_STAGED="$ADK_REL/scripts.root.new"
+    rm -rf "$RELEASE_ROOT_SCRIPTS_STAGED"
+    mkdir -p "$RELEASE_ROOT_SCRIPTS_STAGED"
+    cp "$REPO/scripts/_defaults.sh" "$RELEASE_ROOT_SCRIPTS_STAGED/_defaults.sh"
+    cp "$REPO/scripts/queue-stability-batch.sh" "$RELEASE_ROOT_SCRIPTS_STAGED/queue-stability-batch.sh"
+    chmod +x "$RELEASE_ROOT_SCRIPTS_STAGED/queue-stability-batch.sh"
+else
+    echo "⚠ Queue stability entrypoint source missing: $REPO/scripts/queue-stability-batch.sh"
+    echo "  Skipping queue stability entrypoint staging — existing $ADK_REL/scripts/queue-stability-batch.sh will be retained."
 fi
 
 # Wait for active turns to finish before stopping the server.
@@ -1188,6 +1218,15 @@ if [ -n "${LAUNCHD_MIGRATED_STAGED:-}" ] && [ -d "$LAUNCHD_MIGRATED_STAGED" ]; t
     mv "$LAUNCHD_MIGRATED_STAGED" "$ADK_REL/scripts/launchd-migrated"
     LAUNCHD_MIGRATED_STAGED=""
     rm -rf "$ADK_REL/scripts/launchd-migrated.old"
+fi
+
+if [ -n "${RELEASE_ROOT_SCRIPTS_STAGED:-}" ] && [ -d "$RELEASE_ROOT_SCRIPTS_STAGED" ]; then
+    mkdir -p "$ADK_REL/scripts"
+    mv -f "$RELEASE_ROOT_SCRIPTS_STAGED/_defaults.sh" "$ADK_REL/scripts/_defaults.sh"
+    mv -f "$RELEASE_ROOT_SCRIPTS_STAGED/queue-stability-batch.sh" "$ADK_REL/scripts/queue-stability-batch.sh"
+    chmod +x "$ADK_REL/scripts/queue-stability-batch.sh"
+    rm -rf "$RELEASE_ROOT_SCRIPTS_STAGED"
+    RELEASE_ROOT_SCRIPTS_STAGED=""
 fi
 
 if [ -n "${PROMPTS_STAGED:-}" ] && [ -d "$PROMPTS_STAGED" ]; then

--- a/scripts/launchd-migrated/agent-feedback-briefing.sh
+++ b/scripts/launchd-migrated/agent-feedback-briefing.sh
@@ -5,12 +5,18 @@ NOW_KST="$(TZ=Asia/Seoul date '+%Y-%m-%d %H:%M:%S %Z')"
 PROMPT_FILE="$(mktemp)"
 trap 'rm -f "$PROMPT_FILE"' EXIT
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/launchd-migrated/_portable-resolver.sh
+source "$SCRIPT_DIR/_portable-resolver.sh"
+agentdesk_source_portable_resolver
+agentdesk_optional_dir_or_skip "agent feedback inbox" "$AGENTDESK_AGENT_FEEDBACK_INBOX"
+
 cat >"$PROMPT_FILE" <<EOF
 에이전트 피드백 브리핑을 실행한다.
 현재 시각: $NOW_KST
 
 절차:
-1. /Users/itismyfield/ObsidianVault/RemoteVault/agents/ch-pmd/inbox/ 디렉토리의 모든 .md 파일을 읽는다
+1. $AGENTDESK_AGENT_FEEDBACK_INBOX 디렉토리의 모든 .md 파일을 읽는다
 2. pending 상태인 항목을 모두 수집한다 (오늘 + 과거 미결)
 3. 접수건이 0건이면 NO_REPLY를 반환한다
 4. 1건 이상이면 아래 포맷으로 브리핑을 작성한다:
@@ -43,7 +49,6 @@ Rules:
 - <@1479017284805722200> is the user mention — always include at the top.
 EOF
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec "$SCRIPT_DIR/run-claude-message-job.sh" \
   --source "agent-feedback-briefing" \
   --target "channel:1478652416533463101" \

--- a/scripts/launchd-migrated/ai-integrated-briefing.sh
+++ b/scripts/launchd-migrated/ai-integrated-briefing.sh
@@ -5,8 +5,15 @@ NOW_KST="$(TZ=Asia/Seoul date '+%Y-%m-%d %H:%M:%S %Z')"
 PROMPT_FILE="$(mktemp)"
 trap 'rm -f "$PROMPT_FILE"' EXIT
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/launchd-migrated/_portable-resolver.sh
+source "$SCRIPT_DIR/_portable-resolver.sh"
+agentdesk_source_portable_resolver
+SKILL_PATH="$(agentdesk_obsidian_skill_path "ai-integrated-briefing")"
+agentdesk_optional_file_or_skip "ai-integrated-briefing skill" "$SKILL_PATH"
+
 cat >"$PROMPT_FILE" <<EOF
-Read and follow /Users/itismyfield/ObsidianVault/RemoteVault/99_Skills/ai-integrated-briefing/SKILL.md exactly.
+Read and follow $SKILL_PATH exactly.
 
 current time: $NOW_KST
 
@@ -21,7 +28,6 @@ Rules:
 - Do not wrap the final answer in code fences.
 EOF
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec "$SCRIPT_DIR/run-claude-message-job.sh" \
   --search \
   --source "ai-integrated-briefing" \

--- a/scripts/launchd-migrated/banchan-day-reminder-cook.sh
+++ b/scripts/launchd-migrated/banchan-day-reminder-cook.sh
@@ -5,10 +5,19 @@ NOW_KST="$(TZ=Asia/Seoul date '+%Y-%m-%d %H:%M:%S %Z')"
 PROMPT_FILE="$(mktemp)"
 trap 'rm -f "$PROMPT_FILE"' EXIT
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/launchd-migrated/_portable-resolver.sh
+source "$SCRIPT_DIR/_portable-resolver.sh"
+agentdesk_source_portable_resolver
+SKILL_PATH="$(agentdesk_obsidian_skill_path "banchan-day-reminder")"
+MESSAGES_PATH="$AGENTDESK_OBSIDIAN_SKILL_ROOT/banchan-day-reminder/references/messages.md"
+agentdesk_optional_file_or_skip "banchan-day-reminder skill" "$SKILL_PATH"
+agentdesk_optional_file_or_skip "banchan-day-reminder messages" "$MESSAGES_PATH"
+
 cat >"$PROMPT_FILE" <<EOF
 Read and follow these files exactly:
-- /Users/itismyfield/ObsidianVault/RemoteVault/99_Skills/banchan-day-reminder/SKILL.md
-- /Users/itismyfield/ObsidianVault/RemoteVault/99_Skills/banchan-day-reminder/references/messages.md
+- $SKILL_PATH
+- $MESSAGES_PATH
 
 mode: cook
 target channel: 1473922824350601297
@@ -23,7 +32,6 @@ Rules:
 - Do not wrap the final answer in code fences.
 EOF
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec "$SCRIPT_DIR/run-claude-message-job.sh" \
   --source "banchan-day-reminder:cook" \
   --target "channel:1473922824350601297" \

--- a/scripts/launchd-migrated/banchan-day-reminder-prep.sh
+++ b/scripts/launchd-migrated/banchan-day-reminder-prep.sh
@@ -5,10 +5,19 @@ NOW_KST="$(TZ=Asia/Seoul date '+%Y-%m-%d %H:%M:%S %Z')"
 PROMPT_FILE="$(mktemp)"
 trap 'rm -f "$PROMPT_FILE"' EXIT
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/launchd-migrated/_portable-resolver.sh
+source "$SCRIPT_DIR/_portable-resolver.sh"
+agentdesk_source_portable_resolver
+SKILL_PATH="$(agentdesk_obsidian_skill_path "banchan-day-reminder")"
+MESSAGES_PATH="$AGENTDESK_OBSIDIAN_SKILL_ROOT/banchan-day-reminder/references/messages.md"
+agentdesk_optional_file_or_skip "banchan-day-reminder skill" "$SKILL_PATH"
+agentdesk_optional_file_or_skip "banchan-day-reminder messages" "$MESSAGES_PATH"
+
 cat >"$PROMPT_FILE" <<EOF
 Read and follow these files exactly:
-- /Users/itismyfield/ObsidianVault/RemoteVault/99_Skills/banchan-day-reminder/SKILL.md
-- /Users/itismyfield/ObsidianVault/RemoteVault/99_Skills/banchan-day-reminder/references/messages.md
+- $SKILL_PATH
+- $MESSAGES_PATH
 
 mode: prep
 target channel: 1473922824350601297
@@ -23,7 +32,6 @@ Rules:
 - Do not wrap the final answer in code fences.
 EOF
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec "$SCRIPT_DIR/run-claude-message-job.sh" \
   --source "banchan-day-reminder:prep" \
   --target "channel:1473922824350601297" \

--- a/scripts/launchd-migrated/cookingheart-daily-briefing.sh
+++ b/scripts/launchd-migrated/cookingheart-daily-briefing.sh
@@ -5,8 +5,15 @@ NOW_KST="$(TZ=Asia/Seoul date '+%Y-%m-%d %H:%M:%S %Z')"
 PROMPT_FILE="$(mktemp)"
 trap 'rm -f "$PROMPT_FILE"' EXIT
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/launchd-migrated/_portable-resolver.sh
+source "$SCRIPT_DIR/_portable-resolver.sh"
+agentdesk_source_portable_resolver
+SKILL_PATH="$(agentdesk_obsidian_skill_path "cookingheart-daily-briefing")"
+agentdesk_optional_file_or_skip "cookingheart-daily-briefing skill" "$SKILL_PATH"
+
 cat >"$PROMPT_FILE" <<EOF
-Read and follow /Users/itismyfield/ObsidianVault/RemoteVault/99_Skills/cookingheart-daily-briefing/SKILL.md exactly.
+Read and follow $SKILL_PATH exactly.
 
 current time: $NOW_KST
 
@@ -19,7 +26,6 @@ Rules:
 - Do not wrap the final answer in code fences.
 EOF
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec "$SCRIPT_DIR/run-claude-message-job.sh" \
   --source "cookingheart-daily-briefing" \
   --target "channel:1479644764294086877" \

--- a/scripts/launchd-migrated/family-morning-briefing-obujang.sh
+++ b/scripts/launchd-migrated/family-morning-briefing-obujang.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
 set -euo pipefail
 
-export HOME=/Users/itismyfield
-export PATH=/Users/itismyfield/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/launchd-migrated/_portable-resolver.sh
+source "$SCRIPT_DIR/_portable-resolver.sh"
+agentdesk_source_portable_resolver
 
 NOW_KST="$(TZ=Asia/Seoul date '+%Y-%m-%d %H:%M:%S %Z')"
 TODAY_FROM="$(TZ=Asia/Seoul date '+%Y-%m-%d')T00:00:00+09:00"
 TOMORROW_FROM="$(TZ=Asia/Seoul date -v+1d '+%Y-%m-%d')T00:00:00+09:00"
 
-SCRIPTS_DIR="$HOME/ObsidianVault/RemoteVault/99_Skills/family-morning-briefing/scripts"
+SCRIPTS_DIR="$AGENTDESK_OBSIDIAN_SKILL_ROOT/family-morning-briefing/scripts"
 DATA_DIR="$(mktemp -d)"
 PROMPT_FILE="$(mktemp)"
 trap 'rm -rf "$DATA_DIR" "$PROMPT_FILE"' EXIT
+agentdesk_optional_dir_or_skip "family-morning-briefing scripts" "$SCRIPTS_DIR"
 
 # 1. Weather + AQI
 python3 "$SCRIPTS_DIR/daily_ai_briefing_data.py" \

--- a/scripts/launchd-migrated/family-morning-briefing-yohoejang.sh
+++ b/scripts/launchd-migrated/family-morning-briefing-yohoejang.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
 set -euo pipefail
 
-export HOME=/Users/itismyfield
-export PATH=/Users/itismyfield/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/launchd-migrated/_portable-resolver.sh
+source "$SCRIPT_DIR/_portable-resolver.sh"
+agentdesk_source_portable_resolver
 
 NOW_KST="$(TZ=Asia/Seoul date '+%Y-%m-%d %H:%M:%S %Z')"
 TODAY_FROM="$(TZ=Asia/Seoul date '+%Y-%m-%d')T00:00:00+09:00"
 TOMORROW_FROM="$(TZ=Asia/Seoul date -v+1d '+%Y-%m-%d')T00:00:00+09:00"
 
-SCRIPTS_DIR="$HOME/ObsidianVault/RemoteVault/99_Skills/family-morning-briefing/scripts"
+SCRIPTS_DIR="$AGENTDESK_OBSIDIAN_SKILL_ROOT/family-morning-briefing/scripts"
 DATA_DIR="$(mktemp -d)"
 PROMPT_FILE="$(mktemp)"
 trap 'rm -rf "$DATA_DIR" "$PROMPT_FILE"' EXIT
+agentdesk_optional_dir_or_skip "family-morning-briefing scripts" "$SCRIPTS_DIR"
 
 # 1. Weather + AQI
 python3 "$SCRIPTS_DIR/daily_ai_briefing_data.py" \

--- a/scripts/launchd-migrated/memento-daily-report.sh
+++ b/scripts/launchd-migrated/memento-daily-report.sh
@@ -5,6 +5,11 @@ NOW_KST="$(TZ=Asia/Seoul date '+%Y-%m-%d %H:%M:%S %Z')"
 PROMPT_FILE="$(mktemp)"
 trap 'rm -f "$PROMPT_FILE"' EXIT
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/launchd-migrated/_portable-resolver.sh
+source "$SCRIPT_DIR/_portable-resolver.sh"
+agentdesk_source_portable_resolver
+
 cat >"$PROMPT_FILE" <<PROMPT
 Memento 일일 리포트를 생성한다. 현재 시각: $NOW_KST
 
@@ -39,9 +44,8 @@ Memento 일일 리포트를 생성한다. 현재 시각: $NOW_KST
 반드시 위 포맷 그대로 Discord 메시지로 반환. NO_REPLY 금지 — 항상 리포트를 생성한다.
 PROMPT
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec "$SCRIPT_DIR/run-claude-message-job.sh" \
   --source "memento-daily-report" \
   --target "channel:1480015244062490774" \
-  --workdir "/Users/itismyfield/.adk/release/workspaces/agentfactory" \
+  --workdir "$AGENTDESK_MIGRATED_AGENTFACTORY_WORKDIR" \
   --prompt-file "$PROMPT_FILE"

--- a/scripts/launchd-migrated/memento-hygiene.sh
+++ b/scripts/launchd-migrated/memento-hygiene.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 PROMPT_FILE="$(mktemp)"
 trap 'rm -f "$PROMPT_FILE"' EXIT
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/launchd-migrated/_portable-resolver.sh
+source "$SCRIPT_DIR/_portable-resolver.sh"
+agentdesk_source_portable_resolver
+
 cat >"$PROMPT_FILE" <<'PROMPT'
 Memento 위생 관리 작업을 수행한다. 아래 3단계를 순서대로 실행.
 
@@ -84,9 +89,8 @@ Discord 메시지로 아래 포맷의 한국어 요약을 반환:
 내용이 없으면 NO_REPLY를 반환.
 PROMPT
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec "$SCRIPT_DIR/run-claude-message-job.sh" \
   --source "memento-hygiene" \
   --target "channel:1480015244062490774" \
-  --workdir "/Users/itismyfield/.adk/release/workspaces/agentfactory" \
+  --workdir "$AGENTDESK_MIGRATED_AGENTFACTORY_WORKDIR" \
   --prompt-file "$PROMPT_FILE"

--- a/scripts/launchd-migrated/memory-merge.sh
+++ b/scripts/launchd-migrated/memory-merge.sh
@@ -5,7 +5,12 @@ NOW_KST="$(TZ=Asia/Seoul date '+%Y-%m-%d %H:%M:%S %Z')"
 PROMPT_FILE="$(mktemp)"
 trap 'rm -f "$PROMPT_FILE"' EXIT
 
-DEFAULT_MANAGED_SKILL="$HOME/.adk/release/skills/memory-merge/SKILL.md"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/launchd-migrated/_portable-resolver.sh
+source "$SCRIPT_DIR/_portable-resolver.sh"
+agentdesk_source_portable_resolver
+
+DEFAULT_MANAGED_SKILL="$AGENTDESK_ROOT_DIR/skills/memory-merge/SKILL.md"
 SKILL_PATH="${AGENTDESK_MEMORY_MERGE_SKILL:-$DEFAULT_MANAGED_SKILL}"
 
 if [[ -n "${AGENTDESK_MEMORY_MERGE_SKILL:-}" && ! -f "$SKILL_PATH" ]]; then
@@ -30,9 +35,8 @@ Rules:
 - Do not wrap the final answer in code fences.
 EOF
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec "$SCRIPT_DIR/run-claude-message-job.sh" \
   --source "memory-merge" \
   --target "channel:1480015244062490774" \
-  --workdir "/Users/itismyfield/.adk/release/workspaces/agentfactory" \
+  --workdir "$AGENTDESK_MIGRATED_AGENTFACTORY_WORKDIR" \
   --prompt-file "$PROMPT_FILE"

--- a/scripts/launchd-migrated/run-claude-message-job.sh
+++ b/scripts/launchd-migrated/run-claude-message-job.sh
@@ -1,17 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
-export HOME=/Users/itismyfield
-export PATH=/Users/itismyfield/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH
-export LANG=ko_KR.UTF-8
-export LC_ALL=ko_KR.UTF-8
-# shellcheck source=/dev/null
-[[ -f "$HOME/.zprofile" ]] && source "$HOME/.zprofile"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/launchd-migrated/_portable-resolver.sh
+source "$SCRIPT_DIR/_portable-resolver.sh"
+agentdesk_source_portable_resolver
 
 TARGET=""
 SOURCE=""
 PROMPT_FILE=""
-WORKDIR="/Users/itismyfield"
+WORKDIR="$AGENTDESK_OPERATOR_WORKDIR"
 DRY_RUN=0
 # Accepted for compatibility with existing launchd entrypoints.
 # shellcheck disable=SC2034

--- a/scripts/launchd-migrated/token-daily-report.sh
+++ b/scripts/launchd-migrated/token-daily-report.sh
@@ -1,18 +1,16 @@
 #!/bin/bash
 set -euo pipefail
-export HOME=/Users/itismyfield
-export PATH=/Users/itismyfield/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH
-export LANG=ko_KR.UTF-8
-export LC_ALL=ko_KR.UTF-8
-# shellcheck source=/dev/null
-[[ -f "$HOME/.zprofile" ]] && source "$HOME/.zprofile"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/launchd-migrated/_portable-resolver.sh
+source "$SCRIPT_DIR/_portable-resolver.sh"
+agentdesk_source_portable_resolver
 
 NOW_KST="$(TZ=Asia/Seoul date '+%Y-%m-%d %H:%M:%S %Z')"
 TOKEN_MANAGER_CHANNEL="1481478222439907560"
 OUTPUT_FILE="$(mktemp "${TMPDIR:-/tmp}/token-daily-report-output.XXXXXX")"
 
 # Step 1: Python으로 원시 데이터 수집
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RAW_DATA="$(/usr/bin/python3 "$SCRIPT_DIR/token-daily-report.py" --raw-json)"
 
 PROMPT_FILE="$(mktemp)"
@@ -54,7 +52,7 @@ CRITICAL OUTPUT INSTRUCTION:
 PROMPT
 
 set +e
-cd "$HOME" && claude -p \
+cd "$AGENTDESK_OPERATOR_WORKDIR" && claude -p \
   --model sonnet \
   --permission-mode bypassPermissions \
   --output-format text \

--- a/tests/test_launchd_migrated_entrypoints.py
+++ b/tests/test_launchd_migrated_entrypoints.py
@@ -5,9 +5,7 @@ import unittest
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ROUTINE_DIR = REPO_ROOT / "routines" / "migrated-launchd"
 ENTRYPOINT_DIR = REPO_ROOT / "scripts" / "launchd-migrated"
-RELEASE_ENTRYPOINT_DIR = "/Users/itismyfield/.adk/release/scripts/launchd-migrated"
-
-LOCAL_BIN = "/Users/itismyfield/.local/bin"
+SPECIFIC_USER_HOME = "/Users/itismyfield"
 
 MIGRATED_SHELL_JOBS = [
     "agent-feedback-briefing",
@@ -39,17 +37,18 @@ class LaunchdMigratedEntrypointTests(unittest.TestCase):
             text = routine.read_text(encoding="utf-8")
 
             self.assertTrue(script.exists(), f"missing repo entrypoint for {name}")
-            self.assertIn(f"{RELEASE_ENTRYPOINT_DIR}/{name}.sh", text)
-            self.assertNotIn(LOCAL_BIN, text)
+            self.assertIn(f"scripts/launchd-migrated/{name}.sh", text)
+            self.assertIn("AGENTDESK_ROOT_DIR", text)
+            self.assertNotIn(SPECIFIC_USER_HOME, text)
 
     def test_migrated_entrypoints_do_not_call_local_bin_helpers(self) -> None:
         for path in ENTRYPOINT_DIR.iterdir():
             if path.is_file():
                 text = path.read_text(encoding="utf-8")
                 self.assertNotIn(
-                    LOCAL_BIN,
+                    SPECIFIC_USER_HOME,
                     text,
-                    f"{path.name} still depends on host-local bin",
+                    f"{path.name} still depends on an operator-specific home path",
                 )
 
     def test_issue_2396_memory_jobs_have_concrete_owners(self) -> None:
@@ -75,6 +74,16 @@ class LaunchdMigratedEntrypointTests(unittest.TestCase):
 
         self.assertTrue((ENTRYPOINT_DIR / "token-daily-report.py").exists())
         self.assertIn("$SCRIPT_DIR/token-daily-report.py", token_shell)
+
+    def test_queue_stability_entrypoint_is_release_packaged(self) -> None:
+        self.assertTrue((REPO_ROOT / "scripts" / "queue-stability-batch.sh").exists())
+        for path in (
+            REPO_ROOT / "scripts" / "build-release.sh",
+            REPO_ROOT / "scripts" / "deploy-release.sh",
+        ):
+            text = path.read_text(encoding="utf-8")
+            self.assertIn("queue-stability-batch.sh", text)
+            self.assertIn("_defaults.sh", text)
 
     def test_output_files_use_unique_tmp_paths(self) -> None:
         helper = (ENTRYPOINT_DIR / "run-claude-message-job.sh").read_text(


### PR DESCRIPTION
## 목표

migrated launchd routine entrypoint가 특정 운영자 홈 디렉터리(`/Users/itismyfield`)에 묶이지 않도록 release root와 optional connector 경로를 런타임 환경변수로 해석하게 합니다.

## 쉬운 설명

새 Mac 사용자는 기존 운영자와 같은 홈 경로를 만들 필요가 없습니다. release helper는 `AGENTDESK_ROOT_DIR` 또는 `~/.adk/release`를 기준으로 자기 위치를 찾고, Obsidian/feedback inbox 같은 개인 connector가 없으면 core 작업을 실패시키지 않고 skip합니다. queue stability처럼 release root 바깥 스크립트를 참조하던 routine도 build/deploy 산출물에 함께 포함됩니다.

## 개선되는 것

### Fix 1

migrated launchd shell helper에서 하드코딩된 `HOME`, `PATH`, Obsidian skill path, workdir을 제거하고 `_portable-resolver.sh`의 `AGENTDESK_*` / `OBSIDIAN_*` env 해석을 사용합니다.

### Fix 2

routine prompt가 절대 경로 대신 repo/release 상대 경로와 설정 가능한 env 이름을 안내합니다.

### Fix 3

`scripts/queue-stability-batch.sh`와 `_defaults.sh`를 release build/deploy 산출물에 포함해 bundled routine prompt가 실제 배포 파일을 가리키게 합니다.

## Before → After

| 시나리오 | Before | After |
|---|---|---|
| 새 Mac 사용자 홈 경로 | `/Users/itismyfield/...` 전제가 prompt/script에 남음 | `${AGENTDESK_ROOT_DIR:-$HOME/.adk/release}` 기준으로 해석 |
| Obsidian skill/inbox 없음 | 개인 경로가 없으면 helper가 실패하기 쉬움 | optional connector로 skip 메시지를 내고 core deploy는 계속 진행 |
| queue stability routine | prompt가 repo workdir 내부 스크립트를 가리키지만 release packaging 보장이 없음 | release artifact/deploy에 root script entrypoint 포함 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
|---|---|---|
| 기존 운영자 env 미설정 | 기본값은 `~/.adk/release`와 기존 vault 위치를 사용 | 기존 설치 동작 보존 |
| 새 Mac에 Obsidian vault 없음 | optional connector skipped/invalid 안내 후 기존 config 유지 | core deploy 실패로 번지지 않음 |
| custom release root 사용 | `AGENTDESK_ROOT_DIR` 기준으로 helper/workdir 계산 | portable root 설치와 호환 |

## 해결한 내용

- `scripts/launchd-migrated/*.sh`: `_portable-resolver.sh`를 통해 release root, workdir, optional Obsidian/feedback 경로를 해석합니다.
- `routines/migrated-launchd/*.js`: agent prompt의 절대 경로 안내를 release-relative/env 기반 안내로 바꿉니다.
- `scripts/build-release.sh`, `scripts/deploy-release.sh`: queue stability entrypoint와 `_defaults.sh`를 release 산출물에 포함합니다.
- `docs/launchd-to-routine-migration-plan.md`: migrated entrypoint 위치 문서를 portable root 기준으로 갱신합니다.
- `tests/test_launchd_migrated_entrypoints.py`: 특정 운영자 홈 경로 회귀와 queue stability packaging 회귀를 잡습니다.

## 검증

- `python3 -m pytest tests/test_launchd_migrated_entrypoints.py` — 6 passed
- `shellcheck -S warning <changed shell scripts>` — passed
