### PR TITLE
fix(#3282): clean up anchor hourglass reaction on synthetic turn-start ABORT

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -416,7 +416,7 @@
     helper additionally fires the claude-only AgentDesk-side `/compact` injection
     when live usage crosses `context_compact_percent_claude` (Claude Code ignores
     `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`); see `src/services/claude_compact_trigger.rs`.
-  - `src/services/discord/tui_prompt_relay.rs` (5438 lines; #3016 phase-5b2
+  - `src/services/discord/tui_prompt_relay.rs` (5492 lines; #3016 phase-5b2
     removed the dead `publish_tui_direct_watcher_finalize_debt` producer;
     SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
@@ -567,7 +567,15 @@
     without one (bridge finalizes EXACTLY ONCE, "first wins"). The committed
     runtime-binding offset still advances on successful delivery and the
     start-offset clamp to `committed_relay_offset` is untouched (no double-send).
-    The Codex idle path (`relay_tui_idle_response_through_bridge`) is unchanged.
+    The Codex idle path (`relay_tui_idle_response_through_bridge`) is unchanged;
+    +54 from #3282: the deferred pending-start worker's terminal backstop ABORT
+    (`backstop_abort_foreign_inflight_live`) now runs the injected
+    `pending_start_abort_cleanup_fn` — resolved from the SAME
+    `shared.serenity_http_or_token_fallback()` provider/command-bot identity that
+    added the anchor `⏳` (#3164 add≡remove invariant) — removing the stranded
+    `⏳` and marking `⚠` on the anchor message (precedent: the watcher's
+    auth-expired `⏳ → ⚠` swap), because no claim ever drives the normal
+    `⏳ → ✅` completion for an ABORTed synthetic start.
   - `src/services/discord/idle_recap.rs` (1319 prod lines; idle-recap card
     compose/post/clear surface, registered giant-file (#3036) — bugfix only
     outside an extraction plan. Crossed 1000 prod LoC with #3146 Part 1: the

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -416,7 +416,7 @@
     helper additionally fires the claude-only AgentDesk-side `/compact` injection
     when live usage crosses `context_compact_percent_claude` (Claude Code ignores
     `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`); see `src/services/claude_compact_trigger.rs`.
-  - `src/services/discord/tui_prompt_relay.rs` (5492 lines; #3016 phase-5b2
+  - `src/services/discord/tui_prompt_relay.rs` (5417 lines; #3016 phase-5b2
     removed the dead `publish_tui_direct_watcher_finalize_debt` producer;
     SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
@@ -575,7 +575,10 @@
     added the anchor `⏳` (#3164 add≡remove invariant) — removing the stranded
     `⏳` and marking `⚠` on the anchor message (precedent: the watcher's
     auth-expired `⏳ → ⚠` swap), because no claim ever drives the normal
-    `⏳ → ✅` completion for an ABORTed synthetic start.
+    `⏳ → ✅` completion for an ABORTed synthetic start; -75 from #3282
+    follow-up: verbose multi-line comment blocks compressed (no semantic
+    change) to offset the +54 growth and keep prod LoC under the frozen
+    `giant_file_ratchet` baseline (5438, #3028).
   - `src/services/discord/idle_recap.rs` (1319 prod lines; idle-recap card
     compose/post/clear surface, registered giant-file (#3036) — bugfix only
     outside an extraction plan. Crossed 1000 prod LoC with #3146 Part 1: the

--- a/src/services/discord/tui_direct_pending_start.rs
+++ b/src/services/discord/tui_direct_pending_start.rs
@@ -371,18 +371,38 @@ pub(super) type ViewFn = Box<
         + Sync,
 >;
 
+/// #3282: Discord-side cleanup the worker runs on the terminal backstop ABORT
+/// (`backstop_abort_foreign_inflight_live`). The anchor message earned a `⏳`
+/// lifecycle reaction when the synthetic start was created; an ABORT means no
+/// claim ever saves an inflight for this anchor, so the normal watcher/recovery
+/// `⏳ → ✅` completion never fires — without explicit cleanup the hourglass
+/// lingers forever. Provided by [`super::tui_prompt_relay`] (it owns the
+/// provider/command bot http — the SAME bot identity that added the `⏳`, per
+/// the #3164 add≡remove invariant).
+pub(super) type AbortCleanupFn = Box<
+    dyn for<'a> Fn(
+            &'a Arc<SharedData>,
+            &'a TuiDirectPendingStart,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>>
+        + Send
+        + Sync,
+>;
+
 /// Spawn the DETACHED per-channel worker. Acquires the channel lock (FIFO
 /// serialization), polls the wait predicate until the prior turn finalizes (or
-/// the 8s backstop fires), runs the claim, and deletes the record. Returns
-/// immediately so the observer loop is never blocked.
+/// the 8s backstop fires), runs the claim, and deletes the record. On the
+/// terminal backstop ABORT it runs `abort_cleanup_fn` (the anchor `⏳` cleanup —
+/// #3282) before dropping the record. Returns immediately so the observer loop
+/// is never blocked.
 pub(super) fn spawn_worker(
     shared: Arc<SharedData>,
     record: TuiDirectPendingStart,
     view_fn: ViewFn,
     claim_fn: ClaimFn,
+    abort_cleanup_fn: AbortCleanupFn,
 ) {
     super::task_supervisor::spawn_observed("tui_direct_pending_start_worker", async move {
-        run_worker(shared, record, view_fn, claim_fn).await;
+        run_worker(shared, record, view_fn, claim_fn, abort_cleanup_fn).await;
     });
 }
 
@@ -404,6 +424,7 @@ async fn run_worker(
     record: TuiDirectPendingStart,
     view_fn: ViewFn,
     claim_fn: ClaimFn,
+    abort_cleanup_fn: AbortCleanupFn,
 ) {
     let lock = channel_lock(&record.provider, record.channel_id);
     let _guard = lock.lock().await;
@@ -462,6 +483,11 @@ async fn run_worker(
                         event = "tui_direct_pending_start.backstop_abort_foreign_inflight_live",
                         "tui_direct_pending_start: prior inflight stayed LIVE across the backstop escalation budget; ABORTING the synthetic turn-start claim without overwriting the live prior turn (provider output still relays via the prior turn's owner)"
                     );
+                    // #3282: no claim will ever run for this anchor, so the
+                    // normal `⏳ → ✅` completion never fires — clean up the
+                    // anchor's `⏳` here (same bot identity as the add, #3164)
+                    // instead of leaving the hourglass stranded forever.
+                    abort_cleanup_fn(&shared, &record).await;
                     delete(&record);
                     return;
                 }
@@ -662,6 +688,24 @@ mod tests {
         assert_eq!(record, back);
     }
 
+    /// #3282 test double for the ABORT-path anchor `⏳` cleanup, following the
+    /// `ViewFn`/`ClaimFn` boxed-closure convention. Records each invocation so a
+    /// test can pin WHEN the cleanup fires (terminal backstop ABORT only) and
+    /// when it must NOT (successful claim — the normal `⏳ → ✅` completion owns
+    /// the anchor; retry exhaustion — the record is retained for restart).
+    fn recording_abort_cleanup() -> (AbortCleanupFn, Arc<std::sync::atomic::AtomicU32>) {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let calls = Arc::new(AtomicU32::new(0));
+        let calls_for_fn = calls.clone();
+        let cleanup: AbortCleanupFn = Box::new(move |_shared, _record| {
+            let calls = calls_for_fn.clone();
+            Box::pin(async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+            })
+        });
+        (cleanup, calls)
+    }
+
     fn record(provider: &str, channel_id: u64, anchor: u64) -> TuiDirectPendingStart {
         TuiDirectPendingStart {
             provider: provider.to_string(),
@@ -748,7 +792,14 @@ mod tests {
             pending_synthetic_start_present("claude", 1),
             "A's pending start gates the watcher/idle-queue immediately"
         );
-        let a_handle = tokio::spawn(run_worker(shared.clone(), rec_a, a_view, a_claim));
+        let (a_cleanup, a_cleanup_calls) = recording_abort_cleanup();
+        let a_handle = tokio::spawn(run_worker(
+            shared.clone(),
+            rec_a,
+            a_view,
+            a_claim,
+            a_cleanup,
+        ));
 
         // ---- Channel B: prior turn already finalized → relays immediately. ----
         let b_claimed = Arc::new(AtomicBool::new(false));
@@ -773,7 +824,14 @@ mod tests {
         });
         let rec_b = record("claude", 2, 22);
         persist(&rec_b).unwrap();
-        let b_handle = tokio::spawn(run_worker(shared.clone(), rec_b, b_view, b_claim));
+        let (b_cleanup, b_cleanup_calls) = recording_abort_cleanup();
+        let b_handle = tokio::spawn(run_worker(
+            shared.clone(),
+            rec_b,
+            b_view,
+            b_claim,
+            b_cleanup,
+        ));
 
         // B is on a DIFFERENT channel lock; it must finish without waiting for A.
         b_handle.await.unwrap();
@@ -806,6 +864,12 @@ mod tests {
         assert!(
             !pending_synthetic_start_present("claude", 1),
             "A's pending start cleared after the claim (gate releases)"
+        );
+        assert_eq!(
+            a_cleanup_calls.load(Ordering::SeqCst) + b_cleanup_calls.load(Ordering::SeqCst),
+            0,
+            "#3282: a SUCCESSFUL claim must never run the abort reaction cleanup — \
+             the normal watcher/recovery ⏳ → ✅ completion owns these anchors"
         );
         reset_present_for_tests();
     }
@@ -901,7 +965,8 @@ mod tests {
         persist(&rec).unwrap();
         assert!(pending_synthetic_start_present("claude", 10));
 
-        let handle = tokio::spawn(run_worker(shared.clone(), rec, view, claim));
+        let (abort_cleanup, abort_cleanup_calls) = recording_abort_cleanup();
+        let handle = tokio::spawn(run_worker(shared.clone(), rec, view, claim, abort_cleanup));
 
         // Advance through the full escalation budget of backstop windows.
         for _ in 0..(PENDING_START_MAX_BACKSTOP_CYCLES + 1) {
@@ -922,6 +987,14 @@ mod tests {
             "after the escalation budget the worker ABORTS and drops only the \
              ownership record (no prompt resubmit). RED if abort leaks the record \
              or never fires."
+        );
+        assert_eq!(
+            abort_cleanup_calls.load(Ordering::SeqCst),
+            1,
+            "#3282: the terminal backstop ABORT must run the anchor reaction \
+             cleanup EXACTLY ONCE (removes the stranded ⏳ — no claim will ever \
+             drive the normal ⏳ → ✅ completion for this anchor). RED if the \
+             ABORT branch skips abort_cleanup_fn (the hourglass lingers forever)."
         );
         reset_present_for_tests();
     }
@@ -961,7 +1034,8 @@ mod tests {
 
         let rec = record("claude", 11, 111);
         persist(&rec).unwrap();
-        let handle = tokio::spawn(run_worker(shared.clone(), rec, view, claim));
+        let (abort_cleanup, abort_cleanup_calls) = recording_abort_cleanup();
+        let handle = tokio::spawn(run_worker(shared.clone(), rec, view, claim, abort_cleanup));
 
         // Drive the retry backoffs. After the first false, assert the record is
         // STILL present (RETAINED) before the eventual success deletes it.
@@ -988,6 +1062,12 @@ mod tests {
         assert!(
             !pending_synthetic_start_present("claude", 11),
             "after the claim finally succeeded the record is deleted (gate releases)"
+        );
+        assert_eq!(
+            abort_cleanup_calls.load(Ordering::SeqCst),
+            0,
+            "#3282: transient claim retries that eventually SUCCEED must not run \
+             the abort reaction cleanup — the anchor's ⏳ → ✅ completes normally"
         );
         reset_present_for_tests();
     }
@@ -1023,7 +1103,8 @@ mod tests {
 
         let rec = record("claude", 12, 122);
         persist(&rec).unwrap();
-        let handle = tokio::spawn(run_worker(shared.clone(), rec, view, claim));
+        let (abort_cleanup, abort_cleanup_calls) = recording_abort_cleanup();
+        let handle = tokio::spawn(run_worker(shared.clone(), rec, view, claim, abort_cleanup));
 
         for _ in 0..(PENDING_START_MAX_CLAIM_ATTEMPTS + 2) {
             tokio::time::advance(PENDING_START_CLAIM_RETRY_BACKOFF + PENDING_START_POLL).await;
@@ -1040,6 +1121,13 @@ mod tests {
             pending_synthetic_start_present("claude", 12),
             "on retry exhaustion the record is RETAINED for restart re-attempt — \
              RED if the worker deletes after exhausting claims (turn-loss)."
+        );
+        assert_eq!(
+            abort_cleanup_calls.load(Ordering::SeqCst),
+            0,
+            "#3282: claim-retry exhaustion RETAINS the record for a restart \
+             re-attempt — the anchor's ⏳ must stay (the restored worker may still \
+             claim and complete it normally), so the abort cleanup must NOT fire"
         );
         reset_present_for_tests();
     }

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -492,29 +492,19 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
         );
         return;
     };
-    // #3178 (codex fix — P1 lease-overwrite / the 'state tangle'): classify and
-    // run the slash-command-control DEDUPE check BEFORE recording ANY
-    // external-input lease. A machine slash-command control echo (/loop, /compact,
-    // the expanded `<command-*>` wrapper) now claims a FULL active turn (lease +
-    // ⏳ anchor + synthetic inflight, below). The #3153 double-post delivers the
-    // SAME injection as two independent observed prompts (raw echo + expanded
-    // wrapper) within ~tens-of-ms; the FIRST claims the active turn, but the
-    // SECOND must NOT — and critically must NOT record a lease, because the lease
-    // table is one-per-(provider,session): a second `record_external_input_turn_lease`
-    // would overwrite the first turn's lease and the duplicate's own guard would
-    // then clear that generation, stranding the first turn's bridge tail. So the
-    // duplicate half is dropped HERE, before the lease record on the next line, and
-    // never creates a lease/anchor/inflight at all. A genuine SECOND /loop or
-    // /compact seconds later falls outside the 2s window → fresh first sighting →
-    // its own active turn.
+    // #3178 (codex P1 lease-overwrite): run the slash-command-control dedupe BEFORE
+    // recording ANY external-input lease. The #3153 double-post (raw echo + expanded
+    // `<command-*>` wrapper, ~tens-of-ms apart) must not let the SECOND half record a
+    // lease: the table is one-per-(provider,session), so it would overwrite the first
+    // turn's lease and its guard would clear that generation, stranding the first
+    // bridge tail. Drop the duplicate here, before any lease/anchor/inflight exists;
+    // a genuine second /loop / /compact falls outside the 2s window → fresh turn.
     let injected_class = classify_injected_prompt(&prompt.prompt);
     if matches!(injected_class, InjectedPromptClass::SlashCommandControl) {
         let kind = slash_command_control_kind(&prompt.prompt);
         if !slash_command_control_turn_is_first_sighting(&prompt.tmux_session_name, &kind) {
-            // #3153 double-post second half within the 2s window: drop BEFORE any
-            // lease/anchor/inflight is created, so the first turn's lease is never
-            // overwritten and no guard/lease leaks (none was ever recorded). The
-            // first half already relays the assistant output via its own bridge tail.
+            // #3153 second half within the 2s window: drop before any lease/anchor/
+            // inflight exists; the first half already relays via its own bridge tail.
             tracing::info!(
                 provider = %prompt.provider,
                 channel_id = channel_id.get(),
@@ -527,13 +517,10 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
     }
     let mut lease = record_observed_external_turn_lease(shared, &prompt, channel_id);
     // #3041 P1-4 codex: arm an early-return RAII guard the instant the lease is
-    // recorded & stored. Every FAILURE early-return below (registry None, notify
-    // resolve Err/503, task-card repeat, anchor POST failure) would otherwise leave
-    // this (possibly BridgeAdapter-owned) lease set for the full TTL, blocking the
-    // legitimate watcher/sink delivery for ~10 minutes. The guard clears EXACTLY the
-    // recorded generation on drop; it is DISARMED on the success path just before the
-    // bridge-tail ownership block, so a turn the bridge legitimately owns keeps its
-    // lease (no double-delivery).
+    // recorded — every failure early-return below would otherwise leave the lease set
+    // for the full TTL, blocking watcher/sink delivery ~10min. The guard clears
+    // EXACTLY the recorded generation on drop and is DISARMED on the success path
+    // before the bridge-tail ownership block (a bridge-owned turn keeps its lease).
     let mut observed_lease_early_return_guard = TuiDirectObservedLeaseEarlyReturnGuard::arm(
         &prompt.provider,
         &prompt.tmux_session_name,
@@ -569,34 +556,19 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             return;
         }
     };
-    // #3164: the `⏳` lifecycle reaction MUST be added by the SAME bot identity that
-    // later removes it. The completion path
-    // (`complete_tui_direct_prompt_anchor_lifecycle_if_present`) calls
-    // `remove_reaction_raw(http, ..., '⏳')` with the *provider/command* bot's
-    // `ctx.http` (the watcher parameter, ultimately the provider runtime's serenity
-    // ctx). `remove_reaction_raw` only removes `@me`'s reaction, so if `⏳` is added
-    // by a DIFFERENT bot (previously `notify`), removal silently no-ops and the
-    // hourglass lingers forever. #750 invariant: the command bot is the SINGLE source
-    // of the `⏳` lifecycle emoji (announce/notify bots never carry it). So resolve
-    // the provider/command bot here and use it for the add below. Note: the
-    // *notification body* itself is still posted by `notify_http` — a different bot
-    // reacting to a notify-posted message is fine (Discord lets any bot react to any
-    // message). We intentionally do NOT fall back to `notify_http` for the reaction:
-    // adding with the wrong identity reintroduces the un-removable residual, so on
-    // resolve failure we skip the `⏳` add (with a warning) rather than mis-attribute it.
-    // #3164 codex R2 issue-1: resolve the add-bot from the SAME source the
-    // completion path removes with — this relay's own `shared`
-    // `serenity_http_or_token_fallback()`, NOT a name-only registry lookup.
-    // The completion `complete_tui_direct_prompt_anchor_lifecycle_if_present`
-    // is driven by the watcher's `http`, which is exactly
-    // `shared.serenity_http_or_token_fallback()` (turn_bridge/mod.rs:2187 etc.).
-    // A name-based `resolve_bot_http(registry, provider)` returns the FIRST
-    // client matching the provider name; in a multi-runtime/same-provider
-    // deployment that can be a DIFFERENT bot account than this `shared`'s ctx
-    // http, reintroducing the add≠remove asymmetry. Using `shared`'s own http
-    // guarantees identical `@me` identity, so `remove_reaction_raw` later
-    // removes exactly this `⏳`. On unavailability we SKIP the add (warn) rather
-    // than mis-attribute it via `notify_http` (which would relinger forever).
+    // #3164: the `⏳` MUST be added by the SAME bot identity that later removes it —
+    // `remove_reaction_raw` only removes `@me`'s reaction, so an add by a different
+    // bot (previously `notify`) leaves the hourglass forever. #750 invariant: the
+    // command bot is the single source of the `⏳` lifecycle emoji. The notification
+    // BODY is still posted by `notify_http` (any bot may react to any message), but
+    // we never fall back to `notify_http` for the reaction: on resolve failure we
+    // skip the add (warn) rather than mis-attribute it.
+    // #3164 codex R2 issue-1: resolve the add-bot from the SAME source the completion
+    // (`complete_tui_direct_prompt_anchor_lifecycle_if_present`) removes with — this
+    // relay's own `shared.serenity_http_or_token_fallback()` (the watcher's `http`,
+    // turn_bridge/mod.rs:2187), NOT a name-only `resolve_bot_http` lookup, which in a
+    // multi-runtime/same-provider deployment can return a DIFFERENT bot account and
+    // reintroduce the add≠remove asymmetry.
     let command_http = shared.serenity_http_or_token_fallback();
     if command_http.is_none() {
         tracing::warn!(
@@ -610,27 +582,15 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
              (adding with a different bot would leave an un-removable hourglass)"
         );
     }
-    // #3099 / #3100: `injected_class` was classified at the top of this function
-    // (before the slash-command-control dedupe / lease record). A compact/system
-    // continuation prologue is NOT a human request — it is rendered as a neutral
-    // session note with no `⏳`, no prompt anchor, and no synthetic turn ownership.
-    //
-    // #3099 codex re-review (P1): SystemContinuation must NOT short-circuit the
-    // whole relay. The compact continuation IS fed to the provider and Claude
-    // produces assistant output; that output still has to reach Discord via the
-    // bridge tail. So a SystemContinuation suppresses ONLY the user-turn
-    // lifecycle (the `⏳` reaction, the prompt anchor, and the synthetic
-    // user-turn/inflight ownership) — the assistant-output delivery path (the
-    // Claude bridge tail below) still runs exactly as for any other injection.
-    //
-    // #3178 (codex fix): a SlashCommandControl is NO LONGER suppressed here — it
-    // takes the active-turn `else` block below (anchor + ⏳ + synthetic inflight)
-    // so a message injected mid-/loop queues cleanly (mailbox.has_active_turn()
-    // becomes true). Only SystemContinuation still suppresses the lifecycle.
-    // #3099 codex re-review (P1): suppressing the user-turn lifecycle (⏳ + anchor
-    // + synthetic ownership) is decoupled from output delivery. The bridge tail
-    // below runs regardless so the provider's assistant output still reaches
-    // Discord even for a SystemContinuation.
+    // #3099 / #3100: a compact/system continuation prologue is NOT a human request —
+    // it renders as a neutral session note with no `⏳`, no anchor, and no synthetic
+    // turn ownership. #3099 codex re-review (P1): it must NOT short-circuit the whole
+    // relay — only the user-turn lifecycle is suppressed; the bridge tail below still
+    // runs so the provider's assistant output reaches Discord.
+    // #3178 (codex fix): a SlashCommandControl is NO LONGER suppressed here — it takes
+    // the active-turn `else` block below (anchor + ⏳ + synthetic inflight) so a
+    // message injected mid-/loop queues cleanly (mailbox.has_active_turn() == true).
+    // Only SystemContinuation still suppresses the lifecycle.
     let is_system_continuation = injected_class.suppresses_user_turn_lifecycle();
     debug_assert!(
         injected_class.still_delivers_assistant_output(),
@@ -672,19 +632,14 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             }
         }
     } else {
-        // #3178 (codex fix): a SlashCommandControl (/loop, /compact, the expanded
-        // <command-*> wrapper, or the Compacted stdout) is a FULL active turn now,
-        // so it posts an anchor + ⏳ + synthetic inflight like HumanTuiDirect. Its
-        // anchor CONTENT carries the /loop directive body (the operator wants the
-        // recurring loop content visible — only the #3153 double-post is deduped,
-        // not the content) but NEVER the <command-*> wrapper boilerplate or the
-        // Compacted stdout body. (The #3153 duplicate half was already dropped
-        // before any lease record at the top of this function.)
-        // #3075: a `<task-notification>` auto-turn is a MACHINE event — render it
-        // as a compact structured card and DEDUPE repeats by task-id (a repeat
-        // edits its live card or drops as a no-op → no new ⏳/turn; the first
-        // sighting returns content to post as the #3099 anchor). HumanTuiDirect
-        // keeps the raw render; SystemContinuation is handled above (#3100).
+        // #3178 (codex fix): a SlashCommandControl is a FULL active turn now (anchor +
+        // ⏳ + synthetic inflight like HumanTuiDirect). Its anchor content carries the
+        // /loop directive body but never the <command-*> wrapper or Compacted stdout;
+        // the #3153 duplicate half was already dropped before the lease record above.
+        // #3075: a `<task-notification>` auto-turn is a MACHINE event — render a
+        // compact structured card and dedupe repeats by task-id (a repeat edits its
+        // live card or no-ops; the first sighting posts as the #3099 anchor).
+        // HumanTuiDirect keeps the raw render; SystemContinuation handled above (#3100).
         let content = if matches!(injected_class, InjectedPromptClass::SlashCommandControl) {
             let kind = slash_command_control_kind(&prompt.prompt);
             format_slash_command_control_note(&prompt.tmux_session_name, &kind, &prompt.prompt)
@@ -699,16 +654,11 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             {
                 super::tui_task_card::TaskCardOutcome::Post { content } => content,
                 super::tui_task_card::TaskCardOutcome::Repeat => {
-                    // #3075 codex P1 #2: a repeat edited the live card (or dropped
-                    // as a no-op) and early-returns BEFORE the bridge-tail /
-                    // lease-guard cleanup block below. But `record_observed_external_turn_lease`
-                    // (above) already recorded a fresh external-input turn lease for
-                    // THIS observation, overwriting any prior one. If we returned now
-                    // without clearing it, that dangling non-Unassigned lease would
-                    // make `session_bound_external_lease_blocks_delivery` skip a
-                    // legitimate session-bound / bridge-tail delivery. Clear exactly
-                    // the lease this observation recorded (exact-match, so a newer
-                    // turn that reused this provider/session/channel is preserved).
+                    // #3075 codex P1 #2: a repeat early-returns before the bridge-tail
+                    // lease-guard cleanup, but the lease recorded above would dangle and
+                    // make `session_bound_external_lease_blocks_delivery` skip legitimate
+                    // delivery. Clear exactly the lease THIS observation recorded
+                    // (exact-match preserves a newer turn's lease).
                     clear_observed_external_turn_lease_if_current(&prompt, channel_id, &lease);
                     return;
                 }
@@ -723,19 +673,13 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
         let anchor_message = match channel_id.say(&*notify_http, content).await {
             Ok(message) => message,
             Err(error) => {
-                // #3075 codex P2: for a TaskNotificationEvent the `Post` outcome
-                // above reserved a placeholder card slot (message_id == 0) BEFORE
-                // this post. If the post fails we early-return without ever calling
-                // `record_posted_card`, so the placeholder would linger and force
-                // every later same-task notification to resolve to `Pending`
-                // (`TaskCardOutcome::Repeat` → no-op), silently suppressing that
-                // task-id until the 1h stale purge. Release the reservation we own
-                // (exact-match: only while message_id is still 0) so the NEXT
-                // same-task notification reserves fresh and reposts. A racing
-                // repeat that legitimately saw `Pending` is still a safe no-op:
-                // its slot read happened against this same placeholder, and clearing
-                // it only changes the *next* reservation's outcome — it never turns
-                // an already-dropped repeat into a double-post.
+                // #3075 codex P2: the `Post` outcome reserved a placeholder card slot
+                // (message_id == 0) before this post; on post failure release the
+                // reservation we own (exact-match while message_id is still 0) so the
+                // next same-task notification reserves fresh — otherwise the lingering
+                // placeholder forces every later one to `Pending`/no-op until the 1h
+                // stale purge. Clearing only changes the NEXT reservation's outcome,
+                // never turning an already-dropped repeat into a double-post.
                 if matches!(injected_class, InjectedPromptClass::TaskNotificationEvent) {
                     let task_id =
                         super::tui_task_card::parse_task_notification(&prompt.prompt).task_id;
@@ -762,10 +706,8 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
         current_turn_anchor_id = Some(anchor_message.id.get());
         // #3075: remember this card so a repeat completion edits it. #3164 codex R3
         // issue-2: keep this IMMEDIATELY after the successful post (before the awaited
-        // `⏳` add) — `record_posted_card` is NOT used by lifecycle completion, and
-        // deferring it behind the reaction await widens the task-card `Pending` no-op
-        // window (a repeat `<task-notification>` arriving while message_id is still 0
-        // is dropped as `Pending`, losing the only repeat/update).
+        // `⏳` add) — deferring it behind the reaction await widens the task-card
+        // `Pending` no-op window and can drop the only repeat/update.
         if matches!(injected_class, InjectedPromptClass::TaskNotificationEvent) {
             super::tui_task_card::record_posted_card(
                 channel_id.get(),
@@ -774,17 +716,13 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             );
         }
         // #3164: add `⏳` with the command(provider) bot so it matches the bot that
-        // removes it in `complete_tui_direct_prompt_anchor_lifecycle_if_present`
-        // (watcher provider ctx.http via `shared.serenity_http_or_token_fallback()`).
-        // If that http was unavailable we skip the add entirely (warned above)
-        // rather than add with the wrong identity and strand the hourglass.
-        //
+        // removes it in `complete_tui_direct_prompt_anchor_lifecycle_if_present`; if
+        // that http was unavailable we skip the add (warned above) rather than strand
+        // the hourglass under the wrong identity.
         // #3164 codex R2 issue-2: add the `⏳` BEFORE the anchor becomes findable
-        // (`record_prompt_anchor` below). The completion path locates this turn via
-        // the dedupe anchor; if the anchor were recorded first, a fast watcher could
-        // complete (remove a not-yet-added `⏳`, post `✅`, clear the anchor) and THEN
-        // this delayed add would land — re-leaving `⏳ + ✅`. Adding first guarantees
-        // the `⏳` exists before any anchor-based completion can observe the turn.
+        // (`record_prompt_anchor` below) — anchor-first would let a fast watcher
+        // complete (remove a not-yet-added `⏳`, post `✅`, clear the anchor) and the
+        // delayed add then re-leaves `⏳ + ✅`.
         if let Some(command_http) = command_http.as_ref() {
             super::formatting::add_reaction_raw(command_http, channel_id, anchor_message.id, '⏳')
                 .await;
@@ -795,35 +733,22 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             channel_id.get(),
             anchor_message.id.get(),
         );
-        // #3174: turn-identity guard on the ⏳ lifecycle vs the watcher's
-        // lease-gated completion. If the provider committed terminal output
-        // inside the sub-second `notify-post + ⏳-add` window above, the watcher's
-        // lease-gated completion already fired BEFORE this `record_prompt_anchor`
-        // landed — it found no anchor, was a no-op, and recorded a deferred-
-        // completion marker (the lease it gated on is cleared after that
-        // delivery, so no later watcher pass would reconcile the ⏳). Now that
-        // THIS turn's anchor exists, drain that marker and finish the
-        // ⏳ → ✅ swap against the just-recorded anchor.
-        //
-        // #3174 codex P1 (turn identity): the marker is stamped with the
-        // `generation` of the lease the watcher completion gated on; drain ONLY
-        // the marker matching THIS relay invocation's lease generation
-        // (`lease.generation`), so a NEWER same-(provider,tmux) turn's marker is
-        // never cross-consumed and the wrong turn's ⏳ is never completed.
-        //
-        // #3174 codex P2 (HTTP fail-open): PEEK the marker first, then only
-        // consume (`take_...`) once we have a `command_http` to actually deliver
-        // the ⏳ → ✅ swap. If command_http is unavailable we leave the marker in
-        // place rather than silently dropping it — mirrors the #3164 ⏳-add
-        // fail-open (skip rather than strand worse than before); a later anchor
-        // record / watcher pass can still reconcile it within the marker TTL.
-        // No-op on the common path (no terminal output yet → no marker). The
-        // peek + consume/fail-open DECISION is in
-        // [`decide_deferred_anchor_completion_drain`] (pure, against the real
-        // dedupe state) so it is integration-testable: a test that records a
-        // matching marker and drives this block must see the marker consumed and
-        // the completion delivered; neutralizing the decision (or the consume)
-        // makes that test fail.
+        // #3174: turn-identity guard on the ⏳ lifecycle. If the provider committed
+        // terminal output inside the sub-second `notify-post + ⏳-add` window above,
+        // the watcher's lease-gated completion already fired before this
+        // `record_prompt_anchor` landed — no anchor found, no-op, and a deferred-
+        // completion marker was recorded (its lease is cleared after delivery, so no
+        // later watcher pass reconciles the ⏳). Now that THIS turn's anchor exists,
+        // drain that marker and finish the ⏳ → ✅ swap.
+        // #3174 codex P1 (turn identity): the marker is stamped with the gated lease's
+        // `generation`; drain ONLY the marker matching `lease.generation` so a newer
+        // same-(provider,tmux) turn's marker is never cross-consumed.
+        // #3174 codex P2 (HTTP fail-open): PEEK first, consume (`take_...`) only with a
+        // `command_http` to deliver the swap; otherwise leave the marker in place
+        // (mirrors the #3164 ⏳-add fail-open) for a later pass within the marker TTL.
+        // No-op on the common path (no marker). The peek + consume/fail-open decision
+        // lives in [`decide_deferred_anchor_completion_drain`] (pure) so it is
+        // integration-testable end-to-end.
         match decide_deferred_anchor_completion_drain(
             &prompt.provider,
             &prompt.tmux_session_name,

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -1643,6 +1643,7 @@ fn defer_synthetic_turn_start(
         record,
         pending_start_view_fn(),
         pending_start_claim_fn(),
+        pending_start_abort_cleanup_fn(),
     );
 }
 
@@ -1815,6 +1816,58 @@ fn pending_start_claim_fn() -> super::tui_direct_pending_start::ClaimFn {
     })
 }
 
+/// #3282: the worker's terminal-ABORT reaction cleanup. When the backstop
+/// escalation budget is exhausted (`backstop_abort_foreign_inflight_live`) no
+/// claim ever saves an inflight for this anchor, so the normal watcher/recovery
+/// `⏳ → ✅` completion never fires — without this cleanup the anchor's `⏳`
+/// lingers forever (observed live on msg 1514080986529533972). Remove the `⏳`
+/// and swap in a `⚠` failure marker so the abort is visible rather than a
+/// silent eternal hourglass (precedent: the watcher's auth-expired `⏳ → ⚠`
+/// swap in tmux_watcher.rs).
+///
+/// Bot identity (#3164 invariant): the `⏳` was added with THIS relay's
+/// `shared.serenity_http_or_token_fallback()` (the provider/command bot —
+/// see the `command_http` add in `relay_observed_prompt`), and
+/// `remove_reaction_raw` only removes `@me`'s reaction. Resolving the SAME
+/// source here guarantees the identical `@me` identity, so the removal targets
+/// exactly the reaction the add created. On unavailability we skip with a
+/// warning — removing with a different bot identity would silently no-op.
+fn pending_start_abort_cleanup_fn() -> super::tui_direct_pending_start::AbortCleanupFn {
+    Box::new(|shared, record| {
+        Box::pin(async move {
+            // Defensive: a corrupted durable record could carry a zero anchor id;
+            // `MessageId::new(0)` panics (mirrors the watcher's user_msg_id != 0
+            // guard before its reaction swaps).
+            if record.anchor_message_id == 0 {
+                return;
+            }
+            let Some(http) = shared.serenity_http_or_token_fallback() else {
+                tracing::warn!(
+                    provider = %record.provider,
+                    channel_id = record.channel_id,
+                    tmux_session_name = %record.tmux_session_name,
+                    anchor_message_id = record.anchor_message_id,
+                    "tui_direct_pending_start: skipping anchor ⏳ abort cleanup; provider serenity \
+                     http unavailable (removing with a different bot identity would no-op — #3164)"
+                );
+                return;
+            };
+            let channel_id = ChannelId::new(record.channel_id);
+            let anchor_message_id = MessageId::new(record.anchor_message_id);
+            super::formatting::remove_reaction_raw(&http, channel_id, anchor_message_id, '⏳')
+                .await;
+            super::formatting::add_reaction_raw(&http, channel_id, anchor_message_id, '⚠').await;
+            tracing::info!(
+                provider = %record.provider,
+                channel_id = record.channel_id,
+                tmux_session_name = %record.tmux_session_name,
+                anchor_message_id = record.anchor_message_id,
+                "tui_direct_pending_start: removed the anchor ⏳ and marked ⚠ after the synthetic turn-start ABORT (#3282)"
+            );
+        })
+    })
+}
+
 fn parse_external_input_relay_owner(value: &str) -> ExternalInputRelayOwner {
     match value {
         "bridge_adapter" => ExternalInputRelayOwner::BridgeAdapter,
@@ -1852,6 +1905,7 @@ fn restore_pending_starts(shared: &Arc<SharedData>, provider: &ProviderKind) {
             record,
             pending_start_view_fn(),
             pending_start_claim_fn(),
+            pending_start_abort_cleanup_fn(),
         );
     }
 }


### PR DESCRIPTION
## Summary

`tui_direct_pending_start`의 backstop escalation budget(4 cycle) 소진 ABORT 경로(`backstop_abort_foreign_inflight_live`)가 anchor 메시지의 ⏳ 리액션을 정리하지 않아 영구 잔존하던 누수를 수정한다 (#3282, #3277 Defect F 분리; 실측 표본 msg 1514080986529533972).

## Changes

- **`src/services/discord/tui_direct_pending_start.rs`**: 기존 `ViewFn`/`ClaimFn` 컨벤션을 따르는 `AbortCleanupFn` 주입 타입을 추가하고, `spawn_worker`/`run_worker`에 배선. ABORT 분기에서 `delete(&record)` 직전에 cleanup을 실행한다. ABORT 이후에는 어떤 claim도 이 anchor에 대해 정상 ⏳→✅ 완료를 구동하지 않으므로 명시적 정리가 유일한 회수 경로다.
- **`src/services/discord/tui_prompt_relay.rs`**: 프로덕션 cleanup `pending_start_abort_cleanup_fn` 추가 — ⏳를 add한 것과 동일한 `shared.serenity_http_or_token_fallback()` (provider/command 봇) 정체성으로 `remove_reaction_raw(⏳)` 후 `add_reaction_raw(⚠)`로 실패 표시 (#3164 add≡remove 불변식; ⚠ 교체는 tmux_watcher의 auth-expired ⏳→⚠ 선례를 따름). http 미가용 시 잘못된 정체성으로 제거를 시도하는 대신 경고 후 스킵. defer/restart-restore 양쪽 `spawn_worker` 호출부에 배선.

## Behavior notes

- 성공 claim 경로 / claim-retry 소진(레코드 보존, 재시작 재시도) 경로에서는 cleanup이 절대 발화하지 않는다 — ⏳는 정상 완료 경로가 소유.
- 손상 레코드의 `anchor_message_id == 0` 가드 추가 (`MessageId::new(0)` 패닉 방지, watcher의 `user_msg_id != 0` 가드 미러).

## Tests

- `backstop_foreign_inflight_live_aborts_without_claim`: ABORT 경로에서 reaction cleanup이 정확히 1회 호출됨을 고정 (신규 `recording_abort_cleanup` 테스트 더블).
- `channel_a_defers_until_prior_clears_while_channel_b_does_not_starve`, `claim_false_retains_record_and_retries`, `claim_false_exhausted_still_retains_record`: 비-ABORT 경로에서 cleanup 미발화(0회) 고정.

## Gates

- `cargo fmt --check` 통과
- `cargo check --lib` 0 warning
- `cargo test --lib tui_direct_pending_start` 14 passed / `cargo test --lib tui_prompt_relay` 102 passed
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` freshness check passed (change-surfaces.md tui_prompt_relay 5438→5492, +54 #3282 항목 동기화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)