### PR TITLE
refactor(#3037): relocate AppState to crate::app_state (backflow 9→3)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -734,6 +734,7 @@ src/
 │   ├── stt_streaming.rs
 │   ├── turn_link.rs
 │   └── utils.rs
+├── app_state.rs
 ├── bootstrap.rs
 ├── config.rs
 ├── credential.rs
@@ -776,6 +777,7 @@ This table is generated from the current `src/` root and fails CI when a new top
 | `src/ui/` | Compatibility shims for persisted UI/session types used by the Discord runtime. |
 | `src/utils/` | Shared formatting and Unicode-safe string utilities. |
 | `src/voice/` | Voice command, STT/TTS, prompt, progress, metrics, receiver, and barge-in helpers. |
+| `src/app_state.rs` | Shared HTTP route-handler state (`AppState`); lives at crate root below server+services so service-layer handlers reference it without a service→server backflow. |
 | `src/bootstrap.rs` | Builds config, database, policy engine, and shared app state before launch. |
 | `src/config.rs` | `agentdesk.yaml` parsing, configuration defaults, and shared test env helpers. |
 | `src/credential.rs` | Reads runtime credential files such as Discord bot tokens from the AgentDesk root. |

--- a/scripts/audit_maintainability/baselines/service_server_backflow.json
+++ b/scripts/audit_maintainability/baselines/service_server_backflow.json
@@ -2,29 +2,14 @@
   "schema_version": 1,
   "rule": "service_server_backflow",
   "description": "No-regression baseline for src/services references to crate::server or super::server server-layer modules.",
-  "captured_at": "2026-06-08",
-  "total_count": 14,
+  "captured_at": "2026-06-09",
+  "total_count": 3,
   "files": {
-    "src/services/auto_queue/phase_gate_violations.rs": {
-      "count": 1
-    },
-    "src/services/auto_queue/route.rs": {
-      "count": 1
-    },
     "src/services/discord/internal_api.rs": {
       "count": 1
     },
     "src/services/dispatched_sessions.rs": {
-      "count": 8
-    },
-    "src/services/onboarding/channel.rs": {
-      "count": 1
-    },
-    "src/services/onboarding/mod.rs": {
-      "count": 1
-    },
-    "src/services/session_forwarding.rs": {
-      "count": 1
+      "count": 2
     }
   }
 }

