### PR TITLE
feat(discord): route recovery completion through StatusPanelController (parity, PR-2) (Part of #3078)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -193,9 +193,14 @@
     `reset_state_for_tests` helper; +26 from #3105 codex-P1 sub-case B
     `evict_dead_tmux_mirror` tombstone helper that drops both the runtime and
     channel mirror for a dead/orphaned session and then allows re-registration).
-  - `src/services/discord/recovery_engine.rs` (3978 lines; +36 from #3099
+  - `src/services/discord/recovery_engine.rs` (4033 lines; +36 from #3099
     task-notification anchor `⏳` cleanup for `user_msg_id == 0` recovery; +4
-    from the #3099 re-review pinned-injected-message-id cleanup target).
+    from the #3099 re-review pinned-injected-message-id cleanup target; +55 from
+    #3078 PR-2 routing recovery completion through `StatusPanelController` behind
+    a shadow parity check (the controller adopts the recovered panel id and its
+    chosen completion id is asserted equal to the legacy
+    `recovery_status_panel_message_id_for_completion` result; the legacy path
+    still executes the Discord IO, so behaviour is unchanged)).
   - `src/services/discord/health.rs` (2354 lines after #1879 snapshot/mailbox
     extraction; +3 from #3082 answer-flush-barrier field in the test SharedData
     constructor).

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -434,6 +434,31 @@ async fn complete_recovery_visible_turn(
     let persisted_inflight = super::inflight::load_inflight_state(provider, channel_id.get());
     let status_msg_id =
         recovery_status_panel_message_id_for_completion(state, persisted_inflight.as_ref());
+
+    // EPIC #3078 PR-2 — route recovery completion through the
+    // `StatusPanelController` behind a parity check (shadow mode). The
+    // controller adopts the recovered panel id and reports the id it WOULD
+    // finalize; it must equal the legacy `status_msg_id`. The legacy
+    // `complete_status_panel_v2_with_http` below still executes the actual
+    // Discord edit/delete, so behaviour is verifiably unchanged — only the
+    // (shadow) controller decision is observed. The real cutover (controller
+    // executes the IO) lands in a later PR. The controller actor is only
+    // spawned when v2 is enabled (we are already inside the v2-enabled branch),
+    // so this is inert and untouched when v2 is off.
+    let controller_id = shared
+        .status_panel_controller
+        .recovery_completion_parity_id(
+            super::turn_finalizer::TurnKey::new(
+                channel_id,
+                state.user_msg_id,
+                super::runtime_store::load_generation(),
+            ),
+            provider.clone(),
+            status_msg_id,
+        )
+        .await;
+    assert_recovery_completion_parity(controller_id, status_msg_id, channel_id, source);
+
     let mut last_status_panel_text = String::new();
     let _committed = super::turn_bridge::complete_status_panel_v2_with_http(
         shared,
@@ -472,6 +497,36 @@ fn recovery_status_panel_message_id_for_completion(
         })
 }
 
+/// EPIC #3078 PR-2 — the parity gate between the legacy recovery
+/// status-panel-completion id and the id the `StatusPanelController` chooses for
+/// the same turn. They must agree: a divergence means the controller would
+/// finalize a different (or no) panel, so routing the IO through it later would
+/// change behaviour. `debug_assert` so test/dev builds fail loudly; release
+/// builds emit a bounded `warn!` (no `panic!`) so a never-before-seen recovery
+/// shape can never crash a production restart sweep over the legacy path, which
+/// continues to execute regardless.
+fn assert_recovery_completion_parity(
+    controller_id: Option<MessageId>,
+    legacy_id: Option<MessageId>,
+    channel_id: ChannelId,
+    source: &'static str,
+) {
+    if controller_id == legacy_id {
+        return;
+    }
+    debug_assert_eq!(
+        controller_id, legacy_id,
+        "#3078 PR-2 recovery status-panel completion parity mismatch (channel {channel_id}, source {source}): controller chose {controller_id:?}, legacy chose {legacy_id:?}"
+    );
+    tracing::warn!(
+        channel = channel_id.get(),
+        source = source,
+        controller_id = ?controller_id,
+        legacy_id = ?legacy_id,
+        "#3078 PR-2 recovery status-panel completion parity mismatch — StatusPanelController chose a different completion id than the legacy path; legacy path executed (no behaviour change), divergence logged for the later controller-executes cutover"
+    );
+}
+
 #[cfg(test)]
 mod recovery_dispatch_gate_tests {
     #[test]
@@ -483,7 +538,10 @@ mod recovery_dispatch_gate_tests {
 
 #[cfg(test)]
 mod recovery_completion_outcome_tests {
-    use super::{RecoveryCompletionOutcome, recovery_status_panel_message_id_for_completion};
+    use super::{
+        RecoveryCompletionOutcome, assert_recovery_completion_parity,
+        recovery_status_panel_message_id_for_completion,
+    };
     use crate::services::provider::ProviderKind;
 
     fn state_for_recovery(user_msg_id: u64) -> super::inflight::InflightTurnState {
@@ -540,6 +598,76 @@ mod recovery_completion_outcome_tests {
             recovery_status_panel_message_id_for_completion(&snapshot, Some(&persisted));
 
         assert_eq!(status_msg_id, Some(super::MessageId::new(3003)));
+    }
+
+    // EPIC #3078 PR-2: for representative recovery-completion inputs, the
+    // `StatusPanelController`'s chosen completion id (adopt + read-back through
+    // the live actor) equals the legacy
+    // `recovery_status_panel_message_id_for_completion` result, so the parity
+    // gate passes and `complete_recovery_visible_turn` keeps executing the
+    // legacy path with no behaviour change.
+    #[tokio::test(flavor = "current_thread")]
+    async fn controller_chosen_completion_id_matches_legacy_for_representative_inputs() {
+        use super::ChannelId;
+        use super::status_panel_controller::StatusPanelController;
+        use super::turn_finalizer::TurnKey;
+
+        // Case A: real user_msg_id, persisted id from the SAME turn wins.
+        let mut snapshot = state_for_recovery(9101);
+        snapshot.status_message_id = Some(3003);
+        let mut persisted = state_for_recovery(9101);
+        persisted.status_message_id = Some(4004);
+        let legacy = recovery_status_panel_message_id_for_completion(&snapshot, Some(&persisted));
+        assert_eq!(legacy, Some(super::MessageId::new(4004)));
+
+        let ctl = StatusPanelController::spawn(true);
+        let key = TurnKey::new(ChannelId::new(4243), snapshot.user_msg_id, 0);
+        let controller = ctl
+            .recovery_completion_parity_id(key, ProviderKind::Claude, legacy)
+            .await;
+        assert_eq!(
+            controller, legacy,
+            "controller's chosen completion id must equal the legacy id (real user_msg_id case)"
+        );
+
+        // Case B: channel-only (user_msg_id == 0) recovery turn — the controller
+        // collapses onto the single live entry it adopted, choosing the same id.
+        let mut snapshot0 = state_for_recovery(0);
+        snapshot0.status_message_id = Some(5005);
+        let legacy0 = recovery_status_panel_message_id_for_completion(&snapshot0, None);
+        assert_eq!(legacy0, Some(super::MessageId::new(5005)));
+
+        let ctl0 = StatusPanelController::spawn(true);
+        let key0 = TurnKey::new(ChannelId::new(7777), 0, 0);
+        let controller0 = ctl0
+            .recovery_completion_parity_id(key0, ProviderKind::Claude, legacy0)
+            .await;
+        assert_eq!(
+            controller0, legacy0,
+            "controller's chosen completion id must equal the legacy id (channel-only case)"
+        );
+
+        // Case C: no panel id at all (None) — both agree on None.
+        let snapshot_none = state_for_recovery(9300);
+        let legacy_none = recovery_status_panel_message_id_for_completion(&snapshot_none, None);
+        assert_eq!(legacy_none, None);
+
+        let ctl_none = StatusPanelController::spawn(true);
+        let key_none = TurnKey::new(ChannelId::new(8888), 9300, 0);
+        let controller_none = ctl_none
+            .recovery_completion_parity_id(key_none, ProviderKind::Claude, legacy_none)
+            .await;
+        assert_eq!(controller_none, legacy_none);
+
+        // The parity assert itself must not fire for any of these.
+        assert_recovery_completion_parity(controller, legacy, ChannelId::new(4243), "test");
+        assert_recovery_completion_parity(controller0, legacy0, ChannelId::new(7777), "test");
+        assert_recovery_completion_parity(
+            controller_none,
+            legacy_none,
+            ChannelId::new(8888),
+            "test",
+        );
     }
 }
 

--- a/src/services/discord/status_panel_controller.rs
+++ b/src/services/discord/status_panel_controller.rs
@@ -198,6 +198,17 @@ enum PanelMsg {
         key: TurnKey,
         ack: oneshot::Sender<Option<MessageId>>,
     },
+    /// Adopt an ALREADY-EXISTING panel message into the ledger as the live panel
+    /// for this turn (the post-restart recovery/orphan case: the panel was sent
+    /// by a previous process, so there is nothing to create — the controller
+    /// only needs to learn the id so it can own the finalize). Idempotent and
+    /// non-resurrecting: a terminal entry is left untouched.
+    AdoptRecovered {
+        key: TurnKey,
+        provider: ProviderKind,
+        owner: PanelOwnerKind,
+        msg_id: Option<MessageId>,
+    },
 }
 
 /// The per-runtime actor, held as `Arc<StatusPanelController>` on `SharedData`.
@@ -360,6 +371,42 @@ impl StatusPanelController {
         }
         rx.await.unwrap_or(None)
     }
+
+    /// Adopt an already-existing panel message into the ledger (post-restart
+    /// recovery: the panel was created by a previous process). The controller
+    /// learns the id so it can own the finalize. Idempotent and
+    /// non-resurrecting: a terminal entry is never reopened. Fire-and-forget;
+    /// observe the resulting id with [`Self::current_panel`].
+    pub(in crate::services::discord) fn adopt_recovered(
+        &self,
+        key: TurnKey,
+        provider: ProviderKind,
+        owner: PanelOwnerKind,
+        msg_id: Option<MessageId>,
+    ) {
+        let _ = self.tx.send(PanelMsg::AdoptRecovered {
+            key,
+            provider,
+            owner,
+            msg_id,
+        });
+    }
+
+    /// EPIC #3078 PR-2 — the controller's chosen status-panel completion id for
+    /// a recovery turn, computed through the ledger collapse so it can be
+    /// asserted equal to the legacy `recovery_status_panel_message_id_for_completion`
+    /// result behind a parity check. Adopts the recovered panel id, then reads
+    /// back the resolved id. Shadow-only: this does NOT finalize or touch the
+    /// durable mirror, so the legacy completion path keeps executing unchanged.
+    pub(in crate::services::discord) async fn recovery_completion_parity_id(
+        &self,
+        key: TurnKey,
+        provider: ProviderKind,
+        recovered_msg_id: Option<MessageId>,
+    ) -> Option<MessageId> {
+        self.adopt_recovered(key, provider, PanelOwnerKind::Recovery, recovered_msg_id);
+        self.current_panel(key).await
+    }
 }
 
 /// Resolve a submission to the ledger entry it acts on, reusing the finalizer's
@@ -455,7 +502,51 @@ async fn actor_loop(mut rx: mpsc::UnboundedReceiver<PanelMsg>) {
                 let id = ledger.get(&lk).and_then(|e| e.msg_id);
                 let _ = ack.send(id);
             }
+            PanelMsg::AdoptRecovered {
+                key,
+                provider,
+                owner,
+                msg_id,
+            } => {
+                adopt_recovered(&mut ledger, key, provider, owner, msg_id);
+            }
         }
