### PR TITLE
feat(#3041): P1-2 route bridge terminal delivery through the delivery-lease (watcher<->bridge serialized; B6 no advance outside lease commit)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -128,7 +128,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (8168 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (8102 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -267,6 +267,13 @@
     split before adding non-bugfix behavior).
   - `src/services/discord/turn_bridge/completion_guard.rs` (1849 lines).
   - `src/services/discord/turn_bridge/tmux_runtime.rs` (1242 lines).
+  - `src/services/discord/turn_bridge/terminal_delivery.rs` (1341 prod lines;
+    registered giant-file (#3036) — bugfix only outside an extraction plan.
+    Crossed 1000 prod LoC with #3041 P1-2: the `BridgeDeliveryLease`
+    acquire/commit_and_advance/heartbeat helper that routes the bridge's terminal
+    delivery through the shared delivery-lease, the watcher-owner-channel
+    resolution, and the skip-epilogue/identity-guarded-save decision seams. Split
+    the lease wiring vs the delivery helpers before adding behavior).
   - `src/services/discord/turn_finalizer.rs` (1011 prod lines; single-authority
     turn-finalize state machine — ledger/actor-loop/reconciler. Crossed the
     giant-file threshold when #3041 P1-0 added the dormant `DeliveryLeaseCell`

--- a/scripts/audit_allowlist.toml
+++ b/scripts/audit_allowlist.toml
@@ -70,7 +70,8 @@ direct_discord_sends = [
   # notice for turns with no anchored Discord message. Consistent with the bridge's
   # existing pre-migration direct sends; retire with the #1436 outbound v3 extraction.
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:d77122f8dd3466ba",
-  "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:37e09c3e1136f9b1"
+  "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:37e09c3e1136f9b1",
+  "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:96efc64ae5a0f315"
 ]
 
 # Manual JSON row mapping: legacy mapping callsites pending typed migration.

--- a/scripts/giant_file_registry.toml
+++ b/scripts/giant_file_registry.toml
@@ -285,3 +285,17 @@ file = "src/services/discord/idle_recap.rs"
 owner = "discord-recap"
 deadline = "2026-08-31"
 decompose_issue = "#3036"
+
+[[entry]]
+# Crossed the 1000-prod-LoC threshold when #3041 P1-2 added the
+# `BridgeDeliveryLease` acquire/heartbeat/commit-advance/release guard that
+# routes the bridge's terminal delivery through the shared per-channel
+# delivery-lease (watcher<->bridge serialization; B6 "no advance outside a lease
+# commit"). The bridge terminal-delivery helpers (chunked/replace senders,
+# replace-outcome commit classification, the lease guard) are cohesive but
+# sizable; decompose the lease guard vs the chunk/replace senders into submodules
+# under #3036.
+file = "src/services/discord/turn_bridge/terminal_delivery.rs"
+owner = "discord-relay"
+deadline = "2026-08-31"
+decompose_issue = "#3036"

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -1213,6 +1213,129 @@ fn save_inflight_state_if_absent_in_root(
     Ok(true)
 }
 
+/// Outcome of [`save_inflight_state_if_matches_identity`] — the #3041 P1-2 R3
+/// identity-guarded re-save used on a delivery-lease `Skip` epilogue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::services::discord) enum GuardedSaveOutcome {
+    /// On-disk row still matched the turn identity; the row was rewritten.
+    Saved,
+    /// No inflight row existed (the lease HOLDER already cleared it on its
+    /// success path). We do NOT resurrect it — the turn is already delivered.
+    Missing,
+    /// A row existed but its identity did NOT match (a newer turn replaced it,
+    /// or a planned-restart / rebind-origin marker now owns the row). We do
+    /// NOT clobber it.
+    IdentityMismatch,
+    /// Filesystem / serialization error during the write.
+    IoError,
+}
+
+/// #3041 P1-2 (codex P1-2 R3): identity-guarded re-save for the bridge's
+/// delivery-lease `Skip` epilogue. On a Skip the live HOLDER (the watcher)
+/// owns this turn's inflight lifecycle and CLEARS the row on its own success.
+/// The bridge's epilogue must therefore NOT blindly `save_inflight_state`: if
+/// the holder's clear (a `remove_file` under the same sidecar lock) won the
+/// race and the bridge's blind re-save ran second, it would resurrect a STALE
+/// inflight row for an already-delivered turn — recovery then sees it as
+/// delivered and returns WITHOUT clearing, leaking the row indefinitely.
+///
+/// This helper closes that window the same way `clear_inflight_state_if_matches`
+/// (#2427 D-wire) does: read the on-disk row under the lock and only write when
+/// it is STILL present AND its `(user_msg_id, started_at, tmux_session_name)`
+/// identity (plus `turn_start_offset`, when known) matches the turn the bridge
+/// is preserving. If the row is gone (holder delivered → `Missing`) or has been
+/// replaced by a newer turn / restart-or-rebind marker (`IdentityMismatch`), we
+/// no-op instead of resurrecting. When the holder FAILED and did NOT clear, the
+/// row is still present + matching, so we refresh it (`Saved`) and retry
+/// survives. Windows-safe: the `lock_inflight_state_path` sidecar flock + the
+/// `atomic_write` rename are the same primitives the rest of the module uses.
+pub(in crate::services::discord) fn save_inflight_state_if_matches_identity(
+    state: &InflightTurnState,
+    expected: &InflightTurnIdentity,
+    expected_turn_start_offset: Option<u64>,
+) -> GuardedSaveOutcome {
+    let Some(root) = inflight_runtime_root() else {
+        return GuardedSaveOutcome::IoError;
+    };
+    save_inflight_state_if_matches_identity_in_root(
+        &root,
+        state,
+        expected,
+        expected_turn_start_offset,
+    )
+}
+
+/// Root-explicit inner form of [`save_inflight_state_if_matches_identity`] for
+/// unit tests (avoids `AGENTDESK_ROOT_DIR` env-var races).
+pub(super) fn save_inflight_state_if_matches_identity_in_root(
+    root: &Path,
+    state: &InflightTurnState,
+    expected: &InflightTurnIdentity,
+    expected_turn_start_offset: Option<u64>,
+) -> GuardedSaveOutcome {
+    let Some(provider) = state.provider_kind() else {
+        return GuardedSaveOutcome::IoError;
+    };
+    let path = inflight_state_path(root, &provider, state.channel_id);
+    if let Some(parent) = path.parent() {
+        if fs::create_dir_all(parent).is_err() {
+            return GuardedSaveOutcome::IoError;
+        }
+    }
+    // Hold the sidecar flock across the read AND the write so a concurrent
+    // holder `clear_inflight_state` (which takes the same lock) cannot land its
+    // remove between our identity check and our write.
+    let Ok(_lock) = lock_inflight_state_path(&path) else {
+        return GuardedSaveOutcome::IoError;
+    };
+    // Holder already cleared the row on its success path → do NOT resurrect.
+    let Ok(data) = fs::read_to_string(&path) else {
+        return GuardedSaveOutcome::Missing;
+    };
+    let Ok(on_disk) = serde_json::from_str::<InflightTurnState>(&data) else {
+        // Malformed row: treat like a mismatch and do not clobber — the loader
+        // eviction path GCs malformed payloads on the next read.
+        return GuardedSaveOutcome::IdentityMismatch;
+    };
+    // A newer turn (different identity) or a planned-restart / rebind-origin
+    // marker now owns the row — never overwrite it with this preserved turn.
+    if on_disk.restart_mode.is_some() || on_disk.rebind_origin {
+        return GuardedSaveOutcome::IdentityMismatch;
+    }
+    if expected.user_msg_id == 0 || !expected.matches_state(&on_disk) {
+        return GuardedSaveOutcome::IdentityMismatch;
+    }
+    if let Some(expected_offset) = expected_turn_start_offset {
+        if on_disk.turn_start_offset != Some(expected_offset) {
+            return GuardedSaveOutcome::IdentityMismatch;
+        }
+    }
+    validate_inflight_state_for_save(
+        root,
+        &path,
+        state,
+        "src/services/discord/inflight.rs:save_inflight_state_if_matches_identity_in_root",
+    );
+    let mut updated = state.clone();
+    updated.updated_at = now_string();
+    let Ok(json) = serde_json::to_string_pretty(&updated) else {
+        return GuardedSaveOutcome::IoError;
+    };
+    match atomic_write(&path, &json) {
+        Ok(()) => GuardedSaveOutcome::Saved,
+        Err(error) => {
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel = state.channel_id,
+                expected_user_msg_id = expected.user_msg_id,
+                error = %error,
+                "inflight identity-guarded save failed; leaving on-disk row untouched"
+            );
+            GuardedSaveOutcome::IoError
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // #3077: typed status-panel ownership writes.
 //
@@ -2442,16 +2565,17 @@ pub(in crate::services::discord) enum InflightSignal {
 #[cfg(test)]
 mod stall_recovery_tests {
     use super::{
-        GuardedClearOutcome, INFLIGHT_STALENESS_THRESHOLD_SECS, InflightRestartMode,
-        InflightTurnIdentity, InflightTurnState, RelayOwnerKind, StatusPanelBindGuard,
-        StatusPanelBindOutcome, StatusPanelClearGuard, bind_status_panel_in_root,
-        clear_inflight_state_if_matches_identity_after_delivery_in_root,
+        GuardedClearOutcome, GuardedSaveOutcome, INFLIGHT_STALENESS_THRESHOLD_SECS,
+        InflightRestartMode, InflightTurnIdentity, InflightTurnState, RelayOwnerKind,
+        StatusPanelBindGuard, StatusPanelBindOutcome, StatusPanelClearGuard,
+        bind_status_panel_in_root, clear_inflight_state_if_matches_identity_after_delivery_in_root,
         clear_inflight_state_if_matches_identity_in_root, clear_inflight_state_if_matches_in_root,
         clear_inflight_state_if_matches_tmux_response_in_root,
         clear_status_panel_if_current_in_root, inflight_state_allows_idle_tmux_repair_state,
         inflight_state_is_stale, inflight_state_path, load_inflight_states_from_root,
         lock_inflight_state_path, normalize_response_sent_offset,
-        refresh_inflight_last_offset_if_matches_identity_in_root, save_inflight_state_in_root,
+        refresh_inflight_last_offset_if_matches_identity_in_root,
+        save_inflight_state_if_matches_identity_in_root, save_inflight_state_in_root,
         validate_inflight_state_for_save,
     };
     use crate::services::agent_protocol::RuntimeHandoffKind;
@@ -3835,6 +3959,172 @@ mod stall_recovery_tests {
         let outcome =
             clear_inflight_state_if_matches_in_root(temp.path(), &ProviderKind::Claude, 42, 999);
         assert_eq!(outcome, GuardedClearOutcome::Missing);
+    }
+
+    // ---------------------------------------------------------------------
+    // #3041 P1-2 (codex P1-2 R3): identity-guarded epilogue re-save. On a
+    // delivery-lease `Skip` the watcher (holder) owns the inflight lifecycle
+    // and clears the row on its OWN success. The bridge's epilogue must NOT
+    // resurrect a holder-cleared row; it must refresh a still-present matching
+    // row so retry survives when the holder FAILED.
+    // ---------------------------------------------------------------------
+
+    /// Skip → holder SUCCEEDED and cleared inflight (no row on disk). The bridge
+    /// epilogue's identity-guarded save must NOT resurrect it (`Missing`) — no
+    /// stale leak.
+    #[test]
+    fn skip_save_does_not_resurrect_holder_cleared_inflight() {
+        let temp = TempDir::new().unwrap();
+        // The holder already removed the row on its success path → nothing on disk.
+        let state = build_inflight_for_guard_tests(ProviderKind::Claude, 321, 777);
+        let expected = InflightTurnIdentity::from_state(&state);
+
+        let outcome = save_inflight_state_if_matches_identity_in_root(
+            temp.path(),
+            &state,
+            &expected,
+            state.turn_start_offset,
+        );
+
+        assert_eq!(
+            outcome,
+            GuardedSaveOutcome::Missing,
+            "holder-cleared inflight must NOT be resurrected by the bridge skip epilogue"
+        );
+        assert!(
+            load_inflight_states_from_root(temp.path(), &ProviderKind::Claude).is_empty(),
+            "no row may be recreated for an already-delivered turn"
+        );
+    }
+
+    /// Skip → holder FAILED (NotDelivered) and did NOT clear; the turn-start row
+    /// is still on disk with matching identity. The bridge epilogue's
+    /// identity-guarded save refreshes it (`Saved`) so retry can re-deliver —
+    /// no black-hole.
+    #[test]
+    fn skip_save_preserves_inflight_when_holder_did_not_clear() {
+        let temp = TempDir::new().unwrap();
+        let mut state = build_inflight_for_guard_tests(ProviderKind::Claude, 321, 777);
+        save_inflight_state_in_root(temp.path(), &state).unwrap();
+
+        // The bridge accumulated more of the answer during the turn; it preserves
+        // this updated copy for retry. Identity (user_msg_id/started_at/tmux) is
+        // unchanged, so the guarded save must land.
+        state.full_response = "partially delivered answer, retry me".to_string();
+        let expected = InflightTurnIdentity::from_state(&state);
+
+        let outcome = save_inflight_state_if_matches_identity_in_root(
+            temp.path(),
+            &state,
+            &expected,
+            state.turn_start_offset,
+        );
+
+        assert_eq!(
+            outcome,
+            GuardedSaveOutcome::Saved,
+            "a still-present matching row must be refreshed so retry survives a holder failure"
+        );
+        let rows = load_inflight_states_from_root(temp.path(), &ProviderKind::Claude);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].full_response,
+            "partially delivered answer, retry me"
+        );
+    }
+
+    /// Skip → a NEWER turn (different `user_msg_id`) already wrote its inflight
+    /// before the preserving bridge's epilogue ran. The guarded save must NOT
+    /// clobber the fresh turn (`IdentityMismatch`).
+    #[test]
+    fn skip_save_does_not_clobber_newer_turn() {
+        let temp = TempDir::new().unwrap();
+        // Newer turn currently owns the row on disk. (NB: the guard-test helper's
+        // 3rd arg feeds `current_msg_id`; set the real `user_msg_id` explicitly so
+        // the two turns differ on the identity field the guard actually checks.)
+        let mut newer = build_inflight_for_guard_tests(ProviderKind::Claude, 321, 0);
+        newer.user_msg_id = 999;
+        save_inflight_state_in_root(temp.path(), &newer).unwrap();
+
+        // The preserving bridge is still holding the PREVIOUS turn (user_msg_id
+        // 777). Its identity no longer matches the on-disk newer turn.
+        let mut preserved = build_inflight_for_guard_tests(ProviderKind::Claude, 321, 0);
+        preserved.user_msg_id = 777;
+        let expected = InflightTurnIdentity::from_state(&preserved);
+
+        let outcome = save_inflight_state_if_matches_identity_in_root(
+            temp.path(),
+            &preserved,
+            &expected,
+            preserved.turn_start_offset,
+        );
+
+        assert_eq!(
+            outcome,
+            GuardedSaveOutcome::IdentityMismatch,
+            "a preserved older turn must NOT overwrite a newer turn's inflight"
+        );
+        let rows = load_inflight_states_from_root(temp.path(), &ProviderKind::Claude);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].user_msg_id, 999,
+            "the newer turn's inflight must remain intact"
+        );
+    }
+
+    /// Skip → the on-disk row's `turn_start_offset` no longer matches (a newer
+    /// turn reusing the same `user_msg_id`/session at a different offset). The
+    /// guarded save must refuse (`IdentityMismatch`).
+    #[test]
+    fn skip_save_checks_turn_start_offset() {
+        let temp = TempDir::new().unwrap();
+        let mut on_disk = build_inflight_for_guard_tests(ProviderKind::Claude, 321, 777);
+        on_disk.turn_start_offset = Some(500);
+        save_inflight_state_in_root(temp.path(), &on_disk).unwrap();
+
+        // Same identity (user_msg_id/started_at/tmux) as on_disk so ONLY the
+        // turn_start_offset differs — isolating the offset guard.
+        let mut preserved = on_disk.clone();
+        preserved.turn_start_offset = Some(0);
+        let expected = InflightTurnIdentity::from_state(&preserved);
+
+        // The preserving bridge expects offset 0 but disk shows 500.
+        let outcome = save_inflight_state_if_matches_identity_in_root(
+            temp.path(),
+            &preserved,
+            &expected,
+            Some(0),
+        );
+
+        assert_eq!(outcome, GuardedSaveOutcome::IdentityMismatch);
+    }
+
+    /// Skip → the on-disk row became a planned-restart marker. The guarded save
+    /// must not clobber it (`IdentityMismatch`); restart recovery owns it.
+    #[test]
+    fn skip_save_does_not_clobber_planned_restart_marker() {
+        let temp = TempDir::new().unwrap();
+        let mut marker = build_inflight_for_guard_tests(ProviderKind::Claude, 321, 777);
+        marker.set_restart_mode(InflightRestartMode::DrainRestart);
+        save_inflight_state_in_root(temp.path(), &marker).unwrap();
+
+        let preserved = build_inflight_for_guard_tests(ProviderKind::Claude, 321, 777);
+        let expected = InflightTurnIdentity::from_state(&preserved);
+
+        let outcome = save_inflight_state_if_matches_identity_in_root(
+            temp.path(),
+            &preserved,
+            &expected,
+            preserved.turn_start_offset,
+        );
+
+        assert_eq!(outcome, GuardedSaveOutcome::IdentityMismatch);
+        let rows = load_inflight_states_from_root(temp.path(), &ProviderKind::Claude);
+        assert_eq!(rows.len(), 1);
+        assert!(
+            rows[0].restart_mode.is_some(),
+            "the planned-restart marker must be preserved for recovery"
+        );
     }
 
     #[cfg(unix)]

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -2065,6 +2065,97 @@ impl DeliveryLeaseCell {
         false
     }
 }
