### PR TITLE
feat(discord): faithful watcher CREATE/ADOPT shadow-parity through StatusPanelController (#3078)

### DIFF
--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -466,3 +466,18 @@
   removed flag was a per-handle in-process atomic, and the surviving authority (the
   per-process actor-owned ledger) is unchanged. No new multinode
   ownership/singleton/lease assumption.
+- #3078 (status-panel controller — faithful watcher CREATE/ADOPT shadow-parity):
+  completes the create/adopt sub-step PR-4 deferred. `status_panel_controller.rs`
+  gains a **pure** `watcher_create_parity_decision` (a `WatcherCreateDecision`
+  re-derived from the SAME raw inputs the legacy
+  `watcher_should_create_external_input_status_panel` branch reads — no actor
+  round-trip, no ledger read, no IO); `watcher_panel_parity.rs` gains the
+  `assert_watcher_create_parity` shadow check (independent legacy derivation +
+  `debug_assert`/bounded-warn, legacy still executes the real create/adopt IO);
+  `tmux_watcher.rs` adds a single net-zero hook at the deferred-comment seam
+  (production LoC held at the 9598 freeze, generated docs unchanged). The
+  controller stays a **per-process** in-memory actor on `SharedData` (peer of
+  `TurnFinalizer`); the parity decision reads only the watcher's process-local
+  raw inputs and the still-dormant ledger, performs no Discord IO, acquires no
+  lease, and changes no leader/standby ownership. Behaviour-preserving (shadow
+  only). No new multinode ownership/singleton/lease assumption.

--- a/src/services/discord/status_panel_controller.rs
+++ b/src/services/discord/status_panel_controller.rs
@@ -109,6 +109,33 @@ pub(in crate::services::discord) enum PanelCommitOutcome {
     NoPanel,
 }
 
+/// EPIC #3078 — the controller's independent decision for the watcher's
+/// status-panel CREATE/ADOPT site (`tmux_watcher.rs` ~7213): given a TUI-direct /
+/// external-input turn that has reached the panel-publish gate, does the panel
+/// already exist (adopt it), should a fresh panel be created, or is there nothing
+/// to do?
+///
+/// This is the create/adopt analogue of the RECLAIM parity (`sweeper_reclaim_*`):
+/// instead of echoing the already-resolved legacy id back (the tautology that
+/// scoped PR-4 down — see the deferred-site note below), the controller
+/// independently re-derives the decision from the SAME RAW inputs the legacy
+/// `watcher_should_create_external_input_status_panel` branch reads, so the
+/// shadow parity check is meaningful. The create id is not known until the send
+/// returns, so the faithful comparison is on the DECISION (adopt-which-id /
+/// create / none), not on a post-send message id.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(in crate::services::discord) enum WatcherCreateDecision {
+    /// A panel already persisted on this turn's inflight row (restart-safe
+    /// adoption): adopt the existing id, do NOT publish a duplicate.
+    AdoptPersisted(MessageId),
+    /// No panel exists yet for an eligible external-input turn: the watcher must
+    /// publish (create) the panel itself.
+    Create,
+    /// Nothing to do at this site: v2 off, a (non-persisted) panel already
+    /// exists, or the turn is not an external-input/panel-eligible turn.
+    None,
+}
+
 /// What a panel should render and how to publish it. The actual Discord
 /// create/edit/delete IO is abstracted behind [`PanelSink`] so the ledger +
 /// durable-mirror logic is the single authority and is unit-testable without a
@@ -448,12 +475,43 @@ impl StatusPanelController {
         self.orphan_parity_target(key, panel_msg_id).await
     }
 
