### PR TITLE
fix(#3248): re-seed watcher-owned finalizer ledger on recovery reattach (gap-1)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -576,7 +576,7 @@
     atomic read, closing the present/generation TOCTOU) plus its dedicated accessor unit
     test; the watcher-snapshot no-clobber regression test is retained, rewritten to take
     its G1/G2 snapshots from `external_input_relay_lease(...).map(|l| l.generation)`).
-  - `src/services/discord/recovery_engine.rs` (4034 lines; #3016 phase-5b2
+  - `src/services/discord/recovery_engine.rs` (4094 lines; #3016 phase-5b2
     dropped the `mailbox_finalize_owed` construction from the three recovery
     watcher-spawn handles; +9 from #3166
     fetching real context thresholds for the recovered-turn status panel; +36 from #3099
@@ -589,7 +589,10 @@
     still executes the Discord IO, so behaviour is unchanged); +4 from #3017
     routing the recovery terminal through the single-authority finalizer
     (`submit_terminal` + `FinalizeContext::monitor`) instead of inline
-    `mailbox_finish_turn`).
+    `mailbox_finish_turn`; +60 from #3248 gap-1 adding
+    `reseed_watcher_owned_finalizer_ledger` + two guarded reattach call-sites that
+    re-register the watcher-owned turn in the post-restart finalizer ledger so a
+    mid-turn deploy's live pane auto-reconciles without a new user turn).
   - `src/services/discord/health.rs` (2293 lines after #3038 send-to-agent
     dispatch extraction to `outbound/send_to_agent.rs`; previously 2369 after
     #1879 snapshot/mailbox extraction and #3082 answer-flush-barrier field).

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -556,3 +556,16 @@
   Discord-API probe, and clear/reuse decision is unchanged. No new multinode
   ownership, singleton, or lease assumption is introduced; this is a layering/move
   fix only.
+- #3248 (deploy-survivable relay, gap-1): `recovery_engine.rs` changed by adding
+  `reseed_watcher_owned_finalizer_ledger` and calling it from the two success
+  paths of `reregister_active_turn_from_inflight` (the pane-alive reattach run by
+  recovery after a mid-turn dcserver restart). The new call re-seeds the
+  **in-process** single-authority finalizer ledger (`turn_finalizer` actor) with
+  the watcher-owned `register_start` that the in-memory ledger lost on restart, so
+  the watcher's gate-timeout arms its backstop instead of finalizing-as-orphan.
+  The finalizer ledger is **worker-local** (a per-process in-memory map owned by
+  the watcher/recovery on the SAME node that holds the live tmux pane) — it owns
+  no leader-only side effect, no durable queue, and no PG lease — so re-seeding it
+  introduces no new multinode ownership/singleton/lease assumption. The register
+  is idempotent vs. a later bridge handoff and only ever seeds a full-identity
+  Watcher entry (id-0 guarded); the normal non-restart path is unaffected.

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -27,7 +27,12 @@
 "src/services/discord/mod.rs" = 5187
 "src/services/discord/tui_prompt_relay.rs" = 5120
 "src/services/discord/voice_barge_in.rs" = 4728
-"src/services/discord/recovery_engine.rs" = 4034
+# #3248: +60 for the gap-1 deploy-survivable-relay fix —
+# `reseed_watcher_owned_finalizer_ledger` + two guarded reattach call-sites that
+# re-register the watcher-owned turn in the post-restart finalizer ledger (a P1
+# live-ops fix; the helper is the minimum surface, kept in-file beside its sole
+# caller `reregister_active_turn_from_inflight`).
+"src/services/discord/recovery_engine.rs" = 4094
 "src/services/discord/router/message_handler/intake_turn.rs" = 3771
 "src/services/discord/meeting_orchestrator.rs" = 3227
 "src/services/turn_orchestrator.rs" = 3090

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -1265,6 +1265,45 @@ async fn finish_recovered_turn_mailbox(
     let _ = stop_source;
 }
 
+/// #3248 gap-1 — re-seed the single-authority finalizer ledger for a
+/// watcher-owned turn re-attached by recovery after a mid-turn dcserver restart
+/// (e.g. `SKIP_TURN_DRAIN=1` deploy). The in-memory ledger is empty post-restart,
+/// so without this the watcher's channel-only (id-0) GateTimeout creates a
+/// `RelayOwnerKind::None` entry that finalizes-as-orphan (the 8s gate-backstop
+/// arms only for `relay_owner != None`; the far-backstop reconcile collects only
+/// `relay_owner == Watcher` rows) — the live pane never auto-reconciles until a
+/// NEW user turn. Registering with the Watcher owner reproduces the bridge
+/// handoff (`turn_bridge/mod.rs` `register_start(.., Watcher, ..)`) so the
+/// gate-timeout DEFERS (arms the backstop) and the reconcile can collect the row.
+///
+/// IDEMPOTENT: the actor's `Start` handler is `entry().and_modify().or_insert()`
+/// — never resurrects a `Finalized` turn, `get_or_insert`s the deadline (never
+/// pushes it forward) — so a later bridge handoff `register_start` of the SAME
+/// `TurnKey` is a no-op refresh (the normal, non-restart path is unaffected).
+fn reseed_watcher_owned_finalizer_ledger(
+    shared: &Arc<SharedData>,
+    channel_id: ChannelId,
+    user_msg_id: MessageId,
+    provider: &ProviderKind,
+) {
+    // id-0 would key the channel-only orphan slot; the sole caller already
+    // returns early on id-0, but guard here so this path only ever seeds a
+    // full-identity Watcher entry.
+    if user_msg_id.get() == 0 {
+        return;
+    }
+    shared.turn_finalizer.register_start(
+        super::turn_finalizer::TurnKey::new(
+            channel_id,
+            user_msg_id.get(),
+            shared.current_generation,
+        ),
+        provider.clone(),
+        super::inflight::RelayOwnerKind::Watcher,
+        shared, // #3016 phase-5a: prime the reconcile cache at register time.
+    );
+}
+
 pub(super) async fn reregister_active_turn_from_inflight(
     shared: &Arc<SharedData>,
     state: &inflight::InflightTurnState,
@@ -1312,7 +1351,13 @@ pub(super) async fn reregister_active_turn_from_inflight(
                 "inflight reregister existing active turn",
             );
         }
-        return snapshot.active_user_message_id == Some(user_msg_id);
+        let restored = snapshot.active_user_message_id == Some(user_msg_id);
+        if restored {
+            // #3248 gap-1: existing-active-turn rebind — re-seed the empty
+            // post-restart ledger so the watcher gate-timeout arms its backstop.
+            reseed_watcher_owned_finalizer_ledger(shared, channel_id, user_msg_id, &provider);
+        }
+        return restored;
     }
 
     let cancel_token = Arc::new(CancelToken::new());
