### PR TITLE
refactor(#3037): escalation-settings read path → services (backflow 15→14)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -650,6 +650,7 @@ src/
 │   ├── dispatched_sessions.rs
 │   ├── dispatches_followup.rs
 │   ├── envelope_dedup.rs
+│   ├── escalation_settings.rs
 │   ├── gemini.rs
 │   ├── issue_announcements.rs
 │   ├── kanban.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -94,7 +94,7 @@
   - `src/dispatch/dispatch_status.rs` (1517 lines).
   - `src/services/dispatches/outbox_route.rs` (1118 lines; route extraction
     orchestration surface from #1722, split before adding non-bugfix behavior).
-  - `src/services/dispatches/discord_delivery/orchestration.rs` (1652 lines;
+  - `src/services/dispatches/discord_delivery/orchestration.rs` (1654 lines;
     delivery orchestration surface extracted from the route layer in #1760,
     split before adding non-bugfix behavior).
 - active_callsite_coverage: n/a.
@@ -738,7 +738,7 @@
     `resolve_requesting_agent_id_with_pg` auth/identity helpers to
     `crate::services::kanban`).
   - `src/server/routes/docs.rs` (5880 lines).
-  - `src/server/routes/escalation.rs` (1456 lines).
+  - `src/server/routes/escalation.rs` (1376 lines).
   - `src/server/routes/meetings.rs` (1686 lines).
   - `src/server/routes/review_verdict/decision_route.rs` (4377 lines).
   - `src/server/routes/{agents,agents_crud,agents_setup,v1,resume}.rs` (all

--- a/scripts/audit_maintainability/baselines/service_server_backflow.json
+++ b/scripts/audit_maintainability/baselines/service_server_backflow.json
@@ -3,7 +3,7 @@
   "rule": "service_server_backflow",
   "description": "No-regression baseline for src/services references to crate::server or super::server server-layer modules.",
   "captured_at": "2026-06-08",
-  "total_count": 15,
+  "total_count": 14,
   "files": {
     "src/services/auto_queue/phase_gate_violations.rs": {
       "count": 1
@@ -16,9 +16,6 @@
     },
     "src/services/dispatched_sessions.rs": {
       "count": 8
-    },
-    "src/services/dispatches/discord_delivery/orchestration.rs": {
-      "count": 1
     },
     "src/services/onboarding/channel.rs": {
       "count": 1

--- a/src/server/routes/escalation.rs
+++ b/src/server/routes/escalation.rs
@@ -5,15 +5,17 @@ use serde::Deserialize;
 use serde_json::json;
 use sqlx::Row as SqlxRow;
 
-use crate::config::{
-    Config, DEFAULT_ESCALATION_PM_HOURS, DEFAULT_ESCALATION_TIMEZONE, EscalationMode,
-    EscalationScheduleSettings, EscalationSettings, EscalationSettingsResponse,
-};
+use crate::config::{Config, EscalationMode, EscalationSettings, EscalationSettingsResponse};
 use crate::db::agents::load_agent_channel_bindings_pg;
 use crate::server::routes::AppState;
 use crate::services::discord::health::active_request_owner_for_channel;
+// Escalation-settings read path now lives in the service layer (#3037); the
+// route handlers re-import the resolver helpers as the single source of truth.
+use crate::services::escalation_settings::{
+    ESCALATION_SETTINGS_OVERRIDE_KEY, escalation_defaults, load_override_pg_async,
+    merged_settings_pg, normalize_optional_string,
+};
 
-const ESCALATION_SETTINGS_OVERRIDE_KEY: &str = "escalation-settings-override";
 const ESCALATION_THREAD_KEY_PREFIX: &str = "escalation_thread:";
 const DISCORD_API_BASE: &str = "https://discord.com/api/v10";
 const DISCORD_MESSAGE_CHAR_LIMIT: usize = 2000;
@@ -69,94 +71,12 @@ struct OwnerRoutingTarget {
     source: &'static str,
 }
 
-fn normalize_optional_string(value: Option<String>) -> Option<String> {
-    value
-        .map(|raw| raw.trim().to_string())
-        .filter(|raw| !raw.is_empty())
-}
-
 fn parse_channel_reference(channel: &str) -> Option<u64> {
     channel
         .trim()
         .parse::<u64>()
         .ok()
         .or_else(|| crate::server::routes::dispatches::resolve_channel_alias_pub(channel))
-}
-
-fn escalation_defaults(config: &Config) -> EscalationSettings {
-    EscalationSettings {
-        mode: config.escalation.mode.clone(),
-        owner_user_id: config.escalation.owner_user_id.or(config.discord.owner_id),
-        pm_channel_id: normalize_optional_string(
-            config
-                .escalation
-                .pm_channel_id
-                .clone()
-                .or_else(|| config.kanban.human_alert_channel_id.clone()),
-        ),
-        schedule: EscalationScheduleSettings {
-            pm_hours: config
-                .escalation
-                .schedule
-                .pm_hours
-                .clone()
-                .unwrap_or_else(|| DEFAULT_ESCALATION_PM_HOURS.to_string()),
-            timezone: config
-                .escalation
-                .schedule
-                .timezone
-                .clone()
-                .unwrap_or_else(|| DEFAULT_ESCALATION_TIMEZONE.to_string()),
-        },
-    }
-}
-
-async fn load_override_pg_async(pool: &sqlx::PgPool) -> Result<Option<EscalationSettings>, String> {
-    let raw = sqlx::query_scalar::<_, String>(
-        "SELECT value
-         FROM kv_meta
-         WHERE key = $1
-         LIMIT 1",
-    )
-    .bind(ESCALATION_SETTINGS_OVERRIDE_KEY)
-    .fetch_optional(pool)
-    .await
-    .map_err(|error| {
-        format!(
-            "load postgres escalation settings override {ESCALATION_SETTINGS_OVERRIDE_KEY}: {error}"
-        )
-    })?;
-    Ok(raw.and_then(|value| serde_json::from_str::<EscalationSettings>(&value).ok()))
-}
-
-fn merged_settings_pg(pool: &sqlx::PgPool, config: &Config) -> Result<EscalationSettings, String> {
-    let defaults = escalation_defaults(config);
-    crate::utils::async_bridge::block_on_pg_result(
-        pool,
-        move |bridge_pool| async move {
-            Ok(load_override_pg_async(&bridge_pool)
-                .await?
-                .unwrap_or(defaults))
-        },
-        |error| error,
-    )
-}
-
-pub(crate) fn effective_owner_user_id_with_backends(
-    _db: Option<&crate::db::Db>,
-    pg_pool: Option<&sqlx::PgPool>,
-    config: &Config,
-) -> Option<u64> {
-    if let Some(pool) = pg_pool {
-        match merged_settings_pg(pool, config) {
-            Ok(settings) => return settings.owner_user_id,
-            Err(error) => {
-                tracing::warn!(%error, "[escalation] failed to load postgres escalation settings override");
-            }
-        }
-    }
-
-    escalation_defaults(config).owner_user_id
 }
 
 fn store_override_pg(pool: &sqlx::PgPool, settings: &EscalationSettings) -> Result<(), String> {

--- a/src/services/dispatches/discord_delivery/orchestration.rs
+++ b/src/services/dispatches/discord_delivery/orchestration.rs
@@ -39,7 +39,9 @@ fn resolve_dispatch_thread_owner_user_id(
     pg_pool: Option<&PgPool>,
 ) -> Option<u64> {
     let config = crate::config::load_graceful();
-    crate::server::routes::escalation::effective_owner_user_id_with_backends(db, pg_pool, &config)
+    crate::services::escalation_settings::effective_owner_user_id_with_backends(
+        db, pg_pool, &config,
+    )
 }
 
 fn context_slot_index(dispatch_context: Option<&serde_json::Value>) -> Option<i64> {

--- a/src/services/escalation_settings.rs
+++ b/src/services/escalation_settings.rs
@@ -1,0 +1,113 @@
+//! Escalation-settings resolution (read path).
+//!
+//! These helpers previously lived in `crate::server::routes::escalation`, which
+//! forced service-layer callers (dispatch delivery owner resolution) to reach
+//! back up into the server layer via `crate::server::routes::escalation::*`
+//! (#3037 service→server backflow). The settings-read logic depends only on
+//! `crate::config` types/constants (already below services) and the
+//! `crate::utils::async_bridge` PG bridge, so it belongs in the service layer.
+//!
+//! The escalation route module re-imports these symbols for its handlers, so
+//! this stays the single source of truth and the dependency direction is now
+//! routes -> services (not the reverse).
+
+use crate::config::{
+    Config, DEFAULT_ESCALATION_PM_HOURS, DEFAULT_ESCALATION_TIMEZONE, EscalationScheduleSettings,
+    EscalationSettings,
+};
+
+/// Postgres `kv_meta` key holding the persisted escalation-settings override.
+pub(crate) const ESCALATION_SETTINGS_OVERRIDE_KEY: &str = "escalation-settings-override";
+
+/// Trim a string and treat empty results as absent.
+pub(crate) fn normalize_optional_string(value: Option<String>) -> Option<String> {
+    value
+        .map(|raw| raw.trim().to_string())
+        .filter(|raw| !raw.is_empty())
+}
+
+/// Compute the escalation settings implied by static config (no override).
+pub(crate) fn escalation_defaults(config: &Config) -> EscalationSettings {
+    EscalationSettings {
+        mode: config.escalation.mode.clone(),
+        owner_user_id: config.escalation.owner_user_id.or(config.discord.owner_id),
+        pm_channel_id: normalize_optional_string(
+            config
+                .escalation
+                .pm_channel_id
+                .clone()
+                .or_else(|| config.kanban.human_alert_channel_id.clone()),
+        ),
+        schedule: EscalationScheduleSettings {
+            pm_hours: config
+                .escalation
+                .schedule
+                .pm_hours
+                .clone()
+                .unwrap_or_else(|| DEFAULT_ESCALATION_PM_HOURS.to_string()),
+            timezone: config
+                .escalation
+                .schedule
+                .timezone
+                .clone()
+                .unwrap_or_else(|| DEFAULT_ESCALATION_TIMEZONE.to_string()),
+        },
+    }
+}
+
+/// Load the persisted escalation-settings override from Postgres, if present.
+pub(crate) async fn load_override_pg_async(
+    pool: &sqlx::PgPool,
+) -> Result<Option<EscalationSettings>, String> {
+    let raw = sqlx::query_scalar::<_, String>(
+        "SELECT value
+         FROM kv_meta
+         WHERE key = $1
+         LIMIT 1",
+    )
+    .bind(ESCALATION_SETTINGS_OVERRIDE_KEY)
+    .fetch_optional(pool)
+    .await
+    .map_err(|error| {
+        format!(
+            "load postgres escalation settings override {ESCALATION_SETTINGS_OVERRIDE_KEY}: {error}"
+        )
+    })?;
+    Ok(raw.and_then(|value| serde_json::from_str::<EscalationSettings>(&value).ok()))
+}
+
+/// Resolve effective escalation settings: config defaults overlaid with any
+/// persisted Postgres override.
+pub(crate) fn merged_settings_pg(
+    pool: &sqlx::PgPool,
+    config: &Config,
+) -> Result<EscalationSettings, String> {
+    let defaults = escalation_defaults(config);
+    crate::utils::async_bridge::block_on_pg_result(
+        pool,
+        move |bridge_pool| async move {
+            Ok(load_override_pg_async(&bridge_pool)
+                .await?
+                .unwrap_or(defaults))
+        },
+        |error| error,
+    )
+}
+
+/// Resolve the effective escalation owner user id across available backends.
+pub(crate) fn effective_owner_user_id_with_backends(
+    _db: Option<&crate::db::Db>,
+    pg_pool: Option<&sqlx::PgPool>,
+    config: &Config,
+) -> Option<u64> {
+    if let Some(pool) = pg_pool {
+        match merged_settings_pg(pool, config) {
+            Ok(settings) => return settings.owner_user_id,
+            Err(error) => {
+                tracing::warn!(%error, "[escalation] failed to load postgres escalation settings override");
+            }
+        }
+    }
+
+    escalation_defaults(config).owner_user_id
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -29,6 +29,7 @@ pub mod dispatched_sessions;
 pub mod dispatches;
 pub mod dispatches_followup;
 pub mod envelope_dedup;
+pub mod escalation_settings;
 pub mod gemini;
 pub mod git;
 pub mod issue_announcements;


### PR DESCRIPTION
## 클러스터
**escalation-settings read-path 하향** (DTO/헬퍼 down-shift — 남은 후보 중 가장 자명·저위험 coherent 단위).

서버 라우트(`src/server/routes/escalation.rs`)에 갇혀 있던 escalation-settings 해석 헬퍼를 신규 `crate::services::escalation_settings` 모듈로 하향. 서비스 계층 호출부(`orchestration.rs`)가 더 이상 `crate::server::routes::escalation::*`를 역참조하지 않는다.

이동 심볼:
- `effective_owner_user_id_with_backends`, `merged_settings_pg`, `load_override_pg_async`, `escalation_defaults`, `normalize_optional_string`, `ESCALATION_SETTINGS_OVERRIDE_KEY`
- 의존성은 `crate::config`(이미 services 하위) + `crate::utils::async_bridge`뿐 — AppState/axum/server 타입 무관 → 순환참조 없음.
- 호출부 `src/services/dispatches/discord_delivery/orchestration.rs:42` → 서비스 경로로 갱신. 라우트는 헬퍼를 single-source-of-truth로 re-import(unused-import 0, 미사용 config import 정리). `escalation.rs` -80 LoC(giant 축소).

AppState/axum/ws-eventbus 강결합 클러스터는 의도적으로 손대지 않음(위험). 본 PR은 config 타입에만 의존하는 순수 read-path만 이동.

## backflow
**15 → 14** (`service_server_backflow.json` baseline 갱신; orchestration.rs 항목 제거).

## behavior 불변
순수 코드 relocation. config-defaults + kv_meta-override 해석 로직 바이트 동일. owner 해석은 dispatch delivery에 쓰이며 leader-gated 아님(leader/standby 동일 kv_meta read) → 신규 multinode ownership/lease/singleton 가정 없음 → Audited-touches 항목 불필요(선례: #3233 escalation→config 동일).

## 게이트
- `cargo fmt --check` clean
- `cargo check --lib` / `--lib --tests` clean (신규 경고 0; 기존 경고는 미수정 파일의 dead-code 뿐)
- `cargo test --lib escalation` 3 pass / `cargo test --lib discord_delivery` 20 pass
- backflow baseline 15→14, 회귀 0
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` → freshness passed
- `scripts/ci-script-checks.sh` → exit 0

Refs #3037

🤖 Generated with [Claude Code](https://claude.com/claude-code)