### PR TITLE
feat(#3016): S3 — watcher fresh-idle finalize via structural completion signal (A2/phase-5 enabler)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -130,7 +130,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (9488 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (9524 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -346,6 +346,19 @@
     end-to-end `fresh_idle_empty_terminated_completion_finalizes_via_completion_signal_flag_false`
     (drives the REAL completion signal over a real JSONL transcript + the REAL
     finalizer actor, NOT a re-implementation).
+    +36 from #3016 S3 gate-fix iteration (3 adversarial-gate concerns): (1) the
+    `Done` decision now reads the STRICTER turn-END-only terminator
+    (`jsonl_turn_end_terminator_idle`, accepts ONLY Codex `turn.completed` /
+    Claude `result`+`system{turn_duration|stop_hook_summary}`) so a completed
+    Codex `agent_message` / Claude mid-turn message cannot over-finalize a LIVE
+    turn; (2) the Done-arm destructive `clear_inflight_state` is now gated by
+    `committed_completion_is_stale_for_newer_turn` with BOTH the pinned snapshot
+    AND a LATE on-disk re-read (closing the TOCTOU where a follow-up turn saved
+    inflight during the cleanup awaits), mirroring the canonical clear at
+    tmux.rs; (3) the ignored `turn_start_offset` param was REMOVED from
+    `completion_signal_state` (range-independence is documented: the turn-END
+    scan is offset-independent and turn-correctness comes from the pinned-id +
+    stale-skip). New test `fresh_idle_clear_gate_skips_when_late_reread_is_newer_turn`.
   - `src/services/discord/tui_prompt_relay.rs` (4522 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +4 from #3167: the self-paced TUI loop relay

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -130,7 +130,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (9215 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (9488 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -318,6 +318,34 @@
     so a late completion can never commit the WRONG newer loop turn; the
     `user_msg_id != 0` path is byte-for-byte unchanged. New test
     `watcher_terminal_delivery_commit_marks_loop_turn_with_zero_user_msg_id`.
+    +273 from #3016 S3 (the A2 / phase-5 enabler): REWRITE the watcher fresh-idle
+    finalize decision to consult the S1 STRUCTURAL completion signal
+    (`TurnFinalizer::completion_signal_state` → `CompletionSignal{Done,PausedLive,
+    Unknown}`) instead of the in-memory `mailbox_finalize_owed` flag as the sole
+    finalize signal. A new pure helper `watcher_fresh_idle_finalize_decision`
+    (→ `FreshIdleFinalizeDecision{DeferPausedLive,AbortFollowupTookOver,SkipStale,
+    Finalize,LegacyFlagGated}`) fuses the signal with the #3197 A2 wrong-turn-race
+    defenses (pinned pre-cleanup `pinned_finalize_user_msg_id` + stale-skip via
+    `committed_completion_is_stale_for_newer_turn` + the pause/epoch guard, all
+    evaluated BEFORE the destructive clear because this branch `continue`s before
+    the canonical guard at tmux.rs runs). Done (structural terminator proven, even
+    when the response is EMPTY) → finalize via
+    `finish_restored_watcher_active_turn(.., normal_completion=true, ..)` with the
+    pinned current-turn id; PausedLive (no terminator — paused at selector /
+    permission prompt / subagent running / long silent tool) → DEFER, never
+    finalize; Unknown (non-JSONL runtime: LegacyTmuxWrapper/ProcessBackend/
+    ClaudeEAdapter) → KEEP the legacy `mailbox_finalize_owed` flag path VERBATIM.
+    The DEFER decision now keys on the STRUCTURAL TERMINATOR (not on response
+    emptiness), which is the fix for the contradiction that killed the first A2
+    attempt (deferring `delegated && empty` made the empty-but-done completion's
+    finalize unreachable). The flag is NOT deleted (stage 5); it stays read for the
+    Unknown arm and is still `swap(false)`'d to keep its revoke lifecycle. New tests
+    `fresh_idle_paused_live_defers_via_completion_signal`,
+    `fresh_idle_done_finalizes_and_unknown_falls_through_to_legacy`,
+    `fresh_idle_done_wrong_turn_race_does_not_finalize_followup`, and the
+    end-to-end `fresh_idle_empty_terminated_completion_finalizes_via_completion_signal_flag_false`
+    (drives the REAL completion signal over a real JSONL transcript + the REAL
+    finalizer actor, NOT a re-implementation).
   - `src/services/discord/tui_prompt_relay.rs` (4522 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +4 from #3167: the self-paced TUI loop relay

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -130,7 +130,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (9524 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (9549 lines after #2558
     dead-code sweep; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
@@ -359,6 +359,28 @@
     `completion_signal_state` (range-independence is documented: the turn-END
     scan is offset-independent and turn-correctness comes from the pinned-id +
     stale-skip). New test `fresh_idle_clear_gate_skips_when_late_reread_is_newer_turn`.
+    +25 from #3016 S3 FINAL fix (residual TOCTOU on the Done-arm clear): the
+    gate-fix iteration above still split the clear across TWO locks (late re-read +
+    `committed_completion_is_stale_for_newer_turn` check under one lock, then the
+    UNCONDITIONAL `clear_inflight_state` under another) — on a multi-threaded tokio
+    runtime a follow-up turn could save a NEW inflight between the re-read and the
+    clear, so the unconditional delete wiped it (check-then-act not atomic). The
+    Done arm now performs the on-disk clear with the EXISTING atomic
+    compare-and-clear helper `clear_inflight_state_if_matches_identity`
+    (inflight.rs: read+validate+unlink under a SINGLE sidecar lock), keyed on the
+    PINNED turn's `InflightTurnIdentity::from_state` (the same snapshot the decision
+    helper derived `user_msg_id` from). It deletes ONLY if the on-disk identity is
+    STILL the pinned turn; a follow-up's different identity → `UserMsgMismatch`
+    no-op → its inflight survives. The window is closed atomically (no separate
+    re-read). The finalize-skip stays a SEPARATE pinned-snapshot decision in
+    `watcher_fresh_idle_finalize_decision`; only the destructive CLEAR moved to the
+    atomic helper. The CANONICAL normal-completion clear (tmux_watcher.rs ~11251)
+    still uses the weaker non-atomic re-read+clear pattern — left UNCHANGED (out of
+    scope; the S3 arm is now strictly safer). Test
+    `fresh_idle_clear_gate_skips_when_late_reread_is_newer_turn` rewritten to drive
+    the REAL atomic helper against REAL on-disk inflight: a follow-up's inflight on
+    disk → atomic clear is a no-op (follow-up preserved); the pinned turn on disk →
+    atomic clear removes it (happy path).
   - `src/services/discord/tui_prompt_relay.rs` (4522 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +4 from #3167: the self-paced TUI loop relay

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -135,6 +135,112 @@ fn watcher_should_defer_delegated_fresh_idle(
     delegated_finalize_owed && full_response.trim().is_empty()
 }
 
+/// #3016 S3 (the A2 / phase-5 enabler): the fresh-idle finalize DECISION,
+/// factored out of the production watcher loop so the EXACT production routing is
+/// unit-testable end-to-end (the enclosing `tmux_output_watcher_with_restore` is
+/// not). It fuses two independent disambiguators:
+///
+///   1. The STRUCTURAL completion signal (`CompletionSignal`, S1) — the
+///      authority that finally distinguishes "turn done" from "paused-live",
+///      which the old flag-only path could not:
+///        * `Done`       — a structural JSONL terminator is proven on disk
+///                         (Claude `result`/`system`, Codex `turn.completed`).
+///                         Even when the committed response text is EMPTY/
+///                         suppressed, this is a genuine completed turn → finalize.
+///        * `PausedLive` — NO terminator (Busy/Inconclusive): paused at a
+///                         selector / permission prompt, a subagent still running,
+///                         or a long silent tool call. NEVER finalize → defer.
+///        * `Unknown`    — non-JSONL runtime (LegacyTmuxWrapper / ProcessBackend /
+///                         ClaudeEAdapter, or a non-JSONL provider): the transcript
+///                         probe cannot speak, so KEEP today's legacy
+///                         `mailbox_finalize_owed`-flag behaviour VERBATIM.
+///
+///   2. The A2-banked wrong-turn-race defenses (only relevant once the signal
+///      says we *would* finalize): a follow-up turn can claim the same session
+///      during the cleanup `.await`s, so before the destructive clear we
+///        * `AbortFollowupTookOver` — `paused_now || epoch_changed` (the SAME
+///          predicate as the canonical pause/epoch guard at tmux.rs:7806, but
+///          evaluated HERE because this branch `continue`s before that guard
+///          would run); and
+///        * `SkipStale` — the PINNED pre-cleanup snapshot is a NEWER turn that
+///          began AT/AFTER this committed range (`committed_completion_is_stale_for_newer_turn`,
+///          or `pinned_finalize_user_msg_id == 0`). Finalizing would release the
+///          follow-up; skip and preserve inflight.
+///
+/// The two combine so that the defer decision keys on the STRUCTURAL TERMINATOR,
+/// not on response emptiness — which is the fix for the contradiction that killed
+/// the first A2 attempt (the old defer guard deferred `delegated && empty`, the
+/// SAME condition as the empty completion it wanted to finalize, so finalize was
+/// unreachable). Here an empty-but-TERMINATED completion routes to `Finalize`.
+///
+/// Degenerate-empty-offset safety: a genuine current-turn fresh idle always has
+/// `turn_start_offset < current_offset` (`FreshIdle` requires `output_ever_grew`,
+/// and the watcher resumes at `turn_start_offset`), so the pinned id is its real,
+/// non-zero id and `SkipStale` cannot misfire on the current turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FreshIdleFinalizeDecision {
+    /// `PausedLive` (no terminator) — defer; preserve inflight, keep waiting.
+    DeferPausedLive,
+    /// A follow-up turn paused the watcher / bumped the epoch during the cleanup
+    /// awaits — abort before the destructive clear; preserve inflight.
+    AbortFollowupTookOver,
+    /// The pinned pre-cleanup snapshot is a NEWER turn (started AT/AFTER this
+    /// committed range) — skip the finalize so the follow-up is not released.
+    SkipStale { pinned_user_msg_id: u64 },
+    /// `Done` (terminator proven) AND no follow-up took over — finalize via the
+    /// single-authority path with the PINNED current-turn id.
+    Finalize { user_msg_id: u64 },
+    /// `Unknown` runtime — fall through to the VERBATIM legacy flag-gated path
+    /// (`should_finish_mailbox = finish_mailbox_on_completion || owed`).
+    LegacyFlagGated,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn watcher_fresh_idle_finalize_decision(
+    completion_signal: crate::services::discord::turn_finalizer::CompletionSignal,
+    paused_now: bool,
+    epoch_changed: bool,
+    pinned_pre_cleanup_inflight: Option<&InflightTurnState>,
+    tmux_session_name: &str,
+    current_offset: u64,
+) -> FreshIdleFinalizeDecision {
+    use crate::services::discord::turn_finalizer::CompletionSignal;
+    match completion_signal {
+        // Non-JSONL runtime: the structural probe cannot speak. Hand back to the
+        // legacy flag-gated path so legacy runtimes are byte-for-byte unchanged.
+        CompletionSignal::Unknown => FreshIdleFinalizeDecision::LegacyFlagGated,
+        // No structural terminator: paused at a selector / permission prompt /
+        // subagent running / long silent tool call. NEVER finalize.
+        CompletionSignal::PausedLive => FreshIdleFinalizeDecision::DeferPausedLive,
+        // Structural terminator proven → genuine completion (even if empty). Now
+        // apply the A2 wrong-turn-race defenses before releasing the turn.
+        CompletionSignal::Done => {
+            if paused_now || epoch_changed {
+                return FreshIdleFinalizeDecision::AbortFollowupTookOver;
+            }
+            let stale = committed_completion_is_stale_for_newer_turn(
+                pinned_pre_cleanup_inflight,
+                None,
+                tmux_session_name,
+                current_offset,
+            );
+            let pinned = pinned_finalize_user_msg_id(
+                pinned_pre_cleanup_inflight,
+                tmux_session_name,
+                current_offset,
+            );
+            if stale || pinned == 0 {
+                return FreshIdleFinalizeDecision::SkipStale {
+                    pinned_user_msg_id: pinned,
+                };
+            }
+            FreshIdleFinalizeDecision::Finalize {
+                user_msg_id: pinned,
+            }
+        }
+    }
+}
+
 fn watcher_should_clear_stale_terminal_message_ids(
     inflight_present: bool,
     has_assistant_response: bool,
@@ -7479,13 +7585,63 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             if fresh_ready_for_input_idle {
                 let delegated_finalize_owed_pending =
                     mailbox_finalize_owed.load(std::sync::atomic::Ordering::Acquire);
-                if watcher_should_defer_delegated_fresh_idle(
-                    delegated_finalize_owed_pending,
-                    &full_response,
-                ) {
+                // #3016 S3: the STRUCTURAL completion signal — the authority that
+                // finally distinguishes "turn done" from "paused-live" (which the
+                // old flag-only path could not). Resolve the runtime kind exactly
+                // as `watcher_session_ready_for_input` does (runtime binding →
+                // tmux marker), then read the relay-offset-independent strict
+                // terminator probe via the S1 read-only API. `output_path` is the
+                // provider's on-disk JSONL transcript for this session.
+                let watcher_runtime_kind =
+                    crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(
+                        &tmux_session_name,
+                    )
+                    .map(|binding| binding.runtime_kind)
+                    .or_else(|| {
+                        crate::services::tmux_common::resolve_tmux_runtime_kind_marker(
+                            &tmux_session_name,
+                        )
+                    });
+                let fresh_idle_completion_signal = shared.turn_finalizer.completion_signal_state(
+                    &watcher_provider,
+                    watcher_runtime_kind,
+                    std::path::Path::new(&output_path),
+                    Some(current_offset),
+                );
+                // #3016 S3 (A2 wrong-turn race fix): pin the finalize id from a
+                // snapshot taken NOW — BEFORE the cleanup `.await`s below — and
+                // gate it on the SAME output-range relationship the canonical
+                // normal-completion site uses. A LATE re-read after the cleanup
+                // awaits could observe a follow-up turn that became current on the
+                // SAME session and rewrote inflight, finalizing the WRONG turn.
+                let pinned_pre_cleanup_inflight =
+                    crate::services::discord::inflight::load_inflight_state(
+                        &watcher_provider,
+                        channel_id.get(),
+                    );
+                // #3016 S3: the DEFER decision now keys on the STRUCTURAL
+                // TERMINATOR, not on response emptiness — defeating the
+                // contradiction that killed the first A2 attempt (deferring
+                // `delegated && empty` made the empty-completion finalize
+                // unreachable). PausedLive (no terminator) → defer regardless of
+                // the flag or emptiness. Unknown (non-JSONL runtime) → preserve
+                // the legacy `mailbox_finalize_owed`-flag defer VERBATIM. Done
+                // (terminator proven) → never defer here; fall through to the
+                // cleanup + finalize below (even when the response is empty).
+                let defer_fresh_idle = match fresh_idle_completion_signal {
+                    crate::services::discord::turn_finalizer::CompletionSignal::PausedLive => true,
+                    crate::services::discord::turn_finalizer::CompletionSignal::Done => false,
+                    crate::services::discord::turn_finalizer::CompletionSignal::Unknown => {
+                        watcher_should_defer_delegated_fresh_idle(
+                            delegated_finalize_owed_pending,
+                            &full_response,
+                        )
+                    }
+                };
+                if defer_fresh_idle {
                     let ts = chrono::Local::now().format("%H:%M:%S");
                     tracing::info!(
-                        "  [{ts}] 👁 watcher observed fresh ready-for-input idle for {tmux_session_name} at offset {current_offset}, but bridge-delegated turn has no terminal assistant text yet; preserving inflight and waiting for terminal commit"
+                        "  [{ts}] 👁 watcher observed fresh ready-for-input idle for {tmux_session_name} at offset {current_offset}, but no structural completion terminator yet (signal={fresh_idle_completion_signal:?}); preserving inflight and waiting for terminal commit"
                     );
                     all_data.clear();
                     all_data_start_offset = current_offset;
@@ -7566,55 +7722,172 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 if !panel_cleanup_committed {
                     continue;
                 }
+                // We still `swap(false)` the legacy flag unconditionally to keep
+                // its revoke lifecycle intact (the flag is NOT deleted in S3 —
+                // that's stage 5). It only stays load-bearing for the `Unknown`
+                // (non-JSONL runtime) arm below; the `Done` arm finalizes on the
+                // structural signal, flag-independent.
                 let owed = mailbox_finalize_owed.swap(false, std::sync::atomic::Ordering::AcqRel);
-                let should_finish_mailbox = finish_mailbox_on_completion || owed;
-                if should_finish_mailbox {
-                    // #3016: capture the turn's real id BEFORE clearing inflight,
-                    // so the finalizer ledger match is exact (id-0 would risk a
-                    // stale terminal finalizing a queued follow-up).
-                    let fresh_idle_user_msg_id =
-                        crate::services::discord::inflight::load_inflight_state(
+                // #3016 S3: the finalize DECISION, computed by the same pure helper
+                // the unit tests drive. The completion signal already gated the
+                // defer above (PausedLive deferred, Unknown deferred via the legacy
+                // flag), so here the signal is Done or Unknown.
+                let fresh_idle_decision = watcher_fresh_idle_finalize_decision(
+                    fresh_idle_completion_signal,
+                    paused.load(Ordering::Relaxed),
+                    pause_epoch.load(Ordering::Relaxed) != epoch_snapshot,
+                    pinned_pre_cleanup_inflight.as_ref(),
+                    &tmux_session_name,
+                    current_offset,
+                );
+                match fresh_idle_decision {
+                    FreshIdleFinalizeDecision::DeferPausedLive => {
+                        // Unreachable: PausedLive was deferred at the defer gate
+                        // above. Treat defensively as a defer (preserve inflight).
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        tracing::warn!(
+                            "  [{ts}] 👁 watcher fresh ready-for-input idle for {tmux_session_name}: PausedLive reached the finalize gate unexpectedly; preserving inflight"
+                        );
+                        all_data.clear();
+                        all_data_start_offset = current_offset;
+                        all_data_fully_mirrored_to_session_relay = true;
+                        all_data_session_bound_relay_ack = None;
+                        continue;
+                    }
+                    FreshIdleFinalizeDecision::AbortFollowupTookOver => {
+                        // #3016 S3 (A2 wrong-turn race fix): a Discord turn claimed
+                        // this session during the cleanup `.await`s (paused / epoch
+                        // bumped at handoff). The canonical pause/epoch guard sits
+                        // AFTER this branch's `continue`, so we mirror it HERE,
+                        // before the destructive clear, to avoid releasing the
+                        // follow-up turn.
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        tracing::info!(
+                            "  [{ts}] 👁 watcher fresh ready-for-input idle for {tmux_session_name} aborted before finalize: follow-up turn took over (paused/epoch changed); preserving inflight"
+                        );
+                        all_data.clear();
+                        all_data_start_offset = current_offset;
+                        all_data_fully_mirrored_to_session_relay = true;
+                        all_data_session_bound_relay_ack = None;
+                        continue;
+                    }
+                    FreshIdleFinalizeDecision::SkipStale { pinned_user_msg_id } => {
+                        // #3016 S3 (A2 wrong-turn race fix): the pinned pre-cleanup
+                        // snapshot is a NEWER turn that began AT/AFTER this
+                        // committed range; finalizing would release the follow-up.
+                        // Skip and preserve inflight for the current/newer turn.
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        tracing::info!(
+                            "  [{ts}] 👁 watcher fresh ready-for-input idle for {tmux_session_name} skipped finalize: pinned id {pinned_user_msg_id} is stale for a newer turn at offset {current_offset}; preserving inflight"
+                        );
+                        all_data.clear();
+                        all_data_start_offset = current_offset;
+                        all_data_fully_mirrored_to_session_relay = true;
+                        all_data_session_bound_relay_ack = None;
+                        continue;
+                    }
+                    FreshIdleFinalizeDecision::Finalize { user_msg_id } => {
+                        // #3016 S3 (the A2 / phase-5 enabler): a structural JSONL
+                        // terminator is PROVEN on disk for this turn (Done) AND no
+                        // follow-up took over — so finalize via the single-authority
+                        // path with `normal_completion = true`, FLAG-INDEPENDENT.
+                        // This is the whole point of S3: an EMPTY-but-terminated
+                        // completion now finalizes (the old flag-gated path could
+                        // not distinguish it from a paused-live turn). The finalizer
+                        // is idempotent — a turn already finalized by the bridge
+                        // resolves to `AlreadyFinalized` — so this cannot
+                        // over-finalize. `user_msg_id` is the id PINNED from the
+                        // pre-cleanup snapshot at this `current_offset` (never a
+                        // late re-read), so the ledger match is the CURRENT turn's
+                        // real, non-zero id.
+                        crate::services::discord::inflight::clear_inflight_state(
                             &watcher_provider,
                             channel_id.get(),
+                        );
+                        crate::services::observability::emit_inflight_lifecycle_event(
+                            watcher_provider.as_str(),
+                            channel_id.get(),
+                            None,
+                            None,
+                            None,
+                            "cleared_by_watcher_fresh_idle",
+                            serde_json::json!({
+                                "owed_finalize": owed,
+                                "finish_mailbox_on_completion": finish_mailbox_on_completion,
+                                "completion_signal": "Done",
+                                "tmux_session": tmux_session_name.as_str(),
+                                "offset": current_offset,
+                            }),
+                        );
+                        finish_restored_watcher_active_turn(
+                            &shared,
+                            &watcher_provider,
+                            channel_id,
+                            user_msg_id,
+                            finish_mailbox_on_completion,
+                            owed,
+                            // #3016 S3: Done = confirmed structural completion, so
+                            // drive the finalizer on the normal-completion authority
+                            // independent of the legacy flags (the decoupling phase-5
+                            // depends on).
+                            true,
+                            true,
+                            "watcher fresh ready-for-input idle (structural completion terminator)",
                         )
-                        .map(|s| s.user_msg_id)
-                        .unwrap_or(0);
-                    crate::services::discord::inflight::clear_inflight_state(
-                        &watcher_provider,
-                        channel_id.get(),
-                    );
-                    crate::services::observability::emit_inflight_lifecycle_event(
-                        watcher_provider.as_str(),
-                        channel_id.get(),
-                        None,
-                        None,
-                        None,
-                        "cleared_by_watcher_fresh_idle",
-                        serde_json::json!({
-                            "owed_finalize": owed,
-                            "finish_mailbox_on_completion": finish_mailbox_on_completion,
-                            "tmux_session": tmux_session_name.as_str(),
-                            "offset": current_offset,
-                        }),
-                    );
-                    finish_restored_watcher_active_turn(
-                        &shared,
-                        &watcher_provider,
-                        channel_id,
-                        fresh_idle_user_msg_id,
-                        finish_mailbox_on_completion,
-                        owed,
-                        // #3016 option A: this fresh-idle arm is already gated by
-                        // the outer `if should_finish_mailbox` (= flag-driven), so
-                        // it keeps the legacy flag semantics — `normal_completion`
-                        // stays `false` here. (No new assistant text was committed
-                        // in this pass, so it is not the canonical-completion
-                        // point that the decoupling targets.)
-                        false,
-                        true,
-                        "watcher fresh ready-for-input idle with queued backlog",
-                    )
-                    .await;
+                        .await;
+                    }
+                    FreshIdleFinalizeDecision::LegacyFlagGated => {
+                        // #3016 S3: Unknown (non-JSONL runtime) — KEEP today's
+                        // `mailbox_finalize_owed`-based behaviour VERBATIM so legacy
+                        // runtimes (LegacyTmuxWrapper / ProcessBackend /
+                        // ClaudeEAdapter) are byte-for-byte unchanged.
+                        let should_finish_mailbox = finish_mailbox_on_completion || owed;
+                        if should_finish_mailbox {
+                            // #3016: capture the turn's real id BEFORE clearing
+                            // inflight, so the finalizer ledger match is exact (id-0
+                            // would risk a stale terminal finalizing a follow-up).
+                            let fresh_idle_user_msg_id =
+                                crate::services::discord::inflight::load_inflight_state(
+                                    &watcher_provider,
+                                    channel_id.get(),
+                                )
+                                .map(|s| s.user_msg_id)
+                                .unwrap_or(0);
+                            crate::services::discord::inflight::clear_inflight_state(
+                                &watcher_provider,
+                                channel_id.get(),
+                            );
+                            crate::services::observability::emit_inflight_lifecycle_event(
+                                watcher_provider.as_str(),
+                                channel_id.get(),
+                                None,
+                                None,
+                                None,
+                                "cleared_by_watcher_fresh_idle",
+                                serde_json::json!({
+                                    "owed_finalize": owed,
+                                    "finish_mailbox_on_completion": finish_mailbox_on_completion,
+                                    "completion_signal": "Unknown",
+                                    "tmux_session": tmux_session_name.as_str(),
+                                    "offset": current_offset,
+                                }),
+                            );
+                            finish_restored_watcher_active_turn(
+                                &shared,
+                                &watcher_provider,
+                                channel_id,
+                                fresh_idle_user_msg_id,
+                                finish_mailbox_on_completion,
+                                owed,
+                                // Legacy arm: keep `normal_completion = false`
+                                // (flag-gated), exactly as before S3.
+                                false,
+                                true,
+                                "watcher fresh ready-for-input idle with queued backlog",
+                            )
+                            .await;
+                        }
+                    }
                 }
                 all_data.clear();
                 all_data_start_offset = current_offset;
@@ -11648,7 +11921,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
 #[cfg(test)]
 mod tests {
     use super::{
-        RelaySlotGuard, TuiCompletionGateOutcome, Utf8ChunkDecoder,
+        FreshIdleFinalizeDecision, RelaySlotGuard, TuiCompletionGateOutcome, Utf8ChunkDecoder,
         adopt_watcher_terminal_message_ids_from_inflight, build_watcher_streaming_edit_text,
         discard_restored_response_seed_before_no_inflight_terminal_relay,
         discard_watcher_pending_buffer_after_suppressed_turn,
@@ -11658,10 +11931,10 @@ mod tests {
         watcher_batch_contains_assistant_event, watcher_batch_contains_relayable_response,
         watcher_direct_terminal_should_commit_session_idle,
         watcher_fallback_edit_failure_can_delete_original_placeholder,
-        watcher_inflight_absence_is_abandonment, watcher_inflight_represents_external_input,
-        watcher_jsonl_turn_state_ready_for_input, watcher_output_progressed_recently,
-        watcher_should_clear_stale_terminal_message_ids, watcher_should_defer_delegated_fresh_idle,
-        watcher_should_delete_suppressed_placeholder,
+        watcher_fresh_idle_finalize_decision, watcher_inflight_absence_is_abandonment,
+        watcher_inflight_represents_external_input, watcher_jsonl_turn_state_ready_for_input,
+        watcher_output_progressed_recently, watcher_should_clear_stale_terminal_message_ids,
+        watcher_should_defer_delegated_fresh_idle, watcher_should_delete_suppressed_placeholder,
         watcher_should_suppress_streaming_after_bridge_delivery,
         watcher_terminal_commit_side_effects_for_test, watcher_terminal_edit_consumes_placeholder,
         watcher_terminal_token_update_status,
@@ -12501,6 +12774,352 @@ mod tests {
                 .cancel_token
                 .is_none(),
             "turn B is released by its matching finalize"
+        );
+    }
+
+    // #3016 S3 test helper: build an inflight snapshot with explicit
+    // turn_start_offset / last_offset so the fresh-idle decision's OUTPUT-RANGE
+    // gate (`pinned_finalize_user_msg_id` /
+    // `committed_completion_is_stale_for_newer_turn`) can be exercised against
+    // current vs. newer turns.
+    fn fresh_idle_inflight(
+        provider: ProviderKind,
+        channel_id: u64,
+        tmux_session_name: &str,
+        user_msg_id: u64,
+        turn_start_offset: u64,
+    ) -> InflightTurnState {
+        let mut state = InflightTurnState::new(
+            provider,
+            channel_id,
+            Some("adk-cc".to_string()),
+            42,
+            user_msg_id,
+            user_msg_id + 1,
+            "prompt".to_string(),
+            Some("session".to_string()),
+            Some(tmux_session_name.to_string()),
+            Some("/tmp/out.jsonl".to_string()),
+            None,
+            turn_start_offset,
+        );
+        // `InflightTurnState::new` sets turn_start_offset == last_offset; keep
+        // them equal (the registration invariant) so the range tests behave like
+        // production.
+        state.last_offset = turn_start_offset;
+        state.turn_start_offset = Some(turn_start_offset);
+        state
+    }
+
+    // #3016 S3 — drives the REAL fresh-idle decision helper that the production
+    // watcher branch calls (`watcher_fresh_idle_finalize_decision`), proving the
+    // completion-signal routing without re-implementing it.
+    //
+    // (b) PausedLive (no structural terminator) → DeferPausedLive. This is the
+    // paused-at-selector / permission-prompt / subagent-running / long-silent-tool
+    // case. The defer keys on the STRUCTURAL TERMINATOR, NOT on response
+    // emptiness, so it cannot be made unreachable the way the first A2 attempt
+    // was. The A2 guards (paused/epoch, stale-skip) are NOT consulted here — a
+    // paused-live turn is deferred regardless.
+    #[test]
+    fn fresh_idle_paused_live_defers_via_completion_signal() {
+        use crate::services::discord::turn_finalizer::CompletionSignal;
+        let provider = ProviderKind::Claude;
+        let session = "AgentDesk-claude-adk-cc-9873100";
+        let current_turn = fresh_idle_inflight(provider.clone(), 987_3100, session, 9001, 10);
+        // Even with a perfectly valid current-turn snapshot, no epoch change, and
+        // not paused, PausedLive defers — the signal is the disambiguator.
+        assert_eq!(
+            watcher_fresh_idle_finalize_decision(
+                CompletionSignal::PausedLive,
+                false,
+                false,
+                Some(&current_turn),
+                session,
+                50,
+            ),
+            FreshIdleFinalizeDecision::DeferPausedLive,
+            "no terminator (selector/permission/subagent/long-silent-tool) → defer"
+        );
+    }
+
+    // #3016 S3 — (a/c) Done (structural terminator proven) for a genuine
+    // current-turn empty/suppressed completion → Finalize with the turn's REAL
+    // pinned id, EVEN when the response is empty (the whole point of S3). And (f)
+    // Unknown (non-JSONL runtime) → LegacyFlagGated so legacy runtimes are
+    // unchanged.
+    #[test]
+    fn fresh_idle_done_finalizes_and_unknown_falls_through_to_legacy() {
+        use crate::services::discord::turn_finalizer::CompletionSignal;
+        let provider = ProviderKind::Claude;
+        let session = "AgentDesk-claude-adk-cc-9873101";
+        let channel_id = 987_3101u64;
+        let current_offset = 50u64;
+        // Current turn started at offset 10 < current_offset 50 → in range.
+        let current_turn = fresh_idle_inflight(provider.clone(), channel_id, session, 9001, 10);
+
+        // (a/c) Done + current turn + not paused + epoch unchanged → Finalize
+        // with the REAL id (degenerate-empty-offset safe: empty response still has
+        // turn_start_offset 10 < current_offset 50).
+        assert_eq!(
+            watcher_fresh_idle_finalize_decision(
+                CompletionSignal::Done,
+                false,
+                false,
+                Some(&current_turn),
+                session,
+                current_offset,
+            ),
+            FreshIdleFinalizeDecision::Finalize { user_msg_id: 9001 },
+            "terminator proven for the current turn → finalize once with its real id"
+        );
+
+        // (f) Unknown (non-JSONL runtime) → fall through to the legacy flag-gated
+        // path VERBATIM, regardless of the snapshot / pause / epoch.
+        assert_eq!(
+            watcher_fresh_idle_finalize_decision(
+                CompletionSignal::Unknown,
+                false,
+                false,
+                Some(&current_turn),
+                session,
+                current_offset,
+            ),
+            FreshIdleFinalizeDecision::LegacyFlagGated,
+            "non-JSONL runtime → legacy mailbox_finalize_owed behaviour, unchanged"
+        );
+        // Unknown ignores the A2 guards too (they only apply once the signal says
+        // finalize): even paused / epoch-changed routes to LegacyFlagGated.
+        assert_eq!(
+            watcher_fresh_idle_finalize_decision(
+                CompletionSignal::Unknown,
+                true,
+                true,
+                Some(&current_turn),
+                session,
+                current_offset,
+            ),
+            FreshIdleFinalizeDecision::LegacyFlagGated,
+            "Unknown is unconditionally legacy-gated"
+        );
+    }
+
+    // #3016 S3 — (d) wrong-turn race: a Done signal that would finalize must NOT
+    // release a follow-up turn that took over the session during the cleanup
+    // awaits. Two sub-paths, both reusing the #3197 A2 defenses:
+    //   * paused/epoch changed → AbortFollowupTookOver (mirrors the canonical
+    //     pause/epoch guard, evaluated before the destructive clear);
+    //   * the pinned snapshot is a NEWER turn (turn_start_offset >= current_offset)
+    //     → SkipStale (pinned id 0), so the follow-up is NOT released.
+    #[test]
+    fn fresh_idle_done_wrong_turn_race_does_not_finalize_followup() {
+        use crate::services::discord::turn_finalizer::CompletionSignal;
+        let provider = ProviderKind::Claude;
+        let session = "AgentDesk-claude-adk-cc-9873102";
+        let channel_id = 987_3102u64;
+        let current_offset = 50u64;
+        let current_turn = fresh_idle_inflight(provider.clone(), channel_id, session, 9001, 10);
+
+        // paused_now → abort regardless of the snapshot.
+        assert_eq!(
+            watcher_fresh_idle_finalize_decision(
+                CompletionSignal::Done,
+                true,
+                false,
+                Some(&current_turn),
+                session,
+                current_offset,
+            ),
+            FreshIdleFinalizeDecision::AbortFollowupTookOver,
+            "Done + paused_now → abort before the destructive clear"
+        );
+        // epoch_changed → abort.
+        assert_eq!(
+            watcher_fresh_idle_finalize_decision(
+                CompletionSignal::Done,
+                false,
+                true,
+                Some(&current_turn),
+                session,
+                current_offset,
+            ),
+            FreshIdleFinalizeDecision::AbortFollowupTookOver,
+            "Done + epoch_changed → abort before the destructive clear"
+        );
+
+        // The pinned snapshot is a NEWER follow-up turn that begins AT/AFTER the
+        // committed range (turn_start_offset 50 >= current_offset 50) → SkipStale
+        // (pinned id 0), so the newer turn is NOT released by this older idle.
+        let newer = fresh_idle_inflight(provider.clone(), channel_id, session, 9002, 50);
+        assert_eq!(
+            watcher_fresh_idle_finalize_decision(
+                CompletionSignal::Done,
+                false,
+                false,
+                Some(&newer),
+                session,
+                current_offset,
+            ),
+            FreshIdleFinalizeDecision::SkipStale {
+                pinned_user_msg_id: 0
+            },
+            "a newer follow-up (start >= current_offset) → SkipStale, follow-up NOT finalized"
+        );
+        // A strictly-after start is also skipped.
+        let after = fresh_idle_inflight(provider, channel_id, session, 9003, 60);
+        assert_eq!(
+            watcher_fresh_idle_finalize_decision(
+                CompletionSignal::Done,
+                false,
+                false,
+                Some(&after),
+                session,
+                current_offset,
+            ),
+            FreshIdleFinalizeDecision::SkipStale {
+                pinned_user_msg_id: 0
+            },
+            "a strictly-after follow-up is also skipped"
+        );
+    }
+
+    // #3016 S3 — end-to-end through the REAL completion signal AND the REAL
+    // finalizer actor: a genuine empty/suppressed delegated completion whose
+    // on-disk transcript HAS a structural terminator (Claude `result`) finalizes
+    // via the structural signal even with the legacy `mailbox_finalize_owed` flag
+    // FALSE. This drives:
+    //   1. `TurnFinalizer::completion_signal_state` over a real JSONL file → Done,
+    //   2. `watcher_fresh_idle_finalize_decision(Done, ..)` → Finalize{real id},
+    //   3. `finish_restored_watcher_active_turn(.., normal_completion=true, ..)`
+    //      through the real actor + mailbox → the turn's token is released.
+    // The prior A2 FAIL was re-implementing the decision; this routes the EXACT
+    // production helpers.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn fresh_idle_empty_terminated_completion_finalizes_via_completion_signal_flag_false() {
+        use crate::services::discord::turn_finalizer::CompletionSignal;
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _root_guard = AgentdeskRootGuard::set(tmp.path());
+
+        let shared = crate::services::discord::make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(987_3103);
+        let tmux_session_name = "AgentDesk-claude-adk-cc-9873103";
+        let user_msg_id = 8201u64;
+        let turn_start_offset = 10u64;
+        let current_offset = 50u64;
+
+        // A real on-disk JSONL transcript that ENDS with a structural terminator
+        // (Claude `result`) — i.e. the turn is genuinely done, even though it
+        // committed NO assistant text to relay (empty/suppressed completion).
+        let transcript = tmp.path().join("out.jsonl");
+        std::fs::write(
+            &transcript,
+            "{\"type\":\"user\",\"message\":{\"content\":\"hi\"}}\n\
+             {\"type\":\"result\",\"result\":\"done\",\"session_id\":\"s\"}\n",
+        )
+        .expect("write transcript");
+
+        // 1. The REAL structural signal over the REAL file → Done.
+        let signal = shared.turn_finalizer.completion_signal_state(
+            &provider,
+            Some(RuntimeHandoffKind::ClaudeTui),
+            transcript.as_path(),
+            Some(current_offset),
+        );
+        assert_eq!(
+            signal,
+            CompletionSignal::Done,
+            "a transcript ending in a `result` terminator is structurally Done"
+        );
+
+        // 2. The REAL decision helper for the current turn → Finalize{real id}.
+        let snapshot = fresh_idle_inflight(
+            provider.clone(),
+            channel_id.get(),
+            tmux_session_name,
+            user_msg_id,
+            turn_start_offset,
+        );
+        let finalize_id = match watcher_fresh_idle_finalize_decision(
+            signal,
+            false,
+            false,
+            Some(&snapshot),
+            tmux_session_name,
+            current_offset,
+        ) {
+            FreshIdleFinalizeDecision::Finalize { user_msg_id } => user_msg_id,
+            other => panic!("empty-but-terminated current turn must Finalize, got {other:?}"),
+        };
+        assert_eq!(
+            finalize_id, user_msg_id,
+            "pinned id is the current turn's real id"
+        );
+
+        // Live active mailbox turn with the turn's real id so we can observe the
+        // finalize releasing exactly THIS turn's token.
+        let token = std::sync::Arc::new(CancelToken::new());
+        assert!(
+            mailbox_try_start_turn(
+                &shared,
+                channel_id,
+                token,
+                UserId::new(42),
+                MessageId::new(user_msg_id),
+            )
+            .await
+        );
+
+        // 3. Production fresh-idle commit point with the legacy flag FALSE: clear
+        // inflight, then drive the finalizer on the structural authority.
+        crate::services::discord::inflight::clear_inflight_state(&provider, channel_id.get());
+        let drove = super::finish_restored_watcher_active_turn(
+            &shared,
+            &provider,
+            channel_id,
+            finalize_id,
+            false, // finish_mailbox_on_completion — fresh live watcher
+            false, // delegated_finalize_owed — flag FALSE
+            true,  // normal_completion — S3: structural-signal-driven, flag-independent
+            true,
+            "watcher fresh ready-for-input idle (structural completion terminator)",
+        )
+        .await;
+        assert!(
+            drove,
+            "Done structural completion drives the finalizer regardless of the legacy flag"
+        );
+        assert!(
+            mailbox_snapshot(&shared, channel_id)
+                .await
+                .cancel_token
+                .is_none(),
+            "empty/suppressed but structurally-terminated completion finalizes with the flag FALSE"
+        );
+
+        // Idempotency: a second submit for the same turn is a no-op.
+        super::finish_restored_watcher_active_turn(
+            &shared,
+            &provider,
+            channel_id,
+            finalize_id,
+            false,
+            false,
+            true,
+            true,
+            "watcher fresh ready-for-input idle (structural completion terminator)",
+        )
+        .await;
+        assert!(
+            mailbox_snapshot(&shared, channel_id)
+                .await
+                .cancel_token
+                .is_none(),
+            "second finalize is a no-op (AlreadyFinalized), no double-finalize"
         );
     }
 

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -7800,59 +7800,84 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         // late re-read), so the ledger match is the CURRENT turn's
                         // real, non-zero id.
                         //
-                        // #3016 S3 (Concern 2): the destructive on-disk clear has
-                        // a TOCTOU the decision helper's pinned-snapshot stale gate
-                        // does NOT close: the helper checked staleness against the
-                        // PRE-cleanup snapshot, but `clear_inflight_state` deletes
-                        // whatever is on disk NOW — and a follow-up turn may have
-                        // saved its inflight during the cleanup `.await`s between
-                        // the snapshot and here. Mirror EXACTLY the canonical
-                        // normal-completion clear (tmux.rs ~11251): re-read the
-                        // on-disk inflight NOW and gate the clear with
-                        // `committed_completion_is_stale_for_newer_turn`, passing
-                        // BOTH the pinned snapshot AND the late re-read (the same
-                        // two-snapshot shape the canonical site uses). When the
-                        // late re-read is a NEWER turn (started AT/AFTER this
-                        // committed range) the clear is SKIPPED so the follow-up's
-                        // inflight survives. The finalize below still runs on the
-                        // PINNED id — identity-matched and idempotent — so the
-                        // current turn is finalized without wiping the follow-up.
-                        let late_reread_inflight =
-                            crate::services::discord::inflight::load_inflight_state(
-                                &watcher_provider,
-                                channel_id.get(),
-                            );
-                        let clear_is_stale_for_newer_turn =
-                            committed_completion_is_stale_for_newer_turn(
-                                pinned_pre_cleanup_inflight.as_ref(),
-                                late_reread_inflight.as_ref(),
-                                &tmux_session_name,
-                                current_offset,
-                            );
-                        if !clear_is_stale_for_newer_turn {
-                            crate::services::discord::inflight::clear_inflight_state(
-                                &watcher_provider,
-                                channel_id.get(),
-                            );
-                            crate::services::observability::emit_inflight_lifecycle_event(
-                                watcher_provider.as_str(),
-                                channel_id.get(),
-                                None,
-                                None,
-                                None,
-                                "cleared_by_watcher_fresh_idle",
-                                serde_json::json!({
-                                    "owed_finalize": owed,
-                                    "finish_mailbox_on_completion": finish_mailbox_on_completion,
-                                    "completion_signal": "Done",
-                                    "tmux_session": tmux_session_name.as_str(),
-                                    "offset": current_offset,
-                                }),
-                            );
+                        // #3016 S3 (Concern 2 — residual TOCTOU): the destructive
+                        // on-disk clear must not wipe a FOLLOW-UP turn's inflight.
+                        // The earlier fix re-read on-disk inflight, ran
+                        // `committed_completion_is_stale_for_newer_turn`, and then
+                        // called the UNCONDITIONAL `clear_inflight_state` under a
+                        // SEPARATE lock — a check-then-act split across two locks.
+                        // On a multi-threaded tokio runtime a follow-up turn could
+                        // save a new inflight on another worker thread AFTER the
+                        // re-read but BEFORE the clear, so the unconditional delete
+                        // wiped the follow-up's inflight (the window was not
+                        // atomic). Replace that sequence with the EXISTING atomic
+                        // compare-and-clear helper
+                        // `clear_inflight_state_if_matches_identity` (inflight.rs
+                        // ~1666 / ~1822): it reads + validates + unlinks under a
+                        // SINGLE sidecar lock and deletes ONLY if the on-disk
+                        // identity (`user_msg_id` + `started_at` +
+                        // `tmux_session_name`) still equals the PINNED turn's. A
+                        // follow-up turn carries a different identity, so the helper
+                        // is a guaranteed no-op for it (`UserMsgMismatch`) — the
+                        // window is closed atomically, no re-read/recheck needed.
+                        //
+                        // The pinned identity comes from `pinned_pre_cleanup_inflight`
+                        // — the same snapshot the decision helper used to derive
+                        // `user_msg_id` above (when `Finalize` is reached, that id is
+                        // exactly `pinned_pre_cleanup_inflight.user_msg_id`, because
+                        // `pinned_finalize_user_msg_id` selected it). The
+                        // finalize-skip (a NEWER turn in the pinned snapshot) is a
+                        // SEPARATE decision already handled in
+                        // `watcher_fresh_idle_finalize_decision`; here we only swap
+                        // the destructive CLEAR — the one carrying the TOCTOU — to
+                        // the atomic identity-matched helper. Finalize below still
+                        // runs on the PINNED id (idempotent) regardless of the clear
+                        // outcome.
+                        let pinned_clear_identity = pinned_pre_cleanup_inflight.as_ref().map(
+                            crate::services::discord::inflight::InflightTurnIdentity::from_state,
+                        );
+                        if let Some(pinned_clear_identity) = pinned_clear_identity.as_ref() {
+                            let clear_outcome =
+                                crate::services::discord::inflight::clear_inflight_state_if_matches_identity(
+                                    &watcher_provider,
+                                    channel_id.get(),
+                                    pinned_clear_identity,
+                                );
+                            match clear_outcome {
+                                crate::services::discord::inflight::GuardedClearOutcome::Cleared => {
+                                    crate::services::observability::emit_inflight_lifecycle_event(
+                                        watcher_provider.as_str(),
+                                        channel_id.get(),
+                                        None,
+                                        None,
+                                        None,
+                                        "cleared_by_watcher_fresh_idle",
+                                        serde_json::json!({
+                                            "owed_finalize": owed,
+                                            "finish_mailbox_on_completion": finish_mailbox_on_completion,
+                                            "completion_signal": "Done",
+                                            "tmux_session": tmux_session_name.as_str(),
+                                            "offset": current_offset,
+                                        }),
+                                    );
+                                }
+                                other => {
+                                    let ts = chrono::Local::now().format("%H:%M:%S");
+                                    tracing::info!(
+                                        "  [{ts}] 👁 watcher fresh ready-for-input idle for {tmux_session_name}: atomic identity-matched clear was a no-op (outcome={other:?}) at offset {current_offset} — on-disk inflight is no longer the pinned turn (follow-up preserved); finalizing the pinned current turn only"
+                                    );
+                                }
+                            }
                         } else {
+                            // No pinned snapshot identity available — there is
+                            // nothing safe to clear by identity. Skip the clear and
+                            // finalize on the pinned id only. (Unreachable on the
+                            // `Finalize` arm, since `pinned_finalize_user_msg_id`
+                            // requires a non-zero pinned snapshot to return a
+                            // finalizable id; kept defensive.)
                             let ts = chrono::Local::now().format("%H:%M:%S");
-                            tracing::info!(
-                                "  [{ts}] 👁 watcher fresh ready-for-input idle for {tmux_session_name}: a follow-up turn saved inflight during cleanup (late re-read stale for offset {current_offset}); skipping the on-disk clear and finalizing the pinned current turn only"
+                            tracing::warn!(
+                                "  [{ts}] 👁 watcher fresh ready-for-input idle for {tmux_session_name}: no pinned snapshot identity for the atomic clear at offset {current_offset}; skipping the on-disk clear and finalizing the pinned current turn only"
                             );
                         }
                         finish_restored_watcher_active_turn(
@@ -13019,17 +13044,34 @@ mod tests {
         );
     }
 
-    // #3016 S3 (Concern 2): the destructive on-disk `clear_inflight_state` in the
-    // Done/Finalize arm is gated EXACTLY like the canonical normal-completion
-    // clear (tmux.rs ~11251): `committed_completion_is_stale_for_newer_turn` is
-    // passed BOTH the pre-cleanup PINNED snapshot AND a LATE on-disk re-read.
-    // This proves the TOCTOU is closed: even when the pinned snapshot is the
-    // CURRENT turn (so the decision helper returned Finalize, not SkipStale), a
-    // follow-up turn that saved inflight DURING the cleanup awaits is caught by
-    // the late-re-read arm → the clear is skipped and the follow-up's inflight
-    // survives.
+    // #3016 S3 (Concern 2 — residual TOCTOU CLOSED): the Done/Finalize arm now
+    // performs the on-disk clear with the ATOMIC compare-and-clear helper
+    // `clear_inflight_state_if_matches_identity` (read+validate+unlink under a
+    // SINGLE sidecar lock), keyed on the PINNED turn's identity. This test
+    // exercises the REAL atomic helper against REAL on-disk inflight (no separate
+    // re-read + recheck window) and proves the two distinct failure modes:
+    //
+    //   1. Follow-up preserved: if a follow-up turn saved its inflight DURING the
+    //      cleanup awaits (a DIFFERENT identity than the pinned turn is on disk at
+    //      clear time), the atomic clear is a guaranteed no-op (`UserMsgMismatch`)
+    //      — the follow-up's inflight survives byte-for-byte. There is no window
+    //      between the identity check and the unlink because they share one lock.
+    //   2. Current turn cleared: if the on-disk inflight is STILL the pinned turn
+    //      (no follow-up), the atomic clear removes it (`Cleared`), exactly like
+    //      the old unconditional clear did for the happy path.
+    //
+    // The finalize decision is a SEPARATE concern, still derived from the pinned
+    // snapshot by `watcher_fresh_idle_finalize_decision` (asserted Finalize here);
+    // only the destructive CLEAR — the one that carried the TOCTOU — was swapped to
+    // the atomic identity-matched helper.
     #[test]
     fn fresh_idle_clear_gate_skips_when_late_reread_is_newer_turn() {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _root_guard = AgentdeskRootGuard::set(tmp.path());
+
         let provider = ProviderKind::Claude;
         let session = "AgentDesk-claude-adk-cc-9873200";
         let channel_id = 987_3200u64;
@@ -13037,13 +13079,9 @@ mod tests {
 
         // Pinned pre-cleanup snapshot: the CURRENT turn (start 10 < 50). On this
         // snapshot alone the decision helper returns Finalize (NOT stale), so the
-        // Done arm is entered and the clear is reached.
+        // Done arm is entered and the (now atomic) clear is reached. The pinned id
+        // 9001 is exactly the id the finalize runs on.
         let pinned_current = fresh_idle_inflight(provider.clone(), channel_id, session, 9001, 10);
-        // Late on-disk re-read AFTER the cleanup awaits: a follow-up turn that
-        // started AT/AFTER the committed range (start 50 >= 50) saved its inflight.
-        let late_followup = fresh_idle_inflight(provider.clone(), channel_id, session, 9002, 50);
-
-        // The decision helper (pinned-only) does NOT see the follow-up → Finalize.
         assert_eq!(
             watcher_fresh_idle_finalize_decision(
                 crate::services::discord::turn_finalizer::CompletionSignal::Done,
@@ -13056,29 +13094,62 @@ mod tests {
             FreshIdleFinalizeDecision::Finalize { user_msg_id: 9001 },
             "pinned snapshot alone is the current turn → Finalize (clear arm entered)"
         );
+        // The identity the Done arm builds from the pinned snapshot for the atomic
+        // clear (same `InflightTurnIdentity::from_state` the production code uses).
+        let pinned_identity =
+            crate::services::discord::inflight::InflightTurnIdentity::from_state(&pinned_current);
 
-        // The clear gate (the EXACT call the Done arm makes before clearing): the
-        // two-snapshot check catches the follow-up via the late-re-read arm.
-        assert!(
-            super::committed_completion_is_stale_for_newer_turn(
-                Some(&pinned_current),
-                Some(&late_followup),
-                session,
-                current_offset,
-            ),
-            "a follow-up saved during cleanup is caught by the late-re-read arm → clear SKIPPED"
+        // ── (1) Follow-up preserved ──────────────────────────────────────────
+        // Simulate a follow-up turn that saved a DIFFERENT inflight (id 9002,
+        // start 50 >= current_offset) on another worker thread DURING the cleanup
+        // awaits — i.e. it is what is on disk at clear time, NOT the pinned turn.
+        let late_followup = fresh_idle_inflight(provider.clone(), channel_id, session, 9002, 50);
+        crate::services::discord::inflight::save_inflight_state(&late_followup)
+            .expect("save follow-up inflight");
+
+        // The atomic clear keyed on the PINNED identity is a no-op: the on-disk
+        // identity (id 9002) does NOT match the pinned id 9001 → UserMsgMismatch,
+        // and crucially the read-and-delete happen under ONE lock so there is no
+        // re-read window a follow-up could slip through.
+        let outcome = crate::services::discord::inflight::clear_inflight_state_if_matches_identity(
+            &provider,
+            channel_id,
+            &pinned_identity,
+        );
+        assert_eq!(
+            outcome,
+            crate::services::discord::inflight::GuardedClearOutcome::UserMsgMismatch,
+            "atomic clear keyed on the pinned turn is a no-op when a follow-up's inflight is on disk"
+        );
+        // The follow-up's inflight survives intact (NOT wiped).
+        let survived =
+            crate::services::discord::inflight::load_inflight_state(&provider, channel_id)
+                .expect("follow-up inflight must still be on disk");
+        assert_eq!(
+            survived.user_msg_id, 9002,
+            "the follow-up turn's inflight is preserved — the TOCTOU clear cannot wipe it"
         );
 
-        // Sanity: when the late re-read is ALSO the current turn (no follow-up),
-        // the gate is FALSE → the clear runs, exactly as before.
+        // ── (2) Current turn cleared ─────────────────────────────────────────
+        // No follow-up: the pinned turn itself is on disk at clear time. The atomic
+        // clear removes it, exactly like the old happy path.
+        crate::services::discord::inflight::clear_inflight_state(&provider, channel_id);
+        crate::services::discord::inflight::save_inflight_state(&pinned_current)
+            .expect("save pinned inflight");
+        let outcome = crate::services::discord::inflight::clear_inflight_state_if_matches_identity(
+            &provider,
+            channel_id,
+            &pinned_identity,
+        );
+        assert_eq!(
+            outcome,
+            crate::services::discord::inflight::GuardedClearOutcome::Cleared,
+            "atomic clear removes the inflight when it is STILL the pinned turn (happy path)"
+        );
         assert!(
-            !super::committed_completion_is_stale_for_newer_turn(
-                Some(&pinned_current),
-                Some(&pinned_current),
-                session,
-                current_offset,
-            ),
-            "no follow-up → clear runs"
+            crate::services::discord::inflight::load_inflight_state(&provider, channel_id)
+                .is_none(),
+            "pinned turn's inflight is gone after the atomic clear"
         );
     }
 

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -7606,7 +7606,6 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                     &watcher_provider,
                     watcher_runtime_kind,
                     std::path::Path::new(&output_path),
-                    Some(current_offset),
                 );
                 // #3016 S3 (A2 wrong-turn race fix): pin the finalize id from a
                 // snapshot taken NOW — BEFORE the cleanup `.await`s below — and
@@ -7800,25 +7799,62 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         // pre-cleanup snapshot at this `current_offset` (never a
                         // late re-read), so the ledger match is the CURRENT turn's
                         // real, non-zero id.
-                        crate::services::discord::inflight::clear_inflight_state(
-                            &watcher_provider,
-                            channel_id.get(),
-                        );
-                        crate::services::observability::emit_inflight_lifecycle_event(
-                            watcher_provider.as_str(),
-                            channel_id.get(),
-                            None,
-                            None,
-                            None,
-                            "cleared_by_watcher_fresh_idle",
-                            serde_json::json!({
-                                "owed_finalize": owed,
-                                "finish_mailbox_on_completion": finish_mailbox_on_completion,
-                                "completion_signal": "Done",
-                                "tmux_session": tmux_session_name.as_str(),
-                                "offset": current_offset,
-                            }),
-                        );
+                        //
+                        // #3016 S3 (Concern 2): the destructive on-disk clear has
+                        // a TOCTOU the decision helper's pinned-snapshot stale gate
+                        // does NOT close: the helper checked staleness against the
+                        // PRE-cleanup snapshot, but `clear_inflight_state` deletes
+                        // whatever is on disk NOW — and a follow-up turn may have
+                        // saved its inflight during the cleanup `.await`s between
+                        // the snapshot and here. Mirror EXACTLY the canonical
+                        // normal-completion clear (tmux.rs ~11251): re-read the
+                        // on-disk inflight NOW and gate the clear with
+                        // `committed_completion_is_stale_for_newer_turn`, passing
+                        // BOTH the pinned snapshot AND the late re-read (the same
+                        // two-snapshot shape the canonical site uses). When the
+                        // late re-read is a NEWER turn (started AT/AFTER this
+                        // committed range) the clear is SKIPPED so the follow-up's
+                        // inflight survives. The finalize below still runs on the
+                        // PINNED id — identity-matched and idempotent — so the
+                        // current turn is finalized without wiping the follow-up.
+                        let late_reread_inflight =
+                            crate::services::discord::inflight::load_inflight_state(
+                                &watcher_provider,
+                                channel_id.get(),
+                            );
+                        let clear_is_stale_for_newer_turn =
+                            committed_completion_is_stale_for_newer_turn(
+                                pinned_pre_cleanup_inflight.as_ref(),
+                                late_reread_inflight.as_ref(),
+                                &tmux_session_name,
+                                current_offset,
+                            );
+                        if !clear_is_stale_for_newer_turn {
+                            crate::services::discord::inflight::clear_inflight_state(
+                                &watcher_provider,
+                                channel_id.get(),
+                            );
+                            crate::services::observability::emit_inflight_lifecycle_event(
+                                watcher_provider.as_str(),
+                                channel_id.get(),
+                                None,
+                                None,
+                                None,
+                                "cleared_by_watcher_fresh_idle",
+                                serde_json::json!({
+                                    "owed_finalize": owed,
+                                    "finish_mailbox_on_completion": finish_mailbox_on_completion,
+                                    "completion_signal": "Done",
+                                    "tmux_session": tmux_session_name.as_str(),
+                                    "offset": current_offset,
+                                }),
+                            );
+                        } else {
+                            let ts = chrono::Local::now().format("%H:%M:%S");
+                            tracing::info!(
+                                "  [{ts}] 👁 watcher fresh ready-for-input idle for {tmux_session_name}: a follow-up turn saved inflight during cleanup (late re-read stale for offset {current_offset}); skipping the on-disk clear and finalizing the pinned current turn only"
+                            );
+                        }
                         finish_restored_watcher_active_turn(
                             &shared,
                             &watcher_provider,
@@ -12983,6 +13019,69 @@ mod tests {
         );
     }
 
+    // #3016 S3 (Concern 2): the destructive on-disk `clear_inflight_state` in the
+    // Done/Finalize arm is gated EXACTLY like the canonical normal-completion
+    // clear (tmux.rs ~11251): `committed_completion_is_stale_for_newer_turn` is
+    // passed BOTH the pre-cleanup PINNED snapshot AND a LATE on-disk re-read.
+    // This proves the TOCTOU is closed: even when the pinned snapshot is the
+    // CURRENT turn (so the decision helper returned Finalize, not SkipStale), a
+    // follow-up turn that saved inflight DURING the cleanup awaits is caught by
+    // the late-re-read arm → the clear is skipped and the follow-up's inflight
+    // survives.
+    #[test]
+    fn fresh_idle_clear_gate_skips_when_late_reread_is_newer_turn() {
+        let provider = ProviderKind::Claude;
+        let session = "AgentDesk-claude-adk-cc-9873200";
+        let channel_id = 987_3200u64;
+        let current_offset = 50u64;
+
+        // Pinned pre-cleanup snapshot: the CURRENT turn (start 10 < 50). On this
+        // snapshot alone the decision helper returns Finalize (NOT stale), so the
+        // Done arm is entered and the clear is reached.
+        let pinned_current = fresh_idle_inflight(provider.clone(), channel_id, session, 9001, 10);
+        // Late on-disk re-read AFTER the cleanup awaits: a follow-up turn that
+        // started AT/AFTER the committed range (start 50 >= 50) saved its inflight.
+        let late_followup = fresh_idle_inflight(provider.clone(), channel_id, session, 9002, 50);
+
+        // The decision helper (pinned-only) does NOT see the follow-up → Finalize.
+        assert_eq!(
+            watcher_fresh_idle_finalize_decision(
+                crate::services::discord::turn_finalizer::CompletionSignal::Done,
+                false,
+                false,
+                Some(&pinned_current),
+                session,
+                current_offset,
+            ),
+            FreshIdleFinalizeDecision::Finalize { user_msg_id: 9001 },
+            "pinned snapshot alone is the current turn → Finalize (clear arm entered)"
+        );
+
+        // The clear gate (the EXACT call the Done arm makes before clearing): the
+        // two-snapshot check catches the follow-up via the late-re-read arm.
+        assert!(
+            super::committed_completion_is_stale_for_newer_turn(
+                Some(&pinned_current),
+                Some(&late_followup),
+                session,
+                current_offset,
+            ),
+            "a follow-up saved during cleanup is caught by the late-re-read arm → clear SKIPPED"
+        );
+
+        // Sanity: when the late re-read is ALSO the current turn (no follow-up),
+        // the gate is FALSE → the clear runs, exactly as before.
+        assert!(
+            !super::committed_completion_is_stale_for_newer_turn(
+                Some(&pinned_current),
+                Some(&pinned_current),
+                session,
+                current_offset,
+            ),
+            "no follow-up → clear runs"
+        );
+    }
+
     // #3016 S3 — end-to-end through the REAL completion signal AND the REAL
     // finalizer actor: a genuine empty/suppressed delegated completion whose
     // on-disk transcript HAS a structural terminator (Claude `result`) finalizes
@@ -13028,7 +13127,6 @@ mod tests {
             &provider,
             Some(RuntimeHandoffKind::ClaudeTui),
             transcript.as_path(),
-            Some(current_offset),
         );
         assert_eq!(
             signal,

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -640,22 +640,41 @@ impl TurnFinalizer {
     /// touch the ledger, the actor channel, or any mutable state — it is a
     /// stateless transcript read, so it runs directly on the caller's task.
     ///
-    /// Mirrors EXACTLY how the idle-queue drain consults the structured turn
-    /// state in `tui_turn_state.rs`: first gate on
-    /// `provider_runtime_has_structured_jsonl_turn_state(provider, runtime_kind)`
-    /// (the same gate `jsonl_ready_for_input` / `runtime_binding_ready_for_input`
-    /// apply), then — on the offset-behind drain path — consult
-    /// `jsonl_strict_terminator_idle(provider, transcript_path)` (the
-    /// relay-offset-independent strict reverse-scan). The strict probe is
-    /// offset-independent by construction, so this read needs only the provider,
-    /// runtime kind, and transcript path; `turn_start_offset` is accepted to make
-    /// the call shape explicit for S3/S4 wiring but, like the strict scan itself,
-    /// does not change the structural verdict.
+    /// Mirrors how the idle-queue drain consults the structured turn state in
+    /// `tui_turn_state.rs`, but applies the STRICTER turn-END terminator: first
+    /// gate on `provider_runtime_has_structured_jsonl_turn_state(provider,
+    /// runtime_kind)` (the same gate `jsonl_ready_for_input` /
+    /// `runtime_binding_ready_for_input` apply), then consult
+    /// `jsonl_turn_end_terminator_idle(provider, transcript_path)`.
+    ///
+    /// #3016 S3 (Concern 1): the drain uses the LENIENT
+    /// `jsonl_strict_terminator_idle`, which treats the whole provider
+    /// "Idle-class" family as at-rest (Codex `session_meta`/`thread.started`/
+    /// `task_complete`/completed `agent_message`; Claude `system{init}`). That is
+    /// correct for "is the session ready for input?" but WRONG for "did THIS turn
+    /// end?": a completed `agent_message` right before a tool call is mid-turn.
+    /// The finalize `Done` decision must therefore use the turn-END-only probe,
+    /// which accepts ONLY the authoritative per-provider turn terminator
+    /// (Codex `turn.completed`; Claude `result` / `system{turn_duration |
+    /// stop_hook_summary}`).
     ///
     ///   - non-JSONL runtime (LegacyTmuxWrapper/ProcessBackend/ClaudeEAdapter or
     ///     a non-JSONL provider) → `Unknown`,
-    ///   - else `jsonl_strict_terminator_idle == Idle` → `Done`,
-    ///   - else (Busy/Inconclusive) → `PausedLive`.
+    ///   - else `jsonl_turn_end_terminator_idle == Idle` → `Done`,
+    ///   - else (no turn terminator: Busy/Inconclusive) → `PausedLive`.
+    ///
+    /// #3016 S3 (Concern 3): there is intentionally NO `turn_start_offset`
+    /// parameter. The turn-END reverse scan is relay-offset-INDEPENDENT by
+    /// construction (it reverse-scans the transcript tail for the newest TURN
+    /// terminator and never consults a relay offset), and TURN-correctness is
+    /// guaranteed at the call site, NOT here: the watcher fresh-idle decision
+    /// pins the finalize id from a pre-cleanup inflight snapshot and SKIPS the
+    /// finalize when that snapshot is stale for a newer turn
+    /// (`pinned_finalize_user_msg_id` / `committed_completion_is_stale_for_newer_turn`).
+    /// A range-scoped scan here would add nothing — the terminator it would find
+    /// in `[turn_start_offset, EOF)` is the same newest terminator the tail scan
+    /// finds — so an offset param could only be silently ignored. We omit it
+    /// rather than pass a value that is ignored.
     ///
     /// #3016 S3: wired into the watcher fresh-idle finalize decision
     /// (`tmux_watcher.rs` `watcher_fresh_idle_finalize_decision`) — Done →
@@ -665,7 +684,6 @@ impl TurnFinalizer {
         provider: &ProviderKind,
         runtime_kind: Option<crate::services::agent_protocol::RuntimeHandoffKind>,
         transcript_path: &std::path::Path,
-        _turn_start_offset: Option<u64>,
     ) -> CompletionSignal {
         if !crate::services::tui_turn_state::provider_runtime_has_structured_jsonl_turn_state(
             provider,
@@ -673,8 +691,10 @@ impl TurnFinalizer {
         ) {
             return CompletionSignal::Unknown;
         }
-        if crate::services::tui_turn_state::jsonl_strict_terminator_idle(provider, transcript_path)
-        {
+        if crate::services::tui_turn_state::jsonl_turn_end_terminator_idle(
+            provider,
+            transcript_path,
+        ) {
             CompletionSignal::Done
         } else {
             CompletionSignal::PausedLive
@@ -3079,7 +3099,6 @@ mod tests {
                 &ProviderKind::Claude,
                 Some(RuntimeHandoffKind::ClaudeTui),
                 file.path(),
-                Some(0),
             ),
             CompletionSignal::Done,
         );
@@ -3098,7 +3117,6 @@ mod tests {
                 &ProviderKind::Claude,
                 Some(RuntimeHandoffKind::ClaudeTui),
                 file.path(),
-                Some(0),
             ),
             CompletionSignal::PausedLive,
         );
@@ -3119,7 +3137,6 @@ mod tests {
                 &ProviderKind::Claude,
                 Some(RuntimeHandoffKind::ClaudeTui),
                 file.path(),
-                Some(0),
             ),
             CompletionSignal::PausedLive,
         );
@@ -3139,7 +3156,6 @@ mod tests {
                 &ProviderKind::Codex,
                 Some(RuntimeHandoffKind::CodexTui),
                 file.path(),
-                Some(0),
             ),
             CompletionSignal::Done,
         );
@@ -3158,9 +3174,103 @@ mod tests {
                 &ProviderKind::Codex,
                 Some(RuntimeHandoffKind::CodexTui),
                 file.path(),
-                Some(0),
             ),
             CompletionSignal::PausedLive,
+        );
+    }
+
+    // #3016 S3 (Concern 1): a COMPLETED Codex `agent_message` written right
+    // before a tool call is MID-TURN — the turn has not ended. The lenient drain
+    // probe would call this Idle, but the finalize `Done` decision uses the
+    // turn-END-only probe, so it must resolve to PausedLive (NOT Done) and the
+    // watcher therefore CANNOT over-finalize the live turn.
+    #[test]
+    fn completion_signal_codex_completed_agent_message_is_paused_live_not_done() {
+        let fin = TurnFinalizer::spawn();
+        let file = write_transcript(&[
+            r#"{"type":"session_meta","payload":{"id":"s","cwd":"/repo"}}"#,
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"on it, running a tool next"}}"#,
+        ]);
+        assert_eq!(
+            fin.completion_signal_state(
+                &ProviderKind::Codex,
+                Some(RuntimeHandoffKind::CodexTui),
+                file.path(),
+            ),
+            CompletionSignal::PausedLive,
+            "a completed agent_message with no turn.completed is mid-turn → not Done",
+        );
+    }
+
+    // #3016 S3 (Concern 1): a Codex `event_msg{task_complete}` (a task signal,
+    // not the turn record) is likewise NOT the turn terminator → PausedLive.
+    #[test]
+    fn completion_signal_codex_task_complete_is_paused_live_not_done() {
+        let fin = TurnFinalizer::spawn();
+        let file = write_transcript(&[
+            r#"{"type":"session_meta","payload":{"id":"s","cwd":"/repo"}}"#,
+            r#"{"type":"event_msg","payload":{"type":"task_complete"}}"#,
+        ]);
+        assert_eq!(
+            fin.completion_signal_state(
+                &ProviderKind::Codex,
+                Some(RuntimeHandoffKind::CodexTui),
+                file.path(),
+            ),
+            CompletionSignal::PausedLive,
+        );
+    }
+
+    // #3016 S3 (Concern 1): a Claude mid-turn assistant message (no terminator)
+    // → PausedLive; and a Claude `system{init}` (session-start, not turn-end) is
+    // at-rest to the drain probe but must NOT be Done for the finalize decision.
+    #[test]
+    fn completion_signal_claude_init_and_mid_turn_are_paused_live_not_done() {
+        let fin = TurnFinalizer::spawn();
+        let mid_turn = write_transcript(&[
+            r#"{"type":"user","message":{"content":"hi"}}"#,
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"thinking"}]}}"#,
+        ]);
+        assert_eq!(
+            fin.completion_signal_state(
+                &ProviderKind::Claude,
+                Some(RuntimeHandoffKind::ClaudeTui),
+                mid_turn.path(),
+            ),
+            CompletionSignal::PausedLive,
+        );
+
+        let init_only =
+            write_transcript(&[r#"{"type":"system","subtype":"init","session_id":"s"}"#]);
+        assert_eq!(
+            fin.completion_signal_state(
+                &ProviderKind::Claude,
+                Some(RuntimeHandoffKind::ClaudeTui),
+                init_only.path(),
+            ),
+            CompletionSignal::PausedLive,
+            "system{{init}} is a session-start marker, not a turn-end terminator → not Done",
+        );
+    }
+
+    // #3016 S3 (Concern 1): a Claude `system{turn_duration}` IS a real turn-end
+    // terminator → Done (the stricter probe still accepts the genuine
+    // system-family turn boundary, not only `result`).
+    #[test]
+    fn completion_signal_claude_turn_duration_is_done() {
+        let fin = TurnFinalizer::spawn();
+        let file = write_transcript(&[
+            r#"{"type":"user","message":{"content":"hi"}}"#,
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"done"}]}}"#,
+            r#"{"type":"system","subtype":"turn_duration","session_id":"s"}"#,
+        ]);
+        assert_eq!(
+            fin.completion_signal_state(
+                &ProviderKind::Claude,
+                Some(RuntimeHandoffKind::ClaudeTui),
+                file.path(),
+            ),
+            CompletionSignal::Done,
         );
     }
 
@@ -3176,7 +3286,6 @@ mod tests {
                 &ProviderKind::Claude,
                 Some(RuntimeHandoffKind::LegacyTmuxWrapper),
                 file.path(),
-                Some(0),
             ),
             CompletionSignal::Unknown,
         );
@@ -3186,7 +3295,6 @@ mod tests {
                 &ProviderKind::Claude,
                 Some(RuntimeHandoffKind::ProcessBackend),
                 file.path(),
-                None,
             ),
             CompletionSignal::Unknown,
         );
@@ -3195,7 +3303,6 @@ mod tests {
                 &ProviderKind::Claude,
                 Some(RuntimeHandoffKind::ClaudeEAdapter),
                 file.path(),
-                None,
             ),
             CompletionSignal::Unknown,
         );
@@ -3211,7 +3318,6 @@ mod tests {
                 &ProviderKind::Qwen,
                 Some(RuntimeHandoffKind::ClaudeTui),
                 file.path(),
-                Some(0),
             ),
             CompletionSignal::Unknown,
         );

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -362,7 +362,7 @@ pub(in crate::services::discord) enum FinalizeOutcome {
 ///   state (LegacyTmuxWrapper / ProcessBackend / ClaudeEAdapter, or a non-JSONL
 ///   provider), so the transcript probe cannot speak to completion.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-#[allow(dead_code)] // #3016 S1: wired in S3/S4
+// #3016 S3: wired into the watcher fresh-idle finalize decision.
 pub(in crate::services::discord) enum CompletionSignal {
     Done,
     PausedLive,
@@ -657,8 +657,9 @@ impl TurnFinalizer {
     ///   - else `jsonl_strict_terminator_idle == Idle` → `Done`,
     ///   - else (Busy/Inconclusive) → `PausedLive`.
     ///
-    /// Dead until S3/S4 (#3016).
-    #[allow(dead_code)] // #3016 S1: wired in S3/S4
+    /// #3016 S3: wired into the watcher fresh-idle finalize decision
+    /// (`tmux_watcher.rs` `watcher_fresh_idle_finalize_decision`) — Done →
+    /// finalize, PausedLive → defer, Unknown → legacy flag-gated.
     pub(in crate::services::discord) fn completion_signal_state(
         &self,
         provider: &ProviderKind,

--- a/src/services/tui_turn_state.rs
+++ b/src/services/tui_turn_state.rs
@@ -216,12 +216,58 @@ pub(crate) fn jsonl_ready_for_input(
 ///     own `full_response`-non-empty guard, so this skip cannot tear down a
 ///     spinning-up turn — see #2712.)
 pub(crate) fn jsonl_strict_terminator_idle(provider: &ProviderKind, path: &Path) -> bool {
+    scan_strict_terminator_idle_with_strictness(provider, path, TerminatorStrictness::Lenient)
+}
+
+/// #3016 S3 (Concern 1): the STRICTER turn-END-only sibling of
+/// [`jsonl_strict_terminator_idle`], used ONLY by the finalize `Done` decision
+/// (`TurnFinalizer::completion_signal_state`).
+///
+/// The lenient probe above accepts the whole "Idle-class" envelope family as
+/// proof the session is at rest — for Codex that includes `session_meta`,
+/// `thread.started`, `event_msg{task_complete}`, AND a *completed*
+/// `agent_message` (`item.completed`). That leniency is correct for the
+/// idle-queue *drain* (it asks "is the session ready to accept input?"), but it
+/// is WRONG as a turn-END terminator: a completed `agent_message` written
+/// immediately BEFORE a tool call is mid-turn — the turn is still LIVE — yet the
+/// lenient scan reads it as Idle. Finalizing on that signal over-finalizes a
+/// live turn.
+///
+/// This probe accepts as Idle ONLY the authoritative per-provider TURN
+/// terminator:
+///   - Codex: ONLY `type == "turn.completed"` (NOT `task_complete`, NOT a
+///     completed `agent_message`, NOT `session_meta`/`thread.started`).
+///   - Claude: ONLY the real turn terminator — `type == "result"` or the
+///     `system{turn_duration | stop_hook_summary}` turn-end envelope. NOT
+///     `system{init}` (a SESSION-start marker, never a turn-end), NOT any
+///     housekeeping/mode envelope.
+///
+/// Everything else (the lenient Idle-class markers, housekeeping, unknown
+/// metadata) is treated as "keep looking" so the reverse scan walks back to the
+/// real terminator beneath trailing housekeeping — while streaming/user
+/// envelopes and torn non-housekeeping fragments still report Busy. The
+/// torn-trailing skip and the housekeeping-walk-back are preserved verbatim; the
+/// ONLY behavioural change versus the lenient scan is which envelopes are
+/// allowed to *produce* an Idle verdict.
+pub(crate) fn jsonl_turn_end_terminator_idle(provider: &ProviderKind, path: &Path) -> bool {
+    scan_strict_terminator_idle_with_strictness(provider, path, TerminatorStrictness::TurnEndOnly)
+}
+
+/// Shared windowed reverse-scan driver for both the lenient
+/// ([`jsonl_strict_terminator_idle`]) and the turn-END-only
+/// ([`jsonl_turn_end_terminator_idle`]) probes. Only the `strictness` argument
+/// differs — the windowing, widen-once, and torn-write handling are identical.
+fn scan_strict_terminator_idle_with_strictness(
+    provider: &ProviderKind,
+    path: &Path,
+    strictness: TerminatorStrictness,
+) -> bool {
     // First pass over the default 64KB tail window.
     let Ok(window) = read_recent_jsonl_window(path, TURN_STATE_TAIL_BYTES) else {
         // A read error cannot prove the turn has ended → conservative Busy.
         return false;
     };
-    match scan_strict_terminator(provider, &window.lines) {
+    match scan_strict_terminator(provider, &window.lines, strictness) {
         StrictTerminatorScan::Idle => return true,
         StrictTerminatorScan::Busy => return false,
         // The window contained no definitive turn-state envelope. If it already
@@ -239,13 +285,26 @@ pub(crate) fn jsonl_strict_terminator_idle(provider: &ProviderKind, path: &Path)
     let Ok(wide) = read_recent_jsonl_window(path, TURN_STATE_MAX_TAIL_BYTES) else {
         return false;
     };
-    match scan_strict_terminator(provider, &wide.lines) {
+    match scan_strict_terminator(provider, &wide.lines, strictness) {
         StrictTerminatorScan::Idle => true,
         // Even in the widened window we found no terminator (or the terminator
         // is still older than the 1MB ceiling): stay conservatively Busy rather
         // than assume idle on an ambiguous, unbounded transcript.
         StrictTerminatorScan::Busy | StrictTerminatorScan::Inconclusive => false,
     }
+}
+
+/// How permissive the reverse scan is about what counts as an Idle verdict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TerminatorStrictness {
+    /// The whole provider "Idle-class" family proves at-rest (the idle-queue
+    /// drain's readiness question). Used by [`jsonl_strict_terminator_idle`].
+    Lenient,
+    /// ONLY the authoritative per-provider TURN terminator proves the turn
+    /// ENDED. Every other envelope (including the lenient Idle-class markers) is
+    /// walked past. Used by [`jsonl_turn_end_terminator_idle`] for the finalize
+    /// `Done` decision (#3016 S3, Concern 1).
+    TurnEndOnly,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -264,7 +323,11 @@ enum StrictTerminatorScan {
 /// envelope. Conservatism rule (#3030): never report `Idle` while there is any
 /// plausible evidence of an in-flight turn — false-idle (input injected
 /// mid-turn) is strictly worse than false-busy.
-fn scan_strict_terminator(provider: &ProviderKind, lines: &[String]) -> StrictTerminatorScan {
+fn scan_strict_terminator(
+    provider: &ProviderKind,
+    lines: &[String],
+    strictness: TerminatorStrictness,
+) -> StrictTerminatorScan {
     let mut allow_torn_trailing_skip = true;
     for (rev_index, line) in lines.iter().rev().enumerate() {
         let trimmed = line.trim();
@@ -314,7 +377,25 @@ fn scan_strict_terminator(provider: &ProviderKind, lines: &[String]) -> StrictTe
             _ => return StrictTerminatorScan::Busy,
         };
         match classified {
-            Some(TuiTurnState::Idle) => return StrictTerminatorScan::Idle,
+            Some(TuiTurnState::Idle) => match strictness {
+                // Lenient: any Idle-class envelope proves at-rest.
+                TerminatorStrictness::Lenient => return StrictTerminatorScan::Idle,
+                // Turn-END-only (#3016 S3, Concern 1): an Idle-class envelope
+                // proves the TURN ended ONLY when it is the authoritative
+                // per-provider turn terminator. A non-terminator Idle-class
+                // marker (Codex `session_meta`/`thread.started`/`task_complete`/
+                // completed `agent_message`; Claude `system{init}`) is NOT a
+                // turn boundary — a completed `agent_message` right before a tool
+                // call is mid-turn — so walk PAST it to the real terminator
+                // beneath, exactly like trailing housekeeping. It can never
+                // *create* a Done verdict on its own.
+                TerminatorStrictness::TurnEndOnly => {
+                    if envelope_is_turn_end_terminator(provider, &json) {
+                        return StrictTerminatorScan::Idle;
+                    }
+                    continue;
+                }
+            },
             Some(TuiTurnState::Streaming | TuiTurnState::UserSubmitted) => {
                 return StrictTerminatorScan::Busy;
             }
@@ -328,6 +409,40 @@ fn scan_strict_terminator(provider: &ProviderKind, lines: &[String]) -> StrictTe
         }
     }
     StrictTerminatorScan::Inconclusive
+}
+
+/// #3016 S3 (Concern 1): is this fully-parsed envelope the AUTHORITATIVE
+/// per-provider TURN-END terminator (the genuine turn boundary), as opposed to a
+/// merely "Idle-class" / at-rest marker that the lenient scan also trusts?
+///
+/// This is intentionally the NARROW subset of the Idle-class family:
+///   - Codex: ONLY `turn.completed`. `session_meta`/`thread.started` (session
+///     bring-up), `event_msg{task_complete}` (a task signal, not the turn
+///     record), and a completed `agent_message` (`item.completed`, which can be
+///     written mid-turn right before a tool call) are EXCLUDED.
+///   - Claude: ONLY `result` and the `system{turn_duration | stop_hook_summary}`
+///     turn-end envelopes. `system{init}` is a SESSION-start marker — never a
+///     turn end — and is EXCLUDED.
+///
+/// Callers guarantee `json` already classified as `TuiTurnState::Idle` via the
+/// per-provider classifier, so a `false` here means "Idle-class but not a turn
+/// boundary → keep scanning back".
+fn envelope_is_turn_end_terminator(provider: &ProviderKind, json: &Value) -> bool {
+    let Some(type_str) = json.get("type").and_then(Value::as_str) else {
+        return false;
+    };
+    match provider {
+        ProviderKind::Codex => type_str == "turn.completed",
+        ProviderKind::Claude => match type_str {
+            "result" => true,
+            "system" => matches!(
+                json.get("subtype").and_then(Value::as_str),
+                Some("turn_duration" | "stop_hook_summary")
+            ),
+            _ => false,
+        },
+        _ => false,
+    }
 }
 
 /// A truncated trailing JSON fragment looks like the writer was interrupted
@@ -1655,5 +1770,198 @@ mod tests {
         assert!(is_torn_trailing_fragment(r#"{"type":"mode","mode":"def"#));
         assert!(!is_torn_trailing_fragment(r#"{"type":"result"}"#));
         assert!(!is_torn_trailing_fragment("not-json-at-all"));
+    }
+
+    // =======================================================================
+    // #3016 S3 (Concern 1): the STRICTER turn-END-only terminator probe
+    // (`jsonl_turn_end_terminator_idle`) vs. the lenient drain probe
+    // (`jsonl_strict_terminator_idle`). The finalize `Done` decision must read
+    // the turn-END probe so a non-terminator Idle-class envelope (a completed
+    // Codex `agent_message` mid-turn, a Claude `system{init}`) cannot
+    // over-finalize a LIVE turn.
+    // =======================================================================
+
+    // Codex: a completed `agent_message` written right before a tool call is
+    // MID-TURN. The lenient drain probe reports Idle (it is ready for input by
+    // its definition), but the turn-END probe must NOT — the turn has not ended.
+    #[test]
+    fn codex_completed_agent_message_is_not_turn_end_but_is_lenient_idle() {
+        let file = write_jsonl(&[
+            r#"{"type":"session_meta","payload":{"id":"s","cwd":"/repo"}}"#,
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"on it"}}"#,
+        ]);
+        assert!(
+            jsonl_strict_terminator_idle(&ProviderKind::Codex, file.path()),
+            "lenient drain probe treats a completed agent_message as at-rest"
+        );
+        assert!(
+            !jsonl_turn_end_terminator_idle(&ProviderKind::Codex, file.path()),
+            "turn-END probe must NOT treat a completed agent_message as a turn boundary"
+        );
+    }
+
+    // Codex: the AUTHORITATIVE turn terminator `turn.completed` → BOTH probes
+    // Idle. This is the only Codex envelope the turn-END probe accepts.
+    #[test]
+    fn codex_turn_completed_is_turn_end() {
+        let file = write_jsonl(&[
+            r#"{"type":"session_meta","payload":{"id":"s","cwd":"/repo"}}"#,
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"done"}}"#,
+            r#"{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":3}}"#,
+        ]);
+        assert!(jsonl_strict_terminator_idle(
+            &ProviderKind::Codex,
+            file.path()
+        ));
+        assert!(
+            jsonl_turn_end_terminator_idle(&ProviderKind::Codex, file.path()),
+            "turn.completed is the authoritative Codex turn-end terminator"
+        );
+    }
+
+    // Codex: `event_msg{task_complete}` and `session_meta`/`thread.started` are
+    // Idle-class to the lenient probe but are NOT turn-end terminators.
+    #[test]
+    fn codex_task_complete_and_session_markers_are_not_turn_end() {
+        let task_complete = write_jsonl(&[
+            r#"{"type":"session_meta","payload":{"id":"s","cwd":"/repo"}}"#,
+            r#"{"type":"event_msg","payload":{"type":"task_complete"}}"#,
+        ]);
+        assert!(jsonl_strict_terminator_idle(
+            &ProviderKind::Codex,
+            task_complete.path()
+        ));
+        assert!(
+            !jsonl_turn_end_terminator_idle(&ProviderKind::Codex, task_complete.path()),
+            "event_msg{{task_complete}} is not the turn record terminator"
+        );
+
+        let session_only = write_jsonl(&[r#"{"type":"thread.started","thread_id":"t"}"#]);
+        assert!(jsonl_strict_terminator_idle(
+            &ProviderKind::Codex,
+            session_only.path()
+        ));
+        assert!(
+            !jsonl_turn_end_terminator_idle(&ProviderKind::Codex, session_only.path()),
+            "thread.started is session bring-up, not a turn end"
+        );
+    }
+
+    // Codex: the turn-END probe still walks BACK across trailing non-terminator
+    // Idle-class markers to a real `turn.completed` beneath them (housekeeping
+    // walk-back preserved). A completed agent_message AFTER the terminator that
+    // does NOT belong to a new turn boundary is skipped; the terminator wins.
+    #[test]
+    fn codex_turn_end_walks_back_across_trailing_session_meta() {
+        let file = write_jsonl(&[
+            r#"{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}"#,
+            r#"{"type":"session_meta","payload":{"id":"s2","cwd":"/repo"}}"#,
+        ]);
+        assert!(
+            jsonl_turn_end_terminator_idle(&ProviderKind::Codex, file.path()),
+            "a trailing session_meta is walked past to the real turn.completed beneath"
+        );
+    }
+
+    // Claude: a mid-turn assistant message → neither probe Idle (streaming is
+    // Busy). And `system{init}` is a SESSION-start marker the lenient probe
+    // trusts as idle, but the turn-END probe must NOT.
+    #[test]
+    fn claude_mid_turn_assistant_is_not_turn_end() {
+        let streaming = write_jsonl(&[
+            r#"{"type":"user","message":{"content":"hi"}}"#,
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"working"}]}}"#,
+        ]);
+        assert!(!jsonl_strict_terminator_idle(
+            &ProviderKind::Claude,
+            streaming.path()
+        ));
+        assert!(
+            !jsonl_turn_end_terminator_idle(&ProviderKind::Claude, streaming.path()),
+            "a mid-turn assistant message is not a turn end"
+        );
+
+        let init_only = write_jsonl(&[r#"{"type":"system","subtype":"init","session_id":"s"}"#]);
+        assert!(
+            jsonl_strict_terminator_idle(&ProviderKind::Claude, init_only.path()),
+            "lenient probe treats system{{init}} as at-rest (ready for input)"
+        );
+        assert!(
+            !jsonl_turn_end_terminator_idle(&ProviderKind::Claude, init_only.path()),
+            "system{{init}} is a session-start marker, NOT a turn-end terminator"
+        );
+    }
+
+    // Claude: `result` and `system{turn_duration|stop_hook_summary}` ARE the real
+    // turn terminators → turn-END probe Idle.
+    #[test]
+    fn claude_real_terminators_are_turn_end() {
+        for terminator in [
+            r#"{"type":"result","result":"done","session_id":"s"}"#,
+            r#"{"type":"system","subtype":"turn_duration","session_id":"s"}"#,
+            r#"{"type":"system","subtype":"stop_hook_summary","session_id":"s"}"#,
+        ] {
+            let file = write_jsonl(&[
+                r#"{"type":"user","message":{"content":"hi"}}"#,
+                r#"{"type":"assistant","message":{"content":[{"type":"text","text":"done"}]}}"#,
+                terminator,
+            ]);
+            assert!(
+                jsonl_turn_end_terminator_idle(&ProviderKind::Claude, file.path()),
+                "{terminator} is a real Claude turn-end terminator"
+            );
+        }
+    }
+
+    // Claude: the turn-END probe still walks BACK across trailing post-turn
+    // housekeeping (`mode`, `permission-mode`, `pr-link`) to the real terminator
+    // beneath (the #3030 walk-back is preserved under the stricter mode).
+    #[test]
+    fn claude_turn_end_walks_back_across_trailing_housekeeping() {
+        let file = write_jsonl(&[
+            r#"{"type":"user","message":{"content":"hi"}}"#,
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"done"}]}}"#,
+            r#"{"type":"result","result":"done","session_id":"s"}"#,
+            r#"{"type":"mode","mode":"default"}"#,
+            r#"{"type":"permission-mode","mode":"default"}"#,
+            r#"{"type":"pr-link","url":"https://example.com/pr/1"}"#,
+        ]);
+        assert!(
+            jsonl_turn_end_terminator_idle(&ProviderKind::Claude, file.path()),
+            "trailing housekeeping is walked past to the real result terminator"
+        );
+    }
+
+    // The turn-END terminator classifier directly: only the narrow per-provider
+    // subset returns true.
+    #[test]
+    fn envelope_is_turn_end_terminator_narrow_subset() {
+        let p = |s: &str| serde_json::from_str::<Value>(s).unwrap();
+        // Codex: only turn.completed.
+        assert!(envelope_is_turn_end_terminator(
+            &ProviderKind::Codex,
+            &p(r#"{"type":"turn.completed"}"#)
+        ));
+        assert!(!envelope_is_turn_end_terminator(
+            &ProviderKind::Codex,
+            &p(r#"{"type":"session_meta"}"#)
+        ));
+        assert!(!envelope_is_turn_end_terminator(
+            &ProviderKind::Codex,
+            &p(r#"{"type":"item.completed","item":{"type":"agent_message"}}"#)
+        ));
+        // Claude: result + turn_duration/stop_hook_summary, NOT init.
+        assert!(envelope_is_turn_end_terminator(
+            &ProviderKind::Claude,
+            &p(r#"{"type":"result"}"#)
+        ));
+        assert!(envelope_is_turn_end_terminator(
+            &ProviderKind::Claude,
+            &p(r#"{"type":"system","subtype":"turn_duration"}"#)
+        ));
+        assert!(!envelope_is_turn_end_terminator(
+            &ProviderKind::Claude,
+            &p(r#"{"type":"system","subtype":"init"}"#)
+        ));
     }
 }


### PR DESCRIPTION
## #3016 Stage 3 — rewrite the watcher fresh-idle finalize to consult the STRUCTURAL completion signal

The HIGHEST-RISK relay change (the A2 / phase-5 enabler). The watcher fresh-idle decision previously finalized an empty/suppressed delegated completion using the in-memory `mailbox_finalize_owed` flag as the **sole** signal — which cannot tell "turn done" from "paused-live". This rewrites the decision to consult the S1 structural completion signal (`TurnFinalizer::completion_signal_state` → `CompletionSignal{Done, PausedLive, Unknown}`, the relay-offset-independent JSONL strict-terminator scan).

### Mechanism

New pure helper `watcher_fresh_idle_finalize_decision` (`tmux_watcher.rs:199`), driven by the production branch AND the unit tests, fuses the completion signal with the #3197-banked A2 wrong-turn-race defenses:

- **Done** (structural JSONL terminator proven — Claude `result`/`system`, Codex `turn.completed`; **even when the response text is empty**) → finalize via the existing single-authority path `finish_restored_watcher_active_turn(.., normal_completion=true, ..)` with the REAL pinned `user_msg_id`.
- **PausedLive** (no terminator: Busy/Inconclusive — paused at selector / permission prompt / subagent running / long silent tool) → **DEFER** (preserve inflight, continue). Never finalize.
- **Unknown** (non-JSONL runtime: LegacyTmuxWrapper / ProcessBackend / ClaudeEAdapter, or a non-JSONL provider) → **KEEP today's `mailbox_finalize_owed`-flag behaviour VERBATIM**. The flag stays read (and `swap(false)`'d for its revoke lifecycle) only for this arm. The flag is **not deleted** (that's Stage 5).

Production decision sites:
- `tmux_watcher.rs:7605` — compute `completion_signal_state` once (runtime kind resolved via `runtime_binding_for_tmux_session` → `resolve_tmux_runtime_kind_marker`, transcript = the watcher `output_path`).
- `tmux_watcher.rs:7631` — the DEFER decision now keys on the signal (PausedLive defers; Done falls through; Unknown defers via the legacy `watcher_should_defer_delegated_fresh_idle`).
- `tmux_watcher.rs:7735` — the FINALIZE decision via the helper; `Finalize{user_msg_id}` (`:7789`) drives the finalizer.

### The contradiction that killed the first A2 attempt (now fixed)

The OLD defer guard deferred `(delegated && empty_response)` — the **same** condition as the empty completion we want to finalize, so finalize was unreachable. The disambiguator is now the **STRUCTURAL TERMINATOR, not emptiness**: defer on PausedLive (no terminator), finalize on Done (terminator present) **even when the response is empty**. An empty-but-terminated completion now reaches finalize — the whole point of S3 (verified by `fresh_idle_empty_terminated_completion_finalizes_via_completion_signal_flag_false`).

### Reuse of the #3197 wrong-turn-race defenses

1. The finalize id is **PINNED from the pre-cleanup inflight snapshot** (`load_inflight_state` taken BEFORE the placeholder/panel cleanup `.await`s) via `pinned_finalize_user_msg_id(snapshot, session, current_offset)` — never a late re-read.
2. The finalize is **SKIPPED** when `committed_completion_is_stale_for_newer_turn(..) || pinned == 0` (a newer turn began AT/AFTER this committed range).
3. The **pause/epoch guard** (`paused.load() || pause_epoch != epoch_snapshot`) is evaluated INSIDE the helper, BEFORE the destructive clear, with NO awaits between the epoch snapshot and the clear (the canonical guard sits AFTER this branch's `continue`, so it cannot protect this site).

### Adversarial safety proof

- **(a) paused at selector / permission prompt** — no terminator on disk → `CompletionSignal::PausedLive` → `DeferPausedLive`. Inflight preserved. *(`fresh_idle_paused_live_defers_via_completion_signal`)*
- **(b) subagent running / long silent tool call** — no terminator (the strict scan reports Busy/Inconclusive while assistant/streaming/active envelopes are the latest) → PausedLive → defer. Same arm as (a).
- **(c) genuine empty/suppressed completion** — terminator present (`result`/`turn.completed`) → `Done` → `Finalize{real id}` exactly once. The empty response does NOT block it (defer keys on the terminator, not emptiness). *(`fresh_idle_done_finalizes_and_unknown_falls_through_to_legacy`, end-to-end `…flag_false`)*
- **(d) wrong-turn race (newer turn current at fresh-idle)** — two sub-paths: paused/epoch changed during cleanup → `AbortFollowupTookOver`; the pinned snapshot is a newer turn (`turn_start_offset >= current_offset`) → `SkipStale{pinned 0}`. The follow-up is never released. *(`fresh_idle_done_wrong_turn_race_does_not_finalize_followup`)*
- **(e) bridge already finalized** — `finish_restored_watcher_active_turn` routes through the idempotent single-authority finalizer; a turn already finalized resolves to `AlreadyFinalized` (no-op). *(idempotency tail of the end-to-end test)*
- **(f) non-JSONL runtime** — `provider_runtime_has_structured_jsonl_turn_state` is false → `CompletionSignal::Unknown` → `LegacyFlagGated` → byte-for-byte the pre-change `should_finish_mailbox = finish_mailbox_on_completion || owed` path. The A2 guards are not consulted on this arm. *(`…unknown_falls_through_to_legacy`)*
- **(g) terminator of turn N misread for turn N+1** — prevented by three independent layers: the strict reverse-scan's partial-trailing-line guard (`scan_strict_terminator` allows at most one torn trailing housekeeping line, never a stale `result` fall-back across a new `user`/`permission-mode`), the OUTPUT-RANGE offset gate (`pinned_finalize_user_msg_id`'s `turn_start_offset < current_offset` and its stale complement), and the finalizer ledger's exact-id identity match.

**Degenerate-empty-offset safety:** a genuine current-turn fresh idle always has `turn_start_offset < current_offset` (`FreshIdle` requires `output_ever_grew`; the tracker is built with `::default()`, not `primed_for_recovery()`, and the watcher resumes at `turn_start_offset`). So even an empty completion has a strictly-in-range pinned id → `Finalize` fires and `SkipStale` cannot misfire on the current turn.

### Tests (all drive the REAL production helpers, not re-implementations)

| Test | Property |
|---|---|
| `fresh_idle_paused_live_defers_via_completion_signal` | (a)/(b) PausedLive → defer, regardless of snapshot/pause/epoch |
| `fresh_idle_done_finalizes_and_unknown_falls_through_to_legacy` | (c) Done empty → Finalize{real id}; (f) Unknown → LegacyFlagGated |
| `fresh_idle_done_wrong_turn_race_does_not_finalize_followup` | (d) abort + stale-skip |
| `fresh_idle_empty_terminated_completion_finalizes_via_completion_signal_flag_false` | end-to-end: REAL `completion_signal_state` over a real JSONL transcript → Done → REAL decision helper → REAL `finish_restored_watcher_active_turn` + actor; flag FALSE; idempotent second submit |

### Verification

- `cargo build` clean (only 2 pre-existing unrelated warnings).
- `cargo test --lib turn_finalizer` — **60 passed** (incl. the #3016 actor × terminal-path matrix and decouple-proof).
- `cargo test --lib tmux_watcher` — **149 passed** (incl. `normal_completion_finalizes_with_both_legacy_flags_false`, `stale_normal_completion_does_not_release_newer_active_turn`, and the 4 new S3 tests).
- `cargo fmt --check` clean.
- `python3 scripts/audit_maintainability.py --check` → exit 0 (namespace/giant-file caps).
- `python3 scripts/generate_inventory_docs.py` + `python3 scripts/check_agent_maintenance_docs.py --line-count-gate` → both pass; `change-surfaces.md` synced (tmux_watcher.rs 9215 → 9488).

### Unblocks

This is the **A2** fresh-idle finalize (now armed with the completion signal — the prior A2 attempt failed twice on the wrong-turn race AND the defer-equals-finalize contradiction, both defeated here) and a direct **phase-5** enabler (the structural-signal-driven `normal_completion=true` finalize decouples the Done arm from `mailbox_finalize_owed`, so phase 5 can delete the flag for JSONL runtimes).

DRAFT — do NOT merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

### Follow-up — S3 FINAL fix: residual TOCTOU on the Done-arm clear (this commit)

An independent gate flagged a remaining TOCTOU on the fresh-idle `Done`/`Finalize`
arm. The earlier gate-fix performed the on-disk clear as a **check-then-act split
across two locks**: a late re-read + `committed_completion_is_stale_for_newer_turn`
under one lock, then an **unconditional** `clear_inflight_state` under another. On a
multi-threaded tokio runtime a follow-up turn can save a new inflight on another
worker thread **after the re-read but before the clear**, so the unconditional delete
wipes the follow-up's inflight.

**Fix:** replace that sequence with the existing **atomic** compare-and-clear helper
`clear_inflight_state_if_matches_identity` (inflight.rs:1666 / impl 1822) —
read+validate+unlink under a **single** sidecar lock. It is keyed on the **pinned**
turn's `InflightTurnIdentity::from_state(&pinned_pre_cleanup_inflight)` (matching
`user_msg_id` + `started_at` + `tmux_session_name`). When `Finalize` is reached, that
pinned id is exactly the id the finalize runs on (`pinned_finalize_user_msg_id`
selected it). The helper deletes **only** if the on-disk identity is still the pinned
turn; a follow-up's different identity → `UserMsgMismatch` no-op → its inflight
survives. The two-lock window is gone — **one atomic op**.

The finalize-skip stays a **separate** pinned-snapshot decision in
`watcher_fresh_idle_finalize_decision` (`SkipStale`); only the destructive **clear**
moved to the atomic helper.

**Canonical site noted, NOT changed:** the canonical normal-completion clear
(`tmux_watcher.rs` ~11287) uses the same weaker non-atomic re-read+clear pattern
(`completion_is_stale_for_newer_turn` then unconditional `clear_inflight_state`).
That is a pre-existing weaker pattern and is **out of scope** for this PR — left
unchanged; the S3 fresh-idle arm is now strictly safer.

**Test:** `fresh_idle_clear_gate_skips_when_late_reread_is_newer_turn` rewritten to
drive the **real** atomic helper against **real** on-disk inflight (no separate
re-read window): (1) a follow-up's inflight on disk → atomic clear is a no-op,
follow-up preserved (`UserMsgMismatch`, `load` still returns id 9002); (2) the pinned
turn on disk → atomic clear removes it (`Cleared`, happy path). The decision helper
still returns `Finalize { user_msg_id: 9001 }` from the pinned snapshot.

- `cargo build` clean.
- `cargo test --lib tmux_watcher` → 150 passed; `cargo test --lib turn_finalizer` → 64 passed; `cargo test --lib tui_turn_state` → 56 passed.
- `cargo fmt --check` clean.
- `python3 scripts/audit_maintainability.py --check` → exit 0; inventory + `--line-count-gate` → both pass (`change-surfaces.md` synced, tmux_watcher.rs 9524 → 9549).

DRAFT — do NOT merge.
