### PR TITLE
fix(#3177): queued user messages are never age-evicted — process even past the old 10-min TTL

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -716,7 +716,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   so a live thread-suffixed TUI session with no live watcher slot can be
   re-registered authoritatively instead of dropped forever),
   `src/services/discord_config_audit.rs` (1459).
-- `src/services/turn_orchestrator.rs` (2760).
+- `src/services/turn_orchestrator.rs` (2762).
 
 Decomposed below the giant-file threshold (no longer frozen; bugfix-scoped but
 normal test growth is allowed): `src/services/analytics.rs`,

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -171,8 +171,8 @@ use crate::services::turn_orchestrator::{
     load_pending_queues, warn_legacy_pending_queue_files,
 };
 pub(super) use crate::services::turn_orchestrator::{
-    ChannelMailboxRegistry, INTERVENTION_TTL, Intervention, InterventionMode,
-    MAX_INTERVENTIONS_PER_CHANNEL, PendingQueueItem,
+    ChannelMailboxRegistry, Intervention, InterventionMode, MAX_INTERVENTIONS_PER_CHANNEL,
+    PendingQueueItem,
 };
 pub use discord_io::{
     retry_failed_dm_notifications, send_file_to_channel, send_message_to_channel,

--- a/src/services/discord/queue_io.rs
+++ b/src/services/discord/queue_io.rs
@@ -2,7 +2,8 @@ use super::*;
 
 #[cfg_attr(not(test), allow(dead_code))]
 fn prune_interventions_at(queue: &mut Vec<Intervention>, now: Instant) {
-    queue.retain(|i| now.duration_since(i.created_at) <= INTERVENTION_TTL);
+    // #3177: no age-based eviction — only the overflow cap bounds the queue.
+    let _ = now;
     if queue.len() > MAX_INTERVENTIONS_PER_CHANNEL {
         let overflow = queue.len() - MAX_INTERVENTIONS_PER_CHANNEL;
         queue.drain(0..overflow);

--- a/src/services/turn_orchestrator.rs
+++ b/src/services/turn_orchestrator.rs
@@ -13,7 +13,6 @@ use tokio::sync::{Notify, mpsc, oneshot};
 use crate::services::provider::{CancelToken, ProviderKind};
 
 pub(crate) const MAX_INTERVENTIONS_PER_CHANNEL: usize = 30;
-pub(crate) const INTERVENTION_TTL: Duration = Duration::from_secs(10 * 60);
 pub(crate) const INTERVENTION_DEDUP_WINDOW: Duration = Duration::from_secs(10);
 const STALE_PENDING_QUEUE_TMP_AGE: Duration = Duration::from_secs(60);
 
@@ -71,17 +70,12 @@ fn prune_interventions(queue: &mut Vec<Intervention>) -> Vec<QueueExitEvent> {
 }
 
 fn prune_interventions_at(queue: &mut Vec<Intervention>, now: Instant) -> Vec<QueueExitEvent> {
+    // #3177: queued user messages are never age-evicted. A busy turn can hold a
+    // reply in the queue well past the old 10-minute TTL, and silently dropping
+    // it (the previous `Expired` retain) lost real user input. Only the
+    // MAX_INTERVENTIONS_PER_CHANNEL overflow cap still bounds the queue.
+    let _ = now;
     let mut queue_exit_events = Vec::new();
-    queue.retain(|intervention| {
-        let keep = now.duration_since(intervention.created_at) <= INTERVENTION_TTL;
-        if !keep {
-            queue_exit_events.push(QueueExitEvent::new(
-                intervention.clone(),
-                QueueExitKind::Expired,
-            ));
-        }
-        keep
-    });
     if queue.len() > MAX_INTERVENTIONS_PER_CHANNEL {
         let overflow = queue.len() - MAX_INTERVENTIONS_PER_CHANNEL;
         queue_exit_events.extend(
@@ -214,7 +208,8 @@ pub(crate) fn enqueue_intervention(
 }
 
 pub(crate) fn has_soft_intervention_at(queue: &mut Vec<Intervention>, now: Instant) -> bool {
-    queue.retain(|intervention| now.duration_since(intervention.created_at) <= INTERVENTION_TTL);
+    // #3177: no age-based eviction — only the overflow cap bounds the queue.
+    let _ = now;
     if queue.len() > MAX_INTERVENTIONS_PER_CHANNEL {
         let overflow = queue.len() - MAX_INTERVENTIONS_PER_CHANNEL;
         queue.drain(0..overflow);
@@ -3389,6 +3384,84 @@ mod enqueue_refusal_reason_tests {
         let result = enqueue_intervention(&mut queue, incoming);
         assert!(result.enqueued);
         assert_eq!(result.refusal_reason, None);
+    }
+}
+
+// #3177: queued user messages must never be age-evicted. The old
+// `prune_interventions_at` dropped anything older than `INTERVENTION_TTL`
+// (10 min) as `QueueExitKind::Expired`, silently losing user input when a turn
+// stayed busy. These tests pin the new behaviour: arbitrarily old items survive
+// prune, and only the MAX_INTERVENTIONS_PER_CHANNEL overflow cap still trims the
+// queue (as `Superseded`).
+#[cfg(test)]
+mod no_ttl_evict_tests {
+    use super::*;
+
+    fn intervention_at(message_id: u64, created_at: Instant) -> Intervention {
+        Intervention {
+            author_id: UserId::new(1),
+            author_is_bot: false,
+            message_id: MessageId::new(message_id),
+            source_message_ids: vec![MessageId::new(message_id)],
+            text: format!("msg-{message_id}"),
+            mode: InterventionMode::Soft,
+            created_at,
+            reply_context: None,
+            has_reply_boundary: false,
+            merge_consecutive: false,
+            pending_uploads: Vec::new(),
+            voice_announcement: None,
+        }
+    }
+
+    #[test]
+    fn very_old_intervention_survives_prune() {
+        let now = Instant::now();
+        // Far past the old 10-minute TTL.
+        let ancient = now
+            .checked_sub(Duration::from_secs(60 * 60))
+            .expect("test clock should subtract an hour");
+        let mut queue = vec![intervention_at(1, ancient)];
+
+        let exits = prune_interventions_at(&mut queue, now);
+
+        assert_eq!(
+            queue.len(),
+            1,
+            "an hour-old intervention must remain queued (no age eviction)"
+        );
+        assert_eq!(queue[0].message_id, MessageId::new(1));
+        assert!(
+            exits.is_empty(),
+            "no QueueExitEvent should be produced for an old-but-under-cap queue"
+        );
+        // The soft-queue probe must also keep it.
+        assert!(has_soft_intervention_at(&mut queue, now));
+        assert_eq!(queue.len(), 1);
+    }
+
+    #[test]
+    fn overflow_cap_still_supersedes_oldest() {
+        let now = Instant::now();
+        let mut queue: Vec<Intervention> = (0..(MAX_INTERVENTIONS_PER_CHANNEL as u64 + 3))
+            .map(|i| intervention_at(i + 1, now))
+            .collect();
+
+        let exits = prune_interventions_at(&mut queue, now);
+
+        assert_eq!(
+            queue.len(),
+            MAX_INTERVENTIONS_PER_CHANNEL,
+            "overflow cap must bound the queue"
+        );
+        assert_eq!(exits.len(), 3, "the 3 oldest must be evicted");
+        assert!(
+            exits.iter().all(|e| e.kind == QueueExitKind::Superseded),
+            "overflow eviction must be Superseded, never Expired"
+        );
+        // The evicted ones are the oldest (lowest message ids).
+        assert_eq!(exits[0].intervention.message_id, MessageId::new(1));
+        assert_eq!(exits[2].intervention.message_id, MessageId::new(3));
     }
 }
 


### PR DESCRIPTION
## 문제
큐잉된 사용자 메시지가 `INTERVENTION_TTL`(10분)을 넘기면 `QueueExitKind::Expired`로 큐에서 제거돼 `⌛ 큐에서 제거됨 — 대기 시간 초과로 처리되지 않습니다` 카드만 남고 **처리 없이 영구 drop** → 메시지 소실. (도입 #1975, 후속 #1332)

## 사용자 결정
**"10분 넘어도 무조건 처리"** — 나이 기반 evict를 완전히 제거. 오래된 메시지도 큐 유지→턴 풀리면 처리.

## 변경 (4파일)
- `turn_orchestrator.rs`: `INTERVENTION_TTL` const 제거; `prune_interventions_at`·`has_soft_intervention_at`의 TTL retain(Expired drop) 제거, `now`는 `let _ = now`로 시그니처 보존. **MAX_INTERVENTIONS_PER_CHANNEL overflow cap(가장 오래된 것 Superseded)만 유지**(큐 무한증식 방지)
- `discord/queue_io.rs`: `prune_interventions_at`(test 경로)의 TTL retain 제거, overflow drain 유지
- `discord/mod.rs`: `INTERVENTION_TTL` import 제거
- `QueueExitKind::Expired` variant은 **유지**(mod.rs feedback match가 다룸 — 이제 생성만 안 됨)
- `change-surfaces.md`: freeze LoC 동기화

별개로 mod.rs의 restart catch-up age window(5분/10분)는 재시작 시 오래된 메시지 replay 방지용 **별도 경로**라 범위 밖(intervention evict와 무관, Expired 미생성).

## 검증
- `cargo fmt`/`cargo check --lib`: 통과(신규 에러 0)
- 신규 테스트 2개: 1시간 경과 intervention이 prune 후 생존(evict 안 됨) + overflow는 여전히 Superseded
- `cargo test --lib turn_orchestrator`(single-thread) 36 passed, `queue_io` 1 passed
- maintenance docs freeze 동기화
- codex(gpt-5.5 xhigh): **GATE_PASS, Findings: None**

Closes #3177

🤖 Generated with [Claude Code](https://claude.com/claude-code)