### PR TITLE
fix(#3262): AgentDesk-side /compact injection for Claude (CLAUDE_AUTOCOMPACT_PCT_OVERRIDE ignored)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -641,6 +641,7 @@ src/
 │   ├── automation_candidate_contract.rs
 │   ├── automation_candidate_materializer.rs
 │   ├── claude.rs
+│   ├── claude_compact_trigger.rs
 │   ├── codex.rs
 │   ├── codex_remote_policy.rs
 │   ├── codex_tmux_wrapper.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -131,7 +131,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (9598 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (9582 lines after #2558
     dead-code sweep; #3016 phase-5b2 removed the `mailbox_finalize_owed`
     swap reads, the watcher-fn flag params, and the `LegacyFlagGated`
     decision variant; #1520 watcher loop extraction + #2427 D/A
@@ -410,6 +410,12 @@
     flag-independent; EMPTY `Unknown` DEFERS — the codex HIGH regression case that the
     prior 5b1 build finalized prematurely) +
     `fresh_idle_unknown_keeps_wrong_turn_race_guards`.
+    #3262 (-16): the watcher-completed status-panel context-usage backfill block
+    is extracted into `adk_session::backfill_completed_panel_usage_and_maybe_inject_compact`
+    (a single call now replaces the inline `set_context_panel_usage` block). The
+    helper additionally fires the claude-only AgentDesk-side `/compact` injection
+    when live usage crosses `context_compact_percent_claude` (Claude Code ignores
+    `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`); see `src/services/claude_compact_trigger.rs`.
   - `src/services/discord/tui_prompt_relay.rs` (5438 lines; #3016 phase-5b2
     removed the dead `publish_tui_direct_watcher_finalize_debt` producer;
     SSH-direct TUI

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -906,7 +906,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
 - `src/services/dispatches/outbox_route.rs` (1089) — dispatch outbox route
   support extracted from the route layer; split before adding non-bugfix
   behavior.
-- `src/services/claude.rs` (3909), `src/services/gemini.rs` (1358),
+- `src/services/claude.rs` (3938), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3001),
   `src/services/opencode.rs` (1881), `src/services/provider.rs` (1796) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -257,6 +257,14 @@
   later merge gates can require the exact tested commit before accepting a phase.
 - Local telemetry capture and cache state: `src/services/memory/memento_throttle.rs:128`,
   `src/services/observability/mod.rs:460`, `src/services/observability/metrics.rs:238`.
+- #3262 Claude auto-compact `/compact` injection trigger state:
+  `src/services/claude_compact_trigger.rs`. The once-per-fill-cycle "armed" latch
+  is a **worker-local** process-global `LazyLock<Mutex<HashMap<channel_id, bool>>>`
+  and the injection drives the node-local tmux pane via
+  `claude_tui::input::send_followup_prompt`. A channel's live tmux session is
+  pinned to a single worker (see `tmux_provider_sessions`), so the per-channel
+  latch never needs cross-node coordination; a worker restart simply re-arms the
+  channel (re-injecting at most one redundant `/compact` is harmless and idle-gated).
 
 ## Required Invariants
 

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -58,6 +58,30 @@ fn claude_tui_session_turn_lock(tmux_session_name: &str) -> ClaudeTuiSessionTurn
         .clone()
 }
 
+/// #3262: run a blocking TUI-submit closure under the SAME per-session turn lock
+/// that `execute_streaming_local_tui_tmux` (the normal follow-up path) holds.
+///
+/// The auto-`/compact` injection drives `tmux send-keys` into the same live pane
+/// as a normal Discord follow-up; without sharing this serialization the two can
+/// interleave their readiness check + key sends and corrupt composer input
+/// ordering. Routing the auto-inject through this gate guarantees `/compact` and
+/// a user follow-up never run concurrently against one pane.
+///
+/// This is a synchronous helper: the lock is a `std::sync::Mutex` and `f` is the
+/// blocking submit body, so the guard is never held across an `.await`. Callers
+/// must invoke it from a blocking context (e.g. `spawn_blocking`), exactly like
+/// the normal path which holds this lock inside the blocking
+/// `execute_streaming_local_tui_tmux`.
+#[cfg(unix)]
+pub(crate) fn with_claude_tui_session_turn_lock<R>(
+    tmux_session_name: &str,
+    f: impl FnOnce() -> R,
+) -> R {
+    let turn_lock = claude_tui_session_turn_lock(tmux_session_name);
+    let _turn_guard = turn_lock.lock().unwrap_or_else(|error| error.into_inner());
+    f()
+}
+
 /// Resolve the path to the claude binary.
 pub fn resolve_claude_path() -> Option<String> {
     crate::services::platform::resolve_provider_binary("claude").resolved_path
@@ -632,6 +656,66 @@ where
                 timeout.as_secs()
             ))
         }
+    }
+}
+
+// #3262: the auto `/compact` injection routes through `with_claude_tui_session_turn_lock`
+// — the SAME per-session turn lock the normal follow-up path holds — so a normal
+// user follow-up and the auto-inject can never interleave their readiness check +
+// tmux send against one live pane.
+#[cfg(all(test, unix))]
+mod claude_tui_turn_lock_3262_tests {
+    use super::{claude_tui_session_turn_lock, with_claude_tui_session_turn_lock};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Barrier};
+    use std::time::Duration;
+
+    // The same tmux session name maps to the SAME Arc<Mutex>, so two callers
+    // (a normal follow-up and the auto-inject) contend on one gate.
+    #[test]
+    fn same_session_shares_one_turn_lock() {
+        let a = claude_tui_session_turn_lock("session-3262-shared");
+        let b = claude_tui_session_turn_lock("session-3262-shared");
+        assert!(Arc::ptr_eq(&a, &b));
+        let c = claude_tui_session_turn_lock("session-3262-other");
+        assert!(!Arc::ptr_eq(&a, &c));
+    }
+
+    // Two threads contending on the same session's gate cannot be inside the
+    // critical section simultaneously: serialization holds, so a `/compact`
+    // inject and a normal follow-up never overlap their pane sends.
+    #[test]
+    fn turn_lock_serializes_concurrent_submits() {
+        let session = "session-3262-serialize";
+        let inside = Arc::new(AtomicUsize::new(0));
+        let max_concurrent = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(2));
+
+        let mut handles = Vec::new();
+        for _ in 0..2 {
+            let inside = Arc::clone(&inside);
+            let max_concurrent = Arc::clone(&max_concurrent);
+            let barrier = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                for _ in 0..50 {
+                    with_claude_tui_session_turn_lock(session, || {
+                        let now = inside.fetch_add(1, Ordering::SeqCst) + 1;
+                        max_concurrent.fetch_max(now, Ordering::SeqCst);
+                        std::thread::sleep(Duration::from_micros(50));
+                        inside.fetch_sub(1, Ordering::SeqCst);
+                    });
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(
+            max_concurrent.load(Ordering::SeqCst),
+            1,
+            "turn lock must serialize: at most one submit body inside the gate at a time"
+        );
     }
 }
 

