### PR TITLE
fix(#3016): phase-5b2 — delete write-only mailbox_finalize_owed flag

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -113,10 +113,11 @@
   parsing), `src/services/discord/inflight.rs` (state file contract).
 - legacy_modules: none — relay routes are being consolidated, not replaced.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/services/discord/watchers/lifecycle.rs` (2336 lines — canonical
+  - `src/services/discord/watchers/lifecycle.rs` (2333 lines — canonical
     lifecycle extraction surface from #1435; split further before adding new
-    lifecycle behavior).
-  - `src/services/discord/tmux.rs` (2260 lines after #2558 dead-code sweep;
+    lifecycle behavior; #3016 phase-5b2 dropped the `mailbox_finalize_owed`
+    construction from the watcher-spawn handle).
+  - `src/services/discord/tmux.rs` (2241 lines after #2558 dead-code sweep;
     +4 from #3167: the monitor-auto-turn start passes `ActiveTurnKind::Background`
     so a queued user message can supersede the low-priority monitor/loop turn;
     failover guard; #3087 `session_panel_instance_key`/`write_spawn_nonce`
@@ -130,8 +131,10 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (9631 lines after #2558
-    dead-code sweep; #1520 watcher loop extraction + #2427 D/A
+  - `src/services/discord/tmux_watcher.rs` (9598 lines after #2558
+    dead-code sweep; #3016 phase-5b2 removed the `mailbox_finalize_owed`
+    swap reads, the watcher-fn flag params, and the `LegacyFlagGated`
+    decision variant; #1520 watcher loop extraction + #2427 D/A
     explicit-cleanup wires + #3055 watcher session-panel lifecycle
     refresh + #3087 session-instance-key panel reset + #3095 durable
     provider-selector fallback to the in-memory cache on resume turns
@@ -407,7 +410,9 @@
     flag-independent; EMPTY `Unknown` DEFERS — the codex HIGH regression case that the
     prior 5b1 build finalized prematurely) +
     `fresh_idle_unknown_keeps_wrong_turn_race_guards`.
-  - `src/services/discord/tui_prompt_relay.rs` (5144 lines; SSH-direct TUI
+  - `src/services/discord/tui_prompt_relay.rs` (5120 lines; #3016 phase-5b2
+    removed the dead `publish_tui_direct_watcher_finalize_debt` producer;
+    SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
     outside an extraction plan; +4 from #3167: the self-paced TUI loop relay
     starts its synthetic turn with `ActiveTurnKind::Background` so a queued user
@@ -571,7 +576,9 @@
     atomic read, closing the present/generation TOCTOU) plus its dedicated accessor unit
     test; the watcher-snapshot no-clobber regression test is retained, rewritten to take
     its G1/G2 snapshots from `external_input_relay_lease(...).map(|l| l.generation)`).
-  - `src/services/discord/recovery_engine.rs` (4046 lines; +9 from #3166
+  - `src/services/discord/recovery_engine.rs` (4034 lines; #3016 phase-5b2
+    dropped the `mailbox_finalize_owed` construction from the three recovery
+    watcher-spawn handles; +9 from #3166
     fetching real context thresholds for the recovered-turn status panel; +36 from #3099
     task-notification anchor `⏳` cleanup for `user_msg_id == 0` recovery; +4
     from the #3099 re-review pinned-injected-message-id cleanup target; +55 from

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -445,3 +445,24 @@
   ownership change — finalize remains the same per-process exactly-once unit. No
   new multinode ownership/singleton/lease assumption. (The flag field/producers
   remain until phase-5b2.)
+- #3016 phase-5b2 (delete the `mailbox_finalize_owed` flag entirely): pure
+  dead-write elimination, behaviour-identical. Phase-5b1 had already replaced
+  every finalize-decision CONSUMER, leaving the flag write-only. 5b2 removes: the
+  `TmuxWatcherHandle.mailbox_finalize_owed` field (`mod.rs`); both producers — the
+  `turn_bridge/mod.rs` runtime-handoff `store(true)` and the legacy `TmuxReady`
+  `store(true)`, keeping the adjacent `register_start(RelayOwnerKind::Watcher)`
+  ledger authority that already drives the gate-timeout defer; the
+  `tui_prompt_relay.rs` dead `publish_tui_direct_watcher_finalize_debt` producer;
+  all revoke sites (`tmux.rs` watcher-finalize `store(false)`, the
+  `turn_bridge/mod.rs` non-delegation CAS plus its `bridge_published_finalize_owed_for_this_turn`
+  tracking var, and the `turn_finalizer.rs` backstop `store(false)`); the residual
+  `swap(false)` observability reads in `tmux_watcher.rs` (the `owed_finalize`
+  event field is dropped); the now-unreachable `LegacyFlagGated`
+  `FreshIdleFinalizeDecision` variant; and the `delegated_finalize_owed` parameter
+  of `finish_restored_watcher_active_turn` (redundant under `normal_completion =
+  true` at both production call sites). The stale-skip kickoff suppression the
+  flag-derived term used to provide is already covered by the live-`has_active_turn`
+  gate, so the finalize path is identical. Nothing here is worker-non-local: the
+  removed flag was a per-handle in-process atomic, and the surviving authority (the
+  per-process actor-owned ledger) is unchanged. No new multinode
+  ownership/singleton/lease assumption.

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -17,11 +17,11 @@
 # documentation gate; extend this table to ratchet them too.
 
 [giant_file_ratchet]
-"src/services/discord/tmux_watcher.rs" = 9631
-"src/services/discord/mod.rs" = 5221
-"src/services/discord/tui_prompt_relay.rs" = 5144
+"src/services/discord/tmux_watcher.rs" = 9598
+"src/services/discord/mod.rs" = 5185
+"src/services/discord/tui_prompt_relay.rs" = 5120
 "src/services/discord/voice_barge_in.rs" = 4835
-"src/services/discord/recovery_engine.rs" = 4046
+"src/services/discord/recovery_engine.rs" = 4034
 "src/services/discord/router/message_handler/intake_turn.rs" = 3771
 "src/services/discord/meeting_orchestrator.rs" = 3227
 "src/services/turn_orchestrator.rs" = 3089
@@ -31,16 +31,16 @@
 "src/services/discord/health/recovery.rs" = 2655
 "src/services/discord/inflight.rs" = 2466
 "src/services/discord/health.rs" = 2369
-"src/services/discord/watchers/lifecycle.rs" = 2336
+"src/services/discord/watchers/lifecycle.rs" = 2333
 "src/services/discord/idle_recap.rs" = 2303
-"src/services/discord/tmux.rs" = 2260
+"src/services/discord/tmux.rs" = 2241
 "src/services/discord/turn_bridge/completion_guard.rs" = 1849
 "src/services/discord/session_runtime.rs" = 1781
 "src/services/discord/session_relay_sink.rs" = 1730
 "src/services/discord/turn_bridge/tmux_runtime.rs" = 1545
 "src/services/discord/commands/text_commands.rs" = 1493
 "src/services/discord/turn_bridge/terminal_delivery.rs" = 1341
-"src/services/discord/turn_finalizer.rs" = 1530
+"src/services/discord/turn_finalizer.rs" = 1526
 "src/services/discord/router/message_handler/headless_turn.rs" = 1316
 "src/services/discord/commands/config.rs" = 1054
 "src/services/discord/commands/diagnostics.rs" = 1026

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -1064,51 +1064,15 @@ pub(super) struct TmuxWatcherHandle {
     /// Updated by the watcher task loop. If this stops moving while the registry
     /// still has a slot, the slot is stale and must not suppress a new watcher.
     pub(super) last_heartbeat_ts_ms: Arc<std::sync::atomic::AtomicI64>,
-    /// #1452: turn-scoped finalization debt transferred from bridge to watcher.
-    ///
-    /// When the bridge unpauses a live tmux watcher to take over the
-    /// assistant relay it intentionally skips `mailbox_finish_turn` to
-    /// avoid racing with the still-running watcher turn. Without an
-    /// explicit handoff signal the watcher would also skip the
-    /// finalization (its existing `finish_mailbox_on_completion` gate is
-    /// reserved for inflight-restore semantics), leaving the channel
-    /// mailbox `cancel_token` permanently set and blocking subsequent
-    /// `try_start_turn` calls on brand-new turns.
-    ///
-    /// Protocol:
-    ///   * Bridge unpause: `store(true, Ordering::Release)` at the
-    ///     watcher-unpause site (`turn_bridge/mod.rs` `TmuxReady` branch).
-    ///     The store happens BEFORE `paused.store(false, ...)` so a fast
-    ///     watcher cannot reach its terminal swap before we publish —
-    ///     Codex P1 pointed out that storing later (at the delegation
-    ///     decision in `let has_queued_turns = ...`) is racy.
-    ///   * Bridge non-delegation: when the bridge ends up handling the
-    ///     turn itself, it must take the debt back atomically. It tracks
-    ///     a local `bridge_published_finalize_owed_for_this_turn` flag so
-    ///     it can tell apart "we published debt for this turn" from
-    ///     "we never published" — without this distinction, a paused
-    ///     watcher carried over from a prior turn would leave the
-    ///     handle's value unrelated to the current turn (Codex iter 3 P1).
-    ///     If the flag is set, the bridge runs
-    ///     `compare_exchange(true, false, AcqRel, Acquire)`:
-    ///       * `Ok` → bridge revoked unconsumed debt, runs its own
-    ///         `mailbox_finish_turn`.
-    ///       * `Err(false)` → watcher already swapped and finalized; the
-    ///         bridge MUST skip its own `mailbox_finish_turn` to avoid
-    ///         clearing a turn it no longer owns (Codex P2 from review
-    ///         iter 2).
-    ///     If the flag is NOT set (no `TmuxReady` reached, or watcher
-    ///     missing), the bridge always runs `mailbox_finish_turn`.
-    ///   * Watcher: `swap(false, Ordering::AcqRel)` in its turn-end
-    ///     branch. AcqRel guarantees:
-    ///       1. Acquire — every prior bridge write is observed before we
-    ///          decide to call `mailbox_finish_turn`.
-    ///       2. Release+single-consumer — a paused-survivor watcher
-    ///          cannot accidentally clear a future turn's freshly
-    ///          registered cancel token because the swap returns `false`
-    ///          for it.
-    pub(super) mailbox_finalize_owed: Arc<std::sync::atomic::AtomicBool>,
 }
+
+// #3016 phase-5b2: the per-handle `mailbox_finalize_owed: Arc<AtomicBool>` field
+// (#1452 turn-scoped bridge→watcher finalization debt) has been removed. Phase-5b1
+// replaced every finalize-decision consumer of the flag — the watcher's
+// normal-completion finalize now fires on the confirmed-completion / structural
+// signal (`normal_completion = true`), and the bridge-handoff invariant uses the
+// ledger's `register_start(RelayOwnerKind::Watcher)` authority — so the flag was
+// write-only and is now deleted entirely with identical behaviour.
 
 pub(super) const TMUX_WATCHER_STALE_HEARTBEAT_MS: i64 = 60_000;
 
@@ -1412,7 +1376,6 @@ mod tmux_watcher_registry_restore_tests {
             last_heartbeat_ts_ms: Arc::new(
                 std::sync::atomic::AtomicI64::new(tmux_watcher_now_ms()),
             ),
-            mailbox_finalize_owed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -2495,8 +2495,6 @@ pub(super) async fn restore_inflight_turns(
                         let last_heartbeat_ts_ms = std::sync::Arc::new(
                             std::sync::atomic::AtomicI64::new(super::tmux_watcher_now_ms()),
                         );
-                        let mailbox_finalize_owed =
-                            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
                         let handle = TmuxWatcherHandle {
                             tmux_session_name: tmux_session_name.clone(),
                             output_path: output_path.clone(),
@@ -2506,7 +2504,6 @@ pub(super) async fn restore_inflight_turns(
                             pause_epoch: pause_epoch.clone(),
                             turn_delivered: turn_delivered.clone(),
                             last_heartbeat_ts_ms: last_heartbeat_ts_ms.clone(),
-                            mailbox_finalize_owed: mailbox_finalize_owed.clone(),
                         };
                         let watcher_claimed = {
                             #[cfg(unix)]
@@ -2568,7 +2565,6 @@ pub(super) async fn restore_inflight_turns(
                                         pause_epoch,
                                         turn_delivered,
                                         last_heartbeat_ts_ms,
-                                        mailbox_finalize_owed,
                                         restored_turn,
                                     ),
                                 );
@@ -3633,8 +3629,6 @@ pub(super) async fn restore_inflight_turns(
                 let last_heartbeat_ts_ms = std::sync::Arc::new(std::sync::atomic::AtomicI64::new(
                     super::tmux_watcher_now_ms(),
                 ));
-                let mailbox_finalize_owed =
-                    std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
                 let handle = TmuxWatcherHandle {
                     tmux_session_name: tmux_session_name.clone(),
                     output_path: output_path.clone(),
@@ -3644,7 +3638,6 @@ pub(super) async fn restore_inflight_turns(
                     pause_epoch: pause_epoch.clone(),
                     turn_delivered: turn_delivered.clone(),
                     last_heartbeat_ts_ms: last_heartbeat_ts_ms.clone(),
-                    mailbox_finalize_owed: mailbox_finalize_owed.clone(),
                 };
                 let watcher_claimed = {
                     #[cfg(unix)]
@@ -3705,7 +3698,6 @@ pub(super) async fn restore_inflight_turns(
                                 pause_epoch,
                                 turn_delivered,
                                 last_heartbeat_ts_ms,
-                                mailbox_finalize_owed,
                                 restored_turn,
                             ),
                         );
@@ -4389,8 +4381,6 @@ pub(crate) async fn rebind_inflight_for_channel(
             let last_heartbeat_ts_ms = std::sync::Arc::new(std::sync::atomic::AtomicI64::new(
                 super::tmux_watcher_now_ms(),
             ));
-            let mailbox_finalize_owed =
-                std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
             let handle = TmuxWatcherHandle {
                 tmux_session_name: tmux_session_name.clone(),
                 output_path: output_path.clone(),
@@ -4400,7 +4390,6 @@ pub(crate) async fn rebind_inflight_for_channel(
                 pause_epoch: pause_epoch.clone(),
                 turn_delivered: turn_delivered.clone(),
                 last_heartbeat_ts_ms: last_heartbeat_ts_ms.clone(),
-                mailbox_finalize_owed: mailbox_finalize_owed.clone(),
             };
             // `claim_or_reuse_watcher` reuses a live watcher for the same
             // tmux session and only spawns when it claimed or replaced a
@@ -4432,7 +4421,6 @@ pub(crate) async fn rebind_inflight_for_channel(
                         pause_epoch,
                         turn_delivered,
                         last_heartbeat_ts_ms,
-                        mailbox_finalize_owed,
                     ),
                 );
             }

--- a/src/services/discord/router/message_handler/watchdog.rs
+++ b/src/services/discord/router/message_handler/watchdog.rs
@@ -571,7 +571,6 @@ fn attach_paused_turn_watcher_inner(
         let last_heartbeat_ts_ms = Arc::new(std::sync::atomic::AtomicI64::new(
             super::super::super::tmux_watcher_now_ms(),
         ));
-        let mailbox_finalize_owed = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let handle = TmuxWatcherHandle {
             tmux_session_name: tmux_session_name.clone(),
             output_path: output_path.clone(),
@@ -581,7 +580,6 @@ fn attach_paused_turn_watcher_inner(
             pause_epoch: pause_epoch.clone(),
             turn_delivered: turn_delivered.clone(),
             last_heartbeat_ts_ms: last_heartbeat_ts_ms.clone(),
-            mailbox_finalize_owed: mailbox_finalize_owed.clone(),
         };
         let claim = super::super::super::tmux::claim_or_reuse_watcher(
             &shared.tmux_watchers,
@@ -626,7 +624,6 @@ fn attach_paused_turn_watcher_inner(
                             pause_epoch,
                             turn_delivered,
                             last_heartbeat_ts_ms,
-                            mailbox_finalize_owed,
                         ),
                     );
                 } else {
@@ -701,7 +698,6 @@ mod cold_start_retry_tests {
             last_heartbeat_ts_ms: Arc::new(
                 std::sync::atomic::AtomicI64::new(tmux_watcher_now_ms()),
             ),
-            mailbox_finalize_owed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -2357,33 +2357,32 @@ async fn finish_restored_watcher_active_turn(
     // channel-only terminal cannot finalize a queued follow-up turn.
     user_msg_id: u64,
     finish_mailbox_on_completion: bool,
-    delegated_finalize_owed: bool,
     // #3016 option A: the caller observed a *normal completion* (terminal output
     // committed / pane confirmed idle past the relay) and wants the single-
-    // authority finalizer driven regardless of the legacy flags. The finalizer
+    // authority finalizer driven regardless of the restore flag. The finalizer
     // is idempotent — a turn already finalized by the bridge resolves to
     // `AlreadyFinalized` — so an unconditional submit at the confirmed-completion
-    // point cannot over-finalize. This decouples the watcher's normal-completion
-    // finalize from `mailbox_finalize_owed` / `finish_mailbox_on_completion` so
-    // phase 5 can delete the flag. Restore/recovery callers that have NOT
-    // confirmed a normal completion pass `false` and keep the flag-gated path.
+    // point cannot over-finalize. This decoupled the watcher's normal-completion
+    // finalize from `mailbox_finalize_owed` (removed in #3016 phase-5b2) /
+    // `finish_mailbox_on_completion`. Restore/recovery callers that have NOT
+    // confirmed a normal completion pass `false` and keep the restore-gated path.
     normal_completion: bool,
     kickoff_queue: bool,
     stop_source: &'static str,
 ) -> bool {
-    // Either flag implies the watcher must clear the channel mailbox now:
+    // The mailbox is cleared now when EITHER gate holds:
+    //   * `normal_completion` → confirmed terminal output committed / pane idle
+    //     (#3016 option A). The canonical post-phase-5b1 finalize trigger.
     //   * `finish_mailbox_on_completion` → inflight-restore semantics (a
     //     restored/recovered watcher inherits its turn from the bridge, so
     //     it owns the cancel_token when the turn ends). Pre-existing.
-    //   * `delegated_finalize_owed` → bridge handed finalization debt to the
-    //     watcher because it skipped `mailbox_finish_turn` to avoid racing
-    //     the in-flight watcher relay. New for #1452.
     //
-    // The two flags can coincide (e.g., a recovered watcher whose first
-    // post-recovery turn also went through stream-lost handoff). Calling
-    // `mailbox_finish_turn` once per turn is idempotent for our purposes —
-    // the second call would just observe an empty active slot — but we
-    // gate on the OR to keep the call site to a single place.
+    // #3016 phase-5b2: the third gate — `delegated_finalize_owed`, sourced from
+    // the per-handle `mailbox_finalize_owed` flag (#1452) — has been removed.
+    // At both production call sites the watcher already passes
+    // `normal_completion = true`, so the flag was redundant in this OR and only
+    // fed an observability log/event; the ledger's exactly-once phase gate makes
+    // a double `mailbox_finish_turn` idempotent.
     //
     // `kickoff_queue` is the dispatch-lifecycle gate (codex #1670 P2): the
     // mailbox/inflight cleanup above is required for orphan prevention even
@@ -2391,29 +2390,15 @@ async fn finish_restored_watcher_active_turn(
     // queued turn must NOT happen on a failed dispatch — that decision is
     // left to the operator/user. Callers pass `dispatch_ok` (or an
     // equivalent gate) here.
-    // #3016 option A: a confirmed normal completion always drives the finalizer.
-    // The two legacy flags remain as *additional* triggers for the restore /
-    // delegated-debt paths, but they are no longer the only way the watcher's
-    // normal-completion finalize fires — that's the decoupling. (The finalizer's
-    // idempotence guarantees no double finalize when the bridge already won.)
     //
     // #3016 (codex R1): the return value reports whether this helper actually
     // DROVE the finalize (i.e. did NOT early-return). The caller folds it into
     // `watcher_handled_mailbox_finish` so the post-finalize lifecycle (queue
     // kickoff suppression + terminal-stop-candidate path) reflects the real
-    // finalize, not just the legacy flag intent — otherwise the newly decoupled
-    // `normal_completion`-only finalize would leave that signal false and
-    // double-schedule kickoff / skip terminal-stop handling.
-    if !normal_completion && !finish_mailbox_on_completion && !delegated_finalize_owed {
+    // finalize — otherwise the decoupled `normal_completion`-only finalize would
+    // leave that signal false and double-schedule kickoff / skip terminal-stop.
+    if !normal_completion && !finish_mailbox_on_completion {
         return false;
-    }
-
-    if delegated_finalize_owed {
-        let ts = chrono::Local::now().format("%H:%M:%S");
-        tracing::info!(
-            "  [{ts}] watcher_finalized_delegated_turn: clearing channel {} mailbox after bridge→watcher handoff (#1452)",
-            channel_id.get()
-        );
     }
 
     // #3016 phase 3: route the watcher terminal through the single-authority
@@ -2449,15 +2434,11 @@ async fn finish_restored_watcher_active_turn(
             mailbox_online,
             ..
         } => {
-            // #3016 (codex P1): this watcher finalize consumed the delegated
-            // debt. Revoke the legacy `mailbox_finalize_owed` flag so a later
-            // watcher swap can't run stale cleanup against the NEXT active turn.
-            // (Removed wholesale in phase 5; revoked here in the meantime.)
-            if let Some(watcher) = shared.tmux_watchers.get(&channel_id) {
-                watcher
-                    .mailbox_finalize_owed
-                    .store(false, std::sync::atomic::Ordering::Release);
-            }
+            // #3016 phase-5b2: the legacy `mailbox_finalize_owed` flag that was
+            // revoked here (so a later watcher swap could not run stale cleanup
+            // against the NEXT active turn) has been removed entirely. The
+            // ledger's exactly-once phase gate is now the sole arbiter, so there
+            // is no stale flag a surviving watcher could swap.
             (mailbox_online, has_pending)
         }
         super::turn_finalizer::FinalizeOutcome::AlreadyFinalized

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -202,12 +202,6 @@ enum FreshIdleFinalizeDecision {
     /// (non-JSONL runtime at proven pane-idle) AND no follow-up took over —
     /// finalize via the single-authority path with the PINNED current-turn id.
     Finalize { user_msg_id: u64 },
-    /// #3016 phase-5b1: defunct. `Unknown` used to fall through to the legacy
-    /// `mailbox_finalize_owed`-flag path here; it now routes to `Finalize` on the
-    /// proven pane-idle proxy (flag-independent). The variant is retained as a
-    /// defensive no-op (the flag itself is removed in phase-5b2) and is never
-    /// produced by the decision helper.
-    LegacyFlagGated,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -5434,7 +5428,6 @@ pub(in crate::services::discord) async fn tmux_output_watcher(
     pause_epoch: Arc<std::sync::atomic::AtomicU64>,
     turn_delivered: Arc<std::sync::atomic::AtomicBool>,
     last_heartbeat_ts_ms: Arc<std::sync::atomic::AtomicI64>,
-    mailbox_finalize_owed: Arc<std::sync::atomic::AtomicBool>,
 ) {
     tmux_output_watcher_with_restore(
         channel_id,
@@ -5449,7 +5442,6 @@ pub(in crate::services::discord) async fn tmux_output_watcher(
         pause_epoch,
         turn_delivered,
         last_heartbeat_ts_ms,
-        mailbox_finalize_owed,
         None,
     )
     .await;
@@ -5470,7 +5462,6 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
     pause_epoch: Arc<std::sync::atomic::AtomicU64>,
     turn_delivered: Arc<std::sync::atomic::AtomicBool>,
     last_heartbeat_ts_ms: Arc<std::sync::atomic::AtomicI64>,
-    mailbox_finalize_owed: Arc<std::sync::atomic::AtomicBool>,
     restored_turn: Option<RestoredWatcherTurn>,
 ) {
     use std::io::{Read, Seek, SeekFrom};
@@ -7771,13 +7762,11 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 if !panel_cleanup_committed {
                     continue;
                 }
-                // #3016 phase-5b1: the finalize DECISION below no longer DEPENDS on
-                // this flag — both `Done` and `Unknown` route to the structural /
-                // pane-idle `Finalize` arm with `normal_completion = true`. We still
-                // `swap(false)` here to keep the revoke lifecycle intact (the flag
-                // field is removed in phase-5b2, not here); the read result is now
-                // used only for the observability event payload.
-                let owed = mailbox_finalize_owed.swap(false, std::sync::atomic::Ordering::AcqRel);
+                // #3016 phase-5b2: the legacy `mailbox_finalize_owed` flag is
+                // removed. The finalize DECISION never depended on it — both `Done`
+                // and `Unknown` route to the structural / pane-idle `Finalize` arm
+                // with `normal_completion = true`; the residual `swap(false)` (whose
+                // value fed only the observability payload) is gone with the field.
                 // #3016 S3 / phase-5b1 (codex HIGH fix): the finalize DECISION,
                 // computed by the same pure helper the unit tests drive. The defer
                 // gate above already deferred `PausedLive` and EMPTY `Unknown`, so
@@ -7922,7 +7911,6 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                                         None,
                                         "cleared_by_watcher_fresh_idle",
                                         serde_json::json!({
-                                            "owed_finalize": owed,
                                             "finish_mailbox_on_completion": finish_mailbox_on_completion,
                                             // #3016 phase-5b1: Done (structural) OR
                                             // Unknown (pane-idle proxy) both reach here.
@@ -7957,30 +7945,16 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                             channel_id,
                             user_msg_id,
                             finish_mailbox_on_completion,
-                            owed,
                             // #3016 S3 / phase-5b1: Done = confirmed structural
                             // completion; Unknown = non-JSONL runtime at proven
                             // pane-idle. Both drive the finalizer on the
                             // normal-completion authority, independent of the legacy
-                            // flags (the decoupling phase-5 depends on).
+                            // flag (removed in #3016 phase-5b2).
                             true,
                             true,
                             "watcher fresh ready-for-input idle (structural/pane-idle completion)",
                         )
                         .await;
-                    }
-                    FreshIdleFinalizeDecision::LegacyFlagGated => {
-                        // #3016 phase-5b1: defunct. `Unknown` no longer routes here —
-                        // it finalizes via the `Finalize` arm on the proven pane-idle
-                        // proxy (flag-independent). The decision helper never produces
-                        // this variant now; treated defensively as a preserve-inflight
-                        // no-op (mirroring the `DeferPausedLive` defensive arm). The
-                        // variant + `mailbox_finalize_owed` flag are removed in
-                        // phase-5b2.
-                        let ts = chrono::Local::now().format("%H:%M:%S");
-                        tracing::warn!(
-                            "  [{ts}] 👁 watcher fresh ready-for-input idle for {tmux_session_name}: LegacyFlagGated reached the finalize gate unexpectedly (phase-5b1 defunct path); preserving inflight"
-                        );
                     }
                 }
                 all_data.clear();
@@ -11372,15 +11346,12 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             //     terminal-stop decision) remains gated on `dispatch_ok` further
             //     below.
             //
-            // The `mailbox_finalize_owed.swap(false, AcqRel)` ordering still
-            // matters:
-            //   * Acquire — observes the bridge's prior `Release` store of
-            //     `true` (and any inflight writes that preceded it) before
-            //     we call `mailbox_finish_turn`.
-            //   * Release — publishes our reset back to `false`, so a watcher
-            //     that survives into the next turn will not accidentally clear
-            //     that turn's freshly registered cancel_token.
-            let owed = mailbox_finalize_owed.swap(false, std::sync::atomic::Ordering::AcqRel);
+            // #3016 phase-5b2: the legacy `mailbox_finalize_owed` flag is removed,
+            // so the `swap(false, AcqRel)` that read it here (whose value fed only
+            // the observability payload and the `watcher_handled_mailbox_finish`
+            // bookkeeping below) is gone. Exactly-once is the ledger's job; the
+            // cross-turn safety the Release reset provided is subsumed by the
+            // ledger phase gate.
             // #3016 (codex R3): do NOT delete the on-disk inflight when it
             // belongs to a NEWER follow-up turn (same session, started AT/AFTER
             // this committed range). The same offset decision that makes
@@ -11413,7 +11384,6 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                     watcher_turn_id.as_deref(),
                     "cleared_by_watcher",
                     serde_json::json!({
-                        "owed_finalize": owed,
                         "dispatch_ok": dispatch_ok,
                         "has_assistant_response": has_assistant_response,
                         "full_response_len": full_response.len(),
@@ -11496,16 +11466,13 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             // construction (see the R3 cross-ref comment above).
             //
             // Skip-path bookkeeping: the watcher did NOT drive the finalize, so
-            // `watcher_drove_finalize = false`. The `owed = mailbox_finalize_owed
-            // .swap(false, AcqRel)` at L~8165 already ran UNCONDITIONALLY (pre-
-            // existing option-A ordering), so this skip does not change the atomic's
-            // lifecycle — and dropping the LOCAL `owed` here drops no legitimate
-            // work: with option A's decoupling the newer live turn no longer depends
-            // on the `owed` flag to finalize (it finalizes via its own
-            // `normal_completion = true` path with its real id). `delegated_finalize_owed
-            // = owed` below still feeds `watcher_handled_mailbox_finish` so queue-
-            // kickoff suppression / terminal-stop accounting keep the legacy flag
-            // intent intact on the skip path.
+            // `watcher_drove_finalize = false`. #3016 phase-5b2: the legacy
+            // `mailbox_finalize_owed` flag is removed — the newer live turn no
+            // longer depends on it to finalize (it finalizes via its own
+            // `normal_completion = true` path with its real id), and the
+            // `watcher_handled_mailbox_finish` accounting below no longer folds the
+            // flag in (the stale-skip path is already kickoff-suppressed by
+            // `has_active_turn`, the newer live turn).
             let watcher_drove_finalize = if !completion_is_stale_for_newer_turn {
                 finish_restored_watcher_active_turn(
                     &shared,
@@ -11513,15 +11480,14 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                     channel_id,
                     restored_user_msg_id,
                     finish_mailbox_on_completion,
-                    owed,
                     // #3016 option A: terminal output was committed above
                     // (`terminal_output_committed && !lifecycle_stage_paused`), the
                     // canonical *normal completion* point. Finalize unconditionally —
-                    // independent of `owed` / `finish_mailbox_on_completion` — so the
-                    // normal live bridge→watcher delegation turn no longer depends on
-                    // the legacy `mailbox_finalize_owed` flag. The finalizer is
-                    // idempotent (bridge winner → AlreadyFinalized here), so this
-                    // cannot over-finalize.
+                    // independent of `finish_mailbox_on_completion` — so the normal
+                    // live bridge→watcher delegation turn no longer depends on the
+                    // legacy `mailbox_finalize_owed` flag (removed in #3016
+                    // phase-5b2). The finalizer is idempotent (bridge winner →
+                    // AlreadyFinalized here), so this cannot over-finalize.
                     true,
                     dispatch_ok,
                     "restored watcher completed with queued backlog",
@@ -11545,19 +11511,20 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                     )
                     .await;
             }
