### PR TITLE
refactor(#3038): extract claude.rs fresh-turn finalize phase from execute_streaming_local_tui_tmux

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -854,7 +854,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
 - `src/services/dispatches/outbox_route.rs` (1118) — dispatch outbox route
   support extracted from the route layer; split before adding non-bugfix
   behavior.
-- `src/services/claude.rs` (3912), `src/services/gemini.rs` (1416),
+- `src/services/claude.rs` (3949), `src/services/gemini.rs` (1416),
   `src/services/qwen.rs` (2200), `src/services/codex.rs` (3083),
   `src/services/opencode.rs` (1881), `src/services/provider.rs` (1738) —
   provider adapters.

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -389,6 +389,18 @@
   internally and is invoked at the identical position in `run_bot`. No new
   multinode ownership, singleton, or lease assumption is introduced; the
   leader-only vs worker-local classification of every spawned task is preserved.
+- #3038 (`execute_streaming_local_tui_tmux` god-function decomposition, follow-up
+  slice to #3196): `claude.rs` changed by a **pure, behavior-preserving
+  extraction** of the orchestrator's inline fresh-turn dispatch + completion gate
+  into one `run_claude_tui_fresh_turn_and_finalize` free helper (skip-stale-bytes
+  offset, ready-retry fresh-turn run, and the three terminal outcomes:
+  start-failure, `SessionDied`, and delivery with watcher handoff + producer-exit
+  log). Every original `return Ok/Err` and the audit + exit-reason + kill +
+  owner-marker cleanup ordering are **unchanged** — the helper is invoked at the
+  identical position as a tail call and returns the same `Result` directly. The
+  tmux session ownership marker, turn lock, and termination-audit side effects are
+  all **process-local / per-session**; no new multinode ownership, singleton, or
+  lease assumption is introduced.
 - #3142 (committed-output turn-aliasing safety): `tmux_watcher.rs` changed by
   adding one **pure** decision helper
   (`committed_anchor_cleanup_is_stale_for_newer_turn`, the id==0-inclusive sibling

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -2271,17 +2271,54 @@ fn execute_streaming_local_tui_tmux(
         session_id: resolved_session_id.clone(),
         raw_session_id: Some(resolved_session_id.clone()),
     });
+    run_claude_tui_fresh_turn_and_finalize(
+        &transcript_path,
+        &transcript_path_string,
+        sender,
+        cancel_token,
+        tmux_session_name,
+        &resolved_session_id,
+        report_channel_id,
+        prompt,
+        &owner_path,
+    )
+}
+
+/// Dispatch a fresh Claude TUI turn and resolve its terminal outcome.
+///
+/// Verbatim extraction of the orchestrator's fresh-turn dispatch + completion
+/// gate: skip-stale-bytes offset capture, the ready-retry fresh-turn run, and
+/// the three terminal outcomes — fresh-turn start failure, `SessionDied` before
+/// completion, and successful delivery (watcher handoff + producer-exit log).
+/// Every original `return Ok/Err` is preserved as this fn's return value, and
+/// the two failure paths perform the identical audit + exit-reason + kill +
+/// owner-marker cleanup before returning `Err`. `owner_path` is the owner-marker
+/// path returned by `prepare_and_create_claude_tui_session`, removed on either
+/// failure path exactly as the inline block did.
+#[cfg(unix)]
+#[allow(clippy::too_many_arguments)]
+fn run_claude_tui_fresh_turn_and_finalize(
+    transcript_path: &std::path::Path,
+    transcript_path_string: &str,
+    sender: Sender<StreamMessage>,
+    cancel_token: Option<std::sync::Arc<CancelToken>>,
+    tmux_session_name: &str,
+    resolved_session_id: &str,
+    report_channel_id: Option<u64>,
+    prompt: &str,
+    owner_path: &str,
+) -> Result<(), String> {
     // Skip any transcript bytes that predate this launch. Resume and fresh
     // turns both need this guard because a reused/colliding session_id can
     // leave stale JSONL on disk even when the launch is intentionally fresh.
-    let fresh_turn_start_offset = claude_tui_fresh_turn_start_offset(&transcript_path);
+    let fresh_turn_start_offset = claude_tui_fresh_turn_start_offset(transcript_path);
     let fresh_turn_result = run_claude_tui_fresh_turn_with_ready_retry(
-        &transcript_path_string,
+        transcript_path_string,
         fresh_turn_start_offset,
         sender.clone(),
         cancel_token,
         tmux_session_name,
-        &resolved_session_id,
+        resolved_session_id,
         prompt,
     );
     let read_result = match fresh_turn_result {
@@ -2303,7 +2340,7 @@ fn execute_streaming_local_tui_tmux(
                 tmux_session_name,
                 &format!("claude tui fresh turn failed: {}", error),
             );
-            let _ = std::fs::remove_file(&owner_path);
+            let _ = std::fs::remove_file(owner_path);
             return Err(error);
         }
     };