--- a/src/services/claude_compact_trigger.rs
+++ b/src/services/claude_compact_trigger.rs
@@ -15,12 +15,17 @@
 //! Guards (see the issue's Phase-2 design):
 //!   * **claude-only** — the caller passes the provider and we no-op for anything
 //!     but `ProviderKind::Claude` (Codex compacts natively).
-//!   * **threshold-gated, degrade-safe** — a `0`/unset threshold or a `0`
-//!     usage/window signal short-circuits to "no inject".
+//!   * **threshold-gated, degrade-safe** — a `0`/unset threshold short-circuits
+//!     to "no inject" without touching the latch. A `0`/low usage signal does NOT
+//!     short-circuit: it is the post-compact re-arm signal and never injects on
+//!     its own (`should_inject_compact` requires `usage >= threshold`).
 //!   * **once-per-fill-cycle** — a per-channel armed flag is consumed on inject
 //!     and only RE-ARMS after usage drops back below a hysteresis margin (which
-//!     happens when a compact resets the context), so we never re-inject every
-//!     poll while still parked above the threshold.
+//!     happens when a compact resets the context, including a drop to ~0), so we
+//!     never re-inject every poll while still parked above the threshold. The
+//!     latch is consumed optimistically and restored if the send fails, so a
+//!     busy/dead-pane rejection retries on a later idle poll rather than being
+//!     silently swallowed.
 //!   * **idle-only** — the caller invokes this at the turn-completion boundary
 //!     (pane idle); the injection itself rides `send_followup_prompt`, whose
 //!     `wait_for_prompt_ready` gate refuses to submit into a busy pane.
@@ -70,6 +75,17 @@ pub(crate) fn should_rearm(usage_pct: u64, threshold_pct: u64) -> bool {
 /// report whether THIS observation should inject. Combines [`should_inject_compact`]
 /// (consuming the latch on a yes) with [`should_rearm`] (restoring it after a
 /// post-compact drop), so callers get a single edge-triggered answer.
+///
+/// Disarming here is *optimistic*: it consumes the latch the moment we decide to
+/// inject, so two near-simultaneous idle polls cannot both fire (no
+/// double-injection on success). If the subsequent send fails, the caller calls
+/// [`rearm_after_failed_inject`] to restore the latch so a later idle poll
+/// retries while usage is still parked above the threshold (issue #1).
+///
+/// The re-arm check runs FIRST and is independent of `usage_pct == 0`: a
+/// post-compact drop to (or near) zero MUST re-arm the latch. Callers therefore
+/// must NOT short-circuit on `usage_pct == 0` before reaching here, or a
+/// disarmed channel could never re-arm (issue #4).
 fn observe_and_decide(channel_id: u64, usage_pct: u64, threshold_pct: u64) -> bool {
     let mut guard = ARMED_BY_CHANNEL
         .lock()
@@ -80,10 +96,23 @@ fn observe_and_decide(channel_id: u64, usage_pct: u64, threshold_pct: u64) -> bo
         return false;
     }
     if should_inject_compact(usage_pct, threshold_pct, armed) {
+        // Optimistically consume the latch so concurrent polls don't double-fire.
+        // Restored by `rearm_after_failed_inject` if the send fails.
         guard.insert(channel_id, false);
         return true;
     }
     false
+}
+
+/// Restore the armed latch after an injection attempt failed (busy/dead pane or a
+/// rejected send), so a later idle poll retries `/compact` while usage remains
+/// high. Setting the channel back to armed is idempotent — if a concurrent
+/// post-compact drop already re-armed it, this is a harmless no-op write.
+fn rearm_after_failed_inject(channel_id: u64) {
+    let mut guard = ARMED_BY_CHANNEL
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    guard.insert(channel_id, true);
 }
 
 /// Claude-only: when the latest (turn-idle) context usage crosses the configured
@@ -92,8 +121,10 @@ fn observe_and_decide(channel_id: u64, usage_pct: u64, threshold_pct: u64) -> bo
 ///
 /// `usage_pct` is the live context occupancy percentage already computed for the
 /// status panel; `threshold_pct` is `compact_pct_for(Claude)`. No-ops (and never