@@ -1323,14 +1368,21 @@ pub(super) async fn reregister_active_turn_from_inflight(
         "inflight reregister active turn",
     );
 
-    super::mailbox_try_start_turn(
+    let started = super::mailbox_try_start_turn(
         shared,
         channel_id,
         cancel_token,
         UserId::new(state.request_owner_user_id),
         user_msg_id,
     )
-    .await
+    .await;
+    if started {
+        // #3248 gap-1: freshly re-attached active turn — seed the empty
+        // post-restart ledger with the Watcher owner (idempotent vs. a later
+        // bridge handoff) so the live pane auto-reconciles without a new user turn.
+        reseed_watcher_owned_finalizer_ledger(shared, channel_id, user_msg_id, &provider);
+    }
+    started
 }
 #[cfg(unix)]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -4528,5 +4580,130 @@ mod post_work_evidence_tests {
         state.any_tool_used = false;
         state.last_tool_summary = Some("Bash completed".to_string());
         assert!(recovery_has_post_work_ready_evidence(&state));
+    }
+}
+
+// #3248 gap-1 — the pane-alive reattach path (`reregister_active_turn_from_inflight`)
+// must re-seed the single-authority finalizer ledger with a Watcher-owned entry
+// after a mid-turn dcserver restart clears the in-memory ledger. Without it the
+// live pane never auto-reconciles (the watcher's id-0 gate-timeout creates a
+// `relay_owner=None` orphan that finalizes immediately instead of arming the 8s
+// backstop, and the far-backstop reconcile — which collects only
+// `relay_owner==Watcher` rows — never catches it), so a NEW user turn is required.
+#[cfg(test)]
+mod reregister_ledger_reseed_tests {
+    use super::inflight::InflightTurnState;
+    use crate::services::provider::ProviderKind;
+    use serenity::model::id::ChannelId;
+
+    fn active_turn_state(channel_id: u64, user_msg_id: u64) -> InflightTurnState {
+        // A live (not-yet-committed) ordinary turn whose ids are all non-zero, so
+        // it passes the `reregister_active_turn_from_inflight` early guard and is
+        // NOT short-circuited by `recovery_terminal_delivery_already_committed`.
+        InflightTurnState::new(
+            ProviderKind::Claude,
+            channel_id,
+            Some("adk-cc".to_string()),
+            7, // request_owner_user_id
+            user_msg_id,
+            user_msg_id + 1, // current_msg_id
+            "live prompt".to_string(),
+            Some("session".to_string()),
+            Some("AgentDesk-claude-adk-cc".to_string()),
+            Some("/tmp/claude-transcript.jsonl".to_string()),
+            None,
+            0,
+        )
+    }
+
+    // Gap-1: a fresh reattach (empty mailbox → mailbox turn started) re-seeds the
+    // ledger so the turn is a LIVE Watcher-pending entry. This is precisely the
+    // state that makes the watcher's gate-timeout arm its backstop instead of
+    // finalizing-as-orphan, and makes the far-backstop reconcile able to collect
+    // the row — so the live pane auto-reconciles WITHOUT a new user turn.
+    #[tokio::test(flavor = "current_thread")]
+    async fn reattach_reseeds_watcher_owned_ledger_entry() {
+        let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
+        let ch = ChannelId::new(52_481);
+        let state = active_turn_state(ch.get(), 9001);
+
+        // Pre-condition: post-restart the in-memory ledger is empty — no
+        // watcher-pending entry exists for this turn yet.
+        assert!(
+            !shared
+                .turn_finalizer
+                .has_live_watcher_pending(ch, shared.current_generation)
+                .await,
+            "ledger must start empty (simulating a post-restart in-memory ledger)"
+        );
+
+        let restored = super::reregister_active_turn_from_inflight(&shared, &state).await;
+        assert!(
+            restored,
+            "an empty mailbox must let the reattach start the active turn"
+        );
+
+        // Post-condition: the ledger now has a LIVE Watcher-owned entry under the
+        // turn's full identity + the current (restart) generation.
+        assert!(
+            shared
+                .turn_finalizer
+                .has_live_watcher_pending(ch, shared.current_generation)
+                .await,
+            "#3248 gap-1: reattach must register_start the turn as Watcher-owned"
+        );
+    }
+
+    // Idempotency: a second reattach of the SAME turn (or a later bridge handoff
+    // register_start) must NOT error or duplicate/over-finalize — the actor's
+    // `Start` handler is entry().and_modify().or_insert() and never resurrects a
+    // finalized turn. The turn stays a single live Watcher-pending entry.
+    #[tokio::test(flavor = "current_thread")]
+    async fn repeated_reattach_is_idempotent_single_watcher_entry() {
+        let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
+        let ch = ChannelId::new(52_482);
+        let state = active_turn_state(ch.get(), 9101);
+
+        assert!(super::reregister_active_turn_from_inflight(&shared, &state).await);
+        // Second call: the mailbox already holds the active turn, so this takes
+        // the "existing active turn" rebind branch and re-seeds again.
+        let restored_again = super::reregister_active_turn_from_inflight(&shared, &state).await;
+        assert!(
+            restored_again,
+            "re-attaching an already-active turn re-binds (returns true) without panic"
+        );
+
+        // Still exactly one live Watcher-pending entry (idempotent re-register).
+        assert!(
+            shared
+                .turn_finalizer
+                .has_live_watcher_pending(ch, shared.current_generation)
+                .await,
+            "repeated reattach keeps a single live Watcher-pending entry"
+        );
+    }
+
+    // Safety: a recovery turn WITHOUT a real user_msg_id (== 0) must be skipped by
+    // the early guard — it must NOT register a channel-only (id-0) orphan ledger
+    // entry that could collide with the watcher's id-0 submissions.
+    #[tokio::test(flavor = "current_thread")]
+    async fn zero_user_msg_id_is_not_registered() {
+        let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
+        let ch = ChannelId::new(52_483);
+        // user_msg_id == 0 (and thus the early guard returns false before any
+        // register_start).
+        let mut state = active_turn_state(ch.get(), 0);
+        state.user_msg_id = 0;
+        state.current_msg_id = 0;
+
+        let restored = super::reregister_active_turn_from_inflight(&shared, &state).await;
+        assert!(!restored, "a zero-id recovery turn is not re-attached");
+        assert!(
+            !shared
+                .turn_finalizer
+                .has_live_watcher_pending(ch, shared.current_generation)
+                .await,
+            "a zero user_msg_id turn must NOT seed an orphan ledger entry"
+        );
     }
 }


