### PR TITLE
fix(#3281): truthful claude TUI producer-exit lines + zero-harvest visibility

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -921,7 +921,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
 - `src/services/dispatches/outbox_route.rs` (1089) — dispatch outbox route
   support extracted from the route layer; split before adding non-bugfix
   behavior.
-- `src/services/claude.rs` (3739), `src/services/gemini.rs` (1358),
+- `src/services/claude.rs` (3847), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3001),
   `src/services/opencode.rs` (1881), `src/services/provider.rs` (1796) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
@@ -930,7 +930,10 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   context-window fallback (now cache-first for both `Some(model)` and the
   provider-default `None` path — constant only on absent/unusable cache),
   documented per-provider context-window intent, and a
-  `codex_context_window_from_cache` unit-test module.)
+  `codex_context_window_from_cache` unit-test module. #3281 truthified the
+  Claude TUI producer-exit `lines=` count via `ReadHarvestStats` and added
+  `claude_tui_zero_harvest_*` observability events for delivered turns that
+  forwarded nothing.)
 - `src/services/codex_tui/rollout_tail.rs` (1639) — Codex TUI rollout tail
   parsing and resume identity surface; split before adding non-bugfix behavior
   beyond the #2169 session identity fix.

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -20,11 +20,11 @@ use crate::services::provider::{
 use crate::services::provider_hosting::ProviderSessionDriver;
 use crate::services::remote::RemoteProfile;
 use crate::services::session_backend::{
-    StreamLineState, emit_status_events_from_stream_json, insert_process_session,
+    ReadHarvestStats, StreamLineState, emit_status_events_from_stream_json, insert_process_session,
     observe_stream_context, parse_assistant_extra_tool_uses, parse_stream_message_with_state,
     process_session_is_alive, process_session_pid, process_session_probe,
-    read_output_file_until_result, remove_process_session, send_process_session_input,
-    terminate_process_handle,
+    read_output_file_until_result, read_output_file_until_result_with_harvest,
+    remove_process_session, send_process_session_input, terminate_process_handle,
 };
 #[cfg(unix)]
 use crate::services::tmux_diagnostics::{
@@ -1392,6 +1392,61 @@ fn classify_followup_result(
     }
 }
 
+/// Stable string tag for producer-exit / zero-harvest observability (#3281).
+#[cfg(unix)]
+fn read_output_result_kind(read_result: &ReadOutputResult) -> &'static str {
+    match read_result {
+        ReadOutputResult::Completed { .. } => "completed",
+        ReadOutputResult::SessionDied { .. } => "session_died",
+        ReadOutputResult::Cancelled { .. } => "cancelled",
+    }
+}
+
+/// #3281: a DELIVERED TUI turn that `Completed` without forwarding a single
+/// parsed `StreamMessage` harvested nothing from its transcript window — the
+/// turn's response text never entered the bridge. `Cancelled` is excluded:
+/// `classify_followup_result` maps it to `Delivered` too, and a cancelled turn
+/// legitimately forwards nothing.
+#[cfg(unix)]
+fn tui_delivered_zero_harvest(read_result: &ReadOutputResult, harvest: &ReadHarvestStats) -> bool {
+    matches!(read_result, ReadOutputResult::Completed { .. }) && harvest.forwarded_messages == 0
+}
+
+/// #3281 health signal: one observability event per zero-harvest delivered TUI
+/// turn, so the residual loss window (e.g. a fallback start offset pointing
+/// past the response bytes) is measured in production instead of inferred.
+#[cfg(unix)]
+fn emit_claude_tui_zero_harvest(
+    kind: &str,
+    report_channel_id: Option<u64>,
+    tmux_session_name: &str,
+    transcript_path: &str,
+    start_offset: u64,
+    transcript_len: u64,
+) {
+    tracing::warn!(
+        tmux_session_name,
+        transcript_path,
+        start_offset,
+        transcript_len,
+        "claude_tui delivered turn harvested ZERO stream messages — the turn's response text never entered the bridge ({kind})"
+    );
+    crate::services::observability::emit_inflight_lifecycle_event(
+        "claude",
+        report_channel_id.unwrap_or(0),
+        None,
+        None,
+        None,
+        kind,
+        serde_json::json!({
+            "tmux_session_name": tmux_session_name,
+            "transcript_path": transcript_path,
+            "start_offset": start_offset,
+            "transcript_len": transcript_len,
+        }),
+    );
+}
+
 fn emit_followup_restart_suppressed_notice(sender: &Sender<StreamMessage>, notice: &str) {
     let _ = sender.send(StreamMessage::Text {
         content: format!("\n\n{}", notice),
@@ -2182,7 +2237,7 @@ fn run_claude_tui_fresh_turn_and_finalize(
         resolved_session_id,
         prompt,
     );
-    let read_result = match fresh_turn_result {
+    let (read_result, harvest, turn_read_start_offset) = match fresh_turn_result {
         Ok(result) => result,
         Err(error) => {
             crate::services::termination_audit::record_termination_for_tmux(
@@ -2231,14 +2286,32 @@ fn run_claude_tui_fresh_turn_and_finalize(
         tmux_session_name,
         transcript_path,
     );
+    let transcript_len = std::fs::metadata(transcript_path)
+        .map(|meta| meta.len())
+        .unwrap_or(0);
+    if tui_delivered_zero_harvest(&read_result, &harvest) {
+        emit_claude_tui_zero_harvest(
+            "claude_tui_zero_harvest_turn_delivered",
+            report_channel_id,
+            tmux_session_name,
+            transcript_path_string,
+            turn_read_start_offset,
+            transcript_len,
+        );
+    }
     log_producer_exit(
         "tui_turn_delivered",
         Some(resolved_session_id),
         report_channel_id,
-        0,
+        // #3281: real forwarded-message count (was a hardcoded 0).
+        usize::try_from(harvest.forwarded_messages).unwrap_or(usize::MAX),
         serde_json::json!({
             "tmux_session_name": tmux_session_name,
             "transcript_path": transcript_path_string,
+            "assistant_text_bytes": harvest.assistant_text_bytes,
+            "start_offset": turn_read_start_offset,
+            "transcript_len": transcript_len,
+            "read_result_kind": read_output_result_kind(&read_result),
         }),
     );
     Ok(())
@@ -2646,7 +2719,7 @@ fn try_claude_tui_warm_followup(
             turn_started_at,
             fallback_start_offset,
         );
-        let read_result = match read_claude_tui_transcript_until_done(
+        let (read_result, harvest) = match read_claude_tui_transcript_until_done(
             &transcript_path_string,
             start_offset,
             sender.clone(),
@@ -2661,6 +2734,12 @@ fn try_claude_tui_warm_followup(
                 return ClaudeTuiWarmFollowupOutcome::Terminal(Err(error));
             }
         };
+        // #3281: capture BEFORE `classify_followup_result` consumes the read
+        // result. The zero-harvest gate is `Completed`-only: classify maps
+        // `Cancelled` to `Delivered` too, and a cancelled turn legitimately
+        // forwards nothing.
+        let read_result_kind = read_output_result_kind(&read_result);
+        let delivered_zero_harvest = tui_delivered_zero_harvest(&read_result, &harvest);
         let zero_advance_terminal_result = match &read_result {
             ReadOutputResult::Completed { offset } | ReadOutputResult::Cancelled { offset } => {
                 *offset <= start_offset
@@ -2693,14 +2772,32 @@ fn try_claude_tui_warm_followup(
                     tmux_session_name,
                     &transcript_path,
                 );
+                let transcript_len = std::fs::metadata(&transcript_path)
+                    .map(|meta| meta.len())
+                    .unwrap_or(0);
+                if delivered_zero_harvest {
+                    emit_claude_tui_zero_harvest(
+                        "claude_tui_zero_harvest_warm_followup_delivered",
+                        report_channel_id,
+                        tmux_session_name,
+                        &transcript_path_string,
+                        start_offset,
+                        transcript_len,
+                    );
+                }
                 log_producer_exit(
                     "tui_warm_followup_delivered",
                     Some(&resolved_session_id),
                     report_channel_id,
-                    0,
+                    // #3281: real forwarded-message count (was a hardcoded 0).
+                    usize::try_from(harvest.forwarded_messages).unwrap_or(usize::MAX),
                     serde_json::json!({
                         "tmux_session_name": tmux_session_name,
                         "transcript_path": transcript_path_string,
+                        "assistant_text_bytes": harvest.assistant_text_bytes,
+                        "start_offset": start_offset,
+                        "transcript_len": transcript_len,
+                        "read_result_kind": read_result_kind,
                     }),
                 );
                 return ClaudeTuiWarmFollowupOutcome::Terminal(Ok(()));
@@ -2875,6 +2972,9 @@ fn prepare_and_create_claude_tui_session(
     Ok(owner_path)
 }
 
+/// On success returns the read result, the harvest counters, and the actual
+/// turn-read start offset (the timestamp-scan adjusted offset, #3281) so the
+/// producer-exit log can report real values instead of a hardcoded `lines=0`.
 #[cfg(unix)]
 fn run_claude_tui_fresh_turn_with_ready_retry(
     transcript_path_string: &str,
@@ -2884,7 +2984,7 @@ fn run_claude_tui_fresh_turn_with_ready_retry(
     tmux_session_name: &str,
     resolved_session_id: &str,
     prompt: &str,
-) -> Result<ReadOutputResult, String> {
+) -> Result<(ReadOutputResult, ReadHarvestStats, u64), String> {
     for attempt in 1..=CLAUDE_TUI_FRESH_PROMPT_MAX_READY_ATTEMPTS {
         let hook_rx = crate::services::claude_tui::hook_server::subscribe_hook_events();
         let turn_started_at = chrono::Utc::now();
@@ -2909,7 +3009,8 @@ fn run_claude_tui_fresh_turn_with_ready_retry(
                     resolved_session_id,
                     hook_rx,
                     hook_events_after,
-                );
+                )
+                .map(|(read_result, harvest)| (read_result, harvest, start_offset));
             }
             Err(error) if should_retry_claude_tui_fresh_prompt_ready(&error, attempt) => {
                 let backoff = claude_tui_fresh_prompt_ready_backoff(attempt);
@@ -3000,7 +3101,7 @@ fn read_claude_tui_transcript_until_done(
     session_id: &str,
     hook_rx: tokio::sync::broadcast::Receiver<crate::services::claude_tui::hook_server::HookEvent>,
     hook_events_after: chrono::DateTime<chrono::Utc>,
-) -> Result<ReadOutputResult, String> {
+) -> Result<(ReadOutputResult, ReadHarvestStats), String> {
     let stop_seen = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let stop_seen_for_probe = stop_seen.clone();
     let hook_rx = std::sync::Arc::new(std::sync::Mutex::new(hook_rx));
@@ -3028,10 +3129,17 @@ fn read_claude_tui_transcript_until_done(
         cancel_token.as_deref(),
         tmux_session_name,
     )? {
-        return Ok(early_result);
+        // No transcript read happened — nothing was harvested (#3281).
+        return Ok((early_result, ReadHarvestStats::default()));
     }
-    let result =
-        read_output_file_until_result(transcript_path, start_offset, sender, cancel_token, probe);
+    let result = read_output_file_until_result_with_harvest(
+        transcript_path,
+        start_offset,
+        sender,
+        cancel_token,
+        probe,
+    )
+    .map_err(|failure| failure.error);
     log_claude_tui_hook_relay_failures(&expected_session_id_for_result);
     result
 }
@@ -3204,6 +3312,35 @@ mod claude_tui_ready_probe_tests {
             || true
         ));
         assert!(!stop_seen.load(Ordering::Relaxed));
+    }
+
+    /// #3281 truth table: zero-harvest fires ONLY for a `Completed` read that
+    /// forwarded nothing. Any forwarded message or a non-`Completed` read
+    /// (`Cancelled` is also classified `Delivered` by
+    /// `classify_followup_result`) must NOT fire.
+    #[test]
+    fn tui_delivered_zero_harvest_truth_table() {
+        let zero = ReadHarvestStats::default();
+        let harvested = ReadHarvestStats {
+            forwarded_messages: 3,
+            assistant_text_bytes: 42,
+        };
+        assert!(tui_delivered_zero_harvest(
+            &ReadOutputResult::Completed { offset: 100 },
+            &zero,
+        ));
+        assert!(!tui_delivered_zero_harvest(
+            &ReadOutputResult::Completed { offset: 100 },
+            &harvested,
+        ));
+        assert!(!tui_delivered_zero_harvest(
+            &ReadOutputResult::Cancelled { offset: 100 },
+            &zero,
+        ));
+        assert!(!tui_delivered_zero_harvest(
+            &ReadOutputResult::SessionDied { offset: 100 },
+            &zero,
+        ));
     }
 
     #[test]

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -7029,39 +7029,33 @@ pub(super) fn spawn_turn_bridge(
                 && !recovery_retry,
             bridge_relay_delegated_to_watcher,
         );
-        if bridge_output_owner.is_none()
-            && !cancelled
-            && !is_prompt_too_long
-            && !transport_error
-            && !recovery_retry
-            && current_msg_id.get() != 0
-            && response_portion_after_offset(&full_response, response_sent_offset)
+        // #3281: empty-terminal-response visibility (owner-`None` kind/payload
+        // preserved verbatim; adds the delegated-watcher quadrant) — see
+        // `watcher_handoff::emit_bridge_empty_terminal_response_visibility`.
+        watcher_handoff::emit_bridge_empty_terminal_response_visibility(
+            shared_owned.as_ref(),
+            watcher_owner_channel_id,
+            bridge_output_owner,
+            terminal_error_path,
+            &provider,
+            channel_id,
+            dispatch_id.as_deref(),
+            adk_session_key.as_deref(),
+            turn_id.as_str(),
+            current_msg_id.get(),
+            response_portion_after_offset(&full_response, response_sent_offset)
                 .trim()
-                .is_empty()
-        {
-            crate::services::observability::emit_inflight_lifecycle_event(
-                provider.as_str(),
-                channel_id.get(),
-                dispatch_id.as_deref(),
-                adk_session_key.as_deref(),
-                Some(turn_id.as_str()),
-                "bridge_output_owner_none_empty_response",
-                serde_json::json!({
-                    "current_msg_id": current_msg_id.get(),
-                    "watcher_owns_assistant_relay": watcher_owns_assistant_relay,
-                    "watcher_relay_available_for_turn": watcher_relay_available_for_turn,
-                    "live_watcher_registered": live_watcher_registered_for_relay(
-                        shared_owned.as_ref(),
-                        watcher_owner_channel_id,
-                    ),
-                    "standby_relay_owns_output": standby_relay_owns_output,
-                    "rx_disconnected": rx_disconnected,
-                    "tmux_handed_off": tmux_handed_off,
-                    "response_sent_offset": response_sent_offset,
-                    "full_response_len": full_response.len(),
-                }),
-            );
-        }
+                .is_empty(),
+            watcher_owns_assistant_relay,
+            watcher_relay_available_for_turn,
+            standby_relay_owns_output,
+            rx_disconnected,
+            tmux_handed_off,
+            response_sent_offset,
+            full_response.len(),
+            tmux_last_offset,
+            inflight_state.turn_start_offset,
+        );
 
         // Explicitly complete implementation/rework dispatches only after the
         // terminal Discord delivery commits. Completing here used to let

--- a/src/services/discord/turn_bridge/watcher_handoff.rs
+++ b/src/services/discord/turn_bridge/watcher_handoff.rs
@@ -124,6 +124,104 @@ pub(super) fn busy_turn_already_proven_delivered(
         && tmux_last_offset.is_some_and(|last| last > turn_start_offset)
 }
 
+/// #3281: which empty-terminal-response visibility event (if any) applies to
+/// this finalize. Pure so the gating is unit-testable. `None` owner keeps the
+/// pre-#3281 `bridge_output_owner_none_empty_response` semantics verbatim;
+/// `Some(WatcherRelay)` adds the delegated quadrant ("the watcher must carry
+/// the whole body from its resume offset") so a watcher parked past the
+/// response bytes (#3277-shape loss) is measurable. Terminal-error paths, a
+/// missing placeholder message, and a non-empty unsent response never emit.
+pub(super) fn empty_terminal_response_visibility_kind(
+    bridge_output_owner: Option<BridgeOutputOwner>,
+    terminal_error_path: bool,
+    current_msg_id: u64,
+    response_unsent_empty: bool,
+) -> Option<&'static str> {
+    if terminal_error_path || current_msg_id == 0 || !response_unsent_empty {
+        return None;
+    }
+    match bridge_output_owner {
+        None => Some("bridge_output_owner_none_empty_response"),
+        Some(BridgeOutputOwner::WatcherRelay) => Some("bridge_delegated_watcher_empty_response"),
+        Some(BridgeOutputOwner::StandbyRelay) => None,
+    }
+}
+
+/// #3281: emit the empty-terminal-response visibility event chosen by
+/// [`empty_terminal_response_visibility_kind`]. Moved out of
+/// `turn_bridge/mod.rs` (frozen giant baseline); the owner-`None` kind and
+/// payload are byte-identical to the inline block this replaced, and the
+/// delegated-watcher kind additionally carries `tmux_last_offset` /
+/// `turn_start_offset` for offset forensics. Observability only — never
+/// posts to Discord or alters relay ownership.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn emit_bridge_empty_terminal_response_visibility(
+    shared: &SharedData,
+    watcher_owner_channel_id: ChannelId,
+    bridge_output_owner: Option<BridgeOutputOwner>,
+    terminal_error_path: bool,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    dispatch_id: Option<&str>,
+    session_key: Option<&str>,
+    turn_id: &str,
+    current_msg_id: u64,
+    response_unsent_empty: bool,
+    watcher_owns_assistant_relay: bool,
+    watcher_relay_available_for_turn: bool,
+    standby_relay_owns_output: bool,
+    rx_disconnected: bool,
+    tmux_handed_off: bool,
+    response_sent_offset: usize,
+    full_response_len: usize,
+    tmux_last_offset: Option<u64>,
+    turn_start_offset: Option<u64>,
+) {
+    let Some(kind) = empty_terminal_response_visibility_kind(
+        bridge_output_owner,
+        terminal_error_path,
+        current_msg_id,
+        response_unsent_empty,
+    ) else {
+        return;
+    };
+    let mut extra = serde_json::json!({
+        "current_msg_id": current_msg_id,
+        "watcher_owns_assistant_relay": watcher_owns_assistant_relay,
+        "watcher_relay_available_for_turn": watcher_relay_available_for_turn,
+        "live_watcher_registered": live_watcher_registered_for_relay(
+            shared,
+            watcher_owner_channel_id,
+        ),
+        "standby_relay_owns_output": standby_relay_owns_output,
+        "rx_disconnected": rx_disconnected,
+        "tmux_handed_off": tmux_handed_off,
+        "response_sent_offset": response_sent_offset,
+        "full_response_len": full_response_len,
+    });
+    if kind == "bridge_delegated_watcher_empty_response"
+        && let Some(map) = extra.as_object_mut()
+    {
+        map.insert(
+            "tmux_last_offset".to_string(),
+            serde_json::json!(tmux_last_offset),
+        );
+        map.insert(
+            "turn_start_offset".to_string(),
+            serde_json::json!(turn_start_offset),
+        );
+    }
+    crate::services::observability::emit_inflight_lifecycle_event(
+        provider.as_str(),
+        channel_id.get(),
+        dispatch_id,
+        session_key,
+        Some(turn_id),
+        kind,
+        extra,
+    );
+}
+
 /// #3268 (Defect B): the self-healing watcher handoff itself. When the gate
 /// fires, registers the watcher in the single-authority finalizer ledger,
 /// unpauses it at the bridge's confirmed offset with `turn_delivered = false`,
@@ -290,5 +388,63 @@ mod tests {
             Some(100),
             17_737,
         ));
+        // #3281 cold-start variant: /clear cold-start intake records
+        // turn_start_offset = 0 (the transcript did not exist yet), so a Done
+        // terminator with ANY advanced relay offset is proven — the #3268
+        // handoff stays suppressed, `bridge_output_owner` stays `None`, and
+        // the bridge delivers `full_response` directly.
+        assert!(busy_turn_already_proven_delivered(
+            CompletionSignal::Done,
+            Some(37_154),
+            0,
+        ));
+    }
+
+    /// #3281 truth table for the empty-terminal-response visibility gate:
+    /// owner `None` keeps the pre-#3281 kind verbatim, delegated-watcher gets
+    /// its own kind, and terminal errors / missing placeholder / non-empty
+    /// unsent response / standby owner never emit.
+    #[test]
+    fn empty_terminal_response_visibility_kind_truth_table() {
+        // Owner None + empty unsent response → original kind (verbatim).
+        assert_eq!(
+            empty_terminal_response_visibility_kind(None, false, 42, true),
+            Some("bridge_output_owner_none_empty_response"),
+        );
+        // Delegated to the watcher + empty unsent response → new quadrant kind.
+        assert_eq!(
+            empty_terminal_response_visibility_kind(
+                Some(BridgeOutputOwner::WatcherRelay),
+                false,
+                42,
+                true,
+            ),
+            Some("bridge_delegated_watcher_empty_response"),
+        );
+        // Non-empty unsent response → the bridge still owns deliverable bytes.
+        assert_eq!(
+            empty_terminal_response_visibility_kind(None, false, 42, false),
+            None,
+        );
+        // Terminal-error path → excluded (matches the pre-#3281 gate).
+        assert_eq!(
+            empty_terminal_response_visibility_kind(None, true, 42, true),
+            None,
+        );
+        // No placeholder message id → excluded (matches the pre-#3281 gate).
+        assert_eq!(
+            empty_terminal_response_visibility_kind(None, false, 0, true),
+            None,
+        );
+        // Standby relay owns output → not part of this visibility surface.
+        assert_eq!(
+            empty_terminal_response_visibility_kind(
+                Some(BridgeOutputOwner::StandbyRelay),
+                false,
+                42,
+                true,
+            ),
+            None,
+        );
     }
 }

--- a/src/services/session_backend.rs
+++ b/src/services/session_backend.rs
@@ -284,6 +284,10 @@ pub struct StreamLineState {
     pub stdout_error: Option<(String, String)>,
     pub tool_use_names: HashMap<String, String>,
     pub task_starts: HashMap<String, TaskStartInfo>,
+    /// #3281 observability-only harvest counters (never gate delivery); see
+    /// [`ReadHarvestStats`] for the counting rules.
+    pub forwarded_message_count: u64,
+    pub forwarded_assistant_text_bytes: u64,
 }
 
 impl StreamLineState {
@@ -486,14 +490,24 @@ pub fn process_stream_line(
         _ => {}
     }
 
+    // #3281: harvest accounting, observation-only (counted on successful send).
+    // `StatusUpdate` (turn_duration housekeeping) is metadata, not content.
+    let (harvested, text_bytes) = match &message {
+        StreamMessage::Text { content } => (1, content.len() as u64),
+        StreamMessage::StatusUpdate { .. } => (0, 0),
+        _ => (1, 0),
+    };
     if sender.send(message).is_err() {
         return false;
     }
+    state.forwarded_message_count += harvested;
+    state.forwarded_assistant_text_bytes += text_bytes;
 
     for extra in parse_assistant_extra_tool_uses(&json) {
         if sender.send(extra).is_err() {
             return false;
         }
+        state.forwarded_message_count += 1;
     }
 
     true
@@ -878,6 +892,16 @@ pub fn parse_assistant_extra_tool_uses(json: &Value) -> Vec<StreamMessage> {
     extras
 }
 
+/// #3281 observability-only summary of what one transcript read forwarded to
+/// the bridge (status-only telemetry and synthetic idle-timeout `Done`s are
+/// NOT counted): `forwarded_messages == 0` on a `Completed` read means a
+/// zero-harvest transcript window.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ReadHarvestStats {
+    pub forwarded_messages: u64,
+    pub assistant_text_bytes: u64,
+}
+
 pub fn read_output_file_until_result(
     output_path: &str,
     start_offset: u64,
@@ -896,6 +920,25 @@ pub fn read_output_file_until_result_tracked(
     cancel_token: Option<Arc<CancelToken>>,
     probe: SessionProbe,
 ) -> Result<ReadOutputResult, ReadOutputFailure> {
+    read_output_file_until_result_with_harvest(
+        output_path,
+        start_offset,
+        sender,
+        cancel_token,
+        probe,
+    )
+    .map(|(result, _stats)| result)
+}
+
+/// #3281: full reader that also returns the harvest counters (truthful TUI
+/// producer-exit `lines=` logging).
+pub fn read_output_file_until_result_with_harvest(
+    output_path: &str,
+    start_offset: u64,
+    sender: Sender<StreamMessage>,
+    cancel_token: Option<Arc<CancelToken>>,
+    probe: SessionProbe,
+) -> Result<(ReadOutputResult, ReadHarvestStats), ReadOutputFailure> {
     let mut state = StreamLineState::new();
     let SessionProbe {
         is_alive,
@@ -941,8 +984,12 @@ pub fn read_output_file_until_result_tracked(
         },
     );
 
+    let stats = ReadHarvestStats {
+        forwarded_messages: state.forwarded_message_count,
+        assistant_text_bytes: state.forwarded_assistant_text_bytes,
+    };
     match result {
-        Ok(result) => Ok(result),
+        Ok(result) => Ok((result, stats)),
         Err(error) => Err(ReadOutputFailure {
             error,
             last_offset: last_offset.load(Ordering::Relaxed),
@@ -1045,6 +1092,167 @@ mod stream_tail_guard_tests {
         assert_eq!(usage.cache_create_tokens, 0);
         assert_eq!(usage.output_tokens, 50);
         assert_eq!(usage.context_occupancy_input_tokens(), 1000);
+    }
+
+    /// #3281 forensics pinned as code: the 2026-06-10 incident transcript shape
+    /// (user → attachment → assistant thinking → assistant text → attachment
+    /// hook record → `system{stop_hook_summary}` → trailing housekeeping). The
+    /// producer MUST harvest the assistant text and the `Done` terminator via
+    /// the `has_final` fast path — i.e. in the incident scenario the producer
+    /// forwarded the response to the bridge; the loss was downstream.
+    #[test]
+    fn incident_shape_transcript_harvests_text_and_done() {
+        let dir = tempfile::tempdir().unwrap();
+        let output_path = dir.path().join("incident.jsonl");
+        std::fs::write(
+            &output_path,
+            concat!(
+                r#"{"type":"user","timestamp":"2026-06-10T01:34:29.797Z","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#,
+                "\n",
+                r#"{"type":"attachment","attachment":{"kind":"queued-prompt"}}"#,
+                "\n",
+                r#"{"type":"assistant","timestamp":"2026-06-10T01:34:35.000Z","message":{"content":[{"type":"thinking","thinking":"considering"}]}}"#,
+                "\n",
+                r#"{"type":"assistant","timestamp":"2026-06-10T01:34:39.943Z","message":{"model":"claude-x","content":[{"type":"text","text":"Hello! How can I help you today?"}],"usage":{"input_tokens":10,"output_tokens":9}}}"#,
+                "\n",
+                r#"{"type":"attachment","attachment":{"kind":"hook_success"}}"#,
+                "\n",
+                r#"{"type":"system","subtype":"stop_hook_summary","timestamp":"2026-06-10T01:34:40.095Z","session_id":"297e6f2f-test"}"#,
+                "\n",
+                r#"{"type":"system","subtype":"turn_duration","durationMs":10298}"#,
+                "\n",
+                r#"{"type":"last-prompt","prompt":"hi"}"#,
+                "\n",
+                r#"{"type":"ai-title","title":"greeting"}"#,
+                "\n",
+                r#"{"type":"mode","mode":"default"}"#,
+                "\n",
+                r#"{"type":"permission-mode","mode":"default"}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+
+        let (sender, receiver) = mpsc::channel();
+        let (result, stats) = read_output_file_until_result_with_harvest(
+            output_path.to_string_lossy().as_ref(),
+            0,
+            sender,
+            None,
+            SessionProbe::process(|| true),
+        )
+        .unwrap();
+
+        assert!(
+            matches!(result, ReadOutputResult::Completed { .. }),
+            "stop_hook_summary must complete the read via has_final: {result:?}"
+        );
+        assert!(
+            stats.forwarded_messages > 0,
+            "incident-shape turn must forward harvested messages: {stats:?}"
+        );
+        assert!(
+            stats.assistant_text_bytes > 0,
+            "incident-shape turn must harvest assistant text bytes: {stats:?}"
+        );
+        let messages: Vec<_> = receiver.try_iter().collect();
+        let text_index = messages.iter().position(|message| {
+            matches!(message, StreamMessage::Text { content } if content == "Hello! How can I help you today?")
+        });
+        let done_index = messages
+            .iter()
+            .position(|message| matches!(message, StreamMessage::Done { .. }));
+        let (Some(text_index), Some(done_index)) = (text_index, done_index) else {
+            panic!("expected Text then Done, got: {messages:?}");
+        };
+        assert!(
+            text_index < done_index,
+            "response text must reach the bridge BEFORE the Done terminator: {messages:?}"
+        );
+    }
+
+    /// #3281: a tool_use-only turn forwards messages but zero assistant text
+    /// bytes — the zero-harvest health gate must therefore key on
+    /// `forwarded_messages`, not on `assistant_text_bytes`.
+    #[test]
+    fn tool_use_only_turn_forwards_messages_without_text_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let output_path = dir.path().join("tool-only.jsonl");
+        std::fs::write(
+            &output_path,
+            concat!(
+                r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tu-1","name":"Bash","input":{"command":"ls"}}]}}"#,
+                "\n",
+                r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu-1","content":"ok"}]}}"#,
+                "\n",
+                r#"{"type":"result","subtype":"success","result":"","session_id":"sess-tool"}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+
+        let (sender, _receiver) = mpsc::channel();
+        let (result, stats) = read_output_file_until_result_with_harvest(
+            output_path.to_string_lossy().as_ref(),
+            0,
+            sender,
+            None,
+            SessionProbe::process(|| true),
+        )
+        .unwrap();
+
+        assert!(matches!(result, ReadOutputResult::Completed { .. }));
+        assert!(
+            stats.forwarded_messages > 0,
+            "tool_use-only turn still forwards messages: {stats:?}"
+        );
+        assert_eq!(
+            stats.assistant_text_bytes, 0,
+            "tool_use-only turn has no assistant text bytes: {stats:?}"
+        );
+    }
+
+    /// #3281 zero side: a transcript window containing ONLY housekeeping lines
+    /// (queued-prompt attachment / last-prompt / ai-title / mode records /
+    /// `turn_duration` telemetry) harvests nothing — the counters stay 0 even
+    /// though `turn_duration` still reaches the bridge as a `StatusUpdate`.
+    /// This is the substrate of the `Completed`-only zero-harvest gate: such a
+    /// read can only complete via the synthetic idle-timeout `Done` (also
+    /// uncounted), and the producer-exit log must then report `lines=0` as a
+    /// REAL measurement.
+    #[test]
+    fn housekeeping_only_window_harvests_nothing() {
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let mut state = StreamLineState::new();
+        for line in [
+            r#"{"type":"attachment","attachment":{"kind":"queued-prompt"}}"#,
+            r#"{"type":"last-prompt","prompt":"hi"}"#,
+            r#"{"type":"ai-title","title":"greeting"}"#,
+            r#"{"type":"mode","mode":"default"}"#,
+            r#"{"type":"permission-mode","mode":"default"}"#,
+            r#"{"type":"system","subtype":"turn_duration","durationMs":10298}"#,
+        ] {
+            assert!(process_stream_line(line, &sender, &mut state));
+        }
+        assert_eq!(
+            state.forwarded_message_count, 0,
+            "housekeeping-only window must count zero harvested messages"
+        );
+        assert_eq!(
+            state.forwarded_assistant_text_bytes, 0,
+            "housekeeping-only window must harvest zero assistant text bytes"
+        );
+        let forwarded: Vec<_> = receiver.try_iter().collect();
+        assert!(
+            forwarded
+                .iter()
+                .all(|message| matches!(message, StreamMessage::StatusUpdate { .. })),
+            "only status telemetry may reach the bridge from housekeeping lines: {forwarded:?}"
+        );
+        assert!(
+            !forwarded.is_empty(),
+            "turn_duration must still reach the bridge as StatusUpdate telemetry"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 문제 (#3281)

`tui_turn_delivered` 소비 시 `lines=0` — 이 값은 측정값이 아니라 `log_producer_exit(…, 0, …)`의 **하드코딩된 상수**였다 (warm 경로 동일). 사고(2026-06-10 01:34) 트랜스크립트 포렌식 결과 producer는 실제로 응답(assistant text @32847 + `stop_hook_summary` Done @35061, `has_final` 고속 경로)을 수확해 bridge에 전달했고, 실제 유실 지점은 #3279 이전의 bridge quiescence-timeout handoff였다(미전송 응답 보유 확인 없이 WatcherRelay 승격 → watcher는 transcript EOF에서 resume). 따라서 이 이슈는 이슈 본문이 명시한 최소 옵션인 **가시화 중심 최소 수정**으로 처리한다 — transcript 백필은 Done 이후 Text 송신이 bridge terminal-drain과 경합해 기각.

## 변경

- **session_backend**: `StreamLineState`에 관측 전용 harvest 카운터(`forwarded_message_count` / `forwarded_assistant_text_bytes`) 추가, `read_output_file_until_result_with_harvest` 신설. 기존 reader 시그니처·동작 불변. `StatusUpdate`(`turn_duration` 등 housekeeping)와 synthetic idle-timeout Done은 비계수 — **status-only 윈도우(잔존 zero-harvest 시그니처)가 lines=0으로 보이도록**.
- **claude**: `tui_turn_delivered` / `tui_warm_followup_delivered` exit가 실제 forwarded 수를 로깅하고 extra에 `assistant_text_bytes` / `start_offset` / `transcript_len` / `read_result_kind` 포함. `Completed && forwarded_messages==0`이면 `claude_tui_zero_harvest_turn_delivered` / `claude_tui_zero_harvest_warm_followup_delivered` inflight-lifecycle 이벤트 1회 발행 (Cancelled 제외 — `classify_followup_result`가 Cancelled→Delivered 매핑).
- **turn_bridge/mod.rs**: empty-terminal-response 가시화 블록을 `watcher_handoff::emit_bridge_empty_terminal_response_visibility`로 이동 — prod LoC **8368→8362 순감** (frozen baseline 8417 준수). owner=None kind/payload는 기존과 동일(byte-identical), `bridge_delegated_watcher_empty_response` 사분면 추가 (payload에 `tmux_last_offset` / `turn_start_offset` — watcher가 어느 offset부터 본문 전체를 운반해야 하는지 포렌식 마커).
- **watcher_handoff**: cold-start 변형 진리표 — `busy_turn_already_proven_delivered(Done, Some(37154), 0) == true` 고정. /clear cold-start(`turn_start_offset=0`)에서 #3268 handoff 억제 → `bridge_output_owner=None` 유지 → bridge가 full_response 직접 전달이라는 #3279 보장을 테스트로 못박음.

## 비변경 (안전성)

- Discord 전달·dedupe 경로(relay watermark `confirmed_end_offset`, delivery lease, `tui_prompt_dedupe` 바인딩, posted-marker) 일체 무변경 — 새로 Discord에 포스트하는 코드 없음(중복 전달 표면 0).
- harvest 카운터는 관측 전용 — 분기·전송 로직에 관여하지 않음.
- `tmux_watcher.rs` / `tui_prompt_relay.rs` 미접촉.

## 검증

- `cargo fmt --check` / `cargo check --lib` 0 warnings
- 신규 테스트 (전부 통과): 사고 형태 transcript 재현(Text→Done 순서+harvest>0 — '사고 시 producer는 수확했다' 포렌식 결론을 코드로 고정), tool_use-only 턴(text bytes 0), housekeeping-only 윈도우(zero-harvest), `tui_delivered_zero_harvest` 진리표, visibility kind 진리표(None/WatcherRelay/StandbyRelay/terminal-error/no-placeholder/non-empty), cold-start proven-delivered 변형
- `giant_file_ratchet` / `giant_files` / agent-maintenance freshness / `await_holding_lock`(34) 게이트 전부 통과 — session_backend.rs prod 999(<1000), change-surfaces freeze 동기(claude.rs 3847)
- 전체 `cargo test --lib`: 모듈 테스트(session_backend/claude/turn_bridge) 전부 통과. 잔여 실패(turn_orchestrator persistence 등 12~13개)는 **clean main(d835670c5) 동일 그룹 실행에서도 재현되는 사전 존재 환경 플레이크** — 본 변경과 무관 (워크트리 베이스라인으로 검증).

## 후속

- `claude_tui_zero_harvest_*` 이벤트 발생 빈도가 0이 아니면, transcript 백필이 아닌 watcher resume-offset 보정(턴 시작 offset부터 relay, watermark/lease dedupe 정합 포함)을 별도 이슈로 설계.
- 수동 E2E(/clear cold-start 1턴, lines>0 확인)는 배포 후 agentdesk-relay-e2e 절차로 확인 권장.

관련: #3277 (사고), #3279 (finalize/handoff 수정), #3281 (본 이슈 — 자동 닫기 미사용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)