### PR TITLE
ci(macos): use system TMPDIR for fresh-user smoke sandbox (self-hosted home false-trip)

### DIFF
--- a/scripts/ci-macos-fresh-user-smoke.sh
+++ b/scripts/ci-macos-fresh-user-smoke.sh
@@ -11,7 +11,14 @@ cd "$repo_root"
 
 python3 -m unittest tests.test_install_bootstrap_portable
 
-runner_temp="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+# The sandbox root is written into a generated config that is then checked for
+# private-home markers (e.g. /Users/<operator>). A self-hosted runner's
+# RUNNER_TEMP lives under the operator's home
+# (e.g. /Users/itismyfield/actions-runner/_work/_temp), so deriving the sandbox
+# from it would false-trip that portability check. Prefer the macOS system temp
+# ($TMPDIR → /var/folders/...), which is outside any user home, and only fall
+# back to RUNNER_TEMP/tmp.
+runner_temp="${TMPDIR:-${RUNNER_TEMP:-/tmp}}"
 smoke_base="$(mktemp -d "$runner_temp/agentdesk-fresh-user.XXXXXX")"
 smoke_base="$(cd "$smoke_base" && pwd -P)"
 trap 'rm -rf "$smoke_base"' EXIT


### PR DESCRIPTION
## 문제
self-hosted macOS 활성화 후 `Fresh user portable smoke`가 `refusing to write private starter marker: /Users/itismyfield`로 실패. 원인: self-hosted runner의 `RUNNER_TEMP`가 operator home 아래(`/Users/itismyfield/actions-runner/_work/_temp`)라, fresh-user sandbox root 경로가 generated config에 들어가 `operator-init-portable.py`의 private-marker 가드를 false-trip. (hosted=`/Users/runner`, 로컬=`/var/folders`라 미발생.) 실제 portability 회귀 아님.

## 수정
smoke sandbox temp base를 macOS 시스템 temp(`$TMPDIR`→/var/folders, user-home 밖) 우선으로. `runner_temp="${TMPDIR:-${RUNNER_TEMP:-/tmp}}"`.

## 검증
`RUNNER_TEMP=$HOME/sim-runner/_work/_temp bash scripts/ci-macos-fresh-user-smoke.sh` → SMOKE_EXIT=0 (이전엔 실패). 실제 base가 /var/folders로 잡힘.

🤖 Generated with [Claude Code](https://claude.com/claude-code)