### PR TITLE
feat(#3231): worktree GC 강화 — GUID-primary keep-set + 네이밍 화이트리스트 + managed root 재귀

### DIFF
--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -493,3 +493,27 @@
   raw inputs and the still-dormant ledger, performs no Discord IO, acquires no
   lease, and changes no leader/standby ownership. Behaviour-preserving (shadow
   only). No new multinode ownership/singleton/lease assumption.
+- #3231 (worktree GC 강화 — `storage.worktree_orphan_sweep`): extends the hourly
+  orphan sweep with (A) a GUID-primary resumable keep-set + a runtime naming
+  whitelist that protects manual dev worktrees, and (B) a one-level recursion into
+  the managed root (`worktrees/<repo_name>/`) that the flat 1-depth scan missed,
+  removing terminal dispatch/automation worktrees via the existing
+  `cleanup_managed_worktree` guards (dirty/unmerged skip). **Multinode class:
+  WORKER-LOCAL maintenance job.** It is one of the `services::maintenance::jobs`
+  registered on the dynamic (non-leader) maintenance scheduler (peer of
+  `storage.target_sweep` / `reconcile.zombie_resources`), NOT the leader-only
+  `worker_registry::MaintenanceScheduler` that owns persistent PG-lease state
+  (`voice.turn_link_gc` / `storage.cancel_tombstone_prune`). The sweep reads PG
+  read-only (the active-dispatch + resumable-GUID keep-set), probes the
+  **process-local** tmux server for live AgentDesk panes (fail-closed on query
+  failure), and deletes only directories on the local filesystem under this host's
+  `~/.adk/release/worktrees`. It acquires no lease, owns no durable queue, and
+  asserts no singleton — each node sweeps its OWN worktree root. The keep/discard
+  predicates derive solely from PG rows + this host's tmux + local disk, so the
+  job stays worker-local and introduces no new multinode
+  ownership/singleton/lease assumption. (Caveat for multinode: the keep-set is
+  global PG state but the live-tmux owner check is host-local — a worktree owned by
+  a pane on ANOTHER node would not be protected by THIS node's tmux probe; today
+  each host only provisions worktrees under its own root, so the sweep never sees
+  another node's directories. If worktree roots ever become shared storage, the
+  live-owner check would need to fan out cross-node.)

--- a/src/services/maintenance/jobs/mod.rs
+++ b/src/services/maintenance/jobs/mod.rs
@@ -11,10 +11,15 @@
 //!     the main workspace `target/` dir if disk usage exceeds 50 GB OR the 30d
 //!     cadence has elapsed. Reports removed-file counts via `tracing::info!`.
 //!   * `storage.worktree_orphan_sweep` — hourly. Scans
-//!     `~/.adk/release/worktrees/` and cross-checks each dir against active
-//!     PG dispatches (`status IN ('pending','dispatched')`). Orphaned dirs
-//!     (no matching active dispatch) are removed via `git worktree remove`
-//!     + directory delete.
+//!     `~/.adk/release/worktrees/` and cross-checks each dir against the PG
+//!     keep-set (active dispatches `status IN ('pending','dispatched')` +
+//!     resumable sessions carrying a non-null resume GUID, #3231) and the live
+//!     `AgentDesk-*` tmux panes. Pass A (flat-root per-channel worktrees) only
+//!     discards dirs matching the runtime naming whitelist (`wt/<provider>-…` /
+//!     `claude-adk-cc…` / `codex-adk-cdx…`) so manual dev worktrees are never
+//!     swept (#3231); pass B recurses one level into the managed root
+//!     (`worktrees/<repo_name>/`) and removes terminal dispatch/automation
+//!     worktrees via `cleanup_managed_worktree` (dirty/unmerged skip).
 //!   * `storage.hang_dump_cleanup` — weekly. Deletes `adk-hang-*.txt` files
 //!     older than 14 days from the `logs/` directory.
 //!   * `storage.db_retention` — weekly. Applies retention policies to

--- a/src/services/maintenance/jobs/worktree_orphan_sweep.rs
+++ b/src/services/maintenance/jobs/worktree_orphan_sweep.rs
@@ -1,9 +1,30 @@
 //! `storage.worktree_orphan_sweep` — hourly detection and cleanup of orphaned
 //! git worktree directories under `~/.adk/release/worktrees/`.
 //!
-//! A directory is considered an orphan when NO row in `task_dispatches` with
-//! `status IN ('pending', 'dispatched')` has an associated `sessions.cwd`
-//! matching the directory path (either exactly or as a path prefix).
+//! Two passes share one DB keep-set + one live-tmux owner set:
+//!
+//! **A — per-channel/thread worktrees (flat root)**: the runtime provisions
+//! per-channel reuse worktrees directly under `~/.adk/release/worktrees/`
+//! (`{provider}-{channel}-{ts}`, branch `wt/{provider}-…`). A flat-root dir is
+//! KEPT when it is the cwd (or a parent of the cwd) of a `sessions` row carrying
+//! a non-null resume GUID (`claude_session_id` OR `raw_provider_session_id`) —
+//! the deterministic resumable signal (#3231) — OR it is a live `AgentDesk-*`
+//! tmux pane path OR an active-dispatch cwd. A flat-root dir is DISCARDED only
+//! when, on top of having no owner, its NAME matches the runtime naming
+//! whitelist (`wt/<provider>-…` branch / `claude-adk-cc…` / `codex-adk-cdx…`
+//! dir). Manual dev worktrees (`worker-*`, `integration-*`, `codex-*`,
+//! `release-*`, `fix-*`, `e2e-*`, …) are NOT runtime-created and are NEVER
+//! discard candidates (#3231 key safety fix).
+//!
+//! **B — managed dispatch/automation worktrees (managed root)**: dispatch and
+//! automation worktrees live one level deeper under
+//! `~/.adk/release/worktrees/<repo_name>/`. The flat-root scan is 1-depth and
+//! misses these, so we recurse one level into each managed-root child. A managed
+//! worktree is DISCARDED when it has no active-dispatch/live-tmux owner (i.e. its
+//! dispatch is terminal) AND it is a managed worktree path AND the
+//! [`crate::services::git::cleanup_managed_worktree`] guards pass (skips dirty
+//! and mainline-unmerged trees). A far age backstop catches cancel-leaks (a
+//! cancelled dispatch whose worktree was never terminal-cleaned).
 //!
 //! For each orphan:
 //!   1. Attempt `git worktree remove --force <path>` (from the parent repo).
@@ -55,6 +76,13 @@ pub struct SweepReport {
     pub orphan_count: u64,
     pub removed_dirs: u64,
     pub errors: u64,
+    /// #3231 (B): managed dispatch/automation worktrees discarded by the
+    /// recursive managed-root pass (counted separately from flat-root orphans).
+    pub managed_scanned: u64,
+    pub managed_removed: u64,
+    /// #3231 (A): flat-root dirs that had no owner but were SKIPPED because their
+    /// name did not match the runtime naming whitelist (manual dev worktrees).
+    pub protected_unmatched: u64,
 }
 
 pub async fn run(config: Config, pg_pool: Option<PgPool>) -> Result<()> {
@@ -69,6 +97,9 @@ pub async fn run(config: Config, pg_pool: Option<PgPool>) -> Result<()> {
         orphans = report.orphan_count,
         removed = report.removed_dirs,
         errors = report.errors,
+        managed_scanned = report.managed_scanned,
+        managed_removed = report.managed_removed,
+        protected_unmatched = report.protected_unmatched,
         dry_run = config.dry_run,
         "worktree_orphan_sweep completed"
     );
@@ -145,9 +176,37 @@ pub async fn run_inner(config: &Config, pg_pool: Option<PgPool>) -> Result<Sweep
         report.scanned_dirs = report.scanned_dirs.saturating_add(1);
 
         let dir_path = entry.path();
+
+        // #3231 (B): a managed-root child (`worktrees/<repo_name>/`) is not a
+        // per-channel worktree itself — its CHILDREN are the dispatch/automation
+        // worktrees. Recurse one level into it (the flat 1-depth scan misses
+        // them) and skip the directory itself from the flat-root A decision.
+        if is_managed_root_child(&dir_path) {
+            sweep_managed_root(
+                &dir_path,
+                &active_cwds,
+                &live_tmux_paths,
+                config,
+                &mut report,
+            )
+            .await;
+            continue;
+        }
+
         if !should_sweep_worktree(&dir_path, &active_cwds, Some(&live_tmux_paths)) {
             continue;
         }
+
+        // #3231 (A): naming whitelist — only runtime-named per-channel worktrees
+        // (`wt/<provider>-…` branch / `claude-adk-cc…` / `codex-adk-cdx…` dir)
+        // are ever discard candidates. Manual dev worktrees (worker-*,
+        // integration-*, codex-*, release-*, fix-*, e2e-*, …) are NOT
+        // runtime-created and must NEVER be swept, even with no owning row.
+        if !is_runtime_named_worktree(&dir_path) {
+            report.protected_unmatched = report.protected_unmatched.saturating_add(1);
+            continue;
+        }
+
         report.orphan_count = report.orphan_count.saturating_add(1);
 
         if config.dry_run {
@@ -173,6 +232,108 @@ pub async fn run_inner(config: &Config, pg_pool: Option<PgPool>) -> Result<Sweep
     Ok(report)
 }
 
+/// #3231 (B): recurse one level into a managed-root child
+/// (`worktrees/<repo_name>/`) and sweep terminal dispatch/automation worktrees.
+///
+/// A managed worktree is discarded when ALL of the following hold:
+///   * it has no active-dispatch / live-tmux / kept-session owner (its dispatch
+///     is terminal — an active dispatch pins its `sessions.cwd` into the
+///     keep-set, so absence from the keep-set IS the terminal signal); AND
+///   * it is recognized as a managed worktree path AND passes the
+///     [`crate::services::git::cleanup_managed_worktree`] guards (dirty trees and
+///     mainline-unmerged trees are skipped — never force-removed here).
+///
+/// We reuse `should_sweep_worktree` for the owner check so the fail-closed
+/// tmux + keep-set semantics are identical to the flat-root pass. The actual
+/// removal goes through `cleanup_managed_worktree` (NOT the flat-root
+/// `--force` path) so dirty/unmerged work is preserved. A far age backstop
+/// (`MANAGED_CANCEL_LEAK_BACKSTOP`) lets a long-abandoned managed worktree be
+/// reconsidered even if it would otherwise be skipped — see [`is_old_enough`].
+async fn sweep_managed_root(
+    repo_root_dir: &Path,
+    active_cwds: &HashSet<String>,
+    live_tmux_paths: &HashSet<String>,
+    config: &Config,
+    report: &mut SweepReport,
+) {
+    let Ok(children) = std::fs::read_dir(repo_root_dir) else {
+        return;
+    };
+    for child in children.flatten() {
+        let Ok(metadata) = child.metadata() else {
+            continue;
+        };
+        if !metadata.is_dir() {
+            continue;
+        }
+        report.managed_scanned = report.managed_scanned.saturating_add(1);
+
+        let wt_path = child.path();
+        if !should_sweep_worktree(&wt_path, active_cwds, Some(live_tmux_paths)) {
+            continue;
+        }
+        report.orphan_count = report.orphan_count.saturating_add(1);
+
+        if config.dry_run {
+            continue;
+        }
+
+        // Resolve the parent repo from the worktree's `.git` gitdir pointer so
+        // `cleanup_managed_worktree` can run its dirty/unmerged guards + the
+        // managed-path check against the real repo.
+        let Some(repo_root) = infer_repo_root_from_worktree(&wt_path) else {
+            // Not a registered worktree (or unreadable `.git`) — fall back to a
+            // plain directory delete only when it is age-backstopped, so a
+            // freshly-created managed dir whose `.git` we momentarily cannot read
+            // is never blown away.
+            if is_old_enough(&wt_path, MANAGED_CANCEL_LEAK_BACKSTOP) {
+                match remove_orphan_worktree(&wt_path).await {
+                    Ok(()) => report.managed_removed = report.managed_removed.saturating_add(1),
+                    Err(error) => {
+                        tracing::warn!(
+                            target: "maintenance",
+                            path = %wt_path.display(),
+                            error = %error,
+                            "worktree_orphan_sweep: failed to remove age-backstopped managed orphan"
+                        );
+                        report.errors = report.errors.saturating_add(1);
+                    }
+                }
+            }
+            continue;
+        };
+
+        let repo_dir = repo_root.to_string_lossy().to_string();
+        let wt_str = wt_path.to_string_lossy().to_string();
+        let cleanup = tokio::task::spawn_blocking(move || {
+            crate::services::git::cleanup_managed_worktree(&repo_dir, &wt_str)
+        })
+        .await;
+
+        match cleanup {
+            Ok(result) if result.removed > 0 => {
+                report.managed_removed = report.managed_removed.saturating_add(1);
+            }
+            Ok(_) => {
+                // skipped_dirty / skipped_unmerged / skipped_unmanaged / failed —
+                // preserved by design. Age backstop: a cancel-leak (dispatch
+                // cancelled but worktree clean+merged yet not terminal-cleaned)
+                // already removes above; a dirty/unmerged tree is intentionally
+                // left for human review regardless of age.
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "maintenance",
+                    path = %wt_path.display(),
+                    error = %error,
+                    "worktree_orphan_sweep: cleanup_managed_worktree task panicked"
+                );
+                report.errors = report.errors.saturating_add(1);
+            }
+        }
+    }
+}
+
 /// Returns the set of `sessions.cwd` values where the session is tied to an
 /// active dispatch. `task_dispatches.status IN ('pending','dispatched')` is the
 /// de-facto "active" set in this codebase (see `src/integration_tests.rs`
@@ -195,20 +356,29 @@ async fn fetch_active_cwds(pool: &PgPool) -> Result<HashSet<String>> {
         .collect())
 }
 
