### PR TITLE
refactor(#3038): decompose claude.rs execute_streaming_local_tui_tmux

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -719,7 +719,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
 - `src/services/dispatches/outbox_route.rs` (1118) — dispatch outbox route
   support extracted from the route layer; split before adding non-bugfix
   behavior.
-- `src/services/claude.rs` (3911), `src/services/gemini.rs` (1416),
+- `src/services/claude.rs` (3912), `src/services/gemini.rs` (1416),
   `src/services/qwen.rs` (2200), `src/services/codex.rs` (3083),
   `src/services/opencode.rs` (1881), `src/services/provider.rs` (1738) —
   provider adapters.

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -719,7 +719,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
 - `src/services/dispatches/outbox_route.rs` (1118) — dispatch outbox route
   support extracted from the route layer; split before adding non-bugfix
   behavior.
-- `src/services/claude.rs` (3795), `src/services/gemini.rs` (1416),
+- `src/services/claude.rs` (3911), `src/services/gemini.rs` (1416),
   `src/services/qwen.rs` (2200), `src/services/codex.rs` (3083),
   `src/services/opencode.rs` (1881), `src/services/provider.rs` (1738) —
   provider adapters.

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -2874,6 +2874,7 @@ fn try_claude_tui_warm_followup(
 /// Verbatim extraction of the pre-refactor `else if session_exists` branch.
 #[cfg(unix)]
 fn cleanup_stale_claude_tui_session(tmux_session_name: &str) {
+    debug_log("Stale Claude TUI tmux session found — recreating");
     crate::services::termination_audit::record_termination_for_tmux(
         tmux_session_name,
         None,

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -2216,555 +2216,41 @@ fn execute_streaming_local_tui_tmux(
     }
 
     if session_exists && has_live_pane && resume {
-        debug_log("Existing Claude TUI tmux session found — sending follow-up");
-        if let Some(ref token) = cancel_token {
-            *token.tmux_session.lock().unwrap_or_else(|e| e.into_inner()) =
-                Some(tmux_session_name.to_string());
-        }
-        let hook_rx = crate::services::claude_tui::hook_server::subscribe_hook_events();
-        // #2416: a single busy_waited flag tells the offset-capture site below
-        // that we need to re-read transcript length after the wait succeeded,
-        // because the previous TUI turn may have appended bytes while we were
-        // waiting (otherwise the follow-up reader would treat previous-turn
-        // bytes as new-turn output).
-        let mut busy_waited = false;
-        let mut recreate_before_submit = false;
-        let mut prompt_draft_cleared_before_submit = false;
-        if let Some(snapshot) =
-            claude_tui_followup_busy_before_submit(tmux_session_name, Some(&transcript_path))
-        {
-            if let Some(draft_state) =
-                claude_tui_followup_stranded_prompt_draft_state(&snapshot, &transcript_path)
-            {
-                let allow_recreate = matches!(
-                    draft_state,
-                    ClaudeTuiStrandedPromptDraftState::IdleTranscript
-                );
-                tracing::warn!(
-                    tmux_session_name,
-                    transcript_path = %transcript_path_string,
-                    transcript_turn_state = draft_state.as_str(),
-                    prompt_marker_detected = snapshot.prompt_marker_detected,
-                    prompt_draft_detected = snapshot.prompt_draft_detected,
-                    capture_available = snapshot.capture_available,
-                    pane_tail = %snapshot.pane_tail,
-                    "claude_tui follow-up found non-busy transcript with stranded composer draft; attempting draft clear"
-                );
-                debug_log(&format!(
-                    "Claude TUI follow-up: {} transcript has stranded prompt draft, attempting clear (session={}, transcript={})",
-                    draft_state.as_str(),
-                    tmux_session_name,
-                    transcript_path_string
-                ));
-                let clear_result = if allow_recreate {
-                    clear_claude_tui_stranded_prompt_draft(
-                        tmux_session_name,
-                        cancel_token.as_deref(),
-                    )
-                } else {
-                    gently_clear_claude_tui_prompt_draft(tmux_session_name, cancel_token.as_deref())
-                };
-                match clear_result {
-                    Ok(post_clear_snapshot)
-                        if post_clear_snapshot.tmux_pane_alive
-                            && !post_clear_snapshot.prompt_draft_detected =>
-                    {
-                        busy_waited = true;
-                        prompt_draft_cleared_before_submit = true;
-                        tracing::info!(
-                            tmux_session_name,
-                            transcript_turn_state = draft_state.as_str(),
-                            prompt_marker_detected = post_clear_snapshot.prompt_marker_detected,
-                            capture_available = post_clear_snapshot.capture_available,
-                            "claude_tui stranded prompt draft cleared before follow-up submit"
-                        );
-                        debug_log(&format!(
-                            "Claude TUI follow-up: stranded prompt draft cleared (session={} prompt_marker_detected={} capture_available={})",
-                            tmux_session_name,
-                            post_clear_snapshot.prompt_marker_detected,
-                            post_clear_snapshot.capture_available
-                        ));
-                    }
-                    Ok(post_clear_snapshot) => {
-                        let reason = if post_clear_snapshot.tmux_pane_alive {
-                            "stranded claude tui prompt draft persisted after clear attempts"
-                        } else {
-                            "claude tui pane died while clearing stranded prompt draft"
-                        };
-                        let recreate_after_persistent_draft = allow_recreate
-                            || (matches!(
-                                draft_state,
-                                ClaudeTuiStrandedPromptDraftState::UnknownTranscript
-                            ) && claude_tui_unknown_transcript_draft_recreate_allowed(
-                                &post_clear_snapshot,
-                            ));
-                        if !recreate_after_persistent_draft {
-                            tracing::warn!(
-                                tmux_session_name,
-                                transcript_turn_state = draft_state.as_str(),
-                                prompt_marker_detected = post_clear_snapshot.prompt_marker_detected,
-                                prompt_draft_detected = post_clear_snapshot.prompt_draft_detected,
-                                tmux_pane_alive = post_clear_snapshot.tmux_pane_alive,
-                                capture_available = post_clear_snapshot.capture_available,
-                                pane_tail = %post_clear_snapshot.pane_tail,
-                                "claude_tui unknown-transcript draft recovery did not clear draft; falling back to busy wait"
-                            );
-                            debug_log(&format!(
-                                "Claude TUI follow-up: {} under unknown transcript; falling back to busy wait (session={})",
-                                reason, tmux_session_name
-                            ));
-                        } else {
-                            tracing::warn!(
-                                tmux_session_name,
-                                prompt_marker_detected = post_clear_snapshot.prompt_marker_detected,
-                                prompt_draft_detected = post_clear_snapshot.prompt_draft_detected,
-                                tmux_pane_alive = post_clear_snapshot.tmux_pane_alive,
-                                capture_available = post_clear_snapshot.capture_available,
-                                pane_tail = %post_clear_snapshot.pane_tail,
-                                "claude_tui stranded prompt draft recovery will recreate hosted session"
-                            );
-                            debug_log(&format!(
-                                "Claude TUI follow-up: {} (session={})",
-                                reason, tmux_session_name
-                            ));
-                            crate::services::termination_audit::record_termination_for_tmux(
-                                tmux_session_name,
-                                None,
-                                "claude_tui_provider",
-                                "stranded_prompt_draft_recreate",
-                                Some(reason),
-                                None,
-                            );
-                            record_tmux_exit_reason(tmux_session_name, reason);
-                            crate::services::platform::tmux::kill_session(
-                                tmux_session_name,
-                                reason,
-                            );
-                            let fresh_resolution =
-                                fresh_claude_tui_session_resolution(working_dir_path, None)?;
-                            resolved_session_id = fresh_resolution.session_id;
-                            transcript_path = fresh_resolution.transcript_path;
-                            transcript_path_string = transcript_path.display().to_string();
-                            resume = fresh_resolution.resume;
-                            recreate_before_submit = true;
-                        }
-                    }
-                    Err(error)
-                        if crate::services::claude_tui::input::is_prompt_ready_cancelled_error(
-                            &error,
-                        ) =>
-                    {
-                        debug_log(&format!(
-                            "Claude TUI follow-up: cancellation observed while clearing stranded prompt draft (session={})",
-                            tmux_session_name
-                        ));
-                        log_producer_exit(
-                            "tui_warm_followup_cancelled_during_draft_clear",
-                            Some(&resolved_session_id),
-                            report_channel_id,
-                            0,
-                            serde_json::json!({
-                                "tmux_session_name": tmux_session_name,
-                                "transcript_path": transcript_path_string,
-                            }),
-                        );
-                        return Ok(());
-                    }
-                    Err(error) => {
-                        let recreate_after_clear_error = allow_recreate
-                            || (matches!(
-                                draft_state,
-                                ClaudeTuiStrandedPromptDraftState::UnknownTranscript
-                            ) && claude_tui_unknown_transcript_draft_recreate_allowed(
-                                &snapshot,
-                            ));
-                        if !recreate_after_clear_error {
-                            tracing::warn!(
-                                tmux_session_name,
-                                error = %error,
-                                "claude_tui unknown-transcript draft clear failed; falling back to busy wait"
-                            );
-                            debug_log(&format!(
-                                "Claude TUI follow-up: unknown-transcript draft clear failed, falling back to busy wait (session={} error={})",
-                                tmux_session_name, error
-                            ));
-                        } else {
-                            tracing::warn!(
-                                tmux_session_name,
-                                error = %error,
-                                "claude_tui stranded prompt draft clear failed; recreating hosted session"
-                            );
-                            crate::services::termination_audit::record_termination_for_tmux(
-                                tmux_session_name,
-                                None,
-                                "claude_tui_provider",
-                                "stranded_prompt_draft_clear_failed_recreate",
-                                Some(&format!(
-                                    "claude tui stranded prompt draft clear failed: {}",
-                                    error
-                                )),
-                                None,
-                            );
-                            record_tmux_exit_reason(
-                                tmux_session_name,
-                                &format!(
-                                    "claude tui stranded prompt draft clear failed: {}",
-                                    error
-                                ),
-                            );
-                            crate::services::platform::tmux::kill_session(
-                                tmux_session_name,
-                                &format!(
-                                    "claude tui stranded prompt draft clear failed: {}",
-                                    error
-                                ),
-                            );
-                            let fresh_resolution =
-                                fresh_claude_tui_session_resolution(working_dir_path, None)?;
-                            resolved_session_id = fresh_resolution.session_id;
-                            transcript_path = fresh_resolution.transcript_path;
-                            transcript_path_string = transcript_path.display().to_string();
-                            resume = fresh_resolution.resume;
-                            recreate_before_submit = true;
-                        }
-                    }
-                }
-            }
-        }
-        let submit_plan = claude_tui_warm_followup_submit_plan(
-            recreate_before_submit,
-            prompt_draft_cleared_before_submit,
-        );
-        if submit_plan.submit_existing_session {
-            if submit_plan.recheck_busy_before_submit
-                && let Some(snapshot) = claude_tui_followup_busy_before_submit(
-                    tmux_session_name,
-                    Some(&transcript_path),
-                )
-            {
-                // #2416: instead of dropping the user's message when the TUI is busy,
-                // wait for the next prompt-ready window. The transcript-idle
-                // fallback covers Claude TUI redraws where the JSONL terminal
-                // envelope is authoritative but the prompt glyph is not visible.
-                match crate::services::claude_tui::input::wait_for_prompt_ready_or_idle_transcript(
-                    tmux_session_name,
-                    crate::services::claude_tui::input::PromptReadinessKind::Followup,
-                    cancel_token.as_deref(),
-                    &transcript_path,
-                ) {
-                    Ok(()) => {
-                        busy_waited = true;
-                        debug_log(&format!(
-                            "Claude TUI follow-up: busy at first check, became ready after wait (session={})",
-                            tmux_session_name
-                        ));
-                    }
-                    Err(err) => {
-                        if crate::services::claude_tui::input::is_prompt_ready_cancelled_error(&err)
-                        {
-                            debug_log(&format!(
-                                "Claude TUI follow-up: cancellation observed during busy wait, aborting injection (session={})",
-                                tmux_session_name
-                            ));
-                            log_producer_exit(
-                                "tui_warm_followup_cancelled_during_busy_wait",
-                                Some(&resolved_session_id),
-                                report_channel_id,
-                                0,
-                                serde_json::json!({
-                                    "tmux_session_name": tmux_session_name,
-                                    "transcript_path": transcript_path_string,
-                                }),
-                            );
-                            return Ok(());
-                        }
-                        let timed_out =
-                            crate::services::claude_tui::input::is_prompt_ready_timeout_error(&err);
-                        debug_log(&format!(
-                            "Claude TUI follow-up wait failed after busy snapshot (session={}, timed_out={}): {}",
-                            tmux_session_name, timed_out, err
-                        ));
-                        let post_wait_snapshot =
-                            crate::services::claude_tui::input::prompt_readiness_snapshot(
-                                tmux_session_name,
-                            );
-                        emit_claude_tui_busy_followup_notice(
-                            &sender,
-                            tmux_session_name,
-                            &post_wait_snapshot,
-                        );
-                        log_producer_exit(
-                            "tui_warm_followup_busy_pre_submit",
-                            Some(&resolved_session_id),
-                            report_channel_id,
-                            0,
-                            serde_json::json!({
-                                "tmux_session_name": tmux_session_name,
-                                "transcript_path": transcript_path_string,
-                                "prompt_marker_detected": post_wait_snapshot.prompt_marker_detected,
-                                "prompt_draft_detected": post_wait_snapshot.prompt_draft_detected,
-                                "prompt_draft_blocks_submission": post_wait_snapshot.tmux_pane_alive && post_wait_snapshot.prompt_draft_detected,
-                                "tmux_pane_alive": post_wait_snapshot.tmux_pane_alive,
-                                "capture_available": post_wait_snapshot.capture_available,
-                                "initial_busy_snapshot_prompt_marker_detected": snapshot.prompt_marker_detected,
-                                "initial_busy_snapshot_prompt_draft_detected": snapshot.prompt_draft_detected,
-                                "wait_outcome": if timed_out { "timeout" } else { "error" },
-                                "wait_error": err,
-                            }),
-                        );
-                        return Ok(());
-                    }
-                }
-            }
-            // #2416: capture the transcript offset AFTER the optional busy wait so
-            // that any bytes the previous TUI turn appended while we were waiting
-            // are not replayed as part of this follow-up's output window. This
-            // closes a Codex-flagged HIGH (stale offset → duplicate / early-done
-            // delivery accounting).
-            let fallback_start_offset = std::fs::metadata(&transcript_path)
-                .map(|meta| meta.len())
-                .unwrap_or(0);
-            // #2416: also honour cancellation that may have flipped during the
-            // up-to-45s busy wait. Without this, a user stop reaction / watchdog
-            // cancellation arriving mid-wait would still inject the prompt as
-            // soon as the TUI returns to ready. Closes a Codex-flagged HIGH.
-            if busy_waited && crate::services::provider::cancel_requested(cancel_token.as_deref()) {
-                debug_log(&format!(
-                    "Claude TUI follow-up: cancellation observed after busy wait, aborting injection (session={})",
-                    tmux_session_name
-                ));
-                log_producer_exit(
-                    "tui_warm_followup_cancelled_after_busy_wait",
-                    Some(&resolved_session_id),
-                    report_channel_id,
-                    0,
-                    serde_json::json!({
-                        "tmux_session_name": tmux_session_name,
-                        "transcript_path": transcript_path_string,
-                    }),
-                );
-                return Ok(());
-            }
-            let turn_started_at = chrono::Utc::now();
-            if let Err(error) =
-                crate::services::claude_tui::input::send_followup_prompt_or_idle_transcript(
-                    tmux_session_name,
-                    prompt,
-                    cancel_token.as_deref(),
-                    &transcript_path,
-                )
-            {
-                if crate::services::claude_tui::input::is_prompt_ready_cancelled_error(&error) {
-                    debug_log(&format!(
-                        "Claude TUI follow-up: cancellation observed during prompt submission, aborting injection (session={})",
-                        tmux_session_name
-                    ));
-                    log_producer_exit(
-                        "tui_warm_followup_cancelled_during_prompt_submit",
-                        Some(&resolved_session_id),
-                        report_channel_id,
-                        0,
-                        serde_json::json!({
-                            "tmux_session_name": tmux_session_name,
-                            "transcript_path": transcript_path_string,
-                        }),
-                    );
-                    return Ok(());
-                }
-                return Err(error);
-            }
-            let hook_events_after = chrono::Utc::now();
-            let start_offset = claude_tui_turn_start_offset_after_timestamp(
-                &transcript_path,
-                turn_started_at,
-                fallback_start_offset,
-            );
-            let read_result = read_claude_tui_transcript_until_done(
-                &transcript_path_string,
-                start_offset,
-                sender.clone(),
-                cancel_token.clone(),
-                tmux_session_name,
-                &resolved_session_id,
-                hook_rx,
-                hook_events_after,
-            )?;
-            let zero_advance_terminal_result = match &read_result {
-                ReadOutputResult::Completed { offset } | ReadOutputResult::Cancelled { offset } => {
-                    *offset <= start_offset
-                }
-                ReadOutputResult::SessionDied { .. } => false,
-            };
-            if zero_advance_terminal_result {
-                let snapshot = crate::services::claude_tui::input::prompt_readiness_snapshot(
-                    tmux_session_name,
-                );
-                if claude_tui_prompt_remained_in_input_buffer(&snapshot, prompt) {
-                    return Err(claude_tui_zero_advance_input_buffer_error(
-                        tmux_session_name,
-                        &transcript_path_string,
-                        start_offset,
-                        &snapshot,
-                    ));
-                }
-            }
-            match classify_followup_result(
-                read_result,
-                start_offset,
-                "claude tui session died during follow-up output reading",
-            ) {
-                ClaudeFollowupResult::Delivered => {
-                    emit_claude_tui_watcher_handoff(
-                        &sender,
-                        &transcript_path_string,
-                        tmux_session_name,
-                        &transcript_path,
-                    );
-                    log_producer_exit(
-                        "tui_warm_followup_delivered",
-                        Some(&resolved_session_id),
-                        report_channel_id,
-                        0,
-                        serde_json::json!({
-                            "tmux_session_name": tmux_session_name,
-                            "transcript_path": transcript_path_string,
-                        }),
-                    );
-                    return Ok(());
-                }
-                ClaudeFollowupResult::RecreateSession { error } => {
-                    debug_log(&format!(
-                        "Claude TUI follow-up failed, recreating session: {}",
-                        error
-                    ));
-                    crate::services::termination_audit::record_termination_for_tmux(
-                        tmux_session_name,
-                        None,
-                        "claude_tui_provider",
-                        "followup_failed_recreate",
-                        Some(&format!(
-                            "claude tui follow-up failed, recreating: {}",
-                            error
-                        )),
-                        None,
-                    );
-                    record_tmux_exit_reason(
-                        tmux_session_name,
-                        &format!("claude tui follow-up failed, recreating: {}", error),
-                    );
-                    crate::services::platform::tmux::kill_session(
-                        tmux_session_name,
-                        &format!("claude tui follow-up failed, recreating: {}", error),
-                    );
-                }
-                ClaudeFollowupResult::FinalizeWithNotice { error, notice } => {
-                    debug_log(&format!(
-                        "Claude TUI follow-up streamed partial output before session death — suppressing replay: {}",
-                        error
-                    ));
-                    crate::services::termination_audit::record_termination_for_tmux(
-                        tmux_session_name,
-                        None,
-                        "claude_tui_provider",
-                        "followup_partial_output_no_replay",
-                        Some(&format!(
-                            "claude tui partial follow-up output delivered: {}",
-                            error
-                        )),
-                        None,
-                    );
-                    record_tmux_exit_reason(
-                        tmux_session_name,
-                        &format!("claude tui partial follow-up output delivered: {}", error),
-                    );
-                    crate::services::platform::tmux::kill_session(
-                        tmux_session_name,
-                        &format!("claude tui partial follow-up output delivered: {}", error),
-                    );
-                    emit_followup_restart_suppressed_notice(&sender, &notice);
-                    return Ok(());
-                }
+        match try_claude_tui_warm_followup(
+            resolved_session_id,
+            transcript_path,
+            transcript_path_string,
+            resume,
+            working_dir_path,
+            prompt,
+            sender.clone(),
+            cancel_token.clone(),
+            tmux_session_name,
+            report_channel_id,
+        ) {
+            ClaudeTuiWarmFollowupOutcome::Terminal(result) => return result,
+            ClaudeTuiWarmFollowupOutcome::Recreate(updated) => {
+                resolved_session_id = updated.resolved_session_id;
+                transcript_path = updated.transcript_path;
+                transcript_path_string = updated.transcript_path_string;
+                resume = updated.resume;
             }
         }
     } else if session_exists {
-        debug_log("Stale Claude TUI tmux session found — recreating");
-        crate::services::termination_audit::record_termination_for_tmux(
-            tmux_session_name,
-            None,
-            "claude_tui_provider",
-            "stale_session_recreate",
-            Some("stale claude tui session cleanup before recreate"),
-            None,
-        );
-        record_tmux_exit_reason(
-            tmux_session_name,
-            "stale claude tui session cleanup before recreate",
-        );
-        crate::services::platform::tmux::kill_session(
-            tmux_session_name,
-            "stale claude tui session cleanup before recreate",
-        );
+        cleanup_stale_claude_tui_session(tmux_session_name);
     }
 
-    crate::services::tmux_common::cleanup_session_temp_files(tmux_session_name);
-    write_tmux_owner_marker(tmux_session_name)?;
-    crate::services::tmux_common::write_tmux_runtime_kind_marker(
+    let owner_path = prepare_and_create_claude_tui_session(
         tmux_session_name,
-        crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui,
+        working_dir,
+        working_dir_path,
+        &resolved_session_id,
+        system_prompt,
+        model_override,
+        hook_endpoint,
+        resume,
+        compact_percent,
     )?;
-    let owner_path = tmux_owner_path(tmux_session_name);
-    let mut prepared_session_files = None;
-    let launch_result = (|| -> Result<std::process::Output, String> {
-        let exe =
-            std::env::current_exe().map_err(|e| format!("Failed to get executable path: {}", e))?;
-        let resolution = resolve_claude_binary();
-        let claude_bin = resolution
-            .resolved_path
-            .clone()
-            .ok_or_else(|| "Claude CLI not found".to_string())?;
-        let launch_config = crate::services::claude_tui::session::ClaudeTuiLaunchConfig {
-            tmux_session_name: tmux_session_name.to_string(),
-            working_dir: working_dir_path.to_path_buf(),
-            claude_bin: std::path::PathBuf::from(claude_bin),
-            agentdesk_exe: exe,
-            hook_endpoint,
-            session_id: resolved_session_id.clone(),
-            system_prompt: system_prompt.map(str::to_string),
-            model: model_override.map(str::to_string),
-            resume,
-            compact_percent,
-        };
-        let session_files =
-            crate::services::claude_tui::session::prepare_claude_tui_launch(&launch_config)?;
-        let launch_script_path = session_files.launch_script_path.clone();
-        prepared_session_files = Some(session_files);
-        crate::services::platform::tmux::create_session(
-            tmux_session_name,
-            Some(working_dir),
-            &format!(
-                "bash {}",
-                shell_escape(&launch_script_path.display().to_string())
-            ),
-        )
-    })();
-    let tmux_result = match launch_result {
-        Ok(result) => result,
-        Err(error) => {
-            if let Some(files) = prepared_session_files.as_ref() {
-                files.cleanup_best_effort();
-            }
-            let _ = std::fs::remove_file(&owner_path);
-            return Err(error);
-        }
-    };
-    if !tmux_result.status.success() {
-        let stderr = String::from_utf8_lossy(&tmux_result.stderr);
-        if let Some(files) = prepared_session_files.as_ref() {
-            files.cleanup_best_effort();
-        }
-        let _ = std::fs::remove_file(&owner_path);
-        return Err(format!("tmux error: {}", stderr));
-    }
     crate::services::platform::tmux::set_option(tmux_session_name, "remain-on-exit", "on");
 
     // #3087: stamp a per-spawn nonce on the Claude-TUI DIRECT spawn path too.
@@ -2858,6 +2344,636 @@ fn execute_streaming_local_tui_tmux(
         }),
     );
     Ok(())
+}
+
+/// Updated session resolution carried back to the orchestrator when a warm
+/// follow-up could not be delivered and the hosted session must be recreated.
+#[cfg(unix)]
+struct ClaudeTuiRecreateState {
+    resolved_session_id: String,
+    transcript_path: std::path::PathBuf,
+    transcript_path_string: String,
+    resume: bool,
+}
+
+/// Outcome of an attempted warm follow-up against a live Claude TUI session.
+#[cfg(unix)]
+enum ClaudeTuiWarmFollowupOutcome {
+    /// The follow-up turn was handled (delivered, aborted, or errored); the
+    /// orchestrator returns this `Result` directly without a fresh launch.
+    Terminal(Result<(), String>),
+    /// The follow-up could not proceed; the orchestrator must fall through to a
+    /// fresh launch using the (possibly updated) session resolution.
+    Recreate(ClaudeTuiRecreateState),
+}
+
+/// Attempt a warm follow-up against an existing live Claude TUI tmux session.
+///
+/// Mirrors the pre-refactor inline `if session_exists && has_live_pane && resume`
+/// block verbatim: stranded prompt-draft recovery, busy-wait, prompt submission,
+/// transcript read, and the follow-up result classification. Every original
+/// `return Ok(())` / `return Err(..)` / `?` short-circuit is preserved as a
+/// `Terminal(..)` outcome (so the orchestrator returns immediately with the same
+/// value, before any fresh-launch side-effect). When the block originally fell
+/// through to a fresh launch — `submit_existing_session == false`, the
+/// `RecreateSession` classification, or a draft-recovery recreate — this returns
+/// `Recreate(..)` carrying the session resolution exactly as the inline locals
+/// held it at that point.
+#[cfg(unix)]
+fn try_claude_tui_warm_followup(
+    mut resolved_session_id: String,
+    mut transcript_path: std::path::PathBuf,
+    mut transcript_path_string: String,
+    mut resume: bool,
+    working_dir_path: &std::path::Path,
+    prompt: &str,
+    sender: Sender<StreamMessage>,
+    cancel_token: Option<std::sync::Arc<CancelToken>>,
+    tmux_session_name: &str,
+    report_channel_id: Option<u64>,
+) -> ClaudeTuiWarmFollowupOutcome {
+    debug_log("Existing Claude TUI tmux session found — sending follow-up");
+    if let Some(ref token) = cancel_token {
+        *token.tmux_session.lock().unwrap_or_else(|e| e.into_inner()) =
+            Some(tmux_session_name.to_string());
+    }
+    let hook_rx = crate::services::claude_tui::hook_server::subscribe_hook_events();
+    // #2416: a single busy_waited flag tells the offset-capture site below
+    // that we need to re-read transcript length after the wait succeeded,
+    // because the previous TUI turn may have appended bytes while we were
+    // waiting (otherwise the follow-up reader would treat previous-turn
+    // bytes as new-turn output).
+    let mut busy_waited = false;
+    let mut recreate_before_submit = false;
+    let mut prompt_draft_cleared_before_submit = false;
+    if let Some(snapshot) =
+        claude_tui_followup_busy_before_submit(tmux_session_name, Some(&transcript_path))
+    {
+        if let Some(draft_state) =
+            claude_tui_followup_stranded_prompt_draft_state(&snapshot, &transcript_path)
+        {
+            let allow_recreate = matches!(
+                draft_state,
+                ClaudeTuiStrandedPromptDraftState::IdleTranscript
+            );
+            tracing::warn!(
+                tmux_session_name,
+                transcript_path = %transcript_path_string,
+                transcript_turn_state = draft_state.as_str(),
+                prompt_marker_detected = snapshot.prompt_marker_detected,
+                prompt_draft_detected = snapshot.prompt_draft_detected,
+                capture_available = snapshot.capture_available,
+                pane_tail = %snapshot.pane_tail,
+                "claude_tui follow-up found non-busy transcript with stranded composer draft; attempting draft clear"
+            );
+            debug_log(&format!(
+                "Claude TUI follow-up: {} transcript has stranded prompt draft, attempting clear (session={}, transcript={})",
+                draft_state.as_str(),
+                tmux_session_name,
+                transcript_path_string
+            ));
+            let clear_result = if allow_recreate {
+                clear_claude_tui_stranded_prompt_draft(tmux_session_name, cancel_token.as_deref())
+            } else {
+                gently_clear_claude_tui_prompt_draft(tmux_session_name, cancel_token.as_deref())
+            };
+            match clear_result {
+                Ok(post_clear_snapshot)
+                    if post_clear_snapshot.tmux_pane_alive
+                        && !post_clear_snapshot.prompt_draft_detected =>
+                {
+                    busy_waited = true;
+                    prompt_draft_cleared_before_submit = true;
+                    tracing::info!(
+                        tmux_session_name,
+                        transcript_turn_state = draft_state.as_str(),
+                        prompt_marker_detected = post_clear_snapshot.prompt_marker_detected,
+                        capture_available = post_clear_snapshot.capture_available,
+                        "claude_tui stranded prompt draft cleared before follow-up submit"
+                    );
+                    debug_log(&format!(
+                        "Claude TUI follow-up: stranded prompt draft cleared (session={} prompt_marker_detected={} capture_available={})",
+                        tmux_session_name,
+                        post_clear_snapshot.prompt_marker_detected,
+                        post_clear_snapshot.capture_available
+                    ));
+                }
+                Ok(post_clear_snapshot) => {
+                    let reason = if post_clear_snapshot.tmux_pane_alive {
+                        "stranded claude tui prompt draft persisted after clear attempts"
+                    } else {
+                        "claude tui pane died while clearing stranded prompt draft"
+                    };
+                    let recreate_after_persistent_draft = allow_recreate
+                        || (matches!(
+                            draft_state,
+                            ClaudeTuiStrandedPromptDraftState::UnknownTranscript
+                        ) && claude_tui_unknown_transcript_draft_recreate_allowed(
+                            &post_clear_snapshot,
+                        ));
+                    if !recreate_after_persistent_draft {
+                        tracing::warn!(
+                            tmux_session_name,
+                            transcript_turn_state = draft_state.as_str(),
+                            prompt_marker_detected = post_clear_snapshot.prompt_marker_detected,
+                            prompt_draft_detected = post_clear_snapshot.prompt_draft_detected,
+                            tmux_pane_alive = post_clear_snapshot.tmux_pane_alive,
+                            capture_available = post_clear_snapshot.capture_available,
+                            pane_tail = %post_clear_snapshot.pane_tail,
+                            "claude_tui unknown-transcript draft recovery did not clear draft; falling back to busy wait"
+                        );
+                        debug_log(&format!(
+                            "Claude TUI follow-up: {} under unknown transcript; falling back to busy wait (session={})",
+                            reason, tmux_session_name
+                        ));
+                    } else {
+                        tracing::warn!(
+                            tmux_session_name,
+                            prompt_marker_detected = post_clear_snapshot.prompt_marker_detected,
+                            prompt_draft_detected = post_clear_snapshot.prompt_draft_detected,
+                            tmux_pane_alive = post_clear_snapshot.tmux_pane_alive,
+                            capture_available = post_clear_snapshot.capture_available,
+                            pane_tail = %post_clear_snapshot.pane_tail,
+                            "claude_tui stranded prompt draft recovery will recreate hosted session"
+                        );
+                        debug_log(&format!(
+                            "Claude TUI follow-up: {} (session={})",
+                            reason, tmux_session_name
+                        ));
+                        crate::services::termination_audit::record_termination_for_tmux(
+                            tmux_session_name,
+                            None,
+                            "claude_tui_provider",
+                            "stranded_prompt_draft_recreate",
+                            Some(reason),
+                            None,
+                        );
+                        record_tmux_exit_reason(tmux_session_name, reason);
+                        crate::services::platform::tmux::kill_session(tmux_session_name, reason);
+                        let fresh_resolution =
+                            match fresh_claude_tui_session_resolution(working_dir_path, None) {
+                                Ok(resolution) => resolution,
+                                Err(error) => {
+                                    return ClaudeTuiWarmFollowupOutcome::Terminal(Err(error));
+                                }
+                            };
+                        resolved_session_id = fresh_resolution.session_id;
+                        transcript_path = fresh_resolution.transcript_path;
+                        transcript_path_string = transcript_path.display().to_string();
+                        resume = fresh_resolution.resume;
+                        recreate_before_submit = true;
+                    }
+                }
+                Err(error)
+                    if crate::services::claude_tui::input::is_prompt_ready_cancelled_error(
+                        &error,
+                    ) =>
+                {
+                    debug_log(&format!(
+                        "Claude TUI follow-up: cancellation observed while clearing stranded prompt draft (session={})",
+                        tmux_session_name
+                    ));
+                    log_producer_exit(
+                        "tui_warm_followup_cancelled_during_draft_clear",
+                        Some(&resolved_session_id),
+                        report_channel_id,
+                        0,
+                        serde_json::json!({
+                            "tmux_session_name": tmux_session_name,
+                            "transcript_path": transcript_path_string,
+                        }),
+                    );
+                    return ClaudeTuiWarmFollowupOutcome::Terminal(Ok(()));
+                }
+                Err(error) => {
+                    let recreate_after_clear_error = allow_recreate
+                        || (matches!(
+                            draft_state,
+                            ClaudeTuiStrandedPromptDraftState::UnknownTranscript
+                        ) && claude_tui_unknown_transcript_draft_recreate_allowed(&snapshot));
+                    if !recreate_after_clear_error {
+                        tracing::warn!(
+                            tmux_session_name,
+                            error = %error,
+                            "claude_tui unknown-transcript draft clear failed; falling back to busy wait"
+                        );
+                        debug_log(&format!(
+                            "Claude TUI follow-up: unknown-transcript draft clear failed, falling back to busy wait (session={} error={})",
+                            tmux_session_name, error
+                        ));
+                    } else {
+                        tracing::warn!(
+                            tmux_session_name,
+                            error = %error,
+                            "claude_tui stranded prompt draft clear failed; recreating hosted session"
+                        );
+                        crate::services::termination_audit::record_termination_for_tmux(
+                            tmux_session_name,
+                            None,
+                            "claude_tui_provider",
+                            "stranded_prompt_draft_clear_failed_recreate",
+                            Some(&format!(
+                                "claude tui stranded prompt draft clear failed: {}",
+                                error
+                            )),
+                            None,
+                        );
+                        record_tmux_exit_reason(
+                            tmux_session_name,
+                            &format!("claude tui stranded prompt draft clear failed: {}", error),
+                        );
+                        crate::services::platform::tmux::kill_session(
+                            tmux_session_name,
+                            &format!("claude tui stranded prompt draft clear failed: {}", error),
+                        );
+                        let fresh_resolution =
+                            match fresh_claude_tui_session_resolution(working_dir_path, None) {
+                                Ok(resolution) => resolution,
+                                Err(error) => {
+                                    return ClaudeTuiWarmFollowupOutcome::Terminal(Err(error));
+                                }
+                            };
+                        resolved_session_id = fresh_resolution.session_id;
+                        transcript_path = fresh_resolution.transcript_path;
+                        transcript_path_string = transcript_path.display().to_string();
+                        resume = fresh_resolution.resume;
+                        recreate_before_submit = true;
+                    }
+                }
+            }
+        }
+    }
+    let submit_plan = claude_tui_warm_followup_submit_plan(
+        recreate_before_submit,
+        prompt_draft_cleared_before_submit,
+    );
+    if submit_plan.submit_existing_session {
+        if submit_plan.recheck_busy_before_submit
+            && let Some(snapshot) =
+                claude_tui_followup_busy_before_submit(tmux_session_name, Some(&transcript_path))
+        {
+            // #2416: instead of dropping the user's message when the TUI is busy,
+            // wait for the next prompt-ready window. The transcript-idle
+            // fallback covers Claude TUI redraws where the JSONL terminal
+            // envelope is authoritative but the prompt glyph is not visible.
+            match crate::services::claude_tui::input::wait_for_prompt_ready_or_idle_transcript(
+                tmux_session_name,
+                crate::services::claude_tui::input::PromptReadinessKind::Followup,
+                cancel_token.as_deref(),
+                &transcript_path,
+            ) {
+                Ok(()) => {
+                    busy_waited = true;
+                    debug_log(&format!(
+                        "Claude TUI follow-up: busy at first check, became ready after wait (session={})",
+                        tmux_session_name
+                    ));
+                }
+                Err(err) => {
+                    if crate::services::claude_tui::input::is_prompt_ready_cancelled_error(&err) {
+                        debug_log(&format!(
+                            "Claude TUI follow-up: cancellation observed during busy wait, aborting injection (session={})",
+                            tmux_session_name
+                        ));
+                        log_producer_exit(
+                            "tui_warm_followup_cancelled_during_busy_wait",
+                            Some(&resolved_session_id),
+                            report_channel_id,
+                            0,
+                            serde_json::json!({
+                                "tmux_session_name": tmux_session_name,
+                                "transcript_path": transcript_path_string,
+                            }),
+                        );
+                        return ClaudeTuiWarmFollowupOutcome::Terminal(Ok(()));
+                    }
+                    let timed_out =
+                        crate::services::claude_tui::input::is_prompt_ready_timeout_error(&err);
+                    debug_log(&format!(
+                        "Claude TUI follow-up wait failed after busy snapshot (session={}, timed_out={}): {}",
+                        tmux_session_name, timed_out, err
+                    ));
+                    let post_wait_snapshot =
+                        crate::services::claude_tui::input::prompt_readiness_snapshot(
+                            tmux_session_name,
+                        );
+                    emit_claude_tui_busy_followup_notice(
+                        &sender,
+                        tmux_session_name,
+                        &post_wait_snapshot,
+                    );
+                    log_producer_exit(
+                        "tui_warm_followup_busy_pre_submit",
+                        Some(&resolved_session_id),
+                        report_channel_id,
+                        0,
+                        serde_json::json!({
+                            "tmux_session_name": tmux_session_name,
+                            "transcript_path": transcript_path_string,
+                            "prompt_marker_detected": post_wait_snapshot.prompt_marker_detected,
+                            "prompt_draft_detected": post_wait_snapshot.prompt_draft_detected,
+                            "prompt_draft_blocks_submission": post_wait_snapshot.tmux_pane_alive && post_wait_snapshot.prompt_draft_detected,
+                            "tmux_pane_alive": post_wait_snapshot.tmux_pane_alive,
+                            "capture_available": post_wait_snapshot.capture_available,
+                            "initial_busy_snapshot_prompt_marker_detected": snapshot.prompt_marker_detected,
+                            "initial_busy_snapshot_prompt_draft_detected": snapshot.prompt_draft_detected,
+                            "wait_outcome": if timed_out { "timeout" } else { "error" },
+                            "wait_error": err,
+                        }),
+                    );
+                    return ClaudeTuiWarmFollowupOutcome::Terminal(Ok(()));
+                }
+            }
+        }
+        // #2416: capture the transcript offset AFTER the optional busy wait so
+        // that any bytes the previous TUI turn appended while we were waiting
+        // are not replayed as part of this follow-up's output window. This
+        // closes a Codex-flagged HIGH (stale offset → duplicate / early-done
+        // delivery accounting).
+        let fallback_start_offset = std::fs::metadata(&transcript_path)
+            .map(|meta| meta.len())
+            .unwrap_or(0);
+        // #2416: also honour cancellation that may have flipped during the
+        // up-to-45s busy wait. Without this, a user stop reaction / watchdog
+        // cancellation arriving mid-wait would still inject the prompt as
+        // soon as the TUI returns to ready. Closes a Codex-flagged HIGH.
+        if busy_waited && crate::services::provider::cancel_requested(cancel_token.as_deref()) {
+            debug_log(&format!(
+                "Claude TUI follow-up: cancellation observed after busy wait, aborting injection (session={})",
+                tmux_session_name
+            ));
+            log_producer_exit(
+                "tui_warm_followup_cancelled_after_busy_wait",
+                Some(&resolved_session_id),
+                report_channel_id,
+                0,
+                serde_json::json!({
+                    "tmux_session_name": tmux_session_name,
+                    "transcript_path": transcript_path_string,
+                }),
+            );
+            return ClaudeTuiWarmFollowupOutcome::Terminal(Ok(()));
+        }
+        let turn_started_at = chrono::Utc::now();
+        if let Err(error) =
+            crate::services::claude_tui::input::send_followup_prompt_or_idle_transcript(
+                tmux_session_name,
+                prompt,
+                cancel_token.as_deref(),
+                &transcript_path,
+            )
+        {
+            if crate::services::claude_tui::input::is_prompt_ready_cancelled_error(&error) {
+                debug_log(&format!(
+                    "Claude TUI follow-up: cancellation observed during prompt submission, aborting injection (session={})",
+                    tmux_session_name
+                ));
+                log_producer_exit(
+                    "tui_warm_followup_cancelled_during_prompt_submit",
+                    Some(&resolved_session_id),
+                    report_channel_id,
+                    0,
+                    serde_json::json!({
+                        "tmux_session_name": tmux_session_name,
+                        "transcript_path": transcript_path_string,
+                    }),
+                );
+                return ClaudeTuiWarmFollowupOutcome::Terminal(Ok(()));
+            }
+            return ClaudeTuiWarmFollowupOutcome::Terminal(Err(error));
+        }
+        let hook_events_after = chrono::Utc::now();
+        let start_offset = claude_tui_turn_start_offset_after_timestamp(
+            &transcript_path,
+            turn_started_at,
+            fallback_start_offset,
+        );
+        let read_result = match read_claude_tui_transcript_until_done(
+            &transcript_path_string,
+            start_offset,
+            sender.clone(),
+            cancel_token.clone(),
+            tmux_session_name,
+            &resolved_session_id,
+            hook_rx,
+            hook_events_after,
+        ) {
+            Ok(result) => result,
+            Err(error) => {
+                return ClaudeTuiWarmFollowupOutcome::Terminal(Err(error));
+            }
+        };
+        let zero_advance_terminal_result = match &read_result {
+            ReadOutputResult::Completed { offset } | ReadOutputResult::Cancelled { offset } => {
+                *offset <= start_offset
+            }
+            ReadOutputResult::SessionDied { .. } => false,
+        };
+        if zero_advance_terminal_result {
+            let snapshot =
+                crate::services::claude_tui::input::prompt_readiness_snapshot(tmux_session_name);
+            if claude_tui_prompt_remained_in_input_buffer(&snapshot, prompt) {
+                return ClaudeTuiWarmFollowupOutcome::Terminal(Err(
+                    claude_tui_zero_advance_input_buffer_error(
+                        tmux_session_name,
+                        &transcript_path_string,
+                        start_offset,
+                        &snapshot,
+                    ),
+                ));
+            }
+        }
+        match classify_followup_result(
+            read_result,
+            start_offset,
+            "claude tui session died during follow-up output reading",
+        ) {
+            ClaudeFollowupResult::Delivered => {
+                emit_claude_tui_watcher_handoff(
+                    &sender,
+                    &transcript_path_string,
+                    tmux_session_name,
+                    &transcript_path,
+                );
+                log_producer_exit(
+                    "tui_warm_followup_delivered",
+                    Some(&resolved_session_id),
+                    report_channel_id,
+                    0,
+                    serde_json::json!({
+                        "tmux_session_name": tmux_session_name,
+                        "transcript_path": transcript_path_string,
+                    }),
+                );
+                return ClaudeTuiWarmFollowupOutcome::Terminal(Ok(()));
+            }
+            ClaudeFollowupResult::RecreateSession { error } => {
+                debug_log(&format!(
+                    "Claude TUI follow-up failed, recreating session: {}",
+                    error
+                ));
+                crate::services::termination_audit::record_termination_for_tmux(
+                    tmux_session_name,
+                    None,
+                    "claude_tui_provider",
+                    "followup_failed_recreate",
+                    Some(&format!(
+                        "claude tui follow-up failed, recreating: {}",
+                        error
+                    )),
+                    None,
+                );
+                record_tmux_exit_reason(
+                    tmux_session_name,
+                    &format!("claude tui follow-up failed, recreating: {}", error),
+                );
+                crate::services::platform::tmux::kill_session(
+                    tmux_session_name,
+                    &format!("claude tui follow-up failed, recreating: {}", error),
+                );
+            }
+            ClaudeFollowupResult::FinalizeWithNotice { error, notice } => {
+                debug_log(&format!(
+                    "Claude TUI follow-up streamed partial output before session death — suppressing replay: {}",
+                    error
+                ));
+                crate::services::termination_audit::record_termination_for_tmux(
+                    tmux_session_name,
+                    None,
+                    "claude_tui_provider",
+                    "followup_partial_output_no_replay",
+                    Some(&format!(
+                        "claude tui partial follow-up output delivered: {}",
+                        error
+                    )),
+                    None,
+                );
+                record_tmux_exit_reason(
+                    tmux_session_name,
+                    &format!("claude tui partial follow-up output delivered: {}", error),
+                );
+                crate::services::platform::tmux::kill_session(
+                    tmux_session_name,
+                    &format!("claude tui partial follow-up output delivered: {}", error),
+                );
+                emit_followup_restart_suppressed_notice(&sender, &notice);
+                return ClaudeTuiWarmFollowupOutcome::Terminal(Ok(()));
+            }
+        }
+    }
+
+    ClaudeTuiWarmFollowupOutcome::Recreate(ClaudeTuiRecreateState {
+        resolved_session_id,
+        transcript_path,
+        transcript_path_string,
+        resume,
+    })
+}
+
+/// Tear down a stale (no live pane) Claude TUI tmux session before recreating it.
+/// Verbatim extraction of the pre-refactor `else if session_exists` branch.
+#[cfg(unix)]
+fn cleanup_stale_claude_tui_session(tmux_session_name: &str) {
+    crate::services::termination_audit::record_termination_for_tmux(
+        tmux_session_name,
+        None,
+        "claude_tui_provider",
+        "stale_session_recreate",
+        Some("stale claude tui session cleanup before recreate"),
+        None,
+    );
+    record_tmux_exit_reason(
+        tmux_session_name,
+        "stale claude tui session cleanup before recreate",
+    );
+    crate::services::platform::tmux::kill_session(
+        tmux_session_name,
+        "stale claude tui session cleanup before recreate",
+    );
+}
+
+/// Prepare the Claude TUI launch script and create the hosted tmux session.
+///
+/// Verbatim extraction of the pre-refactor fresh-launch prep/create block: temp
+/// cleanup, owner + runtime-kind markers, launch-script preparation, and the
+/// `create_session` call, with the identical on-failure cleanup (best-effort
+/// session-file cleanup + owner-marker removal) on every error path. Returns the
+/// owner-marker path on success so the caller can remove it on a later fresh-turn
+/// failure. The owner-marker / runtime-kind-marker `?` short-circuits preserve
+/// their original semantics: they return `Err` before any session-file or
+/// owner-marker cleanup, exactly as the inline `?` did.
+#[cfg(unix)]
+fn prepare_and_create_claude_tui_session(
+    tmux_session_name: &str,
+    working_dir: &str,
+    working_dir_path: &std::path::Path,
+    resolved_session_id: &str,
+    system_prompt: Option<&str>,
+    model_override: Option<&str>,
+    hook_endpoint: String,
+    resume: bool,
+    compact_percent: Option<u64>,
+) -> Result<String, String> {
+    crate::services::tmux_common::cleanup_session_temp_files(tmux_session_name);
+    write_tmux_owner_marker(tmux_session_name)?;
+    crate::services::tmux_common::write_tmux_runtime_kind_marker(
+        tmux_session_name,
+        crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui,
+    )?;
+    let owner_path = tmux_owner_path(tmux_session_name);
+    let mut prepared_session_files = None;
+    let launch_result = (|| -> Result<std::process::Output, String> {
+        let exe =
+            std::env::current_exe().map_err(|e| format!("Failed to get executable path: {}", e))?;
+        let resolution = resolve_claude_binary();
+        let claude_bin = resolution
+            .resolved_path
+            .clone()
+            .ok_or_else(|| "Claude CLI not found".to_string())?;
+        let launch_config = crate::services::claude_tui::session::ClaudeTuiLaunchConfig {
+            tmux_session_name: tmux_session_name.to_string(),
+            working_dir: working_dir_path.to_path_buf(),
+            claude_bin: std::path::PathBuf::from(claude_bin),
+            agentdesk_exe: exe,
+            hook_endpoint,
+            session_id: resolved_session_id.to_string(),
+            system_prompt: system_prompt.map(str::to_string),
+            model: model_override.map(str::to_string),
+            resume,
+            compact_percent,
+        };
+        let session_files =
+            crate::services::claude_tui::session::prepare_claude_tui_launch(&launch_config)?;
+        let launch_script_path = session_files.launch_script_path.clone();
+        prepared_session_files = Some(session_files);
+        crate::services::platform::tmux::create_session(
+            tmux_session_name,
+            Some(working_dir),
+            &format!(
+                "bash {}",
+                shell_escape(&launch_script_path.display().to_string())
+            ),
+        )
+    })();
+    let tmux_result = match launch_result {
+        Ok(result) => result,
+        Err(error) => {
+            if let Some(files) = prepared_session_files.as_ref() {
+                files.cleanup_best_effort();
+            }
+            let _ = std::fs::remove_file(&owner_path);
+            return Err(error);
+        }
+    };
+    if !tmux_result.status.success() {
+        let stderr = String::from_utf8_lossy(&tmux_result.stderr);
+        if let Some(files) = prepared_session_files.as_ref() {
+            files.cleanup_best_effort();
+        }
+        let _ = std::fs::remove_file(&owner_path);
+        return Err(format!("tmux error: {}", stderr));
+    }
+    Ok(owner_path)
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
Behavior-preserving decomposition of `execute_streaming_local_tui_tmux` in `src/services/claude.rs` (~714 lines) into a thin sequential orchestrator + cohesive private helpers in the same file, mirroring the codex.rs idiom merged in #3195.

## Helpers extracted
- **`try_claude_tui_warm_followup`** — the entire warm follow-up path (stranded prompt-draft recovery, busy-wait, prompt submission, transcript read, follow-up result classification). Returns `ClaudeTuiWarmFollowupOutcome { Terminal(Result<(),String>) | Recreate(ClaudeTuiRecreateState) }`; every original `return Ok/Err`/`?` short-circuit maps to `Terminal(..)` (orchestrator returns immediately), and the original fall-through-to-fresh-launch maps to `Recreate(..)` carrying the (possibly mutated) session resolution.
- **`cleanup_stale_claude_tui_session`** — verbatim `else if session_exists` stale teardown (audit + exit-reason + kill_session).
- **`prepare_and_create_claude_tui_session`** — temp cleanup + owner/runtime-kind markers + launch-script prep + `create_session`, with identical on-failure cleanup; returns the owner-marker path on success.

## Orchestrator before → after
~714 lines → ~175-line thin orchestrator (signature/setup/runtime-binding recovery + thin if-chain + fresh-launch wiring/dispatch). Net file change +116 production lines (helpers carry doc comments).

## Behavior preservation
Side-effect ordering identical: dedupe register → turn lock → session resolve → runtime-binding recovery → warm-followup → stale cleanup → temp cleanup → owner/runtime-kind markers → launch-script prep → tmux create → remain-on-exit → spawn nonce → cancel-token wiring → Init → fresh-turn dispatch → result resolution → watcher handoff.

A whitespace-insensitive diff of the original warm block vs the new helper body confirms the **only** changes are `cargo fmt` line-wrapping + the documented return/`?` → `Terminal(..)` rewrites — no logic/condition/reorder changes.

### `?` / early-return audit
- `try_claude_tui_warm_followup`: the two `fresh_claude_tui_session_resolution(..)?` and the `read_claude_tui_transcript_until_done(..)?` originally returned `Err` **immediately** — the resolution `?`s sit *after* their branch's `kill_session` (preserved), and the transcript-read `?` does **no** kill. New code returns `Terminal(Err)` → orchestrator returns Err immediately, with **no** added leak-kill on any of these paths (the codex.rs lesson: validations that returned Err before the tail/leak-kill still do).
- `prepare_and_create_claude_tui_session`: the owner-marker / runtime-kind-marker `?`s return Err before any session-file or owner-marker cleanup (as the inline `?` did); the launch/create failures perform the same best-effort session-file cleanup + owner-marker removal.
- Orchestrator `resolve_claude_tui_session_for_launch?` unchanged (early, before any tmux side-effect).

## Verification
- `cargo build` — clean; no new warnings in claude.rs (the 2 remaining warnings are pre-existing in `placeholder_live_events/mod.rs` and `tmux_watcher.rs`, unchanged from main).
- `cargo test --lib services::claude` — 167 passed, 0 failed.
- `cargo fmt` clean; `git diff --stat` — only `claude.rs` + `change-surfaces.md`.
- Freeze gate: claude.rs production line count 3795 → 3911; `change-surfaces.md` updated; `check_agent_maintenance_docs.py --line-count-gate` → passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)