### PR TITLE
feat(#3041): P1-5 unify terminal delivery outcome into 3-way DeliveryOutcome{Delivered,NotDelivered,Unknown}; redefine Ok(Skipped) as NotDelivered

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -128,7 +128,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (8766 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (8826 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -228,7 +228,23 @@
     (`external_input_relay_lease(...)` under a SINGLE STATE lock) and derives BOTH
     the presence bool and the generation from that one atomic read, closing the
     present/generation TOCTOU where two separate accessor calls re-locked STATE and
-    a concurrently-started turn could slip a newer same-key lease into the gap).
+    a concurrently-started turn could slip a newer same-key lease into the gap);
+    +60 from #3041 P1-5 (FINAL phase): unify the terminal delivery outcome into the
+    cross-actor 3-way `DeliveryOutcome { Delivered, NotDelivered, Unknown }`. The
+    watcher's `SessionBoundRelayAckOutcome::TerminalSkipped` is renamed `NotDelivered`
+    (folds ring `DeliveryOutcome::NotDelivered`), a new `RingUnknown` arm folds the
+    explicit ring `Unknown`, and the failure/unconfirmed arms
+    (`RingUnknown`/`Dropped`/`SinkError`/`TimedOut`/`MissingTarget`) collapse to
+    `DeliveryOutcome::Unknown` via the new pure `session_bound_ack_delivery_outcome`
+    fold. `watcher_should_direct_send_after_session_bound_ack` now decides on that
+    3-way (`!= Delivered`) instead of the implicit `ack_outcome != Delivered` bit.
+    §3.2 SAFETY INVARIANT: BOTH `NotDelivered` AND every `Unknown`-class arm still
+    flow through `watcher_terminal_resend_action` (committed-offset reconciliation:
+    `committed >= end` → SkipAlreadyCommitted, else SendFull) — NO blind-skip for
+    NotDelivered, NO blind 10s re-send for Unknown; the should-direct-send bool stays
+    the precondition gate, the send paths stay masked by `!SkipAlreadyCommitted`. New
+    tests `unknown_outcome_triggers_committed_offset_reconciliation_not_blind_resend`
+    and `not_delivered_outcome_keeps_no_resend_when_foreign_owner_committed`).
   - `src/services/discord/tui_prompt_relay.rs` (3982 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +12 from #3041 P1-4 codex: the lease record

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -128,7 +128,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (8826 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (8844 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -244,7 +244,25 @@
     NotDelivered, NO blind 10s re-send for Unknown; the should-direct-send bool stays
     the precondition gate, the send paths stay masked by `!SkipAlreadyCommitted`. New
     tests `unknown_outcome_triggers_committed_offset_reconciliation_not_blind_resend`
-    and `not_delivered_outcome_keeps_no_resend_when_foreign_owner_committed`).
+    and `not_delivered_outcome_keeps_no_resend_when_foreign_owner_committed`);
+    +18 from #3041 P1-5 (codex P1 follow-up) routing the ownerless `TimedOut`
+    through §3.2: the pre-existing #3042 band-aid (`if !relay_owner_present &&
+    TimedOut { return false }` early-return in
+    `watcher_should_direct_send_after_session_bound_ack`) blanket-suppressed an
+    ownerless TimedOut BEFORE it could reach `watcher_terminal_resend_action`
+    (committed-offset reconciliation) — neither reconciling nor resending → a
+    potential black-hole when committed < end. P1-3 Part (a)
+    (`advance_offset_for_confirmed_delegated_terminal`) made the committed offset
+    authoritative on a CONFIRMED post (the same fence that arms the ACK target →
+    TimedOut), so the band-aid is obsolete: the early-return is removed and an
+    ownerless TimedOut now flows through the SAME §3.2 path as every other
+    non-Delivered outcome (committed >= end → SkipAlreadyCommitted → the #3042 3×
+    duplicate is prevented PRINCIPALLY; committed < end → SendFull → black-hole
+    closed). The §3.2 universality invariant now covers EVERY non-Delivered arm with
+    no exception. New/updated tests `ownerless_timed_out_intends_resend_via_gate`
+    (renamed from `ownerless_timeout_suppresses_watcher_direct_fallback`),
+    `ownerless_timed_out_reconciles_skip_when_committed_reaches_end` (#3042
+    regression guard), `ownerless_timed_out_reconciles_full_when_not_committed`.
   - `src/services/discord/tui_prompt_relay.rs` (3982 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +12 from #3041 P1-4 codex: the lease record

--- a/src/services/cluster/stream_relay.rs
+++ b/src/services/cluster/stream_relay.rs
@@ -71,16 +71,31 @@ pub const DEFAULT_RELAY_BUFFER: usize = 1024;
 /// times out → reconciles, never a false ACK).
 pub const TERMINAL_OUTCOME_RING_CAPACITY: usize = 64;
 
-/// #3041 P1-3 R5: the EXACT, per-frame terminal resolution recorded by the sink
-/// for a single terminal (result-bearing) frame's sequence. Distinct from the
+/// #3041 P1-3 R5 / P1-5: the EXACT, per-frame terminal resolution recorded for a
+/// single terminal (result-bearing) frame's sequence. Distinct from the
 /// high-water-mark fields (`last_terminal_committed/skipped_sequence`), which a
 /// LATER, higher-sequence terminal can bump — this is keyed to ONE sequence so a
 /// watcher resolves its ACK on ITS OWN terminal frame's outcome, decoupled from
 /// any other turn sharing the same physical chunk.
+///
+/// #3041 P1-5: the CANONICAL cross-actor 3-way delivery outcome. The sink-local
+/// enum stays 2-way (the sink always KNOWS: confirmed POST → `Delivered`;
+/// deterministic decline → `NotDelivered`; failure → `Err`). `Unknown` is a
+/// CROSS-ACTOR state that arises in the relay ring + watcher when the terminal
+/// resolution cannot be confirmed (the watcher's ACK timed out / target was
+/// missing / the frame was dropped or hit a sink error, or the sink POSTed but
+/// could not confirm the commit). Both `NotDelivered` AND `Unknown` MUST flow
+/// through the watcher's committed-offset reconciliation (§3.2) — there is NO
+/// blind skip for `NotDelivered` and NO blind 10s re-send for `Unknown`.
+///
+/// A NEVER-recorded sequence reads back `None` (distinct from `Some(Unknown)`):
+/// `None` means "not yet resolved" (keep waiting), `Some(Unknown)` is an explicit
+/// "resolved but unconfirmed → reconcile NOW" signal the sink/watcher can record.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum TerminalOutcome {
-    Committed,
-    Skipped,
+pub enum DeliveryOutcome {
+    Delivered,
+    NotDelivered,
+    Unknown,
 }
 
 /// An opaque stream frame emitted by a provider. Carries enough metadata for
@@ -157,7 +172,7 @@ pub struct RelayMetrics {
     /// for the EXACT `target.sequence` so B's tail committing at seq N+1 never
     /// satisfies A's ACK at seq N. Bounded FIFO (`TERMINAL_OUTCOME_RING_CAPACITY`):
     /// an evicted/never-recorded sequence reads back `None`.
-    terminal_outcomes: Mutex<VecDeque<(u64, TerminalOutcome)>>,
+    terminal_outcomes: Mutex<VecDeque<(u64, DeliveryOutcome)>>,
 }
 
 impl RelayMetrics {
@@ -191,12 +206,15 @@ impl RelayMetrics {
         }
     }
 
-    /// #3041 P1-3 R5: record THIS terminal frame's resolved outcome keyed by its
-    /// exact sequence, in a bounded FIFO ring. Called from `deliver_frame` for a
-    /// result-bearing terminal delivery (Committed/Skipped). Idempotent-ish: a
-    /// re-record of the same sequence overwrites the prior entry in place (a
-    /// sequence is delivered once, but this keeps the ring free of duplicates).
-    fn record_terminal_outcome(&self, sequence: u64, outcome: TerminalOutcome) {
+    /// #3041 P1-3 R5 / P1-5: record THIS terminal frame's resolved outcome keyed
+    /// by its exact sequence, in a bounded FIFO ring. Called from `deliver_frame`
+    /// for a result-bearing terminal delivery (`Delivered`/`NotDelivered`) and may
+    /// also carry an explicit cross-actor `Unknown` (sink POSTed but could not
+    /// confirm the commit) so the watcher reconciles immediately instead of waiting
+    /// for the 10s ACK timeout. Idempotent-ish: a re-record of the same sequence
+    /// overwrites the prior entry in place (a sequence is delivered once, but this
+    /// keeps the ring free of duplicates).
+    pub(crate) fn record_terminal_outcome(&self, sequence: u64, outcome: DeliveryOutcome) {
         let mut ring = self
             .terminal_outcomes
             .lock()
@@ -217,7 +235,7 @@ impl RelayMetrics {
     /// The watcher resolves its ACK on its OWN terminal frame's sequence via this
     /// — NOT the `>=` high-water-mark — so a co-chunked higher-sequence terminal
     /// can never satisfy it.
-    pub fn terminal_outcome_for_sequence(&self, sequence: u64) -> Option<TerminalOutcome> {
+    pub fn terminal_outcome_for_sequence(&self, sequence: u64) -> Option<DeliveryOutcome> {
         let ring = self
             .terminal_outcomes
             .lock()
@@ -237,14 +255,14 @@ impl RelayMetrics {
     pub(crate) fn record_terminal_committed_sequence_for_test(&self, sequence: u64) {
         self.last_terminal_committed_sequence_plus_one
             .fetch_max(encode_sequence_marker(sequence), Ordering::AcqRel);
-        self.record_terminal_outcome(sequence, TerminalOutcome::Committed);
+        self.record_terminal_outcome(sequence, DeliveryOutcome::Delivered);
     }
 
     #[cfg(test)]
     pub(crate) fn record_terminal_skipped_sequence_for_test(&self, sequence: u64) {
         self.last_terminal_skipped_sequence_plus_one
             .fetch_max(encode_sequence_marker(sequence), Ordering::AcqRel);
-        self.record_terminal_outcome(sequence, TerminalOutcome::Skipped);
+        self.record_terminal_outcome(sequence, DeliveryOutcome::NotDelivered);
     }
 
     #[cfg(test)]
@@ -327,22 +345,37 @@ pub trait RelaySink: Send + Sync + 'static {
 /// Result of accepting a relay frame into the sink. This deliberately
 /// distinguishes "the sink accepted/parsing-counted this frame" from "a
 /// terminal Discord response was actually committed". Watchers must use only
-/// `TerminalCommitted` as delegation success; `TerminalSkipped` is an explicit
-/// direct-fallback signal, not an error and not a commit.
+/// `TerminalDelivered` as delegation success.
+///
+/// #3041 P1-5: the three terminal variants mirror the cross-actor 3-way
+/// `DeliveryOutcome`. `TerminalDelivered` (confirmed POST/edit) → the watcher
+/// treats the turn as delivered. `TerminalNotDelivered` (a deterministic
+/// route-decision decline — foreign-owner lease block, or bridge-owned /
+/// mismatched inflight) and `TerminalUnknown` (the sink POSTed but could not
+/// confirm the commit) BOTH route the watcher through committed-offset
+/// reconciliation (§3.2): NO blind skip for `NotDelivered`, NO blind re-send for
+/// `Unknown`. The session-bound sink itself emits only `Delivered`/`NotDelivered`
+/// (it always knows); `TerminalUnknown` is reserved for a future/optional sink
+/// site that POSTs-without-confirm and for cross-actor symmetry.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RelaySinkOutcome {
     FrameAccepted,
-    TerminalCommitted,
-    TerminalSkipped,
+    TerminalDelivered,
+    TerminalNotDelivered,
+    TerminalUnknown,
 }
 
 impl RelaySinkOutcome {
-    pub fn terminal_committed(self) -> bool {
-        matches!(self, Self::TerminalCommitted)
+    pub fn terminal_delivered(self) -> bool {
+        matches!(self, Self::TerminalDelivered)
     }
 
-    pub fn terminal_skipped(self) -> bool {
-        matches!(self, Self::TerminalSkipped)
+    pub fn terminal_not_delivered(self) -> bool {
+        matches!(self, Self::TerminalNotDelivered)
+    }
+
+    pub fn terminal_unknown(self) -> bool {
+        matches!(self, Self::TerminalUnknown)
     }
 }
 
@@ -869,7 +902,7 @@ async fn deliver_frame(
             metrics
                 .last_delivered_sequence_plus_one
                 .fetch_max(encode_sequence_marker(frame.sequence), Ordering::AcqRel);
-            if outcome.terminal_committed() {
+            if outcome.terminal_delivered() {
                 metrics.terminal_commits.fetch_add(1, Ordering::AcqRel);
                 metrics
                     .last_terminal_committed_sequence_plus_one
@@ -877,15 +910,26 @@ async fn deliver_frame(
                 // #3041 P1-3 R5: record THIS frame's exact-sequence outcome so the
                 // watcher resolves its ACK on its own terminal frame (decoupled
                 // from any co-chunked higher-sequence terminal).
-                metrics.record_terminal_outcome(frame.sequence, TerminalOutcome::Committed);
+                metrics.record_terminal_outcome(frame.sequence, DeliveryOutcome::Delivered);
             }
-            if outcome.terminal_skipped() {
+            if outcome.terminal_not_delivered() {
                 metrics.terminal_skips.fetch_add(1, Ordering::AcqRel);
                 metrics
                     .last_terminal_skipped_sequence_plus_one
                     .fetch_max(encode_sequence_marker(frame.sequence), Ordering::AcqRel);
-                // #3041 P1-3 R5: per-sequence skip — see committed branch above.
-                metrics.record_terminal_outcome(frame.sequence, TerminalOutcome::Skipped);
+                // #3041 P1-5: a deterministic route-decision decline — recorded as
+                // `NotDelivered` so the watcher reconciles against the committed
+                // offset (§3.2 SendFull-or-Skip), never a blind skip.
+                metrics.record_terminal_outcome(frame.sequence, DeliveryOutcome::NotDelivered);
+            }
+            if outcome.terminal_unknown() {
+                // #3041 P1-5: the sink POSTed but could not confirm the commit. We
+                // do NOT bump the commit/skip high-water-marks (the outcome is, by
+                // definition, unconfirmed) but DO record the per-sequence `Unknown`
+                // so the watcher's per-sequence ACK resolves immediately to
+                // committed-offset reconciliation instead of waiting out the 10s
+                // ACK timeout. Both `NotDelivered` and `Unknown` flow through §3.2.
+                metrics.record_terminal_outcome(frame.sequence, DeliveryOutcome::Unknown);
             }
         }
         Err(error) => {
@@ -961,8 +1005,8 @@ mod tests {
         async fn deliver(&self, frame: &StreamFrame) -> Result<RelaySinkOutcome, RelaySinkError> {
             Ok(match frame.sequence {
                 0 => RelaySinkOutcome::FrameAccepted,
-                1 => RelaySinkOutcome::TerminalSkipped,
-                _ => RelaySinkOutcome::TerminalCommitted,
+                1 => RelaySinkOutcome::TerminalNotDelivered,
+                _ => RelaySinkOutcome::TerminalDelivered,
             })
         }
     }
@@ -1151,11 +1195,11 @@ mod tests {
         let metrics = handle.metrics();
         assert_eq!(
             metrics.terminal_outcome_for_sequence(1),
-            Some(TerminalOutcome::Skipped)
+            Some(DeliveryOutcome::NotDelivered)
         );
         assert_eq!(
             metrics.terminal_outcome_for_sequence(2),
-            Some(TerminalOutcome::Committed)
+            Some(DeliveryOutcome::Delivered)
         );
         assert_eq!(metrics.terminal_outcome_for_sequence(0), None);
         // A sequence that was never terminally resolved reads None.
@@ -1171,17 +1215,17 @@ mod tests {
     fn per_sequence_terminal_outcome_is_independent_of_higher_sequences() {
         let metrics = RelayMetrics::default();
         // A at seq 10 was SKIPPED; B's tail at seq 11 COMMITTED (higher sequence).
-        metrics.record_terminal_outcome(10, TerminalOutcome::Skipped);
-        metrics.record_terminal_outcome(11, TerminalOutcome::Committed);
+        metrics.record_terminal_outcome(10, DeliveryOutcome::NotDelivered);
+        metrics.record_terminal_outcome(11, DeliveryOutcome::Delivered);
         // High-water-mark for committed is now 11 (would falsely satisfy `>= 10`).
         assert_eq!(
             metrics.terminal_outcome_for_sequence(10),
-            Some(TerminalOutcome::Skipped),
-            "A's ACK must read A's OWN outcome (Skipped), not B's committed high-water-mark"
+            Some(DeliveryOutcome::NotDelivered),
+            "A's ACK must read A's OWN outcome (NotDelivered), not B's delivered high-water-mark"
         );
         assert_eq!(
             metrics.terminal_outcome_for_sequence(11),
-            Some(TerminalOutcome::Committed)
+            Some(DeliveryOutcome::Delivered)
         );
     }
 
@@ -1193,7 +1237,7 @@ mod tests {
         let metrics = RelayMetrics::default();
         let total = TERMINAL_OUTCOME_RING_CAPACITY as u64 + 5;
         for seq in 0..total {
-            metrics.record_terminal_outcome(seq, TerminalOutcome::Committed);
+            metrics.record_terminal_outcome(seq, DeliveryOutcome::Delivered);
         }
         // The oldest 5 were evicted.
         for seq in 0..5 {
@@ -1207,9 +1251,33 @@ mod tests {
         for seq in 5..total {
             assert_eq!(
                 metrics.terminal_outcome_for_sequence(seq),
-                Some(TerminalOutcome::Committed)
+                Some(DeliveryOutcome::Delivered)
             );
         }
+    }
+
+    // #3041 P1-5: the ring carries the cross-actor `Unknown` outcome and an
+    // explicit `Some(Unknown)` is DISTINCT from a never-recorded `None`. A sink
+    // that POSTed-without-confirming (or the watcher's reconcile path) records
+    // `Unknown` so the watcher reconciles immediately instead of waiting out the
+    // 10s ACK timeout — while a sequence that was never resolved still reads
+    // `None` ("keep waiting"). This pins the additive third variant.
+    #[test]
+    fn terminal_outcome_ring_carries_unknown() {
+        let metrics = RelayMetrics::default();
+        metrics.record_terminal_outcome(7, DeliveryOutcome::Unknown);
+        assert_eq!(
+            metrics.terminal_outcome_for_sequence(7),
+            Some(DeliveryOutcome::Unknown),
+            "Unknown is recorded and read back as an explicit cross-actor outcome"
+        );
+        assert_ne!(
+            metrics.terminal_outcome_for_sequence(7),
+            None,
+            "Some(Unknown) (resolved-but-unconfirmed) is DISTINCT from None (not yet resolved)"
+        );
+        // A never-recorded sequence still reads None ("keep waiting"), not Unknown.
+        assert_eq!(metrics.terminal_outcome_for_sequence(8), None);
     }
 
     #[tokio::test]

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -586,7 +586,14 @@ impl SessionBoundDiscordRelaySink {
                     false,
                     Some("bridge-owned or mismatched inflight"),
                 );
-                return Ok(SessionRelayDeliveryOutcome::Skipped);
+                // #3041 P1-5: the SOLE sink-local decline. The route decision
+                // declined deterministically (a foreign-owner lease block, or
+                // `route_or_skip` Err = bridge-owned / mismatched inflight). This is
+                // `NotDelivered`, NOT `Unknown`: the sink KNOWS it did not post. The
+                // watcher routes `NotDelivered` through committed-offset
+                // reconciliation (§3.2): if no owner committed, SendFull recovers the
+                // turn — never a blind skip.
+                return Ok(SessionRelayDeliveryOutcome::NotDelivered);
             }
         };
         // #3041 P1-4 (§4-④): arm the RAII release-on-all-paths guard the moment
@@ -689,7 +696,7 @@ impl SessionBoundDiscordRelaySink {
                     &delivery.session_name,
                     &delivery,
                 );
-                return Ok(SessionRelayDeliveryOutcome::Committed);
+                return Ok(SessionRelayDeliveryOutcome::Delivered);
             }
             match formatting::replace_long_message_raw_with_outcome(
                 &http,
@@ -739,7 +746,7 @@ impl SessionBoundDiscordRelaySink {
                         &delivery.session_name,
                         &delivery,
                     );
-                    Ok(SessionRelayDeliveryOutcome::Committed)
+                    Ok(SessionRelayDeliveryOutcome::Delivered)
                 }
                 Ok(ReplaceLongMessageOutcome::SentFallbackAfterEditFailure { edit_error }) => {
                     // #2757: do not delete msg_id here. The 3e158e588 path
@@ -789,7 +796,7 @@ impl SessionBoundDiscordRelaySink {
                         &delivery.session_name,
                         &delivery,
                     );
-                    Ok(SessionRelayDeliveryOutcome::Committed)
+                    Ok(SessionRelayDeliveryOutcome::Delivered)
                 }
                 Ok(ReplaceLongMessageOutcome::PartialContinuationFailure { error, .. }) => {
                     Err(RelaySinkError::Transient(error.to_string()))
@@ -854,15 +861,23 @@ impl SessionBoundDiscordRelaySink {
                 &delivery.session_name,
                 &delivery,
             );
-            Ok(SessionRelayDeliveryOutcome::Committed)
+            Ok(SessionRelayDeliveryOutcome::Delivered)
         }
     }
 }
 
+/// #3041 P1-5: the SINK-LOCAL terminal outcome stays deliberately 2-way. The
+/// session-bound sink always KNOWS its result: a confirmed POST/edit → `Delivered`;
+/// a deterministic route-decision decline (foreign-owner lease block, or
+/// bridge-owned / mismatched inflight) → `NotDelivered`; a transport/format failure
+/// → `Err`. There is NO sink-local `Unknown` (the cross-actor `Unknown` arises in
+/// the relay ring + watcher, not here). `NotDelivered` (the former `Skipped`) is
+/// mapped to `RelaySinkOutcome::TerminalNotDelivered`, which the watcher routes
+/// through committed-offset reconciliation (§3.2) — never a blind skip.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SessionRelayDeliveryOutcome {
-    Committed,
-    Skipped,
+    Delivered,
+    NotDelivered,
 }
 
 #[async_trait]
@@ -870,8 +885,8 @@ impl RelaySink for SessionBoundDiscordRelaySink {
     async fn deliver(&self, frame: &StreamFrame) -> Result<RelaySinkOutcome, RelaySinkError> {
         // #3041 P1-3 R5 (codex P1-3 — REVERT R4 fence-gating of the terminal
         // outcome): a RESULT-bearing delivery reports its terminal outcome
-        // (Committed / Skipped) REGARDLESS of whether THIS frame carries a commit
-        // fence (`terminal_consumed_end`). R4 gated the outcome on the fence, which
+        // (Delivered / NotDelivered) REGARDLESS of whether THIS frame carries a
+        // commit fence (`terminal_consumed_end`). R4 gated the outcome on the fence, which
         // BROKE the legitimate no-inflight session-bound terminal delivery: that
         // delivery legitimately has NO fence but IS a real terminal whose ACK must
         // resolve — under R4 it reported only `FrameAccepted`, so the watcher timed
@@ -889,13 +904,13 @@ impl RelaySink for SessionBoundDiscordRelaySink {
         // ACK marker" (driven by a result-bearing delivery) and "offset advance"
         // (driven by the fence) are now decoupled.
         let deliveries = self.ingest_frame(frame);
-        let mut terminal_committed = false;
-        let mut terminal_skipped = false;
+        let mut terminal_delivered = false;
+        let mut terminal_not_delivered = false;
         for delivery in deliveries {
             let session_name = delivery.session_name.clone();
             match self.deliver_response(delivery).await {
-                Ok(SessionRelayDeliveryOutcome::Committed) => {
-                    terminal_committed = true;
+                Ok(SessionRelayDeliveryOutcome::Delivered) => {
+                    terminal_delivered = true;
                     // #3041 P1-3 (Part a, BLOCKER B1 CLOSED — FRAME-CARRIED): the
                     // offset advance for a confirmed terminal delivery happens INLINE
                     // inside `deliver_response` (the commit fence:
@@ -920,8 +935,8 @@ impl RelaySink for SessionBoundDiscordRelaySink {
                     // watcher's OWN delivery path advances the authority instead.
                     self.finish_terminal_candidate(&session_name);
                 }
-                Ok(SessionRelayDeliveryOutcome::Skipped) => {
-                    terminal_skipped = true;
+                Ok(SessionRelayDeliveryOutcome::NotDelivered) => {
+                    terminal_not_delivered = true;
                     self.finish_terminal_candidate(&session_name);
                 }
                 Err(error) => {
@@ -936,10 +951,15 @@ impl RelaySink for SessionBoundDiscordRelaySink {
         // ITS OWN terminal frame's ACK on its exact sequence, so a co-chunked tail
         // at a different sequence can never satisfy another turn's terminal-ACK.
         // A frame that produced no result-bearing delivery reports `FrameAccepted`.
-        if terminal_committed {
-            Ok(RelaySinkOutcome::TerminalCommitted)
-        } else if terminal_skipped {
-            Ok(RelaySinkOutcome::TerminalSkipped)
+        // #3041 P1-5: the sink emits NO `TerminalUnknown` — it always KNOWS its
+        // own result (confirmed POST → Delivered; deterministic decline →
+        // NotDelivered; failure → the `Err` returned above). `Unknown` is the
+        // cross-actor state (relay ring + watcher), surfaced when the terminal
+        // resolution cannot be confirmed there.
+        if terminal_delivered {
+            Ok(RelaySinkOutcome::TerminalDelivered)
+        } else if terminal_not_delivered {
+            Ok(RelaySinkOutcome::TerminalNotDelivered)
         } else {
             Ok(RelaySinkOutcome::FrameAccepted)
         }
@@ -1962,8 +1982,16 @@ mod tests {
         assert!(result.is_err());
     }
 
+    // #3041 P1-5: a route-layer `Skipped` decision (the route enum legitimately
+    // keeps "Skipped" — a bridge-owned / mismatched inflight has no place to
+    // route) is the SOLE producer of the sink-local `NotDelivered` outcome
+    // (`deliver_response` returns `SessionRelayDeliveryOutcome::NotDelivered` at
+    // the route-decline arm), which `deliver` surfaces as
+    // `RelaySinkOutcome::TerminalNotDelivered`. The watcher then routes
+    // `NotDelivered` through committed-offset reconciliation (§3.2) — never a
+    // blind skip. This pins the route-`Skipped` → `NotDelivered` mapping origin.
     #[test]
-    fn terminal_delivery_route_skip_maps_to_terminal_skipped_outcome() {
+    fn terminal_delivery_route_skip_maps_to_not_delivered_outcome() {
         let tmux = "AgentDesk-claude-relay-test";
         let bridge_owned = inflight_for(tmux, RelayOwnerKind::None, false);
         assert_eq!(
@@ -1973,7 +2001,10 @@ mod tests {
                 &ProviderKind::Claude,
                 42,
             ),
-            SessionBoundTerminalDeliveryRouteDecision::Skipped
+            SessionBoundTerminalDeliveryRouteDecision::Skipped,
+            "a bridge-owned / mismatched inflight declines → route-layer Skipped, \
+             which deliver_response maps to the sink-local NotDelivered outcome \
+             (surfaced as RelaySinkOutcome::TerminalNotDelivered)"
         );
     }
 

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -2177,20 +2177,38 @@ fn watcher_should_direct_send_after_session_bound_ack(
     relay_owner_present: bool,
 ) -> bool {
     use crate::services::cluster::stream_relay::DeliveryOutcome;
-    // #3042 (relay-stability P1, immediate mitigation): after a restart the
-    // channel can run with `relay_owner_kind=none` + `inflight_present=false`
-    // (restore_inflight failed to rebind ownership), so the session-bound
-    // StreamRelay terminal-commit ACK never lands and the 10s wait reports
-    // `TimedOut` on every poll. In that ownerless state a `TimedOut` is NOT a
-    // reliable "not delivered" signal — the StreamRelay sink may have posted
-    // and merely failed to advance the committed-sequence metric — so blindly
-    // re-sending the same byte-range once per ACK-timeout poll produces the
-    // observed 3× duplicate. Suppress the watcher-direct fallback for an
-    // ownerless `TimedOut`. Owned outcomes and non-timeout outcomes keep the
-    // existing fallback behaviour.
-    if !relay_owner_present && matches!(ack_outcome, SessionBoundRelayAckOutcome::TimedOut) {
-        return false;
-    }
+    // #3042 (relay-stability P1, OBSOLETE band-aid — removed by #3041 P1-5):
+    // #3042 added an early `return false` here for an ownerless (`relay_owner_kind=none`
+    // / `inflight_present=false`, the post-restart restore_inflight gap) `TimedOut`,
+    // blanket-suppressing the watcher-direct fallback. Its rationale: in that gap the
+    // StreamRelay sink "may have posted and merely failed to ADVANCE the committed-
+    // sequence metric", so a blind re-send produced the observed 3× duplicate.
+    //
+    // That rationale no longer holds. #3041 P1-3 Part (a)
+    // (`advance_offset_for_confirmed_delegated_terminal`, session_relay_sink.rs ~459)
+    // now COUPLES a CONFIRMED sink terminal POST to advancing the offset authority
+    // (`confirmed_end_offset`) to the producer's fenced `end`. A `TimedOut` (NOT
+    // `MissingTarget`) is ONLY produced when a FENCED terminal frame was forwarded
+    // (tmux_watcher.rs ~2038/2053) — and that SAME fence is what the sink advances on,
+    // so the committed offset now DOES reflect a confirmed post even in the ownerless
+    // state (the authority is a plain owner-independent atomic; it is always readable).
+    //
+    // Therefore the blanket suppression is obsolete and HARMFUL: it returned `false`
+    // BEFORE the outcome could reach the §3.2 committed-offset reconciliation
+    // (`watcher_terminal_resend_action`), so an ownerless `TimedOut` whose bytes were
+    // NOT actually delivered (committed < end) neither reconciled nor resent — a
+    // potential black-hole. Routing it through §3.2 instead (drop the early return):
+    //   * committed >= end → `SkipAlreadyCommitted` → NO resend → the #3042 3×
+    //     duplicate is prevented PRINCIPALLY (not by blanket suppression);
+    //   * committed < end → `SendFull` → the bytes were genuinely undelivered →
+    //     recover → the black-hole the band-aid left is closed.
+    // This completes the P1-5 §3.2 invariant: EVERY non-`Delivered` outcome
+    // (NotDelivered, RingUnknown, MissingTarget, Dropped, SinkError, and now ownerless
+    // `TimedOut`) routes through committed-offset reconciliation — none blind-skips,
+    // none blind-resends. (`relay_owner_present` is retained in the signature for the
+    // flight-recorder/telemetry call site even though the gate no longer branches on
+    // it.)
+    let _ = relay_owner_present;
     // #3041 P1-5: decide on the cross-actor 3-way `DeliveryOutcome` instead of the
     // implicit `ack_outcome != Delivered` bit. `Delivered` → no watcher re-send.
     // `NotDelivered` AND `Unknown` (every failure/unconfirmed arm) BOTH intend a
@@ -3772,6 +3790,17 @@ mod matched_session_jsonl_gate_tests {
             SessionBoundRelayAckOutcome::Delivered,
             true
         ));
+        // #3041 P1-5: an ownerless `TimedOut` now ALSO returns true (intends a
+        // re-send) — the gate is the precondition only; the §3.2 committed-offset
+        // reconciliation at the call site decides Skip vs Full. (Previously #3042
+        // blanket-suppressed this to false.)
+        assert!(watcher_should_direct_send_after_session_bound_ack(
+            true,
+            SessionBoundRelayAckOutcome::TimedOut,
+            false
+        ));
+        // should_direct_send=false still gates the precondition off regardless of
+        // owner presence.
         assert!(!watcher_should_direct_send_after_session_bound_ack(
             false,
             SessionBoundRelayAckOutcome::TimedOut,
@@ -3779,29 +3808,35 @@ mod matched_session_jsonl_gate_tests {
         ));
     }
 
-    /// #3042: after a restart `restore_inflight` can leave the channel with
+    /// #3041 P1-5 (was `ownerless_timeout_suppresses_watcher_direct_fallback`,
+    /// #3042): after a restart `restore_inflight` can leave the channel with
     /// `relay_owner_kind=none`/`inflight_present=false`, so the session-bound
     /// terminal-commit ACK never lands and every 10s poll reports `TimedOut`.
-    /// In that ownerless state a `TimedOut` is not a reliable not-delivered
-    /// signal, so the watcher-direct blind re-send must be suppressed (the
-    /// observed 3× duplicate). Owner-absent + non-timeout outcomes still fall
-    /// back so genuine sink failures/skips are not silently dropped.
+    /// #3042 blanket-suppressed the gate to `false` there to avoid a 3× duplicate;
+    /// #3041 P1-5 REMOVES that band-aid because P1-3 Part (a) made the committed
+    /// offset authoritative on a confirmed post. The gate now returns `true` (intends
+    /// a re-send) for an ownerless `TimedOut` — JUST the precondition — and the §3.2
+    /// committed-offset reconciliation (`watcher_terminal_resend_action`) decides
+    /// Skip-vs-Full downstream. The actual no-duplicate / no-black-hole guarantees
+    /// are asserted by `ownerless_timed_out_reconciles_*` below.
     #[test]
-    fn ownerless_timeout_suppresses_watcher_direct_fallback() {
+    fn ownerless_timed_out_intends_resend_via_gate() {
         // The exact incident shape: should_direct_send=true, TimedOut, no owner.
-        assert!(!watcher_should_direct_send_after_session_bound_ack(
+        // Now PASSES the gate (was suppressed to false by #3042); §3.2 then
+        // reconciles (see `ownerless_timed_out_reconciles_*`).
+        assert!(watcher_should_direct_send_after_session_bound_ack(
             true,
             SessionBoundRelayAckOutcome::TimedOut,
             false
         ));
-        // Owner present with the same TimedOut keeps the fallback (regression
-        // guard so the suppression is owner-scoped, not a blanket TimedOut mute).
+        // Owner present with the same TimedOut also intends the fallback —
+        // universality: the gate no longer branches on owner presence.
         assert!(watcher_should_direct_send_after_session_bound_ack(
             true,
             SessionBoundRelayAckOutcome::TimedOut,
             true
         ));
-        // Ownerless but a non-timeout (definitive) outcome still falls back.
+        // Ownerless but a non-timeout (definitive) outcome still intends the fallback.
         assert!(watcher_should_direct_send_after_session_bound_ack(
             true,
             SessionBoundRelayAckOutcome::SinkError,
@@ -3812,12 +3847,67 @@ mod matched_session_jsonl_gate_tests {
             SessionBoundRelayAckOutcome::NotDelivered,
             false
         ));
-        // Ownerless TimedOut with should_direct_send=false is also suppressed.
+        // should_direct_send=false still gates the precondition off.
         assert!(!watcher_should_direct_send_after_session_bound_ack(
             false,
             SessionBoundRelayAckOutcome::TimedOut,
             false
         ));
+    }
+
+    /// #3041 P1-5 / #3042 REGRESSION GUARD: an ownerless (`relay_owner_present=false`)
+    /// `TimedOut` whose range is ALREADY committed at/past `end` (the sink posted and
+    /// P1-3 advanced `confirmed_end_offset`) reconciles to `SkipAlreadyCommitted` —
+    /// NO re-send. This is the principled replacement for #3042's blanket suppression:
+    /// the observed 3× duplicate is still prevented, but now via the committed-offset
+    /// authority rather than a blind owner-scoped mute (so a genuine non-delivery is
+    /// no longer black-holed — see `ownerless_timed_out_reconciles_full_when_not_committed`).
+    #[test]
+    fn ownerless_timed_out_reconciles_skip_when_committed_reaches_end() {
+        // Ownerless TimedOut now passes the precondition gate (no longer suppressed).
+        assert!(watcher_should_direct_send_after_session_bound_ack(
+            true,
+            SessionBoundRelayAckOutcome::TimedOut,
+            false
+        ));
+        // The §3.2 reconciliation against the offset authority: committed has reached
+        // (or passed) the consumed-terminal `end` → the sink delivered, ACK merely
+        // lagged → SKIP. No duplicate (the #3042 3× incident cannot recur).
+        let (start, end) = (1_000u64, 1_500u64);
+        assert_eq!(
+            watcher_terminal_resend_action(end, start, end),
+            WatcherTerminalResendAction::SkipAlreadyCommitted,
+        );
+        assert_eq!(
+            watcher_terminal_resend_action(end + 256, start, end),
+            WatcherTerminalResendAction::SkipAlreadyCommitted,
+        );
+    }
+
+    /// #3041 P1-5 (black-hole closed): an ownerless `TimedOut` whose range is NOT
+    /// committed (committed < end → the sink did NOT confirm a post) reconciles to
+    /// `SendFull` — the bytes are recovered. Under the old #3042 blanket suppression
+    /// this outcome neither reconciled nor resent: a potential black-hole.
+    #[test]
+    fn ownerless_timed_out_reconciles_full_when_not_committed() {
+        // Same ownerless TimedOut precondition.
+        assert!(watcher_should_direct_send_after_session_bound_ack(
+            true,
+            SessionBoundRelayAckOutcome::TimedOut,
+            false
+        ));
+        // committed < end → genuinely undelivered → re-send the FULL response.
+        let (start, end) = (1_000u64, 1_500u64);
+        assert_eq!(
+            watcher_terminal_resend_action(start, start, end),
+            WatcherTerminalResendAction::SendFull,
+        );
+        // committed at/below start (the all-or-nothing sink delegation's not-delivered
+        // shape) also re-sends.
+        assert_eq!(
+            watcher_terminal_resend_action(0, start, end),
+            WatcherTerminalResendAction::SendFull,
+        );
     }
 
     #[test]

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -2061,14 +2061,52 @@ fn forward_chunk_to_supervisor_relay_inner(
     }
 }
 
+/// #3041 P1-5: the watcher's view of the session-bound terminal ACK. The
+/// non-failure arms fold 1:1 onto the cross-actor 3-way `DeliveryOutcome`:
+///   * `Delivered`      ← ring `DeliveryOutcome::Delivered`
+///   * `NotDelivered`   ← ring `DeliveryOutcome::NotDelivered` (the former
+///                        `TerminalSkipped`; a deterministic sink decline)
+///   * the failure/unconfirmed arms (`Unknown`-class) — `RingUnknown` (the ring
+///     recorded an explicit `Unknown`: sink POSTed without confirming),
+///     `Dropped`, `SinkError`, `TimedOut`, `MissingTarget` — ALL collapse to
+///     `DeliveryOutcome::Unknown` for the resend DECISION (see
+///     [`session_bound_ack_delivery_outcome`]). They stay DISTINCT variants here
+///     so the flight-recorder / metrics keep their exact provenance.
+///
+/// §3.2 SAFETY INVARIANT: BOTH `NotDelivered` AND every `Unknown`-class arm route
+/// through `watcher_terminal_resend_action` (committed-offset reconciliation).
+/// There is NO blind skip for `NotDelivered` and NO blind 10s re-send for any
+/// `Unknown`-class arm.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SessionBoundRelayAckOutcome {
     Delivered,
-    TerminalSkipped,
+    NotDelivered,
+    RingUnknown,
     Dropped,
     SinkError,
     TimedOut,
     MissingTarget,
+}
+
+/// #3041 P1-5: collapse the watcher ACK onto the canonical cross-actor 3-way
+/// `DeliveryOutcome` for the resend DECISION. `Delivered` → delivered (no resend);
+/// `NotDelivered` → not-delivered (reconcile); every failure/unconfirmed arm →
+/// `Unknown` (reconcile). The §3.2 reconciliation treats `NotDelivered` and
+/// `Unknown` IDENTICALLY (both consult the committed offset → SendFull-or-Skip),
+/// so this fold is what guarantees neither gets a blind fast-path.
+fn session_bound_ack_delivery_outcome(
+    ack_outcome: SessionBoundRelayAckOutcome,
+) -> crate::services::cluster::stream_relay::DeliveryOutcome {
+    use crate::services::cluster::stream_relay::DeliveryOutcome;
+    match ack_outcome {
+        SessionBoundRelayAckOutcome::Delivered => DeliveryOutcome::Delivered,
+        SessionBoundRelayAckOutcome::NotDelivered => DeliveryOutcome::NotDelivered,
+        SessionBoundRelayAckOutcome::RingUnknown
+        | SessionBoundRelayAckOutcome::Dropped
+        | SessionBoundRelayAckOutcome::SinkError
+        | SessionBoundRelayAckOutcome::TimedOut
+        | SessionBoundRelayAckOutcome::MissingTarget => DeliveryOutcome::Unknown,
+    }
 }
 
 fn sequence_reached(latest: Option<u64>, target: u64) -> bool {
@@ -2078,7 +2116,7 @@ fn sequence_reached(latest: Option<u64>, target: u64) -> bool {
 fn session_bound_relay_ack_snapshot_outcome(
     target: Option<&SessionBoundRelayAckTarget>,
 ) -> Option<SessionBoundRelayAckOutcome> {
-    use crate::services::cluster::stream_relay::TerminalOutcome;
+    use crate::services::cluster::stream_relay::DeliveryOutcome;
     let target = target?;
     // #3041 P1-3 R5 (per-sequence terminal-ACK correlation): resolve the terminal
     // ACK on THIS watcher's OWN terminal frame (`target.sequence`) EXACT outcome,
@@ -2094,11 +2132,21 @@ fn session_bound_relay_ack_snapshot_outcome(
         .metrics
         .terminal_outcome_for_sequence(target.sequence)
     {
-        Some(TerminalOutcome::Committed) => {
+        Some(DeliveryOutcome::Delivered) => {
             return Some(SessionBoundRelayAckOutcome::Delivered);
         }
-        Some(TerminalOutcome::Skipped) => {
-            return Some(SessionBoundRelayAckOutcome::TerminalSkipped);
+        Some(DeliveryOutcome::NotDelivered) => {
+            return Some(SessionBoundRelayAckOutcome::NotDelivered);
+        }
+        // #3041 P1-5: an explicit ring `Unknown` (sink POSTed but could not confirm
+        // the commit) RESOLVES the per-sequence ACK immediately to a `RingUnknown`
+        // — the watcher reconciles against the committed offset NOW instead of
+        // waiting out the 10s ACK timeout. `RingUnknown` folds to
+        // `DeliveryOutcome::Unknown`, which §3.2 treats exactly like `NotDelivered`
+        // (committed-offset SendFull-or-Skip), so this is a faster path to the SAME
+        // safe reconciliation — never a blind re-send.
+        Some(DeliveryOutcome::Unknown) => {
+            return Some(SessionBoundRelayAckOutcome::RingUnknown);
         }
         None => {}
     }
@@ -2128,6 +2176,7 @@ fn watcher_should_direct_send_after_session_bound_ack(
     ack_outcome: SessionBoundRelayAckOutcome,
     relay_owner_present: bool,
 ) -> bool {
+    use crate::services::cluster::stream_relay::DeliveryOutcome;
     // #3042 (relay-stability P1, immediate mitigation): after a restart the
     // channel can run with `relay_owner_kind=none` + `inflight_present=false`
     // (restore_inflight failed to rebind ownership), so the session-bound
@@ -2142,7 +2191,18 @@ fn watcher_should_direct_send_after_session_bound_ack(
     if !relay_owner_present && matches!(ack_outcome, SessionBoundRelayAckOutcome::TimedOut) {
         return false;
     }
-    should_direct_send && !matches!(ack_outcome, SessionBoundRelayAckOutcome::Delivered)
+    // #3041 P1-5: decide on the cross-actor 3-way `DeliveryOutcome` instead of the
+    // implicit `ack_outcome != Delivered` bit. `Delivered` → no watcher re-send.
+    // `NotDelivered` AND `Unknown` (every failure/unconfirmed arm) BOTH intend a
+    // re-send here — but that intent is only the PRECONDITION GATE; the actual send
+    // is masked downstream by `watcher_terminal_resend_action` (committed-offset
+    // reconciliation), so neither gets a blind skip (NotDelivered) nor a blind
+    // re-send (Unknown). §3.2 SAFETY INVARIANT.
+    should_direct_send
+        && !matches!(
+            session_bound_ack_delivery_outcome(ack_outcome),
+            DeliveryOutcome::Delivered
+        )
 }
 
 /// #3041 P1-3 (Part b, §3.2): the watcher's terminal re-send DECISION after a
@@ -3298,7 +3358,7 @@ mod matched_session_jsonl_gate_tests {
         skipped_metrics.record_terminal_skipped_sequence_for_test(11);
         assert_eq!(
             session_bound_relay_ack_snapshot_outcome(Some(&skipped_target)),
-            Some(SessionBoundRelayAckOutcome::TerminalSkipped)
+            Some(SessionBoundRelayAckOutcome::NotDelivered)
         );
 
         let delivered_metrics =
@@ -3336,8 +3396,8 @@ mod matched_session_jsonl_gate_tests {
     }
 
     // #3041 P1-3 R5 (per-sequence terminal-ACK correlation): turn A (seq N) was
-    // SKIPPED, turn B's tail (seq N+1) COMMITTED in the same chunk. A's ACK must
-    // resolve on A's OWN sequence → TerminalSkipped (so the watcher reconciles /
+    // NOT delivered, turn B's tail (seq N+1) delivered in the same chunk. A's ACK
+    // must resolve on A's OWN sequence → NotDelivered (so the watcher reconciles /
     // SendFull → A delivered, no black-hole), NOT Delivered from B bumping the
     // committed high-water-mark to N+1. B's ACK at its own sequence → Delivered.
     #[test]
@@ -3355,8 +3415,8 @@ mod matched_session_jsonl_gate_tests {
         };
         assert_eq!(
             session_bound_relay_ack_snapshot_outcome(Some(&a_target)),
-            Some(SessionBoundRelayAckOutcome::TerminalSkipped),
-            "A's ACK reads A's own seq-5 outcome (Skipped), not B's committed HWM"
+            Some(SessionBoundRelayAckOutcome::NotDelivered),
+            "A's ACK reads A's own seq-5 outcome (NotDelivered), not B's delivered HWM"
         );
 
         let b_target = SessionBoundRelayAckTarget {
@@ -3699,7 +3759,7 @@ mod matched_session_jsonl_gate_tests {
         ));
         assert!(watcher_should_direct_send_after_session_bound_ack(
             true,
-            SessionBoundRelayAckOutcome::TerminalSkipped,
+            SessionBoundRelayAckOutcome::NotDelivered,
             true
         ));
         assert!(watcher_should_direct_send_after_session_bound_ack(
@@ -3749,7 +3809,7 @@ mod matched_session_jsonl_gate_tests {
         ));
         assert!(watcher_should_direct_send_after_session_bound_ack(
             true,
-            SessionBoundRelayAckOutcome::TerminalSkipped,
+            SessionBoundRelayAckOutcome::NotDelivered,
             false
         ));
         // Ownerless TimedOut with should_direct_send=false is also suppressed.
@@ -3769,7 +3829,7 @@ mod matched_session_jsonl_gate_tests {
         ));
         assert!(watcher_should_direct_send_after_session_bound_ack(
             true,
-            SessionBoundRelayAckOutcome::TerminalSkipped,
+            SessionBoundRelayAckOutcome::NotDelivered,
             true
         ));
         assert!(watcher_should_direct_send_after_session_bound_ack(
@@ -3844,6 +3904,85 @@ mod matched_session_jsonl_gate_tests {
             watcher_terminal_resend_action(40, 50, 100),
             WatcherTerminalResendAction::SendFull,
             "committed below start must send the full range (no black-hole)"
+        );
+    }
+
+    // #3041 P1-5 (§3.2 SAFETY INVARIANT): a cross-actor `Unknown` outcome (the
+    // ring recorded `Unknown` / the ACK timed out / target was missing / dropped /
+    // sink-errored) MUST route through committed-offset reconciliation, NOT a blind
+    // 10s re-send. So `Unknown` with `committed >= end` → SkipAlreadyCommitted (a
+    // foreign owner already committed the range; re-sending would duplicate), and
+    // `Unknown` with `committed < end` → SendFull (the range is uncovered; no
+    // black-hole). The decision is driven SOLELY by the committed offset — it
+    // consults the authority, never blind-sends on the Unknown signal alone.
+    #[test]
+    fn unknown_outcome_triggers_committed_offset_reconciliation_not_blind_resend() {
+        use crate::services::cluster::stream_relay::DeliveryOutcome;
+        // The fold: every failure/unconfirmed ACK arm collapses to `Unknown`.
+        for ack in [
+            SessionBoundRelayAckOutcome::RingUnknown,
+            SessionBoundRelayAckOutcome::Dropped,
+            SessionBoundRelayAckOutcome::SinkError,
+            SessionBoundRelayAckOutcome::TimedOut,
+            SessionBoundRelayAckOutcome::MissingTarget,
+        ] {
+            assert_eq!(
+                session_bound_ack_delivery_outcome(ack),
+                DeliveryOutcome::Unknown,
+                "every failure/unconfirmed ACK arm folds to the cross-actor Unknown"
+            );
+        }
+
+        // §3.2: an Unknown outcome reconciles against the committed offset. The
+        // SAME `watcher_terminal_resend_action` gate that NotDelivered uses — no
+        // separate blind-resend path exists for Unknown.
+        let start = 100u64;
+        let end = 356u64;
+        // committed >= end: a foreign owner already committed the range → SKIP, NOT
+        // a blind re-send (which would duplicate).
+        assert_eq!(
+            watcher_terminal_resend_action(end, start, end),
+            WatcherTerminalResendAction::SkipAlreadyCommitted,
+            "Unknown + committed>=end must consult the offset and SKIP (no blind 10s re-send / no duplicate)"
+        );
+        // committed < end: the range is genuinely uncovered → SendFull (no
+        // black-hole). The decision came from the offset, not the Unknown signal.
+        assert_eq!(
+            watcher_terminal_resend_action(start, start, end),
+            WatcherTerminalResendAction::SendFull,
+            "Unknown + committed<end must SendFull via the offset authority (no black-hole)"
+        );
+    }
+
+    // #3041 P1-5 (§3.2 SAFETY INVARIANT): a `NotDelivered` outcome (the former
+    // `Ok(Skipped)`, redefined this phase) must ALSO route through committed-offset
+    // reconciliation — there is NO blind-skip fast-path for NotDelivered. When a
+    // FOREIGN owner already committed the range (`committed >= end`), the watcher
+    // must SKIP its re-send (no duplicate), exactly like a delivered turn — proving
+    // NotDelivered consults the offset rather than blindly skipping or blindly
+    // re-sending.
+    #[test]
+    fn not_delivered_outcome_keeps_no_resend_when_foreign_owner_committed() {
+        use crate::services::cluster::stream_relay::DeliveryOutcome;
+        assert_eq!(
+            session_bound_ack_delivery_outcome(SessionBoundRelayAckOutcome::NotDelivered),
+            DeliveryOutcome::NotDelivered,
+            "NotDelivered folds to the cross-actor NotDelivered (not Unknown, not Delivered)"
+        );
+        let start = 100u64;
+        let end = 356u64;
+        // A foreign owner committed the full range out from under this watcher.
+        assert_eq!(
+            watcher_terminal_resend_action(end, start, end),
+            WatcherTerminalResendAction::SkipAlreadyCommitted,
+            "NotDelivered + committed>=end (foreign owner committed) must SKIP (no duplicate, no blind-skip-without-checking)"
+        );
+        // But when NOTHING committed it still SendFulls — NotDelivered is never a
+        // silent drop (no black-hole).
+        assert_eq!(
+            watcher_terminal_resend_action(start, start, end),
+            WatcherTerminalResendAction::SendFull,
+            "NotDelivered + committed<end must SendFull (no black-hole; not a blind skip)"
         );
     }
 


### PR DESCRIPTION
## #3041 P1-5 (final phase): 3-way DeliveryOutcome unification

Collapses the 2-way delivery outcome (`SessionRelayDeliveryOutcome { Committed, Skipped }`) plus the watcher's implicit fallback-bit interpretation into an explicit cross-actor 3-way `DeliveryOutcome { Delivered, NotDelivered, Unknown }`, and redefines `Ok(Skipped)` as `NotDelivered`.

### 3-way unification
- **`stream_relay.rs`** — the canonical cross-actor ring becomes 3-way: `TerminalOutcome { Committed, Skipped }` → `DeliveryOutcome { Delivered, NotDelivered, Unknown }`. The ring (`terminal_outcomes`, `record_terminal_outcome`, `terminal_outcome_for_sequence`) carries it. `Some(Unknown)` (resolved-but-unconfirmed) stays DISTINCT from `None` (not yet resolved). The trait result `RelaySinkOutcome` gains a third variant: `{ FrameAccepted, TerminalDelivered, TerminalNotDelivered, TerminalUnknown }` with `terminal_delivered()` / `terminal_not_delivered()` / `terminal_unknown()` helpers.
- **`session_relay_sink.rs`** — the SINK-LOCAL enum stays 2-way: `SessionRelayDeliveryOutcome { Committed, Skipped }` → `{ Delivered, NotDelivered }`. The sink always KNOWS its result (confirmed POST → Delivered; deterministic decline → NotDelivered; failure → `Err`) so it emits NO `Unknown`.
- **`tmux_watcher.rs`** — the watcher folds the ring outcome onto the 3-way: ring `Delivered`→ack `Delivered`, ring `NotDelivered`→ack `NotDelivered`, ring `Unknown`→ack `RingUnknown`. The new pure `session_bound_ack_delivery_outcome` collapses every failure/unconfirmed arm (`RingUnknown`/`Dropped`/`SinkError`/`TimedOut`/`MissingTarget`) to `DeliveryOutcome::Unknown`. `watcher_should_direct_send_after_session_bound_ack` now decides on the 3-way (`!= Delivered`) instead of the implicit `ack_outcome != Delivered` bit.

### The single `Skipped` → `NotDelivered` reclassification
There is exactly ONE sink-local `Skipped` producer (the route-decision decline: foreign-owner lease block, or `route_or_skip` Err = bridge-owned / mismatched inflight). It is reclassified to `NotDelivered`. The four confirmed-POST/edit/fallback-POST sites become `Delivered`. The route-layer enum `SessionBoundTerminalDeliveryRouteDecision { Route, Skipped }` is deliberately untouched (legitimately "Skipped").

### §3.2 SAFETY INVARIANT (load-bearing)
BOTH `NotDelivered` AND every `Unknown`-class arm flow through `watcher_terminal_resend_action` (committed-offset reconciliation: `committed >= end` → `SkipAlreadyCommitted`, else `SendFull`). The exact gate that preserves this: the §3.2 reconciliation site keys on `!matches!(session_bound_ack_outcome, Delivered)` (so NotDelivered + all Unknown-class both reconcile), and `watcher_should_direct_send_after_session_bound_ack` is only the PRECONDITION gate — the send paths stay masked by `!SkipAlreadyCommitted`. There is NO blind-skip fast-path for `NotDelivered` and NO blind 10s re-send for `Unknown`. `Delivered` → no resend.

### New tests
- `stream_relay.rs`: `terminal_outcome_ring_carries_unknown` — `Unknown` records as `Some(Unknown)`, distinct from `None`.
- `tmux_watcher.rs`: `unknown_outcome_triggers_committed_offset_reconciliation_not_blind_resend` — every failure arm folds to `Unknown`; `Unknown` + `committed >= end` → `SkipAlreadyCommitted`, `Unknown` + `committed < end` → `SendFull` (offset-driven, not blind).
- `tmux_watcher.rs`: `not_delivered_outcome_keeps_no_resend_when_foreign_owner_committed` — `NotDelivered` + `committed >= end` → `SkipAlreadyCommitted`.
- `session_relay_sink.rs`: renamed `terminal_delivery_route_skip_maps_to_terminal_skipped_outcome` → `..._maps_to_not_delivered_outcome`, asserting the route-`Skipped` → sink `NotDelivered` mapping.

### Verification
- `cargo fmt --check`: clean
- `cargo build --all-targets`: exit 0
- `cargo clippy --workspace --all-targets --all-features`: no new warnings (only pre-existing dead-code)
- `cargo test` (single-threaded, affected modules: stream_relay, sink, watcher, delivery_lease, turn_finalizer): all 0 failed
- `generate_inventory_docs.py`: no drift; `check_agent_maintenance_docs.py`: passes (tmux_watcher freeze updated 8766→8826 + P1-5 delta note); `ci-script-checks.sh`: exit 0. `stream_relay.rs` remains under the 1000-prod-LoC giant-file threshold (949) so is NOT registered.

Part of #3041 (final phase P1-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)