### PR TITLE
fix(#3288): self-heal policies.dir config drift at deploy time

### DIFF
--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -1253,9 +1253,11 @@ rm -rf "$ADK_REL/policies.old"
 AGENTDESK_YAML="$ADK_REL/config/agentdesk.yaml"
 if [ -f "$AGENTDESK_YAML" ]; then
     POLICIES_DIR_MIGRATION=$(python3 - "$AGENTDESK_YAML" "$ADK_REL/policies" <<'PYEOF' 2>&1
+import os
 import re
 import shutil
 import sys
+import tempfile
 
 path, want = sys.argv[1], sys.argv[2]
 with open(path) as f:
@@ -1265,27 +1267,44 @@ out = []
 in_policies = False
 changed = False
 previous = None
+unsupported = None
 for line in lines:
     body = line.rstrip("\n")
-    if re.match(r"^policies:\s*(#.*)?$", body):
+    if re.match(r"^policies:\s*\{", body):
+        # Flow-style mapping (policies: {dir: ...}) — refuse to edit rather
+        # than risk a bad rewrite; surfaced as a WARN by the caller.
+        unsupported = "inline-map"
+        in_policies = False
+    elif re.match(r"^policies:\s*(#.*)?$", body):
         in_policies = True
     elif in_policies and body.strip() and not body[:1].isspace():
         in_policies = False
     if in_policies:
-        m = re.match(r"^(\s+dir:\s*)([\"']?)(.+?)\2\s*(#.*)?$", body)
+        m = re.match(r"^(\s+dir:\s*)([\"']?)(.+?)\2(\s*)(#.*)?$", body)
         if m:
             previous = m.group(3)
             if previous != want:
-                comment = f" {m.group(4)}" if m.group(4) else ""
-                line = f"{m.group(1)}{want}{comment}\n"
+                quote = m.group(2)
+                tail = f"{m.group(4)}{m.group(5)}" if m.group(5) else ""
+                line = f"{m.group(1)}{quote}{want}{quote}{tail}\n"
                 changed = True
     out.append(line)
 
 if changed:
     shutil.copy2(path, path + ".bak-policies-dir")
-    with open(path, "w") as f:
-        f.writelines(out)
-print(f"changed={changed} previous={previous}")
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path) or ".", prefix=".agentdesk.yaml.")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.writelines(out)
+        shutil.copymode(path, tmp)
+        os.replace(tmp, path)
+    except BaseException:
+        os.unlink(tmp)
+        raise
+if unsupported:
+    print(f"changed=unsupported style={unsupported} previous={previous}")
+else:
+    print(f"changed={changed} previous={previous}")
 PYEOF
 ) || POLICIES_DIR_MIGRATION="error: python exited $?"
     case "$POLICIES_DIR_MIGRATION" in

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -1245,6 +1245,64 @@ mv "$POLICIES_STAGED" "$ADK_REL/policies"
 POLICIES_STAGED=""
 rm -rf "$ADK_REL/policies.old"
 