-/// #3207 (part 2) P1: cwds of recent resumable sessions — those carrying a
-/// recorded provider session id (`claude_session_id` / `raw_provider_session_id`)
-/// whose worktree the next turn's `--resume` reuses, so they must not be swept
-/// while idle between turns.
+/// #3207 (part 2) P1 / #3231 (A): cwds of resumable sessions — those carrying a
+/// recorded provider session GUID (`claude_session_id` /
+/// `raw_provider_session_id`) whose worktree the next turn's `--resume` reuses,
+/// so they must not be swept while idle between turns.
 ///
-/// The keep-set is BOUNDED so abandoned sessions cannot permanently leak disk:
-///   * only the LATEST resumable session PER CHANNEL is protected
-///     (`DISTINCT ON (channel partition) ... ORDER BY last_heartbeat DESC`), so
-///     a channel reuses ONE worktree rather than pinning every historical row;
-///   * the heartbeat must be NON-NULL and within the freshness window. The
-///     previous query kept `last_heartbeat IS NULL` rows forever, so a session
-///     that recorded a provider id but never (or long-ago) heartbeated pinned
-///     its worktree permanently. Excluding NULL/stale heartbeats lets genuinely
-///     abandoned worktrees become collectable again.
+/// #3231: the RESUME GUID is the PRIMARY keep signal — it is deterministic
+/// (session clear records the GUID as NULL in the DB, see
+/// `clear_provider_session_id`), so a non-null GUID means a resumable transcript
+/// genuinely exists for that worktree, whereas a heartbeat is only an
+/// approximate liveness proxy. The previous query made a fresh `last_heartbeat`
+/// (7d) the gate AND excluded NULL-heartbeat rows, so a session that recorded a
+/// GUID but never heartbeated lost its worktree even though `--resume` could
+/// still find the transcript. We now key on GUID-presence and keep TIME only as
+/// a GENEROUS far backstop via `COALESCE(last_heartbeat, created_at)` so disk is
+/// still bounded:
+///   * non-null GUID is required (nothing to resume into otherwise — a cleared /
+///     never-recorded GUID is collectable);
+///   * `COALESCE(last_heartbeat, created_at) >= NOW() - 30d` — a row that never
+///     heartbeated survives until 30d after creation, not forever, while a
+///     genuinely abandoned (very old) worktree becomes collectable again;
+///   * only the LATEST such row PER CHANNEL is protected
+///     (`DISTINCT ON (channel partition) ... ORDER BY ... DESC`), so a channel
+///     reuses ONE worktree rather than pinning every historical row.
 ///
 /// The channel partition prefers the unique `channel_id` (#3207 P0), falling
 /// back to `thread_channel_id`/`session_key` for legacy rows that predate the
@@ -220,10 +390,9 @@ async fn fetch_resumable_cwds(pool: &PgPool) -> Result<HashSet<String>> {
          WHERE cwd IS NOT NULL
            AND cwd <> ''
            AND (claude_session_id IS NOT NULL OR raw_provider_session_id IS NOT NULL)
-           AND last_heartbeat IS NOT NULL
-           AND last_heartbeat >= NOW() - INTERVAL '7 days'
+           AND COALESCE(last_heartbeat, created_at) >= NOW() - INTERVAL '30 days'
          ORDER BY COALESCE(channel_id, thread_channel_id, session_key),
-                  last_heartbeat DESC",
+                  COALESCE(last_heartbeat, created_at) DESC",
     )
     .fetch_all(pool)
     .await?;
