### PR TITLE
fix(#3208): defer follow-up input to queue on genuine-busy + JSONL-authoritative readiness (no idle false-busy)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -526,7 +526,7 @@
     from #3126 stall-watchdog completed-idle false-positive guard tests; +88
     from #3169 stall-watchdog jsonl-mtime liveness guard + tests, closing the
     Death #1 force-clean false-positive on loop mid-write sessions).
-  - `src/services/discord/router/message_handler/intake_turn.rs` (3719 lines;
+  - `src/services/discord/router/message_handler/intake_turn.rs` (3744 lines;
     Discord message intake turn orchestration split from the router message
     handler; bugfix only outside a further extraction plan; +9 from #3082
     queued-only answer-flush gate (`is_queued_notice` on the two

--- a/src/services/claude_tui/transcript_tail.rs
+++ b/src/services/claude_tui/transcript_tail.rs
@@ -107,8 +107,34 @@ pub fn latest_claude_transcript_for_cwd(
     claude_home: Option<&Path>,
     exclude: &std::collections::HashSet<PathBuf>,
 ) -> Option<PathBuf> {
-    let project_dirs = claude_project_dir_candidates_for_cwd(cwd, claude_home).ok()?;
-    let mut best: Option<(std::time::SystemTime, PathBuf)> = None;
+    claude_transcripts_for_cwd_since(cwd, modified_since, claude_home, exclude)
+        .into_iter()
+        .next()
+}
+
+/// #3212 (codex P1): like [`latest_claude_transcript_for_cwd`] but returns ALL
+/// qualifying `<uuid>.jsonl` transcripts under the cwd's Claude project dir(s),
+/// newest mtime first, instead of only the single newest. The follow-up
+/// readiness resolver needs the full candidate set so it can apply an
+/// *ambiguity guard*: when more than one same-cwd transcript qualifies (two
+/// concurrent same-cwd sessions) and there is no stronger per-session identity,
+/// picking the newest mtime is exactly the false-ready / false-busy bug — the
+/// caller refuses to guess. A single candidate is unambiguous and safe to adopt.
+///
+/// `modified_since` floors the result to transcripts at/after this session's
+/// launch (pass `UNIX_EPOCH` to disable); `exclude` drops transcripts already
+/// claimed by OTHER live sessions' bindings.
+pub fn claude_transcripts_for_cwd_since(
+    cwd: &Path,
+    modified_since: std::time::SystemTime,
+    claude_home: Option<&Path>,
+    exclude: &std::collections::HashSet<PathBuf>,
+) -> Vec<PathBuf> {
+    let Ok(project_dirs) = claude_project_dir_candidates_for_cwd(cwd, claude_home) else {
+        return Vec::new();
+    };
+    let mut found: Vec<(std::time::SystemTime, PathBuf)> = Vec::new();
+    let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
     for project_dir in project_dirs {
         let Ok(entries) = std::fs::read_dir(&project_dir) else {
             continue;
@@ -141,15 +167,18 @@ pub fn latest_claude_transcript_for_cwd(
             if modified < modified_since {
                 continue;
             }
-            if best
-                .as_ref()
-                .is_none_or(|(best_modified, _)| modified > *best_modified)
-            {
-                best = Some((modified, path));
+            // Canonical project-dir candidates can overlap (canonicalized vs
+            // raw cwd encode to the same dir); de-dup identical paths so a
+            // single physical transcript never inflates the candidate count and
+            // trips the ambiguity guard.
+            if !seen.insert(path.clone()) {
+                continue;
             }
+            found.push((modified, path));
         }
     }
-    best.map(|(_, path)| path)
+    found.sort_by(|(a, _), (b, _)| b.cmp(a));
+    found.into_iter().map(|(_, path)| path).collect()
 }
 
 pub fn replay_transcript_file(

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -2988,44 +2988,65 @@ pub(in crate::services::discord) async fn handle_text_message(
             session_id.as_deref(),
         );
         if let Some(initial_diagnostic) = initial {
-            let wait_session_name = initial_diagnostic.tmux_session_name.clone();
-            let wait_cancel_token = cancel_token.clone();
-            let wait_provider = provider.clone();
-            let wait_readiness = hosted_tui_busy_preflight_readiness_wait(
-                &wait_provider,
-                Some(&current_path),
-                session_id.as_deref(),
-            );
-            match &wait_readiness {
-                HostedTuiBusyPreflightReadinessWait::Codex => {
-                    tracing::debug!(
-                        channel_id = channel_id.get(),
-                        user_msg_id = user_msg_id.get(),
-                        tmux_session_name = %wait_session_name,
-                        "hosted tui busy preflight will wait for codex composer readiness"
-                    );
+            // #3208 (A): when the authoritative JSONL turn-state says the prior
+            // turn is genuinely in-flight (Streaming/UserSubmitted), do NOT
+            // enter the up-to-45s readiness poll — it would always time out
+            // (the prompt marker is suppressed for the whole agentic turn) and
+            // surface a misleading error after the response already landed.
+            // Route straight to the queue-defer path: the busy diagnostic is
+            // already correct, and the watcher idle signal delivers the queued
+            // input cleanly once the turn reaches Idle.
+            if initial_diagnostic.transcript_turn_state.is_busy() {
+                tracing::info!(
+                    channel_id = channel_id.get(),
+                    user_msg_id = user_msg_id.get(),
+                    tmux_session_name = %initial_diagnostic.tmux_session_name,
+                    transcript_turn_state = initial_diagnostic.transcript_turn_state.as_str(),
+                    "tui follow-up: prior turn genuinely busy per JSONL; deferring to queue without readiness poll"
+                );
+                Some(initial_diagnostic)
+            } else {
+                let wait_session_name = initial_diagnostic.tmux_session_name.clone();
+                let wait_cancel_token = cancel_token.clone();
+                let wait_provider = provider.clone();
+                let wait_readiness = hosted_tui_busy_preflight_readiness_wait(
+                    &wait_provider,
+                    Some(&current_path),
+                    session_id.as_deref(),
+                    tmux_session_name.as_deref(),
+                );
+                match &wait_readiness {
+                    HostedTuiBusyPreflightReadinessWait::Codex => {
+                        tracing::debug!(
+                            channel_id = channel_id.get(),
+                            user_msg_id = user_msg_id.get(),
+                            tmux_session_name = %wait_session_name,
+                            "hosted tui busy preflight will wait for codex composer readiness"
+                        );
+                    }
+                    HostedTuiBusyPreflightReadinessWait::ClaudePromptMarkerOrIdleTranscript(
+                        transcript_path,
+                    ) => {
+                        tracing::debug!(
+                            channel_id = channel_id.get(),
+                            user_msg_id = user_msg_id.get(),
+                            tmux_session_name = %wait_session_name,
+                            transcript_path = %transcript_path.display(),
+                            "hosted tui busy preflight will allow claude idle transcript readiness"
+                        );
+                    }
+                    HostedTuiBusyPreflightReadinessWait::ClaudePromptMarkerOnly => {
+                        tracing::debug!(
+                            channel_id = channel_id.get(),
+                            user_msg_id = user_msg_id.get(),
+                            tmux_session_name = %wait_session_name,
+                            "hosted tui busy preflight will require claude prompt marker readiness"
+                        );
+                    }
                 }
-                HostedTuiBusyPreflightReadinessWait::ClaudePromptMarkerOrIdleTranscript(
-                    transcript_path,
-                ) => {
-                    tracing::debug!(
-                        channel_id = channel_id.get(),
-                        user_msg_id = user_msg_id.get(),
-                        tmux_session_name = %wait_session_name,
-                        transcript_path = %transcript_path.display(),
-                        "hosted tui busy preflight will allow claude idle transcript readiness"
-                    );
-                }
-                HostedTuiBusyPreflightReadinessWait::ClaudePromptMarkerOnly => {
-                    tracing::debug!(
-                        channel_id = channel_id.get(),
-                        user_msg_id = user_msg_id.get(),
-                        tmux_session_name = %wait_session_name,
-                        "hosted tui busy preflight will require claude prompt marker readiness"
-                    );
-                }
-            }
-            let wait_result = tokio::task::spawn_blocking(move || match wait_readiness {
+                let wait_result =
+                    tokio::task::spawn_blocking(move || {
+                        match wait_readiness {
                 HostedTuiBusyPreflightReadinessWait::Codex => {
                     crate::services::codex_tui::input::wait_until_codex_tui_input_ready(
                         &wait_session_name,
@@ -3048,77 +3069,81 @@ pub(in crate::services::discord) async fn handle_text_message(
                         Some(wait_cancel_token.as_ref()),
                     )
                 }
-            })
-            .await
-            .unwrap_or_else(|join_err| {
-                Err(format!("wait_for_prompt_ready join error: {join_err}"))
-            });
-            let post_wait_diagnostic = tui_busy_followup_diagnostic(
-                shared,
-                &provider,
-                channel_id,
-                tmux_session_name.as_deref(),
-                remote_profile.is_some(),
-                Some(&current_path),
-                session_id.as_deref(),
-            );
-            // #2416: cancellation may have flipped during the up-to-45s wait
-            // (user stop reaction, watchdog, etc.). If it did, do NOT continue
-            // to inject the prompt — fall into the busy-notice / cleanup branch
-            // below by surfacing the initial diagnostic. Closes a Codex-flagged
-            // HIGH on the Discord path mirroring the same fix in claude.rs.
-            let cancel_observed_after_wait = cancel_token
-                .cancelled
-                .load(std::sync::atomic::Ordering::Relaxed);
-            match (
-                wait_result,
-                post_wait_diagnostic,
-                cancel_observed_after_wait,
-            ) {
-                (_, _, true) => {
-                    tracing::warn!(
-                        channel_id = channel_id.get(),
-                        user_msg_id = user_msg_id.get(),
-                        tmux_session_name = %initial_diagnostic.tmux_session_name,
-                        "claude_tui follow-up: cancellation observed after busy wait; aborting injection"
-                    );
-                    Some(initial_diagnostic)
-                }
-                (Ok(()), None, _) => {
-                    recapture_offset_after_busy_wait = true;
-                    tracing::info!(
-                        channel_id = channel_id.get(),
-                        user_msg_id = user_msg_id.get(),
-                        tmux_session_name = %initial_diagnostic.tmux_session_name,
-                        "claude_tui follow-up: busy at first check, became ready after wait_for_prompt_ready"
-                    );
-                    None
-                }
-                (Ok(()), Some(diag), _) => {
-                    tracing::warn!(
-                        channel_id = channel_id.get(),
-                        user_msg_id = user_msg_id.get(),
-                        "claude_tui follow-up: wait_for_prompt_ready returned Ok but post-wait diagnostic still busy"
-                    );
-                    Some(diag)
-                }
-                (Err(err), diag_opt, _) => {
-                    let timed_out = match &provider {
-                        ProviderKind::Codex => {
-                            crate::services::codex_tui::input::is_prompt_ready_timeout_error(&err)
-                        }
-                        _ => {
-                            crate::services::claude_tui::input::is_prompt_ready_timeout_error(&err)
-                        }
-                    };
-                    tracing::warn!(
-                        channel_id = channel_id.get(),
-                        user_msg_id = user_msg_id.get(),
-                        timed_out,
-                        error = %err,
-                        "claude_tui follow-up: wait_for_prompt_ready failed; emitting busy notice"
-                    );
-                    Some(diag_opt.unwrap_or(initial_diagnostic))
+            }
+                    })
+                    .await
+                    .unwrap_or_else(|join_err| {
+                        Err(format!("wait_for_prompt_ready join error: {join_err}"))
+                    });
+                let post_wait_diagnostic = tui_busy_followup_diagnostic(
+                    shared,
+                    &provider,
+                    channel_id,
+                    tmux_session_name.as_deref(),
+                    remote_profile.is_some(),
+                    Some(&current_path),
+                    session_id.as_deref(),
+                );
+                // #2416: cancellation may have flipped during the up-to-45s wait
+                // (user stop reaction, watchdog, etc.). If it did, do NOT continue
+                // to inject the prompt — fall into the busy-notice / cleanup branch
+                // below by surfacing the initial diagnostic. Closes a Codex-flagged
+                // HIGH on the Discord path mirroring the same fix in claude.rs.
+                let cancel_observed_after_wait = cancel_token
+                    .cancelled
+                    .load(std::sync::atomic::Ordering::Relaxed);
+                match (
+                    wait_result,
+                    post_wait_diagnostic,
+                    cancel_observed_after_wait,
+                ) {
+                    (_, _, true) => {
+                        tracing::warn!(
+                            channel_id = channel_id.get(),
+                            user_msg_id = user_msg_id.get(),
+                            tmux_session_name = %initial_diagnostic.tmux_session_name,
+                            "claude_tui follow-up: cancellation observed after busy wait; aborting injection"
+                        );
+                        Some(initial_diagnostic)
+                    }
+                    (Ok(()), None, _) => {
+                        recapture_offset_after_busy_wait = true;
+                        tracing::info!(
+                            channel_id = channel_id.get(),
+                            user_msg_id = user_msg_id.get(),
+                            tmux_session_name = %initial_diagnostic.tmux_session_name,
+                            "claude_tui follow-up: busy at first check, became ready after wait_for_prompt_ready"
+                        );
+                        None
+                    }
+                    (Ok(()), Some(diag), _) => {
+                        tracing::warn!(
+                            channel_id = channel_id.get(),
+                            user_msg_id = user_msg_id.get(),
+                            "claude_tui follow-up: wait_for_prompt_ready returned Ok but post-wait diagnostic still busy"
+                        );
+                        Some(diag)
+                    }
+                    (Err(err), diag_opt, _) => {
+                        let timed_out = match &provider {
+                            ProviderKind::Codex => {
+                                crate::services::codex_tui::input::is_prompt_ready_timeout_error(
+                                    &err,
+                                )
+                            }
+                            _ => crate::services::claude_tui::input::is_prompt_ready_timeout_error(
+                                &err,
+                            ),
+                        };
+                        tracing::warn!(
+                            channel_id = channel_id.get(),
+                            user_msg_id = user_msg_id.get(),
+                            timed_out,
+                            error = %err,
+                            "claude_tui follow-up: wait_for_prompt_ready failed; emitting busy notice"
+                        );
+                        Some(diag_opt.unwrap_or(initial_diagnostic))
+                    }
                 }
             }
         } else {

--- a/src/services/discord/router/message_handler/session_strategy_lifecycle_tests.rs
+++ b/src/services/discord/router/message_handler/session_strategy_lifecycle_tests.rs
@@ -462,6 +462,7 @@ fn claude_busy_preflight_uses_idle_transcript_wait_when_transcript_exists() {
         None,
         Some(claude_home.path()),
         None,
+        Some(std::time::SystemTime::UNIX_EPOCH),
     );
 
     assert_eq!(
@@ -484,6 +485,7 @@ fn claude_busy_preflight_falls_back_when_transcript_is_unavailable() {
             None,
             Some(claude_home.path()),
             None,
+            Some(std::time::SystemTime::UNIX_EPOCH),
         ),
         HostedTuiBusyPreflightReadinessWait::ClaudePromptMarkerOnly
     );
@@ -495,6 +497,7 @@ fn claude_busy_preflight_falls_back_when_transcript_is_unavailable() {
             None,
             Some(claude_home.path()),
             None,
+            Some(std::time::SystemTime::UNIX_EPOCH),
         ),
         HostedTuiBusyPreflightReadinessWait::ClaudePromptMarkerOnly
     );
@@ -506,6 +509,7 @@ fn claude_busy_preflight_falls_back_when_transcript_is_unavailable() {
             None,
             Some(claude_home.path()),
             None,
+            Some(std::time::SystemTime::UNIX_EPOCH),
         ),
         HostedTuiBusyPreflightReadinessWait::ClaudePromptMarkerOnly
     );
@@ -520,6 +524,7 @@ fn codex_busy_preflight_keeps_codex_readiness_wait() {
         &ProviderKind::Codex,
         cwd.path().to_str(),
         Some("01234567-89ab-cdef-0123-456789abcdef"),
+        None,
         None,
         None,
         None,
@@ -971,6 +976,7 @@ fn claude_busy_preflight_resolves_worktree_transcript_when_session_id_missing() 
         Some(worktree.path()),
         Some(claude_home.path()),
         None,
+        Some(std::time::SystemTime::UNIX_EPOCH),
     );
     assert_eq!(
         wait_strategy,
@@ -1129,7 +1135,7 @@ fn resolver_runtime_binding_beats_newer_same_cwd_other_session() {
         Some(cwd.path()),
         Some(claude_home.path()),
         Some(&binding),
-        std::time::SystemTime::UNIX_EPOCH,
+        Some(std::time::SystemTime::UNIX_EPOCH),
         &std::collections::HashSet::new(),
     );
     assert_eq!(
@@ -1178,7 +1184,7 @@ fn resolver_rejects_pre_launch_stale_transcript_via_cutoff() {
         Some(cwd.path()),
         Some(claude_home.path()),
         None,
-        launch_cutoff,
+        Some(launch_cutoff),
         &std::collections::HashSet::new(),
     );
     assert_eq!(
@@ -1194,7 +1200,7 @@ fn resolver_rejects_pre_launch_stale_transcript_via_cutoff() {
         Some(cwd.path()),
         Some(claude_home.path()),
         None,
-        std::time::SystemTime::UNIX_EPOCH,
+        Some(std::time::SystemTime::UNIX_EPOCH),
         &std::collections::HashSet::new(),
     );
     assert_eq!(resolved_no_cutoff.as_deref(), Some(stale.as_path()));
@@ -1232,7 +1238,7 @@ fn resolver_runtime_binding_beats_stale_exact_session_id_match() {
         Some(cwd.path()),
         Some(claude_home.path()),
         Some(&binding),
-        std::time::SystemTime::UNIX_EPOCH,
+        Some(std::time::SystemTime::UNIX_EPOCH),
         &std::collections::HashSet::new(),
     );
     assert_eq!(
@@ -1272,7 +1278,7 @@ fn resolver_ambiguous_multi_uuid_same_cwd_refuses_to_guess() {
         Some(cwd.path()),
         Some(claude_home.path()),
         None,
-        std::time::SystemTime::UNIX_EPOCH,
+        Some(std::time::SystemTime::UNIX_EPOCH),
         &std::collections::HashSet::new(),
     );
     assert_eq!(
@@ -1289,7 +1295,7 @@ fn resolver_ambiguous_multi_uuid_same_cwd_refuses_to_guess() {
         Some(cwd.path()),
         Some(claude_home.path()),
         None,
-        std::time::SystemTime::UNIX_EPOCH,
+        Some(std::time::SystemTime::UNIX_EPOCH),
         &exclude,
     );
     assert_eq!(
@@ -1297,4 +1303,134 @@ fn resolver_ambiguous_multi_uuid_same_cwd_refuses_to_guess() {
         Some(a.as_path()),
         "excluding the other live session's transcript disambiguates the cwd fallback"
     );
+}
+
+// #3212 (codex P1-2) RED→GREEN: the pane_cwd holds TWO qualifying transcripts
+// (ambiguous concurrent sessions) while a DIFFERENT current_path holds a single
+// candidate. The old per-cwd `continue` fell through past the ambiguous pane_cwd
+// and adopted the lone current_path transcript. The hard ambiguity guard must
+// instead collect candidates across BOTH cwds and return None — never guess.
+#[cfg(unix)]
+#[test]
+fn resolver_pane_cwd_ambiguous_must_not_fall_through_to_current_path() {
+    let claude_home = tempfile::tempdir().expect("claude home");
+    let pane = tempfile::tempdir().expect("pane cwd");
+    let workspace = tempfile::tempdir().expect("workspace cwd");
+
+    // Two concurrent same-cwd transcripts under the pane cwd → ambiguous.
+    let pane_a = write_busy_claude_transcript(
+        claude_home.path(),
+        pane.path(),
+        "88888888-8888-8888-8888-888888888888",
+    );
+    let pane_b = write_idle_claude_transcript(
+        claude_home.path(),
+        pane.path(),
+        "99999999-9999-9999-9999-999999999999",
+    );
+    // A single (lone) candidate under the configured workspace cwd.
+    let ws_only = write_idle_claude_transcript(
+        claude_home.path(),
+        workspace.path(),
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    );
+    let base = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+    pin_mtime(&pane_a, base);
+    pin_mtime(&pane_b, base + std::time::Duration::from_secs(60));
+    pin_mtime(&ws_only, base + std::time::Duration::from_secs(120));
+
+    let resolved = resolve_claude_followup_transcript_path_with_identity(
+        workspace.path().to_str(),
+        None,
+        Some(pane.path()),
+        Some(claude_home.path()),
+        None,
+        Some(std::time::SystemTime::UNIX_EPOCH),
+        &std::collections::HashSet::new(),
+    );
+    assert_eq!(
+        resolved, None,
+        "ambiguous pane_cwd must hard-stop, not fall through and adopt the lone current_path candidate"
+    );
+}
+
+// #3212 (codex P1-1) GREEN: a SINGLE post-launch candidate (newer than the
+// launch cutoff) with no binding/UUID IS adopted — the legitimate JSONL benefit
+// is retained for the common single-session resume case.
+#[cfg(unix)]
+#[test]
+fn resolver_adopts_single_post_launch_candidate() {
+    let claude_home = tempfile::tempdir().expect("claude home");
+    let cwd = tempfile::tempdir().expect("cwd");
+
+    let live = write_idle_claude_transcript(
+        claude_home.path(),
+        cwd.path(),
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+    );
+    let base = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+    // Session launched BEFORE the transcript was last written → qualifies.
+    let launch_cutoff = base - std::time::Duration::from_secs(60);
+    pin_mtime(&live, base);
+
+    let resolved = resolve_claude_followup_transcript_path_with_identity(
+        cwd.path().to_str(),
+        None,
+        Some(cwd.path()),
+        Some(claude_home.path()),
+        None,
+        Some(launch_cutoff),
+        &std::collections::HashSet::new(),
+    );
+    assert_eq!(
+        resolved.as_deref(),
+        Some(live.as_path()),
+        "a single candidate newer than this session's launch is unambiguous and must be adopted"
+    );
+}
+
+// #3212 (codex P1-1) RED→GREEN: when the launch cutoff CANNOT be obtained
+// (`None`), the cwd-mtime fallback is disabled entirely — an unverified single
+// candidate must NOT be adopted (accept false-busy over false-ready). Stronger
+// identities are absent here, so the resolver returns None.
+#[cfg(unix)]
+#[test]
+fn resolver_conservative_none_when_launch_cutoff_unavailable() {
+    let claude_home = tempfile::tempdir().expect("claude home");
+    let cwd = tempfile::tempdir().expect("cwd");
+
+    let candidate = write_idle_claude_transcript(
+        claude_home.path(),
+        cwd.path(),
+        "cccccccc-cccc-cccc-cccc-cccccccccccc",
+    );
+    let base = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+    pin_mtime(&candidate, base);
+
+    let resolved = resolve_claude_followup_transcript_path_with_identity(
+        cwd.path().to_str(),
+        None,
+        Some(cwd.path()),
+        Some(claude_home.path()),
+        None,
+        None,
+        &std::collections::HashSet::new(),
+    );
+    assert_eq!(
+        resolved, None,
+        "no reliable launch time → must not adopt an unverified cwd candidate (false-ready guard)"
+    );
+
+    // Sanity: WITH a permissive cutoff the same single candidate IS adopted —
+    // proving the None above is the conservative-cutoff guard, not a missing dir.
+    let resolved_with_cutoff = resolve_claude_followup_transcript_path_with_identity(
+        cwd.path().to_str(),
+        None,
+        Some(cwd.path()),
+        Some(claude_home.path()),
+        None,
+        Some(std::time::SystemTime::UNIX_EPOCH),
+        &std::collections::HashSet::new(),
+    );
+    assert_eq!(resolved_with_cutoff.as_deref(), Some(candidate.as_path()));
 }

--- a/src/services/discord/router/message_handler/session_strategy_lifecycle_tests.rs
+++ b/src/services/discord/router/message_handler/session_strategy_lifecycle_tests.rs
@@ -459,6 +459,7 @@ fn claude_busy_preflight_uses_idle_transcript_wait_when_transcript_exists() {
         &ProviderKind::Claude,
         cwd.path().to_str(),
         Some(session_id),
+        None,
         Some(claude_home.path()),
     );
 
@@ -479,6 +480,7 @@ fn claude_busy_preflight_falls_back_when_transcript_is_unavailable() {
             &ProviderKind::Claude,
             cwd.path().to_str(),
             None,
+            None,
             Some(claude_home.path()),
         ),
         HostedTuiBusyPreflightReadinessWait::ClaudePromptMarkerOnly
@@ -488,6 +490,7 @@ fn claude_busy_preflight_falls_back_when_transcript_is_unavailable() {
             &ProviderKind::Claude,
             cwd.path().to_str(),
             Some("not-a-uuid"),
+            None,
             Some(claude_home.path()),
         ),
         HostedTuiBusyPreflightReadinessWait::ClaudePromptMarkerOnly
@@ -497,6 +500,7 @@ fn claude_busy_preflight_falls_back_when_transcript_is_unavailable() {
             &ProviderKind::Claude,
             cwd.path().to_str(),
             Some("01234567-89ab-cdef-0123-456789abcdef"),
+            None,
             Some(claude_home.path()),
         ),
         HostedTuiBusyPreflightReadinessWait::ClaudePromptMarkerOnly
@@ -512,6 +516,7 @@ fn codex_busy_preflight_keeps_codex_readiness_wait() {
         &ProviderKind::Codex,
         cwd.path().to_str(),
         Some("01234567-89ab-cdef-0123-456789abcdef"),
+        None,
         None,
     );
 
@@ -885,5 +890,146 @@ fn provider_worktree_isolation_policy_bypasses_review_e2e_and_consultation_dispa
             !should_force_provider_worktree_isolation(true, None, Some(dispatch_type)),
             "{dispatch_type} dispatches should bypass provider-channel isolation"
         );
+    }
+}
+
+// #3208 — helper: write a Claude JSONL transcript for `<cwd>` under a temp
+// claude_home, returning the resolved transcript path. The transcript ends with
+// a `system/turn_duration` terminator → `observe_*` classifies it as `Idle`.
+#[cfg(unix)]
+fn write_idle_claude_transcript(
+    claude_home: &std::path::Path,
+    cwd: &std::path::Path,
+    session_id: &str,
+) -> std::path::PathBuf {
+    let path = crate::services::claude_tui::transcript_tail::claude_transcript_path(
+        cwd,
+        session_id,
+        Some(claude_home),
+    )
+    .expect("resolve transcript path");
+    std::fs::create_dir_all(path.parent().expect("transcript parent"))
+        .expect("create transcript parent");
+    std::fs::write(
+        &path,
+        concat!(
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"done"}]},"timestamp":"2026-06-07T07:29:12Z"}"#,
+            "\n",
+            r#"{"type":"system","subtype":"turn_duration","durationMs":142231,"pendingBackgroundAgentCount":5,"timestamp":"2026-06-07T07:29:13Z"}"#,
+            "\n",
+        ),
+    )
+    .expect("write transcript");
+    path
+}
+
+// #3208 (B): a genuinely-idle TUI whose live session runs in a *rotating
+// worktree* (pane_cwd) — distinct from the channel's configured workspace
+// (current_path) — and whose Claude session_id is NOT carried into intake (the
+// common `runtime_cached_provider_session` resume case). The preflight readiness
+// resolver MUST find the worktree transcript via the pane cwd and engage the
+// idle-JSONL fallback (ClaudePromptMarkerOrIdleTranscript) instead of falling
+// back to the prompt-marker-only wait that times out at 45s while the screen
+// shows "Waiting for N background agents to finish".
+#[cfg(unix)]
+#[test]
+fn claude_busy_preflight_resolves_worktree_transcript_when_session_id_missing() {
+    let claude_home = tempfile::tempdir().expect("create temp claude home");
+    let workspace = tempfile::tempdir().expect("create temp workspace cwd");
+    let worktree = tempfile::tempdir().expect("create temp worktree cwd");
+    // The running session writes its transcript under the WORKTREE project dir.
+    let worktree_transcript = write_idle_claude_transcript(
+        claude_home.path(),
+        worktree.path(),
+        "6a053a02-fd2d-4329-b421-9f49eb7d5683",
+    );
+
+    // Resolver must locate the worktree transcript even with session_id=None and
+    // current_path pointing at the (empty) configured workspace.
+    let resolved = resolve_claude_followup_transcript_path(
+        workspace.path().to_str(),
+        None,
+        Some(worktree.path()),
+        Some(claude_home.path()),
+    );
+    assert_eq!(
+        resolved.as_deref(),
+        Some(worktree_transcript.as_path()),
+        "resolver must adopt the worktree transcript via pane cwd"
+    );
+
+    // And the preflight wait must therefore allow the idle-transcript fallback.
+    let wait_strategy = hosted_tui_busy_preflight_readiness_wait_with_claude_home(
+        &ProviderKind::Claude,
+        workspace.path().to_str(),
+        None,
+        Some(worktree.path()),
+        Some(claude_home.path()),
+    );
+    assert_eq!(
+        wait_strategy,
+        HostedTuiBusyPreflightReadinessWait::ClaudePromptMarkerOrIdleTranscript(
+            worktree_transcript
+        ),
+        "idle worktree transcript must engage the JSONL fallback, not prompt-marker-only"
+    );
+}
+
+// #3208 (B): the resolved worktree transcript (turn ended; background agents
+// still running) must observe as Idle — a genuinely-idle TUI must never be
+// classified busy. This is the false-busy that produced the 45s timeout.
+#[cfg(unix)]
+#[test]
+fn claude_idle_worktree_transcript_observes_idle_not_busy() {
+    let claude_home = tempfile::tempdir().expect("create temp claude home");
+    let worktree = tempfile::tempdir().expect("create temp worktree cwd");
+    let transcript = write_idle_claude_transcript(
+        claude_home.path(),
+        worktree.path(),
+        "6a053a02-fd2d-4329-b421-9f49eb7d5683",
+    );
+
+    let provider = ProviderKind::Claude;
+    let probe = crate::services::tui_turn_state::JsonlTurnStateProbe::new(&provider, &transcript);
+    let state = crate::services::tui_turn_state::TuiTurnStateProbe::observe(&probe);
+    assert_eq!(
+        state,
+        crate::services::tui_turn_state::TuiTurnState::Idle,
+        "turn_duration terminator with pending background agents is Idle, not busy"
+    );
+    assert!(!state.is_busy());
+}
+
+// #3208 (A): when the prior turn is genuinely in-flight (authoritative JSONL
+// Streaming/UserSubmitted), the follow-up classifier flags a busy diagnostic
+// with `previous_tui_turn_still_running=true`. The intake layer routes this to
+// the queue-defer path WITHOUT entering the 45s readiness poll (gated on
+// `transcript_turn_state.is_busy()`), so no readiness-timeout error surfaces.
+#[cfg(unix)]
+#[test]
+fn claude_busy_followup_defers_to_queue_without_readiness_poll() {
+    for busy in [
+        crate::services::tui_turn_state::TuiTurnState::Streaming,
+        crate::services::tui_turn_state::TuiTurnState::UserSubmitted,
+    ] {
+        assert!(
+            busy.is_busy(),
+            "{busy:?} must be the gate that skips the 45s readiness poll"
+        );
+        let snapshot = HostedTuiPromptReadinessSnapshot::jsonl_authoritative(true);
+        let diagnostic = classify_claude_tui_followup_submission(
+            &snapshot,
+            "attached",
+            None,
+            "missing",
+            busy,
+            "AgentDesk-claude-adk-cc",
+        )
+        .expect("busy turn must yield a defer diagnostic");
+        assert!(
+            diagnostic.previous_tui_turn_still_running,
+            "genuine busy turn must mark previous_tui_turn_still_running"
+        );
+        assert_eq!(diagnostic.transcript_turn_state, busy);
     }
 }

--- a/src/services/discord/router/message_handler/session_strategy_lifecycle_tests.rs
+++ b/src/services/discord/router/message_handler/session_strategy_lifecycle_tests.rs
@@ -461,6 +461,7 @@ fn claude_busy_preflight_uses_idle_transcript_wait_when_transcript_exists() {
         Some(session_id),
         None,
         Some(claude_home.path()),
+        None,
     );
 
     assert_eq!(
@@ -482,6 +483,7 @@ fn claude_busy_preflight_falls_back_when_transcript_is_unavailable() {
             None,
             None,
             Some(claude_home.path()),
+            None,
         ),
         HostedTuiBusyPreflightReadinessWait::ClaudePromptMarkerOnly
     );
@@ -492,6 +494,7 @@ fn claude_busy_preflight_falls_back_when_transcript_is_unavailable() {
             Some("not-a-uuid"),
             None,
             Some(claude_home.path()),
+            None,
         ),
         HostedTuiBusyPreflightReadinessWait::ClaudePromptMarkerOnly
     );
@@ -502,6 +505,7 @@ fn claude_busy_preflight_falls_back_when_transcript_is_unavailable() {
             Some("01234567-89ab-cdef-0123-456789abcdef"),
             None,
             Some(claude_home.path()),
+            None,
         ),
         HostedTuiBusyPreflightReadinessWait::ClaudePromptMarkerOnly
     );
@@ -516,6 +520,7 @@ fn codex_busy_preflight_keeps_codex_readiness_wait() {
         &ProviderKind::Codex,
         cwd.path().to_str(),
         Some("01234567-89ab-cdef-0123-456789abcdef"),
+        None,
         None,
         None,
     );
@@ -965,6 +970,7 @@ fn claude_busy_preflight_resolves_worktree_transcript_when_session_id_missing() 
         None,
         Some(worktree.path()),
         Some(claude_home.path()),
+        None,
     );
     assert_eq!(
         wait_strategy,
@@ -1032,4 +1038,263 @@ fn claude_busy_followup_defers_to_queue_without_readiness_poll() {
         );
         assert_eq!(diagnostic.transcript_turn_state, busy);
     }
+}
+
+// #3212 — helper: write a BUSY Claude JSONL transcript (last meaningful
+// envelope is `assistant` with no terminator) → `observe_*` classifies it as
+// `Streaming` (busy). Used to model a concurrent still-running session.
+#[cfg(unix)]
+fn write_busy_claude_transcript(
+    claude_home: &std::path::Path,
+    cwd: &std::path::Path,
+    session_id: &str,
+) -> std::path::PathBuf {
+    let path = crate::services::claude_tui::transcript_tail::claude_transcript_path(
+        cwd,
+        session_id,
+        Some(claude_home),
+    )
+    .expect("resolve transcript path");
+    std::fs::create_dir_all(path.parent().expect("transcript parent"))
+        .expect("create transcript parent");
+    std::fs::write(
+        &path,
+        concat!(
+            r#"{"type":"user","message":{"content":[{"type":"text","text":"go"}]},"timestamp":"2026-06-07T07:30:00Z"}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"working"}]},"timestamp":"2026-06-07T07:30:01Z"}"#,
+            "\n",
+        ),
+    )
+    .expect("write busy transcript");
+    path
+}
+
+#[cfg(unix)]
+fn pin_mtime(path: &std::path::Path, mtime: std::time::SystemTime) {
+    std::fs::File::options()
+        .write(true)
+        .open(path)
+        .expect("open transcript for mtime pin")
+        .set_modified(mtime)
+        .expect("set transcript mtime");
+}
+
+#[cfg(unix)]
+fn claude_runtime_binding(
+    output_path: &std::path::Path,
+) -> crate::services::tui_prompt_dedupe::TuiRuntimeBinding {
+    crate::services::tui_prompt_dedupe::TuiRuntimeBinding {
+        runtime_kind: crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui,
+        output_path: output_path.display().to_string(),
+        relay_output_path: None,
+        input_fifo_path: None,
+        session_id: None,
+        last_offset: 0,
+        relay_last_offset: None,
+    }
+}
+
+// #3212 (codex P1) RED→GREEN: two distinct-UUID Claude transcripts live in the
+// SAME cwd (two concurrent same-cwd sessions). With no per-session identity the
+// old resolver returned the newest-mtime transcript — the OTHER session's. The
+// runtime binding pins this session's transcript, so the resolver MUST return
+// the bound one even though it is the OLDER of the two.
+#[cfg(unix)]
+#[test]
+fn resolver_runtime_binding_beats_newer_same_cwd_other_session() {
+    let claude_home = tempfile::tempdir().expect("claude home");
+    let cwd = tempfile::tempdir().expect("cwd");
+
+    // THIS session's transcript (bound) — older mtime.
+    let mine = write_busy_claude_transcript(
+        claude_home.path(),
+        cwd.path(),
+        "11111111-1111-1111-1111-111111111111",
+    );
+    // OTHER concurrent session in the same cwd — NEWER mtime, and Idle (finished).
+    let other = write_idle_claude_transcript(
+        claude_home.path(),
+        cwd.path(),
+        "22222222-2222-2222-2222-222222222222",
+    );
+    let base = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+    pin_mtime(&mine, base);
+    pin_mtime(&other, base + std::time::Duration::from_secs(60));
+
+    let binding = claude_runtime_binding(&mine);
+    let resolved = resolve_claude_followup_transcript_path_with_identity(
+        cwd.path().to_str(),
+        None,
+        Some(cwd.path()),
+        Some(claude_home.path()),
+        Some(&binding),
+        std::time::SystemTime::UNIX_EPOCH,
+        &std::collections::HashSet::new(),
+    );
+    assert_eq!(
+        resolved.as_deref(),
+        Some(mine.as_path()),
+        "runtime binding identity must win over the newer other-session transcript"
+    );
+
+    // And the resolved (this-session) transcript observes BUSY — so a follow-up
+    // is correctly deferred, NOT injected because the other session went idle.
+    let provider = ProviderKind::Claude;
+    let probe = crate::services::tui_turn_state::JsonlTurnStateProbe::new(
+        &provider,
+        resolved.as_ref().unwrap(),
+    );
+    let state = crate::services::tui_turn_state::TuiTurnStateProbe::observe(&probe);
+    assert!(
+        state.is_busy(),
+        "this session is still busy; resolving the idle other-session transcript would false-ready"
+    );
+}
+
+// #3212 RED→GREEN: a NEWER stale/other-session transcript whose mtime predates
+// this session's launch must be rejected by the launch-mtime cutoff. With no
+// runtime binding and only a stale candidate, the resolver returns None rather
+// than adopting the prior session's transcript.
+#[cfg(unix)]
+#[test]
+fn resolver_rejects_pre_launch_stale_transcript_via_cutoff() {
+    let claude_home = tempfile::tempdir().expect("claude home");
+    let cwd = tempfile::tempdir().expect("cwd");
+
+    let stale = write_idle_claude_transcript(
+        claude_home.path(),
+        cwd.path(),
+        "33333333-3333-3333-3333-333333333333",
+    );
+    let base = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+    pin_mtime(&stale, base);
+    // Session launched AFTER the stale transcript was last written.
+    let launch_cutoff = base + std::time::Duration::from_secs(300);
+
+    let resolved = resolve_claude_followup_transcript_path_with_identity(
+        cwd.path().to_str(),
+        None,
+        Some(cwd.path()),
+        Some(claude_home.path()),
+        None,
+        launch_cutoff,
+        &std::collections::HashSet::new(),
+    );
+    assert_eq!(
+        resolved, None,
+        "a transcript older than this session's launch belongs to a prior session and must not be adopted"
+    );
+
+    // Sanity: WITHOUT the cutoff (UNIX_EPOCH), the single candidate is adopted —
+    // proving the None above is the cutoff guard, not a missing project dir.
+    let resolved_no_cutoff = resolve_claude_followup_transcript_path_with_identity(
+        cwd.path().to_str(),
+        None,
+        Some(cwd.path()),
+        Some(claude_home.path()),
+        None,
+        std::time::SystemTime::UNIX_EPOCH,
+        &std::collections::HashSet::new(),
+    );
+    assert_eq!(resolved_no_cutoff.as_deref(), Some(stale.as_path()));
+}
+
+// #3212 RED→GREEN: an EXISTING stale transcript at the exact
+// (current_path, session_id) path must NOT short-circuit the happy path when a
+// runtime binding points at the real (different) live transcript. The binding's
+// per-session identity is authoritative and must beat the stale exact-match.
+#[cfg(unix)]
+#[test]
+fn resolver_runtime_binding_beats_stale_exact_session_id_match() {
+    let claude_home = tempfile::tempdir().expect("claude home");
+    let cwd = tempfile::tempdir().expect("cwd");
+    let session_id = "44444444-4444-4444-4444-444444444444";
+
+    // Stale transcript at the exact (cwd, session_id) location (a prior run that
+    // reused this session_id, now finished/idle).
+    let stale_exact = write_idle_claude_transcript(claude_home.path(), cwd.path(), session_id);
+    // The actual live transcript the watcher is bound to (different UUID, busy).
+    let live = write_busy_claude_transcript(
+        claude_home.path(),
+        cwd.path(),
+        "55555555-5555-5555-5555-555555555555",
+    );
+    let base = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+    // Make the stale exact-match the NEWER file to stress that mtime alone is wrong.
+    pin_mtime(&live, base);
+    pin_mtime(&stale_exact, base + std::time::Duration::from_secs(60));
+
+    let binding = claude_runtime_binding(&live);
+    let resolved = resolve_claude_followup_transcript_path_with_identity(
+        cwd.path().to_str(),
+        Some(session_id),
+        Some(cwd.path()),
+        Some(claude_home.path()),
+        Some(&binding),
+        std::time::SystemTime::UNIX_EPOCH,
+        &std::collections::HashSet::new(),
+    );
+    assert_eq!(
+        resolved.as_deref(),
+        Some(live.as_path()),
+        "runtime binding must beat the stale exact (current_path, session_id) match"
+    );
+}
+
+// #3212 RED→GREEN: two concurrent same-cwd transcripts, NO runtime binding and
+// NO usable session_id (the production resume case). The resolver must refuse to
+// guess (ambiguity guard → None) rather than pick the newest mtime, which could
+// be a finished other-session (false-ready) or another busy turn (wrong queue).
+#[cfg(unix)]
+#[test]
+fn resolver_ambiguous_multi_uuid_same_cwd_refuses_to_guess() {
+    let claude_home = tempfile::tempdir().expect("claude home");
+    let cwd = tempfile::tempdir().expect("cwd");
+
+    let a = write_busy_claude_transcript(
+        claude_home.path(),
+        cwd.path(),
+        "66666666-6666-6666-6666-666666666666",
+    );
+    let b = write_idle_claude_transcript(
+        claude_home.path(),
+        cwd.path(),
+        "77777777-7777-7777-7777-777777777777",
+    );
+    let base = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000);
+    pin_mtime(&a, base);
+    pin_mtime(&b, base + std::time::Duration::from_secs(60));
+
+    let resolved = resolve_claude_followup_transcript_path_with_identity(
+        cwd.path().to_str(),
+        None,
+        Some(cwd.path()),
+        Some(claude_home.path()),
+        None,
+        std::time::SystemTime::UNIX_EPOCH,
+        &std::collections::HashSet::new(),
+    );
+    assert_eq!(
+        resolved, None,
+        "two same-cwd candidates with no identity is ambiguous; guessing newest is the P1 bug"
+    );
+
+    // Excluding the other session's claimed transcript collapses to a single
+    // unambiguous candidate → the resolver may then safely adopt it.
+    let exclude: std::collections::HashSet<std::path::PathBuf> = [b.clone()].into_iter().collect();
+    let resolved_excluded = resolve_claude_followup_transcript_path_with_identity(
+        cwd.path().to_str(),
+        None,
+        Some(cwd.path()),
+        Some(claude_home.path()),
+        None,
+        std::time::SystemTime::UNIX_EPOCH,
+        &exclude,
+    );
+    assert_eq!(
+        resolved_excluded.as_deref(),
+        Some(a.as_path()),
+        "excluding the other live session's transcript disambiguates the cwd fallback"
+    );
 }

--- a/src/services/discord/router/message_handler/tui_followup.rs
+++ b/src/services/discord/router/message_handler/tui_followup.rs
@@ -156,17 +156,88 @@ pub(super) fn hosted_tui_draft_should_enter_provider_recovery(
         && snapshot.prompt_draft_detected
 }
 
+/// #3208: resolve the JSONL transcript for the Claude TUI session that is
+/// *actually* serving this channel's tmux session.
+///
+/// The naive resolution `claude_transcript_path(current_path, session_id)` is
+/// brittle in production:
+///   - `session_id` is frequently `None` / a non-UUID fingerprint on the
+///     Discord follow-up path (sessions resume via `runtime_cached_provider_session`
+///     and the real Claude session_id UUID is never carried into intake).
+///   - `current_path` is the channel's *configured* workspace, but the live TUI
+///     often runs in a rotating worktree (`worktrees/claude-adk-cc-<ts>`) — the
+///     DB-restored worktree cwd is ignored at turn start. The workspace project
+///     dir then holds only stale transcripts, so the probe reads `Unknown` (or a
+///     stale `Idle`), and the screen-marker fallback false-flags a genuinely
+///     idle (background-agents-running) turn as busy → the 45s readiness
+///     timeout in #3208.
+///
+/// Resolution order:
+///   1. `claude_transcript_path(current_path, session_id)` when it both has a
+///      valid UUID and the file exists (the happy path).
+///   2. newest UUID transcript under the live tmux pane's *actual* cwd
+///      (`pane_cwd`) — this is the worktree the running session writes to.
+///   3. newest UUID transcript under `current_path` (workspace) as a last
+///      resort.
+#[cfg(unix)]
+pub(super) fn resolve_claude_followup_transcript_path(
+    current_path: Option<&str>,
+    session_id: Option<&str>,
+    pane_cwd: Option<&std::path::Path>,
+    claude_home: Option<&std::path::Path>,
+) -> Option<std::path::PathBuf> {
+    use std::collections::HashSet;
+
+    if let (Some(current_path), Some(session_id)) = (current_path, session_id)
+        && let Ok(path) = crate::services::claude_tui::transcript_tail::claude_transcript_path(
+            std::path::Path::new(current_path),
+            session_id,
+            claude_home,
+        )
+        && path.exists()
+    {
+        return Some(path);
+    }
+
+    let exclude: HashSet<std::path::PathBuf> = HashSet::new();
+    let mut candidate_cwds: Vec<std::path::PathBuf> = Vec::new();
+    if let Some(pane_cwd) = pane_cwd {
+        candidate_cwds.push(pane_cwd.to_path_buf());
+    }
+    if let Some(current_path) = current_path {
+        let workspace = std::path::PathBuf::from(current_path);
+        if !candidate_cwds.contains(&workspace) {
+            candidate_cwds.push(workspace);
+        }
+    }
+    for cwd in candidate_cwds {
+        if let Some(path) =
+            crate::services::claude_tui::transcript_tail::latest_claude_transcript_for_cwd(
+                &cwd,
+                std::time::SystemTime::UNIX_EPOCH,
+                claude_home,
+                &exclude,
+            )
+        {
+            return Some(path);
+        }
+    }
+    None
+}
+
 #[cfg(unix)]
 pub(super) fn observe_claude_tui_transcript_state_for_session(
     current_path: Option<&str>,
     session_id: Option<&str>,
+    tmux_session_name: Option<&str>,
 ) -> crate::services::tui_turn_state::TuiTurnState {
-    let (Some(current_path), Some(session_id)) = (current_path, session_id) else {
-        return crate::services::tui_turn_state::TuiTurnState::Unknown;
-    };
-    let Ok(transcript_path) = crate::services::claude_tui::transcript_tail::claude_transcript_path(
-        std::path::Path::new(current_path),
+    let pane_cwd = tmux_session_name
+        .and_then(crate::services::tmux_diagnostics::tmux_session_pane_cwd)
+        .map(std::path::PathBuf::from);
+    let Some(transcript_path) = resolve_claude_followup_transcript_path(
+        current_path,
         session_id,
+        pane_cwd.as_deref(),
         None,
     ) else {
         return crate::services::tui_turn_state::TuiTurnState::Unknown;
@@ -190,11 +261,16 @@ pub(super) fn hosted_tui_busy_preflight_readiness_wait(
     provider: &ProviderKind,
     current_path: Option<&str>,
     session_id: Option<&str>,
+    tmux_session_name: Option<&str>,
 ) -> HostedTuiBusyPreflightReadinessWait {
+    let pane_cwd = tmux_session_name
+        .and_then(crate::services::tmux_diagnostics::tmux_session_pane_cwd)
+        .map(std::path::PathBuf::from);
     hosted_tui_busy_preflight_readiness_wait_with_claude_home(
         provider,
         current_path,
         session_id,
+        pane_cwd.as_deref(),
         None,
     )
 }
@@ -204,19 +280,18 @@ pub(super) fn hosted_tui_busy_preflight_readiness_wait_with_claude_home(
     provider: &ProviderKind,
     current_path: Option<&str>,
     session_id: Option<&str>,
+    pane_cwd: Option<&std::path::Path>,
     claude_home: Option<&std::path::Path>,
 ) -> HostedTuiBusyPreflightReadinessWait {
     if matches!(provider, ProviderKind::Codex) {
         return HostedTuiBusyPreflightReadinessWait::Codex;
     }
-    let (Some(current_path), Some(session_id)) = (current_path, session_id) else {
-        return HostedTuiBusyPreflightReadinessWait::ClaudePromptMarkerOnly;
-    };
-    let Ok(transcript_path) = crate::services::claude_tui::transcript_tail::claude_transcript_path(
-        std::path::Path::new(current_path),
-        session_id,
-        claude_home,
-    ) else {
+    // #3208: resolve the *running* session's transcript (worktree-aware), not
+    // just `claude_transcript_path(current_path, session_id)`, so the idle
+    // JSONL fallback engages for sessions running in a rotating worktree.
+    let Some(transcript_path) =
+        resolve_claude_followup_transcript_path(current_path, session_id, pane_cwd, claude_home)
+    else {
         return HostedTuiBusyPreflightReadinessWait::ClaudePromptMarkerOnly;
     };
     // Missing Claude JSONL files currently observe as Idle. Only pass a
@@ -362,9 +437,11 @@ pub(super) fn tui_busy_followup_diagnostic(
         super::super::super::inflight::load_inflight_state(provider, channel_id.get());
     let inflight_state = classify_inflight_diagnostic_state(previous_inflight.as_ref());
     let transcript_turn_state = match provider {
-        ProviderKind::Claude => {
-            observe_claude_tui_transcript_state_for_session(current_path, session_id)
-        }
+        ProviderKind::Claude => observe_claude_tui_transcript_state_for_session(
+            current_path,
+            session_id,
+            Some(tmux_session_name),
+        ),
         ProviderKind::Codex => observe_codex_tui_rollout_state_for_cwd(
             current_path,
             Some(tmux_session_name),

--- a/src/services/discord/router/message_handler/tui_followup.rs
+++ b/src/services/discord/router/message_handler/tui_followup.rs
@@ -172,13 +172,31 @@ pub(super) fn hosted_tui_draft_should_enter_provider_recovery(
 ///     idle (background-agents-running) turn as busy → the 45s readiness
 ///     timeout in #3208.
 ///
-/// Resolution order:
-///   1. `claude_transcript_path(current_path, session_id)` when it both has a
+/// #3212 (codex P1): the bare newest-in-cwd fallback (`latest_claude_transcript_for_cwd`
+/// with `UNIX_EPOCH` and an empty exclude) trusts newest mtime under the pane
+/// cwd with NO per-session identity. When two same-cwd sessions run
+/// concurrently it can adopt the WRONG transcript:
+///   - a finished OTHER session's Idle transcript → false-ready → injects a
+///     follow-up into a still-busy TUI, or
+///   - another still-Busy transcript → wrong queue / requeue loop.
+/// The fix establishes a strong per-session identity BEFORE the cwd-mtime
+/// fallback, and hardens the fallback itself.
+///
+/// Resolution order (strongest identity first):
+///   1. The live runtime binding's `output_path` for this tmux session — this
+///      is the watcher's output transcript for the *actual* session and is the
+///      only per-session identity we carry. Trusted when the file exists.
+///   2. `claude_transcript_path(current_path, session_id)` when it both has a
 ///      valid UUID and the file exists (the happy path).
-///   2. newest UUID transcript under the live tmux pane's *actual* cwd
-///      (`pane_cwd`) — this is the worktree the running session writes to.
-///   3. newest UUID transcript under `current_path` (workspace) as a last
-///      resort.
+///   3. newest UUID transcript under the live tmux pane's *actual* cwd
+///      (`pane_cwd`), then `current_path`, BUT only with:
+///        - a `launch_mtime_cutoff` floor (reject transcripts older than this
+///          session's launch — they belong to a prior session), and
+///        - the already-claimed transcripts (`exclude`) of OTHER live sessions
+///          filtered out, and
+///        - an ambiguity guard: when MORE THAN ONE qualifying transcript exists
+///          in a cwd and we have no stronger identity, we refuse to guess
+///          (return `None`) rather than risk false-ready / false-busy.
 #[cfg(unix)]
 pub(super) fn resolve_claude_followup_transcript_path(
     current_path: Option<&str>,
@@ -186,8 +204,48 @@ pub(super) fn resolve_claude_followup_transcript_path(
     pane_cwd: Option<&std::path::Path>,
     claude_home: Option<&std::path::Path>,
 ) -> Option<std::path::PathBuf> {
-    use std::collections::HashSet;
+    resolve_claude_followup_transcript_path_with_identity(
+        current_path,
+        session_id,
+        pane_cwd,
+        claude_home,
+        None,
+        std::time::SystemTime::UNIX_EPOCH,
+        &std::collections::HashSet::new(),
+    )
+}
 
+/// #3212: identity-aware resolver. `runtime_binding` is the strongest per-session
+/// identity (the live watcher output transcript path); `launch_mtime_cutoff`
+/// floors the cwd-mtime fallback so a finished prior session's transcript is
+/// never adopted; `exclude` drops transcripts already claimed by OTHER live
+/// sessions. Production wrappers supply these from the tmux runtime binding
+/// table; tests drive them directly. The bare 4-arg wrapper above keeps the
+/// previous call sites compiling (with the legacy permissive behaviour) but is
+/// no longer used on the production follow-up path.
+#[cfg(unix)]
+pub(super) fn resolve_claude_followup_transcript_path_with_identity(
+    current_path: Option<&str>,
+    session_id: Option<&str>,
+    pane_cwd: Option<&std::path::Path>,
+    claude_home: Option<&std::path::Path>,
+    runtime_binding: Option<&crate::services::tui_prompt_dedupe::TuiRuntimeBinding>,
+    launch_mtime_cutoff: std::time::SystemTime,
+    exclude: &std::collections::HashSet<std::path::PathBuf>,
+) -> Option<std::path::PathBuf> {
+    // 1. Strongest identity: the live runtime binding's output transcript for
+    //    THIS tmux session. This is the only path we carry that is bound to the
+    //    actual session, so it disambiguates concurrent same-cwd sessions.
+    if let Some(binding) = runtime_binding.filter(|binding| {
+        binding.runtime_kind == crate::services::agent_protocol::RuntimeHandoffKind::ClaudeTui
+    }) {
+        let bound_path = std::path::PathBuf::from(binding.output_path.trim());
+        if !binding.output_path.trim().is_empty() && bound_path.exists() {
+            return Some(bound_path);
+        }
+    }
+
+    // 2. Happy path: exact (current_path, session_id) UUID transcript.
     if let (Some(current_path), Some(session_id)) = (current_path, session_id)
         && let Ok(path) = crate::services::claude_tui::transcript_tail::claude_transcript_path(
             std::path::Path::new(current_path),
@@ -199,7 +257,11 @@ pub(super) fn resolve_claude_followup_transcript_path(
         return Some(path);
     }
 
-    let exclude: HashSet<std::path::PathBuf> = HashSet::new();
+    // 3. cwd-mtime fallback, but guarded. We refuse to adopt a transcript when
+    //    the cwd holds more than one qualifying candidate (ambiguous concurrent
+    //    sessions) — picking newest mtime there is exactly the false-ready /
+    //    false-busy bug. We only adopt when there is a single unambiguous
+    //    candidate at/after the launch cutoff.
     let mut candidate_cwds: Vec<std::path::PathBuf> = Vec::new();
     if let Some(pane_cwd) = pane_cwd {
         candidate_cwds.push(pane_cwd.to_path_buf());
@@ -211,15 +273,20 @@ pub(super) fn resolve_claude_followup_transcript_path(
         }
     }
     for cwd in candidate_cwds {
-        if let Some(path) =
-            crate::services::claude_tui::transcript_tail::latest_claude_transcript_for_cwd(
+        let candidates =
+            crate::services::claude_tui::transcript_tail::claude_transcripts_for_cwd_since(
                 &cwd,
-                std::time::SystemTime::UNIX_EPOCH,
+                launch_mtime_cutoff,
                 claude_home,
-                &exclude,
-            )
-        {
-            return Some(path);
+                exclude,
+            );
+        match candidates.len() {
+            0 => continue,
+            1 => return Some(candidates.into_iter().next().expect("len == 1")),
+            // Ambiguous: >1 same-cwd transcript at/after launch with no stronger
+            // identity. Do NOT guess — falling through to the next cwd (or None)
+            // is safer than injecting into the wrong session.
+            _ => continue,
         }
     }
     None
@@ -234,11 +301,16 @@ pub(super) fn observe_claude_tui_transcript_state_for_session(
     let pane_cwd = tmux_session_name
         .and_then(crate::services::tmux_diagnostics::tmux_session_pane_cwd)
         .map(std::path::PathBuf::from);
-    let Some(transcript_path) = resolve_claude_followup_transcript_path(
+    let runtime_binding = tmux_session_name
+        .and_then(crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session);
+    let Some(transcript_path) = resolve_claude_followup_transcript_path_with_identity(
         current_path,
         session_id,
         pane_cwd.as_deref(),
         None,
+        runtime_binding.as_ref(),
+        std::time::SystemTime::UNIX_EPOCH,
+        &std::collections::HashSet::new(),
     ) else {
         return crate::services::tui_turn_state::TuiTurnState::Unknown;
     };
@@ -266,12 +338,15 @@ pub(super) fn hosted_tui_busy_preflight_readiness_wait(
     let pane_cwd = tmux_session_name
         .and_then(crate::services::tmux_diagnostics::tmux_session_pane_cwd)
         .map(std::path::PathBuf::from);
+    let runtime_binding = tmux_session_name
+        .and_then(crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session);
     hosted_tui_busy_preflight_readiness_wait_with_claude_home(
         provider,
         current_path,
         session_id,
         pane_cwd.as_deref(),
         None,
+        runtime_binding.as_ref(),
     )
 }
 
@@ -282,6 +357,7 @@ pub(super) fn hosted_tui_busy_preflight_readiness_wait_with_claude_home(
     session_id: Option<&str>,
     pane_cwd: Option<&std::path::Path>,
     claude_home: Option<&std::path::Path>,
+    runtime_binding: Option<&crate::services::tui_prompt_dedupe::TuiRuntimeBinding>,
 ) -> HostedTuiBusyPreflightReadinessWait {
     if matches!(provider, ProviderKind::Codex) {
         return HostedTuiBusyPreflightReadinessWait::Codex;
@@ -289,9 +365,17 @@ pub(super) fn hosted_tui_busy_preflight_readiness_wait_with_claude_home(
     // #3208: resolve the *running* session's transcript (worktree-aware), not
     // just `claude_transcript_path(current_path, session_id)`, so the idle
     // JSONL fallback engages for sessions running in a rotating worktree.
-    let Some(transcript_path) =
-        resolve_claude_followup_transcript_path(current_path, session_id, pane_cwd, claude_home)
-    else {
+    // #3212: prefer the runtime binding's per-session output transcript over the
+    // ambiguous newest-in-cwd guess so we never wait on the wrong session.
+    let Some(transcript_path) = resolve_claude_followup_transcript_path_with_identity(
+        current_path,
+        session_id,
+        pane_cwd,
+        claude_home,
+        runtime_binding,
+        std::time::SystemTime::UNIX_EPOCH,
+        &std::collections::HashSet::new(),
+    ) else {
         return HostedTuiBusyPreflightReadinessWait::ClaudePromptMarkerOnly;
     };
     // Missing Claude JSONL files currently observe as Idle. Only pass a

--- a/src/services/discord/router/message_handler/tui_followup.rs
+++ b/src/services/discord/router/message_handler/tui_followup.rs
@@ -210,7 +210,7 @@ pub(super) fn resolve_claude_followup_transcript_path(
         pane_cwd,
         claude_home,
         None,
-        std::time::SystemTime::UNIX_EPOCH,
+        Some(std::time::SystemTime::UNIX_EPOCH),
         &std::collections::HashSet::new(),
     )
 }
@@ -223,6 +223,21 @@ pub(super) fn resolve_claude_followup_transcript_path(
 /// table; tests drive them directly. The bare 4-arg wrapper above keeps the
 /// previous call sites compiling (with the legacy permissive behaviour) but is
 /// no longer used on the production follow-up path.
+///
+/// #3212 (codex P1-1): `launch_mtime_cutoff` is `Option`:
+///   - `Some(t)` — only cwd-fallback transcripts modified at/after `t` (this
+///     session's launch) qualify. A stale prior-session transcript is rejected.
+///   - `None` — the launch time could NOT be reliably obtained. The cwd-mtime
+///     fallback is then DISABLED entirely (we never adopt an unverified
+///     candidate). Stronger identities (runtime binding, exact UUID) still
+///     resolve; otherwise we return `None` (prompt-marker-only) and accept the
+///     minor false-busy over the false-ready of adopting an unverifiable
+///     transcript.
+///
+/// #3212 (codex P1-2): the ambiguity guard is a HARD stop. Candidates from BOTH
+/// `pane_cwd` AND `current_path` are collected into one set; if more than one
+/// qualifies (after cutoff + exclude) with no stronger identity, we return
+/// `None` rather than fall through and adopt a single `current_path` candidate.
 #[cfg(unix)]
 pub(super) fn resolve_claude_followup_transcript_path_with_identity(
     current_path: Option<&str>,
@@ -230,7 +245,7 @@ pub(super) fn resolve_claude_followup_transcript_path_with_identity(
     pane_cwd: Option<&std::path::Path>,
     claude_home: Option<&std::path::Path>,
     runtime_binding: Option<&crate::services::tui_prompt_dedupe::TuiRuntimeBinding>,
-    launch_mtime_cutoff: std::time::SystemTime,
+    launch_mtime_cutoff: Option<std::time::SystemTime>,
     exclude: &std::collections::HashSet<std::path::PathBuf>,
 ) -> Option<std::path::PathBuf> {
     // 1. Strongest identity: the live runtime binding's output transcript for
@@ -257,11 +272,19 @@ pub(super) fn resolve_claude_followup_transcript_path_with_identity(
         return Some(path);
     }
 
-    // 3. cwd-mtime fallback, but guarded. We refuse to adopt a transcript when
-    //    the cwd holds more than one qualifying candidate (ambiguous concurrent
-    //    sessions) — picking newest mtime there is exactly the false-ready /
-    //    false-busy bug. We only adopt when there is a single unambiguous
-    //    candidate at/after the launch cutoff.
+    // 3. cwd-mtime fallback, but guarded.
+    //
+    // P1-1: with no reliable launch cutoff we MUST NOT adopt any unverified
+    // candidate — disable the fallback and return None (prompt-marker-only).
+    let Some(launch_mtime_cutoff) = launch_mtime_cutoff else {
+        return None;
+    };
+    // P1-2: collect candidates across BOTH cwds into ONE set, then apply a HARD
+    // ambiguity guard. Picking newest-mtime among >1 candidate is exactly the
+    // false-ready / false-busy bug; a per-cwd `continue` could fall through and
+    // adopt a single `current_path` candidate while pane_cwd was ambiguous —
+    // that is forbidden. Only a single unambiguous candidate across all cwds
+    // (at/after launch, after exclude) may be adopted.
     let mut candidate_cwds: Vec<std::path::PathBuf> = Vec::new();
     if let Some(pane_cwd) = pane_cwd {
         candidate_cwds.push(pane_cwd.to_path_buf());
@@ -272,24 +295,43 @@ pub(super) fn resolve_claude_followup_transcript_path_with_identity(
             candidate_cwds.push(workspace);
         }
     }
+    let mut all_candidates: Vec<std::path::PathBuf> = Vec::new();
+    let mut seen: std::collections::HashSet<std::path::PathBuf> = std::collections::HashSet::new();
     for cwd in candidate_cwds {
-        let candidates =
-            crate::services::claude_tui::transcript_tail::claude_transcripts_for_cwd_since(
-                &cwd,
-                launch_mtime_cutoff,
-                claude_home,
-                exclude,
-            );
-        match candidates.len() {
-            0 => continue,
-            1 => return Some(candidates.into_iter().next().expect("len == 1")),
-            // Ambiguous: >1 same-cwd transcript at/after launch with no stronger
-            // identity. Do NOT guess — falling through to the next cwd (or None)
-            // is safer than injecting into the wrong session.
-            _ => continue,
+        for path in crate::services::claude_tui::transcript_tail::claude_transcripts_for_cwd_since(
+            &cwd,
+            launch_mtime_cutoff,
+            claude_home,
+            exclude,
+        ) {
+            if seen.insert(path.clone()) {
+                all_candidates.push(path);
+            }
+        }
+        // Short-circuit: once two distinct candidates exist anywhere we are
+        // already ambiguous and will return None regardless of the next cwd.
+        if all_candidates.len() > 1 {
+            return None;
         }
     }
-    None
+    match all_candidates.len() {
+        1 => Some(all_candidates.into_iter().next().expect("len == 1")),
+        // 0 → nothing qualifies; >1 → ambiguous concurrent sessions. Never guess.
+        _ => None,
+    }
+}
+
+/// #3212 (codex P1-1): the launch-mtime cutoff for the cwd-fallback, sourced
+/// from the live Claude process's start time (the tmux pane PID's start time).
+/// `None` when the pane PID or its start time cannot be obtained — callers then
+/// take the conservative no-fallback path rather than risk adopting a stale
+/// same-cwd transcript (false-ready).
+#[cfg(unix)]
+fn claude_session_launch_mtime_cutoff(
+    tmux_session_name: Option<&str>,
+) -> Option<std::time::SystemTime> {
+    let pid = crate::services::platform::tmux::pane_pid(tmux_session_name?)?;
+    crate::services::platform::tmux::process_start_time(pid)
 }
 
 #[cfg(unix)]
@@ -303,13 +345,14 @@ pub(super) fn observe_claude_tui_transcript_state_for_session(
         .map(std::path::PathBuf::from);
     let runtime_binding = tmux_session_name
         .and_then(crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session);
+    let launch_mtime_cutoff = claude_session_launch_mtime_cutoff(tmux_session_name);
     let Some(transcript_path) = resolve_claude_followup_transcript_path_with_identity(
         current_path,
         session_id,
         pane_cwd.as_deref(),
         None,
         runtime_binding.as_ref(),
-        std::time::SystemTime::UNIX_EPOCH,
+        launch_mtime_cutoff,
         &std::collections::HashSet::new(),
     ) else {
         return crate::services::tui_turn_state::TuiTurnState::Unknown;
@@ -340,6 +383,7 @@ pub(super) fn hosted_tui_busy_preflight_readiness_wait(
         .map(std::path::PathBuf::from);
     let runtime_binding = tmux_session_name
         .and_then(crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session);
+    let launch_mtime_cutoff = claude_session_launch_mtime_cutoff(tmux_session_name);
     hosted_tui_busy_preflight_readiness_wait_with_claude_home(
         provider,
         current_path,
@@ -347,6 +391,7 @@ pub(super) fn hosted_tui_busy_preflight_readiness_wait(
         pane_cwd.as_deref(),
         None,
         runtime_binding.as_ref(),
+        launch_mtime_cutoff,
     )
 }
 
@@ -358,6 +403,7 @@ pub(super) fn hosted_tui_busy_preflight_readiness_wait_with_claude_home(
     pane_cwd: Option<&std::path::Path>,
     claude_home: Option<&std::path::Path>,
     runtime_binding: Option<&crate::services::tui_prompt_dedupe::TuiRuntimeBinding>,
+    launch_mtime_cutoff: Option<std::time::SystemTime>,
 ) -> HostedTuiBusyPreflightReadinessWait {
     if matches!(provider, ProviderKind::Codex) {
         return HostedTuiBusyPreflightReadinessWait::Codex;
@@ -366,14 +412,15 @@ pub(super) fn hosted_tui_busy_preflight_readiness_wait_with_claude_home(
     // just `claude_transcript_path(current_path, session_id)`, so the idle
     // JSONL fallback engages for sessions running in a rotating worktree.
     // #3212: prefer the runtime binding's per-session output transcript over the
-    // ambiguous newest-in-cwd guess so we never wait on the wrong session.
+    // ambiguous newest-in-cwd guess so we never wait on the wrong session; the
+    // launch-mtime cutoff (P1-1) floors the cwd fallback to this session's launch.
     let Some(transcript_path) = resolve_claude_followup_transcript_path_with_identity(
         current_path,
         session_id,
         pane_cwd,
         claude_home,
         runtime_binding,
-        std::time::SystemTime::UNIX_EPOCH,
+        launch_mtime_cutoff,
         &std::collections::HashSet::new(),
     ) else {
         return HostedTuiBusyPreflightReadinessWait::ClaudePromptMarkerOnly;

--- a/src/services/platform/tmux.rs
+++ b/src/services/platform/tmux.rs
@@ -781,6 +781,67 @@ pub fn read_process_args(pid: u32) -> Option<String> {
     }
 }
 
+/// #3212 (codex P1): the wall-clock start time of a process, as a
+/// [`std::time::SystemTime`]. The follow-up readiness resolver uses this as the
+/// launch-mtime cutoff for the cwd-mtime transcript fallback: only transcripts
+/// modified at/after the live Claude session's launch may be adopted, so a
+/// finished prior session's stale same-cwd transcript can never be mistaken for
+/// the live one (false-ready).
+///
+/// Derived from elapsed-since-start (`ps -o etime=`) rather than the absolute
+/// `lstart` to dodge locale/timezone parsing of the human date. `etime` format
+/// is `[[DD-]HH:]MM:SS`. Returns `None` when the PID is zero/missing or the OS
+/// call fails — callers MUST treat `None` conservatively (no fallback adoption).
+#[cfg(unix)]
+pub fn process_start_time(pid: u32) -> Option<std::time::SystemTime> {
+    if pid == 0 {
+        return None;
+    }
+    let out = std::process::Command::new("ps")
+        .args(["-o", "etime=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let elapsed = parse_ps_etime(String::from_utf8_lossy(&out.stdout).trim())?;
+    std::time::SystemTime::now().checked_sub(elapsed)
+}
+
+/// Return the start time of a process. No implementation on non-unix hosts.
+#[cfg(not(unix))]
+pub fn process_start_time(_pid: u32) -> Option<std::time::SystemTime> {
+    None
+}
+
+/// Parse a `ps -o etime=` field (`[[DD-]HH:]MM:SS`) into an elapsed
+/// [`std::time::Duration`]. Returns `None` for empty/malformed input so the
+/// caller falls back to the conservative no-cutoff path.
+#[cfg(unix)]
+fn parse_ps_etime(raw: &str) -> Option<std::time::Duration> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let (days, hms) = match raw.split_once('-') {
+        Some((d, rest)) => (d.parse::<u64>().ok()?, rest),
+        None => (0, raw),
+    };
+    let parts: Vec<&str> = hms.split(':').collect();
+    let (hours, minutes, seconds) = match parts.as_slice() {
+        [h, m, s] => (
+            h.parse::<u64>().ok()?,
+            m.parse::<u64>().ok()?,
+            s.parse::<u64>().ok()?,
+        ),
+        [m, s] => (0, m.parse::<u64>().ok()?, s.parse::<u64>().ok()?),
+        _ => return None,
+    };
+    Some(std::time::Duration::from_secs(
+        days * 86_400 + hours * 3_600 + minutes * 60 + seconds,
+    ))
+}
+
 /// Check if a session has any live (non-dead) panes.
 pub fn has_live_pane(session_name: &str) -> bool {
     if !has_session(session_name) {
@@ -990,6 +1051,29 @@ mod session_server_tests {
                 },
             ]
         );
+    }
+}
+
+#[cfg(all(test, unix))]
+mod etime_tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn parse_ps_etime_handles_all_field_widths() {
+        assert_eq!(parse_ps_etime("00:05"), Some(Duration::from_secs(5)));
+        assert_eq!(parse_ps_etime("01:02"), Some(Duration::from_secs(62)));
+        assert_eq!(
+            parse_ps_etime("01:02:03"),
+            Some(Duration::from_secs(3_600 + 120 + 3))
+        );
+        assert_eq!(
+            parse_ps_etime("2-03:04:05"),
+            Some(Duration::from_secs(2 * 86_400 + 3 * 3_600 + 4 * 60 + 5))
+        );
+        assert_eq!(parse_ps_etime(""), None);
+        assert_eq!(parse_ps_etime("garbage"), None);
+        assert_eq!(parse_ps_etime("1:2:3:4"), None);
     }
 }
 

--- a/src/services/platform/tmux.rs
+++ b/src/services/platform/tmux.rs
@@ -504,6 +504,39 @@ pub fn pane_pid(_session_name: &str) -> Option<u32> {
     None
 }
 
+/// Return the current working directory of the active pane for a tmux session
+/// (`#{pane_current_path}`).
+///
+/// #3208: a Discord-hosted Claude TUI may run in a rotating worktree
+/// (`~/.adk/release/worktrees/claude-adk-cc-<ts>`) whose cwd differs from the
+/// channel's configured workspace (the DB-restored cwd is sometimes ignored at
+/// turn start). The follow-up readiness path needs the *actual* running cwd to
+/// resolve the live JSONL transcript; the configured workspace path resolves to
+/// a stale/empty Claude project dir, so the structured turn-state probe reports
+/// `Unknown` and the screen-marker fallback then false-flags a genuinely-idle
+/// (background-agents-running) turn as busy. Returns `None` when the session has
+/// no live pane or tmux is unavailable.
+pub fn pane_current_path(session_name: &str) -> Option<String> {
+    if is_blank_session_name(session_name) {
+        return None;
+    }
+    let output = tmux_command()
+        .args([
+            "display-message",
+            "-p",
+            "-t",
+            &exact_target(session_name),
+            "#{pane_current_path}",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if path.is_empty() { None } else { Some(path) }
+}
+
 /// Capture pane content from a tmux session.
 ///
 /// `scroll_back` is the number of lines to capture (negative = from bottom).

--- a/src/services/tmux_diagnostics.rs
+++ b/src/services/tmux_diagnostics.rs
@@ -18,6 +18,14 @@ pub fn tmux_session_has_live_pane(tmux_session_name: &str) -> bool {
     crate::services::platform::tmux::has_live_pane(tmux_session_name)
 }
 
+/// #3208: the current working directory of the live pane for a tmux session.
+/// Used by the follow-up readiness path to resolve the running Claude session's
+/// JSONL transcript when it lives in a rotating worktree that differs from the
+/// channel's configured workspace cwd.
+pub fn tmux_session_pane_cwd(tmux_session_name: &str) -> Option<String> {
+    crate::services::platform::tmux::pane_current_path(tmux_session_name)
+}
+
 pub fn clear_tmux_exit_reason(tmux_session_name: &str) {
     let _ = std::fs::remove_file(tmux_exit_reason_path(tmux_session_name));
 }


### PR DESCRIPTION
Closes #3208

## A/B diagnosis (live evidence)

Correlated the two live `prompt input readiness after 45s` timeouts (2026-06-07T07:31:07 / 07:32:23 UTC, channel `1479671298497183835`) against the running session's JSONL and the `claude_tui_followup_busy_pre_submit` observability event.

**Verdict: primarily B (false-busy); A policy gap also closed.**

- Running session `6a053a02` (status panel `🔑 6a053a02`) lives in worktree `worktrees/claude-adk-cc-20260607-113822`. At turn start the log shows `⚠ Ignoring restored DB cwd ... (configured workspace: workspaces/agentdesk)` — the worktree cwd was dropped (same root as #3207).
- The session's JSONL emitted `system/turn_duration` (`end_turn`, `pendingBackgroundAgentCount=5`) at **07:29:13** — i.e. the **main turn was IDLE**; only 5 background subagents kept running. The screen therefore showed `✻ Waiting for 5 background agents to finish` and the prompt marker stayed suppressed → `prompt_marker_detected=false`.
- The 45s poll fired (07:31:07, 07:32:23) entirely inside the 07:29:13→07:32:45 JSONL quiet window, so the turn was genuinely at rest. The idle-JSONL fallback never engaged because intake only had the *workspace* cwd + a session *fingerprint* (`provider_session_fp=70fee84a...`, not a UUID); `claude_transcript_path(workspace, fingerprint)` resolved to nothing → `transcript_turn_state=unknown` (confirmed in the observability event) → screen-marker fallback false-flagged the idle turn busy.

## Mechanism

- **B**: new worktree-aware `resolve_claude_followup_transcript_path` resolves the running session's JSONL via the live tmux pane cwd (`tmux display-message -p '#{pane_current_path}'`) using the existing `latest_claude_transcript_for_cwd`. It backs both `observe_claude_tui_transcript_state_for_session` and the preflight `hosted_tui_busy_preflight_readiness_wait`, so a genuinely-Idle worktree session observes `Idle` and the idle fallback engages instead of the prompt-marker-only 45s wait. A genuinely-Idle TUI is never declared `previous_tui_turn_still_running`.
- **A**: when the authoritative JSONL turn-state is `Streaming`/`UserSubmitted`, intake skips the 45s readiness poll and routes the follow-up straight to the queue-defer path (📬, no error; delivered at idle). Direct-injection stays a last resort.

Codex twin already resolves rollout state via runtime-binding + cwd match; the A short-circuit is provider-agnostic at the diagnostic layer.

## Tests (deterministic, RED before / GREEN after)

- `claude_busy_preflight_resolves_worktree_transcript_when_session_id_missing` — B: worktree transcript adopted via pane cwd; idle fallback engaged (old code returned `ClaudePromptMarkerOnly` with `session_id=None`).
- `claude_idle_worktree_transcript_observes_idle_not_busy` — B: `turn_duration` + pending background agents observes `Idle`.
- `claude_busy_followup_defers_to_queue_without_readiness_poll` — A: busy JSONL state yields a defer diagnostic, gating out the 45s poll.

`cargo build` + `cargo fmt --check` clean; `session_strategy_lifecycle` 34/34, `claude_tui::` 133/133.

## Residual risk (codex gate)
The A short-circuit and the diagnostic-layer fix are provider-agnostic, but the worktree-cwd transcript resolver is Claude-only (`resolve_claude_followup_transcript_path`); Codex follow-up readiness still relies on its runtime-binding/rollout cwd match. If a Codex session runs in a rotating worktree without a live runtime binding, its idle fallback could still mis-resolve — out of scope here but worth a codex-side mirror if it recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)