+    }
+}
+
+/// Adopt an already-existing (recovery) panel id into the ledger as the live
+/// panel for this turn. Mirrors `Register` but seeds the known `msg_id` and the
+/// `Live` phase, since the panel was created by a previous process and only the
+/// id needs to be learned. Never resurrects a terminal entry; if a live entry
+/// already owns a panel its id is left intact (idempotent re-adopt). No durable
+/// write — adoption only learns the in-memory authority; the durable mirror was
+/// already bound by the process that created the panel.
+fn adopt_recovered(
+    ledger: &mut HashMap<LedgerKey, PanelEntry>,
+    key: TurnKey,
+    provider: ProviderKind,
+    owner: PanelOwnerKind,
+    msg_id: Option<MessageId>,
+) {
+    let lk = resolve_key(ledger, key);
+    let entry = ledger.entry(lk).or_insert_with(|| PanelEntry {
+        msg_id,
+        owner,
+        provider: provider.clone(),
+        phase: PanelPhase::Live,
+        last_text: None,
+    });
+    if entry.phase.is_terminal() {
+        // Never reopen a finalized/reclaimed panel.
+        return;
+    }
+    entry.owner = owner;
+    entry.provider = provider;
+    if entry.msg_id.is_none() {
+        entry.msg_id = msg_id;
+    }
+    if entry.phase == PanelPhase::NotCreated {
+        entry.phase = PanelPhase::Live;
     }
 }
 