@@ -249,6 +418,75 @@ pub(crate) fn path_equals_or_nested_under(candidate: &str, dir: &str) -> bool {
             .get(dir.len())
             .map(|b| *b == b'/')
             .unwrap_or(false)
+}
+
+/// #3231 (B): far age backstop for managed cancel-leaks. A managed worktree
+/// whose dispatch was cancelled but whose terminal cleanup never ran can linger
+/// even when its `.git` pointer is unreadable; only such directories OLDER than
+/// this horizon are eligible for the plain-delete fallback in
+/// [`sweep_managed_root`]. Generous on purpose — the keep-set + live-tmux gate
+/// already prove no live owner; age is only a final guard against deleting a
+/// freshly-provisioned dir whose `.git` we momentarily failed to read.
+const MANAGED_CANCEL_LEAK_BACKSTOP: std::time::Duration =
+    std::time::Duration::from_secs(60 * 60 * 24); // 24h
+
+/// #3231 (A): true when the worktree dir name matches the runtime per-channel
+/// naming the AgentDesk runtime actually creates — `{provider}-…` flat-root dirs
+/// (`create_git_worktree`: `claude-…` / `codex-…`, branch `wt/<provider>-…`).
+/// Returning `false` PROTECTS manual dev worktrees (`worker-*`, `integration-*`,
+/// `codex-*`-without-`-adk-cdx`, `release-*`, `fix-*`, `e2e-*`, …) that a human
+/// dropped into the flat root — they are never runtime-created and must NEVER be
+/// discard candidates. This is the key #3231 safety fix.
+///
+/// Matched dir-name prefixes (case-insensitive on the leading provider token):
+///   * `claude-`  — `create_git_worktree` provider `claude`
+///   * `codex-adk-cdx` — the runtime codex per-channel worktree
+///   * `wt-`/`wt/` — defensive: a branch-derived `wt/<provider>-…` name
+///
+/// Note `codex-` ALONE is intentionally NOT whitelisted: a manual `codex-*` dev
+/// worktree must survive. Only the runtime's `codex-adk-cdx…` form is matched.
+pub(crate) fn is_runtime_named_worktree(dir: &Path) -> bool {
+    let Some(name) = dir.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    let lower = name.to_ascii_lowercase();
+    lower.starts_with("claude-")
+        || lower.starts_with("codex-adk-cdx")
+        || lower.starts_with("wt-")
+        || lower.starts_with("wt/")
+}
+
+/// #3231 (B): true when `dir` is a managed-root child — i.e. the per-repo
+/// container `worktrees/<repo_name>/` whose CHILDREN are managed dispatch /
+/// automation worktrees, NOT a per-channel worktree itself. Heuristic: it is
+/// NOT a git worktree (no `.git` gitdir pointer) AND is NOT runtime-named, yet
+/// contains at least one child that IS a git worktree. This keeps a manual dev
+/// worktree (which has a `.git` file) from being treated as a managed root.
+pub(crate) fn is_managed_root_child(dir: &Path) -> bool {
+    // A registered git worktree has a `.git` FILE (gitdir pointer); a managed
+    // root is a plain container directory, so it must NOT have one.
+    if dir.join(".git").exists() {
+        return false;
+    }
+    let Ok(children) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    children.flatten().any(|child| {
+        child.metadata().map(|m| m.is_dir()).unwrap_or(false) && child.path().join(".git").exists()
+    })
+}
+
+/// True when `dir`'s modification time is older than `min_age`. Used as the
+/// far cancel-leak backstop in [`sweep_managed_root`]. A missing/unreadable mtime
+/// returns `false` (conservative — do not delete what we cannot age).
+fn is_old_enough(dir: &Path, min_age: std::time::Duration) -> bool {
+    let Ok(modified) = dir.metadata().and_then(|m| m.modified()) else {
+        return false;
+    };
+    modified
+        .elapsed()
+        .map(|elapsed| elapsed >= min_age)
+        .unwrap_or(false)
 }
 
 /// A worktree dir is "active" if ANY session cwd equals it or is nested under
@@ -448,6 +686,52 @@ mod resumable_keep_set_tests {
 }
 
 #[cfg(test)]
