### PR TITLE
ci(windows): gate unix-only tmux refs behind #[cfg(unix)] (fix main windows break)

### DIFF
--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -1058,6 +1058,9 @@ fn status_panel_resets_on_two_distinct_nonces_without_provider_id() {
 /// its instance key from `session_panel_instance_key` (which reads that nonce),
 /// and a second TUI-direct spawn mints a DISTINCT nonce → distinct instance key
 /// → reset — even with no provider-session signal at all.
+// Exercises `write_spawn_nonce` / `session_panel_instance_key`, which live in
+// the unix-only `tmux` module (tmux/TUI-direct paths are unix-only).
+#[cfg(unix)]
 #[test]
 fn status_panel_resets_across_two_tui_direct_spawns_via_stamped_nonce() {
     let _lock = match crate::config::shared_test_env_lock().lock() {

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -1634,10 +1634,18 @@ async fn refresh_session_panel_line_from_lifecycle(
     let Some(pg_pool) = shared.pg_pool.as_ref() else {
         return false;
     };
+    // `session_panel_instance_key` lives in the unix-only `tmux` module; on
+    // non-unix targets there is no tmux session, so the instance key is None.
+    #[cfg(unix)]
     let session_instance_key = tmux_session_name
         .map(str::trim)
         .filter(|name| !name.is_empty())
         .and_then(super::tmux::session_panel_instance_key);
+    #[cfg(not(unix))]
+    let session_instance_key = {
+        let _ = tmux_session_name;
+        Option::<String>::None
+    };
     let channel_id_text = channel_id.get().to_string();
     match crate::services::observability::turn_lifecycle::load_latest_session_lifecycle_event(
         pg_pool,


### PR DESCRIPTION
## 문제
main windows 빌드가 깨져 있어 모든 PR의 `Fast check + non-PG tests (windows-latest)` + `Fast check cross OS required context`가 red였다(Nightly d5443b60 동일). 원인: `#[cfg(unix)]` `tmux` 모듈의 `session_panel_instance_key`/`write_spawn_nonce`를 비-unix에서 게이트 없이 참조.

## 수정
- `turn_bridge/mod.rs` `refresh_session_panel_line_from_lifecycle`: instance-key 계산을 `cfg(unix)`/`cfg(not(unix))`로 분기(비-unix은 `None`).
- `placeholder_live_events/tests.rs`: tmux/nonce를 쓰는 테스트 `status_panel_resets_across_two_tui_direct_spawns_via_stamped_nonce`를 `#[cfg(unix)]`로 게이트.

## 검증
- unix `cargo check --all-targets`: green (회귀 없음)
- `cargo check --target x86_64-pc-windows-msvc`: 기존 위반(tmux/write_spawn_nonce/session_panel_instance_key) 전부 해소 확인. 잔여 실패는 `ring` 크레이트 C 빌드스크립트 크로스컴파일 환경 한계(코드 무관, 실제 windows CI에선 정상).
- fmt/clippy/ci-script-checks 모두 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)