### PR TITLE
fix(#3151): reclaimable in-flight sink-delivery marker eliminates slow-sink terminal re-send duplicate without black-hole

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -128,7 +128,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (8844 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (8971 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -281,6 +281,102 @@ impl Drop for SessionBoundExternalInputLeaseGuard {
     }
 }
 
+/// #3151: RAII in-flight sink-delivery marker on the per-channel
+/// [`super::DeliveryLeaseCell`]. The sink ACQUIRES this cell as
+/// [`super::LeaseHolder::Sink`] for the SAME `(channel, turn, [start,end))`
+/// coordinate the watcher's §3.2 reconciliation computes, BEFORE it starts the
+/// Discord POST. While the POST is in flight a [`super::DeliveryLeaseHeartbeat`]
+/// renews the lease deadline, so the watcher's gate reads `Leased{Sink, fresh}`
+/// and WAITS instead of re-sending — closing the slow-sink-in-flight duplicate.
+///
+/// The marker is RECLAIMABLE: it is held by a heartbeat task that dies with the
+/// sink, so a crashed/stalled sink stops renewing → the deadline lapses → the
+/// watcher reclaims and re-sends within ~one deadline (no black-hole).
+///
+/// CLEAR ordering: on the SUCCESS path the caller advances the committed offset
+/// FIRST (via `advance_after_confirmed_post`) then calls [`Self::commit`], so the
+/// instant the marker clears the watcher reconciliation reads `committed >= end`
+/// → Skip (never a re-send into a just-cleared marker). On EVERY exit (Ok / Err /
+/// `?` / panic) Drop RELEASES the lease (compare-and-release on the full
+/// `(holder, turn, [start,end))` identity, so a stale older-turn release no-ops).
+/// A failure path that never commits leaves the cell `Unleased` with committed
+/// NOT advanced — the watcher then reconciles `committed < end` → SendFull.
+struct SinkDeliveryLeaseGuard {
+    cell: Arc<super::DeliveryLeaseCell>,
+    turn: super::turn_finalizer::TurnKey,
+    start: u64,
+    end: u64,
+    /// The in-flight heartbeat; aborted on Drop (mirrors the watcher's RAII).
+    _heartbeat: super::DeliveryLeaseHeartbeat,
+}
+
+impl SinkDeliveryLeaseGuard {
+    /// Self-heal a dead PRIOR holder, then CAS-acquire the cell as
+    /// [`super::LeaseHolder::Sink`] for `(turn, [start,end))`. Returns `Some` (and
+    /// spawns the heartbeat) only when the acquire wins. If the acquire FAILS
+    /// (the watcher/bridge already holds the range), returns `None`: the sink then
+    /// POSTs WITHOUT a marker and WITHOUT a heartbeat — it never blocks delivery on
+    /// a failed acquire (no self-black-hole), and no duplicate arises because the
+    /// other holder owns that range (single-winner CAS).
+    fn acquire(
+        cell: &Arc<super::DeliveryLeaseCell>,
+        turn: super::turn_finalizer::TurnKey,
+        start: u64,
+        end: u64,
+    ) -> Option<Self> {
+        // Mirror the watcher's self-healing acquire (tmux_watcher.rs:8594): reclaim
+        // an EXPIRED prior holder so a stale dead lease cannot make this acquire
+        // lose and leave the sink markerless (which would reintroduce the dup).
+        cell.reclaim_if_expired(super::lease_now_ms());
+        let acquired = cell.try_acquire(
+            turn,
+            super::LeaseHolder::Sink,
+            start,
+            end,
+            super::lease_now_ms().saturating_add(super::DELIVERY_LEASE_DEADLINE_MS),
+        );
+        if !acquired {
+            return None;
+        }
+        let heartbeat =
+            super::DeliveryLeaseHeartbeat::spawn(cell.clone(), super::LeaseHolder::Sink, turn);
+        Some(Self {
+            cell: cell.clone(),
+            turn,
+            start,
+            end,
+            _heartbeat: heartbeat,
+        })
+    }
+
+    /// SUCCESS-path commit. Called AFTER the committed offset has already been
+    /// advanced, so the watcher reconciliation reads `committed >= end` the moment
+    /// the marker clears. Compare-and-X on the full `(Sink, turn, [start,end))`
+    /// identity → a stale clear from an older turn no-ops. Drop still releases.
+    fn commit(&self) {
+        self.cell.commit(
+            super::LeaseHolder::Sink,
+            self.turn,
+            self.start,
+            self.end,
+            super::LeaseOutcome::Delivered,
+        );
+    }
+}
+
+impl Drop for SinkDeliveryLeaseGuard {
+    fn drop(&mut self) {
+        // Release on EVERY exit (Ok after commit, or Err/`?`/panic without commit).
+        // `release` is valid from both `Leased` (failure, never committed) and
+        // `Committed` (success), and is full-identity-gated, so it only ever clears
+        // OUR own marker — a newer turn that re-leased this cell during a slow POST
+        // survives this drop. (The `_heartbeat` field's own Drop aborts the renew
+        // task; field-drop order makes that benign — release is the authority.)
+        self.cell
+            .release(super::LeaseHolder::Sink, self.turn, self.start, self.end);
+    }
+}
+
 fn session_bound_should_send_new_chunks_for_placeholder(response_text: &str) -> bool {
     response_text.len() > super::DISCORD_MSG_LIMIT
 }
@@ -444,6 +540,7 @@ impl SessionBoundDiscordRelaySink {
         channel_id: u64,
         session_name: &str,
         delivery: &SessionRelayDelivery,
+        sink_lease_guard: Option<&SinkDeliveryLeaseGuard>,
     ) {
         let fresh_inflight = super::inflight::load_inflight_state(provider, channel_id);
         self.advance_offset_for_confirmed_delegated_terminal(
@@ -454,6 +551,15 @@ impl SessionBoundDiscordRelaySink {
             delivery,
             fresh_inflight.as_ref(),
         );
+        // #3151 CLEAR (success): advance committed FIRST (above), THEN commit the
+        // marker. Ordering matters — the instant the marker clears the watcher
+        // reconciliation must read `committed >= end` (→ Skip), never re-send into
+        // a just-cleared marker. `commit` is full-identity-gated, so a stale frame
+        // whose `(turn, range)` no longer matches the live lease no-ops. Drop on
+        // exit releases the lease (Committed → Unleased) regardless.
+        if let Some(guard) = sink_lease_guard {
+            guard.commit();
+        }
     }
 
     fn advance_offset_for_confirmed_delegated_terminal(
@@ -641,6 +747,37 @@ impl SessionBoundDiscordRelaySink {
             formatted
         };
         let channel = ChannelId::new(channel_id);
+
+        // #3151: SET the reclaimable in-flight sink-delivery marker BEFORE the
+        // Discord POST. The marker is a `Leased{Sink, turn, [start,end)}` state on
+        // the SAME per-channel `DeliveryLeaseCell` the watcher gates on, for the
+        // SAME `(channel, turn, range)` coordinate the watcher's §3.2
+        // reconciliation computes. While the POST is in flight the heartbeat keeps
+        // the deadline fresh, so the watcher's gate reads `Leased{Sink, fresh}` and
+        // WAITS instead of re-sending the slow-sink range (the #3151 duplicate).
+        // Only mark a real, ordered `[start,end)` (both Some && e>s): a zero/None
+        // range never advances the offset, so leasing it would gain nothing. ONE
+        // acquire covers ALL three POST branches below (the guard lives across the
+        // whole body and the inline advance). A FAILED acquire (watcher/bridge
+        // already holds the range) yields `None` → the sink POSTs markerless and
+        // never blocks delivery (no self-black-hole; no duplicate, because the
+        // other holder owns the range — single-winner CAS).
+        let sink_lease_guard = match (
+            delivery.frame_turn_start_offset,
+            delivery.terminal_consumed_end,
+        ) {
+            (Some(start), Some(end)) if end > start => {
+                let sink_turn = super::turn_finalizer::TurnKey::new(
+                    channel,
+                    delivery.frame_turn_user_msg_id,
+                    shared.current_generation,
+                );
+                let cell = shared.delivery_lease(channel);
+                SinkDeliveryLeaseGuard::acquire(&cell, sink_turn, start, end)
+            }
+            _ => None,
+        };
+
         if let SessionBoundTerminalDeliveryRoute::PlaceholderEdit(msg_id) = route {
             if session_bound_should_send_new_chunks_for_placeholder(&relay_text) {
                 formatting::send_long_message_raw_with_rollback(
@@ -695,6 +832,7 @@ impl SessionBoundDiscordRelaySink {
                     channel_id,
                     &delivery.session_name,
                     &delivery,
+                    sink_lease_guard.as_ref(),
                 );
                 return Ok(SessionRelayDeliveryOutcome::Delivered);
             }
@@ -745,6 +883,7 @@ impl SessionBoundDiscordRelaySink {
                         channel_id,
                         &delivery.session_name,
                         &delivery,
+                        sink_lease_guard.as_ref(),
                     );
                     Ok(SessionRelayDeliveryOutcome::Delivered)
                 }
@@ -795,6 +934,7 @@ impl SessionBoundDiscordRelaySink {
                         channel_id,
                         &delivery.session_name,
                         &delivery,
+                        sink_lease_guard.as_ref(),
                     );
                     Ok(SessionRelayDeliveryOutcome::Delivered)
                 }
@@ -860,6 +1000,7 @@ impl SessionBoundDiscordRelaySink {
                 channel_id,
                 &delivery.session_name,
                 &delivery,
+                sink_lease_guard.as_ref(),
             );
             Ok(SessionRelayDeliveryOutcome::Delivered)
         }
@@ -2731,6 +2872,7 @@ mod tests {
             channel.get(),
             session,
             &delivery,
+            None,
         );
         assert_eq!(
             shared.committed_relay_offset(channel),
@@ -2754,6 +2896,7 @@ mod tests {
             channel.get(),
             session,
             &delivery,
+            None,
         );
         assert_eq!(
             shared.committed_relay_offset(channel),
@@ -2772,6 +2915,7 @@ mod tests {
             channel.get(),
             session,
             &advanced_delivery,
+            None,
         );
         assert_eq!(
             shared.committed_relay_offset(channel),
@@ -3315,5 +3459,146 @@ mod tests {
             Some(recorded_foreign),
             "a foreign-owner lease is preserved (input-dedup / cross-subsystem routing not regressed)"
         );
+    }
+
+    /// #3151: the `SinkDeliveryLeaseGuard` is the deterministic seam for the
+    /// in-flight sink-delivery marker. Driving the full `deliver_response` needs
+    /// Discord HTTP, so these tests exercise the guard's acquire/commit/release
+    /// semantics directly on a real per-channel `DeliveryLeaseCell` — the exact
+    /// cell the watcher gate reads.
+    mod inflight_sink_marker {
+        use super::super::SinkDeliveryLeaseGuard;
+        use crate::services::discord::turn_finalizer::TurnKey;
+        use crate::services::discord::{
+            DeliveryLeaseCell, LeaseHolder, LeaseOutcome, LeaseSnapshot,
+        };
+        use serenity::model::id::ChannelId;
+        use std::sync::Arc;
+
+        const START: u64 = 100;
+        const END: u64 = 200;
+
+        /// (a) SLOW SINK IN FLIGHT: acquiring the guard sets the cell to
+        /// `Leased{Sink, [start,end)}` — the marker the watcher gate reads as
+        /// "a sink POST is in flight" → WaitInFlight (no duplicate).
+        #[tokio::test]
+        async fn acquire_sets_leased_sink_marker() {
+            let ch = ChannelId::new(7301);
+            let cell = Arc::new(DeliveryLeaseCell::new(ch));
+            let turn = TurnKey::new(ch, 5, 0);
+            let guard =
+                SinkDeliveryLeaseGuard::acquire(&cell, turn, START, END).expect("acquire wins");
+            match cell.read() {
+                LeaseSnapshot::Leased {
+                    holder, start, end, ..
+                } => {
+                    assert_eq!(holder, LeaseHolder::Sink);
+                    assert_eq!((start, end), (START, END));
+                }
+                other => panic!("expected Leased{{Sink}}, got {other:?}"),
+            }
+            drop(guard);
+        }
+
+        /// SUCCESS path: commit() flips the marker to `Committed{Sink, Delivered}`;
+        /// the guard's Drop then RELEASES it back to `Unleased`. (Production advances
+        /// the committed offset BEFORE commit, so the watcher reads committed>=end.)
+        #[tokio::test]
+        async fn commit_then_drop_releases_to_unleased() {
+            let ch = ChannelId::new(7302);
+            let cell = Arc::new(DeliveryLeaseCell::new(ch));
+            let turn = TurnKey::new(ch, 5, 0);
+            {
+                let guard =
+                    SinkDeliveryLeaseGuard::acquire(&cell, turn, START, END).expect("acquire wins");
+                guard.commit();
+                match cell.read() {
+                    LeaseSnapshot::Committed {
+                        holder, outcome, ..
+                    } => {
+                        assert_eq!(holder, LeaseHolder::Sink);
+                        assert_eq!(outcome, LeaseOutcome::Delivered);
+                    }
+                    other => panic!("expected Committed{{Sink}}, got {other:?}"),
+                }
+            }
+            // Guard dropped without an explicit release call — Drop released it.
+            assert!(
+                matches!(cell.read(), LeaseSnapshot::Unleased),
+                "Drop releases the committed marker back to Unleased"
+            );
+        }
+
+        /// FAILURE/Err path: the guard is dropped WITHOUT commit (the POST `?`-errored
+        /// or the identity gate blocked the advance) → the cell returns to `Unleased`
+        /// and committed is NOT advanced (the watcher then SendFulls — no black-hole).
+        #[tokio::test]
+        async fn drop_without_commit_releases_without_committing() {
+            let ch = ChannelId::new(7303);
+            let cell = Arc::new(DeliveryLeaseCell::new(ch));
+            let turn = TurnKey::new(ch, 5, 0);
+            {
+                let _guard =
+                    SinkDeliveryLeaseGuard::acquire(&cell, turn, START, END).expect("acquire wins");
+                // No commit() — simulate the Err/`?` path.
+            }
+            assert!(
+                matches!(cell.read(), LeaseSnapshot::Unleased),
+                "a failure path that never commits leaves the cell Unleased (committed not advanced)"
+            );
+        }
+
+        /// ACQUIRE FAILS when the watcher/bridge already holds the range: the guard is
+        /// `None` → the sink POSTs markerless (no double-commit, no self-black-hole),
+        /// and the existing holder's lease is untouched.
+        #[test]
+        fn acquire_fails_when_another_holder_owns_range() {
+            let ch = ChannelId::new(7304);
+            let cell = Arc::new(DeliveryLeaseCell::new(ch));
+            let turn = TurnKey::new(ch, 5, 0);
+            let now = crate::services::discord::lease_now_ms();
+            let watcher_holder = LeaseHolder::Watcher { instance_id: 1 };
+            // A watcher already holds the cell for this range (B2).
+            assert!(
+                cell.try_acquire(turn, watcher_holder, START, END, now.saturating_add(10_000),)
+            );
+            // The sink's acquire loses → None (markerless POST; no duplicate).
+            assert!(
+                SinkDeliveryLeaseGuard::acquire(&cell, turn, START, END).is_none(),
+                "the sink acquire must lose to the watcher's existing lease"
+            );
+            // The watcher's lease is intact (still Leased by the watcher).
+            match cell.read() {
+                LeaseSnapshot::Leased { holder, .. } => assert_eq!(holder, watcher_holder),
+                other => panic!("expected the watcher's lease intact, got {other:?}"),
+            }
+        }
+
+        /// A STALE-EXPIRED prior holder is self-healed by `acquire`'s
+        /// `reclaim_if_expired` (mirrors the watcher) so the sink's acquire still
+        /// wins — otherwise the sink would POST markerless and reintroduce the dup.
+        #[tokio::test]
+        async fn acquire_self_heals_an_expired_prior_holder() {
+            let ch = ChannelId::new(7305);
+            let cell = Arc::new(DeliveryLeaseCell::new(ch));
+            let turn = TurnKey::new(ch, 5, 0);
+            let now = crate::services::discord::lease_now_ms();
+            // A dead prior holder whose deadline is already in the past.
+            assert!(cell.try_acquire(
+                turn,
+                LeaseHolder::Watcher { instance_id: 9 },
+                START,
+                END,
+                now.saturating_sub(1),
+            ));
+            // The sink's acquire reclaims the expired holder first, then wins.
+            let guard = SinkDeliveryLeaseGuard::acquire(&cell, turn, START, END)
+                .expect("acquire wins after self-healing the expired holder");
+            match cell.read() {
+                LeaseSnapshot::Leased { holder, .. } => assert_eq!(holder, LeaseHolder::Sink),
+                other => panic!("expected Leased{{Sink}} after reclaim, got {other:?}"),
+            }
+            drop(guard);
+        }
     }
 }

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -2281,6 +2281,69 @@ enum WatcherTerminalResendAction {
     /// retry). The remaining slow-sink-in-flight duplicate is closed by the future
     /// in-flight sink-delivery marker tracked in #3151.
     SendFull,
+    /// #3151: a sink POST is genuinely IN FLIGHT for this range (the per-channel
+    /// `DeliveryLeaseCell` is `Leased{Sink, fresh}`). The watcher must NOT re-send
+    /// this pass — neither SendFull nor a Skip-log — and let its NEXT terminal pass
+    /// re-evaluate. This is a BOUNDED wait: each pass re-reads the cell, and within
+    /// at most one `DELIVERY_LEASE_DEADLINE_MS` the sink either commits+releases
+    /// (→ committed >= end → Skip) or dies (→ deadline lapses → reclaim + SendFull).
+    /// No busy-loop is introduced — it rides the existing watcher iteration cadence.
+    WaitInFlight,
+}
+
+/// #3151: gate the watcher terminal re-send on the in-flight sink-delivery marker
+/// BEFORE deferring to [`watcher_terminal_resend_action`]. The marker is a
+/// `Leased{Sink, ..}` state on the per-channel `DeliveryLeaseCell`; this reads a
+/// coherent `snapshot` (materialized under the cell's payload mutex) and decides:
+///
+/// - `Leased{Sink}` AND `now_ms < deadline_ms` → [`WatcherTerminalResendAction::WaitInFlight`]
+///   (a sink POST is genuinely in flight — do not re-send this pass).
+/// - `Leased{Sink}` AND `now_ms >= deadline_ms` → RECLAIM (the caller force-clears
+///   the dead sink's marker via `reclaim_if_expired`) then fall through to
+///   `watcher_terminal_resend_action` → `SendFull` (committed < end). No black-hole.
+/// - `Committed{Sink}` (sink committed Delivered, not yet released) → Skip (belt-and-
+///   suspenders; `committed >= end` already yields Skip below).
+/// - ANY non-Sink holder / `Unleased` / committed-covered → behave EXACTLY as today:
+///   defer to `watcher_terminal_resend_action`. The gate ONLY interposes for a
+///   Sink-held lease, so the watcher-direct B2 path is untouched.
+///
+/// Returns `(action, reclaim_expired_sink)`. When `reclaim_expired_sink` is true
+/// the caller MUST call `reclaim_if_expired(now_ms)` on the cell before sending
+/// (the side effect is kept out of this pure decision fn so it stays unit-testable).
+fn watcher_terminal_resend_action_gated(
+    snapshot: &crate::services::discord::LeaseSnapshot,
+    committed: u64,
+    start: u64,
+    end: u64,
+    now_ms: u64,
+) -> (WatcherTerminalResendAction, bool) {
+    use crate::services::discord::{LeaseHolder, LeaseSnapshot};
+    match snapshot {
+        LeaseSnapshot::Leased {
+            holder: LeaseHolder::Sink,
+            deadline_ms,
+            ..
+        } => {
+            if now_ms < *deadline_ms {
+                // Live, in-flight sink POST — wait this pass (bounded by deadline).
+                (WatcherTerminalResendAction::WaitInFlight, false)
+            } else {
+                // Dead/stalled sink — reclaim its marker and re-send (no black-hole).
+                (watcher_terminal_resend_action(committed, start, end), true)
+            }
+        }
+        LeaseSnapshot::Committed {
+            holder: LeaseHolder::Sink,
+            ..
+        } => {
+            // The sink committed Delivered but hasn't released yet; the range is
+            // delivered. Skip (belt-and-suspenders; committed>=end also yields Skip).
+            (WatcherTerminalResendAction::SkipAlreadyCommitted, false)
+        }
+        // Unleased, or held/committed by a non-Sink holder (Watcher/Bridge): the
+        // #3151 marker does not apply — behave exactly as the pre-#3151 path.
+        _ => (watcher_terminal_resend_action(committed, start, end), false),
+    }
 }
 
 /// Reconcile a watcher terminal re-send against the committed offset authority.
@@ -8400,14 +8463,57 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 "watcher_terminal_resend_reconcile",
             );
             let committed = shared.committed_relay_offset(channel_id);
-            Some(watcher_terminal_resend_action(
+            // #3151: gate the re-send on the in-flight sink-delivery marker BEFORE
+            // the committed-offset reconciliation. The marker is a `Leased{Sink}`
+            // state on the SAME per-channel `DeliveryLeaseCell` the watcher's own
+            // direct-send path acquires (B2). Read a coherent snapshot, then:
+            //   * Leased{Sink, fresh}  → WaitInFlight: a sink POST is in flight; do
+            //     NOT re-send this pass (the slow-sink-in-flight duplicate #3151).
+            //   * Leased{Sink, expired} → reclaim the dead sink's marker, then
+            //     SendFull (committed<end) — the no-black-hole arm.
+            //   * Committed{Sink} / committed>=end → Skip (range delivered).
+            //   * Unleased / non-Sink holder → unchanged (defer to the existing
+            //     committed-offset reconciliation).
+            let gate_cell = shared.delivery_lease(channel_id);
+            let snapshot = gate_cell.read();
+            let now_ms = crate::services::discord::lease_now_ms();
+            let (action, reclaim_expired_sink) = watcher_terminal_resend_action_gated(
+                &snapshot,
                 committed,
                 watcher_resend_range_start,
                 watcher_resend_range_end,
-            ))
+                now_ms,
+            );
+            if reclaim_expired_sink {
+                // Force the dead sink's marker Unleased so the watcher-direct path
+                // below can re-acquire and SendFull (no black-hole). Deadline-only /
+                // identity-agnostic — a LIVE sink (fresh deadline) is never reached.
+                gate_cell.reclaim_if_expired(now_ms);
+            }
+            Some(action)
         } else {
             None
         };
+        // #3151: WaitInFlight suppresses BOTH the re-send and the skip-log this
+        // pass — the watcher's NEXT terminal pass re-evaluates (bounded by the
+        // sink's lease deadline). It must NOT be treated as "send" by the fallback.
+        let watcher_resend_wait_in_flight = matches!(
+            watcher_resend_action,
+            Some(WatcherTerminalResendAction::WaitInFlight)
+        );
+        if watcher_resend_wait_in_flight {
+            let ts = chrono::Local::now().format("%H:%M:%S");
+            tracing::info!(
+                provider = watcher_provider.as_str(),
+                channel = channel_id.get(),
+                tmux_session = %tmux_session_name,
+                start = watcher_resend_range_start,
+                end = watcher_resend_range_end,
+                committed = watcher_resend_committed,
+                ?session_bound_ack_outcome,
+                "  [{ts}] 👁 #3151: deferred watcher terminal re-send — sink POST in flight (Leased{{Sink}}, fresh); will re-evaluate next pass (no duplicate)"
+            );
+        }
         if matches!(
             watcher_resend_action,
             Some(WatcherTerminalResendAction::SkipAlreadyCommitted)
@@ -8425,12 +8531,17 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             );
         }
         // The watcher actually direct-sends only when the reconciliation did NOT
-        // skip the range. `SkipAlreadyCommitted` suppresses the re-send (no dup);
-        // `SendFull`/the non-reconciled path proceed to send.
+        // skip the range AND is not WAITING on an in-flight sink POST.
+        // `SkipAlreadyCommitted` suppresses the re-send (no dup); `WaitInFlight`
+        // (#3151) suppresses it this pass (re-evaluated next pass); `SendFull`/the
+        // non-reconciled path proceed to send.
         let watcher_direct_fallback_after_session_bound_ack = watcher_direct_fallback_intended
             && !matches!(
                 watcher_resend_action,
-                Some(WatcherTerminalResendAction::SkipAlreadyCommitted)
+                Some(
+                    WatcherTerminalResendAction::SkipAlreadyCommitted
+                        | WatcherTerminalResendAction::WaitInFlight
+                )
             );
         // codex BLOCKER 2: on a non-skip reconciled re-send the action is always
         // `SendFull` (the watcher response-text coordinate cannot be derived from
@@ -8714,6 +8825,22 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             }
             clear_provider_overload_retry_state(channel_id);
             true
