### PR TITLE
refactor(#3034): delete orphaned dead code in 10 tail service submodules (dirty 40→30)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -554,7 +554,7 @@
     mailbox/inflight probe, and the `post_recheck_action` seam that skips/undoes
     a recap post when a turn raced the compose window. Split compose vs
     lifecycle/clear submodules before adding behavior).
-  - `src/services/codex_tmux_wrapper.rs` (1222 lines; Codex tmux wrapper JSON
+  - `src/services/codex_tmux_wrapper.rs` (1215 lines; Codex tmux wrapper JSON
     event parser and relay bridge for native Codex session events — bugfix only
     outside an extraction plan).
   - `src/services/tui_prompt_dedupe.rs` (1294 lines; shared TUI prompt
@@ -873,7 +873,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   support extracted from the route layer; split before adding non-bugfix
   behavior.
 - `src/services/claude.rs` (3949), `src/services/gemini.rs` (1416),
-  `src/services/qwen.rs` (2200), `src/services/codex.rs` (3083),
+  `src/services/qwen.rs` (2196), `src/services/codex.rs` (3083),
   `src/services/opencode.rs` (1881), `src/services/provider.rs` (1739) —
   provider adapters.
 - `src/services/codex_tui/rollout_tail.rs` (1738) — Codex TUI rollout tail

--- a/src/services/agent_protocol.rs
+++ b/src/services/agent_protocol.rs
@@ -145,18 +145,6 @@ pub enum RuntimeHandoff {
     },
 }
 
-impl RuntimeHandoff {
-    pub fn kind(&self) -> RuntimeHandoffKind {
-        match self {
-            Self::LegacyTmuxWrapper { .. } => RuntimeHandoffKind::LegacyTmuxWrapper,
-            Self::ClaudeTui { .. } => RuntimeHandoffKind::ClaudeTui,
-            Self::CodexTui { .. } => RuntimeHandoffKind::CodexTui,
-            Self::ProcessBackend { .. } => RuntimeHandoffKind::ProcessBackend,
-            Self::ClaudeEAdapter { .. } => RuntimeHandoffKind::ClaudeEAdapter,
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub enum StreamMessage {
     /// Initialization - contains session_id

--- a/src/services/agent_quality/regression_alerts.rs
+++ b/src/services/agent_quality/regression_alerts.rs
@@ -68,13 +68,6 @@ impl QualityMetric {
             QualityMetric::ReviewPassRate => "review_pass_rate",
         }
     }
-
-    pub fn label(&self) -> &'static str {
-        match self {
-            QualityMetric::TurnSuccessRate => "turn success rate",
-            QualityMetric::ReviewPassRate => "review pass rate",
-        }
-    }
 }
 
 /// One regression candidate. Captured before the cooldown filter; the

--- a/src/services/claude_e/mod.rs
+++ b/src/services/claude_e/mod.rs
@@ -9,9 +9,6 @@ pub mod spawn_queue;
 
 pub use process::execute_streaming;
 
-/// Stable telemetry label.
-pub const ADAPTER_LABEL: &str = "claude-e";
-
 /// Returns true when the `claude-e` binary can be located on PATH.
 /// `provider_hosting::resolve_provider_session_selection_with_channel`
 /// reads this to decide whether the operator's `runtime: claude-e`

--- a/src/services/codex_tmux_wrapper.rs
+++ b/src/services/codex_tmux_wrapper.rs
@@ -328,13 +328,6 @@ fn decode_base64_prompt(encoded: &str) -> Result<String, String> {
     String::from_utf8(bytes).map_err(|e| format!("invalid utf-8 payload: {}", e))
 }
 
-fn decode_external_prompt(line: &str) -> Result<String, String> {
-    if let Some(encoded) = line.strip_prefix(TMUX_PROMPT_B64_PREFIX) {
-        return decode_base64_prompt(encoded);
-    }
-    Ok(line.to_string())
-}
-
 fn codex_first_event_timeout() -> std::time::Duration {
     let seconds = std::env::var("AGENTDESK_CODEX_FIRST_EVENT_TIMEOUT_SECS")
         .ok()

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,10 +1,4 @@
-// #3034: 1 residual dead-code items; scoped here so the lint stays
-// live on clean sibling modules. Remove during agent_protocol dead-code cleanup.
-#[allow(dead_code)]
 pub mod agent_protocol;
-// #3034: 1 residual dead-code items; scoped here so the lint stays
-// live on clean sibling modules. Remove during agent_quality dead-code cleanup.
-#[allow(dead_code)]
 pub mod agent_quality;
 pub mod agents;
 pub mod analytics;
@@ -19,9 +13,6 @@ pub mod automation_candidate_materializer;
 // live on clean sibling modules. Remove during claude dead-code cleanup.
 #[allow(dead_code)]
 pub mod claude;
-// #3034: 1 residual dead-code items; scoped here so the lint stays
-// live on clean sibling modules. Remove during claude_e dead-code cleanup.
-#[allow(dead_code)]
 pub mod claude_e;
 // #3034: 16 residual dead-code items; scoped here so the lint stays
 // live on clean sibling modules. Remove during claude_tui dead-code cleanup.
@@ -37,9 +28,6 @@ pub mod cluster;
 pub mod codex;
 pub mod codex_remote_policy;
 #[cfg(unix)]
-// #3034: 1 residual dead-code items; scoped here so the lint stays
-// live on clean sibling modules. Remove during codex_tmux_wrapper dead-code cleanup.
-#[allow(dead_code)]
 pub mod codex_tmux_wrapper;
 // #3034: 31 residual dead-code items; scoped here so the lint stays
 // live on clean sibling modules. Remove during codex_tui dead-code cleanup.
@@ -133,9 +121,6 @@ pub mod provider_auth;
 // live on clean sibling modules. Remove during provider_cli dead-code cleanup.
 #[allow(dead_code)]
 pub mod provider_cli;
-// #3034: 1 residual dead-code items; scoped here so the lint stays
-// live on clean sibling modules. Remove during provider_exec dead-code cleanup.
-#[allow(dead_code)]
 pub mod provider_exec;
 // #3034: 1 residual dead-code items; scoped here so the lint stays
 // live on clean sibling modules. Remove during provider_hosting dead-code cleanup.
@@ -143,9 +128,6 @@ pub mod provider_exec;
 pub mod provider_hosting;
 pub mod provider_runtime;
 pub mod queue;
-// #3034: 1 residual dead-code items; scoped here so the lint stays
-// live on clean sibling modules. Remove during qwen dead-code cleanup.
-#[allow(dead_code)]
 pub mod qwen;
 #[cfg(unix)]
 pub mod qwen_tmux_wrapper;
@@ -167,28 +149,16 @@ pub mod session_activity;
 pub mod session_backend;
 pub mod session_forwarding;
 pub mod settings;
-// #3034: 1 residual dead-code items; scoped here so the lint stays
-// live on clean sibling modules. Remove during shell_guard dead-code cleanup.
-#[allow(dead_code)]
 pub mod shell_guard;
-// #3034: 1 residual dead-code items; scoped here so the lint stays
-// live on clean sibling modules. Remove during slo dead-code cleanup.
-#[allow(dead_code)]
 pub mod slo;
 // #3034: 1 residual dead-code items; scoped here so the lint stays
 // live on clean sibling modules. Remove during termination_audit dead-code cleanup.
 #[allow(dead_code)]
 pub mod termination_audit;
 pub mod tmux_common;
-// #3034: 2 residual dead-code items; scoped here so the lint stays
-// live on clean sibling modules. Remove during tmux_diagnostics dead-code cleanup.
-#[allow(dead_code)]
 pub mod tmux_diagnostics;
 #[cfg(unix)]
 pub mod tmux_wrapper;
-// #3034: 2 residual dead-code items; scoped here so the lint stays
-// live on clean sibling modules. Remove during tool_output_guard dead-code cleanup.
-#[allow(dead_code)]
 pub mod tool_output_guard;
 // #3034: 4 residual dead-code items; scoped here so the lint stays
 // live on clean sibling modules. Remove during tui_prompt_dedupe dead-code cleanup.

--- a/src/services/provider_exec.rs
+++ b/src/services/provider_exec.rs
@@ -37,18 +37,6 @@ pub async fn execute_simple(provider: ProviderKind, prompt: String) -> Result<St
         .map_err(|e| format!("Task join error: {}", e))?
 }
 
-pub async fn execute_simple_with_context(
-    provider: ProviderKind,
-    prompt: String,
-    context: ProviderExecutionContext,
-) -> Result<String, String> {
-    tokio::task::spawn_blocking(move || {
-        execute_simple_blocking(provider, prompt, None, Some(context))
-    })
-    .await
-    .map_err(|e| format!("Task join error: {}", e))?
-}
-
 pub async fn execute_simple_with_timeout(
     provider: ProviderKind,
     prompt: String,

--- a/src/services/qwen.rs
+++ b/src/services/qwen.rs
@@ -260,10 +260,6 @@ fn resolve_qwen_binary() -> crate::services::platform::BinaryResolution {
     crate::services::platform::resolve_provider_binary("qwen")
 }
 
-pub fn execute_command_simple(prompt: &str) -> Result<String, String> {
-    execute_command_simple_cancellable(prompt, None)
-}
-
 pub fn execute_command_simple_cancellable(
     prompt: &str,
     cancel_token: Option<&CancelToken>,

--- a/src/services/shell_guard.rs
+++ b/src/services/shell_guard.rs
@@ -48,16 +48,6 @@ pub enum GuardDecision {
     Block { reason: String, suggestion: String },
 }
 
-impl GuardDecision {
-    pub fn is_allow(&self) -> bool {
-        matches!(self, GuardDecision::Allow)
-    }
-
-    pub fn is_block(&self) -> bool {
-        matches!(self, GuardDecision::Block { .. })
-    }
-}
-
 /// Inspect a single shell command string and decide whether to allow it.
 ///
 /// The detector is intentionally lexical — it does not invoke a real shell

--- a/src/services/slo/mod.rs
+++ b/src/services/slo/mod.rs
@@ -62,12 +62,6 @@ pub enum SloMetric {
 }
 
 impl SloMetric {
-    pub const ALL: &'static [SloMetric] = &[
-        SloMetric::TurnSuccessRate,
-        SloMetric::DuplicateRelayCount,
-        SloMetric::AvgTurnLatencyMs,
-    ];
-
     pub fn as_str(&self) -> &'static str {
         match self {
             SloMetric::TurnSuccessRate => "turn_success_rate",

--- a/src/services/tmux_diagnostics.rs
+++ b/src/services/tmux_diagnostics.rs
@@ -8,8 +8,6 @@ fn tmux_exit_reason_path(tmux_session_name: &str) -> String {
     crate::services::tmux_common::session_temp_path(tmux_session_name, "exit_reason")
 }
 
-pub const TMUX_NORMAL_COMPLETION_REASON: &str = "turn completed (code 0)";
-
 pub fn tmux_session_exists(tmux_session_name: &str) -> bool {
     crate::services::platform::tmux::has_session(tmux_session_name)
 }
@@ -52,10 +50,6 @@ pub fn record_tmux_exit_reason(tmux_session_name: &str, reason: &str) {
         let _ = std::fs::rename(&tmp_path, path);
     }
     let _ = std::fs::remove_file(tmp_path);
-}
-
-pub fn record_normal_tmux_exit_reason(tmux_session_name: &str) {
-    record_tmux_exit_reason(tmux_session_name, TMUX_NORMAL_COMPLETION_REASON);
 }
 
 pub fn tmux_exit_reason_is_normal_completion(reason: &str) -> bool {

--- a/src/services/tool_output_guard.rs
+++ b/src/services/tool_output_guard.rs
@@ -98,28 +98,3 @@ pub fn observe(tool_name: Option<&str>, is_error: bool, content: &str) -> Oversi
     }
     report
 }
-
-/// Snapshot of global counters. Used by `/api/analytics/observability` and
-/// tests. Returned as a plain struct so callers do not depend on atomics.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct ToolOutputCounters {
-    pub tool_output_oversize_count: u64,
-    pub total_output_bytes: u64,
-    pub total_output_samples: u64,
-    /// Convenience: mean bytes per observed tool output. Returns 0 when no
-    /// samples have been recorded yet.
-    pub avg_output_bytes: u64,
-}
-
-pub fn snapshot_counters() -> ToolOutputCounters {
-    let oversize = OVERSIZE_COUNT.load(Ordering::Relaxed);
-    let bytes = TOTAL_OUTPUT_BYTES.load(Ordering::Relaxed);
-    let samples = TOTAL_OUTPUT_SAMPLES.load(Ordering::Relaxed);
-    let avg = if samples == 0 { 0 } else { bytes / samples };
-    ToolOutputCounters {
-        tool_output_oversize_count: oversize,
-        total_output_bytes: bytes,
-        total_output_samples: samples,
-        avg_output_bytes: avg,
-    }
-}


### PR DESCRIPTION
## What
Subtree cleanup under #3034 (dead_code visibility). Deletes genuinely-dead items from 10 tail `services` submodules and removes their now-empty per-submodule scoped `#[allow(dead_code)]` (added by #3254).

Deleted (each verified unused incl. `cargo check --all-targets --all-features` — not even test-referenced):
- `agent_protocol`: `RuntimeHandoff::kind`
- `agent_quality`: `QualityMetric::label`
- `claude_e`: `ADAPTER_LABEL`
- `codex_tmux_wrapper`: `decode_external_prompt`
- `provider_exec`: `execute_simple_with_context`
- `qwen`: `execute_command_simple`
- `shell_guard`: `GuardDecision::is_allow` / `is_block`
- `slo`: `SloMetric::ALL`
- `tmux_diagnostics`: `TMUX_NORMAL_COMPLETION_REASON` + `record_normal_tmux_exit_reason`
- `tool_output_guard`: `ToolOutputCounters` + `snapshot_counters`

## Scope note
Retention-intent items left for a separate annotate pass (NOT deleted): `git/runner` builder API (siblings already `#[allow]`), `pr_summary` instrumentation (doc-described, `len` test-used), `remote_stub` future-SSH placeholder, `operator_connectors` serialized-state enum variants.

## Invariants
- Behavior-preserving — every deleted item had **zero live callers** (compiler-verified across all targets). No cascade (no newly-dead items surfaced).
- The 10 submodules now have `dead_code` lint **live** (scoped allows removed). Dirty services submodules **40 → 30**.

## Gates
- `cargo fmt --check` clean; `cargo check --lib` clean (no new warnings).
- `cargo test --lib` (cli/tool_output_guard touched) compiles + passes.
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` → freshness passed (codex_tmux_wrapper 1222→1215, qwen 2200→2196 freezes synced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)