### PR TITLE
CI: reject operator-specific portable paths

### DIFF
--- a/routines/monitoring/automation-candidate-detector.js
+++ b/routines/monitoring/automation-candidate-detector.js
@@ -157,7 +157,7 @@ function buildMaterializationPrompt(signature, candidate) {
     "",
     "**중요**: `program.repo_dir`가 `<determine from your workspace context>` 상태라면,",
     "현재 워크스페이스의 agentdesk 리포지터리 절대 경로로 대체하세요.",
-    "예: `/Users/kunkun/kunkunGames/agentdesk`",
+    "예: `/Users/example/workspaces/agentdesk`",
     "",
     "API 응답에서 `card_id`를 저장해두세요.",
     "",

--- a/scripts/check-portable-paths.py
+++ b/scripts/check-portable-paths.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Reject operator-specific home paths in deployable portable surfaces."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+SPECIFIC_USER_HOME = re.compile(r"/Users/(?!(?:REPLACE_ME|user|me|example)(?:/|$))[A-Za-z0-9._-]+")
+
+DEFAULT_PATTERNS = (
+    "scripts/_defaults.sh",
+    "scripts/build-release.sh",
+    "scripts/deploy.sh",
+    "scripts/deploy-dashboard.sh",
+    "scripts/deploy-release.sh",
+    "scripts/ensure-agentdesk-cli.sh",
+    "scripts/install.sh",
+    "scripts/queue-stability-batch.sh",
+    "scripts/setup-hooks.sh",
+    "scripts/resolve-python-runner.sh",
+    "scripts/launchd-migrated/*.sh",
+    "scripts/launchd-migrated/*.py",
+    "scripts/check-portable-paths.py",
+    "scripts/operator-init-portable.py",
+    "scripts/portable-operator-migration-dry-run.py",
+    "policies/**/*",
+    "routines/**/*.js",
+    "agentdesk.example.yaml",
+)
+
+
+def iter_default_paths(root: Path) -> list[Path]:
+    paths: list[Path] = []
+    for pattern in DEFAULT_PATTERNS:
+        paths.extend(path for path in root.glob(pattern) if path.is_file())
+    return sorted(set(paths))
+
+
+def rel_display(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def scan_file(path: Path) -> list[tuple[int, str]]:
+    hits: list[tuple[int, str]] = []
+    text = path.read_text(encoding="utf-8")
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        if SPECIFIC_USER_HOME.search(line):
+            hits.append((line_no, line.strip()))
+    return hits
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("paths", nargs="*", type=Path, help="Explicit files to scan instead of the default deployable set")
+    args = parser.parse_args(argv)
+
+    root = args.root.resolve()
+    paths = [path.resolve() for path in args.paths] if args.paths else iter_default_paths(root)
+
+    failures: list[str] = []
+    for path in paths:
+        if not path.is_file():
+            continue
+        for line_no, line in scan_file(path):
+            failures.append(f"{rel_display(path, root)}:{line_no}: {line}")
+
+    if failures:
+        print("ERROR: operator-specific /Users/<name> paths found in portable deployable surfaces:", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+
+    print(f"OK: scanned {len(paths)} portable deployable file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -65,8 +65,11 @@ if [ "$FAIL" -ne 0 ]; then
   exit "$FAIL"
 fi
 
-echo "=== Install bootstrap portable tests ==="
-python3 -m unittest tests.test_install_bootstrap_portable
+echo "=== Portable deployable path lint ==="
+python3 scripts/check-portable-paths.py
+python3 -m unittest \
+  tests.test_portable_path_lint \
+  tests.test_install_bootstrap_portable
 
 echo "=== Generate inventory docs ==="
 python3 scripts/generate_inventory_docs.py

--- a/tests/test_portable_path_lint.py
+++ b/tests/test_portable_path_lint.py
@@ -1,0 +1,147 @@
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "check-portable-paths.py"
+
+
+class PortablePathLintTests(unittest.TestCase):
+    def test_default_deployable_surfaces_have_no_specific_user_home_literals(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--root", str(REPO_ROOT)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_specific_user_home_literal_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bad.sh"
+            path.write_text("echo /Users/itismyfield/.adk/release\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--root", tmp, str(path)],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("/Users/itismyfield", result.stderr)
+
+    def test_default_scan_includes_release_scripts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            scripts_dir = Path(tmp) / "scripts"
+            scripts_dir.mkdir()
+            deploy_release = scripts_dir / "deploy-release.sh"
+            deploy_release.write_text("echo portable\n", encoding="utf-8")
+            deploy_dashboard = scripts_dir / "deploy-dashboard.sh"
+            deploy_dashboard.write_text("echo /Users/itismyfield/.adk/release\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--root", tmp],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("scripts/deploy-dashboard.sh", result.stderr)
+
+    def test_default_scan_includes_release_helpers_and_policies(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            scripts_dir = Path(tmp) / "scripts"
+            scripts_dir.mkdir()
+            bad_script_paths = [
+                scripts_dir / "_defaults.sh",
+                scripts_dir / "deploy.sh",
+                scripts_dir / "ensure-agentdesk-cli.sh",
+                scripts_dir / "queue-stability-batch.sh",
+            ]
+            for path in bad_script_paths:
+                path.write_text("echo /Users/itismyfield/.adk/release\n", encoding="utf-8")
+
+            policies_dir = Path(tmp) / "policies" / "lib"
+            policies_dir.mkdir(parents=True)
+            policy_path = policies_dir / "portable.js"
+            policy_path.write_text("const path = '/Users/itismyfield/.adk/release';\n", encoding="utf-8")
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--root", tmp],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("scripts/_defaults.sh", result.stderr)
+        self.assertIn("scripts/deploy.sh", result.stderr)
+        self.assertIn("scripts/ensure-agentdesk-cli.sh", result.stderr)
+        self.assertIn("scripts/queue-stability-batch.sh", result.stderr)
+        self.assertIn("policies/lib/portable.js", result.stderr)
+
+    def test_placeholder_home_literals_are_allowed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "example.md"
+            path.write_text(
+                "\n".join(
+                    [
+                        "/Users/REPLACE_ME/.adk/release",
+                        "/Users/user/.adk/release",
+                        "/Users/me/.adk/release",
+                        "/Users/example/.adk/release",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--root", tmp, str(path)],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_placeholder_prefix_with_punctuation_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bad.md"
+            path.write_text(
+                "\n".join(
+                    [
+                        "/Users/user-name/.adk/release",
+                        "/Users/me.dev/.adk/release",
+                        "/Users/example-prod/.adk/release",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--root", tmp, str(path)],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("/Users/user-name", result.stderr)
+        self.assertIn("/Users/me.dev", result.stderr)
+        self.assertIn("/Users/example-prod", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 목표

release/deploy 가능한 portable surface에 특정 운영자 홈 경로(`/Users/<name>`)가 다시 들어오면 CI에서 바로 차단합니다.

## 쉬운 설명

새 Mac 사용자에게 배포되는 스크립트, policy, routine prompt에는 기존 운영자 경로가 기본값처럼 남아 있으면 안 됩니다. 이 PR은 실제 release/deploy 흐름에서 실행되거나 복사되는 파일 묶음을 스캔하는 작은 lint를 추가합니다. 예시가 필요할 때는 `/Users/kunkun/...` 같은 개인 경로 대신 `/Users/example/...`, `/Users/user/...`, `$AGENTDESK_*` 같은 portable placeholder를 쓰도록 고정합니다.

## 개선되는 것

### Fix 1

`scripts/check-portable-paths.py`가 operator-specific `/Users/<name>` literal을 검사하고, placeholder는 경로 경계(`/` 또는 문자열 끝)에서만 허용합니다.

### Fix 2

기본 스캔 대상에 release/deploy entrypoint, sourced helper, migrated launchd script, routine JS, example config, deployed `policies/**/*`를 포함합니다.

### Fix 3

automation candidate routine의 `program.repo_dir` 예시는 API가 바로 받을 수 있는 절대 placeholder 경로(`/Users/example/workspaces/agentdesk`)로 유지합니다.

## Before → After

| 시나리오 | Before | After |
|---|---|---|
| deploy helper에 `/Users/kunkun/...` 추가 | CI가 놓칠 수 있음 | portable path lint 실패 |
| `/Users/user-name/...` 같은 실제 계정명 | placeholder prefix로 오인 가능 | 실패 |
| `program.repo_dir` 예시 복사 | shell expansion 없는 값이면 실패 가능 | 절대 placeholder라 계약과 일치 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
|---|---|---|
| 실제 private path가 들어옴 | 실패 위치와 라인을 stderr에 출력 | 회귀 원인 추적 가능 |
| `/Users/example/...` placeholder 사용 | 통과 | 예시 문서는 유지 가능 |
| optional 파일이 없음 | 존재 파일만 검사 | release surface 차이에 안전 |

## 해결한 내용

- `scripts/check-portable-paths.py`: portable deployable surface path lint와 기본 스캔 목록을 추가했습니다.
- `tests/test_portable_path_lint.py`: reject/allow/default scan, helper/policy scan 회귀 테스트를 추가했습니다.
- `scripts/ci-script-checks.sh`: portable path lint와 unittest를 CI script checks에 포함했습니다.
- `routines/monitoring/automation-candidate-detector.js`: 개인 repo path 예시를 절대 portable placeholder로 변경했습니다.

## 검증

- `python3 scripts/check-portable-paths.py` — 106 files scanned, passed
- `python3 -m unittest tests.test_portable_path_lint` — 6 passed
- `python3 -m unittest tests.test_install_bootstrap_portable` — 5 passed
- `shellcheck -S warning scripts/ci-script-checks.sh` — passed
- `git diff --check` — passed
