### PR TITLE
fix(#3221): turn-stop leaves transcript busy — classify `[Request interrupted by user]` marker as Idle

### DIFF
--- a/src/services/tui_turn_state.rs
+++ b/src/services/tui_turn_state.rs
@@ -435,6 +435,12 @@ fn envelope_is_turn_end_terminator(provider: &ProviderKind, json: &Value) -> boo
         ProviderKind::Codex => type_str == "turn.completed",
         ProviderKind::Claude => match type_str {
             "result" => true,
+            // #3221: the `[Request interrupted by user]` marker is a genuine
+            // turn boundary (the turn was aborted), so the turn-END-only scan
+            // used by the finalize `Done` decision must treat it as a
+            // terminator too — keeping the strict scan consistent with the
+            // standard observer's Idle classification of the same envelope.
+            "user" => claude_user_envelope_is_interrupt_marker(json),
             "system" => matches!(
                 json.get("subtype").and_then(Value::as_str),
                 Some("turn_duration" | "stop_hook_summary")
@@ -621,10 +627,48 @@ fn read_recent_jsonl_window(
     })
 }
 
+/// #3221: detect the trailing `[Request interrupted by user]` envelope claude
+/// writes when a turn is aborted by a session-preserving interrupt (ESC for the
+/// TUI / stream-json `control_request{interrupt}` for the wrapper, #3207).
+///
+/// The marker is a `type=user` envelope whose `message.content` carries a text
+/// block beginning with `[Request interrupted by user` (the plain and the
+/// `… for tool use` variants). Matching is deliberately narrow — only a genuine
+/// `text` block with that exact prefix — so coincidental conversation text or
+/// `tool_result` payloads that merely mention "interrupted" never trip it.
+fn claude_user_envelope_is_interrupt_marker(json: &Value) -> bool {
+    let Some(content) = json
+        .get("message")
+        .and_then(|message| message.get("content"))
+        .and_then(Value::as_array)
+    else {
+        return false;
+    };
+    content.iter().any(|block| {
+        block.get("type").and_then(Value::as_str) == Some("text")
+            && block
+                .get("text")
+                .and_then(Value::as_str)
+                .is_some_and(|text| {
+                    text.trim_start()
+                        .starts_with("[Request interrupted by user")
+                })
+    })
+}
+
 fn claude_envelope_turn_state(json: &Value) -> Option<TuiTurnState> {
     match json.get("type").and_then(Value::as_str)? {
         "result" => Some(TuiTurnState::Idle),
         "assistant" => Some(TuiTurnState::Streaming),
+        // #3221: a turn aborted via a session-preserving interrupt leaves a
+        // trailing `[Request interrupted by user]` user envelope as the newest
+        // entry. It is `type=user` but marks the turn as ENDED, not a fresh
+        // submission. Classifying it `UserSubmitted` left the JSONL-authoritative
+        // busy gate (#3208) reporting the stopped turn as in-flight forever, so
+        // the next user message was wrongly queued as `*_tui_busy_pre_submit`
+        // after a ⏳-removal / `!stop` / `/stop` / watchdog stop. Treat the
+        // interrupt marker as Idle so the next input starts a fresh turn.
+        "user" if claude_user_envelope_is_interrupt_marker(json) => Some(TuiTurnState::Idle),
         "user" => Some(TuiTurnState::UserSubmitted),
         // `permission-mode` envelopes (e.g. `bypassPermissions` adoption after
         // a fresh session start triggered by hard_reset or `/compact`) are not
@@ -859,6 +903,114 @@ mod tests {
             observe_claude_jsonl_turn_state(file.path()),
             TuiTurnState::UserSubmitted
         );
+    }
+
+    // #3221: a turn aborted via a session-preserving interrupt (ESC / wrapper
+    // control_request{interrupt}, #3207) leaves a trailing
+    // `[Request interrupted by user]` user envelope. That marks the turn ENDED,
+    // not a fresh submission, so the JSONL-authoritative busy gate (#3208) must
+    // see Idle — otherwise the stopped turn looks in-flight forever and the next
+    // message is wrongly queued as `*_tui_busy_pre_submit`.
+    #[test]
+    fn claude_interrupt_marker_marks_idle() {
+        let file = write_jsonl(&[
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"do something"}]}}"#,
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"working"}]}}"#,
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"[Request interrupted by user]"}]}}"#,
+        ]);
+
+        assert_eq!(
+            observe_claude_jsonl_turn_state(file.path()),
+            TuiTurnState::Idle
+        );
+    }
+
+    // The `… for tool use` interrupt variant must be recognized too.
+    #[test]
+    fn claude_interrupt_marker_for_tool_use_marks_idle() {
+        let file = write_jsonl(&[
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"running tool"}]}}"#,
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"[Request interrupted by user for tool use]"}]}}"#,
+        ]);
+
+        assert_eq!(
+            observe_claude_jsonl_turn_state(file.path()),
+            TuiTurnState::Idle
+        );
+    }
+
+    // Realistic tail: claude appends a `file-history-snapshot` after the
+    // interrupt marker. The observer walks past the snapshot (no turn-state
+    // signal) and still reads the marker as Idle.
+    #[test]
+    fn claude_interrupt_marker_then_file_history_snapshot_marks_idle() {
+        let file = write_jsonl(&[
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"working"}]}}"#,
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"[Request interrupted by user]"}]}}"#,
+            r#"{"type":"file-history-snapshot","messageId":"x"}"#,
+        ]);
+
+        assert_eq!(
+            observe_claude_jsonl_turn_state(file.path()),
+            TuiTurnState::Idle
+        );
+    }
+
+    // Suppression must be one-shot: once the user submits a NEW prompt after the
+    // interrupt marker, the turn is genuinely busy again.
+    #[test]
+    fn claude_new_prompt_after_interrupt_marker_is_user_submitted() {
+        let file = write_jsonl(&[
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"[Request interrupted by user]"}]}}"#,
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"actually do this instead"}]}}"#,
+        ]);
+
+        assert_eq!(
+            observe_claude_jsonl_turn_state(file.path()),
+            TuiTurnState::UserSubmitted
+        );
+    }
+
+    // Precision guard: a real user prompt that merely *mentions* the word
+    // interrupted (or a tool_result echoing it) must NOT be mistaken for the
+    // turn-end marker.
+    #[test]
+    fn claude_user_text_mentioning_interrupted_stays_user_submitted() {
+        let file = write_jsonl(&[
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"why was the request interrupted by user earlier?"}]}}"#,
+        ]);
+
+        assert_eq!(
+            observe_claude_jsonl_turn_state(file.path()),
+            TuiTurnState::UserSubmitted
+        );
+    }
+
+    // The turn-END-only strict scan (finalize `Done` decision) must agree with
+    // the standard observer that the interrupt marker is a genuine terminator.
+    #[test]
+    fn claude_interrupt_marker_is_turn_end_terminator() {
+        let marker: Value = serde_json::from_str(
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"[Request interrupted by user]"}]}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            claude_envelope_turn_state(&marker),
+            Some(TuiTurnState::Idle)
+        );
+        assert!(envelope_is_turn_end_terminator(
+            &ProviderKind::Claude,
+            &marker
+        ));
+
+        let plain_user: Value = serde_json::from_str(
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}"#,
+        )
+        .unwrap();
+        assert!(!envelope_is_turn_end_terminator(
+            &ProviderKind::Claude,
+            &plain_user
+        ));
     }
 
     #[test]

