### PR TITLE
fix(discord): pair status-panel subagent slots by tool_use_id, not FIFO (#3084)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -8,8 +8,9 @@
 > [`docs/generated/giant-file-registry.md`](../generated/giant-file-registry.md);
 > the rows below project the operational meaning of each entry.
 >
-> Last refreshed: 2026-06-03 (against #3082 codex follow-up: edit/replace
-> answer-flush coverage + progress-aware flush wait + queued-only gate).
+> Last refreshed: 2026-06-03 (against #3084: pair status-panel subagent slots
+> by tool_use_id — threaded an `Option<String>` tool-use id through
+> `StreamMessage::ToolUse`/`ToolResult` across provider adapters).
 
 ## Read This First
 
@@ -365,11 +366,11 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
 - `src/services/dispatches/outbox_route.rs` (1118) — dispatch outbox route
   support extracted from the route layer; split before adding non-bugfix
   behavior.
-- `src/services/claude.rs` (3787), `src/services/gemini.rs` (1406),
-  `src/services/qwen.rs` (2189), `src/services/codex.rs` (2907),
-  `src/services/opencode.rs` (1862), `src/services/provider.rs` (1739) —
+- `src/services/claude.rs` (3789), `src/services/gemini.rs` (1417),
+  `src/services/qwen.rs` (2201), `src/services/codex.rs` (2929),
+  `src/services/opencode.rs` (1882), `src/services/provider.rs` (1739) —
   provider adapters.
-- `src/services/codex_tui/rollout_tail.rs` (1726) — Codex TUI rollout tail
+- `src/services/codex_tui/rollout_tail.rs` (1738) — Codex TUI rollout tail
   parsing and resume identity surface; split before adding non-bugfix behavior
   beyond the #2169 session identity fix.
 - `src/services/codex_tui/input.rs` (1492) — Codex TUI input readiness

--- a/src/services/agent_protocol.rs
+++ b/src/services/agent_protocol.rs
@@ -168,10 +168,30 @@ pub enum StreamMessage {
     RetryBoundary,
     /// Text response chunk
     Text { content: String },
-    /// Tool use started
-    ToolUse { name: String, input: String },
-    /// Tool execution result
-    ToolResult { content: String, is_error: bool },
+    /// Tool use started.
+    ///
+    /// `tool_use_id` is the provider-assigned identifier for this tool
+    /// invocation (Anthropic `id`, etc.). It lets consumers pair a
+    /// `ToolResult` back to the exact `ToolUse` instead of relying on FIFO
+    /// ordering, which mis-pairs when a long-running tool (e.g. a Task
+    /// subagent) returns after intervening short foreground tools. Backends
+    /// that cannot surface an id leave this `None`, in which case consumers
+    /// fall back to FIFO pairing.
+    ToolUse {
+        name: String,
+        input: String,
+        tool_use_id: Option<String>,
+    },
+    /// Tool execution result.
+    ///
+    /// `tool_use_id` mirrors the originating [`StreamMessage::ToolUse`] id so
+    /// the result can be matched to its tool use precisely. `None` when the
+    /// backend does not provide one.
+    ToolResult {
+        content: String,
+        is_error: bool,
+        tool_use_id: Option<String>,
+    },
     /// Provider thinking/reasoning progress marker. Raw reasoning payloads must stay redacted.
     Thinking { summary: Option<String> },
     /// Background task notification
@@ -256,12 +276,21 @@ pub enum StatusEvent {
     SubagentStart {
         subagent_type: Option<String>,
         desc: Option<String>,
+        /// Originating Task tool-use id, used to pair the eventual
+        /// `SubagentEnd` to the exact slot rather than the first unfinished
+        /// one (which mis-attributes across parallel subagents). `None` when
+        /// the backend cannot surface an id.
+        tool_use_id: Option<String>,
     },
     SubagentEvent {
         summary: String,
     },
     SubagentEnd {
         success: bool,
+        /// Tool-use id of the Task whose result closed this subagent. Matched
+        /// against [`StatusEvent::SubagentStart::tool_use_id`]; `None` falls
+        /// back to closing the first unfinished slot.
+        tool_use_id: Option<String>,
     },
     TaskToolUpdate {
         name: String,

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -1242,14 +1242,16 @@ IMPORTANT: Format your responses using Markdown for better readability:
                             preview
                         ));
                     }
-                    StreamMessage::ToolUse { name, input } => {
+                    StreamMessage::ToolUse { name, input, .. } => {
                         let input_preview: String = input.chars().take(200).collect();
                         debug_log(&format!(
                             "  >>> ToolUse: name={}, input_preview={:?}",
                             name, input_preview
                         ));
                     }
-                    StreamMessage::ToolResult { content, is_error } => {
+                    StreamMessage::ToolResult {
+                        content, is_error, ..
+                    } => {
                         let content_preview: String = content.chars().take(200).collect();
                         debug_log(&format!(
                             "  >>> ToolResult: is_error={}, content_len={}, preview={:?}",
@@ -5016,7 +5018,7 @@ mod tests {
         ).unwrap();
 
         match parse_stream_message(&json) {
-            Some(StreamMessage::ToolUse { name, input }) => {
+            Some(StreamMessage::ToolUse { name, input, .. }) => {
                 assert_eq!(name, "Bash");
                 assert!(input.contains("ls"));
             }
@@ -5031,7 +5033,9 @@ mod tests {
         ).unwrap();
 
         match parse_stream_message(&json) {
-            Some(StreamMessage::ToolResult { content, is_error }) => {
+            Some(StreamMessage::ToolResult {
+                content, is_error, ..
+            }) => {
                 assert_eq!(content, "file.txt");
                 assert!(!is_error);
             }
@@ -5046,7 +5050,9 @@ mod tests {
         ).unwrap();
 
         match parse_stream_message(&json) {
-            Some(StreamMessage::ToolResult { content, is_error }) => {
+            Some(StreamMessage::ToolResult {
+                content, is_error, ..
+            }) => {
                 assert_eq!(content, "Error: not found");
                 assert!(is_error);
             }

--- a/src/services/codex.rs
+++ b/src/services/codex.rs
@@ -2811,9 +2811,12 @@ fn handle_codex_json_line(
                     "command_execution" => {
                         let command = item.get("command").and_then(|v| v.as_str()).unwrap_or("");
                         let input = serde_json::json!({ "command": command }).to_string();
+                        let tool_use_id =
+                            item.get("id").and_then(|v| v.as_str()).map(str::to_string);
                         let _ = sender.send(StreamMessage::ToolUse {
                             name: "Bash".to_string(),
                             input,
+                            tool_use_id,
                         });
                     }
                     "reasoning" => {
@@ -2827,15 +2830,28 @@ fn handle_codex_json_line(
             if let Some(invocation) = codex_mcp_invocation(&json)
                 && let Some(name) = codex_mcp_tool_name(invocation)
             {
+                let tool_use_id = json
+                    .get("call_id")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string);
                 let _ = sender.send(StreamMessage::ToolUse {
                     name,
                     input: codex_mcp_arguments(invocation),
+                    tool_use_id,
                 });
             }
         }
         "mcp_tool_call_end" => {
             let (content, is_error) = codex_mcp_result(json.get("result").unwrap_or(&Value::Null));
-            let _ = sender.send(StreamMessage::ToolResult { content, is_error });
+            let tool_use_id = json
+                .get("call_id")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            let _ = sender.send(StreamMessage::ToolResult {
+                content,
+                is_error,
+                tool_use_id,
+            });
         }
         "background_event" => {
             if let Some(summary) = codex_background_event_summary(&json) {
@@ -2873,7 +2889,13 @@ fn handle_codex_json_line(
                             .and_then(|v| v.as_i64())
                             .map(|code| code != 0)
                             .unwrap_or(false);
-                        let _ = sender.send(StreamMessage::ToolResult { content, is_error });
+                        let tool_use_id =
+                            item.get("id").and_then(|v| v.as_str()).map(str::to_string);
+                        let _ = sender.send(StreamMessage::ToolResult {
+                            content,
+                            is_error,
+                            tool_use_id,
+                        });
                     }
                     "reasoning" => {
                         let _ = sender.send(StreamMessage::redacted_thinking());
@@ -3682,7 +3704,7 @@ mod tests {
         let items: Vec<StreamMessage> = rx.try_iter().collect();
         assert_eq!(items.len(), 2);
         match &items[0] {
-            StreamMessage::ToolUse { name, input } => {
+            StreamMessage::ToolUse { name, input, .. } => {
                 assert_eq!(name, "mcp__memento__context");
                 assert_eq!(
                     serde_json::from_str::<Value>(input).unwrap(),
@@ -3695,7 +3717,9 @@ mod tests {
             other => panic!("Expected ToolUse, got {:?}", other),
         }
         match &items[1] {
-            StreamMessage::ToolResult { content, is_error } => {
+            StreamMessage::ToolResult {
+                content, is_error, ..
+            } => {
                 assert!(!is_error);
                 assert_eq!(
                     serde_json::from_str::<Value>(content).unwrap(),
@@ -3728,7 +3752,9 @@ mod tests {
         let items: Vec<StreamMessage> = rx.try_iter().collect();
         assert_eq!(items.len(), 1);
         match &items[0] {
-            StreamMessage::ToolResult { content, is_error } => {
+            StreamMessage::ToolResult {
+                content, is_error, ..
+            } => {
                 assert!(*is_error);
                 assert_eq!(
                     serde_json::from_str::<Value>(content).unwrap(),

--- a/src/services/codex_tui/rollout_tail.rs
+++ b/src/services/codex_tui/rollout_tail.rs
@@ -1595,9 +1595,15 @@ fn tool_call_message(payload: &Value) -> Option<StreamMessage> {
         .or_else(|| payload.get("action"))
         .map(compact_json_or_string)
         .unwrap_or_else(|| "{}".to_string());
+    let tool_use_id = payload
+        .get("call_id")
+        .or_else(|| payload.get("id"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
     Some(StreamMessage::ToolUse {
         name: name.to_string(),
         input,
+        tool_use_id,
     })
 }
 
@@ -1609,6 +1615,11 @@ fn tool_result_message(payload: &Value) -> Option<StreamMessage> {
     if content.is_empty() {
         return None;
     }
+    let tool_use_id = payload
+        .get("call_id")
+        .or_else(|| payload.get("id"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
     Some(StreamMessage::ToolResult {
         content,
         is_error: payload
@@ -1616,6 +1627,7 @@ fn tool_result_message(payload: &Value) -> Option<StreamMessage> {
             .or_else(|| payload.get("isError"))
             .and_then(Value::as_bool)
             .unwrap_or(false),
+        tool_use_id,
     })
 }
 
@@ -1807,7 +1819,7 @@ mod tests {
         for payload in [&modern, &legacy_input, &legacy_action] {
             let msg = tool_call_message(payload).expect("tool_call_message emits");
             match msg {
-                StreamMessage::ToolUse { name, input } => {
+                StreamMessage::ToolUse { name, input, .. } => {
                     assert_eq!(name, "exec");
                     assert!(!input.is_empty());
                 }
@@ -1837,7 +1849,9 @@ mod tests {
             serde_json::json!({ "output": "boom", "isError": true }),
         ] {
             match tool_result_message(&payload).expect("tool_result_message emits") {
-                StreamMessage::ToolResult { is_error, content } => {
+                StreamMessage::ToolResult {
+                    is_error, content, ..
+                } => {
                     assert!(is_error);
                     assert_eq!(content, "boom");
                 }
@@ -1894,12 +1908,12 @@ mod tests {
         ));
         assert!(matches!(
             &messages[1],
-            StreamMessage::ToolUse { name, input }
+            StreamMessage::ToolUse { name, input, .. }
                 if name == "exec_command" && input.contains("\"cmd\":\"date\"")
         ));
         assert!(matches!(
             &messages[2],
-            StreamMessage::ToolResult { content, is_error }
+            StreamMessage::ToolResult { content, is_error, .. }
                 if content.contains("Process exited with code 0") && !is_error
         ));
         assert!(matches!(

--- a/src/services/discord/placeholder_live_events/mod.rs
+++ b/src/services/discord/placeholder_live_events/mod.rs
@@ -40,7 +40,8 @@ use status_panel::{
 pub(in crate::services::discord) use recent_events::RecentPlaceholderEvent;
 pub(in crate::services::discord) use status_events::{
     status_events_from_task_notification, status_events_from_tool_result,
-    status_events_from_tool_use,
+    status_events_from_tool_result_with_id, status_events_from_tool_use,
+    status_events_from_tool_use_with_id,
 };
 
 pub(in crate::services::discord) use recent_events::events_from_json;

--- a/src/services/discord/placeholder_live_events/status_events.rs
+++ b/src/services/discord/placeholder_live_events/status_events.rs
@@ -14,6 +14,14 @@ pub(in crate::services::discord) fn status_events_from_tool_use(
     name: &str,
     input: &str,
 ) -> Vec<StatusEvent> {
+    status_events_from_tool_use_with_id(name, input, None)
+}
+
+pub(in crate::services::discord) fn status_events_from_tool_use_with_id(
+    name: &str,
+    input: &str,
+    tool_use_id: Option<&str>,
+) -> Vec<StatusEvent> {
     let args_summary = format_tool_input(name, input)
         .trim()
         .is_empty()
@@ -55,6 +63,7 @@ pub(in crate::services::discord) fn status_events_from_tool_use(
                 .map(str::to_string)
                 .or_else(|| Some(name.to_string())),
             desc: subagent_description(&value).or(args_summary.clone()),
+            tool_use_id: tool_use_id.map(str::to_string),
         });
     }
     if is_todo_write_tool(name) {
@@ -82,9 +91,20 @@ pub(in crate::services::discord) fn status_events_from_tool_result(
     tool_name: Option<&str>,
     is_error: bool,
 ) -> Vec<StatusEvent> {
+    status_events_from_tool_result_with_id(tool_name, is_error, None)
+}
+
+pub(in crate::services::discord) fn status_events_from_tool_result_with_id(
+    tool_name: Option<&str>,
+    is_error: bool,
+    tool_use_id: Option<&str>,
+) -> Vec<StatusEvent> {
     let mut events = vec![StatusEvent::ToolEnd { success: !is_error }];
     if tool_name.is_some_and(tool_result_completes_subagent) {
-        events.push(StatusEvent::SubagentEnd { success: !is_error });
+        events.push(StatusEvent::SubagentEnd {
+            success: !is_error,
+            tool_use_id: tool_use_id.map(str::to_string),
+        });
     }
     events
 }
@@ -105,6 +125,7 @@ pub(in crate::services::discord) fn status_events_from_task_notification(
             if task_notification_is_terminal(status) {
                 events.push(StatusEvent::SubagentEnd {
                     success: !task_notification_is_error(status),
+                    tool_use_id: None,
                 });
             }
         }

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -25,6 +25,10 @@ pub(super) struct SubagentSlot {
     pub(super) desc: String,
     recent: Option<String>,
     finished: Option<bool>,
+    /// Task tool-use id that opened this slot. Lets `SubagentEnd` close the
+    /// exact slot it belongs to (#3084) instead of the first unfinished one,
+    /// which mis-attributes completion across parallel subagents.
+    tool_use_id: Option<String>,
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum DerivedStatus {
@@ -114,6 +118,7 @@ impl StatusPanelState {
             StatusEvent::SubagentStart {
                 subagent_type,
                 desc,
+                tool_use_id,
             } => {
                 let desc = desc
                     .filter(|value| !value.trim().is_empty())
@@ -126,6 +131,7 @@ impl StatusPanelState {
                     desc: desc.clone(),
                     recent: None,
                     finished: None,
+                    tool_use_id,
                 });
                 self.status = DerivedStatus::SubagentRunning { desc };
                 trim_subagents(&mut self.subagents);
@@ -143,13 +149,31 @@ impl StatusPanelState {
                     };
                 }
             }
-            StatusEvent::SubagentEnd { success } => {
-                if let Some(slot) = self
-                    .subagents
-                    .iter_mut()
-                    .rev()
-                    .find(|slot| slot.finished.is_none())
-                {
+            StatusEvent::SubagentEnd {
+                success,
+                tool_use_id,
+            } => {
+                // #3084: prefer closing the slot whose Task tool-use id matches
+                // the result. This pairs a long-running subagent to its own
+                // result even when shorter foreground tools resolved in
+                // between, and attributes completion to the correct slot among
+                // parallel subagents. Fall back to the first unfinished slot
+                // only when no id is available or no slot matches (e.g.
+                // backends that cannot surface a tool-use id).
+                let matched = tool_use_id.as_deref().and_then(|id| {
+                    self.subagents.iter_mut().rev().find(|slot| {
+                        slot.finished.is_none() && slot.tool_use_id.as_deref() == Some(id)
+                    })
+                });
+                let slot = match matched {
+                    Some(slot) => Some(slot),
+                    None => self
+                        .subagents
+                        .iter_mut()
+                        .rev()
+                        .find(|slot| slot.finished.is_none()),
+                };
+                if let Some(slot) = slot {
                     slot.finished = Some(success);
                 }
                 self.status = DerivedStatus::Running;

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -1624,6 +1624,127 @@ fn status_panel_tracks_one_level_subagents() {
     assert!(rendered.contains("✓"));
 }
 
+// #3084: a long-running Task subagent returns its result AFTER intervening
+// short foreground tools. With FIFO pairing the wrong tool was popped and the
+// real subagent's SubagentEnd never fired, leaving a ghost "running" marker
+// (no ✓/✗). With tool_use_id pairing the delayed result must still close the
+// correct slot as done.
+#[test]
+fn status_panel_pairs_subagent_by_tool_use_id_despite_interleaving() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(384);
+
+    // Task A starts (long-running), id "task-a".
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({"subagent_type": "explorer", "description": "Investigate #3084"}).to_string(),
+            Some("task-a"),
+        ),
+    );
+    // Foreground Bash use + result resolves first (id "bash-1").
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Bash",
+            &json!({"command": "cargo test"}).to_string(),
+            Some("bash-1"),
+        ),
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_result_with_id(Some("Bash"), false, Some("bash-1")),
+    );
+    // Foreground Read use + result resolves next (id "read-1").
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Read",
+            &json!({"file_path": "/tmp/x"}).to_string(),
+            Some("read-1"),
+        ),
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_result_with_id(Some("Read"), false, Some("read-1")),
+    );
+    // Finally Task A's own delayed result arrives, paired by id "task-a".
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_result_with_id(Some("Task"), false, Some("task-a")),
+    );
+
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    assert!(rendered.contains("Subagents"));
+    assert!(rendered.contains("explorer Investigate #3084"));
+    // The subagent must be marked done — no ghost running marker.
+    assert!(
+        rendered.contains('✓'),
+        "subagent should be closed as done, got: {rendered}"
+    );
+    assert!(
+        !rendered.contains('✗'),
+        "successful subagent must not show failure marker, got: {rendered}"
+    );
+}
+
+// #3084: two parallel subagents whose results return in reverse order must each
+// close their own slot. The previous "first unfinished slot" logic closed the
+// wrong slot, mis-attributing success/failure across parallel subagents.
+#[test]
+fn status_panel_parallel_subagents_close_correct_slots_in_reverse_order() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(385);
+
+    // Task A and Task B both start.
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({"subagent_type": "alpha", "description": "Task A work"}).to_string(),
+            Some("task-a"),
+        ),
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({"subagent_type": "beta", "description": "Task B work"}).to_string(),
+            Some("task-b"),
+        ),
+    );
+    // B finishes first (success), then A finishes (failure) — reverse order.
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_result_with_id(Some("Task"), false, Some("task-b")),
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_result_with_id(Some("Task"), true, Some("task-a")),
+    );
+
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    // Each slot rendered on its own line; assert per-slot markers so we catch
+    // mis-attribution (e.g. A's failure landing on B).
+    let alpha_line = rendered
+        .lines()
+        .find(|line| line.contains("alpha Task A work"))
+        .unwrap_or_else(|| panic!("alpha slot missing in: {rendered}"));
+    let beta_line = rendered
+        .lines()
+        .find(|line| line.contains("beta Task B work"))
+        .unwrap_or_else(|| panic!("beta slot missing in: {rendered}"));
+    assert!(
+        alpha_line.contains('✗'),
+        "Task A failed and must show ✗, got: {alpha_line}"
+    );
+    assert!(
+        beta_line.contains('✓'),
+        "Task B succeeded and must show ✓, got: {beta_line}"
+    );
+}
+
 #[test]
 fn status_events_from_json_captures_workflow_progress_array() {
     let events = status_events_from_json(&json!({
@@ -2150,7 +2271,10 @@ fn status_tool_result_closes_subagent_only_for_task_tools() {
         status_events_from_tool_result(Some("Task"), true),
         vec![
             StatusEvent::ToolEnd { success: false },
-            StatusEvent::SubagentEnd { success: false }
+            StatusEvent::SubagentEnd {
+                success: false,
+                tool_use_id: None
+            }
         ]
     );
 }

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -4228,7 +4228,15 @@ pub(super) fn spawn_turn_bridge(
         let mut recovery_retry = false;
         let mut last_adk_heartbeat = std::time::Instant::now();
         let mut pending_stream_messages: VecDeque<StreamMessage> = VecDeque::new();
+        // #3084: pair tool_result → tool_use by provider tool-use id when the
+        // backend supplies one. A long-running Task subagent returns its result
+        // after intervening short foreground tools, so the old FIFO queue
+        // popped the wrong tool name and the real subagent's SubagentEnd never
+        // fired (ghost "running" marker). The HashMap pairs precisely by id;
+        // the VecDeque remains the fallback for backends with no tool-use id.
         let mut pending_status_tool_results: VecDeque<String> = VecDeque::new();
+        let mut pending_status_tool_results_by_id: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
         // codex round-8 P1 on PR #1308: while a long-running placeholder is
         // active, bump the inflight file's mtime so the sweeper sees the turn
         // as alive. Without this, a healthy 5+ minute background tool would
@@ -4757,8 +4765,22 @@ pub(super) fn spawn_turn_bridge(
                                 redacted_thinking_transcript_event(summary),
                             );
                         }
-                        StreamMessage::ToolUse { name, input } => {
-                            pending_status_tool_results.push_back(name.clone());
+                        StreamMessage::ToolUse {
+                            name,
+                            input,
+                            tool_use_id,
+                        } => {
+                            // #3084: index the tool name by its tool-use id when
+                            // present so the matching ToolResult resolves the
+                            // exact tool regardless of interleaving; otherwise
+                            // fall back to FIFO ordering.
+                            match tool_use_id.as_deref() {
+                                Some(id) => {
+                                    pending_status_tool_results_by_id
+                                        .insert(id.to_string(), name.clone());
+                                }
+                                None => pending_status_tool_results.push_back(name.clone()),
+                            }
                             any_tool_used = true;
                             has_post_tool_text = false;
                             inflight_state.any_tool_used = true;
@@ -4823,8 +4845,10 @@ pub(super) fn spawn_turn_bridge(
                             status_panel_dirty |= record_status_panel_events(
                                 shared_owned.as_ref(),
                                 channel_id,
-                                super::placeholder_live_events::status_events_from_tool_use(
-                                    &name, &input,
+                                super::placeholder_live_events::status_events_from_tool_use_with_id(
+                                    &name,
+                                    &input,
+                                    tool_use_id.as_deref(),
                                 ),
                             );
                             // #1113 implicit-terminate: a new ToolUse arriving
@@ -4985,8 +5009,21 @@ pub(super) fn spawn_turn_bridge(
                                 state_dirty = true;
                             }
                         }
-                        StreamMessage::ToolResult { content, is_error } => {
-                            let status_tool_name = pending_status_tool_results.pop_front();
+                        StreamMessage::ToolResult {
+                            content,
+                            is_error,
+                            tool_use_id,
+                        } => {
+                            // #3084: resolve the originating tool by id when the
+                            // result carries one (pairing a delayed subagent
+                            // result to its own ToolUse); otherwise fall back to
+                            // FIFO order for id-less backends.
+                            let status_tool_name = match tool_use_id.as_deref() {
+                                Some(id) => pending_status_tool_results_by_id
+                                    .remove(id)
+                                    .or_else(|| pending_status_tool_results.pop_front()),
+                                None => pending_status_tool_results.pop_front(),
+                            };
                             if inflight_state.source == crate::dispatch::Source::Voice {
                                 let label = if is_error {
                                     "tool_result:error"
@@ -5020,9 +5057,10 @@ pub(super) fn spawn_turn_bridge(
                             status_panel_dirty |= record_status_panel_events(
                                 shared_owned.as_ref(),
                                 channel_id,
-                                super::placeholder_live_events::status_events_from_tool_result(
+                                super::placeholder_live_events::status_events_from_tool_result_with_id(
                                     status_tool_name.as_deref(),
                                     is_error,
+                                    tool_use_id.as_deref(),
                                 ),
                             );
                             // #1255: a long-running tool's ToolResult means the

--- a/src/services/gemini.rs
+++ b/src/services/gemini.rs
@@ -1346,7 +1346,17 @@ fn build_gemini_tool_use_message(json: &Value) -> Option<StreamMessage> {
     Some(StreamMessage::ToolUse {
         name: mapped_name,
         input,
+        tool_use_id: gemini_tool_call_id(json),
     })
+}
+
+/// Extracts a Gemini tool-call identifier so a `ToolResult` can be paired back
+/// to its `ToolUse` instead of relying on FIFO ordering.
+fn gemini_tool_call_id(json: &Value) -> Option<String> {
+    ["call_id", "tool_call_id", "callId", "id"]
+        .into_iter()
+        .find_map(|key| json.get(key).and_then(|v| v.as_str()))
+        .map(str::to_string)
 }
 
 fn build_gemini_tool_result_message(json: &Value) -> Option<StreamMessage> {
@@ -1364,6 +1374,7 @@ fn build_gemini_tool_result_message(json: &Value) -> Option<StreamMessage> {
     Some(StreamMessage::ToolResult {
         content,
         is_error: status != "success",
+        tool_use_id: gemini_tool_call_id(json),
     })
 }
 
@@ -1869,7 +1880,7 @@ Available sessions for this project (2):
         });
 
         match build_gemini_tool_use_message(&event) {
-            Some(StreamMessage::ToolUse { name, input }) => {
+            Some(StreamMessage::ToolUse { name, input, .. }) => {
                 assert_eq!(name, "Bash");
                 assert!(input.contains("\"command\":\"pwd\""));
             }
@@ -1886,7 +1897,9 @@ Available sessions for this project (2):
         });
 
         match build_gemini_tool_result_message(&event) {
-            Some(StreamMessage::ToolResult { content, is_error }) => {
+            Some(StreamMessage::ToolResult {
+                content, is_error, ..
+            }) => {
                 assert_eq!(content, "/tmp/example");
                 assert!(!is_error);
             }
@@ -1910,14 +1923,16 @@ Available sessions for this project (2):
         );
 
         match rx.recv().unwrap() {
-            StreamMessage::ToolUse { name, input } => {
+            StreamMessage::ToolUse { name, input, .. } => {
                 assert_eq!(name, "Bash");
                 assert!(input.contains("\"command\":\"pwd\""));
             }
             other => panic!("expected ToolUse, got {:?}", other),
         }
         match rx.recv().unwrap() {
-            StreamMessage::ToolResult { content, is_error } => {
+            StreamMessage::ToolResult {
+                content, is_error, ..
+            } => {
                 assert_eq!(content, "/tmp/example");
                 assert!(!is_error);
             }
@@ -2076,7 +2091,9 @@ Available sessions for this project (2):
             other => panic!("expected ToolUse, got {:?}", other),
         }
         match rx.recv().unwrap() {
-            StreamMessage::ToolResult { content, is_error } => {
+            StreamMessage::ToolResult {
+                content, is_error, ..
+            } => {
                 assert_eq!(content, "/tmp/example");
                 assert!(!is_error);
             }

--- a/src/services/opencode.rs
+++ b/src/services/opencode.rs
@@ -1451,8 +1451,13 @@ fn emit_tool_part(part: &Value, sender: &Sender<StreamMessage>) {
         .map(stream_value)
         .unwrap_or_default();
 
+    let tool_use_id = opencode_tool_call_id(part);
     if !input.is_empty() || matches!(status, "pending" | "running" | "completed" | "error") {
-        let _ = sender.send(StreamMessage::ToolUse { name, input });
+        let _ = sender.send(StreamMessage::ToolUse {
+            name,
+            input,
+            tool_use_id: tool_use_id.clone(),
+        });
     }
 
     let output = state
@@ -1473,8 +1478,18 @@ fn emit_tool_part(part: &Value, sender: &Sender<StreamMessage>) {
         let _ = sender.send(StreamMessage::ToolResult {
             content: stream_value(output),
             is_error,
+            tool_use_id,
         });
     }
+}
+
+/// Extracts the OpenCode tool-call identifier (`callID`/`callId`/`call_id`/`id`)
+/// from a tool part so a `ToolResult` can be paired back to its `ToolUse`.
+fn opencode_tool_call_id(part: &Value) -> Option<String> {
+    ["callID", "callId", "call_id", "id"]
+        .into_iter()
+        .find_map(|key| part.get(key).and_then(|v| v.as_str()))
+        .map(str::to_string)
 }
 
 fn emit_part(
@@ -1521,6 +1536,7 @@ fn emit_part(
             let _ = sender.send(StreamMessage::ToolUse {
                 name: name.to_string(),
                 input,
+                tool_use_id: opencode_tool_call_id(part),
             });
         }
         "tool-result" => {
@@ -1534,7 +1550,11 @@ fn emit_part(
                 .or_else(|| part.get("is_error"))
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
-            let _ = sender.send(StreamMessage::ToolResult { content, is_error });
+            let _ = sender.send(StreamMessage::ToolResult {
+                content,
+                is_error,
+                tool_use_id: opencode_tool_call_id(part),
+            });
         }
         _ => {}
     }
@@ -2295,7 +2315,7 @@ mod tests {
         let (msgs, _) = parse_event(data, "s1");
         assert!(msgs
             .iter()
-            .any(|m| matches!(m, StreamMessage::ToolResult { content, is_error } if content == "file.txt" && !is_error)));
+            .any(|m| matches!(m, StreamMessage::ToolResult { content, is_error, .. } if content == "file.txt" && !is_error)));
     }
 
     #[test]
@@ -2305,12 +2325,12 @@ mod tests {
         assert_eq!(stop, Some(false));
         assert!(
             msgs.iter().any(
-                |m| matches!(m, StreamMessage::ToolUse { name, input } if name == "bash" && input.contains("ls"))
+                |m| matches!(m, StreamMessage::ToolUse { name, input, .. } if name == "bash" && input.contains("ls"))
             )
         );
         assert!(msgs
             .iter()
-            .any(|m| matches!(m, StreamMessage::ToolResult { content, is_error } if content == "file.txt" && !is_error)));
+            .any(|m| matches!(m, StreamMessage::ToolResult { content, is_error, .. } if content == "file.txt" && !is_error)));
     }
 
     #[test]

--- a/src/services/qwen.rs
+++ b/src/services/qwen.rs
@@ -230,6 +230,7 @@ struct QwenStatusSnapshot {
 struct QwenPartialBlockState {
     kind: String,
     tool_name: Option<String>,
+    tool_id: Option<String>,
     input_json: String,
     thinking_emitted: bool,
 }
@@ -813,6 +814,7 @@ fn process_qwen_partial_event(
                         .get("name")
                         .and_then(|v| v.as_str())
                         .map(str::to_string),
+                    tool_id: block.get("id").and_then(|v| v.as_str()).map(str::to_string),
                     input_json,
                     thinking_emitted: false,
                 },
@@ -882,6 +884,7 @@ fn process_qwen_partial_event(
                     state.buffered_messages.push(StreamMessage::ToolUse {
                         name: block_state.tool_name.unwrap_or_else(|| "tool".to_string()),
                         input: normalize_tool_input(block_state.input_json),
+                        tool_use_id: block_state.tool_id,
                     });
                 } else if block_state.kind == "thinking" && !block_state.thinking_emitted {
                     mark_meaningful_progress(state);
@@ -953,9 +956,12 @@ fn process_qwen_assistant_message(json: &Value, state: &mut QwenAttemptState) {
                     .map(render_qwen_value)
                     .map(normalize_tool_input)
                     .unwrap_or_else(|| "{}".to_string());
-                state
-                    .buffered_messages
-                    .push(StreamMessage::ToolUse { name, input });
+                let tool_use_id = block.get("id").and_then(|v| v.as_str()).map(str::to_string);
+                state.buffered_messages.push(StreamMessage::ToolUse {
+                    name,
+                    input,
+                    tool_use_id,
+                });
             }
             _ => {}
         }
@@ -984,10 +990,16 @@ fn process_qwen_user_message(json: &Value, state: &mut QwenAttemptState) {
             .get("is_error")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+        let tool_use_id = block
+            .get("tool_use_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
         mark_meaningful_progress(state);
-        state
-            .buffered_messages
-            .push(StreamMessage::ToolResult { content, is_error });
+        state.buffered_messages.push(StreamMessage::ToolResult {
+            content,
+            is_error,
+            tool_use_id,
+        });
     }
 }
 
@@ -2658,7 +2670,7 @@ mod tests {
         ));
         assert!(matches!(
             state.buffered_messages.last(),
-            Some(StreamMessage::ToolUse { name, input })
+            Some(StreamMessage::ToolUse { name, input, .. })
                 if name == "Bash" && input == "{\"cmd\":\"pwd\"}"
         ));
     }

--- a/src/services/session_backend.rs
+++ b/src/services/session_backend.rs
@@ -613,9 +613,14 @@ pub(crate) fn parse_stream_message_with_state(
                                     serde_json::to_string_pretty(value).unwrap_or_default()
                                 })
                                 .unwrap_or_default();
+                            let tool_use_id = item
+                                .get("id")
+                                .and_then(|value| value.as_str())
+                                .map(str::to_string);
                             return Some(StreamMessage::ToolUse {
                                 name: name.to_string(),
                                 input,
+                                tool_use_id,
                             });
                         }
                     }
@@ -655,9 +660,14 @@ pub(crate) fn parse_stream_message_with_state(
                         .get("is_error")
                         .and_then(|value| value.as_bool())
                         .unwrap_or(false);
+                    let tool_use_id = item
+                        .get("tool_use_id")
+                        .and_then(|value| value.as_str())
+                        .map(str::to_string);
                     return Some(StreamMessage::ToolResult {
                         content: content_text,
                         is_error,
+                        tool_use_id,
                     });
                 }
             }
@@ -850,9 +860,14 @@ pub fn parse_assistant_extra_tool_uses(json: &Value) -> Vec<StreamMessage> {
                         .get("input")
                         .map(|value| serde_json::to_string_pretty(value).unwrap_or_default())
                         .unwrap_or_default();
+                    let tool_use_id = item
+                        .get("id")
+                        .and_then(|value| value.as_str())
+                        .map(str::to_string);
                     extras.push(StreamMessage::ToolUse {
                         name: name.to_string(),
                         input,
+                        tool_use_id,
                     });
                 }
             }


### PR DESCRIPTION
## Problem

The status panel's Subagents section showed an already-finished subagent as
"running" forever (no ✓/✗ marker). Long-running `codex-rescue` /
`general-purpose Implement #…` Tasks lingered in the turn-completion footer
without a terminal marker.

## Root cause (twofold)

1. **FIFO mis-pairing.** `turn_bridge` pushed each `ToolUse` name onto a
   `VecDeque<String>` and `pop_front()`ed it on `ToolResult`. A long-running
   Task subagent returns its result *after* intervening short foreground tools
   (Bash/Read), so the wrong tool was popped. When the real Task `ToolResult`
   finally arrived, the front of the queue held a non-Task name, so
   `status_events_from_tool_result` never emitted `SubagentEnd` →
   `slot.finished` stayed `None` → `render_subagent_slot` rendered no ✓/✗ = a
   ghost "running" marker.
2. **First-unfinished close.** Even when `SubagentEnd` did fire, the
   `status_panel` handler closed the *first unfinished* slot
   (`.rev().find(finished.is_none())`), mis-attributing completion across
   **parallel** subagents.

## Fix — thread a `tool_use_id` through the pipeline

- Add `tool_use_id: Option<String>` to `StreamMessage::ToolUse` /
  `ToolResult`. Populate it from the provider item `id` / `call_id` in every
  backend (`session_backend`, `claude`, `codex`, `codex_tui/rollout_tail`,
  `qwen`, `gemini`, `opencode`). Backends that cannot surface an id leave it
  `None`.
- `turn_bridge`: index pending tool names by `tool_use_id` in a `HashMap` and
  resolve the `ToolResult` precisely by id. The existing FIFO `VecDeque`
  remains as a **fallback** for id-less backends, so they do not regress.
- Carry the id into `SubagentStart` / `SubagentEnd` `StatusEvent`s and store it
  on `SubagentSlot`. `SubagentEnd` now closes the slot whose `tool_use_id`
  **matches**, falling back to first-unfinished only when no id or no match —
  which also fixes the parallel-subagent mis-attribution.

Chose the **full id-threading** approach (preferred): the enum-field change did
ripple across backends, but it was mechanical (add the field at construction
sites, `..` at destructuring sites) and gives robust pairing everywhere rather
than scoping only to Task tools.

## Tests

- `status_panel_pairs_subagent_by_tool_use_id_despite_interleaving`: Task A
  start → Bash use/result → Read use/result → Task A's delayed result closes A
  as done (✓), with no ghost running marker.
- `status_panel_parallel_subagents_close_correct_slots_in_reverse_order`: two
  parallel Tasks A,B finish in reverse order; each closes the correct slot (✗
  for A's failure, ✓ for B's success).

## Verification

- `cargo check --workspace --all-features --all-targets` — clean.
- `cargo fmt --all --check` — clean.
- `cargo test --lib` for turn_bridge / status_panel / status_events /
  session_backend / all provider adapters (incl. new tests) — green.
- `./scripts/ci-script-checks.sh` — exit 0 (`change-surfaces.md` LoC freeze
  synced for the adapters that grew by the new field).

Closes #3084

🤖 Generated with [Claude Code](https://claude.com/claude-code)