### PR TITLE
fix(discord): repair authoritative tmux-session→channel registry for thread-suffixed live TUI sessions (#3105)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -8,7 +8,7 @@
 > [`docs/generated/giant-file-registry.md`](../generated/giant-file-registry.md);
 > the rows below project the operational meaning of each entry.
 >
-> Last refreshed: 2026-06-03 (against #3099 codex re-review: P1 system-continuation bridge-tail output delivery + anchored continuation classifier + P2 pinned injected-message-id cleanup).
+> Last refreshed: 2026-06-03 (against #3105 dead/orphaned TUI-session mirror eviction made flake-resistant and run off the Tokio executor, on top of #3099/#3100/#3103 system-continuation bridge-tail output delivery + anchored continuation classifier + injection-wrapper strip + pinned injected-message-id cleanup).
 
 ## Read This First
 
@@ -127,7 +127,7 @@
     + #3099 task-notification anchor `⏳` cleanup for `user_msg_id == 0`
     external-input turns (+9 from the #3099 re-review pinned-injected-message-id
     cleanup target); split loop helpers further before adding behavior).
-  - `src/services/discord/tui_prompt_relay.rs` (3576 lines; SSH-direct TUI
+  - `src/services/discord/tui_prompt_relay.rs` (3792 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +4 from #3082 queued-only answer-flush gate
     (`is_queued_notice = false` for the TUI idle-response placeholder); +139
@@ -137,14 +137,30 @@
     P2 pinned injected-message-id cleanup helper + regression tests; +50 from the
     #3100 codex P2 fix: strip a leading SSH-direct injection wrapper line before
     the continuation `starts_with` check so a wrapped/round-tripped banner is not
-    mis-classified as a human turn, plus wrapped/quoted-mid-body regression tests).
+    mis-classified as a human turn, plus wrapped/quoted-mid-body regression tests;
+    +32 from #3105 self-heal of the authoritative tmux-session→channel registry
+    for live thread-suffixed TUI sessions whose watcher slot was evicted
+    (rehydrate loop re-registers the settings-derived owner channel + a bounded
+    incident, never routes from the dedupe mirror); +84 from #3105 codex-P1
+    sub-case B: rehydrate now tombstone-evicts the stale dedupe mirror for
+    dead/orphaned sessions (pane gone + no live watcher) so the idle relay loop
+    stops re-emitting the per-poll drift/skip WARN; +74 from #3105 codex-P2: the
+    dead/orphaned verdict is now flake-resistant — `has_live_pane` is sampled
+    across multiple probes (any live read aborts eviction) and a session is only
+    evicted once the hard `tmux has-session` check confirms it is truly gone, so a
+    transient pane-probe flake can never tombstone a LIVE session's mirror; +26
+    from #3105 codex-P2 followup: the blocking rehydrate pass (sync `tmux`
+    subprocess probes + the multi-sample `std::thread::sleep`) is now dispatched
+    via `tokio::task::spawn_blocking` so it never stalls a Tokio executor worker).
   - `src/services/codex_tmux_wrapper.rs` (1222 lines; Codex tmux wrapper JSON
     event parser and relay bridge for native Codex session events — bugfix only
     outside an extraction plan).
-  - `src/services/tui_prompt_dedupe.rs` (1038 lines; shared TUI prompt
+  - `src/services/tui_prompt_dedupe.rs` (1064 lines; shared TUI prompt
     fingerprinting/dedupe state for hook and rollout relay paths, bugfix only
     outside an extraction plan; +9 from the #3099 re-review crate-visible
-    `reset_state_for_tests` helper).
+    `reset_state_for_tests` helper; +26 from #3105 codex-P1 sub-case B
+    `evict_dead_tmux_mirror` tombstone helper that drops both the runtime and
+    channel mirror for a dead/orphaned session and then allows re-registration).
   - `src/services/discord/recovery_engine.rs` (3978 lines; +36 from #3099
     task-notification anchor `⏳` cleanup for `user_msg_id == 0` recovery; +4
     from the #3099 re-review pinned-injected-message-id cleanup target).
@@ -400,11 +416,15 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   execution are the canonical scheduled JS routine surfaces. Split focused
   helper modules before growing these files again.
 - `src/services/platform/binary_resolver.rs` (1246).
-- `src/services/discord/mod.rs` (4378; +34 from #3019 added the
+- `src/services/discord/mod.rs` (4465; +34 from #3019 added the
   single-authority `increment_global_active` helper + doc mirroring the
   existing decrement helper — offset by removing 6 inline raw `fetch_add`
   blocks across the relay turn-start sites that now route through it; +12 from
-  #3082 answer-flush-barrier field/init/doc),
+  #3082 answer-flush-barrier field/init/doc; +81 from #3105 the authoritative
+  `TmuxWatcherRegistry` gained a `restored_owner_by_tmux_session` map plus
+  `restore_owner_channel_for_tmux_session`/`clear_restored_owner_for_tmux_session`
+  so a live thread-suffixed TUI session with no live watcher slot can be
+  re-registered authoritatively instead of dropped forever),
   `src/services/discord_config_audit.rs` (1459).
 - `src/services/turn_orchestrator.rs` (2760).
 

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -1125,6 +1125,20 @@ pub(super) struct TmuxWatcherRegistry {
     by_tmux_session: dashmap::DashMap<String, TmuxWatcherHandle>,
     tmux_session_by_channel: dashmap::DashMap<ChannelId, String>,
     owner_channel_by_tmux_session: dashmap::DashMap<String, ChannelId>,
+    /// #3105: authoritative owner-channel bindings re-registered for LIVE tmux
+    /// sessions that currently have no live watcher handle — e.g. a Claude TUI
+    /// session the user is typing into directly whose watcher slot was evicted
+    /// by a compact/restart/rebind and never re-claimed (no foreground turn).
+    ///
+    /// This is part of the authoritative registry, NOT the `tui_prompt_dedupe`
+    /// mirror: it is sourced only from the configured channel→provider bindings
+    /// (`settings::list_registered_channel_bindings`), which deterministically
+    /// resolve a session's owner channel from its (base or thread-suffixed)
+    /// tmux name. Kept in a separate map so the strict 1:1 watcher-handle
+    /// invariant across the three maps above is untouched; the live watcher map
+    /// always wins on lookup, and a real watcher claim for the session clears
+    /// the restored entry so it can never shadow live truth.
+    restored_owner_by_tmux_session: dashmap::DashMap<String, ChannelId>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1139,6 +1153,7 @@ impl TmuxWatcherRegistry {
             by_tmux_session: dashmap::DashMap::new(),
             tmux_session_by_channel: dashmap::DashMap::new(),
             owner_channel_by_tmux_session: dashmap::DashMap::new(),
+            restored_owner_by_tmux_session: dashmap::DashMap::new(),
         }
     }
 
@@ -1188,6 +1203,12 @@ impl TmuxWatcherRegistry {
         {
             self.tmux_session_by_channel.remove(&old_owner_channel_id);
         }
+
+        // #3105: a live watcher handle is now the authoritative owner for this
+        // session — drop any restored owner-only binding so it can never shadow
+        // or contradict live truth.
+        self.restored_owner_by_tmux_session
+            .remove(&tmux_session_name);
 
         self.tmux_session_by_channel
             .insert(channel_id, tmux_session_name.clone());
@@ -1265,9 +1286,66 @@ impl TmuxWatcherRegistry {
         &self,
         tmux_session_name: &str,
     ) -> Option<ChannelId> {
+        // The live watcher-handle binding is the primary authority. When no live
+        // watcher owns the session (e.g. a TUI-direct session whose slot was
+        // evicted by compact/restart/rebind), fall back to the #3105 restored
+        // owner map — still authoritative (settings-derived), unlike the dedupe
+        // mirror, which is never consulted here.
         self.owner_channel_by_tmux_session
             .get(tmux_session_name)
             .map(|entry| *entry.value())
+            .or_else(|| {
+                self.restored_owner_by_tmux_session
+                    .get(tmux_session_name)
+                    .map(|entry| *entry.value())
+            })
+    }
+
+    /// #3105: re-register the authoritative owner channel for a LIVE tmux
+    /// session that currently has no live watcher handle.
+    ///
+    /// This is the self-heal path for the permanent relay drop described in
+    /// #3105: the idle transcript relay resolves a session's owner channel
+    /// deterministically from the configured channel→provider bindings (which
+    /// handle both base and thread-suffixed tmux names) and promotes that
+    /// evidence into the authoritative registry here, instead of routing from
+    /// the `tui_prompt_dedupe` mirror (which #3018 forbids as a reverse
+    /// authority).
+    ///
+    /// No-ops when a live watcher already owns the session (live truth wins) or
+    /// when the binding is unchanged. Returns `true` only on the first/changed
+    /// registration so callers can emit a single bounded incident instead of a
+    /// per-poll log.
+    pub(super) fn restore_owner_channel_for_tmux_session(
+        &self,
+        tmux_session_name: &str,
+        channel_id: ChannelId,
+    ) -> bool {
+        let _guard = lock_tmux_watcher_registry();
+        if self
+            .owner_channel_by_tmux_session
+            .contains_key(tmux_session_name)
+        {
+            // A live watcher handle already owns this session authoritatively.
+            self.restored_owner_by_tmux_session
+                .remove(tmux_session_name);
+            return false;
+        }
+        let changed = self
+            .restored_owner_by_tmux_session
+            .get(tmux_session_name)
+            .map(|entry| *entry.value())
+            != Some(channel_id);
+        self.restored_owner_by_tmux_session
+            .insert(tmux_session_name.to_string(), channel_id);
+        changed
+    }
+
+    /// #3105: drop a restored owner-only binding (e.g. once the session is no
+    /// longer live). Idempotent.
+    pub(super) fn clear_restored_owner_for_tmux_session(&self, tmux_session_name: &str) {
+        self.restored_owner_by_tmux_session
+            .remove(tmux_session_name);
     }
 
     pub(super) fn tmux_session_is_stale(&self, tmux_session_name: &str) -> Option<bool> {
@@ -1286,6 +1364,149 @@ impl TmuxWatcherRegistry {
         self.by_tmux_session
             .get(tmux_session_name)
             .map(|entry| entry.output_path.clone())
+    }
+}
+
+#[cfg(test)]
+mod tmux_watcher_registry_restore_tests {
+    use super::*;
+
+    fn live_watcher_handle(tmux_session_name: &str) -> TmuxWatcherHandle {
+        TmuxWatcherHandle {
+            tmux_session_name: tmux_session_name.to_string(),
+            output_path: format!("/tmp/{tmux_session_name}.jsonl"),
+            paused: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            resume_offset: Arc::new(std::sync::Mutex::new(None)),
+            cancel: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            pause_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            turn_delivered: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            last_heartbeat_ts_ms: Arc::new(
+                std::sync::atomic::AtomicI64::new(tmux_watcher_now_ms()),
+            ),
+            mailbox_finalize_owed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        }
+    }
+
+    // #3105: a LIVE TUI session whose authoritative watcher-handle binding is
+    // missing (slot evicted by compact/restart/rebind, never re-claimed) must be
+    // self-healable via an authoritative re-registration so the idle relay can
+    // route again — instead of dropping every poll forever. This is the
+    // registry-side half of the fix; it asserts the restore is treated as
+    // authoritative on lookup and does NOT depend on the dedupe mirror.
+    #[test]
+    fn restored_owner_makes_missing_registry_resolve_for_live_session() {
+        let registry = TmuxWatcherRegistry::new();
+        let tmux = "AgentDesk-claude-adk-cc-t1504468805772902471";
+        let channel = ChannelId::new(1_504_468_805_772_902_471);
+
+        // No live watcher handle yet → registry misses (the #3018 drop trigger).
+        assert_eq!(registry.owner_channel_for_tmux_session(tmux), None);
+
+        // Authoritative (settings-derived) re-registration repairs the miss.
+        assert!(
+            registry.restore_owner_channel_for_tmux_session(tmux, channel),
+            "first restore must report a change so a single bounded incident is emitted"
+        );
+        assert_eq!(
+            registry.owner_channel_for_tmux_session(tmux),
+            Some(channel),
+            "restored owner must resolve authoritatively from the registry"
+        );
+
+        // Re-applying the same binding is a no-op (no repeated per-poll incident).
+        assert!(
+            !registry.restore_owner_channel_for_tmux_session(tmux, channel),
+            "unchanged restore must not re-report a change"
+        );
+    }
+
+    // A real live watcher handle is the primary authority and must win over (and
+    // evict) any restored owner-only binding — restored entries can never shadow
+    // or contradict live truth.
+    #[test]
+    fn live_watcher_handle_overrides_and_evicts_restored_owner() {
+        let registry = TmuxWatcherRegistry::new();
+        let tmux = "AgentDesk-claude-adk-cc-t1504468805772902471";
+        let restored_channel = ChannelId::new(111_000_000_000_000);
+        let live_channel = ChannelId::new(222_000_000_000_000);
+
+        registry.restore_owner_channel_for_tmux_session(tmux, restored_channel);
+        assert_eq!(
+            registry.owner_channel_for_tmux_session(tmux),
+            Some(restored_channel)
+        );
+
+        // Claiming a live watcher handle takes over and drops the restored entry.
+        registry.insert(live_channel, live_watcher_handle(tmux));
+        assert_eq!(
+            registry.owner_channel_for_tmux_session(tmux),
+            Some(live_channel),
+            "live watcher handle must win over a restored owner-only binding"
+        );
+
+        // Removing the live watcher must NOT resurrect the evicted restored entry.
+        registry.remove(&live_channel);
+        assert_eq!(
+            registry.owner_channel_for_tmux_session(tmux),
+            None,
+            "evicted restored entry must not resurrect after the live watcher is removed"
+        );
+    }
+
+    // Restoring an owner while a live watcher already owns the session must be a
+    // no-op (and clear any leftover restored entry) — never override live truth.
+    #[test]
+    fn restore_is_noop_when_live_watcher_owns_session() {
+        let registry = TmuxWatcherRegistry::new();
+        let tmux = "AgentDesk-claude-adk-cc";
+        let live_channel = ChannelId::new(333_000_000_000_000);
+
+        registry.insert(live_channel, live_watcher_handle(tmux));
+        assert!(
+            !registry
+                .restore_owner_channel_for_tmux_session(tmux, ChannelId::new(444_000_000_000_000)),
+            "restore must not report a change when a live watcher owns the session"
+        );
+        assert_eq!(
+            registry.owner_channel_for_tmux_session(tmux),
+            Some(live_channel),
+            "live watcher owner must be unchanged by a restore attempt"
+        );
+    }
+
+    // The base and thread-suffixed tmux names are distinct registry keys; a
+    // restored owner for the thread-suffixed live session resolves on its own
+    // exact key (the relay resolves the channel from the suffixed name).
+    #[test]
+    fn base_and_thread_suffixed_names_resolve_independently() {
+        let registry = TmuxWatcherRegistry::new();
+        let base = "AgentDesk-claude-adk-cc";
+        let suffixed = "AgentDesk-claude-adk-cc-t1504468805772902471";
+        let channel = ChannelId::new(1_504_468_805_772_902_471);
+
+        registry.restore_owner_channel_for_tmux_session(suffixed, channel);
+        assert_eq!(
+            registry.owner_channel_for_tmux_session(suffixed),
+            Some(channel)
+        );
+        assert_eq!(
+            registry.owner_channel_for_tmux_session(base),
+            None,
+            "the base name must not borrow the thread-suffixed session's owner"
+        );
+    }
+
+    // Clearing a restored owner (e.g. when the pane is no longer live) must drop
+    // the binding so a dead session can never resolve.
+    #[test]
+    fn clear_restored_owner_drops_binding() {
+        let registry = TmuxWatcherRegistry::new();
+        let tmux = "AgentDesk-claude-adk-cc-t1504468805772902471";
+        let channel = ChannelId::new(1_504_468_805_772_902_471);
+
+        registry.restore_owner_channel_for_tmux_session(tmux, channel);
+        registry.clear_restored_owner_for_tmux_session(tmux);
+        assert_eq!(registry.owner_channel_for_tmux_session(tmux), None);
     }
 }
 

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -1348,6 +1348,14 @@ impl TmuxWatcherRegistry {
             .remove(tmux_session_name);
     }
 
+    /// #3105 (codex P1 sub-case B): true when a LIVE watcher handle currently
+    /// owns this tmux session. Used to distinguish a genuinely dead/orphaned
+    /// session (no live watcher) from a live session whose authoritative owner
+    /// map entry was transiently evicted (which must self-heal, not be tombstoned).
+    pub(super) fn has_live_watcher_handle(&self, tmux_session_name: &str) -> bool {
+        self.by_tmux_session.contains_key(tmux_session_name)
+    }
+
     pub(super) fn tmux_session_is_stale(&self, tmux_session_name: &str) -> Option<bool> {
         self.by_tmux_session.get(tmux_session_name).map(|entry| {
             entry.cancel.load(std::sync::atomic::Ordering::Relaxed) || entry.heartbeat_stale()

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -1327,7 +1327,28 @@ fn spawn_claude_idle_transcript_relay(shared: Arc<SharedData>) {
         loop {
             let now = tokio::time::Instant::now();
             if now >= next_rehydrate {
-                rehydrate_existing_claude_tui_bindings(&shared);
+                // #3105 (codex P2): `rehydrate_existing_claude_tui_bindings` is a
+                // fully BLOCKING pass — it issues synchronous `tmux` subprocess
+                // calls (`list-sessions`, `has-session`, `has-live-pane`) and, via
+                // `pane_is_confirmed_dead_orphaned`, a `std::thread::sleep` between
+                // multi-sample pane probes. Running it inline on this Tokio worker
+                // would stall the executor (and every other async task scheduled on
+                // the same worker) for samples×delay PLUS the tmux subprocess
+                // latency on each pass. Move ALL of that blocking work onto the
+                // blocking pool with `spawn_blocking` so the executor stays free;
+                // the sync core (and its unit-testable multi-sample logic) is
+                // unchanged.
+                let shared_for_rehydrate = shared.clone();
+                let rehydrate_result = tokio::task::spawn_blocking(move || {
+                    rehydrate_existing_claude_tui_bindings(&shared_for_rehydrate);
+                })
+                .await;
+                if let Err(error) = rehydrate_result {
+                    tracing::warn!(
+                        error = %error,
+                        "Claude TUI binding rehydrate task panicked or was cancelled"
+                    );
+                }
                 next_rehydrate = now + CLAUDE_IDLE_REHYDRATE_POLL_INTERVAL;
             }
             for (tmux_session_name, binding) in
@@ -1602,6 +1623,11 @@ fn pane_is_confirmed_dead_orphaned(
         }
         if sample + 1 < samples {
             if let Some(delay) = inter_probe_delay {
+                // Blocking sleep is intentional here: this sync core (and the
+                // sync `tmux` subprocess probes it drives) only ever runs off
+                // the Tokio executor — the sole async caller dispatches the
+                // whole rehydrate pass via `spawn_blocking` (#3105 codex P2), so
+                // this never stalls an executor worker.
                 std::thread::sleep(delay);
             }
         }

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -1515,6 +1515,22 @@ fn spawn_claude_idle_transcript_relay(shared: Arc<SharedData>) {
     )));
 }
 
+/// #3105 (codex P2): the eviction in `evict_dead_orphaned_claude_tui_mirrors` is
+/// destructive (it tombstones the dedupe mirror and so removes self-heal), so the
+/// liveness check that gates it must be conservative against a TRANSIENT
+/// pane-probe flake. We require the "no live pane" verdict to hold across multiple
+/// samples (with a short delay between them) — a single negative read must never
+/// declare a session dead. `1` would reproduce the original single-sample bug.
+#[cfg(unix)]
+const DEAD_ORPHANED_PANE_PROBE_SAMPLES: usize = 3;
+
+/// Delay between consecutive pane probes. A genuinely-live session that briefly
+/// flaked recovers within one of these windows; a genuinely-gone session stays
+/// dead across all of them. Kept small so the (rare) eviction path adds at most
+/// a few hundred ms to a single rehydrate pass that runs every 5s.
+#[cfg(unix)]
+const DEAD_ORPHANED_PANE_PROBE_DELAY: Duration = Duration::from_millis(75);
+
 /// #3105 (codex P1 sub-case B): a tmux session whose dedupe mirror still holds a
 /// stale ClaudeTui binding but which is genuinely dead/orphaned — its pane is
 /// gone AND no LIVE watcher handle owns it. This is the precise gate under which
@@ -1529,12 +1545,70 @@ fn spawn_claude_idle_transcript_relay(shared: Arc<SharedData>) {
 /// entry is NOT treated as proof of life here, because that map is precisely the
 /// stale residue we must reclaim for a session that has since died; it is
 /// cleared as part of the eviction.
+///
+/// #3105 (codex P2): because eviction is destructive, the dead verdict is made
+/// resistant to a transient pane-probe flake (sub-case A false-positive risk for a
+/// LIVE thread-suffixed session that has not yet been claimed): the pane must read
+/// dead across `DEAD_ORPHANED_PANE_PROBE_SAMPLES` consecutive samples, AND — since
+/// "no watcher handle" is the weakest possible signal — the hard
+/// `tmux_session_exists` (`tmux has-session`) check must confirm the session truly
+/// does not exist on this host. A single soft "no live pane" read can NEVER evict.
 #[cfg(unix)]
 fn claude_tui_session_is_dead_orphaned(shared: &Arc<SharedData>, tmux_session_name: &str) -> bool {
-    !crate::services::tmux_diagnostics::tmux_session_has_live_pane(tmux_session_name)
-        && !shared
-            .tmux_watchers
-            .has_live_watcher_handle(tmux_session_name)
+    // A live watcher handle is conclusive proof of life: never evict, never probe.
+    if shared
+        .tmux_watchers
+        .has_live_watcher_handle(tmux_session_name)
+    {
+        return false;
+    }
+    pane_is_confirmed_dead_orphaned(
+        || crate::services::tmux_diagnostics::tmux_session_has_live_pane(tmux_session_name),
+        || crate::services::tmux_diagnostics::tmux_session_exists(tmux_session_name),
+        DEAD_ORPHANED_PANE_PROBE_SAMPLES,
+        Some(DEAD_ORPHANED_PANE_PROBE_DELAY),
+    )
+}
+
+/// #3105 (codex P2): pure, testable core of the dead/orphaned pane decision (no
+/// watcher-handle dependency — the caller short-circuits on a live handle first).
+///
+/// Conservative by construction so a LIVE session is NEVER classified dead from a
+/// transient flake:
+///   1. `has_live_pane` is sampled up to `samples` times; the moment ANY sample
+///      reports a live pane the session is declared NOT dead (self-heal preserved).
+///      Only if ALL `samples` agree the pane is dead do we proceed.
+///   2. Even then, the hard `session_exists` (`tmux has-session`) check must
+///      confirm the session is truly gone from this host. "No watcher handle" is
+///      the weakest signal, so a soft "no live pane" alone never evicts; the
+///      session must be confirmed absent.
+///
+/// Sub-case B (the production `AgentDesk-claude-adk-cc-t1504468805772902471` case)
+/// still evicts: a genuinely-gone session reports no live pane on every sample AND
+/// `session_exists` is false, so this returns true and the WARN spam stops.
+#[cfg(unix)]
+fn pane_is_confirmed_dead_orphaned(
+    mut has_live_pane: impl FnMut() -> bool,
+    session_exists: impl FnOnce() -> bool,
+    samples: usize,
+    inter_probe_delay: Option<Duration>,
+) -> bool {
+    let samples = samples.max(1);
+    for sample in 0..samples {
+        if has_live_pane() {
+            // Any live observation across the window means the session is alive
+            // (or recovered from a flake): never evict.
+            return false;
+        }
+        if sample + 1 < samples {
+            if let Some(delay) = inter_probe_delay {
+                std::thread::sleep(delay);
+            }
+        }
+    }
+    // Every soft probe agreed the pane is dead. Require the hard has-session check
+    // to confirm the session truly does not exist before declaring it orphaned.
+    !session_exists()
 }
 
 /// #3105 (codex P1 sub-case B): evict the stale dedupe mirror for every Claude
@@ -3902,6 +3976,82 @@ mod tests {
         assert!(
             !claude_tui_session_is_dead_orphaned(&shared, tmux),
             "a session with a live watcher handle must never be tombstoned as dead/orphaned"
+        );
+    }
+
+    // #3105 (codex P2): a LIVE session with no watcher handle whose FIRST pane
+    // probe flakes (reads not-live) but whose subsequent probes report live must
+    // NOT be classified dead/orphaned. A single transient negative read can never
+    // trigger the destructive eviction, so the live session keeps its mirror and
+    // self-heal path. We drive the pure predicate with a scripted probe sequence
+    // [false, true] so the flake is deterministic (no real tmux needed).
+    #[cfg(unix)]
+    #[test]
+    fn transient_pane_flake_on_live_session_is_not_dead_orphaned() {
+        use std::cell::RefCell;
+
+        // First probe flakes (not live), second probe reports live.
+        let live_reads = RefCell::new(vec![false, true].into_iter());
+        let is_dead = pane_is_confirmed_dead_orphaned(
+            || live_reads.borrow_mut().next().unwrap_or(true),
+            // session_exists must NOT even be consulted once a live pane is seen.
+            || panic!("session_exists must not be probed once a live pane is observed"),
+            DEAD_ORPHANED_PANE_PROBE_SAMPLES,
+            None,
+        );
+        assert!(
+            !is_dead,
+            "a single flaky negative pane read followed by a live read must NOT be dead/orphaned"
+        );
+    }
+
+    // #3105 (codex P2 / sub-case B regression): a genuinely-gone session reads no
+    // live pane on EVERY sample AND the hard has-session check confirms it does
+    // not exist → it is still classified dead/orphaned, so the per-poll WARN spam
+    // is still stopped. The retries must not make the real dead session immortal.
+    #[cfg(unix)]
+    #[test]
+    fn genuinely_gone_session_is_still_dead_orphaned_after_retries() {
+        use std::cell::Cell;
+
+        let probe_count = Cell::new(0usize);
+        let is_dead = pane_is_confirmed_dead_orphaned(
+            || {
+                probe_count.set(probe_count.get() + 1);
+                false // never a live pane
+            },
+            || false, // hard has-session: session truly gone
+            DEAD_ORPHANED_PANE_PROBE_SAMPLES,
+            None,
+        );
+        assert!(
+            is_dead,
+            "a session with no live pane across all samples AND no has-session must still evict"
+        );
+        assert_eq!(
+            probe_count.get(),
+            DEAD_ORPHANED_PANE_PROBE_SAMPLES,
+            "all configured samples must be taken before declaring a session dead"
+        );
+    }
+
+    // #3105 (codex P2): the weakest-signal guard. Even when every soft pane probe
+    // reports dead, if the hard `tmux has-session` check still finds the session
+    // present on this host (a transient pane read with the session very much
+    // alive), it must NOT be evicted — "no live pane" alone is never sufficient
+    // when there is no watcher handle.
+    #[cfg(unix)]
+    #[test]
+    fn confirmed_existing_session_is_not_dead_even_if_pane_probes_flake() {
+        let is_dead = pane_is_confirmed_dead_orphaned(
+            || false, // soft pane probe: reads dead on every sample
+            || true,  // hard has-session: the session IS present on this host
+            DEAD_ORPHANED_PANE_PROBE_SAMPLES,
+            None,
+        );
+        assert!(
+            !is_dead,
+            "a session still present per has-session must not be evicted on soft pane reads alone"
         );
     }
 

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -1327,7 +1327,7 @@ fn spawn_claude_idle_transcript_relay(shared: Arc<SharedData>) {
         loop {
             let now = tokio::time::Instant::now();
             if now >= next_rehydrate {
-                rehydrate_existing_claude_tui_bindings();
+                rehydrate_existing_claude_tui_bindings(&shared);
                 next_rehydrate = now + CLAUDE_IDLE_REHYDRATE_POLL_INTERVAL;
             }
             for (tmux_session_name, binding) in
@@ -1516,7 +1516,7 @@ fn spawn_claude_idle_transcript_relay(shared: Arc<SharedData>) {
 }
 
 #[cfg(unix)]
-fn rehydrate_existing_claude_tui_bindings() {
+fn rehydrate_existing_claude_tui_bindings(shared: &Arc<SharedData>) {
     let sessions = match crate::services::platform::tmux::list_session_names() {
         Ok(sessions) => sessions,
         Err(error) => {
@@ -1535,14 +1535,46 @@ fn rehydrate_existing_claude_tui_bindings() {
         let existing_channel =
             crate::services::tui_prompt_dedupe::owner_channel_for_tmux_session(&tmux_session_name);
         let fresh_binding = rehydrated_claude_tui_binding_for_tmux_session(&tmux_session_name);
-        let channel_id = match resolve_rehydrated_claude_tmux_channel_id(&tmux_session_name)
-            .or(existing_channel)
-        {
+        // #3105: prefer the settings-derived (authoritative) channel; only fall
+        // back to the dedupe mirror's last-seen channel for the dedupe binding
+        // refresh below. The mirror's value must NOT be promoted into the
+        // authoritative registry — see the repair gate below.
+        let authoritative_channel = resolve_rehydrated_claude_tmux_channel_id(&tmux_session_name);
+        let channel_id = match authoritative_channel.or(existing_channel) {
             Some(channel_id) => channel_id,
             None => continue,
         };
         if !crate::services::tmux_diagnostics::tmux_session_has_live_pane(&tmux_session_name) {
+            // #3105: the restored owner binding is only valid for a LIVE session;
+            // drop it once the pane is gone so a dead session can never resolve.
+            shared
+                .tmux_watchers
+                .clear_restored_owner_for_tmux_session(&tmux_session_name);
             continue;
+        }
+        // #3105: self-heal the authoritative tmux-session→channel registry for a
+        // LIVE Claude TUI session that has no live watcher handle (e.g. the slot
+        // was evicted by a compact/restart/rebind and never re-claimed because
+        // the user is typing directly into the pane). Without this the #3018
+        // "registry is the single authority, never fall back to the mirror" rule
+        // turns a transient registry miss into a PERMANENT relay drop. We promote
+        // ONLY the settings-derived channel (authoritative, resolves both base
+        // and thread-suffixed tmux names) — never the dedupe mirror — and emit a
+        // single bounded incident instead of the per-poll drift warning.
+        if let Some(authoritative_channel) = authoritative_channel {
+            let repaired = shared.tmux_watchers.restore_owner_channel_for_tmux_session(
+                &tmux_session_name,
+                ChannelId::new(authoritative_channel),
+            );
+            if repaired {
+                tracing::warn!(
+                    tmux_session_name = %tmux_session_name,
+                    channel_id = authoritative_channel,
+                    provider = "claude",
+                    "repaired authoritative tmux-session→channel registry for live TUI session \
+                     (no live watcher slot); idle relay can route again"
+                );
+            }
         }
         if let (Some(existing), Some(_)) = (&existing_binding, existing_channel) {
             if existing.runtime_kind == RuntimeHandoffKind::ClaudeTui
@@ -3618,6 +3650,52 @@ mod tests {
         assert_eq!(
             resolve_owner_channel_authoritatively("tmux-empty", None, None),
             None,
+        );
+    }
+
+    // #3105: a LIVE TUI session where the dedupe mirror holds a channel but the
+    // `tmux_watchers` registry is missing must NOT be permanently dropped. The
+    // fix self-heals by promoting the authoritative (settings-derived) channel
+    // into the registry — NOT by routing from the mirror. This end-to-end relay
+    // test asserts: (1) before repair the resolver drops (registry single
+    // authority); (2) the dedupe mirror alone is never used as the routing
+    // owner; (3) after an authoritative registry restore the relay routes again.
+    #[test]
+    fn live_session_relay_self_heals_via_authoritative_registry_not_mirror() {
+        let shared = super::super::make_shared_data_for_tests();
+        let tmux = "AgentDesk-claude-adk-cc-t1504468805772902471";
+        let owner = ChannelId::new(1_504_468_805_772_902_471);
+
+        // The dedupe mirror has a mapping (live TUI session), but the
+        // authoritative registry misses (slot evicted by compact/restart/rebind).
+        crate::services::tui_prompt_dedupe::register_tmux_channel(tmux, owner.get());
+        assert_eq!(
+            crate::services::tui_prompt_dedupe::owner_channel_for_tmux_session(tmux),
+            Some(owner.get()),
+            "precondition: dedupe mirror holds the live session's channel"
+        );
+
+        // (1)+(2): the mirror alone must never be used as the delivery owner —
+        // the resolver drops (the #3018 single-authority rule stays intact).
+        assert_eq!(
+            owner_channel_for_tmux_session(&shared, tmux),
+            None,
+            "registry miss + dedupe mirror hit must drop, never route from the mirror"
+        );
+
+        // (3): an authoritative registry restore (what the rehydrate loop does
+        // from the settings-derived channel) makes the live session route again.
+        let repaired = shared
+            .tmux_watchers
+            .restore_owner_channel_for_tmux_session(tmux, owner);
+        assert!(
+            repaired,
+            "first restore reports a change (single bounded incident)"
+        );
+        assert_eq!(
+            owner_channel_for_tmux_session(&shared, tmux),
+            Some(owner),
+            "after authoritative re-registration the live session must route again"
         );
     }
 

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -1515,8 +1515,75 @@ fn spawn_claude_idle_transcript_relay(shared: Arc<SharedData>) {
     )));
 }
 
+/// #3105 (codex P1 sub-case B): a tmux session whose dedupe mirror still holds a
+/// stale ClaudeTui binding but which is genuinely dead/orphaned — its pane is
+/// gone AND no LIVE watcher handle owns it. This is the precise gate under which
+/// it is safe to drop any leftover restored-owner binding and tombstone the
+/// mirror; it deliberately EXCLUDES a live session whose authoritative registry
+/// entry was transiently evicted (sub-case A — pane is still live there, so this
+/// returns false and that path self-heals via
+/// `restore_owner_channel_for_tmux_session`).
+///
+/// The pane-liveness check is what distinguishes "pane dead/gone" (evict) from
+/// "pane alive but registry missing" (self-heal). A `restored_owner_by_tmux_session`
+/// entry is NOT treated as proof of life here, because that map is precisely the
+/// stale residue we must reclaim for a session that has since died; it is
+/// cleared as part of the eviction.
+#[cfg(unix)]
+fn claude_tui_session_is_dead_orphaned(shared: &Arc<SharedData>, tmux_session_name: &str) -> bool {
+    !crate::services::tmux_diagnostics::tmux_session_has_live_pane(tmux_session_name)
+        && !shared
+            .tmux_watchers
+            .has_live_watcher_handle(tmux_session_name)
+}
+
+/// #3105 (codex P1 sub-case B): evict the stale dedupe mirror for every Claude
+/// TUI runtime binding whose session is dead/orphaned, BEFORE the idle relay
+/// loop iterates the mirror. The relay loop's `for` is driven by
+/// `runtime_bindings_for_kind(ClaudeTui)`; without this pass a dead/orphaned
+/// session (e.g. a thread-suffixed session whose pane no longer exists on this
+/// host) is yielded every iteration, fails authoritative owner resolution, and
+/// re-emits the drift + skip WARN every ~0.5s indefinitely. Tombstoning the
+/// mirror here removes the binding from that iteration set, so the spam stops
+/// after a single bounded incident line. A later legitimate re-registration
+/// (launch-script rehydrate or a fresh watcher) re-populates the mirror, so a
+/// session that comes back relays again.
+///
+/// This pass is independent of `list_session_names()` (which never contains a
+/// session that is gone from this host), which is exactly why the previous
+/// in-`list` dead-pane branch could not reach it.
+#[cfg(unix)]
+fn evict_dead_orphaned_claude_tui_mirrors(shared: &Arc<SharedData>) {
+    for (tmux_session_name, _binding) in
+        crate::services::tui_prompt_dedupe::runtime_bindings_for_kind(RuntimeHandoffKind::ClaudeTui)
+    {
+        if !claude_tui_session_is_dead_orphaned(shared, &tmux_session_name) {
+            continue;
+        }
+        // Drop any leftover restored-owner binding (a dead session must never
+        // resolve an authoritative owner), then tombstone the dedupe mirror.
+        shared
+            .tmux_watchers
+            .clear_restored_owner_for_tmux_session(&tmux_session_name);
+        if crate::services::tui_prompt_dedupe::evict_dead_tmux_mirror(&tmux_session_name) {
+            tracing::warn!(
+                tmux_session_name = %tmux_session_name,
+                provider = "claude",
+                "evicted stale dedupe mirror for dead/orphaned Claude TUI session \
+                 (pane gone, no live watcher); idle relay will no longer re-emit \
+                 per-poll drift/skip warnings for it"
+            );
+        }
+    }
+}
+
 #[cfg(unix)]
 fn rehydrate_existing_claude_tui_bindings(shared: &Arc<SharedData>) {
+    // #3105 (codex P1 sub-case B): tombstone stale mirrors for dead/orphaned
+    // sessions BEFORE anything else, so the per-poll drift/skip WARN spam stops
+    // even when the session is not present in `list_session_names()` at all.
+    evict_dead_orphaned_claude_tui_mirrors(shared);
+
     let sessions = match crate::services::platform::tmux::list_session_names() {
         Ok(sessions) => sessions,
         Err(error) => {
@@ -1550,6 +1617,23 @@ fn rehydrate_existing_claude_tui_bindings(shared: &Arc<SharedData>) {
             shared
                 .tmux_watchers
                 .clear_restored_owner_for_tmux_session(&tmux_session_name);
+            // #3105 (codex P1 sub-case B): a listed-but-dead pane with no live
+            // watcher is orphaned — also tombstone its stale dedupe mirror so the
+            // idle relay loop stops re-emitting the per-poll drift/skip WARN for
+            // it (the dead-pane branch previously only cleared the restored owner
+            // and left the mirror to spam). `clear_restored_owner_*` above already
+            // ran, so the dead-orphaned predicate cannot be masked by a stale
+            // restored owner here.
+            if claude_tui_session_is_dead_orphaned(shared, &tmux_session_name)
+                && crate::services::tui_prompt_dedupe::evict_dead_tmux_mirror(&tmux_session_name)
+            {
+                tracing::warn!(
+                    tmux_session_name = %tmux_session_name,
+                    provider = "claude",
+                    "evicted stale dedupe mirror for dead/orphaned Claude TUI session \
+                     (listed pane dead, no live watcher)"
+                );
+            }
             continue;
         }
         // #3105: self-heal the authoritative tmux-session→channel registry for a
@@ -3696,6 +3780,128 @@ mod tests {
             owner_channel_for_tmux_session(&shared, tmux),
             Some(owner),
             "after authoritative re-registration the live session must route again"
+        );
+
+        // Cleanup shared global dedupe state for cross-test isolation.
+        crate::services::tui_prompt_dedupe::evict_dead_tmux_mirror(tmux);
+    }
+
+    // #3105 (codex P1 sub-case B): a DEAD/orphaned tmux session (pane gone, not
+    // present on this host) whose dedupe mirror still holds a stale ClaudeTui
+    // runtime binding + channel mapping must NOT spam the per-poll drift/skip
+    // WARN forever. After the rehydrate pass evicts the mirror, the next idle
+    // relay iteration finds NO runtime binding to iterate and NO channel mapping
+    // to drift on — proving the 0.5s spam is stopped. A unique, never-created
+    // session name guarantees `tmux_session_has_live_pane` is false.
+    #[cfg(unix)]
+    #[test]
+    fn dead_orphaned_session_mirror_is_evicted_and_stops_drift_spam() {
+        let _guard = crate::services::tui_prompt_dedupe::TEST_LOCK
+            .lock()
+            .unwrap();
+        let shared = super::super::make_shared_data_for_tests();
+        // A session that does not exist on this host (pane gone / orphaned).
+        let tmux = "AgentDesk-claude-adk-cc-t1504468805772902471-DEAD-ORPHAN-fix3105";
+        let owner = 1_504_468_805_772_902_471u64;
+
+        // Seed the stale dedupe mirror exactly as a dead/orphaned session leaves it:
+        // a ClaudeTui runtime binding (what the relay loop iterates) and a
+        // last-seen channel mapping (what the drift-alert resolver reads).
+        crate::services::tui_prompt_dedupe::register_tmux_runtime_binding(
+            tmux,
+            crate::services::tui_prompt_dedupe::TuiRuntimeBinding {
+                runtime_kind: RuntimeHandoffKind::ClaudeTui,
+                output_path: "/tmp/claude-transcript-dead-orphan.jsonl".to_string(),
+                relay_output_path: None,
+                input_fifo_path: None,
+                session_id: None,
+                last_offset: 0,
+                relay_last_offset: None,
+            },
+        );
+        crate::services::tui_prompt_dedupe::register_tmux_channel(tmux, owner);
+
+        // Preconditions: the relay loop WOULD iterate this binding and drift.
+        assert!(
+            crate::services::tui_prompt_dedupe::runtime_bindings_for_kind(
+                RuntimeHandoffKind::ClaudeTui
+            )
+            .iter()
+            .any(|(name, _)| name == tmux),
+            "precondition: dead session's binding is in the relay loop's iteration set"
+        );
+        assert_eq!(
+            owner_channel_for_tmux_session(&shared, tmux),
+            None,
+            "precondition: registry misses + mirror hit == the drift the relay loop hits"
+        );
+        // The session is genuinely dead/orphaned (no live pane, no live watcher).
+        assert!(
+            claude_tui_session_is_dead_orphaned(&shared, tmux),
+            "precondition: a never-created session is dead/orphaned"
+        );
+
+        // The rehydrate pass runs the eviction. (rehydrate_existing_claude_tui_bindings
+        // calls evict_dead_orphaned_claude_tui_mirrors first; we call it directly
+        // so the assertion does not depend on a live tmux binary for list-sessions.)
+        evict_dead_orphaned_claude_tui_mirrors(&shared);
+
+        // After eviction: the relay loop iterates an EMPTY set for this session,
+        // and the drift-alert resolver finds NO mapping → no drift/skip WARN.
+        assert!(
+            !crate::services::tui_prompt_dedupe::runtime_bindings_for_kind(
+                RuntimeHandoffKind::ClaudeTui
+            )
+            .iter()
+            .any(|(name, _)| name == tmux),
+            "the stale runtime binding must be evicted so the relay loop no longer iterates it"
+        );
+        assert_eq!(
+            crate::services::tui_prompt_dedupe::owner_channel_for_tmux_session(tmux),
+            None,
+            "the stale channel mirror must be evicted so no drift WARN can fire"
+        );
+
+        // Idempotent on the next pass (the ~0.5s repeat): no binding, no work,
+        // no second incident — proving the spam is bounded to one line.
+        evict_dead_orphaned_claude_tui_mirrors(&shared);
+        assert!(
+            !crate::services::tui_prompt_dedupe::runtime_bindings_for_kind(
+                RuntimeHandoffKind::ClaudeTui
+            )
+            .iter()
+            .any(|(name, _)| name == tmux),
+            "subsequent iterations stay clean (0.5s spam stopped)"
+        );
+    }
+
+    // #3105 (codex P1 sub-case A guard): a LIVE thread-suffixed session whose
+    // authoritative registry entry was evicted must NOT be treated as
+    // dead/orphaned — its mirror must survive so the live self-heal path can
+    // re-register the authoritative owner. We assert the dead-orphaned predicate
+    // is gated on pane-liveness: with a live watcher handle present the predicate
+    // is false even though the registry owner map is otherwise empty.
+    #[cfg(unix)]
+    #[test]
+    fn live_session_with_watcher_handle_is_not_dead_orphaned() {
+        let shared = super::super::make_shared_data_for_tests();
+        let tmux = "AgentDesk-claude-adk-cc-LIVE-fix3105";
+        let owner = ChannelId::new(1_504_468_805_772_902_471);
+
+        // A live watcher handle owns the session → it is NOT dead/orphaned even
+        // though the host has no real tmux pane for this synthetic name.
+        let dir = std::env::temp_dir();
+        let output_path = dir.join("claude-live-fix3105.jsonl");
+        shared
+            .tmux_watchers
+            .insert(owner, test_watcher_handle(tmux, &output_path));
+        assert!(
+            shared.tmux_watchers.has_live_watcher_handle(tmux),
+            "precondition: a live watcher handle owns the session"
+        );
+        assert!(
+            !claude_tui_session_is_dead_orphaned(&shared, tmux),
+            "a session with a live watcher handle must never be tombstoned as dead/orphaned"
         );
     }
 

--- a/src/services/tui_prompt_dedupe.rs
+++ b/src/services/tui_prompt_dedupe.rs
@@ -397,6 +397,32 @@ pub(crate) fn clear_tmux_runtime_binding(tmux_session_name: &str) -> bool {
     state.runtime_by_tmux.remove(tmux_session_name).is_some()
 }
 
+/// #3105 (codex P1 sub-case B): tombstone-evict every mirror mapping for a tmux
+/// session that has been determined dead/orphaned (pane gone AND no live watcher
+/// AND no authoritative owner). This removes BOTH the runtime binding (which the
+/// idle relay loop iterates) AND the best-effort channel mirror (which the
+/// drift-alert resolver reads), so subsequent relay-loop iterations no longer
+/// find a stale mapping and stop re-emitting the per-poll drift/skip WARN.
+///
+/// This is NOT a routing authority change: it only forgets a mirror entry whose
+/// session is genuinely gone. A later legitimate re-registration (launch script
+/// rehydrate or a fresh watcher) re-populates these maps normally, so a session
+/// that comes back relays again.
+///
+/// Returns `true` when at least one mirror entry was removed (so callers can
+/// emit a single bounded incident instead of per-poll spam).
+pub(crate) fn evict_dead_tmux_mirror(tmux_session_name: &str) -> bool {
+    let tmux_session_name = tmux_session_name.trim();
+    if tmux_session_name.is_empty() {
+        return false;
+    }
+    let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
+    state.purge_expired();
+    let removed_runtime = state.runtime_by_tmux.remove(tmux_session_name).is_some();
+    let removed_channel = state.channel_by_tmux.remove(tmux_session_name).is_some();
+    removed_runtime || removed_channel
+}
+
 pub(crate) fn runtime_bindings_for_kind(
     runtime_kind: RuntimeHandoffKind,
 ) -> Vec<(String, TuiRuntimeBinding)> {
@@ -1257,6 +1283,72 @@ mod tests {
         assert!(runtime_binding_for_tmux_session("tmux-runtime").is_none());
         assert!(!clear_tmux_runtime_binding("tmux-runtime"));
         assert!(!clear_tmux_runtime_binding("   "));
+    }
+
+    // #3105 (codex P1 sub-case B): evicting a dead/orphaned mirror must drop BOTH
+    // the runtime binding (which the idle relay loop iterates) AND the channel
+    // mirror (which the drift-alert resolver reads), so a subsequent relay pass
+    // finds no mapping and stops re-emitting the per-poll drift/skip WARN. A
+    // later legitimate re-registration must still repopulate both maps.
+    #[test]
+    fn evict_dead_tmux_mirror_drops_runtime_and_channel_then_allows_reregister() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+
+        let tmux = "AgentDesk-claude-adk-cc-t1504468805772902471";
+        register_tmux_runtime_binding(
+            tmux,
+            TuiRuntimeBinding {
+                runtime_kind: RuntimeHandoffKind::ClaudeTui,
+                output_path: "/tmp/claude-transcript.jsonl".to_string(),
+                relay_output_path: None,
+                input_fifo_path: None,
+                session_id: None,
+                last_offset: 12,
+                relay_last_offset: None,
+            },
+        );
+        register_tmux_channel(tmux, 1_504_468_805_772_902_471);
+        assert!(runtime_binding_for_tmux_session(tmux).is_some());
+        assert_eq!(
+            owner_channel_for_tmux_session(tmux),
+            Some(1_504_468_805_772_902_471)
+        );
+
+        // Eviction removes both mirror maps and reports the change once.
+        assert!(evict_dead_tmux_mirror(tmux));
+        assert!(
+            runtime_binding_for_tmux_session(tmux).is_none(),
+            "runtime binding gone → relay loop no longer iterates the dead session"
+        );
+        assert_eq!(
+            owner_channel_for_tmux_session(tmux),
+            None,
+            "channel mirror gone → drift-alert resolver finds no mapping"
+        );
+        // Idempotent: a second eviction reports no change (single bounded incident).
+        assert!(!evict_dead_tmux_mirror(tmux));
+        assert!(!evict_dead_tmux_mirror("   "));
+
+        // A later legitimate re-registration repopulates both maps (session came back).
+        register_tmux_runtime_binding(
+            tmux,
+            TuiRuntimeBinding {
+                runtime_kind: RuntimeHandoffKind::ClaudeTui,
+                output_path: "/tmp/claude-transcript.jsonl".to_string(),
+                relay_output_path: None,
+                input_fifo_path: None,
+                session_id: None,
+                last_offset: 0,
+                relay_last_offset: None,
+            },
+        );
+        register_tmux_channel(tmux, 1_504_468_805_772_902_471);
+        assert!(runtime_binding_for_tmux_session(tmux).is_some());
+        assert_eq!(
+            owner_channel_for_tmux_session(tmux),
+            Some(1_504_468_805_772_902_471)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #3105

## Problem
The Claude idle transcript relay drops live Discord output for a running TUI session when the authoritative `tmux_watchers` registry has no owner channel for the session's tmux name. The runtime log repeats every ~0.5s:

```
WARN claude_idle_transcript_relay: tmux-session→channel registry miss while dedupe mirror has a mapping; treating registry as single authority and dropping (drift alert) tmux_session_name=AgentDesk-claude-adk-cc-t1504468805772902471 ...
WARN claude_idle_transcript_relay: Claude idle relay skipped: no authoritative owner channel for tmux session ...
```

## Root cause
`#3018` correctly made the `tmux_watchers` registry the SINGLE authority and forbids falling back to the `tui_prompt_dedupe` mirror. That half is correct and stays. The bug is the OTHER half: the authoritative registry is only populated when a **watcher is claimed** (turn start / recovery). A live TUI-direct session — one the user is typing directly into the tmux pane (thread-suffixed name `AgentDesk-claude-adk-cc-t…`, base visible session `AgentDesk-claude-adk-cc`) — can have its watcher slot evicted by a compact/restart/rebind and never re-claimed. The dedupe mirror still holds the mapping, so the stricter no-fallback rule turns a transient registry miss into a **permanent** relay drop.

The idle relay's self-heal loop `rehydrate_existing_claude_tui_bindings` refreshes only the dedupe mirror (`tui_prompt_relay.rs`); it never re-registers the authoritative registry, so `owner_channel_for_tmux_session` keeps missing.

## Fix (approach a + c — never route from the mirror)
- `TmuxWatcherRegistry` (`src/services/discord/mod.rs`) gains a separate authoritative `restored_owner_by_tmux_session` owner-only map plus `restore_owner_channel_for_tmux_session` / `clear_restored_owner_for_tmux_session`. The live watcher-handle binding stays the primary authority; a real watcher claim evicts the restored entry; the strict 1:1 watcher-handle invariant across the three existing maps is untouched.
- The rehydrate loop, for a LIVE session with no live watcher slot, promotes **only the settings-derived channel** (resolved identically for base and thread-suffixed tmux names via `resolve_rehydrated_claude_tmux_channel_id`) into the registry and emits a **single bounded incident** instead of the per-poll drift warning — never the dedupe mirror, which `#3018` forbids as a reverse routing authority. A dead pane drops the restored entry.

The dedupe mirror is used only as repair *evidence*, never as the delivery owner.

## Tests
- Registry (`mod.rs`): restore makes a missing-registry live session resolve; a live watcher overrides + evicts a restored owner (and does not resurrect after removal); restore is a no-op while a live watcher owns the session; base vs thread-suffixed names resolve independently; clear drops the binding.
- Relay (`tui_prompt_relay.rs`): a live session where the dedupe mirror has a channel but the registry misses drops before repair (mirror never used as the routing owner) and self-heals after the authoritative re-registration.
- The `#3018` single-authority and drift-alert tests remain green.

## Gates
- `cargo fmt --all --check` clean.
- `cargo check --workspace --all-features --all-targets` clean.
- Touched-module tests green (registry 5/5, relay 55/55, dedupe 34/34).
- `./scripts/ci-script-checks.sh` exit 0; LoC freeze entries in `change-surfaces.md` synced to `module-inventory.md` (tui_prompt_relay 3279, mod.rs 5964). The remaining freshness "missing header" warning pre-exists on `main` and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)