--- a/src/services/tui_turn_state.rs
+++ b/src/services/tui_turn_state.rs
@@ -627,33 +627,69 @@ fn read_recent_jsonl_window(
     })
 }
 
+/// #3221: the exact set of trailing `[Request interrupted by user…]` markers
+/// claude writes when a turn is aborted by a session-preserving interrupt (ESC
+/// for the TUI / stream-json `control_request{interrupt}` for the wrapper,
+/// #3207). Verified from real transcripts — these are the only two variants.
+///
+/// Matching is by EXACT equality (not prefix), so a user-TYPED prompt like
+/// `[Request interrupted by user story…]` can never false-positive. A future
+/// unknown variant becoming a false-NEGATIVE is safe (the turn merely stays busy
+/// and self-heals on the next turn); a false-POSITIVE is not (it would drop a
+/// real in-flight user turn). Add new variants here as they are observed.
+const CLAUDE_INTERRUPT_MARKERS: [&str; 2] = [
+    "[Request interrupted by user]",
+    "[Request interrupted by user for tool use]",
+];
+
 /// #3221: detect the trailing `[Request interrupted by user]` envelope claude
 /// writes when a turn is aborted by a session-preserving interrupt (ESC for the
 /// TUI / stream-json `control_request{interrupt}` for the wrapper, #3207).
 ///
