### PR TITLE
refactor(#3037): relocate escalation settings DTOs to config layer (backflow 39→35)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -732,7 +732,7 @@
 - do_not_edit_without_migration_plan (giant-file routes):
   - `src/server/routes/kanban.rs` (2752 lines).
   - `src/server/routes/docs.rs` (5880 lines).
-  - `src/server/routes/escalation.rs` (1492 lines).
+  - `src/server/routes/escalation.rs` (1456 lines).
   - `src/server/routes/meetings.rs` (1708 lines).
   - `src/server/routes/review_verdict/decision_route.rs` (4404 lines).
   - `src/server/routes/{agents,agents_crud,agents_setup,v1,resume,
@@ -783,7 +783,7 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2213 lines).
+  - `src/config.rs` (2272 lines).
   - `src/server/mod.rs` (2239 lines).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1488 lines).

--- a/scripts/audit_maintainability/baselines/service_server_backflow.json
+++ b/scripts/audit_maintainability/baselines/service_server_backflow.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "rule": "service_server_backflow",
   "description": "No-regression baseline for src/services references to crate::server or super::server server-layer modules.",
-  "captured_at": "2026-06-03",
-  "total_count": 43,
+  "captured_at": "2026-06-08",
+  "total_count": 35,
   "files": {
     "src/services/agents/query.rs": {
       "count": 2
@@ -26,19 +26,10 @@
     "src/services/discord/adk_session.rs": {
       "count": 2
     },
-    "src/services/discord/commands/text_commands.rs": {
-      "count": 4
-    },
-    "src/services/discord/idle_detector.rs": {
-      "count": 1
-    },
     "src/services/discord/internal_api.rs": {
       "count": 1
     },
     "src/services/discord/meeting_orchestrator.rs": {
-      "count": 1
-    },
-    "src/services/discord/monitoring_status.rs": {
       "count": 1
     },
     "src/services/discord/recovery_engine.rs": {
@@ -52,9 +43,6 @@
     },
     "src/services/discord/turn_bridge/completion_guard.rs": {
       "count": 5
-    },
-    "src/services/disk_monitor.rs": {
-      "count": 2
     },
     "src/services/dispatched_sessions.rs": {
       "count": 8

--- a/src/config.rs
+++ b/src/config.rs
@@ -1442,6 +1442,65 @@ impl EscalationConfig {
     }
 }
 
+/// Default PM-hours window applied when escalation settings leave it unset.
+pub const DEFAULT_ESCALATION_PM_HOURS: &str = "00:00-08:00";
+/// Default timezone applied when escalation settings leave it unset.
+pub const DEFAULT_ESCALATION_TIMEZONE: &str = "Asia/Seoul";
+
+/// Resolved (non-optional) escalation schedule used by the settings API and
+/// Discord text commands. Distinct from [`EscalationScheduleConfig`], which is
+/// the optional on-disk config representation; this is the materialized
+/// wire/runtime shape with defaults applied.
+///
+/// Lives in the config (domain) layer so service-layer callers can depend on it
+/// without reaching back into the server route module that owns the HTTP
+/// handlers (#3037 service→server backflow).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct EscalationScheduleSettings {
+    pub pm_hours: String,
+    pub timezone: String,
+}
+
+impl Default for EscalationScheduleSettings {
+    fn default() -> Self {
+        Self {
+            pm_hours: DEFAULT_ESCALATION_PM_HOURS.to_string(),
+            timezone: DEFAULT_ESCALATION_TIMEZONE.to_string(),
+        }
+    }
+}
+
+/// Resolved escalation settings (materialized wire/runtime shape with defaults
+/// applied). See [`EscalationScheduleSettings`] for the layering rationale.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct EscalationSettings {
+    pub mode: EscalationMode,
+    pub owner_user_id: Option<u64>,
+    pub pm_channel_id: Option<String>,
+    pub schedule: EscalationScheduleSettings,
+}
+
+impl Default for EscalationSettings {
+    fn default() -> Self {
+        Self {
+            mode: EscalationMode::Pm,
+            owner_user_id: None,
+            pm_channel_id: None,
+            schedule: EscalationScheduleSettings::default(),
+        }
+    }
+}
+
+/// API response body for the escalation settings endpoint: the current
+/// effective settings plus the computed defaults.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct EscalationSettingsResponse {
+    pub current: EscalationSettings,
+    pub defaults: EscalationSettings,
+}
+
 /// Onboarding wizard / agent-factory rules. Externalizes the values that used
 /// to be hardcoded inside the `project-agentfactory` Discord prompt: the
 /// active Discord guild ID, the named category IDs new channels can be

--- a/src/server/routes/escalation.rs
+++ b/src/server/routes/escalation.rs
@@ -1,19 +1,20 @@
 use axum::{Json, extract::State, http::StatusCode};
 use chrono::{DateTime, NaiveTime, Utc};
 use chrono_tz::Tz;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::json;
 use sqlx::Row as SqlxRow;
 
-use crate::config::{Config, EscalationMode};
+use crate::config::{
+    Config, DEFAULT_ESCALATION_PM_HOURS, DEFAULT_ESCALATION_TIMEZONE, EscalationMode,
+    EscalationScheduleSettings, EscalationSettings, EscalationSettingsResponse,
+};
 use crate::db::agents::load_agent_channel_bindings_pg;
 use crate::server::routes::AppState;
 use crate::services::discord::health::active_request_owner_for_channel;
 
 const ESCALATION_SETTINGS_OVERRIDE_KEY: &str = "escalation-settings-override";
 const ESCALATION_THREAD_KEY_PREFIX: &str = "escalation_thread:";
-const DEFAULT_PM_HOURS: &str = "00:00-08:00";
-const DEFAULT_TIMEZONE: &str = "Asia/Seoul";
 const DISCORD_API_BASE: &str = "https://discord.com/api/v10";
 const DISCORD_MESSAGE_CHAR_LIMIT: usize = 2000;
 const ESCALATION_ISSUE_SUMMARY_LINE_LIMIT: usize = 3;
@@ -28,47 +29,10 @@ fn pg_unavailable() -> (StatusCode, Json<serde_json::Value>) {
     )
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(default)]
-pub struct EscalationScheduleSettings {
-    pub pm_hours: String,
-    pub timezone: String,
-}
-
-impl Default for EscalationScheduleSettings {
-    fn default() -> Self {
-        Self {
-            pm_hours: DEFAULT_PM_HOURS.to_string(),
-            timezone: DEFAULT_TIMEZONE.to_string(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(default)]
-pub struct EscalationSettings {
-    pub mode: EscalationMode,
-    pub owner_user_id: Option<u64>,
-    pub pm_channel_id: Option<String>,
-    pub schedule: EscalationScheduleSettings,
-}
-
-impl Default for EscalationSettings {
-    fn default() -> Self {
-        Self {
-            mode: EscalationMode::Pm,
-            owner_user_id: None,
-            pm_channel_id: None,
-            schedule: EscalationScheduleSettings::default(),
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct EscalationSettingsResponse {
-    pub current: EscalationSettings,
-    pub defaults: EscalationSettings,
-}
+// `EscalationScheduleSettings`, `EscalationSettings`, and
+// `EscalationSettingsResponse` now live in `crate::config` so service-layer
+// callers can depend on them without a server-layer backflow (#3037). They are
+// re-exported above via `use crate::config::{...}`.
 
 #[derive(Debug, Deserialize)]
 pub struct EmitEscalationBody {
@@ -136,13 +100,13 @@ fn escalation_defaults(config: &Config) -> EscalationSettings {
                 .schedule
                 .pm_hours
                 .clone()
-                .unwrap_or_else(|| DEFAULT_PM_HOURS.to_string()),
+                .unwrap_or_else(|| DEFAULT_ESCALATION_PM_HOURS.to_string()),
             timezone: config
                 .escalation
                 .schedule
                 .timezone
                 .clone()
-                .unwrap_or_else(|| DEFAULT_TIMEZONE.to_string()),
+                .unwrap_or_else(|| DEFAULT_ESCALATION_TIMEZONE.to_string()),
         },
     }
 }

--- a/src/services/discord/commands/text_commands.rs
+++ b/src/services/discord/commands/text_commands.rs
@@ -81,14 +81,14 @@ fn schedule_text_stop_pending_queue_drain(
 }
 
 async fn fetch_escalation_settings_via_api()
--> Result<crate::server::routes::escalation::EscalationSettingsResponse, String> {
+-> Result<crate::config::EscalationSettingsResponse, String> {
     let body = crate::services::discord::internal_api::get_escalation_settings().await?;
     serde_json::from_value(body).map_err(|err| err.to_string())
 }
 
 async fn save_escalation_settings_via_api(
-    settings: &crate::server::routes::escalation::EscalationSettings,
-) -> Result<crate::server::routes::escalation::EscalationSettingsResponse, String> {
+    settings: &crate::config::EscalationSettings,
+) -> Result<crate::config::EscalationSettingsResponse, String> {
     let body =
         crate::services::discord::internal_api::put_escalation_settings(settings.clone()).await?;
     serde_json::from_value(body).map_err(|err| err.to_string())
@@ -103,9 +103,7 @@ fn parse_discord_user_id(raw: &str) -> Option<u64> {
         .ok()
 }
 
-fn format_escalation_settings_summary(
-    settings: &crate::server::routes::escalation::EscalationSettings,
-) -> String {
+fn format_escalation_settings_summary(settings: &crate::config::EscalationSettings) -> String {
     let mode = match settings.mode {
         crate::config::EscalationMode::Pm => "pm",
         crate::config::EscalationMode::User => "user",

--- a/src/services/discord/internal_api.rs
+++ b/src/services/discord/internal_api.rs
@@ -245,7 +245,7 @@ pub(super) async fn get_escalation_settings() -> Result<Value, String> {
 }
 
 pub(super) async fn put_escalation_settings(
-    settings: routes::escalation::EscalationSettings,
+    settings: crate::config::EscalationSettings,
 ) -> Result<Value, String> {
     request_body(Method::PUT, "/api/settings/escalation", &settings).await
 }


### PR DESCRIPTION
## 클러스터: escalation settings DTOs → config 하향

#3037 service→server backflow의 **비핫파일·self-contained 슬라이스 1개**. 기계적 치환은 소진됐고 남은 건 진짜 cross-layer 의존이라, 가장 자명하고 위험 낮은 클러스터로 **escalation settings DTO relocation**을 골랐다.

### 고른 이유
- `EscalationScheduleSettings` / `EscalationSettings` / `EscalationSettingsResponse`는 순수 serde 데이터 타입(escalation 설정의 materialized wire/runtime shape)으로, 동작 로직이 전혀 없다.
- 외부 참조가 services 2개 파일(`text_commands.rs` 4건, `internal_api.rs`)에 국한 — 표면이 좁고 추적이 명확.
- 자연스러운 도메인 홈인 `config.rs`에 이미 관련 타입(`EscalationConfig`/`EscalationMode`)이 거주. config는 leaf 모듈이라 server·services 양쪽에서 의존해도 **순환참조 없음**.
- 핫파일(turn_bridge/**, tmux_watcher 등) 무관.

### 변경
- `src/server/routes/escalation.rs` → `src/config.rs`로 3개 타입 + `DEFAULT_ESCALATION_PM_HOURS`/`DEFAULT_ESCALATION_TIMEZONE` 상수 이동. escalation.rs는 `use crate::config::{...}`로 재사용.
- `services/discord/commands/text_commands.rs`(4건), `services/discord/internal_api.rs`(escalation 타입 참조)를 `crate::config::Escalation*`로 repoint.
- **behavior 불변** — 순수 이동 + call-site 갱신.

### Backflow 감소
- 라이브 감사(주석 제거 기준) **39 → 35**. `text_commands.rs` 클러스터(4건) 완전 소멸.
- baseline(`service_server_backflow.json`)을 라이브 측정값으로 재생성(단조감소, 가드 충족). 기존 baseline total은 43이었음.

### 게이트 결과
- `cargo fmt --check` clean
- `cargo check --lib` clean (신규 경고 0; 기존 2개는 무관 pre-existing)
- `cargo test --lib escalation` / `config::` 통과
- `python3 scripts/audit_maintainability.py --check` exit 0
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` freshness passed (change-surfaces.md freeze entry를 생성 산출 진실값으로 동기화: escalation.rs 1733→1697, config.rs 2213→2272)
- `bash scripts/ci-script-checks.sh` exit 0

### 비고
- config.rs는 giant-file freeze 대상이라 +59줄로 freeze entry를 갱신했다. 도메인상 올바른 위치(EscalationConfig 옆)로의 이동이라 트레이드오프 수용. multinode 분류 영향 없음(freshness 통과로 확인).
- **#3037은 닫지 않음** — 잔여 35건(인프라/AppState/thread_reuse 계열) 별도 PR.
- **머지하지 말 것** — caller가 codex 게이트 후 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)