### PR TITLE
fix(#3182): clear 📬/➕ queue-pending reaction on dequeue (idle/restart kickoff path)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -440,12 +440,15 @@
     from #3126 stall-watchdog completed-idle false-positive guard tests; +88
     from #3169 stall-watchdog jsonl-mtime liveness guard + tests, closing the
     Death #1 force-clean false-positive on loop mid-write sessions).
-  - `src/services/discord/router/message_handler/intake_turn.rs` (3655 lines;
+  - `src/services/discord/router/message_handler/intake_turn.rs` (3719 lines;
     Discord message intake turn orchestration split from the router message
     handler; bugfix only outside a further extraction plan; +9 from #3082
     queued-only answer-flush gate (`is_queued_notice` on the two
     `send_intake_placeholder` call sites: `true` for the race-lost queued card,
-    `false` for the active-turn placeholder)).
+    `false` for the active-turn placeholder); +57 from #3182 normal-dequeue
+    queue-pending reaction cleanup (`queue_pending_reactions_to_clear` helper +
+    `remove_reaction_raw` at the `started==true` promotion point, removing the
+    stranded `📬`/`➕` so a processed message no longer shows `📬`+`✅`)).
   - `src/services/discord/router/message_handler/headless_turn.rs` (1316 lines;
     headless Discord turn launch/terminal-response path split from the router
     message handler; bugfix only outside a further extraction plan).

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -4697,6 +4697,29 @@ pub(super) async fn kickoff_idle_queues(
             channel_id
         );
 
+        // #3182 codex P1 (idle/restart kickoff leaks queue reactions): the live
+        // dispatch path (`DiscordGateway::dispatch_queued_turn`) clears the
+        // `📬`/`➕` queue-pending REACTIONS on every `source_message_ids` entry
+        // BEFORE re-entering `handle_text_message`, but this idle/restart
+        // kickoff entrypoint only drained the placeholder CARDS below — never
+        // the reactions. So a queued item promoted via `kickoff_idle_queues`
+        // (e.g. one whose visible queued card POST failed, leaving no
+        // `queued_placeholders` mapping for the head, or a merged group whose
+        // non-head sources never get a head hand-off) kept its `📬`/`➕`
+        // alongside the eventual `✅` — the queue version of the #3164 stuck
+        // marker. Mirror `dispatch_queued_turn`'s reaction drain here so both
+        // queued-dispatch entrypoints produce identical post-conditions
+        // regardless of any per-head mapping. `source_message_ids` collects
+        // every contributing message INCLUDING the head, and the removal is
+        // best-effort (`remove_reaction_raw` no-ops on a missing/already-cleared
+        // reaction), so this is safe for standalone, merged, and no-mapping
+        // cases alike. Background-trigger turns never reacted the user message,
+        // so a redundant remove on them is a harmless no-op.
+        for message_id in &intervention.source_message_ids {
+            formatting::remove_reaction_raw(&ctx.http, channel_id, *message_id, '📬').await;
+            formatting::remove_reaction_raw(&ctx.http, channel_id, *message_id, '➕').await;
+        }
+
         // codex review round-5 P2 (finding 3 — drain merged placeholders on
         // idle kickoff): when a merged-source intervention is restored from
         // the persisted queue (or scheduled by `schedule_deferred_idle_queue_kickoff`)

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -352,6 +352,54 @@ pub(super) fn queue_pending_reaction_for(outcome: super::super::MailboxEnqueueOu
     if outcome.merged { '➕' } else { '📬' }
 }
 
