### PR TITLE
fix(#3166): export CLAUDE_AUTOCOMPACT_PCT_OVERRIDE for TUI-hosted claude sessions (fresh + resume)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -399,7 +399,8 @@
     atomic read, closing the present/generation TOCTOU) plus its dedicated accessor unit
     test; the watcher-snapshot no-clobber regression test is retained, rewritten to take
     its G1/G2 snapshots from `external_input_relay_lease(...).map(|l| l.generation)`).
-  - `src/services/discord/recovery_engine.rs` (4037 lines; +36 from #3099
+  - `src/services/discord/recovery_engine.rs` (4046 lines; +9 from #3166
+    fetching real context thresholds for the recovered-turn status panel; +36 from #3099
     task-notification anchor `⏳` cleanup for `user_msg_id == 0` recovery; +4
     from the #3099 re-review pinned-injected-message-id cleanup target; +55 from
     #3078 PR-2 routing recovery completion through `StatusPanelController` behind
@@ -671,7 +672,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
 - `src/services/dispatches/outbox_route.rs` (1118) — dispatch outbox route
   support extracted from the route layer; split before adding non-bugfix
   behavior.
-- `src/services/claude.rs` (3786), `src/services/gemini.rs` (1416),
+- `src/services/claude.rs` (3795), `src/services/gemini.rs` (1416),
   `src/services/qwen.rs` (2200), `src/services/codex.rs` (2928),
   `src/services/opencode.rs` (1881), `src/services/provider.rs` (1738) —
   provider adapters.

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -839,6 +839,7 @@ IMPORTANT: Format your responses using Markdown for better readability:
                         model_override,
                         effective_prompt,
                         hook_endpoint,
+                        compact_percent,
                     );
                 }
                 tracing::warn!(
@@ -2155,6 +2156,13 @@ fn execute_streaming_local_tui_tmux(
     model_override: Option<&str>,
     system_prompt: Option<&str>,
     hook_endpoint: String,
+    // #3166: provider-specific compact threshold (context_compact_percent_claude),
+    // resolved by the caller via fetch_context_thresholds. Threaded into the TUI
+    // launch script so `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` is exported for BOTH fresh
+    // and `--resume` spawns. Before #3166 this path silently dropped it, so every
+    // TUI-hosted claude session (the default local-tmux driver since #2110) ran
+    // without the configured auto-compact override.
+    compact_percent: Option<u64>,
 ) -> Result<(), String> {
     debug_log(&format!(
         "=== execute_streaming_local_tui_tmux START: {} ===",
@@ -2724,6 +2732,7 @@ fn execute_streaming_local_tui_tmux(
             system_prompt: system_prompt.map(str::to_string),
             model: model_override.map(str::to_string),
             resume,
+            compact_percent,
         };
         let session_files =
             crate::services::claude_tui::session::prepare_claude_tui_launch(&launch_config)?;

--- a/src/services/claude_tui/session.rs
+++ b/src/services/claude_tui/session.rs
@@ -27,6 +27,13 @@ pub struct ClaudeTuiLaunchConfig {
     pub system_prompt: Option<String>,
     pub model: Option<String>,
     pub resume: bool,
+    /// #3166: provider-specific auto-compact threshold
+    /// (`context_compact_percent_claude`), resolved by the caller via
+    /// `fetch_context_thresholds`. When `Some(pct)` with `pct > 0` the launch
+    /// script exports `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=pct` so BOTH fresh and
+    /// `--resume` TUI spawns honour the configured override. Mirrors the
+    /// `p > 0` guard used by the non-TUI tmux/process spawn paths.
+    pub compact_percent: Option<u64>,
 }
 
 impl ClaudeTuiLaunchConfig {
@@ -147,13 +154,24 @@ fn write_launch_script(
     // prompt entirely, the placeholder semantics here should be
     // revisited. Track upstream PY6 changes and reflect them in this
     // comment + the unit tests.
+    // #3166: export the configured Claude auto-compact override so TUI-hosted
+    // sessions (fresh AND `--resume`) honour `context_compact_percent_claude`.
+    // Gated on `pct > 0`, mirroring the non-TUI spawn paths
+    // (`build_tmux_launch_env_lines` / `execute_streaming_local_process`); a 0
+    // or absent value leaves the var unset so the Claude CLI keeps its default.
+    let compact_export = match config.compact_percent.filter(|&pct| pct > 0) {
+        Some(pct) => format!("export CLAUDE_AUTOCOMPACT_PCT_OVERRIDE={pct}\n"),
+        None => String::new(),
+    };
     let script = format!(
         "#!/bin/bash\n\
          cd {cwd}\n\
          export CLAUDE_CODE_RESUME_PROMPT=\"_\"\n\
+         {compact_export}\
          exec {claude_bin} {args}\n",
         cwd = shell_escape(&config.working_dir.display().to_string()),
         claude_bin = shell_escape(&config.claude_bin.display().to_string()),
+        compact_export = compact_export,
         args = args,
     );
     std::fs::write(path, script)
@@ -175,6 +193,7 @@ mod tests {
             system_prompt: Some("system prompt".to_string()),
             model: Some("sonnet".to_string()),
             resume: false,
+            compact_percent: None,
         }
     }
 
@@ -278,6 +297,81 @@ mod tests {
             !script.contains("export CLAUDE_CODE_RESUME_PROMPT=\" \""),
             "single-space placeholder is truthy but whitespace-only; #2730 reproduced this poisoning the API conversation history"
         );
+    }
+
+    #[test]
+    fn launch_script_exports_compact_override_when_configured() {
+        // #3166: a configured context_compact_percent_claude must reach the TUI
+        // launch script as CLAUDE_AUTOCOMPACT_PCT_OVERRIDE so resume/restore-
+        // spawned TUI sessions honour the user-set auto-compact threshold.
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = sample_config();
+        config.compact_percent = Some(60);
+        let launch_script_path = dir.path().join("launch.sh");
+
+        write_launch_script(
+            &launch_script_path,
+            &config,
+            Path::new("/tmp/settings.json"),
+        )
+        .unwrap();
+
+        let script = std::fs::read_to_string(&launch_script_path).unwrap();
+        assert!(
+            script.contains("export CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=60\n"),
+            "launch script must export the configured compact override, got:\n{script}"
+        );
+        // The export must precede the `exec` line so the env is in scope for claude.
+        let export_pos = script.find("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE").unwrap();
+        let exec_pos = script.find("exec ").unwrap();
+        assert!(
+            export_pos < exec_pos,
+            "compact override must be exported before exec"
+        );
+    }
+
+    #[test]
+    fn launch_script_resume_exports_compact_override() {
+        // #3166: the resume path is the reported live regression — a --resume
+        // spawn must still carry the override.
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = sample_config();
+        config.resume = true;
+        config.compact_percent = Some(60);
+        let launch_script_path = dir.path().join("launch.sh");
+
+        write_launch_script(
+            &launch_script_path,
+            &config,
+            Path::new("/tmp/settings.json"),
+        )
+        .unwrap();
+
+        let script = std::fs::read_to_string(&launch_script_path).unwrap();
+        assert!(script.contains("export CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=60\n"));
+    }
+
+    #[test]
+    fn launch_script_omits_compact_override_when_absent_or_zero() {
+        // Mirror the `p > 0` guard used by the non-TUI spawn paths: None or 0
+        // leaves the var unset so the Claude CLI keeps its built-in default.
+        let dir = tempfile::tempdir().unwrap();
+        for value in [None, Some(0)] {
+            let mut config = sample_config();
+            config.compact_percent = value;
+            let launch_script_path = dir.path().join("launch.sh");
+            write_launch_script(
+                &launch_script_path,
+                &config,
+                Path::new("/tmp/settings.json"),
+            )
+            .unwrap();
+            let script = std::fs::read_to_string(&launch_script_path).unwrap();
+            assert!(
+                !script.contains("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"),
+                "value {value:?} must not export the override, got:\n{script}"
+            );
+        }
     }
 
     #[test]

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -3961,6 +3961,16 @@ pub(super) async fn restore_inflight_turns(
         let mut state = state;
         state.session_key = state.session_key.or_else(|| adk_session_key.clone());
         state.dispatch_id = state.dispatch_id.or_else(|| recovery_dispatch_id.clone());
+        // #3166: read the real configured thresholds (e.g.
+        // `context_compact_percent_claude`) instead of `ContextThresholds::default()`
+        // so the recovered turn's status panel reflects the user-set auto-compact
+        // percent, matching the live launch paths (intake_turn/headless_turn).
+        // This is the display value; the spawn-side `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`
+        // env is exported by the launch script (claude_tui/session.rs, #3166).
+        let recovery_compact_percent =
+            super::adk_session::fetch_context_thresholds(shared.api_port)
+                .await
+                .compact_pct_for(&provider);
         spawn_turn_bridge(
             shared.clone(),
             cancel_token,
@@ -3986,8 +3996,7 @@ pub(super) async fn restore_inflight_turns(
                 dispatch_kind: recovery_dispatch_kind,
                 memory_recall_usage: crate::services::memory::TokenUsage::default(),
                 context_window_tokens: provider.default_context_window(),
-                context_compact_percent: super::adk_session::ContextThresholds::default()
-                    .compact_pct_for(&provider),
+                context_compact_percent: recovery_compact_percent,
                 current_msg_id,
                 response_sent_offset: state.response_sent_offset,
                 full_response: state.full_response.clone(),


### PR DESCRIPTION
## 근본원인
TUI 호스팅 claude 세션(#2110 이후 기본 local-tmux 드라이버 — fresh **및** `--resume`)이 `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`를 **한 번도 export하지 않아** 사용자가 설정한 auto-compact %(예: 60)가 실제 claude 프로세스에 도달하지 못했다. 비-TUI 직접 spawn 경로(`claude.rs` build_env_lines / command.env)는 이미 export했지만, TUI 경로는 별도 launch-script writer(`claude_tui/session.rs::write_launch_script`)를 쓰는데 거기에 누락돼 있었다. `execute_command_streaming`이 `compact_percent`를 갖고도 `execute_streaming_local_tui_tmux` 분기에 넘기지 않아 통째로 버려졌다.

이슈가 지목한 `recovery_engine.rs:3989`는 status-panel **표시값** 경로일 뿐 env 주입 경로가 아니었다(복원 경로는 claude를 재spawn하지 않고 기존 tmux output만 읽음).

## 변경 (4파일, +117/-4)
- `claude.rs`: `compact_percent`를 `execute_streaming_local_tui_tmux` → `ClaudeTuiLaunchConfig`로 연결
- `claude_tui/session.rs`: `ClaudeTuiLaunchConfig.compact_percent` 추가; `write_launch_script`가 `pct>0`일 때 `exec claude` **앞**에 `export CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=<pct>` 출력 (None/0은 미export). 회귀 테스트 3개
- `recovery_engine.rs`: status-panel 표시 정확성을 위해 `ContextThresholds::default()` → `fetch_context_thresholds(shared.api_port).await` (락 밖, intake/headless와 동일)
- `change-surfaces.md`: LoC freeze 동기화

## resume 커버
resume는 launch 스크립트로 claude를 **재실행**(`exec claude --resume`)하므로 동일 script writer 수정으로 env가 새로 잡힌다(별도 live-process 주입 불필요).

## 검증
- `cargo fmt --check` / `cargo check --lib`: 통과
- 회귀 테스트 9/9(신규 3: fresh export, resume export, None/0 omit + exec 앞 배치)
- maintenance docs freeze 동기화
- codex(gpt-5.5 xhigh) 독립 리뷰: **GATE_PASS, Findings: none** (codex가 직접 `cargo test launch_script`·`compact_threshold` 재실행 통과 확인)

Closes #3166

🤖 Generated with [Claude Code](https://claude.com/claude-code)