-/// disarms) for any non-Claude provider, a `0` threshold, or a `0` usage signal,
-/// so an unset threshold or a missing usage/window degrades safely.
+/// touches the latch) for any non-Claude provider or a `0` threshold, so an unset
+/// threshold degrades safely. A `0`/low `usage_pct` is NOT short-circuited: it is
+/// the post-compact re-arm signal and is handled by `observe_and_decide` (which
+/// only injects when usage has reached the threshold).
 pub(crate) fn maybe_inject_compact(
     channel_id: u64,
     tmux_session_name: &str,
@@ -101,12 +132,23 @@ pub(crate) fn maybe_inject_compact(
     usage_pct: u64,
     threshold_pct: u64,
 ) {
-    if !matches!(provider, ProviderKind::Claude) || threshold_pct == 0 || usage_pct == 0 {
+    // Degrade-safe no-ops: a non-Claude provider (Codex compacts natively) or an
+    // unset/zero threshold (feature off) never inject AND never touch the latch.
+    //
+    // NOTE: `usage_pct == 0` is deliberately NOT short-circuited here. A drop to
+    // (or near) zero is exactly the post-compact signal that must RE-ARM a
+    // disarmed channel; `observe_and_decide` runs the re-arm check first and only
+    // injects when `usage_pct >= threshold_pct`, so usage 0 still cannot inject
+    // (issue #4).
+    if !matches!(provider, ProviderKind::Claude) || threshold_pct == 0 {
         return;
     }
     if !observe_and_decide(channel_id, usage_pct, threshold_pct) {
         return;
     }
+    // The latch was just consumed (disarmed) by `observe_and_decide`. From here
+    // the latch is only left disarmed if the send SUCCEEDS; any failure re-arms
+    // it via `rearm_after_failed_inject` so a later idle poll retries (issue #1).
     let tmux_session_name = tmux_session_name.to_string();
     // `send_followup_prompt` is blocking (it polls the pane for readiness and
     // drives tmux send-keys), so it must not run on the async watcher runtime.
@@ -117,22 +159,48 @@ pub(crate) fn maybe_inject_compact(
             threshold_pct,
             "#3262 auto-injecting /compact: live Claude context usage crossed configured threshold at turn-idle"
         );
-        match crate::services::claude_tui::input::send_followup_prompt(
-            &tmux_session_name,
-            "/compact",
-            None,
-        ) {
+        match inject_compact_under_submit_gate(&tmux_session_name) {
             Ok(()) => tracing::info!(
                 tmux_session_name = %tmux_session_name,
                 "#3262 auto /compact injected into live Claude TUI"
             ),
-            Err(error) => tracing::warn!(
-                tmux_session_name = %tmux_session_name,
-                error = %error,
-                "#3262 auto /compact injection skipped (pane busy/unready or send failed); will retry on a later turn"
-            ),
+            Err(error) => {
+                // Send failed (busy/dead pane or rejected submit): re-arm so a
+                // later idle poll retries `/compact` while usage stays high.
+                rearm_after_failed_inject(channel_id);
+                tracing::warn!(
+                    tmux_session_name = %tmux_session_name,
+                    error = %error,
+                    "#3262 auto /compact injection failed (pane busy/unready or send failed); latch re-armed, will retry on a later turn"
+                );
+            }
         }
     });
+}
+
+/// Drive the `/compact` submit through the SAME per-session turn lock that a
+/// normal Discord follow-up holds (issue #2), so the auto-injection and a user
+/// follow-up can never interleave their readiness check + tmux send against one
+/// live pane. The lock is a `std::sync::Mutex` and `send_followup_prompt` is
+/// blocking (no `.await`), so the guard is never held across an await — matching
+/// the established normal-path pattern in `claude::execute_streaming_local_tui_tmux`.
+#[cfg(unix)]
+fn inject_compact_under_submit_gate(tmux_session_name: &str) -> Result<(), String> {
+    crate::services::claude::with_claude_tui_session_turn_lock(tmux_session_name, || {
+        crate::services::claude_tui::input::send_followup_prompt(
+            tmux_session_name,
+            "/compact",
+            None,
+        )
+    })
+}
+
+/// Non-unix builds have no live tmux TUI (the per-session turn lock and the TUI
+/// driver are `#[cfg(unix)]`), so this path is unreachable in practice. Keep a
+/// degrade-safe direct call so the module still compiles everywhere.
+#[cfg(not(unix))]
+fn inject_compact_under_submit_gate(tmux_session_name: &str) -> Result<(), String> {
+    crate::services::claude_tui::input::send_followup_prompt(tmux_session_name, "/compact", None)
 }
 
 #[cfg(test)]
@@ -146,6 +214,21 @@ pub(crate) fn reset_armed_state_for_test() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, MutexGuard};
+
+    // The latch lives in a single process-global map and `reset_armed_state_for_test`
+    // clears it wholesale, so stateful tests must not interleave (a reset in one
+    // test would wipe another's in-flight latch). Serialize every test that
+    // touches the shared map behind this lock; pure-predicate tests don't need it.
+    static STATE_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn state_guard() -> MutexGuard<'static, ()> {
+        let guard = STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        reset_armed_state_for_test();
+        guard
+    }
 
     // A threshold crossing while armed injects.
     #[test]