-/// The marker is a `type=user` envelope whose `message.content` carries a text
-/// block beginning with `[Request interrupted by user` (the plain and the
-/// `… for tool use` variants). Matching is deliberately narrow — only a genuine
-/// `text` block with that exact prefix — so coincidental conversation text or
-/// `tool_result` payloads that merely mention "interrupted" never trip it.
+/// The marker is a `type=user` envelope whose `message.content` is effectively a
+/// SINGLE text block that IS exactly one of `CLAUDE_INTERRUPT_MARKERS` (the
+/// plain and the `… for tool use` variants). Matching is deliberately narrow on
+/// two axes:
+///   - single-block only: a multi-block user message that merely *includes* a
+///     marker-looking block alongside real content is rejected, so a genuine
+///     in-flight user turn is never dropped;
+///   - exact equality (not prefix): a user-typed prompt such as
+///     `[Request interrupted by user story…]` never trips it.
+/// `content` may also be a plain string (older shape); the same exact check
+/// applies. Coincidental conversation text or `tool_result` payloads that merely
+/// mention "interrupted" therefore never match.
 fn claude_user_envelope_is_interrupt_marker(json: &Value) -> bool {
     let Some(content) = json
         .get("message")
         .and_then(|message| message.get("content"))
-        .and_then(Value::as_array)
     else {
         return false;
     };
-    content.iter().any(|block| {
-        block.get("type").and_then(Value::as_str) == Some("text")
-            && block
-                .get("text")
-                .and_then(Value::as_str)
-                .is_some_and(|text| {
-                    text.trim_start()
-                        .starts_with("[Request interrupted by user")
-                })
-    })
+    let text = match content {
+        // Plain-string content: the whole string must be the marker.
+        Value::String(text) => text.as_str(),
+        // Array content: must be exactly one block, and that block must be a
+        // `text` block whose text is the marker. Rejecting >1 block prevents a
+        // multi-block message that merely embeds a marker-looking block from
+        // being misclassified as a turn terminator.
+        Value::Array(blocks) => {
+            let [block] = blocks.as_slice() else {
+                return false;
+            };
+            if block.get("type").and_then(Value::as_str) != Some("text") {
+                return false;
+            }
+            let Some(text) = block.get("text").and_then(Value::as_str) else {
+                return false;
+            };
+            text
+        }
+        _ => return false,
+    };
+    let text = text.trim();
+    CLAUDE_INTERRUPT_MARKERS
+        .iter()
+        .any(|marker| text == *marker)
 }
 
 fn claude_envelope_turn_state(json: &Value) -> Option<TuiTurnState> {
@@ -980,6 +1016,62 @@ mod tests {
             r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"why was the request interrupted by user earlier?"}]}}"#,
         ]);
 
