### PR TITLE
feat(#3028): ratchet giant production files against re-inflation

### DIFF
--- a/scripts/audit_maintainability.py
+++ b/scripts/audit_maintainability.py
@@ -11,12 +11,13 @@ Stdlib only; Python 3.11+.
 
 Hard and baseline gates
 -----------------------
-Seven checks are blocking in ``--check`` mode: direct Discord send regressions,
+Eight checks are blocking in ``--check`` mode: direct Discord send regressions,
 direct git subprocess regressions, runtime SQLite/legacy DB references,
 source-of-truth alias writes, manual JSON row mapping, giant files missing from
-``docs/agent-maintenance/change-surfaces.md``, and configured namespace size cap
-regressions. Existing findings from the enablement commit are captured in
-``scripts/audit_allowlist.toml``.
+``docs/agent-maintenance/change-surfaces.md``, configured namespace size cap
+regressions, and giant-file re-inflation past a frozen production-LoC baseline
+(``scripts/audit_maintainability_giant_baseline.toml``, #3028). Existing findings
+from the enablement commit are captured in ``scripts/audit_allowlist.toml``.
 
 Some warning-only checks also define no-regression baseline gates. These keep
 existing findings visible in reports while failing ``--check`` only when the
@@ -44,6 +45,7 @@ from audit_maintainability.common import REPO_ROOT, Finding  # noqa: E402
 
 CHECK_MODULES = (
     "audit_maintainability.checks.giant_files",
+    "audit_maintainability.checks.giant_file_ratchet",
     "audit_maintainability.checks.namespace_size_caps",
     "audit_maintainability.checks.route_srp",
     "audit_maintainability.checks.service_server_backflow",

--- a/scripts/audit_maintainability/checks/giant_file_ratchet.py
+++ b/scripts/audit_maintainability/checks/giant_file_ratchet.py
@@ -1,0 +1,112 @@
+"""Check: production giants may not grow beyond their frozen baseline (#3028).
+
+``giant_files`` requires every >= 1000 prod-LoC file to be documented in the
+change-surfaces map, but it puts no ceiling on growth — so decomposed modules
+silently re-inflated (``tmux_watcher.rs`` regrew 7160 -> 9608 production LoC).
+
+This ratchet freezes each listed giant at a baseline production LoC
+(``scripts/audit_maintainability_giant_baseline.toml``) and fails ``--check``
+when a file exceeds it. Lower a baseline as a file shrinks; raising one is a
+deliberate, reviewable admission that a giant grew (prefer splitting instead).
+
+Production LoC (test code excluded) is shared with ``giant_files`` via
+``giant_production_loc()`` so every giant surface agrees on the split (#3036).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable
+
+from .. import common
+from ..common import Finding
+from . import CheckSpec
+from .giant_files import giant_production_loc
+
+CONFIG_REL_PATH = "scripts/audit_maintainability_giant_baseline.toml"
+
+_SECTION_RE = re.compile(r"^\[([A-Za-z0-9_.-]+)\]$")
+_ENTRY_RE = re.compile(r'^"([^"]+)"\s*=\s*(\d+)$')
+
+
+def load_giant_baseline(path: Path | None = None) -> dict[str, int]:
+    """Load the ``[giant_file_ratchet]`` path -> frozen-LoC table.
+
+    Uses the same tiny TOML subset as ``namespace_size_caps``: a single table of
+    quoted repo-relative paths mapped to positive integer baselines.
+    """
+
+    config_path = path or (common.REPO_ROOT / CONFIG_REL_PATH)
+    text = common.read_text(config_path)
+    if not text:
+        return {}
+
+    section: str | None = None
+    baseline: dict[str, int] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        section_match = _SECTION_RE.fullmatch(line)
+        if section_match:
+            section = section_match.group(1)
+            continue
+        if section != "giant_file_ratchet":
+            continue
+        entry_match = _ENTRY_RE.fullmatch(line)
+        if entry_match:
+            value = int(entry_match.group(2))
+            if value > 0:
+                baseline[entry_match.group(1).strip()] = value
+    return baseline
+
+
+def _run(allowlist: set[str]) -> Iterable[Finding]:
+    baseline = load_giant_baseline()
+    if not baseline:
+        return []
+
+    current = giant_production_loc()
+    findings: list[Finding] = []
+    for rel, frozen in baseline.items():
+        if common.is_allowlisted(allowlist, rel):
+            continue
+        loc = current.get(rel)
+        # `loc is None` means the file dropped below the giant threshold, was
+        # split, or was removed — all wins, never a regression.
+        if loc is None or loc <= frozen:
+            continue
+        findings.append(
+            Finding(
+                rule="giant_file_ratchet",
+                severity="warn",
+                file=rel,
+                line=None,
+                message=(
+                    f"{loc} production LoC > {frozen} frozen baseline "
+                    f"(re-inflation); split the file or lower it back. "
+                    f"Baseline: {CONFIG_REL_PATH}"
+                ),
+                extra={
+                    "loc": str(loc),
+                    "baseline": str(frozen),
+                    "config": CONFIG_REL_PATH,
+                },
+            )
+        )
+    findings.sort(key=lambda f: -(int(f.extra.get("loc", "0"))))
+    return findings
+
+
+CHECK = CheckSpec(
+    key="giant_file_ratchet",
+    title="Giant file re-inflation ratchet",
+    description=(
+        "Production giants listed in "
+        f"{CONFIG_REL_PATH} must not exceed their frozen production-LoC "
+        "baseline."
+    ),
+    hard_gate=True,
+    runner=_run,
+)

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -1,0 +1,46 @@
+# Giant-file re-inflation ratchet baseline (#3028).
+#
+# Each entry freezes a production giant at its current production LoC (test code
+# excluded, consistent with the `giant_files` check / #3036). The
+# `giant_file_ratchet` audit check fails `--check` when a file's production LoC
+# exceeds its frozen value, so a decomposed module cannot silently re-inflate
+# (tmux_watcher.rs had regrown 7160 -> 9608 with no upper bound).
+#
+# Workflow:
+#   * As a file shrinks, LOWER its number here to lock in the win.
+#   * Growing a giant requires RAISING its number — a deliberate, reviewable
+#     admission in the diff that the giant got bigger. Prefer splitting instead.
+#
+# Scope (this batch): the M2.x turn-lifecycle decomposition surface
+# (src/services/discord/** and src/services/turn_*), where re-inflation was
+# reported. Other production giants remain covered by the `giant_files`
+# documentation gate; extend this table to ratchet them too.
+
+[giant_file_ratchet]
+"src/services/discord/tmux_watcher.rs" = 9608
+"src/services/discord/mod.rs" = 5221
+"src/services/discord/tui_prompt_relay.rs" = 5142
+"src/services/discord/voice_barge_in.rs" = 4835
+"src/services/discord/recovery_engine.rs" = 4046
+"src/services/discord/router/message_handler/intake_turn.rs" = 3771
+"src/services/discord/meeting_orchestrator.rs" = 3227
+"src/services/turn_orchestrator.rs" = 3089
+"src/services/discord/router/intake_gate.rs" = 2953
+"src/services/discord/formatting.rs" = 2802
+"src/services/discord/runtime_bootstrap.rs" = 2800
+"src/services/discord/health/recovery.rs" = 2655
+"src/services/discord/inflight.rs" = 2466
+"src/services/discord/health.rs" = 2369
+"src/services/discord/watchers/lifecycle.rs" = 2336
+"src/services/discord/idle_recap.rs" = 2303
+"src/services/discord/tmux.rs" = 2251
+"src/services/discord/turn_bridge/completion_guard.rs" = 1849
+"src/services/discord/session_runtime.rs" = 1781
+"src/services/discord/session_relay_sink.rs" = 1730
+"src/services/discord/turn_bridge/tmux_runtime.rs" = 1545
+"src/services/discord/commands/text_commands.rs" = 1493
+"src/services/discord/turn_bridge/terminal_delivery.rs" = 1341
+"src/services/discord/turn_finalizer.rs" = 1327
+"src/services/discord/router/message_handler/headless_turn.rs" = 1316
+"src/services/discord/commands/config.rs" = 1054
+"src/services/discord/commands/diagnostics.rs" = 1026

--- a/tests/test_audit_maintainability.py
+++ b/tests/test_audit_maintainability.py
@@ -47,6 +47,7 @@ from audit_maintainability.checks import (  # noqa: E402
     source_of_truth_alias,
 )
 from audit_maintainability.checks import giant_files  # noqa: E402
+from audit_maintainability.checks import giant_file_ratchet  # noqa: E402
 
 
 def _write(root: Path, rel: str, body: str) -> None:
@@ -157,6 +158,75 @@ class GiantFilesCheck(unittest.TestCase):
             )
             hits = list(giant_files.CHECK.runner(set()))
         self.assertEqual(_files(hits), {"src/other_giant.rs"})
+
+
+class GiantFileRatchetCheck(unittest.TestCase):
+    _BASELINE = "scripts/audit_maintainability_giant_baseline.toml"
+
+    def test_flags_file_grown_past_frozen_baseline(self) -> None:
+        over = "fn x() {}\n" * (giant_files.THRESHOLD + 50)  # 1050 prod LoC
+        with _FakeSrcTree(
+            {
+                "src/services/discord/tmux_watcher.rs": over,
+                "src/other_giant.rs": over,  # no baseline entry -> not ratcheted
+            }
+        ) as root:
+            _write(
+                root,
+                self._BASELINE,
+                """
+                [giant_file_ratchet]
+                "src/services/discord/tmux_watcher.rs" = 1000
+                """,
+            )
+            hits = list(giant_file_ratchet.CHECK.runner(set()))
+        self.assertEqual(_files(hits), {"src/services/discord/tmux_watcher.rs"})
+
+    def test_at_or_under_baseline_passes(self) -> None:
+        content = "fn x() {}\n" * (giant_files.THRESHOLD + 5)  # 1005 prod LoC
+        with _FakeSrcTree({"src/services/discord/tmux_watcher.rs": content}) as root:
+            _write(
+                root,
+                self._BASELINE,
+                """
+                [giant_file_ratchet]
+                "src/services/discord/tmux_watcher.rs" = 2000
+                """,
+            )
+            hits = list(giant_file_ratchet.CHECK.runner(set()))
+        self.assertEqual(hits, [])
+
+    def test_file_dropped_below_threshold_is_not_a_regression(self) -> None:
+        small = "fn y() {}\n" * 10  # below giant threshold -> not in giant map
+        with _FakeSrcTree({"src/services/discord/tmux_watcher.rs": small}) as root:
+            _write(
+                root,
+                self._BASELINE,
+                """
+                [giant_file_ratchet]
+                "src/services/discord/tmux_watcher.rs" = 1000
+                """,
+            )
+            hits = list(giant_file_ratchet.CHECK.runner(set()))
+        self.assertEqual(hits, [])
+
+    def test_allowlist_suppresses(self) -> None:
+        over = "fn x() {}\n" * (giant_files.THRESHOLD + 50)
+        with _FakeSrcTree({"src/services/discord/tmux_watcher.rs": over}) as root:
+            _write(
+                root,
+                self._BASELINE,
+                """
+                [giant_file_ratchet]
+                "src/services/discord/tmux_watcher.rs" = 1000
+                """,
+            )
+            hits = list(
+                giant_file_ratchet.CHECK.runner(
+                    {"src/services/discord/tmux_watcher.rs"}
+                )
+            )
+        self.assertEqual(hits, [])
 
 
 class NamespaceSizeCapsCheck(unittest.TestCase):
@@ -562,7 +632,7 @@ class SourceOfTruthAliasCheck(unittest.TestCase):
 
 
 class HarnessCli(unittest.TestCase):
-    def test_runs_all_ten_checks_and_emits_yaml_keys(self) -> None:
+    def test_runs_all_eleven_checks_and_emits_yaml_keys(self) -> None:
         with _FakeSrcTree({"src/main.rs": "fn main() {}\n"}):
             specs = HARNESS.load_check_specs()
             findings = HARNESS.run_all(specs, {})
@@ -571,6 +641,7 @@ class HarnessCli(unittest.TestCase):
             md_text = HARNESS.render_markdown(specs, findings)
         for key in (
             "giant_files",
+            "giant_file_ratchet",
             "namespace_size_caps",
             "route_srp_violations",
             "service_server_backflow",
@@ -612,6 +683,7 @@ class HarnessCli(unittest.TestCase):
             hard_gated,
             {
                 "giant_files",
+                "giant_file_ratchet",
                 "namespace_size_caps",
                 "direct_discord_sends",
                 "manual_json_row_mapping",
@@ -638,10 +710,10 @@ class HarnessCli(unittest.TestCase):
             yaml_text = HARNESS.render_yaml(specs, findings)
             json_payload = json.loads(HARNESS.render_json(specs, findings))
         self.assertIn("hard_gate_enabled: true", yaml_text)
-        self.assertIn("hard_gate_count: 7", yaml_text)
+        self.assertIn("hard_gate_count: 8", yaml_text)
         self.assertIn("baseline_gate_count: 2", yaml_text)
         self.assertIs(json_payload["hard_gate_enabled"], True)
-        self.assertEqual(json_payload["hard_gate_count"], 7)
+        self.assertEqual(json_payload["hard_gate_count"], 8)
         self.assertEqual(json_payload["baseline_gate_count"], 2)
 
     def test_check_mode_returns_zero_with_no_findings(self) -> None:


### PR DESCRIPTION
## 배경
`giant_files` 체크는 ≥1000 prod-LoC 파일에 *문서화*만 요구할 뿐 **성장 상한이 없어**, M2.x 분해 후 모듈이 조용히 재팽창했습니다 (tmux_watcher.rs 7160→9608 prod LoC, 가드 부재 — #3028).

강의(harness-engineering Lec 6/12)의 "가드를 먼저, 비가역 게이트로" 규율 적용. PR #3224(#3034 await_holding_lock)과 같은 ratchet 패턴.

## 변경
- **새 hard-gate 체크 `giant_file_ratchet`**: baseline TOML(`scripts/audit_maintainability_giant_baseline.toml`)에 거대 파일을 현재 prod LoC로 동결, `audit_maintainability.py --check`에서 초과 시 실패. 단조감소만 — 줄이면 baseline 내림, 키우려면 diff에 baseline 인상이 명시적으로 남음(분해 권장).
- prod LoC(테스트 제외)는 `giant_production_loc()` 재사용으로 `giant_files`와 일관(#3036).
- 이번 배치: M2.x turn-lifecycle 도메인(`src/services/discord/**`, `src/services/turn_*`) 거대 파일 **27개 동결**. 나머지 giant는 문서화 게이트가 계속 커버, 테이블 확장으로 ratchet 확대 가능.
- **CI 연결 불필요**: `ci-script-checks.sh`가 이미 `audit_maintainability.py --check` 호출.

## 검증
- `audit_maintainability.py --check` main 기준 통과(exit 0)
- 새 체크 hard-gate 등록 확인(총 8 hard-gate)
- audit 유닛테스트 42/42 통과 (신규 4건: 재팽창/baseline이하/임계미만drop/allowlist)
- 카운터모델(codex) 리뷰 **VERDICT CLEAN** (NIT 반영: 체크 열거 테스트에 신규 키 추가)

## 알려진 한계(문서화됨)
- 삭제/분해된 파일의 stale baseline 엔트리는 무해하게 무시(`loc is None`). 재구성 시 수동 baseline 갱신 필요 — 의도된 워크플로.
- baseline 파일 부재 시 fail-open(기존 `namespace_size_caps`와 동일 컨벤션).

🤖 Generated with [Claude Code](https://claude.com/claude-code)