### PR TITLE
refactor(db): drop dead sqlite fallback from 6 prod callsites — PG-only (#3035 Phase 0)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -116,12 +116,12 @@
   parsing), `src/services/discord/inflight.rs` (state file contract).
 - legacy_modules: none — relay routes are being consolidated, not replaced.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/services/discord/watchers/lifecycle.rs` (2456 lines — canonical
+  - `src/services/discord/watchers/lifecycle.rs` (2445 lines — canonical
     lifecycle extraction surface from #1435; split further before adding new
     lifecycle behavior).
   - `src/services/discord/tmux.rs` (2206 lines after #2558 dead-code sweep;
     failover guard; still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (6864 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (6861 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh; split loop helpers
@@ -135,7 +135,7 @@
   - `src/services/tui_prompt_dedupe.rs` (1029 lines; shared TUI prompt
     fingerprinting/dedupe state for hook and rollout relay paths, bugfix only
     outside an extraction plan).
-  - `src/services/discord/recovery_engine.rs` (3958 lines).
+  - `src/services/discord/recovery_engine.rs` (3944 lines).
   - `src/services/discord/health.rs` (2817 lines after #1879 snapshot/mailbox
     extraction).
   - `src/services/discord/health/recovery.rs` (2425 lines; health recovery
@@ -157,7 +157,7 @@
   - `src/services/discord/prompt_builder/` (directory, refactored).
   - `src/services/discord/runtime_bootstrap.rs` (2564 lines after #2558
     thread-session GC loopback shim cleanup).
-  - `src/services/discord/session_runtime.rs` (1425 lines).
+  - `src/services/discord/session_runtime.rs` (1418 lines).
   - `src/services/discord/voice_barge_in.rs` (4653 lines; voice STT/TTS,
     lobby routing, progress mirroring, and barge-in orchestration surface;
     tracked decompose target — see `giant-file-registry.md` (owner
@@ -165,7 +165,7 @@
   - `src/voice/receiver.rs` (1046 lines; voice receive pipeline, utterance
     segmentation, artifact cleanup, and retention policy surface; split before
     adding non-bugfix behavior).
-  - `src/services/discord/commands/config.rs` (1900 lines).
+  - `src/services/discord/commands/config.rs` (1894 lines).
   - `src/services/discord/{commands/text_commands.rs, commands/diagnostics.rs,
     discord_config_audit.rs, router/intake_gate.rs, inflight.rs}`
     (all 1000+ production lines).
@@ -209,7 +209,7 @@
   - `src/server/routes/docs.rs` (5877 lines).
   - `src/server/routes/escalation.rs` (2344 lines).
   - `src/server/routes/meetings.rs` (1705 lines).
-  - `src/server/routes/review_verdict/decision_route.rs` (4832 lines).
+  - `src/server/routes/review_verdict/decision_route.rs` (4804 lines).
   - `src/server/routes/{agents,agents_crud,agents_setup,v1,resume,
     dispatches/thread_reuse}.rs` (all 1000+ production lines).
 - active_callsite_coverage: legacy_db helper coverage tracked separately —

--- a/src/server/routes/review_verdict/decision_route.rs
+++ b/src/server/routes/review_verdict/decision_route.rs
@@ -423,34 +423,6 @@ async fn load_review_decision_card_context_pg_first(
         };
     }
 
-    #[cfg(all(test, feature = "legacy-sqlite-tests"))]
-    if let Some(db) = state.legacy_db()
-        && let Ok(conn) = db.separate_conn()
-        && let Ok(Some((status, repo_id, agent_id, title))) = conn
-            .query_row(
-                "SELECT status, repo_id, assigned_agent_id, title
-                 FROM kanban_cards
-                 WHERE id = ?1",
-                [card_id],
-                |row| {
-                    Ok((
-                        row.get::<_, Option<String>>(0)?,
-                        row.get::<_, Option<String>>(1)?,
-                        row.get::<_, Option<String>>(2)?,
-                        row.get::<_, Option<String>>(3)?,
-                    ))
-                },
-            )
-            .optional()
-    {
-        return ReviewDecisionCardContext {
-            status,
-            repo_id,
-            agent_id,
-            title,
-        };
-    }
-
     ReviewDecisionCardContext::default()
 }
 

--- a/src/services/discord/commands/config.rs
+++ b/src/services/discord/commands/config.rs
@@ -365,13 +365,7 @@ pub(in crate::services::discord) async fn current_working_dir(
         return Some(path);
     }
 
-    let sqlite_settings_db = if shared.pg_pool.is_some() {
-        None
-    } else {
-        None::<&crate::db::Db>
-    };
     load_last_session_path(
-        sqlite_settings_db,
         shared.pg_pool.as_ref(),
         &shared.token_hash,
         channel_id.get(),

--- a/src/services/discord/commands/session.rs
+++ b/src/services/discord/commands/session.rs
@@ -204,7 +204,6 @@ pub(in crate::services::discord) async fn cmd_start(
         drop(data);
 
         save_last_session_runtime(
-            None::<&crate::db::Db>,
             ctx.data().shared.pg_pool.as_ref(),
             &ctx.data().shared.token_hash,
             ch_key.parse::<u64>().unwrap_or_default(),

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -3282,13 +3282,7 @@ pub(super) async fn restore_inflight_turns(
                 .map(|(_, ch)| ch)
             });
             {
-                let sqlite_settings_db = if shared.pg_pool.is_some() {
-                    None
-                } else {
-                    None::<&crate::db::Db>
-                };
                 let persisted_session_path = load_last_session_path(
-                    sqlite_settings_db,
                     shared.pg_pool.as_ref(),
                     &shared.token_hash,
                     channel_id.get(),
@@ -3344,7 +3338,6 @@ pub(super) async fn restore_inflight_turns(
                     }
                 };
                 let saved_remote = load_last_remote_profile(
-                    sqlite_settings_db,
                     shared.pg_pool.as_ref(),
                     &shared.token_hash,
                     channel_id.get(),
@@ -3525,13 +3518,7 @@ pub(super) async fn restore_inflight_turns(
             .recovering_channels
             .insert(channel_id, std::time::Instant::now());
 
-        let sqlite_settings_db = if shared.pg_pool.is_some() {
-            None
-        } else {
-            None::<&crate::db::Db>
-        };
         let persisted_session_path = load_last_session_path(
-            sqlite_settings_db,
             shared.pg_pool.as_ref(),
             &shared.token_hash,
             channel_id.get(),
@@ -3586,7 +3573,6 @@ pub(super) async fn restore_inflight_turns(
             }
         };
         let saved_remote = load_last_remote_profile(
-            sqlite_settings_db,
             shared.pg_pool.as_ref(),
             &shared.token_hash,
             channel_id.get(),

--- a/src/services/discord/session_runtime.rs
+++ b/src/services/discord/session_runtime.rs
@@ -684,11 +684,6 @@ pub(super) async fn auto_restore_session_force(
     let (last_path, saved_remote, provider) = {
         let settings = shared.settings.read().await;
         let provider = settings.provider.clone();
-        let sqlite_settings_db = if shared.pg_pool.is_some() {
-            None
-        } else {
-            None::<&crate::db::Db>
-        };
         let configured_path = settings::resolve_workspace(channel_id, restore_ch_name.as_deref())
             .or_else(|| {
                 if is_dm {
@@ -699,7 +694,6 @@ pub(super) async fn auto_restore_session_force(
                 }
             });
         let saved_remote = load_last_remote_profile(
-            sqlite_settings_db,
             shared.pg_pool.as_ref(),
             &shared.token_hash,
             channel_id.get(),
@@ -764,7 +758,6 @@ pub(super) async fn auto_restore_session_force(
             }
         });
         let persisted_path = load_last_session_path(
-            sqlite_settings_db,
             shared.pg_pool.as_ref(),
             &shared.token_hash,
             channel_id.get(),

--- a/src/services/discord/settings/read.rs
+++ b/src/services/discord/settings/read.rs
@@ -185,16 +185,6 @@ fn fallback_legacy_vec<T>(
     }
 }
 
-fn load_kv_meta_value_sqlite(db: Option<&crate::db::Db>, key: &str) -> Option<String> {
-    let db = db?;
-    let conn = db.read_conn().ok()?;
-    conn.query_row("SELECT value FROM kv_meta WHERE key = ?1", [key], |row| {
-        row.get::<_, String>(0)
-    })
-    .ok()
-    .filter(|value| !value.trim().is_empty())
-}
-
 fn load_kv_meta_value_pg(pg_pool: Option<&sqlx::PgPool>, key: &str) -> Option<String> {
     let pg_pool = pg_pool?;
     let key = key.to_string();
@@ -214,46 +204,31 @@ fn load_kv_meta_value_pg(pg_pool: Option<&sqlx::PgPool>, key: &str) -> Option<St
     .filter(|value| !value.trim().is_empty())
 }
 
-fn load_kv_meta_value(
-    db: Option<&crate::db::Db>,
-    pg_pool: Option<&sqlx::PgPool>,
-    key: &str,
-) -> Option<String> {
+fn load_kv_meta_value(pg_pool: Option<&sqlx::PgPool>, key: &str) -> Option<String> {
     if let Ok(value) = crate::services::discord::internal_api::get_kv_value(key) {
         return value.filter(|value| !value.trim().is_empty());
     }
 
-    if pg_pool.is_some() {
-        return load_kv_meta_value_pg(pg_pool, key);
-    }
-
-    load_kv_meta_value_sqlite(db, key)
+    load_kv_meta_value_pg(pg_pool, key)
 }
 
 pub(crate) fn load_last_session_path(
-    db: Option<&crate::db::Db>,
     pg_pool: Option<&sqlx::PgPool>,
     token_hash: &str,
     channel_id: u64,
 ) -> Option<String> {
-    load_kv_meta_value(db, pg_pool, &last_session_path_key(token_hash, channel_id))
+    load_kv_meta_value(pg_pool, &last_session_path_key(token_hash, channel_id))
 }
 
 pub(crate) fn load_last_remote_profile(
-    db: Option<&crate::db::Db>,
     pg_pool: Option<&sqlx::PgPool>,
     token_hash: &str,
     channel_id: u64,
 ) -> Option<String> {
-    load_kv_meta_value(
-        db,
-        pg_pool,
-        &last_remote_profile_key(token_hash, channel_id),
-    )
+    load_kv_meta_value(pg_pool, &last_remote_profile_key(token_hash, channel_id))
 }
 
 pub(crate) fn save_last_session_runtime(
-    db: Option<&crate::db::Db>,
     pg_pool: Option<&sqlx::PgPool>,
     token_hash: &str,
     channel_id: u64,
@@ -331,38 +306,6 @@ pub(crate) fn save_last_session_runtime(
             },
             |message| message,
         );
-        return;
-    }
-
-    let Some(db) = db else {
-        return;
-    };
-    let Ok(conn) = db.lock() else {
-        return;
-    };
-
-    let _ = conn.execute(
-        "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?1, ?2)",
-        [
-            last_session_path_key(token_hash, channel_id),
-            current_path.to_string(),
-        ],
-    );
-
-    let remote_key = last_remote_profile_key(token_hash, channel_id);
-    match remote_profile_name
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        Some(remote) => {
-            let _ = conn.execute(
-                "INSERT OR REPLACE INTO kv_meta (key, value) VALUES (?1, ?2)",
-                [remote_key, remote.to_string()],
-            );
-        }
-        None => {
-            let _ = conn.execute("DELETE FROM kv_meta WHERE key = ?1", [remote_key]);
-        }
     }
 }
 

--- a/src/services/discord/tmux_lifecycle.rs
+++ b/src/services/discord/tmux_lifecycle.rs
@@ -187,6 +187,37 @@ pub(super) fn resolve_dispatch_tmux_protection(
         .flatten();
     }
 
+    resolve_dispatch_tmux_protection_legacy_fallback(
+        db,
+        provider,
+        &thread_channel_id,
+        &session_keys,
+        &namespaced_session_key_prefix,
+    )
+}
+
+// Production runs PostgreSQL-only (#3035 Phase 0): the legacy sqlite handle is
+// always `None`, so after the PG path above prod has no DB fallback and returns
+// `None` — preserving the historical `let db = db?;` short-circuit semantics.
+#[cfg(not(all(test, feature = "legacy-sqlite-tests")))]
+fn resolve_dispatch_tmux_protection_legacy_fallback(
+    _db: Option<&crate::db::Db>,
+    _provider: &ProviderKind,
+    _thread_channel_id: &str,
+    _session_keys: &[String; 2],
+    _namespaced_session_key_prefix: &str,
+) -> Option<DispatchTmuxProtection> {
+    None
+}
+
+#[cfg(all(test, feature = "legacy-sqlite-tests"))]
+fn resolve_dispatch_tmux_protection_legacy_fallback(
+    db: Option<&crate::db::Db>,
+    provider: &ProviderKind,
+    thread_channel_id: &str,
+    session_keys: &[String; 2],
+    namespaced_session_key_prefix: &str,
+) -> Option<DispatchTmuxProtection> {
     let db = db?;
     let conn = db.read_conn().ok()?;
     if let Ok(protection) = conn.query_row(
@@ -218,9 +249,9 @@ pub(super) fn resolve_dispatch_tmux_protection(
         [
             session_keys[0].as_str(),
             session_keys[1].as_str(),
-            thread_channel_id.as_str(),
+            thread_channel_id,
             provider.as_str(),
-            namespaced_session_key_prefix.as_str(),
+            namespaced_session_key_prefix,
         ],
         |row| {
             Ok(DispatchTmuxProtection::SessionRow {
@@ -258,9 +289,9 @@ pub(super) fn resolve_dispatch_tmux_protection(
            td.rowid DESC
          LIMIT 1",
         [
-            thread_channel_id.as_str(),
+            thread_channel_id,
             provider.as_str(),
-            namespaced_session_key_prefix.as_str(),
+            namespaced_session_key_prefix,
         ],
         |row| {
             Ok(DispatchTmuxProtection::ThreadDispatch {

--- a/src/services/discord/tmux_restart_handoff.rs
+++ b/src/services/discord/tmux_restart_handoff.rs
@@ -123,81 +123,46 @@ fn restart_handoff_notice_target(
     RestartHandoffNoticeTarget::Edit(state.current_msg_id)
 }
 
-fn resolve_dispatched_thread_dispatch(
-    sqlite: &crate::db::Db,
-    thread_channel_id: u64,
-) -> Option<String> {
-    let thread_channel_id = thread_channel_id.to_string();
-    let conn = sqlite.read_conn().ok()?;
-
-    conn.query_row(
-        "SELECT id FROM task_dispatches
-         WHERE status = 'dispatched' AND thread_id = ?1
-         ORDER BY datetime(created_at) DESC, rowid DESC
-         LIMIT 1",
-        [thread_channel_id.as_str()],
-        |row| row.get::<_, String>(0),
-    )
-    .ok()
-    .or_else(|| {
-        conn.query_row(
-            "SELECT active_dispatch_id FROM sessions
-             WHERE thread_channel_id = ?1
-               AND status IN ('turn_active', 'working')
-               AND active_dispatch_id IS NOT NULL
-             ORDER BY datetime(COALESCE(last_heartbeat, created_at)) DESC, id DESC
-             LIMIT 1",
-            [thread_channel_id.as_str()],
-            |row| row.get::<_, String>(0),
-        )
-        .ok()
-    })
-}
-
 pub(super) fn resolve_dispatched_thread_dispatch_from_db(
-    db: Option<&crate::db::Db>,
     pg_pool: Option<&sqlx::PgPool>,
     thread_channel_id: u64,
 ) -> Option<String> {
-    if let Some(pg_pool) = pg_pool {
-        let thread_channel_id = thread_channel_id.to_string();
-        return crate::utils::async_bridge::block_on_pg_result(
-            pg_pool,
-            move |pool| async move {
-                if let Some(dispatch_id) = sqlx::query_scalar::<_, String>(
-                    "SELECT id FROM task_dispatches
-                     WHERE status = 'dispatched' AND thread_id = $1
-                     ORDER BY created_at DESC, id DESC
-                     LIMIT 1",
-                )
-                .bind(&thread_channel_id)
-                .fetch_optional(&pool)
-                .await
-                .map_err(|error| format!("load pg dispatched thread dispatch: {error}"))?
-                {
-                    return Ok(Some(dispatch_id));
-                }
+    let pg_pool = pg_pool?;
+    let thread_channel_id = thread_channel_id.to_string();
+    crate::utils::async_bridge::block_on_pg_result(
+        pg_pool,
+        move |pool| async move {
+            if let Some(dispatch_id) = sqlx::query_scalar::<_, String>(
+                "SELECT id FROM task_dispatches
+                 WHERE status = 'dispatched' AND thread_id = $1
+                 ORDER BY created_at DESC, id DESC
+                 LIMIT 1",
+            )
+            .bind(&thread_channel_id)
+            .fetch_optional(&pool)
+            .await
+            .map_err(|error| format!("load pg dispatched thread dispatch: {error}"))?
+            {
+                return Ok(Some(dispatch_id));
+            }
 
-                sqlx::query_scalar::<_, String>(
-                    "SELECT active_dispatch_id FROM sessions
-                     WHERE thread_channel_id = $1
-                       AND status IN ('turn_active', 'working')
-                       AND active_dispatch_id IS NOT NULL
-                     ORDER BY COALESCE(last_heartbeat, created_at) DESC, id DESC
-                     LIMIT 1",
-                )
-                .bind(&thread_channel_id)
-                .fetch_optional(&pool)
-                .await
-                .map_err(|error| format!("load pg session dispatch fallback: {error}"))
-            },
-            |message| message,
-        )
-        .ok()
-        .flatten();
-    }
-
-    resolve_dispatched_thread_dispatch(db?, thread_channel_id)
+            sqlx::query_scalar::<_, String>(
+                "SELECT active_dispatch_id FROM sessions
+                 WHERE thread_channel_id = $1
+                   AND status IN ('turn_active', 'working')
+                   AND active_dispatch_id IS NOT NULL
+                 ORDER BY COALESCE(last_heartbeat, created_at) DESC, id DESC
+                 LIMIT 1",
+            )
+            .bind(&thread_channel_id)
+            .fetch_optional(&pool)
+            .await
+            .map_err(|error| format!("load pg session dispatch fallback: {error}"))
+        },
+        |message| message,
+    )
+    .ok()
+    .flatten()
 }
 
 fn build_restart_handoff_session_key(
@@ -584,12 +549,6 @@ mod tests {
         )
     }
 
-    fn fresh_restart_handoff_db() -> (tempfile::TempDir, crate::db::Db) {
-        let temp = tempfile::tempdir().unwrap();
-        let db = crate::db::test_db();
-        (temp, db)
-    }
-
     #[test]
     fn restart_handoff_prefers_exact_metadata_match() {
         let state = sample_inflight_state();
@@ -695,83 +654,5 @@ mod tests {
         assert!(preserve_dispatch_on_watcher_death(Some("phase-gate")));
         assert!(!preserve_dispatch_on_watcher_death(Some("implementation")));
         assert!(!preserve_dispatch_on_watcher_death(None));
-    }
-
-    #[test]
-    fn watcher_dispatch_db_fallback_prefers_dispatched_thread_row() {
-        let (_temp, db) = fresh_restart_handoff_db();
-        let conn = db.lock().unwrap();
-        conn.execute_batch(
-            "
-            DROP TABLE IF EXISTS task_dispatches;
-            DROP TABLE IF EXISTS sessions;
-            CREATE TABLE task_dispatches (
-                id TEXT PRIMARY KEY,
-                status TEXT,
-                thread_id TEXT,
-                created_at TEXT
-            );
-            CREATE TABLE sessions (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                status TEXT,
-                active_dispatch_id TEXT,
-                created_at TEXT,
-                last_heartbeat TEXT,
-                thread_channel_id TEXT
-            );
-            INSERT INTO task_dispatches (id, status, thread_id, created_at)
-            VALUES
-                ('older-dispatch', 'dispatched', '1492091375422930966', '2026-04-11 00:15:42'),
-                ('latest-dispatch', 'dispatched', '1492091375422930966', '2026-04-11 00:15:43');
-            INSERT INTO sessions (status, active_dispatch_id, created_at, last_heartbeat, thread_channel_id)
-            VALUES ('turn_active', 'session-dispatch', '2026-04-11 00:15:40', '2026-04-11 00:24:21', '1492091375422930966');
-            ",
-        )
-        .unwrap();
-        drop(conn);
-
-        let resolved = super::resolve_dispatched_thread_dispatch_from_db(
-            Some(&db),
-            None,
-            1_492_091_375_422_930_966,
-        );
-        assert_eq!(resolved.as_deref(), Some("latest-dispatch"));
-    }
-
-    #[test]
-    fn watcher_dispatch_db_fallback_uses_session_when_thread_row_missing() {
-        let (_temp, db) = fresh_restart_handoff_db();
-        let conn = db.lock().unwrap();
-        conn.execute_batch(
-            "
-            DROP TABLE IF EXISTS task_dispatches;
-            DROP TABLE IF EXISTS sessions;
-            CREATE TABLE task_dispatches (
-                id TEXT PRIMARY KEY,
-                status TEXT,
-                thread_id TEXT,
-                created_at TEXT
-            );
-            CREATE TABLE sessions (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                status TEXT,
-                active_dispatch_id TEXT,
-                created_at TEXT,
-                last_heartbeat TEXT,
-                thread_channel_id TEXT
-            );
-            INSERT INTO sessions (status, active_dispatch_id, created_at, last_heartbeat, thread_channel_id)
-            VALUES ('turn_active', 'session-dispatch', '2026-04-11 00:15:40', '2026-04-11 00:24:21', '1492091380045189131');
-            ",
-        )
-        .unwrap();
-        drop(conn);
-
-        let resolved = super::resolve_dispatched_thread_dispatch_from_db(
-            Some(&db),
-            None,
-            1_492_091_380_045_189_131,
-        );
-        assert_eq!(resolved.as_deref(), Some("session-dispatch"));
     }
 }

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -3853,7 +3853,6 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                                 crate::services::provider::ReadyForInputIdleState::PostWorkIdleTimeout => {
                                     let ts = chrono::Local::now().format("%H:%M:%S");
                                     let dispatch_id = resolve_dispatched_thread_dispatch_from_db(
-                                        None::<&crate::db::Db>,
                                         shared.pg_pool.as_ref(),
                                         watcher_thread_channel_id.unwrap_or_else(|| channel_id.get()),
                                     )
@@ -6985,7 +6984,6 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                     )
                     .or_else(|| {
                         resolve_dispatched_thread_dispatch_from_db(
-                            None::<&crate::db::Db>,
                             shared.pg_pool.as_ref(),
                             channel_id.get(),
                         )
@@ -7050,7 +7048,6 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             )
             .or_else(|| {
                 resolve_dispatched_thread_dispatch_from_db(
-                    None::<&crate::db::Db>,
                     shared.pg_pool.as_ref(),
                     channel_id.get(),
                 )

--- a/src/services/discord/turn_bridge/completion_guard.rs
+++ b/src/services/discord/turn_bridge/completion_guard.rs
@@ -452,27 +452,6 @@ fn transition_source_uses_live_command_bot(transition_source: &str) -> bool {
     source.starts_with("turn_bridge") || source.starts_with("watcher")
 }
 
-fn reset_linked_auto_queue_entries_on_db(
-    sqlite: &crate::db::Db,
-    dispatch_id: &str,
-) -> Result<usize, String> {
-    let conn = sqlite
-        .separate_conn()
-        .map_err(|error| format!("open sqlite auto_queue_entries connection: {error}"))?;
-    conn.execute(
-        "UPDATE auto_queue_entries
-         SET status = 'pending',
-             dispatch_id = NULL,
-             slot_index = NULL,
-             dispatched_at = NULL,
-             completed_at = NULL
-         WHERE dispatch_id = ?1
-           AND status IN ('pending', 'dispatched', 'failed')",
-        [dispatch_id],
-    )
-    .map_err(|error| format!("reset sqlite auto_queue_entries for {dispatch_id}: {error}"))
-}
-
 fn with_runtime_postgres_result<T, F>(operation: F) -> Result<T, String>
 where
     T: Send + 'static,
@@ -1114,6 +1093,52 @@ fn parse_completion_hint_context(
     }
 }
 
+type LegacyCompletionHintColumns = (Option<i64>, Option<String>, Option<String>, Option<String>);
+
+#[cfg(all(test, feature = "legacy-sqlite-tests"))]
+fn lookup_dispatch_completion_hints_legacy_fallback(
+    db: Option<&crate::db::Db>,
+    dispatch_id: &str,
+) -> LegacyCompletionHintColumns {
+    db.and_then(|db| db.separate_conn().ok())
+        .as_ref()
+        .and_then(|conn| {
+            conn.query_row(
+                "SELECT kc.github_issue_number, td.created_at, td.context, kc.repo_id
+                 FROM task_dispatches td
+                 LEFT JOIN kanban_cards kc ON kc.id = td.kanban_card_id
+                 WHERE td.id = ?1",
+                [dispatch_id],
+                |row| {
+                    let context_raw: Option<String> = row.get(2)?;
+                    let parsed_context = parse_completion_hint_context(
+                        dispatch_id,
+                        context_raw.as_deref(),
+                        row.get::<_, Option<String>>(3).ok().flatten(),
+                    );
+                    Ok((
+                        row.get::<_, Option<i64>>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                        parsed_context.target_repo,
+                        parsed_context.baseline_commit,
+                    ))
+                },
+            )
+            .ok()
+        })
+        .unwrap_or((None, None, None, None))
+}
+
+// Production runs PostgreSQL-only (#3035 Phase 0): the legacy sqlite handle is
+// always `None`, so the prod build has no DB fallback after the PG path.
+#[cfg(not(all(test, feature = "legacy-sqlite-tests")))]
+fn lookup_dispatch_completion_hints_legacy_fallback(
+    _db: Option<&crate::db::Db>,
+    _dispatch_id: &str,
+) -> LegacyCompletionHintColumns {
+    (None, None, None, None)
+}
+
 fn lookup_dispatch_completion_hints(
     db: Option<&crate::db::Db>,
     pg_pool: Option<&sqlx::PgPool>,
@@ -1197,34 +1222,9 @@ fn lookup_dispatch_completion_hints(
         }
     }
 
-    let conn = db.and_then(|db| db.separate_conn().ok());
-    let (issue_number, dispatch_created_at, target_repo, baseline_commit) = conn
-        .as_ref()
-        .and_then(|conn| {
-            conn.query_row(
-                "SELECT kc.github_issue_number, td.created_at, td.context, kc.repo_id
-                 FROM task_dispatches td
-                 LEFT JOIN kanban_cards kc ON kc.id = td.kanban_card_id
-                 WHERE td.id = ?1",
-                [dispatch_id],
-                |row| {
-                    let context_raw: Option<String> = row.get(2)?;
-                    let parsed_context = parse_completion_hint_context(
-                        dispatch_id,
-                        context_raw.as_deref(),
-                        row.get::<_, Option<String>>(3).ok().flatten(),
-                    );
-                    Ok((
-                        row.get::<_, Option<i64>>(0)?,
-                        row.get::<_, Option<String>>(1)?,
-                        parsed_context.target_repo,
-                        parsed_context.baseline_commit,
-                    ))
-                },
-            )
-            .ok()
-        })
-        .unwrap_or((None, None, None, None));
+    let (issue_number, dispatch_created_at, target_repo, baseline_commit) =
+        lookup_dispatch_completion_hints_legacy_fallback(db, dispatch_id);
+
     DispatchCompletionHints {
         issue_number,
         dispatch_created_at,
@@ -2373,168 +2373,5 @@ mod tests {
         assert_eq!(result["completed_without_changes"], true);
         assert_eq!(result["card_status_target"], "ready");
         assert_eq!(result["notes"], "OUTCOME: noop\nalready satisfied");
-    }
-
-    #[test]
-    fn reset_linked_auto_queue_entries_on_conn_resets_retryable_rows() {
-        let db = crate::db::test_db();
-        let conn = db.lock().expect("db lock");
-        conn.execute_batch(
-            "DROP TABLE IF EXISTS auto_queue_entries;
-             CREATE TABLE auto_queue_entries (
-                id TEXT PRIMARY KEY,
-                run_id TEXT,
-                kanban_card_id TEXT,
-                agent_id TEXT,
-                status TEXT,
-                dispatch_id TEXT,
-                slot_index INTEGER,
-                thread_group INTEGER DEFAULT 0,
-                batch_phase INTEGER DEFAULT 0,
-                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                dispatched_at DATETIME,
-                completed_at DATETIME
-            );",
-        )
-        .expect("schema");
-        conn.execute(
-            "INSERT INTO auto_queue_entries (
-                id, run_id, kanban_card_id, agent_id, status, dispatch_id, slot_index, thread_group, batch_phase, dispatched_at, completed_at
-             ) VALUES
-                ('entry-pending', 'run-1', 'card-1', 'agent-1', 'pending', 'dispatch-1', 7, 0, 0, datetime('now'), datetime('now')),
-                ('entry-dispatched', 'run-1', 'card-2', 'agent-1', 'dispatched', 'dispatch-1', 8, 0, 0, datetime('now'), NULL),
-                ('entry-failed', 'run-1', 'card-3', 'agent-1', 'failed', 'dispatch-1', 9, 0, 0, datetime('now'), datetime('now')),
-                ('entry-done', 'run-1', 'card-4', 'agent-1', 'done', 'dispatch-1', 10, 0, 0, datetime('now'), datetime('now'))",
-            [],
-        )
-        .expect("seed entries");
-        drop(conn);
-
-        let changed = reset_linked_auto_queue_entries_on_db(&db, "dispatch-1").expect("reset");
-        assert_eq!(changed, 3);
-
-        let pending: (
-            String,
-            Option<String>,
-            Option<i64>,
-            Option<String>,
-            Option<String>,
-        ) = db
-            .read_conn()
-            .expect("read conn")
-            .query_row(
-                "SELECT status, dispatch_id, slot_index, dispatched_at, completed_at
-                 FROM auto_queue_entries
-                 WHERE id = 'entry-pending'",
-                [],
-                |row| {
-                    Ok((
-                        row.get(0)?,
-                        row.get(1)?,
-                        row.get(2)?,
-                        row.get(3)?,
-                        row.get(4)?,
-                    ))
-                },
-            )
-            .expect("pending row");
-        assert_eq!(pending.0, "pending");
-        assert!(pending.1.is_none());
-        assert!(pending.2.is_none());
-        assert!(pending.3.is_none());
-        assert!(pending.4.is_none());
-
-        let dispatched: (
-            String,
-            Option<String>,
-            Option<i64>,
-            Option<String>,
-            Option<String>,
-        ) = db
-            .read_conn()
-            .expect("read conn")
-            .query_row(
-                "SELECT status, dispatch_id, slot_index, dispatched_at, completed_at
-                 FROM auto_queue_entries
-                 WHERE id = 'entry-dispatched'",
-                [],
-                |row| {
-                    Ok((
-                        row.get(0)?,
-                        row.get(1)?,
-                        row.get(2)?,
-                        row.get(3)?,
-                        row.get(4)?,
-                    ))
-                },
-            )
-            .expect("dispatched row");
-        assert_eq!(dispatched.0, "pending");
-        assert!(dispatched.1.is_none());
-        assert!(dispatched.2.is_none());
-        assert!(dispatched.3.is_none());
-        assert!(dispatched.4.is_none());
-
-        let failed: (
-            String,
-            Option<String>,
-            Option<i64>,
-            Option<String>,
-            Option<String>,
-        ) = db
-            .read_conn()
-            .expect("read conn")
-            .query_row(
-                "SELECT status, dispatch_id, slot_index, dispatched_at, completed_at
-                 FROM auto_queue_entries
-                 WHERE id = 'entry-failed'",
-                [],
-                |row| {
-                    Ok((
-                        row.get(0)?,
-                        row.get(1)?,
-                        row.get(2)?,
-                        row.get(3)?,
-                        row.get(4)?,
-                    ))
-                },
-            )
-            .expect("failed row");
-        assert_eq!(failed.0, "pending");
-        assert!(failed.1.is_none());
-        assert!(failed.2.is_none());
-        assert!(failed.3.is_none());
-        assert!(failed.4.is_none());
-
-        let done: (
-            String,
-            Option<String>,
-            Option<i64>,
-            Option<String>,
-            Option<String>,
-        ) = db
-            .read_conn()
-            .expect("read conn")
-            .query_row(
-                "SELECT status, dispatch_id, slot_index, dispatched_at, completed_at
-                 FROM auto_queue_entries
-                 WHERE id = 'entry-done'",
-                [],
-                |row| {
-                    Ok((
-                        row.get(0)?,
-                        row.get(1)?,
-                        row.get(2)?,
-                        row.get(3)?,
-                        row.get(4)?,
-                    ))
-                },
-            )
-            .expect("done row");
-        assert_eq!(done.0, "done");
-        assert_eq!(done.1.as_deref(), Some("dispatch-1"));
-        assert_eq!(done.2, Some(10));
-        assert!(done.3.is_some());
-        assert!(done.4.is_some());
     }
 }

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -4767,9 +4767,8 @@ pub(super) fn spawn_turn_bridge(
                                     );
                                 }
                             }
-                            if None::<&crate::db::Db>.is_some() || shared_owned.pg_pool.is_some() {
+                            if shared_owned.pg_pool.is_some() {
                                 match record_skill_usage_from_tool_use(
-                                    None::<&crate::db::Db>,
                                     shared_owned.pg_pool.as_ref(),
                                     &name,
                                     &input,

--- a/src/services/discord/turn_bridge/skill_usage.rs
+++ b/src/services/discord/turn_bridge/skill_usage.rs
@@ -1,4 +1,3 @@
-use crate::db::Db;
 use crate::services::discord::settings::RoleBinding;
 
 pub(super) fn extract_skill_id_from_tool_use(name: &str, input: &str) -> Option<String> {
@@ -15,29 +14,6 @@ pub(super) fn extract_skill_id_from_tool_use(name: &str, input: &str) -> Option<
                 .map(str::trim)
                 .filter(|skill| !skill.is_empty())
                 .map(ToString::to_string)
-        })
-}
-
-fn resolve_skill_usage_agent_id(
-    sqlite: &Db,
-    session_key: Option<&str>,
-    role_binding: Option<&RoleBinding>,
-) -> Option<String> {
-    session_key
-        .and_then(|key| {
-            let conn = sqlite.read_conn().ok()?;
-            conn.query_row(
-                "SELECT agent_id FROM sessions WHERE session_key = ?1",
-                [key],
-                |row| row.get::<_, Option<String>>(0),
-            )
-            .ok()
-            .flatten()
-        })
-        .or_else(|| {
-            role_binding
-                .map(|binding| binding.role_id.trim().to_string())
-                .filter(|role_id| !role_id.is_empty())
         })
 }
 
@@ -66,43 +42,6 @@ async fn resolve_skill_usage_agent_id_pg(
         .filter(|role_id| !role_id.is_empty())
 }
 
-fn record_skill_usage_sqlite(
-    sqlite: &Db,
-    skill_id: &str,
-    session_key: Option<&str>,
-    role_binding: Option<&RoleBinding>,
-) -> Result<(), String> {
-    let conn = sqlite.lock().map_err(|e| format!("db lock failed: {e}"))?;
-    let agent_id = resolve_skill_usage_agent_id(sqlite, session_key, role_binding);
-    match (agent_id.as_deref(), session_key) {
-        (Some(agent_id), Some(session_key)) => conn
-            .execute(
-                "INSERT INTO skill_usage (skill_id, agent_id, session_key) VALUES (?1, ?2, ?3)",
-                [skill_id, agent_id, session_key],
-            )
-            .map_err(|e| format!("insert skill_usage failed: {e}"))?,
-        (Some(agent_id), None) => conn
-            .execute(
-                "INSERT INTO skill_usage (skill_id, agent_id, session_key) VALUES (?1, ?2, NULL)",
-                [skill_id, agent_id],
-            )
-            .map_err(|e| format!("insert skill_usage failed: {e}"))?,
-        (None, Some(session_key)) => conn
-            .execute(
-                "INSERT INTO skill_usage (skill_id, agent_id, session_key) VALUES (?1, NULL, ?2)",
-                [skill_id, session_key],
-            )
-            .map_err(|e| format!("insert skill_usage failed: {e}"))?,
-        (None, None) => conn
-            .execute(
-                "INSERT INTO skill_usage (skill_id, agent_id, session_key) VALUES (?1, NULL, NULL)",
-                [skill_id],
-            )
-            .map_err(|e| format!("insert skill_usage failed: {e}"))?,
-    };
-    Ok(())
-}
-
 async fn record_skill_usage_pg(
     pg_pool: &sqlx::PgPool,
     skill_id: &str,
@@ -124,7 +63,6 @@ async fn record_skill_usage_pg(
 }
 
 pub(super) async fn record_skill_usage_from_tool_use(
-    db: Option<&Db>,
     pg_pool: Option<&sqlx::PgPool>,
     name: &str,
     input: &str,
@@ -134,12 +72,9 @@ pub(super) async fn record_skill_usage_from_tool_use(
     let Some(skill_id) = extract_skill_id_from_tool_use(name, input) else {
         return Ok(None);
     };
-    if let Some(pg_pool) = pg_pool {
-        record_skill_usage_pg(pg_pool, &skill_id, session_key, role_binding).await?;
-    } else if let Some(db) = db {
-        record_skill_usage_sqlite(db, &skill_id, session_key, role_binding)?;
-    } else {
+    let Some(pg_pool) = pg_pool else {
         return Err("no runtime database handle available for skill usage".to_string());
-    }
+    };
+    record_skill_usage_pg(pg_pool, &skill_id, session_key, role_binding).await?;
     Ok(Some(skill_id))
 }

--- a/src/services/discord/watchers/lifecycle.rs
+++ b/src/services/discord/watchers/lifecycle.rs
@@ -1732,11 +1732,7 @@ pub(super) async fn resolve_watcher_dispatch_id(
             .await,
         )
         .or_else(|| {
-            resolve_dispatched_thread_dispatch_from_db(
-                None::<&crate::db::Db>,
-                shared.pg_pool.as_ref(),
-                channel_id.get(),
-            )
+            resolve_dispatched_thread_dispatch_from_db(shared.pg_pool.as_ref(), channel_id.get())
         })
 }
 
@@ -2620,26 +2616,19 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
     // and message handlers find an active session with current_path
     if !owned_sessions.is_empty() {
         let mut data = shared.core.lock().await;
-        let sqlite_settings_db = if shared.pg_pool.is_some() {
-            None
-        } else {
-            None::<&crate::db::Db>
-        };
         for (channel_id, channel_name) in &owned_sessions {
             let persisted_path = load_last_session_path(
-                sqlite_settings_db,
                 shared.pg_pool.as_ref(),
                 &shared.token_hash,
                 channel_id.get(),
             );
             let remote_profile = load_last_remote_profile(
-                sqlite_settings_db,
                 shared.pg_pool.as_ref(),
                 &shared.token_hash,
                 channel_id.get(),
             );
             let persisted_session_id = load_restored_provider_session_id(
-                sqlite_settings_db,
+                None::<&crate::db::Db>,
                 shared.pg_pool.as_ref(),
                 &shared.token_hash,
                 &provider,


### PR DESCRIPTION
**Part of #3035** (Phase 0/N — do NOT merge solo; later phases delete the feature-gated legacy test mods + stub types + the `legacy-sqlite-tests` feature). **DO NOT MERGE.**

## Goal
Drain the legacy-sqlite-sunset audit's `prod_db_conn_calls` from **7 → 0** by removing the dead `_sqlite` fallback branches in the 6 production callsites that still called `Db::read_conn()` / `Db::separate_conn()`.

**Grounded fact:** in prod `legacy_db` is always `None` (`src/engine/mod.rs`) and `Db::read_conn/separate_conn` always return `Err` (`src/db/mod.rs`), so the `_sqlite` branches are live-but-dead. Deleting each branch and keeping the `_pg`/`None`-path is behavior-preserving.

## Per-callsite changes
**Trivial single read_conn fallbacks:**
- `src/services/discord/settings/read.rs` — removed `load_kv_meta_value_sqlite` (read_conn) and the dead `db.lock()` block in `save_last_session_runtime`; dropped the unused `db` param from the load/save settings helpers and updated all callers (`session_runtime.rs`, `recovery_engine.rs`, `commands/config.rs`, `commands/session.rs`, `watchers/lifecycle.rs`).
- `src/services/discord/turn_bridge/skill_usage.rs` — removed sqlite `resolve_skill_usage_agent_id` (read_conn) + `record_skill_usage_sqlite`; `record_skill_usage_from_tool_use` is now PG-only (caller in `turn_bridge/mod.rs` updated).
- `src/services/discord/tmux_restart_handoff.rs` — removed sqlite `resolve_dispatched_thread_dispatch` (read_conn); `resolve_dispatched_thread_dispatch_from_db` is PG-only (3 `tmux_watcher.rs` + 1 `watchers/lifecycle.rs` callers updated). Removed the 2 obsolete legacy-gated tests that exercised the deleted fallback.

**Ungated prod call:**
- `src/server/routes/review_verdict/decision_route.rs` — removed the legacy-gated `if let Some(db) = state.legacy_db()` + `separate_conn()` block in the review-decision card-context loader (the audit counted this site, NOT the already-cfg-gated `:272`-style sites). Prod already returns the PG result then `ReviewDecisionCardContext::default()`.

**Relay-adjacent (#3016 contact — extra care, semantics preserved exactly):**
- `src/services/discord/turn_bridge/completion_guard.rs` (2 calls) — deleted the unused sqlite `reset_linked_auto_queue_entries_on_db` (separate_conn) + its obsolete legacy test; moved the post-PG completion-hint sqlite fallback in `lookup_dispatch_completion_hints` behind a cfg-gated `..._legacy_fallback` helper so prod returns `(None, None, None, None)` — identical to the prior `db.and_then(separate_conn)` short-circuit.
- `src/services/discord/tmux_lifecycle.rs` (1 call) — moved the post-PG sqlite protection fallback (read_conn) behind a cfg-gated `resolve_dispatch_tmux_protection_legacy_fallback` helper so prod returns `None` — identical to the prior `let db = db?;` short-circuit. The legacy query logic is preserved verbatim under `legacy-sqlite-tests`.

## Out of scope (deliberately kept)
The legacy stub **types** and feature-gated **test mods** are NOT removed here: `just check` / `cargo check --all-features` compiles the legacy sqlite surface, so the codebase must keep compiling under `--all-features` until the `legacy-sqlite-tests` feature is removed in the final phase.

## Verification
- `python3 scripts/audit_legacy_sqlite_sunset.py` → **`prod_db_conn_calls = 0`**, Phase-0 blockers table empty, `prod_stub_dependency` category gone.
- `cargo check --workspace --all-features --all-targets` → clean (legacy surface still compiles; `cargo test --features legacy-sqlite-tests --no-run` also clean).
- `cargo fmt --all --check` → clean.
- `cargo test --lib` for the touched modules (completion_guard / tmux_lifecycle / decision_route / skill_usage / tmux_restart_handoff / settings) → pass.
- `./scripts/ci-script-checks.sh` → exit 0 (synced 6 `change-surfaces.md` LoC freeze entries after the deletions).

Net diff: 14 files, +135 / −579.

🤖 Generated with [Claude Code](https://claude.com/claude-code)