### PR TITLE
refactor(#3038): extract review-decision leaf transactions into services::review_decision

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -665,6 +665,7 @@ src/
 │   ├── qwen_tmux_wrapper.rs
 │   ├── remote_stub.rs
 │   ├── retrospectives.rs
+│   ├── review_decision.rs
 │   ├── service_error.rs
 │   ├── session_backend.rs
 │   ├── session_forwarding.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -569,7 +569,7 @@
   - `src/server/routes/docs.rs` (5880 lines).
   - `src/server/routes/escalation.rs` (1733 lines).
   - `src/server/routes/meetings.rs` (1708 lines).
-  - `src/server/routes/review_verdict/decision_route.rs` (4491 lines).
+  - `src/server/routes/review_verdict/decision_route.rs` (4404 lines).
   - `src/server/routes/{agents,agents_crud,agents_setup,v1,resume,
     dispatches/thread_reuse}.rs` (all 1000+ production lines).
 - active_callsite_coverage: legacy_db helper coverage tracked separately —

--- a/src/server/routes/review_verdict/decision_route.rs
+++ b/src/server/routes/review_verdict/decision_route.rs
@@ -2034,36 +2034,13 @@ async fn prepare_dispute_review_entry_pg_first(
     state: &AppState,
     card_id: &str,
 ) -> Result<(), String> {
+    // #3038 A1/route_srp: pool extraction stays in the route layer; the tx
+    // orchestration lives in `services::review_decision`. Error emission and
+    // tx boundaries are preserved 1:1.
     let pool = state
         .pg_pool_ref()
         .ok_or_else(|| "postgres pool unavailable for dispute review-entry".to_string())?;
-    let mut tx = pool
-        .begin()
-        .await
-        .map_err(|error| format!("begin dispute review-entry tx for {card_id}: {error}"))?;
-    let dispute_intents = [
-        crate::engine::transition::TransitionIntent::SetReviewStatus {
-            card_id: card_id.to_string(),
-            review_status: Some("reviewing".to_string()),
-        },
-        crate::engine::transition::TransitionIntent::SyncReviewState {
-            card_id: card_id.to_string(),
-            state: "reviewing".to_string(),
-        },
-    ];
-    for intent in &dispute_intents {
-        crate::engine::transition_executor_pg::execute_pg_transition_intent(&mut tx, intent)
-            .await?;
-    }
-    sqlx::query("UPDATE kanban_cards SET review_entered_at = NOW() WHERE id = $1")
-        .bind(card_id)
-        .execute(&mut *tx)
-        .await
-        .map_err(|error| format!("set review_entered_at for {card_id}: {error}"))?;
-    tx.commit()
-        .await
-        .map_err(|error| format!("commit dispute review-entry tx for {card_id}: {error}"))?;
-    Ok(())
+    crate::services::review_decision::prepare_dispute_review_entry(pool, card_id).await
 }
 
 async fn finalize_accept_cleanup_pg_first(
@@ -2071,32 +2048,12 @@ async fn finalize_accept_cleanup_pg_first(
     card_id: &str,
     clear_review_status: bool,
 ) -> Result<(), String> {
+    // #3038 A1/route_srp: see `prepare_dispute_review_entry_pg_first`.
     let Some(pool) = state.pg_pool_ref() else {
         return Err("postgres pool unavailable for accept cleanup".to_string());
     };
-    let mut tx = pool
-        .begin()
+    crate::services::review_decision::finalize_accept_cleanup(pool, card_id, clear_review_status)
         .await
-        .map_err(|error| format!("begin accept cleanup tx for {card_id}: {error}"))?;
-    if clear_review_status {
-        crate::engine::transition_executor_pg::execute_pg_transition_intent(
-            &mut tx,
-            &crate::engine::transition::TransitionIntent::SetReviewStatus {
-                card_id: card_id.to_string(),
-                review_status: None,
-            },
-        )
-        .await?;
-    }
-    sqlx::query("UPDATE kanban_cards SET suggestion_pending_at = NULL WHERE id = $1")
-        .bind(card_id)
-        .execute(&mut *tx)
-        .await
-        .map_err(|error| format!("clear suggestion_pending_at for {card_id}: {error}"))?;
-    tx.commit()
-        .await
-        .map_err(|error| format!("commit accept cleanup tx for {card_id}: {error}"))?;
-    Ok(())
 }
 
 async fn commit_belongs_to_card_issue_pg_first(
@@ -2136,55 +2093,11 @@ async fn cancel_dispatch_pg_first(
 }
 
 async fn dismiss_review_cleanup_pg_first(state: &AppState, card_id: &str) -> Result<(), String> {
+    // #3038 A1/route_srp: see `prepare_dispute_review_entry_pg_first`.
     let Some(pool) = state.pg_pool_ref() else {
         return Err("postgres pool unavailable for dismiss cleanup".to_string());
     };
-    let mut tx = pool
-        .begin()
-        .await
-        .map_err(|error| format!("begin dismiss cleanup tx for {card_id}: {error}"))?;
-
-    let dispatch_ids: Vec<String> = sqlx::query_scalar(
-        "SELECT id FROM task_dispatches
-         WHERE kanban_card_id = $1
-           AND status IN ('pending', 'dispatched')
-           AND dispatch_type IN ('review', 'review-decision')",
-    )
-    .bind(card_id)
-    .fetch_all(&mut *tx)
-    .await
-    .map_err(|error| format!("load dismiss cleanup dispatches for {card_id}: {error}"))?;
-
-    for dispatch_id in &dispatch_ids {
-        crate::dispatch::cancel_dispatch_and_reset_auto_queue_on_pg_tx(&mut tx, dispatch_id, None)
-            .await?;
-    }
-
-    let clear_review_status = crate::engine::transition::TransitionIntent::SetReviewStatus {
-        card_id: card_id.to_string(),
-        review_status: None,
-    };
-    crate::engine::transition_executor_pg::execute_pg_transition_intent(
-        &mut tx,
-        &clear_review_status,
-    )
-    .await?;
-
-    sqlx::query(
-        "UPDATE kanban_cards
-         SET channel_thread_map = NULL,
-             active_thread_id = NULL
-         WHERE id = $1",
-    )
-    .bind(card_id)
-    .execute(&mut *tx)
-    .await
-    .map_err(|error| format!("clear dismiss thread mappings for {card_id}: {error}"))?;
-
-    tx.commit()
-        .await
-        .map_err(|error| format!("commit dismiss cleanup tx for {card_id}: {error}"))?;
-    Ok(())
+    crate::services::review_decision::dismiss_review_cleanup(pool, card_id).await
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -59,6 +59,7 @@ pub mod qwen;
 pub mod qwen_tmux_wrapper;
 pub mod remote_stub;
 pub mod retrospectives;
+pub mod review_decision;
 pub mod routines;
 pub mod service_error;
 pub mod session_backend;

--- a/src/services/review_decision.rs
+++ b/src/services/review_decision.rs
@@ -1,0 +1,140 @@
+//! Review-decision domain logic extracted from the
+//! `/api/review-decision` HTTP route (#3038 god-function decomposition,
+//! A1 / route_srp).
+//!
+//! These are the self-contained, single-transaction cleanup/state-machine
+//! operations that the `submit_review_decision` handler and its phase helpers
+//! invoke after a decision is resolved. They were lifted verbatim out of
+//! `src/server/routes/review_verdict/decision_route.rs`; the only change is
+//! that the Postgres pool is now threaded **explicitly** as a parameter rather
+//! than reached through HTTP request state (`AppState::pg_pool_ref`). The thin
+//! `*_pg_first` wrappers that remain in the route module perform the pool
+//! extraction and preserve the exact "postgres pool unavailable" error
+//! emission, so transaction boundaries, statement ordering, and behavior are
+//! preserved 1:1.
+
+use sqlx::PgPool;
+
+/// Open a card's review-decision dispute review-entry: flip review status to
+/// `reviewing`, sync the canonical review state, and stamp `review_entered_at`.
+///
+/// Single transaction; statement order preserved exactly from the original
+/// `prepare_dispute_review_entry_pg_first` body.
+pub async fn prepare_dispute_review_entry(pool: &PgPool, card_id: &str) -> Result<(), String> {
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|error| format!("begin dispute review-entry tx for {card_id}: {error}"))?;
+    let dispute_intents = [
+        crate::engine::transition::TransitionIntent::SetReviewStatus {
+            card_id: card_id.to_string(),
+            review_status: Some("reviewing".to_string()),
+        },
+        crate::engine::transition::TransitionIntent::SyncReviewState {
+            card_id: card_id.to_string(),
+            state: "reviewing".to_string(),
+        },
+    ];
+    for intent in &dispute_intents {
+        crate::engine::transition_executor_pg::execute_pg_transition_intent(&mut tx, intent)
+            .await?;
+    }
+    sqlx::query("UPDATE kanban_cards SET review_entered_at = NOW() WHERE id = $1")
+        .bind(card_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|error| format!("set review_entered_at for {card_id}: {error}"))?;
+    tx.commit()
+        .await
+        .map_err(|error| format!("commit dispute review-entry tx for {card_id}: {error}"))?;
+    Ok(())
+}
+
+/// Accept cleanup: optionally clear the card's review status and always clear
+/// `suggestion_pending_at`.
+///
+/// Single transaction; statement order preserved exactly from the original
+/// `finalize_accept_cleanup_pg_first` body.
+pub async fn finalize_accept_cleanup(
+    pool: &PgPool,
+    card_id: &str,
+    clear_review_status: bool,
+) -> Result<(), String> {
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|error| format!("begin accept cleanup tx for {card_id}: {error}"))?;
+    if clear_review_status {
+        crate::engine::transition_executor_pg::execute_pg_transition_intent(
+            &mut tx,
+            &crate::engine::transition::TransitionIntent::SetReviewStatus {
+                card_id: card_id.to_string(),
+                review_status: None,
+            },
+        )
+        .await?;
+    }
+    sqlx::query("UPDATE kanban_cards SET suggestion_pending_at = NULL WHERE id = $1")
+        .bind(card_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|error| format!("clear suggestion_pending_at for {card_id}: {error}"))?;
+    tx.commit()
+        .await
+        .map_err(|error| format!("commit accept cleanup tx for {card_id}: {error}"))?;
+    Ok(())
+}
+
+/// Dismiss cleanup: cancel live review / review-decision dispatches, clear the
+/// card's review status, and drop its thread mappings — all atomically.
+///
+/// Single transaction; statement order preserved exactly from the original
+/// `dismiss_review_cleanup_pg_first` body.
+pub async fn dismiss_review_cleanup(pool: &PgPool, card_id: &str) -> Result<(), String> {
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|error| format!("begin dismiss cleanup tx for {card_id}: {error}"))?;
+
+    let dispatch_ids: Vec<String> = sqlx::query_scalar(
+        "SELECT id FROM task_dispatches
+         WHERE kanban_card_id = $1
+           AND status IN ('pending', 'dispatched')
+           AND dispatch_type IN ('review', 'review-decision')",
+    )
+    .bind(card_id)
+    .fetch_all(&mut *tx)
+    .await
+    .map_err(|error| format!("load dismiss cleanup dispatches for {card_id}: {error}"))?;
+
+    for dispatch_id in &dispatch_ids {
+        crate::dispatch::cancel_dispatch_and_reset_auto_queue_on_pg_tx(&mut tx, dispatch_id, None)
+            .await?;
+    }
+
+    let clear_review_status = crate::engine::transition::TransitionIntent::SetReviewStatus {
+        card_id: card_id.to_string(),
+        review_status: None,
+    };
+    crate::engine::transition_executor_pg::execute_pg_transition_intent(
+        &mut tx,
+        &clear_review_status,
+    )
+    .await?;
+
+    sqlx::query(
+        "UPDATE kanban_cards
+         SET channel_thread_map = NULL,
+             active_thread_id = NULL
+         WHERE id = $1",
+    )
+    .bind(card_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|error| format!("clear dismiss thread mappings for {card_id}: {error}"))?;
+
+    tx.commit()
+        .await
+        .map_err(|error| format!("commit dismiss cleanup tx for {card_id}: {error}"))?;
+    Ok(())
+}


### PR DESCRIPTION
#3038 god-function decomposition — incremental slice.

`submit_review_decision` was already largely decomposed (thin ~80-line handler + ~30 helpers). This extracts the 3 most self-contained single-transaction leaf operations (`prepare_dispute_review_entry`, `finalize_accept_cleanup`, `dismiss_review_cleanup`) out of the route file into `services::review_decision`, leaving thin pool-extraction wrappers. SQL/tx-boundaries/error-strings byte-identical; advisory-lock & idempotency logic untouched. decision_route.rs 4491→4404.

codex GATE_PASS. cargo check clean, `cargo test --lib review` 50 pass.

Note: backflow/larger orchestrator extraction deferred as a separate reviewable pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)