### PR TITLE
refactor(#3037): extract WS broadcast bus to crate::eventbus (backflow -5)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -738,6 +738,7 @@ src/
 ├── config.rs
 ├── credential.rs
 ├── error.rs
+├── eventbus.rs
 ├── high_risk_recovery.rs
 ├── launch.rs
 ├── lib.rs
@@ -779,6 +780,7 @@ This table is generated from the current `src/` root and fails CI when a new top
 | `src/config.rs` | `agentdesk.yaml` parsing, configuration defaults, and shared test env helpers. |
 | `src/credential.rs` | Reads runtime credential files such as Discord bot tokens from the AgentDesk root. |
 | `src/error.rs` | Shared HTTP and policy error type with typed codes and JSON response helpers. |
+| `src/eventbus.rs` | In-process broadcast event bus (history/replay/batching) shared by the WS server layer and background services without a service→server backflow. |
 | `src/high_risk_recovery.rs` | PG-only high-risk recovery tests for boot reconciliation and review refire paths. |
 | `src/launch.rs` | Starts the Tokio runtime and hands off to server boot. |
 | `src/lib.rs` | Library crate boundary that exposes the server/CLI modules for the slim binary entry point and tests. |

--- a/scripts/generate_inventory_docs.py
+++ b/scripts/generate_inventory_docs.py
@@ -109,6 +109,7 @@ TOP_LEVEL_MODULE_PURPOSES = {
     "dispatch/": "Dispatch context construction, review metadata, and worktree targeting.",
     "engine/": "QuickJS policy runtime, hook wiring, transition logic, and Rust-JS bridge ops.",
     "error.rs": "Shared HTTP and policy error type with typed codes and JSON response helpers.",
+    "eventbus.rs": "In-process broadcast event bus (history/replay/batching) shared by the WS server layer and background services without a service→server backflow.",
     "github/": "GitHub sync, issue triage, and Definition-of-Done mirroring.",
     "high_risk_recovery.rs": "PG-only high-risk recovery tests for boot reconciliation and review refire paths.",
     "kanban/": "High-level kanban orchestration, state machine facade, and shared test support.",

--- a/src/eventbus.rs
+++ b/src/eventbus.rs
@@ -1,0 +1,161 @@
+//! In-process broadcast event bus for pushing live events to dashboard clients.
+//!
+//! This is shared infrastructure consumed by both the HTTP/WebSocket server
+//! layer (`crate::server::ws`, which owns the axum upgrade handler and re-exports
+//! these primitives) and background services (`crate::services::*`). It lives at
+//! the crate root — below both `server` and `services` in the dependency graph —
+//! so services can emit events without reaching up into `crate::server`
+//! (#3037 service→server backflow removal). The axum `ws_handler`/`handle_socket`
+//! that consume these primitives remain in `crate::server::ws`.
+
+use serde_json::json;
+use std::collections::{HashMap, VecDeque};
+use std::sync::{
+    Arc, Mutex as StdMutex,
+    atomic::{AtomicU64, Ordering},
+};
+use tokio::sync::{Mutex, broadcast};
+
+/// Shared broadcast sender for pushing events to all connected WS clients.
+pub type BroadcastTx = Arc<BroadcastBus>;
+
+/// Buffer for batched events — groups events by key, flushes periodically.
+pub type BatchBuffer = Arc<Mutex<HashMap<String, PendingEvent>>>;
+
+const BROADCAST_HISTORY_LIMIT: usize = 256;
+
+#[derive(Clone, Debug)]
+pub struct BroadcastEvent {
+    pub id: String,
+    pub event: String,
+    pub data: serde_json::Value,
+}
+
+impl BroadcastEvent {
+    pub(crate) fn as_ws_message(&self) -> String {
+        json!({
+            "id": self.id,
+            "type": self.event,
+            "data": self.data,
+        })
+        .to_string()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PendingEvent {
+    event: String,
+    data: serde_json::Value,
+}
+
+pub struct BroadcastBus {
+    tx: broadcast::Sender<BroadcastEvent>,
+    history: StdMutex<VecDeque<BroadcastEvent>>,
+    next_event_id: AtomicU64,
+}
+
+impl BroadcastBus {
+    fn new() -> Self {
+        let (tx, _) = broadcast::channel::<BroadcastEvent>(256);
+        Self {
+            tx,
+            history: StdMutex::new(VecDeque::with_capacity(BROADCAST_HISTORY_LIMIT)),
+            next_event_id: AtomicU64::new(1),
+        }
+    }
+
+    fn send(&self, event: &str, data: serde_json::Value) -> BroadcastEvent {
+        let envelope = BroadcastEvent {
+            id: self
+                .next_event_id
+                .fetch_add(1, Ordering::Relaxed)
+                .to_string(),
+            event: event.to_string(),
+            data,
+        };
+        if let Ok(mut history) = self.history.lock() {
+            if history.len() >= BROADCAST_HISTORY_LIMIT {
+                history.pop_front();
+            }
+            history.push_back(envelope.clone());
+        }
+        let _ = self.tx.send(envelope.clone());
+        envelope
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<BroadcastEvent> {
+        self.tx.subscribe()
+    }
+
+    pub fn replay_since(&self, last_event_id: &str) -> Vec<BroadcastEvent> {
+        let Ok(last_seen) = last_event_id.parse::<u64>() else {
+            return Vec::new();
+        };
+        self.history
+            .lock()
+            .map(|history| {
+                history
+                    .iter()
+                    .filter(|event| {
+                        event
+                            .id
+                            .parse::<u64>()
+                            .ok()
+                            .is_some_and(|event_id| event_id > last_seen)
+                    })
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
+pub fn new_broadcast() -> BroadcastTx {
+    Arc::new(BroadcastBus::new())
+}
+
+/// Immediately emit an event to all connected WebSocket clients.
+pub fn emit_event(tx: &BroadcastTx, event_name: &str, payload: serde_json::Value) {
+    tx.send(event_name, payload);
+}
+
+/// Queue a batched event — deduplicates by key, flushed periodically.
+pub fn emit_batched_event(
+    buffer: &BatchBuffer,
+    event_name: &str,
+    key: impl Into<String>,
+    payload: serde_json::Value,
+) {
+    let key = key.into();
+    let event_name = event_name.to_string();
+    let buffer = buffer.clone();
+    tokio::spawn(async move {
+        buffer.lock().await.insert(
+            key,
+            PendingEvent {
+                event: event_name,
+                data: payload,
+            },
+        );
+    });
+}
+
+/// Spawn background flusher that drains batch buffer every 200ms.
+pub fn spawn_batch_flusher(tx: BroadcastTx) -> BatchBuffer {
+    let buffer: BatchBuffer = Arc::new(Mutex::new(HashMap::new()));
+    let flush_buffer = buffer.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_millis(200));
+        loop {
+            interval.tick().await;
+            let mut buf = flush_buffer.lock().await;
+            if buf.is_empty() {
+                continue;
+            }
+            for (_key, pending) in buf.drain() {
+                tx.send(&pending.event, pending.data);
+            }
+        }
+    });
+    buffer
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,9 @@ mod engine;
 // Error-code helpers are kept for API response boundaries that only some
 // routes currently surface.
 mod error;
+// In-process broadcast event bus shared by the WS server layer and background
+// services; lives at crate root to avoid a service→server backflow (#3037).
+mod eventbus;
 mod github;
 pub(crate) mod kanban;
 mod launch;

--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -1,3 +1,11 @@
+//! WebSocket upgrade handler (axum) for the dashboard live feed.
+//!
+//! The broadcast bus primitives (`BroadcastBus`, `BroadcastTx`, `emit_event`,
+//! `emit_batched_event`, …) live in `crate::eventbus` so background services can
+//! emit events without a service→server backflow (#3037). They are re-exported
+//! here for backward compatibility, so existing `crate::server::ws::*` call sites
+//! continue to resolve unchanged.
+
 use axum::{
     extract::{
         State,
@@ -8,156 +16,11 @@ use axum::{
 };
 use futures::{SinkExt, StreamExt};
 use serde_json::json;
-use std::collections::{HashMap, VecDeque};
-use std::sync::{
-    Arc, Mutex as StdMutex,
-    atomic::{AtomicU64, Ordering},
+use tokio::sync::broadcast;
+
+pub use crate::eventbus::{
+    BatchBuffer, BroadcastEvent, BroadcastTx, emit_event, new_broadcast, spawn_batch_flusher,
 };
-use tokio::sync::{Mutex, broadcast};
-
-/// Shared broadcast sender for pushing events to all connected WS clients.
-pub type BroadcastTx = Arc<BroadcastBus>;
-
-/// Buffer for batched events — groups events by key, flushes periodically.
-pub type BatchBuffer = Arc<Mutex<HashMap<String, PendingEvent>>>;
-
-const BROADCAST_HISTORY_LIMIT: usize = 256;
-
-#[derive(Clone, Debug)]
-pub struct BroadcastEvent {
-    pub id: String,
-    pub event: String,
-    pub data: serde_json::Value,
-}
-
-impl BroadcastEvent {
-    fn as_ws_message(&self) -> String {
-        json!({
-            "id": self.id,
-            "type": self.event,
-            "data": self.data,
-        })
-        .to_string()
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct PendingEvent {
-    event: String,
-    data: serde_json::Value,
-}
-
-pub struct BroadcastBus {
-    tx: broadcast::Sender<BroadcastEvent>,
-    history: StdMutex<VecDeque<BroadcastEvent>>,
-    next_event_id: AtomicU64,
-}
-
-impl BroadcastBus {
-    fn new() -> Self {
-        let (tx, _) = broadcast::channel::<BroadcastEvent>(256);
-        Self {
-            tx,
-            history: StdMutex::new(VecDeque::with_capacity(BROADCAST_HISTORY_LIMIT)),
-            next_event_id: AtomicU64::new(1),
-        }
-    }
-
-    fn send(&self, event: &str, data: serde_json::Value) -> BroadcastEvent {
-        let envelope = BroadcastEvent {
-            id: self
-                .next_event_id
-                .fetch_add(1, Ordering::Relaxed)
-                .to_string(),
-            event: event.to_string(),
-            data,
-        };
-        if let Ok(mut history) = self.history.lock() {
-            if history.len() >= BROADCAST_HISTORY_LIMIT {
-                history.pop_front();
-            }
-            history.push_back(envelope.clone());
-        }
-        let _ = self.tx.send(envelope.clone());
-        envelope
-    }
-
-    pub fn subscribe(&self) -> broadcast::Receiver<BroadcastEvent> {
-        self.tx.subscribe()
-    }
-
-    pub fn replay_since(&self, last_event_id: &str) -> Vec<BroadcastEvent> {
-        let Ok(last_seen) = last_event_id.parse::<u64>() else {
-            return Vec::new();
-        };
-        self.history
-            .lock()
-            .map(|history| {
-                history
-                    .iter()
-                    .filter(|event| {
-                        event
-                            .id
-                            .parse::<u64>()
-                            .ok()
-                            .is_some_and(|event_id| event_id > last_seen)
-                    })
-                    .cloned()
-                    .collect()
-            })
-            .unwrap_or_default()
-    }
-}
-
-pub fn new_broadcast() -> BroadcastTx {
-    Arc::new(BroadcastBus::new())
-}
-
-/// Immediately emit an event to all connected WebSocket clients.
-pub fn emit_event(tx: &BroadcastTx, event_name: &str, payload: serde_json::Value) {
-    tx.send(event_name, payload);
-}
-
-/// Queue a batched event — deduplicates by key, flushed periodically.
-pub fn emit_batched_event(
-    buffer: &BatchBuffer,
-    event_name: &str,
-    key: impl Into<String>,
-    payload: serde_json::Value,
-) {
-    let key = key.into();
-    let event_name = event_name.to_string();
-    let buffer = buffer.clone();
-    tokio::spawn(async move {
-        buffer.lock().await.insert(
-            key,
-            PendingEvent {
-                event: event_name,
-                data: payload,
-            },
-        );
-    });
-}
-
-/// Spawn background flusher that drains batch buffer every 200ms.
-pub fn spawn_batch_flusher(tx: BroadcastTx) -> BatchBuffer {
-    let buffer: BatchBuffer = Arc::new(Mutex::new(HashMap::new()));
-    let flush_buffer = buffer.clone();
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(std::time::Duration::from_millis(200));
-        loop {
-            interval.tick().await;
-            let mut buf = flush_buffer.lock().await;
-            if buf.is_empty() {
-                continue;
-            }
-            for (_key, pending) in buf.drain() {
-                tx.send(&pending.event, pending.data);
-            }
-        }
-    });
-    buffer
-}
 
 pub async fn ws_handler(
     ws: WebSocketUpgrade,

--- a/src/services/dispatched_sessions.rs
+++ b/src/services/dispatched_sessions.rs
@@ -130,13 +130,13 @@ async fn hook_session_pg(
             {
                 Ok(Some(payload)) => {
                     if is_new_session {
-                        crate::server::ws::emit_event(
+                        crate::eventbus::emit_event(
                             &state.broadcast_tx,
                             "dispatched_session_new",
                             payload,
                         );
                     } else {
-                        crate::server::ws::emit_batched_event(
+                        crate::eventbus::emit_batched_event(
                             &state.batch_buffer,
                             "dispatched_session_update",
                             &body.session_key,
@@ -161,7 +161,7 @@ async fn hook_session_pg(
                 .await
                 {
                     Ok(Some(agent)) => {
-                        crate::server::ws::emit_batched_event(
+                        crate::eventbus::emit_batched_event(
                             &state.batch_buffer,
                             "agent_status",
                             aid,
@@ -375,7 +375,7 @@ pub async fn delete_session(
         {
             Ok(result) => {
                 if let Some(session_id) = result.session_id {
-                    crate::server::ws::emit_event(
+                    crate::eventbus::emit_event(
                         &state.broadcast_tx,
                         "dispatched_session_disconnect",
                         json!({"id": session_id.to_string()}),
@@ -556,7 +556,7 @@ pub async fn update_dispatched_session(
             Ok(_) => {
                 match dispatched_sessions_db::load_session_update_payload_pg(pool, id).await {
                     Ok(Some(session)) => {
-                        crate::server::ws::emit_batched_event(
+                        crate::eventbus::emit_batched_event(
                             &state.batch_buffer,
                             "dispatched_session_update",
                             &id.to_string(),


### PR DESCRIPTION
## What
Part of #3037 (service→server backflow removal). `src/services/dispatched_sessions.rs` reached into `crate::server::ws::emit_event` / `emit_batched_event` (5 of the remaining backflow refs).

## How
- New crate-root module **`src/eventbus.rs`** holds the broadcast-bus primitives: `BroadcastBus`, `BroadcastEvent`, `PendingEvent`, `BroadcastTx`, `BatchBuffer`, `new_broadcast`, `emit_event`, `emit_batched_event`, `spawn_batch_flusher`. It sits below both `server` and `services` in the dependency graph, so services emit events without reaching up into `crate::server`.
- **`crate::server::ws`** keeps the axum `ws_handler`/`handle_socket` and `pub use`-re-exports the primitives it still consumes, so every existing `crate::server::ws::*` call site (16 server files + cli) resolves unchanged.
- `dispatched_sessions` now calls `crate::eventbus::emit_event` / `emit_batched_event`.

## Invariants
- **Pure relocation** — no logic, branch, ordering, or channel-capacity change. `BroadcastBus::send`/history/replay/batch-flush bodies are byte-identical; `as_ws_message` lifted from `fn` to `pub(crate) fn` only so the handler (now in a sibling module) can still call it.
- Re-export surface trimmed to what server actually references via `ws::` (dropped `BroadcastBus`/`PendingEvent`/`emit_batched_event` re-exports — unused via that path, confirmed by compiler).

## Gates
- `cargo fmt --check` clean; `cargo check --lib` clean (no new warnings).
- `cargo test --lib dispatched_sessions` → 16 passed.
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` → freshness check passed (new top-level module description added; ARCHITECTURE.md map row added).

Backflow: -5 (dispatched_sessions 8 → 3 server refs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)