### PR TITLE
fix(#3275): persist token telemetry from watcher-owned codex turns

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -575,7 +575,7 @@
     mailbox/inflight probe, and the `post_recheck_action` seam that skips/undoes
     a recap post when a turn raced the compose window. Split compose vs
     lifecycle/clear submodules before adding behavior).
-  - `src/services/codex_tmux_wrapper.rs` (1280 lines; Codex tmux wrapper JSON
+  - `src/services/codex_tmux_wrapper.rs` (1289 lines; Codex tmux wrapper JSON
     event parser and relay bridge for native Codex session events — bugfix only
     outside an extraction plan; +65 from #3275: capture per-call
     `token_count.info.last_token_usage` and re-emit it as a Claude-compatible

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -575,9 +575,13 @@
     mailbox/inflight probe, and the `post_recheck_action` seam that skips/undoes
     a recap post when a turn raced the compose window. Split compose vs
     lifecycle/clear submodules before adding behavior).
-  - `src/services/codex_tmux_wrapper.rs` (1215 lines; Codex tmux wrapper JSON
+  - `src/services/codex_tmux_wrapper.rs` (1280 lines; Codex tmux wrapper JSON
     event parser and relay bridge for native Codex session events — bugfix only
-    outside an extraction plan).
+    outside an extraction plan; +65 from #3275: capture per-call
+    `token_count.info.last_token_usage` and re-emit it as a Claude-compatible
+    nested `usage` on the success result frame so watcher-owned codex turns
+    persist token telemetry — never the session-cumulative
+    `info.total_token_usage`).
   - `src/services/tui_prompt_dedupe.rs` (1294 lines; shared TUI prompt
     fingerprinting/dedupe state for hook and rollout relay paths, bugfix only
     outside an extraction plan; +88 from #3041 P1-4 codex: a per-record

--- a/src/services/codex_tmux_wrapper.rs
+++ b/src/services/codex_tmux_wrapper.rs
@@ -555,10 +555,35 @@ fn run_turn(
     Ok(())
 }
 
+/// #3275: one Codex API call's token usage, parsed from `token_count`
+/// (`info.last_token_usage`) or a terminal event's own per-turn `usage`.
+#[derive(Clone, Copy)]
+struct CodexCallTokenUsage {
+    input_tokens: u64,
+    cached_input_tokens: u64,
+    output_tokens: u64,
+}
+
+impl CodexCallTokenUsage {
+    fn from_value(value: &serde_json::Value) -> Option<Self> {
+        let field = |key: &str| value.get(key).and_then(|v| v.as_u64()).unwrap_or(0);
+        value.is_object().then(|| Self {
+            input_tokens: field("input_tokens"),
+            cached_input_tokens: field("cached_input_tokens"),
+            output_tokens: field("output_tokens"),
+        })
+    }
+}
+
 #[derive(Default)]
 struct CodexWrapperTurnState {
     final_text: String,
     saw_turn_completed: bool,
+    // #3275: per-call context occupancy from the latest `token_count` event
+    // (`info.last_token_usage` only — never the session-cumulative
+    // `info.total_token_usage`), re-emitted as the result frame's nested
+    // Claude-compatible `usage` so watcher/bridge token persistence fires.
+    last_token_usage: Option<CodexCallTokenUsage>,
     // Diagnostic-only count of every unrecognized event (top-level / event_msg /
     // response_item), benign or not, used for the ignored-event log.
     unknown_event_count: u64,
@@ -899,7 +924,11 @@ fn handle_event_msg(
     match payload.get("type").and_then(|v| v.as_str()).unwrap_or("") {
         "task_complete" => emit_success_result(output, payload, thread_id, state, start),
         "agent_reasoning" => emit_json_line(output, assistant_redacted_thinking_event()),
-        "token_count" | "composer_ready" => Ok(()),
+        "token_count" => {
+            capture_last_token_usage(payload, state);
+            Ok(())
+        }
+        "composer_ready" => Ok(()),
         event_type => record_unknown_codex_event(output, state, event_type, payload),
     }
 }
@@ -947,20 +976,56 @@ fn emit_success_result(
         .get("output_tokens")
         .and_then(|v| v.as_u64())
         .unwrap_or(0);
-    emit_json_line(
-        output,
-        serde_json::json!({
-            "type": "result",
-            "subtype": "success",
-            "result": state.final_text,
-            "session_id": thread_id.as_deref(),
-            "duration_ms": start.elapsed().as_millis() as u64,
-            "input_tokens": input_tokens,
-            "output_tokens": output_tokens,
-        }),
-    )?;
+    let mut result = serde_json::json!({
+        "type": "result",
+        "subtype": "success",
+        "result": state.final_text,
+        "session_id": thread_id.as_deref(),
+        "duration_ms": start.elapsed().as_millis() as u64,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+    });
+    // #3275: the shared result-frame token parsers (watcher
+    // `process_watcher_lines`, bridge/recovery `process_stream_line`) read only
+    // a nested Claude-shaped `usage` object, so emitting tokens solely as the
+    // top-level fields above left watcher-owned codex turns with zero persisted
+    // telemetry and an idle recap of "context unknown". Re-emit the per-call
+    // occupancy via the receipt.rs subset convention (`input - cached` +
+    // `cache_read = cached`, so `context_occupancy_input_tokens()` reconstructs
+    // the original codex input). Sources, in order: the captured
+    // `token_count.info.last_token_usage`, then the terminal event's own
+    // per-turn `usage` (codex exec protocol). The session-cumulative
+    // `info.total_token_usage` is never used here, and with no usable source
+    // the nested object is omitted entirely (fail-safe: recap stays Unknown
+    // rather than fabricated). Top-level fields keep their legacy chain.
+    let call_usage = state
+        .last_token_usage
+        .or_else(|| json.get("usage").and_then(CodexCallTokenUsage::from_value));
+    if let Some(call) = call_usage.filter(|call| call.input_tokens > 0) {
+        result["usage"] = serde_json::json!({
+            "input_tokens": call.input_tokens.saturating_sub(call.cached_input_tokens),
+            "cache_read_input_tokens": call.cached_input_tokens,
+            "output_tokens": call.output_tokens,
+        });
+    }
+    emit_json_line(output, result)?;
     state.saw_turn_completed = true;
     Ok(())
+}
+
+/// #3275: record the per-call context occupancy from a `token_count` event.
+/// Only `info.last_token_usage` qualifies; the sibling `info.total_token_usage`
+/// is the session-cumulative count (8.3M in the issue report) and persisting it
+/// would render a wildly inflated context % in the idle recap. Absent payloads
+/// leave prior state untouched.
+fn capture_last_token_usage(payload: &serde_json::Value, state: &mut CodexWrapperTurnState) {
+    if let Some(usage) = payload
+        .get("info")
+        .and_then(|info| info.get("last_token_usage"))
+        .and_then(CodexCallTokenUsage::from_value)
+    {
+        state.last_token_usage = Some(usage);
+    }
 }
 
 /// Decide whether a turn is finalizing in a fail-open schema-drift state.
@@ -1288,6 +1353,203 @@ mod modern_event_tests {
         assert_eq!(lines[1]["result"], "legacy final");
         assert_eq!(lines[1]["input_tokens"], 10);
         assert_eq!(lines[1]["output_tokens"], 3);
+    }
+
+    // #3275: the result frame must carry a Claude-compatible nested `usage`
+    // built from the per-call `token_count.info.last_token_usage` (subset
+    // convention: input - cached / cache_read = cached), because the shared
+    // result-frame token parsers ignore the top-level fields. Top-level fields
+    // keep their legacy chain (no usage/info on task_complete → 0).
+    #[test]
+    fn token_count_last_usage_feeds_nested_result_usage() {
+        let tdir = tempfile::tempdir().unwrap();
+        let path = tdir.path().join("codex.jsonl");
+        let mut output = RotatingJsonlWriter::open(&path).unwrap();
+        let mut thread_id = Some("thread-tokens".to_string());
+        let mut state = CodexWrapperTurnState::default();
+        let start = std::time::Instant::now();
+
+        handle_codex_wrapper_event(
+            &mut output,
+            &json!({
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "last_token_usage": {
+                            "input_tokens": 1000,
+                            "cached_input_tokens": 600,
+                            "output_tokens": 50
+                        }
+                    }
+                }
+            }),
+            &mut thread_id,
+            &mut state,
+            start,
+        )
+        .unwrap();
+        handle_codex_wrapper_event(
+            &mut output,
+            &json!({
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_complete",
+                    "last_agent_message": "tokens final"
+                }
+            }),
+            &mut thread_id,
+            &mut state,
+            start,
+        )
+        .unwrap();
+
+        let lines = read_jsonl(&path);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0]["type"], "result");
+        assert_eq!(lines[0]["subtype"], "success");
+        assert_eq!(lines[0]["usage"]["input_tokens"], 400);
+        assert_eq!(lines[0]["usage"]["cache_read_input_tokens"], 600);
+        assert_eq!(lines[0]["usage"]["output_tokens"], 50);
+        assert_eq!(lines[0]["input_tokens"], 0);
+        assert_eq!(lines[0]["output_tokens"], 0);
+    }
+
+    // #3275: when the terminal event also carries the session-cumulative
+    // `info.total_token_usage` (8.3M in the issue), the nested usage must stay
+    // per-call (last_token_usage) so the persisted context % is not inflated,
+    // while the top-level fields keep the legacy total chain unchanged.
+    #[test]
+    fn nested_result_usage_prefers_last_token_usage_over_cumulative_total() {
+        let tdir = tempfile::tempdir().unwrap();
+        let path = tdir.path().join("codex.jsonl");
+        let mut output = RotatingJsonlWriter::open(&path).unwrap();
+        let mut thread_id = Some("thread-total".to_string());
+        let mut state = CodexWrapperTurnState::default();
+        let start = std::time::Instant::now();
+
+        handle_codex_wrapper_event(
+            &mut output,
+            &json!({
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "last_token_usage": {
+                            "input_tokens": 1000,
+                            "cached_input_tokens": 600,
+                            "output_tokens": 50
+                        },
+                        "total_token_usage": {
+                            "input_tokens": 8_325_687_u64,
+                            "cached_input_tokens": 8_000_000_u64,
+                            "output_tokens": 41_600
+                        }
+                    }
+                }
+            }),
+            &mut thread_id,
+            &mut state,
+            start,
+        )
+        .unwrap();
+        handle_codex_wrapper_event(
+            &mut output,
+            &json!({
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_complete",
+                    "last_agent_message": "total final",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 8_325_687_u64,
+                            "output_tokens": 41_600
+                        }
+                    }
+                }
+            }),
+            &mut thread_id,
+            &mut state,
+            start,
+        )
+        .unwrap();
+
+        let lines = read_jsonl(&path);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0]["type"], "result");
+        assert_eq!(lines[0]["usage"]["input_tokens"], 400);
+        assert_eq!(lines[0]["usage"]["cache_read_input_tokens"], 600);
+        assert_eq!(lines[0]["usage"]["output_tokens"], 50);
+        assert_eq!(lines[0]["input_tokens"], 8_325_687_u64);
+        assert_eq!(lines[0]["output_tokens"], 41_600);
+    }
+
+    // #3275: codex exec protocol — no token_count events, but `turn.completed`
+    // carries a per-turn usage object. It must map through the same subset
+    // convention while the top-level fields keep the legacy values.
+    #[test]
+    fn turn_completed_usage_maps_to_nested_result_usage() {
+        let tdir = tempfile::tempdir().unwrap();
+        let path = tdir.path().join("codex.jsonl");
+        let mut output = RotatingJsonlWriter::open(&path).unwrap();
+        let mut thread_id = Some("thread-exec".to_string());
+        let mut state = CodexWrapperTurnState::default();
+
+        handle_codex_wrapper_event(
+            &mut output,
+            &json!({
+                "type": "turn.completed",
+                "last_agent_message": "exec final",
+                "usage": {"input_tokens": 10, "cached_input_tokens": 4, "output_tokens": 3}
+            }),
+            &mut thread_id,
+            &mut state,
+            std::time::Instant::now(),
+        )
+        .unwrap();
+
+        let lines = read_jsonl(&path);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0]["type"], "result");
+        assert_eq!(lines[0]["usage"]["input_tokens"], 6);
+        assert_eq!(lines[0]["usage"]["cache_read_input_tokens"], 4);
+        assert_eq!(lines[0]["usage"]["output_tokens"], 3);
+        assert_eq!(lines[0]["input_tokens"], 10);
+        assert_eq!(lines[0]["output_tokens"], 3);
+    }
+
+    // #3275 fail-safe: with no token source at all the nested usage must be
+    // omitted (recap stays Unknown rather than fabricating values).
+    #[test]
+    fn result_omits_nested_usage_without_any_token_source() {
+        let tdir = tempfile::tempdir().unwrap();
+        let path = tdir.path().join("codex.jsonl");
+        let mut output = RotatingJsonlWriter::open(&path).unwrap();
+        let mut thread_id = Some("thread-none".to_string());
+        let mut state = CodexWrapperTurnState::default();
+
+        handle_codex_wrapper_event(
+            &mut output,
+            &json!({
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_complete",
+                    "last_agent_message": "no tokens final"
+                }
+            }),
+            &mut thread_id,
+            &mut state,
+            std::time::Instant::now(),
+        )
+        .unwrap();
+
+        let lines = read_jsonl(&path);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0]["type"], "result");
+        assert_eq!(lines[0]["subtype"], "success");
+        assert!(lines[0].get("usage").is_none());
+        assert_eq!(lines[0]["input_tokens"], 0);
+        assert_eq!(lines[0]["output_tokens"], 0);
     }
 
     #[test]

