### PR TITLE
fix(#3278): cut accumulated git execs in merge-automation tick + downgrade deadline noise

### DIFF
--- a/policies/__tests__/merge-automation.test.js
+++ b/policies/__tests__/merge-automation.test.js
@@ -198,3 +198,177 @@ test("direct-merge close-issue still closes when comment posting fails", () => {
   assert.equal(calls.length, 3);
   assert.equal(calls[2][1][1], "close");
 });
+
+// ── #3278: tick git-exec budget ──────────────────────────────────────────
+// onTick5min accumulated up to 2 git execs per inspected dispatch row (×16
+// rows ×N tracked cards) and blew the 5s POLICY_TICK_HOOK_TIMEOUT. The fix:
+// (1) diagnostics-only rows (pending/dispatched, and cancelled rows after the
+// fallback slot is taken) skip the git fallback entirely, and (2) a tick-local
+// cache dedupes fallback lookups per worktree within one tick.
+
+function dispatchRowsRouter(excludedRows, completedRows) {
+  return createSqlRouter([
+    {
+      match: "AND status IN ('pending', 'dispatched', 'cancelled')",
+      result: excludedRows
+    },
+    {
+      match: "AND status = 'completed'",
+      result: completedRows
+    }
+  ]);
+}
+
+test("inspectLatestCompletedWorkTarget skips git fallback for diagnostics-only dispatch rows", () => {
+  const { module, state } = loadPolicy("policies/merge-automation.js", {
+    exec(cmd, args) {
+      throw new Error(`no git fallback expected, got: ${cmd} ${JSON.stringify(args)}`);
+    },
+    dbQuery: dispatchRowsRouter(
+      [
+        { id: "d1", status: "pending", result: null, context: JSON.stringify({ worktree_path: "/tmp/wt-a" }) },
+        { id: "d2", status: "dispatched", result: null, context: JSON.stringify({ worktree_path: "/tmp/wt-a" }) }
+      ],
+      [
+        {
+          id: "d3",
+          status: "completed",
+          result: JSON.stringify({
+            completed_worktree_path: "/tmp/wt-a",
+            completed_branch: "feat/x",
+            completed_commit: "abc123"
+          }),
+          context: null
+        }
+      ]
+    )
+  });
+
+  const info = module.__test.inspectLatestCompletedWorkTarget("card-3278");
+
+  assert.equal(state.execCalls.length, 0, "pending/dispatched rows must not exec git");
+  assert.equal(info.target.branch, "feat/x");
+  assert.equal(info.target.head_sha, "abc123");
+  assert.equal(info.inspected.length, 3);
+});
+
+test("inspectLatestCompletedWorkTarget runs git fallback only for the first cancelled fallback candidate", () => {
+  const { module, state } = loadPolicy("policies/merge-automation.js", {
+    exec(cmd, args) {
+      assert.equal(cmd, "git");
+      assert.equal(args[1], "/tmp/wt-first", "only the first cancelled row may exec git");
+      if (args[2] === "branch") return "fix/cancelled-branch";
+      if (args[2] === "rev-parse") return "cafebabe";
+      throw new Error(`unexpected git args: ${JSON.stringify(args)}`);
+    },
+    dbQuery: dispatchRowsRouter(
+      [
+        { id: "c1", status: "cancelled", result: null, context: JSON.stringify({ worktree_path: "/tmp/wt-first" }) },
+        { id: "c2", status: "cancelled", result: null, context: JSON.stringify({ worktree_path: "/tmp/wt-second" }) }
+      ],
+      []
+    )
+  });
+
+  const info = module.__test.inspectLatestCompletedWorkTarget("card-3278");
+
+  assert.equal(state.execCalls.length, 2, "branch + rev-parse for the first cancelled row only");
+  assert.equal(info.target.worktree_path, "/tmp/wt-first");
+  assert.equal(info.target.branch, "fix/cancelled-branch");
+  assert.equal(info.target.head_sha, "cafebabe");
+  // second cancelled row stays diagnostics-only: no git-derived enrichment
+  assert.equal(info.inspected[1].target.branch, null);
+  assert.equal(info.inspected[1].target.head_sha, null);
+});
+
+test("tick-local cache dedupes git fallback per worktree within one tick", () => {
+  const completedRow = {
+    id: "d-cache",
+    status: "completed",
+    result: JSON.stringify({ completed_worktree_path: "/tmp/wt-cache" }),
+    context: null
+  };
+  const { module, state } = loadPolicy("policies/merge-automation.js", {
+    exec(cmd, args) {
+      if (args[2] === "branch") return "feat/cached";
+      if (args[2] === "rev-parse") return "deadbeef";
+      throw new Error(`unexpected git args: ${JSON.stringify(args)}`);
+    },
+    dbQuery: dispatchRowsRouter([], [completedRow])
+  });
+
+  // simulated single tick: two cards resolving against the same worktree
+  const targets = module.__test.withGitFallbackCache(() => [
+    module.__test.inspectLatestCompletedWorkTarget("card-a").target,
+    module.__test.inspectLatestCompletedWorkTarget("card-b").target
+  ]);
+
+  assert.equal(state.execCalls.length, 2, "second inspection must hit the cache");
+  assert.equal(targets[0].branch, "feat/cached");
+  assert.equal(targets[1].branch, "feat/cached");
+  assert.equal(targets[1].head_sha, "deadbeef");
+
+  // outside the wrapper the cache is disarmed — behavior unchanged
+  module.__test.inspectLatestCompletedWorkTarget("card-c");
+  assert.equal(state.execCalls.length, 4);
+});
+
+// ── #3278: deadline ERROR 강등 ───────────────────────────────────────────
+// 5s 타임아웃 이후에도 tick actor 는 백그라운드 큐에서 훅을 계속 실행하므로
+// bridge deadline 계열 에러는 "이번 tick 예산 소진 + 다음 tick 재시도"이지
+// 훅 실패가 아니다. WARN 으로 강등하고 hook 은 정상 반환해야 한다.
+
+test("onTick5min downgrades bridge deadline errors to WARN and stops the pass", () => {
+  const { policy, state } = loadPolicy("policies/merge-automation.js", {
+    config: { merge_automation_enabled: "true" },
+    extraAgentdesk: {
+      prTracking: {
+        list() {
+          throw new Error("bridge deadline exceeded during async bridge operation");
+        }
+      }
+    }
+  });
+
+  assert.doesNotThrow(() => policy.onTick5min());
+  assert.equal(state.logs.error.length, 0);
+  assert.equal(state.logs.warn.length, 1);
+  assert.match(state.logs.warn[0], /onTick5min hit bridge deadline at step processCodexReviewSignals/);
+  assert.equal(state.queries.length, 0, "later steps must be deferred to the next tick");
+});
+
+test("onTick5min downgrades pre-start deadline errors thrown mid-pass", () => {
+  const { policy, state } = loadPolicy("policies/merge-automation.js", {
+    config: { merge_automation_enabled: "true" },
+    dbQuery() {
+      // first db.query happens in processManualMergeRequests (step 2)
+      throw new Error("bridge deadline passed before async bridge started");
+    },
+    extraAgentdesk: {
+      prTracking: {
+        list() {
+          return [];
+        }
+      }
+    }
+  });
+
+  assert.doesNotThrow(() => policy.onTick5min());
+  assert.equal(state.logs.warn.length, 1);
+  assert.match(state.logs.warn[0], /at step processManualMergeRequests/);
+});
+
+test("onTick5min rethrows non-deadline errors", () => {
+  const { policy } = loadPolicy("policies/merge-automation.js", {
+    config: { merge_automation_enabled: "true" },
+    extraAgentdesk: {
+      prTracking: {
+        list() {
+          throw new Error("boom: schema mismatch");
+        }
+      }
+    }
+  });
+
+  assert.throws(() => policy.onTick5min(), /schema mismatch/);
+});

--- a/policies/merge-automation.js
+++ b/policies/merge-automation.js
@@ -201,11 +201,39 @@ var mergeAutomation = {
   onTick5min: function() {
     if (!isEnabled()) return;
 
-    processCodexReviewSignals();
-    processManualMergeRequests();
-    processTrackedMergeQueue();
-    cleanupMergedWorktrees();
-    detectConflictingPrs();
+    // #3278: run the whole pass under a tick-local git fallback cache so
+    // repeated dispatch-row inspections against the same worktree cost at
+    // most one `git branch`/`git rev-parse` pair per tick.
+    withGitFallbackCache(function() {
+      var steps = [
+        { name: "processCodexReviewSignals", run: processCodexReviewSignals },
+        { name: "processManualMergeRequests", run: processManualMergeRequests },
+        { name: "processTrackedMergeQueue", run: processTrackedMergeQueue },
+        { name: "cleanupMergedWorktrees", run: cleanupMergedWorktrees },
+        { name: "detectConflictingPrs", run: detectConflictingPrs }
+      ];
+      for (var i = 0; i < steps.length; i++) {
+        try {
+          steps[i].run();
+        } catch (e) {
+          // #3278: the tick actor keeps executing this hook in a background
+          // queue after the 5s POLICY_TICK_HOOK_TIMEOUT, so deadline
+          // exhaustion mid-pass means "out of budget this tick", not a hook
+          // failure — every step is idempotent and retried on the next tick.
+          // Downgrade to WARN instead of letting the error escape as an
+          // ERROR-level "hook execution failed". Non-deadline errors still
+          // propagate.
+          if (isBridgeDeadlineError(e)) {
+            agentdesk.log.warn(
+              "[merge] onTick5min hit bridge deadline at step " + steps[i].name +
+              "; deferring remaining steps to next tick: " + e
+            );
+            return;
+          }
+          throw e;
+        }
+      }
+    });
   }
 };
 
@@ -326,7 +354,58 @@ function appendMergeCandidateReason(details, code, message) {
   });
 }
 
