### PR TITLE
fix(#3041): P1-4 RAII guard releases the session-bound external-input relay lease on ALL exit paths (Err/?/HTTP-503/panic) — closes the up-to-10min delivery block (§4-④)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -128,7 +128,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (8763 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (8766 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -223,7 +223,12 @@
     `clear_external_input_relay_lease_if_generation_matches` instead of the
     unconditional by-key `clear_external_input_relay_lease`, closing the
     stale-snapshot clobber where a turn-2 same-key lease recorded during turn-1's
-    in-flight send was wrongly removed by turn-1's success clear).
+    in-flight send was wrongly removed by turn-1's success clear);
+    +3 from #3041 P1-4 codex R3: the snapshot now reads the lease ONCE
+    (`external_input_relay_lease(...)` under a SINGLE STATE lock) and derives BOTH
+    the presence bool and the generation from that one atomic read, closing the
+    present/generation TOCTOU where two separate accessor calls re-locked STATE and
+    a concurrently-started turn could slip a newer same-key lease into the gap).
   - `src/services/discord/tui_prompt_relay.rs` (3982 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +12 from #3041 P1-4 codex: the lease record
@@ -300,7 +305,7 @@
   - `src/services/codex_tmux_wrapper.rs` (1222 lines; Codex tmux wrapper JSON
     event parser and relay bridge for native Codex session events — bugfix only
     outside an extraction plan).
-  - `src/services/tui_prompt_dedupe.rs` (1172 lines; shared TUI prompt
+  - `src/services/tui_prompt_dedupe.rs` (1152 lines; shared TUI prompt
     fingerprinting/dedupe state for hook and rollout relay paths, bugfix only
     outside an extraction plan; +88 from #3041 P1-4 codex: a per-record
     `generation: u64` nonce on `ExternalInputRelayLease` (process-global
@@ -312,11 +317,13 @@
     `reset_state_for_tests` helper; +26 from #3105 codex-P1 sub-case B
     `evict_dead_tmux_mirror` tombstone helper that drops both the runtime and
     channel mirror for a dead/orphaned session and then allows re-registration;
-    +20 from #3041 P1-4 codex follow-up: the `external_input_relay_lease_generation`
-    read-only accessor (returns the CURRENT stored lease's generation iff the channel
-    scope matches, else None) that the watcher snapshots before its awaited relay and
-    the relay early-return guard captures, so post-await clears are generation-scoped
-    no-clobber, plus its accessor + watcher-snapshot no-clobber regression tests).
+    -20 from #3041 P1-4 codex R3: REMOVED the now-unused
+    `external_input_relay_lease_generation` read-only accessor (its only caller was the
+    watcher, which now snapshots the lease ONCE via the single-lock
+    `external_input_relay_lease` and derives both presence + generation from that one
+    atomic read, closing the present/generation TOCTOU) plus its dedicated accessor unit
+    test; the watcher-snapshot no-clobber regression test is retained, rewritten to take
+    its G1/G2 snapshots from `external_input_relay_lease(...).map(|l| l.generation)`).
   - `src/services/discord/recovery_engine.rs` (4037 lines; +36 from #3099
     task-notification anchor `⏳` cleanup for `user_msg_id == 0` recovery; +4
     from the #3099 re-review pinned-injected-message-id cleanup target; +55 from

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -128,7 +128,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (8739 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (8763 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -216,8 +216,15 @@
     So a later turn ALWAYS starts with no inherited ack → MissingTarget → §3.2 reconcile
     (SendFull/Skip) → never black-holed, independent of whether the pinned identity
     refreshed. A's own delivery still resolves on A's ack (the reset is post-wait);
-    split loop helpers further before adding behavior).
-  - `src/services/discord/tui_prompt_relay.rs` (3886 lines; SSH-direct TUI
+    split loop helpers further before adding behavior;
+    +24 from #3041 P1-4 codex: the watcher post-delivery external-input lease clear
+    now snapshots the lease GENERATION before the awaited relay
+    (`external_input_lease_generation_before_relay`) and clears via
+    `clear_external_input_relay_lease_if_generation_matches` instead of the
+    unconditional by-key `clear_external_input_relay_lease`, closing the
+    stale-snapshot clobber where a turn-2 same-key lease recorded during turn-1's
+    in-flight send was wrongly removed by turn-1's success clear).
+  - `src/services/discord/tui_prompt_relay.rs` (3982 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +12 from #3041 P1-4 codex: the lease record
     helpers now RETURN the recorded lease (with its per-record `generation`
@@ -272,7 +279,17 @@
     `claim_tui_direct_synthetic_turn` now clears the stale `📦 … idle N분`
     idle-recap card once a TUI-driven turn is owned for the channel, reusing the
     shared `idle_recap::spawn_clear_idle_recap_for_channel` helper (keyed on
-    `channel_id`, mirrors the Discord-intake clear).
+    `channel_id`, mirrors the Discord-intake clear);
+    +96 from #3041 P1-4 codex: a `TuiDirectObservedLeaseEarlyReturnGuard` (arm right
+    after `record_observed_external_turn_lease`, disarm on the success path before
+    the bridge-tail ownership block) closes the early-return leak where a FAILURE
+    abort (health registry None, notify `resolve_bot_http` Err/503, task-card repeat,
+    anchor POST failure) left the recorded (possibly BridgeAdapter-owned) lease set
+    for the full TTL, blocking the legitimate watcher/sink delivery. The guard clears
+    BY the recorded generation (`clear_external_input_relay_lease_if_generation_matches`)
+    so a newer same-key lease recorded during the await is never clobbered; success
+    persistence is preserved by disarming before the bridge legitimately retains the
+    turn (plus failure-clear / disarm-persist / no-clobber regression tests).
   - `src/services/discord/idle_recap.rs` (1881 prod lines; idle-recap card
     compose/post/clear surface, registered giant-file (#3036) — bugfix only
     outside an extraction plan. Crossed 1000 prod LoC with #3146 Part 1: the
@@ -283,7 +300,7 @@
   - `src/services/codex_tmux_wrapper.rs` (1222 lines; Codex tmux wrapper JSON
     event parser and relay bridge for native Codex session events — bugfix only
     outside an extraction plan).
-  - `src/services/tui_prompt_dedupe.rs` (1152 lines; shared TUI prompt
+  - `src/services/tui_prompt_dedupe.rs` (1172 lines; shared TUI prompt
     fingerprinting/dedupe state for hook and rollout relay paths, bugfix only
     outside an extraction plan; +88 from #3041 P1-4 codex: a per-record
     `generation: u64` nonce on `ExternalInputRelayLease` (process-global
@@ -294,7 +311,12 @@
     a newer lease; +9 from the #3099 re-review crate-visible
     `reset_state_for_tests` helper; +26 from #3105 codex-P1 sub-case B
     `evict_dead_tmux_mirror` tombstone helper that drops both the runtime and
-    channel mirror for a dead/orphaned session and then allows re-registration).
+    channel mirror for a dead/orphaned session and then allows re-registration;
+    +20 from #3041 P1-4 codex follow-up: the `external_input_relay_lease_generation`
+    read-only accessor (returns the CURRENT stored lease's generation iff the channel
+    scope matches, else None) that the watcher snapshots before its awaited relay and
+    the relay early-return guard captures, so post-await clears are generation-scoped
+    no-clobber, plus its accessor + watcher-snapshot no-clobber regression tests).
   - `src/services/discord/recovery_engine.rs` (4037 lines; +36 from #3099
     task-notification anchor `⏳` cleanup for `user_msg_id == 0` recovery; +4
     from the #3099 re-review pinned-injected-message-id cleanup target; +55 from

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -217,9 +217,13 @@
     (SendFull/Skip) → never black-holed, independent of whether the pinned identity
     refreshed. A's own delivery still resolves on A's ack (the reset is post-wait);
     split loop helpers further before adding behavior).
-  - `src/services/discord/tui_prompt_relay.rs` (3874 lines; SSH-direct TUI
+  - `src/services/discord/tui_prompt_relay.rs` (3886 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
-    outside an extraction plan; +4 from #3082 queued-only answer-flush gate
+    outside an extraction plan; +12 from #3041 P1-4 codex: the lease record
+    helpers now RETURN the recorded lease (with its per-record `generation`
+    nonce) and callers adopt it back so a later exact-match/by-generation clear
+    targets the precise stored identity (no clobber of a newer lease); +4 from
+    #3082 queued-only answer-flush gate
     (`is_queued_notice = false` for the TUI idle-response placeholder); +139
     from #3099/#3100 injected-prompt classifier + neutral system-continuation
     note; +140 from the #3099/#3100 codex re-review: P1 bridge-tail output
@@ -279,9 +283,15 @@
   - `src/services/codex_tmux_wrapper.rs` (1222 lines; Codex tmux wrapper JSON
     event parser and relay bridge for native Codex session events — bugfix only
     outside an extraction plan).
-  - `src/services/tui_prompt_dedupe.rs` (1064 lines; shared TUI prompt
+  - `src/services/tui_prompt_dedupe.rs` (1152 lines; shared TUI prompt
     fingerprinting/dedupe state for hook and rollout relay paths, bugfix only
-    outside an extraction plan; +9 from the #3099 re-review crate-visible
+    outside an extraction plan; +88 from #3041 P1-4 codex: a per-record
+    `generation: u64` nonce on `ExternalInputRelayLease` (process-global
+    `AtomicU64`, stamped in `record_external_input_turn_lease` which now returns
+    the recorded lease) plus the `clear_external_input_relay_lease_if_generation_matches`
+    no-clobber primitive — two value-identical `Unassigned` leases for the same
+    key get DISTINCT generations so a slow old delivery's RAII guard never clears
+    a newer lease; +9 from the #3099 re-review crate-visible
     `reset_state_for_tests` helper; +26 from #3105 codex-P1 sub-case B
     `evict_dead_tmux_mirror` tombstone helper that drops both the runtime and
     channel mirror for a dead/orphaned session and then allows re-registration).

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -151,11 +151,89 @@ fn session_bound_external_lease_blocks_delivery(
     ) else {
         return false;
     };
+    // #3041 P1-4 / §4-④: the external_input lease's role is now "input dedup
+    // only". A *foreign-owner* lease (BridgeAdapter / TuiPromptRelay /
+    // TmuxWatcher) still names the OTHER subsystem that owns this terminal
+    // delivery, so the session-bound sink must still defer to it (that is NOT
+    // the self-block that caused the up-to-10min stall). But an `Unassigned`
+    // or `SessionBoundRelay`-owned lease is THIS sink's own input-dedup marker
+    // — it must NOT block our own delivery (terminal-delivery serialization now
+    // belongs to the `DeliveryLeaseCell` B2 gate + per-sequence ACK +
+    // reconciliation, not to this lease). Keeping the foreign-owner deferral is
+    // a routing concern, not a self-serialization lock, so it does not
+    // re-introduce the duplicate the DeliveryLeaseCell now guards against.
     !matches!(
         lease.relay_owner,
         crate::services::tui_prompt_dedupe::ExternalInputRelayOwner::Unassigned
             | crate::services::tui_prompt_dedupe::ExternalInputRelayOwner::SessionBoundRelay
     )
+}
+
+/// RAII guard that guarantees the session-bound `external_input_relay_lease`
+/// is released on EVERY exit path of a terminal delivery (`deliver_response`):
+/// Ok, Err, `?`-propagation, early-return, HTTP-503, and panic/unwind via
+/// `Drop`. #3041 P1-4 (§4-④, fixes the leak behind #2955).
+///
+/// Before P1-4 the lease was cleared only on the four Ok delivery branches; an
+/// `Err` / `?` / 503 left it set for the full 600s TTL, and
+/// `session_bound_external_lease_blocks_delivery` would then block the NEXT
+/// terminal delivery for up to ~10 minutes.
+///
+/// NO-CLOBBER: the guard captures the EXACT lease value it observed when it
+/// armed and clears via `clear_external_input_relay_lease_if_matches`, so a
+/// NEWER turn that re-took the same `(provider, tmux_session, channel)` lease
+/// during a slow delivery is left untouched — the guard only ever releases its
+/// OWN lease (mirrors `TuiDirectExternalInputLeaseGuard`).
+struct SessionBoundExternalInputLeaseGuard {
+    provider: ProviderKind,
+    tmux_session_name: String,
+    channel_id: u64,
+    lease: crate::services::tui_prompt_dedupe::ExternalInputRelayLease,
+}
+
+impl SessionBoundExternalInputLeaseGuard {
+    /// Arm a guard IFF an `Unassigned`/`SessionBoundRelay`-owned input lease is
+    /// currently present for this delivery target. Foreign-owner leases are not
+    /// ours to release (a different subsystem owns them), and no-lease deliveries
+    /// have nothing to clear, so both return `None` (inert — no Drop clear).
+    fn arm_if_present(
+        provider: &ProviderKind,
+        channel_id: u64,
+        tmux_session_name: &str,
+    ) -> Option<Self> {
+        let lease = crate::services::tui_prompt_dedupe::external_input_relay_lease(
+            provider.as_str(),
+            tmux_session_name,
+            channel_id,
+        )?;
+        if !matches!(
+            lease.relay_owner,
+            crate::services::tui_prompt_dedupe::ExternalInputRelayOwner::Unassigned
+                | crate::services::tui_prompt_dedupe::ExternalInputRelayOwner::SessionBoundRelay
+        ) {
+            return None;
+        }
+        Some(Self {
+            provider: provider.clone(),
+            tmux_session_name: tmux_session_name.to_string(),
+            channel_id,
+            lease,
+        })
+    }
+}
+
+impl Drop for SessionBoundExternalInputLeaseGuard {
+    fn drop(&mut self) {
+        // Compare-and-clear: only release the lease if it is STILL the exact one
+        // we armed with. A newer turn's lease (different turn_id/identity) that
+        // re-took this key during a slow delivery survives this drop.
+        crate::services::tui_prompt_dedupe::clear_external_input_relay_lease_if_matches(
+            self.provider.as_str(),
+            &self.tmux_session_name,
+            self.channel_id,
+            &self.lease,
+        );
+    }
 }
 
 fn session_bound_should_send_new_chunks_for_placeholder(response_text: &str) -> bool {
@@ -455,6 +533,18 @@ impl SessionBoundDiscordRelaySink {
                 return Ok(SessionRelayDeliveryOutcome::Skipped);
             }
         };
+        // #3041 P1-4 (§4-④): arm the RAII release-on-all-paths guard the moment
+        // this sink owns the terminal delivery. From here on EVERY exit — Ok,
+        // Err, `?`-propagation (shared/http unavailable, 503), and panic — drops
+        // this guard, which compare-and-clears (`_if_matches`) ONLY our own
+        // input-dedup lease. This replaces the four scattered Ok-path clears with
+        // ONE release path, closing the leak that left the lease set for the full
+        // 600s TTL on Err/`?`/503 and blocked the next delivery for up to ~10min.
+        let _external_input_lease_guard = SessionBoundExternalInputLeaseGuard::arm_if_present(
+            &provider,
+            channel_id,
+            &delivery.session_name,
+        );
         let shared = self
             .health_registry
             .shared_for_provider(&provider)
@@ -526,11 +616,10 @@ impl SessionBoundDiscordRelaySink {
                     true,
                     Some("long response sent as ordered chunks"),
                 );
-                crate::services::tui_prompt_dedupe::clear_external_input_relay_lease(
-                    provider.as_str(),
-                    &delivery.session_name,
-                    channel_id,
-                );
+                // #3041 P1-4 (§4-④): the external_input lease is released by the
+                // RAII `_external_input_lease_guard` on function exit (covering
+                // Err/`?`/503/panic too), so this success branch no longer needs a
+                // manual `clear_external_input_relay_lease`.
                 // #3041 P1-3 (Part a, B1): couple the confirmed POST to the offset
                 // advance in the SAME path. (codex P1-3 issue 3) Re-check the
                 // identity gate against a freshly-reloaded inflight AFTER the POST,
@@ -582,11 +671,7 @@ impl SessionBoundDiscordRelaySink {
                         true,
                         Some("placeholder edit"),
                     );
-                    crate::services::tui_prompt_dedupe::clear_external_input_relay_lease(
-                        provider.as_str(),
-                        &delivery.session_name,
-                        channel_id,
-                    );
+                    // #3041 P1-4 (§4-④): lease released by the RAII guard on exit.
                     // #3041 P1-3 (Part a, B1): commit fence. (codex P1-3 issue 3)
                     // Post-POST fresh-inflight re-check before advancing.
                     self.advance_after_confirmed_post(
@@ -635,11 +720,7 @@ impl SessionBoundDiscordRelaySink {
                         true,
                         Some("fallback after edit failure"),
                     );
-                    crate::services::tui_prompt_dedupe::clear_external_input_relay_lease(
-                        provider.as_str(),
-                        &delivery.session_name,
-                        channel_id,
-                    );
+                    // #3041 P1-4 (§4-④): lease released by the RAII guard on exit.
                     // #3041 P1-3 (Part a, B1): commit fence — the fallback POST
                     // delivered the response, so advance the authority too. (codex
                     // P1-3 issue 3) Post-POST fresh-inflight re-check before advance.
@@ -677,11 +758,7 @@ impl SessionBoundDiscordRelaySink {
                 clear_ssh_direct_prompt_anchor(&provider, &delivery.session_name, prompt_anchor);
             }
             self.delivered_total.fetch_add(1, Ordering::AcqRel);
-            crate::services::tui_prompt_dedupe::clear_external_input_relay_lease(
-                provider.as_str(),
-                &delivery.session_name,
-                channel_id,
-            );
+            // #3041 P1-4 (§4-④): lease released by the RAII guard on exit.
             tracing::info!(
                 provider = provider.as_str(),
                 channel = channel_id,
@@ -1423,6 +1500,7 @@ mod tests {
     use super::*;
     use crate::services::cluster::session_matcher::{MatchedChannel, expected_rollout_path_for};
     use crate::services::discord::inflight::{RelayOwnerKind, TurnSource};
+    use crate::services::tui_prompt_dedupe::{ExternalInputRelayLease, ExternalInputRelayOwner};
 
     fn matched(channel_id: &str) -> MatchedChannel {
         let session = ProviderKind::Claude.build_tmux_session_name(channel_id);
@@ -2843,6 +2921,230 @@ mod tests {
         assert_eq!(
             deliveries[0].task_notification_kind,
             Some(TaskNotificationKind::MonitorAutoTurn)
+        );
+    }
+
+    fn external_input_delivery(session_name: &str, channel_id: u64) -> SessionRelayDelivery {
+        SessionRelayDelivery {
+            provider: ProviderKind::Claude,
+            channel_id,
+            session_name: session_name.to_string(),
+            response_text: "answer".to_string(),
+            task_notification_kind: None,
+            terminal_consumed_end: None,
+            frame_turn_user_msg_id: 0,
+            frame_turn_started_at: "2026-06-04T00:00:00Z".to_string(),
+            frame_turn_start_offset: None,
+        }
+    }
+
+    fn session_bound_lease(
+        channel_id: u64,
+        session: &str,
+        turn_seq: u64,
+    ) -> ExternalInputRelayLease {
+        ExternalInputRelayLease {
+            channel_id: Some(channel_id),
+            turn_id: Some(format!("external:claude:{channel_id}:{session}:{turn_seq}")),
+            session_key: Some(format!("host:{session}")),
+            relay_owner: ExternalInputRelayOwner::SessionBoundRelay,
+            runtime_kind: Some(crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui),
+        }
+    }
+
+    // #3041 P1-4 (§4-④): the CORE regression. Before P1-4 the session-bound
+    // external_input lease was cleared only on the four Ok delivery branches; an
+    // Err / `?` / HTTP-503 left it set for the full 600s TTL. This drives a real
+    // `deliver_response` whose `shared_for_provider` is unavailable (empty
+    // HealthRegistry) so the FIRST `?` returns `Err(Transient)` — and asserts the
+    // RAII guard's Drop STILL released the lease, so the NEXT terminal delivery
+    // is NOT blocked for up to ~10 minutes.
+    //
+    // SAFETY (await_holding_lock): `shared_test_env_lock()` and the dedupe
+    // `TEST_LOCK` are std test-serialization Mutexes (NOT production locks). They
+    // are held across `deliver_response().await` only to keep this test's
+    // `AGENTDESK_ROOT_DIR` + shared dedupe state isolated from other tests; the
+    // awaited future itself never tries to re-acquire either lock, so there is no
+    // deadlock — this is the established pattern (see `src/reconcile.rs`).
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn deliver_response_err_path_releases_external_input_lease_via_guard() {
+        let _env_lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        struct EnvReset(Option<std::ffi::OsString>);
+        impl Drop for EnvReset {
+            fn drop(&mut self) {
+                match self.0.take() {
+                    Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
+                    None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
+                }
+            }
+        }
+        let _env_reset = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        let temp = tempfile::TempDir::new().unwrap();
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+
+        let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
+            .lock()
+            .unwrap();
+        crate::services::tui_prompt_dedupe::reset_state_for_tests();
+
+        let channel_id = 8_041_u64;
+        let session = "AgentDesk-claude-p1-4-err";
+        let lease = session_bound_lease(channel_id, session, 1);
+        crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+            ProviderKind::Claude.as_str(),
+            session,
+            lease.clone(),
+        );
+        // Precondition: the input-dedup lease is present (it routes, does not block).
+        assert!(
+            crate::services::tui_prompt_dedupe::external_input_relay_lease_present(
+                ProviderKind::Claude.as_str(),
+                session,
+                channel_id,
+            )
+        );
+
+        // Empty HealthRegistry → `shared_for_provider` is None → the first `?`
+        // in `deliver_response` returns Err(Transient) before any Discord POST.
+        let sink = SessionBoundDiscordRelaySink::new(Arc::new(HealthRegistry::new()));
+        let result = sink
+            .deliver_response(external_input_delivery(session, channel_id))
+            .await;
+        assert!(
+            matches!(result, Err(RelaySinkError::Transient(_))),
+            "precondition: this path must return Err (shared unavailable) to exercise the leak path, got {result:?}"
+        );
+
+        // The RAII guard's Drop fired on the Err `?` exit → lease released.
+        assert!(
+            !crate::services::tui_prompt_dedupe::external_input_relay_lease_present(
+                ProviderKind::Claude.as_str(),
+                session,
+                channel_id,
+            ),
+            "the external_input lease MUST be released on the Err/`?` path (RAII guard Drop), so the next terminal delivery is not blocked for the 600s TTL"
+        );
+    }
+
+    // #3041 P1-4: NO-CLOBBER. If a NEWER turn re-takes the same
+    // (provider, tmux_session, channel) lease DURING a slow delivery, an old
+    // delivery's guard Drop must NOT clear the newer turn's lease — the guard
+    // compare-and-clears (`_if_matches`) only its OWN captured lease.
+    #[test]
+    fn lease_guard_drop_preserves_newer_turn_lease_no_clobber() {
+        let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
+            .lock()
+            .unwrap();
+        crate::services::tui_prompt_dedupe::reset_state_for_tests();
+
+        let channel_id = 8_042_u64;
+        let session = "AgentDesk-claude-p1-4-no-clobber";
+
+        // Turn 1 records its lease; the sink arms a guard capturing turn 1's lease.
+        let lease1 = session_bound_lease(channel_id, session, 1);
+        crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+            ProviderKind::Claude.as_str(),
+            session,
+            lease1.clone(),
+        );
+        let guard = SessionBoundExternalInputLeaseGuard::arm_if_present(
+            &ProviderKind::Claude,
+            channel_id,
+            session,
+        )
+        .expect("guard arms when a SessionBoundRelay lease is present");
+
+        // DURING the slow delivery a NEWER turn (turn 2) re-takes the same key.
+        let lease2 = session_bound_lease(channel_id, session, 2);
+        crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+            ProviderKind::Claude.as_str(),
+            session,
+            lease2.clone(),
+        );
+
+        // The OLD guard drops (turn 1 finished/errored) — must NOT clobber turn 2.
+        drop(guard);
+        assert_eq!(
+            crate::services::tui_prompt_dedupe::external_input_relay_lease(
+                ProviderKind::Claude.as_str(),
+                session,
+                channel_id,
+            ),
+            Some(lease2),
+            "a newer turn's lease must survive an old guard's drop (compare-and-clear)"
+        );
+    }
+
+    // #3041 P1-4: when the guard's OWN lease is still current at drop time, the
+    // Drop releases it (the happy-path release that replaces the manual Ok-path
+    // clears). Also verifies arm_if_present is INERT for a foreign-owner lease
+    // (BridgeAdapter) — that lease belongs to another subsystem and must be left
+    // for ITS guard, never cleared by the session-bound sink.
+    #[test]
+    fn lease_guard_drop_clears_own_lease_and_is_inert_for_foreign_owner() {
+        let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
+            .lock()
+            .unwrap();
+        crate::services::tui_prompt_dedupe::reset_state_for_tests();
+
+        let channel_id = 8_043_u64;
+        let session = "AgentDesk-claude-p1-4-own";
+
+        // Own (SessionBoundRelay) lease → guard arms and clears on drop.
+        let own = session_bound_lease(channel_id, session, 1);
+        crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+            ProviderKind::Claude.as_str(),
+            session,
+            own.clone(),
+        );
+        {
+            let _guard = SessionBoundExternalInputLeaseGuard::arm_if_present(
+                &ProviderKind::Claude,
+                channel_id,
+                session,
+            )
+            .expect("guard arms for own SessionBoundRelay lease");
+        }
+        assert!(
+            !crate::services::tui_prompt_dedupe::external_input_relay_lease_present(
+                ProviderKind::Claude.as_str(),
+                session,
+                channel_id,
+            ),
+            "the guard releases its own lease on drop (replaces the manual Ok-path clears)"
+        );
+
+        // Foreign-owner (BridgeAdapter) lease → guard does NOT arm; the foreign
+        // lease is left intact for the owning subsystem's own guard.
+        let foreign = ExternalInputRelayLease {
+            relay_owner: ExternalInputRelayOwner::BridgeAdapter,
+            ..session_bound_lease(channel_id, session, 2)
+        };
+        crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+            ProviderKind::Claude.as_str(),
+            session,
+            foreign.clone(),
+        );
+        assert!(
+            SessionBoundExternalInputLeaseGuard::arm_if_present(
+                &ProviderKind::Claude,
+                channel_id,
+                session,
+            )
+            .is_none(),
+            "the session-bound sink must NOT take ownership of a foreign-owner (BridgeAdapter) lease"
+        );
+        assert_eq!(
+            crate::services::tui_prompt_dedupe::external_input_relay_lease(
+                ProviderKind::Claude.as_str(),
+                session,
+                channel_id,
+            ),
+            Some(foreign),
+            "a foreign-owner lease is preserved (input-dedup / cross-subsystem routing not regressed)"
         );
     }
 }

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -125,7 +125,35 @@ fn session_bound_terminal_delivery_route_decision(
     provider: &ProviderKind,
     channel_id: u64,
 ) -> SessionBoundTerminalDeliveryRouteDecision {
-    if session_bound_external_lease_blocks_delivery(provider, channel_id, tmux_session_name) {
+    // #3041 P1-4 codex (TOCTOU close): read the external-input lease ONCE here and
+    // thread that exact snapshot into BOTH the block decision below AND the RAII
+    // release guard (`arm_with_observed_lease`). Re-reading the lease separately
+    // at arm time could capture a DIFFERENT lease (another thread can overwrite it
+    // between the two mutex acquisitions), so the guard might clear a lease the
+    // route never observed. The shared single read makes the guard's captured
+    // identity == what the route decision saw.
+    let observed_lease = crate::services::tui_prompt_dedupe::external_input_relay_lease(
+        provider.as_str(),
+        tmux_session_name,
+        channel_id,
+    );
+    session_bound_terminal_delivery_route_decision_with_lease(
+        inflight,
+        tmux_session_name,
+        provider,
+        channel_id,
+        observed_lease.as_ref(),
+    )
+}
+
+fn session_bound_terminal_delivery_route_decision_with_lease(
+    inflight: Option<&InflightTurnState>,
+    tmux_session_name: &str,
+    provider: &ProviderKind,
+    channel_id: u64,
+    observed_lease: Option<&crate::services::tui_prompt_dedupe::ExternalInputRelayLease>,
+) -> SessionBoundTerminalDeliveryRouteDecision {
+    if session_bound_external_lease_blocks_delivery(observed_lease) {
         return SessionBoundTerminalDeliveryRouteDecision::Skipped;
     }
     match session_bound_terminal_delivery_route_or_skip(
@@ -140,15 +168,9 @@ fn session_bound_terminal_delivery_route_decision(
 }
 
 fn session_bound_external_lease_blocks_delivery(
-    provider: &ProviderKind,
-    channel_id: u64,
-    tmux_session_name: &str,
+    observed_lease: Option<&crate::services::tui_prompt_dedupe::ExternalInputRelayLease>,
 ) -> bool {
-    let Some(lease) = crate::services::tui_prompt_dedupe::external_input_relay_lease(
-        provider.as_str(),
-        tmux_session_name,
-        channel_id,
-    ) else {
+    let Some(lease) = observed_lease else {
         return false;
     };
     // #3041 P1-4 / §4-④: the external_input lease's role is now "input dedup
@@ -179,33 +201,38 @@ fn session_bound_external_lease_blocks_delivery(
 /// `session_bound_external_lease_blocks_delivery` would then block the NEXT
 /// terminal delivery for up to ~10 minutes.
 ///
-/// NO-CLOBBER: the guard captures the EXACT lease value it observed when it
-/// armed and clears via `clear_external_input_relay_lease_if_matches`, so a
+/// NO-CLOBBER: the guard captures the UNIQUE `generation` of the EXACT lease the
+/// route decision observed (a SINGLE read threaded in via `arm_with_observed_lease`)
+/// and clears via `clear_external_input_relay_lease_if_generation_matches`, so a
 /// NEWER turn that re-took the same `(provider, tmux_session, channel)` lease
-/// during a slow delivery is left untouched — the guard only ever releases its
-/// OWN lease (mirrors `TuiDirectExternalInputLeaseGuard`).
+/// during a slow delivery is left untouched — even when the two leases are
+/// value-identical `Unassigned` markers (all trace fields `None`), their
+/// generations differ, so the guard only ever releases its OWN lease (mirrors
+/// `TuiDirectExternalInputLeaseGuard`). #3041 P1-4 codex.
 struct SessionBoundExternalInputLeaseGuard {
     provider: ProviderKind,
     tmux_session_name: String,
     channel_id: u64,
-    lease: crate::services::tui_prompt_dedupe::ExternalInputRelayLease,
+    /// `generation` of the recorded lease this guard armed with. Drop clears ONLY
+    /// this exact generation.
+    generation: u64,
 }
 
 impl SessionBoundExternalInputLeaseGuard {
-    /// Arm a guard IFF an `Unassigned`/`SessionBoundRelay`-owned input lease is
-    /// currently present for this delivery target. Foreign-owner leases are not
-    /// ours to release (a different subsystem owns them), and no-lease deliveries
-    /// have nothing to clear, so both return `None` (inert — no Drop clear).
-    fn arm_if_present(
+    /// Arm a guard IFF the lease the route decision observed (threaded in as
+    /// `observed_lease`, a SINGLE shared read) is an `Unassigned`/
+    /// `SessionBoundRelay`-owned input lease for this delivery target. Foreign-owner
+    /// leases are not ours to release (a different subsystem owns them), and
+    /// no-lease deliveries have nothing to clear, so both return `None` (inert — no
+    /// Drop clear). Capturing the generation from the SAME read the route observed
+    /// closes the TOCTOU where a re-read at arm time could see a different lease.
+    fn arm_with_observed_lease(
         provider: &ProviderKind,
         channel_id: u64,
         tmux_session_name: &str,
+        observed_lease: Option<&crate::services::tui_prompt_dedupe::ExternalInputRelayLease>,
     ) -> Option<Self> {
-        let lease = crate::services::tui_prompt_dedupe::external_input_relay_lease(
-            provider.as_str(),
-            tmux_session_name,
-            channel_id,
-        )?;
+        let lease = observed_lease?;
         if !matches!(
             lease.relay_owner,
             crate::services::tui_prompt_dedupe::ExternalInputRelayOwner::Unassigned
@@ -217,21 +244,39 @@ impl SessionBoundExternalInputLeaseGuard {
             provider: provider.clone(),
             tmux_session_name: tmux_session_name.to_string(),
             channel_id,
-            lease,
+            generation: lease.generation,
         })
+    }
+
+    /// Test-only convenience: read the current lease for this target and arm with
+    /// it (the production path threads in the route's single read instead).
+    #[cfg(test)]
+    fn arm_if_present(
+        provider: &ProviderKind,
+        channel_id: u64,
+        tmux_session_name: &str,
+    ) -> Option<Self> {
+        let observed = crate::services::tui_prompt_dedupe::external_input_relay_lease(
+            provider.as_str(),
+            tmux_session_name,
+            channel_id,
+        );
+        Self::arm_with_observed_lease(provider, channel_id, tmux_session_name, observed.as_ref())
     }
 }
 
 impl Drop for SessionBoundExternalInputLeaseGuard {
     fn drop(&mut self) {
-        // Compare-and-clear: only release the lease if it is STILL the exact one
-        // we armed with. A newer turn's lease (different turn_id/identity) that
-        // re-took this key during a slow delivery survives this drop.
-        crate::services::tui_prompt_dedupe::clear_external_input_relay_lease_if_matches(
+        // Compare-and-clear by generation: only release the lease if the CURRENT
+        // lease for this key is STILL the exact one (same generation) we armed
+        // with. A newer turn's lease that re-took this key during a slow delivery
+        // — even a value-identical `Unassigned` lease — has a DIFFERENT generation
+        // and therefore survives this drop.
+        crate::services::tui_prompt_dedupe::clear_external_input_relay_lease_if_generation_matches(
             self.provider.as_str(),
             &self.tmux_session_name,
             self.channel_id,
-            &self.lease,
+            self.generation,
         );
     }
 }
@@ -497,11 +542,22 @@ impl SessionBoundDiscordRelaySink {
             &delivery.session_name,
             inflight.as_ref(),
         );
-        let route = match session_bound_terminal_delivery_route_decision(
+        // #3041 P1-4 codex (TOCTOU close): read the external-input lease ONCE and
+        // thread the SAME snapshot into both the route/block decision and the RAII
+        // release guard, so the guard's captured generation == the lease the route
+        // observed. No `.await` runs between this read and arming the guard.
+        let observed_external_lease =
+            crate::services::tui_prompt_dedupe::external_input_relay_lease(
+                provider.as_str(),
+                &delivery.session_name,
+                channel_id,
+            );
+        let route = match session_bound_terminal_delivery_route_decision_with_lease(
             inflight.as_ref(),
             &delivery.session_name,
             &provider,
             channel_id,
+            observed_external_lease.as_ref(),
         ) {
             SessionBoundTerminalDeliveryRouteDecision::Route(route) => route,
             SessionBoundTerminalDeliveryRouteDecision::Skipped => {
@@ -540,11 +596,13 @@ impl SessionBoundDiscordRelaySink {
         // input-dedup lease. This replaces the four scattered Ok-path clears with
         // ONE release path, closing the leak that left the lease set for the full
         // 600s TTL on Err/`?`/503 and blocked the next delivery for up to ~10min.
-        let _external_input_lease_guard = SessionBoundExternalInputLeaseGuard::arm_if_present(
-            &provider,
-            channel_id,
-            &delivery.session_name,
-        );
+        let _external_input_lease_guard =
+            SessionBoundExternalInputLeaseGuard::arm_with_observed_lease(
+                &provider,
+                channel_id,
+                &delivery.session_name,
+                observed_external_lease.as_ref(),
+            );
         let shared = self
             .health_registry
             .shared_for_provider(&provider)
@@ -1814,6 +1872,8 @@ mod tests {
                 relay_owner:
                     crate::services::tui_prompt_dedupe::ExternalInputRelayOwner::SessionBoundRelay,
                 runtime_kind: Some(crate::services::agent_protocol::RuntimeHandoffKind::CodexTui),
+                generation:
+                    crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
             },
         );
 
@@ -1848,8 +1908,12 @@ mod tests {
             session_key: Some("host:AgentDesk-codex-bridge-owned-direct".to_string()),
             relay_owner: crate::services::tui_prompt_dedupe::ExternalInputRelayOwner::BridgeAdapter,
             runtime_kind: Some(crate::services::agent_protocol::RuntimeHandoffKind::CodexTui),
+            generation:
+                crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
         };
-        crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+        // Capture the RECORDED lease (with its stamped generation) so the later
+        // `_if_matches` clear compares against the exact stored identity.
+        let recorded = crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
             ProviderKind::Codex.as_str(),
             tmux,
             lease.clone(),
@@ -1864,7 +1928,7 @@ mod tests {
                 ProviderKind::Codex.as_str(),
                 tmux,
                 4243,
-                &lease,
+                &recorded,
             )
         );
         assert_eq!(
@@ -2949,6 +3013,8 @@ mod tests {
             session_key: Some(format!("host:{session}")),
             relay_owner: ExternalInputRelayOwner::SessionBoundRelay,
             runtime_kind: Some(crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui),
+            generation:
+                crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
         }
     }
 
@@ -3059,10 +3125,14 @@ mod tests {
 
         // DURING the slow delivery a NEWER turn (turn 2) re-takes the same key.
         let lease2 = session_bound_lease(channel_id, session, 2);
-        crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+        let recorded2 = crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
             ProviderKind::Claude.as_str(),
             session,
             lease2.clone(),
+        );
+        assert_ne!(
+            guard.generation, recorded2.generation,
+            "each recorded lease must get a DISTINCT generation"
         );
 
         // The OLD guard drops (turn 1 finished/errored) — must NOT clobber turn 2.
@@ -3073,8 +3143,76 @@ mod tests {
                 session,
                 channel_id,
             ),
-            Some(lease2),
-            "a newer turn's lease must survive an old guard's drop (compare-and-clear)"
+            Some(recorded2),
+            "a newer turn's lease must survive an old guard's drop (compare-and-clear by generation)"
+        );
+    }
+
+    // #3041 P1-4 codex: NO-CLOBBER for two VALUE-IDENTICAL `Unassigned` leases.
+    // Two legacy `Unassigned` turns for the same (provider, tmux_session, channel)
+    // have `turn_id`/`session_key`/`runtime_kind` ALL `None`, so they are
+    // indistinguishable by value. The per-record `generation` makes them distinct:
+    // an OLD guard's Drop must clear ONLY its own generation and leave the newer
+    // (value-identical) lease in place. Without the generation, a slow old
+    // delivery's guard would wrongly release the newer turn's lease.
+    #[test]
+    fn lease_guard_drop_preserves_newer_unassigned_lease_by_generation() {
+        let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
+            .lock()
+            .unwrap();
+        crate::services::tui_prompt_dedupe::reset_state_for_tests();
+
+        let channel_id = 8_044_u64;
+        let session = "AgentDesk-claude-p1-4-unassigned-no-clobber";
+
+        // Turn 1: a legacy/Unassigned lease (all trace fields None) is recorded and
+        // the sink arms a guard capturing turn 1's generation.
+        crate::services::tui_prompt_dedupe::record_external_input_relay_lease(
+            ProviderKind::Claude.as_str(),
+            session,
+            Some(channel_id),
+        );
+        let guard = SessionBoundExternalInputLeaseGuard::arm_if_present(
+            &ProviderKind::Claude,
+            channel_id,
+            session,
+        )
+        .expect("guard arms for an Unassigned input-dedup lease");
+
+        // DURING the slow delivery a NEWER, VALUE-IDENTICAL Unassigned turn re-takes
+        // the same key (same provider/session/channel; all trace fields None).
+        crate::services::tui_prompt_dedupe::record_external_input_relay_lease(
+            ProviderKind::Claude.as_str(),
+            session,
+            Some(channel_id),
+        );
+        let newer = crate::services::tui_prompt_dedupe::external_input_relay_lease(
+            ProviderKind::Claude.as_str(),
+            session,
+            channel_id,
+        )
+        .expect("newer Unassigned lease present");
+        assert_eq!(
+            newer.relay_owner,
+            ExternalInputRelayOwner::Unassigned,
+            "the newer lease is the value-identical Unassigned marker"
+        );
+        assert_ne!(
+            guard.generation, newer.generation,
+            "two Unassigned leases for the same key must get DISTINCT generations"
+        );
+
+        // The OLD guard drops — by generation it does NOT match the newer lease, so
+        // the newer (value-identical) lease must SURVIVE.
+        drop(guard);
+        assert_eq!(
+            crate::services::tui_prompt_dedupe::external_input_relay_lease(
+                ProviderKind::Claude.as_str(),
+                session,
+                channel_id,
+            ),
+            Some(newer),
+            "a newer value-identical Unassigned lease must survive an old guard's drop (clear-by-generation, no clobber)"
         );
     }
 
@@ -3123,7 +3261,7 @@ mod tests {
             relay_owner: ExternalInputRelayOwner::BridgeAdapter,
             ..session_bound_lease(channel_id, session, 2)
         };
-        crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+        let recorded_foreign = crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
             ProviderKind::Claude.as_str(),
             session,
             foreign.clone(),
@@ -3143,7 +3281,7 @@ mod tests {
                 session,
                 channel_id,
             ),
-            Some(foreign),
+            Some(recorded_foreign),
             "a foreign-owner lease is preserved (input-dedup / cross-subsystem routing not regressed)"
         );
     }

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -7624,24 +7624,27 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 channel_id.get(),
             )
             .is_some();
-        let external_input_lease_before_relay =
-            crate::services::tui_prompt_dedupe::external_input_relay_lease_present(
-                watcher_provider.as_str(),
-                &tmux_session_name,
-                channel_id.get(),
-            );
-        // #3041 P1-4 codex: capture the GENERATION of the lease observed before the
-        // awaited Discord delivery (at the SAME point as the bool above — no await in
-        // between can change it relative to the bool). The post-delivery clear uses this
+        // #3041 P1-4 codex: snapshot the external-input lease ONCE under a single STATE
+        // lock and derive BOTH the presence bool and the generation from that one atomic
+        // read. Two separate accessor calls (present + generation) re-lock STATE between
+        // them, so a concurrently-started turn could record a NEWER same-key lease in the
+        // gap — leaving the bool reflecting turn-1 but the generation captured from
+        // turn-2's lease (present/generation TOCTOU). The post-delivery clear uses this
         // generation so it only removes the EXACT lease this relay consumed; a NEWER
         // same-key lease recorded by a concurrently-started turn during the slow send
         // survives (no stale-snapshot clobber).
-        let external_input_lease_generation_before_relay =
-            crate::services::tui_prompt_dedupe::external_input_relay_lease_generation(
+        let external_input_lease_before_relay_snapshot =
+            crate::services::tui_prompt_dedupe::external_input_relay_lease(
                 watcher_provider.as_str(),
                 &tmux_session_name,
                 channel_id.get(),
             );
+        let external_input_lease_before_relay =
+            external_input_lease_before_relay_snapshot.is_some();
+        let external_input_lease_generation_before_relay =
+            external_input_lease_before_relay_snapshot
+                .as_ref()
+                .map(|lease| lease.generation);
         let inflight_before_relay = crate::services::discord::inflight::load_inflight_state(
             &watcher_provider,
             channel_id.get(),

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -7630,6 +7630,18 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 &tmux_session_name,
                 channel_id.get(),
             );
+        // #3041 P1-4 codex: capture the GENERATION of the lease observed before the
+        // awaited Discord delivery (at the SAME point as the bool above — no await in
+        // between can change it relative to the bool). The post-delivery clear uses this
+        // generation so it only removes the EXACT lease this relay consumed; a NEWER
+        // same-key lease recorded by a concurrently-started turn during the slow send
+        // survives (no stale-snapshot clobber).
+        let external_input_lease_generation_before_relay =
+            crate::services::tui_prompt_dedupe::external_input_relay_lease_generation(
+                watcher_provider.as_str(),
+                &tmux_session_name,
+                channel_id.get(),
+            );
         let inflight_before_relay = crate::services::discord::inflight::load_inflight_state(
             &watcher_provider,
             channel_id.get(),
@@ -8795,11 +8807,23 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             if relay_ok {
                 if direct_send_delivered || !has_direct_terminal_response {
                     if direct_send_delivered {
-                        if external_input_lease_consumed_by_relay {
-                            crate::services::tui_prompt_dedupe::clear_external_input_relay_lease(
+                        // #3041 P1-4 codex: clear BY the generation snapshotted before
+                        // this awaited delivery, NOT by key. The old unconditional by-key
+                        // clear had a stale-snapshot clobber: turn-1 snapshots the lease
+                        // present, starts its send; turn-2 records a NEWER same-key lease;
+                        // turn-1's send succeeds and the by-key clear removed turn-2's
+                        // lease (re-introducing the exact no-clobber race the generation
+                        // nonce was added to kill). Generation-scoped clear only removes
+                        // the lease this relay actually consumed; sentinel/None (no lease
+                        // was present) clears nothing — guarded by the consumed gate too.
+                        if let Some(generation) = external_input_lease_generation_before_relay
+                            && external_input_lease_consumed_by_relay
+                        {
+                            crate::services::tui_prompt_dedupe::clear_external_input_relay_lease_if_generation_matches(
                                 watcher_provider.as_str(),
                                 &tmux_session_name,
                                 channel_id.get(),
+                                generation,
                             );
                         }
                         if watcher_direct_terminal_should_commit_session_idle(

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -109,6 +109,80 @@ impl Drop for TuiDirectExternalInputLeaseGuard {
     }
 }
 
+/// Early-return RAII guard for [`relay_observed_prompt`]: armed right after
+/// [`record_observed_external_turn_lease`] records & stores a (possibly
+/// `BridgeAdapter`-owned, hence delivery-blocking) lease, it clears that exact
+/// lease BY GENERATION on every early-return between the record and the point
+/// where the bridge legitimately takes ownership of the in-flight turn.
+///
+/// WHY clear-by-generation (not by full value): a NEWER turn may have re-taken
+/// the same `(provider, tmux_session, channel)` lease while this relay was awaiting
+/// the notify HTTP resolve / Discord POST; a by-key or by-value clear could clobber
+/// that newer lease (the exact no-clobber race the per-record generation nonce was
+/// added to kill, #3041 P1-4 codex). Clearing only the captured generation leaves a
+/// newer (even value-identical `Unassigned`) lease untouched.
+///
+/// SUCCESS-PATH PERSISTENCE: on the path where the bridge posts the card/anchor and
+/// retains the in-flight turn, the lease MUST persist so the watcher/sink does not
+/// double-deliver. The caller therefore [`disarm`](Self::disarm)s this guard right
+/// before the bridge-tail ownership block; only the genuinely-aborting early-returns
+/// (registry None, notify resolve `Err`/503, task-card repeat, anchor POST failure)
+/// leave the guard armed → its clear releases the lease so legitimate delivery can
+/// proceed.
+struct TuiDirectObservedLeaseEarlyReturnGuard {
+    provider: Option<ProviderKind>,
+    tmux_session_name: String,
+    channel_id: ChannelId,
+    /// Generation of the lease this guard armed with; Drop clears ONLY this exact
+    /// generation (sentinel `UNRECORDED` clears nothing).
+    generation: u64,
+    active: bool,
+}
+
+impl TuiDirectObservedLeaseEarlyReturnGuard {
+    /// Arm a guard capturing the generation of the just-recorded `lease`. When the
+    /// provider string is not a known [`ProviderKind`] the guard is inert (no key to
+    /// clear by) but still constructed so callers keep a uniform disarm point.
+    fn arm(
+        provider_str: &str,
+        tmux_session_name: &str,
+        channel_id: ChannelId,
+        generation: u64,
+    ) -> Self {
+        Self {
+            provider: ProviderKind::from_str(provider_str),
+            tmux_session_name: tmux_session_name.to_string(),
+            channel_id,
+            generation,
+            active: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for TuiDirectObservedLeaseEarlyReturnGuard {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        let Some(provider) = self.provider.as_ref() else {
+            return;
+        };
+        // Compare-and-clear by the captured generation: a newer same-key lease
+        // recorded during a slow notify-resolve / POST await has a DIFFERENT
+        // generation and survives this drop (no clobber).
+        crate::services::tui_prompt_dedupe::clear_external_input_relay_lease_if_generation_matches(
+            provider.as_str(),
+            &self.tmux_session_name,
+            self.channel_id.get(),
+            self.generation,
+        );
+    }
+}
+
 fn clear_external_input_bridge_lease_if_current(
     provider: &ProviderKind,
     tmux_session_name: &str,
@@ -394,6 +468,20 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
         return;
     };
     let mut lease = record_observed_external_turn_lease(shared, &prompt, channel_id);
+    // #3041 P1-4 codex: arm an early-return RAII guard the instant the lease is
+    // recorded & stored. Every FAILURE early-return below (registry None, notify
+    // resolve Err/503, task-card repeat, anchor POST failure) would otherwise leave
+    // this (possibly BridgeAdapter-owned) lease set for the full TTL, blocking the
+    // legitimate watcher/sink delivery for ~10 minutes. The guard clears EXACTLY the
+    // recorded generation on drop; it is DISARMED on the success path just before the
+    // bridge-tail ownership block, so a turn the bridge legitimately owns keeps its
+    // lease (no double-delivery).
+    let mut observed_lease_early_return_guard = TuiDirectObservedLeaseEarlyReturnGuard::arm(
+        &prompt.provider,
+        &prompt.tmux_session_name,
+        channel_id,
+        lease.generation,
+    );
     let Some(registry) = shared.health_registry() else {
         tracing::warn!(
             provider = %prompt.provider,
@@ -607,6 +695,14 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             "SSH-direct TUI prompt notified; runtime relay attached synthetic ownership when possible"
         );
     }
+
+    // #3041 P1-4 codex: SUCCESS PATH reached — the card/anchor (or system-continuation
+    // note) was posted and the bridge legitimately retains the in-flight turn. DISARM
+    // the early-return guard so the lease PERSISTS for this turn (otherwise the
+    // watcher/sink would double-deliver). From here on, persistence is governed by the
+    // bridge-tail block's own `TuiDirectExternalInputLeaseGuard` (bridge-owner leases)
+    // or simply left set (Unassigned / session-bound-owned leases the sink delivers).
+    observed_lease_early_return_guard.disarm();
 
     #[cfg(unix)]
     {
@@ -5813,5 +5909,165 @@ mod tests {
         assert!(tui_idle_tail_should_commit_runtime_binding_offset(
             "", false
         ));
+    }
+
+    // #3041 P1-4 codex: the early-return guard armed right after
+    // `record_observed_external_turn_lease` must clear EXACTLY its recorded lease on
+    // drop, so a FAILURE early-return (registry None / notify resolve Err-503 /
+    // anchor POST failure) does not leave a dangling (BridgeAdapter-owned) lease
+    // blocking the legitimate watcher/sink delivery for the full TTL.
+    #[test]
+    fn observed_lease_early_return_guard_clears_recorded_lease_on_drop() {
+        let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
+            .lock()
+            .unwrap();
+        let tmux = "AgentDesk-early-return-guard-clear";
+        let channel_id = ChannelId::new(960_000_000_000_001);
+        let lease = ExternalInputRelayLease {
+            channel_id: Some(channel_id.get()),
+            turn_id: Some("external:claude:960000000000001:early:1".to_string()),
+            session_key: Some("host:AgentDesk-early-return-guard-clear".to_string()),
+            relay_owner: ExternalInputRelayOwner::BridgeAdapter,
+            runtime_kind: Some(RuntimeHandoffKind::ClaudeTui),
+            generation:
+                crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
+        };
+        let recorded = crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+            ProviderKind::Claude.as_str(),
+            tmux,
+            lease,
+        );
+        assert!(
+            crate::services::tui_prompt_dedupe::external_input_relay_lease_present(
+                ProviderKind::Claude.as_str(),
+                tmux,
+                channel_id.get(),
+            ),
+            "lease must be present after record (would block delivery)"
+        );
+
+        // Simulate a failure early-return: the guard is armed and never disarmed, so
+        // dropping it (function returns) clears the recorded lease.
+        {
+            let _guard = TuiDirectObservedLeaseEarlyReturnGuard::arm(
+                ProviderKind::Claude.as_str(),
+                tmux,
+                channel_id,
+                recorded.generation,
+            );
+        }
+
+        assert!(
+            crate::services::tui_prompt_dedupe::external_input_relay_lease(
+                ProviderKind::Claude.as_str(),
+                tmux,
+                channel_id.get(),
+            )
+            .is_none(),
+            "an armed early-return guard drop must release the recorded lease so the watcher/sink can deliver"
+        );
+    }
+
+    // #3041 P1-4 codex: on the SUCCESS path the caller DISARMs the guard before the
+    // bridge-tail ownership block, so the lease PERSISTS for the in-flight turn (the
+    // watcher/sink must not double-deliver). A disarmed guard's drop is a no-op.
+    #[test]
+    fn observed_lease_early_return_guard_disarm_preserves_lease() {
+        let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
+            .lock()
+            .unwrap();
+        let tmux = "AgentDesk-early-return-guard-disarm";
+        let channel_id = ChannelId::new(960_000_000_000_002);
+        let lease = ExternalInputRelayLease {
+            channel_id: Some(channel_id.get()),
+            turn_id: Some("external:claude:960000000000002:early:1".to_string()),
+            session_key: Some("host:AgentDesk-early-return-guard-disarm".to_string()),
+            relay_owner: ExternalInputRelayOwner::BridgeAdapter,
+            runtime_kind: Some(RuntimeHandoffKind::ClaudeTui),
+            generation:
+                crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
+        };
+        let recorded = crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+            ProviderKind::Claude.as_str(),
+            tmux,
+            lease,
+        );
+
+        {
+            let mut guard = TuiDirectObservedLeaseEarlyReturnGuard::arm(
+                ProviderKind::Claude.as_str(),
+                tmux,
+                channel_id,
+                recorded.generation,
+            );
+            // SUCCESS path: bridge legitimately takes ownership → disarm.
+            guard.disarm();
+        }
+
+        assert_eq!(
+            crate::services::tui_prompt_dedupe::external_input_relay_lease(
+                ProviderKind::Claude.as_str(),
+                tmux,
+                channel_id.get(),
+            ),
+            Some(recorded),
+            "a disarmed early-return guard must leave the lease intact for the in-flight turn"
+        );
+    }
+
+    // #3041 P1-4 codex: the early-return guard clears BY GENERATION, so an OLD guard
+    // armed with turn-1's generation must NOT clobber a NEWER same-key lease recorded
+    // by turn-2 while turn-1 was awaiting the notify resolve / POST.
+    #[test]
+    fn observed_lease_early_return_guard_does_not_clobber_newer_lease() {
+        let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
+            .lock()
+            .unwrap();
+        let tmux = "AgentDesk-early-return-guard-noclobber";
+        let channel_id = ChannelId::new(960_000_000_000_003);
+        let base = ExternalInputRelayLease {
+            channel_id: Some(channel_id.get()),
+            turn_id: Some("external:claude:960000000000003:early:1".to_string()),
+            session_key: Some("host:AgentDesk-early-return-guard-noclobber".to_string()),
+            relay_owner: ExternalInputRelayOwner::BridgeAdapter,
+            runtime_kind: Some(RuntimeHandoffKind::ClaudeTui),
+            generation:
+                crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
+        };
+        // turn-1 records and the relay arms a guard capturing G1.
+        let recorded_turn1 = crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+            ProviderKind::Claude.as_str(),
+            tmux,
+            base.clone(),
+        );
+        let guard = TuiDirectObservedLeaseEarlyReturnGuard::arm(
+            ProviderKind::Claude.as_str(),
+            tmux,
+            channel_id,
+            recorded_turn1.generation,
+        );
+        // turn-2 records a NEWER same-key lease (G2) while turn-1 is in flight.
+        let recorded_turn2 = crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+            ProviderKind::Claude.as_str(),
+            tmux,
+            ExternalInputRelayLease {
+                turn_id: Some("external:claude:960000000000003:early:2".to_string()),
+                ..base
+            },
+        );
+        assert_ne!(recorded_turn1.generation, recorded_turn2.generation);
+
+        // turn-1's guard drops (failure early-return) — by G1 it must NOT touch G2.
+        drop(guard);
+
+        assert_eq!(
+            crate::services::tui_prompt_dedupe::external_input_relay_lease(
+                ProviderKind::Claude.as_str(),
+                tmux,
+                channel_id.get(),
+            ),
+            Some(recorded_turn2),
+            "an old early-return guard (G1) must leave turn-2's newer lease (G2) intact"
+        );
     }
 }

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -583,10 +583,14 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             .await;
             if claim.claimed && lease.relay_owner != claim.relay_owner {
                 lease.relay_owner = claim.relay_owner;
-                crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+                // Re-record overwrites the lease with a FRESH generation; adopt it
+                // back into `lease` so the bridge-tail guard below captures the
+                // exact stored identity (otherwise the guard would hold the stale
+                // generation and its Drop would clear nothing / the wrong lease).
+                lease = crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
                     provider.as_str(),
                     &prompt.tmux_session_name,
-                    lease.clone(),
+                    lease,
                 );
             }
         }
@@ -672,11 +676,16 @@ fn record_observed_external_turn_lease(
         session_key,
         relay_owner,
         runtime_kind,
+        generation:
+            crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
     };
-    crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+    // Capture the RECORDED lease (with its stamped generation) so the caller's
+    // later `clear_observed_external_turn_lease_if_current` matches the exact
+    // stored identity and never clobbers a newer turn's lease.
+    let lease = crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
         &prompt.provider,
         &prompt.tmux_session_name,
-        lease.clone(),
+        lease,
     );
     tracing::info!(
         provider = %prompt.provider,
@@ -768,13 +777,16 @@ fn record_external_turn_lease_for_output(
         )),
         relay_owner,
         runtime_kind: Some(runtime_kind),
+        generation:
+            crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
     };
+    // Return the RECORDED lease (with its stamped generation) so a later
+    // exact-match clear targets the precise stored identity.
     crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
         provider.as_str(),
         tmux_session_name,
-        lease.clone(),
-    );
-    lease
+        lease,
+    )
 }
 
 fn external_input_turn_id(
@@ -4778,19 +4790,24 @@ mod tests {
             session_key: Some("host:AgentDesk-codex-bridge-guard".to_string()),
             relay_owner: ExternalInputRelayOwner::BridgeAdapter,
             runtime_kind: Some(RuntimeHandoffKind::CodexTui),
+            generation:
+                crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
         };
-        crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
-            ProviderKind::Codex.as_str(),
-            tmux,
-            original.clone(),
-        );
+        // Capture the RECORDED lease (with its stamped generation) — the guard must
+        // hold the exact stored identity to clear it on drop.
+        let recorded_original =
+            crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+                ProviderKind::Codex.as_str(),
+                tmux,
+                original.clone(),
+            );
 
         {
             let _guard = TuiDirectExternalInputLeaseGuard::new(
                 ProviderKind::Codex,
                 tmux,
                 channel_id,
-                &original,
+                &recorded_original,
             );
         }
         assert!(
@@ -4806,19 +4823,21 @@ mod tests {
             turn_id: Some("external:codex:940000000000003:bridge-guard:2".to_string()),
             ..original.clone()
         };
-        crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
-            ProviderKind::Codex.as_str(),
-            tmux,
-            original.clone(),
-        );
+        let recorded_original =
+            crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+                ProviderKind::Codex.as_str(),
+                tmux,
+                original.clone(),
+            );
+        let recorded_newer;
         {
             let _guard = TuiDirectExternalInputLeaseGuard::new(
                 ProviderKind::Codex,
                 tmux,
                 channel_id,
-                &original,
+                &recorded_original,
             );
-            crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+            recorded_newer = crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
                 ProviderKind::Codex.as_str(),
                 tmux,
                 newer.clone(),
@@ -4830,14 +4849,15 @@ mod tests {
                 tmux,
                 channel_id.get(),
             ),
-            Some(newer.clone())
+            Some(recorded_newer.clone()),
+            "the old guard's drop must NOT clobber the newer lease (clear-by-identity)"
         );
         assert!(
             crate::services::tui_prompt_dedupe::clear_external_input_relay_lease_if_matches(
                 ProviderKind::Codex.as_str(),
                 tmux,
                 channel_id.get(),
-                &newer,
+                &recorded_newer,
             )
         );
     }
@@ -4856,6 +4876,8 @@ mod tests {
             session_key: Some("host:AgentDesk-claude-bridge-dedup-skip".to_string()),
             relay_owner: ExternalInputRelayOwner::BridgeAdapter,
             runtime_kind: Some(RuntimeHandoffKind::ClaudeTui),
+            generation:
+                crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
         };
         {
             let mut active = CLAUDE_IDLE_RESPONSE_TAILS
@@ -4864,10 +4886,10 @@ mod tests {
             active.remove(tmux);
             active.insert(tmux.to_string());
         }
-        crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+        let lease = crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
             ProviderKind::Claude.as_str(),
             tmux,
-            lease.clone(),
+            lease,
         );
 
         let spawned = spawn_claude_idle_response_tail_once(
@@ -4928,11 +4950,13 @@ mod tests {
             session_key: Some("host:AgentDesk-claude-bridge-no-binding".to_string()),
             relay_owner: ExternalInputRelayOwner::BridgeAdapter,
             runtime_kind: Some(RuntimeHandoffKind::ClaudeTui),
+            generation:
+                crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
         };
-        crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+        let lease = crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
             ProviderKind::Claude.as_str(),
             tmux,
-            lease.clone(),
+            lease,
         );
 
         let spawned;
@@ -4997,11 +5021,13 @@ mod tests {
             // session-bound delivery if left dangling.
             relay_owner: ExternalInputRelayOwner::BridgeAdapter,
             runtime_kind: Some(RuntimeHandoffKind::ClaudeTui),
+            generation:
+                crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
         };
-        crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+        let lease = crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
             ProviderKind::Claude.as_str(),
             tmux,
-            lease.clone(),
+            lease,
         );
         // Sanity: the lease is present and would block delivery.
         assert!(
@@ -5050,28 +5076,34 @@ mod tests {
             session_key: Some("host:AgentDesk-task-card-repeat-newer".to_string()),
             relay_owner: ExternalInputRelayOwner::BridgeAdapter,
             runtime_kind: Some(RuntimeHandoffKind::ClaudeTui),
+            generation:
+                crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
         };
         let newer_lease = ExternalInputRelayLease {
             turn_id: Some("external:claude:950000000000002:repeat:2".to_string()),
             ..repeat_lease.clone()
         };
-        crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+        let recorded_repeat = crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
             ProviderKind::Claude.as_str(),
             tmux,
             repeat_lease.clone(),
         );
         // A newer turn overwrites the lease before the repeat's cleanup runs.
-        crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
+        let recorded_newer = crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
             ProviderKind::Claude.as_str(),
             tmux,
             newer_lease.clone(),
+        );
+        assert_ne!(
+            recorded_repeat.generation, recorded_newer.generation,
+            "each recorded lease must get a distinct generation",
         );
 
         // The repeat's exact-match clear is a no-op against the newer lease.
         assert!(!clear_observed_external_turn_lease_if_current(
             &prompt,
             channel_id,
-            &repeat_lease,
+            &recorded_repeat,
         ));
         assert_eq!(
             crate::services::tui_prompt_dedupe::external_input_relay_lease(
@@ -5079,7 +5111,7 @@ mod tests {
                 tmux,
                 channel_id.get(),
             ),
-            Some(newer_lease),
+            Some(recorded_newer),
             "exact-match clear must preserve a newer turn's lease",
         );
     }
@@ -5111,6 +5143,8 @@ mod tests {
             session_key: Some("token:AgentDesk-codex-owner-split".to_string()),
             relay_owner: ExternalInputRelayOwner::BridgeAdapter,
             runtime_kind: Some(RuntimeHandoffKind::CodexTui),
+            generation:
+                crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
         };
         let state = build_tui_direct_bridge_inflight_state(
             ProviderKind::Codex,
@@ -5144,6 +5178,8 @@ mod tests {
             session_key: Some("token:AgentDesk-codex-owner-split".to_string()),
             relay_owner: ExternalInputRelayOwner::TmuxWatcher,
             runtime_kind: Some(RuntimeHandoffKind::CodexTui),
+            generation:
+                crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
         };
         let state = build_tui_direct_synthetic_inflight_state(
             ProviderKind::Codex,

--- a/src/services/tui_prompt_dedupe.rs
+++ b/src/services/tui_prompt_dedupe.rs
@@ -736,26 +736,6 @@ pub(crate) fn external_input_relay_lease_present(
     external_input_relay_lease(provider, tmux_session_name, channel_id).is_some()
 }
 
-/// Return the UNIQUE `generation` of the external-input relay lease currently
-/// stored for `(provider, tmux_session)` iff its channel scope matches
-/// `channel_id` (same channel-scope rule as [`external_input_relay_lease_present`]),
-/// else `None`.
-///
-/// Watchers/sinks that observe a lease before an awaited delivery and want to
-/// clear it afterwards MUST capture this generation at observation time and pass
-/// it to [`clear_external_input_relay_lease_if_generation_matches`], rather than
-/// using the unconditional [`clear_external_input_relay_lease`]. That guarantees
-/// a stale snapshot cannot clobber a NEWER same-key lease recorded by a
-/// concurrently-started turn while the first delivery was in flight.
-pub(crate) fn external_input_relay_lease_generation(
-    provider: &str,
-    tmux_session_name: &str,
-    channel_id: u64,
-) -> Option<u64> {
-    external_input_relay_lease(provider, tmux_session_name, channel_id)
-        .map(|lease| lease.generation)
-}
-
 pub(crate) fn clear_external_input_relay_lease(
     provider: &str,
     tmux_session_name: &str,
@@ -1895,43 +1875,11 @@ mod tests {
         assert!(external_input_relay_lease("codex", "tmux-gen", 99).is_none());
     }
 
-    #[test]
-    fn external_input_relay_lease_generation_reports_stored_generation() {
-        let _guard = TEST_LOCK.lock().unwrap();
-        reset_state();
-
-        // No lease yet → None.
-        assert_eq!(
-            external_input_relay_lease_generation("codex", "tmux-genfn", 99),
-            None,
-            "no stored lease must report None"
-        );
-
-        record_external_input_relay_lease("codex", "tmux-genfn", Some(99));
-        let stored = external_input_relay_lease("codex", "tmux-genfn", 99).expect("stored lease");
-        assert_ne!(
-            stored.generation, EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
-            "a recorded lease must carry a non-sentinel generation"
-        );
-
-        // Matching channel scope → returns the stored generation.
-        assert_eq!(
-            external_input_relay_lease_generation("codex", "tmux-genfn", 99),
-            Some(stored.generation),
-            "must report the stored lease's generation for the matching channel"
-        );
-
-        // Channel mismatch → None (same channel-scope rule as `_present`).
-        assert_eq!(
-            external_input_relay_lease_generation("codex", "tmux-genfn", 100),
-            None,
-            "a channel mismatch must report None"
-        );
-    }
-
     /// Watcher-style no-clobber: turn-1 snapshots the lease generation G1 before its
     /// awaited send; turn-2 records a NEWER same-key lease G2 during that send; turn-1
-    /// then clears BY G1 — which must NOT remove turn-2's G2 lease.
+    /// then clears BY G1 — which must NOT remove turn-2's G2 lease. The snapshot is taken
+    /// from a single `external_input_relay_lease` read (the watcher derives both the
+    /// presence bool and the generation from that one atomic read).
     #[test]
     fn watcher_snapshot_generation_clear_preserves_newer_same_key_lease() {
         let _guard = TEST_LOCK.lock().unwrap();
@@ -1939,12 +1887,14 @@ mod tests {
 
         // turn-1 records & the watcher snapshots its generation BEFORE the awaited send.
         record_external_input_relay_lease("codex", "tmux-watch", Some(7));
-        let g1 = external_input_relay_lease_generation("codex", "tmux-watch", 7)
+        let g1 = external_input_relay_lease("codex", "tmux-watch", 7)
+            .map(|lease| lease.generation)
             .expect("turn-1 generation snapshot");
 
         // turn-2 records a NEWER same-key lease while turn-1's send is in flight.
         record_external_input_relay_lease("codex", "tmux-watch", Some(7));
-        let g2 = external_input_relay_lease_generation("codex", "tmux-watch", 7)
+        let g2 = external_input_relay_lease("codex", "tmux-watch", 7)
+            .map(|lease| lease.generation)
             .expect("turn-2 generation");
         assert_ne!(
             g1, g2,
@@ -1957,7 +1907,7 @@ mod tests {
             "clear by the stale G1 snapshot must not match the current G2 lease"
         );
         assert_eq!(
-            external_input_relay_lease_generation("codex", "tmux-watch", 7),
+            external_input_relay_lease("codex", "tmux-watch", 7).map(|lease| lease.generation),
             Some(g2),
             "turn-2's lease must survive turn-1's stale-snapshot clear (no clobber)"
         );

--- a/src/services/tui_prompt_dedupe.rs
+++ b/src/services/tui_prompt_dedupe.rs
@@ -1,5 +1,6 @@
 use serde_json::Value;
 use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
@@ -24,6 +25,25 @@ static STATE: LazyLock<Mutex<TuiPromptDedupeState>> =
 pub(crate) static TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 static OBSERVED_PROMPTS: LazyLock<broadcast::Sender<ObservedTuiPrompt>> =
     LazyLock::new(|| broadcast::channel(OBSERVED_PROMPT_BUFFER).0);
+
+/// Process-global monotonic counter that stamps a UNIQUE `generation` onto every
+/// external-input relay lease at the moment it is RECORDED. Two leases that are
+/// otherwise identical by value — e.g. two newer `Unassigned` (legacy) turns for
+/// the same `(provider, tmux_session, channel)` whose `turn_id`/`session_key`/
+/// `runtime_kind` are all `None` — therefore receive DISTINCT generations and are
+/// no longer indistinguishable. A RAII guard captures the exact recorded lease
+/// (with its generation) and on Drop clears ONLY that generation, so a slow OLD
+/// delivery's guard can never clobber a NEWER identical lease. #3041 P1-4 codex.
+/// Starts at 1 so that 0 stays a reserved "not yet recorded" sentinel.
+static EXTERNAL_INPUT_RELAY_LEASE_GENERATION: AtomicU64 = AtomicU64::new(1);
+
+/// `generation` sentinel for a freshly constructed lease that has NOT yet been
+/// recorded (and therefore not yet stamped with a unique generation).
+pub(crate) const EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED: u64 = 0;
+
+fn next_external_input_relay_lease_generation() -> u64 {
+    EXTERNAL_INPUT_RELAY_LEASE_GENERATION.fetch_add(1, Ordering::Relaxed)
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ObservedTuiPrompt {
@@ -67,6 +87,16 @@ pub(crate) struct ExternalInputRelayLease {
     pub session_key: Option<String>,
     pub relay_owner: ExternalInputRelayOwner,
     pub runtime_kind: Option<RuntimeHandoffKind>,
+    /// Unique, monotonic per-record identity stamped by
+    /// [`record_external_input_turn_lease`] when this lease is inserted into the
+    /// state map. A freshly constructed (not-yet-recorded) lease carries
+    /// [`EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED`] (0); the record path
+    /// overwrites it with a fresh process-global counter value so that two leases
+    /// that are otherwise value-equal (notably two `Unassigned` leases whose
+    /// trace fields are all `None`) are still DISTINGUISHABLE. A RAII guard
+    /// captures the RECORDED lease (via the value returned from the record call)
+    /// and clears only its OWN generation, so it can never clobber a newer lease.
+    pub generation: u64,
 }
 
 impl ExternalInputRelayLease {
@@ -77,6 +107,7 @@ impl ExternalInputRelayLease {
             session_key: None,
             relay_owner: ExternalInputRelayOwner::Unassigned,
             runtime_kind: None,
+            generation: EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
         }
     }
 }
@@ -643,25 +674,37 @@ pub(crate) fn record_external_input_relay_lease(
     );
 }
 
+/// Record an external-input relay lease for `(provider, tmux_session)` and return
+/// the EXACT lease that was stored, including the unique `generation` stamped at
+/// record time. Callers that need to later release THIS lease (e.g. an RAII
+/// guard) MUST capture the returned value, not the pre-record argument: only the
+/// returned value carries the recorded generation that
+/// [`clear_external_input_relay_lease_if_matches`] /
+/// [`clear_external_input_relay_lease_if_generation_matches`] compare against, so
+/// a guard never clobbers a newer (even value-identical `Unassigned`) lease.
 pub(crate) fn record_external_input_turn_lease(
     provider: &str,
     tmux_session_name: &str,
-    lease: ExternalInputRelayLease,
-) {
+    mut lease: ExternalInputRelayLease,
+) -> ExternalInputRelayLease {
     let provider = normalize_provider(provider);
     let tmux_session_name = tmux_session_name.trim();
     if provider.is_empty() || tmux_session_name.is_empty() {
-        return;
+        return lease;
     }
+    // Stamp a UNIQUE generation at the moment of record so two otherwise
+    // value-equal leases for the same key are distinguishable by identity.
+    lease.generation = next_external_input_relay_lease_generation();
     let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
     state.purge_expired();
     state.external_input_relay_lease_by_tmux.insert(
         PromptKey::new(&provider, tmux_session_name),
         TimedValue {
-            value: lease,
+            value: lease.clone(),
             recorded_at: Instant::now(),
         },
     );
+    lease
 }
 
 pub(crate) fn external_input_relay_lease(
@@ -745,6 +788,51 @@ pub(crate) fn clear_external_input_relay_lease_if_matches(
         return false;
     }
     if &entry.value != expected {
+        return false;
+    }
+    state.external_input_relay_lease_by_tmux.remove(&key);
+    true
+}
+
+/// Compare-and-clear the external-input relay lease for `(provider, tmux_session)`
+/// by its UNIQUE `generation` (and channel scope) rather than by full value.
+///
+/// This is the no-clobber primitive for the RAII release guards: the guard
+/// captures the generation of the EXACT lease it observed/recorded and on Drop
+/// clears only that generation. Two value-identical `Unassigned` leases (all
+/// trace fields `None`) for the same key receive distinct generations at record
+/// time, so an OLD guard's Drop leaves a NEWER lease — with a different
+/// generation — untouched. A guard whose captured lease was never recorded
+/// (generation == [`EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED`]) clears
+/// nothing.
+pub(crate) fn clear_external_input_relay_lease_if_generation_matches(
+    provider: &str,
+    tmux_session_name: &str,
+    channel_id: u64,
+    expected_generation: u64,
+) -> bool {
+    if expected_generation == EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED {
+        return false;
+    }
+    let provider = normalize_provider(provider);
+    let tmux_session_name = tmux_session_name.trim();
+    if provider.is_empty() || tmux_session_name.is_empty() || channel_id == 0 {
+        return false;
+    }
+    let mut state = STATE.lock().unwrap_or_else(|error| error.into_inner());
+    state.purge_expired();
+    let key = PromptKey::new(&provider, tmux_session_name);
+    let Some(entry) = state.external_input_relay_lease_by_tmux.get(&key) else {
+        return false;
+    };
+    if entry
+        .value
+        .channel_id
+        .is_some_and(|leased| leased != channel_id)
+    {
+        return false;
+    }
+    if entry.value.generation != expected_generation {
         return false;
     }
     state.external_input_relay_lease_by_tmux.remove(&key);
@@ -1670,6 +1758,7 @@ mod tests {
                 session_key: Some("host:tmux-trace".to_string()),
                 relay_owner: ExternalInputRelayOwner::SessionBoundRelay,
                 runtime_kind: Some(RuntimeHandoffKind::CodexTui),
+                generation: EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
             },
         );
 
@@ -1699,32 +1788,91 @@ mod tests {
             session_key: Some("host:tmux-trace".to_string()),
             relay_owner: ExternalInputRelayOwner::BridgeAdapter,
             runtime_kind: Some(RuntimeHandoffKind::CodexTui),
+            generation: EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
         };
         let newer = ExternalInputRelayLease {
             turn_id: Some("external:codex:42:tmux-trace:2".to_string()),
             ..original.clone()
         };
 
-        record_external_input_turn_lease("codex", "tmux-trace", original.clone());
-        record_external_input_turn_lease("codex", "tmux-trace", newer.clone());
+        // Capture the RECORDED leases (each stamped with a distinct generation) —
+        // those are the exact identities `_if_matches` compares against.
+        let recorded_original =
+            record_external_input_turn_lease("codex", "tmux-trace", original.clone());
+        let recorded_newer = record_external_input_turn_lease("codex", "tmux-trace", newer.clone());
+        assert_ne!(
+            recorded_original.generation, recorded_newer.generation,
+            "each recorded lease must get a distinct generation"
+        );
 
+        // The OLD recorded lease no longer matches the CURRENT (newer) one.
         assert!(!clear_external_input_relay_lease_if_matches(
             "codex",
             "tmux-trace",
             42,
-            &original
+            &recorded_original
         ));
         assert_eq!(
             external_input_relay_lease("codex", "tmux-trace", 42),
-            Some(newer.clone())
+            Some(recorded_newer.clone())
         );
         assert!(clear_external_input_relay_lease_if_matches(
             "codex",
             "tmux-trace",
             42,
-            &newer
+            &recorded_newer
         ));
         assert!(external_input_relay_lease("codex", "tmux-trace", 42).is_none());
+    }
+
+    #[test]
+    fn clear_external_input_relay_lease_if_generation_matches_preserves_newer_unassigned() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+
+        // Two value-identical Unassigned leases (all trace fields None) for the same
+        // key receive DISTINCT generations.
+        record_external_input_relay_lease("codex", "tmux-gen", Some(99));
+        let first = external_input_relay_lease("codex", "tmux-gen", 99).expect("first lease");
+        record_external_input_relay_lease("codex", "tmux-gen", Some(99));
+        let second = external_input_relay_lease("codex", "tmux-gen", 99).expect("second lease");
+
+        assert_eq!(first.relay_owner, ExternalInputRelayOwner::Unassigned);
+        assert_eq!(second.relay_owner, ExternalInputRelayOwner::Unassigned);
+        assert_ne!(
+            first.generation, second.generation,
+            "two Unassigned leases for the same key must get distinct generations"
+        );
+
+        // Clearing by the OLD generation must NOT clear the newer lease.
+        assert!(!clear_external_input_relay_lease_if_generation_matches(
+            "codex",
+            "tmux-gen",
+            99,
+            first.generation
+        ));
+        assert_eq!(
+            external_input_relay_lease("codex", "tmux-gen", 99),
+            Some(second.clone()),
+            "the newer Unassigned lease must survive a clear by the old generation"
+        );
+
+        // The UNRECORDED sentinel generation clears nothing.
+        assert!(!clear_external_input_relay_lease_if_generation_matches(
+            "codex",
+            "tmux-gen",
+            99,
+            EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED
+        ));
+
+        // Clearing by the CURRENT generation clears exactly it.
+        assert!(clear_external_input_relay_lease_if_generation_matches(
+            "codex",
+            "tmux-gen",
+            99,
+            second.generation
+        ));
+        assert!(external_input_relay_lease("codex", "tmux-gen", 99).is_none());
     }
 
     #[test]

--- a/src/services/tui_prompt_dedupe.rs
+++ b/src/services/tui_prompt_dedupe.rs
@@ -736,6 +736,26 @@ pub(crate) fn external_input_relay_lease_present(
     external_input_relay_lease(provider, tmux_session_name, channel_id).is_some()
 }
 
+/// Return the UNIQUE `generation` of the external-input relay lease currently
+/// stored for `(provider, tmux_session)` iff its channel scope matches
+/// `channel_id` (same channel-scope rule as [`external_input_relay_lease_present`]),
+/// else `None`.
+///
+/// Watchers/sinks that observe a lease before an awaited delivery and want to
+/// clear it afterwards MUST capture this generation at observation time and pass
+/// it to [`clear_external_input_relay_lease_if_generation_matches`], rather than
+/// using the unconditional [`clear_external_input_relay_lease`]. That guarantees
+/// a stale snapshot cannot clobber a NEWER same-key lease recorded by a
+/// concurrently-started turn while the first delivery was in flight.
+pub(crate) fn external_input_relay_lease_generation(
+    provider: &str,
+    tmux_session_name: &str,
+    channel_id: u64,
+) -> Option<u64> {
+    external_input_relay_lease(provider, tmux_session_name, channel_id)
+        .map(|lease| lease.generation)
+}
+
 pub(crate) fn clear_external_input_relay_lease(
     provider: &str,
     tmux_session_name: &str,
@@ -1873,6 +1893,74 @@ mod tests {
             second.generation
         ));
         assert!(external_input_relay_lease("codex", "tmux-gen", 99).is_none());
+    }
+
+    #[test]
+    fn external_input_relay_lease_generation_reports_stored_generation() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+
+        // No lease yet → None.
+        assert_eq!(
+            external_input_relay_lease_generation("codex", "tmux-genfn", 99),
+            None,
+            "no stored lease must report None"
+        );
+
+        record_external_input_relay_lease("codex", "tmux-genfn", Some(99));
+        let stored = external_input_relay_lease("codex", "tmux-genfn", 99).expect("stored lease");
+        assert_ne!(
+            stored.generation, EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
+            "a recorded lease must carry a non-sentinel generation"
+        );
+
+        // Matching channel scope → returns the stored generation.
+        assert_eq!(
+            external_input_relay_lease_generation("codex", "tmux-genfn", 99),
+            Some(stored.generation),
+            "must report the stored lease's generation for the matching channel"
+        );
+
+        // Channel mismatch → None (same channel-scope rule as `_present`).
+        assert_eq!(
+            external_input_relay_lease_generation("codex", "tmux-genfn", 100),
+            None,
+            "a channel mismatch must report None"
+        );
+    }
+
+    /// Watcher-style no-clobber: turn-1 snapshots the lease generation G1 before its
+    /// awaited send; turn-2 records a NEWER same-key lease G2 during that send; turn-1
+    /// then clears BY G1 — which must NOT remove turn-2's G2 lease.
+    #[test]
+    fn watcher_snapshot_generation_clear_preserves_newer_same_key_lease() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+
+        // turn-1 records & the watcher snapshots its generation BEFORE the awaited send.
+        record_external_input_relay_lease("codex", "tmux-watch", Some(7));
+        let g1 = external_input_relay_lease_generation("codex", "tmux-watch", 7)
+            .expect("turn-1 generation snapshot");
+
+        // turn-2 records a NEWER same-key lease while turn-1's send is in flight.
+        record_external_input_relay_lease("codex", "tmux-watch", Some(7));
+        let g2 = external_input_relay_lease_generation("codex", "tmux-watch", 7)
+            .expect("turn-2 generation");
+        assert_ne!(
+            g1, g2,
+            "the newer same-key lease must get a distinct generation"
+        );
+
+        // turn-1's post-send clear BY G1 must be a no-op (G1 != current G2).
+        assert!(
+            !clear_external_input_relay_lease_if_generation_matches("codex", "tmux-watch", 7, g1),
+            "clear by the stale G1 snapshot must not match the current G2 lease"
+        );
+        assert_eq!(
+            external_input_relay_lease_generation("codex", "tmux-watch", 7),
+            Some(g2),
+            "turn-2's lease must survive turn-1's stale-snapshot clear (no clobber)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
The session-bound sink's `external_input_relay_lease` (TTL 600s) was `clear_external_input_relay_lease`'d only on the **four Ok delivery branches** of `deliver_response`. An **Err / `?` / HTTP-503 / panic** left it set for the full 600s TTL → the next terminal delivery is blocked for up to ~10 minutes (#2955).

## Leak paths now covered
`deliver_response` Err/`?` exits that previously leaked: `shared_for_provider` unavailable (`?`), `serenity_http_or_token_fallback` unavailable (`?`), `send_long_message_raw_with_rollback` (`?`/503), `send_long_message_raw_with_reference` (`?`/503), the `PartialContinuationFailure` / `Err(error)` returns in the placeholder-edit arm, and any panic/unwind.

## RAII guard + `_if_matches` no-clobber
`SessionBoundExternalInputLeaseGuard` is armed the moment the sink owns the terminal delivery (right after the route decision, before the first `?`). On `Drop` it **compare-and-clears** via `clear_external_input_relay_lease_if_matches`, so it only ever releases its **own** captured lease — a newer turn that re-took the same `(provider, tmux_session, channel)` key during a slow delivery **survives** (mirrors `TuiDirectExternalInputLeaseGuard`). The four scattered manual Ok-path clears are replaced with this single release path. `arm_if_present` is **inert** for a foreign-owner lease (BridgeAdapter/TmuxWatcher/TuiPromptRelay).

## Delivery-blocking decouple (§4-④) + no-duplicate justification
`session_bound_external_lease_blocks_delivery` is documented/reduced to **input-dedup only**: an `Unassigned`/`SessionBoundRelay`-owned lease already does **not** self-block (terminal-delivery serialization belongs to the `DeliveryLeaseCell` B2 gate + per-sequence ACK + reconciliation from P1-1/2/3). The **foreign-owner deferral is kept** as a cross-subsystem routing concern — removing it is out of P1-4 scope and could re-introduce a duplicate (sink AND owning subsystem both posting). No duplicate is re-introduced; the 10-min block was caused by the **leak**, which the guard fixes.

## Backstop
Not added — the RAII guard is the complete fix; a send-deadline reclaim was not cheap enough within P1-4 scope.

## Tests (all green)
- `deliver_response_err_path_releases_external_input_lease_via_guard` — drives a real `deliver_response` whose `shared` is unavailable so the first `?` returns `Err`, then asserts the lease **is released** (guard Drop fired).
- `lease_guard_drop_preserves_newer_turn_lease_no_clobber` — a newer turn's lease survives an old guard's drop (`_if_matches`).
- `lease_guard_drop_clears_own_lease_and_is_inert_for_foreign_owner` — own lease released; foreign-owner lease preserved (input-dedup / routing not regressed).

## Verification (macOS, local)
- `cargo fmt --check`: clean
- `cargo build --all-targets`: ok
- `cargo clippy --workspace --all-targets --all-features`: **no new warnings** (diff vs main identical)
- `cargo test --all-targets` (each `-- --skip _pg --skip pg_ --skip postgres --test-threads=1`): turn_finalizer:: 50, delivery_lease 39, sink 42, relay 215, stream_relay 12, bridge 153, tui_prompt 116, transition 3, cancel 95 — **0 failed**
- `generate_inventory_docs.py` / `check_agent_maintenance_docs.py`: pass
- `ci-script-checks.sh`: only error is the untracked `routines/dependency-update-watcher.js` (ignored per task)

## Windows-safety
No new filesystem/path/process APIs; only in-process lease state + an RAII `Drop`. Windows-safe.

Constraints intact: #3141/#3143 + P1-1/2/3 (DeliveryLeaseCell, per-sequence ACK, frame-fence, reconciliation), monotonic confirmed_end. Scope = P1-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)