### PR TITLE
fix(relay): re-land unmerged phase4 relay-dedup + read-only offset authority (#3017 completion, prereq for #3041)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -116,12 +116,13 @@
   - `src/services/discord/watchers/lifecycle.rs` (2301 lines — canonical
     lifecycle extraction surface from #1435; split further before adding new
     lifecycle behavior).
-  - `src/services/discord/tmux.rs` (2154 lines after #2558 dead-code sweep;
+  - `src/services/discord/tmux.rs` (2228 lines after #2558 dead-code sweep;
     failover guard; #3087 `session_panel_instance_key`/`write_spawn_nonce`
     re-exports; #3107 `RestoredWatcherTurn.injected_prompt_message_id`;
     #3016 option A `normal_completion` finalize-decouple param;
-    still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (7662 lines after #2558
+    #3017 monitor-auto-turn finalizer routing + ledger-generation +
+    relay-watermark reset re-exports; still giant-file territory).
+  - `src/services/discord/tmux_watcher.rs` (7805 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -143,6 +144,10 @@
     (`turn_start_offset.unwrap_or(last_offset) < current_offset`, mirroring the
     yield guard at `tmux.rs:2110-2111`) so a follow-up turn started after this
     range is not released by stale output;
+    +143 from #3017 the no-inflight relay-dedup gate (reads `committed_relay_offset`
+    + generation-aware watermark resets, suppresses a wake/idle terminal already
+    committed by another relay actor) and the monitor-auto-turn synthetic-id /
+    ledger-generation threading through `finish_monitor_auto_turn_if_claimed`;
     split loop helpers further before adding behavior).
   - `src/services/discord/tui_prompt_relay.rs` (3849 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
@@ -201,14 +206,17 @@
     `reset_state_for_tests` helper; +26 from #3105 codex-P1 sub-case B
     `evict_dead_tmux_mirror` tombstone helper that drops both the runtime and
     channel mirror for a dead/orphaned session and then allows re-registration).
-  - `src/services/discord/recovery_engine.rs` (4033 lines; +36 from #3099
+  - `src/services/discord/recovery_engine.rs` (4037 lines; +36 from #3099
     task-notification anchor `⏳` cleanup for `user_msg_id == 0` recovery; +4
     from the #3099 re-review pinned-injected-message-id cleanup target; +55 from
     #3078 PR-2 routing recovery completion through `StatusPanelController` behind
     a shadow parity check (the controller adopts the recovered panel id and its
     chosen completion id is asserted equal to the legacy
     `recovery_status_panel_message_id_for_completion` result; the legacy path
-    still executes the Discord IO, so behaviour is unchanged)).
+    still executes the Discord IO, so behaviour is unchanged); +4 from #3017
+    routing the recovery terminal through the single-authority finalizer
+    (`submit_terminal` + `FinalizeContext::monitor`) instead of inline
+    `mailbox_finish_turn`).
   - `src/services/discord/health.rs` (2354 lines after #1879 snapshot/mailbox
     extraction; +3 from #3082 answer-flush-barrier field in the test SharedData
     constructor).

--- a/scripts/giant_file_registry.toml
+++ b/scripts/giant_file_registry.toml
@@ -250,3 +250,14 @@ file = "src/voice/announce_meta.rs"
 owner = "voice-runtime"
 deadline = "2026-08-31"
 decompose_issue = "#3036"
+
+[[entry]]
+# Crossed the 1000-prod-LoC threshold when #3017 re-landed the single
+# output-offset relay-dedup authority: the idle-JSONL relay loop now consults
+# `committed_relay_offset` (read-only) with generation-aware watermark resets to
+# de-duplicate inflight-less wake/background relays against the tmux watcher.
+# Active relay-dedup surface; decompose the idle-relay loop out once stabilized.
+file = "src/services/discord/session_relay_sink.rs"
+owner = "discord-relay"
+deadline = "2026-08-31"
+decompose_issue = "#3036"

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -1558,10 +1558,19 @@ pub(super) struct TmuxRelayCoord {
     /// End offset (exclusive) of the last relay this process has confirmed
     /// delivery for. 0 = no confirmed delivery yet this process lifetime.
     ///
-    /// This is telemetry/stop-state only. Relay dedupe is scoped to the
-    /// watcher instance via its local `last_relayed_offset`; cross-watcher
-    /// ownership is enforced at registration time so a valid owner is never
-    /// suppressed solely because another watcher advanced this watermark.
+    /// #3017: this is the single output-offset authority for the relay-dedup
+    /// paths (read via `SharedData::committed_relay_offset`, advanced by the
+    /// watcher's `advance_watcher_confirmed_end`). For an inflight-less wake /
+    /// idle-background / monitor-auto-turn turn, the secondary relay actors
+    /// (idle-JSONL relay, session-bound sink) CONSULT this watermark so a
+    /// byte-range the watcher already committed is relayed exactly once
+    /// regardless of which actor observes it first (the E-13 dedup invariant).
+    /// For a normal
+    /// Discord-origin turn (inflight present) the watcher remains the sole
+    /// relay owner and relay dedupe is still scoped to the watcher instance via
+    /// its local `last_relayed_offset` — a valid owner is never suppressed
+    /// solely because another watcher advanced this watermark; only the
+    /// no-inflight wake/idle paths gate on it.
     pub(super) confirmed_end_offset: Arc<std::sync::atomic::AtomicU64>,
     /// Wall-clock timestamp (ms since epoch) of the most recent confirmed
     /// relay. 0 = no confirmed relay observed yet. Read by the
@@ -1963,6 +1972,27 @@ impl SharedData {
             .entry(channel_id)
             .or_insert_with(|| Arc::new(TmuxRelayCoord::new()))
             .clone()
+    }
+
+    /// #3017 single output-offset authority for the relay-dedup paths — a
+    /// read-only snapshot of the authoritative committed relayed offset.
+    ///
+    /// The per-channel `confirmed_end_offset` is the ONE authoritative "JSONL
+    /// byte offset (exclusive) past which output has already been relayed to
+    /// Discord". The single committer is the tmux watcher (the primary relay)
+    /// via `advance_watcher_confirmed_end`. The inflight-less wake /
+    /// idle-background / monitor relay paths (idle-JSONL relay, session-bound
+    /// sink) CONSULT this BEFORE relaying so a byte-range the watcher already
+    /// delivered is relayed EXACTLY ONCE regardless of which actor observes it
+    /// first (the E-13 dedup invariant). They do NOT claim it themselves —
+    /// claiming on a secondary path could suppress the primary watcher's own
+    /// delivery on a failed forward and drop the response. It is the
+    /// cross-actor generalization of the watcher's process-local
+    /// `last_relayed_offset`.
+    pub(super) fn committed_relay_offset(&self, channel_id: ChannelId) -> u64 {
+        self.tmux_relay_coord(channel_id)
+            .confirmed_end_offset
+            .load(Ordering::Acquire)
     }
 
     /// Record that this process spawned a watcher during recovery/reattach.

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -1234,31 +1234,35 @@ async fn finish_recovered_turn_mailbox(
     channel_id: ChannelId,
     stop_source: &'static str,
 ) {
-    let finish = mailbox_finish_turn(shared, provider, channel_id).await;
-    if let Some(removed_token) = finish.removed_token {
-        removed_token
-            .cancelled
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-        super::saturating_decrement_global_active(shared);
-    }
-
-    super::clear_watchdog_deadline_override(channel_id.get()).await;
-    shared
-        .dispatch_thread_parents
-        .retain(|_, thread| *thread != channel_id);
-
-    if !finish.has_pending {
-        shared.dispatch_role_overrides.remove(&channel_id);
-    }
-
-    if finish.mailbox_online && finish.has_pending {
-        super::schedule_deferred_idle_queue_kickoff(
-            shared.clone(),
+    // #3016 phase 4: route the recovery terminal through the single-authority
+    // finalizer. The recovered turn is channel-scoped here (the caller did not
+    // thread its real `user_msg_id`), so we submit `user_msg_id == 0` — the
+    // finalizer resolves it to the channel's single live entry (or finalizes
+    // the orphan directly) and runs the SAME channel-scoped `mailbox_finish_turn`
+    // + gated counter decrement + watchdog-override clear + dispatch_thread_parents
+    // retain + role-override cleanup + queue kickoff this code did inline. The
+    // ledger phase gate keeps a racing watcher/bridge terminal exactly-once safe.
+    // `FinalizeContext::monitor` reproduces the inline side-effect set (no
+    // inflight clear, no completion-cleanup, no voice drain, kick off backlog).
+    //
+    // Recovery is single-turn-per-channel (the channel is being recovered, not
+    // running a fresh turn), so id-0 here is safe: the finalizer's id-0 guard
+    // makes an AMBIGUOUS submission (a recently-Finalized entry AND a different
+    // live turn) a NO-OP — it never releases a newer turn's token — and the
+    // unambiguous case (the recovered turn is the single live entry) finalizes
+    // it exactly as the inline code did. This reproduces the prior
+    // channel-scoped `mailbox_finish_turn` semantics, now ledger-gated.
+    let _ = shared
+        .turn_finalizer
+        .submit_terminal(
+            super::turn_finalizer::TurnKey::new(channel_id, 0, shared.current_generation),
             provider.clone(),
-            channel_id,
-            stop_source,
-        );
-    }
+            super::turn_finalizer::TerminalEvent::Complete,
+            super::turn_finalizer::FinalizeContext::monitor(),
+            shared.clone(),
+        )
+        .await;
+    let _ = stop_source;
 }
 
 pub(super) async fn reregister_active_turn_from_inflight(

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -566,6 +566,25 @@ impl RelaySink for SessionBoundDiscordRelaySink {
             match self.deliver_response(delivery).await {
                 Ok(SessionRelayDeliveryOutcome::Committed) => {
                     terminal_committed = true;
+                    // #3017: the sink deliberately does NOT advance the
+                    // committed relay offset here. The only byte offset
+                    // available at this point is the JSONL EOF, which can
+                    // include bytes appended AFTER this frame was read but
+                    // before the async Discord delivery committed — committing
+                    // that later EOF would mark undelivered appended output as
+                    // already relayed and DROP it (codex r4 P1). The
+                    // `StreamFrame` contract does not carry the exact delivered
+                    // byte-range end, and threading one through the cluster
+                    // stream-relay producer/parser is out of this subset's
+                    // scope. The tmux watcher remains the SOLE committer of the
+                    // authority (`advance_watcher_confirmed_end`, which has the
+                    // exact relayed offset); the idle relay only CONSULTS it.
+                    // This keeps the dedup data-loss-free: the residual
+                    // idle-wins-the-race window is bounded by the idle relay's
+                    // 10s recent-inflight grace (the watcher relays + commits
+                    // within ~250ms), and when no watcher is relaying there is
+                    // no second actor to duplicate against. (See FINAL OUTPUT
+                    // note for the #3017 follow-up to carry the range end.)
                     self.finish_terminal_candidate(&session_name);
                 }
                 Ok(SessionRelayDeliveryOutcome::Skipped) => {
@@ -602,12 +621,13 @@ pub(crate) async fn run_session_bound_discord_relay_supervisor(
     };
 
     SESSION_BOUND_DISCORD_DELIVERY_ENABLED.store(true, Ordering::Release);
+    let idle_health_registry = health_registry.clone();
     let sink: Arc<dyn RelaySink> = Arc::new(SessionBoundDiscordRelaySink::new(health_registry));
     let idle_shutdown = shutdown.clone();
     super::task_supervisor::spawn_observed(
         "session_bound_idle_jsonl_relay",
         async move {
-            run_idle_jsonl_relay_loop(idle_shutdown).await;
+            run_idle_jsonl_relay_loop(idle_shutdown, idle_health_registry).await;
         }
         .instrument(tracing::info_span!("session_bound_idle_jsonl_relay")),
     );
@@ -615,7 +635,10 @@ pub(crate) async fn run_session_bound_discord_relay_supervisor(
     SESSION_BOUND_DISCORD_DELIVERY_ENABLED.store(false, Ordering::Release);
 }
 
-async fn run_idle_jsonl_relay_loop(shutdown: Arc<AtomicBool>) {
+async fn run_idle_jsonl_relay_loop(
+    shutdown: Arc<AtomicBool>,
+    health_registry: Arc<HealthRegistry>,
+) {
     let registry = crate::services::cluster::session_registry::global_session_registry();
     let producers =
         crate::services::cluster::relay_producer_registry::global_relay_producer_registry();
@@ -720,6 +743,89 @@ async fn run_idle_jsonl_relay_loop(shutdown: Arc<AtomicBool>) {
                 );
                 continue;
             };
+            // #3017 single output-offset authority. This idle path and the
+            // tmux watcher both read the SAME JSONL and can both relay an
+            // inflight-less wake / background turn (E-13: a scheduled-wakeup
+            // output relayed twice). The tmux watcher is the PRIMARY relay and
+            // advances the authoritative `confirmed_end_offset` on a confirmed
+            // relay (`advance_watcher_confirmed_end`); this idle path is the
+            // backstop. So the idle relay only CONSULTS the authority read-only:
+            // if the watcher already committed at/past this range end, that
+            // range is already delivered → skip to avoid the duplicate. It does
+            // NOT itself advance the authority — `try_send_frame` only means the
+            // frame was QUEUED (the sink may still skip/drop/fail it), so
+            // committing here could suppress the watcher's own delivery and drop
+            // the response (codex P1). On a standby node with no watcher relaying
+            // there is no second actor to duplicate, so no advance is needed.
+            let channel = ChannelId::new(channel_id);
+            if let Some(shared) = health_registry
+                .shared_for_provider_on_channel(&matched.provider, channel)
+                .await
+                .or(health_registry.shared_for_provider(&matched.provider).await)
+            {
+                // Codex P2: a stale-high `confirmed_end_offset` left by a
+                // previous wrapper (before a watcher ran its regression reset)
+                // would otherwise make this skip the FRESH file's first bytes
+                // and drop a wake response. Run the SAME generation-aware
+                // regression reset the watcher uses BEFORE reading the
+                // watermark, so a truncated/respawned JSONL resets the shared
+                // watermark to 0 (fresh wrapper) and the fresh range is relayed.
+                super::tmux::reset_stale_relay_watermark_if_output_regressed(
+                    shared.as_ref(),
+                    channel,
+                    &session_name,
+                    len,
+                    "idle_jsonl_relay",
+                );
+                // Codex r7 P2: the EOF-regression reset above does NOT fire when
+                // a respawned same-named wrapper's fresh JSONL has already grown
+                // PAST the previous wrapper's watermark. Apply the same
+                // generation-change reset the watcher uses so a stale watermark
+                // from a prior wrapper does not make this idle relay skip fresh
+                // wake/background output as already relayed.
+                super::tmux::reset_relay_watermark_on_generation_change(
+                    shared.as_ref(),
+                    channel,
+                    &session_name,
+                    "idle_jsonl_relay",
+                );
+                let committed = shared.committed_relay_offset(channel);
+                if committed >= end {
+                    // The whole `[start, end)` range was already delivered by the
+                    // watcher → skip entirely.
+                    *offset = end;
+                    tracing::debug!(
+                        provider = matched.provider.as_str(),
+                        channel = channel_id,
+                        tmux_session = %session_name,
+                        committed_relay_offset = committed,
+                        end,
+                        "idle JSONL relay skipped range already relayed by watcher (offset authority dedup)"
+                    );
+                    continue;
+                }
+                if committed > start {
+                    // Codex r5 P2: PARTIAL overlap (`start < committed < end`) —
+                    // the watcher already delivered the `[start, committed)`
+                    // PREFIX (e.g. a wake response) while the file grew past it
+                    // before this 500ms poll. Forwarding the whole payload from
+                    // `start` would re-send the already-delivered prefix. Advance
+                    // our offset to the committed boundary and re-read the
+                    // un-delivered remainder `[committed, end)` on the next tick
+                    // instead of double-sending.
+                    *offset = committed;
+                    tracing::debug!(
+                        provider = matched.provider.as_str(),
+                        channel = channel_id,
+                        tmux_session = %session_name,
+                        committed_relay_offset = committed,
+                        start,
+                        end,
+                        "idle JSONL relay trimmed already-relayed prefix to committed offset (offset authority dedup)"
+                    );
+                    continue;
+                }
+            }
             if producer.try_send_frame(String::from_utf8_lossy(&payload).into_owned()) {
                 *offset = end;
                 tracing::debug!(
@@ -1351,6 +1457,138 @@ mod tests {
                 42,
             ),
             SessionBoundTerminalDeliveryRouteDecision::Skipped
+        );
+    }
+
+    /// #3017 / E-13 dedup invariant: the single output-offset authority makes
+    /// the idle-JSONL relay (and the watcher) relay a given inflight-less wake
+    /// byte-range EXACTLY ONCE.
+    ///
+    /// The tmux watcher is the PRIMARY relay and the SOLE committer of the
+    /// authoritative offset (via `advance_watcher_confirmed_end`, simulated here
+    /// by writing `confirmed_end_offset`). The idle relay and the watcher's
+    /// own no-inflight relay gate are read-only CONSUMERS: each skips a range
+    /// the committed offset already covers (`committed_relay_offset(channel) >=
+    /// end`). This test exercises that exact decision:
+    ///   1. Before any relay, the committed offset is 0 → a wake range
+    ///      `[0, end)` is NOT yet covered → the actor relays it.
+    ///   2. After the watcher commits at `end`, a second actor (idle relay or a
+    ///      re-observing watcher pass) sees the range covered → it SKIPS, so the
+    ///      wake body is never relayed twice (the
+    ///      `duplicate Discord relay body: '[E2E:E13:WAKE]'` failure).
+    ///   3. A genuinely-NEW wake output at a higher offset is past the committed
+    ///      offset → NOT covered → relayed exactly once (dedup, not blanket
+    ///      suppression - E-13 also asserts the wake text is present).
+    #[test]
+    fn offset_authority_relays_wake_range_exactly_once() {
+        use std::sync::atomic::Ordering;
+
+        // The dedup decision both consumers make: skip iff the committed offset
+        // already covers this range end. Mirrors the read-only check in
+        // `run_idle_jsonl_relay_loop` and the watcher's no-inflight gate.
+        fn already_relayed(committed_end: u64, range_end: u64) -> bool {
+            committed_end >= range_end
+        }
+
+        let shared = super::super::make_shared_data_for_tests();
+        let channel = ChannelId::new(7_013);
+        let coord = shared.tmux_relay_coord(channel);
+
+        // (1) Fresh wake turn ending at offset 128: nothing committed yet → the
+        // first actor relays it (not a duplicate).
+        assert_eq!(shared.committed_relay_offset(channel), 0);
+        assert!(
+            !already_relayed(shared.committed_relay_offset(channel), 128),
+            "a wake range past the committed offset must be relayed"
+        );
+
+        // The watcher (primary) commits the relay at 128, exactly as
+        // `advance_watcher_confirmed_end` does after a confirmed delivery.
+        coord.confirmed_end_offset.store(128, Ordering::Release);
+        assert_eq!(shared.committed_relay_offset(channel), 128);
+
+        // (2) The OTHER actor (idle relay, or a re-observing watcher) now sees
+        // the same range covered → it SKIPS → the body is not relayed twice.
+        assert!(
+            already_relayed(shared.committed_relay_offset(channel), 128),
+            "the second actor must skip a range the watcher already committed (E-13 dedup)"
+        );
+        // A sub-range / re-observation of the already-relayed range also skips.
+        assert!(already_relayed(shared.committed_relay_offset(channel), 64));
+
+        // (3) A genuinely-new wake output ending at 256 is PAST the committed
+        // offset → not covered → relayed exactly once.
+        assert!(
+            !already_relayed(shared.committed_relay_offset(channel), 256),
+            "a new wake output past the committed offset must be relayed (not suppressed)"
+        );
+        coord.confirmed_end_offset.store(256, Ordering::Release);
+        assert!(
+            already_relayed(shared.committed_relay_offset(channel), 256),
+            "after it is committed the new range must not be relayed twice"
+        );
+
+        // The authority is per-channel: a different channel starts uncommitted,
+        // so its own first wake range is relayed independently.
+        let other = ChannelId::new(7_014);
+        assert_eq!(shared.committed_relay_offset(other), 0);
+        assert!(!already_relayed(shared.committed_relay_offset(other), 128));
+    }
+
+    /// #3017 / E-13 partial-overlap dedup (codex r5 P2): the idle relay must not
+    /// re-send a PREFIX the watcher already delivered, and the watcher must
+    /// compare against this turn's CONSUMED end (not the whole read batch end).
+    #[test]
+    fn offset_authority_handles_partial_and_batch_overlaps() {
+        // Idle-relay decision for a read range `[start, end)` against the
+        // committed watermark. Mirrors `run_idle_jsonl_relay_loop`:
+        //   - committed >= end  → whole range already delivered → SKIP all.
+        //   - committed > start → PREFIX delivered → trim: re-read from committed.
+        //   - else              → nothing delivered → forward `[start, end)`.
+        #[derive(Debug, PartialEq, Eq)]
+        enum IdleDecision {
+            SkipAll,
+            TrimTo(u64),
+            Forward,
+        }
+        fn idle_decision(committed: u64, start: u64, end: u64) -> IdleDecision {
+            if committed >= end {
+                IdleDecision::SkipAll
+            } else if committed > start {
+                IdleDecision::TrimTo(committed)
+            } else {
+                IdleDecision::Forward
+            }
+        }
+
+        // Fully covered → skip.
+        assert_eq!(idle_decision(200, 0, 128), IdleDecision::SkipAll);
+        assert_eq!(idle_decision(128, 0, 128), IdleDecision::SkipAll);
+        // Partial overlap: watcher delivered [0,128); file grew to 256 before the
+        // idle poll → re-read only [128,256), never re-sending the wake prefix.
+        assert_eq!(idle_decision(128, 0, 256), IdleDecision::TrimTo(128));
+        // No overlap → forward the whole fresh range.
+        assert_eq!(idle_decision(0, 128, 256), IdleDecision::Forward);
+        assert_eq!(idle_decision(64, 128, 256), IdleDecision::Forward);
+
+        // Watcher decision: dedup against the TURN's CONSUMED end, not the whole
+        // read batch end. A batch read `[start=0, current_offset=256)` whose
+        // result line ends at 128 (the trailing 128 bytes are a later turn's
+        // buffered JSONL) consumes to 128. A prior commit at 128 (this same
+        // terminal, already relayed) must suppress — comparing against 256 would
+        // miss it and re-relay. `terminal_event_consumed_offset` = current_offset
+        // - unprocessed_tail.len().
+        let current_offset = 256u64;
+        let unprocessed_tail_len = 128u64; // a later turn's buffered bytes
+        let turn_consumed = current_offset - unprocessed_tail_len; // 128
+        let committed_for_this_terminal = 128u64;
+        assert!(
+            committed_for_this_terminal >= turn_consumed,
+            "a prior commit at the consumed terminal end must suppress the re-relay"
+        );
+        assert!(
+            committed_for_this_terminal < current_offset,
+            "comparing against the whole batch end (256) would WRONGLY miss the duplicate"
         );
     }
 

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -585,6 +585,21 @@ impl RelaySink for SessionBoundDiscordRelaySink {
                     // within ~250ms), and when no watcher is relaying there is
                     // no second actor to duplicate against. (See FINAL OUTPUT
                     // note for the #3017 follow-up to carry the range end.)
+                    //
+                    // EXACT-ONCE GAP (deferred to #3041, NOT a regression):
+                    // because this terminal Discord delivery does NOT advance the
+                    // authority, the "sink wins first" case is not yet exact-once.
+                    // If this sink posts BEFORE the watcher commits, the authority
+                    // (`confirmed_end_offset`) stays stale, so the watcher's later
+                    // no-inflight dedup gate cannot suppress its own delivery →
+                    // a residual duplicate window (the 10s grace reduces but does
+                    // not eliminate it). Closing this requires the sink's delivery
+                    // to advance the authority atomically with the exact relayed
+                    // range end — that is the #3041 delivery-lease (commit-with-
+                    // offset) work, deliberately out of scope here to avoid the
+                    // codex r4 P1 black-hole of committing a too-late EOF. Phase4's
+                    // read-only consult is a strict improvement over no consult;
+                    // it does not by itself achieve full exact-once for this window.
                     self.finish_terminal_candidate(&session_name);
                 }
                 Ok(SessionRelayDeliveryOutcome::Skipped) => {
@@ -692,7 +707,13 @@ async fn run_idle_jsonl_relay_loop(
                 *offset = end;
                 continue;
             }
-            if first_seen.elapsed() < IDLE_JSONL_RELAY_RECENT_INFLIGHT_GRACE {
+            // Classify the WHOLE payload up front so the offset-authority dedup
+            // (and any prefix/suffix trim) operate on an already-classified
+            // turn. Mirrors `idle_relay_range_action`'s ordering; the distinct
+            // per-reason debug logs below are preserved for observability.
+            let in_new_session_grace =
+                first_seen.elapsed() < IDLE_JSONL_RELAY_RECENT_INFLIGHT_GRACE;
+            if in_new_session_grace {
                 *offset = end;
                 tracing::debug!(
                     provider = matched.provider.as_str(),
@@ -790,40 +811,74 @@ async fn run_idle_jsonl_relay_loop(
                     "idle_jsonl_relay",
                 );
                 let committed = shared.committed_relay_offset(channel);
-                if committed >= end {
-                    // The whole `[start, end)` range was already delivered by the
-                    // watcher → skip entirely.
-                    *offset = end;
-                    tracing::debug!(
-                        provider = matched.provider.as_str(),
-                        channel = channel_id,
-                        tmux_session = %session_name,
-                        committed_relay_offset = committed,
-                        end,
-                        "idle JSONL relay skipped range already relayed by watcher (offset authority dedup)"
-                    );
-                    continue;
-                }
-                if committed > start {
-                    // Codex r5 P2: PARTIAL overlap (`start < committed < end`) —
-                    // the watcher already delivered the `[start, committed)`
-                    // PREFIX (e.g. a wake response) while the file grew past it
-                    // before this 500ms poll. Forwarding the whole payload from
-                    // `start` would re-send the already-delivered prefix. Advance
-                    // our offset to the committed boundary and re-read the
-                    // un-delivered remainder `[committed, end)` on the next tick
-                    // instead of double-sending.
-                    *offset = committed;
-                    tracing::debug!(
-                        provider = matched.provider.as_str(),
-                        channel = channel_id,
-                        tmux_session = %session_name,
-                        committed_relay_offset = committed,
-                        start,
-                        end,
-                        "idle JSONL relay trimmed already-relayed prefix to committed offset (offset authority dedup)"
-                    );
-                    continue;
+                // Classification already passed for this whole payload above, so
+                // pass `in_new_session_grace = false`: this consults ONLY the
+                // offset-authority dedup branch of the shared decision.
+                match idle_relay_range_action(&payload, start, end, committed, false) {
+                    IdleRelayRangeAction::SkipAlreadyRelayed => {
+                        // The whole `[start, end)` range was already delivered by
+                        // the watcher → skip entirely.
+                        *offset = end;
+                        tracing::debug!(
+                            provider = matched.provider.as_str(),
+                            channel = channel_id,
+                            tmux_session = %session_name,
+                            committed_relay_offset = committed,
+                            end,
+                            "idle JSONL relay skipped range already relayed by watcher (offset authority dedup)"
+                        );
+                        continue;
+                    }
+                    IdleRelayRangeAction::SendSuffixFrom(from) => {
+                        // Codex r5 P2 + codex r6 P1 (black-hole): PARTIAL overlap
+                        // (`start < committed < end`) — the watcher already
+                        // delivered the `[start, committed)` PREFIX (e.g. a wake
+                        // response) while the file grew past it before this poll.
+                        // Forwarding the whole payload from `start` would re-send
+                        // the already-delivered prefix.
+                        //
+                        // We must NOT bounce to a next tick (the old `*offset =
+                        // committed; continue;`): the next tick re-reads only the
+                        // suffix `[committed, end)`, which no longer carries the
+                        // `system/init` event (that lived in the already-committed
+                        // prefix). The init/classification gate above would then
+                        // re-classify the suffix as a "non-init active-session
+                        // payload" and DROP it → the user never sees the trailing
+                        // part of the response (a black-hole). Instead, deliver
+                        // the un-committed suffix in THIS SAME pass, carrying
+                        // forward the classification we already established for
+                        // this turn: prefix-skip, suffix-send, exactly once.
+                        let suffix =
+                            match read_jsonl_range(&matched.expected_rollout_path, from, end) {
+                                Ok(suffix) => suffix,
+                                Err(_) => continue,
+                            };
+                        if suffix.is_empty() {
+                            *offset = end;
+                            continue;
+                        }
+                        if producer.try_send_frame(String::from_utf8_lossy(&suffix).into_owned()) {
+                            *offset = end;
+                            tracing::debug!(
+                                provider = matched.provider.as_str(),
+                                channel = channel_id,
+                                tmux_session = %session_name,
+                                committed_relay_offset = committed,
+                                start,
+                                end,
+                                bytes = suffix.len(),
+                                "idle JSONL relay sent un-committed suffix after trimming already-relayed prefix (offset authority dedup, no black-hole)"
+                            );
+                        }
+                        continue;
+                    }
+                    // `committed <= start` → nothing covered → fall through to the
+                    // full-range send below.
+                    IdleRelayRangeAction::SendFull => {}
+                    // Classification already happened above; this arm is
+                    // unreachable here because we pass `in_new_session_grace =
+                    // false` and the payload already passed the init gate.
+                    IdleRelayRangeAction::SkipClassified => {}
                 }
             }
             if producer.try_send_frame(String::from_utf8_lossy(&payload).into_owned()) {
@@ -842,6 +897,64 @@ async fn run_idle_jsonl_relay_loop(
         first_seen_at.retain(|session, _| seen_sessions.contains(session));
         last_inflight_seen_at.retain(|session, _| seen_sessions.contains(session));
         tokio::time::sleep(IDLE_JSONL_RELAY_POLL_INTERVAL).await;
+    }
+}
+
+/// The action the idle relay loop takes for one fresh JSONL range
+/// `[start, end)` after classifying the payload and consulting the offset
+/// authority. Encodes the REAL loop ordering: classification gates run on the
+/// WHOLE payload FIRST (so an `init` event anywhere in `[start, end)` keeps the
+/// range classified as a relayable turn), and the offset-authority dedup runs
+/// SECOND on that already-classified range. This is the contract the loop body
+/// must honor; extracting it makes the "init in committed prefix, suffix
+/// uncommitted" black-hole regression testable at loop-ordering granularity
+/// without spinning the live poll loop against the process-global registries.
+#[derive(Debug, PartialEq, Eq)]
+enum IdleRelayRangeAction {
+    /// Classification dropped the range (grace window, user/tool-result event,
+    /// ScheduleWakeup setup, or non-init active-session payload). Advance the
+    /// offset past `end` without relaying.
+    SkipClassified,
+    /// The offset authority already covers `[start, end)` (`committed >= end`).
+    /// Advance past `end` without relaying (dedup, whole range).
+    SkipAlreadyRelayed,
+    /// PARTIAL overlap (`start < committed < end`): the prefix `[start, committed)`
+    /// was already relayed by the watcher; relay ONLY the uncommitted suffix
+    /// `[committed, end)` of THIS SAME classified turn, then advance past `end`.
+    /// The classification already passed on the full payload, so the suffix is
+    /// NOT re-gated as a fresh non-init payload (no black-hole, codex r6 P1).
+    SendSuffixFrom(u64),
+    /// Nothing covered (`committed <= start`): relay the whole `[start, end)`.
+    SendFull,
+}
+
+/// Pure decision for the idle relay's classification + offset-authority dedup,
+/// in the loop's real order. `payload` is the full `[start, end)` bytes.
+/// `in_new_session_grace` mirrors the runtime `first_seen.elapsed() < grace`
+/// gate. `committed` is the offset authority's `committed_relay_offset`.
+fn idle_relay_range_action(
+    payload: &[u8],
+    start: u64,
+    end: u64,
+    committed: u64,
+    in_new_session_grace: bool,
+) -> IdleRelayRangeAction {
+    // Classification first, on the WHOLE payload (matches the loop's gate
+    // ordering at the top of `run_idle_jsonl_relay_loop`).
+    if in_new_session_grace
+        || idle_jsonl_payload_contains_user_event(payload)
+        || idle_jsonl_payload_contains_schedule_wakeup_setup(payload)
+        || !idle_jsonl_payload_contains_init_event(payload)
+    {
+        return IdleRelayRangeAction::SkipClassified;
+    }
+    // Offset-authority dedup second, on the already-classified range.
+    if committed >= end {
+        IdleRelayRangeAction::SkipAlreadyRelayed
+    } else if committed > start {
+        IdleRelayRangeAction::SendSuffixFrom(committed)
+    } else {
+        IdleRelayRangeAction::SendFull
     }
 }
 
@@ -1589,6 +1702,84 @@ mod tests {
         assert!(
             committed_for_this_terminal < current_offset,
             "comparing against the whole batch end (256) would WRONGLY miss the duplicate"
+        );
+    }
+
+    /// #3017 / E-13 codex r6 P1 (black-hole regression): when the `system/init`
+    /// event lives in the already-committed PREFIX and only the suffix is
+    /// uncommitted, the idle relay must deliver the suffix EXACTLY ONCE in the
+    /// SAME pass — it must NOT bounce to a next tick that re-classifies the
+    /// init-less suffix as a "non-init active-session payload" and DROPS it.
+    ///
+    /// Unlike `offset_authority_handles_partial_and_batch_overlaps` (which only
+    /// exercised a re-implemented `idle_decision` enum), this drives the REAL
+    /// loop decision function `idle_relay_range_action` — the exact code the
+    /// loop body runs — so it asserts the actual classification→dedup ORDERING.
+    #[test]
+    fn idle_relay_delivers_suffix_when_init_is_in_committed_prefix() {
+        // A wake turn whose JSONL is: an `init` line (the prefix the watcher
+        // already relayed) followed by the assistant body (the uncommitted
+        // suffix the user still needs to see).
+        let init_line = "{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"s1\"}\n";
+        let body_line = "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"the trailing answer\"}]}}\n";
+        let init_bytes = init_line.len() as u64;
+        let full = format!("{init_line}{body_line}");
+        let full_bytes = full.as_bytes();
+        let start = 0u64;
+        let end = full_bytes.len() as u64;
+        // The watcher already committed the init-line prefix; the file grew to
+        // include the body before this idle poll → PARTIAL overlap.
+        let committed = init_bytes;
+        assert!(
+            start < committed && committed < end,
+            "test sets up a partial overlap"
+        );
+
+        // REAL loop decision on the WHOLE classified payload: relay only the
+        // uncommitted suffix `[committed, end)` — NOT a re-classify-and-drop.
+        let action = idle_relay_range_action(full_bytes, start, end, committed, false);
+        assert_eq!(
+            action,
+            super::IdleRelayRangeAction::SendSuffixFrom(committed),
+            "the loop must deliver the uncommitted suffix in the same pass (no black-hole)"
+        );
+
+        // The suffix that would be delivered is exactly the body line — the
+        // already-relayed init prefix is skipped (no duplicate), the trailing
+        // answer is sent (no black-hole).
+        let suffix = &full_bytes[committed as usize..end as usize];
+        assert_eq!(
+            suffix,
+            body_line.as_bytes(),
+            "suffix is the uncommitted body, prefix skipped"
+        );
+
+        // REGRESSION WITNESS: the OLD code bounced (`*offset = committed;
+        // continue;`) and re-read JUST this suffix on the next tick. Running the
+        // classification on the init-less suffix proves that path BLACK-HOLES
+        // it: classified as non-init → dropped. The fix avoids the bounce so the
+        // suffix is never re-gated this way.
+        let suffix_only_action = idle_relay_range_action(suffix, 0, suffix.len() as u64, 0, false);
+        assert_eq!(
+            suffix_only_action,
+            super::IdleRelayRangeAction::SkipClassified,
+            "re-gating the init-less suffix as a fresh payload WOULD black-hole it (the old bug)"
+        );
+
+        // Whole range uncommitted → relay the full payload (control case).
+        assert_eq!(
+            idle_relay_range_action(full_bytes, start, end, 0, false),
+            super::IdleRelayRangeAction::SendFull
+        );
+        // Whole range already committed → skip (control case).
+        assert_eq!(
+            idle_relay_range_action(full_bytes, start, end, end, false),
+            super::IdleRelayRangeAction::SkipAlreadyRelayed
+        );
+        // New-session grace still wins over everything (ordering preserved).
+        assert_eq!(
+            idle_relay_range_action(full_bytes, start, end, committed, true),
+            super::IdleRelayRangeAction::SkipClassified
         );
     }
 

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -61,11 +61,13 @@ mod watcher_lifecycle;
 
 use self::tmux_reattach_offsets::matching_recent_watcher_reattach_offset;
 pub(super) use self::tmux_session_files::read_generation_file_mtime_ns;
+pub(in crate::services::discord) use self::tmux_session_files::reset_relay_watermark_on_generation_change;
+pub(in crate::services::discord) use self::tmux_session_files::reset_stale_relay_watermark_if_output_regressed;
 pub(super) use self::tmux_session_files::session_panel_instance_key;
 pub(crate) use self::tmux_session_files::write_spawn_nonce;
 use self::tmux_session_files::{
     preserve_mtime_after_write, reset_stale_local_relay_offset_if_output_regressed,
-    reset_stale_relay_watermark_if_output_regressed, sweep_orphan_session_files,
+    sweep_orphan_session_files,
 };
 use self::watcher_lifecycle::*;
 pub(in crate::services::discord) use self::watcher_lifecycle::{
@@ -1093,10 +1095,39 @@ fn enqueue_monitor_auto_turn_deferred_notification(
 struct MonitorAutoTurnStart {
     acquired: bool,
     deferred: bool,
+    /// The synthetic mailbox message id this monitor turn started under
+    /// (`data_start_offset.max(1)`), `Some` only when `acquired`. #3016 P1:
+    /// the finalizer keys its ledger on this so SEQUENTIAL monitor turns in the
+    /// same channel within `FINALIZED_TTL` are DISTINCT entries — a finalized
+    /// monitor turn must not make the next one resolve to `AlreadyFinalized`
+    /// (which would strand its mailbox token + counter).
+    synthetic_message_id: Option<MessageId>,
+    /// #3016 P1 (codex r3): a PROCESS-MONOTONIC ledger generation for this
+    /// monitor turn, `Some` only when `acquired`. The synthetic mailbox message
+    /// id is derived from the JSONL byte offset, which REPEATS after a wrapper
+    /// respawn / JSONL truncation while `current_generation` stays the same — so
+    /// two monitor turns at the same offset within `FINALIZED_TTL` would share a
+    /// finalizer ledger key and the second would resolve to `AlreadyFinalized`,
+    /// stranding its mailbox token + counter. Keying the ledger generation on
+    /// this never-repeating counter makes every monitor turn a DISTINCT entry.
+    /// (It is used ONLY for ledger keying; `do_finalize`'s identity-guarded
+    /// mailbox finish matches on `channel_id` + `synthetic_message_id`, not the
+    /// generation, so this does not affect which mailbox token is released.)
+    ledger_generation: Option<u64>,
 }
 
 const MONITOR_AUTO_TURN_MISSED_SIGNAL_FALLBACK: tokio::time::Duration =
     tokio::time::Duration::from_secs(30);
+
+/// Process-monotonic counter for monitor-auto-turn finalizer ledger
+/// generations (#3016 P1). Starts high to avoid colliding with the
+/// `current_generation` (dcserver restart) namespace used by ordinary turns.
+static MONITOR_AUTO_TURN_LEDGER_GENERATION: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(1 << 48);
+
+fn next_monitor_auto_turn_ledger_generation() -> u64 {
+    MONITOR_AUTO_TURN_LEDGER_GENERATION.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
 
 async fn start_monitor_auto_turn_when_available(
     shared: &SharedData,
@@ -1113,6 +1144,8 @@ async fn start_monitor_auto_turn_when_available(
             return MonitorAutoTurnStart {
                 acquired: false,
                 deferred,
+                synthetic_message_id: None,
+                ledger_generation: None,
             };
         }
 
@@ -1130,9 +1163,26 @@ async fn start_monitor_auto_turn_when_available(
             shared
                 .turn_start_times
                 .insert(channel_id, std::time::Instant::now());
+            // #3016 P1: register the monitor turn in the finalizer ledger under
+            // its synthetic message id keyed by a PROCESS-MONOTONIC ledger
+            // generation (the byte-offset-derived synthetic id repeats after a
+            // wrapper respawn, so the generation is what guarantees distinct
+            // entries for sequential monitor turns — see `MonitorAutoTurnStart`).
+            let ledger_generation = next_monitor_auto_turn_ledger_generation();
+            shared.turn_finalizer.register_start(
+                super::turn_finalizer::TurnKey::new(
+                    channel_id,
+                    synthetic_message_id.get(),
+                    ledger_generation,
+                ),
+                provider.clone(),
+                crate::services::discord::inflight::RelayOwnerKind::Watcher,
+            );
             return MonitorAutoTurnStart {
                 acquired: true,
                 deferred,
+                synthetic_message_id: Some(synthetic_message_id),
+                ledger_generation: Some(ledger_generation),
             };
         }
 
@@ -1165,25 +1215,38 @@ async fn finish_monitor_auto_turn(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
     channel_id: ChannelId,
+    synthetic_message_id: Option<MessageId>,
+    ledger_generation: Option<u64>,
 ) {
-    let finish = super::mailbox_finish_turn(shared, provider, channel_id).await;
-    if let Some(token) = finish.removed_token {
-        token
-            .cancelled
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-        super::saturating_decrement_global_active(shared);
-    }
+    // #3016 phase 4: route the monitor-auto-turn terminal through the
+    // single-authority finalizer instead of calling mailbox_finish_turn +
+    // counter + kickoff inline. The monitor turn was `register_start`'d under
+    // its synthetic message id keyed by a PROCESS-MONOTONIC ledger generation,
+    // so we finalize under THAT exact key — keeping sequential monitor turns in
+    // the same channel within `FINALIZED_TTL` as DISTINCT ledger entries even
+    // when the byte-offset-derived synthetic id repeats after a wrapper respawn
+    // (codex P1: a colliding key would make the second monitor turn resolve to
+    // `AlreadyFinalized` and strand its mailbox token + counter). `do_finalize`
+    // takes the identity-guarded `mailbox_finish_turn_if_matches` path for the
+    // real id (generation is ledger-keying only). The ledger phase gate makes a
+    // racing watcher/bridge terminal exactly-once safe. `FinalizeContext::monitor`
+    // reproduces the inline side-effect set: no inflight clear, no
+    // completion-cleanup, no voice drain, but kick off any queued backlog.
+    let user_msg_id = synthetic_message_id.map(|id| id.get()).unwrap_or(0);
+    let generation = ledger_generation.unwrap_or(shared.current_generation);
+    let _ = shared
+        .turn_finalizer
+        .submit_terminal(
+            super::turn_finalizer::TurnKey::new(channel_id, user_msg_id, generation),
+            provider.clone(),
+            super::turn_finalizer::TerminalEvent::Complete,
+            super::turn_finalizer::FinalizeContext::monitor(),
+            shared.clone(),
+        )
+        .await;
     shared.turn_start_times.remove(&channel_id);
     if let Ok(mut last) = shared.last_turn_at.lock() {
         *last = Some(chrono::Local::now().to_rfc3339());
-    }
-    if finish.has_pending {
-        super::schedule_deferred_idle_queue_kickoff(
-            shared.clone(),
-            provider.clone(),
-            channel_id,
-            "monitor auto-turn completed with queued backlog",
-        );
     }
 }
 
@@ -1193,11 +1256,22 @@ async fn finish_monitor_auto_turn_if_claimed(
     channel_id: ChannelId,
     claimed: &mut bool,
     finished: &mut bool,
+    synthetic_message_id: &mut Option<MessageId>,
+    ledger_generation: &mut Option<u64>,
 ) {
     if *claimed {
-        finish_monitor_auto_turn(shared, provider, channel_id).await;
+        finish_monitor_auto_turn(
+            shared,
+            provider,
+            channel_id,
+            *synthetic_message_id,
+            *ledger_generation,
+        )
+        .await;
         *claimed = false;
         *finished = true;
+        *synthetic_message_id = None;
+        *ledger_generation = None;
     }
 }
 

--- a/src/services/discord/tmux_session_files.rs
+++ b/src/services/discord/tmux_session_files.rs
@@ -217,7 +217,73 @@ pub(super) fn watermark_after_output_regression(
     if same_wrapper { observed_output_end } else { 0 }
 }
 
-pub(super) fn reset_stale_relay_watermark_if_output_regressed(
+/// Reset the shared relay watermark when the `.generation` mtime has CHANGED
+/// since the watermark was committed (#3016 #3017 codex r6/r7). This is the
+/// "different wrapper → reset to 0" case that
+/// `reset_stale_relay_watermark_if_output_regressed` MISSES: that helper only
+/// resets when the current EOF is LOWER than the stored watermark, but a
+/// respawned same-named wrapper whose fresh JSONL has already grown PAST the
+/// previous wrapper's watermark never trips the EOF-regression check. Both the
+/// tmux watcher and the idle-JSONL relay call this before consulting the
+/// committed offset for the no-inflight dedup, so a fresh wake/background result
+/// whose consumed end is below the stale watermark is not wrongly suppressed.
+///
+/// Returns `true` when it reset the watermark. No-op (returns `false`) when the
+/// wrapper identity is unchanged, the watermark is already 0, or either
+/// `.generation` mtime is unavailable (0) — in which case the EOF-regression
+/// path remains the authority.
+pub(in crate::services::discord) fn reset_relay_watermark_on_generation_change(
+    shared: &SharedData,
+    channel_id: ChannelId,
+    tmux_session_name: &str,
+    context: &str,
+) -> bool {
+    let relay_coord = shared.tmux_relay_coord(channel_id);
+    let stored_gen_mtime_ns = relay_coord
+        .confirmed_end_generation_mtime_ns
+        .load(std::sync::atomic::Ordering::Acquire);
+    let current_gen_mtime_ns = read_generation_file_mtime_ns(tmux_session_name);
+    let different_wrapper = stored_gen_mtime_ns != 0
+        && current_gen_mtime_ns != 0
+        && stored_gen_mtime_ns != current_gen_mtime_ns;
+    if !different_wrapper {
+        return false;
+    }
+    let watermark = relay_coord
+        .confirmed_end_offset
+        .load(std::sync::atomic::Ordering::Acquire);
+    if watermark == 0 {
+        return false;
+    }
+    if relay_coord
+        .confirmed_end_offset
+        .compare_exchange(
+            watermark,
+            0,
+            std::sync::atomic::Ordering::AcqRel,
+            std::sync::atomic::Ordering::Acquire,
+        )
+        .is_ok()
+    {
+        relay_coord
+            .confirmed_end_generation_mtime_ns
+            .store(current_gen_mtime_ns, std::sync::atomic::Ordering::Release);
+        let ts = chrono::Local::now().format("%H:%M:%S");
+        tracing::warn!(
+            "  [{ts}] 👁 Reset relay watermark on wrapper generation change for {} (channel {}, context={}, stale_watermark={}, stored_gen_mtime={}, current_gen_mtime={})",
+            tmux_session_name,
+            channel_id.get(),
+            context,
+            watermark,
+            stored_gen_mtime_ns,
+            current_gen_mtime_ns
+        );
+        return true;
+    }
+    false
+}
+
+pub(in crate::services::discord) fn reset_stale_relay_watermark_if_output_regressed(
     shared: &SharedData,
     channel_id: ChannelId,
     tmux_session_name: &str,

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -4180,6 +4180,13 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         let mut monitor_auto_turn_claimed = false;
         let mut monitor_auto_turn_deferred = false;
         let mut monitor_auto_turn_finished = false;
+        // #3016 P1: the synthetic mailbox message id + process-monotonic ledger
+        // generation the active monitor turn started under, threaded to
+        // `finish_monitor_auto_turn_if_claimed` so it finalizes the EXACT monitor
+        // turn (distinct ledger entries for sequential monitor turns even when
+        // the byte-offset-derived synthetic id repeats after a wrapper respawn).
+        let mut monitor_auto_turn_synthetic_msg_id: Option<MessageId> = None;
+        let mut monitor_auto_turn_ledger_generation: Option<u64> = None;
         // #1009: 1-shot tracker for the monitor-auto-turn preamble hint so the
         // hint text is emitted exactly once per watcher turn frame.
         let mut monitor_auto_turn_preamble_injected = false;
@@ -4254,6 +4261,10 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             .await;
             monitor_auto_turn_claimed = start.acquired;
             monitor_auto_turn_deferred = monitor_auto_turn_deferred || start.deferred;
+            if start.acquired {
+                monitor_auto_turn_synthetic_msg_id = start.synthetic_message_id;
+                monitor_auto_turn_ledger_generation = start.ledger_generation;
+            }
             if !start.acquired {
                 all_data.clear();
                 all_data_start_offset = current_offset;
@@ -4465,6 +4476,10 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                                 monitor_auto_turn_claimed = start.acquired;
                                 monitor_auto_turn_deferred =
                                     monitor_auto_turn_deferred || start.deferred;
+                                if start.acquired {
+                                    monitor_auto_turn_synthetic_msg_id = start.synthetic_message_id;
+                                    monitor_auto_turn_ledger_generation = start.ledger_generation;
+                                }
                                 if !start.acquired {
                                     was_paused = true;
                                     break;
@@ -5449,6 +5464,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         channel_id,
                         &mut monitor_auto_turn_claimed,
                         &mut monitor_auto_turn_finished,
+                        &mut monitor_auto_turn_synthetic_msg_id,
+                        &mut monitor_auto_turn_ledger_generation,
                     )
                     .await;
                     continue;
@@ -5585,6 +5602,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                     channel_id,
                     &mut monitor_auto_turn_claimed,
                     &mut monitor_auto_turn_finished,
+                    &mut monitor_auto_turn_synthetic_msg_id,
+                    &mut monitor_auto_turn_ledger_generation,
                 )
                 .await;
                 continue;
@@ -5639,6 +5658,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         channel_id,
                         &mut monitor_auto_turn_claimed,
                         &mut monitor_auto_turn_finished,
+                        &mut monitor_auto_turn_synthetic_msg_id,
+                        &mut monitor_auto_turn_ledger_generation,
                     )
                     .await;
                     continue;
@@ -5737,6 +5758,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                     channel_id,
                     &mut monitor_auto_turn_claimed,
                     &mut monitor_auto_turn_finished,
+                    &mut monitor_auto_turn_synthetic_msg_id,
+                    &mut monitor_auto_turn_ledger_generation,
                 )
                 .await;
                 continue;
@@ -5774,6 +5797,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 channel_id,
                 &mut monitor_auto_turn_claimed,
                 &mut monitor_auto_turn_finished,
+                &mut monitor_auto_turn_synthetic_msg_id,
+                &mut monitor_auto_turn_ledger_generation,
             )
             .await;
             all_data.clear();
@@ -5836,6 +5861,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 channel_id,
                 &mut monitor_auto_turn_claimed,
                 &mut monitor_auto_turn_finished,
+                &mut monitor_auto_turn_synthetic_msg_id,
+                &mut monitor_auto_turn_ledger_generation,
             )
             .await;
             continue;
@@ -5924,6 +5951,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                     channel_id,
                     &mut monitor_auto_turn_claimed,
                     &mut monitor_auto_turn_finished,
+                    &mut monitor_auto_turn_synthetic_msg_id,
+                    &mut monitor_auto_turn_ledger_generation,
                 )
                 .await;
                 continue;
@@ -5975,6 +6004,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 channel_id,
                 &mut monitor_auto_turn_claimed,
                 &mut monitor_auto_turn_finished,
+                &mut monitor_auto_turn_synthetic_msg_id,
+                &mut monitor_auto_turn_ledger_generation,
             )
             .await;
             continue;
@@ -6087,6 +6118,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                     channel_id,
                     &mut monitor_auto_turn_claimed,
                     &mut monitor_auto_turn_finished,
+                    &mut monitor_auto_turn_synthetic_msg_id,
+                    &mut monitor_auto_turn_ledger_generation,
                 )
                 .await;
                 continue;
@@ -6177,6 +6210,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 channel_id,
                 &mut monitor_auto_turn_claimed,
                 &mut monitor_auto_turn_finished,
+                &mut monitor_auto_turn_synthetic_msg_id,
+                &mut monitor_auto_turn_ledger_generation,
             )
             .await;
             continue;
@@ -6220,6 +6255,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 channel_id,
                 &mut monitor_auto_turn_claimed,
                 &mut monitor_auto_turn_finished,
+                &mut monitor_auto_turn_synthetic_msg_id,
+                &mut monitor_auto_turn_ledger_generation,
             )
             .await;
             discard_watcher_pending_buffer_after_suppressed_turn(
@@ -6286,6 +6323,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 channel_id,
                 &mut monitor_auto_turn_claimed,
                 &mut monitor_auto_turn_finished,
+                &mut monitor_auto_turn_synthetic_msg_id,
+                &mut monitor_auto_turn_ledger_generation,
             )
             .await;
             discard_watcher_pending_buffer_after_suppressed_turn(
@@ -6346,6 +6385,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                     channel_id,
                     &mut monitor_auto_turn_claimed,
                     &mut monitor_auto_turn_finished,
+                    &mut monitor_auto_turn_synthetic_msg_id,
+                    &mut monitor_auto_turn_ledger_generation,
                 )
                 .await;
                 discard_watcher_pending_buffer_after_suppressed_turn(
@@ -6644,6 +6685,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 channel_id,
                 &mut monitor_auto_turn_claimed,
                 &mut monitor_auto_turn_finished,
+                &mut monitor_auto_turn_synthetic_msg_id,
+                &mut monitor_auto_turn_ledger_generation,
             )
             .await;
             continue;
@@ -6712,9 +6755,105 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 channel_id,
                 &mut monitor_auto_turn_claimed,
                 &mut monitor_auto_turn_finished,
+                &mut monitor_auto_turn_synthetic_msg_id,
+                &mut monitor_auto_turn_ledger_generation,
             )
             .await;
             continue;
+        }
+
+        // #3017 single output-offset authority — cross-actor relay dedup for
+        // the inflight-less wake / idle-background / monitor turn (E-13). When
+        // there is NO inflight, the idle-JSONL relay
+        // (`session_relay_sink::run_idle_jsonl_relay_loop`) reads the SAME
+        // JSONL and can relay this exact range. If it already committed the
+        // authoritative relayed offset at/past this turn's END, that range was
+        // already delivered to Discord — so the watcher must SKIP to avoid the
+        // duplicate `[E2E:E13:WAKE]`. This is deliberately gated on
+        // `inflight_missing_before_relay`: a normal Discord-origin turn
+        // (inflight present) keeps the watcher as the sole relay owner and is
+        // NEVER suppressed by the shared watermark (the long-standing
+        // invariant), so this only de-duplicates the un-owned wake/idle paths.
+        if inflight_missing_before_relay
+            && has_current_response
+            && current_offset > turn_data_start_offset
+        {
+            // Codex P1: a stale-high `confirmed_end_offset` left by a PREVIOUS
+            // wrapper (before any actor ran the regression reset) would make a
+            // FRESH wake/idle response with a lower `current_offset` look already
+            // delivered and get dropped. Run the SAME generation-aware
+            // regression reset BEFORE reading the watermark (a truncated /
+            // respawned JSONL resets it to 0 for a fresh wrapper), exactly as
+            // the idle relay path does. The unconditional pre-relay reset below
+            // at `pre_relay` is for the general path; this one guards the
+            // no-inflight dedup read specifically.
+            if let Ok(meta) = std::fs::metadata(&output_path) {
+                reset_stale_relay_watermark_if_output_regressed(
+                    &shared,
+                    channel_id,
+                    &tmux_session_name,
+                    meta.len(),
+                    "no_inflight_dedup",
+                );
+            }
+            // Codex r6 P2: `reset_stale_relay_watermark_if_output_regressed` only
+            // resets when the current EOF is LOWER than the stored watermark. A
+            // respawned same-named wrapper whose fresh JSONL has ALREADY grown
+            // PAST the previous wrapper's watermark would NOT trip that
+            // EOF-regression check, so a fresh no-inflight result whose consumed
+            // end is below the stale watermark would be wrongly suppressed.
+            // Independently reset the watermark when the `.generation` mtime has
+            // CHANGED since the watermark was committed (a fresh wrapper names a
+            // different byte stream). Shared with the idle relay path.
+            reset_relay_watermark_on_generation_change(
+                &shared,
+                channel_id,
+                &tmux_session_name,
+                "watcher_no_inflight_dedup",
+            );
+            // Read-only check against the authority. If the sink (fed by the
+            // idle-JSONL relay or the watcher's own session-bound delegation)
+            // already COMMITTED at/past this turn's END, that range was already
+            // delivered — the watcher skips to avoid the duplicate. The watcher
+            // does NOT claim here (a claim followed by a relay failure would mark
+            // the range delivered while dropping it); it advances the authority
+            // only on a CONFIRMED relay at `advance_watcher_confirmed_end` below.
+            //
+            // Codex r5 P2: compare against this TURN's consumed terminal end, NOT
+            // the whole read batch end (`current_offset`). A batch can contain a
+            // completed turn PLUS trailing JSONL for a later turn —
+            // `process_watcher_lines` stops at the first result, so the turn's
+            // output actually ends at `current_offset - all_data.len()` (the
+            // unprocessed tail), which is exactly what the normal commit path
+            // advances to (`runtime_binding_candidate_offset`). Comparing against
+            // `current_offset` would MISS a prior commit at that smaller consumed
+            // end and re-relay the already-committed terminal.
+            let turn_consumed_offset = terminal_event_consumed_offset(current_offset, &all_data);
+            let committed = shared.committed_relay_offset(channel_id);
+            if committed >= turn_consumed_offset && turn_consumed_offset > turn_data_start_offset {
+                let ts = chrono::Local::now().format("%H:%M:%S");
+                tracing::info!(
+                    "  [{ts}] 👁 watcher: suppressed no-inflight terminal relay for channel {} — range {}..{} already committed by another relay actor (offset authority, committed_end={})",
+                    channel_id.get(),
+                    turn_data_start_offset,
+                    turn_consumed_offset,
+                    committed
+                );
+                last_relayed_offset = Some(current_offset);
+                last_observed_generation_mtime_ns =
+                    Some(read_generation_file_mtime_ns(&tmux_session_name));
+                finish_monitor_auto_turn_if_claimed(
+                    &shared,
+                    &watcher_provider,
+                    channel_id,
+                    &mut monitor_auto_turn_claimed,
+                    &mut monitor_auto_turn_finished,
+                    &mut monitor_auto_turn_synthetic_msg_id,
+                    &mut monitor_auto_turn_ledger_generation,
+                )
+                .await;
+                continue;
+            }
         }
 
         // Relay coordination is limited to serialization plus telemetry. The
@@ -6770,6 +6909,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 channel_id,
                 &mut monitor_auto_turn_claimed,
                 &mut monitor_auto_turn_finished,
+                &mut monitor_auto_turn_synthetic_msg_id,
+                &mut monitor_auto_turn_ledger_generation,
             )
             .await;
             continue;
@@ -7836,6 +7977,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             channel_id,
             &mut monitor_auto_turn_claimed,
             &mut monitor_auto_turn_finished,
+            &mut monitor_auto_turn_synthetic_msg_id,
+            &mut monitor_auto_turn_ledger_generation,
         )
         .await;
 

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -264,6 +264,22 @@ impl FinalizeContext {
         }
     }
 
+    /// Monitor-auto-turn / recovery terminal (#3016 phase 4): the caller owns
+    /// the inflight clear (or there is none — synthetic monitor turn / recovery
+    /// already cleared it), does NOT mark completion-cleanup, does NOT drain
+    /// voice, but DOES kick off any queued backlog (the pre-#3016
+    /// `finish_monitor_auto_turn` / `finish_recovered_turn_mailbox` both
+    /// scheduled the deferred idle-queue kickoff on `has_pending`). This is
+    /// `watcher()` plus the queue kickoff.
+    pub(in crate::services::discord) fn monitor() -> Self {
+        Self {
+            clear_inflight: false,
+            allow_completion_cleanup: false,
+            drain_voice: false,
+            kickoff_queue: true,
+        }
+    }
+
     /// Deadline-armed gate-timeout backstop, fired from the reconciler with no
     /// caller to have cleared inflight: finalize fully (clear inflight here),
     /// no completion-cleanup or voice drain (watcher semantics), kick off the


### PR DESCRIPTION
## Summary

Re-lands the **net effect** of the 9 commits on `agentdesk/epic3016-phase4` (EPIC #3016 phase 4 — #3017 "offset/watermark single authority") that were never merged. #3080 already brought `confirmed_end_offset` + `advance_watcher_confirmed_end` to main; this PR completes #3017 with the relay-dedup hardening and the read-only offset accessor that follow-up **#3041** depends on. **No merge intended** — review only.

## Re-landed commits (oldest → newest)

| commit | summary |
|--------|---------|
| `ea2853164` | route standby/monitor/recovery relay through finalizer offset authority — dedup wake relay |
| `1aea85935` | commit idle offset only after forward + preserve generation mtime |
| `efe52f106` | unique monitor turn key + read-only idle dedup + stale-watermark reset |
| `21df2cdfe` | make offset authority read-only for secondary paths |
| `4b6e66e9f` | close round-3 dedup gaps — sink commits offset, monotonic monitor key, watcher reset |
| `5be680aea` | drop sink offset commit to avoid marking undelivered bytes |
| `0b7ea665f` | dedup partial/batch range overlaps in offset authority |
| `b3369f483` | reset relay watermark on wrapper generation change in no-inflight dedup |
| `91d94df1e` | share generation-change watermark reset with idle relay |

## How it was re-landed

The per-commit `git cherry-pick ea2853164^..91d94df1e` was **intractable**: every phase4 commit carried a giant `#[cfg(all(test, feature = "legacy-sqlite-tests"))] mod tests` block that **#3035 removed from main** (the `legacy-sqlite-tests` feature no longer exists in `Cargo.toml`; `tmux.rs` on main has 0 references vs 9 on phase4). That produced a ~3,900-line interleaved test conflict in `tmux.rs`.

Resolution: applied the **consolidated net diff** (`ea2853164^..91d94df1e`), separating production code (applied faithfully) from the dead legacy-sqlite test churn (dropped — it would never compile on main).

- **Production hunks** applied by hand for `mod.rs`, `recovery_engine.rs`, `tmux_session_files.rs`, `turn_finalizer.rs`, `tmux.rs`.
- **`tmux_watcher.rs`** (heavily restructured by #3141, ~1,600-line drift) applied via `git apply --3way` — reconciled **cleanly, no conflicts**.
- The two **non-legacy** dedup unit tests (`offset_authority_relays_wake_range_exactly_once`, `offset_authority_handles_partial_and_batch_overlaps`) were ported into `session_relay_sink.rs`'s plain `mod tests` (they exercise `committed_relay_offset` directly).

## Already on main via #3080

`TmuxRelayCoord::confirmed_end_offset`, `confirmed_end_generation_mtime_ns`, and the watcher committer `advance_watcher_confirmed_end` were already present — early phase4 hunks that re-introduced them were skipped as redundant; this PR adds the **consumers** + the read-only accessor on top.

## New / changed APIs

- `SharedData::committed_relay_offset(channel) -> u64` — read-only consumer of the single output-offset authority. The tmux watcher stays the **sole committer**.
- `FinalizeContext::monitor()` — watcher semantics + queue kickoff; routes the **monitor-auto-turn** and **recovery** terminals through the single-authority finalizer (replacing inline `mailbox_finish_turn`).
- monitor-auto-turn `register_start`s under its synthetic message id keyed by a **process-monotonic ledger generation** so sequential monitor turns are distinct ledger entries (byte-offset-derived synthetic ids repeat after a wrapper respawn → would otherwise strand a token + counter).
- `reset_relay_watermark_on_generation_change` — resets the shared watermark on `.generation` mtime change (the case the EOF-regression reset misses); shared by the watcher no-inflight gate and the idle-JSONL relay.
- idle-JSONL relay (`run_idle_jsonl_relay_loop`) + watcher no-inflight terminal now **consult** `committed_relay_offset` (with generation-aware resets) to de-dup an inflight-less wake/idle range against the primary relay (E-13), with partial-overlap prefix trimming and consumed-end (not batch-end) comparison. Secondary paths **never claim** the authority (claiming on a failed forward could black-hole the response).

## Codex review follow-ups (this branch)

A strict codex review raised two findings:

**Issue 1 (FIXED) — partial-overlap trim could black-hole the suffix.** In `run_idle_jsonl_relay_loop`, the PARTIAL-overlap dedup branch (`start < committed < end`) used to advance `*offset = committed` and `continue`, re-reading only the suffix `[committed, end)` on the **next** tick. But the next tick re-ran the init/classification gate against that suffix — and the `system/init` event lived in the already-committed **prefix**, so the init-less suffix was classified as a "non-init active-session payload" and **dropped** → the user never saw the trailing part of the response (black-hole). The fix delivers the uncommitted suffix in the **same** pass, carrying forward the classification already established for the whole turn: prefix-skip, suffix-send, exactly once, no re-gating. The classification→dedup ordering is extracted into a single `idle_relay_range_action` decision function that the loop body now calls, and a new loop-ordering test (`idle_relay_delivers_suffix_when_init_is_in_committed_prefix`) drives that real decision — asserting the suffix is delivered (`SendSuffixFrom`) and witnessing that re-gating the init-less suffix alone *would* drop it (`SkipClassified`).

**Issue 2 (DOCUMENTED, deferred to #3041) — sink-wins-first is not yet exact-once.** `SessionBoundDiscordRelaySink` deliberately does **not** advance the offset authority after a committed Discord delivery (the only offset available there is the JSONL EOF, which may include bytes appended after the frame was read → committing it would black-hole appended output, codex r4 P1; and `StreamFrame` carries no exact byte-range end). So if the idle/sink path posts **before** the watcher commits, `confirmed_end_offset` stays stale and the watcher's later no-inflight gate cannot suppress its own delivery → a **residual duplicate window** (the 10s recent-inflight grace reduces but does not eliminate it). This is **not a regression** introduced by the re-land — phase4 faithfully has this same gap, and the read-only consult is a strict improvement over no consult. Closing it requires the sink's delivery to advance the authority **atomically** with the exact relayed range end, which is the **#3041 delivery-lease (commit-with-offset)** work — intentionally out of scope here to avoid the black-hole. A code comment at the sink no-advance site documents this and references #3041.

**Honesty note:** phase4 **reduces** duplicate/black-hole relay via the read-only consult; it does **not** by itself achieve full exact-once for the sink-wins-first window. That final gap is closed by **#3041**.

## Reconciliation with #3141

#3141 (just merged) reworked `tmux_watcher.rs` / `turn_finalizer.rs` finalize paths. The no-inflight dedup gate was placed **after** #3141's cancel-tombstone terminal arm and **before** the general relay-coordination block, leaving #3141's wrong-turn-finalize guards untouched. The shared `FinalizeContext` struct (4 fields) and `submit_terminal` / `register_start` signatures matched exactly, so `monitor()` slotted in without weakening any guard.

## Verification (macOS, all green)

- `cargo fmt --check` — pass
- `cargo build --all-targets` — **0 errors**
- `cargo clippy --workspace --all-targets --all-features` — **0 new warnings** (warning set byte-identical to `origin/main` baseline)
- `cargo test … turn_finalizer::` — **26 passed** (#3141 exactly-once matrix stays green)
- relay **199** · offset **45** · dedup **93** · idle **88** — all 0 failed
- `idle_relay_delivers_suffix_when_init_is_in_committed_prefix` (new loop-ordering test for the codex Issue 1 fix) — **1 passed**
- `offset_authority_*` (the `committed_relay_offset` accessor + partial-overlap tests) — pass
- `scripts/check_agent_maintenance_docs.py` — pass (synced freeze line-counts: tmux.rs 2154→2228, tmux_watcher.rs 7662→7805, recovery_engine.rs 4033→4037; registered `session_relay_sink.rs` as a new giant-file `[[entry]]` since the dedup gate pushed it past 1000 prod LoC)
- `scripts/ci-script-checks.sh` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

