### PR TITLE
fix(#3028): correct prod/test splitter (Rust lifetime miscount) + freeze turn_bridge giant

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -547,7 +547,7 @@
     so the relayed window is exactly `[turn_start_offset, EOF)` — no byte skip,
     no prior-turn re-relay (RED→GREEN test: stale-high fallback skips the turn
     under the old scan, explicit anchor relays it whole).
-  - `src/services/discord/idle_recap.rs` (1881 prod lines; idle-recap card
+  - `src/services/discord/idle_recap.rs` (1319 prod lines; idle-recap card
     compose/post/clear surface, registered giant-file (#3036) — bugfix only
     outside an extraction plan. Crossed 1000 prod LoC with #3146 Part 1: the
     shared capture-at-claim + CAS clear helpers, the `channel_has_active_turn`
@@ -631,7 +631,7 @@
     `#[cfg(test)] mod` accounting (previously miscounted as 1341 prod). Its
     giant-file-registry [[entry]] was removed. Split the lease wiring vs the
     delivery helpers before adding behavior).
-  - `src/services/discord/turn_finalizer.rs` (1306 prod lines; single-authority
+  - `src/services/discord/turn_finalizer.rs` (1526 prod lines; single-authority
     turn-finalize state machine — ledger/actor-loop/reconciler. Crossed the
     giant-file threshold when #3041 P1-0 added the dormant `DeliveryLeaseCell`
     finalizer messages/handlers on top of #3143's `FinalizeContext::monitor()` +

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -615,15 +615,22 @@
     stop-token/tmux binding runtime + PID-exit observation helper (#2426),
     split before adding non-bugfix behavior. #3169: added the
     claude-anonymous-teardown SIGINT suppression guard (death #3)).
+  - `src/services/discord/turn_bridge/mod.rs` (8417 prod lines; the BRIDGE
+    spawn/turn-lifecycle surface — `spawn_turn_bridge` and the per-channel
+    turn loop. Registered giant-file (#3016 decompose target — see
+    `giant-file-registry.md`, owner `discord-relay`, deadline 2026-08-31).
+    It surfaced as a giant only after #3028 fixed the prod/test splitter: an
+    unterminated char-literal scan on a Rust lifetime (`&'a self`) inside the
+    first inline `#[cfg(test)] mod` block over-extended the block to EOF, so
+    most of the production code was mislabeled test and the file reported only
+    626 prod LoC. Hotfile — bugfix only outside the #3016/#3028 decompose plan).
   - `src/services/discord/turn_bridge/completion_guard.rs` (1849 lines).
   - `src/services/discord/turn_bridge/tmux_runtime.rs` (1545 lines).
-  - `src/services/discord/turn_bridge/terminal_delivery.rs` (1341 prod lines;
-    registered giant-file (#3036) — bugfix only outside an extraction plan.
-    Crossed 1000 prod LoC with #3041 P1-2: the `BridgeDeliveryLease`
-    acquire/commit_and_advance/heartbeat helper that routes the bridge's terminal
-    delivery through the shared delivery-lease, the watcher-owner-channel
-    resolution, and the skip-epilogue/identity-guarded-save decision seams. Split
-    the lease wiring vs the delivery helpers before adding behavior).
+  - `src/services/discord/turn_bridge/terminal_delivery.rs` (504 prod lines;
+    no longer a giant-file after the #3028 splitter fix corrected its inline
+    `#[cfg(test)] mod` accounting (previously miscounted as 1341 prod). Its
+    giant-file-registry [[entry]] was removed. Split the lease wiring vs the
+    delivery helpers before adding behavior).
   - `src/services/discord/turn_finalizer.rs` (1306 prod lines; single-authority
     turn-finalize state machine — ledger/actor-loop/reconciler. Crossed the
     giant-file threshold when #3041 P1-0 added the dormant `DeliveryLeaseCell`
@@ -725,7 +732,7 @@
 - do_not_edit_without_migration_plan (giant-file routes):
   - `src/server/routes/kanban.rs` (2752 lines).
   - `src/server/routes/docs.rs` (5880 lines).
-  - `src/server/routes/escalation.rs` (1733 lines).
+  - `src/server/routes/escalation.rs` (1492 lines).
   - `src/server/routes/meetings.rs` (1708 lines).
   - `src/server/routes/review_verdict/decision_route.rs` (4404 lines).
   - `src/server/routes/{agents,agents_crud,agents_setup,v1,resume,
@@ -779,7 +786,7 @@
   - `src/config.rs` (2213 lines).
   - `src/server/mod.rs` (2239 lines).
   - `src/receipt.rs` (1842 lines).
-  - `src/github/sync.rs` (1894 lines).
+  - `src/github/sync.rs` (1488 lines).
   - `src/reconcile.rs` (1809 lines; periodic reconcile loop covering stale
     inflights, orphan uploads, dispatched-session drift, and queue-review
     drift — split before adding non-bugfix behavior).
@@ -856,7 +863,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   behavior.
 - `src/services/claude.rs` (3949), `src/services/gemini.rs` (1416),
   `src/services/qwen.rs` (2200), `src/services/codex.rs` (3083),
-  `src/services/opencode.rs` (1881), `src/services/provider.rs` (1738) —
+  `src/services/opencode.rs` (1881), `src/services/provider.rs` (1739) —
   provider adapters.
 - `src/services/codex_tui/rollout_tail.rs` (1738) — Codex TUI rollout tail
   parsing and resume identity surface; split before adding non-bugfix behavior
@@ -895,8 +902,8 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   `restore_owner_channel_for_tmux_session`/`clear_restored_owner_for_tmux_session`
   so a live thread-suffixed TUI session with no live watcher slot can be
   re-registered authoritatively instead of dropped forever),
-  `src/services/discord_config_audit.rs` (1459).
-- `src/services/turn_orchestrator.rs` (3089).
+  `src/services/discord_config_audit.rs` (1318).
+- `src/services/turn_orchestrator.rs` (3090).
 
 Decomposed below the giant-file threshold (no longer frozen; bugfix-scoped but
 normal test growth is allowed): `src/services/analytics.rs`,

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -18,28 +18,36 @@
 
 [giant_file_ratchet]
 "src/services/discord/tmux_watcher.rs" = 9598
+# Frozen at its true production LoC once #3028 fixed the prod/test splitter
+# (lifetime/char-literal brace miscount): the first inline `#[cfg(test)] mod`
+# block was over-extended to EOF, so `spawn_turn_bridge` and ~9000 lines of the
+# turn-lifecycle surface were mislabeled test. This is the actual #3028 guard;
+# decompose lands separately after #3016 settles.
+"src/services/discord/turn_bridge/mod.rs" = 8417
 "src/services/discord/mod.rs" = 5185
 "src/services/discord/tui_prompt_relay.rs" = 5120
 "src/services/discord/voice_barge_in.rs" = 4835
 "src/services/discord/recovery_engine.rs" = 4034
 "src/services/discord/router/message_handler/intake_turn.rs" = 3771
 "src/services/discord/meeting_orchestrator.rs" = 3227
-"src/services/turn_orchestrator.rs" = 3089
-"src/services/discord/router/intake_gate.rs" = 2953
+"src/services/turn_orchestrator.rs" = 3090
+"src/services/discord/router/intake_gate.rs" = 2957
 "src/services/discord/formatting.rs" = 2802
 "src/services/discord/runtime_bootstrap.rs" = 2800
 "src/services/discord/health/recovery.rs" = 2655
 "src/services/discord/inflight.rs" = 2466
 "src/services/discord/health.rs" = 2369
 "src/services/discord/watchers/lifecycle.rs" = 2333
-"src/services/discord/idle_recap.rs" = 2303
+"src/services/discord/idle_recap.rs" = 1319
 "src/services/discord/tmux.rs" = 2241
 "src/services/discord/turn_bridge/completion_guard.rs" = 1849
 "src/services/discord/session_runtime.rs" = 1781
 "src/services/discord/session_relay_sink.rs" = 1730
 "src/services/discord/turn_bridge/tmux_runtime.rs" = 1545
 "src/services/discord/commands/text_commands.rs" = 1493
-"src/services/discord/turn_bridge/terminal_delivery.rs" = 1341
+# terminal_delivery.rs dropped to 504 prod LoC after the #3028 splitter fix
+# (its inline test mod was previously miscounted as production), so it is no
+# longer a giant and its ratchet/registry entries were removed.
 "src/services/discord/turn_finalizer.rs" = 1526
 "src/services/discord/router/message_handler/headless_turn.rs" = 1316
 "src/services/discord/commands/config.rs" = 1054

--- a/scripts/generate_inventory_docs.py
+++ b/scripts/generate_inventory_docs.py
@@ -284,13 +284,51 @@ def split_raw_string_start(text: str, index: int) -> tuple[int, int] | None:
     return None
 
 
+def char_literal_length(text: str, index: int) -> int | None:
+    """Return the length of a Rust char literal starting at ``index``.
+
+    ``text[index]`` is assumed to be ``'``. Returns the number of characters
+    that make up a genuine char literal (e.g. ``'a'`` -> 3, ``'\\n'`` -> 4,
+    ``'\\u{1F600}'`` -> the full escape) or ``None`` when the ``'`` actually
+    begins a lifetime (``'a``, ``'static``, ``'_``) rather than a char literal.
+
+    Distinguishing the two matters because a lifetime is *not* terminated by a
+    closing quote; treating it as a char literal makes the scanner swallow
+    everything up to the next stray ``'`` and corrupts brace balancing (#3028).
+    """
+
+    end = len(text)
+    if index >= end or text[index] != "'":
+        return None
+    body = index + 1
+    if body >= end:
+        return None
+    if text[body] == "\\":
+        # Escaped char literal: scan to the closing quote, honouring escapes.
+        cursor = body + 1
+        while cursor < end:
+            if text[cursor] == "\\":
+                cursor += 2
+                continue
+            if text[cursor] == "'":
+                return cursor - index + 1
+            if text[cursor] == "\n":
+                return None
+            cursor += 1
+        return None
+    # Non-escaped: a char literal holds exactly one char then a closing quote.
+    if body + 1 < end and text[body + 1] == "'":
+        return 3
+    # Otherwise this is a lifetime (``'a``, ``'static`` ...), not a char.
+    return None
+
+
 def scan_balanced(text: str, open_index: int, open_char: str = "(", close_char: str = ")") -> tuple[str, int]:
     if text[open_index] != open_char:
         raise ParseError(f"expected {open_char!r} at offset {open_index}")
     depth = 0
     index = open_index
     in_string = False
-    in_char = False
     escape = False
     raw_hashes: int | None = None
     line_comment = False
@@ -339,25 +377,27 @@ def scan_balanced(text: str, open_index: int, open_char: str = "(", close_char: 
             index += 1
             continue
 
-        if in_char:
-            if escape:
-                escape = False
-                index += 1
-                continue
-            if ch == "\\":
-                escape = True
-                index += 1
-                continue
-            if ch == "'":
-                in_char = False
-            index += 1
-            continue
-
         raw_start = split_raw_string_start(text, index)
         if raw_start is not None:
             index, raw_hashes = raw_start
             in_string = True
             continue
+        # Byte-string / raw-byte-string / byte-char literals: b"..", br#".."#, b'x'.
+        if ch == "b" and index + 1 < len(text):
+            byte_raw = split_raw_string_start(text, index + 1)
+            if byte_raw is not None:
+                index, raw_hashes = byte_raw
+                in_string = True
+                continue
+            if text[index + 1] == '"':
+                in_string = True
+                index += 2
+                continue
+            if text[index + 1] == "'":
+                byte_len = char_literal_length(text, index + 1)
+                if byte_len is not None:
+                    index += 1 + byte_len
+                    continue
         if text.startswith("//", index):
             line_comment = True
             index += 2
@@ -371,7 +411,11 @@ def scan_balanced(text: str, open_index: int, open_char: str = "(", close_char: 
             index += 1
             continue
         if ch == "'":
-            in_char = True
+            char_len = char_literal_length(text, index)
+            if char_len is not None:
+                index += char_len
+                continue
+            # Lifetime (``'a``, ``'static`` ...): skip only the quote.
             index += 1
             continue
         if ch == open_char:
@@ -392,7 +436,6 @@ def split_top_level(text: str, delimiter: str = ",", maxsplit: int = 1) -> list[
     depth_bracket = 0
     index = 0
     in_string = False
-    in_char = False
     escape = False
     raw_hashes: int | None = None
     line_comment = False
@@ -442,25 +485,27 @@ def split_top_level(text: str, delimiter: str = ",", maxsplit: int = 1) -> list[
             index += 1
             continue
 
-        if in_char:
-            if escape:
-                escape = False
-                index += 1
-                continue
-            if ch == "\\":
-                escape = True
-                index += 1
-                continue
-            if ch == "'":
-                in_char = False
-            index += 1
-            continue
-
         raw_start = split_raw_string_start(text, index)
         if raw_start is not None:
             index, raw_hashes = raw_start
             in_string = True
             continue
+        # Byte-string / raw-byte-string / byte-char literals: b"..", br#".."#, b'x'.
+        if ch == "b" and index + 1 < len(text):
+            byte_raw = split_raw_string_start(text, index + 1)
+            if byte_raw is not None:
+                index, raw_hashes = byte_raw
+                in_string = True
+                continue
+            if text[index + 1] == '"':
+                in_string = True
+                index += 2
+                continue
+            if text[index + 1] == "'":
+                byte_len = char_literal_length(text, index + 1)
+                if byte_len is not None:
+                    index += 1 + byte_len
+                    continue
         if text.startswith("//", index):
             line_comment = True
             index += 2
@@ -474,7 +519,11 @@ def split_top_level(text: str, delimiter: str = ",", maxsplit: int = 1) -> list[
             index += 1
             continue
         if ch == "'":
-            in_char = True
+            char_len = char_literal_length(text, index)
+            if char_len is not None:
+                index += char_len
+                continue
+            # Lifetime (``'a``, ``'static`` ...): skip only the quote.
             index += 1
             continue
         if ch == "(":

--- a/scripts/generate_inventory_docs.py
+++ b/scripts/generate_inventory_docs.py
@@ -304,17 +304,36 @@ def char_literal_length(text: str, index: int) -> int | None:
     if body >= end:
         return None
     if text[body] == "\\":
-        # Escaped char literal: scan to the closing quote, honouring escapes.
-        cursor = body + 1
-        while cursor < end:
-            if text[cursor] == "\\":
-                cursor += 2
-                continue
-            if text[cursor] == "'":
-                return cursor - index + 1
-            if text[cursor] == "\n":
-                return None
+        # Escaped char literal (``'\n'``, ``'\\'``, ``'\''``, ``'\x41'``,
+        # ``'\u{1F600}'`` ...). First fully consume the escape sequence that
+        # follows the backslash, *then* require the closing quote. Consuming
+        # the escape is what makes ``'\''`` (escaped quote) and ``'\\'``
+        # (escaped backslash) parse correctly: the first char after ``\`` is
+        # part of the escape and must never be mistaken for the terminator.
+        cursor = body + 1  # first char of the escape sequence
+        if cursor >= end:
+            return None
+        esc = text[cursor]
+        if esc == "\n":
+            return None
+        if esc == "x":
+            # ``\xNN`` -- two hex digits.
+            cursor += 1 + 2
+        elif esc == "u":
+            # ``\u{...}`` -- braced hex escape.
             cursor += 1
+            if cursor >= end or text[cursor] != "{":
+                return None
+            close = text.find("}", cursor)
+            if close == -1:
+                return None
+            cursor = close + 1
+        else:
+            # Simple single-char escape: ``\n \t \r \\ \' \" \0`` etc.
+            cursor += 1
+        # The closing quote must immediately follow the escape sequence.
+        if cursor < end and text[cursor] == "'":
+            return cursor - index + 1
         return None
     # Non-escaped: a char literal holds exactly one char then a closing quote.
     if body + 1 < end and text[body + 1] == "'":

--- a/scripts/giant_file_registry.toml
+++ b/scripts/giant_file_registry.toml
@@ -213,7 +213,9 @@ grandfathered = [
   "src/services/qwen.rs",
   "src/services/routines/agent_executor.rs",
   "src/services/routines/discord_log.rs",
-  "src/services/routines/migrated.rs",
+  # migrated.rs dropped to 883 prod LoC after the #3028 splitter fix (its inline
+  # test mod was previously miscounted as production); no longer a prod-giant, so
+  # it is removed from `grandfathered` (kept in the frozen baseline above).
   "src/services/routines/store.rs",
   "src/services/settings.rs",
   "src/services/tui_prompt_dedupe.rs",
@@ -286,16 +288,21 @@ owner = "discord-recap"
 deadline = "2026-08-31"
 decompose_issue = "#3036"
 
+# NOTE: src/services/discord/turn_bridge/terminal_delivery.rs previously had an
+# [[entry]] here; the #3028 splitter fix dropped its production LoC to 504 (its
+# inline test mod was being miscounted as production), so it is no longer a
+# prod-giant and its entry was removed to avoid a ghost registration.
+
 [[entry]]
-# Crossed the 1000-prod-LoC threshold when #3041 P1-2 added the
-# `BridgeDeliveryLease` acquire/heartbeat/commit-advance/release guard that
-# routes the bridge's terminal delivery through the shared per-channel
-# delivery-lease (watcher<->bridge serialization; B6 "no advance outside a lease
-# commit"). The bridge terminal-delivery helpers (chunked/replace senders,
-# replace-outcome commit classification, the lease guard) are cohesive but
-# sizable; decompose the lease guard vs the chunk/replace senders into submodules
-# under #3036.
-file = "src/services/discord/turn_bridge/terminal_delivery.rs"
+# Surfaced as an 8417-prod-LoC giant only after #3028 fixed the prod/test
+# splitter: the first inline `#[cfg(test)] mod` block (an unterminated char
+# literal from a Rust lifetime `&'a self`) over-extended to EOF, so
+# `spawn_turn_bridge` and ~9000 lines of the turn-lifecycle surface were
+# mislabeled as test (the file reported only 626 prod). This entry is the
+# accounting correction; the production LoC is also frozen in
+# scripts/audit_maintainability_giant_baseline.toml (#3028 ratchet). Decompose
+# the turn-bridge spawn/lifecycle surface once #3016 settles.
+file = "src/services/discord/turn_bridge/mod.rs"
 owner = "discord-relay"
 deadline = "2026-08-31"
-decompose_issue = "#3036"
+decompose_issue = "#3016"

--- a/tests/test_inventory_giant_split.py
+++ b/tests/test_inventory_giant_split.py
@@ -142,6 +142,165 @@ class ProdTestSplitTest(unittest.TestCase):
         self.assertGreaterEqual(test, 1)
 
 
+class BraceScannerTokenTest(unittest.TestCase):
+    """Regression coverage for #3028.
+
+    The brace scanner that bounds each ``#[cfg(test)] mod`` block must skip
+    Rust tokens that contain stray ``{``/``}`` or quotes so the test block does
+    not over-extend into the production code that follows it. Each case puts the
+    problematic token *inside* an early test mod and then asserts production
+    code after the block is still counted as production (i.e. the test block
+    closed at its real brace).
+    """
+
+    def _split(self, body: str) -> tuple[int, int]:
+        return GEN.split_prod_test_lines(_src(body))
+
+    def test_lifetime_not_treated_as_char_literal(self) -> None:
+        # `&'a self` and `impl<'a>` must not open a char literal that swallows
+        # the closing brace (the original #3028 break inside turn_bridge/mod.rs).
+        body = """
+        #[cfg(test)]
+        mod tests {
+            struct W;
+            impl<'a> Trait<'a> for W {
+                fn make(&'a self) -> u32 {
+                    0
+                }
+            }
+        }
+
+        pub fn production_after() -> u32 {
+            1
+        }
+        """
+        prod, test = self._split(body)
+        self.assertEqual(test, 9)  # cfg(test) line through the mod's closing }
+        self.assertEqual(prod, GEN.line_count(_src(body)) - 9)
+
+    def _assert_block_does_not_overrun(self, body: str, block_lines: int) -> None:
+        # The cfg(test) mod occupies exactly ``block_lines`` lines; the blank
+        # line and ``production_after`` below it must stay production. If the
+        # brace scanner over-ran, ``test`` would exceed ``block_lines``.
+        text = _src(body)
+        prod, test = self._split(body)
+        self.assertEqual(test, block_lines)
+        self.assertEqual(prod, GEN.line_count(text) - block_lines)
+
+    def test_static_lifetime_not_treated_as_char(self) -> None:
+        body = """
+        #[cfg(test)]
+        mod tests {
+            const S: &'static str = "x";
+            fn t() {}
+        }
+
+        pub fn production_after() {}
+        """
+        self._assert_block_does_not_overrun(body, 5)
+
+    def test_char_literal_brace_ignored(self) -> None:
+        # `'{'` / `'}'` char literals must not change brace depth.
+        body = """
+        #[cfg(test)]
+        mod tests {
+            fn t() {
+                let open = '{';
+                let close = '}';
+                assert_ne!(open, close);
+            }
+        }
+
+        pub fn production_after() {}
+        """
+        self._assert_block_does_not_overrun(body, 8)
+
+    def test_escaped_char_literal_quote_ignored(self) -> None:
+        # `'\''` (escaped single quote) must close correctly.
+        body = """
+        #[cfg(test)]
+        mod tests {
+            fn t() {
+                let q = '\\'';
+                let nl = '\\n';
+                let _ = (q, nl);
+            }
+        }
+
+        pub fn production_after() {}
+        """
+        self._assert_block_does_not_overrun(body, 8)
+
+    def test_line_comment_brace_ignored(self) -> None:
+        body = """
+        #[cfg(test)]
+        mod tests {
+            fn t() {
+                // a stray } in a comment must not close the block {
+            }
+        }
+
+        pub fn production_after() {}
+        """
+        self._assert_block_does_not_overrun(body, 6)
+
+    def test_raw_string_brace_ignored(self) -> None:
+        body = """
+        #[cfg(test)]
+        mod tests {
+            fn t() {
+                let sql = r#"SELECT json_object('k', '}}}') WHERE x = '{'"#;
+                let _ = sql;
+            }
+        }
+
+        pub fn production_after() {}
+        """
+        self._assert_block_does_not_overrun(body, 7)
+
+    def test_byte_literals_ignored(self) -> None:
+        body = """
+        #[cfg(test)]
+        mod tests {
+            fn t() {
+                let b = b'}';
+                let s = b"unbalanced { brace";
+                let _ = (b, s);
+            }
+        }
+
+        pub fn production_after() {}
+        """
+        self._assert_block_does_not_overrun(body, 8)
+
+    def test_interleaved_test_and_production_blocks(self) -> None:
+        # A test mod with a lifetime, followed by production, followed by a
+        # second test mod: the first block must not absorb the production code
+        # nor the second test block.
+        body = """
+        #[cfg(test)]
+        mod first {
+            fn helper<'a>(x: &'a str) -> &'a str { x }
+        }
+
+        pub fn middle_production() -> u32 { 42 }
+
+        #[cfg(test)]
+        mod second {
+            #[test]
+            fn t() { assert_eq!(super::middle_production(), 42); }
+        }
+        """
+        text = _src(body)
+        prod, test = self._split(body)
+        # First block = 4 lines (cfg..closing }), second block = 5 lines: 9
+        # test lines total. middle_production and the surrounding blanks stay
+        # production (the first block must close at its real brace).
+        self.assertEqual(test, 9)
+        self.assertEqual(prod, GEN.line_count(text) - 9)
+        self.assertGreaterEqual(prod, 1)
+
+
 class TestOnlySubtreeTest(unittest.TestCase):
     def _with_src(self, files: dict[str, str]):
         from contextlib import contextmanager

--- a/tests/test_inventory_giant_split.py
+++ b/tests/test_inventory_giant_split.py
@@ -142,6 +142,67 @@ class ProdTestSplitTest(unittest.TestCase):
         self.assertGreaterEqual(test, 1)
 
 
+class CharLiteralLengthTest(unittest.TestCase):
+    """Regression coverage for #3028 escape handling (PR #3234 review).
+
+    ``char_literal_length`` must recognise *every* Rust char-literal escape
+    form and return the full literal length, while still returning ``None``
+    for lifetimes. The earlier implementation failed two escapes:
+      * ``'\\''`` (escaped single quote) was reported as length 3, because the
+        first char after ``\\`` was mistaken for the closing quote;
+      * ``'\\\\'`` (escaped backslash) returned ``None``, because the escape
+        consumed two chars and overran the closing quote.
+    Both must now parse as length 4.
+    """
+
+    def test_simple_escapes(self) -> None:
+        for literal in ("'\\n'", "'\\t'", "'\\r'", "'\\0'", "'\\\"'"):
+            self.assertEqual(
+                GEN.char_literal_length(literal, 0), 4, repr(literal)
+            )
+
+    def test_escaped_single_quote(self) -> None:
+        # '\'' -- the bug: previously returned 3.
+        self.assertEqual(GEN.char_literal_length("'\\''", 0), 4)
+
+    def test_escaped_backslash(self) -> None:
+        # '\\' -- the bug: previously returned None.
+        self.assertEqual(GEN.char_literal_length("'\\\\'", 0), 4)
+
+    def test_hex_escape(self) -> None:
+        # '\x41' -> 6 chars.
+        self.assertEqual(GEN.char_literal_length("'\\x41'", 0), 6)
+
+    def test_unicode_escape(self) -> None:
+        # '\u{1F600}' -> 11 chars.
+        self.assertEqual(GEN.char_literal_length("'\\u{1F600}'", 0), 11)
+
+    def test_plain_char(self) -> None:
+        self.assertEqual(GEN.char_literal_length("'a'", 0), 3)
+
+    def test_lifetimes_are_not_chars(self) -> None:
+        # The original #3234 fix: lifetimes must not be parsed as char literals.
+        for lifetime in ("'a", "'static", "'_", "'a,", "'a>"):
+            self.assertIsNone(
+                GEN.char_literal_length(lifetime, 0), repr(lifetime)
+            )
+
+    def test_escape_fix_does_not_break_lifetime_detection(self) -> None:
+        # Escapes and lifetimes interleaved in one snippet: the char literals
+        # must measure correctly and the lifetimes must still read as None.
+        text = "let q = '\\''; fn f<'a>(x: &'a u8) { let b = '\\\\'; }"
+        # Locate each interesting quote and assert the classification.
+        q1 = text.index("'\\''")
+        self.assertEqual(GEN.char_literal_length(text, q1), 4)  # '\''
+        b1 = text.index("'\\\\'")
+        self.assertEqual(GEN.char_literal_length(text, b1), 4)  # '\\'
+        # The lifetimes <'a> and &'a must read as None.
+        lt1 = text.index("<'a>") + 1
+        self.assertIsNone(GEN.char_literal_length(text, lt1))
+        lt2 = text.index("&'a") + 1
+        self.assertIsNone(GEN.char_literal_length(text, lt2))
+
+
 class BraceScannerTokenTest(unittest.TestCase):
     """Regression coverage for #3028.
 
@@ -230,6 +291,29 @@ class BraceScannerTokenTest(unittest.TestCase):
         pub fn production_after() {}
         """
         self._assert_block_does_not_overrun(body, 8)
+
+    def test_all_escape_forms_and_lifetimes_mixed(self) -> None:
+        # Every escape form (escaped quote, escaped backslash, hex, unicode,
+        # newline) interleaved with lifetimes inside one test mod. If any
+        # escape were mis-measured the brace scanner would over-run into
+        # ``production_after`` and ``test`` would exceed the block length.
+        body = """
+        #[cfg(test)]
+        mod tests {
+            fn t<'a>(x: &'a str) -> &'a str {
+                let q = '\\'';
+                let bs = '\\\\';
+                let hx = '\\x41';
+                let em = '\\u{1F600}';
+                let nl = '\\n';
+                let _ = (q, bs, hx, em, nl, x);
+                x
+            }
+        }
+
+        pub fn production_after() {}
+        """
+        self._assert_block_does_not_overrun(body, 12)
 
     def test_line_comment_brace_ignored(self) -> None:
         body = """


### PR DESCRIPTION
## Bug mechanism

The maintainability prod/test classifier (`scan_balanced` / `split_top_level` in `scripts/generate_inventory_docs.py`) treated a **Rust lifetime** (`'a`, `'static`, `'_`) as the start of a **char literal**.

Inside the first inline `#[cfg(test)] mod` block of `src/services/discord/turn_bridge/mod.rs`, the `&'a self` in `impl<'a> MakeWriter<'a> for CapturingWriter` (line ~1183) opened a phantom char literal. The scanner then scanned forward to the next stray `'`, swallowing the block's real closing brace (line 1275) and over-extending the test region all the way to EOF (line 9591). The block-bounding `scan_balanced(brace, "{", "}")` therefore swept `spawn_turn_bridge` (top-level at 4208) and ~8000 lines of the turn-lifecycle surface into "test".

Result: `mod.rs` reported **626 production / 10302 test**. True split is **8417 production / 2467 test**.

The same root-cause bug mis-classified other files in both directions:
- `terminal_delivery.rs` / `migrated.rs`: cfg(test) brace match broke (ParseError → block skipped), inflating them to **false giants** (1341/1286 prod, 0 test). True: 504 / 883 prod.
- `idle_recap.rs`, `github/sync.rs`, `escalation.rs`, `discord_config_audit.rs`, and others shrank to their true production LoC once inline test mods were correctly excluded.

## Fix

Added `char_literal_length()` to distinguish genuine char literals (`'a'`, `'\n'`, `'\u{...}'`) from lifetimes (skip only the quote). Also handle byte / byte-string / raw-byte-string literals (`b'x'`, `b"..."`, `br#"..."#`). Applied to both `scan_balanced` and `split_top_level`. **No Rust source touched** — tooling/docs/toml only.

## Blast radius (prod LoC corrected, all using the shared splitter)

| file | old prod | new prod |
|---|---|---|
| turn_bridge/mod.rs | 626 | **8417** |
| idle_recap.rs | 2303 | 1319 |
| terminal_delivery.rs | 1341 | 504 |
| github/sync.rs | 1894 | 1488 |
| migrated.rs | 1286 | 883 |
| escalation.rs | 1733 | 1492 |
| discord_config_audit.rs | 1459 | 1318 |
| watchdog.rs, codex_tui/session.rs, credential.rs, tts/mod.rs, intake_router_hook.rs, platform/tmux.rs, exec_ops.rs, memento_instructions_cache.rs, provider_auth.rs, async_bridge.rs, doctor/startup.rs | (smaller drops) | |
| intake_gate.rs | 2953 | 2957 |
| provider.rs | 1738 | 1739 |
| turn_orchestrator.rs | 3089 | 3090 |

21 files total. Most dropped (test mods now correctly excluded); a few grew by 1–4 (the buggy splitter had under-counted prod where a test mod's closing brace was mis-detected).

## turn_bridge freeze value

`src/services/discord/turn_bridge/mod.rs = 8417` frozen in `scripts/audit_maintainability_giant_baseline.toml` (the #3028 re-inflation ratchet — the actual guard target) and registered with an `[[entry]]` in `giant_file_registry.toml`.

## Accounting corrections
- Removed ghost `[[entry]]` for `terminal_delivery.rs` (504 prod, no longer a giant) + its ratchet line.
- Removed `migrated.rs` from `grandfathered` (883 prod; kept in the frozen `grandfathered_baseline_paths` superset per registry rules).
- Synced `change-surfaces.md` freeze values: escalation 1733→1492, sync 1894→1488, provider 1738→1739, discord_config_audit 1459→1318, turn_orchestrator 3089→3090. Added a turn_bridge/mod.rs surface entry; updated terminal_delivery note.
- Ratchet: idle_recap 2303→1319, intake_gate 2953→2957, turn_orchestrator 3089→3090; added turn_bridge/mod.rs=8417; removed terminal_delivery.

## Tests
`tests/test_inventory_giant_split.py::BraceScannerTokenTest` (8 new cases): lifetimes (`&'a`, `'static`), `'{'`/`'}'` char literals, escaped char quotes, line-comment braces, raw-string braces, byte literals, and an interleaved test/production block pattern.

## Gates (all green)
- `generate_inventory_docs.py && check_agent_maintenance_docs.py` → freshness check passed
- `bash scripts/ci-script-checks.sh` → exit 0 (giant_files + giant_file_ratchet pass; turn_bridge 8417 ≤ frozen 8417)
- `python3 -m unittest discover -s tests` → 176 tests OK
- 643 src files scanned, 0 ParseErrors

## Scope
This is the **#3028 guard correction** only (splitter fix + accounting + baseline freeze). The actual turn_bridge decomposition lands separately after #3016 settles. **#3028 stays open** (decomp remaining). Do not merge — pending codex review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)