+        } else if matches!(
+            watcher_resend_action,
+            Some(WatcherTerminalResendAction::WaitInFlight)
+        ) {
+            // #3151: a sink POST is genuinely IN FLIGHT for this range
+            // (`Leased{Sink, fresh}` on the per-channel delivery lease). Do NOT
+            // re-send and do NOT finalize this pass — and crucially do NOT delete
+            // the placeholder (the sink is about to edit/post into it). Return
+            // `false` so `terminal_output_committed` stays false: the turn is left
+            // OPEN and the watcher re-enters this terminal block on its NEXT pass.
+            // The wait is BOUNDED by the sink's lease deadline — within one
+            // `DELIVERY_LEASE_DEADLINE_MS` the sink either commits+releases
+            // (→ committed>=end → SkipAlreadyCommitted next pass) or dies (→ the
+            // deadline lapses → the gate reclaims + SendFull next pass). This is the
+            // sole arm that closes the slow-sink-in-flight duplicate (#3151).
+            false
         } else if watcher_lease_b2_skip {
             // #3041 P1-1 B2 (single-holder, §5.2): a DIFFERENT watcher instance
             // already holds the delivery lease for this exact channel/turn/range
@@ -12351,6 +12478,239 @@ TUI-E2E-marker ssh-direct
                 !cell.renew(holder, turn, extended.saturating_add(1)),
                 "a renew on a Committed lease (a late tick after commit) is a no-op"
             );
