### PR TITLE
fix(#3183): idle-response-tail must not re-relay output the watcher already delivered (double-relay)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -304,7 +304,7 @@
     (incl. id==0 external/injected) NOT adopted/edited, in-range id==0
     watcher-direct STILL adopts+edits (over-suppression guard), and in-range id!=0
     unchanged.
-  - `src/services/discord/tui_prompt_relay.rs` (4394 lines; SSH-direct TUI
+  - `src/services/discord/tui_prompt_relay.rs` (4464 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +185 from #3178: the machine slash-command
     control trigger (`/loop`/`/compact`/`<command-*>`) is a FULL active turn —
@@ -381,7 +381,16 @@
     BY the recorded generation (`clear_external_input_relay_lease_if_generation_matches`)
     so a newer same-key lease recorded during the await is never clobbered; success
     persistence is preserved by disarming before the bridge legitimately retains the
-    turn (plus failure-clear / disarm-persist / no-clobber regression tests).
+    turn (plus failure-clear / disarm-persist / no-clobber regression tests);
+    +90 from #3183: the idle-response-tail start offset is now clamped to
+    `>= shared.committed_relay_offset(channel_id)` (the watcher's confirmed
+    delivery watermark, #3017) at the single `spawn_claude_idle_response_tail_once`
+    choke point, so when the tmux watcher already relayed a turn's terminal
+    response the idle tail starts past it and cannot re-relay the same byte range
+    (the double-relay duplicate). When the watcher stopped / never covered the turn
+    the watermark is 0 (or lags), so the clamp is a no-op and the tail still relays
+    from the prompt-timestamp offset — the #3176 outage fallback is preserved
+    (plus clamp-up / outage-noop unit tests).
   - `src/services/discord/idle_recap.rs` (1881 prod lines; idle-recap card
     compose/post/clear surface, registered giant-file (#3036) — bugfix only
     outside an extraction plan. Crossed 1000 prod LoC with #3146 Part 1: the

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -1698,6 +1698,35 @@ fn normalize_transcript_fallback_offset(transcript_path: &Path, fallback_offset:
     }
 }
 
+/// #3183: clamp the idle-tail start offset to at least the watcher's committed
+/// delivery offset.
+///
+/// The idle-tail start offset is derived purely from the prompt timestamp (or
+/// the just-scanned prompt's `line_end_offset`), so it does NOT account for what
+/// the tmux watcher already delivered for this turn. When the watcher relayed a
+/// terminal response and THEN the idle tail spawns (e.g. an owner-arbitration /
+/// watcher-registration race lets the tail through before the
+/// `watcher_covers_current_transcript` suppression observes it), the tail
+/// re-relays the SAME byte range — the duplicate message in #3183.
+///
+/// `committed_relay_offset` is the single authoritative "JSONL byte offset
+/// (exclusive) past which the watcher has confirmed delivery" (#3017), in the
+/// SAME transcript-byte space as `start_offset`. Clamping
+/// `start_offset = max(start_offset, committed)` means the tail only ever scans
+/// output the watcher has NOT delivered:
+///   - watcher delivered up to X  → tail starts at >= X (no duplicate; if the
+///     watcher covered the whole turn the tail finds nothing to relay).
+///   - watcher stopped / not covering (the #3176 outage case) → `committed` is
+///     0 or below the timestamp offset, so the clamp is a no-op and the tail
+///     still relays from the timestamp offset (no relay-loss regression).
+///
+/// Returns the clamped offset; `committed == 0` (no confirmed delivery this
+/// process lifetime) leaves `start_offset` untouched.
+#[cfg(unix)]
+fn clamp_idle_tail_start_offset_to_committed(start_offset: u64, committed_offset: u64) -> u64 {
+    start_offset.max(committed_offset)
+}
+
 #[cfg(unix)]
 fn spawn_claude_idle_response_tail_once(
     shared: Arc<SharedData>,
@@ -1708,6 +1737,47 @@ fn spawn_claude_idle_response_tail_once(
     prompt_text: String,
     lease: ExternalInputRelayLease,
 ) -> bool {
+    // #3183: never re-relay output the watcher already committed delivery for.
+    // Both spawn paths (the observed-prompt path and the background poll loop)
+    // funnel through here, so clamping once at this choke point covers both.
+    //
+    // #3183 codex (CRITICAL outage-safety): `committed_relay_offset` is a
+    // PER-CHANNEL watermark, not per-transcript. A stale-high watermark left by a
+    // PREVIOUS wrapper (e.g. 5000) would, after a respawn whose fresh transcript
+    // starts near 0, clamp this tail forward and SKIP the new turn's response —
+    // exactly the relay-loss the idle tail exists to prevent. Run the SAME
+    // generation-aware regression resets the watcher / idle-JSONL sink run BEFORE
+    // consulting the watermark (session_relay_sink.rs): a truncated/respawned
+    // transcript (EOF below the watermark) or a wrapper-generation change resets
+    // the shared watermark to 0, so the fresh range is relayed. Only a watermark
+    // that genuinely covers THIS transcript's bytes then clamps (dedupe).
+    let transcript_len = std::fs::metadata(&transcript_path)
+        .map(|meta| meta.len())
+        .unwrap_or(0);
+    super::tmux::reset_stale_relay_watermark_if_output_regressed(
+        shared.as_ref(),
+        channel_id,
+        &tmux_session_name,
+        transcript_len,
+        "idle_response_tail",
+    );
+    super::tmux::reset_relay_watermark_on_generation_change(
+        shared.as_ref(),
+        channel_id,
+        &tmux_session_name,
+        "idle_response_tail",
+    );
+    let committed_offset = shared.committed_relay_offset(channel_id);
+    let start_offset = clamp_idle_tail_start_offset_to_committed(start_offset, committed_offset);
+    if committed_offset > 0 {
+        tracing::debug!(
+            channel_id = channel_id.get(),
+            tmux_session_name = %tmux_session_name,
+            committed_offset,
+            start_offset,
+            "Claude idle response tail start offset clamped to watcher committed delivery offset"
+        );
+    }
     {
         let mut active = CLAUDE_IDLE_RESPONSE_TAILS
             .lock()
@@ -6774,6 +6844,53 @@ mod tests {
             ),
             Some(recorded_turn2),
             "an old early-return guard (G1) must leave turn-2's newer lease (G2) intact"
+        );
+    }
+
+    // #3183: the idle-tail start offset must never fall below the watcher's
+    // committed delivery offset, so the tail cannot re-relay a byte range the
+    // tmux watcher already delivered (the double-relay regression).
+    #[cfg(unix)]
+    #[test]
+    fn idle_tail_start_offset_clamps_up_to_watcher_committed_offset() {
+        // Watcher already committed delivery up to byte 500. A prompt-timestamp
+        // derived start offset of 200 sits BELOW the committed end, so the tail
+        // would re-relay [200, 500) — exactly the duplicate. The clamp lifts the
+        // start to the committed end so nothing the watcher delivered is re-sent.
+        assert_eq!(
+            clamp_idle_tail_start_offset_to_committed(200, 500),
+            500,
+            "start offset below the watcher committed offset must clamp up to it"
+        );
+        // When the watcher covered the whole turn (committed == EOF-ish), the
+        // tail starts at the committed end and finds nothing new to relay.
+        assert_eq!(
+            clamp_idle_tail_start_offset_to_committed(500, 500),
+            500,
+            "equal start offset is unchanged (no re-relay, no over-skip)"
+        );
+    }
+
+    // #3183 outage fallback (#3176): when the watcher stopped / never covered the
+    // turn, `committed_relay_offset` is 0 (no confirmed delivery this process),
+    // so the clamp is a no-op and the tail still relays from the timestamp
+    // offset — no relay-loss regression.
+    #[cfg(unix)]
+    #[test]
+    fn idle_tail_start_offset_clamp_is_noop_when_watcher_not_covering() {
+        // committed == 0: watcher delivered nothing → the tail keeps its
+        // timestamp-derived start offset and relays the full turn.
+        assert_eq!(
+            clamp_idle_tail_start_offset_to_committed(200, 0),
+            200,
+            "no committed delivery must leave the timestamp start offset intact (outage fallback)"
+        );
+        // A committed offset that lags the timestamp offset (watcher delivered an
+        // OLDER region only) also must not pull the start backwards.
+        assert_eq!(
+            clamp_idle_tail_start_offset_to_committed(800, 300),
+            800,
+            "a lagging committed offset must not drag the start offset backwards"
         );
     }
 }


### PR DESCRIPTION
## 버그 (직접 검수 + 로그 확정)
동일 prose 응답이 두 message id로 **중복 릴레이**(예 09:29:00/09:29:27, 10:18:05/10:18:29). tmux_watcher가 터미널 응답을 릴레이한 뒤 `claude_idle_response_tail`이 같은 구간을 재릴레이. #3176이 idle-tail self-block을 제거한 뒤 watcher와 동시 릴레이되며 발생(간헐). 사용자가 반복 보고한 중복의 실제 원인.

## 수정 (tui_prompt_relay.rs only — 핫파일 미변경)
idle-tail의 `start_offset`을 **watcher가 commit한 delivery offset(`committed_relay_offset` = #3017 E-13 dedup authority) 이상으로 clamp** → watcher가 deliver한 바이트는 재릴레이 안 함. 단일 choke point(`spawn_claude_idle_response_tail_once`)에서 처리해 두 spawn 경로 모두 커버.

**outage-safety(codex 지적 반영)**: `committed_relay_offset`은 per-channel watermark라, 이전 wrapper의 stale-high 값이 새 transcript를 스킵할 수 있음. clamp 전에 session_relay_sink와 **동일한 generation/EOF regression reset 2개**(`reset_stale_relay_watermark_if_output_regressed` + `reset_relay_watermark_on_generation_change`)를 호출 → truncated/respawn/generation 변경 시 watermark를 0으로 리셋해 fresh 응답 보존. watcher 미커버 시 no-op → #3176 outage fallback 유지(릴레이 끊김 회귀 없음).

## 검증
- codex(gpt-5.5 xhigh) 2라운드: R1이 정확히 outage 회귀(stale watermark) 지적 → reset 추가 → **R2 GATE_PASS, Findings: none**(same-transcript dedup 유지 + stale watermark 시나리오 커버 확인)
- cargo fmt/check 통과, idle_tail_start_offset 테스트 2/2, maintenance freeze 동기화

Closes #3183

🤖 Generated with [Claude Code](https://claude.com/claude-code)