### PR TITLE
ci(macos): SCCACHE_GHA_ENABLED=false on self-hosted runner (was empty → sccache abort)

### DIFF
--- a/.github/workflows/ci-macos-trusted.yml
+++ b/.github/workflows/ci-macos-trusted.yml
@@ -191,7 +191,11 @@ jobs:
           if command -v sccache >/dev/null 2>&1; then
             sccache_dir="${SCCACHE_DIR:-$HOME/.cache/sccache}"
             {
-              echo "SCCACHE_GHA_ENABLED="
+              # Disable the GHA-backed cache and use the local SCCACHE_DIR.
+              # sccache rejects an empty value, so this must be an explicit
+              # `false` (not ``) — otherwise rustc-as-wrapper aborts with
+              # "SCCACHE_GHA_ENABLED must be 'true'/'false'/...".
+              echo "SCCACHE_GHA_ENABLED=false"
               echo "RUSTC_WRAPPER=$(command -v sccache)"
               echo "SCCACHE_DIR=${sccache_dir}"
               echo "SCCACHE_CACHE_SIZE=${SCCACHE_CACHE_SIZE:-20G}"
@@ -200,7 +204,7 @@ jobs:
           else
             echo "::warning::sccache not found on self-hosted macOS runner; continuing without rustc wrapper."
             {
-              echo "SCCACHE_GHA_ENABLED="
+              echo "SCCACHE_GHA_ENABLED=false"
               echo "RUSTC_WRAPPER="
             } >> "$GITHUB_ENV"
           fi


### PR DESCRIPTION
## 문제
self-hosted macOS 활성화 후 첫 run에서 `cargo check` 실패: `sccache: error: SCCACHE_GHA_ENABLED must be 'true','on','1','false','off' or '0'.` self-hosted는 RUSTC_WRAPPER=sccache라 빈 `SCCACHE_GHA_ENABLED=`가 거부됨(hosted는 RUSTC_WRAPPER도 비워 미호출이라 잠복).

## 수정
'Configure local sccache' 두 분기의 `SCCACHE_GHA_ENABLED=` → `=false`. 로컬 SCCACHE_DIR 캐시는 그대로 사용.

## 머지 방식
이 PR의 self-hosted macOS 체크는 **바로 이 버그 때문에** 머지 전까지 fail함(bootstrap). YAML 검증 통과 + 1줄 값 수정이라 --admin 머지 후 후속 PR에서 self-hosted green 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)