### PR TITLE
refactor(#3037): drop final service→server re-export hops (backflow 3→0, closes #3037)

### DIFF
--- a/scripts/audit_maintainability/baselines/service_server_backflow.json
+++ b/scripts/audit_maintainability/baselines/service_server_backflow.json
@@ -3,13 +3,6 @@
   "rule": "service_server_backflow",
   "description": "No-regression baseline for src/services references to crate::server or super::server server-layer modules.",
   "captured_at": "2026-06-09",
-  "total_count": 3,
-  "files": {
-    "src/services/discord/internal_api.rs": {
-      "count": 1
-    },
-    "src/services/dispatched_sessions.rs": {
-      "count": 2
-    }
-  }
+  "total_count": 0,
+  "files": {}
 }

--- a/src/services/discord/internal_api.rs
+++ b/src/services/discord/internal_api.rs
@@ -7,7 +7,6 @@ use serde::Serialize;
 use serde_json::Value;
 use sqlx::Row;
 
-use crate::server::routes;
 use crate::services::dispatches::LinkDispatchThreadBody;
 
 #[derive(Clone)]
@@ -150,7 +149,7 @@ pub(super) async fn lookup_pending_dispatch_for_thread(thread_id: u64) -> Result
 }
 
 pub(super) async fn hook_session(
-    body: routes::dispatched_sessions::HookSessionBody,
+    body: crate::services::dispatched_sessions::HookSessionBody,
 ) -> Result<Value, String> {
     request_body(Method::POST, "/api/dispatched-sessions/webhook", &body).await
 }
@@ -195,7 +194,7 @@ pub(super) async fn delete_session(session_key: &str) -> Result<Value, String> {
     request_query(
         Method::DELETE,
         "/api/dispatched-sessions/webhook",
-        &routes::dispatched_sessions::DeleteSessionQuery {
+        &crate::services::dispatched_sessions::DeleteSessionQuery {
             session_key: session_key.to_string(),
             provider: None,
         },
@@ -228,7 +227,7 @@ pub(super) async fn get_provider_session_id(
     request_query(
         Method::GET,
         "/api/dispatched-sessions/claude-session-id",
-        &routes::dispatched_sessions::DeleteSessionQuery {
+        &crate::services::dispatched_sessions::DeleteSessionQuery {
             session_key: session_key.to_string(),
             provider: provider.map(str::to_string),
         },

--- a/src/services/dispatched_sessions.rs
+++ b/src/services/dispatched_sessions.rs
@@ -191,9 +191,9 @@ fn spawn_auto_queue_activate_for_agent(state: AppState, agent_id: String) {
     tokio::spawn(async move {
         // Let the session/dispatch cleanup commit before queue activation probes.
         tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-        let _ = crate::server::routes::auto_queue::activate(
+        let _ = crate::services::auto_queue::route::activate(
             State(state),
-            Json(crate::server::routes::auto_queue::ActivateBody {
+            Json(crate::services::auto_queue::route::ActivateBody {
                 run_id: None,
                 repo: None,
                 agent_id: Some(agent_id),


### PR DESCRIPTION
## What
Final part of #3037. The last 3 service→server backflow refs reached server-layer paths that are **mere re-exports of types/functions already defined in `services`**:

1. `dispatched_sessions` called `crate::server::routes::auto_queue::{activate, ActivateBody}`. The server `activate` is a thin wrapper over `crate::services::auto_queue::route::activate`, and `ActivateBody` lives in `crate::services::auto_queue::route_types` (re-exported via `route`). → repointed to `crate::services::auto_queue::route::{activate, ActivateBody}`.
2. `discord/internal_api` referenced `crate::server::routes::dispatched_sessions::{HookSessionBody, DeleteSessionQuery}`; both structs are defined in `crate::services::dispatched_sessions` and only re-exported by the server route. → repointed directly; dropped the now-unused `use crate::server::routes;`.

## Invariants
- **Pure path swaps** to the canonical service-layer definitions — identical types/functions, no behavior change. `activate` keeps the same `State<AppState>, Json<ActivateBody>` signature.

## Gates
- `cargo fmt --check` clean; `cargo check --lib` clean (no errors, no new warnings).
- `cargo test --lib dispatched_sessions` → 16 passed; `internal_api` compiles.
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` → freshness passed.
- **Backflow audit count: 0.** Baseline ratcheted **3 → 0** — the `service_server_backflow` rule is now a hard zero-floor guard against any new `src/services → crate::server` reference.

Completes the #3037 arc (114 → … → 9 → 3 → **0**). Closes #3037.

🤖 Generated with [Claude Code](https://claude.com/claude-code)