### PR TITLE
fix(tmux): context-usage bar / completed-thinking line are not running signals (repair #3051 regression)

### DIFF
--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -68,7 +68,14 @@ fn tmux_lines_after_claude_prompt_show_idle_suggestion_chrome(lines: &[&str]) ->
     });
     let idle_footer = lines.iter().any(|line| {
         let line = trim_prompt_line(line);
-        line.contains("Tools: 0 done") || line.contains("bypass permissions")
+        // `Tools: 0 done` means a turn has just started (no tools run yet) — a
+        // running, not idle, signal — so it must NOT count as idle chrome (it
+        // previously let a freshly-submitted running prompt read as ready, #3051).
+        // A completed-work footer (`Tools: N>0 done`) or the permission-mode
+        // banner are the genuine idle markers; mirrors the `!Tools: 0 done` guard
+        // in `..._show_completed_history`.
+        line.contains("bypass permissions")
+            || (line.contains("Tools:") && line.contains(" done") && !line.contains("Tools: 0 done"))
     });
     separator && idle_footer
 }
@@ -153,13 +160,14 @@ fn tmux_recent_lines_show_claude_tui_active_work(lines: &[&str]) -> bool {
             || line.contains("Musing")
             || lower.contains("esc to interrupt")
             || lower.contains("current work")
-            // A freshly-submitted prompt renders a meaningfully advanced
-            // progress bar (e.g. `██░░░░░░░░ │ 24%`) in the footer chrome while
-            // the turn runs. An idle composer shows an empty or barely-filled
-            // bar (`░░░░░░░░░░`, `█░░░░░░░░░` at a few percent), so a run of two
-            // or more filled block glyphs (`██`) marks active work and must not
-            // be judged ready-for-input (#3051 / #2896 regression).
-            || line.contains("██")
+            // NOTE: neither the footer context-usage bar (`🤖 Model │ ██░░ │ NN%`)
+            // nor the completed-thinking summary line (`✻ Churned for 4m 56s`) is a
+            // running signal — both render in IDLE/ready states too. #3051 keyed
+            // active-work on the `██` run, which flipped a ready prompt with >20%
+            // context usage to not-ready; the running vs. idle distinction is
+            // instead carried by the footer (`Tools: 0 done` = freshly-started, no
+            // tools yet) handled in `..._show_idle_suggestion_chrome`, plus the
+            // explicit `esc to interrupt`/spinner-verb keywords above.
             || (line.starts_with('⏺')
                 && ((line.contains("Running ") && line.contains("command"))
                     || line.contains("Searching for ")


### PR DESCRIPTION
## 회귀 수정 (PR #3058 / #3051 후속)

PR #3058(#3051)이 Claude-TUI active-work 판정에 footer의 `██` run을 신호로 추가했으나, `🤖 Model │ ██░░ │ NN%` **컨텍스트 사용량 바는 idle 상태에서도 표시**됩니다. 그 결과 컨텍스트 >20%인 ready 프롬프트가 not-ready로 뒤집혀 `provider::ready_input_prompt_tests::detects_claude_tui_prompt_above_footer`가 main에서 실패했습니다(해당 에이전트가 그 모듈을 안 돌려 놓침). 완료된 thinking 요약 라인(`✻ Churned for 4m 56s`)도 idle capture에 나오므로 leading-spinner 휴리스틱도 부적절.

### 수정
- `██` active-work 신호 제거(스피너-글자 휴리스틱도 도입하지 않음) — 둘 다 running/idle를 구별 못 함.
- running vs idle 구별을 footer로 이전: `Tools: 0 done`(도구 0개 실행 = 갓 시작 = running)은 `..._show_idle_suggestion_chrome`에서 idle chrome으로 더 이상 계산하지 않음. 진짜 idle 신호는 완료-작업 footer(`Tools: N>0 done`) 또는 권한모드 배너. 이는 `..._show_completed_history`의 기존 `!Tools: 0 done` 가드와 일치.

### 검증
- `cargo check --lib` clean
- `provider::ready_input_prompt_tests` 5 passed (회귀 테스트 복구)
- `tmux_common` 19 passed (`claude_prompt_draft_detector_treats_running_submitted_prompt_as_not_ready` 포함 — running→not ready 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)