### PR TITLE
fix(discord): self-heal inflight + don't suppress/reclaim while pane is actively streaming (#3107)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -113,20 +113,23 @@
   parsing), `src/services/discord/inflight.rs` (state file contract).
 - legacy_modules: none — relay routes are being consolidated, not replaced.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/services/discord/watchers/lifecycle.rs` (2286 lines — canonical
+  - `src/services/discord/watchers/lifecycle.rs` (2301 lines — canonical
     lifecycle extraction surface from #1435; split further before adding new
     lifecycle behavior).
   - `src/services/discord/tmux.rs` (2123 lines after #2558 dead-code sweep;
     failover guard; #3087 `session_panel_instance_key`/`write_spawn_nonce`
     re-exports; still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (6939 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (7114 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
     provider-selector fallback to the in-memory cache on resume turns
     + #3099 task-notification anchor `⏳` cleanup for `user_msg_id == 0`
     external-input turns (+9 from the #3099 re-review pinned-injected-message-id
-    cleanup target); split loop helpers further before adding behavior).
+    cleanup target) + #3107 self-heal: throttled live-pane-busy probe gates the
+    inflight-missing suppressions, re-acquires a watcher-owned inflight, and
+    preserves the panel under an active turn; split loop helpers further before
+    adding behavior).
   - `src/services/discord/tui_prompt_relay.rs` (3792 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +4 from #3082 queued-only answer-flush gate

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -116,11 +116,11 @@
   - `src/services/discord/watchers/lifecycle.rs` (2301 lines — canonical
     lifecycle extraction surface from #1435; split further before adding new
     lifecycle behavior).
-  - `src/services/discord/tmux.rs` (2128 lines after #2558 dead-code sweep;
+  - `src/services/discord/tmux.rs` (2129 lines after #2558 dead-code sweep;
     failover guard; #3087 `session_panel_instance_key`/`write_spawn_nonce`
     re-exports; #3107 `RestoredWatcherTurn.injected_prompt_message_id`;
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (7187 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (7207 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -116,10 +116,11 @@
   - `src/services/discord/watchers/lifecycle.rs` (2301 lines — canonical
     lifecycle extraction surface from #1435; split further before adding new
     lifecycle behavior).
-  - `src/services/discord/tmux.rs` (2123 lines after #2558 dead-code sweep;
+  - `src/services/discord/tmux.rs` (2128 lines after #2558 dead-code sweep;
     failover guard; #3087 `session_panel_instance_key`/`write_spawn_nonce`
-    re-exports; still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (7114 lines after #2558
+    re-exports; #3107 `RestoredWatcherTurn.injected_prompt_message_id`;
+    still giant-file territory).
+  - `src/services/discord/tmux_watcher.rs` (7187 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -1154,6 +1154,65 @@ fn save_inflight_state_in_root(root: &Path, state: &InflightTurnState) -> Result
     atomic_write(&path, &json)
 }
 
+/// #3107 codex re-review (P1): atomic compare-and-set save. Writes `state`
+/// ONLY when no inflight row currently exists for `(provider, channel_id)`,
+/// returning `true` iff it wrote.
+///
+/// The watcher self-heal re-acquire (`reacquire_watcher_inflight_for_active_stream`)
+/// previously did a non-atomic `load_inflight_state(...).is_some()` preflight
+/// followed by an unconditional `save_inflight_state`. Between the check and
+/// the save the Discord intake path could create a REAL inflight for a brand
+/// new user turn on the same `(provider, channel_id)`; the synthetic
+/// `user_msg_id = 0` re-acquire save would then clobber it and the legitimate
+/// turn would be lost.
+///
+/// This helper closes that window by performing the existence check AND the
+/// write while holding the same `lock_inflight_state_path` sidecar flock that
+/// `save_inflight_state_in_root` / `clear_inflight_state*` already serialize
+/// on. A concurrent intake `save_inflight_state` either ran before us (we see
+/// its row → no-op, intake wins) or after us (it overwrites our synthetic row
+/// with the real turn → intake still wins). The synthetic row is therefore
+/// only ever written when there is genuinely no inflight at the moment of the
+/// atomic write.
+pub(super) fn save_inflight_state_if_absent(state: &InflightTurnState) -> Result<bool, String> {
+    let Some(root) = inflight_runtime_root() else {
+        return Err("Home directory not found".to_string());
+    };
+    save_inflight_state_if_absent_in_root(&root, state)
+}
+
+fn save_inflight_state_if_absent_in_root(
+    root: &Path,
+    state: &InflightTurnState,
+) -> Result<bool, String> {
+    let Some(provider) = state.provider_kind() else {
+        return Err(format!("Unknown provider '{}'", state.provider));
+    };
+    let path = inflight_state_path(root, &provider, state.channel_id);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    // Hold the sidecar flock across the existence check AND the write so a
+    // concurrent intake `save_inflight_state_in_root` (which takes the same
+    // lock) cannot land a real inflight in the gap. `path.exists()` under the
+    // lock is the compare; `atomic_write` is the set.
+    let _lock = lock_inflight_state_path(&path)?;
+    if path.exists() {
+        return Ok(false);
+    }
+    validate_inflight_state_for_save(
+        root,
+        &path,
+        state,
+        "src/services/discord/inflight.rs:save_inflight_state_if_absent_in_root",
+    );
+    let mut updated = state.clone();
+    updated.updated_at = now_string();
+    let json = serde_json::to_string_pretty(&updated).map_err(|e| e.to_string())?;
+    atomic_write(&path, &json)?;
+    Ok(true)
+}
+
 pub(crate) fn clear_inflight_state(provider: &ProviderKind, channel_id: u64) -> bool {
     let Some(root) = inflight_runtime_root() else {
         return false;

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -2471,3 +2471,46 @@ mod watcher_stream_progress_tests {
         unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") };
     }
 }
+
+#[cfg(test)]
+mod restored_turn_injected_anchor_tests {
+    use super::restored_watcher_turn_from_inflight;
+    use crate::services::discord::inflight::InflightTurnState;
+    use crate::services::provider::ProviderKind;
+
+    // #3107 codex re-review (P2, F3): the streaming-interval re-acquire site reads
+    // the #3099 hourglass anchor (`injected_prompt_message_id`) from the restored
+    // turn captured up front (before `restored_turn.take()` consumes it). This test
+    // pins the source of that capture: a hourglass-anchored inflight that the
+    // watcher restores must carry the anchor onto the `RestoredWatcherTurn`, so the
+    // mid-stream re-acquire can re-pin it instead of orphaning the `⏳`.
+    #[test]
+    fn restored_turn_carries_injected_prompt_message_id_for_streaming_reacquire() {
+        let provider = ProviderKind::Claude;
+        let tmux_session_name = "AgentDesk-claude-adk-cc-3107-f3";
+        let mut state = InflightTurnState::new(
+            provider,
+            123_456,
+            Some("adk-cc".to_string()),
+            0, // headless / synthetic user turn (task-notification auto-turn)
+            0,
+            55_555, // current_msg_id must be non-zero for a restorable turn
+            "anchored auto-turn".to_string(),
+            None,
+            Some(tmux_session_name.to_string()),
+            Some("/tmp/agentdesk-3107-f3.jsonl".to_string()),
+            None,
+            0,
+        );
+        state.injected_prompt_message_id = Some(424_242);
+
+        let restored = restored_watcher_turn_from_inflight(&state, tmux_session_name, false)
+            .expect("a non-rebind inflight with a real current_msg_id restores");
+        assert_eq!(
+            restored.injected_prompt_message_id,
+            Some(424_242),
+            "the restored turn must carry the #3099 hourglass anchor so the \
+             streaming-interval re-acquire can re-pin it (F3 regression)"
+        );
+    }
+}

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -139,6 +139,10 @@ pub(super) struct RestoredWatcherTurn {
     last_edit_text: String,
     task_notification_kind: Option<TaskNotificationKind>,
     finish_mailbox_on_completion: bool,
+    /// #3107 codex re-review (P2#3): the #3099 hourglass anchor from the
+    /// restored inflight, carried so a watcher-owned re-acquire (after the row
+    /// is cleared mid-turn) can re-pin it instead of orphaning the `⏳`.
+    pub(super) injected_prompt_message_id: Option<u64>,
 }
 
 #[derive(Debug)]
@@ -210,6 +214,7 @@ pub(super) fn restored_watcher_turn_from_inflight(
         last_edit_text: reconstructed_inflight_placeholder_body(state),
         task_notification_kind: state.task_notification_kind,
         finish_mailbox_on_completion,
+        injected_prompt_message_id: state.injected_prompt_message_id,
     })
 }
 

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -199,7 +199,18 @@ fn watcher_external_input_turn_abandoned(
     expected_identity: Option<&crate::services::discord::inflight::InflightTurnIdentity>,
 ) -> bool {
     match crate::services::discord::inflight::load_inflight_state(provider, channel_id.get()) {
-        None => true,
+        // #3107: inflight-absence alone is NOT abandonment. A live agentic TUI
+        // turn can lose its inflight mid-turn (a momentary idle observation
+        // commits and clears it) while the pane keeps producing — deleting the
+        // status panel here would orphan the live turn (frame_ack MissingTarget).
+        // Probe the pane lazily (only on this `None` arm, so the
+        // `tmux capture-pane` cost is paid only for an abandonment candidate):
+        // if it is actively streaming the turn is live → NOT abandoned. A
+        // genuinely finished/stopped turn returns to ready-for-input, so real
+        // orphans (inflight gone AND pane idle) are still reclaimed.
+        None => watcher_inflight_absence_is_abandonment(watcher_pane_actively_streaming(
+            tmux_session_name,
+        )),
         Some(state) => {
             let replaced = expected_identity.is_some_and(|expected| {
                 *expected
@@ -214,6 +225,91 @@ fn watcher_external_input_turn_abandoned(
                 .is_some()
         }
     }
+}
+
+/// #3107 (CHANGE 3): pure decision for the `load_inflight_state == None` arm of
+/// `watcher_external_input_turn_abandoned`. A missing inflight is abandonment
+/// ONLY when the pane is not actively streaming; an actively-streaming pane is a
+/// live turn that merely lost its inflight, so its status panel must be
+/// preserved (not reclaimed/deleted).
+fn watcher_inflight_absence_is_abandonment(pane_actively_streaming: bool) -> bool {
+    !pane_actively_streaming
+}
+
+/// #3107: inflight-INDEPENDENT probe — capture the pane right now and classify
+/// it as "actively producing assistant output" (busy/streaming) vs.
+/// "finished/idle". Used to tell a live agentic TUI turn that merely lost its
+/// inflight mid-turn apart from genuine post-finish ghost noise.
+///
+/// THROTTLED hot-path cost: this spawns a `tmux capture-pane` subprocess, so the
+/// callers only invoke it lazily — when they are *already about to suppress*
+/// (the cheap `inflight_missing` prefix is true) — mirroring the existing lazy
+/// SSH-direct / external-lease computations in the post-terminal guard, which
+/// are themselves gated on `turn_result_relayed && post_terminal_inflight_missing`.
+fn watcher_pane_actively_streaming(tmux_session_name: &str) -> bool {
+    let Some(pane) = crate::services::platform::tmux::capture_pane(tmux_session_name, -160) else {
+        // Capture failed (pane gone / tmux error): not a positive streaming
+        // signal — fall back to the existing suppression behavior.
+        return false;
+    };
+    crate::services::tmux_common::tmux_capture_indicates_claude_tui_actively_streaming(&pane)
+}
+
+/// #3107 self-heal (CHANGE 2): when the pane is actively streaming but the
+/// dcserver has no inflight for this channel, re-establish a minimal
+/// watcher-owned `InflightTurnState` so subsequent streaming edits relay and the
+/// terminal ack has a target (kills `frame_ack_outcome=MissingTarget`). Mirrors
+/// the watcher-commit / `build_tui_direct_synthetic_inflight_state` construction
+/// (`relay_owner_kind = Watcher`, ExternalInput turn source, session-bound paths)
+/// and reuses the still-present status-panel / placeholder message ids as the
+/// streaming target.
+///
+/// Returns true when a fresh inflight was written (so the caller emits the
+/// one-shot incident log).
+#[allow(clippy::too_many_arguments)]
+fn reacquire_watcher_inflight_for_active_stream(
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    tmux_session_name: &str,
+    output_path: &str,
+    start_offset: u64,
+    status_panel_msg_id: Option<serenity::MessageId>,
+    placeholder_msg_id: Option<serenity::MessageId>,
+) -> bool {
+    // Idempotent: never clobber a concurrently-created legitimate inflight.
+    if crate::services::discord::inflight::load_inflight_state(provider, channel_id.get()).is_some()
+    {
+        return false;
+    }
+    // The streaming-edit target is the placeholder/status-panel message still
+    // owned by this watcher; pin it as `current_msg_id` so edits + the terminal
+    // ack resolve a target instead of MissingTarget.
+    let current_msg_id = placeholder_msg_id
+        .or(status_panel_msg_id)
+        .map(serenity::MessageId::get)
+        .unwrap_or(0);
+    let mut state = crate::services::discord::inflight::InflightTurnState::new(
+        provider.clone(),
+        channel_id.get(),
+        None,
+        // Headless watcher-owned re-acquire: no request owner, no user message.
+        // `user_msg_id == 0` is the established headless/synthetic-turn signal.
+        0,
+        0,
+        current_msg_id,
+        String::new(),
+        None,
+        Some(tmux_session_name.to_string()),
+        Some(output_path.to_string()),
+        None,
+        start_offset,
+    );
+    state.turn_source = crate::services::discord::inflight::TurnSource::ExternalInput;
+    state.set_relay_owner_kind(crate::services::discord::inflight::RelayOwnerKind::Watcher);
+    if let Some(panel) = status_panel_msg_id {
+        state.status_message_id = Some(panel.get());
+    }
+    crate::services::discord::inflight::save_inflight_state(&state).is_ok()
 }
 
 fn discard_restored_response_seed_before_no_inflight_terminal_relay(
@@ -2834,6 +2930,12 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
     // bursts; logging every chunk would spam the timeline.
     let mut post_terminal_continuation_logged = false;
     let mut last_post_terminal_suppressed_range: Option<(u64, u64)> = None;
+    // #3107: 1-shot guard so the "self-heal: re-acquired watcher-owned inflight
+    // for an actively-streaming pane that lost its inflight" incident log is
+    // emitted at most once per dispatch (mirrors the one-shot suppressed-range
+    // logs above). The re-acquire itself is idempotent (no-op when an inflight
+    // already exists), so this only bounds the log, not the heal.
+    let mut active_stream_inflight_reacquire_logged = false;
     let mut restored_turn = restored_turn;
     // Guard against duplicate relay: track the offset from which the last relay was sent.
     // If the outer loop circles back and current_offset hasn't advanced past this point,
@@ -3267,6 +3369,45 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             } else {
                 false
             };
+        // #3107: lazy pane-busy probe — only capture the pane when the cheap
+        // (terminal + no-inflight) prefix is already true and we are about to
+        // suppress, mirroring the SSH-direct / external-lease computations
+        // above. Keeps the `tmux capture-pane` subprocess off the hot path.
+        let post_terminal_pane_actively_streaming = turn_result_relayed
+            && post_terminal_inflight_missing
+            && watcher_pane_actively_streaming(&tmux_session_name);
+        if post_terminal_pane_actively_streaming {
+            // Self-heal: a live turn lost its inflight and kept producing
+            // post-terminal output. Re-establish a watcher-owned inflight so
+            // the continuation relays and the terminal ack has a target.
+            // Reuse the restored turn's persisted message ids when present.
+            let restored_panel = restored_turn
+                .as_ref()
+                .and_then(|turn| turn.status_message_id);
+            let restored_placeholder = restored_turn
+                .as_ref()
+                .and_then(|turn| (turn.current_msg_id.get() != 0).then_some(turn.current_msg_id));
+            let reacquired = reacquire_watcher_inflight_for_active_stream(
+                &watcher_provider,
+                channel_id,
+                &tmux_session_name,
+                &output_path,
+                data_start_offset,
+                restored_panel,
+                restored_placeholder,
+            );
+            if reacquired && !active_stream_inflight_reacquire_logged {
+                let ts = chrono::Local::now().format("%H:%M:%S");
+                tracing::warn!(
+                    "  [{ts}] 🩹 watcher: re-acquired watcher-owned inflight for actively-streaming pane after post-terminal output without inflight (channel {}, tmux={}, range {}..{})",
+                    channel_id.get(),
+                    tmux_session_name,
+                    data_start_offset,
+                    current_offset
+                );
+                active_stream_inflight_reacquire_logged = true;
+            }
+        }
         let post_terminal_no_inflight_should_suppress =
             should_suppress_post_terminal_output_without_inflight(
                 turn_result_relayed,
@@ -3274,6 +3415,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 ssh_direct_prompt_pending,
                 external_input_lease_present,
                 watcher_batch_contains_assistant_event(&data),
+                post_terminal_pane_actively_streaming,
             ) && !post_terminal_payload_allows_external_relay;
         if post_terminal_payload_allows_external_relay {
             tracing::info!(
@@ -4153,8 +4295,41 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                             channel_id.get(),
                         )
                         .is_none();
+                    // #3107: only pay for the pane-capture probe when we are
+                    // already about to suppress (inflight is missing) — the
+                    // expensive signal stays off the hot path, mirroring the
+                    // lazy SSH-direct computation in the post-terminal guard.
+                    let pane_actively_streaming_for_streaming = inflight_missing_for_streaming
+                        && watcher_pane_actively_streaming(&tmux_session_name);
+                    if inflight_missing_for_streaming && pane_actively_streaming_for_streaming {
+                        // #3107 self-heal: the pane is live but inflight was
+                        // cleared mid-turn — re-establish a watcher-owned
+                        // inflight so this and subsequent edits relay and the
+                        // terminal ack has a target. Idempotent + 1-shot log.
+                        let reacquired = reacquire_watcher_inflight_for_active_stream(
+                            &watcher_provider,
+                            channel_id,
+                            &tmux_session_name,
+                            &output_path,
+                            data_start_offset,
+                            status_panel_msg_id,
+                            placeholder_msg_id,
+                        );
+                        if reacquired && !active_stream_inflight_reacquire_logged {
+                            let ts = chrono::Local::now().format("%H:%M:%S");
+                            tracing::warn!(
+                                "  [{ts}] 🩹 watcher: re-acquired watcher-owned inflight for actively-streaming pane that lost its inflight (channel {}, tmux={}, range {}..{})",
+                                channel_id.get(),
+                                tmux_session_name,
+                                data_start_offset,
+                                current_offset
+                            );
+                            active_stream_inflight_reacquire_logged = true;
+                        }
+                    }
                     if should_skip_streaming_placeholder_without_inflight(
                         inflight_missing_for_streaming,
+                        pane_actively_streaming_for_streaming,
                     ) {
                         if !streaming_suppressed_by_missing_inflight {
                             let ts = chrono::Local::now().format("%H:%M:%S");
@@ -7865,14 +8040,14 @@ mod tests {
         discard_restored_response_seed_before_no_inflight_terminal_relay,
         discard_watcher_pending_buffer_after_suppressed_turn,
         legacy_wrapper_prompt_candidates_from_pane, mark_watcher_terminal_delivery_committed,
-        resolve_persistable_provider_session_id, should_probe_tmux_liveness,
-        terminal_event_consumed_offset, watcher_batch_contains_assistant_event,
-        watcher_batch_contains_relayable_response,
+        reacquire_watcher_inflight_for_active_stream, resolve_persistable_provider_session_id,
+        should_probe_tmux_liveness, terminal_event_consumed_offset,
+        watcher_batch_contains_assistant_event, watcher_batch_contains_relayable_response,
         watcher_direct_terminal_should_commit_session_idle,
         watcher_fallback_edit_failure_can_delete_original_placeholder,
-        watcher_inflight_represents_external_input, watcher_jsonl_turn_state_ready_for_input,
-        watcher_should_clear_stale_terminal_message_ids, watcher_should_defer_delegated_fresh_idle,
-        watcher_should_delete_suppressed_placeholder,
+        watcher_inflight_absence_is_abandonment, watcher_inflight_represents_external_input,
+        watcher_jsonl_turn_state_ready_for_input, watcher_should_clear_stale_terminal_message_ids,
+        watcher_should_defer_delegated_fresh_idle, watcher_should_delete_suppressed_placeholder,
         watcher_should_suppress_streaming_after_bridge_delivery,
         watcher_terminal_commit_side_effects_for_test, watcher_terminal_edit_consumes_placeholder,
         watcher_terminal_token_update_status,
@@ -8026,6 +8201,98 @@ mod tests {
         assert_eq!(persisted.last_offset, 128);
         assert_eq!(persisted.last_watcher_relayed_offset, Some(64));
         assert_eq!(persisted.last_watcher_relayed_generation_mtime_ns, Some(7));
+    }
+
+    // #3107 (CHANGE 3): a missing inflight is abandonment ONLY when the pane is
+    // not actively streaming. An actively-streaming pane is a live turn that
+    // merely lost its inflight, so its status panel must be preserved; a
+    // ready-for-input / idle pane is a genuine orphan and is still reclaimed.
+    #[test]
+    fn watcher_inflight_absence_is_abandonment_requires_idle_pane() {
+        assert!(
+            !watcher_inflight_absence_is_abandonment(true),
+            "actively-streaming pane (busy) -> live turn -> NOT abandoned (panel preserved)"
+        );
+        assert!(
+            watcher_inflight_absence_is_abandonment(false),
+            "ready-for-input/idle pane -> real orphan -> still reclaimed"
+        );
+    }
+
+    // #3107 (CHANGE 2): when the pane is actively streaming but no inflight
+    // exists, the watcher re-establishes a minimal Watcher-owned inflight so
+    // subsequent edits relay and the terminal ack has a target. The re-acquire
+    // is idempotent — it must never clobber an already-present inflight.
+    #[test]
+    fn reacquire_watcher_inflight_registers_watcher_owned_state_and_is_idempotent() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _root_guard = AgentdeskRootGuard::set(tmp.path());
+
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(987_3107);
+        let tmux_session_name = "AgentDesk-claude-adk-cc";
+        let output_path = "/tmp/agentdesk-3107-output.jsonl";
+        let panel_id = MessageId::new(5_555);
+        let placeholder_id = MessageId::new(6_666);
+
+        // No inflight yet -> a fresh active-stream observation re-acquires one.
+        assert!(
+            crate::services::discord::inflight::load_inflight_state(&provider, channel_id.get())
+                .is_none()
+        );
+        assert!(reacquire_watcher_inflight_for_active_stream(
+            &provider,
+            channel_id,
+            tmux_session_name,
+            output_path,
+            128,
+            Some(panel_id),
+            Some(placeholder_id),
+        ));
+
+        let restored =
+            crate::services::discord::inflight::load_inflight_state(&provider, channel_id.get())
+                .expect("inflight re-acquired");
+        assert_eq!(
+            restored.effective_relay_owner_kind(),
+            crate::services::discord::inflight::RelayOwnerKind::Watcher,
+            "re-acquired inflight must be watcher-owned"
+        );
+        assert_eq!(
+            restored.tmux_session_name.as_deref(),
+            Some(tmux_session_name)
+        );
+        assert_eq!(restored.output_path.as_deref(), Some(output_path));
+        assert_eq!(restored.turn_start_offset, Some(128));
+        // The still-present placeholder is pinned as the streaming-edit target
+        // (kills frame_ack MissingTarget); the status panel id is preserved too.
+        assert_eq!(restored.current_msg_id, placeholder_id.get());
+        assert_eq!(restored.status_message_id, Some(panel_id.get()));
+
+        // Idempotent: a second observation must NOT clobber the existing row.
+        assert!(
+            !reacquire_watcher_inflight_for_active_stream(
+                &provider,
+                channel_id,
+                tmux_session_name,
+                output_path,
+                256,
+                Some(panel_id),
+                Some(placeholder_id),
+            ),
+            "re-acquire must be a no-op when an inflight already exists"
+        );
+        let unchanged =
+            crate::services::discord::inflight::load_inflight_state(&provider, channel_id.get())
+                .expect("inflight still present");
+        assert_eq!(
+            unchanged.turn_start_offset,
+            Some(128),
+            "existing inflight offset must be left intact"
+        );
     }
 
     #[tokio::test]

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -195,6 +195,7 @@ fn watcher_external_input_turn_abandoned(
     provider: &ProviderKind,
     channel_id: ChannelId,
     tmux_session_name: &str,
+    output_path: &str,
     data_start_offset: u64,
     expected_identity: Option<&crate::services::discord::inflight::InflightTurnIdentity>,
 ) -> bool {
@@ -205,11 +206,13 @@ fn watcher_external_input_turn_abandoned(
         // status panel here would orphan the live turn (frame_ack MissingTarget).
         // Probe the pane lazily (only on this `None` arm, so the
         // `tmux capture-pane` cost is paid only for an abandonment candidate):
-        // if it is actively streaming the turn is live → NOT abandoned. A
-        // genuinely finished/stopped turn returns to ready-for-input, so real
-        // orphans (inflight gone AND pane idle) are still reclaimed.
-        None => watcher_inflight_absence_is_abandonment(watcher_pane_actively_streaming(
+        // if it is actively streaming AND making progress the turn is live →
+        // NOT abandoned. A genuinely finished/stopped turn returns to
+        // ready-for-input (or its pane freezes), so real orphans (inflight gone
+        // AND pane idle/frozen) are still reclaimed.
+        None => watcher_inflight_absence_is_abandonment(watcher_pane_live_turn_in_progress(
             tmux_session_name,
+            output_path,
         )),
         Some(state) => {
             let replaced = expected_identity.is_some_and(|expected| {
@@ -255,6 +258,46 @@ fn watcher_pane_actively_streaming(tmux_session_name: &str) -> bool {
     crate::services::tmux_common::tmux_capture_indicates_claude_tui_actively_streaming(&pane)
 }
 
+/// #3107 codex re-review (P2#3): abandonment-side progress check. A single
+/// static busy frame (e.g. a frozen spinner left on screen by a turn that has
+/// actually stopped) must NOT pin the status panel forever. So the abandonment
+/// `None` arm requires BOTH a positive busy pane AND *evidence of progress* —
+/// the session JSONL was written within `LIVE_TURN_PROGRESS_WINDOW`. A truly
+/// live turn keeps appending output, so its file mtime stays fresh; a frozen
+/// pane's output file goes stale and the turn is correctly declared abandoned
+/// and reclaimed.
+///
+/// This is intentionally distinct from `watcher_pane_actively_streaming` (used
+/// by the self-heal re-acquire): re-acquiring a live-but-inflight-lost turn is
+/// safe even on a single busy frame, but BLOCKING a reclaim is the dangerous
+/// direction (panel orphan leak), so the reclaim path adds the freshness gate.
+fn watcher_pane_live_turn_in_progress(tmux_session_name: &str, output_path: &str) -> bool {
+    watcher_pane_actively_streaming(tmux_session_name)
+        && watcher_output_progressed_recently(output_path)
+}
+
+/// Maximum age of the session JSONL's last write for the turn to count as
+/// "still making progress". A live agentic Claude turn appends stream-json
+/// frames continuously (token deltas, tool events); even a slow tool keeps the
+/// wrapper writing well inside this window. Generous enough not to false-reclaim
+/// a momentarily-quiet live turn, tight enough that a frozen/stopped pane's
+/// stale file trips abandonment within one sweep.
+const LIVE_TURN_PROGRESS_WINDOW: std::time::Duration = std::time::Duration::from_secs(20);
+
+fn watcher_output_progressed_recently(output_path: &str) -> bool {
+    let Ok(meta) = std::fs::metadata(output_path) else {
+        // No readable output file: cannot prove progress → not "in progress".
+        return false;
+    };
+    let Ok(modified) = meta.modified() else {
+        return false;
+    };
+    modified
+        .elapsed()
+        .map(|age| age <= LIVE_TURN_PROGRESS_WINDOW)
+        .unwrap_or(false)
+}
+
 /// #3107 self-heal (CHANGE 2): when the pane is actively streaming but the
 /// dcserver has no inflight for this channel, re-establish a minimal
 /// watcher-owned `InflightTurnState` so subsequent streaming edits relay and the
@@ -275,12 +318,17 @@ fn reacquire_watcher_inflight_for_active_stream(
     start_offset: u64,
     status_panel_msg_id: Option<serenity::MessageId>,
     placeholder_msg_id: Option<serenity::MessageId>,
+    // #3107 codex re-review (P2#3): the #3099 hourglass anchor from the
+    // just-cleared inflight, when a source still has it. The watcher-owned
+    // re-acquire mints a `user_msg_id == 0` synthetic row; per #3099/#3100 the
+    // watcher path does NOT add a `⏳` to a real Discord *user* message for
+    // such turns, so leaving this `None` is safe for the common case. But if
+    // the cleared row HAD pinned an injected message id (e.g. a
+    // task-notification auto-turn that lost its inflight mid-flight), preserving
+    // it here keeps the `⏳ → ✅` completion cleanup able to find its own
+    // message instead of orphaning the hourglass.
+    injected_prompt_message_id: Option<u64>,
 ) -> bool {
-    // Idempotent: never clobber a concurrently-created legitimate inflight.
-    if crate::services::discord::inflight::load_inflight_state(provider, channel_id.get()).is_some()
-    {
-        return false;
-    }
     // The streaming-edit target is the placeholder/status-panel message still
     // owned by this watcher; pin it as `current_msg_id` so edits + the terminal
     // ack resolve a target instead of MissingTarget.
@@ -309,7 +357,17 @@ fn reacquire_watcher_inflight_for_active_stream(
     if let Some(panel) = status_panel_msg_id {
         state.status_message_id = Some(panel.get());
     }
-    crate::services::discord::inflight::save_inflight_state(&state).is_ok()
+    state.injected_prompt_message_id = injected_prompt_message_id;
+    // #3107 codex re-review (P1): atomic compare-and-set. The previous
+    // implementation did a non-atomic `load_inflight_state(...).is_some()`
+    // preflight here and then an unconditional `save_inflight_state`, leaving a
+    // window in which the Discord intake path could create a REAL inflight for a
+    // new user turn on this `(provider, channel_id)` that the synthetic save
+    // would then clobber. `save_inflight_state_if_absent` performs the
+    // existence check and the write under one sidecar flock (shared with
+    // intake's `save_inflight_state`), so a concurrent intake inflight always
+    // wins and the re-acquire degrades to a no-op.
+    crate::services::discord::inflight::save_inflight_state_if_absent(&state).unwrap_or(false)
 }
 
 fn discard_restored_response_seed_before_no_inflight_terminal_relay(
@@ -3387,6 +3445,9 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             let restored_placeholder = restored_turn
                 .as_ref()
                 .and_then(|turn| (turn.current_msg_id.get() != 0).then_some(turn.current_msg_id));
+            let restored_injected_prompt_message_id = restored_turn
+                .as_ref()
+                .and_then(|turn| turn.injected_prompt_message_id);
             let reacquired = reacquire_watcher_inflight_for_active_stream(
                 &watcher_provider,
                 channel_id,
@@ -3395,6 +3456,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 data_start_offset,
                 restored_panel,
                 restored_placeholder,
+                restored_injected_prompt_message_id,
             );
             if reacquired && !active_stream_inflight_reacquire_logged {
                 let ts = chrono::Local::now().format("%H:%M:%S");
@@ -4152,6 +4214,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                             &watcher_provider,
                             channel_id,
                             &tmux_session_name,
+                            &output_path,
                             data_start_offset,
                             turn_identity_for_panel.as_ref(),
                         )
@@ -4314,6 +4377,14 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                             data_start_offset,
                             status_panel_msg_id,
                             placeholder_msg_id,
+                            // #3107 codex re-review (P2#3): no recoverable source
+                            // for the #3099 hourglass anchor in the streaming-interval
+                            // block — the inflight was already cleared and the restored
+                            // seed (if any) was consumed at turn-restore time. The
+                            // re-acquired row is `user_msg_id == 0`, which per #3099/#3100
+                            // the watcher path never ⏳-anchors to a real user message, so
+                            // leaving this None is safe for this owner kind.
+                            None,
                         );
                         if reacquired && !active_stream_inflight_reacquire_logged {
                             let ts = chrono::Local::now().format("%H:%M:%S");
@@ -4469,6 +4540,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                             &watcher_provider,
                             channel_id,
                             &tmux_session_name,
+                            &output_path,
                             data_start_offset,
                             turn_identity_for_panel.as_ref(),
                         ) {
@@ -5892,6 +5964,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                     &watcher_provider,
                     channel_id,
                     &tmux_session_name,
+                    &output_path,
                     data_start_offset,
                     turn_identity_for_panel.as_ref(),
                 )) {
@@ -8046,8 +8119,9 @@ mod tests {
         watcher_direct_terminal_should_commit_session_idle,
         watcher_fallback_edit_failure_can_delete_original_placeholder,
         watcher_inflight_absence_is_abandonment, watcher_inflight_represents_external_input,
-        watcher_jsonl_turn_state_ready_for_input, watcher_should_clear_stale_terminal_message_ids,
-        watcher_should_defer_delegated_fresh_idle, watcher_should_delete_suppressed_placeholder,
+        watcher_jsonl_turn_state_ready_for_input, watcher_output_progressed_recently,
+        watcher_should_clear_stale_terminal_message_ids, watcher_should_defer_delegated_fresh_idle,
+        watcher_should_delete_suppressed_placeholder,
         watcher_should_suppress_streaming_after_bridge_delivery,
         watcher_terminal_commit_side_effects_for_test, watcher_terminal_edit_consumes_placeholder,
         watcher_terminal_token_update_status,
@@ -8219,6 +8293,39 @@ mod tests {
         );
     }
 
+    // #3107 codex re-review (P2#3): the abandonment progress gate. A live turn
+    // whose session JSONL was written recently counts as "progressing"; a
+    // finished/stopped turn whose pane shows a STALE lingering frame (no recent
+    // output) does not — so a frozen spinner can no longer pin the panel.
+    #[test]
+    fn watcher_output_progress_gate_distinguishes_fresh_from_stale_output() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let fresh = tmp.path().join("fresh.jsonl");
+        std::fs::write(&fresh, "{\"type\":\"assistant\"}\n").expect("write fresh output");
+        assert!(
+            watcher_output_progressed_recently(fresh.to_str().unwrap()),
+            "a just-written output file must read as recent progress"
+        );
+
+        // A stale file (mtime well past the window) reads as no progress, so a
+        // finished turn with a lingering busy frame is still declared abandoned.
+        let stale = tmp.path().join("stale.jsonl");
+        let stale_file = std::fs::File::create(&stale).expect("create stale output");
+        stale_file
+            .set_modified(std::time::SystemTime::now() - std::time::Duration::from_secs(120))
+            .expect("backdate stale output mtime");
+        assert!(
+            !watcher_output_progressed_recently(stale.to_str().unwrap()),
+            "a stale output file (frozen turn) must NOT read as progress -> reclaimable"
+        );
+
+        // A missing output file cannot prove progress.
+        assert!(
+            !watcher_output_progressed_recently(tmp.path().join("missing.jsonl").to_str().unwrap()),
+            "a missing output file must read as no progress"
+        );
+    }
+
     // #3107 (CHANGE 2): when the pane is actively streaming but no inflight
     // exists, the watcher re-establishes a minimal Watcher-owned inflight so
     // subsequent edits relay and the terminal ack has a target. The re-acquire
@@ -8251,6 +8358,8 @@ mod tests {
             128,
             Some(panel_id),
             Some(placeholder_id),
+            // #3107 P2#3: a recoverable hourglass anchor is preserved.
+            Some(7_777),
         ));
 
         let restored =
@@ -8271,6 +8380,8 @@ mod tests {
         // (kills frame_ack MissingTarget); the status panel id is preserved too.
         assert_eq!(restored.current_msg_id, placeholder_id.get());
         assert_eq!(restored.status_message_id, Some(panel_id.get()));
+        // #3107 P2#3: the #3099 hourglass anchor is preserved when recoverable.
+        assert_eq!(restored.injected_prompt_message_id, Some(7_777));
 
         // Idempotent: a second observation must NOT clobber the existing row.
         assert!(
@@ -8282,6 +8393,7 @@ mod tests {
                 256,
                 Some(panel_id),
                 Some(placeholder_id),
+                None,
             ),
             "re-acquire must be a no-op when an inflight already exists"
         );
@@ -8293,6 +8405,68 @@ mod tests {
             Some(128),
             "existing inflight offset must be left intact"
         );
+    }
+
+    // #3107 codex re-review (P1): the re-acquire must NOT clobber a REAL inflight
+    // that the intake path created on the same (provider, channel) between the
+    // (now removed) preflight check and the write. With the atomic
+    // compare-and-set save the concurrent intake inflight always wins and the
+    // re-acquire degrades to a no-op.
+    #[test]
+    fn reacquire_watcher_inflight_does_not_clobber_concurrent_intake_inflight() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _root_guard = AgentdeskRootGuard::set(tmp.path());
+
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(987_31071);
+        let tmux_session_name = "AgentDesk-claude-adk-cc";
+        let output_path = "/tmp/agentdesk-3107-cas-output.jsonl";
+
+        // Simulate the intake path having already created a REAL user-authored
+        // inflight (non-zero user_msg_id) for a brand new turn on this channel.
+        let real = InflightTurnState::new(
+            provider.clone(),
+            channel_id.get(),
+            Some("adk-cc".to_string()),
+            777,    // request_owner_user_id
+            12_345, // user_msg_id — a REAL Discord user turn
+            54_321, // current_msg_id
+            "real turn".to_string(),
+            None,
+            Some(tmux_session_name.to_string()),
+            Some(output_path.to_string()),
+            None,
+            999,
+        );
+        crate::services::discord::inflight::save_inflight_state(&real)
+            .expect("seed real intake inflight");
+
+        // The watcher-owned re-acquire must see the row and no-op (intake wins).
+        assert!(
+            !reacquire_watcher_inflight_for_active_stream(
+                &provider,
+                channel_id,
+                tmux_session_name,
+                output_path,
+                128,
+                Some(MessageId::new(5_555)),
+                Some(MessageId::new(6_666)),
+                None,
+            ),
+            "re-acquire must no-op when a concurrent intake inflight exists"
+        );
+
+        let persisted =
+            crate::services::discord::inflight::load_inflight_state(&provider, channel_id.get())
+                .expect("intake inflight must survive");
+        assert_eq!(
+            persisted.user_msg_id, 12_345,
+            "the legitimate intake turn must NOT be overwritten by the synthetic re-acquire"
+        );
+        assert_eq!(persisted.current_msg_id, 54_321);
     }
 
     #[tokio::test]

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -295,7 +295,15 @@ fn watcher_output_progressed_recently(output_path: &str) -> bool {
     modified
         .elapsed()
         .map(|age| age <= LIVE_TURN_PROGRESS_WINDOW)
-        .unwrap_or(false)
+        // #3107 codex re-review (P2, F4): `elapsed()` returns Err when the file
+        // mtime is in the FUTURE (clock drift / NTP jump / an external write with
+        // a skewed clock). Bias the ambiguous case toward "in progress" (true):
+        // the SAFE direction here is to PRESERVE a live turn's panel, not to
+        // reclaim it. A false "not in progress" would delete a genuinely live
+        // turn's panel; a false "in progress" merely defers reclaim by one sweep.
+        // (Distinct from the mtime-MISSING case above, which returns false for the
+        // abandonment path — that's a different, stale-file signal.)
+        .unwrap_or(true)
 }
 
 /// #3107 self-heal (CHANGE 2): when the pane is actively streaming but the
@@ -2995,6 +3003,18 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
     // already exists), so this only bounds the log, not the heal.
     let mut active_stream_inflight_reacquire_logged = false;
     let mut restored_turn = restored_turn;
+    // #3107 codex re-review (P2#3, F3): the #3099 hourglass anchor
+    // (`injected_prompt_message_id`) pinned by the restored turn, captured ONCE
+    // up front before `restored_turn` is consumed by the streaming path's
+    // `restored_turn.take()`. The streaming-interval re-acquire site fires later
+    // in the same dispatch, by which point `restored_turn` is already gone — so
+    // we stash the anchor here and thread it through. This keeps a
+    // hourglass-anchored turn that loses its inflight MID-STREAM re-acquiring an
+    // inflight that still carries the pinned message id, so the `⏳ → ✅`
+    // completion cleanup can find its own message instead of orphaning it.
+    let restored_injected_prompt_message_id = restored_turn
+        .as_ref()
+        .and_then(|turn| turn.injected_prompt_message_id);
     // Guard against duplicate relay: track the offset from which the last relay was sent.
     // If the outer loop circles back and current_offset hasn't advanced past this point,
     // the relay is suppressed.
@@ -3445,9 +3465,6 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             let restored_placeholder = restored_turn
                 .as_ref()
                 .and_then(|turn| (turn.current_msg_id.get() != 0).then_some(turn.current_msg_id));
-            let restored_injected_prompt_message_id = restored_turn
-                .as_ref()
-                .and_then(|turn| turn.injected_prompt_message_id);
             let reacquired = reacquire_watcher_inflight_for_active_stream(
                 &watcher_provider,
                 channel_id,
@@ -4377,14 +4394,17 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                             data_start_offset,
                             status_panel_msg_id,
                             placeholder_msg_id,
-                            // #3107 codex re-review (P2#3): no recoverable source
-                            // for the #3099 hourglass anchor in the streaming-interval
-                            // block — the inflight was already cleared and the restored
-                            // seed (if any) was consumed at turn-restore time. The
-                            // re-acquired row is `user_msg_id == 0`, which per #3099/#3100
-                            // the watcher path never ⏳-anchors to a real user message, so
-                            // leaving this None is safe for this owner kind.
-                            None,
+                            // #3107 codex re-review (P2#3, F3): thread the #3099
+                            // hourglass anchor captured up front from the restored
+                            // turn (before `restored_turn` was consumed by the
+                            // streaming path's `.take()`). Previously this was
+                            // hardcoded `None`, so a hourglass-anchored turn that
+                            // lost its inflight MID-STREAM was re-acquired WITHOUT the
+                            // pinned message id — orphaning the `⏳` because the
+                            // `⏳ → ✅` cleanup could no longer find its own anchor.
+                            // Preserving it keeps the re-acquired streaming inflight
+                            // pointing at the hourglass message.
+                            restored_injected_prompt_message_id,
                         );
                         if reacquired && !active_stream_inflight_reacquire_logged {
                             let ts = chrono::Local::now().format("%H:%M:%S");
@@ -8323,6 +8343,20 @@ mod tests {
         assert!(
             !watcher_output_progressed_recently(tmp.path().join("missing.jsonl").to_str().unwrap()),
             "a missing output file must read as no progress"
+        );
+
+        // #3107 codex re-review (P2, F4): a FUTURE mtime (clock drift / NTP jump /
+        // an external write with a skewed clock) makes `elapsed()` return Err. The
+        // safe direction is to PRESERVE a live turn's panel, so an unresolvable
+        // elapsed must read as "in progress" — NOT as reclaimable.
+        let future = tmp.path().join("future.jsonl");
+        let future_file = std::fs::File::create(&future).expect("create future output");
+        future_file
+            .set_modified(std::time::SystemTime::now() + std::time::Duration::from_secs(3_600))
+            .expect("post-date future output mtime");
+        assert!(
+            watcher_output_progressed_recently(future.to_str().unwrap()),
+            "a future mtime (clock skew) must bias to in-progress so a live turn's panel is preserved"
         );
     }
 

--- a/src/services/discord/watchers/lifecycle.rs
+++ b/src/services/discord/watchers/lifecycle.rs
@@ -1602,8 +1602,18 @@ pub(super) fn should_suppress_streaming_placeholder_after_recent_stop(
     has_assistant_response && inflight_missing && recent_turn_stop
 }
 
-pub(super) fn should_skip_streaming_placeholder_without_inflight(inflight_missing: bool) -> bool {
-    inflight_missing
+pub(super) fn should_skip_streaming_placeholder_without_inflight(
+    inflight_missing: bool,
+    pane_actively_streaming: bool,
+) -> bool {
+    // #3107: a live agentic TUI turn can lose its inflight mid-turn (a momentary
+    // idle observation between tool calls commits and clears it). When the pane
+    // is still actively producing assistant output, the missing inflight is a
+    // self-heal opportunity, NOT a signal to suppress — dropping the edit here
+    // is exactly the relay-degradation bug. Only suppress when inflight is
+    // missing AND the pane looks finished/idle (genuine post-finish ghost noise
+    // like provider-selector chrome).
+    inflight_missing && !pane_actively_streaming
 }
 
 pub(super) fn should_suppress_post_terminal_output_without_inflight(
@@ -1612,6 +1622,7 @@ pub(super) fn should_suppress_post_terminal_output_without_inflight(
     ssh_direct_prompt_pending: bool,
     external_input_lease_present: bool,
     assistant_continuation_present: bool,
+    pane_actively_streaming: bool,
 ) -> bool {
     // SSH-direct prompts never create an inflight (they bypass the Discord
     // message path), so the (terminal + no-inflight) shape alone is not enough
@@ -1620,11 +1631,15 @@ pub(super) fn should_suppress_post_terminal_output_without_inflight(
     // we must still relay even when notification/anchor creation failed.
     // Likewise, another assistant event after an early terminal relay means
     // the provider turn continued with tool calls or final text; do not drop it.
+    // #3107: and if the pane is still actively producing assistant output, the
+    // turn is live and merely lost its inflight — relay (and re-acquire) rather
+    // than suppress.
     terminal_success_seen
         && inflight_missing
         && !ssh_direct_prompt_pending
         && !external_input_lease_present
         && !assistant_continuation_present
+        && !pane_actively_streaming
 }
 
 #[cfg(test)]
@@ -1637,30 +1652,36 @@ mod post_terminal_output_tests {
     #[test]
     fn post_terminal_output_without_inflight_is_suppressed() {
         assert!(should_suppress_post_terminal_output_without_inflight(
-            true, true, false, false, false
+            true, true, false, false, false, false
         ));
         assert!(
             !should_suppress_post_terminal_output_without_inflight(
-                false, true, false, false, false
+                false, true, false, false, false, false
             ),
             "pre-terminal output still belongs to the active watcher turn"
         );
         assert!(
             !should_suppress_post_terminal_output_without_inflight(
-                true, false, false, false, false
+                true, false, false, false, false, false
             ),
             "a newly active inflight owns subsequent output"
         );
         assert!(
-            !should_suppress_post_terminal_output_without_inflight(true, true, true, false, false),
+            !should_suppress_post_terminal_output_without_inflight(
+                true, true, true, false, false, false
+            ),
             "SSH-direct prompt anchor present: output is a real direct-input response"
         );
         assert!(
-            !should_suppress_post_terminal_output_without_inflight(true, true, false, true, false),
+            !should_suppress_post_terminal_output_without_inflight(
+                true, true, false, true, false, false
+            ),
             "ExternalInput lease present: notification failure must not suppress response output"
         );
         assert!(
-            !should_suppress_post_terminal_output_without_inflight(true, true, false, false, true),
+            !should_suppress_post_terminal_output_without_inflight(
+                true, true, false, false, true, false
+            ),
             "assistant continuation after early terminal relay still belongs to the provider turn"
         );
     }
@@ -1668,27 +1689,71 @@ mod post_terminal_output_tests {
     #[test]
     fn post_terminal_hard_result_after_committed_turn_requires_direct_input_evidence() {
         assert!(
-            should_suppress_post_terminal_output_without_inflight(true, true, false, false, false),
+            should_suppress_post_terminal_output_without_inflight(
+                true, true, false, false, false, false
+            ),
             "a late hard_result envelope after a committed Discord turn must not relay again"
         );
         assert!(
-            !should_suppress_post_terminal_output_without_inflight(true, true, true, false, false),
+            !should_suppress_post_terminal_output_without_inflight(
+                true, true, true, false, false, false
+            ),
             "a pending SSH-direct prompt is explicit evidence of a fresh direct-input turn"
         );
         assert!(
-            !should_suppress_post_terminal_output_without_inflight(true, true, false, true, false),
+            !should_suppress_post_terminal_output_without_inflight(
+                true, true, false, true, false, false
+            ),
             "an ExternalInput lease is explicit evidence of a fresh direct-input turn"
         );
         assert!(
-            should_suppress_post_terminal_output_without_inflight(true, true, false, false, false),
+            should_suppress_post_terminal_output_without_inflight(
+                true, true, false, false, false, false
+            ),
             "a result-only duplicate without assistant continuation stays suppressed"
         );
     }
 
     #[test]
+    fn post_terminal_output_with_actively_streaming_pane_is_not_suppressed() {
+        // #3107: the (terminal + no-inflight) shape that would otherwise be
+        // suppressed must still relay when the pane is actively producing —
+        // the turn is live and merely lost its inflight.
+        assert!(
+            !should_suppress_post_terminal_output_without_inflight(
+                true, true, false, false, false, true
+            ),
+            "an actively-streaming pane means the turn is live: relay, do not suppress"
+        );
+        // Asymmetry: with a finished/idle pane the same shape is still genuine
+        // post-finish ghost noise and stays suppressed.
+        assert!(
+            should_suppress_post_terminal_output_without_inflight(
+                true, true, false, false, false, false
+            ),
+            "a finished pane with missing inflight is real ghost noise: still suppressed"
+        );
+    }
+
+    #[test]
     fn streaming_placeholder_without_inflight_is_skipped() {
-        assert!(should_skip_streaming_placeholder_without_inflight(true));
-        assert!(!should_skip_streaming_placeholder_without_inflight(false));
+        // Genuine ghost noise: inflight missing AND pane idle/finished.
+        assert!(should_skip_streaming_placeholder_without_inflight(
+            true, false
+        ));
+        assert!(!should_skip_streaming_placeholder_without_inflight(
+            false, false
+        ));
+        // #3107 asymmetry: inflight missing but pane actively streaming → the
+        // live turn lost its inflight; do NOT skip the streaming edit.
+        assert!(
+            !should_skip_streaming_placeholder_without_inflight(true, true),
+            "an actively-streaming pane with missing inflight is a live turn: relay"
+        );
+        // A present inflight is never skipped regardless of pane state.
+        assert!(!should_skip_streaming_placeholder_without_inflight(
+            false, true
+        ));
     }
 }
 

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -121,6 +121,36 @@ pub(crate) fn tmux_capture_indicates_claude_tui_ready_for_input(capture: &str) -
         })
 }
 
+/// #3107: inflight-INDEPENDENT "the pane is in an active TUI turn" signal.
+///
+/// A multi-step agentic Claude TUI turn can lose its dcserver inflight mid-turn
+/// (a momentary idle observation between tool calls trips the completion gate,
+/// commits, and clears inflight) while the pane keeps producing assistant
+/// output. Once inflight is gone every later batch is treated as ownerless and
+/// suppressed (`should_skip_streaming_placeholder_without_inflight` /
+/// `should_suppress_post_terminal_output_without_inflight`), so the live turn
+/// goes dark even though the watcher is still alive.
+///
+/// This predicate gives the suppression/reclaim paths a way to tell a genuinely
+/// finished turn (returned to ready-for-input, or showing idle-suggestion
+/// chrome — the real post-finish ghost noise we DO want to suppress) apart from
+/// a live turn that merely lost its inflight. `true` means: the pane is neither
+/// ready-for-input NOR showing idle-suggestion chrome ⇒ it is actively
+/// producing ⇒ an active turn (that lost its inflight). `false` means the pane
+/// looks finished/idle, so existing suppression must stand.
+pub(crate) fn tmux_capture_indicates_claude_tui_actively_streaming(capture: &str) -> bool {
+    if capture.trim().is_empty() {
+        return false;
+    }
+    if tmux_capture_indicates_claude_tui_ready_for_input(capture) {
+        return false;
+    }
+    if tmux_capture_indicates_claude_tui_idle_suggestion(capture) {
+        return false;
+    }
+    true
+}
+
 pub(crate) fn tmux_capture_indicates_claude_tui_prompt_draft(capture: &str) -> bool {
     tmux_capture_claude_tui_prompt_draft_backspace_budget(capture).is_some()
 }
@@ -1019,5 +1049,69 @@ assistant output
 
         assert!(tmux_capture_indicates_claude_tui_prompt_draft(capture));
         assert!(tmux_capture_indicates_claude_tui_idle_suggestion(capture));
+    }
+
+    #[test]
+    fn actively_streaming_detects_busy_pane_with_esc_to_interrupt() {
+        // #3107: a live agentic turn that lost its inflight — the pane still
+        // shows the busy/"esc to interrupt" marker and is producing.
+        let capture = "\
+⏺ Running 1 shell command…
+· Actioning… (4m 7s · esc to interrupt)
+─────────────────────────────────────────────────────────────────────────────
+❯\u{00a0}
+─────────────────────────────────────────────────────────────────────────────
+  🤖 Opus(H) │ █░░░░░░░░░ │ 7%";
+
+        assert!(!tmux_capture_indicates_claude_tui_ready_for_input(capture));
+        assert!(tmux_capture_indicates_claude_tui_actively_streaming(
+            capture
+        ));
+    }
+
+    #[test]
+    fn actively_streaming_rejects_ready_for_input_pane() {
+        // A genuinely finished turn returned to ready-for-input: not streaming.
+        let capture = "\
+✻ Churned for 4m 56s
+─────────────────────────────────────────────────────────────────────────────
+❯\u{00a0}
+─────────────────────────────────────────────────────────────────────────────
+  🤖 Opus(H) │ █░░░░░░░░░ │ 7%
+  CLAUDE.md: 1, MCP: 2 │ Tools: 17 done
+  ⏵⏵ bypass permissions on";
+
+        assert!(tmux_capture_indicates_claude_tui_ready_for_input(capture));
+        assert!(!tmux_capture_indicates_claude_tui_actively_streaming(
+            capture
+        ));
+    }
+
+    #[test]
+    fn actively_streaming_rejects_idle_suggestion_chrome() {
+        // Idle-suggestion chrome is real post-finish ghost noise, not a live
+        // turn — must not be treated as actively streaming.
+        let capture = "\
+⏺ TUI-E2E marker
+✻ Worked for 2s
+────────────────────────────────────────────────────────────────────────────
+❯\u{00a0}좋아, 잘 동작하네
+────────────────────────────────────────────────────────────────────────────
+  🤖 Opus(H) │ ░░░░░░░░░░ │ 4%
+  CLAUDE.md: 1, MCP: 2 │ Tools: 0 done
+  ⏵⏵ bypass permissions on";
+
+        assert!(tmux_capture_indicates_claude_tui_idle_suggestion(capture));
+        assert!(!tmux_capture_indicates_claude_tui_actively_streaming(
+            capture
+        ));
+    }
+
+    #[test]
+    fn actively_streaming_rejects_empty_capture() {
+        assert!(!tmux_capture_indicates_claude_tui_actively_streaming(""));
+        assert!(!tmux_capture_indicates_claude_tui_actively_streaming(
+            "   \n  \n"
+        ));
     }
 }

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -239,7 +239,53 @@ fn tmux_line_is_claude_tui_spinner_progress(line: &str) -> bool {
         "crunching",
         "churning",
     ];
-    WORK_VERBS.iter().any(|verb| lower.starts_with(verb))
+    if !WORK_VERBS.iter().any(|verb| lower.starts_with(verb)) {
+        return false;
+    }
+    // #3107 codex re-review (F2): the leading glyph + work verb alone is NOT
+    // enough — a plain assistant sentence that happens to begin with a spinner
+    // glyph and a verb (e.g. `· Thinking through the problem and running the
+    // tests`) would otherwise read as the streaming footer. The REAL Claude TUI
+    // spinner line ALWAYS carries a status SUFFIX — it renders like
+    // `✻ Thinking… (12s · ↑ 1.2k tokens · esc to interrupt)`. Require at least
+    // one of those status markers so assistant prose can't trip it:
+    //   - the literal `esc to interrupt`, OR
+    //   - a parenthesized TUI status group containing a duration (`<N>s` /
+    //     `<N>m`), a `tokens` count, and/or the `·` separator the TUI uses.
+    if lower.contains("esc to interrupt") {
+        return true;
+    }
+    line_has_claude_tui_spinner_status_group(line)
+}
+
+/// `true` when `line` contains the parenthesized status group the Claude TUI
+/// spinner footer renders next to the work verb, e.g.
+/// `(12s · ↑ 1.2k tokens · esc to interrupt)`. The group must carry at least one
+/// of: a duration token (`<N>s` / `<N>m`), a `tokens` count, or the interior `·`
+/// separator the TUI draws between status fields. A bare parenthetical in
+/// assistant prose (no such marker) does NOT qualify.
+fn line_has_claude_tui_spinner_status_group(line: &str) -> bool {
+    let Some(open) = line.find('(') else {
+        return false;
+    };
+    let after_open = &line[open + 1..];
+    let Some(close_rel) = after_open.find(')') else {
+        return false;
+    };
+    let group = &after_open[..close_rel];
+    let lower = group.to_ascii_lowercase();
+    if lower.contains("esc to interrupt") || lower.contains("tokens") || group.contains('·') {
+        return true;
+    }
+    // A standalone duration token such as `12s` / `4m` inside the group.
+    group
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .any(|tok| {
+            let bytes = tok.as_bytes();
+            bytes.len() >= 2
+                && matches!(bytes[bytes.len() - 1], b's' | b'm')
+                && bytes[..bytes.len() - 1].iter().all(|b| b.is_ascii_digit())
+        })
 }
 
 pub(crate) fn tmux_capture_indicates_claude_tui_prompt_draft(capture: &str) -> bool {
@@ -1304,6 +1350,73 @@ some earlier assistant prose still on screen
 (13s · ↓ 1.2k tokens · esc to interrupt)";
         assert!(tmux_capture_indicates_claude_tui_busy(capture));
         assert!(tmux_capture_indicates_claude_tui_actively_streaming(
+            capture
+        ));
+    }
+
+    // #3107 codex re-review (F2 PARTIAL close): a spinner-progress line keyed on
+    // ONLY the leading glyph + work verb still false-positived on assistant prose
+    // that happens to begin with a spinner glyph and a verb. The real Claude TUI
+    // spinner footer ALWAYS carries a status SUFFIX (`esc to interrupt`, a
+    // duration, a token count, and/or the `·` separator). The recognizer now
+    // requires that suffix, so bare prose can no longer trip it.
+    #[test]
+    fn actively_streaming_rejects_glyph_verb_prose_without_status_suffix() {
+        // Assistant body line: leading spinner glyph + work verb, but NO Claude
+        // TUI status suffix → NOT a spinner-progress footer → NOT busy.
+        let capture = "\
+· Thinking through the problem and running the tests
+some more scrolled-back assistant prose
+another line of prior output";
+        assert!(!tmux_line_is_claude_tui_spinner_progress(
+            "· Thinking through the problem and running the tests"
+        ));
+        assert!(!tmux_capture_indicates_claude_tui_busy(capture));
+        assert!(!tmux_capture_indicates_claude_tui_actively_streaming(
+            capture
+        ));
+    }
+
+    #[test]
+    fn actively_streaming_accepts_real_spinner_with_status_suffix() {
+        // The genuine Claude TUI spinner footer: glyph + verb + parenthesized
+        // status group with a duration, token count, and `esc to interrupt`.
+        let line = "✻ Thinking… (12s · ↑ 1.2k tokens · esc to interrupt)";
+        assert!(tmux_line_is_claude_tui_spinner_progress(line));
+        let capture = format!("earlier assistant prose\n{line}");
+        assert!(tmux_capture_indicates_claude_tui_busy(&capture));
+        assert!(tmux_capture_indicates_claude_tui_actively_streaming(
+            &capture
+        ));
+    }
+
+    #[test]
+    fn actively_streaming_accepts_spinner_with_duration_only_status() {
+        // A spinner footer whose status group carries only a bare duration token
+        // (no `esc to interrupt`, no `tokens`) still qualifies.
+        let line = "✻ Thinking… (12s)";
+        assert!(tmux_line_is_claude_tui_spinner_progress(line));
+    }
+
+    #[test]
+    fn actively_streaming_rejects_glyph_verb_with_plain_parenthetical() {
+        // Glyph + verb followed by an ordinary parenthetical with no TUI status
+        // marker (no duration, no `tokens`, no `·`) must NOT qualify.
+        let line = "· Thinking about the design (a fresh idea here)";
+        assert!(!tmux_line_is_claude_tui_spinner_progress(line));
+    }
+
+    #[test]
+    fn actively_streaming_rejects_glyph_verb_past_tense_completion() {
+        // Past-tense `<verb> for <duration>` completion summary stays excluded.
+        let line = "· Running for 3s";
+        assert!(!tmux_line_is_claude_tui_spinner_progress(line));
+        let capture = "\
+· Running for 3s
+some scrolled-back prose line
+another scrolled-back prose line";
+        assert!(!tmux_capture_indicates_claude_tui_busy(capture));
+        assert!(!tmux_capture_indicates_claude_tui_actively_streaming(
             capture
         ));
     }

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -134,10 +134,19 @@ pub(crate) fn tmux_capture_indicates_claude_tui_ready_for_input(capture: &str) -
 /// This predicate gives the suppression/reclaim paths a way to tell a genuinely
 /// finished turn (returned to ready-for-input, or showing idle-suggestion
 /// chrome — the real post-finish ghost noise we DO want to suppress) apart from
