### PR TITLE
feat(#3204): relay live subagent activity in status panel

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -407,6 +407,7 @@ src/
 │   │   │   ├── status_events.rs
 │   │   │   ├── status_panel.rs
 │   │   │   ├── subagent_rollout.rs
+│   │   │   ├── subagent_summary.rs
 │   │   │   ├── task_panel.rs
 │   │   │   ├── tests.rs
 │   │   │   └── workflow_panel.rs

--- a/src/services/agent_protocol.rs
+++ b/src/services/agent_protocol.rs
@@ -316,6 +316,19 @@ pub enum StatusEvent {
     SubagentEvent {
         summary: String,
     },
+    /// Live activity from a still-running subagent (especially a
+    /// `run_in_background` one), attributed to its slot via the nested record's
+    /// top-level `parent_tool_use_id` — the launching Task's tool-use id stored
+    /// on [`StatusEvent::SubagentStart::tool_use_id`]. Carries the subagent's
+    /// latest activity line (current tool / short summary) so a long background
+    /// task is not an opaque "running". The panel updates the slot's recent line
+    /// on each new activity and NEVER resurrects a finished slot (#3198 ack-only
+    /// / background-finalize semantics are preserved). `tool_use_id` is the
+    /// parent Task id; `None` falls back to the last unfinished slot.
+    SubagentActivity {
+        tool_use_id: Option<String>,
+        summary: String,
+    },
     SubagentEnd {
         success: bool,
         /// Tool-use id of the Task whose result closed this subagent. Matched

--- a/src/services/discord/placeholder_live_events/mod.rs
+++ b/src/services/discord/placeholder_live_events/mod.rs
@@ -14,6 +14,7 @@ mod session_panel;
 mod status_events;
 mod status_panel;
 mod subagent_rollout;
+mod subagent_summary;
 mod task_panel;
 mod workflow_panel;
 

--- a/src/services/discord/placeholder_live_events/status_events.rs
+++ b/src/services/discord/placeholder_live_events/status_events.rs
@@ -172,6 +172,16 @@ pub(in crate::services::discord) fn status_events_from_json(value: &Value) -> Ve
         return workflow_events;
     }
 
+    // A nested subagent record carries the launching Task's tool-use id as a
+    // top-level `parent_tool_use_id`. Its tool activity belongs to that subagent
+    // slot, not the main panel status, so route it to `SubagentActivity` keyed by
+    // the parent id (matched against the slot's stored Task tool-use id) rather
+    // than emitting a top-level `ToolStart` that would clobber the panel header
+    // and resurrect the foreground "tool running" status.
+    if let Some(parent_id) = subagent_parent_tool_use_id(value) {
+        return subagent_activity_status_events(value, parent_id);
+    }
+
     match value.get("type").and_then(Value::as_str).unwrap_or("") {
         "assistant" => assistant_status_events(value),
         "content_block_start" => content_block_start_status_events(value),
@@ -543,6 +553,81 @@ fn system_status_events(value: &Value) -> Vec<StatusEvent> {
     let status = value.get("status").and_then(Value::as_str).unwrap_or("");
     let summary = value.get("summary").and_then(Value::as_str).unwrap_or("");
     status_events_from_task_notification(kind, status, summary)
+}
+
+/// Returns the launching Task's tool-use id from a nested subagent record's
+/// top-level `parent_tool_use_id` (Claude Code stream-json marks every
+/// subagent-internal `assistant`/`content_block_start` record with it). `None`
+/// for top-level records (no parent) so they take the normal panel path.
+fn subagent_parent_tool_use_id(value: &Value) -> Option<String> {
+    ["parent_tool_use_id", "parentToolUseId"]
+        .into_iter()
+        .find_map(|key| value.get(key).and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string)
+}
+
+/// Builds [`StatusEvent::SubagentActivity`] events for a nested subagent record,
+/// one per tool_use block, keyed by the parent Task id so the panel updates the
+/// owning subagent slot's recent line. The activity line is the same
+/// `[Tool] args` summary the main panel uses for a tool, so a long background
+/// subagent surfaces its current step instead of an opaque "running".
+fn subagent_activity_status_events(value: &Value, parent_id: String) -> Vec<StatusEvent> {
+    let blocks: Vec<(&str, String)> = match value.get("type").and_then(Value::as_str) {
+        Some("assistant") => value
+            .get("message")
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter(|block| block.get("type").and_then(Value::as_str) == Some("tool_use"))
+            .map(|block| {
+                let name = block.get("name").and_then(Value::as_str).unwrap_or("Tool");
+                let input = value_to_compact_string(block.get("input").unwrap_or(&Value::Null));
+                (name, input)
+            })
+            .collect(),
+        Some("content_block_start") => value
+            .get("content_block")
+            .filter(|block| block.get("type").and_then(Value::as_str) == Some("tool_use"))
+            .map(|block| {
+                let name = block.get("name").and_then(Value::as_str).unwrap_or("Tool");
+                let input = block
+                    .get("input")
+                    .map(value_to_compact_string)
+                    .unwrap_or_default();
+                vec![(name, input)]
+            })
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    };
+
+    blocks
+        .into_iter()
+        .filter_map(|(name, input)| {
+            subagent_activity_line(name, &input).map(|summary| StatusEvent::SubagentActivity {
+                tool_use_id: Some(parent_id.clone()),
+                summary,
+            })
+        })
+        .collect()
+}
+
+/// Formats a subagent's tool step into a compact activity line, e.g.
+/// `[Bash] cargo test`. Falls back to the bare tool label when no args summary
+/// is available. Returns `None` only when the tool name is unusable.
+fn subagent_activity_line(name: &str, input: &str) -> Option<String> {
+    use super::common::tool_prefix;
+    let args = format_tool_input(name, input);
+    let args = args.trim();
+    let line = if args.is_empty() {
+        tool_prefix(name)
+    } else {
+        format!("{} {}", tool_prefix(name), args)
+    };
+    let line = normalize_summary(&line);
+    (!line.trim().is_empty()).then_some(truncate_chars(&line, EVENT_LINE_MAX_CHARS))
 }
 
 fn background_status_events(value: &Value) -> Vec<StatusEvent> {

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -10,6 +10,7 @@ use super::common::{
 use super::context_panel::{ContextPanelSnapshot, render_context_panel_line};
 use super::session_panel::{SessionPanelSnapshot, render_session_panel_line};
 use super::status_events::{is_schedule_wakeup_tool, parse_eta_secs};
+use super::subagent_summary::render_subagent_done_summary;
 use super::task_panel::{
     TaskPanelSnapshot, TaskToolSlot, clean_task_tool_value, render_task_panel_line,
     render_task_tool_slot,
@@ -162,6 +163,10 @@ impl StatusPanelState {
                     };
                 }
             }
+            StatusEvent::SubagentActivity {
+                tool_use_id,
+                summary,
+            } => self.set_subagent_activity(tool_use_id, summary),
             StatusEvent::SubagentEnd {
                 success,
                 tool_use_id,
@@ -330,6 +335,33 @@ impl StatusPanelState {
                 if matches!(self.status, DerivedStatus::Running) {
                     self.status = DerivedStatus::Running;
                 }
+            }
+        }
+    }
+
+    /// Routes a still-running subagent's live step (#3204) onto its slot's
+    /// recent line. Prefers the UNFINISHED slot whose Task id matches the
+    /// nested record's `parent_tool_use_id`; an id-bearing activity that matches
+    /// no slot is dropped (never mis-routed). Only unfinished slots are touched,
+    /// so a finished/background-finalized slot is never resurrected (#3198). The
+    /// panel header is left unchanged — the subagent is already on its own line.
+    fn set_subagent_activity(&mut self, tool_use_id: Option<String>, summary: String) {
+        let id = tool_use_id.as_deref();
+        let target =
+            match id {
+                Some(id) => self.subagents.iter_mut().rev().find(|slot| {
+                    slot.finished.is_none() && slot.tool_use_id.as_deref() == Some(id)
+                }),
+                None => self
+                    .subagents
+                    .iter_mut()
+                    .rev()
+                    .find(|slot| slot.finished.is_none()),
+            };
+        if let Some(slot) = target {
+            let summary = normalize_summary(&summary);
+            if !summary.trim().is_empty() {
+                slot.recent = Some(summary);
             }
         }
     }
@@ -614,70 +646,6 @@ fn render_subagent_slot(slot: &SubagentSlot) -> String {
         line.push_str(marker);
     }
     truncate_chars(&line, EVENT_LINE_MAX_CHARS)
-}
-
-/// Formats the TUI-parity `Done (N tools · M tokens · Xs)` summary. Each part is
-/// included only when present, so a partial summary still renders what it has.
-/// Returns `None` when no part is available.
-fn render_subagent_done_summary(summary: &SubagentSummary) -> Option<String> {
-    let mut parts = Vec::new();
-    if let Some(count) = summary.tool_count {
-        let noun = if count == 1 { "tool" } else { "tools" };
-        parts.push(format!("{count} {noun}"));
-    }
-    if let Some(tokens) = summary.tokens {
-        parts.push(format!("{} tokens", format_compact_count(tokens)));
-    }
-    if let Some(secs) = summary.duration_secs {
-        parts.push(format_duration_secs(secs));
-    }
-    if parts.is_empty() {
-        return None;
-    }
-    Some(format!("Done ({})", parts.join(" · ")))
-}
-
-/// Compact count formatting mirroring the TUI (`28824` → `28.8k`, `1_500_000`
-/// → `1.5m`). Values under 1000 render verbatim.
-fn format_compact_count(value: u64) -> String {
-    if value < 1_000 {
-        return value.to_string();
-    }
-    if value < 1_000_000 {
-        let scaled = value as f64 / 1_000.0;
-        return format!("{}k", trim_one_decimal(scaled));
-    }
-    let scaled = value as f64 / 1_000_000.0;
-    format!("{}m", trim_one_decimal(scaled))
-}
-
-/// Renders a one-decimal number without a trailing `.0` (`28.8` stays,
-/// `19.0` → `19`).
-fn trim_one_decimal(value: f64) -> String {
-    let rounded = (value * 10.0).round() / 10.0;
-    if (rounded.fract()).abs() < f64::EPSILON {
-        format!("{}", rounded as u64)
-    } else {
-        format!("{rounded:.1}")
-    }
-}
-
-/// Humanizes a duration in seconds the way the TUI does: `45s`, `19m`, `1h2m`.
-fn format_duration_secs(secs: u64) -> String {
-    if secs < 60 {
-        return format!("{secs}s");
-    }
-    let minutes = secs / 60;
-    if minutes < 60 {
-        return format!("{minutes}m");
-    }
-    let hours = minutes / 60;
-    let rem_minutes = minutes % 60;
-    if rem_minutes == 0 {
-        format!("{hours}h")
-    } else {
-        format!("{hours}h{rem_minutes}m")
-    }
 }
 
 fn sanitize_label(raw: &str) -> String {

--- a/src/services/discord/placeholder_live_events/subagent_summary.rs
+++ b/src/services/discord/placeholder_live_events/subagent_summary.rs
@@ -1,0 +1,69 @@
+//! TUI-parity `Done (N tools · M tokens · Xs)` summary formatting for finished
+//! subagent slots (#3086). Split out of `status_panel.rs` to keep that file
+//! within the placeholder_live_events namespace size cap.
+
+use crate::services::agent_protocol::SubagentSummary;
+
+/// Formats the TUI-parity `Done (N tools · M tokens · Xs)` summary. Each part is
+/// included only when present, so a partial summary still renders what it has.
+/// Returns `None` when no part is available.
+pub(super) fn render_subagent_done_summary(summary: &SubagentSummary) -> Option<String> {
+    let mut parts = Vec::new();
+    if let Some(count) = summary.tool_count {
+        let noun = if count == 1 { "tool" } else { "tools" };
+        parts.push(format!("{count} {noun}"));
+    }
+    if let Some(tokens) = summary.tokens {
+        parts.push(format!("{} tokens", format_compact_count(tokens)));
+    }
+    if let Some(secs) = summary.duration_secs {
+        parts.push(format_duration_secs(secs));
+    }
+    if parts.is_empty() {
+        return None;
+    }
+    Some(format!("Done ({})", parts.join(" · ")))
+}
+
+/// Compact count formatting mirroring the TUI (`28824` → `28.8k`, `1_500_000`
+/// → `1.5m`). Values under 1000 render verbatim.
+fn format_compact_count(value: u64) -> String {
+    if value < 1_000 {
+        return value.to_string();
+    }
+    if value < 1_000_000 {
+        let scaled = value as f64 / 1_000.0;
+        return format!("{}k", trim_one_decimal(scaled));
+    }
+    let scaled = value as f64 / 1_000_000.0;
+    format!("{}m", trim_one_decimal(scaled))
+}
+
+/// Renders a one-decimal number without a trailing `.0` (`28.8` stays,
+/// `19.0` → `19`).
+fn trim_one_decimal(value: f64) -> String {
+    let rounded = (value * 10.0).round() / 10.0;
+    if (rounded.fract()).abs() < f64::EPSILON {
+        format!("{}", rounded as u64)
+    } else {
+        format!("{rounded:.1}")
+    }
+}
+
+/// Humanizes a duration in seconds the way the TUI does: `45s`, `19m`, `1h2m`.
+fn format_duration_secs(secs: u64) -> String {
+    if secs < 60 {
+        return format!("{secs}s");
+    }
+    let minutes = secs / 60;
+    if minutes < 60 {
+        return format!("{minutes}m");
+    }
+    let hours = minutes / 60;
+    let rem_minutes = minutes % 60;
+    if rem_minutes == 0 {
+        format!("{hours}h")
+    } else {
+        format!("{hours}h{rem_minutes}m")
+    }
+}

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -1692,6 +1692,205 @@ fn status_panel_pairs_subagent_by_tool_use_id_despite_interleaving() {
     );
 }
 
+// Live subagent activity: a nested subagent record carries the launching Task's
+// id as a top-level `parent_tool_use_id`. Its tool step must surface on the
+// owning subagent slot (`└ type desc — [Tool] args`), not the panel header, so a
+// long (background) subagent is not an opaque "running".
+#[test]
+fn status_panel_shows_live_subagent_activity_by_parent_id() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(900);
+
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({"subagent_type": "general-purpose", "description": "Audit logs"}).to_string(),
+            Some("task-z"),
+        ),
+    );
+    // Nested subagent tool_use record (parent = the Task's id).
+    events.push_status_events(
+        channel_id,
+        status_events_from_json(&json!({
+            "type": "assistant",
+            "parent_tool_use_id": "task-z",
+            "message": {
+                "content": [{
+                    "type": "tool_use",
+                    "name": "Bash",
+                    "input": {"command": "grep ERROR app.log"}
+                }]
+            }
+        })),
+    );
+
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    assert!(rendered.contains("general-purpose Audit logs"));
+    assert!(
+        rendered.contains("[Bash]") && rendered.contains("grep ERROR app.log"),
+        "subagent activity line missing, got: {rendered}"
+    );
+    // Nested activity must NOT turn the panel header into a foreground tool run.
+    assert!(
+        !rendered.contains("🔧 도구 실행 중"),
+        "nested subagent step must not clobber the panel header, got: {rendered}"
+    );
+}
+
+// The activity line updates to the subagent's LATEST step on each new event.
+#[test]
+fn status_panel_subagent_activity_updates_to_latest_step() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(901);
+
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({"subagent_type": "explorer", "description": "Trace"}).to_string(),
+            Some("t1"),
+        ),
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_json(&json!({
+            "type": "assistant",
+            "parent_tool_use_id": "t1",
+            "message": {"content": [{"type": "tool_use", "name": "Read", "input": {"file_path": "/a"}}]}
+        })),
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_json(&json!({
+            "type": "assistant",
+            "parent_tool_use_id": "t1",
+            "message": {"content": [{"type": "tool_use", "name": "Grep", "input": {"pattern": "needle"}}]}
+        })),
+    );
+
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    assert!(
+        rendered.contains("[Grep]"),
+        "latest step missing, got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("[Read]"),
+        "stale step retained, got: {rendered}"
+    );
+}
+
+// #3198 safety: activity whose parent id matches a FINISHED slot must not
+// resurrect it (no re-mark, no recent line on a closed background subagent), and
+// an id-bearing activity that matches no slot is dropped, never mis-routed to an
+// unrelated running subagent.
+#[test]
+fn status_panel_subagent_activity_never_resurrects_or_misroutes() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(902);
+
+    // Slot A finished (foreground, closed by its ack).
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({"subagent_type": "alpha", "description": "Done work"}).to_string(),
+            Some("a"),
+        ),
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_result_with_id(Some("Task"), false, Some("a")),
+    );
+    // Slot B still running.
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({"subagent_type": "beta", "description": "Live work"}).to_string(),
+            Some("b"),
+        ),
+    );
+
+    // Late activity for the FINISHED slot A — must be ignored, not resurrected.
+    events.push_status_events(
+        channel_id,
+        status_events_from_json(&json!({
+            "type": "assistant",
+            "parent_tool_use_id": "a",
+            "message": {"content": [{"type": "tool_use", "name": "Bash", "input": {"command": "late-ghost"}}]}
+        })),
+    );
+    // Activity for an UNKNOWN id — must be dropped, not routed to slot B.
+    events.push_status_events(
+        channel_id,
+        status_events_from_json(&json!({
+            "type": "assistant",
+            "parent_tool_use_id": "ghost",
+            "message": {"content": [{"type": "tool_use", "name": "Bash", "input": {"command": "stray"}}]}
+        })),
+    );
+
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    assert!(
+        !rendered.contains("late-ghost"),
+        "finished slot must not be resurrected, got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("stray"),
+        "unmatched activity must not mis-route onto running slot B, got: {rendered}"
+    );
+}
+
+// A background subagent keeps running past its launch ack (#3198), and its live
+// activity surfaces on the still-open slot — exactly the visibility this feature
+// adds.
+#[test]
+fn status_panel_background_subagent_shows_live_activity_while_running() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(903);
+
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({
+                "subagent_type": "general-purpose",
+                "description": "Long background job",
+                "run_in_background": true
+            })
+            .to_string(),
+            Some("bg-1"),
+        ),
+    );
+    // Launch ack — background slot stays open (not ✓).
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_result_with_id(Some("Task"), false, Some("bg-1")),
+    );
+    // Live step from the still-running background subagent.
+    events.push_status_events(
+        channel_id,
+        status_events_from_json(&json!({
+            "type": "content_block_start",
+            "parent_tool_use_id": "bg-1",
+            "content_block": {"type": "tool_use", "name": "WebSearch", "input": {"query": "rust async"}}
+        })),
+    );
+
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    assert!(rendered.contains("general-purpose Long background job"));
+    assert!(
+        rendered.contains("[WebSearch]"),
+        "background subagent live activity missing, got: {rendered}"
+    );
+    // Still running — no completion marker yet.
+    assert!(
+        !rendered.contains('✓'),
+        "background subagent must not show ✓ on a launch ack, got: {rendered}"
+    );
+}
+
 // #3084: two parallel subagents whose results return in reverse order must each
 // close their own slot. The previous "first unfinished slot" logic closed the
 // wrong slot, mis-attributing success/failure across parallel subagents.


