### PR TITLE
refactor(#3034): batch5 dead-code sweep (server routes + standalone services)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -757,7 +757,7 @@
     `crate::services::kanban`).
   - `src/server/routes/docs.rs` (5880 lines).
   - `src/server/routes/escalation.rs` (1376 lines).
-  - `src/server/routes/meetings.rs` (1686 lines).
+  - `src/server/routes/meetings.rs` (1675 lines).
   - `src/server/routes/review_verdict/decision_route.rs` (4377 lines).
   - `src/server/routes/{agents,agents_crud,agents_setup,v1,resume}.rs` (all
     1000+ production lines). (`dispatches/thread_reuse.rs` dropped below the

--- a/src/server/routes/meetings.rs
+++ b/src/server/routes/meetings.rs
@@ -1602,17 +1602,6 @@ fn direct_start_error_status(error: &str) -> StatusCode {
     StatusCode::INTERNAL_SERVER_ERROR
 }
 
-// reason: meeting-start command builder currently exercised only by the
-// `#[cfg(test)]` unit tests in this module; no production caller in the lib
-// build. See #3034.
-#[allow(dead_code)]
-fn build_meeting_start_command(agenda: &str, primary_provider: Option<ProviderKind>) -> String {
-    match primary_provider {
-        Some(provider) => format!("/meeting start --primary {} {}", provider.as_str(), agenda),
-        None => format!("/meeting start {agenda}"),
-    }
-}
-
 fn short_query_hash(input: &str) -> String {
     use sha2::{Digest, Sha256};
 

--- a/src/services/memory/mod.rs
+++ b/src/services/memory/mod.rs
@@ -72,8 +72,12 @@ pub(crate) enum RecallMode {
 }
 
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 pub(crate) struct RecallRequest {
+    // reason: populated by all discord recall constructors for parity with
+    // CaptureRequest but not yet consumed on the recall path; kept as a stable
+    // request field rather than churning the (out-of-scope) discord call sites.
+    // See #3034.
+    #[allow(dead_code)]
     pub provider: ProviderKind,
     pub role_id: String,
     pub channel_id: u64,

--- a/src/services/observability/quality_alert.rs
+++ b/src/services/observability/quality_alert.rs
@@ -39,42 +39,12 @@ async fn quality_alert_target_pg(pool: &PgPool) -> Result<Option<String>> {
     Ok(value.as_deref().and_then(normalize_channel_target))
 }
 
-#[allow(dead_code)] // #2049 Finding 7: superseded by claim_quality_alert_slot_pg.
-// Kept for unit tests and operator-facing ad-hoc tooling.
-async fn quality_alert_recently_sent_pg(pool: &PgPool, key: &str, now_ms: i64) -> Result<bool> {
-    let last_ms =
-        sqlx::query_scalar::<_, Option<String>>("SELECT value FROM kv_meta WHERE key = $1 LIMIT 1")
-            .bind(key)
-            .fetch_optional(pool)
-            .await
-            .map_err(|error| anyhow!("load quality alert dedupe key {key}: {error}"))?
-            .flatten()
-            .and_then(|value| value.parse::<i64>().ok());
-    Ok(last_ms.is_some_and(|last_ms| now_ms.saturating_sub(last_ms) < QUALITY_ALERT_DEDUPE_MS))
-}
-
-#[allow(dead_code)] // #2049 Finding 7: superseded by claim_quality_alert_slot_pg.
-async fn mark_quality_alert_sent_pg(pool: &PgPool, key: &str, now_ms: i64) -> Result<()> {
-    sqlx::query(
-        "INSERT INTO kv_meta (key, value)
-         VALUES ($1, $2)
-         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value",
-    )
-    .bind(key)
-    .bind(now_ms.to_string())
-    .execute(pool)
-    .await
-    .map_err(|error| anyhow!("mark quality alert dedupe key {key}: {error}"))?;
-    Ok(())
-}
-
 /// #2049 Finding 7: atomically claim the dedupe slot for `key` if and only if
 /// the previous claim is older than `QUALITY_ALERT_DEDUPE_MS`. Returns `true`
 /// when this caller won the race and may proceed to enqueue the outbox row;
 /// `false` when another concurrent rollup already claimed the slot. Compresses
-/// the prior `quality_alert_recently_sent_pg` + `mark_quality_alert_sent_pg`
-/// two-step (TOCTOU) into a single statement using `INSERT ... ON CONFLICT ...
-/// WHERE`.
+/// the prior recently-sent check + mark-sent two-step (TOCTOU) into a single
+/// statement using `INSERT ... ON CONFLICT ... WHERE`.
 async fn claim_quality_alert_slot_pg(pool: &PgPool, key: &str, now_ms: i64) -> Result<bool> {
     let dedupe_ms = QUALITY_ALERT_DEDUPE_MS;
     // Defensive cast: kv_meta.value is shared by other writers and may hold


### PR DESCRIPTION
Batch 5 of #3034 dead-code lint-debt removal. Scope: assigned server-tree files + non-relay/non-discord standalone service files only. No axum route handler or wire DTO was deleted — router wiring and Json-extractor usage were verified first.

## Per-file outcome

| File | DELETED | KEPT (+ narrow allow / reason) |
| --- | --- | --- |
| `src/server/routes/mod.rs` | — | `api_router_with_pg` — cfg(test) router builder (caller in `health_api.rs` `#[cfg(test)] mod tests`) |
| `src/server/dto/kanban.rs` | — | `RetryCardBody`, `RedispatchCardBody`, `ReopenBody` — axum `Json<...>` extractors; allow masks unread wire fields |
| `src/server/resource_locks.rs` | — | `unreal_project_lock_key` — only `multinode_regression.rs` (entirely `#[cfg(test)]`) + in-file unit tests |
| `src/server/routes/meetings.rs` | **`build_meeting_start_command`** — zero references anywhere (stale "cfg(test)-only" docstring) | — |
| `src/server/routes/kanban_repos.rs` | — | `UpdateRepoBody` — axum `Json<...>` extractor (handler line 156) |
| `src/server/routes/receipt.rs` | — | `prewarm_token_analytics_cache` — intentional ready-but-unwired boot hook |
| `src/services/cluster/node_registry.rs` | — | `wait_until_leader` — used by `#[tokio::test]` leadership-transition test |
| `src/services/observability/quality_alert.rs` | **`quality_alert_recently_sent_pg`**, **`mark_quality_alert_sent_pg`** — superseded by `claim_quality_alert_slot_pg` (#2049 F7); no call sites incl. tests | `claim_quality_alert_slot_pg` (live, used line 149) |
| `src/services/routines/loader.rs` | — | `load_dir` — cfg(test) shim used by 6 in-file tests |
| `src/services/auto_queue/route_types.rs` | — | `mode`/`parallel`/`max_concurrent_per_agent` — legacy serde wire-compat fields (deserialized, intentionally ignored) |
| `src/services/memory/mod.rs` | — | `RecallRequest.provider` — struct-wide allow **narrowed** to field-level allow (only unread field); struct is live, field populated by out-of-scope discord call sites |

## Cascade
- `quality_alert.rs`: fixed surviving `claim_quality_alert_slot_pg` docstring that named the two deleted fns. `anyhow!` import still used (14x), `QUALITY_ALERT_DEDUPE_MS` still used. No orphaned imports.
- `meetings.rs`: `ProviderKind` import still used (parsers/binders). No orphaned imports.

## STOPPED — human decision needed
None. All ambiguous items resolved (test-only or intentional-unwired → kept with narrow scoped allow + reason).

## Gates
- `cargo fmt --check`: clean
- `cargo check --lib`: clean (2 pre-existing unrelated warnings: `tmux_watcher.rs` unused-assignment + one other, both present on origin/main baseline; no new dead-code warnings)
- lib tests (affected modules): resource_locks 2/2, routines::loader 31/31, cluster::node_registry 11/11, services::memory 19/19, routes::kanban 5/5 — all pass; meetings/quality_alert test build compiles clean
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py`: **agent-maintenance freshness check passed** (synced `meetings.rs` production line count 1686→1675 in change-surfaces.md). multinode-transition.md touch NOT required by the gate.
- `audit_maintainability.py`: exit 0

Net: +8 / -45 across 4 files. Pure dead-code removal + one struct→field allow narrowing; no runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)