### PR TITLE
fix(#3198): status panel — don't mark background subagents ✓ on launching-turn finalize

### DIFF
--- a/src/services/agent_protocol.rs
+++ b/src/services/agent_protocol.rs
@@ -305,6 +305,13 @@ pub enum StatusEvent {
         /// one (which mis-attributes across parallel subagents). `None` when
         /// the backend cannot surface an id.
         tool_use_id: Option<String>,
+        /// `true` when the Task/Agent was launched with `run_in_background`.
+        /// A background dispatch's immediate `tool_result` is only a launch
+        /// ack — the subagent keeps running and outlives the launching turn —
+        /// so the panel must NOT mark it ✓ (completed) on that ack-only
+        /// `SubagentEnd`; only a genuine completion (summary-bearing end or a
+        /// terminal task_notification) finalizes it (#3041 / status panel).
+        background: bool,
     },
     SubagentEvent {
         summary: String,
@@ -315,10 +322,18 @@ pub enum StatusEvent {
         /// against [`StatusEvent::SubagentStart::tool_use_id`]; `None` falls
         /// back to closing the first unfinished slot.
         tool_use_id: Option<String>,
-        /// TUI-parity accounting (tool count / tokens / duration) reconstructed
+        /// TUI-parity accounting (tool count / tokens · duration) reconstructed
         /// from the Task `toolUseResult` and/or `subagents/*.jsonl` (#3086).
         /// `None` when no summary fields were recoverable.
         summary: Option<SubagentSummary>,
+        /// `true` when this end is only the immediate `tool_result` launch ack
+        /// for a Task (it always fires when the Task tool returns, even for a
+        /// `run_in_background` dispatch whose subagent keeps running). The panel
+        /// uses this to avoid marking a still-running background subagent ✓: an
+        /// ack-only end finalizes a foreground slot but NOT a background slot.
+        /// A genuine completion (summary-bearing end, or a terminal
+        /// task_notification) sets this `false` and always finalizes.
+        ack_only: bool,
     },
     TaskToolUpdate {
         name: String,

--- a/src/services/discord/placeholder_live_events/status_events.rs
+++ b/src/services/discord/placeholder_live_events/status_events.rs
@@ -55,6 +55,10 @@ pub(in crate::services::discord) fn status_events_from_tool_use_with_id(
     }
     if is_task_tool(name) {
         let value = tool_input_value(input);
+        let background = value
+            .get("run_in_background")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
         events.push(StatusEvent::SubagentStart {
             subagent_type: value
                 .get("subagent_type")
@@ -64,6 +68,7 @@ pub(in crate::services::discord) fn status_events_from_tool_use_with_id(
                 .or_else(|| Some(name.to_string())),
             desc: subagent_description(&value).or(args_summary.clone()),
             tool_use_id: tool_use_id.map(str::to_string),
+            background,
         });
     }
     if is_todo_write_tool(name) {
@@ -105,6 +110,14 @@ pub(in crate::services::discord) fn status_events_from_tool_result_with_id(
             success: !is_error,
             tool_use_id: tool_use_id.map(str::to_string),
             summary: None,
+            // The Task `tool_result` always fires when the tool returns. Only a
+            // SUCCESSFUL `run_in_background` launch is an ack-only end: the
+            // dispatch succeeded and the subagent keeps running (often
+            // outliving the launching turn), so the panel must NOT mark it ✓.
+            // A FAILED launch (`is_error`) is terminal — the subagent never
+            // started — so it is not ack-only and the panel finalizes the slot
+            // as failed (✗), exactly like a foreground failure.
+            ack_only: !is_error,
         });
     }
     events
@@ -128,6 +141,10 @@ pub(in crate::services::discord) fn status_events_from_task_notification(
                     success: !task_notification_is_error(status),
                     tool_use_id: None,
                     summary: None,
+                    // A terminal task_notification is the subagent's REAL
+                    // completion (including background subagents), so it always
+                    // finalizes the slot — not an ack.
+                    ack_only: false,
                 });
             }
         }