+/// #3182: add the queue-pending reaction (📬 standalone / ➕ merged) and
+/// self-heal the late-add race.
+///
+/// Every `intake_gate` enqueue path adds this reaction AFTER one or more
+/// Discord `await`s (placeholder POST, queued-card render, dispatch-guard
+/// bookkeeping). During that await the active turn can finish and the
+/// queued-dispatch entrypoints (`DiscordGateway::dispatch_queued_turn` /
+/// `kickoff_idle_queues`) can dequeue THIS message and run their 📬/➕ reaction
+/// drain BEFORE the add lands — stranding the reaction on an
+/// already-promoted/processed message (the gate-path analog of the
+/// `intake_turn.rs` Surface-3 self-heal, #2036). So after the add await
+/// resolves, re-snapshot the mailbox and strip the reaction if the message is
+/// no longer queued.
+///
+/// Validity uses SOURCE MEMBERSHIP — head id OR any `source_message_ids`
+/// entry — for BOTH standalone and merged. The head-only rule is correct only
+/// for placeholder-card OWNERSHIP (one card per active turn); a merged source
+/// `B` that is still queued under a newer head `C` keeps a valid `➕`, so a
+/// head-only check would wrongly remove it. `remove_reaction_raw` is
+/// best-effort (no-op when already cleared), and only the calling provider
+/// bot's own @me reaction is removed.
+async fn add_queue_pending_reaction_self_healing(
+    ctx: &serenity::Context,
+    data: &Data,
+    channel_id: serenity::ChannelId,
+    user_msg_id: serenity::MessageId,
+    emoji: char,
+) {
+    add_reaction(&ctx.http, channel_id, user_msg_id, emoji).await;
+    let still_queued = {
+        let snapshot = mailbox_snapshot(&data.shared, channel_id).await;
+        snapshot.intervention_queue.iter().any(|intervention| {
+            intervention.message_id == user_msg_id
+                || intervention.source_message_ids.contains(&user_msg_id)
+        })
+    };
+    if !still_queued {
+        super::super::formatting::remove_reaction_raw(&ctx.http, channel_id, user_msg_id, emoji)
+            .await;
+        let ts = chrono::Local::now().format("%H:%M:%S");
+        tracing::info!(
+            "  [{ts}] 🔁 RACE: queue-pending {emoji} reacted after dequeue promotion (channel {}, msg {}); removed stale reaction",
+            channel_id,
+            user_msg_id
+        );
+    }
+}
+
 /// #1446 Layer 2 — load the thread's persisted inflight state and report
 /// whether its `updated_at` is older than `INFLIGHT_STALENESS_THRESHOLD_SECS`.
 /// Returns `false` when no state file exists (nothing to clean) or when
@@ -2290,8 +2338,9 @@ pub(in crate::services::discord) async fn handle_event(
                                 resolved_voice_announcement.clone(),
                             )
                             .await;
