### PR TITLE
fix(#3142): turn-aliasing safety for committed-output dispatch/history/anchor/status-panel consumers

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -128,7 +128,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (8971 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (9124 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -263,6 +263,47 @@
     (renamed from `ownerless_timeout_suppresses_watcher_direct_fallback`),
     `ownerless_timed_out_reconciles_skip_when_committed_reaches_end` (#3042
     regression guard), `ownerless_timed_out_reconciles_full_when_not_committed`.
+    +93 from #3142 (EPIC, follow-up to #3141): TURN-ALIASING SAFETY for the
+    remaining committed-output consumers that the #3141 finalize/clear/reaction
+    gate did not cover. A new pure sibling helper
+    `committed_anchor_cleanup_is_stale_for_newer_turn` (the id==0-INCLUSIVE variant
+    of #3141's `committed_completion_is_stale_for_newer_turn`, mirroring the same
+    `turn_start_offset.unwrap_or(last_offset) >= current_offset` yield-guard offset
+    test but requiring anchor-relevance — `user_msg_id != 0 ||
+    injected_prompt_message_id.is_some() || external_input`) gates the two
+    anchor-cleanup branches (the `should_complete_tui_direct_anchor_lifecycle`
+    first branch — also the `lifecycle_stage_paused`-with-inflight path — and the
+    `injected_prompt_message_id` task-notification branch) so an id==0
+    external-input/injected newer turn's anchor is never `✅`'d mid-flight. The
+    id!=0 `completion_is_stale_for_newer_turn` now ALSO gates dispatch finalization
+    (the `else if let Some(did) = resolved_did.as_deref().filter(|_| !stale)` arm
+    falls through to the no-finalize `else => true` so a newer dispatch is not
+    completed with the older `full_response`) and the TUI history push (the newer
+    turn's `user_text` is never cross-paired with the older response). The
+    status-panel completion identity is offset-pinned via `pinned_finalize_user_msg_id`
+    (None for a newer pre-relay snapshot) so the panel binding agrees by
+    construction with the reaction/transcript/analytics gate. Matrix tests
+    `committed_anchor_cleanup_stale_for_newer_turn_matrix` (+ per-consumer
+    `dispatch_finalization_skips_when_stale`, `history_append_skips_when_stale`,
+    `status_panel_id_none_when_pre_relay_snapshot_is_newer`,
+    `anchor_cleanup_skips_when_stale_id0`, `paused_first_branch_anchor_gate`).
+    +54 from the #3142 codex re-review (residual status-panel aliasing gap): the
+    completion IDENTITY was offset-pinned but the status-panel ADOPT site
+    (`should_adopt_inflight_terminal_message_ids` → `status_message_id`) and the
+    EDIT/finalize site (`complete_watcher_status_panel_v2` + the external-input
+    orphan-store reconciliation) still acted on a stale NEWER pre-relay snapshot,
+    so the older committed range could pull a newer turn's panel id and EDIT it.
+    Both sites now gate on
+    `!committed_anchor_cleanup_is_stale_for_newer_turn(inflight_before_relay, None,
+    session, current_offset)` (the id==0-INCLUSIVE anchor variant catches a newer
+    id==0 external-input/injected panel owner the id!=0 sibling would miss; the
+    OFFSET test — not `pinned == 0` — keeps an in-range id==0 watcher-direct turn
+    NON-suppressed). turn_bridge/mod.rs:2009 (BRIDGE path / #3016 core hotfile) is
+    explicitly OUT OF SCOPE and deferred to a follow-up. New test
+    `status_panel_adopt_and_edit_gate_is_turn_aliasing_safe` covers stale-newer
+    (incl. id==0 external/injected) NOT adopted/edited, in-range id==0
+    watcher-direct STILL adopts+edits (over-suppression guard), and in-range id!=0
+    unchanged.
   - `src/services/discord/tui_prompt_relay.rs` (3994 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +12 from #3041 P1-4 codex: the lease record

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -389,3 +389,19 @@
   internally and is invoked at the identical position in `run_bot`. No new
   multinode ownership, singleton, or lease assumption is introduced; the
   leader-only vs worker-local classification of every spawned task is preserved.
+- #3142 (committed-output turn-aliasing safety): `tmux_watcher.rs` changed by
+  adding one **pure** decision helper
+  (`committed_anchor_cleanup_is_stale_for_newer_turn`, the id==0-inclusive sibling
+  of #3141's `committed_completion_is_stale_for_newer_turn`) and gating four
+  consumers of the committed-output block (dispatch finalization, TUI history
+  push, the two anchor-cleanup branches, and the status-panel completion
+  identity) on the offset-pinned stale test so an older committed range cannot
+  act on a NEWER same-session turn's inflight identity. The gate is computed
+  purely from the **process-local** in-memory inflight snapshots
+  (`inflight_before_relay` / late-read `inflight_state`) and the per-session JSONL
+  `current_offset` already owned by THIS watcher loop — it reads no cross-node
+  state, acquires no lease, and changes no leader/standby ownership. The watcher
+  loop remains **session-owner-local** (a watcher only processes a tmux session
+  it owns); this change only narrows which in-process side-effects fire on a
+  turn boundary and introduces no new multinode ownership/singleton/lease
+  assumption.

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1123,6 +1123,54 @@ fn committed_completion_is_stale_for_newer_turn(
     snapshot_is_newer_turn(inflight_before_relay) || snapshot_is_newer_turn(inflight_state)
 }
 
+/// #3142: sibling of [`committed_completion_is_stale_for_newer_turn`] for the
+/// ANCHOR-CLEANUP branches of the committed-output block (the
+/// `should_complete_tui_direct_anchor_lifecycle` first branch and the
+/// `injected_prompt_message_id` task-notification branch). Those branches act on
+/// an anchor identity that can belong to a `user_msg_id == 0` external-input /
+/// injected-anchor newer turn — a case the id!=0 sibling DELIBERATELY excludes
+/// (its `user_msg_id != 0` filter protects the finalize/clear contract against
+/// the id-0 channel-collapse warned about at the clear site). So this helper
+/// must be the id==0-INCLUSIVE variant for the anchor branches ONLY.
+///
+/// Detection rule (mirrors the watcher-yield guard tmux.rs:2110-2111 offset test
+/// exactly, like the sibling): a snapshot is a stale NEWER turn iff trimmed
+/// session match AND effective start
+/// `turn_start_offset.unwrap_or(last_offset) >= current_offset` AND the snapshot
+/// is anchor-relevant — it carries a real anchor/external identity
+/// (`user_msg_id != 0` OR `injected_prompt_message_id.is_some()` OR it represents
+/// external input). The anchor-relevance disjunct ensures a truly empty/no-anchor
+/// row is NOT spuriously treated as a stale newer turn (such a row also fails the
+/// branch's own `watcher_inflight_needs_anchor_lifecycle_cleanup` precondition).
+/// OR-ed across both snapshots exactly like the sibling so the pre-relay snapshot
+/// and the late re-read are both checked.
+///
+/// Narrow by construction: for a normal anchor completion (the inflight is THIS
+/// or an OLDER turn with `start < current_offset`, absent, or on a different
+/// session) this returns FALSE → the anchor cleanup runs as today.
+fn committed_anchor_cleanup_is_stale_for_newer_turn(
+    inflight_before_relay: Option<&crate::services::discord::inflight::InflightTurnState>,
+    inflight_state: Option<&crate::services::discord::inflight::InflightTurnState>,
+    tmux_session_name: &str,
+    current_offset: u64,
+) -> bool {
+    let snapshot_is_newer_anchor_turn =
+        |snapshot: Option<&crate::services::discord::inflight::InflightTurnState>| {
+            snapshot.is_some_and(|state| {
+                (state.user_msg_id != 0
+                    || state.injected_prompt_message_id.is_some()
+                    || watcher_inflight_represents_external_input(Some(state)))
+                    && state.tmux_session_name.as_deref().map(str::trim)
+                        == Some(tmux_session_name.trim())
+                    // Same `turn_start_offset.unwrap_or(last_offset)` fallback as
+                    // the sibling helper and the yield guard.
+                    && state.turn_start_offset.unwrap_or(state.last_offset) >= current_offset
+            })
+        };
+    snapshot_is_newer_anchor_turn(inflight_before_relay)
+        || snapshot_is_newer_anchor_turn(inflight_state)
+}
+
 fn refresh_watcher_turn_identity(
     current: &mut Option<crate::services::discord::inflight::InflightTurnIdentity>,
     provider: &ProviderKind,
@@ -1403,6 +1451,450 @@ mod pane_dead_identity_tests {
             "stale newer turn pins to 0 — submitting Complete with this id would \
              collapse onto the newer live ledger entry (wrong-turn finalize)"
         );
+    }
+
+    // #3142 test scaffolding: build a snapshot at given offsets that ALSO carries
+    // an anchor/external identity (injected_prompt_message_id and/or
+    // ExternalInput turn_source). `state_with_offsets` cannot set those fields, so
+    // mutate them directly (all pub).
+    fn state_with_anchor(
+        user_msg_id: u64,
+        tmux_session_name: &str,
+        turn_start_offset: Option<u64>,
+        last_offset: u64,
+        injected_prompt_message_id: Option<u64>,
+        external_input: bool,
+    ) -> InflightTurnState {
+        let mut state = state_with_offsets(
+            user_msg_id,
+            tmux_session_name,
+            turn_start_offset,
+            last_offset,
+        );
+        state.injected_prompt_message_id = injected_prompt_message_id;
+        if external_input {
+            state.turn_source = crate::services::discord::inflight::TurnSource::ExternalInput;
+        }
+        state
+    }
+
+    // #3142 (EPIC, follow-up to #3141). The committed-output anchor-cleanup
+    // branches act on a `user_msg_id == 0` external-input / injected-anchor newer
+    // turn that the id!=0 `committed_completion_is_stale_for_newer_turn`
+    // deliberately excludes. `committed_anchor_cleanup_is_stale_for_newer_turn` is
+    // the id==0-inclusive sibling for those branches. This matrix mirrors
+    // `committed_completion_stale_for_newer_turn_matrix` and locks the divergence.
+    #[test]
+    fn committed_anchor_cleanup_stale_for_newer_turn_matrix() {
+        let session = "AgentDesk-codex-adk-cdx";
+
+        // (a) id!=0 newer turn after range (start 50 >= current 50) → true.
+        let newer_id = state_with_offsets(800, session, Some(50), 50);
+        assert!(committed_anchor_cleanup_is_stale_for_newer_turn(
+            None,
+            Some(&newer_id),
+            session,
+            50
+        ));
+
+        // (b) id==0 + injected_prompt_message_id newer after range → true.
+        // THE new coverage: assert the id!=0 sibling returns FALSE on the SAME
+        // state, locking the divergence.
+        let newer_injected = state_with_anchor(0, session, Some(50), 50, Some(4242), false);
+        assert!(committed_anchor_cleanup_is_stale_for_newer_turn(
+            None,
+            Some(&newer_injected),
+            session,
+            50
+        ));
+        assert!(
+            !committed_completion_is_stale_for_newer_turn(None, Some(&newer_injected), session, 50),
+            "id!=0 sibling must NOT classify an id==0 injected newer turn as stale"
+        );
+
+        // (c) id==0 + ExternalInput turn_source newer after range → true.
+        let newer_external = state_with_anchor(0, session, Some(50), 50, None, true);
+        assert!(committed_anchor_cleanup_is_stale_for_newer_turn(
+            None,
+            Some(&newer_external),
+            session,
+            50
+        ));
+        assert!(!committed_completion_is_stale_for_newer_turn(
+            None,
+            Some(&newer_external),
+            session,
+            50
+        ));
+
+        // (d) this/older turn (start 10 < 50), any id → false.
+        let in_range_id = state_with_offsets(700, session, Some(10), 10);
+        assert!(!committed_anchor_cleanup_is_stale_for_newer_turn(
+            Some(&in_range_id),
+            Some(&in_range_id),
+            session,
+            50
+        ));
+        let in_range_injected = state_with_anchor(0, session, Some(10), 10, Some(4243), false);
+        assert!(!committed_anchor_cleanup_is_stale_for_newer_turn(
+            Some(&in_range_injected),
+            Some(&in_range_injected),
+            session,
+            50
+        ));
+
+        // (e) wrong session, even though newer → false.
+        let other_session = state_with_anchor(
+            0,
+            "AgentDesk-codex-adk-cdx-fresh",
+            Some(50),
+            50,
+            Some(9),
+            true,
+        );
+        assert!(!committed_anchor_cleanup_is_stale_for_newer_turn(
+            None,
+            Some(&other_session),
+            session,
+            50
+        ));
+
+        // (f) None / None → false.
+        assert!(!committed_anchor_cleanup_is_stale_for_newer_turn(
+            None, None, session, 50
+        ));
+
+        // (g) id==0 + no anchor + no external (plain empty newer row) → false:
+        // the anchor-relevance disjunct gates it out.
+        let empty_newer = state_with_anchor(0, session, Some(50), 50, None, false);
+        assert!(!committed_anchor_cleanup_is_stale_for_newer_turn(
+            None,
+            Some(&empty_newer),
+            session,
+            50
+        ));
+
+        // (h) only inflight_before_relay newer (state older) → true; and vice-versa.
+        assert!(committed_anchor_cleanup_is_stale_for_newer_turn(
+            Some(&newer_injected),
+            Some(&in_range_id),
+            session,
+            50
+        ));
+        assert!(committed_anchor_cleanup_is_stale_for_newer_turn(
+            Some(&in_range_id),
+            Some(&newer_injected),
+            session,
+            50
+        ));
+
+        // (i) turn_start_offset=None fallback to last_offset parity.
+        let no_start_after = state_with_anchor(0, session, None, 50, Some(7), false);
+        assert!(committed_anchor_cleanup_is_stale_for_newer_turn(
+            None,
+            Some(&no_start_after),
+            session,
+            50
+        ));
+        let no_start_before = state_with_anchor(0, session, None, 10, Some(7), false);
+        assert!(!committed_anchor_cleanup_is_stale_for_newer_turn(
+            None,
+            Some(&no_start_before),
+            session,
+            50
+        ));
+    }
+
+    // #3142 consumer-1 (dispatch finalization). The call site at the
+    // `else if let Some(did) = resolved_did.as_deref().filter(|_| !stale)` arm
+    // falls through to the `else => true` no-finalize arm when stale. Pure
+    // predicate alignment: stale → skip; in-range → run.
+    #[test]
+    fn dispatch_finalization_skips_when_stale() {
+        let session = "AgentDesk-codex-adk-cdx";
+        // (a) newer id!=0 snapshot → stale true → dispatch finalize skipped.
+        let newer = state_with_offsets(999, session, Some(50), 50);
+        assert!(committed_completion_is_stale_for_newer_turn(
+            None,
+            Some(&newer),
+            session,
+            50
+        ));
+        // (b) common case: in-range turn → stale false → finalize runs.
+        let in_range = state_with_offsets(700, session, Some(10), 10);
+        assert!(!committed_completion_is_stale_for_newer_turn(
+            Some(&in_range),
+            Some(&in_range),
+            session,
+            50
+        ));
+    }
+
+    // #3142 consumer-2 (history append). The push is gated on
+    // `!completion_is_stale_for_newer_turn`. Same predicate as dispatch; assert
+    // both directions so the (user_text, response) pair is never cross-paired.
+    #[test]
+    fn history_append_skips_when_stale() {
+        let session = "AgentDesk-codex-adk-cdx";
+        // The #3142 history push gate is
+        // `!completion_is_stale_for_newer_turn && !anchor_cleanup_is_stale_for_newer_turn`.
+        let newer = state_with_offsets(800, session, Some(50), 50);
+        assert!(
+            committed_completion_is_stale_for_newer_turn(None, Some(&newer), session, 50),
+            "id!=0 stale newer turn → history push suppressed (no cross-paired user_text/response)"
+        );
+        let in_range = state_with_offsets(700, session, Some(10), 10);
+        assert!(
+            !committed_completion_is_stale_for_newer_turn(
+                Some(&in_range),
+                Some(&in_range),
+                session,
+                50
+            ),
+            "common case → not id!=0-stale (history push runs)"
+        );
+        assert!(
+            !committed_anchor_cleanup_is_stale_for_newer_turn(
+                Some(&in_range),
+                Some(&in_range),
+                session,
+                50
+            ),
+            "common case → not anchor-stale either (history push runs)"
+        );
+
+        // #3142 history-append id==0 gap: a NEWER external-input turn with
+        // `user_msg_id == 0` is DELIBERATELY excluded by the id!=0 sibling, so the
+        // push must ALSO gate on the id==0-inclusive anchor helper — otherwise the
+        // newer turn's `user_text` cross-pairs with the OLDER response in TUI
+        // history (the exact residual the EPIC's proposed direction called out).
+        let newer_external_id0 = state_with_anchor(0, session, Some(50), 50, None, true);
+        assert!(
+            !committed_completion_is_stale_for_newer_turn(
+                None,
+                Some(&newer_external_id0),
+                session,
+                50
+            ),
+            "id!=0 sibling alone does NOT suppress an id==0 external newer turn (the gap)"
+        );
+        assert!(
+            committed_anchor_cleanup_is_stale_for_newer_turn(
+                None,
+                Some(&newer_external_id0),
+                session,
+                50
+            ),
+            "id==0-inclusive anchor helper suppresses the id==0 external newer turn (gap closed)"
+        );
+    }
+
+    // #3142 consumer-4 (status-panel). The completion identity is offset-pinned
+    // via `pinned_finalize_user_msg_id`: None for a newer pre-relay snapshot,
+    // Some(id) in-range, None for rebind_origin/id==0. Mirrors the new derivation.
+    #[test]
+    fn status_panel_id_none_when_pre_relay_snapshot_is_newer() {
+        let session = "AgentDesk-codex-adk-cdx";
+
+        // Reproduce the new derivation as a pure expression.
+        let derive = |inflight: Option<&InflightTurnState>, current: u64| -> Option<u64> {
+            let pinned = pinned_finalize_user_msg_id(inflight, session, current);
+            inflight
+                .filter(|i| !i.rebind_origin)
+                .and_then(|_| (pinned != 0).then_some(pinned))
+        };
+
+        // (a) newer pre-relay snapshot (start 50 >= current 50) → None.
+        let newer = state_with_offsets(800, session, Some(50), 50);
+        assert_eq!(derive(Some(&newer), 50), None);
+
+        // (b) in-range snapshot → Some(its id).
+        let in_range = state_with_offsets(700, session, Some(10), 10);
+        assert_eq!(derive(Some(&in_range), 50), Some(700));
+
+        // (c) rebind_origin in-range → None (parity with the old filter).
+        let mut rebind = state_with_offsets(701, session, Some(10), 10);
+        rebind.rebind_origin = true;
+        assert_eq!(derive(Some(&rebind), 50), None);
+
+        // (d) id==0 in-range → None.
+        let id_zero = state_with_offsets(0, session, Some(10), 10);
+        assert_eq!(derive(Some(&id_zero), 50), None);
+
+        // (e) absent → None.
+        assert_eq!(derive(None, 50), None);
+    }
+
+    // #3142 consumer-4 (status-panel ADOPT + EDIT gate). codex review found a
+    // residual aliasing gap: the completion IDENTITY is offset-pinned (covered
+    // above), but the adopt site (L8328) and the EDIT/finalize site (L10063)
+    // were NOT gated, so the older committed range could still pull
+    // `status_message_id` from a stale NEWER pre-relay snapshot and EDIT that
+    // newer turn's panel. Both sites now gate on
+    // `!committed_anchor_cleanup_is_stale_for_newer_turn(inflight_before_relay,
+    // None, session, current_offset)`. This test exercises:
+    //   (a) stale newer turn (incl. id==0 external/injected) → NOT adopted, NOT
+    //       edited;
+    //   (b) in-range id==0 watcher-direct turn → STILL adopts + edits (the
+    //       over-suppression guard: gate keys off OFFSET staleness, not pinned==0,
+    //       so the common id==0 case is NOT suppressed);
+    //   (c) in-range id!=0 normal turn → unchanged (adopts + edits).
+    #[test]
+    fn status_panel_adopt_and_edit_gate_is_turn_aliasing_safe() {
+        let session = "AgentDesk-codex-adk-cdx";
+
+        // Mirror the call-site predicate exactly: pre-relay snapshot + None second
+        // arg + the function-level current_offset.
+        let gate_skips = |inflight: Option<&InflightTurnState>, current: u64| -> bool {
+            committed_anchor_cleanup_is_stale_for_newer_turn(inflight, None, session, current)
+        };
+
+        // Model the adopt site: a status_panel_msg_id is pulled from the snapshot's
+        // status_message_id ONLY when the gate does NOT skip.
+        let adopt = |inflight: &InflightTurnState, current: u64| -> Option<serenity::MessageId> {
+            let mut placeholder: Option<serenity::MessageId> = None;
+            let mut placeholder_from_restored = false;
+            let mut status_panel: Option<serenity::MessageId> = None;
+            if !gate_skips(Some(inflight), current) {
+                adopt_watcher_terminal_message_ids_from_inflight(
+                    &mut placeholder,
+                    &mut placeholder_from_restored,
+                    &mut status_panel,
+                    inflight,
+                    session,
+                );
+            }
+            status_panel
+        };
+
+        let with_panel = |mut state: InflightTurnState, panel: u64| -> InflightTurnState {
+            state.status_message_id = Some(panel);
+            state
+        };
+
+        // (a-i) stale newer id!=0 turn (start 50 >= current 50): owns panel 5550.
+        // Gate skips → not adopted, not edited.
+        let newer_id = with_panel(state_with_offsets(800, session, Some(50), 50), 5550);
+        assert!(
+            gate_skips(Some(&newer_id), 50),
+            "newer id!=0 → EDIT gate skips"
+        );
+        assert_eq!(
+            adopt(&newer_id, 50),
+            None,
+            "newer id!=0 → panel NOT adopted"
+        );
+
+        // (a-ii) stale newer id==0 EXTERNAL-input turn: owns panel 5551. The id!=0
+        // sibling would MISS this; the anchor variant catches it.
+        let newer_ext = with_panel(
+            state_with_anchor(0, session, Some(50), 50, None, true),
+            5551,
+        );
+        assert!(gate_skips(Some(&newer_ext), 50));
+        assert!(
+            !committed_completion_is_stale_for_newer_turn(Some(&newer_ext), None, session, 50),
+            "id!=0 sibling MISSES the id==0 external panel owner — anchor variant required"
+        );
+        assert_eq!(
+            adopt(&newer_ext, 50),
+            None,
+            "newer id==0 external → panel NOT adopted"
+        );
+
+        // (a-iii) stale newer id==0 INJECTED turn: owns panel 5552 → not adopted.
+        let newer_inj = with_panel(
+            state_with_anchor(0, session, Some(50), 50, Some(4242), false),
+            5552,
+        );
+        assert!(gate_skips(Some(&newer_inj), 50));
+        assert_eq!(adopt(&newer_inj, 50), None);
+
+        // (b) OVER-SUPPRESSION GUARD: in-range id==0 watcher-direct turn
+        // (start 10 < current 50, user_msg_id==0). pinned==0 here (ambiguous), but
+        // the OFFSET gate is FALSE → STILL adopts + edits its panel 6660.
+        let in_range_id0 = with_panel(state_with_offsets(0, session, Some(10), 10), 6660);
+        assert!(
+            !gate_skips(Some(&in_range_id0), 50),
+            "in-range id==0 watcher-direct → EDIT gate must NOT skip (not over-suppressed)"
+        );
+        assert_eq!(
+            adopt(&in_range_id0, 50),
+            Some(serenity::MessageId::new(6660)),
+            "in-range id==0 watcher-direct → panel STILL adopted"
+        );
+
+        // (c) in-range id!=0 normal turn → unchanged: adopts + edits panel 7770.
+        let in_range_id = with_panel(state_with_offsets(700, session, Some(10), 10), 7770);
+        assert!(!gate_skips(Some(&in_range_id), 50));
+        assert_eq!(
+            adopt(&in_range_id, 50),
+            Some(serenity::MessageId::new(7770)),
+            "in-range id!=0 normal → panel adopted as today"
+        );
+
+        // (d) no pre-relay snapshot → gate false (no-op): nothing to adopt anyway.
+        assert!(!gate_skips(None, 50));
+    }
+
+    // #3142 consumer-3 (anchor cleanup, id==0). The second branch is gated on
+    // `!committed_anchor_cleanup_is_stale_for_newer_turn`. Stale id==0 injected
+    // newer → skipped; in-range id==0 injected → runs (not over-suppressed).
+    #[test]
+    fn anchor_cleanup_skips_when_stale_id0() {
+        let session = "AgentDesk-codex-adk-cdx";
+        let newer = state_with_anchor(0, session, Some(50), 50, Some(4242), false);
+        assert!(committed_anchor_cleanup_is_stale_for_newer_turn(
+            None,
+            Some(&newer),
+            session,
+            50
+        ));
+        // Common case: id==0 injected turn whose output reaches current_offset.
+        let in_range = state_with_anchor(0, session, Some(10), 10, Some(4243), false);
+        assert!(!committed_anchor_cleanup_is_stale_for_newer_turn(
+            None,
+            Some(&in_range),
+            session,
+            50
+        ));
+    }
+
+    // #3142 first-anchor branch (lifecycle_stage_paused). The branch head is
+    // gated on `!committed_anchor_cleanup_is_stale_for_newer_turn`. A paused turn
+    // WITH a newer inflight present → stale true → first branch skipped; with an
+    // in-range inflight → false → runs. (Helper is independent of the paused flag;
+    // the paused flag selects WHICH branch reaches the gate at the call site.)
+    #[test]
+    fn paused_first_branch_anchor_gate() {
+        let session = "AgentDesk-codex-adk-cdx";
+        // Newer inflight present (the paused-with-inflight scenario) → stale.
+        let newer = state_with_anchor(0, session, Some(50), 50, Some(55), true);
+        assert!(committed_anchor_cleanup_is_stale_for_newer_turn(
+            None,
+            Some(&newer),
+            session,
+            50
+        ));
+        // In-range inflight → not stale → first branch runs.
+        let in_range = state_with_anchor(0, session, Some(10), 10, Some(55), true);
+        assert!(!committed_anchor_cleanup_is_stale_for_newer_turn(
+            None,
+            Some(&in_range),
+            session,
+            50
+        ));
+        // !inflight_present arm: inflight_state is None, only before_relay
+        // inspected. Absent/in-range before_relay → false → legitimate cleanup.
+        assert!(!committed_anchor_cleanup_is_stale_for_newer_turn(
+            None, None, session, 50
+        ));
+        assert!(!committed_anchor_cleanup_is_stale_for_newer_turn(
+            Some(&in_range),
+            None,
+            session,
+            50
+        ));
     }
 
     #[test]
@@ -7945,7 +8437,28 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             matching_watcher_turn_identity(inflight_before_relay.as_ref(), &tmux_session_name);
         let should_adopt_inflight_terminal_message_ids = !external_input_lease_before_relay
             || watcher_inflight_represents_external_input(inflight_before_relay.as_ref());
+        // #3142: do NOT adopt the pre-relay snapshot's terminal message ids
+        // (placeholder_msg_id / status_panel_msg_id) when that snapshot is a STALE
+        // NEWER follow-up turn (`turn_start_offset >= current_offset`). Otherwise the
+        // older committed range pulls `status_message_id` from the still-running newer
+        // turn and aliases its status panel. Use the id==0-INCLUSIVE anchor variant
+        // (NOT the id!=0 sibling) so a newer turn whose `user_msg_id == 0` (external-
+        // input / injected task-notification) panel owner is also caught; the `None`
+        // second arg is sound — the helper's inner closure is `is_some_and`, so it
+        // contributes `false` and the predicate reduces to evaluating only
+        // `inflight_before_relay`, the sole panel-id source at this site. An in-range
+        // id==0 watcher-direct turn (`start < current_offset`) is NOT flagged
+        // (stale=false) and STILL adopts normally — the gate keys off the OFFSET
+        // staleness test, not `pinned == 0`.
+        let inflight_before_relay_is_stale_newer_turn =
+            committed_anchor_cleanup_is_stale_for_newer_turn(
+                inflight_before_relay.as_ref(),
+                None,
+                &tmux_session_name,
+                current_offset,
+            );
         if should_adopt_inflight_terminal_message_ids
+            && !inflight_before_relay_is_stale_newer_turn
             && let Some(inflight) = inflight_before_relay.as_ref()
         {
             adopt_watcher_terminal_message_ids_from_inflight(
@@ -9581,21 +10094,50 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             // path). The recovery_engine D wire is preserved because its
             // `state.user_msg_id` is captured from the inflight snapshot
             // pinned at recovery entry, not re-read at completion time.
-            let status_panel_completion_user_msg_id =
-                inflight_before_relay.as_ref().and_then(|inflight| {
-                    let matches_current_watcher_session = inflight
-                        .tmux_session_name
-                        .as_deref()
-                        .map(str::trim)
-                        .is_some_and(|name| !name.is_empty() && name == tmux_session_name);
-                    if !inflight.rebind_origin
-                        && inflight.user_msg_id != 0
-                        && matches_current_watcher_session
-                    {
-                        Some(inflight.user_msg_id)
-                    } else {
-                        None
-                    }
+            // #3142: offset-pin the status-panel completion identity. The old
+            // session-only derivation would bind the panel to the pre-relay
+            // snapshot's `user_msg_id` even when that snapshot is a NEWER
+            // follow-up turn (`turn_start_offset >= current_offset`) that this
+            // committed range does NOT belong to — aliasing the panel completion
+            // onto the still-running newer turn. Reuse `pinned_finalize_user_msg_id`
+            // (the proven `< current_offset` range test) so the identity is None
+            // for a newer pre-relay snapshot, agreeing by construction with the
+            // reaction/transcript/analytics + finalize gate (both keyed off the
+            // same offset test). The panel EDIT/finalize call below is now ALSO
+            // gated on `!inflight_before_relay_is_stale_newer_turn` (see the binding
+            // just below) so a stale NEWER pre-relay snapshot's panel is never
+            // EDIT-ed/completed — closing the residual UI-only aliasing gap. For an
+            // in-range turn the gate is false and completion fires exactly as today;
+            // only the `expected_user_msg_id` binding is pinned, so the common
+            // (in-range) case is unchanged. `!rebind_origin` is preserved for parity
+            // with the old filter.
+            //
+            // #3142: same stale-newer predicate as the adopt site (L8328). The status
+            // panel can be owned by a NEWER turn whose `user_msg_id == 0` (external-
+            // input / injected), so the id==0-INCLUSIVE anchor variant is required —
+            // the id!=0 sibling would MISS that owner and leave the panel aliased. The
+            // `None` second arg is sound (helper closure is `is_some_and` → contributes
+            // false); an in-range id==0 watcher-direct turn (`start < current_offset`)
+            // is NOT flagged and STILL completes its panel — the gate keys off the
+            // OFFSET staleness test, not `pinned == 0`.
+            let inflight_before_relay_is_stale_newer_turn =
+                committed_anchor_cleanup_is_stale_for_newer_turn(
+                    inflight_before_relay.as_ref(),
+                    None,
+                    &tmux_session_name,
+                    current_offset,
+                );
+            let pinned_status_panel_user_msg_id = pinned_finalize_user_msg_id(
+                inflight_before_relay.as_ref(),
+                &tmux_session_name,
+                current_offset,
+            );
+            let status_panel_completion_user_msg_id = inflight_before_relay
+                .as_ref()
+                .filter(|inflight| !inflight.rebind_origin)
+                .and_then(|_| {
+                    (pinned_status_panel_user_msg_id != 0)
+                        .then_some(pinned_status_panel_user_msg_id)
                 });
             // #3055: re-derive this turn's session lifecycle panel line before
             // finalizing. The bridge does this on every status tick via
@@ -9624,53 +10166,66 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 &tmux_session_name,
             )
             .await;
-            let completion_committed = complete_watcher_status_panel_v2(
-                &http,
-                &shared,
-                channel_id,
-                status_panel_msg_id,
-                &watcher_provider,
-                status_panel_started_at,
-                &mut last_status_panel_text,
-                matches!(
-                    task_notification_kind,
-                    Some(TaskNotificationKind::Background | TaskNotificationKind::MonitorAutoTurn)
-                ),
-                status_panel_completion_user_msg_id,
-            )
-            .await;
-            if turn_is_external_input_for_session && let Some(panel_msg_id) = status_panel_msg_id {
-                if completion_committed {
-                    // #3003 (codex P2 r21): an earlier reclaim attempt this turn may
-                    // have enqueued this panel after a transient delete failure, but it
-                    // has now been completed/edited into its final state. Drop the stale
-                    // durable record so a later drain does not delete the valid panel.
-                    crate::services::discord::status_panel_orphan_store::remove(
-                        &watcher_provider,
-                        &shared.token_hash,
-                        channel_id.get(),
-                        panel_msg_id.get(),
-                    );
-                } else {
-                    // #3003 (codex P2 r20): the final completion edit failed transiently
-                    // and the inflight is about to be cleared on this committed-output
-                    // path, dropping the only handle to the panel that is still stuck at
-                    // the processing state. Enqueue it in the durable store so the sweeper
-                    // drain reclaims (deletes) it independent of inflight lifecycle.
-                    crate::services::discord::status_panel_orphan_store::enqueue(
-                        &watcher_provider,
-                        &shared.token_hash,
-                        channel_id.get(),
-                        panel_msg_id.get(),
-                    );
-                    let ts = chrono::Local::now().format("%H:%M:%S");
-                    tracing::warn!(
-                        "  [{ts}] ⚠ watcher: status-panel-v2 completion did not commit for channel {} panel_msg {}; enqueued durable reclaim",
-                        channel_id.get(),
-                        panel_msg_id.get()
-                    );
+            // #3142: gate the EDIT/finalize + orphan-store reconciliation on
+            // `!inflight_before_relay_is_stale_newer_turn`. When the pre-relay
+            // snapshot is a stale NEWER turn the older committed range must NOT touch
+            // that newer turn's panel (or its orphan record). The current in-range
+            // turn's own panel, if any, is created via the streaming sources and is
+            // unaffected (in-range => gate false => completion fires as today).
+            if !inflight_before_relay_is_stale_newer_turn {
+                let completion_committed = complete_watcher_status_panel_v2(
+                    &http,
+                    &shared,
+                    channel_id,
+                    status_panel_msg_id,
+                    &watcher_provider,
+                    status_panel_started_at,
+                    &mut last_status_panel_text,
+                    matches!(
+                        task_notification_kind,
+                        Some(
+                            TaskNotificationKind::Background
+                                | TaskNotificationKind::MonitorAutoTurn
+                        )
+                    ),
+                    status_panel_completion_user_msg_id,
+                )
+                .await;
+                if turn_is_external_input_for_session
+                    && let Some(panel_msg_id) = status_panel_msg_id
+                {
+                    if completion_committed {
+                        // #3003 (codex P2 r21): an earlier reclaim attempt this turn may
+                        // have enqueued this panel after a transient delete failure, but it
+                        // has now been completed/edited into its final state. Drop the stale
+                        // durable record so a later drain does not delete the valid panel.
+                        crate::services::discord::status_panel_orphan_store::remove(
+                            &watcher_provider,
+                            &shared.token_hash,
+                            channel_id.get(),
+                            panel_msg_id.get(),
+                        );
+                    } else {
+                        // #3003 (codex P2 r20): the final completion edit failed transiently
+                        // and the inflight is about to be cleared on this committed-output
+                        // path, dropping the only handle to the panel that is still stuck at
+                        // the processing state. Enqueue it in the durable store so the sweeper
+                        // drain reclaims (deletes) it independent of inflight lifecycle.
+                        crate::services::discord::status_panel_orphan_store::enqueue(
+                            &watcher_provider,
+                            &shared.token_hash,
+                            channel_id.get(),
+                            panel_msg_id.get(),
+                        );
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        tracing::warn!(
+                            "  [{ts}] ⚠ watcher: status-panel-v2 completion did not commit for channel {} panel_msg {}; enqueued durable reclaim",
+                            channel_id.get(),
+                            panel_msg_id.get()
+                        );
+                    }
                 }
-            }
+            } // #3142: end `if !inflight_before_relay_is_stale_newer_turn` (EDIT/finalize gate)
             // #3003 single-chokepoint reclaim safety: after completion the turn
             // frame ends and the next frame re-seeds `status_panel_msg_id`, so the
             // top-of-interval abandon reclaim never observes this finalized panel's
@@ -9900,7 +10455,24 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             current_offset,
         );
 
-        if crate::services::discord::tui_prompt_relay::should_complete_tui_direct_anchor_lifecycle(
+        // #3142: the id==0-inclusive sibling gate for the two anchor-cleanup
+        // branches below. The id!=0 `completion_is_stale_for_newer_turn` above
+        // deliberately excludes `user_msg_id == 0` newer turns (to protect the
+        // finalize/clear id-0 contract), but a newer external-input / injected
+        // task-notification turn can have `user_msg_id == 0` while still owning a
+        // real anchor (`injected_prompt_message_id` or the shared
+        // `prompt_anchor_by_tmux` slot). Computing this once here keeps the late
+        // re-read and the pre-relay snapshot both checked for the anchor branches.
+        let anchor_cleanup_is_stale_for_newer_turn =
+            committed_anchor_cleanup_is_stale_for_newer_turn(
+                inflight_before_relay.as_ref(),
+                inflight_state.as_ref(),
+                &tmux_session_name,
+                current_offset,
+            );
+
+        if !anchor_cleanup_is_stale_for_newer_turn
+            && crate::services::discord::tui_prompt_relay::should_complete_tui_direct_anchor_lifecycle(
             terminal_output_committed,
             tui_direct_anchor_terminal_body_visible,
             tui_direct_anchor_or_lease_present_for_lifecycle,
@@ -9921,6 +10493,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             .await;
         } else if terminal_output_committed
             && !lifecycle_stage_paused
+            && !anchor_cleanup_is_stale_for_newer_turn
             && inflight_state
                 .as_ref()
                 .is_some_and(watcher_inflight_needs_anchor_lifecycle_cleanup)
@@ -10124,7 +10697,17 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 "[{ts}] ⚠ watcher: dispatch finalization deferred — TUI quiescence gate timed out (#2161)"
             );
             false
-        } else if let Some(did) = resolved_did.as_deref() {
+        } else if let Some(did) = resolved_did
+            .as_deref()
+            .filter(|_| !completion_is_stale_for_newer_turn)
+        {
+            // #3142: when stale, the late `inflight_state.dispatch_id` (the first
+            // fallback in `resolved_did`) belongs to the NEWER running turn;
+            // completing it here with the OLDER `full_response` is wrong-turn
+            // corruption. Fall through to the `else => true` no-finalize arm
+            // (dispatch_ok stays true; downstream clear/finalize keep their own
+            // stale gates) — the newer turn finalizes its own dispatch on its later
+            // pass. FALSE in every normal case, so the common finalize is untouched.
             let finalization =
                 crate::services::discord::streaming_finalizer::finalize_watcher_streaming_dispatch(
                     crate::services::discord::streaming_finalizer::WatcherStreamingFinalRequest {
@@ -10162,7 +10745,21 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         // re-evaluates the gate and finishes the cleanup once the pane
         // actually reports idle.
         if terminal_output_committed && !lifecycle_stage_paused {
+            // #3142: gate the TUI history push on `!completion_is_stale_for_newer_turn`.
+            // When stale, the late `inflight_state.user_text` is the NEWER turn's
+            // prompt; pairing it with the OLDER `full_response` would poison the
+            // TUI history. The newer turn pushes its own (user_text, response) pair
+            // on its own completion pass. Only the push is suppressed —
+            // `turn_result_relayed` and the clear/finalize bookkeeping below keep
+            // their own (already-shipped) stale gates. FALSE in every normal case.
+            // #3142: gate on BOTH the id!=0 stale helper AND the id==0-inclusive
+            // `anchor_cleanup_is_stale_for_newer_turn` (computed above) so a NEWER
+            // external-input turn with `user_msg_id == 0` (no own dispatch id,
+            // `rebind_origin == false`, populated `user_text`) cannot cross-pair
+            // its `user_text` with the OLDER `full_response` in the TUI history.
             if has_assistant_response
+                && !completion_is_stale_for_newer_turn
+                && !anchor_cleanup_is_stale_for_newer_turn
                 && let Some(state) = inflight_state.as_ref().filter(|state| !state.rebind_origin)
             {
                 let mut data = shared.core.lock().await;


### PR DESCRIPTION
## What

EPIC #3142. Makes the watcher committed-output completion block (`src/services/discord/tmux_watcher.rs`) turn-aliasing-safe: when a follow-up turn starts with `turn_start_offset >= current_offset`, the watcher processes the OLDER committed range while the late-read `inflight_state` holds the NEWER turn's identity. This gates all visible/destructive ops on offset-pinned turn identity (or skip when stale).

## Consumers closed (4/4)
1. **Dispatch finalization** — `resolved_did` gated on `!completion_is_stale_for_newer_turn`; a newer dispatch is never completed with the old `full_response`.
2. **History append** — gated on BOTH the id!=0 helper AND the id==0-inclusive `committed_anchor_cleanup_is_stale_for_newer_turn`, so a newer external-input turn (`user_msg_id==0`) never cross-pairs its `user_text` with the older response.
3. **Anchor cleanup** — both branches (incl. `lifecycle_stage_paused`) gated by the id==0-inclusive helper; a newer turn's anchor (incl. `user_msg_id==0` injected/external) is never `✅`'d.
4. **Status-panel** — completion identity offset-pinned via `pinned_finalize_user_msg_id`; ADOPT (`should_adopt_inflight_terminal_message_ids`) and EDIT/complete (`complete_watcher_status_panel_v2`) now gated on `!inflight_before_relay_is_stale_newer_turn` so a newer turn's `status_message_id` is neither adopted nor edited.

**Over-suppression guard**: all gates key off OFFSET staleness, never `pinned==0` (which is ambiguous with a legitimate in-range id==0 watcher-direct turn) — so normal single-turn completions (incl. watcher-direct id==0) are unchanged.

## Scope
`tmux_watcher.rs` only. The BRIDGE-path status-panel edit (`turn_bridge/mod.rs:2009`) is a **#3016 core hotfile** and is intentionally deferred to a follow-up (tracked separately).

## Tests
Matrix tests in `pane_dead_identity_tests` mirroring the #3140 finalizer matrix: per-consumer stale-vs-in-range, id==0 external/injected, lifecycle_stage_paused, and the status-panel adopt/edit over-suppression guard. 139 tmux_watcher tests pass; `cargo fmt --check`, `cargo check --lib`, `agent-maintenance` all clean.

Reviewed: codex `gpt-5.5` xhigh — VERDICT CLEAN (watcher block scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)