### PR TITLE
Settings: expose optional operator connector status

### DIFF
--- a/src/cli/doctor/orchestrator.rs
+++ b/src/cli/doctor/orchestrator.rs
@@ -9,6 +9,9 @@ use crate::cli::dcserver;
 use crate::config;
 #[cfg(all(test, feature = "legacy-sqlite-tests"))]
 use crate::db::{open_write_connection, schema};
+use crate::services::operator_connectors::{
+    OptionalConnectorState, OptionalConnectorStatus, optional_connector_statuses,
+};
 use crate::services::provider::ProviderKind;
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -29,6 +32,7 @@ pub(crate) struct DoctorOptions {
 enum CheckGroup {
     Core,
     ProviderRuntime,
+    OptionalConnectors,
     Voice,
 }
 
@@ -37,6 +41,7 @@ impl CheckGroup {
         match self {
             CheckGroup::Core => "core",
             CheckGroup::ProviderRuntime => "provider_runtime",
+            CheckGroup::OptionalConnectors => "optional_connectors",
             CheckGroup::Voice => "voice",
         }
     }
@@ -45,6 +50,7 @@ impl CheckGroup {
         match self {
             CheckGroup::Core => "server",
             CheckGroup::ProviderRuntime => "provider_runtime",
+            CheckGroup::OptionalConnectors => "optional_connectors",
             CheckGroup::Voice => "voice",
         }
     }
@@ -350,6 +356,13 @@ pub(crate) struct DoctorCheckReport {
     security_exposure: &'static str,
 }
 
+#[derive(Serialize)]
+pub(crate) struct DoctorSectionReport {
+    status: &'static str,
+    summary: DoctorSummary,
+    check_ids: Vec<&'static str>,
+}
+
 #[derive(Clone, Serialize)]
 pub(crate) struct DoctorFixReport {
     id: &'static str,
@@ -375,6 +388,7 @@ pub(crate) struct DoctorReport {
     artifact_path: Option<String>,
     profile: Option<&'static str>,
     summary: DoctorSummary,
+    sections: BTreeMap<&'static str, DoctorSectionReport>,
     checks: Vec<DoctorCheckReport>,
     auto_fixes: Vec<DoctorFixReport>,
     fixes: Vec<DoctorFixReport>,
@@ -1579,8 +1593,67 @@ fn check_credential_permissions(cfg: &config::Config) -> Check {
 fn build_all_checks(cfg: &config::Config, snapshot: &HealthSnapshot) -> Vec<Check> {
     let mut checks = build_core_checks(cfg, snapshot);
     checks.extend(build_provider_checks(cfg, snapshot));
+    checks.extend(build_optional_connector_checks());
     checks.extend(build_voice_checks(cfg));
     checks
+}
+
+fn build_optional_connector_checks() -> Vec<Check> {
+    optional_connector_statuses()
+        .into_iter()
+        .map(optional_connector_check)
+        .collect()
+}
+
+fn optional_connector_check(status: OptionalConnectorStatus) -> Check {
+    let (id, name) = optional_connector_check_identity(status.id);
+    let evidence = json!({
+        "connector": status.id,
+        "state": status.state.as_str(),
+        "source": status.source.as_deref(),
+        "reason": status.reason,
+        "optional": status.optional,
+        "env_var": status.env_var,
+        "capabilities": &status.capabilities,
+        "setup_actions": &status.setup_actions,
+    });
+    let check = match status.state {
+        OptionalConnectorState::Ready
+        | OptionalConnectorState::Skipped
+        | OptionalConnectorState::MissingConfig => {
+            Check::ok(id, CheckGroup::OptionalConnectors, name, status.detail.clone())
+        }
+        OptionalConnectorState::MissingPath
+        | OptionalConnectorState::MissingProvider
+        | OptionalConnectorState::InvalidConfig => Check::warn(
+            id,
+            CheckGroup::OptionalConnectors,
+            name,
+            status.detail.clone(),
+            format!(
+                "{} is not ready (state={}). Core runtime can continue, but connector-backed routines stay disabled until setup is fixed.",
+                status.env_var,
+                status.state.as_str()
+            ),
+        )
+        .with_expected_actual("optional connector ready or not configured", status.state.as_str())
+        .with_next_steps(status.setup_actions.clone()),
+    };
+
+    let check = if let Some(source) = &status.source {
+        check.with_path(source.clone())
+    } else {
+        check
+    };
+    check.with_evidence(evidence)
+}
+
+fn optional_connector_check_identity(id: &str) -> (&'static str, &'static str) {
+    match id {
+        "obsidian_agent_prompts" => ("optional_obsidian_agents", "Obsidian agent prompts"),
+        "obsidian_skill_root" => ("optional_obsidian_skill_root", "Obsidian skill root"),
+        _ => ("optional_connector", "Optional connector"),
+    }
 }
 
 fn build_voice_checks(cfg: &config::Config) -> Vec<Check> {
@@ -1772,12 +1845,64 @@ fn summarize_checks(checks: &[Check]) -> DoctorSummary {
     }
 }
 
+fn doctor_summary_status(summary: &DoctorSummary) -> &'static str {
+    if summary.failed > 0 {
+        "fail"
+    } else if summary.warned > 0 {
+        "warn"
+    } else {
+        "pass"
+    }
+}
+
+fn build_doctor_sections(checks: &[Check]) -> BTreeMap<&'static str, DoctorSectionReport> {
+    const SECTION_NAMES: [&str; 4] = ["core", "config", "launchd", "optional_connectors"];
+
+    let mut sections = BTreeMap::new();
+    for section in SECTION_NAMES {
+        let section_checks = checks
+            .iter()
+            .filter(|check| doctor_section_includes_check(section, check))
+            .cloned()
+            .collect::<Vec<_>>();
+        let summary = summarize_checks(&section_checks);
+        sections.insert(
+            section,
+            DoctorSectionReport {
+                status: doctor_summary_status(&summary),
+                summary,
+                check_ids: section_checks.iter().map(|check| check.id).collect(),
+            },
+        );
+    }
+    sections
+}
+
+fn doctor_section_includes_check(section: &str, check: &Check) -> bool {
+    match section {
+        "core" => matches!(check.group, CheckGroup::Core),
+        "config" => {
+            check.subsystem.contains("config")
+                || check.id.contains("config")
+                || check.id.contains("runtime")
+        }
+        "launchd" => {
+            check.subsystem.contains("launchd")
+                || check.id.contains("launchd")
+                || check.detail.contains("launchd")
+        }
+        "optional_connectors" => matches!(check.group, CheckGroup::OptionalConnectors),
+        _ => false,
+    }
+}
+
 fn build_json_report(
     options: &DoctorOptions,
     checks: &[Check],
     actions: &[FixAction],
 ) -> DoctorReport {
     let summary = summarize_checks(checks);
+    let sections = build_doctor_sections(checks);
     let checks = checks
         .iter()
         .map(|check| DoctorCheckReport {
@@ -1829,6 +1954,7 @@ fn build_json_report(
             .map(|path| path.display().to_string()),
         profile: options.profile.map(DoctorProfile::as_str),
         summary,
+        sections,
         checks,
         auto_fixes: if matches!(options.run_context, RunContext::StartupOnce) {
             fixes.clone()
@@ -4036,7 +4162,7 @@ fn doctor_profile_includes_check(profile: DoctorProfile, check: &Check) -> bool 
     match profile {
         DoctorProfile::Quick => matches!(
             check.subsystem,
-            "server" | "health" | "provider_runtime" | "dispatch_outbox"
+            "server" | "health" | "provider_runtime" | "dispatch_outbox" | "optional_connectors"
         ),
         DoctorProfile::Deep => true,
         DoctorProfile::Security => {
@@ -4045,6 +4171,15 @@ fn doctor_profile_includes_check(profile: DoctorProfile, check: &Check) -> bool 
                 "security" | "config_audit" | "health" | "provider_runtime"
             ) || !matches!(check.security_exposure, SecurityExposure::None)
         }
+    }
+}
+
+fn check_group_from_report(group: &str) -> CheckGroup {
+    match group {
+        "provider_runtime" => CheckGroup::ProviderRuntime,
+        "optional_connectors" => CheckGroup::OptionalConnectors,
+        "voice" => CheckGroup::Voice,
+        _ => CheckGroup::Core,
     }
 }
 
@@ -4097,11 +4232,7 @@ pub fn cmd_doctor(options: DoctorOptions) -> Result<(), String> {
             .iter()
             .map(|check| Check {
                 id: check.id,
-                group: if check.group == "provider_runtime" {
-                    CheckGroup::ProviderRuntime
-                } else {
-                    CheckGroup::Core
-                },
+                group: check_group_from_report(check.group),
                 name: check.name,
                 status: match check.status {
                     "pass" => CheckStatus::Pass,
@@ -4138,19 +4269,19 @@ pub fn cmd_doctor(options: DoctorOptions) -> Result<(), String> {
                 },
             })
             .collect::<Vec<_>>();
-        let core_checks: Vec<Check> = checks
-            .iter()
-            .filter(|check| matches!(check.group, CheckGroup::Core))
-            .cloned()
-            .collect();
-        let provider_checks: Vec<Check> = checks
-            .iter()
-            .filter(|check| matches!(check.group, CheckGroup::ProviderRuntime))
-            .cloned()
-            .collect();
-
-        print_group("Core", &core_checks);
-        print_group("Provider Runtime", &provider_checks);
+        for (group, label) in [
+            (CheckGroup::Core, "Core"),
+            (CheckGroup::ProviderRuntime, "Provider Runtime"),
+            (CheckGroup::OptionalConnectors, "Optional Connectors"),
+            (CheckGroup::Voice, "Voice"),
+        ] {
+            let group_checks: Vec<Check> = checks
+                .iter()
+                .filter(|check| check.group == group)
+                .cloned()
+                .collect();
+            print_group(label, &group_checks);
+        }
 
         println!(
             "  {} passed, {} warned, {} failed out of {} checks",
@@ -4173,8 +4304,11 @@ pub fn cmd_doctor(options: DoctorOptions) -> Result<(), String> {
 
 #[cfg(test)]
 mod profile_filter_tests {
-    use super::{Check, CheckGroup, doctor_profile_includes_check};
-    use crate::cli::doctor::contract::DoctorProfile;
+    use super::{
+        Check, CheckGroup, DoctorOptions, build_json_report, check_group_from_report,
+        doctor_profile_includes_check,
+    };
+    use crate::cli::doctor::contract::{DoctorProfile, RunContext};
 
     #[test]
     fn quick_profile_keeps_dispatch_outbox_checks() {
@@ -4201,6 +4335,69 @@ mod profile_filter_tests {
             DoctorProfile::Quick,
             &config_audit
         ));
+    }
+
+    #[test]
+    fn quick_profile_keeps_portable_optional_state_checks() {
+        let optional_connector = Check::ok(
+            "optional_obsidian_agents",
+            CheckGroup::OptionalConnectors,
+            "Obsidian agent prompts",
+            "state=missing_config reason=missing_config",
+        );
+
+        assert!(doctor_profile_includes_check(
+            DoctorProfile::Quick,
+            &optional_connector
+        ));
+    }
+
+    #[test]
+    fn json_report_exposes_portable_readiness_sections() {
+        let checks = vec![
+            Check::ok("runtime_root", CheckGroup::Core, "Runtime root", "ok")
+                .with_subsystem("config"),
+            Check::ok(
+                "launchd_service",
+                CheckGroup::Core,
+                "Launchd service",
+                "launchd not loaded in manual mode",
+            )
+            .with_subsystem("launchd"),
+            Check::ok(
+                "optional_obsidian_agents",
+                CheckGroup::OptionalConnectors,
+                "Obsidian agent prompts",
+                "state=missing_config reason=missing_config",
+            ),
+        ];
+        let options = DoctorOptions {
+            fix: false,
+            json: true,
+            allow_restart: false,
+            repair_sqlite_cache: false,
+            allow_remote: false,
+            profile: None,
+            run_context: RunContext::ManualCli,
+            artifact_path: None,
+        };
+        let report = build_json_report(&options, &checks, &[]);
+
+        for section in ["core", "config", "launchd", "optional_connectors"] {
+            assert!(
+                report.sections.contains_key(section),
+                "missing doctor section {section}"
+            );
+        }
+        assert_eq!(report.sections["optional_connectors"].summary.total, 1);
+    }
+
+    #[test]
+    fn report_group_round_trip_keeps_portable_groups() {
+        assert_eq!(
+            check_group_from_report("optional_connectors"),
+            CheckGroup::OptionalConnectors
+        );
     }
 }
 

--- a/src/server/routes/docs.rs
+++ b/src/server/routes/docs.rs
@@ -3259,6 +3259,44 @@ fn all_endpoints() -> Vec<EndpointDoc> {
             }),
         ),
         ep(
+            "GET",
+            "/api/settings/operator-connectors",
+            "settings",
+            "Get optional operator connector status and setup actions. Missing optional connectors do not block the core runtime.",
+        )
+        .with_example(
+            json!({}),
+            json!({
+                "connectors": [
+                    {
+                        "id": "obsidian_skill_root",
+                        "name": "Obsidian skill root",
+                        "state": "missing_config",
+                        "optional": true,
+                        "env_var": "AGENTDESK_OBSIDIAN_SKILL_ROOT",
+                        "source": "/Users/user/ObsidianVault/RemoteVault/99_Skills",
+                        "reason": "missing_config",
+                        "detail": "state=missing_config source=/Users/user/ObsidianVault/RemoteVault/99_Skills reason=missing_config",
+                        "setup_actions": [
+                            "Set AGENTDESK_OBSIDIAN_SKILL_ROOT to an existing skill directory containing at least one <skill>/SKILL.md, or run scripts/operator-init-portable.py --with-obsidian-stubs before syncing real skills."
+                        ],
+                        "capabilities": ["obsidian_skill_root"]
+                    }
+                ],
+                "summary": {
+                    "ready": 0,
+                    "skipped": 0,
+                    "missing_config": 1,
+                    "missing_path": 0,
+                    "missing_provider": 0,
+                    "invalid_config": 0,
+                    "invalid": 0,
+                    "total": 1,
+                    "core_runtime_blocking": false
+                }
+            }),
+        ),
+        ep(
             "PUT",
             "/api/settings/runtime-config",
             "settings",

--- a/src/server/routes/domains/admin.rs
+++ b/src/server/routes/domains/admin.rs
@@ -58,6 +58,10 @@ pub(crate) fn router(state: AppState) -> ApiRouter {
                 get(settings::get_runtime_config).put(settings::put_runtime_config),
             )
             .route(
+                "/settings/operator-connectors",
+                get(settings::get_operator_connectors),
+            )
+            .route(
                 "/settings/escalation",
                 get(escalation::get_escalation_settings).put(escalation::put_escalation_settings),
             )

--- a/src/server/routes/settings.rs
+++ b/src/server/routes/settings.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use super::AppState;
 use crate::error::AppError;
 use crate::server::dto::settings::SettingsErrorResponse;
+use crate::services::operator_connectors::OptionalConnectorsResponse;
 
 fn settings_json_response<T: Serialize>(status: StatusCode, body: T) -> (StatusCode, Json<Value>) {
     (
@@ -73,6 +74,11 @@ pub async fn get_runtime_config(State(state): State<AppState>) -> (StatusCode, J
         Ok(body) => settings_json_response(StatusCode::OK, body),
         Err(error) => service_error_response(error),
     }
+}
+
+/// GET /api/settings/operator-connectors
+pub async fn get_operator_connectors() -> (StatusCode, Json<Value>) {
+    settings_json_response(StatusCode::OK, OptionalConnectorsResponse::current())
 }
 
 /// PUT /api/settings/runtime-config

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -41,6 +41,7 @@ pub mod message_outbox;
 pub mod observability;
 pub mod onboarding;
 pub mod opencode;
+pub mod operator_connectors;
 pub mod pipeline_override;
 pub mod pipeline_routes;
 pub mod platform;

--- a/src/services/operator_connectors.rs
+++ b/src/services/operator_connectors.rs
@@ -1,0 +1,477 @@
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+
+pub const OBSIDIAN_AGENT_PROMPTS_CONNECTOR: &str = "obsidian_agent_prompts";
+pub const OBSIDIAN_SKILL_ROOT_CONNECTOR: &str = "obsidian_skill_root";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OptionalConnectorState {
+    Ready,
+    Skipped,
+    MissingConfig,
+    MissingPath,
+    MissingProvider,
+    InvalidConfig,
+}
+
+impl OptionalConnectorState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::Skipped => "skipped",
+            Self::MissingConfig => "missing_config",
+            Self::MissingPath => "missing_path",
+            Self::MissingProvider => "missing_provider",
+            Self::InvalidConfig => "invalid_config",
+        }
+    }
+
+    pub fn needs_operator_setup(self) -> bool {
+        matches!(
+            self,
+            Self::MissingPath | Self::MissingProvider | Self::InvalidConfig
+        )
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct OptionalConnectorStatus {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub state: OptionalConnectorState,
+    pub optional: bool,
+    pub env_var: &'static str,
+    pub source: Option<String>,
+    pub reason: Option<&'static str>,
+    pub detail: String,
+    pub setup_actions: Vec<String>,
+    pub capabilities: Vec<&'static str>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct OptionalConnectorSummary {
+    pub ready: usize,
+    pub skipped: usize,
+    pub missing_config: usize,
+    pub missing_path: usize,
+    pub missing_provider: usize,
+    pub invalid_config: usize,
+    pub invalid: usize,
+    pub total: usize,
+    pub core_runtime_blocking: bool,
+}
+
+impl OptionalConnectorSummary {
+    pub fn from_statuses(statuses: &[OptionalConnectorStatus]) -> Self {
+        let mut summary = Self {
+            ready: 0,
+            skipped: 0,
+            missing_config: 0,
+            missing_path: 0,
+            missing_provider: 0,
+            invalid_config: 0,
+            invalid: 0,
+            total: statuses.len(),
+            core_runtime_blocking: false,
+        };
+        for status in statuses {
+            match status.state {
+                OptionalConnectorState::Ready => summary.ready += 1,
+                OptionalConnectorState::Skipped => summary.skipped += 1,
+                OptionalConnectorState::MissingConfig => summary.missing_config += 1,
+                OptionalConnectorState::MissingPath => summary.missing_path += 1,
+                OptionalConnectorState::MissingProvider => summary.missing_provider += 1,
+                OptionalConnectorState::InvalidConfig => summary.invalid_config += 1,
+            }
+            if status.state.needs_operator_setup() {
+                summary.invalid += 1;
+            }
+        }
+        summary
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct OptionalConnectorsResponse {
+    pub connectors: Vec<OptionalConnectorStatus>,
+    pub summary: OptionalConnectorSummary,
+}
+
+impl OptionalConnectorsResponse {
+    pub fn current() -> Self {
+        let connectors = optional_connector_statuses();
+        let summary = OptionalConnectorSummary::from_statuses(&connectors);
+        Self {
+            connectors,
+            summary,
+        }
+    }
+}
+
+pub fn optional_connector_statuses() -> Vec<OptionalConnectorStatus> {
+    vec![
+        obsidian_agent_prompts_status(),
+        obsidian_skill_root_status(),
+    ]
+}
+
+pub fn optional_connector_status_by_id(id: &str) -> Option<OptionalConnectorStatus> {
+    optional_connector_statuses().into_iter().find(|status| {
+        status.id == id
+            || status
+                .capabilities
+                .iter()
+                .any(|capability| *capability == id)
+    })
+}
+
+fn obsidian_agent_prompts_status() -> OptionalConnectorStatus {
+    let source = explicit_env_path("AGENTDESK_OBSIDIAN_AGENTS_SRC").or_else(|| {
+        obsidian_remote_vault_root().map(|root| root.join("adk-config").join("agents"))
+    });
+    connector_dir_status(ConnectorDirSpec {
+        id: OBSIDIAN_AGENT_PROMPTS_CONNECTOR,
+        name: "Obsidian agent prompts",
+        env_var: "AGENTDESK_OBSIDIAN_AGENTS_SRC",
+        source,
+        explicit: explicit_env_path("AGENTDESK_OBSIDIAN_AGENTS_SRC").is_some(),
+        capability: OBSIDIAN_AGENT_PROMPTS_CONNECTOR,
+        setup_hint: "Set AGENTDESK_OBSIDIAN_AGENTS_SRC to an existing prompts directory, or run scripts/operator-init-portable.py --with-obsidian-stubs to create starter directories.",
+    })
+}
+
+fn obsidian_skill_root_status() -> OptionalConnectorStatus {
+    let source = explicit_env_path("AGENTDESK_OBSIDIAN_SKILL_ROOT")
+        .or_else(|| obsidian_remote_vault_root().map(|root| root.join("99_Skills")));
+    let mut status = connector_dir_status(ConnectorDirSpec {
+        id: OBSIDIAN_SKILL_ROOT_CONNECTOR,
+        name: "Obsidian skill root",
+        env_var: "AGENTDESK_OBSIDIAN_SKILL_ROOT",
+        source: source.clone(),
+        explicit: explicit_env_path("AGENTDESK_OBSIDIAN_SKILL_ROOT").is_some(),
+        capability: OBSIDIAN_SKILL_ROOT_CONNECTOR,
+        setup_hint: "Set AGENTDESK_OBSIDIAN_SKILL_ROOT to an existing skill directory containing at least one <skill>/SKILL.md, or run scripts/operator-init-portable.py --with-obsidian-stubs before syncing real skills.",
+    });
+    if status.state == OptionalConnectorState::Ready
+        && !source
+            .as_deref()
+            .is_some_and(obsidian_skill_root_contains_skill)
+    {
+        let source_text = status.source.clone().unwrap_or_default();
+        status.state = OptionalConnectorState::InvalidConfig;
+        status.reason = Some("missing_skill_files");
+        status.detail =
+            format!("state=invalid_config source={source_text} reason=missing_skill_files");
+        status.setup_actions = vec![format!(
+            "Add at least one skill directory containing SKILL.md under {source_text}."
+        )];
+    }
+    status
+}
+
+struct ConnectorDirSpec {
+    id: &'static str,
+    name: &'static str,
+    env_var: &'static str,
+    source: Option<PathBuf>,
+    explicit: bool,
+    capability: &'static str,
+    setup_hint: &'static str,
+}
+
+fn connector_dir_status(spec: ConnectorDirSpec) -> OptionalConnectorStatus {
+    let Some(source) = spec.source else {
+        return OptionalConnectorStatus {
+            id: spec.id,
+            name: spec.name,
+            state: OptionalConnectorState::MissingConfig,
+            optional: true,
+            env_var: spec.env_var,
+            source: None,
+            reason: Some("home_unavailable"),
+            detail: "state=missing_config reason=home_unavailable; core runtime does not require this connector".to_string(),
+            setup_actions: vec![format!("Set {} to an existing directory.", spec.env_var)],
+            capabilities: vec![spec.capability],
+        };
+    };
+
+    let source_text = source.display().to_string();
+    if source.is_dir() {
+        OptionalConnectorStatus {
+            id: spec.id,
+            name: spec.name,
+            state: OptionalConnectorState::Ready,
+            optional: true,
+            env_var: spec.env_var,
+            source: Some(source_text.clone()),
+            reason: None,
+            detail: format!("state=ready source={source_text}"),
+            setup_actions: Vec::new(),
+            capabilities: vec![spec.capability],
+        }
+    } else if spec.explicit {
+        OptionalConnectorStatus {
+            id: spec.id,
+            name: spec.name,
+            state: OptionalConnectorState::MissingPath,
+            optional: true,
+            env_var: spec.env_var,
+            source: Some(source_text.clone()),
+            reason: Some("missing_path"),
+            detail: format!("state=missing_path source={source_text} reason=missing_path"),
+            setup_actions: vec![
+                format!("Create the configured directory: {source_text}"),
+                format!(
+                    "Unset {} or point it at an existing directory.",
+                    spec.env_var
+                ),
+            ],
+            capabilities: vec![spec.capability],
+        }
+    } else {
+        OptionalConnectorStatus {
+            id: spec.id,
+            name: spec.name,
+            state: OptionalConnectorState::MissingConfig,
+            optional: true,
+            env_var: spec.env_var,
+            source: Some(source_text.clone()),
+            reason: Some("missing_config"),
+            detail: format!("state=missing_config source={source_text} reason=missing_config"),
+            setup_actions: vec![spec.setup_hint.to_string()],
+            capabilities: vec![spec.capability],
+        }
+    }
+}
+
+fn obsidian_skill_root_contains_skill(root: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return false;
+    };
+    entries.filter_map(Result::ok).any(|entry| {
+        let path = entry.path();
+        path.is_dir() && path.join("SKILL.md").is_file()
+    })
+}
+
+fn explicit_env_path(name: &str) -> Option<PathBuf> {
+    std::env::var_os(name)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+fn obsidian_remote_vault_root() -> Option<PathBuf> {
+    explicit_env_path("OBSIDIAN_REMOTE_VAULT_ROOT").or_else(|| {
+        explicit_env_path("OBSIDIAN_VAULT_ROOT")
+            .map(|root| root.join("RemoteVault"))
+            .or_else(runtime_root_obsidian_remote_vault_root)
+            .or_else(|| {
+                operator_home_dir().map(|home| home.join("ObsidianVault").join("RemoteVault"))
+            })
+    })
+}
+
+fn runtime_root_obsidian_remote_vault_root() -> Option<PathBuf> {
+    let remote = crate::config::runtime_root()?
+        .join("ObsidianVault")
+        .join("RemoteVault");
+    remote.exists().then_some(remote)
+}
+
+fn operator_home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("USERPROFILE")
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+        })
+        .or_else(dirs::home_dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        OptionalConnectorState, OptionalConnectorSummary, optional_connector_status_by_id,
+        optional_connector_statuses,
+    };
+    use std::sync::Mutex;
+
+    static CONNECTOR_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_connector_env<F>(f: F)
+    where
+        F: FnOnce(),
+    {
+        let _guard = CONNECTOR_ENV_LOCK.lock().unwrap();
+        let saved_home = std::env::var_os("HOME");
+        let saved_userprofile = std::env::var_os("USERPROFILE");
+        let saved_obsidian_root = std::env::var_os("OBSIDIAN_VAULT_ROOT");
+        let saved_remote_root = std::env::var_os("OBSIDIAN_REMOTE_VAULT_ROOT");
+        let saved_agents_src = std::env::var_os("AGENTDESK_OBSIDIAN_AGENTS_SRC");
+        let saved_skill_root = std::env::var_os("AGENTDESK_OBSIDIAN_SKILL_ROOT");
+        let saved_runtime_root = std::env::var_os("AGENTDESK_ROOT_DIR");
+
+        f();
+
+        restore_env("HOME", saved_home);
+        restore_env("USERPROFILE", saved_userprofile);
+        restore_env("OBSIDIAN_VAULT_ROOT", saved_obsidian_root);
+        restore_env("OBSIDIAN_REMOTE_VAULT_ROOT", saved_remote_root);
+        restore_env("AGENTDESK_OBSIDIAN_AGENTS_SRC", saved_agents_src);
+        restore_env("AGENTDESK_OBSIDIAN_SKILL_ROOT", saved_skill_root);
+        restore_env("AGENTDESK_ROOT_DIR", saved_runtime_root);
+    }
+
+    fn restore_env(name: &str, value: Option<std::ffi::OsString>) {
+        match value {
+            Some(value) => unsafe { std::env::set_var(name, value) },
+            None => unsafe { std::env::remove_var(name) },
+        }
+    }
+
+    #[test]
+    fn connector_lookup_matches_capability_alias() {
+        let status = optional_connector_status_by_id("obsidian_skill_root")
+            .expect("known connector should resolve");
+        assert_eq!(status.id, "obsidian_skill_root");
+    }
+
+    #[test]
+    fn connector_state_labels_are_api_stable() {
+        assert_eq!(OptionalConnectorState::Ready.as_str(), "ready");
+        assert_eq!(OptionalConnectorState::Skipped.as_str(), "skipped");
+        assert_eq!(
+            OptionalConnectorState::MissingConfig.as_str(),
+            "missing_config"
+        );
+        assert_eq!(OptionalConnectorState::MissingPath.as_str(), "missing_path");
+        assert_eq!(
+            OptionalConnectorState::MissingProvider.as_str(),
+            "missing_provider"
+        );
+        assert_eq!(
+            OptionalConnectorState::InvalidConfig.as_str(),
+            "invalid_config"
+        );
+    }
+
+    #[test]
+    fn implicit_missing_connector_reports_missing_config() {
+        with_connector_env(|| {
+            let temp = tempfile::tempdir().unwrap();
+            unsafe {
+                std::env::set_var("HOME", temp.path());
+                std::env::set_var("USERPROFILE", temp.path());
+                std::env::remove_var("OBSIDIAN_VAULT_ROOT");
+                std::env::remove_var("OBSIDIAN_REMOTE_VAULT_ROOT");
+                std::env::remove_var("AGENTDESK_OBSIDIAN_AGENTS_SRC");
+                std::env::remove_var("AGENTDESK_OBSIDIAN_SKILL_ROOT");
+            }
+
+            let statuses = optional_connector_statuses();
+            assert!(
+                statuses
+                    .iter()
+                    .all(|status| status.state == OptionalConnectorState::MissingConfig)
+            );
+            let summary = OptionalConnectorSummary::from_statuses(&statuses);
+            assert_eq!(summary.missing_config, statuses.len());
+            assert_eq!(summary.invalid, 0);
+        });
+    }
+
+    #[test]
+    fn explicit_missing_connector_reports_missing_path() {
+        with_connector_env(|| {
+            let temp = tempfile::tempdir().unwrap();
+            let missing = temp.path().join("missing-agents");
+            unsafe {
+                std::env::set_var("HOME", temp.path());
+                std::env::set_var("USERPROFILE", temp.path());
+                std::env::set_var("AGENTDESK_OBSIDIAN_AGENTS_SRC", &missing);
+                std::env::remove_var("OBSIDIAN_VAULT_ROOT");
+                std::env::remove_var("OBSIDIAN_REMOTE_VAULT_ROOT");
+                std::env::remove_var("AGENTDESK_OBSIDIAN_SKILL_ROOT");
+            }
+
+            let status = optional_connector_status_by_id("obsidian_agent_prompts").unwrap();
+            assert_eq!(status.state, OptionalConnectorState::MissingPath);
+            assert_eq!(status.reason, Some("missing_path"));
+            let summary = OptionalConnectorSummary::from_statuses(&[status]);
+            assert_eq!(summary.missing_path, 1);
+            assert_eq!(summary.invalid, 1);
+        });
+    }
+
+    #[test]
+    fn runtime_root_obsidian_stubs_are_discoverable_without_obsidian_env() {
+        with_connector_env(|| {
+            let temp = tempfile::tempdir().unwrap();
+            let home = temp.path().join("home");
+            let root = temp.path().join("release");
+            let remote = root.join("ObsidianVault").join("RemoteVault");
+            std::fs::create_dir_all(remote.join("adk-config").join("agents")).unwrap();
+            let skill_root = remote.join("99_Skills");
+            std::fs::create_dir_all(skill_root.join("ai-integrated-briefing")).unwrap();
+            std::fs::write(
+                skill_root.join("ai-integrated-briefing").join("SKILL.md"),
+                "# AI integrated briefing\n",
+            )
+            .unwrap();
+            unsafe {
+                std::env::set_var("HOME", &home);
+                std::env::set_var("USERPROFILE", &home);
+                std::env::set_var("AGENTDESK_ROOT_DIR", &root);
+                std::env::remove_var("OBSIDIAN_VAULT_ROOT");
+                std::env::remove_var("OBSIDIAN_REMOTE_VAULT_ROOT");
+                std::env::remove_var("AGENTDESK_OBSIDIAN_AGENTS_SRC");
+                std::env::remove_var("AGENTDESK_OBSIDIAN_SKILL_ROOT");
+            }
+
+            let statuses = optional_connector_statuses();
+
+            assert!(
+                statuses
+                    .iter()
+                    .all(|status| status.state == OptionalConnectorState::Ready)
+            );
+            assert!(statuses.iter().all(|status| {
+                status
+                    .source
+                    .as_deref()
+                    .is_some_and(|source| source.contains("ObsidianVault"))
+            }));
+        });
+    }
+
+    #[test]
+    fn empty_obsidian_skill_stub_requires_real_skill_content() {
+        with_connector_env(|| {
+            let temp = tempfile::tempdir().unwrap();
+            let home = temp.path().join("home");
+            let root = temp.path().join("release");
+            let remote = root.join("ObsidianVault").join("RemoteVault");
+            std::fs::create_dir_all(remote.join("adk-config").join("agents")).unwrap();
+            std::fs::create_dir_all(remote.join("99_Skills")).unwrap();
+            unsafe {
+                std::env::set_var("HOME", &home);
+                std::env::set_var("USERPROFILE", &home);
+                std::env::set_var("AGENTDESK_ROOT_DIR", &root);
+                std::env::remove_var("OBSIDIAN_VAULT_ROOT");
+                std::env::remove_var("OBSIDIAN_REMOTE_VAULT_ROOT");
+                std::env::remove_var("AGENTDESK_OBSIDIAN_AGENTS_SRC");
+                std::env::remove_var("AGENTDESK_OBSIDIAN_SKILL_ROOT");
+            }
+
+            let prompts = optional_connector_status_by_id("obsidian_agent_prompts").unwrap();
+            let skills = optional_connector_status_by_id("obsidian_skill_root").unwrap();
+
+            assert_eq!(prompts.state, OptionalConnectorState::Ready);
+            assert_eq!(skills.state, OptionalConnectorState::InvalidConfig);
+            assert_eq!(skills.reason, Some("missing_skill_files"));
+        });
+    }
+}


### PR DESCRIPTION
## 목표

새 Mac 사용자가 Obsidian 같은 operator-local connector를 아직 설정하지 않아도 core runtime은 정상 상태로 두고, Doctor와 Settings API에서 connector 준비 상태와 setup action을 확인할 수 있게 합니다.

## 쉬운 설명

AgentDesk 설치 직후에는 개인 Obsidian vault나 skill mirror가 없을 수 있습니다. 이 PR은 그런 경로를 core 실패로 보지 않고 optional connector 상태로 분류합니다. 운영자는 Doctor JSON이나 `/api/settings/operator-connectors`에서 어떤 경로를 설정해야 하는지 바로 볼 수 있습니다.

## 개선되는 것

### Fix 1

`obsidian_agent_prompts`, `obsidian_skill_root` optional connector 상태 모델을 추가합니다.

### Fix 2

`agentdesk doctor --json --profile quick` 결과에 optional connector check와 readiness section을 포함합니다.

### Fix 3

Dashboard가 사용할 수 있는 `GET /api/settings/operator-connectors` endpoint와 API docs 항목을 추가합니다.

## Before → After

| 시나리오 | Before | After |
|---|---|---|
| fresh Mac에 Obsidian vault 없음 | 누락 경로가 core 문제처럼 보이거나 파악하기 어려움 | `missing_config` optional 상태로 노출 |
| env가 잘못된 경로를 가리킴 | 어떤 env를 고쳐야 하는지 확인이 번거로움 | `missing_path`와 setup action 제공 |
| Dashboard에서 connector 상태 조회 | 전용 API 없음 | `/api/settings/operator-connectors`에서 summary/connectors 반환 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
|---|---|---|
| connector 미설정 | Doctor pass check로 표시하되 상태는 `missing_config` | core runtime 비차단 |
| 명시 env가 존재하지 않는 디렉터리 | Doctor warning과 setup action 표시 | 운영자 설정 오류만 드러냄 |
| runtime root 아래 Obsidian stubs 존재 | env 없이도 stub 경로 탐지 | portable scaffold와 호환 |

## 해결한 내용

- `src/services/operator_connectors.rs`: optional connector 상태, summary, setup action 모델을 추가했습니다.
- `src/cli/doctor/orchestrator.rs`: quick/deep Doctor JSON에 optional connector checks와 `optional_connectors` section을 추가했습니다.
- `src/server/routes/settings.rs`, `src/server/routes/domains/admin.rs`: settings API endpoint를 등록했습니다.
- `src/server/routes/docs.rs`: endpoint 문서 예시를 추가했습니다.

## 검증

- `cargo fmt --all --check` — passed
- `cargo test connector_ -- --test-threads=1` — 4 passed
- `cargo test portable_optional -- --test-threads=1` — 1 passed
- `cargo test json_report_exposes_portable_readiness_sections -- --test-threads=1` — 1 passed
- `cargo test report_group_round_trip_keeps_portable_groups -- --test-threads=1` — 1 passed
- `cargo test runtime_root_obsidian_stubs_are_discoverable_without_obsidian_env -- --test-threads=1` — 1 passed
- `cargo test empty_obsidian_skill_stub_requires_real_skill_content -- --test-threads=1` — 1 passed
- `cargo check --all-targets` — passed