@@ -762,6 +853,73 @@ mod tests {
             again,
             PanelCommitOutcome::AlreadyTerminal | PanelCommitOutcome::NoPanel
         ));
+    }
+
+    /// EPIC #3078 PR-2: `adopt_recovered` seeds an existing (recovery) panel id
+    /// into the ledger as Live, is idempotent (a second adopt keeps the first
+    /// id), and never resurrects a terminal entry.
+    #[test]
+    fn adopt_recovered_seeds_idempotent_and_never_resurrects() {
+        let mut ledger: HashMap<LedgerKey, PanelEntry> = HashMap::new();
+        let key = TurnKey::new(ChannelId::new(8), 80, 0);
+        let k = key.exact_key();
+
+        adopt_recovered(
+            &mut ledger,
+            key,
+            ProviderKind::Claude,
+            PanelOwnerKind::Recovery,
+            Some(MessageId::new(800)),
+        );
+        let entry = ledger.get(&k).unwrap();
+        assert_eq!(entry.msg_id, Some(MessageId::new(800)));
+        assert_eq!(entry.phase, PanelPhase::Live);
+        assert_eq!(entry.owner, PanelOwnerKind::Recovery);
+
+        // Idempotent: a second adopt keeps the already-bound id (does not clobber
+        // with a stale id) while still refreshing the owner.
+        adopt_recovered(
+            &mut ledger,
+            key,
+            ProviderKind::Claude,
+            PanelOwnerKind::Watcher,
+            Some(MessageId::new(999)),
+        );
+        let entry = ledger.get(&k).unwrap();
+        assert_eq!(entry.msg_id, Some(MessageId::new(800)));
+        assert_eq!(entry.owner, PanelOwnerKind::Watcher);
+
+        // Non-resurrecting: after a terminal commit, adopt is a no-op on phase.
+        let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
+        commit_terminal(&mut ledger, key, PanelPhase::Completed, None, &shared);
+        adopt_recovered(
+            &mut ledger,
+            key,
+            ProviderKind::Claude,
+            PanelOwnerKind::Recovery,
+            Some(MessageId::new(801)),
+        );
+        assert_eq!(ledger.get(&k).unwrap().phase, PanelPhase::Completed);
+    }
+
+    /// EPIC #3078 PR-2: the shadow parity helper adopts the recovered id and
+    /// reports it back as the controller's chosen completion id, exercised
+    /// through the live actor loop.
+    #[tokio::test(flavor = "current_thread")]
+    async fn recovery_completion_parity_id_reports_adopted_id() {
+        let ctl = StatusPanelController::spawn(true);
+        let key = TurnKey::new(ChannelId::new(9), 90, 0);
+        let chosen = ctl
+            .recovery_completion_parity_id(key, ProviderKind::Claude, Some(MessageId::new(900)))
+            .await;
+        assert_eq!(chosen, Some(MessageId::new(900)));
+
+        // A None recovered id (no panel) reports None.
+        let key2 = TurnKey::new(ChannelId::new(9), 91, 0);
+        let none = ctl
+            .recovery_completion_parity_id(key2, ProviderKind::Claude, None)
+            .await;
+        assert_eq!(none, None);
     }
 
     /// A channel-only (`user_msg_id == 0`) finalize collapses onto the single


