### PR TITLE
chore(lint): restore await_holding_lock enforcement (Part of #3034)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -301,7 +301,7 @@
 - do_not_edit_without_migration_plan (giant-file routes):
   - `src/server/routes/kanban.rs` (2752 lines).
   - `src/server/routes/docs.rs` (5880 lines).
-  - `src/server/routes/escalation.rs` (1728 lines).
+  - `src/server/routes/escalation.rs` (1733 lines).
   - `src/server/routes/meetings.rs` (1708 lines).
   - `src/server/routes/review_verdict/decision_route.rs` (4191 lines).
   - `src/server/routes/{agents,agents_crud,agents_setup,v1,resume,
@@ -393,7 +393,7 @@
     adding new feature logic).
   - `src/db/kanban_cards/` (1932 total lines; kanban card persistence and
     GitHub sync lookup surface).
-  - `src/db/postgres.rs` (1009 lines).
+  - `src/db/postgres.rs` (1018 lines).
   - `src/db/dispatched_sessions.rs` (1554 lines; dispatched session
     persistence helpers).
   - `src/db/session_transcripts.rs` is a retained PG-cleanup surface (now below

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -845,6 +845,11 @@ pub(crate) async fn connect_test_pool(database_url: &str, label: &str) -> Result
 }
 
 #[cfg(test)]
+// SAFETY (await_holding_lock): `lock_test_setup()` is a std Mutex held across
+// the pool-connect/query awaits *on purpose* — it serializes concurrent
+// PG-backed test DB create/drop so they cannot race. Dropping the guard before
+// the awaits would reintroduce the CI race this lock was added to fix. Test-only.
+#[allow(clippy::await_holding_lock)]
 pub(crate) async fn create_test_database(
     admin_url: &str,
     database_name: &str,
@@ -942,6 +947,10 @@ pub(crate) async fn connect_test_pool_and_migrate_config(
 }
 
 #[cfg(test)]
+// SAFETY (await_holding_lock): same serialization rationale as
+// `create_test_database` — `lock_test_setup()` is held across the teardown
+// awaits to keep concurrent PG test DB drops from racing. Test-only.
+#[allow(clippy::await_holding_lock)]
 pub(crate) async fn drop_test_database(
     admin_url: &str,
     database_name: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,14 @@
 //
 // `too_many_arguments` is governed solely by this crate-wide allow; per-function
 // `#[allow(clippy::too_many_arguments)]` attributes are redundant and removed.
+//
+// `await_holding_lock` is intentionally NOT suppressed here (#3034): production
+// lock-across-await races must surface in clippy. The only legitimate holders
+// are test-serialization guards (process-global env/metrics/PG-setup Mutexes),
+// each carrying a narrow `#[allow(clippy::await_holding_lock)]` + `// SAFETY:`.
 #![allow(
     clippy::absurd_extreme_comparisons,
     clippy::assertions_on_constants,
-    clippy::await_holding_lock,
     clippy::bind_instead_of_map,
     clippy::bool_assert_comparison,
     clippy::clone_on_copy,

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -2175,6 +2175,12 @@ mod dispatch_delivery_reconcile_tests {
         pg_db.drop().await;
     }
 
+    // SAFETY (await_holding_lock): `lock_dispatch_delivery_metric_tests()` is a
+    // std Mutex held across awaits to serialize tests that read/reset the
+    // process-global dispatch-delivery mismatch metrics. The hold is required —
+    // releasing before the awaits would let concurrent tests clobber the shared
+    // metric counters. Test-only.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test(flavor = "current_thread")]
     async fn dispatch_delivery_reconcile_logs_dispatch_id_and_increments_metric_pg() {
         let _serial = lock_dispatch_delivery_metric_tests();
@@ -2638,6 +2644,10 @@ mod dispatch_delivery_reconcile_tests {
         pg_db.drop().await;
     }
 
+    // SAFETY (await_holding_lock): same rationale as
+    // `dispatch_delivery_reconcile_logs_dispatch_id_and_increments_metric_pg` —
+    // the metric-serialization Mutex must stay held across the awaits. Test-only.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test(flavor = "current_thread")]
     async fn dispatch_delivery_reconcile_recovers_and_clears_backlog_pg() {
         let _serial = lock_dispatch_delivery_metric_tests();

--- a/src/server/routes/dispatches/crud.rs
+++ b/src/server/routes/dispatches/crud.rs
@@ -1018,6 +1018,11 @@ mod tests {
         pg_db.drop().await;
     }
 
+    // SAFETY (await_holding_lock): the shared dispatch-delivery metric Mutex is
+    // intentionally held across awaits to serialize tests that mutate the
+    // process-global mismatch metrics; releasing early would race concurrent
+    // tests. Test-only.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn dispatch_delivery_reconcile_stats_route_returns_current_stats_and_metric_rows() {
         let _serial = crate::reconcile::lock_dispatch_delivery_metric_tests();

--- a/src/server/routes/escalation.rs
+++ b/src/server/routes/escalation.rs
@@ -1640,6 +1640,11 @@ mod manual_decision_gate_tests {
         format!("{}/{}", pg_test_base_database_url(), admin_db)
     }
 
+    // SAFETY (await_holding_lock): `env_lock()` is a std Mutex held across awaits
+    // to serialize tests that mutate process-global env vars (AGENTDESK_ROOT_DIR
+    // etc.); the hold must span the awaits so a concurrent test cannot observe or
+    // clobber the env mid-flight. Test-only.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn emit_escalation_pg_rejects_superseded_manual_decision_cards_without_discord_send() {
         let _env_lock = env_lock();

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -8789,6 +8789,10 @@ mod tests {
         assert_eq!(persisted.current_msg_id, 54_321);
     }
 
+    // SAFETY (await_holding_lock): see the inline comment — the process-wide
+    // env-dir Mutex is held across awaits to serialize env-mutating tests, which
+    // is sound on the current-thread test runtime. Test-only.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn terminal_delivery_timeout_cleanup_releases_mailbox_and_preserves_followup_queue() {
         // Serialize on the PROCESS-WIDE `AGENTDESK_ROOT_DIR` lock (shared with

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -4879,6 +4879,10 @@ mod tests {
             .remove(tmux);
     }
 
+    // SAFETY (await_holding_lock): `tui_prompt_dedupe::TEST_LOCK` is a std Mutex
+    // held across awaits to serialize tests that share the prompt-dedupe global
+    // state; the hold is required for serialization. Test-only.
+    #[allow(clippy::await_holding_lock)]
     #[cfg(unix)]
     #[tokio::test]
     async fn claude_bridge_lease_guard_cleans_no_binding_precondition_skip() {

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -888,6 +888,10 @@ mod tests {
     /// across threads; concurrent tests on other OS threads simply block on
     /// `lock()` until this test releases the guard, which is exactly the
     /// serialization we want.
+    // SAFETY (await_holding_lock): the doc comment above explains why the
+    // env-dir Mutex is intentionally held across the test awaits (current-thread
+    // runtime, serialization is the whole point). Test-only.
+    #[allow(clippy::await_holding_lock)]
     async fn with_isolated_runtime_root<F, Fut>(f: F)
     where
         F: FnOnce() -> Fut,

--- a/src/services/turn_lifecycle.rs
+++ b/src/services/turn_lifecycle.rs
@@ -376,6 +376,11 @@ mod policy_observability_tests {
         );
     }
 
+    // SAFETY (await_holding_lock): `observability::test_runtime_lock()` is a std
+    // Mutex held across awaits to serialize tests that reset/init the
+    // process-global observability runtime; the hold must span the awaits to
+    // keep concurrent tests from racing on the shared runtime. Test-only.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn cancel_observability_emits_unknown_noop_direct_fallback() {
         let _guard = crate::services::observability::test_runtime_lock();

--- a/src/services/turn_orchestrator.rs
+++ b/src/services/turn_orchestrator.rs
@@ -2897,6 +2897,10 @@ mod actor_hydrate_regression_tests {
         assert!(other.exists());
     }
 
+    // SAFETY (await_holding_lock): the test-env Mutex is held across awaits to
+    // serialize tests that mutate the process-global `AGENTDESK_ROOT_DIR` env;
+    // releasing before the awaits would race concurrent tests. Test-only.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn hydrate_from_disk_does_not_reinsert_after_actor_dequeue_removed_file() {
         let _lock = lock_test_env();
@@ -3482,6 +3486,10 @@ mod persistence_tests {
         }
     }
 
+    // SAFETY (await_holding_lock): `TEST_ENV_LOCK` serializes env-mutating tests
+    // and must stay held across the awaits to prevent concurrent env clobbering.
+    // Test-only.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn enqueue_rolls_back_when_pending_queue_persistence_fails() {
         let _lock = TEST_ENV_LOCK.lock().unwrap();
@@ -3637,6 +3645,9 @@ mod persistence_tests {
         );
     }
 
+    // SAFETY (await_holding_lock): `TEST_ENV_LOCK` serializes env-mutating tests
+    // and must stay held across the awaits. Test-only.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn actor_hydrate_from_disk_preserves_voice_announcement_payload() {
         let _lock = TEST_ENV_LOCK.lock().unwrap();
@@ -3681,6 +3692,9 @@ mod persistence_tests {
         );
     }
 
+    // SAFETY (await_holding_lock): `TEST_ENV_LOCK` serializes env-mutating tests
+    // and must stay held across the awaits. Test-only.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn restart_drain_persists_voice_announcement_payload() {
         let _lock = TEST_ENV_LOCK.lock().unwrap();
@@ -3715,6 +3729,9 @@ mod persistence_tests {
         assert_eq!(saved[0].voice_announcement.as_ref(), Some(&announcement));
     }
 
+    // SAFETY (await_holding_lock): `TEST_ENV_LOCK` serializes env-mutating tests
+    // and must stay held across the awaits. Test-only.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn restart_drain_all_reports_pending_queue_persistence_errors() {
         let _lock = TEST_ENV_LOCK.lock().unwrap();
@@ -3939,6 +3956,9 @@ mod finish_cancelled_turn_tests {
         }
     }
 
