### PR TITLE
refactor(#3037): relocate round-table meeting DTOs to services (backflow 22→21)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -739,7 +739,7 @@
     `crate::services::kanban`).
   - `src/server/routes/docs.rs` (5880 lines).
   - `src/server/routes/escalation.rs` (1456 lines).
-  - `src/server/routes/meetings.rs` (1708 lines).
+  - `src/server/routes/meetings.rs` (1686 lines).
   - `src/server/routes/review_verdict/decision_route.rs` (4404 lines).
   - `src/server/routes/{agents,agents_crud,agents_setup,v1,resume}.rs` (all
     1000+ production lines). (`dispatches/thread_reuse.rs` dropped below the

--- a/scripts/audit_maintainability/baselines/service_server_backflow.json
+++ b/scripts/audit_maintainability/baselines/service_server_backflow.json
@@ -3,7 +3,7 @@
   "rule": "service_server_backflow",
   "description": "No-regression baseline for src/services references to crate::server or super::server server-layer modules.",
   "captured_at": "2026-06-08",
-  "total_count": 22,
+  "total_count": 21,
   "files": {
     "src/services/auto_queue/phase_gate_violations.rs": {
       "count": 1
@@ -12,9 +12,6 @@
       "count": 1
     },
     "src/services/discord/internal_api.rs": {
-      "count": 1
-    },
-    "src/services/discord/meeting_orchestrator.rs": {
       "count": 1
     },
     "src/services/discord/recovery_engine.rs": {

--- a/src/server/routes/meetings.rs
+++ b/src/server/routes/meetings.rs
@@ -4,12 +4,13 @@ use axum::{
     http::StatusCode,
 };
 use poise::serenity_prelude::ChannelId;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::json;
 use sqlx::{PgPool, Row};
 use std::collections::{HashMap, HashSet};
 
 use super::AppState;
+use crate::services::discord::meeting_artifact_store::UpsertMeetingBody;
 use crate::services::discord::{health, meeting, settings};
 use crate::services::provider::ProviderKind;
 
@@ -29,33 +30,10 @@ pub struct StartMeetingBody {
     pub fixed_participants: Option<Vec<String>>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-pub struct MeetingEntryBody {
-    pub seq: Option<i64>,
-    pub round: Option<i64>,
-    pub speaker_role_id: Option<String>,
-    pub speaker_name: Option<String>,
-    pub content: Option<String>,
-    pub is_summary: Option<bool>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct UpsertMeetingBody {
-    pub id: String,
-    pub channel_id: Option<String>,
-    pub agenda: Option<String>,
-    pub summary: Option<String>,
-    pub selection_reason: Option<String>,
-    pub status: Option<String>,
-    pub primary_provider: Option<String>,
-    pub reviewer_provider: Option<String>,
-    pub participant_names: Option<Vec<String>>,
-    pub total_rounds: Option<i64>,
-    pub started_at: Option<i64>,
-    pub completed_at: Option<i64>,
-    pub thread_id: Option<String>,
-    pub entries: Option<Vec<MeetingEntryBody>>,
-}
+// `MeetingEntryBody` and `UpsertMeetingBody` now live beside their
+// service-layer producers in `crate::services::discord::meeting_artifact_store`
+// so those callers can depend on the request shape they build without a
+// server-layer backflow (#3037). `UpsertMeetingBody` is re-`use`d above.
 
 fn normalize_selection_reason(value: &str) -> Option<String> {
     let compact = value.split_whitespace().collect::<Vec<_>>().join(" ");

--- a/src/services/discord/internal_api.rs
+++ b/src/services/discord/internal_api.rs
@@ -311,7 +311,7 @@ pub(super) async fn submit_review_verdict(
 }
 
 pub(super) async fn upsert_meeting(
-    body: routes::meetings::UpsertMeetingBody,
+    body: crate::services::discord::meeting_artifact_store::UpsertMeetingBody,
 ) -> Result<Value, String> {
     request_body(Method::POST, "/api/round-table-meetings", &body).await
 }

--- a/src/services/discord/meeting_artifact_store.rs
+++ b/src/services/discord/meeting_artifact_store.rs
@@ -15,6 +15,48 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+// ─── Round-table persistence request DTOs ──────────────────────────────────
+//
+// `MeetingEntryBody` / `UpsertMeetingBody` were previously defined in
+// `crate::server::routes::meetings`, which forced the service-layer producers
+// (`meeting_orchestrator`, `internal_api`) to reach back into the server layer
+// for the request shape they themselves construct (#3037 service→server
+// backflow). They are pure serde payloads with no axum / `AppState` coupling,
+// so they now live beside the meeting service layer; the server route module
+// and the service-layer producers `use` them from here.
+
+/// Single round-table meeting entry posted back from the Discord runtime as
+/// part of an [`UpsertMeetingBody`].
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct MeetingEntryBody {
+    pub seq: Option<i64>,
+    pub round: Option<i64>,
+    pub speaker_role_id: Option<String>,
+    pub speaker_name: Option<String>,
+    pub content: Option<String>,
+    pub is_summary: Option<bool>,
+}
+
+/// Completed/cancelled meeting payload persisted via
+/// `POST /api/round-table-meetings`.
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct UpsertMeetingBody {
+    pub id: String,
+    pub channel_id: Option<String>,
+    pub agenda: Option<String>,
+    pub summary: Option<String>,
+    pub selection_reason: Option<String>,
+    pub status: Option<String>,
+    pub primary_provider: Option<String>,
+    pub reviewer_provider: Option<String>,
+    pub participant_names: Option<Vec<String>>,
+    pub total_rounds: Option<i64>,
+    pub started_at: Option<i64>,
+    pub completed_at: Option<i64>,
+    pub thread_id: Option<String>,
+    pub entries: Option<Vec<MeetingEntryBody>>,
+}
+
 /// Artifact category. Kept as a string slug (rather than an enum with a fixed
 /// set) so future kinds (action-items, decisions, follow-up tasks) can be
 /// added without a cross-module change.

--- a/src/services/discord/meeting_orchestrator.rs
+++ b/src/services/discord/meeting_orchestrator.rs
@@ -3029,7 +3029,7 @@ fn build_meeting_status_payload(m: &Meeting) -> Option<serde_json::Value> {
 async fn persist_meeting_status(
     payload: serde_json::Value,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let body: crate::server::routes::meetings::UpsertMeetingBody = serde_json::from_value(payload)?;
+    let body: super::meeting_artifact_store::UpsertMeetingBody = serde_json::from_value(payload)?;
     super::internal_api::upsert_meeting(body)
         .await
         .map(|_| ())


### PR DESCRIPTION
## Cluster
Round-table meeting persistence request DTOs (server route → services).

Moves the pure-serde DTOs `UpsertMeetingBody` and `MeetingEntryBody` from
`crate::server::routes::meetings` down to the service-layer meeting module
(`crate::services::discord::meeting_artifact_store`), beside their producers
(`meeting_orchestrator`, `internal_api`). The server route handler now `use`s
`UpsertMeetingBody` from services instead of owning it — the correct dependency
direction (services owns the domain types; the route depends on services).

These structs have no axum / `AppState` coupling, so this is a pure relocation:
identical fields and derives, behavior unchanged.

## backflow 22 → 21
Removes the `src/services/discord/meeting_orchestrator.rs` service→server
backflow reference (was `crate::server::routes::meetings::UpsertMeetingBody`).
Baseline `service_server_backflow.json` lowered 22→21, meeting_orchestrator.rs
entry dropped.

## Scope / safety
- No hot files touched (turn_bridge/completion_guard, tmux_watcher,
  session_relay_sink, turn_finalizer untouched).
- No `crate::server::routes::AppState` / axum / ws / cluster coupling changed.
- No circular dependency introduced.
- All call sites updated: `internal_api::upsert_meeting`, the `meetings.rs`
  route handler, and the orchestrator `persist_meeting_status` path.
- DTOs placed in an existing (non-frozen) sibling module so no giant-file
  ratchet re-inflation; `meeting_orchestrator.rs` net line count unchanged.

## Behavior invariant
Pure type-definition move — no logic, field, or derive change. Serde
(de)serialization contract for `POST /api/round-table-meetings` is identical.

## Gates
- `cargo fmt --check` clean
- `cargo check --lib` clean (0 new warnings; 2 pre-existing on main)
- `cargo check --lib --tests` clean
- escalation pg route test (`manual_decision_gate_tests`) green
- `audit_maintainability --check` exit 0 — backflow 21, giant-file ratchet 0
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` →
  freshness passed (change-surfaces meetings.rs freeze synced 1708→1686 prod LoC)
- `ci-script-checks.sh` exit 0
- No multinode-audited surface touched → no multinode-transition.md update.

Refs #3037