### PR TITLE
refactor(#3034): batch7 dead-code cleanup — turn_orchestrator + discord leftovers

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -943,7 +943,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   so a live thread-suffixed TUI session with no live watcher slot can be
   re-registered authoritatively instead of dropped forever),
   `src/services/discord_config_audit.rs` (1273).
-- `src/services/turn_orchestrator.rs` (3090).
+- `src/services/turn_orchestrator.rs` (3086).
 
 Decomposed below the giant-file threshold (no longer frozen; bugfix-scoped but
 normal test growth is allowed): `src/services/analytics.rs`,

--- a/src/services/discord/org_schema.rs
+++ b/src/services/discord/org_schema.rs
@@ -20,8 +20,13 @@ pub(super) struct OrgSchema {
     // compatibility; no in-code reader today.
     #[allow(dead_code)]
     pub version: u32,
+    // #3034: serde wire field deserialized from the org schema for forward
+    // compatibility; no in-code reader today.
     #[allow(dead_code)]
     pub name: Option<String>,
+    // serde-deserialized; consumed by `load_shared_prompt_path` (the shared-prompt
+    // fallback chain whose root caller is currently dormant — see that fn).
+    #[allow(dead_code)]
     pub shared_prompt: Option<String>,
     /// Root directory for prompt files (e.g. "$AGENTDESK_ROOT_DIR/prompts").
     /// When set, agent prompt_file is auto-derived as

--- a/src/services/discord/voice_sensitivity.rs
+++ b/src/services/discord/voice_sensitivity.rs
@@ -60,6 +60,9 @@ impl SensitivityState {
         }
     }
 
