### PR TITLE
CI: add macOS fresh user portable smoke

### DIFF
--- a/.github/workflows/ci-macos-trusted.yml
+++ b/.github/workflows/ci-macos-trusted.yml
@@ -140,6 +140,10 @@ jobs:
           cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
           cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres
 
+      - name: Fresh user portable smoke
+        shell: bash
+        run: bash scripts/ci-macos-fresh-user-smoke.sh
+
   macos_self_hosted:
     name: Trusted macOS check (self-hosted)
     needs: resolve_macos_runner
@@ -228,6 +232,10 @@ jobs:
           cargo test --all-targets cancel -- --skip _pg --skip pg_ --skip postgres
           cargo test --all-targets review_decision -- --skip _pg --skip pg_ --skip postgres
           cargo test invariant --all-targets -- --skip _pg --skip pg_ --skip postgres
+
+      - name: Fresh user portable smoke
+        shell: bash
+        run: bash scripts/ci-macos-fresh-user-smoke.sh
 
       - name: sccache stats
         if: always()

--- a/scripts/ci-macos-fresh-user-smoke.sh
+++ b/scripts/ci-macos-fresh-user-smoke.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "fresh user smoke is macOS-only; skipping on $(uname -s)"
+  exit 0
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+python3 -m unittest tests.test_install_bootstrap_portable
+
+runner_temp="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+smoke_base="$(mktemp -d "$runner_temp/agentdesk-fresh-user.XXXXXX")"
+smoke_base="$(cd "$smoke_base" && pwd -P)"
+trap 'rm -rf "$smoke_base"' EXIT
+
+fresh_home="$smoke_base/home"
+fresh_root="$smoke_base/release"
+mkdir -p "$fresh_home" "$fresh_root/bin" "$fresh_home/Library/LaunchAgents"
+
+runner_home_was_set="${HOME+x}"
+runner_home="${HOME:-}"
+export HOME="$fresh_home"
+export AGENTDESK_ROOT_DIR="$fresh_root"
+export AGENTDESK_CONFIG="$fresh_root/config/agentdesk.yaml"
+
+python3 scripts/operator-init-portable.py \
+  --root "$fresh_root" \
+  --config "$AGENTDESK_CONFIG"
+
+test -f "$AGENTDESK_CONFIG"
+test -d "$fresh_root/workspaces"
+
+if [[ -n "$runner_home_was_set" ]]; then
+  export HOME="$runner_home"
+else
+  unset HOME
+fi
+
+cargo run --quiet -- emit-launchd-plist \
+  --flavor release \
+  --home "$fresh_home" \
+  --root-dir "$fresh_root" \
+  --agentdesk-bin "$fresh_root/bin/agentdesk" \
+  --output "$fresh_home/Library/LaunchAgents/com.agentdesk.release.plist"
+
+plutil -lint "$fresh_home/Library/LaunchAgents/com.agentdesk.release.plist"
+
+python3 - "$fresh_home" "$fresh_root" "$AGENTDESK_CONFIG" <<'PY'
+from pathlib import Path
+import sys
+
+home = Path(sys.argv[1])
+root = Path(sys.argv[2])
+config = Path(sys.argv[3])
+plist = home / "Library" / "LaunchAgents" / "com.agentdesk.release.plist"
+
+private_markers = ("/Users/itismyfield", "/Users/kunkun")
+for path in (config, plist):
+    text = path.read_text(encoding="utf-8")
+    for marker in private_markers:
+        if marker in text:
+            raise SystemExit(f"{path} contains private path marker {marker}")
+
+plist_text = plist.read_text(encoding="utf-8")
+for expected in (str(home), str(root), str(root / "bin" / "agentdesk")):
+    if expected not in plist_text:
+        raise SystemExit(f"plist missing expected fresh-user path: {expected}")
+
+print("fresh-user portable config and launchd plist are path-clean")
+PY
+
+cargo test cli::init::launchd_plist_tests::generate_launchd_plist_uses_requested_fresh_home_and_root_only -- --exact


### PR DESCRIPTION
## 목표

macOS trusted CI에서 fresh user portable install/scaffold 경로가 특정 기존 Mac 사용자 홈에 의존하지 않는지 검증하는 smoke를 추가합니다.

## 쉬운 설명

새 Mac 사용자는 빈 home과 빈 release root에서 시작합니다. 이 PR은 CI가 그런 임시 home/root를 만들고 `operator-init-portable.py`와 launchd plist 생성을 실제로 실행해 봅니다. 결과 config/plist에 `/Users/itismyfield`나 `/Users/kunkun` 같은 개인 경로가 섞이면 실패합니다.

## 개선되는 것

### Fix 1

`scripts/ci-macos-fresh-user-smoke.sh`를 추가해 portable scaffold, launchd plist 생성, path-clean 검증을 한 번에 실행합니다.

### Fix 2

GitHub macOS trusted workflow의 GitHub-hosted/self-hosted job 양쪽에 fresh user smoke 단계를 추가합니다.

## Before → After

| 시나리오 | Before | After |
|---|---|---|
| fresh Mac bootstrap 회귀 | 개별 unit test만으로 확인 | 임시 HOME/ROOT에서 end-to-end smoke 실행 |
| launchd plist path 회귀 | 특정 테스트를 수동으로 찾아야 함 | CI 단계에서 plist lint와 private marker 검증 |
| operator scaffold path 회귀 | config 생성 결과를 별도 확인 | generated config/plist를 smoke에서 직접 검사 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
|---|---|---|
| Linux/Windows runner | 스크립트가 macOS-only skip | 비macOS CI 영향 없음 |
| macOS runner에 기존 HOME 설정 | 임시 HOME으로 교체 후 복구 | runner 사용자 설정 오염 없음 |
| connector 미설정 | connector 검증은 이 PR 범위에서 제외 | #2823 backend와 독립 유지 |

## 해결한 내용

- `scripts/ci-macos-fresh-user-smoke.sh`: fresh home/root를 만들고 portable scaffold, launchd plist, private path marker를 검증합니다.
- `.github/workflows/ci-macos-trusted.yml`: GitHub-hosted 및 self-hosted macOS trusted job에 smoke 단계를 추가합니다.

## 검증

- `shellcheck -S warning scripts/ci-macos-fresh-user-smoke.sh` — passed
- `bash scripts/ci-macos-fresh-user-smoke.sh` — passed
- `cargo test cli::init::launchd_plist_tests::generate_launchd_plist_uses_requested_fresh_home_and_root_only -- --exact` — 1 passed