-    // EPIC #3078: watcher CREATE/ADOPT and COMPLETION parity query methods were
-    // deferred to the controller execute-cutover PR. A faithful check must
-    // replicate `watcher_should_create_external_input_status_panel` and the
-    // SendFallback-aware completion id from RAW inputs (not the resolved output,
-    // which `orphan_parity_target` would echo back tautologically). PR-4 ships
-    // only the faithful RECLAIM parity via `sweeper_reclaim_parity_id`.
+    /// EPIC #3078 — the controller's INDEPENDENT decision for the watcher's
+    /// status-panel CREATE/ADOPT site, re-derived from RAW inputs (not the
+    /// already-resolved legacy id, which `orphan_parity_target` would echo back
+    /// tautologically — the codex P2 finding that scoped PR-4 down). Faithful to
+    /// the legacy branch order at `tmux_watcher.rs` ~7213:
+    ///
+    /// 1. a persisted (restart-safe) panel id on this turn's inflight row →
+    ///    [`WatcherCreateDecision::AdoptPersisted`] (adopt, never duplicate);
+    /// 2. else if `watcher_should_create_external_input_status_panel`
+    ///    (v2 on, no panel yet, external-input/panel-eligible turn) →
+    ///    [`WatcherCreateDecision::Create`];
+    /// 3. else [`WatcherCreateDecision::None`].
+    ///
+    /// Pure (no actor round-trip, no ledger read, no IO): the create/adopt
+    /// decision is a function of the raw inputs ALONE, so this stays faithfully
+    /// shadow-only. The legacy `!watcher_external_input_turn_abandoned` guard is a
+    /// separate suppression LAYERED AFTER this decision (it reads turn-tombstone
+    /// files); a faithful create/adopt parity compares the publish DECISION before
+    /// that suppression, so the abandoned guard is intentionally NOT modeled here.
+    /// COMPLETION parity remains deferred to the controller execute-cutover PR:
+    /// it needs the SendFallback-aware terminal id from the legacy completion
+    /// path, which is only known after the bridge/watcher send resolves.
+    pub(in crate::services::discord) fn watcher_create_parity_decision(
+        &self,
+        status_panel_v2_enabled: bool,
+        panel_present: bool,
+        inflight_represents_external_input: bool,
+        persisted_panel_id: Option<MessageId>,
+    ) -> WatcherCreateDecision {
+        if let Some(persisted) = persisted_panel_id {
+            return WatcherCreateDecision::AdoptPersisted(persisted);
+        }
+        if status_panel_v2_enabled && !panel_present && inflight_represents_external_input {
+            return WatcherCreateDecision::Create;
+        }
+        WatcherCreateDecision::None
+    }
 
     /// EPIC #3078 PR-3 — the controller's view of "does the live turn still own
     /// THIS EXACT panel?", the gate the orphan-store drain uses to defer a delete
@@ -1224,6 +1282,53 @@ mod tests {
         let shared2 = super::super::make_shared_data_for_tests_with_storage(None, None);
         let again = ctl.finalize(key, None, shared2).await;
         assert_eq!(again, PanelCommitOutcome::AlreadyTerminal);
+    }
+
+    /// EPIC #3078: the watcher CREATE/ADOPT decision is re-derived from RAW
+    /// inputs and is faithful to the legacy branch order — persisted id wins
+    /// (adopt), else an eligible external-input turn with no panel creates, else
+    /// nothing. Mirrors `watcher_should_create_external_input_status_panel`'s
+    /// truth table plus the persisted-adopt branch above it.
+    #[test]
+    fn watcher_create_decision_is_faithful_to_legacy_branch_order() {
+        let ctl = StatusPanelController::spawn(false);
+        let persisted = MessageId::new(1234);
+
+        // 1. A persisted (restart-safe) id wins regardless of the other inputs:
+        //    adopt it, never create a duplicate.
+        assert_eq!(
+            ctl.watcher_create_parity_decision(true, false, true, Some(persisted)),
+            WatcherCreateDecision::AdoptPersisted(persisted)
+        );
+        // Persisted still wins even when v2 is off / not external-input (the
+        // legacy branch order checks `persisted_panel_msg_id` first).
+        assert_eq!(
+            ctl.watcher_create_parity_decision(false, true, false, Some(persisted)),
+            WatcherCreateDecision::AdoptPersisted(persisted)
+        );
+
+        // 2. No persisted id, v2 on, no live panel, external-input turn → Create.
+        assert_eq!(
+            ctl.watcher_create_parity_decision(true, false, true, None),
+            WatcherCreateDecision::Create
+        );
+
+        // 3a. v2 off → None (the `status_panel_v2_enabled` gate).
+        assert_eq!(
+            ctl.watcher_create_parity_decision(false, false, true, None),
+            WatcherCreateDecision::None
+        );
+        // 3b. A panel already exists → None (no duplicate).
+        assert_eq!(
+            ctl.watcher_create_parity_decision(true, true, true, None),
+            WatcherCreateDecision::None
+        );
+        // 3c. Not an external-input/panel-eligible turn → None (the Discord
+        //     intake path owns the panel for those turns).
+        assert_eq!(
+            ctl.watcher_create_parity_decision(true, false, false, None),
+            WatcherCreateDecision::None
+        );
     }
 
     /// A channel-only (`user_msg_id == 0`) finalize collapses onto the single

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -7444,12 +7444,12 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                                 }
                             }
                         }
