### PR TITLE
fix(#3176): idle-relay drain-wait self-deadlock — identity-pin this turn's own synthetic inflight

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -304,9 +304,11 @@
     (incl. id==0 external/injected) NOT adopted/edited, in-range id==0
     watcher-direct STILL adopts+edits (over-suppression guard), and in-range id!=0
     unchanged.
-  - `src/services/discord/tui_prompt_relay.rs` (4145 lines; SSH-direct TUI
+  - `src/services/discord/tui_prompt_relay.rs` (4209 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
-    outside an extraction plan; +12 from #3041 P1-4 codex: the lease record
+    outside an extraction plan; +64 from #3176: identity-pinned idle-tail
+    drain-wait (`inflight_is_current_turn_synthetic` + `current_turn_anchor_id`
+    threading) closes a relay self-deadlock; +12 from #3041 P1-4 codex: the lease record
     helpers now RETURN the recorded lease (with its per-record `generation`
     nonce) and callers adopt it back so a later exact-match/by-generation clear
     targets the precise stored identity (no clobber of a newer lease); +4 from

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -574,6 +574,11 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
         injected_class.still_delivers_assistant_output(),
         "every injected class must still deliver assistant output via the bridge tail",
     );
+    // #3176: the anchor message id of THIS turn's TUI-direct synthetic inflight, set
+    // only on the branch that actually posts an anchor + creates the synthetic. Used
+    // by the idle-tail drain-wait to identity-pin our own inflight (so it does not
+    // self-deadlock) while still waiting on any genuinely distinct previous turn.
+    let mut current_turn_anchor_id: Option<u64> = None;
     if is_system_continuation {
         if matches!(injected_class, InjectedPromptClass::SlashCommandControl) {
             // #3153: a MACHINE slash-command control echo (/loop, /compact, the
@@ -687,6 +692,9 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
                 return;
             }
         };
+        // #3176: pin this turn's anchor id — it becomes the synthetic inflight's
+        // `user_msg_id` below, so the idle-tail drain-wait can recognise our own row.
+        current_turn_anchor_id = Some(anchor_message.id.get());
         // #3075: remember this card so a repeat completion edits it. #3164 codex R3
         // issue-2: keep this IMMEDIATELY after the successful post (before the awaited
         // `⏳` add) — `record_posted_card` is NOT used by lifecycle completion, and
@@ -795,8 +803,14 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             })
         });
         if bridge_adapter_owns_external_turn(lease.relay_owner)
