### PR TITLE
refactor: sub-decompose decision_route_resolve_pending into phase helpers (Part of #3038)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -314,7 +314,7 @@
   - `src/server/routes/docs.rs` (5880 lines).
   - `src/server/routes/escalation.rs` (1733 lines).
   - `src/server/routes/meetings.rs` (1708 lines).
-  - `src/server/routes/review_verdict/decision_route.rs` (4438 lines).
+  - `src/server/routes/review_verdict/decision_route.rs` (4491 lines).
   - `src/server/routes/{agents,agents_crud,agents_setup,v1,resume,
     dispatches/thread_reuse}.rs` (all 1000+ production lines).
 - active_callsite_coverage: legacy_db helper coverage tracked separately —

--- a/src/server/routes/review_verdict/decision_route.rs
+++ b/src/server/routes/review_verdict/decision_route.rs
@@ -2308,315 +2308,368 @@ async fn decision_route_resolve_pending(
     let mut resume_side_effects_pending = false;
 
     if pending_rd_id.is_none() {
-        if let Some(ref submitted_did) = body.dispatch_id {
-            match lookup_review_decision_dispatch_by_id(state, &body.card_id, submitted_did).await {
-                ReviewDecisionDispatchLookup::LiveAndCurrent => {
-                    tracing::info!(
-                        card_id = %body.card_id,
-                        dispatch_id = %submitted_did,
-                        "[review-decision] #2200 sub-fix 4: honoring submitted dispatch_id whose link rows were cleared but dispatch is still live and current"
-                    );
-                    pending_rd_id = Some(submitted_did.clone());
-                }
-                ReviewDecisionDispatchLookup::LiveButSuperseded => {
+        decision_route_resolve_pending_by_id_recovery(state, body, &mut pending_rd_id).await?;
+    }
+
+    if pending_rd_id.is_none() {
+        // #2341 / #2200 sub-3 idempotent resume (scope_mismatch_closed) runs
+        // first; it either short-circuits with an early return (handled inside
+        // the helper) or falls through. The #2200 sub-fix 1 stale-state branch
+        // then runs in the SAME order it did inline.
+        decision_route_resolve_pending_scope_mismatch_resume(state, body).await?;
+        decision_route_resolve_pending_stale_state(
+            state,
+            body,
+            &mut pending_rd_id,
+            &mut resume_side_effects_pending,
+        )
+        .await?;
+    }
+
+    Ok((pending_rd_id, resume_side_effects_pending))
+}
+
+/// Sub-phase of `decision_route_resolve_pending` (#3038): #2200 sub-fix 4
+/// (`stale-dispatch-mismatch`) by-id recovery. Pure extraction of the original
+/// `if let Some(ref submitted_did) = body.dispatch_id { match lookup_...by_id }`
+/// block. The only mutation that escapes is setting `pending_rd_id` to the
+/// honored dispatch id on `LiveAndCurrent`; every other variant either returns
+/// `Err` (propagated via `?`) or falls through with `Ok(())`. The caller only
+/// invokes this when `pending_rd_id.is_none()`, exactly as the inline guard did.
+async fn decision_route_resolve_pending_by_id_recovery(
+    state: &AppState,
+    body: &ReviewDecisionBody,
+    pending_rd_id: &mut Option<String>,
+) -> Result<(), DecisionResponse> {
+    if let Some(ref submitted_did) = body.dispatch_id {
+        match lookup_review_decision_dispatch_by_id(state, &body.card_id, submitted_did).await {
+            ReviewDecisionDispatchLookup::LiveAndCurrent => {
+                tracing::info!(
+                    card_id = %body.card_id,
+                    dispatch_id = %submitted_did,
+                    "[review-decision] #2200 sub-fix 4: honoring submitted dispatch_id whose link rows were cleared but dispatch is still live and current"
+                );
+                *pending_rd_id = Some(submitted_did.clone());
+            }
+            ReviewDecisionDispatchLookup::LiveButSuperseded => {
+                return Err((
+                    StatusCode::CONFLICT,
+                    Json(json!({
+                        "error": "review-decision dispatch is superseded by a newer live dispatch for this card",
+                        "card_id": body.card_id,
+                        "dispatch_id": submitted_did,
+                    })),
+                ));
+            }
+            ReviewDecisionDispatchLookup::Terminal => {
+                // Intentional fall-through: the row is terminal, which is
+                // sub-fix 1's territory (PR #2280 proven-finalized).
+                // Returning the canonical 409 here keeps the response
+                // shape compatible with sub-1 and lets that branch
+                // promote to 200 already_finalized once merged.
+            }
+            ReviewDecisionDispatchLookup::NotFound => {
+                if !finalized_review_decision_info_pg_first(state, &body.card_id)
+                    .await
+                    .has_originating_dispatch()
+                {
                     return Err((
-                        StatusCode::CONFLICT,
+                        StatusCode::NOT_FOUND,
                         Json(json!({
-                            "error": "review-decision dispatch is superseded by a newer live dispatch for this card",
+                            "error": "review-decision dispatch not found for this card",
                             "card_id": body.card_id,
                             "dispatch_id": submitted_did,
                         })),
                     ));
                 }
-                ReviewDecisionDispatchLookup::Terminal => {
-                    // Intentional fall-through: the row is terminal, which is
-                    // sub-fix 1's territory (PR #2280 proven-finalized).
-                    // Returning the canonical 409 here keeps the response
-                    // shape compatible with sub-1 and lets that branch
-                    // promote to 200 already_finalized once merged.
-                }
-                ReviewDecisionDispatchLookup::NotFound => {
-                    if !finalized_review_decision_info_pg_first(state, &body.card_id)
-                        .await
-                        .has_originating_dispatch()
-                    {
-                        return Err((
-                            StatusCode::NOT_FOUND,
-                            Json(json!({
-                                "error": "review-decision dispatch not found for this card",
-                                "card_id": body.card_id,
-                                "dispatch_id": submitted_did,
-                            })),
-                        ));
-                    }
-                }
             }
         }
     }
+    Ok(())
+}
 
-    if pending_rd_id.is_none() {
-        // #2341 / #2200 sub-3 idempotent resume: a prior dispute+out_of_scope
-        // call already finalized the originating review-decision dispatch
-        // with `result.outcome = scope_mismatch_closed`. The pending lookup
-        // correctly returns None (the dispatch is no longer pending), but we
-        // must NOT reject the retry — that would mislead the operator into
-        // thinking the close failed. Instead, detect the prior finalize and
-        // return 200 already_finalized.
-        //
-        // Compose with sub-fix 1 (PR #2280): sub-1's `proven_finalized_decision`
-        // path only fires for `accept`/`dispute`/`dismiss` decisions emitted
-        // by `review_decision_api` or `review_auto_accept_policy`. Our
-        // scope_mismatch_closed close path emits the same shape with
-        // `completion_source = review_decision_api` and
-        // `decision = dispute`, but with the additional `outcome` field. To
-        // avoid sub-1 incorrectly classifying this as a normal dispute and
-        // accepting an `accept` retry against it, we detect the outcome
-        // first and short-circuit before sub-1's branch runs.
-        if body.decision == "dispute" && body.out_of_scope == Some(true) {
-            if let Some(prior) =
-                recent_scope_mismatch_finalized_pg_first(state, &body.card_id).await
-            {
-                // dispatch_id must match the finalized dispatch — closes the
-                // probing oracle that would let a caller learn which
-                // dispatch_id terminalized this card.
-                if let Some(submitted) = body.dispatch_id.as_deref() {
-                    if submitted != prior.dispatch_id {
-                        return Err((
-                            StatusCode::CONFLICT,
-                            Json(json!({
-                                "error": format!(
-                                    "out_of_scope retry dispatch_id mismatch: submitted {submitted} but prior finalized scope_mismatch_closed is {}",
-                                    prior.dispatch_id
-                                ),
-                                "card_id": body.card_id,
-                            })),
-                        ));
-                    }
-                } else {
-                    // No dispatch_id supplied — refuse with the generic 409
-                    // rather than disclosing the prior close.
+/// Sub-phase of `decision_route_resolve_pending` (#3038): #2341 / #2200 sub-3
+/// idempotent resume of a prior `scope_mismatch_closed` dispute. Pure
+/// extraction of the original
+/// `if body.decision == "dispute" && body.out_of_scope == Some(true) { if let
+/// Some(prior) = recent_scope_mismatch_finalized_pg_first(...) { ... } }` block.
+/// Every path inside the matched-`prior` arm short-circuited the original with
+/// an early `return Err(..)`/`return Ok(..)`-shaped `DecisionResponse`; those
+/// are reproduced verbatim as `return Err(..)` and propagated via `?`. When the
+/// gate condition is false, or no prior `scope_mismatch_closed` proof exists,
+/// the helper falls through with `Ok(())` — identical to the inline fall-through
+/// into the stale-state branch. The DB read/write ordering (recent-finalized
+/// lookup → card-context/pipeline reads → lifecycle-generation guard →
+/// cancel-stale → transition → dismiss-cleanup → update_card_review_state →
+/// emit_card_updated) is preserved exactly.
+async fn decision_route_resolve_pending_scope_mismatch_resume(
+    state: &AppState,
+    body: &ReviewDecisionBody,
+) -> Result<(), DecisionResponse> {
+    if body.decision == "dispute" && body.out_of_scope == Some(true) {
+        if let Some(prior) = recent_scope_mismatch_finalized_pg_first(state, &body.card_id).await {
+            // dispatch_id must match the finalized dispatch — closes the
+            // probing oracle that would let a caller learn which
+            // dispatch_id terminalized this card.
+            if let Some(submitted) = body.dispatch_id.as_deref() {
+                if submitted != prior.dispatch_id {
                     return Err((
                         StatusCode::CONFLICT,
                         Json(json!({
-                            "error": "no pending review-decision dispatch for this card",
+                            "error": format!(
+                                "out_of_scope retry dispatch_id mismatch: submitted {submitted} but prior finalized scope_mismatch_closed is {}",
+                                prior.dispatch_id
+                            ),
                             "card_id": body.card_id,
                         })),
                     ));
                 }
+            } else {
+                // No dispatch_id supplied — refuse with the generic 409
+                // rather than disclosing the prior close.
+                return Err((
+                    StatusCode::CONFLICT,
+                    Json(json!({
+                        "error": "no pending review-decision dispatch for this card",
+                        "card_id": body.card_id,
+                    })),
+                ));
+            }
 
-                // Determine whether the card already reached terminal in a
-                // prior successful call. Terminal cleanup clears
-                // `kanban_cards.latest_dispatch_id` (Codex round-2 [medium]),
-                // which would otherwise make the stored lifecycle generation
-                // diverge from the current snapshot for a fully successful
-                // close — leading to a spurious 409 on retry. So:
-                //   - If the card IS terminal: the prior close completed;
-                //     skip the strict generation comparison, return
-                //     already_finalized.
-                //   - If the card is NOT terminal: the prior close was
-                //     partial (tx committed but transition / cleanup did
-                //     not run). Strict generation comparison is then the
-                //     correct guard against terminalizing a re-opened card.
-                let card_ctx =
-                    load_review_decision_card_context_pg_first(state, &body.card_id).await;
-                let effective_pipeline = resolve_effective_pipeline_pg_first(
-                    state,
-                    card_ctx.repo_id.as_deref(),
-                    card_ctx.agent_id.as_deref(),
-                )
-                .await;
-                let current_status = card_ctx.status.clone().unwrap_or_default();
-                let terminal_state = effective_pipeline
-                    .states
-                    .iter()
-                    .find(|s| s.terminal)
-                    .map(|s| s.id.clone())
-                    .unwrap_or_else(|| "done".to_string());
-                let card_is_terminal = effective_pipeline.is_terminal(&current_status);
+            // Determine whether the card already reached terminal in a
+            // prior successful call. Terminal cleanup clears
+            // `kanban_cards.latest_dispatch_id` (Codex round-2 [medium]),
+            // which would otherwise make the stored lifecycle generation
+            // diverge from the current snapshot for a fully successful
+            // close — leading to a spurious 409 on retry. So:
+            //   - If the card IS terminal: the prior close completed;
+            //     skip the strict generation comparison, return
+            //     already_finalized.
+            //   - If the card is NOT terminal: the prior close was
+            //     partial (tx committed but transition / cleanup did
+            //     not run). Strict generation comparison is then the
+            //     correct guard against terminalizing a re-opened card.
+            let card_ctx = load_review_decision_card_context_pg_first(state, &body.card_id).await;
+            let effective_pipeline = resolve_effective_pipeline_pg_first(
+                state,
+                card_ctx.repo_id.as_deref(),
+                card_ctx.agent_id.as_deref(),
+            )
+            .await;
+            let current_status = card_ctx.status.clone().unwrap_or_default();
+            let terminal_state = effective_pipeline
+                .states
+                .iter()
+                .find(|s| s.terminal)
+                .map(|s| s.id.clone())
+                .unwrap_or_else(|| "done".to_string());
+            let card_is_terminal = effective_pipeline.is_terminal(&current_status);
 
-                if !card_is_terminal {
-                    // Generation marker: enforce only on the non-terminal
-                    // resume path. Terminalizing a re-opened card from a
-                    // stale closure is the failure mode HIGH 2 warned
-                    // about. The dispatch_id match above already proved
-                    // dispatch-scope authorization; lifecycle proves the
-                    // card is the same generation we closed against.
-                    let Some(expected) = prior.lifecycle_generation.clone() else {
-                        tracing::warn!(
-                            card_id = %body.card_id,
-                            pending_rd_id = %prior.dispatch_id,
-                            "[review-decision] #2341 idempotent resume refused: prior scope_mismatch_closed proof has no lifecycle_generation"
-                        );
-                        return Err((
-                            StatusCode::CONFLICT,
-                            Json(json!({
-                                "error": "prior scope_mismatch_closed proof is missing lifecycle_generation; refusing idempotent close on a non-terminal card",
-                                "card_id": body.card_id,
-                                "pending_dispatch_id": prior.dispatch_id,
-                                "reason": "missing_lifecycle_generation",
-                            })),
-                        ));
-                    };
-                    let actual = card_lifecycle_snapshot_pg_first(state, &body.card_id).await;
-                    if actual != expected {
-                        tracing::warn!(
-                            card_id = %body.card_id,
-                            ?expected,
-                            ?actual,
-                            "[review-decision] #2341 idempotent resume refused: card lifecycle advanced since prior scope_mismatch_closed (non-terminal card)"
-                        );
-                        return Err((
-                            StatusCode::CONFLICT,
-                            Json(json!({
-                                "error": "card lifecycle has advanced since the prior scope_mismatch_closed; refusing idempotent close on a re-opened card",
-                                "card_id": body.card_id,
-                                "pending_dispatch_id": prior.dispatch_id,
-                                "reason": "lifecycle_generation_mismatch",
-                            })),
-                        ));
-                    }
-                }
-
-                let mut resumed_steps: Vec<&'static str> = Vec::new();
-                if !card_is_terminal {
-                    // Resume: cancel stale + transition + cleanup. We
-                    // already verified lifecycle generation above, so the
-                    // card is still the same generation we closed against.
+            if !card_is_terminal {
+                // Generation marker: enforce only on the non-terminal
+                // resume path. Terminalizing a re-opened card from a
+                // stale closure is the failure mode HIGH 2 warned
+                // about. The dispatch_id match above already proved
+                // dispatch-scope authorization; lifecycle proves the
+                // card is the same generation we closed against.
+                let Some(expected) = prior.lifecycle_generation.clone() else {
                     tracing::warn!(
                         card_id = %body.card_id,
                         pending_rd_id = %prior.dispatch_id,
-                        current_status = %current_status,
-                        terminal_state = %terminal_state,
-                        "[review-decision] #2341 resuming partial-close: dispatch was scope_mismatch_closed but card never reached terminal"
+                        "[review-decision] #2341 idempotent resume refused: prior scope_mismatch_closed proof has no lifecycle_generation"
                     );
+                    return Err((
+                        StatusCode::CONFLICT,
+                        Json(json!({
+                            "error": "prior scope_mismatch_closed proof is missing lifecycle_generation; refusing idempotent close on a non-terminal card",
+                            "card_id": body.card_id,
+                            "pending_dispatch_id": prior.dispatch_id,
+                            "reason": "missing_lifecycle_generation",
+                        })),
+                    ));
+                };
+                let actual = card_lifecycle_snapshot_pg_first(state, &body.card_id).await;
+                if actual != expected {
+                    tracing::warn!(
+                        card_id = %body.card_id,
+                        ?expected,
+                        ?actual,
+                        "[review-decision] #2341 idempotent resume refused: card lifecycle advanced since prior scope_mismatch_closed (non-terminal card)"
+                    );
+                    return Err((
+                        StatusCode::CONFLICT,
+                        Json(json!({
+                            "error": "card lifecycle has advanced since the prior scope_mismatch_closed; refusing idempotent close on a re-opened card",
+                            "card_id": body.card_id,
+                            "pending_dispatch_id": prior.dispatch_id,
+                            "reason": "lifecycle_generation_mismatch",
+                        })),
+                    ));
+                }
+            }
 
-                    let expected = prior
-                        .lifecycle_generation
-                        .as_ref()
-                        .expect("non-terminal scope_mismatch resume already required lifecycle");
-                    let cancelled_stale =
-                        match cancel_stale_review_dispatches_for_scope_mismatch_pg_first(
-                            state,
-                            &body.card_id,
-                            "scope_mismatch_closed_resume",
-                            expected,
-                        )
-                        .await
-                        {
-                            Ok(count) => count,
-                            Err(error) => {
-                                return Err((
-                                    StatusCode::INTERNAL_SERVER_ERROR,
-                                    Json(json!({
-                                        "error": error,
-                                        "card_id": body.card_id,
-                                        "pending_dispatch_id": prior.dispatch_id,
-                                        "resumed_steps": resumed_steps,
-                                    })),
-                                ));
-                            }
-                        };
-                    if cancelled_stale > 0 {
-                        resumed_steps.push("cancelled_stale");
-                    }
+            let mut resumed_steps: Vec<&'static str> = Vec::new();
+            if !card_is_terminal {
+                // Resume: cancel stale + transition + cleanup. We
+                // already verified lifecycle generation above, so the
+                // card is still the same generation we closed against.
+                tracing::warn!(
+                    card_id = %body.card_id,
+                    pending_rd_id = %prior.dispatch_id,
+                    current_status = %current_status,
+                    terminal_state = %terminal_state,
+                    "[review-decision] #2341 resuming partial-close: dispatch was scope_mismatch_closed but card never reached terminal"
+                );
 
-                    match transition_status_pg_first(
+                let expected = prior
+                    .lifecycle_generation
+                    .as_ref()
+                    .expect("non-terminal scope_mismatch resume already required lifecycle");
+                let cancelled_stale =
+                    match cancel_stale_review_dispatches_for_scope_mismatch_pg_first(
                         state,
                         &body.card_id,
-                        &terminal_state,
-                        "dispute_scope_mismatch_closed_resume",
-                        crate::engine::transition::ForceIntent::SystemRecovery,
+                        "scope_mismatch_closed_resume",
+                        expected,
                     )
                     .await
                     {
-                        Ok(_) => {
-                            resumed_steps.push("transition_terminal");
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                card_id = %body.card_id,
-                                pending_rd_id = %prior.dispatch_id,
-                                terminal_state = %terminal_state,
-                                error = %e,
-                                "[review-decision] #2341 resume failed to transition card to terminal"
-                            );
+                        Ok(count) => count,
+                        Err(error) => {
                             return Err((
                                 StatusCode::INTERNAL_SERVER_ERROR,
                                 Json(json!({
-                                    "error": format!(
-                                        "scope_mismatch_closed resume: card transition to {terminal_state} failed: {e}"
-                                    ),
+                                    "error": error,
                                     "card_id": body.card_id,
                                     "pending_dispatch_id": prior.dispatch_id,
                                     "resumed_steps": resumed_steps,
                                 })),
                             ));
                         }
-                    }
-
-                    if let Err(error) = dismiss_review_cleanup_pg_first(state, &body.card_id).await
-                    {
-                        return Err((
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(json!({
-                                "error": error,
-                                "card_id": body.card_id,
-                                "pending_dispatch_id": prior.dispatch_id,
-                                "resumed_steps": resumed_steps,
-                            })),
-                        ));
-                    }
-                    resumed_steps.push("dismiss_cleanup");
-
-                    if let Err(error) = update_card_review_state(
-                        review_state_db(state),
-                        state.pg_pool_ref(),
-                        &body.card_id,
-                        "dispute_scope_mismatch_closed",
-                        Some(&prior.dispatch_id),
-                    ) {
-                        return Err((
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(json!({
-                                "error": error,
-                                "card_id": body.card_id,
-                                "pending_dispatch_id": prior.dispatch_id,
-                                "resumed_steps": resumed_steps,
-                            })),
-                        ));
-                    }
-
-                    emit_card_updated(state, &body.card_id).await;
+                    };
+                if cancelled_stale > 0 {
+                    resumed_steps.push("cancelled_stale");
                 }
 
-                tracing::info!(
-                    card_id = %body.card_id,
-                    pending_rd_id = %prior.dispatch_id,
-                    card_was_terminal = card_is_terminal,
-                    resumed_steps = ?resumed_steps,
-                    "[review-decision] #2341 idempotent: returning 200 already_finalized for retried scope_mismatch_closed"
-                );
-                return Err((
-                    StatusCode::OK,
-                    Json(json!({
-                        "ok": true,
-                        "card_id": body.card_id,
-                        "decision": "dispute",
-                        "outcome": "scope_mismatch_closed",
-                        "pending_dispatch_id": prior.dispatch_id,
-                        "review_dispatch_id": prior.review_dispatch_id,
-                        "reviewed_commit": prior.reviewed_commit,
-                        "resumed": !card_is_terminal,
-                        "resumed_steps": resumed_steps,
-                        "message": if card_is_terminal {
-                            "scope_mismatch_closed already finalized; idempotent no-op"
-                        } else {
-                            "scope_mismatch_closed resumed: card transitioned to terminal after prior partial close"
-                        },
-                    })),
-                ));
+                match transition_status_pg_first(
+                    state,
+                    &body.card_id,
+                    &terminal_state,
+                    "dispute_scope_mismatch_closed_resume",
+                    crate::engine::transition::ForceIntent::SystemRecovery,
+                )
+                .await
+                {
+                    Ok(_) => {
+                        resumed_steps.push("transition_terminal");
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            card_id = %body.card_id,
+                            pending_rd_id = %prior.dispatch_id,
+                            terminal_state = %terminal_state,
+                            error = %e,
+                            "[review-decision] #2341 resume failed to transition card to terminal"
+                        );
+                        return Err((
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(json!({
+                                "error": format!(
+                                    "scope_mismatch_closed resume: card transition to {terminal_state} failed: {e}"
+                                ),
+                                "card_id": body.card_id,
+                                "pending_dispatch_id": prior.dispatch_id,
+                                "resumed_steps": resumed_steps,
+                            })),
+                        ));
+                    }
+                }
+
+                if let Err(error) = dismiss_review_cleanup_pg_first(state, &body.card_id).await {
+                    return Err((
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({
+                            "error": error,
+                            "card_id": body.card_id,
+                            "pending_dispatch_id": prior.dispatch_id,
+                            "resumed_steps": resumed_steps,
+                        })),
+                    ));
+                }
+                resumed_steps.push("dismiss_cleanup");
+
+                if let Err(error) = update_card_review_state(
+                    review_state_db(state),
+                    state.pg_pool_ref(),
+                    &body.card_id,
+                    "dispute_scope_mismatch_closed",
+                    Some(&prior.dispatch_id),
+                ) {
+                    return Err((
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({
+                            "error": error,
+                            "card_id": body.card_id,
+                            "pending_dispatch_id": prior.dispatch_id,
+                            "resumed_steps": resumed_steps,
+                        })),
+                    ));
+                }
+
+                emit_card_updated(state, &body.card_id).await;
             }
+
+            tracing::info!(
+                card_id = %body.card_id,
+                pending_rd_id = %prior.dispatch_id,
+                card_was_terminal = card_is_terminal,
+                resumed_steps = ?resumed_steps,
+                "[review-decision] #2341 idempotent: returning 200 already_finalized for retried scope_mismatch_closed"
+            );
+            return Err((
+                StatusCode::OK,
+                Json(json!({
+                    "ok": true,
+                    "card_id": body.card_id,
+                    "decision": "dispute",
+                    "outcome": "scope_mismatch_closed",
+                    "pending_dispatch_id": prior.dispatch_id,
+                    "review_dispatch_id": prior.review_dispatch_id,
+                    "reviewed_commit": prior.reviewed_commit,
+                    "resumed": !card_is_terminal,
+                    "resumed_steps": resumed_steps,
+                    "message": if card_is_terminal {
+                        "scope_mismatch_closed already finalized; idempotent no-op"
+                    } else {
+                        "scope_mismatch_closed resumed: card transitioned to terminal after prior partial close"
+                    },
+                })),
+            ));
         }
+    }
+    Ok(())
+}
+
+/// Sub-phase of `decision_route_resolve_pending` (#3038): #2200 sub-fix 1
+/// (`stale-state`) idempotency branch. Pure extraction of the remainder of the
+/// original `if pending_rd_id.is_none()` block that ran after the
+/// scope_mismatch_closed resume fell through. Every original early
+/// `return Err(..)`/`return Err((StatusCode::OK, ..))` is reproduced verbatim
+/// and propagated via `?`. The two escaping mutations — setting `pending_rd_id`
+/// to the submitted dispatch id and flipping `resume_side_effects_pending` to
+/// `true` on a successful side-effects-resume claim — are threaded through
+/// `&mut` params so the caller observes them exactly as the inline code did.
+/// The DB read/write ordering (finalized-info lookup → latest-id match guard →
+/// pending-side-effects-decision branch with its staleness gate and
+/// claim_..._resume write → else proven-finalized idempotent branch → final
+/// `!resume_side_effects_pending` legacy-409 guard) is preserved exactly.
+async fn decision_route_resolve_pending_stale_state(
+    state: &AppState,
+    body: &ReviewDecisionBody,
+    pending_rd_id: &mut Option<String>,
+    resume_side_effects_pending: &mut bool,
+) -> Result<(), DecisionResponse> {
+    {
         // No pending review-decision dispatch → stale or duplicate call.
         // No dispatch_id to disambiguate either.
         //
@@ -2725,8 +2778,8 @@ async fn decision_route_resolve_pending(
                         ));
                     }
                 }
-                pending_rd_id = Some(submitted_did.to_string());
-                resume_side_effects_pending = true;
+                *pending_rd_id = Some(submitted_did.to_string());
+                *resume_side_effects_pending = true;
             } else {
                 tracing::warn!(
                     card_id = %body.card_id,
@@ -2771,7 +2824,7 @@ async fn decision_route_resolve_pending(
             );
         }
 
-        if !resume_side_effects_pending {
+        if !*resume_side_effects_pending {
             // Originating dispatch matches but proof of finalization is missing
             // (e.g. status=failed, missing completion_source, or recorded decision
             // does not match). Return the legacy 409.
@@ -2785,7 +2838,7 @@ async fn decision_route_resolve_pending(
         }
     }
 
-    Ok((pending_rd_id, resume_side_effects_pending))
+    Ok(())
 }
 
 /// POST /api/reviews/decision


### PR DESCRIPTION
## Summary

Behavior-preserving sub-decomposition of `decision_route_resolve_pending` (~504 lines) in `src/server/routes/review_verdict/decision_route.rs`. This is the **#2200/#2341 idempotent-resume recovery block** — RACE-SENSITIVE idempotency logic. Part of #3038 (decompose god-functions). **No auto-close.**

The function is a short-circuiting helper returning `Result<(Option<String>, bool), DecisionResponse>`. The recovery block is split into three named phase helpers, called in the SAME order they ran inline:

1. **`decision_route_resolve_pending_by_id_recovery`** — #2200 sub-fix 4 by-id recovery. Wraps the `lookup_review_decision_dispatch_by_id` match (`LiveAndCurrent` / `LiveButSuperseded` / `Terminal` / `NotFound`). Only escaping mutation: sets `pending_rd_id` on `LiveAndCurrent` (threaded `&mut`). Other variants return `Err` (propagated via `?`) or fall through `Ok(())`.
2. **`decision_route_resolve_pending_scope_mismatch_resume`** — #2341 / #2200 sub-3 `scope_mismatch_closed` idempotent resume. Pure early-return logic; falls through `Ok(())` when the `dispute && out_of_scope` gate is false or no prior `scope_mismatch_closed` proof exists. Captures no escaping mutation (`resumed_steps` stays local).
3. **`decision_route_resolve_pending_stale_state`** — #2200 sub-fix 1 stale-state idempotency. Threads `pending_rd_id` and `resume_side_effects_pending` via `&mut`.

## Behavior-preservation argument

- **Order:** Orchestrator runs phase 1 inside `if pending_rd_id.is_none()`, then phases 2 then 3 inside a second `if pending_rd_id.is_none()` — identical to the original two `is_none()` blocks (phases 2 & 3 shared one block inline). Phase 2 cannot mutate `pending_rd_id`, so phase 3 always sees the same value it did inline.
- **Early returns / short-circuits:** Every original `return Err(..)` / `return Err((StatusCode::OK, ..))` is reproduced verbatim and propagated via `?` at the identical point. No short-circuit added or removed.
- **Idempotent-resume gating:** Every guard is preserved exactly — `dispatch_id` match-vs-prior, no-dispatch_id generic 409, `card_is_terminal` branch, the non-terminal `lifecycle_generation` presence + snapshot-equality guards, `pending_side_effects_decision` staleness gate, `proven_finalized_decision` decision-match, and the final `!resume_side_effects_pending` legacy-409 guard.
- **DB read/write ordering:** Phase 2's sequence (recent-finalized lookup → card-context/pipeline reads → lifecycle-generation guard → `cancel_stale` → `transition` → `dismiss_cleanup` → `update_card_review_state` → `emit_card_updated`) and phase 3's sequence (finalized-info lookup → latest-id match → pending-side-effects branch with its `claim_..._resume` write → proven-finalized branch → final guard) are unchanged. No idempotency check moved relative to any write.
- **Statement-level equivalence:** every removed line reappears in a helper; added lines are only scaffolding (signatures, three helper calls, `&mut` threading, deref of the two escaping mutations).

## LoC

`decision_route.rs`: 4438 → 4491 production lines (+53, scaffolding/doc-comments). `change-surfaces.md` synced via `generate_inventory_docs.py` per the #3036 giant-file gate.

## Verification

- `cargo fmt --all --check` clean
- `cargo check --workspace --all-features --all-targets` clean
- `cargo test --lib review_verdict` green (no Rust tests exercise this function — it is PG-side-effect driven; relying on statement-level equivalence)
- `./scripts/ci-script-checks.sh` exit 0

## Note for codex review

This is a behavior-preserving refactor of **RACE-SENSITIVE idempotent-resume logic**. Review should focus on whether ANY guard condition, side-effect ordering, early-return point, or idempotency-check-vs-write position changed. An idempotency check that moved relative to a DB write would be a real race bug.

**Do NOT merge** — codex review follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)