### PR TITLE
fix: guard stall-watchdog against killing completed-then-idle sessions (Part of #3126)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -206,10 +206,9 @@
   - `src/services/discord/health.rs` (2354 lines after #1879 snapshot/mailbox
     extraction; +3 from #3082 answer-flush-barrier field in the test SharedData
     constructor).
-  - `src/services/discord/health/recovery.rs` (2488 lines; health recovery
-    extraction surface, split further before adding non-bugfix behavior; +71
-    from #3126 stall-watchdog completed-idle false-positive guard + 1446
-    resume-selector preservation helpers/tests).
+  - `src/services/discord/health/recovery.rs` (2438 lines; health recovery
+    extraction surface, split further before adding non-bugfix behavior; +70
+    from #3126 stall-watchdog completed-idle false-positive guard tests).
   - `src/services/discord/router/message_handler/intake_turn.rs` (3620 lines;
     Discord message intake turn orchestration split from the router message
     handler; bugfix only outside a further extraction plan; +9 from #3082

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -206,8 +206,10 @@
   - `src/services/discord/health.rs` (2354 lines after #1879 snapshot/mailbox
     extraction; +3 from #3082 answer-flush-barrier field in the test SharedData
     constructor).
-  - `src/services/discord/health/recovery.rs` (2417 lines; health recovery
-    extraction surface, split further before adding non-bugfix behavior).
+  - `src/services/discord/health/recovery.rs` (2488 lines; health recovery
+    extraction surface, split further before adding non-bugfix behavior; +71
+    from #3126 stall-watchdog completed-idle false-positive guard + 1446
+    resume-selector preservation helpers/tests).
   - `src/services/discord/router/message_handler/intake_turn.rs` (3620 lines;
     Discord message intake turn orchestration split from the router message
     handler; bugfix only outside a further extraction plan; +9 from #3082

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -1395,43 +1395,6 @@ pub(crate) const STALL_WATCHDOG_INITIAL_DELAY_SECS: u64 = 90;
 pub(crate) const STALL_WATCHDOG_THRESHOLD_SECS: u64 =
     2 * discord::inflight::INFLIGHT_STALENESS_THRESHOLD_SECS;
 
-/// #3126: snapshot the in-memory provider session selector (`session_id`) for
-/// `channel_id` before the 1446 force-clean tears the channel down. Returns
-/// `None` when there is no session row or no selector to preserve, in which
-/// case the matching `restore_resume_selector_snapshot` is a no-op.
-async fn preserve_resume_selector_snapshot(
-    shared: &Arc<SharedData>,
-    channel_id: ChannelId,
-) -> Option<String> {
-    let data = shared.core.lock().await;
-    data.sessions
-        .get(&channel_id)
-        .and_then(|session| session.session_id.clone())
-}
-
-/// #3126: re-assert a selector captured by `preserve_resume_selector_snapshot`
-/// after the 1446 force-clean. The force-clean tears down the tmux pane but
-/// must not invalidate the provider conversation selector; restoring it here
-/// keeps `claude --resume` viable for the user's next message. Only writes when
-/// a selector was captured AND the current row lacks one (so a legitimate
-/// concurrent clear/intake that already established a *different* session is
-/// never clobbered).
-async fn restore_resume_selector_snapshot(
-    shared: &Arc<SharedData>,
-    channel_id: ChannelId,
-    preserved: Option<String>,
-) {
-    let Some(selector) = preserved else {
-        return;
-    };
-    let mut data = shared.core.lock().await;
-    if let Some(session) = data.sessions.get_mut(&channel_id)
-        && session.session_id.is_none()
-    {
-        session.restore_provider_session(Some(selector));
-    }
-}
-
 /// Run a single stall-watchdog pass against one provider+SharedData.
 ///
 /// Iterates every attached watcher (via `tmux_watchers.iter()`), pulls the
@@ -1707,18 +1670,6 @@ pub(crate) async fn run_stall_watchdog_pass(
             discord::inflight::load_inflight_state(provider, channel_id.get())
                 .filter(|state| state.user_msg_id != 0)
                 .map(|state| state.user_msg_id);
-        // #3126 resume-selector preservation (1446 path ONLY): the force-clean
-        // below tears down the tmux session (`CleanupSession`) so any genuinely
-        // hung provider process is killed. But the *provider session selector*
-        // (the durable `claude_session_id` / in-memory `session_id` used by
-        // `claude --resume`) identifies the conversation, not the dead pane —
-        // it must survive so the user's next message resumes the same session
-        // instead of starting fresh. Snapshot it here and re-assert it after
-        // the mailbox/orphan finalize so this watchdog never invalidates a
-        // resumable selector. This is scoped to `1446_stall_watchdog`; /clear
-        // and genuine stale-resume invalidation paths are unaffected.
-        let preserved_resume_selector =
-            preserve_resume_selector_snapshot(&shared, channel_id).await;
         discord::inflight::delete_inflight_state_file(provider, channel_id.get());
         let cleared = discord::mailbox_clear_channel(&shared, provider, channel_id).await;
         discord::stall_recovery::finalize_orphaned_clear(
@@ -1727,7 +1678,6 @@ pub(crate) async fn run_stall_watchdog_pass(
             cleared.removed_token,
             "1446_stall_watchdog",
         );
-        restore_resume_selector_snapshot(&shared, channel_id, preserved_resume_selector).await;
         shared
             .dispatch_thread_parents
             .retain(|_, thread_id| *thread_id != channel_id);

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -1198,25 +1198,45 @@ pub fn spawn_watchdog(port: u16) {
 /// invoking the cleanup (so the helper can be exercised by unit tests
 /// without a live `SharedData`).
 ///
-/// Both gates must hold:
+/// All gates must hold:
 /// - `attached == true` and `desynced == true` (snapshot already classified
 ///   the watcher as detached/diverged), AND
 /// - `inflight_updated_at` is older than `threshold_secs` seconds
-///   (defaults to `2 * INFLIGHT_STALENESS_THRESHOLD_SECS`).
+///   (defaults to `2 * INFLIGHT_STALENESS_THRESHOLD_SECS`), AND
+/// - `terminal_delivery_committed == false` (the in-flight row is NOT a
+///   normally-completed turn that is merely sleeping; see below).
 ///
-/// Either signal alone is insufficient — a fresh desynced watcher might
-/// just be mid-stream and a stale-but-synced one might be waiting on an
+/// Either staleness signal alone is insufficient — a fresh desynced watcher
+/// might just be mid-stream and a stale-but-synced one might be waiting on an
 /// idle agent. The conjunction is the actual stall pattern from issue
 /// #1446 (parent channel queues forever because thread inflight stayed
 /// behind after the dispatch terminated).
+///
+/// #3126 false-positive guard: a turn that finished normally commits its
+/// terminal response to the outbound delivery path
+/// (`InflightTurnState::terminal_delivery_committed`) and then leaves the
+/// session idle — e.g. the agent scheduled a `ScheduleWakeup` or the loop
+/// wound down with a `stop_hook_summary`/`turn_duration` transcript record and
+/// no further events. That idle row goes stale (no relay writes) and can read
+/// as `desynced` (#2965: a ready-for-input TUI has capture bytes past the
+/// relay offsets), which previously tripped the desynced force-clean and
+/// killed a perfectly healthy wakeup-waiting session. Excluding committed
+/// turns keeps the watchdog targeting only genuinely hung (never-completed)
+/// turns.
 pub(crate) fn stall_watchdog_should_force_clean(
     attached: bool,
     desynced: bool,
+    inflight_terminal_delivery_committed: bool,
     inflight_updated_at: Option<&str>,
     now_unix_secs: i64,
     threshold_secs: u64,
 ) -> bool {
     if !attached || !desynced {
+        return false;
+    }
+    // #3126: a normally-completed turn that is now idle (wakeup/loop
+    // wind-down) is not a hang — never force-clean it.
+    if inflight_terminal_delivery_committed {
         return false;
     }
     let Some(updated_at) = inflight_updated_at else {
@@ -1374,6 +1394,43 @@ pub(crate) const STALL_WATCHDOG_INITIAL_DELAY_SECS: u64 = 90;
 /// trigger) so the watchdog never races ahead of an in-flight intake call.
 pub(crate) const STALL_WATCHDOG_THRESHOLD_SECS: u64 =
     2 * discord::inflight::INFLIGHT_STALENESS_THRESHOLD_SECS;
+
+/// #3126: snapshot the in-memory provider session selector (`session_id`) for
+/// `channel_id` before the 1446 force-clean tears the channel down. Returns
+/// `None` when there is no session row or no selector to preserve, in which
+/// case the matching `restore_resume_selector_snapshot` is a no-op.
+async fn preserve_resume_selector_snapshot(
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+) -> Option<String> {
+    let data = shared.core.lock().await;
+    data.sessions
+        .get(&channel_id)
+        .and_then(|session| session.session_id.clone())
+}
+
+/// #3126: re-assert a selector captured by `preserve_resume_selector_snapshot`
+/// after the 1446 force-clean. The force-clean tears down the tmux pane but
+/// must not invalidate the provider conversation selector; restoring it here
+/// keeps `claude --resume` viable for the user's next message. Only writes when
+/// a selector was captured AND the current row lacks one (so a legitimate
+/// concurrent clear/intake that already established a *different* session is
+/// never clobbered).
+async fn restore_resume_selector_snapshot(
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+    preserved: Option<String>,
+) {
+    let Some(selector) = preserved else {
+        return;
+    };
+    let mut data = shared.core.lock().await;
+    if let Some(session) = data.sessions.get_mut(&channel_id)
+        && session.session_id.is_none()
+    {
+        session.restore_provider_session(Some(selector));
+    }
+}
 
 /// Run a single stall-watchdog pass against one provider+SharedData.
 ///
@@ -1534,6 +1591,7 @@ pub(crate) async fn run_stall_watchdog_pass(
         let should_clean = stall_watchdog_should_force_clean(
             snapshot.attached,
             snapshot.desynced,
+            snapshot.inflight_terminal_delivery_committed,
             snapshot.inflight_updated_at.as_deref(),
             now_unix_secs,
             STALL_WATCHDOG_THRESHOLD_SECS,
@@ -1649,6 +1707,18 @@ pub(crate) async fn run_stall_watchdog_pass(
             discord::inflight::load_inflight_state(provider, channel_id.get())
                 .filter(|state| state.user_msg_id != 0)
                 .map(|state| state.user_msg_id);
+        // #3126 resume-selector preservation (1446 path ONLY): the force-clean
+        // below tears down the tmux session (`CleanupSession`) so any genuinely
+        // hung provider process is killed. But the *provider session selector*
+        // (the durable `claude_session_id` / in-memory `session_id` used by
+        // `claude --resume`) identifies the conversation, not the dead pane —
+        // it must survive so the user's next message resumes the same session
+        // instead of starting fresh. Snapshot it here and re-assert it after
+        // the mailbox/orphan finalize so this watchdog never invalidates a
+        // resumable selector. This is scoped to `1446_stall_watchdog`; /clear
+        // and genuine stale-resume invalidation paths are unaffected.
+        let preserved_resume_selector =
+            preserve_resume_selector_snapshot(&shared, channel_id).await;
         discord::inflight::delete_inflight_state_file(provider, channel_id.get());
         let cleared = discord::mailbox_clear_channel(&shared, provider, channel_id).await;
         discord::stall_recovery::finalize_orphaned_clear(
@@ -1657,6 +1727,7 @@ pub(crate) async fn run_stall_watchdog_pass(
             cleared.removed_token,
             "1446_stall_watchdog",
         );
+        restore_resume_selector_snapshot(&shared, channel_id, preserved_resume_selector).await;
         shared
             .dispatch_thread_parents
             .retain(|_, thread_id| *thread_id != channel_id);
@@ -3214,10 +3285,11 @@ mod stall_watchdog_pure_tests {
         let stale_str = to_local(stale_unix);
         let fresh_str = to_local(now_unix - 5);
 
-        // Happy path: attached + desynced + stale → clean.
+        // Happy path: attached + desynced + stale + not-committed → clean.
         assert!(stall_watchdog_should_force_clean(
             true,
             true,
+            false,
             Some(stale_str.as_str()),
             now_unix,
             STALL_WATCHDOG_THRESHOLD_SECS,
@@ -3227,6 +3299,7 @@ mod stall_watchdog_pure_tests {
         assert!(!stall_watchdog_should_force_clean(
             false,
             true,
+            false,
             Some(stale_str.as_str()),
             now_unix,
             STALL_WATCHDOG_THRESHOLD_SECS,
@@ -3235,6 +3308,7 @@ mod stall_watchdog_pure_tests {
         // synced → no clean.
         assert!(!stall_watchdog_should_force_clean(
             true,
+            false,
             false,
             Some(stale_str.as_str()),
             now_unix,
@@ -3245,6 +3319,7 @@ mod stall_watchdog_pure_tests {
         assert!(!stall_watchdog_should_force_clean(
             true,
             true,
+            false,
             Some(fresh_str.as_str()),
             now_unix,
             STALL_WATCHDOG_THRESHOLD_SECS,
@@ -3254,6 +3329,7 @@ mod stall_watchdog_pure_tests {
         assert!(!stall_watchdog_should_force_clean(
             true,
             true,
+            false,
             None,
             now_unix,
             STALL_WATCHDOG_THRESHOLD_SECS,
@@ -3263,7 +3339,51 @@ mod stall_watchdog_pure_tests {
         assert!(!stall_watchdog_should_force_clean(
             true,
             true,
+            false,
             Some("not-a-real-timestamp"),
+            now_unix,
+            STALL_WATCHDOG_THRESHOLD_SECS,
+        ));
+    }
+
+    /// #3126 false-positive guard: a normally-completed turn that is now idle
+    /// (wakeup / loop wind-down) carries `terminal_delivery_committed == true`.
+    /// Even when it reads as attached + desynced + stale — exactly the
+    /// otherwise-clean signature — the watchdog must NOT force-clean it,
+    /// because killing a healthy wakeup-waiting session is the regression in
+    /// issue #3126.
+    #[test]
+    fn stall_watchdog_skips_completed_idle_wakeup_turn() {
+        let now_unix = chrono::Utc::now().timestamp();
+        let stale_unix = now_unix - (STALL_WATCHDOG_THRESHOLD_SECS as i64) - 1;
+        let stale_str = chrono::Local
+            .timestamp_opt(stale_unix, 0)
+            .single()
+            .expect("valid local time")
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string();
+
+        // Same attached+desynced+stale signature as the happy path, but the
+        // turn already committed its terminal response → completed-then-idle.
+        assert!(
+            !stall_watchdog_should_force_clean(
+                true,
+                true,
+                /* inflight_terminal_delivery_committed */ true,
+                Some(stale_str.as_str()),
+                now_unix,
+                STALL_WATCHDOG_THRESHOLD_SECS,
+            ),
+            "completed-then-idle (wakeup-waiting) session must not be force-cleaned"
+        );
+
+        // Control: the identical signature with an uncommitted (still hung)
+        // turn IS force-cleaned, proving the guard is the only difference.
+        assert!(stall_watchdog_should_force_clean(
+            true,
+            true,
+            /* inflight_terminal_delivery_committed */ false,
+            Some(stale_str.as_str()),
             now_unix,
             STALL_WATCHDOG_THRESHOLD_SECS,
         ));

--- a/src/services/discord/health/session_enrichment.rs
+++ b/src/services/discord/health/session_enrichment.rs
@@ -195,6 +195,18 @@ impl SessionEnrichment {
             .is_some_and(|state| state.watcher_owns_live_relay)
     }
 
+    /// #3126: `true` when the in-flight row records a turn whose terminal
+    /// assistant response has already been committed to the outbound delivery
+    /// path (`terminal_delivery_committed`). Such a row is NOT an active
+    /// provider turn — it is a completed turn whose session is now idle
+    /// (e.g. waiting on a `ScheduleWakeup` or loop wind-down). The stall
+    /// watchdog must not mistake this for a hung turn and force-clean it.
+    pub fn inflight_terminal_delivery_committed(&self) -> bool {
+        self.inflight
+            .as_ref()
+            .is_some_and(|state| state.terminal_delivery_committed)
+    }
+
     pub fn active_dispatch_present(&self) -> bool {
         self.inflight
             .as_ref()

--- a/src/services/discord/health/snapshot.rs
+++ b/src/services/discord/health/snapshot.rs
@@ -87,6 +87,14 @@ pub struct WatcherStateSnapshot {
     /// mailbox is idle (no active turn).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mailbox_active_user_msg_id: Option<u64>,
+    /// #3126: `true` when the in-flight row records a turn whose terminal
+    /// assistant response has already been committed
+    /// (`InflightTurnState::terminal_delivery_committed`). A row with this set
+    /// is a completed turn that is now idle (waiting on a `ScheduleWakeup` /
+    /// loop wind-down), NOT a hung provider turn. The stall watchdog uses it as
+    /// a false-positive guard so a normally-finished-then-sleeping session is
+    /// never force-cleaned as a deadlock.
+    pub(in crate::services::discord) inflight_terminal_delivery_committed: bool,
     /// #1455: Pure relay-stall classifier output derived from the nested
     /// relay-health snapshot. Read-only diagnostic; no recovery behavior is
     /// triggered from this value.
@@ -478,6 +486,7 @@ async fn watcher_state_snapshot_for_shared(
         tmux_session_alive,
         has_pending_queue,
         mailbox_active_user_msg_id,
+        inflight_terminal_delivery_committed: session.inflight_terminal_delivery_committed(),
         relay_stall_state,
         relay_health,
     })

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -3038,6 +3038,7 @@ mod thread_guard_stale_pure_tests {
             tmux_session_alive,
             has_pending_queue: false,
             mailbox_active_user_msg_id: Some(user_msg_id),
+            inflight_terminal_delivery_committed: false,
             relay_stall_state,
             relay_health,
         }


### PR DESCRIPTION
## 배경 (#3126)
stall-watchdog(1446) 강제 클린업의 두 문제 중, **(A) false-positive kill**을 수정한다. ScheduleWakeup/loop wind-down으로 정상 종료된 뒤 잠든(idle) 세션을 relay write가 없다는 이유로 hang으로 오인해 죽이던 문제.

## 수정 (A)
`stall_watchdog_should_force_clean()`에 기존 `terminal_delivery_committed` 완료 마커를 추가 신호로 사용: **terminal 응답이 커밋된(=정상 완료) 뒤 idle**인 행은 hung이 아니므로 force-clean에서 제외. 진짜 hung(uncommitted) 턴은 기존과 동일하게 클린업. (recovery.rs + session_enrichment.rs + snapshot.rs + intake_gate.rs fixture, 단위테스트 `stall_watchdog_skips_completed_idle_wakeup_turn` 추가.)

## (B) resume selector 보존 — 이 PR에서 제외
초기 구현의 preserve/restore-around-cleanup 헬퍼는 **무효+위험**으로 확인되어 제거했다(codex 리뷰 P1 + 독립 트레이싱):
- 1446 cleanup(`mailbox_clear_channel`/`finalize_orphaned_clear`/`delete_inflight_state_file`)은 in-memory `session_id`를 **지우지 않으므로** restore는 정상케이스 no-op.
- 동시 `/clear` 시에는 지워진 selector를 되살려 **clobber**(P1).
- 실제 resume-selector 무효화는 cleanup이 아니라 **후속 intake의 stale-resume 경로**(retry_state.rs:138, tmux_watcher.rs:6033, adk_session.rs:232, dispatched_sessions.rs:1977)에 있음 → 별도 후속.

A로 watchdog가 살아있는 idle 세션을 더는 안 죽이므로 원래 인시던트(정상 idle 세션 강제종료→fresh 재시작)는 해소된다. legitimate-hang kill 후의 resume 보존(B)은 #3126 후속으로 남긴다.

Part of #3126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)