### PR TITLE
fix(discord): single trailing queued-turn card, never split multi-chunk answers (#3082)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -499,6 +499,7 @@ src/
 │   │   ├── adk_session.rs
 │   │   ├── agent_handoff.rs
 │   │   ├── agentdesk_config.rs
+│   │   ├── answer_flush_barrier.rs
 │   │   ├── discord_io.rs
 │   │   ├── formatting.rs
 │   │   ├── gateway.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -157,11 +157,14 @@
     split before adding non-bugfix behavior).
   - `src/services/discord/turn_bridge/completion_guard.rs` (1909 lines).
   - `src/services/discord/turn_bridge/tmux_runtime.rs` (1243 lines).
-  - `src/services/discord/formatting.rs` (2755 lines; +35 from #3082
+  - `src/services/discord/formatting.rs` (2766 lines; +46 from #3082
     answer-flush-barrier guards (+11 around the plain multi-chunk send loops;
     +24 from the #3082 codex follow-up that also guards the edit/replace path
     `replace_long_message_raw_with_outcome` and bumps `note_progress` after each
-    delivered chunk for the progress-aware flush wait)).
+    delivered chunk for the progress-aware flush wait; +11 from the codex P1-2
+    residual that bumps `note_progress` after the FIRST edited chunk too, on the
+    multi-chunk path only, so the queued-card waiter's inactivity grace cannot
+    expire between the first edit and the first continuation)).
   - `src/services/discord/settings.rs` (2479 lines).
   - `src/services/discord/prompt_builder/` (directory, refactored).
   - `src/services/discord/runtime_bootstrap.rs` (2567 lines after #2558

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -135,8 +135,9 @@
     fingerprinting/dedupe state for hook and rollout relay paths, bugfix only
     outside an extraction plan).
   - `src/services/discord/recovery_engine.rs` (3944 lines).
-  - `src/services/discord/health.rs` (2817 lines after #1879 snapshot/mailbox
-    extraction).
+  - `src/services/discord/health.rs` (2820 lines after #1879 snapshot/mailbox
+    extraction; +3 from #3082 answer-flush-barrier field in the test SharedData
+    constructor).
   - `src/services/discord/health/recovery.rs` (2425 lines; health recovery
     extraction surface, split further before adding non-bugfix behavior).
   - `src/services/discord/router/message_handler/intake_turn.rs` (3611 lines;
@@ -151,11 +152,13 @@
     split before adding non-bugfix behavior).
   - `src/services/discord/turn_bridge/completion_guard.rs` (1909 lines).
   - `src/services/discord/turn_bridge/tmux_runtime.rs` (1243 lines).
-  - `src/services/discord/formatting.rs` (2720 lines).
+  - `src/services/discord/formatting.rs` (2731 lines; +11 from #3082
+    answer-flush-barrier guard around the multi-chunk send loops).
   - `src/services/discord/settings.rs` (2479 lines).
   - `src/services/discord/prompt_builder/` (directory, refactored).
-  - `src/services/discord/runtime_bootstrap.rs` (2564 lines after #2558
-    thread-session GC loopback shim cleanup).
+  - `src/services/discord/runtime_bootstrap.rs` (2567 lines after #2558
+    thread-session GC loopback shim cleanup; +3 from #3082 answer-flush-barrier
+    field in the SharedData constructor).
   - `src/services/discord/session_runtime.rs` (1418 lines).
   - `src/services/discord/voice_barge_in.rs` (4653 lines; voice STT/TTS,
     lobby routing, progress mirroring, and barge-in orchestration surface;
@@ -380,10 +383,11 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   execution are the canonical scheduled JS routine surfaces. Split focused
   helper modules before growing these files again.
 - `src/services/platform/binary_resolver.rs` (1936).
-- `src/services/discord/mod.rs` (5871; +34 from #3019 added the
+- `src/services/discord/mod.rs` (5883; +34 from #3019 added the
   single-authority `increment_global_active` helper + doc mirroring the
   existing decrement helper — offset by removing 6 inline raw `fetch_add`
-  blocks across the relay turn-start sites that now route through it),
+  blocks across the relay turn-start sites that now route through it; +12 from
+  #3082 answer-flush-barrier field/init/doc),
   `src/services/discord_config_audit.rs` (1318).
 - `src/services/turn_orchestrator.rs` (2932).
 

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -8,7 +8,8 @@
 > [`docs/generated/giant-file-registry.md`](../generated/giant-file-registry.md);
 > the rows below project the operational meaning of each entry.
 >
-> Last refreshed: 2026-06-02 (against #3036 production-LoC remeasure).
+> Last refreshed: 2026-06-03 (against #3082 codex follow-up: edit/replace
+> answer-flush coverage + progress-aware flush wait + queued-only gate).
 
 ## Read This First
 
@@ -125,9 +126,10 @@
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh; split loop helpers
     further before adding behavior).
-  - `src/services/discord/tui_prompt_relay.rs` (3237 lines; SSH-direct TUI
+  - `src/services/discord/tui_prompt_relay.rs` (3241 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
-    outside an extraction plan).
+    outside an extraction plan; +4 from #3082 queued-only answer-flush gate
+    (`is_queued_notice = false` for the TUI idle-response placeholder)).
   - `src/services/codex_tmux_wrapper.rs` (1223 lines; Codex tmux wrapper JSON
     event parser and relay bridge for native Codex session events — bugfix only
     outside an extraction plan).
@@ -140,9 +142,12 @@
     constructor).
   - `src/services/discord/health/recovery.rs` (2425 lines; health recovery
     extraction surface, split further before adding non-bugfix behavior).
-  - `src/services/discord/router/message_handler/intake_turn.rs` (3611 lines;
+  - `src/services/discord/router/message_handler/intake_turn.rs` (3620 lines;
     Discord message intake turn orchestration split from the router message
-    handler; bugfix only outside a further extraction plan).
+    handler; bugfix only outside a further extraction plan; +9 from #3082
+    queued-only answer-flush gate (`is_queued_notice` on the two
+    `send_intake_placeholder` call sites: `true` for the race-lost queued card,
+    `false` for the active-turn placeholder)).
   - `src/services/discord/router/message_handler/headless_turn.rs` (1316 lines;
     headless Discord turn launch/terminal-response path split from the router
     message handler; bugfix only outside a further extraction plan).
@@ -152,8 +157,11 @@
     split before adding non-bugfix behavior).
   - `src/services/discord/turn_bridge/completion_guard.rs` (1909 lines).
   - `src/services/discord/turn_bridge/tmux_runtime.rs` (1243 lines).
-  - `src/services/discord/formatting.rs` (2731 lines; +11 from #3082
-    answer-flush-barrier guard around the multi-chunk send loops).
+  - `src/services/discord/formatting.rs` (2755 lines; +35 from #3082
+    answer-flush-barrier guards (+11 around the plain multi-chunk send loops;
+    +24 from the #3082 codex follow-up that also guards the edit/replace path
+    `replace_long_message_raw_with_outcome` and bumps `note_progress` after each
+    delivered chunk for the progress-aware flush wait)).
   - `src/services/discord/settings.rs` (2479 lines).
   - `src/services/discord/prompt_builder/` (directory, refactored).
   - `src/services/discord/runtime_bootstrap.rs` (2567 lines after #2558

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -370,3 +370,12 @@
 - If a new worker, durable queue, provider, MCP integration, or exclusive test
   resource is added, classify it as leader-only, PG-lease-backed, or worker-local
   before merging.
+
+### Audited touches
+
+- #3082 (queued-card / answer-flush barrier): `runtime_bootstrap.rs` changed
+  only to initialize the new in-process `answer_flush_barrier` field on
+  `SharedData`. The barrier is **worker-local** (a per-process, per-channel
+  in-memory gate guarding queued-card ordering) — it owns no leader-only side
+  effect, no durable queue, and no PG lease, so it introduces no new multinode
+  ownership/singleton/lease assumption.

--- a/src/services/discord/answer_flush_barrier.rs
+++ b/src/services/discord/answer_flush_barrier.rs
@@ -453,4 +453,56 @@ mod tests {
             "queued card releases with true once the edit/replace flush finishes — it lands as a trailing notice, never interleaved"
         );
     }