@@ -474,6 +491,10 @@ fn user_status_events(value: &Value) -> Vec<StatusEvent> {
                         success: !is_error,
                         tool_use_id,
                         summary: Some(summary),
+                        // A summary-bearing end carries real accounting
+                        // (`toolUseResult`/rollout) — a genuine completion that
+                        // always finalizes the slot, never just an ack.
+                        ack_only: false,
                     },
                 ];
             }

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -199,14 +199,12 @@ impl StatusPanelState {
                 };
                 let slot = target.map(|index| &mut self.subagents[index]);
                 if let Some(slot) = slot {
-                    // A `run_in_background` subagent's immediate Task
-                    // `tool_result` arrives as an ack-only end while the
-                    // subagent keeps running (often outliving the launching
-                    // turn). Finalizing it here would render a premature ✓. Skip
-                    // the finalize for background slots on an ack-only end; a
-                    // genuine completion (summary-bearing end or terminal
-                    // task_notification, both `ack_only == false`) still closes
-                    // it. Foreground subagents finalize on the ack as before.
+                    // A background subagent's ack-only end is just a launch ack
+                    // (it keeps running, often past the launching turn), so
+                    // finalizing here would render a premature ✓. Skip it for
+                    // background slots on ack-only ends; a genuine completion
+                    // (`ack_only == false`) still closes it. Foreground finalizes
+                    // on the ack as before.
                     let finalize = !(ack_only && slot.background);
                     if finalize {
                         slot.finished = Some(success);

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -33,6 +33,12 @@ pub(super) struct SubagentSlot {
     /// finishing `SubagentEnd` (#3086). Drives the `Done (N tools · M tokens ·
     /// Xs)` summary on the slot's render line.
     summary: Option<SubagentSummary>,
+    /// `true` when this subagent was launched with `run_in_background`. Such a
+    /// subagent's immediate Task `tool_result` is only a launch ack and the
+    /// subagent keeps running (often outliving the launching turn), so an
+    /// ack-only `SubagentEnd` must NOT mark it ✓ — only a genuine completion
+    /// (summary-bearing end or a terminal task_notification) finalizes it.
+    background: bool,
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum DerivedStatus {
@@ -123,6 +129,7 @@ impl StatusPanelState {
                 subagent_type,
                 desc,
                 tool_use_id,
+                background,
             } => {
                 let desc = desc
                     .filter(|value| !value.trim().is_empty())
@@ -137,6 +144,7 @@ impl StatusPanelState {
                     finished: None,
                     tool_use_id,
                     summary: None,
+                    background,
                 });
                 self.status = DerivedStatus::SubagentRunning { desc };
                 trim_subagents(&mut self.subagents);
@@ -158,6 +166,7 @@ impl StatusPanelState {
                 success,
                 tool_use_id,
                 summary,
+                ack_only,
             } => {
                 // #3084: prefer closing the slot whose Task tool-use id matches
                 // the result. This pairs a long-running subagent to its own
@@ -190,7 +199,18 @@ impl StatusPanelState {
                 };
                 let slot = target.map(|index| &mut self.subagents[index]);
                 if let Some(slot) = slot {
-                    slot.finished = Some(success);
+                    // A `run_in_background` subagent's immediate Task
+                    // `tool_result` arrives as an ack-only end while the
+                    // subagent keeps running (often outliving the launching
+                    // turn). Finalizing it here would render a premature ✓. Skip
+                    // the finalize for background slots on an ack-only end; a
+                    // genuine completion (summary-bearing end or terminal
+                    // task_notification, both `ack_only == false`) still closes
+                    // it. Foreground subagents finalize on the ack as before.
+                    let finalize = !(ack_only && slot.background);
+                    if finalize {
+                        slot.finished = Some(success);
+                    }
                     // #3086: attach the TUI-parity Done summary to the closing
                     // slot. Only overwrite when the event actually carries
                     // accounting, so an id-less terminal notification does not

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -1973,6 +1973,145 @@ fn status_panel_subagent_summary_attaches_only_to_matching_slot() {
     );
 }
 
+// Status-panel premature-✓ bug: a subagent launched with `run_in_background`
+// returns its Task `tool_result` immediately (a launch ack) while the subagent
+// keeps running and outlives the launching turn. The panel must NOT mark such a
+// background subagent ✓ on that ack-only end; it stays running until a GENUINE
+// completion (terminal task_notification) arrives.
+#[test]
+fn status_panel_background_subagent_not_marked_done_on_launch_ack() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(871);
+
+    // Background subagent launched.
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({
+                "subagent_type": "bgworker",
+                "description": "Long background job",
+                "run_in_background": true
+            })
+            .to_string(),
+            Some("toolu_bg"),
+        ),
+    );
+    // The Task tool_result fires immediately — only a launch ack. For a
+    // background dispatch the subagent is still running, so this MUST NOT
+    // finalize the slot.
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_result_with_id(Some("Task"), false, Some("toolu_bg")),
+    );
+
+    let rendered_running =
+        events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    let bg_line = rendered_running
+        .lines()
+        .find(|line| line.contains("bgworker Long background job"))
+        .unwrap_or_else(|| panic!("background subagent slot missing in: {rendered_running}"));
+    assert!(
+        !bg_line.contains('✓') && !bg_line.contains('✗'),
+        "background subagent must stay running on the launch ack (no ✓), got: {bg_line}"
+    );
+
+    // A terminal task_notification is the real completion → now it is ✓.
+    events.push_status_events(
+        channel_id,
+        status_events_from_task_notification("subagent", "completed", "all done"),
+    );
+    let rendered_done =
+        events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    let bg_done_line = rendered_done
+        .lines()
+        .find(|line| line.contains("bgworker Long background job"))
+        .unwrap_or_else(|| panic!("background subagent slot missing in: {rendered_done}"));
+    assert!(
+        bg_done_line.contains('✓'),
+        "background subagent must be ✓ after a terminal task_notification, got: {bg_done_line}"
+    );
+}
+
+// Edge case of the premature-✓ fix: a `run_in_background` LAUNCH that FAILS
+// (the Task `tool_result` is an error — the subagent never started) is TERMINAL,
+// not a launch ack. The slot must finalize as failed (✗) instead of being stuck
+// 'running' forever. Guards against the ack-only suppression swallowing a failed
+// background launch.
+#[test]
+fn status_panel_background_subagent_failed_launch_marked_failed() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(873);
+
+    // Background subagent launched.
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({
+                "subagent_type": "bgworker",
+                "description": "Doomed background job",
+                "run_in_background": true
+            })
+            .to_string(),
+            Some("toolu_bg_fail"),
+        ),
+    );
+    // The Task tool_result returns an ERROR: the background launch FAILED, the
+    // subagent never started. This is terminal — the slot must render ✗, not
+    // stay stuck running.
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_result_with_id(Some("Task"), true, Some("toolu_bg_fail")),
+    );
+
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    let bg_line = rendered
+        .lines()
+        .find(|line| line.contains("bgworker Doomed background job"))
+        .unwrap_or_else(|| panic!("background subagent slot missing in: {rendered}"));
+    assert!(
+        bg_line.contains('✗'),
+        "failed background launch must finalize as ✗, got: {bg_line}"
+    );
+    assert!(
+        !bg_line.contains('✓'),
+        "failed background launch must not be marked ✓, got: {bg_line}"
+    );
+}
+
+// A FOREGROUND subagent's Task tool_result IS its real completion, so the
+// ack-only end still finalizes it (✓). Guards against the background fix
+// regressing the foreground path.
+#[test]
+fn status_panel_foreground_subagent_marked_done_on_tool_result() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(872);
+
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({"subagent_type": "fgworker", "description": "Quick job"}).to_string(),
+            Some("toolu_fg"),
+        ),
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_result_with_id(Some("Task"), false, Some("toolu_fg")),
+    );
+
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    let fg_line = rendered
+        .lines()
+        .find(|line| line.contains("fgworker Quick job"))
+        .unwrap_or_else(|| panic!("foreground subagent slot missing in: {rendered}"));
+    assert!(
+        fg_line.contains('✓'),
+        "foreground subagent must be ✓ on its tool_result, got: {fg_line}"
+    );
+}
+
 // #3086 P1: a single `user` record may BATCH multiple finished subagents, each
 // `tool_result` block carrying its OWN `toolUseResult` aggregate. Each Done
 // summary must land on ITS OWN slot (keyed by that block's tool_use_id), not all
