### PR TITLE
feat(#3041): P1-1 wire watcher terminal delivery through delivery-lease (commit advances confirmed_end; B2 single-holder)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -116,13 +116,17 @@
   - `src/services/discord/watchers/lifecycle.rs` (2301 lines — canonical
     lifecycle extraction surface from #1435; split further before adding new
     lifecycle behavior).
-  - `src/services/discord/tmux.rs` (2228 lines after #2558 dead-code sweep;
+  - `src/services/discord/tmux.rs` (2238 lines after #2558 dead-code sweep;
     failover guard; #3087 `session_panel_instance_key`/`write_spawn_nonce`
     re-exports; #3107 `RestoredWatcherTurn.injected_prompt_message_id`;
     #3016 option A `normal_completion` finalize-decouple param;
     #3017 monitor-auto-turn finalizer routing + ledger-generation +
-    relay-watermark reset re-exports; still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (7805 lines after #2558
+    relay-watermark reset re-exports; +10 from #3041 P1-1 making
+    `advance_watcher_confirmed_end` `pub(in crate::services::discord)` +
+    doc-comment so the finalizer actor's `CommitDelivery` handler drives the
+    SAME monotonic-CAS offset advance on a `Delivered` lease commit;
+    still giant-file territory).
+  - `src/services/discord/tmux_watcher.rs` (7981 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -148,6 +152,13 @@
     + generation-aware watermark resets, suppresses a wake/idle terminal already
     committed by another relay actor) and the monitor-auto-turn synthetic-id /
     ledger-generation threading through `finish_monitor_auto_turn_if_claimed`;
+    +176 from #3041 P1-1 wiring the WATCHER terminal delivery through the live
+    `DeliveryLeaseCell`: a per-spawn `instance_id`, the B3 acquire-deadline
+    constant + rationale, the pre-send `try_acquire` on the turn-pinned identity,
+    the B2 single-holder skip arm (a replacement watcher must not re-emit a held
+    range), and replacing the inline `advance_watcher_confirmed_end` for the
+    watcher terminal path with the actor `commit_delivery`(advances offset on
+    `Delivered`)+`release_delivery` lifecycle;
     split loop helpers further before adding behavior).
   - `src/services/discord/tui_prompt_relay.rs` (3849 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -116,17 +116,19 @@
   - `src/services/discord/watchers/lifecycle.rs` (2301 lines — canonical
     lifecycle extraction surface from #1435; split further before adding new
     lifecycle behavior).
-  - `src/services/discord/tmux.rs` (2238 lines after #2558 dead-code sweep;
+  - `src/services/discord/tmux.rs` (2241 lines after #2558 dead-code sweep;
     failover guard; #3087 `session_panel_instance_key`/`write_spawn_nonce`
     re-exports; #3107 `RestoredWatcherTurn.injected_prompt_message_id`;
     #3016 option A `normal_completion` finalize-decouple param;
     #3017 monitor-auto-turn finalizer routing + ledger-generation +
     relay-watermark reset re-exports; +10 from #3041 P1-1 making
     `advance_watcher_confirmed_end` `pub(in crate::services::discord)` +
-    doc-comment so the finalizer actor's `CommitDelivery` handler drives the
-    SAME monotonic-CAS offset advance on a `Delivered` lease commit;
+    doc-comment — the watcher commits the delivery lease and advances this
+    monotonic-CAS offset INLINE (synchronously) on a `Delivered` outcome; the
+    finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
+    (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (7981 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (8166 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -152,13 +154,18 @@
     + generation-aware watermark resets, suppresses a wake/idle terminal already
     committed by another relay actor) and the monitor-auto-turn synthetic-id /
     ledger-generation threading through `finish_monitor_auto_turn_if_claimed`;
-    +176 from #3041 P1-1 wiring the WATCHER terminal delivery through the live
+    +185 from #3041 P1-1 wiring the WATCHER terminal delivery through the live
     `DeliveryLeaseCell`: a per-spawn `instance_id`, the B3 acquire-deadline
     constant + rationale, the pre-send `try_acquire` on the turn-pinned identity,
     the B2 single-holder skip arm (a replacement watcher must not re-emit a held
-    range), and replacing the inline `advance_watcher_confirmed_end` for the
-    watcher terminal path with the actor `commit_delivery`(advances offset on
-    `Delivered`)+`release_delivery` lifecycle;
+    range), and committing the lease + advancing `advance_watcher_confirmed_end`
+    for the watcher terminal path INLINE (synchronously; the actor
+    `commit_delivery`/`release_delivery` round-trip was reverted in R2 — those
+    actor handlers are DORMANT, retained for a later phase); plus the R2 Issue-1
+    heartbeat: a `DeliveryLeaseHeartbeat` background task `renew()`s the lease
+    every 5s while the send future is in flight (deadline cut to 15s for fast
+    dead-holder recovery), stopped before the inline commit so a long multi-chunk
+    send is never reclaimed mid-flight;
     split loop helpers further before adding behavior).
   - `src/services/discord/tui_prompt_relay.rs` (3849 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -128,7 +128,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (8166 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (8168 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -2001,6 +2001,51 @@ impl DeliveryLeaseCell {
         true
     }
 
+    /// #3041 P1-1 (§3, codex R2 Issue-1): HEARTBEAT renew. While the holder's
+    /// terminal send future is in flight, the holder periodically calls this to
+    /// extend the lease deadline so the (deliberately SHORT) deadline is a
+    /// HOLDER-LIVENESS signal, not a hard cap on delivery duration. If the cell
+    /// is `Leased` by EXACTLY `(holder, turn)` (matched on holder + the turn's
+    /// `exact_key()`), its `deadline_ms` is overwritten with `new_deadline_ms`
+    /// and `true` is returned. ANY other state — a different holder, a stale
+    /// older turn, a `Committed`/`Unleased` cell, or a cell already reclaimed and
+    /// reacquired by someone else — is a no-op returning `false`. The range is
+    /// intentionally NOT matched: a renew only ever needs to prove "this exact
+    /// holder for this exact turn is still alive", and the live holder's range is
+    /// fixed for the lifetime of the lease anyway.
+    ///
+    /// Race-safety (why renew can never extend SOMEONE ELSE's lease): the match
+    /// requires the recorded `holder` AND `turn` to equal the caller's, both
+    /// taken UNDER the same payload mutex as every other mutation. If the cell
+    /// was reclaimed (→ `Unleased`) and reacquired by a replacement, the holder
+    /// or turn will differ and the renew no-ops. A late heartbeat tick that
+    /// fires after the holder already committed sees `Committed` (not `Leased`)
+    /// and no-ops. The ONLY successful renew extends the caller's OWN live lease.
+    pub(in crate::services::discord) fn renew(
+        &self,
+        holder: LeaseHolder,
+        turn: turn_finalizer::TurnKey,
+        new_deadline_ms: u64,
+    ) -> bool {
+        let mut guard = self
+            .payload
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let LeaseState::Leased {
+            holder: cur_holder,
+            turn: cur_turn,
+            deadline_ms,
+            ..
+        } = &mut *guard
+        {
+            if *cur_holder == holder && cur_turn.exact_key() == turn.exact_key() {
+                *deadline_ms = new_deadline_ms;
+                return true;
+            }
+        }
+        false
+    }
+
     /// Deadline reclaim: if the lease is `Leased` and `now_ms >= deadline_ms`,
     /// force it back to `Unleased` regardless of holder (the holder is presumed
     /// dead/stuck). Returns `true` if a reclaim occurred. A `Committed` lease is

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -1622,17 +1622,16 @@ impl TmuxRelayCoord {
 }
 
 // ===========================================================================
-// #3041 §2-§3 P1-0 — Delivery-lease scaffolding (DORMANT).
+// #3041 §2-§3 — Delivery-lease `DeliveryLeaseCell` state machine.
 //
-// This block introduces the `DeliveryLeaseCell` type and its state machine.
-// It is intentionally INERT in P1-0: NOTHING in any existing call path
-// constructs, reads, or mutates a cell yet. The `relay_slot` field above is
-// the current single-winner coordination primitive and is LEFT UNTOUCHED here
-// — its migration onto the lease lands in P1-1. Everything below is a pure
-// addition that later phases (P1-1..P1-5) wire in. Because it is dormant it
-// is necessarily dead code today; that is acknowledged via the targeted
-// `#[allow(dead_code)]` attributes, each tagged with this issue/phase so the
-// follow-up wiring can remove them.
+// As of P1-1 the WATCHER terminal-delivery path wires this LIVE: the watcher
+// acquires the cell before sending, heartbeat-renews it during the send, and
+// commits+advances+releases INLINE. The `relay_slot` field above is LEFT
+// UNTOUCHED for now (its guard migration is a later step). The SINK/BRIDGE
+// committers (P1-2) and the 3-way ACK reconciliation (P1-3) are not wired yet,
+// so the actor `CommitDelivery`/`ReleaseDelivery` messages and some helpers
+// remain dormant — those still carry targeted `#[allow(dead_code)]` attributes
+// tagged with this issue/phase, to be wired/removed by the follow-up phases.
 //
 // Design (faithful to #3041 §2-§3):
 //   lease = (channel_id, turn_identity: TurnKey, byte_range [start,end))

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -1598,16 +1598,25 @@ pub(super) struct TmuxRelayCoord {
     /// written once per spawn and never touched by the live wrapper, so its
     /// mtime survives jsonl rotation but flips on a fresh spawn.
     pub(super) confirmed_end_generation_mtime_ns: Arc<std::sync::atomic::AtomicI64>,
+    /// #3041 P1-1: the LIVE per-channel delivery lease. Added ALONGSIDE
+    /// `relay_slot` (which is NOT removed yet — its guard migration is a later
+    /// step). The watcher acquires this before delivering the terminal response
+    /// and commits it after; the commit is what advances `confirmed_end_offset`
+    /// (replacing the watcher's inline advance). Shared via `Arc` across all
+    /// watcher instances for the channel so a replacement watcher observes a
+    /// live holder's lease and skips the duplicate send (the §5.2 B2 invariant).
+    pub(in crate::services::discord) delivery_lease: Arc<DeliveryLeaseCell>,
 }
 
 impl TmuxRelayCoord {
-    pub(super) fn new() -> Self {
+    pub(super) fn new(channel_id: ChannelId) -> Self {
         Self {
             relay_slot: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             confirmed_end_offset: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             last_relay_ts_ms: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             reconnect_count: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             confirmed_end_generation_mtime_ns: Arc::new(std::sync::atomic::AtomicI64::new(0)),
+            delivery_lease: Arc::new(DeliveryLeaseCell::new(channel_id)),
         }
     }
 }
@@ -1708,6 +1717,22 @@ enum LeaseState {
         end: u64,
         outcome: LeaseOutcome,
     },
+}
+
+/// #3041 P1-1: process-monotonic millisecond clock for delivery-lease
+/// deadlines. The acquire deadline and the reconciler's `reclaim_if_expired`
+/// MUST read the SAME clock; a wall clock would jump on NTP steps and could
+/// reclaim a live holder or strand a dead one. Anchored to a process-start
+/// `Instant` so it is purely monotonic (never goes backwards). NOTE: this is a
+/// real wall-monotonic clock, not the Tokio test clock; gated-clock tests drive
+/// `reclaim_if_expired` with explicit `now_ms` arguments rather than this fn.
+pub(in crate::services::discord) fn lease_now_ms() -> u64 {
+    use std::sync::OnceLock;
+    static START: OnceLock<std::time::Instant> = OnceLock::new();
+    START
+        .get_or_init(std::time::Instant::now)
+        .elapsed()
+        .as_millis() as u64
 }
 
 /// Internal CAS gate tag for the [`DeliveryLeaseCell`]. The CAS that flips
@@ -2355,8 +2380,40 @@ impl SharedData {
     pub(super) fn tmux_relay_coord(&self, channel_id: ChannelId) -> Arc<TmuxRelayCoord> {
         self.tmux_relay_coords
             .entry(channel_id)
-            .or_insert_with(|| Arc::new(TmuxRelayCoord::new()))
+            .or_insert_with(|| Arc::new(TmuxRelayCoord::new(channel_id)))
             .clone()
+    }
+
+    /// #3041 P1-1: the LIVE per-channel delivery-lease cell, created on first
+    /// access alongside the relay coord. The watcher acquires/commits through
+    /// this to make terminal delivery + offset advance a single-holder unit
+    /// (§5.2). The returned `Arc` is shared across all watcher instances for the
+    /// channel so a replacement watcher sees the live holder and skips the
+    /// duplicate send (B2).
+    pub(in crate::services::discord) fn delivery_lease(
+        &self,
+        channel_id: ChannelId,
+    ) -> Arc<DeliveryLeaseCell> {
+        self.tmux_relay_coord(channel_id).delivery_lease.clone()
+    }
+
+    /// #3041 P1-1 (B3): reclaim any delivery lease whose acquire deadline has
+    /// elapsed, force-returning a dead holder's cell to `Unleased` so a later
+    /// legitimate acquire can win. Identity-agnostic (deadline-only) by design —
+    /// a `Committed` lease is never reclaimed here (it awaits an explicit holder
+    /// release). Driven from the finalizer's reconcile tick. Returns the number
+    /// of cells reclaimed (for observability/tests).
+    pub(in crate::services::discord) fn reclaim_expired_delivery_leases(
+        &self,
+        now_ms: u64,
+    ) -> usize {
+        let mut reclaimed = 0usize;
+        for coord in self.tmux_relay_coords.iter() {
+            if coord.value().delivery_lease.reclaim_if_expired(now_ms) {
+                reclaimed += 1;
+            }
+        }
+        reclaimed
     }
 
     /// #3017 single output-offset authority for the relay-dedup paths — a

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -1339,13 +1339,16 @@ fn ensure_monitor_auto_turn_inflight(
 /// Monotonic-CAS advance of the channel's `confirmed_end_offset` watermark to
 /// `committed_end_offset`, pairing the pre-CAS `.generation` mtime on a real
 /// advance and recording the `tmux_confirmed_end_monotonic` invariant. #3041
-/// P1-1 makes this `pub(in crate::services::discord)` so the `TurnFinalizer`
-/// actor's `CommitDelivery` handler can drive the SAME advance on a `Delivered`
-/// commit — the lease commit, not the watcher's inline call, is now the single
-/// thing that advances the watermark for the watcher terminal path (§5.2). The
-/// monotonic CAS keeps the advance idempotent: a second `Delivered` commit of
-/// an already-confirmed range observes `cur >= committed_end_offset` and does
-/// not move (and does not refresh the mtime), so no double-advance.
+/// P1-1 makes this `pub(in crate::services::discord)`. The watcher commits its
+/// delivery lease and then calls this to advance the watermark INLINE
+/// (synchronously) on a `Delivered` outcome — the lease commit + this inline
+/// advance are the single thing that advances the watermark for the watcher
+/// terminal path (§5.2). (The `TurnFinalizer` actor's `CommitDelivery`/
+/// `ReleaseDelivery` handlers are DORMANT — retained for a later phase, NOT the
+/// live watcher path after the R2 revert.) The monotonic CAS keeps the advance
+/// idempotent: a second `Delivered` commit of an already-confirmed range
+/// observes `cur >= committed_end_offset` and does not move (and does not
+/// refresh the mtime), so no double-advance.
 pub(in crate::services::discord) fn advance_watcher_confirmed_end(
     shared: &SharedData,
     provider: &ProviderKind,

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -1336,7 +1336,17 @@ fn ensure_monitor_auto_turn_inflight(
     }
 }
 
-fn advance_watcher_confirmed_end(
+/// Monotonic-CAS advance of the channel's `confirmed_end_offset` watermark to
+/// `committed_end_offset`, pairing the pre-CAS `.generation` mtime on a real
+/// advance and recording the `tmux_confirmed_end_monotonic` invariant. #3041
+/// P1-1 makes this `pub(in crate::services::discord)` so the `TurnFinalizer`
+/// actor's `CommitDelivery` handler can drive the SAME advance on a `Delivered`
+/// commit — the lease commit, not the watcher's inline call, is now the single
+/// thing that advances the watermark for the watcher terminal path (§5.2). The
+/// monotonic CAS keeps the advance idempotent: a second `Delivered` commit of
+/// an already-confirmed range observes `cur >= committed_end_offset` and does
+/// not move (and does not refresh the mtime), so no double-advance.
+pub(in crate::services::discord) fn advance_watcher_confirmed_end(
     shared: &SharedData,
     provider: &ProviderKind,
     channel_id: ChannelId,

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -13,19 +13,102 @@ fn next_watcher_instance_id() -> u64 {
     WATCHER_INSTANCE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
 }
 
-/// #3041 P1-1 (B3): delivery-lease acquire deadline for the watcher terminal
-/// send. The realistic worst case is NOT a single POST: a long terminal
-/// response is split into multiple Discord messages, each separated by the
-/// long-message inter-chunk pacing wait (`formatting.rs` 500ms), and may be
-/// preceded by a session-bound relay ACK wait (`tmux_watcher.rs` 10s). A very
-/// long answer can be ~20+ chunks; 20 × 500ms = 10s of pacing alone, plus the
-/// 10s ACK wait, plus HTTP/rate-limit slack. We pick 90s — comfortably above a
-/// worst-case multi-chunk rate-limited send — so a live holder is never
-/// reclaimed mid-send, while still bounding a genuinely-dead holder so the
-/// reconciler's `reclaim_if_expired` frees the cell for a legitimate successor.
-/// This is the lease DEADLINE, independent of the finalizer's `GATE_BACKSTOP`
-/// (8s, a different concern: visible-completion gating, not delivery duration).
-const WATCHER_DELIVERY_LEASE_DEADLINE_MS: u64 = 90_000;
+/// #3041 P1-1 (B3, codex R2 Issue-1): delivery-lease acquire deadline for the
+/// watcher terminal send. The deadline is a HOLDER-LIVENESS signal, NOT a hard
+/// cap on delivery duration — while the send future is in flight the watcher
+/// keeps the lease alive with a background HEARTBEAT that `renew()`s the
+/// deadline every `WATCHER_DELIVERY_LEASE_HEARTBEAT_MS` (see below). Because a
+/// LIVE holder always re-extends within one interval, a long multi-chunk send
+/// (which can exceed any FIXED deadline — an unbounded response splits into
+/// 2000-char chunks paced ~500ms apart plus a 1s rate limiter, so 60+ chunks
+/// can run past 90s) is NEVER reclaimed mid-flight. Conversely, a genuinely
+/// DEAD holder (its watcher task/process gone) stops renewing, so the lease
+/// expires and a replacement reclaims it within ~one deadline.
+///
+/// INVARIANT — deadline must be a small multiple of the heartbeat: large enough
+/// that a live holder never expires between two renews (covers a missed/late
+/// tick under scheduler pressure), small enough that a dead holder is reclaimed
+/// PROMPTLY. We pick 3× the heartbeat (15s = 3 × 5s): one tick can be skipped
+/// entirely and the lease still survives to the next, while dead-holder
+/// recovery is ~15s instead of the old fixed 90s. This is the lease DEADLINE,
+/// independent of the finalizer's `GATE_BACKSTOP` (8s, a different concern:
+/// visible-completion gating, not delivery duration).
+const WATCHER_DELIVERY_LEASE_DEADLINE_MS: u64 = 15_000;
+
+/// #3041 P1-1 (§3, codex R2 Issue-1): how often the in-flight watcher send
+/// renews its delivery lease. Must be strictly less than (and a small fraction
+/// of) `WATCHER_DELIVERY_LEASE_DEADLINE_MS` so a live holder always re-extends
+/// before expiry even if one tick is delayed (the deadline is 3× this).
+const WATCHER_DELIVERY_LEASE_HEARTBEAT_MS: u64 = 5_000;
+
+/// #3041 P1-1 (§3, codex R2 Issue-1): RAII handle for the in-flight
+/// delivery-lease heartbeat task. The watcher spawns the heartbeat right after a
+/// successful `try_acquire` and `stop()`s it BEFORE the inline commit (and the
+/// `Drop` impl aborts it on any early return / panic), so the renew loop can
+/// NEVER outlive the send and race the commit. While the watcher task lives the
+/// heartbeat keeps the lease alive (`renew`); if the watcher TASK dies the
+/// spawned heartbeat is dropped/aborted with it → the lease stops being renewed
+/// → it expires → a replacement reclaims it. A heartbeat tick can only ever
+/// `renew` THIS holder's OWN still-`Leased` lease (matched on holder+turn), so a
+/// last tick that races `stop()`+commit merely extends our own deadline, which
+/// the immediately-following commit then flips to `Committed` — harmless.
+struct DeliveryLeaseHeartbeat {
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl DeliveryLeaseHeartbeat {
+    /// Spawn a background task that renews `(holder, turn)`'s lease on `cell`
+    /// every `WATCHER_DELIVERY_LEASE_HEARTBEAT_MS`, each time pushing the
+    /// deadline to `lease_now_ms() + WATCHER_DELIVERY_LEASE_DEADLINE_MS`. The
+    /// first tick fires AFTER one interval (the acquire already set a fresh
+    /// deadline). The loop exits on its own as soon as a `renew` returns false
+    /// (the lease is no longer ours — committed, released, or reclaimed), so it
+    /// self-terminates even before an explicit `stop()`.
+    fn spawn(
+        cell: std::sync::Arc<crate::services::discord::DeliveryLeaseCell>,
+        holder: crate::services::discord::LeaseHolder,
+        turn: crate::services::discord::turn_finalizer::TurnKey,
+    ) -> Self {
+        let handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_millis(
+                WATCHER_DELIVERY_LEASE_HEARTBEAT_MS,
+            ));
+            // Skip the immediate tick `interval` emits at t=0; the acquire just
+            // set a fresh deadline, so the first renew is one interval later.
+            interval.tick().await;
+            loop {
+                interval.tick().await;
+                let renewed = cell.renew(
+                    holder,
+                    turn,
+                    crate::services::discord::lease_now_ms()
+                        .saturating_add(WATCHER_DELIVERY_LEASE_DEADLINE_MS),
+                );
+                if !renewed {
+                    // Lease is no longer ours (committed/released/reclaimed):
+                    // nothing left to keep alive.
+                    break;
+                }
+            }
+        });
+        Self { handle }
+    }
+
+    /// Stop the heartbeat. Idempotent. Called BEFORE the inline commit so the
+    /// renew loop is guaranteed not to race the commit.
+    fn stop(self) {
+        self.handle.abort();
+    }
+}
+
+impl Drop for DeliveryLeaseHeartbeat {
+    fn drop(&mut self) {
+        // Safety net: if the send path returns early / panics before an explicit
+        // `stop()`, aborting on drop guarantees the heartbeat cannot outlive the
+        // owning watcher frame.
+        self.handle.abort();
+    }
+}
 
 /// #2441 (H1) — race a fixed sleep against a `notify`-backed wake-up
 /// from `JsonlWatcher`. Returns as soon as EITHER the sleep elapses or
@@ -7157,8 +7240,9 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 // (black-hole). `reclaim_if_expired` only frees a `Leased` lease
                 // whose `deadline_ms` has elapsed against the SAME process-monotonic
                 // `lease_now_ms()` clock the acquire deadline is computed against,
-                // so a LIVE holder mid-send (deadline 90s out) is NOT reclaimed and
-                // this watcher still correctly B2-skips it (single-holder, §5.2).
+                // so a LIVE holder mid-send (whose deadline is continuously pushed
+                // forward by the heartbeat below) is NOT reclaimed and this watcher
+                // still correctly B2-skips it (single-holder, §5.2).
                 // This makes the acquire the PRIMARY black-hole guarantee — bounded
                 // to the lease deadline, with NO dependency on the finalizer actor
                 // having `SharedData` cached. The reconcile-tick reclaim stays as a
@@ -7190,6 +7274,38 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         let watcher_lease_b2_skip = watcher_will_direct_send
             && watcher_lease_end > watcher_lease_start
             && !watcher_lease_acquired;
+
+        // #3041 P1-1 (codex R2 Issue-2, BLOCKER B5 — DEFERRED, NOT a regression):
+        // the lease range is the FULL `[data_start_offset, consumed_end)`. If THIS
+        // holder dies AFTER posting chunk 1 but BEFORE its commit, a replacement
+        // reclaims the EXPIRED lease (after the deadline) and re-sends the WHOLE
+        // range → a partial DUPLICATE of the already-posted chunks. Exact-once on
+        // a partial multi-chunk crash needs per-message-id partial-commit state,
+        // which the #3041 design EXPLICITLY defers to BLOCKER B5 (a later phase) —
+        // it is intentionally NOT built here. This is NOT a P1-1 regression: the
+        // heartbeat (just below) guarantees a LIVE holder is NEVER reclaimed
+        // mid-send, so this duplicate can only happen on a GENUINE crash mid-send
+        // — which is EXACTLY the pre-P1-1 behavior (pre-P1-1 had no lease, so a
+        // replacement watcher re-sent the full range on crash too). P1-1 only ADDS
+        // a bounded delay (≤ the lease deadline) before the replacement re-delivers.
+        //
+        // #3041 P1-1 (§3, codex R2 Issue-1): keep the lease alive WHILE the send
+        // future is in flight. The deadline is short (15s) for fast dead-holder
+        // recovery; a long legitimate send (60+ rate-limited chunks can exceed any
+        // FIXED deadline) is covered because this background heartbeat `renew()`s
+        // the lease every 5s. The heartbeat is `stop()`ped BEFORE the inline commit
+        // (and aborts on drop), so it can never race the commit. Spawned ONLY when
+        // we actually acquired (the send arm runs); on the B2-skip / no-send arms
+        // there is no lease of ours to renew.
+        let watcher_lease_heartbeat = if watcher_lease_acquired {
+            Some(DeliveryLeaseHeartbeat::spawn(
+                watcher_lease_cell.clone(),
+                watcher_lease_holder,
+                watcher_lease_turn,
+            ))
+        } else {
+            None
+        };
 
         let relay_ok = if session_bound_relay_owns_terminal_delivery {
             let ts = chrono::Local::now().format("%H:%M:%S");
@@ -8059,6 +8175,17 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         // `confirmed_end` on the retry, falsely claiming there's nothing
         // new to relay.
         let terminal_committed_offset = runtime_binding_candidate_offset.unwrap_or(current_offset);
+        // #3041 P1-1 (§3, codex R2 Issue-1): the send future has completed (success
+        // or failure) by here. STOP the heartbeat BEFORE the inline commit so the
+        // renew loop is guaranteed not to race the `commit`/`release` below. Even a
+        // tick that already fired between the send completing and this `stop()` can
+        // only `renew` our OWN still-`Leased` lease (a no-op extension), which the
+        // commit immediately flips to `Committed`. After `stop()` no further renews
+        // can occur. On the non-acquired arms `watcher_lease_heartbeat` is `None`,
+        // so this is a no-op there.
+        if let Some(hb) = watcher_lease_heartbeat {
+            hb.stop();
+        }
         if watcher_lease_acquired {
             // #3041 P1-1 (§5.2): the watcher-direct terminal delivery was leased
             // above. Commit the 3-way outcome and, on `Delivered`, advance the
@@ -8125,8 +8252,9 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             }
             // Release so the cell returns to Unleased for the next turn. Inline
             // (same-holder) compare-and-release. Idempotent: a release that loses
-            // the identity match (e.g. the lease was reclaimed mid-send because
-            // the 90s deadline elapsed) is a harmless no-op.
+            // the identity match (e.g. the lease was reclaimed because the holder
+            // died and stopped heartbeating, so the short deadline elapsed) is a
+            // harmless no-op.
             let _ = watcher_lease_cell.release(
                 watcher_lease_holder,
                 watcher_lease_turn,
@@ -10655,5 +10783,190 @@ TUI-E2E-marker ssh-direct
         assert_eq!(format!("{}{}", first.text, second.text), payload);
         assert!(!first.text.contains('\u{FFFD}'));
         assert!(!second.text.contains('\u{FFFD}'));
+    }
+
+    /// #3041 P1-1 (§3, codex R2 Issue-1): heartbeat-renew lifecycle for the
+    /// in-flight watcher delivery lease. These tests use the GATED Tokio clock
+    /// (`start_paused`) to drive the heartbeat's `tokio::time::interval` WITHOUT
+    /// real sleeps; `lease_now_ms()` is a separate real monotonic clock, so we
+    /// assert reclaim behaviour with EXPLICIT `now_ms` arguments anchored to the
+    /// observed `lease_now_ms()` baseline.
+    mod delivery_lease_heartbeat {
+        use super::super::{
+            DeliveryLeaseHeartbeat, WATCHER_DELIVERY_LEASE_DEADLINE_MS,
+            WATCHER_DELIVERY_LEASE_HEARTBEAT_MS,
+        };
+        use crate::services::discord::turn_finalizer::TurnKey;
+        use crate::services::discord::{
+            DeliveryLeaseCell, LeaseHolder, LeaseOutcome, LeaseSnapshot, lease_now_ms,
+        };
+        use serenity::model::id::ChannelId;
+        use std::sync::Arc;
+
+        fn watcher(id: u64) -> LeaseHolder {
+            LeaseHolder::Watcher { instance_id: id }
+        }
+
+        fn deadline_of(cell: &DeliveryLeaseCell) -> Option<u64> {
+            match cell.read() {
+                LeaseSnapshot::Leased { deadline_ms, .. } => Some(deadline_ms),
+                _ => None,
+            }
+        }
+
+        /// (a) A send that runs LONGER than the (short) deadline, but with the
+        /// heartbeat renewing every interval, is NEVER reclaimed mid-send: the
+        /// ORIGINAL holder's commit SUCCEEDS and advances the offset exactly once.
+        /// We acquire with a deliberately SHORT deadline (would expire almost
+        /// immediately), then let the heartbeat push it far forward, and confirm a
+        /// reclaim attempt well past the original deadline is a no-op.
+        #[tokio::test(flavor = "current_thread", start_paused = true)]
+        async fn long_send_heartbeat_renew_prevents_midsend_reclaim() {
+            let ch = ChannelId::new(7101);
+            let cell = Arc::new(DeliveryLeaseCell::new(ch));
+            let turn = TurnKey::new(ch, 11, 0);
+            let h = watcher(1);
+
+            // Acquire with a TINY deadline relative to lease_now_ms(): without a
+            // heartbeat it would be reclaimable almost immediately.
+            let acquire_now = lease_now_ms();
+            let short_deadline = acquire_now.saturating_add(100);
+            assert!(cell.try_acquire(turn, h, 0, 64, short_deadline));
+            assert_eq!(deadline_of(&cell), Some(short_deadline));
+
+            // Start the heartbeat (owned by this "watcher" frame).
+            let hb = DeliveryLeaseHeartbeat::spawn(cell.clone(), h, turn);
+
+            // Drive the gated clock across SEVERAL heartbeat intervals — i.e. a
+            // long multi-chunk send. Each crossed interval fires one renew.
+            for _ in 0..6 {
+                tokio::time::advance(std::time::Duration::from_millis(
+                    WATCHER_DELIVERY_LEASE_HEARTBEAT_MS,
+                ))
+                .await;
+                tokio::task::yield_now().await;
+            }
+
+            // The heartbeat has pushed the deadline far beyond the original short
+            // one: it is now lease_now_ms()+DEADLINE_MS (a much larger value).
+            let renewed_deadline = deadline_of(&cell).expect("still Leased mid-send");
+            assert!(
+                renewed_deadline > short_deadline,
+                "heartbeat must have renewed the deadline forward (was {short_deadline}, now {renewed_deadline})"
+            );
+
+            // A reclaim attempt at a time PAST the ORIGINAL short deadline (but
+            // before the renewed one) is a no-op — the live holder is protected.
+            assert!(
+                !cell.reclaim_if_expired(short_deadline.saturating_add(1)),
+                "a renewed (live) lease must NOT be reclaimed past its original deadline"
+            );
+
+            // Stop the heartbeat (as the watcher does before committing), then the
+            // ORIGINAL holder commits successfully and advances exactly once.
+            hb.stop();
+            tokio::task::yield_now().await;
+            assert!(
+                cell.commit(h, turn, 0, 64, LeaseOutcome::Delivered),
+                "the original holder's own commit must succeed (lease never lost)"
+            );
+            match cell.read() {
+                LeaseSnapshot::Committed { outcome, end, .. } => {
+                    assert_eq!(outcome, LeaseOutcome::Delivered);
+                    assert_eq!(end, 64);
+                }
+                other => panic!("expected Committed, got {other:?}"),
+            }
+        }
+
+        /// (b) A holder that "dies" (its heartbeat is dropped/stopped and never
+        /// renews) lets the SHORT deadline elapse, so a replacement reclaims and
+        /// acquires. We simulate death by dropping the heartbeat handle BEFORE the
+        /// renew interval fires, then asserting a reclaim past the (un-renewed)
+        /// deadline succeeds and a replacement acquires.
+        #[tokio::test(flavor = "current_thread", start_paused = true)]
+        async fn dead_holder_no_renew_is_reclaimed_after_short_deadline() {
+            let ch = ChannelId::new(7102);
+            let cell = Arc::new(DeliveryLeaseCell::new(ch));
+            let turn = TurnKey::new(ch, 22, 0);
+            let dead = watcher(1);
+
+            let acquire_now = lease_now_ms();
+            let deadline = acquire_now.saturating_add(WATCHER_DELIVERY_LEASE_DEADLINE_MS);
+            assert!(cell.try_acquire(turn, dead, 0, 40, deadline));
+
+            // The holder "dies": its heartbeat is dropped immediately (Drop aborts
+            // it) WITHOUT ever renewing.
+            let hb = DeliveryLeaseHeartbeat::spawn(cell.clone(), dead, turn);
+            drop(hb);
+            tokio::task::yield_now().await;
+
+            // Before the deadline: NOT reclaimable (single-holder still honored).
+            assert!(!cell.reclaim_if_expired(deadline.saturating_sub(1)));
+            // Past the (un-renewed, short) deadline: a replacement reclaims it.
+            assert!(
+                cell.reclaim_if_expired(deadline),
+                "a dead holder that stopped heartbeating is reclaimed after the short deadline"
+            );
+            // And a replacement (new instance, new turn) can acquire the freed cell.
+            let replacement = watcher(2);
+            let turn_b = TurnKey::new(ch, 33, 0);
+            assert!(
+                cell.try_acquire(
+                    turn_b,
+                    replacement,
+                    40,
+                    72,
+                    deadline.saturating_add(WATCHER_DELIVERY_LEASE_DEADLINE_MS),
+                ),
+                "a reclaimed cell is acquirable by the replacement (no black-hole)"
+            );
+        }
+
+        /// (c) `renew` by a NON-holder, or for the WRONG turn, is a no-op (false)
+        /// and does NOT touch the live holder's deadline — the heartbeat of one
+        /// holder can never extend (or steal) another's lease.
+        #[tokio::test(flavor = "current_thread", start_paused = true)]
+        async fn renew_by_non_holder_or_wrong_turn_is_noop() {
+            let ch = ChannelId::new(7103);
+            let cell = DeliveryLeaseCell::new(ch);
+            let turn = TurnKey::new(ch, 44, 0);
+            let holder = watcher(1);
+
+            let now = lease_now_ms();
+            let deadline = now.saturating_add(1_000);
+            assert!(cell.try_acquire(turn, holder, 0, 16, deadline));
+
+            // Wrong holder, correct turn → no-op.
+            assert!(
+                !cell.renew(watcher(2), turn, now.saturating_add(99_999)),
+                "a different holder cannot renew the lease"
+            );
+            // Correct holder, wrong (stale) turn → no-op.
+            let wrong_turn = TurnKey::new(ch, 45, 0);
+            assert!(
+                !cell.renew(holder, wrong_turn, now.saturating_add(99_999)),
+                "a stale/wrong turn cannot renew the lease"
+            );
+            // The deadline is UNCHANGED by the rejected renews.
+            assert_eq!(
+                deadline_of(&cell),
+                Some(deadline),
+                "rejected renews must not mutate the deadline"
+            );
+
+            // The TRUE holder/turn CAN renew → deadline extends.
+            let extended = now.saturating_add(WATCHER_DELIVERY_LEASE_DEADLINE_MS);
+            assert!(cell.renew(holder, turn, extended));
+            assert_eq!(deadline_of(&cell), Some(extended));
+
+            // After commit (Committed, not Leased) even the true holder's renew
+            // no-ops — a late heartbeat tick after commit cannot disturb the cell.
+            assert!(cell.commit(holder, turn, 0, 16, LeaseOutcome::Delivered));
+            assert!(
+                !cell.renew(holder, turn, extended.saturating_add(1)),
+                "a renew on a Committed lease (a late tick after commit) is a no-op"
+            );
+        }
     }
 }

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -7204,8 +7204,10 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         // holds this cell (Leased, not yet committed/released/reclaimed) for the
         // same channel, `try_acquire` returns false and this watcher MUST NOT
         // direct-send (see the dedicated skip arm below). The acquire is the
-        // atomic fast-path on the cell (B4); commit/release route through the
-        // finalizer actor.
+        // atomic fast-path on the cell (B4); commit/advance/release happen
+        // INLINE in the watcher (synchronously, to preserve the pre-P1-1 prompt
+        // confirmed_end advance and avoid an actor-deferral duplicate window).
+        // The actor CommitDelivery/ReleaseDelivery messages remain dormant.
         let watcher_lease_turn = crate::services::discord::turn_finalizer::TurnKey::new(
             channel_id,
             pinned_finalize_user_msg_id(
@@ -7743,7 +7745,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 // retry the SAME range on the next loop iteration. If we left the
                 // lease `Leased`, the retry's `try_acquire` would lose to our own
                 // held lease and the B2 skip arm would suppress the legitimate
-                // retry until the 90s deadline reclaim. Abandon-release the lease
+                // retry until the lease-deadline reclaim. Abandon-release the lease
                 // here (Leased→Unleased) so the retry can re-acquire. This is the
                 // sole abandon point that must not commit; it is released on the
                 // cell directly (a same-holder abandon, not a commit/release race

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1,6 +1,32 @@
 use super::*;
 use crate::services::discord::InflightTurnState;
 
+/// #3041 P1-1: process-global monotonic counter that mints a unique
+/// `instance_id` for each watcher spawn. It distinguishes an outgoing watcher
+/// from its replacement across a reattach so the delivery-lease holder
+/// (`LeaseHolder::Watcher { instance_id }`) of a still-running send cannot be
+/// confused with — or released/committed by — a successor watcher that picks
+/// up the same channel/session (the §5.2 B2 single-holder invariant).
+static WATCHER_INSTANCE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+fn next_watcher_instance_id() -> u64 {
+    WATCHER_INSTANCE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
+
+/// #3041 P1-1 (B3): delivery-lease acquire deadline for the watcher terminal
+/// send. The realistic worst case is NOT a single POST: a long terminal
+/// response is split into multiple Discord messages, each separated by the
+/// long-message inter-chunk pacing wait (`formatting.rs` 500ms), and may be
+/// preceded by a session-bound relay ACK wait (`tmux_watcher.rs` 10s). A very
+/// long answer can be ~20+ chunks; 20 × 500ms = 10s of pacing alone, plus the
+/// 10s ACK wait, plus HTTP/rate-limit slack. We pick 90s — comfortably above a
+/// worst-case multi-chunk rate-limited send — so a live holder is never
+/// reclaimed mid-send, while still bounding a genuinely-dead holder so the
+/// reconciler's `reclaim_if_expired` frees the cell for a legitimate successor.
+/// This is the lease DEADLINE, independent of the finalizer's `GATE_BACKSTOP`
+/// (8s, a different concern: visible-completion gating, not delivery duration).
+const WATCHER_DELIVERY_LEASE_DEADLINE_MS: u64 = 90_000;
+
 /// #2441 (H1) — race a fixed sleep against a `notify`-backed wake-up
 /// from `JsonlWatcher`. Returns as soon as EITHER the sleep elapses or
 /// the watcher fires its `Notify`. This is the primitive used to replace
@@ -3412,6 +3438,11 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
     tracing::info!(
         "  [{ts}] 👁 tmux watcher started for #{tmux_session_name} at offset {initial_offset}"
     );
+
+    // #3041 P1-1: this watcher instance's delivery-lease holder id. Minted once
+    // per spawn so a replacement watcher cannot release/commit (or be mistaken
+    // for) this instance's lease across a reattach (§5.2 B2).
+    let watcher_instance_id = next_watcher_instance_id();
 
     // E5 (#2412): cache the supervisor-owned StreamRelay producer for this
     // tmux session, if the supervisor is running and has matched the
@@ -7075,6 +7106,73 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         let mut tui_direct_anchor_terminal_body_visible = false;
         let mut tui_direct_anchor_or_lease_present_for_lifecycle =
             prompt_anchor_present_before_relay || external_input_lease_before_relay;
+
+        // #3041 P1-1: acquire the delivery lease BEFORE the watcher direct-sends
+        // its terminal response. The lease identity is the turn-pinned id (NOT a
+        // stale late re-read — `pinned_finalize_user_msg_id` mirrors the same
+        // id-pinning #3141 established) and the byte range this delivery covers,
+        // `[data_start_offset, terminal_event_consumed_offset(..))` — the SAME
+        // consumed end the commit/offset-advance uses, so acquire and commit
+        // carry one identity. We only acquire on the watcher-direct path: the
+        // session-bound delegation path is the sink's lease (P1-2) and the
+        // suppression/no-response arms deliver nothing.
+        //
+        // B2 (single-holder, §5.2): if a DIFFERENT watcher instance already
+        // holds this cell (Leased, not yet committed/released/reclaimed) for the
+        // same channel, `try_acquire` returns false and this watcher MUST NOT
+        // direct-send (see the dedicated skip arm below). The acquire is the
+        // atomic fast-path on the cell (B4); commit/release route through the
+        // finalizer actor.
+        let watcher_lease_turn = crate::services::discord::turn_finalizer::TurnKey::new(
+            channel_id,
+            pinned_finalize_user_msg_id(
+                inflight_before_relay.as_ref(),
+                &tmux_session_name,
+                current_offset,
+            ),
+            shared.current_generation,
+        );
+        let watcher_lease_holder = crate::services::discord::LeaseHolder::Watcher {
+            instance_id: watcher_instance_id,
+        };
+        let watcher_lease_start = data_start_offset;
+        let watcher_lease_end = terminal_event_consumed_offset(current_offset, &all_data);
+        let watcher_lease_cell = shared.delivery_lease(channel_id);
+        // Only the watcher-direct fallback path actually direct-sends; acquire
+        // exactly when that path will run with a real body so the lease identity
+        // matches the bytes we are about to deliver. A zero/inverted range never
+        // delivers, so do not lease it.
+        let watcher_will_direct_send =
+            watcher_direct_fallback_after_session_bound_ack && has_direct_terminal_response;
+        let watcher_lease_acquired =
+            if watcher_will_direct_send && watcher_lease_end > watcher_lease_start {
+                watcher_lease_cell.try_acquire(
+                    watcher_lease_turn,
+                    watcher_lease_holder,
+                    watcher_lease_start,
+                    watcher_lease_end,
+                    crate::services::discord::lease_now_ms()
+                        .saturating_add(WATCHER_DELIVERY_LEASE_DEADLINE_MS),
+                )
+            } else {
+                false
+            };
+        // B2 skip flag: the watcher intended to direct-send but a different
+        // holder owns the lease for this range. Used to route to the skip arm
+        // (no duplicate send) instead of the send arm. NOTE (P1-3 residual): the
+        // 10s ACK-timeout blind re-send is intentionally NOT removed here. If the
+        // SAME watcher that holds the lease hits its ACK timeout it would
+        // re-enter this block in a LATER iteration; because the prior iteration
+        // committed-and-released the lease (Committed→Unleased), a same-holder
+        // re-send re-acquires and re-commits the SAME range — but the commit's
+        // offset advance is a monotonic CAS, so it CANNOT double-advance
+        // `confirmed_end_offset`. P1-3 replaces the blind re-send with
+        // committed-offset reconciliation; until then this residual same-holder
+        // re-send window is bounded and offset-idempotent.
+        let watcher_lease_b2_skip = watcher_will_direct_send
+            && watcher_lease_end > watcher_lease_start
+            && !watcher_lease_acquired;
+
         let relay_ok = if session_bound_relay_owns_terminal_delivery {
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::info!(
@@ -7110,6 +7208,26 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             }
             clear_provider_overload_retry_state(channel_id);
             true
+        } else if watcher_lease_b2_skip {
+            // #3041 P1-1 B2 (single-holder, §5.2): a DIFFERENT watcher instance
+            // already holds the delivery lease for this exact channel/turn/range
+            // (it is mid-send or its lease has not yet been committed/released/
+            // reclaimed). A replacement watcher MUST NOT re-acquire and re-emit
+            // the same range — that is precisely the duplicate-send vector the
+            // lease closes. Skip the direct send; `terminal_output_committed`
+            // stays false so no offset advance / lifecycle side-effects run for
+            // this suppressed re-emit. The live holder will commit-advance the
+            // offset itself.
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            tracing::warn!(
+                provider = %watcher_provider.as_str(),
+                channel = channel_id.get(),
+                tmux_session = %tmux_session_name,
+                data_start_offset = watcher_lease_start,
+                lease_end = watcher_lease_end,
+                "  [{ts}] 👁 #3041 B2: delivery lease held by another holder — skipped duplicate terminal send for {tmux_session_name} (range {watcher_lease_start}..{watcher_lease_end})"
+            );
+            false
         } else if watcher_direct_fallback_after_session_bound_ack {
             let formatted = if shared.status_panel_v2_enabled {
                 crate::services::discord::formatting::format_for_discord_with_status_panel(
@@ -7486,6 +7604,25 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 clear_provider_overload_retry_state(channel_id);
             }
             if retry_terminal_delivery_from_offset {
+                // #3041 P1-1: this is a SAME-holder abandon-without-commit — the
+                // partial send failed and we are about to reset the offset and
+                // retry the SAME range on the next loop iteration. If we left the
+                // lease `Leased`, the retry's `try_acquire` would lose to our own
+                // held lease and the B2 skip arm would suppress the legitimate
+                // retry until the 90s deadline reclaim. Abandon-release the lease
+                // here (Leased→Unleased) so the retry can re-acquire. This is the
+                // sole abandon point that must not commit; it is released on the
+                // cell directly (a same-holder abandon, not a commit/release race
+                // that needs actor serialization). Identity-matched no-op if the
+                // lease was never acquired on this path.
+                if watcher_lease_acquired {
+                    watcher_lease_cell.release(
+                        watcher_lease_holder,
+                        watcher_lease_turn,
+                        watcher_lease_start,
+                        watcher_lease_end,
+                    );
+                }
                 current_offset = turn_data_start_offset;
                 all_data.clear();
                 all_data_start_offset = current_offset;
@@ -7904,7 +8041,65 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         // `confirmed_end` on the retry, falsely claiming there's nothing
         // new to relay.
         let terminal_committed_offset = runtime_binding_candidate_offset.unwrap_or(current_offset);
-        if terminal_output_committed && !lifecycle_stage_paused {
+        if watcher_lease_acquired {
+            // #3041 P1-1 (§5.2): the watcher-direct terminal delivery was leased
+            // above. The lease COMMIT — not an inline advance — is now the single
+            // thing that advances `confirmed_end_offset` for this path. Commit the
+            // 3-way outcome through the finalizer actor (B4): `Delivered` on a
+            // confirmed send (advances the watermark to the leased `end`),
+            // `NotDelivered` on a clean send failure, `Unknown` when the TUI
+            // quiescence gate left us lifecycle-paused (ambiguous — the visible
+            // completion is deferred to the backstop, so we must NOT claim these
+            // bytes delivered). The commit handler advances the watermark ONLY on
+            // `Delivered`, mirroring the old inline `!lifecycle_stage_paused` gate
+            // exactly. Then release the lease so the cell is free for the next
+            // turn. The leased `end` equals `terminal_committed_offset` on the
+            // committed path, so the offset reaches the same value the inline call
+            // used.
+            let commit_outcome = if lifecycle_stage_paused {
+                crate::services::discord::LeaseOutcome::Unknown
+            } else if relay_ok {
+                crate::services::discord::LeaseOutcome::Delivered
+            } else {
+                crate::services::discord::LeaseOutcome::NotDelivered
+            };
+            let committed = shared
+                .turn_finalizer
+                .commit_delivery(
+                    watcher_lease_turn,
+                    watcher_lease_cell.clone(),
+                    watcher_lease_holder,
+                    watcher_lease_start,
+                    watcher_lease_end,
+                    commit_outcome,
+                    watcher_provider.clone(),
+                    tmux_session_name.clone(),
+                    shared.clone(),
+                )
+                .await;
+            debug_assert!(
+                committed,
+                "watcher must be able to commit its own freshly-acquired lease"
+            );
+            // Release so the cell returns to Unleased for the next turn. Routed
+            // through the actor (B4). Idempotent: a release that loses the
+            // identity match (e.g. the lease was reclaimed mid-send because the
+            // 90s deadline elapsed) is a harmless no-op.
+            let _ = shared
+                .turn_finalizer
+                .release_delivery(
+                    watcher_lease_turn,
+                    watcher_lease_cell.clone(),
+                    watcher_lease_holder,
+                    watcher_lease_start,
+                    watcher_lease_end,
+                )
+                .await;
+        } else if terminal_output_committed && !lifecycle_stage_paused {
+            // Non-watcher-direct committed paths (relay-suppressed task
+            // notifications, empty-turn cleanup, session-bound delegation that
+            // still consumed the range) keep the inline monotonic-CAS advance —
+            // they are NOT the watcher terminal-delivery path the lease governs.
             advance_watcher_confirmed_end(
                 &shared,
                 &watcher_provider,

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -7146,6 +7146,24 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             watcher_direct_fallback_after_session_bound_ack && has_direct_terminal_response;
         let watcher_lease_acquired =
             if watcher_will_direct_send && watcher_lease_end > watcher_lease_start {
+                // #3041 P1-1 (B3, Issue 1): SELF-HEALING acquire. Before trying to
+                // acquire, reclaim the current lease IFF it is EXPIRED — a dead
+                // holder that `try_acquire`d but died before commit/release (e.g.
+                // on a cold/no-terminal path where the finalizer actor never
+                // cached `SharedData`, so the reconcile-tick reclaim would never
+                // run). Without this, a replacement watcher's `try_acquire` would
+                // lose to the dead holder's stuck `Leased` lease forever and take
+                // the B2 skip arm permanently → the range is never delivered
+                // (black-hole). `reclaim_if_expired` only frees a `Leased` lease
+                // whose `deadline_ms` has elapsed against the SAME process-monotonic
+                // `lease_now_ms()` clock the acquire deadline is computed against,
+                // so a LIVE holder mid-send (deadline 90s out) is NOT reclaimed and
+                // this watcher still correctly B2-skips it (single-holder, §5.2).
+                // This makes the acquire the PRIMARY black-hole guarantee — bounded
+                // to the lease deadline, with NO dependency on the finalizer actor
+                // having `SharedData` cached. The reconcile-tick reclaim stays as a
+                // secondary net (harmless if redundant).
+                watcher_lease_cell.reclaim_if_expired(crate::services::discord::lease_now_ms());
                 watcher_lease_cell.try_acquire(
                     watcher_lease_turn,
                     watcher_lease_holder,
@@ -8043,19 +8061,39 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         let terminal_committed_offset = runtime_binding_candidate_offset.unwrap_or(current_offset);
         if watcher_lease_acquired {
             // #3041 P1-1 (§5.2): the watcher-direct terminal delivery was leased
-            // above. The lease COMMIT — not an inline advance — is now the single
-            // thing that advances `confirmed_end_offset` for this path. Commit the
-            // 3-way outcome through the finalizer actor (B4): `Delivered` on a
-            // confirmed send (advances the watermark to the leased `end`),
-            // `NotDelivered` on a clean send failure, `Unknown` when the TUI
-            // quiescence gate left us lifecycle-paused (ambiguous — the visible
-            // completion is deferred to the backstop, so we must NOT claim these
-            // bytes delivered). The commit handler advances the watermark ONLY on
-            // `Delivered`, mirroring the old inline `!lifecycle_stage_paused` gate
-            // exactly. Then release the lease so the cell is free for the next
-            // turn. The leased `end` equals `terminal_committed_offset` on the
-            // committed path, so the offset reaches the same value the inline call
-            // used.
+            // above. Commit the 3-way outcome and, on `Delivered`, advance the
+            // `confirmed_end_offset` watermark — both INLINE (synchronously),
+            // exactly at the pre-P1-1 call site/timing.
+            //
+            // WHY INLINE (and NOT the awaited `CommitDelivery`/`ReleaseDelivery`
+            // actor round-trip a prior P1-1 iteration used): the actor-commit
+            // DEFERRED the offset advance behind the finalize owner's mailbox.
+            // A `CommitDelivery` can queue behind an awaited `Terminal` handler,
+            // so `confirmed_end_offset` stays OLD for the duration of that await.
+            // Meanwhile `session_relay_sink` dedups purely on
+            // `shared.committed_relay_offset(channel)` (no lease consult until
+            // P1-2), so during the deferral window it can re-relay the SAME range
+            // → duplicate. That reopened the #3143 read-only offset-authority
+            // duplicate window the pre-P1-1 inline advance had closed. Committing
+            // the cell and advancing the watermark inline restores the prompt
+            // advance so #3143's `committed_relay_offset` consult sees it
+            // immediately — closing the window. The cell's `commit` is itself an
+            // atomic CAS on the payload mutex, so §5.2's "offset advances IFF the
+            // Delivered commit succeeds" still holds atomically without the actor.
+            // The ledger-coupling of the commit (§5.3) is a deferred later step;
+            // nothing here requires the actor to serialize commit against
+            // `Terminal` today (the advance is a standalone monotonic CAS).
+            //
+            // 3-way outcome: `Delivered` on a confirmed send (advances the
+            // watermark to the leased `end`), `NotDelivered` on a clean send
+            // failure, `Unknown` when the TUI quiescence gate left us
+            // lifecycle-paused (ambiguous — visible completion deferred to the
+            // backstop, so we must NOT claim these bytes delivered). We advance
+            // ONLY on `Delivered`, mirroring the old inline `!lifecycle_stage_paused`
+            // gate exactly. The leased `end` equals `terminal_committed_offset` on
+            // the committed path, so the offset reaches the same value the inline
+            // call used. Then release the lease (inline, same-holder) so the cell
+            // is free for the next turn.
             let commit_outcome = if lifecycle_stage_paused {
                 crate::services::discord::LeaseOutcome::Unknown
             } else if relay_ok {
@@ -8063,38 +8101,38 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             } else {
                 crate::services::discord::LeaseOutcome::NotDelivered
             };
-            let committed = shared
-                .turn_finalizer
-                .commit_delivery(
-                    watcher_lease_turn,
-                    watcher_lease_cell.clone(),
-                    watcher_lease_holder,
-                    watcher_lease_start,
-                    watcher_lease_end,
-                    commit_outcome,
-                    watcher_provider.clone(),
-                    tmux_session_name.clone(),
-                    shared.clone(),
-                )
-                .await;
+            let committed = watcher_lease_cell.commit(
+                watcher_lease_holder,
+                watcher_lease_turn,
+                watcher_lease_start,
+                watcher_lease_end,
+                commit_outcome,
+            );
             debug_assert!(
                 committed,
                 "watcher must be able to commit its own freshly-acquired lease"
             );
-            // Release so the cell returns to Unleased for the next turn. Routed
-            // through the actor (B4). Idempotent: a release that loses the
-            // identity match (e.g. the lease was reclaimed mid-send because the
-            // 90s deadline elapsed) is a harmless no-op.
-            let _ = shared
-                .turn_finalizer
-                .release_delivery(
-                    watcher_lease_turn,
-                    watcher_lease_cell.clone(),
-                    watcher_lease_holder,
-                    watcher_lease_start,
+            if committed && commit_outcome == crate::services::discord::LeaseOutcome::Delivered {
+                // INLINE advance — exactly the pre-P1-1 call site/timing.
+                advance_watcher_confirmed_end(
+                    &shared,
+                    &watcher_provider,
+                    channel_id,
+                    &tmux_session_name,
                     watcher_lease_end,
-                )
-                .await;
+                    "src/services/discord/tmux_watcher.rs:watcher_lease_commit_advance",
+                );
+            }
+            // Release so the cell returns to Unleased for the next turn. Inline
+            // (same-holder) compare-and-release. Idempotent: a release that loses
+            // the identity match (e.g. the lease was reclaimed mid-send because
+            // the 90s deadline elapsed) is a harmless no-op.
+            let _ = watcher_lease_cell.release(
+                watcher_lease_holder,
+                watcher_lease_turn,
+                watcher_lease_start,
+                watcher_lease_end,
+            );
         } else if terminal_output_committed && !lifecycle_stage_paused {
             // Non-watcher-direct committed paths (relay-suppressed task
             // notifications, empty-turn cleanup, session-bound delegation that

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -389,14 +389,21 @@ enum FinalizeMsg {
         deadline_ms: u64,
         ack: oneshot::Sender<bool>,
     },
-    /// #3041 P1-1: three-way commit; full-identity mismatch = no-op. On a
-    /// `Delivered` commit the handler also advances the channel's
-    /// `confirmed_end_offset` watermark to `end` (§5.2 atomicity) via the SAME
-    /// monotonic CAS the watcher's inline advance used, so commit-advances-offset
-    /// and the lease transition are one serialized unit on the finalize owner.
+    /// #3041 three-way commit; full-identity mismatch = no-op. On a `Delivered`
+    /// commit the handler also advances the channel's `confirmed_end_offset`
+    /// watermark to `end` (§5.2 atomicity) via the SAME monotonic CAS the
+    /// watcher's inline advance uses, so commit-advances-offset and the lease
+    /// transition are one serialized unit on the finalize owner.
     /// `provider`/`tmux_session_name`/`shared` are carried so the handler can call
     /// `advance_watcher_confirmed_end` (the `.generation`-mtime bookkeeping needs
-    /// the session name). They are `None`/unused for non-watcher holders.
+    /// the session name).
+    ///
+    /// DORMANT (reverted in P1-1): the watcher now commits + advances the offset
+    /// INLINE (see tmux_watcher.rs `watcher_lease_commit_advance`), NOT via this
+    /// awaited actor round-trip — the actor-commit deferral reopened the #3143
+    /// duplicate window. Kept defined (no production sender) for the later phase
+    /// that re-couples the commit to the ledger (§5.3).
+    #[allow(dead_code)] // #3041: wired in a later phase (ledger-coupled commit, §5.3).
     CommitDelivery {
         key: TurnKey,
         lease: Arc<DeliveryLeaseCell>,
@@ -409,7 +416,10 @@ enum FinalizeMsg {
         shared: Arc<SharedData>,
         ack: oneshot::Sender<bool>,
     },
-    /// #3041 §2-§3 P1-0 (DORMANT): compare-and-release; full-identity match only.
+    /// #3041 compare-and-release; full-identity match only. DORMANT (reverted in
+    /// P1-1): the watcher releases its lease INLINE after the inline commit, NOT
+    /// via this awaited actor round-trip. Kept defined for a later phase.
+    #[allow(dead_code)] // #3041: wired in a later phase (alongside CommitDelivery).
     ReleaseDelivery {
         key: TurnKey,
         lease: Arc<DeliveryLeaseCell>,
@@ -496,12 +506,18 @@ impl TurnFinalizer {
         rx.await.unwrap_or(FinalizeOutcome::AlreadyFinalized)
     }
 
-    /// #3041 P1-1: route a three-way `CommitDelivery` through the actor so the
-    /// lease transition AND the `Delivered`-commit offset advance run as one
-    /// serialized unit on the finalize owner (B4: commit/release/reclaim are
-    /// actor transitions; only acquire/read are atomic fast-paths on the cell).
-    /// Returns whether the lease actually committed (identity matched a live
-    /// `Leased` lease). If the actor task is gone (teardown) returns `false`.
+    /// #3041: route a three-way `CommitDelivery` through the actor so the lease
+    /// transition AND the `Delivered`-commit offset advance run as one serialized
+    /// unit on the finalize owner. Returns whether the lease actually committed
+    /// (identity matched a live `Leased` lease). If the actor task is gone
+    /// (teardown) returns `false`.
+    ///
+    /// DORMANT (reverted in P1-1): the watcher commits + advances INLINE (see
+    /// tmux_watcher.rs) to keep the pre-P1-1 prompt advance — awaiting this
+    /// behind the actor's `Terminal` mailbox reopened the #3143 duplicate window.
+    /// Retained (exercised only by the lease unit tests) for a later
+    /// ledger-coupled-commit phase (§5.3).
+    #[allow(dead_code)] // #3041: wired in a later phase (ledger-coupled commit, §5.3).
     pub(in crate::services::discord) async fn commit_delivery(
         &self,
         key: TurnKey,
@@ -536,11 +552,14 @@ impl TurnFinalizer {
         rx.await.unwrap_or(false)
     }
 
-    /// #3041 P1-1: route a compare-and-`ReleaseDelivery` through the actor (B4:
-    /// release is an actor transition). Returns the standard
-    /// `Committed`/`Leased` → `Unleased` result; identity mismatch is a no-op
-    /// `false`. The watcher releases its lease after committing so the cell is
-    /// free for the next turn. If the actor task is gone returns `false`.
+    /// #3041: route a compare-and-`ReleaseDelivery` through the actor. Returns
+    /// the standard `Committed`/`Leased` → `Unleased` result; identity mismatch
+    /// is a no-op `false`. If the actor task is gone returns `false`.
+    ///
+    /// DORMANT (reverted in P1-1): the watcher releases INLINE after its inline
+    /// commit. Retained (exercised only by the lease unit tests) for a later
+    /// phase.
+    #[allow(dead_code)] // #3041: wired in a later phase (alongside commit_delivery).
     pub(in crate::services::discord) async fn release_delivery(
         &self,
         key: TurnKey,
@@ -2895,13 +2914,18 @@ mod tests {
     // =======================================================================
     // #3041 P1-1 — LIVE watcher-terminal-delivery lease wiring tests.
     //
-    // These exercise the wiring P1-1 added: the lease COMMIT advancing
-    // `confirmed_end_offset` through the actor, B2 single-holder contention,
-    // commit idempotency on the monotonic-CAS offset, and deadline reclaim of a
-    // dead holder. They run on a gated clock (`current_thread`/`start_paused`)
-    // and through the public `commit_delivery`/`release_delivery` actor methods
-    // — the same path the watcher uses — mirroring the 26-test finalizer matrix
-    // style.
+    // NOTE on the commit path: the watcher commits + advances the offset INLINE
+    // (see `watcher_inline_*` tests below + tmux_watcher.rs) — the awaited
+    // `CommitDelivery`/`ReleaseDelivery` actor round-trip was reverted to dormant
+    // because the actor-commit deferral reopened the #3143 duplicate window. The
+    // tests immediately below still drive the RETAINED-for-a-later-phase actor
+    // `commit_delivery`/`release_delivery` methods to keep that machinery proven
+    // correct (lease COMMIT advances `confirmed_end_offset`, B2 single-holder
+    // contention, commit idempotency on the monotonic CAS, deadline reclaim,
+    // release). The `watcher_inline_*` tests assert the NEW production inline
+    // path (synchronous commit+advance, acquire-time self-reclaim). All run on a
+    // gated clock (`current_thread`/`start_paused`), mirroring the 26-test
+    // finalizer matrix style.
     // =======================================================================
     mod delivery_lease_p1_1 {
         use super::super::{LeaseHolder, LeaseOutcome, TurnFinalizer, TurnKey};
@@ -3144,6 +3168,124 @@ mod tests {
                 assert!(
                     lease.try_acquire(turn2, watcher(2), 24, 48, 1_000),
                     "released cell is free for the next turn"
+                );
+            })
+            .await;
+        }
+
+        /// Issue 1 (HIGH) — acquire-time SELF-RECLAIM of a dead holder, the REAL
+        /// black-hole path: a holder `try_acquire`s and then "dies" (never
+        /// commits/releases) on a cold path where NO finalizer `Terminal` message
+        /// ever cached `SharedData`. Without acquire-time self-reclaim a
+        /// replacement watcher would B2-skip the stuck `Leased` lease forever
+        /// (permanent black-hole). This asserts the REAL fix: a replacement
+        /// reclaims the EXPIRED lease at acquire time and SUCCEEDS — WITHOUT any
+        /// finalizer actor, `SharedData`, or reconcile tick involved. It also
+        /// asserts a NON-expired live lease still B2-skips (single-holder, §5.2).
+        #[tokio::test(flavor = "current_thread", start_paused = true)]
+        async fn watcher_inline_acquire_reclaims_dead_holder_without_terminal() {
+            with_isolated_runtime_root(|| async move {
+                let shared = make_shared_data_for_tests_with_storage(None, None);
+                let ch = ChannelId::new(7007);
+                let lease = shared.delivery_lease(ch);
+                let dead_turn = TurnKey::new(ch, 101, 0);
+                let dead = watcher(1);
+
+                // Dead holder acquires with deadline 100 (monotonic units) and
+                // then dies — never commits, never releases. No `SharedData` was
+                // ever cached in any finalizer (we never spawn/route a Terminal).
+                assert!(lease.try_acquire(dead_turn, dead, 0, 40, 100));
+
+                // BEFORE the deadline: a NON-expired live lease still B2-skips —
+                // the replacement's acquire-time reclaim is a no-op and the
+                // acquire loses (single-holder invariant intact, no duplicate).
+                let live = watcher(2);
+                assert!(
+                    !lease.reclaim_if_expired(50),
+                    "a non-expired lease must NOT be reclaimed (would reintroduce duplicates)"
+                );
+                assert!(
+                    !lease.try_acquire(dead_turn, live, 0, 40, 100),
+                    "B2: a replacement cannot acquire while the holder's lease is live (non-expired)"
+                );
+
+                // AFTER the deadline: the replacement's acquire-time
+                // `reclaim_if_expired` frees the dead holder's EXPIRED lease, then
+                // its `try_acquire` SUCCEEDS — the range is delivered, NOT
+                // black-holed. This is the exact in-watcher self-heal sequence
+                // (reclaim_if_expired immediately before try_acquire), with NO
+                // finalizer/SharedData/reconcile dependency.
+                let replacement = watcher(3);
+                let now_after_deadline = 150_u64;
+                let reclaimed = lease.reclaim_if_expired(now_after_deadline);
+                assert!(
+                    reclaimed,
+                    "acquire-time reclaim must free the dead holder's EXPIRED lease"
+                );
+                assert!(
+                    lease.try_acquire(
+                        dead_turn,
+                        replacement,
+                        0,
+                        40,
+                        now_after_deadline.saturating_add(1_000),
+                    ),
+                    "the replacement acquires the reclaimed cell and delivers (no black-hole)"
+                );
+            })
+            .await;
+        }
+
+        /// Issue 2 (HIGH) — the inline commit advances `confirmed_end_offset`
+        /// SYNCHRONOUSLY by the time control returns to the caller (no
+        /// actor-deferral window). This replicates the EXACT in-watcher inline
+        /// sequence (`cell.commit(Delivered)` then `advance_watcher_confirmed_end`)
+        /// and asserts the offset is already advanced with NO `.await` on any
+        /// actor in between — closing the #3143 duplicate window the deferred
+        /// actor-commit had reopened.
+        #[tokio::test(flavor = "current_thread", start_paused = true)]
+        async fn watcher_inline_commit_advances_offset_synchronously() {
+            with_isolated_runtime_root(|| async move {
+                let shared = make_shared_data_for_tests_with_storage(None, None);
+                let ch = ChannelId::new(7008);
+                let lease = shared.delivery_lease(ch);
+                let turn = TurnKey::new(ch, 202, 0);
+                let h = watcher(1);
+
+                assert!(lease.try_acquire(turn, h, 0, 96, 1_000));
+                assert_eq!(
+                    shared.committed_relay_offset(ch),
+                    0,
+                    "no advance before commit"
+                );
+
+                // The INLINE production sequence: synchronous cell commit, then
+                // (on Delivered) the synchronous offset advance — NO actor await.
+                let committed = lease.commit(h, turn, 0, 96, LeaseOutcome::Delivered);
+                assert!(committed, "fresh lease commits");
+                super::super::super::tmux::advance_watcher_confirmed_end(
+                    &shared,
+                    &ProviderKind::Claude,
+                    ch,
+                    "p1-1-inline-session",
+                    96,
+                    "test:watcher_inline_commit_advances_offset_synchronously",
+                );
+
+                // By the time control returns here — with no actor round-trip in
+                // between — the offset is ALREADY advanced. There is no window in
+                // which `committed_relay_offset` still reads the old value.
+                assert_eq!(
+                    shared.committed_relay_offset(ch),
+                    96,
+                    "inline commit+advance moves confirmed_end_offset synchronously \
+                     (no actor-deferral duplicate window)"
+                );
+
+                // Inline same-holder release returns the cell to Unleased.
+                assert!(
+                    lease.release(h, turn, 0, 96),
+                    "inline release frees the committed cell for the next turn"
                 );
             })
             .await;

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -1061,6 +1061,11 @@ fn handle_commit_delivery(
     shared: &SharedData,
 ) -> bool {
     let committed = lease.commit(holder, key, start, end, outcome);
+    // `mod tmux` (and `advance_watcher_confirmed_end`) is `#[cfg(unix)]` — the
+    // tmux relay only runs on unix. Gate the watermark advance accordingly; on
+    // non-unix this dormant handler commits the lease without an advance and
+    // consumes the otherwise-unused unix-only params.
+    #[cfg(unix)]
     if committed && outcome == LeaseOutcome::Delivered {
         super::tmux::advance_watcher_confirmed_end(
             shared,
@@ -1071,6 +1076,8 @@ fn handle_commit_delivery(
             "src/services/discord/turn_finalizer.rs:commit_delivery_advance",
         );
     }
+    #[cfg(not(unix))]
+    let _ = (shared, provider, tmux_session_name);
     committed
 }
 
@@ -3246,6 +3253,9 @@ mod tests {
         /// and asserts the offset is already advanced with NO `.await` on any
         /// actor in between — closing the #3143 duplicate window the deferred
         /// actor-commit had reopened.
+        // `advance_watcher_confirmed_end` lives in the `#[cfg(unix)] mod tmux`;
+        // this test drives it directly, so it is unix-only.
+        #[cfg(unix)]
         #[tokio::test(flavor = "current_thread", start_paused = true)]
         async fn watcher_inline_commit_advances_offset_synchronously() {
             with_isolated_runtime_root(|| async move {

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -1015,12 +1015,14 @@ async fn do_finalize(
 
 // #3041 §2-§3 — delivery-lease handlers: thin wrappers over the
 // `DeliveryLeaseCell` state machine (mod.rs), run in the actor task. P1-1 wires
-// the WATCHER terminal path (commit/release go through the actor via the public
-// `commit_delivery`/`release_delivery` methods; acquire is the cell fast-path).
-// The acquire/release handler wrappers and the `AcquireDelivery` message remain
-// available for the sink/bridge wiring (P1-2..) but the watcher acquires the
-// cell directly (B4 fast-path), so `handle_acquire_delivery` is currently only
-// reached via the (still-routed) `AcquireDelivery` actor arm and tests.
+// the WATCHER terminal path, but after the R2 revert the watcher acquires,
+// commits, and releases the cell INLINE (synchronously) on its own task — it
+// does NOT route through these actor handlers. The `AcquireDelivery` /
+// `CommitDelivery` / `ReleaseDelivery` messages and their `handle_*` wrappers
+// are DORMANT here: retained (and unit-tested) for the sink/bridge wiring
+// (P1-2..), but the live watcher path no longer uses them. `commit_delivery` /
+// `release_delivery` (the public actor methods below) and these handlers are
+// reached only by tests today.
 
 /// CAS-acquire for `(key, [start,end))` on behalf of `holder`. #3041. Still
 /// dormant in the non-test build: the watcher acquires the cell directly

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -375,7 +375,11 @@ enum FinalizeMsg {
         shared: Arc<SharedData>,
         ack: oneshot::Sender<FinalizeOutcome>,
     },
-    /// #3041 §2-§3 P1-0 (DORMANT): CAS-acquire `(key, [start,end))` for `holder`.
+    /// #3041 §2-§3 (DORMANT until P1-2..): CAS-acquire `(key, [start,end))` for
+    /// `holder` via the actor. The watcher acquires the cell directly (B4
+    /// fast-path), so this variant has no sender yet — it is reserved for the
+    /// sink/bridge wiring.
+    #[allow(dead_code)] // #3041: no sender until sink/bridge wiring (P1-2..).
     AcquireDelivery {
         key: TurnKey,
         lease: Arc<DeliveryLeaseCell>,
@@ -385,7 +389,14 @@ enum FinalizeMsg {
         deadline_ms: u64,
         ack: oneshot::Sender<bool>,
     },
-    /// #3041 §2-§3 P1-0 (DORMANT): three-way commit; full-identity mismatch = no-op.
+    /// #3041 P1-1: three-way commit; full-identity mismatch = no-op. On a
+    /// `Delivered` commit the handler also advances the channel's
+    /// `confirmed_end_offset` watermark to `end` (§5.2 atomicity) via the SAME
+    /// monotonic CAS the watcher's inline advance used, so commit-advances-offset
+    /// and the lease transition are one serialized unit on the finalize owner.
+    /// `provider`/`tmux_session_name`/`shared` are carried so the handler can call
+    /// `advance_watcher_confirmed_end` (the `.generation`-mtime bookkeeping needs
+    /// the session name). They are `None`/unused for non-watcher holders.
     CommitDelivery {
         key: TurnKey,
         lease: Arc<DeliveryLeaseCell>,
@@ -393,6 +404,9 @@ enum FinalizeMsg {
         start: u64,
         end: u64,
         outcome: LeaseOutcome,
+        provider: ProviderKind,
+        tmux_session_name: String,
+        shared: Arc<SharedData>,
         ack: oneshot::Sender<bool>,
     },
     /// #3041 §2-§3 P1-0 (DORMANT): compare-and-release; full-identity match only.
@@ -480,6 +494,77 @@ impl TurnFinalizer {
             return FinalizeOutcome::AlreadyFinalized;
         }
         rx.await.unwrap_or(FinalizeOutcome::AlreadyFinalized)
+    }
+
+    /// #3041 P1-1: route a three-way `CommitDelivery` through the actor so the
+    /// lease transition AND the `Delivered`-commit offset advance run as one
+    /// serialized unit on the finalize owner (B4: commit/release/reclaim are
+    /// actor transitions; only acquire/read are atomic fast-paths on the cell).
+    /// Returns whether the lease actually committed (identity matched a live
+    /// `Leased` lease). If the actor task is gone (teardown) returns `false`.
+    pub(in crate::services::discord) async fn commit_delivery(
+        &self,
+        key: TurnKey,
+        lease: Arc<DeliveryLeaseCell>,
+        holder: LeaseHolder,
+        start: u64,
+        end: u64,
+        outcome: LeaseOutcome,
+        provider: ProviderKind,
+        tmux_session_name: String,
+        shared: Arc<SharedData>,
+    ) -> bool {
+        let (ack, rx) = oneshot::channel();
+        if self
+            .tx
+            .send(FinalizeMsg::CommitDelivery {
+                key,
+                lease,
+                holder,
+                start,
+                end,
+                outcome,
+                provider,
+                tmux_session_name,
+                shared,
+                ack,
+            })
+            .is_err()
+        {
+            return false;
+        }
+        rx.await.unwrap_or(false)
+    }
+
+    /// #3041 P1-1: route a compare-and-`ReleaseDelivery` through the actor (B4:
+    /// release is an actor transition). Returns the standard
+    /// `Committed`/`Leased` → `Unleased` result; identity mismatch is a no-op
+    /// `false`. The watcher releases its lease after committing so the cell is
+    /// free for the next turn. If the actor task is gone returns `false`.
+    pub(in crate::services::discord) async fn release_delivery(
+        &self,
+        key: TurnKey,
+        lease: Arc<DeliveryLeaseCell>,
+        holder: LeaseHolder,
+        start: u64,
+        end: u64,
+    ) -> bool {
+        let (ack, rx) = oneshot::channel();
+        if self
+            .tx
+            .send(FinalizeMsg::ReleaseDelivery {
+                key,
+                lease,
+                holder,
+                start,
+                end,
+                ack,
+            })
+            .is_err()
+        {
+            return false;
+        }
+        rx.await.unwrap_or(false)
     }
 }
 
@@ -573,10 +658,22 @@ async fn actor_loop(mut rx: mpsc::UnboundedReceiver<FinalizeMsg>) {
                         start,
                         end,
                         outcome,
+                        provider,
+                        tmux_session_name,
+                        shared,
                         ack,
                     } => {
-                        let committed =
-                            handle_commit_delivery(&lease, key, holder, start, end, outcome);
+                        let committed = handle_commit_delivery(
+                            &lease,
+                            key,
+                            holder,
+                            start,
+                            end,
+                            outcome,
+                            &provider,
+                            &tmux_session_name,
+                            &shared,
+                        );
                         let _ = ack.send(committed);
                     }
                     FinalizeMsg::ReleaseDelivery {
@@ -897,11 +994,19 @@ async fn do_finalize(
     }
 }
 
-// #3041 §2-§3 P1-0 — Dormant delivery-lease handlers: thin wrappers over the
-// `DeliveryLeaseCell` state machine (mod.rs), run in the actor task. No senders yet.
+// #3041 §2-§3 — delivery-lease handlers: thin wrappers over the
+// `DeliveryLeaseCell` state machine (mod.rs), run in the actor task. P1-1 wires
+// the WATCHER terminal path (commit/release go through the actor via the public
+// `commit_delivery`/`release_delivery` methods; acquire is the cell fast-path).
+// The acquire/release handler wrappers and the `AcquireDelivery` message remain
+// available for the sink/bridge wiring (P1-2..) but the watcher acquires the
+// cell directly (B4 fast-path), so `handle_acquire_delivery` is currently only
+// reached via the (still-routed) `AcquireDelivery` actor arm and tests.
 
-/// CAS-acquire for `(key, [start,end))` on behalf of `holder`. #3041 P1-0.
-#[allow(dead_code)] // #3041 P1-0: dormant, wired in P1-1..
+/// CAS-acquire for `(key, [start,end))` on behalf of `holder`. #3041. Still
+/// dormant in the non-test build: the watcher acquires the cell directly
+/// (B4 fast-path) and no other holder routes `AcquireDelivery` yet (P1-2..).
+#[allow(dead_code)] // #3041: AcquireDelivery actor arm dormant until sink/bridge wiring.
 fn handle_acquire_delivery(
     lease: &DeliveryLeaseCell,
     key: TurnKey,
@@ -913,8 +1018,16 @@ fn handle_acquire_delivery(
     lease.try_acquire(key, holder, start, end, deadline_ms)
 }
 
-/// Three-way commit; full `(holder, key, [start,end))` mismatch = no-op. #3041.
-#[allow(dead_code)] // #3041 P1-0: dormant, wired in P1-1..
+/// Three-way commit; full `(holder, key, [start,end))` mismatch = no-op. #3041
+/// P1-1: on a successful `Delivered` commit, advance the channel's
+/// `confirmed_end_offset` watermark to `end` (§5.2). The advance is gated on the
+/// `lease.commit` having actually committed (identity matched AND state was
+/// `Leased`), so a stale/duplicate commit that the lease rejects does NOT touch
+/// the offset. The advance itself reuses `advance_watcher_confirmed_end`'s
+/// monotonic CAS, so even if the lease somehow let a same-range commit through
+/// twice the watermark only ever moves forward — no double-advance
+/// (`tmux_confirmed_end_monotonic` holds). `NotDelivered`/`Unknown` never
+/// advance: an ambiguous terminal must not claim bytes as delivered.
 fn handle_commit_delivery(
     lease: &DeliveryLeaseCell,
     key: TurnKey,
@@ -922,8 +1035,22 @@ fn handle_commit_delivery(
     start: u64,
     end: u64,
     outcome: LeaseOutcome,
+    provider: &ProviderKind,
+    tmux_session_name: &str,
+    shared: &SharedData,
 ) -> bool {
-    lease.commit(holder, key, start, end, outcome)
+    let committed = lease.commit(holder, key, start, end, outcome);
+    if committed && outcome == LeaseOutcome::Delivered {
+        super::tmux::advance_watcher_confirmed_end(
+            shared,
+            provider,
+            key.channel_id,
+            tmux_session_name,
+            end,
+            "src/services/discord/turn_finalizer.rs:commit_delivery_advance",
+        );
+    }
+    committed
 }
 
 /// Compare-and-release; full `(holder, key, [start,end))` match only. #3041.
@@ -945,6 +1072,15 @@ fn handle_release_delivery(
 /// bounded.
 async fn reconcile(ledger: &mut HashMap<LedgerKey, LedgerEntry>, shared: &Arc<SharedData>) {
     let now = Instant::now();
+
+    // #3041 P1-1 (B3): reclaim any delivery lease whose acquire deadline has
+    // elapsed (a dead/stuck holder), so a legitimate successor can acquire. This
+    // runs on the reconcile tick (1s) and is identity-agnostic; a `Committed`
+    // lease is never reclaimed (it awaits an explicit holder release). Uses the
+    // process-monotonic `lease_now_ms()` clock — the SAME clock the watcher's
+    // acquire deadline is computed against — so a live holder mid-send (deadline
+    // 90s out) is never reclaimed.
+    let _ = shared.reclaim_expired_delivery_leases(super::lease_now_ms());
 
     // Collect deadline-elapsed gate-timeout entries to finalize. We must not
     // hold a `&mut` borrow across the `do_finalize` await, so snapshot first.
@@ -2757,6 +2893,274 @@ mod tests {
     }
 
     // =======================================================================
+    // #3041 P1-1 — LIVE watcher-terminal-delivery lease wiring tests.
+    //
+    // These exercise the wiring P1-1 added: the lease COMMIT advancing
+    // `confirmed_end_offset` through the actor, B2 single-holder contention,
+    // commit idempotency on the monotonic-CAS offset, and deadline reclaim of a
+    // dead holder. They run on a gated clock (`current_thread`/`start_paused`)
+    // and through the public `commit_delivery`/`release_delivery` actor methods
+    // — the same path the watcher uses — mirroring the 26-test finalizer matrix
+    // style.
+    // =======================================================================
+    mod delivery_lease_p1_1 {
+        use super::super::{LeaseHolder, LeaseOutcome, TurnFinalizer, TurnKey};
+        // `make_shared_data_for_tests_with_storage` lives in the discord module
+        // (mod.rs), three module hops up from here (p1_1 → tests → turn_finalizer
+        // → discord). `with_isolated_runtime_root` is in the parent `tests` mod.
+        use super::super::super::make_shared_data_for_tests_with_storage;
+        use super::with_isolated_runtime_root;
+        use crate::services::discord::DeliveryLeaseCell;
+        use crate::services::provider::ProviderKind;
+        use serenity::model::id::ChannelId;
+        use std::sync::Arc;
+
+        fn watcher(id: u64) -> LeaseHolder {
+            LeaseHolder::Watcher { instance_id: id }
+        }
+
+        /// Watcher/Delivered: a freshly-acquired lease committed `Delivered`
+        /// advances `confirmed_end_offset` to the leased `end` EXACTLY ONCE, and
+        /// no duplicate occurs.
+        #[tokio::test(flavor = "current_thread", start_paused = true)]
+        async fn watcher_delivered_advances_offset_once() {
+            with_isolated_runtime_root(|| async move {
+                let shared = make_shared_data_for_tests_with_storage(None, None);
+                let fin = TurnFinalizer::spawn();
+                let ch = ChannelId::new(7001);
+                let lease = shared.delivery_lease(ch);
+                let turn = TurnKey::new(ch, 11, 0);
+                let h = watcher(1);
+
+                // Acquire on the cell (the watcher fast-path), then commit through
+                // the actor (the path the watcher uses).
+                assert!(lease.try_acquire(turn, h, 0, 64, 1_000));
+                let committed = fin
+                    .commit_delivery(
+                        turn,
+                        lease.clone(),
+                        h,
+                        0,
+                        64,
+                        LeaseOutcome::Delivered,
+                        ProviderKind::Claude,
+                        "p1-1-delivered-session".to_string(),
+                        shared.clone(),
+                    )
+                    .await;
+                assert!(committed, "fresh lease must commit");
+                assert_eq!(
+                    shared.committed_relay_offset(ch),
+                    64,
+                    "Delivered commit advances confirmed_end_offset to the leased end"
+                );
+            })
+            .await;
+        }
+
+        /// Watcher acquire-contention (B2): two watcher instances race to acquire
+        /// the SAME turn/range on one channel; exactly one acquires (and would
+        /// send), the other is rejected and must skip its duplicate send.
+        #[tokio::test(flavor = "current_thread", start_paused = true)]
+        async fn watcher_acquire_contention_admits_one_holder() {
+            with_isolated_runtime_root(|| async move {
+                let shared = make_shared_data_for_tests_with_storage(None, None);
+                let ch = ChannelId::new(7002);
+                let lease = shared.delivery_lease(ch);
+                let turn = TurnKey::new(ch, 22, 0);
+
+                let w1 = watcher(1);
+                let w2 = watcher(2);
+                // First watcher acquires for [0,32).
+                assert!(lease.try_acquire(turn, w1, 0, 32, 5_000));
+                // Replacement watcher's acquire for the SAME turn/range loses
+                // while w1 still holds it (B2: it must NOT re-acquire+re-emit).
+                assert!(
+                    !lease.try_acquire(turn, w2, 0, 32, 5_000),
+                    "B2: a second watcher cannot acquire the live lease"
+                );
+                // No offset advanced yet (nothing committed).
+                assert_eq!(shared.committed_relay_offset(ch), 0);
+            })
+            .await;
+        }
+
+        /// Watcher/Unknown: a commit with `Unknown` outcome (ambiguous terminal —
+        /// e.g. lifecycle-paused TUI gate) does NOT advance the offset.
+        #[tokio::test(flavor = "current_thread", start_paused = true)]
+        async fn watcher_unknown_commit_does_not_advance_offset() {
+            with_isolated_runtime_root(|| async move {
+                let shared = make_shared_data_for_tests_with_storage(None, None);
+                let fin = TurnFinalizer::spawn();
+                let ch = ChannelId::new(7003);
+                let lease = shared.delivery_lease(ch);
+                let turn = TurnKey::new(ch, 33, 0);
+                let h = watcher(1);
+
+                assert!(lease.try_acquire(turn, h, 0, 48, 1_000));
+                let committed = fin
+                    .commit_delivery(
+                        turn,
+                        lease.clone(),
+                        h,
+                        0,
+                        48,
+                        LeaseOutcome::Unknown,
+                        ProviderKind::Claude,
+                        "p1-1-unknown-session".to_string(),
+                        shared.clone(),
+                    )
+                    .await;
+                assert!(committed, "Unknown still commits the lease state");
+                assert_eq!(
+                    shared.committed_relay_offset(ch),
+                    0,
+                    "Unknown outcome must NOT advance the confirmed offset"
+                );
+            })
+            .await;
+        }
+
+        /// Watcher/Delivered then a SECOND commit of the same range is idempotent
+        /// on the offset (monotonic CAS): the second commit is a lease no-op (the
+        /// cell is Committed, not Leased) and the offset does not double-advance.
+        #[tokio::test(flavor = "current_thread", start_paused = true)]
+        async fn watcher_second_commit_is_idempotent_on_offset() {
+            with_isolated_runtime_root(|| async move {
+                let shared = make_shared_data_for_tests_with_storage(None, None);
+                let fin = TurnFinalizer::spawn();
+                let ch = ChannelId::new(7004);
+                let lease = shared.delivery_lease(ch);
+                let turn = TurnKey::new(ch, 44, 0);
+                let h = watcher(1);
+
+                assert!(lease.try_acquire(turn, h, 0, 80, 1_000));
+                assert!(
+                    fin.commit_delivery(
+                        turn,
+                        lease.clone(),
+                        h,
+                        0,
+                        80,
+                        LeaseOutcome::Delivered,
+                        ProviderKind::Claude,
+                        "p1-1-idem-session".to_string(),
+                        shared.clone(),
+                    )
+                    .await
+                );
+                assert_eq!(shared.committed_relay_offset(ch), 80);
+
+                // A second commit of the same range: the lease is now Committed,
+                // so `commit` is a no-op (returns false) and the handler does NOT
+                // advance. Even if it did, the monotonic CAS would refuse to move
+                // the watermark backward or re-advance it.
+                let second = fin
+                    .commit_delivery(
+                        turn,
+                        lease.clone(),
+                        h,
+                        0,
+                        80,
+                        LeaseOutcome::Delivered,
+                        ProviderKind::Claude,
+                        "p1-1-idem-session".to_string(),
+                        shared.clone(),
+                    )
+                    .await;
+                assert!(!second, "second commit on a Committed lease is a no-op");
+                assert_eq!(
+                    shared.committed_relay_offset(ch),
+                    80,
+                    "offset must not double-advance on a repeated commit"
+                );
+            })
+            .await;
+        }
+
+        /// Deadline reclaim of a dead holder: a leased-but-never-committed cell
+        /// past its deadline is reclaimed by `reclaim_expired_delivery_leases`,
+        /// returns to Unleased, and a later legitimate acquire succeeds.
+        #[tokio::test(flavor = "current_thread", start_paused = true)]
+        async fn deadline_reclaim_frees_cell_for_later_acquire() {
+            with_isolated_runtime_root(|| async move {
+                let shared = make_shared_data_for_tests_with_storage(None, None);
+                let ch = ChannelId::new(7005);
+                let lease = shared.delivery_lease(ch);
+                let turn_a = TurnKey::new(ch, 55, 0);
+                let dead = watcher(1);
+
+                // A holder acquires with deadline 100ms (monotonic units) but never
+                // commits/releases (dead).
+                assert!(lease.try_acquire(turn_a, dead, 0, 16, 100));
+                // Before the deadline, the sweep is a no-op and the cell stays held.
+                assert_eq!(shared.reclaim_expired_delivery_leases(50), 0);
+                assert!(!lease.try_acquire(turn_a, watcher(2), 0, 16, 100));
+                // Past the deadline, the sweep reclaims exactly this cell.
+                assert_eq!(shared.reclaim_expired_delivery_leases(100), 1);
+                // A later legitimate acquire (new instance, new turn) succeeds.
+                let turn_b = TurnKey::new(ch, 66, 0);
+                assert!(
+                    lease.try_acquire(turn_b, watcher(3), 16, 32, 1_000),
+                    "a reclaimed cell is acquirable again"
+                );
+            })
+            .await;
+        }
+
+        /// Release after commit returns the cell to Unleased so the NEXT turn can
+        /// acquire — the lifecycle the watcher drives (acquire→commit→release).
+        #[tokio::test(flavor = "current_thread", start_paused = true)]
+        async fn release_after_commit_frees_cell_for_next_turn() {
+            with_isolated_runtime_root(|| async move {
+                let shared = make_shared_data_for_tests_with_storage(None, None);
+                let fin = TurnFinalizer::spawn();
+                let ch = ChannelId::new(7006);
+                let lease = shared.delivery_lease(ch);
+                let turn1 = TurnKey::new(ch, 77, 0);
+                let h = watcher(1);
+
+                assert!(lease.try_acquire(turn1, h, 0, 24, 1_000));
+                assert!(
+                    fin.commit_delivery(
+                        turn1,
+                        lease.clone(),
+                        h,
+                        0,
+                        24,
+                        LeaseOutcome::Delivered,
+                        ProviderKind::Claude,
+                        "p1-1-release-session".to_string(),
+                        shared.clone(),
+                    )
+                    .await
+                );
+                assert!(
+                    fin.release_delivery(turn1, lease.clone(), h, 0, 24).await,
+                    "the holder releases its committed lease"
+                );
+                // Next turn (different range) can now acquire the freed cell.
+                let turn2 = TurnKey::new(ch, 88, 0);
+                assert!(
+                    lease.try_acquire(turn2, watcher(2), 24, 48, 1_000),
+                    "released cell is free for the next turn"
+                );
+            })
+            .await;
+        }
+
+        fn _assert_send<T: Send>(_: &T) {}
+
+        /// The shared lease cell is `Send + Sync` (it is shared across watcher
+        /// instances via `Arc` and passed into the actor task).
+        #[test]
+        fn lease_cell_is_send_sync() {
+            let c: Arc<DeliveryLeaseCell> = Arc::new(DeliveryLeaseCell::new(ChannelId::new(9)));
+            _assert_send(&c);
+        }
+    }
+
+    // =======================================================================
     // #3041 §2-§3 §6 P1-0 — Dormant `DeliveryLeaseCell` state-machine tests.
     //
     // The cell is wired into no call path yet (P1-1..), but its transitions
@@ -3098,13 +3502,20 @@ mod tests {
                 6,
                 1_000
             ));
+            // #3041 P1-1: the commit handler now takes provider/session/shared so
+            // a `Delivered` commit can advance the channel watermark. Supply a
+            // throwaway `SharedData`; the advance targets the cell's channel (42).
+            let shared = super::super::super::make_shared_data_for_tests_with_storage(None, None);
             assert!(handle_commit_delivery(
                 &c,
                 turn(),
                 h,
                 0,
                 6,
-                LeaseOutcome::Delivered
+                LeaseOutcome::Delivered,
+                &crate::services::provider::ProviderKind::Claude,
+                "dormant-handler-test-session",
+                &shared,
             ));
             assert!(!handle_release_delivery(
                 &c,

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -1099,8 +1099,9 @@ async fn reconcile(ledger: &mut HashMap<LedgerKey, LedgerEntry>, shared: &Arc<Sh
     // runs on the reconcile tick (1s) and is identity-agnostic; a `Committed`
     // lease is never reclaimed (it awaits an explicit holder release). Uses the
     // process-monotonic `lease_now_ms()` clock — the SAME clock the watcher's
-    // acquire deadline is computed against — so a live holder mid-send (deadline
-    // 90s out) is never reclaimed.
+    // acquire deadline is computed against — so a live holder mid-send (whose
+    // ~15s deadline is kept ahead by the watcher's heartbeat-renew) is never
+    // reclaimed.
     let _ = shared.reclaim_expired_delivery_leases(super::lease_now_ms());
 
     // Collect deadline-elapsed gate-timeout entries to finalize. We must not


### PR DESCRIPTION
## #3041 P1-1 — first LIVE delivery-lease wiring (watcher terminal path)

Wires the WATCHER terminal delivery through the (previously dormant, P1-0)
`DeliveryLeaseCell`. The watcher acquires the per-channel lease before its
terminal direct-send and commits it after; the lease **COMMIT** — not the
inline advance — is now the single thing that advances `confirmed_end_offset`
on a `Delivered` outcome (design §5.2 atomicity). Behavior-changing but minimal.

### Wiring
- **Live lease field** — `TmuxRelayCoord.delivery_lease: Arc<DeliveryLeaseCell>`
  (`mod.rs`), constructed in `TmuxRelayCoord::new(channel_id)`, **alongside**
  `relay_slot` (NOT removed — its guard migration is a later step). Accessors:
  `SharedData::delivery_lease(channel)` and `reclaim_expired_delivery_leases(now_ms)`.
- **Watcher acquire→send→commit** (`tmux_watcher.rs`): per-spawn `instance_id`;
  pre-send `try_acquire` on the turn-pinned id (`pinned_finalize_user_msg_id`,
  the #3141 id-pinning) + byte range `[data_start, terminal_event_consumed_offset)`;
  after the send the actor `commit_delivery` (3-way outcome) + `release_delivery`.
- **Commit advances offset** (`turn_finalizer.rs`): `CommitDelivery` on
  `Delivered` advances the watermark to `end` via the SAME monotonic CAS
  (`advance_watcher_confirmed_end`, now `pub(in discord)`), so a repeated commit
  cannot double-advance (`tmux_confirmed_end_monotonic` holds). `NotDelivered`/
  `Unknown` never advance. The watcher's inline advance for the terminal path is
  replaced by this (unrelated committed paths keep the inline advance).

### B2 single-holder (§5.2)
While the lease is `Leased`, a replacement watcher's `try_acquire` for the same
turn/range returns false and it routes to a dedicated **skip arm** — no
duplicate send. The same-holder partial-send retry abandon-releases its own
lease first so the retry can re-acquire (no self-deadlock).

### B3 deadline
`WATCHER_DELIVERY_LEASE_DEADLINE_MS = 90s` — worst-case multi-chunk
rate-limited send (≈20+ chunks × 500ms inter-chunk pacing + the 10s session-bound
ACK wait + HTTP/rate-limit slack), NOT a single POST. The finalizer reconcile
tick (1s) calls `reclaim_if_expired` on the process-monotonic `lease_now_ms()`
clock so a dead holder's lease is reclaimed; a live holder mid-send is never
reclaimed. B4: acquire/read are the cell fast-path; commit/release/reclaim are
actor transitions.

### Deferred (NOT in P1-1)
sink/bridge committers (P1-2), the 10s blind re-send removal (P1-3, ACK polling
kept for parity here — residual same-holder re-send window is offset-idempotent),
Err-leak RAII (P1-4, the 90s reclaim is the safety net meanwhile), 2→3-way sink
enum (P1-5).

### Tests
+7 gated-clock (`tokio::time::pause`) P1-1 cases mirroring the matrix style:
Watcher/Delivered advances offset exactly once; B2 acquire-contention (one
acquires+sends, the other skips); Watcher/Unknown no-advance; second commit of
the same range is idempotent (no double-advance); deadline reclaim frees the
cell for a later legitimate acquire; release-after-commit frees the cell for the
next turn. Existing **26** finalizer matrix + **15** dormant lease tests stay
green; #3141 finalize guards and #3143 relay dedup intact.

### Verification (macOS local, all green)
`cargo fmt --check` ✓ · `cargo build --all-targets` ✓ · clippy 11 warnings =
baseline (no new) ✓ · `turn_finalizer::` 48 ✓ · `delivery_lease` 22 ✓ · `relay`
199 ✓ · `offset` 48 ✓ · `transition` 3 / `cancel` 94 ✓ · `tmux_watcher` 103 ✓ ·
`check_agent_maintenance_docs.py` ✓ (giant-file freeze entries synced:
tmux.rs 2238, tmux_watcher.rs 7981).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## R2 update (codex P1-1 round-2 findings)

### Inline commit (supersedes the actor-commit description above)
The earlier actor `commit_delivery`/`release_delivery` round-trip was reverted:
the watcher now commits the lease + advances `confirmed_end_offset` **INLINE**
(synchronously) on its own task, closing the #3143 read-only-offset duplicate
window the deferred actor-commit had reopened. The actor
`AcquireDelivery`/`CommitDelivery`/`ReleaseDelivery` handlers are **DORMANT**
(retained for the sink/bridge wiring in a later phase, unit-tested, but NOT the
live watcher path). Stale "actor drives the advance" comments/docs were fixed
(`change-surfaces.md`, `tmux.rs`, `turn_finalizer.rs`).

### Issue 1 (HIGH) — heartbeat-renew so a long live send is never reclaimed mid-flight
A fixed 90s deadline is **not** a correctness bound: an unbounded response splits
into 2000-char chunks paced ~500ms apart behind a 1s rate limiter, so a 60+
chunk answer can exceed 90s and get reclaimed mid-send → the original holder's
`commit` then fails and never advances the offset → duplicate.

Fix — implement the design §3 **HEARTBEAT/RENEW**:
- New `DeliveryLeaseCell::renew(holder, turn, new_deadline_ms) -> bool`: extends
  the deadline IFF the cell is `Leased` by EXACTLY `(holder, turn)` (matched on
  holder + `turn.exact_key()`, under the same payload mutex as every mutation);
  any other state — wrong holder, stale turn, `Committed`/`Unleased` — is a
  no-op `false`. It can only ever extend the caller's OWN live lease.
- A `DeliveryLeaseHeartbeat` background Tokio task is spawned right after a
  successful `try_acquire` and `renew()`s the lease every **5s**
  (`lease_now_ms() + DEADLINE`). It is **stopped before the inline commit** (and
  `abort`s on drop), so the renew loop can never race the commit; a last tick
  between stop and commit only extends our own still-`Leased` deadline, which the
  commit immediately flips to `Committed`. Because the heartbeat is owned by the
  watcher task, a dead watcher stops renewing → the lease expires → a replacement
  reclaims it.
- `WATCHER_DELIVERY_LEASE_DEADLINE_MS` reduced **90s → 15s** (= 3× the 5s
  heartbeat: covers a missed/late tick for a live holder, while a genuinely dead
  holder is reclaimed in ~15s instead of 90s). The deadline is now a
  HOLDER-LIVENESS signal, not a delivery-time cap.

New gated-clock tests (`tokio::time::pause`):
(a) `long_send_heartbeat_renew_prevents_midsend_reclaim` — a send longer than the
deadline keeps the lease via renews; a reclaim past the original deadline is a
no-op and the original holder's commit succeeds + advances exactly once.
(b) `dead_holder_no_renew_is_reclaimed_after_short_deadline` — a holder whose
heartbeat is dropped (never renews) is reclaimed after the short deadline and a
replacement acquires.
(c) `renew_by_non_holder_or_wrong_turn_is_noop` — a non-holder / wrong-turn /
post-commit renew is a no-op and never mutates the deadline.

### Issue 2 (HIGH) — partial-duplicate-on-crash is B5-deferred (Honesty note)
The lease range is the full `[data_start, consumed_end)`. If a holder dies AFTER
posting chunk 1 but BEFORE its commit, the replacement reclaims the expired lease
and re-sends the WHOLE range → a partial duplicate of the already-posted chunks.
**Exact-once on a partial multi-chunk crash is delivered by BLOCKER B5**
(per-message-id multi-chunk partial-commit state), which the #3041 design
EXPLICITLY defers to a later phase — it is NOT built in P1-1.

This is **NOT a P1-1 regression**: with the Issue-1 heartbeat a LIVE holder is
never reclaimed mid-send, so this duplicate can only occur on a GENUINE crash
mid-send — which is EXACTLY the pre-P1-1 behavior (pre-P1-1 had no lease, so a
replacement watcher re-sent the full range on crash too). P1-1 only ADDS a
bounded delay (≤ the 15s deadline) before the replacement finishes delivery.

### R2 verification (macOS local, all green)
`cargo fmt --check` ✓ · `cargo build --all-targets` ✓ · clippy = baseline (no new
warnings) ✓ · `turn_finalizer::` 50 ✓ · `delivery_lease` 27 ✓ (incl. 3 new
heartbeat tests) · `relay` 199 ✓ · `offset` 49 ✓ · `transition` 3 / `cancel`
94 ✓ · `check_agent_maintenance_docs.py` ✓ (giant-file freeze synced:
tmux.rs 2241, tmux_watcher.rs 8166).
