### PR TITLE
chore(lint): remove dead_code blankets for db and voice modules (#3034)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -161,9 +161,20 @@
     lobby routing, progress mirroring, and barge-in orchestration surface;
     tracked decompose target — see `giant-file-registry.md` (owner
     `voice-runtime`, deadline 2026-08-31, #3036)).
-  - `src/voice/receiver.rs` (1046 lines; voice receive pipeline, utterance
+  - `src/voice/receiver.rs` (1052 lines; voice receive pipeline, utterance
     segmentation, artifact cleanup, and retention policy surface; split before
     adding non-bugfix behavior).
+  - `src/voice/announce_meta.rs` (1001 lines; voice announcement durability /
+    handoff metadata surface; crossed the giant threshold when #3034 restored
+    per-item dead_code reasoning on the runtime-gated durable helpers; tracked
+    decompose target — see `giant-file-registry.md` (owner `voice-runtime`,
+    deadline 2026-08-31, #3036)).
+  - `src/db/automation_candidates.rs` (1003 lines; pipeline-v2 automation
+    candidate iteration repository surface (#2064); crossed the giant threshold
+    when #3034 restored per-item dead_code reasoning on the still-unwired
+    iteration-loop helpers; tracked decompose target — see
+    `giant-file-registry.md` (owner `automation-pipeline`, deadline
+    2026-08-31, #3036)).
   - `src/services/discord/commands/config.rs` (1894 lines).
   - `src/services/discord/{commands/text_commands.rs, commands/diagnostics.rs,
     discord_config_audit.rs, router/intake_gate.rs, inflight.rs}`
@@ -289,7 +300,7 @@
   - `src/db/auto_queue/tests.rs` is the migrated auto-queue test harness; it is a
     dedicated `*_tests.rs` file (excluded from the production giant-file count),
     so add coverage freely but keep it split-friendly.
-  - `src/db/auto_queue/entries.rs` (1505 lines; awaiting follow-up split per
+  - `src/db/auto_queue/entries.rs` (1508 lines; awaiting follow-up split per
     auto-queue decompose epic #1782).
   - `src/db/auto_queue/phase_gates.rs` (1639 lines after #1980 durable
     reconciliation, production LoC; PG-backed tests for `current_batch_phase_pg`
@@ -302,8 +313,8 @@
     adding new feature logic).
   - `src/db/kanban_cards/` (1932 total lines; kanban card persistence and
     GitHub sync lookup surface).
-  - `src/db/postgres.rs` (1006 lines).
-  - `src/db/dispatched_sessions.rs` (1639 lines; dispatched session
+  - `src/db/postgres.rs` (1009 lines).
+  - `src/db/dispatched_sessions.rs` (1630 lines; dispatched session
     persistence helpers).
   - `src/db/session_transcripts.rs` is a retained PG-cleanup surface (now below
     the giant-file threshold; bugfix only).

--- a/scripts/giant_file_registry.toml
+++ b/scripts/giant_file_registry.toml
@@ -238,3 +238,20 @@ file = "src/services/discord/voice_barge_in.rs"
 owner = "voice-runtime"
 deadline = "2026-08-31"
 decompose_issue = "#3036"
+
+[[entry]]
+# Crossed the 1000-prod-LoC threshold when #3034 restored per-item dead_code
+# reasoning on the (still-unwired) automation-candidate iteration repo helpers.
+# Active pipeline-v2 surface (#2064); decompose once the iteration loop is wired.
+file = "src/db/automation_candidates.rs"
+owner = "automation-pipeline"
+deadline = "2026-08-31"
+decompose_issue = "#3036"
+
+[[entry]]
+# Crossed the 1000-prod-LoC threshold when #3034 restored per-item dead_code
+# reasoning on the runtime-gated voice announcement durability helpers.
+file = "src/voice/announce_meta.rs"
+owner = "voice-runtime"
+deadline = "2026-08-31"
+decompose_issue = "#3036"

--- a/src/db/agents.rs
+++ b/src/db/agents.rs
@@ -13,6 +13,9 @@ use crate::config::{AgentChannel, AgentDef};
 use crate::db::Db;
 use crate::services::provider::ProviderKind;
 
+// reason: used only by the legacy-sqlite-tests-gated agent alias path below;
+// the production copy lives in db/postgres.rs. See #3034 / #3035.
+#[allow(dead_code)]
 const LEGACY_AGENT_PREFIX: &str = "openclaw-";
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/src/db/auto_queue/entries.rs
+++ b/src/db/auto_queue/entries.rs
@@ -22,6 +22,9 @@ pub const ENTRY_STATUS_USER_CANCELLED: &str = "user_cancelled";
 /// tick to pick up and dispatch. Exposed as a small shim so callers can
 /// treat `user_cancelled` uniformly alongside other non-dispatchable states
 /// (#815).
+// reason: auto-queue dispatchability shim wired on select tick paths; current
+// callers live in the dispatch-cancel test surface. See #3034.
+#[allow(dead_code)]
 pub fn is_dispatchable_entry_status(status: &str) -> bool {
     matches!(status.trim(), ENTRY_STATUS_PENDING)
 }

--- a/src/db/automation_candidates.rs
+++ b/src/db/automation_candidates.rs
@@ -141,6 +141,7 @@ fn ensure_one_card_row_affected(
 #[cfg(test)]
 mod verdict_tests;
 
+#[allow(dead_code)] // staged-rollout automation-candidate repo helper; not on every target. See #3034
 pub async fn insert_iteration_pg(
     pool: &PgPool,
     params: InsertIterationParams,
@@ -315,6 +316,7 @@ pub async fn list_iterations_for_card_pg(
 }
 
 /// Load `title` and `metadata` JSON for a card — used by the discard path to seed child cards.
+#[allow(dead_code)] // staged-rollout automation-candidate repo helper; not on every target. See #3034
 pub async fn load_card_header_pg(
     pool: &PgPool,
     card_id: &str,
@@ -648,6 +650,7 @@ async fn lock_candidate_dedupe_key_in_tx(
     Ok(())
 }
 
+#[allow(dead_code)] // staged-rollout automation-candidate repo helper; not on every target. See #3034
 pub async fn iteration_count_for_card_pg(pool: &PgPool, card_id: &str) -> Result<i64, String> {
     sqlx::query_scalar::<_, i64>(
         "SELECT COUNT(*) FROM automation_candidate_iterations WHERE card_id = $1",
@@ -820,6 +823,7 @@ fn program_iteration_budget(program: &serde_json::Value) -> i32 {
 }
 
 /// Transition the card to a new status.
+#[allow(dead_code)] // staged-rollout automation-candidate repo helper; not on every target. See #3034
 pub async fn transition_card_status_pg(
     pool: &PgPool,
     card_id: &str,
@@ -844,6 +848,7 @@ pub async fn transition_card_status_pg(
 }
 
 /// Persist the last completed automation iteration on the card's program metadata.
+#[allow(dead_code)] // staged-rollout automation-candidate repo helper; not on every target. See #3034
 pub async fn update_card_program_current_iteration_pg(
     pool: &PgPool,
     card_id: &str,
@@ -880,6 +885,7 @@ pub async fn update_card_program_current_iteration_pg(
 }
 
 /// Create a child card for the next iteration of an automation candidate.
+#[allow(dead_code)] // staged-rollout automation-candidate repo helper; not on every target. See #3034
 pub async fn create_child_candidate_card_pg(
     pool: &PgPool,
     parent_card_id: &str,
@@ -933,6 +939,7 @@ pub async fn create_child_candidate_card_pg(
 /// Read `metadata->'program'->>'repo_dir'` for the card.
 ///
 /// Returns `None` if the card doesn't exist or the field isn't set.
+#[allow(dead_code)] // staged-rollout automation-candidate repo helper; not on every target. See #3034
 pub async fn load_card_repo_dir_pg(pool: &PgPool, card_id: &str) -> Result<Option<String>, String> {
     let value: Option<String> = sqlx::query_scalar(
         r#"
@@ -955,6 +962,7 @@ pub async fn load_card_repo_dir_pg(pool: &PgPool, card_id: &str) -> Result<Optio
 ///
 /// Returns `None` if the card doesn't exist or the field isn't set.
 /// Expected values: `"manual_review"` (default) | `"auto_apply_after_green"`.
+#[allow(dead_code)] // staged-rollout automation-candidate repo helper; not on every target. See #3034
 pub async fn load_card_final_gate_pg(
     pool: &PgPool,
     card_id: &str,

--- a/src/db/cancel_tombstones.rs
+++ b/src/db/cancel_tombstones.rs
@@ -55,6 +55,9 @@ pub const CANCEL_TOMBSTONE_FALLBACK_TTL_SECS: i64 = 60;
 /// death is no longer attributable to the cancel.
 pub const CANCEL_TEARDOWN_GRACE_BYTES: i64 = 4 * 1024;
 
+// reason: public cancel-tombstone DTO for the read path; consumers are wired on
+// selected cancel-attribution routes, not every compile target. See #3034.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct CancelTombstone {
     pub channel_id: i64,

--- a/src/db/dispatched_sessions.rs
+++ b/src/db/dispatched_sessions.rs
@@ -1838,15 +1838,6 @@ pub(crate) struct UpdateSessionParams<'a> {
     pub(crate) session_info: Option<&'a str>,
 }
 
-pub(crate) async fn session_exists_pg(pool: &PgPool, session_key: &str) -> Result<bool, String> {
-    sqlx::query("SELECT 1 FROM sessions WHERE session_key = $1 LIMIT 1")
-        .bind(session_key)
-        .fetch_optional(pool)
-        .await
-        .map(|row| row.is_some())
-        .map_err(|error| format!("load postgres session existence for {session_key}: {error}"))
-}
-
 /// Upsert a hook session row.
 ///
 /// #2045 Finding 7 (P2): the helper now returns whether the row was inserted

--- a/src/db/idempotency.rs
+++ b/src/db/idempotency.rs
@@ -32,6 +32,9 @@ pub enum IdempotencyOutcome {
     Replay {
         status: u16,
         body: Value,
+        // reason: carried for the replay-response route layer that consumes it
+        // on selected idempotent paths. See #3034.
+        #[allow(dead_code)]
         completed_at: DateTime<Utc>,
     },
     /// Another caller holds the key but has not finished yet. The right
@@ -39,7 +42,12 @@ pub enum IdempotencyOutcome {
     InFlight,
     /// The key was reused with a different request body. The right
     /// response at the route layer is `422 Unprocessable Entity`.
-    FingerprintMismatch { stored_fingerprint: String },
+    FingerprintMismatch {
+        // reason: carried for the 422 route layer that consumes it on selected
+        // idempotent paths. See #3034.
+        #[allow(dead_code)]
+        stored_fingerprint: String,
+    },
 }
 
 /// Attempt to take ownership of `(scope, key)` for a new request.
@@ -153,6 +161,9 @@ pub async fn record_response(
 /// permanently occupy the slot until `expires_at`. Callers can invoke
 /// this when they hit a code path that wants to release ownership
 /// (e.g. validation failed before any business mutation ran).
+// reason: best-effort idempotency-slot cleanup invoked on selected validation
+// failure paths, not every compile target. See #3034.
+#[allow(dead_code)]
 pub async fn release_unclaimed(pool: &PgPool, scope: &str, key: &str) -> Result<(), sqlx::Error> {
     sqlx::query(
         "DELETE FROM idempotency_keys

--- a/src/db/intake_outbox.rs
+++ b/src/db/intake_outbox.rs
@@ -39,9 +39,15 @@ pub(crate) struct IntakeOutboxRow {
     pub wait_for_completion: bool,
     pub agent_id: String,
     pub status: String,
+    // reason: intake-outbox row column consumed by select claim/retry routes,
+    // not every compile target. See #3034.
+    #[allow(dead_code)]
     pub claim_owner: Option<String>,
     pub attempt_no: i32,
     pub parent_outbox_id: Option<i64>,
+    // reason: intake-outbox row column consumed by select claim/retry routes,
+    // not every compile target. See #3034.
+    #[allow(dead_code)]
     pub retry_count: i32,
 }
 
@@ -171,6 +177,9 @@ pub(crate) fn classify_insert_pending_error(error: &sqlx::Error) -> Option<Intak
 /// Compute `MAX(attempt_no)` for a `(channel_id, user_msg_id)` family,
 /// or 0 if no row exists yet. Used by retry-on-`failed_pre_accept` to
 /// allocate `attempt_no = family_max + 1` (round-4 P0 — monotonic).
+// reason: intake-outbox retry helper exercised only by the pg-integration test
+// suite; production retry path wired on select routes. See #3034.
+#[allow(dead_code)]
 pub(crate) async fn family_max_attempt(
     pool: &PgPool,
     channel_id: &str,
@@ -394,6 +403,9 @@ pub(crate) async fn mark_failed_post_accept(
 ///
 /// Returns the number of rows reset. Phase 4 emits this count as a
 /// metric for operator monitoring.
+// reason: leader-sweep maintenance helper exercised by the pg-integration test
+// suite; production sweep wired on the leader path. See #3034.
+#[allow(dead_code)]
 pub(crate) async fn sweep_stale_pre_accept_claims(
     pool: &PgPool,
     stale_after_secs: i64,
@@ -595,6 +607,9 @@ pub(crate) async fn list_recent_rows(
 /// `sla_secs` without reaching `spawned`. Round-3 P1 #3: the operator
 /// alert IS the recovery signal — auto-retry forbidden post-accept.
 /// Returns `(id, accepted_at)` tuples for each row exceeding the SLA.
+// reason: SLA-alert maintenance helper exercised by the pg-integration test
+// suite; production alert path wired on the leader sweep. See #3034.
+#[allow(dead_code)]
 pub(crate) async fn list_accepted_unspawned_sla(
     pool: &PgPool,
     sla_secs: i64,

--- a/src/db/memento_feedback_stats.rs
+++ b/src/db/memento_feedback_stats.rs
@@ -126,6 +126,9 @@ pub fn list_daily_stats(conn: &Connection) -> Result<Vec<MementoFeedbackDailySta
     Ok(rows.collect::<sqlite_test::Result<Vec<_>>>()?)
 }
 
+// reason: only caller is the legacy-sqlite-tests-gated upsert_turn_stat_on_conn;
+// dead in the production build. See #3034 / #3035.
+#[allow(dead_code)]
 fn validate_turn_stat(stat: &MementoFeedbackTurnStat) -> Result<()> {
     if stat.turn_id.trim().is_empty() {
         return Err(anyhow!("memento feedback stats require non-empty turn_id"));

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -58,9 +58,15 @@ impl std::error::Error for LegacySqliteError {}
 #[cfg(not(all(test, feature = "legacy-sqlite-tests")))]
 pub struct LegacySqliteConnection;
 
+// reason: production-side shim mirroring the legacy-sqlite-tests API surface;
+// constructed only under the legacy-sqlite-tests feature. See #3034 / #3035.
+#[allow(dead_code)]
 #[cfg(not(all(test, feature = "legacy-sqlite-tests")))]
 pub struct LegacySqliteStatement;
 
+// reason: production-side shim mirroring the legacy-sqlite-tests API surface;
+// constructed only under the legacy-sqlite-tests feature. See #3034 / #3035.
+#[allow(dead_code)]
 #[cfg(not(all(test, feature = "legacy-sqlite-tests")))]
 pub struct LegacySqliteRows;
 
@@ -73,10 +79,16 @@ impl LegacySqliteDisabled {
         Err(LegacySqliteError)
     }
 
+    // reason: legacy-sqlite API parity shim; exercised only under
+    // legacy-sqlite-tests. See #3034 / #3035.
+    #[allow(dead_code)]
     pub fn read_conn(&self) -> Result<LegacySqliteConnection, LegacySqliteError> {
         Err(LegacySqliteError)
     }
 
+    // reason: legacy-sqlite API parity shim; exercised only under
+    // legacy-sqlite-tests. See #3034 / #3035.
+    #[allow(dead_code)]
     pub fn separate_conn(&self) -> Result<LegacySqliteConnection, LegacySqliteError> {
         Err(LegacySqliteError)
     }
@@ -88,10 +100,16 @@ impl LegacySqliteConnection {
         Err(LegacySqliteError)
     }
 
+    // reason: legacy-sqlite API parity shim; exercised only under
+    // legacy-sqlite-tests. See #3034 / #3035.
+    #[allow(dead_code)]
     pub fn execute_batch(&self, _sql: &str) -> Result<(), LegacySqliteError> {
         Err(LegacySqliteError)
     }
 
+    // reason: legacy-sqlite API parity shim; exercised only under
+    // legacy-sqlite-tests. See #3034 / #3035.
+    #[allow(dead_code)]
     pub fn prepare(&self, _sql: &str) -> Result<LegacySqliteStatement, LegacySqliteError> {
         Err(LegacySqliteError)
     }
@@ -106,10 +124,16 @@ impl LegacySqliteConnection {
 
 #[cfg(not(all(test, feature = "legacy-sqlite-tests")))]
 impl LegacySqliteStatement {
+    // reason: legacy-sqlite API parity shim; exercised only under
+    // legacy-sqlite-tests. See #3034 / #3035.
+    #[allow(dead_code)]
     pub fn query<P>(&mut self, _params: P) -> Result<LegacySqliteRows, LegacySqliteError> {
         Err(LegacySqliteError)
     }
 
+    // reason: legacy-sqlite API parity shim; exercised only under
+    // legacy-sqlite-tests. See #3034 / #3035.
+    #[allow(dead_code)]
     pub fn query_map<P, F, T>(
         &mut self,
         _params: P,
@@ -124,6 +148,9 @@ impl LegacySqliteStatement {
 
 #[cfg(not(all(test, feature = "legacy-sqlite-tests")))]
 impl LegacySqliteRows {
+    // reason: legacy-sqlite API parity shim; exercised only under
+    // legacy-sqlite-tests. See #3034 / #3035.
+    #[allow(dead_code)]
     pub fn next(&mut self) -> Result<Option<LegacySqliteRow>, LegacySqliteError> {
         Err(LegacySqliteError)
     }

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -358,6 +358,9 @@ pub async fn applied_migration_checksum_mismatch_details(
     Ok(mismatches)
 }
 
+// reason: public migration-diagnostics wrapper surfaced by maintenance paths,
+// not by every compile target. See #3034.
+#[allow(dead_code)]
 pub async fn applied_migration_checksum_mismatches(pool: &PgPool) -> Result<Vec<i64>, String> {
     Ok(applied_migration_checksum_mismatch_details(pool)
         .await?

--- a/src/db/prompt_manifests/builder.rs
+++ b/src/db/prompt_manifests/builder.rs
@@ -37,6 +37,9 @@ impl PromptManifestBuilder {
         self
     }
 
+    // reason: builder convenience exercised by the prompt-manifest test suite;
+    // production callers use the lower-level `layer` API. See #3034.
+    #[allow(dead_code)]
     pub fn content_layer(
         self,
         layer_name: impl Into<String>,

--- a/src/db/session_transcripts.rs
+++ b/src/db/session_transcripts.rs
@@ -54,6 +54,9 @@ pub struct PersistSessionTranscript<'a> {
     pub duration_ms: Option<i64>,
 }
 
+// reason: public transcript record for the read/fetch route; the pg-side load
+// path that builds it is wired only on selected API paths. See #3034.
+#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct SessionTranscriptRecord {
     pub id: i64,
@@ -506,6 +509,9 @@ fn normalize_search_query(raw_query: &str) -> Option<String> {
     }
 }
 
+// reason: transcript read-side helper that feeds SessionTranscriptRecord; wired
+// only on the selected transcript-fetch path. See #3034.
+#[allow(dead_code)]
 fn parse_events_json(raw: Option<&str>) -> Vec<SessionTranscriptEvent> {
     raw.and_then(|value| {
         let trimmed = value.trim();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,6 @@ mod config;
 pub(crate) mod credential;
 // Database repositories intentionally expose cross-route helpers that are only
 // wired from selected API/maintenance paths.
-#[allow(dead_code)]
 mod db;
 mod dispatch;
 // Policy-engine loader/runtime helpers cover hot-reload and test-only entry
@@ -131,7 +130,6 @@ mod ui;
 mod utils;
 // Voice runtime is an optional provider feature; most entry points are wired
 // only when voice config is enabled.
-#[allow(dead_code)]
 pub(crate) mod voice;
 
 #[cfg(test)]

--- a/src/voice/announce_meta.rs
+++ b/src/voice/announce_meta.rs
@@ -129,6 +129,7 @@ impl VoiceAnnouncementMetaStore {
         }
     }
 
+    #[allow(dead_code)] // voice runtime wired only when voice config enabled; no target exercises it. See #3034
     pub(crate) fn take(&self, message_id: MessageId) -> Option<VoiceTranscriptAnnouncement> {
         self.take_with_acceptance(message_id)
             .map(|(announcement, _)| announcement)
@@ -155,6 +156,7 @@ impl VoiceAnnouncementMetaStore {
             .map(|stored| (stored.announcement, stored.accepted_replay))
     }
 
+    #[allow(dead_code)] // voice runtime wired only when voice config enabled; no target exercises it. See #3034
     pub(crate) fn contains(&self, message_id: MessageId) -> bool {
         let mut entries = match self.entries.write() {
             Ok(entries) => entries,
@@ -165,6 +167,7 @@ impl VoiceAnnouncementMetaStore {
         entries.contains_key(&message_id.get())
     }
 
+    #[allow(dead_code)] // voice runtime wired only when voice config enabled; no target exercises it. See #3034
     pub(crate) fn insert_handoff(&self, message_id: MessageId, meta: VoiceBackgroundHandoffMeta) {
         self.insert_handoff_with_remaining_ttl(message_id, meta, HANDOFF_META_TTL);
     }
@@ -507,6 +510,7 @@ pub(crate) async fn bind_pending_voice_announcement_by_key_durable(
 
 /// Atomic consume variant for workers that receive a forwarded readable
 /// announcement before the posting process successfully binds `message_id`.
+#[allow(dead_code)] // voice runtime wired only when voice config enabled; no target exercises it. See #3034
 pub(crate) async fn take_pending_voice_announcement_by_key_durable(
     pool: &PgPool,
     pending_key: &str,
@@ -586,6 +590,7 @@ pub(crate) async fn load_consumed_voice_announcement_durable(
     value.map(decode_voice_announcement_value).transpose()
 }
 
+#[allow(dead_code)] // voice runtime wired only when voice config enabled; no target exercises it. See #3034
 pub(crate) async fn take_voice_announcement_durable(
     pool: &PgPool,
     message_id: MessageId,
@@ -654,6 +659,7 @@ fn is_durable_pending_message_id(message_id: &str) -> bool {
 /// `ON CONFLICT … DO UPDATE` deliberately refuses to update rows that were
 /// already consumed. A late publish/persist retry must not resurrect a
 /// handoff after terminal delivery has claimed it (#2392).
+#[allow(dead_code)] // voice runtime wired only when voice config enabled; no target exercises it. See #3034
 pub(crate) async fn persist_handoff_durable(
     pool: &PgPool,
     message_id: MessageId,

--- a/src/voice/barge_in.rs
+++ b/src/voice/barge_in.rs
@@ -125,6 +125,9 @@ impl LiveBargeInMonitor {
         }
     }
 
+    // reason: voice runtime is wired only when voice config is enabled; no
+    // compile target exercises it. See #3034.
+    #[allow(dead_code)]
     pub(crate) fn sensitivity(&self) -> BargeInSensitivity {
         self.sensitivity
     }
@@ -257,6 +260,9 @@ impl DeferredBargeInBuffer {
         }
     }
 
+    // reason: voice runtime is wired only when voice config is enabled; no
+    // compile target exercises it. See #3034.
+    #[allow(dead_code)]
     pub(crate) fn push_transcript(&mut self, transcript: &str) -> bool {
         let cleaned = cleaned_transcript_for_prompt(transcript);
         if cleaned.is_empty() || is_repeated_noise_transcript(&cleaned) {
@@ -280,6 +286,9 @@ impl DeferredBargeInBuffer {
         }
     }
 
+    // reason: voice runtime is wired only when voice config is enabled; no
+    // compile target exercises it. See #3034.
+    #[allow(dead_code)]
     pub(crate) fn len(&self) -> usize {
         self.turn_count
     }
@@ -334,6 +343,9 @@ pub(crate) async fn run_sensitivity_ttl_reset(
     }
 }
 
+// reason: voice runtime is wired only when voice config is enabled; no compile
+// target exercises it. See #3034.
+#[allow(dead_code)]
 pub(crate) fn pcm16_stereo_levels(buf: &[u8]) -> (f32, f32) {
     let levels = pcm16_stereo_levels_struct(buf);
     (levels.mean_db, levels.max_db)

--- a/src/voice/commands.rs
+++ b/src/voice/commands.rs
@@ -12,6 +12,9 @@ use crate::voice::barge_in::{BargeInSensitivity, parse_sensitivity_command};
 use crate::voice::config::DEFAULT_ACTIVE_AGENT_TTL_SECS;
 use crate::voice::progress;
 
+// reason: voice runtime is wired only when voice config is enabled; no compile
+// target exercises it. See #3034.
+#[allow(dead_code)]
 pub(crate) const VOICE_ACTIVE_AGENT_CONTEXT_TTL: Duration =
     Duration::from_secs(DEFAULT_ACTIVE_AGENT_TTL_SECS);
 pub(crate) const DEFAULT_WAKE_WORD: &str = "agentdesk";

--- a/src/voice/config.rs
+++ b/src/voice/config.rs
@@ -104,6 +104,9 @@ impl VoiceConfig {
             .and_then(|value| value.parse::<u64>().ok())
     }
 
+    // reason: voice runtime is wired only when voice config is enabled; no
+    // compile target exercises it. See #3034.
+    #[allow(dead_code)]
     pub(crate) fn is_lobby_channel(&self, channel_id: u64) -> bool {
         self.lobby_channel_id_u64() == Some(channel_id)
     }

--- a/src/voice/metrics.rs
+++ b/src/voice/metrics.rs
@@ -119,6 +119,9 @@ pub fn finish_agent_start(channel_id: u64) -> Option<u64> {
 /// when the turn fails before the answer is ready (e.g. `start_voice_turn`
 /// errors out) so the next turn's `mark_agent_start` doesn't carry a stale
 /// instant.
+// reason: voice runtime is wired only when voice config is enabled; no compile
+// target exercises it. See #3034.
+#[allow(dead_code)]
 pub fn discard_agent_start(channel_id: u64) {
     if let Ok(mut map) = agent_start_registry().lock() {
         map.remove(&channel_id);

--- a/src/voice/progress.rs
+++ b/src/voice/progress.rs
@@ -312,6 +312,9 @@ pub(crate) fn parse_verbose_progress_command(transcript: &str) -> Option<Verbose
     None
 }
 
+// reason: voice runtime is wired only when voice config is enabled; no compile
+// target exercises it. See #3034.
+#[allow(dead_code)]
 pub(crate) fn is_turn_start_event(label: &str) -> bool {
     label.trim().eq_ignore_ascii_case("agent:start")
 }

--- a/src/voice/prompt.rs
+++ b/src/voice/prompt.rs
@@ -342,6 +342,9 @@ pub(crate) fn voice_transcript_announcement_meta(
     }
 }
 
+// reason: voice runtime is wired only when voice config is enabled; no compile
+// target exercises it. See #3034.
+#[allow(dead_code)]
 pub(crate) fn parse_voice_transcript_announcement(
     text: &str,
 ) -> Option<VoiceTranscriptAnnouncement> {
@@ -460,6 +463,9 @@ fn voice_background_handoff_header_line(line: &str) -> Option<&str> {
         .then_some(unspoiled)
 }
 
+// reason: voice runtime is wired only when voice config is enabled; no compile
+// target exercises it. See #3034.
+#[allow(dead_code)]
 pub(crate) fn parse_authorized_voice_transcript_announcement(
     text: &str,
     author_id: u64,
@@ -481,6 +487,9 @@ fn readable_transcript_line(text: &str) -> String {
     escape_discord_mentions(&text.split_whitespace().collect::<Vec<_>>().join(" "))
 }
 
+// reason: voice runtime is wired only when voice config is enabled; no compile
+// target exercises it. See #3034.
+#[allow(dead_code)]
 fn unescape_discord_mentions(text: &str) -> String {
     text.replace("@\u{200B}", "@")
 }
@@ -505,6 +514,9 @@ fn nonce_bound_transcript_close(nonce: &str) -> String {
     format!("</{TRANSCRIPT_TAG_PREFIX}{nonce}>")
 }
 
+// reason: voice runtime is wired only when voice config is enabled; no compile
+// target exercises it. See #3034.
+#[allow(dead_code)]
 fn is_valid_transcript_nonce(nonce: &str) -> bool {
     !nonce.is_empty()
         && nonce
@@ -519,6 +531,9 @@ fn is_valid_voice_background_handoff_correlation_id(correlation_id: &str) -> boo
     raw.len() == 32 && raw.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
+// reason: voice runtime is wired only when voice config is enabled; no compile
+// target exercises it. See #3034.
+#[allow(dead_code)]
 fn extract_transcript_between<'a>(text: &'a str, open: &str, close: &str) -> Option<&'a str> {
     Some(text.split_once(open)?.1.split_once(close)?.0)
 }

--- a/src/voice/receiver.rs
+++ b/src/voice/receiver.rs
@@ -122,6 +122,7 @@ pub(crate) struct VoiceReceiver {
 }
 
 impl VoiceReceiver {
+    #[allow(dead_code)] // voice runtime wired only when voice config enabled; no target exercises it. See #3034
     pub(crate) fn new(config: VoiceReceiverConfig) -> Self {
         Self::new_with_hook(config, None)
     }
@@ -140,6 +141,7 @@ impl VoiceReceiver {
         }
     }
 
+    #[allow(dead_code)] // voice runtime wired only when voice config enabled; no target exercises it. See #3034
     pub(crate) fn from_voice_config(config: &VoiceConfig) -> Self {
         Self::new(VoiceReceiverConfig::from_voice_config(config))
     }
@@ -192,6 +194,7 @@ impl VoiceReceiver {
             .await
     }
 
+    #[allow(dead_code)] // voice runtime wired only when voice config enabled; no target exercises it. See #3034
     pub(crate) async fn flush_all(&self) -> Vec<CompletedUtterance> {
         self.inner.flush_all().await
     }
@@ -208,6 +211,7 @@ impl VoiceReceiver {
             .await
     }
 
+    #[allow(dead_code)] // voice runtime wired only when voice config enabled; no target exercises it. See #3034
     pub(crate) async fn take_pending(&self) -> Vec<CompletedUtterance> {
         self.inner.take_pending().await
     }
@@ -598,6 +602,7 @@ impl ReceiverState {
         Ok(Some(completed))
     }
 
+    #[allow(dead_code)] // voice runtime wired only when voice config enabled; no target exercises it. See #3034
     async fn flush_all(self: &Arc<Self>) -> Vec<CompletedUtterance> {
         let pending_after_wait = self.wait_for_pending_io_to_clear(|_, _| true).await;
         if pending_after_wait > 0 {
@@ -718,6 +723,7 @@ impl ReceiverState {
         completed
     }
 
+    #[allow(dead_code)] // voice runtime wired only when voice config enabled; no target exercises it. See #3034
     async fn take_pending(&self) -> Vec<CompletedUtterance> {
         std::mem::take(&mut *self.pending.lock().await)
     }

--- a/src/voice/runtime_boundary.rs
+++ b/src/voice/runtime_boundary.rs
@@ -1,6 +1,11 @@
 //! Serializable command/event contracts for moving voice runtime work across a
 //! process boundary.
 
+// reason: out-of-process voice runtime boundary; the whole protocol surface is
+// wired only once the voice runtime process is enabled, which no compile target
+// exercises today. See #3034.
+#![allow(dead_code)]
+
 use serde::{Deserialize, Serialize};
 
 use crate::voice::barge_in::BargeInSensitivity;

--- a/src/voice/runtime_process.rs
+++ b/src/voice/runtime_process.rs
@@ -33,6 +33,9 @@ impl Default for VoiceRuntimeProcessConfig {
 }
 
 impl VoiceRuntimeProcessConfig {
+    // reason: out-of-process voice runtime launch is wired only when the voice
+    // runtime process is enabled; no compile target exercises it. See #3034.
+    #[allow(dead_code)]
     pub(crate) fn launch_spec(&self) -> Option<VoiceRuntimeLaunchSpec> {
         if !self.enabled {
             return None;
@@ -48,6 +51,9 @@ impl VoiceRuntimeProcessConfig {
     }
 }
 
+// reason: out-of-process voice runtime surface; wired only when the voice
+// runtime process is enabled, which no compile target exercises. See #3034.
+#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct VoiceRuntimeLaunchSpec {
     pub executable: PathBuf,
@@ -56,11 +62,17 @@ pub(crate) struct VoiceRuntimeLaunchSpec {
     pub protocol_version: u16,
 }
 
+// reason: out-of-process voice runtime surface; wired only when the voice
+// runtime process is enabled, which no compile target exercises. See #3034.
+#[allow(dead_code)]
 #[async_trait]
 pub(crate) trait VoiceRuntimeProcessSupervisor: Send + Sync {
     async fn start(&self, spec: VoiceRuntimeLaunchSpec) -> Result<Box<dyn VoiceRuntimeProcess>>;
 }
 
+// reason: out-of-process voice runtime surface; wired only when the voice
+// runtime process is enabled, which no compile target exercises. See #3034.
+#[allow(dead_code)]
 #[async_trait]
 pub(crate) trait VoiceRuntimeProcess: Send + Sync {
     fn protocol_version(&self) -> u16;
@@ -68,6 +80,9 @@ pub(crate) trait VoiceRuntimeProcess: Send + Sync {
     async fn stop(&self) -> Result<()>;
 }
 
+// reason: out-of-process voice runtime surface; wired only when the voice
+// runtime process is enabled, which no compile target exercises. See #3034.
+#[allow(dead_code)]
 #[derive(Debug, Default)]
 pub(crate) struct DisabledVoiceRuntimeProcessSupervisor;
 
@@ -80,6 +95,9 @@ impl VoiceRuntimeProcessSupervisor for DisabledVoiceRuntimeProcessSupervisor {
     }
 }
 
+// reason: out-of-process voice runtime surface; wired only when the voice
+// runtime process is enabled, which no compile target exercises. See #3034.
+#[allow(dead_code)]
 #[derive(Debug, Default)]
 pub(crate) struct TokioVoiceRuntimeProcessSupervisor;
 
@@ -108,6 +126,9 @@ impl VoiceRuntimeProcessSupervisor for TokioVoiceRuntimeProcessSupervisor {
     }
 }
 
+// reason: out-of-process voice runtime surface; wired only when the voice
+// runtime process is enabled, which no compile target exercises. See #3034.
+#[allow(dead_code)]
 struct TokioVoiceRuntimeProcess {
     protocol_version: u16,
     child: Mutex<Child>,

--- a/src/voice/sanitizer.rs
+++ b/src/voice/sanitizer.rs
@@ -2,6 +2,9 @@
 
 pub(crate) const DEFAULT_SPOKEN_RESULT_CHAR_LIMIT: usize = 900;
 
+// reason: voice runtime is wired only when voice config is enabled; no compile
+// target exercises it. See #3034.
+#[allow(dead_code)]
 pub(crate) fn spoken_result_only(answer: &str, language: &str) -> String {
     spoken_result_only_with_limit(answer, language, DEFAULT_SPOKEN_RESULT_CHAR_LIMIT)
 }

--- a/src/voice/stt.rs
+++ b/src/voice/stt.rs
@@ -135,10 +135,16 @@ pub(crate) struct SttRuntime {
 }
 
 impl SttRuntime {
+    // reason: voice runtime is wired only when voice config is enabled; no
+    // compile target exercises it. See #3034.
+    #[allow(dead_code)]
     pub(crate) fn from_voice_config(config: &VoiceConfig) -> Self {
         Self::new(SttConfig::from_voice_config(config))
     }
 
+    // reason: voice runtime is wired only when voice config is enabled; no
+    // compile target exercises it. See #3034.
+    #[allow(dead_code)]
     pub(crate) fn new(config: SttConfig) -> Self {
         let runner = subprocess_runner(config.timeout);
         Self { config, runner }
@@ -595,11 +601,17 @@ impl VoiceStt for WhisperStream {
     }
 }
 
+// reason: voice runtime is wired only when voice config is enabled; no compile
+// target exercises it. See #3034.
+#[allow(dead_code)]
 pub(crate) async fn transcribe(wav_path: impl AsRef<Path>) -> Result<String> {
     let config = VoiceConfig::default();
     transcribe_with_config(wav_path, &config).await
 }
 
+// reason: voice runtime is wired only when voice config is enabled; no compile
+// target exercises it. See #3034.
+#[allow(dead_code)]
 pub(crate) async fn transcribe_with_config(
     wav_path: impl AsRef<Path>,
     config: &VoiceConfig,

--- a/src/voice/stt_streaming.rs
+++ b/src/voice/stt_streaming.rs
@@ -106,6 +106,9 @@ impl WhisperStreamOverlapSegmenter {
         })
     }
 
+    // reason: voice runtime is wired only when voice config is enabled; no
+    // compile target exercises it. See #3034.
+    #[allow(dead_code)]
     pub(crate) fn config(&self) -> StreamingOverlapConfig {
         self.config
     }

--- a/src/voice/tts/chunks.rs
+++ b/src/voice/tts/chunks.rs
@@ -13,6 +13,9 @@ pub(crate) fn split_for_tts(text: &str, max_chars: usize) -> Vec<String> {
     pack_sentence_segments(sentence_segments(text), max_chars)
 }
 
+// reason: incremental TTS chunking is wired only when voice config is enabled;
+// no compile target exercises it. See #3034.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub(crate) struct IncrementalTtsChunkQueue {
     max_chars: usize,
@@ -20,6 +23,9 @@ pub(crate) struct IncrementalTtsChunkQueue {
     ready_chunks: VecDeque<String>,
 }
 
+// reason: incremental TTS chunking is wired only when voice config is enabled;
+// no compile target exercises it. See #3034.
+#[allow(dead_code)]
 impl IncrementalTtsChunkQueue {
     pub(crate) fn new(max_chars: usize) -> Self {
         let max_chars = if max_chars == 0 {
@@ -243,6 +249,9 @@ fn is_closing_punctuation(ch: char) -> bool {
     )
 }
 
+// reason: incremental TTS chunking is wired only when voice config is enabled;
+// no compile target exercises it. See #3034.
+#[allow(dead_code)]
 fn ends_with_sentence_boundary(text: &str) -> bool {
     for ch in text.chars().rev() {
         if ch == '\n' || ch == '\r' {

--- a/src/voice/tts/edge.rs
+++ b/src/voice/tts/edge.rs
@@ -62,6 +62,9 @@ impl EdgeTtsBackend {
         Self { config, runner }
     }
 
+    // reason: voice runtime is wired only when voice config is enabled; no
+    // compile target exercises it. See #3034.
+    #[allow(dead_code)]
     pub(crate) fn with_runner(config: EdgeTtsConfig, runner: EdgeTtsCommandRunner) -> Self {
         Self { config, runner }
     }

--- a/src/voice/tts/mod.rs
+++ b/src/voice/tts/mod.rs
@@ -130,11 +130,17 @@ impl TtsRuntime {
 
     /// Re-read voice config after a voice-change command mutates backend
     /// settings, rebinding the backend and progress cache target together.
+    // reason: voice runtime is wired only when voice config is enabled; no
+    // compile target exercises it. See #3034.
+    #[allow(dead_code)]
     pub(crate) fn rebind_from_voice_config(&mut self, config: &VoiceConfig) -> Result<()> {
         *self = Self::from_voice_config(config)?;
         Ok(())
     }
 
+    // reason: voice runtime is wired only when voice config is enabled; no
+    // compile target exercises it. See #3034.
+    #[allow(dead_code)]
     pub(crate) fn cache_key_parts(&self) -> Vec<String> {
         self.backend.cache_key_parts()
     }

--- a/src/voice/tts/playback.rs
+++ b/src/voice/tts/playback.rs
@@ -25,6 +25,9 @@ use tracing::warn;
 
 pub(crate) const DEFAULT_TTS_CHUNK_MAX_CHARS: usize = 220;
 
+// reason: streaming TTS playback is wired only when voice config is enabled; no
+// compile target exercises it. See #3034.
+#[allow(dead_code)]
 pub(crate) const DEFAULT_STREAMING_TTS_QUEUE_CAPACITY: usize = 8;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -42,12 +45,18 @@ struct SynthesizedChunk {
     synthesis_elapsed: Duration,
 }
 
+// reason: streaming TTS playback is wired only when voice config is enabled; no
+// compile target exercises it. See #3034.
+#[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct StreamingTtsChunkSender {
     queue: IncrementalTtsChunkQueue,
     tx: mpsc::Sender<String>,
 }
 
+// reason: streaming TTS playback is wired only when voice config is enabled; no
+// compile target exercises it. See #3034.
+#[allow(dead_code)]
 impl StreamingTtsChunkSender {
     pub(crate) async fn push_text(&mut self, text: &str) -> Result<()> {
         self.queue.push_text(text);
@@ -70,12 +79,18 @@ impl StreamingTtsChunkSender {
     }
 }
 
+// reason: streaming TTS playback is wired only when voice config is enabled; no
+// compile target exercises it. See #3034.
+#[allow(dead_code)]
 pub(crate) fn streaming_tts_chunk_channel(
     max_chars: usize,
 ) -> (StreamingTtsChunkSender, mpsc::Receiver<String>) {
     streaming_tts_chunk_channel_with_capacity(max_chars, DEFAULT_STREAMING_TTS_QUEUE_CAPACITY)
 }
 
+// reason: streaming TTS playback is wired only when voice config is enabled; no
+// compile target exercises it. See #3034.
+#[allow(dead_code)]
 pub(crate) fn streaming_tts_chunk_channel_with_capacity(
     max_chars: usize,
     capacity: usize,
@@ -123,6 +138,9 @@ where
     .await
 }
 
+// reason: streaming TTS playback is wired only when voice config is enabled; no
+// compile target exercises it. See #3034.
+#[allow(dead_code)]
 pub(crate) async fn play_streaming_chunks_with_prefetch<F>(
     call_lock: Arc<Mutex<songbird::Call>>,
     tts: TtsRuntime,

--- a/src/voice/turn_link.rs
+++ b/src/voice/turn_link.rs
@@ -43,6 +43,7 @@ pub enum VoiceTurnLinkStatus {
 }
 
 impl VoiceTurnLinkStatus {
+    #[allow(dead_code)] // voice turn-link helper; wired only when voice config enabled. See #3034
     pub fn as_str(self) -> &'static str {
         match self {
             VoiceTurnLinkStatus::Active => "active",
@@ -184,6 +185,7 @@ const RETURNING_COLUMNS: &str = "id, guild_id, voice_channel_id, background_chan
 /// [`retarget_voice_turn_link_pg`].
 ///
 /// Returns the inserted row on success, or `None` on idempotent dedup.
+#[allow(dead_code)] // voice turn-link helper; wired only when voice config enabled. See #3034
 pub async fn insert_voice_turn_link_pg(
     pool: &PgPool,
     insert: &VoiceTurnLinkInsert,
@@ -603,6 +605,7 @@ pub async fn attach_voice_turn_link_ids_pg(
     }
 }
 
+#[allow(dead_code)] // voice turn-link helper; wired only when voice config enabled. See #3034
 pub async fn attach_announce_message_id_voice_turn_link_pg(
     pool: &PgPool,
     guild_id: u64,
@@ -630,6 +633,7 @@ pub async fn attach_announce_message_id_voice_turn_link_pg(
     }
 }
 
+#[allow(dead_code)] // voice turn-link helper; wired only when voice config enabled. See #3034
 pub async fn attach_dispatch_id_voice_turn_link_pg(
     pool: &PgPool,
     guild_id: u64,
@@ -657,6 +661,7 @@ pub async fn attach_dispatch_id_voice_turn_link_pg(
     }
 }
 
+#[allow(dead_code)] // voice turn-link helper; wired only when voice config enabled. See #3034
 pub async fn attach_turn_id_voice_turn_link_pg(
     pool: &PgPool,
     guild_id: u64,
@@ -725,6 +730,7 @@ fn advisory_lock_key(guild_id: u64, voice_channel_id: u64, utterance_id: &str) -
 /// because dispatch_id is a globally unique opaque token, but the
 /// `ORDER BY updated_at DESC` is defensive against any future scheme where
 /// a single dispatch is reused.
+#[allow(dead_code)] // voice turn-link helper; wired only when voice config enabled. See #3034
 pub async fn lookup_voice_turn_link_by_dispatch_id_pg(
     pool: &PgPool,
     dispatch_id: &str,
@@ -765,6 +771,7 @@ pub async fn lookup_active_voice_turn_link_by_dispatch_id_pg(
 /// Reverse lookup by `announce_message_id`. Same shape as the
 /// dispatch_id lookup; primarily used by barge-in cancel resolution when
 /// only the announce message anchor is available.
+#[allow(dead_code)] // voice turn-link helper; wired only when voice config enabled. See #3034
 pub async fn lookup_voice_turn_link_by_announce_message_id_pg(
     pool: &PgPool,
     announce_message_id: u64,
@@ -802,6 +809,7 @@ pub async fn lookup_active_voice_turn_link_by_announce_message_id_pg(
     Ok(row.as_ref().map(row_to_link))
 }
 
+#[allow(dead_code)] // voice turn-link helper; wired only when voice config enabled. See #3034
 pub async fn lookup_voice_turn_link_by_turn_id_pg(
     pool: &PgPool,
     turn_id: &str,
@@ -862,6 +870,7 @@ pub async fn lookup_active_voice_turn_link_by_utterance_pg(
 /// If multiple utterances are active in that voice channel, the most recently
 /// updated link wins; callers with an utterance id should use
 /// [`lookup_active_voice_turn_link_by_utterance_pg`] for an exact match.
+#[allow(dead_code)] // voice turn-link helper; wired only when voice config enabled. See #3034
 pub async fn resolve_active_voice_turn_target_pg(
     pool: &PgPool,
     guild_id: u64,
@@ -885,6 +894,7 @@ pub async fn resolve_active_voice_turn_target_pg(
 }
 
 /// Resolve the active source voice channel for a background text channel.
+#[allow(dead_code)] // voice turn-link helper; wired only when voice config enabled. See #3034
 pub async fn resolve_active_voice_turn_source_pg(
     pool: &PgPool,
     guild_id: u64,


### PR DESCRIPTION
Part of #3034 (Part 3/N).

Removes the module-level `#[allow(dead_code)]` blanket from **two** modules in `src/lib.rs` — `mod db` and `pub(crate) mod voice` — then clears every surfaced dead_code warning. `server`, `services`, and the crate-wide `#![allow(clippy::await_holding_lock)]` are intentionally left untouched (server is a later part; services + await_holding_lock are on the #3016 relay serial track).

## Per-module changes

### db (deleted 1 / scoped N)
- **Deleted**: `session_exists_pg` (db/dispatched_sessions.rs) — provably superseded; the doc on `upsert_hook_session_pg` (#2045 Finding 7) records that the separate-SELECT path it served was replaced by the race-free `xmax = 0` upsert. Zero callers in any cfg.
- **Scoped item-level allow** (reasoned, links #3034): legacy-sqlite parity shims in `db/mod.rs` (constructed only under `legacy-sqlite-tests`, also #3035); `LEGACY_AGENT_PREFIX` (legacy-gated twin of the production copy in postgres.rs); automation-candidate iteration repository helpers in `automation_candidates.rs` (8 still-unwired siblings of an active pg API, #2064); idempotency-outcome enum fields + `release_unclaimed`; intake-outbox `claim_owner`/`retry_count` columns + retry/sweep/SLA helpers exercised only by pg-integration tests; `applied_migration_checksum_mismatches`, `SessionTranscriptRecord` + `parse_events_json`, `CancelTombstone`, `validate_turn_stat` (legacy-gated caller, #3035), `content_layer` (test-only builder), `is_dispatchable_entry_status`.
- **Left untouched**: the lone `legacy-sqlite-tests`-gated unused import in `db/dispatches/outbox/mod.rs` — it is `unused_import` (not `dead_code`, so unaffected by the blanket removal) and lives in #3035's gated surface; it only surfaces under `--features legacy-sqlite-tests`.

### voice (deleted 0 / scoped N)
- **Scoped item-level allow** (reasoned, links #3034) across announce_meta, barge_in, commands, config, metrics, progress, prompt, receiver, runtime_process, sanitizer, stt, stt_streaming, tts/{mod,chunks,edge,playback}, turn_link. The voice runtime is an optional provider feature wired only when voice config is enabled, so no compile target exercises these paths (delete-risk too high; leaned to reasoned scoped-allow per epic guidance).
- One **file-level inner** `#![allow(dead_code)]` on `runtime_boundary.rs` — the entire out-of-process voice-runtime protocol module is unwired.
- schema.rs / legacy-sqlite-tests db code left to #3035 (not touched here).

## Giant-file registry / change-surfaces (#3036)
Restoring per-item reasoning (vs. the single blanket line) pushed two still-unwired-sibling files over the 1000-prod-LoC giant threshold: `src/db/automation_candidates.rs` (1003) and `src/voice/announce_meta.rs` (1001). Both registered as `[[entry]]` in `scripts/giant_file_registry.toml` and listed in `change-surfaces.md` (owner + deadline + decompose_issue #3036). LoC drift synced for the other touched giants (receiver.rs, postgres.rs, dispatched_sessions.rs, auto_queue/entries.rs). Annotations use the compact single-line form to minimize footprint; `turn_link.rs` stays under threshold.

## Verification
- `cargo check --workspace --all-features --all-targets` → clean (zero new db/voice dead_code; only the pre-existing legacy-gated unused import remains)
- `cargo check --features legacy-sqlite-tests --all-targets` → compiles (#3035 surface intact)
- `cargo fmt --all --check` → clean
- `cargo test --lib db::` → 160 passed / 0 failed; `cargo test --lib voice::` → 184 passed / 0 failed
- `./scripts/ci-script-checks.sh` → exit 0

Part of #3034 (Part 3/N; remaining: server module + services/await_holding_lock on the #3016 track).

🤖 Generated with [Claude Code](https://claude.com/claude-code)