### PR TITLE
refactor(#3038): extract stranded-draft recovery from warm followup (S1)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -932,7 +932,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
 - `src/services/dispatches/outbox_route.rs` (1089) — dispatch outbox route
   support extracted from the route layer; split before adding non-bugfix
   behavior.
-- `src/services/claude.rs` (3847), `src/services/gemini.rs` (1358),
+- `src/services/claude.rs` (3948), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3001),
   `src/services/opencode.rs` (1881), `src/services/provider.rs` (1796) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
@@ -944,7 +944,15 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   `codex_context_window_from_cache` unit-test module. #3281 truthified the
   Claude TUI producer-exit `lines=` count via `ReadHarvestStats` and added
   `claude_tui_zero_harvest_*` observability events for delivered turns that
-  forwarded nothing.)
+  forwarded nothing. #3038 S1: +101 from extracting the warm-followup stranded
+  prompt-draft recovery block into `recover_claude_tui_stranded_prompt_draft`
+  with the `#[must_use] ClaudeTuiDraftRecoveryOutcome` carrier — behaviour-
+  preserving, the +101 is the new outcome enum, the two verbatim-extraction doc
+  contracts, and the call-site `match` dispatch (the recovery body itself is a
+  move). claude.rs is not in the giant-file ratchet baseline; this is a
+  freshness-annotation sync, not a baseline raise. Slice S3 relocates the
+  hosting cluster to a directory and drives claude.rs back under the giant
+  threshold.)
 - `src/services/codex_tui/rollout_tail.rs` (1639) — Codex TUI rollout tail
   parsing and resume identity surface; split before adding non-bugfix behavior
   beyond the #2169 session identity fix.

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -2327,6 +2327,34 @@ struct ClaudeTuiRecreateState {
     resume: bool,
 }
 
