### PR TITLE
refactor(#3038): extract AcknowledgementConfig from VoiceBargeInRuntime (voice giant -1 LoC)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -535,6 +535,7 @@ src/
 │   │   ├── tui_prompt_relay.rs
 │   │   ├── tui_task_card.rs
 │   │   ├── turn_finalizer.rs
+│   │   ├── voice_acknowledgement.rs
 │   │   ├── voice_background_driver.rs
 │   │   ├── voice_barge_in.rs
 │   │   ├── voice_routing.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -667,7 +667,7 @@
     inline — its move-captured locals make a clean extraction risky and is
     deferred).
   - `src/services/discord/session_runtime.rs` (1781 lines).
-  - `src/services/discord/voice_barge_in.rs` (4835 lines; voice STT/TTS,
+  - `src/services/discord/voice_barge_in.rs` (4834 lines; voice STT/TTS,
     lobby routing, progress mirroring, and barge-in orchestration surface;
     tracked decompose target — see `giant-file-registry.md` (owner
     `voice-runtime`, deadline 2026-08-31, #3036)).

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -26,7 +26,7 @@
 "src/services/discord/turn_bridge/mod.rs" = 8417
 "src/services/discord/mod.rs" = 5185
 "src/services/discord/tui_prompt_relay.rs" = 5120
-"src/services/discord/voice_barge_in.rs" = 4835
+"src/services/discord/voice_barge_in.rs" = 4834
 "src/services/discord/recovery_engine.rs" = 4034
 "src/services/discord/router/message_handler/intake_turn.rs" = 3771
 "src/services/discord/meeting_orchestrator.rs" = 3227

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -30,9 +30,6 @@ mod placeholder_cleanup;
 mod placeholder_controller;
 mod placeholder_live_events;
 mod placeholder_sweeper;
-// Phase 5.3 of intake-node-routing (issue #2011): standalone JSONL → Discord
-// relay loop spawned by the bridge on cluster-standby nodes (where the tmux
-// watcher's relay path does not fire). Leader keeps using tmux_watcher.
 mod prompt_builder;
 mod queue_io;
 mod queued_placeholders_store;
@@ -41,6 +38,8 @@ mod relay_recovery;
 pub(crate) mod response_sanitizer;
 #[cfg(unix)]
 mod session_relay_sink;
+// #2011 Phase 5.3: standalone JSONL → Discord relay loop spawned by the bridge
+// on cluster-standby nodes (leader keeps using tmux_watcher's relay path).
 #[cfg(unix)]
 mod standby_relay;
 // #1074: landing zone for the future recovery-engine module split
@@ -90,6 +89,7 @@ mod tui_prompt_relay;
 mod tui_task_card;
 mod turn_bridge;
 mod turn_finalizer;
+mod voice_acknowledgement;
 mod voice_background_driver;
 mod voice_barge_in;
 mod voice_routing;

--- a/src/services/discord/voice_acknowledgement.rs
+++ b/src/services/discord/voice_acknowledgement.rs
@@ -1,0 +1,61 @@
+//! Barge-in acknowledgement settings extracted from `VoiceBargeInRuntime`
+//! (#3038 god-object split, acknowledgement slice).
+//!
+//! Hosts [`AcknowledgementConfig`], the cohesive pair of immutable config
+//! values that previously lived as sibling fields (`acknowledgement_enabled`,
+//! `acknowledgement_text`) on `VoiceBargeInRuntime`. Moving them into this
+//! sibling module both isolates the concern and physically shrinks the
+//! `voice_barge_in.rs` giant rather than re-inflating it.
+
+use crate::voice::VoiceConfig;
+
+/// Cohesive sub-concern of `VoiceBargeInRuntime`: the barge-in acknowledgement
+/// settings.
+///
+/// Bundles the two immutable config values that were previously sibling fields
+/// on `VoiceBargeInRuntime` and were only ever consumed together when draining a
+/// deferred barge-in buffer:
+/// - `enabled` mirrors `config.barge_in.acknowledgement_enabled`, and
+/// - `text` mirrors `config.barge_in.acknowledgement_text`.
+///
+/// Both are seeded once at construction (from `VoiceConfig`, or to the disabled
+/// defaults `false` / empty string) and never mutated thereafter, so no locking
+/// or ordering is involved. The single read site
+/// (`acknowledgement_before_drain`) consumes `enabled()` and `text()` as a pair,
+/// exactly as the original
+/// `buffer.acknowledgement_before_drain(self.acknowledgement_enabled,
+/// &self.acknowledgement_text)` call did. Behavior is unchanged.
+pub(in crate::services::discord) struct AcknowledgementConfig {
+    enabled: bool,
+    text: String,
+}
+
+impl AcknowledgementConfig {
+    /// Build from a `VoiceConfig`, mirroring the original
+    /// `config.barge_in.acknowledgement_*` reads.
+    pub(in crate::services::discord) fn from_voice_config(config: &VoiceConfig) -> Self {
+        Self {
+            enabled: config.barge_in.acknowledgement_enabled,
+            text: config.barge_in.acknowledgement_text.clone(),
+        }
+    }
+
+    /// Disabled defaults, matching the original `false` / `String::new()` pair
+    /// used by `VoiceBargeInRuntime::disabled`.
+    pub(in crate::services::discord) fn disabled() -> Self {
+        Self {
+            enabled: false,
+            text: String::new(),
+        }
+    }
+
+    /// Whether the spoken acknowledgement is enabled.
+    pub(in crate::services::discord) fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// The configured acknowledgement text.
+    pub(in crate::services::discord) fn text(&self) -> &str {
+        &self.text
+    }
+}

--- a/src/services/discord/voice_barge_in.rs
+++ b/src/services/discord/voice_barge_in.rs
@@ -34,6 +34,7 @@ use crate::voice::tts::{
 use crate::voice::{CompletedUtterance, VoiceConfig, VoiceReceiveHook};
 
 use super::SharedData;
+use super::voice_acknowledgement::AcknowledgementConfig;
 #[cfg(test)]
 use super::voice_background_driver::{VoiceBackgroundDriverKind, VoiceBackgroundStartOutcome};
 use super::voice_background_driver::{
@@ -1333,8 +1334,7 @@ pub(in crate::services::discord) struct VoiceBargeInRuntime {
     // #3038: sensitivity 관심사를 sub-struct 로 격리. default_sensitivity /
     // atomic mirror / RwLock 상태를 하나로 묶어 락 순서와 폴백 동작을 보존.
     sensitivity: SensitivityState,
-    acknowledgement_enabled: bool,
-    acknowledgement_text: String,
+    acknowledgement: AcknowledgementConfig,
     transcript_dirs: Vec<PathBuf>,
     voice_config_state: RwLock<VoiceConfig>,
     spoken_result_language: RwLock<String>,
@@ -1395,8 +1395,7 @@ impl VoiceBargeInRuntime {
             enabled: config.enabled,
             barge_in_enabled: config.enabled && config.barge_in.enabled,
             sensitivity: SensitivityState::new(default_sensitivity, conservative_ttl),
-            acknowledgement_enabled: config.barge_in.acknowledgement_enabled,
-            acknowledgement_text: config.barge_in.acknowledgement_text.clone(),
+            acknowledgement: AcknowledgementConfig::from_voice_config(config),
             transcript_dirs: transcript_dirs_from_config(config),
             voice_config_state: RwLock::new(config.clone()),
             spoken_result_language: RwLock::new(config.stt.language.clone()),
@@ -1426,8 +1425,7 @@ impl VoiceBargeInRuntime {
             enabled: false,
             barge_in_enabled: false,
             sensitivity: SensitivityState::disabled(),
-            acknowledgement_enabled: false,
-            acknowledgement_text: String::new(),
+            acknowledgement: AcknowledgementConfig::disabled(),
             transcript_dirs: Vec::new(),
             voice_config_state: RwLock::new(VoiceConfig::default()),
             spoken_result_language: RwLock::new(DEFAULT_STT_LANGUAGE.to_string()),
@@ -4143,8 +4141,9 @@ impl VoiceBargeInRuntime {
             .get(&channel_id.get())
             .map(|entry| entry.value().clone())?;
         let mut buffer = buffer.lock().await;
+        let ack = &self.acknowledgement;
         let acknowledgement = buffer
-            .acknowledgement_before_drain(self.acknowledgement_enabled, &self.acknowledgement_text)
+            .acknowledgement_before_drain(ack.enabled(), ack.text())
             .map(ToOwned::to_owned);
         let prompt = buffer.drain_prompt()?;
         Some(DeferredBargeInDrain {


### PR DESCRIPTION
## 요약
#3038 EPIC god-object 분해의 **비핫파일 슬라이스**. `VoiceBargeInRuntime`(~28필드)의 잔여 필드 중 가장 응집도 높고 call-site 가 적은 한 묶음을 sub-struct 로 추출한다. 이전 4개(SensitivityState/VoiceIdSequences/ConfigSnapshotCache/StreamingSttSessions, #3131~3133·#3139)에 이은 5번째 슬라이스.

## 추출한 필드 묶음 → sub-struct
| 추출 전 (sibling 필드) | 추출 후 |
|---|---|
| `acknowledgement_enabled: bool`<br>`acknowledgement_text: String` | `acknowledgement: AcknowledgementConfig` |

**위치**: 새 sibling 모듈 `src/services/discord/voice_acknowledgement.rs`.

**이유 (응집도)**: 두 필드는 모두 `config.barge_in.acknowledgement_*` 에서 construction 시 1회 seed 되고 이후 **불변**이며, 유일한 읽기 지점인 `take_deferred_prompt` 의 `acknowledgement_before_drain(enabled, text)` 에서 **항상 쌍으로만** 소비된다. 외부 call-site 1곳(읽기), 생성자 2곳. 동시성/락 의미 없음.

## behavior 불변
순수 필드 재그룹화 + 접근 경로 갱신만. `acknowledgement_before_drain` 은 `ack.enabled()` / `ack.text()` 를 원래와 동일한 순서·값으로 받는다. 동작/락/순서 변화 없음.

## in-file 대신 sibling 모듈을 쓴 이유 (결정)
이전 4 슬라이스는 in-file sub-struct 였으나, 그 방식은 struct+impl boilerplate 때문에 `voice_barge_in.rs` production LoC 를 늘려 **`giant_file_ratchet` 하드게이트를 위반**한다(예: 단순 in-file 추출 시 +53 LoC). 이번엔 voice_routing.rs / voice_background_driver.rs 와 동일한 sibling-module 패턴으로 격리해 `voice_barge_in.rs` 를 **4835 → 4834 로 단조감소**시킨다.

## 변경한 change-surfaces / baseline
- `audit_maintainability_giant_baseline.toml`: `voice_barge_in.rs` 4835 → **4834** 하향 (단조감소 win 잠금)
- `docs/agent-maintenance/change-surfaces.md`: freeze 값 4835 → 4834 동기
- `src/services/discord/mod.rs`: `mod voice_acknowledgement;` 추가 + **net-zero** (misplaced 된 standby_relay #2011 주석을 올바른 모듈 위로 재배치 → mod.rs 5185 유지, 자체 ratchet 위반 없음)
- `ARCHITECTURE.md` / `docs/generated/*`: 인벤토리 generator 산출물 동기

## 게이트 (전부 통과)
- `cargo fmt --check` clean
- `cargo check --lib` 신규 경고 0 (기존 2개 pre-existing 만)
- `cargo test --lib voice_barge_in` → 52 passed (acknowledgement drain 테스트 포함)
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` → freshness **passed**
- `bash scripts/ci-script-checks.sh` → **exit 0** (audit_maintainability `--check` 하드게이트 통과)

## 비고
- **#3038 닫지 않음** (EPIC, 잔여: spawn_turn_bridge / SharedData / health 등)
- 핫파일(turn_bridge/**, tmux_watcher.rs, session_relay_sink.rs, turn_finalizer.rs) 미접촉
- **머지 금지** — caller 가 codex 검토 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)