-            && maybe_spawn_claude_idle_response_tail(shared.clone(), channel_id, &prompt, &lease)
-                .await
+            && maybe_spawn_claude_idle_response_tail(
+                shared.clone(),
+                channel_id,
+                &prompt,
+                &lease,
+                current_turn_anchor_id,
+            )
+            .await
             && let Some(guard) = lease_guard.as_mut()
         {
             guard.disarm();
@@ -1410,6 +1424,7 @@ async fn maybe_spawn_claude_idle_response_tail(
     channel_id: ChannelId,
     prompt: &ObservedTuiPrompt,
     lease: &ExternalInputRelayLease,
+    current_turn_anchor_id: Option<u64>,
 ) -> bool {
     if !prompt
         .provider
@@ -1431,7 +1446,13 @@ async fn maybe_spawn_claude_idle_response_tail(
         );
         return false;
     }
-    if !wait_for_claude_inflight_to_clear(channel_id).await {
+    if !wait_for_claude_inflight_to_clear(
+        channel_id,
+        &prompt.tmux_session_name,
+        current_turn_anchor_id,
+    )
+    .await
+    {
         tracing::warn!(
             provider = %prompt.provider,
             channel_id = channel_id.get(),
@@ -1496,17 +1517,60 @@ async fn maybe_spawn_claude_idle_response_tail(
 }
 
 #[cfg(unix)]
-async fn wait_for_claude_inflight_to_clear(channel_id: ChannelId) -> bool {
+/// #3176: is the present inflight THIS turn's own TUI-direct synthetic row?
+///
+/// The drain-wait must only skip waiting on the inflight WE just created for the
+/// current turn. The discriminator is the precise current-turn identity —
+/// `ExternalInput` + same tmux session + `user_msg_id == this turn's anchor
+/// message id` — NOT merely same-session `ExternalInput` (which would also match a
+/// still-draining PREVIOUS same-session TUI turn and wrongly skip it, risking
+/// interleaved or lost delivery). When the current turn created no synthetic
+/// (`current_turn_anchor_id == None` — e.g. system-continuation / slash-control
+/// paths), nothing here is "ours", so any present inflight remains a previous turn
+/// and still blocks.
+#[cfg(unix)]
+fn inflight_is_current_turn_synthetic(
+    state: Option<&InflightTurnState>,
+    tmux_session_name: &str,
+    current_turn_anchor_id: Option<u64>,
+) -> bool {
+    match (state, current_turn_anchor_id) {
+        (Some(state), Some(anchor_id)) => {
+            state.turn_source == TurnSource::ExternalInput
+                && state.tmux_session_name.as_deref() == Some(tmux_session_name)
+                && state.user_msg_id == anchor_id
+        }
+        _ => false,
+    }
+}
+
+#[cfg(unix)]
+async fn wait_for_claude_inflight_to_clear(
+    channel_id: ChannelId,
+    tmux_session_name: &str,
+    current_turn_anchor_id: Option<u64>,
+) -> bool {
     let mut observed_inflight = false;
     let cleared = wait_for_transient_state_to_clear(
         CLAUDE_IDLE_INFLIGHT_DRAIN_WAIT,
         CLAUDE_IDLE_INFLIGHT_DRAIN_POLL,
         || {
-            let present =
-                super::inflight::load_inflight_state(&ProviderKind::Claude, channel_id.get())
-                    .is_some();
-            observed_inflight |= present;
-            present
+            // #3176: a present inflight only BLOCKS this turn's idle tail when it
+            // belongs to a DIFFERENT (previous) turn. Our OWN synthetic for THIS turn
+            // (created upstream in the notify/anchor block) must not be waited on —
+            // doing so self-deadlocks (we created it; it never "drains" within the
+            // window), permanently skipping the relay and silently dropping every
+            // subsequent response. Identity-pinned via `inflight_is_current_turn_synthetic`.
+            let state =
+                super::inflight::load_inflight_state(&ProviderKind::Claude, channel_id.get());
+            let blocking = state.is_some()
+                && !inflight_is_current_turn_synthetic(
+                    state.as_ref(),
+                    tmux_session_name,
+                    current_turn_anchor_id,
+                );
+            observed_inflight |= blocking;
+            blocking
         },
     )
     .await;
@@ -5338,6 +5402,7 @@ mod tests {
                 channel_id,
                 &prompt,
                 &lease,
+                None,
             )
             .await;
             if spawned {
@@ -5532,6 +5597,68 @@ mod tests {
         assert_eq!(state.session_key.as_deref(), lease.session_key.as_deref());
         assert_eq!(state.runtime_kind, Some(RuntimeHandoffKind::CodexTui));
         assert_eq!(state.turn_start_offset, Some(333));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn drain_wait_does_not_block_on_own_synthetic_inflight() {
+        // #3176: the idle-tail drain-wait must treat THIS turn's own TUI-direct
+        // synthetic inflight as non-blocking. If it waited on it, it would
+        // self-deadlock (we created it; it never drains) and permanently skip the
+        // relay. The discrimination is `tui_direct_synthetic_inflight_matches`:
+        // ExternalInput + same tmux session => our own => non-blocking.
+        let output_path = PathBuf::from("/tmp/adk-selfblock.jsonl");
+        let lease = ExternalInputRelayLease {
+            channel_id: Some(7),
+            turn_id: Some("external:claude:7:tmux:1".to_string()),
+            session_key: Some("token:AgentDesk-claude-self".to_string()),
+            relay_owner: ExternalInputRelayOwner::BridgeAdapter,
+            runtime_kind: Some(RuntimeHandoffKind::ClaudeTui),
+            generation:
+                crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
+        };
+        let state = build_tui_direct_bridge_inflight_state(
+            ProviderKind::Claude,
+            ChannelId::new(7),
+            MessageId::new(11),
+            MessageId::new(22),
+            "typed in TUI",
+            "AgentDesk-claude-self",
+            &output_path,
+            0,
+            &lease,
+        );
+
+        // state.user_msg_id == 11 (the anchor id for this turn).
+        // Our own synthetic for THIS turn (matching anchor id) => non-blocking.
+        assert!(
+            inflight_is_current_turn_synthetic(Some(&state), "AgentDesk-claude-self", Some(11)),
+            "own synthetic (same session + matching anchor id) must be non-blocking"
+        );
+        // A PREVIOUS same-session TUI turn (different anchor id) => still blocks,
+        // even though it is also ExternalInput on the same session. This is the
+        // precision codex required: do not skip a genuinely distinct previous turn.
+        assert!(
+            !inflight_is_current_turn_synthetic(Some(&state), "AgentDesk-claude-self", Some(999)),
+            "a different turn's inflight (anchor id mismatch) must stay blocking"
+        );
+        // This turn created no synthetic (system-continuation / slash) => anchor None
+        // => any present inflight is a previous turn and still blocks.
+        assert!(
+            !inflight_is_current_turn_synthetic(Some(&state), "AgentDesk-claude-self", None),
+            "no current synthetic (anchor None) must keep any inflight blocking"
+        );
+        // A different tmux session is never ours.
+        assert!(
+            !inflight_is_current_turn_synthetic(Some(&state), "AgentDesk-claude-other", Some(11)),
+            "an inflight for a different tmux session must stay blocking"
+        );
+        // No inflight at all => nothing to wait on (not ours either).
+        assert!(!inflight_is_current_turn_synthetic(
+            None,
+            "AgentDesk-claude-self",
+            Some(11)
+        ));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## 라이브 outage
채널 1479671298497183835에서 내 claude 응답이 04:21Z 이후 Discord에 안 닿음(릴레이 끊김). 입력 릴레이(알림봇 주입 래퍼)는 정상, **응답 출력 릴레이만 영구 중단** → 런타임 재시작으로만 복구.

## 근본원인
`tui_prompt_relay.rs` `wait_for_claude_inflight_to_clear`(idle-response-tail drain-wait)가 **모든** present inflight을 "이전 턴"으로 보고 대기. 그러나 옵저버는 이 턴의 synthetic ExternalInput inflight을 앞단에서 생성하므로 **자기 생성물을 기다리는 self-deadlock** → ~5s 타임아웃 → `previous inflight did not drain` → 이후 모든 응답이 Discord에서 조용히 drop.

선행 트리거: 13:21 warm-followup `tui_warm_followup_cancelled_during_prompt_submit` → turn_bridge Stopped → 채널이 external/SSH-direct TUI 턴으로 라우팅되어 이 옵저버 경로만 돎(#3174/#3154/#3171 핸드오프 계열). 정상 시엔 turn_bridge primary가 릴레이해 self-block이 안 드러남.

## 수정
drain-wait를 **현재 턴 identity로 핀**: `inflight_is_current_turn_synthetic(state, tmux, current_turn_anchor_id)` = `ExternalInput && 같은 tmux && user_msg_id == 이 턴의 anchor message id`.
- `current_turn_anchor_id`는 옵저버에서 hoist, **anchor를 실제 post하고 synthetic을 생성하는 분기에서만** `Some(anchor_message.id)` (synthetic의 user_msg_id가 곧 그 anchor id).
- synthetic을 안 만드는 턴(system-continuation/slash)은 `None` → present inflight을 보수적으로 차단(기존 동작 유지).
- 따라서 **이전 같은-세션 턴**(user_msg_id 불일치)은 여전히 차단 → interleaving/delivery 손실 없음(codex round-1 지적 해소).

## 검증
- `cargo check --lib` / `cargo fmt`: 통과
- 신규 회귀 테스트 `drain_wait_does_not_block_on_own_synthetic_inflight`(현재-턴 매칭=non-blocking, 이전 턴/None/다른 세션=blocking) + 기존 drain-wait·no-binding 테스트 통과
- codex(gpt-5.5 xhigh) 2라운드: R1 FAIL(과도 매칭 지적)→identity-pin 수정→**R2 GATE_PASS, No blocking findings**

## 임시 완화(이미 적용)
런타임 재시작으로 in-memory 오분류+stuck inflight 클리어해 릴레이 복귀(tmux 세션 독립 생존).

Closes #3176

🤖 Generated with [Claude Code](https://claude.com/claude-code)