### PR TITLE
fix(#3219): prefer existing managed worktree over base on session recovery

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -113,7 +113,7 @@
   parsing), `src/services/discord/inflight.rs` (state file contract).
 - legacy_modules: none — relay routes are being consolidated, not replaced.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/services/discord/watchers/lifecycle.rs` (2329 lines — canonical
+  - `src/services/discord/watchers/lifecycle.rs` (2336 lines — canonical
     lifecycle extraction surface from #1435; split further before adding new
     lifecycle behavior).
   - `src/services/discord/tmux.rs` (2251 lines after #2558 dead-code sweep;
@@ -626,7 +626,7 @@
     are net-zero. The poise framework-builder/setup closure (~580 lines) is left
     inline — its move-captured locals make a clean extraction risky and is
     deferred).
-  - `src/services/discord/session_runtime.rs` (1662 lines).
+  - `src/services/discord/session_runtime.rs` (1781 lines).
   - `src/services/discord/voice_barge_in.rs` (4835 lines; voice STT/TTS,
     lobby routing, progress mirroring, and barge-in orchestration surface;
     tracked decompose target — see `giant-file-registry.md` (owner

--- a/src/services/discord/session_runtime.rs
+++ b/src/services/discord/session_runtime.rs
@@ -44,6 +44,28 @@ pub(super) fn select_restored_session_path(
     yaml_path: Option<String>,
     remote_profile_name: Option<&str>,
 ) -> Option<String> {
+    // #3219: a channel-scoped DB cwd that points to an existing, AgentDesk-managed
+    // worktree must win over the configured *base* workspace. Otherwise
+    // provider-channel worktree isolation re-derives a FRESH worktree from the
+    // base on recovery, abandoning the session's existing worktree and its
+    // provider transcript — so `--resume` falls back to a fresh session-id.
+    // While the tmux pane survives this is masked by the live-TUI-binding recovery
+    // path; once the pane dies (crash/kill/restart) there is no fallback and
+    // resume breaks (root cause of the 2026-06-07 resume failure: recovery read
+    // the correct worktree from the DB, logged "Ignoring restored DB cwd", then
+    // built a fresh worktree + session-id).
+    //
+    // Reconfiguration safety is preserved: a moved/renamed base relocates
+    // `worktrees_root()`, so a stale worktree no longer matches
+    // `is_managed_worktree_path` and falls through to the configured path below.
+    // A configured workspace that merely *is* a linked worktree lives outside
+    // `worktrees_root()` and is likewise unaffected.
+    if let Some(worktree) = db_cwd.as_ref().filter(|path| {
+        is_managed_worktree_path(path) && session_path_is_usable(path, remote_profile_name)
+    }) {
+        return Some(worktree.clone());
+    }
+
     configured_path
         .filter(|path| session_path_is_usable(path, remote_profile_name))
         .or_else(|| db_cwd.filter(|path| session_path_is_usable(path, remote_profile_name)))
@@ -1657,6 +1679,97 @@ pub(super) async fn resolve_thread_parent(
             Some((parent_id, parent_name))
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod select_restored_session_path_tests {
+    //! #3219: `select_restored_session_path` must prefer an existing managed
+    //! worktree (the channel-scoped DB cwd) over the configured *base* workspace,
+    //! or crash/kill recovery re-derives a fresh worktree and `--resume` breaks.
+    use super::select_restored_session_path;
+
+    struct EnvGuard(Option<std::ffi::OsString>);
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
+                None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
+            }
+        }
+    }
+
+    fn with_root<T>(root: &std::path::Path, f: impl FnOnce() -> T) -> T {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let _guard = EnvGuard(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", root) };
+        f()
+    }
+
+    #[test]
+    fn prefers_existing_managed_worktree_over_configured_base() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let base = root.join("workspaces").join("agentdesk");
+        let worktree = root.join("worktrees").join("claude-adk-cc-20260607-113822");
+        std::fs::create_dir_all(&base).unwrap();
+        std::fs::create_dir_all(&worktree).unwrap();
+
+        let selected = with_root(root, || {
+            select_restored_session_path(
+                Some(base.to_string_lossy().into_owned()),
+                Some(worktree.to_string_lossy().into_owned()),
+                None,
+                None,
+            )
+        });
+        assert_eq!(selected.as_deref(), worktree.to_str());
+    }
+
+    #[test]
+    fn falls_back_to_configured_when_managed_worktree_missing() {
+        // A stale/phantom worktree (not on disk) must not be selected; recovery
+        // falls through to the configured base workspace.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let base = root.join("workspaces").join("agentdesk");
+        let worktree = root.join("worktrees").join("claude-adk-cc-deleted");
+        std::fs::create_dir_all(&base).unwrap();
+        // worktree intentionally NOT created on disk
+
+        let selected = with_root(root, || {
+            select_restored_session_path(
+                Some(base.to_string_lossy().into_owned()),
+                Some(worktree.to_string_lossy().into_owned()),
+                None,
+                None,
+            )
+        });
+        assert_eq!(selected.as_deref(), base.to_str());
+    }
+
+    #[test]
+    fn db_cwd_outside_worktrees_root_does_not_override_configured() {
+        // A DB cwd that is NOT under `worktrees_root()` (e.g. a relocated base
+        // after reconfiguration) must keep configured-path priority.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let base = root.join("workspaces").join("agentdesk");
+        let other = root.join("somewhere").join("else");
+        std::fs::create_dir_all(&base).unwrap();
+        std::fs::create_dir_all(&other).unwrap();
+
+        let selected = with_root(root, || {
+            select_restored_session_path(
+                Some(base.to_string_lossy().into_owned()),
+                Some(other.to_string_lossy().into_owned()),
+                None,
+                None,
+            )
+        });
+        assert_eq!(selected.as_deref(), base.to_str());
     }
 }
 

--- a/src/services/discord/session_runtime.rs
+++ b/src/services/discord/session_runtime.rs
@@ -781,7 +781,7 @@ pub(super) async fn auto_restore_session_force(
         // Use the effective tmux channel name here so restart recovery keeps
         // looking up the same session key for thread sessions that intentionally
         // use a synthetic "{parent}-t{thread_id}" channel name.
-        let mut db_cwd: Option<String> = restore_ch_name.as_ref().and_then(|ch| {
+        let restored_cwd = restore_ch_name.as_ref().and_then(|ch| {
             // #3207 (part 2) P0-a: the DB cwd resolve is channel-scoped (see
             // `restore_session_cwd_from_db`); only a usable path is honored for
             // install into `session.current_path`.
@@ -792,8 +792,19 @@ pub(super) async fn auto_restore_session_force(
                 ch,
                 channel_id.get(),
             )
-            .filter(|p| !p.is_empty() && session_path_is_usable(p, saved_remote.as_deref()))
+            .filter(|r| {
+                !r.path.is_empty() && session_path_is_usable(&r.path, saved_remote.as_deref())
+            })
         });
+        let mut db_cwd: Option<String> = restored_cwd.as_ref().map(|r| r.path.clone());
+        // #3219: only a channel-scoped cwd (exact channel-id match) — or the
+        // tmux-reconciled cwd below, which is THIS channel's live pane — may
+        // outrank the configured base. A NULL-channel_id legacy fallback is not
+        // proven to be this channel's worktree.
+        let mut db_cwd_channel_scoped = restored_cwd
+            .as_ref()
+            .map(|r| r.channel_scoped)
+            .unwrap_or(false);
 
         // #3216 GAP 2: reconcile the DB cwd against the live tmux pane. The live
         // pane is the source of truth for where the session actually runs; if the
@@ -834,6 +845,10 @@ pub(super) async fn auto_restore_session_force(
                     &reconciled,
                 );
                 db_cwd = Some(reconciled);
+                // The reconciled cwd is THIS channel's live tmux pane and
+                // `correct_session_cwd_to_tmux` just stamped channel_id, so it is
+                // channel-owned and eligible for elevation (#3219).
+                db_cwd_channel_scoped = true;
             }
         }
         let persisted_path = load_last_session_path(
@@ -844,9 +859,10 @@ pub(super) async fn auto_restore_session_force(
 
         // #3219: validate whether the restored DB cwd is the channel's own
         // reusable managed worktree BEFORE selecting, so the log below reflects
-        // the actual decision (we only "ignore" it when it is NOT reused).
-        let reusable_worktree =
-            db_cwd_is_reusable_worktree(configured_path.as_deref(), db_cwd.as_deref());
+        // the actual decision (we only "ignore" it when it is NOT reused). Only a
+        // channel-scoped cwd is eligible — never a NULL-fallback cwd.
+        let reusable_worktree = db_cwd_channel_scoped
+            && db_cwd_is_reusable_worktree(configured_path.as_deref(), db_cwd.as_deref());
         if let (Some(configured), Some(restored)) = (configured_path.as_ref(), db_cwd.as_ref())
             && configured != restored
             && !reusable_worktree
@@ -974,7 +990,7 @@ async fn resolve_cwd_for_session_key(
     pool: &sqlx::PgPool,
     session_key: &str,
     channel_id: &str,
-) -> Result<Option<String>, String> {
+) -> Result<Option<RestoredCwd>, String> {
     // 1. Channel-scoped match (the #3207 cross-channel guard).
     let scoped = sqlx::query_scalar::<_, Option<String>>(
         "SELECT cwd FROM sessions \
@@ -987,7 +1003,10 @@ async fn resolve_cwd_for_session_key(
     .map_err(|error| format!("load session cwd {session_key}: {error}"))?
     .flatten();
     if let Some(path) = scoped.filter(|p| !p.is_empty()) {
-        return Ok(Some(path));
+        return Ok(Some(RestoredCwd {
+            path,
+            channel_scoped: true,
+        }));
     }
 
     // 2. #3216 GAP 1 safe legacy fallback: inspect ALL rows for this
@@ -1012,7 +1031,14 @@ async fn resolve_cwd_for_session_key(
                 session_key,
                 channel_id
             );
-            return Ok(Some(path));
+            // #3219: a NULL-channel_id row is NOT proven to belong to THIS
+            // channel (a name-collision channel resolves the same globally-unique
+            // session_key). Mark it non-channel-scoped so it never gets elevated
+            // over the safe configured base in `select_restored_session_path`.
+            return Ok(Some(RestoredCwd {
+                path,
+                channel_scoped: false,
+            }));
         }
     }
     Ok(None)
@@ -1028,13 +1054,25 @@ async fn resolve_cwd_for_session_key(
 ///
 /// The on-disk usability filter (`session_path_is_usable`) is applied by the
 /// caller so this helper stays a pure DB resolve.
+/// A persisted `sessions.cwd` resolved during restart recovery, tagged with
+/// whether it came from an exact channel-id match (`channel_scoped = true`) or
+/// the #3216 legacy NULL-channel_id fallback (`false`). Only a channel-scoped
+/// cwd is eligible to outrank the configured base in
+/// [`select_restored_session_path`] (#3219) — a NULL-fallback cwd is not proven
+/// to belong to this channel.
+#[derive(Debug, Clone)]
+struct RestoredCwd {
+    path: String,
+    channel_scoped: bool,
+}
+
 fn restore_session_cwd_from_db(
     pg_pool: Option<&sqlx::PgPool>,
     token_hash: &str,
     provider: &ProviderKind,
     channel_name: &str,
     channel_id: u64,
-) -> Option<String> {
+) -> Option<RestoredCwd> {
     let tmux_name = provider.build_tmux_session_name(channel_name);
     let session_keys = build_session_key_candidates(token_hash, provider, &tmux_name);
     let channel_id = channel_id.to_string();
@@ -1043,10 +1081,10 @@ fn restore_session_cwd_from_db(
         pg_pool,
         move |pool| async move {
             for session_key in session_keys {
-                if let Some(path) =
+                if let Some(restored) =
                     resolve_cwd_for_session_key(&pool, &session_key, &channel_id).await?
                 {
-                    return Ok(Some(path));
+                    return Ok(Some(restored));
                 }
             }
             Ok(None)
@@ -1154,10 +1192,12 @@ fn restore_thread_worktree_path_from_db(
         pg_pool,
         move |pool| async move {
             for session_key in session_keys {
-                if let Some(path) =
+                if let Some(restored) =
                     resolve_cwd_for_session_key(&pool, &session_key, &channel_id).await?
                 {
-                    return Ok(Some(path));
+                    // The worktree-reuse path applies its own managed/belongs-to
+                    // -parent guards downstream; it only needs the path here.
+                    return Ok(Some(restored.path));
                 }
             }
             Ok(None)
@@ -1985,9 +2025,13 @@ mod worktree_reuse_channel_isolation_tests {
             channel_a,
         );
         assert_eq!(
-            owner.as_deref(),
+            owner.as_ref().map(|r| r.path.as_str()),
             Some(owner_cwd),
             "the owning channel must resolve its own restart-restore cwd"
+        );
+        assert!(
+            owner.as_ref().map(|r| r.channel_scoped).unwrap_or(false),
+            "an exact channel-id match must be marked channel_scoped (#3219)"
         );
 
         // The colliding (different-id) channel must NOT install channel A's cwd
@@ -1999,8 +2043,8 @@ mod worktree_reuse_channel_isolation_tests {
             collide_name,
             channel_b,
         );
-        assert_eq!(
-            cross, None,
+        assert!(
+            cross.is_none(),
             "a different channel sharing the same session_key must NOT resolve \
              another channel's restart-restore cwd"
         );
@@ -2034,10 +2078,15 @@ mod worktree_reuse_channel_isolation_tests {
             channel_id,
         );
         assert_eq!(
-            resolved.as_deref(),
+            resolved.as_ref().map(|r| r.path.as_str()),
             Some(cwd),
             "a single legacy NULL-channel_id row must be reused for restart \
              restore via the #3216 safe fallback"
+        );
+        assert!(
+            !resolved.as_ref().map(|r| r.channel_scoped).unwrap_or(true),
+            "a NULL-channel_id legacy fallback must NOT be channel_scoped, so it \
+             is never elevated over the configured base (#3219)"
         );
 
         pool.close().await;

--- a/src/services/discord/session_runtime.rs
+++ b/src/services/discord/session_runtime.rs
@@ -836,7 +836,7 @@ pub(super) async fn auto_restore_session_force(
                     db_cwd.as_deref(),
                     reconciled
                 );
-                correct_session_cwd_to_tmux(
+                let claimed_rows = correct_session_cwd_to_tmux(
                     shared.pg_pool.as_ref(),
                     &shared.token_hash,
                     &provider,
@@ -845,10 +845,14 @@ pub(super) async fn auto_restore_session_force(
                     &reconciled,
                 );
                 db_cwd = Some(reconciled);
-                // The reconciled cwd is THIS channel's live tmux pane and
-                // `correct_session_cwd_to_tmux` just stamped channel_id, so it is
-                // channel-owned and eligible for elevation (#3219).
-                db_cwd_channel_scoped = true;
+                // #3219: only treat the reconciled cwd as channel-owned (and thus
+                // eligible to outrank the configured base) when the scoped UPDATE
+                // actually claimed a row (`channel_id = $2 OR channel_id IS NULL`).
+                // A name-collision channel that shares the tmux session name but
+                // not the row (it carries a different non-null channel_id) updates
+                // 0 rows here, so it is NOT elevated into the other channel's
+                // worktree — it falls through to the configured base.
+                db_cwd_channel_scoped = claimed_rows > 0;
             }
         }
         let persisted_path = load_last_session_path(
@@ -1101,6 +1105,13 @@ fn restore_session_cwd_from_db(
 /// row (the #3207 cross-channel guard). A legacy NULL-channel_id row is matched
 /// too — only the row whose id equals THIS channel OR is NULL is updated — so the
 /// row both adopts the correct cwd and gets self-healed onto this channel.
+///
+/// Returns the number of rows updated. #3219: the caller uses this to decide
+/// whether the reconciled cwd is channel-OWNED (≥1 row matched `channel_id = $2
+/// OR channel_id IS NULL`) before letting it outrank the configured base. A
+/// name-collision channel sharing the tmux session name but NOT the row (the row
+/// carries a different non-null channel_id) updates 0 rows and is thus never
+/// elevated into another channel's worktree.
 fn correct_session_cwd_to_tmux(
     pg_pool: Option<&sqlx::PgPool>,
     token_hash: &str,
@@ -1108,9 +1119,9 @@ fn correct_session_cwd_to_tmux(
     channel_name: &str,
     channel_id: u64,
     tmux_cwd: &str,
-) {
+) -> u64 {
     let Some(pool) = pg_pool else {
-        return;
+        return 0;
     };
     let tmux_name = provider.build_tmux_session_name(channel_name);
     let session_keys = build_session_key_candidates(token_hash, provider, &tmux_name);
@@ -1141,17 +1152,23 @@ fn correct_session_cwd_to_tmux(
         |error| error,
     );
     match result {
-        Ok(updated) if updated > 0 => tracing::info!(
-            "  ↻ #3216 reconciled DB cwd to live tmux pane for channel {} ({} row(s))",
-            channel_id,
+        Ok(updated) if updated > 0 => {
+            tracing::info!(
+                "  ↻ #3216 reconciled DB cwd to live tmux pane for channel {} ({} row(s))",
+                channel_id,
+                updated
+            );
             updated
-        ),
-        Ok(_) => {}
-        Err(err) => tracing::warn!(
-            "  ⚠ #3216 failed to reconcile DB cwd to live tmux for channel {}: {}",
-            channel_id,
-            err
-        ),
+        }
+        Ok(_) => 0,
+        Err(err) => {
+            tracing::warn!(
+                "  ⚠ #3216 failed to reconcile DB cwd to live tmux for channel {}: {}",
+                channel_id,
+                err
+            );
+            0
+        }
     }
 }
 

--- a/src/services/discord/session_runtime.rs
+++ b/src/services/discord/session_runtime.rs
@@ -1002,7 +1002,14 @@ async fn resolve_cwd_for_session_key(
     session_key: &str,
     channel_id: &str,
 ) -> Result<Option<RestoredCwd>, String> {
-    // 1. Channel-scoped match (the #3207 cross-channel guard).
+    // 1. Channel-scoped match (the #3207 cross-channel guard). `fetch_optional`
+    //    returns the OUTER Option: `Some(_)` iff an exact channel-owned row
+    //    exists, independent of whether its `cwd` is currently populated. #3219:
+    //    ownership is reported (`channel_scoped: true`) from row EXISTENCE — a
+    //    NULL/empty cwd must NOT erase ownership, or an owned channel whose row
+    //    has a stale/missing cwd could not elevate the valid worktree the tmux
+    //    reconcile later supplies. The caller filters the (possibly empty) path
+    //    for usability separately.
     let scoped = sqlx::query_scalar::<_, Option<String>>(
         "SELECT cwd FROM sessions \
          WHERE session_key = $1 AND channel_id = $2 LIMIT 1",
@@ -1011,11 +1018,10 @@ async fn resolve_cwd_for_session_key(
     .bind(channel_id)
     .fetch_optional(pool)
     .await
-    .map_err(|error| format!("load session cwd {session_key}: {error}"))?
-    .flatten();
-    if let Some(path) = scoped.filter(|p| !p.is_empty()) {
+    .map_err(|error| format!("load session cwd {session_key}: {error}"))?;
+    if let Some(cwd) = scoped {
         return Ok(Some(RestoredCwd {
-            path,
+            path: cwd.unwrap_or_default(),
             channel_scoped: true,
         }));
     }
@@ -1208,8 +1214,12 @@ fn restore_thread_worktree_path_from_db(
                     resolve_cwd_for_session_key(&pool, &session_key, &channel_id).await?
                 {
                     // The worktree-reuse path applies its own managed/belongs-to
-                    // -parent guards downstream; it only needs the path here.
-                    return Ok(Some(restored.path));
+                    // -parent guards downstream; it only needs the path here. Skip
+                    // an owned row whose cwd is empty/NULL (#3219) — it carries no
+                    // reusable worktree, so continue scanning the remaining keys.
+                    if !restored.path.is_empty() {
+                        return Ok(Some(restored.path));
+                    }
                 }
             }
             Ok(None)
@@ -2099,6 +2109,57 @@ mod worktree_reuse_channel_isolation_tests {
             !resolved.as_ref().map(|r| r.channel_scoped).unwrap_or(true),
             "a NULL-channel_id legacy fallback must NOT be channel_scoped, so it \
              is never elevated over the configured base (#3219)"
+        );
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    // #3219: an EXACT channel-owned row whose `cwd` is NULL must still report
+    // ownership (channel_scoped=true) with an empty path, so an owned channel
+    // whose persisted cwd went stale/missing can still elevate the valid worktree
+    // the tmux reconcile later supplies. Ownership comes from row EXISTENCE, not
+    // the cwd value.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn exact_owned_row_with_null_cwd_is_channel_scoped_empty_path() {
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+
+        let provider = ProviderKind::Claude;
+        let token_hash = "tok-3219-null-cwd";
+        let channel_name = "null-cwd-owner";
+        let tmux_name = provider.build_tmux_session_name(channel_name);
+        let session_key = build_namespaced_session_key(token_hash, &provider, &tmux_name);
+        let channel_id: u64 = 777_777_777_777_777_777;
+
+        // Seed an exact channel-owned row with a NULL cwd.
+        sqlx::query(
+            "INSERT INTO sessions (session_key, provider, status, cwd, channel_id, last_heartbeat)
+             VALUES ($1, 'claude', 'idle', NULL, $2, NOW())",
+        )
+        .bind(&session_key)
+        .bind(channel_id.to_string())
+        .execute(&pool)
+        .await
+        .expect("seed NULL-cwd owned row");
+
+        let resolved = restore_session_cwd_from_db(
+            Some(&pool),
+            token_hash,
+            &provider,
+            channel_name,
+            channel_id,
+        );
+        assert!(
+            resolved.as_ref().map(|r| r.channel_scoped).unwrap_or(false),
+            "an exact channel-owned row must be channel_scoped even when its cwd \
+             is NULL (#3219 ownership from row existence)"
+        );
+        assert_eq!(
+            resolved.as_ref().map(|r| r.path.as_str()),
+            Some(""),
+            "a NULL cwd resolves to an empty path; the caller's usability filter \
+             then drops it from db_cwd while preserving ownership"
         );
 
         pool.close().await;

--- a/src/services/discord/session_runtime.rs
+++ b/src/services/discord/session_runtime.rs
@@ -995,8 +995,11 @@ pub(super) async fn auto_restore_session_force(
 /// defensive belt-and-braces guard. If the single row carries a DIFFERENT
 /// non-null `channel_id`, the fallback is refused — that would reintroduce the
 /// #3207 cross-channel hazard. New heartbeats stamp `channel_id`, so this
-/// self-heals over time. Returns the resolved cwd (non-empty) for this
-/// `session_key`.
+/// self-heals over time. Returns a [`RestoredCwd`] for this `session_key`:
+/// `channel_scoped = true` for an exact channel-id match (whose `path` may be
+/// empty when the owned row's `cwd` is NULL/missing — ownership comes from row
+/// existence, #3219), or `channel_scoped = false` with a non-empty path for the
+/// legacy NULL fallback.
 async fn resolve_cwd_for_session_key(
     pool: &sqlx::PgPool,
     session_key: &str,

--- a/src/services/discord/session_runtime.rs
+++ b/src/services/discord/session_runtime.rs
@@ -781,10 +781,9 @@ pub(super) async fn auto_restore_session_force(
         // Use the effective tmux channel name here so restart recovery keeps
         // looking up the same session key for thread sessions that intentionally
         // use a synthetic "{parent}-t{thread_id}" channel name.
+        // #3207 (part 2) P0-a: the DB cwd resolve is channel-scoped (see
+        // `restore_session_cwd_from_db`).
         let restored_cwd = restore_ch_name.as_ref().and_then(|ch| {
-            // #3207 (part 2) P0-a: the DB cwd resolve is channel-scoped (see
-            // `restore_session_cwd_from_db`); only a usable path is honored for
-            // install into `session.current_path`.
             restore_session_cwd_from_db(
                 shared.pg_pool.as_ref(),
                 &shared.token_hash,
@@ -792,20 +791,25 @@ pub(super) async fn auto_restore_session_force(
                 ch,
                 channel_id.get(),
             )
-            .filter(|r| {
-                !r.path.is_empty() && session_path_is_usable(&r.path, saved_remote.as_deref())
-            })
         });
-        let mut db_cwd: Option<String> = restored_cwd.as_ref().map(|r| r.path.clone());
-        // #3219: only a channel-scoped cwd (the resolver's exact `channel_id = $2`
-        // match) may outrank the configured base. A NULL-channel_id legacy
-        // fallback is not proven to be this channel's worktree, so it is not
-        // elevated. This flag is preserved across the tmux reconcile below —
-        // reconcile changes a row's cwd value, not its ownership.
+        // #3219: capture ownership from the resolver's exact `channel_id = $2`
+        // match BEFORE the path-usability filter — a stale/unusable persisted cwd
+        // does not change WHO owns the row. Only a channel-scoped cwd may outrank
+        // the configured base; a NULL-channel_id legacy fallback returns false and
+        // is never elevated. This flag is preserved across the tmux reconcile
+        // below (reconcile changes a row's cwd value, not its ownership), so an
+        // owned channel whose persisted cwd went stale can still elevate the valid
+        // live worktree the reconcile supplies (the #3216 GAP2 phantom-rotation
+        // case). The final db_cwd is still re-validated by `db_cwd_is_reusable
+        // _worktree` before it can win.
         let db_cwd_channel_scoped = restored_cwd
             .as_ref()
             .map(|r| r.channel_scoped)
             .unwrap_or(false);
+        // Only a usable path is honored for install into `session.current_path`.
+        let mut db_cwd: Option<String> = restored_cwd
+            .map(|r| r.path)
+            .filter(|p| !p.is_empty() && session_path_is_usable(p, saved_remote.as_deref()));
 
         // #3216 GAP 2: reconcile the DB cwd against the live tmux pane. The live
         // pane is the source of truth for where the session actually runs; if the

--- a/src/services/discord/session_runtime.rs
+++ b/src/services/discord/session_runtime.rs
@@ -797,11 +797,12 @@ pub(super) async fn auto_restore_session_force(
             })
         });
         let mut db_cwd: Option<String> = restored_cwd.as_ref().map(|r| r.path.clone());
-        // #3219: only a channel-scoped cwd (exact channel-id match) — or the
-        // tmux-reconciled cwd below, which is THIS channel's live pane — may
-        // outrank the configured base. A NULL-channel_id legacy fallback is not
-        // proven to be this channel's worktree.
-        let mut db_cwd_channel_scoped = restored_cwd
+        // #3219: only a channel-scoped cwd (the resolver's exact `channel_id = $2`
+        // match) may outrank the configured base. A NULL-channel_id legacy
+        // fallback is not proven to be this channel's worktree, so it is not
+        // elevated. This flag is preserved across the tmux reconcile below —
+        // reconcile changes a row's cwd value, not its ownership.
+        let db_cwd_channel_scoped = restored_cwd
             .as_ref()
             .map(|r| r.channel_scoped)
             .unwrap_or(false);
@@ -836,7 +837,7 @@ pub(super) async fn auto_restore_session_force(
                     db_cwd.as_deref(),
                     reconciled
                 );
-                let claimed_rows = correct_session_cwd_to_tmux(
+                correct_session_cwd_to_tmux(
                     shared.pg_pool.as_ref(),
                     &shared.token_hash,
                     &provider,
@@ -845,14 +846,16 @@ pub(super) async fn auto_restore_session_force(
                     &reconciled,
                 );
                 db_cwd = Some(reconciled);
-                // #3219: only treat the reconciled cwd as channel-owned (and thus
-                // eligible to outrank the configured base) when the scoped UPDATE
-                // actually claimed a row (`channel_id = $2 OR channel_id IS NULL`).
-                // A name-collision channel that shares the tmux session name but
-                // not the row (it carries a different non-null channel_id) updates
-                // 0 rows here, so it is NOT elevated into the other channel's
-                // worktree — it falls through to the configured base.
-                db_cwd_channel_scoped = claimed_rows > 0;
+                // #3219: do NOT recompute channel-ownership here. Reconcile only
+                // changes a row's cwd VALUE, not WHO owns the row, so we preserve
+                // `db_cwd_channel_scoped` from the resolver's bulletproof exact
+                // `channel_id = $2` match. `session_key` is globally unique, so
+                // under a tmux-name collision only the TRUE owner ever gets
+                // `channel_scoped = true` from the resolver; the intruder gets
+                // false and is never elevated into the owner's worktree. (A row
+                // freshly stamped from a NULL legacy row stays non-scoped — its
+                // ownership is ambiguous under collision — so it is not elevated;
+                // it self-heals to an exact match on the next heartbeat.)
             }
         }
         let persisted_path = load_last_session_path(
@@ -1106,12 +1109,6 @@ fn restore_session_cwd_from_db(
 /// too — only the row whose id equals THIS channel OR is NULL is updated — so the
 /// row both adopts the correct cwd and gets self-healed onto this channel.
 ///
-/// Returns the number of rows updated. #3219: the caller uses this to decide
-/// whether the reconciled cwd is channel-OWNED (≥1 row matched `channel_id = $2
-/// OR channel_id IS NULL`) before letting it outrank the configured base. A
-/// name-collision channel sharing the tmux session name but NOT the row (the row
-/// carries a different non-null channel_id) updates 0 rows and is thus never
-/// elevated into another channel's worktree.
 fn correct_session_cwd_to_tmux(
     pg_pool: Option<&sqlx::PgPool>,
     token_hash: &str,
@@ -1119,9 +1116,9 @@ fn correct_session_cwd_to_tmux(
     channel_name: &str,
     channel_id: u64,
     tmux_cwd: &str,
-) -> u64 {
+) {
     let Some(pool) = pg_pool else {
-        return 0;
+        return;
     };
     let tmux_name = provider.build_tmux_session_name(channel_name);
     let session_keys = build_session_key_candidates(token_hash, provider, &tmux_name);
@@ -1152,23 +1149,17 @@ fn correct_session_cwd_to_tmux(
         |error| error,
     );
     match result {
-        Ok(updated) if updated > 0 => {
-            tracing::info!(
-                "  ↻ #3216 reconciled DB cwd to live tmux pane for channel {} ({} row(s))",
-                channel_id,
-                updated
-            );
+        Ok(updated) if updated > 0 => tracing::info!(
+            "  ↻ #3216 reconciled DB cwd to live tmux pane for channel {} ({} row(s))",
+            channel_id,
             updated
-        }
-        Ok(_) => 0,
-        Err(err) => {
-            tracing::warn!(
-                "  ⚠ #3216 failed to reconcile DB cwd to live tmux for channel {}: {}",
-                channel_id,
-                err
-            );
-            0
-        }
+        ),
+        Ok(_) => {}
+        Err(err) => tracing::warn!(
+            "  ⚠ #3216 failed to reconcile DB cwd to live tmux for channel {}: {}",
+            channel_id,
+            err
+        ),
     }
 }
 

--- a/src/services/discord/session_runtime.rs
+++ b/src/services/discord/session_runtime.rs
@@ -43,26 +43,29 @@ pub(super) fn select_restored_session_path(
     db_cwd: Option<String>,
     yaml_path: Option<String>,
     remote_profile_name: Option<&str>,
+    db_cwd_is_reusable_worktree: bool,
 ) -> Option<String> {
-    // #3219: a channel-scoped DB cwd that points to an existing, AgentDesk-managed
-    // worktree must win over the configured *base* workspace. Otherwise
-    // provider-channel worktree isolation re-derives a FRESH worktree from the
-    // base on recovery, abandoning the session's existing worktree and its
-    // provider transcript — so `--resume` falls back to a fresh session-id.
-    // While the tmux pane survives this is masked by the live-TUI-binding recovery
-    // path; once the pane dies (crash/kill/restart) there is no fallback and
-    // resume breaks (root cause of the 2026-06-07 resume failure: recovery read
-    // the correct worktree from the DB, logged "Ignoring restored DB cwd", then
-    // built a fresh worktree + session-id).
+    // #3219: when the channel-scoped DB cwd is the channel's OWN existing managed
+    // worktree (caller-validated by `db_cwd_is_reusable_worktree`: under
+    // `worktrees_root`, a linked worktree, and sharing the configured parent
+    // repo's git common dir), prefer it over the configured *base* workspace.
+    // Otherwise crash/kill recovery installs the base as cwd, provider-channel
+    // worktree isolation re-derives a FRESH worktree + provider session-id, and
+    // `--resume` breaks — abandoning the session's transcript. The live-TUI
+    // -binding recovery path masks this only while the tmux pane survives; once
+    // the pane dies there is no fallback (root cause of the 2026-06-07 resume
+    // failure: recovery read the correct worktree from the DB, logged "Ignoring
+    // restored DB cwd", then built a fresh worktree + session-id).
     //
-    // Reconfiguration safety is preserved: a moved/renamed base relocates
-    // `worktrees_root()`, so a stale worktree no longer matches
-    // `is_managed_worktree_path` and falls through to the configured path below.
-    // A configured workspace that merely *is* a linked worktree lives outside
-    // `worktrees_root()` and is likewise unaffected.
-    if let Some(worktree) = db_cwd.as_ref().filter(|path| {
-        is_managed_worktree_path(path) && session_path_is_usable(path, remote_profile_name)
-    }) {
+    // The predicate uses the SAME guard set as `resolve_reusable_worktree`, so a
+    // stale/foreign/relocated worktree — including a workspace repointed to a
+    // different repo under the same `worktrees_root` — is NOT elevated and falls
+    // through to the configured path below.
+    if db_cwd_is_reusable_worktree
+        && let Some(worktree) = db_cwd
+            .as_ref()
+            .filter(|path| session_path_is_usable(path, remote_profile_name))
+    {
         return Some(worktree.clone());
     }
 
@@ -70,6 +73,27 @@ pub(super) fn select_restored_session_path(
         .filter(|path| session_path_is_usable(path, remote_profile_name))
         .or_else(|| db_cwd.filter(|path| session_path_is_usable(path, remote_profile_name)))
         .or_else(|| yaml_path.filter(|path| session_path_is_usable(path, remote_profile_name)))
+}
+
+/// #3219: true when the recovered DB cwd is the channel's own reusable managed
+/// worktree and must therefore outrank the configured base workspace in
+/// [`select_restored_session_path`]. Mirrors the exact guard set used by
+/// [`resolve_reusable_worktree`]: the cwd must be an AgentDesk-managed
+/// (`is_managed_worktree_path`) linked worktree that shares the configured
+/// parent repo's git common dir (`restored_worktree_belongs_to_parent`, which
+/// also rejects non-existent and remote-only paths). Returns `false` when there
+/// is no configured parent (then `select_restored_session_path`'s existing
+/// configured→db_cwd→yaml fallback already does the right thing).
+pub(super) fn db_cwd_is_reusable_worktree(
+    configured_path: Option<&str>,
+    db_cwd: Option<&str>,
+) -> bool {
+    match (configured_path, db_cwd) {
+        (Some(parent), Some(cwd)) => {
+            is_managed_worktree_path(cwd) && restored_worktree_belongs_to_parent(parent, cwd)
+        }
+        _ => false,
+    }
 }
 
 /// #3216 GAP 2: decide whether a live tmux pane's cwd should override the
@@ -818,8 +842,14 @@ pub(super) async fn auto_restore_session_force(
             channel_id.get(),
         );
 
+        // #3219: validate whether the restored DB cwd is the channel's own
+        // reusable managed worktree BEFORE selecting, so the log below reflects
+        // the actual decision (we only "ignore" it when it is NOT reused).
+        let reusable_worktree =
+            db_cwd_is_reusable_worktree(configured_path.as_deref(), db_cwd.as_deref());
         if let (Some(configured), Some(restored)) = (configured_path.as_ref(), db_cwd.as_ref())
             && configured != restored
+            && !reusable_worktree
         {
             let ts = chrono::Local::now().format("%H:%M:%S");
             tracing::info!(
@@ -835,6 +865,7 @@ pub(super) async fn auto_restore_session_force(
             db_cwd,
             persisted_path,
             saved_remote.as_deref(),
+            reusable_worktree,
         );
 
         (last_path, saved_remote, provider)
@@ -1684,92 +1715,76 @@ pub(super) async fn resolve_thread_parent(
 
 #[cfg(test)]
 mod select_restored_session_path_tests {
-    //! #3219: `select_restored_session_path` must prefer an existing managed
-    //! worktree (the channel-scoped DB cwd) over the configured *base* workspace,
-    //! or crash/kill recovery re-derives a fresh worktree and `--resume` breaks.
-    use super::select_restored_session_path;
+    //! #3219: `select_restored_session_path` must prefer the channel's own
+    //! reusable managed worktree (the channel-scoped DB cwd) over the configured
+    //! *base* workspace, or crash/kill recovery re-derives a fresh worktree and
+    //! `--resume` breaks. The reusable-worktree decision is made by the caller
+    //! (`db_cwd_is_reusable_worktree`, git-validated against the configured parent
+    //! repo); here we verify the selector honors that decision and otherwise
+    //! preserves the configured→db_cwd→yaml fallback order unchanged.
+    use super::{db_cwd_is_reusable_worktree, select_restored_session_path};
 
-    struct EnvGuard(Option<std::ffi::OsString>);
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match self.0.take() {
-                Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
-                None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
-            }
-        }
-    }
+    const BASE: &str = "/repo/workspaces/agentdesk";
+    const WT: &str = "/repo/worktrees/claude-adk-cc-113822";
 
-    fn with_root<T>(root: &std::path::Path, f: impl FnOnce() -> T) -> T {
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        let _guard = EnvGuard(std::env::var_os("AGENTDESK_ROOT_DIR"));
-        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", root) };
-        f()
+    #[test]
+    fn reusable_worktree_outranks_configured_base() {
+        let selected = select_restored_session_path(
+            Some(BASE.into()),
+            Some(WT.into()),
+            None,
+            // remote profile set → session_path_is_usable short-circuits true so
+            // the assertion does not depend on these paths existing on disk.
+            Some("remote"),
+            true,
+        );
+        assert_eq!(selected.as_deref(), Some(WT));
     }
 
     #[test]
-    fn prefers_existing_managed_worktree_over_configured_base() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path();
-        let base = root.join("workspaces").join("agentdesk");
-        let worktree = root.join("worktrees").join("claude-adk-cc-20260607-113822");
-        std::fs::create_dir_all(&base).unwrap();
-        std::fs::create_dir_all(&worktree).unwrap();
-
-        let selected = with_root(root, || {
-            select_restored_session_path(
-                Some(base.to_string_lossy().into_owned()),
-                Some(worktree.to_string_lossy().into_owned()),
-                None,
-                None,
-            )
-        });
-        assert_eq!(selected.as_deref(), worktree.to_str());
+    fn non_reusable_db_cwd_keeps_configured_priority() {
+        // When the caller's git validation says the worktree is NOT reusable
+        // (stale/foreign/relocated/remote), configured base wins as before.
+        let selected = select_restored_session_path(
+            Some(BASE.into()),
+            Some(WT.into()),
+            None,
+            Some("remote"),
+            false,
+        );
+        assert_eq!(selected.as_deref(), Some(BASE));
     }
 
     #[test]
-    fn falls_back_to_configured_when_managed_worktree_missing() {
-        // A stale/phantom worktree (not on disk) must not be selected; recovery
-        // falls through to the configured base workspace.
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path();
-        let base = root.join("workspaces").join("agentdesk");
-        let worktree = root.join("worktrees").join("claude-adk-cc-deleted");
-        std::fs::create_dir_all(&base).unwrap();
-        // worktree intentionally NOT created on disk
+    fn falls_back_to_db_cwd_then_yaml_when_no_configured() {
+        // No configured path: existing fallback order is unchanged regardless of
+        // the reusable flag.
+        let selected = select_restored_session_path(
+            None,
+            Some(WT.into()),
+            Some("/yaml/path".into()),
+            Some("remote"),
+            false,
+        );
+        assert_eq!(selected.as_deref(), Some(WT));
 
-        let selected = with_root(root, || {
-            select_restored_session_path(
-                Some(base.to_string_lossy().into_owned()),
-                Some(worktree.to_string_lossy().into_owned()),
-                None,
-                None,
-            )
-        });
-        assert_eq!(selected.as_deref(), base.to_str());
+        let selected = select_restored_session_path(
+            None,
+            None,
+            Some("/yaml/path".into()),
+            Some("remote"),
+            true,
+        );
+        assert_eq!(selected.as_deref(), Some("/yaml/path"));
     }
 
     #[test]
-    fn db_cwd_outside_worktrees_root_does_not_override_configured() {
-        // A DB cwd that is NOT under `worktrees_root()` (e.g. a relocated base
-        // after reconfiguration) must keep configured-path priority.
-        let tmp = tempfile::tempdir().unwrap();
-        let root = tmp.path();
-        let base = root.join("workspaces").join("agentdesk");
-        let other = root.join("somewhere").join("else");
-        std::fs::create_dir_all(&base).unwrap();
-        std::fs::create_dir_all(&other).unwrap();
-
-        let selected = with_root(root, || {
-            select_restored_session_path(
-                Some(base.to_string_lossy().into_owned()),
-                Some(other.to_string_lossy().into_owned()),
-                None,
-                None,
-            )
-        });
-        assert_eq!(selected.as_deref(), base.to_str());
+    fn reusable_predicate_requires_configured_and_db_cwd() {
+        // No git work here: a missing configured parent or missing db_cwd can
+        // never be "reusable" (the full git validation only runs when both exist).
+        assert!(!db_cwd_is_reusable_worktree(None, Some(WT)));
+        assert!(!db_cwd_is_reusable_worktree(Some(BASE), None));
+        assert!(!db_cwd_is_reusable_worktree(None, None));
     }
 }
 

--- a/src/services/discord/watchers/lifecycle.rs
+++ b/src/services/discord/watchers/lifecycle.rs
@@ -2637,10 +2637,16 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
 
             // Restore current_path: DB cwd (worktree-aware) > last_sessions (yaml, main workspace)
             if session.current_path.is_none() {
+                // #3219: prefer the channel's own reusable managed worktree over
+                // the configured base; only log "ignoring" when it is NOT reused.
+                let reusable_worktree = super::super::session_runtime::db_cwd_is_reusable_worktree(
+                    configured_path.as_deref(),
+                    db_cwd.as_deref(),
+                );
                 if let (Some(configured), Some(restored)) =
                     (configured_path.as_ref(), db_cwd.as_ref())
                 {
-                    if configured != restored {
+                    if configured != restored && !reusable_worktree {
                         let ts = chrono::Local::now().format("%H:%M:%S");
                         tracing::info!(
                             "  [{ts}] ⚠ Ignoring restored DB cwd for channel {}: {} (configured workspace: {})",
@@ -2655,6 +2661,7 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
                     db_cwd,
                     persisted_path,
                     remote_profile.as_deref(),
+                    reusable_worktree,
                 );
                 if let Some(path) = effective_path {
                     session.current_path = Some(path);


### PR DESCRIPTION
Fixes #3219.

## Root cause
`select_restored_session_path` prioritized the configured base workspace over the channel-scoped DB cwd, so crash/kill recovery discarded the session's existing managed worktree (logged `⚠ Ignoring restored DB cwd`) and worktree isolation re-derived a fresh worktree + session-id → `--resume` broke. Live-TUI-binding masked it while the tmux pane survived; once the pane died there was no fallback (2026-06-07 resume failure after the #3216 B-verification kill).

## Fix
When the DB cwd points to an existing AgentDesk-managed worktree (under `worktrees_root`), prefer it over the configured base. Reconfiguration safety preserved: a relocated base moves `worktrees_root`, so a stale worktree falls through to the configured path. A configured workspace that merely *is* a linked worktree lives outside `worktrees_root` and is unaffected.

Both recovery call sites (`session_runtime.rs` + `watchers/lifecycle.rs`) funnel through this one function.

## Tests
3 unit tests: prefer-managed-worktree, phantom-fallback-to-base, db-cwd-outside-root-keeps-base. All green; fmt clean; cargo check clean; script-checks 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)