--- a/scripts/generate_inventory_docs.py
+++ b/scripts/generate_inventory_docs.py
@@ -103,6 +103,7 @@ TOP_LEVEL_MODULE_PURPOSES = {
     "bootstrap.rs": "Builds config, database, policy engine, and shared app state before launch.",
     "cli/": "Operator-facing CLI commands, direct API shims, migrations, and Discord send helpers.",
     "compat/": "Centralised home for compatibility/legacy/fallback shims (#1076). Each public item carries a `REMOVE_WHEN` comment so retirement is grep-driven.",
+    "app_state.rs": "Shared HTTP route-handler state (`AppState`); lives at crate root below server+services so service-layer handlers reference it without a service→server backflow.",
     "config.rs": "`agentdesk.yaml` parsing, configuration defaults, and shared test env helpers.",
     "credential.rs": "Reads runtime credential files such as Discord bot tokens from the AgentDesk root.",
     "db/": "SQLite access layer and schema authority (`src/db/schema.rs`).",

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,0 +1,47 @@
+//! Shared application state (`AppState`) passed to all HTTP route handlers.
+//!
+//! Lives at the crate root — below both `server` and `services` in the
+//! dependency graph — so service-layer handler helpers that operate on the
+//! shared state can reference `crate::app_state::AppState` without reaching up
+//! into `crate::server` (#3037 service→server backflow removal). The struct is
+//! re-exported from `crate::server::routes` so existing
+//! `crate::server::routes::AppState` call sites resolve unchanged.
+
+use std::sync::Arc;
+
+use crate::engine::PolicyEngine;
+use crate::services::discord::health::HealthRegistry;
+
+/// Shared application state passed to all route handlers.
+#[derive(Clone)]
+pub struct AppState {
+    pub pg_pool: Option<sqlx::PgPool>,
+    pub engine: PolicyEngine,
+    pub config: Arc<crate::config::Config>,
+    pub broadcast_tx: crate::eventbus::BroadcastTx,
+    pub batch_buffer: crate::eventbus::BatchBuffer,
+    pub health_registry: Option<Arc<HealthRegistry>>,
+    pub cluster_instance_id: Option<String>,
+}
+
+impl AppState {
+    pub fn pg_pool_ref(&self) -> Option<&sqlx::PgPool> {
+        self.pg_pool.as_ref()
+    }
+
+    pub fn dispatch_service(&self) -> crate::services::dispatches::DispatchService {
+        crate::services::dispatches::DispatchService::new(self.engine.clone())
+    }
+
+    pub fn auto_queue_service(&self) -> crate::services::auto_queue::AutoQueueService {
+        crate::services::auto_queue::AutoQueueService::new(self.engine.clone())
+    }
+
+    pub fn queue_service(&self) -> crate::services::queue::QueueService {
+        crate::services::queue::QueueService::new(self.pg_pool.clone())
+    }
+
+    pub fn settings_service(&self) -> crate::services::settings::SettingsService {
+        crate::services::settings::SettingsService::new(self.pg_pool.clone(), self.config.clone())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,9 @@ mod error;
 // services; lives at crate root to avoid a service→server backflow (#3037).
 mod eventbus;
 mod github;
+// Shared HTTP route handler state; lives at crate root (below server+services)
+// so service-layer handlers reference it without a service→server backflow (#3037).
+mod app_state;
 pub(crate) mod kanban;
 mod launch;
 mod logging;

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -65,38 +65,11 @@ use crate::services::discord::health::HealthRegistry;
 
 /// Shared application state passed to all route handlers.
 ///
-#[derive(Clone)]
-pub struct AppState {
-    pub pg_pool: Option<sqlx::PgPool>,
-    pub engine: PolicyEngine,
-    pub config: Arc<crate::config::Config>,
-    pub broadcast_tx: crate::server::ws::BroadcastTx,
-    pub batch_buffer: crate::server::ws::BatchBuffer,
-    pub health_registry: Option<Arc<HealthRegistry>>,
-    pub cluster_instance_id: Option<String>,
-}
-
-impl AppState {
-    pub fn pg_pool_ref(&self) -> Option<&sqlx::PgPool> {
-        self.pg_pool.as_ref()
-    }
-
-    pub fn dispatch_service(&self) -> crate::services::dispatches::DispatchService {
-        crate::services::dispatches::DispatchService::new(self.engine.clone())
-    }
-
-    pub fn auto_queue_service(&self) -> crate::services::auto_queue::AutoQueueService {
-        crate::services::auto_queue::AutoQueueService::new(self.engine.clone())
-    }
-
-    pub fn queue_service(&self) -> crate::services::queue::QueueService {
-        crate::services::queue::QueueService::new(self.pg_pool.clone())
-    }
-
-    pub fn settings_service(&self) -> crate::services::settings::SettingsService {
-        crate::services::settings::SettingsService::new(self.pg_pool.clone(), self.config.clone())
-    }
-}
+/// Defined in `crate::app_state` (a crate-root module below both `server` and
+/// `services`) and re-exported here so existing `crate::server::routes::AppState`
+/// call sites resolve unchanged while service-layer handlers reference it without
+/// a service→server backflow (#3037).
+pub use crate::app_state::AppState;
 
 pub(crate) type ApiRouter = Router<AppState>;
 

--- a/src/services/auto_queue/phase_gate_violations.rs
+++ b/src/services/auto_queue/phase_gate_violations.rs
@@ -22,7 +22,7 @@ use serde::Serialize;
 use serde_json::json;
 use sqlx::{PgPool, Row as SqlxRow};
 
-use crate::server::routes::AppState;
+use crate::app_state::AppState;
 
 /// A single observed ordering violation.
 #[derive(Debug, Clone, Serialize)]

--- a/src/services/auto_queue/route.rs
+++ b/src/services/auto_queue/route.rs
@@ -10,7 +10,7 @@ use sqlx::{Postgres, QueryBuilder, Row as SqlxRow};
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
 
-use crate::server::routes::AppState;
+use crate::app_state::AppState;
 use crate::services::{auto_queue::AutoQueueLogContext, provider::ProviderKind};
 
 #[path = "activate_bridge.rs"]

--- a/src/services/dispatched_sessions.rs
+++ b/src/services/dispatched_sessions.rs
@@ -1,3 +1,4 @@
+use crate::app_state::AppState;
 use crate::db::dispatched_sessions as dispatched_sessions_db;
 use crate::db::session_agent_resolution::{
     normalize_thread_channel_id, parse_thread_channel_id_from_session_key,
@@ -6,7 +7,6 @@ use crate::db::session_agent_resolution::{
 use crate::db::session_status::{
     is_live_status, is_user_wait_status, normalize_incoming_session_status,
 };
-use crate::server::routes::AppState;
 use crate::services::provider::ProviderKind;
 use crate::services::turn_lifecycle::{TurnLifecycleTarget, force_kill_turn};
 use axum::{

--- a/src/services/onboarding/channel.rs
+++ b/src/services/onboarding/channel.rs
@@ -9,7 +9,7 @@ use axum::{Json, http::StatusCode};
 use serde::Deserialize;
 use serde_json::json;
 
-use crate::server::routes::AppState;
+use crate::app_state::AppState;
 
 use super::{load_onboarding_config, pg_kv_value};
 

--- a/src/services/onboarding/mod.rs
+++ b/src/services/onboarding/mod.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 
-use crate::server::routes::AppState;
+use crate::app_state::AppState;
 
 const DISCORD_API_BASE: &str = "https://discord.com/api/v10";
 const ONBOARDING_DRAFT_VERSION: u8 = 1;

--- a/src/services/session_forwarding.rs
+++ b/src/services/session_forwarding.rs
@@ -8,7 +8,7 @@ use reqwest::header::HeaderValue;
 use serde_json::{Value, json};
 use sqlx::PgPool;
 
-use crate::server::routes::AppState;
+use crate::app_state::AppState;
 
 const FORWARDED_BY_HEADER: &str = "x-agentdesk-forwarded-by";
 const SESSION_OWNER_HEADER: &str = "x-agentdesk-session-owner";


### PR DESCRIPTION
## What
Part of #3037 (service→server backflow removal). Six service-layer handler/helper modules imported `crate::server::routes::AppState` — the bulk of the remaining backflow:
`auto_queue/route`, `auto_queue/phase_gate_violations`, `onboarding/channel`, `onboarding/mod`, `session_forwarding`, `dispatched_sessions`.

## How
`AppState`'s dependencies are all neutral or below `services` (config, engine, eventbus, `services::*`, sqlx) — it never needs `crate::server`. So:
- Moved the `AppState` struct + impl into a new crate-root module **`src/app_state.rs`** (below both `server` and `services`).
- **`crate::server::routes`** re-exports it (`pub use crate::app_state::AppState;`) so every existing `crate::server::routes::AppState` call site and `AppState { .. }` construction resolves unchanged.
- The six service modules now reference `crate::app_state::AppState`.
- `broadcast_tx`/`batch_buffer` field types switched from `crate::server::ws::*` to `crate::eventbus::*` (same underlying types via #3251's re-export) so `app_state` itself carries no server path.

## Invariants
- **Pure relocation** — no field, logic, or behavior change. `derive(Clone)` and all five service-constructor methods (`dispatch_service`/`auto_queue_service`/`queue_service`/`settings_service`/`pg_pool_ref`) are byte-identical.
- No new backflow / no cycle: `app_state.rs` imports only `std`, `sqlx`, `crate::{config,engine,eventbus,services}`.

## Gates
- `cargo fmt --check` clean; `cargo check --lib` clean (only 2 pre-existing warnings).
- Affected modules tested in isolation (onboarding / auto_queue / session_forwarding / dispatched_sessions / turn_orchestrator persistence) → pass. Full-suite parallel run shows only pre-existing env/shared-state flakes (each passes when run individually).
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` → freshness passed (new top-level module description + ARCHITECTURE.md row added).
- Backflow audit baseline ratcheted **9 → 3** (remaining: `dispatched_sessions` `auto_queue::activate` ×2 + `internal_api` ×1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)