### PR DESCRIPTION
## 문제 (#3248)
`SKIP_TURN_DRAIN=1` mid-turn dcserver 재시작(배포) 후, 활성 채널 terminal relay가 멈추고 ⏳만 남으며 **새 사용자 턴이 와야** reconcile됨.

**근본 원인 (갭1)**: pane-alive watcher 재부착 경로 `recovery_engine.rs`의 `reregister_active_turn_from_inflight`가 mailbox cancel_token만 재바인딩하고 `turn_finalizer.register_start`를 호출 안 함. 재시작 후 in-memory finalizer ledger가 비어 재부착 턴은 엔트리 없음 → watcher의 id-0 GateTimeout이 `relay_owner=None` orphan 엔트리 생성 → 8s 백스톱 미arm(`relay_owner != None`일 때만 arm) + far-backstop 미수집(`relay_owner==Watcher` Pending만 수집).

## 갭1 구현
- **`recovery_engine.rs`**: `reseed_watcher_owned_finalizer_ledger` 헬퍼 추가, `reregister_active_turn_from_inflight`의 두 success 반환점(기존 active-turn rebind + fresh mailbox start)에서 호출.
- 등록 형태는 production 핸드오프(`turn_bridge/mod.rs:4186` `register_start(...)`)와 **100% 동일**: `register_start(TurnKey::new(channel_id, user_msg_id, shared.current_generation), provider.clone(), RelayOwnerKind::Watcher, shared)` — #3016 phase-5a의 `&Arc<SharedData>` reconcile-cache 프라이밍 포함.
- 결과: GateTimeout이 이제 DEFER(8s 백스톱 arm) + far-backstop reconcile가 row 수집 → 새 턴 없이 watcher가 다음 pass에서 relay.