-            let delegated_finalize_owed = owed;
             let mailbox = shared.mailbox(channel_id);
             let has_active_turn = mailbox.has_active_turn().await;
-            // #3016 (codex R1): couple the post-finalize lifecycle to the ACTUAL
-            // finalize, not just the legacy flag intent. `watcher_drove_finalize`
-            // is true whenever the helper ran the finalizer (here always, via
-            // `normal_completion = true`) — so queue-kickoff suppression and the
-            // terminal-stop-candidate path below correctly account for the newly
-            // decoupled normal-completion finalize even when both legacy flags are
-            // false. (Folding the flags in too keeps behavior identical on the
-            // flag-driven paths.)
+            // #3016 (codex R1) / phase-5b2: couple the post-finalize lifecycle to
+            // the ACTUAL finalize. `watcher_drove_finalize` is true whenever the
+            // helper ran the finalizer (here always, via `normal_completion =
+            // true`) — so queue-kickoff suppression and the terminal-stop-candidate
+            // path below correctly account for the decoupled normal-completion
+            // finalize. The legacy `mailbox_finalize_owed`-derived
+            // `delegated_finalize_owed` term has been dropped from this OR: on the
+            // only path where `watcher_drove_finalize` is false (stale-newer-turn
+            // skip) a newer turn is live, so `has_active_turn` already suppresses
+            // the kickoff below — behaviour is identical.
             let watcher_handled_mailbox_finish =