+    // SAFETY (await_holding_lock): `TEST_ENV_LOCK` serializes env-mutating tests
+    // and must stay held across the awaits. Test-only.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn finish_cancelled_turn_clears_cancelled_active_without_rehydrating_queue() {
         let _lock = match TEST_ENV_LOCK.lock() {


### PR DESCRIPTION
## What

Part of #3034 (maintainability: restore global lint enforcement). This PR delivers **Part 2: `await_holding_lock`**.

Removes `clippy::await_holding_lock` from the crate-wide `#![allow(...)]` in `src/lib.rs`, restoring static detection of lock-across-await races in **production** code.

## Findings

Surfacing the lint flagged **16 sites across 9 files**. After auditing each: **every single one is `#[cfg(test)]` code** — a `std::sync::Mutex<()>` test-serialization guard held across `.await` *on purpose* to serialize tests that mutate process-global state:

- `db/postgres.rs` (×2) — `lock_test_setup()`: serializes PG test-DB create/drop.
- `reconcile.rs` (×2), `server/routes/dispatches/crud.rs` (×1) — `lock_dispatch_delivery_metric_tests()`: serializes the global dispatch-delivery mismatch metrics.
- `server/routes/escalation.rs` (×1), `tmux_watcher.rs` (×1), `turn_finalizer.rs` (×1), `turn_orchestrator.rs` (×6) — `env_lock()` / `shared_test_env_lock()` / `TEST_ENV_LOCK`: serialize tests mutating `AGENTDESK_ROOT_DIR` and other env.
- `tui_prompt_relay.rs` (×1) — `tui_prompt_dedupe::TEST_LOCK`.
- `turn_lifecycle.rs` (×1) — `observability::test_runtime_lock()`.

There were **zero production lock-across-await violations**. Dropping any of these guards before the await would defeat the serialization and reintroduce the exact cross-test races they were added to fix — so the hold is required and unavoidable.

Per the issue's guidance ("if genuinely safe and unavoidable, narrow the allow to that site with a `// SAFETY:` justification — not globally"), each site now carries a narrow `#[allow(clippy::await_holding_lock)]` + `// SAFETY:` comment. Future *production* lock-across-await will now fail clippy.

## Scope / safety

- Edits are **attribute + comment only**, behavior-preserving.
- Protected relay hot files touched (`tmux_watcher.rs`, `tui_prompt_relay.rs`) only gain an allow attribute + comment on an existing `#[tokio::test]` — **no logic change**.
- Synced `change-surfaces.md` freeze entries for the two giant files whose production LoC grew by the SAFETY comments (`postgres.rs` 1009→1018, `escalation.rs` 1728→1733) to keep the #3036 LoC gate green.

## Deferred (follow-up)

**Part 1 of #3034** — removing the remaining `#[allow(dead_code)]` blanket on `mod services` and deleting surfaced dead code. Measured: it surfaces **~538 dead-code items across ~138 files**, including the protected relay hot files (`status_panel_controller.rs`, `turn_bridge/mod.rs`, `inflight.rs`, etc.). Too large/risky for one reviewable PR; should be sliced separately. (The earlier merged commit `9e2829df9` already cleared the leaf-module blankets; only `services` remains.)

## Verification

- `cargo fmt --all --check` — clean
- `cargo check --workspace --all-features --all-targets` — no new dead_code warnings (9 pre-existing baseline, unchanged; `services` blanket still in place since Part 1 is deferred)
- `cargo clippy --workspace --all-features --all-targets` — `await_holding_lock` hits = **0**
- Affected tests pass run serially (`--test-threads=1`, as CI runs). Note: the `turn_orchestrator::` suite fails under default parallel test execution due to a pre-existing process-global-env race (confirmed identical on clean `origin/main`) — not introduced by this attribute-only change.
- `./scripts/ci-script-checks.sh` — exit 0

## Review note

The `// SAFETY:` reasoning on each await_holding_lock site is the load-bearing logic of this PR (concurrency-correctness judgement that each test guard *must* span the await). Flagging for codex review of that reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)