-function buildWorkTargetFromDispatchRow(row) {
+// #3278: bridge ops surface deadline exhaustion as thrown Errors
+// ("bridge deadline exceeded during async bridge operation" /
+// "bridge deadline passed before async bridge started" — see
+// src/utils/async_bridge.rs). Match both phrasings so onTick5min can treat
+// them as a retry-next-tick condition rather than a hook failure.
+function isBridgeDeadlineError(error) {
+  var message = error && error.message ? String(error.message) : String(error || "");
+  return message.indexOf("bridge deadline") !== -1
+    || message.indexOf("deadline exceeded") !== -1
+    || message.indexOf("deadline passed") !== -1;
+}
+
+// #3278: tick-local cache for git fallback lookups in
+// buildWorkTargetFromDispatchRow. inspectLatestCompletedWorkTarget walks up
+// to 16 dispatch rows per card and every row missing branch/head_sha
+// metadata used to cost two git child processes; across the tracked merge
+// queue the accumulated execs blew the 5s POLICY_TICK_HOOK_TIMEOUT even
+// though each individual exec is deadline-aware (#2378). The cache is only
+// armed inside withGitFallbackCache (onTick5min); everywhere else
+// _gitFallbackCache stays null and behavior is unchanged.
+var _gitFallbackCache = null;
+
+function withGitFallbackCache(fn) {
+  var created = false;
+  if (!_gitFallbackCache) {
+    _gitFallbackCache = {};
+    created = true;
+  }
+  try {
+    return fn();
+  } finally {
+    if (created) _gitFallbackCache = null;
+  }
+}
+
+function execGitFallback(op, worktreePath, args) {
+  var cacheKey = op + ":" + worktreePath;
+  if (_gitFallbackCache
+      && Object.prototype.hasOwnProperty.call(_gitFallbackCache, cacheKey)) {
+    return _gitFallbackCache[cacheKey];
+  }
+  var result = agentdesk.exec("git", args);
+  var value = result && result.indexOf("ERROR") !== 0 && result.trim()
+    ? result.trim()
+    : null;
+  if (_gitFallbackCache) {
+    _gitFallbackCache[cacheKey] = value;
+  }
+  return value;
+}
+
+function buildWorkTargetFromDispatchRow(row, options) {
   var result = parseJsonObject(row.result);
   var context = parseJsonObject(row.context);
   var dispatchStatus = row && row.status ? String(row.status) : null;
@@ -351,16 +430,24 @@ function buildWorkTargetFromDispatchRow(row) {
     context.reviewed_commit
   );
 
-  if (!branch && worktreePath) {
-    var branchResult = agentdesk.exec("git", ["-C", worktreePath, "branch", "--show-current"]);
-    if (branchResult && branchResult.indexOf("ERROR") !== 0 && branchResult.trim()) {
-      branch = branchResult.trim();
+  // #3278: git fallback only when the caller can actually consume the
+  // enriched target (selected completed rows / cancelled terminal fallback).
+  // Diagnostics-only rows skip it — see inspectLatestCompletedWorkTarget.
+  var allowGitFallback = !options || options.git_fallback !== false;
+  if (allowGitFallback) {
+    if (!branch && worktreePath) {
+      branch = execGitFallback(
+        "branch",
+        worktreePath,
+        ["-C", worktreePath, "branch", "--show-current"]
+      );
     }
-  }
-  if (!headSha && worktreePath) {
-    var headResult = agentdesk.exec("git", ["-C", worktreePath, "rev-parse", "HEAD"]);
-    if (headResult && headResult.indexOf("ERROR") !== 0 && headResult.trim()) {
-      headSha = headResult.trim();
+    if (!headSha && worktreePath) {
+      headSha = execGitFallback(
+        "head",
+        worktreePath,
+        ["-C", worktreePath, "rev-parse", "HEAD"]
+      );
     }
   }
 
@@ -389,7 +476,16 @@ function inspectLatestCompletedWorkTarget(cardId) {
   );
   for (var i = 0; i < excludedRows.length; i++) {
     var excludedRow = excludedRows[i];
-    var excludedTarget = buildWorkTargetFromDispatchRow(excludedRow);
+    // #3278: pending/dispatched rows are inspected purely for diagnostics —
+    // their result payload is empty until completion, so the git fallback
+    // used to burn up to two child processes per row for data nobody
+    // consumes. Only the first cancelled row with a worktree_path can become
+    // the terminal fallback candidate, so enable the fallback only while
+    // that slot is still open (eligibility itself needs no git: it depends
+    // on row status + metadata worktree_path alone).
+    var excludedTarget = buildWorkTargetFromDispatchRow(excludedRow, {
+      git_fallback: excludedRow.status === "cancelled" && cancelledFallbackIndex === -1
+    });
     var fallbackEligible = excludedRow.status === "cancelled" && !!excludedTarget.worktree_path;
     inspected.push({
       dispatch_id: excludedRow.id,
@@ -2000,7 +2096,10 @@ if (typeof module !== "undefined" && module.exports) {
       loadRequiredPhaseKeysForCard: loadRequiredPhaseKeysForCard,
       verifyRequiredPhaseEvidence: verifyRequiredPhaseEvidence,
       verifyTrackedPrMergeReadiness: verifyTrackedPrMergeReadiness,
-      closeGithubIssueAfterDirectMerge: closeGithubIssueAfterDirectMerge
+      closeGithubIssueAfterDirectMerge: closeGithubIssueAfterDirectMerge,
+      inspectLatestCompletedWorkTarget: inspectLatestCompletedWorkTarget,
+      withGitFallbackCache: withGitFallbackCache,
+      isBridgeDeadlineError: isBridgeDeadlineError
     }
   };
 }


### PR DESCRIPTION
## Summary

Addresses #3278 — `merge-automation` onTick5min timed out against the 5s `POLICY_TICK_HOOK_TIMEOUT` every cycle (even at `queue_depth=0`) and failed with ERROR-level `bridge deadline exceeded during async bridge operation`.

## Root cause

`inspectLatestCompletedWorkTarget` (called per tracked card via `processTrackedMergeQueue → resolveTerminalMergeCandidate`) ran the git fallback in `buildWorkTargetFromDispatchRow` — `git branch --show-current` + `git rev-parse HEAD` — for **every** inspected dispatch row missing branch/head_sha metadata:

- pending/dispatched rows carry no `completed_*` result payload until completion, so the up-to-8 diagnostics-only "excluded" rows each cost 2 child processes for data nobody consumes
- repeated per tracked card per tick, plus the canonical re-validation exec

Each exec is individually deadline-aware (#2378), but the accumulation was not — the hook's bridge budget was exhausted mid-pass, and the next `db.query` threw the deadline error out of the hook.

## Changes (`policies/merge-automation.js`)

1. **Git fallback skip for diagnostics-only rows** — pending/dispatched rows and cancelled rows after the terminal-fallback slot is taken never exec git (eligibility needs only row status + metadata `worktree_path`). Rows whose enriched target is actually consumed (selected completed rows, first cancelled fallback candidate) keep the fallback.
2. **Tick-local cache** — remaining fallback lookups are deduped per `(op, worktree)` via a cache armed only inside `onTick5min` (`withGitFallbackCache`); outside the tick the cache stays disarmed and behavior is unchanged. Canonical branch re-validation in `resolveTerminalMergeCandidate` is intentionally untouched.
3. **Deadline ERROR → WARN** — each tick step runs under a try/catch; `bridge deadline exceeded/passed` errors are logged as WARN with the failing step name and the rest of the pass is deferred to the next tick (matching the reality that the tick actor finishes the work post-timeout in its background queue). Non-deadline errors still propagate. Rust-side `POLICY_TICK_HOOK_TIMEOUT` (5s) is unchanged.

### Git exec count per tick (worst case, 1 tracked create-pr card)

| | before | after |
|---|---|---|
| excluded rows (8 × pending/dispatched) | up to 16 | 0 |
| cancelled fallback rows | 2 per row | 2 (first candidate only) |
| completed rows w/ full metadata | 0 | 0 |
| repeated inspection, same worktree | 2 per call | 2 per tick (cached) |

## Tests

6 new cases in `policies/__tests__/merge-automation.test.js` (existing harness, `node --test`):
- git fallback skipped for pending/dispatched diagnostics rows
- fallback runs only for the first cancelled fallback candidate
- tick-local cache dedupes per worktree within one tick; disarmed outside
- onTick5min downgrades `deadline exceeded` and `deadline passed` errors to WARN, stops the pass, no ERROR log
- non-deadline errors still rethrow

## Verification

- `npm run test:policies` — 142 pass / 0 fail
- `cargo fmt --check` — clean (no Rust changes; `cargo check --lib` skipped accordingly)
- `python3 scripts/generate_inventory_docs.py` + `python3 scripts/check_agent_maintenance_docs.py` — "agent-maintenance freshness check passed"
- `scripts/ci-script-checks.sh`, `scripts/check-portable-paths.py` — exit 0

Refs #3278

🤖 Generated with [Claude Code](https://claude.com/claude-code)