+                        // EPIC #3078: faithful create/adopt shadow-parity. `panel_present`
+                        // is `false` here (the enclosing gate requires `status_panel_msg_id
+                        // .is_none()`), so the controller re-derives the SAME decision from
+                        // the raw inputs the legacy branch above read. Legacy still executes.
+                        crate::services::discord::watcher_panel_parity::assert_watcher_create_parity(&shared, channel_id, shared.status_panel_v2_enabled, false, panel_eligible_turn, persisted_panel_msg_id);
                     }
-                    // EPIC #3078: create/adopt parity is DEFERRED to the controller
-                    // execute-cutover PR. A faithful check must replicate
-                    // watcher_should_create_external_input_status_panel from raw
-                    // inputs (comparing the resolved id to itself is tautological).
-                    // PR-4 ships only the faithful RECLAIM shadow-parity below.
 
                     loop {
                         let current_portion =

--- a/src/services/discord/watcher_panel_parity.rs
+++ b/src/services/discord/watcher_panel_parity.rs
@@ -8,15 +8,21 @@
 //! watcher decision, while the legacy path keeps executing the real Discord IO.
 //! The executing cutover lands in a later PR.
 //!
-//! Scope note: CREATE/ADOPT and COMPLETION parity are DEFERRED to that
-//! controller execute-cutover PR. A faithful create/complete check must
-//! replicate `watcher_should_create_external_input_status_panel` and the
-//! SendFallback-aware completion id from RAW inputs (the controller's read-only
-//! `orphan_parity_target` collapse would only echo the already-resolved output
-//! back — a tautological, non-meaningful comparison). The RECLAIM path is
-//! genuinely faithful: it reuses `sweeper_reclaim_parity_id`, the same read-only
-//! collapse codex validated for PR-3, against the panel id the legacy reclaim is
-//! about to delete.
+//! Scope note: CREATE/ADOPT parity is now FAITHFUL — the controller re-derives
+//! the create/adopt DECISION from the SAME RAW inputs the legacy
+//! `watcher_should_create_external_input_status_panel` branch reads
+//! (`WatcherCreateDecision`), so the shadow check validates the controller would
+//! make the same publish/adopt choice, NOT the tautology of echoing the already-
+//! resolved id back (the codex P2 finding that scoped PR-4 to RECLAIM-only). The
+//! create id is not known until the send returns, so the comparison is on the
+//! decision (adopt-which-id / create / none), not on a post-send message id.
+//!
+//! COMPLETION parity is still DEFERRED to the controller execute-cutover PR: a
+//! faithful completion check needs the SendFallback-aware terminal id from the
+//! legacy completion path, which is only known after the bridge/watcher send
+//! resolves. The RECLAIM path is faithful via `sweeper_reclaim_parity_id` (the
+//! read-only collapse codex validated for PR-3) against the panel id the legacy
+//! reclaim is about to delete.
 //!
 //! The parity LOGIC lives here (not inline in the grandfathered, LoC-frozen
 //! `tmux_watcher.rs`): the watcher reclaim site adds only a single `.await` hook
@@ -34,6 +40,7 @@ use serenity::model::id::{ChannelId, MessageId};
 
 use super::SharedData;
 use super::shadow_parity_warn::ParityWarnOnce;
+use super::status_panel_controller::WatcherCreateDecision;
 use super::turn_finalizer::TurnKey;
 use crate::services::provider::ProviderKind;
 use std::sync::Arc;
@@ -124,6 +131,103 @@ pub(in crate::services::discord) async fn assert_watcher_reclaim_parity(
     );
 }
 
