### PR TITLE
refactor(#3038): isolate VoiceIdSequences into sibling module (real LoC drop)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -541,6 +541,7 @@ src/
 │   │   ├── voice_background_driver.rs
 │   │   ├── voice_barge_in.rs
 │   │   ├── voice_config_cache.rs
+│   │   ├── voice_id_sequences.rs
 │   │   ├── voice_routing.rs
 │   │   └── watcher_panel_parity.rs
 │   ├── dispatches/

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -670,7 +670,7 @@
     inline — its move-captured locals make a clean extraction risky and is
     deferred).
   - `src/services/discord/session_runtime.rs` (1781 lines).
-  - `src/services/discord/voice_barge_in.rs` (4780 lines; voice STT/TTS,
+  - `src/services/discord/voice_barge_in.rs` (4728 lines; voice STT/TTS,
     lobby routing, progress mirroring, and barge-in orchestration surface;
     tracked decompose target — see `giant-file-registry.md` (owner
     `voice-runtime`, deadline 2026-08-31, #3036)).

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -24,9 +24,9 @@
 # turn-lifecycle surface were mislabeled test. This is the actual #3028 guard;
 # decompose lands separately after #3016 settles.
 "src/services/discord/turn_bridge/mod.rs" = 8417
-"src/services/discord/mod.rs" = 5186
+"src/services/discord/mod.rs" = 5187
 "src/services/discord/tui_prompt_relay.rs" = 5120
-"src/services/discord/voice_barge_in.rs" = 4780
+"src/services/discord/voice_barge_in.rs" = 4728
 "src/services/discord/recovery_engine.rs" = 4034
 "src/services/discord/router/message_handler/intake_turn.rs" = 3771
 "src/services/discord/meeting_orchestrator.rs" = 3227

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -93,6 +93,7 @@ mod voice_acknowledgement;
 mod voice_background_driver;
 mod voice_barge_in;
 mod voice_config_cache;
+mod voice_id_sequences;
 mod voice_routing;
 #[path = "watchers/lifecycle_decision.rs"]
 mod watcher_lifecycle_decision;

--- a/src/services/discord/voice_barge_in.rs
+++ b/src/services/discord/voice_barge_in.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 #[cfg(test)]
 use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 
@@ -42,6 +42,7 @@ use super::voice_background_driver::{
     select_voice_background_driver, voice_announce_delivery_id,
 };
 use super::voice_config_cache::ConfigSnapshotCache;
+use super::voice_id_sequences::VoiceIdSequences;
 pub(in crate::services::discord) const INTERNAL_VOICE_MESSAGE_ID_START: u64 =
     9_000_000_000_000_000_000;
 
@@ -57,9 +58,6 @@ pub(in crate::services::discord) fn is_synthetic_voice_message_id(
 ) -> bool {
     msg_id.get() >= INTERNAL_VOICE_MESSAGE_ID_START
 }
-// F4 (#2046): progress/ack 재생 owner id 시작점. spoken_result owner 공간(1..)과
-// 분리하기 위해 high range 사용.
-const PROGRESS_PLAYBACK_OWNER_START: u64 = 1u64 << 63;
 const STT_TRANSCRIPT_POLL_TIMEOUT: Duration = Duration::from_secs(5);
 const STT_TRANSCRIPT_POLL_INTERVAL: Duration = Duration::from_millis(200);
 const PROCESSING_CHIME_FILE_NAME: &str = "agentdesk-voice-processing-chime.wav";
@@ -1171,56 +1169,6 @@ impl SensitivityState {
             .try_read()
             .map(|state| state.sensitivity())
             .unwrap_or_else(|_| BargeInSensitivity::from_u8(self.atom.load(Ordering::Relaxed)))
-    }
-}
-
-/// Cohesive sub-concern of [`VoiceBargeInRuntime`]: monotonic ID allocators
-/// (#3038 god-object split, id-sequence slice).
-///
-/// Bundles the three independent `AtomicU64` counters that previously lived
-/// directly on `VoiceBargeInRuntime`. Each `next_*` accessor preserves the
-/// original `fetch_add` semantics — including the exact memory `Ordering` and
-/// the per-counter seed value — so issued IDs are byte-for-byte identical to
-/// the pre-extraction layout:
-/// - spoken-result playbacks seed at `1` (`SeqCst`),
-/// - progress playbacks seed at `PROGRESS_PLAYBACK_OWNER_START` (`SeqCst`),
-/// - internal voice messages seed at `INTERNAL_VOICE_MESSAGE_ID_START`
-///   (`Relaxed`).
-struct VoiceIdSequences {
-    next_spoken_result_playback_id: AtomicU64,
-    // F4 (#2046): progress/ack 재생 owner id 발급용. 30s 만료 타이머가 owner 일치
-    // 시에만 playback entry 를 정리하도록 한다.
-    next_progress_playback_id: AtomicU64,
-    next_internal_message_id: AtomicU64,
-}
-
-impl VoiceIdSequences {
-    fn new() -> Self {
-        Self {
-            next_spoken_result_playback_id: AtomicU64::new(1),
-            next_progress_playback_id: AtomicU64::new(PROGRESS_PLAYBACK_OWNER_START),
-            next_internal_message_id: AtomicU64::new(INTERNAL_VOICE_MESSAGE_ID_START),
-        }
-    }
-
-    /// Allocate the next spoken-result playback id (`SeqCst`, seeded at `1`).
-    fn next_spoken_result_playback_id(&self) -> u64 {
-        self.next_spoken_result_playback_id
-            .fetch_add(1, Ordering::SeqCst)
-    }
-
-    /// Allocate the next progress/ack playback owner id (`SeqCst`, seeded at
-    /// `PROGRESS_PLAYBACK_OWNER_START`).
-    fn next_progress_playback_id(&self) -> u64 {
-        self.next_progress_playback_id
-            .fetch_add(1, Ordering::SeqCst)
-    }
-
-    /// Allocate the next internal voice message id (`Relaxed`, seeded at
-    /// `INTERNAL_VOICE_MESSAGE_ID_START`).
-    fn next_internal_message_id(&self) -> u64 {
-        self.next_internal_message_id
-            .fetch_add(1, Ordering::Relaxed)
     }
 }
 

--- a/src/services/discord/voice_id_sequences.rs
+++ b/src/services/discord/voice_id_sequences.rs
@@ -1,0 +1,69 @@
+//! Monotonic ID allocators extracted from `VoiceBargeInRuntime`
+//! (#3038 god-object split, id-sequence slice).
+//!
+//! Hosts [`VoiceIdSequences`], the three independent `AtomicU64` counters that
+//! previously lived directly on `VoiceBargeInRuntime`. Moving them (together
+//! with their sole private seed constant `PROGRESS_PLAYBACK_OWNER_START`) into
+//! this sibling module isolates the concern and physically shrinks the
+//! `voice_barge_in.rs` giant rather than re-inflating it. Each `next_*`
+//! accessor preserves the original `fetch_add` semantics byte-for-byte —
+//! including the exact memory `Ordering` and the per-counter seed — so issued
+//! IDs are identical to the pre-extraction layout.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use super::voice_barge_in::INTERNAL_VOICE_MESSAGE_ID_START;
+
+// F4 (#2046): progress/ack 재생 owner id 시작점. spoken_result owner 공간(1..)과
+// 분리하기 위해 high range 사용.
+const PROGRESS_PLAYBACK_OWNER_START: u64 = 1u64 << 63;
+
+/// Cohesive sub-concern of `VoiceBargeInRuntime`: monotonic ID allocators
+/// (#3038 god-object split, id-sequence slice).
+///
+/// Bundles the three independent `AtomicU64` counters that previously lived
+/// directly on `VoiceBargeInRuntime`. Each `next_*` accessor preserves the
+/// original `fetch_add` semantics — including the exact memory `Ordering` and
+/// the per-counter seed value — so issued IDs are byte-for-byte identical to
+/// the pre-extraction layout:
+/// - spoken-result playbacks seed at `1` (`SeqCst`),
+/// - progress playbacks seed at `PROGRESS_PLAYBACK_OWNER_START` (`SeqCst`),
+/// - internal voice messages seed at `INTERNAL_VOICE_MESSAGE_ID_START`
+///   (`Relaxed`).
+pub(in crate::services::discord) struct VoiceIdSequences {
+    next_spoken_result_playback_id: AtomicU64,
+    // F4 (#2046): progress/ack 재생 owner id 발급용. 30s 만료 타이머가 owner 일치
+    // 시에만 playback entry 를 정리하도록 한다.
+    next_progress_playback_id: AtomicU64,
+    next_internal_message_id: AtomicU64,
+}
+
+impl VoiceIdSequences {
+    pub(in crate::services::discord) fn new() -> Self {
+        Self {
+            next_spoken_result_playback_id: AtomicU64::new(1),
+            next_progress_playback_id: AtomicU64::new(PROGRESS_PLAYBACK_OWNER_START),
+            next_internal_message_id: AtomicU64::new(INTERNAL_VOICE_MESSAGE_ID_START),
+        }
+    }
+
+    /// Allocate the next spoken-result playback id (`SeqCst`, seeded at `1`).
+    pub(in crate::services::discord) fn next_spoken_result_playback_id(&self) -> u64 {
+        self.next_spoken_result_playback_id
+            .fetch_add(1, Ordering::SeqCst)
+    }
+
+    /// Allocate the next progress/ack playback owner id (`SeqCst`, seeded at
+    /// `PROGRESS_PLAYBACK_OWNER_START`).
+    pub(in crate::services::discord) fn next_progress_playback_id(&self) -> u64 {
+        self.next_progress_playback_id
+            .fetch_add(1, Ordering::SeqCst)
+    }
+
+    /// Allocate the next internal voice message id (`Relaxed`, seeded at
+    /// `INTERNAL_VOICE_MESSAGE_ID_START`).
+    pub(in crate::services::discord) fn next_internal_message_id(&self) -> u64 {
+        self.next_internal_message_id
+            .fetch_add(1, Ordering::Relaxed)
+    }
+}


### PR DESCRIPTION
## What

god-object 분해 (#3038): `voice_barge_in.rs` 거대 파일에 in-file로 정의돼 있던 sub-struct 중 하나를 **진짜 sibling 모듈로 물리 이동**해 실제 production LoC를 줄였다.

## 이동한 sub-struct + 선택 이유

**`VoiceIdSequences`** — 3개의 monotonic `AtomicU64` ID 할당기(spoken-result / progress playback / internal message). 남은 in-file sub-struct 중 **가장 self-contained**:
- 다른 voice 타입/락(`RwLock`/`DashMap`/`SttSessionHandle` 등)에 전혀 결합되지 않은 순수 atomic 카운터 3개
- 외부 의존은 상수 2개뿐, call-site 단 3곳(+ 생성 2곳)

(비교: `SensitivityState`는 `BargeInSensitivityState`/`RwLock`/TTL 결합, `StreamingSttSessions`는 `SttSessionHandle`/`StreamingSttKey`/feed-task `JoinHandle` 결합으로 더 깊음.)

## 이동 내역

- `struct VoiceIdSequences` + `impl` + 전용 private 상수 `PROGRESS_PLAYBACK_OWNER_START` → 신규 `src/services/discord/voice_id_sequences.rs`
- `INTERNAL_VOICE_MESSAGE_ID_START`는 `is_synthetic_voice_message_id`와 공유되므로 `voice_barge_in.rs`에 잔류 → 신규 모듈이 `use super::voice_barge_in::INTERNAL_VOICE_MESSAGE_ID_START`로 import
- `VoiceBargeInRuntime`은 `id_sequences: VoiceIdSequences` 필드를 그대로 보유하고 accessor만 호출 (call-site 무변경)
- 가시성 최소화: `pub(in crate::services::discord)`

## Behavior 불변

각 `next_*` accessor의 `fetch_add` seed 값과 memory `Ordering`(SeqCst/SeqCst/Relaxed)을 byte-for-byte 보존. 순환참조 없음.

## LoC 변화

- `voice_barge_in.rs`: 4780 → **4728** production LoC (실제 −52)
- `mod.rs`: 5186 → 5187 (모듈 등록 +1)
- 신규 `voice_id_sequences.rs`: 71 LoC (giant 아님)
- baseline / change-surfaces freeze entry / generated inventory docs 동기

## 게이트

- `cargo fmt --check` clean
- `cargo check --lib` / `--lib --tests` clean — 신규 경고 0 (불필요해진 `AtomicU64` import 제거)
- `cargo test --lib voice_barge_in` → 52 passed
- giant ratchet audit (`audit_maintainability.py --check`) passed
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` → freshness passed
- `bash scripts/ci-script-checks.sh` → exit 0

Refs #3038 (닫지 않음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)