### PR TITLE
fix(#3016): A2 fresh-idle finalize via ledger authority (phase-5 enabler)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -130,7 +130,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (9215 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (9250 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -130,7 +130,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (9250 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (9385 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -318,6 +318,35 @@
     so a late completion can never commit the WRONG newer loop turn; the
     `user_msg_id != 0` path is byte-for-byte unchanged. New test
     `watcher_terminal_delivery_commit_marks_loop_turn_with_zero_user_msg_id`.
+    +135 from #3016 A2 (fresh-idle ledger authority + wrong-turn race fix): the
+    fresh-idle delegated completion finalizes via the single-authority
+    `TurnFinalizer` ledger (`has_live_watcher_pending`) rather than the in-memory
+    `mailbox_finalize_owed` flag (the last load-bearing flag use; phase-5 deletion
+    enabler — the flag is NOT deleted here). The adversarial-review wrong-turn RACE
+    is closed by REUSING the canonical option-A machinery instead of a late
+    inflight re-read: the finalize id is PINNED from a pre-cleanup inflight snapshot
+    via `pinned_finalize_user_msg_id(snapshot, session, current_offset)` and the
+    decision is gated by `committed_completion_is_stale_for_newer_turn`. The whole
+    routing is FACTORED into a pure helper `watcher_fresh_idle_finalize_decision`
+    (→ `FreshIdleFinalizeDecision::{AbortFollowupTookOver, SkipStale, Finalize}`)
+    so the production branch and the unit tests share the EXACT decision: (1) a
+    pause/epoch guard runs BEFORE the destructive clear (mirroring the canonical
+    pause/epoch guard which sits AFTER this branch's `continue`) → abort if a
+    follow-up turn took over during the cleanup `.await`s; (2) SkipStale when the
+    pinned snapshot is a NEWER turn that began AT/AFTER this committed range
+    (`turn_start_offset >= current_offset`, pinned id 0) → the follow-up is NOT
+    finalized; (3) Finalize with the CURRENT turn's real pinned id otherwise.
+    Degenerate-empty-offset safety: a genuine current-turn empty/suppressed
+    FreshIdle always has `turn_start_offset < current_offset` (the loop builds the
+    idle tracker with `::default()`, never `primed_for_recovery()`, so FreshIdle
+    requires `output_ever_grew`; the watcher resumes at `turn_start_offset`), so
+    the pinned id is the turn's real non-zero id and SkipStale cannot misfire on
+    the current turn. Tests rewritten to drive the REAL path:
+    `fresh_idle_empty_delegated_completion_finalizes_via_ledger_flag_false`
+    (routes through `watcher_fresh_idle_finalize_decision` then finalizes via the
+    real actor + mailbox, flag FALSE),
+    `fresh_idle_paused_live_delegated_turn_defers_through_real_path`,
+    `fresh_idle_followup_turn_race_does_not_finalize_the_followup` (abort + stale-skip).
   - `src/services/discord/tui_prompt_relay.rs` (4522 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +4 from #3167: the self-paced TUI loop relay

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -146,6 +146,66 @@ fn watcher_should_defer_delegated_fresh_idle(
     delegated_turn_owned && full_response.trim().is_empty()
 }
 
+/// #3016 A2 (wrong-turn race fix): the fresh-idle finalize DECISION, factored out
+/// of the production watcher loop so the exact production logic is unit-testable
+/// end-to-end (the enclosing `tmux_output_watcher_with_restore` is not).
+///
+/// Ordering mirrors the canonical normal-completion site's protections:
+///   1. `AbortFollowupTookOver` — a Discord turn claimed the session during the
+///      cleanup `.await`s (`paused_now || epoch_changed`). Same predicate as the
+///      pause/epoch guard at the canonical site (tmux.rs:7841+), but evaluated
+///      BEFORE this branch's destructive clear (which `continue`s before that
+///      guard would run).
+///   2. `SkipStale` — the pinned pre-cleanup snapshot is a NEWER turn that began
+///      AT/AFTER this committed range (`completion_is_stale_for_newer_turn` true,
+///      or `pinned_finalize_user_msg_id == 0`). Finalizing would release the
+///      follow-up turn; skip and preserve inflight.
+///   3. `Finalize { user_msg_id }` — a genuine current-turn empty/suppressed
+///      idle. `user_msg_id` is the id PINNED from the pre-cleanup snapshot at the
+///      same `current_offset` (never a late re-read).
+///
+/// Degenerate-empty-offset safety: a genuine current-turn fresh idle always has
+/// `turn_start_offset < current_offset` (FreshIdle requires `output_ever_grew`,
+/// and the watcher resumes at `turn_start_offset`), so the pinned id is its real,
+/// non-zero id and `SkipStale` cannot misfire on the current turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FreshIdleFinalizeDecision {
+    AbortFollowupTookOver,
+    SkipStale { pinned_user_msg_id: u64 },
+    Finalize { user_msg_id: u64 },
+}
+
+fn watcher_fresh_idle_finalize_decision(
+    paused_now: bool,
+    epoch_changed: bool,
+    pinned_pre_cleanup_inflight: Option<&crate::services::discord::inflight::InflightTurnState>,
+    tmux_session_name: &str,
+    current_offset: u64,
+) -> FreshIdleFinalizeDecision {
+    if paused_now || epoch_changed {
+        return FreshIdleFinalizeDecision::AbortFollowupTookOver;
+    }
+    let stale = committed_completion_is_stale_for_newer_turn(
+        pinned_pre_cleanup_inflight,
+        None,
+        tmux_session_name,
+        current_offset,
+    );
+    let pinned = pinned_finalize_user_msg_id(
+        pinned_pre_cleanup_inflight,
+        tmux_session_name,
+        current_offset,
+    );
+    if stale || pinned == 0 {
+        return FreshIdleFinalizeDecision::SkipStale {
+            pinned_user_msg_id: pinned,
+        };
+    }
+    FreshIdleFinalizeDecision::Finalize {
+        user_msg_id: pinned,
+    }
+}
+
 fn watcher_should_clear_stale_terminal_message_ids(
     inflight_present: bool,
     has_assistant_response: bool,
@@ -7501,6 +7561,41 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                     .turn_finalizer
                     .has_live_watcher_pending(channel_id, shared.current_generation)
                     .await;
+                // #3016 A2 (wrong-turn race fix): pin the finalize id from a
+                // snapshot taken NOW — BEFORE the cleanup `.await`s below — and
+                // gate it on the SAME output-range relationship the canonical
+                // normal-completion site uses (`pinned_finalize_user_msg_id` +
+                // `committed_completion_is_stale_for_newer_turn`). The prior A2
+                // code loaded `fresh_idle_user_msg_id` from a LATE re-read AFTER
+                // the placeholder/panel cleanup awaits, during which a follow-up
+                // turn on the SAME session can become current and rewrite
+                // inflight; the unconditional finalize then released the WRONG
+                // (newer, still-running) turn. Pinning here from the pre-cleanup
+                // snapshot — and skipping when the snapshot is a NEWER turn that
+                // started AT/AFTER `current_offset` — defeats that exactly as the
+                // canonical site does.
+                //
+                // Degenerate-empty-offset safety (the #3174/#3154 crux): an
+                // empty/suppressed fresh-idle commits no new terminal text, but
+                // it is NEVER offset-degenerate here. `FreshIdle` is only
+                // produced when `ReadyForInputIdleTracker::observe_idle_state`
+                // sees `output_ever_grew == true` (this loop builds the tracker
+                // with `::default()`, NOT `primed_for_recovery()`, so the
+                // `recovery_primed` bypass cannot apply) — i.e.
+                // `current_offset > data_start_offset`, and `data_start_offset`
+                // never precedes the watcher's resume baseline `turn_start_offset`
+                // (the bridge sets `resume_offset == last_offset == turn_start_offset`
+                // at handoff). Hence for the genuine current turn
+                // `turn_start_offset < current_offset` STRICTLY, so
+                // `pinned_finalize_user_msg_id` returns its REAL id (never 0) and
+                // the stale gate is FALSE. Only a real follow-up turn whose
+                // `turn_start_offset >= current_offset` yields pinned 0 / stale =
+                // TRUE, which is precisely when we must skip.
+                let pinned_pre_cleanup_inflight =
+                    crate::services::discord::inflight::load_inflight_state(
+                        &watcher_provider,
+                        channel_id.get(),
+                    );
                 if watcher_should_defer_delegated_fresh_idle(delegated_turn_owned, &full_response) {
                     let ts = chrono::Local::now().format("%H:%M:%S");
                     tracing::info!(
@@ -7585,6 +7680,50 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 if !panel_cleanup_committed {
                     continue;
                 }
+                // #3016 A2 (wrong-turn race fix): the finalize DECISION, computed
+                // by the same pure helper the unit tests drive. Two protections,
+                // BOTH evaluated before this branch's destructive clear (which
+                // `continue`s before the canonical pause/epoch guard at
+                // tmux.rs:7841+ would run):
+                //   * AbortFollowupTookOver — a Discord turn claimed the session
+                //     during the cleanup `.await`s above (paused / epoch bumped at
+                //     handoff). Mirrors the canonical pause/epoch guard.
+                //   * SkipStale — the pinned pre-cleanup snapshot is a NEWER turn
+                //     that began AT/AFTER this committed range; finalizing would
+                //     release the follow-up. Mirrors the canonical site's
+                //     `completion_is_stale_for_newer_turn` skip.
+                let fresh_idle_decision = watcher_fresh_idle_finalize_decision(
+                    paused.load(Ordering::Relaxed),
+                    pause_epoch.load(Ordering::Relaxed) != epoch_snapshot,
+                    pinned_pre_cleanup_inflight.as_ref(),
+                    &tmux_session_name,
+                    current_offset,
+                );
+                let fresh_idle_user_msg_id = match fresh_idle_decision {
+                    FreshIdleFinalizeDecision::AbortFollowupTookOver => {
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        tracing::info!(
+                            "  [{ts}] 👁 watcher fresh ready-for-input idle for {tmux_session_name} aborted before finalize: follow-up turn took over (paused/epoch changed); preserving inflight"
+                        );
+                        all_data.clear();
+                        all_data_start_offset = current_offset;
+                        all_data_fully_mirrored_to_session_relay = true;
+                        all_data_session_bound_relay_ack = None;
+                        continue;
+                    }
+                    FreshIdleFinalizeDecision::SkipStale { pinned_user_msg_id } => {
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        tracing::info!(
+                            "  [{ts}] 👁 watcher fresh ready-for-input idle for {tmux_session_name} skipped finalize: pinned id {pinned_user_msg_id} is stale for a newer turn at offset {current_offset}; preserving inflight for the current/newer turn"
+                        );
+                        all_data.clear();
+                        all_data_start_offset = current_offset;
+                        all_data_fully_mirrored_to_session_relay = true;
+                        all_data_session_bound_relay_ack = None;
+                        continue;
+                    }
+                    FreshIdleFinalizeDecision::Finalize { user_msg_id } => user_msg_id,
+                };
                 // #3016 A2 (phase-5 enabler): the fresh-idle finalize is now
                 // LEDGER-driven, not flag-driven. Reaching here means every
                 // upstream guard already decided this is a REAL idle to act on:
@@ -7593,21 +7732,17 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 //     assistant text yet — so a turn merely PAUSED at a
                 //     selector/subagent prompt (empty committed response) never
                 //     reaches this point; and
-                //   * the placeholder + orphan-panel cleanup guards committed.
+                //   * the placeholder + orphan-panel cleanup guards committed; and
+                //   * the pause/epoch guard + the pinned stale-skip above ruled
+                //     out a follow-up turn having taken over the session.
                 // We still `swap(false)` the legacy flag to keep its revoke
                 // lifecycle intact (the flag is NOT deleted in this PR — only made
                 // non-load-bearing), exactly as the canonical option-A site does.
                 let owed = mailbox_finalize_owed.swap(false, std::sync::atomic::Ordering::AcqRel);
-                // #3016: capture the turn's real id BEFORE clearing inflight, so
-                // the finalizer ledger match is exact (id-0 would risk a stale
-                // terminal finalizing a queued follow-up).
-                let fresh_idle_user_msg_id =
-                    crate::services::discord::inflight::load_inflight_state(
-                        &watcher_provider,
-                        channel_id.get(),
-                    )
-                    .map(|s| s.user_msg_id)
-                    .unwrap_or(0);
+                // `fresh_idle_user_msg_id` is the id PINNED from the pre-cleanup
+                // snapshot at the same `current_offset` (bound by the `Finalize`
+                // arm above; never a late inflight re-read). The stale-skip
+                // guarantees it is the CURRENT turn's real, non-zero id.
                 crate::services::discord::inflight::clear_inflight_state(
                     &watcher_provider,
                     channel_id.get(),
@@ -11683,7 +11818,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
 #[cfg(test)]
 mod tests {
     use super::{
-        RelaySlotGuard, TuiCompletionGateOutcome, Utf8ChunkDecoder,
+        FreshIdleFinalizeDecision, RelaySlotGuard, TuiCompletionGateOutcome, Utf8ChunkDecoder,
         adopt_watcher_terminal_message_ids_from_inflight, build_watcher_streaming_edit_text,
         discard_restored_response_seed_before_no_inflight_terminal_relay,
         discard_watcher_pending_buffer_after_suppressed_turn,
@@ -11693,10 +11828,10 @@ mod tests {
         watcher_batch_contains_assistant_event, watcher_batch_contains_relayable_response,
         watcher_direct_terminal_should_commit_session_idle,
         watcher_fallback_edit_failure_can_delete_original_placeholder,
-        watcher_inflight_absence_is_abandonment, watcher_inflight_represents_external_input,
-        watcher_jsonl_turn_state_ready_for_input, watcher_output_progressed_recently,
-        watcher_should_clear_stale_terminal_message_ids, watcher_should_defer_delegated_fresh_idle,
-        watcher_should_delete_suppressed_placeholder,
+        watcher_fresh_idle_finalize_decision, watcher_inflight_absence_is_abandonment,
+        watcher_inflight_represents_external_input, watcher_jsonl_turn_state_ready_for_input,
+        watcher_output_progressed_recently, watcher_should_clear_stale_terminal_message_ids,
+        watcher_should_defer_delegated_fresh_idle, watcher_should_delete_suppressed_placeholder,
         watcher_should_suppress_streaming_after_bridge_delivery,
         watcher_terminal_commit_side_effects_for_test, watcher_terminal_edit_consumes_placeholder,
         watcher_terminal_token_update_status,
@@ -12539,20 +12674,56 @@ mod tests {
         );
     }
 
-    // #3016 A2 (fresh-idle ledger authority). Proves the THREE properties the
-    // PR depends on, end-to-end through the real `TurnFinalizer` actor:
+    // #3016 A2 test helper: build an inflight snapshot with explicit
+    // turn_start_offset / last_offset, so the fresh-idle decision's OUTPUT-RANGE
+    // gate (`pinned_finalize_user_msg_id` / `committed_completion_is_stale_for_newer_turn`)
+    // can be exercised against current/older/newer turns.
+    fn fresh_idle_inflight(
+        provider: ProviderKind,
+        channel_id: u64,
+        tmux_session_name: &str,
+        user_msg_id: u64,
+        turn_start_offset: u64,
+    ) -> InflightTurnState {
+        let mut state = InflightTurnState::new(
+            provider,
+            channel_id,
+            Some("adk-cc".to_string()),
+            42,
+            user_msg_id,
+            user_msg_id + 1,
+            "prompt".to_string(),
+            Some("session".to_string()),
+            Some(tmux_session_name.to_string()),
+            Some("/tmp/out.jsonl".to_string()),
+            None,
+            turn_start_offset,
+        );
+        // `InflightTurnState::new` sets turn_start_offset == last_offset; keep
+        // them equal (the registration invariant) so the range tests behave like
+        // production.
+        state.last_offset = turn_start_offset;
+        state.turn_start_offset = Some(turn_start_offset);
+        state
+    }
+
+    // #3016 A2 (fresh-idle wrong-turn race fix). Drives the REAL production
+    // decision logic via the factored `watcher_fresh_idle_finalize_decision` (the
+    // exact helper the production fresh-idle branch calls), then finalizes through
+    // the REAL `TurnFinalizer` actor + mailbox. The prior version of this test
+    // bypassed the production branch by clearing inflight + calling the finalizer
+    // manually; this one routes through the real decision so under-finalize
+    // closure is proven through the actual branch.
     //
-    //   (i)   An empty/suppressed DELEGATED completion at fresh-idle finalizes
-    //         via the LEDGER even with the legacy `mailbox_finalize_owed` flag
-    //         FALSE — the finalize is no longer gated on the flag.
-    //   (ii)  The fresh-idle DEFER decision is now ledger-driven: a live
-    //         watcher-owned Pending entry makes `has_live_watcher_pending` (the
-    //         defer-guard input) report `true` BEFORE finalize, then `false`
-    //         after — so a paused-live turn (empty response + live entry) is
-    //         deferred, not finalized.
-    //   (iii) Idempotency: a second fresh-idle submit for the same turn is a
-    //         no-op (AlreadyFinalized) — no double-finalize, no counter
-    //         underflow.
+    // Property (i): a genuine empty/suppressed DELEGATED completion (current turn,
+    // `turn_start_offset < current_offset`, not paused, epoch unchanged) yields
+    // `Finalize { user_msg_id = real id }` and finalizes via the LEDGER even with
+    // the legacy `mailbox_finalize_owed` flag FALSE.
+    //
+    // Degenerate-empty-offset coverage: the completion commits NO new terminal
+    // text (empty response), yet `current_offset` strictly exceeds the turn start
+    // (as it always does for a real FreshIdle — `output_ever_grew`), so the pinned
+    // id is the turn's REAL id and the finalize fires.
     #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn fresh_idle_empty_delegated_completion_finalizes_via_ledger_flag_false() {
@@ -12568,6 +12739,10 @@ mod tests {
         let tmux_session_name = "AgentDesk-claude-adk-cc-9873018";
         let user_msg_id = 8001u64;
         let generation = shared.current_generation;
+        // Current turn started at offset 10; the watcher idled at offset 50, so
+        // turn_start_offset (10) < current_offset (50) → in range.
+        let turn_start_offset = 10u64;
+        let current_offset = 50u64;
 
         // Real watcher handle with the legacy flag FALSE: the fresh-idle
         // finalize must NOT depend on the flag.
@@ -12590,23 +12765,18 @@ mod tests {
         // Allow the actor to drain the Start before we query.
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
 
-        // (ii) BEFORE finalize: the ledger reports a live watcher-owned entry,
-        // so the defer guard would defer an empty-response paused-live turn.
+        // The ledger reports a live watcher-owned entry → the defer guard would
+        // defer an empty-response paused-live turn. A genuine *completed* empty
+        // idle proceeds past the defer guard (the bridge finalized the ledger
+        // entry, or the turn truly produced its terminal); here we model the
+        // proceed case and let the REAL decision helper route it.
         assert!(
             shared
                 .turn_finalizer
                 .has_live_watcher_pending(channel_id, generation)
                 .await,
-            "live watcher-owned Pending entry → defer guard input is true (paused-live deferred)"
+            "live watcher-owned Pending entry → defer guard input is true"
         );
-        assert!(
-            watcher_should_defer_delegated_fresh_idle(true, ""),
-            "empty response + live delegated entry → DEFER (paused-live not finalized)"
-        );
-        // A genuine empty completion is the one that proceeds past the guard:
-        // the guard only defers while the response is empty AND the turn is a
-        // live delegated entry; the proceed decision below is the post-guard
-        // commit point.
 
         // Live active mailbox turn with the turn's real id, so we can observe
         // the finalize releasing exactly THIS turn's token.
@@ -12621,7 +12791,7 @@ mod tests {
             .await
         );
 
-        // (i) Precondition: the legacy flag is FALSE on the real handle.
+        // Precondition: the legacy flag is FALSE on the real handle.
         let watcher = shared
             .tmux_watchers
             .get(&channel_id)
@@ -12634,14 +12804,41 @@ mod tests {
         );
         drop(watcher);
 
-        // Fresh-idle commit point: clear inflight inline (mirrors the call site)
-        // then drive the finalizer UNCONDITIONALLY with normal_completion = true.
+        // REAL decision: pre-cleanup snapshot is the CURRENT turn, not paused,
+        // epoch unchanged → Finalize with the turn's REAL id.
+        let snapshot = fresh_idle_inflight(
+            provider.clone(),
+            channel_id.get(),
+            tmux_session_name,
+            user_msg_id,
+            turn_start_offset,
+        );
+        let decision = watcher_fresh_idle_finalize_decision(
+            false, // paused_now
+            false, // epoch_changed
+            Some(&snapshot),
+            tmux_session_name,
+            current_offset,
+        );
+        let finalize_id = match decision {
+            FreshIdleFinalizeDecision::Finalize { user_msg_id } => user_msg_id,
+            other => panic!(
+                "genuine current-turn empty idle must Finalize with the real id, got {other:?}"
+            ),
+        };
+        assert_eq!(
+            finalize_id, user_msg_id,
+            "the pinned finalize id is the CURRENT turn's real id (degenerate-empty-offset safe)"
+        );
+
+        // Production fresh-idle commit point: clear inflight then drive the
+        // finalizer with the PINNED id (exactly what the branch does).
         crate::services::discord::inflight::clear_inflight_state(&provider, channel_id.get());
         let drove = super::finish_restored_watcher_active_turn(
             &shared,
             &provider,
             channel_id,
-            user_msg_id,
+            finalize_id,
             false, // finish_mailbox_on_completion — fresh live watcher
             false, // delegated_finalize_owed — flag FALSE (swapped at the site)
             true,  // normal_completion — A2: ledger-driven, flag-independent
@@ -12662,8 +12859,8 @@ mod tests {
             "empty/suppressed delegated completion finalizes via the ledger with the flag FALSE"
         );
 
-        // (ii) AFTER finalize: the ledger entry is Finalized → defer guard input
-        // flips to false (the turn is done; nothing left to defer).
+        // AFTER finalize: the ledger entry is Finalized → defer guard input flips
+        // to false (the turn is done; nothing left to defer).
         assert!(
             !shared
                 .turn_finalizer
@@ -12672,8 +12869,8 @@ mod tests {
             "finalized entry → defer guard input is false"
         );
 
-        // (iii) Idempotency: a second fresh-idle submit for the same turn is a
-        // no-op (AlreadyFinalized) — no double-finalize, no counter underflow.
+        // Idempotency: a second fresh-idle submit for the same turn is a no-op
+        // (AlreadyFinalized) — no double-finalize, no counter underflow.
         let global_before = shared
             .global_active
             .load(std::sync::atomic::Ordering::Acquire);
@@ -12681,7 +12878,7 @@ mod tests {
             &shared,
             &provider,
             channel_id,
-            user_msg_id,
+            finalize_id,
             false,
             false,
             true,
@@ -12699,6 +12896,133 @@ mod tests {
         assert_eq!(
             global_before, global_after,
             "double fresh-idle finalize must NOT underflow the active counter (AlreadyFinalized)"
+        );
+    }
+
+    // #3016 A2 (ii): a PAUSED-live delegated turn is DEFERRED through the real
+    // branch, not finalized. The defer is the first gate in the production
+    // fresh-idle block; this proves the ledger-fed defer predicate AND that the
+    // finalize decision is never reached for it.
+    #[tokio::test]
+    async fn fresh_idle_paused_live_delegated_turn_defers_through_real_path() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _root_guard = AgentdeskRootGuard::set(tmp.path());
+
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(987_3019);
+        let generation = shared.current_generation;
+        let user_msg_id = 8101u64;
+
+        // Live watcher-owned Pending entry → the ledger-fed defer input is true.
+        shared.turn_finalizer.register_start(
+            crate::services::discord::turn_finalizer::TurnKey::new(
+                channel_id,
+                user_msg_id,
+                generation,
+            ),
+            provider.clone(),
+            crate::services::discord::inflight::RelayOwnerKind::Watcher,
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let delegated_turn_owned = shared
+            .turn_finalizer
+            .has_live_watcher_pending(channel_id, generation)
+            .await;
+        assert!(delegated_turn_owned, "live entry → defer input is true");
+
+        // Production defer gate: empty response + live delegated entry → DEFER.
+        // This is the exact predicate the production fresh-idle branch evaluates
+        // first; when true the branch `continue`s and NEVER reaches the finalize
+        // decision below.
+        assert!(
+            watcher_should_defer_delegated_fresh_idle(delegated_turn_owned, ""),
+            "paused-live delegated turn with empty response is DEFERRED (not finalized)"
+        );
+        // Non-empty response would NOT defer (the turn produced terminal text).
+        assert!(
+            !watcher_should_defer_delegated_fresh_idle(delegated_turn_owned, "answer"),
+            "a committed response is not a paused-live defer case"
+        );
+    }
+
+    // #3016 A2 (iii): a FOLLOW-UP-turn race (a newer turn is current at
+    // fresh-idle) must NOT finalize the follow-up. Two production sub-paths:
+    //   (a) the follow-up paused the watcher / bumped the epoch during the
+    //       cleanup awaits → AbortFollowupTookOver.
+    //   (b) the follow-up rewrote inflight to a turn that started AT/AFTER this
+    //       committed range (`turn_start_offset >= current_offset`) → SkipStale
+    //       (pinned id 0), so the stale-skip fires and the follow-up is NOT
+    //       released.
+    #[test]
+    fn fresh_idle_followup_turn_race_does_not_finalize_the_followup() {
+        let provider = ProviderKind::Claude;
+        let session = "AgentDesk-claude-adk-cc-9873020";
+        let channel_id = 987_3020u64;
+        let current_offset = 50u64;
+
+        // (a) Paused / epoch changed → abort regardless of the snapshot.
+        let current_turn = fresh_idle_inflight(provider.clone(), channel_id, session, 9001, 10);
+        assert_eq!(
+            watcher_fresh_idle_finalize_decision(
+                true, // paused_now — follow-up handoff paused the watcher
+                false,
+                Some(&current_turn),
+                session,
+                current_offset,
+            ),
+            FreshIdleFinalizeDecision::AbortFollowupTookOver,
+            "paused_now → abort before the destructive clear"
+        );
+        assert_eq!(
+            watcher_fresh_idle_finalize_decision(
+                false,
+                true, // epoch_changed — follow-up bumped pause_epoch
+                Some(&current_turn),
+                session,
+                current_offset,
+            ),
+            FreshIdleFinalizeDecision::AbortFollowupTookOver,
+            "epoch_changed → abort before the destructive clear"
+        );
+
+        // (b) Follow-up rewrote inflight to a NEWER turn that begins AT/AFTER the
+        // committed range (turn_start_offset 50 >= current_offset 50). The pinned
+        // id is 0 and the stale gate fires → SkipStale, so the newer turn is NOT
+        // released by this older idle.
+        let newer_followup = fresh_idle_inflight(provider.clone(), channel_id, session, 9002, 50);
+        assert_eq!(
+            watcher_fresh_idle_finalize_decision(
+                false,
+                false,
+                Some(&newer_followup),
+                session,
+                current_offset,
+            ),
+            FreshIdleFinalizeDecision::SkipStale {
+                pinned_user_msg_id: 0
+            },
+            "a newer follow-up turn (start >= current_offset) → SkipStale, follow-up NOT finalized"
+        );
+
+        // Strictly-after start is also skipped.
+        let strictly_after = fresh_idle_inflight(provider, channel_id, session, 9003, 60);
+        assert_eq!(
+            watcher_fresh_idle_finalize_decision(
+                false,
+                false,
+                Some(&strictly_after),
+                session,
+                current_offset,
+            ),
+            FreshIdleFinalizeDecision::SkipStale {
+                pinned_user_msg_id: 0
+            },
+            "a strictly-after follow-up turn is also skipped"
         );
     }
 

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -128,11 +128,22 @@ fn watcher_fallback_edit_failure_can_delete_original_placeholder(
     false
 }
 
+/// #3016 A2: defer fresh-idle finalization for a delegated turn that the watcher
+/// still owns but has not yet committed any terminal assistant text for.
+///
+/// `delegated_turn_owned` is the "this is a live bridge→watcher delegated turn
+/// the watcher owns" signal. It was historically the in-memory
+/// `mailbox_finalize_owed` flag; as of A2 the call site feeds the LEDGER
+/// authority (`TurnFinalizer::has_live_watcher_pending`) instead, so the flag is
+/// no longer load-bearing here. The two are equivalent for a fresh delegated
+/// turn — the bridge publishes the flag AND the watcher-owned `register_start`
+/// ledger entry together at the unpause handoff. The boolean contract (and the
+/// pure-function unit tests) are unchanged.
 fn watcher_should_defer_delegated_fresh_idle(
-    delegated_finalize_owed: bool,
+    delegated_turn_owned: bool,
     full_response: &str,
 ) -> bool {
-    delegated_finalize_owed && full_response.trim().is_empty()
+    delegated_turn_owned && full_response.trim().is_empty()
 }
 
 fn watcher_should_clear_stale_terminal_message_ids(
@@ -7477,12 +7488,20 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             }
 
             if fresh_ready_for_input_idle {
-                let delegated_finalize_owed_pending =
-                    mailbox_finalize_owed.load(std::sync::atomic::Ordering::Acquire);
-                if watcher_should_defer_delegated_fresh_idle(
-                    delegated_finalize_owed_pending,
-                    &full_response,
-                ) {
+                // #3016 A2 (phase-5 enabler): drive the defer decision from the
+                // LEDGER, not the in-memory `mailbox_finalize_owed` flag. The
+                // bridge publishes BOTH together at the watcher-unpause handoff
+                // (flag store + watcher-owned `register_start`), so a live
+                // watcher-owned Pending entry is exactly the "delegated turn the
+                // watcher still owns" condition the flag expressed — without the
+                // flag being load-bearing. This is the flag's last load-bearing
+                // use at the fresh-idle site; making it ledger-driven unblocks
+                // the flag deletion (separate phase-5 PR).
+                let delegated_turn_owned = shared
+                    .turn_finalizer
+                    .has_live_watcher_pending(channel_id, shared.current_generation)
+                    .await;
+                if watcher_should_defer_delegated_fresh_idle(delegated_turn_owned, &full_response) {
                     let ts = chrono::Local::now().format("%H:%M:%S");
                     tracing::info!(
                         "  [{ts}] 👁 watcher observed fresh ready-for-input idle for {tmux_session_name} at offset {current_offset}, but bridge-delegated turn has no terminal assistant text yet; preserving inflight and waiting for terminal commit"
@@ -7566,56 +7585,72 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 if !panel_cleanup_committed {
                     continue;
                 }
+                // #3016 A2 (phase-5 enabler): the fresh-idle finalize is now
+                // LEDGER-driven, not flag-driven. Reaching here means every
+                // upstream guard already decided this is a REAL idle to act on:
+                //   * `watcher_should_defer_delegated_fresh_idle` (now ledger-fed)
+                //     already `continue`d for a delegated turn with no terminal
+                //     assistant text yet — so a turn merely PAUSED at a
+                //     selector/subagent prompt (empty committed response) never
+                //     reaches this point; and
+                //   * the placeholder + orphan-panel cleanup guards committed.
+                // We still `swap(false)` the legacy flag to keep its revoke
+                // lifecycle intact (the flag is NOT deleted in this PR — only made
+                // non-load-bearing), exactly as the canonical option-A site does.
                 let owed = mailbox_finalize_owed.swap(false, std::sync::atomic::Ordering::AcqRel);
-                let should_finish_mailbox = finish_mailbox_on_completion || owed;
-                if should_finish_mailbox {
-                    // #3016: capture the turn's real id BEFORE clearing inflight,
-                    // so the finalizer ledger match is exact (id-0 would risk a
-                    // stale terminal finalizing a queued follow-up).
-                    let fresh_idle_user_msg_id =
-                        crate::services::discord::inflight::load_inflight_state(
-                            &watcher_provider,
-                            channel_id.get(),
-                        )
-                        .map(|s| s.user_msg_id)
-                        .unwrap_or(0);
-                    crate::services::discord::inflight::clear_inflight_state(
+                // #3016: capture the turn's real id BEFORE clearing inflight, so
+                // the finalizer ledger match is exact (id-0 would risk a stale
+                // terminal finalizing a queued follow-up).
+                let fresh_idle_user_msg_id =
+                    crate::services::discord::inflight::load_inflight_state(
                         &watcher_provider,
                         channel_id.get(),
-                    );
-                    crate::services::observability::emit_inflight_lifecycle_event(
-                        watcher_provider.as_str(),
-                        channel_id.get(),
-                        None,
-                        None,
-                        None,
-                        "cleared_by_watcher_fresh_idle",
-                        serde_json::json!({
-                            "owed_finalize": owed,
-                            "finish_mailbox_on_completion": finish_mailbox_on_completion,
-                            "tmux_session": tmux_session_name.as_str(),
-                            "offset": current_offset,
-                        }),
-                    );
-                    finish_restored_watcher_active_turn(
-                        &shared,
-                        &watcher_provider,
-                        channel_id,
-                        fresh_idle_user_msg_id,
-                        finish_mailbox_on_completion,
-                        owed,
-                        // #3016 option A: this fresh-idle arm is already gated by
-                        // the outer `if should_finish_mailbox` (= flag-driven), so
-                        // it keeps the legacy flag semantics — `normal_completion`
-                        // stays `false` here. (No new assistant text was committed
-                        // in this pass, so it is not the canonical-completion
-                        // point that the decoupling targets.)
-                        false,
-                        true,
-                        "watcher fresh ready-for-input idle with queued backlog",
                     )
-                    .await;
-                }
+                    .map(|s| s.user_msg_id)
+                    .unwrap_or(0);
+                crate::services::discord::inflight::clear_inflight_state(
+                    &watcher_provider,
+                    channel_id.get(),
+                );
+                crate::services::observability::emit_inflight_lifecycle_event(
+                    watcher_provider.as_str(),
+                    channel_id.get(),
+                    None,
+                    None,
+                    None,
+                    "cleared_by_watcher_fresh_idle",
+                    serde_json::json!({
+                        "owed_finalize": owed,
+                        "finish_mailbox_on_completion": finish_mailbox_on_completion,
+                        "tmux_session": tmux_session_name.as_str(),
+                        "offset": current_offset,
+                    }),
+                );
+                finish_restored_watcher_active_turn(
+                    &shared,
+                    &watcher_provider,
+                    channel_id,
+                    fresh_idle_user_msg_id,
+                    finish_mailbox_on_completion,
+                    owed,
+                    // #3016 A2: this fresh-idle commit point is a confirmed real
+                    // idle (the defer + cleanup guards above gated out the
+                    // paused-live / not-yet-committed cases), so drive the
+                    // single-authority finalizer UNCONDITIONALLY — independent of
+                    // the legacy `owed` / `finish_mailbox_on_completion` flags.
+                    // This is an empty/suppressed delegated completion: no new
+                    // assistant text was committed this pass, but the turn IS done
+                    // and must finalize via the ledger. The finalizer is
+                    // idempotent (bridge winner → AlreadyFinalized) and
+                    // identity-guarded (real `fresh_idle_user_msg_id` →
+                    // `finish_turn_if_matches`, so a stale/wrong id cannot release
+                    // a newer live turn), so an unconditional submit here cannot
+                    // over-finalize.
+                    true,
+                    true,
+                    "watcher fresh ready-for-input idle with queued backlog",
+                )
+                .await;
                 all_data.clear();
                 all_data_start_offset = current_offset;
                 all_data_fully_mirrored_to_session_relay = true;
@@ -12501,6 +12536,169 @@ mod tests {
                 .cancel_token
                 .is_none(),
             "turn B is released by its matching finalize"
+        );
+    }
+
+    // #3016 A2 (fresh-idle ledger authority). Proves the THREE properties the
+    // PR depends on, end-to-end through the real `TurnFinalizer` actor:
+    //
+    //   (i)   An empty/suppressed DELEGATED completion at fresh-idle finalizes
+    //         via the LEDGER even with the legacy `mailbox_finalize_owed` flag
+    //         FALSE — the finalize is no longer gated on the flag.
+    //   (ii)  The fresh-idle DEFER decision is now ledger-driven: a live
+    //         watcher-owned Pending entry makes `has_live_watcher_pending` (the
+    //         defer-guard input) report `true` BEFORE finalize, then `false`
+    //         after — so a paused-live turn (empty response + live entry) is
+    //         deferred, not finalized.
+    //   (iii) Idempotency: a second fresh-idle submit for the same turn is a
+    //         no-op (AlreadyFinalized) — no double-finalize, no counter
+    //         underflow.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn fresh_idle_empty_delegated_completion_finalizes_via_ledger_flag_false() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _root_guard = AgentdeskRootGuard::set(tmp.path());
+
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(987_3018);
+        let tmux_session_name = "AgentDesk-claude-adk-cc-9873018";
+        let user_msg_id = 8001u64;
+        let generation = shared.current_generation;
+
+        // Real watcher handle with the legacy flag FALSE: the fresh-idle
+        // finalize must NOT depend on the flag.
+        shared
+            .tmux_watchers
+            .insert(channel_id, test_watcher_handle(tmux_session_name, false));
+
+        // Bridge→watcher unpause handoff (LEDGER half): register a live
+        // watcher-owned Pending entry under the turn's real id. This is what the
+        // ledger-driven defer guard reads instead of the flag.
+        shared.turn_finalizer.register_start(
+            crate::services::discord::turn_finalizer::TurnKey::new(
+                channel_id,
+                user_msg_id,
+                generation,
+            ),
+            provider.clone(),
+            crate::services::discord::inflight::RelayOwnerKind::Watcher,
+        );
+        // Allow the actor to drain the Start before we query.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        // (ii) BEFORE finalize: the ledger reports a live watcher-owned entry,
+        // so the defer guard would defer an empty-response paused-live turn.
+        assert!(
+            shared
+                .turn_finalizer
+                .has_live_watcher_pending(channel_id, generation)
+                .await,
+            "live watcher-owned Pending entry → defer guard input is true (paused-live deferred)"
+        );
+        assert!(
+            watcher_should_defer_delegated_fresh_idle(true, ""),
+            "empty response + live delegated entry → DEFER (paused-live not finalized)"
+        );
+        // A genuine empty completion is the one that proceeds past the guard:
+        // the guard only defers while the response is empty AND the turn is a
+        // live delegated entry; the proceed decision below is the post-guard
+        // commit point.
+
+        // Live active mailbox turn with the turn's real id, so we can observe
+        // the finalize releasing exactly THIS turn's token.
+        assert!(
+            mailbox_try_start_turn(
+                &shared,
+                channel_id,
+                std::sync::Arc::new(CancelToken::new()),
+                UserId::new(42),
+                MessageId::new(user_msg_id),
+            )
+            .await
+        );
+
+        // (i) Precondition: the legacy flag is FALSE on the real handle.
+        let watcher = shared
+            .tmux_watchers
+            .get(&channel_id)
+            .expect("real watcher handle present");
+        assert!(
+            !watcher
+                .mailbox_finalize_owed
+                .load(std::sync::atomic::Ordering::Acquire),
+            "precondition: mailbox_finalize_owed FALSE — finalize must drive via the ledger"
+        );
+        drop(watcher);
+
+        // Fresh-idle commit point: clear inflight inline (mirrors the call site)
+        // then drive the finalizer UNCONDITIONALLY with normal_completion = true.
+        crate::services::discord::inflight::clear_inflight_state(&provider, channel_id.get());
+        let drove = super::finish_restored_watcher_active_turn(
+            &shared,
+            &provider,
+            channel_id,
+            user_msg_id,
+            false, // finish_mailbox_on_completion — fresh live watcher
+            false, // delegated_finalize_owed — flag FALSE (swapped at the site)
+            true,  // normal_completion — A2: ledger-driven, flag-independent
+            true,  // kickoff_queue
+            "fresh_idle_ledger_test",
+        )
+        .await;
+        assert!(
+            drove,
+            "fresh-idle finalize must drive the finalizer (flag-independent, normal_completion=true)"
+        );
+
+        // (i) The empty/suppressed completion finalized via the ledger even with
+        // the flag false: the matching turn's mailbox token is released.
+        let snapshot = mailbox_snapshot(&shared, channel_id).await;
+        assert!(
+            snapshot.cancel_token.is_none(),
+            "empty/suppressed delegated completion finalizes via the ledger with the flag FALSE"
+        );
+
+        // (ii) AFTER finalize: the ledger entry is Finalized → defer guard input
+        // flips to false (the turn is done; nothing left to defer).
+        assert!(
+            !shared
+                .turn_finalizer
+                .has_live_watcher_pending(channel_id, generation)
+                .await,
+            "finalized entry → defer guard input is false"
+        );
+
+        // (iii) Idempotency: a second fresh-idle submit for the same turn is a
+        // no-op (AlreadyFinalized) — no double-finalize, no counter underflow.
+        let global_before = shared
+            .global_active
+            .load(std::sync::atomic::Ordering::Acquire);
+        let drove_again = super::finish_restored_watcher_active_turn(
+            &shared,
+            &provider,
+            channel_id,
+            user_msg_id,
+            false,
+            false,
+            true,
+            true,
+            "fresh_idle_ledger_test_double",
+        )
+        .await;
+        assert!(
+            drove_again,
+            "second submit still passes the helper gate (normal_completion=true) but is a no-op"
+        );
+        let global_after = shared
+            .global_active
+            .load(std::sync::atomic::Ordering::Acquire);
+        assert_eq!(
+            global_before, global_after,
+            "double fresh-idle finalize must NOT underflow the active counter (AlreadyFinalized)"
         );
     }
 

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -375,6 +375,18 @@ enum FinalizeMsg {
         shared: Arc<SharedData>,
         ack: oneshot::Sender<FinalizeOutcome>,
     },
+    /// #3016 A2 (phase-5 enabler): read-only ledger probe. Answers "does this
+    /// `(channel, generation)` have a live (non-`Finalized`) entry owned by the
+    /// watcher?" — the LEDGER equivalent of the legacy in-memory
+    /// `mailbox_finalize_owed` flag, set together with the entry's
+    /// `register_start` at the bridge→watcher unpause handoff. Used ONLY by the
+    /// fresh-idle defer guard so it no longer reads the in-memory flag. Pure
+    /// query: never mutates the ledger.
+    QueryLivePending {
+        channel_id: ChannelId,
+        generation: u64,
+        ack: oneshot::Sender<bool>,
+    },
     /// #3041 §2-§3 (DORMANT until P1-2..): CAS-acquire `(key, [start,end))` for
     /// `holder` via the actor. The watcher acquires the cell directly (B4
     /// fast-path), so this variant has no sender yet — it is reserved for the
@@ -504,6 +516,43 @@ impl TurnFinalizer {
             return FinalizeOutcome::AlreadyFinalized;
         }
         rx.await.unwrap_or(FinalizeOutcome::AlreadyFinalized)
+    }
+
+    /// #3016 A2 (phase-5 enabler): is there a live (non-`Finalized`) ledger
+    /// entry for this `(channel, generation)` that the WATCHER owns?
+    ///
+    /// This is the LEDGER authority that replaces the in-memory
+    /// `mailbox_finalize_owed` flag at the fresh-idle defer guard. The bridge
+    /// publishes BOTH together at the watcher-unpause handoff
+    /// (`mailbox_finalize_owed.store(true)` AND `register_start(.., Watcher)`),
+    /// so a `true` here is exactly the "this is a live bridge→watcher delegated
+    /// turn the watcher still owns" condition the flag used to express — without
+    /// reading the flag. The watcher-owner filter mirrors the flag's meaning:
+    /// the flag was only ever set when the watcher took over relay/finalize, so
+    /// a bridge-owned (`RelayOwnerKind::None`/non-watcher) entry must NOT make
+    /// the defer guard fire (it never did under the flag).
+    ///
+    /// Read-only: it never mutates the ledger, so it cannot affect the
+    /// exactly-once gate. On actor teardown it returns `false` (no live entry to
+    /// defer for), matching `submit_terminal`'s teardown convention.
+    pub(in crate::services::discord) async fn has_live_watcher_pending(
+        &self,
+        channel_id: ChannelId,
+        generation: u64,
+    ) -> bool {
+        let (ack, rx) = oneshot::channel();
+        if self
+            .tx
+            .send(FinalizeMsg::QueryLivePending {
+                channel_id,
+                generation,
+                ack,
+            })
+            .is_err()
+        {
+            return false;
+        }
+        rx.await.unwrap_or(false)
     }
 
     /// #3041: route a three-way `CommitDelivery` through the actor so the lease
@@ -647,6 +696,23 @@ async fn actor_loop(mut rx: mpsc::UnboundedReceiver<FinalizeMsg>) {
                             handle_terminal(&mut ledger, key, provider, event, ctx, &shared)
                                 .await;
                         let _ = ack.send(outcome);
+                    }
+                    FinalizeMsg::QueryLivePending {
+                        channel_id,
+                        generation,
+                        ack,
+                    } => {
+                        // Read-only probe: no ledger mutation, no exactly-once
+                        // interaction. Runs on the actor task so it observes a
+                        // consistent snapshot of the same map the terminal/start
+                        // handlers mutate.
+                        let live = ledger.iter().any(|(lk, e)| {
+                            lk.channel_id == channel_id
+                                && lk.generation == generation
+                                && e.phase != Phase::Finalized
+                                && e.relay_owner == RelayOwnerKind::Watcher
+                        });
+                        let _ = ack.send(live);
                     }
                     // #3041 §2-§3 P1-0 (DORMANT, UNREACHABLE today). Routing these
                     // through the actor serializes lease transitions on the finalize
@@ -1265,6 +1331,84 @@ mod tests {
                 )
                 .await;
             assert!(matches!(second, FinalizeOutcome::AlreadyFinalized));
+        })
+        .await;
+    }
+
+    /// #3016 A2: `has_live_watcher_pending` is the LEDGER authority that
+    /// replaces the in-memory `mailbox_finalize_owed` flag at the fresh-idle
+    /// defer guard. It must report a live, watcher-owned, non-finalized entry as
+    /// `true`, and flip to `false` once that entry finalizes — so the defer
+    /// guard no longer needs the flag.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn has_live_watcher_pending_tracks_ledger_not_flag() {
+        with_isolated_runtime_root(|| async move {
+            let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
+            shared.global_active.store(1, Ordering::Relaxed);
+            let fin = TurnFinalizer::spawn();
+            let ch = ChannelId::new(3_016_021);
+            let generation = 0;
+            let k = TurnKey::new(ch, 7001, generation);
+
+            // No entry yet → no live pending.
+            assert!(
+                !fin.has_live_watcher_pending(ch, generation).await,
+                "no ledger entry → not pending"
+            );
+
+            // Bridge→watcher unpause handoff: register_start with the watcher
+            // owner (the LEDGER half of the old `flag store + register_start`
+            // pairing).
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            assert!(
+                fin.has_live_watcher_pending(ch, generation).await,
+                "live watcher-owned Pending entry → pending (ledger == old flag)"
+            );
+
+            // A different generation must NOT match (cross-restart isolation).
+            assert!(
+                !fin.has_live_watcher_pending(ch, generation + 1).await,
+                "different generation → not pending"
+            );
+
+            // Finalize the turn → the entry is Finalized → no longer pending.
+            let outcome = fin
+                .submit_terminal(
+                    k,
+                    ProviderKind::Claude,
+                    TerminalEvent::Complete,
+                    FinalizeContext::watcher(),
+                    shared.clone(),
+                )
+                .await;
+            assert!(matches!(outcome, FinalizeOutcome::Finalized { .. }));
+            assert!(
+                !fin.has_live_watcher_pending(ch, generation).await,
+                "finalized entry → not pending (defer guard stops deferring)"
+            );
+        })
+        .await;
+    }
+
+    /// #3016 A2: a bridge-owned (non-watcher) live entry must NOT be reported as
+    /// watcher-pending — the old `mailbox_finalize_owed` flag was only ever set
+    /// when the watcher took over relay/finalize, so a bridge-owned turn must not
+    /// make the fresh-idle defer guard fire.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn has_live_watcher_pending_ignores_bridge_owned_entry() {
+        with_isolated_runtime_root(|| async move {
+            let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
+            let _ = shared;
+            let fin = TurnFinalizer::spawn();
+            let ch = ChannelId::new(3_016_022);
+            let generation = 0;
+            let k = TurnKey::new(ch, 7002, generation);
+            // Registered, live, but NOT watcher-owned.
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::None);
+            assert!(
+                !fin.has_live_watcher_pending(ch, generation).await,
+                "bridge-owned (RelayOwnerKind::None) entry → not watcher-pending"
+            );
         })
         .await;
     }


### PR DESCRIPTION
## #3016 A2 — fresh-idle delegated completion finalizes via the ledger authority (phase-5 enabler)

The **fresh-idle path** in `tmux_watcher.rs` was the **last load-bearing use** of the in-memory `mailbox_finalize_owed` flag — the blocker for phase-5 (flag deletion). It handles the pane reaching ready-for-input idle with **no terminal assistant text committed** (an empty/suppressed delegated completion). For a fresh live bridge→watcher delegated turn `finish_mailbox_on_completion=false`, so `owed` (swapped from the flag) was the **sole** finalize gate.

This PR makes that decision **ledger-driven** (single-authority `TurnFinalizer`), leaving the flag in place but **no longer load-bearing**. The flag is **NOT deleted** here — that is the separate phase-5 follow-up.

### Mechanism (exact edits)

1. **`src/services/discord/turn_finalizer.rs`** — new read-only ledger probe:
   - `FinalizeMsg::QueryLivePending { channel_id, generation, ack }` (message variant).
   - `TurnFinalizer::has_live_watcher_pending(channel_id, generation) -> bool` (public method).
   - Actor-loop handler: `ledger.iter().any(|(lk, e)| lk.channel == .. && lk.generation == .. && e.phase != Finalized && e.relay_owner == Watcher)`.
   - **Pure query**: never mutates the ledger, so it cannot affect the exactly-once gate. Returns the ledger equivalent of the flag — the bridge publishes BOTH together at the watcher-unpause handoff (`mailbox_finalize_owed.store(true)` **and** `register_start(.., Watcher)`, `turn_bridge/mod.rs` ~6019/6037).

2. **`src/services/discord/tmux_watcher.rs` — defer guard (~7491)**: feed `has_live_watcher_pending(channel, current_generation)` (not the flag load) into `watcher_should_defer_delegated_fresh_idle`. The boolean contract (and the pure-function unit tests) are unchanged; only the *source* of the "delegated turn the watcher owns" signal moves from the flag to the ledger. Parameter renamed `delegated_finalize_owed` → `delegated_turn_owned`.

3. **`src/services/discord/tmux_watcher.rs` — finalize (~7585)**: drop the `should_finish_mailbox = owed || finish_mailbox_on_completion` gate; drive `finish_restored_watcher_active_turn(.., normal_completion=true, ..)` **unconditionally**, mirroring the canonical option-A site (`tmux_watcher.rs` ~11093, `tmux.rs` `finish_restored_watcher_active_turn`). The legacy flag `swap(false)` still runs (revoke lifecycle preserved).

4. **`docs/agent-maintenance/change-surfaces.md`**: synced `tmux_watcher.rs` freeze count 9215 → 9250.

### Paused-live safety proof (KEY — adversarial enumeration)

**Why the finalizer alone is NOT the gate:** a `Complete` terminal with a real `user_msg_id` ALWAYS finalizes — `handle_terminal` does `ledger.entry(key).or_insert(Pending)` then finalizes (orphan path). So the upstream **defer + cleanup guards** are the safety boundary, not the finalizer. The only path to the finalize point is `fresh_ready_for_input_idle`, which requires **JSONL turn-state Idle** (turn *terminated*, not paused; `Streaming`/`UserSubmitted` → Busy) or a pane-fallback ready. Enumeration of every "still live" scenario:

| Scenario | Reaches finalize? | Why safe |
|---|---|---|
| **Paused at selector** (turn not terminated) | No | JSONL turn-state is `Busy` (turn not terminated) → `fresh_ready_for_input_idle` does not fire. If the pane-fallback false-positives ready, the turn is delegated (`owed`/ledger live) with empty committed response → ledger-fed defer guard `continue`s, inflight preserved. |
| **Subagent running** | No | Same: turn not terminated in JSONL → not fresh-idle; if pane-fallback fires, empty response + live watcher-owned ledger entry → deferred. |
| **Long silent tool call** | No | Turn still in-flight in JSONL (no terminator) → not fresh-idle. Live watcher-owned entry + empty response → deferred if it ever pane-falls-through. |
| **Genuine empty / suppressed completion** | **Yes (intended)** | Turn terminated in JSONL, response empty/suppressed. For a delegated turn that the bridge already finalized: `AlreadyFinalized` (no-op). For a TUI-direct turn the watcher owns: finalizes via the identity-guarded `finish_turn_if_matches` — releasing exactly that turn's mailbox token. This is the empty/suppressed completion phase-5 targets. |

The defer guard input moved from `owed` to the ledger, but the two are **equivalent for a fresh delegated turn** (set together at the unpause handoff), so no paused-live turn that the flag previously deferred is now let through. **No behavior change** on the canonical option-A completion path, restore semantics, or the non-empty completion path.

### Idempotency / identity (wrong-turn finalize prevented)

- **Exactly-once**: the finalizer's per-turn `Phase` gate (`Pending → Finalizing → Finalized`) returns `AlreadyFinalized` to the loser — if the bridge/canonical path already finalized, the fresh-idle submit is a no-op.
- **Identity guard**: the fresh-idle submit uses the **real captured** `fresh_idle_user_msg_id` (from inflight, before clearing — never 0 when known), so `do_finalize` takes `mailbox_finish_turn_if_matches`. A stale/wrong id misses the live turn (`removed_token = None`) → no token release, no counter decrement, no channel cleanup (the `guarded_finish_missed` no-op path). The id-0/identity-collapse guard (`handle_terminal` ~749) additionally prevents a channel-only stale terminal from collapsing onto a newer live turn.
- **No counter underflow**: the active-counter decrement is gated on `removed_token.is_some()`, so a double-submit cannot underflow.

### Tests added
- `turn_finalizer::has_live_watcher_pending_tracks_ledger_not_flag` — the probe reports a live watcher-owned entry as `true`, flips to `false` after finalize, isolates by generation.
- `turn_finalizer::has_live_watcher_pending_ignores_bridge_owned_entry` — a bridge-owned (`RelayOwnerKind::None`) live entry is NOT watcher-pending (mirrors the flag's meaning).
- `tmux_watcher::fresh_idle_empty_delegated_completion_finalizes_via_ledger_flag_false` — end-to-end through the real actor: **(i)** empty/suppressed delegated completion finalizes via the ledger with the flag **FALSE**; **(ii)** the ledger-driven defer guard defers a paused-live turn (live entry + empty response); **(iii)** idempotency — a second submit is `AlreadyFinalized`, the active counter does not underflow.

### Verification
- `cargo build` clean (only pre-existing warnings).
- `cargo test --lib turn_finalizer` → **52 passed** (incl. the (actor × terminal-path) exactly-once matrix + 2 new).
- `cargo test --lib tmux_watcher` → **146 passed** (incl. the decouple-proof `normal_completion_finalizes_with_both_legacy_flags_false`, `stale_normal_completion_does_not_release_newer_active_turn`, `delegated_fresh_idle_without_response_is_not_terminal_commit` + 1 new).
- `cargo test --lib services::discord -- --test-threads=1` → **1139 passed** (a parallel-run flake in the unrelated `health::recovery::chunk_ledger_*` test — process-global shared state — passes in isolation and single-threaded on both base and this branch).
- `cargo fmt` applied.
- Freeze gate: `python3 scripts/check_agent_maintenance_docs.py --line-count-gate` → **passed** after syncing change-surfaces.md.

**Scope**: confined to the fresh-idle path + a minimal read-only finalizer helper. `codex.rs`/`claude.rs` untouched. The flag deletion is deliberately left for phase-5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
