### PR TITLE
fix(discord): clear stale '계속 처리 중' streaming footer on turn completion/idle (#3104)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -120,7 +120,7 @@
     failover guard; #3087 `session_panel_instance_key`/`write_spawn_nonce`
     re-exports; #3107 `RestoredWatcherTurn.injected_prompt_message_id`;
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (7369 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (7419 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -135,6 +135,8 @@
     +124 from #3077 codex P1 honoring the `bind_status_panel` return at the
     TUI-direct publish site (delete the just-sent panel + disown the handle when
     the bind did not record it, instead of leaking a duplicate);
+    +50 from #3104 terminal/idle reconciliation pass that strips a lingering
+    `계속 처리 중` streaming footer off the committed-but-unrelayed placeholder;
     split loop helpers further before adding behavior).
   - `src/services/discord/tui_prompt_relay.rs` (3849 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
@@ -216,14 +218,16 @@
     split before adding non-bugfix behavior).
   - `src/services/discord/turn_bridge/completion_guard.rs` (1849 lines).
   - `src/services/discord/turn_bridge/tmux_runtime.rs` (1242 lines).
-  - `src/services/discord/formatting.rs` (2765 lines; +46 from #3082
+  - `src/services/discord/formatting.rs` (2802 lines; +46 from #3082
     answer-flush-barrier guards (+11 around the plain multi-chunk send loops;
     +24 from the #3082 codex follow-up that also guards the edit/replace path
     `replace_long_message_raw_with_outcome` and bumps `note_progress` after each
     delivered chunk for the progress-aware flush wait; +11 from the codex P1-2
     residual that bumps `note_progress` after the FIRST edited chunk too, on the
     multi-chunk path only, so the queued-card waiter's inactivity grace cannot
-    expire between the first edit and the first continuation)).
+    expire between the first edit and the first continuation); +37 from #3104
+    `finalize_stale_streaming_footer` / `text_ends_with_streaming_footer` shared
+    terminal-idle reconciliation helpers + their unit tests).
   - `src/services/discord/prompt_builder/` (directory, refactored).
   - `src/services/discord/runtime_bootstrap.rs` (2568 lines after #2558
     thread-session GC loopback shim cleanup; +3 from #3082 answer-flush-barrier

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -935,6 +935,47 @@ mod status_panel_v2_formatter_tests {
     }
 
     #[test]
+    fn finalize_stale_streaming_footer_strips_completed_body() {
+        // #3104: a turn that streamed then returned idle leaves the last edit
+        // text ending in `⠏ 계속 처리 중`; finalize must strip it.
+        let last_edit = "E2E answer\n- did the work\n\n⠏ 계속 처리 중";
+        let finalized = super::finalize_stale_streaming_footer(last_edit, &ProviderKind::Claude);
+        assert_eq!(finalized.as_deref(), Some("E2E answer\n- did the work"));
+    }
+
+    #[test]
+    fn finalize_stale_streaming_footer_leaves_streaming_body_untouched() {
+        // A genuinely-still-streaming body (no trailing footer) is left as-is so
+        // the reconciliation pass never clears a live footer prematurely.
+        let still_streaming = "Partial answer so far";
+        assert_eq!(
+            super::finalize_stale_streaming_footer(still_streaming, &ProviderKind::Claude),
+            None
+        );
+    }
+
+    #[test]
+    fn finalize_stale_streaming_footer_skips_footer_only_body() {
+        // Footer-only placeholder (no real content) must NOT be edited to blank;
+        // the caller's delete/replace path owns that case.
+        let footer_only = "⠏ 계속 처리 중";
+        assert_eq!(
+            super::finalize_stale_streaming_footer(footer_only, &ProviderKind::Claude),
+            None
+        );
+    }
+
+    #[test]
+    fn text_ends_with_streaming_footer_detects_korean_footer() {
+        assert!(super::text_ends_with_streaming_footer(
+            "Answer\n\n⠏ 계속 처리 중"
+        ));
+        assert!(!super::text_ends_with_streaming_footer(
+            "Answer\n\nmore text"
+        ));
+    }
+
+    #[test]
     fn format_for_discord_removes_leading_tui_no_response_chrome() {
         let input = "No response requested.\n\nFinal answer";
         let output = format_for_discord_with_provider(input, &ProviderKind::Claude);
@@ -1031,6 +1072,43 @@ fn strip_trailing_streaming_status_footer(lines: &mut Vec<&str>) {
         }
         lines.truncate(last_nonblank);
     }
+}
+
+/// True when `text`'s last non-blank line is a transient streaming footer
+/// (e.g. `⠏ 계속 처리 중`). Used by the terminal/idle reconciliation pass to
+/// detect a message that still advertises "still processing" after the turn
+/// has actually finished, without re-running the full formatter.
+pub(super) fn text_ends_with_streaming_footer(text: &str) -> bool {
+    text.lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .is_some_and(|line| is_streaming_placeholder_status_line(line.trim()))
+}
+
+/// #3104: terminal/idle reconciliation. Given the last text the bridge/watcher
+/// edited onto the visible response message, return the footer-stripped final
+/// body that should replace it — but ONLY when the message still ends with a
+/// transient `계속 처리 중` (still processing) streaming footer.
+///
+/// Returns `None` when the message does not end with a streaming footer (so a
+/// genuinely-still-streaming or already-finalized body is left untouched), or
+/// when stripping the footer would leave no visible content (the caller should
+/// then delete/replace via its own empty-body path rather than edit to blank).
+pub(super) fn finalize_stale_streaming_footer(
+    last_edit_text: &str,
+    provider: &crate::services::provider::ProviderKind,
+) -> Option<String> {
+    if !text_ends_with_streaming_footer(last_edit_text) {
+        return None;
+    }
+    let cleaned = format_for_discord_with_provider(last_edit_text, provider);
+    if cleaned.trim().is_empty() {
+        return None;
+    }
+    if cleaned == last_edit_text {
+        return None;
+    }
+    Some(cleaned)
 }
 
 pub(super) fn is_streaming_placeholder_status_line(line: &str) -> bool {

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -7444,6 +7444,56 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 "src/services/discord/tmux.rs:tmux_output_watcher_confirmed_end",
             );
         }