-                watcher_drove_finalize || finish_mailbox_on_completion || delegated_finalize_owed;
+                watcher_drove_finalize || finish_mailbox_on_completion;
             let should_kickoff_queue = if watcher_handled_mailbox_finish
                 || monitor_auto_turn_finished
                 || has_active_turn
@@ -12614,8 +12581,7 @@ mod tests {
             channel_id,
             state.user_msg_id,
             true,  // finish_mailbox_on_completion (restore semantics)
-            false, // delegated_finalize_owed
-            false, // normal_completion (#3016: this path is flag-gated, not the decoupled normal-completion arm)
+            false, // normal_completion (#3016: this path is restore-gated, not the decoupled normal-completion arm)
             false, // kickoff_queue
             "terminal_delivery_timeout_cleanup_test",
         )
@@ -12635,14 +12601,11 @@ mod tests {
         assert_eq!(next.as_deref(), Some("queued follow-up"));
     }
 
-    // #3016 test helper: a real, non-stale watcher handle so the
-    // `mailbox_finalize_owed` precondition is NON-vacuous and the helper's
-    // `swap(false)` revoke path actually has a slot to act on. Mirrors the
-    // `live_watcher_handle` builder in mod.rs's registry tests.
-    fn test_watcher_handle(
-        tmux_session_name: &str,
-        mailbox_finalize_owed: bool,
-    ) -> crate::services::discord::TmuxWatcherHandle {
+    // #3016 test helper: a real, non-stale watcher handle so the registry slot
+    // exists for the finalize. Mirrors the `live_watcher_handle` builder in
+    // mod.rs's registry tests. (#3016 phase-5b2: the `mailbox_finalize_owed`
+    // field has been removed, so the helper no longer carries that flag.)
+    fn test_watcher_handle(tmux_session_name: &str) -> crate::services::discord::TmuxWatcherHandle {
         crate::services::discord::TmuxWatcherHandle {
             tmux_session_name: tmux_session_name.to_string(),
             output_path: format!("/tmp/{tmux_session_name}.jsonl"),
@@ -12654,30 +12617,24 @@ mod tests {
             last_heartbeat_ts_ms: std::sync::Arc::new(std::sync::atomic::AtomicI64::new(
                 crate::services::discord::tmux_watcher_now_ms(),
             )),
-            mailbox_finalize_owed: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
-                mailbox_finalize_owed,
-            )),
         }
     }
 
     // #3016 option A (watcher normal-completion finalize decouple).
     //
     // Proves the decoupling directly: a *normal completion* drives the
