### PR TITLE
fix(cancel): reliable interrupt — escalate on PID-lookup miss, honor force in body, clear active anchor on force purge

### DIFF
--- a/src/server/routes/queue_api.rs
+++ b/src/server/routes/queue_api.rs
@@ -4,6 +4,7 @@
 
 use axum::{
     Json,
+    body::Bytes,
     extract::{Path, Query, State},
     http::StatusCode,
 };
@@ -154,6 +155,34 @@ pub struct CancelTurnQuery {
     pub force: bool,
 }
 
+/// #3029(C): `force` carried in the request *body*, mirroring the JSON-body
+/// shape of `cancel_all_dispatches` / `extend_turn_timeout`. Clients that POST
+/// `{"force": true}` previously had it silently dropped because the handler
+/// only read `Query<CancelTurnQuery>`, downgrading an intended hard-kill to a
+/// soft cancel.
+#[derive(Debug, Default, Deserialize)]
+pub struct CancelTurnBody {
+    #[serde(default)]
+    pub force: bool,
+}
+
+/// #3029(C): resolve the effective `force` intent from query + body. The body
+/// wins when present and parseable (it's the canonical JSON shape); the query
+/// param remains an honored fallback for existing `?force=true` clients. An
+/// empty or non-JSON body falls through to the query value, so callers that
+/// never sent a body keep working unchanged.
+fn resolve_cancel_force(query_force: bool, body: &Bytes) -> bool {
+    if body.is_empty() {
+        return query_force;
+    }
+    match serde_json::from_slice::<CancelTurnBody>(body) {
+        Ok(parsed) => parsed.force || query_force,
+        // Unparseable body: do not silently swallow the request; honor the
+        // query fallback so a `?force=true` with a junk body still forces.
+        Err(_) => query_force,
+    }
+}
+
 /// Cancel the active turn in a channel.
 ///
 /// Default (`force=false`): preserves the live provider session and watcher;