+        }
+    }
+
+    /// #3151: the deterministic decision seam for the in-flight sink-delivery
+    /// marker gate (`watcher_terminal_resend_action_gated`). Table-drives the gate
+    /// over every lease-snapshot variant and asserts the reclaim side-effect flag.
+    /// The decision fn is PURE (no cell mutation) so the side effect is testable in
+    /// isolation; the integration tests below exercise the actual `reclaim_if_expired`.
+    mod inflight_sink_marker_gate {
+        use super::super::{
+            WatcherTerminalResendAction, watcher_terminal_resend_action,
+            watcher_terminal_resend_action_gated,
+        };
+        use crate::services::discord::turn_finalizer::TurnKey;
+        use crate::services::discord::{
+            DeliveryLeaseCell, LeaseHolder, LeaseOutcome, LeaseSnapshot, lease_now_ms,
+        };
+        use serenity::model::id::ChannelId;
+
+        const START: u64 = 100;
+        const END: u64 = 200;
+        // `committed < end` so the underlying reconciliation would choose SendFull.
+        const COMMITTED_BELOW_END: u64 = 100;
+        const NOW: u64 = 50_000;
+
+        fn turn() -> TurnKey {
+            TurnKey::new(ChannelId::new(7201), 9, 0)
+        }
+
+        /// Unleased → behaves EXACTLY as the ungated reconciliation (SendFull when
+        /// committed<end), no reclaim.
+        #[test]
+        fn unleased_defers_to_reconciliation() {
+            let (action, reclaim) = watcher_terminal_resend_action_gated(
+                &LeaseSnapshot::Unleased,
+                COMMITTED_BELOW_END,
+                START,
+                END,
+                NOW,
+            );
+            assert_eq!(action, WatcherTerminalResendAction::SendFull);
+            assert!(!reclaim);
+            // ... and committed>=end on an Unleased cell still Skips (unchanged).
+            let (skip, reclaim2) = watcher_terminal_resend_action_gated(
+                &LeaseSnapshot::Unleased,
+                END,
+                START,
+                END,
+                NOW,
+            );
+            assert_eq!(skip, WatcherTerminalResendAction::SkipAlreadyCommitted);
+            assert!(!reclaim2);
+        }
+
+        /// Leased{Sink, FRESH} (now < deadline) → WaitInFlight, no reclaim. This is
+        /// the slow-sink-in-flight case: the watcher must NOT re-send this pass.
+        #[test]
+        fn leased_sink_fresh_waits_in_flight() {
+            let snap = LeaseSnapshot::Leased {
+                holder: LeaseHolder::Sink,
+                turn: turn(),
+                deadline_ms: NOW + 5_000, // fresh: deadline strictly in the future
+                start: START,
+                end: END,
+            };
+            let (action, reclaim) =
+                watcher_terminal_resend_action_gated(&snap, COMMITTED_BELOW_END, START, END, NOW);
+            assert_eq!(action, WatcherTerminalResendAction::WaitInFlight);
+            assert!(!reclaim, "a fresh sink lease must NOT be reclaimed");
+        }
+
+        /// Leased{Sink, EXPIRED} (now >= deadline) → reclaim flag set AND SendFull
+        /// (committed<end). This is the dead-sink no-black-hole arm.
+        #[test]
+        fn leased_sink_expired_reclaims_and_sends_full() {
+            let snap = LeaseSnapshot::Leased {
+                holder: LeaseHolder::Sink,
+                turn: turn(),
+                deadline_ms: NOW, // expired: now >= deadline
+                start: START,
+                end: END,
+            };
+            let (action, reclaim) =
+                watcher_terminal_resend_action_gated(&snap, COMMITTED_BELOW_END, START, END, NOW);
+            assert_eq!(action, WatcherTerminalResendAction::SendFull);
+            assert!(
+                reclaim,
+                "an expired sink lease MUST be reclaimed (no black-hole)"
+            );
+        }
+
+        /// Committed{Sink} (sink committed Delivered, not yet released) → Skip,
+        /// no reclaim (belt-and-suspenders early Skip).
+        #[test]
+        fn committed_sink_skips() {
+            let snap = LeaseSnapshot::Committed {
+                holder: LeaseHolder::Sink,
+                turn: turn(),
+                start: START,
+                end: END,
+                outcome: LeaseOutcome::Delivered,
+            };
+            let (action, reclaim) =
+                watcher_terminal_resend_action_gated(&snap, COMMITTED_BELOW_END, START, END, NOW);
+            assert_eq!(action, WatcherTerminalResendAction::SkipAlreadyCommitted);
+            assert!(!reclaim);
+        }
+
+        /// Leased by a WATCHER (non-Sink) holder → the #3151 gate does NOT interpose;
+        /// it defers to the existing reconciliation (the B2 path is untouched).
+        #[test]
+        fn leased_by_watcher_defers_to_reconciliation() {
+            let snap = LeaseSnapshot::Leased {
+                holder: LeaseHolder::Watcher { instance_id: 1 },
+                turn: turn(),
+                deadline_ms: NOW + 5_000,
+                start: START,
+                end: END,
+            };
+            // committed<end → SendFull (NOT WaitInFlight: only a Sink lease waits).
+            let (action, reclaim) =
+                watcher_terminal_resend_action_gated(&snap, COMMITTED_BELOW_END, START, END, NOW);
+            assert_eq!(action, WatcherTerminalResendAction::SendFull);
+            assert!(!reclaim);
+            // committed>=end on a watcher-held lease still Skips.
+            let (skip, _) = watcher_terminal_resend_action_gated(&snap, END, START, END, NOW);
+            assert_eq!(skip, WatcherTerminalResendAction::SkipAlreadyCommitted);
+        }
+
+        /// committed>=end with a Bridge holder → Skip (the range is delivered),
+        /// matching the ungated path.
+        #[test]
+        fn committed_covered_skips_for_non_sink() {
+            let snap = LeaseSnapshot::Leased {
+                holder: LeaseHolder::Bridge,
+                turn: turn(),
+                deadline_ms: NOW + 1,
+                start: START,
+                end: END,
+            };
+            let (action, _) = watcher_terminal_resend_action_gated(&snap, END, START, END, NOW);
+            assert_eq!(action, WatcherTerminalResendAction::SkipAlreadyCommitted);
+            // Sanity: the gated decision equals the ungated reconciliation here.
+            assert_eq!(action, watcher_terminal_resend_action(END, START, END));
+        }
+
+        /// (b) Integration: a DEAD/STALE sink marker on a real cell is reclaimed by
+        /// the gate's `reclaim_if_expired` side effect, then the watcher re-acquires
+        /// and SendFulls — NO black-hole. Drives the actual cell, not just the flag.
+        #[test]
+        fn dead_sink_marker_reclaimed_then_resent_no_blackhole() {
+            let ch = ChannelId::new(7202);
+            let cell = DeliveryLeaseCell::new(ch);
+            let sink_turn = TurnKey::new(ch, 9, 0);
+            let now = lease_now_ms();
+            let deadline = now.saturating_add(10);
+            // Sink set the marker then "died" (no heartbeat renews it).
+            assert!(cell.try_acquire(sink_turn, LeaseHolder::Sink, START, END, deadline));
+
+            // The gate, observed at a time PAST the deadline, decides reclaim+SendFull.
+            let past = deadline.saturating_add(1);
+            let snap = cell.read();
+            let (action, reclaim) =
+                watcher_terminal_resend_action_gated(&snap, COMMITTED_BELOW_END, START, END, past);
+            assert_eq!(action, WatcherTerminalResendAction::SendFull);
+            assert!(reclaim);
+
+            // The caller performs the reclaim → the dead marker clears → a
+            // replacement watcher re-acquires and re-delivers (no black-hole).
+            assert!(cell.reclaim_if_expired(past));
+            assert!(matches!(cell.read(), LeaseSnapshot::Unleased));
+            let watcher_turn = TurnKey::new(ch, 9, 0);
+            assert!(
+                cell.try_acquire(
+                    watcher_turn,
+                    LeaseHolder::Watcher { instance_id: 1 },
+                    START,
+                    END,
+                    past.saturating_add(10_000),
+                ),
+                "the reclaimed cell is re-acquirable by the watcher (no black-hole)"
+            );
+        }
+
+        /// (c) reclaim-races-with-late-sink-success cannot corrupt the lease: after a
+        /// dead sink's marker is reclaimed and the watcher re-acquires, the zombie
+        /// sink's late `commit`/`release` (full-identity-gated) NO-OP against the
+        /// watcher's lease — no wrong-holder advance, no stolen release.
+        #[test]
+        fn reclaim_then_late_sink_commit_cannot_corrupt_lease() {
+            let ch = ChannelId::new(7203);
+            let cell = DeliveryLeaseCell::new(ch);
+            let sink_turn = TurnKey::new(ch, 9, 0);
+            let now = lease_now_ms();
+            let deadline = now.saturating_add(10);
+            assert!(cell.try_acquire(sink_turn, LeaseHolder::Sink, START, END, deadline));
+
+            // Watcher reclaims the expired sink marker and re-acquires the SAME range.
+            let past = deadline.saturating_add(1);
+            assert!(cell.reclaim_if_expired(past));
+            let watcher_holder = LeaseHolder::Watcher { instance_id: 1 };
+            assert!(cell.try_acquire(
+                sink_turn,
+                watcher_holder,
+                START,
+                END,
+                past.saturating_add(10_000),
+            ));
+
+            // The zombie sink's LATE commit/release target Sink+sink_turn; the cell
+            // is now held by the Watcher → both no-op (false). No corruption.
+            assert!(
+                !cell.commit(
+                    LeaseHolder::Sink,
+                    sink_turn,
+                    START,
+                    END,
+                    LeaseOutcome::Delivered
+                ),
+                "a late sink commit must NOT act on the watcher's lease"
+            );
+            assert!(
+                !cell.release(LeaseHolder::Sink, sink_turn, START, END),
+                "a late sink release must NOT free the watcher's lease"
+            );
+            // The watcher's lease is intact and committable by its true holder.
+            assert!(cell.commit(
+                watcher_holder,
+                sink_turn,
+                START,
+                END,
+                LeaseOutcome::Delivered
+            ));
         }
     }
 }


