### PR TITLE
chore(lint): drop 5 leaf-module dead_code blankets (#3034)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -61,18 +61,18 @@
 ### `policy_engine`
 
 - canonical_modules: `src/engine/mod.rs` (driver) plus `src/engine/ops/*.rs`
-  (per-domain op handlers). `src/pipeline.rs` (1340 lines, giant-file)
+  (per-domain op handlers). `src/pipeline.rs` (1351 lines, giant-file)
   composes the policy pipeline.
 - legacy_modules: none — there is no parallel engine. The whole surface is
   pre-migration giant-file territory.
 - do_not_edit_without_migration_plan:
-  - `src/engine/mod.rs` (1449 lines, giant-file).
+  - `src/engine/mod.rs` (1453 lines, giant-file).
   - `src/engine/ops/review_automation_ops.rs` (1056 lines, giant-file).
   - `src/engine/ops/kanban_ops.rs` (1141 lines, giant-file).
   - `src/engine/ops/db_ops.rs` (1286 lines, giant-file).
-  - `src/engine/loader.rs` (1325 lines, giant-file) — engine loader / QuickJS
+  - `src/engine/loader.rs` (1332 lines, giant-file) — engine loader / QuickJS
     validator surface; split before adding non-bugfix behavior.
-  - `src/pipeline.rs` (1340 lines, giant-file).
+  - `src/pipeline.rs` (1351 lines, giant-file).
 - non-giant migration-sensitive note: `src/engine/intent.rs` is below the
   giant-file threshold but remains a migration-sensitive intent surface; keep
   changes scoped to the typed-facade contract.
@@ -258,7 +258,7 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2246 lines).
+  - `src/config.rs` (2242 lines).
   - `src/runtime_layout/mod.rs` (1663 lines).
   - `src/server/mod.rs` (2484 lines).
   - `src/receipt.rs` (1843 lines).

--- a/src/config.rs
+++ b/src/config.rs
@@ -184,23 +184,6 @@ impl Config {
             .unwrap_or_else(|| default_provider_tui_hosting(&key))
     }
 
-    pub fn any_provider_tui_hosting_requested(&self) -> bool {
-        crate::services::provider::supported_provider_ids()
-            .iter()
-            .any(|provider| self.provider_tui_hosting_enabled(provider))
-            || self
-                .providers
-                .values()
-                .any(|provider| provider.tui_hosting == Some(true))
-            || self.agents.iter().any(|agent| {
-                agent
-                    .channels
-                    .iter()
-                    .into_iter()
-                    .any(|(_, channel)| channel.and_then(AgentChannel::tui_hosting) == Some(true))
-            })
-    }
-
     /// Issue #2193 — Codex remote SSH gate accessor.
     ///
     /// Returns `true` only when the operator has explicitly set