### 멱등성/중복 방지
- actor `Start` 핸들러는 `entry().and_modify().or_insert()` — `Finalized` 턴 resurrect 안 함, `watcher_backstop_deadline.get_or_insert_with(...)`로 deadline 앞당김 없음. 이후 bridge 핸드오프가 같은 `TurnKey`로 `register_start`해도 no-op refresh (정상 non-restart 경로 무영향).
- `user_msg_id == 0` 가드(헬퍼 + caller 조기 return) → 실 user id 없는 recovery 턴 미등록 (channel-only orphan 슬롯 미생성).
- `generation = shared.current_generation` (기존 호출처 동일).

### 정상 경로 무영향
register_start는 오직 재시작 재부착 성공 시에만 추가. 정상 턴은 bridge 핸드오프로 기존과 동일 등록, 재시작이 아니면 reregister 자체가 미호출.

## 갭2 평가 — 미구현 (안전상 의도적)
- terminal relay(Discord EDIT/POST)는 watcher terminal 블록 **상단**(`tmux_watcher.rs:9354+` `relay_decision`)에서 gate 결정 **이전에** 실행 — unpaused watcher면 무조건 relay. `lifecycle_stage_paused` gate는 user-visible **completion emit**(✅/패널 finalize)만 억제하지 assistant-text relay를 막지 않음.
- 복구 watcher는 세 spawn 사이트 모두 `paused = AtomicBool::new(false)`(recovery_engine.rs:2557/3692/4444) — **unpaused** spawn. 따라서 갭1만으로 relay 회복:
  - pane quiesce(흔한 배포 케이스): ConfirmedIdle → relay + completion emit.
  - pane busy(TimedOut): relay는 이미 수행, completion만 defer; 갭1로 GateTimeout이 8s 백스톱 arm → 이후 quiesce pass에서 completion emit.
- `do_finalize`/`run_backstop_finalize`는 relay 안 하고 inflight/mailbox cleanup만 — relay 불필요.
- **갭2 미구현 이유**: backstop은 finalizer actor에서 실행되어 watcher의 committed-offset/lease 접근 불가 → watcher relay 블록과 backstop이 같은 terminal을 둘 다 post하는 **double-post**를 막는다고 코드로 입증 불가. 위험이 크므로 미구현.

## 테스트
회귀 테스트 3건(`recovery_engine.rs` `reregister_ledger_reseed_tests`):
- `reattach_reseeds_watcher_owned_ledger_entry`: 재부착이 Watcher-owned 엔트리 등록(`has_live_watcher_pending` true).
- `repeated_reattach_is_idempotent_single_watcher_entry`: 중복 재부착이 단일 live Watcher 엔트리 유지, panic/over-finalize 없음.
- `zero_user_msg_id_is_not_registered`: user_msg_id==0 recovery 턴 미등록.

기존 suite 통과: turn_finalizer 69 / recovery_engine 26 / tmux_watcher 150.

## 게이트
- `cargo fmt --check` clean / `cargo check --lib` clean(신규 경고 0; 기존 2 baseline 경고만) / `cargo check --lib --tests` clean
- giant ratchet: recovery_engine 4034→4094(+60, 정당 사유 inline 명시 — gap-1 P1 live-ops fix 최소 surface)
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` freshness passed(change-surfaces.md sync)
- multinode-transition.md ### Audited touches에 #3248 추가(finalizer ledger = worker-local 분류)
- `bash scripts/ci-script-checks.sh` → exit 0

Refs #3248 (닫지 않음 — codex 다라운드 후 caller가 머지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)