+/// EPIC #3078 — the legacy watcher CREATE/ADOPT decision, re-derived from the
+/// SAME RAW inputs the `tmux_watcher.rs` ~7213 branch reads, as the parity
+/// reference. Mirrors that branch order exactly: a persisted (restart-safe) id
+/// adopts, else `watcher_should_create_external_input_status_panel`
+/// (v2 on, no live panel, external-input/panel-eligible turn) creates, else
+/// nothing. Kept here (not calling the private `tmux_watcher` helper) so the
+/// reference and the controller's [`WatcherCreateDecision::watcher_create_parity_decision`]
+/// are two INDEPENDENT derivations of the same truth table — that independence is
+/// what makes the shadow check meaningful rather than tautological.
+fn legacy_watcher_create_decision(
+    status_panel_v2_enabled: bool,
+    panel_present: bool,
+    inflight_represents_external_input: bool,
+    persisted_panel_id: Option<MessageId>,
+) -> WatcherCreateDecision {
+    if let Some(persisted) = persisted_panel_id {
+        return WatcherCreateDecision::AdoptPersisted(persisted);
+    }
+    if status_panel_v2_enabled && !panel_present && inflight_represents_external_input {
+        return WatcherCreateDecision::Create;
+    }
+    WatcherCreateDecision::None
+}
+
+/// A create/adopt decision rendered to a stable `(adopt_id, create, none)` shape
+/// for the bounded one-shot warn (a `WatcherCreateDecision` is not directly a
+/// warn-key, and an `AdoptPersisted` id must distinguish from `Create`/`None`).
+fn decision_shape(decision: WatcherCreateDecision) -> (Option<u64>, bool, bool) {
+    match decision {
+        WatcherCreateDecision::AdoptPersisted(id) => (Some(id.get()), false, false),
+        WatcherCreateDecision::Create => (None, true, false),
+        WatcherCreateDecision::None => (None, false, true),
+    }
+}
+
+/// One-shot bound for the CREATE/ADOPT decision parity warn, keyed by
+/// `(channel, controller_shape, legacy_shape)` so each distinct divergence logs
+/// at most once on a hot watcher loop. Separate from `WATCHER_PARITY_WARNED`
+/// (which keys on message-id parity) because the decision shape carries a
+/// create/none discriminant a bare id cannot.
+type WatcherCreateShape = (u64, (Option<u64>, bool, bool), (Option<u64>, bool, bool));
+static WATCHER_CREATE_WARNED: ParityWarnOnce<WatcherCreateShape> = ParityWarnOnce::new();
+
+/// CREATE/ADOPT site: assert the controller's INDEPENDENT create/adopt decision
+/// (re-derived from raw inputs) equals the legacy watcher decision. v2-off →
+/// inert (the legacy decision is `None` and the controller agrees; no controller
+/// actor read is needed — the decision is pure). Never panics in release
+/// (`debug_assert` + bounded log-once `warn!`); the legacy path keeps executing
+/// the real create/adopt IO.
+pub(in crate::services::discord) fn assert_watcher_create_parity(
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+    status_panel_v2_enabled: bool,
+    panel_present: bool,
+    inflight_represents_external_input: bool,
+    persisted_panel_id: Option<MessageId>,
+) {
+    let controller = shared
+        .status_panel_controller
+        .watcher_create_parity_decision(
+            status_panel_v2_enabled,
+            panel_present,
+            inflight_represents_external_input,
+            persisted_panel_id,
+        );
+    let legacy = legacy_watcher_create_decision(
+        status_panel_v2_enabled,
+        panel_present,
+        inflight_represents_external_input,
+        persisted_panel_id,
+    );
+    if controller == legacy {
+        return;
+    }
+    debug_assert_eq!(
+        controller,
+        legacy,
+        "#3078 watcher status-panel create/adopt parity mismatch (channel {}): controller chose {controller:?}, legacy chose {legacy:?}",
+        channel_id.get()
+    );
+    let shape = (
+        channel_id.get(),
+        decision_shape(controller),
+        decision_shape(legacy),
+    );
+    if !WATCHER_CREATE_WARNED.should_warn(shape) {
+        return;
+    }
+    tracing::warn!(
+        channel = channel_id.get(),
+        site = "create",
+        controller_decision = ?controller,
+        legacy_decision = ?legacy,
+        "#3078 watcher status-panel create/adopt parity mismatch — StatusPanelController would make a different create/adopt decision than the legacy watcher; legacy path executed (no behaviour change), divergence logged once for the later controller-executes cutover"
+    );
+}
+
 #[cfg(test)]
 mod tests {
     //! EPIC #3078 PR-4: confirm the controller's chosen RECLAIM id equals the
@@ -176,5 +280,51 @@ mod tests {
         let shape: WatcherShape = (4999, "reclaim", Some(1), Some(2));
         assert!(super::WATCHER_PARITY_WARNED.should_warn(shape));
         assert!(!super::WATCHER_PARITY_WARNED.should_warn(shape));
+    }
+
+    /// EPIC #3078 CREATE/ADOPT: the controller's independent decision agrees with
+    /// the legacy reference across the full truth table — persisted adopt,
+    /// create (v2 on / no panel / external-input), and each `None` branch —
+    /// driven through the SharedData-backed `assert_watcher_create_parity` so the
+    /// real wiring (no panic, no spurious warn) is exercised.
+    #[tokio::test(flavor = "current_thread")]
+    async fn create_parity_agrees_across_truth_table() {
+        let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
+        let channel = ChannelId::new(5001);
+        let persisted = MessageId::new(6001);
+
+        // Persisted id → adopt (matching on both sides → no warn/panic).
+        assert_watcher_create_parity(&shared, channel, true, false, true, Some(persisted));
+        // Eligible external-input turn, no panel, v2 on → create.
+        assert_watcher_create_parity(&shared, channel, true, false, true, None);
+        // v2 off / panel present / not-external → none (each agrees).
+        assert_watcher_create_parity(&shared, channel, false, false, true, None);
+        assert_watcher_create_parity(&shared, channel, true, true, true, None);
+        assert_watcher_create_parity(&shared, channel, true, false, false, None);
+
+        // The two independent derivations agree element-for-element.
+        for &(v2, present, ext, id) in &[
+            (true, false, true, Some(persisted)),
+            (true, false, true, None),
+            (false, false, true, None),
+            (true, true, true, None),
+            (true, false, false, None),
+        ] {
+            assert_eq!(
+                shared
+                    .status_panel_controller
+                    .watcher_create_parity_decision(v2, present, ext, id),
+                legacy_watcher_create_decision(v2, present, ext, id),
+            );
+        }
+    }
+
+    /// The CREATE/ADOPT decision warn is bounded once per distinct
+    /// `(channel, controller_shape, legacy_shape)` divergence.
+    #[test]
+    fn create_warn_is_bounded_once_per_shape() {
+        let shape: WatcherCreateShape = (5099, (None, true, false), (None, false, true));
+        assert!(super::WATCHER_CREATE_WARNED.should_warn(shape));
+        assert!(!super::WATCHER_CREATE_WARNED.should_warn(shape));
     }
 }


