### PR TITLE
refactor(#3038): extract ConfigSnapshotCache to voice_config_cache sibling module

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -539,6 +539,7 @@ src/
 │   │   ├── voice_acknowledgement.rs
 │   │   ├── voice_background_driver.rs
 │   │   ├── voice_barge_in.rs
+│   │   ├── voice_config_cache.rs
 │   │   ├── voice_routing.rs
 │   │   └── watcher_panel_parity.rs
 │   ├── dispatches/

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -670,7 +670,7 @@
     inline — its move-captured locals make a clean extraction risky and is
     deferred).
   - `src/services/discord/session_runtime.rs` (1781 lines).
-  - `src/services/discord/voice_barge_in.rs` (4834 lines; voice STT/TTS,
+  - `src/services/discord/voice_barge_in.rs` (4780 lines; voice STT/TTS,
     lobby routing, progress mirroring, and barge-in orchestration surface;
     tracked decompose target — see `giant-file-registry.md` (owner
     `voice-runtime`, deadline 2026-08-31, #3036)).

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -24,9 +24,9 @@
 # turn-lifecycle surface were mislabeled test. This is the actual #3028 guard;
 # decompose lands separately after #3016 settles.
 "src/services/discord/turn_bridge/mod.rs" = 8417
-"src/services/discord/mod.rs" = 5185
+"src/services/discord/mod.rs" = 5186
 "src/services/discord/tui_prompt_relay.rs" = 5120
-"src/services/discord/voice_barge_in.rs" = 4834
+"src/services/discord/voice_barge_in.rs" = 4780
 "src/services/discord/recovery_engine.rs" = 4034
 "src/services/discord/router/message_handler/intake_turn.rs" = 3771
 "src/services/discord/meeting_orchestrator.rs" = 3227

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -92,6 +92,7 @@ mod turn_finalizer;
 mod voice_acknowledgement;
 mod voice_background_driver;
 mod voice_barge_in;
+mod voice_config_cache;
 mod voice_routing;
 #[path = "watchers/lifecycle_decision.rs"]
 mod watcher_lifecycle_decision;

--- a/src/services/discord/voice_barge_in.rs
+++ b/src/services/discord/voice_barge_in.rs
@@ -41,6 +41,7 @@ use super::voice_background_driver::{
     VoiceBackgroundStartRequest, VoiceBackgroundTurnDriver, default_voice_announce_generation,
     select_voice_background_driver, voice_announce_delivery_id,
 };
+use super::voice_config_cache::ConfigSnapshotCache;
 pub(in crate::services::discord) const INTERNAL_VOICE_MESSAGE_ID_START: u64 =
     9_000_000_000_000_000_000;
 
@@ -59,8 +60,6 @@ pub(in crate::services::discord) fn is_synthetic_voice_message_id(
 // F4 (#2046): progress/ack 재생 owner id 시작점. spoken_result owner 공간(1..)과
 // 분리하기 위해 high range 사용.
 const PROGRESS_PLAYBACK_OWNER_START: u64 = 1u64 << 63;
-// F6 (#2046): voice config 핫캐시 TTL. 5초 안 utterance 는 캐시 재사용.
-const VOICE_CONFIG_CACHE_TTL: Duration = Duration::from_secs(5);
 const STT_TRANSCRIPT_POLL_TIMEOUT: Duration = Duration::from_secs(5);
 const STT_TRANSCRIPT_POLL_INTERVAL: Duration = Duration::from_millis(200);
 const PROCESSING_CHIME_FILE_NAME: &str = "agentdesk-voice-processing-chime.wav";
@@ -1272,59 +1271,6 @@ impl StreamingSttSessions {
     fn clear(&self) {
         self.sessions.clear();
         self.feed_tasks.clear();
-    }
-}
-
-/// Cohesive sub-concern of [`VoiceBargeInRuntime`]: the F6 (#2046) `Config`
-/// snapshot hot-cache (#3038 god-object split, config-cache slice).
-///
-/// Wraps the single `Mutex<Option<(Instant, Arc<Config>)>>` slot that used to
-/// live directly on `VoiceBargeInRuntime`. The accessors below preserve the
-/// original lock discipline and TTL fallback exactly:
-/// - `lookup_within_ttl` returns the cached `Arc<Config>` only while the entry
-///   is younger than `VOICE_CONFIG_CACHE_TTL`, silently treating a poisoned /
-///   contended lock as a miss (`Ok` guard required, never blocking-on-panic),
-/// - `store` overwrites the slot with a freshly stamped entry, also ignoring a
-///   failed lock,
-/// - the spawn_blocking reload itself stays on the runtime so the async control
-///   flow and side-effect ordering are byte-for-byte unchanged.
-struct ConfigSnapshotCache {
-    slot: std::sync::Mutex<Option<(Instant, Arc<crate::config::Config>)>>,
-}
-
-impl ConfigSnapshotCache {
-    fn new() -> Self {
-        Self {
-            slot: std::sync::Mutex::new(None),
-        }
-    }
-
-    /// Return the cached snapshot iff it is still within the TTL window as of
-    /// `now`. A poisoned or contended lock is treated as a cache miss, matching
-    /// the original `if let Ok(guard) = ... .lock()` fallback.
-    fn lookup_within_ttl(&self, now: Instant) -> Option<Arc<crate::config::Config>> {
-        if let Ok(guard) = self.slot.lock()
-            && let Some((loaded_at, cached)) = guard.as_ref()
-            && now.duration_since(*loaded_at) < VOICE_CONFIG_CACHE_TTL
-        {
-            return Some(cached.clone());
-        }
-        None
-    }
-
-    /// Stamp and store a freshly loaded snapshot. A failed lock is ignored,
-    /// matching the original `if let Ok(mut guard) = ... .lock()` write.
-    fn store(&self, loaded_at: Instant, config: Arc<crate::config::Config>) {
-        if let Ok(mut guard) = self.slot.lock() {
-            *guard = Some((loaded_at, config));
-        }
-    }
-
-    /// Test-only seed of the cache slot (mirrors the previous direct
-    /// `*runtime.config_cache.lock().unwrap() = Some(...)` writes).
-    #[cfg(test)]
-    fn seed(&self, loaded_at: Instant, config: Arc<crate::config::Config>) {
-        *self.slot.lock().unwrap() = Some((loaded_at, config));
     }
 }
 

--- a/src/services/discord/voice_config_cache.rs
+++ b/src/services/discord/voice_config_cache.rs
@@ -1,0 +1,79 @@
+//! F6 (#2046) `Config` snapshot hot-cache extracted from `VoiceBargeInRuntime`
+//! (#3038 god-object split, config-cache slice).
+//!
+//! Hosts [`ConfigSnapshotCache`], the single `Mutex`-guarded snapshot slot that
+//! previously lived directly on `VoiceBargeInRuntime`. Moving it (together with
+//! its sole TTL constant `VOICE_CONFIG_CACHE_TTL`) into this sibling module both
+//! isolates the concern and physically shrinks the `voice_barge_in.rs` giant
+//! rather than re-inflating it. The lock discipline, TTL fallback, and
+//! side-effect ordering are byte-for-byte unchanged.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// F6 (#2046): voice config 핫캐시 TTL. 5초 안 utterance 는 캐시 재사용.
+const VOICE_CONFIG_CACHE_TTL: Duration = Duration::from_secs(5);
+
+/// Cohesive sub-concern of `VoiceBargeInRuntime`: the F6 (#2046) `Config`
+/// snapshot hot-cache (#3038 god-object split, config-cache slice).
+///
+/// Wraps the single `Mutex<Option<(Instant, Arc<Config>)>>` slot that used to
+/// live directly on `VoiceBargeInRuntime`. The accessors below preserve the
+/// original lock discipline and TTL fallback exactly:
+/// - `lookup_within_ttl` returns the cached `Arc<Config>` only while the entry
+///   is younger than `VOICE_CONFIG_CACHE_TTL`, silently treating a poisoned /
+///   contended lock as a miss (`Ok` guard required, never blocking-on-panic),
+/// - `store` overwrites the slot with a freshly stamped entry, also ignoring a
+///   failed lock,
+/// - the spawn_blocking reload itself stays on the runtime so the async control
+///   flow and side-effect ordering are byte-for-byte unchanged.
+pub(in crate::services::discord) struct ConfigSnapshotCache {
+    slot: std::sync::Mutex<Option<(Instant, Arc<crate::config::Config>)>>,
+}
+
+impl ConfigSnapshotCache {
+    pub(in crate::services::discord) fn new() -> Self {
+        Self {
+            slot: std::sync::Mutex::new(None),
+        }
+    }
+
+    /// Return the cached snapshot iff it is still within the TTL window as of
+    /// `now`. A poisoned or contended lock is treated as a cache miss, matching
+    /// the original `if let Ok(guard) = ... .lock()` fallback.
+    pub(in crate::services::discord) fn lookup_within_ttl(
+        &self,
+        now: Instant,
+    ) -> Option<Arc<crate::config::Config>> {
+        if let Ok(guard) = self.slot.lock()
+            && let Some((loaded_at, cached)) = guard.as_ref()
+            && now.duration_since(*loaded_at) < VOICE_CONFIG_CACHE_TTL
+        {
+            return Some(cached.clone());
+        }
+        None
+    }
+
+    /// Stamp and store a freshly loaded snapshot. A failed lock is ignored,
+    /// matching the original `if let Ok(mut guard) = ... .lock()` write.
+    pub(in crate::services::discord) fn store(
+        &self,
+        loaded_at: Instant,
+        config: Arc<crate::config::Config>,
+    ) {
+        if let Ok(mut guard) = self.slot.lock() {
+            *guard = Some((loaded_at, config));
+        }
+    }
+
+    /// Test-only seed of the cache slot (mirrors the previous direct
+    /// `*runtime.config_cache.lock().unwrap() = Some(...)` writes).
+    #[cfg(test)]
+    pub(in crate::services::discord) fn seed(
+        &self,
+        loaded_at: Instant,
+        config: Arc<crate::config::Config>,
+    ) {
+        *self.slot.lock().unwrap() = Some((loaded_at, config));
+    }
+}


### PR DESCRIPTION
## 배경
`src/services/discord/voice_barge_in.rs`(giant)의 `VoiceBargeInRuntime` god-object 분해 다음 묶음. 기존에 SensitivityState/VoiceIdSequences/StreamingSttSessions 등은 여전히 **in-file** 정의로 남아 실제 LoC 감소가 없었고(ratchet 관점 in-file 은 격리 효과 없음), AcknowledgementConfig 만 sibling 모듈로 격리된 상태였다. 이번에는 sibling-module 패턴으로 실제 production LoC 를 감소시켰다.

## 추출 필드 묶음 → sub-struct
- **필드**: `config_cache: ConfigSnapshotCache` + 전용 상수 `VOICE_CONFIG_CACHE_TTL`
- **이동 대상**: `ConfigSnapshotCache`(struct + impl)와 그 TTL 상수
- **신규 모듈**: `src/services/discord/voice_config_cache.rs`
- **응집 근거**: 단일 `Mutex<Option<(Instant, Arc<Config>)>>` 슬롯과 그 TTL 상수만으로 구성된 self-contained 캐시. call-site 가 적다 — production 2개(`lookup_within_ttl`, `store`), test seed 4개. F6 (#2046) Config 핫캐시 관심사로 명확히 분리된다.

## 이동 심볼 (이전 file:line)
- `const VOICE_CONFIG_CACHE_TTL` — voice_barge_in.rs:63 → voice_config_cache.rs
- `struct ConfigSnapshotCache` + impl(`new`/`lookup_within_ttl`/`store`/`seed`) — voice_barge_in.rs:1290–1328 → voice_config_cache.rs
- import 추가: `use super::voice_config_cache::ConfigSnapshotCache;` (voice_barge_in.rs)
- 모듈 등록: `mod voice_config_cache;` (services/discord/mod.rs)

## 동시성 / behavior 불변
- `Mutex` lock discipline, TTL 폴백(poisoned/contended lock → cache miss), `store`/`seed` write 의미가 byte-for-byte 불변.
- `cached_config` 의 `spawn_blocking` reload 는 runtime 에 그대로 남겨 async 제어 흐름과 side-effect 순서 불변.
- 이동 후 voice_barge_in 및 그 `#[cfg(test)] mod tests`(`super::*`)에서 접근하도록 메서드를 `pub(in crate::services::discord)` 로 노출. `seed` 는 `#[cfg(test)]` 유지.

## LoC 변화
- `voice_barge_in.rs` production: **4834 → 4780 (-54)** — sibling 격리로 실제 감소. giant baseline 하향.
- `services/discord/mod.rs`: 모듈 등록 1줄(5185 → 5186), baseline +1 동기화.

## 게이트
- `cargo fmt --check` clean
- `cargo check --lib` clean (이 변경으로 인한 신규 경고 0; 잔여 2개 경고는 origin/main 기존)
- `cargo check --lib --tests` clean (신규 경고 0)
- `cargo test --lib voice_barge_in` → 52 passed (config-cache seed 테스트 포함)
- `giant_file_ratchet` count 0 (baseline 동기화 후)
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` → freshness passed (change-surfaces freeze 동기)
- `bash scripts/ci-script-checks.sh` → exit 0

Refs #3038 (닫지 않음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)