### PR TITLE
chore(lint): remove dead_code blanket for the server module (#3034)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -215,10 +215,10 @@
 - legacy_modules: none, but several routes still call `legacy_db()` against
   the SQLite compat handle (see `known-legacy.md`).
 - do_not_edit_without_migration_plan (giant-file routes):
-  - `src/server/routes/kanban.rs` (3222 lines).
-  - `src/server/routes/docs.rs` (5877 lines).
-  - `src/server/routes/escalation.rs` (2344 lines).
-  - `src/server/routes/meetings.rs` (1705 lines).
+  - `src/server/routes/kanban.rs` (2887 lines).
+  - `src/server/routes/docs.rs` (5880 lines).
+  - `src/server/routes/escalation.rs` (2310 lines).
+  - `src/server/routes/meetings.rs` (1709 lines).
   - `src/server/routes/review_verdict/decision_route.rs` (4804 lines).
   - `src/server/routes/{agents,agents_crud,agents_setup,v1,resume,
     dispatches/thread_reuse}.rs` (all 1000+ production lines).

--- a/src/db/kanban_cards/crud.rs
+++ b/src/db/kanban_cards/crud.rs
@@ -331,22 +331,6 @@ pub async fn card_id_by_issue_number_pg(
         .map_err(|error| format!("postgres lookup failed: {error}"))
 }
 
-pub async fn card_ids_by_issue_number_pg(
-    pool: &PgPool,
-    issue_number: i64,
-) -> Result<Vec<String>, String> {
-    sqlx::query_scalar::<_, String>(
-        "SELECT id
-         FROM kanban_cards
-         WHERE github_issue_number = $1
-         ORDER BY id ASC",
-    )
-    .bind(issue_number)
-    .fetch_all(pool)
-    .await
-    .map_err(|error| format!("{error}"))
-}
-
 pub async fn load_card_pipeline_context_pg(
     pool: &PgPool,
     card_id: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,9 +115,6 @@ pub(crate) mod reconcile;
 pub(crate) mod runtime;
 // Runtime layout exposes migration helpers used by setup and repair commands.
 pub(crate) mod runtime_layout;
-// Server route modules include API endpoints whose handlers are selected by
-// router composition and integration tests.
-#[allow(dead_code)]
 mod server;
 // Service modules contain provider, Discord, maintenance, and observability
 // feature surfaces that are enabled by runtime config rather than all targets.

--- a/src/server/cluster.rs
+++ b/src/server/cluster.rs
@@ -113,6 +113,11 @@ impl ClusterRuntime {
         }
     }
 
+    // reason: cluster-runtime leadership-wait API exercised directly by the
+    // `#[cfg(test)]` leadership-transition test; the production supervisor path
+    // now blocks via `wait_until_leader_or_shutdown`, so the lib build sees no
+    // caller. See #3034.
+    #[allow(dead_code)]
     pub(crate) async fn wait_until_leader(&self) {
         if !self.enabled {
             return;
@@ -716,17 +721,6 @@ pub(crate) async fn list_worker_nodes(
             })
         })
         .collect())
-}
-
-pub(crate) async fn worker_node_snapshot_by_instance(
-    pool: &PgPool,
-    instance_id: &str,
-    lease_ttl_secs: u64,
-) -> Result<Option<Value>, String> {
-    Ok(list_worker_nodes(pool, lease_ttl_secs)
-        .await?
-        .into_iter()
-        .find(|node| node.get("instance_id").and_then(|value| value.as_str()) == Some(instance_id)))
 }
 
 pub(crate) fn explain_capability_match(

--- a/src/server/cron_catalog.rs
+++ b/src/server/cron_catalog.rs
@@ -41,19 +41,6 @@ pub fn tier_descriptors() -> Vec<CronJobDescriptor> {
         .collect()
 }
 
-pub fn tier_descriptor_by_label(label: &str) -> Option<CronJobDescriptor> {
-    TIER_DEFINITIONS
-        .iter()
-        .find_map(|(job_id, name, every_ms, kv_label)| {
-            (*kv_label == label).then(|| CronJobDescriptor {
-                job_id: (*job_id).to_string(),
-                name: (*name).to_string(),
-                every_ms: *every_ms,
-                kv_label: (*kv_label).to_string(),
-            })
-        })
-}
-
 pub fn legacy_policy_descriptors(engine: &PolicyEngine) -> Vec<CronJobDescriptor> {
     engine
         .list_policies()
@@ -77,16 +64,4 @@ pub fn github_issue_sync_descriptor(interval_minutes: u64) -> Option<CronJobDesc
         every_ms: (interval_minutes as i64) * 60_000,
         kv_label: "github_sync".to_string(),
     })
-}
-
-/// #1072 Turn-lifecycle SLO aggregation (Epic #905 Phase 1).
-/// Piggybacks on the 5-minute tier — exposed separately so the cron-jobs API
-/// can surface the aggregator as a distinct job for observability.
-pub fn slo_aggregation_descriptor() -> CronJobDescriptor {
-    CronJobDescriptor {
-        job_id: "slo_aggregation".to_string(),
-        name: "SLO aggregation — 3 turn-lifecycle metrics (success rate, duplicate relays, avg latency) + threshold alerter".to_string(),
-        every_ms: 300_000,
-        kv_label: "5min".to_string(),
-    }
 }