### PR DESCRIPTION
Closes #3204.

## Approach

The relay status-panel "Subagents" section previously showed each subagent's name + completed/running marker only — a long-running, especially `run_in_background`, subagent was an opaque "running". This relays each running subagent's **latest activity line** (current tool / step) live in the panel.

- **agent_protocol**: new `StatusEvent::SubagentActivity { tool_use_id, summary }`.
- **status_events**: when a stream record carries a top-level `parent_tool_use_id`, its nested `tool_use` blocks are routed to `SubagentActivity` (keyed by that parent id) instead of a top-level `ToolStart` — so a subagent's internal step does NOT clobber the main panel header.
- **status_panel**: `set_subagent_activity` matches the owning **unfinished** slot by parent id and updates its existing `recent` line. An id-bearing activity that matches no slot is dropped (never mis-routed onto an unrelated running subagent — mirrors the summary-bearing `SubagentEnd` rule). #3198 ack-only / background-finalize semantics are preserved: a finished or background-finalized slot is never resurrected or remarked.
- Render reuses the existing subagent line; no new section.

## Feasibility finding

**Per-subagent activity IS cleanly attributable** with no new provider plumbing. Claude Code's stream-json marks every subagent-internal record (`assistant` / `content_block_start`) with a top-level **`parent_tool_use_id`** = the launching Task's tool-use id. The panel already stores that id on each `SubagentSlot` (`tool_use_id`, #3084), so the signal is just routed to the right slot — IO-free, on the existing hot path. (Codex's subagent section is already gated off and it does not surface this field the same way, so this is Claude-stream-scoped; noted as a follow-up in the issue.)

## New panel line (in words)

Before — opaque:
```
Subagents
└ general-purpose Audit logs
```
After — live current step on the running slot:
```
Subagents
└ general-purpose Audit logs — [Bash] grep ERROR app.log
```
The activity updates to the latest step on each new event and a finished slot keeps its existing `✓ Done (N tools · M tokens · Xs)` rendering untouched.

## Namespace cap

`status_panel.rs` was at 699/700 LoC (the placeholder_live_events namespace cap). The four TUI-parity Done-summary formatters were extracted into a new `subagent_summary.rs` sibling, leaving `status_panel.rs` at 667 LoC.

## Verification

- `cargo build` clean (no new warnings).
- `cargo test --lib placeholder_live_events::` → 87 passed, 0 failed (4 new tests).
- `python3 scripts/audit_maintainability.py --check` → exit 0 (namespace cap respected).
- `python3 scripts/generate_inventory_docs.py` + `python3 scripts/check_agent_maintenance_docs.py --line-count-gate` → exit 0 (ARCHITECTURE.md tree updated for the new module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)