+
+    /// P1-2 residual: in the edit/replace path the FIRST chunk is delivered via
+    /// `edit_channel_message`, and only the continuation loop bumps progress.
+    /// On a multi-chunk answer there is a real gap between acquiring the guard
+    /// (which seeds `last_progress`) and the first continuation send: the first
+    /// edit itself takes time (rate-limit wait + HTTP round-trip). If that gap
+    /// exceeds the waiter's inactivity grace, the queued-card waiter would
+    /// spuriously expire mid-flush. The fix bumps `note_progress` right after the
+    /// first edit succeeds (multi-chunk path only). This test models that bridge:
+    /// guard acquired, then a delay LONGER than the inactivity grace, then the
+    /// first-edit progress bump — the waiter must NOT have expired across the gap.
+    #[tokio::test]
+    async fn first_edit_progress_bump_bridges_gap_before_first_continuation() {
+        let barrier = Arc::new(AnswerFlushBarrier::default());
+        let channel = ChannelId::new(11);
+
+        // begin_flush seeds last_progress at acquire time.
+        let guard = barrier.begin_flush(channel);
+
+        let barrier_for_card = barrier.clone();
+        // Short 100ms inactivity grace so the first-edit gap can exceed it.
+        let queued_card = tokio::spawn(async move {
+            barrier_for_card
+                .wait_for_flush(channel, Duration::from_millis(100), Duration::from_secs(30))
+                .await
+        });
+
+        // The first edit is in flight for ~80ms (under grace so far)...
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        // ...the first edit SUCCEEDS — this is the new multi-chunk bump that the
+        // residual fix adds. Without it, the next progress signal would only come
+        // from the first continuation send, and the cumulative gap below would
+        // trip the 100ms inactivity grace.
+        barrier.note_progress(channel);
+
+        // The first continuation is then itself in flight for another ~80ms. The
+        // total elapsed (≈160ms) now exceeds the 100ms grace, but because the
+        // first-edit bump reset the window the waiter must still be blocked.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert!(
+            !queued_card.is_finished(),
+            "first-edit progress bump must keep the queued-card waiter blocked across the edit→continuation gap (multi-chunk path)"
+        );
+
+        // First continuation lands (continuation-loop bump), then the answer ends.
+        barrier.note_progress(channel);
+        drop(guard);
+        assert!(
+            queued_card.await.unwrap(),
+            "queued card releases with true once the multi-chunk edit/replace answer finishes — never cut short mid-flush"
+        );
+    }
 }

