### PR TITLE
refactor(#3038): extract SensitivityState to voice_sensitivity sibling

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -543,6 +543,7 @@ src/
 │   │   ├── voice_config_cache.rs
 │   │   ├── voice_id_sequences.rs
 │   │   ├── voice_routing.rs
+│   │   ├── voice_sensitivity.rs
 │   │   └── watcher_panel_parity.rs
 │   ├── dispatches/
 │   │   ├── discord_delivery/

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -673,7 +673,7 @@
     inline — its move-captured locals make a clean extraction risky and is
     deferred).
   - `src/services/discord/session_runtime.rs` (1781 lines).
-  - `src/services/discord/voice_barge_in.rs` (4728 lines; voice STT/TTS,
+  - `src/services/discord/voice_barge_in.rs` (4657 lines; voice STT/TTS,
     lobby routing, progress mirroring, and barge-in orchestration surface;
     tracked decompose target — see `giant-file-registry.md` (owner
     `voice-runtime`, deadline 2026-08-31, #3036)).

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -24,9 +24,11 @@
 # turn-lifecycle surface were mislabeled test. This is the actual #3028 guard;
 # decompose lands separately after #3016 settles.
 "src/services/discord/turn_bridge/mod.rs" = 8417
-"src/services/discord/mod.rs" = 5187
+"src/services/discord/mod.rs" = 5188
 "src/services/discord/tui_prompt_relay.rs" = 5120
-"src/services/discord/voice_barge_in.rs" = 4728
+# #3038: lowered 4728 -> 4657 (-71) as `SensitivityState` (definition + impl)
+# moved to the `voice_sensitivity` sibling module. Locks in the shrink win.
+"src/services/discord/voice_barge_in.rs" = 4657
 # #3248: +60 for the gap-1 deploy-survivable-relay fix —
 # `reseed_watcher_owned_finalizer_ledger` + two guarded reattach call-sites that
 # re-register the watcher-owned turn in the post-restart finalizer ledger (a P1

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -95,6 +95,7 @@ mod voice_barge_in;
 mod voice_config_cache;
 mod voice_id_sequences;
 mod voice_routing;
+mod voice_sensitivity;
 #[path = "watchers/lifecycle_decision.rs"]
 mod watcher_lifecycle_decision;
 

--- a/src/services/discord/voice_barge_in.rs
+++ b/src/services/discord/voice_barge_in.rs
@@ -13,8 +13,8 @@ use tokio_util::sync::CancellationToken;
 
 use crate::services::provider::ProviderKind;
 use crate::voice::barge_in::{
-    BargeInPlayerStop, BargeInSensitivity, BargeInSensitivityState, DeferredBargeInBuffer,
-    LiveBargeInCut, LiveBargeInMonitor, ProcessingBargeInDecision, run_sensitivity_ttl_reset,
+    BargeInPlayerStop, BargeInSensitivity, DeferredBargeInBuffer, LiveBargeInCut,
+    LiveBargeInMonitor, ProcessingBargeInDecision, run_sensitivity_ttl_reset,
 };
 use crate::voice::commands::{
     DEFAULT_WAKE_WORD, VoiceActiveAgentContext, VoiceCommand, VoiceLobbyRouteDecision,
@@ -43,6 +43,7 @@ use super::voice_background_driver::{
 };
 use super::voice_config_cache::ConfigSnapshotCache;
 use super::voice_id_sequences::VoiceIdSequences;
+use super::voice_sensitivity::SensitivityState;
 pub(in crate::services::discord) const INTERNAL_VOICE_MESSAGE_ID_START: u64 =
     9_000_000_000_000_000_000;
 
@@ -1098,78 +1099,6 @@ impl VoiceProgressChannelState {
 
 fn progress_feedback_channel_id(channel_id: u64, playback_channel_id: Option<u64>) -> u64 {
     playback_channel_id.unwrap_or(channel_id)
-}
-
-/// Cohesive sub-concern of [`VoiceBargeInRuntime`]: the live barge-in
-/// sensitivity state (#3038 STT/TTS/playback/routing split, sensitivity slice).
-///
-/// Bundles the three sensitivity-related fields that previously lived directly
-/// on `VoiceBargeInRuntime`. Behavior is preserved exactly: the atomic mirror is
-/// always stored *before* the `RwLock` write (F18, #2046), and `current` falls
-/// back to the atomic mirror on `try_read` contention.
-struct SensitivityState {
-    // F18 (#2046): boot-time default. Retained for parity with the original
-    // field layout; never read after construction.
-    #[allow(dead_code)]
-    default_sensitivity: BargeInSensitivity,
-    // F18 (#2046): RwLock try_read 실패 시 default 로 폴백하면 사용자가 설정한
-    // Conservative 가 잠깐 Normal 로 잘못 평가될 수 있다. 최신 값을 lock-free 로
-    // 읽을 수 있도록 atomic mirror 유지.
-    atom: std::sync::atomic::AtomicU8,
-    state: Arc<RwLock<BargeInSensitivityState>>,
-}
-
-impl SensitivityState {
-    fn new(default_sensitivity: BargeInSensitivity, conservative_ttl: Duration) -> Self {
-        Self {
-            default_sensitivity,
-            atom: std::sync::atomic::AtomicU8::new(default_sensitivity.as_u8()),
-            state: Arc::new(RwLock::new(BargeInSensitivityState::new(
-                default_sensitivity,
-                conservative_ttl,
-            ))),
-        }
-    }
-
-    fn disabled() -> Self {
-        let default_sensitivity = BargeInSensitivity::Normal;
-        Self {
-            default_sensitivity,
-            atom: std::sync::atomic::AtomicU8::new(default_sensitivity.as_u8()),
-            state: Arc::new(RwLock::new(BargeInSensitivityState::default())),
-        }
-    }
-
-    /// Clone the shared `RwLock` handle for the TTL reset background task.
-    fn state_handle(&self) -> Arc<RwLock<BargeInSensitivityState>> {
-        self.state.clone()
-    }
-
-    /// F18 (#2046): atomic mirror 를 먼저 갱신해 두면 try_read 충돌 윈도우에서도
-    /// `current` 가 최신 값을 본다.
-    async fn set(&self, sensitivity: BargeInSensitivity) {
-        self.atom.store(sensitivity.as_u8(), Ordering::Relaxed);
-        self.state
-            .write()
-            .await
-            .set_sensitivity(sensitivity, Instant::now());
-    }
-
-    async fn apply_voice_command(&self, transcript: &str) -> Option<BargeInSensitivity> {
-        self.state
-            .write()
-            .await
-            .apply_voice_command(transcript, Instant::now())
-    }
-
-    /// F18 (#2046): try_read 실패 시 boot-time default 가 아닌 가장 최근에
-    /// 설정된 sensitivity 를 반환하도록 atomic mirror 로 폴백한다.
-    fn current(&self) -> BargeInSensitivity {
-        self.state
-            .try_read()
-            .map(|state| state.sensitivity())
-            .unwrap_or_else(|_| BargeInSensitivity::from_u8(self.atom.load(Ordering::Relaxed)))
-    }
 }
 
 /// Cohesive sub-concern of [`VoiceBargeInRuntime`]: the streaming-STT per-user

--- a/src/services/discord/voice_sensitivity.rs
+++ b/src/services/discord/voice_sensitivity.rs
@@ -1,0 +1,107 @@
+//! Live barge-in sensitivity state extracted from `VoiceBargeInRuntime`
+//! (#3038 god-object split, sensitivity slice).
+//!
+//! Hosts [`SensitivityState`], the three sensitivity-related fields
+//! (`default_sensitivity` boot default, lock-free `AtomicU8` mirror, and the
+//! shared `Arc<RwLock<BargeInSensitivityState>>`) that previously lived directly
+//! on `VoiceBargeInRuntime`. Moving them into this sibling module isolates the
+//! concern and physically shrinks the `voice_barge_in.rs` giant rather than
+//! re-inflating it.
+//!
+//! Concurrency semantics are preserved byte-for-byte relative to the
+//! pre-extraction layout:
+//! - the `AtomicU8` mirror is always stored *before* the `RwLock` write
+//!   (F18, #2046), so a concurrent `try_read` failure never regresses to the
+//!   boot-time default;
+//! - `current()` falls back to the atomic mirror (not the boot default) on
+//!   `try_read` contention;
+//! - the exact memory `Ordering` (`Relaxed` on both store and load) and the
+//!   `Arc<RwLock<_>>` sharing of `state_handle()` are unchanged.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::time::{Duration, Instant};
+
+use tokio::sync::RwLock;
+
+use crate::voice::barge_in::{BargeInSensitivity, BargeInSensitivityState};
+
+/// Cohesive sub-concern of `VoiceBargeInRuntime`: the live barge-in
+/// sensitivity state (#3038 STT/TTS/playback/routing split, sensitivity slice).
+///
+/// Bundles the three sensitivity-related fields that previously lived directly
+/// on `VoiceBargeInRuntime`. Behavior is preserved exactly: the atomic mirror is
+/// always stored *before* the `RwLock` write (F18, #2046), and `current` falls
+/// back to the atomic mirror on `try_read` contention.
+pub(in crate::services::discord) struct SensitivityState {
+    // F18 (#2046): boot-time default. Retained for parity with the original
+    // field layout; never read after construction.
+    #[allow(dead_code)]
+    default_sensitivity: BargeInSensitivity,
+    // F18 (#2046): RwLock try_read 실패 시 default 로 폴백하면 사용자가 설정한
+    // Conservative 가 잠깐 Normal 로 잘못 평가될 수 있다. 최신 값을 lock-free 로
+    // 읽을 수 있도록 atomic mirror 유지.
+    atom: AtomicU8,
+    state: Arc<RwLock<BargeInSensitivityState>>,
+}
+
+impl SensitivityState {
+    pub(in crate::services::discord) fn new(
+        default_sensitivity: BargeInSensitivity,
+        conservative_ttl: Duration,
+    ) -> Self {
+        Self {
+            default_sensitivity,
+            atom: AtomicU8::new(default_sensitivity.as_u8()),
+            state: Arc::new(RwLock::new(BargeInSensitivityState::new(
+                default_sensitivity,
+                conservative_ttl,
+            ))),
+        }
+    }
+
+    pub(in crate::services::discord) fn disabled() -> Self {
+        let default_sensitivity = BargeInSensitivity::Normal;
+        Self {
+            default_sensitivity,
+            atom: AtomicU8::new(default_sensitivity.as_u8()),
+            state: Arc::new(RwLock::new(BargeInSensitivityState::default())),
+        }
+    }
+
+    /// Clone the shared `RwLock` handle for the TTL reset background task.
+    pub(in crate::services::discord) fn state_handle(
+        &self,
+    ) -> Arc<RwLock<BargeInSensitivityState>> {
+        self.state.clone()
+    }
+
+    /// F18 (#2046): atomic mirror 를 먼저 갱신해 두면 try_read 충돌 윈도우에서도
+    /// `current` 가 최신 값을 본다.
+    pub(in crate::services::discord) async fn set(&self, sensitivity: BargeInSensitivity) {
+        self.atom.store(sensitivity.as_u8(), Ordering::Relaxed);
+        self.state
+            .write()
+            .await
+            .set_sensitivity(sensitivity, Instant::now());
+    }
+
+    pub(in crate::services::discord) async fn apply_voice_command(
+        &self,
+        transcript: &str,
+    ) -> Option<BargeInSensitivity> {
+        self.state
+            .write()
+            .await
+            .apply_voice_command(transcript, Instant::now())
+    }
+
+    /// F18 (#2046): try_read 실패 시 boot-time default 가 아닌 가장 최근에
+    /// 설정된 sensitivity 를 반환하도록 atomic mirror 로 폴백한다.
+    pub(in crate::services::discord) fn current(&self) -> BargeInSensitivity {
+        self.state
+            .try_read()
+            .map(|state| state.sensitivity())
+            .unwrap_or_else(|_| BargeInSensitivity::from_u8(self.atom.load(Ordering::Relaxed)))
+    }
+}


### PR DESCRIPTION
## Summary

Continues the #3038 god-object split by physically moving the live barge-in **`SensitivityState`** sub-struct (definition + impl) out of the `voice_barge_in.rs` giant into a new sibling `src/services/discord/voice_sensitivity.rs`. Follows the same pattern as AcknowledgementConfig (#3237), ConfigSnapshotCache (#3242), VoiceIdSequences (#3244).

## Why this sub-struct (selection + reason)

Of the remaining in-file candidates (`SensitivityState`, `StreamingSttSessions`, `VoiceProgressChannelState`), `SensitivityState` has the **highest cohesion and shallowest external coupling**:
- All 8 call-sites go through methods (`self.sensitivity.{set,apply_voice_command,current,state_handle,new,disabled}`) — no leaked field access.
- Depends only on already-public external types (`BargeInSensitivity`, `BargeInSensitivityState` from `crate::voice::barge_in`); no in-file private type dependency.

The other candidates are deliberately left in-file (too entangled):
- `StreamingSttSessions` is keyed by the in-file private `StreamingSttKey` and hands back `&DashMap` with entry guards held across `await` during session finalization.
- `VoiceProgressChannelState` is woven into progress-driver methods (`HashMap<u64, VoiceProgressChannelState>` locals) that stay in-file.

## Moved symbols

`SensitivityState` struct + impl (was `voice_barge_in.rs:1103-1173`) → `voice_sensitivity.rs`. `VoiceBargeInRuntime` keeps the `sensitivity: SensitivityState` field and only calls into it. Visibility minimized to `pub(in crate::services::discord)`.

## Concurrency preservation (byte-identical)

- `AtomicU8` mirror is stored **before** the `RwLock` write (F18, #2046).
- `current()` falls back to the atomic mirror (not the boot default) on `try_read` contention.
- Exact `Relaxed` memory `Ordering` on both store and load is unchanged.
- `state_handle()` clones the same `Arc<RwLock<BargeInSensitivityState>>` consumed by the TTL-reset background task.

Behavior is unchanged — no locking, ordering, or seed/consume change.

## LoC change

- `voice_barge_in.rs` production: **4728 → 4657 (-71)** — baseline lowered.
- `mod.rs`: +1 for module registration (baseline 5187 → 5188).
- `voice_sensitivity.rs` is below the 1000-LoC giant threshold (no new baseline entry).

## Gates

- `cargo fmt --check` clean
- `cargo check --lib` / `cargo check --lib --tests` clean (0 new warnings; remaining warnings are pre-existing in unrelated files)
- `cargo test --lib voice_barge_in` → 52 passed
- giant ratchet + agent-maintenance freshness → passed (change-surfaces freeze synced)
- `bash scripts/ci-script-checks.sh` → exit 0

Refs #3038

🤖 Generated with [Claude Code](https://claude.com/claude-code)