### PR TITLE
fix(#3159): close terminal-delivery black-hole — commit Sink lease outcome on real advance + race-safe committed read

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -128,7 +128,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (9124 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (9143 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -349,17 +349,21 @@ impl SinkDeliveryLeaseGuard {
         })
     }
 
-    /// SUCCESS-path commit. Called AFTER the committed offset has already been
-    /// advanced, so the watcher reconciliation reads `committed >= end` the moment
-    /// the marker clears. Compare-and-X on the full `(Sink, turn, [start,end))`
-    /// identity → a stale clear from an older turn no-ops. Drop still releases.
-    fn commit(&self) {
+    /// Terminal-decision commit. Called AFTER the committed-offset advance was
+    /// attempted; `outcome` reflects whether the advance ACTUALLY happened —
+    /// `Delivered` only when the offset advanced (so the watcher reads
+    /// `committed >= end` the moment the marker clears → Skip), `NotDelivered`
+    /// when the identity gate REFUSED the advance (the offset stayed `< end`, so
+    /// the watcher reconciliation re-sends → SendFull, no black-hole). Compare-and-X
+    /// on the full `(Sink, turn, [start,end))` identity → a stale clear from an
+    /// older turn no-ops. Drop still releases.
+    fn commit(&self, outcome: super::LeaseOutcome) {
         self.cell.commit(
             super::LeaseHolder::Sink,
             self.turn,
             self.start,
             self.end,
-            super::LeaseOutcome::Delivered,
+            outcome,
         );
     }
 }
@@ -543,7 +547,7 @@ impl SessionBoundDiscordRelaySink {
         sink_lease_guard: Option<&SinkDeliveryLeaseGuard>,
     ) {
         let fresh_inflight = super::inflight::load_inflight_state(provider, channel_id);
-        self.advance_offset_for_confirmed_delegated_terminal(
+        let advanced = self.advance_offset_for_confirmed_delegated_terminal(
             shared,
             provider,
             channel_id,
@@ -551,14 +555,23 @@ impl SessionBoundDiscordRelaySink {
             delivery,
             fresh_inflight.as_ref(),
         );
-        // #3151 CLEAR (success): advance committed FIRST (above), THEN commit the
-        // marker. Ordering matters — the instant the marker clears the watcher
-        // reconciliation must read `committed >= end` (→ Skip), never re-send into
-        // a just-cleared marker. `commit` is full-identity-gated, so a stale frame
-        // whose `(turn, range)` no longer matches the live lease no-ops. Drop on
+        // #3151 CLEAR: advance committed FIRST (above), THEN commit the marker.
+        // Ordering matters — the instant the marker clears the watcher reconciliation
+        // reads the committed offset. The commit outcome MUST reflect whether the
+        // advance ACTUALLY happened (#3159 BUG 1): if the identity gate refused the
+        // advance, the offset stayed `< end`, so committing `Delivered` would let the
+        // watcher treat the range as delivered (under-delivery / black-hole). Commit
+        // `Delivered` ONLY when `advanced` (committed >= end → Skip); otherwise commit
+        // `NotDelivered` so the watcher's committed-offset reconciliation re-sends
+        // (committed < end → SendFull). `commit` is full-identity-gated, so a stale
+        // frame whose `(turn, range)` no longer matches the live lease no-ops. Drop on
         // exit releases the lease (Committed → Unleased) regardless.
         if let Some(guard) = sink_lease_guard {
-            guard.commit();
+            guard.commit(if advanced {
+                super::LeaseOutcome::Delivered
+            } else {
+                super::LeaseOutcome::NotDelivered
+            });
         }
     }
 
@@ -570,9 +583,9 @@ impl SessionBoundDiscordRelaySink {
         session_name: &str,
         delivery: &SessionRelayDelivery,
         inflight: Option<&super::inflight::InflightTurnState>,
-    ) {
+    ) -> bool {
         let Some(end) = delivery.terminal_consumed_end.filter(|end| *end > 0) else {
-            return;
+            return false;
         };
         // IDENTITY GATE: the frame's pinned turn identity must still match the
         // channel's current inflight. A delayed frame from an already-replaced
@@ -585,7 +598,7 @@ impl SessionBoundDiscordRelaySink {
                 frame_user_msg_id = delivery.frame_turn_user_msg_id,
                 "session-bound sink: terminal frame carried a commit fence but inflight is gone; identity gate blocks advance"
             );
-            return;
+            return false;
         };
         // #3041 P1-3 (codex P1-3 issue 2 R4): STRICT `turn_start_offset` identity.
         // Two consecutive `user_msg_id == 0` turns started in the SAME second
@@ -615,7 +628,7 @@ impl SessionBoundDiscordRelaySink {
                 inflight_turn_start_offset = inflight.turn_start_offset,
                 "session-bound sink: terminal frame identity != current inflight; identity gate blocks advance (delayed/wrong-turn frame)"
             );
-            return;
+            return false;
         }
         super::tmux::advance_watcher_confirmed_end(
             shared,
@@ -625,6 +638,7 @@ impl SessionBoundDiscordRelaySink {
             end,
             "src/services/discord/session_relay_sink.rs:sink_confirmed_terminal_advance",
         );
+        true
     }
 
     async fn deliver_response(
@@ -3511,7 +3525,7 @@ mod tests {
             {
                 let guard =
                     SinkDeliveryLeaseGuard::acquire(&cell, turn, START, END).expect("acquire wins");
-                guard.commit();
+                guard.commit(LeaseOutcome::Delivered);
                 match cell.read() {
                     LeaseSnapshot::Committed {
                         holder, outcome, ..
@@ -3526,6 +3540,40 @@ mod tests {
             assert!(
                 matches!(cell.read(), LeaseSnapshot::Unleased),
                 "Drop releases the committed marker back to Unleased"
+            );
+        }
+
+        /// #3159 BUG 1: REFUSED-ADVANCE path. When the identity gate refuses the
+        /// offset advance, `advance_after_confirmed_post` commits `NotDelivered`
+        /// instead of `Delivered`. The marker is `Committed{Sink, NotDelivered}`,
+        /// which the watcher routes through committed-offset reconciliation (committed
+        /// stayed < end because the advance never ran) → SendFull. No under-delivery.
+        #[tokio::test]
+        async fn commit_not_delivered_marks_refused_advance() {
+            let ch = ChannelId::new(7306);
+            let cell = Arc::new(DeliveryLeaseCell::new(ch));
+            let turn = TurnKey::new(ch, 5, 0);
+            {
+                let guard =
+                    SinkDeliveryLeaseGuard::acquire(&cell, turn, START, END).expect("acquire wins");
+                guard.commit(LeaseOutcome::NotDelivered);
+                match cell.read() {
+                    LeaseSnapshot::Committed {
+                        holder, outcome, ..
+                    } => {
+                        assert_eq!(holder, LeaseHolder::Sink);
+                        assert_eq!(
+                            outcome,
+                            LeaseOutcome::NotDelivered,
+                            "a refused advance must commit NotDelivered, not Delivered"
+                        );
+                    }
+                    other => panic!("expected Committed{{Sink, NotDelivered}}, got {other:?}"),
+                }
+            }
+            assert!(
+                matches!(cell.read(), LeaseSnapshot::Unleased),
+                "Drop releases the NotDelivered marker back to Unleased"
             );
         }
 

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -2793,8 +2793,11 @@ enum WatcherTerminalResendAction {
 /// - `Leased{Sink}` AND `now_ms >= deadline_ms` → RECLAIM (the caller force-clears
 ///   the dead sink's marker via `reclaim_if_expired`) then fall through to
 ///   `watcher_terminal_resend_action` → `SendFull` (committed < end). No black-hole.
-/// - `Committed{Sink}` (sink committed Delivered, not yet released) → Skip (belt-and-
-///   suspenders; `committed >= end` already yields Skip below).
+/// - `Committed{Sink}` (sink committed its terminal decision, not yet released) →
+///   route through the committed-offset reconciliation: `committed >= end` (a real
+///   Delivered commit) → Skip, `committed < end` (a NotDelivered / refused-advance
+///   commit) → SendFull (re-send; no black-hole). #3159 BUG 1: the marker is no
+///   longer blindly treated as delivered.
 /// - ANY non-Sink holder / `Unleased` / committed-covered → behave EXACTLY as today:
 ///   defer to `watcher_terminal_resend_action`. The gate ONLY interposes for a
 ///   Sink-held lease, so the watcher-direct B2 path is untouched.
@@ -2828,9 +2831,15 @@ fn watcher_terminal_resend_action_gated(
             holder: LeaseHolder::Sink,
             ..
         } => {
-            // The sink committed Delivered but hasn't released yet; the range is
-            // delivered. Skip (belt-and-suspenders; committed>=end also yields Skip).
-            (WatcherTerminalResendAction::SkipAlreadyCommitted, false)
+            // #3159 BUG 1: a Committed{Sink} marker is NO LONGER assumed delivered.
+            // Route through the committed-offset reconciliation; committed >= end
+            // (a real Delivered commit, which advanced the offset BEFORE committing)
+            // → SkipAlreadyCommitted (unchanged), committed < end (a NotDelivered /
+            // refused-advance commit) → SendFull (the range was NOT delivered, so
+            // re-send; no black-hole). This also subsumes the Drop-release fallback
+            // (Unleased + committed < end → SendFull). The committed offset is the
+            // sole delivered-test, so a genuinely-delivered range is never re-sent.
+            (watcher_terminal_resend_action(committed, start, end), false)
         }
         // Unleased, or held/committed by a non-Sink holder (Watcher/Bridge): the
         // #3151 marker does not apply — behave exactly as the pre-#3151 path.
@@ -8975,7 +8984,6 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 &tmux_session_name,
                 "watcher_terminal_resend_reconcile",
             );
-            let committed = shared.committed_relay_offset(channel_id);
             // #3151: gate the re-send on the in-flight sink-delivery marker BEFORE
             // the committed-offset reconciliation. The marker is a `Leased{Sink}`
             // state on the SAME per-channel `DeliveryLeaseCell` the watcher's own
@@ -8984,11 +8992,22 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             //     NOT re-send this pass (the slow-sink-in-flight duplicate #3151).
             //   * Leased{Sink, expired} → reclaim the dead sink's marker, then
             //     SendFull (committed<end) — the no-black-hole arm.
-            //   * Committed{Sink} / committed>=end → Skip (range delivered).
+            //   * Committed{Sink} → reconcile vs committed offset: committed>=end →
+            //     Skip (delivered), committed<end → SendFull (#3159: a refused/
+            //     NotDelivered commit re-sends, no black-hole).
             //   * Unleased / non-Sink holder → unchanged (defer to the existing
             //     committed-offset reconciliation).
             let gate_cell = shared.delivery_lease(channel_id);
             let snapshot = gate_cell.read();
+            // #3159 BUG 1 (codex race-1): read `committed` AFTER the lease snapshot.
+            // The sink's CLEAR protocol advances `committed` FIRST, THEN commits the
+            // marker (`Committed{Sink}`). So observing `Committed{Sink}` in `snapshot`
+            // happens-after the sink's committed-offset write; reading `committed`
+            // next is therefore guaranteed to see the advanced value (committed>=end
+            // for a real Delivered commit → Skip). Reading it BEFORE the snapshot
+            // could capture a pre-advance `committed < end` paired with a now-
+            // Committed{Delivered} marker → a spurious SendFull duplicate.
+            let committed = shared.committed_relay_offset(channel_id);
             let now_ms = crate::services::discord::lease_now_ms();
             let (action, reclaim_expired_sink) = watcher_terminal_resend_action_gated(
                 &snapshot,
@@ -13166,10 +13185,55 @@ TUI-E2E-marker ssh-direct
             );
         }
 
-        /// Committed{Sink} (sink committed Delivered, not yet released) → Skip,
-        /// no reclaim (belt-and-suspenders early Skip).
+        /// #3159 BUG 1: Committed{Sink, Delivered} with committed >= end (a real
+        /// delivered commit advances the offset BEFORE committing) → Skip, no reclaim.
+        /// This is the no-duplicate invariant: a genuinely-delivered range is never
+        /// re-sent.
         #[test]
-        fn committed_sink_skips() {
+        fn committed_sink_delivered_covered_skips() {
+            let snap = LeaseSnapshot::Committed {
+                holder: LeaseHolder::Sink,
+                turn: turn(),
+                start: START,
+                end: END,
+                outcome: LeaseOutcome::Delivered,
+            };
+            // committed >= end (END): the advance ran before commit.
+            let (action, reclaim) =
+                watcher_terminal_resend_action_gated(&snap, END, START, END, NOW);
+            assert_eq!(action, WatcherTerminalResendAction::SkipAlreadyCommitted);
+            assert!(!reclaim);
+        }
+
+        /// #3159 BUG 1 (no black-hole): Committed{Sink, NotDelivered} — the identity
+        /// gate REFUSED the advance, so committed stayed < end. The gate now routes
+        /// through committed-offset reconciliation → SendFull (re-send, not Skip).
+        /// Previously this blind-Skipped → under-delivery / black-hole.
+        #[test]
+        fn committed_sink_not_delivered_sends_full() {
+            let snap = LeaseSnapshot::Committed {
+                holder: LeaseHolder::Sink,
+                turn: turn(),
+                start: START,
+                end: END,
+                outcome: LeaseOutcome::NotDelivered,
+            };
+            let (action, reclaim) =
+                watcher_terminal_resend_action_gated(&snap, COMMITTED_BELOW_END, START, END, NOW);
+            assert_eq!(
+                action,
+                WatcherTerminalResendAction::SendFull,
+                "a NotDelivered commit (committed<end) must re-send, not Skip"
+            );
+            assert!(!reclaim);
+        }
+
+        /// #3159 BUG 1 belt-and-suspenders: even a Delivered-labelled commit with
+        /// committed < end (which the fixed producer no longer emits, since Delivered
+        /// is committed only after a real advance) re-sends — the committed offset is
+        /// the SOLE delivered-test, not the outcome label. No black-hole regardless.
+        #[test]
+        fn committed_sink_below_end_sends_full_regardless_of_label() {
             let snap = LeaseSnapshot::Committed {
                 holder: LeaseHolder::Sink,
                 turn: turn(),
@@ -13179,7 +13243,7 @@ TUI-E2E-marker ssh-direct
             };
             let (action, reclaim) =
                 watcher_terminal_resend_action_gated(&snap, COMMITTED_BELOW_END, START, END, NOW);
-            assert_eq!(action, WatcherTerminalResendAction::SkipAlreadyCommitted);
+            assert_eq!(action, WatcherTerminalResendAction::SendFull);
             assert!(!reclaim);
         }
 


### PR DESCRIPTION
## What

Split-out **BUG 1 only** fix for the #3159 reclaimable in-flight sink-delivery marker. Codex caught 3 real correctness issues in the combined fix; this PR lands the impactful **under-delivery / black-hole** fix cleanly and defers **BUG 2** (bounding an unbounded `WaitInFlight` on a genuinely-hung POST) — whose fixed-bound approach (whole-helper timeout + shared-heartbeat renewal cap) cut legitimate slow multi-chunk sends short and risked duplicates — to a separate PR with a progress-based design.

### The bug
A `Committed{Sink}` lease marker was blindly treated as Delivered (Skip). When the sink's identity gate **refused** to advance the committed offset, the watcher skipped re-sending → the message was silently dropped (black-hole).

### The fix
1. `advance_offset_for_confirmed_delegated_terminal` returns `bool` (true only when `advance_watcher_confirmed_end` actually ran; every refusal arm returns false).
2. `SinkDeliveryLeaseGuard::commit` takes a `LeaseOutcome` — `Delivered` only when advanced, else `NotDelivered`.
3. `watcher_terminal_resend_action_gated` routes `Committed{Sink}` through the committed-offset reconciliation (`committed>=end` → Skip, `committed<end` → SendFull). The committed offset is the sole delivered-test.
4. **Race fix (codex)**: read `committed` **after** the lease snapshot. The sink advances `committed` before committing the marker, so observing `Committed{Sink}` guarantees the advanced value is visible — closes a spurious-SendFull duplicate window.

## Verification
- `cargo fmt --check`, `cargo check --lib` clean (2 pre-existing warnings).
- Targeted tests pass: `commit_not_delivered_marks_refused_advance`, `committed_sink_not_delivered_sends_full`, `committed_sink_below_end_sends_full_regardless_of_label`, `committed_sink_delivered_covered_skips`, plus existing `leased_sink_*` / `dead_sink_marker_reclaimed_then_resent_no_blackhole` / `reclaim_then_late_sink_commit_cannot_corrupt_lease`.
- Independent codex review (gpt-5.5 xhigh): **VERDICT: CLEAN** (ran the targeted suites itself: 16 sink-marker + 10 watcher-gate passed).

## Deferred
BUG 2 (rare hung-POST `WaitInFlight`) — a pre-existing latent condition in merged #3159, not made worse by this PR. Separate progress-based-bound PR to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)