### PR TITLE
chore: gitignore routines/ as per-user config space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ __pycache__/
 
 # Transient ops playbooks (campaign prompts, incident runbooks)
 /docs/ops/
+
+# Per-user routine scripts — individual user config space (#3081 follow-up; keeps already-tracked shared routines, ignores new local ones)
+routines/


### PR DESCRIPTION
## 배경
`routines/`는 개별 사용자 설정 공간입니다. 로컬 per-user 루틴 스크립트(`dependency-update-watcher.js`, `memento-scope-audit.js`)가 worktree를 dirty 상태로 만들어 clean 릴리스 배포(`deploy-release.sh`의 dirty-worktree 거부)를 막았습니다.

## 변경
`.gitignore`에 `routines/` 추가 — untracked per-user 루틴은 무시. 이미 tracked인 공유 루틴 22개(가족 브리핑 등)는 그대로 유지(gitignore는 tracked를 untrack하지 않음). 새 공유 루틴이 필요하면 `git add -f`로 의도적으로 추가.

검증: `git check-ignore`로 2개 untracked 무시 확인, tracked 22개 불변 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)