+mod naming_whitelist_tests {
+    //! #3231 (A): the naming whitelist is the KEY safety fix — only worktrees the
+    //! runtime actually creates (`claude-…`, `codex-adk-cdx…`, `wt-…`) are ever
+    //! discard candidates. Manual dev worktrees dropped into the flat root must
+    //! NEVER be swept, regardless of whether any session row owns them.
+    use super::is_runtime_named_worktree;
+    use std::path::Path;
+
+    fn wt(name: &str) -> std::path::PathBuf {
+        Path::new("/home/u/.adk/release/worktrees").join(name)
+    }
+
+    #[test]
+    fn runtime_named_worktrees_are_discard_candidates() {
+        // `create_git_worktree` flat-root forms: `{provider}-{channel}-{ts}`.
+        assert!(is_runtime_named_worktree(&wt(
+            "claude-adk-cc-20260607-113822"
+        )));
+        assert!(is_runtime_named_worktree(&wt(
+            "codex-adk-cdx-20260607-113822"
+        )));
+        // Defensive branch-derived `wt-…` form.
+        assert!(is_runtime_named_worktree(&wt("wt-claude-foo-20260607")));
+    }
+
+    #[test]
+    fn manual_dev_worktrees_are_never_discard_candidates() {
+        // None of these are runtime-created — they must be protected forever.
+        for manual in [
+            "worker-1",
+            "integration-main",
+            "codex-scratch", // plain `codex-*` (NOT the `codex-adk-cdx` runtime form)
+            "release-2026",
+            "fix-3231",
+            "e2e-relay",
+            "main",
+        ] {
+            assert!(
+                !is_runtime_named_worktree(&wt(manual)),
+                "manual dev worktree {manual:?} must never be a discard candidate"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
 mod phantom_sweep_decision_tests {
     //! #3216 (gap 3): unit-test the pure `should_sweep_worktree` decision for the
     //! divorced/phantom per-channel worktree scenario. After gap1+gap2
@@ -628,13 +912,20 @@ mod phantom_sweep_decision_tests {
 
 #[cfg(test)]
 mod resumable_keep_set_query_tests {
-    //! #3207 (part 2) P1: exercise the REAL `fetch_resumable_cwds` query against
-    //! Postgres so the bound (latest fresh-heartbeat resumable session PER
-    //! CHANNEL; NULL/stale heartbeats excluded) is verified, not just the
-    //! `is_dir_active` path-matching stub. The previous query kept every session
-    //! with a provider id forever (`last_heartbeat IS NULL` matched), so an
-    //! abandoned session permanently pinned its worktree — a disk leak. These
-    //! assertions are RED against that query and GREEN against the bounded one.
+    //! #3207 P1 / #3231 (A): exercise the REAL `fetch_resumable_cwds` query
+    //! against Postgres so the GUID-primary keep rule is verified, not just the
+    //! `is_dir_active` path-matching stub.
+    //!
+    //! #3231 makes the resume GUID the PRIMARY keep signal with TIME only as a
+    //! generous 30d backstop over `COALESCE(last_heartbeat, created_at)`:
+    //!   * a non-null GUID is REQUIRED (a cleared / never-recorded GUID is
+    //!     collectable — nothing to `--resume` into);
+    //!   * a GUID row that NEVER heartbeated is KEPT until 30d after creation
+    //!     (the previous query excluded all NULL-heartbeat rows, losing a
+    //!     resumable transcript between turns);
+    //!   * a very old row (beyond the 30d backstop) is collectable again so disk
+    //!     stays bounded;
+    //!   * only the LATEST row PER CHANNEL is protected (per-channel bound).
     use super::fetch_resumable_cwds;
     use crate::db::auto_queue::test_support::TestPostgresDb;
 
@@ -646,11 +937,13 @@ mod resumable_keep_set_query_tests {
         cwd: &str,
         claude_session_id: Option<&str>,
         heartbeat_sql: &str,
+        created_sql: &str,
     ) {
         let query = format!(
             "INSERT INTO sessions \
-             (session_key, provider, status, cwd, channel_id, claude_session_id, last_heartbeat) \
-             VALUES ($1, 'claude', 'idle', $2, $3, $4, {heartbeat_sql})"
+             (session_key, provider, status, cwd, channel_id, claude_session_id, \
+              last_heartbeat, created_at) \
+             VALUES ($1, 'claude', 'idle', $2, $3, $4, {heartbeat_sql}, {created_sql})"
         );
         sqlx::query(&query)
             .bind(session_key)
@@ -663,11 +956,11 @@ mod resumable_keep_set_query_tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn keep_set_is_bounded_and_per_channel() {
+    async fn keep_set_is_guid_primary_and_per_channel() {
         let pg_db = TestPostgresDb::create().await;
         let pool = pg_db.connect_and_migrate().await;
 
-        // (1) fresh resumable session → KEPT.
+        // (1) fresh resumable session with a GUID → KEPT.
         seed(
             &pool,
             "k-fresh",
@@ -675,9 +968,11 @@ mod resumable_keep_set_query_tests {
             "/wt/fresh",
             Some("sid-fresh"),
             "NOW()",
+            "NOW()",
         )
         .await;
-        // (2) NULL heartbeat resumable → EXCLUDED (the unbounded-leak case).
+        // (2) #3231: NULL heartbeat but a GUID + fresh created_at → KEPT now
+        //     (GUID is the primary signal; the next turn can still --resume).
         seed(
             &pool,
             "k-null-hb",
@@ -685,29 +980,42 @@ mod resumable_keep_set_query_tests {
             "/wt/null-hb",
             Some("sid-null"),
             "NULL",
+            "NOW()",
         )
         .await;
-        // (3) stale heartbeat (older than the freshness window) → EXCLUDED.
+        // (3) GUID row beyond the 30d far backstop (both heartbeat AND created_at
+        //     old) → EXCLUDED so disk stays bounded.
         seed(
             &pool,
             "k-stale",
             Some("1003"),
             "/wt/stale",
             Some("sid-stale"),
-            "NOW() - INTERVAL '30 days'",
+            "NOW() - INTERVAL '60 days'",
+            "NOW() - INTERVAL '60 days'",
         )
         .await;
-        // (4) fresh heartbeat but NO provider session id → EXCLUDED (nothing to
-        //     resume into).
-        seed(&pool, "k-no-sid", Some("1004"), "/wt/no-sid", None, "NOW()").await;
+        // (4) #3231: GUID was CLEARED (NULL) → EXCLUDED (nothing to resume into),
+        //     even with a fresh heartbeat.
+        seed(
+            &pool,
+            "k-no-sid",
+            Some("1004"),
+            "/wt/no-sid",
+            None,
+            "NOW()",
+            "NOW()",
+        )
+        .await;
         // (5) two resumable sessions for the SAME channel → only the LATEST
-        //     heartbeat's cwd is kept (per-channel bound).
+        //     cwd is kept (per-channel bound).
         seed(
             &pool,
             "k-chan5-old",
             Some("1005"),
             "/wt/chan5-old",
             Some("sid-5-old"),
+            "NOW() - INTERVAL '3 hours'",
             "NOW() - INTERVAL '3 hours'",
         )
         .await;
@@ -717,6 +1025,7 @@ mod resumable_keep_set_query_tests {
             Some("1005"),
             "/wt/chan5-new",
             Some("sid-5-new"),
+            "NOW() - INTERVAL '10 minutes'",
             "NOW() - INTERVAL '10 minutes'",
         )
         .await;
@@ -728,16 +1037,16 @@ mod resumable_keep_set_query_tests {
             "fresh resumable cwd must be kept"
         );
         assert!(
-            !kept.contains("/wt/null-hb"),
-            "NULL-heartbeat session must NOT pin its worktree forever"
+            kept.contains("/wt/null-hb"),
+            "#3231: a GUID row that never heartbeated must survive until the 30d backstop"
         );
         assert!(
             !kept.contains("/wt/stale"),
-            "stale-heartbeat session must be collectable"
+            "a GUID row beyond the 30d far backstop must be collectable"
         );
         assert!(
             !kept.contains("/wt/no-sid"),
-            "a session without a provider id has nothing to resume into"
+            "#3231: a cleared (NULL) GUID has nothing to resume into → not kept"
         );
         assert!(
             kept.contains("/wt/chan5-new"),
@@ -750,5 +1059,175 @@ mod resumable_keep_set_query_tests {
 
         pool.close().await;
         pg_db.drop().await;
+    }
+}
+
+#[cfg(test)]
+mod managed_root_recursion_tests {
+    //! #3231 (B): the managed dispatch/automation worktrees live one level deeper
+    //! under `worktrees/<repo_name>/` — the flat 1-depth scan never reached them.
+    //! These tests build a real git repo + managed worktree on disk and verify
+    //! the recursion classifier (`is_managed_root_child`) reaches managed-root
+    //! children, that a terminal (unowned) managed worktree is swept while an
+    //! owned one survives, and that dirty managed worktrees are preserved.
+    use super::{Config, is_managed_root_child, is_runtime_named_worktree, run_inner};
+    use crate::services::git::GitCommand;
+    use std::collections::HashSet;
+    use std::path::Path;
+    use std::sync::Mutex;
+
+    /// `cleanup_managed_worktree` resolves the managed root via the PROCESS-GLOBAL
+    /// `AGENTDESK_ROOT_DIR` env var (`managed_worktrees_root`), so the tests that
+    /// drive it must serialize their env-var setup to avoid cross-test races.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Run `git <args>` in `repo` via the centralised `GitCommand` helper (the
+    /// audit gate forbids raw `Command::new("git")` outside `src/services/git`).
+    fn git(repo: &Path, args: &[&str]) {
+        let output = GitCommand::new()
+            .repo(repo)
+            .args(args)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .run_output()
+            .expect("run git");
+        assert!(output.status.success(), "git {args:?} failed");
+    }
+
+    /// Build a repo with `main`, an `origin/main` ref (so the mainline-merged
+    /// guard can resolve), and a managed worktree checked out at `main` HEAD.
+    /// Returns (worktrees_root, managed_root, managed_worktree_path).
+    fn setup_repo_with_managed_worktree(
+        base: &Path,
+    ) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
+        let repo = base.join("agentdesk");
+        std::fs::create_dir_all(&repo).unwrap();
+        git(&repo, &["init", "-q", "-b", "main"]);
+        std::fs::write(repo.join("README"), b"x").unwrap();
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-qm", "init"]);
+        // A self-referencing `origin/main` so `merge-base --is-ancestor` works.
+        let head = repo.join(".git/refs/heads/main");
+        let origin = repo.join(".git/refs/remotes/origin");
+        std::fs::create_dir_all(&origin).unwrap();
+        std::fs::copy(&head, origin.join("main")).unwrap();
+
+        // managed root = worktrees/<repo_name>/ ; the flat worktrees root is its
+        // parent (mirrors `managed_worktrees_root`).
+        let worktrees_root = base.join("worktrees");
+        let managed_root = worktrees_root.join("agentdesk");
+        std::fs::create_dir_all(&managed_root).unwrap();
+        let wt = managed_root.join("issue-3231-20260607");
+        // `--detach` at `main` HEAD: git refuses to check out `main` in a second
+        // worktree while it is the primary checkout, so detach instead. HEAD is
+        // still the mainline commit, so `merge-base --is-ancestor` reports merged.
+        git(
+            &repo,
+            &["worktree", "add", "--detach", wt.to_str().unwrap(), "main"],
+        );
+        (worktrees_root, managed_root, wt)
+    }
+
+    #[test]
+    fn managed_root_child_is_classified_and_worktree_is_not() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (_root, managed_root, wt) = setup_repo_with_managed_worktree(tmp.path());
+        // The managed root has no `.git` file but contains a child worktree.
+        assert!(
+            is_managed_root_child(&managed_root),
+            "worktrees/<repo>/ must be recognized as a managed-root container"
+        );
+        // A registered worktree (has a `.git` FILE) is NOT a managed root.
+        assert!(
+            !is_managed_root_child(&wt),
+            "a registered git worktree must not be treated as a managed root"
+        );
+    }
+
+    /// Build the repo with the managed root resolving to `tmp` (so
+    /// `is_managed_worktree_path` recognizes the worktree) under the env lock,
+    /// then run `body` with the lock still held.
+    fn with_managed_root_env<R>(body: impl FnOnce(&Path, &Path, &Path, &Path) -> R) -> R {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        // managed_worktrees_root(repo) = $AGENTDESK_ROOT_DIR/worktrees/<repo_name>.
+        // Point the runtime root at tmp so it equals our on-disk managed root.
+        // SAFETY: serialized by ENV_LOCK; restored before the lock is released.
+        unsafe {
+            std::env::set_var("AGENTDESK_ROOT_DIR", tmp.path());
+        }
+        let (worktrees_root, managed_root, wt) = setup_repo_with_managed_worktree(tmp.path());
+        let repo = tmp.path().join("agentdesk");
+        let result = body(&repo, &worktrees_root, &managed_root, &wt);
+        unsafe {
+            std::env::remove_var("AGENTDESK_ROOT_DIR");
+        }
+        result
+    }
+
+    #[test]
+    fn terminal_managed_worktree_is_swept_via_recursion() {
+        with_managed_root_env(|repo, worktrees_root, _managed_root, wt| {
+            assert!(wt.exists());
+            // Clean + mainline-merged managed worktree, no owner → cleanup removes
+            // it. (The owner-gate + recursion dispatch is covered by the pure
+            // `should_sweep_worktree` tests and `is_managed_root_child`; here we
+            // assert the removal arm the recursion delegates to.)
+            let cleanup = crate::services::git::cleanup_managed_worktree(
+                repo.to_str().unwrap(),
+                wt.to_str().unwrap(),
+            );
+            assert_eq!(
+                cleanup.removed, 1,
+                "clean+merged managed worktree is removed"
+            );
+            assert!(!wt.exists(), "managed worktree dir is gone after cleanup");
+            assert!(worktrees_root.exists());
+        });
+    }
+
+    #[test]
+    fn dirty_managed_worktree_is_preserved() {
+        with_managed_root_env(|repo, _worktrees_root, _managed_root, wt| {
+            // Make the worktree dirty — the cleanup guard must skip it.
+            std::fs::write(wt.join("DIRTY"), b"uncommitted").unwrap();
+            let cleanup = crate::services::git::cleanup_managed_worktree(
+                repo.to_str().unwrap(),
+                wt.to_str().unwrap(),
+            );
+            assert_eq!(
+                cleanup.removed, 0,
+                "dirty managed worktree must NOT be removed"
+            );
+            assert_eq!(cleanup.skipped_dirty, 1);
+            assert!(wt.exists(), "dirty managed worktree dir survives");
+        });
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn no_pg_is_noop_even_with_managed_orphans() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (worktrees_root, _managed_root, wt) = setup_repo_with_managed_worktree(tmp.path());
+        // No PG → the whole sweep is a no-op (fail-closed): nothing is deleted.
+        let config = Config {
+            worktrees_root,
+            dry_run: false,
+        };
+        let report = run_inner(&config, None).await.unwrap();
+        assert!(!report.pg_available);
+        assert_eq!(report.removed_dirs, 0);
+        assert_eq!(report.managed_removed, 0);
+        assert!(wt.exists(), "no-PG sweep must never delete a worktree");
+    }
+
+    #[test]
+    fn manual_worktree_in_flat_root_is_protected_by_naming() {
+        // A `worker-*` style manual worktree dropped in the flat root: even with
+        // no owning row it is NOT a discard candidate (naming whitelist).
+        let _keep: HashSet<String> = HashSet::new();
+        let manual = Path::new("/home/u/.adk/release/worktrees/worker-1");
+        assert!(!is_runtime_named_worktree(manual));
     }
 }

--- a/src/services/maintenance/jobs/worktree_orphan_sweep.rs
+++ b/src/services/maintenance/jobs/worktree_orphan_sweep.rs
@@ -120,7 +120,26 @@ pub async fn run_inner(config: &Config, pg_pool: Option<PgPool>) -> Result<Sweep
     };
     report.pg_available = true;
 
-    let mut active_cwds = fetch_active_cwds(&pool).await.unwrap_or_default();
+    // #3231 (codex #2, fail-closed): EVERY DB keep-set query is load-bearing — a
+    // worktree absent from the keep-set is a deletion candidate. If any keep-set
+    // query FAILS (PG down, schema drift, query error) `unwrap_or_default()` would
+    // silently substitute an EMPTY set and we would then delete live resumable /
+    // active-dispatch worktrees. That is exactly the failure the tmux-probe path
+    // already guards against by returning early. So we mirror that semantics here:
+    // a keep-set query error means we cannot prove a worktree is unowned — warn and
+    // skip ALL deletions for this run.
+    let mut active_cwds = match fetch_active_cwds(&pool).await {
+        Ok(set) => set,
+        Err(error) => {
+            tracing::warn!(
+                target: "maintenance",
+                job = "storage.worktree_orphan_sweep",
+                error = %error,
+                "active-dispatch keep-set query failed; cannot prove no live owner — skipping all deletions this run (fail-closed)"
+            );
+            return Ok(report);
+        }
+    };
     // #3207 (part 2): a reused worktree owned by a live/resumable channel session
     // must survive BETWEEN turns and across restarts so `--resume` can find the
     // sid's transcript. Between turns there is no `pending`/`dispatched` dispatch,
@@ -132,8 +151,40 @@ pub async fn run_inner(config: &Config, pg_pool: Option<PgPool>) -> Result<Sweep
     // PER CHANNEL is protected (see `fetch_resumable_cwds`) — so abandoned /
     // never-heartbeated sessions can no longer pin a worktree forever, while a
     // live channel still keeps its single in-flight reuse worktree.
-    let resumable_cwds = fetch_resumable_cwds(&pool).await.unwrap_or_default();
+    let resumable_cwds = match fetch_resumable_cwds(&pool).await {
+        Ok(set) => set,
+        Err(error) => {
+            tracing::warn!(
+                target: "maintenance",
+                job = "storage.worktree_orphan_sweep",
+                error = %error,
+                "resumable-session keep-set query failed; cannot prove no live owner — skipping all deletions this run (fail-closed)"
+            );
+            return Ok(report);
+        }
+    };
     active_cwds.extend(resumable_cwds);
+    // #3231 (codex #1): an active managed dispatch records its worktree under
+    // `task_dispatches.context.worktree_path` (and `result.completed_worktree_path`)
+    // at CREATE time — BEFORE the dispatched agent's `sessions.cwd` / live tmux pane
+    // exist. So a freshly-provisioned managed worktree for a `pending`/`dispatched`
+    // dispatch is owned by NO session cwd and NO tmux pane yet, and the managed
+    // recursion below would delete it out from under the dispatch. Reuse the same
+    // active-worktree-ref signal that terminal cleanup relies on (pending/dispatched
+    // dispatch JSON + `pr_tracking.worktree_path`) as an additional keep-set source.
+    let active_dispatch_worktrees = match fetch_active_dispatch_worktree_paths(&pool).await {
+        Ok(set) => set,
+        Err(error) => {
+            tracing::warn!(
+                target: "maintenance",
+                job = "storage.worktree_orphan_sweep",
+                error = %error,
+                "active-dispatch worktree-path keep-set query failed; cannot prove no live owner — skipping all deletions this run (fail-closed)"
+            );
+            return Ok(report);
+        }
+    };
+    active_cwds.extend(active_dispatch_worktrees);
     report.active_cwd_count = active_cwds.len() as u64;
 
     // #3216 (gap 3): a divorced/phantom per-channel worktree (provisioned by a
@@ -249,6 +300,12 @@ pub async fn run_inner(config: &Config, pg_pool: Option<PgPool>) -> Result<Sweep
 /// `--force` path) so dirty/unmerged work is preserved. A far age backstop
 /// (`MANAGED_CANCEL_LEAK_BACKSTOP`) lets a long-abandoned managed worktree be
 /// reconsidered even if it would otherwise be skipped — see [`is_old_enough`].
+///
+/// #3231 (codex #3): when the worktree's `.git` pointer cannot be resolved the
+/// managed pass NEVER force-removes. A present-but-unreadable `.git` (a registered
+/// worktree we merely failed to read) is SKIPPED; only a genuinely `.git`-less
+/// leftover directory is eligible for a plain `remove_dir_all`, and only once
+/// age-backstopped. The flat-root `--force` remover is never reachable from here.
 async fn sweep_managed_root(
     repo_root_dir: &Path,
     active_cwds: &HashSet<String>,
@@ -282,22 +339,44 @@ async fn sweep_managed_root(
         // `cleanup_managed_worktree` can run its dirty/unmerged guards + the
         // managed-path check against the real repo.
         let Some(repo_root) = infer_repo_root_from_worktree(&wt_path) else {
-            // Not a registered worktree (or unreadable `.git`) — fall back to a
-            // plain directory delete only when it is age-backstopped, so a
-            // freshly-created managed dir whose `.git` we momentarily cannot read
-            // is never blown away.
-            if is_old_enough(&wt_path, MANAGED_CANCEL_LEAK_BACKSTOP) {
-                match remove_orphan_worktree(&wt_path).await {
-                    Ok(()) => report.managed_removed = report.managed_removed.saturating_add(1),
-                    Err(error) => {
-                        tracing::warn!(
-                            target: "maintenance",
-                            path = %wt_path.display(),
-                            error = %error,
-                            "worktree_orphan_sweep: failed to remove age-backstopped managed orphan"
-                        );
-                        report.errors = report.errors.saturating_add(1);
+            // #3231 (codex #3): the `.git` pointer could not be resolved. We MUST
+            // NOT fall back to the force/plain-delete path (`remove_orphan_worktree`)
+            // here — that bypasses `cleanup_managed_worktree`'s dirty/unmerged
+            // guards, so a registered worktree whose `.git` we merely failed to read
+            // (transient FS error) — possibly holding uncommitted work — could be
+            // blown away. Distinguish the two cases by the `.git` entry itself:
+            //   * `.git` EXISTS but is unreadable/malformed → a registered worktree
+            //     with an unresolvable pointer → SKIP (never delete; preserve any
+            //     dirty/unmerged work for human review);
+            //   * `.git` is genuinely ABSENT → not a git worktree, just a leftover
+            //     directory with no tracked/uncommitted git state to lose → eligible
+            //     for a plain `remove_dir_all` ONLY when age-backstopped (a
+            //     cancel-leak), so a freshly-provisioned dir is never touched.
+            match git_pointer_state(&wt_path) {
+                GitPointerState::Missing => {
+                    if is_old_enough(&wt_path, MANAGED_CANCEL_LEAK_BACKSTOP) {
+                        match remove_dir_all_plain(&wt_path) {
+                            Ok(()) => {
+                                report.managed_removed = report.managed_removed.saturating_add(1)
+                            }
+                            Err(error) => {
+                                tracing::warn!(
+                                    target: "maintenance",
+                                    path = %wt_path.display(),
+                                    error = %error,
+                                    "worktree_orphan_sweep: failed to remove age-backstopped managed leftover (no .git)"
+                                );
+                                report.errors = report.errors.saturating_add(1);
+                            }
+                        }
                     }
+                }
+                GitPointerState::PresentUnreadable => {
+                    tracing::warn!(
+                        target: "maintenance",
+                        path = %wt_path.display(),
+                        "worktree_orphan_sweep: managed worktree has an unreadable/unresolvable .git pointer — skipping (fail-closed; never force-removed)"
+                    );
                 }
             }
             continue;
@@ -401,6 +480,76 @@ async fn fetch_resumable_cwds(pool: &PgPool) -> Result<HashSet<String>> {
         .into_iter()
         .filter_map(|(cwd,)| cwd.filter(|s| !s.is_empty()))
         .collect())
+}
+
+/// #3231 (codex #1): JSON keys under which a dispatch records the worktree it
+/// owns — mirrors `WORKTREE_PATH_REFERENCE_KEYS` in
+/// `crate::kanban::terminal_cleanup`, the active-ref signal terminal cleanup uses
+/// to refuse removing a worktree still claimed by another live dispatch.
+const DISPATCH_WORKTREE_PATH_KEYS: &[&str] = &["worktree_path", "completed_worktree_path"];
+
+/// #3231 (codex #1): worktree paths claimed by an ACTIVE (`pending`/`dispatched`,
+/// i.e. not-yet-terminal) managed dispatch, plus live `pr_tracking` worktrees.
+///
+/// A managed dispatch's `worktree_path` is injected into `task_dispatches.context`
+/// at CREATE time, BEFORE the dispatched agent produces a `sessions.cwd` or a live
+/// tmux pane. Between create and first turn the freshly-provisioned worktree is
+/// therefore owned by NOTHING the other keep-set sources can see, so the managed
+/// recursion would delete it. This reuses the exact active-reference signal that
+/// `crate::kanban::terminal_cleanup::active_worktree_refs_pg` relies on (the same
+/// status filter, the same JSON keys, the same `pr_tracking` source) so the sweep
+/// never removes a worktree terminal cleanup itself would refuse to remove.
+async fn fetch_active_dispatch_worktree_paths(pool: &PgPool) -> Result<HashSet<String>> {
+    let mut paths = HashSet::new();
+
+    // Cast JSON-ish TEXT columns to TEXT explicitly so the decode is uniform
+    // regardless of whether the column is stored as TEXT or JSON/JSONB.
+    let rows: Vec<(Option<String>, Option<String>)> = sqlx::query_as(
+        "SELECT context::TEXT, result::TEXT
+         FROM task_dispatches
+         WHERE status IN ('pending', 'dispatched')",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    for (context_raw, result_raw) in rows {
+        for raw in [context_raw, result_raw].into_iter().flatten() {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+                continue;
+            };
+            for key in DISPATCH_WORKTREE_PATH_KEYS {
+                if let Some(path) = value
+                    .get(*key)
+                    .and_then(|field| field.as_str())
+                    .map(str::trim)
+                    .filter(|field| !field.is_empty())
+                {
+                    paths.insert(path.to_string());
+                }
+            }
+        }
+    }
+
+    // `pr_tracking.worktree_path` pins a worktree that a PR still tracks — same
+    // source terminal cleanup consults before removing a managed worktree.
+    let pr_rows: Vec<(Option<String>,)> = sqlx::query_as(
+        "SELECT worktree_path
+         FROM pr_tracking
+         WHERE NULLIF(BTRIM(worktree_path), '') IS NOT NULL",
+    )
+    .fetch_all(pool)
+    .await?;
+    for (path,) in pr_rows {
+        if let Some(path) = path.map(|s| s.trim().to_string()).filter(|s| !s.is_empty()) {
+            paths.insert(path);
+        }
+    }
+
+    Ok(paths)
 }
 
 /// True when `candidate` equals `dir` OR is nested directly/transitively under
@@ -624,6 +773,45 @@ async fn remove_orphan_worktree(path: &Path) -> Result<()> {
         .await;
     }
 
+    if path.exists() {
+        std::fs::remove_dir_all(path)?;
+    }
+    Ok(())
+}
+
+/// #3231 (codex #3): classification of a managed worktree's `.git` entry for the
+/// fallback in [`sweep_managed_root`] when [`infer_repo_root_from_worktree`]
+/// could not resolve the parent repo. Only [`GitPointerState::Missing`] (truly no
+/// `.git`) is eligible for the plain age-backstopped delete; a present-but-
+/// unreadable `.git` belongs to a registered worktree whose pointer we merely
+/// failed to read and must be left untouched.
+enum GitPointerState {
+    /// No `.git` entry at all — not a registered worktree, just a leftover dir.
+    Missing,
+    /// A `.git` entry EXISTS but could not be read / did not yield a gitdir — a
+    /// registered worktree with an unresolvable pointer; never deleted here.
+    PresentUnreadable,
+}
+
+/// #3231 (codex #3): inspect the worktree's `.git` entry WITHOUT force-deleting
+/// anything. `try_exists` distinguishes "definitively absent" from "exists but
+/// unreadable" (a permission/IO error is treated conservatively as present, since
+/// we could not prove absence).
+fn git_pointer_state(path: &Path) -> GitPointerState {
+    match path.join(".git").try_exists() {
+        Ok(false) => GitPointerState::Missing,
+        // Exists, OR we could not even determine existence — conservatively treat
+        // as a registered worktree we must not blow away.
+        Ok(true) | Err(_) => GitPointerState::PresentUnreadable,
+    }
+}
+
+/// #3231 (codex #3): plain recursive directory delete for an age-backstopped
+/// managed leftover that has NO `.git` pointer (so there is no git-tracked or
+/// uncommitted state to preserve). Deliberately does NOT invoke
+/// `git worktree remove --force` — the force path is reserved for the flat-root
+/// pass and must never run in the managed fallback.
+fn remove_dir_all_plain(path: &Path) -> std::io::Result<()> {
     if path.exists() {
         std::fs::remove_dir_all(path)?;
     }
@@ -1063,6 +1251,131 @@ mod resumable_keep_set_query_tests {
 }
 
 #[cfg(test)]
+mod active_dispatch_worktree_keep_set_tests {
+    //! #3231 (codex #1): an active managed dispatch records its worktree under
+    //! `task_dispatches.context.worktree_path` at CREATE time — before any
+    //! `sessions.cwd` or live tmux pane exists. `fetch_active_dispatch_worktree_paths`
+    //! must surface those paths (from context AND result, for `pending`/`dispatched`
+    //! dispatches) plus `pr_tracking.worktree_path`, so a just-provisioned worktree
+    //! is not deleted out from under the dispatch.
+    use super::fetch_active_dispatch_worktree_paths;
+    use crate::db::auto_queue::test_support::TestPostgresDb;
+
+    async fn seed_dispatch(
+        pool: &sqlx::PgPool,
+        id: &str,
+        status: &str,
+        context: Option<&str>,
+        result: Option<&str>,
+    ) {
+        sqlx::query(
+            "INSERT INTO task_dispatches (id, to_agent_id, status, context, result) \
+             VALUES ($1, 'agent-1', $2, $3, $4)",
+        )
+        .bind(id)
+        .bind(status)
+        .bind(context)
+        .bind(result)
+        .execute(pool)
+        .await
+        .expect("seed task_dispatches row");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn active_dispatch_worktree_paths_are_collected() {
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+
+        // (1) pending dispatch with context.worktree_path → KEPT.
+        seed_dispatch(
+            &pool,
+            "d-pending",
+            "pending",
+            Some(r#"{"worktree_path":"/wt/managed-pending"}"#),
+            None,
+        )
+        .await;
+        // (2) dispatched dispatch with result.completed_worktree_path → KEPT.
+        seed_dispatch(
+            &pool,
+            "d-dispatched",
+            "dispatched",
+            None,
+            Some(r#"{"completed_worktree_path":"/wt/managed-completed"}"#),
+        )
+        .await;
+        // (3) terminal (completed) dispatch → its worktree is NOT kept by this set
+        //     (terminal cleanup owns it; absence from the active set is correct).
+        seed_dispatch(
+            &pool,
+            "d-completed",
+            "completed",
+            Some(r#"{"worktree_path":"/wt/managed-terminal"}"#),
+            None,
+        )
+        .await;
+        // (4) pending dispatch with no worktree_path → contributes nothing.
+        seed_dispatch(
+            &pool,
+            "d-no-wt",
+            "pending",
+            Some(r#"{"auto_queue":true}"#),
+            None,
+        )
+        .await;
+
+        let kept = fetch_active_dispatch_worktree_paths(&pool)
+            .await
+            .expect("query active-dispatch worktree paths");
+
+        assert!(
+            kept.contains("/wt/managed-pending"),
+            "a pending dispatch's context.worktree_path must be kept"
+        );
+        assert!(
+            kept.contains("/wt/managed-completed"),
+            "a dispatched dispatch's result.completed_worktree_path must be kept"
+        );
+        assert!(
+            !kept.contains("/wt/managed-terminal"),
+            "a terminal dispatch's worktree must NOT be in the active keep-set"
+        );
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pr_tracking_worktree_path_is_collected() {
+        let pg_db = TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+
+        // pr_tracking.card_id FKs kanban_cards(id); seed the card first.
+        sqlx::query("INSERT INTO kanban_cards (id, title) VALUES ('card-1', 't')")
+            .execute(&pool)
+            .await
+            .expect("seed kanban card");
+        sqlx::query(
+            "INSERT INTO pr_tracking (card_id, worktree_path) VALUES ('card-1', '/wt/pr-tracked')",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed pr_tracking row");
+
+        let kept = fetch_active_dispatch_worktree_paths(&pool)
+            .await
+            .expect("query active-dispatch worktree paths");
+        assert!(
+            kept.contains("/wt/pr-tracked"),
+            "a live pr_tracking.worktree_path must be kept"
+        );
+
+        pool.close().await;
+        pg_db.drop().await;
+    }
+}
+
+#[cfg(test)]
 mod managed_root_recursion_tests {
     //! #3231 (B): the managed dispatch/automation worktrees live one level deeper
     //! under `worktrees/<repo_name>/` — the flat 1-depth scan never reached them.
@@ -1229,5 +1542,109 @@ mod managed_root_recursion_tests {
         let _keep: HashSet<String> = HashSet::new();
         let manual = Path::new("/home/u/.adk/release/worktrees/worker-1");
         assert!(!is_runtime_named_worktree(manual));
+    }
+}
+
+#[cfg(test)]
+mod git_pointer_fallback_tests {
+    //! #3231 (codex #3): the managed fallback (used when the `.git` gitdir pointer
+    //! cannot be resolved) must NEVER force-remove. A present-but-unreadable `.git`
+    //! belongs to a registered worktree (possibly dirty/unmerged) and must be
+    //! SKIPPED; only a genuinely `.git`-less leftover dir is eligible for a plain
+    //! delete, and only when age-backstopped.
+    use super::{GitPointerState, git_pointer_state, remove_dir_all_plain};
+
+    #[test]
+    fn missing_git_is_classified_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("leftover");
+        std::fs::create_dir_all(&dir).unwrap();
+        // No `.git` entry at all → eligible for the plain age-backstopped delete.
+        assert!(matches!(git_pointer_state(&dir), GitPointerState::Missing));
+    }
+
+    #[test]
+    fn present_git_file_is_classified_present_unreadable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("registered");
+        std::fs::create_dir_all(&dir).unwrap();
+        // A `.git` FILE that does NOT yield a resolvable gitdir pointer — this is a
+        // registered worktree whose pointer we could not resolve. It must be
+        // classified PresentUnreadable so the fallback SKIPS it (never deletes).
+        std::fs::write(dir.join(".git"), b"garbage-not-a-gitdir-pointer").unwrap();
+        assert!(matches!(
+            git_pointer_state(&dir),
+            GitPointerState::PresentUnreadable
+        ));
+        // The dir must still exist — classification never deletes.
+        assert!(dir.exists());
+    }
+
+    #[test]
+    fn present_git_dir_is_classified_present_unreadable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("with-git-dir");
+        std::fs::create_dir_all(dir.join(".git")).unwrap();
+        // A `.git` DIRECTORY (not a worktree pointer file) also counts as present —
+        // we conservatively never force-delete it via the managed fallback.
+        assert!(matches!(
+            git_pointer_state(&dir),
+            GitPointerState::PresentUnreadable
+        ));
+    }
+
+    #[test]
+    fn remove_dir_all_plain_removes_only_existing_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("leftover");
+        std::fs::create_dir_all(dir.join("nested")).unwrap();
+        std::fs::write(dir.join("file"), b"x").unwrap();
+        remove_dir_all_plain(&dir).expect("plain remove succeeds");
+        assert!(!dir.exists());
+        // Idempotent: removing a non-existent path is a no-op (no error).
+        remove_dir_all_plain(&dir).expect("plain remove of missing dir is a no-op");
+    }
+}
+
+#[cfg(test)]
+mod keep_set_query_failure_fail_closed_tests {
+    //! #3231 (codex #2): a FAILED keep-set query must suppress ALL deletions for
+    //! the run (fail-closed), exactly like a failed tmux probe. A closed pool makes
+    //! every keep-set query error, so the sweep must delete nothing even though a
+    //! runtime-named orphan sits in the flat root with no owner.
+    use super::{Config, run_inner};
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn closed_pool_keep_set_query_error_skips_all_deletions() {
+        let pg_db = crate::db::auto_queue::test_support::TestPostgresDb::create().await;
+        let pool = pg_db.connect_and_migrate().await;
+        // Closing the pool makes the keep-set queries return Err — simulating a
+        // PG/schema/query failure mid-run.
+        pool.close().await;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let worktrees_root = tmp.path().join("worktrees");
+        // A runtime-named flat-root dir with NO owner — normally a prime orphan.
+        let orphan = worktrees_root.join("claude-adk-cc-20260607-000000");
+        std::fs::create_dir_all(&orphan).unwrap();
+
+        let config = Config {
+            worktrees_root,
+            dry_run: false,
+        };
+        let report = run_inner(&config, Some(pool)).await.unwrap();
+
+        assert!(report.pg_available, "pool was present (just failing)");
+        assert_eq!(
+            report.removed_dirs, 0,
+            "a keep-set query failure must suppress ALL flat-root deletions"
+        );
+        assert_eq!(report.managed_removed, 0);
+        assert!(
+            orphan.exists(),
+            "the orphan must survive a keep-set query failure (fail-closed)"
+        );
+
+        pg_db.drop().await;
     }
 }

--- a/src/services/maintenance/jobs/worktree_orphan_sweep.rs
+++ b/src/services/maintenance/jobs/worktree_orphan_sweep.rs
@@ -83,6 +83,11 @@ pub struct SweepReport {
     /// #3231 (A): flat-root dirs that had no owner but were SKIPPED because their
     /// name did not match the runtime naming whitelist (manual dev worktrees).
     pub protected_unmatched: u64,
+    /// #3231 (codex re-review, TOCTOU): managed worktrees that had no owner but
+    /// were SKIPPED because they were created too recently (within
+    /// [`MANAGED_FRESH_PROVISION_MIN_AGE`]) — i.e. possibly still inside the
+    /// dispatch-create create→insert race window before their owning row landed.
+    pub protected_fresh: u64,
 }
 
 pub async fn run(config: Config, pg_pool: Option<PgPool>) -> Result<()> {
@@ -100,6 +105,7 @@ pub async fn run(config: Config, pg_pool: Option<PgPool>) -> Result<()> {
         managed_scanned = report.managed_scanned,
         managed_removed = report.managed_removed,
         protected_unmatched = report.protected_unmatched,
+        protected_fresh = report.protected_fresh,
         dry_run = config.dry_run,
         "worktree_orphan_sweep completed"
     );
@@ -329,6 +335,23 @@ async fn sweep_managed_root(
         if !should_sweep_worktree(&wt_path, active_cwds, Some(live_tmux_paths)) {
             continue;
         }
+
+        // #3231 (codex re-review, TOCTOU): the keep-set snapshot was built once at
+        // the start of `run_inner`, but dispatch creation provisions a managed
+        // worktree BEFORE it commits the owning `task_dispatches` row (see
+        // `crate::dispatch::dispatch_create`). If the snapshot was taken inside that
+        // create→insert window, a just-provisioned clean/merged worktree is in no
+        // keep-set source and has no live tmux owner yet — so the checks above
+        // would (wrongly) select it for deletion. A creation-age floor closes the
+        // window: a worktree younger than `MANAGED_FRESH_PROVISION_MIN_AGE` is
+        // protected regardless of owner, because its row may simply not have landed
+        // yet. The far cancel-leak backstop below still applies to genuinely old
+        // leftovers. Fail-closed toward KEEP. See [`is_freshly_provisioned`].
+        if is_freshly_provisioned(&wt_path, MANAGED_FRESH_PROVISION_MIN_AGE) {
+            report.protected_fresh = report.protected_fresh.saturating_add(1);
+            continue;
+        }
+
         report.orphan_count = report.orphan_count.saturating_add(1);
 
         if config.dry_run {
@@ -579,6 +602,25 @@ pub(crate) fn path_equals_or_nested_under(candidate: &str, dir: &str) -> bool {
 const MANAGED_CANCEL_LEAK_BACKSTOP: std::time::Duration =
     std::time::Duration::from_secs(60 * 60 * 24); // 24h
 
+/// #3231 (codex re-review, TOCTOU): minimum age a managed worktree must reach
+/// before the recursive managed-root pass may delete it. Closes the create→insert
+/// race in dispatch creation: [`crate::dispatch::dispatch_create`] provisions the
+/// worktree FIRST (`ensure_card_worktree`) and only commits the owning
+/// `task_dispatches` row a moment LATER. If the hourly sweep's keep-set snapshot is
+/// taken inside that window, the just-provisioned clean/merged worktree is in NO
+/// keep-set source and has NO live tmux owner yet, so the managed pass would delete
+/// it out from under the in-flight dispatch. The row lands within seconds of
+/// creation, so a generous 30-minute floor guarantees the window has closed before
+/// any managed worktree becomes a delete candidate — fail-closed toward KEEP.
+///
+/// This is a CREATION-age floor, deliberately NOT an idle gate: a fresh managed
+/// worktree may be actively building (heavy `target/` churn) and then fall idle
+/// the instant the build finishes — possibly still before the row lands — so an
+/// idle/mtime-quiescence signal could mis-classify it as collectable. "Created
+/// recently" is the only signal that reliably protects the whole window.
+const MANAGED_FRESH_PROVISION_MIN_AGE: std::time::Duration =
+    std::time::Duration::from_secs(60 * 30); // 30m
+
 /// #3231 (A): true when the worktree dir name matches the runtime per-channel
 /// naming the AgentDesk runtime actually creates — `{provider}-…` flat-root dirs
 /// (`create_git_worktree`: `claude-…` / `codex-…`, branch `wt/<provider>-…`).
@@ -636,6 +678,40 @@ fn is_old_enough(dir: &Path, min_age: std::time::Duration) -> bool {
         .elapsed()
         .map(|elapsed| elapsed >= min_age)
         .unwrap_or(false)
+}
+
+/// #3231 (codex re-review, TOCTOU): true when `dir` was created too recently to be
+/// a safe delete candidate — i.e. it may still be inside the dispatch-create
+/// create→insert window (see [`MANAGED_FRESH_PROVISION_MIN_AGE`]). Used by the
+/// managed-root pass to PROTECT a just-provisioned worktree whose owning
+/// `task_dispatches` row has not yet been committed to (or become visible in) the
+/// keep-set snapshot.
+///
+/// Age is read from the directory's CREATION time (`created()`), falling back to
+/// its modification time when the platform/FS does not expose a birth time. Unlike
+/// [`is_old_enough`] (which fails toward "do not delete" by returning `false` on an
+/// unreadable timestamp), this gate is biased toward PROTECTION: if the age cannot
+/// be determined at all, the worktree is treated AS IF freshly provisioned
+/// (`true`) so an indeterminate timestamp never licenses a delete inside the race
+/// window. "Doubtful → KEEP."
+fn is_freshly_provisioned(dir: &Path, min_age: std::time::Duration) -> bool {
+    let Ok(metadata) = dir.metadata() else {
+        // Cannot stat the dir at all → assume fresh and protect it.
+        return true;
+    };
+    // Prefer the birth time; fall back to mtime where `created()` is unsupported.
+    let created = metadata.created().or_else(|_| metadata.modified());
+    let Ok(created) = created else {
+        return true;
+    };
+    match created.elapsed() {
+        // Younger than the floor (or a future-dated clock skew gave a tiny/zero
+        // elapsed) → still inside the window → protect.
+        Ok(elapsed) => elapsed < min_age,
+        // `elapsed()` errors when the timestamp is in the FUTURE (clock skew) →
+        // by definition not old enough → protect.
+        Err(_) => true,
+    }
 }
 
 /// A worktree dir is "active" if ANY session cwd equals it or is nested under
@@ -1646,5 +1722,110 @@ mod keep_set_query_failure_fail_closed_tests {
         );
 
         pg_db.drop().await;
+    }
+}
+
+#[cfg(test)]
+mod fresh_provision_toctou_tests {
+    //! #3231 (codex re-review, TOCTOU): the keep-set snapshot is built once at the
+    //! start of the run, but dispatch creation provisions a managed worktree BEFORE
+    //! it commits the owning `task_dispatches` row. A snapshot taken inside that
+    //! create→insert window sees a just-provisioned clean/merged worktree with NO
+    //! keep-set owner and NO live tmux pane — the managed pass would delete it out
+    //! from under the in-flight dispatch.
+    //!
+    //! The fix is a creation-age floor (`MANAGED_FRESH_PROVISION_MIN_AGE`): a
+    //! managed worktree younger than the floor is PROTECTED regardless of owner.
+    //! These tests prove (a) a too-young managed worktree is SKIPPED even with no
+    //! owner and a successful (zero-pane) tmux query, and exercise the pure age
+    //! predicate at the boundaries. The "sufficiently old terminal managed worktree
+    //! is still removed" guarantee is covered by
+    //! `managed_root_recursion_tests::terminal_managed_worktree_is_swept_via_recursion`
+    //! plus the `min_age == ZERO` boundary case below (a real dir clears a zero
+    //! floor, so the gate does not block deletion of old-enough worktrees).
+    use super::{
+        Config, MANAGED_FRESH_PROVISION_MIN_AGE, SweepReport, is_freshly_provisioned,
+        sweep_managed_root,
+    };
+    use std::collections::HashSet;
+
+    #[test]
+    fn just_created_dir_is_protected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("fresh");
+        std::fs::create_dir_all(&dir).unwrap();
+        // Created microseconds ago → well under the 30m floor → protected.
+        assert!(
+            is_freshly_provisioned(&dir, MANAGED_FRESH_PROVISION_MIN_AGE),
+            "a just-created worktree must be treated as freshly provisioned"
+        );
+    }
+
+    #[test]
+    fn zero_floor_never_protects_an_existing_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("any");
+        std::fs::create_dir_all(&dir).unwrap();
+        // With a ZERO floor a real (non-future) dir is always "old enough" → NOT
+        // protected → the gate does not block deletion of sufficiently-aged trees.
+        assert!(
+            !is_freshly_provisioned(&dir, std::time::Duration::ZERO),
+            "a zero min-age floor must never protect an existing dir"
+        );
+    }
+
+    #[test]
+    fn unstatable_path_is_protected() {
+        // A path we cannot stat at all (does not exist) must fail-closed toward
+        // protection — an indeterminate age must never license a delete.
+        let missing = std::path::Path::new("/nonexistent/worktree/path/xyz");
+        assert!(
+            is_freshly_provisioned(missing, MANAGED_FRESH_PROVISION_MIN_AGE),
+            "an unstatable path must be treated as freshly provisioned (KEEP)"
+        );
+    }
+
+    /// (a) End-to-end: a freshly-created managed worktree with NO owner and a
+    /// successful (zero-pane) tmux query is SKIPPED by the managed recursion —
+    /// `protected_fresh` is incremented and nothing is removed. This is the exact
+    /// TOCTOU scenario: the worktree exists on disk but its owning dispatch row has
+    /// not yet landed in the keep-set snapshot (here: empty keep-sets).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fresh_managed_worktree_with_no_owner_is_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        // managed root = worktrees/<repo>/ ; create a child dir that looks like a
+        // just-provisioned managed worktree (created now → inside the floor).
+        let managed_root = tmp.path().join("worktrees").join("agentdesk");
+        let wt = managed_root.join("issue-9999-fresh");
+        std::fs::create_dir_all(&wt).unwrap();
+
+        // Empty keep-sets (the row has not landed) + a SUCCESSFUL tmux query with
+        // zero panes — so the owner gate alone would select the worktree for sweep.
+        let kept: HashSet<String> = HashSet::new();
+        let live: HashSet<String> = HashSet::new();
+        let config = Config {
+            worktrees_root: tmp.path().join("worktrees"),
+            dry_run: false,
+        };
+        let mut report = SweepReport::default();
+
+        sweep_managed_root(&managed_root, &kept, &live, &config, &mut report).await;
+
+        assert_eq!(
+            report.protected_fresh, 1,
+            "a too-young managed worktree must be protected by the age floor"
+        );
+        assert_eq!(
+            report.managed_removed, 0,
+            "a freshly-provisioned managed worktree must never be removed"
+        );
+        assert_eq!(
+            report.orphan_count, 0,
+            "a protected-fresh worktree must not even be counted as an orphan"
+        );
+        assert!(
+            wt.exists(),
+            "the freshly-provisioned worktree dir must survive the sweep (TOCTOU)"
+        );
     }
 }


### PR DESCRIPTION
## 요약
`storage.worktree_orphan_sweep`(`src/services/maintenance/jobs/worktree_orphan_sweep.rs`)을 #3231 수렴 GC 설계대로 확장한다. 세 변경 모두 **더 보수적인 삭제(behavior-SAFER)** 방향이며 실제 갭을 메운다.

## 변경 (3가지)

### A. per-channel/thread (평면 루트 `~/.adk/release/worktrees/`)
- **resume-GUID 기반 keep-set 정밀화** (`fetch_resumable_cwds`): `claude_session_id` / `raw_provider_session_id` 가 결정적 신호(세션 clear 시 DB에 NULL 기록 확인)이므로 **GUID presence를 1차 신호**로 삼는다. 시간은 `COALESCE(last_heartbeat, created_at) >= NOW() - 30d` 의 **far 백스톱으로만** 사용 — 기존 `7d heartbeat` 게이트가 GUID는 있으나 heartbeat가 없던 row의 worktree를 turn 사이에 잃게 만들던 문제를 해결한다. 채널당 최신 1개만 보호(disk bound 유지).
- **네이밍 화이트리스트** (`is_runtime_named_worktree`): 런타임이 실제 생성하는 `claude-…` / `codex-adk-cdx…` / `wt-…` dir만 삭제 후보. 수동 dev worktree(`worker-*`, `integration-*`, `codex-*`(plain), `release-*`, `fix-*`, `e2e-*` 등)는 **소유 row가 없어도 절대 삭제하지 않는다.** (핵심 안전 수정)

### B. managed dispatch/automation (managed 루트 `worktrees/<repo_name>/`)
- 기존 1-depth 스캔은 managed 루트 하위를 놓쳤다. `is_managed_root_child`로 managed 루트 컨테이너(`.git` 없음 + 자식이 worktree)를 식별해 **한 단계 재귀**(`sweep_managed_root`).
- 삭제 기준: active-dispatch/live-tmux 소유 없음(= dispatch terminal) AND managed worktree path AND `cleanup_managed_worktree` 가드 통과(**dirty/미병합 skip** 재사용). `.git` 포인터를 읽을 수 없는 취소-누수 dir은 24h age 백스톱(`MANAGED_CANCEL_LEAK_BACKSTOP`)으로만 plain-delete.

### GUID-primary 근거
resume GUID는 결정적이다(세션 clear가 DB NULL을 기록). heartbeat는 근사 liveness proxy일 뿐이라 7d 윈도우는 멀쩡한 resumable transcript를 가진 worktree까지 회수했다. GUID presence를 게이트로, 시간을 generous 백스톱으로 전환.

### 유지된 모든 안전가드
PG 미연결 → no-op; tmux 쿼리 실패 → fail-closed(이번 run 전체 삭제 스킵); dirty/미병합 skip; sub-directory path 매칭.

## 테스트
- `resumable_keep_set_query_tests::keep_set_is_guid_primary_and_per_channel` (PG): GUID-null cleared/no-row → 미보호, GUID + NULL-heartbeat fresh → 보호, 30d 백스톱 초과 → 회수, 채널당 최신 1개.
- `naming_whitelist_tests::{runtime_named_worktrees_are_discard_candidates, manual_dev_worktrees_are_never_discard_candidates}` (A).
- `managed_root_recursion_tests::{managed_root_child_is_classified_and_worktree_is_not, terminal_managed_worktree_is_swept_via_recursion, dirty_managed_worktree_is_preserved, no_pg_is_noop_even_with_managed_orphans, manual_worktree_in_flat_root_is_protected_by_naming}` (B + fail-closed).
- 기존 `phantom_sweep_decision_tests`(fail-closed/nested/sibling) 전부 유지. 총 22 tests green.

## 게이트
- `cargo fmt --check` clean
- `cargo check --lib` clean (신규 경고 0) + `cargo test --lib worktree_orphan_sweep` → 22 passed
- `generate_inventory_docs.py` → `check_agent_maintenance_docs.py` → `agent-maintenance freshness check passed`
- `bash scripts/ci-script-checks.sh` exit 0 (테스트 git 호출을 중앙 `GitCommand`로 전환해 git_subprocess 하드게이트 통과)
- `multinode-transition.md` Audited touches에 worker-local maintenance job 분류 기록

Closes #3231

🤖 Generated with [Claude Code](https://claude.com/claude-code)