@@ -2324,18 +2361,18 @@ fn execute_streaming_local_tui_tmux(
             tmux_session_name,
             "claude tui session died before turn completion",
         );
-        let _ = std::fs::remove_file(&owner_path);
+        let _ = std::fs::remove_file(owner_path);
         return Err("claude tui session died before turn completion".to_string());
     }
     emit_claude_tui_watcher_handoff(
         &sender,
-        &transcript_path_string,
+        transcript_path_string,
         tmux_session_name,
-        &transcript_path,
+        transcript_path,
     );
     log_producer_exit(
         "tui_turn_delivered",
-        Some(&resolved_session_id),
+        Some(resolved_session_id),
         report_channel_id,
         0,
         serde_json::json!({


### PR DESCRIPTION
## Which function
`execute_streaming_local_tui_tmux` in `src/services/claude.rs`.

This is a **follow-up slice** to the already-merged #3196 (which decomposed the original ~714-line god-function into a thin orchestrator + `try_claude_tui_warm_followup` / `cleanup_stale_claude_tui_session` / `prepare_and_create_claude_tui_session`). One cohesive phase remained inline in the orchestrator — the fresh-turn dispatch + completion gate — and is extracted here, leaving `execute_streaming_local_tui_tmux` as a thin sequential orchestrator that ends in a tail call.

## Helper extracted
- **`run_claude_tui_fresh_turn_and_finalize`** — verbatim extraction of the orchestrator's fresh-turn dispatch + completion gate: skip-stale-bytes offset capture, the ready-retry fresh-turn run (`run_claude_tui_fresh_turn_with_ready_retry`), and the three terminal outcomes:
  1. **fresh-turn start failure** → audit + exit-reason + `kill_session` + owner-marker removal → `Err`,
  2. **`SessionDied` before completion** → same teardown → `Err`,
  3. **delivery** → `emit_claude_tui_watcher_handoff` + `log_producer_exit("tui_turn_delivered")` → `Ok(())`.

  `owner_path` is threaded as `&str` so both failure paths remove the owner marker exactly as the inline block did.

## Behavior-preserving argument
The only diffs vs the inline block are:
- the `&`-removals where moved params became borrows (`transcript_path: &Path`, `transcript_path_string: &str`, `resolved_session_id: &str`, `owner_path: &str`),
- the orchestrator's trailing tail call returning the helper's `Result` directly.

No logic, condition, ordering, or side-effect change. Every original `return Ok/Err` maps to the helper's return value; the audit + exit-reason + kill + owner-marker cleanup ordering on both failure paths is byte-identical. `cargo test --lib services::claude` count is unchanged at 167 / 0.

## Gates (in order)
1. `cargo fmt --check` — clean.
2. `cargo check --lib` — clean (only the 2 pre-existing warnings in `placeholder_live_events/mod.rs` + `tmux_watcher.rs`, unchanged from main); `cargo test --lib services::claude` — **167 passed, 0 failed** (identical to #3196).
3. `python3 scripts/generate_inventory_docs.py` → `python3 scripts/check_agent_maintenance_docs.py` → **agent-maintenance freshness check passed** (change-surfaces.md freeze `3912 → 3949` synced); `bash scripts/ci-script-checks.sh` — **exit 0**. `multinode-transition.md` `### Audited touches` note added for #3038 (process-local / per-session side effects, no new multinode ownership/lease). claude.rs is **not** in the `giant_file_ratchet` table (scoped to `discord/**` + `turn_*`), so no baseline edit; the table is never raised.

## Residual risk
Low. Pure same-file extraction with identical control flow, ordering, and error handling; covered by the existing 167-test claude suite which passes unchanged. Net +37 production lines (doc comment + signature), reflecting the maintainability-vs-LoC tradeoff also present in #3196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)