### PR TITLE
ci(macos): support repo-level self-hosted runner (label-based, no group)

### DIFF
--- a/.github/workflows/ci-macos-trusted.yml
+++ b/.github/workflows/ci-macos-trusted.yml
@@ -48,8 +48,7 @@ jobs:
           fi
 
           if [ -z "${MACOS_RUNNER_GROUP:-}" ]; then
-            echo "::error::MACOS_RUNNER is set, but MACOS_RUNNER_GROUP is empty. Configure the org runner group first, restrict it to this repo, then set MACOS_RUNNER_GROUP to the exact group name."
-            exit 1
+            echo "MACOS_RUNNER_GROUP is empty; using repo-level self-hosted runner (label-based routing, no runner group). Runner groups require an organization; personal-account repos register repo-level runners and select them purely by label."
           fi
 
           labels="$(
@@ -148,9 +147,11 @@ jobs:
     name: Trusted macOS check (self-hosted)
     needs: resolve_macos_runner
     if: needs.resolve_macos_runner.outputs.mode == 'self-hosted'
-    runs-on:
-      group: ${{ needs.resolve_macos_runner.outputs.group }}
-      labels: ${{ fromJSON(needs.resolve_macos_runner.outputs.labels) }}
+    # Repo-level self-hosted runners (personal-account repos) select purely by
+    # label — runner groups are an organization-only feature. If this repo is
+    # ever moved under an org, switch back to the `group:`+`labels:` form and
+    # set MACOS_RUNNER_GROUP.
+    runs-on: ${{ fromJSON(needs.resolve_macos_runner.outputs.labels) }}
     steps:
       - name: Trusted event / runner sanity check
         shell: bash


### PR DESCRIPTION
## 배경
`itismyfield/AgentDesk`는 개인(User) 계정 + public 저장소다. GitHub Actions **runner group은 조직 전용**이라, 기존 `ci-macos-trusted.yml`의 self-hosted 경로(`MACOS_RUNNER_GROUP` 강제 + `runs-on: { group: }`)는 개인 저장소에서 동작 불가다.

## 변경
- `resolve_macos_runner`: `MACOS_RUNNER_GROUP`가 비어 있어도 에러로 중단하지 않고, 라벨 기반 repo-level 라우팅으로 진행(로그만 남김).
- `macos_self_hosted`: `runs-on`을 labels-only(`fromJSON(...labels)`) 형태로 전환. 조직 이전 시 `group:`+`labels:` 복원하도록 주석 명시.

## 안전성
- `MACOS_RUNNER` 변수가 unset인 동안 `mode=hosted`로 기존과 100% 동일(dormant). 이 PR만으로는 동작 변화 없음.
- 트리거는 `push`(main 제외)/`workflow_dispatch`/`merge_group`뿐 — `pull_request`/`pull_request_target` 없음 → fork PR이 self-hosted runner를 트리거할 수 없음(public repo 보안 게이팅 유지).

YAML 문법 검증 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)