+# #3288: self-heal policies.dir config drift. The release runtime must load
+# policies from the deployed snapshot ($ADK_REL/policies, staged above from the
+# deploy-time git shape) — never from a dev workspace working tree, whose
+# checked-out branch can silently diverge from the deployed binary. Runs while
+# dcserver is stopped, so the rewrite is picked up by the post-deploy start.
+AGENTDESK_YAML="$ADK_REL/config/agentdesk.yaml"
+if [ -f "$AGENTDESK_YAML" ]; then
+    POLICIES_DIR_MIGRATION=$(python3 - "$AGENTDESK_YAML" "$ADK_REL/policies" <<'PYEOF' 2>&1
+import re
+import shutil
+import sys
+
+path, want = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    lines = f.readlines()
+
+out = []
+in_policies = False
+changed = False
+previous = None
+for line in lines:
+    body = line.rstrip("\n")
+    if re.match(r"^policies:\s*(#.*)?$", body):
+        in_policies = True
+    elif in_policies and body.strip() and not body[:1].isspace():
+        in_policies = False
+    if in_policies:
+        m = re.match(r"^(\s+dir:\s*)([\"']?)(.+?)\2\s*(#.*)?$", body)
+        if m:
+            previous = m.group(3)
+            if previous != want:
+                comment = f" {m.group(4)}" if m.group(4) else ""
+                line = f"{m.group(1)}{want}{comment}\n"
+                changed = True
+    out.append(line)
+
+if changed:
+    shutil.copy2(path, path + ".bak-policies-dir")
+    with open(path, "w") as f:
+        f.writelines(out)
+print(f"changed={changed} previous={previous}")
+PYEOF
+) || POLICIES_DIR_MIGRATION="error: python exited $?"
+    case "$POLICIES_DIR_MIGRATION" in
+        changed=True*)
+            echo "▸ Migrated policies.dir → $ADK_REL/policies ($POLICIES_DIR_MIGRATION; backup: $AGENTDESK_YAML.bak-policies-dir) [#3288]"
+            ;;
+        changed=False*)
+            # Already aligned, or no explicit dir key (the binary's ./policies
+            # default resolves to $ADK_REL/policies under the launchd CWD).
+            ;;
+        *)
+            echo "⚠ policies.dir drift check failed (non-fatal): $POLICIES_DIR_MIGRATION"
+            echo "  Verify $AGENTDESK_YAML policies.dir points at $ADK_REL/policies [#3288]"
+            ;;
+    esac
+fi
+
 if [ -n "${ROUTINES_STAGED:-}" ] && [ -d "$ROUTINES_STAGED" ]; then
     rm -rf "$ADK_REL/routines.old"
     [ -d "$ADK_REL/routines" ] && mv "$ADK_REL/routines" "$ADK_REL/routines.old"

--- a/scripts/deploy-release.sh
+++ b/scripts/deploy-release.sh
@@ -1280,13 +1280,21 @@ for line in lines:
     elif in_policies and body.strip() and not body[:1].isspace():
         in_policies = False
     if in_policies:
-        m = re.match(r"^(\s+dir:\s*)([\"']?)(.+?)\2(\s*)(#.*)?$", body)
-        if m:
-            previous = m.group(3)
+        # A '#' starts a comment only after whitespace (YAML); an unquoted
+        # value may itself contain '#'. Bare/comment-only dir is healed too.
+        empty = re.match(r"^(\s+dir:)((?:\s+#.*)|\s*)$", body)
+        value = None if empty else re.match(r"^(\s+dir:\s*)([\"']?)(.+?)\2(\s+#.*)?\s*$", body)
+        if empty:
+            previous = ""
+            comment = empty.group(2) if "#" in empty.group(2) else ""
+            line = f"{empty.group(1)} {want}{comment}\n"
+            changed = True
+        elif value:
+            previous = value.group(3)
             if previous != want:
-                quote = m.group(2)
-                tail = f"{m.group(4)}{m.group(5)}" if m.group(5) else ""
-                line = f"{m.group(1)}{quote}{want}{quote}{tail}\n"
+                quote = value.group(2)
+                tail = value.group(4) or ""
+                line = f"{value.group(1)}{quote}{want}{quote}{tail}\n"
                 changed = True
     out.append(line)
 


### PR DESCRIPTION
## Problem (#3288)

dcserver loads JS policies from `config.policies.dir` at startup. The live release config had drifted to point at the **dev workspace working tree** (`workspaces/agentdesk/policies`), so whatever branch that checkout happened to be on determined live policy behavior — observed today when the #3285 policy fix was merged to main but the live server kept running the stale branch's policy until a manual workspace switch + restart.

Repo-side defaults are already coherent: the Rust default `./policies` resolves to `$ADK_REL/policies` under the launchd CWD, `install.sh` installs policies there, and `deploy-release.sh` atomically swaps a fresh snapshot there on every deploy. The drift was purely in the operator yaml — and nothing detected or healed it.

## Fix

After the policies snapshot swap (dcserver stopped window), `deploy-release.sh` now checks `config/agentdesk.yaml` and rewrites a drifted `policies.dir` to `$ADK_REL/policies`:
- idempotent (`changed=False` when aligned or key absent)
- scoped to the `policies:` block — `dir:` keys in other blocks untouched
- backs up the yaml to `*.bak-policies-dir` before rewriting
- non-fatal on parse failure (WARN + remediation hint; deploy continues)

## Verification

- `bash -n` clean
- python migration logic tested standalone against a copy of the live (drifted) yaml: rewrite ✓, backup ✓, idempotent re-run ✓, other-block `dir:` untouched ✓, sibling keys (`hot_reload` etc.) preserved ✓
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` → freshness check passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)