### PR TITLE
fix(relay): single-authority global_active increment helper (#3019)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -118,14 +118,14 @@
   - `src/services/discord/watchers/lifecycle.rs` (2445 lines — canonical
     lifecycle extraction surface from #1435; split further before adding new
     lifecycle behavior).
-  - `src/services/discord/tmux.rs` (2206 lines after #2558 dead-code sweep;
+  - `src/services/discord/tmux.rs` (2204 lines after #2558 dead-code sweep;
     failover guard; still giant-file territory).
   - `src/services/discord/tmux_watcher.rs` (6861 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh; split loop helpers
     further before adding behavior).
-  - `src/services/discord/tui_prompt_relay.rs` (3241 lines; SSH-direct TUI
+  - `src/services/discord/tui_prompt_relay.rs` (3237 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan).
   - `src/services/codex_tmux_wrapper.rs` (1223 lines; Codex tmux wrapper JSON
@@ -139,10 +139,10 @@
     extraction).
   - `src/services/discord/health/recovery.rs` (2425 lines; health recovery
     extraction surface, split further before adding non-bugfix behavior).
-  - `src/services/discord/router/message_handler/intake_turn.rs` (3613 lines;
+  - `src/services/discord/router/message_handler/intake_turn.rs` (3611 lines;
     Discord message intake turn orchestration split from the router message
     handler; bugfix only outside a further extraction plan).
-  - `src/services/discord/router/message_handler/headless_turn.rs` (1318 lines;
+  - `src/services/discord/router/message_handler/headless_turn.rs` (1316 lines;
     headless Discord turn launch/terminal-response path split from the router
     message handler; bugfix only outside a further extraction plan).
   - `src/services/discord/meeting_orchestrator.rs` (3228 lines).
@@ -369,7 +369,10 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   execution are the canonical scheduled JS routine surfaces. Split focused
   helper modules before growing these files again.
 - `src/services/platform/binary_resolver.rs` (1936).
-- `src/services/discord/mod.rs` (5837),
+- `src/services/discord/mod.rs` (5871; +34 from #3019 added the
+  single-authority `increment_global_active` helper + doc mirroring the
+  existing decrement helper — offset by removing 6 inline raw `fetch_add`
+  blocks across the relay turn-start sites that now route through it),
   `src/services/discord_config_audit.rs` (1318).
 - `src/services/turn_orchestrator.rs` (2932).
 

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -915,9 +915,43 @@ pub(in crate::services::discord) fn saturating_decrement_global_active(
     saturating_decrement_counter(shared.global_active.as_ref())
 }
 
+/// Single authoritative writer for the INCREMENT side of `global_active`,
+/// mirroring [`saturating_decrement_global_active`] on the decrement side
+/// (#3019, sub-issue of #3016).
+///
+/// INVARIANT: `global_active` == number of mailbox slots currently in the
+/// started-not-yet-finished state. This helper MUST be called +1 IFF a mailbox
+/// `try_start_turn` / `recovery_kickoff` actually activated a slot
+/// (`started` / `activated_turn == true`); the matching -1 happens IFF a
+/// mailbox finish/clear actually removed it (`removed_token.is_some()`). Keeping
+/// increment/decrement 1:1 with the real mailbox state transition — NEVER caller
+/// intent — is what prevents the drift/underflow seen in #2934.
+///
+/// Callers are responsible for the mailbox-activation gate; this helper does NOT
+/// change WHEN the counter moves, only funnels HOW it moves so increment is
+/// single-authority/single-helper exactly like decrement. `reason` is recorded
+/// for observability so every increment is attributable to its activation site.
+pub(in crate::services::discord) fn increment_global_active(
+    shared: &SharedData,
+    reason: &str,
+) -> usize {
+    increment_counter(shared.global_active.as_ref(), reason)
+}
+
+fn increment_counter(counter: &AtomicUsize, reason: &str) -> usize {
+    let next = counter.fetch_add(1, Ordering::Relaxed) + 1;
+    tracing::debug!(
+        target: "agentdesk::global_active",
+        reason,
+        global_active = next,
+        "global_active increment"
+    );
+    next
+}
+
 #[cfg(test)]
 mod global_active_counter_tests {
-    use super::saturating_decrement_counter;
+    use super::{increment_counter, saturating_decrement_counter};
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
@@ -934,6 +968,35 @@ mod global_active_counter_tests {
 
         assert!(saturating_decrement_counter(&counter));
         assert_eq!(counter.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn increment_counter_increments_once_and_returns_new_value() {
+        let counter = AtomicUsize::new(0);
+
+        assert_eq!(increment_counter(&counter, "unit_test"), 1);
+        assert_eq!(counter.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn paired_increment_then_decrement_keeps_counter_balanced() {
+        let counter = AtomicUsize::new(0);
+
+        // A single activated mailbox transition: +1 on start, -1 on finish.
+        increment_counter(&counter, "mailbox_started");
+        assert_eq!(counter.load(Ordering::Relaxed), 1);
+        assert!(saturating_decrement_counter(&counter));
+        assert_eq!(counter.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn increment_counter_is_strictly_additive_across_repeated_calls() {
+        let counter = AtomicUsize::new(0);
+
+        for expected in 1..=6 {
+            assert_eq!(increment_counter(&counter, "repeated_site"), expected);
+        }
+        assert_eq!(counter.load(Ordering::Relaxed), 6);
     }
 }
 
@@ -2744,9 +2807,7 @@ async fn mailbox_recovery_kickoff(
         .recovery_kickoff(cancel_token, request_owner, user_message_id)
         .await;
     if result.activated_turn {
-        shared
-            .global_active
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        increment_global_active(shared, "recovery_kickoff");
     }
     result
 }

--- a/src/services/discord/router/message_handler/headless_turn.rs
+++ b/src/services/discord/router/message_handler/headless_turn.rs
@@ -551,9 +551,7 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
         adk_session_key.as_deref(),
     )
     .await;
-    shared
-        .global_active
-        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    crate::services::discord::increment_global_active(shared, "headless_turn_start");
     shared
         .turn_start_times
         .insert(channel_id, std::time::Instant::now());

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -2308,9 +2308,7 @@ pub(in crate::services::discord) async fn handle_text_message(
             }
         }
     };
-    shared
-        .global_active
-        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    crate::services::discord::increment_global_active(shared, "intake_after_mailbox_slot");
     shared
         .turn_start_times
         .insert(channel_id, std::time::Instant::now());

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -1135,9 +1135,7 @@ async fn start_monitor_auto_turn_when_available(
         )
         .await;
         if started {
-            shared
-                .global_active
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            super::increment_global_active(shared, "tmux_monitor_auto_turn");
             shared
                 .turn_start_times
                 .insert(channel_id, std::time::Instant::now());

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -824,9 +824,7 @@ async fn claim_tui_direct_synthetic_turn(
             };
         }
         if started {
-            shared
-                .global_active
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            super::increment_global_active(shared, "tui_direct_synthetic_refresh");
             shared
                 .turn_start_times
                 .insert(channel_id, std::time::Instant::now());
@@ -873,9 +871,7 @@ async fn claim_tui_direct_synthetic_turn(
     }
 
     if started {
-        shared
-            .global_active
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        super::increment_global_active(shared, "tui_direct_synthetic_save");
         shared
             .turn_start_times
             .insert(channel_id, std::time::Instant::now());


### PR DESCRIPTION
## Defect

The global `active` (in-progress turn) counter had a single-authority **DECREMENT** path (`saturating_decrement_global_active`, gated on the mailbox `removed_token.is_some()` in `turn_finalizer`, landed in #3016 phases 1-3) — but the **INCREMENT** side had **no helper**. There were ~6 raw `global_active.fetch_add(1, Relaxed)` production sites, each ad-hoc paired with a mailbox start-success. Multiple ad-hoc writers is exactly the accounting-drift / underflow risk surfaced in #2934 that the `normalize_*` clamp band-aids over (see issue observation: E-18 cancel left `global_active=2` while `agentdesk status` reported 0 active sessions).

## Fix

Add `increment_global_active(shared, reason)` next to the decrement helper (wrapping a logged `increment_counter`), making increment **single-authority / single-helper** exactly like decrement. Route all 6 production increment sites through it, **keeping each site's existing mailbox-activation gate unchanged** — this changes *how* the counter moves, not *when*. `reason` is recorded (debug log, `agentdesk::global_active` target) so every increment is attributable to its activation site.

## Invariant preserved

`global_active` == number of mailbox slots currently in the started-not-yet-finished state.
- **+1** IFF a mailbox `try_start_turn` / `recovery_kickoff` actually activated a slot (`started` / `activated_turn == true`)
- **-1** IFF a mailbox finish/clear actually removed it (`removed_token.is_some()`)

Increment/decrement stay **1:1 with the mailbox state transition, never caller intent** — this is what prevents underflow (#2934).

## 6 routed production sites (each keeps its activation gate)

1. `src/services/discord/mod.rs` — `recovery_kickoff` (gated on `result.activated_turn`)
2. `src/services/discord/router/message_handler/intake_turn.rs` — after mailbox slot acquired
3. `src/services/discord/router/message_handler/headless_turn.rs` — headless turn start
4. `src/services/discord/tmux.rs` — monitor auto-turn (gated on `started`)
5. `src/services/discord/tui_prompt_relay.rs` — synthetic TUI refresh path (gated on `started`)
6. `src/services/discord/tui_prompt_relay.rs` — synthetic TUI save path (gated on `started`)

The 2 test-harness `fetch_add` in `health.rs` (`seed_active_turn` / start-turn seed helpers) are intentionally left as-is.

## Deferred (follow-up, NOT this PR)

Collapsing the ~12 out-of-finalizer decrement **callers** — each is already correctly gated on `removed_token`; that consolidation is separate. This PR is scoped to increment-side authority only.

## Tests

- `increment_counter` increments once and returns the new value
- paired increment+decrement keeps the counter balanced (single activated transition)
- strictly-additive across repeated calls
- (mirrors the existing decrement counter tests)

## Verification

- `cargo check --workspace --all-features --all-targets` — clean
- `cargo fmt --all --check` — clean
- `cargo test --lib` for the counter / turn_finalizer / discord modules (incl. new tests) — pass (tui_prompt_relay 53, tmux 117, message_handler 40, health::recovery 20, global_active counter 7)
- `./scripts/ci-script-checks.sh` — exit 0 (synced `change-surfaces.md` LoC drift)

Sub-issue of #3016.

🤖 Generated with [Claude Code](https://claude.com/claude-code)