@@ -162,15 +191,19 @@ pub struct CancelTurnQuery {
 ///
 /// `force=true`: tear the tmux session down, SIGKILL the PID tree, clear
 /// inflight state. The turn will not complete gracefully; in-flight
-/// `cargo`/`claude` subprocesses get terminated.
+/// `cargo`/`claude` subprocesses get terminated. `force` may be supplied either
+/// as a query param (`?force=true`) or in the JSON body (`{"force": true}`,
+/// #3029); the body wins when both are present.
 pub async fn cancel_turn(
     State(state): State<AppState>,
     Path(channel_id): Path<String>,
     Query(query): Query<CancelTurnQuery>,
+    body: Bytes,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    let force = resolve_cancel_force(query.force, &body);
     match state
         .queue_service()
-        .cancel_turn(state.health_registry.as_ref(), &channel_id, query.force)
+        .cancel_turn(state.health_registry.as_ref(), &channel_id, force)
         .await
     {
         Ok(response) => (StatusCode::OK, Json(response)),
@@ -470,5 +503,59 @@ mod tests {
 
         // Clean up the global store entry to avoid polluting other tests.
         let _ = global_store().take_handoff(message_id);
+    }
+}
+
+// #3029(C): `resolve_cancel_force` is a pure parser with no DB/runtime
+// dependency, so its coverage lives in a plain `#[cfg(test)]` module that runs
+// under the default `cargo test` invocation (the suite above is gated behind
+// the `legacy-sqlite-tests` feature, which CI does not enable by default).
+#[cfg(test)]
+mod cancel_force_tests {
+    use super::*;
+    use axum::body::Bytes;
+
+    #[test]
+    fn body_force_true_is_honored_even_when_query_false() {
+        let body = Bytes::from_static(b"{\"force\": true}");
+        assert!(
+            resolve_cancel_force(false, &body),
+            "force in body must be honored (#3029 C): previously dropped to default=false"
+        );
+    }
+
+    #[test]
+    fn body_force_false_is_respected() {
+        let body = Bytes::from_static(b"{\"force\": false}");
+        assert!(!resolve_cancel_force(false, &body));
+    }
+
+    #[test]
+    fn empty_body_falls_back_to_query() {
+        let empty = Bytes::new();
+        assert!(
+            resolve_cancel_force(true, &empty),
+            "existing ?force=true clients (no body) must keep forcing"
+        );
+        assert!(!resolve_cancel_force(false, &empty));
+    }
+
+    #[test]
+    fn query_force_remains_fallback_when_body_omits_force() {
+        // Body is valid JSON but omits `force` → serde default false; the query
+        // value still wins as a fallback.
+        let body = Bytes::from_static(b"{}");
+        assert!(resolve_cancel_force(true, &body));
+        assert!(!resolve_cancel_force(false, &body));
+    }
+
+    #[test]
+    fn unparseable_body_falls_back_to_query() {
+        let junk = Bytes::from_static(b"not json");
+        assert!(
+            resolve_cancel_force(true, &junk),
+            "a junk body must not silently swallow a ?force=true intent"
+        );
+        assert!(!resolve_cancel_force(false, &junk));
     }
 }

--- a/src/services/discord/turn_bridge/tmux_runtime.rs
+++ b/src/services/discord/turn_bridge/tmux_runtime.rs
@@ -61,6 +61,41 @@ pub(in crate::services::discord) struct ProviderTurnInterruptOutcome {
     pub sent_keys: bool,
     pub fallback_sigint_pid: Option<u32>,
     pub missing_tmux_session: bool,
+    /// #3029(A): set when the SIGINT-only interrupt path (empty key list —
+    /// claude, whose pane C-c targets the wrapper) needed to deliver a SIGINT
+    /// to an actively-generating turn but the provider PID lookup returned
+    /// `None` (ps failure, command-name drift, or a just-spawned child not yet
+    /// visible). On that path the interrupt is the *only* delivery mechanism,
+    /// so a `None` PID is a silent no-op: the mailbox marks the turn [Stopped]
+    /// but no signal reaches the provider. This flag converts that into an
+    /// explicit failure the hard-stop path can escalate on, instead of
+    /// reporting unconditional success.
+    pub sigint_target_missing: bool,
+}
+
+/// #3029(A): does this provider/plan combination treat the direct SIGINT
+/// fallback as its *only* interrupt delivery (i.e. there is no send-keys path
+/// that could have reached the turn)? Claude uses an empty key list because a
+/// pane C-c hits the wrapper and tears the session down (#1260) — so when its
+/// SIGINT target is missing, the interrupt silently did nothing.
+fn interrupt_is_sigint_only(provider: &ProviderKind, plan_keys_empty: bool) -> bool {
+    plan_keys_empty && matches!(provider, ProviderKind::Claude)
+}
+
+/// #3029(A): the interrupt silently did nothing when the SIGINT-only path was
+/// the only delivery mechanism, the turn was genuinely active
+/// (`ready_for_input == false`), yet no SIGINT target PID could be resolved.
+/// An idle pane (`ready_for_input == true`) intentionally resolves to no PID
+/// and is NOT a missed interrupt (#3021).
+fn interrupt_sigint_target_missing(
+    provider: &ProviderKind,
+    plan_keys_empty: bool,
+    ready_for_input: bool,
+    resolved_sigint_pid: Option<u32>,
+) -> bool {
+    interrupt_is_sigint_only(provider, plan_keys_empty)
+        && !ready_for_input
+        && resolved_sigint_pid.is_none()
 }
 
 fn provider_turn_interrupt_plan(provider: &ProviderKind) -> Option<ProviderTurnInterruptPlan> {
@@ -169,6 +204,7 @@ pub(in crate::services::discord) async fn interrupt_provider_cli_turn(
             sent_keys: false,
             fallback_sigint_pid: None,
             missing_tmux_session: true,
+            sigint_target_missing: false,
         };
     };
     let Some(plan) = provider_turn_interrupt_plan(provider) else {
@@ -177,6 +213,7 @@ pub(in crate::services::discord) async fn interrupt_provider_cli_turn(
             sent_keys: false,
             fallback_sigint_pid: None,
             missing_tmux_session: false,
+            sigint_target_missing: false,
         };
     };
 
@@ -238,6 +275,7 @@ pub(in crate::services::discord) async fn interrupt_provider_cli_turn(
             sent_keys,
             fallback_sigint_pid: None,
             missing_tmux_session: false,
+            sigint_target_missing: false,
         };
     }
 
@@ -358,6 +396,32 @@ pub(in crate::services::discord) async fn interrupt_provider_cli_turn(
 
     let fallback_sigint_pid =
         fallback_sigint_pid_for_provider(provider, ready_for_input, provider_pid);
+
+    // #3029(A): on the SIGINT-only path (claude — empty key list, so the
+    // direct SIGINT is the *only* way to reach the turn), an active turn
+    // (`ready_for_input == false`) that yields no SIGINT target is a silent
+    // no-op: nothing actually interrupts the provider even though the caller
+    // marks the turn [Stopped]. `ready_for_input == false` here means the
+    // confirmation re-probe agreed the turn is genuinely generating (an idle
+    // pane correctly resolves to `None` and is intentionally left alone, #3021).
+    // Flag this so the hard-stop path escalates instead of trusting an
+    // unconditional success.
+    let sigint_target_missing = interrupt_sigint_target_missing(
+        provider,
+        plan.keys.is_empty(),
+        ready_for_input,
+        fallback_sigint_pid,
+    );
+    if sigint_target_missing {
+        tracing::error!(
+            "provider turn interrupt SIGINT target missing: provider={} session={} reason={} \
+             detail=active_turn_without_provider_pid (PID lookup returned None; SIGINT not delivered) — escalating",
+            provider.as_str(),
+            tmux_session_name,
+            reason
+        );
+    }
+
     if let Some(pid) = fallback_sigint_pid {
         if let Err(error) = send_sigint(pid) {
             tracing::warn!(
@@ -384,6 +448,7 @@ pub(in crate::services::discord) async fn interrupt_provider_cli_turn(
         sent_keys,
         fallback_sigint_pid,
         missing_tmux_session: false,
+        sigint_target_missing,
     }
 }
 
@@ -559,6 +624,48 @@ async fn hard_stop_unresponsive_provider_cli_turn(
             (false, false, None, None)
         }
     };
+
+    // #3029(A): the initial interrupt could not find a SIGINT target for an
+    // active SIGINT-only (claude) turn, so no signal was delivered. The
+    // post-grace re-probe runs against current `ps` state and may now resolve
+    // the provider PID (the child became visible / `ps` recovered). Deliver
+    // the SIGINT we previously missed — but only to a live provider PID that
+    // is NOT the pane foreground, so we never SIGINT the wrapper/pane and tear
+    // down a reusable session (PreserveSession intent stays intact; this is a
+    // contained, reach-guaranteed escalation, not the #3018 mapping rework).
+    if interrupt_outcome.sigint_target_missing && session_alive && !ready_for_input {
+        match current_provider_pid {
+            Some(pid) if Some(pid) != pane_pid => {
+                if let Err(error) = send_sigint(pid) {
+                    tracing::warn!(
+                        "provider hard-stop SIGINT re-delivery failed: provider={} session={} pid={} reason={} error={}",
+                        provider.as_str(),
+                        tmux_session_name,
+                        pid,
+                        reason,
+                        error
+                    );
+                } else {
+                    tracing::info!(
+                        "provider hard-stop SIGINT re-delivered after missed interrupt target: provider={} session={} pid={} reason={}",
+                        provider.as_str(),
+                        tmux_session_name,
+                        pid,
+                        reason
+                    );
+                }
+            }
+            _ => {
+                tracing::error!(
+                    "provider hard-stop could not escalate missed SIGINT: provider={} session={} reason={} \
+                     detail=no_live_non_pane_provider_pid (interrupt did not reach the turn)",
+                    provider.as_str(),
+                    tmux_session_name,
+                    reason
+                );
+            }
+        }
+    }
 
     let Some(pid) = hard_stop_pid_for_unresponsive_provider(
         provider,
@@ -1785,5 +1892,61 @@ mod pid_exit_tests {
             elapsed < Duration::from_secs(2),
             "the upper bound must not be exceeded by more than scheduler jitter (took {elapsed:?})"
         );
+    }
+}
+
+// #3029(A): the "missed SIGINT target" decision is a pure boolean and runs
+// under the default `cargo test` invocation (the main suite is gated behind
+// the `legacy-sqlite-tests` feature, which CI does not enable by default).
+#[cfg(test)]
+mod sigint_target_missing_tests {
+    use super::interrupt_sigint_target_missing;
+    use crate::services::provider::ProviderKind;
+
+    #[test]
+    fn active_claude_without_pid_is_a_missed_interrupt() {
+        // SIGINT-only path (empty keys = claude), turn actively generating
+        // (ready_for_input=false), and NO resolved PID → silent no-op that must
+        // now be flagged for escalation instead of reporting success.
+        assert!(
+            interrupt_sigint_target_missing(&ProviderKind::Claude, true, false, None),
+            "active claude with no resolvable PID must escalate (#3029 A), not silently succeed"
+        );
+    }
+
+    #[test]
+    fn active_claude_with_pid_is_not_missed() {
+        assert!(
+            !interrupt_sigint_target_missing(&ProviderKind::Claude, true, false, Some(42)),
+            "a resolved PID means the SIGINT had a target — not a miss"
+        );
+    }
+
+    #[test]
+    fn idle_claude_without_pid_is_not_missed() {
+        // #3021: an idle pane intentionally resolves to no PID and is left
+        // alone; that is NOT a missed interrupt.
+        assert!(
+            !interrupt_sigint_target_missing(&ProviderKind::Claude, true, true, None),
+            "idle claude (ready_for_input=true) is intentionally skipped, not a miss (#3021)"
+        );
+    }
+
+    #[test]
+    fn wrapped_providers_are_not_sigint_only() {
+        // Codex/Qwen have a send-keys path, so a missing fallback PID is not a
+        // SIGINT-only silent no-op (their send-keys still reaches the wrapper).
+        assert!(!interrupt_sigint_target_missing(
+            &ProviderKind::Codex,
+            false,
+            false,
+            None
+        ));
+        assert!(!interrupt_sigint_target_missing(
+            &ProviderKind::Qwen,
+            false,
+            false,
+            None
+        ));
     }
 }

--- a/src/services/queue.rs
+++ b/src/services/queue.rs
@@ -96,12 +96,19 @@ async fn force_purge_channel_mailbox(
         &token_hash,
         None,
     );
-    let purged = handle.purge_queue(persistence).await;
+    // #3029(D): force purge must also release the active-turn anchor so the
+    // next dispatch is not blocked by a stale `cancel_token` /
+    // `active_user_message_id`. The handler only clears an anchor whose token
+    // is already `cancelled` (the force-kill above flipped it), so a fresh
+    // turn that raced in after the kill keeps its anchor (#2706).
+    let purge = handle.purge_queue(persistence, true).await;
+    let purged = purge.drained;
     tracing::info!(
         provider = provider.as_str(),
         channel_id = channel_id.get(),
         purged,
         disk_files_removed,
+        cleared_active_anchor = purge.cleared_active_anchor,
         session_key,
         "force purged channel mailbox queue"
     );

--- a/src/services/turn_orchestrator.rs
+++ b/src/services/turn_orchestrator.rs
@@ -1009,6 +1009,17 @@ pub(crate) struct CancelActiveTurnResult {
     pub(crate) already_stopping: bool,
 }
 
+/// #3029(D): outcome of a `PurgeQueue` request.
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub(crate) struct PurgeQueueResult {
+    /// Number of intervention-queue entries drained.
+    pub(crate) drained: usize,
+    /// Whether the request also released a *cancelled* active-turn anchor
+    /// (only possible when `clear_cancelled_active_anchor` was requested and
+    /// the anchored token was already cancelled).
+    pub(crate) cleared_active_anchor: bool,
+}
+
 pub(crate) struct HasPendingSoftQueueResult {
     pub(crate) has_pending: bool,
     pub(crate) queue_exit_events: Vec<QueueExitEvent>,
@@ -1499,10 +1510,23 @@ impl ChannelMailboxHandle {
     /// touching the active `cancel_token`, so a turn that entered the
     /// mailbox between a sibling force-kill and this call is not
     /// collaterally cancelled.
-    pub(crate) async fn purge_queue(&self, persistence: QueuePersistenceContext) -> usize {
+    ///
+    /// #3029(D): `clear_cancelled_active_anchor=true` additionally releases the
+    /// active-turn anchor when its token is already `cancelled` (force purge),
+    /// so a force cancel does not leave a stale anchor that blocks the next
+    /// dispatch. Pass `false` for a pure queue drain.
+    pub(crate) async fn purge_queue(
+        &self,
+        persistence: QueuePersistenceContext,
+        clear_cancelled_active_anchor: bool,
+    ) -> PurgeQueueResult {
         self.request(
-            |reply| ChannelMailboxMsg::PurgeQueue { persistence, reply },
-            0,
+            |reply| ChannelMailboxMsg::PurgeQueue {
+                persistence,
+                clear_cancelled_active_anchor,
+                reply,
+            },
+            PurgeQueueResult::default(),
         )
         .await
     }
@@ -1983,9 +2007,19 @@ enum ChannelMailboxMsg {
     /// `cancel_token`. Used by `cancel_turn(force=true)` so the in-memory
     /// channel mailbox is emptied even if a fresh turn entered the actor
     /// between `force_kill_turn_without_cancel_event` and this purge.
+    ///
+    /// #3029(D): when `clear_cancelled_active_anchor` is set (force purge),
+    /// also release the active-turn anchor (`cancel_token` /
+    /// `active_request_owner` / `active_user_message_id` / `turn_started_at`)
+    /// — but ONLY if that anchor's token is already `cancelled`. The force
+    /// path cancels the token via `cancel_active_token` before purging, so the
+    /// just-killed turn's anchor is cleared, while a fresh *uncancelled* turn
+    /// that entered the actor between force-kill and purge keeps its anchor
+    /// (preserving the #2706 no-collateral-cancel guarantee).
     PurgeQueue {
         persistence: QueuePersistenceContext,
-        reply: oneshot::Sender<usize>,
+        clear_cancelled_active_anchor: bool,
+        reply: oneshot::Sender<PurgeQueueResult>,
     },
     ReplaceQueue {
         queue: Vec<Intervention>,
@@ -2844,16 +2878,42 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                     let _ = reply.send(result);
                     mark_turn_finished_signal_done(channel_id);
                 }
-                ChannelMailboxMsg::PurgeQueue { persistence, reply } => {
+                ChannelMailboxMsg::PurgeQueue {
+                    persistence,
+                    clear_cancelled_active_anchor,
+                    reply,
+                } => {
                     // #2706: queue-only purge. Leaves `cancel_token`,
                     // `active_request_owner`, `active_user_message_id`
                     // untouched so a turn that entered the actor in
                     // between force-kill and purge is not collaterally
                     // cancelled.
+                    //
+                    // #3029(D): a force purge additionally releases the
+                    // active-turn anchor, but ONLY when the anchored token is
+                    // already `cancelled`. The force path flips that flag via
+                    // `cancel_active_token` before purging, so this clears the
+                    // just-killed turn's anchor while still leaving a fresh,
+                    // uncancelled turn (which raced in after the force-kill)
+                    // fully intact — keeping the #2706 guarantee.
+                    let cleared_active_anchor = if clear_cancelled_active_anchor
+                        && state.cancel_token.as_ref().is_some_and(|token| {
+                            token.cancelled.load(std::sync::atomic::Ordering::Relaxed)
+                        }) {
+                        state.cancel_token = None;
+                        state.active_request_owner = None;
+                        state.active_user_message_id = None;
+                        state.recovery_started_at = None;
+                        state.turn_started_at = None;
+                        reset_watchdog_extension_state(&mut state);
+                        true
+                    } else {
+                        false
+                    };
                     state.last_persistence = Some(persistence.clone());
                     let previous_queue = state.intervention_queue.clone();
                     let drained = state.intervention_queue.drain(..).count();
-                    let result = if persist_queue_or_restore(
+                    let drained = if persist_queue_or_restore(
                         &mut state,
                         channel_id,
                         &persistence,
@@ -2866,7 +2926,13 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                     } else {
                         drained
                     };
-                    let _ = reply.send(result);
+                    if cleared_active_anchor {
+                        mark_turn_finished_signal_done(channel_id);
+                    }
+                    let _ = reply.send(PurgeQueueResult {
+                        drained,
+                        cleared_active_anchor,
+                    });
                 }
                 ChannelMailboxMsg::ReplaceQueue {
                     queue,
@@ -4697,8 +4763,9 @@ mod purge_queue_tests {
             .restore_active_turn(active_token.clone(), UserId::new(7), MessageId::new(70))
             .await;
 
-        let drained = handle.purge_queue(persistence).await;
-        assert_eq!(drained, 3);
+        let purge = handle.purge_queue(persistence, false).await;
+        assert_eq!(purge.drained, 3);
+        assert!(!purge.cleared_active_anchor);
 
         let snapshot = handle.snapshot().await;
         assert!(snapshot.intervention_queue.is_empty());
@@ -4719,11 +4786,71 @@ mod purge_queue_tests {
         let persistence =
             QueuePersistenceContext::new(&provider, "mailbox-purge-idempotent-2706", None);
 
-        let drained_first = handle.purge_queue(persistence.clone()).await;
-        let drained_second = handle.purge_queue(persistence).await;
-        assert_eq!(drained_first, 0);
-        assert_eq!(drained_second, 0);
+        let drained_first = handle.purge_queue(persistence.clone(), false).await;
+        let drained_second = handle.purge_queue(persistence, false).await;
+        assert_eq!(drained_first.drained, 0);
+        assert_eq!(drained_second.drained, 0);
         assert!(handle.snapshot().await.intervention_queue.is_empty());
+    }
+
+    // #3029(D): a force purge (clear_cancelled_active_anchor=true) against an
+    // already-cancelled active turn releases the anchor so the next dispatch
+    // is not blocked by a stale cancel_token / active_user_message_id.
+    #[tokio::test]
+    async fn force_purge_clears_cancelled_active_anchor() {
+        let provider = ProviderKind::Claude;
+        let registry = ChannelMailboxRegistry::default();
+        let channel_id = ChannelId::new(30290);
+        let handle = registry.handle(channel_id);
+        let persistence = QueuePersistenceContext::new(&provider, "mailbox-force-purge-3029", None);
+
+        let active_token = Arc::new(CancelToken::new());
+        handle
+            .restore_active_turn(active_token.clone(), UserId::new(7), MessageId::new(70))
+            .await;
+        // The force path flips `cancelled` (via cancel_active_token) before
+        // purging; emulate that here.
+        active_token
+            .cancelled
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let purge = handle.purge_queue(persistence, true).await;
+        assert!(
+            purge.cleared_active_anchor,
+            "force purge must release a cancelled active-turn anchor (#3029 D)"
+        );
+        assert!(
+            handle.cancel_token().await.is_none(),
+            "cancelled active anchor must be cleared after force purge"
+        );
+    }
+
+    // #3029(D) / #2706: a force purge must NOT clear the anchor of a fresh,
+    // *uncancelled* turn that raced into the actor after the force-kill —
+    // otherwise force=true would collaterally cancel the new turn.
+    #[tokio::test]
+    async fn force_purge_preserves_uncancelled_active_anchor() {
+        let provider = ProviderKind::Claude;
+        let registry = ChannelMailboxRegistry::default();
+        let channel_id = ChannelId::new(30291);
+        let handle = registry.handle(channel_id);
+        let persistence =
+            QueuePersistenceContext::new(&provider, "mailbox-force-purge-fresh-3029", None);
+
+        let fresh_token = Arc::new(CancelToken::new());
+        handle
+            .restore_active_turn(fresh_token.clone(), UserId::new(7), MessageId::new(71))
+            .await;
+        // Token is NOT cancelled — represents a fresh turn that raced in.
+
+        let purge = handle.purge_queue(persistence, true).await;
+        assert!(
+            !purge.cleared_active_anchor,
+            "uncancelled fresh turn must keep its anchor (#2706 no-collateral-cancel)"
+        );
+        let surviving = handle.cancel_token().await;
+        assert!(surviving.is_some());
+        assert!(Arc::ptr_eq(&surviving.unwrap(), &fresh_token));
     }
 }
 


### PR DESCRIPTION
## Root cause

Three cancel-**initiation** defects (the teardown/finalize side was already covered by #1553 / #3016 / #3026 — this fixes the upstream "did the signal reach the provider, was force honored, was the anchor cleared" side).

### (A) SIGINT silent no-op on PID-lookup miss — `tmux_runtime.rs`
Claude's only interrupt is a direct SIGINT (a pane `C-c` hits the wrapper and tears the session down, #1260), so the empty-key path is the **sole** delivery mechanism. When the turn was actively generating (`ready_for_input=false`) but `provider_cli_pid_in_tmux` → `select_provider_pid_in_pane` returned `None` (ps failure / CLI command-name drift / a just-spawned child not yet in `ps`), the empty-key path still reported unconditional success — the mailbox marked the turn `[Stopped]` while **no signal reached claude**, so it kept generating and the watcher kept relaying.

### (C) `force` honored only from Query, body dropped — `queue_api.rs`
`cancel_turn` took only `Query<CancelTurnQuery>`, so a client POSTing `{"force":true}` in the **body** had it silently dropped to `default=false` — a hard-kill intent quietly downgraded to a soft cancel. Asymmetric with `cancel_all_dispatches` / `extend_turn_timeout`, which take `Json`.

### (D) Force purge left the active anchor — `turn_orchestrator.rs` / `queue.rs`
`PurgeQueue` intentionally leaves `cancel_token` / `active_request_owner` / `active_user_message_id` untouched (#2706, to avoid collaterally cancelling a turn that raced in between force-kill and purge). But that also meant `force=true` never cleared the just-killed turn's anchor, so the next dispatch could stay blocked behind a stale active-turn anchor.

## Fix

- **(A)** Added `ProviderTurnInterruptOutcome.sigint_target_missing`, computed by the pure `interrupt_sigint_target_missing()` (SIGINT-only provider + active turn + no resolved PID). It now logs an explicit error instead of a silent success, and the hard-stop path performs a **contained, reach-guaranteed escalation**: re-probe after the settle grace and SIGINT a freshly-resolved provider PID — but only one that is **not** the pane foreground, so a reusable TUI session is never torn down. PreserveSession intent stays intact; no #3018 mapping rework.
- **(C)** Added a `Bytes` body extractor + `resolve_cancel_force()`: body `force` wins when present, `?force=` query remains an honored fallback for existing clients, and empty/unparseable bodies fall through to the query value.
- **(D)** Added `clear_cancelled_active_anchor` to `PurgeQueue` (new `PurgeQueueResult`). A force purge now releases the anchor **only when its token is already `cancelled`** (the force-kill flips it), preserving the #2706 no-collateral-cancel guarantee for a fresh, uncancelled turn.

## Out of scope (residual)
- **(B)** The `PreserveSession` hard-stop backstop (`hard_stop_pid_for_unresponsive_provider` returns `None` when `candidate == pane_pid`) is left as documented residual.
- The broad #3018 session→pid mapping unification (binding the SIGINT target to a spawn-time PID instead of `ps` heuristics) and the 5-surface cancel-transaction boundary are deferred.

## Verification
- `cargo check --lib` clean (no new warnings).
- New unit tests pass: `sigint_target_missing_tests` (A: escalate-on-None / idle-not-missed / wrapped-providers), `cancel_force_tests` (C: body-force parsing, query fallback, junk-body fallback), `force_purge_clears_cancelled_active_anchor` + `force_purge_preserves_uncancelled_active_anchor` (D).
- Existing `purge_queue_tests`, `finish_cancelled_turn_tests`, `pid_exit_tests` still pass.

Closes #3029

🤖 Generated with [Claude Code](https://claude.com/claude-code)