### PR TITLE
feat(#3034): gate await_holding_lock as deny + ratchet existing allows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,12 @@ path = "src/main.rs"
 dbg_macro = "deny"
 todo = "deny"
 unimplemented = "deny"
+# #3034: hold-lock-across-await is a race/deadlock primitive behind much of the
+# turn-lifecycle backlog. Denied crate-wide so new occurrences fail CI; existing
+# benign sites carry a narrow `#[allow(clippy::await_holding_lock)]` + `// SAFETY:`.
+# The allow count is ratcheted (monotonic decrease) by
+# scripts/check_await_holding_lock_ratchet.py.
+await_holding_lock = "deny"
 
 [dependencies]
 # HTTP server

--- a/scripts/check_await_holding_lock_ratchet.py
+++ b/scripts/check_await_holding_lock_ratchet.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Ratchet guard for `#[allow(clippy::await_holding_lock)]` (#3034).
+
+`await_holding_lock` is denied crate-wide in Cargo.toml `[lints.clippy]`, so any
+NEW hold-lock-across-await site fails CI on its own. This guard covers the other
+direction: the count of *existing* per-site `#[allow(clippy::await_holding_lock)]`
+escape hatches may only ever go DOWN. It can never grow back, so the suppression
+debt converges to zero without anyone having to remember to chase it.
+
+To intentionally remove a suppression, delete the `#[allow]` (and fix the site),
+then lower BASELINE to the new count. Raising BASELINE is a deliberate, reviewable
+diff edit and should carry justification — it is not the normal path.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Monotonic ceiling: the number of `#[allow(clippy::await_holding_lock)]`
+# attributes permitted across the workspace. Lower this as sites are removed;
+# never raise it casually.
+BASELINE = 34
+
+ALLOW_RE = re.compile(r"#\[allow\([^)]*\bclippy::await_holding_lock\b")
+
+
+def count_allows(repo_root: Path) -> tuple[int, list[str]]:
+    """Count real `#[allow(clippy::await_holding_lock)]` attributes.
+
+    Best-effort source scan: full-line comments are skipped and trailing line
+    comments are stripped so prose mentioning the lint (e.g. lib.rs guidance)
+    is not counted. Assumes single-line attributes, which rustfmt (enforced by
+    fmt-check in CI) normalizes to. The crate-wide `deny` in Cargo.toml is the
+    primary gate; this ratchet only prevents the documented allow count from
+    creeping back up.
+    """
+    total = 0
+    locations: list[str] = []
+    for path in sorted(repo_root.rglob("*.rs")):
+        rel = path.relative_to(repo_root)
+        if "target" in rel.parts:
+            continue
+        for lineno, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            if line.lstrip().startswith("//"):
+                continue
+            code = line.split("//", 1)[0]
+            for _ in ALLOW_RE.finditer(code):
+                total += 1
+                locations.append(f"{rel}:{lineno}")
+    return total, locations
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    current, locations = count_allows(repo_root)
+
+    if current > BASELINE:
+        print(
+            f"FAIL: {current} `#[allow(clippy::await_holding_lock)]` sites "
+            f"exceed the ratchet baseline of {BASELINE}.",
+            file=sys.stderr,
+        )
+        print(
+            "      The await_holding_lock allow count may only decrease. "
+            "Remove/fix a site instead of adding one.",
+            file=sys.stderr,
+        )
+        for loc in locations:
+            print(f"        {loc}", file=sys.stderr)
+        return 1
+
+    if current < BASELINE:
+        print(
+            f"NOTE: {current} allow sites is below the baseline of {BASELINE}. "
+            f"Lower BASELINE to {current} in scripts/check_await_holding_lock_ratchet.py "
+            "to lock in the win."
+        )
+        return 0
+
+    print(f"OK: {current} `#[allow(clippy::await_holding_lock)]` sites (baseline {BASELINE}).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci-script-checks.sh
+++ b/scripts/ci-script-checks.sh
@@ -23,6 +23,9 @@ python3 scripts/check_postgres_migration_checksums.py
 echo "=== State/lint hardening guard ==="
 python3 scripts/audit_state_lint_hardening.py
 
+echo "=== await_holding_lock ratchet guard ==="
+python3 scripts/check_await_holding_lock_ratchet.py
+
 echo "=== CI runner hardening guard ==="
 ./scripts/check-ci-runner-hardening.sh
 

--- a/src/services/discord/tui_direct_pending_start.rs
+++ b/src/services/discord/tui_direct_pending_start.rs
@@ -689,6 +689,12 @@ mod tests {
     ///   - A claims ONLY after turn1's inflight clears, and the EOF offset the
     ///     claim reads at THAT moment is recorded (asserting the claim is seeded
     ///     post-drain, never from the stale prior cursor).
+    // SAFETY (await_holding_lock): `worker_test_lock()` serializes tests that
+    // mutate the process-wide PRESENT index / durable store root; the guard is
+    // held across `tokio::time::advance` awaits that drive `run_worker`.
+    // Releasing before the awaits would let concurrent tests stomp the statics.
+    // Test-only.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test(start_paused = true)]
     async fn channel_a_defers_until_prior_clears_while_channel_b_does_not_starve() {
         use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -854,6 +860,12 @@ mod tests {
     /// across the WHOLE escalation budget. The worker must NEVER claim (no
     /// overwrite) and, after the budget, ABORT safely WITHOUT resubmitting —
     /// proven by the claim closure never running.
+    // SAFETY (await_holding_lock): `worker_test_lock()` serializes tests that
+    // mutate the process-wide PRESENT index / durable store root; the guard is
+    // held across `tokio::time::advance` awaits that drive `run_worker`.
+    // Releasing before the awaits would let concurrent tests stomp the statics.
+    // Test-only.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test(start_paused = true)]
     async fn backstop_foreign_inflight_live_aborts_without_claim() {
         use std::sync::atomic::{AtomicU32, Ordering};
@@ -918,6 +930,12 @@ mod tests {
     /// owns the mailbox). The worker MUST retain the durable record (never lose a
     /// Discord-submitted prompt) and retry; once the claim later succeeds it
     /// deletes. Proves the record is RETAINED across the false returns.
+    // SAFETY (await_holding_lock): `worker_test_lock()` serializes tests that
+    // mutate the process-wide PRESENT index / durable store root; the guard is
+    // held across `tokio::time::advance` awaits that drive `run_worker`.
+    // Releasing before the awaits would let concurrent tests stomp the statics.
+    // Test-only.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test(start_paused = true)]
     async fn claim_false_retains_record_and_retries() {
         use std::sync::atomic::{AtomicU32, Ordering};
@@ -977,6 +995,12 @@ mod tests {
     /// P2-2 (b'): the claim returns `false` ACROSS THE WHOLE retry budget. The
     /// worker exhausts attempts but STILL must NOT delete the record (it is left
     /// for a restart re-attempt — never silently lose the prompt).
+    // SAFETY (await_holding_lock): `worker_test_lock()` serializes tests that
+    // mutate the process-wide PRESENT index / durable store root; the guard is
+    // held across `tokio::time::advance` awaits that drive `run_worker`.
+    // Releasing before the awaits would let concurrent tests stomp the statics.
+    // Test-only.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test(start_paused = true)]
     async fn claim_false_exhausted_still_retains_record() {
         use std::sync::atomic::{AtomicU32, Ordering};


### PR DESCRIPTION
## 배경
`#[allow(clippy::await_holding_lock)]` 억제가 turn-lifecycle 백로그(#3016/#3041 등 race 다수)의 근본 primitive를 비가시화하던 문제(#3034)의 게이트 부분.

강의(harness-engineering Lec 9/10/12)의 "불변식을 비가역 게이트로" 규율을 적용 — 부채를 *티켓팅*하는 대신 *재발 자체를 차단*.

## 변경
- **deny 게이트**: `Cargo.toml [lints.clippy]`에 `await_holding_lock = "deny"` 추가(#2954 stage-1 게이트와 동일 패턴). 신규 hold-lock-across-await 사이트는 CI에서 즉시 실패.
- **기존 사이트 가시화**: `tui_direct_pending_start.rs`의 미커버 테스트 4곳에 narrow `#[allow]` + `// SAFETY:` 부착(테스트 전용 std Mutex 직렬화, 프로덕션 race 아님). 총 34개 attribute가 모두 문서화됨.
- **ratchet 가드**: `scripts/check_await_holding_lock_ratchet.py`(→ `ci-script-checks.sh`)가 allow 개수를 34로 캡, 단조감소만 허용. 주석/산문 오탐 제외, trailing 주석 strip, 줄당 다중 카운트, 전체 워크스페이스 스캔(target 제외).

## 검증
- `cargo clippy --all-targets --all-features -D await_holding_lock` 통과(에러 0)
- ratchet 가드 34/34 OK
- `tui_direct_pending_start` 테스트 14/14 통과
- 카운터모델(codex) 리뷰 VERDICT CLEAN (3 blocker 반영: 주석 오탐/스캔 갭/범위 확인)

## 후속(별건)
56곳→0 실제 락 수정은 ratchet이 강제하는 자동 수렴 작업. `ci_relax_safe` skip은 모든 기존 가드 공통의 레포 전역 escape hatch라 범위 외.

🤖 Generated with [Claude Code](https://claude.com/claude-code)