### PR TITLE
Docs: clean portable example config defaults

### DIFF
--- a/agentdesk.example.yaml
+++ b/agentdesk.example.yaml
@@ -163,8 +163,6 @@ voice:
 
 shared_prompt: "~/.adk/release/config/agents/_shared.prompt.md"
 
-shared_prompt: "~/.adk/release/config/agents/_shared.prompt.md"
-
 agents:
   - id: ch-td
     name: "TD"
@@ -175,17 +173,17 @@ agents:
         id: "123456789012345678"
         name: "td-cc"
         workspace: "~/.adk/release/workspaces/ch-td"
-        prompt_file: "~/.adk/release/config/agents/ch-td/IDENTITY.md"
+        prompt_file: "~/.adk/release/config/agents/ch-td.prompt.md"
       codex:
         id: "223456789012345678"
         name: "td-cdx"
         workspace: "~/.adk/release/workspaces/ch-td"
-        prompt_file: "~/.adk/release/config/agents/ch-td/IDENTITY.md"
+        prompt_file: "~/.adk/release/config/agents/ch-td.prompt.md"
       opencode:
         id: "323456789012345678"
         name: "td-oc"
         workspace: "~/.adk/release/workspaces/ch-td"
-        prompt_file: "~/.adk/release/config/agents/ch-td/IDENTITY.md"
+        prompt_file: "~/.adk/release/config/agents/ch-td.prompt.md"
     keywords:
       - "아키텍처"
       - "코드"
@@ -361,7 +359,7 @@ automation:
   enabled: false
   strategy: "squash"
   strategy_mode: "direct-first"
-  allowed_authors: "itismyfield,octocat"
+  allowed_authors: "REPLACE_ME,octocat"
 
 # Onboarding wizard / project-agentfactory rules — externalize what was once
 # hardcoded inside the Discord factory prompt. (#1110, Epic #912 Phase P6)

--- a/tests/test_portable_docs_examples.py
+++ b/tests/test_portable_docs_examples.py
@@ -18,12 +18,15 @@ class PortableDocsExamplesTests(unittest.TestCase):
 
         self.assertNotIn("mac-mini-release", text)
         self.assertNotIn("mac-book-release", text)
+        self.assertNotIn("itismyfield", text)
         self.assertNotIn("1469870512812462284", text)
         self.assertIn("example-main-node", text)
         self.assertIn("example-worker-node", text)
         self.assertIn("YOUR_GUILD_ID", text)
         self.assertIn("YOUR_DEV_CATEGORY_ID", text)
         self.assertIn("YOUR_OPERATIONS_CATEGORY_ID", text)
+        self.assertEqual(text.count("shared_prompt:"), 1)
+        self.assertNotIn("/IDENTITY.md", text)
 
     def test_readme_cluster_snippet_uses_starter_node_names(self):
         text = self.read("README.md")


### PR DESCRIPTION
## 목표

`agentdesk.example.yaml`의 starter 기본값에서 기존 operator 흔적과 구형 prompt 경로를 제거해 새 Mac 사용자가 그대로 복사해도 덜 헷갈리게 합니다.

## 쉬운 설명

예제 config에 중복 `shared_prompt`가 있었고, 기본 `allowed_authors`에 특정 GitHub 사용자명이 들어 있었습니다. starter agent prompt 경로도 현재 flat prompt layout과 맞지 않는 `IDENTITY.md` 형태였습니다. 이 PR은 예제만 정리하고 런타임 동작은 바꾸지 않습니다.

## 개선되는 것

### Fix 1

Before: `shared_prompt`가 두 번 선언되어 예제 config를 읽는 사람이 어느 값이 canonical인지 혼동할 수 있었습니다.

After: `shared_prompt`는 한 번만 남습니다.

### Fix 2

Before: starter 예제에 `itismyfield`와 `config/agents/<role>/IDENTITY.md` 경로가 남아 있었습니다.

After: `REPLACE_ME` placeholder와 `config/agents/<role>.prompt.md` flat prompt 경로를 사용합니다.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| 새 사용자가 예제 config 복사 | 특정 author 이름 포함 | `REPLACE_ME`로 교체 지점 명확 |
| prompt 파일 경로 확인 | 구형 `IDENTITY.md` layout | 현재 flat `.prompt.md` layout |
| shared prompt 확인 | 같은 키 2회 선언 | 같은 키 1회 선언 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| runtime config 로딩 | 예제 파일만 변경 | 실제 런타임 영향 없음 |
| E2E example agents | 그대로 유지 | 기존 예제 범위 보존 |
| portable docs guard | 새 assertion 추가 | operator-specific 값 재유입 방지 |

## 해결한 내용

- `agentdesk.example.yaml`에서 중복 `shared_prompt`를 제거했습니다.
- starter agent prompt path를 flat `.prompt.md` layout으로 맞췄습니다.
- `automation.allowed_authors`의 특정 사용자명을 placeholder로 바꿨습니다.
- portable docs test가 `itismyfield`, 중복 `shared_prompt`, `/IDENTITY.md` 재유입을 잡도록 보강했습니다.

## 검증

- `python3 -m unittest tests.test_portable_docs_examples`
- `python3` YAML parse check for `agentdesk.example.yaml`