+
+/// #3041 P1-1/P1-2: delivery-lease acquire deadline shared by BOTH the watcher
+/// and the bridge terminal-delivery paths. The deadline is a HOLDER-LIVENESS
+/// signal, NOT a hard cap on delivery duration — while a send future is in
+/// flight the holder keeps the lease alive with a background HEARTBEAT that
+/// `renew()`s the deadline every [`DELIVERY_LEASE_HEARTBEAT_MS`]. Because a LIVE
+/// holder always re-extends within one interval, a long multi-chunk send (which
+/// can exceed any FIXED deadline) is NEVER reclaimed mid-flight; a genuinely
+/// DEAD holder stops renewing, so the lease expires and a replacement reclaims
+/// it within ~one deadline. Picked as 3× the heartbeat (15s = 3 × 5s): one tick
+/// can be skipped entirely and the lease still survives to the next, while
+/// dead-holder recovery is ~15s. P1-2 reuses this so the WATCHER and the BRIDGE
+/// share one deadline against the one per-channel cell — whoever holds it blocks
+/// the other's acquire (cross-actor duplicate prevention).
+pub(in crate::services::discord) const DELIVERY_LEASE_DEADLINE_MS: u64 = 15_000;
+
+/// #3041 P1-1/P1-2: how often an in-flight holder renews its delivery lease.
+/// Must be strictly less than (and a small fraction of)
+/// [`DELIVERY_LEASE_DEADLINE_MS`] so a live holder always re-extends before
+/// expiry even if one tick is delayed (the deadline is 3× this).
+pub(in crate::services::discord) const DELIVERY_LEASE_HEARTBEAT_MS: u64 = 5_000;
+
+/// #3041 P1-1 (§3, codex R2 Issue-1) / P1-2: RAII handle for the in-flight
+/// delivery-lease heartbeat task, shared by the watcher and the bridge. The
+/// holder spawns the heartbeat right after a successful `try_acquire` and
+/// `stop()`s it BEFORE the inline commit (and the `Drop` impl aborts it on any
+/// early return / panic), so the renew loop can NEVER outlive the send and race
+/// the commit. While the holder task lives the heartbeat keeps the lease alive
+/// (`renew`); if the holder TASK dies the spawned heartbeat is dropped/aborted
+/// with it → the lease stops being renewed → it expires → a replacement reclaims
+/// it. A heartbeat tick can only ever `renew` THIS holder's OWN still-`Leased`
+/// lease (matched on holder+turn), so a last tick that races `stop()`+commit
+/// merely extends our own deadline, which the immediately-following commit then
+/// flips to `Committed` — harmless.
+pub(in crate::services::discord) struct DeliveryLeaseHeartbeat {
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl DeliveryLeaseHeartbeat {
+    /// Spawn a background task that renews `(holder, turn)`'s lease on `cell`
+    /// every [`DELIVERY_LEASE_HEARTBEAT_MS`], each time pushing the deadline to
+    /// `lease_now_ms() + DELIVERY_LEASE_DEADLINE_MS`. The first tick fires AFTER
+    /// one interval (the acquire already set a fresh deadline). The loop exits on
+    /// its own as soon as a `renew` returns false (the lease is no longer ours —
+    /// committed, released, or reclaimed), so it self-terminates even before an
+    /// explicit `stop()`.
+    pub(in crate::services::discord) fn spawn(
+        cell: std::sync::Arc<DeliveryLeaseCell>,
+        holder: LeaseHolder,
+        turn: turn_finalizer::TurnKey,
+    ) -> Self {
+        let handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_millis(
+                DELIVERY_LEASE_HEARTBEAT_MS,
+            ));
+            // Skip the immediate tick `interval` emits at t=0; the acquire just
+            // set a fresh deadline, so the first renew is one interval later.
+            interval.tick().await;
+            loop {
+                interval.tick().await;
+                let renewed = cell.renew(
+                    holder,
+                    turn,
+                    lease_now_ms().saturating_add(DELIVERY_LEASE_DEADLINE_MS),
+                );
+                if !renewed {
+                    // Lease is no longer ours (committed/released/reclaimed):
+                    // nothing left to keep alive.
+                    break;
+                }
+            }
+        });
+        Self { handle }
+    }
+
+    /// Stop the heartbeat. Idempotent. Called BEFORE the inline commit so the
+    /// renew loop is guaranteed not to race the commit.
+    pub(in crate::services::discord) fn stop(self) {
+        self.handle.abort();
+    }
+}
+
+impl Drop for DeliveryLeaseHeartbeat {
+    fn drop(&mut self) {
+        // Safety net: if the send path returns early / panics before an explicit
+        // `stop()`, aborting on drop guarantees the heartbeat cannot outlive the
+        // owning holder frame.
+        self.handle.abort();
+    }
+}
+
 #[derive(Clone)]
 pub(super) struct ModelPickerPendingState {
     pub(super) owner_user_id: UserId,

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -17,98 +17,32 @@ fn next_watcher_instance_id() -> u64 {
 /// watcher terminal send. The deadline is a HOLDER-LIVENESS signal, NOT a hard
 /// cap on delivery duration — while the send future is in flight the watcher
 /// keeps the lease alive with a background HEARTBEAT that `renew()`s the
-/// deadline every `WATCHER_DELIVERY_LEASE_HEARTBEAT_MS` (see below). Because a
-/// LIVE holder always re-extends within one interval, a long multi-chunk send
-/// (which can exceed any FIXED deadline — an unbounded response splits into
-/// 2000-char chunks paced ~500ms apart plus a 1s rate limiter, so 60+ chunks
-/// can run past 90s) is NEVER reclaimed mid-flight. Conversely, a genuinely
-/// DEAD holder (its watcher task/process gone) stops renewing, so the lease
-/// expires and a replacement reclaims it within ~one deadline.
+/// deadline every heartbeat interval. Because a LIVE holder always re-extends
+/// within one interval, a long multi-chunk send (which can exceed any FIXED
+/// deadline — an unbounded response splits into 2000-char chunks paced ~500ms
+/// apart plus a 1s rate limiter, so 60+ chunks can run past 90s) is NEVER
+/// reclaimed mid-flight. Conversely, a genuinely DEAD holder (its watcher
+/// task/process gone) stops renewing, so the lease expires and a replacement
+/// reclaims it within ~one deadline.
 ///
-/// INVARIANT — deadline must be a small multiple of the heartbeat: large enough
-/// that a live holder never expires between two renews (covers a missed/late
-/// tick under scheduler pressure), small enough that a dead holder is reclaimed
-/// PROMPTLY. We pick 3× the heartbeat (15s = 3 × 5s): one tick can be skipped
-/// entirely and the lease still survives to the next, while dead-holder
-/// recovery is ~15s instead of the old fixed 90s. This is the lease DEADLINE,
-/// independent of the finalizer's `GATE_BACKSTOP` (8s, a different concern:
-/// visible-completion gating, not delivery duration).
-const WATCHER_DELIVERY_LEASE_DEADLINE_MS: u64 = 15_000;
+/// #3041 P1-2: this is now an ALIAS for the shared
+/// [`crate::services::discord::DELIVERY_LEASE_DEADLINE_MS`] so the watcher and
+/// the bridge use the SAME deadline against the SAME per-channel cell. Kept as a
+/// named alias to minimize churn at the watcher call/test sites.
+const WATCHER_DELIVERY_LEASE_DEADLINE_MS: u64 =
+    crate::services::discord::DELIVERY_LEASE_DEADLINE_MS;
 
 /// #3041 P1-1 (§3, codex R2 Issue-1): how often the in-flight watcher send
-/// renews its delivery lease. Must be strictly less than (and a small fraction
-/// of) `WATCHER_DELIVERY_LEASE_DEADLINE_MS` so a live holder always re-extends
-/// before expiry even if one tick is delayed (the deadline is 3× this).
-const WATCHER_DELIVERY_LEASE_HEARTBEAT_MS: u64 = 5_000;
+/// renews its delivery lease. Alias for the shared
+/// [`crate::services::discord::DELIVERY_LEASE_HEARTBEAT_MS`] (P1-2).
+const WATCHER_DELIVERY_LEASE_HEARTBEAT_MS: u64 =
+    crate::services::discord::DELIVERY_LEASE_HEARTBEAT_MS;
 
-/// #3041 P1-1 (§3, codex R2 Issue-1): RAII handle for the in-flight
-/// delivery-lease heartbeat task. The watcher spawns the heartbeat right after a
-/// successful `try_acquire` and `stop()`s it BEFORE the inline commit (and the
-/// `Drop` impl aborts it on any early return / panic), so the renew loop can
-/// NEVER outlive the send and race the commit. While the watcher task lives the
-/// heartbeat keeps the lease alive (`renew`); if the watcher TASK dies the
-/// spawned heartbeat is dropped/aborted with it → the lease stops being renewed
-/// → it expires → a replacement reclaims it. A heartbeat tick can only ever
-/// `renew` THIS holder's OWN still-`Leased` lease (matched on holder+turn), so a
-/// last tick that races `stop()`+commit merely extends our own deadline, which
-/// the immediately-following commit then flips to `Committed` — harmless.
-struct DeliveryLeaseHeartbeat {
-    handle: tokio::task::JoinHandle<()>,
-}
-
-impl DeliveryLeaseHeartbeat {
-    /// Spawn a background task that renews `(holder, turn)`'s lease on `cell`
-    /// every `WATCHER_DELIVERY_LEASE_HEARTBEAT_MS`, each time pushing the
-    /// deadline to `lease_now_ms() + WATCHER_DELIVERY_LEASE_DEADLINE_MS`. The
-    /// first tick fires AFTER one interval (the acquire already set a fresh
-    /// deadline). The loop exits on its own as soon as a `renew` returns false
-    /// (the lease is no longer ours — committed, released, or reclaimed), so it
-    /// self-terminates even before an explicit `stop()`.
-    fn spawn(
-        cell: std::sync::Arc<crate::services::discord::DeliveryLeaseCell>,
-        holder: crate::services::discord::LeaseHolder,
-        turn: crate::services::discord::turn_finalizer::TurnKey,
-    ) -> Self {
-        let handle = tokio::spawn(async move {
-            let mut interval = tokio::time::interval(std::time::Duration::from_millis(
-                WATCHER_DELIVERY_LEASE_HEARTBEAT_MS,
-            ));
-            // Skip the immediate tick `interval` emits at t=0; the acquire just
-            // set a fresh deadline, so the first renew is one interval later.
-            interval.tick().await;
-            loop {
-                interval.tick().await;
-                let renewed = cell.renew(
-                    holder,
-                    turn,
-                    crate::services::discord::lease_now_ms()
-                        .saturating_add(WATCHER_DELIVERY_LEASE_DEADLINE_MS),
-                );
-                if !renewed {
-                    // Lease is no longer ours (committed/released/reclaimed):
-                    // nothing left to keep alive.
-                    break;
-                }
-            }
-        });
-        Self { handle }
-    }
-
-    /// Stop the heartbeat. Idempotent. Called BEFORE the inline commit so the
-    /// renew loop is guaranteed not to race the commit.
-    fn stop(self) {
-        self.handle.abort();
-    }
-}
-
-impl Drop for DeliveryLeaseHeartbeat {
-    fn drop(&mut self) {
-        // Safety net: if the send path returns early / panics before an explicit
-        // `stop()`, aborting on drop guarantees the heartbeat cannot outlive the
-        // owning watcher frame.
-        self.handle.abort();
-    }
-}
+/// #3041 P1-2: the heartbeat RAII handle now lives in the shared `discord` module
+/// (`super::DeliveryLeaseHeartbeat`) so the watcher and the bridge reuse one
+/// implementation. Re-exported here under the watcher-local name to keep the
+/// existing watcher call sites and tests unchanged.
+use crate::services::discord::DeliveryLeaseHeartbeat;
 
 /// #2441 (H1) — race a fixed sleep against a `notify`-backed wake-up
 /// from `JsonlWatcher`. Returns as soon as EITHER the sleep elapses or

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -1412,8 +1412,9 @@ use stale_resume::{
 use terminal_delivery::{
     BridgeDeliveryLease, BridgeLeaseAcquire, send_ordered_long_terminal_response,
     should_complete_work_dispatch_after_terminal_delivery,
-    should_fail_dispatch_after_terminal_delivery, terminal_delivery_should_send_new_chunks,
-    tui_quiescence_timeout_requires_inflight_retry, turn_bridge_replace_outcome_committed,
+    should_fail_dispatch_after_terminal_delivery, silent_turn_skip_marks_committed,
+    terminal_delivery_should_send_new_chunks, tui_quiescence_timeout_requires_inflight_retry,
+    turn_bridge_replace_outcome_committed,
 };
 use tmux_runtime::is_dcserver_restart_command;
 use turn_analytics::{
@@ -7269,11 +7270,21 @@ pub(super) fn spawn_turn_bridge(
             // shared delivery lease BEFORE delivering the `[Stopped]` terminal
             // body. A B2 Skip means the watcher (or another bridge path) owns the
             // live lease for this turn/range → do NOT deliver+advance.
+            //
+            // #3041 P1-2 (codex P1-a): lease on the SAME channel's cell the WATCHER
+            // uses — `watcher_owner_channel_id`. A reused watcher can own a channel
+            // DIFFERENT from this bridge's `channel_id`; the watcher leases (and
+            // advances `confirmed_end_offset`) on ITS owner channel, and the bridge
+            // already advances on `watcher_owner_channel_id` (see
+            // `commit_and_advance`). Keying the cell + the `TurnKey` channel on
+            // `watcher_owner_channel_id` makes the bridge and watcher resolve to the
+            // SAME cell for the same actual turn so their acquires CONTEND
+            // (single-holder B2) instead of both delivering = duplicate.
             let stop_lease_acquire = BridgeDeliveryLease::acquire(
                 shared_owned.as_ref(),
-                channel_id,
+                watcher_owner_channel_id,
                 super::turn_finalizer::TurnKey::new(
-                    channel_id,
+                    watcher_owner_channel_id,
                     inflight_state.user_msg_id,
                     shared_owned.current_generation,
                 ),
@@ -7309,9 +7320,13 @@ pub(super) fn spawn_turn_bridge(
                 if replace_committed {
                     status_panel_terminal_committed = true;
                 }
-                // B6: advance ONLY via the lease commit (Delivered on a committed
-                // replace, NotDelivered otherwise). NoRange → preserve the direct
-                // advance for parity (no offset to advance for a zero/None range).
+                // B6: the ONLY confirmed_end advance on the bridge path is via a
+                // successful lease commit. `Held` → commit (Delivered advances,
+                // NotDelivered does not). `NoRange` (`end <= start` or None/0) has
+                // NO new bytes to commit, so there is nothing to advance — do NOT
+                // call `advance_tmux_relay_confirmed_end` outside a lease (codex
+                // P1-b: a degenerate equal-nonzero range like start==end==64 must
+                // not advance the offset outside a lease commit).
                 if let Some(lease) = stop_lease {
                     let outcome = if replace_committed {
                         crate::services::discord::LeaseOutcome::Delivered
@@ -7323,13 +7338,6 @@ pub(super) fn spawn_turn_bridge(
                         watcher_owner_channel_id,
                         inflight_state.tmux_session_name.as_deref(),
                         outcome,
-                    );
-                } else if replace_committed {
-                    advance_tmux_relay_confirmed_end(
-                        shared_owned.as_ref(),
-                        watcher_owner_channel_id,
-                        tmux_last_offset,
-                        inflight_state.tmux_session_name.as_deref(),
                     );
                 }
                 if !replace_committed {
@@ -7355,12 +7363,14 @@ pub(super) fn spawn_turn_bridge(
             );
             // #3041 P1-2 (site 2 — prompt-too-long terminal replace): same lease
             // routing as site 1. Acquire before the replace; B2-skip if another
-            // holder owns the live lease.
+            // holder owns the live lease. (codex P1-a) lease on
+            // `watcher_owner_channel_id` so the bridge and the (possibly reused)
+            // watcher share the SAME cell + TurnKey channel.
             let plt_lease_acquire = BridgeDeliveryLease::acquire(
                 shared_owned.as_ref(),
-                channel_id,
+                watcher_owner_channel_id,
                 super::turn_finalizer::TurnKey::new(
-                    channel_id,
+                    watcher_owner_channel_id,
                     inflight_state.user_msg_id,
                     shared_owned.current_generation,
                 ),
@@ -7396,6 +7406,8 @@ pub(super) fn spawn_turn_bridge(
                 if replace_committed {
                     status_panel_terminal_committed = true;
                 }
+                // B6 (codex P1-b): advance ONLY via a successful lease commit.
+                // NoRange has no new bytes → no advance outside the lease.
                 if let Some(lease) = plt_lease {
                     let outcome = if replace_committed {
                         crate::services::discord::LeaseOutcome::Delivered
@@ -7407,13 +7419,6 @@ pub(super) fn spawn_turn_bridge(
                         watcher_owner_channel_id,
                         inflight_state.tmux_session_name.as_deref(),
                         outcome,
-                    );
-                } else if replace_committed {
-                    advance_tmux_relay_confirmed_end(
-                        shared_owned.as_ref(),
-                        watcher_owner_channel_id,
-                        tmux_last_offset,
-                        inflight_state.tmux_session_name.as_deref(),
                     );
                 }
                 if !replace_committed {
@@ -7763,7 +7768,6 @@ pub(super) fn spawn_turn_bridge(
                     channel_id,
                     delivery_response.len()
                 );
-                terminal_delivery_committed = true;
                 terminal_body_visible = true;
                 // #3041 P1-2 (site 3 — silent_turn suppression): no Discord post
                 // happens, but the offset STILL advances so the suppressed range is
@@ -7775,17 +7779,34 @@ pub(super) fn spawn_turn_bridge(
                 // heartbeat is a formality (spawned then immediately stopped at
                 // commit). Outcome=Delivered because the offset DOES advance (the
                 // range is accounted for), exactly mirroring the pre-P1-2 advance.
+                //
+                // (codex P1-a) lease on `watcher_owner_channel_id` (same cell +
+                // TurnKey channel as the watcher).
+                //
+                // (codex P1-c) `terminal_delivery_committed` is set ONLY when THIS
+                // actor actually resolves the range — `Held`→commit (we own it) or
+                // `NoRange` (no bytes to deliver, suppression is the resolution). On
+                // `Skip` the live holder (the watcher) owns delivery; the bridge must
+                // be a NO-OP on completion side-effects: do NOT mark committed, do
+                // NOT advance, do NOT clear inflight as delivered — leave the turn
+                // retry-able so if the holder ultimately commits NotDelivered/Unknown
+                // the existing retry machinery (ACK-poll / next pass) re-attempts.
                 let lease_acquire = BridgeDeliveryLease::acquire(
                     shared_owned.as_ref(),
-                    channel_id,
+                    watcher_owner_channel_id,
                     super::turn_finalizer::TurnKey::new(
-                        channel_id,
+                        watcher_owner_channel_id,
                         inflight_state.user_msg_id,
                         shared_owned.current_generation,
                     ),
                     inflight_state.turn_start_offset.unwrap_or(0),
                     tmux_last_offset,
                 );
+                // (codex P1-c) one source of truth for "does this acquire outcome
+                // mark the silent turn committed": Skip → false (holder owns it,
+                // stay retry-able), Held/NoRange → true.
+                terminal_delivery_committed =
+                    silent_turn_skip_marks_committed(&lease_acquire);
                 match lease_acquire {
                     BridgeLeaseAcquire::Held(lease) => {
                         lease.commit_and_advance(
@@ -7796,22 +7817,20 @@ pub(super) fn spawn_turn_bridge(
                         );
                     }
                     BridgeLeaseAcquire::Skip => {
+                        // B2-skip: the watcher holds the live lease and owns this
+                        // range's delivery. Do NOT mark committed / advance / clear
+                        // inflight — leave the turn retry-able (codex P1-c).
                         let ts = chrono::Local::now().format("%H:%M:%S");
                         tracing::warn!(
                             channel = channel_id.get(),
-                            "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge silent_turn skipped offset advance (channel {})",
+                            "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge silent_turn skipped offset advance, left turn retry-able (channel {})",
                             channel_id
                         );
                     }
                     BridgeLeaseAcquire::NoRange => {
-                        // No offset to advance (zero/None range): the direct call is
-                        // a no-op, preserved for parity. B6 not violated (no advance).
-                        advance_tmux_relay_confirmed_end(
-                            shared_owned.as_ref(),
-                            watcher_owner_channel_id,
-                            tmux_last_offset,
-                            inflight_state.tmux_session_name.as_deref(),
-                        );
+                        // No offset to advance (zero/inverted range): nothing to
+                        // deliver, the suppression itself resolves the (empty) range.
+                        // B6 holds (no advance).
                     }
                 }
             } else if delivery_response.trim().is_empty() {
@@ -7850,12 +7869,14 @@ pub(super) fn spawn_turn_bridge(
                         // `send_long_message_with_rollback` with per-chunk pacing),
                         // so the lease's HEARTBEAT (spawned in `acquire`) is what
                         // keeps it alive mid-send. Acquire BEFORE the send; B2-skip
-                        // if another holder owns the live lease.
+                        // if another holder owns the live lease. (codex P1-a) lease
+                        // on `watcher_owner_channel_id` (shared cell + TurnKey
+                        // channel with the watcher).
                         let lease_acquire = BridgeDeliveryLease::acquire(
                             shared_owned.as_ref(),
-                            channel_id,
+                            watcher_owner_channel_id,
                             super::turn_finalizer::TurnKey::new(
-                                channel_id,
+                                watcher_owner_channel_id,
                                 inflight_state.user_msg_id,
                                 shared_owned.current_generation,
                             ),
@@ -7893,23 +7914,15 @@ pub(super) fn spawn_turn_bridge(
                                     terminal_body_visible = true;
                                     response_sent_offset = full_response.len();
                                     inflight_state.response_sent_offset = response_sent_offset;
-                                    // B6: advance ONLY via the lease commit
-                                    // (Delivered). NoRange → preserve the direct
-                                    // advance for parity (no offset to advance for a
-                                    // zero/None range).
+                                    // B6 (codex P1-b): advance ONLY via a successful
+                                    // lease commit (Delivered). `NoRange` has no new
+                                    // bytes to commit → no advance outside the lease.
                                     if let Some(lease) = lease {
                                         lease.commit_and_advance(
                                             shared_owned.as_ref(),
                                             watcher_owner_channel_id,
                                             inflight_state.tmux_session_name.as_deref(),
                                             crate::services::discord::LeaseOutcome::Delivered,
-                                        );
-                                    } else {
-                                        advance_tmux_relay_confirmed_end(
-                                            shared_owned.as_ref(),
-                                            watcher_owner_channel_id,
-                                            tmux_last_offset,
-                                            inflight_state.tmux_session_name.as_deref(),
                                         );
                                     }
                                 }
@@ -7942,11 +7955,13 @@ pub(super) fn spawn_turn_bridge(
                         // the watcher and the bridge serialize on this channel. On
                         // a B2 Skip the watcher (or another bridge path) owns the
                         // live lease for this range/turn → do NOT deliver+advance.
+                        // (codex P1-a) lease on `watcher_owner_channel_id` (shared
+                        // cell + TurnKey channel with the watcher).
                         let lease_acquire = BridgeDeliveryLease::acquire(
                             shared_owned.as_ref(),
-                            channel_id,
+                            watcher_owner_channel_id,
                             super::turn_finalizer::TurnKey::new(
-                                channel_id,
+                                watcher_owner_channel_id,
                                 inflight_state.user_msg_id,
                                 shared_owned.current_generation,
                             ),
@@ -8018,18 +8033,12 @@ pub(super) fn spawn_turn_bridge(
                                     replace_committed
                                 } else {
                                     // NoRange (zero/inverted range or no tmux session):
-                                    // there is no offset to advance, so delivering
-                                    // without a lease cannot violate B6. Preserve the
-                                    // pre-P1-2 advance call for parity — it is a no-op
-                                    // for a zero/None range.
-                                    if replace_committed {
-                                        advance_tmux_relay_confirmed_end(
-                                            shared_owned.as_ref(),
-                                            watcher_owner_channel_id,
-                                            tmux_last_offset,
-                                            inflight_state.tmux_session_name.as_deref(),
-                                        );
-                                    }
+                                    // there are NO new bytes to commit, so there is
+                                    // nothing to advance. Deliver without a lease and
+                                    // WITHOUT advancing `confirmed_end_offset` (codex
+                                    // P1-b: no advance outside a lease commit). The
+                                    // message still reaches Discord; only the offset
+                                    // advance is gated to a real range.
                                     replace_committed
                                 };
                                 if outcome {

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -1410,7 +1410,8 @@ use stale_resume::{
     stream_error_requires_terminal_session_reset,
 };
 use terminal_delivery::{
-    send_ordered_long_terminal_response, should_complete_work_dispatch_after_terminal_delivery,
+    BridgeDeliveryLease, BridgeLeaseAcquire, send_ordered_long_terminal_response,
+    should_complete_work_dispatch_after_terminal_delivery,
     should_fail_dispatch_after_terminal_delivery, terminal_delivery_should_send_new_chunks,
     tui_quiescence_timeout_requires_inflight_retry, turn_bridge_replace_outcome_committed,
 };
@@ -7264,30 +7265,76 @@ pub(super) fn spawn_turn_bridge(
                 format!("{}\n\n[Stopped]", formatted)
             };
 
-            let replace_committed = turn_bridge_replace_outcome_committed(
+            // #3041 P1-2 (site 1 — cancel/stop terminal replace): acquire the
+            // shared delivery lease BEFORE delivering the `[Stopped]` terminal
+            // body. A B2 Skip means the watcher (or another bridge path) owns the
+            // live lease for this turn/range → do NOT deliver+advance.
+            let stop_lease_acquire = BridgeDeliveryLease::acquire(
                 shared_owned.as_ref(),
-                &provider,
                 channel_id,
-                current_msg_id,
-                inflight_state.tmux_session_name.as_deref(),
-                gateway
-                    .replace_message_with_outcome(channel_id, current_msg_id, &terminal_response)
-                    .await,
-                dispatch_id.as_deref(),
-                adk_session_key.as_deref(),
-                Some(turn_id.as_str()),
-                "turn_bridge_cancelled_terminal_replace",
+                super::turn_finalizer::TurnKey::new(
+                    channel_id,
+                    inflight_state.user_msg_id,
+                    shared_owned.current_generation,
+                ),
+                inflight_state.turn_start_offset.unwrap_or(0),
+                tmux_last_offset,
             );
-            if replace_committed {
-                status_panel_terminal_committed = true;
-                advance_tmux_relay_confirmed_end(
-                    shared_owned.as_ref(),
-                    watcher_owner_channel_id,
-                    tmux_last_offset,
-                    inflight_state.tmux_session_name.as_deref(),
+            if matches!(stop_lease_acquire, BridgeLeaseAcquire::Skip) {
+                let ts = chrono::Local::now().format("%H:%M:%S");
+                tracing::warn!(
+                    channel = channel_id.get(),
+                    "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge skipped duplicate cancel/stop terminal replace (channel {})",
+                    channel_id
                 );
             } else {
-                preserve_inflight_for_cleanup_retry = true;
+                let stop_lease = match stop_lease_acquire {
+                    BridgeLeaseAcquire::Held(lease) => Some(lease),
+                    _ => None,
+                };
+                let replace_committed = turn_bridge_replace_outcome_committed(
+                    shared_owned.as_ref(),
+                    &provider,
+                    channel_id,
+                    current_msg_id,
+                    inflight_state.tmux_session_name.as_deref(),
+                    gateway
+                        .replace_message_with_outcome(channel_id, current_msg_id, &terminal_response)
+                        .await,
+                    dispatch_id.as_deref(),
+                    adk_session_key.as_deref(),
+                    Some(turn_id.as_str()),
+                    "turn_bridge_cancelled_terminal_replace",
+                );
+                if replace_committed {
+                    status_panel_terminal_committed = true;
+                }
+                // B6: advance ONLY via the lease commit (Delivered on a committed
+                // replace, NotDelivered otherwise). NoRange → preserve the direct
+                // advance for parity (no offset to advance for a zero/None range).
+                if let Some(lease) = stop_lease {
+                    let outcome = if replace_committed {
+                        crate::services::discord::LeaseOutcome::Delivered
+                    } else {
+                        crate::services::discord::LeaseOutcome::NotDelivered
+                    };
+                    lease.commit_and_advance(
+                        shared_owned.as_ref(),
+                        watcher_owner_channel_id,
+                        inflight_state.tmux_session_name.as_deref(),
+                        outcome,
+                    );
+                } else if replace_committed {
+                    advance_tmux_relay_confirmed_end(
+                        shared_owned.as_ref(),
+                        watcher_owner_channel_id,
+                        tmux_last_offset,
+                        inflight_state.tmux_session_name.as_deref(),
+                    );
+                }
+                if !replace_committed {
+                    preserve_inflight_for_cleanup_retry = true;
+                }
             }
 
             if preserved_restart_mode.is_none()
@@ -7306,30 +7353,72 @@ pub(super) fn spawn_turn_bridge(
                  컨텍스트를 줄이려면 `/compact` 또는 `/clear`를 사용해 주세요.",
                 mention
             );
-            let replace_committed = turn_bridge_replace_outcome_committed(
+            // #3041 P1-2 (site 2 — prompt-too-long terminal replace): same lease
+            // routing as site 1. Acquire before the replace; B2-skip if another
+            // holder owns the live lease.
+            let plt_lease_acquire = BridgeDeliveryLease::acquire(
                 shared_owned.as_ref(),
-                &provider,
                 channel_id,
-                current_msg_id,
-                inflight_state.tmux_session_name.as_deref(),
-                gateway
-                    .replace_message_with_outcome(channel_id, current_msg_id, &full_response)
-                    .await,
-                dispatch_id.as_deref(),
-                adk_session_key.as_deref(),
-                Some(turn_id.as_str()),
-                "turn_bridge_prompt_too_long_replace",
+                super::turn_finalizer::TurnKey::new(
+                    channel_id,
+                    inflight_state.user_msg_id,
+                    shared_owned.current_generation,
+                ),
+                inflight_state.turn_start_offset.unwrap_or(0),
+                tmux_last_offset,
             );
-            if replace_committed {
-                status_panel_terminal_committed = true;
-                advance_tmux_relay_confirmed_end(
-                    shared_owned.as_ref(),
-                    watcher_owner_channel_id,
-                    tmux_last_offset,
-                    inflight_state.tmux_session_name.as_deref(),
+            if matches!(plt_lease_acquire, BridgeLeaseAcquire::Skip) {
+                let ts = chrono::Local::now().format("%H:%M:%S");
+                tracing::warn!(
+                    channel = channel_id.get(),
+                    "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge skipped duplicate prompt-too-long terminal replace (channel {})",
+                    channel_id
                 );
             } else {
-                preserve_inflight_for_cleanup_retry = true;
+                let plt_lease = match plt_lease_acquire {
+                    BridgeLeaseAcquire::Held(lease) => Some(lease),
+                    _ => None,
+                };
+                let replace_committed = turn_bridge_replace_outcome_committed(
+                    shared_owned.as_ref(),
+                    &provider,
+                    channel_id,
+                    current_msg_id,
+                    inflight_state.tmux_session_name.as_deref(),
+                    gateway
+                        .replace_message_with_outcome(channel_id, current_msg_id, &full_response)
+                        .await,
+                    dispatch_id.as_deref(),
+                    adk_session_key.as_deref(),
+                    Some(turn_id.as_str()),
+                    "turn_bridge_prompt_too_long_replace",
+                );
+                if replace_committed {
+                    status_panel_terminal_committed = true;
+                }
+                if let Some(lease) = plt_lease {
+                    let outcome = if replace_committed {
+                        crate::services::discord::LeaseOutcome::Delivered
+                    } else {
+                        crate::services::discord::LeaseOutcome::NotDelivered
+                    };
+                    lease.commit_and_advance(
+                        shared_owned.as_ref(),
+                        watcher_owner_channel_id,
+                        inflight_state.tmux_session_name.as_deref(),
+                        outcome,
+                    );
+                } else if replace_committed {
+                    advance_tmux_relay_confirmed_end(
+                        shared_owned.as_ref(),
+                        watcher_owner_channel_id,
+                        tmux_last_offset,
+                        inflight_state.tmux_session_name.as_deref(),
+                    );
+                }
+                if !replace_committed {
+                    preserve_inflight_for_cleanup_retry = true;
+                }
             }
 
             if let Some(user_msg_id) = user_msg_id {
@@ -7676,12 +7765,55 @@ pub(super) fn spawn_turn_bridge(
                 );
                 terminal_delivery_committed = true;
                 terminal_body_visible = true;
-                advance_tmux_relay_confirmed_end(
+                // #3041 P1-2 (site 3 — silent_turn suppression): no Discord post
+                // happens, but the offset STILL advances so the suppressed range is
+                // marked consumed (not re-delivered by recovery). Per B6 the advance
+                // must flow through a lease commit, so we acquire→commit(Delivered)
+                // →release here: the bridge OWNS and resolves this range. If the
+                // watcher already holds the live lease for this turn/range we B2-skip
+                // (the watcher will advance it). The "send" is instantaneous, so the
+                // heartbeat is a formality (spawned then immediately stopped at
+                // commit). Outcome=Delivered because the offset DOES advance (the
+                // range is accounted for), exactly mirroring the pre-P1-2 advance.
+                let lease_acquire = BridgeDeliveryLease::acquire(
                     shared_owned.as_ref(),
-                    watcher_owner_channel_id,
+                    channel_id,
+                    super::turn_finalizer::TurnKey::new(
+                        channel_id,
+                        inflight_state.user_msg_id,
+                        shared_owned.current_generation,
+                    ),
+                    inflight_state.turn_start_offset.unwrap_or(0),
                     tmux_last_offset,
-                    inflight_state.tmux_session_name.as_deref(),
                 );
+                match lease_acquire {
+                    BridgeLeaseAcquire::Held(lease) => {
+                        lease.commit_and_advance(
+                            shared_owned.as_ref(),
+                            watcher_owner_channel_id,
+                            inflight_state.tmux_session_name.as_deref(),
+                            crate::services::discord::LeaseOutcome::Delivered,
+                        );
+                    }
+                    BridgeLeaseAcquire::Skip => {
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        tracing::warn!(
+                            channel = channel_id.get(),
+                            "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge silent_turn skipped offset advance (channel {})",
+                            channel_id
+                        );
+                    }
+                    BridgeLeaseAcquire::NoRange => {
+                        // No offset to advance (zero/None range): the direct call is
+                        // a no-op, preserved for parity. B6 not violated (no advance).
+                        advance_tmux_relay_confirmed_end(
+                            shared_owned.as_ref(),
+                            watcher_owner_channel_id,
+                            tmux_last_offset,
+                            inflight_state.tmux_session_name.as_deref(),
+                        );
+                    }
+                }
             } else if delivery_response.trim().is_empty() {
                 if gateway
                     .edit_message(
@@ -7712,91 +7844,208 @@ pub(super) fn spawn_turn_bridge(
                         can_chain_locally,
                         &delivery_response,
                     ) {
-                        match send_ordered_long_terminal_response(
+                        // #3041 P1-2 (site 4 — long chunked terminal delivery):
+                        // this is the one bridge delivery that can run PAST the
+                        // 15s lease deadline (a multi-chunk
+                        // `send_long_message_with_rollback` with per-chunk pacing),
+                        // so the lease's HEARTBEAT (spawned in `acquire`) is what
+                        // keeps it alive mid-send. Acquire BEFORE the send; B2-skip
+                        // if another holder owns the live lease.
+                        let lease_acquire = BridgeDeliveryLease::acquire(
                             shared_owned.as_ref(),
-                            gateway.as_ref(),
-                            &provider,
                             channel_id,
-                            current_msg_id,
-                            inflight_state.tmux_session_name.as_deref(),
-                            &delivery_response,
-                            dispatch_id.as_deref(),
-                            adk_session_key.as_deref(),
-                            Some(turn_id.as_str()),
-                        )
-                        .await
-                        {
-                            Ok(_) => {
-                                terminal_delivery_committed = true;
-                                terminal_body_visible = true;
-                                response_sent_offset = full_response.len();
-                                inflight_state.response_sent_offset = response_sent_offset;
-                                advance_tmux_relay_confirmed_end(
-                                    shared_owned.as_ref(),
-                                    watcher_owner_channel_id,
-                                    tmux_last_offset,
-                                    inflight_state.tmux_session_name.as_deref(),
-                                );
-                            }
-                            Err(error) => {
-                                let ts = chrono::Local::now().format("%H:%M:%S");
-                                tracing::warn!(
-                                    "  [{ts}] ⚠ terminal long response send failed for channel {}: {} — preserving inflight for retry",
-                                    channel_id,
-                                    error
-                                );
-                                preserve_inflight_for_cleanup_retry = true;
+                            super::turn_finalizer::TurnKey::new(
+                                channel_id,
+                                inflight_state.user_msg_id,
+                                shared_owned.current_generation,
+                            ),
+                            inflight_state.turn_start_offset.unwrap_or(0),
+                            tmux_last_offset,
+                        );
+                        if matches!(lease_acquire, BridgeLeaseAcquire::Skip) {
+                            let ts = chrono::Local::now().format("%H:%M:%S");
+                            tracing::warn!(
+                                channel = channel_id.get(),
+                                "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge skipped duplicate long terminal send (channel {})",
+                                channel_id
+                            );
+                        } else {
+                            let lease = match lease_acquire {
+                                BridgeLeaseAcquire::Held(lease) => Some(lease),
+                                _ => None,
+                            };
+                            match send_ordered_long_terminal_response(
+                                shared_owned.as_ref(),
+                                gateway.as_ref(),
+                                &provider,
+                                channel_id,
+                                current_msg_id,
+                                inflight_state.tmux_session_name.as_deref(),
+                                &delivery_response,
+                                dispatch_id.as_deref(),
+                                adk_session_key.as_deref(),
+                                Some(turn_id.as_str()),
+                            )
+                            .await
+                            {
+                                Ok(_) => {
+                                    terminal_delivery_committed = true;
+                                    terminal_body_visible = true;
+                                    response_sent_offset = full_response.len();
+                                    inflight_state.response_sent_offset = response_sent_offset;
+                                    // B6: advance ONLY via the lease commit
+                                    // (Delivered). NoRange → preserve the direct
+                                    // advance for parity (no offset to advance for a
+                                    // zero/None range).
+                                    if let Some(lease) = lease {
+                                        lease.commit_and_advance(
+                                            shared_owned.as_ref(),
+                                            watcher_owner_channel_id,
+                                            inflight_state.tmux_session_name.as_deref(),
+                                            crate::services::discord::LeaseOutcome::Delivered,
+                                        );
+                                    } else {
+                                        advance_tmux_relay_confirmed_end(
+                                            shared_owned.as_ref(),
+                                            watcher_owner_channel_id,
+                                            tmux_last_offset,
+                                            inflight_state.tmux_session_name.as_deref(),
+                                        );
+                                    }
+                                }
+                                Err(error) => {
+                                    let ts = chrono::Local::now().format("%H:%M:%S");
+                                    tracing::warn!(
+                                        "  [{ts}] ⚠ terminal long response send failed for channel {}: {} — preserving inflight for retry",
+                                        channel_id,
+                                        error
+                                    );
+                                    // Send failed: NotDelivered → no advance. The
+                                    // lease's `commit_and_advance` records the
+                                    // outcome and releases so the next turn / the
+                                    // watcher can proceed.
+                                    if let Some(lease) = lease {
+                                        lease.commit_and_advance(
+                                            shared_owned.as_ref(),
+                                            watcher_owner_channel_id,
+                                            inflight_state.tmux_session_name.as_deref(),
+                                            crate::services::discord::LeaseOutcome::NotDelivered,
+                                        );
+                                    }
+                                    preserve_inflight_for_cleanup_retry = true;
+                                }
                             }
                         }
                     } else {
-                        let replace_outcome = gateway
-                            .replace_message_with_outcome(
-                                channel_id,
-                                current_msg_id,
-                                &delivery_response,
-                            )
-                            .await;
-                        // #2860: the answer reached the channel if the placeholder was
-                        // edited OR a fallback message was posted. A fallback posts the
-                        // full delivery_response as a fresh message and reports the
-                        // placeholder edit as non-committed; record it as delivered
-                        // (advance the offset) so this turn does not later present as a
-                        // never-delivered completed-stale leak and get re-delivered by
-                        // the stall-watchdog recovery.
-                        let fallback_delivered = matches!(
-                            &replace_outcome,
-                            Ok(super::formatting::ReplaceLongMessageOutcome::SentFallbackAfterEditFailure { .. })
-                        );
-                        let replace_committed = turn_bridge_replace_outcome_committed(
+                        // #3041 P1-2 (site 5 — normal bridge terminal replace):
+                        // acquire the shared delivery lease BEFORE delivering so
+                        // the watcher and the bridge serialize on this channel. On
+                        // a B2 Skip the watcher (or another bridge path) owns the
+                        // live lease for this range/turn → do NOT deliver+advance.
+                        let lease_acquire = BridgeDeliveryLease::acquire(
                             shared_owned.as_ref(),
-                            &provider,
                             channel_id,
-                            current_msg_id,
-                            inflight_state.tmux_session_name.as_deref(),
-                            replace_outcome,
-                            dispatch_id.as_deref(),
-                            adk_session_key.as_deref(),
-                            Some(turn_id.as_str()),
-                            "turn_bridge_terminal_replace",
+                            super::turn_finalizer::TurnKey::new(
+                                channel_id,
+                                inflight_state.user_msg_id,
+                                shared_owned.current_generation,
+                            ),
+                            inflight_state.turn_start_offset.unwrap_or(0),
+                            tmux_last_offset,
                         );
-                        if replace_committed {
-                            advance_tmux_relay_confirmed_end(
-                                shared_owned.as_ref(),
-                                watcher_owner_channel_id,
-                                tmux_last_offset,
-                                inflight_state.tmux_session_name.as_deref(),
+                        if matches!(lease_acquire, BridgeLeaseAcquire::Skip) {
+                            let ts = chrono::Local::now().format("%H:%M:%S");
+                            tracing::warn!(
+                                channel = channel_id.get(),
+                                "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge skipped duplicate terminal replace (channel {})",
+                                channel_id
                             );
-                            terminal_delivery_committed = true;
-                            terminal_body_visible = true;
                         } else {
-                            preserve_inflight_for_cleanup_retry = true;
-                            if fallback_delivered {
-                                // Mark the whole response delivered: the fallback
-                                // message carried it. The preserved-inflight save on
-                                // the `preserve_inflight_for_cleanup_retry` path below
-                                // persists this advanced offset, so the turn never
-                                // re-presents as a never-delivered leak for recovery.
-                                inflight_state.response_sent_offset = full_response.len();
+                            // `Held(lease)` → commit via the lease; `NoRange` →
+                            // deliver without a lease (no offset to advance).
+                            let lease = match lease_acquire {
+                                BridgeLeaseAcquire::Held(lease) => Some(lease),
+                                _ => None,
+                            };
+                            {
+                                let replace_outcome = gateway
+                                    .replace_message_with_outcome(
+                                        channel_id,
+                                        current_msg_id,
+                                        &delivery_response,
+                                    )
+                                    .await;
+                                // #2860: the answer reached the channel if the placeholder was
+                                // edited OR a fallback message was posted. A fallback posts the
+                                // full delivery_response as a fresh message and reports the
+                                // placeholder edit as non-committed; record it as delivered
+                                // (advance the offset) so this turn does not later present as a
+                                // never-delivered completed-stale leak and get re-delivered by
+                                // the stall-watchdog recovery.
+                                let fallback_delivered = matches!(
+                                    &replace_outcome,
+                                    Ok(super::formatting::ReplaceLongMessageOutcome::SentFallbackAfterEditFailure { .. })
+                                );
+                                let replace_committed = turn_bridge_replace_outcome_committed(
+                                    shared_owned.as_ref(),
+                                    &provider,
+                                    channel_id,
+                                    current_msg_id,
+                                    inflight_state.tmux_session_name.as_deref(),
+                                    replace_outcome,
+                                    dispatch_id.as_deref(),
+                                    adk_session_key.as_deref(),
+                                    Some(turn_id.as_str()),
+                                    "turn_bridge_terminal_replace",
+                                );
+                                // #3041 P1-2 / B6: the confirmed_end advance now flows
+                                // ONLY through the lease commit. `Delivered` on a
+                                // committed replace (advances), `NotDelivered` on a
+                                // non-committed one (no advance) — mirroring the
+                                // pre-P1-2 `if replace_committed { advance }` gate.
+                                let outcome = if let Some(lease) = lease {
+                                    let outcome = if replace_committed {
+                                        crate::services::discord::LeaseOutcome::Delivered
+                                    } else {
+                                        crate::services::discord::LeaseOutcome::NotDelivered
+                                    };
+                                    lease.commit_and_advance(
+                                        shared_owned.as_ref(),
+                                        watcher_owner_channel_id,
+                                        inflight_state.tmux_session_name.as_deref(),
+                                        outcome,
+                                    );
+                                    replace_committed
+                                } else {
+                                    // NoRange (zero/inverted range or no tmux session):
+                                    // there is no offset to advance, so delivering
+                                    // without a lease cannot violate B6. Preserve the
+                                    // pre-P1-2 advance call for parity — it is a no-op
+                                    // for a zero/None range.
+                                    if replace_committed {
+                                        advance_tmux_relay_confirmed_end(
+                                            shared_owned.as_ref(),
+                                            watcher_owner_channel_id,
+                                            tmux_last_offset,
+                                            inflight_state.tmux_session_name.as_deref(),
+                                        );
+                                    }
+                                    replace_committed
+                                };
+                                if outcome {
+                                    terminal_delivery_committed = true;
+                                    terminal_body_visible = true;
+                                } else {
+                                    preserve_inflight_for_cleanup_retry = true;
+                                    if fallback_delivered {
+                                        // Mark the whole response delivered: the fallback
+                                        // message carried it. The preserved-inflight save on
+                                        // the `preserve_inflight_for_cleanup_retry` path below
+                                        // persists this advanced offset, so the turn never
+                                        // re-presents as a never-delivered leak for recovery.
+                                        inflight_state.response_sent_offset = full_response.len();
+                                    }
+                                }
                             }
                         }
                     }

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -1411,8 +1411,8 @@ use stale_resume::{
 };
 use terminal_delivery::{
     BridgeDeliveryLease, BridgeLeaseAcquire, bridge_epilogue_clears_inflight,
-    bridge_epilogue_marks_watcher_delivered, send_ordered_long_terminal_response,
-    should_complete_work_dispatch_after_terminal_delivery,
+    bridge_epilogue_marks_watcher_delivered, bridge_epilogue_skip_save_is_identity_guarded,
+    send_ordered_long_terminal_response, should_complete_work_dispatch_after_terminal_delivery,
     should_fail_dispatch_after_terminal_delivery, silent_turn_skip_marks_committed,
     terminal_delivery_should_send_new_chunks, tui_quiescence_timeout_requires_inflight_retry,
     turn_bridge_replace_outcome_committed,
@@ -7208,6 +7208,25 @@ pub(super) fn spawn_turn_bridge(
             has_pending_after_voice
         };
         let mut preserve_inflight_for_cleanup_retry = false;
+        // #3041 P1-2 (codex P1-2 R3): set ONLY on a delivery-lease `Skip`, where
+        // the live HOLDER (the watcher) — a different actor sharing the same
+        // per-channel `DeliveryLeaseCell` — owns this turn's delivery AND its
+        // inflight lifecycle (the watcher CLEARS inflight on its own success).
+        // Distinct from the bridge-owned `preserve_inflight_for_cleanup_retry`
+        // sites (EditFailed, PG-cancel-fail, replace-not-committed, send/enqueue
+        // failure, TUI quiescence timeout) where the BRIDGE still owns the row
+        // and its epilogue `save_inflight_state` is load-bearing. On a Skip the
+        // bridge must NOT blindly rewrite inflight: the holder may have already
+        // cleared it on success, and a blind re-save would resurrect a STALE
+        // inflight row for an already-delivered turn (recovery sees it as
+        // delivered and returns without clearing → permanent stale leak). The
+        // epilogue's save is therefore made IDENTITY-GUARDED on a Skip
+        // (`save_inflight_state_if_matches_identity`): it only rewrites if the
+        // on-disk row STILL matches this turn's identity, so a watcher-clear
+        // (file gone) or a newer turn (identity mismatch) no-ops instead of
+        // resurrecting. When the holder FAILS (does not clear), the row is still
+        // present + matching, so the bridge refreshes it and retry survives.
+        let mut bridge_skip_holder_owns_inflight = false;
         let mut terminal_delivery_committed = false;
         let mut terminal_body_visible = false;
         let mut status_panel_terminal_committed = false;
@@ -7453,6 +7472,10 @@ pub(super) fn spawn_turn_bridge(
                 // the existing ACK-poll / next-pass machinery re-delivers the
                 // still-retry-able turn instead of black-holing it.
                 preserve_inflight_for_cleanup_retry = true;
+                // codex P1-2 R3: the watcher (holder) owns the inflight lifecycle
+                // on a Skip — make the epilogue save identity-guarded so it never
+                // resurrects a row the holder already cleared on success.
+                bridge_skip_holder_owns_inflight = true;
             } else {
                 let stop_lease = match stop_lease_acquire {
                     BridgeLeaseAcquire::Held(lease) => Some(lease),
@@ -7543,6 +7566,8 @@ pub(super) fn spawn_turn_bridge(
                 // holder owns delivery; the bridge must not clear inflight or mark
                 // the watcher delivered. See the cancel/stop skip arm above.
                 preserve_inflight_for_cleanup_retry = true;
+                // codex P1-2 R3: holder owns the inflight lifecycle on a Skip.
+                bridge_skip_holder_owns_inflight = true;
             } else {
                 let plt_lease = match plt_lease_acquire {
                     BridgeLeaseAcquire::Held(lease) => Some(lease),
@@ -7987,6 +8012,9 @@ pub(super) fn spawn_turn_bridge(
                         // and the holder's eventual NotDelivered/Unknown stays
                         // re-deliverable.
                         preserve_inflight_for_cleanup_retry = true;
+                        // codex P1-2 R3: holder owns the inflight lifecycle on a
+                        // Skip — identity-guard the epilogue save (no resurrect).
+                        bridge_skip_holder_owns_inflight = true;
                         let ts = chrono::Local::now().format("%H:%M:%S");
                         tracing::warn!(
                             channel = channel_id.get(),
@@ -8062,6 +8090,9 @@ pub(super) fn spawn_turn_bridge(
                             // clear inflight or mark the watcher delivered. See the
                             // cancel/stop skip arm.
                             preserve_inflight_for_cleanup_retry = true;
+                            // codex P1-2 R3: holder owns the inflight lifecycle on
+                            // a Skip — identity-guard the epilogue save.
+                            bridge_skip_holder_owns_inflight = true;
                         } else {
                             let lease = match lease_acquire {
                                 BridgeLeaseAcquire::Held(lease) => Some(lease),
@@ -8152,6 +8183,9 @@ pub(super) fn spawn_turn_bridge(
                             // clear inflight or mark the watcher delivered. See the
                             // cancel/stop skip arm.
                             preserve_inflight_for_cleanup_retry = true;
+                            // codex P1-2 R3: holder owns the inflight lifecycle on
+                            // a Skip — identity-guard the epilogue save.
+                            bridge_skip_holder_owns_inflight = true;
                         } else {
                             // `Held(lease)` → commit via the lease; `NoRange` →
                             // deliver without a lease (no offset to advance).
@@ -9132,7 +9166,49 @@ pub(super) fn spawn_turn_bridge(
             let _ = save_inflight_state(&inflight_state);
             inflight_guard.provider.take();
         } else if preserve_inflight_for_cleanup_retry || bridge_output_owner.is_some() {
-            let _ = save_inflight_state(&inflight_state);
+            // #3041 P1-2 (codex P1-2 R3): on a delivery-lease `Skip` the live
+            // HOLDER (the watcher) owns this turn's inflight lifecycle and CLEARS
+            // the row on its own success. A blind `save_inflight_state` here would
+            // RACE the holder's clear: if the clear wins first and our save runs
+            // second, we resurrect a STALE inflight row for an already-delivered
+            // turn (recovery then sees it delivered and returns WITHOUT clearing
+            // → permanent stale leak). So on the skip-holder path we use an
+            // IDENTITY-GUARDED save that only rewrites when the on-disk row STILL
+            // matches this turn — a holder-cleared row (Missing) or a newer turn
+            // (IdentityMismatch) no-ops. When the holder FAILED (did not clear),
+            // the row is still present + matching, so the refresh lands and retry
+            // survives. Every other preserve site (bridge-owned cleanup retry) and
+            // the delegated-owner path keep the blind save: there is no competing
+            // holder, so the bridge's save is authoritative.
+            let identity_guarded_skip_save =
+                bridge_epilogue_skip_save_is_identity_guarded(bridge_skip_holder_owns_inflight);
+            if identity_guarded_skip_save {
+                let expected_identity =
+                    crate::services::discord::inflight::InflightTurnIdentity::from_state(
+                        &inflight_state,
+                    );
+                let guarded_outcome =
+                    crate::services::discord::inflight::save_inflight_state_if_matches_identity(
+                        &inflight_state,
+                        &expected_identity,
+                        inflight_state.turn_start_offset,
+                    );
+                crate::services::observability::emit_inflight_lifecycle_event(
+                    provider.as_str(),
+                    channel_id.get(),
+                    dispatch_id.as_deref(),
+                    adk_session_key.as_deref(),
+                    Some(turn_id.as_str()),
+                    "skip_identity_guarded_save",
+                    serde_json::json!({
+                        "guarded_save_outcome": format!("{guarded_outcome:?}"),
+                        "user_msg_id": inflight_state.user_msg_id,
+                        "turn_start_offset": inflight_state.turn_start_offset,
+                    }),
+                );
+            } else {
+                let _ = save_inflight_state(&inflight_state);
+            }
             inflight_guard.provider.take();
             if let Some(owner) = bridge_output_owner {
                 let lifecycle_event = match owner {

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -1410,7 +1410,8 @@ use stale_resume::{
     stream_error_requires_terminal_session_reset,
 };
 use terminal_delivery::{
-    BridgeDeliveryLease, BridgeLeaseAcquire, send_ordered_long_terminal_response,
+    BridgeDeliveryLease, BridgeLeaseAcquire, bridge_epilogue_clears_inflight,
+    bridge_epilogue_marks_watcher_delivered, send_ordered_long_terminal_response,
     should_complete_work_dispatch_after_terminal_delivery,
     should_fail_dispatch_after_terminal_delivery, silent_turn_skip_marks_committed,
     terminal_delivery_should_send_new_chunks, tui_quiescence_timeout_requires_inflight_retry,
@@ -3102,12 +3103,127 @@ fn live_watcher_registered_for_relay(shared: &SharedData, owner_channel_id: Chan
         .is_some_and(|watcher| !watcher.cancel.load(Ordering::Relaxed))
 }
 
+/// #3041 P1-2 (codex P1-a): resolve the AUTHORITATIVE owner channel a turn's
+/// tmux session belongs to, so the bridge's availability check AND its delivery
+/// lease acquire+advance key on the SAME channel the (possibly reused) watcher
+/// leases+advances on.
+///
+/// A RECOVERED/restored bridge can reach delivery WITHOUT going through the
+/// `TmuxReady`/`RuntimeReady` claim paths (which set `watcher_owner_channel_id =
+/// claim.owner_channel_id()`). If it kept its dispatch `channel_id` (Y) while a
+/// reused watcher leases on its owner channel (X), the two would hit DIFFERENT
+/// `DeliveryLeaseCell`s and both could acquire+deliver = duplicate. Resolving
+/// the session's owner channel from the registry here closes that gap in EVERY
+/// path. When no reused watcher owns the session (`None`), the bridge owns its
+/// own channel → fall back to `dispatch_channel_id`.
+fn resolve_bridge_owner_channel(
+    tmux_watchers: &TmuxWatcherRegistry,
+    tmux_session_name: Option<&str>,
+    dispatch_channel_id: ChannelId,
+) -> ChannelId {
+    tmux_session_name
+        .and_then(|session| tmux_watchers.owner_channel_for_tmux_session(session))
+        .unwrap_or(dispatch_channel_id)
+}
+
 fn bridge_should_reclaim_relay_from_missing_watcher(
     watcher_owns_assistant_relay: bool,
     standby_relay_owns_output: bool,
     live_watcher_registered: bool,
 ) -> bool {
     watcher_owns_assistant_relay && !standby_relay_owns_output && !live_watcher_registered
+}
+
+#[cfg(test)]
+mod bridge_owner_channel_resolution_tests {
+    use super::*;
+
+    fn live_watcher_handle(tmux_session_name: &str) -> TmuxWatcherHandle {
+        TmuxWatcherHandle {
+            tmux_session_name: tmux_session_name.to_string(),
+            output_path: format!("/tmp/{tmux_session_name}.jsonl"),
+            paused: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            resume_offset: Arc::new(std::sync::Mutex::new(None)),
+            cancel: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            pause_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            turn_delivered: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            last_heartbeat_ts_ms: Arc::new(std::sync::atomic::AtomicI64::new(0)),
+            mailbox_finalize_owed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        }
+    }
+
+    // #3041 P1-2 (codex P1-a): a RECOVERED/restored bridge whose dispatch channel
+    // (Y) differs from a REUSED watcher's owner channel (X) for the SAME tmux
+    // session must resolve the AUTHORITATIVE owner channel to X — so its
+    // availability check and delivery-lease acquire+advance key on the SAME cell
+    // the watcher leases+advances on (single-holder B2), not the dispatch
+    // channel's separate cell (which would let both deliver = duplicate).
+    #[test]
+    fn recovered_bridge_resolves_reused_watcher_owner_channel_not_dispatch() {
+        let registry = TmuxWatcherRegistry::new();
+        let tmux = "AgentDesk-claude-adk-cc-t1500000000000000001";
+        let owner_channel_x = ChannelId::new(1_500_000_000_000_000_001);
+        let dispatch_channel_y = ChannelId::new(2_600_000_000_000_000_002);
+        assert_ne!(owner_channel_x, dispatch_channel_y);
+
+        // A live (reused) watcher owns the session under channel X.
+        registry.insert(owner_channel_x, live_watcher_handle(tmux));
+
+        // The bridge dispatches on Y but the turn's session is owned by X →
+        // resolve to X (the channel the watcher leases on), NOT Y.
+        assert_eq!(
+            resolve_bridge_owner_channel(&registry, Some(tmux), dispatch_channel_y),
+            owner_channel_x,
+            "a recovered bridge must lease on the reused watcher's owner channel, not its dispatch channel"
+        );
+
+        // The watcher's OWN lease channel is exactly its
+        // `owner_channel_for_tmux_session` result — so the two truly match.
+        assert_eq!(
+            registry.owner_channel_for_tmux_session(tmux),
+            Some(owner_channel_x),
+            "the watcher's own lease channel must equal the resolved owner channel"
+        );
+    }
+
+    // #3105 restored-owner (no live watcher handle, settings-derived owner) is
+    // still authoritative: a recovered bridge resolves to it so it cannot lease a
+    // different cell than the relay path that re-registered the owner.
+    #[test]
+    fn recovered_bridge_resolves_restored_owner_channel() {
+        let registry = TmuxWatcherRegistry::new();
+        let tmux = "AgentDesk-claude-adk-cc-t1500000000000000003";
+        let restored_owner = ChannelId::new(1_500_000_000_000_000_003);
+        let dispatch_channel_y = ChannelId::new(2_600_000_000_000_000_004);
+
+        registry.restore_owner_channel_for_tmux_session(tmux, restored_owner);
+        assert_eq!(
+            resolve_bridge_owner_channel(&registry, Some(tmux), dispatch_channel_y),
+            restored_owner,
+        );
+    }
+
+    // When NO reused watcher (and no restored owner) owns the session, the bridge
+    // owns its own channel → fall back to the dispatch channel.
+    #[test]
+    fn no_reused_watcher_falls_back_to_dispatch_channel() {
+        let registry = TmuxWatcherRegistry::new();
+        let dispatch_channel = ChannelId::new(3_700_000_000_000_000_005);
+        assert_eq!(
+            resolve_bridge_owner_channel(
+                &registry,
+                Some("AgentDesk-claude-adk-cc-t-unowned"),
+                dispatch_channel,
+            ),
+            dispatch_channel,
+            "no owner mapping → the bridge owns its own dispatch channel"
+        );
+        // No tmux session at all → also falls back to the dispatch channel.
+        assert_eq!(
+            resolve_bridge_owner_channel(&registry, None, dispatch_channel),
+            dispatch_channel,
+        );
+    }
 }
 
 fn advance_tmux_relay_confirmed_end(
@@ -4138,10 +4254,34 @@ pub(super) fn spawn_turn_bridge(
                 provider.as_str(),
             );
         }
+        // #3041 P1-2 (codex P1-a): resolve the AUTHORITATIVE owner channel for
+        // this turn's tmux session BEFORE the watcher availability check and the
+        // bridge delivery-lease acquisition. A RECOVERED/restored bridge that
+        // REUSES an existing watcher (without going through the
+        // `TmuxReady`/`RuntimeReady` claim paths, which set
+        // `watcher_owner_channel_id = claim.owner_channel_id()`) would otherwise
+        // keep `watcher_owner_channel_id == channel_id` (the bridge's dispatch
+        // channel Y) while the reused watcher leases + advances on its owner
+        // channel X — different cells, so both could acquire and deliver
+        // (duplicate). Resolving the session's owner channel here makes EVERY
+        // path (normal, claim, recovered/restored) key the availability check
+        // AND the lease acquire+advance on the SAME channel the watcher uses.
+        // When no reused watcher owns the session, this falls back to
+        // `channel_id` (the bridge owns its own channel). The claim paths below
+        // still re-assert `claim.owner_channel_id()` (which equals this resolved
+        // value for the same session) so live truth always wins.
+        let resolved_watcher_owner_channel_id = resolve_bridge_owner_channel(
+            &shared_owned.tmux_watchers,
+            bridge.inflight_state.tmux_session_name.as_deref(),
+            channel_id,
+        );
         let mut watcher_owns_assistant_relay =
             matches!(initial_relay_owner_kind, super::inflight::RelayOwnerKind::Watcher);
         let mut watcher_relay_available_for_turn = watcher_owns_assistant_relay
-            && live_watcher_registered_for_relay(shared_owned.as_ref(), channel_id);
+            && live_watcher_registered_for_relay(
+                shared_owned.as_ref(),
+                resolved_watcher_owner_channel_id,
+            );
         let mut watcher_handoff_claim_outcome = WatcherHandoffClaimOutcome::None;
         // Durable recovery must honor typed non-bridge owners too. `Unknown`
         // is treated like a live external owner so future relay variants do
@@ -4282,7 +4422,13 @@ pub(super) fn spawn_turn_bridge(
         let mut streaming_rollover_frozen_msg_ids: Vec<MessageId> = Vec::new();
         let mut terminal_full_replay_cleanup_msg_ids: Vec<MessageId> = Vec::new();
         let mut tmux_last_offset = bridge.tmux_last_offset;
-        let mut watcher_owner_channel_id = channel_id;
+        // #3041 P1-2 (codex P1-a): seed from the session's AUTHORITATIVE owner
+        // channel (resolved above) so a recovered/restored bridge reusing an
+        // existing watcher leases on the SAME cell the watcher leases+advances
+        // on — not its dispatch `channel_id`. The claim paths below still
+        // overwrite this with `claim.owner_channel_id()` (equal for the same
+        // session) when they run.
+        let mut watcher_owner_channel_id = resolved_watcher_owner_channel_id;
         let mut new_session_id = bridge.new_session_id.clone();
         let mut new_raw_provider_session_id: Option<String> = None;
         let defer_watcher_resume = bridge.defer_watcher_resume;
@@ -7298,6 +7444,15 @@ pub(super) fn spawn_turn_bridge(
                     "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge skipped duplicate cancel/stop terminal replace (channel {})",
                     channel_id
                 );
+                // #3041 P1-2 (codex P1-c): a B2 Skip means the live lease holder
+                // (the watcher) owns delivery of this range — the bridge must be a
+                // TRUE no-op on completion side-effects. PRESERVE the inflight so
+                // the cleanup epilogue does NOT clear it (~9017) and does NOT mark
+                // `watcher.turn_delivered = true` (~8356); the bridge never
+                // delivered this range. If the holder ultimately fails to deliver,
+                // the existing ACK-poll / next-pass machinery re-delivers the
+                // still-retry-able turn instead of black-holing it.
+                preserve_inflight_for_cleanup_retry = true;
             } else {
                 let stop_lease = match stop_lease_acquire {
                     BridgeLeaseAcquire::Held(lease) => Some(lease),
@@ -7384,6 +7539,10 @@ pub(super) fn spawn_turn_bridge(
                     "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge skipped duplicate prompt-too-long terminal replace (channel {})",
                     channel_id
                 );
+                // #3041 P1-2 (codex P1-c): preserve retry state on a B2 Skip — the
+                // holder owns delivery; the bridge must not clear inflight or mark
+                // the watcher delivered. See the cancel/stop skip arm above.
+                preserve_inflight_for_cleanup_retry = true;
             } else {
                 let plt_lease = match plt_lease_acquire {
                     BridgeLeaseAcquire::Held(lease) => Some(lease),
@@ -7819,7 +7978,15 @@ pub(super) fn spawn_turn_bridge(
                     BridgeLeaseAcquire::Skip => {
                         // B2-skip: the watcher holds the live lease and owns this
                         // range's delivery. Do NOT mark committed / advance / clear
-                        // inflight — leave the turn retry-able (codex P1-c).
+                        // inflight — leave the turn retry-able (codex P1-c). The
+                        // `terminal_delivery_committed = false` above is NOT enough
+                        // on its own: the cleanup epilogue still marks
+                        // `watcher.turn_delivered = true` (~8356) and CLEARS inflight
+                        // (~9017) unless `preserve_inflight_for_cleanup_retry` is set.
+                        // Set it so a Skip is a TRUE no-op on completion side-effects
+                        // and the holder's eventual NotDelivered/Unknown stays
+                        // re-deliverable.
+                        preserve_inflight_for_cleanup_retry = true;
                         let ts = chrono::Local::now().format("%H:%M:%S");
                         tracing::warn!(
                             channel = channel_id.get(),
@@ -7890,6 +8057,11 @@ pub(super) fn spawn_turn_bridge(
                                 "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge skipped duplicate long terminal send (channel {})",
                                 channel_id
                             );
+                            // #3041 P1-2 (codex P1-c): preserve retry state on a B2
+                            // Skip — the holder owns delivery; the bridge must not
+                            // clear inflight or mark the watcher delivered. See the
+                            // cancel/stop skip arm.
+                            preserve_inflight_for_cleanup_retry = true;
                         } else {
                             let lease = match lease_acquire {
                                 BridgeLeaseAcquire::Held(lease) => Some(lease),
@@ -7975,6 +8147,11 @@ pub(super) fn spawn_turn_bridge(
                                 "  [{ts}] 🌉 #3041 B2: delivery lease held by another holder — bridge skipped duplicate terminal replace (channel {})",
                                 channel_id
                             );
+                            // #3041 P1-2 (codex P1-c): preserve retry state on a B2
+                            // Skip — the holder owns delivery; the bridge must not
+                            // clear inflight or mark the watcher delivered. See the
+                            // cancel/stop skip arm.
+                            preserve_inflight_for_cleanup_retry = true;
                         } else {
                             // `Held(lease)` → commit via the lease; `NoRange` →
                             // deliver without a lease (no offset to advance).
@@ -8353,9 +8530,15 @@ pub(super) fn spawn_turn_bridge(
 
             // Signal the watcher that this turn's response was already delivered.
             // Prevents the watcher from relaying the same response when it resumes.
-            if !preserve_inflight_for_cleanup_retry
-                && !bridge_relay_delegated_to_watcher
-                && let Some(watcher) = shared_owned.tmux_watchers.get(&watcher_owner_channel_id)
+            // #3041 P1-2 (codex P1-c): a B2 Skip set
+            // `preserve_inflight_for_cleanup_retry = true`, so this gate (encoded in
+            // `bridge_epilogue_marks_watcher_delivered`) does NOT mark the watcher
+            // delivered — the bridge never delivered the range; the holder owns it.
+            if bridge_epilogue_marks_watcher_delivered(
+                preserve_inflight_for_cleanup_retry,
+                bridge_relay_delegated_to_watcher,
+            ) && let Some(watcher) =
+                shared_owned.tmux_watchers.get(&watcher_owner_channel_id)
             {
                 watcher.turn_delivered.store(true, Ordering::Release);
             }
@@ -8982,6 +9165,20 @@ pub(super) fn spawn_turn_bridge(
                 );
             }
         } else {
+            // #3041 P1-2 (codex P1-c): the clear branch is reached IFF the pure
+            // epilogue seam agrees inflight must be cleared — i.e. NOT preserving
+            // for retry (a B2 Skip sets `preserve_inflight_for_cleanup_retry`) and
+            // NOT delegating output. This keeps the production fork and the
+            // unit-tested `bridge_epilogue_clears_inflight` seam in lockstep so a
+            // Skip can never silently reach this destroy-inflight path.
+            debug_assert!(
+                bridge_epilogue_clears_inflight(
+                    preserve_inflight_for_cleanup_retry,
+                    bridge_output_owner.is_some(),
+                    cancelled && cancel_token.restart_mode().is_some(),
+                ),
+                "inflight clear must only run when neither preserving for retry nor delegating output"
+            );
             // #2838 (relay-stability P0-1): detect the missing-answer vector
             // (root causes #1b / #4). We are about to clear inflight (not
             // preserving, no delegated owner). If a non-empty full_response was

--- a/src/services/discord/turn_bridge/terminal_delivery.rs
+++ b/src/services/discord/turn_bridge/terminal_delivery.rs
@@ -238,6 +238,186 @@ pub(super) fn tui_quiescence_timeout_requires_inflight_retry(
     !terminal_delivery_committed
 }
 
+/// #3041 P1-2: per-channel global counter that mints a unique `instance_id` for
+/// each bridge delivery-lease attempt. `LeaseHolder::Bridge` has no `instance_id`
+/// field today (only the watcher's holder kind carries one), so the bridge holder
+/// identity is `(Bridge, turn, range)`. The counter is retained as future-proofing
+/// / observability anchor but does not enter the lease key; the turn+range identity
+/// already distinguishes sequential bridge attempts (each turn re-keys on its own
+/// pinned `TurnKey`).
+static BRIDGE_DELIVERY_LEASE_SEQ: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(1);
+
+/// #3041 P1-2: RAII-ish guard that routes the BRIDGE's terminal delivery through
+/// the SAME per-channel [`crate::services::discord::DeliveryLeaseCell`] the
+/// watcher (P1-1) uses, so the watcher and the bridge are SERIALIZED — whoever
+/// holds the live lease blocks the other's acquire (cross-actor duplicate
+/// prevention, BLOCKER B6 / design §6 P1-2).
+///
+/// Lifecycle (mirrors the watcher's inline P1-1 wiring):
+///   1. [`Self::acquire`] — `reclaim_if_expired` (self-heal a dead holder) then
+///      `try_acquire(turn, Bridge, [start,end), now+deadline)`. On success spawns
+///      a [`crate::services::discord::DeliveryLeaseHeartbeat`] so a long chunked
+///      send (which can exceed the 15s deadline) is never reclaimed mid-flight.
+///      On FAILURE the cell is held by the watcher (or another bridge path) for
+///      this range/turn → the caller MUST take a B2-style skip (NOT deliver+
+///      advance); the live holder owns delivery.
+///   2. caller performs `replace_message_with_outcome` / chunked send.
+///   3. [`Self::commit_and_advance`] — stop the heartbeat, `commit(Bridge, turn,
+///      start, end, outcome)`; on `Delivered` AND a successful commit, advance
+///      `confirmed_end_offset` (the B6 gate: the advance now ONLY happens via a
+///      successful lease commit), then `release` so the cell is free for the next
+///      turn. `NotDelivered`/`Unknown` → no advance.
+///
+/// No-deadlock: every cell op (`reclaim`/`try_acquire`/`renew`/`commit`/
+/// `release`) is a synchronous, non-blocking lock on the cell's payload mutex —
+/// none of them awaits or calls back into the other actor. The heartbeat lives on
+/// its own task and only `renew`s our OWN lease; it is `stop()`ped before commit.
+/// So the bridge never blocks on the watcher and vice-versa.
+pub(super) struct BridgeDeliveryLease {
+    cell: std::sync::Arc<crate::services::discord::DeliveryLeaseCell>,
+    holder: crate::services::discord::LeaseHolder,
+    turn: super::super::turn_finalizer::TurnKey,
+    start: u64,
+    end: u64,
+    heartbeat: Option<crate::services::discord::DeliveryLeaseHeartbeat>,
+}
+
+/// The result of attempting to acquire the bridge delivery lease for a terminal
+/// delivery point.
+pub(super) enum BridgeLeaseAcquire {
+    /// We hold the lease; proceed to deliver, then `commit_and_advance`.
+    Held(BridgeDeliveryLease),
+    /// A different live holder (the watcher, or another bridge path) owns the
+    /// lease for this range/turn. The caller MUST B2-skip: do NOT deliver or
+    /// advance — the holder will commit-advance the offset itself.
+    Skip,
+    /// The range is empty / inverted (`end <= start`) or there is no `tmux_session`
+    /// to advance against, so there is nothing to lease. The caller delivers
+    /// exactly as before WITHOUT a lease and WITHOUT an offset advance (a zero
+    /// range never advances `confirmed_end_offset`). This is the only path where a
+    /// bridge terminal delivery is exempt from the lease — and it is exempt
+    /// precisely because it never advances the offset, so B6 ("no advance outside
+    /// a lease commit") is not violated.
+    NoRange,
+}
+
+impl BridgeDeliveryLease {
+    /// Acquire the per-channel delivery lease for the bridge's terminal delivery
+    /// covering `[start, end)` for `turn`. `target_end` is the same end offset the
+    /// pre-P1-2 `advance_tmux_relay_confirmed_end` advanced to (the bridge's
+    /// `tmux_last_offset`); `start` is the turn's start offset (`turn_start_offset`,
+    /// falling back to the same end so an unknown start yields an empty range that
+    /// routes to [`BridgeLeaseAcquire::NoRange`]).
+    pub(super) fn acquire(
+        shared: &SharedData,
+        channel_id: ChannelId,
+        turn: super::super::turn_finalizer::TurnKey,
+        start: u64,
+        target_end: Option<u64>,
+    ) -> BridgeLeaseAcquire {
+        let Some(end) = target_end.filter(|e| *e > 0) else {
+            return BridgeLeaseAcquire::NoRange;
+        };
+        if end <= start {
+            return BridgeLeaseAcquire::NoRange;
+        }
+        let _seq = BRIDGE_DELIVERY_LEASE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let holder = crate::services::discord::LeaseHolder::Bridge;
+        let cell = shared.delivery_lease(channel_id);
+        // SELF-HEALING acquire (mirrors the watcher B3): reclaim the lease IFF it
+        // is EXPIRED (a dead holder that acquired but died before commit/release).
+        // A LIVE holder mid-send keeps its deadline pushed forward by its
+        // heartbeat, so it is NOT reclaimed and we correctly B2-skip it below.
+        cell.reclaim_if_expired(crate::services::discord::lease_now_ms());
+        let acquired = cell.try_acquire(
+            turn,
+            holder,
+            start,
+            end,
+            crate::services::discord::lease_now_ms()
+                .saturating_add(crate::services::discord::DELIVERY_LEASE_DEADLINE_MS),
+        );
+        if !acquired {
+            return BridgeLeaseAcquire::Skip;
+        }
+        // Keep the lease alive WHILE the (possibly chunked, >15s) send runs.
+        let heartbeat = Some(crate::services::discord::DeliveryLeaseHeartbeat::spawn(
+            cell.clone(),
+            holder,
+            turn,
+        ));
+        BridgeLeaseAcquire::Held(BridgeDeliveryLease {
+            cell,
+            holder,
+            turn,
+            start,
+            end,
+            heartbeat,
+        })
+    }
+
+    /// Stop the heartbeat, commit the 3-way `outcome`, and — ONLY on a successful
+    /// `Delivered` commit — advance `confirmed_end_offset` to the leased `end` via
+    /// `advance_tmux_relay_confirmed_end`. Then release. This is the B6 gate: the
+    /// confirmed-end advance happens IFF the Delivered lease commit succeeds. Returns
+    /// `true` iff the commit succeeded (debug invariant: the bridge must be able to
+    /// commit its own freshly-acquired lease).
+    pub(super) fn commit_and_advance(
+        mut self,
+        shared: &SharedData,
+        watcher_owner_channel_id: ChannelId,
+        tmux_session_name: Option<&str>,
+        outcome: crate::services::discord::LeaseOutcome,
+    ) -> bool {
+        // STOP the heartbeat BEFORE the commit so the renew loop cannot race it.
+        if let Some(hb) = self.heartbeat.take() {
+            hb.stop();
+        }
+        let committed = self
+            .cell
+            .commit(self.holder, self.turn, self.start, self.end, outcome);
+        debug_assert!(
+            committed,
+            "bridge must be able to commit its own freshly-acquired delivery lease"
+        );
+        if committed && outcome == crate::services::discord::LeaseOutcome::Delivered {
+            // B6: the ONLY confirmed_end advance on the bridge terminal path now
+            // flows through this successful lease commit.
+            super::advance_tmux_relay_confirmed_end(
+                shared,
+                watcher_owner_channel_id,
+                Some(self.end),
+                tmux_session_name,
+            );
+        }
+        // Release (compare-and-release, identity-matched) so the cell returns to
+        // Unleased for the NEXT turn — this is what lets the OTHER actor (watcher)
+        // proceed. Idempotent no-op if the lease was reclaimed (holder presumed
+        // dead) in the meantime.
+        let _ = self
+            .cell
+            .release(self.holder, self.turn, self.start, self.end);
+        committed
+    }
+}
+
+impl Drop for BridgeDeliveryLease {
+    fn drop(&mut self) {
+        // Safety net for an early return / panic between `acquire` and
+        // `commit_and_advance`: abort the heartbeat (its own Drop also does this)
+        // and abandon-release the still-`Leased` lease so a dropped bridge frame
+        // never strands the cell (the deadline reclaim would also free it, but
+        // releasing immediately lets the next turn / the watcher proceed without
+        // waiting out the deadline). Identity-matched, so it is a harmless no-op
+        // if `commit_and_advance` already released.
+        self.heartbeat.take();
+        let _ = self
+            .cell
+            .release(self.holder, self.turn, self.start, self.end);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -602,5 +782,245 @@ mod tests {
         assert!(!should_fail_dispatch_after_terminal_delivery(
             false, true, false,
         ));
+    }
+
+    // #3041 P1-2: matrix tests for the BRIDGE delivery-lease wiring. These drive
+    // `BridgeDeliveryLease::acquire` / `commit_and_advance` against a REAL
+    // per-channel `DeliveryLeaseCell` (the SAME cell the watcher uses), proving:
+    //   - Bridge/Delivered advances `confirmed_end_offset` exactly once via the
+    //     lease commit (B6: advance only on a successful Delivered commit);
+    //   - Bridge acquire-contention with a watcher holding the lease → Skip (and
+    //     the converse: the watcher's `try_acquire` skips when the bridge holds);
+    //   - Bridge/Unknown and Bridge/NotDelivered → no advance;
+    //   - Bridge then watcher next turn → the second turn acquires fine (release
+    //     works);
+    //   - no double-advance on a same-range re-commit.
+    // `start_paused` keeps the heartbeat's `tokio::time::interval` from doing real
+    // sleeps; the lease deadline reclaim is driven via explicit `now_ms` args.
+    mod bridge_delivery_lease {
+        use crate::services::discord::turn_finalizer::TurnKey;
+        use crate::services::discord::{
+            DELIVERY_LEASE_DEADLINE_MS, LeaseHolder, LeaseOutcome, LeaseSnapshot, lease_now_ms,
+            make_shared_data_for_tests,
+        };
+        use poise::serenity_prelude::ChannelId;
+
+        use super::super::{BridgeDeliveryLease, BridgeLeaseAcquire};
+
+        const CH: u64 = 909_001;
+
+        fn channel() -> ChannelId {
+            ChannelId::new(CH)
+        }
+
+        fn turn(user_msg_id: u64) -> TurnKey {
+            TurnKey::new(channel(), user_msg_id, 1)
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn bridge_delivered_advances_offset_once_via_lease_commit() {
+            let shared = make_shared_data_for_tests();
+            let ch = channel();
+            assert_eq!(shared.committed_relay_offset(ch), 0);
+
+            let acquire = BridgeDeliveryLease::acquire(&shared, ch, turn(11), 0, Some(64));
+            let lease = match acquire {
+                BridgeLeaseAcquire::Held(lease) => lease,
+                _ => panic!("expected Held on a fresh cell with a real range"),
+            };
+            // While the bridge holds the lease, the cell is Leased by Bridge.
+            assert!(matches!(
+                shared.delivery_lease(ch).read(),
+                LeaseSnapshot::Leased {
+                    holder: LeaseHolder::Bridge,
+                    ..
+                }
+            ));
+
+            let committed = lease.commit_and_advance(&shared, ch, None, LeaseOutcome::Delivered);
+            assert!(committed, "bridge must commit its own fresh lease");
+            assert_eq!(
+                shared.committed_relay_offset(ch),
+                64,
+                "Delivered commit advances confirmed_end to the leased end"
+            );
+            // Released back to Unleased after commit.
+            assert!(matches!(
+                shared.delivery_lease(ch).read(),
+                LeaseSnapshot::Unleased
+            ));
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn bridge_unknown_outcome_does_not_advance() {
+            let shared = make_shared_data_for_tests();
+            let ch = channel();
+            let lease = match BridgeDeliveryLease::acquire(&shared, ch, turn(12), 0, Some(64)) {
+                BridgeLeaseAcquire::Held(lease) => lease,
+                _ => panic!("expected Held"),
+            };
+            lease.commit_and_advance(&shared, ch, None, LeaseOutcome::Unknown);
+            assert_eq!(
+                shared.committed_relay_offset(ch),
+                0,
+                "Unknown must NOT advance the offset"
+            );
+            assert!(matches!(
+                shared.delivery_lease(ch).read(),
+                LeaseSnapshot::Unleased
+            ));
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn bridge_not_delivered_does_not_advance() {
+            let shared = make_shared_data_for_tests();
+            let ch = channel();
+            let lease = match BridgeDeliveryLease::acquire(&shared, ch, turn(13), 0, Some(64)) {
+                BridgeLeaseAcquire::Held(lease) => lease,
+                _ => panic!("expected Held"),
+            };
+            lease.commit_and_advance(&shared, ch, None, LeaseOutcome::NotDelivered);
+            assert_eq!(shared.committed_relay_offset(ch), 0);
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn bridge_skips_when_watcher_holds_lease() {
+            let shared = make_shared_data_for_tests();
+            let ch = channel();
+            // A watcher acquires the SAME per-channel cell first (live, not yet
+            // committed/released/reclaimed).
+            let cell = shared.delivery_lease(ch);
+            let watcher = LeaseHolder::Watcher { instance_id: 7 };
+            assert!(cell.try_acquire(
+                turn(20),
+                watcher,
+                0,
+                64,
+                lease_now_ms().saturating_add(DELIVERY_LEASE_DEADLINE_MS),
+            ));
+            // The bridge's acquire for the same range must B2-skip.
+            assert!(matches!(
+                BridgeDeliveryLease::acquire(&shared, ch, turn(20), 0, Some(64)),
+                BridgeLeaseAcquire::Skip
+            ));
+            assert_eq!(
+                shared.committed_relay_offset(ch),
+                0,
+                "skipped bridge must not advance"
+            );
+            // Watcher still holds it (the bridge's failed acquire did not touch it).
+            assert!(matches!(
+                cell.read(),
+                LeaseSnapshot::Leased {
+                    holder: LeaseHolder::Watcher { instance_id: 7 },
+                    ..
+                }
+            ));
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn watcher_skips_when_bridge_holds_lease() {
+            let shared = make_shared_data_for_tests();
+            let ch = channel();
+            // The bridge acquires first.
+            let _lease = match BridgeDeliveryLease::acquire(&shared, ch, turn(21), 0, Some(64)) {
+                BridgeLeaseAcquire::Held(lease) => lease,
+                _ => panic!("expected Held"),
+            };
+            // A watcher's `try_acquire` on the SAME cell must lose (single holder).
+            let cell = shared.delivery_lease(ch);
+            let watcher = LeaseHolder::Watcher { instance_id: 8 };
+            assert!(
+                !cell.try_acquire(
+                    turn(21),
+                    watcher,
+                    0,
+                    64,
+                    lease_now_ms().saturating_add(DELIVERY_LEASE_DEADLINE_MS),
+                ),
+                "watcher must B2-skip while the bridge holds the live lease"
+            );
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn bridge_release_lets_next_turn_acquire() {
+            let shared = make_shared_data_for_tests();
+            let ch = channel();
+            // Turn 1: bridge delivers and commits.
+            let lease = match BridgeDeliveryLease::acquire(&shared, ch, turn(30), 0, Some(32)) {
+                BridgeLeaseAcquire::Held(lease) => lease,
+                _ => panic!("expected Held"),
+            };
+            lease.commit_and_advance(&shared, ch, None, LeaseOutcome::Delivered);
+            assert_eq!(shared.committed_relay_offset(ch), 32);
+
+            // Turn 2 (a later, non-overlapping range): the watcher acquires fine
+            // because the bridge released the cell.
+            let cell = shared.delivery_lease(ch);
+            let watcher = LeaseHolder::Watcher { instance_id: 9 };
+            assert!(
+                cell.try_acquire(
+                    turn(31),
+                    watcher,
+                    32,
+                    96,
+                    lease_now_ms().saturating_add(DELIVERY_LEASE_DEADLINE_MS),
+                ),
+                "release must free the cell for the next turn's acquirer"
+            );
+            assert!(cell.commit(watcher, turn(31), 32, 96, LeaseOutcome::Delivered));
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn no_double_advance_on_same_range_recommit() {
+            let shared = make_shared_data_for_tests();
+            let ch = channel();
+            // First Delivered commit advances to 64.
+            let lease = match BridgeDeliveryLease::acquire(&shared, ch, turn(40), 0, Some(64)) {
+                BridgeLeaseAcquire::Held(lease) => lease,
+                _ => panic!("expected Held"),
+            };
+            lease.commit_and_advance(&shared, ch, None, LeaseOutcome::Delivered);
+            assert_eq!(shared.committed_relay_offset(ch), 64);
+
+            // A same-holder re-acquire+commit of the SAME range advances to the SAME
+            // 64 — the monotonic CAS in `advance_tmux_relay_confirmed_end` cannot
+            // double-advance.
+            let lease2 = match BridgeDeliveryLease::acquire(&shared, ch, turn(40), 0, Some(64)) {
+                BridgeLeaseAcquire::Held(lease) => lease,
+                _ => panic!("expected Held on re-acquire after release"),
+            };
+            lease2.commit_and_advance(&shared, ch, None, LeaseOutcome::Delivered);
+            assert_eq!(
+                shared.committed_relay_offset(ch),
+                64,
+                "same-range re-commit must not double-advance"
+            );
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn empty_range_routes_to_no_range() {
+            let shared = make_shared_data_for_tests();
+            let ch = channel();
+            // end <= start → NoRange (nothing to lease, never advances).
+            assert!(matches!(
+                BridgeDeliveryLease::acquire(&shared, ch, turn(50), 64, Some(64)),
+                BridgeLeaseAcquire::NoRange
+            ));
+            // None / zero end → NoRange.
+            assert!(matches!(
+                BridgeDeliveryLease::acquire(&shared, ch, turn(50), 0, None),
+                BridgeLeaseAcquire::NoRange
+            ));
+            assert!(matches!(
+                BridgeDeliveryLease::acquire(&shared, ch, turn(50), 0, Some(0)),
+                BridgeLeaseAcquire::NoRange
+            ));
+            assert_eq!(shared.committed_relay_offset(ch), 0);
+            assert!(matches!(
+                shared.delivery_lease(ch).read(),
+                LeaseSnapshot::Unleased
+            ));
+        }
     }
 }

--- a/src/services/discord/turn_bridge/terminal_delivery.rs
+++ b/src/services/discord/turn_bridge/terminal_delivery.rs
@@ -315,6 +315,42 @@ pub(super) fn silent_turn_skip_marks_committed(acquire: &BridgeLeaseAcquire) -> 
     !matches!(acquire, BridgeLeaseAcquire::Skip)
 }
 
+/// #3041 P1-2 (codex P1-c): the cleanup-epilogue decision seam. On EVERY bridge
+/// skip arm (cancel/stop, prompt-too-long, silent_turn, long-send,
+/// normal-replace) the bridge sets `preserve_inflight_for_cleanup_retry = true`
+/// when the delivery-lease acquire returns [`BridgeLeaseAcquire::Skip`] — the
+/// live holder (the watcher) owns delivery of this range, so the bridge must be a
+/// TRUE no-op on completion side-effects.
+///
+/// These two pure predicates mirror the downstream epilogue gates so the
+/// "a Skip preserves retry state" contract is unit-testable without driving the
+/// whole 5000-line turn loop:
+///   * [`bridge_epilogue_clears_inflight`] — the `~9017` clear-vs-preserve fork:
+///     a preserved turn is SAVED (re-deliverable), never cleared.
+///   * [`bridge_epilogue_marks_watcher_delivered`] — the `~8422` gate that signs
+///     the watcher off as already-delivered: a preserved turn must NOT mark the
+///     watcher delivered (it never delivered the range).
+///
+/// `~9017`: the bridge clears inflight ONLY when neither preserving for retry nor
+/// delegating output to another owner. A preserved turn is saved, not cleared.
+pub(super) fn bridge_epilogue_clears_inflight(
+    preserve_inflight_for_cleanup_retry: bool,
+    bridge_output_delegated: bool,
+    cancelled_with_restart_mode: bool,
+) -> bool {
+    !cancelled_with_restart_mode && !preserve_inflight_for_cleanup_retry && !bridge_output_delegated
+}
+
+/// `~8422`: the bridge signs the watcher off as already-delivered ONLY when not
+/// preserving for retry and not delegating relay to the watcher. A preserved turn
+/// must NOT mark the watcher delivered.
+pub(super) fn bridge_epilogue_marks_watcher_delivered(
+    preserve_inflight_for_cleanup_retry: bool,
+    bridge_relay_delegated_to_watcher: bool,
+) -> bool {
+    !preserve_inflight_for_cleanup_retry && !bridge_relay_delegated_to_watcher
+}
+
 impl BridgeDeliveryLease {
     /// Acquire the per-channel delivery lease for the bridge's terminal delivery
     /// covering `[start, end)` for `turn`. `target_end` is the same end offset the
@@ -445,6 +481,7 @@ impl Drop for BridgeDeliveryLease {
 #[cfg(test)]
 mod tests {
     use super::{
+        bridge_epilogue_clears_inflight, bridge_epilogue_marks_watcher_delivered,
         replace_outcome_commits_terminal_delivery, send_ordered_long_terminal_chunks,
         should_complete_work_dispatch_after_terminal_delivery,
         should_fail_dispatch_after_terminal_delivery, terminal_delivery_should_send_new_chunks,
@@ -664,6 +701,45 @@ mod tests {
             !tui_quiescence_timeout_requires_inflight_retry(true),
             "after Discord terminal delivery commits, timeout may suppress visible completion but must not preserve stale inflight ownership"
         );
+    }
+
+    // #3041 P1-2 (codex P1-c): every bridge skip arm sets
+    // `preserve_inflight_for_cleanup_retry = true`. These predicates encode the two
+    // downstream epilogue gates the production loop now routes through; the
+    // assertions prove a Skip (preserve = true) is a TRUE no-op on completion
+    // side-effects — inflight is NOT cleared and the watcher is NOT marked
+    // delivered — so the turn stays fully retry-able if the holder later fails.
+    #[test]
+    fn bridge_skip_preserves_inflight_and_does_not_mark_watcher_delivered() {
+        // A B2 Skip sets preserve = true → the epilogue must NOT clear inflight…
+        assert!(
+            !bridge_epilogue_clears_inflight(true, false, false),
+            "a preserved (skipped) turn must NOT clear inflight — it stays retry-able"
+        );
+        // …and must NOT mark the watcher delivered (the bridge never delivered it).
+        assert!(
+            !bridge_epilogue_marks_watcher_delivered(true, false),
+            "a preserved (skipped) turn must NOT mark the watcher delivered"
+        );
+    }
+
+    #[test]
+    fn bridge_non_skip_normal_completion_clears_and_marks_delivered() {
+        // A normal committed turn (preserve = false, no delegation, not a
+        // restart-cancel) DOES clear inflight and DOES mark the watcher delivered.
+        assert!(bridge_epilogue_clears_inflight(false, false, false));
+        assert!(bridge_epilogue_marks_watcher_delivered(false, false));
+    }
+
+    #[test]
+    fn bridge_delegation_and_restart_cancel_never_clear_inflight() {
+        // Output delegated to another owner → preserve (save), never clear.
+        assert!(!bridge_epilogue_clears_inflight(false, true, false));
+        // A restart-mode cancel saves inflight on its own branch → never clear here.
+        assert!(!bridge_epilogue_clears_inflight(false, false, true));
+        // Relay delegated to the watcher → the watcher relays itself; the bridge
+        // must not also sign it off as delivered.
+        assert!(!bridge_epilogue_marks_watcher_delivered(false, true));
     }
 
     #[test]

--- a/src/services/discord/turn_bridge/terminal_delivery.rs
+++ b/src/services/discord/turn_bridge/terminal_delivery.rs
@@ -302,6 +302,19 @@ pub(super) enum BridgeLeaseAcquire {
     NoRange,
 }
 
+/// #3041 P1-2 (codex P1-c): whether the silent-turn suppression site (mod.rs
+/// site 3) may mark `terminal_delivery_committed` for a given acquire outcome.
+///
+/// A B2 `Skip` means the live holder (the watcher) owns delivery of this range —
+/// the bridge MUST be a no-op on completion side-effects (do NOT mark committed,
+/// advance, or clear inflight as delivered) so the existing retry machinery can
+/// re-attempt if the holder ultimately fails to deliver. `Held` (the bridge
+/// committed the range itself) and `NoRange` (no bytes to deliver; the
+/// suppression resolves the empty range) DO mark committed.
+pub(super) fn silent_turn_skip_marks_committed(acquire: &BridgeLeaseAcquire) -> bool {
+    !matches!(acquire, BridgeLeaseAcquire::Skip)
+}
+
 impl BridgeDeliveryLease {
     /// Acquire the per-channel delivery lease for the bridge's terminal delivery
     /// covering `[start, end)` for `turn`. `target_end` is the same end offset the
@@ -309,6 +322,17 @@ impl BridgeDeliveryLease {
     /// `tmux_last_offset`); `start` is the turn's start offset (`turn_start_offset`,
     /// falling back to the same end so an unknown start yields an empty range that
     /// routes to [`BridgeLeaseAcquire::NoRange`]).
+    ///
+    /// `channel_id` MUST be the channel whose cell the WATCHER also leases on for
+    /// this turn — the watcher's owner channel (`watcher_owner_channel_id` on the
+    /// bridge side), NOT the bridge's dispatch `channel_id`. A reused watcher can
+    /// own a DIFFERENT channel; if the bridge leased on its dispatch channel while
+    /// the watcher leased on its owner channel, the two would hit DIFFERENT cells
+    /// and both could acquire+deliver = duplicate (codex P1-a). Keying both on the
+    /// watcher's owner channel makes their acquires contend on the SAME cell
+    /// (single-holder B2). The same channel is used for the `TurnKey` and the
+    /// `confirmed_end_offset` advance in `commit_and_advance`, so acquire, commit,
+    /// and advance all operate on one consistent channel.
     pub(super) fn acquire(
         shared: &SharedData,
         channel_id: ChannelId,
@@ -995,6 +1019,176 @@ mod tests {
                 shared.committed_relay_offset(ch),
                 64,
                 "same-range re-commit must not double-advance"
+            );
+        }
+
+        // #3041 P1-2 (codex P1-a): a REUSED watcher can own a channel DIFFERENT
+        // from the bridge's dispatch `channel_id`. The watcher leases (and advances
+        // `confirmed_end_offset`) on ITS owner channel's cell. The bridge MUST lease
+        // on that SAME owner-channel cell (it passes `watcher_owner_channel_id`), so
+        // the two contend on ONE cell (single-holder B2) and never both deliver.
+        // This test proves the cell is shared by-channel: the watcher holds the
+        // OWNER channel's cell; the bridge acquiring on the OWNER channel B2-skips
+        // (same cell), while a bridge acquiring on the unrelated dispatch channel
+        // would have hit a DIFFERENT cell and wrongly acquired — which is exactly
+        // the duplicate the P1-a fix routes the bridge onto the owner channel to
+        // avoid.
+        #[tokio::test(start_paused = true)]
+        async fn bridge_leases_on_watcher_owner_channel_shares_cell_under_reuse() {
+            let shared = make_shared_data_for_tests();
+            // The reused watcher's OWNER channel (where it leases + advances).
+            let owner_ch = ChannelId::new(CH);
+            // The bridge's dispatch channel — DIFFERENT from the owner (watcher
+            // reuse). Its cell is a SEPARATE `DeliveryLeaseCell`.
+            let dispatch_ch = ChannelId::new(CH + 1);
+            assert_ne!(owner_ch, dispatch_ch);
+
+            // The watcher acquires the OWNER channel's cell, keyed on the owner
+            // channel's TurnKey (mirrors `tmux_output_watcher_with_restore`, which
+            // leases on its own `channel_id` == owner).
+            let owner_cell = shared.delivery_lease(owner_ch);
+            let watcher = LeaseHolder::Watcher { instance_id: 70 };
+            let watcher_turn = TurnKey::new(owner_ch, 99, 1);
+            assert!(owner_cell.try_acquire(
+                watcher_turn,
+                watcher,
+                0,
+                64,
+                lease_now_ms().saturating_add(DELIVERY_LEASE_DEADLINE_MS),
+            ));
+
+            // P1-a fix: the bridge acquires on `watcher_owner_channel_id` (the OWNER
+            // channel) → SAME cell → B2-skip (contention detected, NOT both-deliver).
+            let bridge_turn = TurnKey::new(owner_ch, 99, 1);
+            assert!(
+                matches!(
+                    BridgeDeliveryLease::acquire(&shared, owner_ch, bridge_turn, 0, Some(64)),
+                    BridgeLeaseAcquire::Skip
+                ),
+                "bridge keyed on the watcher's owner channel must hit the SAME cell and B2-skip"
+            );
+
+            // Regression contrast: keying on the unrelated DISPATCH channel hits a
+            // DIFFERENT cell → the bridge would WRONGLY acquire (the pre-fix
+            // duplicate). This documents WHY the bridge must use the owner channel.
+            let dispatch_turn = TurnKey::new(dispatch_ch, 99, 1);
+            assert!(
+                matches!(
+                    BridgeDeliveryLease::acquire(&shared, dispatch_ch, dispatch_turn, 0, Some(64)),
+                    BridgeLeaseAcquire::Held(_)
+                ),
+                "the unrelated dispatch-channel cell is a DIFFERENT cell — leasing there would duplicate"
+            );
+
+            // The watcher still holds the owner cell; neither bridge acquire touched it.
+            assert!(matches!(
+                owner_cell.read(),
+                LeaseSnapshot::Leased {
+                    holder: LeaseHolder::Watcher { instance_id: 70 },
+                    ..
+                }
+            ));
+        }
+
+        // #3041 P1-2 (codex P1-b): an equal NONZERO range (`end == start`, e.g.
+        // start==end==64) routes to `NoRange` — there are NO new bytes to commit, so
+        // the bridge delivers WITHOUT a lease and NEVER advances `confirmed_end`. The
+        // pre-fix bug advanced the offset to 64 outside any lease commit (B6
+        // violation); this asserts no advance happens.
+        #[tokio::test(start_paused = true)]
+        async fn equal_nonzero_range_is_no_range_and_never_advances() {
+            let shared = make_shared_data_for_tests();
+            let ch = channel();
+            assert_eq!(shared.committed_relay_offset(ch), 0);
+            // start == end == 64 (nonzero, degenerate) → NoRange.
+            assert!(matches!(
+                BridgeDeliveryLease::acquire(&shared, ch, turn(60), 64, Some(64)),
+                BridgeLeaseAcquire::NoRange
+            ));
+            // No lease was held, so there is nothing to commit/advance. The offset
+            // MUST remain at its prior value (B6: no advance outside a lease commit).
+            assert_eq!(
+                shared.committed_relay_offset(ch),
+                0,
+                "an equal nonzero range must NOT advance confirmed_end (codex P1-b / B6)"
+            );
+            assert!(matches!(
+                shared.delivery_lease(ch).read(),
+                LeaseSnapshot::Unleased
+            ));
+        }
+
+        // #3041 P1-2 (codex P1-c): when the bridge B2-skips (the watcher holds the
+        // live lease), the skip must be a NO-OP on completion side-effects — the
+        // bridge must NOT advance and the watcher (the live holder) retains exclusive
+        // ownership of the range. If the holder later commits NotDelivered (it did
+        // NOT actually deliver), a SUBSEQUENT acquirer can still take the range and
+        // deliver — i.e. the skip never black-holes the delivery.
+        // #3041 P1-2 (codex P1-c): the silent-turn commit decision. A Skip must NOT
+        // mark `terminal_delivery_committed` (the holder owns delivery; stay
+        // retry-able); Held/NoRange DO mark it.
+        #[test]
+        fn silent_turn_skip_does_not_mark_committed() {
+            use super::super::silent_turn_skip_marks_committed;
+            assert!(
+                !silent_turn_skip_marks_committed(&BridgeLeaseAcquire::Skip),
+                "a B2-skip must leave the turn uncommitted so retry remains possible (codex P1-c)"
+            );
+            assert!(silent_turn_skip_marks_committed(
+                &BridgeLeaseAcquire::NoRange
+            ));
+            // `Held` carries a lease we cannot cheaply construct here; the match in
+            // `silent_turn_skip_marks_committed` returns `true` for every non-Skip
+            // variant (verified for `NoRange` above and exercised for `Held` by the
+            // lease-level tests that drive the real site).
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn bridge_skip_leaves_range_deliverable_after_holder_not_delivered() {
+            let shared = make_shared_data_for_tests();
+            let ch = channel();
+            // Watcher holds the live lease.
+            let cell = shared.delivery_lease(ch);
+            let watcher = LeaseHolder::Watcher { instance_id: 77 };
+            assert!(cell.try_acquire(
+                turn(80),
+                watcher,
+                0,
+                64,
+                lease_now_ms().saturating_add(DELIVERY_LEASE_DEADLINE_MS),
+            ));
+            // Bridge B2-skips and does NOT advance.
+            assert!(matches!(
+                BridgeDeliveryLease::acquire(&shared, ch, turn(80), 0, Some(64)),
+                BridgeLeaseAcquire::Skip
+            ));
+            assert_eq!(
+                shared.committed_relay_offset(ch),
+                0,
+                "a B2-skip must not advance — the holder owns delivery"
+            );
+
+            // The holder later commits NotDelivered (it did NOT deliver) and releases.
+            assert!(cell.commit(watcher, turn(80), 0, 64, LeaseOutcome::NotDelivered));
+            assert_eq!(
+                shared.committed_relay_offset(ch),
+                0,
+                "NotDelivered must not advance — the range is still undelivered"
+            );
+            assert!(cell.release(watcher, turn(80), 0, 64));
+
+            // Because the skip was a no-op (offset still 0, cell released), a
+            // subsequent acquirer (the bridge or a later watcher pass) can STILL take
+            // the range and deliver it — the skip never black-holed the delivery.
+            let retry = match BridgeDeliveryLease::acquire(&shared, ch, turn(80), 0, Some(64)) {
+                BridgeLeaseAcquire::Held(lease) => lease,
+                _ => panic!("range must be re-acquirable after the holder released NotDelivered"),
+            };
+            assert!(retry.commit_and_advance(&shared, ch, None, LeaseOutcome::Delivered));
+            assert_eq!(
+                shared.committed_relay_offset(ch),
+                64,
+                "the retry delivers the previously-skipped range (no black-hole)"
             );
         }
 

--- a/src/services/discord/turn_bridge/terminal_delivery.rs
+++ b/src/services/discord/turn_bridge/terminal_delivery.rs
@@ -341,6 +341,30 @@ pub(super) fn bridge_epilogue_clears_inflight(
     !cancelled_with_restart_mode && !preserve_inflight_for_cleanup_retry && !bridge_output_delegated
 }
 
+/// #3041 P1-2 (codex P1-2 R3): the cleanup-epilogue save-mode seam. On a
+/// delivery-lease `Skip` the live HOLDER (the watcher) — a different actor
+/// sharing the same per-channel `DeliveryLeaseCell` — owns this turn's delivery
+/// AND its inflight lifecycle (the holder CLEARS inflight on its own success).
+/// If the bridge's epilogue blindly re-`save_inflight_state`s after the holder
+/// cleared the row, it resurrects a STALE inflight for an already-delivered turn
+/// (recovery sees it delivered → returns WITHOUT clearing → permanent leak).
+///
+/// This predicate gates the epilogue's `~9168` preserve-save: when the preserve
+/// is due to a Skip (`bridge_skip_holder_owns_inflight`), the save MUST be
+/// identity-guarded (`save_inflight_state_if_matches_identity`) so a
+/// holder-cleared / newer-turn row no-ops instead of resurrecting. Every other
+/// preserve site (bridge-owned cleanup retry: EditFailed, PG-cancel-fail,
+/// replace-not-committed, send/enqueue failure, TUI quiescence timeout) and the
+/// delegated-owner path have NO competing holder, so the blind save stays
+/// authoritative (this returns `false` → blind save). Pure so the
+/// "a Skip never resurrects a holder-cleared inflight" contract is unit-testable
+/// without driving the whole turn loop.
+pub(super) fn bridge_epilogue_skip_save_is_identity_guarded(
+    bridge_skip_holder_owns_inflight: bool,
+) -> bool {
+    bridge_skip_holder_owns_inflight
+}
+
 /// `~8422`: the bridge signs the watcher off as already-delivered ONLY when not
 /// preserving for retry and not delegating relay to the watcher. A preserved turn
 /// must NOT mark the watcher delivered.
@@ -482,8 +506,8 @@ impl Drop for BridgeDeliveryLease {
 mod tests {
     use super::{
         bridge_epilogue_clears_inflight, bridge_epilogue_marks_watcher_delivered,
-        replace_outcome_commits_terminal_delivery, send_ordered_long_terminal_chunks,
-        should_complete_work_dispatch_after_terminal_delivery,
+        bridge_epilogue_skip_save_is_identity_guarded, replace_outcome_commits_terminal_delivery,
+        send_ordered_long_terminal_chunks, should_complete_work_dispatch_after_terminal_delivery,
         should_fail_dispatch_after_terminal_delivery, terminal_delivery_should_send_new_chunks,
         tui_quiescence_timeout_requires_inflight_retry,
     };
@@ -720,6 +744,27 @@ mod tests {
         assert!(
             !bridge_epilogue_marks_watcher_delivered(true, false),
             "a preserved (skipped) turn must NOT mark the watcher delivered"
+        );
+    }
+
+    // #3041 P1-2 (codex P1-2 R3): the epilogue preserve-save MUST be
+    // identity-guarded ONLY on a Skip (the holder owns the inflight lifecycle and
+    // may have cleared the row on success). Bridge-owned preserve sites and the
+    // delegated-owner path keep the blind save (no competing holder).
+    #[test]
+    fn bridge_skip_save_is_identity_guarded_only_when_holder_owns_inflight() {
+        // Skip → holder (watcher) owns inflight → the save MUST be identity-guarded
+        // so a holder-cleared row is never resurrected.
+        assert!(
+            bridge_epilogue_skip_save_is_identity_guarded(true),
+            "on a Skip the holder owns the inflight lifecycle; the epilogue save must be identity-guarded so it never resurrects a holder-cleared row"
+        );
+        // Bridge-owned preserve (EditFailed / PG-cancel-fail / send-fail / TUI
+        // timeout) or delegated-owner → no competing holder → the blind save stays
+        // authoritative.
+        assert!(
+            !bridge_epilogue_skip_save_is_identity_guarded(false),
+            "bridge-owned preserve and delegated paths have no competing holder; the blind epilogue save stays authoritative"
         );
     }
 


### PR DESCRIPTION
## P1-2: route the BRIDGE's terminal delivery through the shared delivery-lease

Mirrors P1-1 (watcher) for the BRIDGE. The bridge now acquires the SAME
per-channel `DeliveryLeaseCell` (`TmuxRelayCoord::delivery_lease`) before
delivering and commits (advancing `confirmed_end_offset`) after. Because the
watcher and the bridge share one cell per channel, they are SERIALIZED — whoever
holds the live lease blocks the other's acquire (cross-actor duplicate
prevention). **B6**: after P1-2 no `confirmed_end_offset` advance happens outside
a successful lease commit on the bridge path.

### The 5 advance sites — mapped & routed
All 5 share the bridge's authoritative `TurnKey::new(channel_id,
inflight_state.user_msg_id, current_generation)` (the same identity the bridge
`register_start`s into the finalizer ledger, and which the watcher's
`pinned_finalize_user_msg_id` resolves to) and the range `[turn_start_offset,
tmux_last_offset)`.

| # | scenario | routing | B6 |
|---|----------|---------|----|
| 1 (cancel/stop `[Stopped]` replace) | genuine terminal delivery | acquire->replace->commit(Delivered if committed else NotDelivered)->advance-on-Delivered->release; **B2-skip** on contention | advance only via commit |
| 2 (prompt-too-long replace) | genuine terminal delivery | same as site 1 | advance only via commit |
| 3 (silent_turn suppression) | **no Discord post**, but offset MUST advance to mark the range consumed (not re-delivered by recovery) | acquire->commit(**Delivered**)->advance->release; B2-skip if another holder owns it | advance only via commit |
| 4 (long chunked `send_ordered_long_terminal_response`) | genuine terminal delivery, **can exceed 15s** | acquire(+heartbeat)->chunked send->commit(Delivered on Ok / NotDelivered on Err)->advance-on-Delivered->release; B2-skip on contention | advance only via commit |
| 5 (normal `replace_message_with_outcome`) | genuine terminal delivery | acquire->replace->commit-gated advance->release; B2-skip on contention | advance only via commit |

**NoRange exemption** (the only remaining direct advance): when the range is
zero/inverted or there is no tmux session, `BridgeDeliveryLease::acquire` returns
`NoRange` and the caller keeps the pre-P1-2 direct `advance_tmux_relay_confirmed_end`
call. This is B6-safe **because that call never advances the offset for a
zero/None range** (the committer early-returns on `end == 0` / `end <= current`).

### Wiring (file:line)
- `BridgeDeliveryLease` guard + `BridgeLeaseAcquire` enum: `src/services/discord/turn_bridge/terminal_delivery.rs` (acquire / commit_and_advance / Drop release).
- Shared `DeliveryLeaseHeartbeat` + `DELIVERY_LEASE_DEADLINE_MS` (15s) / `DELIVERY_LEASE_HEARTBEAT_MS` (5s): moved into `src/services/discord/mod.rs` (re-exported into the watcher under its existing `WATCHER_DELIVERY_LEASE_*` aliases — no watcher behavior change).
- 5 sites wired in `src/services/discord/turn_bridge/mod.rs`.

### Heartbeat decision
**Kept.** Site 4 (chunked `send_long_message_with_rollback` with per-chunk
pacing) can run past the 15s deadline, so its in-flight lease is renewed every 5s
by the heartbeat. The fast replace/silent paths spawn-then-immediately-stop the
heartbeat at commit (cheap, uniform).

### watcher<->bridge serialization & no-deadlock
- Same cell: both use `shared.delivery_lease(channel)` -> `TmuxRelayCoord::delivery_lease`.
- When the bridge holds the lease the watcher's `try_acquire` loses (single-winner CAS) and B2-skips; when the watcher holds, the bridge `acquire` returns `Skip`. Tests assert both directions.
- The bridge `release` (and the Drop safety-net release) return the cell to `Unleased` so the OTHER actor / next turn can acquire.
- No deadlock: every cell op is a synchronous non-blocking mutex op that never awaits or calls into the other actor; the heartbeat is its own task, renews only our own lease, and is `stop()`ped before commit.

### Tests (gated clock, all green)
`bridge_delivery_lease` matrix in terminal_delivery.rs: Delivered advances once
via commit; bridge B2-skip when watcher holds (+ converse watcher-skip);
Unknown/NotDelivered -> no advance; release lets the next turn acquire;
no double-advance on same-range re-commit; empty/zero range -> NoRange.

### Verification (macOS local, all passed)
- `cargo fmt --check`: clean
- `cargo build --all-targets`: ok
- `cargo clippy --workspace --all-targets --all-features`: no NEW warnings (none in touched files)
- turn_finalizer:: -> 50 passed / 0 failed
- delivery_lease -> 35 passed / 0 failed (incl. 8 new bridge matrix tests)
- bridge -> 142 passed / 0 failed
- relay -> 199 passed / 0 failed
- offset -> 50 passed / 0 failed
- transition -> 3 / 0; cancel -> 94 / 0
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py`: pass (registered `terminal_delivery.rs` as a giant-file `[[entry]]`; synced the `tmux_watcher.rs` freeze line — it shrank after the heartbeat move)

### Windows safety
New bridge code references only cross-platform items (`DeliveryLeaseCell` /
`DeliveryLeaseHeartbeat` / `LeaseHolder` / `LeaseOutcome` and the already
cross-platform `advance_tmux_relay_confirmed_end`). No `#[cfg(unix)] mod tmux`
refs added.

### Out of scope (untouched)
Sink committer, 10s blind re-send (P1-3), Err-leak RAII (P1-4), #3141 finalize
guards, #3143 dedup, and P1-1's watcher lease behavior — all intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)