-    // single-authority finalizer even when BOTH legacy flags are false —
-    // `finish_mailbox_on_completion = false` (fresh live watcher, see
-    // tmux.rs:`tmux_output_watcher` default) AND `delegated_finalize_owed =
-    // false` (`mailbox_finalize_owed` never set / already revoked). This is the
-    // exact gate that `mailbox_finalize_owed` USED to be the sole driver of on
-    // the normal live bridge→watcher delegation turn; after this change the
-    // finalize fires from the confirmed-completion signal instead, so the flag
-    // is now redundant for this path (flag_now_redundant). The finalizer's
+    // single-authority finalizer with `finish_mailbox_on_completion = false`
+    // (fresh live watcher, see tmux.rs:`tmux_output_watcher` default). Under the
+    // OLD flag-only gate the watcher's normal live bridge→watcher delegation turn
+    // would only finalize when the now-removed `mailbox_finalize_owed` flag was
+    // set; after option A the finalize fires from the confirmed-completion signal
+    // instead, so the flag was redundant for this path. The finalizer's
     // idempotence (proven by the #3140 matrix) keeps this from over-finalizing
     // when the bridge already finalized first.
     //
-    // codex R1 hardening: registers a REAL watcher handle (so the
-    // `mailbox_finalize_owed` precondition is non-vacuous and the helper's
-    // `swap(false)` revoke path is exercised), asserts the finalize drove via
-    // the return value, and keeps the idempotence assertion.
+    // #3016 phase-5b2: with the flag removed, `finish_mailbox_on_completion =
+    // false` is now the only legacy gate, and `normal_completion = true` is the
+    // sole finalize driver.
     #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn normal_completion_finalizes_with_both_legacy_flags_false() {
