### PR TITLE
test(dispatch): fix stale delivery-state assertion to match #2036 sent_at dominance

### DIFF
--- a/src/db/dispatched_sessions.rs
+++ b/src/db/dispatched_sessions.rs
@@ -867,10 +867,20 @@ mod dispatch_surface_tests {
 
     #[test]
     fn delivery_state_uppercase_status_is_normalized() {
-        // Defensive: callers occasionally write status values uppercase.
+        // Defensive: callers occasionally write status values uppercase, so
+        // classify_delivery_state lowercases before matching.
+        // NOTE: per #2036, sent_at dominates session_is_working — so a
+        // DISPATCHED turn only reads "codex_active" once sent_at is set
+        // (the bridge handed the prompt to codex); with sent_at unset it is
+        // still "queued". This test pins the case-normalization, not the
+        // sent_at gating, so it passes sent_at_is_set=true for the active case.
+        assert_eq!(
+            classify_delivery_state(Some("DISPATCHED"), true, true),
+            "codex_active"
+        );
         assert_eq!(
             classify_delivery_state(Some("DISPATCHED"), true, false),
-            "codex_active"
+            "queued"
         );
         assert_eq!(
             classify_delivery_state(Some("Completed"), false, false),


### PR DESCRIPTION
## 배경
세션 회귀 스윕 중 `db::dispatched_sessions::dispatch_surface_tests::delivery_state_uppercase_status_is_normalized`가 main에서 격리 실행·baseline(3e0f2e39a) 양쪽에서 실패함을 확인(pre-existing, 세션 회귀 아님).

## 원인
`classify_delivery_state`는 이미 status를 `to_ascii_lowercase`로 정규화하지만, 테스트가 **#2036 이전 동작**을 단언: `(DISPATCHED, working, sent_at=false) => codex_active`. #2036에서 sent_at이 session_is_working을 dominate하도록 바뀌어, sent_at 미설정이면 정답은 `queued`. 함수가 옳고 테스트가 stale.

## 수정
대소문자 정규화 의도를 유지하도록 테스트만 갱신: `(DISPATCHED, working, sent_at=true) => codex_active`, `(DISPATCHED, working, sent_at=false) => queued` 추가. 프로덕션 로직 무변경.

검증: 해당 테스트 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)