### PR TITLE
feat(claude-tui): nudge tells model how to load deferred tool_feedback

### DIFF
--- a/src/services/claude_tui/hook_relay.rs
+++ b/src/services/claude_tui/hook_relay.rs
@@ -225,7 +225,10 @@ fn memento_feedback_instruction(search_event_id: Option<String>) -> String {
         "Action required: you just received a memento search result. Before your next memento \
 recall/context/search call, submit one `mcp__memento__tool_feedback` call for THIS result with \
 {target}, `relevant` = whether any returned fragment was on-topic, and `sufficient` = whether the \
-results were enough to proceed. This is a single quick call — do it now, then continue."
+results were enough to proceed. If `mcp__memento__tool_feedback` is not in your active tools \
+(memento tools are deferred), first load it with ToolSearch query \
+`select:mcp__memento__tool_feedback`, then make the call. This is a single quick step — do it now, \
+then continue."
     )
 }
 
@@ -501,6 +504,8 @@ mod tests {
         assert_eq!(value["hookSpecificOutput"]["hookEventName"], "PostToolUse");
         assert!(ctx.contains("search_event_id=22752"));
         assert!(ctx.contains("mcp__memento__tool_feedback"));
+        // Deferred-tool friction hint: tell the model how to load the tool.
+        assert!(ctx.contains("select:mcp__memento__tool_feedback"));
         assert_eq!(value["suppressOutput"], true);
     }
 


### PR DESCRIPTION
## 배경
PR #3047 의 memento `tool_feedback` nudge 는 정상 동작한다 — PostToolUse 훅이 발화하고, 올바른 `search_event_id` 와 함께 `additionalContext` 가 모델 컨텍스트에 주입되는 것을 라이브로 확인했다 (recall → nudge 수신 → tool_feedback 제출 id 285 까지 end-to-end 검증).

그럼에도 feedback 제출이 늘지 않는 이유 중 코드로 줄일 수 있는 마찰: **memento MCP 도구가 deferred tool** 이라, nudge 를 받아도 모델이 `mcp__memento__tool_feedback` 을 부르려면 먼저 `ToolSearch` 로 로드해야 한다. 작업 중인 에이전트는 이 한 단계에서 이탈한다.

## 변경
`memento_feedback_instruction` 의 nudge 문구에 한 줄 추가: 도구가 활성 toolset 에 없으면 `ToolSearch select:mcp__memento__tool_feedback` 로 먼저 로드한 뒤 호출하라고 명시. nudge 와 제출 사이의 주 마찰 제거.

## 검증
- `cargo test --lib hook_relay` → 15/15 통과
- 신규 hint 문구를 테스트에 assertion 으로 고정 (`select:mcp__memento__tool_feedback`)
- `cargo fmt` 적용, diff 는 hook_relay.rs 한 파일

🤖 Generated with [Claude Code](https://claude.com/claude-code)