+        // #3104: terminal/idle reconciliation. A turn can commit (the channel is
+        // about to return to idle) without ever relaying a body onto the live
+        // streaming placeholder — e.g. a session-bound/subagent-only turn whose
+        // terminal output was delegated elsewhere, so `placeholder_msg_id` keeps
+        // the last streaming edit it received. When that last edit still ends in
+        // the transient `⠏ 계속 처리 중` footer, the message is left advertising
+        // "still processing" forever (the legacy in-body footer counterpart to
+        // the status-panel reclaim below). Strip the footer through the shared
+        // final-output formatter so the visible message matches the idle runtime.
+        //
+        // Self-gated: only on genuine commit (not a TimedOut/lifecycle-paused
+        // pane), and only when the body still ends with a footer — a
+        // genuinely-still-streaming message never reaches this committed-output
+        // block, and an already-finalized body is left untouched.
+        if terminal_output_committed
+            && !lifecycle_stage_paused
+            && let Some(placeholder) = placeholder_msg_id
+            && let Some(finalized) =
+                crate::services::discord::formatting::finalize_stale_streaming_footer(
+                    &last_edit_text,
+                    &watcher_provider,
+                )
+        {
+            match crate::services::discord::http::edit_channel_message(
+                &http,
+                channel_id,
+                placeholder,
+                &finalized,
+            )
+            .await
+            {
+                Ok(_) => {
+                    last_edit_text = finalized;
+                    let ts = chrono::Local::now().format("%H:%M:%S");
+                    tracing::info!(
+                        "  [{ts}] 👁 #3104 reconciled stale '계속 처리 중' streaming footer on channel {} msg {} at idle",
+                        channel_id.get(),
+                        placeholder.get()
+                    );
+                }
+                Err(error) => {
+                    let ts = chrono::Local::now().format("%H:%M:%S");
+                    tracing::warn!(
+                        "  [{ts}] ⚠ #3104 failed to reconcile stale streaming footer on channel {} msg {}: {error}",
+                        channel_id.get(),
+                        placeholder.get()
+                    );
+                }
+            }
+        }
         // Release the emission slot regardless of success. If delivery failed
         // the local `last_relayed_offset` also stayed put, so the same watcher
         // (or its replacement) can retry on the next tick without fighting


### PR DESCRIPTION
## Problem

A Discord response message could remain visibly stuck with the streaming footer `⠏ 계속 처리 중` (still processing) even after the channel/runtime returned to idle (`idle-no-pending`).

## Root cause

`src/services/discord/tmux_watcher.rs` committed-output path: a turn can commit (channel about to go idle) without ever relaying a final body onto the live streaming placeholder — e.g. a session-bound / subagent-only turn whose terminal output was delegated elsewhere. In that case `placeholder_msg_id` keeps its last streaming edit (the `계속 처리 중` footer) and no path edited it through the final-output formatter. This is the legacy in-body footer counterpart to the status-panel-v2 orphan reclaim that already existed there.

## Fix

- New shared, pure, unit-tested helpers in `formatting.rs`:
  - `text_ends_with_streaming_footer` — detects a trailing transient footer.
  - `finalize_stale_streaming_footer` — strips it through the same final-output formatter; returns `None` for still-streaming / already-finalized bodies (left untouched) and for footer-only bodies (caller's delete/replace path owns that case).
- Terminal/idle reconciliation pass in the watcher committed-output block: on genuine commit (not a `TimedOut`/lifecycle-paused pane), if the placeholder's last edit still ends in the footer, edit it to the footer-stripped final body so the visible message matches idle runtime.

Self-gated: a genuinely-still-streaming turn never reaches this block and keeps its footer; only true completion/idle clears it. Does **not** touch preserve-for-retry placeholders (the bridge keeps those for recovery re-delivery).

## Tests

- Focused unit tests on the finalize/footer-detection logic: completed body stripped, still-streaming untouched, footer-only not blanked, Korean footer detected.
- formatting (28) + tmux_watcher (5) + turn_bridge (104) module tests green.

## Gates

- `cargo fmt --all --check` clean
- `cargo check --workspace --all-features --all-targets` clean
- touched module tests green
- `./scripts/ci-script-checks.sh` exit 0 (change-surfaces.md LoC freeze entries synced for tmux_watcher.rs 7419 / formatting.rs 2802)

Closes #3104

🤖 Generated with [Claude Code](https://claude.com/claude-code)