### PR TITLE
fix(claude): apply context_compact_percent_claude to CLAUDE_AUTOCOMPACT_PCT_OVERRIDE (#3097)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -127,7 +127,7 @@
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset; split loop helpers
     further before adding behavior).
-  - `src/services/discord/tui_prompt_relay.rs` (3241 lines; SSH-direct TUI
+  - `src/services/discord/tui_prompt_relay.rs` (3247 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +4 from #3082 queued-only answer-flush gate
     (`is_queued_notice = false` for the TUI idle-response placeholder)).

--- a/src/services/discord/adk_session.rs
+++ b/src/services/discord/adk_session.rs
@@ -899,6 +899,49 @@ mod context_usage_tests {
     }
 }
 
+#[cfg(test)]
+mod compact_threshold_tests {
+    use super::ContextThresholds;
+    use crate::services::provider::ProviderKind;
+
+    /// #3097: a configured `context_compact_percent_claude` value must be the
+    /// value `compact_pct_for(Claude)` returns — this is exactly the number that
+    /// flows into the claude spawn's `compact_percent` and thus sets
+    /// `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` (the spawn only sets the env var when
+    /// the value is `> 0`).
+    #[test]
+    fn compact_pct_for_claude_uses_claude_specific_override() {
+        let thresholds = ContextThresholds {
+            compact_pct: 80,
+            compact_pct_codex: 100,
+            compact_pct_claude: 60,
+            context_window: 1_000_000,
+        };
+        // Claude takes its own override, distinct from the generic value.
+        assert_eq!(thresholds.compact_pct_for(&ProviderKind::Claude), 60);
+        // Codex still uses its own override.
+        assert_eq!(thresholds.compact_pct_for(&ProviderKind::Codex), 100);
+        // Other providers fall back to the generic value.
+        assert_eq!(thresholds.compact_pct_for(&ProviderKind::Gemini), 80);
+        // A configured Claude value is > 0, so the override env var would be set.
+        assert!(thresholds.compact_pct_for(&ProviderKind::Claude) > 0);
+    }
+
+    /// When only the generic threshold is configured, Claude inherits it.
+    /// `fetch_context_thresholds` defaults `compact_pct_claude` to the generic
+    /// `compact_pct`, so this mirrors the runtime fallback behaviour.
+    #[test]
+    fn compact_pct_for_claude_falls_back_to_generic() {
+        let thresholds = ContextThresholds {
+            compact_pct: 55,
+            compact_pct_codex: 100,
+            compact_pct_claude: 55,
+            context_window: 1_000_000,
+        };
+        assert_eq!(thresholds.compact_pct_for(&ProviderKind::Claude), 55);
+    }
+}
+
 /// Context window management thresholds.
 /// Single source of truth used by Rust turn-end compact logic.
 /// Provider-specific overrides: `context_compact_percent_codex`, `context_compact_percent_claude`, etc.
@@ -906,6 +949,9 @@ pub(super) struct ContextThresholds {
     pub compact_pct: u64,
     /// Provider-specific override (if set). Falls back to compact_pct.
     pub compact_pct_codex: u64,
+    /// Claude-specific override (if set). Falls back to compact_pct.
+    /// Flows to `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` on the claude spawn (#3097).
+    pub compact_pct_claude: u64,
     pub context_window: u64,
 }
 
@@ -914,6 +960,9 @@ impl Default for ContextThresholds {
         Self {
             compact_pct: 60,
             compact_pct_codex: 100,
+            // Default to the generic compact_pct default so Claude inherits the
+            // shared threshold unless `context_compact_percent_claude` is set.
+            compact_pct_claude: 60,
             context_window: 1_000_000,
         }
     }
