### PR TITLE
chore(lint): remove dead_code blankets for cli/github/kanban/dispatch (#3034)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -92,9 +92,9 @@
 - canonical_modules: `src/dispatch/{mod,dispatch_context,dispatch_create,dispatch_status}.rs`.
 - legacy_modules: none.
 - do_not_edit_without_migration_plan (giant-file, awaiting split issue):
-  - `src/dispatch/dispatch_context.rs` (5237 lines).
+  - `src/dispatch/dispatch_context.rs` (5258 lines).
   - `src/dispatch/dispatch_create.rs` (3639 lines).
-  - `src/dispatch/dispatch_status.rs` (2169 lines).
+  - `src/dispatch/dispatch_status.rs` (2129 lines).
   - `src/services/dispatches/outbox_route.rs` (1118 lines; route extraction
     orchestration surface from #1722, split before adding non-bugfix behavior).
   - `src/services/dispatches/discord_delivery/orchestration.rs` (1697 lines;
@@ -234,7 +234,7 @@
 - do_not_edit_without_migration_plan (giant-file):
   - `src/cli/migrate.rs` is the retired postgres-cutover facade (now below the
     giant-file threshold; bugfix only).
-  - `src/cli/doctor/orchestrator.rs` (4430 lines).
+  - `src/cli/doctor/orchestrator.rs` (4385 lines).
   - `src/cli/migrate/apply.rs` (3146 lines).
   - `src/cli/migrate/{plan.rs (1513), source.rs (1612)}`.
   - `src/cli/{init.rs (1445), client.rs (2955), direct.rs (1781),

--- a/src/cli/client.rs
+++ b/src/cli/client.rs
@@ -117,11 +117,6 @@ pub(crate) fn post_json_value(path: &str, body: Value) -> Result<Value, String> 
     post_json(path, Some(body))
 }
 
-pub(crate) fn patch_json_value(path: &str, body: Value) -> Result<Value, String> {
-    let body_string = body.to_string();
-    request_json("PATCH", path, Some(&body_string))
-}
-
 fn parse_github_repo_from_remote(remote: &str) -> Option<String> {
     crate::services::platform::shell::parse_github_repo_from_remote(remote)
 }
@@ -1936,26 +1931,6 @@ pub fn cmd_dispatch(
             obj.insert("dispatch".to_string(), dispatch);
         }
     }
-    print_json(&value);
-    Ok(())
-}
-
-/// `agentdesk dispatch retry <card_id>`
-pub fn cmd_dispatch_retry(card_id: &str) -> Result<(), String> {
-    let value = post_json(
-        &format!("/api/kanban-cards/{card_id}/retry"),
-        Some(serde_json::json!({})),
-    )?;
-    print_json(&value);
-    Ok(())
-}
-
-/// `agentdesk dispatch redispatch <card_id>`
-pub fn cmd_dispatch_redispatch(card_id: &str) -> Result<(), String> {
-    let value = post_json(
-        &format!("/api/kanban-cards/{card_id}/redispatch"),
-        Some(serde_json::json!({})),
-    )?;
     print_json(&value);
     Ok(())
 }

--- a/src/cli/doctor/orchestrator.rs
+++ b/src/cli/doctor/orchestrator.rs
@@ -7,8 +7,6 @@ use super::contract::{DoctorProfile, FixSafety, RunContext, SecurityExposure, Se
 use super::{health, mailbox};
 use crate::cli::dcserver;
 use crate::config;
-#[cfg(all(test, feature = "legacy-sqlite-tests"))]
-use crate::db::{open_write_connection, schema};
 use crate::services::operator_connectors::{
     OptionalConnectorState, OptionalConnectorStatus, optional_connector_statuses,
 };
@@ -481,13 +479,6 @@ fn provider_runtime_guidance(provider: &ProviderKind) -> String {
     let log_hint = dcserver_log_hint();
     format!(
         "{provider_name} CLI 설치/PATH와 서비스 런타임 PATH를 확인하고, 연결 문제가 있으면 {log_hint} 로그와 provider 인증 상태를 점검하세요."
-    )
-}
-
-fn provider_unused_guidance(provider: &ProviderKind) -> String {
-    format!(
-        "{} CLI는 설치되어 있지만 현재 config/health 기준 활성 provider가 아닙니다. 의도한 구성이면 무시해도 됩니다.",
-        provider.as_str()
     )
 }
 
@@ -4068,42 +4059,6 @@ fn check_github_repo_registry(cfg: &config::Config) -> Check {
     .with_security_exposure(SecurityExposure::OperationalMetadata)
     .with_path(db_path.display().to_string())
     .with_expected_actual("Postgres source-of-truth active", "SQLite registry check retired");
-}
-
-fn normalized_config_repo_ids(cfg: &config::Config) -> (BTreeSet<String>, Vec<String>) {
-    let mut valid = BTreeSet::new();
-    let mut invalid = BTreeSet::new();
-
-    for raw_repo_id in &cfg.github.repos {
-        let repo_id = raw_repo_id.trim();
-        if repo_id.is_empty() {
-            continue;
-        }
-        if repo_id.contains('/') {
-            valid.insert(repo_id.to_string());
-        } else {
-            invalid.insert(repo_id.to_string());
-        }
-    }
-
-    (valid, invalid.into_iter().collect())
-}
-
-#[cfg(all(test, feature = "legacy-sqlite-tests"))]
-fn open_registered_github_repo_ids(db_path: &std::path::Path) -> Result<BTreeSet<String>, String> {
-    let conn = open_write_connection(db_path).map_err(|e| format!("cannot open: {e}"))?;
-    let mut stmt = conn
-        .prepare("SELECT id FROM github_repos ORDER BY id")
-        .map_err(|e| format!("prepare: {e}"))?;
-    let rows = stmt
-        .query_map([], |row| row.get::<_, String>(0))
-        .map_err(|e| format!("query: {e}"))?;
-
-    let mut repos = BTreeSet::new();
-    for row in rows {
-        repos.insert(row.map_err(|e| format!("row: {e}"))?);
-    }
-    Ok(repos)
 }
 
 const DISK_WARN_BYTES: u64 = 30 * 1024 * 1024 * 1024;

--- a/src/dispatch/dispatch_context.rs
+++ b/src/dispatch/dispatch_context.rs
@@ -760,7 +760,10 @@ pub(crate) fn commit_belongs_to_card_issue(
     commit_subject_references_issue(&subject, issue_number)
 }
 
+// reason: production cfg-arm of the commit/card-issue scope check; live callers
+// and the _pg twin are cfg/test-gated in the default lib build. See #3034.
 #[cfg(not(all(test, feature = "legacy-sqlite-tests")))]
+#[allow(dead_code)]
 pub(crate) fn commit_belongs_to_card_issue(
     _db: &Db,
     card_id: &str,
@@ -860,7 +863,10 @@ pub(crate) fn commit_belongs_to_card_issue_tri(
     }
 }
 
+// reason: production cfg-arm of the tri-state commit/card-issue scope check;
+// live callers and the _pg_tri twin are cfg/test-gated in the lib build. See #3034.
 #[cfg(not(all(test, feature = "legacy-sqlite-tests")))]
+#[allow(dead_code)]
 pub(crate) fn commit_belongs_to_card_issue_tri(
     _db: &Db,
     card_id: &str,
@@ -944,6 +950,9 @@ fn worktree_path_belongs_to_repo(worktree_path: &str, repo_dir: &str) -> bool {
 /// reviewer sees is the descendant, not the reviewed commit. Exact HEAD
 /// match is the only way to guarantee the on-disk state matches the
 /// reviewed commit.
+// reason: worktree HEAD validation helper for the review-target resolver cluster;
+// callers are cfg/test-gated in the default lib build. See #3034.
+#[allow(dead_code)]
 fn worktree_head_matches_commit(dir: &str, commit_sha: &str) -> bool {
     let Ok(output) = GitCommand::new()
         .repo(dir)
@@ -966,6 +975,9 @@ fn worktree_head_matches_commit(dir: &str, commit_sha: &str) -> bool {
 /// when the underlying git invocation or the join handle fails. The
 /// failure case is logged at warn level for observability so it does not
 /// silently look like "clean worktree" without any trace.
+// reason: async clean-worktree probe for the review-target resolver paths;
+// invoked from cfg/test-gated resolver flows in the default lib build. See #3034.
+#[allow(dead_code)]
 async fn dirty_tracked_change_paths_async(path: &str) -> Vec<String> {
     let path_owned = path.to_string();
     let join_result = tokio::task::spawn_blocking(move || {
@@ -1106,6 +1118,9 @@ async fn probe_clean_exact_review_worktree(
     probe
 }
 
+// reason: review-worktree cleanliness resolver; callers are cfg/test-gated in
+// the default lib build. See #3034.
+#[allow(dead_code)]
 async fn clean_exact_review_worktree_path(
     card_id: &str,
     source: &str,
@@ -1502,10 +1517,16 @@ fn latest_completed_work_dispatch_target(
         })
 }
 
+// reason: work-dispatch classifier shared with the outbox route; lib-build
+// callers are cfg/test-gated. See #3034.
+#[allow(dead_code)]
 fn is_work_dispatch_type(dispatch_type: Option<&str>) -> bool {
     matches!(dispatch_type, Some("implementation") | Some("rework"))
 }
 
+// reason: work-completion-evidence predicate for the dispatch-result gate;
+// lib-build callers are cfg/test-gated. See #3034.
+#[allow(dead_code)]
 fn result_has_work_completion_evidence(result: &serde_json::Value) -> bool {
     json_string_field(result, "completed_commit").is_some()
         || json_string_field(result, "assistant_message").is_some()

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -907,6 +907,8 @@ async fn set_dispatch_status_on_pg_with_sync(
     Ok(changed)
 }
 
+// reason: Postgres dispatch-status writer; lib-build callers are cfg/test-gated. See #3034.
+#[allow(dead_code)]
 async fn set_dispatch_status_on_pg(
     pool: &PgPool,
     dispatch_id: &str,
@@ -1446,6 +1448,9 @@ pub(crate) fn set_dispatch_status_on_conn(
 ///   2. OnDispatchCompleted hook firing  (pipeline event hooks)
 ///   3. Side-effect draining  (intents, transitions, follow-up dispatches)
 ///   4. Safety-net re-fire of OnReviewEnter (#139)
+// reason: pub dispatch-completion authority (#143) re-exported via dispatch::*;
+// lib-build callers are recovery/turn_bridge + cfg/test-gated paths. See #3034.
+#[allow(dead_code)]
 pub fn finalize_dispatch(
     db: &Db,
     engine: &PolicyEngine,
@@ -1484,6 +1489,9 @@ pub fn finalize_dispatch_with_backends(
 /// Used by specialized paths (review_verdict, pm-decision) that fire their own
 /// domain-specific hooks instead of the generic OnDispatchCompleted.
 /// Returns the number of rows updated (0 = already completed/cancelled/not found).
+// reason: pub pg-first completion API for review_verdict/pm-decision paths,
+// re-exported via dispatch::*; lib-build callers are cfg/test-gated. See #3034.
+#[allow(dead_code)]
 pub fn mark_dispatch_completed_pg_first(
     db: &Db,
     pg_pool: Option<&PgPool>,
@@ -1502,6 +1510,9 @@ pub fn mark_dispatch_completed_pg_first(
     )
 }
 
+// reason: pub pg-first status setter re-exported via dispatch::*; lib-build
+// callers are cfg/test-gated. See #3034.
+#[allow(dead_code)]
 pub fn set_dispatch_status_pg_first(
     db: &Db,
     pg_pool: Option<&PgPool>,
@@ -1644,60 +1655,6 @@ fn set_dispatch_status_with_backends_and_sync(
     })
 }
 
-#[cfg(all(test, feature = "legacy-sqlite-tests"))]
-fn set_dispatch_status_sqlite_for_tests(
-    db: &Db,
-    dispatch_id: &str,
-    to_status: &str,
-    result: Option<&serde_json::Value>,
-    allowed_from: Option<&[&str]>,
-    touch_completed_at: bool,
-) -> Result<usize> {
-    let conn = db
-        .separate_conn()
-        .map_err(|error| anyhow::anyhow!("open sqlite dispatch status connection: {error}"))?;
-    let current_status = conn
-        .query_row(
-            "SELECT status FROM task_dispatches WHERE id = ?1",
-            [dispatch_id],
-            |row| row.get::<_, String>(0),
-        )
-        .optional()?;
-    let Some(current_status) = current_status else {
-        return Ok(0);
-    };
-    if let Some(allowed_from) = allowed_from
-        && !allowed_from.contains(&current_status.as_str())
-    {
-        return Ok(0);
-    }
-
-    let result_json = result.map(serde_json::Value::to_string);
-    let changed = if touch_completed_at {
-        conn.execute(
-            "UPDATE task_dispatches
-             SET status = ?1,
-                 result = COALESCE(?2, result),
-                 updated_at = datetime('now'),
-                 last_stuck_alert_at = NULL,
-                 completed_at = CASE WHEN ?1 = 'completed' THEN datetime('now') ELSE completed_at END
-             WHERE id = ?3",
-            sqlite_test::params![to_status, result_json, dispatch_id],
-        )?
-    } else {
-        conn.execute(
-            "UPDATE task_dispatches
-             SET status = ?1,
-                 result = COALESCE(?2, result),
-                 updated_at = datetime('now'),
-                 last_stuck_alert_at = NULL
-             WHERE id = ?3",
-            sqlite_test::params![to_status, result_json, dispatch_id],
-        )?
-    };
-    Ok(changed)
-}
-
 pub(crate) fn set_dispatch_status_without_queue_sync_with_backends(
     db: Option<&Db>,
     pg_pool: Option<&PgPool>,
@@ -1743,6 +1700,9 @@ pub(crate) fn set_dispatch_status_without_queue_sync_on_conn(
     )
 }
 
+// reason: pub pg-first dispatch-row loader re-exported via dispatch::*; lib-build
+// callers are cfg/test-gated. See #3034.
+#[allow(dead_code)]
 pub fn load_dispatch_row_pg_first(
     db: &Db,
     pg_pool: Option<&PgPool>,

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -605,10 +605,15 @@ pub fn fetch_pr_view(repo: &str, pr_number: i64) -> Result<PrView, String> {
 /// Fetch only the head SHA + state of a PR. Used by the cache to cheaply
 /// validate freshness — if the SHA matches the cached entry we can serve a
 /// stale body without paying for the full payload.
+// reason: pub gh-integration probe (PR head/state) wired by the runtime-gated
+// PR-cache freshness path, not the default lib/test build. See #3034.
+#[allow(dead_code)]
 pub fn fetch_pr_head_state(repo: &str, pr_number: i64) -> Result<(Option<String>, String), String> {
     fetch_pr_head_state_with(adapter(), repo, pr_number)
 }
 
+// reason: private impl of the runtime-gated fetch_pr_head_state probe above. See #3034.
+#[allow(dead_code)]
 fn fetch_pr_head_state_with(
     adapter: &dyn GitHubAdapter,
     repo: &str,
@@ -689,7 +694,10 @@ pub fn list_repos(db: &Db) -> Result<Vec<RepoRow>, String> {
     Ok(rows.filter_map(|r| r.ok()).collect())
 }
 
+// reason: production-build twin of the legacy-sqlite-tests list_repos; the live
+// path is list_repos_pg, this stub keeps the symbol present for non-test builds. See #3034 (M2 dead-twin).
 #[cfg(not(all(test, feature = "legacy-sqlite-tests")))]
+#[allow(dead_code)]
 pub fn list_repos(_db: &Db) -> Result<Vec<RepoRow>, String> {
     Err("sqlite github repo registry is unavailable in production".to_string())
 }
@@ -753,7 +761,10 @@ pub fn register_repo(db: &Db, repo_id: &str) -> Result<RepoRow, String> {
     Ok(row)
 }
 
+// reason: production-build twin of the legacy-sqlite-tests register_repo; the live
+// path is db::postgres::register_repo, this stub keeps the symbol present for non-test builds. See #3034 (M2 dead-twin).
 #[cfg(not(all(test, feature = "legacy-sqlite-tests")))]
+#[allow(dead_code)]
 pub fn register_repo(_db: &Db, repo_id: &str) -> Result<RepoRow, String> {
     Err(format!(
         "sqlite github repo registry is unavailable in production for {repo_id}"

--- a/src/github/triage.rs
+++ b/src/github/triage.rs
@@ -159,17 +159,6 @@ enum TriageRoutingOutcome {
     UnknownAgent,
 }
 
-/// Find GitHub issues that don't have kanban cards yet and create backlog cards for them.
-///
-/// Returns the number of new cards created.
-pub fn triage_new_issues(
-    _db: &crate::db::Db,
-    _repo: &str,
-    _issues: &[GhIssue],
-) -> Result<usize, String> {
-    Err("postgres backend required for GitHub issue triage; use triage_new_issues_pg".to_string())
-}
-
 /// PostgreSQL variant of issue auto-triage.
 pub async fn triage_new_issues_pg(
     pool: &PgPool,

--- a/src/kanban/hooks.rs
+++ b/src/kanban/hooks.rs
@@ -58,6 +58,8 @@ pub(super) fn fire_dynamic_hooks(
 ///
 /// Hooks cannot re-enter the engine, so transition requests and dispatch
 /// creations are accumulated for post-hook replay.
+// reason: pub kanban hook side-effect drainer; lib-build callers are cfg/test-gated. See #3034.
+#[allow(dead_code)]
 pub fn drain_hook_side_effects(db: &Db, engine: &PolicyEngine) {
     drain_hook_side_effects_with_backends(Some(db), engine);
 }
@@ -90,6 +92,8 @@ pub fn drain_hook_side_effects_with_backends(db: Option<&Db>, engine: &PolicyEng
 /// Looks up the `events` section of the effective pipeline and fires each
 /// hook name via `try_fire_hook_by_name`. Falls back to firing the default
 /// hook name if no pipeline config or no event binding is found.
+// reason: pub kanban event-hook firer used by dispatched_sessions; lib-build callers are cfg/test-gated. See #3034.
+#[allow(dead_code)]
 pub fn fire_event_hooks(
     db: &Db,
     engine: &PolicyEngine,
@@ -219,6 +223,8 @@ fn resolve_effective_pipeline_for_hooks(
     }
 }
 
+// reason: pub kanban state-hook firer used by dispatch_create; lib-build callers are cfg/test-gated. See #3034.
+#[allow(dead_code)]
 pub fn fire_state_hooks(db: &Db, engine: &PolicyEngine, card_id: &str, from: &str, to: &str) {
     fire_state_hooks_with_backends(Some(db), engine, card_id, from, to);
 }
@@ -244,6 +250,8 @@ pub fn fire_state_hooks_with_backends(
 ///
 /// Used when re-entering the same state (e.g., restarting review from awaiting_dod)
 /// where `fire_state_hooks` would no-op because from == to.
+// reason: pub kanban enter-hook firer; lib-build callers are cfg/test-gated. See #3034.
+#[allow(dead_code)]
 pub fn fire_enter_hooks(db: &Db, engine: &PolicyEngine, card_id: &str, state: &str) {
     fire_enter_hooks_with_backends(Some(db), engine, card_id, state);
 }
@@ -273,6 +281,8 @@ pub fn fire_enter_hooks_with_backends(
 
 /// Fire hooks for a status transition that already happened in the DB.
 /// Use this when the DB UPDATE was done elsewhere (e.g., update_card with mixed fields).
+// reason: pub kanban transition-hook firer; lib-build callers are cfg/test-gated. See #3034.
+#[allow(dead_code)]
 pub fn fire_transition_hooks(db: &Db, engine: &PolicyEngine, card_id: &str, from: &str, to: &str) {
     fire_transition_hooks_with_backends(Some(db), engine.pg_pool(), engine, card_id, from, to);
 }

--- a/src/kanban/review_tuning.rs
+++ b/src/kanban/review_tuning.rs
@@ -6,6 +6,8 @@ use sqlx::Row as SqlxRow;
 /// #119: When a card reaches done after a review pass verdict, record a true_negative
 /// tuning outcome. This confirms the review was correct in not finding issues.
 /// Returns true if a TN was actually inserted.
+// reason: review-tuning TN recorder (#119) called from hooks; lib-build callers are cfg/test-gated. See #3034.
+#[allow(dead_code)]
 pub(super) fn record_true_negative_if_pass(
     db: &Db,
     pg_pool: Option<&sqlx::PgPool>,

--- a/src/kanban/terminal_cleanup.rs
+++ b/src/kanban/terminal_cleanup.rs
@@ -15,14 +15,20 @@ const STALE_WORKTREE_KEYS: &[&str] = &[
 
 const WORKTREE_PATH_REFERENCE_KEYS: &[&str] = &["worktree_path", "completed_worktree_path"];
 
+// reason: terminal-card-state sync entry; lib-build callers are cfg/test-gated. See #3034.
+#[allow(dead_code)]
 pub(super) fn sync_terminal_card_state(db: &Db, card_id: &str) {
     sync_terminal_card_state_with_scope(db, card_id, true);
 }
 
+// reason: terminal-transition follow-up sync called from hooks; lib-build callers are cfg/test-gated. See #3034.
+#[allow(dead_code)]
 pub(super) fn sync_terminal_transition_followups(db: &Db, card_id: &str) {
     sync_terminal_card_state_with_scope(db, card_id, false);
 }
 
+// reason: scoped impl of the terminal-cleanup sync (sqlite/non-sqlite cfg arms); callers are cfg/test-gated. See #3034.
+#[allow(dead_code)]
 fn sync_terminal_card_state_with_scope(db: &Db, card_id: &str, cancel_implementation: bool) {
     #[cfg(not(all(test, feature = "legacy-sqlite-tests")))]
     {

--- a/src/kanban/test_support.rs
+++ b/src/kanban/test_support.rs
@@ -207,7 +207,9 @@ impl Drop for EnvVarGuard {
     }
 }
 
+// reason: test-support helper used by integration_tests; only that target invokes it. See #3034.
 #[cfg(unix)]
+#[allow(dead_code)]
 pub(crate) fn write_executable_script(path: &std::path::Path, contents: &str) {
     use std::os::unix::fs::PermissionsExt;
 
@@ -412,32 +414,6 @@ pub(crate) fn seed_pipeline_stages(db: &Db, repo_id: &str) -> (i64, i64) {
     .unwrap();
     let stage2 = conn.last_insert_rowid();
     (stage1, stage2)
-}
-
-pub(crate) fn seed_auto_queue_run(db: &Db, agent_id: &str) -> (String, String, String) {
-    ensure_auto_queue_tables(db);
-    let conn = db.lock().unwrap();
-    let run_id = "run-1";
-    let entry_a = "entry-a";
-    let entry_b = "entry-b";
-    conn.execute(
-        "INSERT INTO auto_queue_runs (id, status, agent_id, created_at) VALUES (?1, 'active', ?2, datetime('now'))",
-        sqlite_test::params![run_id, agent_id],
-    )
-    .unwrap();
-    conn.execute(
-        "INSERT INTO auto_queue_entries (id, run_id, kanban_card_id, agent_id, status, priority_rank)
-         VALUES (?1, ?2, 'card-q1', ?3, 'dispatched', 1)",
-        sqlite_test::params![entry_a, run_id, agent_id],
-    )
-    .unwrap();
-    conn.execute(
-        "INSERT INTO auto_queue_entries (id, run_id, kanban_card_id, agent_id, status, priority_rank)
-         VALUES (?1, ?2, 'card-q2', ?3, 'pending', 2)",
-        sqlite_test::params![entry_b, run_id, agent_id],
-    )
-    .unwrap();
-    (run_id.to_string(), entry_a.to_string(), entry_b.to_string())
 }
 
 pub(crate) async fn seed_auto_queue_run_pg(

--- a/src/kanban/transition_core.rs
+++ b/src/kanban/transition_core.rs
@@ -612,6 +612,9 @@ pub async fn transition_status_with_opts_and_allowed_cleanup_pg_only(
     .await
 }
 
+// reason: pub pg transition wrapper exposing cleanup counts; operational entry
+// point not wired by the default lib build. See #3034.
+#[allow(dead_code)]
 pub async fn transition_status_with_opts_and_allowed_cleanup_pg(
     db: Option<&Db>,
     pg_pool: &sqlx::PgPool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,9 +83,6 @@
 )]
 
 mod bootstrap;
-// CLI subcommands include operational and migration surfaces that are not all
-// exercised by every binary/test target yet.
-#[allow(dead_code)]
 mod cli;
 // Legacy path shims remain available while runtime-layout migrations settle.
 pub(crate) mod compat;
@@ -97,9 +94,6 @@ pub(crate) mod credential;
 // wired from selected API/maintenance paths.
 #[allow(dead_code)]
 mod db;
-// Dispatch orchestration spans direct, review, auto-queue, and test-support
-// paths that are not all active in each target.
-#[allow(dead_code)]
 mod dispatch;
 // Policy-engine loader/runtime helpers cover hot-reload and test-only entry
 // points outside the default server launch path.
@@ -107,13 +101,7 @@ mod engine;
 // Error-code helpers are kept for API response boundaries that only some
 // routes currently surface.
 mod error;
-// GitHub sync/triage helpers are optional integration surfaces behind runtime
-// configuration.
-#[allow(dead_code)]
 mod github;
-// Kanban transition helpers include hook and cleanup entry points selected by
-// policy/runtime flows.
-#[allow(dead_code)]
 pub(crate) mod kanban;
 mod launch;
 mod logging;


### PR DESCRIPTION
## Summary

Part 2 of the maintainability epic. Removes the module-level `#[allow(dead_code)]` blanket from FOUR modules in `src/lib.rs` only — `cli`, `github`, `kanban`, `dispatch` — and resolves every surfaced dead_code warning by either deleting genuinely-dead items or adding a narrowly-scoped item-level `#[allow(dead_code)]` with a reason comment + issue ref.

Guidance applied: these modules contain runtime/binary/feature/test-gated surfaces that only LOOK dead to the default lib check, so pub/pub(crate) operational entry points, migration surfaces, pg-first API re-exports, and SQLite/Postgres dead-twins were retained with a reasoned scoped allow; only provably-dead items (zero callers in any target, or superseded duplicates) were deleted.

## Per-module resolutions

**cli — deleted 5, scoped 0**
- `patch_json_value` (unused PATCH client primitive, no callers)
- `cmd_dispatch_retry` / `cmd_dispatch_redispatch` in client.rs (superseded by the async `direct.rs` variants wired from run.rs)
- `provider_unused_guidance` (unused diagnostic helper)
- `normalized_config_repo_ids` (unused helper)
- `open_registered_github_repo_ids` (test-gated, no callers) + dropped the now-orphaned `use crate::db::{open_write_connection, schema}` import

**github — deleted 1, scoped 3**
- deleted `triage_new_issues` (legacy SQLite stub that only errors; live path is `triage_new_issues_pg`)
- scoped `fetch_pr_head_state` + `fetch_pr_head_state_with` (runtime-gated PR-cache freshness probe)
- scoped `list_repos` / `register_repo` production cfg-twins (M2 dead-twin of the legacy-sqlite-tests variants; live paths are `list_repos_pg` / `db::postgres::register_repo`)

**kanban — deleted 1, scoped 11**
- deleted `seed_auto_queue_run` (SQLite test-helper twin; live path is `seed_auto_queue_run_pg`, no callers)
- scoped: `drain_hook_side_effects`, `fire_event_hooks`, `fire_state_hooks`, `fire_enter_hooks`, `fire_transition_hooks` (hook firers with prod + test-gated callers), `record_true_negative_if_pass`, `sync_terminal_card_state` / `sync_terminal_transition_followups` / `sync_terminal_card_state_with_scope`, `transition_status_with_opts_and_allowed_cleanup_pg` (pub pg transition wrapper), `write_executable_script` (test-support)

**dispatch — deleted 1, scoped 11**
- deleted `set_dispatch_status_sqlite_for_tests` (test-only, zero callers)
- scoped: `commit_belongs_to_card_issue` / `_tri` (production cfg-arms), `worktree_head_matches_commit`, `dirty_tracked_change_paths_async`, `clean_exact_review_worktree_path`, `is_work_dispatch_type`, `result_has_work_completion_evidence`, `set_dispatch_status_on_pg`, `finalize_dispatch`, `mark_dispatch_completed_pg_first`, `set_dispatch_status_pg_first`, `load_dispatch_row_pg_first` (pg-first dispatch-status API re-exported via `dispatch::*`)

## Verification

- `cargo check --workspace --all-features --all-targets` → clean; zero dead_code warnings remain in the four modules (other modules keep their blankets).
- `cargo fmt --all --check` → clean.
- `cargo test --lib --features legacy-sqlite-tests` for the deleted-code modules: dispatch_status 22 passed, kanban 42 passed, github 39 passed, cli 240 passed. The 6 cli failures observed are pre-existing environment-dependent failures (`PostgreSQL is required for OpenClaw DB import.` + provider-binary detection) reproduced identically on clean origin/main; none touch the deleted code.
- `./scripts/ci-script-checks.sh` → exit 0 (synced the three change-surfaces.md freeze entries for dispatch_context 5258 / dispatch_status 2129 / orchestrator 4385 after the LoC drift from these edits; no giant dropped below threshold → no ghost-registration).

Part of #3034 (Part 2/N; remaining: db, voice, server, services + await_holding_lock on #3016 track).

DO NOT MERGE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)