### PR DESCRIPTION
## Roadmap step

EPIC #3078 (single `StatusPanelController` for status-panel lifecycle). Landed so far: PR-0 (#3077, typed inflight writes), PR-1 (dormant controller), PR-2 (recovery shadow-parity), PR-3 (sweeper + orphan-store shadow-parity), PR-4 (#3118, watcher RECLAIM shadow-parity — **scoped down** from create/complete).

**This PR completes the watcher CREATE/ADOPT sub-step PR-4 deferred.** It does NOT do PR-5 (bridge rewrite), PR-6 (finalizer hand-off), or PR-7 (visibility narrowing).

## Why

PR-4 shadow-routed only the watcher RECLAIM decision because the CREATE/ADOPT and COMPLETION checks were tautological (codex P2): the old hook fed the already-resolved legacy panel id into the controller's read-only collapse, which echoed it straight back — validating nothing.

## What the controller introduces

- `WatcherCreateDecision` (`AdoptPersisted` / `Create` / `None`) + `watcher_create_parity_decision` on `StatusPanelController`: a **pure** re-derivation of the legacy `watcher_should_create_external_input_status_panel` branch order from the SAME RAW inputs (no actor round-trip, no ledger read, no IO). The comparison is on the publish/adopt DECISION, not on a post-send id (unknown until the send returns).
- `legacy_watcher_create_decision` + `assert_watcher_create_parity` in `watcher_panel_parity.rs`: an INDEPENDENT second derivation of the same truth table (so the shadow check is two independent derivations — what makes it meaningful) + a bounded one-shot warn keyed on the create/none-discriminant decision shape.

Shadow-only, same posture as PR-2/3/4: legacy keeps executing the real Discord create/adopt IO (zero behaviour change); never `panic!` in release (`debug_assert` + bounded `warn!`); v2-aware.

## Scope boundaries

- Hotfile touch is a **single net-zero hook** in `tmux_watcher.rs` at the deferred-comment seam (production LoC held at the 9598 grandfathered freeze; generated docs unchanged).
- No bridge rewrite, no watcher/finalizer rewrite. The heavy PR-5/PR-6/PR-7 work remains deferred.
- The legacy `!watcher_external_input_turn_abandoned` suppression is layered AFTER this decision and intentionally not modeled (faithful publish-decision parity compares before it). COMPLETION parity stays deferred (needs the SendFallback-aware terminal id only known post-send).

## Tests

- `status_panel_controller`: controller truth-table (persisted adopt / create / each None branch).
- `watcher_panel_parity`: truth-table agreement through the SharedData wrapper + bounded-warn test.
- No regression: turn_bridge (139), tmux_watcher (150), controller (14), parity (5) — all green.

## Gates

- `cargo fmt --check` clean.
- `cargo check --lib` clean; `cargo test --lib turn_bridge` / `tmux_watcher` / new module tests pass.
- `generate_inventory_docs.py` → no generated diff; `check_agent_maintenance_docs.py` → `agent-maintenance freshness check passed`; `bash scripts/ci-script-checks.sh` exit 0 (LoC freeze + baseline.toml unchanged — net-zero hook, no new file).
- `multinode-transition.md` `### Audited touches` note added for #3078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)