### PR TITLE
fix(#3174): relay re-checks terminal completion after anchor — close lease/anchor ⏳-stranding race without timing waits

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -306,7 +306,7 @@
     (incl. id==0 external/injected) NOT adopted/edited, in-range id==0
     watcher-direct STILL adopts+edits (over-suppression guard), and in-range id!=0
     unchanged.
-  - `src/services/discord/tui_prompt_relay.rs` (4522 lines; SSH-direct TUI
+  - `src/services/discord/tui_prompt_relay.rs` (4656 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +4 from #3167: the self-paced TUI loop relay
     starts its synthetic turn with `ActiveTurnKind::Background` so a queued user
@@ -401,7 +401,16 @@
     (the double-relay duplicate). When the watcher stopped / never covered the turn
     the watermark is 0 (or lags), so the clamp is a no-op and the tail still relays
     from the prompt-timestamp offset — the #3176 outage fallback is preserved
-    (plus clamp-up / outage-noop unit tests).
+    (plus clamp-up / outage-noop unit tests). +134 from #3174 (ported from #3164
+    codex R3): relay-side re-check closes the lease/anchor ordering race without a
+    timing wait — `relay_observed_prompt` snapshots `committed_relay_offset` BEFORE
+    the notify-post and re-reads it AFTER `record_prompt_anchor`; a strict increase
+    (`relay_watcher_overtook_anchor_record`) proves the watcher committed + ran its
+    no-op anchor gate before the anchor was findable, so
+    `relay_recheck_complete_own_anchor_if_watcher_overtook` removes this turn's own
+    `⏳`, posts `✅`, and clears the shared slot only when it still points at this
+    turn's own anchor id (newer same-(provider,tmux,channel) turn keeps its `⏳`)
+    (plus overtake-detector / no-double-removal / own-id-scoped-clear unit tests).
   - `src/services/discord/idle_recap.rs` (1881 prod lines; idle-recap card
     compose/post/clear surface, registered giant-file (#3036) — bugfix only
     outside an extraction plan. Crossed 1000 prod LoC with #3146 Part 1: the

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -306,7 +306,7 @@
     (incl. id==0 external/injected) NOT adopted/edited, in-range id==0
     watcher-direct STILL adopts+edits (over-suppression guard), and in-range id!=0
     unchanged.
-  - `src/services/discord/tui_prompt_relay.rs` (4656 lines; SSH-direct TUI
+  - `src/services/discord/tui_prompt_relay.rs` (4745 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +4 from #3167: the self-paced TUI loop relay
     starts its synthetic turn with `ActiveTurnKind::Background` so a queued user
@@ -411,6 +411,19 @@
     `⏳`, posts `✅`, and clears the shared slot only when it still points at this
     turn's own anchor id (newer same-(provider,tmux,channel) turn keeps its `⏳`)
     (plus overtake-detector / no-double-removal / own-id-scoped-clear unit tests).
+    +89 from #3193 codex GATE_FAIL fix: the overtake TRIGGER is now bound to THIS
+    turn's identity, not the bare channel-wide watermark. `committed_relay_offset`
+    is per-CHANNEL, so an unrelated/different-turn commit in the same channel during
+    the relay window can strict-increase it → the bare signal mis-fired
+    (false-positive ⏳-removal/✅ for a turn whose own anchor was NOT overtaken).
+    `relay_watcher_overtook_anchor_record` now ALSO requires
+    `own_external_input_lease_consumed` (`external_input_lease_was_consumed`/
+    `relay_own_external_input_lease_consumed`): the watcher clears a turn's
+    external-input lease BY its unique `generation` exactly when it commits THAT
+    turn, so "our recorded generation is no longer the present lease" proves the
+    committing turn was ours. Unrelated commit → watermark up but our generation
+    still present → no trigger (plus unrelated-same-channel-commit false-positive
+    test + own-generation lease-consumption predicate test).
   - `src/services/discord/idle_recap.rs` (1881 prod lines; idle-recap card
     compose/post/clear surface, registered giant-file (#3036) — bugfix only
     outside an extraction plan. Crossed 1000 prod LoC with #3146 Part 1: the

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -306,7 +306,7 @@
     (incl. id==0 external/injected) NOT adopted/edited, in-range id==0
     watcher-direct STILL adopts+edits (over-suppression guard), and in-range id!=0
     unchanged.
-  - `src/services/discord/tui_prompt_relay.rs` (4745 lines; SSH-direct TUI
+  - `src/services/discord/tui_prompt_relay.rs` (4767 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +4 from #3167: the self-paced TUI loop relay
     starts its synthetic turn with `ActiveTurnKind::Background` so a queued user

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -535,6 +535,13 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
     // `⏳` ourselves, with no timing wait. The non-race case (watcher not yet
     // committed) leaves the watermark unchanged → we no-op and the watcher does
     // the normal removal later.
+    //
+    // #3193 codex GATE_FAIL fix: the watermark is per-CHANNEL, so a strict increase
+    // can also be produced by an UNRELATED / different-turn commit in the same
+    // channel during this window. The watermark snapshot is therefore NOT sufficient
+    // on its own to conclude OUR anchor was overtaken — the post-anchor re-check
+    // ALSO requires that THIS turn's own external-input lease was consumed (see the
+    // re-check site below), which the watcher does exactly when it commits OUR turn.
     let committed_relay_offset_before_relay = shared.committed_relay_offset(channel_id);
     let mut lease = record_observed_external_turn_lease(shared, &prompt, channel_id);
     // #3041 P1-4 codex: arm an early-return RAII guard the instant the lease is
@@ -831,9 +838,26 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             // identity). Re-reading the watermark here (post-anchor) catches a
             // watcher that committed + ran its no-op gate during the `⏳` add I/O.
             let committed_relay_offset_after_anchor = shared.committed_relay_offset(channel_id);
+            // #3193 codex GATE_FAIL fix: bind the overtake TRIGGER to THIS turn's
+            // identity, not the bare channel-wide watermark. The watermark is
+            // per-channel and advances on ANY commit in the window (an unrelated /
+            // different-turn commit included). The watcher consumes THIS turn's
+            // external-input lease (clearing it by its UNIQUE `generation`) EXACTLY
+            // when it commits THIS turn — so "our recorded lease generation is no
+            // longer the present lease" proves the commit that advanced the
+            // watermark was OURS. An unrelated commit advances the watermark but
+            // leaves our lease generation present → `own_lease_consumed == false` →
+            // no false-positive trigger.
+            let own_external_input_lease_consumed = relay_own_external_input_lease_consumed(
+                &prompt.provider,
+                &prompt.tmux_session_name,
+                channel_id,
+                lease.generation,
+            );
             if relay_watcher_overtook_anchor_record(
                 committed_relay_offset_before_relay,
                 committed_relay_offset_after_anchor,
+                own_external_input_lease_consumed,
             ) {
                 relay_recheck_complete_own_anchor_if_watcher_overtook(
                     command_http,
@@ -4066,19 +4090,84 @@ pub(super) async fn complete_tui_direct_anchor_lifecycle_for_inflight(
     Some(anchor)
 }
 
-/// #3174 (ported from #3164 codex R3): pure decision for whether the tmux watcher
-/// already committed a terminal turn (advancing `committed_relay_offset`) AND ran
-/// its anchor-completion gate BEFORE `relay_observed_prompt` finished recording the
-/// anchor — i.e. the watcher overtook the relay and its no-op gate left the `⏳`
-/// stranded. The watermark is monotonic (CAS advance), so a strict increase between
-/// the pre-relay snapshot and the post-anchor re-read is the overtake signal. Equal
-/// (the common case: watcher not yet committed) → no overtake → the relay no-ops
-/// and the watcher removes the `⏳` normally on its own later completion pass.
+/// #3174 (ported from #3164 codex R3; tightened per #3193 codex GATE_FAIL): pure
+/// decision for whether the tmux watcher already committed THIS turn's terminal
+/// output AND ran (and no-op'd) its anchor-completion gate BEFORE
+/// `relay_observed_prompt` finished recording the anchor — i.e. the watcher
+/// overtook THIS relay and left THIS turn's `⏳` stranded.
+///
+/// #3193 codex (the sole GATE_FAIL blocker): a bare channel-wide
+/// `committed_relay_offset` strict-increase is NOT a per-turn signal. The watermark
+/// is per-CHANNEL, advanced by ANY committed output in the channel during this relay
+/// window — including an UNRELATED / different-turn commit that never touched THIS
+/// turn's anchor. Triggering on the watermark alone therefore mis-fires
+/// (false-positive): it would remove `⏳` / post `✅` for a turn whose own anchor was
+/// NOT overtaken. (The downstream ACTION is already correctly scoped to this turn's
+/// own `anchor_message.id` — codex confirmed the anti-aliasing — so the breadth was
+/// purely in this TRIGGER.)
+///
+/// The fix binds the trigger to THIS turn's identity via its own external-input
+/// lease. The watcher consumes a turn's lease EXACTLY when it commits that turn's
+/// terminal output: it clears the lease by its UNIQUE `generation`
+/// (`clear_external_input_relay_lease_if_generation_matches`) on the SAME inline
+/// commit pass that advances `confirmed_end_offset` and runs the no-op
+/// anchor-completion gate. So the precise overtake signal for THIS turn is BOTH:
+///   1. the watermark strictly increased (a commit happened in the window), AND
+///   2. `own_external_input_lease_consumed` — THIS turn's recorded lease generation
+///      is no longer the present lease, i.e. the committing turn was OURS, not an
+///      unrelated same-channel turn.
+/// An unrelated commit advances the watermark (1) but leaves our lease generation
+/// present (2 is false) → no trigger → no false-positive. Equal watermark (the
+/// common case: watcher not yet committed) → no overtake regardless of (2).
 fn relay_watcher_overtook_anchor_record(
     committed_before_relay: u64,
     committed_after_anchor: u64,
+    own_external_input_lease_consumed: bool,
 ) -> bool {
-    committed_after_anchor > committed_before_relay
+    committed_after_anchor > committed_before_relay && own_external_input_lease_consumed
+}
+
+/// #3193 codex GATE_FAIL fix: pure decision for whether THIS turn's own
+/// external-input lease (identified by its UNIQUE recorded `generation`) has been
+/// consumed — i.e. is no longer the lease currently present for
+/// `(provider, tmux_session, channel)`. `present_generation` is the generation of
+/// the lease the state map holds NOW (the post-anchor re-read), or `None` if no
+/// lease is present.
+///
+/// "Consumed" is true when the present lease is gone (`None`) OR carries a
+/// DIFFERENT generation than ours — both mean the watcher (or a superseding turn)
+/// cleared/replaced the exact lease THIS turn recorded. The watcher clears a
+/// turn's lease by its generation EXACTLY on the commit pass for that turn, so this
+/// is the per-turn binding that distinguishes our own overtake from an unrelated
+/// same-channel commit (which leaves our generation present → returns `false`).
+/// `own_generation == UNRECORDED` (0) means our lease was never recorded, so there
+/// is nothing of ours to have been consumed → `false`.
+fn external_input_lease_was_consumed(own_generation: u64, present_generation: Option<u64>) -> bool {
+    if own_generation
+        == crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED
+    {
+        return false;
+    }
+    present_generation != Some(own_generation)
+}
+
+/// #3193 codex GATE_FAIL fix: runtime adapter that reads the lease state map NOW
+/// and applies [`external_input_lease_was_consumed`] against THIS turn's recorded
+/// `own_generation`. Returns `true` iff the watcher already consumed THIS turn's
+/// own external-input lease — the per-turn binding for the overtake trigger.
+fn relay_own_external_input_lease_consumed(
+    provider: &str,
+    tmux_session_name: &str,
+    channel_id: ChannelId,
+    own_generation: u64,
+) -> bool {
+    let present_generation = crate::services::tui_prompt_dedupe::external_input_relay_lease(
+        provider,
+        tmux_session_name,
+        channel_id.get(),
+    )
+    .map(|lease| lease.generation);
+    external_input_lease_was_consumed(own_generation, present_generation)
 }
 
 /// #3174 (ported from #3164 codex R3): relay-side completion that closes the
@@ -5596,23 +5685,71 @@ mod tests {
     // `⏳` itself later.
     #[test]
     fn relay_rechecks_when_watcher_committed_before_anchor_was_recorded() {
-        // Watermark advanced between the pre-relay snapshot and the post-anchor
-        // re-read → the watcher already committed a terminal turn and ran its
-        // no-op gate before our anchor was findable → relay must clean up its `⏳`.
-        assert!(relay_watcher_overtook_anchor_record(100, 240));
-        assert!(relay_watcher_overtook_anchor_record(0, 1));
+        // True positive: the watermark advanced between the pre-relay snapshot and
+        // the post-anchor re-read AND THIS turn's own external-input lease was
+        // consumed by that commit → the committing turn was OURS → the watcher ran
+        // its no-op gate before our anchor was findable → relay must clean up `⏳`.
+        assert!(relay_watcher_overtook_anchor_record(100, 240, true));
+        assert!(relay_watcher_overtook_anchor_record(0, 1, true));
     }
 
     #[test]
     fn relay_does_not_recheck_when_watcher_has_not_committed() {
         // Unchanged watermark (turn not yet complete) → no overtake → the relay is
         // a pure no-op and the watcher does the normal `⏳` removal later. This is
-        // what prevents the relay from double-removing in the common path.
-        assert!(!relay_watcher_overtook_anchor_record(100, 100));
-        assert!(!relay_watcher_overtook_anchor_record(0, 0));
+        // what prevents the relay from double-removing in the common path. (Even if
+        // some other path had cleared our lease, an unchanged watermark can never be
+        // an overtake of THIS turn.)
+        assert!(!relay_watcher_overtook_anchor_record(100, 100, true));
+        assert!(!relay_watcher_overtook_anchor_record(0, 0, true));
         // Defensive: the watermark is monotonic, so it never regresses; a (would-be
         // impossible) lower re-read must still be treated as "no overtake".
-        assert!(!relay_watcher_overtook_anchor_record(240, 100));
+        assert!(!relay_watcher_overtook_anchor_record(240, 100, true));
+    }
+
+    // #3193 codex GATE_FAIL fix: the FALSE-POSITIVE guard. The committed-relay
+    // watermark is per-CHANNEL, so an UNRELATED / different-turn commit in the SAME
+    // channel during this relay window advances it WITHOUT touching THIS turn's
+    // anchor. The bare watermark strict-increase alone (the pre-fix trigger) would
+    // mis-fire and remove `⏳` / post `✅` for a turn whose own anchor was NOT
+    // overtaken. The fix binds the trigger to THIS turn's identity: it fires ONLY
+    // when our OWN external-input lease was also consumed (`own_lease_consumed`),
+    // which the watcher does EXACTLY when it commits OUR turn. An unrelated commit
+    // advances the watermark but leaves our lease present → no trigger.
+    #[test]
+    fn relay_does_not_recheck_on_unrelated_same_channel_commit() {
+        // Watermark advanced (an unrelated same-channel turn committed) but THIS
+        // turn's own lease was NOT consumed → our anchor was NOT overtaken → the
+        // relay must NOT remove its `⏳` / post `✅`. This is the codex #3193
+        // false-positive case that the bare watermark trigger would have hit.
+        assert!(!relay_watcher_overtook_anchor_record(100, 240, false));
+        assert!(!relay_watcher_overtook_anchor_record(0, 999, false));
+    }
+
+    // #3193 codex GATE_FAIL fix: the per-turn lease-consumption predicate that backs
+    // the trigger binding. "Consumed" means the lease present NOW is no longer THIS
+    // turn's recorded generation — either gone (the watcher cleared it on OUR commit)
+    // or replaced by a different generation (a superseding turn). A present lease
+    // that STILL carries our own generation is NOT consumed: that is the unrelated-
+    // commit / not-yet-committed case that must NOT trigger the re-check.
+    #[test]
+    fn external_input_lease_consumption_is_bound_to_own_generation() {
+        // Our generation still present → not consumed (unrelated commit / pre-commit).
+        assert!(!external_input_lease_was_consumed(42, Some(42)));
+        // Our lease gone (watcher cleared it on OUR commit) → consumed.
+        assert!(external_input_lease_was_consumed(42, None));
+        // A DIFFERENT generation present (a superseding newer turn) → ours consumed.
+        assert!(external_input_lease_was_consumed(42, Some(43)));
+        // An UNRECORDED own generation (our lease was never recorded) → nothing of
+        // ours to consume, regardless of what is present.
+        assert!(!external_input_lease_was_consumed(
+            crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
+            None,
+        ));
+        assert!(!external_input_lease_was_consumed(
+            crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
+            Some(7),
+        ));
     }
 
     // #3174 (ported from #3164 codex R3): identity guard for the relay re-check's

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -520,6 +520,22 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             return;
         }
     }
+    // #3174 (ported from #3164 codex R3): snapshot the channel's authoritative
+    // committed-relay watermark BEFORE we post the notify / add the `⏳` / record
+    // the anchor. The tmux watcher advances `confirmed_end_offset` (read here) on
+    // the SAME inline commit pass that, a few statements later, runs the
+    // anchor-completion gate
+    // (`complete_tui_direct_prompt_anchor_lifecycle_if_present`). If THIS turn's
+    // terminal output is fast, the watcher can commit (advancing the watermark)
+    // and run that gate BEFORE `record_prompt_anchor` below has made our anchor
+    // findable — the gate then observes `None`, no-ops, and (with no further
+    // terminal output) never removes the `⏳` we are about to add → the stranded
+    // hourglass. Capturing the watermark NOW lets us detect that overtake AFTER we
+    // record the anchor (`committed_after > committed_before`) and remove our own
+    // `⏳` ourselves, with no timing wait. The non-race case (watcher not yet
+    // committed) leaves the watermark unchanged → we no-op and the watcher does
+    // the normal removal later.
+    let committed_relay_offset_before_relay = shared.committed_relay_offset(channel_id);
     let mut lease = record_observed_external_turn_lease(shared, &prompt, channel_id);
     // #3041 P1-4 codex: arm an early-return RAII guard the instant the lease is
     // recorded & stored. Every FAILURE early-return below (registry None, notify
@@ -785,6 +801,50 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             channel_id.get(),
             anchor_message.id.get(),
         );
+        // #3174 (ported from #3164 codex R3): relay-side re-check that closes the
+        // lease/anchor ordering race WITHOUT any timing wait. The watcher's
+        // anchor-completion gate
+        // (`complete_tui_direct_prompt_anchor_lifecycle_if_present`) can open on the
+        // external-input LEASE alone — `external_input_lease_before_relay == true`,
+        // `prompt_anchor_present_before_relay == false` — and run BEFORE the
+        // `record_prompt_anchor` above made our anchor findable. The gate then reads
+        // the anchor as `None`, no-ops, and (with no further terminal output) leaves
+        // our just-added `⏳` stranded forever.
+        //
+        // The watcher advances `confirmed_end_offset` (= `committed_relay_offset`) on
+        // the SAME inline commit pass, strictly BEFORE that gate. So if the watermark
+        // has advanced past our pre-relay snapshot, the watcher has already committed
+        // a terminal turn and already run (and no-op'd) the gate for it — exactly the
+        // overtake. We then remove our OWN `⏳` and post `✅` here.
+        //
+        // Identity guard: we act ONLY on `anchor_message.id` (this turn's own posted
+        // message), never on a re-read of the shared `prompt_anchor_by_tmux` slot,
+        // and we clear that shared slot only if it STILL points at our id — a newer
+        // same-(provider,tmux,channel) turn that already overwrote the slot keeps its
+        // own `⏳`. No double-completion: clearing the shared slot makes any later
+        // watcher gate read `None` → no-op; `remove_reaction_raw`/`✅` add target our
+        // own message and are idempotent. The common (non-overtake) case leaves the
+        // watermark unchanged → this is a pure no-op and the watcher removes the `⏳`
+        // normally on its own completion pass.
+        if let Some(command_http) = command_http.as_ref() {
+            // Only meaningful when we actually added the `⏳` above (same `@me`
+            // identity). Re-reading the watermark here (post-anchor) catches a
+            // watcher that committed + ran its no-op gate during the `⏳` add I/O.
+            let committed_relay_offset_after_anchor = shared.committed_relay_offset(channel_id);
+            if relay_watcher_overtook_anchor_record(
+                committed_relay_offset_before_relay,
+                committed_relay_offset_after_anchor,
+            ) {
+                relay_recheck_complete_own_anchor_if_watcher_overtook(
+                    command_http,
+                    &prompt.provider,
+                    &prompt.tmux_session_name,
+                    channel_id,
+                    anchor_message.id,
+                )
+                .await;
+            }
+        }
         // #3099: a `<task-notification>` auto-turn is still a real provider turn
         // that earns the same synthetic ownership as human direct input — the
         // difference is purely that its `⏳` completion cleanup must be anchored on
@@ -4006,6 +4066,80 @@ pub(super) async fn complete_tui_direct_anchor_lifecycle_for_inflight(
     Some(anchor)
 }
 
+/// #3174 (ported from #3164 codex R3): pure decision for whether the tmux watcher
+/// already committed a terminal turn (advancing `committed_relay_offset`) AND ran
+/// its anchor-completion gate BEFORE `relay_observed_prompt` finished recording the
+/// anchor — i.e. the watcher overtook the relay and its no-op gate left the `⏳`
+/// stranded. The watermark is monotonic (CAS advance), so a strict increase between
+/// the pre-relay snapshot and the post-anchor re-read is the overtake signal. Equal
+/// (the common case: watcher not yet committed) → no overtake → the relay no-ops
+/// and the watcher removes the `⏳` normally on its own later completion pass.
+fn relay_watcher_overtook_anchor_record(
+    committed_before_relay: u64,
+    committed_after_anchor: u64,
+) -> bool {
+    committed_after_anchor > committed_before_relay
+}
+
+/// #3174 (ported from #3164 codex R3): relay-side completion that closes the
+/// lease/anchor ordering race. Called from `relay_observed_prompt` ONLY after it
+/// has detected — via the `committed_relay_offset` watermark advancing past the
+/// pre-relay snapshot — that the watcher already committed a terminal turn and
+/// already ran (and no-op'd) its anchor-completion gate before our
+/// `record_prompt_anchor` made the anchor findable. In that overtake the watcher's
+/// gate left our `⏳` un-removed, so we remove it ourselves and post `✅`.
+///
+/// Scoped strictly to `own_anchor_message_id` — THIS turn's own posted message —
+/// so it can never touch a newer same-(provider,tmux,channel) turn's `⏳`. We use
+/// the SAME `command_http` (`@me`) identity that added the `⏳` so
+/// `remove_reaction_raw` (which only removes `@me`'s reaction) actually removes
+/// it. The shared `prompt_anchor_by_tmux` slot is cleared only when it still
+/// points at our id (a later injection that overwrote it keeps its own `⏳`),
+/// which also makes any subsequent watcher gate read `None` → no-op (no
+/// double-completion). All reaction ops are idempotent.
+async fn relay_recheck_complete_own_anchor_if_watcher_overtook(
+    http: &serenity::Http,
+    provider: &str,
+    tmux_session_name: &str,
+    channel_id: ChannelId,
+    own_anchor_message_id: MessageId,
+) {
+    super::formatting::remove_reaction_raw(http, channel_id, own_anchor_message_id, '⏳').await;
+    let completion_reaction = serenity::ReactionType::Unicode('✅'.to_string());
+    if let Err(error) = channel_id
+        .create_reaction(http, own_anchor_message_id, completion_reaction)
+        .await
+    {
+        tracing::warn!(
+            provider = %provider,
+            channel_id = channel_id.get(),
+            tmux_session_name = %tmux_session_name,
+            anchor_message_id = own_anchor_message_id.get(),
+            error = %error,
+            "relay re-check: failed to post ✅ after removing own ⏳ for watcher-overtaken turn; keeping anchor for the watcher's retry"
+        );
+        return;
+    }
+    // Clear the shared slot ONLY if it still points at our own message id, so a
+    // newer injection that already overwrote it keeps its own `⏳`/anchor. This
+    // also disarms any later watcher gate for this id (it reads `None` → no-op).
+    crate::services::tui_prompt_dedupe::clear_prompt_anchor_for_response(
+        provider,
+        tmux_session_name,
+        crate::services::tui_prompt_dedupe::TuiPromptAnchor {
+            channel_id: channel_id.get(),
+            message_id: own_anchor_message_id.get(),
+        },
+    );
+    tracing::info!(
+        provider = %provider,
+        channel_id = channel_id.get(),
+        tmux_session_name = %tmux_session_name,
+        anchor_message_id = own_anchor_message_id.get(),
+        "relay re-check: watcher committed terminal output before the anchor was findable; relay removed its own ⏳ and posted ✅ (lease/anchor race closed without a timing wait)"
+    );
+}
+
 fn owner_channel_for_prompt(
     shared: &Arc<SharedData>,
     prompt: &ObservedTuiPrompt,
@@ -5449,6 +5583,86 @@ mod tests {
             },
         ));
         assert_eq!(prompt_anchor_for_response("claude", tmux, channel), None);
+    }
+
+    // #3174 (ported from #3164 codex R3): the lease/anchor ordering race detector.
+    // The tmux watcher advances `committed_relay_offset` on the SAME inline commit
+    // pass that runs its anchor-completion gate, strictly BEFORE that gate. So when
+    // the watcher overtakes the relay (commits + no-op gate BEFORE
+    // `record_prompt_anchor` made the anchor findable), the post-anchor watermark is
+    // STRICTLY GREATER than the pre-relay snapshot → the relay must remove its own
+    // `⏳`. When the watcher has not yet committed (the common case) the watermark is
+    // unchanged → the relay must NOT act (no double-removal); the watcher removes the
+    // `⏳` itself later.
+    #[test]
+    fn relay_rechecks_when_watcher_committed_before_anchor_was_recorded() {
+        // Watermark advanced between the pre-relay snapshot and the post-anchor
+        // re-read → the watcher already committed a terminal turn and ran its
+        // no-op gate before our anchor was findable → relay must clean up its `⏳`.
+        assert!(relay_watcher_overtook_anchor_record(100, 240));
+        assert!(relay_watcher_overtook_anchor_record(0, 1));
+    }
+
+    #[test]
+    fn relay_does_not_recheck_when_watcher_has_not_committed() {
+        // Unchanged watermark (turn not yet complete) → no overtake → the relay is
+        // a pure no-op and the watcher does the normal `⏳` removal later. This is
+        // what prevents the relay from double-removing in the common path.
+        assert!(!relay_watcher_overtook_anchor_record(100, 100));
+        assert!(!relay_watcher_overtook_anchor_record(0, 0));
+        // Defensive: the watermark is monotonic, so it never regresses; a (would-be
+        // impossible) lower re-read must still be treated as "no overtake".
+        assert!(!relay_watcher_overtook_anchor_record(240, 100));
+    }
+
+    // #3174 (ported from #3164 codex R3): identity guard for the relay re-check's
+    // shared-slot clear. When the relay cleans up its OWN overtaken `⏳`, it must
+    // clear the shared `prompt_anchor_by_tmux` slot ONLY if the slot still points at
+    // its own message id. A newer same-(provider,tmux,channel) injection that already
+    // overwrote the slot must keep its own `⏳`/anchor — exactly the same
+    // match-guarded clear the cross-turn cleanup relies on. This proves the relay
+    // re-check cannot strand or double-complete a later turn.
+    #[test]
+    fn relay_recheck_slot_clear_is_scoped_to_own_message_id() {
+        use crate::services::tui_prompt_dedupe::{
+            TuiPromptAnchor, clear_prompt_anchor_for_response, prompt_anchor_for_response,
+            record_prompt_anchor,
+        };
+        let _dedupe_guard = crate::services::tui_prompt_dedupe::TEST_LOCK
+            .lock()
+            .unwrap();
+        crate::services::tui_prompt_dedupe::reset_state_for_tests();
+
+        let tmux = "AgentDesk-claude-relay-recheck-race";
+        let channel = 64_u64;
+        let own = 3003_u64;
+        let newer = 4004_u64;
+
+        // Our turn recorded the slot, then a NEWER injection overwrote it.
+        record_prompt_anchor("claude", tmux, channel, own);
+        record_prompt_anchor("claude", tmux, channel, newer);
+
+        // The relay re-check clears the shared slot for ITS OWN id; the slot now
+        // holds the newer turn, so the match guard refuses → newer `⏳` preserved.
+        assert!(
+            !clear_prompt_anchor_for_response(
+                "claude",
+                tmux,
+                TuiPromptAnchor {
+                    channel_id: channel,
+                    message_id: own,
+                },
+            ),
+            "relay re-check must NOT clear a newer turn's shared slot",
+        );
+        assert_eq!(
+            prompt_anchor_for_response("claude", tmux, channel),
+            Some(TuiPromptAnchor {
+                channel_id: channel,
+                message_id: newer,
+            }),
+            "the newer turn's anchor survives the relay re-check",
+        );
     }
 
     #[test]

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -4114,11 +4114,17 @@ pub(super) async fn complete_tui_direct_anchor_lifecycle_for_inflight(
 /// anchor-completion gate. So the precise overtake signal for THIS turn is BOTH:
 ///   1. the watermark strictly increased (a commit happened in the window), AND
 ///   2. `own_external_input_lease_consumed` — THIS turn's recorded lease generation
-///      is no longer the present lease, i.e. the committing turn was OURS, not an
-///      unrelated same-channel turn.
+///      is ABSENT (the watcher's generation-matched clear removed our entry), i.e.
+///      the committing turn was OURS, not an unrelated same-channel turn AND not a
+///      newer turn that merely OVERWROTE our lease (#3193 codex R3: a newer same-key
+///      lease replacing ours during our notify/POST window leaves a DIFFERENT
+///      generation present, which is NOT consumed → see
+///      `external_input_lease_was_consumed`).
 /// An unrelated commit advances the watermark (1) but leaves our lease generation
-/// present (2 is false) → no trigger → no false-positive. Equal watermark (the
-/// common case: watcher not yet committed) → no overtake regardless of (2).
+/// present (2 is false) → no trigger → no false-positive. A newer turn replacing
+/// our lease also leaves a (different) generation present (2 is false) → no trigger.
+/// Equal watermark (the common case: watcher not yet committed) → no overtake
+/// regardless of (2).
 fn relay_watcher_overtook_anchor_record(
     committed_before_relay: u64,
     committed_after_anchor: u64,
@@ -4127,19 +4133,31 @@ fn relay_watcher_overtook_anchor_record(
     committed_after_anchor > committed_before_relay && own_external_input_lease_consumed
 }
 
-/// #3193 codex GATE_FAIL fix: pure decision for whether THIS turn's own
-/// external-input lease (identified by its UNIQUE recorded `generation`) has been
-/// consumed — i.e. is no longer the lease currently present for
-/// `(provider, tmux_session, channel)`. `present_generation` is the generation of
-/// the lease the state map holds NOW (the post-anchor re-read), or `None` if no
-/// lease is present.
+/// #3193 codex GATE_FAIL fix (R3, decisive): pure decision for whether THIS turn's
+/// own external-input lease (identified by its UNIQUE recorded `generation`) was
+/// consumed by the WATCHER committing THIS turn — i.e. the watcher's
+/// generation-MATCHED clear
+/// (`clear_external_input_relay_lease_if_generation_matches`) removed exactly our
+/// entry. `present_generation` is the generation of the lease the state map holds
+/// NOW (the post-anchor re-read), or `None` if no lease is present.
 ///
-/// "Consumed" is true when the present lease is gone (`None`) OR carries a
-/// DIFFERENT generation than ours — both mean the watcher (or a superseding turn)
-/// cleared/replaced the exact lease THIS turn recorded. The watcher clears a
-/// turn's lease by its generation EXACTLY on the commit pass for that turn, so this
-/// is the per-turn binding that distinguishes our own overtake from an unrelated
-/// same-channel commit (which leaves our generation present → returns `false`).
+/// "Consumed" is true ONLY when the present lease is ABSENT (`None`). The watcher's
+/// generation-matched clear `remove`s the entry from the map (it does NOT leave an
+/// `Unassigned` sentinel behind), so our generation being GONE is the exact
+/// per-turn signal that the watcher committed OUR turn.
+///
+/// A DIFFERENT (newer) generation being present must return `false`: per #3193
+/// codex R3, a NEWER same-key external-input lease can be RECORDED (a new, distinct
+/// generation) while THIS older relay is still awaiting notify/POST — see the guard
+/// tests `..._preserves_newer_unassigned` / no-clobber tests in `tui_prompt_dedupe`
+/// that explicitly allow newer same-key leases to coexist with an older awaiting
+/// relay. In that case our generation is gone because a newer turn OVERWROTE the
+/// lease, NOT because the watcher generation-matched-cleared OUR turn. Treating a
+/// different-generation-present as "consumed" reintroduces the false-positive:
+/// newer-turn-replaces-lease + watermark-increase would falsely trigger the
+/// ⏳-removal/✅. Keying strictly on ABSENT (`None`) ties the trigger to the
+/// watcher clearing THIS turn's own generation and nothing else.
+///
 /// `own_generation == UNRECORDED` (0) means our lease was never recorded, so there
 /// is nothing of ours to have been consumed → `false`.
 fn external_input_lease_was_consumed(own_generation: u64, present_generation: Option<u64>) -> bool {
@@ -4148,7 +4166,11 @@ fn external_input_lease_was_consumed(own_generation: u64, present_generation: Op
     {
         return false;
     }
-    present_generation != Some(own_generation)
+    // Consumed ONLY when our recorded generation is ABSENT/cleared (the watcher's
+    // generation-matched clear removed the entry). A present-but-DIFFERENT
+    // generation means a newer turn replaced the lease, not our watcher commit
+    // (#3193 codex R3) → NOT consumed.
+    present_generation.is_none()
 }
 
 /// #3193 codex GATE_FAIL fix: runtime adapter that reads the lease state map NOW
@@ -5726,20 +5748,29 @@ mod tests {
         assert!(!relay_watcher_overtook_anchor_record(0, 999, false));
     }
 
-    // #3193 codex GATE_FAIL fix: the per-turn lease-consumption predicate that backs
-    // the trigger binding. "Consumed" means the lease present NOW is no longer THIS
-    // turn's recorded generation — either gone (the watcher cleared it on OUR commit)
-    // or replaced by a different generation (a superseding turn). A present lease
-    // that STILL carries our own generation is NOT consumed: that is the unrelated-
-    // commit / not-yet-committed case that must NOT trigger the re-check.
+    // #3193 codex GATE_FAIL fix (R3, decisive): the per-turn lease-consumption
+    // predicate that backs the trigger binding. "Consumed" means the watcher
+    // generation-MATCHED-cleared THIS turn's recorded lease — which `remove`s the
+    // entry, so our generation is ABSENT (`None`) on the re-read. A present lease is
+    // NEVER "consumed", regardless of generation:
+    //   - same generation → unrelated commit / not yet committed.
+    //   - DIFFERENT (newer) generation → a newer same-key turn RECORDED a fresh lease
+    //     while THIS older relay is still awaiting notify/POST (the dedupe guard tests
+    //     explicitly allow this). Our generation is gone because a newer turn
+    //     OVERWROTE the lease, NOT because the watcher committed OUR turn. Treating
+    //     this as "consumed" reintroduces the #3193 false-positive, so it must be
+    //     `false`.
     #[test]
     fn external_input_lease_consumption_is_bound_to_own_generation() {
         // Our generation still present → not consumed (unrelated commit / pre-commit).
         assert!(!external_input_lease_was_consumed(42, Some(42)));
-        // Our lease gone (watcher cleared it on OUR commit) → consumed.
+        // Our lease gone (the watcher's generation-matched clear removed OUR entry on
+        // OUR commit) → consumed.
         assert!(external_input_lease_was_consumed(42, None));
-        // A DIFFERENT generation present (a superseding newer turn) → ours consumed.
-        assert!(external_input_lease_was_consumed(42, Some(43)));
+        // A DIFFERENT (newer) generation present (a newer turn REPLACED our lease,
+        // NOT our watcher commit) → NOT consumed. #3193 codex R3: this is the
+        // false-positive that the predicate must reject.
+        assert!(!external_input_lease_was_consumed(42, Some(43)));
         // An UNRECORDED own generation (our lease was never recorded) → nothing of
         // ours to consume, regardless of what is present.
         assert!(!external_input_lease_was_consumed(
@@ -5750,6 +5781,37 @@ mod tests {
             crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
             Some(7),
         ));
+    }
+
+    // #3193 codex GATE_FAIL fix (R3): the decisive false-positive guard. A NEWER
+    // same-key external-input lease can be RECORDED (a fresh, distinct generation)
+    // while THIS older relay is still awaiting notify/POST — the dedupe guard tests
+    // (`clear_external_input_relay_lease_if_generation_matches_preserves_newer_unassigned`)
+    // explicitly allow this. If that newer-turn replacement also coincides with the
+    // per-CHANNEL watermark advancing (`committed_after > committed_before`), the
+    // OLD bind (different-generation-present == "consumed") would FALSELY trigger the
+    // re-check and remove OUR `⏳` / post `✅` for a turn the watcher never committed.
+    // Keying "consumed" strictly on our generation being ABSENT closes this: a
+    // newer/different generation present → NOT consumed → no trigger.
+    #[test]
+    fn relay_does_not_recheck_when_newer_turn_replaced_lease() {
+        // own generation 42; a newer turn replaced the lease (generation 43 present).
+        let own_generation = 42_u64;
+        let newer_generation_present = Some(43_u64);
+        // The newer-turn replacement is NOT a consumption of OUR lease.
+        let own_lease_consumed =
+            external_input_lease_was_consumed(own_generation, newer_generation_present);
+        assert!(
+            !own_lease_consumed,
+            "a newer same-key lease replacing ours is NOT our watcher commit"
+        );
+        // Even WITH the watermark advanced, the composite trigger must be false:
+        // newer-turn-replaces-lease + watermark-increase must NOT fire the re-check.
+        assert!(
+            !relay_watcher_overtook_anchor_record(100, 240, own_lease_consumed),
+            "newer-turn lease replacement during the notify/POST window must not \
+             falsely trigger the ⏳-removal/✅ (#3193 codex R3)"
+        );
     }
 
     // #3174 (ported from #3164 codex R3): identity guard for the relay re-check's


### PR DESCRIPTION
Closes #3174.

Narrow ⏳-stranding ordering race: between recording the external-input lease and `record_prompt_anchor`, a fast provider commits terminal output; the watcher's lease-gated anchor-completion gate fires before the anchor is recorded, sees `anchor=None`, no-ops, and leaves the `⏳` stranded.

This ports the relay-side re-check from #3164 (commit `79ae01ffd`), re-anchored against current `main` (the surrounding lease/anchor code drifted since it was authored). Entirely within `src/services/discord/tui_prompt_relay.rs` — no watcher change.

Fix (no timing wait):
- snapshot `committed_relay_offset(channel)` BEFORE the notify-post; re-read it AFTER `record_prompt_anchor`. The watcher advances that watermark (monotonic CAS) on the SAME inline commit pass that runs the no-op gate, strictly BEFORE it. A strict increase (`relay_watcher_overtook_anchor_record`) proves the overtake.
- on overtake, `relay_recheck_complete_own_anchor_if_watcher_overtook` removes this turn's OWN `⏳` and posts `✅`, scoped strictly to its own `anchor_message.id` using the same `@me` identity that added the `⏳`; the shared `prompt_anchor_by_tmux` slot is cleared ONLY when it still points at that id (a newer same-(provider,tmux,channel) turn keeps its own `⏳`).
- the non-overtake (common) case leaves the watermark unchanged → pure no-op; the watcher removes the `⏳` normally on its own later pass.

Tests (`cargo test --lib tui_prompt_relay`): overtake-detector, no-double-removal (unchanged watermark → no-op), and own-id-scoped shared-slot clear (a newer turn's anchor survives). 90 passed / 0 failed.

Quality gate: `cargo fmt`; `cargo build --lib` clean; line-count gate passes (freeze synced +134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)