--- a/src/server/dto/kanban.rs
+++ b/src/server/dto/kanban.rs
@@ -66,14 +66,6 @@ pub struct DeferDodBody {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct BulkActionBody {
-    pub action: String,
-    pub card_ids: Vec<String>,
-    /// Target status for "transition" action (e.g. "ready", "backlog").
-    pub target_status: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
 pub struct AssignIssueBody {
     pub github_repo: String,
     pub github_issue_number: i64,
@@ -108,14 +100,6 @@ pub struct ReopenBody {
     pub dispatch_type: Option<String>,
     pub reason: Option<String>,
     pub reset_full: Option<bool>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct BatchTransitionBody {
-    pub issue_numbers: Option<Vec<i64>>,
-    pub card_ids: Option<Vec<String>>,
-    pub status: String,
-    pub cancel_dispatches: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/server/resource_locks.rs
+++ b/src/server/resource_locks.rs
@@ -39,6 +39,10 @@ pub fn default_resource_lock_ttl_secs() -> i64 {
     DEFAULT_RESOURCE_LOCK_TTL_SECS
 }
 
+// reason: Unreal project lock-key builder referenced only by the
+// `#[cfg(test)]` multinode regression suite and unit tests; no production
+// caller in the lib build. See #3034.
+#[allow(dead_code)]
 pub fn unreal_project_lock_key(repo: &str) -> String {
     format!("unreal:project:{}", repo.trim())
 }

--- a/src/server/routes/dispatches/thread_reuse.rs
+++ b/src/server/routes/dispatches/thread_reuse.rs
@@ -14,22 +14,6 @@ use super::parse_channel_id;
 
 // ── Channel-thread map helpers ────────────────────────────────
 
-fn parse_channel_thread_map(
-    raw: Option<&str>,
-) -> Option<serde_json::Map<String, serde_json::Value>> {
-    raw.and_then(|value| {
-        serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(value).ok()
-    })
-}
-
-fn lookup_thread_for_channel_from_map(map_json: Option<&str>, channel_id: u64) -> Option<String> {
-    parse_channel_thread_map(map_json).and_then(|map| {
-        map.get(&channel_id.to_string())
-            .and_then(|value| value.as_str())
-            .map(|value| value.to_string())
-    })
-}
-
 fn json_value_kind(value: &serde_json::Value) -> &'static str {
     match value {
         serde_json::Value::Null => "null",
@@ -89,16 +73,6 @@ fn lookup_thread_for_channel_from_map_pg(
         }
         None => None,
     }
-}
-
-/// Look up the thread_id for a specific channel from channel_thread_map.
-/// Falls back to active_thread_id for backward compatibility.
-pub(super) fn get_thread_for_channel<T>(
-    _conn: &T,
-    _card_id: &str,
-    _channel_id: u64,
-) -> Option<String> {
-    None
 }
 
 pub(crate) async fn get_thread_for_channel_pg(
@@ -173,16 +147,6 @@ pub(crate) async fn get_mapped_thread_for_channel_pg(
     ))
 }
 
-/// Set the thread_id for a specific channel in channel_thread_map.
-/// Also updates active_thread_id for backward compatibility.
-pub(super) fn set_thread_for_channel<T>(
-    _conn: &T,
-    _card_id: &str,
-    _channel_id: u64,
-    _thread_id: &str,
-) {
-}
-
 pub(crate) async fn set_thread_for_channel_pg(
     pool: &PgPool,
     card_id: &str,
@@ -225,9 +189,6 @@ async fn set_thread_for_channel_pg_with_active(
     .map_err(|error| format!("save postgres thread map for {card_id}: {error}"))?;
     Ok(())
 }
-
-/// Clear thread mapping for a specific channel.
-pub(super) fn clear_thread_for_channel<T>(_conn: &T, _card_id: &str, _channel_id: u64) {}
 
 pub(crate) async fn clear_thread_for_channel_pg(
     pool: &PgPool,
@@ -295,16 +256,6 @@ pub(crate) async fn clear_thread_for_channel_pg(
     .map_err(|error| format!("clear postgres thread map for {card_id}: {error}"))?;
     Ok(())
 }
-
-pub(crate) async fn should_defer_thread_archive_pg(
-    pg_pool: Option<&PgPool>,
-    thread_id: &str,
-) -> Result<bool, String> {
-    crate::services::discord::should_defer_thread_archive_pg(pg_pool, thread_id).await
-}
-
-/// Clear ALL thread mappings (card done).
-pub(in crate::server::routes) fn clear_all_threads<T>(_conn: &T, _card_id: &str) {}
 
 #[derive(Debug)]
 struct ThreadMapValidationRow {

--- a/src/server/routes/docs.rs
+++ b/src/server/routes/docs.rs
@@ -246,6 +246,9 @@ fn body_param(kind: &'static str, required: bool, description: &'static str) -> 
 // Endpoints not in this list may rely on `// TODO: example` markers in their
 // description text while paired coverage expands in follow-up issues.
 // ---------------------------------------------------------------------------
+// reason: fixture table asserted by the `#[cfg(test)]` api_docs paired-coverage
+// test; it has no production reader, so the lib build flags it as dead. See #3034.
+#[allow(dead_code)]
 pub(crate) const TOP_40_PAIRED_PATHS: &[(&str, &str)] = &[
     ("GET", "/api/health"),
     ("POST", "/api/discord/send"),

--- a/src/server/routes/escalation.rs
+++ b/src/server/routes/escalation.rs
@@ -466,33 +466,6 @@ async fn load_cached_thread_id_pg_async(
     .map_err(|error| format!("load postgres cached escalation thread {key}: {error}"))
 }
 
-fn save_cached_thread_id_pg(
-    pool: &sqlx::PgPool,
-    card_id: &str,
-    thread_id: &str,
-) -> Result<(), String> {
-    let key = escalation_thread_key(card_id);
-    let thread_id = thread_id.to_string();
-    crate::utils::async_bridge::block_on_pg_result(
-        pool,
-        move |bridge_pool| async move {
-            sqlx::query(
-                "INSERT INTO kv_meta (key, value)
-                 VALUES ($1, $2)
-                 ON CONFLICT (key) DO UPDATE
-                 SET value = EXCLUDED.value",
-            )
-            .bind(&key)
-            .bind(&thread_id)
-            .execute(&bridge_pool)
-            .await
-            .map_err(|error| format!("save postgres cached escalation thread {key}: {error}"))?;
-            Ok(())
-        },
-        |error| error,
-    )
-}
-
 fn clear_cached_thread_id_pg(pool: &sqlx::PgPool, card_id: &str) -> Result<(), String> {
     let key = escalation_thread_key(card_id);
     crate::utils::async_bridge::block_on_pg_result(
@@ -1836,13 +1809,6 @@ mod tests {
 
     fn test_db() -> crate::db::Db {
         crate::db::test_db()
-    }
-
-    fn test_engine(db: &crate::db::Db) -> crate::engine::PolicyEngine {
-        let mut config = crate::config::Config::default();
-        config.policies.dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("policies");
-        config.policies.hot_reload = false;
-        crate::engine::PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
     }
 
     fn test_engine_with_pg(pg_pool: sqlx::PgPool) -> crate::engine::PolicyEngine {

--- a/src/server/routes/kanban.rs
+++ b/src/server/routes/kanban.rs
@@ -10,9 +10,9 @@ use super::AppState;
 use crate::db::kanban_cards as kanban_db;
 use crate::db::kanban_cards::{IssueCardUpsert, upsert_card_from_issue_pg};
 pub use crate::server::dto::kanban::{
-    AssignCardBody, AssignIssueBody, BatchRereviewBody, BatchTransitionBody, BulkActionBody,
-    CreateCardBody, DeferDodBody, ForceTransitionBody, ListCardsQuery, PmDecisionBody,
-    RedispatchCardBody, ReopenBody, RereviewBody, RetryCardBody, UpdateCardBody,
+    AssignCardBody, AssignIssueBody, BatchRereviewBody, CreateCardBody, DeferDodBody,
+    ForceTransitionBody, ListCardsQuery, PmDecisionBody, RedispatchCardBody, ReopenBody,
+    RereviewBody, RetryCardBody, UpdateCardBody,
 };
 use crate::services::provider::ProviderKind;
 use crate::services::turn_lifecycle::{TurnLifecycleTarget, force_kill_turn};
@@ -1119,79 +1119,6 @@ pub async fn stalled_cards(State(state): State<AppState>) -> (StatusCode, Json<s
     (StatusCode::OK, Json(json!(cards)))
 }
 
-/// POST /api/kanban-cards/bulk-action
-pub async fn bulk_action(
-    State(state): State<AppState>,
-    Json(body): Json<BulkActionBody>,
-) -> (StatusCode, Json<serde_json::Value>) {
-    // Pipeline-driven target status for bulk actions
-    crate::pipeline::ensure_loaded();
-    let pipeline = crate::pipeline::get();
-    let terminal_state = pipeline
-        .states
-        .iter()
-        .find(|s| s.terminal)
-        .map(|s| s.id.as_str())
-        .expect("Pipeline must have at least one terminal state");
-    let initial_state = pipeline.initial_state();
-    let target_status = match body.action.as_str() {
-        "pass" => terminal_state.to_string(),
-        "reset" => initial_state.to_string(),
-        "cancel" => terminal_state.to_string(),
-        "transition" => match body.target_status {
-            Some(ref s) => s.clone(),
-            None => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(json!({"error": "transition action requires target_status field"})),
-                );
-            }
-        },
-        other => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(json!({"error": format!("unknown action: {other}")})),
-            );
-        }
-    };
-
-    let mut results: Vec<serde_json::Value> = Vec::new();
-    for card_id in &body.card_ids {
-        let Some(pool) = state.pg_pool_ref() else {
-            return pg_pool_required_error();
-        };
-        let transition_result = if target_status == "backlog" {
-            transition_card_to_backlog_with_cleanup(&state, card_id, "bulk-action:backlog").await
-        } else {
-            crate::kanban::transition_status_with_opts_pg_only(
-                pool,
-                &state.engine,
-                card_id,
-                &target_status,
-                "bulk-action",
-                crate::engine::transition::ForceIntent::OperatorOverride,
-            )
-            .await
-        };
-
-        match transition_result {
-            Ok(_) => {
-                // Emit updated card for each successful transition
-                if let Ok(Some(card)) = load_card_json_pg(pool, card_id).await {
-                    crate::server::ws::emit_event(&state.broadcast_tx, "kanban_card_updated", card);
-                }
-                results.push(json!({"id": card_id, "ok": true}));
-            }
-            Err(e) => results.push(json!({"id": card_id, "ok": false, "error": format!("{e}")})),
-        }
-    }
-
-    (
-        StatusCode::OK,
-        Json(json!({"action": body.action, "results": results})),
-    )
-}
-
 /// POST /api/kanban-cards/assign-issue
 pub async fn assign_issue(
     State(state): State<AppState>,
@@ -1386,7 +1313,10 @@ async fn assign_transition_to_dispatchable_pg(
     })
 }
 
+// reason: legacy-sqlite parity wrapper keeping `kanban_db::card_row_to_json`
+// reachable from the test backend; PG paths build card JSON directly. See #3034.
 #[cfg(all(test, feature = "legacy-sqlite-tests"))]
+#[allow(dead_code)]
 pub(super) fn card_row_to_json(row: &sqlite_test::Row) -> sqlite_test::Result<serde_json::Value> {
     kanban_db::card_row_to_json(row)
 }
@@ -1851,13 +1781,13 @@ pub async fn pm_decision(
 
 // ── Administrative review recovery helpers ───────────────────────
 
+// reason: legacy-sqlite parity wrapper keeping
+// `kanban_db::find_active_review_dispatch_id_on_conn` reachable from the test
+// backend; PG paths call the `_pg` variant directly. See #3034.
 #[cfg(all(test, feature = "legacy-sqlite-tests"))]
+#[allow(dead_code)]
 fn find_active_review_dispatch_id(conn: &sqlite_test::Connection, card_id: &str) -> Option<String> {
     kanban_db::find_active_review_dispatch_id_on_conn(conn, card_id)
-}
-
-async fn find_active_review_dispatch_id_pg(pool: &sqlx::PgPool, card_id: &str) -> Option<String> {
-    kanban_db::find_active_review_dispatch_id_pg(pool, card_id).await
 }
 
 fn trimmed_header_value<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
@@ -1909,7 +1839,12 @@ pub(crate) fn require_explicit_bearer_token(
     Ok(())
 }
 
+// reason: legacy-sqlite parity wrappers keeping
+// `kanban_db::resolve_agent_id_from_channel_id_on_conn` /
+// `resolve_existing_agent_id_on_conn` reachable from the test backend; PG paths
+// use the `_with_pg` variants below. See #3034.
 #[cfg(all(test, feature = "legacy-sqlite-tests"))]
+#[allow(dead_code)]
 fn resolve_agent_id_from_channel_id_on_conn(
     conn: &sqlite_test::Connection,
     channel_id: &str,
@@ -1925,6 +1860,7 @@ async fn resolve_agent_id_from_channel_id_with_pg(
 }
 
 #[cfg(all(test, feature = "legacy-sqlite-tests"))]
+#[allow(dead_code)]
 pub(super) fn resolve_requesting_agent_id_on_conn(
     conn: &sqlite_test::Connection,
     headers: &HeaderMap,
@@ -2521,215 +2457,6 @@ pub async fn reopen_card(
     pg_pool_required_error()
 }
 
-/// POST /api/kanban-cards/batch-transition
-///
-/// Administrative endpoint. Applies the same force semantics as force-transition to
-/// multiple cards, resolving targets by either explicit card IDs or GitHub
-/// issue numbers. Returns per-card success/failure details.
-pub async fn batch_transition(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-    Json(body): Json<BatchTransitionBody>,
-) -> (StatusCode, Json<serde_json::Value>) {
-    if let Err(response) = require_explicit_bearer_token(&headers, "batch-transition") {
-        return response;
-    }
-
-    let has_issue_numbers = body
-        .issue_numbers
-        .as_ref()
-        .is_some_and(|nums| !nums.is_empty());
-    let has_card_ids = body.card_ids.as_ref().is_some_and(|ids| !ids.is_empty());
-    if !has_issue_numbers && !has_card_ids {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({"error": "batch-transition requires issue_numbers or card_ids"})),
-        );
-    }
-
-    let Some(pg_pool) = state.pg_pool_ref() else {
-        return pg_pool_required_error();
-    };
-    let caller_source = resolve_requesting_agent_id_with_pg(pg_pool, &headers)
-        .await
-        .unwrap_or_else(|| "api".to_string());
-    let batch_transition_source = format!("{caller_source}:batch-transition");
-    let mut targets: Vec<(String, Option<i64>)> = Vec::new();
-    let mut results = Vec::new();
-
-    if let Some(card_ids) = body.card_ids.as_ref() {
-        for card_id in card_ids {
-            targets.push((card_id.clone(), None));
-        }
-    }
-
-    if let Some(issue_numbers) = body.issue_numbers.as_ref() {
-        for issue_number in issue_numbers {
-            let card_ids: Vec<String> =
-                match kanban_db::card_ids_by_issue_number_pg(pg_pool, *issue_number).await {
-                    Ok(ids) => ids,
-                    Err(error) => {
-                        return (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(json!({"error": error})),
-                        );
-                    }
-                };
-            if card_ids.is_empty() {
-                results.push(json!({
-                    "issue_number": issue_number,
-                    "ok": false,
-                    "error": format!("card not found for issue #{issue_number}"),
-                }));
-                continue;
-            }
-            for card_id in card_ids {
-                targets.push((card_id, Some(*issue_number)));
-            }
-        }
-    }
-
-    for (card_id, issue_number) in targets {
-        let pool = pg_pool;
-        let terminal_cleanup = match kanban_db::load_card_pipeline_context_pg(pool, &card_id).await
-        {
-            Ok(Some(card_context)) => {
-                match crate::kanban::resolve_pipeline_with_pg(
-                    pool,
-                    card_context.repo_id.as_deref(),
-                    card_context.assigned_agent_id.as_deref(),
-                )
-                .await
-                {
-                    Ok(effective) => {
-                        effective.is_terminal(&body.status)
-                            && body.cancel_dispatches.unwrap_or(true)
-                    }
-                    Err(error) => {
-                        results.push(json!({
-                            "card_id": card_id,
-                            "issue_number": issue_number,
-                            "ok": false,
-                            "error": format!("{error}"),
-                        }));
-                        continue;
-                    }
-                }
-            }
-            Ok(None) => false,
-            Err(error) => {
-                results.push(json!({
-                    "card_id": card_id,
-                    "issue_number": issue_number,
-                    "ok": false,
-                    "error": error,
-                }));
-                continue;
-            }
-        };
-
-        let transition_result =
-            if force_transition_needs_cleanup(&body.status, body.cancel_dispatches) {
-                crate::kanban::transition_status_with_opts_and_allowed_cleanup_pg_only(
-                    pool,
-                    &state.engine,
-                    &card_id,
-                    &body.status,
-                    &batch_transition_source,
-                    crate::engine::transition::ForceIntent::OperatorOverride,
-                    crate::kanban::AllowedOnConnMutation::ForceTransitionRevertCleanup,
-                )
-                .await
-                .map(|(result, counts)| {
-                    (
-                        result,
-                        (
-                            counts.cancelled_dispatches,
-                            counts.skipped_auto_queue_entries,
-                        ),
-                    )
-                })
-            } else if terminal_cleanup {
-                crate::kanban::transition_status_with_opts_and_allowed_cleanup_pg_only(
-                    pool,
-                    &state.engine,
-                    &card_id,
-                    &body.status,
-                    &batch_transition_source,
-                    crate::engine::transition::ForceIntent::OperatorOverride,
-                    crate::kanban::AllowedOnConnMutation::ForceTransitionTerminalCleanup,
-                )
-                .await
-                .map(|(result, counts)| {
-                    (
-                        result,
-                        (
-                            counts.cancelled_dispatches,
-                            counts.skipped_auto_queue_entries,
-                        ),
-                    )
-                })
-            } else {
-                crate::kanban::transition_status_with_opts_pg_only(
-                    pool,
-                    &state.engine,
-                    &card_id,
-                    &body.status,
-                    &batch_transition_source,
-                    crate::engine::transition::ForceIntent::OperatorOverride,
-                )
-                .await
-                .map(|result| (result, (0, 0)))
-            };
-
-        match transition_result {
-            Ok(result) => {
-                crate::kanban::drain_hook_side_effects_with_backends(None, &state.engine);
-                let card = match load_card_json_pg(pg_pool, &card_id).await {
-                    Ok(Some(card)) => {
-                        crate::server::ws::emit_event(
-                            &state.broadcast_tx,
-                            "kanban_card_updated",
-                            card.clone(),
-                        );
-                        Some(card)
-                    }
-                    Ok(None) => None,
-                    Err(error) => {
-                        results.push(json!({
-                            "card_id": card_id,
-                            "issue_number": issue_number,
-                            "ok": false,
-                            "error": error,
-                        }));
-                        continue;
-                    }
-                };
-                results.push(json!({
-                    "card_id": card_id,
-                    "issue_number": issue_number,
-                    "ok": true,
-                    "from": result.0.from,
-                    "to": result.0.to,
-                    "cancelled_dispatches": result.1.0,
-                    "skipped_auto_queue_entries": result.1.1,
-                    "card": card,
-                }));
-            }
-            Err(e) => {
-                results.push(json!({
-                    "card_id": card_id,
-                    "issue_number": issue_number,
-                    "ok": false,
-                    "error": format!("{e}"),
-                }));
-            }
-        }
-    }
-
-    (StatusCode::OK, Json(json!({ "results": results })))
-}
-
 // ── Administrative force transition ──────────────────────────────
 
 fn force_transition_needs_cleanup(target_status: &str, cancel_dispatches: Option<bool>) -> bool {
@@ -2743,7 +2470,13 @@ fn force_transition_force_intent_present(body: &ForceTransitionBody) -> bool {
     body.force.unwrap_or(false) || body.cancel_dispatches.unwrap_or(false)
 }
 
+// reason: legacy-sqlite parity wrappers retained so the `legacy-sqlite-tests`
+// backend keeps a single call surface mirroring the `_pg` route paths; the PG
+// production paths call `kanban_db::*` directly, so these read as dead in the
+// default lib build. They keep the `db::kanban_cards` `_on_conn` test helpers
+// reachable from one place. See #3034.
 #[cfg(all(test, feature = "legacy-sqlite-tests"))]
+#[allow(dead_code)]
 fn count_live_auto_queue_entries_for_card_on_conn(
     conn: &sqlite_test::Connection,
     card_id: &str,
@@ -2752,6 +2485,7 @@ fn count_live_auto_queue_entries_for_card_on_conn(
 }
 
 #[cfg(all(test, feature = "legacy-sqlite-tests"))]
+#[allow(dead_code)]
 fn clear_force_transition_terminalized_links_on_conn(
     conn: &sqlite_test::Connection,
     card_id: &str,
@@ -2760,6 +2494,7 @@ fn clear_force_transition_terminalized_links_on_conn(
 }
 
 #[cfg(all(test, feature = "legacy-sqlite-tests"))]
+#[allow(dead_code)]
 fn cleanup_force_transition_revert_on_conn(
     conn: &sqlite_test::Connection,
     card_id: &str,
@@ -2769,6 +2504,7 @@ fn cleanup_force_transition_revert_on_conn(
 }
 
 #[cfg(all(test, feature = "legacy-sqlite-tests"))]
+#[allow(dead_code)]
 fn skip_live_auto_queue_entries_for_card_legacy(
     conn: &sqlite_test::Connection,
     card_id: &str,
@@ -2777,6 +2513,7 @@ fn skip_live_auto_queue_entries_for_card_legacy(
 }
 
 #[cfg(all(test, feature = "legacy-sqlite-tests"))]
+#[allow(dead_code)]
 fn move_auto_queue_entry_to_dispatched_on_conn(
     conn: &sqlite_test::Connection,
     entry_id: &str,
@@ -2786,24 +2523,8 @@ fn move_auto_queue_entry_to_dispatched_on_conn(
     kanban_db::move_auto_queue_entry_to_dispatched_on_conn(conn, entry_id, trigger_source, options)
 }
 
-async fn move_auto_queue_entry_to_dispatched_on_pg(
-    pool: &sqlx::PgPool,
-    entry_id: &str,
-    trigger_source: &str,
-    options: &crate::db::auto_queue::EntryStatusUpdateOptions,
-) -> Result<(), String> {
-    kanban_db::move_auto_queue_entry_to_dispatched_on_pg(pool, entry_id, trigger_source, options)
-        .await
-}
-
-async fn reactivate_done_auto_queue_entries_pg(
-    pool: &sqlx::PgPool,
-    card_id: &str,
-) -> anyhow::Result<()> {
-    kanban_db::reactivate_done_auto_queue_entries_pg(pool, card_id).await
-}
-
 #[cfg(all(test, feature = "legacy-sqlite-tests"))]
+#[allow(dead_code)]
 fn load_card_metadata_map_on_conn(
     conn: &sqlite_test::Connection,
     card_id: &str,
@@ -2811,14 +2532,8 @@ fn load_card_metadata_map_on_conn(
     kanban_db::load_card_metadata_map_on_conn(conn, card_id)
 }
 
-async fn load_card_metadata_map_pg(
-    pool: &sqlx::PgPool,
-    card_id: &str,
-) -> anyhow::Result<serde_json::Map<String, serde_json::Value>> {
-    kanban_db::load_card_metadata_map_pg(pool, card_id).await
-}
-
 #[cfg(all(test, feature = "legacy-sqlite-tests"))]
+#[allow(dead_code)]
 fn save_card_metadata_map_on_conn(
     conn: &sqlite_test::Connection,
     card_id: &str,
@@ -2827,15 +2542,8 @@ fn save_card_metadata_map_on_conn(
     kanban_db::save_card_metadata_map_on_conn(conn, card_id, metadata)
 }
 
-async fn save_card_metadata_map_pg(
-    pool: &sqlx::PgPool,
-    card_id: &str,
-    metadata: &serde_json::Map<String, serde_json::Value>,
-) -> anyhow::Result<()> {
-    kanban_db::save_card_metadata_map_pg(pool, card_id, metadata).await
-}
-
 #[cfg(all(test, feature = "legacy-sqlite-tests"))]
+#[allow(dead_code)]
 fn mark_api_reopen_skip_preflight_on_conn(
     conn: &sqlite_test::Connection,
     card_id: &str,
@@ -2843,14 +2551,8 @@ fn mark_api_reopen_skip_preflight_on_conn(
     kanban_db::mark_api_reopen_skip_preflight_on_conn(conn, card_id)
 }
 
-async fn mark_api_reopen_skip_preflight_on_pg(
-    pool: &sqlx::PgPool,
-    card_id: &str,
-) -> anyhow::Result<()> {
-    kanban_db::mark_api_reopen_skip_preflight_on_pg(pool, card_id).await
-}
-
 #[cfg(all(test, feature = "legacy-sqlite-tests"))]
+#[allow(dead_code)]
 fn clear_api_reopen_skip_preflight_on_conn(
     conn: &sqlite_test::Connection,
     card_id: &str,
@@ -2858,14 +2560,8 @@ fn clear_api_reopen_skip_preflight_on_conn(
     kanban_db::clear_api_reopen_skip_preflight_on_conn(conn, card_id)
 }
 
-async fn clear_api_reopen_skip_preflight_on_pg(
-    pool: &sqlx::PgPool,
-    card_id: &str,
-) -> anyhow::Result<()> {
-    kanban_db::clear_api_reopen_skip_preflight_on_pg(pool, card_id).await
-}
-
 #[cfg(all(test, feature = "legacy-sqlite-tests"))]
+#[allow(dead_code)]
 fn consume_api_reopen_preflight_skip_on_conn(
     conn: &sqlite_test::Connection,
     card_id: &str,
@@ -2873,44 +2569,13 @@ fn consume_api_reopen_preflight_skip_on_conn(
     kanban_db::consume_api_reopen_preflight_skip_on_conn(conn, card_id)
 }
 
-async fn consume_api_reopen_preflight_skip_on_pg(
-    pool: &sqlx::PgPool,
-    card_id: &str,
-) -> anyhow::Result<()> {
-    kanban_db::consume_api_reopen_preflight_skip_on_pg(pool, card_id).await
-}
-
 #[cfg(all(test, feature = "legacy-sqlite-tests"))]
+#[allow(dead_code)]
 fn clear_reopen_preflight_cache_on_conn(
     conn: &sqlite_test::Connection,
     card_id: &str,
 ) -> anyhow::Result<()> {
     kanban_db::clear_reopen_preflight_cache_on_conn(conn, card_id)
-}
-
-async fn clear_reopen_preflight_cache_on_pg(
-    pool: &sqlx::PgPool,
-    card_id: &str,
-) -> anyhow::Result<()> {
-    kanban_db::clear_reopen_preflight_cache_on_pg(pool, card_id).await
-}
-
-async fn active_dispatch_ids_for_card_pg(
-    pool: &sqlx::PgPool,
-    card_id: &str,
-) -> anyhow::Result<Vec<String>> {
-    kanban_db::active_dispatch_ids_for_card_pg(pool, card_id).await
-}
-
-async fn cancelled_dispatch_ids_among_pg(
-    pool: &sqlx::PgPool,
-    dispatch_ids: &[String],
-) -> anyhow::Result<Vec<String>> {
-    kanban_db::cancelled_dispatch_ids_among_pg(pool, dispatch_ids).await
-}
-
-async fn clear_all_threads_pg(pool: &sqlx::PgPool, card_id: &str) -> anyhow::Result<()> {
-    kanban_db::clear_all_threads_pg(pool, card_id).await
 }
 
 /// POST /api/kanban-cards/:id/force-transition

--- a/src/server/routes/meetings.rs
+++ b/src/server/routes/meetings.rs
@@ -1624,6 +1624,10 @@ fn direct_start_error_status(error: &str) -> StatusCode {
     StatusCode::INTERNAL_SERVER_ERROR
 }
 
+// reason: meeting-start command builder currently exercised only by the
+// `#[cfg(test)]` unit tests in this module; no production caller in the lib
+// build. See #3034.
+#[allow(dead_code)]
 fn build_meeting_start_command(agenda: &str, primary_provider: Option<ProviderKind>) -> String {
     match primary_provider {
         Some(provider) => format!("/meeting start --primary {} {}", provider.as_str(), agenda),

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -93,10 +93,6 @@ impl AppState {
         self.pg_pool.as_ref()
     }
 
-    pub fn kanban_service(&self) -> crate::services::kanban::KanbanService {
-        crate::services::kanban::KanbanService::new(self.pg_pool.clone())
-    }
-
     pub fn dispatch_service(&self) -> crate::services::dispatches::DispatchService {
         crate::services::dispatches::DispatchService::new(self.engine.clone())
     }
@@ -317,6 +313,9 @@ pub fn api_router(
     )
 }
 
+// reason: PG-pool router constructor used only by the `#[cfg(test)]` router
+// builders in health_api/route tests; the lib build sees no caller. See #3034.
+#[allow(dead_code)]
 pub fn api_router_with_pg(
     engine: PolicyEngine,
     config: crate::config::Config,

--- a/src/server/routes/pipeline.rs
+++ b/src/server/routes/pipeline.rs
@@ -382,11 +382,6 @@ mod tests {
         crate::db::wrap_conn(conn)
     }
 
-    fn test_engine(db: &Db) -> PolicyEngine {
-        let config = crate::config::Config::default();
-        PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
-    }
-
     fn test_engine_with_pg(pg_pool: sqlx::PgPool) -> PolicyEngine {
         let mut config = crate::config::Config::default();
         config.policies.dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("policies");

--- a/src/server/routes/receipt.rs
+++ b/src/server/routes/receipt.rs
@@ -128,6 +128,11 @@ pub(crate) async fn cached_or_collect_token_analytics(
 /// onto the same blocking pool slot at the same moment, and we tolerate
 /// individual failures so a transient parse error in one period doesn't
 /// kill the prewarm for the others.
+// reason: boot-time token-analytics cache prewarm entry point. The detached
+// `tokio::spawn` boot hook described above is not currently wired, so the lib
+// build flags it as dead; retained as a ready entry point rather than silently
+// dropping the prewarm capability. See #3034.
+#[allow(dead_code)]
 pub async fn prewarm_token_analytics_cache() {
     for period in ["7d", "30d", "90d"] {
         let (days, label) = match period {

--- a/src/server/routes/settings_tests.rs
+++ b/src/server/routes/settings_tests.rs
@@ -13,13 +13,6 @@ fn test_db() -> db::Db {
     db::wrap_conn(conn)
 }
 
-fn test_engine(db: &db::Db) -> PolicyEngine {
-    let mut config = crate::config::Config::default();
-    config.policies.dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("policies");
-    config.policies.hot_reload = false;
-    PolicyEngine::new_with_legacy_db(&config, db.clone()).unwrap()
-}
-
 fn test_engine_with_pg(pg_pool: sqlx::PgPool) -> PolicyEngine {
     let mut config = crate::config::Config::default();
     config.policies.dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("policies");


### PR DESCRIPTION
Part 4 of the maintainability epic. Removes the module-level `#[allow(dead_code)]` blanket from `mod server` in `src/lib.rs` and handles every dead_code warning it surfaced in `server/*`. The `services` blanket and the crate-wide `#![allow(clippy::await_holding_lock)]` are deliberately left in place — both remain on the #3016 relay serial track.

## Resolutions (53 surfaced server dead_code warnings)

### Deleted — provably dead, zero callers in any cfg (31 items)
- **kanban routes:** `bulk_action` + `batch_transition` (their `/api/kanban-cards/bulk-action` and `/batch-transition` endpoints are already fully removed per `docs.rs`) and their DTOs `BulkActionBody` / `BatchTransitionBody`; the dead `_pg` delegating shims (`load/save_card_metadata_map_pg`, the four `*_reopen_*_pg`, `move_auto_queue_entry_to_dispatched_on_pg`, `reactivate_done_auto_queue_entries_pg`, `active_dispatch_ids_for_card_pg`, `cancelled_dispatch_ids_among_pg`, `clear_all_threads_pg`, `find_active_review_dispatch_id_pg`) — every caller already invokes `kanban_db::*` directly.
- **thread_reuse:** legacy SQLite no-op stubs `get/set/clear_thread_for_channel`, `clear_all_threads`, dead helpers `parse_channel_thread_map` / `lookup_thread_for_channel_from_map`, and the redundant `should_defer_thread_archive_pg` wrapper.
- **cron_catalog:** unwired `tier_descriptor_by_label`, `slo_aggregation_descriptor`.
- **cluster:** `worker_node_snapshot_by_instance`. **routes/mod:** `kanban_service`. **escalation:** dead-twin `save_cached_thread_id_pg`. Dead test helpers `test_engine` in escalation / pipeline / settings_tests.
- **db cascade (1):** `db::kanban_cards::card_ids_by_issue_number_pg`, whose only caller was the now-removed `batch_transition` handler.

### Scoped item-level `#[allow(dead_code)]` with reason + #3034 (21 items / 10 reason comments)
Entry points the default lib check can't see (router/test/runtime paths):
- 14 **legacy-sqlite parity wrappers** in `kanban.rs` that keep the `db::kanban_cards::*_on_conn` test helpers reachable from one call surface under the `legacy-sqlite-tests` backend.
- `wait_until_leader` (cluster leadership-transition test), `unreal_project_lock_key` (multinode regression suite), `TOP_40_PAIRED_PATHS` (api_docs paired-coverage fixture), `build_meeting_start_command` (unit-tested command builder), `api_router_with_pg` (test router constructor), `prewarm_token_analytics_cache` (boot prewarm entry point whose detached-spawn hook is currently unwired — retained rather than silently dropping the prewarm capability).

## Giant-file registry
No file crossed the 1000-prod-LoC giant threshold (the scoped-allow comments added ≤4 lines each; all four touched giant routes stay registered and above threshold, no ghost-registration, no new registration). Synced the kanban/docs/escalation/meetings production-LoC drift in `docs/agent-maintenance/change-surfaces.md`.

## Verification
- `cargo check --workspace --all-features --all-targets` → clean, **zero new dead_code warnings in server** (total warning count unchanged from baseline).
- `cargo check --features legacy-sqlite-tests --all-targets` → compiles.
- `cargo fmt --all --check` → clean.
- `cargo test --lib` for every touched module (cluster, resource_locks, cron_catalog, docs, kanban, thread_reuse, escalation, pipeline, settings, meetings under `legacy-sqlite-tests`) → pass. The pre-existing `api_docs_exposes_paired_examples_for_top_40` failure reproduces identically on `origin/main` (missing example docs for unrelated endpoints) and is out of scope.
- `./scripts/ci-script-checks.sh` → exit 0.

Part of #3034 (Part 4/N; only the `services` blanket + the crate-wide `await_holding_lock` allow remain, both on the #3016 relay track).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
