### PR TITLE
refactor: extract StreamingSttSessions from VoiceBargeInRuntime (Part of #3038)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -253,7 +253,7 @@
     inline — its move-captured locals make a clean extraction risky and is
     deferred).
   - `src/services/discord/session_runtime.rs` (1396 lines).
-  - `src/services/discord/voice_barge_in.rs` (4786 lines; voice STT/TTS,
+  - `src/services/discord/voice_barge_in.rs` (4835 lines; voice STT/TTS,
     lobby routing, progress mirroring, and barge-in orchestration surface;
     tracked decompose target — see `giant-file-registry.md` (owner
     `voice-runtime`, deadline 2026-08-31, #3036)).

--- a/src/services/discord/voice_barge_in.rs
+++ b/src/services/discord/voice_barge_in.rs
@@ -1224,6 +1224,56 @@ impl VoiceIdSequences {
     }
 }
 
+/// Cohesive sub-concern of [`VoiceBargeInRuntime`]: the streaming-STT per-user
+/// session bookkeeping (#3038 god-object split, streaming-STT slice).
+///
+/// Bundles the two `DashMap`s that were previously sibling fields on
+/// `VoiceBargeInRuntime`, both keyed by the same `StreamingSttKey`
+/// (channel/user pair):
+/// - `sessions` holds the in-flight `SttSessionHandle` for each speaker, and
+/// - `feed_tasks` holds the per-key bucket of spawned PCM-feed `JoinHandle`s.
+///
+/// The accessors below are intentionally thin: `sessions()` / `feed_tasks()`
+/// hand back `&DashMap<...>` so the existing entry / get / remove call sites
+/// keep their exact `DashMap` semantics — including entry guards held across
+/// `await` during session finalization — and `clear()` wipes both maps in the
+/// same order as the original inline `streaming_stt_sessions.clear();
+/// streaming_stt_feed_tasks.clear();` pair. No locking, ordering, or
+/// side-effect sequencing changes relative to the pre-extraction layout.
+struct StreamingSttSessions {
+    sessions: dashmap::DashMap<StreamingSttKey, SttSessionHandle>,
+    feed_tasks: dashmap::DashMap<StreamingSttKey, Arc<StdMutex<Vec<tokio::task::JoinHandle<()>>>>>,
+}
+
+impl StreamingSttSessions {
+    fn new() -> Self {
+        Self {
+            sessions: dashmap::DashMap::new(),
+            feed_tasks: dashmap::DashMap::new(),
+        }
+    }
+
+    /// Per-speaker streaming session handles, keyed by channel/user pair.
+    fn sessions(&self) -> &dashmap::DashMap<StreamingSttKey, SttSessionHandle> {
+        &self.sessions
+    }
+
+    /// Per-speaker buckets of spawned PCM-feed tasks, keyed by channel/user pair.
+    fn feed_tasks(
+        &self,
+    ) -> &dashmap::DashMap<StreamingSttKey, Arc<StdMutex<Vec<tokio::task::JoinHandle<()>>>>> {
+        &self.feed_tasks
+    }
+
+    /// Drop every session and feed-task bucket. Sessions are cleared before
+    /// feed tasks, matching the original inline ordering in
+    /// `set_runtime_language`.
+    fn clear(&self) {
+        self.sessions.clear();
+        self.feed_tasks.clear();
+    }
+}
+
 /// Cohesive sub-concern of [`VoiceBargeInRuntime`]: the F6 (#2046) `Config`
 /// snapshot hot-cache (#3038 god-object split, config-cache slice).
 ///
@@ -1290,9 +1340,10 @@ pub(in crate::services::discord) struct VoiceBargeInRuntime {
     spoken_result_language: RwLock<String>,
     verbose_progress: AtomicBool,
     stt: RwLock<Option<VoiceSttRuntime>>,
-    streaming_stt_sessions: dashmap::DashMap<StreamingSttKey, SttSessionHandle>,
-    streaming_stt_feed_tasks:
-        dashmap::DashMap<StreamingSttKey, Arc<StdMutex<Vec<tokio::task::JoinHandle<()>>>>>,
+    // #3038: streaming-STT 세션/피드 태스크 DashMap 쌍을 sub-struct 로 격리.
+    // 동일한 StreamingSttKey 로 묶이며 entry/get/remove 의미와 clear 순서를
+    // 그대로 보존한다.
+    streaming_stt: StreamingSttSessions,
     tts: RwLock<Option<TtsRuntime>>,
     progress_tx: broadcast::Sender<VoiceProgressEvent>,
     monitors: dashmap::DashMap<u64, Arc<std::sync::Mutex<LiveBargeInMonitor>>>,
@@ -1351,8 +1402,7 @@ impl VoiceBargeInRuntime {
             spoken_result_language: RwLock::new(config.stt.language.clone()),
             verbose_progress: AtomicBool::new(config.verbose_progress),
             stt: RwLock::new(stt),
-            streaming_stt_sessions: dashmap::DashMap::new(),
-            streaming_stt_feed_tasks: dashmap::DashMap::new(),
+            streaming_stt: StreamingSttSessions::new(),
             tts: RwLock::new(tts),
             progress_tx,
             monitors: dashmap::DashMap::new(),
@@ -1383,8 +1433,7 @@ impl VoiceBargeInRuntime {
             spoken_result_language: RwLock::new(DEFAULT_STT_LANGUAGE.to_string()),
             verbose_progress: AtomicBool::new(false),
             stt: RwLock::new(None),
-            streaming_stt_sessions: dashmap::DashMap::new(),
-            streaming_stt_feed_tasks: dashmap::DashMap::new(),
+            streaming_stt: StreamingSttSessions::new(),
             tts: RwLock::new(None),
             progress_tx,
             monitors: dashmap::DashMap::new(),
@@ -1727,8 +1776,7 @@ impl VoiceBargeInRuntime {
         };
         *self.spoken_result_language.write().await = language;
         if self.enabled {
-            self.streaming_stt_sessions.clear();
-            self.streaming_stt_feed_tasks.clear();
+            self.streaming_stt.clear();
             *self.stt.write().await = Some(VoiceSttRuntime::from_voice_config(&config));
         }
     }
@@ -2406,7 +2454,8 @@ impl VoiceBargeInRuntime {
             user_id,
         };
         let task_bucket = self
-            .streaming_stt_feed_tasks
+            .streaming_stt
+            .feed_tasks()
             .entry(key)
             .or_insert_with(|| Arc::new(StdMutex::new(Vec::new())))
             .clone();
@@ -2439,7 +2488,7 @@ impl VoiceBargeInRuntime {
             channel_id: channel_id.get(),
             user_id,
         };
-        let session = match self.streaming_stt_sessions.get(&key) {
+        let session = match self.streaming_stt.sessions().get(&key) {
             Some(entry) => entry.value().clone(),
             None => {
                 let language = self.spoken_result_language().await;
@@ -2455,7 +2504,7 @@ impl VoiceBargeInRuntime {
                         return;
                     }
                 };
-                match self.streaming_stt_sessions.entry(key) {
+                match self.streaming_stt.sessions().entry(key) {
                     dashmap::mapref::entry::Entry::Occupied(entry) => {
                         let existing = entry.get().clone();
                         if let Err(error) = stt.finalize(new_session).await {
@@ -2509,7 +2558,7 @@ impl VoiceBargeInRuntime {
     }
 
     async fn drain_streaming_stt_feed_tasks(&self, key: StreamingSttKey) {
-        let Some((_, task_bucket)) = self.streaming_stt_feed_tasks.remove(&key) else {
+        let Some((_, task_bucket)) = self.streaming_stt.feed_tasks().remove(&key) else {
             return;
         };
         let tasks = match task_bucket.lock() {
@@ -4410,7 +4459,7 @@ impl VoiceBargeInRuntime {
                     user_id: utterance.user_id,
                 };
                 self.drain_streaming_stt_feed_tasks(key).await;
-                if let Some((_, session)) = self.streaming_stt_sessions.remove(&key) {
+                if let Some((_, session)) = self.streaming_stt.sessions().remove(&key) {
                     match stt.finalize(session).await {
                         Ok(transcript) if !transcript.text.trim().is_empty() => {
                             let stt_latency_ms =


### PR DESCRIPTION
## 대상
`VoiceBargeInRuntime` (`src/services/discord/voice_barge_in.rs`) — #3038 god-object 분해의 한 보수적 슬라이스. 외부 결합도 0인 streaming-STT DashMap 쌍을 cohesive sub-struct로 격리. relay/turn/finalize 경로와 무관.

## 추출 내역
새 sub-struct `StreamingSttSessions`를 같은 파일 내에 추가하고, 두 sibling `DashMap` 필드를 그 안으로 이동. 접근자(`sessions()`/`feed_tasks()`)는 `&DashMap<...>`를 그대로 반환하여 기존 entry/get/remove 의미(특히 session finalize 중 await를 가로지르는 entry guard)를 byte-identical하게 보존. `clear()`는 원래 인라인 순서(sessions → feed_tasks)를 유지.

## 이동 필드
- `streaming_stt_sessions: DashMap<StreamingSttKey, SttSessionHandle>` → `StreamingSttSessions::sessions`
- `streaming_stt_feed_tasks: DashMap<StreamingSttKey, Arc<StdMutex<Vec<JoinHandle<()>>>>>` → `StreamingSttSessions::feed_tasks`

두 필드는 동일한 `StreamingSttKey`(channel/user)로 묶이는 한 클러스터.

## 호출처 변경 수
외부 파일(다른 모듈) 변경 0곳. 동일 파일 내 접근 site 7곳만 sub-struct 경유로 갱신(2 constructor, clear, entry/get/entry, 2 remove). 공개 API/시그니처/제어흐름/락 순서/atomic Ordering 변경 없음.

검증: cargo fmt --check, build, clippy(워크스페이스, error 0), voice_barge_in 테스트 51 pass, transition/auto_queue/cancel/review_decision/invariant green, ci-script-checks(0), cargo check --all-targets, macOS fresh-user smoke(0) 모두 통과. change-surfaces.md freeze 줄수를 module-inventory 실측(code 4786→4835)과 동기화.

Part of #3038

🤖 Generated with [Claude Code](https://claude.com/claude-code)