### PR TITLE
refactor: sub-decompose decision_route_accept into phase helpers (Part of #3038)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -314,7 +314,7 @@
   - `src/server/routes/docs.rs` (5880 lines).
   - `src/server/routes/escalation.rs` (1733 lines).
   - `src/server/routes/meetings.rs` (1708 lines).
-  - `src/server/routes/review_verdict/decision_route.rs` (4351 lines).
+  - `src/server/routes/review_verdict/decision_route.rs` (4438 lines).
   - `src/server/routes/{agents,agents_crud,agents_setup,v1,resume,
     dispatches/thread_reuse}.rs` (all 1000+ production lines).
 - active_callsite_coverage: legacy_db helper coverage tracked separately —

--- a/src/server/routes/review_verdict/decision_route.rs
+++ b/src/server/routes/review_verdict/decision_route.rs
@@ -2976,223 +2976,31 @@ async fn decision_route_accept(
     // OnReviewEnter fires naturally (increments review_round, sets
     // review_status, creates review dispatch via review-automation.js).
     let direct_review_attempted = skip_rework;
-    let mut direct_review_created = if skip_rework {
-        // Find the review state from the pipeline (gated transition from rework_target)
-        let review_state = effective_pipeline
-            .transitions
-            .iter()
-            .find(|t| {
-                t.from == rework_target
-                    && t.transition_type == crate::pipeline::TransitionType::Gated
-            })
-            .map(|t| t.to.clone());
-
-        if let Some(ref review_st) = review_state {
-            if let Err(error) = mark_next_review_round_advance_pg_first(state, &body.card_id).await
-            {
-                accept_failures.push(format!(
-                    "failed to mark review round advance before direct review: {error}"
-                ));
-                tracing::warn!(
-                    "[review-decision] failed to mark direct-review round advance for card {}: {}",
-                    body.card_id,
-                    error
-                );
-            }
-            // Step 1: Transition to rework_target (e.g., in_progress)
-            match transition_status_pg_first(
-                state,
-                &body.card_id,
-                &rework_target,
-                "review_decision_accept_skip_rework_step1",
-                crate::engine::transition::ForceIntent::SystemRecovery,
-            )
-            .await
-            {
-                Ok(_) => {
-                    // Step 2: Transition to review — fires OnReviewEnter
-                    match transition_status_pg_first(
-                        state,
-                        &body.card_id,
-                        review_st,
-                        "review_decision_accept_skip_rework_step2",
-                        crate::engine::transition::ForceIntent::SystemRecovery,
-                    )
-                    .await
-                    {
-                        Ok(_) => {
-                            // Materialize any follow-up transitions queued by
-                            // OnReviewEnter (for example, single-provider
-                            // auto-approval to terminal) before checking
-                            // whether a live review dispatch exists.
-                            crate::kanban::drain_hook_side_effects_with_backends(
-                                None,
-                                &state.engine,
-                            );
-                            let followups =
-                                active_accept_followups_pg_first(state, &body.card_id).await;
-                            if followups.review > 0 {
-                                tracing::info!(
-                                    "[review-decision] #246 Direct review re-entry for card {}: {} → {} → {} (rework skipped)",
-                                    body.card_id,
-                                    card_status_now,
-                                    rework_target,
-                                    review_st
-                                );
-                                true
-                            } else if current_card_status_pg_first(state, &body.card_id)
-                                .await
-                                .as_deref()
-                                .map(|status| effective_pipeline.is_terminal(status))
-                                .unwrap_or(false)
-                            {
-                                direct_review_auto_approved = true;
-                                tracing::info!(
-                                    "[review-decision] #483 Direct review re-entry for card {} auto-approved without review dispatch (no alternate reviewer)",
-                                    body.card_id
-                                );
-                                false
-                            } else {
-                                accept_failures.push(format!(
-                                        "direct review transition reached {} but no active review dispatch was created",
-                                        review_st
-                                    ));
-                                tracing::warn!(
-                                    "[review-decision] #339 Direct review re-entry for card {} reached {} but no active review dispatch exists",
-                                    body.card_id,
-                                    review_st
-                                );
-                                false
-                            }
-                        }
-                        Err(e) => {
-                            accept_failures.push(format!(
-                                "direct review step2 transition to {} failed: {e}",
-                                review_st
-                            ));
-                            tracing::warn!(
-                                "[review-decision] #246 Step 2 transition to {} failed for card {}: {e}",
-                                review_st,
-                                body.card_id
-                            );
-                            false
-                        }
-                    }
-                }
-                Err(e) => {
-                    accept_failures.push(format!(
-                        "direct review step1 transition to {} failed: {e}",
-                        rework_target
-                    ));
-                    tracing::warn!(
-                        "[review-decision] #339 Step 1 transition to {} failed for card {} during direct review: {e}",
-                        rework_target,
-                        body.card_id
-                    );
-                    false
-                }
-            }
-        } else {
-            accept_failures.push(format!(
-                "skip_rework requested but no review state could be resolved from rework target {}",
-                rework_target
-            ));
-            false
-        }
-    } else {
-        false
-    };
+    let mut direct_review_created = decision_route_accept_direct_review_reentry(
+        state,
+        body,
+        &effective_pipeline,
+        &rework_target,
+        &card_status_now,
+        skip_rework,
+        &mut accept_failures,
+        &mut direct_review_auto_approved,
+    )
+    .await;
 
     // Create rework dispatch on the normal accept path, or as a fallback when
     // direct review re-entry fails / produces no active review dispatch.
-    let existing_followups_before_rework =
-        active_accept_followups_pg_first(state, &body.card_id).await;
-    if !existing_followups_before_rework.has_followup()
-        && !direct_review_created
-        && !direct_review_auto_approved
-    {
-        let card_status_before_rework = current_card_status_pg_first(state, &body.card_id).await;
-        let rework_transition_ready = card_status_before_rework.as_deref()
-            == Some(rework_target.as_str())
-            || match transition_status_pg_first(
-                state,
-                &body.card_id,
-                &rework_target,
-                "review_decision_accept",
-                crate::engine::transition::ForceIntent::SystemRecovery,
-            )
-            .await
-            {
-                Ok(_) => true,
-                Err(e) => {
-                    accept_failures.push(format!(
-                        "transition to rework target {} failed: {e}",
-                        rework_target
-                    ));
-                    tracing::warn!(
-                        "[review-decision] #195 Transition to rework target failed for card {}: {e}",
-                        body.card_id
-                    );
-                    false
-                }
-            };
-
-        if rework_transition_ready {
-            if let Some(ref agent_id) = card_agent_id {
-                let rework_title = format!(
-                    "[Rework] {}",
-                    card_title.as_deref().unwrap_or(&body.card_id)
-                );
-                let rework_dispatch_result = if let Some(pool) = state.pg_pool_ref() {
-                    crate::dispatch::create_dispatch_with_options_pg_only(
-                        pool,
-                        &state.engine,
-                        &body.card_id,
-                        agent_id,
-                        "rework",
-                        &rework_title,
-                        &json!({}),
-                        crate::dispatch::DispatchCreateOptions::default(),
-                    )
-                } else {
-                    {
-                        Err(anyhow::anyhow!(
-                            "postgres pool unavailable for rework dispatch"
-                        ))
-                    }
-                };
-                match rework_dispatch_result {
-                    Ok(dispatch) => {
-                        let dispatch_id = dispatch
-                            .get("id")
-                            .and_then(|value| value.as_str())
-                            .unwrap_or("(unknown)");
-                        tracing::info!(
-                            "[review-decision] #195 Rework dispatch created: card={} dispatch={}",
-                            body.card_id,
-                            dispatch_id
-                        );
-                    }
-                    Err(e) => {
-                        accept_failures.push(format!("rework dispatch creation failed: {e}"));
-                        tracing::warn!(
-                            "[review-decision] #195 Rework dispatch creation failed for card {}: {e}",
-                            body.card_id
-                        );
-                    }
-                }
-            } else {
-                accept_failures.push(format!(
-                    "no assigned agent for rework dispatch on card {}",
-                    body.card_id
-                ));
-                tracing::warn!(
-                    "[review-decision] #195 No agent assigned to card {} — cannot create rework dispatch",
-                    body.card_id
-                );
-            }
-        }
-    }
+    decision_route_accept_rework_dispatch(
+        state,
+        body,
+        &rework_target,
+        direct_review_created,
+        direct_review_auto_approved,
+        card_agent_id.as_deref(),
+        card_title.as_deref(),
+        &mut accept_failures,
+    )
+    .await;
 
     let followups = active_accept_followups_pg_first(state, &body.card_id).await;
     direct_review_created = followups.review > 0;
@@ -3332,6 +3140,324 @@ async fn decision_route_accept(
         }
     }
 
+    if let Err(response) = decision_route_accept_finalize_pending_dispatch(
+        state,
+        body,
+        pending_rd_id,
+        rd_consumed,
+        terminal_auto_approved,
+        followups,
+    )
+    .await
+    {
+        return response;
+    }
+
+    if let Err(response) = mark_consumed_review_decision_complete_or_response(
+        state,
+        &body.card_id,
+        pending_rd_id.as_deref(),
+        "accept",
+        rd_consumed,
+        if resume_side_effects_pending {
+            "side_effects_resuming"
+        } else {
+            "side_effects_pending"
+        },
+    )
+    .await
+    {
+        return response;
+    }
+
+    emit_card_updated(state, &body.card_id).await;
+    let message = if terminal_auto_approved {
+        "Review-decision accepted, review auto-approved (no alternate reviewer)"
+    } else if direct_review_created {
+        "Review-decision accepted, direct review dispatch created (rework skipped)"
+    } else {
+        "Review-decision accepted, rework dispatch created"
+    };
+    return (
+        StatusCode::OK,
+        Json(json!({
+            "ok": true,
+            "card_id": body.card_id,
+            "decision": "accept",
+            "rework_dispatch_created": rework_dispatch_created,
+            "direct_review_created": direct_review_created,
+            "review_auto_approved": terminal_auto_approved,
+            "skip_rework": skip_rework,
+            "skip_rework_diagnostics": skip_rework_diagnostics.to_json(),
+            "message": message,
+        })),
+    );
+}
+
+/// Sub-phase of `decision_route_accept` (#246/#483/#339): the direct-review
+/// re-entry block. Pure extraction of the original
+/// `let mut direct_review_created = if skip_rework { ... } else { false };`
+/// initializer expression. Returns the same `direct_review_created` bool and
+/// mutates `accept_failures` / `direct_review_auto_approved` through `&mut`
+/// exactly as the inline block did — so control flow, side-effect ordering and
+/// the resulting locals are identical.
+#[allow(clippy::too_many_arguments)]
+async fn decision_route_accept_direct_review_reentry(
+    state: &AppState,
+    body: &ReviewDecisionBody,
+    effective_pipeline: &crate::pipeline::PipelineConfig,
+    rework_target: &str,
+    card_status_now: &str,
+    skip_rework: bool,
+    accept_failures: &mut Vec<String>,
+    direct_review_auto_approved: &mut bool,
+) -> bool {
+    if skip_rework {
+        // Find the review state from the pipeline (gated transition from rework_target)
+        let review_state = effective_pipeline
+            .transitions
+            .iter()
+            .find(|t| {
+                t.from == rework_target
+                    && t.transition_type == crate::pipeline::TransitionType::Gated
+            })
+            .map(|t| t.to.clone());
+
+        if let Some(ref review_st) = review_state {
+            if let Err(error) = mark_next_review_round_advance_pg_first(state, &body.card_id).await
+            {
+                accept_failures.push(format!(
+                    "failed to mark review round advance before direct review: {error}"
+                ));
+                tracing::warn!(
+                    "[review-decision] failed to mark direct-review round advance for card {}: {}",
+                    body.card_id,
+                    error
+                );
+            }
+            // Step 1: Transition to rework_target (e.g., in_progress)
+            match transition_status_pg_first(
+                state,
+                &body.card_id,
+                rework_target,
+                "review_decision_accept_skip_rework_step1",
+                crate::engine::transition::ForceIntent::SystemRecovery,
+            )
+            .await
+            {
+                Ok(_) => {
+                    // Step 2: Transition to review — fires OnReviewEnter
+                    match transition_status_pg_first(
+                        state,
+                        &body.card_id,
+                        review_st,
+                        "review_decision_accept_skip_rework_step2",
+                        crate::engine::transition::ForceIntent::SystemRecovery,
+                    )
+                    .await
+                    {
+                        Ok(_) => {
+                            // Materialize any follow-up transitions queued by
+                            // OnReviewEnter (for example, single-provider
+                            // auto-approval to terminal) before checking
+                            // whether a live review dispatch exists.
+                            crate::kanban::drain_hook_side_effects_with_backends(
+                                None,
+                                &state.engine,
+                            );
+                            let followups =
+                                active_accept_followups_pg_first(state, &body.card_id).await;
+                            if followups.review > 0 {
+                                tracing::info!(
+                                    "[review-decision] #246 Direct review re-entry for card {}: {} → {} → {} (rework skipped)",
+                                    body.card_id,
+                                    card_status_now,
+                                    rework_target,
+                                    review_st
+                                );
+                                true
+                            } else if current_card_status_pg_first(state, &body.card_id)
+                                .await
+                                .as_deref()
+                                .map(|status| effective_pipeline.is_terminal(status))
+                                .unwrap_or(false)
+                            {
+                                *direct_review_auto_approved = true;
+                                tracing::info!(
+                                    "[review-decision] #483 Direct review re-entry for card {} auto-approved without review dispatch (no alternate reviewer)",
+                                    body.card_id
+                                );
+                                false
+                            } else {
+                                accept_failures.push(format!(
+                                        "direct review transition reached {} but no active review dispatch was created",
+                                        review_st
+                                    ));
+                                tracing::warn!(
+                                    "[review-decision] #339 Direct review re-entry for card {} reached {} but no active review dispatch exists",
+                                    body.card_id,
+                                    review_st
+                                );
+                                false
+                            }
+                        }
+                        Err(e) => {
+                            accept_failures.push(format!(
+                                "direct review step2 transition to {} failed: {e}",
+                                review_st
+                            ));
+                            tracing::warn!(
+                                "[review-decision] #246 Step 2 transition to {} failed for card {}: {e}",
+                                review_st,
+                                body.card_id
+                            );
+                            false
+                        }
+                    }
+                }
+                Err(e) => {
+                    accept_failures.push(format!(
+                        "direct review step1 transition to {} failed: {e}",
+                        rework_target
+                    ));
+                    tracing::warn!(
+                        "[review-decision] #339 Step 1 transition to {} failed for card {} during direct review: {e}",
+                        rework_target,
+                        body.card_id
+                    );
+                    false
+                }
+            }
+        } else {
+            accept_failures.push(format!(
+                "skip_rework requested but no review state could be resolved from rework target {}",
+                rework_target
+            ));
+            false
+        }
+    } else {
+        false
+    }
+}
+
+/// Sub-phase of `decision_route_accept` (#195): the rework-dispatch creation
+/// block, run on the normal accept path or as a fallback when direct review
+/// re-entry fails / produces no active review dispatch. Pure extraction of the
+/// original inline block; it performs the same side effects in the same order
+/// and pushes to `accept_failures` through `&mut` exactly as before.
+#[allow(clippy::too_many_arguments)]
+async fn decision_route_accept_rework_dispatch(
+    state: &AppState,
+    body: &ReviewDecisionBody,
+    rework_target: &str,
+    direct_review_created: bool,
+    direct_review_auto_approved: bool,
+    card_agent_id: Option<&str>,
+    card_title: Option<&str>,
+    accept_failures: &mut Vec<String>,
+) {
+    let existing_followups_before_rework =
+        active_accept_followups_pg_first(state, &body.card_id).await;
+    if !existing_followups_before_rework.has_followup()
+        && !direct_review_created
+        && !direct_review_auto_approved
+    {
+        let card_status_before_rework = current_card_status_pg_first(state, &body.card_id).await;
+        let rework_transition_ready = card_status_before_rework.as_deref() == Some(rework_target)
+            || match transition_status_pg_first(
+                state,
+                &body.card_id,
+                rework_target,
+                "review_decision_accept",
+                crate::engine::transition::ForceIntent::SystemRecovery,
+            )
+            .await
+            {
+                Ok(_) => true,
+                Err(e) => {
+                    accept_failures.push(format!(
+                        "transition to rework target {} failed: {e}",
+                        rework_target
+                    ));
+                    tracing::warn!(
+                        "[review-decision] #195 Transition to rework target failed for card {}: {e}",
+                        body.card_id
+                    );
+                    false
+                }
+            };
+
+        if rework_transition_ready {
+            if let Some(agent_id) = card_agent_id {
+                let rework_title = format!("[Rework] {}", card_title.unwrap_or(&body.card_id));
+                let rework_dispatch_result = if let Some(pool) = state.pg_pool_ref() {
+                    crate::dispatch::create_dispatch_with_options_pg_only(
+                        pool,
+                        &state.engine,
+                        &body.card_id,
+                        agent_id,
+                        "rework",
+                        &rework_title,
+                        &json!({}),
+                        crate::dispatch::DispatchCreateOptions::default(),
+                    )
+                } else {
+                    {
+                        Err(anyhow::anyhow!(
+                            "postgres pool unavailable for rework dispatch"
+                        ))
+                    }
+                };
+                match rework_dispatch_result {
+                    Ok(dispatch) => {
+                        let dispatch_id = dispatch
+                            .get("id")
+                            .and_then(|value| value.as_str())
+                            .unwrap_or("(unknown)");
+                        tracing::info!(
+                            "[review-decision] #195 Rework dispatch created: card={} dispatch={}",
+                            body.card_id,
+                            dispatch_id
+                        );
+                    }
+                    Err(e) => {
+                        accept_failures.push(format!("rework dispatch creation failed: {e}"));
+                        tracing::warn!(
+                            "[review-decision] #195 Rework dispatch creation failed for card {}: {e}",
+                            body.card_id
+                        );
+                    }
+                }
+            } else {
+                accept_failures.push(format!(
+                    "no assigned agent for rework dispatch on card {}",
+                    body.card_id
+                ));
+                tracing::warn!(
+                    "[review-decision] #195 No agent assigned to card {} — cannot create rework dispatch",
+                    body.card_id
+                );
+            }
+        }
+    }
+}
+
+/// Sub-phase of `decision_route_accept` (#339/#483): finalize the pending
+/// review-decision dispatch (mark `completed`) after a follow-up dispatch was
+/// created. Pure extraction of the original
+/// `if !rd_consumed && let Some(rd_id) = pending_rd_id { ... }` block. Each
+/// original early `return <DecisionResponse>` becomes `return Err(<same
+/// response>)`; the success / no-op paths return `Ok(())`. The caller
+/// propagates `Err` immediately, so the net return + short-circuit points are
+/// identical.
+async fn decision_route_accept_finalize_pending_dispatch(
+    state: &AppState,
+    body: &ReviewDecisionBody,
+    pending_rd_id: &Option<String>,
+    rd_consumed: bool,
+    terminal_auto_approved: bool,
+    followups: ActiveAcceptFollowups,
+) -> Result<(), DecisionResponse> {
     if !rd_consumed && let Some(rd_id) = pending_rd_id {
         let status_db = None;
         match crate::dispatch::set_dispatch_status_with_backends(
@@ -3394,14 +3520,14 @@ async fn decision_route_accept(
                         active_review_decision = live_dispatches.review_decision,
                         "[review-decision] #339 accept created a follow-up dispatch but failed to finalize the pending review-decision"
                     );
-                    return (
+                    return Err((
                         StatusCode::CONFLICT,
                         Json(json!({
                             "error": "failed to finalize pending review-decision after follow-up dispatch creation",
                             "card_id": body.card_id,
                             "pending_dispatch_id": rd_id,
                         })),
-                    );
+                    ));
                 }
             }
             Err(e) => {
@@ -3413,57 +3539,18 @@ async fn decision_route_accept(
                     error = %e,
                     "[review-decision] #339 accept created a follow-up dispatch but mark_dispatch_completed errored"
                 );
-                return (
+                return Err((
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(json!({
                         "error": format!("failed to finalize pending review-decision: {e}"),
                         "card_id": body.card_id,
                         "pending_dispatch_id": rd_id,
                     })),
-                );
+                ));
             }
         }
     }
