### PR TITLE
fix(#3154): serialize wakeup/loop turn-start against prior inflight relay drain

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -318,7 +318,7 @@
     so a late completion can never commit the WRONG newer loop turn; the
     `user_msg_id != 0` path is byte-for-byte unchanged. New test
     `watcher_terminal_delivery_commit_marks_loop_turn_with_zero_user_msg_id`.
-  - `src/services/discord/tui_prompt_relay.rs` (4522 lines; SSH-direct TUI
+  - `src/services/discord/tui_prompt_relay.rs` (4605 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +4 from #3167: the self-paced TUI loop relay
     starts its synthetic turn with `ActiveTurnKind::Background` so a queued user
@@ -413,7 +413,25 @@
     (the double-relay duplicate). When the watcher stopped / never covered the turn
     the watermark is 0 (or lags), so the clamp is a no-op and the tail still relays
     from the prompt-timestamp offset — the #3176 outage fallback is preserved
-    (plus clamp-up / outage-noop unit tests).
+    (plus clamp-up / outage-noop unit tests); +83 from #3154: the wakeup/loop
+    (self-paced) synthetic turn-START now serializes against the PREVIOUS turn's
+    inflight relay drain — `claim_tui_direct_synthetic_turn` runs the SAME bounded
+    `wait_for_claude_inflight_to_clear` drain-wait (Claude-only, per-channel
+    inflight row, `CLAUDE_IDLE_INFLIGHT_DRAIN_WAIT`-bounded; our own synthetic is
+    exempted via `inflight_is_current_turn_synthetic` which also requires the same
+    `tmux_session_name`) BEFORE `mailbox_try_start_turn_kinded`, so a new wakeup
+    turn cannot begin writing `response_sent_offset` while turn1's terminal relay
+    is still draining (closes the `response_sent_offset_monotonic` regression /
+    double-relay). Our own synthetic does not exist yet at this point so the wait
+    can never self-deadlock. On TIMEOUT, if a genuinely-distinct prior inflight is
+    STILL present, the claim is DECLINED (`claimed: false`) BEFORE the mailbox/save
+    so a fresh synthetic never overwrites the prior row's `response_sent_offset`
+    (which would itself trip the invariant) — identical to the existing
+    "mailbox already owns a different turn" decline; nothing was started so no
+    cleanup is needed. The change can only DELAY or decline a synthetic claim,
+    never drop/duplicate delivery (plus the
+    `turn_start_drain_wait_blocks_until_prior_inflight_clears` end-to-end
+    regression test).
   - `src/services/discord/idle_recap.rs` (1881 prod lines; idle-recap card
     compose/post/clear surface, registered giant-file (#3036) — bugfix only
     outside an extraction plan. Crossed 1000 prod LoC with #3146 Part 1: the

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -1131,6 +1131,89 @@ async fn claim_tui_direct_synthetic_turn(
     anchor_message_id: MessageId,
     lease: &ExternalInputRelayLease,
 ) -> TuiDirectSyntheticTurnClaim {
+    // #3154: serialize the wakeup/loop (self-paced) turn START against the
+    // PREVIOUS turn's still-inflight relay drain. Without this, a wakeup turn
+    // begins writing `response_sent_offset` while turn1's terminal relay is
+    // still draining → the two turns' offset bookkeeping collide and the
+    // `response_sent_offset_monotonic` invariant goes backwards (74 production
+    // violations on channel 1479671298497183835). #3041 serialized DELIVERY but
+    // NOT turn-START.
+    //
+    // We BLOCK here only on a genuinely DIFFERENT (previous) turn's inflight: our
+    // own synthetic for THIS turn does not exist yet (created below), so nothing
+    // here can be ours and the wait can never self-deadlock. The wait is BOUNDED
+    // by `CLAUDE_IDLE_INFLIGHT_DRAIN_WAIT` and channel-scoped (it loads the single
+    // per-channel Claude inflight row; one channel maps to one tmux session, and
+    // `inflight_is_current_turn_synthetic` further requires the same
+    // `tmux_session_name`).
+    //
+    // codex GATE fix: on TIMEOUT we must NOT proceed to start + save a fresh
+    // synthetic over a STILL-PRESENT prior inflight — that overwrite resets
+    // `response_sent_offset` to 0 and trips the very `response_sent_offset_monotonic`
+    // invariant this change exists to close (`save_inflight_state`'s monotonic
+    // observer fires on the overwrite even if the mailbox happened to free up).
+    // Instead we DECLINE the synthetic claim (return `claimed: false`) BEFORE
+    // touching the mailbox or inflight store — identical in effect to the existing
+    // "mailbox already owns a different turn" decline. Nothing was started, so no
+    // cleanup is needed; this can only DELAY/decline a synthetic claim, never drop
+    // or duplicate delivery (the bridge tail / next observation still handles the
+    // turn). A genuinely-distinct prior inflight must STILL be present at this
+    // instant to decline — if it cleared between the last poll and now, we fall
+    // through and start normally.
+    #[cfg(unix)]
+    if matches!(provider, ProviderKind::Claude)
+        && !wait_for_claude_inflight_to_clear(
+            channel_id,
+            tmux_session_name,
+            // Our synthetic for THIS turn is not yet created, so the anchor id
+            // matches no inflight here; threading it keeps identity-pinning
+            // symmetric with the idle-tail drain-wait and harmless if a racing
+            // refresh of our own row lands mid-wait.
+            Some(anchor_message_id.get()),
+        )
+        .await
+    {
+        let prior = super::inflight::load_inflight_state(&ProviderKind::Claude, channel_id.get());
+        if prior.is_some()
+            && !inflight_is_current_turn_synthetic(
+                prior.as_ref(),
+                tmux_session_name,
+                Some(anchor_message_id.get()),
+            )
+        {
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel_id = channel_id.get(),
+                tmux_session_name = %tmux_session_name,
+                anchor_message_id = anchor_message_id.get(),
+                wait_ms = CLAUDE_IDLE_INFLIGHT_DRAIN_WAIT.as_millis(),
+                "declining TUI-direct synthetic turn-start; prior inflight relay still draining after bounded wait (avoids overwriting its response_sent_offset)"
+            );
+            let relay_owner = if tui_direct_watcher_can_own_output(
+                &shared.tmux_watchers,
+                tmux_session_name,
+                external_input_relay_output_path(
+                    shared,
+                    provider.as_str(),
+                    tmux_session_name,
+                    channel_id,
+                    crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(
+                        tmux_session_name,
+                    )
+                    .as_ref(),
+                )
+                .as_deref(),
+            ) {
+                ExternalInputRelayOwner::TmuxWatcher
+            } else {
+                ExternalInputRelayOwner::BridgeAdapter
+            };
+            return TuiDirectSyntheticTurnClaim {
+                relay_owner,
+                claimed: false,
+            };
+        }
+    }
     let binding =
         crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(tmux_session_name);
     let output_path = external_input_relay_output_path(
@@ -6144,6 +6227,198 @@ mod tests {
             "AgentDesk-claude-self",
             Some(11)
         ));
+    }
+
+    /// #3154: the wakeup/loop turn-START drain-wait must WAIT while the PREVIOUS
+    /// turn's inflight is still draining and PROCEED once it clears — and must
+    /// NOT wait when there is no draining inflight. This drives the exact helper
+    /// (`wait_for_claude_inflight_to_clear`) the turn-START path now calls before
+    /// `mailbox_try_start_turn_kinded`, against the real persisted inflight store.
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn turn_start_drain_wait_blocks_until_prior_inflight_clears() {
+        // `load_inflight_state` reads the process-wide `AGENTDESK_ROOT_DIR`;
+        // serialize on the shared env lock and isolate the root to our temp dir.
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let dir = tempfile::tempdir().expect("temp dir");
+        struct EnvReset(Option<std::ffi::OsString>);
+        impl Drop for EnvReset {
+            fn drop(&mut self) {
+                match self.0.take() {
+                    Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
+                    None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
+                }
+            }
+        }
+        let _env_reset = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", dir.path()) };
+
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(940_000_000_003_154);
+        let tmux_session_name = "AgentDesk-claude-3154-turnstart";
+        // The NEW (wakeup) turn's anchor id — distinct from the previous turn's.
+        let new_turn_anchor = MessageId::new(940_000_000_003_200);
+        let output_path = dir.path().join("prior.jsonl");
+        let lease = ExternalInputRelayLease {
+            channel_id: Some(channel_id.get()),
+            turn_id: Some("external:claude:940000000003154:turnstart:1".to_string()),
+            session_key: Some("token:AgentDesk-claude-3154-turnstart".to_string()),
+            relay_owner: ExternalInputRelayOwner::BridgeAdapter,
+            runtime_kind: Some(RuntimeHandoffKind::ClaudeTui),
+            generation:
+                crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
+        };
+
+        // (1) No inflight at all => the turn-START drain-wait returns immediately.
+        super::super::inflight::clear_inflight_state(&provider, channel_id.get());
+        let started = std::time::Instant::now();
+        assert!(
+            wait_for_claude_inflight_to_clear(
+                channel_id,
+                tmux_session_name,
+                Some(new_turn_anchor.get()),
+            )
+            .await,
+            "no draining inflight => turn-start proceeds without waiting"
+        );
+        assert!(
+            started.elapsed() < CLAUDE_IDLE_INFLIGHT_DRAIN_WAIT,
+            "with no inflight the wait must not consume the full timeout"
+        );
+
+        // (2) A PREVIOUS turn's inflight (DIFFERENT anchor id) is draining. The
+        // turn-START drain-wait must BLOCK until it clears, then PROCEED. The
+        // previous turn's `user_msg_id` differs from `new_turn_anchor`, so it is
+        // NOT recognised as "ours" and correctly blocks.
+        let prior = build_tui_direct_synthetic_inflight_state(
+            provider.clone(),
+            channel_id,
+            MessageId::new(940_000_000_003_100), // previous turn's anchor id
+            None,
+            "prior turn still draining",
+            tmux_session_name,
+            Some(&output_path),
+            0,
+            &lease,
+            RelayOwnerKind::None,
+        );
+        super::super::inflight::save_inflight_state(&prior).expect("save prior inflight");
+
+        // Clear the prior inflight after a delay that exceeds at least one poll
+        // interval but stays well within the bounded timeout, so the wait must
+        // observe the "blocking" state at least once before it clears.
+        let clear_after = CLAUDE_IDLE_INFLIGHT_DRAIN_POLL * 3;
+        let clear_provider = provider.clone();
+        let clearer = tokio::spawn(async move {
+            tokio::time::sleep(clear_after).await;
+            super::super::inflight::clear_inflight_state(&clear_provider, channel_id.get());
+        });
+
+        let started = std::time::Instant::now();
+        let proceeded = wait_for_claude_inflight_to_clear(
+            channel_id,
+            tmux_session_name,
+            Some(new_turn_anchor.get()),
+        )
+        .await;
+        let waited = started.elapsed();
+        clearer.await.expect("clearer task");
+
+        assert!(
+            proceeded,
+            "once the prior inflight drains the turn-start must proceed (never hang)"
+        );
+        assert!(
+            waited >= clear_after,
+            "turn-start must WAIT while the prior inflight is still draining \
+             (waited {waited:?}, prior cleared after {clear_after:?})"
+        );
+        assert!(
+            waited < CLAUDE_IDLE_INFLIGHT_DRAIN_WAIT,
+            "the wait is bounded and returns as soon as the prior inflight clears, \
+             not at the full timeout (waited {waited:?})"
+        );
+    }
+
+    /// #3154 codex GATE fix: on a TIMED-OUT turn-start drain-wait, the synthetic
+    /// claim must DECLINE only when a genuinely-distinct prior inflight is STILL
+    /// present (so it never overwrites that row's `response_sent_offset` and trips
+    /// the monotonic invariant), and must NOT decline when the present row is our
+    /// own synthetic or when nothing remains. This drives the exact decline
+    /// predicate `claim_tui_direct_synthetic_turn` evaluates after the wait
+    /// returns `false`.
+    #[cfg(unix)]
+    #[test]
+    fn turn_start_decline_predicate_only_fires_on_distinct_prior_inflight() {
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(940_000_000_003_155);
+        let tmux_session_name = "AgentDesk-claude-3154-decline";
+        let new_turn_anchor: u64 = 940_000_000_003_300;
+        let output_path = PathBuf::from("/tmp/adk-3154-decline.jsonl");
+        let lease = ExternalInputRelayLease {
+            channel_id: Some(channel_id.get()),
+            turn_id: Some("external:claude:940000000003155:decline:1".to_string()),
+            session_key: Some("token:AgentDesk-claude-3154-decline".to_string()),
+            relay_owner: ExternalInputRelayOwner::BridgeAdapter,
+            runtime_kind: Some(RuntimeHandoffKind::ClaudeTui),
+            generation:
+                crate::services::tui_prompt_dedupe::EXTERNAL_INPUT_RELAY_LEASE_GENERATION_UNRECORDED,
+        };
+
+        // A PREVIOUS turn's inflight (DIFFERENT anchor id) still present at timeout
+        // => the predicate says DECLINE (do not overwrite its offset).
+        let prior = build_tui_direct_synthetic_inflight_state(
+            provider.clone(),
+            channel_id,
+            MessageId::new(940_000_000_003_111),
+            None,
+            "prior turn",
+            tmux_session_name,
+            Some(&output_path),
+            0,
+            &lease,
+            RelayOwnerKind::None,
+        );
+        let should_decline = !inflight_is_current_turn_synthetic(
+            Some(&prior),
+            tmux_session_name,
+            Some(new_turn_anchor),
+        );
+        assert!(
+            should_decline,
+            "a still-present DIFFERENT prior inflight must make the timed-out turn-start DECLINE"
+        );
+
+        // The present row is OUR OWN synthetic (matching anchor id) => do NOT
+        // decline (we would just be waiting on ourselves; let the claim proceed).
+        let own = build_tui_direct_synthetic_inflight_state(
+            provider.clone(),
+            channel_id,
+            MessageId::new(new_turn_anchor),
+            None,
+            "our own synthetic",
+            tmux_session_name,
+            Some(&output_path),
+            0,
+            &lease,
+            RelayOwnerKind::None,
+        );
+        assert!(
+            inflight_is_current_turn_synthetic(
+                Some(&own),
+                tmux_session_name,
+                Some(new_turn_anchor),
+            ),
+            "our own synthetic must NOT trigger a decline"
+        );
+
+        // Nothing present => no decline (the `prior.is_some()` guard is false).
+        assert!(
+            !inflight_is_current_turn_synthetic(None, tmux_session_name, Some(new_turn_anchor)),
+            "an absent inflight must not be treated as a blocking prior turn"
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
Closes #3154.

## Problem
Wakeup/loop (self-paced) synthetic turns started WITHOUT serializing against the previous turn's inflight relay drain. A new wakeup turn began writing `response_sent_offset` while turn1's terminal relay was still draining, so the two turns' offset bookkeeping collided — `response_sent_offset_monotonic` went backwards (74 production violations on channel `1479671298497183835`), producing double / un-ACKed relay. #3041 serialized DELIVERY but NOT turn-START.

## Fix (scoped strictly to `tui_prompt_relay.rs`)
`claim_tui_direct_synthetic_turn` now runs the SAME bounded drain-wait the idle-tail path uses (`wait_for_claude_inflight_to_clear`) BEFORE `mailbox_try_start_turn_kinded`:

- **Bounded** — `CLAUDE_IDLE_INFLIGHT_DRAIN_WAIT` (5s) timeout + 100ms poll; cannot hang.
- **Channel/turn-scoped** — per-channel Claude inflight row; our own synthetic for THIS turn is exempted via `inflight_is_current_turn_synthetic` (same tmux session + matching anchor `user_msg_id`).
- **Deadlock-free** — our synthetic for THIS turn does not exist yet at the wait point, so it can never wait on itself.
- **Only delays or declines, never drops/duplicates** — on TIMEOUT, if a genuinely-distinct prior inflight is STILL present, the claim is DECLINED (`claimed: false`) BEFORE touching the mailbox/inflight store, so a fresh synthetic never overwrites the prior row's `response_sent_offset` (which would itself trip the invariant). Identical in effect to the existing "mailbox already owns a different turn" decline; nothing was started, so no cleanup is needed.

No #3016 frozen hotfile (`turn_bridge/mod.rs`, `tmux_watcher.rs`, `session_relay_sink.rs`, `turn_finalizer.rs`) was touched.

## Tests
- `turn_start_drain_wait_blocks_until_prior_inflight_clears` — end-to-end against the real inflight store: WAITS while a prior turn's inflight drains, PROCEEDS once it clears, and does NOT wait when no draining inflight is present.
- `turn_start_decline_predicate_only_fires_on_distinct_prior_inflight` — the timeout decline predicate fires only for a still-present distinct prior inflight, never for our own synthetic or an absent row.

`cargo build --lib` clean; `cargo test --lib tui_prompt_relay` 89 passed / 0 failed. Freeze in `change-surfaces.md` synced to production count (4522 → 4605, +83; cfg(test) excluded). codex GATE: GATE_PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)