+    // #3038 slice constructor mirroring `VoiceBargeInRuntime::disabled()`; that
+    // runtime constructor is currently dormant, so the lib build sees no caller.
+    #[allow(dead_code)]
     pub(in crate::services::discord) fn disabled() -> Self {
         let default_sensitivity = BargeInSensitivity::Normal;
         Self {
@@ -86,6 +89,9 @@ impl SensitivityState {
             .set_sensitivity(sensitivity, Instant::now());
     }
 
+    // #3038 slice delegate behind `VoiceBargeInRuntime::apply_voice_command`,
+    // which is currently dormant, so the lib build sees no live caller.
+    #[allow(dead_code)]
     pub(in crate::services::discord) async fn apply_voice_command(
         &self,
         transcript: &str,

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -15,8 +15,10 @@ pub mod codex_remote_policy;
 #[cfg(unix)]
 pub mod codex_tmux_wrapper;
 pub mod codex_tui;
-// #3034: 113 residual dead-code items; scoped here so the lint stays
-// live on clean sibling modules. Remove during discord dead-code cleanup.
+// #3034: residual dead-code items in not-yet-cleaned discord submodules;
+// scoped here so the lint stays live on clean sibling modules. Cleaned
+// submodules carry their own narrow per-item allows. Remove once the remaining
+// discord submodules are cleaned.
 #[allow(dead_code)]
 pub mod discord;
 pub mod discord_config_audit;
@@ -123,9 +125,6 @@ pub(crate) mod tui_prompt_dedupe;
 pub(crate) mod tui_turn_state;
 pub mod turn_cancel_finalizer;
 pub mod turn_lifecycle;
-// #3034: 10 residual dead-code items; scoped here so the lint stays
-// live on clean sibling modules. Remove during turn_orchestrator dead-code cleanup.
-#[allow(dead_code)]
 pub mod turn_orchestrator;
 
 // Compatibility alias: code referencing services::remote::* uses the stub

--- a/src/services/turn_orchestrator.rs
+++ b/src/services/turn_orchestrator.rs
@@ -49,6 +49,11 @@ pub(crate) struct Intervention {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum QueueExitKind {
     Cancelled,
+    // #3177: age-eviction was removed (queued user input must never expire), so
+    // nothing constructs this arm anymore; the display contract in
+    // `discord::queue_exit_feedback_emoji`/`queue_exit_card_body` still handles
+    // it, so it is kept as a stable feedback-surface variant.
+    #[allow(dead_code)]
     Expired,
     Superseded,
 }
@@ -480,23 +485,6 @@ fn cleanup_stale_pending_queue_tmp_files_under_root(
     audits
 }
 
-pub(crate) fn cleanup_stale_pending_queue_tmp_files(
-    provider: &ProviderKind,
-    token_hash: &str,
-) -> Vec<PendingQueueTmpCleanupAudit> {
-    let Some(root) = pending_queue_root() else {
-        return Vec::new();
-    };
-    let dir = root.join(provider.as_str()).join(token_hash);
-    cleanup_stale_pending_queue_tmp_files_in_dir(
-        provider,
-        token_hash,
-        &dir,
-        SystemTime::now(),
-        STALE_PENDING_QUEUE_TMP_AGE,
-    )
-}
-
 pub(crate) fn cleanup_stale_pending_queue_tmp_files_all_tokens() -> Vec<PendingQueueTmpCleanupAudit>
 {
     let Some(root) = pending_queue_root() else {
@@ -817,12 +805,20 @@ pub(crate) struct FinishTurnResult {
     pub(crate) has_pending: bool,
     pub(crate) mailbox_online: bool,
     pub(crate) queue_exit_events: Vec<QueueExitEvent>,
+    // Carries a real `persist_queue_or_restore` failure on the finish-turn path;
+    // part of the uniform queue-mutation result contract. No caller consumes it
+    // yet, but it is written with genuine error info so it is kept rather than
+    // silently dropped.
+    #[allow(dead_code)]
     pub(crate) persistence_error: Option<String>,
 }
 
 pub(crate) struct ClearChannelResult {
     pub(crate) removed_token: Option<Arc<CancelToken>>,
     pub(crate) queue_exit_events: Vec<QueueExitEvent>,
+    // Uniform queue-mutation persistence-result surface; written on the
+    // clear-channel path, no consumer yet. See `FinishTurnResult`.
+    #[allow(dead_code)]
     pub(crate) persistence_error: Option<String>,
 }
 
@@ -845,6 +841,9 @@ pub(crate) struct PurgeQueueResult {
 pub(crate) struct HasPendingSoftQueueResult {
     pub(crate) has_pending: bool,
     pub(crate) queue_exit_events: Vec<QueueExitEvent>,
+    // Uniform queue-mutation persistence-result surface; no consumer yet.
+    // See `FinishTurnResult`.
+    #[allow(dead_code)]
     pub(crate) persistence_error: Option<String>,
 }
 
@@ -917,6 +916,9 @@ pub(crate) struct EnqueueInterventionResult {
 pub(crate) struct CancelQueuedMessageResult {
     pub(crate) removed: Option<Intervention>,
     pub(crate) queue_exit_events: Vec<QueueExitEvent>,
+    // Uniform queue-mutation persistence-result surface; no consumer yet.
+    // See `FinishTurnResult`.
+    #[allow(dead_code)]
     pub(crate) persistence_error: Option<String>,
 }
 
@@ -930,6 +932,9 @@ pub(crate) struct TakeNextSoftResult {
 
 pub(crate) struct RequeueInterventionResult {
     pub(crate) queue_exit_events: Vec<QueueExitEvent>,
+    // Uniform queue-mutation persistence-result surface; no consumer yet.
+    // See `FinishTurnResult`.
+    #[allow(dead_code)]
     pub(crate) persistence_error: Option<String>,
 }
 
@@ -972,17 +977,6 @@ impl ChannelMailboxHandle {
             .await
     }
 
-    pub(crate) async fn cancel_active_turn(&self) -> CancelActiveTurnResult {
-        self.request(
-            |reply| ChannelMailboxMsg::CancelActiveTurn { reply },
-            CancelActiveTurnResult {
-                token: None,
-                already_stopping: false,
-            },
-        )
-        .await
-    }
-
     /// #2374 — atomic "set cancel reason + flip cancelled" performed by
     /// the mailbox actor. PR #2373 (#2335) set `cancel_source` from the
     /// caller task before sending the actor a `CancelActiveTurn`; that
@@ -1014,6 +1008,9 @@ impl ChannelMailboxHandle {
         .await
     }
 
+    // Unguarded `if_current` cancel; production uses the
+    // `_with_reason` variant. Exercised only by `#[cfg(test)]` tests.
+    #[allow(dead_code)]
     pub(crate) async fn cancel_active_turn_if_current(
         &self,
         expected_token: Arc<CancelToken>,
@@ -1146,6 +1143,10 @@ impl ChannelMailboxHandle {
         .await
     }
 
+    // Default-kind restore wrapper; the production restore path lives in the
+    // (currently dormant) `mailbox_restore_active_turn`. Exercised only by
+    // `#[cfg(test)]` tests.
+    #[allow(dead_code)]
     pub(crate) async fn restore_active_turn(
         &self,
         cancel_token: Arc<CancelToken>,
@@ -1165,6 +1166,8 @@ impl ChannelMailboxHandle {
     /// #3167 — kinded variant of [`Self::restore_active_turn`]. Preserves the
     /// background classification across a restore so the dequeue gates stay
     /// background-aware after a re-bind.
+    // Reached only via the dormant restore wrapper / `#[cfg(test)]` tests.
+    #[allow(dead_code)]
     pub(crate) async fn restore_active_turn_kinded(
         &self,
         cancel_token: Arc<CancelToken>,
@@ -1190,6 +1193,10 @@ impl ChannelMailboxHandle {
     /// (no `cancel_token`). Lets the dequeue path detect a background turn
     /// holding the slot so it can cancel-then-redispatch instead of starving
     /// a queued user intervention.
+    // Production gates read `active_turn_kind` off the snapshot
+    // (`snapshot.active_turn_kind`); this async accessor is exercised only by
+    // `#[cfg(test)]` tests.
+    #[allow(dead_code)]
     pub(crate) async fn active_turn_kind(&self) -> Option<ActiveTurnKind> {
         self.request(|reply| ChannelMailboxMsg::ActiveTurnKind { reply }, None)
             .await
@@ -1749,6 +1756,9 @@ impl ChannelMailboxRegistry {
         resolved
     }
 
+    // Global-registry accessor for the latched turn-finished signal; exercised
+    // only by `#[cfg(test)]` late-subscriber tests.
+    #[allow(dead_code)]
     pub(crate) fn global_turn_finished(channel_id: ChannelId) -> Option<Arc<TurnFinishedSignal>> {
         GLOBAL_TURN_FINISHED_SIGNALS
             .get(&channel_id)
@@ -1814,20 +1824,21 @@ enum ChannelMailboxMsg {
         reply: oneshot::Sender<bool>,
     },
     /// #3167 — current active-turn kind, or `None` when the channel is idle.
+    // Constructed only by the test-only `active_turn_kind` accessor.
+    #[allow(dead_code)]
     ActiveTurnKind {
         reply: oneshot::Sender<Option<ActiveTurnKind>>,
     },
     CancelToken {
         reply: oneshot::Sender<Option<Arc<CancelToken>>>,
     },
-    CancelActiveTurn {
-        reply: oneshot::Sender<CancelActiveTurnResult>,
-    },
     /// #2374 — atomic reason-write + cancel flip performed by the actor.
     CancelActiveTurnWithReason {
         reason: String,
         reply: oneshot::Sender<CancelActiveTurnResult>,
     },
+    // Constructed only by the test-only `cancel_active_turn_if_current`.
+    #[allow(dead_code)]
     CancelActiveTurnIfCurrent {
         expected_token: Arc<CancelToken>,
         reply: oneshot::Sender<CancelActiveTurnResult>,
@@ -1867,6 +1878,8 @@ enum ChannelMailboxMsg {
         turn_kind: ActiveTurnKind,
         reply: oneshot::Sender<bool>,
     },
+    // Constructed only via the dormant restore wrapper / `#[cfg(test)]` tests.
+    #[allow(dead_code)]
     RestoreActiveTurn {
         cancel_token: Arc<CancelToken>,
         request_owner: UserId,
@@ -2390,23 +2403,6 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                 }
                 ChannelMailboxMsg::CancelToken { reply } => {
                     let _ = reply.send(state.cancel_token.clone());
-                }
-                ChannelMailboxMsg::CancelActiveTurn { reply } => {
-                    let token = state.cancel_token.clone();
-                    let already_stopping = token.as_ref().is_some_and(|token| {
-                        token.cancelled.load(std::sync::atomic::Ordering::Relaxed)
-                    });
-                    if let Some(token) = token.as_ref()
-                        && !already_stopping
-                    {
-                        token
-                            .cancelled
-                            .store(true, std::sync::atomic::Ordering::Relaxed);
-                    }
-                    let _ = reply.send(CancelActiveTurnResult {
-                        token,
-                        already_stopping,
-                    });
                 }
                 ChannelMailboxMsg::CancelActiveTurnWithReason { reason, reply } => {
                     // #2374 — atomic, actor-serialized "reason then flip"


### PR DESCRIPTION
## #3034 batch7 — turn_orchestrator + remaining discord scoped allows

Progressively deletes genuinely-dead code and replaces blanket masking with narrow per-item `#[allow(dead_code)]` reasons across the remaining non-hotfile, non-relay-critical modules that still carried scoped allows. Drops the `turn_orchestrator` mod.rs blanket entirely; the discord blanket stays (other discord submodules are still residual, reserved for future batches) with an updated comment.

Prior batches: #3037, #3259, #3264, #3265, #3266, #3267 (batch6).

### Scope confirmation
Enumerated `grep -rl 'allow(dead_code)' src/services` and classified every hit. After exclusions (#3016 relay hotfiles, relay-critical files, provider/envelope_dedup, batch6's 12 files), the only files still carrying their **own** scoped allow in-scope were `discord/org_schema.rs`, `discord/meeting_orchestrator.rs`, `discord/voice_sensitivity.rs`, plus blanket-masked `turn_orchestrator.rs`. The named subdirs (cluster/observability/auto_queue/memory) were already cleaned by prior batches (their allows already carry `// reason` comments referencing #3034).

### Per-file changes

| File | Item | Action | Reason |
|------|------|--------|--------|
| `turn_orchestrator.rs` | `cancel_active_turn` method | DELETED | zero refs incl. tests; prod uses `cancel_active_turn_with_reason` |
| `turn_orchestrator.rs` | `ChannelMailboxMsg::CancelActiveTurn` + actor arm | DELETED | only constructed by the deleted method |
| `turn_orchestrator.rs` | `cleanup_stale_pending_queue_tmp_files` (single-token) | DELETED | zero refs; prod uses `_all_tokens` / `_in_dir` |
| `turn_orchestrator.rs` | `QueueExitKind::Expired` | KEPT (allow) | #3177 stopped constructing it; display contract in `discord::queue_exit_*` still matches it |
| `turn_orchestrator.rs` | 5× `persistence_error` fields (FinishTurn/ClearChannel/HasPendingSoftQueue/CancelQueuedMessage/RequeueIntervention) | KEPT (allow) | uniform queue-mutation persistence-result contract; written with real errors, no consumer yet |
| `turn_orchestrator.rs` | `cancel_active_turn_if_current`, `restore_active_turn`, `restore_active_turn_kinded`, `active_turn_kind`, `global_turn_finished` + their msg variants | KEPT (allow) | exercised only by `#[cfg(test)]` tests (prod restore path is the dormant `mailbox_restore_active_turn`) |
| `discord/org_schema.rs` | `RegisteredChannel` struct + `list_registered_channels` | DELETED | zero refs (HTTP selector never wired) |
| `discord/org_schema.rs` | `version`/`name`/`shared_prompt`/`skills_root` fields, `load_shared_prompt_path` | KEPT (allow+reason) | serde wire fields + dormant shared-prompt fallback arm (root caller unwired) |
| `discord/meeting_orchestrator.rs` | `is_meeting_channel` | DELETED | zero refs |
| `discord/meeting_orchestrator.rs` | `MeetingConfig.channel_name` | KEPT (allow) | sole reader (`is_meeting_channel`) removed; still populated from schema/role_map config |
| `discord/voice_sensitivity.rs` | `disabled()`, `apply_voice_command()` | KEPT (allow) | #3038 slice reached via dormant `VoiceBargeInRuntime::disabled()/apply_voice_command()` |
| `services/mod.rs` | turn_orchestrator blanket | REMOVED | module now clean |
| `services/mod.rs` | discord blanket | RESTORED (comment updated) | other discord submodules still residual |

### Blanket-off zero-warning verification
With both the discord and turn_orchestrator blankets temporarily stripped, `cargo check --lib --tests` shows **0 dead_code warnings** in all scoped files (`turn_orchestrator.rs`, `discord/org_schema.rs`, `discord/meeting_orchestrator.rs`, `discord/voice_sensitivity.rs`). Blankets restored before finalizing.

### Gate results
- ✅ `cargo fmt --check` clean
- ✅ `cargo check --lib` clean — no new dead_code (the 2 remaining warnings, `unused_imports` in placeholder_live_events and `unused_assignments` `last_edit_text` in tmux_watcher, are pre-existing on origin/main)
- ✅ blanket-off `cargo check --lib --tests` → 0 dead_code in scoped files
- ✅ tests: turn_orchestrator 46/0, voice_barge_in 52/0 (exercises voice_sensitivity slice), turn_finalizer 70/0 (exercises `restore_active_turn`)
- ✅ `./scripts/ci-script-checks.sh` exit 0 — await_holding_lock baseline 34 unchanged, giant-file registry unchanged, no new findings
- ✅ `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` → "agent-maintenance freshness check passed" (change-surfaces.md line counts synced: meeting_orchestrator 3227→3224, turn_orchestrator 3090→3086)

Net: +72 / -106 (−34). No multinode-transition.md note required: pure dead-code removal with no behavioral / worker-locality change (maintenance freshness gate passed without one, consistent with prior batches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Rebase note:** Rebased onto the latest `origin/main` after a parallel #3034 batch landed the `org_schema.rs` (skills_root loader removal, serde-field reasons, `RegisteredChannel`/`list_registered_channels` deletion, `load_shared_prompt_path` allow) and `meeting_orchestrator.rs` (`is_meeting_channel` removal + `channel_name` allow) cleanups identically. Conflicts resolved by taking main's canonical wording for those overlapping items. This branch's remaining unique contribution: the full `turn_orchestrator.rs` cleanup, the `voice_sensitivity.rs` allows, and both `mod.rs` blanket changes (turn_orchestrator blanket removed; discord blanket comment updated). All gates (fmt, lib check, blanket-off zero-warning, ci-script-checks exit 0, tests, maintenance freshness) re-verified green on the rebased tree.
