### PR TITLE
refactor(#3034): lower mod services dead_code blanket to per-submodule scoped allows

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -903,7 +903,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   migrated launchd validation, Discord notification plumbing, and agent
   execution are the canonical scheduled JS routine surfaces. Split focused
   helper modules before growing these files again.
-- `src/services/platform/binary_resolver.rs` (1246).
+- `src/services/platform/binary_resolver.rs` (1244).
 - `src/services/discord/mod.rs` (4465; +34 from #3019 added the
   single-authority `increment_global_active` helper + doc mirroring the
   existing decrement helper — offset by removing 6 inline raw `fetch_add`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,10 @@ pub(crate) mod runtime_layout;
 mod server;
 // Service modules contain provider, Discord, maintenance, and observability
 // feature surfaces that are enabled by runtime config rather than all targets.
-#[allow(dead_code)]
+// #3034: the crate-wide dead_code blanket has been lowered into `services::mod`
+// as per-submodule scoped allows, so the lint is now live on the ~37 clean
+// service submodules. The remaining dirty submodules each carry a scoped allow
+// (with a residual count) to be retired subtree-by-subtree.
 mod services;
 // Supervisor test hooks are intentionally retained for dispatch/runtime tests.
 pub(crate) mod supervisor;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,21 +1,57 @@
+// #3034: 1 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during agent_protocol dead-code cleanup.
+#[allow(dead_code)]
 pub mod agent_protocol;
+// #3034: 1 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during agent_quality dead-code cleanup.
+#[allow(dead_code)]
 pub mod agent_quality;
 pub mod agents;
 pub mod analytics;
 pub mod api_friction;
+// #3034: 29 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during auto_queue dead-code cleanup.
+#[allow(dead_code)]
 pub mod auto_queue;
 pub mod automation_candidate_contract;
 pub mod automation_candidate_materializer;
+// #3034: 5 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during claude dead-code cleanup.
+#[allow(dead_code)]
 pub mod claude;
+// #3034: 1 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during claude_e dead-code cleanup.
+#[allow(dead_code)]
 pub mod claude_e;
+// #3034: 16 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during claude_tui dead-code cleanup.
+#[allow(dead_code)]
 pub mod claude_tui;
+// #3034: 15 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during cluster dead-code cleanup.
+#[allow(dead_code)]
 pub mod cluster;
+// #3034: 10 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during codex dead-code cleanup.
+#[allow(dead_code)]
 pub mod codex;
 pub mod codex_remote_policy;
 #[cfg(unix)]
+// #3034: 1 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during codex_tmux_wrapper dead-code cleanup.
+#[allow(dead_code)]
 pub mod codex_tmux_wrapper;
+// #3034: 31 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during codex_tui dead-code cleanup.
+#[allow(dead_code)]
 pub mod codex_tui;
+// #3034: 113 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during discord dead-code cleanup.
+#[allow(dead_code)]
 pub mod discord;
+// #3034: 3 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during discord_config_audit dead-code cleanup.
+#[allow(dead_code)]
 pub mod discord_config_audit;
 // #1693: `discord_delivery` moved to `dispatches::discord_delivery`. The
 // flat path is preserved as a re-export so existing import sites and
@@ -25,61 +61,145 @@ pub(crate) use dispatches::discord_delivery;
 pub mod discord_dm_reply_store;
 pub mod disk_monitor;
 pub mod dispatch_watchdog;
+// #3034: 1 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during dispatched_sessions dead-code cleanup.
+#[allow(dead_code)]
 pub mod dispatched_sessions;
+// #3034: 23 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during dispatches dead-code cleanup.
+#[allow(dead_code)]
 pub mod dispatches;
+// #3034: 1 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during dispatches_followup dead-code cleanup.
+#[allow(dead_code)]
 pub mod dispatches_followup;
+// #3034: 3 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during envelope_dedup dead-code cleanup.
+#[allow(dead_code)]
 pub mod envelope_dedup;
 pub mod escalation_settings;
+// #3034: 4 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during gemini dead-code cleanup.
+#[allow(dead_code)]
 pub mod gemini;
+// #3034: 2 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during git dead-code cleanup.
+#[allow(dead_code)]
 pub mod git;
 pub mod issue_announcements;
 pub mod kanban;
 pub mod kanban_cards;
+// #3034: 81 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during maintenance dead-code cleanup.
+#[allow(dead_code)]
 pub mod maintenance;
 pub mod mcp_config;
 pub mod memory;
+// #3034: 1 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during message_outbox dead-code cleanup.
+#[allow(dead_code)]
 pub mod message_outbox;
 pub mod monitoring_store;
+// #3034: 24 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during observability dead-code cleanup.
+#[allow(dead_code)]
 pub mod observability;
 pub mod onboarding;
 pub mod opencode;
+// #3034: 1 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during operator_connectors dead-code cleanup.
+#[allow(dead_code)]
 pub mod operator_connectors;
 pub mod pipeline_override;
 pub mod pipeline_routes;
+// #3034: 5 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during platform dead-code cleanup.
+#[allow(dead_code)]
 pub mod platform;
+// #3034: 2 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during pr_summary dead-code cleanup.
+#[allow(dead_code)]
 pub mod pr_summary;
+// #3034: 14 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during process dead-code cleanup.
+#[allow(dead_code)]
 pub mod process;
+// #3034: 8 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during provider dead-code cleanup.
+#[allow(dead_code)]
 pub mod provider;
 pub mod provider_auth;
+// #3034: 18 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during provider_cli dead-code cleanup.
+#[allow(dead_code)]
 pub mod provider_cli;
+// #3034: 1 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during provider_exec dead-code cleanup.
+#[allow(dead_code)]
 pub mod provider_exec;
+// #3034: 1 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during provider_hosting dead-code cleanup.
+#[allow(dead_code)]
 pub mod provider_hosting;
 pub mod provider_runtime;
 pub mod queue;
+// #3034: 1 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during qwen dead-code cleanup.
+#[allow(dead_code)]
 pub mod qwen;
 #[cfg(unix)]
 pub mod qwen_tmux_wrapper;
+// #3034: 2 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during remote_stub dead-code cleanup.
+#[allow(dead_code)]
 pub mod remote_stub;
 pub mod retrospectives;
 pub mod review_decision;
+// #3034: 5 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during routines dead-code cleanup.
+#[allow(dead_code)]
 pub mod routines;
 pub mod service_error;
 pub mod session_activity;
+// #3034: 1 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during session_backend dead-code cleanup.
+#[allow(dead_code)]
 pub mod session_backend;
 pub mod session_forwarding;
 pub mod settings;
+// #3034: 1 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during shell_guard dead-code cleanup.
+#[allow(dead_code)]
 pub mod shell_guard;
+// #3034: 1 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during slo dead-code cleanup.
+#[allow(dead_code)]
 pub mod slo;
+// #3034: 1 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during termination_audit dead-code cleanup.
+#[allow(dead_code)]
 pub mod termination_audit;
 pub mod tmux_common;
+// #3034: 2 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during tmux_diagnostics dead-code cleanup.
+#[allow(dead_code)]
 pub mod tmux_diagnostics;
 #[cfg(unix)]
 pub mod tmux_wrapper;
+// #3034: 2 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during tool_output_guard dead-code cleanup.
+#[allow(dead_code)]
 pub mod tool_output_guard;
+// #3034: 4 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during tui_prompt_dedupe dead-code cleanup.
+#[allow(dead_code)]
 pub(crate) mod tui_prompt_dedupe;
 pub(crate) mod tui_turn_state;
 pub mod turn_cancel_finalizer;
 pub mod turn_lifecycle;
+// #3034: 10 residual dead-code items; scoped here so the lint stays
+// live on clean sibling modules. Remove during turn_orchestrator dead-code cleanup.
+#[allow(dead_code)]
 pub mod turn_orchestrator;
 
 // Compatibility alias: code referencing services::remote::* uses the stub

--- a/src/services/platform/binary_resolver.rs
+++ b/src/services/platform/binary_resolver.rs
@@ -3,8 +3,6 @@
 //! Provides a single resolution contract for provider CLIs across macOS,
 //! Linux, and Windows.
 
-#![allow(dead_code)]
-
 use std::cell::RefCell;
 use std::collections::{BTreeSet, HashMap};
 use std::ffi::{OsStr, OsString};

--- a/src/services/process.rs
+++ b/src/services/process.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::process::{Command, Output};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src/services/shell_guard.rs
+++ b/src/services/shell_guard.rs
@@ -22,8 +22,6 @@
 //! reason to the user surface (Discord) and for applying the no-output
 //! timeout independently — see [`wait_with_no_output_timeout`] below.
 
-#![allow(dead_code)]
-
 use std::io::Read;
 use std::process::Child;
 use std::sync::mpsc;


### PR DESCRIPTION
## What
Part of #3034 (restore lint visibility). The last crate-wide dead_code blanket was `#[allow(dead_code)] mod services;` in `lib.rs` — it suppressed `dead_code` across the **entire ~75-submodule `services` tree**, hiding residual dead items **and** preventing the lint from catching *new* dead code anywhere under `services`.

## How
Lower the blanket into `services::mod`:
- Each submodule that currently holds residual dead code gets its own scoped `#[allow(dead_code)]`, annotated with its residual count + a `remove during <name> dead-code cleanup` marker (e.g. `discord` 113, `maintenance` 81, `codex_tui` 31, `process` 14, …).
- Also removed three **stale inner `#![allow(dead_code)]` blankets** (`process.rs`, `shell_guard.rs`, `platform/binary_resolver.rs`) so `services/mod.rs` is the **single** per-submodule suppression point (no hidden inner blankets). Removing them surfaced `process` (14) and `shell_guard` (1) as dirty — now scoped in `mod.rs` like the rest; `binary_resolver` is covered by the `platform` scoped allow.
- **Net: 40 dirty submodules scoped, 35 clean submodules lint-live.**
- `lib.rs` drops the `mod services` blanket.

## Why this first
#3034's remaining scope is a per-item triage (delete truly-dead vs annotate intentionally-retained: serde-only fields, feature-gated, future API). That must be done **subtree-by-subtree** to stay safe. This PR is the enabler: it scopes the suppression so each subtree can be retired independently, and immediately re-activates the lint on the clean ~half of the tree.

## Invariants
- **Behavior-identical** — exactly the same set of items is suppressed, only at submodule granularity. No code deleted.
- No CI-gate change: Lint runs `-W clippy::all` (warn), not `-D`.

## Gates
- `cargo fmt --check` clean; `cargo check --lib` — **0 new dead_code warnings** under `services` (the one remaining `services` warning is a pre-existing `unused_assignments` in `tmux_watcher.rs:10871`, a different lint).
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` → freshness passed (binary_resolver freeze synced 1246→1244 after inner-blanket line removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)