--- a/src/services/codex_tmux_wrapper.rs
+++ b/src/services/codex_tmux_wrapper.rs
@@ -566,8 +566,17 @@ struct CodexCallTokenUsage {
 
 impl CodexCallTokenUsage {
     fn from_value(value: &serde_json::Value) -> Option<Self> {
+        // Guard: at least one known token field must actually be present. An
+        // empty/unrelated object (e.g. a protocol variant sending
+        // `last_token_usage: {}`) parses to None so it cannot clobber a
+        // previously captured real usage with all zeros, and the result-frame
+        // `or_else` fallback chain keeps working.
+        const KNOWN_FIELDS: [&str; 3] = ["input_tokens", "cached_input_tokens", "output_tokens"];
+        if !KNOWN_FIELDS.iter().any(|key| value.get(key).is_some()) {
+            return None;
+        }
         let field = |key: &str| value.get(key).and_then(|v| v.as_u64()).unwrap_or(0);
-        value.is_object().then(|| Self {
+        Some(Self {
             input_tokens: field("input_tokens"),
             cached_input_tokens: field("cached_input_tokens"),
             output_tokens: field("output_tokens"),
@@ -1413,6 +1422,77 @@ mod modern_event_tests {
         assert_eq!(lines[0]["usage"]["output_tokens"], 50);
         assert_eq!(lines[0]["input_tokens"], 0);
         assert_eq!(lines[0]["output_tokens"], 0);
+    }
+
+    // #3275: a protocol variant sending `token_count` with an empty
+    // `info.last_token_usage: {}` must not clobber a previously captured real
+    // per-call usage with all zeros — the empty object parses to None, the
+    // earlier capture is preserved, and the nested result usage still emits.
+    #[test]
+    fn empty_last_token_usage_object_preserves_prior_capture() {
+        let tdir = tempfile::tempdir().unwrap();
+        let path = tdir.path().join("codex.jsonl");
+        let mut output = RotatingJsonlWriter::open(&path).unwrap();
+        let mut thread_id = Some("thread-empty-usage".to_string());
+        let mut state = CodexWrapperTurnState::default();
+        let start = std::time::Instant::now();
+
+        handle_codex_wrapper_event(
+            &mut output,
+            &json!({
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "last_token_usage": {
+                            "input_tokens": 1000,
+                            "cached_input_tokens": 600,
+                            "output_tokens": 50
+                        }
+                    }
+                }
+            }),
+            &mut thread_id,
+            &mut state,
+            start,
+        )
+        .unwrap();
+        handle_codex_wrapper_event(
+            &mut output,
+            &json!({
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": { "last_token_usage": {} }
+                }
+            }),
+            &mut thread_id,
+            &mut state,
+            start,
+        )
+        .unwrap();
+        handle_codex_wrapper_event(
+            &mut output,
+            &json!({
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_complete",
+                    "last_agent_message": "empty-variant final"
+                }
+            }),
+            &mut thread_id,
+            &mut state,
+            start,
+        )
+        .unwrap();
+
+        let lines = read_jsonl(&path);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0]["type"], "result");
+        assert_eq!(lines[0]["subtype"], "success");
+        assert_eq!(lines[0]["usage"]["input_tokens"], 400);
+        assert_eq!(lines[0]["usage"]["cache_read_input_tokens"], 600);
+        assert_eq!(lines[0]["usage"]["output_tokens"], 50);
     }
 
     // #3275: when the terminal event also carries the session-cumulative

--- a/src/services/discord/tmux_output_stream.rs
+++ b/src/services/discord/tmux_output_stream.rs
@@ -754,6 +754,46 @@ mod tests {
         assert!(full_response.is_empty());
     }
 
+    /// #3275 cross-module contract: the codex tmux wrapper emits its result
+    /// frame with tokens as top-level fields plus a Claude-compatible nested
+    /// `usage` (receipt.rs subset convention). This is the exact frame shape
+    /// `emit_success_result` produces; the watcher's result-usage fallback
+    /// must adopt it so `stream_line_state_token_usage` turns Some and
+    /// watcher-owned completion persists session/turn token telemetry
+    /// (idle recap context source) instead of falling to "context unknown".
+    #[test]
+    fn process_watcher_lines_adopts_codex_wrapper_result_usage() {
+        let mut buffer = concat!(
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"codex reply\"}]}}\n",
+            "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"codex reply\",\"session_id\":\"sess-cdx\",\"duration_ms\":12,\"input_tokens\":8325687,\"output_tokens\":41600,\"usage\":{\"input_tokens\":400,\"cache_read_input_tokens\":600,\"output_tokens\":50}}\n",
+        )
+        .to_string();
+        let mut state = StreamLineState::new();
+        let mut full_response = String::new();
+        let mut tool_state = WatcherToolState::new();
+
+        let outcome =
+            process_watcher_lines(&mut buffer, &mut state, &mut full_response, &mut tool_state);
+
+        assert!(outcome.found_result);
+        // Codex wrapper assistant frames never carry per-message usage, so the
+        // result-frame fallback must engage.
+        assert!(!state.saw_per_message_usage);
+        assert_eq!(state.accum_input_tokens, 400);
+        assert_eq!(state.accum_cache_read_tokens, 600);
+        assert_eq!(state.accum_cache_create_tokens, 0);
+        assert_eq!(state.accum_output_tokens, 50);
+        // Occupancy reconstruction: input + cache_read == the original codex
+        // last_token_usage.input_tokens — NOT the cumulative top-level 8.3M.
+        let usage = crate::db::turns::TurnTokenUsage {
+            input_tokens: state.accum_input_tokens,
+            cache_create_tokens: state.accum_cache_create_tokens,
+            cache_read_tokens: state.accum_cache_read_tokens,
+            output_tokens: state.accum_output_tokens,
+        };
+        assert_eq!(usage.context_occupancy_input_tokens(), 1000);
+    }
+
     #[test]
     fn process_watcher_lines_strips_tui_no_response_before_stop_hook_summary() {
         let mut buffer = concat!(

--- a/src/services/session_backend.rs
+++ b/src/services/session_backend.rs
@@ -1012,6 +1012,41 @@ mod stream_tail_guard_tests {
         ));
     }
 
+    /// #3275 cross-module contract: the codex tmux wrapper's result frame now
+    /// carries a Claude-compatible nested `usage` next to the legacy top-level
+    /// token fields. The result-usage fallback in `process_stream_line` must
+    /// adopt it so bridge analytics reparsing and recovery backfill
+    /// (`extract_turn_analytics_from_output_range`) return Some usage with the
+    /// per-call occupancy — not the cumulative top-level counters.
+    #[test]
+    fn extract_turn_analytics_adopts_codex_wrapper_result_usage() {
+        let dir = tempfile::tempdir().unwrap();
+        let output_path = dir.path().join("codex-wrapper.jsonl");
+        std::fs::write(
+            &output_path,
+            concat!(
+                "{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"sess-cdx\"}\n",
+                "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"codex reply\"}]}}\n",
+                "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"codex reply\",\"session_id\":\"sess-cdx\",\"duration_ms\":12,\"input_tokens\":8325687,\"output_tokens\":41600,\"usage\":{\"input_tokens\":400,\"cache_read_input_tokens\":600,\"output_tokens\":50}}\n",
+            ),
+        )
+        .unwrap();
+
+        let (session_id, usage) = super::extract_turn_analytics_from_output_range(
+            output_path.to_string_lossy().as_ref(),
+            0,
+            None,
+        );
+
+        assert_eq!(session_id.as_deref(), Some("sess-cdx"));
+        let usage = usage.expect("codex wrapper result usage must be recoverable");
+        assert_eq!(usage.input_tokens, 400);
+        assert_eq!(usage.cache_read_tokens, 600);
+        assert_eq!(usage.cache_create_tokens, 0);
+        assert_eq!(usage.output_tokens, 50);
+        assert_eq!(usage.context_occupancy_input_tokens(), 1000);
+    }
+
     #[test]
     fn process_stream_line_emits_workflow_status_events() {
         let (sender, receiver) = std::sync::mpsc::channel();


### PR DESCRIPTION
Issue #3275 (no auto-close; verify on live adk-cdx before closing).

## Root cause

The codex tmux wrapper emitted result-frame tokens only as top-level `input_tokens`/`output_tokens`, while both shared result-frame token parsers — the watcher's `process_watcher_lines` (`tmux_output_stream.rs`) and bridge analytics reparse / recovery backfill `process_stream_line` (`session_backend.rs`) — read only a nested Claude-shaped `usage` object (the `!saw_per_message_usage` Qwen fallback). With no `usage` object on codex frames the `StreamLineState` accumulators stayed zero, `stream_line_state_token_usage` returned `None`, and the existing watcher-owned persist plumbing (turns row + `sessions.tokens` via `upsert_hook_session_pg`) never fired → `select_recap_context` priorities 2 (latest turn) and 3 (fresh session tokens) were empty → `RecapContextDisplay::Unknown` ("📦 context unknown").

Secondary: the wrapper discarded the per-call `token_count.info.last_token_usage` and only had the session-cumulative `info.total_token_usage` (8.3M in the issue report) available, which would distort context % even if parsed.

## Fix (producer-side only)

`src/services/codex_tmux_wrapper.rs`:

- Capture `token_count.info.last_token_usage` (per-call context occupancy) into `CodexWrapperTurnState`; `info.total_token_usage` is never captured.
- `emit_success_result` now adds a Claude-compatible nested `usage` to the result frame using the proven `receipt.rs` subset convention: `input_tokens = input - cached`, `cache_read_input_tokens = cached`, so `TurnTokenUsage::context_occupancy_input_tokens()` reconstructs the original codex input. Source priority: ① captured `last_token_usage`, ② the terminal event's own per-turn `usage` (codex exec protocol).
- Top-level fields keep their legacy chain unchanged (backward compatible).

Existing parser fallbacks then light up the entire downstream chain (watcher session/turn persist, bridge reparse, recovery backfill, idle recap) with zero changes to shared code.

## Invariants

- Hot files untouched: `tmux_watcher.rs` and `turn_bridge/mod.rs` have zero changes (giant-file ratchet trivially satisfied).
- Other providers unaffected: only the codex producer changes; Claude sets `saw_per_message_usage=true` and never enters the result-frame fallback; Qwen's existing nested-usage path is unchanged. Grep gate over `get("usage")` readers confirmed only the two intended parser beneficiaries consume wrapper result frames.
- Cumulative counter never persisted: `info.total_token_usage` is never emitted as nested usage, so the recap cannot show a distorted "over limit" (8.3M / 272K).
- Fail-safe: with no token source at all, no nested usage is emitted — recap stays Unknown rather than fabricating values (no regression vs today).
- Idempotent persist: turns upsert keeps the `EXCLUDED > 0` guard, `sessions.tokens` only updates on `Some` — bridge/watcher double-fire converges on the same JSONL-derived values.

## Tests

- `codex_tmux_wrapper`: token_count → nested usage {400,600,50} with top-level legacy chain intact; last_token_usage preferred over cumulative total (top-level stays 8,325,687); exec-protocol `turn.completed.usage` mapping {6,4,3}; fail-safe omission with no token source. Existing top-level assertions (`old_item_completed_and_turn_completed_...`) unchanged and passing.
- `tmux_output_stream` (cross-module contract): the exact new frame shape feeds `process_watcher_lines` → accumulators adopt per-call usage, occupancy reconstructs 1000 (not the cumulative 8.3M).
- `session_backend` (cross-module contract): same frame through `extract_turn_analytics_from_output_range` returns `Some(usage)` (bridge reparse / recovery backfill path).
- Full `idle_recap` test suite passes (35/35); related sweep 68/68.

## Gates

- `cargo fmt --check` clean
- `cargo check --lib` 0 warnings
- `cargo test --lib` codex_tmux_wrapper / tmux_output_stream / session_backend / idle_recap: 68 passed
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py`: freshness check passed (codex_tmux_wrapper freeze entry synced 1215 → 1280 with #3275 rationale)
- `check_await_holding_lock_ratchet.py`: 34 tracked sites == baseline 34 (local run also counts other agents' stale `.claude/worktrees` copies; CI checkout sees 34)

Post-deploy E2E (separate step): complete one codex turn on adk-cdx, confirm `sessions.tokens > 0` via runtime API and recap header renders `📦 N / M tokens (x%)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)