### PR TITLE
fix(#3293): recovery relay retry budget + unrecoverable-row cleanup + mailbox registry purge

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -437,6 +437,7 @@ src/
 │   │   │   └── section_dedupe.rs
 │   │   ├── recovery_paths/
 │   │   │   ├── mod.rs
+│   │   │   ├── restart.rs
 │   │   │   └── shared.rs
 │   │   ├── router/
 │   │   │   ├── message_handler/
@@ -650,6 +651,8 @@ src/
 │   │   └── store.rs
 │   ├── slo/
 │   │   └── mod.rs
+│   ├── turn_orchestrator/
+│   │   └── registry_purge.rs
 │   ├── agent_protocol.rs
 │   ├── analytics.rs
 │   ├── auto_queue.rs

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -404,6 +404,8 @@ src/
 │   │   │   ├── send_target.rs
 │   │   │   ├── session_enrichment.rs
 │   │   │   └── snapshot.rs
+│   │   ├── inflight/
+│   │   │   └── budget.rs
 │   │   ├── outbound/
 │   │   │   ├── confirmation.rs
 │   │   │   ├── decision.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1009,7 +1009,10 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   lifting cluster C — the three queued-placeholder fields + their nine inherent
   methods — into `shared_state::QueuedPlaceholderState`, leaving a single
   `queued: QueuedPlaceholderState` group field on `SharedData` and re-exporting
-  the type for surface freeze),
+  the type for surface freeze; ±0 from #3293 — the +13 closed-retry rewires
+  (`mailbox_peek` + `*_with_closed_retry` routing for recovery kickoff and
+  intervention enqueue) are offset by queue-exit comment dedup in the same
+  root, no baseline raise),
   `src/services/discord_config_audit.rs` (1273).
 - `src/services/turn_orchestrator.rs` (3089; +3 from #3293 declaring the
   `registry_purge` child module — the non-creating `peek` lookup and the

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -628,7 +628,12 @@
     `mailbox_finish_turn`; +60 from #3248 gap-1 adding
     `reseed_watcher_owned_finalizer_ledger` + two guarded reattach call-sites that
     re-register the watcher-owned turn in the post-restart finalizer ledger so a
-    mid-turn deploy's live pane auto-reconciles without a new user turn).
+    mid-turn deploy's live pane auto-reconciles without a new user turn; net ±0
+    from #3293 promoting the recovery terminal relay from `bool` to the 3-state
+    `RecoveryRelayOutcome` — the five notice branches route through
+    `recovery_paths/restart.rs::dispose_recovery_relay_outcome` (permanent
+    Discord 404/403/410 force-clear + 3-restart transient budget); the pure
+    decision matrix lives in `recovery_paths/shared.rs`).
   - `src/services/discord/health.rs` (402 prod lines after the #3038 Phase A
     directory decomposition; module root keeps the `HealthRegistry` core +
     re-export surface, and the former monolith body lives in six flat
@@ -638,11 +643,14 @@
     the #3034 dead-code sweep, 2292 after #3038 send-to-agent dispatch
     extraction to `outbound/send_to_agent.rs`, #1879 snapshot/mailbox
     extraction, and #3082 answer-flush-barrier field).
-  - `src/services/discord/health/recovery.rs` (2645 lines; health recovery
+  - `src/services/discord/health/recovery.rs` (2641 lines; health recovery
     extraction surface, split further before adding non-bugfix behavior; +70
     from #3126 stall-watchdog completed-idle false-positive guard tests; +88
     from #3169 stall-watchdog jsonl-mtime liveness guard + tests, closing the
-    Death #1 force-clean false-positive on loop mid-write sessions).
+    Death #1 force-clean false-positive on loop mid-write sessions; -4 from
+    #3293 routing the mailbox probe through the non-creating
+    `health/mailbox.rs::peeked_provider_mailbox_state` so repair probes stop
+    minting permanent registry entries for non-existent channels).
   - `src/services/discord/router/message_handler/intake_turn.rs` (3771 lines;
     Discord message intake turn orchestration split from the router message
     handler; bugfix only outside a further extraction plan; +9 from #3082
@@ -800,7 +808,9 @@
     relocated the `require_explicit_bearer_token` /
     `resolve_requesting_agent_id_with_pg` auth/identity helpers to
     `crate::services::kanban`).
-  - `src/server/routes/docs.rs` (5880 lines).
+  - `src/server/routes/docs.rs` (5884 lines; +4 from #3293 documenting
+    the stale-mailbox repair `purge` body param + registry-purge response
+    fields).
   - `src/server/routes/escalation.rs` (1376 lines).
   - `src/server/routes/meetings.rs` (1675 lines).
   - `src/server/routes/review_verdict/decision_route.rs` was decomposed in
@@ -1001,7 +1011,10 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   `queued: QueuedPlaceholderState` group field on `SharedData` and re-exporting
   the type for surface freeze),
   `src/services/discord_config_audit.rs` (1273).
-- `src/services/turn_orchestrator.rs` (3086).
+- `src/services/turn_orchestrator.rs` (3089; +3 from #3293 declaring the
+  `registry_purge` child module — the non-creating `peek` lookup and the
+  operator-gated `remove_idle_entry` purge live in
+  `turn_orchestrator/registry_purge.rs`, outside the frozen module root).
 
 Decomposed below the giant-file threshold (no longer frozen; bugfix-scoped but
 normal test growth is allowed): `src/services/analytics.rs`,

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -34,6 +34,10 @@
 # #3038 S1: lowered 5188 -> 4987 (-201) as `QueuedPlaceholderState` (cluster C:
 # 3 fields + 9 inherent methods) moved to the `shared_state` sibling module.
 # Locks in the shrink win (ratchet down only).
+# #3293: the +13 closed-retry rewires (`mailbox_peek` + routing the recovery
+# kickoff / intervention enqueue through `*_with_closed_retry`) are offset by
+# queue-exit comment dedup in the same root, so the frozen baseline stays at
+# 4987 (no raise; #3028 ratchet).
 "src/services/discord/mod.rs" = 4987
 "src/services/discord/tui_prompt_relay.rs" = 5438
 # #3038: lowered 4728 -> 4657 (-71) as `SensitivityState` (definition + impl)

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -56,7 +56,11 @@
 # #3293: +3 for the `registry_purge` child-module declaration (peek +
 # operator-gated idle-entry purge live outside the frozen root); lowered
 # 3090 -> 3089 to lock the net position.
-"src/services/turn_orchestrator.rs" = 3089
+# #3297 r2 (codex TOCTOU fix): +15 for the actor-root pieces of the purge
+# `CloseIfIdle` tombstone (msg variant + state flag + dispatch arm +
+# `TryStartTurn` guard) — the enum/state/loop can only live in the root;
+# the verdict logic + handle wrapper stay in `registry_purge.rs`.
+"src/services/turn_orchestrator.rs" = 3104
 # #3034 batch-8: +1 for a test-only `#[allow(dead_code)]` on
 # `thread_guard_inflight_is_stale` (#1446 Layer-2 classifier, pinned by tests).
 # #3038 S1: +2 (2958 -> 2960) for the two mechanical `.queued_placeholders` ->

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -56,11 +56,12 @@
 # #3293: +3 for the `registry_purge` child-module declaration (peek +
 # operator-gated idle-entry purge live outside the frozen root); lowered
 # 3090 -> 3089 to lock the net position.
-# #3297 r2 (codex TOCTOU fix): +15 for the actor-root pieces of the purge
+# #3297 r2 (codex TOCTOU fix): the +15 actor-root pieces of the purge
 # `CloseIfIdle` tombstone (msg variant + state flag + dispatch arm +
-# `TryStartTurn` guard) — the enum/state/loop can only live in the root;
-# the verdict logic + handle wrapper stay in `registry_purge.rs`.
-"src/services/turn_orchestrator.rs" = 3104
+# `TryStartTurn` guard — the enum/state/loop can only live in the root)
+# are offset by #2374 actor-arm comment dedup in the same root, so the
+# frozen baseline stays at 3089 (no raise; #3028 ratchet).
+"src/services/turn_orchestrator.rs" = 3089
 # #3034 batch-8: +1 for a test-only `#[allow(dead_code)]` on
 # `thread_guard_inflight_is_stale` (#1446 Layer-2 classifier, pinned by tests).
 # #3038 S1: +2 (2958 -> 2960) for the two mechanical `.queued_placeholders` ->

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -53,7 +53,10 @@
 # by lifting cluster C into `QueuedPlaceholderState`. Net program-wide: mod.rs -201.
 "src/services/discord/router/message_handler/intake_turn.rs" = 3771
 "src/services/discord/meeting_orchestrator.rs" = 3227
-"src/services/turn_orchestrator.rs" = 3090
+# #3293: +3 for the `registry_purge` child-module declaration (peek +
+# operator-gated idle-entry purge live outside the frozen root); lowered
+# 3090 -> 3089 to lock the net position.
+"src/services/turn_orchestrator.rs" = 3089
 # #3034 batch-8: +1 for a test-only `#[allow(dead_code)]` on
 # `thread_guard_inflight_is_stale` (#1446 Layer-2 classifier, pinned by tests).
 # #3038 S1: +2 (2958 -> 2960) for the two mechanical `.queued_placeholders` ->
@@ -68,8 +71,13 @@
 # `run_bot_spawn_recovery_and_flush_restart_reports`. Net program-wide: mod.rs -201.
 "src/services/discord/runtime_bootstrap.rs" = 2802
 # #3034 batch-8: lowered 2655 -> 2645 (dead-code removal: `stop_provider_channel_runtime`).
-"src/services/discord/health/recovery.rs" = 2645
-"src/services/discord/inflight.rs" = 2466
+# #3293: lowered 2645 -> 2641 (mailbox probe routed through the non-creating
+# `health/mailbox.rs::peeked_provider_mailbox_state`).
+"src/services/discord/health/recovery.rs" = 2641
+# #3293: +11 for the additive `recovery_relay_attempts` restart-budget counter
+# (field + `RECOVERY_RELAY_RESTART_ATTEMPT_BUDGET`), lowered 2466 -> 2465 to
+# lock the net position.
+"src/services/discord/inflight.rs" = 2465
 # #3038 Phase A: health.rs decomposed into health/ directory modules (root 402
 # prod LoC + 6 sub-1000-LoC submodules) — dropped below the giant threshold, so
 # its ratchet entry is deleted (win; no baseline raises).

--- a/src/server/routes/docs.rs
+++ b/src/server/routes/docs.rs
@@ -1174,10 +1174,14 @@ fn all_endpoints() -> Vec<EndpointDoc> {
                 "expected_has_cancel_token",
                 body_param("boolean", false, "Optional guard for the observed mailbox token state"),
             ),
+            (
+                "purge",
+                body_param("boolean", false, "Default false. After a fully applied repair, also unlink the channel's idle in-memory mailbox registry entry (no disk/DB mutation; refused while live work evidence exists)"),
+            ),
         ])
         .with_example(
-            json!({"body": {"channel_id": "1486017489027469493", "provider": "claude", "expected_has_cancel_token": true}}),
-            json!({"ok": true, "applied": true}),
+            json!({"body": {"channel_id": "1486017489027469493", "provider": "claude", "expected_has_cancel_token": true, "purge": true}}),
+            json!({"ok": true, "applied": true, "registry_entry_removed": true, "registry_purge_skipped_reason": null}),
         )
         .with_error_example(
             403,

--- a/src/server/routes/health_api.rs
+++ b/src/server/routes/health_api.rs
@@ -51,6 +51,11 @@ struct StaleMailboxRepairRequest {
     #[serde(default)]
     provider: Option<String>,
     expected_has_cancel_token: Option<bool>,
+    /// #3293 (c): when true AND the repair fully applied, also unlink the
+    /// channel's idle in-memory mailbox registry entry (no disk/DB mutation).
+    /// `#[serde(default)]` keeps existing clients compatible.
+    #[serde(default)]
+    purge: bool,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -535,6 +540,30 @@ fn stale_mailbox_repair_applied(
     session_disconnected_count: usize,
 ) -> bool {
     removed_token || inflight_cleared || session_disconnected_count > 0
+}
+
+/// #3293 (c): whether the optional mailbox-registry purge may run after a
+/// stale-mailbox repair, and the skip reason to report when it may not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RegistryPurgeDecision {
+    /// `purge` was not requested — report nothing.
+    NotRequested,
+    /// Repair fully applied (no residual inflight/session/token evidence) —
+    /// the idle-entry purge may run.
+    Run,
+    /// Purge requested but the repair did not fully apply — refuse.
+    Skip(&'static str),
+}
+
+fn registry_purge_decision(purge_requested: bool, repair_status: &str) -> RegistryPurgeDecision {
+    if !purge_requested {
+        return RegistryPurgeDecision::NotRequested;
+    }
+    if repair_status == "applied" {
+        RegistryPurgeDecision::Run
+    } else {
+        RegistryPurgeDecision::Skip("repair_not_fully_applied")
+    }
 }
 
 async fn load_config_audit_report_pg(pg_pool: Option<&PgPool>) -> Option<serde_json::Value> {
@@ -1211,6 +1240,26 @@ pub async fn stale_mailbox_repair_handler(
         } else {
             "applied"
         };
+    // #3293 (c): optional registry purge — only after the full gate chain
+    // above passed AND the repair fully applied. `remove_idle_entry` re-checks
+    // actor idleness right before the in-memory unlink.
+    let (registry_entry_removed, registry_purge_skipped_reason) =
+        match registry_purge_decision(request.purge, status) {
+            RegistryPurgeDecision::NotRequested => (false, None),
+            RegistryPurgeDecision::Skip(reason) => (false, Some(reason)),
+            RegistryPurgeDecision::Run => match state.health_registry.as_deref() {
+                Some(registry) => {
+                    let purge = health::purge_idle_channel_mailbox_registry_entry(
+                        registry,
+                        provider_filter.as_ref().map(ProviderKind::as_str),
+                        request.channel_id,
+                    )
+                    .await;
+                    (purge.removed, purge.skipped_reason)
+                }
+                None => (false, Some("registry_unavailable")),
+            },
+        };
     (
         StatusCode::OK,
         Json(serde_json::json!({
@@ -1230,6 +1279,8 @@ pub async fn stale_mailbox_repair_handler(
             "pre_repair_session": before_session_state,
             "post_repair_session": after_session_state,
             "delivery_completed": false,
+            "registry_entry_removed": registry_entry_removed,
+            "registry_purge_skipped_reason": registry_purge_skipped_reason,
             "post_repair_mailbox": after,
             "post_repair_watcher_inflight": after_watcher_inflight
         })),
@@ -1459,7 +1510,8 @@ pub async fn senddm_handler(
 #[cfg(test)]
 mod tests {
     use super::{
-        discord_control_endpoints_allowed, public_health_json, stale_mailbox_repair_applied,
+        RegistryPurgeDecision, discord_control_endpoints_allowed, public_health_json,
+        registry_purge_decision, stale_mailbox_repair_applied,
     };
     use axum::{
         body::Body,
@@ -1668,6 +1720,29 @@ mod tests {
         assert!(stale_mailbox_repair_applied(true, false, 0));
         assert!(stale_mailbox_repair_applied(false, true, 0));
         assert!(!stale_mailbox_repair_applied(false, false, 0));
+    }
+
+    /// #3293 (c): the registry purge runs ONLY when explicitly requested AND
+    /// the repair fully applied; a partial repair reports the skip reason that
+    /// surfaces as `registry_purge_skipped_reason` in the response.
+    #[test]
+    fn registry_purge_decision_gates_on_request_and_fully_applied_repair() {
+        assert_eq!(
+            registry_purge_decision(false, "applied"),
+            RegistryPurgeDecision::NotRequested
+        );
+        assert_eq!(
+            registry_purge_decision(false, "partial_repair"),
+            RegistryPurgeDecision::NotRequested
+        );
+        assert_eq!(
+            registry_purge_decision(true, "applied"),
+            RegistryPurgeDecision::Run
+        );
+        assert_eq!(
+            registry_purge_decision(true, "partial_repair"),
+            RegistryPurgeDecision::Skip("repair_not_fully_applied")
+        );
     }
 
     /// `fully_recovered` is the startup/recovery completion signal. Runtime

--- a/src/services/discord/health.rs
+++ b/src/services/discord/health.rs
@@ -40,6 +40,7 @@ pub use headless_turn::{
     start_headless_agent_turn, start_headless_agent_turn_in_dm, start_reserved_headless_agent_turn,
     start_reserved_headless_agent_turn_in_dm,
 };
+pub use mailbox::purge_idle_channel_mailbox_registry_entry;
 pub(crate) use manual_delivery::ManualOutboundDeliveryId;
 pub(crate) use recovery::stop_provider_channel_runtime_with_policy;
 #[allow(unused_imports)]
@@ -250,6 +251,18 @@ impl HealthRegistry {
             .await
             .iter()
             .filter(|entry| entry.name.eq_ignore_ascii_case(provider.as_str()))
+            .map(|entry| entry.shared.clone())
+            .collect()
+    }
+
+    /// #3293: every registered runtime regardless of provider. Used by the
+    /// provider-unfiltered mailbox-registry purge, which must visit every
+    /// instance registry because a bogus entry may live in any of them.
+    pub(in crate::services::discord) async fn all_registered_shared(&self) -> Vec<Arc<SharedData>> {
+        self.providers
+            .lock()
+            .await
+            .iter()
             .map(|entry| entry.shared.clone())
             .collect()
     }

--- a/src/services/discord/health/mailbox.rs
+++ b/src/services/discord/health/mailbox.rs
@@ -1,6 +1,14 @@
 use serde::Serialize;
 
+use poise::serenity_prelude::ChannelId;
+
+use crate::services::discord::SharedData;
 use crate::services::discord::relay_health::{RelayHealthSnapshot, RelayStallState};
+use crate::services::provider::ProviderKind;
+use crate::services::turn_orchestrator::registry_purge::MailboxPurgeOutcome;
+
+use super::HealthRegistry;
+use super::recovery::ProviderMailboxState;
 
 #[derive(Debug, Serialize)]
 pub(super) struct MailboxHealthSnapshot {
@@ -19,4 +27,85 @@ pub(super) struct MailboxHealthSnapshot {
     pub(super) active_dispatch_present: bool,
     pub(super) relay_stall_state: RelayStallState,
     pub(super) relay_health: RelayHealthSnapshot,
+}
+
+/// #3293 (c): probe a channel's mailbox state WITHOUT creating a registry
+/// entry. `shared.mailbox()` (the pre-#3293 probe path) mints a permanent
+/// mailbox actor for every channel id it is asked about, so health/repair
+/// before+after probes against a non-existent channel id polluted the
+/// registry forever. No entry simply reports the idle/empty state.
+pub(super) async fn peeked_provider_mailbox_state(
+    shared: &SharedData,
+    channel_id: u64,
+) -> ProviderMailboxState {
+    let Some(handle) = shared.mailbox_peek(ChannelId::new(channel_id)) else {
+        return ProviderMailboxState {
+            channel_id,
+            has_cancel_token: false,
+            queue_depth: 0,
+            recovery_started: false,
+        };
+    };
+    let snapshot = handle.snapshot().await;
+    ProviderMailboxState {
+        channel_id,
+        has_cancel_token: snapshot.cancel_token.is_some(),
+        queue_depth: snapshot.intervention_queue.len(),
+        recovery_started: snapshot.recovery_started_at.is_some(),
+    }
+}
+
+/// Result of [`purge_idle_channel_mailbox_registry_entry`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MailboxRegistryPurgeResult {
+    /// At least one runtime's registry entry was unlinked.
+    pub removed: bool,
+    /// Why nothing (or not everything) was removed; `None` on full success.
+    pub skipped_reason: Option<&'static str>,
+}
+
+/// #3293 (c): operator-gated purge of a channel's idle mailbox registry
+/// entry. Called by the stale-mailbox repair endpoint AFTER its full gate
+/// chain (CAS `expected_has_cancel_token` + `no_live_work_evidence`) passed
+/// and the repair reported `applied`. Visits every registered runtime for
+/// the provider filter (or all runtimes when unfiltered) because the bogus
+/// entry may live in any instance registry; each removal re-verifies actor
+/// idleness right before the unlink. In-memory only — no disk/DB mutation.
+pub async fn purge_idle_channel_mailbox_registry_entry(
+    registry: &HealthRegistry,
+    provider_name: Option<&str>,
+    channel_id: u64,
+) -> MailboxRegistryPurgeResult {
+    let runtimes = match provider_name {
+        Some(name) => match ProviderKind::from_str(name) {
+            Some(provider) => registry.all_shared_for_provider(&provider).await,
+            None => Vec::new(),
+        },
+        None => registry.all_registered_shared().await,
+    };
+    if runtimes.is_empty() {
+        return MailboxRegistryPurgeResult {
+            removed: false,
+            skipped_reason: Some("no_registered_runtime"),
+        };
+    }
+    let channel = ChannelId::new(channel_id);
+    let mut removed = false;
+    let mut refused: Option<&'static str> = None;
+    for shared in runtimes {
+        match shared.mailboxes.remove_idle_entry(channel).await {
+            MailboxPurgeOutcome::Removed => removed = true,
+            MailboxPurgeOutcome::NoEntry => {}
+            MailboxPurgeOutcome::RefusedLiveWork(reason) => refused = Some(reason),
+        }
+    }
+    let skipped_reason = refused.or(if removed {
+        None
+    } else {
+        Some("no_registry_entry")
+    });
+    MailboxRegistryPurgeResult {
+        removed,
+        skipped_reason,
+    }
 }

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -699,13 +699,9 @@ pub async fn provider_channel_mailbox_state(
     let provider = ProviderKind::from_str(provider_name)?;
     let channel = ChannelId::new(channel_id);
     let shared = shared_for_provider(registry, &provider, channel).await?;
-    let snapshot = shared.mailbox(channel).snapshot().await;
-    Some(ProviderMailboxState {
-        channel_id,
-        has_cancel_token: snapshot.cancel_token.is_some(),
-        queue_depth: snapshot.intervention_queue.len(),
-        recovery_started: snapshot.recovery_started_at.is_some(),
-    })
+    // #3293 (c): peek, never create — the previous `shared.mailbox()` probe
+    // minted a permanent registry entry for every queried channel id.
+    Some(super::mailbox::peeked_provider_mailbox_state(&shared, channel_id).await)
 }
 
 pub async fn stop_runtime_turn_preserving_watcher(

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -1,10 +1,11 @@
 //! Inflight turn state persistence.
 //!
-//! `response_sent_offset`, `current_msg_id`, and
-//! `last_watcher_relayed_offset` participate in the relay state contract
-//! documented in `docs/relay-state-contract.md` (#1222 / #1224).
-//! Any change that touches relay producers/consumers must keep the
-//! invariants enumerated there satisfied.
+//! `response_sent_offset`, `current_msg_id`, and `last_watcher_relayed_offset`
+//! participate in the relay state contract documented in
+//! `docs/relay-state-contract.md` (#1222 / #1224). Any change that touches
+//! relay producers/consumers must keep the invariants there satisfied.
+
+pub(in crate::services::discord) mod budget;
 
 use std::collections::HashMap;
 use std::fs;
@@ -20,13 +21,12 @@ use crate::services::agent_protocol::{RuntimeHandoffKind, TaskNotificationKind};
 use crate::services::provider::ProviderKind;
 
 // #2235 (follow-up to #2213): bump v7→v8. v7 added `runtime_kind` without a
-// version change, so rolling back from new→old binaries could read rows whose
-// FIFO synthesis was elided for ClaudeTui and reject recovery with a misleading
-// "input fifo path missing" notice. v8 marks the on-disk shape that ships the
-// compat-fixed `input_fifo_path` alongside ClaudeTui plus the silent-skip
-// recovery branch; old binaries continue to deserialize v8 rows via
-// `#[serde(default)]` and treat the new `runtime_kind` as legacy, so the
-// compat window is one release in each direction.
+// version change, so new→old rollbacks could read rows whose FIFO synthesis
+// was elided for ClaudeTui and reject recovery with a misleading "input fifo
+// path missing" notice. v8 marks the shape shipping the compat-fixed
+// `input_fifo_path` alongside ClaudeTui plus the silent-skip recovery branch;
+// old binaries deserialize v8 rows via `#[serde(default)]` (compat window:
+// one release each direction).
 const INFLIGHT_STATE_VERSION: u32 = 8;
 const INFLIGHT_MAX_AGE_SECS: u64 = 300; // 5 minutes
 const DRAIN_RESTART_MAX_AGE_SECS: u64 = 1800; // 30 minutes

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -31,6 +31,10 @@ const INFLIGHT_STATE_VERSION: u32 = 8;
 const INFLIGHT_MAX_AGE_SECS: u64 = 300; // 5 minutes
 const DRAIN_RESTART_MAX_AGE_SECS: u64 = 1800; // 30 minutes
 const HOT_SWAP_HANDOFF_MAX_AGE_SECS: u64 = 900; // 15 minutes
+/// #3293: restarts-with-failed-terminal-relay budget. `recovery_relay_attempts`
+/// grows at most once per boot (recovery runs once per boot), so this is a
+/// "3 consecutive restarts" budget, not a per-process retry cap.
+pub(super) const RECOVERY_RELAY_RESTART_ATTEMPT_BUDGET: u32 = 3;
 
 /// #1446 stall-deadlock recovery: an inflight state is treated as "stale"
 /// (i.e. the dispatch that wrote it almost certainly already terminated
@@ -164,6 +168,11 @@ pub(super) struct InflightTurnState {
     /// Restart generation at which this turn was born.
     #[serde(default)]
     pub born_generation: u64,
+    /// #3293: count of restarts whose recovery terminal relay failed
+    /// transiently for this row. Additive `#[serde(default)]` field —
+    /// no `INFLIGHT_STATE_VERSION` bump per the #2235 compat convention.
+    #[serde(default)]
+    pub recovery_relay_attempts: u32,
     /// Whether any tool_use was seen during this turn (persisted for restart recovery).
     #[serde(default)]
     pub any_tool_used: bool,
@@ -577,6 +586,7 @@ impl InflightTurnState {
             started_at: now.clone(),
             updated_at: now,
             born_generation: super::runtime_store::load_generation(),
+            recovery_relay_attempts: 0,
             any_tool_used: false,
             has_post_tool_text: false,
             session_key: None,
@@ -4424,8 +4434,9 @@ mod stall_recovery_tests {
 
     /// Process-wide mutex so the two halves of the alive/dead override
     /// regression do not race against each other when cargo test runs them
-    /// in parallel (the override is global state).
-    fn stale_override_test_mutex() -> &'static std::sync::Mutex<()> {
+    /// in parallel (the override is global state). `pub(super)` so the
+    /// #3293 `recovery_relay_attempts_tests` module serializes on it too.
+    pub(super) fn stale_override_test_mutex() -> &'static std::sync::Mutex<()> {
         static M: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
         M.get_or_init(|| std::sync::Mutex::new(()))
     }
@@ -4788,5 +4799,170 @@ mod wave_a_cleanup_tests {
         assert_eq!(after.len(), 1);
         assert_eq!(after[0].restart_generation, Some(2));
         assert_eq!(after[0].user_msg_id, 78);
+    }
+}
+
+#[cfg(test)]
+mod recovery_relay_attempts_tests {
+    //! #3293: the `recovery_relay_attempts` restart-budget counter.
+    //!
+    //! The field is an additive `#[serde(default)]` column (NO
+    //! `INFLIGHT_STATE_VERSION` bump, #2235 convention): legacy rows must
+    //! deserialize with `0`, the value must round-trip, survive the
+    //! boot-time `mark_all_inflight_states_restart_mode` re-marking pass
+    //! (the infinite-WARN-loop carrier), and never weaken the pane-alive
+    //! stale-removal guard.
+    use super::{
+        InflightTurnState, RECOVERY_RELAY_RESTART_ATTEMPT_BUDGET, load_inflight_states_from_root,
+        save_inflight_state_in_root,
+    };
+    use crate::services::discord::InflightRestartMode;
+    use crate::services::provider::ProviderKind;
+    use tempfile::TempDir;
+
+    fn make_state(channel_id: u64) -> InflightTurnState {
+        InflightTurnState::new(
+            ProviderKind::Codex,
+            channel_id,
+            Some("adk-cdx".to_string()),
+            7,
+            42,
+            43,
+            "hello".to_string(),
+            Some("session-3293".to_string()),
+            Some(format!("AgentDesk-codex-adk-cdx-{channel_id}")),
+            Some("/tmp/out.jsonl".to_string()),
+            Some("/tmp/in.fifo".to_string()),
+            0,
+        )
+    }
+
+    #[test]
+    fn budget_is_three_restarts() {
+        assert_eq!(RECOVERY_RELAY_RESTART_ATTEMPT_BUDGET, 3);
+    }
+
+    #[test]
+    fn legacy_row_without_field_deserializes_to_zero() {
+        // A pre-#3293 on-disk row has no `recovery_relay_attempts` key; the
+        // additive field must default to 0 instead of failing the parse
+        // (which would GC the row as malformed).
+        let state: InflightTurnState = serde_json::from_value(serde_json::json!({
+            "version": 8,
+            "provider": "codex",
+            "channel_id": 42,
+            "channel_name": "adk-cdx",
+            "request_owner_user_id": 7,
+            "user_msg_id": 8,
+            "current_msg_id": 9,
+            "current_msg_len": 0,
+            "user_text": "hello",
+            "source": "text",
+            "session_id": null,
+            "tmux_session_name": "AgentDesk-codex-adk-cdx",
+            "output_path": "/tmp/out.jsonl",
+            "input_fifo_path": null,
+            "last_offset": 0,
+            "full_response": "",
+            "response_sent_offset": 0,
+            "started_at": "2026-05-17 10:00:00",
+            "updated_at": "2026-05-17 10:00:00"
+        }))
+        .expect("legacy row without recovery_relay_attempts must deserialize");
+        assert_eq!(state.recovery_relay_attempts, 0);
+    }
+
+    #[test]
+    fn counter_round_trips_through_serde() {
+        let mut state = make_state(3293);
+        state.recovery_relay_attempts = 2;
+        let json = serde_json::to_string(&state).expect("serialize");
+        let parsed: InflightTurnState = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed.recovery_relay_attempts, 2);
+    }
+
+    #[test]
+    fn counter_survives_disk_round_trip_in_isolated_root() {
+        let temp = TempDir::new().unwrap();
+        let mut state = make_state(932_931);
+        state.recovery_relay_attempts = 2;
+        save_inflight_state_in_root(temp.path(), &state).expect("save");
+
+        let loaded = load_inflight_states_from_root(temp.path(), &ProviderKind::Codex);
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].recovery_relay_attempts, 2);
+    }
+
+    /// The boot-time `mark_all_inflight_states_restart_mode` pass rewrites
+    /// every row (the carrier of the pre-#3293 infinite WARN loop). The
+    /// counter must survive that rewrite or the budget could never trip.
+    #[test]
+    fn counter_survives_restart_mode_remarking() {
+        // `mark_all_inflight_states_restart_mode` resolves the root from the
+        // process-global `AGENTDESK_ROOT_DIR`; serialize against every other
+        // env-touching test and restore the previous value on exit.
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous_root = std::env::var("AGENTDESK_ROOT_DIR").ok();
+        let temp = TempDir::new().unwrap();
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+
+        struct EnvRestore(Option<String>);
+        impl Drop for EnvRestore {
+            fn drop(&mut self) {
+                match self.0.take() {
+                    Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
+                    None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
+                }
+            }
+        }
+        let _restore = EnvRestore(previous_root);
+
+        // `mark_all_…` scans `$AGENTDESK_ROOT_DIR/runtime/discord_inflight`;
+        // seed the row under that exact root.
+        let inflight_root = super::inflight_runtime_root().expect("env root must resolve");
+        let mut state = make_state(932_932);
+        state.recovery_relay_attempts = 2;
+        save_inflight_state_in_root(&inflight_root, &state).expect("save");
+
+        let updated = super::mark_all_inflight_states_restart_mode(
+            &ProviderKind::Codex,
+            InflightRestartMode::DrainRestart,
+        );
+        assert_eq!(updated, 1, "the seeded row must be re-marked");
+
+        let loaded = load_inflight_states_from_root(&inflight_root, &ProviderKind::Codex);
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(
+            loaded[0].restart_mode,
+            Some(InflightRestartMode::DrainRestart)
+        );
+        assert_eq!(
+            loaded[0].recovery_relay_attempts, 2,
+            "re-marking must not reset the restart-relay budget counter"
+        );
+    }
+
+    /// #3293 invariant: the counter must not interact with the pane-alive
+    /// stale-removal guard — a row carrying a saturated counter whose tmux
+    /// pane is still alive is preserved by `stale_removal_reason`.
+    #[test]
+    fn saturated_counter_does_not_weaken_pane_alive_stale_guard() {
+        let _guard = super::stall_recovery_tests::stale_override_test_mutex()
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        super::set_test_tmux_alive_override(Some(&["AgentDesk-codex-adk-cdx-932933"]));
+
+        let mut state = make_state(932_933);
+        state.tmux_session_name = Some("AgentDesk-codex-adk-cdx-932933".to_string());
+        state.recovery_relay_attempts = 99;
+
+        let result = super::stale_removal_reason(&state, super::INFLIGHT_MAX_AGE_SECS + 1, 7);
+        super::set_test_tmux_alive_override(None);
+        assert!(
+            result.is_none(),
+            "alive tmux pane must preserve the row regardless of the relay counter; got {result:?}"
+        );
     }
 }

--- a/src/services/discord/inflight/budget.rs
+++ b/src/services/discord/inflight/budget.rs
@@ -1,0 +1,338 @@
+//! #3293 verify r1 (finding 1): restart-budget counter persistence that works
+//! on restart-marked rows.
+//!
+//! The #3293 carrier row is re-marked `DrainRestart` by
+//! `mark_all_inflight_states_restart_mode` on EVERY shutdown, so at recovery
+//! time its on-disk form always has `restart_mode = Some(..)`. The generic
+//! [`super::save_inflight_state_if_matches_identity`] guard refuses any write
+//! to such a row (and to `user_msg_id == 0` TUI-direct rows), which made the
+//! `PreserveAndCount` disposition a permanent no-op: `recovery_relay_attempts`
+//! stayed 0 forever and `ClearBudgetExhausted` was unreachable on exactly the
+//! row class the budget exists for.
+//!
+//! This module adds a narrow read-modify-write that increments ONLY the
+//! counter on the on-disk row (preserving `restart_mode`, `rebind_origin`,
+//! and every other field as-is), gated by the same strong turn identity
+//! (`user_msg_id` + `started_at` + `tmux_session_name`, plus
+//! `turn_start_offset` for TUI-direct disambiguation). The original guard's
+//! purpose — never clobber a different turn's row — is kept: a newer turn or
+//! a fresh rebind row has a different identity and is refused.
+
+use std::fs;
+use std::path::Path;
+
+use super::{GuardedSaveOutcome, InflightTurnIdentity, InflightTurnState};
+use crate::services::provider::ProviderKind;
+
+/// Increment `recovery_relay_attempts` on the on-disk inflight row for
+/// `(provider, channel_id)` when it still matches `expected`. Unlike the full
+/// guarded save this NEVER rejects restart-marked / rebind-origin /
+/// TUI-direct rows by marker alone — only identity decides, because the write
+/// preserves the on-disk row (markers included) and bumps a single counter.
+pub(in crate::services::discord) fn bump_recovery_relay_attempts_if_matches_identity(
+    provider: &ProviderKind,
+    channel_id: u64,
+    expected: &InflightTurnIdentity,
+    expected_turn_start_offset: Option<u64>,
+) -> GuardedSaveOutcome {
+    let Some(root) = super::inflight_runtime_root() else {
+        return GuardedSaveOutcome::IoError;
+    };
+    bump_recovery_relay_attempts_if_matches_identity_in_root(
+        &root,
+        provider,
+        channel_id,
+        expected,
+        expected_turn_start_offset,
+    )
+}
+
+/// Root-explicit inner form for unit tests (avoids `AGENTDESK_ROOT_DIR` env
+/// races, same pattern as the other `_in_root` helpers in this subtree).
+pub(in crate::services::discord) fn bump_recovery_relay_attempts_if_matches_identity_in_root(
+    root: &Path,
+    provider: &ProviderKind,
+    channel_id: u64,
+    expected: &InflightTurnIdentity,
+    expected_turn_start_offset: Option<u64>,
+) -> GuardedSaveOutcome {
+    let path = super::inflight_state_path(root, provider, channel_id);
+    // Same sidecar flock as the rest of the module: hold it across the read
+    // AND the write so a concurrent clear/save cannot interleave.
+    let Ok(_lock) = super::lock_inflight_state_path(&path) else {
+        return GuardedSaveOutcome::IoError;
+    };
+    // Row already cleared (delivered / force-cleared) → never resurrect.
+    let Ok(data) = fs::read_to_string(&path) else {
+        return GuardedSaveOutcome::Missing;
+    };
+    let Ok(mut on_disk) = serde_json::from_str::<InflightTurnState>(&data) else {
+        // Malformed row: do not clobber — the loader eviction path GCs it.
+        return GuardedSaveOutcome::IdentityMismatch;
+    };
+    // Strong identity: user_msg_id + started_at + tmux_session_name must all
+    // match the turn whose relay just failed. Restart/rebind markers are NOT
+    // grounds for refusal here — they are preserved verbatim below.
+    if !expected.matches_state(&on_disk) {
+        return GuardedSaveOutcome::IdentityMismatch;
+    }
+    if let Some(expected_offset) = expected_turn_start_offset {
+        if on_disk.turn_start_offset != Some(expected_offset) {
+            return GuardedSaveOutcome::IdentityMismatch;
+        }
+    } else if expected.user_msg_id == 0 && on_disk.turn_start_offset.is_some() {
+        // TUI-direct turns (`user_msg_id == 0`) collide on `started_at`'s
+        // 1-second resolution; without an offset to compare we cannot prove
+        // this is the same turn, so refuse rather than count a stranger's row.
+        return GuardedSaveOutcome::IdentityMismatch;
+    }
+    on_disk.recovery_relay_attempts = on_disk.recovery_relay_attempts.saturating_add(1);
+    on_disk.updated_at = super::now_string();
+    let Ok(json) = serde_json::to_string_pretty(&on_disk) else {
+        return GuardedSaveOutcome::IoError;
+    };
+    match super::atomic_write(&path, &json) {
+        Ok(()) => GuardedSaveOutcome::Saved,
+        Err(error) => {
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel = channel_id,
+                error = %error,
+                "inflight relay-attempt bump failed; leaving on-disk row untouched"
+            );
+            GuardedSaveOutcome::IoError
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Red-green coverage for the #3297 adversarial finding 1 blind spot:
+    //! "counter increment WRITE succeeds on a restart-marked row".
+    //!
+    //! Hermetic by construction: rows are written/read with the root-explicit
+    //! save + a direct file parse (NOT `load_inflight_states_from_root`, whose
+    //! eviction side-effect consults the env-global generation counter — the
+    //! #3293 scope-(a) parallel-test race this PR deliberately avoids adding
+    //! to). `restart_mode` is set directly for the same reason
+    //! (`set_restart_mode` stamps `restart_generation` from the env root).
+    use std::path::Path;
+
+    use tempfile::TempDir;
+
+    use super::super::{
+        GuardedSaveOutcome, InflightTurnIdentity, InflightTurnState, inflight_state_path,
+        save_inflight_state_if_matches_identity_in_root, save_inflight_state_in_root,
+    };
+    use super::bump_recovery_relay_attempts_if_matches_identity_in_root;
+    use crate::services::discord::InflightRestartMode;
+    use crate::services::provider::ProviderKind;
+
+    fn make_state(channel_id: u64) -> InflightTurnState {
+        InflightTurnState::new(
+            ProviderKind::Codex,
+            channel_id,
+            Some("adk-cdx".to_string()),
+            7,
+            42,
+            43,
+            "hello".to_string(),
+            Some("session-3293".to_string()),
+            Some(format!("AgentDesk-codex-adk-cdx-{channel_id}")),
+            Some("/tmp/out.jsonl".to_string()),
+            Some("/tmp/in.fifo".to_string()),
+            0,
+        )
+    }
+
+    fn read_row(root: &Path, channel_id: u64) -> Option<InflightTurnState> {
+        let path = inflight_state_path(root, &ProviderKind::Codex, channel_id);
+        let content = std::fs::read_to_string(path).ok()?;
+        serde_json::from_str(&content).ok()
+    }
+
+    /// THE finding-1 red-green: the generic guarded save refuses a
+    /// restart-marked row (red — the pre-fix path, attempts pinned at 0
+    /// forever), while the dedicated bump persists the increment AND
+    /// preserves the restart marker (green).
+    #[test]
+    fn bump_persists_attempts_on_restart_marked_row() {
+        let temp = TempDir::new().unwrap();
+        let mut state = make_state(932_941);
+        state.restart_mode = Some(InflightRestartMode::DrainRestart);
+        save_inflight_state_in_root(temp.path(), &state).expect("seed restart-marked row");
+        let identity = InflightTurnIdentity::from_state(&state);
+
+        // Pre-fix path: the generic identity-guarded save refuses the write
+        // outright because `restart_mode.is_some()` — this is the exact
+        // mechanism that kept the budget counter at 0 on the carrier row.
+        let mut counted = state.clone();
+        counted.recovery_relay_attempts = 1;
+        assert_eq!(
+            save_inflight_state_if_matches_identity_in_root(
+                temp.path(),
+                &counted,
+                &identity,
+                state.turn_start_offset,
+            ),
+            GuardedSaveOutcome::IdentityMismatch,
+            "generic guarded save must still refuse restart-marked rows (its #3041 contract)"
+        );
+
+        // Fixed path: the dedicated bump lands on the same row.
+        assert_eq!(
+            bump_recovery_relay_attempts_if_matches_identity_in_root(
+                temp.path(),
+                &ProviderKind::Codex,
+                state.channel_id,
+                &identity,
+                state.turn_start_offset,
+            ),
+            GuardedSaveOutcome::Saved,
+            "the budget counter must persist on a restart-marked carrier row"
+        );
+
+        let row = read_row(temp.path(), state.channel_id).expect("row must remain on disk");
+        assert_eq!(
+            row.recovery_relay_attempts, 1,
+            "attempts must be 1 after one bump"
+        );
+        assert_eq!(
+            row.restart_mode,
+            Some(InflightRestartMode::DrainRestart),
+            "the restart marker must be preserved verbatim by the bump"
+        );
+    }
+
+    /// Three consecutive boot failures must accumulate to the budget value —
+    /// the counter is monotonic across re-marked boots, so
+    /// `ClearBudgetExhausted` is actually reachable now.
+    #[test]
+    fn bump_accumulates_across_remarked_boots() {
+        let temp = TempDir::new().unwrap();
+        let mut state = make_state(932_942);
+        state.restart_mode = Some(InflightRestartMode::DrainRestart);
+        save_inflight_state_in_root(temp.path(), &state).expect("seed");
+        let identity = InflightTurnIdentity::from_state(&state);
+
+        for expected_attempts in 1..=3u32 {
+            assert_eq!(
+                bump_recovery_relay_attempts_if_matches_identity_in_root(
+                    temp.path(),
+                    &ProviderKind::Codex,
+                    state.channel_id,
+                    &identity,
+                    state.turn_start_offset,
+                ),
+                GuardedSaveOutcome::Saved,
+            );
+            let row = read_row(temp.path(), state.channel_id).expect("row must remain");
+            assert_eq!(row.recovery_relay_attempts, expected_attempts);
+        }
+    }
+
+    /// TUI-direct (`user_msg_id == 0`) rows are countable too — the second
+    /// half of finding 1 (the generic guard rejected them unconditionally).
+    #[test]
+    fn bump_persists_attempts_on_tui_direct_row() {
+        let temp = TempDir::new().unwrap();
+        let mut state = make_state(932_943);
+        state.user_msg_id = 0;
+        state.turn_start_offset = Some(512);
+        save_inflight_state_in_root(temp.path(), &state).expect("seed");
+        let identity = InflightTurnIdentity::from_state(&state);
+
+        assert_eq!(
+            bump_recovery_relay_attempts_if_matches_identity_in_root(
+                temp.path(),
+                &ProviderKind::Codex,
+                state.channel_id,
+                &identity,
+                state.turn_start_offset,
+            ),
+            GuardedSaveOutcome::Saved,
+        );
+        let row = read_row(temp.path(), state.channel_id).expect("row must remain");
+        assert_eq!(row.recovery_relay_attempts, 1);
+    }
+
+    /// A TUI-direct row whose offset cannot be proven equal must be refused —
+    /// `started_at` alone (1s resolution) is not a strong enough identity.
+    #[test]
+    fn bump_refuses_tui_direct_row_without_offset_proof() {
+        let temp = TempDir::new().unwrap();
+        let mut state = make_state(932_944);
+        state.user_msg_id = 0;
+        state.turn_start_offset = Some(512);
+        save_inflight_state_in_root(temp.path(), &state).expect("seed");
+        let mut expected = InflightTurnIdentity::from_state(&state);
+        expected.turn_start_offset = None;
+
+        assert_eq!(
+            bump_recovery_relay_attempts_if_matches_identity_in_root(
+                temp.path(),
+                &ProviderKind::Codex,
+                state.channel_id,
+                &expected,
+                None,
+            ),
+            GuardedSaveOutcome::IdentityMismatch,
+        );
+        let row = read_row(temp.path(), state.channel_id).expect("row must remain");
+        assert_eq!(
+            row.recovery_relay_attempts, 0,
+            "stranger row must stay uncounted"
+        );
+    }
+
+    /// Identity guard intact: a NEWER turn now owning the row is never
+    /// counted (the original guard's core purpose, preserved).
+    #[test]
+    fn bump_refuses_row_owned_by_newer_turn() {
+        let temp = TempDir::new().unwrap();
+        let mut newer = make_state(932_945);
+        newer.user_msg_id = 999;
+        save_inflight_state_in_root(temp.path(), &newer).expect("seed newer turn");
+
+        let mut older = make_state(932_945);
+        older.user_msg_id = 777;
+        let identity = InflightTurnIdentity::from_state(&older);
+
+        assert_eq!(
+            bump_recovery_relay_attempts_if_matches_identity_in_root(
+                temp.path(),
+                &ProviderKind::Codex,
+                older.channel_id,
+                &identity,
+                older.turn_start_offset,
+            ),
+            GuardedSaveOutcome::IdentityMismatch,
+        );
+        let row = read_row(temp.path(), older.channel_id).expect("row must remain");
+        assert_eq!(row.user_msg_id, 999, "newer turn's row must be untouched");
+        assert_eq!(row.recovery_relay_attempts, 0);
+    }
+
+    /// A cleared (missing) row is never resurrected by the bump.
+    #[test]
+    fn bump_does_not_resurrect_missing_row() {
+        let temp = TempDir::new().unwrap();
+        let state = make_state(932_946);
+        let identity = InflightTurnIdentity::from_state(&state);
+
+        assert_eq!(
+            bump_recovery_relay_attempts_if_matches_identity_in_root(
+                temp.path(),
+                &ProviderKind::Codex,
+                state.channel_id,
+                &identity,
+                state.turn_start_offset,
+            ),
+            GuardedSaveOutcome::Missing,
+        );
+        assert!(
+            read_row(temp.path(), state.channel_id).is_none(),
+            "bump must not create a row"
+        );
+    }
+}

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -2425,6 +2425,12 @@ impl SharedData {
         self.mailboxes.handle(channel_id)
     }
 
+    /// #3293: non-creating mailbox lookup for probes — `mailbox()` mints a
+    /// permanent registry entry for any channel id it is asked about.
+    fn mailbox_peek(&self, channel_id: ChannelId) -> Option<ChannelMailboxHandle> {
+        self.mailboxes.peek(channel_id)
+    }
+
     fn health_registry(&self) -> Option<Arc<health::HealthRegistry>> {
         self.health_registry.upgrade()
     }

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -3229,13 +3229,10 @@ async fn queue_exit_drain_queued_placeholders(
     queue_exit_events: &[&QueueExitEvent],
 ) -> Vec<QueueExitVisibleCard> {
     // codex review round-4 P2 + round-5 P2: hold the channel's persistence
-    // mutex across the whole batch drain + snapshot write. Without this, a
-    // concurrent `insert_queued_placeholder` for the same channel could
-    // observe its mutation reflected in memory but lose the race to write
-    // the *post-drain* snapshot to disk — leaving a stale entry that
-    // resurrects on restart for an intervention that has already exited the
-    // queue. Round-5 promoted the lock to `tokio::sync::Mutex` so callers
-    // that span `.await` can still serialize against this drain.
+    // mutex (async since round-5 so `.await`-spanning callers serialize too)
+    // across the whole batch drain + snapshot write, or a concurrent
+    // `insert_queued_placeholder` could win the disk write with a pre-drain
+    // snapshot that resurrects already-exited entries on restart.
     let persist_lock = shared.queued_placeholders_persist_lock(channel_id);
     let _persist_guard = persist_lock.lock().await;
     let mut visible_cards_to_clear: Vec<QueueExitVisibleCard> = Vec::new();
@@ -3287,22 +3284,14 @@ async fn apply_queue_exit_feedback(
         return;
     }
 
-    // #1332: drop any stale `📬 메시지 대기 중` placeholder mappings up front
-    // so a subsequent dispatch never wires a newly-started turn to a placeholder
-    // that belongs to a cancelled/expired intervention. Also detach the
-    // controller entry so the cap-bounded `placeholder_controller.entries`
-    // map does not retain a stale Queued row (Queued is not in the standard
-    // eviction sweep — it is meant to live until dispatch). The mapping/
-    // controller bookkeeping runs regardless of whether the cached serenity
-    // ctx is available so a missing ctx never silently misroutes the next
-    // turn.
-    //
-    // codex review P2 (#1332 follow-up): the visible Discord card edited to
-    // `📬 메시지 대기 중` must ALSO be cleaned up — leaving it behind would
-    // promise a turn that has been cancelled/expired/superseded. Collect the
-    // placeholder ids here and rewrite/delete them once we have a serenity
-    // ctx (best-effort: log on cache miss and leave the bookkeeping in place
-    // so a future ctx can still reach the same rows via `detach_by_message`).
+    // #1332: drop stale `📬 메시지 대기 중` placeholder mappings + controller
+    // entries up front (Queued rows are exempt from the standard eviction
+    // sweep) so a later dispatch never wires a new turn to a cancelled/expired
+    // intervention's placeholder; the bookkeeping runs even without a cached
+    // serenity ctx so a missing ctx never misroutes the next turn. codex
+    // review P2 (#1332 follow-up): also collect the visible card ids to
+    // rewrite/delete once a ctx exists (best-effort; drain rationale on the
+    // `queue_exit_drain_queued_placeholders` doc).
     let visible_cards_to_clear =
         queue_exit_drain_queued_placeholders(shared, channel_id, &queue_exit_events).await;
 
@@ -3343,18 +3332,14 @@ async fn apply_queue_exit_feedback(
     }
 
     for event in queue_exit_events {
-        // Clean up the queue-pending reactions on EVERY message that contributed
-        // to this intervention. After #1190 follow-up, merged messages carry ➕
-        // and standalone heads carry 📬; remove both unconditionally so cancel /
-        // expiry / supersede leaves only the exit-state reaction visible.
-        //
-        // #2044 F9: when the intervention has a single source message
-        // (standalone head, no merges), there was never a ➕ reaction
-        // to remove. Previously we called `remove_reaction_raw('➕')`
-        // anyway, doubling the channel-level rate-limited HTTP traffic
-        // per exit. Skip it for standalone messages — merged groups
-        // (`len() > 1`) still receive both removals because the merge
-        // path adds ➕ to every non-head source.
+        // Clean up the queue-pending reactions on EVERY contributing message:
+        // after #1190 follow-up, merged messages carry ➕ and standalone heads
+        // carry 📬 — remove both so cancel/expiry/supersede leaves only the
+        // exit-state reaction visible. #2044 F9: a standalone head (no merges)
+        // never had a ➕, so skip that removal instead of doubling the
+        // rate-limited HTTP traffic per exit; merged groups (`len() > 1`)
+        // still get both removals (the merge path adds ➕ to every non-head
+        // source).
         let is_standalone = event.intervention.source_message_ids.len() <= 1;
         for message_id in &event.intervention.source_message_ids {
             formatting::remove_reaction_raw(&http, channel_id, *message_id, '📬').await;

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -3052,15 +3052,19 @@ async fn mailbox_recovery_kickoff(
     // (user_msg_id == 0, e.g. a TUI-direct turn).
     user_message_id: Option<MessageId>,
 ) -> RecoveryKickoffResult {
-    // #2443 — reset the per-channel `recovery_done` latch BEFORE the
-    // recovery actually starts. A stale "done" flag from a previous cycle
-    // would otherwise let `watchers/lifecycle.rs` (which selects on
-    // `recovery_done.wait()`) immediately graduate the skip and race the
-    // ongoing recovery. Reset is idempotent and cheap.
+    // #2443 — reset the per-channel `recovery_done` latch BEFORE recovery
+    // starts; a stale "done" flag would let `watchers/lifecycle.rs` graduate
+    // its skip early and race the ongoing recovery. Idempotent and cheap.
     shared.mailboxes.recovery_done(channel_id).reset();
+    // #3297 r3 — tombstone refusal ⇒ retry on a fresh registered actor.
     let result = shared
-        .mailbox(channel_id)
-        .recovery_kickoff(cancel_token, request_owner, user_message_id)
+        .mailboxes
+        .recovery_kickoff_with_closed_retry(
+            channel_id,
+            cancel_token,
+            request_owner,
+            user_message_id,
+        )
         .await;
     if result.activated_turn {
         increment_global_active(shared, "recovery_kickoff");
@@ -3157,9 +3161,12 @@ async fn mailbox_enqueue_intervention(
     channel_id: ChannelId,
     intervention: Intervention,
 ) -> MailboxEnqueueOutcome {
+    // #3297 r3 — tombstone refusal ⇒ retry on a fresh registered actor
+    // instead of orphaning the queue on a purged one.
     let result = shared
-        .mailbox(channel_id)
-        .enqueue(
+        .mailboxes
+        .enqueue_with_closed_retry(
+            channel_id,
             intervention,
             queue_persistence_context(shared, provider, channel_id),
         )

--- a/src/services/discord/placeholder_sweeper.rs
+++ b/src/services/discord/placeholder_sweeper.rs
@@ -175,8 +175,9 @@ pub(in crate::services::discord) enum PlaceholderProbe {
 /// (5xx, 429 rate-limit, no status at all) is treated as transient.
 ///
 /// Split out so the classification can be unit-tested without constructing
-/// the `#[non_exhaustive]` `serenity::http::ErrorResponse`.
-fn is_permanent_message_gone_status(status: u16) -> bool {
+/// the `#[non_exhaustive]` `serenity::http::ErrorResponse`. #3293 reuses the
+/// same allowlist for the recovery terminal-relay outcome classifier.
+pub(in crate::services::discord) fn is_permanent_message_gone_status(status: u16) -> bool {
     matches!(status, 404 | 403 | 410)
 }
 

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -1,5 +1,7 @@
 use super::gateway::DiscordGateway;
 use super::inflight::optional_message_id;
+use super::recovery_paths::restart::dispose_recovery_relay_outcome;
+use super::recovery_paths::shared::RecoveryRelayOutcome;
 use super::settings::{
     load_last_remote_profile, load_last_session_path, resolve_role_binding,
     validate_bot_channel_routing_with_provider_channel,
@@ -254,7 +256,7 @@ async fn relay_recovery_terminal_notice(
     shared: &Arc<SharedData>,
     state: &super::inflight::InflightTurnState,
     text: &str,
-) -> bool {
+) -> RecoveryRelayOutcome {
     relay_recovered_terminal_text_to_placeholder(
         http,
         shared,
@@ -265,31 +267,28 @@ async fn relay_recovery_terminal_notice(
     .await
 }
 
-/// Deliver the recovered terminal text to Discord. When the turn anchored a
-/// placeholder (`current_msg_id != 0`) the placeholder is edited in place;
-/// when it did NOT (a TUI-direct / recovery turn with `current_msg_id == 0`,
-/// surfaced here as `placeholder == None`) the text is delivered as a NEW
-/// channel message instead. Either way `true` means the assistant response
-/// actually reached Discord, so the caller can safely advance recovery
-/// (release mailbox/inflight, complete the dispatch). Reporting success
-/// WITHOUT delivering would silently drop the answer (Codex P1). `MessageId::new(0)`
-/// would panic, hence the `Option`.
+/// Deliver the recovered terminal text to Discord: edit the placeholder in
+/// place when one was anchored, else (`placeholder == None`, e.g. TUI-direct —
+/// `MessageId::new(0)` would panic) send a NEW message. Only `Delivered` lets
+/// callers advance recovery (Codex P1); #3293 classifies failures so a
+/// permanent Discord rejection (404/403/410) can end the retry loop.
 async fn relay_recovered_terminal_text_to_placeholder(
     http: &Arc<serenity::Http>,
     shared: &Arc<SharedData>,
     channel_id: ChannelId,
     placeholder: Option<MessageId>,
     text: &str,
-) -> bool {
-    match placeholder {
+) -> RecoveryRelayOutcome {
+    let delivery = match placeholder {
         Some(placeholder) => {
             super::formatting::replace_long_message_raw(http, channel_id, placeholder, text, shared)
                 .await
-                .is_ok()
         }
-        None => super::formatting::send_long_message_raw(http, channel_id, text, shared)
-            .await
-            .is_ok(),
+        None => super::formatting::send_long_message_raw(http, channel_id, text, shared).await,
+    };
+    match delivery {
+        Ok(()) => RecoveryRelayOutcome::Delivered,
+        Err(error) => super::recovery_paths::shared::classify_recovery_relay_error(error.as_ref()),
     }
 }
 
@@ -941,7 +940,7 @@ fn interrupted_recovery_message(
         .unwrap_or_else(|| stale_inflight_message(saved_response))
 }
 
-fn save_missing_session_handoff(
+pub(super) fn save_missing_session_handoff(
     provider: &ProviderKind,
     state: &inflight::InflightTurnState,
     best_response: &str,
@@ -1228,7 +1227,7 @@ fn recovery_spawn_adk_cwd(
     Ok(persisted_session_path)
 }
 
-async fn finish_recovered_turn_mailbox(
+pub(super) async fn finish_recovered_turn_mailbox(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
     channel_id: ChannelId,
@@ -2150,7 +2149,8 @@ pub(super) async fn restore_inflight_turns(
                     optional_message_id(state.current_msg_id),
                     &final_text,
                 )
-                .await;
+                .await
+                .delivered();
                 if !should_advance_recovery_dispatch_after_relay(relay_ok) {
                     let ts = chrono::Local::now().format("%H:%M:%S");
                     tracing::warn!(
@@ -2784,7 +2784,8 @@ pub(super) async fn restore_inflight_turns(
                 current_msg_id,
                 &final_text,
             )
-            .await;
+            .await
+            .delivered();
 
             if !should_advance_recovery_dispatch_after_relay(relay_ok) {
                 let ts = chrono::Local::now().format("%H:%M:%S");
@@ -3036,7 +3037,8 @@ pub(super) async fn restore_inflight_turns(
                 current_msg_id,
                 &final_text,
             )
-            .await;
+            .await
+            .delivered();
 
             if !should_advance_recovery_dispatch_after_relay(relay_ok) {
                 let ts = chrono::Local::now().format("%H:%M:%S");
@@ -3299,21 +3301,22 @@ pub(super) async fn restore_inflight_turns(
                     &state.full_response,
                     provider,
                 );
-                if relay_recovery_terminal_notice(http, shared, &state, &final_text).await {
-                    finish_recovered_turn_mailbox(
-                        shared,
-                        provider,
-                        channel_id,
-                        "recovery_ready_without_output",
-                    )
-                    .await;
-                    clear_inflight_state(provider, state.channel_id);
-                } else {
-                    let ts = chrono::Local::now().format("%H:%M:%S");
-                    tracing::warn!(
-                        "  [{ts}] ⚠ recovery: ready-without-output notice failed — preserving inflight for retry"
-                    );
-                }
+                let outcome =
+                    relay_recovery_terminal_notice(http, shared, &state, &final_text).await;
+                // #3293: tmux_alive=true — budget force-clear forbidden here
+                // (pane-alive invariant); only a permanent verdict clears.
+                dispose_recovery_relay_outcome(
+                    shared,
+                    provider,
+                    &state,
+                    outcome,
+                    true,
+                    "recovery_ready_without_output",
+                    "ready_without_output",
+                    &state.full_response,
+                    false,
+                )
+                .await;
                 continue;
             }
             tracing::warn!(
@@ -3360,7 +3363,7 @@ pub(super) async fn restore_inflight_turns(
                     best_response.len()
                 );
             }
-            let relay_ok = relay_recovery_terminal_notice(http, shared, &state, &stale_text).await;
+            let outcome = relay_recovery_terminal_notice(http, shared, &state, &stale_text).await;
             if let Some(ref sk) = state.session_key {
                 crate::services::termination_audit::record_termination_with_handles(
                     None::<&crate::db::Db>,
@@ -3376,21 +3379,19 @@ pub(super) async fn restore_inflight_turns(
                 );
             }
             save_missing_session_handoff(provider, &state, &best_response);
-            if relay_ok {
-                finish_recovered_turn_mailbox(
-                    shared,
-                    provider,
-                    channel_id,
-                    "recovery_missing_tmux",
-                )
-                .await;
-                clear_inflight_state(provider, state.channel_id);
-            } else {
-                let ts = chrono::Local::now().format("%H:%M:%S");
-                tracing::warn!(
-                    "  [{ts}] ⚠ recovery: missing-tmux notice failed — preserving inflight for retry"
-                );
-            }
+            // Handoff already saved above for every outcome (last arg).
+            dispose_recovery_relay_outcome(
+                shared,
+                provider,
+                &state,
+                outcome,
+                false,
+                "recovery_missing_tmux",
+                "missing_tmux",
+                &best_response,
+                true,
+            )
+            .await;
             continue;
         }
 
@@ -3401,20 +3402,19 @@ pub(super) async fn restore_inflight_turns(
                 state.channel_id
             );
             let text = stale_inflight_message("tmux session name missing during recovery");
-            if relay_recovery_terminal_notice(http, shared, &state, &text).await {
-                finish_recovered_turn_mailbox(
-                    shared,
-                    provider,
-                    channel_id,
-                    "recovery_missing_tmux_name",
-                )
-                .await;
-                clear_inflight_state(provider, state.channel_id);
-            } else {
-                tracing::warn!(
-                    "  [{ts}] ⚠ recovery: missing-tmux-name notice failed — preserving inflight for retry"
-                );
-            }
+            let outcome = relay_recovery_terminal_notice(http, shared, &state, &text).await;
+            dispose_recovery_relay_outcome(
+                shared,
+                provider,
+                &state,
+                outcome,
+                false,
+                "recovery_missing_tmux_name",
+                "missing_tmux_name",
+                &state.full_response,
+                false,
+            )
+            .await;
             continue;
         };
         let Some(output_path) = output_path else {
@@ -3424,20 +3424,19 @@ pub(super) async fn restore_inflight_turns(
                 state.channel_id
             );
             let text = stale_inflight_message("output path missing during recovery");
-            if relay_recovery_terminal_notice(http, shared, &state, &text).await {
-                finish_recovered_turn_mailbox(
-                    shared,
-                    provider,
-                    channel_id,
-                    "recovery_missing_output_path",
-                )
-                .await;
-                clear_inflight_state(provider, state.channel_id);
-            } else {
-                tracing::warn!(
-                    "  [{ts}] ⚠ recovery: missing-output-path notice failed — preserving inflight for retry"
-                );
-            }
+            let outcome = relay_recovery_terminal_notice(http, shared, &state, &text).await;
+            dispose_recovery_relay_outcome(
+                shared,
+                provider,
+                &state,
+                outcome,
+                false,
+                "recovery_missing_output_path",
+                "missing_output_path",
+                &state.full_response,
+                false,
+            )
+            .await;
             continue;
         };
         let input_fifo_path = match recovery_input_fifo_for_runtime(runtime_kind, input_fifo_path) {
@@ -3475,20 +3474,19 @@ pub(super) async fn restore_inflight_turns(
                     runtime_kind.as_str()
                 );
                 let text = stale_inflight_message(reason);
-                if relay_recovery_terminal_notice(http, shared, &state, &text).await {
-                    finish_recovered_turn_mailbox(
-                        shared,
-                        provider,
-                        channel_id,
-                        "recovery_missing_input_fifo",
-                    )
-                    .await;
-                    clear_inflight_state(provider, state.channel_id);
-                } else {
-                    tracing::warn!(
-                        "  [{ts}] ⚠ recovery: missing-input-fifo notice failed — preserving inflight for retry"
-                    );
-                }
+                let outcome = relay_recovery_terminal_notice(http, shared, &state, &text).await;
+                dispose_recovery_relay_outcome(
+                    shared,
+                    provider,
+                    &state,
+                    outcome,
+                    false,
+                    "recovery_missing_input_fifo",
+                    "missing_input_fifo",
+                    &state.full_response,
+                    false,
+                )
+                .await;
                 continue;
             }
         };
@@ -3571,7 +3569,8 @@ pub(super) async fn restore_inflight_turns(
                             current_msg_id,
                             &format!("❌ {error}\nmain workspace fallback blocked."),
                         )
-                        .await;
+                        .await
+                        .delivered();
                         if should_advance_recovery_dispatch_after_relay(relay_ok) {
                             super::turn_bridge::fail_dispatch_with_retry(
                                 shared.api_port,
@@ -3801,7 +3800,8 @@ pub(super) async fn restore_inflight_turns(
                     current_msg_id,
                     &format!("❌ {error}\nmain workspace fallback blocked."),
                 )
-                .await;
+                .await
+                .delivered();
                 if should_advance_recovery_dispatch_after_relay(relay_ok) {
                     super::turn_bridge::fail_dispatch_with_retry(
                         shared.api_port,

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -31,25 +31,14 @@ fn tmux_session_has_live_pane(_name: &str) -> bool {
 }
 
 /// #2428 H5: exponential backoff (+ jitter) for the 3-attempt recovery retry
-/// loops in this module. Replaces the previous fixed `1s` gap with an
-/// exponential schedule that *preserves the old wall-clock budget*.
-///
-/// Budget contract (Codex pass-1 review):
-/// - Old: 3 attempts × 1000ms gap → wait between attempts = 1000ms + 1000ms = **2000ms**
-///   total grace window before declaring tmux/finalize recovery failed.
-/// - New: gap schedule = `[700, 1300, 2000]` ms + 0..=100ms jitter, callers
-///   sleep on attempt 1 and 2 (`if attempt < 3`). Wait between attempts =
-///   `700 + 1300 = 2000ms +0..=200ms` (jitter only adds). **Total budget preserved** while
-///   distributing the gaps exponentially so a transient failure that resolves
-///   in <1s wakes ~300ms earlier on average.
-/// - The third slot (`2000ms`) is reachable only if a future change bumps
-///   the loop past 3 attempts; it caps the per-gap wait without exploding the
-///   total when more attempts are added.
-///
-/// `attempt` is 1-indexed and matches the loop variable: it is the attempt
-/// that *just failed*, and the returned duration is how long to wait before
-/// the next attempt. Callers should only invoke this when another attempt
-/// will actually be tried (typically `if attempt < 3`).
+/// loops in this module. Budget contract (Codex pass-1 review): the old fixed
+/// schedule waited 1000+1000 = 2000ms total; the new gap schedule
+/// `[700, 1300, 2000]`ms + 0..=100ms jitter preserves that wall-clock budget
+/// (callers sleep on attempts 1 and 2: 700+1300 = 2000ms, jitter only adds)
+/// while waking ~300ms earlier on average for sub-second transients. The
+/// third slot is reachable only if a future change adds attempts; it caps the
+/// per-gap wait. `attempt` is 1-indexed = the attempt that *just failed*;
+/// call only when another attempt will actually run (`if attempt < 3`).
 pub(super) fn recovery_retry_backoff(attempt: u32) -> std::time::Duration {
     // Gap schedule between attempts 1→2, 2→3, 3→4, …: 700ms, 1300ms, 2000ms.
     // The 700 + 1300 = 2000ms sum is what makes the 3-attempt total grace
@@ -271,7 +260,9 @@ async fn relay_recovery_terminal_notice(
 /// place when one was anchored, else (`placeholder == None`, e.g. TUI-direct —
 /// `MessageId::new(0)` would panic) send a NEW message. Only `Delivered` lets
 /// callers advance recovery (Codex P1); #3293 classifies failures so a
-/// permanent Discord rejection (404/403/410) can end the retry loop.
+/// permanent Discord rejection (404/403/410) can end the retry loop. #3297
+/// finding 2: the anchored path flattens errors into Strings, so a transient
+/// classification gets a second opinion from an active channel probe.
 async fn relay_recovered_terminal_text_to_placeholder(
     http: &Arc<serenity::Http>,
     shared: &Arc<SharedData>,
@@ -288,7 +279,15 @@ async fn relay_recovered_terminal_text_to_placeholder(
     };
     match delivery {
         Ok(()) => RecoveryRelayOutcome::Delivered,
-        Err(error) => super::recovery_paths::shared::classify_recovery_relay_error(error.as_ref()),
+        Err(error) => {
+            let classified =
+                super::recovery_paths::shared::classify_recovery_relay_error(error.as_ref());
+            super::recovery_paths::shared::escalate_transient_relay_outcome_with_probe(
+                classified,
+                || super::recovery_paths::restart::probe_channel_liveness(http, channel_id),
+            )
+            .await
+        }
     }
 }
 
@@ -940,6 +939,9 @@ fn interrupted_recovery_message(
         .unwrap_or_else(|| stale_inflight_message(saved_response))
 }
 
+/// WARN-only trace (160-char response tail) — writes NOTHING to disk. The
+/// durable full-response artifact for force-clears is
+/// `recovery_paths::restart::persist_force_clear_report` (#3297 finding 3).
 pub(super) fn save_missing_session_handoff(
     provider: &ProviderKind,
     state: &inflight::InflightTurnState,
@@ -3403,12 +3405,14 @@ pub(super) async fn restore_inflight_turns(
             );
             let text = stale_inflight_message("tmux session name missing during recovery");
             let outcome = relay_recovery_terminal_notice(http, shared, &state, &text).await;
+            // #3297 finding 4: past the can_recover gate tmux absence is NOT
+            // established — tmux_alive=true forbids budget force-clear here.
             dispose_recovery_relay_outcome(
                 shared,
                 provider,
                 &state,
                 outcome,
-                false,
+                true,
                 "recovery_missing_tmux_name",
                 "missing_tmux_name",
                 &state.full_response,
@@ -3425,12 +3429,15 @@ pub(super) async fn restore_inflight_turns(
             );
             let text = stale_inflight_message("output path missing during recovery");
             let outcome = relay_recovery_terminal_notice(http, shared, &state, &text).await;
+            // #3297 finding 4: tmux session existence was confirmed above
+            // (can_recover consumed the missing-tmux rows) — tmux_alive=true,
+            // so the budget can never clear a possibly-live pane here.
             dispose_recovery_relay_outcome(
                 shared,
                 provider,
                 &state,
                 outcome,
-                false,
+                true,
                 "recovery_missing_output_path",
                 "missing_output_path",
                 &state.full_response,
@@ -3475,12 +3482,14 @@ pub(super) async fn restore_inflight_turns(
                 );
                 let text = stale_inflight_message(reason);
                 let outcome = relay_recovery_terminal_notice(http, shared, &state, &text).await;
+                // #3297 finding 4: tmux existence already confirmed —
+                // tmux_alive=true (budget clear forbidden; permanent only).
                 dispose_recovery_relay_outcome(
                     shared,
                     provider,
                     &state,
                     outcome,
-                    false,
+                    true,
                     "recovery_missing_input_fifo",
                     "missing_input_fifo",
                     &state.full_response,
@@ -4137,28 +4146,19 @@ impl std::fmt::Display for RebindError {
 }
 
 /// #896: Rebind a live tmux session to a freshly-created inflight state and
-/// (re)spawn the output watcher. Used to recover from orphan states where
-/// the tmux session is alive but the inflight JSON was cleared by a prior
-/// turn's cleanup, leaving subsequent output with no relay path.
+/// (re)spawn the output watcher — recovers orphan states whose tmux is alive
+/// but whose inflight JSON was cleared, leaving output with no relay path.
 ///
-/// Preconditions (enforced — caller gets a typed error on violation):
-/// * Tmux session must be alive. Absent session ⇒ nothing to rebind; the
-///   caller should force-kill + restart instead.
-/// * No existing inflight must exist for the channel. Caller clears first
-///   to avoid racing with a live turn's state.
-/// * Channel must be bound to the requested provider in the role-map.
+/// Preconditions (enforced, typed error on violation): tmux session alive
+/// (absent ⇒ force-kill + restart instead); no existing inflight for the
+/// channel (caller clears first); channel role-map-bound to the provider.
 ///
-/// Side effects on success:
-/// * Writes `~/.adk/release/runtime/discord_inflight/{provider}/{channel}.json`
-///   with `last_offset` set to the tmux output file's current size, so the
-///   watcher only picks up output produced *after* this call. Retroactive
-///   emission of already-dropped output is intentionally out of scope.
-/// * Registers / refreshes the `DiscordSession` entry in `shared.core.sessions`.
-/// * Spawns a `tmux_output_watcher` via the single-watcher claim policy. If
-///   a live watcher already owns the tmux session, the existing owner is
-///   reused and `watcher_spawned=false` is returned — the inflight we just
-///   created will still be picked up by the existing watcher, so this is not
-///   an error.
+/// Side effects on success: writes the provider/channel inflight JSON with
+/// `last_offset` = current output size (only NEW output is relayed —
+/// retroactive emission is out of scope); registers/refreshes the
+/// `DiscordSession`; spawns a `tmux_output_watcher` via the single-watcher
+/// claim policy (an existing live owner is reused, `watcher_spawned=false`,
+/// and still picks up the new inflight — not an error).
 pub(crate) async fn rebind_inflight_for_channel(
     http: &Arc<serenity::Http>,
     shared: &Arc<SharedData>,

--- a/src/services/discord/recovery_paths/mod.rs
+++ b/src/services/discord/recovery_paths/mod.rs
@@ -26,4 +26,5 @@
 //! recovery code should add helpers here if they are cross-path, and in the
 //! path-specific module otherwise.
 
+pub(super) mod restart;
 pub(super) mod shared;

--- a/src/services/discord/recovery_paths/restart.rs
+++ b/src/services/discord/recovery_paths/restart.rs
@@ -4,20 +4,48 @@
 //! `recovery_engine::restore_inflight_turns` whose terminal relay to Discord
 //! did NOT deliver. The pure decision matrix lives in [`super::shared`]; this
 //! module executes the chosen [`RowDisposition`] with the no-silent-delete
-//! guarantees from the #3293 design (handoff + audit + structured WARN on
-//! every force-clear, identity-guarded counter persistence on preserve).
+//! guarantees from the #3293 design: every force-clear writes an on-disk
+//! force-clear report (full response text + row metadata, see
+//! [`persist_force_clear_report`]) + a termination audit + a structured WARN,
+//! and the preserve path persists the attempt counter through a
+//! restart-marker-preserving identity-guarded bump.
 
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use poise::serenity_prelude as serenity;
 use poise::serenity_prelude::ChannelId;
+use serde::{Deserialize, Serialize};
 
 use super::super::recovery_engine::{finish_recovered_turn_mailbox, save_missing_session_handoff};
+use super::super::runtime_store::{atomic_write, discord_recovery_force_clear_root};
 use super::super::{SharedData, inflight};
 use super::shared::{
-    RecoveryRelayOutcome, RowDisposition, disposition_reason_code, unrecoverable_relay_disposition,
+    ChannelProbeVerdict, RecoveryRelayOutcome, RowDisposition, classify_channel_probe_status,
+    disposition_reason_code, unrecoverable_relay_disposition,
 };
 use crate::services::provider::ProviderKind;
 use crate::services::turn_orchestrator::ChannelMailboxRegistry;
+
+/// #3297 finding 2: active channel-liveness probe used as the second opinion
+/// after a transient-looking relay failure. A direct `get_channel` bypasses
+/// the String-flattened formatting error chain entirely: 404/403/410 on the
+/// CHANNEL itself is an authoritative "gone" verdict; everything else
+/// (success, 5xx, 429, transport) stays inconclusive so the conservative
+/// transient classification survives.
+pub(in crate::services::discord) async fn probe_channel_liveness(
+    http: &serenity::Http,
+    channel_id: ChannelId,
+) -> ChannelProbeVerdict {
+    match http.get_channel(channel_id).await {
+        Ok(_) => ChannelProbeVerdict::Inconclusive,
+        Err(serenity::Error::Http(http_err)) => {
+            classify_channel_probe_status(http_err.status_code().map(|status| status.as_u16()))
+        }
+        Err(_) => ChannelProbeVerdict::Inconclusive,
+    }
+}
 
 /// #3293 (c): finish the recovered turn's mailbox ONLY when a registry entry
 /// already exists. `finish_recovered_turn_mailbox` routes through the turn
@@ -96,12 +124,17 @@ pub(in crate::services::discord) async fn dispose_recovery_relay_outcome(
 
 /// Execute a non-`Delivered` [`RowDisposition`] for a recovery branch.
 ///
-/// * `ClearPermanent` / `ClearBudgetExhausted` — termination audit (when the
-///   row carries a `session_key`), missing-session handoff (unless the branch
-///   already saved one), a structured WARN that ALWAYS fires, then finish the
-///   mailbox (existing entries only) and clear the inflight row.
-/// * `PreserveAndCount` — persist `recovery_relay_attempts + 1` through the
-///   identity-guarded save (never clobbers a newer turn / restart marker) and
+/// * `ClearPermanent` / `ClearBudgetExhausted` — persist the on-disk
+///   force-clear report (the full response text + row metadata; a write
+///   failure WARNs but never blocks the clear), termination audit (when the
+///   row carries a `session_key`), the legacy missing-session handoff WARN
+///   (unless the branch already emitted one), a structured WARN that ALWAYS
+///   fires, then finish the mailbox (existing entries only) and clear the
+///   inflight row.
+/// * `PreserveAndCount` — persist `recovery_relay_attempts + 1` through
+///   [`inflight::budget::bump_recovery_relay_attempts_if_matches_identity`],
+///   which preserves restart/rebind markers on the carrier row (the #3297
+///   finding-1 fix) while still refusing rows owned by a different turn, and
 ///   WARN with the attempt budget so the loop is observable.
 /// * `FinishAndClear` is the caller's delivered epilogue — a no-op here.
 #[allow(clippy::too_many_arguments)]
@@ -120,6 +153,30 @@ async fn apply_undeliverable_relay_disposition(
         RowDisposition::ClearPermanent | RowDisposition::ClearBudgetExhausted => {
             let reason_code = disposition_reason_code(disposition)
                 .expect("clearing dispositions always carry a reason code");
+            // #3297 finding 3: preserve the full response + row metadata on
+            // disk BEFORE the row is destroyed. Failure to write must not
+            // block the clear (the loop must still terminate) but is WARNed.
+            let report = RecoveryForceClearReport::from_state(
+                provider,
+                state,
+                branch,
+                reason_code,
+                best_response,
+            );
+            let report_path = match persist_force_clear_report(&report) {
+                Ok(path) => Some(path),
+                Err(error) => {
+                    tracing::warn!(
+                        provider = %provider.as_str(),
+                        channel = state.channel_id,
+                        reason_code,
+                        error = %error,
+                        "recovery force-clear report write FAILED — clearing anyway; \
+                         full response text is NOT preserved on disk for this row"
+                    );
+                    None
+                }
+            };
             if let Some(ref session_key) = state.session_key {
                 crate::services::termination_audit::record_termination_with_handles(
                     None::<&crate::db::Db>,
@@ -137,6 +194,7 @@ async fn apply_undeliverable_relay_disposition(
             if !handoff_already_saved {
                 save_missing_session_handoff(provider, state, best_response);
             }
+            let report_path_display = report_path.as_ref().map(|path| path.display().to_string());
             tracing::warn!(
                 provider = %provider.as_str(),
                 channel = state.channel_id,
@@ -145,6 +203,7 @@ async fn apply_undeliverable_relay_disposition(
                 reason_code,
                 attempts = state.recovery_relay_attempts,
                 budget = inflight::RECOVERY_RELAY_RESTART_ATTEMPT_BUDGET,
+                report_path = report_path_display.as_deref(),
                 "recovery relay unrecoverable — force-clearing inflight row"
             );
             finish_recovered_turn_mailbox_if_registered(
@@ -157,11 +216,13 @@ async fn apply_undeliverable_relay_disposition(
             inflight::clear_inflight_state(provider, state.channel_id);
         }
         RowDisposition::PreserveAndCount => {
-            let mut updated = state.clone();
-            updated.recovery_relay_attempts = state.recovery_relay_attempts.saturating_add(1);
             let identity = inflight::InflightTurnIdentity::from_state(state);
-            let save_outcome = inflight::save_inflight_state_if_matches_identity(
-                &updated,
+            // #3297 finding 1: the carrier row is restart-marked on every
+            // boot, so the counter must persist through a bump that PRESERVES
+            // the marker instead of the generic guarded save that refuses it.
+            let save_outcome = inflight::budget::bump_recovery_relay_attempts_if_matches_identity(
+                provider,
+                state.channel_id,
                 &identity,
                 state.turn_start_offset,
             );
@@ -169,11 +230,191 @@ async fn apply_undeliverable_relay_disposition(
                 provider = %provider.as_str(),
                 channel = state.channel_id,
                 branch,
-                attempts = updated.recovery_relay_attempts,
+                attempts = state.recovery_relay_attempts.saturating_add(1),
                 budget = inflight::RECOVERY_RELAY_RESTART_ATTEMPT_BUDGET,
                 counter_persisted = matches!(save_outcome, inflight::GuardedSaveOutcome::Saved),
                 "recovery relay failed — preserving inflight for retry on next restart"
             );
         }
+    }
+}
+
+const FORCE_CLEAR_REPORT_VERSION: u32 = 1;
+
+/// #3297 finding 3: the durable artifact a recovery force-clear leaves
+/// behind. Written to `runtime/discord_recovery_force_clear/<provider>/`
+/// immediately before the inflight row is destroyed, so the full assistant
+/// response and enough row metadata to re-deliver it by hand survive even a
+/// misclassified clear (e.g. a transient 403 surge read as permanent).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(in crate::services::discord) struct RecoveryForceClearReport {
+    pub version: u32,
+    pub provider: String,
+    pub channel_id: u64,
+    pub user_msg_id: u64,
+    pub current_msg_id: u64,
+    pub session_key: Option<String>,
+    pub dispatch_id: Option<String>,
+    pub tmux_session_name: Option<String>,
+    pub branch: String,
+    pub reason_code: String,
+    pub attempts: u32,
+    pub budget: u32,
+    pub started_at: String,
+    pub cleared_at: String,
+    /// The FULL recovered response text (best of extracted output and the
+    /// row's accumulated `full_response`) — never truncated.
+    pub full_response: String,
+}
+
+impl RecoveryForceClearReport {
+    fn from_state(
+        provider: &ProviderKind,
+        state: &inflight::InflightTurnState,
+        branch: &str,
+        reason_code: &str,
+        best_response: &str,
+    ) -> Self {
+        Self {
+            version: FORCE_CLEAR_REPORT_VERSION,
+            provider: provider.as_str().to_string(),
+            channel_id: state.channel_id,
+            user_msg_id: state.user_msg_id,
+            current_msg_id: state.current_msg_id,
+            session_key: state.session_key.clone(),
+            dispatch_id: state.dispatch_id.clone(),
+            tmux_session_name: state.tmux_session_name.clone(),
+            branch: branch.to_string(),
+            reason_code: reason_code.to_string(),
+            attempts: state.recovery_relay_attempts,
+            budget: inflight::RECOVERY_RELAY_RESTART_ATTEMPT_BUDGET,
+            started_at: state.started_at.clone(),
+            cleared_at: chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
+            full_response: best_response.to_string(),
+        }
+    }
+}
+
+/// Persist a [`RecoveryForceClearReport`] under the process runtime root.
+/// File names carry a nanosecond suffix so repeated clears of the same
+/// channel never overwrite an earlier artifact.
+fn persist_force_clear_report(report: &RecoveryForceClearReport) -> Result<PathBuf, String> {
+    let Some(root) = discord_recovery_force_clear_root() else {
+        return Err("runtime root not resolvable".to_string());
+    };
+    persist_force_clear_report_in_root(&root, report)
+}
+
+/// Root-explicit inner form for unit tests.
+fn persist_force_clear_report_in_root(
+    root: &Path,
+    report: &RecoveryForceClearReport,
+) -> Result<PathBuf, String> {
+    let dir = root.join(&report.provider);
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let path = dir.join(format!(
+        "{}-{}-{nanos}.json",
+        report.channel_id, report.reason_code
+    ));
+    let json = serde_json::to_string_pretty(report).map_err(|e| e.to_string())?;
+    atomic_write(&path, &json)?;
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    //! #3297 finding-3 red-green: a force-clear must leave a real on-disk
+    //! artifact carrying the FULL response text (the prior implementation
+    //! only WARN-logged a 160-char tail and wrote nothing).
+    use tempfile::TempDir;
+
+    use super::super::super::inflight::InflightTurnState;
+    use super::{RecoveryForceClearReport, persist_force_clear_report_in_root};
+    use crate::services::provider::ProviderKind;
+
+    fn make_state(channel_id: u64) -> InflightTurnState {
+        let mut state = InflightTurnState::new(
+            ProviderKind::Codex,
+            channel_id,
+            Some("adk-cdx".to_string()),
+            7,
+            42,
+            43,
+            "hello".to_string(),
+            Some("session-3293".to_string()),
+            Some(format!("AgentDesk-codex-adk-cdx-{channel_id}")),
+            Some("/tmp/out.jsonl".to_string()),
+            Some("/tmp/in.fifo".to_string()),
+            0,
+        );
+        state.session_key = Some("sk-3293".to_string());
+        state.dispatch_id = Some("disp-3293".to_string());
+        state.recovery_relay_attempts = 2;
+        state
+    }
+
+    #[test]
+    fn force_clear_report_preserves_full_response_and_metadata_on_disk() {
+        let temp = TempDir::new().unwrap();
+        let state = make_state(932_951);
+        // Long enough that the legacy 160-char WARN tail provably truncates.
+        let full_response = "A".repeat(4000) + " — final answer body";
+        let report = RecoveryForceClearReport::from_state(
+            &ProviderKind::Codex,
+            &state,
+            "missing_tmux",
+            "recovery_retry_budget_exhausted",
+            &full_response,
+        );
+
+        let path = persist_force_clear_report_in_root(temp.path(), &report)
+            .expect("force-clear report must be written to disk");
+        assert!(path.starts_with(temp.path().join("codex")));
+
+        let written = std::fs::read_to_string(&path).expect("artifact must exist on disk");
+        let parsed: RecoveryForceClearReport =
+            serde_json::from_str(&written).expect("artifact must round-trip");
+        assert_eq!(
+            parsed.full_response, full_response,
+            "FULL text, no truncation"
+        );
+        assert_eq!(parsed.channel_id, 932_951);
+        assert_eq!(parsed.session_key.as_deref(), Some("sk-3293"));
+        assert_eq!(parsed.dispatch_id.as_deref(), Some("disp-3293"));
+        assert_eq!(parsed.reason_code, "recovery_retry_budget_exhausted");
+        assert_eq!(parsed.branch, "missing_tmux");
+        assert_eq!(parsed.attempts, 2);
+        assert_eq!(
+            parsed.tmux_session_name.as_deref(),
+            Some("AgentDesk-codex-adk-cdx-932951")
+        );
+    }
+
+    #[test]
+    fn repeated_force_clears_never_overwrite_earlier_artifacts() {
+        let temp = TempDir::new().unwrap();
+        let state = make_state(932_952);
+        let first = RecoveryForceClearReport::from_state(
+            &ProviderKind::Codex,
+            &state,
+            "missing_tmux",
+            "recovery_permanent_relay_failure",
+            "first response",
+        );
+        let second = RecoveryForceClearReport::from_state(
+            &ProviderKind::Codex,
+            &state,
+            "missing_tmux",
+            "recovery_permanent_relay_failure",
+            "second response",
+        );
+        let path_a = persist_force_clear_report_in_root(temp.path(), &first).unwrap();
+        let path_b = persist_force_clear_report_in_root(temp.path(), &second).unwrap();
+        assert_ne!(path_a, path_b, "artifacts must be uniquely named");
+        assert!(path_a.exists() && path_b.exists());
     }
 }

--- a/src/services/discord/recovery_paths/restart.rs
+++ b/src/services/discord/recovery_paths/restart.rs
@@ -1,0 +1,179 @@
+//! Restart-path helpers (issue #1074 landing zone; first occupant: #3293).
+//!
+//! Hosts the side-effecting epilogue for the boot-time recovery branches in
+//! `recovery_engine::restore_inflight_turns` whose terminal relay to Discord
+//! did NOT deliver. The pure decision matrix lives in [`super::shared`]; this
+//! module executes the chosen [`RowDisposition`] with the no-silent-delete
+//! guarantees from the #3293 design (handoff + audit + structured WARN on
+//! every force-clear, identity-guarded counter persistence on preserve).
+
+use std::sync::Arc;
+
+use poise::serenity_prelude::ChannelId;
+
+use super::super::recovery_engine::{finish_recovered_turn_mailbox, save_missing_session_handoff};
+use super::super::{SharedData, inflight};
+use super::shared::{
+    RecoveryRelayOutcome, RowDisposition, disposition_reason_code, unrecoverable_relay_disposition,
+};
+use crate::services::provider::ProviderKind;
+use crate::services::turn_orchestrator::ChannelMailboxRegistry;
+
+/// #3293 (c): finish the recovered turn's mailbox ONLY when a registry entry
+/// already exists. `finish_recovered_turn_mailbox` routes through the turn
+/// finalizer, whose channel-scoped resolution mints a mailbox actor on first
+/// touch — on a force-clear of a row for a non-existent (bogus) channel that
+/// would re-pollute the registry with a permanent entry. Peek, never create.
+pub(in crate::services::discord) async fn finish_recovered_turn_mailbox_if_registered(
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    stop_source: &'static str,
+) {
+    let registered = shared.mailbox_peek(channel_id).is_some()
+        || ChannelMailboxRegistry::global_handle(channel_id).is_some();
+    if !registered {
+        tracing::debug!(
+            provider = %provider.as_str(),
+            channel = channel_id.get(),
+            stop_source,
+            "recovery force-clear: no mailbox registry entry — skipping finish to avoid creating one"
+        );
+        return;
+    }
+    finish_recovered_turn_mailbox(shared, provider, channel_id, stop_source).await;
+}
+
+/// #3293: shared epilogue for the five recovery notice branches. Computes the
+/// [`RowDisposition`] from the relay `outcome` and executes it:
+///
+/// * `FinishAndClear` (delivered) — the branch's historical epilogue:
+///   `finish_recovered_turn_mailbox(finish_stop_source)` + clear.
+/// * everything else — [`apply_undeliverable_relay_disposition`].
+#[allow(clippy::too_many_arguments)]
+pub(in crate::services::discord) async fn dispose_recovery_relay_outcome(
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    state: &inflight::InflightTurnState,
+    outcome: RecoveryRelayOutcome,
+    tmux_alive: bool,
+    finish_stop_source: &'static str,
+    branch: &'static str,
+    best_response: &str,
+    handoff_already_saved: bool,
+) {
+    match unrecoverable_relay_disposition(
+        outcome,
+        state.recovery_relay_attempts,
+        inflight::RECOVERY_RELAY_RESTART_ATTEMPT_BUDGET,
+        tmux_alive,
+    ) {
+        RowDisposition::FinishAndClear => {
+            finish_recovered_turn_mailbox(
+                shared,
+                provider,
+                ChannelId::new(state.channel_id),
+                finish_stop_source,
+            )
+            .await;
+            inflight::clear_inflight_state(provider, state.channel_id);
+        }
+        disposition => {
+            apply_undeliverable_relay_disposition(
+                shared,
+                provider,
+                state,
+                disposition,
+                branch,
+                tmux_alive,
+                best_response,
+                handoff_already_saved,
+            )
+            .await;
+        }
+    }
+}
+
+/// Execute a non-`Delivered` [`RowDisposition`] for a recovery branch.
+///
+/// * `ClearPermanent` / `ClearBudgetExhausted` — termination audit (when the
+///   row carries a `session_key`), missing-session handoff (unless the branch
+///   already saved one), a structured WARN that ALWAYS fires, then finish the
+///   mailbox (existing entries only) and clear the inflight row.
+/// * `PreserveAndCount` — persist `recovery_relay_attempts + 1` through the
+///   identity-guarded save (never clobbers a newer turn / restart marker) and
+///   WARN with the attempt budget so the loop is observable.
+/// * `FinishAndClear` is the caller's delivered epilogue — a no-op here.
+#[allow(clippy::too_many_arguments)]
+async fn apply_undeliverable_relay_disposition(
+    shared: &Arc<SharedData>,
+    provider: &ProviderKind,
+    state: &inflight::InflightTurnState,
+    disposition: RowDisposition,
+    branch: &'static str,
+    tmux_alive: bool,
+    best_response: &str,
+    handoff_already_saved: bool,
+) {
+    match disposition {
+        RowDisposition::FinishAndClear => {}
+        RowDisposition::ClearPermanent | RowDisposition::ClearBudgetExhausted => {
+            let reason_code = disposition_reason_code(disposition)
+                .expect("clearing dispositions always carry a reason code");
+            if let Some(ref session_key) = state.session_key {
+                crate::services::termination_audit::record_termination_with_handles(
+                    None::<&crate::db::Db>,
+                    shared.pg_pool.as_ref(),
+                    session_key,
+                    state.dispatch_id.as_deref(),
+                    "recovery",
+                    reason_code,
+                    Some("recovery terminal relay unrecoverable; inflight force-cleared"),
+                    None,
+                    Some(state.last_offset),
+                    Some(tmux_alive),
+                );
+            }
+            if !handoff_already_saved {
+                save_missing_session_handoff(provider, state, best_response);
+            }
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel = state.channel_id,
+                user_msg_id = state.user_msg_id,
+                branch,
+                reason_code,
+                attempts = state.recovery_relay_attempts,
+                budget = inflight::RECOVERY_RELAY_RESTART_ATTEMPT_BUDGET,
+                "recovery relay unrecoverable — force-clearing inflight row"
+            );
+            finish_recovered_turn_mailbox_if_registered(
+                shared,
+                provider,
+                ChannelId::new(state.channel_id),
+                reason_code,
+            )
+            .await;
+            inflight::clear_inflight_state(provider, state.channel_id);
+        }
+        RowDisposition::PreserveAndCount => {
+            let mut updated = state.clone();
+            updated.recovery_relay_attempts = state.recovery_relay_attempts.saturating_add(1);
+            let identity = inflight::InflightTurnIdentity::from_state(state);
+            let save_outcome = inflight::save_inflight_state_if_matches_identity(
+                &updated,
+                &identity,
+                state.turn_start_offset,
+            );
+            tracing::warn!(
+                provider = %provider.as_str(),
+                channel = state.channel_id,
+                branch,
+                attempts = updated.recovery_relay_attempts,
+                budget = inflight::RECOVERY_RELAY_RESTART_ATTEMPT_BUDGET,
+                counter_persisted = matches!(save_outcome, inflight::GuardedSaveOutcome::Saved),
+                "recovery relay failed — preserving inflight for retry on next restart"
+            );
+        }
+    }
+}

--- a/src/services/discord/recovery_paths/shared.rs
+++ b/src/services/discord/recovery_paths/shared.rs
@@ -11,3 +11,259 @@
 //!   - explicitly documented as the canonical owner.
 //!
 //! See `docs/recovery-paths.md` for the path contract.
+
+/// #3293: outcome of relaying a recovered terminal text/notice to Discord.
+///
+/// Replaces the prior `bool` so the restart path can distinguish a Discord
+/// "this destination is permanently gone" verdict (HTTP 404/403/410, the
+/// `placeholder_sweeper::is_permanent_message_gone_status` allowlist) from a
+/// transient failure (5xx / 429 / network, where retrying is correct).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::services::discord) enum RecoveryRelayOutcome {
+    /// The assistant response actually reached Discord.
+    Delivered,
+    /// Discord said the channel/message can never come back (404/403/410).
+    /// Retrying on every future boot would WARN-loop forever.
+    PermanentFailure,
+    /// Anything else: no HTTP status, 5xx, 429 rate-limit, transport error.
+    /// Must stay retryable — never escalate these to a destructive verdict.
+    TransientFailure,
+}
+
+impl RecoveryRelayOutcome {
+    /// Adapter for the pre-#3293 `bool` call sites (dispatch-flow branches):
+    /// `true` only when the response actually reached Discord.
+    pub(in crate::services::discord) fn delivered(self) -> bool {
+        matches!(self, RecoveryRelayOutcome::Delivered)
+    }
+}
+
+/// Status-code half of the relay-error classification, split out (same
+/// pattern as `placeholder_sweeper::is_permanent_message_gone_status`) so it
+/// can be table-tested without constructing the `#[non_exhaustive]`
+/// `serenity::http::ErrorResponse`.
+pub(in crate::services::discord) fn classify_recovery_relay_status(
+    status: Option<u16>,
+) -> RecoveryRelayOutcome {
+    match status {
+        Some(code) if super::super::placeholder_sweeper::is_permanent_message_gone_status(code) => {
+            RecoveryRelayOutcome::PermanentFailure
+        }
+        _ => RecoveryRelayOutcome::TransientFailure,
+    }
+}
+
+/// Classify a boxed relay error (`formatting::replace_long_message_raw` /
+/// `send_long_message_raw` return `Box<dyn Error>`): walk the source chain
+/// for a `serenity::Error::Http` carrying a status code and feed it through
+/// the conservative allowlist above. Anything unrecognized is transient.
+pub(in crate::services::discord) fn classify_recovery_relay_error(
+    error: &(dyn std::error::Error + 'static),
+) -> RecoveryRelayOutcome {
+    let mut current: Option<&(dyn std::error::Error + 'static)> = Some(error);
+    while let Some(err) = current {
+        if let Some(poise::serenity_prelude::Error::Http(http_err)) =
+            err.downcast_ref::<poise::serenity_prelude::Error>()
+        {
+            return classify_recovery_relay_status(
+                http_err.status_code().map(|status| status.as_u16()),
+            );
+        }
+        current = err.source();
+    }
+    RecoveryRelayOutcome::TransientFailure
+}
+
+/// #3293: what the restart path should do with the on-disk inflight row after
+/// a terminal-relay attempt. Pure decision so the safety matrix is testable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::services::discord) enum RowDisposition {
+    /// Relay delivered — run the branch's normal finish + clear epilogue.
+    FinishAndClear,
+    /// Discord permanently rejected the destination — force-clear now (with
+    /// handoff + audit) regardless of the attempt counter.
+    ClearPermanent,
+    /// Transient failures exhausted the restart budget on a row whose tmux is
+    /// already confirmed gone — force-clear (with handoff + audit).
+    ClearBudgetExhausted,
+    /// Preserve the row for the next boot and persist `attempts + 1`.
+    PreserveAndCount,
+}
+
+/// Decision matrix for the post-relay row disposition.
+///
+/// `attempts` is the row's persisted `recovery_relay_attempts` BEFORE this
+/// boot's failure is counted, so the budget trips when `attempts + 1 >=
+/// budget`. `tmux_alive == true` (the ready-without-output branch) must NEVER
+/// budget-clear: a live pane can still produce/own the answer (#1446 /
+/// 2026-05-26 incident class) — only a permanent Discord verdict may clear it.
+pub(in crate::services::discord) fn unrecoverable_relay_disposition(
+    outcome: RecoveryRelayOutcome,
+    attempts: u32,
+    budget: u32,
+    tmux_alive: bool,
+) -> RowDisposition {
+    match outcome {
+        RecoveryRelayOutcome::Delivered => RowDisposition::FinishAndClear,
+        RecoveryRelayOutcome::PermanentFailure => RowDisposition::ClearPermanent,
+        RecoveryRelayOutcome::TransientFailure => {
+            if !tmux_alive && attempts.saturating_add(1) >= budget {
+                RowDisposition::ClearBudgetExhausted
+            } else {
+                RowDisposition::PreserveAndCount
+            }
+        }
+    }
+}
+
+/// `termination_audit` reason code for a force-clear disposition; `None` for
+/// the non-clearing dispositions. Extracted so the wire-visible codes are
+/// pinned by tests (the audit insert itself is skipped when PG is absent).
+pub(in crate::services::discord) fn disposition_reason_code(
+    disposition: RowDisposition,
+) -> Option<&'static str> {
+    match disposition {
+        RowDisposition::ClearPermanent => Some("recovery_permanent_relay_failure"),
+        RowDisposition::ClearBudgetExhausted => Some("recovery_retry_budget_exhausted"),
+        RowDisposition::FinishAndClear | RowDisposition::PreserveAndCount => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        RecoveryRelayOutcome, RowDisposition, classify_recovery_relay_status,
+        disposition_reason_code, unrecoverable_relay_disposition,
+    };
+
+    const BUDGET: u32 = crate::services::discord::inflight::RECOVERY_RELAY_RESTART_ATTEMPT_BUDGET;
+
+    #[test]
+    fn classify_status_treats_message_gone_codes_as_permanent() {
+        for code in [404, 403, 410] {
+            assert_eq!(
+                classify_recovery_relay_status(Some(code)),
+                RecoveryRelayOutcome::PermanentFailure,
+                "status {code} must be a permanent relay failure"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_status_keeps_everything_else_transient() {
+        // 429 rate-limit, 5xx, odd client errors, and "no status at all"
+        // (gateway not connected / transport error) must all stay retryable.
+        for code in [400, 401, 408, 429, 500, 502, 503, 504] {
+            assert_eq!(
+                classify_recovery_relay_status(Some(code)),
+                RecoveryRelayOutcome::TransientFailure,
+                "status {code} must stay transient"
+            );
+        }
+        assert_eq!(
+            classify_recovery_relay_status(None),
+            RecoveryRelayOutcome::TransientFailure
+        );
+    }
+
+    #[test]
+    fn delivered_adapter_matches_legacy_bool_contract() {
+        assert!(RecoveryRelayOutcome::Delivered.delivered());
+        assert!(!RecoveryRelayOutcome::PermanentFailure.delivered());
+        assert!(!RecoveryRelayOutcome::TransientFailure.delivered());
+    }
+
+    #[test]
+    fn delivered_outcome_always_finishes_and_clears() {
+        for (attempts, tmux_alive) in [(0, false), (99, false), (0, true), (99, true)] {
+            assert_eq!(
+                unrecoverable_relay_disposition(
+                    RecoveryRelayOutcome::Delivered,
+                    attempts,
+                    BUDGET,
+                    tmux_alive
+                ),
+                RowDisposition::FinishAndClear
+            );
+        }
+    }
+
+    #[test]
+    fn permanent_failure_clears_immediately_regardless_of_attempts() {
+        for (attempts, tmux_alive) in [(0, false), (0, true), (99, false)] {
+            assert_eq!(
+                unrecoverable_relay_disposition(
+                    RecoveryRelayOutcome::PermanentFailure,
+                    attempts,
+                    BUDGET,
+                    tmux_alive
+                ),
+                RowDisposition::ClearPermanent
+            );
+        }
+    }
+
+    #[test]
+    fn transient_failure_counts_until_budget_then_clears_when_tmux_gone() {
+        for attempts in 0..(BUDGET - 1) {
+            assert_eq!(
+                unrecoverable_relay_disposition(
+                    RecoveryRelayOutcome::TransientFailure,
+                    attempts,
+                    BUDGET,
+                    false
+                ),
+                RowDisposition::PreserveAndCount,
+                "attempt {attempts} must still preserve the row"
+            );
+        }
+        assert_eq!(
+            unrecoverable_relay_disposition(
+                RecoveryRelayOutcome::TransientFailure,
+                BUDGET - 1,
+                BUDGET,
+                false
+            ),
+            RowDisposition::ClearBudgetExhausted,
+            "the budget'th failed restart must force-clear a tmux-gone row"
+        );
+    }
+
+    #[test]
+    fn pane_alive_row_is_never_budget_cleared() {
+        // Adversarial scenario 1: repeated deploys during a Discord outage
+        // with a live pane — even an absurd attempt count must preserve.
+        for attempts in [0, BUDGET - 1, BUDGET, 99] {
+            assert_eq!(
+                unrecoverable_relay_disposition(
+                    RecoveryRelayOutcome::TransientFailure,
+                    attempts,
+                    BUDGET,
+                    true
+                ),
+                RowDisposition::PreserveAndCount,
+                "pane-alive row must never be budget-cleared (attempts={attempts})"
+            );
+        }
+    }
+
+    #[test]
+    fn audit_reason_codes_are_pinned_for_clearing_dispositions() {
+        assert_eq!(
+            disposition_reason_code(RowDisposition::ClearPermanent),
+            Some("recovery_permanent_relay_failure")
+        );
+        assert_eq!(
+            disposition_reason_code(RowDisposition::ClearBudgetExhausted),
+            Some("recovery_retry_budget_exhausted")
+        );
+        assert_eq!(
+            disposition_reason_code(RowDisposition::FinishAndClear),
+            None
+        );
+        assert_eq!(
+            disposition_reason_code(RowDisposition::PreserveAndCount),
+            None
+        );
+    }
+}

--- a/src/services/discord/recovery_paths/shared.rs
+++ b/src/services/discord/recovery_paths/shared.rs
@@ -74,6 +74,61 @@ pub(in crate::services::discord) fn classify_recovery_relay_error(
     RecoveryRelayOutcome::TransientFailure
 }
 
+/// #3297 finding 2: verdict of the post-failure channel-liveness probe.
+///
+/// The placeholder-anchor relay path (`replace_long_message_raw` →
+/// `send_long_message_raw_with_rollback`) flattens its error chain into
+/// `String`s, so the typed-chain walk above classifies a dead channel's
+/// 404/403/410 as `TransientFailure` and the permanent verdict was
+/// unreachable on the common (anchored) path. Instead of rebuilding the
+/// formatting error chain, callers actively probe the channel with a direct
+/// Discord HTTP `get_channel` AFTER a transient-looking relay failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::services::discord) enum ChannelProbeVerdict {
+    /// The probe itself got an authoritative 404/403/410 for the CHANNEL —
+    /// the destination is permanently gone.
+    Gone,
+    /// The channel exists, or the probe failed transiently (5xx / 429 /
+    /// transport). Conservative: never escalates a relay failure.
+    Inconclusive,
+}
+
+/// Status-code half of the channel probe, sharing the permanent allowlist
+/// with the relay classification so the two can never drift.
+pub(in crate::services::discord) fn classify_channel_probe_status(
+    status: Option<u16>,
+) -> ChannelProbeVerdict {
+    match classify_recovery_relay_status(status) {
+        RecoveryRelayOutcome::PermanentFailure => ChannelProbeVerdict::Gone,
+        _ => ChannelProbeVerdict::Inconclusive,
+    }
+}
+
+/// Second-opinion escalation for an already-classified relay failure. The
+/// probe runs ONLY for a transient classification (a typed permanent verdict
+/// needs no probe; `Delivered` never reaches here), and only an authoritative
+/// [`ChannelProbeVerdict::Gone`] upgrades the outcome — probe failures keep
+/// the conservative transient verdict. The probe is a closure so tests can
+/// inject verdicts without a live Discord client (the #3297 finding-2 test
+/// seam). Takes the pre-classified outcome (not the error) so callers'
+/// futures stay `Send` — `&dyn Error` is not `Sync`.
+pub(in crate::services::discord) async fn escalate_transient_relay_outcome_with_probe<F, Fut>(
+    classified: RecoveryRelayOutcome,
+    probe: F,
+) -> RecoveryRelayOutcome
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = ChannelProbeVerdict>,
+{
+    match classified {
+        RecoveryRelayOutcome::TransientFailure => match probe().await {
+            ChannelProbeVerdict::Gone => RecoveryRelayOutcome::PermanentFailure,
+            ChannelProbeVerdict::Inconclusive => RecoveryRelayOutcome::TransientFailure,
+        },
+        verdict => verdict,
+    }
+}
+
 /// #3293: what the restart path should do with the on-disk inflight row after
 /// a terminal-relay attempt. Pure decision so the safety matrix is testable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -81,10 +136,11 @@ pub(in crate::services::discord) enum RowDisposition {
     /// Relay delivered — run the branch's normal finish + clear epilogue.
     FinishAndClear,
     /// Discord permanently rejected the destination — force-clear now (with
-    /// handoff + audit) regardless of the attempt counter.
+    /// on-disk force-clear report + audit) regardless of the attempt counter.
     ClearPermanent,
     /// Transient failures exhausted the restart budget on a row whose tmux is
-    /// already confirmed gone — force-clear (with handoff + audit).
+    /// already confirmed gone — force-clear (with on-disk force-clear report
+    /// + audit).
     ClearBudgetExhausted,
     /// Preserve the row for the next boot and persist `attempts + 1`.
     PreserveAndCount,
@@ -132,8 +188,9 @@ pub(in crate::services::discord) fn disposition_reason_code(
 #[cfg(test)]
 mod tests {
     use super::{
-        RecoveryRelayOutcome, RowDisposition, classify_recovery_relay_status,
-        disposition_reason_code, unrecoverable_relay_disposition,
+        ChannelProbeVerdict, RecoveryRelayOutcome, RowDisposition, classify_channel_probe_status,
+        classify_recovery_relay_error, classify_recovery_relay_status, disposition_reason_code,
+        escalate_transient_relay_outcome_with_probe, unrecoverable_relay_disposition,
     };
 
     const BUDGET: u32 = crate::services::discord::inflight::RECOVERY_RELAY_RESTART_ATTEMPT_BUDGET;
@@ -163,6 +220,86 @@ mod tests {
         assert_eq!(
             classify_recovery_relay_status(None),
             RecoveryRelayOutcome::TransientFailure
+        );
+    }
+
+    /// #3297 finding-2 red-green: the placeholder-anchor relay path
+    /// (`send_long_message_raw_with_rollback` & co.) flattens the serenity
+    /// 404 into a `String` (`format!(...).into()`), so the typed-chain walk
+    /// alone misclassifies a dead channel as transient (the RED half,
+    /// asserted explicitly). The active channel probe restores the permanent
+    /// verdict (GREEN) — with the probe injected through the test seam.
+    #[tokio::test]
+    async fn string_flattened_error_with_dead_channel_probe_is_permanent() {
+        let flattened: Box<dyn std::error::Error + Send + Sync> =
+            "failed to edit message for replace: 404 Not Found (Unknown Channel)"
+                .to_string()
+                .into();
+        let classified = classify_recovery_relay_error(flattened.as_ref());
+        assert_eq!(
+            classified,
+            RecoveryRelayOutcome::TransientFailure,
+            "RED: the String-flattened chain hides the typed 404 from the chain walk"
+        );
+        assert_eq!(
+            escalate_transient_relay_outcome_with_probe(classified, || async {
+                ChannelProbeVerdict::Gone
+            })
+            .await,
+            RecoveryRelayOutcome::PermanentFailure,
+            "GREEN: a dead-channel probe must upgrade the flattened failure to permanent"
+        );
+    }
+
+    /// Conservative direction: an inconclusive probe (alive channel, probe
+    /// transport error, 5xx, 429) must keep the transient verdict.
+    #[tokio::test]
+    async fn inconclusive_probe_keeps_transient_verdict() {
+        let flattened: Box<dyn std::error::Error + Send + Sync> =
+            "edit failed: connection reset by peer".to_string().into();
+        let classified = classify_recovery_relay_error(flattened.as_ref());
+        assert_eq!(
+            escalate_transient_relay_outcome_with_probe(classified, || async {
+                ChannelProbeVerdict::Inconclusive
+            })
+            .await,
+            RecoveryRelayOutcome::TransientFailure
+        );
+    }
+
+    /// A pre-classified permanent verdict passes through without consulting
+    /// the probe (the closure panics if invoked).
+    #[tokio::test]
+    async fn permanent_classification_skips_the_probe() {
+        assert_eq!(
+            escalate_transient_relay_outcome_with_probe(
+                RecoveryRelayOutcome::PermanentFailure,
+                || async { panic!("probe must not run for a typed permanent verdict") }
+            )
+            .await,
+            RecoveryRelayOutcome::PermanentFailure
+        );
+    }
+
+    #[test]
+    fn probe_status_shares_the_permanent_allowlist() {
+        for code in [404, 403, 410] {
+            assert_eq!(
+                classify_channel_probe_status(Some(code)),
+                ChannelProbeVerdict::Gone,
+                "channel-gone status {code} must be authoritative"
+            );
+        }
+        for code in [200, 400, 401, 408, 429, 500, 502, 503, 504] {
+            assert_eq!(
+                classify_channel_probe_status(Some(code)),
+                ChannelProbeVerdict::Inconclusive,
+                "status {code} must stay inconclusive"
+            );
+        }
+        assert_eq!(
+            classify_channel_probe_status(None),
+            ChannelProbeVerdict::Inconclusive
         );
     }
 

--- a/src/services/discord/router/message_handler/tui_followup.rs
+++ b/src/services/discord/router/message_handler/tui_followup.rs
@@ -17,7 +17,10 @@ pub(super) fn claude_tui_busy_followup_refusal_notice(
         Some(crate::services::turn_orchestrator::EnqueueRefusalReason::LastItemDedup) => {
             CLAUDE_TUI_BUSY_FOLLOWUP_DEDUP_NOTICE
         }
-        Some(crate::services::turn_orchestrator::EnqueueRefusalReason::ActorUnreachable) => {
+        // #3297 r3 — a post-retry purge-tombstone refusal is user-actionable
+        // the same way as an unreachable actor: resend shortly.
+        Some(crate::services::turn_orchestrator::EnqueueRefusalReason::ActorUnreachable)
+        | Some(crate::services::turn_orchestrator::EnqueueRefusalReason::MailboxClosed) => {
             CLAUDE_TUI_BUSY_FOLLOWUP_QUEUE_UNREACHABLE_NOTICE
         }
         None => CLAUDE_TUI_BUSY_FOLLOWUP_NOTICE,

--- a/src/services/discord/runtime_store.rs
+++ b/src/services/discord/runtime_store.rs
@@ -46,6 +46,14 @@ pub(super) fn discord_restart_reports_root() -> Option<PathBuf> {
     runtime_root().map(|root| root.join("discord_restart_reports"))
 }
 
+/// #3293 verify r1 (finding 3): durable preservation of the full assistant
+/// response + row metadata for every recovery force-clear. Kept OUT of
+/// `discord_restart_reports/` because that store is flushed-and-deleted on
+/// boot; these files are operator-recovery artifacts and are never GC'd.
+pub(super) fn discord_recovery_force_clear_root() -> Option<PathBuf> {
+    runtime_root().map(|root| root.join("discord_recovery_force_clear"))
+}
+
 pub(crate) fn discord_pending_queue_root() -> Option<PathBuf> {
     runtime_root().map(|root| root.join("discord_pending_queue"))
 }

--- a/src/services/turn_orchestrator.rs
+++ b/src/services/turn_orchestrator.rs
@@ -12,6 +12,9 @@ use tokio::sync::{Notify, mpsc, oneshot};
 
 use crate::services::provider::{CancelToken, ProviderKind};
 
+// #3293: non-creating registry lookup + operator-gated idle-entry purge.
+pub(crate) mod registry_purge;
+
 pub(crate) const MAX_INTERVENTIONS_PER_CHANNEL: usize = 30;
 pub(crate) const INTERVENTION_DEDUP_WINDOW: Duration = Duration::from_secs(10);
 const STALE_PENDING_QUEUE_TMP_AGE: Duration = Duration::from_secs(60);

--- a/src/services/turn_orchestrator.rs
+++ b/src/services/turn_orchestrator.rs
@@ -852,6 +852,8 @@ pub(crate) struct HasPendingSoftQueueResult {
 
 pub(crate) struct RecoveryKickoffResult {
     pub(crate) activated_turn: bool,
+    /// #3297 r3 — kickoff refused by a purge tombstone (`state.closed`).
+    pub(crate) refused_closed: bool,
 }
 
 pub(crate) struct RestartDrainResult {
@@ -888,6 +890,9 @@ pub(crate) enum EnqueueRefusalReason {
     /// The `ChannelMailboxHandle` could not reach the mailbox actor (mpsc
     /// closed or oneshot dropped). Surfaced only at the handle layer.
     ActorUnreachable,
+    /// #3297 r3 — the resolved actor is purge-tombstoned (`closed`). The
+    /// registry's `enqueue_with_closed_retry` re-resolves a fresh actor.
+    MailboxClosed,
 }
 
 impl EnqueueRefusalReason {
@@ -896,6 +901,7 @@ impl EnqueueRefusalReason {
             EnqueueRefusalReason::SourceIdAlreadyQueued => "source_id_already_queued",
             EnqueueRefusalReason::LastItemDedup => "last_item_dedup",
             EnqueueRefusalReason::ActorUnreachable => "actor_unreachable",
+            EnqueueRefusalReason::MailboxClosed => "mailbox_closed",
         }
     }
 }
@@ -1234,6 +1240,7 @@ impl ChannelMailboxHandle {
             },
             RecoveryKickoffResult {
                 activated_turn: false,
+                refused_closed: false,
             },
         )
         .await
@@ -1815,6 +1822,19 @@ impl ChannelMailboxRegistry {
     }
 }
 
+// #3297 r3 (codex) — tombstone classification, enforced for EVERY arm by
+// `registry_purge::gate_closed_arm` ahead of the actor's match. Once
+// `CloseIfIdle` sets `state.closed` (actor about to be unlinked):
+//  (a) START-LIKE arms — anything that binds an active turn / recovery marker
+//      or accepts NEW work (`TryStartTurn`, `RestoreActiveTurn`,
+//      `RecoveryKickoff`, `Enqueue`) — are REFUSED with that arm's existing
+//      "cannot start" reply (`TryStartTurn` ⇒ `false`); callers re-resolve a
+//      fresh actor via the registry `*_with_closed_retry` helpers and replay.
+//  (b) everything else stays ALLOWED — reads, cancels, finishes, drains, and
+//      queue RESTITUTION (`RequeueFront`/`ReplaceQueue`/hydrate, which
+//      re-persist already-accepted work to disk for a successor actor to
+//      hydrate — refusing those would drop user messages).
+// New arms must be classified here and (if start-like) gated there.
 enum ChannelMailboxMsg {
     Snapshot {
         reply: oneshot::Sender<ChannelMailboxSnapshot>,
@@ -2385,6 +2405,10 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
     tokio::spawn(async move {
         let mut state = ChannelMailboxState::default();
         while let Some(msg) = rx.recv().await {
+            // #3297 r3 — tombstoned actor refuses start-like arms (enum docs).
+            let Some(msg) = registry_purge::gate_closed_arm(&state, msg) else {
+                continue;
+            };
             match msg {
                 ChannelMailboxMsg::Snapshot { reply } => {
                     let _ = reply.send(ChannelMailboxSnapshot {
@@ -2524,35 +2548,13 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                     });
                 }
                 ChannelMailboxMsg::CancelActiveBackgroundTurnIfCurrent { reply } => {
-                    // #3167 — atomic, kind-guarded supersede. ONLY cancel when
-                    // a background turn currently holds the slot; a real
-                    // user/agent turn (or an idle slot) is left untouched. This
-                    // closes the TOCTOU window the previous dequeue gate had: it
-                    // read `active_turn_kind()` and THEN sent a separate
-                    // unguarded `cancel_active_turn_with_reason()`, so between
-                    // the read and the cancel the background turn could finalize
-                    // and a real user turn start — and the cancel would abort
-                    // the real turn. Doing the `is_background` check and the
-                    // cancel flip in one serialized actor step removes that gap.
-                    //
-                    // Cancel semantics mirror `CancelActiveTurnWithReason`
-                    // exactly: set the reason, flip `cancelled`, and leave the
-                    // slot-release to the background turn's own
-                    // identity-guarded finalizer (the slot is NOT cleared here).
-                    //
-                    // #3167 BLOCKER-1 — reply `true` ONLY when this step performs
-                    // a NEW cancel: a background token is present AND it is not
-                    // already cancelled/stopping. If the background token is
-                    // ALREADY cancelling, this is a no-op and we reply `false`.
-                    // Rationale: the mod.rs caller schedules an immediate re-kick
-                    // on `true`. If we replied `true` for an already-cancelling
-                    // slot, each re-kick would re-observe the same already-
-                    // cancelled slot (the finalizer has not released it yet),
-                    // reply `true`, and spawn yet another immediate re-kick — a
-                    // HOT-LOOP/LIVELOCK. On `false` the caller spawns NO new
-                    // re-kick and falls through to the normal dequeue/await path;
-                    // the existing deferred-retry cadence (queue_io.rs, ~2s) waits
-                    // for the background finalizer to release the slot.
+                    // #3167 — atomic kind-guarded supersede: cancel ONLY a
+                    // background-held slot (reason+flip mirror
+                    // `CancelActiveTurnWithReason`; slot release stays with the
+                    // turn's own finalizer). #3167 BLOCKER-1: reply `true` only
+                    // for a NEW cancel — `true` on an already-cancelling slot
+                    // would hot-loop the caller's immediate re-kick. Full
+                    // rationale on the handle + enum variant docs.
                     let is_background_active =
                         state.cancel_token.is_some() && state.active_turn_kind.is_background();
                     let newly_cancelled = if is_background_active {
@@ -2620,33 +2622,29 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                             state.pending_user_dispatch_yield_count = 0;
                         }
                     }
-                    // #3297 r2 — a `closed` (purge-tombstoned) actor must never
-                    // activate a turn: it is (about to be) unlinked from the
-                    // registry, so a started turn would be unreachable.
-                    let started =
-                        if state.closed || state.cancel_token.is_some() || background_yields {
-                            false
-                        } else {
-                            reset_turn_finished_signal(channel_id);
-                            state.cancel_token = Some(cancel_token);
-                            state.active_request_owner = Some(request_owner);
-                            state.active_user_message_id = Some(user_message_id);
-                            // #3167 — record the slot's priority class so the
-                            // dequeue gates can treat a background turn as
-                            // non-blocking.
-                            state.active_turn_kind = turn_kind;
-                            // #3167 BLOCKER-2 — a real (UserOrAgent) turn claiming the
-                            // slot satisfies any reserved dequeue→claim window: clear
-                            // the reservation and reset the valve counter.
-                            if turn_kind == ActiveTurnKind::UserOrAgent {
-                                state.pending_user_dispatch = None;
-                                state.pending_user_dispatch_yield_count = 0;
-                            }
-                            state.recovery_started_at = None;
-                            state.turn_started_at = Some(Utc::now());
-                            reset_watchdog_extension_state(&mut state);
-                            true
-                        };
+                    let started = if state.cancel_token.is_some() || background_yields {
+                        false
+                    } else {
+                        reset_turn_finished_signal(channel_id);
+                        state.cancel_token = Some(cancel_token);
+                        state.active_request_owner = Some(request_owner);
+                        state.active_user_message_id = Some(user_message_id);
+                        // #3167 — record the slot's priority class so the
+                        // dequeue gates can treat a background turn as
+                        // non-blocking.
+                        state.active_turn_kind = turn_kind;
+                        // #3167 BLOCKER-2 — a real (UserOrAgent) turn claiming the
+                        // slot satisfies any reserved dequeue→claim window: clear
+                        // the reservation and reset the valve counter.
+                        if turn_kind == ActiveTurnKind::UserOrAgent {
+                            state.pending_user_dispatch = None;
+                            state.pending_user_dispatch_yield_count = 0;
+                        }
+                        state.recovery_started_at = None;
+                        state.turn_started_at = Some(Utc::now());
+                        reset_watchdog_extension_state(&mut state);
+                        true
+                    };
                     let _ = reply.send(started);
                 }
                 ChannelMailboxMsg::RestoreActiveTurn {
@@ -2687,7 +2685,10 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                         state.turn_started_at = Some(Utc::now());
                     }
                     reset_watchdog_extension_state(&mut state);
-                    let _ = reply.send(RecoveryKickoffResult { activated_turn });
+                    let _ = reply.send(RecoveryKickoffResult {
+                        activated_turn,
+                        refused_closed: false,
+                    });
                 }
                 ChannelMailboxMsg::ClearRecoveryMarker { reply } => {
                     state.recovery_started_at = None;

--- a/src/services/turn_orchestrator.rs
+++ b/src/services/turn_orchestrator.rs
@@ -2417,21 +2417,10 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                 }
                 ChannelMailboxMsg::CancelActiveTurnWithReason { reason, reply } => {
                     // #2374 — atomic, actor-serialized "reason then flip"
-                    // for the active turn. The previous design (#2373)
-                    // wrote `cancel_source` from the caller task BEFORE
-                    // sending the actor a `CancelActiveTurn`. That kept
-                    // the writes ordered for the common path but two
-                    // concurrent cancellers could both observe the same
-                    // pre-flip token, race on `set_cancel_source`, then
-                    // have the actor flip `cancelled` on whichever
-                    // message it dequeued first — losing one of the
-                    // reasons. By owning the reason write here, the
-                    // mailbox actor serializes both writes per channel.
-                    //
-                    // Existing-cancellation guard mirrors #2373: do NOT
-                    // overwrite a reason once `cancelled` is set so
-                    // earlier attribution (e.g. a watchdog timeout that
-                    // already fired) wins over a later voice cancel.
+                    // (full race rationale on the
+                    // `cancel_active_turn_with_reason` handle doc). Guard
+                    // mirrors #2373: never overwrite a reason once
+                    // `cancelled` is set — earlier attribution wins.
                     let token = state.cancel_token.clone();
                     let already_stopping = token.as_ref().is_some_and(|token| {
                         token.cancelled.load(std::sync::atomic::Ordering::Relaxed)
@@ -2505,17 +2494,11 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                     reason,
                     reply,
                 } => {
-                    // #2374 Codex round-1 fix (HIGH-1): only cancel
-                    // when the active turn's `user_message_id` matches
-                    // the caller's expected handoff message id. The
-                    // tombstone retry path uses this so a still-later
-                    // cancel for the same handoff cannot accidentally
-                    // kill an unrelated turn that happened to start on
-                    // the same target channel after the original
-                    // handoff turn finalized. The actor performs the
-                    // identity check + cancel as a single serialized
-                    // step so no concurrent caller can swap the active
-                    // turn between the check and the flip.
+                    // #2374 Codex round-1 fix (HIGH-1): identity check +
+                    // cancel as one serialized step, keyed by
+                    // `user_message_id` (full rationale on the
+                    // `cancel_active_turn_if_user_message_with_reason`
+                    // handle doc).
                     let identity_matches = state
                         .active_user_message_id
                         .is_some_and(|id| id == expected_user_message_id);

--- a/src/services/turn_orchestrator.rs
+++ b/src/services/turn_orchestrator.rs
@@ -1990,6 +1990,12 @@ enum ChannelMailboxMsg {
     ClearTimeoutOverride {
         reply: oneshot::Sender<()>,
     },
+    /// #3297 r2 (codex) — registry purge: verify idleness and set the `closed`
+    /// tombstone in ONE serialized actor step, closing the snapshot→unlink
+    /// TOCTOU race. Full rationale + verdict logic live in `registry_purge.rs`.
+    CloseIfIdle {
+        reply: oneshot::Sender<Result<(), &'static str>>,
+    },
 }
 
 /// #3167 — priority class of the mailbox active-turn slot. Lets the external-input
@@ -2051,6 +2057,8 @@ struct ChannelMailboxState {
     pending_user_dispatch_yield_count: u32,
     last_persistence: Option<QueuePersistenceContext>,
     recovery_started_at: Option<Instant>,
+    /// #3297 r2 — purge tombstone set by `CloseIfIdle`; see `registry_purge.rs`.
+    closed: bool,
     /// #1031: see `ChannelMailboxSnapshot::turn_started_at`. Mirrors the
     /// `cancel_token.is_some()` lifetime so the idle-detector freshness
     /// anchor is always source-of-truth from the mailbox actor itself.
@@ -2629,29 +2637,33 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                             state.pending_user_dispatch_yield_count = 0;
                         }
                     }
-                    let started = if state.cancel_token.is_some() || background_yields {
-                        false
-                    } else {
-                        reset_turn_finished_signal(channel_id);
-                        state.cancel_token = Some(cancel_token);
-                        state.active_request_owner = Some(request_owner);
-                        state.active_user_message_id = Some(user_message_id);
-                        // #3167 — record the slot's priority class so the
-                        // dequeue gates can treat a background turn as
-                        // non-blocking.
-                        state.active_turn_kind = turn_kind;
-                        // #3167 BLOCKER-2 — a real (UserOrAgent) turn claiming the
-                        // slot satisfies any reserved dequeue→claim window: clear
-                        // the reservation and reset the valve counter.
-                        if turn_kind == ActiveTurnKind::UserOrAgent {
-                            state.pending_user_dispatch = None;
-                            state.pending_user_dispatch_yield_count = 0;
-                        }
-                        state.recovery_started_at = None;
-                        state.turn_started_at = Some(Utc::now());
-                        reset_watchdog_extension_state(&mut state);
-                        true
-                    };
+                    // #3297 r2 — a `closed` (purge-tombstoned) actor must never
+                    // activate a turn: it is (about to be) unlinked from the
+                    // registry, so a started turn would be unreachable.
+                    let started =
+                        if state.closed || state.cancel_token.is_some() || background_yields {
+                            false
+                        } else {
+                            reset_turn_finished_signal(channel_id);
+                            state.cancel_token = Some(cancel_token);
+                            state.active_request_owner = Some(request_owner);
+                            state.active_user_message_id = Some(user_message_id);
+                            // #3167 — record the slot's priority class so the
+                            // dequeue gates can treat a background turn as
+                            // non-blocking.
+                            state.active_turn_kind = turn_kind;
+                            // #3167 BLOCKER-2 — a real (UserOrAgent) turn claiming the
+                            // slot satisfies any reserved dequeue→claim window: clear
+                            // the reservation and reset the valve counter.
+                            if turn_kind == ActiveTurnKind::UserOrAgent {
+                                state.pending_user_dispatch = None;
+                                state.pending_user_dispatch_yield_count = 0;
+                            }
+                            state.recovery_started_at = None;
+                            state.turn_started_at = Some(Utc::now());
+                            reset_watchdog_extension_state(&mut state);
+                            true
+                        };
                     let _ = reply.send(started);
                 }
                 ChannelMailboxMsg::RestoreActiveTurn {
@@ -3117,6 +3129,9 @@ fn spawn_channel_mailbox(channel_id: ChannelId) -> ChannelMailboxHandle {
                 ChannelMailboxMsg::ClearTimeoutOverride { reply } => {
                     state.watchdog_deadline_override = None;
                     let _ = reply.send(());
+                }
+                ChannelMailboxMsg::CloseIfIdle { reply } => {
+                    let _ = reply.send(registry_purge::close_if_idle_verdict(&mut state));
                 }
             }
         }

--- a/src/services/turn_orchestrator/registry_purge.rs
+++ b/src/services/turn_orchestrator/registry_purge.rs
@@ -1,0 +1,178 @@
+//! #3293 (c): channel-mailbox registry hygiene.
+//!
+//! Two additions, kept out of the (ratchet-frozen) `turn_orchestrator.rs`
+//! module root:
+//!
+//! * [`ChannelMailboxRegistry::peek`] — a NON-creating lookup. Health/repair
+//!   probes previously used `handle()`, which mints a permanent mailbox actor
+//!   + registry entry for every probed channel id, so a probe against a
+//!   non-existent (bogus) channel polluted the registry forever.
+//! * [`ChannelMailboxRegistry::remove_idle_entry`] — operator-gated in-memory
+//!   unlink of an idle entry across all six maps (instance `handles` /
+//!   `recovery_done` / `turn_finished` + the three process-global mirrors).
+//!   No disk or DB state is touched; the actor task ends naturally once the
+//!   last `ChannelMailboxHandle` sender is dropped.
+
+use poise::serenity_prelude::ChannelId;
+
+use super::{
+    ChannelMailboxHandle, ChannelMailboxRegistry, GLOBAL_CHANNEL_MAILBOXES,
+    GLOBAL_RECOVERY_DONE_SIGNALS, GLOBAL_TURN_FINISHED_SIGNALS,
+};
+
+/// Outcome of [`ChannelMailboxRegistry::remove_idle_entry`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MailboxPurgeOutcome {
+    /// No registry entry existed for the channel — nothing to unlink.
+    NoEntry,
+    /// Entry existed, the final actor-snapshot recheck confirmed idle, and
+    /// every map was unlinked.
+    Removed,
+    /// Live-work evidence appeared on the final snapshot recheck — refused.
+    RefusedLiveWork(&'static str),
+}
+
+impl ChannelMailboxRegistry {
+    /// Non-creating lookup: returns the existing handle for `channel_id`, or
+    /// `None`. Unlike [`ChannelMailboxRegistry::handle`] this NEVER spawns a
+    /// mailbox actor or inserts registry/global entries — safe for probes.
+    pub(crate) fn peek(&self, channel_id: ChannelId) -> Option<ChannelMailboxHandle> {
+        self.handles
+            .get(&channel_id)
+            .map(|entry| entry.value().clone())
+    }
+
+    /// Remove the channel's registry entry IF (and only if) the mailbox actor
+    /// is verifiably idle at the moment of removal: no cancel token, empty
+    /// intervention queue, no recovery in progress. Callers (the repair API)
+    /// have already passed the CAS `expected_has_cancel_token` +
+    /// `no_live_work_evidence` gate chain; this final snapshot recheck closes
+    /// the remaining race window. Removal is an in-memory unlink only — the
+    /// worst-case race outcome is a short-lived second actor for a channel,
+    /// never data loss.
+    pub(crate) async fn remove_idle_entry(&self, channel_id: ChannelId) -> MailboxPurgeOutcome {
+        let Some(handle) = self.peek(channel_id) else {
+            return MailboxPurgeOutcome::NoEntry;
+        };
+        let snapshot = handle.snapshot().await;
+        if snapshot.cancel_token.is_some() {
+            return MailboxPurgeOutcome::RefusedLiveWork("live_cancel_token");
+        }
+        if !snapshot.intervention_queue.is_empty() {
+            return MailboxPurgeOutcome::RefusedLiveWork("queue_not_empty");
+        }
+        if snapshot.recovery_started_at.is_some() {
+            return MailboxPurgeOutcome::RefusedLiveWork("recovery_in_progress");
+        }
+        self.handles.remove(&channel_id);
+        self.recovery_done.remove(&channel_id);
+        self.turn_finished.remove(&channel_id);
+        GLOBAL_CHANNEL_MAILBOXES.remove(&channel_id);
+        GLOBAL_RECOVERY_DONE_SIGNALS.remove(&channel_id);
+        GLOBAL_TURN_FINISHED_SIGNALS.remove(&channel_id);
+        tracing::warn!(
+            channel = channel_id.get(),
+            "mailbox registry entry purged (operator repair; in-memory unlink only)"
+        );
+        MailboxPurgeOutcome::Removed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use poise::serenity_prelude::{ChannelId, MessageId, UserId};
+
+    use super::super::{
+        ChannelMailboxRegistry, GLOBAL_CHANNEL_MAILBOXES, GLOBAL_RECOVERY_DONE_SIGNALS,
+        GLOBAL_TURN_FINISHED_SIGNALS,
+    };
+    use super::MailboxPurgeOutcome;
+    use crate::services::provider::CancelToken;
+
+    // The GLOBAL_* maps are process-wide; every test here uses a unique
+    // channel id (93293xxx block) so parallel tests cannot collide.
+
+    #[tokio::test]
+    async fn peek_never_creates_an_entry() {
+        let registry = ChannelMailboxRegistry::default();
+        let channel = ChannelId::new(93_293_001);
+
+        assert!(registry.peek(channel).is_none());
+        assert!(
+            registry.handles.is_empty(),
+            "peek must not insert into the instance handle map"
+        );
+        assert!(
+            !GLOBAL_CHANNEL_MAILBOXES.contains_key(&channel),
+            "peek must not insert into the global handle map"
+        );
+
+        // And it returns the existing handle once one exists.
+        let _ = registry.handle(channel);
+        assert!(registry.peek(channel).is_some());
+        GLOBAL_CHANNEL_MAILBOXES.remove(&channel);
+    }
+
+    #[tokio::test]
+    async fn remove_idle_entry_noops_when_no_entry_exists() {
+        let registry = ChannelMailboxRegistry::default();
+        let channel = ChannelId::new(93_293_002);
+        assert_eq!(
+            registry.remove_idle_entry(channel).await,
+            MailboxPurgeOutcome::NoEntry
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_idle_entry_refuses_live_cancel_token() {
+        let registry = ChannelMailboxRegistry::default();
+        let channel = ChannelId::new(93_293_003);
+        let handle = registry.handle(channel);
+        assert!(
+            handle
+                .try_start_turn(
+                    Arc::new(CancelToken::new()),
+                    UserId::new(7),
+                    MessageId::new(11),
+                )
+                .await
+        );
+
+        let outcome = registry.remove_idle_entry(channel).await;
+        assert_eq!(
+            outcome,
+            MailboxPurgeOutcome::RefusedLiveWork("live_cancel_token")
+        );
+        assert!(
+            registry.peek(channel).is_some(),
+            "refused purge must leave the entry in place"
+        );
+        GLOBAL_CHANNEL_MAILBOXES.remove(&channel);
+    }
+
+    #[tokio::test]
+    async fn remove_idle_entry_unlinks_all_six_maps_when_idle() {
+        let registry = ChannelMailboxRegistry::default();
+        let channel = ChannelId::new(93_293_004);
+        let _ = registry.handle(channel);
+        let _ = registry.recovery_done(channel);
+        let _ = registry.turn_finished(channel);
+        assert!(GLOBAL_CHANNEL_MAILBOXES.contains_key(&channel));
+        assert!(GLOBAL_RECOVERY_DONE_SIGNALS.contains_key(&channel));
+        assert!(GLOBAL_TURN_FINISHED_SIGNALS.contains_key(&channel));
+
+        assert_eq!(
+            registry.remove_idle_entry(channel).await,
+            MailboxPurgeOutcome::Removed
+        );
+
+        assert!(registry.handles.get(&channel).is_none());
+        assert!(registry.recovery_done.get(&channel).is_none());
+        assert!(registry.turn_finished.get(&channel).is_none());
+        assert!(!GLOBAL_CHANNEL_MAILBOXES.contains_key(&channel));
+        assert!(!GLOBAL_RECOVERY_DONE_SIGNALS.contains_key(&channel));
+        assert!(!GLOBAL_TURN_FINISHED_SIGNALS.contains_key(&channel));
+    }
+}

--- a/src/services/turn_orchestrator/registry_purge.rs
+++ b/src/services/turn_orchestrator/registry_purge.rs
@@ -13,6 +13,8 @@
 //!   No disk or DB state is touched; the actor task ends naturally once the
 //!   last `ChannelMailboxHandle` sender is dropped.
 
+use std::sync::Arc;
+
 use poise::serenity_prelude::ChannelId;
 
 use super::{
@@ -26,7 +28,9 @@ pub(crate) enum MailboxPurgeOutcome {
     /// No registry entry existed for the channel — nothing to unlink.
     NoEntry,
     /// Entry existed, the final actor-snapshot recheck confirmed idle, and
-    /// every map was unlinked.
+    /// the instance maps were unlinked. Global mirrors are unlinked only when
+    /// they still point at the exact objects this instance verified idle
+    /// (#3297 finding 5) — a mismatching mirror is skipped with a WARN.
     Removed,
     /// Live-work evidence appeared on the final snapshot recheck — refused.
     RefusedLiveWork(&'static str),
@@ -64,14 +68,42 @@ impl ChannelMailboxRegistry {
         if snapshot.recovery_started_at.is_some() {
             return MailboxPurgeOutcome::RefusedLiveWork("recovery_in_progress");
         }
-        self.handles.remove(&channel_id);
-        self.recovery_done.remove(&channel_id);
-        self.turn_finished.remove(&channel_id);
-        GLOBAL_CHANNEL_MAILBOXES.remove(&channel_id);
-        GLOBAL_RECOVERY_DONE_SIGNALS.remove(&channel_id);
-        GLOBAL_TURN_FINISHED_SIGNALS.remove(&channel_id);
+        // Unlink the instance maps only when they still hold the exact
+        // entries this purge verified: the handle that was snapshotted and
+        // the signal Arcs the instance owns.
+        self.handles.remove_if(&channel_id, |_, current| {
+            current.sender.same_channel(&handle.sender)
+        });
+        let removed_recovery_done = self.recovery_done.remove(&channel_id);
+        let removed_turn_finished = self.turn_finished.remove(&channel_id);
+        // #3297 finding 5: the GLOBAL_* maps are process-wide single slots —
+        // another registry instance may have published a DIFFERENT (possibly
+        // busy) actor/signal for this channel after ours. The idle check above
+        // only proved OUR objects idle, so unlink a global mirror entry only
+        // when it still points at the exact object we verified; otherwise
+        // skip it and WARN.
+        let global_handle_removed = GLOBAL_CHANNEL_MAILBOXES
+            .remove_if(&channel_id, |_, mirrored| {
+                mirrored.sender.same_channel(&handle.sender)
+            })
+            .is_some();
+        if !global_handle_removed && GLOBAL_CHANNEL_MAILBOXES.contains_key(&channel_id) {
+            tracing::warn!(
+                channel = channel_id.get(),
+                "global mailbox mirror points at a different actor — mirror unlink skipped"
+            );
+        }
+        if let Some((_, signal)) = removed_recovery_done {
+            GLOBAL_RECOVERY_DONE_SIGNALS
+                .remove_if(&channel_id, |_, mirrored| Arc::ptr_eq(mirrored, &signal));
+        }
+        if let Some((_, signal)) = removed_turn_finished {
+            GLOBAL_TURN_FINISHED_SIGNALS
+                .remove_if(&channel_id, |_, mirrored| Arc::ptr_eq(mirrored, &signal));
+        }
         tracing::warn!(
             channel = channel_id.get(),
+            global_handle_removed,
             "mailbox registry entry purged (operator repair; in-memory unlink only)"
         );
         MailboxPurgeOutcome::Removed
@@ -174,5 +206,64 @@ mod tests {
         assert!(!GLOBAL_CHANNEL_MAILBOXES.contains_key(&channel));
         assert!(!GLOBAL_RECOVERY_DONE_SIGNALS.contains_key(&channel));
         assert!(!GLOBAL_TURN_FINISHED_SIGNALS.contains_key(&channel));
+    }
+
+    /// #3297 finding-5 red-green: the global mirrors are process-wide single
+    /// slots. When a SECOND registry instance has published a different
+    /// (busy) actor for the same channel, purging the FIRST instance's idle
+    /// entry must unlink only the instance maps — the global mirror pointing
+    /// at the busy foreign actor must survive (pre-fix code removed it
+    /// unconditionally on the instance-local idle verdict alone).
+    #[tokio::test]
+    async fn remove_idle_entry_skips_global_mirrors_owned_by_another_instance() {
+        let registry_a = ChannelMailboxRegistry::default();
+        let registry_b = ChannelMailboxRegistry::default();
+        let channel = ChannelId::new(93_293_005);
+
+        // A registers first (its actor briefly owns the global slot)...
+        let handle_a = registry_a.handle(channel);
+        let _signal_a = registry_a.recovery_done(channel);
+        // ...then B registers the same channel: B's actor + signal now own
+        // the global mirrors (last-writer-wins), and B's actor is BUSY.
+        let handle_b = registry_b.handle(channel);
+        let signal_b = registry_b.recovery_done(channel);
+        assert!(
+            handle_b
+                .try_start_turn(
+                    Arc::new(CancelToken::new()),
+                    UserId::new(7),
+                    MessageId::new(11),
+                )
+                .await
+        );
+        assert!(
+            !handle_a.sender.same_channel(&handle_b.sender),
+            "test precondition: two distinct actors for the channel"
+        );
+
+        // Purging A's (idle) entry must NOT unlink B's busy global mirror.
+        assert_eq!(
+            registry_a.remove_idle_entry(channel).await,
+            MailboxPurgeOutcome::Removed
+        );
+        assert!(
+            registry_a.peek(channel).is_none(),
+            "A's instance entry must be unlinked"
+        );
+        let surviving = ChannelMailboxRegistry::global_handle(channel)
+            .expect("global mirror owned by B must survive A's purge");
+        assert!(
+            surviving.sender.same_channel(&handle_b.sender),
+            "the surviving global mirror must still be B's actor"
+        );
+        let surviving_signal = ChannelMailboxRegistry::global_recovery_done(channel)
+            .expect("global recovery-done signal owned by B must survive A's purge");
+        assert!(Arc::ptr_eq(&surviving_signal, &signal_b));
+
+        // Cleanup: direct global-map removal (same convention as the other
+        // tests in this module) to keep the process-global maps clean.
+        GLOBAL_CHANNEL_MAILBOXES.remove(&channel);
+        GLOBAL_RECOVERY_DONE_SIGNALS.remove(&channel);
+        GLOBAL_TURN_FINISHED_SIGNALS.remove(&channel);
     }
 }

--- a/src/services/turn_orchestrator/registry_purge.rs
+++ b/src/services/turn_orchestrator/registry_purge.rs
@@ -22,15 +22,26 @@
 //! processes its mailbox FIFO, every racing `TryStartTurn` lands either
 //! BEFORE the verdict (live token ⇒ purge refused) or AFTER it (tombstone ⇒
 //! start refused; the caller re-resolves a fresh actor via the registry).
+//!
+//! #3297 round 3 (codex): the tombstone gate covers EVERY start-like arm, not
+//! just `TryStartTurn` — [`gate_closed_arm`] intercepts `RecoveryKickoff`,
+//! `Enqueue`, and `RestoreActiveTurn` too, so no arm in the verdict→unlink
+//! FIFO window can mint live work (or queue content) on an actor that is
+//! about to be severed from the registry. Refused callers recover through the
+//! `*_with_closed_retry` registry helpers below, which re-resolve a FRESH
+//! actor (the unlink runs right after the verdict) and replay the request.
 
 use std::sync::Arc;
 
-use poise::serenity_prelude::ChannelId;
+use poise::serenity_prelude::{ChannelId, MessageId, UserId};
 
 use super::{
     ChannelMailboxHandle, ChannelMailboxMsg, ChannelMailboxRegistry, ChannelMailboxState,
-    GLOBAL_CHANNEL_MAILBOXES, GLOBAL_RECOVERY_DONE_SIGNALS, GLOBAL_TURN_FINISHED_SIGNALS,
+    EnqueueInterventionResult, EnqueueRefusalReason, GLOBAL_CHANNEL_MAILBOXES,
+    GLOBAL_RECOVERY_DONE_SIGNALS, GLOBAL_TURN_FINISHED_SIGNALS, Intervention,
+    QueuePersistenceContext, RecoveryKickoffResult,
 };
+use crate::services::provider::CancelToken;
 
 /// Actor-side verdict for [`ChannelMailboxMsg::CloseIfIdle`], invoked from the
 /// mailbox actor loop while it exclusively owns `state` — the idle decision
@@ -47,8 +58,139 @@ pub(super) fn close_if_idle_verdict(state: &mut ChannelMailboxState) -> Result<(
     if state.recovery_started_at.is_some() {
         return Err("recovery_in_progress");
     }
+    // #3297 r3 — a `TakeNextSoft` head handed out for dispatch but not yet
+    // claimed (`pending_user_dispatch`) IS live work: tombstoning during that
+    // window would force the in-flight user turn onto its requeue/retry
+    // fallbacks. Refuse, like any other live-work evidence.
+    if state.pending_user_dispatch.is_some() {
+        return Err("pending_user_dispatch");
+    }
     state.closed = true;
     Ok(())
+}
+
+/// #3297 r3 (codex) — single tombstone gate run by the actor loop BEFORE the
+/// arm match. When `state.closed` is set, every START-LIKE arm (class (a) in
+/// the `ChannelMailboxMsg` classification docs) is answered here with its
+/// arm's existing "cannot start" reply and `None` is returned so the loop
+/// skips the match; all other arms pass through untouched. Keeping the
+/// classification in ONE place (instead of per-arm `state.closed` checks)
+/// makes "new arm ⇒ classify it" reviewable at a glance.
+pub(super) fn gate_closed_arm(
+    state: &ChannelMailboxState,
+    msg: ChannelMailboxMsg,
+) -> Option<ChannelMailboxMsg> {
+    if !state.closed {
+        return Some(msg);
+    }
+    match msg {
+        // Mirrors the lost-race reply of a slot already held (#3297 r2).
+        ChannelMailboxMsg::TryStartTurn { reply, .. } => {
+            let _ = reply.send(false);
+            None
+        }
+        // Fire-and-forget restore: the only refusal shape is a no-op ack.
+        // (Dormant/test-only wrapper, but it binds a token — class (a).)
+        ChannelMailboxMsg::RestoreActiveTurn { reply, .. } => {
+            let _ = reply.send(());
+            None
+        }
+        // Pre-fix this arm unconditionally bound the cancel token, marked
+        // `recovery_started_at`, and (via the wrapper's `activated_turn`)
+        // incremented `global_active` — live work on a severed actor.
+        ChannelMailboxMsg::RecoveryKickoff { reply, .. } => {
+            let _ = reply.send(RecoveryKickoffResult {
+                activated_turn: false,
+                refused_closed: true,
+            });
+            None
+        }
+        // Pre-fix this arm accepted (and disk-persisted) queue content that
+        // the unlink then orphaned out of every registered-mailbox scan.
+        ChannelMailboxMsg::Enqueue { reply, .. } => {
+            let _ = reply.send(EnqueueInterventionResult {
+                enqueued: false,
+                merged: false,
+                refusal_reason: Some(EnqueueRefusalReason::MailboxClosed),
+                queue_exit_events: Vec::new(),
+                persistence_error: None,
+            });
+            None
+        }
+        other => Some(other),
+    }
+}
+
+/// Bounded attempts for the `*_with_closed_retry` helpers. A `MailboxClosed`
+/// refusal means the registry resolved a tombstoned actor inside the tiny
+/// verdict→unlink window of [`ChannelMailboxRegistry::remove_idle_entry`];
+/// the unlink lands without further awaits, so one yield is normally enough
+/// for `handle()` to mint a fresh actor. The bound only matters if a purge
+/// future is dropped mid-removal (tombstoned entry never unlinked).
+const CLOSED_RETRY_ATTEMPTS: usize = 3;
+
+impl ChannelMailboxRegistry {
+    /// #3297 r3 — enqueue that survives a purge-tombstone race: on a
+    /// [`EnqueueRefusalReason::MailboxClosed`] refusal, re-resolve the channel
+    /// through the registry (minting a fresh actor once the purge unlink
+    /// lands) and replay. Any other outcome — success, dedup refusal,
+    /// persistence error, actor-unreachable — is returned unchanged, so
+    /// callers keep their existing semantics.
+    pub(crate) async fn enqueue_with_closed_retry(
+        &self,
+        channel_id: ChannelId,
+        intervention: Intervention,
+        persistence: QueuePersistenceContext,
+    ) -> EnqueueInterventionResult {
+        for attempt in 1..=CLOSED_RETRY_ATTEMPTS {
+            let result = self
+                .handle(channel_id)
+                .enqueue(intervention.clone(), persistence.clone())
+                .await;
+            if result.refusal_reason != Some(EnqueueRefusalReason::MailboxClosed) {
+                return result;
+            }
+            if attempt == CLOSED_RETRY_ATTEMPTS {
+                tracing::error!(
+                    channel = channel_id.get(),
+                    "enqueue still refused by a purge-tombstoned mailbox after retries"
+                );
+                return result;
+            }
+            tokio::task::yield_now().await;
+        }
+        unreachable!("loop always returns by the final attempt");
+    }
+
+    /// #3297 r3 — recovery kickoff with the same tombstone-refusal retry as
+    /// [`Self::enqueue_with_closed_retry`], keyed on
+    /// `RecoveryKickoffResult::refused_closed`.
+    pub(crate) async fn recovery_kickoff_with_closed_retry(
+        &self,
+        channel_id: ChannelId,
+        cancel_token: Arc<CancelToken>,
+        request_owner: UserId,
+        user_message_id: Option<MessageId>,
+    ) -> RecoveryKickoffResult {
+        for attempt in 1..=CLOSED_RETRY_ATTEMPTS {
+            let result = self
+                .handle(channel_id)
+                .recovery_kickoff(cancel_token.clone(), request_owner, user_message_id)
+                .await;
+            if !result.refused_closed {
+                return result;
+            }
+            if attempt == CLOSED_RETRY_ATTEMPTS {
+                tracing::error!(
+                    channel = channel_id.get(),
+                    "recovery kickoff still refused by a purge-tombstoned mailbox after retries"
+                );
+                return result;
+            }
+            tokio::task::yield_now().await;
+        }
+        unreachable!("loop always returns by the final attempt");
+    }
 }
 
 impl ChannelMailboxHandle {
@@ -152,18 +294,50 @@ impl ChannelMailboxRegistry {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::time::Instant;
 
     use poise::serenity_prelude::{ChannelId, MessageId, UserId};
 
+    use super::super::test_support::{AGENTDESK_ROOT_DIR_ENV, lock_test_env};
     use super::super::{
-        ChannelMailboxRegistry, GLOBAL_CHANNEL_MAILBOXES, GLOBAL_RECOVERY_DONE_SIGNALS,
-        GLOBAL_TURN_FINISHED_SIGNALS,
+        ChannelMailboxRegistry, ChannelMailboxState, EnqueueRefusalReason,
+        GLOBAL_CHANNEL_MAILBOXES, GLOBAL_RECOVERY_DONE_SIGNALS, GLOBAL_TURN_FINISHED_SIGNALS,
+        Intervention, InterventionMode, QueuePersistenceContext,
     };
     use super::MailboxPurgeOutcome;
-    use crate::services::provider::CancelToken;
+    use crate::services::provider::{CancelToken, ProviderKind};
 
     // The GLOBAL_* maps are process-wide; every test here uses a unique
     // channel id (93293xxx block) so parallel tests cannot collide.
+
+    struct EnvGuard;
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe { std::env::remove_var(AGENTDESK_ROOT_DIR_ENV) };
+        }
+    }
+
+    fn make_intervention(message_id: u64, text: &str) -> Intervention {
+        Intervention {
+            author_id: UserId::new(7),
+            author_is_bot: false,
+            message_id: MessageId::new(message_id),
+            source_message_ids: vec![MessageId::new(message_id)],
+            text: text.to_string(),
+            mode: InterventionMode::Soft,
+            created_at: Instant::now(),
+            reply_context: None,
+            has_reply_boundary: false,
+            merge_consecutive: false,
+            pending_uploads: Vec::new(),
+            voice_announcement: None,
+        }
+    }
+
+    fn test_persistence(token_hash: &str) -> QueuePersistenceContext {
+        QueuePersistenceContext::new(&ProviderKind::Claude, token_hash, None)
+    }
 
     #[tokio::test]
     async fn peek_never_creates_an_entry() {
@@ -407,5 +581,236 @@ mod tests {
         );
         let _ = handle.hard_stop().await;
         GLOBAL_CHANNEL_MAILBOXES.remove(&channel);
+    }
+
+    /// #3297 round-3 red-green (codex finding 1): a `RecoveryKickoff` that
+    /// lands in the actor FIFO AFTER the purge verdict must be refused by the
+    /// tombstone. Pre-fix the arm unconditionally bound the cancel token, set
+    /// `recovery_started_at`, and replied `activated_turn = true` (which made
+    /// the wrapper increment `global_active`) — live work on an actor the
+    /// purge had just severed from the registry/global mirrors.
+    #[tokio::test]
+    async fn purged_actor_refuses_a_racing_recovery_kickoff() {
+        let registry = ChannelMailboxRegistry::default();
+        let channel = ChannelId::new(93_293_101);
+        let stale_handle = registry.handle(channel);
+
+        assert_eq!(
+            registry.remove_idle_entry(channel).await,
+            MailboxPurgeOutcome::Removed
+        );
+
+        let result = stale_handle
+            .recovery_kickoff(
+                Arc::new(CancelToken::new()),
+                UserId::new(7),
+                Some(MessageId::new(11)),
+            )
+            .await;
+        assert!(
+            result.refused_closed,
+            "a kickoff racing the purge must be refused by the closed tombstone"
+        );
+        assert!(
+            !result.activated_turn,
+            "a refused kickoff must not report an activated turn \
+             (pre-fix this incremented global_active for an unreachable actor)"
+        );
+        assert!(
+            !stale_handle.has_active_turn().await,
+            "the tombstoned actor must remain idle"
+        );
+        let snapshot = stale_handle.snapshot().await;
+        assert!(
+            snapshot.recovery_started_at.is_none(),
+            "the tombstoned actor must not carry a recovery marker"
+        );
+        GLOBAL_CHANNEL_MAILBOXES.remove(&channel);
+    }
+
+    /// #3297 round-3 red-green (codex finding 2): an `Enqueue` that lands in
+    /// the actor FIFO AFTER the purge verdict must be refused by the
+    /// tombstone. Pre-fix the arm accepted the intervention into memory AND
+    /// persisted it to the disk queue; the unlink then dropped that queue out
+    /// of every registered-mailbox scan — orphaned until some later hydrate
+    /// path happened to touch the channel.
+    #[tokio::test]
+    async fn purged_actor_refuses_a_racing_enqueue() {
+        let registry = ChannelMailboxRegistry::default();
+        let channel = ChannelId::new(93_293_102);
+        let stale_handle = registry.handle(channel);
+
+        assert_eq!(
+            registry.remove_idle_entry(channel).await,
+            MailboxPurgeOutcome::Removed
+        );
+
+        let result = stale_handle
+            .enqueue(
+                make_intervention(11, "post-verdict enqueue"),
+                test_persistence("registry-purge-r3-refusal"),
+            )
+            .await;
+        assert!(
+            !result.enqueued,
+            "an enqueue racing the purge must be refused by the closed tombstone \
+             (pre-fix it was accepted and orphaned on the unlinked actor)"
+        );
+        assert_eq!(
+            result.refusal_reason,
+            Some(EnqueueRefusalReason::MailboxClosed)
+        );
+        assert!(
+            result.persistence_error.is_none(),
+            "the refusal happens before any disk write"
+        );
+        let snapshot = stale_handle.snapshot().await;
+        assert!(
+            snapshot.intervention_queue.is_empty(),
+            "the tombstoned actor must not hold queue content"
+        );
+        GLOBAL_CHANNEL_MAILBOXES.remove(&channel);
+    }
+
+    /// #3297 r3 — the registry-level retry helper turns a tombstone refusal
+    /// into a successful enqueue on a FRESHLY minted actor (the production
+    /// path for the verdict→unlink FIFO window). A sync `#[test]` holds the
+    /// shared env lock with no await in scope (the awaits run inside
+    /// `block_on`), so no `await_holding_lock` allow is needed.
+    #[test]
+    fn enqueue_closed_retry_lands_on_a_fresh_actor_after_purge() {
+        let _lock = lock_test_env();
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var(AGENTDESK_ROOT_DIR_ENV, tmp.path().to_str().unwrap()) };
+        let _env_guard = EnvGuard;
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let registry = ChannelMailboxRegistry::default();
+            let channel = ChannelId::new(93_293_103);
+            let stale_handle = registry.handle(channel);
+            assert_eq!(
+                registry.remove_idle_entry(channel).await,
+                MailboxPurgeOutcome::Removed
+            );
+
+            let result = registry
+                .enqueue_with_closed_retry(
+                    channel,
+                    make_intervention(12, "retry onto fresh actor"),
+                    test_persistence("registry-purge-r3-retry"),
+                )
+                .await;
+            assert!(
+                result.enqueued,
+                "the retry helper must land the enqueue on a fresh registry actor"
+            );
+            assert!(result.persistence_error.is_none());
+
+            // The intervention lives on the REGISTERED (fresh) actor — not on
+            // the tombstone the stale handle still points at.
+            let fresh_handle = registry.handle(channel);
+            assert_eq!(fresh_handle.snapshot().await.intervention_queue.len(), 1);
+            assert!(stale_handle.snapshot().await.intervention_queue.is_empty());
+
+            // Drain the durable queue file before the tempdir goes away.
+            let _ = fresh_handle
+                .purge_queue(test_persistence("registry-purge-r3-retry"), false)
+                .await;
+            GLOBAL_CHANNEL_MAILBOXES.remove(&channel);
+        });
+    }
+
+    /// #3297 r3 — the retry helpers are BOUNDED: when a tombstoned actor is
+    /// never unlinked (a purge future dropped between verdict and unlink),
+    /// the helper gives up after its fixed attempts and surfaces the refusal
+    /// instead of spinning. Tombstoning the actor directly (no unlink) pins
+    /// the registry to the tombstone for every retry deterministically.
+    #[tokio::test]
+    async fn closed_retry_helpers_give_up_when_tombstone_never_unlinks() {
+        let registry = ChannelMailboxRegistry::default();
+        let channel = ChannelId::new(93_293_104);
+        let handle = registry.handle(channel);
+        assert_eq!(handle.close_if_idle().await, Ok(()));
+
+        let enqueue = registry
+            .enqueue_with_closed_retry(
+                channel,
+                make_intervention(13, "never accepted"),
+                test_persistence("registry-purge-r3-bounded"),
+            )
+            .await;
+        assert!(!enqueue.enqueued);
+        assert_eq!(
+            enqueue.refusal_reason,
+            Some(EnqueueRefusalReason::MailboxClosed)
+        );
+
+        let kickoff = registry
+            .recovery_kickoff_with_closed_retry(
+                channel,
+                Arc::new(CancelToken::new()),
+                UserId::new(7),
+                None,
+            )
+            .await;
+        assert!(kickoff.refused_closed);
+        assert!(!kickoff.activated_turn);
+        assert!(!handle.has_active_turn().await);
+        GLOBAL_CHANNEL_MAILBOXES.remove(&channel);
+    }
+
+    /// #3297 r3 — kickoff twin of the enqueue retry test: after the purge
+    /// unlink, the retry helper resolves a fresh actor that ACCEPTS the
+    /// recovery kickoff (anchoring the recovery turn on the registered
+    /// mailbox, where cancel/dedup gates can see it).
+    #[tokio::test]
+    async fn recovery_kickoff_closed_retry_lands_on_a_fresh_actor() {
+        let registry = ChannelMailboxRegistry::default();
+        let channel = ChannelId::new(93_293_105);
+        let _ = registry.handle(channel);
+        assert_eq!(
+            registry.remove_idle_entry(channel).await,
+            MailboxPurgeOutcome::Removed
+        );
+
+        let result = registry
+            .recovery_kickoff_with_closed_retry(
+                channel,
+                Arc::new(CancelToken::new()),
+                UserId::new(7),
+                Some(MessageId::new(11)),
+            )
+            .await;
+        assert!(!result.refused_closed);
+        assert!(result.activated_turn);
+        let fresh_handle = registry.handle(channel);
+        assert!(fresh_handle.has_active_turn().await);
+
+        let _ = fresh_handle.hard_stop().await;
+        GLOBAL_CHANNEL_MAILBOXES.remove(&channel);
+    }
+
+    /// #3297 r3 — a `TakeNextSoft` head handed out for dispatch but not yet
+    /// claimed (`pending_user_dispatch` reservation) is live work: the idle
+    /// verdict must refuse to tombstone during that dequeue→claim window.
+    #[test]
+    fn close_verdict_refuses_during_dequeue_dispatch_window() {
+        let mut state = ChannelMailboxState {
+            pending_user_dispatch: Some(MessageId::new(11)),
+            ..ChannelMailboxState::default()
+        };
+        assert_eq!(
+            super::close_if_idle_verdict(&mut state),
+            Err("pending_user_dispatch")
+        );
+        assert!(!state.closed, "a refused verdict must not tombstone");
+
+        state.pending_user_dispatch = None;
+        assert_eq!(super::close_if_idle_verdict(&mut state), Ok(()));
+        assert!(state.closed);
     }
 }

--- a/src/services/turn_orchestrator/registry_purge.rs
+++ b/src/services/turn_orchestrator/registry_purge.rs
@@ -12,27 +12,69 @@
 //!   `recovery_done` / `turn_finished` + the three process-global mirrors).
 //!   No disk or DB state is touched; the actor task ends naturally once the
 //!   last `ChannelMailboxHandle` sender is dropped.
+//!
+//! #3297 round 2 (codex): the idle check is actor-mediated. The original
+//! `snapshot().await`-then-unlink sequence left a TOCTOU window — a
+//! `TryStartTurn` processed by the SAME actor between the idle snapshot and
+//! the unlink activated a turn, and the unlink then severed that LIVE actor
+//! from the registry/global mirrors. `CloseIfIdle` verifies idleness and sets
+//! the `closed` tombstone in one serialized actor step; because the actor
+//! processes its mailbox FIFO, every racing `TryStartTurn` lands either
+//! BEFORE the verdict (live token ⇒ purge refused) or AFTER it (tombstone ⇒
+//! start refused; the caller re-resolves a fresh actor via the registry).
 
 use std::sync::Arc;
 
 use poise::serenity_prelude::ChannelId;
 
 use super::{
-    ChannelMailboxHandle, ChannelMailboxRegistry, GLOBAL_CHANNEL_MAILBOXES,
-    GLOBAL_RECOVERY_DONE_SIGNALS, GLOBAL_TURN_FINISHED_SIGNALS,
+    ChannelMailboxHandle, ChannelMailboxMsg, ChannelMailboxRegistry, ChannelMailboxState,
+    GLOBAL_CHANNEL_MAILBOXES, GLOBAL_RECOVERY_DONE_SIGNALS, GLOBAL_TURN_FINISHED_SIGNALS,
 };
+
+/// Actor-side verdict for [`ChannelMailboxMsg::CloseIfIdle`], invoked from the
+/// mailbox actor loop while it exclusively owns `state` — the idle decision
+/// and the tombstone write are therefore one atomic (actor-serialized) step.
+/// Kept here, out of the ratchet-frozen module root, with the rest of the
+/// purge logic. Gate order mirrors the original snapshot recheck.
+pub(super) fn close_if_idle_verdict(state: &mut ChannelMailboxState) -> Result<(), &'static str> {
+    if state.cancel_token.is_some() {
+        return Err("live_cancel_token");
+    }
+    if !state.intervention_queue.is_empty() {
+        return Err("queue_not_empty");
+    }
+    if state.recovery_started_at.is_some() {
+        return Err("recovery_in_progress");
+    }
+    state.closed = true;
+    Ok(())
+}
+
+impl ChannelMailboxHandle {
+    /// Ask the actor to verify it is idle and, if so, tombstone itself
+    /// (`Ok(())` ⇒ purgeable; `Err(reason)` ⇒ live work, purge refused).
+    /// A dead actor (mailbox closed / reply dropped) can never start work
+    /// again, so the request fallback treats it as trivially purgeable.
+    async fn close_if_idle(&self) -> Result<(), &'static str> {
+        self.request(|reply| ChannelMailboxMsg::CloseIfIdle { reply }, Ok(()))
+            .await
+    }
+}
 
 /// Outcome of [`ChannelMailboxRegistry::remove_idle_entry`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MailboxPurgeOutcome {
     /// No registry entry existed for the channel — nothing to unlink.
     NoEntry,
-    /// Entry existed, the final actor-snapshot recheck confirmed idle, and
-    /// the instance maps were unlinked. Global mirrors are unlinked only when
+    /// Entry existed, the actor-serialized `CloseIfIdle` verdict confirmed
+    /// idle (tombstoning the actor against post-verdict starts), and the
+    /// instance maps were unlinked. Global mirrors are unlinked only when
     /// they still point at the exact objects this instance verified idle
     /// (#3297 finding 5) — a mismatching mirror is skipped with a WARN.
     Removed,
-    /// Live-work evidence appeared on the final snapshot recheck — refused.
+    /// Live-work evidence appeared on the actor's `CloseIfIdle` verdict —
+    /// refused, and the actor is left un-tombstoned.
     RefusedLiveWork(&'static str),
 }
 
@@ -50,23 +92,20 @@ impl ChannelMailboxRegistry {
     /// is verifiably idle at the moment of removal: no cancel token, empty
     /// intervention queue, no recovery in progress. Callers (the repair API)
     /// have already passed the CAS `expected_has_cancel_token` +
-    /// `no_live_work_evidence` gate chain; this final snapshot recheck closes
-    /// the remaining race window. Removal is an in-memory unlink only — the
-    /// worst-case race outcome is a short-lived second actor for a channel,
-    /// never data loss.
+    /// `no_live_work_evidence` gate chain.
+    ///
+    /// #3297 round 2 (codex): the final idle recheck is performed by the
+    /// actor itself (`CloseIfIdle`), which tombstones the actor in the same
+    /// serialized step — a `TryStartTurn` racing the unlink can therefore
+    /// never activate the to-be-unlinked actor (see the module docs). Removal
+    /// is an in-memory unlink only — the worst-case race outcome is a
+    /// short-lived second actor for a channel, never data loss.
     pub(crate) async fn remove_idle_entry(&self, channel_id: ChannelId) -> MailboxPurgeOutcome {
         let Some(handle) = self.peek(channel_id) else {
             return MailboxPurgeOutcome::NoEntry;
         };
-        let snapshot = handle.snapshot().await;
-        if snapshot.cancel_token.is_some() {
-            return MailboxPurgeOutcome::RefusedLiveWork("live_cancel_token");
-        }
-        if !snapshot.intervention_queue.is_empty() {
-            return MailboxPurgeOutcome::RefusedLiveWork("queue_not_empty");
-        }
-        if snapshot.recovery_started_at.is_some() {
-            return MailboxPurgeOutcome::RefusedLiveWork("recovery_in_progress");
+        if let Err(refusal) = handle.close_if_idle().await {
+            return MailboxPurgeOutcome::RefusedLiveWork(refusal);
         }
         // Unlink the instance maps only when they still hold the exact
         // entries this purge verified: the handle that was snapshotted and
@@ -265,5 +304,108 @@ mod tests {
         GLOBAL_CHANNEL_MAILBOXES.remove(&channel);
         GLOBAL_RECOVERY_DONE_SIGNALS.remove(&channel);
         GLOBAL_TURN_FINISHED_SIGNALS.remove(&channel);
+    }
+
+    /// #3297 round-2 red-green (codex TOCTOU finding): a `TryStartTurn`
+    /// processed by the actor AFTER the purge's idle verdict — i.e. the
+    /// interleaving where, pre-fix, the start landed between the idle
+    /// `snapshot()` and the registry unlink — must be REFUSED. To the actor,
+    /// "between verdict and unlink" and "after unlink" are indistinguishable
+    /// (the unlink never touches the actor), so driving the start through a
+    /// retained handle clone after `remove_idle_entry` pins exactly the
+    /// post-snapshot interleaving deterministically. Pre-fix this test fails:
+    /// the start returned `true`, activating a turn on an actor that the
+    /// purge had just severed from the registry/global mirrors.
+    #[tokio::test]
+    async fn purged_actor_refuses_a_racing_try_start_turn() {
+        let registry = ChannelMailboxRegistry::default();
+        let channel = ChannelId::new(93_293_006);
+        // The racing starter's retained handle clone (in production: a task
+        // that resolved the handle before the purge, or a start already
+        // queued in the actor mailbox behind the idle verdict).
+        let stale_handle = registry.handle(channel);
+
+        assert_eq!(
+            registry.remove_idle_entry(channel).await,
+            MailboxPurgeOutcome::Removed
+        );
+
+        let started = stale_handle
+            .try_start_turn(
+                Arc::new(CancelToken::new()),
+                UserId::new(7),
+                MessageId::new(11),
+            )
+            .await;
+        assert!(
+            !started,
+            "a start racing the purge must be refused by the closed tombstone \
+             (pre-fix it activated a turn on the unlinked actor)"
+        );
+        assert!(
+            !stale_handle.has_active_turn().await,
+            "the tombstoned actor must remain idle"
+        );
+
+        // The channel itself stays serviceable: a fresh registry resolution
+        // mints a NEW actor that accepts work normally.
+        let fresh_handle = registry.handle(channel);
+        assert!(
+            fresh_handle
+                .try_start_turn(
+                    Arc::new(CancelToken::new()),
+                    UserId::new(7),
+                    MessageId::new(12),
+                )
+                .await,
+            "a freshly minted actor must accept work after the purge"
+        );
+        let _ = fresh_handle.hard_stop().await;
+        GLOBAL_CHANNEL_MAILBOXES.remove(&channel);
+    }
+
+    /// Companion exhaustiveness check for the round-2 fix: the actor mailbox
+    /// is FIFO, so EVERY racing `TryStartTurn` is processed strictly before
+    /// or strictly after the `CloseIfIdle` verdict. Before ⇒ the verdict sees
+    /// the live token and the purge is refused (actor untouched, no
+    /// tombstone); after ⇒ the tombstone refuses the start (previous test).
+    /// Together the two orderings leave no interleaving in which an ACTIVE
+    /// actor is unlinked.
+    #[tokio::test]
+    async fn close_verdict_refuses_when_start_won_the_race() {
+        let registry = ChannelMailboxRegistry::default();
+        let channel = ChannelId::new(93_293_007);
+        let handle = registry.handle(channel);
+        assert!(
+            handle
+                .try_start_turn(
+                    Arc::new(CancelToken::new()),
+                    UserId::new(7),
+                    MessageId::new(11),
+                )
+                .await
+        );
+
+        assert_eq!(handle.close_if_idle().await, Err("live_cancel_token"));
+        assert_eq!(
+            registry.remove_idle_entry(channel).await,
+            MailboxPurgeOutcome::RefusedLiveWork("live_cancel_token")
+        );
+
+        // The refused verdict must NOT have tombstoned the actor: after the
+        // live turn finishes, the same actor keeps serving starts.
+        let _ = handle.hard_stop().await;
+        assert!(
+            handle
+                .try_start_turn(
+                    Arc::new(CancelToken::new()),
+                    UserId::new(7),
+                    MessageId::new(12),
+                )
+                .await,
+            "a refused purge must leave the actor fully operational"
+        );
+        let _ = handle.hard_stop().await;
+        GLOBAL_CHANNEL_MAILBOXES.remove(&channel);
     }
 }


### PR DESCRIPTION
Part of #3293 — scope (b)+(c). Scope (a) (test fixture leak isolation) is intentionally out of scope (followup slice).

## 순환 구조 (what loops, and where it breaks now)

Pre-#3293, an inflight row whose recovery terminal relay could never succeed looped forever:

```
boot → mark_all_inflight_states_restart_mode (re-marks the row)
     → restore_inflight_turns → relay notice → Err (bool=false, reason lost)
     → "preserving inflight for retry" WARN → row survives → next boot → …
```

The relay result was a `bool`, so a Discord **permanent** rejection (404 unknown channel / 403 / 410 — e.g. a bogus fixture channel like `777000000000000001`) was indistinguishable from a transient outage. The carrier row was re-marked every restart and the WARN loop never terminated. Probing such channels through `shared.mailbox()` additionally minted **permanent registry entries** for non-existent channels.

This PR breaks the loop at the carrier: once the row is force-cleared (permanent verdict or exhausted restart budget), there is nothing left for `mark_all_inflight_states_restart_mode` to re-mark.

## 변경 (b) — 3-state relay outcome + restart budget

- `RecoveryRelayOutcome { Delivered, PermanentFailure, TransientFailure }` (`recovery_paths/shared.rs`, pure + table-tested). Permanent = HTTP **{404, 403, 410}** only, reusing the `placeholder_sweeper::is_permanent_message_gone_status` allowlist. No status / 5xx / 429 / transport errors stay transient. **verify r1**: the placeholder-anchor relay path flattens its error chain into `String`s, so a transient classification now gets a second opinion from an **active `get_channel` probe** (`probe_channel_liveness` + `escalate_transient_relay_outcome_with_probe`, probe injected via closure test seam); only an authoritative channel-level 404/403/410 upgrades to permanent, probe failures stay transient.
- `InflightTurnState.recovery_relay_attempts: u32` — additive `#[serde(default)]` field, **no `INFLIGHT_STATE_VERSION` bump** (#2235 convention; same as `turn_source` / `terminal_delivery_committed`). Budget `RECOVERY_RELAY_RESTART_ATTEMPT_BUDGET = 3`; recovery runs once per boot so this is a "3 consecutive restarts" budget — in-process transient blips cannot consume it.
- Pure decision matrix `unrecoverable_relay_disposition(outcome, attempts, budget, tmux_alive) -> RowDisposition`; executed by `recovery_paths/restart.rs::dispose_recovery_relay_outcome` in the five notice branches (ready-without-output + missing-tmux / missing-tmux-name / missing-output-path / missing-input-fifo).
- The five dispatch-flow relay sites keep **exact** prior behavior via the `.delivered()` adapter (followup slice).

## 오삭제 방어 (deletion-safety invariants)

- **pane-alive 절대 보존** (verify r1에서 강화): budget force-clear runs ONLY in the `missing_tmux` branch, the single point where tmux absence is established (`can_recover=false`). The `missing_output_path` / `missing_input_fifo` / (dead-code) `missing_tmux_name` branches sit PAST the can_recover gate — tmux existence confirmed — and now pass `tmux_alive=true`, for which the matrix can never return `ClearBudgetExhausted` (only a permanent Discord verdict clears them). Ready-without-output (tmux alive) likewise passes `tmux_alive=true` — pinned by `pane_alive_row_is_never_budget_cleared` (adversarial: 3 deploys during a Discord outage with a live pane → preserved). `stale_removal_reason`'s pane-alive guard untouched + regression test that a saturated counter does not weaken it.
- **보수적 allowlist**: only {404,403,410} is permanent; misclassifying 429/5xx as permanent is impossible by construction (table test). Worst case for a long outage is budget exhaustion — which still leaves the on-disk force-clear report (full response) + audit row.
- **무음 삭제 없음** (verify r1에서 실체화): every force-clear FIRST writes an on-disk `RecoveryForceClearReport` JSON to `runtime/discord_recovery_force_clear/<provider>/` — **full_response 전문** + channel/session_key/dispatch_id/tmux/branch/reason/attempts/timestamps. Write failure WARNs but never blocks the clear. Additionally: `termination_audit` (`recovery_permanent_relay_failure` / `recovery_retry_budget_exhausted`, when `session_key` exists) + a structured WARN (always, with channel/provider/attempts/budget/report_path). `save_missing_session_handoff` itself is a WARN-only 160-char-tail trace (doc corrected) — it is NOT the disk-preservation mechanism.
- **identity-guarded counter persist** (verify r1에서 재설계): `attempts+1` goes through `inflight::budget::bump_recovery_relay_attempts_if_matches_identity` — a read-modify-write that bumps ONLY the counter on the on-disk row, **preserving `restart_mode`/`rebind_origin` verbatim**. The #3293 carrier row is DrainRestart-re-marked every boot, so the generic `save_inflight_state_if_matches_identity` (which refuses any restart-marked or `user_msg_id==0` row) could never persist the counter — budget exhaustion was unreachable on exactly the row class it exists for. Strong identity (`user_msg_id`+`started_at`+`tmux_session_name`, plus `turn_start_offset` proof for TUI-direct) still refuses rows owned by a different turn; failure to persist only delays clearing (fail-safe toward preservation).
- **ID 패턴 삭제 전면 배제**: snowflake-shape heuristics are useless (the bogus fixture id passes `is_discord_snowflake`); verdicts come only from Discord permanent errors or the restart budget.
- `terminal_delivery_committed` rows, forward-version / rebind-origin silent-skip paths: untouched.

## 변경 (c) — mailbox registry hygiene

1. **probe 비생성**: `ChannelMailboxRegistry::peek` + `SharedData::mailbox_peek`; `provider_channel_mailbox_state` now answers via `health/mailbox.rs::peeked_provider_mailbox_state` — a probe for a non-existent channel returns the idle state instead of minting a permanent actor+entry (the repair before/after probes were the bogus-entry factory).
2. **force-clear 경로 비생성**: permanent/budget clears call `finish_recovered_turn_mailbox` only if an entry already exists (`finish_recovered_turn_mailbox_if_registered`) — the finalizer would otherwise create one.
3. **operator-gated purge**: `POST /api/doctor/stale-mailbox/repair` gains `#[serde(default)] purge: bool`. Runs only when (i) the endpoint's existing gate chain (local/configured auth → CAS `expected_has_cancel_token` → `queue_not_empty` → `active_dispatch_present` → `tmux_present`) fully passed, (ii) the repair reports `status == "applied"` (no residual inflight/session evidence), and (iii) `ChannelMailboxRegistry::remove_idle_entry` re-verifies the actor snapshot is idle (no cancel token, empty queue, no recovery) immediately before unlinking the instance maps (`handles`/`recovery_done`/`turn_finished`); **verify r1**: the 3 process-global mirrors are unlinked only when they still point at the exact objects this instance verified idle (`sender.same_channel` / `Arc::ptr_eq`) — a mirror owned by another instance's (possibly busy) actor is skipped with a WARN. In-memory unlink only — no disk/DB mutation; the actor task ends by sender drop. Worst-case race = a short-lived second actor for one channel, zero data loss. Response: `registry_entry_removed` / `registry_purge_skipped_reason`; `docs.rs` updated; doctor CLI unaffected (additive).

## 테스트 (all new tests tempdir-isolated)

- classification table: 404/403/410 → Permanent; 400/401/408/429/5xx/no-status → Transient; `.delivered()` adapter contract.
- disposition matrix: Delivered → FinishAndClear (any attempts); Permanent → immediate clear; `(Transient, 2, 3, tmux gone)` → budget clear; `(Transient, 0..=1)` → preserve+count; `(Transient, 99, tmux alive)` → preserve (pane-alive guard).
- audit reason codes pinned; repair `purge` decision gate (`repair_not_fully_applied` skip).
- serde: legacy row without the field → 0; round-trip; counter survives disk round-trip AND a real `mark_all_inflight_states_restart_mode` re-marking pass (env-guarded tempdir root); saturated counter does not weaken the pane-alive stale guard.
- registry: `peek` never creates; `remove_idle_entry` refuses on a live cancel token and unlinks all six maps when idle (unique channel-id block to avoid global-map collisions).

## 수정 라운드 verify r1 (적대적 검증 5건 반영)

1. **[major] 예산 카운터 영속**: `inflight/budget.rs` 신설 — restart-marked/TUI-direct 행에서도 attempts 증가가 영속 (`bump_persists_attempts_on_restart_marked_row` red-green: 동일 행에 대해 구 가드 `IdentityMismatch` → 신규 bump `Saved` + marker 보존을 함께 고정. `bump_accumulates_across_remarked_boots`로 3연속 부트 누적 → 예산 도달 가능 증명).
2. **[major] Permanent 도달성**: relay 실패가 transient로 분류되면 `get_channel` 능동 프로브로 재판정 (`string_flattened_error_with_dead_channel_probe_is_permanent` red-green: String 평탄화 에러의 Transient 오분류를 RED로 명시 후 프로브 Gone으로 GREEN. `inconclusive_probe_keeps_transient_verdict` / `permanent_classification_skips_the_probe` / `probe_status_shares_the_permanent_allowlist`).
3. **[major] 디스크 보존 실체화**: `persist_force_clear_report`가 강제 clear 직전 full_response 전문 + 메타데이터 JSON을 `runtime/discord_recovery_force_clear/<provider>/`에 기록; 실패 시 WARN 후 clear 진행 (`force_clear_report_preserves_full_response_and_metadata_on_disk`, `repeated_force_clears_never_overwrite_earlier_artifacts`).
4. **[major] pane-alive 불변식**: `missing_output_path`/`missing_input_fifo`/`missing_tmux_name` 분기 `tmux_alive=true`로 정정 — 예산 강제 clear는 tmux 부재 확정 분기(`missing_tmux`)에서만 가능.
5. **[minor] 전역 미러 unlink 가드**: `remove_idle_entry`가 핸들/시그널 동일성 확인 후에만 전역 미러를 unlink (`remove_idle_entry_skips_global_mirrors_owned_by_another_instance` red-green).

## 게이트

- `cargo fmt --all --check` / `cargo check --workspace --all-features --all-targets` / `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- Targeted lib tests (recovery_engine / recovery_paths / inflight / turn_orchestrator / health_api / placeholder_sweeper) + the CI `test-non-pg` subset (transition/auto_queue/cancel/review_decision/invariant): all green.
- `audit_maintainability --check`: pass with **no baseline raises** — `recovery_engine.rs` lands exactly at its 4090 freeze (new logic lives in `recovery_paths/{shared,restart}.rs` and `turn_orchestrator/registry_purge.rs`); 3 baselines lowered to lock shrink wins (`health/recovery.rs` 2645→2641, `inflight.rs` 2466→2465, `turn_orchestrator.rs` 3090→3089).
- `check_await_holding_lock_ratchet`: 34 (unchanged). `generate_inventory_docs --check` + `check_agent_maintenance_docs`: pass (change-surfaces freeze entries synced).
- Note: full `cargo test --lib` shows a pre-existing env-race poison-cascade failure family — verified identical on **untouched origin/main** (11 failures at merge-base, same tests). That is exactly #3293 scope (a), deliberately left to the followup slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
