### PR TITLE
refactor: sub-decompose decision_route_dispute into phase helpers (Part of #3038)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -314,7 +314,7 @@
   - `src/server/routes/docs.rs` (5880 lines).
   - `src/server/routes/escalation.rs` (1733 lines).
   - `src/server/routes/meetings.rs` (1708 lines).
-  - `src/server/routes/review_verdict/decision_route.rs` (4315 lines).
+  - `src/server/routes/review_verdict/decision_route.rs` (4351 lines).
   - `src/server/routes/{agents,agents_crud,agents_setup,v1,resume,
     dispatches/thread_reuse}.rs` (all 1000+ production lines).
 - active_callsite_coverage: legacy_db helper coverage tracked separately —

--- a/src/server/routes/review_verdict/decision_route.rs
+++ b/src/server/routes/review_verdict/decision_route.rs
@@ -3493,6 +3493,25 @@ async fn decision_route_dispute(
     // atomically with a stale re-check inside the close
     // transaction.
     if body.out_of_scope == Some(true) {
+        return decision_route_dispute_scope_mismatch_close(state, body, pending_rd_id).await;
+    }
+
+    decision_route_dispute_re_review(state, body, pending_rd_id, resume_side_effects_pending).await
+}
+
+/// Phase 3b-i of `submit_review_decision` dispute branch: the out-of-scope
+/// (`body.out_of_scope == Some(true)`) close path. Pure extraction of the
+/// original `if body.out_of_scope == Some(true) { ... }` block (steps 1–8).
+/// Every original early `return` inside the block is preserved verbatim as a
+/// `return` from this helper; the parent dispatches to it unconditionally
+/// inside the same `if`, so control flow, side-effect ordering, and error
+/// paths are identical.
+async fn decision_route_dispute_scope_mismatch_close(
+    state: &AppState,
+    body: &ReviewDecisionBody,
+    pending_rd_id: &Option<String>,
+) -> DecisionResponse {
+    {
         // 1. Caller must prove ownership of the pending review-decision
         //    dispatch via `dispatch_id` matching `pending_rd_id`.
         let rd_id = match (body.dispatch_id.as_deref(), pending_rd_id.as_deref()) {
@@ -3865,7 +3884,24 @@ async fn decision_route_dispute(
             })),
         );
     }
+}
 
+/// Phase 3b-ii of `submit_review_decision` dispute branch: the regular
+/// (non-out-of-scope) re-review path. Pure extraction of the original code
+/// that followed the `if body.out_of_scope` block — consume the pending
+/// review-decision, prepare the dispute re-review entry, record tuning,
+/// cancel stale dispatches, re-fire `OnReviewEnter`, validate the live
+/// review dispatch, update review state, finalize the pending
+/// review-decision, and return. Every original early `return` is preserved
+/// verbatim; the trailing value (originally the function tail) becomes this
+/// helper's tail and is returned by the parent. Control flow, side-effect
+/// ordering, and error paths are identical.
+async fn decision_route_dispute_re_review(
+    state: &AppState,
+    body: &ReviewDecisionBody,
+    pending_rd_id: &Option<String>,
+    resume_side_effects_pending: bool,
+) -> DecisionResponse {
     let rd_consumed = if resume_side_effects_pending {
         true
     } else {


### PR DESCRIPTION
## Summary
Part of #3038 (EPIC: decompose god-functions). Behavior-preserving sub-decomposition of `decision_route_dispute` (~689 lines), the next-best NON-RELAY god-function in the already-once-refactored `decision_route.rs`.

The function held two cohesive, mutually exclusive phases gated by `body.out_of_scope`. Split into two named helpers:

- **`decision_route_dispute_scope_mismatch_close(state, body, pending_rd_id)`** — the `if body.out_of_scope == Some(true)` close path (steps 1–8: ownership proof → source-review binding → tri-state scope verify → lifecycle snapshot → atomic finalize → post-tx lifecycle re-check → cancel-stale → transition → dismiss cleanup → tuning → emit). Parent dispatches inside the same `if` and returns.
- **`decision_route_dispute_re_review(state, body, pending_rd_id, resume_side_effects_pending)`** — the regular non-out-of-scope re-review path (consume pending RD → prepare dispute entry → record tuning → cancel stale → fire/drain `OnReviewEnter` + #229 safety-net re-fire → validate live review dispatch + scope → update review state → finalize pending RD → emit → return). Parent calls it as the tail expression.

## Behavior preservation argument
- **Pure extraction.** Every original statement reappears verbatim inside a helper; the only added lines are two helper signatures, doc comments, two call sites, and one brace pair wrapping the moved out_of_scope block. `git diff` is additive: 37 insertions, 1 deletion (the LoC freeze number in change-surfaces.md). Zero deletions of logic.
- **Early returns identical.** Each helper returns `DecisionResponse` (`= (StatusCode, Json<Value>)`); every original `return (...)` short-circuits the helper exactly as before, and the parent propagates it (one path via `return helper().await`, the other via tail expression).
- **Control flow / side-effect ordering / error paths unchanged.** The two phases were already mutually exclusive (the out_of_scope block always ended in `return`), so no cross-phase bindings exist. `rd_consumed` and all downstream state moved wholesale into the re_review helper.

## LoC
- `decision_route_dispute` body: ~689 lines → now a 4-line dispatcher.
- New helpers: scope-mismatch-close ~373 lines, re-review ~288 lines (statement-equal to the original two phases).
- File: 4315 → 4351 lines (+36 scaffolding; change-surfaces.md freeze entry synced).

## Verification
- `cargo fmt --all --check` clean
- `cargo check --workspace --all-features --all-targets` clean (only pre-existing dead-code warnings)
- `./scripts/ci-script-checks.sh` exit 0 (freshness gate passed after syncing change-surfaces.md)
- No Rust tests for this PG-side-effect-driven path; correctness rests on statement-level equivalence (documented above for review).

## For codex review
This is a **behavior-preserving refactor**. Review should focus solely on whether ANY behavior / control-flow / ordering / early-return changed. Do NOT merge — codex review follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)