### PR TITLE
fix(ci): restore green main — rustfmt + sync giant-file freeze entries (#3060, #3065)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -557,6 +557,7 @@ src/
 │   │   ├── shared_memory.rs
 │   │   ├── stall_recovery.rs
 │   │   ├── standby_relay.rs
+│   │   ├── status_panel_orphan_store.rs
 │   │   ├── streaming_finalizer.rs
 │   │   ├── task_supervisor.rs
 │   │   ├── tmux.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -121,23 +121,23 @@
     lifecycle behavior).
   - `src/services/discord/tmux.rs` (2206 lines after #2558 dead-code sweep;
     failover guard; still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (6056 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (6725 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires; split loop helpers
     further before adding behavior).
-  - `src/services/discord/tui_prompt_relay.rs` (3184 lines; SSH-direct TUI
+  - `src/services/discord/tui_prompt_relay.rs` (3241 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan).
   - `src/services/codex_tmux_wrapper.rs` (1223 lines; Codex tmux wrapper JSON
     event parser and relay bridge for native Codex session events — bugfix only
     outside an extraction plan).
-  - `src/services/tui_prompt_dedupe.rs` (1020 lines; shared TUI prompt
+  - `src/services/tui_prompt_dedupe.rs` (1029 lines; shared TUI prompt
     fingerprinting/dedupe state for hook and rollout relay paths, bugfix only
     outside an extraction plan).
   - `src/services/discord/recovery_engine.rs` (3958 lines).
   - `src/services/discord/health.rs` (2817 lines after #1879 snapshot/mailbox
     extraction).
-  - `src/services/discord/health/recovery.rs` (2382 lines; health recovery
+  - `src/services/discord/health/recovery.rs` (2425 lines; health recovery
     extraction surface, split further before adding non-bugfix behavior).
   - `src/services/discord/router/message_handler/intake_turn.rs` (3613 lines;
     Discord message intake turn orchestration split from the router message
@@ -146,12 +146,12 @@
     headless Discord turn launch/terminal-response path split from the router
     message handler; bugfix only outside a further extraction plan).
   - `src/services/discord/meeting_orchestrator.rs` (3228 lines).
-  - `src/services/discord/turn_bridge/tmux_runtime.rs` (1132 lines; provider
+  - `src/services/discord/turn_bridge/tmux_runtime.rs` (1243 lines; provider
     stop-token/tmux binding runtime + PID-exit observation helper (#2426),
     split before adding non-bugfix behavior).
   - `src/services/discord/turn_bridge/completion_guard.rs` (1909 lines).
-  - `src/services/discord/turn_bridge/tmux_runtime.rs` (1132 lines).
-  - `src/services/discord/formatting.rs` (2708 lines).
+  - `src/services/discord/turn_bridge/tmux_runtime.rs` (1243 lines).
+  - `src/services/discord/formatting.rs` (2713 lines).
   - `src/services/discord/settings.rs` (2479 lines).
   - `src/services/discord/prompt_builder/` (directory, refactored).
   - `src/services/discord/runtime_bootstrap.rs` (2564 lines after #2558
@@ -332,7 +332,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   `src/services/auto_queue/cancel_run.rs` (1032) is also giant-file territory;
   split before further non-bugfix growth.
 - `src/services/onboarding/mod.rs` (4955),
-  `src/services/dispatched_sessions.rs` (3347), and
+  `src/services/dispatched_sessions.rs` (3393), and
   `src/services/settings.rs` (1089) — service-layer route support surfaces
   split out of the large dashboard route modules. (`src/services/onboarding.rs`
   and `src/services/api_friction.rs` have been removed/decomposed.)
@@ -356,7 +356,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   readiness/cancel contract.
 - `src/services/memory/memento.rs` (3062).
 - `src/services/observability/pg_io.rs` (1047).
-- `src/services/dispatched_sessions.rs` (3347) — dispatched session domain
+- `src/services/dispatched_sessions.rs` (3393) — dispatched session domain
   service. This is the post-#1515 SRP extraction target for route/database
   callsites, but the module itself is now giant-file territory; split focused
   helpers before adding non-bugfix behavior.
@@ -369,9 +369,9 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   execution are the canonical scheduled JS routine surfaces. Split focused
   helper modules before growing these files again.
 - `src/services/platform/binary_resolver.rs` (1936).
-- `src/services/discord/mod.rs` (5835),
+- `src/services/discord/mod.rs` (5837),
   `src/services/discord_config_audit.rs` (1318).
-- `src/services/turn_orchestrator.rs` (2866).
+- `src/services/turn_orchestrator.rs` (2932).
 
 Decomposed below the giant-file threshold (no longer frozen; bugfix-scoped but
 normal test growth is allowed): `src/services/analytics.rs`,

--- a/src/db/dispatched_sessions.rs
+++ b/src/db/dispatched_sessions.rs
@@ -1158,7 +1158,10 @@ mod selector_cleanup_tests {
             .await
             .unwrap()
             .expect("session row must still exist after tmux-only cleanup");
-        assert_eq!(ids.claude_session_id.as_deref(), Some("claude-selector-1841"));
+        assert_eq!(
+            ids.claude_session_id.as_deref(),
+            Some("claude-selector-1841")
+        );
         assert_eq!(
             ids.raw_provider_session_id.as_deref(),
             Some("raw-selector-1841"),

--- a/src/dispatch/dispatch_cancel.rs
+++ b/src/dispatch/dispatch_cancel.rs
@@ -708,7 +708,8 @@ mod pg_observability_tests {
         let pool = pg_db.connect_and_migrate().await;
 
         let dispatch_id = "dispatch-cancel-obs-3039";
-        crate::dispatch::test_support::seed_pg_dispatch(&pool, dispatch_id, "Cancel obs test").await;
+        crate::dispatch::test_support::seed_pg_dispatch(&pool, dispatch_id, "Cancel obs test")
+            .await;
 
         let changed = cancel_dispatch_and_reset_auto_queue_on_pg(
             &pool,
@@ -722,8 +723,7 @@ mod pg_observability_tests {
         let event = crate::services::observability::events::recent(64)
             .into_iter()
             .find(|event| {
-                event.event_type == "dispatch_result"
-                    && event.payload["dispatch_id"] == dispatch_id
+                event.event_type == "dispatch_result" && event.payload["dispatch_id"] == dispatch_id
             })
             .expect("cancel must record a dispatch_result observability event (#3039)");
         assert_eq!(event.payload["to_status"], "cancelled");

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -3274,11 +3274,7 @@ mod tests {
     #[test]
     fn registry_miss_but_dedupe_hit_drops_and_does_not_use_mirror() {
         assert_eq!(
-            resolve_owner_channel_authoritatively(
-                "tmux-drift",
-                None,
-                Some(456_000_000_000_000),
-            ),
+            resolve_owner_channel_authoritatively("tmux-drift", None, Some(456_000_000_000_000),),
             None,
             "dedupe mirror must never act as a reverse routing authority"
         );

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -75,7 +75,9 @@ fn tmux_lines_after_claude_prompt_show_idle_suggestion_chrome(lines: &[&str]) ->
         // banner are the genuine idle markers; mirrors the `!Tools: 0 done` guard
         // in `..._show_completed_history`.
         line.contains("bypass permissions")
-            || (line.contains("Tools:") && line.contains(" done") && !line.contains("Tools: 0 done"))
+            || (line.contains("Tools:")
+                && line.contains(" done")
+                && !line.contains("Tools: 0 done"))
     });
     separator && idle_footer
 }


### PR DESCRIPTION
## main CI red 복구

### #3065 — Full tests (`just check`)
`cargo fmt --all --check` 실패: 최근 머지된 버그픽스 PR들(#3018/#3039/#3052/#3031 + #3051 회귀 복구)이 rustfmt 미적용으로 머지됨. `cargo fmt --all` 적용(dispatched_sessions.rs, dispatch_cancel.rs, tui_prompt_relay.rs, tmux_common.rs). (다른 Full-tests blocker였던 stale `delivery_state` 단언은 #3067에서 해결.)

### #3060 — Script checks
agent-maintenance LoC hard-gate(#3036)가 `change-surfaces.md`(freeze) ↔ 재생성된 `module-inventory.md` 간 production-LoC drift 11건을 검출(머지된 픽스들이 추적 giant 파일을 키움). `generate_inventory_docs.py` 재실행(ARCHITECTURE.md) + 게이트 처방대로 freeze 항목을 현재 카운트로 동기화.

### 검증
- `cargo fmt --all --check` clean
- `./scripts/ci-script-checks.sh` exit 0
- `tests.test_agent_maintenance_docs` 23 passed

### 후속(프로세스)
이후 wave 구현 에이전트는 PR 전 `cargo fmt --all` + `just check`를 필수 실행하도록 강화.

Closes #3060
Closes #3065

🤖 Generated with [Claude Code](https://claude.com/claude-code)