@@ -1508,6 +1491,10 @@ impl OnboardingConfig {
     /// `setupWizardHelpers.ts::PROVIDER_SUFFIX_MAP`. Used as a fallback
     /// when `provider_suffix_map` is unset, so backend and dashboard stay
     /// in lockstep without a config file present.
+    // reason: onboarding suffix-resolution config API mirroring the dashboard
+    // `setupWizardHelpers.ts`; test-covered but not yet wired into a production
+    // caller (the live path uses dispatch::provider_from_channel_suffix).
+    #[allow(dead_code)]
     pub fn provider_suffix_default_map() -> &'static [(&'static str, &'static str)] {
         &[
             ("-cc", "claude"),
@@ -1525,6 +1512,9 @@ impl OnboardingConfig {
     /// Resolves a provider id from a channel name (or any string with the
     /// suffix-bearing trailing token). Reads `provider_suffix_map` first;
     /// falls back to the built-in default map. Case-insensitive.
+    // reason: onboarding config-driven suffix resolver; covered by config tests,
+    // pending wiring into the setup flow.
+    #[allow(dead_code)]
     pub fn provider_from_channel_suffix(&self, channel_name: &str) -> Option<String> {
         let lowered = channel_name.trim().to_ascii_lowercase();
         if lowered.is_empty() {
@@ -1555,6 +1545,9 @@ impl OnboardingConfig {
 
     /// Resolve a category by either a label key (e.g. `dev`) or a raw
     /// numeric Discord category ID. Returns the resolved Discord ID.
+    // reason: onboarding category resolver (label or raw Discord ID); test-covered,
+    // pending wiring into the setup flow.
+    #[allow(dead_code)]
     pub fn resolve_category(&self, label_or_id: &str) -> Option<String> {
         let trimmed = label_or_id.trim();
         if trimmed.is_empty() {
@@ -1582,6 +1575,9 @@ impl OnboardingConfig {
 
 /// Normalise a user-provided suffix key so both `cc` and `-cc` resolve to
 /// `-cc`. Empty strings stay empty so the caller can drop them.
+// reason: helper for provider_from_channel_suffix (onboarding config API), dead
+// until that resolver is wired into the setup flow.
+#[allow(dead_code)]
 fn normalize_suffix_key(raw: &str) -> String {
     let trimmed = raw.trim().trim_start_matches('-').to_ascii_lowercase();
     if trimmed.is_empty() {

--- a/src/engine/loader.rs
+++ b/src/engine/loader.rs
@@ -211,6 +211,9 @@ pub fn load_policies_from_dir(ctx: &Context, dir: &Path) -> Result<Vec<LoadedPol
 /// Load policies from a directory, returning an error if any validation fails.
 /// Used by hot-reload pre-validation so the previous loaded version can be
 /// preserved on failure.
+// reason: hot-reload pre-validation entry point; production hot-reload uses the
+// `_inner` variant, while this thin wrapper is exercised by engine loader tests.
+#[allow(dead_code)]
 pub fn load_policies_from_dir_validated(ctx: &Context, dir: &Path) -> Result<Vec<LoadedPolicy>> {
     load_policies_from_dir_validated_inner(ctx, dir, None)
 }
@@ -1045,6 +1048,10 @@ pub struct HotReloadGuard {
     /// aborts the eval once the deadline passes (#2372). Exposed on the
     /// guard so tests and callers can arm a deadline for live evals running
     /// on the shared runtime.
+    // reason: armed/cleared by the QuickJS interrupt path and read via the
+    // cfg(test)-only `arm_eval_deadline`; the non-test build writes but never
+    // reads this slot.
+    #[allow(dead_code)]
     eval_deadline: Arc<AtomicU64>,
 }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -292,6 +292,10 @@ pub struct PolicyInfo {
 
 impl PolicyEngine {
     /// Create a new policy engine, initializing QuickJS and loading policies.
+    // reason: SQLite-path constructor consumed only by cross-module test setups
+    // (server route tests build engines via new_with_pg); kept as the public
+    // non-PG entry point.
+    #[allow(dead_code)]
     pub fn new(config: &Config) -> Result<Self> {
         Self::new_with_pg_and_label(config, None, "main")
     }
@@ -1554,12 +1558,6 @@ mod tests {
             },
             ..Config::default()
         }
-    }
-
-    fn test_engine_with_pg(_db: &Db, pg_pool: sqlx::PgPool) -> PolicyEngine {
-        let mut config = crate::config::Config::default();
-        config.policies.hot_reload = false;
-        PolicyEngine::new_with_pg(&config, Some(pg_pool)).unwrap()
     }
 
     fn test_engine_with_pg_and_config(config: Config, pg_pool: sqlx::PgPool) -> PolicyEngine {

--- a/src/engine/ops/tests.rs
+++ b/src/engine/ops/tests.rs
@@ -12,63 +12,6 @@ fn test_db() -> Db {
     crate::db::test_db()
 }
 
-fn legacy_review_state_sync_for_tests(conn: &sqlite_test::Connection, json_str: &str) -> String {
-    let params: serde_json::Value = match serde_json::from_str(json_str) {
-        Ok(v) => v,
-        Err(e) => return format!(r#"{{"error":"invalid JSON: {}"}}"#, e),
-    };
-
-    let card_id = params["card_id"].as_str().unwrap_or("");
-    let state = params["state"].as_str().unwrap_or("");
-    if card_id.is_empty() || state.is_empty() {
-        return r#"{"error":"card_id and state are required"}"#.to_string();
-    }
-
-    if state == "clear_verdict" {
-        let result = conn.execute(
-            "UPDATE card_review_state SET last_verdict = NULL, updated_at = datetime('now') WHERE card_id = ?1",
-            sqlite_test::params![card_id],
-        );
-        return match result {
-            Ok(n) => format!(r#"{{"ok":true,"rows_affected":{n}}}"#),
-            Err(e) => format!(r#"{{"error":"sql error: {}"}}"#, e),
-        };
-    }
-
-    let review_round = params["review_round"].as_i64();
-    let last_verdict = params["last_verdict"].as_str();
-    let last_decision = params["last_decision"].as_str();
-    let pending_dispatch_id = params["pending_dispatch_id"].as_str();
-    let review_entered_at = params["review_entered_at"].as_str();
-
-    let result = conn.execute(
-        "INSERT INTO card_review_state (card_id, state, review_round, last_verdict, last_decision, pending_dispatch_id, review_entered_at, updated_at) \
-         VALUES (?1, ?2, COALESCE(?3, (SELECT COALESCE(review_round, 0) FROM kanban_cards WHERE id = ?1), 0), ?4, ?5, ?6, COALESCE(?7, CASE WHEN ?2 = 'reviewing' THEN datetime('now') ELSE NULL END), datetime('now')) \
-         ON CONFLICT(card_id) DO UPDATE SET \
-         state = ?2, \
-         review_round = COALESCE(?3, (SELECT COALESCE(review_round, 0) FROM kanban_cards WHERE id = ?1), review_round), \
-         last_verdict = COALESCE(?4, last_verdict), \
-         last_decision = COALESCE(?5, last_decision), \
-         pending_dispatch_id = CASE WHEN ?6 IS NOT NULL THEN ?6 WHEN ?2 = 'suggestion_pending' THEN pending_dispatch_id ELSE NULL END, \
-         review_entered_at = COALESCE(?7, CASE WHEN ?2 = 'reviewing' THEN datetime('now') ELSE review_entered_at END), \
-         updated_at = datetime('now')",
-        sqlite_test::params![
-            card_id,
-            state,
-            review_round,
-            last_verdict,
-            last_decision,
-            pending_dispatch_id,
-            review_entered_at,
-        ],
-    );
-
-    match result {
-        Ok(n) => format!(r#"{{"ok":true,"rows_affected":{n}}}"#),
-        Err(e) => format!(r#"{{"error":"sql error: {}"}}"#, e),
-    }
-}
-
 fn test_engine_with_pg(_db: &Db, pg_pool: sqlx::PgPool) -> crate::engine::PolicyEngine {
     let mut config = crate::config::Config::default();
     config.policies.hot_reload = false;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,6 @@ mod cli;
 pub(crate) mod compat;
 // Config helpers are shared by CLI/server/tests, with some provider-onboarding
 // helpers only called from rollout flows.
-#[allow(dead_code)]
 mod config;
 pub(crate) mod credential;
 // Database repositories intentionally expose cross-route helpers that are only
@@ -104,7 +103,6 @@ mod db;
 mod dispatch;
 // Policy-engine loader/runtime helpers cover hot-reload and test-only entry
 // points outside the default server launch path.
-#[allow(dead_code)]
 mod engine;
 // Error-code helpers are kept for API response boundaries that only some
 // routes currently surface.
@@ -122,12 +120,10 @@ mod logging;
 pub(crate) mod manual_intervention;
 // Pipeline policy structs include retry/override fields retained for policy
 // compatibility across staged rollout paths.
-#[allow(dead_code)]
 pub(crate) mod pipeline;
 pub(crate) mod receipt;
 // Reconciliation sweep jobs are invoked by maintenance scheduling, not by every
 // compile target.
-#[allow(dead_code)]
 pub(crate) mod reconcile;
 pub(crate) mod runtime;
 // Runtime layout exposes migration helpers used by setup and repair commands.
@@ -141,7 +137,6 @@ mod server;
 #[allow(dead_code)]
 mod services;
 // Supervisor test hooks are intentionally retained for dispatch/runtime tests.
-#[allow(dead_code)]
 pub(crate) mod supervisor;
 mod ui;
 // Utility detectors are shared opportunistically across provider paths.

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -152,6 +152,10 @@ impl PipelineOverrideHealthReport {
     }
 }
 
+// reason: postgres override-health loader exercised by pipeline tests; the live
+// refresh path persists via refresh_override_health_report, so this read-back
+// helper has no production caller yet.
+#[allow(dead_code)]
 pub async fn load_persisted_override_health_report(
     _db: &crate::db::Db,
     pg_pool: Option<&PgPool>,
@@ -782,6 +786,9 @@ impl Default for BackoffPolicy {
 }
 
 /// `on_failure` policy for stages (#1082).
+// reason: staged-rollout policy enum retained for config compatibility; the
+// runtime mirror lives in services::pipeline_routes and is not yet wired here.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum OnFailurePolicy {
@@ -839,6 +846,10 @@ pub struct TimeoutConfig {
     pub condition: Option<String>,
 }
 
+// reason: #1082 timeout retry/backoff resolution surface retained for staged
+// policy rollout; currently consumed only by the #1082 DoD unit tests, pending
+// wiring into the live timeout executor.
+#[allow(dead_code)]
 impl TimeoutConfig {
     /// Default max_retries when caller did not specify (1, per #1082 DoD).
     pub const DEFAULT_MAX_RETRIES: u32 = 1;


### PR DESCRIPTION
## What

First scoped slice of maintainability epic #3034 (lint 전역 억제 복원). Removes the module-level `#[allow(dead_code)]` blanket from **5 leaf/low-risk modules** (`config`, `engine`, `pipeline`, `supervisor`, `reconcile`) and resolves every surfaced dead_code warning — either by deleting genuinely-dead items or by adding a narrowly-scoped item-level `#[allow(dead_code)]` with a `// reason` comment (mirroring the PR #3046 pattern).

**This PR does NOT close #3034** (multi-PR epic). DO NOT MERGE without review.

## Per-module resolution counts

| module | deleted | scoped-allow | notes |
|---|---|---|---|
| `config` | 1 | 4 | deleted unused #2110 scaffold `any_provider_tui_hosting_requested`; scoped the onboarding suffix/category API mirror (test-covered, unwired) |
| `engine` | 2 | 3 | deleted dead duplicate `test_engine_with_pg` (mod.rs) + dead legacy `legacy_review_state_sync_for_tests` (ops/tests.rs); scoped `PolicyEngine::new`, `loader::load_policies_from_dir_validated`, `HotReloadGuard.eval_deadline` |
| `pipeline` | 0 | 3 | scoped #1082 staged-rollout policy surfaces (`load_persisted_override_health_report`, `OnFailurePolicy`, `TimeoutConfig` retry/backoff impl) |
| `supervisor` | 0 | 0 | clean no-op (no surfaced warnings) |
| `reconcile` | 0 | 0 | clean no-op (no surfaced warnings) |

## Deferred: await_holding_lock

The planned crate-wide `clippy::await_holding_lock` allow removal was **dropped from this PR**. A full `cargo clippy --workspace --all-features --all-targets` shows that removing it surfaces **~156 real `await_holding_lock` warnings** concentrated in `services/`/`server/` — including #3016 relay hot-files (`discord/mod.rs`, `turn_finalizer.rs`, etc.). This contradicts the "zero warnings" assumption and, per #3034's own comment, belongs on the **serial #3016 relay track**. The allow is retained here so clippy stays clean and this PR remains file-disjoint and non-relay.

## Verification

- `cargo check --workspace --all-features --all-targets` → clean; zero new dead_code warnings in the 5 modules
- `cargo fmt --all --check` → clean
- `cargo clippy --workspace --all-features --all-targets | grep -c await_holding_lock` → **0**
- `cargo test --lib config` → 65 passed; `cargo test --lib engine` → 62 passed
- `./scripts/ci-script-checks.sh` → exit 0 (synced `change-surfaces.md` freeze LoC for config/pipeline/engine after edits)

Part of #3034 (5/13 module blankets + await block deferred; remaining for later parts: services / server / db / voice / cli / github / kanban / dispatch, plus await_holding_lock on the #3016 track).

🤖 Generated with [Claude Code](https://claude.com/claude-code)