### PR DESCRIPTION
## What

PR-2 of the #3078 staged migration: route the **lowest-risk** actor — recovery completion — through the dormant `StatusPanelController` (landed in PR-1, #3114) **behind a shadow parity check**.

## Decision: shadow-parity, legacy executes

This is the safest first cut per the #3078 design comment ("route recovery behind a parity check… a shadow-parity that logs divergence without changing the executed behavior is the safest first cut, with the real cutover in a later PR").

`complete_recovery_visible_turn` now asks the controller for the id it **would** finalize and asserts it equals the legacy `recovery_status_panel_message_id_for_completion` result. The legacy `complete_status_panel_v2_with_http` **still performs the actual Discord edit/delete IO**, so behaviour is verifiably unchanged — only the (shadow) controller decision is observed.

The controller runs in shadow mode: it adopts the recovered panel id into its in-memory ledger and reports the resolved completion id with **no durable-mirror write and no Discord IO**.

## Why no live `PanelSink`

The `PanelSink` trait is synchronous (`fn create(...) -> Option<MessageId>`), but the recovery completion IO is async (`super::http::edit_channel_message(...).await`). Wiring a live sink means resolving that impedance, which belongs with the **controller-executes cutover** in a later PR. Shadow-parity does not execute IO, so no live sink is needed here.