+/// Outcome of the stranded prompt-draft recovery probe that runs before a warm
+/// follow-up submit.
+///
+/// `Terminal` carries the original early-return `Result` verbatim — the warm
+/// follow-up orchestrator must surface it immediately (the recovery block's
+/// `return Ok(())` cancellation exits and `Err(..)` fresh-resolution failures
+/// short-circuit before any submit-phase side-effect). `Proceed` carries the
+/// (possibly recreated) session resolution plus the three submit-gating flags
+/// exactly as the inline locals held them at the original fall-through point.
+#[cfg(unix)]
+#[must_use]
+enum ClaudeTuiDraftRecoveryOutcome {
+    /// Recovery completed and the follow-up may continue to submit-plan
+    /// computation. `state` carries the session quartet (recreated when a
+    /// draft-recovery kill ladder ran), and the three flags reflect whether a
+    /// busy wait occurred, whether the session was recreated before submit, and
+    /// whether a stranded prompt draft was cleared before submit.
+    Proceed {
+        state: ClaudeTuiRecreateState,
+        busy_waited: bool,
+        recreate_before_submit: bool,
+        prompt_draft_cleared_before_submit: bool,
+    },
+    /// Recovery hit an original early return; `Result` is forwarded verbatim to
+    /// the orchestrator's caller.
+    Terminal(Result<(), String>),
+}
+
 /// Outcome of an attempted warm follow-up against a live Claude TUI session.
 #[cfg(unix)]
 enum ClaudeTuiWarmFollowupOutcome {
@@ -2338,37 +2366,33 @@ enum ClaudeTuiWarmFollowupOutcome {
     Recreate(ClaudeTuiRecreateState),
 }
 
-/// Attempt a warm follow-up against an existing live Claude TUI tmux session.
+/// Recover from a stranded prompt draft left in the composer before a warm
+/// follow-up submit.
 ///
-/// Mirrors the pre-refactor inline `if session_exists && has_live_pane && resume`
-/// block verbatim: stranded prompt-draft recovery, busy-wait, prompt submission,
-/// transcript read, and the follow-up result classification. Every original
-/// `return Ok(())` / `return Err(..)` / `?` short-circuit is preserved as a
-/// `Terminal(..)` outcome (so the orchestrator returns immediately with the same
-/// value, before any fresh-launch side-effect). When the block originally fell
-/// through to a fresh launch — `submit_existing_session == false`, the
-/// `RecreateSession` classification, or a draft-recovery recreate — this returns
-/// `Recreate(..)` carrying the session resolution exactly as the inline locals
-/// held it at that point.
+/// Verbatim extraction of the stranded prompt-draft recovery block from
+/// `try_claude_tui_warm_followup` (#3196/#3228 extraction convention): the
+/// session quartet enters via [`ClaudeTuiRecreateState`] and is destructured
+/// into the same mutable locals the inline block used, so the body is preserved
+/// token-for-token. Every original early return is forwarded as
+/// `ClaudeTuiDraftRecoveryOutcome::Terminal(..)` carrying the same `Result` (the
+/// draft-clear cancellation exit returns `Ok(())`; the two
+/// `fresh_claude_tui_session_resolution` failures return `Err(..)`). The
+/// original fall-through is `Proceed` carrying the (possibly recreated) quartet
+/// and the three submit-gating flags exactly as the inline locals held them.
 #[cfg(unix)]
-fn try_claude_tui_warm_followup(
-    mut resolved_session_id: String,
-    mut transcript_path: std::path::PathBuf,
-    mut transcript_path_string: String,
-    mut resume: bool,
+fn recover_claude_tui_stranded_prompt_draft(
+    state: ClaudeTuiRecreateState,
     working_dir_path: &std::path::Path,
-    prompt: &str,
-    sender: Sender<StreamMessage>,
-    cancel_token: Option<std::sync::Arc<CancelToken>>,
+    cancel_token: &Option<std::sync::Arc<CancelToken>>,
     tmux_session_name: &str,
     report_channel_id: Option<u64>,
-) -> ClaudeTuiWarmFollowupOutcome {
-    debug_log("Existing Claude TUI tmux session found — sending follow-up");
-    if let Some(ref token) = cancel_token {
-        *token.tmux_session.lock().unwrap_or_else(|e| e.into_inner()) =
-            Some(tmux_session_name.to_string());
-    }
-    let hook_rx = crate::services::claude_tui::hook_server::subscribe_hook_events();
+) -> ClaudeTuiDraftRecoveryOutcome {
+    let ClaudeTuiRecreateState {
+        mut resolved_session_id,
+        mut transcript_path,
+        mut transcript_path_string,
+        mut resume,
+    } = state;
     // #2416: a single busy_waited flag tells the offset-capture site below
     // that we need to re-read transcript length after the wait succeeded,
     // because the previous TUI turn may have appended bytes while we were
@@ -2485,7 +2509,7 @@ fn try_claude_tui_warm_followup(
                             match fresh_claude_tui_session_resolution(working_dir_path, None) {
                                 Ok(resolution) => resolution,
                                 Err(error) => {
-                                    return ClaudeTuiWarmFollowupOutcome::Terminal(Err(error));
+                                    return ClaudeTuiDraftRecoveryOutcome::Terminal(Err(error));
                                 }
                             };
                         resolved_session_id = fresh_resolution.session_id;
@@ -2514,7 +2538,7 @@ fn try_claude_tui_warm_followup(
                             "transcript_path": transcript_path_string,
                         }),
                     );
-                    return ClaudeTuiWarmFollowupOutcome::Terminal(Ok(()));
+                    return ClaudeTuiDraftRecoveryOutcome::Terminal(Ok(()));
                 }
                 Err(error) => {
                     let recreate_after_clear_error = allow_recreate
@@ -2561,7 +2585,7 @@ fn try_claude_tui_warm_followup(
                             match fresh_claude_tui_session_resolution(working_dir_path, None) {
                                 Ok(resolution) => resolution,
                                 Err(error) => {
-                                    return ClaudeTuiWarmFollowupOutcome::Terminal(Err(error));
+                                    return ClaudeTuiDraftRecoveryOutcome::Terminal(Err(error));
                                 }
                             };
                         resolved_session_id = fresh_resolution.session_id;
@@ -2574,6 +2598,83 @@ fn try_claude_tui_warm_followup(
             }
         }
     }
+    ClaudeTuiDraftRecoveryOutcome::Proceed {
+        state: ClaudeTuiRecreateState {
+            resolved_session_id,
+            transcript_path,
+            transcript_path_string,
+            resume,
+        },
+        busy_waited,
+        recreate_before_submit,
+        prompt_draft_cleared_before_submit,
+    }
+}
+
+/// Attempt a warm follow-up against an existing live Claude TUI tmux session.
+///
+/// Mirrors the pre-refactor inline `if session_exists && has_live_pane && resume`
+/// block verbatim: stranded prompt-draft recovery, busy-wait, prompt submission,
+/// transcript read, and the follow-up result classification. Every original
+/// `return Ok(())` / `return Err(..)` / `?` short-circuit is preserved as a
+/// `Terminal(..)` outcome (so the orchestrator returns immediately with the same
+/// value, before any fresh-launch side-effect). When the block originally fell
+/// through to a fresh launch — `submit_existing_session == false`, the
+/// `RecreateSession` classification, or a draft-recovery recreate — this returns
+/// `Recreate(..)` carrying the session resolution exactly as the inline locals
+/// held it at that point.
+#[cfg(unix)]
+fn try_claude_tui_warm_followup(
+    mut resolved_session_id: String,
+    mut transcript_path: std::path::PathBuf,
+    mut transcript_path_string: String,
+    mut resume: bool,
+    working_dir_path: &std::path::Path,
+    prompt: &str,
+    sender: Sender<StreamMessage>,
+    cancel_token: Option<std::sync::Arc<CancelToken>>,
+    tmux_session_name: &str,
+    report_channel_id: Option<u64>,
+) -> ClaudeTuiWarmFollowupOutcome {
+    debug_log("Existing Claude TUI tmux session found — sending follow-up");
+    if let Some(ref token) = cancel_token {
+        *token.tmux_session.lock().unwrap_or_else(|e| e.into_inner()) =
+            Some(tmux_session_name.to_string());
+    }
+    let hook_rx = crate::services::claude_tui::hook_server::subscribe_hook_events();
+    let (mut busy_waited, recreate_before_submit, prompt_draft_cleared_before_submit) =
+        match recover_claude_tui_stranded_prompt_draft(
+            ClaudeTuiRecreateState {
+                resolved_session_id,
+                transcript_path,
+                transcript_path_string,
+                resume,
+            },
+            working_dir_path,
+            &cancel_token,
+            tmux_session_name,
+            report_channel_id,
+        ) {
+            ClaudeTuiDraftRecoveryOutcome::Proceed {
+                state,
+                busy_waited,
+                recreate_before_submit,
+                prompt_draft_cleared_before_submit,
+            } => {
+                resolved_session_id = state.resolved_session_id;
+                transcript_path = state.transcript_path;
+                transcript_path_string = state.transcript_path_string;
+                resume = state.resume;
+                (
+                    busy_waited,
+                    recreate_before_submit,
+                    prompt_draft_cleared_before_submit,
+                )
+            }
+            ClaudeTuiDraftRecoveryOutcome::Terminal(r) => {
+                return ClaudeTuiWarmFollowupOutcome::Terminal(r);
+            }
+        };
     let submit_plan = claude_tui_warm_followup_submit_plan(
         recreate_before_submit,
         prompt_draft_cleared_before_submit,
@@ -4849,5 +4950,67 @@ mod claude_tui_session_resolution_tests {
         let recreate = claude_tui_warm_followup_submit_plan(true, false);
         assert!(!recreate.submit_existing_session);
         assert!(recreate.recheck_busy_before_submit);
+    }
+
+    /// Seed for the #3038 S1 extraction: the session quartet carried into and
+    /// back out of `recover_claude_tui_stranded_prompt_draft` via the `Proceed`
+    /// arm must be the identity on the no-op fall-through path (no recreate
+    /// ladder, all flags `false`). This guards the move-in/move-out contract the
+    /// orchestrator relies on to rebind its session locals.
+    #[test]
+    fn draft_recovery_proceed_round_trips_session_quartet() {
+        let session_id = uuid::Uuid::new_v4().to_string();
+        let transcript_path = std::path::PathBuf::from("/tmp/agentdesk-3038-seed.jsonl");
+        let transcript_path_string = transcript_path.display().to_string();
+        let outcome = ClaudeTuiDraftRecoveryOutcome::Proceed {
+            state: ClaudeTuiRecreateState {
+                resolved_session_id: session_id.clone(),
+                transcript_path: transcript_path.clone(),
+                transcript_path_string: transcript_path_string.clone(),
+                resume: true,
+            },
+            busy_waited: false,
+            recreate_before_submit: false,
+            prompt_draft_cleared_before_submit: false,
+        };
+
+        match outcome {
+            ClaudeTuiDraftRecoveryOutcome::Proceed {
+                state,
+                busy_waited,
+                recreate_before_submit,
+                prompt_draft_cleared_before_submit,
+            } => {
+                assert_eq!(state.resolved_session_id, session_id);
+                assert_eq!(state.transcript_path, transcript_path);
+                assert_eq!(state.transcript_path_string, transcript_path_string);
+                assert!(state.resume);
+                assert!(!busy_waited);
+                assert!(!recreate_before_submit);
+                assert!(!prompt_draft_cleared_before_submit);
+            }
+            ClaudeTuiDraftRecoveryOutcome::Terminal(_) => {
+                panic!("Proceed outcome must not destructure as Terminal");
+            }
+        }
+    }
+
+    /// The `Terminal` arm must forward the original early-return `Result`
+    /// verbatim (the recovery block's cancellation exit returns `Ok(())`, fresh
+    /// resolution failures return `Err(..)`). This pins the payload-passthrough
+    /// contract the orchestrator depends on to surface the same value its
+    /// inline early returns produced.
+    #[test]
+    fn draft_recovery_terminal_forwards_result_verbatim() {
+        match ClaudeTuiDraftRecoveryOutcome::Terminal(Ok(())) {
+            ClaudeTuiDraftRecoveryOutcome::Terminal(r) => assert_eq!(r, Ok(())),
+            ClaudeTuiDraftRecoveryOutcome::Proceed { .. } => panic!("expected Terminal(Ok)"),
+        }
+        match ClaudeTuiDraftRecoveryOutcome::Terminal(Err("boom".to_string())) {
+            ClaudeTuiDraftRecoveryOutcome::Terminal(r) => {
+                assert_eq!(r, Err("boom".to_string()));
+            }
+            ClaudeTuiDraftRecoveryOutcome::Proceed { .. } => panic!("expected Terminal(Err)"),
+        }
     }
 }


### PR DESCRIPTION
## Summary (#3038 Phase A — S1 slice)

Verbatim-extract the **stranded prompt-draft recovery block** out of `try_claude_tui_warm_followup` (the lone remaining god function on this surface, ~513 lines on `origin/main` `808d000e4`) into a dedicated `recover_claude_tui_stranded_prompt_draft` helper plus a `#[must_use] ClaudeTuiDraftRecoveryOutcome` carrier, following the #3196/#3228 verbatim-extraction + outcome-enum convention.

> Boundaries are described **structurally**; line numbers are `origin/main` `808d000e4` reference values (recovery block `claude.rs:2380-2576`, ~197 lines).

The recovery body moves **token-for-token**. The session quartet (`resolved_session_id` / `transcript_path` / `transcript_path_string` / `resume`) enters the helper via `ClaudeTuiRecreateState` (move-in), is destructured into the same mutable locals the inline block used, and returns via the `Proceed` arm (move-out). The orchestrator then rebinds its session locals and the three submit-gating flags exactly as the inline locals held them at the original fall-through. `warm-followup` shrinks ~513 → ~330 lines.

## Allowed body modifications (per-item identity argument)

Per the design's allow-list, only two classes of token changes were made inside the moved body; everything else is verbatim:

- **(a) enum-name swap on early returns.** The three `return ClaudeTuiWarmFollowupOutcome::Terminal(x)` short-circuits become `return ClaudeTuiDraftRecoveryOutcome::Terminal(x)`. The `Result` payload is byte-identical in all three: 1× cancellation exit `Ok(())` (`tui_warm_followup_cancelled_during_draft_clear`), 2× `fresh_claude_tui_session_resolution` failures `Err(error)`. The orchestrator's `Terminal(r)` match arm re-wraps verbatim: `return ClaudeTuiWarmFollowupOutcome::Terminal(r)` — so the value the caller observes is unchanged.
- **(b) fall-through → `Proceed`.** The original implicit fall-through (after the `if let Some(snapshot) … { … }` block) becomes `ClaudeTuiDraftRecoveryOutcome::Proceed { state: ClaudeTuiRecreateState { … }, busy_waited, recreate_before_submit, prompt_draft_cleared_before_submit }`, equivalent to the inline fall-through state. No other body token changed.

`cancel_token` is received as `&Option<Arc<CancelToken>>`; the body's `cancel_token.as_deref()` call sites work unchanged via autoref. `busy_waited` is rebound `mut` at the call site because the (unchanged, S2-territory) submit phase still reassigns it.

## Invariants preserved

- **Turn-lock machinery stays put.** `CLAUDE_TUI_SESSION_TURN_LOCKS` + `with_claude_tui_session_turn_lock` (shared by `claude_compact_trigger.rs`) and the `_turn_guard` binding remain in the orchestrator's top frame — not moved into the helper.
- **Cancel contract.** The draft-clear cancellation branch still emits only its producer-exit log (`tui_warm_followup_cancelled_during_draft_clear`) and terminates `Ok(())` — no extra `StreamMessage`. The `#[must_use]` attribute forces the orchestrator to consume the outcome, and clippy `-D warnings` enforces it.
- **Teardown order** (`record_termination_for_tmux` → `record_tmux_exit_reason` → `kill_session` → fresh resolution) is verbatim in both recreate ladders.
- **Visibility surface frozen.** The new items are `private` + `#[cfg(unix)]`; no `pub`/`pub(crate)` re-export changed (`grep` confirms zero references to the new symbols outside `claude.rs`).

## Tests

- **Existing inline tests pass unmodified** (`cargo test --lib services::claude` → 185 passed): turn-lock #3262 serialization, stranded-draft state machine, unknown-transcript recreate allowance, submit-plan, zero-harvest gate, ready probe, session resolution.
- **New seed tests** (in `claude_tui_session_resolution_tests`, `#[cfg(all(test, unix))]`): `draft_recovery_proceed_round_trips_session_quartet` (Proceed quartet move-in/move-out identity on the no-op fall-through) and `draft_recovery_terminal_forwards_result_verbatim` (Terminal `Ok`/`Err` passthrough).
- **`#[must_use]` compile guard** on `ClaudeTuiDraftRecoveryOutcome`.
- e2e characterization (`tests/e2e/tui_relay` `E-10-stranded-draft` / `E-18-stop-mid-turn-cancel` / `E-19-session-continuity` / `E-12-tmux-pane-kill`) is the design's supplementary safety net; it is environment-coupled (live tmux + dcserver) and was **not run** in this single-live-checkout workspace to avoid touching the live control plane. The inline unit layer fully pins the pure predicates this slice depends on.

## CI gates

| gate | result |
| --- | --- |
| `cargo fmt --check` | pass |
| `cargo check --lib --tests` | pass, 0 warnings |
| `cargo clippy --all-targets -- -D warnings` | pass |
| `cargo test --lib services::claude` | 185 passed |
| `generate_inventory_docs` + `check_agent_maintenance_docs` | pass (freshness synced) |
| `audit_maintainability --check` | pass |
| `check_await_holding_lock_ratchet` | OK, 34 (baseline unchanged) |

## Accounting

In-file slice. `claude.rs` is **not** in the `giant_file_ratchet` baseline, so the `change-surfaces.md` annotation update (3847 → 3948, **+101**) is a **freshness-annotation sync, not a baseline raise** — the +101 is the new outcome enum, the two verbatim-extraction doc contracts, and the call-site `match` dispatch (the recovery body itself is a move). No ratchet baselines raised. Generated `docs/generated/*` are gitignored and unchanged in substance.

## Follow-up slice DAG

- **S2 (depends on S1):** extract `submit_existing_session` body (busy-recheck + prompt-ready wait, offset/cancel, prompt injection, transcript read, zero-advance guard, classify 3-arm dispatch) into `run_claude_tui_warm_followup_submit_and_stream` returning `{ Terminal(Result) | FallThroughRecreate }`.
- **S3 (depends on S1+S2, #3294/#3295 directory pattern):** relocate the Direct-TUI hosting cluster to `src/services/claude_tui/hosting/` submodules, driving `claude.rs` back under the giant threshold. Turn-lock machinery + `pub` surface stay at the root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)