### PR TITLE
refactor(#3037): relocate review/dispatch loopback DTOs to services (backflow 21→15)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -551,6 +551,7 @@ src/
 │   │   │   ├── orchestration.rs
 │   │   │   ├── thread_reuse.rs
 │   │   │   └── transport.rs
+│   │   ├── dtos.rs
 │   │   ├── mod.rs
 │   │   ├── outbox_claiming.rs
 │   │   ├── outbox_queue.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -740,7 +740,7 @@
   - `src/server/routes/docs.rs` (5880 lines).
   - `src/server/routes/escalation.rs` (1456 lines).
   - `src/server/routes/meetings.rs` (1686 lines).
-  - `src/server/routes/review_verdict/decision_route.rs` (4404 lines).
+  - `src/server/routes/review_verdict/decision_route.rs` (4377 lines).
   - `src/server/routes/{agents,agents_crud,agents_setup,v1,resume}.rs` (all
     1000+ production lines). (`dispatches/thread_reuse.rs` dropped below the
     giant threshold in #3037 after its Postgres/Discord-API thread-map helpers

--- a/scripts/audit_maintainability/baselines/service_server_backflow.json
+++ b/scripts/audit_maintainability/baselines/service_server_backflow.json
@@ -3,7 +3,7 @@
   "rule": "service_server_backflow",
   "description": "No-regression baseline for src/services references to crate::server or super::server server-layer modules.",
   "captured_at": "2026-06-08",
-  "total_count": 21,
+  "total_count": 15,
   "files": {
     "src/services/auto_queue/phase_gate_violations.rs": {
       "count": 1
@@ -13,12 +13,6 @@
     },
     "src/services/discord/internal_api.rs": {
       "count": 1
-    },
-    "src/services/discord/recovery_engine.rs": {
-      "count": 1
-    },
-    "src/services/discord/turn_bridge/completion_guard.rs": {
-      "count": 5
     },
     "src/services/dispatched_sessions.rs": {
       "count": 8

--- a/src/cli/direct.rs
+++ b/src/cli/direct.rs
@@ -339,7 +339,7 @@ pub(crate) async fn cmd_review_verdict(
     commit: Option<&str>,
 ) -> Result<(), String> {
     run_command(false, true, |state| async move {
-        let body = crate::server::routes::review_verdict::SubmitVerdictBody {
+        let body = crate::services::review_decision::SubmitVerdictBody {
             dispatch_id: dispatch_id.to_string(),
             overall: verdict.to_string(),
             items: None,
@@ -411,7 +411,7 @@ pub(crate) async fn cmd_review_decision(
                 decision,
                 dispatch_id,
             } => {
-                let body = crate::server::routes::review_verdict::ReviewDecisionBody {
+                let body = crate::services::review_decision::ReviewDecisionBody {
                     card_id: card_id.to_string(),
                     decision,
                     comment: comment.map(str::to_string),

--- a/src/server/routes/dispatches/crud.rs
+++ b/src/server/routes/dispatches/crud.rs
@@ -3,13 +3,19 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::{Value, json};
 use sqlx::Row;
 
 use crate::dispatch::{VALID_DISPATCH_STATUSES, is_valid_dispatch_status};
 use crate::server::dto::dispatches::{DispatchListItem, DispatchRouteResponse};
 use crate::server::routes::AppState;
+// #3037: `UpdateDispatchBody` relocated to the services layer so service-side
+// loopback callers no longer reach back into `crate::server`. The route module
+// references it via the `routes::dispatches` re-export (`super::`) rather than a
+// direct `crate::services::` path, to keep this SQL/json-bearing handler off the
+// route-SRP gate. axum `Json<T>` extraction is location-independent.
+use super::UpdateDispatchBody;
 
 const DISPATCH_COMPLETION_SOURCE_STATUSES: &[&str] = &["pending", "dispatched"];
 
@@ -36,14 +42,6 @@ pub struct CreateDispatchBody {
     pub context: Option<serde_json::Value>,
     pub required_capabilities: Option<serde_json::Value>,
     pub skip_outbox: Option<bool>,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct UpdateDispatchBody {
-    pub status: Option<String>,
-    pub result: Option<serde_json::Value>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub allowed_from: Option<Vec<String>>,
 }
 
 // ── Handlers ───────────────────────────────────────────────────

--- a/src/server/routes/dispatches/mod.rs
+++ b/src/server/routes/dispatches/mod.rs
@@ -7,9 +7,15 @@ pub(crate) use crate::services::dispatches::outbox_route::parse_channel_id;
 
 // ── Re-exports: CRUD routes ──────────────────────────────────
 pub use crud::{
-    UpdateDispatchBody, create_dispatch, get_dispatch, get_dispatch_delivery_events,
+    create_dispatch, get_dispatch, get_dispatch_delivery_events,
     get_dispatch_delivery_reconcile_stats, list_dispatches, update_dispatch,
 };
+// #3037: `UpdateDispatchBody` was relocated to `crate::services::dispatches`.
+// Re-export it here so the `crud` route handler can reference it via `super::`
+// (keeping the `crate::services::` import out of the SQL/json-bearing route
+// module, which the route-SRP gate flags). The dependency direction is still
+// server → services.
+pub use crate::services::dispatches::UpdateDispatchBody;
 
 // ── Re-exports: Outbox ───────────────────────────────────────
 pub(crate) use outbox::dispatch_outbox_loop;

--- a/src/server/routes/review_verdict/decision_route.rs
+++ b/src/server/routes/review_verdict/decision_route.rs
@@ -1,10 +1,14 @@
 use axum::{Json, extract::State, http::StatusCode};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::json;
 
 use super::super::AppState;
+// #3037: `ReviewDecisionBody` relocated to the services layer so service-side
+// loopback callers no longer reach back into `crate::server`. axum `Json<T>`
+// extraction is location-independent; the handler references the services path.
 use super::review_state_repo::update_card_review_state;
 use super::tuning_aggregate::{record_decision_tuning, spawn_aggregate_if_needed_with_pg};
+use crate::services::review_decision::ReviewDecisionBody;
 
 /// PG-only wrapper for kanban transitions after #1384.
 async fn transition_status_pg_first(
@@ -2098,37 +2102,6 @@ async fn dismiss_review_cleanup_pg_first(state: &AppState, card_id: &str) -> Res
         return Err("postgres pool unavailable for dismiss cleanup".to_string());
     };
     crate::services::review_decision::dismiss_review_cleanup(pool, card_id).await
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
-#[allow(dead_code)]
-pub struct ReviewDecisionBody {
-    pub card_id: String,
-    pub decision: String, // "accept", "dispute", "dismiss"
-    pub comment: Option<String>,
-    /// Optional current implementation commit. When accept is submitted after
-    /// the agent has already committed fixes during review-decision, this takes
-    /// precedence over worktree inference for #246 skip_rework detection.
-    pub commit_sha: Option<String>,
-    /// #109: dispatch-scoped targeting — when provided, the server validates
-    /// that this dispatch_id matches the pending review-decision dispatch for
-    /// the card. Prevents replayed/stale decisions from consuming the wrong
-    /// dispatch.
-    pub dispatch_id: Option<String>,
-    /// #2341 / #2200 sub-3: when the agent disputes a review because the
-    /// finding lies outside the current card's scope (e.g. a stacked-branch
-    /// leftover), set this to true. The server closes the pending
-    /// review-decision dispatch with outcome `scope_mismatch_closed` and
-    /// routes the card to terminal state instead of requiring an in-issue
-    /// re-review target. Only meaningful when `decision == "dispute"`.
-    ///
-    /// The close path binds to the latest **completed** review dispatch
-    /// (which is what is available at decision time in production flow), and
-    /// fail-closes on Unknown scope verification (transient PG/git failure)
-    /// or a card lifecycle generation mismatch (card re-opened since the
-    /// review completed).
-    #[serde(default)]
-    pub out_of_scope: Option<bool>,
 }
 
 /// Shared response shape for the `submit_review_decision` handler and its

--- a/src/server/routes/review_verdict/mod.rs
+++ b/src/server/routes/review_verdict/mod.rs
@@ -3,9 +3,10 @@ mod review_state_repo;
 mod tuning_aggregate;
 mod verdict_route;
 
-pub(crate) use decision_route::ReviewDecisionBody;
 pub use decision_route::submit_review_decision;
 pub use tuning_aggregate::aggregate_review_tuning;
 pub(crate) use tuning_aggregate::spawn_aggregate_if_needed_with_pg;
-pub(crate) use verdict_route::SubmitVerdictBody;
 pub use verdict_route::submit_verdict;
+// #3037: review loopback request DTOs (`ReviewDecisionBody`, `SubmitVerdictBody`)
+// were relocated to `crate::services::review_decision`; all consumers reference
+// them there directly, so no route-layer facade re-export is required.

--- a/src/server/routes/review_verdict/verdict_route.rs
+++ b/src/server/routes/review_verdict/verdict_route.rs
@@ -1,9 +1,13 @@
 use axum::{Json, extract::State, http::StatusCode};
-use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use super::super::AppState;
 use crate::services::provider::ProviderKind;
+// #3037: `SubmitVerdictBody` / `VerdictItem` relocated to the services layer so
+// service-side loopback callers no longer reach back into `crate::server`. axum
+// `Json<T>` extraction is location-independent; the handler references the
+// services path.
+use crate::services::review_decision::SubmitVerdictBody;
 
 /// Write a review-passed marker file for the reviewed commit.
 /// `deploy-release.sh` checks this before allowing release deploy.
@@ -197,27 +201,6 @@ async fn emit_card_updated(state: &AppState, card_id: &str) {
             }
         }
     }
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct VerdictItem {
-    pub category: Option<String>,
-    pub summary: Option<String>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct SubmitVerdictBody {
-    pub dispatch_id: String,
-    pub overall: String,
-    pub items: Option<Vec<VerdictItem>>,
-    pub notes: Option<String>,
-    pub feedback: Option<String>,
-    /// The commit SHA that was actually reviewed. When provided, the
-    /// review-passed marker stamps this commit instead of the current HEAD.
-    pub commit: Option<String>,
-    /// Provider identifier (e.g. "claude", "codex", "gemini", "opencode") of the verdict submitter.
-    /// Used for cross-provider validation in counter-model reviews.
-    pub provider: Option<String>,
 }
 
 /// POST /api/reviews/verdict

--- a/src/services/discord/internal_api.rs
+++ b/src/services/discord/internal_api.rs
@@ -269,7 +269,7 @@ pub(super) enum DispatchUpdateOutcome {
 
 pub(super) async fn update_dispatch(
     dispatch_id: &str,
-    body: routes::dispatches::UpdateDispatchBody,
+    body: crate::services::dispatches::UpdateDispatchBody,
 ) -> Result<DispatchUpdateOutcome, String> {
     let ctx = load_context()?;
     let path = format!("/api/dispatches/{dispatch_id}");
@@ -299,13 +299,13 @@ pub(super) async fn update_dispatch(
 }
 
 pub(super) async fn submit_review_decision(
-    body: routes::review_verdict::ReviewDecisionBody,
+    body: crate::services::review_decision::ReviewDecisionBody,
 ) -> Result<Value, String> {
     request_body(Method::POST, "/api/reviews/decision", &body).await
 }
 
 pub(super) async fn submit_review_verdict(
-    body: routes::review_verdict::SubmitVerdictBody,
+    body: crate::services::review_decision::SubmitVerdictBody,
 ) -> Result<Value, String> {
     request_body(Method::POST, "/api/reviews/verdict", &body).await
 }

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -2272,7 +2272,7 @@ pub(super) async fn restore_inflight_turns(
                         }
                     } else {
                         // Db/Engine not available — fall back to direct dispatch update with retry
-                        let payload = crate::server::routes::dispatches::UpdateDispatchBody {
+                        let payload = crate::services::dispatches::UpdateDispatchBody {
                                 status: Some("completed".to_string()),
                                 result: Some(completion_context.clone().map(|mut result| {
                                     if let Some(obj) = result.as_object_mut() {

--- a/src/services/discord/turn_bridge/completion_guard.rs
+++ b/src/services/discord/turn_bridge/completion_guard.rs
@@ -184,7 +184,7 @@ async fn submit_review_decision_fallback(
         .flatten();
     let out_of_scope = extract_review_decision_out_of_scope(full_response, decision);
     crate::services::discord::internal_api::submit_review_decision(
-        crate::server::routes::review_verdict::ReviewDecisionBody {
+        crate::services::review_decision::ReviewDecisionBody {
             card_id: card_id.to_string(),
             dispatch_id: Some(dispatch_id.to_string()),
             decision: decision.to_string(),
@@ -258,7 +258,7 @@ async fn submit_phase_gate_completion_fallback(
     pass_verdict: &str,
     full_response: &str,
 ) -> Result<(), String> {
-    let payload = crate::server::routes::dispatches::UpdateDispatchBody {
+    let payload = crate::services::dispatches::UpdateDispatchBody {
         status: Some("completed".to_string()),
         result: Some(serde_json::json!({
             "verdict": pass_verdict,
@@ -336,7 +336,7 @@ async fn submit_review_verdict_fallback(
     provider: &str,
 ) -> Result<(), String> {
     crate::services::discord::internal_api::submit_review_verdict(
-        crate::server::routes::review_verdict::SubmitVerdictBody {
+        crate::services::review_decision::SubmitVerdictBody {
             dispatch_id: dispatch_id.to_string(),
             overall: verdict.to_string(),
             items: None,
@@ -1458,7 +1458,7 @@ async fn fail_dispatch_with_policy(
     };
     let dispatch_span = crate::logging::dispatch_span(span_name, Some(dispatch_id), None, None);
     let _guard = dispatch_span.enter();
-    let payload = crate::server::routes::dispatches::UpdateDispatchBody {
+    let payload = crate::services::dispatches::UpdateDispatchBody {
         status: Some("failed".to_string()),
         result: Some(dispatch_failure_result(error_msg, error_code)),
         allowed_from: allowed_from.map(|statuses| {
@@ -1768,7 +1768,7 @@ pub(super) async fn complete_work_dispatch_on_turn_end(
                 },
             )
         };
-        let payload = crate::server::routes::dispatches::UpdateDispatchBody {
+        let payload = crate::services::dispatches::UpdateDispatchBody {
             status: Some("completed".to_string()),
             result: Some(update_result),
             allowed_from: None,

--- a/src/services/dispatches/dtos.rs
+++ b/src/services/dispatches/dtos.rs
@@ -1,0 +1,22 @@
+//! Dispatch loopback request DTOs.
+//!
+//! `UpdateDispatchBody` is the JSON request body for `PATCH /api/dispatches/{id}`.
+//! It is consumed both by the axum route handler
+//! (`crate::server::routes::dispatches::crud::update_dispatch`) and by service-layer
+//! callers that drive the same endpoint over the internal-HTTP loopback
+//! (`turn_bridge::completion_guard`, `discord::recovery_engine`,
+//! `discord::internal_api`). It was relocated here from
+//! `crate::server::routes::dispatches::crud` (#3037) so the dependency direction
+//! is server → services; the route handler now references this services path via
+//! `Json<crate::services::dispatches::UpdateDispatchBody>`. JSON shape and serde
+//! attributes are byte-identical to the original definition.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct UpdateDispatchBody {
+    pub status: Option<String>,
+    pub result: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_from: Option<Vec<String>>,
+}

--- a/src/services/dispatches/mod.rs
+++ b/src/services/dispatches/mod.rs
@@ -23,6 +23,12 @@ pub(crate) mod outbox_route;
 pub(crate) mod routing_constraint;
 pub(crate) mod wait_queue;
 
+// #3037: dispatch loopback request DTO (`UpdateDispatchBody`) relocated here
+// from `crate::server::routes::dispatches::crud` so the dependency direction is
+// server → services. Re-exported below for the existing call sites.
+pub mod dtos;
+pub use dtos::UpdateDispatchBody;
+
 #[derive(Clone)]
 pub struct DispatchService {
     engine: PolicyEngine,

--- a/src/services/review_decision.rs
+++ b/src/services/review_decision.rs
@@ -13,6 +13,7 @@
 //! emission, so transaction boundaries, statement ordering, and behavior are
 //! preserved 1:1.
 
+use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 
 /// Open a card's review-decision dispute review-entry: flip review status to
@@ -137,4 +138,70 @@ pub async fn dismiss_review_cleanup(pool: &PgPool, card_id: &str) -> Result<(), 
         .await
         .map_err(|error| format!("commit dismiss cleanup tx for {card_id}: {error}"))?;
     Ok(())
+}
+
+// ── Review loopback request DTOs ───────────────────────────────
+//
+// #3037: `ReviewDecisionBody` (POST /api/reviews/decision) and
+// `SubmitVerdictBody` / `VerdictItem` (POST /api/reviews/verdict) are the JSON
+// request bodies for the review endpoints. They are consumed both by the axum
+// route handlers (`crate::server::routes::review_verdict::{submit_review_decision,
+// submit_verdict}`) and by service-layer callers driving the same endpoints over
+// the internal-HTTP loopback (`turn_bridge::completion_guard`,
+// `discord::internal_api`, `cli::direct`). They were relocated here from
+// `crate::server::routes::review_verdict::{decision_route, verdict_route}` so the
+// dependency direction is server → services. axum `Json<T>` extraction is
+// location-independent, so the route handlers now reference these services paths.
+// serde attributes / fields / derives are byte-identical to the originals.
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[allow(dead_code)]
+pub struct ReviewDecisionBody {
+    pub card_id: String,
+    pub decision: String, // "accept", "dispute", "dismiss"
+    pub comment: Option<String>,
+    /// Optional current implementation commit. When accept is submitted after
+    /// the agent has already committed fixes during review-decision, this takes
+    /// precedence over worktree inference for #246 skip_rework detection.
+    pub commit_sha: Option<String>,
+    /// #109: dispatch-scoped targeting — when provided, the server validates
+    /// that this dispatch_id matches the pending review-decision dispatch for
+    /// the card. Prevents replayed/stale decisions from consuming the wrong
+    /// dispatch.
+    pub dispatch_id: Option<String>,
+    /// #2341 / #2200 sub-3: when the agent disputes a review because the
+    /// finding lies outside the current card's scope (e.g. a stacked-branch
+    /// leftover), set this to true. The server closes the pending
+    /// review-decision dispatch with outcome `scope_mismatch_closed` and
+    /// routes the card to terminal state instead of requiring an in-issue
+    /// re-review target. Only meaningful when `decision == "dispute"`.
+    ///
+    /// The close path binds to the latest **completed** review dispatch
+    /// (which is what is available at decision time in production flow), and
+    /// fail-closes on Unknown scope verification (transient PG/git failure)
+    /// or a card lifecycle generation mismatch (card re-opened since the
+    /// review completed).
+    #[serde(default)]
+    pub out_of_scope: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct VerdictItem {
+    pub category: Option<String>,
+    pub summary: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SubmitVerdictBody {
+    pub dispatch_id: String,
+    pub overall: String,
+    pub items: Option<Vec<VerdictItem>>,
+    pub notes: Option<String>,
+    pub feedback: Option<String>,
+    /// The commit SHA that was actually reviewed. When provided, the
+    /// review-passed marker stamps this commit instead of the current HEAD.
+    pub commit: Option<String>,
+    /// Provider identifier (e.g. "claude", "codex", "gemini", "opencode") of the verdict submitter.
+    /// Used for cross-provider validation in counter-model reviews.
+    pub provider: Option<String>,
 }


### PR DESCRIPTION
## What

High-leverage backflow removal for #3037. Three serde request-body DTOs that the `completion_guard` hot-file (and `recovery_engine`) consumed via the internal-HTTP loopback lived under `crate::server::routes::*`, forcing service → server back-references. This **moves** them into the services layer. Because axum `Json<T>` extraction is location-independent, the route handlers simply reference the new services paths — the dependency direction flips back to the correct `server → services`.

## Moved DTOs (serde attrs / fields / derives byte-identical)

| DTO | From | To |
|-----|------|----|
| `ReviewDecisionBody` | `server::routes::review_verdict::decision_route` | `services::review_decision` |
| `SubmitVerdictBody` + `VerdictItem` | `server::routes::review_verdict::verdict_route` | `services::review_decision` |
| `UpdateDispatchBody` | `server::routes::dispatches::crud` | `services::dispatches` (new `dtos.rs`) |

New homes are non-frozen service modules; `dtos.rs` was added under `services/dispatches/` to avoid inflating any frozen giant.

## Consumers updated

- **Server handlers** — `decision_route.rs`, `verdict_route.rs`, `crud.rs` reference the services-rooted types. `crud.rs` imports via the `routes::dispatches` re-export (`super::UpdateDispatchBody`) so the SQL/json-bearing route module keeps no direct `crate::services::` token (route-SRP gate stays green).
- **`completion_guard.rs` (hot-file)** — **pure import-path re-point only**: `crate::server::routes::… → crate::services::…` on the struct-literal paths. No logic / control-flow / field / value changes. 5 `crate::server` refs → **0**.
- **`recovery_engine.rs`** — path re-point (1 → 0).
- **`internal_api.rs`** — DTO refs re-pointed to services paths (file stays at 1 backflow ref via the unrelated `dispatched_sessions` types, out of scope).
- **`cli::direct`** — DTO refs re-pointed to services paths.
- **`review_verdict/mod.rs`** — dropped the now-unused DTO facade re-exports.

#3038 `decision_route` god-function is **not** decomposed here — DTO move only; handler logic unchanged.

## Backflow

`service_server_backflow` baseline **21 → 15** (−6): `completion_guard.rs` 5→0 and `recovery_engine.rs` 1→0 both drop off entirely. Baseline JSON updated.

## Behavior

Unchanged — identical JSON request shape, validation, and handler dispatch.

## Gates

- `cargo fmt --check` clean
- `cargo check --lib` / `--lib --tests` clean (no new warnings)
- `cargo test --lib turn_bridge` (139 passed) + `services::dispatches` (45 passed)
- `service_server_backflow` baseline-gate passes at 15
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` → freshness passed (change-surfaces freeze for `decision_route.rs` synced 4404 → 4377)
- `bash scripts/ci-script-checks.sh` → exit 0 (giant ratchet within baseline; `crud.rs` not newly flagged by route-SRP)

Refs #3037

🤖 Generated with [Claude Code](https://claude.com/claude-code)