-                            add_reaction(
-                                &ctx.http,
+                            add_queue_pending_reaction_self_healing(
+                                ctx,
+                                data,
                                 channel_id,
                                 new_message.id,
                                 queue_pending_reaction_for(outcome),
@@ -2353,8 +2402,9 @@ pub(in crate::services::discord) async fn handle_event(
                         "  [{ts}] 📬 DISPATCH-GUARD: queued dispatch message in channel {} (active turn in progress)",
                         channel_id
                     );
-                    add_reaction(
-                        &ctx.http,
+                    add_queue_pending_reaction_self_healing(
+                        ctx,
+                        data,
                         channel_id,
                         new_message.id,
                         queue_pending_reaction_for(outcome),
@@ -2435,9 +2485,12 @@ pub(in crate::services::discord) async fn handle_event(
                     .await;
                 }
 
-                // React 📬 (standalone queue head) or ➕ (merged into previous head).
-                add_reaction(
-                    &ctx.http,
+                // React 📬 (standalone queue head) or ➕ (merged into previous
+                // head), self-healing against the #3182 late-add race (see
+                // `add_queue_pending_reaction_self_healing`).
+                add_queue_pending_reaction_self_healing(
+                    ctx,
+                    data,
                     channel_id,
                     new_message.id,
                     queue_pending_reaction_for(outcome),
@@ -2556,8 +2609,9 @@ pub(in crate::services::discord) async fn handle_event(
                 );
 
                 // React 📬 (standalone) or ➕ (merged into previous queue head).
-                add_reaction(
-                    &ctx.http,
+                add_queue_pending_reaction_self_healing(
+                    ctx,
+                    data,
                     channel_id,
                     new_message.id,
                     queue_pending_reaction_for(outcome),
@@ -2647,8 +2701,9 @@ pub(in crate::services::discord) async fn handle_event(
                         "  [{ts}] 📬 IDLE-QUEUE: queued message from [{user_name}] in channel {} behind pending backlog",
                         channel_id
                     );
-                    add_reaction(
-                        &ctx.http,
+                    add_queue_pending_reaction_self_healing(
+                        ctx,
+                        data,
                         channel_id,
                         new_message.id,
                         queue_pending_reaction_for(outcome),

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -1,5 +1,23 @@
 use super::*;
 
+/// #3182: the queue-pending reaction(s) to strip from a user message when its
+/// queued turn is dequeued and promoted to active.
+///
+/// The intake gate reacts a queued user message with `📬` (standalone queue
+/// head) or `➕` (merged into a previous head) via `queue_pending_reaction_for`.
+/// At the normal dequeue/promotion point (`handle_text_message`, `started==true`)
+/// we only know the head `user_msg_id`, not whether it carried `📬` or `➕`, so
+/// we attempt to remove BOTH candidates. Removing a reaction that was never
+/// added is a harmless no-op, and this mirrors the existing live-dispatch
+/// cleanup in `DiscordGateway::dispatch_queued_turn` (gateway.rs) and the
+/// queue-exit drain (mod.rs), both of which remove `📬` and `➕` together.
+///
+/// Returned as a fixed array so the emoji set is unit-testable without driving
+/// the full async intake path.
+pub(super) const fn queue_pending_reactions_to_clear() -> [char; 2] {
+    ['📬', '➕']
+}
+
 pub(super) async fn send_restore_notification(
     shared: &Arc<SharedData>,
     fallback_http: &Arc<serenity::Http>,
@@ -1673,6 +1691,51 @@ pub(in crate::services::discord) async fn handle_text_message(
     } else {
         None
     };
+
+    // #3182: the normal dequeue path removed the `📬 메시지 대기 중` placeholder
+    // CARD above (`remove_queued_placeholder`) but historically left the
+    // queue-pending REACTION (`📬` standalone / `➕` merged) on the user message,
+    // so a processed message kept showing `📬`+`✅` together — the queue version
+    // of the #3164 stuck-hourglass. The reaction was added in `intake_gate` via
+    // the provider bot's `ctx.http`, which is the SAME @me identity as the `http`
+    // available here (kickoff passes `&ctx.http`, the live dispatch passes
+    // `&live_turn.ctx.http`; both resolve to `cached_serenity_ctx` = the provider
+    // bot — see runtime_bootstrap.rs `cached_serenity_ctx.set(ctx)`), so this
+    // `http` can actually remove the bot's own reaction (Discord remove-reaction
+    // only clears the calling bot's @me reaction).
+    //
+    // AUTHORITATIVE cleanup lives at the two queued-dispatch ENTRYPOINTS, which
+    // each clear `📬`/`➕` on EVERY `source_message_ids` entry (head + merged
+    // tails) BEFORE re-entering `handle_text_message`:
+    //   • live dispatch — `DiscordGateway::dispatch_queued_turn` (gateway.rs)
+    //   • idle/restart kickoff — `kickoff_idle_queues` (mod.rs, #3182 codex P1)
+    // That entrypoint pass covers the merged-tail and no-mapping cases the
+    // per-head hand-off cannot see. This block is an idempotent HEAD-level
+    // belt-and-suspenders for the dispatch hand-off (where a `queued_placeholders`
+    // mapping for the head was consumed just above): it re-asserts the head is
+    // clear even if the message reached here by some path other than the two
+    // entrypoints. Gate: only when THIS message actually held a queued
+    // placeholder mapping (`queued_placeholder_handoff.is_some()`), and not for
+    // background-trigger turns (#796 — those keep their info-only placeholder and
+    // never reacted the user message). A redundant remove is a no-op, so this
+    // composes safely with the entrypoint drains.
+    if queued_placeholder_handoff.is_some() && !turn_kind.is_background_trigger() {
+        for emoji in queue_pending_reactions_to_clear() {
+            super::super::super::formatting::remove_reaction_raw(
+                http,
+                channel_id,
+                user_msg_id,
+                emoji,
+            )
+            .await;
+        }
+        let ts = chrono::Local::now().format("%H:%M:%S");
+        tracing::info!(
+            "  [{ts}] 📭 DEQUEUE: cleared queue-pending reaction(s) on promoted message (channel {}, msg {})",
+            channel_id,
+            user_msg_id
+        );
+    }
 
     // codex review P1/P2: when this turn lost the race, drive the entire
     // race-loss path (placeholder POST, mapping insert, enqueue, idle-drain
@@ -3846,5 +3909,54 @@ mod voice_route_tests {
 
         pool.close().await;
         pg_db.drop().await;
+    }
+}
+
+#[cfg(test)]
+mod queue_pending_reaction_clear_tests {
+    use super::*;
+
+    /// #3182: the dequeue cleanup must attempt to remove BOTH queue-pending
+    /// reactions — `📬` (standalone head) and `➕` (merged) — because the
+    /// promotion point only knows the head message id, not which emoji it
+    /// carried. This guards against a regression that drops one (which would
+    /// re-strand the other variant, as in the original bug).
+    #[test]
+    fn clears_both_standalone_and_merged_queue_reactions() {
+        let emojis = queue_pending_reactions_to_clear();
+        assert!(
+            emojis.contains(&'📬'),
+            "standalone queue-head 📬 must be cleared on dequeue"
+        );
+        assert!(
+            emojis.contains(&'➕'),
+            "merged queue ➕ must be cleared on dequeue"
+        );
+        assert_eq!(
+            emojis.len(),
+            2,
+            "exactly the two intake-gate queue-pending emojis are cleared"
+        );
+    }
+
+    /// The cleared set must match exactly what the intake gate ADDS via
+    /// `queue_pending_reaction_for`, so no queued message can be reacted with an
+    /// emoji the dequeue path will not later remove.
+    #[test]
+    fn cleared_set_covers_every_intake_gate_queue_reaction() {
+        let cleared = queue_pending_reactions_to_clear();
+        for merged in [false, true] {
+            let added = crate::services::discord::router::intake_gate::queue_pending_reaction_for(
+                crate::services::discord::MailboxEnqueueOutcome {
+                    enqueued: true,
+                    merged,
+                    ..Default::default()
+                },
+            );
+            assert!(
+                cleared.contains(&added),
+                "intake-gate add emoji {added:?} (merged={merged}) must be in the dequeue clear set"
+            );
+        }
     }
 }


### PR DESCRIPTION
## #3182 — stuck 📬 on processed (dequeued) messages

A queued message kept its `📬`(standalone) / `➕`(merged) queue-pending reaction even after it was dequeued and processed, so it showed `📬`+`✅` together — the queue version of the #3164 stuck-hourglass.

### Root cause
The live dispatch path (`DiscordGateway::dispatch_queued_turn`) clears the queue reactions on **every** `source_message_ids` entry before re-entering `handle_text_message`. The **idle/restart kickoff** entrypoint (`kickoff_idle_queues`) only drained the placeholder *cards*, never the *reactions* — so any item promoted via kickoff (including ones whose visible queued-card POST failed → no head mapping, and merged groups' non-head sources) leaked the reaction.

### Fix
- `kickoff_idle_queues` (mod.rs): mirror `dispatch_queued_turn`'s reaction drain — remove `📬`/`➕` on every `source_message_ids` entry (head + merged tails) before dispatch. Idempotent best-effort; background-trigger turns no-op.
- `intake_turn.rs`: the per-head cleanup is reframed as an idempotent belt-and-suspenders; the authoritative all-source clear now lives at both queued-dispatch entrypoints (gateway + kickoff), matching the existing `drain_merged_queued_placeholders` symmetry.

### Verification
- `cargo check --lib` clean; `queue_pending_reaction_clear_tests` (2) pass.
- agent-maintenance line-count gate synced (intake_turn.rs 3712→3719) and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)