@@ -12692,12 +12649,11 @@ mod tests {
         let channel_id = ChannelId::new(987_3016);
         let tmux_session_name = "AgentDesk-claude-adk-cc-9873016";
 
-        // Register a REAL watcher handle. The `mailbox_finalize_owed` flag is
-        // false here, so the precondition below is observed on an ACTUAL slot
+        // Register a REAL watcher handle so the finalize acts on an ACTUAL slot
         // (not the vacuous "no handle exists" case the original test had).
         shared
             .tmux_watchers
-            .insert(channel_id, test_watcher_handle(tmux_session_name, false));
+            .insert(channel_id, test_watcher_handle(tmux_session_name));
 
         // Seed a live active mailbox turn (cancel token registered) so we can
         // observe the finalize releasing it.
@@ -12712,23 +12668,6 @@ mod tests {
             .await
         );
 
-        // Pre-condition (NON-vacuous: real handle present): the legacy debt flag
-        // is NOT set for this channel's watcher. Combined with
-        // `finish_mailbox_on_completion = false` below, BOTH legacy gates are
-        // off — the only thing that can drive the finalize is the new
-        // `normal_completion` signal.
-        let watcher = shared
-            .tmux_watchers
-            .get(&channel_id)
-            .expect("real watcher handle must be registered for a non-vacuous precondition");
-        assert!(
-            !watcher
-                .mailbox_finalize_owed
-                .load(std::sync::atomic::Ordering::Acquire),
-            "precondition: mailbox_finalize_owed must be false for the decouple proof"
-        );
-        drop(watcher);
-
         crate::services::discord::inflight::clear_inflight_state(&provider, channel_id.get());
         let drove = super::finish_restored_watcher_active_turn(
             &shared,
@@ -12736,7 +12675,6 @@ mod tests {
             channel_id,
             3001,  // real user_msg_id (exact ledger match)
             false, // finish_mailbox_on_completion — fresh live watcher
-            false, // delegated_finalize_owed — flag never set
             true,  // normal_completion — confirmed terminal-output-committed point
             false, // kickoff_queue
             "normal_completion_decouple_test",
@@ -12748,13 +12686,13 @@ mod tests {
         );
 
         // The finalize fired purely on `normal_completion`: the active mailbox
-        // turn's cancel token is released even though both legacy flags were
+        // turn's cancel token is released even with `finish_mailbox_on_completion`
         // false. Under the OLD flag-only gate this call would have early-returned
         // and left the token in place.
         let snapshot = mailbox_snapshot(&shared, channel_id).await;
         assert!(
             snapshot.cancel_token.is_none(),
-            "normal completion must finalize and release the mailbox token even with both legacy flags false"
+            "normal completion must finalize and release the mailbox token with the legacy gate off"
         );
 
         // Idempotent: a second normal-completion submit for the same turn is a
@@ -12764,7 +12702,6 @@ mod tests {
             &provider,
             channel_id,
             3001,
-            false,
             false,
             true,
             false,
@@ -12805,12 +12742,10 @@ mod tests {
         let channel_id = ChannelId::new(987_3017);
         let tmux_session_name = "AgentDesk-claude-adk-cc-9873017";
 
-        // Real watcher handle with the legacy debt flag PRE-SET so we can also
-        // assert the helper's `swap(false)` revoke path runs on the matching
-        // (correct-turn) finalize.
+        // Real watcher handle so the finalize acts on an actual registry slot.
         shared
             .tmux_watchers
-            .insert(channel_id, test_watcher_handle(tmux_session_name, true));
+            .insert(channel_id, test_watcher_handle(tmux_session_name));
 
         // Turn A is the live active turn (id 3001).
         assert!(
@@ -12825,15 +12760,13 @@ mod tests {
         );
 
         crate::services::discord::inflight::clear_inflight_state(&provider, channel_id.get());
-        // Finalize turn A with its OWN id — releases turn A and revokes the
-        // legacy flag.
+        // Finalize turn A with its OWN id — releases turn A.
         let drove_a = super::finish_restored_watcher_active_turn(
             &shared,
             &provider,
             channel_id,
             3001,
             false,
-            true, // delegated_finalize_owed (real flag-driven correct-turn finalize)
             true,
             false,
             "stale_guard_turn_a",
@@ -12847,18 +12780,6 @@ mod tests {
                 .is_none(),
             "turn A must be released by its matching finalize"
         );
-        // The matching finalize consumed the debt: legacy flag revoked.
-        let watcher = shared
-            .tmux_watchers
-            .get(&channel_id)
-            .expect("handle present");
-        assert!(
-            !watcher
-                .mailbox_finalize_owed
-                .load(std::sync::atomic::Ordering::Acquire),
-            "matching finalize must revoke mailbox_finalize_owed (swap(false) path)"
-        );
-        drop(watcher);
 
         // A NEWER turn B (id 4002) becomes the live active turn.
         let token_b = std::sync::Arc::new(CancelToken::new());
@@ -12882,7 +12803,6 @@ mod tests {
             channel_id,
             3001, // STALE id (turn A), while turn B (4002) is live
             false,
-            false,
             true, // normal_completion fires unconditionally
             false,
             "stale_guard_stale_id",
@@ -12904,7 +12824,6 @@ mod tests {
             &provider,
             channel_id,
             4002,
-            false,
             false,
             true,
             false,
@@ -13433,7 +13352,6 @@ mod tests {
             channel_id,
             finalize_id,
             false, // finish_mailbox_on_completion — fresh live watcher
-            false, // delegated_finalize_owed — flag FALSE
             true,  // normal_completion — S3: structural-signal-driven, flag-independent
             true,
             "watcher fresh ready-for-input idle (structural completion terminator)",
@@ -13457,7 +13375,6 @@ mod tests {
             &provider,
             channel_id,
             finalize_id,
-            false,
             false,
             true,
             true,

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -1496,12 +1496,6 @@ async fn claim_tui_direct_synthetic_turn(
                 .turn_start_times
                 .insert(channel_id, std::time::Instant::now());
         }
-        publish_tui_direct_watcher_finalize_debt(
-            shared,
-            channel_id,
-            tmux_session_name,
-            relay_owner,
-        );
         return TuiDirectSyntheticTurnClaim {
             relay_owner,
             claimed: true,
@@ -1545,7 +1539,6 @@ async fn claim_tui_direct_synthetic_turn(
             .turn_start_times
             .insert(channel_id, std::time::Instant::now());
     }
-    publish_tui_direct_watcher_finalize_debt(shared, channel_id, tmux_session_name, relay_owner);
     tracing::info!(
         provider = %provider.as_str(),
         channel_id = channel_id.get(),
@@ -1863,29 +1856,12 @@ fn restore_pending_starts(shared: &Arc<SharedData>, provider: &ProviderKind) {
     }
 }
 
-fn publish_tui_direct_watcher_finalize_debt(
-    shared: &Arc<SharedData>,
-    channel_id: ChannelId,
-    tmux_session_name: &str,
-    relay_owner: ExternalInputRelayOwner,
-) {
-    if !matches!(relay_owner, ExternalInputRelayOwner::TmuxWatcher) {
-        return;
-    }
-    let owner_channel = shared
-        .tmux_watchers
-        .owner_channel_for_tmux_session(tmux_session_name)
-        .unwrap_or(channel_id);
-    let Some(watcher) = shared.tmux_watchers.get(&owner_channel) else {
-        return;
-    };
-    if watcher.tmux_session_name != tmux_session_name {
-        return;
-    }
-    watcher
-        .mailbox_finalize_owed
-        .store(true, std::sync::atomic::Ordering::Release);
-}
+// #3016 phase-5b2: `publish_tui_direct_watcher_finalize_debt` was removed. It
+// stored the per-handle `mailbox_finalize_owed` flag (#1452) for TUI-direct
+// synthetic turns, but that flag has no remaining finalize-decision readers —
+// the watcher finalizes on the confirmed-completion / structural signal
+// (`normal_completion = true`) and the ledger's `register_start` is the
+// authority — so the producer was a dead write and is gone.
 
 fn tui_direct_watcher_can_own_output(
     watchers: &super::TmuxWatcherRegistry,
@@ -6327,7 +6303,6 @@ mod tests {
             last_heartbeat_ts_ms: Arc::new(std::sync::atomic::AtomicI64::new(
                 super::super::tmux_watcher_now_ms(),
             )),
-            mailbox_finalize_owed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -3214,7 +3214,6 @@ mod bridge_owner_channel_resolution_tests {
             pause_epoch: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             turn_delivered: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             last_heartbeat_ts_ms: Arc::new(std::sync::atomic::AtomicI64::new(0)),
-            mailbox_finalize_owed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 
@@ -3923,7 +3922,6 @@ fn handle_watcher_runtime_handoff(
     watcher_handoff_claim_outcome: &mut WatcherHandoffClaimOutcome,
     tmux_handed_off: &mut bool,
     watcher_owns_assistant_relay: &mut bool,
-    bridge_published_finalize_owed_for_this_turn: &mut bool,
     state_dirty: &mut bool,
     done: bool,
     terminal_control_drain_until: &mut Option<std::time::Instant>,
@@ -3970,7 +3968,6 @@ fn handle_watcher_runtime_handoff(
     let last_heartbeat_ts_ms = Arc::new(std::sync::atomic::AtomicI64::new(
         super::tmux_watcher_now_ms(),
     ));
-    let mailbox_finalize_owed = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let handle = TmuxWatcherHandle {
         tmux_session_name: tmux_session_name.clone(),
         output_path: output_path.clone(),
@@ -3980,7 +3977,6 @@ fn handle_watcher_runtime_handoff(
         pause_epoch: pause_epoch.clone(),
         turn_delivered: turn_delivered.clone(),
         last_heartbeat_ts_ms: last_heartbeat_ts_ms.clone(),
-        mailbox_finalize_owed: mailbox_finalize_owed.clone(),
     };
     #[cfg(unix)]
     let (watcher_claimed, watcher_claim_replaced_existing) = {
@@ -4144,7 +4140,6 @@ fn handle_watcher_runtime_handoff(
                         pause_epoch,
                         turn_delivered,
                         last_heartbeat_ts_ms,
-                        mailbox_finalize_owed,
                         restored_turn,
                     ),
                 );
@@ -4180,19 +4175,14 @@ fn handle_watcher_runtime_handoff(
             watcher
                 .turn_delivered
                 .store(false, std::sync::atomic::Ordering::Relaxed);
-            watcher
-                .mailbox_finalize_owed
-                .store(true, std::sync::atomic::Ordering::Release);
-            *bridge_published_finalize_owed_for_this_turn = true;
             // #3016 phase 2: register the turn with the single-authority
             // finalizer BEFORE unpausing the watcher. Message arrival order in
             // the actor replaces the deleted Release/AcqRel ordering: the
             // ledger now knows the turn exists (with the watcher as relay
-            // owner) before the watcher can submit its terminal. The legacy
-            // `mailbox_finalize_owed` store stays for the incremental window
-            // (the watcher still consumes it until phase 3 / removed in phase
-            // 5); the ledger is the authority that supersedes the CAS revoke
-            // deleted from the bridge finalize branches below.
+            // owner) before the watcher can submit its terminal. The ledger is
+            // the authority that superseded the legacy `mailbox_finalize_owed`
+            // flag (removed in #3016 phase-5b2) and the CAS revoke deleted from
+            // the bridge finalize branches below.
             shared_owned.turn_finalizer.register_start(
                 super::turn_finalizer::TurnKey::new(
                     channel_id,
@@ -4360,16 +4350,6 @@ pub(super) fn spawn_turn_bridge(
                 | super::inflight::RelayOwnerKind::SessionBoundRelay
                 | super::inflight::RelayOwnerKind::Unknown
         );
-        // #1452 (Codex iter 3 P1): track whether THIS turn published a
-        // mailbox-finalization debt onto the watcher handle. Without this
-        // flag, the bridge's non-delegation `compare_exchange(true, false, ...)`
-        // cannot tell apart "watcher consumed our debt" (skip finalize) from
-        // "we never set debt at all" (must finalize). The flag flips to
-        // true at the watcher-unpause site below; the non-delegation
-        // finalization branch consults it to decide whether the
-        // compare_exchange Err arm means "watcher beat us" or "no debt at
-        // all".
-        let mut bridge_published_finalize_owed_for_this_turn = false;
         // #1255 live-turn long-running tool placeholder card.
         //
         // `last_assistant_text_line` captures the last non-empty single-line
@@ -5842,8 +5822,6 @@ pub(super) fn spawn_turn_bridge(
                                 Arc::new(std::sync::atomic::AtomicI64::new(
                                     super::tmux_watcher_now_ms(),
                                 ));
-                            let mailbox_finalize_owed =
-                                Arc::new(std::sync::atomic::AtomicBool::new(false));
                             let handle = TmuxWatcherHandle {
                                 tmux_session_name: tmux_session_name.clone(),
                                 output_path: output_path.clone(),
@@ -5853,7 +5831,6 @@ pub(super) fn spawn_turn_bridge(
                                 pause_epoch: pause_epoch.clone(),
                                 turn_delivered: turn_delivered.clone(),
                                 last_heartbeat_ts_ms: last_heartbeat_ts_ms.clone(),
-                                mailbox_finalize_owed: mailbox_finalize_owed.clone(),
                             };
                             #[cfg(unix)]
                             let (watcher_claimed, watcher_claim_replaced_existing) = {
@@ -6049,7 +6026,6 @@ pub(super) fn spawn_turn_bridge(
                                             pause_epoch,
                                             turn_delivered,
                                             last_heartbeat_ts_ms,
-                                            mailbox_finalize_owed,
                                             restored_turn,
                                             ),
                                         );
@@ -6100,18 +6076,12 @@ pub(super) fn spawn_turn_bridge(
                                     // permanently set OR is consumed by a future
                                     // watcher event for the WRONG turn.
                                     //
-                                    // We treat "watcher is now responsible for relay"
-                                    // as a superset of "bridge will delegate
-                                    // finalization": the store is unconditional here,
-                                    // and the bridge's later non-delegation paths
-                                    // (cancelled/prompt_too_long/transport_error/
-                                    // recovery_retry) revoke the debt with a
-                                    // `store(false, Release)` before running their
-                                    // own `mailbox_finish_turn`.
-                                    watcher
-                                        .mailbox_finalize_owed
-                                        .store(true, Ordering::Release);
-                                    bridge_published_finalize_owed_for_this_turn = true;
+                                    // #3016 phase-5b2: the legacy
+                                    // `mailbox_finalize_owed` store that used to
+                                    // publish "bridge will delegate finalization"
+                                    // here is removed; the `register_start` below
+                                    // (RelayOwnerKind::Watcher) is the ledger
+                                    // authority that replaced it.
                                     // #3016 phase 3: register the turn with the
                                     // single-authority finalizer BEFORE
                                     // unpausing the watcher — same as the
@@ -6138,18 +6108,17 @@ pub(super) fn spawn_turn_bridge(
                                         // at register time.
                                         &shared_owned,
                                     );
-                                    // #1452 (Codex iter 3 P1): unpause must
-                                    // use Release ordering so a watcher
-                                    // observing `paused = false` is
-                                    // guaranteed to also observe the
-                                    // `mailbox_finalize_owed = true` store
-                                    // above. With Relaxed ordering on a
-                                    // weakly-ordered platform the two
-                                    // stores can be reordered, letting the
-                                    // watcher unpause, race to its terminal
-                                    // swap, observe `false`, and skip
-                                    // `mailbox_finish_turn` — recreating
-                                    // the leak this change is meant to fix.
+                                    // #1452 (Codex iter 3 P1) / #3016 phase-5b2:
+                                    // unpause uses Release ordering so a watcher
+                                    // observing `paused = false` is guaranteed to
+                                    // also observe the prior writes — the
+                                    // `register_start` (RelayOwnerKind::Watcher)
+                                    // ledger entry that now drives the
+                                    // gate-timeout defer. With Relaxed ordering on
+                                    // a weakly-ordered platform the writes could
+                                    // be reordered, letting the watcher unpause
+                                    // and submit a terminal before the ledger
+                                    // knows the turn exists.
                                     watcher.paused.store(false, Ordering::Release);
                                 }
                             }
@@ -6184,7 +6153,6 @@ pub(super) fn spawn_turn_bridge(
                                     &mut watcher_handoff_claim_outcome,
                                     &mut tmux_handed_off,
                                     &mut watcher_owns_assistant_relay,
-                                    &mut bridge_published_finalize_owed_for_this_turn,
                                     &mut state_dirty,
                                     done,
                                     &mut terminal_control_drain_until,
@@ -6212,7 +6180,6 @@ pub(super) fn spawn_turn_bridge(
                                     &mut watcher_handoff_claim_outcome,
                                     &mut tmux_handed_off,
                                     &mut watcher_owns_assistant_relay,
-                                    &mut bridge_published_finalize_owed_for_this_turn,
                                     &mut state_dirty,
                                     done,
                                     &mut terminal_control_drain_until,
@@ -6244,7 +6211,6 @@ pub(super) fn spawn_turn_bridge(
                                     &mut watcher_handoff_claim_outcome,
                                     &mut tmux_handed_off,
                                     &mut watcher_owns_assistant_relay,
-                                    &mut bridge_published_finalize_owed_for_this_turn,
                                     &mut state_dirty,
                                     done,
                                     &mut terminal_control_drain_until,
@@ -7199,37 +7165,21 @@ pub(super) fn spawn_turn_bridge(
                 has_pending_after_voice
             }
         } else {
-            // #1452 non-delegation path. The watcher-unpause site
-            // optimistically publishes `mailbox_finalize_owed = true`, but
-            // we are now finalizing on the bridge side instead (cancelled /
-            // prompt_too_long / transport_error / recovery_retry, or the
-            // watcher never ended up owning relay).
+            // #1452 non-delegation path: we are finalizing on the bridge side
+            // (cancelled / prompt_too_long / transport_error / recovery_retry,
+            // or the watcher never ended up owning relay).
             //
             // #3016 phase 2/3: the single-authority finalizer's per-turn
-            // ledger phase gate now ARBITRATES exactly-once — whoever submits
+            // ledger phase gate ARBITRATES exactly-once — whoever submits
             // the terminal first finalizes; the loser receives
-            // `AlreadyFinalized` and does nothing. The CAS no longer decides
-            // who finalizes.
+            // `AlreadyFinalized` and does nothing.
             //
-            // BUT we still REVOKE the legacy `mailbox_finalize_owed` flag here
-            // until it is fully removed (phase 5). The watcher consumes that
-            // flag via `swap(false)` and, when set, routes a terminal into the
-            // finalizer. If the bridge finalizes this turn and leaves the flag
-            // set, a watcher that survives into the NEXT turn would swap the
-            // stale `true` and submit a channel-only terminal that collapses
-            // onto — and prematurely finalizes — the next turn's live ledger
-            // entry. Clearing it here (only when THIS turn published it) closes
-            // that cross-turn hazard.
-            if bridge_published_finalize_owed_for_this_turn
-                && let Some(watcher) = shared_owned.tmux_watchers.get(&watcher_owner_channel_id)
-            {
-                let _ = watcher.mailbox_finalize_owed.compare_exchange(
-                    true,
-                    false,
-                    std::sync::atomic::Ordering::AcqRel,
-                    std::sync::atomic::Ordering::Acquire,
-                );
-            }
+            // #3016 phase-5b2: the legacy `mailbox_finalize_owed` flag has been
+            // removed entirely, so the CAS true→false revoke that used to run
+            // here (gated on `bridge_published_finalize_owed_for_this_turn`) is
+            // gone. The ledger's exactly-once gate already guards the
+            // cross-turn hazard the CAS protected against — a watcher surviving
+            // into the NEXT turn no longer has a flag to swap.
             if bridge_early_gate_timed_out {
                 let ts = chrono::Local::now().format("%H:%M:%S");
                 tracing::warn!(

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -1399,10 +1399,10 @@ fn watcher_backstop_turn_is_terminal(
 
 /// Run the deadline-elapsed backstop finalize for ONE entry: flip
 /// `Pending → Finalizing` (skip if a concurrent terminal already advanced it),
-/// run `do_finalize` on the backstop context, revoke the legacy
-/// `mailbox_finalize_owed` debt (still present until phase-5b), then flip
-/// `Finalized`. Shared by the gate-timeout deadline arm and the phase-5a
-/// watcher far-backstop arm so exactly-once is decided in one place.
+/// run `do_finalize` on the backstop context, then flip `Finalized`. Shared by
+/// the gate-timeout deadline arm and the phase-5a watcher far-backstop arm so
+/// exactly-once is decided in one place. (#3016 phase-5b2: the legacy
+/// `mailbox_finalize_owed` revoke that used to run here is gone with the flag.)
 async fn run_backstop_finalize(
     ledger: &mut HashMap<LedgerKey, LedgerEntry>,
     ledger_key: LedgerKey,
@@ -1428,16 +1428,12 @@ async fn run_backstop_finalize(
         shared,
     )
     .await;
-    // Codex P1 — the watcher skipped its cleanup block (lifecycle paused), so
-    // its legacy `mailbox_finalize_owed` flag is still `true`. The backstop just
-    // released the mailbox/inflight, so revoke that debt now; otherwise the
-    // watcher could later `swap(true)` and run stale cleanup against the NEXT
-    // active turn. (Flag removed wholesale in phase-5b.)
-    if let Some(watcher) = shared.tmux_watchers.get(&turn_key.channel_id) {
-        watcher
-            .mailbox_finalize_owed
-            .store(false, std::sync::atomic::Ordering::Release);
-    }
+    // #3016 phase-5b2: the legacy `mailbox_finalize_owed` flag that was revoked
+    // here (the watcher skipped its cleanup block while lifecycle-paused, leaving
+    // the flag set; the backstop revoked it so a later watcher swap could not run
+    // stale cleanup against the NEXT active turn) has been removed. The ledger's
+    // exactly-once phase gate is now the sole arbiter, so there is no stale flag a
+    // surviving watcher could swap.
     if let Some(entry) = ledger.get_mut(&ledger_key) {
         entry.phase = Phase::Finalized;
         entry.finalized_at = Some(now);
@@ -4418,7 +4414,6 @@ mod tests {
             last_heartbeat_ts_ms: Arc::new(std::sync::atomic::AtomicI64::new(
                 crate::services::discord::tmux_watcher_now_ms(),
             )),
-            mailbox_finalize_owed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 

--- a/src/services/discord/watchers/lifecycle.rs
+++ b/src/services/discord/watchers/lifecycle.rs
@@ -885,7 +885,6 @@ mod tests {
             pause_epoch: Arc::new(AtomicU64::new(0)),
             turn_delivered: Arc::new(AtomicBool::new(false)),
             last_heartbeat_ts_ms: Arc::new(AtomicI64::new(tmux_watcher_now_ms())),
-            mailbox_finalize_owed: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -2708,7 +2707,6 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
         let last_heartbeat_ts_ms = Arc::new(std::sync::atomic::AtomicI64::new(
             super::super::tmux_watcher_now_ms(),
         ));
-        let mailbox_finalize_owed = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
         let handle = TmuxWatcherHandle {
             tmux_session_name: pw.session_name.clone(),
@@ -2719,7 +2717,6 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
             pause_epoch: pause_epoch.clone(),
             turn_delivered: turn_delivered.clone(),
             last_heartbeat_ts_ms: last_heartbeat_ts_ms.clone(),
-            mailbox_finalize_owed: mailbox_finalize_owed.clone(),
         };
         if !try_claim_watcher(&shared.tmux_watchers, pw.channel_id, handle) {
             let ts = chrono::Local::now().format("%H:%M:%S");
@@ -2756,7 +2753,6 @@ pub(in crate::services::discord) async fn restore_tmux_watchers(
                 pause_epoch,
                 turn_delivered,
                 last_heartbeat_ts_ms,
-                mailbox_finalize_owed,
                 pw.restored_turn,
             ),
         );


### PR DESCRIPTION
## #3016 phase-5b2 — delete the `mailbox_finalize_owed` flag

### Confirmation: zero finalize-readers post-5b1
phase-5b1 (merged, `cdcc67575`) replaced every finalize-decision **consumer** of the per-handle `mailbox_finalize_owed` flag:
- Unknown fresh-idle finalize is flag-independent (empty→defer via `full_response.empty()`, non-empty→`Finalize`); the `LegacyFlagGated` variant became unreachable.
- The `bridge_handoff_finds_watcher_handle` invariant uses the ledger's `has_live_watcher_pending` instead of the flag.

Post-5b1 the flag was set/revoked but never **read to drive a finalize decision** — only a residual `swap(false)` whose value fed an observability event. This PR is pure dead-write elimination.

### Removed sites
- **Field**: `TmuxWatcherHandle.mailbox_finalize_owed` + doc (`mod.rs`).
- **Producers** (`store(true)`): `turn_bridge/mod.rs` runtime-handoff + legacy `TmuxReady` handoff (kept the adjacent `register_start(RelayOwnerKind::Watcher)` ledger authority); the dead `publish_tui_direct_watcher_finalize_debt` producer in `tui_prompt_relay.rs`.
- **Revoke sites**: `tmux.rs` watcher-finalize `store(false)`; `turn_bridge/mod.rs` non-delegation CAS true→false + its `bridge_published_finalize_owed_for_this_turn` tracking var/param/passes; `turn_finalizer.rs` `run_backstop_finalize` `store(false)`.
- **Observability read**: the two `swap(false)` reads in `tmux_watcher.rs` (fresh-idle + relay-completed); the `owed_finalize` event payload field dropped.
- **`LegacyFlagGated`**: the `FreshIdleFinalizeDecision` variant + its match arm.
- **`delegated_finalize_owed` param** of `finish_restored_watcher_active_turn` (`tmux.rs`) — redundant under `normal_completion = true` at both production call sites; only fed an observability log.
- **Constructor fan-out**: `recovery_engine.rs` (×3), `watchers/lifecycle.rs`, `turn_bridge/mod.rs`, `tui_prompt_relay.rs`, `router/message_handler/watchdog.rs`, and test handle builders.

### Behaviour-identical argument
- Both production call sites of `finish_restored_watcher_active_turn` pass `normal_completion = true`, so the `delegated_finalize_owed` OR-term never affected the finalize decision.
- On the only path where `watcher_drove_finalize` is false (stale-newer-turn skip), a newer turn is live, so `has_active_turn` already suppresses queue kickoff — the dropped flag-derived term changes nothing.
- Exactly-once is the ledger's job; the cross-turn safety the revokes provided is subsumed by the per-process actor-owned ledger phase gate.

### Gate results
- `cargo fmt --check`: clean.
- `cargo check --lib`: clean; `grep mailbox_finalize_owed src/` returns only removal-note comments (zero code references).
- `cargo test --lib turn_finalizer` (69), `tmux_watcher` (150), `turn_bridge` (139): all pass **unchanged** (incl. phase-5a backstop, phase-5b1 Unknown-routing, exactly-once, paused-live defer).
- `python3 scripts/check_agent_maintenance_docs.py`: `agent-maintenance freshness check passed` (change-surfaces freeze synced; giant-file baseline lowered to new actuals; multinode-transition Audited touches note added).
- `bash scripts/ci-script-checks.sh`: exit 0, `giant_file_ratchet` findings empty.

### Readers that blocked removal
None. The `delegated_finalize_owed` reader inside `finish_restored_watcher_active_turn` was observability-only and dominated by `normal_completion = true` at both production sites — not a finalize-decision consumer 5b1 missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)