### PR TITLE
fix(discord): add /branch to BUILTIN_SKILLS (CC /fork→/branch rename) (#3081)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -151,7 +151,7 @@
     split before adding non-bugfix behavior).
   - `src/services/discord/turn_bridge/completion_guard.rs` (1909 lines).
   - `src/services/discord/turn_bridge/tmux_runtime.rs` (1243 lines).
-  - `src/services/discord/formatting.rs` (2713 lines).
+  - `src/services/discord/formatting.rs` (2720 lines).
   - `src/services/discord/settings.rs` (2479 lines).
   - `src/services/discord/prompt_builder/` (directory, refactored).
   - `src/services/discord/runtime_bootstrap.rs` (2564 lines after #2558

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -171,6 +171,10 @@ pub(super) fn risk_badge(destructive: bool) -> &'static str {
 
 /// Claude Code built-in slash commands
 pub(super) const BUILTIN_SKILLS: &[(&str, &str)] = &[
+    (
+        "branch",
+        "Create a branch (fork) of the current conversation",
+    ),
     ("clear", "Clear conversation context and start fresh"),
     ("compact", "Compact conversation to reduce context"),
     ("context", "Visualize current context usage"),
@@ -180,7 +184,10 @@ pub(super) const BUILTIN_SKILLS: &[(&str, &str)] = &[
     ("export", "Export conversation to file"),
     ("fast", "Toggle fast output mode"),
     ("files", "List all files currently in context"),
-    ("fork", "Create a fork of the current conversation"),
+    (
+        "fork",
+        "Alias for /branch: create a branch of the current conversation",
+    ),
     ("init", "Initialize project with CLAUDE.md guide"),
     ("memory", "Edit CLAUDE.md memory files"),
     ("model", "Switch AI model"),


### PR DESCRIPTION
## What
- Add `("branch", "Create a branch (fork) of the current conversation")` to `BUILTIN_SKILLS` in `src/services/discord/formatting.rs`, in alphabetical position.
- Update the existing `("fork", ...)` description to note it is now an alias for `/branch` (kept, since CC still accepts `/fork`).
- Sync the `formatting.rs` production LoC (2713 → 2720) in `docs/agent-maintenance/change-surfaces.md` to satisfy the maintenance freshness gate.

## Why
Claude Code renamed `/fork` → `/branch` (with `/fork` retained as an alias). `BUILTIN_SKILLS` only had `fork`, so Discord slash-command autocomplete/help — populated via `scan_skills(ProviderKind::Claude)` in `mod.rs` — was stale vs current CC. No other change needed; `scan_skills` iterates `BUILTIN_SKILLS` automatically.

The `tui_prompt_relay.rs` fork-pointer mtime edge case noted in the issue's 비고 is out of scope (deferred until reproducible).

## Verify
- `cargo check --lib`: clean
- `cargo fmt --all --check`: clean
- `cargo test --lib formatting`: 26 passed
- `./scripts/ci-script-checks.sh`: exit 0

Closes #3081

🤖 Generated with [Claude Code](https://claude.com/claude-code)