@@ -2094,6 +2233,7 @@ fn status_panel_unmatched_summary_end_is_dropped_not_misrouted() {
                 tokens: Some(99_999),
                 duration_secs: Some(99),
             }),
+            ack_only: false,
         }],
     );
 
@@ -2695,6 +2835,9 @@ fn status_tool_result_closes_subagent_only_for_task_tools() {
         status_events_from_tool_result(Some("TaskCreate"), false),
         vec![StatusEvent::ToolEnd { success: true }]
     );
+    // A FAILED Task tool_result is terminal (the launch errored — the subagent
+    // never ran), so it is NOT ack-only: the panel must finalize the slot (✗)
+    // rather than keep a background slot 'running' forever.
     assert_eq!(
         status_events_from_tool_result(Some("Task"), true),
         vec![
@@ -2702,7 +2845,22 @@ fn status_tool_result_closes_subagent_only_for_task_tools() {
             StatusEvent::SubagentEnd {
                 success: false,
                 tool_use_id: None,
-                summary: None
+                summary: None,
+                ack_only: false
+            }
+        ]
+    );
+    // A SUCCESSFUL Task tool_result is the (possibly background) launch ack →
+    // ack_only so a still-running background subagent is not prematurely ✓.
+    assert_eq!(
+        status_events_from_tool_result(Some("Task"), false),
+        vec![
+            StatusEvent::ToolEnd { success: true },
+            StatusEvent::SubagentEnd {
+                success: true,
+                tool_use_id: None,
+                summary: None,
+                ack_only: true
             }
         ]
     );


### PR DESCRIPTION
Fixes #3198.

## Root cause

The relay status panel renders a subagent line's ✓ (completed) marker purely from `SubagentSlot.finished` (`status_panel.rs:563`), set in the `SubagentEnd` handler (`status_panel.rs:201`). `SubagentEnd` is produced from the Task tool's **tool_result** (`status_events.rs` `status_events_from_tool_result_with_id`).

For a `run_in_background` subagent the Task tool_result is only the **immediate launch ack** — the subagent keeps running and outlives the launching turn (already documented in `formatting.rs:3090`). The panel emitted `SubagentEnd { success: true }` on that ack regardless, so a still-running background subagent showed ✓ as soon as the launching turn finalized ("✅ 응답 완료").

The wrong signal driving ✓: the Task **tool_result launch ack**, not the subagent's actual lifecycle.

## Fix

- Record `run_in_background` on the slot at `SubagentStart` (parsed from Task input).
- Add an `ack_only` flag to `StatusEvent::SubagentEnd`: `true` for the immediate tool_result ack; `false` for summary-bearing ends and terminal task_notifications (genuine completions).
- In the panel's `SubagentEnd` handler, do NOT finalize a **background** slot on an **ack-only** end — it stays running until a genuine completion arrives. Foreground subagents finalize on the tool_result ack exactly as before.

✓ now reflects actual per-subagent completion. Touches only the status-panel modules (`status_panel.rs` / `status_events.rs` / `agent_protocol.rs`); **none of the frozen #3016 hotfiles**.

## Verification

- `cargo build` clean.
- `cargo test --lib placeholder_live_events::` → 82 passed (incl. 2 new tests):
  - background subagent stays running on launch ack; ✓ only after terminal task_notification
  - foreground subagent still ✓ on its tool_result
- `cargo fmt` applied; freeze gate (`check_agent_maintenance_docs.py --line-count-gate`) passes; inventory regen produced no diff (touched files are not on the giant-file registry).
- Full `cargo test --lib` showed 13 failures isolated to `turn_orchestrator::persistence_tests`, which **pass in isolation** — pre-existing parallel-run flakiness, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)