-
-    if let Err(response) = mark_consumed_review_decision_complete_or_response(
-        state,
-        &body.card_id,
-        pending_rd_id.as_deref(),
-        "accept",
-        rd_consumed,
-        if resume_side_effects_pending {
-            "side_effects_resuming"
-        } else {
-            "side_effects_pending"
-        },
-    )
-    .await
-    {
-        return response;
-    }
-
-    emit_card_updated(state, &body.card_id).await;
-    let message = if terminal_auto_approved {
-        "Review-decision accepted, review auto-approved (no alternate reviewer)"
-    } else if direct_review_created {
-        "Review-decision accepted, direct review dispatch created (rework skipped)"
-    } else {
-        "Review-decision accepted, rework dispatch created"
-    };
-    return (
-        StatusCode::OK,
-        Json(json!({
-            "ok": true,
-            "card_id": body.card_id,
-            "decision": "accept",
-            "rework_dispatch_created": rework_dispatch_created,
-            "direct_review_created": direct_review_created,
-            "review_auto_approved": terminal_auto_approved,
-            "skip_rework": skip_rework,
-            "skip_rework_diagnostics": skip_rework_diagnostics.to_json(),
-            "message": message,
-        })),
-    );
+    Ok(())
 }
 
 /// Phase 3b of `submit_review_decision`: the `dispute` decision branch. Covers