--- a/src/services/discord/answer_flush_barrier.rs
+++ b/src/services/discord/answer_flush_barrier.rs
@@ -1,0 +1,225 @@
+//! #3082 part B — per-channel answer-flush barrier.
+//!
+//! Problem: when the active turn's final answer exceeds Discord's 2000-char
+//! limit it is delivered as multiple chunks (`send_long_message_raw*`). The
+//! chunk loop sleeps ~500ms between sends, opening a window where a queued-turn
+//! notice POST (`send_intake_placeholder`) could land *between* answer chunks:
+//!
+//! ```text
+//! answer chunk 1
+//! 📬 메시지 대기 중   <- interleaved, wrong order
+//! answer chunk 2
+//! ```
+//!
+//! This barrier lets the queued-card POST path wait until the in-flight
+//! multi-chunk answer has finished flushing, so the notice always lands AFTER
+//! the final chunk (a single trailing card).
+//!
+//! Safety: the barrier is *advisory and bounded*. It never blocks indefinitely.
+//!
+//! * Setting the gate is done through an RAII [`AnswerFlushGuard`]; the count is
+//!   decremented on `Drop`, so every exit path of the chunk loop (success,
+//!   early `return Err`, `?`, panic-unwind) clears it. It can never strand set.
+//! * The waiter (`wait_for_flush`) polls with a hard deadline. If the flush is
+//!   stuck or the turn errored without dropping the guard (impossible given the
+//!   guard, but defended anyway), the waiter proceeds once the deadline elapses
+//!   and the queued card still posts. No deadlock, no permanent suppression.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use poise::serenity_prelude::ChannelId;
+
+/// Maximum time the queued-card POST path will defer behind an in-flight
+/// multi-chunk answer flush before proceeding anyway. Generous enough to cover
+/// the inter-chunk 500ms sleeps of a realistic multi-chunk answer, but bounded
+/// so a stuck flush never strands the queued card.
+pub(super) const ANSWER_FLUSH_WAIT_TIMEOUT: Duration = Duration::from_secs(8);
+
+/// Poll interval while waiting for the gate to clear.
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+#[derive(Default)]
+pub(in crate::services::discord) struct AnswerFlushBarrier {
+    /// Per-channel count of in-flight multi-chunk answer flushes. A channel is
+    /// "flushing" while its count is > 0. A count (not a bool) tolerates the
+    /// rare overlap of two multi-chunk sends on the same channel without one
+    /// clearing the other's gate.
+    inflight: Mutex<HashMap<ChannelId, usize>>,
+}
+
+impl AnswerFlushBarrier {
+    /// Mark the start of a multi-chunk answer flush for `channel_id`. The
+    /// returned guard clears the mark on drop. Call this ONLY for genuine
+    /// multi-chunk (>1 chunk) sends — single-chunk answers cannot be split, so
+    /// there is no interleaving window to guard.
+    pub(in crate::services::discord) fn begin_flush(
+        self: &std::sync::Arc<Self>,
+        channel_id: ChannelId,
+    ) -> AnswerFlushGuard {
+        if let Ok(mut map) = self.inflight.lock() {
+            *map.entry(channel_id).or_insert(0) += 1;
+        }
+        AnswerFlushGuard {
+            barrier: self.clone(),
+            channel_id,
+        }
+    }
+
+    fn is_flushing(&self, channel_id: ChannelId) -> bool {
+        self.inflight
+            .lock()
+            .map(|map| map.get(&channel_id).copied().unwrap_or(0) > 0)
+            .unwrap_or(false)
+    }
+
+    fn end_flush(&self, channel_id: ChannelId) {
+        if let Ok(mut map) = self.inflight.lock() {
+            if let Some(count) = map.get_mut(&channel_id) {
+                *count = count.saturating_sub(1);
+                if *count == 0 {
+                    map.remove(&channel_id);
+                }
+            }
+        }
+    }
+
+    /// Wait until no multi-chunk answer flush is in flight for `channel_id`, or
+    /// until `timeout` elapses — whichever comes first. Returns `true` if the
+    /// gate cleared before the deadline, `false` if it timed out (caller should
+    /// proceed anyway). Always returns promptly when no flush is active.
+    pub(in crate::services::discord) async fn wait_for_flush(
+        &self,
+        channel_id: ChannelId,
+        timeout: Duration,
+    ) -> bool {
+        if !self.is_flushing(channel_id) {
+            return true;
+        }
+        let deadline = Instant::now() + timeout;
+        loop {
+            tokio::time::sleep(POLL_INTERVAL).await;
+            if !self.is_flushing(channel_id) {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+        }
+    }
+}
+
+/// RAII guard that clears its channel's answer-flush mark on drop. Holding it
+/// across the entire multi-chunk send loop guarantees the gate is cleared on
+/// every exit path (Ok, Err via `?`, panic-unwind).
+pub(in crate::services::discord) struct AnswerFlushGuard {
+    barrier: std::sync::Arc<AnswerFlushBarrier>,
+    channel_id: ChannelId,
+}
+
+impl Drop for AnswerFlushGuard {
+    fn drop(&mut self) {
+        self.barrier.end_flush(self.channel_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn no_flush_returns_immediately() {
+        let barrier = Arc::new(AnswerFlushBarrier::default());
+        let channel = ChannelId::new(1);
+        let start = Instant::now();
+        assert!(
+            barrier
+                .wait_for_flush(channel, Duration::from_secs(5))
+                .await,
+            "with no flush in flight the waiter must return true immediately"
+        );
+        assert!(
+            start.elapsed() < Duration::from_millis(200),
+            "no-flush wait must not block"
+        );
+    }
+
+    #[tokio::test]
+    async fn guard_clears_gate_on_drop() {
+        let barrier = Arc::new(AnswerFlushBarrier::default());
+        let channel = ChannelId::new(2);
+        {
+            let _guard = barrier.begin_flush(channel);
+            assert!(barrier.is_flushing(channel), "gate set while guard held");
+        }
+        assert!(
+            !barrier.is_flushing(channel),
+            "gate must clear when guard drops"
+        );
+        assert!(
+            barrier
+                .wait_for_flush(channel, Duration::from_secs(5))
+                .await,
+            "waiter sees cleared gate after guard drop"
+        );
+    }
+
+    #[tokio::test]
+    async fn waiter_unblocks_when_flush_ends() {
+        let barrier = Arc::new(AnswerFlushBarrier::default());
+        let channel = ChannelId::new(3);
+        let guard = barrier.begin_flush(channel);
+        let barrier_for_wait = barrier.clone();
+        let waiter = tokio::spawn(async move {
+            barrier_for_wait
+                .wait_for_flush(channel, Duration::from_secs(5))
+                .await
+        });
+        // Hold the gate briefly, then release; the waiter must observe the
+        // release and return true (not time out).
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        drop(guard);
+        assert!(
+            waiter.await.unwrap(),
+            "waiter must unblock with true once the flush ends"
+        );
+    }
+
+    #[tokio::test]
+    async fn waiter_times_out_when_flush_never_ends() {
+        let barrier = Arc::new(AnswerFlushBarrier::default());
+        let channel = ChannelId::new(4);
+        // Leak the guard so the gate stays set — simulates a stuck/errored
+        // flush that never dropped its guard. The waiter MUST still return
+        // (false) so the queued card is never permanently suppressed.
+        let guard = barrier.begin_flush(channel);
+        std::mem::forget(guard);
+        let cleared = barrier
+            .wait_for_flush(channel, Duration::from_millis(200))
+            .await;
+        assert!(
+            !cleared,
+            "a never-ending flush must time out (false), not deadlock"
+        );
+    }
+
+    #[tokio::test]
+    async fn nested_flushes_keep_gate_until_last_drop() {
+        let barrier = Arc::new(AnswerFlushBarrier::default());
+        let channel = ChannelId::new(5);
+        let g1 = barrier.begin_flush(channel);
+        let g2 = barrier.begin_flush(channel);
+        drop(g1);
+        assert!(
+            barrier.is_flushing(channel),
+            "gate stays set while one of two overlapping flushes is live"
+        );
+        drop(g2);
+        assert!(
+            !barrier.is_flushing(channel),
+            "gate clears only after the last overlapping flush drops"
+        );
+    }
+}

--- a/src/services/discord/answer_flush_barrier.rs
+++ b/src/services/discord/answer_flush_barrier.rs
@@ -20,10 +20,15 @@
 //! * Setting the gate is done through an RAII [`AnswerFlushGuard`]; the count is
 //!   decremented on `Drop`, so every exit path of the chunk loop (success,
 //!   early `return Err`, `?`, panic-unwind) clears it. It can never strand set.
-//! * The waiter (`wait_for_flush`) polls with a hard deadline. If the flush is
-//!   stuck or the turn errored without dropping the guard (impossible given the
-//!   guard, but defended anyway), the waiter proceeds once the deadline elapses
-//!   and the queued card still posts. No deadlock, no permanent suppression.
+//! * The waiter (`wait_for_flush`) is *progress-aware*: the holder bumps a
+//!   per-channel "last progress" instant on guard acquire, on EACH chunk
+//!   delivered, and on guard release. The waiter proceeds when the gate clears,
+//!   when no progress has been observed for an inactivity grace window
+//!   ([`ANSWER_FLUSH_WAIT_TIMEOUT`]), or when an absolute hard ceiling
+//!   ([`ANSWER_FLUSH_WAIT_HARD_CEILING`]) is hit — whichever comes first. A long
+//!   answer that keeps making progress never trips the inactivity timeout, but a
+//!   genuinely stuck/crashed flush still releases. No deadlock, no permanent
+//!   suppression.
 
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -31,35 +36,55 @@ use std::time::{Duration, Instant};
 
 use poise::serenity_prelude::ChannelId;
 
-/// Maximum time the queued-card POST path will defer behind an in-flight
-/// multi-chunk answer flush before proceeding anyway. Generous enough to cover
-/// the inter-chunk 500ms sleeps of a realistic multi-chunk answer, but bounded
-/// so a stuck flush never strands the queued card.
+/// Inactivity grace window: the queued-card POST path proceeds once the
+/// in-flight flush has made NO progress (no new chunk delivered) for this long.
+/// This is a *per-chunk* inactivity bound, NOT a total-time bound — a long
+/// answer that keeps delivering chunks resets the window on every chunk and so
+/// never trips it. Generous enough to cover the inter-chunk 500ms sleeps plus
+/// realistic rate-limit/network delay on a single chunk.
 pub(super) const ANSWER_FLUSH_WAIT_TIMEOUT: Duration = Duration::from_secs(8);
+
+/// Absolute hard ceiling on the total wait, regardless of progress. A final
+/// backstop so the queued card can never wait forever even if a flush somehow
+/// keeps bumping progress without ever finishing. Large enough that a genuine
+/// long multi-chunk answer (~16+ chunks) completes well within it.
+pub(super) const ANSWER_FLUSH_WAIT_HARD_CEILING: Duration = Duration::from_secs(60);
 
 /// Poll interval while waiting for the gate to clear.
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 #[derive(Default)]
+struct ChannelFlushState {
+    /// Number of in-flight multi-chunk answer flushes on this channel. A count
+    /// (not a bool) tolerates the rare overlap of two multi-chunk sends on the
+    /// same channel without one clearing the other's gate.
+    inflight: usize,
+    /// Instant of the most recent observable progress (guard acquire, chunk
+    /// delivered, or guard release) for this channel. The waiter reads this to
+    /// decide whether the flush is still making progress.
+    last_progress: Option<Instant>,
+}
+
+#[derive(Default)]
 pub(in crate::services::discord) struct AnswerFlushBarrier {
-    /// Per-channel count of in-flight multi-chunk answer flushes. A channel is
-    /// "flushing" while its count is > 0. A count (not a bool) tolerates the
-    /// rare overlap of two multi-chunk sends on the same channel without one
-    /// clearing the other's gate.
-    inflight: Mutex<HashMap<ChannelId, usize>>,
+    /// Per-channel flush bookkeeping. A channel is "flushing" while its
+    /// `inflight` count is > 0.
+    channels: Mutex<HashMap<ChannelId, ChannelFlushState>>,
 }
 
 impl AnswerFlushBarrier {
     /// Mark the start of a multi-chunk answer flush for `channel_id`. The
     /// returned guard clears the mark on drop. Call this ONLY for genuine
     /// multi-chunk (>1 chunk) sends — single-chunk answers cannot be split, so
-    /// there is no interleaving window to guard.
+    /// there is no interleaving window to guard. Acquiring counts as progress.
     pub(in crate::services::discord) fn begin_flush(
         self: &std::sync::Arc<Self>,
         channel_id: ChannelId,
     ) -> AnswerFlushGuard {
-        if let Ok(mut map) = self.inflight.lock() {
-            *map.entry(channel_id).or_insert(0) += 1;
+        if let Ok(mut map) = self.channels.lock() {
+            let state = map.entry(channel_id).or_default();
+            state.inflight += 1;
+            state.last_progress = Some(Instant::now());
         }
         AnswerFlushGuard {
             barrier: self.clone(),
@@ -67,43 +92,98 @@ impl AnswerFlushBarrier {
         }
     }
 
+    /// Record that the flush on `channel_id` just made progress (e.g. delivered
+    /// another chunk). Resets the waiter's inactivity window so a legitimately
+    /// long answer is never cut off mid-flush. No-op if the channel is not
+    /// currently flushing.
+    pub(in crate::services::discord) fn note_progress(&self, channel_id: ChannelId) {
+        if let Ok(mut map) = self.channels.lock()
+            && let Some(state) = map.get_mut(&channel_id)
+            && state.inflight > 0
+        {
+            state.last_progress = Some(Instant::now());
+        }
+    }
+
     fn is_flushing(&self, channel_id: ChannelId) -> bool {
-        self.inflight
+        self.channels
             .lock()
-            .map(|map| map.get(&channel_id).copied().unwrap_or(0) > 0)
+            .map(|map| {
+                map.get(&channel_id)
+                    .map(|state| state.inflight > 0)
+                    .unwrap_or(false)
+            })
             .unwrap_or(false)
     }
 
+    /// Snapshot `(still_flushing, last_progress)` for `channel_id` under a
+    /// single lock acquire, so the waiter never holds the lock across `.await`.
+    fn flush_snapshot(&self, channel_id: ChannelId) -> (bool, Option<Instant>) {
+        self.channels
+            .lock()
+            .map(|map| {
+                map.get(&channel_id)
+                    .map(|state| (state.inflight > 0, state.last_progress))
+                    .unwrap_or((false, None))
+            })
+            .unwrap_or((false, None))
+    }
+
     fn end_flush(&self, channel_id: ChannelId) {
-        if let Ok(mut map) = self.inflight.lock() {
-            if let Some(count) = map.get_mut(&channel_id) {
-                *count = count.saturating_sub(1);
-                if *count == 0 {
-                    map.remove(&channel_id);
-                }
+        if let Ok(mut map) = self.channels.lock()
+            && let Some(state) = map.get_mut(&channel_id)
+        {
+            state.inflight = state.inflight.saturating_sub(1);
+            if state.inflight == 0 {
+                map.remove(&channel_id);
+            } else {
+                // A release while other overlapping flushes remain still counts
+                // as progress for the survivors.
+                state.last_progress = Some(Instant::now());
             }
         }
     }
 
-    /// Wait until no multi-chunk answer flush is in flight for `channel_id`, or
-    /// until `timeout` elapses — whichever comes first. Returns `true` if the
-    /// gate cleared before the deadline, `false` if it timed out (caller should
-    /// proceed anyway). Always returns promptly when no flush is active.
+    /// Wait until no multi-chunk answer flush is in flight for `channel_id`.
+    ///
+    /// Progress-aware (see module docs): returns `true` as soon as the gate
+    /// clears; returns `false` (caller proceeds anyway) once the flush has made
+    /// NO progress for `inactivity_grace`, OR once `hard_ceiling` of total wall
+    /// time elapses — whichever comes first. A flush that keeps delivering
+    /// chunks resets the inactivity window on each chunk and so is never cut
+    /// off by it. Always returns `true` promptly when no flush is active.
+    ///
+    /// Deadlock-free: the lock is never held across an `.await`.
     pub(in crate::services::discord) async fn wait_for_flush(
         &self,
         channel_id: ChannelId,
-        timeout: Duration,
+        inactivity_grace: Duration,
+        hard_ceiling: Duration,
     ) -> bool {
-        if !self.is_flushing(channel_id) {
+        let (flushing, _) = self.flush_snapshot(channel_id);
+        if !flushing {
             return true;
         }
-        let deadline = Instant::now() + timeout;
+        let start = Instant::now();
         loop {
             tokio::time::sleep(POLL_INTERVAL).await;
-            if !self.is_flushing(channel_id) {
+            let now = Instant::now();
+            let (flushing, last_progress) = self.flush_snapshot(channel_id);
+            if !flushing {
                 return true;
             }
-            if Instant::now() >= deadline {
+            // Absolute backstop: never wait past the hard ceiling.
+            if now.duration_since(start) >= hard_ceiling {
+                return false;
+            }
+            // Inactivity backstop: proceed if the flush has stopped making
+            // progress for the grace window. `last_progress` is bumped on
+            // acquire and on each delivered chunk, so an actively-progressing
+            // flush keeps this from tripping.
+            let stalled_for = last_progress
+                .map(|p| now.duration_since(p))
+                .unwrap_or(Duration::ZERO);
+            if stalled_for >= inactivity_grace {
                 return false;
             }
         }
@@ -129,15 +209,21 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
+    /// Convenience: wait with a generous hard ceiling so these tests exercise
+    /// the gate-clear / inactivity paths rather than the ceiling.
+    async fn wait(barrier: &AnswerFlushBarrier, channel: ChannelId, grace: Duration) -> bool {
+        barrier
+            .wait_for_flush(channel, grace, Duration::from_secs(30))
+            .await
+    }
+
     #[tokio::test]
     async fn no_flush_returns_immediately() {
         let barrier = Arc::new(AnswerFlushBarrier::default());
         let channel = ChannelId::new(1);
         let start = Instant::now();
         assert!(
-            barrier
-                .wait_for_flush(channel, Duration::from_secs(5))
-                .await,
+            wait(&barrier, channel, Duration::from_secs(5)).await,
             "with no flush in flight the waiter must return true immediately"
         );
         assert!(
@@ -159,9 +245,7 @@ mod tests {
             "gate must clear when guard drops"
         );
         assert!(
-            barrier
-                .wait_for_flush(channel, Duration::from_secs(5))
-                .await,
+            wait(&barrier, channel, Duration::from_secs(5)).await,
             "waiter sees cleared gate after guard drop"
         );
     }
@@ -172,11 +256,10 @@ mod tests {
         let channel = ChannelId::new(3);
         let guard = barrier.begin_flush(channel);
         let barrier_for_wait = barrier.clone();
-        let waiter = tokio::spawn(async move {
-            barrier_for_wait
-                .wait_for_flush(channel, Duration::from_secs(5))
-                .await
-        });
+        let waiter =
+            tokio::spawn(
+                async move { wait(&barrier_for_wait, channel, Duration::from_secs(5)).await },
+            );
         // Hold the gate briefly, then release; the waiter must observe the
         // release and return true (not time out).
         tokio::time::sleep(Duration::from_millis(120)).await;
@@ -192,17 +275,121 @@ mod tests {
         let barrier = Arc::new(AnswerFlushBarrier::default());
         let channel = ChannelId::new(4);
         // Leak the guard so the gate stays set — simulates a stuck/errored
-        // flush that never dropped its guard. The waiter MUST still return
-        // (false) so the queued card is never permanently suppressed.
+        // flush that never dropped its guard AND never reports progress. The
+        // waiter MUST still return (false) via the inactivity backstop so the
+        // queued card is never permanently suppressed.
         let guard = barrier.begin_flush(channel);
         std::mem::forget(guard);
-        let cleared = barrier
-            .wait_for_flush(channel, Duration::from_millis(200))
-            .await;
+        let cleared = wait(&barrier, channel, Duration::from_millis(200)).await;
         assert!(
             !cleared,
             "a never-ending flush must time out (false), not deadlock"
         );
+    }
+
+    /// P1-2: a long answer that keeps making progress beyond the (short)
+    /// inactivity grace must NOT trip the timeout — the waiter keeps waiting as
+    /// long as chunks are still being delivered, so the queued card waits to the
+    /// very end of the answer.
+    #[tokio::test]
+    async fn progress_keeps_waiter_blocked_past_inactivity_grace() {
+        let barrier = Arc::new(AnswerFlushBarrier::default());
+        let channel = ChannelId::new(6);
+        let guard = barrier.begin_flush(channel);
+
+        let barrier_for_wait = barrier.clone();
+        // Short 100ms inactivity grace, but a generous hard ceiling.
+        let waiter = tokio::spawn(async move {
+            barrier_for_wait
+                .wait_for_flush(channel, Duration::from_millis(100), Duration::from_secs(30))
+                .await
+        });
+
+        // Simulate a long answer: bump progress every 40ms (< grace) for ~500ms,
+        // which is FAR longer than the 100ms inactivity grace. If the timeout
+        // were absolute (old behavior) it would have fired; progress-awareness
+        // must keep the waiter blocked.
+        for _ in 0..12 {
+            tokio::time::sleep(Duration::from_millis(40)).await;
+            barrier.note_progress(channel);
+        }
+        assert!(
+            !waiter.is_finished(),
+            "an actively-progressing flush must keep the waiter blocked past the inactivity grace"
+        );
+
+        // The answer finishes — release the guard. The waiter must now return
+        // true (it waited to the END of the answer, never timed out).
+        drop(guard);
+        assert!(
+            waiter.await.unwrap(),
+            "once the long answer finishes the waiter returns true, having waited to the end"
+        );
+    }
+
+    /// P1-2: a flush that stops making progress (stuck/crashed mid-answer)
+    /// still releases the waiter after the inactivity grace, even though it
+    /// reported some early progress.
+    #[tokio::test]
+    async fn stalled_flush_releases_after_inactivity_grace() {
+        let barrier = Arc::new(AnswerFlushBarrier::default());
+        let channel = ChannelId::new(7);
+        let guard = barrier.begin_flush(channel);
+        // One early progress bump, then silence (simulating a crash mid-flush).
+        barrier.note_progress(channel);
+        std::mem::forget(guard);
+
+        let start = Instant::now();
+        let cleared = barrier
+            .wait_for_flush(channel, Duration::from_millis(150), Duration::from_secs(30))
+            .await;
+        assert!(
+            !cleared,
+            "a stalled flush must release via the inactivity grace (false)"
+        );
+        // It should have waited at least roughly the grace window, but far less
+        // than the 30s hard ceiling — proving inactivity, not ceiling, fired.
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "inactivity grace (not the hard ceiling) must release a stalled flush"
+        );
+    }
+
+    /// P1-2: the hard ceiling is the final backstop — even a flush that keeps
+    /// bumping progress forever cannot make the waiter wait past the ceiling.
+    #[tokio::test]
+    async fn hard_ceiling_releases_even_with_continuous_progress() {
+        let barrier = Arc::new(AnswerFlushBarrier::default());
+        let channel = ChannelId::new(8);
+        let guard = barrier.begin_flush(channel);
+
+        let barrier_for_wait = barrier.clone();
+        // Tiny hard ceiling, large inactivity grace: only the ceiling can fire.
+        let waiter = tokio::spawn(async move {
+            barrier_for_wait
+                .wait_for_flush(channel, Duration::from_secs(30), Duration::from_millis(200))
+                .await
+        });
+
+        // Keep bumping progress continuously so the inactivity grace never
+        // trips; only the hard ceiling can release the waiter.
+        let pump = tokio::spawn({
+            let barrier = barrier.clone();
+            async move {
+                for _ in 0..50 {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    barrier.note_progress(channel);
+                }
+            }
+        });
+
+        let cleared = waiter.await.unwrap();
+        assert!(
+            !cleared,
+            "the hard ceiling must release the waiter (false) even under continuous progress"
+        );
+        pump.abort();
+        drop(guard);
     }
 
     #[tokio::test]
@@ -220,6 +407,50 @@ mod tests {
         assert!(
             !barrier.is_flushing(channel),
             "gate clears only after the last overlapping flush drops"
+        );
+    }
+
+    /// P1-1: the edit/replace answer path (`replace_long_message_raw_with_outcome`)
+    /// now holds the SAME barrier guard for multi-chunk sends as the plain send
+    /// path. This test exercises that contract end-to-end from the queued card's
+    /// perspective: while the edit/replace flush holds its guard AND keeps
+    /// delivering continuation chunks (each a `note_progress`), the queued-card
+    /// waiter must stay blocked — even past the inactivity grace — and only
+    /// release (true) once the final continuation lands and the guard drops.
+    #[tokio::test]
+    async fn edit_replace_flush_holds_barrier_and_queued_card_waits_for_it() {
+        let barrier = Arc::new(AnswerFlushBarrier::default());
+        let channel = ChannelId::new(9);
+
+        // The edit/replace path acquires the guard before the first edit when
+        // total chunks > 1, exactly as the send path does.
+        let replace_guard = barrier.begin_flush(channel);
+
+        let barrier_for_card = barrier.clone();
+        // The queued "📬" card POST path waits behind the in-flight flush.
+        let queued_card = tokio::spawn(async move {
+            barrier_for_card
+                .wait_for_flush(channel, Duration::from_millis(120), Duration::from_secs(30))
+                .await
+        });
+
+        // Simulate the edit/replace continuation loop delivering several chunks,
+        // each bumping progress (mirroring the new `note_progress` call after a
+        // successful continuation send). Span well past the inactivity grace.
+        for _ in 0..6 {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            barrier.note_progress(channel);
+        }
+        assert!(
+            !queued_card.is_finished(),
+            "queued card must wait while the edit/replace answer is still flushing chunks"
+        );
+
+        // Final continuation landed; the replace fn returns and drops its guard.
+        drop(replace_guard);
+        assert!(
+            queued_card.await.unwrap(),
+            "queued card releases with true once the edit/replace flush finishes — it lands as a trailing notice, never interleaved"
         );
     }
 }

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -2661,6 +2661,11 @@ pub(in crate::services::discord) async fn send_long_message_raw_with_reference(
 
     let chunks = split_message(text);
     let total = chunks.len();
+    // #3082 part B: hold the per-channel answer-flush barrier for the whole
+    // multi-chunk send so a queued-turn notice POST cannot interleave between
+    // chunks. The guard clears the gate on every exit path (Ok, `?`, panic).
+    let _answer_flush_guard =
+        (total > 1).then(|| shared.answer_flush_barrier.begin_flush(channel_id));
     tracing::debug!(
         target: "discord::chunker",
         path = "send_long_message_raw",
@@ -2789,6 +2794,12 @@ pub(super) async fn send_long_message_raw_with_rollback(
     if total == 0 {
         return Ok(Vec::new());
     }
+
+    // #3082 part B: same answer-flush barrier as `send_long_message_raw` so a
+    // queued-turn notice POST cannot interleave between this turn's final-answer
+    // chunks. RAII guard clears the gate on every exit path.
+    let _answer_flush_guard =
+        (total > 1).then(|| shared.answer_flush_barrier.begin_flush(channel_id));
 
     tracing::debug!(
         target: "discord::chunker",

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -3146,6 +3146,17 @@ pub(super) async fn replace_long_message_raw_with_outcome(
         return Ok(ReplaceLongMessageOutcome::SentFallbackAfterEditFailure { edit_error });
     }
 
+    // #3082 P1-2 residual: the FIRST edited chunk also delivers answer payload
+    // while the multi-chunk barrier guard is held. Mirror the continuation loop
+    // (and the two send loops) by bumping the answer-flush barrier's inactivity
+    // window here too, so a queued-card waiter's inactivity grace cannot
+    // spuriously expire between this first edit and the first continuation send.
+    // Only on the multi-chunk path (guard active) — single-chunk edits hold no
+    // guard and have no continuation to race against.
+    if total > 1 {
+        shared.answer_flush_barrier.note_progress(channel_id);
+    }
+
     if total == 1 {
         tracing::debug!(
             target: "discord::chunker",

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -2693,6 +2693,10 @@ pub(in crate::services::discord) async fn send_long_message_raw_with_reference(
                 .await;
         match send_result {
             Ok(_) => {
+                // #3082 P1-2: chunk landed — keep the answer-flush barrier's
+                // inactivity window fresh so a long answer never trips the
+                // queued-card wait while it is still making progress.
+                shared.answer_flush_barrier.note_progress(channel_id);
                 if is_last {
                     tracing::debug!(
                         target: "discord::chunker",
@@ -2828,6 +2832,10 @@ pub(super) async fn send_long_message_raw_with_rollback(
         rate_limit_wait(shared, channel_id).await;
         match super::http::send_channel_message(http, channel_id, chunk).await {
             Ok(message) => {
+                // #3082 P1-2: chunk landed — refresh the answer-flush barrier's
+                // inactivity window so a long rollback-tracked answer never
+                // trips the queued-card wait while still progressing.
+                shared.answer_flush_barrier.note_progress(channel_id);
                 sent_message_ids.push(message.id.get());
                 if let Err(error) =
                     record_replace_continuation_rollback(rollback_key, sent_message_ids.clone())
@@ -3086,6 +3094,18 @@ pub(super) async fn replace_long_message_raw_with_outcome(
         }
     }
 
+    // #3082 part B (codex P1-1): the edit/replace path is ALSO a multi-chunk
+    // send (chunk 0 edited, continuations sent). Hold the same per-channel
+    // answer-flush barrier across the whole edit+continuation send so a
+    // queued-turn "📬" notice POST cannot interleave between this answer's
+    // chunks. Acquired BEFORE the first edit await and held (RAII) across every
+    // continuation send and every cleanup/error return below — the guard clears
+    // the gate on every exit path (Ok, early `return`, `?`, panic-unwind). The
+    // fallback `send_long_message_raw_with_rollback` acquires its own guard, so
+    // we intentionally do NOT also hold one there (no double-count needed).
+    let _answer_flush_guard =
+        (total > 1).then(|| shared.answer_flush_barrier.begin_flush(channel_id));
+
     tracing::debug!(
         target: "discord::chunker",
         path = "replace_long_message_raw",
@@ -3158,6 +3178,10 @@ pub(super) async fn replace_long_message_raw_with_outcome(
         rate_limit_wait(shared, channel_id).await;
         match super::http::send_channel_message(http, channel_id, chunk).await {
             Ok(message) => {
+                // #3082 P1-2: this chunk landed — reset the answer-flush
+                // barrier's inactivity window so a long edit/replace answer
+                // that keeps making progress never trips the queued-card wait.
+                shared.answer_flush_barrier.note_progress(channel_id);
                 sent_continuation_message_ids.push(message.id.get());
                 if let Err(error) = record_replace_continuation_rollback(
                     rollback_key,

--- a/src/services/discord/gateway.rs
+++ b/src/services/discord/gateway.rs
@@ -411,6 +411,28 @@ pub(super) async fn send_intake_placeholder(
     channel_id: ChannelId,
     reference: Option<(ChannelId, MessageId)>,
 ) -> Result<MessageId, String> {
+    // #3082 part B: never let the queued-turn notice interleave between the
+    // active turn's multi-chunk final answer. Wait (bounded) for any in-flight
+    // multi-chunk answer flush on this channel to finish first, so the notice
+    // lands as a single TRAILING card after the last chunk. The wait is
+    // bounded and the barrier guard is RAII-cleared, so a stuck/errored flush
+    // can never permanently suppress the queued card — we proceed regardless
+    // once the timeout elapses.
+    if !shared
+        .answer_flush_barrier
+        .wait_for_flush(
+            channel_id,
+            super::answer_flush_barrier::ANSWER_FLUSH_WAIT_TIMEOUT,
+        )
+        .await
+    {
+        let ts = chrono::Local::now().format("%H:%M:%S");
+        tracing::warn!(
+            "  [{ts}] ⏱ INTAKE: answer-flush barrier timed out for channel {}; posting queued card anyway (no deadlock)",
+            channel_id
+        );
+    }
+
     let client = SerenityTurnOutboundClient { http, shared };
     let mut msg = gateway_outbound_message(channel_id, "...");
     if let Some((reference_channel, reference_message)) = reference {

--- a/src/services/discord/gateway.rs
+++ b/src/services/discord/gateway.rs
@@ -405,24 +405,33 @@ pub(super) async fn drain_merged_queued_placeholders(
     to_delete
 }
 
-pub(super) async fn send_intake_placeholder(
-    http: Arc<serenity::Http>,
-    shared: Arc<SharedData>,
+/// #3082 part B (codex P2-3): the answer-flush wait gate for intake
+/// placeholders, factored out so the queued-only gating is unit-testable
+/// without a live Discord HTTP client.
+///
+/// Only the queued-turn "📬" notice path waits behind an in-flight multi-chunk
+/// answer flush — so the notice lands as a single TRAILING card after the last
+/// chunk, never interleaved between answer chunks. Active-turn placeholders (a
+/// turn starting NOW, or a TUI idle-response card) pass `is_queued_notice =
+/// false` and return immediately, never delayed behind a flush.
+///
+/// The wait is bounded (progress-aware inactivity grace + absolute hard
+/// ceiling) and the barrier guard is RAII-cleared, so a stuck/errored flush can
+/// never permanently suppress the queued card — we proceed regardless once it
+/// elapses (logged, no deadlock).
+async fn await_answer_flush_if_queued_notice(
+    barrier: &Arc<super::answer_flush_barrier::AnswerFlushBarrier>,
     channel_id: ChannelId,
-    reference: Option<(ChannelId, MessageId)>,
-) -> Result<MessageId, String> {
-    // #3082 part B: never let the queued-turn notice interleave between the
-    // active turn's multi-chunk final answer. Wait (bounded) for any in-flight
-    // multi-chunk answer flush on this channel to finish first, so the notice
-    // lands as a single TRAILING card after the last chunk. The wait is
-    // bounded and the barrier guard is RAII-cleared, so a stuck/errored flush
-    // can never permanently suppress the queued card — we proceed regardless
-    // once the timeout elapses.
-    if !shared
-        .answer_flush_barrier
+    is_queued_notice: bool,
+) {
+    if !is_queued_notice {
+        return;
+    }
+    if !barrier
         .wait_for_flush(
             channel_id,
             super::answer_flush_barrier::ANSWER_FLUSH_WAIT_TIMEOUT,
+            super::answer_flush_barrier::ANSWER_FLUSH_WAIT_HARD_CEILING,
         )
         .await
     {
@@ -432,6 +441,24 @@ pub(super) async fn send_intake_placeholder(
             channel_id
         );
     }
+}
+
+pub(super) async fn send_intake_placeholder(
+    http: Arc<serenity::Http>,
+    shared: Arc<SharedData>,
+    channel_id: ChannelId,
+    reference: Option<(ChannelId, MessageId)>,
+    // #3082 part B (codex P2-3): only the queued-turn notice path must wait on
+    // the answer-flush barrier. Active-turn placeholders (a turn starting NOW,
+    // or a TUI idle-response card) are NOT a trailing "📬 queued" notice and
+    // must NOT be delayed behind a multi-chunk answer flush — set this `false`
+    // for those callers.
+    is_queued_notice: bool,
+) -> Result<MessageId, String> {
+    // codex P2-3: gate the answer-flush wait to the queued-notice path only;
+    // unrelated active-turn placeholders skip the barrier entirely.
+    await_answer_flush_if_queued_notice(&shared.answer_flush_barrier, channel_id, is_queued_notice)
+        .await;
 
     let client = SerenityTurnOutboundClient { http, shared };
     let mut msg = gateway_outbound_message(channel_id, "...");
@@ -1042,5 +1069,78 @@ mod tests {
                 assert_eq!(shared.queued_placeholders.len(), 1);
             });
         });
+    }
+}
+
+/// #3082 part B (codex P2-3): gate-behavior tests for the answer-flush wait.
+/// These do not need a live Discord HTTP client (they exercise only the
+/// `await_answer_flush_if_queued_notice` seam against a real barrier), so they
+/// are compiled unconditionally rather than behind `legacy-sqlite-tests`.
+#[cfg(test)]
+mod answer_flush_gate_tests {
+    use super::await_answer_flush_if_queued_notice;
+    use crate::services::discord::answer_flush_barrier::AnswerFlushBarrier;
+    use poise::serenity_prelude::ChannelId;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    /// P2-3: a non-queued active-turn placeholder must NOT wait on the barrier,
+    /// even while a multi-chunk answer flush is in flight on the same channel.
+    #[tokio::test]
+    async fn active_turn_placeholder_does_not_wait_on_barrier() {
+        let barrier = Arc::new(AnswerFlushBarrier::default());
+        let channel = ChannelId::new(101);
+        // A multi-chunk answer flush is in flight (guard held) for this channel.
+        let _flush_guard = barrier.begin_flush(channel);
+
+        // An ACTIVE-turn placeholder (is_queued_notice = false) must return
+        // immediately, never blocking behind the in-flight flush.
+        let start = Instant::now();
+        await_answer_flush_if_queued_notice(&barrier, channel, false).await;
+        assert!(
+            start.elapsed() < Duration::from_millis(150),
+            "an active-turn placeholder must NOT wait on the answer-flush barrier"
+        );
+    }
+
+    /// P2-3 (counterpart): the queued-notice path DOES wait behind an in-flight
+    /// flush and only proceeds once the flush ends — proving the gate routes the
+    /// two callers differently.
+    #[tokio::test]
+    async fn queued_notice_placeholder_waits_for_flush() {
+        let barrier = Arc::new(AnswerFlushBarrier::default());
+        let channel = ChannelId::new(102);
+        let flush_guard = barrier.begin_flush(channel);
+
+        let barrier_for_card = barrier.clone();
+        let card = tokio::spawn(async move {
+            // is_queued_notice = true — must block behind the flush.
+            await_answer_flush_if_queued_notice(&barrier_for_card, channel, true).await;
+        });
+
+        // Hold the flush briefly; the queued notice must still be waiting.
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        assert!(
+            !card.is_finished(),
+            "the queued-notice placeholder must wait while the flush is in flight"
+        );
+
+        // Flush ends — the queued notice proceeds.
+        drop(flush_guard);
+        card.await.expect("queued-notice wait task must complete");
+    }
+
+    /// P2-3: with no flush in flight, even the queued-notice path returns
+    /// immediately (the wait is only paid when there is something to wait for).
+    #[tokio::test]
+    async fn queued_notice_returns_immediately_when_no_flush() {
+        let barrier = Arc::new(AnswerFlushBarrier::default());
+        let channel = ChannelId::new(103);
+        let start = Instant::now();
+        await_answer_flush_if_queued_notice(&barrier, channel, true).await;
+        assert!(
+            start.elapsed() < Duration::from_millis(150),
+            "with no flush in flight the queued-notice path must not block"
+        );
     }
 }

--- a/src/services/discord/health.rs
+++ b/src/services/discord/health.rs
@@ -428,6 +428,9 @@ impl TestHealthHarness {
             queued_placeholders: dashmap::DashMap::new(),
             queue_exit_placeholder_clears: dashmap::DashMap::new(),
             queued_placeholders_persist_locks: dashmap::DashMap::new(),
+            answer_flush_barrier: std::sync::Arc::new(
+                super::answer_flush_barrier::AnswerFlushBarrier::default(),
+            ),
             recovering_channels: dashmap::DashMap::new(),
             shutting_down: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             finalizing_turns: Arc::new(std::sync::atomic::AtomicUsize::new(0)),

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -1,6 +1,7 @@
 mod adk_session;
 pub(crate) mod agent_handoff;
 pub(crate) mod agentdesk_config;
+mod answer_flush_barrier;
 mod commands;
 mod discord_io;
 pub(crate) mod formatting;
@@ -1609,6 +1610,17 @@ pub(crate) struct SharedData {
     /// without blocking the runtime worker.
     pub(in crate::services::discord) queued_placeholders_persist_locks:
         dashmap::DashMap<ChannelId, Arc<tokio::sync::Mutex<()>>>,
+    /// #3082 part B — per-channel answer-flush barrier. Set while a multi-chunk
+    /// final answer is being delivered (>1 Discord chunk) by
+    /// `send_long_message_raw*`, so a queued-turn notice POST
+    /// (`send_intake_placeholder`) does NOT interleave between the answer's
+    /// chunks. The queued-card POST path waits on this gate with a BOUNDED
+    /// timeout and proceeds regardless once it elapses, so a stuck/errored
+    /// flush can never permanently suppress the queued card. The gate is
+    /// cleared by an RAII guard on every exit path (success, error, panic) so
+    /// it never strands set.
+    pub(in crate::services::discord) answer_flush_barrier:
+        Arc<answer_flush_barrier::AnswerFlushBarrier>,
     /// Per-channel in-flight turn recovery marker (restart resume in progress)
     /// Value is the Instant when recovery started, used for stale-recovery timeout.
     pub(super) recovering_channels: dashmap::DashMap<ChannelId, std::time::Instant>,
@@ -2409,6 +2421,7 @@ pub(super) fn make_shared_data_for_tests_with_storage(
         queued_placeholders: dashmap::DashMap::new(),
         queue_exit_placeholder_clears: dashmap::DashMap::new(),
         queued_placeholders_persist_locks: dashmap::DashMap::new(),
+        answer_flush_barrier: Arc::new(answer_flush_barrier::AnswerFlushBarrier::default()),
         recovering_channels: dashmap::DashMap::new(),
         shutting_down: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         finalizing_turns: Arc::new(std::sync::atomic::AtomicUsize::new(0)),

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -994,6 +994,177 @@ async fn reuse_merged_queued_placeholder(
     MergedPlaceholderReuse::Handled
 }
 
+/// #3082 part A — pure decision helper: of the existing queued cards on a
+/// channel (`(owner_msg_id, placeholder_msg_id)` pairs), pick the single card to
+/// re-key onto `new_head` so the channel keeps AT MOST ONE visible queued card.
+///
+/// * Never reuse a card already owned by `new_head` (it has no card yet / would
+///   be a self-reuse).
+/// * Prefer a card whose owner is still present in the live queue (`queued_ids`)
+///   — that is the canonical waiting card; fall back to any other channel card
+///   (e.g. a stale owner whose intervention already drained but whose card has
+///   not been cleaned up yet) so we coalesce rather than stack.
+/// * `None` when there is no other channel card to reuse → caller posts fresh.
+fn pick_channel_queued_placeholder(
+    channel_cards: &[(serenity::MessageId, serenity::MessageId)],
+    new_head: serenity::MessageId,
+    queued_ids: &std::collections::HashSet<serenity::MessageId>,
+) -> Option<(serenity::MessageId, serenity::MessageId)> {
+    let mut fallback: Option<(serenity::MessageId, serenity::MessageId)> = None;
+    for &(owner, placeholder) in channel_cards {
+        if owner == new_head {
+            continue;
+        }
+        if queued_ids.contains(&owner) {
+            return Some((owner, placeholder));
+        }
+        fallback.get_or_insert((owner, placeholder));
+    }
+    fallback
+}
+
+/// #3082 part A — generalize "AT MOST ONE queued card per channel/active turn".
+///
+/// `reuse_merged_queued_placeholder` only collapses *merge-eligible*
+/// follow-ups (same author, no reply boundary, within the merge rules). Messages
+/// that skip merge — a different author, a reply-boundary message, or an
+/// identical re-send outside the 10s dedup window — each used to POST their own
+/// fresh `📬` card, leaving multiple waiting cards in the timeline. This helper
+/// closes that gap: before POSTing a fresh card, reuse ANY existing queued card
+/// already owned by this channel's active turn, re-keying it onto the new head
+/// id and re-rendering it with the latest request text.
+///
+/// Returns:
+/// * `Some(true)`  — an existing card was successfully re-keyed/re-rendered onto
+///   `user_msg_id`. Caller must NOT post a fresh card.
+/// * `Some(false)` — we found a card and tried to reuse it but the re-render
+///   failed; the mapping was rolled back. Caller should fall through to the
+///   fresh POST path (which deletes/replaces as needed).
+/// * `None`        — there is no existing queued card to reuse on this channel.
+///   Caller posts a fresh card as before.
+async fn reuse_any_queued_placeholder_for_channel(
+    ctx: &serenity::Context,
+    data: &Data,
+    channel_id: serenity::ChannelId,
+    user_msg_id: serenity::MessageId,
+    text: &str,
+) -> Option<bool> {
+    // Serialize against every other `queued_placeholders` mutation on this
+    // channel (dispatch hand-off, queue-exit drain, merged reuse) — same TOCTOU
+    // guard as `reuse_merged_queued_placeholder`.
+    let persist_lock = data.shared.queued_placeholders_persist_lock(channel_id);
+    let persist_guard = persist_lock.lock_owned().await;
+
+    let snapshot = mailbox_snapshot(&data.shared, channel_id).await;
+    // Only reuse while this message is genuinely still queued behind an active
+    // turn. If it already started, the dispatch hand-off owns its card; if it is
+    // no longer queued, there is nothing to represent.
+    let still_queued = snapshot.intervention_queue.iter().any(|intervention| {
+        intervention.message_id == user_msg_id
+            || intervention.source_message_ids.contains(&user_msg_id)
+    });
+    if snapshot.active_user_message_id == Some(user_msg_id) || !still_queued {
+        return None;
+    }
+
+    // Find ANY existing queued card on this channel that does not already belong
+    // to `user_msg_id`. Prefer the card owned by a message still present in the
+    // queue (the live waiting head) so we re-key the canonical card; fall back to
+    // any other channel-scoped card otherwise. Either way the invariant is "one
+    // visible card", so reusing whichever exists is correct.
+    let queued_ids: std::collections::HashSet<serenity::MessageId> = snapshot
+        .intervention_queue
+        .iter()
+        .flat_map(|intervention| {
+            std::iter::once(intervention.message_id)
+                .chain(intervention.source_message_ids.iter().copied())
+        })
+        .collect();
+
+    let channel_cards: Vec<(serenity::MessageId, serenity::MessageId)> = data
+        .shared
+        .queued_placeholders
+        .iter()
+        .filter_map(|entry| {
+            let (ch, owner) = *entry.key();
+            (ch == channel_id).then_some((owner, *entry.value()))
+        })
+        .collect();
+
+    let Some((prior_owner, placeholder_msg_id)) =
+        pick_channel_queued_placeholder(&channel_cards, user_msg_id, &queued_ids)
+    else {
+        return None;
+    };
+
+    // Re-key the single card onto this message id so the dispatch hand-off /
+    // queue-exit drain track exactly one card per active turn.
+    data.shared
+        .remove_queued_placeholder_locked(channel_id, prior_owner);
+    data.shared
+        .insert_queued_placeholder_locked(channel_id, user_msg_id, placeholder_msg_id);
+
+    let gateway = super::super::gateway::DiscordGateway::new(
+        ctx.http.clone(),
+        data.shared.clone(),
+        data.provider.clone(),
+        None,
+    );
+    let key = super::super::placeholder_controller::PlaceholderKey {
+        provider: data.provider.clone(),
+        channel_id,
+        message_id: placeholder_msg_id,
+    };
+    let queued_input = super::super::placeholder_controller::PlaceholderActiveInput {
+        reason: super::super::formatting::MonitorHandoffReason::Queued,
+        started_at_unix: chrono::Utc::now().timestamp(),
+        tool_summary: None,
+        command_summary: None,
+        reason_detail: None,
+        context_line: None,
+        request_line: Some(text.to_string()),
+        progress_line: None,
+    };
+    let outcome = data
+        .shared
+        .placeholder_controller
+        .ensure_queued(&gateway, key, queued_input)
+        .await;
+
+    if !matches!(
+        outcome,
+        super::super::placeholder_controller::PlaceholderControllerOutcome::Edited
+            | super::super::placeholder_controller::PlaceholderControllerOutcome::Coalesced
+    ) {
+        // Render failed — roll back the re-key so the prior owner keeps the card,
+        // and let the caller post a fresh one (which handles deletion/cleanup).
+        data.shared
+            .remove_queued_placeholder_locked(channel_id, user_msg_id);
+        data.shared
+            .insert_queued_placeholder_locked(channel_id, prior_owner, placeholder_msg_id);
+        drop(persist_guard);
+        let ts = chrono::Local::now().format("%H:%M:%S");
+        tracing::warn!(
+            "  [{ts}] ⚠ QUEUE-ACK: channel-wide reuse of placeholder {} for message {} in channel {} failed to render ({:?}); kept prior mapping, falling back to fresh card",
+            placeholder_msg_id,
+            user_msg_id,
+            channel_id,
+            outcome,
+        );
+        return Some(false);
+    }
+    drop(persist_guard);
+
+    let ts = chrono::Local::now().format("%H:%M:%S");
+    tracing::info!(
+        "  [{ts}] ➕ QUEUE-ACK: coalesced queued message {} into existing channel placeholder {} in channel {} (one card per active turn)",
+        user_msg_id,
+        placeholder_msg_id,
+        channel_id
+    );
+    Some(true)
+}
+
 async fn render_visible_queued_ack(
     ctx: &serenity::Context,
     data: &Data,
@@ -1013,6 +1184,17 @@ async fn render_visible_queued_ack(
             MergedPlaceholderReuse::Handled => return true,
             MergedPlaceholderReuse::PostFresh => {}
         }
+    }
+    // #3082 part A: even when this message did NOT merge (different author, a
+    // reply-boundary message, or an identical re-send outside the dedup window),
+    // enforce a single visible queued card per active turn by reusing any card
+    // already owned by this channel's active turn instead of POSTing a second
+    // one. `Some(true)` => handled (no fresh card); `Some(false)`/`None` => fall
+    // through to the fresh POST below.
+    if let Some(true) =
+        reuse_any_queued_placeholder_for_channel(ctx, data, channel_id, user_msg_id, text).await
+    {
+        return true;
     }
     let post_result = super::super::gateway::send_intake_placeholder(
         ctx.http.clone(),
@@ -3097,6 +3279,136 @@ mod merged_placeholder_reuse_pure_tests {
         let picked = pick_reusable_merged_placeholder(&[a, b], b, |id| map.get(&id).copied());
 
         assert_eq!(picked, None);
+    }
+}
+
+/// #3082 part A pure decision tests for `pick_channel_queued_placeholder` — the
+/// "one card per active turn" coalescing that closes the gaps merge cannot
+/// (different author, reply-boundary, identical re-send outside the dedup
+/// window). These don't need a live serenity ctx.
+#[cfg(test)]
+mod channel_queued_placeholder_pure_tests {
+    use super::*;
+    use poise::serenity_prelude::MessageId;
+    use std::collections::HashSet;
+
+    fn ids(items: &[MessageId]) -> HashSet<MessageId> {
+        items.iter().copied().collect()
+    }
+
+    #[test]
+    fn different_author_reuses_existing_channel_card() {
+        // Author A queued first (card CA, still in queue). Author B's message —
+        // which does NOT merge with A — must reuse CA, not POST a second card.
+        let a = MessageId::new(900_000_000_000_001);
+        let b = MessageId::new(900_000_000_000_002);
+        let card_a = MessageId::new(710_000_000_000_001);
+        let cards = vec![(a, card_a)];
+        let queued = ids(&[a, b]);
+
+        let picked = pick_channel_queued_placeholder(&cards, b, &queued);
+        assert_eq!(picked, Some((a, card_a)), "B must coalesce onto A's card");
+    }
+
+    #[test]
+    fn reply_boundary_message_reuses_existing_card() {
+        // Same author, but the new message has a reply boundary so merge was
+        // skipped. Still must coalesce onto the single channel card.
+        let a = MessageId::new(900_000_000_000_010);
+        let b = MessageId::new(900_000_000_000_011);
+        let card_a = MessageId::new(710_000_000_000_010);
+        let cards = vec![(a, card_a)];
+        let queued = ids(&[a, b]);
+
+        let picked = pick_channel_queued_placeholder(&cards, b, &queued);
+        assert_eq!(picked, Some((a, card_a)));
+    }
+
+    #[test]
+    fn identical_resend_outside_dedup_window_reuses_card() {
+        // The identical-resend dedup only fires within 10s; a later identical
+        // re-send is enqueued as a new head but must still coalesce.
+        let a = MessageId::new(900_000_000_000_020);
+        let b = MessageId::new(900_000_000_000_021);
+        let card_a = MessageId::new(710_000_000_000_020);
+        let cards = vec![(a, card_a)];
+        let queued = ids(&[a, b]);
+
+        let picked = pick_channel_queued_placeholder(&cards, b, &queued);
+        assert_eq!(picked, Some((a, card_a)));
+    }
+
+    #[test]
+    fn prefers_live_queue_owner_over_stale_card() {
+        // Two cards exist on the channel: a stale one (owner drained) and the
+        // live waiting head. The live head's card must win so we re-key the
+        // canonical card; the stale one is left for normal cleanup.
+        let stale = MessageId::new(900_000_000_000_030);
+        let live = MessageId::new(900_000_000_000_031);
+        let new = MessageId::new(900_000_000_000_032);
+        let card_stale = MessageId::new(710_000_000_000_030);
+        let card_live = MessageId::new(710_000_000_000_031);
+        // Stale first so the loop would hit it before the live one — preference
+        // logic must still return the live card.
+        let cards = vec![(stale, card_stale), (live, card_live)];
+        let queued = ids(&[live, new]);
+
+        let picked = pick_channel_queued_placeholder(&cards, new, &queued);
+        assert_eq!(picked, Some((live, card_live)));
+    }
+
+    #[test]
+    fn falls_back_to_any_card_when_no_live_owner() {
+        // No card owner is still in the queue (all drained) but a visible card
+        // lingers — coalesce onto it rather than stacking a new one.
+        let stale = MessageId::new(900_000_000_000_040);
+        let new = MessageId::new(900_000_000_000_041);
+        let card_stale = MessageId::new(710_000_000_000_040);
+        let cards = vec![(stale, card_stale)];
+        let queued = ids(&[new]);
+
+        let picked = pick_channel_queued_placeholder(&cards, new, &queued);
+        assert_eq!(picked, Some((stale, card_stale)));
+    }
+
+    #[test]
+    fn no_existing_card_posts_fresh() {
+        // Nothing on the channel yet → None → caller posts the first card.
+        let new = MessageId::new(900_000_000_000_050);
+        let cards: Vec<(MessageId, MessageId)> = Vec::new();
+        let queued = ids(&[new]);
+
+        assert_eq!(pick_channel_queued_placeholder(&cards, new, &queued), None);
+    }
+
+    #[test]
+    fn own_card_is_never_self_reused() {
+        // Defensive: a card already keyed to the new head must be ignored so we
+        // never "reuse" the card we are about to create for it.
+        let new = MessageId::new(900_000_000_000_060);
+        let card_new = MessageId::new(710_000_000_000_060);
+        let cards = vec![(new, card_new)];
+        let queued = ids(&[new]);
+
+        assert_eq!(pick_channel_queued_placeholder(&cards, new, &queued), None);
+    }
+
+    #[test]
+    fn three_queued_messages_collapse_to_one_card() {
+        // Acceptance: queueing 3 messages leaves exactly one visible card.
+        // m1 posts CA. m2 reuses CA (re-keyed to m2). m3 reuses it again.
+        let m1 = MessageId::new(900_000_000_000_070);
+        let m2 = MessageId::new(900_000_000_000_071);
+        let m3 = MessageId::new(900_000_000_000_072);
+        let card = MessageId::new(710_000_000_000_070);
+
+        // m2: only m1 owns the card.
+        let picked_2 = pick_channel_queued_placeholder(&[(m1, card)], m2, &ids(&[m1, m2]));
+        assert_eq!(picked_2, Some((m1, card)), "m2 coalesces onto m1's card");
+
+        // After re-key, the card is owned by m2; m3 coalesces onto it.
+        let picked_3 = pick_channel_queued_placeholder(&[(m2, card)], m3, &ids(&[m1, m2, m3]));
+        assert_eq!(picked_3, Some((m2, card)), "m3 coalesces onto the one card");
     }
 }
 

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -1201,6 +1201,10 @@ async fn render_visible_queued_ack(
         data.shared.clone(),
         channel_id,
         None,
+        // #3082 P2-3: this IS the queued-turn "📬" notice — wait behind any
+        // in-flight multi-chunk answer flush so the card lands as a trailing
+        // notice, never interleaved between answer chunks.
+        true,
     )
     .await;
     let placeholder_msg_id = match post_result {

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -1793,6 +1793,10 @@ pub(in crate::services::discord) async fn handle_text_message(
                 } else {
                     None
                 },
+                // #3082 P2-3: this message lost the start-turn race and is now
+                // QUEUED — its "📬" card is a trailing notice that must wait
+                // behind any in-flight multi-chunk answer flush.
+                true,
             )
             .await;
 
@@ -2269,6 +2273,11 @@ pub(in crate::services::discord) async fn handle_text_message(
             } else {
                 None
             },
+            // #3082 P2-3: the active turn started cleanly and we are POSTing its
+            // OWN fresh placeholder (not a queued "📬" notice). It must NOT wait
+            // behind a multi-chunk answer flush — this is the turn doing the
+            // answering, gating it would self-deadlock the active turn's card.
+            false,
         )
         .await
         {

--- a/src/services/discord/runtime_bootstrap.rs
+++ b/src/services/discord/runtime_bootstrap.rs
@@ -1053,6 +1053,9 @@ pub(crate) async fn run_bot(token: &str, provider: ProviderKind, context: RunBot
             map
         },
         queued_placeholders_persist_locks: dashmap::DashMap::new(),
+        answer_flush_barrier: std::sync::Arc::new(
+            super::answer_flush_barrier::AnswerFlushBarrier::default(),
+        ),
         recovering_channels: dashmap::DashMap::new(),
         shutting_down: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         finalizing_turns: Arc::new(std::sync::atomic::AtomicUsize::new(0)),

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -2870,6 +2870,10 @@ async fn relay_tui_idle_response_through_bridge(
         shared.clone(),
         channel_id,
         reference,
+        // #3082 P2-3: a TUI idle-response placeholder is an ACTIVE-turn card,
+        // not a queued "📬" notice — it must not wait on the answer-flush
+        // barrier.
+        false,
     )
     .await?;
     let user_msg_id = anchor

--- a/src/services/discord/voice_barge_in.rs
+++ b/src/services/discord/voice_barge_in.rs
@@ -4782,6 +4782,9 @@ mod tests {
             queued_placeholders: dashmap::DashMap::new(),
             queue_exit_placeholder_clears: dashmap::DashMap::new(),
             queued_placeholders_persist_locks: dashmap::DashMap::new(),
+            answer_flush_barrier: std::sync::Arc::new(
+                super::super::answer_flush_barrier::AnswerFlushBarrier::default(),
+            ),
             recovering_channels: dashmap::DashMap::new(),
             shutting_down: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             finalizing_turns: Arc::new(std::sync::atomic::AtomicUsize::new(0)),


### PR DESCRIPTION
## Root cause

When user messages are queued while a turn is active, AgentDesk could leave **multiple** `📬 메시지 대기 중` cards in the timeline, and a queued notice could be inserted **between** the chunks of the active turn's multi-chunk final answer:

```text
answer chunk 1
📬 메시지 대기 중   <- interleaved, wrong order
answer chunk 2
```

Two independent problems:

**A — coalescing gap.** `reuse_merged_queued_placeholder` (intake_gate.rs) only collapsed *merge-eligible* follow-ups (same author, no reply boundary, within the merge rules). Messages that skip merge — a **different author**, a **reply-boundary** message, or an **identical re-send outside the 10s dedup window** — each POSTed their own fresh `📬` card, leaving multiple waiting cards.

**B — chunk contiguity.** Multi-chunk answers (>2000 chars) are delivered as several Discord messages with ~500ms gaps via `send_long_message_raw*`. Nothing prevented a queued-card POST from landing between chunks.

## Fix

**Part A — at most one card per (channel, active turn).**
New pure decision helper `pick_channel_queued_placeholder` + `reuse_any_queued_placeholder_for_channel` (intake_gate.rs). Before POSTing a fresh card, `render_visible_queued_ack` now reuses ANY existing queued card already owned by the channel's active turn — re-keying it onto the new head id and re-rendering with the latest request text. This closes the merge gaps (different author / reply-boundary / identical-resend-outside-window all coalesce onto the single card). Render failures roll the re-key back and fall through to the prior fresh-POST path, so behavior degrades gracefully.

**Part B — answer-flush barrier (`QueuedNotice` ordered after final chunk).**
New per-channel `AnswerFlushBarrier` (`answer_flush_barrier.rs`). The multi-chunk send loops in `send_long_message_raw` / `send_long_message_raw_with_rollback` hold an RAII guard while delivering (>1 chunk only). The queued-card POST path (`send_intake_placeholder`) waits on the barrier before posting, so the notice always lands as a **single trailing card after the last chunk** rather than interleaving.

## Barrier safety (no deadlock / no permanent suppression)

- The gate is set **only** via an RAII guard whose `Drop` decrements the per-channel count, so **every** exit path of the chunk loop (Ok, `?`/Err, panic-unwind) clears it — it can never strand set.
- The waiter uses a **hard bounded timeout (8s)** and proceeds regardless once it elapses, so a stuck/errored flush can never permanently suppress the queued card.
- A count (not a bool) tolerates overlapping multi-chunk sends on the same channel.
- The barrier is purely advisory in the queued-card path; the relay chunk-delivery / finalizer path is untouched apart from the cheap RAII guard, so the relay cluster is not destabilized.

## Tests

- `answer_flush_barrier`: no-flush returns immediately; guard clears gate on drop; waiter unblocks when flush ends; **waiter times out (false) when a flush never ends** (cleared-on-terminal safety — queued card still posts); nested flushes hold until last drop.
- `channel_queued_placeholder_pure_tests`: different-author / reply-boundary / identical-resend-outside-window each reuse the one card; prefers live-queue owner over stale card; falls back to any card; never self-reuses; **3 queued messages collapse to one card**.

## Verification

- `cargo check --workspace --all-features --all-targets` — clean
- `cargo fmt --all --check` — clean
- targeted `cargo test --lib` for intake_gate (22), gateway (4), answer_flush_barrier (5), channel-placeholder + merged-placeholder pure tests — all pass
- `./scripts/ci-script-checks.sh` — exit 0 (change-surfaces.md LoC freeze synced for health.rs/formatting.rs/runtime_bootstrap.rs/mod.rs)

Note: two pre-existing test failures (`turn_orchestrator::*persistence*` env-races requiring `--test-threads=1`, and `formatting::*monitor_handoff_placeholder*` copy-snapshot asserts) reproduce identically on pristine `origin/main` and are unrelated to this change.

Closes #3082

🤖 Generated with [Claude Code](https://claude.com/claude-code)