## Changes

**`status_panel_controller.rs`**
- `AdoptRecovered` message + `adopt_recovered` ledger op: seed an already-existing (post-restart) panel id as `Live`. Idempotent (keeps the first bound id), refreshes owner, never resurrects a terminal entry, no durable write (the creating process already bound the mirror).
- `recovery_completion_parity_id`: shadow helper that adopts the recovered id and reads back the controller's chosen completion id through the live actor loop.

**`recovery_engine.rs`**
- Parity wire in `complete_recovery_visible_turn` (inside the `status_panel_v2_enabled` branch, before the legacy completion call).
- `assert_recovery_completion_parity`: `debug_assert_eq!` (test/dev fail loud) + a bounded `warn!` in release — never `panic!`, so an unseen recovery shape cannot crash a production restart sweep over the still-executing legacy path.

## v2-off is untouched

When `status_panel_v2_enabled` is false the function returns before any controller code, and the controller actor is only spawned when v2 is on (PR-1 gating). Legacy path identical.

## Tests

- controller: `adopt_recovered_seeds_idempotent_and_never_resurrects`, `recovery_completion_parity_id_reports_adopted_id`.
- recovery_engine: `controller_chosen_completion_id_matches_legacy_for_representative_inputs` — real `user_msg_id`, channel-only (`user_msg_id == 0`) collapse, and no-panel (None) cases all agree.

## Verification

- `cargo fmt --all --check` clean
- `cargo check --workspace --all-features --all-targets` clean
- controller + recovery_engine + turn_finalizer tests green (166 recovery/finalizer + 32 controller/recovery)
- `./scripts/ci-script-checks.sh` exit 0 (change-surfaces.md `recovery_engine.rs` freeze entry resynced 3978 → 4033 prod LoC)

Part of #3078

🤖 Generated with [Claude Code](https://claude.com/claude-code)