### PR TITLE
fix(discord): durably persist provider-session selector so TUI resume survives restart/idle-expiry (#3095)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -122,11 +122,12 @@
   - `src/services/discord/tmux.rs` (2206 lines after #2558 dead-code sweep;
     failover guard; #3087 `session_panel_instance_key`/`write_spawn_nonce`
     re-exports; still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (6870 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (6897 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
-    refresh + #3087 session-instance-key panel reset; split loop helpers
-    further before adding behavior).
+    refresh + #3087 session-instance-key panel reset + #3095 durable
+    provider-selector fallback to the in-memory cache on resume turns;
+    split loop helpers further before adding behavior).
   - `src/services/discord/tui_prompt_relay.rs` (3247 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +4 from #3082 queued-only answer-flush gate

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1285,6 +1285,28 @@ fn terminal_event_consumed_offset(current_offset: u64, unprocessed_tail: &str) -
     current_offset.saturating_sub(unprocessed_tail.len() as u64)
 }
 
+/// Resolve the provider session selector to durably persist at turn end.
+///
+/// #3095: a TUI resume turn frequently does NOT re-emit the provider session id
+/// in its pane output, so `observed_session_id` (`state.last_session_id`) is
+/// `None` on most committed turns even though resume is working off the durable
+/// in-memory selector. Falling back to the cached `session.session_id` keeps the
+/// DB selector in sync on every committed turn so resume survives an in-memory
+/// cache loss (idle-expiry / dcserver restart). The fallback is guarded against
+/// empty values so a stale/blank selector never overwrites a good DB row.
+fn resolve_persistable_provider_session_id(
+    observed_session_id: Option<&str>,
+    cached_session_id: Option<&str>,
+) -> Option<String> {
+    let nonempty = |value: Option<&str>| {
+        value
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    };
+    nonempty(observed_session_id).or_else(|| nonempty(cached_session_id))
+}
+
 async fn persist_watcher_provider_session_id(
     shared: &Arc<SharedData>,
     channel_id: ChannelId,
@@ -1292,18 +1314,23 @@ async fn persist_watcher_provider_session_id(
     tmux_session_name: &str,
     session_id: Option<&str>,
 ) {
-    let Some(session_id) = session_id.map(str::trim).filter(|value| !value.is_empty()) else {
-        return;
-    };
-
-    {
+    // #3095: when the TUI did not re-emit a session id this turn, fall back to
+    // the durable in-memory selector so the DB row is refreshed on every
+    // committed turn — not only on the rare turns that print the id.
+    let session_id = {
         let mut data = shared.core.lock().await;
-        if let Some(session) = data.sessions.get_mut(&channel_id)
-            && !session.cleared
-        {
-            session.restore_provider_session(Some(session_id.to_string()));
+        let session = data.sessions.get_mut(&channel_id).filter(|s| !s.cleared);
+        let cached_session_id = session.as_ref().and_then(|s| s.session_id.clone());
+        let Some(session_id) =
+            resolve_persistable_provider_session_id(session_id, cached_session_id.as_deref())
+        else {
+            return;
+        };
+        if let Some(session) = session {
+            session.restore_provider_session(Some(session_id.clone()));
         }
-    }
+        session_id
+    };
 
     let session_key = crate::services::discord::adk_session::build_namespaced_session_key(
         &shared.token_hash,
@@ -1312,8 +1339,8 @@ async fn persist_watcher_provider_session_id(
     );
     crate::services::discord::adk_session::save_provider_session_id(
         &session_key,
-        session_id,
-        Some(session_id),
+        &session_id,
+        Some(&session_id),
         provider,
         channel_id,
         shared.api_port,
@@ -7762,8 +7789,9 @@ mod tests {
         discard_restored_response_seed_before_no_inflight_terminal_relay,
         discard_watcher_pending_buffer_after_suppressed_turn,
         legacy_wrapper_prompt_candidates_from_pane, mark_watcher_terminal_delivery_committed,
-        should_probe_tmux_liveness, terminal_event_consumed_offset,
-        watcher_batch_contains_assistant_event, watcher_batch_contains_relayable_response,
+        resolve_persistable_provider_session_id, should_probe_tmux_liveness,
+        terminal_event_consumed_offset, watcher_batch_contains_assistant_event,
+        watcher_batch_contains_relayable_response,
         watcher_direct_terminal_should_commit_session_idle,
         watcher_fallback_edit_failure_can_delete_original_placeholder,
         watcher_inflight_represents_external_input, watcher_jsonl_turn_state_ready_for_input,
@@ -7807,6 +7835,48 @@ mod tests {
     fn terminal_event_consumed_offset_excludes_buffered_tail() {
         assert_eq!(terminal_event_consumed_offset(128, "next-turn\n"), 118);
         assert_eq!(terminal_event_consumed_offset(8, "longer-than-offset"), 0);
+    }
+
+    // #3095: a freshly observed TUI session id always wins so the DB tracks the
+    // newest selector.
+    #[test]
+    fn persistable_provider_session_prefers_freshly_observed_id() {
+        assert_eq!(
+            resolve_persistable_provider_session_id(Some("fresh-sid"), Some("cached-sid")),
+            Some("fresh-sid".to_string())
+        );
+    }
+
+    // #3095 core fix: a resume turn whose TUI output did NOT re-emit a session id
+    // must still persist the durable in-memory selector so the DB row is kept in
+    // sync and resume survives idle-expiry / dcserver restart.
+    #[test]
+    fn persistable_provider_session_falls_back_to_cached_selector_on_resume_turn() {
+        assert_eq!(
+            resolve_persistable_provider_session_id(None, Some("cached-sid")),
+            Some("cached-sid".to_string())
+        );
+    }
+
+    // #3095 guard: never overwrite a good DB row with an empty/blank selector —
+    // neither the observed nor the cached value is usable, so persist is skipped.
+    #[test]
+    fn persistable_provider_session_skips_when_no_usable_selector() {
+        assert_eq!(
+            resolve_persistable_provider_session_id(None, None),
+            None,
+            "no selector available -> skip persist"
+        );
+        assert_eq!(
+            resolve_persistable_provider_session_id(Some("   "), Some("")),
+            None,
+            "blank observed + empty cached -> skip persist"
+        );
+        assert_eq!(
+            resolve_persistable_provider_session_id(Some(""), Some("cached-sid")),
+            Some("cached-sid".to_string()),
+            "blank observed must fall through to the usable cached selector"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #3095

## Root cause

A hosted TUI **resume** turn frequently does NOT re-emit the provider session id in its pane output, so `state.last_session_id` is `None` on most committed turns. `persist_watcher_provider_session_id` (in `tmux_watcher.rs`) **early-returned** whenever the observed session id was absent, so the durable DB selector was only ever written on the rare turns that printed the id.

Resume then survived purely on the volatile in-memory cache (`runtime_cached_provider_session`). Once that cache was lost to `idle_session_expiry` or a dcserver restart, the DB selector lookup missed (`has_claude_selector=false has_session_id=false`) and AgentDesk bootstrapped a brand-new worktree + fresh provider session — losing the entire conversation history (`no_cached_provider_session resumed=false`). This exactly matches the release-log evidence in the issue: the selector DB stopped being written after `06-01 00:11`, yet later turns still showed `resumed=true` (in-memory only).

## Fix

At every committed turn end, resolve the selector to persist by **preferring the freshly observed session id and falling back to the durable in-memory `session.session_id`**. This keeps the DB row in sync with whatever selector resume is actually running off, so resume also works after a cold restart / idle-expiry instead of starting fresh.

The fallback is guarded against empty/blank values so a stale selector never overwrites a good DB row (the original empty-guard is preserved and extended to the fallback path).

### Files / functions changed
- `src/services/discord/tmux_watcher.rs`
  - New pure helper `resolve_persistable_provider_session_id(observed, cached)` — prefers observed, falls back to cached, guards empty/blank.
  - `persist_watcher_provider_session_id` — now resolves the persistable selector via the helper (observed → in-memory cache) instead of early-returning when no id was observed this turn; still restores the in-memory session and preserves all downstream behavior (`save_provider_session_id`, heartbeat touch).
- `docs/agent-maintenance/change-surfaces.md` — synced the `tmux_watcher.rs` freeze entry to the regenerated module inventory.

## Tests
Added focused regression tests on the resolver:
- `persistable_provider_session_prefers_freshly_observed_id`
- `persistable_provider_session_falls_back_to_cached_selector_on_resume_turn` (the core durability invariant)
- `persistable_provider_session_skips_when_no_usable_selector` (empty/blank guards)

## Verification
- `cargo fmt --all --check` — clean
- `cargo check --workspace --all-features --all-targets` — clean (legacy-sqlite-tests compiles)
- `cargo test --lib tmux_watcher` — 75 passed
- `./scripts/ci-script-checks.sh` — exit 0 (after LoC freeze-entry sync)

Do NOT merge — codex review runs first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)