@@ -189,7 +272,7 @@ mod tests {
     // above → re-arm after a post-compact drop → inject again next cross.
     #[test]
     fn full_cycle_once_per_fill_then_rearm() {
-        reset_armed_state_for_test();
+        let _g = state_guard();
         let ch = 4242;
         let threshold = 60;
         // Below threshold: no inject, stays armed.
@@ -210,11 +293,108 @@ mod tests {
     // Channels are independent: one channel's latch does not gate another's.
     #[test]
     fn per_channel_latch_is_independent() {
-        reset_armed_state_for_test();
+        let _g = state_guard();
         let threshold = 80;
         assert!(observe_and_decide(1, 85, threshold));
         // Channel 1 is now disarmed, but channel 2 is still armed.
         assert!(!observe_and_decide(1, 90, threshold));
         assert!(observe_and_decide(2, 85, threshold));
+    }
+
+    // Issue #1: a FAILED send must leave the latch ARMED so a later idle poll
+    // retries `/compact` while usage is still parked above the threshold.
+    #[test]
+    fn failed_send_rearms_for_retry() {
+        let _g = state_guard();
+        let ch = 9001;
+        let threshold = 60;
+        // First crossing injects and (optimistically) disarms.
+        assert!(observe_and_decide(ch, 80, threshold));
+        // While disarmed, a re-cross does NOT inject (once-per-cycle).
+        assert!(!observe_and_decide(ch, 85, threshold));
+        // Simulate the send failing: re-arm.
+        rearm_after_failed_inject(ch);
+        // Now a re-cross at the same (still-high) usage injects again (retry).
+        assert!(observe_and_decide(ch, 85, threshold));
+    }
+
+    // Issue #4: re-arm must be reachable even when usage drops to 0 (post-compact).
+    // The usage==0 case is the canonical re-arm signal and must NOT be skipped.
+    #[test]
+    fn usage_zero_rearms_disarmed_channel() {
+        let _g = state_guard();
+        let ch = 9002;
+        let threshold = 60;
+        // Fire once, disarm.
+        assert!(observe_and_decide(ch, 80, threshold));
+        assert!(!observe_and_decide(ch, 90, threshold));
+        // Post-compact drop to 0 re-arms (and does not inject).
+        assert!(!observe_and_decide(ch, 0, threshold));
+        // Next genuine crossing injects again.
+        assert!(observe_and_decide(ch, 70, threshold));
+    }
+
+    // Issue #4: a small threshold (<= REARM_MARGIN_PCT) underflows the re-arm
+    // floor to 0 via saturating_sub. Re-arm must then require usage to fall to 0,
+    // which a post-compact drop reaches — the latch must NOT be permanently stuck.
+    #[test]
+    fn small_threshold_rearms_only_at_zero() {
+        // threshold 3, margin 5 → saturating floor is 0.
+        assert_eq!(3u64.saturating_sub(REARM_MARGIN_PCT), 0);
+        // Only usage 0 reaches the floor; any non-zero usage does not re-arm.
+        assert!(should_rearm(0, 3));
+        assert!(!should_rearm(1, 3));
+        assert!(!should_rearm(2, 3));
+
+        let _g = state_guard();
+        let ch = 9003;
+        let threshold = 3;
+        // Crossing at/above 3 injects and disarms.
+        assert!(observe_and_decide(ch, 5, threshold));
+        // Still parked above: no re-inject.
+        assert!(!observe_and_decide(ch, 9, threshold));
+        // A small dip that does not reach 0 does NOT re-arm.
+        assert!(!observe_and_decide(ch, 1, threshold));
+        // Post-compact drop to 0 re-arms.
+        assert!(!observe_and_decide(ch, 0, threshold));
+        // Next crossing injects again — latch was never permanently blocked.
+        assert!(observe_and_decide(ch, 4, threshold));
+    }
+
+    // Issue #4 corollary: threshold == 1 (margin underflows) still re-arms at 0.
+    #[test]
+    fn threshold_one_rearms_at_zero() {
+        assert_eq!(1u64.saturating_sub(REARM_MARGIN_PCT), 0);
+        assert!(should_rearm(0, 1));
+        assert!(!should_rearm(1, 1));
+
+        let _g = state_guard();
+        let ch = 9004;
+        let threshold = 1;
+        assert!(observe_and_decide(ch, 1, threshold));
+        assert!(!observe_and_decide(ch, 50, threshold));
+        assert!(!observe_and_decide(ch, 0, threshold)); // re-arm
+        assert!(observe_and_decide(ch, 1, threshold)); // injects again
+    }
+
+    // The end-to-end no-op guards still hold: a zero threshold never injects and
+    // never disarms, so the latch is untouched (degrade-safe / feature off).
+    #[test]
+    fn zero_threshold_maybe_inject_is_noop() {
+        let _g = state_guard();
+        let ch = 9005;
+        // threshold 0 → maybe_inject_compact returns before observe_and_decide.
+        maybe_inject_compact(ch, "irrelevant-session", &ProviderKind::Claude, 100, 0);
+        // Latch untouched: still armed (default), so a real threshold later fires.
+        assert!(observe_and_decide(ch, 80, 60));
+    }
+
+    // Non-Claude providers never inject and never touch the latch.
+    #[test]
+    fn non_claude_provider_maybe_inject_is_noop() {
+        let _g = state_guard();
+        let ch = 9006;
+        maybe_inject_compact(ch, "irrelevant-session", &ProviderKind::Codex, 100, 60);
+        assert!(observe_and_decide(ch, 80, 60));
     }
 }

--- a/src/services/claude_compact_trigger.rs
+++ b/src/services/claude_compact_trigger.rs
@@ -211,23 +211,51 @@ pub(crate) fn reset_armed_state_for_test() {
         .clear();
 }
 
+/// Test seam (#3262 issue #4): expose the pure latch transition so a CALL-SITE
+/// integration test (in `adk_session`) can prove a turn-completion observation
+/// with `usage_pct == 0` reaches the re-arm — i.e. that the call site does not
+/// short-circuit zero usage before this latch runs. Returns whether THIS
+/// observation injects (the re-arm itself returns `false`). Side-effecting on the
+/// shared latch, so callers must hold [`state_test_guard`].
+#[cfg(test)]
+pub(crate) fn observe_and_decide_for_test(
+    channel_id: u64,
+    usage_pct: u64,
+    threshold_pct: u64,
+) -> bool {
+    observe_and_decide(channel_id, usage_pct, threshold_pct)
+}
+
+/// The latch lives in a single process-global map and `reset_armed_state_for_test`
+/// clears it wholesale, so stateful tests (in THIS module and in any cross-module
+/// call-site integration test) must not interleave. Serialize every test that
+/// touches the shared map behind this lock.
+#[cfg(test)]
+pub(crate) static STATE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Acquire the shared-latch test serialization guard AND reset the latch, so a
+/// stateful test starts from a known-clean armed map. Used by this module's tests
+/// and by the `adk_session` call-site integration test so both serialize against
+/// the same global latch.
+#[cfg(test)]
+pub(crate) fn state_test_guard() -> std::sync::MutexGuard<'static, ()> {
+    let guard = STATE_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    reset_armed_state_for_test();
+    guard
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
 
-    // The latch lives in a single process-global map and `reset_armed_state_for_test`
-    // clears it wholesale, so stateful tests must not interleave (a reset in one
-    // test would wipe another's in-flight latch). Serialize every test that
-    // touches the shared map behind this lock; pure-predicate tests don't need it.
-    static STATE_TEST_LOCK: Mutex<()> = Mutex::new(());
-
+    // Serialize stateful tests behind the module-level `STATE_TEST_LOCK` (lifted to
+    // `pub(crate)` so the `adk_session` call-site integration test serializes
+    // against the SAME global latch). `state_guard` also resets the latch.
     fn state_guard() -> MutexGuard<'static, ()> {
-        let guard = STATE_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        reset_armed_state_for_test();
-        guard
+        state_test_guard()
     }
 
     // A threshold crossing while armed injects.

--- a/src/services/claude_compact_trigger.rs
+++ b/src/services/claude_compact_trigger.rs
@@ -1,0 +1,220 @@
+//! #3262: AgentDesk-side `/compact` injection for the Claude TUI.
+//!
+//! Claude Code IGNORES the `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` env var AgentDesk
+//! exports (services/claude.rs), so a configured `context_compact_percent_claude`
+//! threshold never actually changes when Claude auto-compacts — it only compacts
+//! at its own internal default. Codex, by contrast, honours a real
+//! `model_auto_compact_token_limit` launch knob; Claude's TUI has no equivalent.
+//!
+//! The Claude TUI *does* respond to a user typing `/compact`, and AgentDesk
+//! already delivers `/compact` into the live pane on demand (the manual
+//! `ClaudeSlashPassthrough::Compact` command → `claude_tui::input::send_followup_prompt`).
+//! This module fires that exact injection AUTOMATICALLY when live context usage
+//! crosses the configured threshold, at a safe (turn-idle) point.
+//!
+//! Guards (see the issue's Phase-2 design):
+//!   * **claude-only** — the caller passes the provider and we no-op for anything
+//!     but `ProviderKind::Claude` (Codex compacts natively).
+//!   * **threshold-gated, degrade-safe** — a `0`/unset threshold or a `0`
+//!     usage/window signal short-circuits to "no inject".
+//!   * **once-per-fill-cycle** — a per-channel armed flag is consumed on inject
+//!     and only RE-ARMS after usage drops back below a hysteresis margin (which
+//!     happens when a compact resets the context), so we never re-inject every
+//!     poll while still parked above the threshold.
+//!   * **idle-only** — the caller invokes this at the turn-completion boundary
+//!     (pane idle); the injection itself rides `send_followup_prompt`, whose
+//!     `wait_for_prompt_ready` gate refuses to submit into a busy pane.
+//!   * **no Discord leak** — `send_followup_prompt` records the prompt as
+//!     Discord-originated (`record_discord_originated_prompt`), and the observed
+//!     `/compact` echo is suppressed by the #3153 machine-slash-command
+//!     classifier, so the control string never surfaces as user-visible prose.
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
+use crate::services::provider::ProviderKind;
+
+/// Hysteresis margin (percentage points): once we inject at/above the threshold,
+/// the channel only RE-ARMS after usage falls to `threshold - REARM_MARGIN_PCT`
+/// or below. A successful `/compact` drops usage far below the threshold, so this
+/// re-arms naturally on the next turn; a small jitter around the threshold does
+/// not. Keeping the margin modest means a genuine post-compact drop always
+/// re-arms while a same-cycle re-cross never does.
+const REARM_MARGIN_PCT: u64 = 5;
+
+/// Per-channel "armed" state for the once-per-fill-cycle guard. `true` (the
+/// default, via `entry().or_insert(true)`) means the next threshold crossing is
+/// allowed to inject; injecting flips it to `false` until usage drops below the
+/// re-arm point.
+static ARMED_BY_CHANNEL: LazyLock<Mutex<HashMap<u64, bool>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Pure decision: should we inject `/compact` for this poll?
+///
+/// `armed` carries the once-per-cycle latch. Returns `true` only when the
+/// threshold is meaningful (`> 0`), the live usage has reached it, and the
+/// channel is still armed for this fill cycle.
+pub(crate) fn should_inject_compact(usage_pct: u64, threshold_pct: u64, armed: bool) -> bool {
+    threshold_pct > 0 && armed && usage_pct >= threshold_pct
+}
+
+/// Pure re-arm decision: after a channel has fired (disarmed), should usage at
+/// `usage_pct` re-arm it? Re-arm once usage falls to the hysteresis floor
+/// (`threshold - REARM_MARGIN_PCT`, saturating) or below — i.e. a real context
+/// reset occurred, not a same-cycle jitter at the threshold.
+pub(crate) fn should_rearm(usage_pct: u64, threshold_pct: u64) -> bool {
+    usage_pct <= threshold_pct.saturating_sub(REARM_MARGIN_PCT)
+}
+
+/// Update the per-channel armed latch from the latest usage observation and
+/// report whether THIS observation should inject. Combines [`should_inject_compact`]
+/// (consuming the latch on a yes) with [`should_rearm`] (restoring it after a
+/// post-compact drop), so callers get a single edge-triggered answer.
+fn observe_and_decide(channel_id: u64, usage_pct: u64, threshold_pct: u64) -> bool {
+    let mut guard = ARMED_BY_CHANNEL
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let armed = *guard.entry(channel_id).or_insert(true);
+    if !armed && should_rearm(usage_pct, threshold_pct) {
+        guard.insert(channel_id, true);
+        return false;
+    }
+    if should_inject_compact(usage_pct, threshold_pct, armed) {
+        guard.insert(channel_id, false);
+        return true;
+    }
+    false
+}
+
+/// Claude-only: when the latest (turn-idle) context usage crosses the configured
+/// threshold for the first time this fill cycle, inject `/compact` into the live
+/// TUI via the proven `send_followup_prompt` path on a blocking thread.
+///
+/// `usage_pct` is the live context occupancy percentage already computed for the
+/// status panel; `threshold_pct` is `compact_pct_for(Claude)`. No-ops (and never
+/// disarms) for any non-Claude provider, a `0` threshold, or a `0` usage signal,
+/// so an unset threshold or a missing usage/window degrades safely.
+pub(crate) fn maybe_inject_compact(
+    channel_id: u64,
+    tmux_session_name: &str,
+    provider: &ProviderKind,
+    usage_pct: u64,
+    threshold_pct: u64,
+) {
+    if !matches!(provider, ProviderKind::Claude) || threshold_pct == 0 || usage_pct == 0 {
+        return;
+    }
+    if !observe_and_decide(channel_id, usage_pct, threshold_pct) {
+        return;
+    }
+    let tmux_session_name = tmux_session_name.to_string();
+    // `send_followup_prompt` is blocking (it polls the pane for readiness and
+    // drives tmux send-keys), so it must not run on the async watcher runtime.
+    tokio::task::spawn_blocking(move || {
+        tracing::info!(
+            tmux_session_name = %tmux_session_name,
+            usage_pct,
+            threshold_pct,
+            "#3262 auto-injecting /compact: live Claude context usage crossed configured threshold at turn-idle"
+        );
+        match crate::services::claude_tui::input::send_followup_prompt(
+            &tmux_session_name,
+            "/compact",
+            None,
+        ) {
+            Ok(()) => tracing::info!(
+                tmux_session_name = %tmux_session_name,
+                "#3262 auto /compact injected into live Claude TUI"
+            ),
+            Err(error) => tracing::warn!(
+                tmux_session_name = %tmux_session_name,
+                error = %error,
+                "#3262 auto /compact injection skipped (pane busy/unready or send failed); will retry on a later turn"
+            ),
+        }
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn reset_armed_state_for_test() {
+    ARMED_BY_CHANNEL
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A threshold crossing while armed injects.
+    #[test]
+    fn injects_when_threshold_crossed_and_armed() {
+        assert!(should_inject_compact(60, 60, true));
+        assert!(should_inject_compact(95, 60, true));
+    }
+
+    // Below the threshold never injects, armed or not.
+    #[test]
+    fn does_not_inject_below_threshold() {
+        assert!(!should_inject_compact(59, 60, true));
+        assert!(!should_inject_compact(0, 60, true));
+    }
+
+    // Already fired this cycle (disarmed) never re-injects, even far above.
+    #[test]
+    fn does_not_inject_when_already_fired_this_cycle() {
+        assert!(!should_inject_compact(99, 60, false));
+        assert!(!should_inject_compact(60, 60, false));
+    }
+
+    // An unset / zero threshold degrades to no-inject.
+    #[test]
+    fn zero_threshold_never_injects() {
+        assert!(!should_inject_compact(100, 0, true));
+    }
+
+    // Re-arm only after usage drops to the hysteresis floor (post-compact),
+    // not on a same-cycle jitter right at/just-below the threshold.
+    #[test]
+    fn rearms_only_after_post_compact_drop() {
+        // threshold 60, margin 5 → re-arm floor is 55.
+        assert!(should_rearm(55, 60));
+        assert!(should_rearm(20, 60)); // typical post-compact usage
+        assert!(!should_rearm(56, 60));
+        assert!(!should_rearm(60, 60));
+    }
+
+    // Full per-channel cycle: cross → inject once → stay disarmed while parked
+    // above → re-arm after a post-compact drop → inject again next cross.
+    #[test]
+    fn full_cycle_once_per_fill_then_rearm() {
+        reset_armed_state_for_test();
+        let ch = 4242;
+        let threshold = 60;
+        // Below threshold: no inject, stays armed.
+        assert!(!observe_and_decide(ch, 50, threshold));
+        // First crossing: injects, disarms.
+        assert!(observe_and_decide(ch, 62, threshold));
+        // Still parked above on subsequent polls: NO re-inject (once-per-cycle).
+        assert!(!observe_and_decide(ch, 70, threshold));
+        assert!(!observe_and_decide(ch, 99, threshold));
+        // A small dip that does NOT reach the re-arm floor still no-ops.
+        assert!(!observe_and_decide(ch, 58, threshold));
+        // Post-compact drop reaches the floor: re-arms (and does not inject).
+        assert!(!observe_and_decide(ch, 18, threshold));
+        // Next genuine crossing injects again.
+        assert!(observe_and_decide(ch, 65, threshold));
+    }
+
+    // Channels are independent: one channel's latch does not gate another's.
+    #[test]
+    fn per_channel_latch_is_independent() {
+        reset_armed_state_for_test();
+        let threshold = 80;
+        assert!(observe_and_decide(1, 85, threshold));
+        // Channel 1 is now disarmed, but channel 2 is still armed.
+        assert!(!observe_and_decide(1, 90, threshold));
+        assert!(observe_and_decide(2, 85, threshold));
+    }
+}

--- a/src/services/discord/adk_session.rs
+++ b/src/services/discord/adk_session.rs
@@ -755,6 +755,65 @@ mod compact_threshold_tests {
     }
 }
 
+#[cfg(test)]
+mod compact_call_site_tests {
+    use super::claude_compact_trigger_evaluates_at_completion;
+    use crate::services::claude_compact_trigger::{observe_and_decide_for_test, state_test_guard};
+
+    // #3262 issue #4 (pure call-site gate): a zero-usage observation
+    // (`occupied == 0`) must NOT short-circuit the trigger evaluation — it is the
+    // canonical post-compact re-arm signal. Only a disabled feature (threshold 0)
+    // skips. This is the decision the call site lost in the early-`return`.
+    #[test]
+    fn zero_usage_does_not_short_circuit_trigger_evaluation() {
+        // usage 0 with a live threshold STILL evaluates (re-arm must be reached).
+        assert!(claude_compact_trigger_evaluates_at_completion(0, 60));
+        // A small threshold whose re-arm floor requires usage ≈ 0 still evaluates.
+        assert!(claude_compact_trigger_evaluates_at_completion(0, 1));
+        // Non-zero usage of course evaluates too.
+        assert!(claude_compact_trigger_evaluates_at_completion(123_456, 60));
+        // Only a disabled feature (unset/zero threshold) skips — degrade-safe.
+        assert!(!claude_compact_trigger_evaluates_at_completion(0, 0));
+        assert!(!claude_compact_trigger_evaluates_at_completion(999, 0));
+    }
+
+    // #3262 issue #4 (closes the integration gap the unit tests missed): drive the
+    // CALL-SITE path — gate → `observe_and_decide` — and prove that a
+    // turn-completion observation with usage == 0 RE-ARMS a previously-fired latch
+    // so the next threshold crossing fires again. The prior early-return
+    // (`if occupied == 0 { return; }`) starved this re-arm: a low-threshold channel
+    // fired once and stayed permanently disarmed.
+    #[test]
+    fn zero_usage_turn_completion_rearms_via_call_site_path() {
+        let _g = state_test_guard();
+        // Low threshold whose re-arm floor (threshold - 5, saturating) lands at 0,
+        // so ONLY a usage==0 observation can re-arm — exactly the case the
+        // early-return used to starve.
+        let ch = 770_001_u64;
+        let threshold = 3_u64;
+
+        // Helper mirroring the call site: gate first (usage==0 must NOT skip),
+        // then run the latch transition with the real usage percent.
+        let evaluate = |occupied: u64, usage_pct: u64| -> bool {
+            if !claude_compact_trigger_evaluates_at_completion(occupied, threshold) {
+                return false;
+            }
+            observe_and_decide_for_test(ch, usage_pct, threshold)
+        };
+
+        // First crossing fires (injects) and disarms.
+        assert!(evaluate(50_000, 5));
+        // Still parked above on a later completion: no re-fire (once-per-cycle).
+        assert!(!evaluate(90_000, 9));
+        // Post-compact turn-completion drops to ZERO usage. With the prior
+        // early-return this observation never reached the latch and the channel
+        // stayed disarmed forever. It must now re-arm (and not inject).
+        assert!(!evaluate(0, 0));
+        // Proof of re-arm: the next genuine crossing fires again.
+        assert!(evaluate(40_000, 4));
+    }
+}
+
 /// Context window management thresholds.
 /// Single source of truth used by Rust turn-end compact logic.
 /// Provider-specific overrides: `context_compact_percent_codex`, `context_compact_percent_claude`, etc.
@@ -861,18 +920,17 @@ pub(super) async fn backfill_completed_panel_usage_and_maybe_inject_compact(
         output_tokens: state.accum_output_tokens,
     };
     let occupied = usage.context_occupancy_input_tokens();
-    if occupied == 0 {
-        return;
-    }
     let context_window = provider.resolve_context_window(state.last_model.as_deref());
-    if context_window == 0 {
-        return;
-    }
     let ctx_cfg = fetch_context_thresholds(shared.api_port).await;
     let compact_pct = ctx_cfg.compact_pct_for(provider);
-    // v2-gated: only the status-panel-v2 Context line backfill depends on the
-    // feature flag. The compact trigger below does not.
-    if shared.status_panel_v2_enabled {
+
+    // v2-gated panel backfill: the Context line write legitimately needs a real
+    // usage signal — skip it when there is no occupancy (`occupied == 0`) or no
+    // resolvable window (`context_window == 0`). This guard belongs to the panel
+    // write ONLY; it must NOT gate the compact trigger below (#3262 issue #4: a
+    // post-compact drop to ~0 usage is exactly the re-arm signal the trigger
+    // needs, so a zero-usage turn-completion must still reach the trigger).
+    if occupied != 0 && context_window != 0 && shared.status_panel_v2_enabled {
         shared.placeholder_live_events.set_context_panel_usage(
             channel_id,
             state.last_session_id.as_deref(),
@@ -883,17 +941,54 @@ pub(super) async fn backfill_completed_panel_usage_and_maybe_inject_compact(
             compact_pct,
         );
     }
+
     // #3262: Claude ignores CLAUDE_AUTOCOMPACT_PCT_OVERRIDE, so enforce the
     // configured threshold ourselves by injecting `/compact` into the live TUI
     // (claude-only, once-per-fill-cycle, idle-gated — see claude_compact_trigger).
     // Runs regardless of status_panel_v2_enabled so disabling the v2 panel never
     // silently disables auto-compact.
-    let usage_pct = context_usage_percent(occupied, context_window);
-    crate::services::claude_compact_trigger::maybe_inject_compact(
-        channel_id.get(),
-        tmux_session_name,
-        provider,
-        usage_pct,
-        compact_pct,
-    );
+    //
+    // #3262 issue #4 (call-site integration gap): the trigger evaluation runs
+    // UNCONDITIONALLY at this turn-completion boundary, including when
+    // `occupied == 0` (usage 0). A zero-usage observation cannot inject
+    // (`should_inject_compact` still requires `usage_pct >= threshold`) but it is
+    // the canonical post-compact signal that RE-ARMS the latch via
+    // `observe_and_decide`. Short-circuiting on zero usage (the prior early-return)
+    // starved the live re-arm path, leaving a low-threshold channel permanently
+    // disarmed after the first fire. `context_usage_percent` returns 0 safely when
+    // `context_window == 0`, so an unresolved window degrades to a re-arm-only 0.
+    if claude_compact_trigger_evaluates_at_completion(occupied, compact_pct) {
+        let usage_pct = context_usage_percent(occupied, context_window);
+        crate::services::claude_compact_trigger::maybe_inject_compact(
+            channel_id.get(),
+            tmux_session_name,
+            provider,
+            usage_pct,
+            compact_pct,
+        );
+    }
+}
+
+/// Pure call-site gate for the #3262 Claude `/compact` trigger evaluation at a
+/// turn-completion boundary. Returns whether
+/// [`backfill_completed_panel_usage_and_maybe_inject_compact`] should evaluate the
+/// compact trigger for this completion.
+///
+/// The load-bearing property (issue #4): a zero-usage observation
+/// (`occupied == 0`) must NOT short-circuit — it is the canonical post-compact
+/// re-arm signal that has to reach `observe_and_decide`. The only thing that lets
+/// us skip the trigger entirely is a degrade-safe `0`/unset threshold (the feature
+/// is off), which `maybe_inject_compact` would itself no-op on anyway; gating here
+/// just avoids the redundant call. Provider gating (claude-only) and the actual
+/// re-arm/inject decision stay inside `maybe_inject_compact` /
+/// `observe_and_decide`.
+pub(crate) fn claude_compact_trigger_evaluates_at_completion(
+    occupied: u64,
+    threshold_pct: u64,
+) -> bool {
+    // usage==0 (occupied==0) MUST still evaluate (re-arm). Only a disabled feature
+    // (threshold 0) skips. `occupied` is referenced to make the zero-usage
+    // non-short-circuit explicit and testable.
+    let _ = occupied;
+    threshold_pct > 0
 }

--- a/src/services/discord/adk_session.rs
+++ b/src/services/discord/adk_session.rs
@@ -830,3 +830,61 @@ pub(super) async fn fetch_context_thresholds(_api_port: u16) -> ContextThreshold
         context_window: defaults.context_window,
     }
 }
+
+/// #2849 + #3262: at a watcher-completed turn boundary (pane idle), backfill the
+/// exact final context usage onto the status panel AND — for Claude only — inject
+/// `/compact` if live usage just crossed the configured
+/// `context_compact_percent_claude` threshold.
+///
+/// Extracted from the tmux_watcher completion path so the trigger rides the same
+/// turn-idle signal the panel backfill already uses (exact usage, resolvable
+/// window). Degrades safely: no exact usage, a `0` window, or a non-Claude
+/// provider simply skips. The compact injection itself is once-per-fill-cycle and
+/// pane-ready-gated inside `claude_compact_trigger` / `send_followup_prompt`.
+pub(super) async fn backfill_completed_panel_usage_and_maybe_inject_compact(
+    shared: &Arc<SharedData>,
+    channel_id: serenity::ChannelId,
+    state: &crate::services::session_backend::StreamLineState,
+    provider: &ProviderKind,
+    tmux_session_name: &str,
+) {
+    if !shared.status_panel_v2_enabled {
+        return;
+    }
+    let usage = crate::db::turns::TurnTokenUsage {
+        input_tokens: state.accum_input_tokens,
+        cache_create_tokens: state.accum_cache_create_tokens,
+        cache_read_tokens: state.accum_cache_read_tokens,
+        output_tokens: state.accum_output_tokens,
+    };
+    let occupied = usage.context_occupancy_input_tokens();
+    if occupied == 0 {
+        return;
+    }
+    let context_window = provider.resolve_context_window(state.last_model.as_deref());
+    if context_window == 0 {
+        return;
+    }
+    let ctx_cfg = fetch_context_thresholds(shared.api_port).await;
+    let compact_pct = ctx_cfg.compact_pct_for(provider);
+    shared.placeholder_live_events.set_context_panel_usage(
+        channel_id,
+        state.last_session_id.as_deref(),
+        usage.input_tokens,
+        usage.cache_create_tokens,
+        usage.cache_read_tokens,
+        context_window,
+        compact_pct,
+    );
+    // #3262: Claude ignores CLAUDE_AUTOCOMPACT_PCT_OVERRIDE, so enforce the
+    // configured threshold ourselves by injecting `/compact` into the live TUI
+    // (claude-only, once-per-fill-cycle, idle-gated — see claude_compact_trigger).
+    let usage_pct = context_usage_percent(occupied, context_window);
+    crate::services::claude_compact_trigger::maybe_inject_compact(
+        channel_id.get(),
+        tmux_session_name,
+        provider,
+        usage_pct,
+        compact_pct,
+    );
+}

--- a/src/services/discord/adk_session.rs
+++ b/src/services/discord/adk_session.rs
@@ -848,9 +848,12 @@ pub(super) async fn backfill_completed_panel_usage_and_maybe_inject_compact(
     provider: &ProviderKind,
     tmux_session_name: &str,
 ) {
-    if !shared.status_panel_v2_enabled {
-        return;
-    }
+    // #3262: the usage/window/threshold signal is needed by BOTH the v2 panel
+    // backfill AND the Claude `/compact` trigger. Compute it once, unconditionally
+    // — gating it behind `status_panel_v2_enabled` (as the original wire-in did)
+    // silently disabled auto-compact whenever the v2 panel was turned off. The
+    // trigger must run on every turn-completion (pane idle) regardless of the v2
+    // feature flag; only the panel `set_context_panel_usage` write stays v2-gated.
     let usage = crate::db::turns::TurnTokenUsage {
         input_tokens: state.accum_input_tokens,
         cache_create_tokens: state.accum_cache_create_tokens,
@@ -867,18 +870,24 @@ pub(super) async fn backfill_completed_panel_usage_and_maybe_inject_compact(
     }
     let ctx_cfg = fetch_context_thresholds(shared.api_port).await;
     let compact_pct = ctx_cfg.compact_pct_for(provider);
-    shared.placeholder_live_events.set_context_panel_usage(
-        channel_id,
-        state.last_session_id.as_deref(),
-        usage.input_tokens,
-        usage.cache_create_tokens,
-        usage.cache_read_tokens,
-        context_window,
-        compact_pct,
-    );
+    // v2-gated: only the status-panel-v2 Context line backfill depends on the
+    // feature flag. The compact trigger below does not.
+    if shared.status_panel_v2_enabled {
+        shared.placeholder_live_events.set_context_panel_usage(
+            channel_id,
+            state.last_session_id.as_deref(),
+            usage.input_tokens,
+            usage.cache_create_tokens,
+            usage.cache_read_tokens,
+            context_window,
+            compact_pct,
+        );
+    }
     // #3262: Claude ignores CLAUDE_AUTOCOMPACT_PCT_OVERRIDE, so enforce the
     // configured threshold ourselves by injecting `/compact` into the live TUI
     // (claude-only, once-per-fill-cycle, idle-gated — see claude_compact_trigger).
+    // Runs regardless of status_panel_v2_enabled so disabling the v2 panel never
+    // silently disables auto-compact.
     let usage_pct = context_usage_percent(occupied, context_window);
     crate::services::claude_compact_trigger::maybe_inject_compact(
         channel_id.get(),

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -10554,29 +10554,13 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             // completed panel. Skip entirely when no exact usage exists or the
             // provider/model has no resolvable window — never fabricate numbers
             // and never reuse stale prior-turn usage. set_context_panel_usage is
-            // also internally gated to context_window != 0.
-            if shared.status_panel_v2_enabled
-                && let Some(usage) = stream_line_state_token_usage(&state)
-                    .filter(|usage| usage.context_occupancy_input_tokens() > 0)
-            {
-                let context_window =
-                    watcher_provider.resolve_context_window(state.last_model.as_deref());
-                if context_window > 0 {
-                    let ctx_cfg = crate::services::discord::adk_session::fetch_context_thresholds(
-                        shared.api_port,
-                    )
-                    .await;
-                    shared.placeholder_live_events.set_context_panel_usage(
-                        channel_id,
-                        state.last_session_id.as_deref(),
-                        usage.input_tokens,
-                        usage.cache_create_tokens,
-                        usage.cache_read_tokens,
-                        context_window,
-                        ctx_cfg.compact_pct_for(&watcher_provider),
-                    );
-                }
-            }
+            // also internally gated to context_window != 0. #3262: the same
+            // turn-idle helper also injects `/compact` when live Claude usage
+            // crosses the configured threshold (claude-only, once-per-cycle).
+            crate::services::discord::adk_session::backfill_completed_panel_usage_and_maybe_inject_compact(
+                &shared, channel_id, &state, &watcher_provider, &tmux_session_name,
+            )
+            .await;
             // #2427 D wire (Codex round 2 HIGH-1): the watcher loop is not
             // turn-scoped — by the time we reach here a new turn may have
             // rewritten the inflight on disk. Reading user_msg_id from that

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -7,6 +7,7 @@ pub mod auto_queue;
 pub mod automation_candidate_contract;
 pub mod automation_candidate_materializer;
 pub mod claude;
+pub mod claude_compact_trigger;
 pub mod claude_e;
 pub mod claude_tui;
 pub mod cluster;


### PR DESCRIPTION
## #3262: Claude auto-compact threshold (`context_compact_percent_claude`) had no effect — AgentDesk-side `/compact` injection

Closes #3262.

### Problem
AgentDesk exports `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=<pct>` to the Claude process, but **Claude Code ignores this env var**, so the configured `context_compact_percent_claude` threshold never actually changes when Claude auto-compacts — Claude only compacts at its own internal default. Codex honours a real `model_auto_compact_token_limit` launch knob; Claude's TUI has no equivalent. The fix direction (issue title): AgentDesk should **inject `/compact`** into the Claude TUI when live context usage crosses the configured threshold.

### Phase 1 — Investigation map (file:line)
1. **Threshold config / env export**
   - `context_compact_percent_claude` read: `src/config.rs:1297`, `src/services/settings.rs:171/488`, parsed into `ContextThresholds` at `src/services/discord/adk_session.rs:824` (falls back to generic `context_compact_percent`).
   - `compact_pct_for(Claude)` selector: `src/services/discord/adk_session.rs:786`.
   - `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` exported (ignored by Claude Code): `src/services/claude.rs:123`, `:946`, `:3932`; `src/services/provider.rs:448`. Nothing else *consumes* it on the Claude side — it is a dead knob.
2. **Live context-usage signal** (status panel `📦 .. / .. tokens`)
   - Tokens-used accumulated on `StreamLineState.accum_*` (`src/services/session_backend.rs:274`), surfaced via `TurnTokenUsage::context_occupancy_input_tokens()` (`src/db/turns.rs:21`).
   - Window: `ProviderKind::resolve_context_window` (`src/services/provider.rs:472`); percent: `adk_session::context_usage_percent` (`:278`).
   - Turn-completion (idle) backfill onto the panel: `src/services/discord/tmux_watcher.rs` ~L10558 via `set_context_panel_usage` (`placeholder_live_events/mod.rs:319`). **This is the trigger signal + safe (idle) point.**
3. **TUI injection mechanism**
   - `claude_tui::input::send_followup_prompt` (`src/services/claude_tui/input.rs:234`) → `wait_for_prompt_ready` (idle gate) → `record_discord_originated_prompt` (no-leak dedupe) → tmux submit. **`/compact` is already injected this exact way manually**: `ClaudeSlashPassthrough::Compact` → `send_followup_prompt(.., "/compact", ..)` (`src/services/discord/commands/tui_passthrough.rs:90/232`).
4. **Echo-leak precedent (#3153)**
   - `is_slash_command_control_prompt` classifies the observed `/compact` echo as `SlashCommandControl` (`tui_prompt_relay.rs:5111`/`5125`), suppressing it from user-visible prose. The auto-injection reuses this unchanged.

### Phase 2 — Design (go=true) + guards
New module `src/services/claude_compact_trigger.rs`:
- **claude-only** — no-op for any non-Claude provider (Codex compacts natively).
- **once-per-fill-cycle** — per-channel in-memory `armed` latch; consumed on inject, **re-arms only after usage drops to `threshold − 5pp`** (hysteresis), which a successful `/compact` reset guarantees. Never re-injects every poll while parked above threshold.
- **idle-only** — fired at the turn-completion boundary (pane idle); injection rides `send_followup_prompt`, whose `wait_for_prompt_ready` refuses a busy pane (never mid-turn).
- **no Discord leak** — `record_discord_originated_prompt` + #3153 classifier suppress the `/compact` control string.
- **degrade-safe** — `0`/unset threshold or `0` usage/window short-circuits to no-inject.

Wire-in: the watcher's turn-completion status-panel usage block is **extracted** into `adk_session::backfill_completed_panel_usage_and_maybe_inject_compact` (one call replaces ~22 inline lines → **net −16 LoC in the ratcheted `tmux_watcher.rs`**, 9598→9582), which now also fires the trigger off the same idle signal it already used for the panel.

### Phase 3 — Tests
7 unit tests in `claude_compact_trigger`: threshold-crossed+armed → inject; below-threshold / already-fired-this-cycle / zero-threshold → no inject; re-arm only after post-compact drop (hysteresis); full per-channel cycle (cross → inject once → stay disarmed while parked above → re-arm after drop → inject next cross); per-channel latch independence.

### Multinode classification
Trigger state is **worker-local** (process-global `LazyLock<Mutex<HashMap<channel_id,bool>>>`); a channel's tmux session is pinned to one worker, so the latch needs no cross-node coordination. Documented in `multinode-transition.md` (Worker-Local Side Effects).

### Gate results
- `cargo fmt --check` clean
- `cargo check --lib` clean (only pre-existing warnings, identical on origin/main); `cargo test --lib` for `claude_compact_trigger` (7/7) + `adk_session` (4/4) green
- `./scripts/ci-script-checks.sh` exit 0 — `giant_file_ratchet` tmux_watcher 9582 ≤ 9598, `await_holding_lock` baseline 34 (no new sites)
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` → "agent-maintenance freshness check passed" (change-surfaces.md line-count synced, multinode-transition.md worker-local entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