-/// a live turn that merely lost its inflight. `true` means: the pane is neither
-/// ready-for-input NOR showing idle-suggestion chrome ⇒ it is actively
-/// producing ⇒ an active turn (that lost its inflight). `false` means the pane
-/// looks finished/idle, so existing suppression must stand.
+/// a live turn that merely lost its inflight.
+///
+/// #3107 codex re-review (P2#1): the original definition was
+/// `!ready_for_input && !idle_suggestion`, i.e. it treated the *absence* of
+/// idle markers as "streaming". That false-positived on every pane that is
+/// neither idle-marked nor busy: a scrolled pane, an error screen, a
+/// non-Claude-TUI pane, or a generic prompt-waiting pane all read as
+/// "streaming" → spurious un-suppress + re-acquire + reclaim-block. We now
+/// require a POSITIVE Claude-TUI busy signal, not merely the absence of idle
+/// chrome. `true` means: the pane IS a Claude TUI showing an active/busy
+/// indicator AND is not ready-for-input ⇒ a live turn that lost its inflight.
+/// Anything ambiguous (blank / error / scrolled / non-Claude / generic prompt)
+/// biases to `false` (keep suppressing) — the safe direction.
 pub(crate) fn tmux_capture_indicates_claude_tui_actively_streaming(capture: &str) -> bool {
     if capture.trim().is_empty() {
         return false;
@@ -148,7 +157,39 @@ pub(crate) fn tmux_capture_indicates_claude_tui_actively_streaming(capture: &str
     if tmux_capture_indicates_claude_tui_idle_suggestion(capture) {
         return false;
     }
-    true
+    // Positive busy signal required (bias to FALSE/suppress when ambiguous).
+    tmux_capture_indicates_claude_tui_busy(capture)
+}
+
+/// #3107 codex re-review (P2#1): a POSITIVE "Claude TUI is mid-response right
+/// now" signal. Reuses the same busy keywords / active-work markers that the
+/// ready-for-input detector keys off (`esc to interrupt`, spinner verbs,
+/// `⏺ Running/Searching/Reading/Editing …`, etc.) over the recent capture
+/// window. Unlike the absence-of-idle heuristic this cannot be satisfied by a
+/// scrolled / error / non-Claude / generic-prompt pane, so an ambiguous pane is
+/// never misclassified as streaming.
+pub(crate) fn tmux_capture_indicates_claude_tui_busy(capture: &str) -> bool {
+    let non_empty = capture
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .collect::<Vec<_>>();
+    if non_empty.is_empty() {
+        return false;
+    }
+    let start = non_empty.len().saturating_sub(CLAUDE_TUI_ACTIVE_SCAN_LINES);
+    let recent = &non_empty[start..];
+    // The spinner-verb / "esc to interrupt" / "processing"/"thinking"/"running"
+    // keywords (the same set `..._show_idle_suggestion_chrome` treats as the
+    // "busy → not idle" override) plus the explicit active-work markers
+    // (`Actioning`, `Musing`, `⏺ Running/Searching/Reading/Editing …`).
+    recent.iter().any(|line| {
+        let trimmed = trim_prompt_line(line);
+        let lower = trimmed.to_ascii_lowercase();
+        lower.contains("esc to interrupt")
+            || lower.contains("processing")
+            || lower.contains("thinking")
+            || lower.contains("running")
+    }) || tmux_recent_lines_show_claude_tui_active_work(recent)
 }
 
 pub(crate) fn tmux_capture_indicates_claude_tui_prompt_draft(capture: &str) -> bool {
@@ -1112,6 +1153,74 @@ assistant output
         assert!(!tmux_capture_indicates_claude_tui_actively_streaming(""));
         assert!(!tmux_capture_indicates_claude_tui_actively_streaming(
             "   \n  \n"
+        ));
+    }
+
+    // #3107 codex re-review (P2#1): the original `!ready && !idle` definition
+    // false-positived any pane that was merely not-idle as "streaming". The
+    // tightened definition requires a POSITIVE busy signal, so a non-Claude /
+    // error / scrolled / generic-prompt pane biases to FALSE (keep suppressing).
+    #[test]
+    fn actively_streaming_rejects_non_claude_pane() {
+        // A plain shell prompt — not a Claude TUI at all — has no busy marker.
+        let capture = "\
+user@host ~/work %\u{00a0}
+$ ls -la
+total 0
+$ ";
+        assert!(!tmux_capture_indicates_claude_tui_actively_streaming(
+            capture
+        ));
+    }
+
+    #[test]
+    fn actively_streaming_rejects_error_screen() {
+        // An error/backtrace screen left in the pane is finished, not streaming.
+        let capture = "\
+thread 'main' panicked at src/lib.rs:42:9:
+called `Result::unwrap()` on an `Err` value: Broken pipe
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+error: process didn't exit successfully (exit status: 101)";
+        assert!(!tmux_capture_indicates_claude_tui_actively_streaming(
+            capture
+        ));
+    }
+
+    #[test]
+    fn actively_streaming_rejects_scrolled_pane_without_busy_marker() {
+        // A scrolled-back pane showing prior assistant output with no live
+        // busy/spinner marker must not read as streaming.
+        let capture = "\
+⏺ Here is the summary of the changes I made earlier.
+  ⎿  Edited 3 files, ran the test suite, all green.
+some scrolled-back prose line
+another scrolled-back prose line";
+        assert!(!tmux_capture_indicates_claude_tui_actively_streaming(
+            capture
+        ));
+    }
+
+    #[test]
+    fn actively_streaming_rejects_generic_prompt_waiting_pane() {
+        // A generic prompt-waiting pane (no Claude busy chrome) is ambiguous and
+        // must bias to FALSE (suppress), not be relayed as streaming.
+        let capture = "\
+Press any key to continue . . .
+> ";
+        assert!(!tmux_capture_indicates_claude_tui_actively_streaming(
+            capture
+        ));
+    }
+
+    #[test]
+    fn actively_streaming_accepts_claude_busy_spinner_verb() {
+        // A real Claude TUI mid-response with a spinner verb + active-work marker
+        // (no ready/idle chrome) is the genuine "live turn lost its inflight" case.
+        let capture = "\
+⏺ Reading src/main.rs
+· Musing… (12s · ↓ 2.1k tokens)";
+        assert!(tmux_capture_indicates_claude_tui_actively_streaming(
+            capture
         ));
     }
 }

--- a/src/services/tmux_common.rs
+++ b/src/services/tmux_common.rs
@@ -161,13 +161,28 @@ pub(crate) fn tmux_capture_indicates_claude_tui_actively_streaming(capture: &str
     tmux_capture_indicates_claude_tui_busy(capture)
 }
 
-/// #3107 codex re-review (P2#1): a POSITIVE "Claude TUI is mid-response right
-/// now" signal. Reuses the same busy keywords / active-work markers that the
-/// ready-for-input detector keys off (`esc to interrupt`, spinner verbs,
-/// `⏺ Running/Searching/Reading/Editing …`, etc.) over the recent capture
-/// window. Unlike the absence-of-idle heuristic this cannot be satisfied by a
-/// scrolled / error / non-Claude / generic-prompt pane, so an ambiguous pane is
-/// never misclassified as streaming.
+/// #3107 codex re-review (P2#1, F2): a POSITIVE "Claude TUI is mid-response
+/// right now" signal that requires Claude-TUI-SPECIFIC CHROME, not generic
+/// words. The previous implementation accepted any recent line containing the
+/// bare substrings `processing` / `thinking` / `running`. Those words routinely
+/// appear in ASSISTANT BODY TEXT (e.g. the model writing "the test is
+/// running…") and in non-Claude program output, so a finished or even
+/// non-Claude pane could read as "actively streaming" → wrongly un-suppress /
+/// re-acquire / block reclaim.
+///
+/// The reliable in-progress markers the Claude TUI actually RENDERS are:
+///   1. the `esc to interrupt` footer — the strongest, unambiguous signal; it
+///      only renders while a turn is in flight; and
+///   2. the spinner progress line — a leading spinner glyph (`· ✢ ✻ ✽ ✶ ✳ ✦`)
+///      immediately followed by a work verb (`Actioning…`, `Musing…`,
+///      `Thinking…`, `Processing…`, `Running…`, …). This is the footer the TUI
+///      draws while streaming, NOT free-text in the response body.
+/// Plus the explicit `⏺ Running command / Searching for / Reading / Editing …`
+/// active-work markers via `tmux_recent_lines_show_claude_tui_active_work`.
+///
+/// Bare `processing`/`thinking`/`running` NOT anchored to the spinner glyph or
+/// the `esc to interrupt` footer are DROPPED. Anything that is not a
+/// recognizable Claude-TUI in-progress frame biases to FALSE.
 pub(crate) fn tmux_capture_indicates_claude_tui_busy(capture: &str) -> bool {
     let non_empty = capture
         .lines()
@@ -178,18 +193,53 @@ pub(crate) fn tmux_capture_indicates_claude_tui_busy(capture: &str) -> bool {
     }
     let start = non_empty.len().saturating_sub(CLAUDE_TUI_ACTIVE_SCAN_LINES);
     let recent = &non_empty[start..];
-    // The spinner-verb / "esc to interrupt" / "processing"/"thinking"/"running"
-    // keywords (the same set `..._show_idle_suggestion_chrome` treats as the
-    // "busy → not idle" override) plus the explicit active-work markers
-    // (`Actioning`, `Musing`, `⏺ Running/Searching/Reading/Editing …`).
     recent.iter().any(|line| {
         let trimmed = trim_prompt_line(line);
-        let lower = trimmed.to_ascii_lowercase();
-        lower.contains("esc to interrupt")
-            || lower.contains("processing")
-            || lower.contains("thinking")
-            || lower.contains("running")
+        // (1) the `esc to interrupt` footer — strongest in-flight marker.
+        if trimmed.to_ascii_lowercase().contains("esc to interrupt") {
+            return true;
+        }
+        // (2) the spinner progress line: a leading spinner glyph adjacent to a
+        // work verb, as the Claude TUI renders the streaming footer. The
+        // verb-word match is ANCHORED to the spinner glyph so the same word in
+        // assistant body text does NOT trip it.
+        tmux_line_is_claude_tui_spinner_progress(trimmed)
     }) || tmux_recent_lines_show_claude_tui_active_work(recent)
+}
+
+/// `true` when `line` is a Claude TUI spinner progress footer: a leading spinner
+/// glyph (the rotating set the TUI cycles through) directly followed by a work
+/// verb. Anchoring the verb to the spinner glyph is what distinguishes the TUI
+/// chrome from the same verb appearing in assistant body text.
+fn tmux_line_is_claude_tui_spinner_progress(line: &str) -> bool {
+    const SPINNER_GLYPHS: [char; 8] = ['·', '✢', '✳', '✶', '✻', '✽', '✦', '∗'];
+    let line = line.trim_start();
+    let mut chars = line.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !SPINNER_GLYPHS.contains(&first) {
+        return false;
+    }
+    // The remainder after the glyph (and its following space) must lead with a
+    // work verb the TUI uses for the streaming footer. Completed-work summaries
+    // (`✻ Churned for 4m 56s`, `✻ Worked for 2s`) use a past-tense "<verb> for
+    // <duration>" shape and must NOT count as in-progress.
+    let rest = chars.as_str().trim_start();
+    let lower = rest.to_ascii_lowercase();
+    if lower.contains(" for ") && !lower.contains("esc to interrupt") {
+        return false;
+    }
+    const WORK_VERBS: [&str; 7] = [
+        "actioning",
+        "musing",
+        "thinking",
+        "processing",
+        "running",
+        "crunching",
+        "churning",
+    ];
+    WORK_VERBS.iter().any(|verb| lower.starts_with(verb))
 }
 
 pub(crate) fn tmux_capture_indicates_claude_tui_prompt_draft(capture: &str) -> bool {
@@ -1219,6 +1269,40 @@ Press any key to continue . . .
         let capture = "\
 ⏺ Reading src/main.rs
 · Musing… (12s · ↓ 2.1k tokens)";
+        assert!(tmux_capture_indicates_claude_tui_actively_streaming(
+            capture
+        ));
+    }
+
+    // #3107 codex re-review (P2, F2): the busy classifier previously accepted any
+    // recent line containing the bare substrings `running`/`processing`/`thinking`.
+    // Those words appear in normal ASSISTANT BODY text, so a pane that has
+    // finished but still shows such prose was mis-read as streaming. The marker
+    // must be Claude-TUI chrome (spinner glyph / `esc to interrupt`), not a word.
+    #[test]
+    fn actively_streaming_rejects_assistant_body_with_busy_words_but_no_chrome() {
+        // Assistant body text mentions "running" / "processing" / "thinking" but
+        // there is NO `esc to interrupt` footer and NO spinner progress line.
+        let capture = "\
+⏺ I checked the build: the test suite is running in CI and the worker is
+  still processing the queue while thinking through the edge cases.
+some more scrolled-back assistant prose
+another line of prior output";
+        assert!(!tmux_capture_indicates_claude_tui_busy(capture));
+        assert!(!tmux_capture_indicates_claude_tui_actively_streaming(
+            capture
+        ));
+    }
+
+    // #3107 F2: a real Claude TUI in-progress frame keyed only on the strongest
+    // marker (`esc to interrupt`) — no spinner verb, no `⏺` active-work line —
+    // must still read as streaming.
+    #[test]
+    fn actively_streaming_accepts_esc_to_interrupt_footer_only() {
+        let capture = "\
+some earlier assistant prose still on screen
+(13s · ↓ 1.2k tokens · esc to interrupt)";
+        assert!(tmux_capture_indicates_claude_tui_busy(capture));
         assert!(tmux_capture_indicates_claude_tui_actively_streaming(
             capture
         ));


### PR DESCRIPTION
Closes #3107

## Problem
A multi-step agentic Claude TUI turn (watcher_direct) can lose its dcserver inflight mid-turn — a momentary idle observation between tool calls (pane briefly drops the busy marker, or an intermediate JSONL `result`/Stop hook) trips the completion gate, commits, and clears inflight while the pane keeps producing. After that `inflight_missing` is latched and every later streaming/post-terminal batch is treated as ownerless and suppressed, so the live base session goes dark. The #3003 reclaim then deletes the live turn's status panel (`frame_ack_outcome=MissingTarget`).

## Root cause (verified, current lines)
- `should_skip_streaming_placeholder_without_inflight` (lifecycle.rs) / streaming guard (tmux_watcher.rs) suppress on `inflight_missing` alone.
- `should_suppress_post_terminal_output_without_inflight` (lifecycle.rs) / post-terminal guard (tmux_watcher.rs) likewise.
- `watcher_external_input_turn_abandoned` (tmux_watcher.rs) returns `true` on `load_inflight_state == None`, so the reclaim deletes the live panel.

## Fix — SAFE, ADDITIVE self-heal
Does **not** weaken suppression for genuine post-finish ghost noise (provider-selector chrome etc. still suppressed). The asymmetry is the whole point and is unit-tested.

**CHANGE 1 — gate both suppressions on a live-pane-busy probe.** New inflight-INDEPENDENT signal `tmux_capture_indicates_claude_tui_actively_streaming` (tmux_common.rs): NOT ready-for-input AND NOT idle-suggestion chrome ⇒ actively producing. Both lifecycle predicates take a `pane_actively_streaming` arg and only suppress when inflight is missing AND the pane is not streaming. The probe is **throttled** — captured only when the cheap inflight-missing prefix is already true and we are about to suppress (mirrors the existing lazy SSH-direct computation), so the hot path cost is unchanged.

**CHANGE 2 — re-acquire a watcher-owned inflight** when the pane is actively streaming but inflight is missing. `reacquire_watcher_inflight_for_active_stream` writes a minimal `InflightTurnState` (`relay_owner_kind = Watcher`, `TurnSource::ExternalInput`, session tmux/output paths, reusing the still-present status-panel/placeholder ids as the streaming-edit target → kills MissingTarget). Idempotent (no-op if an inflight already exists) + one bounded incident log per dispatch.

**CHANGE 3 — stop deleting a live turn's panel on inflight-absence alone.** The `None` arm of `watcher_external_input_turn_abandoned` now requires the pane is NOT actively streaming (`watcher_inflight_absence_is_abandonment`). Genuine orphans (inflight gone AND pane idle/ready-for-input) are still reclaimed.

## Tests
- lifecycle: `(inflight_missing=true, pane_streaming=true) → not suppressed`, `(true,false) → suppressed` for both predicates (asymmetry proven).
- tmux_common: classifier returns true for busy `esc to interrupt` pane, false for ready-for-input / idle-suggestion chrome / empty.
- watcher: re-acquire registers a Watcher-owned inflight with the placeholder pinned as target and is idempotent; abandonment decision preserves the panel for a busy pane and reclaims an idle one.

## Gates
- `cargo fmt --all --check` clean
- `cargo check --workspace --all-features --all-targets` clean
- touched-module tests green (tmux_watcher, watchers/lifecycle, inflight, tmux_common)
- `./scripts/ci-script-checks.sh` exit 0 (synced `change-surfaces.md` freeze entries: lifecycle.rs 2286→2301, tmux_watcher.rs 6939→7114)

🤖 Generated with [Claude Code](https://claude.com/claude-code)