### PR TITLE
refactor(#3037): re-point tmux_watcher monitoring_store off server facade (backflow 25→24)

### DIFF
--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -517,3 +517,13 @@
   each host only provisions worktrees under its own root, so the sweep never sees
   another node's directories. If worktree roots ever become shared storage, the
   live-owner check would need to fan out cross-node.)
+- #3037 (backflow hotfile re-point): `tmux_watcher.rs` changed by a **pure import
+  path correction** — the single `global_monitoring_store()` call in the
+  suppressed-placeholder monitor-entry-key snapshot now resolves the function via
+  its canonical service home (`crate::services::monitoring_store::*`) instead of
+  the `crate::server::routes::state::*` compatibility facade (which re-exports the
+  same symbol). The resolved function, the per-node in-memory `MonitoringStore`,
+  and every call argument are **byte-identical**; the store remains
+  **process-local** (one in-memory `Arc<Mutex<MonitoringStore>>` per node, no PG
+  lease, no durable queue, no leader-only side effect). No behavior, ownership,
+  singleton, or lease assumption changes — this is a layering/import fix only.

--- a/scripts/audit_maintainability/baselines/service_server_backflow.json
+++ b/scripts/audit_maintainability/baselines/service_server_backflow.json
@@ -3,7 +3,7 @@
   "rule": "service_server_backflow",
   "description": "No-regression baseline for src/services references to crate::server or super::server server-layer modules.",
   "captured_at": "2026-06-08",
-  "total_count": 25,
+  "total_count": 24,
   "files": {
     "src/services/auto_queue/phase_gate_violations.rs": {
       "count": 1
@@ -21,9 +21,6 @@
       "count": 1
     },
     "src/services/discord/runtime_bootstrap.rs": {
-      "count": 1
-    },
-    "src/services/discord/tmux_watcher.rs": {
       "count": 1
     },
     "src/services/discord/turn_bridge/completion_guard.rs": {

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -10302,7 +10302,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 task_notification_kind,
                 Some(TaskNotificationKind::MonitorAutoTurn)
             ) {
-                let store_arc = crate::server::routes::state::global_monitoring_store();
+                let store_arc = crate::services::monitoring_store::global_monitoring_store();
                 let store = store_arc.lock().await;
                 store
                     .list(channel_id.get())


### PR DESCRIPTION
## Summary
#3037 backflow **hotfile** slice. Of the 6 remaining hotfile references, exactly **one** is a safe (a)-class pure relocation; the other **five** are (b)-class entangled DTOs deferred to #3038.

### (a) Processed — 1 reference
`src/services/discord/tmux_watcher.rs:10305`
- Was: `crate::server::routes::state::global_monitoring_store()` — a **compatibility facade** (`src/server/state.rs`, explicitly documented as #3037 bucket-3 facade) that only re-exports the canonical symbol relocated to `src/services/monitoring_store.rs` in #3211.
- Now: `crate::services::monitoring_store::global_monitoring_store()` — the canonical service path used by every sibling service caller (`disk_monitor.rs`, `idle_detector.rs`, `monitoring_status.rs`).
- **Pure import-path correction**: same function, same per-node in-memory `MonitoringStore`, byte-identical args. Zero behavior / control-flow / finalize-authority change.

### (b) Deferred — 5 references (`completion_guard.rs`) → with #3038 review_decision extraction
All five construct **genuine server route DTOs** passed over the internal HTTP loopback to `internal_api`. None has a service-layer/shared home:
- `:187` `ReviewDecisionBody`, `:339` `SubmitVerdictBody` — defined under `server/routes/review_verdict/{decision_route,verdict_route}.rs`. `ReviewDecisionBody` is threaded through **15+ functions inside `decision_route.rs`** (the #3038 god-function) and is an axum `Json<>` handler body. Relocation = the #3038 review_decision extraction (bucket 2).
- `:261`, `:1461`, `:1771` `UpdateDispatchBody` — defined in `server/routes/dispatches/crud.rs`, used as the axum handler body and by `recovery_engine.rs`. Relocation = the "진짜 server DTO" large/risky bucket.

Moving any of these requires broad server-side call-site churn entangled with #3038 — out of scope for a careful hotfile slice. Left untouched per #3037 guidance.

## Gates
- `cargo fmt --check` clean
- `cargo check --lib` clean (0 new warnings; 2 pre-existing baseline warnings identical to origin/main)
- `cargo check --lib --tests` clean
- `cargo test --lib turn_bridge` 139 passed; `completion_guard` 3 passed; `monitoring_store` ok
- backflow baseline lowered **25 → 24** (tmux_watcher entry removed; total_count reconciled)
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` → freshness passed
- `bash scripts/ci-script-checks.sh` → exit 0 (giant_file_ratchet count 0; service_server_backflow count 24)
- multinode-transition.md `### Audited touches` updated (per-node MonitoringStore, process-local, no lease/ownership change)

Refs #3037

🤖 Generated with [Claude Code](https://claude.com/claude-code)