### PR TITLE
refactor: extract VoiceIdSequences sub-struct from VoiceBargeInRuntime (Part of #3038)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -252,7 +252,7 @@
     inline — its move-captured locals make a clean extraction risky and is
     deferred).
   - `src/services/discord/session_runtime.rs` (1396 lines).
-  - `src/services/discord/voice_barge_in.rs` (4699 lines; voice STT/TTS,
+  - `src/services/discord/voice_barge_in.rs` (4737 lines; voice STT/TTS,
     lobby routing, progress mirroring, and barge-in orchestration surface;
     tracked decompose target — see `giant-file-registry.md` (owner
     `voice-runtime`, deadline 2026-08-31, #3036)).

--- a/src/services/discord/voice_barge_in.rs
+++ b/src/services/discord/voice_barge_in.rs
@@ -1174,6 +1174,56 @@ impl SensitivityState {
     }
 }
 
+/// Cohesive sub-concern of [`VoiceBargeInRuntime`]: monotonic ID allocators
+/// (#3038 god-object split, id-sequence slice).
+///
+/// Bundles the three independent `AtomicU64` counters that previously lived
+/// directly on `VoiceBargeInRuntime`. Each `next_*` accessor preserves the
+/// original `fetch_add` semantics — including the exact memory `Ordering` and
+/// the per-counter seed value — so issued IDs are byte-for-byte identical to
+/// the pre-extraction layout:
+/// - spoken-result playbacks seed at `1` (`SeqCst`),
+/// - progress playbacks seed at `PROGRESS_PLAYBACK_OWNER_START` (`SeqCst`),
+/// - internal voice messages seed at `INTERNAL_VOICE_MESSAGE_ID_START`
+///   (`Relaxed`).
+struct VoiceIdSequences {
+    next_spoken_result_playback_id: AtomicU64,
+    // F4 (#2046): progress/ack 재생 owner id 발급용. 30s 만료 타이머가 owner 일치
+    // 시에만 playback entry 를 정리하도록 한다.
+    next_progress_playback_id: AtomicU64,
+    next_internal_message_id: AtomicU64,
+}
+
+impl VoiceIdSequences {
+    fn new() -> Self {
+        Self {
+            next_spoken_result_playback_id: AtomicU64::new(1),
+            next_progress_playback_id: AtomicU64::new(PROGRESS_PLAYBACK_OWNER_START),
+            next_internal_message_id: AtomicU64::new(INTERNAL_VOICE_MESSAGE_ID_START),
+        }
+    }
+
+    /// Allocate the next spoken-result playback id (`SeqCst`, seeded at `1`).
+    fn next_spoken_result_playback_id(&self) -> u64 {
+        self.next_spoken_result_playback_id
+            .fetch_add(1, Ordering::SeqCst)
+    }
+
+    /// Allocate the next progress/ack playback owner id (`SeqCst`, seeded at
+    /// `PROGRESS_PLAYBACK_OWNER_START`).
+    fn next_progress_playback_id(&self) -> u64 {
+        self.next_progress_playback_id
+            .fetch_add(1, Ordering::SeqCst)
+    }
+
+    /// Allocate the next internal voice message id (`Relaxed`, seeded at
+    /// `INTERNAL_VOICE_MESSAGE_ID_START`).
+    fn next_internal_message_id(&self) -> u64 {
+        self.next_internal_message_id
+            .fetch_add(1, Ordering::Relaxed)
+    }
+}
+
 pub(in crate::services::discord) struct VoiceBargeInRuntime {
     enabled: bool,
     barge_in_enabled: bool,
@@ -1198,11 +1248,10 @@ pub(in crate::services::discord) struct VoiceBargeInRuntime {
     voice_guilds: dashmap::DashMap<u64, GuildId>,
     active_voice_routes: dashmap::DashMap<u64, ActiveVoiceRoute>,
     deferred_buffers: dashmap::DashMap<u64, Arc<Mutex<DeferredBargeInBuffer>>>,
-    next_spoken_result_playback_id: AtomicU64,
-    // F4 (#2046): progress/ack 재생 owner id 발급용. 30s 만료 타이머가 owner 일치
-    // 시에만 playback entry 를 정리하도록 한다.
-    next_progress_playback_id: AtomicU64,
-    next_internal_message_id: AtomicU64,
+    // #3038: monotonic ID 발급 관심사를 sub-struct 로 격리. 세 카운터(spoken
+    // result / progress playback / internal message)의 seed 값과 memory
+    // Ordering 을 그대로 보존한다.
+    id_sequences: VoiceIdSequences,
     // F6 (#2046): `resolve_voice_turn_target` 가 매 utterance 마다 YAML 을
     // 재파싱하지 않도록 한 `Config` snapshot 핫캐시.
     config_cache: std::sync::Mutex<Option<(Instant, Arc<crate::config::Config>)>>,
@@ -1258,9 +1307,7 @@ impl VoiceBargeInRuntime {
             voice_guilds: dashmap::DashMap::new(),
             active_voice_routes: dashmap::DashMap::new(),
             deferred_buffers: dashmap::DashMap::new(),
-            next_spoken_result_playback_id: AtomicU64::new(1),
-            next_progress_playback_id: AtomicU64::new(PROGRESS_PLAYBACK_OWNER_START),
-            next_internal_message_id: AtomicU64::new(INTERNAL_VOICE_MESSAGE_ID_START),
+            id_sequences: VoiceIdSequences::new(),
             config_cache: std::sync::Mutex::new(None),
             alias_collision_signature: std::sync::Mutex::new(None),
             inflight_foreground_cancels: dashmap::DashMap::new(),
@@ -1292,9 +1339,7 @@ impl VoiceBargeInRuntime {
             voice_guilds: dashmap::DashMap::new(),
             active_voice_routes: dashmap::DashMap::new(),
             deferred_buffers: dashmap::DashMap::new(),
-            next_spoken_result_playback_id: AtomicU64::new(1),
-            next_progress_playback_id: AtomicU64::new(PROGRESS_PLAYBACK_OWNER_START),
-            next_internal_message_id: AtomicU64::new(INTERNAL_VOICE_MESSAGE_ID_START),
+            id_sequences: VoiceIdSequences::new(),
             config_cache: std::sync::Mutex::new(None),
             alias_collision_signature: std::sync::Mutex::new(None),
             inflight_foreground_cancels: dashmap::DashMap::new(),
@@ -2233,9 +2278,7 @@ impl VoiceBargeInRuntime {
     }
 
     fn start_spoken_result_playback(&self, channel_id: ChannelId) -> (u64, CancellationToken) {
-        let id = self
-            .next_spoken_result_playback_id
-            .fetch_add(1, Ordering::SeqCst);
+        let id = self.id_sequences.next_spoken_result_playback_id();
         let cancellation = CancellationToken::new();
         if let Some(previous) = self.spoken_result_playbacks.insert(
             channel_id.get(),
@@ -3984,10 +4027,7 @@ impl VoiceBargeInRuntime {
             }
         }
 
-        let message_id = MessageId::new(
-            self.next_internal_message_id
-                .fetch_add(1, Ordering::Relaxed),
-        );
+        let message_id = MessageId::new(self.id_sequences.next_internal_message_id());
         super::enqueue_internal_followup(
             shared,
             provider,
@@ -4150,9 +4190,7 @@ impl VoiceBargeInRuntime {
         // 30s 만료 타이머는 `clear_playback_if_owner` 로 동일 owner 일 때만 정리.
         // 후속 progress/spoken_result playback 이 entry 를 덮어쓰면 mismatch 로
         // no-op → 후속 playback 의 barge-in 이 깨지지 않는다.
-        let playback_id = self
-            .next_progress_playback_id
-            .fetch_add(1, Ordering::SeqCst);
+        let playback_id = self.id_sequences.next_progress_playback_id();
         self.reset_after_playback_start_with_owner(
             channel_id,
             Arc::new(track),


### PR DESCRIPTION
## What

Extracts a cohesive **monotonic ID-allocator** concern out of the `VoiceBargeInRuntime` god-object into a same-file `VoiceIdSequences` sub-struct. This is the second conservative #3038 slice, following the `SensitivityState` extraction in PR #3131 (left untouched here).

The three `AtomicU64` counters form the lowest-coupling, most self-contained cluster in the runtime: they are pure ID generators with **zero external call-sites** and no relay/turn coupling.

## Moved fields

Relocated from `VoiceBargeInRuntime` into `VoiceIdSequences`:
- `next_spoken_result_playback_id` (`SeqCst`, seed `1`)
- `next_progress_playback_id` (`SeqCst`, seed `PROGRESS_PLAYBACK_OWNER_START`)
- `next_internal_message_id` (`Relaxed`, seed `INTERNAL_VOICE_MESSAGE_ID_START`)

Each is wrapped behind a `next_*()` accessor that preserves the **exact** `fetch_add` memory `Ordering` and seed value, so issued IDs are byte-for-byte identical to the pre-extraction layout. Both constructors (`from_voice_config`, `disabled`) now delegate seeding to `VoiceIdSequences::new()`.

## Behavior preservation

- Signatures / public API / control flow / error handling / lock ordering: unchanged.
- Field access order and side-effect order at all three call sites: unchanged.
- No relay/turn paths touched (no turn_bridge / tmux_watcher / TurnFinalizer / stall-watchdog).

## Call-site footprint

- External call-sites changed (runtime_bootstrap.rs / discord/mod.rs / commands/voice.rs / voice/cancel_tombstone.rs): **0**
- Internal call sites updated within voice_barge_in.rs: 3 (plus 2 constructors)

## Verification (all local CI gates green)

- `cargo fmt --check` exit 0
- `cargo build -p agentdesk` 0 errors
- `cargo clippy --workspace --all-targets --all-features` 0 errors
- `cargo test -p agentdesk voice` (skipping pg/postgres): 248 passed
- `cargo check --all-targets` exit 0
- `cargo test --all-targets transition` + `auto_queue` / `cancel` / `review_decision` / `invariant` (`--test-threads=1`, skip pg): all green
- `bash scripts/ci-macos-fresh-user-smoke.sh` exit 0
- `./scripts/ci-script-checks.sh` exit 0
- inventory freeze line in `change-surfaces.md` synced to module-inventory (4699 → 4737 code lines)

Part of #3038

🤖 Generated with [Claude Code](https://claude.com/claude-code)