### PR TITLE
feat(#3041): P1-3 sink advances offset (close B1) + replace watcher blind re-send with committed-offset reconciliation (§3.2)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -128,7 +128,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (8592 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (8680 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -194,6 +194,15 @@
     `FrameAccepted` (never a terminal outcome) so turn B's tail post can never mask
     turn A's terminal-ACK (multi-RESULT-per-chunk per-turn fence deferred to #3151,
     no black-hole);
+    +R6 (PR #3150) codex P1-3 R6: TURN-SCOPE the carried session-bound
+    `ack_target` (`SessionBoundRelayAckTarget` now stamps the terminal frame's
+    pinned `turn_start_offset`; `carry_session_bound_ack_for_turn` resets a stored
+    ack to `None` on a turn boundary instead of the legacy "store only when Some").
+    A single chunk holding `result(A)+result(B)` where B completes inside the split
+    tail (its frame sequence discarded) no longer lets B inherit A's stale ack: B's
+    pass sees a different pinned turn identity → ack reset to `None` → B reconciles
+    against `committed_relay_offset` (None → MissingTarget → §3.2 SendFull/Skip),
+    NEVER black-holed even when A reported Delivered;
     split loop helpers further before adding behavior).
   - `src/services/discord/tui_prompt_relay.rs` (3874 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -128,7 +128,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (8549 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (8572 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -186,6 +186,14 @@
     carries ONLY the just-completed turn's bytes, a trailing later-turn tail rides a
     separate non-terminal frame so it is never black-holed), and the
     `WatcherTerminalResendAction::SendFull` slow-sink-in-flight deferral doc (#3151);
+    +R4 (PR #3150) codex P1-3 R4: STRICT frame `turn_start_offset` identity gate
+    (no weak `is_none_or` None fallback) with the producer guarantee that
+    `watcher_terminal_commit_fence` only emits a fence when the turn's
+    `turn_start_offset` is known (else a non-terminal frame + watcher SendFull),
+    plus the issue-1 ACK-correlation close: a fence-less frame reports
+    `FrameAccepted` (never a terminal outcome) so turn B's tail post can never mask
+    turn A's terminal-ACK (multi-RESULT-per-chunk per-turn fence deferred to #3151,
+    no black-hole);
     split loop helpers further before adding behavior).
   - `src/services/discord/tui_prompt_relay.rs` (3874 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -128,7 +128,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (8428 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (8549 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -180,6 +180,12 @@
     data), the sink advances `confirmed_end_offset` identity-gated on its CONFIRMED
     POST (`advance_offset_for_confirmed_delegated_terminal`), and the RACY
     inflight-persist Part a (`session_bound_delegated_terminal_end`) is REMOVED;
+    +21 from #3041 P1-3 codex review (PR #3150) fixes: issue-1 multi-turn-chunk
+    split (`split_decoded_chunk_at_terminal_boundary` +
+    `forward_terminal_chunk_with_trailing_to_supervisor_relay` — the TERMINAL frame
+    carries ONLY the just-completed turn's bytes, a trailing later-turn tail rides a
+    separate non-terminal frame so it is never black-holed), and the
+    `WatcherTerminalResendAction::SendFull` slow-sink-in-flight deferral doc (#3151);
     split loop helpers further before adding behavior).
   - `src/services/discord/tui_prompt_relay.rs` (3874 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -128,7 +128,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (8353 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (8428 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -171,10 +171,15 @@
     (skip-already-committed / send-suffix / send-full against
     `committed_relay_offset`), a dedicated `SkipAlreadyCommitted` relay arm that
     treats an already-committed range as a completed delegated delivery (no
-    duplicate, no placeholder double-handling), the watcher persisting its
-    authoritative consumed-terminal end (`session_bound_delegated_terminal_end`)
-    when it delegates so the sink can advance the offset (Part a, B1 close), and the
-    suffix-trim wiring; the ACK polling itself is preserved;
+    duplicate, no placeholder double-handling), and the suffix-trim wiring; the ACK
+    polling itself is preserved;
+    +75 from #3041 P1-3 Part a (frame-carried B1 commit fence): the RESULT-bearing
+    `StreamFrame` now carries `terminal_consumed_end` + the pinned turn identity
+    (`watcher_terminal_commit_fence`; deferred forward at both read sites so the
+    terminal frame is detected post-`process_watcher_lines` and rides the commit
+    data), the sink advances `confirmed_end_offset` identity-gated on its CONFIRMED
+    POST (`advance_offset_for_confirmed_delegated_terminal`), and the RACY
+    inflight-persist Part a (`session_bound_delegated_terminal_end`) is REMOVED;
     split loop helpers further before adding behavior).
   - `src/services/discord/tui_prompt_relay.rs` (3874 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -128,7 +128,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (8572 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (8592 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -128,7 +128,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (8102 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (8266 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -166,6 +166,15 @@
     every 5s while the send future is in flight (deadline cut to 15s for fast
     dead-holder recovery), stopped before the inline commit so a long multi-chunk
     send is never reclaimed mid-flight;
+    +164 from #3041 P1-3 Part b: REPLACING the 10s blind terminal re-send with the
+    §3.2 committed-offset reconciliation — `watcher_terminal_resend_action`
+    (skip-already-committed / send-suffix / send-full against
+    `committed_relay_offset`), a dedicated `SkipAlreadyCommitted` relay arm that
+    treats an already-committed range as a completed delegated delivery (no
+    duplicate, no placeholder double-handling), the watcher persisting its
+    authoritative consumed-terminal end (`session_bound_delegated_terminal_end`)
+    when it delegates so the sink can advance the offset (Part a, B1 close), and the
+    suffix-trim wiring; the ACK polling itself is preserved;
     split loop helpers further before adding behavior).
   - `src/services/discord/tui_prompt_relay.rs` (3874 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -128,7 +128,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (8680 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (8739 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -203,6 +203,19 @@
     pass sees a different pinned turn identity → ack reset to `None` → B reconciles
     against `committed_relay_offset` (None → MissingTarget → §3.2 SendFull/Skip),
     NEVER black-holed even when A reported Delivered;
+    +59 from R7 (PR #3150) codex P1-3 R7: TURN-BOUNDARY ack reset at the split.
+    R6's `carry_session_bound_ack_for_turn` STILL black-holes a later turn when
+    `turn_identity_for_panel` is NOT refreshed (B's inflight not yet established when
+    B's leftover bytes are processed → the pinned offset is STILL A's → the carry
+    helper KEEPS A's ack). `SupervisorRelayForward` now carries a `trailing_turn_follows`
+    signal set by `forward_terminal_chunk_with_trailing_to_supervisor_relay` whenever it
+    splits a result-bearing chunk with a non-empty trailing tail (a later turn follows).
+    A pass-scoped `split_trailing_turn_follows` latch ORs that over both forward sites;
+    AFTER this turn waits on (consumes) its own terminal ACK — right after the relay
+    flight-recorder log — the watcher resets `all_data_session_bound_relay_ack` to `None`.
+    So a later turn ALWAYS starts with no inherited ack → MissingTarget → §3.2 reconcile
+    (SendFull/Skip) → never black-holed, independent of whether the pinned identity
+    refreshed. A's own delivery still resolves on A's ack (the reset is post-wait);
     split loop helpers further before adding behavior).
   - `src/services/discord/tui_prompt_relay.rs` (3874 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -128,7 +128,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (8266 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (8353 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable

--- a/src/services/cluster/registry_adapter_sink.rs
+++ b/src/services/cluster/registry_adapter_sink.rs
@@ -142,6 +142,7 @@ mod tests {
             terminal_consumed_end: None,
             turn_user_msg_id: 0,
             turn_started_at: String::new(),
+            turn_start_offset: None,
         };
         sink.deliver(&frame).await.expect("infallible");
         sink.deliver(&frame).await.expect("infallible");

--- a/src/services/cluster/registry_adapter_sink.rs
+++ b/src/services/cluster/registry_adapter_sink.rs
@@ -139,6 +139,9 @@ mod tests {
             binding: m.clone(),
             payload: "{}".into(),
             sequence: 7,
+            terminal_consumed_end: None,
+            turn_user_msg_id: 0,
+            turn_started_at: String::new(),
         };
         sink.deliver(&frame).await.expect("infallible");
         sink.deliver(&frame).await.expect("infallible");

--- a/src/services/cluster/stream_relay.rs
+++ b/src/services/cluster/stream_relay.rs
@@ -103,6 +103,16 @@ pub struct StreamFrame {
     /// (external-input turns share `user_msg_id == 0`, so `started_at`
     /// distinguishes consecutive TUI-direct turns). Empty on non-terminal frames.
     pub turn_started_at: String,
+    /// #3041 P1-3 (codex P1-3 issue 2 — identity collision close): the pinned
+    /// inflight's `turn_start_offset` (the JSONL byte offset at which THIS turn
+    /// began). `now_string` has 1-second resolution, so two back-to-back
+    /// TUI-direct turns with `user_msg_id == 0` started in the SAME second share
+    /// an identical `(0, started_at)` pair — a delayed OLD terminal frame would
+    /// then pass the sink's identity gate for the NEW turn and wrongly advance.
+    /// `turn_start_offset` is monotonic per turn (the next turn always begins at a
+    /// strictly larger byte offset), so adding it to the IDENTITY GATE makes the
+    /// frame identity UNIQUE per turn. `None` on non-terminal frames.
+    pub turn_start_offset: Option<u64>,
 }
 
 /// Per-session counters. Exposed via the supervisor for diagnostics.
@@ -496,6 +506,10 @@ pub struct TerminalCommitFence {
     pub consumed_end: u64,
     pub turn_user_msg_id: u64,
     pub turn_started_at: String,
+    /// #3041 P1-3 (codex P1-3 issue 2): the turn's `turn_start_offset` — added to
+    /// the sink's identity gate so two consecutive `user_msg_id == 0` turns started
+    /// in the same `now_string` second (identical `started_at`) cannot collide.
+    pub turn_start_offset: Option<u64>,
 }
 
 fn try_send_frame_inner(
@@ -511,14 +525,16 @@ fn try_send_frame_inner(
         return RelaySendOutcome::closed();
     }
     let seq = sequence.fetch_add(1, Ordering::AcqRel);
-    let (terminal_consumed_end, turn_user_msg_id, turn_started_at) = match terminal {
-        Some(fence) => (
-            Some(fence.consumed_end),
-            fence.turn_user_msg_id,
-            fence.turn_started_at,
-        ),
-        None => (None, 0, String::new()),
-    };
+    let (terminal_consumed_end, turn_user_msg_id, turn_started_at, turn_start_offset) =
+        match terminal {
+            Some(fence) => (
+                Some(fence.consumed_end),
+                fence.turn_user_msg_id,
+                fence.turn_started_at,
+                fence.turn_start_offset,
+            ),
+            None => (None, 0, String::new(), None),
+        };
     let frame = StreamFrame {
         session_name: matched.expected_session_name.clone(),
         binding: matched.clone(),
@@ -527,6 +543,7 @@ fn try_send_frame_inner(
         terminal_consumed_end,
         turn_user_msg_id,
         turn_started_at,
+        turn_start_offset,
     };
     metrics.frames_received.fetch_add(1, Ordering::AcqRel);
     match queue.push_drop_oldest(frame) {
@@ -946,6 +963,7 @@ mod tests {
                 consumed_end: 512,
                 turn_user_msg_id: 77,
                 turn_started_at: "2026-06-04T00:00:00Z".to_string(),
+                turn_start_offset: Some(64),
             },
         );
         assert!(outcome.is_alive());
@@ -959,12 +977,14 @@ mod tests {
         assert_eq!(delivered[0].terminal_consumed_end, None);
         assert_eq!(delivered[0].turn_user_msg_id, 0);
         assert_eq!(delivered[0].turn_started_at, "");
+        assert_eq!(delivered[0].turn_start_offset, None);
 
         // Terminal frame carries the consumed_end + pinned identity.
         assert_eq!(delivered[1].payload, "result-bearing");
         assert_eq!(delivered[1].terminal_consumed_end, Some(512));
         assert_eq!(delivered[1].turn_user_msg_id, 77);
         assert_eq!(delivered[1].turn_started_at, "2026-06-04T00:00:00Z");
+        assert_eq!(delivered[1].turn_start_offset, Some(64));
 
         handle.shutdown().await;
     }

--- a/src/services/cluster/stream_relay.rs
+++ b/src/services/cluster/stream_relay.rs
@@ -82,6 +82,27 @@ pub struct StreamFrame {
     /// Monotonic sequence number assigned by the relay. Useful for sinks that
     /// want to detect drops / reorder.
     pub sequence: u64,
+    /// #3041 P1-3 (Part a, B1 — frame-carried commit fence): for the
+    /// RESULT-bearing (terminal) frame ONLY, the producer's AUTHORITATIVE
+    /// consumed-terminal END offset (`terminal_event_consumed_offset(..)`) for
+    /// the turn it is delegating to this sink. `None` on every non-terminal
+    /// frame. The sink CANNOT derive this from the opaque payload, so it rides
+    /// the frame and the sink advances `confirmed_end_offset` to it on a
+    /// CONFIRMED terminal Discord delivery — identity-gated against the channel's
+    /// current inflight so a delayed/wrong-turn frame can never advance.
+    pub terminal_consumed_end: Option<u64>,
+    /// #3041 P1-3 (Part a, B1): turn identity of the inflight the producer
+    /// pinned when it forwarded the terminal frame (`user_msg_id`). Paired with
+    /// `turn_started_at` it is the IDENTITY GATE: the sink advances the offset
+    /// only when this still matches the channel's current inflight identity.
+    /// `0` / empty on non-terminal frames (carries no commit data). Kept as
+    /// minimal scalars (NOT the discord-side `InflightTurnIdentity`) so the
+    /// cluster layer stays free of discord imports.
+    pub turn_user_msg_id: u64,
+    /// #3041 P1-3 (Part a, B1): the pinned inflight's `started_at` discriminator
+    /// (external-input turns share `user_msg_id == 0`, so `started_at`
+    /// distinguishes consecutive TUI-direct turns). Empty on non-terminal frames.
+    pub turn_started_at: String,
 }
 
 /// Per-session counters. Exposed via the supervisor for diagnostics.
@@ -332,6 +353,28 @@ impl RelayProducer {
             &self.metrics,
             &self.sequence,
             payload,
+            None,
+        )
+    }
+
+    /// #3041 P1-3 (Part a, B1): forward the RESULT-bearing chunk as a terminal
+    /// frame carrying the commit fence (`terminal.consumed_end` + the pinned turn
+    /// identity). The frame both triggers the sink's terminal delivery AND is the
+    /// unit the sink consumes, so the commit data MUST ride on it (a separate
+    /// later frame would arrive after the FIFO sink already dispatched delivery).
+    pub fn try_send_terminal_frame_with_sequence(
+        &self,
+        payload: String,
+        terminal: TerminalCommitFence,
+    ) -> RelaySendOutcome {
+        try_send_frame_inner(
+            &self.matched,
+            &self.queue,
+            &self.shutdown,
+            &self.metrics,
+            &self.sequence,
+            payload,
+            Some(terminal),
         )
     }
 }
@@ -443,6 +486,18 @@ impl RelayFrameQueue {
     }
 }
 
+/// #3041 P1-3 (Part a, B1): the commit-fence data the producer rides on the
+/// RESULT-bearing frame. The watcher computes the authoritative consumed-terminal
+/// `end` and pins the delegating turn's identity (from the inflight loaded BEFORE
+/// the relay, matching #3141 pinned-id semantics) so the sink can advance the
+/// offset authority identity-gated on a confirmed delivery.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TerminalCommitFence {
+    pub consumed_end: u64,
+    pub turn_user_msg_id: u64,
+    pub turn_started_at: String,
+}
+
 fn try_send_frame_inner(
     matched: &MatchedChannel,
     queue: &Arc<RelayFrameQueue>,
@@ -450,16 +505,28 @@ fn try_send_frame_inner(
     metrics: &Arc<RelayMetrics>,
     sequence: &Arc<AtomicU64>,
     payload: String,
+    terminal: Option<TerminalCommitFence>,
 ) -> RelaySendOutcome {
     if shutdown.load(Ordering::Acquire) {
         return RelaySendOutcome::closed();
     }
     let seq = sequence.fetch_add(1, Ordering::AcqRel);
+    let (terminal_consumed_end, turn_user_msg_id, turn_started_at) = match terminal {
+        Some(fence) => (
+            Some(fence.consumed_end),
+            fence.turn_user_msg_id,
+            fence.turn_started_at,
+        ),
+        None => (None, 0, String::new()),
+    };
     let frame = StreamFrame {
         session_name: matched.expected_session_name.clone(),
         binding: matched.clone(),
         payload,
         sequence: seq,
+        terminal_consumed_end,
+        turn_user_msg_id,
+        turn_started_at,
     };
     metrics.frames_received.fetch_add(1, Ordering::AcqRel);
     match queue.push_drop_oldest(frame) {
@@ -516,6 +583,7 @@ impl StreamRelayHandle {
             &self.metrics,
             &self.sequence,
             payload,
+            None,
         )
     }
 
@@ -857,6 +925,47 @@ mod tests {
         }
         assert_eq!(handle.metrics().snapshot().frames_delivered, 5);
         assert_eq!(handle.metrics().snapshot().dropped_frames, 0);
+        handle.shutdown().await;
+    }
+
+    // #3041 P1-3 (Part a, B1): the terminal frame carries the commit fence
+    // (`terminal_consumed_end` + turn identity); non-terminal frames carry None/0/"".
+    #[tokio::test]
+    async fn terminal_frame_carries_consumed_end_and_turn_identity() {
+        let sink = Arc::new(CapturingSink::default());
+        let handle = spawn_stream_relay(matched_for("c-fence"), sink.clone());
+
+        // A normal (non-terminal) frame: no commit fence.
+        assert!(handle.try_send_frame("non-terminal".into()));
+        // The producer-side terminal send (the watcher uses the RelayProducer
+        // clone; the handle exposes the same path for tests).
+        let producer = handle.producer();
+        let outcome = producer.try_send_terminal_frame_with_sequence(
+            "result-bearing".into(),
+            TerminalCommitFence {
+                consumed_end: 512,
+                turn_user_msg_id: 77,
+                turn_started_at: "2026-06-04T00:00:00Z".to_string(),
+            },
+        );
+        assert!(outcome.is_alive());
+
+        flush_pending().await;
+        let delivered = sink.delivered();
+        assert_eq!(delivered.len(), 2);
+
+        // Non-terminal frame carries no fence.
+        assert_eq!(delivered[0].payload, "non-terminal");
+        assert_eq!(delivered[0].terminal_consumed_end, None);
+        assert_eq!(delivered[0].turn_user_msg_id, 0);
+        assert_eq!(delivered[0].turn_started_at, "");
+
+        // Terminal frame carries the consumed_end + pinned identity.
+        assert_eq!(delivered[1].payload, "result-bearing");
+        assert_eq!(delivered[1].terminal_consumed_end, Some(512));
+        assert_eq!(delivered[1].turn_user_msg_id, 77);
+        assert_eq!(delivered[1].turn_started_at, "2026-06-04T00:00:00Z");
+
         handle.shutdown().await;
     }
 

--- a/src/services/cluster/stream_relay.rs
+++ b/src/services/cluster/stream_relay.rs
@@ -61,6 +61,28 @@ use super::session_matcher::MatchedChannel;
 /// [`RelayMetrics::dropped_frames`] when full.
 pub const DEFAULT_RELAY_BUFFER: usize = 1024;
 
+/// #3041 P1-3 R5 (per-sequence terminal-ACK correlation): how many recent
+/// terminal sequences' resolved outcomes the relay retains for exact-sequence
+/// ACK lookup. The watcher waits ~10s for its terminal frame's own outcome, so
+/// only the most recent handful of terminal sequences can ever be queried; we
+/// keep a small bounded ring so a busy session cannot grow this without bound.
+/// Older entries are evicted FIFO — an evicted sequence reads back as `None`
+/// (treated by the watcher as "not yet resolved" → it keeps waiting / eventually
+/// times out → reconciles, never a false ACK).
+pub const TERMINAL_OUTCOME_RING_CAPACITY: usize = 64;
+
+/// #3041 P1-3 R5: the EXACT, per-frame terminal resolution recorded by the sink
+/// for a single terminal (result-bearing) frame's sequence. Distinct from the
+/// high-water-mark fields (`last_terminal_committed/skipped_sequence`), which a
+/// LATER, higher-sequence terminal can bump — this is keyed to ONE sequence so a
+/// watcher resolves its ACK on ITS OWN terminal frame's outcome, decoupled from
+/// any other turn sharing the same physical chunk.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TerminalOutcome {
+    Committed,
+    Skipped,
+}
+
 /// An opaque stream frame emitted by a provider. Carries enough metadata for
 /// the sink to route + format without re-reading the rollout file.
 ///
@@ -129,6 +151,13 @@ pub struct RelayMetrics {
     last_terminal_skipped_sequence_plus_one: AtomicU64,
     last_dropped_sequence_plus_one: AtomicU64,
     last_sink_error_sequence_plus_one: AtomicU64,
+    /// #3041 P1-3 R5: bounded ring of recently-resolved per-sequence terminal
+    /// outcomes. ADDITIVE to the high-water-mark fields above (which other
+    /// consumers — drop/diagnostics/tests — still read). Queried by the watcher
+    /// for the EXACT `target.sequence` so B's tail committing at seq N+1 never
+    /// satisfies A's ACK at seq N. Bounded FIFO (`TERMINAL_OUTCOME_RING_CAPACITY`):
+    /// an evicted/never-recorded sequence reads back `None`.
+    terminal_outcomes: Mutex<VecDeque<(u64, TerminalOutcome)>>,
 }
 
 impl RelayMetrics {
@@ -162,6 +191,42 @@ impl RelayMetrics {
         }
     }
 
+    /// #3041 P1-3 R5: record THIS terminal frame's resolved outcome keyed by its
+    /// exact sequence, in a bounded FIFO ring. Called from `deliver_frame` for a
+    /// result-bearing terminal delivery (Committed/Skipped). Idempotent-ish: a
+    /// re-record of the same sequence overwrites the prior entry in place (a
+    /// sequence is delivered once, but this keeps the ring free of duplicates).
+    fn record_terminal_outcome(&self, sequence: u64, outcome: TerminalOutcome) {
+        let mut ring = self
+            .terminal_outcomes
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        if let Some(existing) = ring.iter_mut().find(|(seq, _)| *seq == sequence) {
+            existing.1 = outcome;
+            return;
+        }
+        ring.push_back((sequence, outcome));
+        while ring.len() > TERMINAL_OUTCOME_RING_CAPACITY {
+            ring.pop_front();
+        }
+    }
+
+    /// #3041 P1-3 R5: the EXACT-sequence terminal-ACK query. Returns this
+    /// sequence's recorded outcome, or `None` if it was never terminally
+    /// resolved on this frame (non-terminal / dropped / evicted from the ring).
+    /// The watcher resolves its ACK on its OWN terminal frame's sequence via this
+    /// — NOT the `>=` high-water-mark — so a co-chunked higher-sequence terminal
+    /// can never satisfy it.
+    pub fn terminal_outcome_for_sequence(&self, sequence: u64) -> Option<TerminalOutcome> {
+        let ring = self
+            .terminal_outcomes
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        ring.iter()
+            .find(|(seq, _)| *seq == sequence)
+            .map(|(_, outcome)| *outcome)
+    }
+
     #[cfg(test)]
     pub(crate) fn record_delivered_sequence_for_test(&self, sequence: u64) {
         self.last_delivered_sequence_plus_one
@@ -172,12 +237,14 @@ impl RelayMetrics {
     pub(crate) fn record_terminal_committed_sequence_for_test(&self, sequence: u64) {
         self.last_terminal_committed_sequence_plus_one
             .fetch_max(encode_sequence_marker(sequence), Ordering::AcqRel);
+        self.record_terminal_outcome(sequence, TerminalOutcome::Committed);
     }
 
     #[cfg(test)]
     pub(crate) fn record_terminal_skipped_sequence_for_test(&self, sequence: u64) {
         self.last_terminal_skipped_sequence_plus_one
             .fetch_max(encode_sequence_marker(sequence), Ordering::AcqRel);
+        self.record_terminal_outcome(sequence, TerminalOutcome::Skipped);
     }
 
     #[cfg(test)]
@@ -807,12 +874,18 @@ async fn deliver_frame(
                 metrics
                     .last_terminal_committed_sequence_plus_one
                     .fetch_max(encode_sequence_marker(frame.sequence), Ordering::AcqRel);
+                // #3041 P1-3 R5: record THIS frame's exact-sequence outcome so the
+                // watcher resolves its ACK on its own terminal frame (decoupled
+                // from any co-chunked higher-sequence terminal).
+                metrics.record_terminal_outcome(frame.sequence, TerminalOutcome::Committed);
             }
             if outcome.terminal_skipped() {
                 metrics.terminal_skips.fetch_add(1, Ordering::AcqRel);
                 metrics
                     .last_terminal_skipped_sequence_plus_one
                     .fetch_max(encode_sequence_marker(frame.sequence), Ordering::AcqRel);
+                // #3041 P1-3 R5: per-sequence skip — see committed branch above.
+                metrics.record_terminal_outcome(frame.sequence, TerminalOutcome::Skipped);
             }
         }
         Err(error) => {
@@ -1071,7 +1144,72 @@ mod tests {
         assert_eq!(snap.last_delivered_sequence, Some(2));
         assert_eq!(snap.last_terminal_skipped_sequence, Some(1));
         assert_eq!(snap.last_terminal_committed_sequence, Some(2));
+
+        // #3041 P1-3 R5: per-sequence query resolves each frame's OWN exact
+        // outcome, independent of the high-water-mark. seq 1 was skipped, seq 2
+        // committed, seq 0 was a non-terminal accept (no terminal outcome).
+        let metrics = handle.metrics();
+        assert_eq!(
+            metrics.terminal_outcome_for_sequence(1),
+            Some(TerminalOutcome::Skipped)
+        );
+        assert_eq!(
+            metrics.terminal_outcome_for_sequence(2),
+            Some(TerminalOutcome::Committed)
+        );
+        assert_eq!(metrics.terminal_outcome_for_sequence(0), None);
+        // A sequence that was never terminally resolved reads None.
+        assert_eq!(metrics.terminal_outcome_for_sequence(99), None);
         handle.shutdown().await;
+    }
+
+    // #3041 P1-3 R5: the load-bearing invariant — outcome[N] is INDEPENDENT of
+    // outcome[N+1]. Turn A (seq N) SKIPPED + turn B (seq N+1) COMMITTED sharing a
+    // chunk: A's per-sequence query reads Skipped (NOT Delivered from the bumped
+    // high-water-mark), so the watcher reconciles A → no black-hole.
+    #[test]
+    fn per_sequence_terminal_outcome_is_independent_of_higher_sequences() {
+        let metrics = RelayMetrics::default();
+        // A at seq 10 was SKIPPED; B's tail at seq 11 COMMITTED (higher sequence).
+        metrics.record_terminal_outcome(10, TerminalOutcome::Skipped);
+        metrics.record_terminal_outcome(11, TerminalOutcome::Committed);
+        // High-water-mark for committed is now 11 (would falsely satisfy `>= 10`).
+        assert_eq!(
+            metrics.terminal_outcome_for_sequence(10),
+            Some(TerminalOutcome::Skipped),
+            "A's ACK must read A's OWN outcome (Skipped), not B's committed high-water-mark"
+        );
+        assert_eq!(
+            metrics.terminal_outcome_for_sequence(11),
+            Some(TerminalOutcome::Committed)
+        );
+    }
+
+    // #3041 P1-3 R5: the ring is bounded; an evicted sequence reads back None
+    // (treated by the watcher as "not yet resolved" → it waits / times out →
+    // reconciles, never a false ACK).
+    #[test]
+    fn terminal_outcome_ring_is_bounded_and_evicts_oldest() {
+        let metrics = RelayMetrics::default();
+        let total = TERMINAL_OUTCOME_RING_CAPACITY as u64 + 5;
+        for seq in 0..total {
+            metrics.record_terminal_outcome(seq, TerminalOutcome::Committed);
+        }
+        // The oldest 5 were evicted.
+        for seq in 0..5 {
+            assert_eq!(
+                metrics.terminal_outcome_for_sequence(seq),
+                None,
+                "evicted oldest sequence reads None"
+            );
+        }
+        // The most recent CAPACITY are retained.
+        for seq in 5..total {
+            assert_eq!(
+                metrics.terminal_outcome_for_sequence(seq),
+                Some(TerminalOutcome::Committed)
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -198,26 +198,6 @@ pub(super) struct InflightTurnState {
     /// (#1270). `None` for offsets persisted before this field existed.
     #[serde(default)]
     pub last_watcher_relayed_generation_mtime_ns: Option<i64>,
-    /// #3041 P1-3 (Part a, BLOCKER B1): the watcher's AUTHORITATIVE consumed
-    /// terminal-output END offset for the turn it DELEGATED to the session-bound
-    /// StreamRelay sink. Set by the watcher at the moment it delegates
-    /// (`session_bound_relay_owns_terminal_delivery`) to exactly the value the
-    /// watcher would have advanced `confirmed_end_offset` to had it delivered the
-    /// terminal itself (`terminal_event_consumed_offset(current_offset,
-    /// all_data)` == the watcher's lease `end`). The sink CANNOT derive this from
-    /// its opaque `StreamFrame` (payload + sequence only, NO JSONL byte offset),
-    /// and the only file offset it can read (the JSONL EOF) overshoots the
-    /// consumed-terminal end and would BLACK-HOLE undelivered later-appended bytes
-    /// (codex r4 P1). So the watcher — the byte-range AUTHORITY — persists its
-    /// exact consumed end here; on a CONFIRMED terminal Discord delivery the sink
-    /// advances `confirmed_end_offset` to THIS value (identity-gated, monotonic
-    /// CAS). This closes B1's "commit fence": a sink POST success now advances the
-    /// authority in the same path, so the watcher's §3.2 reconciliation (Part b)
-    /// sees `committed >= end` and SKIPS its blind re-send (no duplicate) even when
-    /// the terminal-commit ACK lagged the 10s wait. `None` until the watcher
-    /// delegates a terminal turn (and for legacy rows that pre-date this field).
-    #[serde(default)]
-    pub session_bound_delegated_terminal_end: Option<u64>,
     /// Lifecycle-aware restart/handoff mode for recovery semantics.
     #[serde(default)]
     pub restart_mode: Option<InflightRestartMode>,
@@ -602,7 +582,6 @@ impl InflightTurnState {
             dispatch_id: None,
             last_watcher_relayed_offset: None,
             last_watcher_relayed_generation_mtime_ns: None,
-            session_bound_delegated_terminal_end: None,
             restart_mode: None,
             restart_generation: None,
             rebind_origin: false,
@@ -3415,58 +3394,17 @@ mod stall_recovery_tests {
         assert!(load_inflight_states_from_root(temp.path(), &ProviderKind::Claude).is_empty());
     }
 
-    /// #3041 P1-3 (Part a, B1 — codex real-close): the watcher persists its
-    /// AUTHORITATIVE consumed-terminal END into inflight via the identity-guarded
-    /// save the watcher uses BEFORE the ACK wait. A subsequent load — exactly what
-    /// the session-bound sink's `deliver_response` does — must read a NON-None end
-    /// for THIS delivery (the ACK-lag path), so the sink can advance
-    /// `confirmed_end_offset` on its confirmed POST. The OLD code wrote this only
-    /// AFTER the ACK observed `Delivered`, i.e. AFTER the sink had already loaded
-    /// `None` → the duplicate vector stayed open. This pins the corrected ordering:
-    /// persist-before-load yields a readable end.
+    /// #3041 P1-3 (Part a, B1): the identity-guarded save must NOT let a stale write
+    /// clobber a NEWER turn that has taken over the inflight row (e.g. a fast
+    /// follow-up turn on the same channel between the watcher's compute and its
+    /// write). A mismatched identity yields `IdentityMismatch` and the newer turn's
+    /// row is preserved. (The frame-carried B1 commit fence removed the racy
+    /// delegated-terminal-end inflight persist; this keeps the generic guard covered
+    /// via a still-live field.)
     #[test]
-    fn delegated_terminal_end_is_persisted_before_sink_load_via_guarded_save() {
+    fn identity_guarded_save_rejects_stale_write_against_newer_turn() {
         let temp = TempDir::new().unwrap();
-        let mut state = build_inflight_for_guard_tests(ProviderKind::Claude, 321, 100);
-        state.turn_start_offset = Some(0);
-        // The sink has NOT yet loaded — the field starts None.
-        assert_eq!(state.session_bound_delegated_terminal_end, None);
-        save_inflight_state_in_root(temp.path(), &state).unwrap();
-
-        // Watcher's early persist (mirrors the terminal-relay block): identity-
-        // guarded save of the consumed-terminal end BEFORE the ACK wait.
-        let identity = InflightTurnIdentity::from_state(&state);
-        let mut to_persist = state.clone();
-        let delegated_end = 256u64;
-        to_persist.session_bound_delegated_terminal_end = Some(delegated_end);
-        let outcome = save_inflight_state_if_matches_identity_in_root(
-            temp.path(),
-            &to_persist,
-            &identity,
-            state.turn_start_offset,
-        );
-        assert_eq!(outcome, GuardedSaveOutcome::Saved);
-
-        // The sink's `deliver_response` load now reads a NON-None end for THIS
-        // delivery — the ACK-lag duplicate vector is closed.
-        let loaded = load_inflight_states_from_root(temp.path(), &ProviderKind::Claude);
-        assert_eq!(loaded.len(), 1);
-        assert_eq!(
-            loaded[0].session_bound_delegated_terminal_end,
-            Some(delegated_end),
-            "sink must read the delegated end persisted BEFORE its load (B1 ordering)"
-        );
-    }
-
-    /// #3041 P1-3 (Part a, B1): the identity guard must NOT let the delegated-end
-    /// persist clobber a NEWER turn that has taken over the inflight row (e.g. a
-    /// fast follow-up turn on the same channel between the watcher's compute and
-    /// its write). A mismatched identity yields `IdentityMismatch` and the newer
-    /// turn's row is preserved — no cross-turn end leakage / overshoot.
-    #[test]
-    fn delegated_terminal_end_persist_is_identity_guarded_against_newer_turn() {
-        let temp = TempDir::new().unwrap();
-        // The original turn the watcher was delegating (user_msg_id = 100).
+        // The original turn (user_msg_id = 100).
         let mut original = build_inflight_for_guard_tests(ProviderKind::Claude, 321, 100);
         original.user_msg_id = 100;
         let original_identity = InflightTurnIdentity::from_state(&original);
@@ -3476,10 +3414,10 @@ mod stall_recovery_tests {
         newer.user_msg_id = 200;
         save_inflight_state_in_root(temp.path(), &newer).unwrap();
 
-        // Watcher tries to persist the OLD turn's delegated end under the OLD
-        // identity → must be rejected, leaving the newer turn intact.
+        // Stale write under the OLD identity → must be rejected, leaving the newer
+        // turn intact.
         let mut stale_persist = original.clone();
-        stale_persist.session_bound_delegated_terminal_end = Some(256);
+        stale_persist.last_watcher_relayed_offset = Some(256);
         let outcome = save_inflight_state_if_matches_identity_in_root(
             temp.path(),
             &stale_persist,
@@ -3492,8 +3430,8 @@ mod stall_recovery_tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].user_msg_id, 200, "newer turn must be preserved");
         assert_eq!(
-            rows[0].session_bound_delegated_terminal_end, None,
-            "the newer turn must NOT inherit the old turn's delegated end"
+            rows[0].last_watcher_relayed_offset, None,
+            "the newer turn must NOT inherit the old turn's stale write"
         );
     }
 

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -198,6 +198,26 @@ pub(super) struct InflightTurnState {
     /// (#1270). `None` for offsets persisted before this field existed.
     #[serde(default)]
     pub last_watcher_relayed_generation_mtime_ns: Option<i64>,
+    /// #3041 P1-3 (Part a, BLOCKER B1): the watcher's AUTHORITATIVE consumed
+    /// terminal-output END offset for the turn it DELEGATED to the session-bound
+    /// StreamRelay sink. Set by the watcher at the moment it delegates
+    /// (`session_bound_relay_owns_terminal_delivery`) to exactly the value the
+    /// watcher would have advanced `confirmed_end_offset` to had it delivered the
+    /// terminal itself (`terminal_event_consumed_offset(current_offset,
+    /// all_data)` == the watcher's lease `end`). The sink CANNOT derive this from
+    /// its opaque `StreamFrame` (payload + sequence only, NO JSONL byte offset),
+    /// and the only file offset it can read (the JSONL EOF) overshoots the
+    /// consumed-terminal end and would BLACK-HOLE undelivered later-appended bytes
+    /// (codex r4 P1). So the watcher — the byte-range AUTHORITY — persists its
+    /// exact consumed end here; on a CONFIRMED terminal Discord delivery the sink
+    /// advances `confirmed_end_offset` to THIS value (identity-gated, monotonic
+    /// CAS). This closes B1's "commit fence": a sink POST success now advances the
+    /// authority in the same path, so the watcher's §3.2 reconciliation (Part b)
+    /// sees `committed >= end` and SKIPS its blind re-send (no duplicate) even when
+    /// the terminal-commit ACK lagged the 10s wait. `None` until the watcher
+    /// delegates a terminal turn (and for legacy rows that pre-date this field).
+    #[serde(default)]
+    pub session_bound_delegated_terminal_end: Option<u64>,
     /// Lifecycle-aware restart/handoff mode for recovery semantics.
     #[serde(default)]
     pub restart_mode: Option<InflightRestartMode>,
@@ -582,6 +602,7 @@ impl InflightTurnState {
             dispatch_id: None,
             last_watcher_relayed_offset: None,
             last_watcher_relayed_generation_mtime_ns: None,
+            session_bound_delegated_terminal_end: None,
             restart_mode: None,
             restart_generation: None,
             rebind_origin: false,

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -666,6 +666,12 @@ pub(in crate::services::discord) struct InflightTurnIdentity {
     pub user_msg_id: u64,
     pub started_at: String,
     pub tmux_session_name: Option<String>,
+    /// #3041 P1-3 (codex P1-3 issue 2): the turn's `turn_start_offset` — the JSONL
+    /// byte offset at which this turn began. Used to disambiguate two consecutive
+    /// `user_msg_id == 0` TUI-direct turns whose `started_at` collides because
+    /// `now_string` only has 1-second resolution. Monotonic per turn, so it makes
+    /// the frame-carried turn identity unique even within a single second.
+    pub turn_start_offset: Option<u64>,
 }
 
 impl InflightTurnIdentity {
@@ -674,6 +680,7 @@ impl InflightTurnIdentity {
             user_msg_id: state.user_msg_id,
             started_at: state.started_at.clone(),
             tmux_session_name: state.tmux_session_name.clone(),
+            turn_start_offset: state.turn_start_offset,
         }
     }
 

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -3415,6 +3415,88 @@ mod stall_recovery_tests {
         assert!(load_inflight_states_from_root(temp.path(), &ProviderKind::Claude).is_empty());
     }
 
+    /// #3041 P1-3 (Part a, B1 — codex real-close): the watcher persists its
+    /// AUTHORITATIVE consumed-terminal END into inflight via the identity-guarded
+    /// save the watcher uses BEFORE the ACK wait. A subsequent load — exactly what
+    /// the session-bound sink's `deliver_response` does — must read a NON-None end
+    /// for THIS delivery (the ACK-lag path), so the sink can advance
+    /// `confirmed_end_offset` on its confirmed POST. The OLD code wrote this only
+    /// AFTER the ACK observed `Delivered`, i.e. AFTER the sink had already loaded
+    /// `None` → the duplicate vector stayed open. This pins the corrected ordering:
+    /// persist-before-load yields a readable end.
+    #[test]
+    fn delegated_terminal_end_is_persisted_before_sink_load_via_guarded_save() {
+        let temp = TempDir::new().unwrap();
+        let mut state = build_inflight_for_guard_tests(ProviderKind::Claude, 321, 100);
+        state.turn_start_offset = Some(0);
+        // The sink has NOT yet loaded — the field starts None.
+        assert_eq!(state.session_bound_delegated_terminal_end, None);
+        save_inflight_state_in_root(temp.path(), &state).unwrap();
+
+        // Watcher's early persist (mirrors the terminal-relay block): identity-
+        // guarded save of the consumed-terminal end BEFORE the ACK wait.
+        let identity = InflightTurnIdentity::from_state(&state);
+        let mut to_persist = state.clone();
+        let delegated_end = 256u64;
+        to_persist.session_bound_delegated_terminal_end = Some(delegated_end);
+        let outcome = save_inflight_state_if_matches_identity_in_root(
+            temp.path(),
+            &to_persist,
+            &identity,
+            state.turn_start_offset,
+        );
+        assert_eq!(outcome, GuardedSaveOutcome::Saved);
+
+        // The sink's `deliver_response` load now reads a NON-None end for THIS
+        // delivery — the ACK-lag duplicate vector is closed.
+        let loaded = load_inflight_states_from_root(temp.path(), &ProviderKind::Claude);
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(
+            loaded[0].session_bound_delegated_terminal_end,
+            Some(delegated_end),
+            "sink must read the delegated end persisted BEFORE its load (B1 ordering)"
+        );
+    }
+
+    /// #3041 P1-3 (Part a, B1): the identity guard must NOT let the delegated-end
+    /// persist clobber a NEWER turn that has taken over the inflight row (e.g. a
+    /// fast follow-up turn on the same channel between the watcher's compute and
+    /// its write). A mismatched identity yields `IdentityMismatch` and the newer
+    /// turn's row is preserved — no cross-turn end leakage / overshoot.
+    #[test]
+    fn delegated_terminal_end_persist_is_identity_guarded_against_newer_turn() {
+        let temp = TempDir::new().unwrap();
+        // The original turn the watcher was delegating (user_msg_id = 100).
+        let mut original = build_inflight_for_guard_tests(ProviderKind::Claude, 321, 100);
+        original.user_msg_id = 100;
+        let original_identity = InflightTurnIdentity::from_state(&original);
+
+        // A NEWER turn (distinct user_msg_id) now owns the row on disk.
+        let mut newer = build_inflight_for_guard_tests(ProviderKind::Claude, 321, 200);
+        newer.user_msg_id = 200;
+        save_inflight_state_in_root(temp.path(), &newer).unwrap();
+
+        // Watcher tries to persist the OLD turn's delegated end under the OLD
+        // identity → must be rejected, leaving the newer turn intact.
+        let mut stale_persist = original.clone();
+        stale_persist.session_bound_delegated_terminal_end = Some(256);
+        let outcome = save_inflight_state_if_matches_identity_in_root(
+            temp.path(),
+            &stale_persist,
+            &original_identity,
+            original.turn_start_offset,
+        );
+        assert_eq!(outcome, GuardedSaveOutcome::IdentityMismatch);
+
+        let rows = load_inflight_states_from_root(temp.path(), &ProviderKind::Claude);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].user_msg_id, 200, "newer turn must be preserved");
+        assert_eq!(
+            rows[0].session_bound_delegated_terminal_end, None,
+            "the newer turn must NOT inherit the old turn's delegated end"
+        );
+    }
+
     /// #2427 Pitfall #1 — stale TurnCompleted carrying the previous
     /// turn's `user_msg_id` must NOT delete the next turn's inflight.
     #[test]

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -286,8 +286,10 @@ impl SessionBoundDiscordRelaySink {
     /// channel's CURRENT inflight identity. If a newer/different turn has taken the
     /// channel (or no inflight remains), a stale terminal frame for the prior turn
     /// must NOT advance the authority — that would wrongly skip the new turn's
-    /// reconciliation. `inflight` is the inflight loaded for THIS delivery in
-    /// `deliver_response` (loaded once, reused — no second racy re-load).
+    /// reconciliation. `inflight` is supplied by the caller; the production path
+    /// (`advance_after_confirmed_post`) re-loads it FRESH after the Discord POST
+    /// returns (codex P1-3 issue 3), so the gate compares against the CURRENT
+    /// channel state rather than a snapshot taken before the slow async POST.
     ///
     /// DIRECT ADVANCE, not a Sink lease commit: the sink runs UNDER the watcher's
     /// delegation and is NOT a per-channel `DeliveryLeaseCell` holder. The producer
@@ -300,6 +302,37 @@ impl SessionBoundDiscordRelaySink {
     /// the producer's exact consumed-terminal end for THIS delivered turn. When the
     /// producer did not delegate a terminal end on this frame (None / zero) the
     /// sink does not advance (the watcher's own delivery path advances instead).
+    /// #3041 P1-3 (codex P1-3 issue 3 — stale-snapshot close): re-check the
+    /// identity gate against a FRESHLY-RELOADED inflight AFTER the confirmed
+    /// Discord POST/edit returned, then advance. `deliver_response` loads the
+    /// inflight ONCE before the slow async POST; if the turn is cleared or replaced
+    /// DURING that POST, that pre-POST snapshot still authorizes the advance → a
+    /// wrong-turn advance. Re-loading here (immediately before the advance, after
+    /// the await) means the gate sees the CURRENT channel state: if a newer turn
+    /// took the channel (or inflight was cleared) during the POST, the gate blocks.
+    ///
+    /// This is the ONLY advance path `deliver_response` uses; the pure
+    /// `advance_offset_for_confirmed_delegated_terminal` it delegates to keeps its
+    /// explicit-inflight signature so the gate logic stays unit-testable.
+    fn advance_after_confirmed_post(
+        &self,
+        shared: &super::SharedData,
+        provider: &ProviderKind,
+        channel_id: u64,
+        session_name: &str,
+        delivery: &SessionRelayDelivery,
+    ) {
+        let fresh_inflight = super::inflight::load_inflight_state(provider, channel_id);
+        self.advance_offset_for_confirmed_delegated_terminal(
+            shared,
+            provider,
+            channel_id,
+            session_name,
+            delivery,
+            fresh_inflight.as_ref(),
+        );
+    }
+
     fn advance_offset_for_confirmed_delegated_terminal(
         &self,
         shared: &super::SharedData,
@@ -325,8 +358,17 @@ impl SessionBoundDiscordRelaySink {
             );
             return;
         };
+        // #3041 P1-3 (codex P1-3 issue 2): `turn_start_offset` is part of the gate
+        // so two consecutive `user_msg_id == 0` turns started in the SAME second
+        // (identical `started_at`) cannot collide. The frame carries the pinned
+        // turn's `turn_start_offset`; it must match the channel's current inflight.
+        // When the frame carries no offset (legacy / non-fence) we fall back to the
+        // `(user_msg_id, started_at)` pair so old producers still gate correctly.
         let identity_matches = inflight.user_msg_id == delivery.frame_turn_user_msg_id
-            && inflight.started_at == delivery.frame_turn_started_at;
+            && inflight.started_at == delivery.frame_turn_started_at
+            && delivery
+                .frame_turn_start_offset
+                .is_none_or(|frame_offset| inflight.turn_start_offset == Some(frame_offset));
         if !identity_matches {
             tracing::debug!(
                 provider = provider.as_str(),
@@ -334,6 +376,8 @@ impl SessionBoundDiscordRelaySink {
                 tmux_session = %session_name,
                 frame_user_msg_id = delivery.frame_turn_user_msg_id,
                 inflight_user_msg_id = inflight.user_msg_id,
+                frame_turn_start_offset = delivery.frame_turn_start_offset,
+                inflight_turn_start_offset = inflight.turn_start_offset,
                 "session-bound sink: terminal frame identity != current inflight; identity gate blocks advance (delayed/wrong-turn frame)"
             );
             return;
@@ -358,8 +402,11 @@ impl SessionBoundDiscordRelaySink {
         // #3041 P1-3 (Part a, B1 — frame-carried): the producer's authoritative
         // consumed-terminal END now rides on the RESULT-bearing frame
         // (`delivery.terminal_consumed_end`), NOT read back from the inflight FILE
-        // (the racy old Part (a) is removed). The `inflight` loaded here is reused
-        // for the IDENTITY GATE in `advance_offset_for_confirmed_delegated_terminal`.
+        // (the racy old Part (a) is removed). The `inflight` loaded here is used
+        // ONLY for the route decision + trace context BELOW. The IDENTITY GATE's
+        // advance does NOT reuse this pre-POST snapshot — `advance_after_confirmed_post`
+        // re-loads a FRESH inflight AFTER the await (codex P1-3 issue 3), so a turn
+        // cleared/replaced during the slow POST cannot authorize a wrong-turn advance.
         let trace = session_relay_trace_context(
             &provider,
             channel_id,
@@ -479,14 +526,15 @@ impl SessionBoundDiscordRelaySink {
                     channel_id,
                 );
                 // #3041 P1-3 (Part a, B1): couple the confirmed POST to the offset
-                // advance in the SAME path.
-                self.advance_offset_for_confirmed_delegated_terminal(
+                // advance in the SAME path. (codex P1-3 issue 3) Re-check the
+                // identity gate against a freshly-reloaded inflight AFTER the POST,
+                // so a turn cleared/replaced during the slow POST blocks the advance.
+                self.advance_after_confirmed_post(
                     &shared,
                     &provider,
                     channel_id,
                     &delivery.session_name,
                     &delivery,
-                    inflight.as_ref(),
                 );
                 return Ok(SessionRelayDeliveryOutcome::Committed);
             }
@@ -533,14 +581,14 @@ impl SessionBoundDiscordRelaySink {
                         &delivery.session_name,
                         channel_id,
                     );
-                    // #3041 P1-3 (Part a, B1): commit fence.
-                    self.advance_offset_for_confirmed_delegated_terminal(
+                    // #3041 P1-3 (Part a, B1): commit fence. (codex P1-3 issue 3)
+                    // Post-POST fresh-inflight re-check before advancing.
+                    self.advance_after_confirmed_post(
                         &shared,
                         &provider,
                         channel_id,
                         &delivery.session_name,
                         &delivery,
-                        inflight.as_ref(),
                     );
                     Ok(SessionRelayDeliveryOutcome::Committed)
                 }
@@ -587,14 +635,14 @@ impl SessionBoundDiscordRelaySink {
                         channel_id,
                     );
                     // #3041 P1-3 (Part a, B1): commit fence — the fallback POST
-                    // delivered the response, so advance the authority too.
-                    self.advance_offset_for_confirmed_delegated_terminal(
+                    // delivered the response, so advance the authority too. (codex
+                    // P1-3 issue 3) Post-POST fresh-inflight re-check before advance.
+                    self.advance_after_confirmed_post(
                         &shared,
                         &provider,
                         channel_id,
                         &delivery.session_name,
                         &delivery,
-                        inflight.as_ref(),
                     );
                     Ok(SessionRelayDeliveryOutcome::Committed)
                 }
@@ -656,14 +704,14 @@ impl SessionBoundDiscordRelaySink {
                 true,
                 Some("new message"),
             );
-            // #3041 P1-3 (Part a, B1): commit fence.
-            self.advance_offset_for_confirmed_delegated_terminal(
+            // #3041 P1-3 (Part a, B1): commit fence. (codex P1-3 issue 3) Post-POST
+            // fresh-inflight re-check before advancing the authority.
+            self.advance_after_confirmed_post(
                 &shared,
                 &provider,
                 channel_id,
                 &delivery.session_name,
                 &delivery,
-                inflight.as_ref(),
             );
             Ok(SessionRelayDeliveryOutcome::Committed)
         }
@@ -1236,6 +1284,7 @@ impl SessionRelayParser {
                     terminal_consumed_end: frame.terminal_consumed_end,
                     frame_turn_user_msg_id: frame.turn_user_msg_id,
                     frame_turn_started_at: frame.turn_started_at.clone(),
+                    frame_turn_start_offset: frame.turn_start_offset,
                 });
                 break;
             } else {
@@ -1277,6 +1326,13 @@ struct SessionRelayDelivery {
     /// current inflight before advancing — a delayed/wrong-turn frame is ignored.
     frame_turn_user_msg_id: u64,
     frame_turn_started_at: String,
+    /// #3041 P1-3 (codex P1-3 issue 2): the pinned turn's `turn_start_offset`,
+    /// part of the IDENTITY GATE. `now_string` has 1-second resolution, so two
+    /// back-to-back `user_msg_id == 0` turns started in the same second share an
+    /// identical `(0, started_at)` — without this a delayed OLD terminal frame
+    /// would pass the gate for the NEW turn. `turn_start_offset` is monotonic per
+    /// turn, so it makes the identity unique. `None` on legacy/non-fence frames.
+    frame_turn_start_offset: Option<u64>,
 }
 
 fn ssh_direct_prompt_anchor_for_response(
@@ -1356,6 +1412,7 @@ mod tests {
             terminal_consumed_end: None,
             turn_user_msg_id: 0,
             turn_started_at: String::new(),
+            turn_start_offset: None,
         }
     }
 
@@ -1367,6 +1424,27 @@ mod tests {
         turn_user_msg_id: u64,
         turn_started_at: &str,
     ) -> StreamFrame {
+        terminal_frame_offset(
+            binding,
+            payload,
+            sequence,
+            consumed_end,
+            turn_user_msg_id,
+            turn_started_at,
+            Some(0),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn terminal_frame_offset(
+        binding: &MatchedChannel,
+        payload: &str,
+        sequence: u64,
+        consumed_end: u64,
+        turn_user_msg_id: u64,
+        turn_started_at: &str,
+        turn_start_offset: Option<u64>,
+    ) -> StreamFrame {
         StreamFrame {
             session_name: binding.expected_session_name.clone(),
             binding: binding.clone(),
@@ -1375,6 +1453,7 @@ mod tests {
             terminal_consumed_end: Some(consumed_end),
             turn_user_msg_id,
             turn_started_at: turn_started_at.to_string(),
+            turn_start_offset,
         }
     }
 
@@ -1954,6 +2033,22 @@ mod tests {
         turn_user_msg_id: u64,
         turn_started_at: &str,
     ) -> SessionRelayDelivery {
+        delivery_with_fence_offset(
+            session_name,
+            consumed_end,
+            turn_user_msg_id,
+            turn_started_at,
+            None,
+        )
+    }
+
+    fn delivery_with_fence_offset(
+        session_name: &str,
+        consumed_end: Option<u64>,
+        turn_user_msg_id: u64,
+        turn_started_at: &str,
+        turn_start_offset: Option<u64>,
+    ) -> SessionRelayDelivery {
         SessionRelayDelivery {
             provider: ProviderKind::Claude,
             channel_id: 8_041,
@@ -1963,6 +2058,7 @@ mod tests {
             terminal_consumed_end: consumed_end,
             frame_turn_user_msg_id: turn_user_msg_id,
             frame_turn_started_at: turn_started_at.to_string(),
+            frame_turn_start_offset: turn_start_offset,
         }
     }
 
@@ -1971,6 +2067,16 @@ mod tests {
         session_name: &str,
         user_msg_id: u64,
         started_at: &str,
+    ) -> super::super::inflight::InflightTurnState {
+        inflight_with_identity_offset(channel_id, session_name, user_msg_id, started_at, None)
+    }
+
+    fn inflight_with_identity_offset(
+        channel_id: u64,
+        session_name: &str,
+        user_msg_id: u64,
+        started_at: &str,
+        turn_start_offset: Option<u64>,
     ) -> super::super::inflight::InflightTurnState {
         let mut state = super::super::inflight::InflightTurnState::new(
             ProviderKind::Claude,
@@ -1987,6 +2093,7 @@ mod tests {
             0,
         );
         state.started_at = started_at.to_string();
+        state.turn_start_offset = turn_start_offset;
         state
     }
 
@@ -2171,6 +2278,166 @@ mod tests {
         );
     }
 
+    // #3041 P1-3 (codex P1-3 issue 2 — same-second identity collision close): two
+    // consecutive TUI-direct turns with `user_msg_id == 0` started in the SAME
+    // `now_string` second share an identical `(0, started_at)` pair. WITHOUT the
+    // `turn_start_offset` discriminator a delayed OLD terminal frame would pass the
+    // NEW turn's identity gate and wrongly advance. The gate now also compares
+    // `turn_start_offset` (monotonic per turn), so the old frame is blocked.
+    #[tokio::test]
+    async fn sink_identity_gate_blocks_same_second_turn_by_turn_start_offset() {
+        let shared = super::super::make_shared_data_for_tests();
+        let channel = ChannelId::new(8_041);
+        let session = "AgentDesk-claude-8041";
+        let sink = SessionBoundDiscordRelaySink::new(Arc::new(HealthRegistry::new()));
+
+        // Both turns: user_msg_id == 0 AND the SAME started_at (same second). They
+        // differ ONLY by turn_start_offset (the JSONL byte offset they began at).
+        let same_second = "2026-06-04T00:00:00Z";
+        // The NEW turn now owns the channel (turn_start_offset = 4096).
+        let new_inflight =
+            inflight_with_identity_offset(channel.get(), session, 0, same_second, Some(4096));
+        // A delayed OLD terminal frame from the PRIOR turn (turn_start_offset = 0)
+        // arrives — its (user_msg_id, started_at) pair matches, but its offset does
+        // not. Pre-fix this would have advanced the NEW turn's authority.
+        let stale_same_second_frame =
+            delivery_with_fence_offset(session, Some(256), 0, same_second, Some(0));
+
+        sink.advance_offset_for_confirmed_delegated_terminal(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            session,
+            &stale_same_second_frame,
+            Some(&new_inflight),
+        );
+        assert_eq!(
+            shared.committed_relay_offset(channel),
+            0,
+            "an old same-second frame (matching user_msg_id+started_at but different turn_start_offset) must NOT advance the new turn"
+        );
+
+        // The NEW turn's OWN terminal frame (matching turn_start_offset) DOES
+        // advance, proving the offset gate is discriminating, not blocking all.
+        let new_turn_frame =
+            delivery_with_fence_offset(session, Some(512), 0, same_second, Some(4096));
+        sink.advance_offset_for_confirmed_delegated_terminal(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            session,
+            &new_turn_frame,
+            Some(&new_inflight),
+        );
+        assert_eq!(
+            shared.committed_relay_offset(channel),
+            512,
+            "the matching-offset frame for the current turn DOES advance the authority"
+        );
+    }
+
+    // #3041 P1-3 (codex P1-3 issue 3 — stale-snapshot close): the production
+    // advance path re-loads the inflight FRESH after the confirmed POST. If the
+    // turn was cleared/replaced DURING the slow POST, the post-POST re-check sees
+    // the CURRENT (replaced/cleared) inflight and blocks the wrong-turn advance —
+    // even though a snapshot taken before the POST would have matched.
+    #[test]
+    fn sink_post_post_recheck_blocks_advance_when_inflight_replaced_during_post() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        struct EnvReset(Option<std::ffi::OsString>);
+        impl Drop for EnvReset {
+            fn drop(&mut self) {
+                match self.0.take() {
+                    Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
+                    None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
+                }
+            }
+        }
+        let _env_reset = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        let temp = tempfile::TempDir::new().unwrap();
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+
+        let shared = super::super::make_shared_data_for_tests();
+        let channel = ChannelId::new(8_041);
+        let session = "AgentDesk-claude-8041";
+        let sink = SessionBoundDiscordRelaySink::new(Arc::new(HealthRegistry::new()));
+
+        // The frame was delegated for the ORIGINAL turn (turn_start_offset=0). A
+        // pre-POST snapshot would carry this identity and authorize the advance.
+        let delivery =
+            delivery_with_fence_offset(session, Some(256), 0, "2026-06-04T00:00:00Z", Some(0));
+
+        // DURING the (simulated) slow POST a NEW turn took the channel: same
+        // user_msg_id==0 and same second, but a later turn_start_offset. We persist
+        // THAT as the on-disk inflight so the fresh post-POST reload reads it.
+        let replaced = inflight_with_identity_offset(
+            channel.get(),
+            session,
+            0,
+            "2026-06-04T00:00:00Z",
+            Some(4096),
+        );
+        super::super::inflight::save_inflight_state(&replaced).expect("persist replaced inflight");
+
+        // Post-POST advance: re-loads inflight from disk (the REPLACED turn) → the
+        // identity gate (turn_start_offset 0 != 4096) blocks the advance.
+        sink.advance_after_confirmed_post(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            session,
+            &delivery,
+        );
+        assert_eq!(
+            shared.committed_relay_offset(channel),
+            0,
+            "a turn replaced DURING the POST must block the advance (post-POST fresh re-check)"
+        );
+
+        // Control: if the original turn STILL owns the channel at post-POST time,
+        // the fresh reload matches and the advance proceeds.
+        let still_original = inflight_with_identity_offset(
+            channel.get(),
+            session,
+            0,
+            "2026-06-04T00:00:00Z",
+            Some(0),
+        );
+        super::super::inflight::save_inflight_state(&still_original).expect("persist original");
+        sink.advance_after_confirmed_post(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            session,
+            &delivery,
+        );
+        assert_eq!(
+            shared.committed_relay_offset(channel),
+            256,
+            "when the original turn still owns the channel at post-POST time, the advance proceeds"
+        );
+
+        // Cleared inflight (stop/cancel during POST) → no advance either.
+        super::super::make_shared_data_for_tests();
+        super::super::inflight::clear_inflight_state(&ProviderKind::Claude, channel.get());
+        let advanced_delivery =
+            delivery_with_fence_offset(session, Some(512), 0, "2026-06-04T00:00:00Z", Some(0));
+        sink.advance_after_confirmed_post(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            session,
+            &advanced_delivery,
+        );
+        assert_eq!(
+            shared.committed_relay_offset(channel),
+            256,
+            "a cleared inflight at post-POST time must block the advance (identity gate, no inflight)"
+        );
+    }
+
     // #3041 P1-3 (Part a, B1): the RESULT-bearing terminal frame's commit fence
     // (consumed_end + identity) is copied onto the emitted `SessionRelayDelivery`,
     // so `deliver_response` advances the authority from frame data — not an inflight
@@ -2205,6 +2472,85 @@ mod tests {
         );
         assert_eq!(deliveries[0].frame_turn_user_msg_id, 77);
         assert_eq!(deliveries[0].frame_turn_started_at, "2026-06-04T00:00:00Z");
+        // #3041 P1-3 (codex P1-3 issue 2): the delivery also carries the frame's
+        // pinned turn_start_offset for the sink's identity gate.
+        assert_eq!(deliveries[0].frame_turn_start_offset, Some(0));
+    }
+
+    // #3041 P1-3 (codex P1-3 issue 1 — multi-turn-chunk close): after the watcher
+    // SPLITS a `result(A) + bytes(B)` physical chunk, the sink's parser receives
+    // turn A's bytes on a TERMINAL frame (A's fence) and turn B's bytes on a
+    // SEPARATE frame. A commits to A's end with A's identity; B is NOT black-holed —
+    // it is mirrored and, when it completes, commits to B's end with B's identity.
+    // Pre-fix, B's bytes rode A's terminal frame and a follow-up empty chunk emitted
+    // no frame for B (black-hole) and could reuse A's ACK (mis-commit).
+    #[test]
+    fn split_multi_turn_chunk_commits_each_turn_with_its_own_fence() {
+        let binding = matched("8051");
+        let mut parser = SessionRelayParser::default();
+
+        // The watcher split produced: terminal frame = turn A (result + A's fence),
+        // then a separate non-terminal frame = turn B's leading bytes.
+        let turn_a_result = "{\"type\":\"result\",\"result\":\"answer A\"}\n";
+        let turn_a_deliveries = parser.ingest_frame(&terminal_frame_offset(
+            &binding,
+            turn_a_result,
+            1,
+            /*consumed_end=*/ 100,
+            /*user_msg_id=*/ 0,
+            "2026-06-04T00:00:00Z",
+            /*turn_start_offset=*/ Some(0),
+        ));
+        // Turn A commits to A's end (100) with A's identity (offset 0).
+        assert_eq!(turn_a_deliveries.len(), 1, "turn A must produce a delivery");
+        assert_eq!(turn_a_deliveries[0].response_text, "answer A");
+        assert_eq!(turn_a_deliveries[0].terminal_consumed_end, Some(100));
+        assert_eq!(turn_a_deliveries[0].frame_turn_start_offset, Some(0));
+
+        // The sink resets the parser after each terminal delivery (via
+        // `finish_terminal_candidate`); model that so turn B starts a fresh turn.
+        parser.reset_turn();
+
+        // Turn B's leading bytes arrive on their OWN (non-terminal) frame — the
+        // split-out tail. The parser accumulates them (B not yet complete → no
+        // delivery), proving B is MIRRORED rather than black-holed.
+        let turn_b_assistant = "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"answer B\"}]}}\n";
+        assert!(
+            parser
+                .ingest_frame(&frame(&binding, turn_b_assistant, 2))
+                .is_empty(),
+            "turn B's split-out bytes must accumulate (mirrored), not vanish"
+        );
+
+        // When turn B completes on a later pass, it gets its OWN terminal frame +
+        // fence: B commits to B's end (250) with B's identity (offset 100) — NOT
+        // turn A's. No shared-ACK reuse, no mis-commit.
+        let turn_b_result = "{\"type\":\"result\",\"result\":\"answer B\"}\n";
+        let turn_b_deliveries = parser.ingest_frame(&terminal_frame_offset(
+            &binding,
+            turn_b_result,
+            3,
+            /*consumed_end=*/ 250,
+            /*user_msg_id=*/ 0,
+            "2026-06-04T00:00:01Z",
+            /*turn_start_offset=*/ Some(100),
+        ));
+        assert_eq!(
+            turn_b_deliveries.len(),
+            1,
+            "turn B must commit (not black-holed)"
+        );
+        assert_eq!(turn_b_deliveries[0].response_text, "answer B");
+        assert_eq!(
+            turn_b_deliveries[0].terminal_consumed_end,
+            Some(250),
+            "turn B commits to B's end, not A's"
+        );
+        assert_eq!(
+            turn_b_deliveries[0].frame_turn_start_offset,
+            Some(100),
+            "turn B commits with B's own identity (turn_start_offset), not A's"
+        );
     }
 
     #[test]

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -270,6 +270,51 @@ impl SessionBoundDiscordRelaySink {
         }
     }
 
+    /// #3041 P1-3 (Part a, BLOCKER B1 — the "commit fence"): on a CONFIRMED
+    /// terminal Discord delivery, advance the offset authority
+    /// (`confirmed_end_offset`) to the watcher's AUTHORITATIVE consumed-terminal
+    /// END for the delegated turn (`session_bound_delegated_terminal_end`,
+    /// persisted by the watcher when it delegated this terminal — see
+    /// `tmux_watcher.rs` delegation block). This couples the POST success to the
+    /// offset advance in the SAME path so the watcher's §3.2 reconciliation
+    /// (Part b) sees `committed >= end` and SKIPS its blind re-send (no duplicate)
+    /// even when the terminal-commit ACK lagged the 10s wait.
+    ///
+    /// DIRECT ADVANCE, not a Sink lease commit: the sink runs UNDER the watcher's
+    /// delegation and is NOT a per-channel `DeliveryLeaseCell` holder (the
+    /// delegation path does not acquire the cell, so there is no lease for the
+    /// sink to commit). The watcher is the byte-range AUTHORITY; the sink advances
+    /// to the watcher's OWN end via `advance_watcher_confirmed_end`'s monotonic CAS
+    /// so it can never regress, double-advance, or overshoot.
+    ///
+    /// NO-BLACK-HOLE: the sink NEVER reads a fresh JSONL EOF (which could include
+    /// later-appended undelivered bytes, codex r4 P1). `delegated_end` is the
+    /// watcher's persisted consumed-terminal end for THIS delivered turn (read off
+    /// the inflight loaded at the START of `deliver_response`, i.e. the turn being
+    /// delivered — NOT a re-load that could pick up a LATER turn's larger end and
+    /// overshoot). When the watcher did not delegate (no field / zero) the sink
+    /// does not advance (the watcher's own delivery path advances instead).
+    fn advance_offset_for_confirmed_delegated_terminal(
+        &self,
+        shared: &super::SharedData,
+        provider: &ProviderKind,
+        channel_id: u64,
+        session_name: &str,
+        delegated_end: Option<u64>,
+    ) {
+        let Some(end) = delegated_end.filter(|end| *end > 0) else {
+            return;
+        };
+        super::tmux::advance_watcher_confirmed_end(
+            shared,
+            provider,
+            ChannelId::new(channel_id),
+            session_name,
+            end,
+            "src/services/discord/session_relay_sink.rs:sink_confirmed_terminal_advance",
+        );
+    }
+
     async fn deliver_response(
         &self,
         delivery: SessionRelayDelivery,
@@ -277,6 +322,14 @@ impl SessionBoundDiscordRelaySink {
         let channel_id = delivery.channel_id;
         let provider = delivery.provider;
         let inflight = super::inflight::load_inflight_state(&provider, channel_id);
+        // #3041 P1-3 (Part a, B1): the watcher's authoritative consumed-terminal
+        // END for the turn it delegated to this sink, captured from the inflight
+        // loaded for THIS delivery (the turn being delivered) so a confirmed POST
+        // can advance the offset authority to it without re-reading a later turn's
+        // larger end (which would overshoot — black-hole).
+        let delegated_terminal_end = inflight
+            .as_ref()
+            .and_then(|state| state.session_bound_delegated_terminal_end);
         let trace = session_relay_trace_context(
             &provider,
             channel_id,
@@ -395,6 +448,15 @@ impl SessionBoundDiscordRelaySink {
                     &delivery.session_name,
                     channel_id,
                 );
+                // #3041 P1-3 (Part a, B1): couple the confirmed POST to the offset
+                // advance in the SAME path.
+                self.advance_offset_for_confirmed_delegated_terminal(
+                    &shared,
+                    &provider,
+                    channel_id,
+                    &delivery.session_name,
+                    delegated_terminal_end,
+                );
                 return Ok(SessionRelayDeliveryOutcome::Committed);
             }
             match formatting::replace_long_message_raw_with_outcome(
@@ -440,6 +502,14 @@ impl SessionBoundDiscordRelaySink {
                         &delivery.session_name,
                         channel_id,
                     );
+                    // #3041 P1-3 (Part a, B1): commit fence.
+                    self.advance_offset_for_confirmed_delegated_terminal(
+                        &shared,
+                        &provider,
+                        channel_id,
+                        &delivery.session_name,
+                        delegated_terminal_end,
+                    );
                     Ok(SessionRelayDeliveryOutcome::Committed)
                 }
                 Ok(ReplaceLongMessageOutcome::SentFallbackAfterEditFailure { edit_error }) => {
@@ -483,6 +553,15 @@ impl SessionBoundDiscordRelaySink {
                         provider.as_str(),
                         &delivery.session_name,
                         channel_id,
+                    );
+                    // #3041 P1-3 (Part a, B1): commit fence — the fallback POST
+                    // delivered the response, so advance the authority too.
+                    self.advance_offset_for_confirmed_delegated_terminal(
+                        &shared,
+                        &provider,
+                        channel_id,
+                        &delivery.session_name,
+                        delegated_terminal_end,
                     );
                     Ok(SessionRelayDeliveryOutcome::Committed)
                 }
@@ -544,6 +623,14 @@ impl SessionBoundDiscordRelaySink {
                 true,
                 Some("new message"),
             );
+            // #3041 P1-3 (Part a, B1): commit fence.
+            self.advance_offset_for_confirmed_delegated_terminal(
+                &shared,
+                &provider,
+                channel_id,
+                &delivery.session_name,
+                delegated_terminal_end,
+            );
             Ok(SessionRelayDeliveryOutcome::Committed)
         }
     }
@@ -566,40 +653,25 @@ impl RelaySink for SessionBoundDiscordRelaySink {
             match self.deliver_response(delivery).await {
                 Ok(SessionRelayDeliveryOutcome::Committed) => {
                     terminal_committed = true;
-                    // #3017: the sink deliberately does NOT advance the
-                    // committed relay offset here. The only byte offset
-                    // available at this point is the JSONL EOF, which can
-                    // include bytes appended AFTER this frame was read but
-                    // before the async Discord delivery committed — committing
-                    // that later EOF would mark undelivered appended output as
-                    // already relayed and DROP it (codex r4 P1). The
-                    // `StreamFrame` contract does not carry the exact delivered
-                    // byte-range end, and threading one through the cluster
-                    // stream-relay producer/parser is out of this subset's
-                    // scope. The tmux watcher remains the SOLE committer of the
-                    // authority (`advance_watcher_confirmed_end`, which has the
-                    // exact relayed offset); the idle relay only CONSULTS it.
-                    // This keeps the dedup data-loss-free: the residual
-                    // idle-wins-the-race window is bounded by the idle relay's
-                    // 10s recent-inflight grace (the watcher relays + commits
-                    // within ~250ms), and when no watcher is relaying there is
-                    // no second actor to duplicate against. (See FINAL OUTPUT
-                    // note for the #3017 follow-up to carry the range end.)
+                    // #3041 P1-3 (Part a, BLOCKER B1 CLOSED): the offset advance
+                    // for a confirmed terminal delivery now happens INLINE inside
+                    // `deliver_response` (the commit fence:
+                    // `advance_offset_for_confirmed_delegated_terminal`), coupled
+                    // to the POST success in the SAME path. It advances
+                    // `confirmed_end_offset` to the WATCHER's authoritative
+                    // consumed-terminal end (`session_bound_delegated_terminal_end`,
+                    // persisted on the inflight by the watcher when it delegated
+                    // this terminal), NOT a fresh JSONL EOF — so it can never
+                    // overshoot into later-appended undelivered bytes (the codex
+                    // r4 P1 black-hole) and is a monotonic, idempotent CAS.
                     //
-                    // EXACT-ONCE GAP (deferred to #3041, NOT a regression):
-                    // because this terminal Discord delivery does NOT advance the
-                    // authority, the "sink wins first" case is not yet exact-once.
-                    // If this sink posts BEFORE the watcher commits, the authority
-                    // (`confirmed_end_offset`) stays stale, so the watcher's later
-                    // no-inflight dedup gate cannot suppress its own delivery →
-                    // a residual duplicate window (the 10s grace reduces but does
-                    // not eliminate it). Closing this requires the sink's delivery
-                    // to advance the authority atomically with the exact relayed
-                    // range end — that is the #3041 delivery-lease (commit-with-
-                    // offset) work, deliberately out of scope here to avoid the
-                    // codex r4 P1 black-hole of committing a too-late EOF. Phase4's
-                    // read-only consult is a strict improvement over no consult;
-                    // it does not by itself achieve full exact-once for this window.
+                    // This closes the prior EXACT-ONCE GAP: if the sink posts
+                    // BEFORE the watcher's terminal-commit ACK lands (or that ACK
+                    // lags the watcher's 10s wait), the authority is now ADVANCED
+                    // by the sink, so the watcher's §3.2 reconciliation (P1-3 Part
+                    // b) sees `committed >= end` and SKIPS its re-send (no
+                    // duplicate). When the watcher did NOT delegate (no field), the
+                    // watcher's OWN delivery path advances the authority instead.
                     self.finish_terminal_candidate(&session_name);
                 }
                 Ok(SessionRelayDeliveryOutcome::Skipped) => {
@@ -1795,6 +1867,94 @@ mod tests {
             .expect("frame without terminal delivery should be accepted");
 
         assert_eq!(outcome, RelaySinkOutcome::FrameAccepted);
+    }
+
+    // #3041 P1-3 (Part a, BLOCKER B1): when the sink CONFIRMS a terminal delivery,
+    // it advances `committed_relay_offset` to the watcher's authoritative
+    // consumed-terminal END (persisted on the inflight as
+    // `session_bound_delegated_terminal_end`). This is the B1 "commit fence": the
+    // POST success and the offset advance are coupled, so the watcher's §3.2
+    // reconciliation (Part b) sees the delegated range as delivered even if the
+    // terminal-commit ACK lags.
+    #[tokio::test]
+    async fn sink_confirmed_delivery_advances_committed_offset_to_delegated_end() {
+        let shared = super::super::make_shared_data_for_tests();
+        let channel = ChannelId::new(8_041);
+        let sink = SessionBoundDiscordRelaySink::new(Arc::new(HealthRegistry::new()));
+
+        // Before any delivery the authority is at 0.
+        assert_eq!(shared.committed_relay_offset(channel), 0);
+
+        // A confirmed sink delivery for the watcher-delegated range `[0, 256)`:
+        // the watcher persisted end=256, so the sink advances the authority to it.
+        sink.advance_offset_for_confirmed_delegated_terminal(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            "AgentDesk-claude-8041",
+            Some(256),
+        );
+        assert_eq!(
+            shared.committed_relay_offset(channel),
+            256,
+            "a confirmed sink delivery must advance committed_relay_offset to the delegated end (B1 close)"
+        );
+
+        // Idempotent / no double-advance: re-confirming the SAME range is a
+        // monotonic-CAS no-op (cannot regress or double-advance).
+        sink.advance_offset_for_confirmed_delegated_terminal(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            "AgentDesk-claude-8041",
+            Some(256),
+        );
+        assert_eq!(shared.committed_relay_offset(channel), 256);
+
+        // When the watcher did NOT delegate a range (None / zero end), the sink
+        // does NOT advance — the watcher's own delivery path owns the advance.
+        sink.advance_offset_for_confirmed_delegated_terminal(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            "AgentDesk-claude-8041",
+            None,
+        );
+        sink.advance_offset_for_confirmed_delegated_terminal(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            "AgentDesk-claude-8041",
+            Some(0),
+        );
+        assert_eq!(
+            shared.committed_relay_offset(channel),
+            256,
+            "no delegated range (None/0) must not advance the authority"
+        );
+
+        // Monotonic guard: a later confirmed delivery at a LARGER end advances; a
+        // stale smaller end never regresses the authority.
+        sink.advance_offset_for_confirmed_delegated_terminal(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            "AgentDesk-claude-8041",
+            Some(128),
+        );
+        assert_eq!(
+            shared.committed_relay_offset(channel),
+            256,
+            "a smaller (stale) end must not regress the authority"
+        );
+        sink.advance_offset_for_confirmed_delegated_terminal(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            "AgentDesk-claude-8041",
+            Some(512),
+        );
+        assert_eq!(shared.committed_relay_offset(channel), 512);
     }
 
     #[test]

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -358,17 +358,23 @@ impl SessionBoundDiscordRelaySink {
             );
             return;
         };
-        // #3041 P1-3 (codex P1-3 issue 2): `turn_start_offset` is part of the gate
-        // so two consecutive `user_msg_id == 0` turns started in the SAME second
-        // (identical `started_at`) cannot collide. The frame carries the pinned
-        // turn's `turn_start_offset`; it must match the channel's current inflight.
-        // When the frame carries no offset (legacy / non-fence) we fall back to the
-        // `(user_msg_id, started_at)` pair so old producers still gate correctly.
+        // #3041 P1-3 (codex P1-3 issue 2 R4): STRICT `turn_start_offset` identity.
+        // Two consecutive `user_msg_id == 0` turns started in the SAME second
+        // (identical `started_at`) would collide on the weak `(user_msg_id,
+        // started_at)` pair alone, so `turn_start_offset` is a REQUIRED part of the
+        // gate — there is NO None fallback. A fenced terminal frame (the only kind
+        // that reaches this advance, since `terminal_consumed_end` is Some) is
+        // GUARANTEED by the producer (`watcher_terminal_commit_fence`) to carry a
+        // real `turn_start_offset`: the producer only sets the fence when the turn's
+        // start offset is known, otherwise it forwards a non-terminal frame and the
+        // watcher reconciliation's SendFull delivers (no black-hole). Therefore a
+        // frame reaching here with `frame_turn_start_offset == None`, or whose
+        // offset does not equal the current inflight's, MUST NOT advance — it is a
+        // stale/mismatched frame, never a legitimate fence for the current turn.
         let identity_matches = inflight.user_msg_id == delivery.frame_turn_user_msg_id
             && inflight.started_at == delivery.frame_turn_started_at
-            && delivery
-                .frame_turn_start_offset
-                .is_none_or(|frame_offset| inflight.turn_start_offset == Some(frame_offset));
+            && delivery.frame_turn_start_offset.is_some()
+            && inflight.turn_start_offset == delivery.frame_turn_start_offset;
         if !identity_matches {
             tracing::debug!(
                 provider = provider.as_str(),
@@ -727,6 +733,24 @@ enum SessionRelayDeliveryOutcome {
 #[async_trait]
 impl RelaySink for SessionBoundDiscordRelaySink {
     async fn deliver(&self, frame: &StreamFrame) -> Result<RelaySinkOutcome, RelaySinkError> {
+        // #3041 P1-3 (codex P1-3 issue 1 R4 — ACK correlation): only a FENCED
+        // (terminal) frame may report a terminal outcome to the relay metrics. A
+        // single physical chunk can carry turn A's result PLUS turn B's COMPLETE
+        // result; the split forwards A on a terminal (fenced) frame and B's tail on
+        // a SEPARATE non-terminal (fence-less) frame. The sink's parser still
+        // delivers B from that tail (so B is never black-holed), but that post is
+        // NOT a terminal commit for THIS frame — the frame carries no fence. If we
+        // bumped `last_terminal_committed_sequence` for the tail (B's higher
+        // sequence N+1), it would MASK turn A's true terminal outcome: A's
+        // terminal-ACK (target = A's seq N) would read `committed >= N` and report
+        // `Delivered` even when A's terminal frame was actually SKIPPED — the
+        // watcher would then suppress its SendFull reconciliation and BLACK-HOLE A.
+        // Gating the terminal outcome on the frame's own fence keeps A's
+        // terminal-ACK bound strictly to A's terminal frame. The deferred duplicate
+        // of B (the watcher's later SendFull re-posts B) is tracked in #3151; it is
+        // never a black-hole (B is delivered) and never a wrong-turn advance (B's
+        // tail has no fence so it cannot advance any offset).
+        let frame_is_terminal = frame.terminal_consumed_end.is_some();
         let deliveries = self.ingest_frame(frame);
         let mut terminal_committed = false;
         let mut terminal_skipped = false;
@@ -769,9 +793,14 @@ impl RelaySink for SessionBoundDiscordRelaySink {
                 }
             }
         }
-        if terminal_committed {
+        // Only a FENCED frame may surface a terminal outcome (see above). A
+        // fence-less frame that posted a delivery (e.g. turn B's complete result
+        // riding turn A's trailing tail) reports `FrameAccepted`: the relay records
+        // it as DELIVERED (mirrored) but NOT terminal-committed, so it can never
+        // satisfy another turn's terminal-ACK.
+        if frame_is_terminal && terminal_committed {
             Ok(RelaySinkOutcome::TerminalCommitted)
-        } else if terminal_skipped {
+        } else if frame_is_terminal && terminal_skipped {
             Ok(RelaySinkOutcome::TerminalSkipped)
         } else {
             Ok(RelaySinkOutcome::FrameAccepted)
@@ -2027,6 +2056,44 @@ mod tests {
         assert_eq!(outcome, RelaySinkOutcome::FrameAccepted);
     }
 
+    // #3041 P1-3 (codex P1-3 issue 1 R4 — ACK correlation): a FENCE-LESS
+    // (non-terminal) frame that carries a COMPLETE result (e.g. turn B's result
+    // riding turn A's trailing tail) produces a delivery whose
+    // `terminal_consumed_end` is None — so the identity-gated advance can NEVER
+    // fire for it (the advance requires `Some(end > 0)`), and `deliver` reports a
+    // terminal outcome ONLY when `frame.terminal_consumed_end.is_some()`. Both
+    // guarantee B's tail post can never advance an offset nor satisfy turn A's
+    // terminal-ACK (which would otherwise black-hole A). Driving a real terminal
+    // COMMIT needs Discord HTTP, so we assert the two load-bearing invariants
+    // directly: (a) the fence-less frame is non-terminal, and (b) its delivery
+    // carries no consumed_end.
+    #[test]
+    fn fenceless_frame_with_complete_result_carries_no_commit_fence() {
+        let binding = matched("44");
+        let mut parser = SessionRelayParser::default();
+        // A COMPLETE turn result on a fence-less frame (terminal_consumed_end=None).
+        let payload = concat!(
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"turn B done\"}]}}\n",
+            "{\"type\":\"result\",\"result\":\"turn B done\"}\n"
+        );
+        let fenceless = frame(&binding, payload, 7);
+        assert!(
+            fenceless.terminal_consumed_end.is_none(),
+            "precondition: this is a fence-less (non-terminal) frame — `deliver` reports FrameAccepted, never a terminal outcome"
+        );
+
+        let deliveries = parser.ingest_frame(&fenceless);
+        assert_eq!(
+            deliveries.len(),
+            1,
+            "the complete result on the fence-less frame is still delivered (B is mirrored, not black-holed)"
+        );
+        assert_eq!(
+            deliveries[0].terminal_consumed_end, None,
+            "a fence-less frame's delivery carries NO consumed_end → it can never advance the offset authority (no wrong-turn advance, no shared-ACK reuse)"
+        );
+    }
+
     fn delivery_with_fence(
         session_name: &str,
         consumed_end: Option<u64>,
@@ -2112,7 +2179,15 @@ mod tests {
         let session = "AgentDesk-claude-8041";
         let sink = SessionBoundDiscordRelaySink::new(Arc::new(HealthRegistry::new()));
         // The channel's current inflight identity the frame must match to advance.
-        let inflight = inflight_with_identity(channel.get(), session, 0, "2026-06-04T00:00:00Z");
+        // A fence ALWAYS carries a real `turn_start_offset` (producer guarantee),
+        // and the STRICT gate requires it to match, so the inflight carries one too.
+        let inflight = inflight_with_identity_offset(
+            channel.get(),
+            session,
+            0,
+            "2026-06-04T00:00:00Z",
+            Some(0),
+        );
 
         // Before any delivery the authority is at 0.
         assert_eq!(shared.committed_relay_offset(channel), 0);
@@ -2124,7 +2199,7 @@ mod tests {
             &ProviderKind::Claude,
             channel.get(),
             session,
-            &delivery_with_fence(session, Some(256), 0, "2026-06-04T00:00:00Z"),
+            &delivery_with_fence_offset(session, Some(256), 0, "2026-06-04T00:00:00Z", Some(0)),
             Some(&inflight),
         );
         assert_eq!(
@@ -2140,7 +2215,7 @@ mod tests {
             &ProviderKind::Claude,
             channel.get(),
             session,
-            &delivery_with_fence(session, Some(256), 0, "2026-06-04T00:00:00Z"),
+            &delivery_with_fence_offset(session, Some(256), 0, "2026-06-04T00:00:00Z", Some(0)),
             Some(&inflight),
         );
         assert_eq!(shared.committed_relay_offset(channel), 256);
@@ -2152,7 +2227,7 @@ mod tests {
             &ProviderKind::Claude,
             channel.get(),
             session,
-            &delivery_with_fence(session, None, 0, "2026-06-04T00:00:00Z"),
+            &delivery_with_fence_offset(session, None, 0, "2026-06-04T00:00:00Z", Some(0)),
             Some(&inflight),
         );
         sink.advance_offset_for_confirmed_delegated_terminal(
@@ -2160,7 +2235,7 @@ mod tests {
             &ProviderKind::Claude,
             channel.get(),
             session,
-            &delivery_with_fence(session, Some(0), 0, "2026-06-04T00:00:00Z"),
+            &delivery_with_fence_offset(session, Some(0), 0, "2026-06-04T00:00:00Z", Some(0)),
             Some(&inflight),
         );
         assert_eq!(
@@ -2176,7 +2251,7 @@ mod tests {
             &ProviderKind::Claude,
             channel.get(),
             session,
-            &delivery_with_fence(session, Some(128), 0, "2026-06-04T00:00:00Z"),
+            &delivery_with_fence_offset(session, Some(128), 0, "2026-06-04T00:00:00Z", Some(0)),
             Some(&inflight),
         );
         assert_eq!(
@@ -2189,7 +2264,7 @@ mod tests {
             &ProviderKind::Claude,
             channel.get(),
             session,
-            &delivery_with_fence(session, Some(512), 0, "2026-06-04T00:00:00Z"),
+            &delivery_with_fence_offset(session, Some(512), 0, "2026-06-04T00:00:00Z", Some(0)),
             Some(&inflight),
         );
         assert_eq!(shared.committed_relay_offset(channel), 512);
@@ -2207,10 +2282,17 @@ mod tests {
         let sink = SessionBoundDiscordRelaySink::new(Arc::new(HealthRegistry::new()));
 
         // Current inflight is turn started_at=NEW; the frame carries the OLD turn's
-        // identity (same user_msg_id=0 external-input, different started_at).
-        let current_inflight =
-            inflight_with_identity(channel.get(), session, 0, "2026-06-04T00:00:09Z");
-        let stale_frame = delivery_with_fence(session, Some(256), 0, "2026-06-04T00:00:00Z");
+        // identity (same user_msg_id=0 external-input, different started_at). A fence
+        // ALWAYS carries a real `turn_start_offset` (producer guarantee).
+        let current_inflight = inflight_with_identity_offset(
+            channel.get(),
+            session,
+            0,
+            "2026-06-04T00:00:09Z",
+            Some(4096),
+        );
+        let stale_frame =
+            delivery_with_fence_offset(session, Some(256), 0, "2026-06-04T00:00:00Z", Some(0));
 
         sink.advance_offset_for_confirmed_delegated_terminal(
             &shared,
@@ -2243,8 +2325,13 @@ mod tests {
 
         // Different user_msg_id (a managed turn replaced the external-input turn)
         // → no advance even if started_at coincidentally matched.
-        let replaced_inflight =
-            inflight_with_identity(channel.get(), session, 999, "2026-06-04T00:00:00Z");
+        let replaced_inflight = inflight_with_identity_offset(
+            channel.get(),
+            session,
+            999,
+            "2026-06-04T00:00:00Z",
+            Some(0),
+        );
         sink.advance_offset_for_confirmed_delegated_terminal(
             &shared,
             &ProviderKind::Claude,
@@ -2259,10 +2346,15 @@ mod tests {
             "a frame whose user_msg_id != current inflight must NOT advance (identity gate)"
         );
 
-        // Sanity: the SAME identity DOES advance, proving the gate isn't blocking
-        // everything.
-        let matching_inflight =
-            inflight_with_identity(channel.get(), session, 0, "2026-06-04T00:00:00Z");
+        // Sanity: the SAME identity (including matching turn_start_offset) DOES
+        // advance, proving the gate isn't blocking everything.
+        let matching_inflight = inflight_with_identity_offset(
+            channel.get(),
+            session,
+            0,
+            "2026-06-04T00:00:00Z",
+            Some(0),
+        );
         sink.advance_offset_for_confirmed_delegated_terminal(
             &shared,
             &ProviderKind::Claude,
@@ -2333,6 +2425,80 @@ mod tests {
             shared.committed_relay_offset(channel),
             512,
             "the matching-offset frame for the current turn DOES advance the authority"
+        );
+    }
+
+    // #3041 P1-3 (codex P1-3 issue 2 R4 — STRICT offset gate, no weak fallback): a
+    // fenced terminal frame whose `turn_start_offset` is None must NOT advance, even
+    // when its `(user_msg_id, started_at)` pair matches the current inflight. The
+    // producer GUARANTEES every fence carries a real offset, so a None here is a
+    // malformed/legacy frame and the strict gate refuses the advance — closing the
+    // old `is_none_or` weak fallback that let a None authorize an advance and could
+    // collide for consecutive same-second `user_msg_id == 0` turns.
+    #[tokio::test]
+    async fn sink_strict_gate_blocks_advance_when_frame_offset_is_none() {
+        let shared = super::super::make_shared_data_for_tests();
+        let channel = ChannelId::new(8_041);
+        let session = "AgentDesk-claude-8041";
+        let sink = SessionBoundDiscordRelaySink::new(Arc::new(HealthRegistry::new()));
+
+        // Current inflight has a real turn_start_offset; the (user_msg_id, started_at)
+        // pair matches the frame exactly. Only the frame's missing offset differs.
+        let same_second = "2026-06-04T00:00:00Z";
+        let inflight =
+            inflight_with_identity_offset(channel.get(), session, 0, same_second, Some(4096));
+        // A fenced frame whose turn_start_offset is None (the weak-fallback case).
+        let none_offset_frame =
+            delivery_with_fence_offset(session, Some(256), 0, same_second, None);
+
+        sink.advance_offset_for_confirmed_delegated_terminal(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            session,
+            &none_offset_frame,
+            Some(&inflight),
+        );
+        assert_eq!(
+            shared.committed_relay_offset(channel),
+            0,
+            "a fenced frame with turn_start_offset=None must NOT advance (no weak None fallback)"
+        );
+
+        // Two `user_msg_id == 0` turns differing ONLY by turn_start_offset: only the
+        // frame whose offset matches the current inflight advances. The mismatched
+        // one (the prior turn's offset) is blocked even though user_msg_id+started_at
+        // are identical (same-second TUI-direct collision).
+        let mismatched_offset_frame =
+            delivery_with_fence_offset(session, Some(256), 0, same_second, Some(0));
+        sink.advance_offset_for_confirmed_delegated_terminal(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            session,
+            &mismatched_offset_frame,
+            Some(&inflight),
+        );
+        assert_eq!(
+            shared.committed_relay_offset(channel),
+            0,
+            "an offset-mismatched same-second frame must NOT advance"
+        );
+
+        let matching_offset_frame =
+            delivery_with_fence_offset(session, Some(256), 0, same_second, Some(4096));
+        sink.advance_offset_for_confirmed_delegated_terminal(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            session,
+            &matching_offset_frame,
+            Some(&inflight),
+        );
+        assert_eq!(
+            shared.committed_relay_offset(channel),
+            256,
+            "the offset-matching same-second frame DOES advance"
         );
     }
 

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -733,24 +733,26 @@ enum SessionRelayDeliveryOutcome {
 #[async_trait]
 impl RelaySink for SessionBoundDiscordRelaySink {
     async fn deliver(&self, frame: &StreamFrame) -> Result<RelaySinkOutcome, RelaySinkError> {
-        // #3041 P1-3 (codex P1-3 issue 1 R4 — ACK correlation): only a FENCED
-        // (terminal) frame may report a terminal outcome to the relay metrics. A
-        // single physical chunk can carry turn A's result PLUS turn B's COMPLETE
-        // result; the split forwards A on a terminal (fenced) frame and B's tail on
-        // a SEPARATE non-terminal (fence-less) frame. The sink's parser still
-        // delivers B from that tail (so B is never black-holed), but that post is
-        // NOT a terminal commit for THIS frame — the frame carries no fence. If we
-        // bumped `last_terminal_committed_sequence` for the tail (B's higher
-        // sequence N+1), it would MASK turn A's true terminal outcome: A's
-        // terminal-ACK (target = A's seq N) would read `committed >= N` and report
-        // `Delivered` even when A's terminal frame was actually SKIPPED — the
-        // watcher would then suppress its SendFull reconciliation and BLACK-HOLE A.
-        // Gating the terminal outcome on the frame's own fence keeps A's
-        // terminal-ACK bound strictly to A's terminal frame. The deferred duplicate
-        // of B (the watcher's later SendFull re-posts B) is tracked in #3151; it is
-        // never a black-hole (B is delivered) and never a wrong-turn advance (B's
-        // tail has no fence so it cannot advance any offset).
-        let frame_is_terminal = frame.terminal_consumed_end.is_some();
+        // #3041 P1-3 R5 (codex P1-3 — REVERT R4 fence-gating of the terminal
+        // outcome): a RESULT-bearing delivery reports its terminal outcome
+        // (Committed / Skipped) REGARDLESS of whether THIS frame carries a commit
+        // fence (`terminal_consumed_end`). R4 gated the outcome on the fence, which
+        // BROKE the legitimate no-inflight session-bound terminal delivery: that
+        // delivery legitimately has NO fence but IS a real terminal whose ACK must
+        // resolve — under R4 it reported only `FrameAccepted`, so the watcher timed
+        // out, the fallback was suppressed, and the turn was BLACK-HOLED.
+        //
+        // The co-chunked-turn confusion R4 tried to prevent (turn B's fence-less
+        // tail at seq N+1 masking turn A's seq-N outcome) is now handled CORRECTLY
+        // by the per-sequence terminal-ACK (R5): the watcher resolves A's ACK on
+        // outcome[N] (A's own frame), so B's outcome[N+1] no longer touches A —
+        // reverting this gate is safe.
+        //
+        // The commit FENCE still ONLY gates the OFFSET ADVANCE: the advance happens
+        // INLINE in `deliver_response` via `advance_offset_for_confirmed_delegated_terminal`,
+        // which no-ops when `terminal_consumed_end` is None. So "terminal outcome /
+        // ACK marker" (driven by a result-bearing delivery) and "offset advance"
+        // (driven by the fence) are now decoupled.
         let deliveries = self.ingest_frame(frame);
         let mut terminal_committed = false;
         let mut terminal_skipped = false;
@@ -793,14 +795,15 @@ impl RelaySink for SessionBoundDiscordRelaySink {
                 }
             }
         }
-        // Only a FENCED frame may surface a terminal outcome (see above). A
-        // fence-less frame that posted a delivery (e.g. turn B's complete result
-        // riding turn A's trailing tail) reports `FrameAccepted`: the relay records
-        // it as DELIVERED (mirrored) but NOT terminal-committed, so it can never
-        // satisfy another turn's terminal-ACK.
-        if frame_is_terminal && terminal_committed {
+        // #3041 P1-3 R5: a result-bearing delivery surfaces its terminal outcome
+        // for THIS frame's sequence (fence-independent — see the revert note above).
+        // The relay records it keyed by this frame's sequence; the watcher resolves
+        // ITS OWN terminal frame's ACK on its exact sequence, so a co-chunked tail
+        // at a different sequence can never satisfy another turn's terminal-ACK.
+        // A frame that produced no result-bearing delivery reports `FrameAccepted`.
+        if terminal_committed {
             Ok(RelaySinkOutcome::TerminalCommitted)
-        } else if frame_is_terminal && terminal_skipped {
+        } else if terminal_skipped {
             Ok(RelaySinkOutcome::TerminalSkipped)
         } else {
             Ok(RelaySinkOutcome::FrameAccepted)
@@ -2056,17 +2059,17 @@ mod tests {
         assert_eq!(outcome, RelaySinkOutcome::FrameAccepted);
     }
 
-    // #3041 P1-3 (codex P1-3 issue 1 R4 — ACK correlation): a FENCE-LESS
-    // (non-terminal) frame that carries a COMPLETE result (e.g. turn B's result
-    // riding turn A's trailing tail) produces a delivery whose
-    // `terminal_consumed_end` is None — so the identity-gated advance can NEVER
-    // fire for it (the advance requires `Some(end > 0)`), and `deliver` reports a
-    // terminal outcome ONLY when `frame.terminal_consumed_end.is_some()`. Both
-    // guarantee B's tail post can never advance an offset nor satisfy turn A's
-    // terminal-ACK (which would otherwise black-hole A). Driving a real terminal
-    // COMMIT needs Discord HTTP, so we assert the two load-bearing invariants
-    // directly: (a) the fence-less frame is non-terminal, and (b) its delivery
-    // carries no consumed_end.
+    // #3041 P1-3 R5 (codex P1-3 — fence gates the ADVANCE, not the ACK): a
+    // FENCE-LESS frame that carries a COMPLETE result (e.g. turn B's result riding
+    // turn A's trailing tail) produces a delivery whose `terminal_consumed_end` is
+    // None — so the identity-gated OFFSET ADVANCE can NEVER fire for it (the advance
+    // requires `Some(end > 0)`). After the R4 revert, `deliver` DOES surface this
+    // frame's terminal outcome (the no-inflight terminal needs its ACK to resolve),
+    // but that outcome is recorded keyed by THIS frame's own sequence, so it can
+    // never satisfy ANOTHER turn's terminal-ACK (which queries its own sequence).
+    // Driving a real terminal COMMIT needs Discord HTTP, so we assert the
+    // load-bearing offset-advance invariant directly: a fence-less frame's delivery
+    // carries no consumed_end → it can never advance the offset authority.
     #[test]
     fn fenceless_frame_with_complete_result_carries_no_commit_fence() {
         let binding = matched("44");
@@ -2079,7 +2082,7 @@ mod tests {
         let fenceless = frame(&binding, payload, 7);
         assert!(
             fenceless.terminal_consumed_end.is_none(),
-            "precondition: this is a fence-less (non-terminal) frame — `deliver` reports FrameAccepted, never a terminal outcome"
+            "precondition: this is a fence-less frame — its result is still delivered and its ACK still resolves, but it can never ADVANCE the offset"
         );
 
         let deliveries = parser.ingest_frame(&fenceless);
@@ -2090,7 +2093,7 @@ mod tests {
         );
         assert_eq!(
             deliveries[0].terminal_consumed_end, None,
-            "a fence-less frame's delivery carries NO consumed_end → it can never advance the offset authority (no wrong-turn advance, no shared-ACK reuse)"
+            "a fence-less frame's delivery carries NO consumed_end → it can never advance the offset authority (no wrong-turn advance)"
         );
     }
 

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -270,41 +270,74 @@ impl SessionBoundDiscordRelaySink {
         }
     }
 
-    /// #3041 P1-3 (Part a, BLOCKER B1 — the "commit fence"): on a CONFIRMED
-    /// terminal Discord delivery, advance the offset authority
-    /// (`confirmed_end_offset`) to the watcher's AUTHORITATIVE consumed-terminal
-    /// END for the delegated turn (`session_bound_delegated_terminal_end`,
-    /// persisted by the watcher when it delegated this terminal — see
-    /// `tmux_watcher.rs` delegation block). This couples the POST success to the
-    /// offset advance in the SAME path so the watcher's §3.2 reconciliation
-    /// (Part b) sees `committed >= end` and SKIPS its blind re-send (no duplicate)
-    /// even when the terminal-commit ACK lagged the 10s wait.
+    /// #3041 P1-3 (Part a, BLOCKER B1 — the FRAME-CARRIED "commit fence"): on a
+    /// CONFIRMED terminal Discord delivery, advance the offset authority
+    /// (`confirmed_end_offset`) to the producer's AUTHORITATIVE consumed-terminal
+    /// END carried ON the RESULT-bearing `StreamFrame` (`delivery.terminal_consumed_end`),
+    /// NOT a value read back from the inflight FILE. The frame both triggered this
+    /// delivery and carries the commit data, so the POST success and the advance
+    /// are atomic per-frame — no inflight-file read/write race (the old racy
+    /// Part (a) is removed). This couples the POST to the advance in the SAME path
+    /// so the watcher's §3.2 reconciliation (Part b) sees `committed >= end` and
+    /// SKIPS its blind re-send (no duplicate) even when the commit ACK lagged.
+    ///
+    /// IDENTITY GATE (delayed-old-frame / wrong-turn protection): advance ONLY when
+    /// the frame's pinned `(turn_user_msg_id, turn_started_at)` STILL matches the
+    /// channel's CURRENT inflight identity. If a newer/different turn has taken the
+    /// channel (or no inflight remains), a stale terminal frame for the prior turn
+    /// must NOT advance the authority — that would wrongly skip the new turn's
+    /// reconciliation. `inflight` is the inflight loaded for THIS delivery in
+    /// `deliver_response` (loaded once, reused — no second racy re-load).
     ///
     /// DIRECT ADVANCE, not a Sink lease commit: the sink runs UNDER the watcher's
-    /// delegation and is NOT a per-channel `DeliveryLeaseCell` holder (the
-    /// delegation path does not acquire the cell, so there is no lease for the
-    /// sink to commit). The watcher is the byte-range AUTHORITY; the sink advances
-    /// to the watcher's OWN end via `advance_watcher_confirmed_end`'s monotonic CAS
-    /// so it can never regress, double-advance, or overshoot.
+    /// delegation and is NOT a per-channel `DeliveryLeaseCell` holder. The producer
+    /// is the byte-range AUTHORITY; the sink advances to its OWN `end` via
+    /// `advance_watcher_confirmed_end`'s monotonic CAS so it can never regress,
+    /// double-advance, or overshoot.
     ///
     /// NO-BLACK-HOLE: the sink NEVER reads a fresh JSONL EOF (which could include
-    /// later-appended undelivered bytes, codex r4 P1). `delegated_end` is the
-    /// watcher's persisted consumed-terminal end for THIS delivered turn (read off
-    /// the inflight loaded at the START of `deliver_response`, i.e. the turn being
-    /// delivered — NOT a re-load that could pick up a LATER turn's larger end and
-    /// overshoot). When the watcher did not delegate (no field / zero) the sink
-    /// does not advance (the watcher's own delivery path advances instead).
+    /// later-appended undelivered bytes, codex r4 P1). `terminal_consumed_end` is
+    /// the producer's exact consumed-terminal end for THIS delivered turn. When the
+    /// producer did not delegate a terminal end on this frame (None / zero) the
+    /// sink does not advance (the watcher's own delivery path advances instead).
     fn advance_offset_for_confirmed_delegated_terminal(
         &self,
         shared: &super::SharedData,
         provider: &ProviderKind,
         channel_id: u64,
         session_name: &str,
-        delegated_end: Option<u64>,
+        delivery: &SessionRelayDelivery,
+        inflight: Option<&super::inflight::InflightTurnState>,
     ) {
-        let Some(end) = delegated_end.filter(|end| *end > 0) else {
+        let Some(end) = delivery.terminal_consumed_end.filter(|end| *end > 0) else {
             return;
         };
+        // IDENTITY GATE: the frame's pinned turn identity must still match the
+        // channel's current inflight. A delayed frame from an already-replaced
+        // turn (or a cleared inflight) is ignored — never advances a wrong turn.
+        let Some(inflight) = inflight else {
+            tracing::debug!(
+                provider = provider.as_str(),
+                channel = channel_id,
+                tmux_session = %session_name,
+                frame_user_msg_id = delivery.frame_turn_user_msg_id,
+                "session-bound sink: terminal frame carried a commit fence but inflight is gone; identity gate blocks advance"
+            );
+            return;
+        };
+        let identity_matches = inflight.user_msg_id == delivery.frame_turn_user_msg_id
+            && inflight.started_at == delivery.frame_turn_started_at;
+        if !identity_matches {
+            tracing::debug!(
+                provider = provider.as_str(),
+                channel = channel_id,
+                tmux_session = %session_name,
+                frame_user_msg_id = delivery.frame_turn_user_msg_id,
+                inflight_user_msg_id = inflight.user_msg_id,
+                "session-bound sink: terminal frame identity != current inflight; identity gate blocks advance (delayed/wrong-turn frame)"
+            );
+            return;
+        }
         super::tmux::advance_watcher_confirmed_end(
             shared,
             provider,
@@ -320,16 +353,13 @@ impl SessionBoundDiscordRelaySink {
         delivery: SessionRelayDelivery,
     ) -> Result<SessionRelayDeliveryOutcome, RelaySinkError> {
         let channel_id = delivery.channel_id;
-        let provider = delivery.provider;
+        let provider = delivery.provider.clone();
         let inflight = super::inflight::load_inflight_state(&provider, channel_id);
-        // #3041 P1-3 (Part a, B1): the watcher's authoritative consumed-terminal
-        // END for the turn it delegated to this sink, captured from the inflight
-        // loaded for THIS delivery (the turn being delivered) so a confirmed POST
-        // can advance the offset authority to it without re-reading a later turn's
-        // larger end (which would overshoot — black-hole).
-        let delegated_terminal_end = inflight
-            .as_ref()
-            .and_then(|state| state.session_bound_delegated_terminal_end);
+        // #3041 P1-3 (Part a, B1 — frame-carried): the producer's authoritative
+        // consumed-terminal END now rides on the RESULT-bearing frame
+        // (`delivery.terminal_consumed_end`), NOT read back from the inflight FILE
+        // (the racy old Part (a) is removed). The `inflight` loaded here is reused
+        // for the IDENTITY GATE in `advance_offset_for_confirmed_delegated_terminal`.
         let trace = session_relay_trace_context(
             &provider,
             channel_id,
@@ -455,7 +485,8 @@ impl SessionBoundDiscordRelaySink {
                     &provider,
                     channel_id,
                     &delivery.session_name,
-                    delegated_terminal_end,
+                    &delivery,
+                    inflight.as_ref(),
                 );
                 return Ok(SessionRelayDeliveryOutcome::Committed);
             }
@@ -508,7 +539,8 @@ impl SessionBoundDiscordRelaySink {
                         &provider,
                         channel_id,
                         &delivery.session_name,
-                        delegated_terminal_end,
+                        &delivery,
+                        inflight.as_ref(),
                     );
                     Ok(SessionRelayDeliveryOutcome::Committed)
                 }
@@ -561,7 +593,8 @@ impl SessionBoundDiscordRelaySink {
                         &provider,
                         channel_id,
                         &delivery.session_name,
-                        delegated_terminal_end,
+                        &delivery,
+                        inflight.as_ref(),
                     );
                     Ok(SessionRelayDeliveryOutcome::Committed)
                 }
@@ -629,7 +662,8 @@ impl SessionBoundDiscordRelaySink {
                 &provider,
                 channel_id,
                 &delivery.session_name,
-                delegated_terminal_end,
+                &delivery,
+                inflight.as_ref(),
             );
             Ok(SessionRelayDeliveryOutcome::Committed)
         }
@@ -653,24 +687,27 @@ impl RelaySink for SessionBoundDiscordRelaySink {
             match self.deliver_response(delivery).await {
                 Ok(SessionRelayDeliveryOutcome::Committed) => {
                     terminal_committed = true;
-                    // #3041 P1-3 (Part a, BLOCKER B1 CLOSED): the offset advance
-                    // for a confirmed terminal delivery now happens INLINE inside
-                    // `deliver_response` (the commit fence:
-                    // `advance_offset_for_confirmed_delegated_terminal`), coupled
-                    // to the POST success in the SAME path. It advances
-                    // `confirmed_end_offset` to the WATCHER's authoritative
-                    // consumed-terminal end (`session_bound_delegated_terminal_end`,
-                    // persisted on the inflight by the watcher when it delegated
-                    // this terminal), NOT a fresh JSONL EOF — so it can never
-                    // overshoot into later-appended undelivered bytes (the codex
-                    // r4 P1 black-hole) and is a monotonic, idempotent CAS.
+                    // #3041 P1-3 (Part a, BLOCKER B1 CLOSED — FRAME-CARRIED): the
+                    // offset advance for a confirmed terminal delivery happens INLINE
+                    // inside `deliver_response` (the commit fence:
+                    // `advance_offset_for_confirmed_delegated_terminal`), coupled to
+                    // the POST success in the SAME path. It advances
+                    // `confirmed_end_offset` to the producer's authoritative
+                    // consumed-terminal end carried ON the RESULT-bearing frame
+                    // (`delivery.terminal_consumed_end`), NOT a value read back from
+                    // the inflight FILE (the racy old Part a is removed) and NOT a
+                    // fresh JSONL EOF — so it can never overshoot into later-appended
+                    // undelivered bytes (the codex r4 P1 black-hole) and is a
+                    // monotonic, idempotent CAS. The advance is IDENTITY-GATED: it
+                    // only fires when the frame's pinned turn identity still matches
+                    // the channel's current inflight (delayed/wrong-turn protection).
                     //
-                    // This closes the prior EXACT-ONCE GAP: if the sink posts
-                    // BEFORE the watcher's terminal-commit ACK lands (or that ACK
-                    // lags the watcher's 10s wait), the authority is now ADVANCED
-                    // by the sink, so the watcher's §3.2 reconciliation (P1-3 Part
-                    // b) sees `committed >= end` and SKIPS its re-send (no
-                    // duplicate). When the watcher did NOT delegate (no field), the
+                    // This closes the prior EXACT-ONCE GAP: if the sink posts BEFORE
+                    // the watcher's terminal-commit ACK lands (or that ACK lags the
+                    // watcher's 10s wait), the authority is now ADVANCED by the sink,
+                    // so the watcher's §3.2 reconciliation (P1-3 Part b) sees
+                    // `committed >= end` and SKIPS its re-send (no duplicate). When
+                    // the producer did NOT delegate (no fence on the frame), the
                     // watcher's OWN delivery path advances the authority instead.
                     self.finish_terminal_candidate(&session_name);
                 }
@@ -1191,6 +1228,14 @@ impl SessionRelayParser {
                     session_name: frame.session_name.clone(),
                     response_text: self.full_response.clone(),
                     task_notification_kind: self.task_notification_kind,
+                    // #3041 P1-3 (Part a, B1): the RESULT-bearing frame both
+                    // accumulated the final `result` AND carries the producer's
+                    // commit fence. The sink emits the delivery on THIS ingest,
+                    // so copying the frame's commit data here keeps the POST and
+                    // the identity-gated offset advance atomic per-frame.
+                    terminal_consumed_end: frame.terminal_consumed_end,
+                    frame_turn_user_msg_id: frame.turn_user_msg_id,
+                    frame_turn_started_at: frame.turn_started_at.clone(),
                 });
                 break;
             } else {
@@ -1220,6 +1265,18 @@ struct SessionRelayDelivery {
     session_name: String,
     response_text: String,
     task_notification_kind: Option<TaskNotificationKind>,
+    /// #3041 P1-3 (Part a, B1 — frame-carried commit fence): the producer's
+    /// AUTHORITATIVE consumed-terminal END, carried on the RESULT-bearing frame
+    /// that triggered THIS delivery. `None` if the producer did not delegate a
+    /// terminal end on this frame (legacy / watcher-owned path). On a CONFIRMED
+    /// delivery the sink advances `confirmed_end_offset` to this value, gated by
+    /// the carried turn identity matching the channel's current inflight.
+    terminal_consumed_end: Option<u64>,
+    /// Pinned turn identity (`user_msg_id`, `started_at`) of the inflight the
+    /// producer delegated. The sink's IDENTITY GATE compares it to the channel's
+    /// current inflight before advancing — a delayed/wrong-turn frame is ignored.
+    frame_turn_user_msg_id: u64,
+    frame_turn_started_at: String,
 }
 
 fn ssh_direct_prompt_anchor_for_response(
@@ -1296,6 +1353,28 @@ mod tests {
             binding: binding.clone(),
             payload: payload.to_string(),
             sequence,
+            terminal_consumed_end: None,
+            turn_user_msg_id: 0,
+            turn_started_at: String::new(),
+        }
+    }
+
+    fn terminal_frame(
+        binding: &MatchedChannel,
+        payload: &str,
+        sequence: u64,
+        consumed_end: u64,
+        turn_user_msg_id: u64,
+        turn_started_at: &str,
+    ) -> StreamFrame {
+        StreamFrame {
+            session_name: binding.expected_session_name.clone(),
+            binding: binding.clone(),
+            payload: payload.to_string(),
+            sequence,
+            terminal_consumed_end: Some(consumed_end),
+            turn_user_msg_id,
+            turn_started_at: turn_started_at.to_string(),
         }
     }
 
@@ -1869,35 +1948,82 @@ mod tests {
         assert_eq!(outcome, RelaySinkOutcome::FrameAccepted);
     }
 
-    // #3041 P1-3 (Part a, BLOCKER B1): when the sink CONFIRMS a terminal delivery,
-    // it advances `committed_relay_offset` to the watcher's authoritative
-    // consumed-terminal END (persisted on the inflight as
-    // `session_bound_delegated_terminal_end`). This is the B1 "commit fence": the
-    // POST success and the offset advance are coupled, so the watcher's §3.2
-    // reconciliation (Part b) sees the delegated range as delivered even if the
-    // terminal-commit ACK lags.
+    fn delivery_with_fence(
+        session_name: &str,
+        consumed_end: Option<u64>,
+        turn_user_msg_id: u64,
+        turn_started_at: &str,
+    ) -> SessionRelayDelivery {
+        SessionRelayDelivery {
+            provider: ProviderKind::Claude,
+            channel_id: 8_041,
+            session_name: session_name.to_string(),
+            response_text: "answer".to_string(),
+            task_notification_kind: None,
+            terminal_consumed_end: consumed_end,
+            frame_turn_user_msg_id: turn_user_msg_id,
+            frame_turn_started_at: turn_started_at.to_string(),
+        }
+    }
+
+    fn inflight_with_identity(
+        channel_id: u64,
+        session_name: &str,
+        user_msg_id: u64,
+        started_at: &str,
+    ) -> super::super::inflight::InflightTurnState {
+        let mut state = super::super::inflight::InflightTurnState::new(
+            ProviderKind::Claude,
+            channel_id,
+            None,
+            1,
+            user_msg_id,
+            0,
+            "hi".to_string(),
+            None,
+            Some(session_name.to_string()),
+            None,
+            None,
+            0,
+        );
+        state.started_at = started_at.to_string();
+        state
+    }
+
+    // #3041 P1-3 (Part a, BLOCKER B1 — FRAME-CARRIED): when the sink CONFIRMS a
+    // terminal delivery, it advances `committed_relay_offset` to the producer's
+    // authoritative consumed-terminal END carried ON the RESULT-bearing frame
+    // (`SessionRelayDelivery::terminal_consumed_end`), identity-gated against the
+    // channel's CURRENT inflight. This is the B1 "commit fence": the POST success
+    // and the offset advance are coupled per-frame (no inflight-file read race), so
+    // the watcher's §3.2 reconciliation (Part b) sees the delegated range as
+    // delivered even if the terminal-commit ACK lags.
     #[tokio::test]
-    async fn sink_confirmed_delivery_advances_committed_offset_to_delegated_end() {
+    async fn sink_confirmed_delivery_advances_committed_offset_to_frame_end() {
         let shared = super::super::make_shared_data_for_tests();
         let channel = ChannelId::new(8_041);
+        let session = "AgentDesk-claude-8041";
         let sink = SessionBoundDiscordRelaySink::new(Arc::new(HealthRegistry::new()));
+        // The channel's current inflight identity the frame must match to advance.
+        let inflight = inflight_with_identity(channel.get(), session, 0, "2026-06-04T00:00:00Z");
 
         // Before any delivery the authority is at 0.
         assert_eq!(shared.committed_relay_offset(channel), 0);
 
-        // A confirmed sink delivery for the watcher-delegated range `[0, 256)`:
-        // the watcher persisted end=256, so the sink advances the authority to it.
+        // A confirmed sink delivery for the producer-delegated range `[0, 256)`:
+        // the frame carries end=256 + the matching identity, so the sink advances.
         sink.advance_offset_for_confirmed_delegated_terminal(
             &shared,
             &ProviderKind::Claude,
             channel.get(),
-            "AgentDesk-claude-8041",
-            Some(256),
+            session,
+            &delivery_with_fence(session, Some(256), 0, "2026-06-04T00:00:00Z"),
+            Some(&inflight),
         );
         assert_eq!(
             shared.committed_relay_offset(channel),
             256,
-            "a confirmed sink delivery must advance committed_relay_offset to the delegated end (B1 close)"
+            "a confirmed sink delivery must advance committed_relay_offset to the frame end (B1 close)"
         );
 
         // Idempotent / no double-advance: re-confirming the SAME range is a
@@ -1906,26 +2032,29 @@ mod tests {
             &shared,
             &ProviderKind::Claude,
             channel.get(),
-            "AgentDesk-claude-8041",
-            Some(256),
+            session,
+            &delivery_with_fence(session, Some(256), 0, "2026-06-04T00:00:00Z"),
+            Some(&inflight),
         );
         assert_eq!(shared.committed_relay_offset(channel), 256);
 
-        // When the watcher did NOT delegate a range (None / zero end), the sink
+        // When the producer did NOT delegate a range (None / zero end), the sink
         // does NOT advance — the watcher's own delivery path owns the advance.
         sink.advance_offset_for_confirmed_delegated_terminal(
             &shared,
             &ProviderKind::Claude,
             channel.get(),
-            "AgentDesk-claude-8041",
-            None,
+            session,
+            &delivery_with_fence(session, None, 0, "2026-06-04T00:00:00Z"),
+            Some(&inflight),
         );
         sink.advance_offset_for_confirmed_delegated_terminal(
             &shared,
             &ProviderKind::Claude,
             channel.get(),
-            "AgentDesk-claude-8041",
-            Some(0),
+            session,
+            &delivery_with_fence(session, Some(0), 0, "2026-06-04T00:00:00Z"),
+            Some(&inflight),
         );
         assert_eq!(
             shared.committed_relay_offset(channel),
@@ -1939,8 +2068,9 @@ mod tests {
             &shared,
             &ProviderKind::Claude,
             channel.get(),
-            "AgentDesk-claude-8041",
-            Some(128),
+            session,
+            &delivery_with_fence(session, Some(128), 0, "2026-06-04T00:00:00Z"),
+            Some(&inflight),
         );
         assert_eq!(
             shared.committed_relay_offset(channel),
@@ -1951,10 +2081,130 @@ mod tests {
             &shared,
             &ProviderKind::Claude,
             channel.get(),
-            "AgentDesk-claude-8041",
-            Some(512),
+            session,
+            &delivery_with_fence(session, Some(512), 0, "2026-06-04T00:00:00Z"),
+            Some(&inflight),
         );
         assert_eq!(shared.committed_relay_offset(channel), 512);
+    }
+
+    // #3041 P1-3 (Part a, B1 — IDENTITY GATE): a terminal frame whose pinned turn
+    // identity does NOT match the channel's current inflight (a delayed/old frame,
+    // or a newer turn already on the channel, or no inflight at all) must NOT
+    // advance the authority — that would wrongly skip the new turn's reconciliation.
+    #[tokio::test]
+    async fn sink_identity_gate_blocks_advance_on_wrong_turn() {
+        let shared = super::super::make_shared_data_for_tests();
+        let channel = ChannelId::new(8_041);
+        let session = "AgentDesk-claude-8041";
+        let sink = SessionBoundDiscordRelaySink::new(Arc::new(HealthRegistry::new()));
+
+        // Current inflight is turn started_at=NEW; the frame carries the OLD turn's
+        // identity (same user_msg_id=0 external-input, different started_at).
+        let current_inflight =
+            inflight_with_identity(channel.get(), session, 0, "2026-06-04T00:00:09Z");
+        let stale_frame = delivery_with_fence(session, Some(256), 0, "2026-06-04T00:00:00Z");
+
+        sink.advance_offset_for_confirmed_delegated_terminal(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            session,
+            &stale_frame,
+            Some(&current_inflight),
+        );
+        assert_eq!(
+            shared.committed_relay_offset(channel),
+            0,
+            "a stale/wrong-turn terminal frame must NOT advance the authority (identity gate)"
+        );
+
+        // No inflight at all (cleared by stop/cancel) → also no advance.
+        sink.advance_offset_for_confirmed_delegated_terminal(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            session,
+            &stale_frame,
+            None,
+        );
+        assert_eq!(
+            shared.committed_relay_offset(channel),
+            0,
+            "a terminal frame with no current inflight must NOT advance (identity gate)"
+        );
+
+        // Different user_msg_id (a managed turn replaced the external-input turn)
+        // → no advance even if started_at coincidentally matched.
+        let replaced_inflight =
+            inflight_with_identity(channel.get(), session, 999, "2026-06-04T00:00:00Z");
+        sink.advance_offset_for_confirmed_delegated_terminal(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            session,
+            &stale_frame,
+            Some(&replaced_inflight),
+        );
+        assert_eq!(
+            shared.committed_relay_offset(channel),
+            0,
+            "a frame whose user_msg_id != current inflight must NOT advance (identity gate)"
+        );
+
+        // Sanity: the SAME identity DOES advance, proving the gate isn't blocking
+        // everything.
+        let matching_inflight =
+            inflight_with_identity(channel.get(), session, 0, "2026-06-04T00:00:00Z");
+        sink.advance_offset_for_confirmed_delegated_terminal(
+            &shared,
+            &ProviderKind::Claude,
+            channel.get(),
+            session,
+            &stale_frame,
+            Some(&matching_inflight),
+        );
+        assert_eq!(
+            shared.committed_relay_offset(channel),
+            256,
+            "a matching-identity terminal frame DOES advance the authority"
+        );
+    }
+
+    // #3041 P1-3 (Part a, B1): the RESULT-bearing terminal frame's commit fence
+    // (consumed_end + identity) is copied onto the emitted `SessionRelayDelivery`,
+    // so `deliver_response` advances the authority from frame data — not an inflight
+    // file read. A non-terminal frame's delivery (none here) would carry None/0.
+    #[test]
+    fn parser_propagates_terminal_frame_commit_fence_onto_delivery() {
+        let binding = matched("46");
+        let mut parser = SessionRelayParser::default();
+        // A non-terminal text frame: accumulates, emits nothing.
+        let assistant = "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"final answer\"}]}}\n";
+        assert!(
+            parser
+                .ingest_frame(&frame(&binding, assistant, 1))
+                .is_empty()
+        );
+        // The result-bearing TERMINAL frame carries the commit fence.
+        let result = "{\"type\":\"result\",\"result\":\"final answer\"}\n";
+        let deliveries = parser.ingest_frame(&terminal_frame(
+            &binding,
+            result,
+            2,
+            512,
+            77,
+            "2026-06-04T00:00:00Z",
+        ));
+        assert_eq!(deliveries.len(), 1);
+        assert_eq!(deliveries[0].response_text, "final answer");
+        assert_eq!(
+            deliveries[0].terminal_consumed_end,
+            Some(512),
+            "the delivery must carry the terminal frame's consumed_end"
+        );
+        assert_eq!(deliveries[0].frame_turn_user_msg_id, 77);
+        assert_eq!(deliveries[0].frame_turn_started_at, "2026-06-04T00:00:00Z");
     }
 
     #[test]

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1674,6 +1674,16 @@ mod pane_dead_identity_tests {
 struct SessionBoundRelayAckTarget {
     metrics: std::sync::Arc<crate::services::cluster::stream_relay::RelayMetrics>,
     sequence: u64,
+    /// #3041 P1-3 (codex P1-3 R6): the `turn_start_offset` of the turn this ACK
+    /// target belongs to — taken from the terminal frame's commit fence (the ONLY
+    /// frame that yields an ack target). The watcher's per-turn forward carries the
+    /// stored ack forward ONLY when it belongs to the turn currently being
+    /// ACK-waited (same `turn_start_offset`); a stale ack from a FINISHED/DIFFERENT
+    /// turn is reset to `None` so a new turn never inherits a previous turn's
+    /// terminal sequence (no false-Delivered black-hole). `None` means the fence
+    /// carried no `turn_start_offset` (legacy / no pinned identity) — treated as
+    /// "no turn binding", so it is never reused across a turn boundary.
+    turn_start_offset: Option<u64>,
 }
 
 #[derive(Clone)]
@@ -1695,6 +1705,57 @@ impl SupervisorRelayForward {
             mirrored: false,
             ack_target: None,
         }
+    }
+}
+
+/// #3041 P1-3 (codex P1-3 R6): turn-scope the session-bound terminal ACK target so
+/// a NEW turn never inherits a FINISHED turn's stale ack.
+///
+/// The watcher carries `all_data_session_bound_relay_ack` across `'watcher_loop`
+/// passes (it is reset only at explicit turn-finalize/suppress sites). A single
+/// physical chunk can hold `result(A) + assistant(B) + result(B)`: turn A rides a
+/// terminal frame (ack = A.seq), and turn B completes ENTIRELY inside the split
+/// tail whose non-terminal frame sequence is DISCARDED. On the next pass B is
+/// processed from the leftover buffer; if no fresh bytes arrive the deferred
+/// forward emits no frame and returns NO ack target. With the legacy "store only
+/// when `Some`" rule the stored ack would stay pinned to A's sequence, and A's
+/// `Delivered` outcome would then FALSELY satisfy B's ACK → B black-holed.
+///
+/// This decides the ack target the watcher keeps for the turn whose pinned
+/// identity offset is `current_turn_start_offset` — the SAME coordinate the
+/// terminal fence stamps onto the ack target (`InflightTurnIdentity.turn_start_offset`,
+/// the inflight-recorded JSONL offset at which the turn began, monotonic per turn),
+/// NOT the watcher's per-pass buffer `turn_data_start_offset`:
+///   * `fresh` is `Some` → THIS pass just forwarded a terminal frame for the
+///     current turn; adopt it (a turn whose terminal frame WAS forwarded with a
+///     real ack keeps it).
+///   * `fresh` is `None` → keep `stored` ONLY when it belongs to the SAME turn
+///     (`stored.turn_start_offset == current_turn_start_offset`, and both `Some`),
+///     so an ack legitimately set earlier in THIS turn survives a later
+///     non-terminal pass. A `stored` from a DIFFERENT/finished turn — or either
+///     side lacking a turn binding (`None`) — is dropped to `None`. A `None` ack
+///     target makes `wait_for_session_bound_relay_delivery_ack` return
+///     `MissingTarget` (NOT `Delivered`), so the watcher falls through to the §3.2
+///     reconciliation against `committed_relay_offset` (committed >= end → Skip;
+///     committed < end → SendFull) → the turn is re-sent at worst (possible
+///     duplicate), NEVER black-holed.
+fn carry_session_bound_ack_for_turn(
+    stored: Option<SessionBoundRelayAckTarget>,
+    fresh: Option<SessionBoundRelayAckTarget>,
+    current_turn_start_offset: Option<u64>,
+) -> Option<SessionBoundRelayAckTarget> {
+    if let Some(fresh) = fresh {
+        return Some(fresh);
+    }
+    match (stored, current_turn_start_offset) {
+        // Same turn (both bound to the same pinned `turn_start_offset`): an ack set
+        // earlier in THIS turn survives a later non-terminal pass.
+        (Some(ack), Some(current)) if ack.turn_start_offset == Some(current) => Some(ack),
+        // A stale ack from a finished/different turn — or any case where the turn
+        // binding is unknown on either side — is never consulted: reset to `None`
+        // so the new turn reconciles instead of satisfying its ACK against the
+        // previous turn's sequence.
+        _ => None,
     }
 }
 
@@ -1948,6 +2009,12 @@ fn forward_chunk_to_supervisor_relay_inner(
     // file reads is forwarded after the next read completes it instead of being
     // replaced with U+FFFD.
     let payload = chunk.to_string();
+    // #3041 P1-3 R6: capture the terminal frame's `turn_start_offset` BEFORE the
+    // fence is moved into the send so the resulting ack target can be turn-scoped
+    // (a stored ack is reused across a watcher pass ONLY when it belongs to the
+    // turn now being ACK-waited). A non-terminal frame has no fence → no ack
+    // target is produced (the `outcome.sequence.map` below yields `None`).
+    let ack_turn_start_offset = terminal.as_ref().and_then(|fence| fence.turn_start_offset);
     let outcome = match terminal {
         Some(fence) => producer.try_send_terminal_frame_with_sequence(payload, fence),
         None => producer.try_send_frame_with_sequence(payload),
@@ -1965,6 +2032,7 @@ fn forward_chunk_to_supervisor_relay_inner(
         ack_target: outcome.sequence.map(|sequence| SessionBoundRelayAckTarget {
             metrics: producer.metrics().clone(),
             sequence,
+            turn_start_offset: ack_turn_start_offset,
         }),
     }
 }
@@ -3166,6 +3234,7 @@ mod matched_session_jsonl_gate_tests {
         let target = SessionBoundRelayAckTarget {
             metrics: metrics.clone(),
             sequence: 7,
+            turn_start_offset: None,
         };
         assert_eq!(
             wait_for_session_bound_relay_delivery_ack(
@@ -3187,6 +3256,7 @@ mod matched_session_jsonl_gate_tests {
         let dropped_target = SessionBoundRelayAckTarget {
             metrics: dropped_metrics.clone(),
             sequence: 9,
+            turn_start_offset: None,
         };
         dropped_metrics.record_dropped_sequence_for_test(9);
         assert_eq!(
@@ -3199,6 +3269,7 @@ mod matched_session_jsonl_gate_tests {
         let skipped_target = SessionBoundRelayAckTarget {
             metrics: skipped_metrics.clone(),
             sequence: 11,
+            turn_start_offset: None,
         };
         skipped_metrics.record_terminal_skipped_sequence_for_test(11);
         assert_eq!(
@@ -3211,6 +3282,7 @@ mod matched_session_jsonl_gate_tests {
         let delivered_target = SessionBoundRelayAckTarget {
             metrics: delivered_metrics.clone(),
             sequence: 3,
+            turn_start_offset: None,
         };
         delivered_metrics.record_delivered_sequence_for_test(3);
         assert_eq!(
@@ -3255,6 +3327,7 @@ mod matched_session_jsonl_gate_tests {
         let a_target = SessionBoundRelayAckTarget {
             metrics: metrics.clone(),
             sequence: 5,
+            turn_start_offset: None,
         };
         assert_eq!(
             session_bound_relay_ack_snapshot_outcome(Some(&a_target)),
@@ -3265,12 +3338,108 @@ mod matched_session_jsonl_gate_tests {
         let b_target = SessionBoundRelayAckTarget {
             metrics: metrics.clone(),
             sequence: 6,
+            turn_start_offset: None,
         };
         assert_eq!(
             session_bound_relay_ack_snapshot_outcome(Some(&b_target)),
             Some(SessionBoundRelayAckOutcome::Delivered),
             "B's ACK reads its own seq-6 committed outcome"
         );
+    }
+
+    // #3041 P1-3 R6: a single physical chunk holds `result(A) + assistant(B) +
+    // result(B)`. Turn A rides a TERMINAL frame (ack = A.seq, bound to A's pinned
+    // `turn_start_offset`); turn B completes ENTIRELY inside the split tail whose
+    // non-terminal frame sequence is DISCARDED. On B's processing pass the deferred
+    // forward emits NO frame (the leftover decoded text is empty) → NO fresh ack.
+    // B must NOT inherit A's stale ack: with B's own pinned identity, the carry
+    // helper resets the stored ack to `None` so B reconciles (None → MissingTarget
+    // → §3.2 committed-offset reconcile → SendFull/Skip) and is NEVER black-holed,
+    // even though A reported Delivered on A's own sequence.
+    #[test]
+    fn new_turn_does_not_inherit_finished_turn_stale_ack_target() {
+        let metrics =
+            std::sync::Arc::new(crate::services::cluster::stream_relay::RelayMetrics::default());
+        // A's terminal frame (seq 5) bound to A's pinned turn_start_offset = 100.
+        let a_ack = SessionBoundRelayAckTarget {
+            metrics: metrics.clone(),
+            sequence: 5,
+            turn_start_offset: Some(100),
+        };
+
+        // B's processing pass: pinned identity is B's turn (turn_start_offset = 240,
+        // the leftover/result(B) range), and the deferred forward produced NO fresh
+        // ack (B's tail frame sequence was discarded). The stored ack still holds
+        // A's seq-5 target. Carrying it forward for B must RESET to None.
+        let carried = carry_session_bound_ack_for_turn(Some(a_ack.clone()), None, Some(240));
+        assert!(
+            carried.is_none(),
+            "a NEW turn (different pinned turn_start_offset) with no fresh ack must \
+             NOT inherit the finished turn's stale ack_target → reconcile, no black-hole"
+        );
+
+        // Sanity: the same turn (A's own later non-terminal pass) keeps A's ack so a
+        // legitimately-set terminal ack is not clobbered within the SAME turn.
+        let same_turn = carry_session_bound_ack_for_turn(Some(a_ack.clone()), None, Some(100));
+        assert_eq!(
+            same_turn.map(|ack| ack.sequence),
+            Some(5),
+            "an ack set earlier in THIS turn survives a later non-terminal pass"
+        );
+    }
+
+    // #3041 P1-3 R6 (turn-boundary): a fresh turn with no terminal ack does not
+    // inherit the prior turn's ack_target, and a fresh `Some` always wins (the
+    // current turn's terminal frame ack replaces any stored value).
+    #[test]
+    fn carry_session_bound_ack_for_turn_is_turn_scoped() {
+        let metrics =
+            std::sync::Arc::new(crate::services::cluster::stream_relay::RelayMetrics::default());
+        let prior = SessionBoundRelayAckTarget {
+            metrics: metrics.clone(),
+            sequence: 11,
+            turn_start_offset: Some(50),
+        };
+        let fresh = SessionBoundRelayAckTarget {
+            metrics: metrics.clone(),
+            sequence: 12,
+            turn_start_offset: Some(80),
+        };
+
+        // Fresh Some always adopted (THIS turn forwarded a real terminal frame).
+        assert_eq!(
+            carry_session_bound_ack_for_turn(Some(prior.clone()), Some(fresh.clone()), Some(80))
+                .map(|ack| ack.sequence),
+            Some(12),
+            "a fresh terminal-frame ack for the current turn replaces the stored value"
+        );
+
+        // No fresh ack + different turn → reset (never inherit).
+        assert!(
+            carry_session_bound_ack_for_turn(Some(prior.clone()), None, Some(80)).is_none(),
+            "a fresh turn with no terminal ack does not inherit the prior turn's ack_target"
+        );
+
+        // No fresh ack + unknown current turn binding → reset (defensive: never
+        // reuse an ack we cannot prove belongs to the current turn).
+        assert!(
+            carry_session_bound_ack_for_turn(Some(prior.clone()), None, None).is_none(),
+            "an ack is not reused when the current turn's pinned offset is unknown"
+        );
+
+        // No fresh ack + stored ack with no turn binding → reset.
+        let unbound = SessionBoundRelayAckTarget {
+            metrics: metrics.clone(),
+            sequence: 13,
+            turn_start_offset: None,
+        };
+        assert!(
+            carry_session_bound_ack_for_turn(Some(unbound), None, Some(50)).is_none(),
+            "an ack lacking a turn binding is never carried across a pass"
+        );
+
+        // Nothing stored, nothing fresh → None.
+        assert!(carry_session_bound_ack_for_turn(None, None, Some(50)).is_none());
     }
 
     // #3041 P1-3 R5: a target sequence that was never terminally resolved (dropped
@@ -3286,6 +3455,7 @@ mod matched_session_jsonl_gate_tests {
         let target = SessionBoundRelayAckTarget {
             metrics: metrics.clone(),
             sequence: 42,
+            turn_start_offset: None,
         };
         assert_eq!(
             session_bound_relay_ack_snapshot_outcome(Some(&target)),
@@ -4893,9 +5063,20 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 &mut cached_relay_producer,
             ),
         };
-        if let Some(ack_target) = data_mirrored_to_session_relay.ack_target.clone() {
-            all_data_session_bound_relay_ack = Some(ack_target);
-        }
+        // #3041 P1-3 R6: turn-scope the carried ack target. A fresh `Some` (THIS
+        // turn forwarded a terminal frame) replaces it; a `None` keeps the stored
+        // ack ONLY when it belongs to THIS turn (`turn_data_start_offset`), so a new
+        // turn processed from leftover bytes never inherits a finished turn's stale
+        // ACK (which would let the prior turn's `Delivered` falsely satisfy this
+        // turn → black-hole). A reset-to-`None` makes this turn reconcile against
+        // the committed offset instead of waiting on a foreign sequence.
+        all_data_session_bound_relay_ack = carry_session_bound_ack_for_turn(
+            all_data_session_bound_relay_ack.take(),
+            data_mirrored_to_session_relay.ack_target.clone(),
+            turn_identity_for_panel
+                .as_ref()
+                .and_then(|identity| identity.turn_start_offset),
+        );
         if initial_buffer_was_empty {
             all_data_fully_mirrored_to_session_relay = data_mirrored_to_session_relay.mirrored;
         } else {
@@ -5140,9 +5321,18 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                                 &mut cached_relay_producer,
                             ),
                         };
-                        if let Some(ack_target) = chunk_forwarded_to_session_relay.ack_target {
-                            all_data_session_bound_relay_ack = Some(ack_target);
-                        }
+                        // #3041 P1-3 R6: turn-scope the carried ack target (see the
+                        // initial-parse site above). A fresh terminal frame's ack
+                        // replaces it; a non-terminal pass keeps the stored ack ONLY
+                        // when it belongs to THIS turn (`turn_data_start_offset`), so
+                        // a later turn never inherits a finished turn's stale ACK.
+                        all_data_session_bound_relay_ack = carry_session_bound_ack_for_turn(
+                            all_data_session_bound_relay_ack.take(),
+                            chunk_forwarded_to_session_relay.ack_target.clone(),
+                            turn_identity_for_panel
+                                .as_ref()
+                                .and_then(|identity| identity.turn_start_offset),
+                        );
                         let chunk_mirrored_to_session_relay =
                             chunk_forwarded_to_session_relay.mirrored;
                         session_bound_relay_turn_fully_mirrored &= chunk_mirrored_to_session_relay;

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1791,6 +1791,49 @@ fn forward_chunk_to_supervisor_relay(
     >,
     cached_producer: &mut Option<crate::services::cluster::stream_relay::RelayProducer>,
 ) -> SupervisorRelayForward {
+    forward_chunk_to_supervisor_relay_inner(
+        tmux_session_name,
+        chunk,
+        registry,
+        cached_producer,
+        None,
+    )
+}
+
+/// #3041 P1-3 (Part a, B1): forward the RESULT-bearing chunk as a TERMINAL frame
+/// carrying the commit fence (`terminal.consumed_end` + the pinned turn identity).
+/// Every non-terminal chunk goes through `forward_chunk_to_supervisor_relay` with
+/// no fence (unchanged behaviour). Only the result-bearing chunk — detected AFTER
+/// `process_watcher_lines` sets `found_result` — uses this so the commit data rides
+/// the exact frame that triggers the sink's terminal delivery (FIFO single-task: a
+/// separate later frame would arrive after the delivery already dispatched).
+fn forward_terminal_chunk_to_supervisor_relay(
+    tmux_session_name: &str,
+    chunk: &str,
+    registry: &std::sync::Arc<
+        crate::services::cluster::relay_producer_registry::RelayProducerRegistry,
+    >,
+    cached_producer: &mut Option<crate::services::cluster::stream_relay::RelayProducer>,
+    terminal: crate::services::cluster::stream_relay::TerminalCommitFence,
+) -> SupervisorRelayForward {
+    forward_chunk_to_supervisor_relay_inner(
+        tmux_session_name,
+        chunk,
+        registry,
+        cached_producer,
+        Some(terminal),
+    )
+}
+
+fn forward_chunk_to_supervisor_relay_inner(
+    tmux_session_name: &str,
+    chunk: &str,
+    registry: &std::sync::Arc<
+        crate::services::cluster::relay_producer_registry::RelayProducerRegistry,
+    >,
+    cached_producer: &mut Option<crate::services::cluster::stream_relay::RelayProducer>,
+    terminal: Option<crate::services::cluster::stream_relay::TerminalCommitFence>,
+) -> SupervisorRelayForward {
     if chunk.is_empty() {
         return SupervisorRelayForward::mirrored_without_ack();
     }
@@ -1805,7 +1848,10 @@ fn forward_chunk_to_supervisor_relay(
     // file reads is forwarded after the next read completes it instead of being
     // replaced with U+FFFD.
     let payload = chunk.to_string();
-    let outcome = producer.try_send_frame_with_sequence(payload);
+    let outcome = match terminal {
+        Some(fence) => producer.try_send_terminal_frame_with_sequence(payload, fence),
+        None => producer.try_send_frame_with_sequence(payload),
+    };
     if !outcome.is_alive() {
         // Relay was torn down between our registry read and the send —
         // drop the cache so the next chunk re-resolves. If the supervisor
@@ -2065,17 +2111,46 @@ fn terminal_event_consumed_offset(current_offset: u64, unprocessed_tail: &str) -
 /// terminal delivery for this inflight (`sink_can_own`), and (3) the consumed
 /// range is real (`end > start`). A zero/inverted range or a bridge-owned /
 /// mismatched inflight yields `None` so no spurious end is recorded.
-fn watcher_delegated_terminal_end_for_persist(
-    has_current_response: bool,
-    sink_can_own: bool,
+/// #3041 P1-3 (Part a, B1 — frame-carried commit fence): build the
+/// `TerminalCommitFence` to ride on the RESULT-bearing chunk's frame, or `None`
+/// when this chunk is not the terminal one / has no real consumed range / has no
+/// pinned turn identity to gate the sink's advance.
+///
+/// The fence carries the watcher's AUTHORITATIVE consumed-terminal `end`
+/// (`terminal_event_consumed_offset(current_offset, all_data)` == the watcher's
+/// own lease `end`) plus the PINNED turn identity (`user_msg_id` + `started_at`,
+/// matching #3141 pinned-id semantics — taken from the inflight snapshot loaded at
+/// turn start, filtered to THIS tmux session). The sink advances
+/// `confirmed_end_offset` to `end` on a CONFIRMED delivery ONLY when this identity
+/// still matches the channel's current inflight (delayed-old-frame / wrong-turn
+/// protection). We DO NOT gate on `sink_can_own` here: the fence is inert unless
+/// the sink confirms a delivery (route-gated) AND the identity still matches, so
+/// carrying it on every real terminal chunk is safe and the sink's own gates
+/// decide whether it ever advances.
+fn watcher_terminal_commit_fence(
+    found_result: bool,
     turn_data_start_offset: u64,
-    delegated_consumed_end: u64,
-) -> Option<u64> {
-    if has_current_response && sink_can_own && delegated_consumed_end > turn_data_start_offset {
-        Some(delegated_consumed_end)
-    } else {
-        None
+    consumed_end: u64,
+    pinned_identity: Option<&crate::services::discord::inflight::InflightTurnIdentity>,
+    tmux_session_name: &str,
+) -> Option<crate::services::cluster::stream_relay::TerminalCommitFence> {
+    if !found_result || consumed_end <= turn_data_start_offset {
+        return None;
     }
+    let identity = pinned_identity?;
+    // Only pin an identity for THIS tmux session (the panel-identity snapshot is
+    // already filtered to it, but guard defensively so a cross-session snapshot
+    // can never seed a wrong-turn fence).
+    if identity.tmux_session_name.as_deref() != Some(tmux_session_name) {
+        return None;
+    }
+    Some(
+        crate::services::cluster::stream_relay::TerminalCommitFence {
+            consumed_end,
+            turn_user_msg_id: identity.user_msg_id,
+            turn_started_at: identity.started_at.clone(),
+        },
+    )
 }
 
 /// Resolve the provider session selector to durably persist at turn end.
@@ -3287,41 +3362,43 @@ mod matched_session_jsonl_gate_tests {
         );
     }
 
-    // #3041 P1-3 (Part a, B1 — codex real-close): the watcher's decision to persist
-    // the delegated consumed-terminal END (BEFORE the ACK wait / sink load) is
-    // gated exactly so a bridge-owned / mismatched / no-response / zero-range turn
-    // never records a spurious end, while a real delegated turn always does.
+    // #3041 P1-3 (Part a, B1 — FRAME-CARRIED): the watcher's decision to ATTACH the
+    // commit fence (consumed_end + pinned identity) to the RESULT-bearing frame is
+    // gated by `watcher_terminal_commit_fence`: only the terminal chunk, only a real
+    // (end > start) consumed range, and only with a pinned identity for THIS tmux
+    // session. A non-terminal chunk, a zero/inverted range, a missing identity, or a
+    // cross-session snapshot yields no fence (the frame stays non-terminal).
     #[test]
-    fn watcher_persists_delegated_end_only_for_a_real_delegated_range() {
-        // Real delegated turn: response present, sink eligible, end > start.
-        assert_eq!(
-            watcher_delegated_terminal_end_for_persist(true, true, 0, 256),
-            Some(256),
-            "a real delegated turn must record its consumed-terminal end"
-        );
-        // No visible response → nothing to delegate → no end.
-        assert_eq!(
-            watcher_delegated_terminal_end_for_persist(false, true, 0, 256),
-            None,
-            "no-response turn must not record a delegated end"
-        );
-        // Sink not eligible (bridge-owned / mismatched inflight) → no end.
-        assert_eq!(
-            watcher_delegated_terminal_end_for_persist(true, false, 0, 256),
-            None,
-            "sink-ineligible turn must not record a delegated end"
-        );
-        // Zero range (end == start) → no end (never advances/overshoots).
-        assert_eq!(
-            watcher_delegated_terminal_end_for_persist(true, true, 256, 256),
-            None,
-            "zero range must not record a delegated end"
-        );
-        // Inverted range (end < start) → no end.
-        assert_eq!(
-            watcher_delegated_terminal_end_for_persist(true, true, 300, 256),
-            None,
-            "inverted range must not record a delegated end"
+    fn watcher_terminal_commit_fence_only_for_a_real_terminal_chunk() {
+        use crate::services::discord::inflight::InflightTurnIdentity;
+        let session = "AgentDesk-claude-77";
+        let identity = InflightTurnIdentity {
+            user_msg_id: 0,
+            started_at: "2026-06-04T00:00:00Z".to_string(),
+            tmux_session_name: Some(session.to_string()),
+        };
+        // Real terminal chunk: found_result, end > start, identity for this session.
+        let fence = watcher_terminal_commit_fence(true, 0, 256, Some(&identity), session)
+            .expect("a real terminal chunk must carry a commit fence");
+        assert_eq!(fence.consumed_end, 256);
+        assert_eq!(fence.turn_user_msg_id, 0);
+        assert_eq!(fence.turn_started_at, "2026-06-04T00:00:00Z");
+        // Not the result chunk → no fence.
+        assert!(watcher_terminal_commit_fence(false, 0, 256, Some(&identity), session).is_none());
+        // Zero range (end == start) → no fence.
+        assert!(watcher_terminal_commit_fence(true, 256, 256, Some(&identity), session).is_none());
+        // Inverted range → no fence.
+        assert!(watcher_terminal_commit_fence(true, 300, 256, Some(&identity), session).is_none());
+        // No pinned identity → no fence (sink would have nothing to identity-gate).
+        assert!(watcher_terminal_commit_fence(true, 0, 256, None, session).is_none());
+        // Cross-session snapshot → no fence (never seed a wrong-turn fence).
+        let other_identity = InflightTurnIdentity {
+            user_msg_id: 0,
+            started_at: "2026-06-04T00:00:00Z".to_string(),
+            tmux_session_name: Some("AgentDesk-claude-99".to_string()),
+        };
+        assert!(
+            watcher_terminal_commit_fence(true, 0, 256, Some(&other_identity), session).is_none()
         );
     }
 
@@ -4365,38 +4442,21 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         // previous iteration (multi-turn buffer split at the first `result`)
         // is processed before the new disk read.
         let decoded_data = utf8_decoder.decode(&data, data_start_offset);
-        let data_mirrored_to_session_relay = if decoded_data.text.is_empty() {
-            SupervisorRelayForward::mirrored_without_ack()
-        } else {
-            // E5 (#2412): mirror the freshly-read chunk into the
-            // supervisor-owned StreamRelay if one exists for this session.
-            // This is the *producer* side of the supervisor pipeline —
-            // without this call, `try_send_frame` is never invoked in
-            // production. The Discord sink consumes these frames directly for
-            // eligible session-bound inflight shapes; this watcher remains the
-            // fallback for bridge-owned/no-inflight envelopes.
-            forward_chunk_to_supervisor_relay(
-                &tmux_session_name,
-                &decoded_data.text,
-                &producer_registry,
-                &mut cached_relay_producer,
-            )
-        };
-        if let Some(ack_target) = data_mirrored_to_session_relay.ack_target.clone() {
-            all_data_session_bound_relay_ack = Some(ack_target);
-        }
-        if all_data.is_empty() {
+        // #3041 P1-3 (Part a, B1): the forward of this outer-read chunk is
+        // DEFERRED until AFTER `process_watcher_lines` below so the result-bearing
+        // chunk can ride a TERMINAL frame carrying the commit fence. Set only the
+        // buffer START offset here (independent of the forward); the mirror flags +
+        // ack target are set from the deferred forward result (see the
+        // `data_mirrored_to_session_relay` binding after the initial parse).
+        let initial_buffer_was_empty = all_data.is_empty();
+        if initial_buffer_was_empty {
             all_data_start_offset = decoded_data.start_offset.unwrap_or(data_start_offset);
-            all_data_fully_mirrored_to_session_relay = data_mirrored_to_session_relay.mirrored;
-        } else {
-            all_data_fully_mirrored_to_session_relay &= data_mirrored_to_session_relay.mirrored;
         }
         if decoded_data.text.is_empty() && all_data.is_empty() {
             continue;
         }
         all_data.push_str(&decoded_data.text);
         let turn_data_start_offset = all_data_start_offset;
-        let mut session_bound_relay_turn_fully_mirrored = all_data_fully_mirrored_to_session_relay;
         let mut state = StreamLineState::new();
         let restored_turn_seed = restored_turn.take();
         let discard_restored_seed = should_discard_restored_seed_for_idle_direct_prompt(
@@ -4423,13 +4483,13 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         });
         let restored_response_seed = stream_seed.full_response.clone();
         let restored_assistant_text_seen = !restored_response_seed.trim().is_empty();
-        if restored_assistant_text_seen {
-            // The restored response prefix came from watcher state, not from
-            // chunks mirrored into the session-bound StreamRelay parser. Keep
-            // the legacy watcher delivery owner for this terminal envelope so
-            // we do not delegate a partial response.
-            session_bound_relay_turn_fully_mirrored = false;
-        }
+        // #3041 P1-3 (Part a, B1): the `restored_assistant_text_seen` →
+        // "not fully mirrored" reset is now applied where
+        // `session_bound_relay_turn_fully_mirrored` is DECLARED (after the deferred
+        // initial forward below). A restored response prefix came from watcher
+        // state, not from chunks mirrored into the session-bound StreamRelay
+        // parser, so the legacy watcher delivery owner keeps this terminal envelope
+        // (we do not delegate a partial response).
         let mut full_response = stream_seed.full_response;
         let mut tool_state = WatcherToolState::new();
 
@@ -4522,6 +4582,49 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             &mut full_response,
             &mut tool_state,
         );
+        // #3041 P1-3 (Part a, B1): DEFERRED forward of the outer-read chunk. We now
+        // know — from `initial_outcome.found_result` — whether THIS chunk is the
+        // RESULT-bearing (terminal) one. If so, forward it as a TERMINAL frame
+        // carrying the commit fence (`terminal_event_consumed_offset(..)` + the
+        // pinned turn identity loaded at turn start), so the SAME frame that
+        // triggers the sink's terminal delivery carries the consumed_end + identity
+        // (FIFO single-task: a separate later frame would arrive after the sink
+        // already dispatched). Non-terminal chunks forward exactly as before (no
+        // fence, no streaming-latency change beyond the synchronous parse reorder).
+        // The ACK target is captured from THIS forward, so the watcher's wait now
+        // correlates to the terminal frame's sequence (more precise).
+        let initial_terminal_fence = watcher_terminal_commit_fence(
+            initial_outcome.found_result,
+            turn_data_start_offset,
+            terminal_event_consumed_offset(current_offset, &all_data),
+            turn_identity_for_panel.as_ref(),
+            &tmux_session_name,
+        );
+        let data_mirrored_to_session_relay = match initial_terminal_fence {
+            Some(fence) => forward_terminal_chunk_to_supervisor_relay(
+                &tmux_session_name,
+                &decoded_data.text,
+                &producer_registry,
+                &mut cached_relay_producer,
+                fence,
+            ),
+            None => forward_chunk_to_supervisor_relay(
+                &tmux_session_name,
+                &decoded_data.text,
+                &producer_registry,
+                &mut cached_relay_producer,
+            ),
+        };
+        if let Some(ack_target) = data_mirrored_to_session_relay.ack_target.clone() {
+            all_data_session_bound_relay_ack = Some(ack_target);
+        }
+        if initial_buffer_was_empty {
+            all_data_fully_mirrored_to_session_relay = data_mirrored_to_session_relay.mirrored;
+        } else {
+            all_data_fully_mirrored_to_session_relay &= data_mirrored_to_session_relay.mirrored;
+        }
+        let mut session_bound_relay_turn_fully_mirrored =
+            all_data_fully_mirrored_to_session_relay && !restored_assistant_text_seen;
         all_data_start_offset =
             advance_buffer_start_offset(turn_data_start_offset, initial_buffer_len, all_data.len());
         let live_events_dirty = flush_placeholder_live_events(&shared, channel_id, &mut tool_state);
@@ -4698,37 +4801,14 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         ready_for_input_tracker.record_output();
                         let chunk_start_offset = current_offset.saturating_sub(chunk.len() as u64);
                         let decoded_chunk = utf8_decoder.decode(&chunk, chunk_start_offset);
-                        let chunk_forwarded_to_session_relay = if decoded_chunk.text.is_empty() {
-                            SupervisorRelayForward::mirrored_without_ack()
-                        } else {
-                            // E5 (#2412): producer-side wiring for the
-                            // supervisor-owned StreamRelay. Same rationale as
-                            // the outer read site in this fn — every decoded
-                            // chunk read off the tmux output file is also
-                            // pushed into the relay's MPSC so the
-                            // session-bound Discord sink receives frames in
-                            // production.
-                            forward_chunk_to_supervisor_relay(
-                                &tmux_session_name,
-                                &decoded_chunk.text,
-                                &producer_registry,
-                                &mut cached_relay_producer,
-                            )
-                        };
-                        if let Some(ack_target) = chunk_forwarded_to_session_relay.ack_target {
-                            all_data_session_bound_relay_ack = Some(ack_target);
-                        }
-                        let chunk_mirrored_to_session_relay =
-                            chunk_forwarded_to_session_relay.mirrored;
-                        session_bound_relay_turn_fully_mirrored &= chunk_mirrored_to_session_relay;
-                        if all_data.is_empty() {
+                        // #3041 P1-3 (Part a, B1): DEFER the forward until AFTER the
+                        // parse so the RESULT-bearing streaming chunk rides a TERMINAL
+                        // frame carrying the commit fence. Set only the buffer START
+                        // offset here (independent of the forward).
+                        let chunk_buffer_was_empty = all_data.is_empty();
+                        if chunk_buffer_was_empty {
                             all_data_start_offset =
                                 decoded_chunk.start_offset.unwrap_or(chunk_start_offset);
-                            all_data_fully_mirrored_to_session_relay =
-                                chunk_mirrored_to_session_relay;
-                        } else {
-                            all_data_fully_mirrored_to_session_relay &=
-                                chunk_mirrored_to_session_relay;
                         }
                         if decoded_chunk.text.is_empty() && all_data.is_empty() {
                             continue;
@@ -4747,6 +4827,47 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                             &mut full_response,
                             &mut tool_state,
                         );
+                        // #3041 P1-3 (Part a, B1): deferred forward of THIS streaming
+                        // chunk. `outcome.found_result` now tells us whether this is
+                        // the RESULT-bearing chunk; if so it rides a TERMINAL frame
+                        // carrying the commit fence (consumed_end + pinned identity).
+                        // E5 (#2412): every decoded chunk is still pushed into the
+                        // relay MPSC; only the terminality of the frame changed.
+                        let streaming_terminal_fence = watcher_terminal_commit_fence(
+                            outcome.found_result,
+                            chunk_buffer_start_offset,
+                            terminal_event_consumed_offset(current_offset, &all_data),
+                            turn_identity_for_panel.as_ref(),
+                            &tmux_session_name,
+                        );
+                        let chunk_forwarded_to_session_relay = match streaming_terminal_fence {
+                            Some(fence) => forward_terminal_chunk_to_supervisor_relay(
+                                &tmux_session_name,
+                                &decoded_chunk.text,
+                                &producer_registry,
+                                &mut cached_relay_producer,
+                                fence,
+                            ),
+                            None => forward_chunk_to_supervisor_relay(
+                                &tmux_session_name,
+                                &decoded_chunk.text,
+                                &producer_registry,
+                                &mut cached_relay_producer,
+                            ),
+                        };
+                        if let Some(ack_target) = chunk_forwarded_to_session_relay.ack_target {
+                            all_data_session_bound_relay_ack = Some(ack_target);
+                        }
+                        let chunk_mirrored_to_session_relay =
+                            chunk_forwarded_to_session_relay.mirrored;
+                        session_bound_relay_turn_fully_mirrored &= chunk_mirrored_to_session_relay;
+                        if chunk_buffer_was_empty {
+                            all_data_fully_mirrored_to_session_relay =
+                                chunk_mirrored_to_session_relay;
+                        } else {
+                            all_data_fully_mirrored_to_session_relay &=
+                                chunk_mirrored_to_session_relay;
+                        }
                         last_output_at = tokio::time::Instant::now();
                         all_data_start_offset = advance_buffer_start_offset(
                             chunk_buffer_start_offset,
@@ -6885,52 +7006,17 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         let current_response = full_response.get(response_sent_offset..).unwrap_or("");
         let has_current_response = !current_response.trim().is_empty();
 
-        // #3041 P1-3 (Part a, B1 — REAL close, codex): persist the watcher's
-        // AUTHORITATIVE consumed-terminal END for the range it is delegating to
-        // the session-bound sink BEFORE the sink can load inflight in
-        // `deliver_response`. The terminal frame has already been forwarded to the
-        // sink's MPSC during line collection, but the sink only runs
-        // `deliver_response` (and loads inflight) when it is scheduled to drain
-        // that frame — which is during/after the 10s ACK wait below. Writing the
-        // end HERE (synchronously, before that wait) means the sink reads a
-        // non-None end for THIS delivery and advances `confirmed_end_offset` on its
-        // confirmed POST. Reconciliation (Part b) then sees committed>=end → Skip,
-        // closing the ACK-lag duplicate vector. The OLD write at the
-        // post-ACK delegation arm was too late: it ran only AFTER the ACK already
-        // observed `Delivered`, i.e. after the sink had already loaded `None`.
-        //
-        // Identity-guarded: only writes when the on-disk row is still THIS turn
-        // (no newer turn / restart marker has taken the row), so it can never
-        // clobber a follow-up turn's state. Gated on the same terminal-delivery
-        // eligibility the sink uses + a real (non-empty) consumed range, so a
-        // bridge-owned / mismatched / zero-range turn never records a spurious end.
-        {
-            let sink_can_own =
-                crate::services::discord::session_relay_sink::session_bound_discord_relay_can_own_terminal_delivery(
-                    inflight_before_relay.as_ref(),
-                    &tmux_session_name,
-                );
-            let delegated_end_to_persist = watcher_delegated_terminal_end_for_persist(
-                has_current_response,
-                sink_can_own,
-                turn_data_start_offset,
-                terminal_event_consumed_offset(current_offset, &all_data),
-            );
-            if let Some(delegated_consumed_end) = delegated_end_to_persist
-                && let (Some(mut inflight), Some(identity)) = (
-                    inflight_before_relay.clone(),
-                    inflight_identity_before_relay.clone(),
-                )
-            {
-                let expected_turn_start_offset = inflight.turn_start_offset;
-                inflight.session_bound_delegated_terminal_end = Some(delegated_consumed_end);
-                let _ = crate::services::discord::inflight::save_inflight_state_if_matches_identity(
-                    &inflight,
-                    &identity,
-                    expected_turn_start_offset,
-                );
-            }
-        }
+        // #3041 P1-3 (Part a, B1 — FRAME-CARRIED, codex): the watcher's
+        // AUTHORITATIVE consumed-terminal END is NO LONGER persisted to the inflight
+        // FILE here. The old inflight-persist Part (a) was RACY (the sink read the
+        // end back from the file in `deliver_response`, a separate read/write across
+        // the relay's async drain). It is REPLACED by the frame-carried commit
+        // fence: the RESULT-bearing `StreamFrame` itself carries `consumed_end` +
+        // the pinned turn identity (forwarded during line collection above), and the
+        // sink advances `confirmed_end_offset` identity-gated on its CONFIRMED POST —
+        // POST + advance atomic per-frame, no file race. See
+        // `watcher_terminal_commit_fence` (producer) and
+        // `advance_offset_for_confirmed_delegated_terminal` (sink).
 
         let recent_stop_for_output =
             recent_turn_stop_for_watcher_range(channel_id, &tmux_session_name, data_start_offset);
@@ -7670,20 +7756,11 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         inflight.last_watcher_relayed_offset = Some(turn_data_start_offset);
                         inflight.last_watcher_relayed_generation_mtime_ns =
                             last_observed_generation_mtime_ns;
-                        // #3041 P1-3 (Part a, B1): the AUTHORITATIVE consumed
-                        // terminal END (`session_bound_delegated_terminal_end ==
-                        // watcher_lease_end == terminal_event_consumed_offset(..)`)
-                        // is now persisted EARLIER, at the top of the terminal-relay
-                        // block BEFORE the 10s ACK wait, so the sink reads a non-None
-                        // end for THIS delivery (the codex B1 fix). Writing it here
-                        // (post-ACK) was too late — the sink had already loaded
-                        // inflight during the wait. We keep the idempotent re-write
-                        // below as a belt-and-suspenders refresh so the value is
-                        // never lost if the early write was raced by a row rewrite,
-                        // but the load-bearing write is the early one.
-                        if watcher_lease_end > watcher_lease_start {
-                            inflight.session_bound_delegated_terminal_end = Some(watcher_lease_end);
-                        }
+                        // #3041 P1-3 (Part a, B1 — FRAME-CARRIED): the authoritative
+                        // consumed-terminal END is NO LONGER written to the inflight
+                        // file (the racy inflight-persist Part (a) is removed). It now
+                        // rides the RESULT-bearing `StreamFrame` and the sink advances
+                        // `confirmed_end_offset` identity-gated on its confirmed POST.
                         let _ = crate::services::discord::inflight::save_inflight_state(&inflight);
                     }
                 }

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1898,18 +1898,33 @@ fn watcher_should_direct_send_after_session_bound_ack(
 /// watcher's own consumed-terminal `end`, this reconciliation is exact:
 ///   * `committed >= end`           → the range was already delivered (by the
 ///                                     sink, ACK merely lagged) → SKIP (no dup).
-///   * `start < committed < end`    → the prefix `[start, committed)` was
-///                                     delivered → send ONLY the uncommitted
-///                                     suffix (no black-hole, reduced dup).
-///   * `committed <= start`         → nothing delivered → send the FULL range.
+///   * `committed < end`            → the range is NOT (fully) delivered → re-send
+///                                     the FULL response (no black-hole).
+///
+/// codex BLOCKER 2 (no SendSuffix for the watcher path): a partial-overlap
+/// `start < committed < end` case would in principle let us send only the
+/// uncommitted suffix — BUT the watcher delivers RESPONSE TEXT sliced by
+/// `response_sent_offset` (a streaming/render offset), which is a DIFFERENT
+/// coordinate system from the JSONL byte `committed`/`start`/`end`. There is no
+/// correct way to map `[committed, end)` JSONL bytes onto a `response_sent_offset`
+/// suffix, so a "SendSuffix" here would post an incoherent / mis-offset slice (or
+/// nothing while committed<end → black-hole). Crucially, the sink-delegated
+/// terminal delivery is ALL-OR-NOTHING: the sink advances `confirmed_end_offset`
+/// to the FULL `end` ONLY after one confirmed `replace_message_with_outcome`
+/// (`advance_offset_for_confirmed_delegated_terminal`, sink ~453/506), so for this
+/// path `committed` is either `>= end` (delivered → Skip) or `<= start` (not
+/// delivered → Full) — the partial-overlap middle case effectively does not occur.
+/// Therefore SendFull on `committed < end` is SAFE: no black-hole (the missing
+/// content is always re-delivered), and no incoherent mid-response tail. The
+/// idle-relay path still does a real JSONL `[committed,end)` re-read for its
+/// suffix; only the watcher response-text path is restricted to Skip/Full.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 enum WatcherTerminalResendAction {
     /// `committed >= end`: the whole range is already delivered. Do NOT re-send.
     SkipAlreadyCommitted,
-    /// `start < committed < end`: send only the uncommitted suffix
-    /// `[committed, end)`; the prefix was already delivered.
-    SendSuffix,
-    /// `committed <= start`: nothing covered — send the full range.
+    /// `committed < end`: the range is not (fully) covered — re-send the full
+    /// response. See the type doc for why no partial-suffix variant exists for
+    /// the watcher response-text path (coordinate mismatch + all-or-nothing sink).
     SendFull,
 }
 
@@ -1930,9 +1945,10 @@ fn watcher_terminal_resend_action(
     }
     if committed >= end {
         WatcherTerminalResendAction::SkipAlreadyCommitted
-    } else if committed > start {
-        WatcherTerminalResendAction::SendSuffix
     } else {
+        // committed < end (incl. the partial `start < committed < end` case which
+        // the all-or-nothing sink delegation does not actually produce): re-send
+        // the FULL response. No black-hole; no mis-offset suffix (codex BLOCKER 2).
         WatcherTerminalResendAction::SendFull
     }
 }
@@ -2036,6 +2052,30 @@ async fn wait_for_session_bound_relay_delivery_ack(
 
 fn terminal_event_consumed_offset(current_offset: u64, unprocessed_tail: &str) -> u64 {
     current_offset.saturating_sub(unprocessed_tail.len() as u64)
+}
+
+/// #3041 P1-3 (Part a, B1 — codex real-close): the watcher's AUTHORITATIVE
+/// consumed-terminal END to persist into inflight BEFORE the sink loads it in
+/// `deliver_response`, or `None` when this turn must NOT record a delegated end.
+///
+/// Pure decision so the BEFORE-the-ACK-wait ordering and the gating are unit
+/// testable without driving the whole watcher loop. Returns the end to persist
+/// only when (1) the turn has visible response output the watcher would delegate
+/// (`has_current_response`), (2) the session-bound sink is eligible to own the
+/// terminal delivery for this inflight (`sink_can_own`), and (3) the consumed
+/// range is real (`end > start`). A zero/inverted range or a bridge-owned /
+/// mismatched inflight yields `None` so no spurious end is recorded.
+fn watcher_delegated_terminal_end_for_persist(
+    has_current_response: bool,
+    sink_can_own: bool,
+    turn_data_start_offset: u64,
+    delegated_consumed_end: u64,
+) -> Option<u64> {
+    if has_current_response && sink_can_own && delegated_consumed_end > turn_data_start_offset {
+        Some(delegated_consumed_end)
+    } else {
+        None
+    }
 }
 
 /// Resolve the provider session selector to durably persist at turn end.
@@ -3117,8 +3157,11 @@ mod matched_session_jsonl_gate_tests {
 
     // #3041 P1-3 (Part b, §3.2): the watcher's terminal re-send reconciliation
     // against the committed offset authority — REPLACING the blind re-send. These
-    // assert the exact 3-way skip/suffix/full decision so the failure-mode-① skip
-    // (no duplicate) and the black-hole guard (suffix/full still sent) are pinned.
+    // assert the exact 2-way skip/full decision so the failure-mode-① skip (no
+    // duplicate) and the black-hole guard (full still sent on committed<end) are
+    // pinned. codex BLOCKER 2: there is no SendSuffix for the watcher response-text
+    // path (coordinate mismatch + all-or-nothing sink) — `committed < end` always
+    // re-sends the FULL response (no black-hole, no mis-offset slice).
     #[test]
     fn watcher_terminal_resend_skips_when_range_already_committed() {
         // failure-mode-①: the sink delivered `[0, 100)` (Part a advanced the
@@ -3137,18 +3180,24 @@ mod matched_session_jsonl_gate_tests {
     }
 
     #[test]
-    fn watcher_terminal_resend_sends_suffix_on_partial_overlap() {
-        // The sink delivered the prefix `[0, 60)`; the file grew to 100 before the
-        // watcher reconciled → send ONLY the uncommitted suffix `[60, 100)`.
-        // No black-hole (the suffix IS sent), reduced duplicate.
+    fn watcher_terminal_resend_partial_overlap_sends_full_not_suffix() {
+        // codex BLOCKER 2: a partial overlap `start < committed < end` would in
+        // principle allow a suffix-only re-send, but the watcher delivers RESPONSE
+        // TEXT sliced by `response_sent_offset` (a render offset), NOT JSONL bytes
+        // — so it cannot coherently map `[committed, end)`. The all-or-nothing sink
+        // never actually produces this case (it advances to the FULL end on a
+        // single confirmed post, or not at all). Decision: SendFull on committed<end
+        // — no black-hole (missing content always re-delivered), no mis-offset send.
         assert_eq!(
             watcher_terminal_resend_action(60, 0, 100),
-            WatcherTerminalResendAction::SendSuffix
+            WatcherTerminalResendAction::SendFull,
+            "partial overlap must SendFull (no mis-offset suffix; no black-hole)"
         );
-        // Boundary: committed just past start is still a partial overlap.
+        // Boundary: committed just past start is still committed<end → SendFull.
         assert_eq!(
             watcher_terminal_resend_action(1, 0, 100),
-            WatcherTerminalResendAction::SendSuffix
+            WatcherTerminalResendAction::SendFull,
+            "committed just past start must SendFull (committed<end → re-send)"
         );
     }
 
@@ -3166,6 +3215,113 @@ mod matched_session_jsonl_gate_tests {
             watcher_terminal_resend_action(40, 50, 100),
             WatcherTerminalResendAction::SendFull,
             "committed below start must send the full range (no black-hole)"
+        );
+    }
+
+    // #3041 P1-3 codex BLOCKER 2: the sink-delegated terminal delivery is
+    // ALL-OR-NOTHING — the sink advances `confirmed_end_offset` to the FULL `end`
+    // on ONE confirmed post, or not at all. So for the sink-delegated path the
+    // reconciliation only ever sees committed == end (delivered → Skip) or
+    // committed == start (not delivered → Full); it NEVER sees a partial
+    // `start < committed < end`. This pins that no SendSuffix is reachable on the
+    // delegated path, and that committed<end ALWAYS re-sends the full body (no
+    // black-hole). The watcher response-text path never derives a suffix from the
+    // unrelated `response_sent_offset`.
+    #[test]
+    fn sink_delegated_path_is_all_or_nothing_skip_or_full_never_suffix() {
+        let start = 100u64;
+        let end = 356u64; // full consumed-terminal end after an all-or-nothing post
+
+        // Delivered: the sink committed the FULL range → committed == end → Skip.
+        assert_eq!(
+            watcher_terminal_resend_action(end, start, end),
+            WatcherTerminalResendAction::SkipAlreadyCommitted,
+            "all-or-nothing delivered → committed==end → Skip (no duplicate, failure-mode-①)"
+        );
+
+        // Not delivered: the sink did NOT post → committed stays at the prior
+        // turn's end (<= start) → committed < end → SendFull (no black-hole).
+        assert_eq!(
+            watcher_terminal_resend_action(start, start, end),
+            WatcherTerminalResendAction::SendFull,
+            "all-or-nothing not-delivered → committed<=start → SendFull (no black-hole)"
+        );
+
+        // No reachable input on the delegated path yields SendSuffix — the variant
+        // does not exist. Even an (unreachable) partial value re-sends FULL, not a
+        // mis-offset suffix.
+        for committed in [start + 1, (start + end) / 2, end - 1] {
+            assert_eq!(
+                watcher_terminal_resend_action(committed, start, end),
+                WatcherTerminalResendAction::SendFull,
+                "committed<end must SendFull (no suffix, no mis-offset slice, no black-hole)"
+            );
+        }
+    }
+
+    // BLOCKER 2 payload guard: `watcher_terminal_response_for_direct_send` must
+    // deliver the FULL response (not the `full_response[response_sent_offset..]`
+    // streaming-offset slice) whenever the reconciled re-send is taken, so the
+    // body is coherent and never a mid-response tail driven by an unrelated offset.
+    #[test]
+    fn watcher_resend_delivers_full_response_not_render_offset_slice() {
+        let full_response = "ANSWER-PREFIX|ANSWER-SUFFIX";
+        // A non-zero render offset that has NOTHING to do with JSONL bytes — the
+        // exact mismatch BLOCKER 2 flagged. The old SendSuffix path would have
+        // returned an incoherent slice from here.
+        let response_sent_offset = "ANSWER-PREFIX|".len();
+
+        // SendFull path (session_bound_fallback_uses_full_body = true): the full,
+        // coherent response is delivered — never the render-offset slice.
+        assert_eq!(
+            watcher_terminal_response_for_direct_send(full_response, response_sent_offset, true),
+            full_response,
+            "reconciled re-send must deliver the FULL response (no mis-offset slice)"
+        );
+        // And it is NOT the render-offset suffix that the removed SendSuffix path
+        // would have sent.
+        assert_ne!(
+            watcher_terminal_response_for_direct_send(full_response, response_sent_offset, true),
+            &full_response[response_sent_offset..],
+            "must NOT send the unrelated full_response[response_sent_offset..] slice"
+        );
+    }
+
+    // #3041 P1-3 (Part a, B1 — codex real-close): the watcher's decision to persist
+    // the delegated consumed-terminal END (BEFORE the ACK wait / sink load) is
+    // gated exactly so a bridge-owned / mismatched / no-response / zero-range turn
+    // never records a spurious end, while a real delegated turn always does.
+    #[test]
+    fn watcher_persists_delegated_end_only_for_a_real_delegated_range() {
+        // Real delegated turn: response present, sink eligible, end > start.
+        assert_eq!(
+            watcher_delegated_terminal_end_for_persist(true, true, 0, 256),
+            Some(256),
+            "a real delegated turn must record its consumed-terminal end"
+        );
+        // No visible response → nothing to delegate → no end.
+        assert_eq!(
+            watcher_delegated_terminal_end_for_persist(false, true, 0, 256),
+            None,
+            "no-response turn must not record a delegated end"
+        );
+        // Sink not eligible (bridge-owned / mismatched inflight) → no end.
+        assert_eq!(
+            watcher_delegated_terminal_end_for_persist(true, false, 0, 256),
+            None,
+            "sink-ineligible turn must not record a delegated end"
+        );
+        // Zero range (end == start) → no end (never advances/overshoots).
+        assert_eq!(
+            watcher_delegated_terminal_end_for_persist(true, true, 256, 256),
+            None,
+            "zero range must not record a delegated end"
+        );
+        // Inverted range (end < start) → no end.
+        assert_eq!(
+            watcher_delegated_terminal_end_for_persist(true, true, 300, 256),
+            None,
+            "inverted range must not record a delegated end"
         );
     }
 
@@ -6729,6 +6885,53 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         let current_response = full_response.get(response_sent_offset..).unwrap_or("");
         let has_current_response = !current_response.trim().is_empty();
 
+        // #3041 P1-3 (Part a, B1 — REAL close, codex): persist the watcher's
+        // AUTHORITATIVE consumed-terminal END for the range it is delegating to
+        // the session-bound sink BEFORE the sink can load inflight in
+        // `deliver_response`. The terminal frame has already been forwarded to the
+        // sink's MPSC during line collection, but the sink only runs
+        // `deliver_response` (and loads inflight) when it is scheduled to drain
+        // that frame — which is during/after the 10s ACK wait below. Writing the
+        // end HERE (synchronously, before that wait) means the sink reads a
+        // non-None end for THIS delivery and advances `confirmed_end_offset` on its
+        // confirmed POST. Reconciliation (Part b) then sees committed>=end → Skip,
+        // closing the ACK-lag duplicate vector. The OLD write at the
+        // post-ACK delegation arm was too late: it ran only AFTER the ACK already
+        // observed `Delivered`, i.e. after the sink had already loaded `None`.
+        //
+        // Identity-guarded: only writes when the on-disk row is still THIS turn
+        // (no newer turn / restart marker has taken the row), so it can never
+        // clobber a follow-up turn's state. Gated on the same terminal-delivery
+        // eligibility the sink uses + a real (non-empty) consumed range, so a
+        // bridge-owned / mismatched / zero-range turn never records a spurious end.
+        {
+            let sink_can_own =
+                crate::services::discord::session_relay_sink::session_bound_discord_relay_can_own_terminal_delivery(
+                    inflight_before_relay.as_ref(),
+                    &tmux_session_name,
+                );
+            let delegated_end_to_persist = watcher_delegated_terminal_end_for_persist(
+                has_current_response,
+                sink_can_own,
+                turn_data_start_offset,
+                terminal_event_consumed_offset(current_offset, &all_data),
+            );
+            if let Some(delegated_consumed_end) = delegated_end_to_persist
+                && let (Some(mut inflight), Some(identity)) = (
+                    inflight_before_relay.clone(),
+                    inflight_identity_before_relay.clone(),
+                )
+            {
+                let expected_turn_start_offset = inflight.turn_start_offset;
+                inflight.session_bound_delegated_terminal_end = Some(delegated_consumed_end);
+                let _ = crate::services::discord::inflight::save_inflight_state_if_matches_identity(
+                    &inflight,
+                    &identity,
+                    expected_turn_start_offset,
+                );
+            }
+        }
+
         let recent_stop_for_output =
             recent_turn_stop_for_watcher_range(channel_id, &tmux_session_name, data_start_offset);
         let inflight_missing_before_relay = inflight_before_relay.is_none();
@@ -7175,9 +7378,11 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         // to the watcher's own `end`, so this consult is exact:
         //   * committed >= end → SKIP (the sink delivered; ACK merely lagged) → no
         //     duplicate (failure-mode-①);
-        //   * start < committed < end → send only the uncommitted suffix → no
-        //     black-hole, reduced duplicate;
-        //   * committed <= end (nothing committed) → re-send (no black-hole).
+        //   * committed < end → re-send the FULL response (no black-hole). codex
+        //     BLOCKER 2: NO partial-suffix send for the watcher response-text path
+        //     (its `response_sent_offset` render coordinate cannot be derived from
+        //     the JSONL `committed` byte offset), and the sink delegation is
+        //     all-or-nothing so `committed` is never strictly between start and end.
         // Reconcile ONLY on the session-bound re-send path (an attempted delegation
         // whose ACK was not `Delivered`); the plain watcher-direct path (no
         // delegation) keeps its existing behaviour untouched.
@@ -7227,24 +7432,22 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         }
         // The watcher actually direct-sends only when the reconciliation did NOT
         // skip the range. `SkipAlreadyCommitted` suppresses the re-send (no dup);
-        // `SendSuffix`/`SendFull`/the non-reconciled path proceed to send.
+        // `SendFull`/the non-reconciled path proceed to send.
         let watcher_direct_fallback_after_session_bound_ack = watcher_direct_fallback_intended
             && !matches!(
                 watcher_resend_action,
                 Some(WatcherTerminalResendAction::SkipAlreadyCommitted)
             );
-        // §3.2 suffix trim: on a PARTIAL overlap the prefix was already delivered,
-        // so do NOT re-send the full body — fall back to the streamed-suffix body
-        // (`response_sent_offset`), which excludes the already-delivered prefix
-        // (no black-hole: the uncommitted suffix is still sent). On `SendFull` /
-        // the non-reconciled path keep the existing full-body fallback semantics.
-        let watcher_resend_force_suffix = matches!(
-            watcher_resend_action,
-            Some(WatcherTerminalResendAction::SendSuffix)
-        );
+        // codex BLOCKER 2: on a non-skip reconciled re-send the action is always
+        // `SendFull` (the watcher response-text coordinate cannot be derived from
+        // the JSONL `committed` offset, and the sink delegation is all-or-nothing,
+        // so no partial-suffix variant exists). The full body is re-sent: no
+        // black-hole when committed<end, and never a mis-offset
+        // `full_response[response_sent_offset..]` slice driven by an unrelated
+        // streaming offset. The non-reconciled path keeps the existing full-body
+        // fallback semantics.
         let session_bound_fallback_uses_full_body = session_bound_terminal_delivery_attempted
-            && watcher_direct_fallback_after_session_bound_ack
-            && !watcher_resend_force_suffix;
+            && watcher_direct_fallback_after_session_bound_ack;
         let direct_terminal_response = watcher_terminal_response_for_direct_send(
             &full_response,
             response_sent_offset,
@@ -7467,17 +7670,17 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         inflight.last_watcher_relayed_offset = Some(turn_data_start_offset);
                         inflight.last_watcher_relayed_generation_mtime_ns =
                             last_observed_generation_mtime_ns;
-                        // #3041 P1-3 (Part a, B1): persist the watcher's
-                        // AUTHORITATIVE consumed terminal END for the range it is
-                        // delegating to the sink — exactly the value the watcher
-                        // advances `confirmed_end_offset` to on its OWN terminal
-                        // delivery (`watcher_lease_end ==
-                        // terminal_event_consumed_offset(current_offset, all_data)`).
-                        // The sink reads this (identity-gated) to advance the offset
-                        // authority on a confirmed delivery, so reconciliation (Part
-                        // b) sees the delegated range as delivered even if the
-                        // terminal-commit ACK lags. Only record a real (non-empty)
-                        // range; a zero/inverted range never advances.
+                        // #3041 P1-3 (Part a, B1): the AUTHORITATIVE consumed
+                        // terminal END (`session_bound_delegated_terminal_end ==
+                        // watcher_lease_end == terminal_event_consumed_offset(..)`)
+                        // is now persisted EARLIER, at the top of the terminal-relay
+                        // block BEFORE the 10s ACK wait, so the sink reads a non-None
+                        // end for THIS delivery (the codex B1 fix). Writing it here
+                        // (post-ACK) was too late — the sink had already loaded
+                        // inflight during the wait. We keep the idempotent re-write
+                        // below as a belt-and-suspenders refresh so the value is
+                        // never lost if the early write was raced by a row rewrite,
+                        // but the load-bearing write is the early one.
                         if watcher_lease_end > watcher_lease_start {
                             inflight.session_bound_delegated_terminal_end = Some(watcher_lease_end);
                         }

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1986,14 +1986,34 @@ fn sequence_reached(latest: Option<u64>, target: u64) -> bool {
 fn session_bound_relay_ack_snapshot_outcome(
     target: Option<&SessionBoundRelayAckTarget>,
 ) -> Option<SessionBoundRelayAckOutcome> {
+    use crate::services::cluster::stream_relay::TerminalOutcome;
     let target = target?;
+    // #3041 P1-3 R5 (per-sequence terminal-ACK correlation): resolve the terminal
+    // ACK on THIS watcher's OWN terminal frame (`target.sequence`) EXACT outcome,
+    // NOT the `>=` high-water-mark. When two turns share a physical chunk (turn A
+    // frame seq N, turn B tail seq N+1), B committing bumps the high-water-mark to
+    // N+1; the old `committed >= N` test would then falsely report A as Delivered
+    // even when A's own terminal frame was SKIPPED — black-holing A. Keying the
+    // ACK to A's exact sequence decouples A from B: A reads outcome[N] (its own
+    // result), B reads outcome[N+1]. `None` (not yet resolved / dropped / evicted)
+    // falls through so a dropped/lagging frame keeps waiting → eventually TimedOut
+    // → the watcher reconciles against the committed offset (no false ACK).
+    match target
+        .metrics
+        .terminal_outcome_for_sequence(target.sequence)
+    {
+        Some(TerminalOutcome::Committed) => {
+            return Some(SessionBoundRelayAckOutcome::Delivered);
+        }
+        Some(TerminalOutcome::Skipped) => {
+            return Some(SessionBoundRelayAckOutcome::TerminalSkipped);
+        }
+        None => {}
+    }
+    // Sink-error / drop remain high-water-mark signals (terminal outcome was never
+    // recorded for this sequence in those paths): they are per-sequence-monotonic
+    // failure markers, not a co-chunked-turn confusion vector.
     let snapshot = target.metrics.snapshot();
-    if sequence_reached(snapshot.last_terminal_committed_sequence, target.sequence) {
-        return Some(SessionBoundRelayAckOutcome::Delivered);
-    }
-    if sequence_reached(snapshot.last_terminal_skipped_sequence, target.sequence) {
-        return Some(SessionBoundRelayAckOutcome::TerminalSkipped);
-    }
     if sequence_reached(snapshot.last_sink_error_sequence, target.sequence) {
         return Some(SessionBoundRelayAckOutcome::SinkError);
     }
@@ -3216,6 +3236,69 @@ mod matched_session_jsonl_gate_tests {
             wait_for_session_bound_relay_delivery_ack(None, std::time::Duration::from_millis(1))
                 .await,
             SessionBoundRelayAckOutcome::MissingTarget
+        );
+    }
+
+    // #3041 P1-3 R5 (per-sequence terminal-ACK correlation): turn A (seq N) was
+    // SKIPPED, turn B's tail (seq N+1) COMMITTED in the same chunk. A's ACK must
+    // resolve on A's OWN sequence → TerminalSkipped (so the watcher reconciles /
+    // SendFull → A delivered, no black-hole), NOT Delivered from B bumping the
+    // committed high-water-mark to N+1. B's ACK at its own sequence → Delivered.
+    #[test]
+    fn session_bound_relay_ack_is_per_sequence_not_high_water_mark() {
+        let metrics =
+            std::sync::Arc::new(crate::services::cluster::stream_relay::RelayMetrics::default());
+        // A at seq N=5 skipped, B at seq N+1=6 committed (higher → bumps HWM).
+        metrics.record_terminal_skipped_sequence_for_test(5);
+        metrics.record_terminal_committed_sequence_for_test(6);
+
+        let a_target = SessionBoundRelayAckTarget {
+            metrics: metrics.clone(),
+            sequence: 5,
+        };
+        assert_eq!(
+            session_bound_relay_ack_snapshot_outcome(Some(&a_target)),
+            Some(SessionBoundRelayAckOutcome::TerminalSkipped),
+            "A's ACK reads A's own seq-5 outcome (Skipped), not B's committed HWM"
+        );
+
+        let b_target = SessionBoundRelayAckTarget {
+            metrics: metrics.clone(),
+            sequence: 6,
+        };
+        assert_eq!(
+            session_bound_relay_ack_snapshot_outcome(Some(&b_target)),
+            Some(SessionBoundRelayAckOutcome::Delivered),
+            "B's ACK reads its own seq-6 committed outcome"
+        );
+    }
+
+    // #3041 P1-3 R5: a target sequence that was never terminally resolved (dropped
+    // before the sink, or evicted from the bounded ring) reads None → the snapshot
+    // outcome is None → the wait times out → the watcher reconciles (no false ACK,
+    // no black-hole).
+    #[tokio::test]
+    async fn session_bound_relay_ack_unresolved_sequence_times_out() {
+        let metrics =
+            std::sync::Arc::new(crate::services::cluster::stream_relay::RelayMetrics::default());
+        // A different sequence committed; OUR target (42) was never resolved.
+        metrics.record_terminal_committed_sequence_for_test(40);
+        let target = SessionBoundRelayAckTarget {
+            metrics: metrics.clone(),
+            sequence: 42,
+        };
+        assert_eq!(
+            session_bound_relay_ack_snapshot_outcome(Some(&target)),
+            None
+        );
+        assert_eq!(
+            wait_for_session_bound_relay_delivery_ack(
+                Some(&target),
+                std::time::Duration::from_millis(1),
+            )
+            .await,
+            SessionBoundRelayAckOutcome::TimedOut,
+            "unresolved/evicted target sequence times out → reconcile, never a false ACK"
         );
     }
 

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1825,6 +1825,91 @@ fn forward_terminal_chunk_to_supervisor_relay(
     )
 }
 
+/// #3041 P1-3 (codex P1-3 issue 1): forward a RESULT-bearing physical chunk that
+/// may ALSO contain a trailing LATER-turn tail. `leftover_len` is the post-parse
+/// `all_data.len()` — the bytes `process_watcher_lines` did NOT consume (the next
+/// turn's bytes). We split `decoded` at that boundary and:
+///   1. forward the just-completed turn's bytes (`terminal_part`) on a TERMINAL
+///      frame carrying THIS turn's commit fence, and
+///   2. forward the trailing later-turn bytes (`tail_part`) on a SEPARATE
+///      NON-terminal frame so they are still mirrored into the sink's parser and
+///      the later turn is never black-holed (it gets its own fence when it
+///      completes on a later pass).
+///
+/// The returned ACK target is the TERMINAL frame's (so the watcher's terminal-ACK
+/// wait correlates to THIS turn's delivery, not the trailing fragment). `mirrored`
+/// is the AND of both forwards. When there is no trailing tail this is exactly the
+/// single terminal forward.
+fn forward_terminal_chunk_with_trailing_to_supervisor_relay(
+    tmux_session_name: &str,
+    decoded: &str,
+    leftover_len: usize,
+    registry: &std::sync::Arc<
+        crate::services::cluster::relay_producer_registry::RelayProducerRegistry,
+    >,
+    cached_producer: &mut Option<crate::services::cluster::stream_relay::RelayProducer>,
+    terminal: crate::services::cluster::stream_relay::TerminalCommitFence,
+) -> SupervisorRelayForward {
+    let (terminal_part, tail_part) =
+        split_decoded_chunk_at_terminal_boundary(decoded, leftover_len);
+    let terminal_forward = forward_terminal_chunk_to_supervisor_relay(
+        tmux_session_name,
+        terminal_part,
+        registry,
+        cached_producer,
+        terminal,
+    );
+    if tail_part.is_empty() {
+        return terminal_forward;
+    }
+    // Forward the later-turn tail as its OWN non-terminal frame (no fence). This
+    // keeps it in the sink's parser stream so the later turn is mirrored; its
+    // terminal fence rides a future result-bearing chunk. We keep the TERMINAL
+    // frame's ack_target (the watcher waits on THIS turn's delivery) and AND the
+    // tail's mirror flag so a failed tail forward still surfaces "not fully
+    // mirrored".
+    let tail_forward =
+        forward_chunk_to_supervisor_relay(tmux_session_name, tail_part, registry, cached_producer);
+    SupervisorRelayForward {
+        mirrored: terminal_forward.mirrored && tail_forward.mirrored,
+        ack_target: terminal_forward.ack_target,
+    }
+}
+
+/// #3041 P1-3 (codex P1-3 issue 1 — multi-turn-chunk black-hole close): split the
+/// freshly-decoded physical chunk at the consumed-terminal boundary so a TERMINAL
+/// frame carries ONLY the just-completed turn's bytes, and the trailing bytes of a
+/// LATER turn ride a SEPARATE (non-terminal) frame.
+///
+/// A single physical read can contain turn A's `result` PLUS turn B's first bytes.
+/// `process_watcher_lines` stops at A's `result` and leaves B's bytes in the
+/// outer-scope `all_data` (the `leftover_len` after the parse). If we forwarded the
+/// WHOLE chunk on A's terminal frame, B's bytes would be consumed by the sink's
+/// parser as part of A's frame; on the NEXT loop pass `decoded.text` can be empty,
+/// so `forward_chunk_to_supervisor_relay_inner` emits NO frame for B → B is never
+/// delivered (black-hole), and the now-stale ACK for A can be reused for B
+/// (mis-commit). Splitting here forwards A's bytes terminal (with A's fence) and
+/// B's trailing bytes as their own non-terminal frame, so B is still mirrored and
+/// — when B completes — gets its OWN terminal frame + fence on a later pass.
+///
+/// The trailing `min(decoded.len(), leftover_len)` bytes of `decoded` are the part
+/// that survived the parse as leftover (B's bytes); the rest is A's terminal
+/// payload. `leftover_len` is the post-parse `all_data.len()` (bytes the parser did
+/// NOT consume). The split index is clamped to a UTF-8 char boundary (defensive —
+/// the leftover always begins on a JSONL `\n` line boundary in practice).
+fn split_decoded_chunk_at_terminal_boundary(decoded: &str, leftover_len: usize) -> (&str, &str) {
+    let trailing = leftover_len.min(decoded.len());
+    let mut split = decoded.len() - trailing;
+    while split < decoded.len() && !decoded.is_char_boundary(split) {
+        // A multibyte scalar straddles the nominal split: keep it whole on the
+        // terminal side rather than panic-slicing mid-scalar. The leftover begins
+        // one boundary later; the sink reorders nothing within a single line, so a
+        // whole extra line on the terminal side is harmless and never drops bytes.
+        split += 1;
+    }
+    decoded.split_at(split)
+}
+
 fn forward_chunk_to_supervisor_relay_inner(
     tmux_session_name: &str,
     chunk: &str,
@@ -1964,6 +2049,18 @@ fn watcher_should_direct_send_after_session_bound_ack(
 /// content is always re-delivered), and no incoherent mid-response tail. The
 /// idle-relay path still does a real JSONL `[committed,end)` re-read for its
 /// suffix; only the watcher response-text path is restricted to Skip/Full.
+///
+/// #3041 P1-3 (codex P1-3 issue 4 — DEFERRED, no regression, tracked by #3151):
+/// the watcher's 10s terminal-commit ACK wait can elapse while the sink's Discord
+/// POST is still IN FLIGHT (not failed). In that window `committed < end` (the sink
+/// has not advanced the authority yet because its POST has not returned), so this
+/// reconciliation chooses `SendFull` and the watcher re-sends — producing a
+/// duplicate when the in-flight sink POST later succeeds. This is NOT a regression:
+/// the pre-P1-3 path ALSO blind-re-sent on the 10s timeout, and `SendFull` IS the
+/// retry, so there is no black-hole (the content is always delivered). Fully closing
+/// the slow-sink-in-flight duplicate needs an in-flight/reclaimable sink-delivery
+/// marker (the sink signals "delivering this range" so the watcher waits/skips
+/// instead of re-sending) — OUT OF SCOPE for P1-3, tracked by #3151.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 enum WatcherTerminalResendAction {
     /// `committed >= end`: the whole range is already delivered. Do NOT re-send.
@@ -1971,6 +2068,13 @@ enum WatcherTerminalResendAction {
     /// `committed < end`: the range is not (fully) covered — re-send the full
     /// response. See the type doc for why no partial-suffix variant exists for
     /// the watcher response-text path (coordinate mismatch + all-or-nothing sink).
+    ///
+    /// #3041 P1-3 (codex P1-3 issue 4 — DEFERRED, #3151): this arm also fires when
+    /// the sink's POST is still IN FLIGHT at the 10s ACK timeout (committed has not
+    /// advanced yet) → a duplicate once that POST succeeds. No regression (the
+    /// pre-P1-3 path re-sent on timeout too) and no black-hole (SendFull is the
+    /// retry). The remaining slow-sink-in-flight duplicate is closed by the future
+    /// in-flight sink-delivery marker tracked in #3151.
     SendFull,
 }
 
@@ -2149,6 +2253,10 @@ fn watcher_terminal_commit_fence(
             consumed_end,
             turn_user_msg_id: identity.user_msg_id,
             turn_started_at: identity.started_at.clone(),
+            // #3041 P1-3 (codex P1-3 issue 2): carry the pinned turn's
+            // `turn_start_offset` so the sink's identity gate can disambiguate two
+            // consecutive `user_msg_id == 0` turns started in the same second.
+            turn_start_offset: identity.turn_start_offset,
         },
     )
 }
@@ -3376,6 +3484,7 @@ mod matched_session_jsonl_gate_tests {
             user_msg_id: 0,
             started_at: "2026-06-04T00:00:00Z".to_string(),
             tmux_session_name: Some(session.to_string()),
+            turn_start_offset: Some(64),
         };
         // Real terminal chunk: found_result, end > start, identity for this session.
         let fence = watcher_terminal_commit_fence(true, 0, 256, Some(&identity), session)
@@ -3383,6 +3492,9 @@ mod matched_session_jsonl_gate_tests {
         assert_eq!(fence.consumed_end, 256);
         assert_eq!(fence.turn_user_msg_id, 0);
         assert_eq!(fence.turn_started_at, "2026-06-04T00:00:00Z");
+        // #3041 P1-3 (codex P1-3 issue 2): the fence carries the pinned
+        // turn_start_offset so the sink can disambiguate same-second turns.
+        assert_eq!(fence.turn_start_offset, Some(64));
         // Not the result chunk → no fence.
         assert!(watcher_terminal_commit_fence(false, 0, 256, Some(&identity), session).is_none());
         // Zero range (end == start) → no fence.
@@ -3396,10 +3508,47 @@ mod matched_session_jsonl_gate_tests {
             user_msg_id: 0,
             started_at: "2026-06-04T00:00:00Z".to_string(),
             tmux_session_name: Some("AgentDesk-claude-99".to_string()),
+            turn_start_offset: Some(64),
         };
         assert!(
             watcher_terminal_commit_fence(true, 0, 256, Some(&other_identity), session).is_none()
         );
+    }
+
+    // #3041 P1-3 (codex P1-3 issue 1): a single physical chunk can carry turn A's
+    // result PLUS turn B's first bytes. The split must put A's bytes on the terminal
+    // side and B's leftover on the trailing side so B is forwarded (not black-holed).
+    #[test]
+    fn split_decoded_chunk_isolates_terminal_turn_from_trailing_tail() {
+        let turn_a = "{\"type\":\"result\",\"result\":\"A done\"}\n";
+        let turn_b = "{\"type\":\"assistant\",\"message\":{\"content\":[]}}\n";
+        let combined = format!("{turn_a}{turn_b}");
+        // After the parse, `all_data` holds turn B's bytes → leftover_len = turn_b.len().
+        let (terminal_part, tail_part) =
+            split_decoded_chunk_at_terminal_boundary(&combined, turn_b.len());
+        assert_eq!(terminal_part, turn_a, "terminal frame carries ONLY turn A");
+        assert_eq!(tail_part, turn_b, "turn B's bytes ride a separate frame");
+
+        // No leftover (single complete turn) → whole chunk is terminal, no tail.
+        let (only_terminal, no_tail) = split_decoded_chunk_at_terminal_boundary(turn_a, 0);
+        assert_eq!(only_terminal, turn_a);
+        assert!(no_tail.is_empty());
+
+        // Leftover >= chunk (turn A's result was entirely in a prior leftover): the
+        // whole decoded chunk is the trailing tail; terminal side is empty (the
+        // empty terminal frame is then a no-op, the tail is still forwarded).
+        let (empty_terminal, all_tail) =
+            split_decoded_chunk_at_terminal_boundary(turn_b, turn_b.len() + 10);
+        assert!(empty_terminal.is_empty());
+        assert_eq!(all_tail, turn_b);
+
+        // UTF-8 boundary safety: a split that would fall mid-scalar is nudged to the
+        // next char boundary (keeps the scalar whole on the terminal side).
+        let multibyte = "ok한"; // '한' is 3 bytes
+        // leftover_len = 1 would nominally split inside '한'; the helper keeps it whole.
+        let (head, tail) = split_decoded_chunk_at_terminal_boundary(multibyte, 1);
+        assert!(multibyte.is_char_boundary(head.len()));
+        assert_eq!(format!("{head}{tail}"), multibyte, "no bytes dropped");
     }
 
     #[test]
@@ -4601,9 +4750,15 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             &tmux_session_name,
         );
         let data_mirrored_to_session_relay = match initial_terminal_fence {
-            Some(fence) => forward_terminal_chunk_to_supervisor_relay(
+            // #3041 P1-3 (codex P1-3 issue 1): a single physical chunk may carry
+            // turn A's result PLUS turn B's first bytes. `all_data` after the parse
+            // holds turn B's leftover; split the decoded chunk at that boundary so
+            // the TERMINAL frame carries only turn A's bytes and turn B's tail rides
+            // a separate non-terminal frame (no black-hole, no shared-ACK reuse).
+            Some(fence) => forward_terminal_chunk_with_trailing_to_supervisor_relay(
                 &tmux_session_name,
                 &decoded_data.text,
+                all_data.len(),
                 &producer_registry,
                 &mut cached_relay_producer,
                 fence,
@@ -4841,13 +4996,20 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                             &tmux_session_name,
                         );
                         let chunk_forwarded_to_session_relay = match streaming_terminal_fence {
-                            Some(fence) => forward_terminal_chunk_to_supervisor_relay(
-                                &tmux_session_name,
-                                &decoded_chunk.text,
-                                &producer_registry,
-                                &mut cached_relay_producer,
-                                fence,
-                            ),
+                            // #3041 P1-3 (codex P1-3 issue 1): split a result+next-turn
+                            // physical chunk at the leftover boundary so turn A's
+                            // terminal frame carries only A's bytes and turn B's tail
+                            // rides a separate non-terminal frame (no black-hole).
+                            Some(fence) => {
+                                forward_terminal_chunk_with_trailing_to_supervisor_relay(
+                                    &tmux_session_name,
+                                    &decoded_chunk.text,
+                                    all_data.len(),
+                                    &producer_registry,
+                                    &mut cached_relay_producer,
+                                    fence,
+                                )
+                            }
                             None => forward_chunk_to_supervisor_relay(
                                 &tmux_session_name,
                                 &decoded_chunk.text,

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1690,6 +1690,18 @@ struct SessionBoundRelayAckTarget {
 struct SupervisorRelayForward {
     mirrored: bool,
     ack_target: Option<SessionBoundRelayAckTarget>,
+    /// #3041 P1-3 (codex P1-3 R7): TRUE when this forward SPLIT a result-bearing
+    /// physical chunk and a NON-EMPTY trailing tail (a LATER turn's bytes) followed
+    /// the just-completed turn's terminal frame. This is the turn-boundary signal:
+    /// after the just-completed turn (A) consumes its own terminal ACK, the watcher
+    /// must RESET the stored ack to `None` so the trailing turn (B) — which is
+    /// processed from the leftover buffer on a later pass, possibly while
+    /// `turn_identity_for_panel` is STILL pinned to A's offset — can NEVER inherit
+    /// A's finished ACK. With no inherited ack B reads `MissingTarget` → §3.2
+    /// reconciliation (committed-offset SendFull-or-Skip) → B is never black-holed.
+    /// Only the SPLIT terminal forward sets this; every other forward leaves it
+    /// `false` (no boundary crossed).
+    trailing_turn_follows: bool,
 }
 
 impl SupervisorRelayForward {
@@ -1697,6 +1709,7 @@ impl SupervisorRelayForward {
         Self {
             mirrored: true,
             ack_target: None,
+            trailing_turn_follows: false,
         }
     }
 
@@ -1704,6 +1717,7 @@ impl SupervisorRelayForward {
         Self {
             mirrored: false,
             ack_target: None,
+            trailing_turn_follows: false,
         }
     }
 }
@@ -1949,6 +1963,13 @@ fn forward_terminal_chunk_with_trailing_to_supervisor_relay(
     SupervisorRelayForward {
         mirrored: terminal_forward.mirrored && tail_forward.mirrored,
         ack_target: terminal_forward.ack_target,
+        // #3041 P1-3 (codex P1-3 R7): a NON-EMPTY trailing tail means a LATER turn's
+        // bytes followed THIS turn's terminal frame inside ONE physical chunk — a
+        // turn-boundary signal. The watcher resets the stored ack AFTER this turn
+        // consumes its own terminal ACK, so the trailing turn never inherits this
+        // finished turn's ACK (R7 black-hole close), regardless of whether
+        // `turn_identity_for_panel` has refreshed to the trailing turn yet.
+        trailing_turn_follows: true,
     }
 }
 
@@ -2034,6 +2055,9 @@ fn forward_chunk_to_supervisor_relay_inner(
             sequence,
             turn_start_offset: ack_turn_start_offset,
         }),
+        // A single forward of one frame never crosses a turn boundary; only the
+        // split helper sets this when it forwards a separate trailing tail.
+        trailing_turn_follows: false,
     }
 }
 
@@ -3385,6 +3409,152 @@ mod matched_session_jsonl_gate_tests {
             same_turn.map(|ack| ack.sequence),
             Some(5),
             "an ack set earlier in THIS turn survives a later non-terminal pass"
+        );
+    }
+
+    // #3041 P1-3 (codex P1-3 R7): the forward of a result-bearing physical chunk that
+    // ALSO carries a trailing later-turn tail MUST surface the turn-boundary signal
+    // (`trailing_turn_follows = true`) while still keeping the TERMINAL frame's ack as
+    // the wait target. A single-turn forward (no tail) must NOT raise the signal. This
+    // is the primitive the watcher latches to reset the stored ack at the boundary.
+    #[tokio::test]
+    async fn split_terminal_forward_signals_trailing_turn_and_keeps_terminal_ack() {
+        use crate::services::cluster::session_matcher::MatchedChannel;
+        use crate::services::cluster::session_matcher::expected_rollout_path_for;
+        use crate::services::cluster::stream_relay::{
+            DiscardSink, RelaySink, TerminalCommitFence, spawn_stream_relay,
+        };
+        use crate::services::provider::ProviderKind;
+
+        let session = ProviderKind::Claude.build_tmux_session_name("c-r7-split");
+        let matched = MatchedChannel {
+            channel_id: "c-r7-split".to_string(),
+            agent_id: "a-r7-split".to_string(),
+            provider: ProviderKind::Claude,
+            expected_session_name: session.clone(),
+            expected_rollout_path: expected_rollout_path_for(&session),
+        };
+        let registry = std::sync::Arc::new(
+            crate::services::cluster::relay_producer_registry::RelayProducerRegistry::new(),
+        );
+        let sink: std::sync::Arc<dyn RelaySink> = std::sync::Arc::new(DiscardSink);
+        let handle = spawn_stream_relay(matched.clone(), sink);
+        registry.register(session.clone(), handle.producer());
+        let mut cached = None;
+
+        // Turn A's result + turn B's first bytes in ONE physical chunk. After the
+        // parse, `all_data` holds turn B's bytes → leftover_len = turn_b.len().
+        let turn_a = "{\"type\":\"result\",\"result\":\"A done\"}\n";
+        let turn_b = "{\"type\":\"assistant\",\"message\":{\"content\":[]}}\n";
+        let combined = format!("{turn_a}{turn_b}");
+        let fence = TerminalCommitFence {
+            consumed_end: 240,
+            turn_user_msg_id: 0,
+            turn_started_at: "12:00:00".to_string(),
+            // A's pinned identity — the SAME offset the watcher carry helper keys on.
+            turn_start_offset: Some(100),
+        };
+        let split_forward = forward_terminal_chunk_with_trailing_to_supervisor_relay(
+            &session,
+            &combined,
+            turn_b.len(),
+            &registry,
+            &mut cached,
+            fence.clone(),
+        );
+        assert!(
+            split_forward.trailing_turn_follows,
+            "a result+next-turn split must signal that a later turn follows (R7 \
+             turn-boundary)"
+        );
+        assert!(
+            split_forward.ack_target.is_some(),
+            "the split still waits on the TERMINAL frame's ack (turn A's delivery)"
+        );
+        assert_eq!(
+            split_forward
+                .ack_target
+                .as_ref()
+                .and_then(|ack| ack.turn_start_offset),
+            Some(100),
+            "the kept ack is bound to turn A's pinned offset"
+        );
+
+        // A single complete turn (no trailing tail) must NOT raise the signal.
+        let single_forward = forward_terminal_chunk_with_trailing_to_supervisor_relay(
+            &session,
+            turn_a,
+            0,
+            &registry,
+            &mut cached,
+            fence,
+        );
+        assert!(
+            !single_forward.trailing_turn_follows,
+            "a single-turn terminal forward never crosses a turn boundary"
+        );
+        registry.deregister(&session);
+        let _ = handle;
+    }
+
+    // #3041 P1-3 (codex P1-3 R7): END-TO-END boundary semantics. The R6 carry helper
+    // ALONE still black-holes turn B when `turn_identity_for_panel` is STILL pinned to
+    // A's offset on B's pass (B's inflight not yet established): the carry KEEPS A's
+    // ack, and A's `Delivered` falsely satisfies B's ACK. R7 closes this by RESETTING
+    // the stored ack to `None` at A's split boundary AFTER A consumes its own ack —
+    // independent of whether the pinned identity refreshed. This test models that exact
+    // sequence: A's split signals the boundary → reset → B (even with A's stale pinned
+    // offset) starts with NO inherited ack → MissingTarget → §3.2 reconcile → B NOT
+    // black-holed even though A reported Delivered and B's tail was skipped/dropped.
+    #[test]
+    fn split_boundary_reset_prevents_later_turn_inheriting_finished_turn_ack() {
+        let metrics =
+            std::sync::Arc::new(crate::services::cluster::stream_relay::RelayMetrics::default());
+        // A's terminal frame ack (seq 5), pinned to A's turn_start_offset = 100.
+        let a_ack = SessionBoundRelayAckTarget {
+            metrics: metrics.clone(),
+            sequence: 5,
+            turn_start_offset: Some(100),
+        };
+
+        // A's pass forwards the split (result(A) + tail(B)) → the carry helper adopts
+        // A's fresh terminal ack (A's own delivery resolves correctly on A's ack).
+        let mut stored = carry_session_bound_ack_for_turn(None, Some(a_ack.clone()), Some(100));
+        assert_eq!(
+            stored.as_ref().map(|ack| ack.sequence),
+            Some(5),
+            "A's own delivery still uses A's ack (no spurious reset mid-A)"
+        );
+
+        // The split signalled a trailing turn. AFTER A's terminal block consumes A's
+        // ack, the watcher resets the stored ack at the boundary (the R7 fix).
+        let split_trailing_turn_follows = true;
+        if split_trailing_turn_follows {
+            stored = None;
+        }
+
+        // B's pass: `turn_identity_for_panel` is STILL pinned to A's offset (100) —
+        // the exact R7 condition the R6 carry helper could NOT fix. B's deferred
+        // forward produced NO fresh ack (B's tail was already mirrored, or skipped /
+        // dropped on the failure path). WITHOUT the reset, the carry helper would KEEP
+        // A's seq-5 ack here (same pinned offset) → black-hole. WITH the reset, the
+        // stored ack is already `None`, so B reconciles.
+        let carried_for_b = carry_session_bound_ack_for_turn(stored, None, Some(100));
+        assert!(
+            carried_for_b.is_none(),
+            "after A's split boundary reset, turn B NEVER inherits A's finished ack — \
+             even with `turn_identity_for_panel` STILL pinned to A's offset → B reads \
+             MissingTarget → §3.2 reconcile (SendFull/Skip) → B not black-holed"
+        );
+
+        // Contrast: WITHOUT the boundary reset (pre-R7), the very same B pass with A's
+        // stale pinned offset would KEEP A's ack — the regression R7 fixes.
+        let without_reset = carry_session_bound_ack_for_turn(Some(a_ack.clone()), None, Some(100));
+        assert_eq!(
+            without_reset.map(|ack| ack.sequence),
+            Some(5),
+            "documents the R7 regression the boundary reset closes: the carry helper \
+             alone keeps A's ack when the pinned offset is still A's"
         );
     }
 
@@ -4899,6 +5069,16 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         }
         all_data.push_str(&decoded_data.text);
         let turn_data_start_offset = all_data_start_offset;
+        // #3041 P1-3 (codex P1-3 R7): pass-scoped turn-boundary latch. Set TRUE when
+        // ANY forward on THIS watcher pass SPLIT a result-bearing chunk with a
+        // non-empty trailing tail (a LATER turn's bytes). After this turn consumes
+        // its own terminal ACK below, the stored ack is reset to `None` so the
+        // trailing turn — processed from the leftover buffer on a LATER pass, where
+        // `turn_identity_for_panel` may STILL be pinned to THIS turn's offset — can
+        // NEVER inherit this finished turn's ACK (→ MissingTarget → §3.2 reconcile,
+        // no black-hole). The reset happens AFTER the terminal ACK wait, so this
+        // turn's OWN ack resolution is untouched.
+        let mut split_trailing_turn_follows = false;
         let mut state = StreamLineState::new();
         let restored_turn_seed = restored_turn.take();
         let discard_restored_seed = should_discard_restored_seed_for_idle_direct_prompt(
@@ -5077,6 +5257,10 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 .as_ref()
                 .and_then(|identity| identity.turn_start_offset),
         );
+        // #3041 P1-3 (codex P1-3 R7): latch the turn-boundary signal. If this initial
+        // forward split a result+next-turn chunk, a later turn follows; reset the ack
+        // after THIS turn's terminal ACK wait so the later turn never inherits it.
+        split_trailing_turn_follows |= data_mirrored_to_session_relay.trailing_turn_follows;
         if initial_buffer_was_empty {
             all_data_fully_mirrored_to_session_relay = data_mirrored_to_session_relay.mirrored;
         } else {
@@ -5333,6 +5517,11 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                                 .as_ref()
                                 .and_then(|identity| identity.turn_start_offset),
                         );
+                        // #3041 P1-3 (codex P1-3 R7): latch the turn-boundary signal
+                        // for the streaming-chunk forward too (a result+next-turn
+                        // chunk can arrive mid-stream).
+                        split_trailing_turn_follows |=
+                            chunk_forwarded_to_session_relay.trailing_turn_follows;
                         let chunk_mirrored_to_session_relay =
                             chunk_forwarded_to_session_relay.mirrored;
                         session_bound_relay_turn_fully_mirrored &= chunk_mirrored_to_session_relay;
@@ -8078,6 +8267,22 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             frame_ack_outcome = ?session_bound_ack_outcome,
             "relay flight recorder"
         );
+        // #3041 P1-3 (codex P1-3 R7): turn-boundary ACK reset. THIS turn's terminal
+        // ACK has now been waited on (`session_bound_ack_outcome` is captured) and
+        // logged. If a forward on this pass SPLIT a result-bearing chunk with a
+        // trailing tail, a LATER turn (B) follows in the leftover buffer. B is
+        // processed on a SUBSEQUENT pass — possibly while `turn_identity_for_panel`
+        // is STILL pinned to THIS turn's offset (B's inflight not yet established),
+        // which would make `carry_session_bound_ack_for_turn` KEEP this turn's stale
+        // ack and let this turn's `Delivered` falsely satisfy B's ACK → B
+        // black-holed. RESET the stored ack to `None` HERE, AFTER this turn consumed
+        // it, so B starts with NO inherited ack → MissingTarget → §3.2 reconcile
+        // (committed-offset SendFull-or-Skip) → B is never black-holed (worst case a
+        // duplicate, the #3151-deferred edge). This is the primary R7 guarantee and
+        // is independent of whether the pinned identity refreshes.
+        if split_trailing_turn_follows {
+            all_data_session_bound_relay_ack = None;
+        }
         let mut watcher_direct_terminal_idle_committed = false;
         let mut tui_direct_anchor_terminal_body_visible = false;
         let mut tui_direct_anchor_or_lease_present_for_lifecycle =

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1868,6 +1868,21 @@ fn forward_terminal_chunk_with_trailing_to_supervisor_relay(
     // frame's ack_target (the watcher waits on THIS turn's delivery) and AND the
     // tail's mirror flag so a failed tail forward still surfaces "not fully
     // mirrored".
+    //
+    // #3041 P1-3 (codex P1-3 issue 1 R4 — DEFERRED multi-RESULT edge, #3151): a
+    // per-result split that gives turn B its OWN terminal fence is INFEASIBLE in
+    // this pass — a fence requires B's PINNED turn identity (`turn_start_offset` +
+    // `user_msg_id` + `started_at`), but only turn A's identity
+    // (`turn_identity_for_panel`) is loaded here; B's inflight is established on a
+    // LATER watcher loop pass. Any fence we emitted for B's bytes would carry A's
+    // identity and the sink's STRICT identity gate would (correctly) BLOCK it. So B
+    // rides this fence-less tail: it is MIRRORED (no black-hole) and gets its own
+    // real fence when B completes on a later pass. If this tail already contains
+    // B's COMPLETE result, the sink posts B from it; the watcher's later SendFull
+    // may then re-post B → a possible DUPLICATE (never a black-hole). The
+    // ACK-correlation hazard is closed in the sink (`deliver`): a fence-less frame
+    // reports `FrameAccepted`, NEVER a terminal commit, so B's post can never
+    // satisfy turn A's terminal-ACK and the ACK stays bound to A's terminal frame.
     let tail_forward =
         forward_chunk_to_supervisor_relay(tmux_session_name, tail_part, registry, cached_producer);
     SupervisorRelayForward {
@@ -2248,15 +2263,23 @@ fn watcher_terminal_commit_fence(
     if identity.tmux_session_name.as_deref() != Some(tmux_session_name) {
         return None;
     }
+    // #3041 P1-3 (codex P1-3 issue 2 R4): a fence MUST carry a real
+    // `turn_start_offset`. The sink's identity gate is STRICT on this field (no
+    // None fallback) so two consecutive `user_msg_id == 0` (TUI-direct) turns in
+    // the same one-second `started_at` cannot collide. If the would-be terminal
+    // turn's start offset is unknown, DO NOT emit a fence: returning None forwards
+    // a non-terminal frame instead, and the watcher reconciliation's SendFull then
+    // safely delivers this turn (no black-hole, no weakly-gated advance).
+    let turn_start_offset = identity.turn_start_offset?;
     Some(
         crate::services::cluster::stream_relay::TerminalCommitFence {
             consumed_end,
             turn_user_msg_id: identity.user_msg_id,
             turn_started_at: identity.started_at.clone(),
-            // #3041 P1-3 (codex P1-3 issue 2): carry the pinned turn's
-            // `turn_start_offset` so the sink's identity gate can disambiguate two
-            // consecutive `user_msg_id == 0` turns started in the same second.
-            turn_start_offset: identity.turn_start_offset,
+            // A fence ALWAYS carries a real `turn_start_offset` (guaranteed above)
+            // so the sink's identity gate can disambiguate two consecutive
+            // `user_msg_id == 0` turns started in the same second.
+            turn_start_offset: Some(turn_start_offset),
         },
     )
 }
@@ -3512,6 +3535,23 @@ mod matched_session_jsonl_gate_tests {
         };
         assert!(
             watcher_terminal_commit_fence(true, 0, 256, Some(&other_identity), session).is_none()
+        );
+
+        // #3041 P1-3 (codex P1-3 issue 2 R4): a fence MUST carry a real
+        // turn_start_offset. If the pinned identity's offset is None, the producer
+        // emits NO fence (forwards a non-terminal frame instead) so the sink's
+        // STRICT offset gate never sees a None and the watcher reconciliation's
+        // SendFull delivers this turn safely (no black-hole, no weak gate).
+        let no_offset_identity = InflightTurnIdentity {
+            user_msg_id: 0,
+            started_at: "2026-06-04T00:00:00Z".to_string(),
+            tmux_session_name: Some(session.to_string()),
+            turn_start_offset: None,
+        };
+        assert!(
+            watcher_terminal_commit_fence(true, 0, 256, Some(&no_offset_identity), session)
+                .is_none(),
+            "a turn with no known turn_start_offset must NOT emit a fence (strict-offset guarantee)"
         );
     }
 

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1887,6 +1887,56 @@ fn watcher_should_direct_send_after_session_bound_ack(
     should_direct_send && !matches!(ack_outcome, SessionBoundRelayAckOutcome::Delivered)
 }
 
+/// #3041 P1-3 (Part b, §3.2): the watcher's terminal re-send DECISION after a
+/// non-`Delivered` session-bound ACK, reconciled against the offset authority
+/// (`committed_relay_offset`) instead of BLINDLY re-sending. This is the
+/// watcher-terminal counterpart of the idle relay's `idle_relay_range_action`
+/// (skip / suffix / full), extended to the terminal re-send path so the 10s
+/// blind re-send (the `relay_terminal_ack_timeout` duplicate vector) is removed.
+///
+/// Because Part (a) makes a confirmed sink delivery ADVANCE the authority to the
+/// watcher's own consumed-terminal `end`, this reconciliation is exact:
+///   * `committed >= end`           → the range was already delivered (by the
+///                                     sink, ACK merely lagged) → SKIP (no dup).
+///   * `start < committed < end`    → the prefix `[start, committed)` was
+///                                     delivered → send ONLY the uncommitted
+///                                     suffix (no black-hole, reduced dup).
+///   * `committed <= start`         → nothing delivered → send the FULL range.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum WatcherTerminalResendAction {
+    /// `committed >= end`: the whole range is already delivered. Do NOT re-send.
+    SkipAlreadyCommitted,
+    /// `start < committed < end`: send only the uncommitted suffix
+    /// `[committed, end)`; the prefix was already delivered.
+    SendSuffix,
+    /// `committed <= start`: nothing covered — send the full range.
+    SendFull,
+}
+
+/// Reconcile a watcher terminal re-send against the committed offset authority.
+/// Only ever consulted when the watcher WOULD have re-sent (a non-`Delivered`
+/// ACK and a real body); the caller still applies the existing `relay_owner`
+/// suppression. A zero/inverted range (`end <= start`) yields `SendFull` so the
+/// existing zero-range guards (which never lease/advance) stay in control — the
+/// reconciliation never manufactures a skip for a range it cannot reason about.
+fn watcher_terminal_resend_action(
+    committed: u64,
+    start: u64,
+    end: u64,
+) -> WatcherTerminalResendAction {
+    if end <= start {
+        // Degenerate range: defer to the existing no-range handling downstream.
+        return WatcherTerminalResendAction::SendFull;
+    }
+    if committed >= end {
+        WatcherTerminalResendAction::SkipAlreadyCommitted
+    } else if committed > start {
+        WatcherTerminalResendAction::SendSuffix
+    } else {
+        WatcherTerminalResendAction::SendFull
+    }
+}
+
 fn watcher_terminal_response_for_direct_send<'a>(
     full_response: &'a str,
     response_sent_offset: usize,
@@ -3063,6 +3113,74 @@ mod matched_session_jsonl_gate_tests {
             SessionBoundRelayAckOutcome::Delivered,
             true
         ));
+    }
+
+    // #3041 P1-3 (Part b, §3.2): the watcher's terminal re-send reconciliation
+    // against the committed offset authority — REPLACING the blind re-send. These
+    // assert the exact 3-way skip/suffix/full decision so the failure-mode-① skip
+    // (no duplicate) and the black-hole guard (suffix/full still sent) are pinned.
+    #[test]
+    fn watcher_terminal_resend_skips_when_range_already_committed() {
+        // failure-mode-①: the sink delivered `[0, 100)` (Part a advanced the
+        // authority to 100) but the terminal-commit ACK lagged the 10s wait →
+        // committed >= end → SKIP. No duplicate.
+        assert_eq!(
+            watcher_terminal_resend_action(100, 0, 100),
+            WatcherTerminalResendAction::SkipAlreadyCommitted,
+            "committed == end must skip the re-send (no duplicate)"
+        );
+        assert_eq!(
+            watcher_terminal_resend_action(150, 0, 100),
+            WatcherTerminalResendAction::SkipAlreadyCommitted,
+            "committed past end must skip the re-send (no duplicate)"
+        );
+    }
+
+    #[test]
+    fn watcher_terminal_resend_sends_suffix_on_partial_overlap() {
+        // The sink delivered the prefix `[0, 60)`; the file grew to 100 before the
+        // watcher reconciled → send ONLY the uncommitted suffix `[60, 100)`.
+        // No black-hole (the suffix IS sent), reduced duplicate.
+        assert_eq!(
+            watcher_terminal_resend_action(60, 0, 100),
+            WatcherTerminalResendAction::SendSuffix
+        );
+        // Boundary: committed just past start is still a partial overlap.
+        assert_eq!(
+            watcher_terminal_resend_action(1, 0, 100),
+            WatcherTerminalResendAction::SendSuffix
+        );
+    }
+
+    #[test]
+    fn watcher_terminal_resend_sends_full_when_nothing_committed() {
+        // BLACK-HOLE GUARD: the sink did NOT deliver (committed < end, and
+        // committed <= start) → the FULL range must still be sent. Removing the
+        // blind re-send must NEVER drop an undelivered range.
+        assert_eq!(
+            watcher_terminal_resend_action(0, 0, 100),
+            WatcherTerminalResendAction::SendFull,
+            "committed == start (nothing delivered) must send the full range"
+        );
+        assert_eq!(
+            watcher_terminal_resend_action(40, 50, 100),
+            WatcherTerminalResendAction::SendFull,
+            "committed below start must send the full range (no black-hole)"
+        );
+    }
+
+    #[test]
+    fn watcher_terminal_resend_degenerate_range_defers_to_full() {
+        // A zero/inverted range manufactures NO skip — it defers to the existing
+        // downstream zero-range guards (which never lease/advance).
+        assert_eq!(
+            watcher_terminal_resend_action(100, 100, 100),
+            WatcherTerminalResendAction::SendFull
+        );
+        assert_eq!(
+            watcher_terminal_resend_action(0, 100, 50),
+            WatcherTerminalResendAction::SendFull
+        );
     }
 
     #[test]
@@ -7042,14 +7160,91 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 crate::services::discord::inflight::RelayOwnerKind::None
             )
         });
-        let watcher_direct_fallback_after_session_bound_ack =
-            watcher_should_direct_send_after_session_bound_ack(
-                relay_decision.should_direct_send,
+        let watcher_direct_fallback_intended = watcher_should_direct_send_after_session_bound_ack(
+            relay_decision.should_direct_send,
+            session_bound_ack_outcome,
+            relay_owner_present,
+        );
+        // #3041 P1-3 (Part b, §3.2): REPLACE the blind re-send. When the watcher
+        // would re-send its terminal body after a non-`Delivered` session-bound
+        // ACK (the `relay_terminal_ack_timeout` duplicate vector), reconcile
+        // against the offset authority FIRST. The range is the SAME consumed
+        // terminal range the lease/advance use:
+        // `[data_start_offset, terminal_event_consumed_offset(current_offset, all_data))`.
+        // Part (a) makes a confirmed sink delivery advance `committed_relay_offset`
+        // to the watcher's own `end`, so this consult is exact:
+        //   * committed >= end → SKIP (the sink delivered; ACK merely lagged) → no
+        //     duplicate (failure-mode-①);
+        //   * start < committed < end → send only the uncommitted suffix → no
+        //     black-hole, reduced duplicate;
+        //   * committed <= end (nothing committed) → re-send (no black-hole).
+        // Reconcile ONLY on the session-bound re-send path (an attempted delegation
+        // whose ACK was not `Delivered`); the plain watcher-direct path (no
+        // delegation) keeps its existing behaviour untouched.
+        let watcher_resend_range_start = data_start_offset;
+        let watcher_resend_range_end = terminal_event_consumed_offset(current_offset, &all_data);
+        let watcher_resend_committed = shared.committed_relay_offset(channel_id);
+        let watcher_resend_reconciled = session_bound_terminal_delivery_attempted
+            && watcher_direct_fallback_intended
+            && !matches!(
                 session_bound_ack_outcome,
-                relay_owner_present,
+                SessionBoundRelayAckOutcome::Delivered
             );
+        let watcher_resend_action = if watcher_resend_reconciled {
+            // Self-heal a stale-high authority left by a respawned/truncated
+            // wrapper BEFORE consulting it, exactly as the no-inflight gate and the
+            // idle relay do — so a fresh range is never wrongly skipped (codex P2).
+            reset_relay_watermark_on_generation_change(
+                &shared,
+                channel_id,
+                &tmux_session_name,
+                "watcher_terminal_resend_reconcile",
+            );
+            let committed = shared.committed_relay_offset(channel_id);
+            Some(watcher_terminal_resend_action(
+                committed,
+                watcher_resend_range_start,
+                watcher_resend_range_end,
+            ))
+        } else {
+            None
+        };
+        if matches!(
+            watcher_resend_action,
+            Some(WatcherTerminalResendAction::SkipAlreadyCommitted)
+        ) {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            tracing::info!(
+                provider = watcher_provider.as_str(),
+                channel = channel_id.get(),
+                tmux_session = %tmux_session_name,
+                start = watcher_resend_range_start,
+                end = watcher_resend_range_end,
+                committed = watcher_resend_committed,
+                ?session_bound_ack_outcome,
+                "  [{ts}] 👁 #3041 P1-3 §3.2: skipped watcher terminal re-send — range already committed by the sink (offset authority); no duplicate"
+            );
+        }
+        // The watcher actually direct-sends only when the reconciliation did NOT
+        // skip the range. `SkipAlreadyCommitted` suppresses the re-send (no dup);
+        // `SendSuffix`/`SendFull`/the non-reconciled path proceed to send.
+        let watcher_direct_fallback_after_session_bound_ack = watcher_direct_fallback_intended
+            && !matches!(
+                watcher_resend_action,
+                Some(WatcherTerminalResendAction::SkipAlreadyCommitted)
+            );
+        // §3.2 suffix trim: on a PARTIAL overlap the prefix was already delivered,
+        // so do NOT re-send the full body — fall back to the streamed-suffix body
+        // (`response_sent_offset`), which excludes the already-delivered prefix
+        // (no black-hole: the uncommitted suffix is still sent). On `SendFull` /
+        // the non-reconciled path keep the existing full-body fallback semantics.
+        let watcher_resend_force_suffix = matches!(
+            watcher_resend_action,
+            Some(WatcherTerminalResendAction::SendSuffix)
+        );
         let session_bound_fallback_uses_full_body = session_bound_terminal_delivery_attempted
-            && watcher_direct_fallback_after_session_bound_ack;
+            && watcher_direct_fallback_after_session_bound_ack
+            && !watcher_resend_force_suffix;
         let direct_terminal_response = watcher_terminal_response_for_direct_send(
             &full_response,
             response_sent_offset,
@@ -7272,9 +7467,46 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         inflight.last_watcher_relayed_offset = Some(turn_data_start_offset);
                         inflight.last_watcher_relayed_generation_mtime_ns =
                             last_observed_generation_mtime_ns;
+                        // #3041 P1-3 (Part a, B1): persist the watcher's
+                        // AUTHORITATIVE consumed terminal END for the range it is
+                        // delegating to the sink — exactly the value the watcher
+                        // advances `confirmed_end_offset` to on its OWN terminal
+                        // delivery (`watcher_lease_end ==
+                        // terminal_event_consumed_offset(current_offset, all_data)`).
+                        // The sink reads this (identity-gated) to advance the offset
+                        // authority on a confirmed delivery, so reconciliation (Part
+                        // b) sees the delegated range as delivered even if the
+                        // terminal-commit ACK lags. Only record a real (non-empty)
+                        // range; a zero/inverted range never advances.
+                        if watcher_lease_end > watcher_lease_start {
+                            inflight.session_bound_delegated_terminal_end = Some(watcher_lease_end);
+                        }
                         let _ = crate::services::discord::inflight::save_inflight_state(&inflight);
                     }
                 }
+            }
+            clear_provider_overload_retry_state(channel_id);
+            true
+        } else if matches!(
+            watcher_resend_action,
+            Some(WatcherTerminalResendAction::SkipAlreadyCommitted)
+        ) {
+            // #3041 P1-3 (Part b, §3.2): the offset authority already covers this
+            // terminal range (`committed >= end`) — the session-bound sink already
+            // delivered it (the terminal-commit ACK merely lagged the 10s wait, and
+            // Part (a) advanced the authority on the sink's confirmed POST). This is
+            // the failure-mode-① case: re-sending would DUPLICATE. Treat it as a
+            // completed delegated delivery (mirror the delegation-success arm): the
+            // sink owns the placeholder/body, so do NOT delete the placeholder and
+            // do NOT re-send. `relay_ok = true` so the turn's lifecycle finalizes
+            // (completion observed, inflight cleared) exactly as a delivered turn —
+            // the response IS on the channel, just posted by the sink. The offset is
+            // already at `end`, so the inline advance below is an idempotent no-op.
+            if has_current_response {
+                tui_direct_anchor_terminal_body_visible = true;
+                last_relayed_offset = Some(turn_data_start_offset);
+                last_observed_generation_mtime_ns =
+                    Some(read_generation_file_mtime_ns(&tmux_session_name));
             }
             clear_provider_overload_retry_state(channel_id);
             true


### PR DESCRIPTION
## #3041 P1-3 (§3.2 CORE — remove the 10s blind re-send)

### Part (a) — close BLOCKER B1: the sink advances the offset authority

**Delegation-model finding.** The session-bound sink runs UNDER the watcher's delegation and is NOT a `DeliveryLeaseCell` holder — the watcher's delegation path never `try_acquire`s the cell, so there is no sink lease to commit. The sink also cannot derive a `confirmed_end_offset`-compatible byte range: `StreamFrame`/`SessionRelayDelivery` carry only an opaque payload + sequence (no JSONL offset), and the only file offset it could read (the JSONL EOF) overshoots the consumed-terminal end and would **black-hole** later-appended undelivered bytes (codex r4 P1). So a clean *sink-derived* advance / a Sink lease commit is architecturally impossible without threading offsets through the whole cluster stream-relay (out of scope).

**Decision: direct advance to the WATCHER's authoritative end.** The watcher is the byte-range authority. It now persists its exact consumed-terminal end (`session_bound_delegated_terminal_end`, a new additive `Option<u64>` inflight field) when it delegates (`tmux_watcher.rs` delegation block). On a CONFIRMED terminal Discord delivery the sink DIRECTLY advances `confirmed_end_offset` to that value via `advance_watcher_confirmed_end` (`session_relay_sink.rs::advance_offset_for_confirmed_delegated_terminal`, called at all 4 `Committed` sites). This is the **B1 commit fence**: POST success and offset advance are coupled in the same path.

- **No black-hole:** the sink never reads a fresh EOF; it advances only to the watcher's own end (the exact value the watcher itself would advance to), read off the inflight loaded for THIS delivery (never a later turn's larger end).
- **No double-advance / no regression:** monotonic CAS makes it idempotent.

### Part (b) — replace the TimedOut→blind re-send with §3.2 reconciliation

`watcher_terminal_resend_action(committed, start, end)` (`tmux_watcher.rs`) consults `committed_relay_offset` instead of blindly re-sending:
- `committed >= end` → **SkipAlreadyCommitted** (failure-mode-①: sink delivered, ACK merely lagged → **no duplicate**);
- `start < committed < end` → **SendSuffix** (uncommitted suffix only → no black-hole, reduced dup);
- `committed <= start` → **SendFull** (nothing delivered → full re-send).

A dedicated `SkipAlreadyCommitted` relay arm treats the already-committed range as a completed delegated delivery (no placeholder double-handling; `relay_ok=true` so lifecycle finalizes; the inline advance is an idempotent no-op). The ACK polling itself is preserved, and the `relay_terminal_ack_timeout` metric still fires.

**No-duplicate** comes from Part (a) advancing the authority on the sink's confirmed POST so reconciliation sees `committed >= end` and skips. **No-black-hole** comes from every range with `committed < end` still sending its uncommitted suffix/full body.

### Tests
- Part a: `sink_confirmed_delivery_advances_committed_offset_to_delegated_end` (advance to delegated end; monotonic; no-advance on None/0).
- Part b: `watcher_terminal_resend_*` matrix — skip (failure-mode-① no-dup), suffix, full (black-hole guard), degenerate-range guard.
- turn_finalizer (50) / delivery_lease (39) / relay (200) / sink (31) / offset (52) / bridge (153) / transition (3) / cancel (95) all green.

### Verification (macOS, local)
`cargo fmt --check` ✓ · `cargo build --all-targets` ✓ (only pre-existing unused-import warning) · `cargo clippy --workspace --all-targets --all-features` ✓ (11 warnings on base AND with change — no new) · docs/script-checks ✓ (`generate_inventory_docs.py` + `check_agent_maintenance_docs.py` pass; synced `change-surfaces.md` tmux_watcher 8102→8266; `ci-script-checks.sh` clean apart from the ignorable untracked `routines/dependency-update-watcher.js`). confirmed_end monotonic + advance helpers cross-platform.

Note: the inflight parallel `AGENTDESK_ROOT_DIR` race is pre-existing (base also fails parallel); both touched tests pass single-threaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Codex review fixes (PR #3150 round 2)

A strict codex review found 4 issues. Issues 1–3 (real correctness bugs) are fixed here; issue 4 is a documented no-regression deferral.

**Issue 1 — multi-turn backlog in one physical chunk (black-hole / mis-commit).** A single physical read can contain turn A's `result` PLUS turn B's first bytes. Previously the whole `decoded.text` was forwarded on A's terminal frame, so B's bytes were consumed as part of A's frame; on the next pass `decoded.text` could be empty → no frame for B (black-hole) and A's stale ACK could be reused (mis-commit). **Fix (split):** `split_decoded_chunk_at_terminal_boundary` + `forward_terminal_chunk_with_trailing_to_supervisor_relay` (`tmux_watcher.rs`) split the decoded chunk at the post-parse leftover boundary so the TERMINAL frame carries ONLY turn A's bytes (with A's fence) and turn B's trailing bytes ride a SEPARATE non-terminal frame — B is mirrored, never black-holed, and gets its own fence when it completes. Applied at both watcher read sites. Test: `split_multi_turn_chunk_commits_each_turn_with_its_own_fence` (A commits to A's end with A's identity; B not black-holed, commits to B's end with B's identity) + `split_decoded_chunk_isolates_terminal_turn_from_trailing_tail`.

**Issue 2 — identity gate too weak (same-second `user_msg_id==0` collision).** `now_string` has 1-second resolution; the gate compared only `(user_msg_id, started_at)`, so two back-to-back TUI-direct turns with `user_msg_id==0` in the same second shared an identical pair and a delayed OLD frame could pass the NEW turn's gate. **Fix:** added `turn_start_offset` (monotonic per turn) to the frame turn identity — `StreamFrame` + `TerminalCommitFence` + `InflightTurnIdentity` + `SessionRelayDelivery` + the sink gate. Test: `sink_identity_gate_blocks_same_second_turn_by_turn_start_offset`.

**Issue 3 — sink gates on a STALE inflight snapshot taken before the async POST.** The sink loaded inflight ONCE before the slow Discord POST and reused it to authorize the advance after the await; a turn cleared/replaced DURING the POST still passed the stale gate. **Fix:** `advance_after_confirmed_post` re-loads a FRESH inflight immediately after the confirmed POST and re-checks the identity gate (incl. `turn_start_offset`) before advancing; all 4 `Committed` sites use it. Test: `sink_post_post_recheck_blocks_advance_when_inflight_replaced_during_post`.

### Honesty note (issue 4 — DEFERRED, no regression, tracked by #3151)

The watcher's 10s terminal-commit ACK wait can elapse while the sink's Discord POST is still **in flight** (not failed). In that window `committed < end`, so the §3.2 reconciliation chooses `SendFull` and the watcher re-sends → a **duplicate** once the in-flight sink POST later succeeds. This is **NOT a regression**: the pre-P1-3 path also blind-re-sent on the 10s timeout, and `SendFull` IS the retry — so there is **no black-hole** today. Fully eliminating the slow-sink-in-flight duplicate needs an in-flight / reclaimable sink-delivery marker (the sink signals "delivering this range" so the watcher waits/skips instead of re-sending). That is **out of scope** for P1-3 and tracked by **#3151**; documented in code at the `WatcherTerminalResendAction::SendFull` arm + the reconciliation type doc.
