### PR TITLE
fix(relay): clear stale session lifecycle panel on watcher-direct turns (#3055)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -121,9 +121,10 @@
     lifecycle behavior).
   - `src/services/discord/tmux.rs` (2206 lines after #2558 dead-code sweep;
     failover guard; still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (6725 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (6826 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
-    explicit-cleanup wires; split loop helpers
+    explicit-cleanup wires + #3055 watcher session-panel lifecycle
+    refresh; split loop helpers
     further before adding behavior).
   - `src/services/discord/tui_prompt_relay.rs` (3241 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -495,6 +495,42 @@ fn status_panel_appends_recovery_message_count_line_when_present() {
     assert!(rendered.contains("(최근 대화 7개를 읽어들였습니다)"));
 }
 
+/// #3055 — a watcher-direct turn that has no session lifecycle event of its own
+/// must not reuse the per-channel session panel snapshot left behind by a prior
+/// turn's `session_fresh(recoveryMessageCount=N)`. The watcher completion path
+/// re-derives the snapshot for the current turn; when the current turn has no
+/// lifecycle row it clears the panel (mirroring the bridge), so the stale
+/// `🆕 새 세션 시작 (최근 대화 N개…)` line is gone.
+#[test]
+fn status_panel_clears_stale_session_line_for_watcher_turn_without_lifecycle() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3055);
+
+    // Turn A: a fresh-session/recovery event sets the channel-scoped snapshot.
+    assert!(events.set_session_panel_lifecycle_event(
+        channel_id,
+        "session_fresh",
+        &json!({
+            "reason": "no_cached_provider_session",
+            "recoveryMessageCount": 33,
+        }),
+    ));
+    let turn_a = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    assert!(turn_a.contains("🆕 새 세션 시작"));
+    assert!(turn_a.contains("(최근 대화 33개를 읽어들였습니다)"));
+
+    // Turn B (watcher-direct, no lifecycle row): the completion path clears the
+    // session panel before rendering. The cleared snapshot must drop the stale
+    // new-session/recovery line.
+    assert!(events.clear_session_panel(channel_id));
+    let turn_b = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    assert!(!turn_b.contains("🆕 새 세션 시작"));
+    assert!(!turn_b.contains("최근 대화"));
+
+    // Idempotent: clearing an already-cleared panel reports no change.
+    assert!(!events.clear_session_panel(channel_id));
+}
+
 #[test]
 fn status_panel_omits_recovery_line_when_count_is_zero_or_missing() {
     let events = PlaceholderLiveEvents::default();

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1473,6 +1473,65 @@ async fn complete_watcher_status_panel_v2(
     .await
 }
 
+/// #3055 — the per-channel session lifecycle panel snapshot (`🆕 새 세션 시작`,
+/// `기존 세션 복원`, …) is set by the bridge's
+/// `refresh_session_panel_line_from_lifecycle` and is keyed only by channel,
+/// not by turn. The bridge re-derives it from the *current* turn's lifecycle
+/// row on every status tick (and clears it when the current turn has no
+/// session lifecycle event). The watcher-direct render/completion paths never
+/// performed that refresh, so a watcher-direct TUI turn would reuse a stale
+/// snapshot left behind by a prior turn's `session_fresh`/`session_resumed`
+/// event (e.g. a `(최근 대화 N개…)` recovery line from an earlier
+/// recovery/new-session turn).
+///
+/// Mirror the bridge behaviour for the watcher: load the latest session
+/// lifecycle event for *this* watcher turn and set the panel from it, or clear
+/// the panel when the current turn has no such event. Watcher-direct TUI turns
+/// carry `user_msg_id == 0` (no anchored Discord message) so they key onto the
+/// invariant-guarded `discord:<channel>:0` turn id, which by construction has
+/// no session lifecycle row — the panel is therefore cleared and the stale
+/// line is never reused.
+async fn refresh_watcher_session_panel_from_lifecycle(
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+    user_msg_id: u64,
+) {
+    if !shared.status_panel_v2_enabled {
+        return;
+    }
+    let Some(pg_pool) = shared.pg_pool.as_ref() else {
+        return;
+    };
+    let turn_id = format!("discord:{}:{}", channel_id.get(), user_msg_id);
+    let channel_id_text = channel_id.get().to_string();
+    match crate::services::observability::turn_lifecycle::load_latest_session_lifecycle_event(
+        pg_pool,
+        &channel_id_text,
+        &turn_id,
+    )
+    .await
+    {
+        Ok(Some(event)) => {
+            shared
+                .placeholder_live_events
+                .set_session_panel_lifecycle_event(channel_id, &event.kind, &event.details_json);
+        }
+        Ok(None) => {
+            shared
+                .placeholder_live_events
+                .clear_session_panel(channel_id);
+        }
+        Err(error) => {
+            tracing::debug!(
+                "[tmux_watcher] failed to load session lifecycle line for turn {} in channel {}: {}",
+                turn_id,
+                channel_id,
+                error
+            );
+        }
+    }
+}
+
 /// #2161 — TUI completion gate. Callers ask `run_tui_completion_gate` to
 /// confirm the underlying tmux pane has reached a `Ready for input`
 /// quiescent state before pushing `StatusEvent::TurnCompleted` to the live
@@ -3868,6 +3927,22 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                     if shared.status_panel_v2_enabled
                         && let Some(status_msg_id) = status_panel_msg_id
                     {
+                        // #3055: re-derive the session lifecycle panel line for
+                        // *this* watcher turn before each streaming render, the
+                        // same way the bridge does on every status tick. Without
+                        // this the watcher-direct path renders a stale
+                        // per-channel `🆕 새 세션 시작 (최근 대화 N개…)` snapshot left
+                        // by an earlier recovery/new-session turn. The lookup is
+                        // already throttled by `status_update_interval`.
+                        refresh_watcher_session_panel_from_lifecycle(
+                            &shared,
+                            channel_id,
+                            turn_identity_for_panel
+                                .as_ref()
+                                .map(|identity| identity.user_msg_id)
+                                .unwrap_or(0),
+                        )
+                        .await;
                         let panel_text = shared.placeholder_live_events.render_status_panel(
                             channel_id,
                             &watcher_provider,
@@ -6649,6 +6724,32 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         None
                     }
                 });
+            // #3055: re-derive this turn's session lifecycle panel line before
+            // finalizing. The bridge does this on every status tick via
+            // `refresh_session_panel_line_from_lifecycle`; the watcher-direct
+            // completion path historically skipped it and so reused a stale
+            // per-channel `🆕 새 세션 시작 (최근 대화 N개…)` snapshot from a prior
+            // recovery/new-session turn. A watcher-direct TUI turn has
+            // `user_msg_id == 0`, keying onto the `discord:<channel>:0` turn id
+            // which has no session lifecycle row, so the panel is cleared and
+            // the stale line is not rendered.
+            let session_panel_lifecycle_user_msg_id = inflight_before_relay
+                .as_ref()
+                .filter(|inflight| {
+                    inflight
+                        .tmux_session_name
+                        .as_deref()
+                        .map(str::trim)
+                        .is_some_and(|name| !name.is_empty() && name == tmux_session_name)
+                })
+                .map(|inflight| inflight.user_msg_id)
+                .unwrap_or(0);
+            refresh_watcher_session_panel_from_lifecycle(
+                &shared,
+                channel_id,
+                session_panel_lifecycle_user_msg_id,
+            )
+            .await;
             let completion_committed = complete_watcher_status_panel_v2(
                 &http,
                 &shared,


### PR DESCRIPTION
## Root cause

A watcher-direct TUI completion in `adk-cc` rendered `🆕 새 세션 시작 (최근 대화 33개를 읽어들였습니다)` even though no new provider/tmux session was created at that time.

The per-channel session lifecycle panel snapshot (`🆕 새 세션 시작`, `기존 세션 복원`, …) is keyed only by **channel**, not by **turn**. The bridge re-derives it from the *current* turn's lifecycle row on every status tick via `refresh_session_panel_line_from_lifecycle` (and clears the panel when the current turn has no session lifecycle event). The watcher-direct render paths — `render_status_panel` during streaming and `complete_watcher_status_panel_v2` at completion — never performed that refresh, so a watcher-direct TUI turn reused a stale snapshot left behind by a prior turn's `session_fresh`/`session_resumed` event.

In the reported incident, the `session_fresh(recoveryMessageCount=33)` snapshot was set by turn `discord:…:1511438006018511070` at 03:35 KST; the 04:05 watcher-direct TUI turn (synthetic ownership, `user_msg_id == 0`, no lifecycle row) reused that snapshot at completion.

## Fix

- Add `refresh_watcher_session_panel_from_lifecycle` in `tmux_watcher.rs`, mirroring the bridge. It loads the latest session lifecycle event for *this* watcher turn (turn id `discord:<channel>:<user_msg_id>`) and sets the panel from it, or clears the panel when the current turn has no such row.
- Watcher-direct TUI turns carry `user_msg_id == 0`, keying onto the invariant-guarded `discord:<channel>:0` turn id which by construction has no session lifecycle row — so the panel is cleared and the stale line is never reused.
- Wired before both the streaming render (throttled by the existing `status_update_interval` gate) and the final completion render.

## Regression test

`status_panel_clears_stale_session_line_for_watcher_turn_without_lifecycle`: after a `session_fresh(recoveryMessageCount=33)` snapshot on turn A, a watcher-direct turn B with no lifecycle event clears the panel via `clear_session_panel` and the rendered completion contains neither `🆕 새 세션 시작` nor `최근 대화 33개`.

## Verification

- `cargo check --lib` — clean, no new warnings
- `cargo fmt --all --check` — clean
- `cargo test --lib placeholder_live_events` — 56 passed (incl. new regression test)
- `cargo test --lib tmux_watcher` — 72 passed
- `./scripts/ci-script-checks.sh` — exit 0 (synced `docs/agent-maintenance/change-surfaces.md` freeze entry for tmux_watcher.rs: 6725 → 6826, since the edit grew a tracked giant file)

Closes #3055

🤖 Generated with [Claude Code](https://claude.com/claude-code)