### PR TITLE
fix(#3016): phase-5a reconciler far-backstop for watcher-owned register_start Pending

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -116,7 +116,7 @@
   - `src/services/discord/watchers/lifecycle.rs` (2336 lines — canonical
     lifecycle extraction surface from #1435; split further before adding new
     lifecycle behavior).
-  - `src/services/discord/tmux.rs` (2251 lines after #2558 dead-code sweep;
+  - `src/services/discord/tmux.rs` (2260 lines after #2558 dead-code sweep;
     +4 from #3167: the monitor-auto-turn start passes `ActiveTurnKind::Background`
     so a queued user message can supersede the low-priority monitor/loop turn;
     failover guard; #3087 `session_panel_instance_key`/`write_spawn_nonce`
@@ -381,7 +381,7 @@
     the REAL atomic helper against REAL on-disk inflight: a follow-up's inflight on
     disk → atomic clear is a no-op (follow-up preserved); the pinned turn on disk →
     atomic clear removes it (happy path).
-  - `src/services/discord/tui_prompt_relay.rs` (5142 lines; SSH-direct TUI
+  - `src/services/discord/tui_prompt_relay.rs` (5144 lines; SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +4 from #3167: the self-paced TUI loop relay
     starts its synthetic turn with `ActiveTurnKind::Background` so a queued user

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -405,3 +405,16 @@
   it owns); this change only narrows which in-process side-effects fire on a
   turn boundary and introduces no new multinode ownership/singleton/lease
   assumption.
+- #3016 phase-5a (reconciler far-backstop enabler): `turn_finalizer.rs` changed
+  by arming a generous `WATCHER_REGISTER_BACKSTOP` (the legacy 1800s
+  placeholder-sweeper horizon) on watcher-owned `register_start` Pending entries
+  and adding a reconciler pass that finalizes them ONLY after a liveness
+  re-check (`watcher_backstop_turn_is_terminal`: never a `PausedLive`/paused/
+  pane-busy turn; `Unknown` non-JSONL runtimes gated on pane-idle). The
+  `TurnFinalizer` actor is already **worker-local** (one actor per in-process
+  `SharedData`, owning its ledger and a `Weak<SharedData>`); the backstop reads
+  only this process's ledger plus the local tmux pane/transcript via the
+  existing `tmux_watchers` registry and `tui_turn_state`/`provider` probes. It
+  acquires no lease, touches no durable queue, and changes no leader/standby
+  ownership — finalize remains the same per-process exactly-once unit. No new
+  multinode ownership/singleton/lease assumption is introduced.

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -417,4 +417,10 @@
   existing `tmux_watchers` registry and `tui_turn_state`/`provider` probes. It
   acquires no lease, touches no durable queue, and changes no leader/standby
   ownership — finalize remains the same per-process exactly-once unit. No new
-  multinode ownership/singleton/lease assumption is introduced.
+  multinode ownership/singleton/lease assumption is introduced. (codex HIGH
+  follow-up: the reconcile cache `Weak<SharedData>` is now primed at the FIRST
+  `register_start` — the `Start` message carries a `Weak` downgraded from the
+  caller's `Arc<SharedData>` — instead of only at the first `Terminal`, so the
+  far-backstop is deterministic for a fresh worker-local actor whose first
+  watcher turn never submits its own terminal. Still worker-local `Weak`, no
+  cross-node reference.)

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -1130,7 +1130,12 @@ fn next_monitor_auto_turn_ledger_generation() -> u64 {
 }
 
 async fn start_monitor_auto_turn_when_available(
-    shared: &SharedData,
+    // #3016 phase-5a: `&Arc<SharedData>` (not `&SharedData`) so `register_start`
+    // can downgrade a `Weak` into the `Start` message and prime the finalizer's
+    // reconcile cache at register time — the watcher callers already pass
+    // `&shared` (an `Arc`), so the `&SharedData` deref-coercion is simply
+    // dropped here; no caller change is needed.
+    shared: &Arc<SharedData>,
     provider: &ProviderKind,
     channel_id: ChannelId,
     data_start_offset: u64,
@@ -1181,6 +1186,10 @@ async fn start_monitor_auto_turn_when_available(
                 ),
                 provider.clone(),
                 crate::services::discord::inflight::RelayOwnerKind::Watcher,
+                // #3016 phase-5a: prime the reconcile cache at register time so
+                // the watcher far-backstop fires even for a fresh actor whose
+                // first watcher turn never submits its own terminal.
+                shared,
             );
             return MonitorAutoTurnStart {
                 acquired: true,

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -1715,6 +1715,8 @@ fn pending_start_claim_fn() -> super::tui_direct_pending_start::ClaimFn {
                 ),
                 provider.clone(),
                 super::inflight::RelayOwnerKind::Watcher,
+                // #3016 phase-5a: prime the reconcile cache at register time.
+                shared,
             );
 
             let claim = claim_tui_direct_synthetic_turn(

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -4201,6 +4201,8 @@ fn handle_watcher_runtime_handoff(
                 ),
                 provider.clone(),
                 super::inflight::RelayOwnerKind::Watcher,
+                // #3016 phase-5a: prime the reconcile cache at register time.
+                shared_owned,
             );
             watcher
                 .paused
@@ -6132,6 +6134,9 @@ pub(super) fn spawn_turn_bridge(
                                         ),
                                         provider.clone(),
                                         super::inflight::RelayOwnerKind::Watcher,
+                                        // #3016 phase-5a: prime the reconcile cache
+                                        // at register time.
+                                        &shared_owned,
                                     );
                                     // #1452 (Codex iter 3 P1): unpause must
                                     // use Release ordering so a watcher

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -64,6 +64,21 @@ const RECONCILE_INTERVAL: Duration = Duration::from_millis(1000);
 /// guarantees finalize eventually fires.
 const GATE_BACKSTOP: Duration = Duration::from_secs(8);
 
+/// #3016 phase-5a — the FAR backstop for a watcher-owned `register_start`
+/// Pending that never received a terminal (the under-finalize gap: the watcher
+/// delegated relay, delivered content, but the fresh-idle finalize never fired,
+/// and the legacy `placeholder_sweeper` SKIPS such rows because content was
+/// already delivered — see `placeholder_sweeper.rs` ~393). Reusing the legacy
+/// 1800s placeholder-sweeper abandon horizon keeps the window GENEROUS on
+/// purpose: it must NOT prematurely finalize a legitimately long paused-live
+/// turn (a selector / permission prompt, a subagent, or a long silent tool
+/// call can idle for minutes). This is explicitly NOT the short 8s
+/// `GATE_BACKSTOP`, and at the deadline the reconciler additionally re-checks
+/// liveness (`watcher_backstop_turn_is_terminal`) so a still-live turn is
+/// deferred rather than finalized.
+const WATCHER_REGISTER_BACKSTOP: Duration =
+    Duration::from_secs(super::placeholder_sweeper::ABANDON_THRESHOLD_SECS);
+
 /// TTL after which a `Finalized` ledger entry is garbage-collected so the
 /// ledger stays bounded while still suppressing a late double-submit.
 const FINALIZED_TTL: Duration = Duration::from_secs(60);
@@ -389,6 +404,14 @@ struct LedgerEntry {
     /// Backstop deadline for a deferred gate-timeout. `None` unless a
     /// `GateTimeout{Some(false)}` armed it.
     terminal_deadline: Option<Instant>,
+    /// #3016 phase-5a — FAR backstop deadline armed at `register_start` for a
+    /// watcher-owned turn. Distinct from `terminal_deadline` (the short 8s
+    /// gate-timeout backstop): this is the generous `WATCHER_REGISTER_BACKSTOP`
+    /// horizon that makes a never-terminated watcher handoff VISIBLE to the
+    /// reconciler so the mailbox/inflight is finalized even when no terminal is
+    /// ever submitted. The reconciler re-checks liveness before finalizing it.
+    /// `None` for non-watcher owners (bridge/standby finalize inline).
+    watcher_backstop_deadline: Option<Instant>,
     /// When the entry reached `Finalized`, for TTL-based GC.
     finalized_at: Option<Instant>,
 }
@@ -685,20 +708,7 @@ impl TurnFinalizer {
         runtime_kind: Option<crate::services::agent_protocol::RuntimeHandoffKind>,
         transcript_path: &std::path::Path,
     ) -> CompletionSignal {
-        if !crate::services::tui_turn_state::provider_runtime_has_structured_jsonl_turn_state(
-            provider,
-            runtime_kind,
-        ) {
-            return CompletionSignal::Unknown;
-        }
-        if crate::services::tui_turn_state::jsonl_turn_end_terminator_idle(
-            provider,
-            transcript_path,
-        ) {
-            CompletionSignal::Done
-        } else {
-            CompletionSignal::PausedLive
-        }
+        completion_signal_from_transcript(provider, runtime_kind, transcript_path)
     }
 
     /// #3016 S1 (A2-banked, READ-ONLY): whether the channel's `generation` has a
@@ -753,6 +763,20 @@ async fn actor_loop(mut rx: mpsc::UnboundedReceiver<FinalizeMsg>) {
                         provider,
                         relay_owner,
                     } => {
+                        // #3016 phase-5a: a watcher-owned handoff arms the FAR
+                        // backstop so a never-terminated turn still becomes visible
+                        // to the reconciler. `get_or_insert`: set ONCE — never push
+                        // an armed deadline forward on a repeat `Start` (the EPIC's
+                        // never-finalizing bug, mirrored from the gate-timeout arm).
+                        // The reconcile that consumes this deadline runs off the
+                        // actor's cached `Weak<SharedData>`, which is populated by
+                        // the first `Terminal` the finalizer ever processes; a live
+                        // runtime finalizes turns continuously, so the cache is set
+                        // long before any `WATCHER_REGISTER_BACKSTOP` horizon
+                        // elapses (a `Start` carries no `SharedData` to cache here,
+                        // and the rows the backstop catches never submit a terminal
+                        // of their own).
+                        let arm_watcher_backstop = relay_owner == RelayOwnerKind::Watcher;
                         // A `Start` always carries the real `user_msg_id`, so it
                         // registers under the exact full-identity key.
                         ledger
@@ -764,6 +788,11 @@ async fn actor_loop(mut rx: mpsc::UnboundedReceiver<FinalizeMsg>) {
                                     e.relay_owner = relay_owner;
                                     e.provider = provider.clone();
                                     e.turn_key = key;
+                                    if arm_watcher_backstop {
+                                        e.watcher_backstop_deadline.get_or_insert_with(|| {
+                                            Instant::now() + WATCHER_REGISTER_BACKSTOP
+                                        });
+                                    }
                                 }
                             })
                             .or_insert(LedgerEntry {
@@ -772,6 +801,8 @@ async fn actor_loop(mut rx: mpsc::UnboundedReceiver<FinalizeMsg>) {
                                 provider,
                                 turn_key: key,
                                 terminal_deadline: None,
+                                watcher_backstop_deadline: arm_watcher_backstop
+                                    .then(|| Instant::now() + WATCHER_REGISTER_BACKSTOP),
                                 finalized_at: None,
                             });
                     }
@@ -914,6 +945,9 @@ async fn handle_terminal(
         provider,
         turn_key: key,
         terminal_deadline: None,
+        // Orphan/terminal-first entries (no prior `register_start`) finalize
+        // right here, so they never need the watcher far-backstop.
+        watcher_backstop_deadline: None,
         finalized_at: None,
     });
 
@@ -1244,9 +1278,146 @@ fn handle_release_delivery(
     lease.release(holder, key, start, end)
 }
 
+/// #3016 S1 (PURE) — the structural completion signal derived solely from the
+/// provider's on-disk JSONL transcript. Free-function core shared by the public
+/// `TurnFinalizer::completion_signal_state` (caller-task read) and the
+/// reconciler's watcher-backstop liveness re-check, which has no `&self`
+/// `TurnFinalizer` to call the method on. See `completion_signal_state` for the
+/// full Done/PausedLive/Unknown rationale.
+fn completion_signal_from_transcript(
+    provider: &ProviderKind,
+    runtime_kind: Option<crate::services::agent_protocol::RuntimeHandoffKind>,
+    transcript_path: &std::path::Path,
+) -> CompletionSignal {
+    if !crate::services::tui_turn_state::provider_runtime_has_structured_jsonl_turn_state(
+        provider,
+        runtime_kind,
+    ) {
+        return CompletionSignal::Unknown;
+    }
+    if crate::services::tui_turn_state::jsonl_turn_end_terminator_idle(provider, transcript_path) {
+        CompletionSignal::Done
+    } else {
+        CompletionSignal::PausedLive
+    }
+}
+
+/// #3016 phase-5a — the reconciler's liveness re-check at a watcher-owned
+/// `register_start` far-backstop deadline. Returns `true` ONLY when the turn is
+/// genuinely terminal, so a legitimately long paused-live turn is NEVER
+/// finalized at the deadline (the over-finalize hazard the EPIC must avoid):
+///   * NO live watcher handle → terminal. Nothing left will drive the pane to
+///     quiescence or submit a terminal, so finalizing is the only way the
+///     mailbox/inflight is ever released (mirrors the no-owner immediate
+///     gate-timeout path in `handle_terminal`).
+///   * `paused` (a Discord turn took the session over during the long wait) →
+///     NOT terminal: defer, exactly like the fresh-idle `AbortFollowupTookOver`
+///     guard, so the backstop never releases a follow-up turn.
+///   * `PausedLive` (JSONL terminator absent — selector / permission prompt /
+///     subagent / long silent tool call) → NOT terminal: defer.
+///   * `Done` (JSONL terminator PROVEN, offset-independent by construction) →
+///     terminal.
+///   * `Unknown` (non-JSONL runtime: legacy tmux wrapper, or a non-JSONL
+///     provider — Gemini / OpenCode / Qwen) → terminal ONLY when the tmux pane
+///     is idle / ready-for-input. With no structured transcript, `deadline +
+///     pane-idle` is the sole terminal criterion available, and the pane-idle
+///     probe is the SAME one the live watcher's `watcher_session_ready_for_input`
+///     fallback uses.
+fn watcher_backstop_turn_is_terminal(
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+    provider: &ProviderKind,
+) -> bool {
+    let (tmux_session_name, output_path, paused) = {
+        let Some(handle) = shared.tmux_watchers.get(&channel_id) else {
+            return true;
+        };
+        (
+            handle.tmux_session_name.clone(),
+            handle.output_path.clone(),
+            handle.paused.load(std::sync::atomic::Ordering::Acquire),
+        )
+        // dashmap `Ref` dropped here, BEFORE the (blocking) pane capture below.
+    };
+    if paused {
+        return false;
+    }
+    let runtime_kind =
+        crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(&tmux_session_name)
+            .map(|binding| binding.runtime_kind)
+            .or_else(|| {
+                crate::services::tmux_common::resolve_tmux_runtime_kind_marker(&tmux_session_name)
+            });
+    match completion_signal_from_transcript(
+        provider,
+        runtime_kind,
+        std::path::Path::new(&output_path),
+    ) {
+        CompletionSignal::PausedLive => false,
+        CompletionSignal::Done => true,
+        CompletionSignal::Unknown => {
+            crate::services::tui_turn_state::pane_ready_fallback_allowed(provider, runtime_kind)
+                && crate::services::provider::tmux_session_ready_for_input(
+                    &tmux_session_name,
+                    provider,
+                )
+        }
+    }
+}
+
+/// Run the deadline-elapsed backstop finalize for ONE entry: flip
+/// `Pending → Finalizing` (skip if a concurrent terminal already advanced it),
+/// run `do_finalize` on the backstop context, revoke the legacy
+/// `mailbox_finalize_owed` debt (still present until phase-5b), then flip
+/// `Finalized`. Shared by the gate-timeout deadline arm and the phase-5a
+/// watcher far-backstop arm so exactly-once is decided in one place.
+async fn run_backstop_finalize(
+    ledger: &mut HashMap<LedgerKey, LedgerEntry>,
+    ledger_key: LedgerKey,
+    turn_key: TurnKey,
+    provider: ProviderKind,
+    shared: &Arc<SharedData>,
+    now: Instant,
+) {
+    match ledger.get_mut(&ledger_key) {
+        Some(entry) if entry.phase == Phase::Pending => entry.phase = Phase::Finalizing,
+        _ => return,
+    }
+    // Backstop finalize: the deferred terminal originated from the watcher but
+    // no caller is around to clear inflight, so the backstop context clears it
+    // here.
+    let _ = do_finalize(
+        turn_key,
+        provider,
+        &TerminalEvent::GateTimeout {
+            pane_quiescent: Some(true),
+        },
+        FinalizeContext::gate_backstop(),
+        shared,
+    )
+    .await;
+    // Codex P1 — the watcher skipped its cleanup block (lifecycle paused), so
+    // its legacy `mailbox_finalize_owed` flag is still `true`. The backstop just
+    // released the mailbox/inflight, so revoke that debt now; otherwise the
+    // watcher could later `swap(true)` and run stale cleanup against the NEXT
+    // active turn. (Flag removed wholesale in phase-5b.)
+    if let Some(watcher) = shared.tmux_watchers.get(&turn_key.channel_id) {
+        watcher
+            .mailbox_finalize_owed
+            .store(false, std::sync::atomic::Ordering::Release);
+    }
+    if let Some(entry) = ledger.get_mut(&ledger_key) {
+        entry.phase = Phase::Finalized;
+        entry.finalized_at = Some(now);
+        entry.terminal_deadline = None;
+        entry.watcher_backstop_deadline = None;
+    }
+}
+
 /// The one reconciler. Finalizes deadline-armed gate-timeouts whose backstop
-/// elapsed (the deadline-armed path; pane-quiescence/owner-death re-checks land
-/// with the watcher rewire in Phase 3 and Phase 4 respectively) and
+/// elapsed, GUARANTEES the phase-5a watcher far-backstop for watcher-owned
+/// `register_start` Pending entries that never received a terminal (re-checking
+/// liveness so a paused-live turn is deferred, never over-finalized), and
 /// garbage-collects `Finalized` entries past their TTL so the ledger stays
 /// bounded.
 async fn reconcile(ledger: &mut HashMap<LedgerKey, LedgerEntry>, shared: &Arc<SharedData>) {
@@ -1280,39 +1451,39 @@ async fn reconcile(ledger: &mut HashMap<LedgerKey, LedgerEntry>, shared: &Arc<Sh
         .collect();
 
     for (ledger_key, turn_key, provider) in due {
-        if let Some(entry) = ledger.get_mut(&ledger_key) {
-            if entry.phase != Phase::Pending {
-                continue;
+        run_backstop_finalize(ledger, ledger_key, turn_key, provider, shared, now).await;
+    }
+
+    // #3016 phase-5a — the watcher-owned `register_start` FAR backstop. Collect
+    // watcher-owned Pending entries whose generous `watcher_backstop_deadline`
+    // elapsed (those the watcher fresh-idle finalize never caught — the
+    // under-finalize gap the `placeholder_sweeper` SKIPS once content was
+    // delivered). Snapshot first so no `&mut` borrow is held across the awaits.
+    let watcher_due: Vec<(LedgerKey, TurnKey, ProviderKind)> = ledger
+        .iter()
+        .filter_map(|(ledger_key, entry)| {
+            if entry.phase == Phase::Pending
+                && entry.relay_owner == RelayOwnerKind::Watcher
+                && let Some(deadline) = entry.watcher_backstop_deadline
+                && now >= deadline
+            {
+                Some((*ledger_key, entry.turn_key, entry.provider.clone()))
+            } else {
+                None
             }
-            entry.phase = Phase::Finalizing;
-        }
-        // Backstop finalize: the deferred gate-timeout originated from the
-        // watcher terminal but no caller is around to clear inflight, so the
-        // backstop context clears it here.
-        let _ = do_finalize(
-            turn_key,
-            provider,
-            &TerminalEvent::GateTimeout {
-                pane_quiescent: Some(true),
-            },
-            FinalizeContext::gate_backstop(),
-            shared,
-        )
-        .await;
-        // Codex P1 — the watcher skipped its cleanup block (lifecycle paused),
-        // so its legacy `mailbox_finalize_owed` flag is still `true`. The
-        // backstop just released the mailbox/inflight, so revoke that debt now;
-        // otherwise the watcher could later `swap(true)` and run stale cleanup
-        // against the NEXT active turn. (Flag removed wholesale in phase 5.)
-        if let Some(watcher) = shared.tmux_watchers.get(&turn_key.channel_id) {
-            watcher
-                .mailbox_finalize_owed
-                .store(false, std::sync::atomic::Ordering::Release);
-        }
-        if let Some(entry) = ledger.get_mut(&ledger_key) {
-            entry.phase = Phase::Finalized;
-            entry.finalized_at = Some(now);
-            entry.terminal_deadline = None;
+        })
+        .collect();
+
+    for (ledger_key, turn_key, provider) in watcher_due {
+        // Liveness re-check: NEVER finalize a paused-live / still-busy turn at
+        // the deadline. Only a genuinely terminal turn is finalized; a still-live
+        // one EXTENDS its backstop and is re-checked next horizon.
+        if watcher_backstop_turn_is_terminal(shared, turn_key.channel_id, &provider) {
+            run_backstop_finalize(ledger, ledger_key, turn_key, provider, shared, now).await;
+        } else if let Some(entry) = ledger.get_mut(&ledger_key) {
+            if entry.phase == Phase::Pending {
+                entry.watcher_backstop_deadline = Some(now + WATCHER_REGISTER_BACKSTOP);
+            }
         }
     }
 
@@ -4148,5 +4319,271 @@ mod tests {
             assert!(handle_release_delivery(&c, turn(), h, 0, 6));
             assert!(matches!(c.read(), LeaseSnapshot::Unleased));
         }
+    }
+
+    // ===================================================================
+    // #3016 phase-5a — reconciler watcher-owned `register_start` far-backstop.
+    //
+    // Actor × terminal-path matrix (#3140 guard discipline):
+    //   * watcher-owned, content delivered but UNTERMINATED → finalized by the
+    //     backstop after the deadline, no flag needed;
+    //   * paused-live past the deadline → NOT finalized (no over-finalize);
+    //   * JSONL Done terminal → finalizes PROMPTLY even with the backstop armed;
+    //   * exactly-once → no double-finalize when both a terminal and the
+    //     backstop window apply.
+    // ===================================================================
+
+    /// A live, non-stale watcher handle so the reconciler liveness re-check
+    /// resolves a real `tmux_session_name` + transcript `output_path` for the
+    /// channel. Mirrors `tmux_watcher::tests::test_watcher_handle`.
+    fn backstop_watcher_handle(
+        tmux_session_name: &str,
+        output_path: &str,
+    ) -> crate::services::discord::TmuxWatcherHandle {
+        crate::services::discord::TmuxWatcherHandle {
+            tmux_session_name: tmux_session_name.to_string(),
+            output_path: output_path.to_string(),
+            paused: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            resume_offset: Arc::new(std::sync::Mutex::new(None)),
+            cancel: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            pause_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            turn_delivered: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            last_heartbeat_ts_ms: Arc::new(std::sync::atomic::AtomicI64::new(
+                crate::services::discord::tmux_watcher_now_ms(),
+            )),
+            mailbox_finalize_owed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        }
+    }
+
+    /// The reconciler runs off the actor's cached `Weak<SharedData>`, which the
+    /// production finalizer populates from its continuous stream of `Terminal`
+    /// submissions (a `Start` carries no `SharedData`). A test exercising the
+    /// far-backstop on a turn that never submits its OWN terminal must prime that
+    /// cache the same way — one unrelated orphan terminal (no mailbox token, so a
+    /// harmless no-op beyond setting the cache).
+    async fn prime_reconcile_shared(fin: &TurnFinalizer, shared: &Arc<SharedData>) {
+        let _ = fin
+            .submit_terminal(
+                TurnKey::new(ChannelId::new(9_999_999), 0, 0),
+                ProviderKind::Claude,
+                TerminalEvent::Complete,
+                FinalizeContext::watcher(),
+                shared.clone(),
+            )
+            .await;
+    }
+
+    /// A watcher-owned `register_start` Pending whose content was delivered but
+    /// whose mailbox was NEVER finalized (no terminal ever submitted — the
+    /// under-finalize gap the `placeholder_sweeper` SKIPS once content is
+    /// delivered) is finalized by the reconciler far-backstop after the deadline,
+    /// WITHOUT any `mailbox_finalize_owed` flag. The active mailbox token is
+    /// released exactly once (counter decremented). No live watcher handle exists
+    /// for the channel, so the liveness re-check treats the turn as terminal
+    /// (nothing left will ever drive it).
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn watcher_register_start_backstop_finalizes_unterminated_turn() {
+        use serenity::model::id::{MessageId, UserId};
+        with_isolated_runtime_root(|| async move {
+            let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
+            shared.global_active.store(1, Ordering::Relaxed);
+            let ch = ChannelId::new(5101);
+            let active_token = Arc::new(CancelToken::new());
+            shared
+                .mailbox(ch)
+                .restore_active_turn(active_token, UserId::new(7), MessageId::new(70))
+                .await;
+
+            let fin = TurnFinalizer::spawn();
+            prime_reconcile_shared(&fin, &shared).await;
+            // Watcher handoff registered the turn; NO terminal is ever submitted
+            // for it (the stuck row).
+            let k = TurnKey::new(ch, 70, 0);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+
+            tokio::time::sleep(WATCHER_REGISTER_BACKSTOP + RECONCILE_INTERVAL * 3).await;
+            tokio::task::yield_now().await;
+
+            assert_eq!(
+                shared.global_active.load(Ordering::Relaxed),
+                0,
+                "the far-backstop must finalize the stuck watcher turn and release its token"
+            );
+            let late = fin
+                .submit_terminal(
+                    k,
+                    ProviderKind::Claude,
+                    TerminalEvent::Complete,
+                    FinalizeContext::watcher(),
+                    shared.clone(),
+                )
+                .await;
+            assert!(
+                matches!(late, FinalizeOutcome::AlreadyFinalized),
+                "a late terminal must lose the exactly-once gate after the backstop finalized"
+            );
+        })
+        .await;
+    }
+
+    /// A watcher-owned turn that is genuinely PAUSED-LIVE at the deadline (a
+    /// live watcher whose JSONL transcript shows NO turn terminator: selector /
+    /// permission prompt / subagent / long tool call) must NOT be finalized by
+    /// the far-backstop — over-finalizing it would strand a follow-up and kill a
+    /// legitimately long turn. The liveness re-check returns `PausedLive`, so the
+    /// backstop defers (re-arms) and the token stays held.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn watcher_register_start_backstop_defers_paused_live_turn() {
+        use serenity::model::id::{MessageId, UserId};
+        with_isolated_runtime_root(|| async move {
+            let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
+            shared.global_active.store(1, Ordering::Relaxed);
+            let ch = ChannelId::new(5202);
+            let active_token = Arc::new(CancelToken::new());
+            shared
+                .mailbox(ch)
+                .restore_active_turn(active_token, UserId::new(7), MessageId::new(80))
+                .await;
+
+            // A live watcher whose transcript has content but NO Claude turn
+            // terminator → `completion_signal == PausedLive`.
+            let session = format!("3016-phase5a-paused-{}", std::process::id());
+            let transcript = std::env::temp_dir().join(format!("{session}.jsonl"));
+            std::fs::write(
+                &transcript,
+                "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"working…\"}]}}\n",
+            )
+            .unwrap();
+            shared.tmux_watchers.insert(
+                ch,
+                backstop_watcher_handle(&session, transcript.to_str().unwrap()),
+            );
+
+            let fin = TurnFinalizer::spawn();
+            prime_reconcile_shared(&fin, &shared).await;
+            let k = TurnKey::new(ch, 80, 0);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+
+            tokio::time::sleep(WATCHER_REGISTER_BACKSTOP + RECONCILE_INTERVAL * 3).await;
+            tokio::task::yield_now().await;
+
+            // NOT finalized: token still held, counter unchanged.
+            assert_eq!(
+                shared.global_active.load(Ordering::Relaxed),
+                1,
+                "a paused-live turn must NOT be finalized by the far-backstop"
+            );
+            // The entry is still Pending → an explicit terminal now finalizes it
+            // (returns Finalized, not AlreadyFinalized), proving the backstop did
+            // not consume it.
+            let outcome = fin
+                .submit_terminal(
+                    k,
+                    ProviderKind::Claude,
+                    TerminalEvent::Complete,
+                    FinalizeContext::watcher(),
+                    shared.clone(),
+                )
+                .await;
+            assert!(
+                matches!(outcome, FinalizeOutcome::Finalized { .. }),
+                "the deferred paused-live turn must still be live for its real terminal"
+            );
+            let _ = std::fs::remove_file(&transcript);
+        })
+        .await;
+    }
+
+    /// With the watcher far-backstop ARMED at `register_start`, a JSONL Done
+    /// terminal still finalizes PROMPTLY (the backstop only catches turns that
+    /// never terminate; it must never delay a real terminal). Exactly once.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn jsonl_done_terminal_finalizes_promptly_with_backstop_armed() {
+        use serenity::model::id::{MessageId, UserId};
+        with_isolated_runtime_root(|| async move {
+            let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
+            shared.global_active.store(1, Ordering::Relaxed);
+            let ch = ChannelId::new(5303);
+            let active_token = Arc::new(CancelToken::new());
+            shared
+                .mailbox(ch)
+                .restore_active_turn(active_token, UserId::new(7), MessageId::new(90))
+                .await;
+
+            let fin = TurnFinalizer::spawn();
+            let k = TurnKey::new(ch, 90, 0);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+
+            // No sleep — the real terminal must win immediately despite the armed
+            // 1800s backstop.
+            let outcome = fin
+                .submit_terminal(
+                    k,
+                    ProviderKind::Claude,
+                    TerminalEvent::Complete,
+                    FinalizeContext::watcher(),
+                    shared.clone(),
+                )
+                .await;
+            assert!(
+                matches!(
+                    outcome,
+                    FinalizeOutcome::Finalized {
+                        removed_token: Some(_),
+                        ..
+                    }
+                ),
+                "a Done terminal must finalize promptly and release the token, backstop armed"
+            );
+            assert_eq!(shared.global_active.load(Ordering::Relaxed), 0);
+        })
+        .await;
+    }
+
+    /// Exactly-once across the backstop window: a turn finalized PROMPTLY by its
+    /// real terminal must NOT be finalized a second time when the
+    /// `WATCHER_REGISTER_BACKSTOP` horizon later elapses — the entry is already
+    /// `Finalized`, so the reconciler's watcher pass skips it (no double counter
+    /// decrement, no double side-effects).
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn watcher_backstop_no_double_finalize_after_terminal() {
+        use serenity::model::id::{MessageId, UserId};
+        with_isolated_runtime_root(|| async move {
+            let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
+            shared.global_active.store(1, Ordering::Relaxed);
+            let ch = ChannelId::new(5404);
+            let active_token = Arc::new(CancelToken::new());
+            shared
+                .mailbox(ch)
+                .restore_active_turn(active_token, UserId::new(7), MessageId::new(100))
+                .await;
+
+            let fin = TurnFinalizer::spawn();
+            let k = TurnKey::new(ch, 100, 0);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            let first = fin
+                .submit_terminal(
+                    k,
+                    ProviderKind::Claude,
+                    TerminalEvent::Complete,
+                    FinalizeContext::watcher(),
+                    shared.clone(),
+                )
+                .await;
+            assert!(matches!(first, FinalizeOutcome::Finalized { .. }));
+            assert_eq!(shared.global_active.load(Ordering::Relaxed), 0);
+
+            // Cross the far-backstop horizon. The reconciler watcher pass must
+            // find the entry already Finalized (or GC'd) and do nothing.
+            tokio::time::sleep(WATCHER_REGISTER_BACKSTOP + RECONCILE_INTERVAL * 3).await;
+            tokio::task::yield_now().await;
+
+            assert_eq!(
+                shared.global_active.load(Ordering::Relaxed),
+                0,
+                "the far-backstop must not double-finalize an already-finalized turn"
+            );
+        })
+        .await;
     }
 }

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -425,10 +425,20 @@ enum FinalizeMsg {
     /// before the watcher can submit a terminal, so the ledger knows the turn
     /// exists and message arrival order replaces the deleted Release/AcqRel
     /// `mailbox_finalize_owed.store` ordering.
+    ///
+    /// #3016 phase-5a: carries a `Weak<SharedData>` (NOT `Arc`, to avoid the
+    /// SharedData → finalizer → actor → SharedData cycle) so the actor can prime
+    /// its `cached_shared` from the very FIRST `Start`. Without this the
+    /// reconcile tick only ran after the first `Terminal` ever processed by the
+    /// actor populated the cache, so a FRESH actor whose first watcher-owned
+    /// turn gets stuck (no terminal ever submitted) had `cached_shared == None`
+    /// and the watcher far-backstop NEVER fired — the non-deterministic gap this
+    /// field closes.
     Start {
         key: TurnKey,
         provider: ProviderKind,
         relay_owner: RelayOwnerKind,
+        shared: std::sync::Weak<SharedData>,
     },
     Terminal {
         key: TurnKey,
@@ -532,11 +542,18 @@ impl TurnFinalizer {
     /// #3018 — register a turn so the ledger knows it exists before any
     /// terminal can arrive. Idempotent: a second `Start` for a key already in
     /// the ledger only refreshes the relay owner.
+    ///
+    /// #3016 phase-5a: `shared` is downgraded to a `Weak` and carried on the
+    /// `Start` so the actor primes its `cached_shared` from the first register
+    /// (not just the first terminal). This is what guarantees the watcher
+    /// far-backstop reconcile tick runs for a FRESH actor whose first
+    /// watcher-owned turn never submits its own terminal.
     pub(in crate::services::discord) fn register_start(
         &self,
         key: TurnKey,
         provider: ProviderKind,
         relay_owner: RelayOwnerKind,
+        shared: &Arc<SharedData>,
     ) {
         // UnboundedSender::send only fails if the actor task is gone (process
         // teardown); dropping the Start there is harmless because no terminal
@@ -545,6 +562,7 @@ impl TurnFinalizer {
             key,
             provider,
             relay_owner,
+            shared: Arc::downgrade(shared),
         });
     }
 
@@ -762,20 +780,33 @@ async fn actor_loop(mut rx: mpsc::UnboundedReceiver<FinalizeMsg>) {
                         key,
                         provider,
                         relay_owner,
+                        shared,
                     } => {
+                        // #3016 phase-5a: prime the reconcile cache from the very
+                        // FIRST register so a FRESH actor whose first watcher-owned
+                        // turn never submits its own terminal still gets the
+                        // far-backstop reconcile tick. Previously `cached_shared` was
+                        // populated ONLY by the first `Terminal` the actor processed,
+                        // so the backstop fired non-deterministically — only once some
+                        // UNRELATED terminal happened to prime it. `is_none()` guard:
+                        // the `Terminal` arm stays authoritative (it always overwrites
+                        // with the live Arc); this only fills a `None`. A `Start` whose
+                        // Arc already dropped carries a dead `Weak`; `Weak::upgrade` in
+                        // the reconcile tick then yields `None`, harmlessly skipping
+                        // until a live submission re-primes it.
+                        if cached_shared.is_none() {
+                            cached_shared = Some(shared);
+                        }
                         // #3016 phase-5a: a watcher-owned handoff arms the FAR
                         // backstop so a never-terminated turn still becomes visible
                         // to the reconciler. `get_or_insert`: set ONCE — never push
                         // an armed deadline forward on a repeat `Start` (the EPIC's
                         // never-finalizing bug, mirrored from the gate-timeout arm).
                         // The reconcile that consumes this deadline runs off the
-                        // actor's cached `Weak<SharedData>`, which is populated by
-                        // the first `Terminal` the finalizer ever processes; a live
-                        // runtime finalizes turns continuously, so the cache is set
-                        // long before any `WATCHER_REGISTER_BACKSTOP` horizon
-                        // elapses (a `Start` carries no `SharedData` to cache here,
-                        // and the rows the backstop catches never submit a terminal
-                        // of their own).
+                        // actor's cached `Weak<SharedData>`, now primed at the FIRST
+                        // `Start` above (no longer dependent on a prior `Terminal`),
+                        // so the backstop is GUARANTEED for the rows it catches —
+                        // which never submit a terminal of their own.
                         let arm_watcher_backstop = relay_owner == RelayOwnerKind::Watcher;
                         // A `Start` always carries the real `user_msg_id`, so it
                         // registers under the exact full-identity key.
@@ -1564,7 +1595,7 @@ mod tests {
             shared.global_active.store(1, Ordering::Relaxed);
             let fin = TurnFinalizer::spawn();
             let k = key(101);
-            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
 
             let first = fin
                 .submit_terminal(
@@ -1605,7 +1636,12 @@ mod tests {
             let ch = ChannelId::new(606);
             let registered = TurnKey::new(ch, 99_999, 0);
             let channel_only = TurnKey::new(ch, 0, 0);
-            fin.register_start(registered, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(
+                registered,
+                ProviderKind::Claude,
+                RelayOwnerKind::Watcher,
+                &shared,
+            );
 
             // Channel-only (id 0) terminal finalizes the registered turn.
             let first = fin
@@ -1648,7 +1684,12 @@ mod tests {
             let turn1 = TurnKey::new(ch, 1001, 0);
             let turn2 = TurnKey::new(ch, 1002, 0);
 
-            fin.register_start(turn1, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(
+                turn1,
+                ProviderKind::Claude,
+                RelayOwnerKind::Watcher,
+                &shared,
+            );
             let f1 = fin
                 .submit_terminal(
                     turn1,
@@ -1662,7 +1703,12 @@ mod tests {
 
             // turn-2 starts immediately (well within the 60s Finalized TTL) and
             // must finalize on its own, not be swallowed by turn-1's entry.
-            fin.register_start(turn2, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(
+                turn2,
+                ProviderKind::Claude,
+                RelayOwnerKind::Watcher,
+                &shared,
+            );
             let f2 = fin
                 .submit_terminal(
                     turn2,
@@ -1695,7 +1741,12 @@ mod tests {
             let turn2 = TurnKey::new(ch, 2002, 0);
             let channel_only = TurnKey::new(ch, 0, 0);
 
-            fin.register_start(turn1, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(
+                turn1,
+                ProviderKind::Claude,
+                RelayOwnerKind::Watcher,
+                &shared,
+            );
             let _ = fin
                 .submit_terminal(
                     turn1,
@@ -1707,7 +1758,12 @@ mod tests {
                 .await;
 
             // turn-2 registers (queued follow-up now live).
-            fin.register_start(turn2, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(
+                turn2,
+                ProviderKind::Claude,
+                RelayOwnerKind::Watcher,
+                &shared,
+            );
 
             // A STALE id-0 terminal (from turn-1's watcher) arrives. Because a
             // Finalized entry exists AND a different live entry (turn-2) exists,
@@ -1791,7 +1847,7 @@ mod tests {
             let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
             let fin = TurnFinalizer::spawn();
             let k = key(303);
-            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
 
             let deferred = fin
                 .submit_terminal(
@@ -1840,7 +1896,7 @@ mod tests {
             let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
             let fin = TurnFinalizer::spawn();
             let k = key(313);
-            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
 
             // Re-submit gate-timeouts at ~1/3 of the backstop apart, three times,
             // staying UNDER the single backstop window in total. Each is Deferred;
@@ -1893,7 +1949,7 @@ mod tests {
             let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
             let fin = TurnFinalizer::spawn();
             let k = key(404);
-            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
 
             let outcome = fin
                 .submit_terminal(
@@ -1919,7 +1975,7 @@ mod tests {
             let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
             let fin = TurnFinalizer::spawn();
             let k = key(505);
-            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
 
             let cancelled = fin
                 .submit_terminal(
@@ -1959,7 +2015,7 @@ mod tests {
             shared.global_active.store(0, Ordering::Relaxed);
             let fin = TurnFinalizer::spawn();
             let k = key(707);
-            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
 
             let watcher = fin
                 .submit_terminal(
@@ -2007,7 +2063,7 @@ mod tests {
             let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
             let fin = TurnFinalizer::spawn();
             let k = key(808);
-            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
 
             let deferred = fin
                 .submit_terminal(
@@ -2424,6 +2480,7 @@ mod tests {
             TurnKey::new(ch, registered_id, 0),
             ProviderKind::Claude,
             RelayOwnerKind::Watcher,
+            &shared,
         );
 
         // id-0 terminal → resolves to the registered entry → finalize_key uses
@@ -2513,7 +2570,7 @@ mod tests {
             let token = seed_active_turn(&shared, ch, tid).await;
             let fin = TurnFinalizer::spawn();
             let k = TurnKey::new(ch, tid, 0);
-            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
 
             let first = fin
                 .submit_terminal(
@@ -2581,7 +2638,7 @@ mod tests {
             let token = seed_active_turn(&shared, ch, tid).await;
             let fin = TurnFinalizer::spawn();
             let k = TurnKey::new(ch, tid, 0);
-            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
 
             let first = fin
                 .submit_terminal(
@@ -2705,7 +2762,7 @@ mod tests {
             let token = seed_active_turn(&shared, ch, tid).await;
             let fin = TurnFinalizer::spawn();
             let k = TurnKey::new(ch, tid, 0);
-            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
 
             let cancelled = fin
                 .submit_terminal(
@@ -2777,7 +2834,7 @@ mod tests {
             let k = TurnKey::new(ch, tid, 0);
             // A live relay owner is what makes `GateTimeout{Some(false)}` defer
             // (arming the backstop) rather than finalize immediately.
-            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
 
             let deferred = fin
                 .submit_terminal(
@@ -2867,7 +2924,7 @@ mod tests {
             let k = TurnKey::new(ch, tid, 0);
             // Register with a live owner so we PROVE None does not defer the way
             // Some(false) would with an owner present.
-            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
 
             let outcome = fin
                 .submit_terminal(
@@ -2922,7 +2979,7 @@ mod tests {
             let token = seed_active_turn(&shared, ch, tid).await;
             let fin = TurnFinalizer::spawn();
             let k = TurnKey::new(ch, tid, 0);
-            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
 
             let outcome = fin
                 .submit_terminal(
@@ -3067,7 +3124,7 @@ mod tests {
             let token = seed_active_turn(&shared, ch, tid).await;
             let fin = TurnFinalizer::spawn();
             let k = TurnKey::new(ch, tid, 0);
-            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
 
             let watcher = fin
                 .submit_terminal(
@@ -3119,7 +3176,7 @@ mod tests {
             let token = seed_active_turn(&shared, ch, tid).await;
             let fin = TurnFinalizer::spawn();
             let k = TurnKey::new(ch, tid, 0);
-            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
 
             let first = fin
                 .submit_terminal(
@@ -3497,12 +3554,17 @@ mod tests {
     // has_live_watcher_pending: true for a watcher-owned non-finalized entry.
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn watcher_pending_true_for_live_watcher_entry() {
+        // #3016 phase-5a: `register_start` now takes `&Arc<SharedData>` (to prime
+        // the reconcile cache). This test only registers + probes the ledger (no
+        // terminal, no reconcile), so an inert shared suffices.
+        let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
         let fin = TurnFinalizer::spawn();
         let ch = ChannelId::new(7001);
         fin.register_start(
             TurnKey::new(ch, 1, 5),
             ProviderKind::Claude,
             RelayOwnerKind::Watcher,
+            &shared,
         );
         // Let the actor drain the Start before querying.
         tokio::task::yield_now().await;
@@ -3517,6 +3579,9 @@ mod tests {
     // not the watcher).
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn watcher_pending_false_for_bridge_owned_entry() {
+        // #3016 phase-5a: inert shared for the `register_start` Arc param (this
+        // test only registers + probes; no terminal, no reconcile).
+        let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
         let fin = TurnFinalizer::spawn();
         let ch = ChannelId::new(7101);
         // `RelayOwnerKind::SessionBoundRelay` is a bridge-owned (non-watcher)
@@ -3525,6 +3590,7 @@ mod tests {
             TurnKey::new(ch, 1, 0),
             ProviderKind::Claude,
             RelayOwnerKind::SessionBoundRelay,
+            &shared,
         );
         tokio::task::yield_now().await;
         assert!(!fin.has_live_watcher_pending(ch, 0).await);
@@ -3538,7 +3604,7 @@ mod tests {
             let fin = TurnFinalizer::spawn();
             let ch = ChannelId::new(7201);
             let k = TurnKey::new(ch, 42, 0);
-            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
             tokio::task::yield_now().await;
             assert!(fin.has_live_watcher_pending(ch, 0).await);
 
@@ -4399,7 +4465,7 @@ mod tests {
             // Watcher handoff registered the turn; NO terminal is ever submitted
             // for it (the stuck row).
             let k = TurnKey::new(ch, 70, 0);
-            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
 
             tokio::time::sleep(WATCHER_REGISTER_BACKSTOP + RECONCILE_INTERVAL * 3).await;
             tokio::task::yield_now().await;
@@ -4408,6 +4474,65 @@ mod tests {
                 shared.global_active.load(Ordering::Relaxed),
                 0,
                 "the far-backstop must finalize the stuck watcher turn and release its token"
+            );
+            let late = fin
+                .submit_terminal(
+                    k,
+                    ProviderKind::Claude,
+                    TerminalEvent::Complete,
+                    FinalizeContext::watcher(),
+                    shared.clone(),
+                )
+                .await;
+            assert!(
+                matches!(late, FinalizeOutcome::AlreadyFinalized),
+                "a late terminal must lose the exactly-once gate after the backstop finalized"
+            );
+        })
+        .await;
+    }
+
+    /// #3016 phase-5a regression (codex HIGH): a FRESH actor — `cached_shared`
+    /// starts `None`, NO prior terminal of ANY turn was ever processed — whose
+    /// VERY FIRST watcher-owned `register_start` gets stuck (its own terminal is
+    /// never submitted) must STILL be finalized by the far-backstop at the
+    /// deadline. The reconcile cache is now primed by the `Start` itself, so the
+    /// tick fires WITHOUT any unrelated terminal priming `cached_shared` first.
+    ///
+    /// This is the same scenario as
+    /// `watcher_register_start_backstop_finalizes_unterminated_turn` but it
+    /// deliberately does NOT call `prime_reconcile_shared`: before the fix the
+    /// reconcile tick short-circuited on `cached_shared == None` and the token
+    /// stayed stuck forever, so this test FAILS on the pre-fix code and PASSES
+    /// once `Start` primes the cache.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn fresh_actor_watcher_backstop_finalizes_without_prior_terminal() {
+        use serenity::model::id::{MessageId, UserId};
+        with_isolated_runtime_root(|| async move {
+            let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
+            shared.global_active.store(1, Ordering::Relaxed);
+            let ch = ChannelId::new(5111);
+            let active_token = Arc::new(CancelToken::new());
+            shared
+                .mailbox(ch)
+                .restore_active_turn(active_token, UserId::new(7), MessageId::new(71))
+                .await;
+
+            // FRESH actor: nothing ever submitted a terminal, so `cached_shared`
+            // is `None` until the `register_start` below primes it. NO
+            // `prime_reconcile_shared` — that is the whole point of this test.
+            let fin = TurnFinalizer::spawn();
+            let k = TurnKey::new(ch, 71, 0);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
+
+            tokio::time::sleep(WATCHER_REGISTER_BACKSTOP + RECONCILE_INTERVAL * 3).await;
+            tokio::task::yield_now().await;
+
+            assert_eq!(
+                shared.global_active.load(Ordering::Relaxed),
+                0,
+                "a fresh actor's first stuck watcher turn must be finalized by the \
+                 far-backstop even though no prior terminal ever primed cached_shared"
             );
             let late = fin
                 .submit_terminal(
@@ -4462,7 +4587,7 @@ mod tests {
             let fin = TurnFinalizer::spawn();
             prime_reconcile_shared(&fin, &shared).await;
             let k = TurnKey::new(ch, 80, 0);
-            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
 
             tokio::time::sleep(WATCHER_REGISTER_BACKSTOP + RECONCILE_INTERVAL * 3).await;
             tokio::task::yield_now().await;
@@ -4512,7 +4637,7 @@ mod tests {
 
             let fin = TurnFinalizer::spawn();
             let k = TurnKey::new(ch, 90, 0);
-            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
 
             // No sleep — the real terminal must win immediately despite the armed
             // 1800s backstop.
@@ -4560,7 +4685,7 @@ mod tests {
 
             let fin = TurnFinalizer::spawn();
             let k = TurnKey::new(ch, 100, 0);
-            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher);
+            fin.register_start(k, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
             let first = fin
                 .submit_terminal(
                     k,


### PR DESCRIPTION
## Goal (phase-5a only)

Make the single-authority finalizer's reconciler a **GUARANTEED backstop** for watcher-owned `register_start` Pending entries, so `mailbox_finalize_owed` becomes **REDUNDANT** (NOT removed — that is phase-5b) on the last path where it is still load-bearing: the non-JSONL/Unknown fresh-idle arm. Additive + behavior-preserving — the flag stays primary; the backstop only catches what the flag would have, plus the existing under-finalize gap (content delivered but mailbox never finalized, which the `placeholder_sweeper` SKIPS once content is delivered).

## Deadline + liveness design (`turn_finalizer.rs` only)

1. **Arm a generous far-backstop deadline** on watcher-owned `register_start` Pending: new `LedgerEntry.watcher_backstop_deadline`, armed in the `Start` handler for `RelayOwnerKind::Watcher` with `WATCHER_REGISTER_BACKSTOP = placeholder_sweeper::ABANDON_THRESHOLD_SECS` (the legacy **1800s** abandon horizon). Distinct from the existing short 8s gate-timeout `terminal_deadline` — explicitly NOT a short timer, so a legitimately long paused-live turn (selector / permission prompt / subagent / long tool call) is never prematurely finalized.
2. **Reconciler liveness re-check** before finalizing at the deadline — `watcher_backstop_turn_is_terminal` (`turn_finalizer.rs`):
   - no live watcher handle → terminal (nothing left will ever drive it);
   - `paused` (a Discord turn took the session over) → **defer** (re-arm);
   - `PausedLive` (JSONL terminator absent) → **defer** (NEVER finalize);
   - `Done` (JSONL terminator proven, offset-independent) → finalize;
   - `Unknown` (non-JSONL) → finalize **only when the tmux pane is idle** (`deadline + pane-idle`, via the same `tmux_session_ready_for_input` probe the live watcher uses).
   A still-live turn EXTENDS its backstop rather than being finalized.
3. **Exactly-once**: `run_backstop_finalize` helper is shared by the gate-timeout arm and the new watcher arm (flip `Pending → Finalizing → Finalized`, revoke the legacy flag, idempotent `do_finalize`). The watcher pass filters on `phase == Pending`, so a turn already finalized by its real terminal is skipped.

`register_start`'s signature is **unchanged**; the reconcile consumes the actor's existing cached `Weak<SharedData>` (populated by the continuous `Terminal` stream). This avoids cascading an `Arc` through the `&SharedData`-only monitor callsite (`tmux.rs` `start_monitor_auto_turn_when_available`).

## Unknown-arm runtime finding

The non-JSONL **Unknown** watcher fresh-idle arm (`tmux_watcher.rs` `LegacyFlagGated`) **IS reached in production**:
- **non-JSONL providers** Gemini / OpenCode / Qwen (always `Unknown`), and
- **LegacyTmuxWrapper** Claude/Codex fallback (`claude.rs` / `codex.rs` `execute_streaming_local_tmux`).

`ClaudeEAdapter` (sender-streamed, empty `output_path`) and `ProcessBackend` do **NOT** reach the tmux-output watcher fresh-idle path. → phase-5b flag removal on the Unknown arm is load-bearing for the providers above, so the backstop must be correct (it is, via the liveness re-check).

## Invariants

- Worker-local: the `TurnFinalizer` actor owns its ledger + a `Weak<SharedData>`; the backstop reads only this process's ledger and the local pane/transcript. No lease, no durable queue, no leader/standby change (see `multinode-transition.md` Audited touches).
- Behavior-preserving with the flag present: a normally-completing turn finalizes via its terminal well before 1800s → `Finalized` → the reconciler skips it. The backstop only fires for never-terminated / under-finalized rows.

## Tests (actor × terminal-path matrix)

- `watcher_register_start_backstop_finalizes_unterminated_turn` — content-delivered-but-unterminated → finalized after deadline (no flag), token released once.
- `watcher_register_start_backstop_defers_paused_live_turn` — paused-live past deadline → NOT finalized (token held, counter unchanged).
- `jsonl_done_terminal_finalizes_promptly_with_backstop_armed` — Done terminal finalizes promptly with the backstop armed, exactly once.
- `watcher_backstop_no_double_finalize_after_terminal` — no double-finalize across the backstop window.

## Gate results

- `cargo fmt --check` clean.
- `cargo check --lib` clean (2 pre-existing unrelated warnings).
- `cargo test --lib turn_finalizer` → 68 passed; `cargo test --lib tmux_watcher` → 150 passed.
- `python3 scripts/generate_inventory_docs.py` → `check_agent_maintenance_docs.py` → `agent-maintenance freshness check passed` (added `#3016 phase-5a` Audited-touches note).

## Residual risks for review

- **Under-finalize (conservative)**: a non-JSONL pane that is genuinely hung-busy forever is re-armed (never finalized), matching today's behavior — no regression, but not "fixed".
- **`cached_shared` dependency**: the reconcile runs once the actor has processed any `Terminal` (always true in a live runtime); the truly-first-turn-stuck-with-zero-other-activity edge is cleaned up by the next terminal. Documented inline.

Do NOT merge — caller runs the codex VERDICT CLEAN gate + merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)