### PR DESCRIPTION
## What

Issue #3151 (follow-up to #3041 P1-3, PR #3150). Eliminates the slow-sink-in-flight terminal re-send duplicate: the watcher's 10s ACK timeout could elapse while the sink's Discord POST was still IN FLIGHT, so the #3041 P1-3 reconciliation saw `committed < end` and chose SendFull → a duplicate.

## Design — reuse the existing #3041 delivery-lease, no new struct

The in-flight marker IS a `Leased { holder: LeaseHolder::Sink, turn, deadline_ms, [start,end) }` state on the existing per-channel `DeliveryLeaseCell` (the dormant `LeaseHolder::Sink` discriminant). No new field, no parallel channel.
- **Freshness/expiry** = the existing `deadline_ms`, kept alive by the existing `DeliveryLeaseHeartbeat` the sink spawns over its POST (renew 5s, deadline 15s = 3× slack).
- **In-memory only** (deliberately NOT persisted to the inflight file): a persisted marker would be a dead-on-disk black-hole vector. A sink crash kills its heartbeat → deadline lapses → watcher reclaims; a process restart drops the cell and respawns the watcher, whose committed-offset reconciliation re-delivers.

## Invariants

**NO DUPLICATE (slow live sink)**: sink CAS-acquires the lease as `Leased{Sink}` BEFORE the POST. When the 10s ACK timeout fires mid-POST, the heartbeat has already renewed (deadline ≈20s > now 10s) → watcher reads `Leased{Sink, fresh}` → `WaitInFlight` (no SendFull, placeholder kept). Success path advances `committed` FIRST then commits the marker, so the watcher reads `Committed{Sink}`/`committed>=end` → Skip — never a re-send into a just-cleared marker.

**NO BLACK-HOLE (dead sink)**: heartbeat task dies with the sink → deadline lapses → watcher's `reclaim_if_expired(now)` forces `Leased{Sink}` → `Unleased` → re-acquires as Watcher and SendFulls (delivery completes ≤15s). A reclaim racing a late sink success cannot corrupt state: commit/release are full-(holder,turn,range)-identity-gated, so a zombie sink's late commit no-ops.

**NO DEADLOCK**: `WaitInFlight` leaves the turn open and re-evaluates on the next watcher pass; a live sink eventually commits (→Skip) or dies (→reclaim+SendFull within one deadline). No busy-loop.

## Tests
13 new unit tests over the two deterministic decision seams: watcher gate (8 — unleased/fresh-sink-waits/expired-sink-reclaims/committed-skips/watcher-holder-defers/dead-sink-reclaim-resent/reclaim-vs-late-success) + sink guard (5 — acquire-sets-marker/commit-releases/drop-without-commit/foreign-holder-rejected/self-heal-expired). All pass + 4 pre-existing reconciliation tests. `cargo fmt --check`, `cargo check --lib`, `scripts/check_agent_maintenance_docs.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)