@@ -924,6 +973,7 @@ impl ContextThresholds {
     pub fn compact_pct_for(&self, provider: &crate::services::provider::ProviderKind) -> u64 {
         match provider {
             crate::services::provider::ProviderKind::Codex => self.compact_pct_codex,
+            crate::services::provider::ProviderKind::Claude => self.compact_pct_claude,
             _ => self.compact_pct,
         }
     }
@@ -954,10 +1004,16 @@ pub(super) async fn fetch_context_thresholds(_api_port: u16) -> ContextThreshold
     let compact_pct = find_u64("context_compact_percent").unwrap_or(defaults.compact_pct);
     let compact_pct_codex =
         find_u64("context_compact_percent_codex").unwrap_or(defaults.compact_pct_codex);
+    // #3097: read the Claude-specific override. Fall back to the *generic*
+    // `compact_pct` (not a fixed default) so a user who only sets the generic
+    // value still applies it to Claude, while `context_compact_percent_claude`
+    // takes precedence when present.
+    let compact_pct_claude = find_u64("context_compact_percent_claude").unwrap_or(compact_pct);
 
     ContextThresholds {
         compact_pct,
         compact_pct_codex,
+        compact_pct_claude,
         context_window: defaults.context_window,
     }
 }

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -2853,6 +2853,12 @@ async fn relay_tui_idle_response_through_bridge(
             provider.as_str()
         ));
     };
+    // #3097: resolve the provider-specific compact threshold so the status
+    // panel reflects the configured value (e.g. `context_compact_percent_claude`)
+    // instead of the hardcoded 0 it used previously.
+    let context_compact_percent = super::adk_session::fetch_context_thresholds(shared.api_port)
+        .await
+        .compact_pct_for(&provider);
     let anchor = prompt_anchor_for_response_after_wait(
         provider.as_str(),
         tmux_session_name,
@@ -2912,7 +2918,7 @@ async fn relay_tui_idle_response_through_bridge(
         dispatch_kind: None,
         memory_recall_usage: TokenUsage::default(),
         context_window_tokens: 0,
-        context_compact_percent: 0,
+        context_compact_percent,
         current_msg_id: Some(current_msg_id),
         response_sent_offset: 0,
         full_response: String::new(),


### PR DESCRIPTION
## Root cause
The `context_compact_percent_claude` setting is defined in `config.rs`/`settings.rs` and exposed in the UI, but was **never read at runtime**:
- `ContextThresholds` (adk_session.rs ~905) had no `compact_pct_claude` field.
- `fetch_context_thresholds` read only `context_compact_percent` (generic) and `context_compact_percent_codex`.
- `compact_pct_for(provider)` special-cased only Codex; Claude fell through to the generic `compact_pct`.

So a user's `context_compact_percent_claude=60` was dropped and `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` stayed at the Claude Code default (~83%). Additionally `tui_prompt_relay.rs` hardcoded `context_compact_percent: 0`.

## Fix (wiring)
- **adk_session.rs**: add `compact_pct_claude` to `ContextThresholds` (Default 60, matching the generic `compact_pct` default). `fetch_context_thresholds` now reads `context_compact_percent_claude`, falling back to the **generic `compact_pct`** (not a fixed default) so setting only the generic value still applies to Claude, while the Claude-specific key overrides it. `compact_pct_for(ProviderKind::Claude)` => `compact_pct_claude`.
- **intake_turn.rs / headless_turn.rs**: already build `compact_percent_for_claude` from `compact_pct_for(&provider)` — now they propagate the real Claude value into the claude spawn's `compact_percent`, which sets `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` (the intentional `p > 0` filter is preserved; a configured value is > 0).
- **tui_prompt_relay.rs**: replace hardcoded `context_compact_percent: 0` with `fetch_context_thresholds(...).compact_pct_for(&provider)` so the TUI-direct status panel reflects the configured threshold.
- **recovery_engine.rs**: already uses `compact_pct_for(&provider)` (no change needed).

## Keys read / spawn paths
- Read: `context_compact_percent_claude` (new) with fallback to generic `context_compact_percent`.
- Propagate now: intake_turn, headless_turn (env var → CLAUDE_AUTOCOMPACT_PCT_OVERRIDE), tui_prompt_relay (panel display), recovery_engine (already correct).

## Tests
Regression tests in `adk_session.rs`:
- `compact_pct_for(Claude)` returns the Claude-specific override (distinct from generic/codex, and `> 0` so the env var would be set).
- Falls back to the generic value when no Claude-specific key is set.

## Verification
- `cargo check --workspace --all-features --all-targets` clean
- `cargo fmt --all --check` clean
- New + existing `adk_session` lib tests pass
- `./scripts/ci-script-checks.sh` exit 0 (synced `change-surfaces.md` LoC freeze for tui_prompt_relay.rs)

Closes #3097

🤖 Generated with [Claude Code](https://claude.com/claude-code)