+        assert_eq!(
+            observe_claude_jsonl_turn_state(file.path()),
+            TuiTurnState::UserSubmitted
+        );
+    }
+
+    // Precision guard (#3222 codex follow-up): a user-TYPED prompt that merely
+    // *starts with* the marker prefix (`[Request interrupted by user story…]`)
+    // must NOT match. Exact-equality matching keeps it `UserSubmitted` and not a
+    // terminator, so a real in-flight turn is never dropped.
+    #[test]
+    fn claude_interrupt_marker_prefixed_prose_stays_user_submitted() {
+        let prose: Value = serde_json::from_str(
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"[Request interrupted by user story]"}]}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            claude_envelope_turn_state(&prose),
+            Some(TuiTurnState::UserSubmitted)
+        );
+        assert!(!envelope_is_turn_end_terminator(
+            &ProviderKind::Claude,
+            &prose
+        ));
+
+        let file = write_jsonl(&[
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"[Request interrupted by user story]"}]}}"#,
+        ]);
+        assert_eq!(
+            observe_claude_jsonl_turn_state(file.path()),
+            TuiTurnState::UserSubmitted
+        );
+    }
+
+    // Precision guard (#3222 codex follow-up): a multi-block user message where
+    // one block equals the marker but another carries real user content must NOT
+    // match. Single-block-only matching keeps it `UserSubmitted` and not a
+    // terminator, so the in-flight turn is preserved.
+    #[test]
+    fn claude_interrupt_marker_with_extra_block_stays_user_submitted() {
+        let multi_block: Value = serde_json::from_str(
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"[Request interrupted by user]"},{"type":"text","text":"actually keep going"}]}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            claude_envelope_turn_state(&multi_block),
+            Some(TuiTurnState::UserSubmitted)
+        );
+        assert!(!envelope_is_turn_end_terminator(
+            &ProviderKind::Claude,
+            &multi_block
+        ));
+
+        let file = write_jsonl(&[
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"[Request interrupted by user]"},{"type":"text","text":"actually keep going"}]}}"#,
+        ]);
         assert_eq!(
             observe_claude_jsonl_turn_state(file.path()),
             TuiTurnState::UserSubmitted


### PR DESCRIPTION
## Root cause (file:line)
`src/services/tui_turn_state.rs` — `claude_envelope_turn_state` mapped every `type=user` JSONL envelope to `TuiTurnState::UserSubmitted` (busy).

When a turn is stopped by a **session-preserving interrupt** (#3207: ESC for the TUI / stream-json `control_request{interrupt}` for the wrapper), Claude appends a trailing `[Request interrupted by user]` envelope as the newest JSONL entry. That envelope is `type=user`, so the transcript classifier reported the **already-stopped** turn as still in-flight. The #3208 **JSONL-authoritative busy gate** (`tui_busy_followup_diagnostic` → `observe_claude_tui_transcript_state_for_session` → `observe_claude_jsonl_turn_state`) then deferred the next user message to the queue as `*_tui_busy_pre_submit` — forever, because the transcript never advances past the marker.

This is **not** a stop-plumbing bug. Verified against the live repro (adk-cc `1479671298497183835`, 2026-06-07 KST):
- `21:31:00` `claude turn interrupt delivered (session preserved): … reason=reaction remove ⏳ (if_current) mechanism=TuiEscape` — the real interrupt **was** delivered via the #3207/#3213 path.
- `21:31:01` `🛑 TURN-STOP: cancelled active turn … via reaction removal` — stop tombstone recorded, inflight cleared (busy diagnostic shows `inflight_state="missing"`).
- `21:31:35` `tui follow-up: prior turn genuinely busy per JSONL … transcript_turn_state="user_submitted"` → message queued; deferred drain then spun `hosted_tui_busy_pre_submit_pending` 150×.

So the interrupt + stop-record + inflight-clear all happened; the **only** wrong signal was the transcript classification of the interrupt marker.

(Note on the issue's `recent_stop_reason="none"`: that field is offset-gated — `recent_turn_stop_for_watcher_range` matches only `data_start_offset < stop_offset`, so it correctly reads `none` once the watcher range crosses the stop boundary. It is a red herring; the stop **was** recorded.)

## The fix
`src/services/tui_turn_state.rs` only:
- New `claude_user_envelope_is_interrupt_marker(json)` — narrow match: a `type=user` envelope whose `message.content` array has a `text` block beginning with `[Request interrupted by user` (covers the plain and `… for tool use` variants). Coincidental "interrupted" mentions / `tool_result` payloads do not trip it.
- `claude_envelope_turn_state`: `"user"` + interrupt marker → `Idle` (turn ENDED), otherwise `UserSubmitted` as before.
- `envelope_is_turn_end_terminator`: the turn-END-only strict scan (finalize `Done` decision) recognizes the same marker as a genuine terminator, keeping it consistent with the standard walk-back observer.

Fixes **all** stop surfaces (reaction-remove / `!stop` / `/stop` / watchdog), since they all route through the same #3207 interrupt and leave the same marker.

## Invariants preserved
- Normal path unchanged: a plain user prompt is still `UserSubmitted` (busy); a **new** prompt after the marker is `UserSubmitted` again (one-shot suppression, not sticky).
- #3207 (session preserved on stop): untouched — no change to interrupt/cancel plumbing.
- #3208 (no false-busy + JSONL-authoritative readiness): strengthened — an interrupted turn is now correctly at-rest instead of stuck busy.
- No #3016 core hot file touched (`turn_bridge/mod.rs`, `tmux_watcher.rs`, `session_relay_sink.rs`, `turn_finalizer.rs` all untouched).

## Tests (new, in `tui_turn_state`)
- `claude_interrupt_marker_marks_idle`
- `claude_interrupt_marker_for_tool_use_marks_idle`
- `claude_interrupt_marker_then_file_history_snapshot_marks_idle` (realistic tail)
- `claude_new_prompt_after_interrupt_marker_is_user_submitted` (one-shot)
- `claude_user_text_mentioning_interrupted_stays_user_submitted` (precision guard)
- `claude_interrupt_marker_is_turn_end_terminator` (strict-scan agreement)

## Gate results
- `cargo fmt --check` clean.
- `cargo check --lib` clean (only pre-existing unrelated warnings).
- `cargo test --lib tui_turn_state` → 62 passed, 0 failed (incl. 6 new).
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` → `agent-maintenance freshness check passed` (no doc deltas).

## Residual risk for reviewer
- Assumes Claude always writes the `[Request interrupted by user]` marker on a session-preserving abort. Confirmed across many on-disk transcripts; both the plain and `for tool use` variants are handled. If a wrapper (stream-json) abort path ever omitted the marker, the runtime stop tombstone (recorded unconditionally on every stop) remains an available secondary signal — out of scope here.
- The marker→Idle change also flows into the Lenient strict scan (`jsonl_strict_terminator_idle`) and finalize `Done` path; this is intentional (an interrupted turn is genuinely done) and behavior-preserving, but worth a look re: finalize timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)