### PR TITLE
refactor(services): route bucket-1 dispatch helpers off the server facade to canonical paths (#3037)

### DIFF
--- a/scripts/audit_maintainability/baselines/service_server_backflow.json
+++ b/scripts/audit_maintainability/baselines/service_server_backflow.json
@@ -2,17 +2,14 @@
   "schema_version": 1,
   "rule": "service_server_backflow",
   "description": "No-regression baseline for src/services references to crate::server or super::server server-layer modules.",
-  "captured_at": "2026-05-30",
-  "total_count": 115,
+  "captured_at": "2026-06-03",
+  "total_count": 70,
   "files": {
     "src/services/agents/query.rs": {
       "count": 2
     },
     "src/services/agents/turn.rs": {
       "count": 2
-    },
-    "src/services/auto_queue.rs": {
-      "count": 4
     },
     "src/services/auto_queue/control_routes.rs": {
       "count": 1
@@ -21,9 +18,6 @@
       "count": 2
     },
     "src/services/auto_queue/phase_gate_violations.rs": {
-      "count": 1
-    },
-    "src/services/auto_queue/query.rs": {
       "count": 1
     },
     "src/services/auto_queue/route.rs": {
@@ -38,18 +32,6 @@
     "src/services/discord/commands/text_commands.rs": {
       "count": 4
     },
-    "src/services/discord/commands/voice.rs": {
-      "count": 2
-    },
-    "src/services/discord/discord_io.rs": {
-      "count": 2
-    },
-    "src/services/discord/gateway.rs": {
-      "count": 14
-    },
-    "src/services/discord/health.rs": {
-      "count": 2
-    },
     "src/services/discord/idle_detector.rs": {
       "count": 1
     },
@@ -57,19 +39,10 @@
       "count": 1
     },
     "src/services/discord/meeting_orchestrator.rs": {
-      "count": 2
+      "count": 1
     },
     "src/services/discord/monitoring_status.rs": {
-      "count": 2
-    },
-    "src/services/discord/outbound/confirmation.rs": {
       "count": 1
-    },
-    "src/services/discord/outbound/delivery.rs": {
-      "count": 1
-    },
-    "src/services/discord/outbound/transport.rs": {
-      "count": 4
     },
     "src/services/discord/recovery_engine.rs": {
       "count": 1
@@ -77,14 +50,8 @@
     "src/services/discord/router/intake_gate.rs": {
       "count": 1
     },
-    "src/services/discord/router/message_handler.rs": {
-      "count": 0
-    },
-    "src/services/discord/router/thread_binding.rs": {
-      "count": 0
-    },
     "src/services/discord/runtime_bootstrap.rs": {
-      "count": 4
+      "count": 3
     },
     "src/services/discord/tmux_lifecycle.rs": {
       "count": 2
@@ -105,7 +72,7 @@
       "count": 1
     },
     "src/services/dispatches/discord_delivery/orchestration.rs": {
-      "count": 3
+      "count": 2
     },
     "src/services/dispatches/outbox_claiming.rs": {
       "count": 4
@@ -113,17 +80,11 @@
     "src/services/dispatches/outbox_queue.rs": {
       "count": 1
     },
-    "src/services/dispatches/outbox_route.rs": {
-      "count": 0
-    },
     "src/services/dispatches/routing_constraint.rs": {
       "count": 3
     },
     "src/services/dispatches/wait_queue.rs": {
       "count": 1
-    },
-    "src/services/issue_announcements.rs": {
-      "count": 3
     },
     "src/services/kanban_cards.rs": {
       "count": 1
@@ -133,15 +94,6 @@
     },
     "src/services/onboarding/mod.rs": {
       "count": 8
-    },
-    "src/services/routines/agent_executor.rs": {
-      "count": 1
-    },
-    "src/services/routines/discord_log.rs": {
-      "count": 3
-    },
-    "src/services/routines/session_control.rs": {
-      "count": 3
     },
     "src/services/session_forwarding.rs": {
       "count": 3

--- a/src/services/auto_queue.rs
+++ b/src/services/auto_queue.rs
@@ -1512,7 +1512,7 @@ fn dispatch_thread_channel_id(
     bindings: Option<&crate::db::agents::AgentChannelBindings>,
 ) -> Option<u64> {
     let bindings = bindings?;
-    let channel = if crate::server::routes::dispatches::use_counter_model_channel(
+    let channel = if crate::services::dispatches::outbox_route::use_counter_model_channel(
         fact.dispatch_type.as_deref(),
     ) {
         bindings.counter_model_channel()
@@ -1521,7 +1521,7 @@ fn dispatch_thread_channel_id(
     };
     channel
         .as_deref()
-        .and_then(crate::server::routes::dispatches::parse_channel_id)
+        .and_then(crate::services::dispatches::outbox_route::parse_channel_id)
 }
 
 fn dispatch_thread_status_suppresses_link(status: &str) -> bool {
@@ -1538,11 +1538,11 @@ fn build_thread_link_candidates(
     let work_channel = bindings
         .primary_channel()
         .as_deref()
-        .and_then(crate::server::routes::dispatches::parse_channel_id);
+        .and_then(crate::services::dispatches::outbox_route::parse_channel_id);
     let review_channel = bindings
         .counter_model_channel()
         .as_deref()
-        .and_then(crate::server::routes::dispatches::parse_channel_id);
+        .and_then(crate::services::dispatches::outbox_route::parse_channel_id);
 
     match (work_channel, review_channel) {
         (Some(work_channel), Some(review_channel)) if work_channel == review_channel => {

--- a/src/services/auto_queue/query.rs
+++ b/src/services/auto_queue/query.rs
@@ -306,7 +306,7 @@ pub(super) fn resolve_activate_dispatch_channel_id(channel: &str) -> Option<u64>
     channel
         .parse::<u64>()
         .ok()
-        .or_else(|| crate::server::routes::dispatches::resolve_channel_alias_pub(channel))
+        .or_else(|| crate::services::dispatches::outbox_route::resolve_channel_alias_pub(channel))
 }
 
 pub(super) async fn group_has_dispatched_entries_pg(

--- a/src/services/discord/commands/voice.rs
+++ b/src/services/discord/commands/voice.rs
@@ -941,9 +941,9 @@ async fn notify_voice_alert(channel_id: ChannelId, content: String, kind: &'stat
         return;
     };
     let client = reqwest::Client::new();
-    let base = crate::server::routes::dispatches::discord_delivery::discord_api_base_url();
+    let base = crate::services::dispatches::discord_delivery::discord_api_base_url();
     let target = channel_id.get().to_string();
-    if let Err(error) = crate::server::routes::dispatches::discord_delivery::post_raw_message_once(
+    if let Err(error) = crate::services::dispatches::discord_delivery::post_raw_message_once(
         &client, &token, &base, &target, &content,
     )
     .await

--- a/src/services/discord/discord_io.rs
+++ b/src/services/discord/discord_io.rs
@@ -199,7 +199,7 @@ fn notification_context(context: &serde_json::Value) -> serde_json::Value {
 /// Parse a channel identifier — numeric ID or name alias (e.g. "윤호네비서") → u64.
 fn resolve_channel_to_u64(raw: &str) -> Result<u64, String> {
     raw.parse::<u64>().or_else(|_| {
-        crate::server::routes::dispatches::resolve_channel_alias_pub(raw)
+        crate::services::dispatches::outbox_route::resolve_channel_alias_pub(raw)
             .ok_or_else(|| format!("cannot resolve channel '{raw}'"))
     })
 }
@@ -455,7 +455,7 @@ async fn deliver_channel_message(
     let client = HttpOutboundClient::new(
         reqwest::Client::new(),
         token.to_string(),
-        crate::server::routes::dispatches::discord_delivery::discord_api_base_url(),
+        crate::services::dispatches::discord_delivery::discord_api_base_url(),
     );
     let mut policy = DiscordOutboundPolicy::review_notification();
     if delivery_id.is_none() {

--- a/src/services/discord/gateway.rs
+++ b/src/services/discord/gateway.rs
@@ -248,7 +248,7 @@ impl DiscordOutboundClient for SerenityTurnOutboundClient {
         &self,
         target_channel: &str,
         content: &str,
-    ) -> Result<String, crate::server::routes::dispatches::discord_delivery::DispatchMessagePostError>
+    ) -> Result<String, crate::services::dispatches::discord_delivery::DispatchMessagePostError>
     {
         let channel_id = parse_channel_id(target_channel)?;
         rate_limit_wait(&self.shared, channel_id).await;
@@ -270,13 +270,13 @@ impl DiscordOutboundClient for SerenityTurnOutboundClient {
         content: &str,
         reference_channel: &str,
         reference_message: &str,
-    ) -> Result<String, crate::server::routes::dispatches::discord_delivery::DispatchMessagePostError>
+    ) -> Result<String, crate::services::dispatches::discord_delivery::DispatchMessagePostError>
     {
         let channel_id = parse_channel_id(target_channel)?;
         let reference_channel_id = parse_channel_id(reference_channel)?;
         let reference_message_id = parse_message_id(reference_message).map_err(|error| {
-            crate::server::routes::dispatches::discord_delivery::DispatchMessagePostError::new(
-                crate::server::routes::dispatches::discord_delivery::DispatchMessagePostErrorKind::Other,
+            crate::services::dispatches::discord_delivery::DispatchMessagePostError::new(
+                crate::services::dispatches::discord_delivery::DispatchMessagePostErrorKind::Other,
                 error,
             )
         })?;
@@ -299,12 +299,12 @@ impl DiscordOutboundClient for SerenityTurnOutboundClient {
         target_channel: &str,
         message_id: &str,
         content: &str,
-    ) -> Result<String, crate::server::routes::dispatches::discord_delivery::DispatchMessagePostError>
+    ) -> Result<String, crate::services::dispatches::discord_delivery::DispatchMessagePostError>
     {
         let channel_id = parse_channel_id(target_channel)?;
         let message_id = parse_message_id(message_id).map_err(|error| {
-            crate::server::routes::dispatches::discord_delivery::DispatchMessagePostError::new(
-                crate::server::routes::dispatches::discord_delivery::DispatchMessagePostErrorKind::Other,
+            crate::services::dispatches::discord_delivery::DispatchMessagePostError::new(
+                crate::services::dispatches::discord_delivery::DispatchMessagePostErrorKind::Other,
                 error,
             )
         })?;
@@ -325,32 +325,29 @@ impl DiscordOutboundClient for SerenityTurnOutboundClient {
 
 fn parse_channel_id(
     raw: &str,
-) -> Result<ChannelId, crate::server::routes::dispatches::discord_delivery::DispatchMessagePostError>
-{
-    raw.parse::<u64>()
-        .map(ChannelId::new)
-        .map_err(|error| {
-            crate::server::routes::dispatches::discord_delivery::DispatchMessagePostError::new(
-                crate::server::routes::dispatches::discord_delivery::DispatchMessagePostErrorKind::Other,
-                format!("invalid Discord channel id {raw}: {error}"),
-            )
-        })
+) -> Result<ChannelId, crate::services::dispatches::discord_delivery::DispatchMessagePostError> {
+    raw.parse::<u64>().map(ChannelId::new).map_err(|error| {
+        crate::services::dispatches::discord_delivery::DispatchMessagePostError::new(
+            crate::services::dispatches::discord_delivery::DispatchMessagePostErrorKind::Other,
+            format!("invalid Discord channel id {raw}: {error}"),
+        )
+    })
 }
 
 fn dispatch_post_error(
     error: serenity::Error,
-) -> crate::server::routes::dispatches::discord_delivery::DispatchMessagePostError {
+) -> crate::services::dispatches::discord_delivery::DispatchMessagePostError {
     let detail = crate::utils::redact::redact_known_secrets(&error.to_string());
     let lowered = detail.to_ascii_lowercase();
     let kind = if detail.contains("BASE_TYPE_MAX_LENGTH")
         || lowered.contains("2000 or fewer in length")
         || lowered.contains("length")
     {
-        crate::server::routes::dispatches::discord_delivery::DispatchMessagePostErrorKind::MessageTooLong
+        crate::services::dispatches::discord_delivery::DispatchMessagePostErrorKind::MessageTooLong
     } else {
-        crate::server::routes::dispatches::discord_delivery::DispatchMessagePostErrorKind::Other
+        crate::services::dispatches::discord_delivery::DispatchMessagePostErrorKind::Other
     };
-    crate::server::routes::dispatches::discord_delivery::DispatchMessagePostError::new(kind, detail)
+    crate::services::dispatches::discord_delivery::DispatchMessagePostError::new(kind, detail)
 }
 
 /// codex review P2 (#1332 follow-up): drain the `queued_placeholders` /

--- a/src/services/discord/health.rs
+++ b/src/services/discord/health.rs
@@ -10,9 +10,6 @@ use sqlx::PgPool;
 use super::SharedData;
 use super::formatting::{build_long_message_attachment, split_message};
 use crate::db::Db;
-use crate::server::routes::dispatches::discord_delivery::{
-    DispatchMessagePostError, DispatchMessagePostErrorKind,
-};
 use crate::services::discord::outbound::delivery::{
     deliver_outbound as deliver_v3_outbound, first_raw_message_id,
 };
@@ -22,6 +19,9 @@ use crate::services::discord::outbound::result::{DeliveryResult, FallbackUsed};
 use crate::services::discord::outbound::{
     DISCORD_HARD_LIMIT_CHARS, DISCORD_SAFE_LIMIT_CHARS, DiscordOutboundClient, OutboundDedupClaim,
     OutboundDedupReservation, OutboundDedupWait, OutboundDeduper, shared_outbound_deduper,
+};
+use crate::services::dispatches::discord_delivery::{
+    DispatchMessagePostError, DispatchMessagePostErrorKind,
 };
 use crate::services::provider::ProviderKind;
 
@@ -1373,7 +1373,7 @@ fn parse_channel_target_value(target: &str) -> Option<u64> {
     trimmed
         .parse::<u64>()
         .ok()
-        .or_else(|| crate::server::routes::dispatches::resolve_channel_alias_pub(trimmed))
+        .or_else(|| crate::services::dispatches::outbox_route::resolve_channel_alias_pub(trimmed))
 }
 
 fn parse_agent_target(target: &str) -> Result<Option<&str>, SendTargetResolutionError> {

--- a/src/services/discord/meeting_orchestrator.rs
+++ b/src/services/discord/meeting_orchestrator.rs
@@ -26,7 +26,7 @@ use super::outbound::{
 use super::role_map::load_meeting_config as load_meeting_config_from_role_map;
 use super::settings::{ResolvedMemorySettings, RoleBinding, load_role_prompt};
 use super::{DispatchProfile, SharedData, rate_limit_wait};
-use crate::server::routes::dispatches::discord_delivery::{
+use crate::services::dispatches::discord_delivery::{
     DispatchMessagePostError, DispatchMessagePostErrorKind,
 };
 

--- a/src/services/discord/monitoring_status.rs
+++ b/src/services/discord/monitoring_status.rs
@@ -13,10 +13,10 @@ use super::outbound::{
     OutboundDeduper, shared_outbound_deduper,
 };
 use super::{SharedData, health, rate_limit_wait};
-use crate::server::routes::dispatches::discord_delivery::{
+use crate::server::routes::state::{MonitoringEntry, MonitoringStore, global_monitoring_store};
+use crate::services::dispatches::discord_delivery::{
     DispatchMessagePostError, DispatchMessagePostErrorKind,
 };
-use crate::server::routes::state::{MonitoringEntry, MonitoringStore, global_monitoring_store};
 
 const RENDER_DEBOUNCE: StdDuration = StdDuration::from_millis(300);
 

--- a/src/services/discord/outbound/confirmation.rs
+++ b/src/services/discord/outbound/confirmation.rs
@@ -17,7 +17,7 @@ pub(crate) async fn send_command_confirmation_message(
     let client = HttpOutboundClient::new(
         reqwest::Client::new(),
         token.to_string(),
-        crate::server::routes::dispatches::discord_delivery::discord_api_base_url(),
+        crate::services::dispatches::discord_delivery::discord_api_base_url(),
     );
     let message = DiscordOutboundMessage::new(
         "discord-command-confirmation",

--- a/src/services/discord/outbound/delivery.rs
+++ b/src/services/discord/outbound/delivery.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use poise::serenity_prelude::ChannelId;
 
-use crate::server::routes::dispatches::discord_delivery::{
+use crate::services::dispatches::discord_delivery::{
     DispatchMessagePostError, DispatchMessagePostErrorKind,
 };
 use crate::services::provider::{CancelToken, cancel_requested};

--- a/src/services/discord/outbound/transport.rs
+++ b/src/services/discord/outbound/transport.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use sha2::{Digest, Sha256};
 use tokio::sync::Notify;
 
-use crate::server::routes::dispatches::discord_delivery::{
+use crate::services::dispatches::discord_delivery::{
     DispatchMessagePostError, DispatchMessagePostErrorKind,
 };
 
@@ -288,7 +288,7 @@ impl DiscordOutboundClient for HttpOutboundClient {
         target_channel: &str,
         content: &str,
     ) -> Result<String, DispatchMessagePostError> {
-        crate::server::routes::dispatches::discord_delivery::post_raw_message_once(
+        crate::services::dispatches::discord_delivery::post_raw_message_once(
             &self.client,
             &self.token,
             &self.discord_api_base,
@@ -304,7 +304,7 @@ impl DiscordOutboundClient for HttpOutboundClient {
         message_id: &str,
         content: &str,
     ) -> Result<String, DispatchMessagePostError> {
-        crate::server::routes::dispatches::discord_delivery::edit_raw_message_once(
+        crate::services::dispatches::discord_delivery::edit_raw_message_once(
             &self.client,
             &self.token,
             &self.discord_api_base,
@@ -316,7 +316,7 @@ impl DiscordOutboundClient for HttpOutboundClient {
     }
 
     async fn resolve_dm_channel(&self, user_id: &str) -> Result<String, DispatchMessagePostError> {
-        let url = crate::server::routes::dispatches::discord_delivery::discord_api_url(
+        let url = crate::services::dispatches::discord_delivery::discord_api_url(
             &self.discord_api_base,
             "/users/@me/channels",
         );

--- a/src/services/discord/runtime_bootstrap.rs
+++ b/src/services/discord/runtime_bootstrap.rs
@@ -582,7 +582,7 @@ async fn recover_orphan_pending_dispatches(shared: &Arc<SharedData>) {
         );
 
         let recovery_result = if let Some(pool) = pg_pool {
-            crate::server::routes::dispatches::requeue_dispatch_notify_pg(pool, dispatch_id)
+            crate::db::dispatches::outbox::requeue_dispatch_notify_pg(pool, dispatch_id)
                 .await
                 .map(|queued| {
                     if !queued {

--- a/src/services/dispatches/discord_delivery/orchestration.rs
+++ b/src/services/dispatches/discord_delivery/orchestration.rs
@@ -11,11 +11,11 @@ use crate::db::dispatches::{
 };
 #[cfg(all(test, feature = "legacy-sqlite-tests"))]
 use crate::dispatch::dispatch_destination_provider_override;
-use crate::server::routes::dispatches::resolve_channel_alias;
 use crate::server::routes::dispatches::thread_reuse::{
     clear_thread_for_channel_pg, get_thread_for_channel_pg, set_thread_for_channel_map_only_pg,
     set_thread_for_channel_pg, try_reuse_thread,
 };
+use crate::services::dispatches::outbox_route::resolve_channel_alias;
 use crate::services::dispatches::outbox_route::{
     build_minimal_dispatch_message, format_dispatch_message, prefix_dispatch_message,
     review_submission_hint, review_target_hint,

--- a/src/services/issue_announcements.rs
+++ b/src/services/issue_announcements.rs
@@ -2,13 +2,13 @@ use chrono::{DateTime, Utc};
 use poise::serenity_prelude::ChannelId;
 use sqlx::{PgPool, Row};
 
-use crate::server::routes::dispatches::discord_delivery::DispatchMessagePostError;
 use crate::services::discord::outbound::delivery::{deliver_outbound, first_raw_message_id};
 use crate::services::discord::outbound::message::OutboundTarget;
 use crate::services::discord::outbound::{
     DeliveryResult, DiscordOutboundClient, DiscordOutboundMessage, DiscordOutboundPolicy,
     HttpOutboundClient, shared_outbound_deduper,
 };
+use crate::services::dispatches::discord_delivery::DispatchMessagePostError;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct IssueAnnouncementDeliveryError {
@@ -433,7 +433,7 @@ async fn send_issue_announcement_message(
     let client = HttpOutboundClient::new(
         reqwest::Client::new(),
         token.to_string(),
-        crate::server::routes::dispatches::discord_delivery::discord_api_base_url(),
+        crate::services::dispatches::discord_delivery::discord_api_base_url(),
     );
     let channel_id = channel_id.trim();
     let channel_id_num = channel_id.parse::<u64>().map_err(|error| {
@@ -488,7 +488,7 @@ fn normalize_channel_id(channel_id: &str) -> String {
     if trimmed.parse::<u64>().is_ok() {
         return trimmed.to_string();
     }
-    crate::server::routes::dispatches::resolve_channel_alias_pub(trimmed)
+    crate::services::dispatches::outbox_route::resolve_channel_alias_pub(trimmed)
         .map(|value| value.to_string())
         .unwrap_or_else(|| trimmed.to_string())
 }

--- a/src/services/routines/agent_executor.rs
+++ b/src/services/routines/agent_executor.rs
@@ -454,7 +454,7 @@ impl RoutineAgentExecutor {
             .primary_channel()
             .ok_or_else(|| anyhow!("agent {agent_id} primary channel is not configured"))?;
         let Some(channel_id_num) =
-            crate::server::routes::dispatches::resolve_channel_alias_pub(&primary_channel)
+            crate::services::dispatches::outbox_route::resolve_channel_alias_pub(&primary_channel)
                 .or_else(|| primary_channel.parse::<u64>().ok())
         else {
             return Err(anyhow!(

--- a/src/services/routines/discord_log.rs
+++ b/src/services/routines/discord_log.rs
@@ -468,7 +468,7 @@ impl RoutineDiscordLogger {
         let client = HttpOutboundClient::new(
             reqwest::Client::new(),
             token,
-            crate::server::routes::dispatches::discord_delivery::discord_api_base_url(),
+            crate::services::dispatches::discord_delivery::discord_api_base_url(),
         );
         let channel = channel_id.parse::<u64>().map_err(|error| {
             format!("invalid routine run Discord summary channel id {channel_id}: {error}")
@@ -595,7 +595,7 @@ impl RoutineDiscordLogger {
         let primary_channel = bindings
             .primary_channel()
             .ok_or_else(|| anyhow!("agent {agent_id} has no primary channel for routine log"))?;
-        let parent_channel_id = crate::server::routes::dispatches::resolve_channel_alias_pub(
+        let parent_channel_id = crate::services::dispatches::outbox_route::resolve_channel_alias_pub(
             &primary_channel,
         )
         .or_else(|| primary_channel.parse::<u64>().ok())
@@ -895,13 +895,14 @@ async fn resolve_agent_channel_target(pool: &PgPool, agent_id: &str) -> Result<S
     let primary_channel = bindings
         .primary_channel()
         .ok_or_else(|| format!("agent {agent_id} has no primary channel for routine log"))?;
-    let channel_id = crate::server::routes::dispatches::resolve_channel_alias_pub(&primary_channel)
-        .or_else(|| primary_channel.parse::<u64>().ok())
-        .ok_or_else(|| {
-            format!(
-                "agent {agent_id} primary channel is invalid for routine log: {primary_channel}"
-            )
-        })?;
+    let channel_id =
+        crate::services::dispatches::outbox_route::resolve_channel_alias_pub(&primary_channel)
+            .or_else(|| primary_channel.parse::<u64>().ok())
+            .ok_or_else(|| {
+                format!(
+                    "agent {agent_id} primary channel is invalid for routine log: {primary_channel}"
+                )
+            })?;
     Ok(format!("channel:{channel_id}"))
 }
 

--- a/src/services/routines/session_control.rs
+++ b/src/services/routines/session_control.rs
@@ -353,7 +353,7 @@ impl RoutineSessionController {
             .primary_channel()
             .ok_or_else(|| anyhow!("agent {agent_id} primary channel is not configured"))?;
         let primary_channel_id =
-            crate::server::routes::dispatches::resolve_channel_alias_pub(&primary_channel)
+            crate::services::dispatches::outbox_route::resolve_channel_alias_pub(&primary_channel)
                 .or_else(|| primary_channel.parse::<u64>().ok())
                 .ok_or_else(|| {
                     anyhow!("agent {agent_id} primary channel is invalid: {primary_channel}")
@@ -406,7 +406,7 @@ impl RoutineSessionController {
             .primary_channel()
             .ok_or_else(|| anyhow!("agent {agent_id} primary channel is not configured"))?;
         let channel_id =
-            crate::server::routes::dispatches::resolve_channel_alias_pub(&primary_channel)
+            crate::services::dispatches::outbox_route::resolve_channel_alias_pub(&primary_channel)
                 .or_else(|| primary_channel.parse::<u64>().ok())
                 .ok_or_else(|| {
                     anyhow!("agent {agent_id} primary channel is invalid: {primary_channel}")
@@ -469,7 +469,7 @@ impl RoutineSessionController {
             .primary_channel()
             .ok_or_else(|| anyhow!("agent {agent_id} primary channel is not configured"))?;
         let primary_channel_id =
-            crate::server::routes::dispatches::resolve_channel_alias_pub(&primary_channel)
+            crate::services::dispatches::outbox_route::resolve_channel_alias_pub(&primary_channel)
                 .or_else(|| primary_channel.parse::<u64>().ok())
                 .ok_or_else(|| {
                     anyhow!("agent {agent_id} primary channel is invalid: {primary_channel}")


### PR DESCRIPTION
## What

Bucket-1 of the service→server backflow remediation (#3037). Under `src/services/*`, domain/infra dispatch helpers were imported through the server-layer route facade `crate::server::routes::dispatches[::discord_delivery]::{...}`. That facade is a pure re-export of items actually defined in the service/db layer. This PR mechanically rewrites those importers to the **canonical** module paths so services no longer reach up through `crate::server::routes`.

Pure import-path rewrites — **no behavior change**.

## Sites rewritten: 45 (across 18 service files)

- `discord_delivery` facade → `crate::services::dispatches::discord_delivery::{...}`
  (`discord_api_base_url`, `discord_api_url`, `post_raw_message_once`, `edit_raw_message_once`, `DispatchMessagePostError`, `DispatchMessagePostErrorKind`, `DispatchTransport`, `HttpDispatchTransport`, …)
- outbox_route helpers → `crate::services::dispatches::outbox_route::{...}`
  (`resolve_channel_alias`, `resolve_channel_alias_pub`, `parse_channel_id`, `use_counter_model_channel`)
- `requeue_dispatch_notify_pg` → `crate::db::dispatches::outbox::requeue_dispatch_notify_pg`

## Baseline update

`scripts/audit_maintainability/baselines/service_server_backflow.json` recomputed per-file; `total_count` **115 → 70** (= sum of per-file counts), keeping the backflow gate consistent (gate fails on increase and requires total == sum).

## Left for later buckets

Symbols genuinely **defined** in the server route layer (not just re-exported) were left in place and noted:
- `UpdateDispatchBody`, `update_dispatch` — `server/routes/dispatches/crud.rs`
- `validate_channel_thread_maps_on_startup_with_backends`, `thread_reuse::{...}` — `server/routes/dispatches/thread_reuse.rs`

(7 backflow sites in services remain pointing at these — moving their definitions belongs to a later bucket.)

## Verification

- `cargo check --workspace --all-features --all-targets` → clean (no new warnings)
- `cargo fmt --all --check` → clean
- `cargo test --lib` for touched modules: pre-existing Postgres/fixture-dependent failures only; reproduced identically on clean `origin/main` for untouched tests (e.g. `services::discord::commands::config::tests::picker_options_*`). Not introduced by this PR.
- `./scripts/ci-script-checks.sh` → exit 0 (service_server_backflow gate green at 70; agent-maintenance LoC gate green, no surfaces flagged)

Part of #3037 (PR-1/N).

🤖 Generated with [Claude Code](https://claude.com/claude-code)