### PR TITLE
refactor(discord): typed InflightTurnState ownership writes (status panel bind/clear-if-current) (#3077)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -120,7 +120,7 @@
     failover guard; #3087 `session_panel_instance_key`/`write_spawn_nonce`
     re-exports; #3107 `RestoredWatcherTurn.injected_prompt_message_id`;
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (7223 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (7347 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -132,6 +132,9 @@
     preserves the panel under an active turn; +16 from #3077 routing the
     TUI-direct status-panel publish + orphan-cleanup writes through the typed
     `inflight::bind_status_panel` / `clear_status_panel_if_current` ownership ops;
+    +124 from #3077 codex P1 honoring the `bind_status_panel` return at the
+    TUI-direct publish site (delete the just-sent panel + disown the handle when
+    the bind did not record it, instead of leaking a duplicate);
     split loop helpers further before adding behavior).
   - `src/services/discord/tui_prompt_relay.rs` (3849 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -120,7 +120,7 @@
     failover guard; #3087 `session_panel_instance_key`/`write_spawn_nonce`
     re-exports; #3107 `RestoredWatcherTurn.injected_prompt_message_id`;
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (7207 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (7223 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -129,8 +129,10 @@
     external-input turns (+9 from the #3099 re-review pinned-injected-message-id
     cleanup target) + #3107 self-heal: throttled live-pane-busy probe gates the
     inflight-missing suppressions, re-acquires a watcher-owned inflight, and
-    preserves the panel under an active turn; split loop helpers further before
-    adding behavior).
+    preserves the panel under an active turn; +16 from #3077 routing the
+    TUI-direct status-panel publish + orphan-cleanup writes through the typed
+    `inflight::bind_status_panel` / `clear_status_panel_if_current` ownership ops;
+    split loop helpers further before adding behavior).
   - `src/services/discord/tui_prompt_relay.rs` (3849 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +4 from #3082 queued-only answer-flush gate

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -120,7 +120,7 @@
     failover guard; #3087 `session_panel_instance_key`/`write_spawn_nonce`
     re-exports; #3107 `RestoredWatcherTurn.injected_prompt_message_id`;
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (7347 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (7369 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -1260,9 +1260,12 @@ pub(in crate::services::discord) enum StatusPanelBindOutcome {
     Bound,
     /// The row already carried `msg_id`; nothing was written.
     AlreadyBound,
-    /// The row exists but a real panel id is already set and
-    /// `skip_if_panel_already_set` was requested — left untouched.
-    SkippedPanelAlreadySet,
+    /// The row exists but a DIFFERENT real panel id is already set and
+    /// `skip_if_panel_already_set` was requested — left untouched. Carries the
+    /// row's currently-owned (real) panel id as observed under the same flock,
+    /// so the caller can adopt the row's actual panel without a second
+    /// (racy) re-read of the inflight row.
+    SkippedPanelAlreadySet(u64),
     /// No inflight row exists for `(provider, channel_id)`.
     Missing,
     /// The on-disk row did not satisfy `require_user_msg_id` /
@@ -1318,11 +1321,23 @@ fn bind_status_panel_in_root(
     {
         return StatusPanelBindOutcome::GuardMismatch;
     }
-    if guard.skip_if_panel_already_set && status_panel_id_is_real(state.status_message_id) {
-        return StatusPanelBindOutcome::SkippedPanelAlreadySet;
-    }
+    // Same-id re-bind is idempotent and must classify as `AlreadyBound`
+    // REGARDLESS of `skip_if_panel_already_set` — an idempotent re-bind of the
+    // panel this row already owns is a no-op, not a "duplicate skip". Checking
+    // the skip flag first (#3077 codex P2 #1) misclassified a same-id re-bind as
+    // `SkippedPanelAlreadySet`, which the TUI-direct caller then routed to a
+    // DELETE of the row's own already-bound panel. Order: same-id → AlreadyBound;
+    // else a DIFFERENT real id already set + skip flag → SkippedPanelAlreadySet.
     if state.status_message_id == Some(msg_id) {
         return StatusPanelBindOutcome::AlreadyBound;
+    }
+    if guard.skip_if_panel_already_set && status_panel_id_is_real(state.status_message_id) {
+        // Safe: `status_panel_id_is_real` only returns true for `Some(real)`,
+        // and we already handled `Some(msg_id)` above, so this is a DIFFERENT
+        // real panel id. Carry it so the caller adopts the row's owned panel.
+        return StatusPanelBindOutcome::SkippedPanelAlreadySet(
+            state.status_message_id.unwrap_or_default(),
+        );
     }
     state.status_message_id = Some(msg_id);
     match persist_under_lock(
@@ -2690,9 +2705,76 @@ mod stall_recovery_tests {
             },
         );
 
-        assert_eq!(outcome, StatusPanelBindOutcome::SkippedPanelAlreadySet);
+        // Carries the row's owned (DIFFERENT) panel id so the caller can adopt it.
+        assert_eq!(
+            outcome,
+            StatusPanelBindOutcome::SkippedPanelAlreadySet(4242)
+        );
         // Canonical panel preserved — not overwritten by the duplicate.
         assert_eq!(loaded_status_message_id(temp.path(), 7004), Some(4242));
+    }
+
+    #[test]
+    fn bind_status_panel_same_id_is_already_bound_even_with_skip_flag() {
+        // #3077 (codex P2 #1): an idempotent re-bind of the SAME panel id the row
+        // already owns must classify as `AlreadyBound`, NOT
+        // `SkippedPanelAlreadySet`, even when `skip_if_panel_already_set` is set.
+        // Misclassifying it routed the TUI-direct caller to DELETE its own panel.
+        let temp = TempDir::new().unwrap();
+        seed_status_panel_state(
+            temp.path(),
+            7007,
+            10,
+            11,
+            Some("AgentDesk-claude-a"),
+            Some(5555),
+        );
+
+        let outcome = bind_status_panel_in_root(
+            temp.path(),
+            &ProviderKind::Claude,
+            7007,
+            5555,
+            &StatusPanelBindGuard {
+                skip_if_panel_already_set: true,
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(outcome, StatusPanelBindOutcome::AlreadyBound);
+        assert_eq!(loaded_status_message_id(temp.path(), 7007), Some(5555));
+    }
+
+    #[test]
+    fn bind_status_panel_different_id_skips_and_reports_owned_id() {
+        // A DIFFERENT real panel id already set + skip flag → SkippedPanelAlreadySet
+        // carrying the row's owned id (so the caller adopts the real panel).
+        let temp = TempDir::new().unwrap();
+        seed_status_panel_state(
+            temp.path(),
+            7008,
+            10,
+            11,
+            Some("AgentDesk-claude-a"),
+            Some(4242),
+        );
+
+        let outcome = bind_status_panel_in_root(
+            temp.path(),
+            &ProviderKind::Claude,
+            7008,
+            5555,
+            &StatusPanelBindGuard {
+                skip_if_panel_already_set: true,
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(
+            outcome,
+            StatusPanelBindOutcome::SkippedPanelAlreadySet(4242)
+        );
+        assert_eq!(loaded_status_message_id(temp.path(), 7008), Some(4242));
     }
 
     #[test]

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -1213,6 +1213,237 @@ fn save_inflight_state_if_absent_in_root(
     Ok(true)
 }
 
+// ---------------------------------------------------------------------------
+// #3077: typed status-panel ownership writes.
+//
+// `status_message_id` is the de-facto "this turn owns status panel M" pointer,
+// and several independent actors (turn-bridge completion fallback, tmux watcher
+// TUI-direct publish/orphan-cleanup, placeholder sweeper) used to mutate it via
+// a non-atomic `load_inflight_state(...)` → `state.status_message_id = …` →
+// `save_inflight_state(...)` triple. Because the read and the write were not
+// serialized against each other, a newer turn that rebound the panel between a
+// stale actor's load and its blind `= None` could have its panel silently
+// orphaned (the #3099/#3100/#3105/#3107 panel-lifecycle race family).
+//
+// These helpers centralize that read-modify-write behind intentful operations
+// that hold the same `lock_inflight_state_path` sidecar flock across the whole
+// compare-and-set, exactly like `save_inflight_state_if_absent`. Callers no
+// longer touch the field directly; they declare *what* they own and *under
+// which precondition*, and the store enforces it atomically.
+
+/// Per-turn precondition for `bind_status_panel`. Lets each caller carry its
+/// own ownership invariant into the lock-held read-modify-write so the guard
+/// check and the write cannot be split by a concurrent writer (TOCTOU).
+#[derive(Debug, Clone, Default)]
+pub(in crate::services::discord) struct StatusPanelBindGuard {
+    /// Bind only when the on-disk row still belongs to this `user_msg_id`.
+    /// `None` means "do not guard on user_msg_id" (used by callers that have
+    /// already established identity another way). Mirrors the turn-bridge
+    /// status-panel-v2 completion fallback guard.
+    pub require_user_msg_id: Option<u64>,
+    /// Bind only when the on-disk row still matches this full turn identity
+    /// (user_msg_id + started_at + tmux_session_name). Mirrors the tmux
+    /// watcher TUI-direct publish guard that defeats turn handoff during the
+    /// Discord send await.
+    pub require_identity: Option<InflightTurnIdentity>,
+    /// When true, do not overwrite a real (non-synthetic) panel id already on
+    /// the row — an overlapping actor already published the canonical panel
+    /// and our send is a duplicate (#3003 reclaim path). Synthetic-headless
+    /// ids do not count as "already set".
+    pub skip_if_panel_already_set: bool,
+}
+
+/// Outcome of a `bind_status_panel` attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::services::discord) enum StatusPanelBindOutcome {
+    /// The row was found, passed the guard, and now carries `msg_id`.
+    Bound,
+    /// The row already carried `msg_id`; nothing was written.
+    AlreadyBound,
+    /// The row exists but a real panel id is already set and
+    /// `skip_if_panel_already_set` was requested — left untouched.
+    SkippedPanelAlreadySet,
+    /// No inflight row exists for `(provider, channel_id)`.
+    Missing,
+    /// The on-disk row did not satisfy `require_user_msg_id` /
+    /// `require_identity` — left untouched (a different turn now owns the row).
+    GuardMismatch,
+    /// Filesystem / serialization failure while persisting the bind.
+    IoError,
+}
+
+/// Intentful "this turn now owns status panel `msg_id`" write. Performs the
+/// guard check and the field set atomically under the inflight sidecar flock,
+/// so it is consistent with `save_inflight_state` / `save_inflight_state_if_absent`.
+pub(in crate::services::discord) fn bind_status_panel(
+    provider: &ProviderKind,
+    channel_id: u64,
+    msg_id: u64,
+    guard: &StatusPanelBindGuard,
+) -> StatusPanelBindOutcome {
+    let Some(root) = inflight_runtime_root() else {
+        return StatusPanelBindOutcome::IoError;
+    };
+    bind_status_panel_in_root(&root, provider, channel_id, msg_id, guard)
+}
+
+fn bind_status_panel_in_root(
+    root: &Path,
+    provider: &ProviderKind,
+    channel_id: u64,
+    msg_id: u64,
+    guard: &StatusPanelBindGuard,
+) -> StatusPanelBindOutcome {
+    let path = inflight_state_path(root, provider, channel_id);
+    if let Some(parent) = path.parent()
+        && fs::create_dir_all(parent).is_err()
+    {
+        return StatusPanelBindOutcome::IoError;
+    }
+    // Hold the sidecar flock across load → guard → set so a concurrent
+    // writer cannot land between the guard check and the write.
+    let Ok(_lock) = lock_inflight_state_path(&path) else {
+        return StatusPanelBindOutcome::IoError;
+    };
+    let Some(mut state) = load_inflight_state_unlocked(&path) else {
+        return StatusPanelBindOutcome::Missing;
+    };
+    if let Some(expected) = guard.require_user_msg_id
+        && state.user_msg_id != expected
+    {
+        return StatusPanelBindOutcome::GuardMismatch;
+    }
+    if let Some(expected) = guard.require_identity.as_ref()
+        && !expected.matches_state(&state)
+    {
+        return StatusPanelBindOutcome::GuardMismatch;
+    }
+    if guard.skip_if_panel_already_set && status_panel_id_is_real(state.status_message_id) {
+        return StatusPanelBindOutcome::SkippedPanelAlreadySet;
+    }
+    if state.status_message_id == Some(msg_id) {
+        return StatusPanelBindOutcome::AlreadyBound;
+    }
+    state.status_message_id = Some(msg_id);
+    match persist_under_lock(
+        root,
+        &path,
+        &state,
+        "src/services/discord/inflight.rs:bind_status_panel_in_root",
+    ) {
+        Ok(()) => StatusPanelBindOutcome::Bound,
+        Err(_) => StatusPanelBindOutcome::IoError,
+    }
+}
+
+/// Per-turn precondition for `clear_status_panel_if_current`. The msg-id
+/// compare-and-clear is unconditional; these add the caller's extra ownership
+/// guards (so a sweeper/cleanup that loaded a stale snapshot does not clear a
+/// row a newer turn already advanced).
+#[derive(Debug, Clone, Default)]
+pub(in crate::services::discord) struct StatusPanelClearGuard {
+    /// Clear only when the on-disk row still belongs to this `user_msg_id`.
+    pub require_user_msg_id: Option<u64>,
+    /// Clear only when the on-disk row still carries this `current_msg_id`
+    /// (placeholder sweeper convergence guard).
+    pub require_current_msg_id: Option<u64>,
+    /// Clear only when the on-disk row's tmux session still matches (watcher
+    /// orphan-cleanup guard).
+    pub require_tmux_session_name: Option<String>,
+}
+
+/// Compare-and-clear: clears `status_message_id` ONLY when it currently equals
+/// `msg_id` (and every guard precondition holds). Returns `true` iff it
+/// cleared. This is the #3077 hardening — a blind `= None` becomes a
+/// compare-and-clear so a panel a *newer* turn rebound is never wiped by a
+/// stale actor that loaded an older snapshot.
+pub(in crate::services::discord) fn clear_status_panel_if_current(
+    provider: &ProviderKind,
+    channel_id: u64,
+    msg_id: u64,
+    guard: &StatusPanelClearGuard,
+) -> bool {
+    let Some(root) = inflight_runtime_root() else {
+        return false;
+    };
+    clear_status_panel_if_current_in_root(&root, provider, channel_id, msg_id, guard)
+}
+
+fn clear_status_panel_if_current_in_root(
+    root: &Path,
+    provider: &ProviderKind,
+    channel_id: u64,
+    msg_id: u64,
+    guard: &StatusPanelClearGuard,
+) -> bool {
+    let path = inflight_state_path(root, provider, channel_id);
+    let Ok(_lock) = lock_inflight_state_path(&path) else {
+        return false;
+    };
+    let Some(mut state) = load_inflight_state_unlocked(&path) else {
+        return false;
+    };
+    if state.status_message_id != Some(msg_id) {
+        return false;
+    }
+    if let Some(expected) = guard.require_user_msg_id
+        && state.user_msg_id != expected
+    {
+        return false;
+    }
+    if let Some(expected) = guard.require_current_msg_id
+        && state.current_msg_id != expected
+    {
+        return false;
+    }
+    if let Some(expected) = guard.require_tmux_session_name.as_deref()
+        && state.tmux_session_name.as_deref() != Some(expected)
+    {
+        return false;
+    }
+    state.status_message_id = None;
+    persist_under_lock(
+        root,
+        &path,
+        &state,
+        "src/services/discord/inflight.rs:clear_status_panel_if_current_in_root",
+    )
+    .is_ok()
+}
+
+/// `true` when `id` is a real Discord panel id (present and not a synthetic
+/// headless placeholder). Mirrors `turn_bridge::normalize_status_panel_message_id`
+/// without pulling in the serenity `MessageId` newtype.
+fn status_panel_id_is_real(id: Option<u64>) -> bool {
+    match id {
+        Some(value) => !super::is_synthetic_headless_message_id_raw(value),
+        None => false,
+    }
+}
+
+/// Reads + deserializes the inflight row at `path` while the caller holds the
+/// sidecar flock. Returns `None` on a missing/malformed file (same lenient
+/// posture as `load_inflight_state`).
+fn load_inflight_state_unlocked(path: &Path) -> Option<InflightTurnState> {
+    let data = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+/// Shared lock-held persist tail: validate, stamp `updated_at`, atomic-write.
+/// Caller must already hold `lock_inflight_state_path`.
+fn persist_under_lock(
+    root: &Path,
+    path: &Path,
+    state: &InflightTurnState,
+    caller: &'static str,
+) -> Result<(), String> {
+    validate_inflight_state_for_save(root, path, state, caller);
+    let mut updated = state.clone();
+    updated.updated_at = now_string();
+    let json = serde_json::to_string_pretty(&updated).map_err(|e| e.to_string())?;
+    atomic_write(path, &json)
+}
+
 pub(crate) fn clear_inflight_state(provider: &ProviderKind, channel_id: u64) -> bool {
     let Some(root) = inflight_runtime_root() else {
         return false;
@@ -2197,18 +2428,21 @@ pub(in crate::services::discord) enum InflightSignal {
 mod stall_recovery_tests {
     use super::{
         GuardedClearOutcome, INFLIGHT_STALENESS_THRESHOLD_SECS, InflightRestartMode,
-        InflightTurnIdentity, InflightTurnState, RelayOwnerKind,
+        InflightTurnIdentity, InflightTurnState, RelayOwnerKind, StatusPanelBindGuard,
+        StatusPanelBindOutcome, StatusPanelClearGuard, bind_status_panel_in_root,
         clear_inflight_state_if_matches_identity_after_delivery_in_root,
         clear_inflight_state_if_matches_identity_in_root, clear_inflight_state_if_matches_in_root,
         clear_inflight_state_if_matches_tmux_response_in_root,
-        inflight_state_allows_idle_tmux_repair_state, inflight_state_is_stale, inflight_state_path,
-        load_inflight_states_from_root, lock_inflight_state_path, normalize_response_sent_offset,
+        clear_status_panel_if_current_in_root, inflight_state_allows_idle_tmux_repair_state,
+        inflight_state_is_stale, inflight_state_path, load_inflight_states_from_root,
+        lock_inflight_state_path, normalize_response_sent_offset,
         refresh_inflight_last_offset_if_matches_identity_in_root, save_inflight_state_in_root,
         validate_inflight_state_for_save,
     };
     use crate::services::agent_protocol::RuntimeHandoffKind;
     use crate::services::provider::ProviderKind;
     use chrono::TimeZone;
+    use std::path::Path;
     use tempfile::TempDir;
 
     /// `inflight_state_is_stale` must flip to true once `updated_at` is
@@ -2325,6 +2559,343 @@ mod stall_recovery_tests {
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].status_message_id, Some(123_456));
         assert_eq!(loaded[0].current_msg_id, 99);
+    }
+
+    // ---- #3077: typed status-panel ownership write tests ----
+
+    /// Seeds a single inflight row in `root` and returns it. `user_msg_id` /
+    /// `current_msg_id` / `status_message_id` are caller-controlled so the
+    /// guard semantics can be exercised.
+    fn seed_status_panel_state(
+        root: &Path,
+        channel_id: u64,
+        user_msg_id: u64,
+        current_msg_id: u64,
+        tmux_session_name: Option<&str>,
+        status_message_id: Option<u64>,
+    ) -> InflightTurnState {
+        let mut state = InflightTurnState::new(
+            ProviderKind::Claude,
+            channel_id,
+            Some("adk-claude".to_string()),
+            user_msg_id,
+            user_msg_id,
+            current_msg_id,
+            "hello".to_string(),
+            Some("session-1".to_string()),
+            tmux_session_name.map(str::to_string),
+            Some("/tmp/out.jsonl".to_string()),
+            Some("/tmp/in.fifo".to_string()),
+            0,
+        );
+        // `new()` takes (.., request_owner_user_id, user_msg_id, current_msg_id, ..);
+        // pin the guard-relevant fields explicitly so the test intent is exact.
+        state.user_msg_id = user_msg_id;
+        state.current_msg_id = current_msg_id;
+        state.status_message_id = status_message_id;
+        save_inflight_state_in_root(root, &state).expect("seed inflight state");
+        state
+    }
+
+    fn loaded_status_message_id(root: &Path, channel_id: u64) -> Option<u64> {
+        load_inflight_states_from_root(root, &ProviderKind::Claude)
+            .into_iter()
+            .find(|s| s.channel_id == channel_id)
+            .and_then(|s| s.status_message_id)
+    }
+
+    #[test]
+    fn bind_status_panel_sets_id_when_unguarded() {
+        let temp = TempDir::new().unwrap();
+        seed_status_panel_state(temp.path(), 7001, 10, 11, Some("AgentDesk-claude-a"), None);
+
+        let outcome = bind_status_panel_in_root(
+            temp.path(),
+            &ProviderKind::Claude,
+            7001,
+            5555,
+            &StatusPanelBindGuard::default(),
+        );
+
+        assert_eq!(outcome, StatusPanelBindOutcome::Bound);
+        assert_eq!(loaded_status_message_id(temp.path(), 7001), Some(5555));
+    }
+
+    #[test]
+    fn bind_status_panel_is_idempotent_when_already_bound() {
+        let temp = TempDir::new().unwrap();
+        seed_status_panel_state(
+            temp.path(),
+            7002,
+            10,
+            11,
+            Some("AgentDesk-claude-a"),
+            Some(5555),
+        );
+
+        let outcome = bind_status_panel_in_root(
+            temp.path(),
+            &ProviderKind::Claude,
+            7002,
+            5555,
+            &StatusPanelBindGuard::default(),
+        );
+
+        assert_eq!(outcome, StatusPanelBindOutcome::AlreadyBound);
+        assert_eq!(loaded_status_message_id(temp.path(), 7002), Some(5555));
+    }
+
+    #[test]
+    fn bind_status_panel_respects_user_msg_id_guard() {
+        let temp = TempDir::new().unwrap();
+        seed_status_panel_state(temp.path(), 7003, 10, 11, Some("AgentDesk-claude-a"), None);
+
+        // Guard expects a different user_msg_id (a newer turn now owns the row).
+        let outcome = bind_status_panel_in_root(
+            temp.path(),
+            &ProviderKind::Claude,
+            7003,
+            5555,
+            &StatusPanelBindGuard {
+                require_user_msg_id: Some(99),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(outcome, StatusPanelBindOutcome::GuardMismatch);
+        assert_eq!(loaded_status_message_id(temp.path(), 7003), None);
+    }
+
+    #[test]
+    fn bind_status_panel_skips_when_real_panel_already_set() {
+        let temp = TempDir::new().unwrap();
+        // A real (non-synthetic) panel id already on the row.
+        seed_status_panel_state(
+            temp.path(),
+            7004,
+            10,
+            11,
+            Some("AgentDesk-claude-a"),
+            Some(4242),
+        );
+
+        let outcome = bind_status_panel_in_root(
+            temp.path(),
+            &ProviderKind::Claude,
+            7004,
+            5555,
+            &StatusPanelBindGuard {
+                skip_if_panel_already_set: true,
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(outcome, StatusPanelBindOutcome::SkippedPanelAlreadySet);
+        // Canonical panel preserved — not overwritten by the duplicate.
+        assert_eq!(loaded_status_message_id(temp.path(), 7004), Some(4242));
+    }
+
+    #[test]
+    fn bind_status_panel_overwrites_synthetic_even_with_skip_flag() {
+        let temp = TempDir::new().unwrap();
+        // A synthetic-headless id does NOT count as "already set".
+        seed_status_panel_state(
+            temp.path(),
+            7005,
+            10,
+            11,
+            Some("AgentDesk-claude-a"),
+            Some(crate::services::discord::SYNTHETIC_HEADLESS_MESSAGE_ID_FLOOR + 1),
+        );
+
+        let outcome = bind_status_panel_in_root(
+            temp.path(),
+            &ProviderKind::Claude,
+            7005,
+            5555,
+            &StatusPanelBindGuard {
+                skip_if_panel_already_set: true,
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(outcome, StatusPanelBindOutcome::Bound);
+        assert_eq!(loaded_status_message_id(temp.path(), 7005), Some(5555));
+    }
+
+    #[test]
+    fn bind_status_panel_missing_row_reports_missing() {
+        let temp = TempDir::new().unwrap();
+        let outcome = bind_status_panel_in_root(
+            temp.path(),
+            &ProviderKind::Claude,
+            7006,
+            5555,
+            &StatusPanelBindGuard::default(),
+        );
+        assert_eq!(outcome, StatusPanelBindOutcome::Missing);
+    }
+
+    #[test]
+    fn clear_status_panel_if_current_clears_on_match() {
+        let temp = TempDir::new().unwrap();
+        seed_status_panel_state(
+            temp.path(),
+            7101,
+            10,
+            11,
+            Some("AgentDesk-claude-a"),
+            Some(5555),
+        );
+
+        let cleared = clear_status_panel_if_current_in_root(
+            temp.path(),
+            &ProviderKind::Claude,
+            7101,
+            5555,
+            &StatusPanelClearGuard::default(),
+        );
+
+        assert!(cleared);
+        assert_eq!(loaded_status_message_id(temp.path(), 7101), None);
+    }
+
+    #[test]
+    fn clear_status_panel_if_current_preserves_newer_turns_panel_on_mismatch() {
+        let temp = TempDir::new().unwrap();
+        // A newer turn already rebound the panel to 9999; a stale actor still
+        // believes it owns 5555 and asks to clear it. The compare-and-clear
+        // must NOT wipe the newer turn's panel.
+        seed_status_panel_state(
+            temp.path(),
+            7102,
+            10,
+            11,
+            Some("AgentDesk-claude-a"),
+            Some(9999),
+        );
+
+        let cleared = clear_status_panel_if_current_in_root(
+            temp.path(),
+            &ProviderKind::Claude,
+            7102,
+            5555,
+            &StatusPanelClearGuard::default(),
+        );
+
+        assert!(!cleared);
+        assert_eq!(loaded_status_message_id(temp.path(), 7102), Some(9999));
+    }
+
+    #[test]
+    fn clear_status_panel_if_current_respects_extra_guards() {
+        let temp = TempDir::new().unwrap();
+        seed_status_panel_state(
+            temp.path(),
+            7103,
+            10,
+            11,
+            Some("AgentDesk-claude-a"),
+            Some(5555),
+        );
+
+        // msg-id matches, but user_msg_id/current_msg_id/tmux guards point at a
+        // different turn → must NOT clear.
+        let user_mismatch = clear_status_panel_if_current_in_root(
+            temp.path(),
+            &ProviderKind::Claude,
+            7103,
+            5555,
+            &StatusPanelClearGuard {
+                require_user_msg_id: Some(99),
+                ..Default::default()
+            },
+        );
+        assert!(!user_mismatch);
+
+        let current_mismatch = clear_status_panel_if_current_in_root(
+            temp.path(),
+            &ProviderKind::Claude,
+            7103,
+            5555,
+            &StatusPanelClearGuard {
+                require_current_msg_id: Some(99),
+                ..Default::default()
+            },
+        );
+        assert!(!current_mismatch);
+
+        let tmux_mismatch = clear_status_panel_if_current_in_root(
+            temp.path(),
+            &ProviderKind::Claude,
+            7103,
+            5555,
+            &StatusPanelClearGuard {
+                require_tmux_session_name: Some("AgentDesk-claude-other".to_string()),
+                ..Default::default()
+            },
+        );
+        assert!(!tmux_mismatch);
+
+        assert_eq!(loaded_status_message_id(temp.path(), 7103), Some(5555));
+
+        // All guards satisfied → clears.
+        let cleared = clear_status_panel_if_current_in_root(
+            temp.path(),
+            &ProviderKind::Claude,
+            7103,
+            5555,
+            &StatusPanelClearGuard {
+                require_user_msg_id: Some(10),
+                require_current_msg_id: Some(11),
+                require_tmux_session_name: Some("AgentDesk-claude-a".to_string()),
+            },
+        );
+        assert!(cleared);
+        assert_eq!(loaded_status_message_id(temp.path(), 7103), None);
+    }
+
+    #[test]
+    fn clear_status_panel_if_current_noops_on_missing_row() {
+        let temp = TempDir::new().unwrap();
+        let cleared = clear_status_panel_if_current_in_root(
+            temp.path(),
+            &ProviderKind::Claude,
+            7104,
+            5555,
+            &StatusPanelClearGuard::default(),
+        );
+        assert!(!cleared);
+    }
+
+    #[test]
+    fn bind_then_clear_if_current_round_trips_atomically() {
+        let temp = TempDir::new().unwrap();
+        seed_status_panel_state(temp.path(), 7200, 10, 11, Some("AgentDesk-claude-a"), None);
+
+        // bind then clear-if-current with the same id returns the row to None,
+        // mirroring the watcher publish → orphan-cleanup lifecycle through the
+        // single locked store path.
+        assert_eq!(
+            bind_status_panel_in_root(
+                temp.path(),
+                &ProviderKind::Claude,
+                7200,
+                5555,
+                &StatusPanelBindGuard::default(),
+            ),
+            StatusPanelBindOutcome::Bound
+        );
+        assert_eq!(loaded_status_message_id(temp.path(), 7200), Some(5555));
+
+        assert!(clear_status_panel_if_current_in_root(
+            temp.path(),
+            &ProviderKind::Claude,
+            7200,
+            5555,
+            &StatusPanelClearGuard::default(),
+        ));
+        assert_eq!(loaded_status_message_id(temp.path(), 7200), None);
     }
 
     #[test]

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -185,6 +185,20 @@ pub(crate) use settings::resolve_role_binding as resolve_channel_role_binding;
 
 /// Discord message length limit
 pub(super) const DISCORD_MSG_LIMIT: usize = 2000;
+
+/// Lower bound of the synthetic-headless message-id range. Real Discord
+/// snowflake ids never reach this value, so any id at or above it is a
+/// synthetic placeholder (headless recovery / creation-failed fallback).
+/// Centralized here so both `turn_bridge::is_synthetic_headless_message_id`
+/// and the typed `inflight` status-panel ownership ops (#3077) agree on the
+/// boundary without coupling `inflight` to the serenity `MessageId` newtype.
+pub(in crate::services::discord) const SYNTHETIC_HEADLESS_MESSAGE_ID_FLOOR: u64 =
+    8_000_000_000_000_000_000;
+
+/// Raw `u64` form of `turn_bridge::is_synthetic_headless_message_id`.
+pub(in crate::services::discord) fn is_synthetic_headless_message_id_raw(value: u64) -> bool {
+    value >= SYNTHETIC_HEADLESS_MESSAGE_ID_FLOOR
+}
 const UPLOAD_CLEANUP_INTERVAL: Duration = Duration::from_secs(60 * 60);
 const UPLOAD_MAX_AGE: Duration = Duration::from_secs(3 * 24 * 60 * 60);
 const SESSION_CLEANUP_INTERVAL: Duration = Duration::from_secs(60 * 60); // 1 hour

--- a/src/services/discord/placeholder_sweeper.rs
+++ b/src/services/discord/placeholder_sweeper.rs
@@ -849,17 +849,27 @@ async fn sweep_orphan_status_panel(
             let _ = delete_inflight_state_file(provider, state.channel_id);
         }
     } else if placeholder_sweep_leaves_row_unevicted(state)
-        && let Some(mut current) = super::inflight::load_inflight_state(provider, state.channel_id)
-        && current.user_msg_id == state.user_msg_id
-        && current.current_msg_id == state.current_msg_id
-        && current.status_message_id == state.status_message_id
+        && let Some(panel_msg_id) = state.status_message_id
     {
         // Partial-response rows (real placeholder + streamed output) are owned by
         // the placeholder sweeper's deferred follow-up; do not evict them here.
         // Only clear our panel reference so we stop re-detecting it (codex P2 r12).
         // On a transient failure the durable store owns the retry, so this is safe.
-        current.status_message_id = None;
-        let _ = super::inflight::save_inflight_state(&current);
+        //
+        // #3077: compare-and-clear under the inflight flock. The user_msg_id +
+        // current_msg_id + msg-id guards reproduce the prior "same turn, same
+        // panel" precondition atomically, so a newer turn that rebound the panel
+        // between our snapshot load and this clear is never wiped.
+        let _ = super::inflight::clear_status_panel_if_current(
+            provider,
+            state.channel_id,
+            panel_msg_id,
+            &super::inflight::StatusPanelClearGuard {
+                require_user_msg_id: Some(state.user_msg_id),
+                require_current_msg_id: Some(state.current_msg_id),
+                ..Default::default()
+            },
+        );
     }
     if !committed {
         return;

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1669,14 +1669,19 @@ async fn cleanup_orphan_external_input_status_panel(
         );
     }
     *status_panel_msg_id = None;
-    if let Some(mut state) =
-        crate::services::discord::inflight::load_inflight_state(provider, channel_id.get())
-        && state.tmux_session_name.as_deref() == Some(tmux_session_name)
-        && state.status_message_id == Some(panel_msg_id.get())
-    {
-        state.status_message_id = None;
-        let _ = crate::services::discord::inflight::save_inflight_state(&state);
-    }
+    // #3077: compare-and-clear under the inflight flock so a newer turn that
+    // rebound this panel between our load and our clear is never wiped. The
+    // tmux-session guard preserves the prior precondition (only clear our own
+    // TUI-direct turn's row).
+    let _ = crate::services::discord::inflight::clear_status_panel_if_current(
+        provider,
+        channel_id.get(),
+        panel_msg_id.get(),
+        &crate::services::discord::inflight::StatusPanelClearGuard {
+            require_tmux_session_name: Some(tmux_session_name.to_string()),
+            ..Default::default()
+        },
+    );
     let ts = chrono::Local::now().format("%H:%M:%S");
     tracing::info!(
         "  [{ts}] 🧹 watcher: cleaned orphan status-panel-v2 for TUI-direct turn (channel {}, tmux={}, panel_msg={})",
@@ -4613,14 +4618,25 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                                     });
                                     if identity_matches
                                         && !fresh_panel_already_set
-                                        && let Some(mut inflight) = fresh_inflight
+                                        && fresh_inflight.is_some()
                                     {
+                                        // #3077: bind through the typed op so the
+                                        // identity guard + "don't clobber an already-set
+                                        // panel" check are re-validated atomically under
+                                        // the inflight flock — closing the window where an
+                                        // overlapping watcher rebinds between our snapshot
+                                        // load and this write (#3003).
                                         status_panel_msg_id = Some(panel_msg.id);
-                                        inflight.status_message_id = Some(panel_msg.id.get());
-                                        let _ =
-                                            crate::services::discord::inflight::save_inflight_state(
-                                                &inflight,
-                                            );
+                                        let _ = crate::services::discord::inflight::bind_status_panel(
+                                            &watcher_provider,
+                                            channel_id.get(),
+                                            panel_msg.id.get(),
+                                            &crate::services::discord::inflight::StatusPanelBindGuard {
+                                                require_identity: pre_send_identity.clone(),
+                                                skip_if_panel_already_set: true,
+                                                ..Default::default()
+                                            },
+                                        );
                                         let ts = chrono::Local::now().format("%H:%M:%S");
                                         tracing::info!(
                                             "  [{ts}] 🪧 watcher: created status-panel-v2 for TUI-direct turn (channel {}, tmux={}, panel_msg={})",

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -134,6 +134,48 @@ fn watcher_should_create_external_input_status_panel(
 /// `tmux_session_name`, mirroring the restore-path session guard. Synthetic
 /// headless ids are filtered via `normalize_status_panel_message_id` (codex P2
 /// r3) so the adoption path never edits a nonexistent Discord message.
+/// #3077 (codex P1): decision for the TUI-direct status-panel publish site
+/// once the atomic [`bind_status_panel`] has returned. The bind — not the
+/// pre-send `identity_matches` snapshot — is the source of truth for whether the
+/// just-sent panel was recorded on the inflight row, so the watcher's local
+/// handle MUST be chosen from its outcome:
+///
+/// * `Bound` / `AlreadyBound` → the row now owns this exact panel; adopt it and
+///   do NOT delete (deleting would remove a legitimately-bound panel).
+/// * any other outcome (`SkippedPanelAlreadySet` → the row owns a *different*
+///   panel; `GuardMismatch` / `Missing` / `IoError` → the bind never happened)
+///   → the row does NOT reference our panel, so the watcher must not claim
+///   ownership of it. Delete the just-sent duplicate and adopt the row's panel
+///   only when it is the SAME turn we sent for (`identity_matches`); a
+///   replacement turn's panel belongs to that turn and must not be tracked here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TuiStatusPanelBindDecision {
+    /// Delete (or enqueue-delete) the just-sent panel message.
+    delete_sent_panel: bool,
+    /// When `true`, adopt the just-sent `panel_msg.id`; when `false`, adopt the
+    /// row's persisted handle (only if this is the same turn).
+    adopt_sent_panel: bool,
+}
+
+fn resolve_tui_status_panel_bind_decision(
+    outcome: crate::services::discord::inflight::StatusPanelBindOutcome,
+) -> TuiStatusPanelBindDecision {
+    use crate::services::discord::inflight::StatusPanelBindOutcome as Outcome;
+    match outcome {
+        Outcome::Bound | Outcome::AlreadyBound => TuiStatusPanelBindDecision {
+            delete_sent_panel: false,
+            adopt_sent_panel: true,
+        },
+        Outcome::SkippedPanelAlreadySet
+        | Outcome::GuardMismatch
+        | Outcome::Missing
+        | Outcome::IoError => TuiStatusPanelBindDecision {
+            delete_sent_panel: true,
+            adopt_sent_panel: false,
+        },
+    }
+}
+
 fn watcher_persisted_status_panel_msg_id(
     inflight: Option<&InflightTurnState>,
     tmux_session_name: &str,
@@ -1112,6 +1154,70 @@ mod pane_dead_identity_tests {
             watcher_persisted_status_panel_msg_id(None, "AgentDesk-codex-adk-cdx"),
             None
         );
+    }
+
+    // #3077 (codex P1): the TUI-direct publish site must adopt the just-sent
+    // panel ONLY when the atomic bind recorded it on the inflight row. A
+    // successful bind (or one where the row already owns this exact id) adopts
+    // the handle and never deletes; any other outcome means the row does not
+    // reference our panel, so we delete the just-sent duplicate (not leak it)
+    // and never adopt it as the watcher's owned handle.
+    #[test]
+    fn tui_status_panel_bind_bound_adopts_without_delete() {
+        let decision = resolve_tui_status_panel_bind_decision(
+            crate::services::discord::inflight::StatusPanelBindOutcome::Bound,
+        );
+        assert!(decision.adopt_sent_panel);
+        assert!(!decision.delete_sent_panel);
+    }
+
+    #[test]
+    fn tui_status_panel_bind_already_bound_adopts_without_delete() {
+        let decision = resolve_tui_status_panel_bind_decision(
+            crate::services::discord::inflight::StatusPanelBindOutcome::AlreadyBound,
+        );
+        assert!(decision.adopt_sent_panel);
+        assert!(!decision.delete_sent_panel);
+    }
+
+    #[test]
+    fn tui_status_panel_bind_skipped_panel_already_set_deletes_and_disowns() {
+        // The inflight row already carries a DIFFERENT panel id: our just-sent
+        // panel is a duplicate and must be deleted, never adopted as our handle.
+        let decision = resolve_tui_status_panel_bind_decision(
+            crate::services::discord::inflight::StatusPanelBindOutcome::SkippedPanelAlreadySet,
+        );
+        assert!(decision.delete_sent_panel);
+        assert!(!decision.adopt_sent_panel);
+    }
+
+    #[test]
+    fn tui_status_panel_bind_guard_mismatch_deletes_and_disowns() {
+        let decision = resolve_tui_status_panel_bind_decision(
+            crate::services::discord::inflight::StatusPanelBindOutcome::GuardMismatch,
+        );
+        assert!(decision.delete_sent_panel);
+        assert!(!decision.adopt_sent_panel);
+    }
+
+    #[test]
+    fn tui_status_panel_bind_missing_deletes_and_disowns() {
+        let decision = resolve_tui_status_panel_bind_decision(
+            crate::services::discord::inflight::StatusPanelBindOutcome::Missing,
+        );
+        assert!(decision.delete_sent_panel);
+        assert!(!decision.adopt_sent_panel);
+    }
+
+    #[test]
+    fn tui_status_panel_bind_io_error_deletes_and_disowns() {
+        // A persist/IO failure means the bind did not happen; do not keep a
+        // local handle that claims ownership of an unrecorded panel.
+        let decision = resolve_tui_status_panel_bind_decision(
+            crate::services::discord::inflight::StatusPanelBindOutcome::IoError,
+        );
+        assert!(decision.delete_sent_panel);
+        assert!(!decision.adopt_sent_panel);
     }
 
     #[test]
@@ -4626,8 +4732,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                                         // the inflight flock — closing the window where an
                                         // overlapping watcher rebinds between our snapshot
                                         // load and this write (#3003).
-                                        status_panel_msg_id = Some(panel_msg.id);
-                                        let _ = crate::services::discord::inflight::bind_status_panel(
+                                        let bind_outcome = crate::services::discord::inflight::bind_status_panel(
                                             &watcher_provider,
                                             channel_id.get(),
                                             panel_msg.id.get(),
@@ -4637,13 +4742,96 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                                                 ..Default::default()
                                             },
                                         );
-                                        let ts = chrono::Local::now().format("%H:%M:%S");
-                                        tracing::info!(
-                                            "  [{ts}] 🪧 watcher: created status-panel-v2 for TUI-direct turn (channel {}, tmux={}, panel_msg={})",
-                                            channel_id.get(),
-                                            tmux_session_name,
-                                            panel_msg.id.get()
-                                        );
+                                        // #3077 (codex P1): the pre-send snapshot/`identity_matches`
+                                        // check narrows the race window but does NOT close it — an
+                                        // overlapping watcher can rebind/replace the inflight row
+                                        // between our `load_inflight_state` and this atomic bind.
+                                        // The bind is the single source of truth for whether THIS
+                                        // panel is now recorded on the inflight row, so the handle
+                                        // we adopt MUST be decided by its return. Adopting
+                                        // `panel_msg.id` unconditionally would leave a sent-but-
+                                        // unrecorded panel that the watcher then treats as its own
+                                        // → duplicate-panel leak / wrong-panel lifecycle.
+                                        let decision =
+                                            resolve_tui_status_panel_bind_decision(bind_outcome);
+                                        if decision.delete_sent_panel {
+                                            // The inflight row did NOT record our panel:
+                                            //  - SkippedPanelAlreadySet → the row already carries a
+                                            //    DIFFERENT (real) panel id; ours is a duplicate.
+                                            //  - GuardMismatch / Missing / IoError → the bind never
+                                            //    happened (the row changed/disappeared or a guard
+                                            //    failed); we must not claim ownership of a panel the
+                                            //    row doesn't know about.
+                                            // Delete the just-sent duplicate so it never leaks. This
+                                            // reuses the same delete path the "inflight changed
+                                            // during send" branch below uses
+                                            // (delete_nonterminal_placeholder → tmux.rs:803). It
+                                            // never double-deletes a legitimately-bound panel: we
+                                            // only reach here when our bind did NOT record
+                                            // `panel_msg.id`, so the row's owned panel (if any) is a
+                                            // *different* id we never delete.
+                                            let discard_outcome = delete_nonterminal_placeholder(
+                                                &http,
+                                                channel_id,
+                                                &shared,
+                                                &watcher_provider,
+                                                &tmux_session_name,
+                                                panel_msg.id,
+                                                "watcher_external_input_status_panel_bind_unowned",
+                                            )
+                                            .await;
+                                            if !discard_outcome.is_committed()
+                                                && !discard_outcome.is_permanent_failure()
+                                            {
+                                                // Transient delete failure: the duplicate panel
+                                                // still exists and this path does not persist it to
+                                                // inflight, so record it in the durable store for
+                                                // the sweeper drain to reclaim independent of turn
+                                                // lifecycle (#3003 codex P2 r14 pattern).
+                                                crate::services::discord::status_panel_orphan_store::enqueue(
+                                                    &watcher_provider,
+                                                    &shared.token_hash,
+                                                    channel_id.get(),
+                                                    panel_msg.id.get(),
+                                                );
+                                            }
+                                            // Resolve the handle from the inflight row, never from
+                                            // the just-sent duplicate: only adopt the row's panel
+                                            // when it is the SAME turn we sent for
+                                            // (`identity_matches`); a replacement turn's panel
+                                            // belongs to that turn and must not be tracked here.
+                                            let resolved_handle = if identity_matches {
+                                                watcher_persisted_status_panel_msg_id(
+                                                    fresh_inflight.as_ref(),
+                                                    &tmux_session_name,
+                                                )
+                                            } else {
+                                                None
+                                            };
+                                            status_panel_msg_id = resolved_handle;
+                                            let ts = chrono::Local::now().format("%H:%M:%S");
+                                            // Single bounded incident log per unowned-bind event.
+                                            tracing::warn!(
+                                                "  [{ts}] ⚠ watcher: status-panel-v2 bind did not record our panel for TUI-direct turn in channel {} (outcome={:?}, panel_msg={}, delete_committed={}, adopted_handle={:?}); discarded duplicate instead of leaking it",
+                                                channel_id.get(),
+                                                bind_outcome,
+                                                panel_msg.id.get(),
+                                                discard_outcome.is_committed(),
+                                                resolved_handle.map(serenity::MessageId::get)
+                                            );
+                                        } else {
+                                            // Bound / AlreadyBound: the row now owns this exact
+                                            // panel id — adopt the just-sent panel as today.
+                                            debug_assert!(decision.adopt_sent_panel);
+                                            status_panel_msg_id = Some(panel_msg.id);
+                                            let ts = chrono::Local::now().format("%H:%M:%S");
+                                            tracing::info!(
+                                                "  [{ts}] 🪧 watcher: created status-panel-v2 for TUI-direct turn (channel {}, tmux={}, panel_msg={})",
+                                                channel_id.get(),
+                                                tmux_session_name,
+                                                panel_msg.id.get()
+                                            );
+                                        }
                                     } else {
                                         // The turn vanished/changed during the send await,
                                         // or an overlapping watcher already owns the panel;

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -142,19 +142,28 @@ fn watcher_should_create_external_input_status_panel(
 ///
 /// * `Bound` / `AlreadyBound` → the row now owns this exact panel; adopt it and
 ///   do NOT delete (deleting would remove a legitimately-bound panel).
-/// * any other outcome (`SkippedPanelAlreadySet` → the row owns a *different*
-///   panel; `GuardMismatch` / `Missing` / `IoError` → the bind never happened)
-///   → the row does NOT reference our panel, so the watcher must not claim
-///   ownership of it. Delete the just-sent duplicate and adopt the row's panel
-///   only when it is the SAME turn we sent for (`identity_matches`); a
-///   replacement turn's panel belongs to that turn and must not be tracked here.
+/// * `SkippedPanelAlreadySet(owned)` → the row owns a *different* panel id,
+///   observed under the bind's flock. Delete the just-sent duplicate and adopt
+///   the row's CURRENT owned panel id (`owned`) — never the pre-bind snapshot,
+///   which can be stale when a concurrent writer set the panel between the
+///   watcher's snapshot load and this atomic bind (#3077 codex P2 #2). The
+///   adoption is still gated on `identity_matches` at the call site, so a
+///   replacement turn's panel is not tracked here.
+/// * `GuardMismatch` / `Missing` / `IoError` → the bind never happened → the
+///   row does NOT reference our panel, so the watcher must not claim ownership
+///   of it. Delete the just-sent duplicate and adopt nothing here.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct TuiStatusPanelBindDecision {
     /// Delete (or enqueue-delete) the just-sent panel message.
     delete_sent_panel: bool,
     /// When `true`, adopt the just-sent `panel_msg.id`; when `false`, adopt the
-    /// row's persisted handle (only if this is the same turn).
+    /// row's owned handle (`owned_panel_id`, only if this is the same turn).
     adopt_sent_panel: bool,
+    /// On `SkippedPanelAlreadySet`, the row's CURRENT owned (real) panel id as
+    /// observed by the bind under its flock. The caller adopts this — gated on
+    /// `identity_matches` — instead of re-reading the (possibly stale) pre-bind
+    /// snapshot. `None` for every other outcome.
+    owned_panel_id: Option<u64>,
 }
 
 fn resolve_tui_status_panel_bind_decision(
@@ -165,14 +174,20 @@ fn resolve_tui_status_panel_bind_decision(
         Outcome::Bound | Outcome::AlreadyBound => TuiStatusPanelBindDecision {
             delete_sent_panel: false,
             adopt_sent_panel: true,
+            owned_panel_id: None,
         },
-        Outcome::SkippedPanelAlreadySet
-        | Outcome::GuardMismatch
-        | Outcome::Missing
-        | Outcome::IoError => TuiStatusPanelBindDecision {
+        Outcome::SkippedPanelAlreadySet(owned) => TuiStatusPanelBindDecision {
             delete_sent_panel: true,
             adopt_sent_panel: false,
+            owned_panel_id: Some(owned),
         },
+        Outcome::GuardMismatch | Outcome::Missing | Outcome::IoError => {
+            TuiStatusPanelBindDecision {
+                delete_sent_panel: true,
+                adopt_sent_panel: false,
+                owned_panel_id: None,
+            }
+        }
     }
 }
 
@@ -1181,14 +1196,20 @@ mod pane_dead_identity_tests {
     }
 
     #[test]
-    fn tui_status_panel_bind_skipped_panel_already_set_deletes_and_disowns() {
-        // The inflight row already carries a DIFFERENT panel id: our just-sent
-        // panel is a duplicate and must be deleted, never adopted as our handle.
+    fn tui_status_panel_bind_skipped_panel_already_set_deletes_and_adopts_owned() {
+        // #3077 codex P2 #2: the inflight row already carries a DIFFERENT panel id
+        // (observed under the bind's flock). Our just-sent panel is a duplicate and
+        // must be deleted, never adopted as our handle. The decision must surface
+        // the row's CURRENT owned id so the caller adopts the real panel instead of
+        // the (possibly stale) pre-bind snapshot.
         let decision = resolve_tui_status_panel_bind_decision(
-            crate::services::discord::inflight::StatusPanelBindOutcome::SkippedPanelAlreadySet,
+            crate::services::discord::inflight::StatusPanelBindOutcome::SkippedPanelAlreadySet(
+                4242,
+            ),
         );
         assert!(decision.delete_sent_panel);
         assert!(!decision.adopt_sent_panel);
+        assert_eq!(decision.owned_panel_id, Some(4242));
     }
 
     #[test]
@@ -1198,6 +1219,8 @@ mod pane_dead_identity_tests {
         );
         assert!(decision.delete_sent_panel);
         assert!(!decision.adopt_sent_panel);
+        // No owned id to adopt → handle left unset (safe).
+        assert_eq!(decision.owned_panel_id, None);
     }
 
     #[test]
@@ -1207,6 +1230,7 @@ mod pane_dead_identity_tests {
         );
         assert!(decision.delete_sent_panel);
         assert!(!decision.adopt_sent_panel);
+        assert_eq!(decision.owned_panel_id, None);
     }
 
     #[test]
@@ -1218,6 +1242,7 @@ mod pane_dead_identity_tests {
         );
         assert!(decision.delete_sent_panel);
         assert!(!decision.adopt_sent_panel);
+        assert_eq!(decision.owned_panel_id, None);
     }
 
     #[test]
@@ -4795,16 +4820,23 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                                                     panel_msg.id.get(),
                                                 );
                                             }
-                                            // Resolve the handle from the inflight row, never from
-                                            // the just-sent duplicate: only adopt the row's panel
-                                            // when it is the SAME turn we sent for
-                                            // (`identity_matches`); a replacement turn's panel
-                                            // belongs to that turn and must not be tracked here.
+                                            // Resolve the handle from the row's CURRENT owned panel
+                                            // id as observed by the bind (decision.owned_panel_id),
+                                            // never from the just-sent duplicate and never from the
+                                            // pre-bind `fresh_inflight` snapshot (#3077 codex P2 #2).
+                                            // The snapshot can be stale: when a concurrent writer set
+                                            // the panel between our snapshot load and this atomic
+                                            // bind, the bind returns SkippedPanelAlreadySet carrying
+                                            // the freshly-set id while the snapshot still shows none.
+                                            // `owned_panel_id` is `None` for GuardMismatch / Missing /
+                                            // IoError (the bind observed no panel we may claim), which
+                                            // correctly leaves the handle unset (safe). Adopt only for
+                                            // the SAME turn we sent for (`identity_matches`); a
+                                            // replacement turn's panel belongs to that turn.
                                             let resolved_handle = if identity_matches {
-                                                watcher_persisted_status_panel_msg_id(
-                                                    fresh_inflight.as_ref(),
-                                                    &tmux_session_name,
-                                                )
+                                                decision
+                                                    .owned_panel_id
+                                                    .map(serenity::MessageId::new)
                                             } else {
                                                 None
                                             };

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -2120,33 +2120,36 @@ fn persist_status_panel_completion_fallback_message_id(
     let Some(expected_user_msg_id) = expected_user_msg_id else {
         return;
     };
-    let Some(mut inflight_state) = super::inflight::load_inflight_state(provider, channel_id.get())
-    else {
-        return;
+    // #3077: route the load-modify-save through the typed bind op so the
+    // user_msg_id guard and the field set are serialized under the inflight
+    // flock (no TOCTOU with a concurrent turn rebinding the row). Behavior is
+    // preserved: bind only when the on-disk row still belongs to this turn.
+    let guard = super::inflight::StatusPanelBindGuard {
+        require_user_msg_id: Some(expected_user_msg_id),
+        ..Default::default()
     };
-    if inflight_state.user_msg_id != expected_user_msg_id {
-        tracing::debug!(
-            "[turn_bridge] skipped persisting status-panel-v2 fallback id {} in channel {} from {}: inflight user_msg_id {} != expected {}",
-            message_id,
-            channel_id,
-            source,
-            inflight_state.user_msg_id,
-            expected_user_msg_id
-        );
-        return;
-    }
-    if inflight_state.status_message_id == Some(message_id.get()) {
-        return;
-    }
-    inflight_state.status_message_id = Some(message_id.get());
-    if let Err(error) = super::inflight::save_inflight_state(&inflight_state) {
-        tracing::warn!(
-            "[turn_bridge] failed to persist fallback status-panel-v2 message {} in channel {} from {}: {}",
-            message_id,
-            channel_id,
-            source,
-            error
-        );
+    match super::inflight::bind_status_panel(provider, channel_id.get(), message_id.get(), &guard) {
+        super::inflight::StatusPanelBindOutcome::Bound
+        | super::inflight::StatusPanelBindOutcome::AlreadyBound
+        | super::inflight::StatusPanelBindOutcome::SkippedPanelAlreadySet => {}
+        super::inflight::StatusPanelBindOutcome::Missing => {}
+        super::inflight::StatusPanelBindOutcome::GuardMismatch => {
+            tracing::debug!(
+                "[turn_bridge] skipped persisting status-panel-v2 fallback id {} in channel {} from {}: inflight user_msg_id != expected {}",
+                message_id,
+                channel_id,
+                source,
+                expected_user_msg_id
+            );
+        }
+        super::inflight::StatusPanelBindOutcome::IoError => {
+            tracing::warn!(
+                "[turn_bridge] failed to persist fallback status-panel-v2 message {} in channel {} from {}",
+                message_id,
+                channel_id,
+                source
+            );
+        }
     }
 }
 
@@ -2194,7 +2197,7 @@ enum HeadlessPlaceholderCleanupAction {
 }
 
 fn is_synthetic_headless_message_id(message_id: MessageId) -> bool {
-    message_id.get() >= 8_000_000_000_000_000_000
+    super::is_synthetic_headless_message_id_raw(message_id.get())
 }
 
 /// Synthetic placeholder id used when a recovery turn has no anchored Discord

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -2131,7 +2131,7 @@ fn persist_status_panel_completion_fallback_message_id(
     match super::inflight::bind_status_panel(provider, channel_id.get(), message_id.get(), &guard) {
         super::inflight::StatusPanelBindOutcome::Bound
         | super::inflight::StatusPanelBindOutcome::AlreadyBound
-        | super::inflight::StatusPanelBindOutcome::SkippedPanelAlreadySet => {}
+        | super::inflight::StatusPanelBindOutcome::SkippedPanelAlreadySet(_) => {}
         super::inflight::StatusPanelBindOutcome::Missing => {}
         super::inflight::StatusPanelBindOutcome::GuardMismatch => {
             tracing::debug!(


### PR DESCRIPTION
## Summary

`InflightTurnState.status_message_id` was mutated by several independent actors via a non-atomic `load_inflight_state(...)` → `state.status_message_id = …` → `save_inflight_state(...)` triple. Because the read and write were not serialized against each other, this is the root smell behind the panel-lifecycle races (#3099/#3100/#3105/#3107): a newer turn that rebound the panel between a stale actor's load and its blind `= None` could have its panel silently orphaned.

This PR introduces **typed ownership write APIs** so the field is only mutated through intentful, race-safe operations that centralize the read-modify-write under the existing `lock_inflight_state_path` sidecar flock (same atomicity contract as `save_inflight_state_if_absent`, #3107).

## Typed ops (in `src/services/discord/inflight.rs`)

- **`bind_status_panel(provider, channel_id, msg_id, guard)`** — intentful "this turn now owns panel M" set. Optional guards (`require_user_msg_id`, `require_identity`, `skip_if_panel_already_set`) are re-validated **under the lock**, returning a typed `StatusPanelBindOutcome` (`Bound` / `AlreadyBound` / `SkippedPanelAlreadySet` / `Missing` / `GuardMismatch` / `IoError`).
- **`clear_status_panel_if_current(provider, channel_id, msg_id, guard)`** — compare-and-clear: clears ONLY when `status_message_id == Some(msg_id)` (plus optional `user_msg_id` / `current_msg_id` / `tmux_session_name` guards). Returns whether it cleared. A panel a *newer* turn rebound is never wiped.

A small raw-`u64` synthetic-headless helper (`is_synthetic_headless_message_id_raw` + `SYNTHETIC_HEADLESS_MESSAGE_ID_FLOOR`) is hoisted to the discord module root so `inflight` can classify panel ids without coupling to the serenity `MessageId` newtype; `turn_bridge::is_synthetic_headless_message_id` now delegates to it.

## Migrated production sites

| Site | Op | Why |
|------|-----|-----|
| `turn_bridge::persist_status_panel_completion_fallback_message_id` | `bind_status_panel` | Unconditional set guarded by `user_msg_id` match — a bind |
| `tmux_watcher` orphan-cleanup (`complete_watcher_status_panel_v2` neighbor) | `clear_status_panel_if_current` (tmux-session guard) | Was a blind `= None`; hardened to compare-and-clear |
| `tmux_watcher` TUI-direct panel publish (#3003) | `bind_status_panel` (identity + skip-if-panel-already-set) | A set guarded by identity + not-already-set; now atomic re-check |
| `placeholder_sweeper` convergence | `clear_status_panel_if_current` (user_msg_id + current_msg_id guards) | Clear-after-sweep; hardened to compare-and-clear |

The turn-bridge **streaming-loop** sites (`status_panel_message_id_for_turn`, the publish/edit branches) mutate the bridge's own working `InflightTurnState` copy that the same actor persists later — they are **not** cross-actor load-modify-save and are intentionally left untouched. The remaining `status_message_id =` matches are test code.

## Non-goals / scope

- Field visibility is unchanged (narrowing is #3078 PR-7).
- No panel lifecycle semantics changed beyond making the writes typed + race-safe. **This PR is the substrate for the #3078 `StatusPanelController`, not the controller.**

## Tests

11 new unit tests in `inflight::stall_recovery_tests` (mirroring the `save_inflight_state_if_absent` style): bind sets / idempotent / `user_msg_id` guard mismatch / skip-if-real-panel-already-set / overwrites synthetic with skip flag / missing-row; clear-on-match / **preserves a newer turn's panel on mismatch** / extra-guard (user/current/tmux) mismatch / missing-row no-op / bind→clear-if-current round trip.

## Verification

- `cargo fmt --all --check` — clean
- `cargo check --workspace --all-features --all-targets` — 0 errors (only a pre-existing unrelated unused-import warning)
- Touched-module tests green: inflight `stall_recovery_tests` 47/47, turn_bridge 104/104, tmux_watcher 82/82, placeholder_sweeper 17/17
- `./scripts/ci-script-checks.sh` — exit 0 (synced `change-surfaces.md` tmux_watcher freeze entry 7207→7223 for the LoC drift)

Closes #3077

🤖 Generated with [Claude Code](https://claude.com/claude-code)