### PR TITLE
refactor(#3034): batch4 dead-code cleanup — tui/process/git/dispatched_sessions

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -880,7 +880,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   `src/services/auto_queue/cancel_run.rs` (1032) is also giant-file territory;
   split before further non-bugfix growth.
 - `src/services/onboarding/mod.rs` (2936),
-  `src/services/dispatched_sessions.rs` (1342), and
+  `src/services/dispatched_sessions.rs` (1328), and
   `src/services/settings.rs` (1007) — service-layer route support surfaces
   split out of the large dashboard route modules. (`src/services/onboarding.rs`
   and `src/services/api_friction.rs` have been removed/decomposed.)
@@ -893,19 +893,19 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded
   `select_counterpart_from` from provider.)
-- `src/services/codex_tui/rollout_tail.rs` (1738) — Codex TUI rollout tail
+- `src/services/codex_tui/rollout_tail.rs` (1639) — Codex TUI rollout tail
   parsing and resume identity surface; split before adding non-bugfix behavior
   beyond the #2169 session identity fix.
-- `src/services/codex_tui/input.rs` (1492) — Codex TUI input readiness
+- `src/services/codex_tui/input.rs` (1350) — Codex TUI input readiness
   detector and prompt delivery surface (#2399 hardened the post-turn
   handoff deadline). Treat as giant-file territory; split before adding
   non-bugfix behavior beyond the readiness/cancel contract.
-- `src/services/claude_tui/input.rs` (1296) — Claude TUI input readiness
+- `src/services/claude_tui/input.rs` (1294) — Claude TUI input readiness
   detector, prompt delivery, and cancellation/offset handoff surface. Treat as
   giant-file territory; split before adding non-bugfix behavior beyond the
   readiness/cancel contract.
 - `src/services/memory/memento.rs` (1893).