### PR DESCRIPTION
## Summary

Pure, behavior-preserving sub-decomposition of `decision_route_accept` (~581 lines) in `src/server/routes/review_verdict/decision_route.rs`, mirroring the prior `decision_route_dispute` slice (`_scope_mismatch_close` + `_re_review`). Three cohesive sub-phases are extracted into named helpers, called in the **same order** with identical control flow, side-effect ordering, early returns and captured locals.

**Part of #3038** (NO auto-close).

## Sub-helpers (names + order + role)

1. `decision_route_accept_direct_review_reentry(...) -> bool` (#246/#483/#339) — the `skip_rework` two-step transition block (rework_target → review, OnReviewEnter, auto-approval detection). Pure extraction of the `let mut direct_review_created = if skip_rework { ... } else { false };` initializer expression. Returns the same `bool` and mutates `accept_failures` / `direct_review_auto_approved` via `&mut` exactly as the inline block did.
2. `decision_route_accept_rework_dispatch(...)` (#195) — the rework-dispatch creation block (normal accept path / fallback when direct review re-entry produced no active dispatch). Pure extraction; same side effects in the same order, pushes to `accept_failures` via `&mut`.
3. `decision_route_accept_finalize_pending_dispatch(...) -> Result<(), DecisionResponse>` (#339/#483) — the `if !rd_consumed && let Some(rd_id) = pending_rd_id { ... }` mark-`completed` block. Each original early `return <DecisionResponse>` becomes `return Err(<same response>)`; the caller does `if let Err(response) = ... { return response; }`.

The remaining in-place phases (setup/terminal-guard, consume-pending, rework-target resolution, skip-rework diagnostics, followup-reconcile + restamp + terminal-auto-approval detection + fail-closed early return, finalize-cleanup/tuning/review-state, mark-consumed, emit + response) are unchanged and call the helpers at the exact same points.

## Behavior-preservation argument

- **Control flow / early returns:** Helper 3 returns `Result<_, DecisionResponse>`; the caller propagates `Err` immediately, so the net return value and every short-circuit point are identical. Helpers 1 & 2 contain no early `return` of a response (they only compute a bool / perform side effects), so extracting them changes nothing.
- **Side-effect ordering:** Every PG read/write, transition, dispatch creation, hook drain and `tracing` log stays in the original sequence; helpers run synchronously inline at the original call points.
- **Captured locals:** All locals are threaded as params; `accept_failures` and `direct_review_auto_approved` are passed `&mut` so accumulation across phases is preserved. No local is dropped, recreated, or reordered.
- **Param-type adjustments only:** `rework_target` is passed as `&str` instead of `&String` (call sites changed `&rework_target` → `rework_target`, and `Some(rework_target.as_str())` → `Some(rework_target)`); `card_agent_id`/`card_title` passed as `Option<&str>` via `.as_deref()`. These are deref/borrow-only changes with identical runtime behavior.
- **Statement-level equivalence:** Every removed line reappears verbatim in a helper. Added lines are only signatures, doc comments, braces, call sites, and the `&mut` derefs / `&str` adjustments above — no new logic, no reorder, no double-execution.

## LoC

`decision_route.rs`: 4351 → 4438 production lines (+87, all helper signatures + doc comments + call-site scaffolding). change-surfaces.md freeze entry synced via `generate_inventory_docs.py`.

## Verification

- `cargo fmt --all --check` — clean
- `cargo check --workspace --all-features --all-targets` — clean (only pre-existing warnings)
- `./scripts/ci-script-checks.sh` — exit 0 (giant-file registry / agent-maintenance LoC hard-gate satisfied)
- `decision_route` has **no Rust tests** (PG-side-effect driven) → relies on statement-level equivalence. No fake harness invented.

## For codex review

This is a **behavior-preserving refactor**. Review should focus on whether **any** behavior / control-flow / ordering / early-return / capture changed between the original inline blocks and the extracted helpers — in particular the `Result<(), DecisionResponse>` propagation in helper 3 and the `&mut accept_failures` / `&mut direct_review_auto_approved` threading in helper 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)