-- `src/services/dispatched_sessions.rs` (1342) — dispatched session domain
+- `src/services/dispatched_sessions.rs` (1328) — dispatched session domain
   service. This is the post-#1515 SRP extraction target for route/database
   callsites, but the module itself is now giant-file territory; split focused
   helpers before adding non-bugfix behavior. (+5 from #3169 exposing the idle-

--- a/src/services/claude_tui/hook_bundle.rs
+++ b/src/services/claude_tui/hook_bundle.rs
@@ -579,6 +579,9 @@ static LAUNCH_SELF_CHECK_SEEN: std::sync::LazyLock<
 ///
 /// Returns `true` if the launch binary passed the check (or was already
 /// reported in this process); `false` if a warning was logged.
+// #3034: test-only default-exec-path convenience wrapper; production callers
+// invoke `run_codex_hook_launch_self_check_with_exec_path` directly.
+#[allow(dead_code)]
 pub fn run_codex_hook_launch_self_check(codex_bin_path: &str) -> bool {
     run_codex_hook_launch_self_check_with_exec_path(codex_bin_path, None)
 }

--- a/src/services/claude_tui/hook_server.rs
+++ b/src/services/claude_tui/hook_server.rs
@@ -1,14 +1,13 @@
-use std::net::SocketAddr;
 use std::sync::{Arc, LazyLock, RwLock};
 
 use axum::extract::{DefaultBodyLimit, Path, Query, State};
 use axum::http::StatusCode;
-use axum::routing::{get, post};
+use axum::routing::post;
 use axum::{Json, Router};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use tokio::sync::{Notify, broadcast, oneshot};
+use tokio::sync::{Notify, broadcast};
 
 const EVENT_BUFFER_CAPACITY: usize = 256;
 
@@ -30,6 +29,8 @@ pub fn prompt_ready_notify() -> Arc<Notify> {
 /// Internal entry point used by `receive_hook` to wake `prompt_ready_notify`
 /// waiters. Exposed (crate-visible) for unit tests that exercise the wake path
 /// without spinning up the full HTTP receiver.
+// #3034: test-only wake hook (consumed by input.rs end-to-end wiring tests).
+#[allow(dead_code)]
 pub(crate) fn signal_prompt_ready_for_test() {
     PROMPT_READY_NOTIFY.notify_waiters();
 }
@@ -125,33 +126,8 @@ impl Default for HookServerState {
     }
 }
 
-pub struct HookServerHandle {
-    addr: SocketAddr,
-    shutdown_tx: Option<oneshot::Sender<()>>,
-    task: tokio::task::JoinHandle<()>,
-}
-
 pub struct HookEndpointGuard {
     endpoint: String,
-}
-
-impl HookServerHandle {
-    pub fn addr(&self) -> SocketAddr {
-        self.addr
-    }
-
-    pub fn base_url(&self) -> String {
-        format!("http://{}", self.addr)
-    }
-}
-
-impl Drop for HookServerHandle {
-    fn drop(&mut self) {
-        if let Some(tx) = self.shutdown_tx.take() {
-            let _ = tx.send(());
-        }
-        clear_hook_endpoint_if_current(&self.base_url());
-    }
 }
 
 impl Drop for HookEndpointGuard {
@@ -187,54 +163,8 @@ pub fn subscribe_hook_events() -> broadcast::Receiver<HookEvent> {
     HOOK_SERVER_STATE.subscribe()
 }
 
-pub async fn spawn_hook_server() -> Result<HookServerHandle, String> {
-    spawn_hook_server_with_state(HOOK_SERVER_STATE.clone()).await
-}
-
-pub async fn spawn_hook_server_with_state(
-    state: HookServerState,
-) -> Result<HookServerHandle, String> {
-    let app = hook_standalone_router(state);
-    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
-        .await
-        .map_err(|error| format!("bind hook server: {error}"))?;
-    let addr = listener
-        .local_addr()
-        .map_err(|error| format!("hook server local_addr: {error}"))?;
-    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
-    let task = tokio::spawn(async move {
-        let result = axum::serve(listener, app)
-            .with_graceful_shutdown(async {
-                let _ = shutdown_rx.await;
-            })
-            .await;
-        if let Err(error) = result {
-            tracing::warn!("tui hook server stopped with error: {error}");
-        }
-    });
-
-    let handle = HookServerHandle {
-        addr,
-        shutdown_tx: Some(shutdown_tx),
-        task,
-    };
-    *HOOK_ENDPOINT
-        .write()
-        .unwrap_or_else(|error| error.into_inner()) = Some(handle.base_url());
-    tracing::info!(endpoint = handle.base_url(), "tui hook server started");
-    Ok(handle)
-}
-
 pub fn hook_receiver_router() -> Router {
     hook_receiver_router_with_state(HOOK_SERVER_STATE.clone())
-}
-
-fn hook_standalone_router(state: HookServerState) -> Router {
-    Router::new()
-        .route("/health", get(health))
-        .route("/hooks/{provider}/{event}", post(receive_hook))
-        .layer(DefaultBodyLimit::max(8 * 1024 * 1024))
-        .with_state(state)
 }
 
 fn hook_receiver_router_with_state(state: HookServerState) -> Router {
@@ -242,10 +172,6 @@ fn hook_receiver_router_with_state(state: HookServerState) -> Router {
         .route("/hooks/{provider}/{event}", post(receive_hook))
         .layer(DefaultBodyLimit::max(8 * 1024 * 1024))
         .with_state(state)
-}
-
-async fn health() -> Json<Value> {
-    Json(json!({ "ok": true }))
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/services/claude_tui/input.rs
+++ b/src/services/claude_tui/input.rs
@@ -158,6 +158,9 @@ pub fn plan_prompt_submit(prompt: &str) -> Result<Vec<TuiInputAction>, String> {
     Ok(actions)
 }
 
+// #3034: test-only — pins the Escape cancel-key plan; production cancel now
+// routes through the orchestrator, not this helper.
+#[allow(dead_code)]
 pub fn plan_cancel() -> Vec<TuiInputAction> {
     vec![TuiInputAction::Escape]
 }
@@ -239,14 +242,6 @@ pub fn send_followup_prompt(
         PromptReadinessKind::Followup,
         cancel_token,
     )
-}
-
-pub fn send_prompt(
-    session_name: &str,
-    prompt: &str,
-    cancel_token: Option<&CancelToken>,
-) -> Result<(), String> {
-    send_followup_prompt(session_name, prompt, cancel_token)
 }
 
 pub fn is_prompt_ready_timeout_error(error: &str) -> bool {
@@ -525,10 +520,6 @@ fn log_selector_never_opened(
     );
 }
 
-pub fn send_cancel(session_name: &str) -> Result<(), String> {
-    run_actions(session_name, &plan_cancel(), None)
-}
-
 /// #2730: settle delay between a PasteBuffer action and any follow-up
 /// (typically `Enter`). Claude TUI 2.1.x parses bracketed-paste sequences
 /// byte-by-byte from the pane; without a brief settle window the Enter sent
@@ -720,6 +711,9 @@ pub(crate) fn claude_prompt_draft_is_idle_suggestion_tail(pane_tail: &str) -> bo
     crate::services::tmux_common::tmux_capture_indicates_claude_tui_idle_suggestion(pane_tail)
 }
 
+// #3034: test-only thin wrapper retained to pin the tmux_common backspace
+// budget contract from this module's test suite.
+#[allow(dead_code)]
 pub(crate) fn claude_prompt_draft_backspace_budget_from_line(line: &str) -> Option<usize> {
     crate::services::tmux_common::claude_tui_prompt_draft_backspace_budget_from_line(line)
 }
@@ -925,6 +919,10 @@ fn wait_for_prompt_ready_inner(
 /// invoked and the select being polled is still observed. Combined with the
 /// subscribe-before-snapshot ordering in `run_prompt_ready_fast_path`, this
 /// closes the residual race flagged in #2445.
+// #3034: test-only — the #2445 race-closing wrapper is exercised directly by
+// the regression suite; production drives readiness through the fast-path
+// caller. Retained as the canonical pinned implementation of the wake ordering.
+#[allow(dead_code)]
 fn wait_for_prompt_ready_event(notify: Arc<Notify>, budget: Duration) -> HookFastPathOutcome {
     let fut = async move {
         let notified = notify.notified();

--- a/src/services/claude_tui/transcript_tail.rs
+++ b/src/services/claude_tui/transcript_tail.rs
@@ -6,6 +6,10 @@ use crate::services::agent_protocol::StreamMessage;
 use crate::services::session_backend::{StreamLineState, process_stream_line};
 use chrono::{DateTime, Utc};
 
+// #3034: test-only replay surface — `replay_transcript_file` and its outcome
+// type are exercised by the transcript-parser regression suite but not wired to
+// a production caller (replay now happens via the streaming session backend).
+#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TranscriptReplayOutcome {
     pub bytes_read: u64,
@@ -48,6 +52,9 @@ pub fn claude_transcript_path_candidates(
         .collect())
 }
 
+// #3034: test-only single-candidate helper; production resolves transcripts via
+// `claude_project_dir_candidates_for_cwd` (the multi-candidate form).
+#[allow(dead_code)]
 pub fn claude_project_dir_for_cwd(
     cwd: &Path,
     claude_home: Option<&Path>,
@@ -181,6 +188,9 @@ pub fn claude_transcripts_for_cwd_since(
     found.into_iter().map(|(_, path)| path).collect()
 }
 
+// #3034: test-only — see `TranscriptReplayOutcome` note. Pins the JSONL replay
+// parser contract; no production caller (streaming backend owns live replay).
+#[allow(dead_code)]
 pub fn replay_transcript_file(
     transcript_path: &Path,
     sender: &Sender<StreamMessage>,

--- a/src/services/codex_tui/input.rs
+++ b/src/services/codex_tui/input.rs
@@ -93,6 +93,12 @@ use crate::services::provider::{CancelToken, cancel_requested};
 use tokio::runtime::{Handle, RuntimeFlavor};
 use tokio::sync::Notify;
 
+// #3034: test-only — the `TuiInputAction` action-plan layer below (plan/run/
+// validate/executor) is exercised by this module's regression suite but no
+// longer has a production caller; live codex input drives tmux directly through
+// the readiness-gated path. Retained as the pinned contract for that test
+// surface; individual `#[allow(dead_code)]` markers below.
+#[allow(dead_code)]
 const DEFAULT_LITERAL_CHUNK_CHARS: usize = 1800;
 const PROMPT_READY_CAPTURE_SCROLLBACK: i32 = -80;
 const PROMPT_READY_DEBUG_TAIL_LINES: usize = 24;
@@ -138,6 +144,9 @@ pub const PROMPT_READY_CANCELLED_ERROR: &str = "codex tui prompt readiness wait 
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PromptReadinessKind {
+    // #3034: constructed only by tests now (the fresh-turn send path was
+    // retired); kept for taxonomy completeness — `timeout`/`label` match it.
+    #[allow(dead_code)]
     FreshTurn,
     Followup,
     /// Bounded post-turn probe used by the Codex TUI launch frame to
@@ -175,6 +184,9 @@ impl PromptReadinessKind {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum PromptDraftPolicy {
     RejectDraft,
+    // #3034: the accept-for-clear policy fed the retired draft-clear path;
+    // retained as the second policy state pinned by `accepts`.
+    #[allow(dead_code)]
     AcceptDraftForClear,
 }
 
@@ -236,6 +248,7 @@ pub(crate) fn record_rollout_composer_ready(session_name: &str) {
     state.notify.notify_waiters();
 }
 
+#[allow(dead_code)] // #3034: test-only; consumed by composer-ready state tests.
 fn mark_rollout_composer_busy(session_name: &str) {
     rollout_composer_ready_state()
         .ready_sessions
@@ -266,6 +279,7 @@ pub struct PromptReadinessSnapshot {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(dead_code)] // #3034: test-only action taxonomy (see header note).
 pub enum TuiInputAction {
     Literal(String),
     PasteBuffer(String),
@@ -276,6 +290,7 @@ pub enum TuiInputAction {
 /// Plan the sequence of tmux input actions required to deliver `prompt`
 /// to a Codex TUI composer. Multiline prompts use a paste buffer so
 /// embedded newlines do not get interpreted as `Enter` submissions.
+#[allow(dead_code)] // #3034: test-only (see header note).
 pub fn plan_prompt_submit(prompt: &str) -> Result<Vec<TuiInputAction>, String> {
     let normalized_prompt;
     let prompt = if prompt.contains('\r') {
@@ -298,38 +313,9 @@ pub fn plan_prompt_submit(prompt: &str) -> Result<Vec<TuiInputAction>, String> {
     Ok(actions)
 }
 
+#[allow(dead_code)] // #3034: test-only (see header note).
 pub fn plan_cancel() -> Vec<TuiInputAction> {
     vec![TuiInputAction::Escape]
-}
-
-/// Inject a fresh-turn prompt: waits up to `FRESH_PROMPT_READY_TIMEOUT`
-/// for the composer to appear before sending.
-pub fn send_fresh_prompt(
-    session_name: &str,
-    prompt: &str,
-    cancel_token: Option<&Arc<CancelToken>>,
-) -> Result<(), String> {
-    send_prompt_with_readiness(
-        session_name,
-        prompt,
-        PromptReadinessKind::FreshTurn,
-        cancel_token,
-    )
-}
-
-/// Inject a follow-up prompt: waits up to `FOLLOWUP_PROMPT_READY_TIMEOUT`
-/// for the composer to redraw after the previous turn before sending.
-pub fn send_followup_prompt(
-    session_name: &str,
-    prompt: &str,
-    cancel_token: Option<&Arc<CancelToken>>,
-) -> Result<(), String> {
-    send_prompt_with_readiness(
-        session_name,
-        prompt,
-        PromptReadinessKind::Followup,
-        cancel_token,
-    )
 }
 
 pub fn is_prompt_ready_timeout_error(error: &str) -> bool {
@@ -417,19 +403,6 @@ pub fn wait_until_codex_tui_input_ready(
         readiness,
         cancel_token,
         PromptDraftPolicy::RejectDraft,
-    )
-}
-
-fn wait_until_codex_tui_input_visible_for_clear(
-    session_name: &str,
-    readiness: PromptReadinessKind,
-    cancel_token: Option<&Arc<CancelToken>>,
-) -> Result<(), String> {
-    wait_until_codex_tui_input_ready_with_policy(
-        session_name,
-        readiness,
-        cancel_token,
-        PromptDraftPolicy::AcceptDraftForClear,
     )
 }
 
@@ -806,110 +779,7 @@ impl FastPathFallback for (HookFastPathOutcome, Option<PromptReadinessSnapshot>)
     }
 }
 
-fn send_prompt_with_readiness(
-    session_name: &str,
-    prompt: &str,
-    readiness: PromptReadinessKind,
-    cancel_token: Option<&Arc<CancelToken>>,
-) -> Result<(), String> {
-    let actions = plan_prompt_submit(prompt)?;
-    wait_until_codex_tui_input_visible_for_clear(session_name, readiness, cancel_token)?;
-    clear_codex_tui_prompt_draft_if_present(session_name, cancel_token.map(Arc::as_ref))?;
-    wait_until_codex_tui_input_ready(session_name, readiness, cancel_token)?;
-    mark_rollout_composer_busy(session_name);
-    if cancel_requested(cancel_token.map(Arc::as_ref)) {
-        return Err(PROMPT_READY_CANCELLED_ERROR.to_string());
-    }
-    crate::services::tui_prompt_dedupe::record_discord_originated_prompt(
-        "codex",
-        session_name,
-        prompt,
-    );
-    match run_actions(session_name, &actions, cancel_token.map(Arc::as_ref)) {
-        Ok(()) => Ok(()),
-        Err(error) => {
-            crate::services::tui_prompt_dedupe::remove_discord_originated_prompt(
-                "codex",
-                session_name,
-                prompt,
-            );
-            Err(error)
-        }
-    }
-}
-
-fn clear_codex_tui_prompt_draft_if_present(
-    session_name: &str,
-    cancel_token: Option<&CancelToken>,
-) -> Result<(), String> {
-    let mut snapshot = prompt_readiness_snapshot(session_name);
-    if !snapshot.prompt_draft_detected || !snapshot.tmux_pane_alive {
-        return Ok(());
-    }
-
-    let clear_key_plans: [&[&str]; 4] = [
-        &["Escape", "Escape"],
-        &["C-e", "C-u"],
-        &["C-a", "C-k"],
-        &["C-u"],
-    ];
-    for attempt in 1..=2 {
-        check_prompt_cancel(cancel_token)?;
-        for keys in clear_key_plans {
-            let output = crate::services::platform::tmux::send_keys(session_name, keys)?;
-            ensure_tmux_key_success(output, "clear-draft")?;
-            std::thread::sleep(Duration::from_millis(240));
-            check_prompt_cancel(cancel_token)?;
-            snapshot = prompt_readiness_snapshot(session_name);
-            if !snapshot.prompt_draft_detected || !snapshot.tmux_pane_alive {
-                tracing::info!(
-                    tmux_session_name = session_name,
-                    attempt,
-                    "codex_tui prompt draft cleared before submit"
-                );
-                return Ok(());
-            }
-        }
-        if let Some(backspace_count) = codex_visible_prompt_draft_backspace_budget(&snapshot) {
-            let mut backspace_keys = Vec::with_capacity(backspace_count + 1);
-            backspace_keys.push("C-e");
-            backspace_keys.extend(std::iter::repeat_n("BSpace", backspace_count));
-            let output = crate::services::platform::tmux::send_keys(session_name, &backspace_keys)?;
-            ensure_tmux_key_success(output, "clear-draft-backspace")?;
-            std::thread::sleep(Duration::from_millis(240));
-            check_prompt_cancel(cancel_token)?;
-            snapshot = prompt_readiness_snapshot(session_name);
-            if !snapshot.prompt_draft_detected || !snapshot.tmux_pane_alive {
-                tracing::info!(
-                    tmux_session_name = session_name,
-                    attempt,
-                    backspace_count,
-                    "codex_tui prompt draft cleared by backspace sweep before submit"
-                );
-                return Ok(());
-            }
-        }
-        tracing::warn!(
-            tmux_session_name = session_name,
-            attempt,
-            composer_marker_detected = snapshot.composer_marker_detected,
-            prompt_draft_detected = snapshot.prompt_draft_detected,
-            tmux_pane_alive = snapshot.tmux_pane_alive,
-            capture_available = snapshot.capture_available,
-            pane_tail = %snapshot.pane_tail,
-            "codex_tui prompt draft still present after clear attempt"
-        );
-    }
-    Err(format!(
-        "codex tui prompt draft could not be cleared before prompt submit (tmux_session_name={session_name} pane_tail={})",
-        snapshot.pane_tail
-    ))
-}
-
-pub fn send_cancel(session_name: &str) -> Result<(), String> {
-    run_actions(session_name, &plan_cancel(), None)
-}
-
+#[allow(dead_code)] // #3034: test-only executor abstraction (see header note).
 trait TuiActionExecutor {
     fn send_literal(&mut self, session_name: &str, text: &str) -> Result<Output, String>;
     fn load_buffer(&mut self, buffer_name: &str, text: &str) -> Result<Output, String>;
@@ -922,6 +792,8 @@ trait TuiActionExecutor {
     fn send_keys(&mut self, session_name: &str, keys: &[&str]) -> Result<Output, String>;
 }
 
+#[allow(dead_code)] // #3034: production executor impl, only reached via the
+// test-only action layer; kept as the real tmux backing for `run_actions_with_executor`.
 struct TmuxTuiActionExecutor;
 
 impl TuiActionExecutor for TmuxTuiActionExecutor {
@@ -947,15 +819,7 @@ impl TuiActionExecutor for TmuxTuiActionExecutor {
     }
 }
 
-fn run_actions(
-    session_name: &str,
-    actions: &[TuiInputAction],
-    cancel_token: Option<&CancelToken>,
-) -> Result<(), String> {
-    let mut executor = TmuxTuiActionExecutor;
-    run_actions_with_executor(session_name, actions, cancel_token, &mut executor)
-}
-
+#[allow(dead_code)] // #3034: test-only (see header note).
 fn run_actions_with_executor(
     session_name: &str,
     actions: &[TuiInputAction],
@@ -981,6 +845,7 @@ fn run_actions_with_executor(
     Ok(())
 }
 
+#[allow(dead_code)] // #3034: test-only (reached via run_actions_with_executor).
 fn check_prompt_cancel(cancel_token: Option<&CancelToken>) -> Result<(), String> {
     if cancel_requested(cancel_token) {
         Err(PROMPT_READY_CANCELLED_ERROR.to_string())
@@ -989,6 +854,7 @@ fn check_prompt_cancel(cancel_token: Option<&CancelToken>) -> Result<(), String>
     }
 }
 
+#[allow(dead_code)] // #3034: test-only (reached via run_actions_with_executor).
 fn ensure_tmux_success(output: Output, action: &TuiInputAction) -> Result<(), String> {
     if output.status.success() {
         return Ok(());
@@ -1000,18 +866,6 @@ fn ensure_tmux_success(output: Output, action: &TuiInputAction) -> Result<(), St
         TuiInputAction::Enter => "enter",
         TuiInputAction::Escape => "escape",
     };
-    if stderr.is_empty() {
-        Err(format!("tmux send {action_name} failed: {}", output.status))
-    } else {
-        Err(format!("tmux send {action_name} failed: {stderr}"))
-    }
-}
-
-fn ensure_tmux_key_success(output: Output, action_name: &str) -> Result<(), String> {
-    if output.status.success() {
-        return Ok(());
-    }
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
     if stderr.is_empty() {
         Err(format!("tmux send {action_name} failed: {}", output.status))
     } else {
@@ -1275,6 +1129,7 @@ fn pane_has_codex_prompt_draft(pane: &str) -> bool {
             .any(|line| codex_composer_body_line_has_draft(line))
 }
 
+#[allow(dead_code)] // #3034: test-only (draft-clear path retired).
 fn codex_visible_prompt_draft_backspace_budget(
     snapshot: &PromptReadinessSnapshot,
 ) -> Option<usize> {
@@ -1447,6 +1302,7 @@ fn prompt_ready_debug_tail(pane: &str) -> String {
     crate::utils::format::safe_suffix(tail.trim(), PROMPT_READY_DEBUG_TAIL_BYTES).to_string()
 }
 
+#[allow(dead_code)] // #3034: test-only (reached via plan_prompt_submit).
 fn validate_prompt_text(input: &str) -> Result<(), String> {
     // Block terminal control channels such as ESC bracketed-paste markers,
     // DEL, and C1 controls before either literal send or tmux paste-buffer
@@ -1461,6 +1317,7 @@ fn validate_prompt_text(input: &str) -> Result<(), String> {
     Ok(())
 }
 
+#[allow(dead_code)] // #3034: test-only (reached via plan_prompt_submit).
 fn validate_prompt_not_empty(input: &str) -> Result<(), String> {
     if input.trim().is_empty() {
         return Err("prompt must contain non-whitespace text".to_string());
@@ -1468,6 +1325,7 @@ fn validate_prompt_not_empty(input: &str) -> Result<(), String> {
     Ok(())
 }
 
+#[allow(dead_code)] // #3034: test-only (reached via plan_prompt_submit).
 fn split_literal_chunks(input: &str, max_chars: usize) -> Vec<String> {
     if input.is_empty() {
         return Vec::new();

--- a/src/services/codex_tui/rollout_tail.rs
+++ b/src/services/codex_tui/rollout_tail.rs
@@ -237,23 +237,6 @@ pub fn default_codex_sessions_dir() -> Option<PathBuf> {
         .map(|home| home.join("sessions"))
 }
 
-pub fn tail_latest_rollout_for_cwd(
-    cwd: &Path,
-    modified_since: SystemTime,
-    sender: Sender<StreamMessage>,
-    cancel_token: Option<Arc<CancelToken>>,
-    is_alive: impl FnMut() -> bool,
-) -> Result<ReadOutputResult, String> {
-    tail_latest_rollout_for_cwd_with_options(
-        cwd,
-        modified_since,
-        sender,
-        cancel_token,
-        is_alive,
-        RolloutTailOptions::default(),
-    )
-}
-
 pub(crate) fn observe_rollout_turn_state(
     rollout_path: &Path,
 ) -> crate::services::tui_turn_state::TuiTurnState {
@@ -263,23 +246,6 @@ pub(crate) fn observe_rollout_turn_state(
 pub(crate) fn rollout_file_matches_cwd(rollout_path: &Path, cwd: &Path) -> bool {
     let canonical_cwd = std::fs::canonicalize(cwd).unwrap_or_else(|_| cwd.to_path_buf());
     rollout_session_cwd_matches(rollout_path, &canonical_cwd)
-}
-
-pub fn tail_latest_rollout_for_cwd_with_handoff(
-    cwd: &Path,
-    modified_since: SystemTime,
-    sender: Sender<StreamMessage>,
-    cancel_token: Option<Arc<CancelToken>>,
-    is_alive: impl FnMut() -> bool,
-) -> Result<CodexTuiTailResult, String> {
-    tail_latest_rollout_for_cwd_with_handoff_options(
-        cwd,
-        modified_since,
-        sender,
-        cancel_token,
-        is_alive,
-        RolloutTailOptions::default(),
-    )
 }
 
 pub fn tail_latest_rollout_for_cwd_with_handoff_for_tmux(
@@ -302,25 +268,6 @@ pub fn tail_latest_rollout_for_cwd_with_handoff_for_tmux(
         is_alive,
         options,
     )
-}
-
-pub fn tail_latest_rollout_for_cwd_with_options(
-    cwd: &Path,
-    modified_since: SystemTime,
-    sender: Sender<StreamMessage>,
-    cancel_token: Option<Arc<CancelToken>>,
-    is_alive: impl FnMut() -> bool,
-    options: RolloutTailOptions,
-) -> Result<ReadOutputResult, String> {
-    tail_latest_rollout_for_cwd_with_handoff_options(
-        cwd,
-        modified_since,
-        sender,
-        cancel_token,
-        is_alive,
-        options,
-    )
-    .map(|result| result.read_result)
 }
 
 fn tail_latest_rollout_for_cwd_with_handoff_options(
@@ -365,6 +312,9 @@ fn tail_latest_rollout_for_cwd_with_handoff_options(
     })
 }
 
+// #3034: test-only — pins the from-offset replay contract; production replays
+// via `tail_rollout_file_from_offset` (which threads cancel/is-alive).
+#[allow(dead_code)]
 pub fn replay_rollout_file(
     rollout_path: &Path,
     start_offset: u64,
@@ -420,58 +370,6 @@ pub fn tail_rollout_file_from_offset(
     .map(|result| result.0)
 }
 
-pub fn tail_resumed_rollout_for_session(
-    cwd: &Path,
-    session_id: &str,
-    previous_rollout_path: &Path,
-    previous_start_offset: u64,
-    modified_since: SystemTime,
-    sender: Sender<StreamMessage>,
-    cancel_token: Option<Arc<CancelToken>>,
-    is_alive: impl FnMut() -> bool,
-) -> Result<ReadOutputResult, String> {
-    let sessions_dir = default_codex_sessions_dir()
-        .ok_or_else(|| "Codex sessions directory is unavailable".to_string())?;
-    tail_resumed_rollout_for_session_with_options(
-        cwd,
-        session_id,
-        previous_rollout_path,
-        previous_start_offset,
-        modified_since,
-        &sessions_dir,
-        sender,
-        cancel_token,
-        is_alive,
-        RolloutTailOptions::default(),
-    )
-}
-
-pub fn tail_resumed_rollout_for_session_with_handoff(
-    cwd: &Path,
-    session_id: &str,
-    previous_rollout_path: &Path,
-    previous_start_offset: u64,
-    modified_since: SystemTime,
-    sender: Sender<StreamMessage>,
-    cancel_token: Option<Arc<CancelToken>>,
-    is_alive: impl FnMut() -> bool,
-) -> Result<CodexTuiTailResult, String> {
-    let sessions_dir = default_codex_sessions_dir()
-        .ok_or_else(|| "Codex sessions directory is unavailable".to_string())?;
-    tail_resumed_rollout_for_session_with_handoff_options(
-        cwd,
-        session_id,
-        previous_rollout_path,
-        previous_start_offset,
-        modified_since,
-        &sessions_dir,
-        sender,
-        cancel_token,
-        is_alive,
-        RolloutTailOptions::default(),
-    )
-}
-
 pub fn tail_resumed_rollout_for_session_with_handoff_for_tmux(
     cwd: &Path,
     session_id: &str,
@@ -503,6 +401,9 @@ pub fn tail_resumed_rollout_for_session_with_handoff_for_tmux(
     )
 }
 
+// #3034: test-only — the non-handoff resumed-tail variant is exercised by the
+// resume regression tests; production uses the `_with_handoff_for_tmux` form.
+#[allow(dead_code)]
 fn tail_resumed_rollout_for_session_with_options(
     cwd: &Path,
     session_id: &str,

--- a/src/services/dispatched_sessions.rs
+++ b/src/services/dispatched_sessions.rs
@@ -595,20 +595,6 @@ pub struct ForceKillOptions {
     pub reason: Option<String>,
 }
 
-pub(crate) async fn force_kill_session_impl(
-    state: &AppState,
-    session_key: &str,
-    retry: bool,
-) -> (StatusCode, Json<serde_json::Value>) {
-    force_kill_session_impl_with_reason(
-        state,
-        session_key,
-        retry,
-        "force-kill API 직접 호출 (호출자 미상)",
-    )
-    .await
-}
-
 pub(crate) async fn force_kill_session_impl_with_reason(
     state: &AppState,
     session_key: &str,

--- a/src/services/git/runner.rs
+++ b/src/services/git/runner.rs
@@ -56,6 +56,9 @@ impl GitCommand {
         self
     }
 
+    // #3034: test-only builder setter — exercised by the runner timeout tests;
+    // production callers rely on the default timeout.
+    #[allow(dead_code)]
     pub fn timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
         self
@@ -316,6 +319,9 @@ impl GitCommandError {
         &self.stdout
     }
 
+    // #3034: test-only accessor — the error tests assert on raw stderr;
+    // production formats via Display.
+    #[allow(dead_code)]
     pub fn stderr(&self) -> &[u8] {
         &self.stderr
     }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -8,18 +8,12 @@ pub mod automation_candidate_contract;
 pub mod automation_candidate_materializer;
 pub mod claude;
 pub mod claude_e;
-// #3034: 16 residual dead-code items; scoped here so the lint stays
-// live on clean sibling modules. Remove during claude_tui dead-code cleanup.
-#[allow(dead_code)]
 pub mod claude_tui;
 pub mod cluster;
 pub mod codex;
 pub mod codex_remote_policy;
 #[cfg(unix)]
 pub mod codex_tmux_wrapper;
-// #3034: 31 residual dead-code items; scoped here so the lint stays
-// live on clean sibling modules. Remove during codex_tui dead-code cleanup.
-#[allow(dead_code)]
 pub mod codex_tui;
 // #3034: 113 residual dead-code items; scoped here so the lint stays
 // live on clean sibling modules. Remove during discord dead-code cleanup.
@@ -34,9 +28,6 @@ pub(crate) use dispatches::discord_delivery;
 pub mod discord_dm_reply_store;
 pub mod disk_monitor;
 pub mod dispatch_watchdog;
-// #3034: 1 residual dead-code items; scoped here so the lint stays
-// live on clean sibling modules. Remove during dispatched_sessions dead-code cleanup.
-#[allow(dead_code)]
 pub mod dispatched_sessions;
 pub mod dispatches;
 // #3034: 1 residual dead-code items; scoped here so the lint stays
@@ -50,9 +41,6 @@ pub mod dispatches_followup;
 pub mod envelope_dedup;
 pub mod escalation_settings;
 pub mod gemini;
-// #3034: 2 residual dead-code items; scoped here so the lint stays
-// live on clean sibling modules. Remove during git dead-code cleanup.
-#[allow(dead_code)]
 pub mod git;
 pub mod issue_announcements;
 pub mod kanban;
@@ -82,9 +70,6 @@ pub mod platform;
 // live on clean sibling modules. Remove during pr_summary dead-code cleanup.
 #[allow(dead_code)]
 pub mod pr_summary;
-// #3034: 14 residual dead-code items; scoped here so the lint stays
-// live on clean sibling modules. Remove during process dead-code cleanup.
-#[allow(dead_code)]
 pub mod process;
 // #3034: residual dead code here is the intentional-but-unwired #2662/#2668
 // envelope + dev-role dedup infrastructure (gated behind AGENTDESK_ENVELOPE_DEDUP

--- a/src/services/process.rs
+++ b/src/services/process.rs
@@ -124,14 +124,6 @@ pub fn wait_with_output_timeout(
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SortField {
-    Pid,
-    Cpu,
-    Mem,
-    Command,
-}
-
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct ProcessInfo {
@@ -461,48 +453,6 @@ pub(crate) fn shell_escape(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
 
-/// Protected PIDs that should never be killed
-const PROTECTED_PIDS: &[i32] = &[1, 2];
-
-/// Minimum PID threshold - PIDs below this are likely kernel threads
-const MIN_SAFE_PID: i32 = 300;
-
-/// Validate PID is a safe positive integer
-fn is_valid_pid(pid: i32) -> bool {
-    pid > 0 && pid <= 4194304 // Max PID on Linux
-}
-
-/// Check if PID is protected from being killed
-fn is_protected_pid(pid: i32, command: Option<&str>) -> Result<(), String> {
-    // Check if it's our own process
-    let current_pid = std::process::id() as i32;
-    if pid == current_pid {
-        return Err("Cannot kill the file manager itself".to_string());
-    }
-
-    // Check protected system PIDs
-    if PROTECTED_PIDS.contains(&pid) {
-        return Err(format!("Cannot kill system process (PID {})", pid));
-    }
-
-    // Warn about low PIDs (likely kernel threads)
-    if pid < MIN_SAFE_PID {
-        return Err(format!(
-            "Cannot kill low PID ({}) - likely a kernel thread",
-            pid
-        ));
-    }
-
-    // Check if command indicates kernel thread
-    if let Some(cmd) = command {
-        if cmd.starts_with('[') && cmd.ends_with(']') {
-            return Err("Cannot kill kernel threads".to_string());
-        }
-    }
-
-    Ok(())
-}
-
 /// Result type for process list operations
 pub type ProcessListResult = Result<Vec<ProcessInfo>, String>;
 
@@ -590,6 +540,9 @@ fn parse_process_line(line: &str) -> Option<ProcessInfo> {
     })
 }
 
+// #3034: Windows-only — reached solely from the tasklist branch of
+// `get_process_list_result`; gated so the non-Windows build does not flag it.
+#[cfg(target_os = "windows")]
 fn parse_tasklist_line(line: &str) -> Option<ProcessInfo> {
     let fields = parse_csv_record(line)?;
     if fields.len() < 5 {
@@ -629,6 +582,8 @@ fn parse_tasklist_line(line: &str) -> Option<ProcessInfo> {
     })
 }
 
+// #3034: Windows-only — CSV splitter for tasklist output (see parse_tasklist_line).
+#[cfg(target_os = "windows")]
 fn parse_csv_record(line: &str) -> Option<Vec<String>> {
     let mut fields = Vec::new();
     let mut current = String::new();
@@ -661,6 +616,8 @@ fn parse_csv_record(line: &str) -> Option<Vec<String>> {
     Some(fields)
 }
 
+// #3034: Windows-only — parses tasklist "Mem Usage" KB column (see parse_tasklist_line).
+#[cfg(target_os = "windows")]
 fn parse_tasklist_memory_kb(value: &str) -> u64 {
     value
         .chars()
@@ -676,161 +633,6 @@ fn get_process_starttime(pid: i32) -> Option<u64> {
     let stat_path = format!("/proc/{}/stat", pid);
     let content = std::fs::read_to_string(stat_path).ok()?;
     parse_linux_proc_stat_starttime(&content)
-}
-
-/// Verify process identity before kill to mitigate PID reuse race condition
-#[cfg(target_os = "linux")]
-fn verify_process_identity(pid: i32, saved_starttime: Option<u64>) -> Result<(), String> {
-    if let Some(saved) = saved_starttime {
-        if let Some(current) = get_process_starttime(pid) {
-            if saved != current {
-                return Err("Process PID was reused by a different process".to_string());
-            }
-        }
-    }
-    Ok(())
-}
-
-#[cfg(not(target_os = "linux"))]
-fn verify_process_identity(_pid: i32, _saved_starttime: Option<u64>) -> Result<(), String> {
-    // On non-Linux platforms, skip starttime verification
-    Ok(())
-}
-
-/// Kill a process by PID
-pub fn kill_process(pid: i32) -> Result<(), String> {
-    kill_process_with_verification(pid, None)
-}
-
-/// Kill a process by PID with optional starttime verification
-pub fn kill_process_with_verification(pid: i32, starttime: Option<u64>) -> Result<(), String> {
-    if !is_valid_pid(pid) {
-        return Err("Invalid PID".to_string());
-    }
-
-    // Get process info to check if it's a kernel thread
-    let command = get_process_command(pid);
-    is_protected_pid(pid, command.as_deref())?;
-
-    verify_process_identity(pid, starttime)?;
-
-    #[cfg(unix)]
-    {
-        // Use libc kill for safety
-        #[allow(unsafe_code)]
-        let result = unsafe { libc::kill(pid, libc::SIGTERM) };
-        if result == 0 {
-            Ok(())
-        } else {
-            let errno = std::io::Error::last_os_error();
-            match errno.raw_os_error() {
-                Some(libc::ESRCH) => Err("Process not found".to_string()),
-                Some(libc::EPERM) => Err("Permission denied".to_string()),
-                _ => Err(errno.to_string()),
-            }
-        }
-    }
-    #[cfg(not(unix))]
-    {
-        // Use taskkill on Windows
-        let status = Command::new("taskkill")
-            .args(["/PID", &pid.to_string()])
-            .status()
-            .map_err(|e| format!("Failed to execute taskkill: {}", e))?;
-        if status.success() {
-            Ok(())
-        } else {
-            Err(format!("taskkill failed with code {:?}", status.code()))
-        }
-    }
-}
-
-/// Force kill a process by PID (SIGKILL)
-pub fn force_kill_process(pid: i32) -> Result<(), String> {
-    force_kill_process_with_verification(pid, None)
-}
-
-/// Force kill a process by PID (SIGKILL) with optional starttime verification
-pub fn force_kill_process_with_verification(
-    pid: i32,
-    starttime: Option<u64>,
-) -> Result<(), String> {
-    if !is_valid_pid(pid) {
-        return Err("Invalid PID".to_string());
-    }
-
-    let command = get_process_command(pid);
-    is_protected_pid(pid, command.as_deref())?;
-
-    verify_process_identity(pid, starttime)?;
-
-    #[cfg(unix)]
-    {
-        #[allow(unsafe_code)]
-        let result = unsafe { libc::kill(pid, libc::SIGKILL) };
-        if result == 0 {
-            Ok(())
-        } else {
-            let errno = std::io::Error::last_os_error();
-            match errno.raw_os_error() {
-                Some(libc::ESRCH) => Err("Process not found".to_string()),
-                Some(libc::EPERM) => Err("Permission denied".to_string()),
-                _ => Err(errno.to_string()),
-            }
-        }
-    }
-    #[cfg(not(unix))]
-    {
-        // Use taskkill /F for force kill on Windows
-        let status = Command::new("taskkill")
-            .args(["/F", "/PID", &pid.to_string()])
-            .status()
-            .map_err(|e| format!("Failed to execute taskkill: {}", e))?;
-        if status.success() {
-            Ok(())
-        } else {
-            Err(format!("taskkill failed with code {:?}", status.code()))
-        }
-    }
-}
-
-/// Get process command by PID
-fn get_process_command(pid: i32) -> Option<String> {
-    #[cfg(target_os = "windows")]
-    {
-        let filter = format!("PID eq {pid}");
-        let output = Command::new("tasklist")
-            .args(["/FO", "CSV", "/NH", "/FI", &filter])
-            .output()
-            .ok()?;
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        stdout.lines().find_map(|line| {
-            let fields = parse_csv_record(line)?;
-            let image = fields.first()?.trim();
-            if image.is_empty() || image.starts_with("INFO:") {
-                None
-            } else {
-                Some(image.to_string())
-            }
-        })
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    {
-        // Use "command=" format to suppress header (POSIX compatible, works on Linux and macOS)
-        let output = Command::new("ps")
-            .args(["-p", &pid.to_string(), "-o", "command="])
-            .output()
-            .ok()?;
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let command = stdout.trim();
-        if command.is_empty() {
-            None
-        } else {
-            Some(command.to_string())
-        }
-    }
 }
 
 #[cfg(all(test, unix))]


### PR DESCRIPTION
Batch 4 of #3034. Removes the per-submodule scoped `#[allow(dead_code)]` for **claude_tui, codex_tui, process, git, dispatched_sessions** by deleting genuinely-dead items and narrowly annotating the rest. Net **-525 lines** (77 +, 602 -), 11 files.

> The original prompt referenced `qwen.rs`, `shell_guard.rs`, `agent_protocol.rs`, `turn_cancel_finalizer.rs`, `monitoring_store.rs` as in-scope — these already had **no scoped allow and no dead-code warnings** (clean), so no change was needed.

## Per-file table

| File | DELETED (zero-ref) | KEPT + annotated (reason) |
|------|--------------------|---------------------------|
| `claude_tui/hook_server.rs` | `HookServerHandle` (+`addr`/`base_url`/`Drop`), `spawn_hook_server`, `spawn_hook_server_with_state`, `hook_standalone_router`, `health` — standalone server never spawned (prod mounts `hook_receiver_router`) | `signal_prompt_ready_for_test` (test-only wake hook) |
| `claude_tui/input.rs` | `send_prompt`, `send_cancel` (no callers) | `plan_cancel`, `wait_for_prompt_ready_event`, `claude_prompt_draft_backspace_budget_from_line` (test-only) |
| `claude_tui/hook_bundle.rs` | — | `run_codex_hook_launch_self_check` (test-only; prod uses `_with_exec_path`) |
| `claude_tui/transcript_tail.rs` | — | `TranscriptReplayOutcome`, `replay_transcript_file`, `claude_project_dir_for_cwd` (test-only replay surface) |
| `codex_tui/input.rs` | dead `TuiInputAction` send path: `send_fresh_prompt`, `send_followup_prompt`, `send_cancel`, `send_prompt_with_readiness`, `wait_until_codex_tui_input_visible_for_clear`, `clear_codex_tui_prompt_draft_if_present`, `run_actions`, `ensure_tmux_key_success` | test-only action layer: `TuiInputAction`, `plan_prompt_submit`, `plan_cancel`, `run_actions_with_executor`, `TuiActionExecutor`, `TmuxTuiActionExecutor`, `check_prompt_cancel`, `ensure_tmux_success`, `validate_prompt_text`, `validate_prompt_not_empty`, `split_literal_chunks`, `codex_visible_prompt_draft_backspace_budget`, `mark_rollout_composer_busy`, `DEFAULT_LITERAL_CHUNK_CHARS`, `PromptReadinessKind::FreshTurn`, `PromptDraftPolicy::AcceptDraftForClear` |
| `codex_tui/rollout_tail.rs` | superseded wrappers: `tail_latest_rollout_for_cwd`, `_with_handoff`, `_with_options`, `tail_resumed_rollout_for_session`, `_with_handoff` (prod uses `_for_tmux` variants) | `replay_rollout_file`, `tail_resumed_rollout_for_session_with_options` (test-only) |
| `process.rs` | dead kill subsystem: `kill_process[_with_verification]`, `force_kill_process[_with_verification]`, `is_valid_pid`, `is_protected_pid`, `PROTECTED_PIDS`, `MIN_SAFE_PID`, `verify_process_identity`, `get_process_command`; `SortField` enum | `parse_tasklist_line`, `parse_csv_record`, `parse_tasklist_memory_kb` → `#[cfg(target_os="windows")]` (Windows-live, only flagged on macOS) |
| `git/runner.rs` | — | `GitCommand::timeout`, `GitCommandError::stderr` (test-only builder/accessor) |
| `dispatched_sessions.rs` | `force_kill_session_impl` thin wrapper (no callers) | — |
| `services/mod.rs` | scoped allows + #3034 comments for the 5 cleaned modules | — |

## Cascade deletions
- `claude_tui/hook_server.rs`: removed now-unused `std::net::SocketAddr`, `axum::routing::get`, `tokio::sync::oneshot` imports.
- `process.rs`: `get_process_command` (only reached by deleted kill fns); `get_process_starttime` **kept** (still used by live `read_process_starttime`).

## STOPPED — human decision needed
None. Every retained item is either test-referenced (pinned contract) or platform-conditional-live; no env-flag-gated / follow-up-issue infra was touched. The `provider.rs`/`envelope_dedup` intentional-unwired allows and all hard-excluded relay/discord/turn_orchestrator files were left untouched.

## Gate results
- `cargo fmt --check`: clean
- `cargo check --lib`: no errors; **zero dead_code warnings in scope** (only 2 pre-existing out-of-scope `discord/` warnings remain)
- `cargo test --lib`: claude_tui 133 / codex_tui 105 / process 11 / git 4 passed; dispatched_sessions compiles
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py`: **agent-maintenance freshness check passed** (synced 4 production line counts in change-surfaces.md)
- `audit_maintainability.py`: exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)