### PR TITLE
fix(#3296): keep ⏳ on synthetic turn-start ABORT; reconcile ✅/⚠ via durable aborted-anchor marker

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -551,6 +551,7 @@ src/
 │   │   ├── tmux_restart_handoff.rs
 │   │   ├── tmux_session_files.rs
 │   │   ├── tmux_watcher.rs
+│   │   ├── tui_direct_abort_marker.rs
 │   │   ├── tui_direct_pending_start.rs
 │   │   ├── tui_prompt_relay.rs
 │   │   ├── tui_task_card.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -419,19 +419,26 @@
     +19 from #3296: the aborted-anchor reconcile chokepoint — on a body-visible
     normal commit (`terminal_output_committed &&
     tui_direct_anchor_terminal_body_visible && !lifecycle_stage_paused`, sited
-    AFTER `clear_inflight_state` for race ordering) the watcher calls
+    BEFORE `clear_inflight_state` since codex r2) the watcher durably records a
+    `tui_direct_abort_marker::record_commit_tombstone` (committed turn
+    identity — written FIRST, so any reconciler that observes "no live row"
+    already sees the commit evidence) and then calls
     `tui_direct_abort_marker::drain_on_terminal_commit` with the COMMITTED
     turn's identity (codex r1: positive correlation — only the foreign prior
     inflight the ABORT pinned may cover), so an anchor whose synthetic
     turn-start ABORTed (input already provider-submitted, `⏳` kept) flips
     `⏳ → ✅` when that turn commits; the marker logic itself lives in the new
-    non-giant `tui_direct_abort_marker.rs` (sweeper TTL/hard-cap `⚠` fallback);
-    the +19 is offset in-file by compressing the #3016-S3 finalize/TOCTOU
-    comment block (−20), so the 9583 ratchet baseline is unchanged.
-  - `src/services/discord/tui_prompt_relay.rs` (5431 lines; +14 from #3296
-    codex r1: the ABORT cleanup hook pins the live foreign prior inflight's
-    identity — or records the marker pre-covered when that row is already
-    gone — before persisting the aborted-anchor marker; #3016 phase-5b2
+    non-giant `tui_direct_abort_marker.rs` (sweeper TTL/hard-cap `⚠` fallback +
+    commit-tombstone 대조); the additions are offset in-file by compressing the
+    #3016-S3 finalize/TOCTOU and #1670/#1708 decoupling comment blocks, so the
+    9583 ratchet baseline is unchanged.
+  - `src/services/discord/tui_prompt_relay.rs` (5438 production lines; #3296
+    codex r1+r2: the ABORT cleanup hook pins the foreign prior inflight's
+    identity — the live row at the record instant, or the worker's LAST-VIEW
+    identity when that row just vanished — and persists the marker via
+    `record_for_abort`, whose commit-tombstone 대조 (never bare row-absence:
+    codex r2 removed the unfounded pre-covered promotion) decides whether it
+    starts covered; #3016 phase-5b2
     removed the dead `publish_tui_direct_watcher_finalize_debt` producer;
     SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only
@@ -590,7 +597,9 @@
     added the anchor `⏳` (#3164 add≡remove invariant) — removing the stranded
     `⏳` and marking `⚠` on the anchor message (precedent: the watcher's
     auth-expired `⏳ → ⚠` swap), because no claim ever drives the normal
-    `⏳ → ✅` completion for an ABORTed synthetic start; -75 from #3282
+    `⏳ → ✅` completion for an ABORTed synthetic start (the `⚠` swap itself is
+    superseded by #3296: the hook now KEEPS the `⏳` and records the durable
+    aborted-anchor marker — see the entry head); -75 from #3282
     follow-up: verbose multi-line comment blocks compressed (no semantic
     change) to offset the +54 growth and keep prod LoC under the frozen
     `giant_file_ratchet` baseline (5438, #3028).

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -131,7 +131,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (9600 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (9580 lines after #2558
     dead-code sweep; #3016 phase-5b2 removed the `mailbox_finalize_owed`
     swap reads, the watcher-fn flag params, and the `LegacyFlagGated`
     decision variant; #1520 watcher loop extraction + #2427 D/A
@@ -416,14 +416,16 @@
     helper additionally fires the claude-only AgentDesk-side `/compact` injection
     when live usage crosses `context_compact_percent_claude` (Claude Code ignores
     `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`); see `src/services/claude_compact_trigger.rs`.
-    +19 from #3296: the aborted-anchor reconcile chokepoint — after the terminal
+    +17 from #3296: the aborted-anchor reconcile chokepoint — after the terminal
     anchor-cleanup branches, a body-visible normal commit
     (`terminal_output_committed && tui_direct_anchor_terminal_body_visible &&
     !lifecycle_stage_paused`) calls
     `tui_direct_abort_marker::drain_on_terminal_commit` so an anchor whose
     synthetic turn-start ABORTed (input already provider-submitted, `⏳` kept)
     flips `⏳ → ✅` when the prior owner covers it; the marker logic itself lives
-    in the new non-giant `tui_direct_abort_marker.rs` (sweeper TTL `⚠` fallback).
+    in the new non-giant `tui_direct_abort_marker.rs` (sweeper TTL `⚠` fallback);
+    the +17 is offset in-file by compressing the #3016-S3 finalize/TOCTOU
+    comment block (−20), so the 9583 ratchet baseline is unchanged.
   - `src/services/discord/tui_prompt_relay.rs` (5417 lines; #3016 phase-5b2
     removed the dead `publish_tui_direct_watcher_finalize_debt` producer;
     SSH-direct TUI

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -131,7 +131,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (9581 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (9600 lines after #2558
     dead-code sweep; #3016 phase-5b2 removed the `mailbox_finalize_owed`
     swap reads, the watcher-fn flag params, and the `LegacyFlagGated`
     decision variant; #1520 watcher loop extraction + #2427 D/A
@@ -416,6 +416,14 @@
     helper additionally fires the claude-only AgentDesk-side `/compact` injection
     when live usage crosses `context_compact_percent_claude` (Claude Code ignores
     `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`); see `src/services/claude_compact_trigger.rs`.
+    +19 from #3296: the aborted-anchor reconcile chokepoint — after the terminal
+    anchor-cleanup branches, a body-visible normal commit
+    (`terminal_output_committed && tui_direct_anchor_terminal_body_visible &&
+    !lifecycle_stage_paused`) calls
+    `tui_direct_abort_marker::drain_on_terminal_commit` so an anchor whose
+    synthetic turn-start ABORTed (input already provider-submitted, `⏳` kept)
+    flips `⏳ → ✅` when the prior owner covers it; the marker logic itself lives
+    in the new non-giant `tui_direct_abort_marker.rs` (sweeper TTL `⚠` fallback).
   - `src/services/discord/tui_prompt_relay.rs` (5417 lines; #3016 phase-5b2
     removed the dead `publish_tui_direct_watcher_finalize_debt` producer;
     SSH-direct TUI

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -131,7 +131,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (9580 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (9582 lines after #2558
     dead-code sweep; #3016 phase-5b2 removed the `mailbox_finalize_owed`
     swap reads, the watcher-fn flag params, and the `LegacyFlagGated`
     decision variant; #1520 watcher loop extraction + #2427 D/A
@@ -416,17 +416,22 @@
     helper additionally fires the claude-only AgentDesk-side `/compact` injection
     when live usage crosses `context_compact_percent_claude` (Claude Code ignores
     `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`); see `src/services/claude_compact_trigger.rs`.
-    +17 from #3296: the aborted-anchor reconcile chokepoint — after the terminal
-    anchor-cleanup branches, a body-visible normal commit
-    (`terminal_output_committed && tui_direct_anchor_terminal_body_visible &&
-    !lifecycle_stage_paused`) calls
-    `tui_direct_abort_marker::drain_on_terminal_commit` so an anchor whose
-    synthetic turn-start ABORTed (input already provider-submitted, `⏳` kept)
-    flips `⏳ → ✅` when the prior owner covers it; the marker logic itself lives
-    in the new non-giant `tui_direct_abort_marker.rs` (sweeper TTL `⚠` fallback);
-    the +17 is offset in-file by compressing the #3016-S3 finalize/TOCTOU
+    +19 from #3296: the aborted-anchor reconcile chokepoint — on a body-visible
+    normal commit (`terminal_output_committed &&
+    tui_direct_anchor_terminal_body_visible && !lifecycle_stage_paused`, sited
+    AFTER `clear_inflight_state` for race ordering) the watcher calls
+    `tui_direct_abort_marker::drain_on_terminal_commit` with the COMMITTED
+    turn's identity (codex r1: positive correlation — only the foreign prior
+    inflight the ABORT pinned may cover), so an anchor whose synthetic
+    turn-start ABORTed (input already provider-submitted, `⏳` kept) flips
+    `⏳ → ✅` when that turn commits; the marker logic itself lives in the new
+    non-giant `tui_direct_abort_marker.rs` (sweeper TTL/hard-cap `⚠` fallback);
+    the +19 is offset in-file by compressing the #3016-S3 finalize/TOCTOU
     comment block (−20), so the 9583 ratchet baseline is unchanged.
-  - `src/services/discord/tui_prompt_relay.rs` (5417 lines; #3016 phase-5b2
+  - `src/services/discord/tui_prompt_relay.rs` (5431 lines; +14 from #3296
+    codex r1: the ABORT cleanup hook pins the live foreign prior inflight's
+    identity — or records the marker pre-covered when that row is already
+    gone — before persisting the aborted-anchor marker; #3016 phase-5b2
     removed the dead `publish_tui_direct_watcher_finalize_debt` producer;
     SSH-direct TUI
     prompt notification plus Codex rollout response relay surface, bugfix only

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -131,7 +131,7 @@
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
     still giant-file territory).
-  - `src/services/discord/tmux_watcher.rs` (9582 lines after #2558
+  - `src/services/discord/tmux_watcher.rs` (9580 lines after #2558
     dead-code sweep; #3016 phase-5b2 removed the `mailbox_finalize_owed`
     swap reads, the watcher-fn flag params, and the `LegacyFlagGated`
     decision variant; #1520 watcher loop extraction + #2427 D/A

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -615,10 +615,14 @@
   `runtime/discord_tui_direct_abort_marker/` root instead of swapping `⏳ → ⚠`;
   the watcher terminal-commit chokepoint (`tmux_watcher.rs`) drains it `⏳ → ✅`
   on a covering commit and the placeholder sweeper applies the TTL'd `⏳ → ⚠`
-  fallback (`tui_direct_abort_marker.rs`). **Worker-local**: the store lives on
-  the SAME node's filesystem as the pending-start store it mirrors, is written
-  and drained only by that node's own relay worker / watcher loop / sweeper task
-  (all already worker-local surfaces), and the reaction ops resolve the
-  process-local `serenity_http_or_token_fallback()` bot identity — no PG lease,
-  no cross-node reads, no leader-only side effect. No new multinode
-  ownership/singleton/lease assumption is introduced.
+  fallback (`tui_direct_abort_marker.rs`). Codex r2 adds a sibling node-local
+  `runtime/discord_tui_direct_commit_tombstone/` root (`CommitTombstone`):
+  written only by the same node's watcher chokepoint BEFORE its inflight-row
+  clear, read only by that node's ABORT path / sweeper 대조, GC'd by the same
+  sweeper — the same worker-local surfaces. **Worker-local**: both stores live
+  on the SAME node's filesystem as the pending-start store they mirror, are
+  written and drained only by that node's own relay worker / watcher loop /
+  sweeper task, and the reaction ops resolve the process-local
+  `serenity_http_or_token_fallback()` bot identity — no PG lease, no cross-node
+  reads, no leader-only side effect. No new multinode ownership/singleton/lease
+  assumption is introduced.

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -609,3 +609,16 @@
   (`~/.codex/models_cache.json`) on the node that owns the session — it owns no
   global state, no durable queue, and no lease, and touches no PG-lease/leader
   path. No new multinode ownership, singleton, or lease assumption is introduced.
+- #3296 (aborted-anchor reaction reconcile): the synthetic turn-start ABORT path
+  (`tui_prompt_relay.rs` / `tui_direct_pending_start.rs`) now records a durable
+  `AbortedAnchorMarker` under the new node-local
+  `runtime/discord_tui_direct_abort_marker/` root instead of swapping `⏳ → ⚠`;
+  the watcher terminal-commit chokepoint (`tmux_watcher.rs`) drains it `⏳ → ✅`
+  on a covering commit and the placeholder sweeper applies the TTL'd `⏳ → ⚠`
+  fallback (`tui_direct_abort_marker.rs`). **Worker-local**: the store lives on
+  the SAME node's filesystem as the pending-start store it mirrors, is written
+  and drained only by that node's own relay worker / watcher loop / sweeper task
+  (all already worker-local surfaces), and the reaction ops resolve the
+  process-local `serenity_http_or_token_fallback()` bot identity — no PG lease,
+  no cross-node reads, no leader-only side effect. No new multinode
+  ownership/singleton/lease assumption is introduced.

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -24,13 +24,14 @@
 # #3262/#3272, which extracted the inline completed-panel backfill block into
 # `adk_session::backfill_completed_panel_usage_and_maybe_inject_compact` (−16
 # prod lines), so the frozen true production LoC settles at 9583. KEPT surfaces.
-# #3296: +17 in-file for the aborted-anchor reconcile chokepoint — the single
-# guarded `tui_direct_abort_marker::drain_on_terminal_commit` call after the
-# terminal anchor-cleanup branches (the marker logic lives in the new
+# #3296: +19 in-file for the aborted-anchor reconcile chokepoint — the single
+# guarded `tui_direct_abort_marker::drain_on_terminal_commit` call, sited
+# after `clear_inflight_state` and passing the committed turn's identity
+# (codex r1 positive correlation; the marker logic lives in the new
 # non-giant `tui_direct_abort_marker.rs`) — offset in the same change by
 # compressing the #3016-S3 finalize/TOCTOU comment block (−20, issue
 # references and the atomicity rationale preserved), so the file lands at
-# 9580 under the unchanged frozen baseline (no raise).
+# 9582 under the unchanged frozen baseline (no raise).
 "src/services/discord/tmux_watcher.rs" = 9583
 # Frozen at its true production LoC once #3028 fixed the prod/test splitter
 # (lifetime/char-literal brace miscount): the first inline `#[cfg(test)] mod`

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -24,13 +24,14 @@
 # #3262/#3272, which extracted the inline completed-panel backfill block into
 # `adk_session::backfill_completed_panel_usage_and_maybe_inject_compact` (−16
 # prod lines), so the frozen true production LoC settles at 9583. KEPT surfaces.
-# #3296: +17 (9583 -> 9600) for the aborted-anchor reconcile chokepoint — the
-# single guarded `tui_direct_abort_marker::drain_on_terminal_commit` call after
-# the terminal anchor-cleanup branches. The marker logic itself lives in the
-# new (non-giant) `tui_direct_abort_marker.rs`; this is the minimum in-file
-# surface (one call site at the only body-visible terminal-commit chokepoint).
-# Deliberate, workflow-sanctioned raise.
-"src/services/discord/tmux_watcher.rs" = 9600
+# #3296: +17 in-file for the aborted-anchor reconcile chokepoint — the single
+# guarded `tui_direct_abort_marker::drain_on_terminal_commit` call after the
+# terminal anchor-cleanup branches (the marker logic lives in the new
+# non-giant `tui_direct_abort_marker.rs`) — offset in the same change by
+# compressing the #3016-S3 finalize/TOCTOU comment block (−20, issue
+# references and the atomicity rationale preserved), so the file lands at
+# 9580 under the unchanged frozen baseline (no raise).
+"src/services/discord/tmux_watcher.rs" = 9583
 # Frozen at its true production LoC once #3028 fixed the prod/test splitter
 # (lifetime/char-literal brace miscount): the first inline `#[cfg(test)] mod`
 # block was over-extended to EOF, so `spawn_turn_bridge` and ~9000 lines of the

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -24,14 +24,16 @@
 # #3262/#3272, which extracted the inline completed-panel backfill block into
 # `adk_session::backfill_completed_panel_usage_and_maybe_inject_compact` (−16
 # prod lines), so the frozen true production LoC settles at 9583. KEPT surfaces.
-# #3296: +19 in-file for the aborted-anchor reconcile chokepoint — the single
-# guarded `tui_direct_abort_marker::drain_on_terminal_commit` call, sited
-# after `clear_inflight_state` and passing the committed turn's identity
-# (codex r1 positive correlation; the marker logic lives in the new
+# #3296: the aborted-anchor reconcile chokepoint — one guarded block recording
+# the `tui_direct_abort_marker::record_commit_tombstone` commit evidence and
+# calling `drain_on_terminal_commit`, sited BEFORE `clear_inflight_state`
+# (codex r2: tombstone → drain → clear, so a racing sweep that observes "no
+# live row" always sees the commit evidence) and passing the committed turn's
+# identity (codex r1 positive correlation; the marker logic lives in the new
 # non-giant `tui_direct_abort_marker.rs`) — offset in the same change by
-# compressing the #3016-S3 finalize/TOCTOU comment block (−20, issue
-# references and the atomicity rationale preserved), so the file lands at
-# 9582 under the unchanged frozen baseline (no raise).
+# compressing the #3016-S3 finalize/TOCTOU and #1670/#1708 decoupling comment
+# blocks (issue references and rationale preserved), so the file lands at
+# 9580 under the unchanged frozen baseline (no raise).
 "src/services/discord/tmux_watcher.rs" = 9583
 # Frozen at its true production LoC once #3028 fixed the prod/test splitter
 # (lifetime/char-literal brace miscount): the first inline `#[cfg(test)] mod`

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -24,7 +24,13 @@
 # #3262/#3272, which extracted the inline completed-panel backfill block into
 # `adk_session::backfill_completed_panel_usage_and_maybe_inject_compact` (−16
 # prod lines), so the frozen true production LoC settles at 9583. KEPT surfaces.
-"src/services/discord/tmux_watcher.rs" = 9583
+# #3296: +17 (9583 -> 9600) for the aborted-anchor reconcile chokepoint — the
+# single guarded `tui_direct_abort_marker::drain_on_terminal_commit` call after
+# the terminal anchor-cleanup branches. The marker logic itself lives in the
+# new (non-giant) `tui_direct_abort_marker.rs`; this is the minimum in-file
+# surface (one call site at the only body-visible terminal-commit chokepoint).
+# Deliberate, workflow-sanctioned raise.
+"src/services/discord/tmux_watcher.rs" = 9600
 # Frozen at its true production LoC once #3028 fixed the prod/test splitter
 # (lifetime/char-literal brace miscount): the first inline `#[cfg(test)] mod`
 # block was over-extended to EOF, so `spawn_turn_bridge` and ~9000 lines of the

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -87,6 +87,7 @@ mod tmux_overload_retry;
 mod tmux_reaper;
 #[cfg(unix)]
 mod tmux_restart_handoff;
+mod tui_direct_abort_marker;
 mod tui_direct_pending_start;
 mod tui_prompt_relay;
 mod tui_task_card;

--- a/src/services/discord/placeholder_sweeper.rs
+++ b/src/services/discord/placeholder_sweeper.rs
@@ -953,17 +953,28 @@ pub(super) fn spawn_placeholder_sweeper(
                 &shared.token_hash,
             )
             .await;
+            // #3296: reconcile durable aborted-anchor markers — retry the ✅ for
+            // markers a terminal commit already covered, and apply the TTL'd
+            // `⏳ → ⚠` fallback for anchors nothing ever covered (held while a
+            // live inflight for the session may still cover them). The sweeper
+            // owns this reclaim so an aborted anchor always converges (#3282).
+            let drained_abort_markers =
+                super::tui_direct_abort_marker::sweep_expired(&shared, &provider).await;
             sweeps_since_heartbeat = sweeps_since_heartbeat.saturating_add(1);
-            if should_log_sweep_report(report, sweeps_since_heartbeat) || drained > 0 {
+            if should_log_sweep_report(report, sweeps_since_heartbeat)
+                || drained > 0
+                || drained_abort_markers > 0
+            {
                 let ts = chrono::Local::now().format("%H:%M:%S");
                 tracing::info!(
-                    "  [{ts}] 🧹 placeholder sweeper ({}): scanned={} stalled={} abandoned={} reclaimed_panels={} drained_orphans={}",
+                    "  [{ts}] 🧹 placeholder sweeper ({}): scanned={} stalled={} abandoned={} reclaimed_panels={} drained_orphans={} drained_abort_markers={}",
                     provider.as_str(),
                     report.scanned,
                     report.stalled,
                     report.abandoned,
                     report.reclaimed_panels,
-                    drained
+                    drained,
+                    drained_abort_markers
                 );
                 sweeps_since_heartbeat = 0;
             }

--- a/src/services/discord/runtime_store.rs
+++ b/src/services/discord/runtime_store.rs
@@ -67,6 +67,15 @@ pub(crate) fn tui_direct_pending_start_root() -> Option<PathBuf> {
     runtime_root().map(|root| root.join("discord_tui_direct_pending_start"))
 }
 
+/// #3296: durable aborted-anchor markers for TUI-direct synthetic turn-starts
+/// that ABORTed after the input was already provider-submitted. The anchor
+/// keeps its `⏳`; the watcher terminal-commit drain flips it to `✅` when the
+/// prior owner covers it, and the placeholder sweeper flips it to `⚠` after
+/// the TTL when nothing did. See `tui_direct_abort_marker`.
+pub(crate) fn tui_direct_abort_marker_root() -> Option<PathBuf> {
+    runtime_root().map(|root| root.join("discord_tui_direct_abort_marker"))
+}
+
 /// #3003: durable retry store for orphaned status-panel-v2 message deletes that
 /// failed transiently when no per-turn inflight handle survived (e.g. a
 /// stopped/cancelled TUI-direct turn). Drained by the placeholder sweeper.

--- a/src/services/discord/runtime_store.rs
+++ b/src/services/discord/runtime_store.rs
@@ -76,6 +76,16 @@ pub(crate) fn tui_direct_abort_marker_root() -> Option<PathBuf> {
     runtime_root().map(|root| root.join("discord_tui_direct_abort_marker"))
 }
 
+/// #3296 codex r2: durable terminal-commit tombstones for `(provider, tmux,
+/// channel)`. The tmux watcher's terminal-commit chokepoint records one BEFORE
+/// it clears the inflight row, so the aborted-anchor reconcilers can
+/// distinguish "the foreign row vanished because its owner committed" (`✅`)
+/// from a non-commit deletion (force-clear/stop/recovery → bounded `⚠`).
+/// Short-lived: the marker sweep GC's tombstones past the marker hard cap.
+pub(crate) fn tui_direct_commit_tombstone_root() -> Option<PathBuf> {
+    runtime_root().map(|root| root.join("discord_tui_direct_commit_tombstone"))
+}
+
 /// #3003: durable retry store for orphaned status-panel-v2 message deletes that
 /// failed transiently when no per-turn inflight handle survived (e.g. a
 /// stopped/cancelled TUI-direct turn). Drained by the placeholder sweeper.

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -11050,6 +11050,25 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             .await;
         }
 
+        // #3296: aborted-anchor reconcile chokepoint. A synthetic turn-start
+        // that ABORTed (backstop_abort_foreign_inflight_live) kept its `⏳` and
+        // recorded a durable marker; a body-visible normal commit on this SAME
+        // (provider, tmux, channel) means the prior owner covered that input —
+        // drain the marker (`⏳ → ✅` on the marker's own pinned anchor id).
+        // Reaction identity resolves inside the module (#3164 add≡remove).
+        if terminal_output_committed
+            && tui_direct_anchor_terminal_body_visible
+            && !lifecycle_stage_paused
+        {
+            let _ = crate::services::discord::tui_direct_abort_marker::drain_on_terminal_commit(
+                &shared,
+                watcher_provider.as_str(),
+                &tmux_session_name,
+                channel_id.get(),
+            )
+            .await;
+        }
+
         // Mark user message as completed: ⏳ → ✅ when inflight metadata is
         // available and terminal output is committed. #897 round-3 Medium:
         // skip the reaction + transcript + analytics block entirely for

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -11285,44 +11285,63 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             turn_result_relayed = true;
             // #1670/#1708: Always consume the handoff debt and clear inflight
             // when terminal output was committed — the bridge's
-            // `bridge_relay_delegated_to_watcher`
-            // arm in `turn_bridge/mod.rs` (the `else if` at ~line 4071) saves
-            // inflight and immediately returns, so the bridge will NOT come back
-            // to revoke the debt or clear the inflight even if dispatch
-            // finalization fails. Organic user turns (`dispatch_id = null`)
-            // surfaced this regression: when the streaming finalizer fell
-            // through to a stale fallback dispatch_id and reported
-            // `dispatch_ok = false`, the watcher used to leave the inflight and
-            // the channel mailbox cancel_token in place, orphaning them
-            // forever. The decoupling rule is:
-            //
-            //   * `clear_inflight_state` + `finish_restored_watcher_active_turn`
-            //     fire whenever the watcher committed terminal output
-            //     (delivered or intentionally suppressed) — both bridge and
-            //     watcher are now safe to call them concurrently because
-            //     `mailbox_finish_turn` is idempotent (the second caller
-            //     observes an empty active slot).
-            //   * Anything that genuinely depends on the dispatch lifecycle
-            //     having completed (queue kickoff, dispatch followup,
-            //     terminal-stop decision) remains gated on `dispatch_ok` further
-            //     below.
-            //
-            // #3016 phase-5b2: the legacy `mailbox_finalize_owed` flag is removed,
-            // so the `swap(false, AcqRel)` that read it here (whose value fed only
-            // the observability payload and the `watcher_handled_mailbox_finish`
-            // bookkeeping below) is gone. Exactly-once is the ledger's job; the
-            // cross-turn safety the Release reset provided is subsumed by the
-            // ledger phase gate.
+            // `bridge_relay_delegated_to_watcher` arm in `turn_bridge/mod.rs`
+            // (the `else if` at ~line 4071) saves inflight and returns, so it
+            // never comes back to revoke the debt / clear the inflight even if
+            // dispatch finalization fails (organic `dispatch_id = null` turns
+            // surfaced this: a stale fallback dispatch_id reporting
+            // `dispatch_ok = false` used to orphan the inflight + mailbox
+            // cancel_token forever). Decoupling rule: `clear_inflight_state` +
+            // `finish_restored_watcher_active_turn` fire whenever the watcher
+            // committed terminal output (delivered or intentionally
+            // suppressed; bridge + watcher may call them concurrently —
+            // `mailbox_finish_turn` is idempotent), while anything genuinely
+            // dependent on the dispatch lifecycle (queue kickoff, dispatch
+            // followup, terminal-stop decision) stays gated on `dispatch_ok`
+            // further below.
+            // #3016 phase-5b2: the legacy `mailbox_finalize_owed` flag (and its
+            // `swap(false, AcqRel)` read here) is removed — exactly-once is the
+            // ledger's job; the Release-reset cross-turn safety is subsumed by
+            // the ledger phase gate.
             // #3016 (codex R3): do NOT delete the on-disk inflight when it
             // belongs to a NEWER follow-up turn (same session, started AT/AFTER
-            // this committed range). The same offset decision that makes
-            // `pinned_finalize_user_msg_id` return 0 just below gates the clear
-            // here, so this stale-range pass cannot wipe the newer turn's
-            // inflight out from under it. Only the on-disk file is gated; the
-            // in-memory `inflight_state` used afterward (finalize id source,
-            // dispatch resolution, history push) is unaffected. The
-            // `cleared_by_watcher` observability event only fires when the clear
-            // actually ran (preserve existing semantics).
+            // this committed range) — the same offset decision that makes
+            // `pinned_finalize_user_msg_id` return 0 below gates the clear, so
+            // this stale-range pass cannot wipe the newer turn's inflight. Only
+            // the on-disk file is gated; the in-memory `inflight_state` used
+            // afterward is unaffected, and `cleared_by_watcher` fires only when
+            // the clear actually ran (preserve existing semantics).
+            // #3296 codex r2: aborted-anchor reconcile, sited BEFORE the row
+            // clear — commit-tombstone evidence (committed turn identity) lands
+            // first, then the drain covers any marker pinned to this turn, then
+            // the clear. A sweep pass claiming a marker mid-commit can thus
+            // observe "no live row" only AFTER the tombstone is durable, so its
+            // 대조 lands ✅ instead of ⚠ (r2 finding 1 — the flock alone only
+            // serialized the reconcilers, it never ordered the verdicts); an
+            // ABORT recording its marker after this drain pass still converges
+            // via the tombstone (record-instant or sweep 대조).
+            if tui_direct_anchor_terminal_body_visible
+                && !completion_is_stale_for_newer_turn
+                && let Some(committed) = inflight_state.as_ref()
+            {
+                crate::services::discord::tui_direct_abort_marker::record_commit_tombstone(
+                    watcher_provider.as_str(),
+                    &tmux_session_name,
+                    channel_id.get(),
+                    committed.user_msg_id,
+                    &committed.started_at,
+                );
+                let _ =
+                    crate::services::discord::tui_direct_abort_marker::drain_on_terminal_commit(
+                        &shared,
+                        watcher_provider.as_str(),
+                        &tmux_session_name,
+                        channel_id.get(),
+                        committed.user_msg_id,
+                        &committed.started_at,
+                    )
+                    .await;
+            }
             if !completion_is_stale_for_newer_turn {
                 crate::services::discord::inflight::clear_inflight_state(
                     &provider_kind,
@@ -11350,27 +11369,6 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         "full_response_len": full_response.len(),
                     }),
                 );
-            }
-            // #3296 codex r1: aborted-anchor reconcile drain — covers a marker
-            // ONLY when the committed turn (late inflight read; never a stale
-            // NEWER turn) IS the foreign prior inflight the ABORT pinned. Sited
-            // AFTER clear_inflight_state so an abort racing this pass either
-            // writes its marker before this drain runs or finds the row already
-            // cleared and records itself pre-covered (no orphaned marker).
-            if tui_direct_anchor_terminal_body_visible
-                && !completion_is_stale_for_newer_turn
-                && let Some(committed) = inflight_state.as_ref()
-            {
-                let _ =
-                    crate::services::discord::tui_direct_abort_marker::drain_on_terminal_commit(
-                        &shared,
-                        watcher_provider.as_str(),
-                        &tmux_session_name,
-                        channel_id.get(),
-                        committed.user_msg_id,
-                        &committed.started_at,
-                    )
-                    .await;
             }
             // codex P2 (#1670): cleanup (mailbox_finish_turn + cancel_token
             // release) MUST run on every relay-completed terminal even when

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -11030,25 +11030,6 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             .await;
         }
 
-        // #3296: aborted-anchor reconcile chokepoint. A synthetic turn-start
-        // that ABORTed (backstop_abort_foreign_inflight_live) kept its `⏳` and
-        // recorded a durable marker; a body-visible normal commit on this SAME
-        // (provider, tmux, channel) means the prior owner covered that input —
-        // drain the marker (`⏳ → ✅` on the marker's own pinned anchor id).
-        // Reaction identity resolves inside the module (#3164 add≡remove).
-        if terminal_output_committed
-            && tui_direct_anchor_terminal_body_visible
-            && !lifecycle_stage_paused
-        {
-            let _ = crate::services::discord::tui_direct_abort_marker::drain_on_terminal_commit(
-                &shared,
-                watcher_provider.as_str(),
-                &tmux_session_name,
-                channel_id.get(),
-            )
-            .await;
-        }
-
         // Mark user message as completed: ⏳ → ✅ when inflight metadata is
         // available and terminal output is committed. #897 round-3 Medium:
         // skip the reaction + transcript + analytics block entirely for
@@ -11369,6 +11350,27 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         "full_response_len": full_response.len(),
                     }),
                 );
+            }
+            // #3296 codex r1: aborted-anchor reconcile drain — covers a marker
+            // ONLY when the committed turn (late inflight read; never a stale
+            // NEWER turn) IS the foreign prior inflight the ABORT pinned. Sited
+            // AFTER clear_inflight_state so an abort racing this pass either
+            // writes its marker before this drain runs or finds the row already
+            // cleared and records itself pre-covered (no orphaned marker).
+            if tui_direct_anchor_terminal_body_visible
+                && !completion_is_stale_for_newer_turn
+                && let Some(committed) = inflight_state.as_ref()
+            {
+                let _ =
+                    crate::services::discord::tui_direct_abort_marker::drain_on_terminal_commit(
+                        &shared,
+                        watcher_provider.as_str(),
+                        &tmux_session_name,
+                        channel_id.get(),
+                        committed.user_msg_id,
+                        &committed.started_at,
+                    )
+                    .await;
             }
             // codex P2 (#1670): cleanup (mailbox_finish_turn + cancel_token
             // release) MUST run on every relay-completed terminal even when

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -7837,51 +7837,31 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                     FreshIdleFinalizeDecision::Finalize { user_msg_id } => {
                         // #3016 S3 (the A2 / phase-5 enabler): a structural JSONL
                         // terminator is PROVEN on disk for this turn (Done) AND no
-                        // follow-up took over — so finalize via the single-authority
-                        // path with `normal_completion = true`, FLAG-INDEPENDENT.
-                        // This is the whole point of S3: an EMPTY-but-terminated
-                        // completion now finalizes (the old flag-gated path could
-                        // not distinguish it from a paused-live turn). The finalizer
-                        // is idempotent — a turn already finalized by the bridge
-                        // resolves to `AlreadyFinalized` — so this cannot
-                        // over-finalize. `user_msg_id` is the id PINNED from the
-                        // pre-cleanup snapshot at this `current_offset` (never a
-                        // late re-read), so the ledger match is the CURRENT turn's
-                        // real, non-zero id.
+                        // follow-up took over — finalize via the single-authority
+                        // path with `normal_completion = true`, FLAG-INDEPENDENT,
+                        // so an EMPTY-but-terminated completion finalizes too (the
+                        // old flag-gated path could not tell it from a paused-live
+                        // turn). The finalizer is idempotent (`AlreadyFinalized`),
+                        // and `user_msg_id` is PINNED from the pre-cleanup snapshot
+                        // at this `current_offset` (never a late re-read), so the
+                        // ledger match is the CURRENT turn's real, non-zero id.
                         //
                         // #3016 S3 (Concern 2 — residual TOCTOU): the destructive
                         // on-disk clear must not wipe a FOLLOW-UP turn's inflight.
-                        // The earlier fix re-read on-disk inflight, ran
-                        // `committed_completion_is_stale_for_newer_turn`, and then
-                        // called the UNCONDITIONAL `clear_inflight_state` under a
-                        // SEPARATE lock — a check-then-act split across two locks.
-                        // On a multi-threaded tokio runtime a follow-up turn could
-                        // save a new inflight on another worker thread AFTER the
-                        // re-read but BEFORE the clear, so the unconditional delete
-                        // wiped the follow-up's inflight (the window was not
-                        // atomic). Replace that sequence with the EXISTING atomic
-                        // compare-and-clear helper
-                        // `clear_inflight_state_if_matches_identity` (inflight.rs
-                        // ~1666 / ~1822): it reads + validates + unlinks under a
-                        // SINGLE sidecar lock and deletes ONLY if the on-disk
-                        // identity (`user_msg_id` + `started_at` +
-                        // `tmux_session_name`) still equals the PINNED turn's. A
-                        // follow-up turn carries a different identity, so the helper
-                        // is a guaranteed no-op for it (`UserMsgMismatch`) — the
-                        // window is closed atomically, no re-read/recheck needed.
-                        //
-                        // The pinned identity comes from `pinned_pre_cleanup_inflight`
-                        // — the same snapshot the decision helper used to derive
-                        // `user_msg_id` above (when `Finalize` is reached, that id is
-                        // exactly `pinned_pre_cleanup_inflight.user_msg_id`, because
-                        // `pinned_finalize_user_msg_id` selected it). The
-                        // finalize-skip (a NEWER turn in the pinned snapshot) is a
-                        // SEPARATE decision already handled in
-                        // `watcher_fresh_idle_finalize_decision`; here we only swap
-                        // the destructive CLEAR — the one carrying the TOCTOU — to
-                        // the atomic identity-matched helper. Finalize below still
-                        // runs on the PINNED id (idempotent) regardless of the clear
-                        // outcome.
+                        // The earlier read→check→unconditional-clear spanned TWO
+                        // locks, so a follow-up saved on another worker thread in
+                        // the gap was wiped. `clear_inflight_state_if_matches_identity`
+                        // (inflight.rs) closes the window atomically: read +
+                        // validate + unlink under ONE sidecar lock, deleting only
+                        // while the on-disk identity (`user_msg_id` + `started_at`
+                        // + `tmux_session_name`) still equals the PINNED turn's
+                        // (`pinned_pre_cleanup_inflight`, the same snapshot that
+                        // derived `user_msg_id` above) — a follow-up's identity
+                        // differs (`UserMsgMismatch`), guaranteed no-op. The
+                        // finalize-skip for a NEWER pinned turn stays a SEPARATE
+                        // decision in `watcher_fresh_idle_finalize_decision`;
+                        // finalize below runs on the PINNED id (idempotent)
+                        // regardless of the clear outcome.
                         let pinned_clear_identity = pinned_pre_cleanup_inflight.as_ref().map(
                             crate::services::discord::inflight::InflightTurnIdentity::from_state,
                         );

--- a/src/services/discord/tui_direct_abort_marker.rs
+++ b/src/services/discord/tui_direct_abort_marker.rs
@@ -1,0 +1,889 @@
+//! #3296 — durable aborted-anchor markers: reconcile the anchor reaction after
+//! a synthetic turn-start ABORT instead of branding it a failure.
+//!
+//! ## Why this exists
+//! When a TUI-direct synthetic turn-start ABORTs on the backstop escalation
+//! budget (`backstop_abort_foreign_inflight_live`, see
+//! [`super::tui_direct_pending_start`]), the user's input was ALREADY submitted
+//! to the provider — the abort drops only the synthetic OWNERSHIP claim. In
+//! every live observation the prior turn's owner then relayed the response
+//! normally, yet the #3282-era cleanup swapped the anchor's `⏳` for a `⚠`,
+//! permanently branding an ANSWERED message as failed (#3296).
+//!
+//! ## Mechanism
+//! The ABORT path now KEEPS the `⏳` (it is still true: the provider holds the
+//! input) and records a durable [`AbortedAnchorMarker`] here. Two reconcilers
+//! own the marker afterwards:
+//!
+//! 1. **Terminal-commit drain** ([`drain_on_terminal_commit`]) — the tmux
+//!    watcher's terminal chokepoint calls this on every body-visible normal
+//!    commit; a commit on the SAME `(provider, tmux, channel)` AFTER the abort
+//!    (and within the TTL, bounding session-recreation aliasing) means the
+//!    prior owner covered the input → `⏳ → ✅`, marker drained.
+//! 2. **TTL sweep** ([`sweep_expired`]) — the placeholder sweeper's pass: once
+//!    [`ABORT_MARKER_TTL`] elapsed with NO live inflight for the session (a
+//!    long turn still streaming holds the verdict), nothing ever covered the
+//!    anchor → `⏳ → ⚠`, so a genuine failure is still surfaced in bounded
+//!    time (no #3282 eternal-hourglass regression: the sweeper is the owner).
+//!
+//! ## Invariants
+//! * **I1 (#3164 add≡remove)**: every reaction op (`⏳` remove, `✅`/`⚠` add)
+//!   resolves `shared.serenity_http_or_token_fallback()` INSIDE this module —
+//!   the same bot identity that added the `⏳`. No caller-provided http is
+//!   accepted, so a watcher/sweeper-bootstrap http can never be misused.
+//! * **I4 (turn-identity pin)**: every correction targets ONLY the marker's own
+//!   `anchor_message_id` — the shared `prompt_anchor_by_tmux` slot is never
+//!   re-read (slot aliasing under rapid injection would hit the wrong turn).
+//! * **I5 (zero-id guard)**: a zero anchor id is never recorded or reacted on
+//!   (`MessageId::new(0)` panics).
+//! * **I6 (fail-open)**: when http is unavailable or a delivery fails, the
+//!   marker is PRESERVED (a covering commit stamps `covered_at_ms` so the
+//!   sweep retries the `✅`) — never silently dropped.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use serenity::{ChannelId, MessageId};
+
+use poise::serenity_prelude as serenity;
+
+use super::SharedData;
+
+/// How long an aborted anchor may wait for a covering terminal commit before
+/// the sweep declares it a genuine failure (`⏳ → ⚠`). Rationale: the observed
+/// ABORT→covered window is ~30-180s (backstop 32s + prior-owner long turns);
+/// 600s comfortably covers a long streaming prior turn while still bounding a
+/// truly-lost input to TTL + sweeper initial delay (180s) + pass interval (30s).
+pub(super) const ABORT_MARKER_TTL: std::time::Duration = std::time::Duration::from_secs(600);
+
+/// Durable record for an anchor whose synthetic turn-start ABORTed while the
+/// input was already provider-submitted. All fields are primitives so the JSON
+/// survives a dcserver version swap.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct AbortedAnchorMarker {
+    pub provider: String,
+    pub channel_id: u64,
+    /// Identity pin (I4): the ONLY message any `✅`/`⚠` correction may target.
+    pub anchor_message_id: u64,
+    pub tmux_session_name: String,
+    /// Wall-clock ms of the ABORT. A covering commit must be strictly later.
+    pub aborted_at_ms: u64,
+    /// Stamped when a covering terminal commit was seen but the `✅` delivery
+    /// failed (or http was unavailable) — the sweep retries the completion
+    /// instead of ever degrading a covered anchor to `⚠` (I6).
+    #[serde(default)]
+    pub covered_at_ms: Option<u64>,
+}
+
+impl AbortedAnchorMarker {
+    fn file_stem(&self) -> String {
+        format!(
+            "{}_{}_{}",
+            self.provider, self.channel_id, self.anchor_message_id
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Durable store (mirrors `tui_direct_pending_start`'s store + atomic writes)
+// ---------------------------------------------------------------------------
+
+fn root() -> Option<std::path::PathBuf> {
+    super::runtime_store::tui_direct_abort_marker_root()
+}
+
+/// Persist (or update) a marker. Recorded by the ABORT path BEFORE any http
+/// availability check so a restart or late-arriving http can still reconcile.
+/// Zero anchor ids are rejected (I5: nothing could ever be reconciled on them).
+pub(super) fn record(marker: &AbortedAnchorMarker) -> Result<(), String> {
+    if marker.anchor_message_id == 0 {
+        return Err("refusing to record aborted-anchor marker with zero anchor_message_id".into());
+    }
+    let Some(root) = root() else {
+        return Ok(()); // tests / unconfigured root — nothing durable to write
+    };
+    let path = root.join(format!("{}.json", marker.file_stem()));
+    let data = serde_json::to_string_pretty(marker).map_err(|e| e.to_string())?;
+    super::runtime_store::critical_atomic_write(
+        &path,
+        &data,
+        super::runtime_store::AtomicWriteContext::new("tui_direct_abort_marker")
+            .provider(&marker.provider)
+            .channel_id(marker.channel_id),
+    )
+}
+
+/// Drop a marker once its correction was delivered. Idempotent.
+pub(super) fn delete(marker: &AbortedAnchorMarker) {
+    if let Some(root) = root() {
+        let path = root.join(format!("{}.json", marker.file_stem()));
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// Load every durable marker (sweep + restart survival: the store IS the
+/// restart state — no in-memory index to rebuild).
+pub(super) fn load_all() -> Vec<AbortedAnchorMarker> {
+    let Some(root) = root() else {
+        return Vec::new();
+    };
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        if let Ok(text) = std::fs::read_to_string(&path)
+            && let Ok(marker) = serde_json::from_str::<AbortedAnchorMarker>(&text)
+        {
+            out.push(marker);
+        }
+    }
+    out
+}
+
+/// Markers scoped to one `(provider, channel)` — the terminal-commit drain's
+/// working set.
+pub(super) fn load_for_channel(provider: &str, channel_id: u64) -> Vec<AbortedAnchorMarker> {
+    load_all()
+        .into_iter()
+        .filter(|m| m.channel_id == channel_id && m.provider.eq_ignore_ascii_case(provider))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Pure decision functions (truth-table tested — no I/O, no clock)
+// ---------------------------------------------------------------------------
+
+/// What the sweep should do with a marker this pass.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum MarkerDisposition {
+    /// TTL not elapsed, or a live inflight for the session still holds the
+    /// verdict (a long prior turn may yet cover the anchor) — re-evaluate next
+    /// pass.
+    KeepWaiting,
+    /// A covering commit was already seen (`covered_at_ms`) — (re)deliver the
+    /// `⏳ → ✅` completion.
+    DeliverCompletion,
+    /// TTL elapsed with no live inflight and no covering commit — deliver the
+    /// `⏳ → ⚠` failure fallback (I10: the only path that may `⚠`).
+    DeliverFailureWarn,
+    /// Http unavailable — leave every marker intact (I6 fail-open).
+    LeftIntactHttpUnavailable,
+}
+
+/// The sweep's per-marker verdict. Conservative by design (I10): `⚠` requires
+/// BOTH the TTL to have elapsed AND no live inflight for the session, so a
+/// long-running prior turn is never falsely branded; `✅` retry requires a
+/// previously-seen covering commit.
+pub(super) fn decide_marker_disposition(
+    now_ms: u64,
+    marker: &AbortedAnchorMarker,
+    live_inflight_for_session: bool,
+    ttl: std::time::Duration,
+    http_available: bool,
+) -> MarkerDisposition {
+    if !http_available {
+        return MarkerDisposition::LeftIntactHttpUnavailable;
+    }
+    if marker.covered_at_ms.is_some() {
+        return MarkerDisposition::DeliverCompletion;
+    }
+    let ttl_elapsed = now_ms.saturating_sub(marker.aborted_at_ms) >= ttl.as_millis() as u64;
+    if !ttl_elapsed || live_inflight_for_session {
+        return MarkerDisposition::KeepWaiting;
+    }
+    MarkerDisposition::DeliverFailureWarn
+}
+
+/// Does a terminal commit observed at `now_ms` cover this marker? Only a commit
+/// STRICTLY AFTER the abort counts (a pre-abort commit belongs to an older
+/// turn), and only within the TTL (bounding `✅` mis-fires from an unrelated
+/// commit after the session was recycled — SC2/R3).
+pub(super) fn terminal_commit_covers_marker(
+    now_ms: u64,
+    marker: &AbortedAnchorMarker,
+    ttl: std::time::Duration,
+) -> bool {
+    marker.anchor_message_id != 0
+        && now_ms > marker.aborted_at_ms
+        && now_ms.saturating_sub(marker.aborted_at_ms) <= ttl.as_millis() as u64
+}
+
+// ---------------------------------------------------------------------------
+// Reaction applier (boxed-fn injection, `ClaimFn`/`AbortCleanupFn` convention)
+// ---------------------------------------------------------------------------
+
+/// The reaction correction to apply to the marker's pinned anchor message.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ReactionOp {
+    /// `⏳` remove + `✅` add (anchor covered by the prior owner).
+    Complete,
+    /// `⏳` remove + `⚠` add (TTL'd genuine failure).
+    FailureWarn,
+}
+
+/// Outcome of one applier invocation, driving keep/delete of the marker.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ReactionDelivery {
+    Delivered,
+    Failed,
+    HttpUnavailable,
+}
+
+/// Boxed applier so tests record ops instead of calling Discord. The PRODUCTION
+/// applier is [`shared_reaction_applier`]; per I1 it does NOT accept an http
+/// parameter — it resolves `shared.serenity_http_or_token_fallback()` per call.
+pub(super) type ReactionApplierFn = Box<
+    dyn Fn(
+            &AbortedAnchorMarker,
+            ReactionOp,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ReactionDelivery> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// The production applier. Bot identity (#3164 add≡remove, I1): the `⏳` was
+/// added via the relay's `shared.serenity_http_or_token_fallback()` (the
+/// provider/command bot), and `remove_reaction_raw` only removes `@me`'s
+/// reaction — resolving the SAME source here guarantees the removal targets
+/// exactly the reaction the add created. Success is keyed on the `✅`/`⚠`
+/// create (the remove is best-effort, mirroring
+/// `complete_tui_direct_prompt_anchor_lifecycle_if_present`).
+pub(super) fn shared_reaction_applier(shared: Arc<SharedData>) -> ReactionApplierFn {
+    Box::new(move |marker, op| {
+        let shared = shared.clone();
+        let provider = marker.provider.clone();
+        let channel_id = marker.channel_id;
+        let anchor_message_id = marker.anchor_message_id;
+        Box::pin(async move {
+            if anchor_message_id == 0 {
+                return ReactionDelivery::Failed; // I5 (defensive; record() already rejects)
+            }
+            let Some(http) = shared.serenity_http_or_token_fallback() else {
+                return ReactionDelivery::HttpUnavailable;
+            };
+            let channel = ChannelId::new(channel_id);
+            let message = MessageId::new(anchor_message_id);
+            super::formatting::remove_reaction_raw(&http, channel, message, '⏳').await;
+            let emoji = match op {
+                ReactionOp::Complete => '✅',
+                ReactionOp::FailureWarn => '⚠',
+            };
+            let reaction = serenity::ReactionType::Unicode(emoji.to_string());
+            match channel.create_reaction(&http, message, reaction).await {
+                Ok(_) => ReactionDelivery::Delivered,
+                Err(error) => {
+                    tracing::warn!(
+                        provider = %provider,
+                        channel_id,
+                        anchor_message_id,
+                        op = ?op,
+                        error = %error,
+                        "tui_direct_abort_marker: reaction correction delivery failed; marker preserved for retry (I6)"
+                    );
+                    ReactionDelivery::Failed
+                }
+            }
+        })
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Reconcilers
+// ---------------------------------------------------------------------------
+
+fn now_ms() -> u64 {
+    chrono::Utc::now().timestamp_millis().max(0) as u64
+}
+
+/// Watcher terminal-commit chokepoint: a body-visible normal commit for
+/// `(provider, tmux, channel)` covers every matching marker → `⏳ → ✅`.
+/// Returns the number of markers fully drained.
+pub(super) async fn drain_on_terminal_commit(
+    shared: &Arc<SharedData>,
+    provider: &str,
+    tmux_session_name: &str,
+    channel_id: u64,
+) -> usize {
+    let applier = shared_reaction_applier(shared.clone());
+    drain_on_terminal_commit_with_applier(
+        provider,
+        tmux_session_name,
+        channel_id,
+        now_ms(),
+        &applier,
+    )
+    .await
+}
+
+pub(super) async fn drain_on_terminal_commit_with_applier(
+    provider: &str,
+    tmux_session_name: &str,
+    channel_id: u64,
+    now_ms: u64,
+    applier: &ReactionApplierFn,
+) -> usize {
+    let mut drained = 0usize;
+    for mut marker in load_for_channel(provider, channel_id) {
+        if marker.tmux_session_name != tmux_session_name {
+            continue; // I4: a different session's marker is never this commit's
+        }
+        if !terminal_commit_covers_marker(now_ms, &marker, ABORT_MARKER_TTL) {
+            continue;
+        }
+        match applier(&marker, ReactionOp::Complete).await {
+            ReactionDelivery::Delivered => {
+                delete(&marker);
+                drained += 1;
+                tracing::info!(
+                    provider = %marker.provider,
+                    channel_id = marker.channel_id,
+                    tmux_session_name = %marker.tmux_session_name,
+                    anchor_message_id = marker.anchor_message_id,
+                    "tui_direct_abort_marker: aborted anchor covered by prior-owner terminal commit; ⏳ → ✅ delivered and marker drained (#3296)"
+                );
+            }
+            ReactionDelivery::Failed | ReactionDelivery::HttpUnavailable => {
+                // I6 fail-open: the anchor IS covered — stamp it so the sweep
+                // retries the ✅ (and can never degrade it to ⚠).
+                marker.covered_at_ms = Some(now_ms);
+                let _ = record(&marker);
+            }
+        }
+    }
+    drained
+}
+
+/// Placeholder-sweeper pass: retry `✅` for covered markers; apply the TTL'd
+/// `⏳ → ⚠` fallback for anchors no commit ever covered (held while a live
+/// inflight for the session may still cover them). Returns markers resolved.
+pub(super) async fn sweep_expired(
+    shared: &Arc<SharedData>,
+    provider: &super::ProviderKind,
+) -> usize {
+    let http_available = shared.serenity_http_or_token_fallback().is_some();
+    let applier = shared_reaction_applier(shared.clone());
+    let live_inflight = |marker: &AbortedAnchorMarker| -> bool {
+        super::inflight::load_inflight_state(provider, marker.channel_id).is_some_and(|state| {
+            // Conservative (I10): an inflight without a tmux name COULD be the
+            // covering prior owner — hold rather than risk a false ⚠.
+            state
+                .tmux_session_name
+                .as_deref()
+                .is_none_or(|name| name == marker.tmux_session_name)
+        })
+    };
+    sweep_expired_with_applier(
+        provider.as_str(),
+        now_ms(),
+        http_available,
+        &live_inflight,
+        &applier,
+    )
+    .await
+}
+
+pub(super) async fn sweep_expired_with_applier(
+    provider: &str,
+    now_ms: u64,
+    http_available: bool,
+    live_inflight_for_session: &(dyn Fn(&AbortedAnchorMarker) -> bool + Send + Sync),
+    applier: &ReactionApplierFn,
+) -> usize {
+    let mut resolved = 0usize;
+    for marker in load_all() {
+        if !marker.provider.eq_ignore_ascii_case(provider) {
+            continue;
+        }
+        if marker.anchor_message_id == 0 {
+            delete(&marker); // I5: corrupt record — nothing could ever target it
+            continue;
+        }
+        let disposition = decide_marker_disposition(
+            now_ms,
+            &marker,
+            live_inflight_for_session(&marker),
+            ABORT_MARKER_TTL,
+            http_available,
+        );
+        let op = match disposition {
+            MarkerDisposition::KeepWaiting | MarkerDisposition::LeftIntactHttpUnavailable => {
+                continue;
+            }
+            MarkerDisposition::DeliverCompletion => ReactionOp::Complete,
+            MarkerDisposition::DeliverFailureWarn => ReactionOp::FailureWarn,
+        };
+        match applier(&marker, op).await {
+            ReactionDelivery::Delivered => {
+                delete(&marker);
+                resolved += 1;
+                tracing::info!(
+                    provider = %marker.provider,
+                    channel_id = marker.channel_id,
+                    tmux_session_name = %marker.tmux_session_name,
+                    anchor_message_id = marker.anchor_message_id,
+                    op = ?op,
+                    "tui_direct_abort_marker: sweep resolved aborted anchor (#3296)"
+                );
+            }
+            // I6: keep the marker for the next pass (delivery failed late).
+            ReactionDelivery::Failed | ReactionDelivery::HttpUnavailable => {}
+        }
+    }
+    resolved
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes env-root mutation + restores `AGENTDESK_ROOT_DIR` on drop
+    /// (the `durable_restore_roundtrip_loads_fifo_order` precedent in
+    /// `tui_direct_pending_start`). Field order matters: tempdir first, then
+    /// env restore, then the shared env lock releases.
+    struct TestRoot {
+        _temp: tempfile::TempDir,
+        _env: EnvReset,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    struct EnvReset(Option<std::ffi::OsString>);
+    impl Drop for EnvReset {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
+                None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
+            }
+        }
+    }
+
+    fn test_root() -> TestRoot {
+        let lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let env = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        let temp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+        std::fs::create_dir_all(root().expect("durable root configured under temp")).unwrap();
+        TestRoot {
+            _temp: temp,
+            _env: env,
+            _lock: lock,
+        }
+    }
+
+    /// Sync tests + an explicit current-thread runtime keep the env-lock guard
+    /// out of any async scope (no new `await_holding_lock` allow sites — the
+    /// repo ratchet is frozen at its baseline).
+    fn test_rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    fn marker(
+        provider: &str,
+        channel: u64,
+        anchor: u64,
+        aborted_at_ms: u64,
+    ) -> AbortedAnchorMarker {
+        AbortedAnchorMarker {
+            provider: provider.to_string(),
+            channel_id: channel,
+            anchor_message_id: anchor,
+            tmux_session_name: format!("tmux-{channel}"),
+            aborted_at_ms,
+            covered_at_ms: None,
+        }
+    }
+
+    type RecordedOps = Arc<Mutex<Vec<(u64, ReactionOp)>>>;
+
+    /// Recording applier (the `recording_abort_cleanup` convention): captures
+    /// `(anchor_message_id, op)` so tests pin the identity-pinned target (I4)
+    /// and returns a fixed delivery outcome.
+    fn recording_applier(outcome: ReactionDelivery) -> (ReactionApplierFn, RecordedOps) {
+        let calls: RecordedOps = Arc::new(Mutex::new(Vec::new()));
+        let calls_for_fn = calls.clone();
+        let applier: ReactionApplierFn = Box::new(move |marker, op| {
+            let calls = calls_for_fn.clone();
+            let anchor = marker.anchor_message_id;
+            Box::pin(async move {
+                calls.lock().unwrap().push((anchor, op));
+                outcome
+            })
+        });
+        (applier, calls)
+    }
+
+    const TTL_MS: u64 = ABORT_MARKER_TTL.as_millis() as u64;
+
+    /// RED-4: the full {ttl}×{live inflight}×{covered}×{http} truth table.
+    #[test]
+    fn decide_marker_disposition_truth_table() {
+        let base = marker("claude", 1, 10, 1_000);
+        let covered = AbortedAnchorMarker {
+            covered_at_ms: Some(2_000),
+            ..base.clone()
+        };
+        let pre_ttl = 1_000 + TTL_MS - 1;
+        let post_ttl = 1_000 + TTL_MS;
+        for (now, m, live, http, want) in [
+            // http unavailable → ALWAYS left intact (I6), regardless of the rest.
+            (
+                pre_ttl,
+                &base,
+                false,
+                false,
+                MarkerDisposition::LeftIntactHttpUnavailable,
+            ),
+            (
+                pre_ttl,
+                &base,
+                true,
+                false,
+                MarkerDisposition::LeftIntactHttpUnavailable,
+            ),
+            (
+                post_ttl,
+                &base,
+                false,
+                false,
+                MarkerDisposition::LeftIntactHttpUnavailable,
+            ),
+            (
+                post_ttl,
+                &base,
+                true,
+                false,
+                MarkerDisposition::LeftIntactHttpUnavailable,
+            ),
+            (
+                pre_ttl,
+                &covered,
+                false,
+                false,
+                MarkerDisposition::LeftIntactHttpUnavailable,
+            ),
+            (
+                pre_ttl,
+                &covered,
+                true,
+                false,
+                MarkerDisposition::LeftIntactHttpUnavailable,
+            ),
+            (
+                post_ttl,
+                &covered,
+                false,
+                false,
+                MarkerDisposition::LeftIntactHttpUnavailable,
+            ),
+            (
+                post_ttl,
+                &covered,
+                true,
+                false,
+                MarkerDisposition::LeftIntactHttpUnavailable,
+            ),
+            // covered → completion retry, before AND after the TTL, inflight or not.
+            (
+                pre_ttl,
+                &covered,
+                false,
+                true,
+                MarkerDisposition::DeliverCompletion,
+            ),
+            (
+                pre_ttl,
+                &covered,
+                true,
+                true,
+                MarkerDisposition::DeliverCompletion,
+            ),
+            (
+                post_ttl,
+                &covered,
+                false,
+                true,
+                MarkerDisposition::DeliverCompletion,
+            ),
+            (
+                post_ttl,
+                &covered,
+                true,
+                true,
+                MarkerDisposition::DeliverCompletion,
+            ),
+            // uncovered, TTL not elapsed → wait (no premature ⚠, RED if ⚠ here).
+            (pre_ttl, &base, false, true, MarkerDisposition::KeepWaiting),
+            (pre_ttl, &base, true, true, MarkerDisposition::KeepWaiting),
+            // uncovered, TTL elapsed, live inflight → HOLD (long-turn ⚠ guard, I10).
+            (post_ttl, &base, true, true, MarkerDisposition::KeepWaiting),
+            // uncovered, TTL elapsed, no inflight → the ONLY ⚠ path (I10).
+            (
+                post_ttl,
+                &base,
+                false,
+                true,
+                MarkerDisposition::DeliverFailureWarn,
+            ),
+        ] {
+            assert_eq!(
+                decide_marker_disposition(now, m, live, ABORT_MARKER_TTL, http),
+                want,
+                "now={now} covered={:?} live={live} http={http}",
+                m.covered_at_ms
+            );
+        }
+    }
+
+    #[test]
+    fn terminal_commit_cover_requires_post_abort_within_ttl() {
+        let m = marker("claude", 1, 10, 5_000);
+        // Strictly-after-abort: a commit AT or BEFORE the abort instant belongs
+        // to an older turn and must not cover (RED if `>=`).
+        assert!(!terminal_commit_covers_marker(5_000, &m, ABORT_MARKER_TTL));
+        assert!(!terminal_commit_covers_marker(4_000, &m, ABORT_MARKER_TTL));
+        assert!(terminal_commit_covers_marker(5_001, &m, ABORT_MARKER_TTL));
+        assert!(terminal_commit_covers_marker(
+            5_000 + TTL_MS,
+            &m,
+            ABORT_MARKER_TTL
+        ));
+        // Past the TTL an unrelated commit (recycled session) must not ✅ (SC2).
+        assert!(!terminal_commit_covers_marker(
+            5_000 + TTL_MS + 1,
+            &m,
+            ABORT_MARKER_TTL
+        ));
+        // Zero anchor id never covers (I5).
+        let zero = AbortedAnchorMarker {
+            anchor_message_id: 0,
+            ..m
+        };
+        assert!(!terminal_commit_covers_marker(
+            5_001,
+            &zero,
+            ABORT_MARKER_TTL
+        ));
+    }
+
+    /// I5: the recorder refuses zero anchor ids outright.
+    #[test]
+    fn record_rejects_zero_anchor_id() {
+        let _root = test_root();
+        let zero = AbortedAnchorMarker {
+            anchor_message_id: 0,
+            ..marker("claude", 7, 1, 100)
+        };
+        assert!(record(&zero).is_err());
+        assert!(load_all().is_empty());
+    }
+
+    /// Restart survival: a persisted marker reloads with full field fidelity
+    /// so the post-restart sweep handles it identically.
+    #[test]
+    fn durable_roundtrip_survives_reload() {
+        let _root = test_root();
+        let mut m = marker("codex", 42, 9001, 123_456);
+        m.covered_at_ms = Some(123_999);
+        record(&m).unwrap();
+        let loaded = load_for_channel("codex", 42);
+        assert_eq!(loaded, vec![m.clone()]);
+        delete(&m);
+        assert!(load_for_channel("codex", 42).is_empty());
+    }
+
+    /// RED-1 (covered direction): a same-(provider,tmux,channel) terminal
+    /// commit after the abort drains the marker with EXACTLY ONE `Complete`
+    /// op on the pinned anchor id — and never a `⚠`.
+    #[test]
+    fn drain_on_terminal_commit_completes_covered_marker() {
+        let _root = test_root();
+        let m = marker("claude", 100, 555, 10_000);
+        record(&m).unwrap();
+        let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
+        let drained = test_rt().block_on(drain_on_terminal_commit_with_applier(
+            "claude", "tmux-100", 100, 10_500, // commit strictly after the abort, within TTL
+            &applier,
+        ));
+        assert_eq!(drained, 1);
+        let calls = calls.lock().unwrap();
+        assert_eq!(
+            calls.as_slice(),
+            &[(555, ReactionOp::Complete)],
+            "exactly one ⏳→✅ on the marker's own anchor id (I4), ⚠ never — \
+             RED if the drain skips the marker (the 10:52 ⚠-on-answered case) \
+             or targets a shared slot"
+        );
+        assert!(
+            load_for_channel("claude", 100).is_empty(),
+            "delivered completion must drain the durable marker"
+        );
+    }
+
+    /// I4/R3 + identity scoping: a commit for a DIFFERENT tmux session or a
+    /// commit at/before the abort instant must not touch the marker.
+    #[test]
+    fn drain_skips_foreign_session_and_pre_abort_commit() {
+        let _root = test_root();
+        let m = marker("claude", 100, 556, 10_000);
+        record(&m).unwrap();
+        let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
+        let rt = test_rt();
+        // Foreign tmux session on the same channel → no-op.
+        let drained = rt.block_on(drain_on_terminal_commit_with_applier(
+            "claude",
+            "tmux-other",
+            100,
+            10_500,
+            &applier,
+        ));
+        assert_eq!(drained, 0);
+        // Commit not after the abort → no-op (an older turn's commit).
+        let drained = rt.block_on(drain_on_terminal_commit_with_applier(
+            "claude", "tmux-100", 100, 10_000, &applier,
+        ));
+        assert_eq!(drained, 0);
+        assert!(calls.lock().unwrap().is_empty());
+        assert_eq!(load_for_channel("claude", 100).len(), 1, "marker retained");
+    }
+
+    /// I6: a covering commit whose ✅ delivery FAILS preserves the marker with
+    /// `covered_at_ms` stamped, and the next sweep retries the COMPLETION
+    /// (never degrades the covered anchor to ⚠ even past the TTL).
+    #[test]
+    fn failed_delivery_stamps_covered_and_sweep_retries_completion() {
+        let _root = test_root();
+        let m = marker("claude", 100, 557, 10_000);
+        record(&m).unwrap();
+        let rt = test_rt();
+        let (failing, _calls) = recording_applier(ReactionDelivery::Failed);
+        let drained = rt.block_on(drain_on_terminal_commit_with_applier(
+            "claude", "tmux-100", 100, 10_500, &failing,
+        ));
+        assert_eq!(drained, 0);
+        let kept = load_for_channel("claude", 100);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(
+            kept[0].covered_at_ms,
+            Some(10_500),
+            "failed ✅ delivery must stamp covered_at and keep the marker (I6) — \
+             RED if the marker is dropped (silent loss) or left unstamped (would ⚠ a covered anchor)"
+        );
+        // Sweep far past the TTL with no inflight: still retries ✅, never ⚠.
+        let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
+        let resolved = rt.block_on(sweep_expired_with_applier(
+            "claude",
+            10_000 + TTL_MS * 2,
+            true,
+            &|_| false,
+            &applier,
+        ));
+        assert_eq!(resolved, 1);
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &[(557, ReactionOp::Complete)]
+        );
+        assert!(load_for_channel("claude", 100).is_empty());
+    }
+
+    /// RED-2 (a): TTL elapsed but a live inflight for the session exists —
+    /// the sweep HOLDS (no reaction op, marker preserved).
+    #[test]
+    fn sweep_holds_while_live_inflight_present() {
+        let _root = test_root();
+        let m = marker("claude", 100, 558, 10_000);
+        record(&m).unwrap();
+        let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
+        let resolved = test_rt().block_on(sweep_expired_with_applier(
+            "claude",
+            10_000 + TTL_MS + 1,
+            true,
+            &|_| true, // live inflight for the session
+            &applier,
+        ));
+        assert_eq!(resolved, 0);
+        assert!(
+            calls.lock().unwrap().is_empty(),
+            "a long-running prior turn must hold the ⚠ verdict (I10) — \
+             RED if the sweep warns while an inflight is live (false ⚠ on a long turn)"
+        );
+        assert_eq!(load_for_channel("claude", 100).len(), 1);
+    }
+
+    /// RED-2 (b): TTL elapsed and NO live inflight — the sweep delivers the
+    /// `⏳ → ⚠` fallback exactly once on the pinned anchor and drains the
+    /// marker (bounded convergence: no #3282 eternal hourglass).
+    #[test]
+    fn sweep_warns_after_ttl_without_inflight() {
+        let _root = test_root();
+        let m = marker("claude", 100, 559, 10_000);
+        record(&m).unwrap();
+        let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
+        let resolved = test_rt().block_on(sweep_expired_with_applier(
+            "claude",
+            10_000 + TTL_MS + 1,
+            true,
+            &|_| false,
+            &applier,
+        ));
+        assert_eq!(resolved, 1);
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &[(559, ReactionOp::FailureWarn)],
+            "a genuinely-uncovered anchor must reach ⚠ in bounded time — \
+             RED if the sweep never warns (the ⏳ would linger forever, #3282)"
+        );
+        assert!(load_for_channel("claude", 100).is_empty());
+    }
+
+    /// RED-2 (c) / I6: http unavailable — EVERY marker is preserved untouched.
+    #[test]
+    fn sweep_preserves_all_when_http_unavailable() {
+        let _root = test_root();
+        let m = marker("claude", 100, 560, 10_000);
+        record(&m).unwrap();
+        let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
+        let resolved = test_rt().block_on(sweep_expired_with_applier(
+            "claude",
+            10_000 + TTL_MS + 1,
+            false, // http unavailable
+            &|_| false,
+            &applier,
+        ));
+        assert_eq!(resolved, 0);
+        assert!(calls.lock().unwrap().is_empty());
+        assert_eq!(
+            load_for_channel("claude", 100).len(),
+            1,
+            "http-unavailable must fail open (marker preserved for the next pass, I6)"
+        );
+    }
+
+    /// Sweep scoping: another provider's markers are never touched.
+    #[test]
+    fn sweep_is_provider_scoped() {
+        let _root = test_root();
+        let m = marker("codex", 100, 561, 10_000);
+        record(&m).unwrap();
+        let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
+        let resolved = test_rt().block_on(sweep_expired_with_applier(
+            "claude",
+            10_000 + TTL_MS + 1,
+            true,
+            &|_| false,
+            &applier,
+        ));
+        assert_eq!(resolved, 0);
+        assert!(calls.lock().unwrap().is_empty());
+        assert_eq!(load_for_channel("codex", 100).len(), 1);
+    }
+}

--- a/src/services/discord/tui_direct_abort_marker.rs
+++ b/src/services/discord/tui_direct_abort_marker.rs
@@ -3,12 +3,11 @@
 //!
 //! ## Why this exists
 //! When a TUI-direct synthetic turn-start ABORTs on the backstop escalation
-//! budget (`backstop_abort_foreign_inflight_live`, see
-//! [`super::tui_direct_pending_start`]), the user's input was ALREADY submitted
-//! to the provider — the abort drops only the synthetic OWNERSHIP claim. In
-//! every live observation the prior turn's owner then relayed the response
-//! normally, yet the #3282-era cleanup swapped the anchor's `⏳` for a `⚠`,
-//! permanently branding an ANSWERED message as failed (#3296).
+//! budget (`backstop_abort_foreign_inflight_live`,
+//! [`super::tui_direct_pending_start`]), the input was ALREADY provider-
+//! submitted — the abort drops only the synthetic OWNERSHIP claim — and the
+//! prior owner then relays the response; the #3282-era `⏳ → ⚠` swap branded
+//! that ANSWERED message as failed (#3296).
 //!
 //! ## Mechanism
 //! The ABORT path now KEEPS the `⏳` (it is still true: the provider holds the
@@ -17,30 +16,35 @@
 //!
 //! 1. **Terminal-commit drain** ([`drain_on_terminal_commit`]) — the tmux
 //!    watcher's terminal chokepoint calls this on every body-visible normal
-//!    commit, passing the identity of the turn that just committed. A marker
-//!    is covered ONLY by a commit whose turn identity MATCHES the foreign
-//!    prior inflight the ABORT recorded (`foreign_user_msg_id` +
-//!    `foreign_started_at` — codex r1: positive correlation; the bare
-//!    same-`(provider, tmux, channel)` + strictly-after-abort wall-clock test
-//!    let a prior-owner commit racing the marker write, a recreated same-name
-//!    tmux session, or a dropped-input prior turn falsely `✅` an unanswered
-//!    anchor). Covering commits are deliberately NOT TTL-bounded (verify r1):
-//!    the sweep defers to a live same-session inflight, so a foreign turn
-//!    streaming past the TTL must still have its eventual commit accepted.
+//!    commit, passing the committed turn's identity. A marker is covered ONLY
+//!    by a commit whose identity MATCHES the foreign prior inflight the ABORT
+//!    recorded (codex r1: positive correlation — the bare same-session +
+//!    after-abort wall-clock test falsely `✅`'d unanswered anchors). Covering
+//!    commits are deliberately NOT TTL-bounded (verify r1): the sweep defers
+//!    to a live same-session inflight, so a foreign turn streaming past the
+//!    TTL must still have its eventual commit accepted.
 //! 2. **TTL sweep** ([`sweep_expired`]) — the placeholder sweeper's pass: once
 //!    [`ABORT_MARKER_TTL`] elapsed with NO live inflight for the session (a
-//!    long turn still streaming holds the verdict; a NAME-LESS inflight holds
-//!    only when it IS the recorded foreign turn — codex r1 finding 2), nothing
-//!    ever covered the anchor → `⏳ → ⚠`, so a genuine failure is still
-//!    surfaced in bounded time (no #3282 eternal-hourglass regression). The
-//!    inflight hold itself is bounded by the absolute
-//!    [`ABORT_MARKER_HARD_CAP_TTL_MULTIPLIER`] cap, so a stale/recreated
+//!    long streaming turn holds the verdict; a NAME-LESS inflight holds only
+//!    when it IS the recorded foreign turn — r1 finding 2), nothing ever
+//!    covered the anchor → `⏳ → ⚠`: a genuine failure still surfaces in
+//!    bounded time (no #3282 eternal hourglass), and the hold itself is capped
+//!    by [`ABORT_MARKER_HARD_CAP_TTL_MULTIPLIER`] so a stale/recreated
 //!    same-channel inflight can never orphan a `⏳` forever.
 //!
 //! The two reconcilers are mutually excluded per marker by a non-blocking
 //! sidecar flock claim ([`try_claim_marker`], the `inflight.rs` sidecar-lock
 //! pattern): claim → re-read → react → delete, so a commit racing the sweep's
 //! delivery window can never stack `✅` + `⚠` on one anchor (verify r1).
+//!
+//! **Commit tombstones** (codex r2) make the RIGHT verdict win those races,
+//! not just the first claimant: the watcher chokepoint durably records a
+//! [`CommitTombstone`] BEFORE it clears the inflight row and runs the drain.
+//! The sweep 대조s uncovered markers against them (post-live-read, so a
+//! commit-caused row clear is never mistaken for "nothing covers this"), and
+//! the ABORT record path 대조s once at record time — replacing the r1
+//! "pre-covered" promotion, which treated bare row-absence as commit evidence
+//! even though force-clears (sweeper/stop/recovery) also delete rows.
 //!
 //! ## Invariants
 //! * **I1 (#3164 add≡remove)**: every reaction op (`⏳` remove, `✅`/`⚠` add)
@@ -123,17 +127,15 @@ impl AbortedAnchorMarker {
         )
     }
 
-    /// Build the marker the ABORT path records. `foreign` is the live foreign
-    /// prior inflight's `(user_msg_id, started_at)` loaded AT the record
-    /// instant: when present, it is pinned so only THAT turn's commit covers.
-    /// When the row is ALREADY gone, the prior owner terminal-committed inside
-    /// the µs gap since the final backstop view read (which saw it LIVE) — its
-    /// drain chokepoint may have run before this marker existed, so the marker
-    /// is recorded PRE-COVERED (the anchor's input was provider-submitted long
-    /// before that commit; the sweep delivers the `✅`). The pair cannot alias
-    /// another turn: one inflight row exists per `(provider, channel)` and a
-    /// successor row starts ≥ the 32s backstop budget after `started_at`
-    /// (1-second resolution), so equality identifies the foreign turn.
+    /// Build the marker the ABORT path records. `foreign` is the foreign prior
+    /// inflight's `(user_msg_id, started_at)` — the live row read AT the record
+    /// instant, or (codex r2) the worker's LAST-VIEW identity when that row
+    /// vanished in the µs gap since the final backstop view. ALWAYS uncovered:
+    /// bare row-absence is NOT commit evidence (force-clears also delete rows;
+    /// the r1 "pre-covered" promotion false-`✅`'d those) — coverage needs the
+    /// drain or a commit-tombstone 대조. The pair cannot alias another turn:
+    /// one row exists per `(provider, channel)` and a successor starts ≥ the
+    /// 32s backstop after `started_at`, so equality identifies the turn.
     pub(super) fn for_abort(
         provider: String,
         channel_id: u64,
@@ -142,7 +144,6 @@ impl AbortedAnchorMarker {
         aborted_at_ms: u64,
         foreign: Option<(u64, String)>,
     ) -> Self {
-        let covered_at_ms = foreign.is_none().then_some(aborted_at_ms);
         let (foreign_user_msg_id, foreign_started_at) = match foreign {
             Some((user_msg_id, started_at)) => (Some(user_msg_id), Some(started_at)),
             None => (None, None),
@@ -153,7 +154,7 @@ impl AbortedAnchorMarker {
             anchor_message_id,
             tmux_session_name,
             aborted_at_ms,
-            covered_at_ms,
+            covered_at_ms: None,
             foreign_user_msg_id,
             foreign_started_at,
         }
@@ -173,13 +174,13 @@ impl AbortedAnchorMarker {
 // Durable store (mirrors `tui_direct_pending_start`'s store + atomic writes)
 // ---------------------------------------------------------------------------
 
-// Thread-local test seam for the durable root (the `TEST_TMUX_ALIVE_OVERRIDE`
-// convention, inflight.rs). Tests inject a tempdir here instead of mutating
-// the process-global `AGENTDESK_ROOT_DIR` env: env mutation races every test
-// that READS the root without holding the crate env lock (e.g. the
-// `tui_direct_pending_start` worker tests' `persist()`), and a thread-local
-// needs no lock at all (each test thread sees only its own override; the
-// current-thread `block_on` runtimes the tests use stay on this thread).
+// Thread-local test seam for the durable BASE root (the
+// `TEST_TMUX_ALIVE_OVERRIDE` convention, inflight.rs). Tests inject a tempdir
+// here instead of mutating the process-global `AGENTDESK_ROOT_DIR` env (env
+// mutation races lock-free root readers, e.g. the `tui_direct_pending_start`
+// worker tests' `persist()`); a thread-local needs no lock and the tests'
+// current-thread `block_on` runtimes stay on this thread. The override is the
+// BASE both sibling stores (markers + commit tombstones) join subdirs onto.
 #[cfg(test)]
 thread_local! {
     static TEST_ROOT_OVERRIDE: std::cell::RefCell<Option<std::path::PathBuf>> =
@@ -193,10 +194,18 @@ pub(super) fn set_test_root_override(path: Option<std::path::PathBuf>) {
 
 fn root() -> Option<std::path::PathBuf> {
     #[cfg(test)]
-    if let Some(path) = TEST_ROOT_OVERRIDE.with(|cell| cell.borrow().clone()) {
-        return Some(path);
+    if let Some(base) = TEST_ROOT_OVERRIDE.with(|cell| cell.borrow().clone()) {
+        return Some(base.join("discord_tui_direct_abort_marker"));
     }
     super::runtime_store::tui_direct_abort_marker_root()
+}
+
+fn tombstone_root() -> Option<std::path::PathBuf> {
+    #[cfg(test)]
+    if let Some(base) = TEST_ROOT_OVERRIDE.with(|cell| cell.borrow().clone()) {
+        return Some(base.join("discord_tui_direct_commit_tombstone"));
+    }
+    super::runtime_store::tui_direct_commit_tombstone_root()
 }
 
 /// Persist (or update) a marker. Recorded by the ABORT path BEFORE any http
@@ -223,9 +232,8 @@ pub(super) fn record(marker: &AbortedAnchorMarker) -> Result<(), String> {
 /// Drop a marker once its correction was delivered (plus its claim sidecar so
 /// the store does not accumulate lock files). Idempotent. The sidecar unlink
 /// is benign even if a contender still holds an fd on the old inode: it
-/// re-reads the marker file under its claim and finds it gone (file stems are
-/// keyed on unique anchor snowflakes, so a stem is never reused for a
-/// different logical marker).
+/// re-reads the marker under its claim and finds it gone (stems are keyed on
+/// unique anchor snowflakes — never reused for a different logical marker).
 pub(super) fn delete(marker: &AbortedAnchorMarker) {
     if let Some(root) = root() {
         let stem = marker.file_stem();
@@ -235,10 +243,9 @@ pub(super) fn delete(marker: &AbortedAnchorMarker) {
 }
 
 /// Load every durable marker (sweep + restart survival: the store IS the
-/// restart state — no in-memory index to rebuild). Unparseable JSON (writes
-/// are atomic, so this means corruption or an incompatible schema, never a
-/// torn write) is QUARANTINED via a `.bad` rename instead of being silently
-/// re-skipped forever (verify r1 fix #3 — bounded noise, one WARN per file).
+/// restart state). Unparseable JSON (atomic writes ⇒ corruption or schema
+/// drift, never a torn write) is QUARANTINED via a `.bad` rename instead of
+/// silently re-skipped forever (verify r1 fix #3 — one WARN per file).
 pub(super) fn load_all() -> Vec<AbortedAnchorMarker> {
     let Some(root) = root() else {
         return Vec::new();
@@ -291,6 +298,222 @@ pub(super) fn load_for_channel(provider: &str, channel_id: u64) -> Vec<AbortedAn
 }
 
 // ---------------------------------------------------------------------------
+// Commit tombstones (codex r2 — durable terminal-commit evidence)
+// ---------------------------------------------------------------------------
+
+/// Tombstone retention = the marker hard cap (1h): any marker a tombstone
+/// could still cover resolves within that bound, so older evidence has no
+/// consumer. GC runs at the END of each sweep pass, so a first post-restart
+/// pass still 대조s against evidence that aged out during downtime.
+pub(super) const COMMIT_TOMBSTONE_RETENTION_MS: u64 =
+    ABORT_MARKER_TTL.as_millis() as u64 * ABORT_MARKER_HARD_CAP_TTL_MULTIPLIER;
+
+/// Durable record of one body-visible terminal commit, written by the watcher
+/// chokepoint BEFORE it clears the inflight row (codex r2). Write-before-clear
+/// is the load-bearing invariant: whenever a reconciler observes "the foreign
+/// row is gone", a commit-caused deletion has ALREADY made its tombstone
+/// visible — row-absence + matching tombstone proves the prior owner committed
+/// (`✅`); row-absence WITHOUT one is a non-commit force-clear/stop/recovery
+/// deletion (bounded `⚠`). Primitive fields survive a dcserver version swap.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct CommitTombstone {
+    pub provider: String,
+    pub channel_id: u64,
+    pub tmux_session_name: String,
+    /// Identity of the COMMITTED turn (`inflight.rs` `InflightTurnIdentity`
+    /// convention) — 대조 against a marker's recorded foreign identity is the
+    /// same positive correlation the drain cover uses (codex r1).
+    pub committed_user_msg_id: u64,
+    pub committed_started_at: String,
+    /// Wall-clock ms of the commit (the chokepoint's clock). Also the GC key.
+    pub committed_at_ms: u64,
+}
+
+/// Persist a terminal-commit tombstone. Best-effort by design (a failed write
+/// degrades to the conservative `⚠`-after-cap path, never a false `✅`); the
+/// stem is keyed on the write instant so successive commits on one channel
+/// never erase earlier still-retained evidence.
+pub(super) fn record_commit_tombstone(
+    provider: &str,
+    tmux_session_name: &str,
+    channel_id: u64,
+    committed_user_msg_id: u64,
+    committed_started_at: &str,
+) {
+    record_commit_tombstone_at(
+        now_ms(),
+        provider,
+        tmux_session_name,
+        channel_id,
+        committed_user_msg_id,
+        committed_started_at,
+    );
+}
+
+pub(super) fn record_commit_tombstone_at(
+    now_ms: u64,
+    provider: &str,
+    tmux_session_name: &str,
+    channel_id: u64,
+    committed_user_msg_id: u64,
+    committed_started_at: &str,
+) {
+    let Some(root) = tombstone_root() else {
+        return; // tests / unconfigured root — nothing durable to write
+    };
+    let tombstone = CommitTombstone {
+        provider: provider.to_string(),
+        channel_id,
+        tmux_session_name: tmux_session_name.to_string(),
+        committed_user_msg_id,
+        committed_started_at: committed_started_at.to_string(),
+        committed_at_ms: now_ms,
+    };
+    let path = root.join(format!("{provider}_{channel_id}_{now_ms}.json"));
+    let written = serde_json::to_string_pretty(&tombstone)
+        .map_err(|e| e.to_string())
+        .and_then(|data| {
+            super::runtime_store::critical_atomic_write(
+                &path,
+                &data,
+                super::runtime_store::AtomicWriteContext::new("tui_direct_commit_tombstone")
+                    .provider(provider)
+                    .channel_id(channel_id),
+            )
+        });
+    if let Err(error) = written {
+        tracing::warn!(
+            provider,
+            channel_id,
+            committed_user_msg_id,
+            error = %error,
+            "tui_direct_abort_marker: failed to persist commit tombstone; a racing marker degrades to the bounded ⚠ fallback (#3296 r2)"
+        );
+    }
+}
+
+/// Every parseable tombstone as `(path, tombstone)`. Unparseable JSON is
+/// deleted outright (unlike markers there is nothing to reconcile from
+/// corrupt evidence — losing it degrades to the conservative `⚠`).
+fn tombstone_files() -> Vec<(std::path::PathBuf, CommitTombstone)> {
+    let Some(root) = tombstone_root() else {
+        return Vec::new();
+    };
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue; // transient read failure — retry next pass
+        };
+        match serde_json::from_str::<CommitTombstone>(&text) {
+            Ok(t) => out.push((path, t)),
+            Err(error) => {
+                let removed = std::fs::remove_file(&path);
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %error,
+                    removed_ok = removed.is_ok(),
+                    "tui_direct_abort_marker: unparseable commit tombstone deleted (#3296 r2)"
+                );
+            }
+        }
+    }
+    out
+}
+
+/// Retained tombstones for one `(provider, channel)` — the 대조 working set.
+pub(super) fn load_commit_tombstones(provider: &str, channel_id: u64) -> Vec<CommitTombstone> {
+    tombstone_files()
+        .into_iter()
+        .map(|(_, t)| t)
+        .filter(|t| t.channel_id == channel_id && t.provider.eq_ignore_ascii_case(provider))
+        .collect()
+}
+
+/// Drop tombstones older than [`COMMIT_TOMBSTONE_RETENTION_MS`]. Called at the
+/// END of each sweep pass (post-대조, see the retention const's rationale).
+pub(super) fn gc_expired_commit_tombstones(now_ms: u64) {
+    for (path, t) in tombstone_files() {
+        if now_ms.saturating_sub(t.committed_at_ms) >= COMMIT_TOMBSTONE_RETENTION_MS {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+}
+
+/// `true` iff this tombstone is commit evidence for this marker's recorded
+/// foreign turn: same tmux session AND the committed identity IS the pinned
+/// foreign identity (the codex-r1 positive correlation — identity-absent
+/// markers match nothing, and an unrelated turn's tombstone never covers).
+fn commit_tombstone_matches_marker(marker: &AbortedAnchorMarker, t: &CommitTombstone) -> bool {
+    t.tmux_session_name == marker.tmux_session_name
+        && marker.matches_foreign_identity(t.committed_user_msg_id, &t.committed_started_at)
+}
+
+/// Record-instant 대조 (codex r2 — replaces the unfounded "pre-covered"
+/// promotion): a tombstone matching the marker's foreign identity ALREADY
+/// durable at record time means that turn terminal-committed before this
+/// marker existed (its drain pass could never see it) → stamp covered with the
+/// commit instant. No wall-clock condition: the identity was captured from a
+/// row observed LIVE after the anchor's input was provider-submitted, so that
+/// turn's unique terminal commit post-dates the submission regardless of how
+/// it interleaves with the marker write.
+pub(super) fn cover_from_commit_tombstone(marker: &mut AbortedAnchorMarker) -> bool {
+    if marker.covered_at_ms.is_some() {
+        return false;
+    }
+    let Some(t) = load_commit_tombstones(&marker.provider, marker.channel_id)
+        .into_iter()
+        .find(|t| commit_tombstone_matches_marker(marker, t))
+    else {
+        return false;
+    };
+    marker.covered_at_ms = Some(t.committed_at_ms);
+    true
+}
+
+/// Sweep-side 대조: a tombstone covers an UNCOVERED marker when it matches the
+/// foreign identity AND its commit is strictly later than the abort (the
+/// record-instant 대조 above owns evidence that predates the marker, so the
+/// subsidiary wall-clock guard costs nothing here and mirrors the drain's).
+pub(super) fn post_abort_commit_tombstone(marker: &AbortedAnchorMarker) -> Option<u64> {
+    load_commit_tombstones(&marker.provider, marker.channel_id)
+        .into_iter()
+        .find(|t| {
+            commit_tombstone_matches_marker(marker, t) && t.committed_at_ms > marker.aborted_at_ms
+        })
+        .map(|t| t.committed_at_ms)
+}
+
+/// The ABORT path's one-call record: build the marker (always uncovered —
+/// codex r2), run the record-instant tombstone 대조, persist. Returns the
+/// persisted marker for the caller's structured log fields.
+pub(super) fn record_for_abort(
+    provider: String,
+    channel_id: u64,
+    anchor_message_id: u64,
+    tmux_session_name: String,
+    foreign: Option<(u64, String)>,
+) -> Result<AbortedAnchorMarker, String> {
+    let mut marker = AbortedAnchorMarker::for_abort(
+        provider,
+        channel_id,
+        anchor_message_id,
+        tmux_session_name,
+        now_ms(),
+        foreign,
+    );
+    cover_from_commit_tombstone(&mut marker);
+    record(&marker)?;
+    Ok(marker)
+}
+
+// ---------------------------------------------------------------------------
 // Per-marker claim (verify r1 fix #2 — the inflight.rs sidecar-flock pattern)
 // ---------------------------------------------------------------------------
 
@@ -314,10 +537,9 @@ impl Drop for MarkerClaim {
 
 /// NON-BLOCKING exclusive claim on one marker's `<stem>.json.lock` sidecar.
 /// `None` means the OTHER reconciler (drain vs sweep) owns the marker this
-/// instant — skip it; the loser's pass is idempotent and retries later. The
-/// claim is awaited across the Discord delivery deliberately: it is a file
-/// flock guard (not a `std::sync` lock — no `await_holding_lock` site), and
-/// the only possible waiter skips instead of blocking.
+/// instant — skip; the loser's pass is idempotent and retries later. The claim
+/// is held across the Discord delivery deliberately: it is a file flock (no
+/// `await_holding_lock` site) and the only possible waiter skips, not blocks.
 pub(super) fn try_claim_marker(marker: &AbortedAnchorMarker) -> Option<MarkerClaim> {
     let root = root()?;
     let lock_path = root.join(format!("{}.json.lock", marker.file_stem()));
@@ -362,12 +584,11 @@ pub(super) enum MarkerDisposition {
 }
 
 /// The sweep's per-marker verdict. Conservative by design (I10): `⚠` requires
-/// BOTH the TTL to have elapsed AND no live inflight for the session, so a
-/// long-running prior turn is never falsely branded; `✅` retry requires a
-/// previously-seen covering commit. The live-inflight hold is absolutely
-/// bounded by [`ABORT_MARKER_HARD_CAP_TTL_MULTIPLIER`] (codex r1 finding 2) so
-/// no inflight churn can orphan the `⏳` forever — this hard cap is also the
-/// sole terminator for identity-ABSENT markers, which the drain never covers.
+/// BOTH an elapsed TTL AND no live inflight for the session (a long prior turn
+/// is never falsely branded); `✅` retry requires a previously-seen covering
+/// commit. The live-inflight hold is bounded by the hard cap (r1 finding 2) so
+/// no inflight churn can orphan the `⏳` — the cap is also the sole terminator
+/// for identity-ABSENT markers, which the drain never covers.
 pub(super) fn decide_marker_disposition(
     now_ms: u64,
     marker: &AbortedAnchorMarker,
@@ -392,20 +613,16 @@ pub(super) fn decide_marker_disposition(
     MarkerDisposition::DeliverFailureWarn
 }
 
-/// Does a terminal commit by the turn identified by `(committed_user_msg_id,
-/// committed_started_at)` cover this marker? Codex r1: POSITIVE correlation
-/// required — the committed turn must BE the foreign prior inflight recorded
-/// at ABORT time. The old condition (any same-`(provider,tmux,channel)`
-/// commit with `now_ms > aborted_at_ms`) let three impostors through: a
-/// prior-owner commit racing the marker write, a later turn in a re-created
-/// same-name tmux session, and an ordinary prior commit whose queued input
-/// was dropped — each a false `✅` on a possibly-unanswered anchor. The
-/// strictly-after-abort wall-clock test is retained as a SUBSIDIARY guard
-/// only. Identity-absent (legacy) markers never cover here — the sweep's
-/// TTL/hard-cap bound is their sole terminator. Deliberately NO TTL upper
-/// bound (verify r1): the sweep defers to a live same-session inflight, so a
-/// foreign turn streaming past the TTL must still have its eventual commit
-/// accepted — a TTL bound here re-created the false-`⚠`-on-answered symptom.
+/// Does a terminal commit by `(committed_user_msg_id, committed_started_at)`
+/// cover this marker? Codex r1: POSITIVE correlation required — the committed
+/// turn must BE the foreign prior inflight recorded at ABORT time (the old
+/// wall-clock-only condition let a racing prior-owner commit, a re-created
+/// same-name tmux session, and a dropped-input prior commit each false-`✅` a
+/// possibly-unanswered anchor); strictly-after-abort stays as a SUBSIDIARY
+/// guard only. Identity-absent (legacy) markers never cover here — the sweep
+/// bound is their sole terminator. Deliberately NO TTL upper bound (verify
+/// r1): the sweep defers to a live same-session inflight, so a foreign turn
+/// streaming past the TTL must still have its eventual commit accepted.
 pub(super) fn terminal_commit_covers_marker(
     now_ms: u64,
     marker: &AbortedAnchorMarker,
@@ -489,12 +706,11 @@ pub(super) type ReactionApplierFn = Box<
 >;
 
 /// The production applier. Bot identity (#3164 add≡remove, I1): the `⏳` was
-/// added via the relay's `shared.serenity_http_or_token_fallback()` (the
-/// provider/command bot), and `remove_reaction_raw` only removes `@me`'s
-/// reaction — resolving the SAME source here guarantees the removal targets
-/// exactly the reaction the add created. Success is keyed on the `✅`/`⚠`
-/// create (the remove is best-effort, mirroring
-/// `complete_tui_direct_prompt_anchor_lifecycle_if_present`).
+/// added via the relay's `shared.serenity_http_or_token_fallback()`, and
+/// `remove_reaction_raw` only removes `@me`'s reaction — resolving the SAME
+/// source guarantees the removal targets exactly the reaction the add created.
+/// Success is keyed on the `✅`/`⚠` create (the remove is best-effort,
+/// mirroring `complete_tui_direct_prompt_anchor_lifecycle_if_present`).
 pub(super) fn shared_reaction_applier(shared: Arc<SharedData>) -> ReactionApplierFn {
     Box::new(move |marker, op| {
         let shared = shared.clone();
@@ -553,10 +769,9 @@ fn now_ms() -> u64 {
     chrono::Utc::now().timestamp_millis().max(0) as u64
 }
 
-/// Watcher terminal-commit chokepoint: a body-visible normal commit for
-/// `(provider, tmux, channel)` covers every marker whose recorded foreign
-/// identity matches the COMMITTED turn (`committed_user_msg_id` +
-/// `committed_started_at` — codex r1) → `⏳ → ✅`. Returns markers drained.
+/// Watcher terminal-commit chokepoint: a body-visible normal commit covers
+/// every marker whose recorded foreign identity matches the COMMITTED turn
+/// (codex r1) → `⏳ → ✅`. Returns markers drained.
 pub(super) async fn drain_on_terminal_commit(
     shared: &Arc<SharedData>,
     provider: &str,
@@ -637,11 +852,10 @@ pub(super) async fn drain_on_terminal_commit_with_applier(
                 // retries the ✅ (and can never degrade it to ⚠).
                 marker.covered_at_ms = Some(now_ms);
                 if let Err(error) = record(&marker) {
-                    // verify r1 fix #4: a swallowed stamp failure would let the
-                    // sweep ⚠ a COVERED anchor after the TTL. Surface it loudly;
-                    // the marker stays on disk un-stamped, so the next covering
-                    // drain pass retries the ✅ (idempotent — covers are not
-                    // TTL-bounded since verify r1 fix #1).
+                    // verify r1 fix #4: surface loudly — a swallowed stamp
+                    // failure would let the sweep ⚠ a COVERED anchor after the
+                    // TTL; un-stamped, the next covering drain pass retries
+                    // the ✅ (covers are not TTL-bounded since fix #1).
                     tracing::error!(
                         provider = %marker.provider,
                         channel_id = marker.channel_id,
@@ -658,8 +872,7 @@ pub(super) async fn drain_on_terminal_commit_with_applier(
 
 /// Placeholder-sweeper pass: retry `✅` for covered markers; apply the TTL'd
 /// `⏳ → ⚠` fallback for anchors no commit ever covered (held while a live
-/// inflight may still cover them — see [`inflight_defers_sweep`] — up to the
-/// absolute hard cap). Returns markers resolved.
+/// inflight may still cover them, up to the hard cap). Returns resolved.
 pub(super) async fn sweep_expired(
     shared: &Arc<SharedData>,
     provider: &super::ProviderKind,
@@ -708,13 +921,37 @@ pub(super) async fn sweep_expired_with_applier(
         let Some(_claim) = try_claim_marker(&marker) else {
             continue; // the drain owns this marker right now
         };
-        let Some(marker) = reload(&marker) else {
+        let Some(mut marker) = reload(&marker) else {
             continue; // drained while unclaimed
         };
+        // codex r2 ordering: live-inflight read FIRST, tombstone 대조 SECOND.
+        // The chokepoint writes the tombstone BEFORE clearing the row, so "no
+        // live row" here guarantees a commit-caused clear already made its
+        // tombstone visible to the 대조 — a sweep pass claiming the marker
+        // mid-commit can no longer beat the correct ✅ with a ⚠ (finding 1;
+        // the flock only serializes, it does not order the verdicts).
+        let live_inflight = live_inflight_for_session(&marker);
+        if marker.covered_at_ms.is_none()
+            && let Some(committed_at_ms) = post_abort_commit_tombstone(&marker)
+        {
+            marker.covered_at_ms = Some(committed_at_ms);
+            if let Err(error) = record(&marker) {
+                // Loud (verify-r1 fix #4): un-persisted, the stamp re-derives
+                // from the tombstone next pass — but a Discord outage outliving
+                // the tombstone retention would then ⚠ a covered anchor.
+                tracing::error!(
+                    provider = %marker.provider,
+                    channel_id = marker.channel_id,
+                    anchor_message_id = marker.anchor_message_id,
+                    error = %error,
+                    "tui_direct_abort_marker: failed to persist tombstone-covered stamp; next sweep pass re-derives (#3296 r2)"
+                );
+            }
+        }
         let disposition = decide_marker_disposition(
             now_ms,
             &marker,
-            live_inflight_for_session(&marker),
+            live_inflight,
             ABORT_MARKER_TTL,
             http_available,
         );
@@ -754,6 +991,9 @@ pub(super) async fn sweep_expired_with_applier(
             ReactionDelivery::Failed | ReactionDelivery::HttpUnavailable => {}
         }
     }
+    // GC AFTER the marker loop: the first pass after long downtime must 대조
+    // against evidence that aged past the retention cap before deleting it.
+    gc_expired_commit_tombstones(now_ms);
     resolved
 }
 
@@ -762,11 +1002,13 @@ mod tests {
     use super::*;
     use std::sync::Mutex;
 
-    /// Injects a per-test tempdir as the durable root via the THREAD-LOCAL
-    /// override (never the process-global `AGENTDESK_ROOT_DIR` env — mutating
-    /// that races every test that reads the root without the crate env lock,
-    /// e.g. the `tui_direct_pending_start` worker tests' `persist()`). No lock
-    /// is needed: each test thread sees only its own override.
+    /// Injects a per-test tempdir as the durable BASE root (marker store +
+    /// commit-tombstone store are siblings under it — codex r2) via the
+    /// THREAD-LOCAL override (never the process-global `AGENTDESK_ROOT_DIR`
+    /// env — mutating that races every test that reads the root without the
+    /// crate env lock, e.g. the `tui_direct_pending_start` worker tests'
+    /// `persist()`). No lock is needed: each test thread sees only its own
+    /// override.
     struct TestRoot {
         _temp: tempfile::TempDir,
     }
@@ -779,8 +1021,10 @@ mod tests {
 
     fn test_root() -> TestRoot {
         let temp = tempfile::tempdir().unwrap();
-        set_test_root_override(Some(temp.path().join("discord_tui_direct_abort_marker")));
+        set_test_root_override(Some(temp.path().to_path_buf()));
         std::fs::create_dir_all(root().expect("durable root configured under temp")).unwrap();
+        std::fs::create_dir_all(tombstone_root().expect("tombstone root configured under temp"))
+            .unwrap();
         TestRoot { _temp: temp }
     }
 
@@ -1036,14 +1280,16 @@ mod tests {
         );
     }
 
-    /// codex r1: the ABORT constructor. A LIVE foreign prior inflight pins its
-    /// identity (marker uncovered); an ALREADY-GONE foreign row means the
-    /// prior owner committed in the µs race before the marker existed — its
-    /// drain chokepoint can never see this marker, so it is recorded
-    /// PRE-COVERED and the sweep delivers the `✅` (RED as a TTL'd false `⚠`
-    /// on an answered anchor otherwise).
+    /// codex r2 (reverses the r1 pre-covered semantics): the ABORT constructor
+    /// NEVER records a covered marker. Bare row-absence is not commit evidence
+    /// — a placeholder-sweeper/stop/recovery force-clear also deletes rows, so
+    /// the r1 `foreign: None ⇒ covered_at = aborted_at` promotion false-`✅`'d
+    /// unanswered anchors (RED on the r1 code: `raced.covered_at_ms` was
+    /// `Some(aborted_at)`). Coverage now requires positive evidence (the drain
+    /// or a commit-tombstone 대조 — see
+    /// `record_instant_tombstone_covers_when_row_vanished_for_commit`).
     #[test]
-    fn for_abort_pins_identity_or_records_pre_covered() {
+    fn for_abort_pins_identity_and_never_pre_covers() {
         let live = AbortedAnchorMarker::for_abort(
             "claude".into(),
             9,
@@ -1064,10 +1310,9 @@ mod tests {
         let raced =
             AbortedAnchorMarker::for_abort("claude".into(), 9, 902, "tmux-9".into(), 42_000, None);
         assert_eq!(
-            raced.covered_at_ms,
-            Some(42_000),
-            "foreign row gone at the record instant ⇒ its commit already \
-             happened ⇒ pre-covered (the drain can never see this marker)"
+            raced.covered_at_ms, None,
+            "row-absence alone must NOT cover (r2: the deletion may be a \
+             non-commit force-clear — only tombstone evidence may cover)"
         );
         assert_eq!(raced.foreign_user_msg_id, None);
         assert_eq!(raced.foreign_started_at, None);
@@ -1473,60 +1718,52 @@ mod tests {
         );
     }
 
-    /// #3296 verify r1 (TOCTOU): the drain and the sweep must never BOTH
-    /// react to one marker. Simulates the race by running the watcher drain
-    /// from INSIDE the sweep's delivery window (a terminal commit arriving
-    /// mid-`⚠`). RED pre-claim: both reconcilers loaded the marker
-    /// independently and an answered-looking anchor collected `✅` + `⚠`.
+    /// codex r2 finding 1 (RED ① — REVERSES the r1
+    /// `sweep_and_drain_cannot_both_react_to_one_marker` pin, which froze this
+    /// exact race as `FailureWarn`): a terminal commit by the recorded foreign
+    /// turn landing BETWEEN the sweep's claim and its verdict must end `✅`,
+    /// never `⚠` — the flock only serializes the reconcilers, it does not make
+    /// the RIGHT verdict win. The chokepoint's tombstone-before-clear write
+    /// plus the sweep's live-read-then-대조 ordering closes it: by the time the
+    /// sweep can observe "no live row", the commit's tombstone is durable.
+    /// Mutual exclusion stays intact (the racing drain still skips — exactly
+    /// ONE reaction lands, and it is the completion).
     #[test]
-    fn sweep_and_drain_cannot_both_react_to_one_marker() {
+    fn sweep_claim_racing_terminal_commit_resolves_completion_not_warn() {
         let _root = test_root();
         let m = marker("claude", 100, 562, 10_000);
         record(&m).unwrap();
-        let calls: RecordedOps = Arc::new(Mutex::new(Vec::new()));
-        let sweep_calls = calls.clone();
-        let sweep_applier: ReactionApplierFn = Box::new(move |marker, op| {
-            let calls = sweep_calls.clone();
-            let anchor = marker.anchor_message_id;
-            Box::pin(async move {
-                // A terminal commit races in while the sweep is delivering ⚠.
-                let drain_calls = calls.clone();
-                let drain_applier: ReactionApplierFn = Box::new(move |m, op| {
-                    let calls = drain_calls.clone();
-                    let anchor = m.anchor_message_id;
-                    Box::pin(async move {
-                        calls.lock().unwrap().push((anchor, op));
-                        ReactionDelivery::Delivered
-                    })
-                });
-                drain_on_terminal_commit_with_applier(
-                    "claude",
-                    "tmux-100",
-                    100,
-                    10_500,
-                    562 + 500_000, // the marker's recorded foreign turn
-                    FOREIGN_STARTED_AT,
-                    &drain_applier,
-                )
-                .await;
-                calls.lock().unwrap().push((anchor, op));
-                ReactionDelivery::Delivered
-            })
-        });
+        let (cid, cstart) = committed(&m);
+        let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
+        let commit_at = 10_000 + TTL_MS + 5_000;
+        // The watcher chokepoint interleaves inside the sweep's live-inflight
+        // read (post-claim, pre-verdict): tombstone FIRST (durable before the
+        // row clear), then its drain pass — which must SKIP the sweep-claimed
+        // marker (try_claim is the drain's first step) — then the row clear
+        // (this closure returns false = no live row).
+        let live_inflight = move |marker: &AbortedAnchorMarker| -> bool {
+            record_commit_tombstone_at(commit_at, "claude", "tmux-100", 100, cid, &cstart);
+            assert!(
+                try_claim_marker(marker).is_none(),
+                "sweep holds the claim; the racing drain must skip (exclusion)"
+            );
+            false
+        };
         let resolved = test_rt().block_on(sweep_expired_with_applier(
             "claude",
-            10_000 + TTL_MS + 1,
+            commit_at + 1_000,
             true,
-            &|_| false,
-            &sweep_applier,
+            &live_inflight,
+            &applier,
         ));
         assert_eq!(resolved, 1);
         let calls = calls.lock().unwrap();
         assert_eq!(
             calls.as_slice(),
-            &[(562, ReactionOp::FailureWarn)],
-            "exactly ONE reconciler may react per marker — RED without the \
-             per-marker claim (✅ AND ⚠ both landed on the same anchor)"
+            &[(562, ReactionOp::Complete)],
+            "the committed turn's tombstone must decide the verdict: exactly \
+             ONE reaction and it is ✅ — RED pre-r2 (without the 대조 the sweep \
+             ⚠'d this ANSWERED anchor; the old test pinned that ⚠ as expected)"
         );
         assert!(load_for_channel("claude", 100).is_empty());
     }
@@ -1703,5 +1940,193 @@ mod tests {
         assert_eq!(resolved, 0);
         assert!(calls.lock().unwrap().is_empty());
         assert_eq!(load_for_channel("codex", 100).len(), 1);
+    }
+
+    /// codex r2: tombstone store roundtrip — durable, provider/channel scoped.
+    #[test]
+    fn commit_tombstone_roundtrip_is_provider_and_channel_scoped() {
+        let _root = test_root();
+        record_commit_tombstone_at(50_000, "claude", "tmux-100", 100, 777, FOREIGN_STARTED_AT);
+        record_commit_tombstone_at(50_001, "codex", "tmux-100", 100, 778, FOREIGN_STARTED_AT);
+        record_commit_tombstone_at(50_002, "claude", "tmux-200", 200, 779, FOREIGN_STARTED_AT);
+        let loaded = load_commit_tombstones("claude", 100);
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].committed_user_msg_id, 777);
+        assert_eq!(loaded[0].committed_at_ms, 50_000);
+        assert_eq!(loaded[0].tmux_session_name, "tmux-100");
+        assert_eq!(load_commit_tombstones("codex", 100).len(), 1);
+        assert_eq!(load_commit_tombstones("claude", 200).len(), 1);
+    }
+
+    /// codex r2 (RED ② — replaces the pre-covered promotion): the ABORT record
+    /// path with the foreign row already GONE. With a matching tombstone the
+    /// deletion WAS the prior owner's terminal commit → the marker records
+    /// covered at the tombstone's commit instant (evidence-backed — note the
+    /// commit PRECEDES `aborted_at`, the case the sweep's strictly-post-abort
+    /// 대조 deliberately excludes). WITHOUT one (a placeholder-sweeper/stop/
+    /// recovery force-clear) it records UNCOVERED and the sweep bound delivers
+    /// the conservative `⚠` — RED pre-r2: bare row-absence pre-covered the
+    /// marker and a force-cleared, genuinely-unanswered anchor got a false ✅.
+    #[test]
+    fn record_instant_tombstone_evidence_decides_cover_for_vanished_row() {
+        let _root = test_root();
+        // (a) commit-caused deletion: tombstone for the foreign turn exists.
+        record_commit_tombstone_at(
+            60_000,
+            "claude",
+            "tmux-100",
+            100,
+            600_777,
+            FOREIGN_STARTED_AT,
+        );
+        let covered = record_for_abort(
+            "claude".into(),
+            100,
+            600,
+            "tmux-100".into(),
+            Some((600_777, FOREIGN_STARTED_AT.into())),
+        )
+        .unwrap();
+        assert_eq!(
+            covered.covered_at_ms,
+            Some(60_000),
+            "matching tombstone at record time ⇒ evidence-backed cover"
+        );
+        // (b) non-commit deletion (force-clear simulation): no tombstone for
+        // THIS identity ⇒ uncovered; the sweep bound then delivers ⚠.
+        let uncovered = record_for_abort(
+            "claude".into(),
+            100,
+            601,
+            "tmux-100".into(),
+            Some((601_888, FOREIGN_STARTED_AT.into())),
+        )
+        .unwrap();
+        assert_eq!(
+            uncovered.covered_at_ms, None,
+            "row-absence without commit evidence must stay uncovered (RED ②: \
+             the r1 pre-covered promotion ✅'d this force-clear case)"
+        );
+        let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
+        let resolved = test_rt().block_on(sweep_expired_with_applier(
+            "claude",
+            uncovered.aborted_at_ms + TTL_MS * ABORT_MARKER_HARD_CAP_TTL_MULTIPLIER,
+            true,
+            &|_| false,
+            &applier,
+        ));
+        assert_eq!(resolved, 2);
+        let calls = calls.lock().unwrap();
+        assert!(
+            calls.contains(&(600, ReactionOp::Complete)),
+            "evidence-covered marker completes"
+        );
+        assert!(
+            calls.contains(&(601, ReactionOp::FailureWarn)),
+            "force-clear marker takes the conservative ⚠ in bounded time"
+        );
+        assert!(load_for_channel("claude", 100).is_empty());
+    }
+
+    /// codex r2 (RED ③): GC removes only RETAINED-out tombstones, and once the
+    /// matching evidence is gone an UNRELATED turn's fresh tombstone must never
+    /// cover the marker (positive identity correlation, exactly like the
+    /// drain) — the hard-capped `⚠` stays the terminator.
+    #[test]
+    fn expired_tombstone_gc_and_unrelated_commit_never_cover() {
+        let _root = test_root();
+        let m = marker("claude", 100, 564, 10_000);
+        record(&m).unwrap();
+        let (cid, cstart) = committed(&m);
+        // The foreign turn's own tombstone, but already past retention at the
+        // sweep instant below; plus a FRESH unrelated turn's tombstone.
+        record_commit_tombstone_at(11_000, "claude", "tmux-100", 100, cid, &cstart);
+        let now = 11_000 + COMMIT_TOMBSTONE_RETENTION_MS;
+        record_commit_tombstone_at(now - 1_000, "claude", "tmux-100", 100, cid + 7, &cstart);
+        // Pass 1: a sweep for a provider with NO markers — it runs only the
+        // end-of-pass GC. (A claude pass would 대조 BEFORE the GC and the
+        // still-present expired evidence would cover — deliberate
+        // post-restart semantics; this test targets the post-GC world.)
+        let (applier, _calls) = recording_applier(ReactionDelivery::Delivered);
+        let resolved = test_rt().block_on(sweep_expired_with_applier(
+            "gemini", // no gemini markers: this pass only runs the GC
+            now,
+            true,
+            &|_| false,
+            &applier,
+        ));
+        assert_eq!(resolved, 0);
+        let remaining = load_commit_tombstones("claude", 100);
+        assert_eq!(
+            remaining.len(),
+            1,
+            "GC must drop the retention-expired tombstone and keep the fresh one"
+        );
+        assert_eq!(remaining[0].committed_user_msg_id, cid + 7);
+        // Pass 2: only the unrelated tombstone remains — it must NOT cover;
+        // the hard cap delivers the conservative ⚠ (RED ③ if an unrelated
+        // commit covers or the expired evidence resurrects).
+        let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
+        let resolved = test_rt().block_on(sweep_expired_with_applier(
+            "claude",
+            10_000 + TTL_MS * ABORT_MARKER_HARD_CAP_TTL_MULTIPLIER,
+            true,
+            &|_| false,
+            &applier,
+        ));
+        assert_eq!(resolved, 1);
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &[(564, ReactionOp::FailureWarn)],
+            "an unrelated commit's tombstone must never ✅ a foreign marker"
+        );
+    }
+
+    /// codex r2: the sweep's tombstone-covered stamp is PERSISTED, so a ✅
+    /// delivery failure followed by the tombstone aging out of retention can
+    /// never degrade the covered anchor to `⚠` (the persisted `covered_at_ms`
+    /// outlives the evidence that produced it).
+    #[test]
+    fn tombstone_cover_stamp_survives_delivery_failure_and_evidence_gc() {
+        let _root = test_root();
+        let m = marker("claude", 100, 565, 10_000);
+        record(&m).unwrap();
+        let (cid, cstart) = committed(&m);
+        let commit_at = 20_000;
+        record_commit_tombstone_at(commit_at, "claude", "tmux-100", 100, cid, &cstart);
+        let rt = test_rt();
+        // Pass 1: 대조 covers, but the ✅ delivery fails transiently.
+        let (failing, _ops) = recording_applier(ReactionDelivery::Failed);
+        let resolved = rt.block_on(sweep_expired_with_applier(
+            "claude",
+            commit_at + 1_000,
+            true,
+            &|_| false,
+            &failing,
+        ));
+        assert_eq!(resolved, 0);
+        let kept = load_for_channel("claude", 100);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(
+            kept[0].covered_at_ms,
+            Some(commit_at),
+            "the 대조 stamp must be durable, not in-memory only"
+        );
+        // Pass 2: far past tombstone retention (evidence GC'd) — the persisted
+        // stamp still drives the ✅ retry, never a ⚠.
+        let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
+        let resolved = rt.block_on(sweep_expired_with_applier(
+            "claude",
+            commit_at + COMMIT_TOMBSTONE_RETENTION_MS * 2,
+            true,
+            &|_| false,
+            &applier,
+        ));
+        assert_eq!(resolved, 1);
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &[(565, ReactionOp::Complete)]
+        );
+        assert!(load_commit_tombstones("claude", 100).is_empty());
     }
 }

--- a/src/services/discord/tui_direct_abort_marker.rs
+++ b/src/services/discord/tui_direct_abort_marker.rs
@@ -17,17 +17,25 @@
 //!
 //! 1. **Terminal-commit drain** ([`drain_on_terminal_commit`]) — the tmux
 //!    watcher's terminal chokepoint calls this on every body-visible normal
-//!    commit; a commit on the SAME `(provider, tmux, channel)` strictly AFTER
-//!    the abort means the prior owner covered the input → `⏳ → ✅`, marker
-//!    drained. Deliberately NOT TTL-bounded (verify r1): the sweep defers to
-//!    a live same-session inflight indefinitely, so a foreign turn streaming
-//!    past the TTL must still have its eventual commit accepted — a TTL bound
-//!    here turned exactly that case into a false `⚠` on an answered anchor.
+//!    commit, passing the identity of the turn that just committed. A marker
+//!    is covered ONLY by a commit whose turn identity MATCHES the foreign
+//!    prior inflight the ABORT recorded (`foreign_user_msg_id` +
+//!    `foreign_started_at` — codex r1: positive correlation; the bare
+//!    same-`(provider, tmux, channel)` + strictly-after-abort wall-clock test
+//!    let a prior-owner commit racing the marker write, a recreated same-name
+//!    tmux session, or a dropped-input prior turn falsely `✅` an unanswered
+//!    anchor). Covering commits are deliberately NOT TTL-bounded (verify r1):
+//!    the sweep defers to a live same-session inflight, so a foreign turn
+//!    streaming past the TTL must still have its eventual commit accepted.
 //! 2. **TTL sweep** ([`sweep_expired`]) — the placeholder sweeper's pass: once
 //!    [`ABORT_MARKER_TTL`] elapsed with NO live inflight for the session (a
-//!    long turn still streaming holds the verdict), nothing ever covered the
-//!    anchor → `⏳ → ⚠`, so a genuine failure is still surfaced in bounded
-//!    time (no #3282 eternal-hourglass regression: the sweeper is the owner).
+//!    long turn still streaming holds the verdict; a NAME-LESS inflight holds
+//!    only when it IS the recorded foreign turn — codex r1 finding 2), nothing
+//!    ever covered the anchor → `⏳ → ⚠`, so a genuine failure is still
+//!    surfaced in bounded time (no #3282 eternal-hourglass regression). The
+//!    inflight hold itself is bounded by the absolute
+//!    [`ABORT_MARKER_HARD_CAP_TTL_MULTIPLIER`] cap, so a stale/recreated
+//!    same-channel inflight can never orphan a `⏳` forever.
 //!
 //! The two reconcilers are mutually excluded per marker by a non-blocking
 //! sidecar flock claim ([`try_claim_marker`], the `inflight.rs` sidecar-lock
@@ -66,6 +74,16 @@ use super::SharedData;
 /// `✅` cover is not TTL-bounded (see [`terminal_commit_covers_marker`]).
 pub(super) const ABORT_MARKER_TTL: std::time::Duration = std::time::Duration::from_secs(600);
 
+/// Absolute bound on the sweep's live-inflight hold (codex r1 finding 2):
+/// once `aborted_at + TTL × THIS` (6 × 600s = 1 hour) elapses, an UNCOVERED
+/// marker takes the `⚠` fallback regardless of any live inflight. Without it,
+/// back-to-back turns, a recreated same-name tmux session, or a stale
+/// same-channel row could renew the hold forever and orphan the `⏳`.
+/// Documented trade-off: a genuinely-covering prior turn that streams for
+/// over an hour past the abort without committing loses its hold — accepted,
+/// since bounded convergence is the sweeper's contract (#3282).
+pub(super) const ABORT_MARKER_HARD_CAP_TTL_MULTIPLIER: u64 = 6;
+
 /// Durable record for an anchor whose synthetic turn-start ABORTed while the
 /// input was already provider-submitted. All fields are primitives so the JSON
 /// survives a dcserver version swap.
@@ -80,9 +98,21 @@ pub(super) struct AbortedAnchorMarker {
     pub aborted_at_ms: u64,
     /// Stamped when a covering terminal commit was seen but the `✅` delivery
     /// failed (or http was unavailable) — the sweep retries the completion
-    /// instead of ever degrading a covered anchor to `⚠` (I6).
+    /// instead of ever degrading a covered anchor to `⚠` (I6). Also stamped at
+    /// RECORD time when the foreign prior inflight is already gone (see
+    /// [`AbortedAnchorMarker::for_abort`]).
     #[serde(default)]
     pub covered_at_ms: Option<u64>,
+    /// Identity of the live FOREIGN prior inflight at the ABORT instant
+    /// (codex r1: positive correlation — `inflight.rs` `InflightTurnIdentity`
+    /// convention). The drain covers this marker ONLY on a terminal commit
+    /// whose turn identity matches BOTH fields. `None` on legacy (pre-r1)
+    /// markers: those are never drain-covered — the sweep alone resolves them
+    /// within its TTL/hard-cap bound.
+    #[serde(default)]
+    pub foreign_user_msg_id: Option<u64>,
+    #[serde(default)]
+    pub foreign_started_at: Option<String>,
 }
 
 impl AbortedAnchorMarker {
@@ -91,6 +121,51 @@ impl AbortedAnchorMarker {
             "{}_{}_{}",
             self.provider, self.channel_id, self.anchor_message_id
         )
+    }
+
+    /// Build the marker the ABORT path records. `foreign` is the live foreign
+    /// prior inflight's `(user_msg_id, started_at)` loaded AT the record
+    /// instant: when present, it is pinned so only THAT turn's commit covers.
+    /// When the row is ALREADY gone, the prior owner terminal-committed inside
+    /// the µs gap since the final backstop view read (which saw it LIVE) — its
+    /// drain chokepoint may have run before this marker existed, so the marker
+    /// is recorded PRE-COVERED (the anchor's input was provider-submitted long
+    /// before that commit; the sweep delivers the `✅`). The pair cannot alias
+    /// another turn: one inflight row exists per `(provider, channel)` and a
+    /// successor row starts ≥ the 32s backstop budget after `started_at`
+    /// (1-second resolution), so equality identifies the foreign turn.
+    pub(super) fn for_abort(
+        provider: String,
+        channel_id: u64,
+        anchor_message_id: u64,
+        tmux_session_name: String,
+        aborted_at_ms: u64,
+        foreign: Option<(u64, String)>,
+    ) -> Self {
+        let covered_at_ms = foreign.is_none().then_some(aborted_at_ms);
+        let (foreign_user_msg_id, foreign_started_at) = match foreign {
+            Some((user_msg_id, started_at)) => (Some(user_msg_id), Some(started_at)),
+            None => (None, None),
+        };
+        Self {
+            provider,
+            channel_id,
+            anchor_message_id,
+            tmux_session_name,
+            aborted_at_ms,
+            covered_at_ms,
+            foreign_user_msg_id,
+            foreign_started_at,
+        }
+    }
+
+    /// `true` iff this marker carries a recorded foreign identity AND it
+    /// equals the given turn identity (codex r1: the positive-correlation
+    /// test shared by the drain cover and the sweep's name-less-inflight
+    /// hold). Identity-absent markers match nothing.
+    pub(super) fn matches_foreign_identity(&self, user_msg_id: u64, started_at: &str) -> bool {
+        self.foreign_user_msg_id == Some(user_msg_id)
+            && self.foreign_started_at.as_deref() == Some(started_at)
     }
 }
 
@@ -289,7 +364,10 @@ pub(super) enum MarkerDisposition {
 /// The sweep's per-marker verdict. Conservative by design (I10): `⚠` requires
 /// BOTH the TTL to have elapsed AND no live inflight for the session, so a
 /// long-running prior turn is never falsely branded; `✅` retry requires a
-/// previously-seen covering commit.
+/// previously-seen covering commit. The live-inflight hold is absolutely
+/// bounded by [`ABORT_MARKER_HARD_CAP_TTL_MULTIPLIER`] (codex r1 finding 2) so
+/// no inflight churn can orphan the `⏳` forever — this hard cap is also the
+/// sole terminator for identity-ABSENT markers, which the drain never covers.
 pub(super) fn decide_marker_disposition(
     now_ms: u64,
     marker: &AbortedAnchorMarker,
@@ -303,26 +381,59 @@ pub(super) fn decide_marker_disposition(
     if marker.covered_at_ms.is_some() {
         return MarkerDisposition::DeliverCompletion;
     }
-    let ttl_elapsed = now_ms.saturating_sub(marker.aborted_at_ms) >= ttl.as_millis() as u64;
-    if !ttl_elapsed || live_inflight_for_session {
+    let elapsed_ms = now_ms.saturating_sub(marker.aborted_at_ms);
+    let ttl_ms = ttl.as_millis() as u64;
+    if elapsed_ms >= ttl_ms.saturating_mul(ABORT_MARKER_HARD_CAP_TTL_MULTIPLIER) {
+        return MarkerDisposition::DeliverFailureWarn;
+    }
+    if elapsed_ms < ttl_ms || live_inflight_for_session {
         return MarkerDisposition::KeepWaiting;
     }
     MarkerDisposition::DeliverFailureWarn
 }
 
-/// Does a terminal commit observed at `now_ms` cover this marker? Only a commit
-/// STRICTLY AFTER the abort counts (a pre-abort commit belongs to an older
-/// turn). Deliberately NO TTL upper bound (verify r1, I10: covering commit
-/// time > aborted_at is the design condition): the sweep defers to a live
-/// same-session inflight indefinitely, so a foreign turn streaming past the
-/// TTL must still have its eventual commit accepted — a TTL bound here
-/// re-created the false `⚠`-on-answered-anchor symptom this module fixes.
-/// The recycled-session `✅` mis-fire the bound targeted (SC2/R3) stays
-/// narrow without it: a marker only outlives the TTL while the sweep is
-/// deferring, i.e. while a live same-`(provider, tmux, channel)` inflight —
-/// the covering prior owner — exists; otherwise the sweep already resolved it.
-pub(super) fn terminal_commit_covers_marker(now_ms: u64, marker: &AbortedAnchorMarker) -> bool {
-    marker.anchor_message_id != 0 && now_ms > marker.aborted_at_ms
+/// Does a terminal commit by the turn identified by `(committed_user_msg_id,
+/// committed_started_at)` cover this marker? Codex r1: POSITIVE correlation
+/// required — the committed turn must BE the foreign prior inflight recorded
+/// at ABORT time. The old condition (any same-`(provider,tmux,channel)`
+/// commit with `now_ms > aborted_at_ms`) let three impostors through: a
+/// prior-owner commit racing the marker write, a later turn in a re-created
+/// same-name tmux session, and an ordinary prior commit whose queued input
+/// was dropped — each a false `✅` on a possibly-unanswered anchor. The
+/// strictly-after-abort wall-clock test is retained as a SUBSIDIARY guard
+/// only. Identity-absent (legacy) markers never cover here — the sweep's
+/// TTL/hard-cap bound is their sole terminator. Deliberately NO TTL upper
+/// bound (verify r1): the sweep defers to a live same-session inflight, so a
+/// foreign turn streaming past the TTL must still have its eventual commit
+/// accepted — a TTL bound here re-created the false-`⚠`-on-answered symptom.
+pub(super) fn terminal_commit_covers_marker(
+    now_ms: u64,
+    marker: &AbortedAnchorMarker,
+    committed_user_msg_id: u64,
+    committed_started_at: &str,
+) -> bool {
+    marker.anchor_message_id != 0
+        && now_ms > marker.aborted_at_ms
+        && marker.matches_foreign_identity(committed_user_msg_id, committed_started_at)
+}
+
+/// Does a live same-channel inflight defer the sweep's `⚠` fallback for this
+/// marker? A NAME-BEARING row defers on a tmux-session-name match (the
+/// long-prior-turn hold). A NAME-LESS row defers ONLY when it IS the recorded
+/// foreign prior turn (codex r1 finding 2: the old `is_none_or(..)` treated
+/// EVERY name-less same-channel row as "could be the prior owner", letting an
+/// unrelated/stale inflight hold the marker; the hold is now positive-match
+/// only, and even a matching hold is bounded by the hard cap upstream).
+pub(super) fn inflight_defers_sweep(
+    marker: &AbortedAnchorMarker,
+    inflight_tmux_session_name: Option<&str>,
+    inflight_user_msg_id: u64,
+    inflight_started_at: &str,
+) -> bool {
+    match inflight_tmux_session_name {
+        Some(name) => name == marker.tmux_session_name,
+        None => marker.matches_foreign_identity(inflight_user_msg_id, inflight_started_at),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -443,13 +554,16 @@ fn now_ms() -> u64 {
 }
 
 /// Watcher terminal-commit chokepoint: a body-visible normal commit for
-/// `(provider, tmux, channel)` covers every matching marker → `⏳ → ✅`.
-/// Returns the number of markers fully drained.
+/// `(provider, tmux, channel)` covers every marker whose recorded foreign
+/// identity matches the COMMITTED turn (`committed_user_msg_id` +
+/// `committed_started_at` — codex r1) → `⏳ → ✅`. Returns markers drained.
 pub(super) async fn drain_on_terminal_commit(
     shared: &Arc<SharedData>,
     provider: &str,
     tmux_session_name: &str,
     channel_id: u64,
+    committed_user_msg_id: u64,
+    committed_started_at: &str,
 ) -> usize {
     let applier = shared_reaction_applier(shared.clone());
     drain_on_terminal_commit_with_applier(
@@ -457,6 +571,8 @@ pub(super) async fn drain_on_terminal_commit(
         tmux_session_name,
         channel_id,
         now_ms(),
+        committed_user_msg_id,
+        committed_started_at,
         &applier,
     )
     .await
@@ -467,6 +583,8 @@ pub(super) async fn drain_on_terminal_commit_with_applier(
     tmux_session_name: &str,
     channel_id: u64,
     now_ms: u64,
+    committed_user_msg_id: u64,
+    committed_started_at: &str,
     applier: &ReactionApplierFn,
 ) -> usize {
     let mut drained = 0usize;
@@ -482,7 +600,12 @@ pub(super) async fn drain_on_terminal_commit_with_applier(
         let Some(mut marker) = reload(&marker) else {
             continue; // resolved while unclaimed
         };
-        if !terminal_commit_covers_marker(now_ms, &marker) {
+        if !terminal_commit_covers_marker(
+            now_ms,
+            &marker,
+            committed_user_msg_id,
+            committed_started_at,
+        ) {
             continue;
         }
         match applier(&marker, ReactionOp::Complete).await {
@@ -535,7 +658,8 @@ pub(super) async fn drain_on_terminal_commit_with_applier(
 
 /// Placeholder-sweeper pass: retry `✅` for covered markers; apply the TTL'd
 /// `⏳ → ⚠` fallback for anchors no commit ever covered (held while a live
-/// inflight for the session may still cover them). Returns markers resolved.
+/// inflight may still cover them — see [`inflight_defers_sweep`] — up to the
+/// absolute hard cap). Returns markers resolved.
 pub(super) async fn sweep_expired(
     shared: &Arc<SharedData>,
     provider: &super::ProviderKind,
@@ -544,12 +668,12 @@ pub(super) async fn sweep_expired(
     let applier = shared_reaction_applier(shared.clone());
     let live_inflight = |marker: &AbortedAnchorMarker| -> bool {
         super::inflight::load_inflight_state(provider, marker.channel_id).is_some_and(|state| {
-            // Conservative (I10): an inflight without a tmux name COULD be the
-            // covering prior owner — hold rather than risk a false ⚠.
-            state
-                .tmux_session_name
-                .as_deref()
-                .is_none_or(|name| name == marker.tmux_session_name)
+            inflight_defers_sweep(
+                marker,
+                state.tmux_session_name.as_deref(),
+                state.user_msg_id,
+                &state.started_at,
+            )
         })
     };
     sweep_expired_with_applier(
@@ -671,6 +795,10 @@ mod tests {
             .unwrap()
     }
 
+    /// `started_at` of every test marker's recorded foreign prior turn
+    /// (`now_string` localtime form, 1-second resolution like production).
+    const FOREIGN_STARTED_AT: &str = "2026-06-10 12:00:00";
+
     fn marker(
         provider: &str,
         channel: u64,
@@ -684,7 +812,22 @@ mod tests {
             tmux_session_name: format!("tmux-{channel}"),
             aborted_at_ms,
             covered_at_ms: None,
+            // codex r1: test markers carry a recorded foreign identity by
+            // default (the ABORT path pins one whenever the prior row is live).
+            foreign_user_msg_id: Some(anchor + 500_000),
+            foreign_started_at: Some(FOREIGN_STARTED_AT.to_string()),
         }
+    }
+
+    /// The committed-turn identity that MATCHES `marker()`'s recorded foreign
+    /// prior turn — what the watcher passes when that turn terminal-commits.
+    fn committed(m: &AbortedAnchorMarker) -> (u64, String) {
+        (
+            m.foreign_user_msg_id.expect("test markers carry identity"),
+            m.foreign_started_at
+                .clone()
+                .expect("test markers carry identity"),
+        )
     }
 
     type RecordedOps = Arc<Mutex<Vec<(u64, ReactionOp)>>>;
@@ -831,23 +974,163 @@ mod tests {
     #[test]
     fn terminal_commit_cover_requires_strictly_post_abort_commit() {
         let m = marker("claude", 1, 10, 5_000);
+        let (cid, cstart) = committed(&m);
         // Strictly-after-abort: a commit AT or BEFORE the abort instant belongs
         // to an older turn and must not cover (RED if `>=`).
-        assert!(!terminal_commit_covers_marker(5_000, &m));
-        assert!(!terminal_commit_covers_marker(4_000, &m));
-        assert!(terminal_commit_covers_marker(5_001, &m));
-        assert!(terminal_commit_covers_marker(5_000 + TTL_MS, &m));
+        assert!(!terminal_commit_covers_marker(5_000, &m, cid, &cstart));
+        assert!(!terminal_commit_covers_marker(4_000, &m, cid, &cstart));
+        assert!(terminal_commit_covers_marker(5_001, &m, cid, &cstart));
+        assert!(terminal_commit_covers_marker(
+            5_000 + TTL_MS,
+            &m,
+            cid,
+            &cstart
+        ));
         // verify r1 fix #1: a commit PAST the TTL still covers — the sweep
         // defers to a live same-session inflight indefinitely, so a foreign
         // turn streaming longer than the TTL must not lose its cover (RED on
         // the old `<= ttl` bound: false ⚠ on an answered anchor).
-        assert!(terminal_commit_covers_marker(5_000 + TTL_MS + 1, &m));
+        assert!(terminal_commit_covers_marker(
+            5_000 + TTL_MS + 1,
+            &m,
+            cid,
+            &cstart
+        ));
         // Zero anchor id never covers (I5).
         let zero = AbortedAnchorMarker {
             anchor_message_id: 0,
             ..m
         };
-        assert!(!terminal_commit_covers_marker(5_001, &zero));
+        assert!(!terminal_commit_covers_marker(5_001, &zero, cid, &cstart));
+    }
+
+    /// codex r1 (RED ① — pure): a commit by a DIFFERENT turn must NOT cover,
+    /// however plausible its wall-clock. RED pre-fix: the cover test was
+    /// `now_ms > aborted_at_ms` alone, so a prior-owner commit racing the
+    /// marker write, a recreated same-name tmux session, and a prior turn
+    /// that DROPPED the queued input all false-`✅`'d the anchor.
+    #[test]
+    fn terminal_commit_cover_requires_matching_foreign_identity() {
+        let m = marker("claude", 1, 11, 5_000);
+        let (cid, cstart) = committed(&m);
+        assert!(
+            terminal_commit_covers_marker(6_000, &m, cid, &cstart),
+            "sanity: the recorded foreign turn's own commit covers"
+        );
+        assert!(
+            !terminal_commit_covers_marker(6_000, &m, cid + 1, &cstart),
+            "a different user_msg_id is a different turn — no cover (RED ①)"
+        );
+        assert!(
+            !terminal_commit_covers_marker(6_000, &m, cid, "2026-06-10 12:00:01"),
+            "a different started_at is a different turn — no cover"
+        );
+        let legacy = AbortedAnchorMarker {
+            foreign_user_msg_id: None,
+            foreign_started_at: None,
+            ..m
+        };
+        assert!(
+            !terminal_commit_covers_marker(6_000, &legacy, cid, &cstart),
+            "an identity-absent (legacy) marker is sweep-only — never drain-covered"
+        );
+    }
+
+    /// codex r1: the ABORT constructor. A LIVE foreign prior inflight pins its
+    /// identity (marker uncovered); an ALREADY-GONE foreign row means the
+    /// prior owner committed in the µs race before the marker existed — its
+    /// drain chokepoint can never see this marker, so it is recorded
+    /// PRE-COVERED and the sweep delivers the `✅` (RED as a TTL'd false `⚠`
+    /// on an answered anchor otherwise).
+    #[test]
+    fn for_abort_pins_identity_or_records_pre_covered() {
+        let live = AbortedAnchorMarker::for_abort(
+            "claude".into(),
+            9,
+            901,
+            "tmux-9".into(),
+            42_000,
+            Some((777, "2026-06-10 09:00:00".into())),
+        );
+        assert_eq!(live.foreign_user_msg_id, Some(777));
+        assert_eq!(
+            live.foreign_started_at.as_deref(),
+            Some("2026-06-10 09:00:00")
+        );
+        assert_eq!(
+            live.covered_at_ms, None,
+            "a still-live foreign turn has covered nothing yet"
+        );
+        let raced =
+            AbortedAnchorMarker::for_abort("claude".into(), 9, 902, "tmux-9".into(), 42_000, None);
+        assert_eq!(
+            raced.covered_at_ms,
+            Some(42_000),
+            "foreign row gone at the record instant ⇒ its commit already \
+             happened ⇒ pre-covered (the drain can never see this marker)"
+        );
+        assert_eq!(raced.foreign_user_msg_id, None);
+        assert_eq!(raced.foreign_started_at, None);
+    }
+
+    /// codex r1 finding 2 (RED ③ — pure): a NAME-LESS same-channel inflight
+    /// defers the sweep ONLY when it IS the recorded foreign turn. RED
+    /// pre-fix: `is_none_or(..)` held for EVERY name-less row, so an
+    /// unrelated/stale inflight kept the marker `KeepWaiting` indefinitely
+    /// (orphaned ⏳). Name-bearing rows keep the session-name hold.
+    #[test]
+    fn nameless_inflight_defers_sweep_only_on_foreign_identity_match() {
+        let m = marker("claude", 1, 12, 5_000);
+        let (cid, cstart) = committed(&m);
+        // Name-bearing rows: session-name match decides (unchanged).
+        assert!(inflight_defers_sweep(&m, Some("tmux-1"), 0, ""));
+        assert!(!inflight_defers_sweep(&m, Some("tmux-other"), cid, &cstart));
+        // Name-less rows: positive identity match only.
+        assert!(inflight_defers_sweep(&m, None, cid, &cstart));
+        assert!(
+            !inflight_defers_sweep(&m, None, cid + 1, &cstart),
+            "an unrelated name-less inflight must not hold the marker (RED ③)"
+        );
+        assert!(!inflight_defers_sweep(&m, None, cid, "1999-01-01 00:00:00"));
+        let legacy = AbortedAnchorMarker {
+            foreign_user_msg_id: None,
+            foreign_started_at: None,
+            ..m
+        };
+        assert!(
+            !inflight_defers_sweep(&legacy, None, cid, &cstart),
+            "an identity-absent marker gains no name-less hold"
+        );
+    }
+
+    /// codex r1 finding 2 (hard cap): past `TTL × ABORT_MARKER_HARD_CAP_TTL_MULTIPLIER`
+    /// an UNCOVERED marker takes the `⚠` fallback even with a live holding
+    /// inflight — the hold can no longer be renewed forever (RED pre-fix:
+    /// unconditional `KeepWaiting` while any holding inflight existed).
+    /// A COVERED marker stays immune: completion always wins.
+    #[test]
+    fn sweep_hard_cap_overrides_live_inflight_hold() {
+        let base = marker("claude", 1, 13, 1_000);
+        let cap = 1_000 + TTL_MS * ABORT_MARKER_HARD_CAP_TTL_MULTIPLIER;
+        assert_eq!(
+            decide_marker_disposition(cap - 1, &base, true, ABORT_MARKER_TTL, true),
+            MarkerDisposition::KeepWaiting,
+            "inside the cap a live inflight still holds the verdict"
+        );
+        assert_eq!(
+            decide_marker_disposition(cap, &base, true, ABORT_MARKER_TTL, true),
+            MarkerDisposition::DeliverFailureWarn,
+            "at the cap the ⚠ fallback fires regardless of the inflight (RED: eternal hold)"
+        );
+        let covered = AbortedAnchorMarker {
+            covered_at_ms: Some(2_000),
+            ..base
+        };
+        assert_eq!(
+            decide_marker_disposition(cap + 1, &covered, true, ABORT_MARKER_TTL, true),
+            MarkerDisposition::DeliverCompletion,
+            "a covered anchor is never degraded to ⚠, cap or not"
+        );
     }
 
     /// I5: the recorder refuses zero anchor ids outright.
@@ -884,10 +1167,11 @@ mod tests {
         let _root = test_root();
         let m = marker("claude", 100, 555, 10_000);
         record(&m).unwrap();
+        let (cid, cstart) = committed(&m);
         let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
         let drained = test_rt().block_on(drain_on_terminal_commit_with_applier(
             "claude", "tmux-100", 100, 10_500, // commit strictly after the abort, within TTL
-            &applier,
+            cid, &cstart, &applier,
         ));
         assert_eq!(drained, 1);
         let calls = calls.lock().unwrap();
@@ -911,6 +1195,7 @@ mod tests {
         let _root = test_root();
         let m = marker("claude", 100, 556, 10_000);
         record(&m).unwrap();
+        let (cid, cstart) = committed(&m);
         let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
         let rt = test_rt();
         // Foreign tmux session on the same channel → no-op.
@@ -919,16 +1204,103 @@ mod tests {
             "tmux-other",
             100,
             10_500,
+            cid,
+            &cstart,
             &applier,
         ));
         assert_eq!(drained, 0);
         // Commit not after the abort → no-op (an older turn's commit).
         let drained = rt.block_on(drain_on_terminal_commit_with_applier(
-            "claude", "tmux-100", 100, 10_000, &applier,
+            "claude", "tmux-100", 100, 10_000, cid, &cstart, &applier,
         ));
         assert_eq!(drained, 0);
         assert!(calls.lock().unwrap().is_empty());
         assert_eq!(load_for_channel("claude", 100).len(), 1, "marker retained");
+    }
+
+    /// codex r1 (RED ① — drain level): a body-visible commit by an UNRELATED
+    /// turn on the SAME `(provider, tmux, channel)` leaves the marker
+    /// untouched; the recorded foreign turn's own commit then drains it.
+    /// RED pre-fix: the unrelated commit `✅`'d the possibly-unanswered anchor
+    /// (wall-clock was the only test).
+    #[test]
+    fn drain_refuses_unrelated_commit_and_accepts_foreign_identity_commit() {
+        let _root = test_root();
+        let m = marker("claude", 100, 580, 10_000);
+        record(&m).unwrap();
+        let (cid, cstart) = committed(&m);
+        let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
+        let rt = test_rt();
+        let drained = rt.block_on(drain_on_terminal_commit_with_applier(
+            "claude",
+            "tmux-100",
+            100,
+            10_500,
+            cid + 7, // an unrelated turn (recreated session / dropped-input prior)
+            &cstart,
+            &applier,
+        ));
+        assert_eq!(drained, 0, "no positive identity match → no cover (RED ①)");
+        assert!(calls.lock().unwrap().is_empty());
+        assert_eq!(load_for_channel("claude", 100).len(), 1, "marker retained");
+        let drained = rt.block_on(drain_on_terminal_commit_with_applier(
+            "claude", "tmux-100", 100, 11_000, cid, &cstart, &applier,
+        ));
+        assert_eq!(drained, 1, "the foreign turn's own commit covers (②)");
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &[(580, ReactionOp::Complete)]
+        );
+        assert!(load_for_channel("claude", 100).is_empty());
+    }
+
+    /// codex r1 schema compat: a legacy (pre-r1) marker JSON without the
+    /// foreign-identity fields loads with `None` identity — NEVER
+    /// drain-covered (no wall-clock fallback), terminated by the sweep's
+    /// TTL/hard-cap bound alone.
+    #[test]
+    fn legacy_marker_without_identity_fields_is_sweep_only() {
+        let _root = test_root();
+        let store = root().unwrap();
+        std::fs::write(
+            store.join("claude_100_590.json"),
+            r#"{"provider":"claude","channel_id":100,"anchor_message_id":590,"tmux_session_name":"tmux-100","aborted_at_ms":10000}"#,
+        )
+        .unwrap();
+        let loaded = load_for_channel("claude", 100);
+        assert_eq!(
+            loaded.len(),
+            1,
+            "legacy schema must keep parsing (#[serde(default)])"
+        );
+        assert_eq!(loaded[0].foreign_user_msg_id, None);
+        assert_eq!(loaded[0].foreign_started_at, None);
+        assert_eq!(loaded[0].covered_at_ms, None);
+        let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
+        let rt = test_rt();
+        let drained = rt.block_on(drain_on_terminal_commit_with_applier(
+            "claude",
+            "tmux-100",
+            100,
+            10_500,
+            12_345,
+            FOREIGN_STARTED_AT,
+            &applier,
+        ));
+        assert_eq!(drained, 0, "identity-absent marker is never drain-covered");
+        assert!(calls.lock().unwrap().is_empty());
+        let resolved = rt.block_on(sweep_expired_with_applier(
+            "claude",
+            10_000 + TTL_MS + 1,
+            true,
+            &|_| false,
+            &applier,
+        ));
+        assert_eq!(resolved, 1, "the sweep bound terminates it");
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &[(590, ReactionOp::FailureWarn)]
+        );
     }
 
     /// I6: a covering commit whose ✅ delivery FAILS preserves the marker with
@@ -939,10 +1311,11 @@ mod tests {
         let _root = test_root();
         let m = marker("claude", 100, 557, 10_000);
         record(&m).unwrap();
+        let (cid, cstart) = committed(&m);
         let rt = test_rt();
         let (failing, _calls) = recording_applier(ReactionDelivery::Failed);
         let drained = rt.block_on(drain_on_terminal_commit_with_applier(
-            "claude", "tmux-100", 100, 10_500, &failing,
+            "claude", "tmux-100", 100, 10_500, cid, &cstart, &failing,
         ));
         assert_eq!(drained, 0);
         let kept = load_for_channel("claude", 100);
@@ -1056,6 +1429,7 @@ mod tests {
         let _root = test_root();
         let m = marker("claude", 100, 563, 10_000);
         record(&m).unwrap();
+        let (cid, cstart) = committed(&m);
         let rt = test_rt();
         let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
         // Sweep passes during the long foreign turn: live inflight → hold.
@@ -1070,7 +1444,7 @@ mod tests {
         // The foreign turn finally commits ~100s past the TTL.
         let commit_at = 10_000 + TTL_MS + 100_000;
         let drained = rt.block_on(drain_on_terminal_commit_with_applier(
-            "claude", "tmux-100", 100, commit_at, &applier,
+            "claude", "tmux-100", 100, commit_at, cid, &cstart, &applier,
         ));
         assert_eq!(
             drained, 1,
@@ -1130,6 +1504,8 @@ mod tests {
                     "tmux-100",
                     100,
                     10_500,
+                    562 + 500_000, // the marker's recorded foreign turn
+                    FOREIGN_STARTED_AT,
                     &drain_applier,
                 )
                 .await;
@@ -1163,11 +1539,12 @@ mod tests {
         let _root = test_root();
         let m = marker("claude", 100, 570, 10_000);
         record(&m).unwrap();
+        let (cid, cstart) = committed(&m);
         let claim = try_claim_marker(&m).expect("first claim succeeds");
         let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
         let rt = test_rt();
         let drained = rt.block_on(drain_on_terminal_commit_with_applier(
-            "claude", "tmux-100", 100, 10_500, &applier,
+            "claude", "tmux-100", 100, 10_500, cid, &cstart, &applier,
         ));
         assert_eq!(drained, 0, "drain must skip a claimed marker");
         let resolved = rt.block_on(sweep_expired_with_applier(
@@ -1182,7 +1559,7 @@ mod tests {
         assert_eq!(load_for_channel("claude", 100).len(), 1);
         drop(claim);
         let drained = rt.block_on(drain_on_terminal_commit_with_applier(
-            "claude", "tmux-100", 100, 10_500, &applier,
+            "claude", "tmux-100", 100, 10_500, cid, &cstart, &applier,
         ));
         assert_eq!(drained, 1, "released claim → next pass processes normally");
     }
@@ -1199,8 +1576,9 @@ mod tests {
         // Drain path: covering commit, but the anchor message is gone.
         let m = marker("claude", 100, 571, 10_000);
         record(&m).unwrap();
+        let (cid, cstart) = committed(&m);
         let drained = rt.block_on(drain_on_terminal_commit_with_applier(
-            "claude", "tmux-100", 100, 10_500, &applier,
+            "claude", "tmux-100", 100, 10_500, cid, &cstart, &applier,
         ));
         assert_eq!(drained, 0, "a terminated marker is not a delivered ✅");
         assert!(
@@ -1277,6 +1655,7 @@ mod tests {
         let store = root().unwrap();
         let m = marker("claude", 100, 573, 10_000);
         record(&m).unwrap();
+        let (cid, cstart) = committed(&m);
         // Pre-create the claim sidecar so the read-only store below blocks
         // ONLY the stamp rewrite, not the claim acquisition.
         drop(try_claim_marker(&m).expect("pre-create claim sidecar"));
@@ -1284,7 +1663,7 @@ mod tests {
         let rt = test_rt();
         let (failing, _ops) = recording_applier(ReactionDelivery::Failed);
         let drained = rt.block_on(drain_on_terminal_commit_with_applier(
-            "claude", "tmux-100", 100, 10_500, &failing,
+            "claude", "tmux-100", 100, 10_500, cid, &cstart, &failing,
         ));
         std::fs::set_permissions(&store, std::fs::Permissions::from_mode(0o755)).unwrap();
         assert_eq!(drained, 0);
@@ -1297,7 +1676,7 @@ mod tests {
         // The next covering commit retries and completes (✅ idempotent).
         let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
         let drained = rt.block_on(drain_on_terminal_commit_with_applier(
-            "claude", "tmux-100", 100, 11_000, &applier,
+            "claude", "tmux-100", 100, 11_000, cid, &cstart, &applier,
         ));
         assert_eq!(drained, 1, "next drain pass must retry the cover");
         assert_eq!(

--- a/src/services/discord/tui_direct_abort_marker.rs
+++ b/src/services/discord/tui_direct_abort_marker.rs
@@ -17,14 +17,22 @@
 //!
 //! 1. **Terminal-commit drain** ([`drain_on_terminal_commit`]) — the tmux
 //!    watcher's terminal chokepoint calls this on every body-visible normal
-//!    commit; a commit on the SAME `(provider, tmux, channel)` AFTER the abort
-//!    (and within the TTL, bounding session-recreation aliasing) means the
-//!    prior owner covered the input → `⏳ → ✅`, marker drained.
+//!    commit; a commit on the SAME `(provider, tmux, channel)` strictly AFTER
+//!    the abort means the prior owner covered the input → `⏳ → ✅`, marker
+//!    drained. Deliberately NOT TTL-bounded (verify r1): the sweep defers to
+//!    a live same-session inflight indefinitely, so a foreign turn streaming
+//!    past the TTL must still have its eventual commit accepted — a TTL bound
+//!    here turned exactly that case into a false `⚠` on an answered anchor.
 //! 2. **TTL sweep** ([`sweep_expired`]) — the placeholder sweeper's pass: once
 //!    [`ABORT_MARKER_TTL`] elapsed with NO live inflight for the session (a
 //!    long turn still streaming holds the verdict), nothing ever covered the
 //!    anchor → `⏳ → ⚠`, so a genuine failure is still surfaced in bounded
 //!    time (no #3282 eternal-hourglass regression: the sweeper is the owner).
+//!
+//! The two reconcilers are mutually excluded per marker by a non-blocking
+//! sidecar flock claim ([`try_claim_marker`], the `inflight.rs` sidecar-lock
+//! pattern): claim → re-read → react → delete, so a commit racing the sweep's
+//! delivery window can never stack `✅` + `⚠` on one anchor (verify r1).
 //!
 //! ## Invariants
 //! * **I1 (#3164 add≡remove)**: every reaction op (`⏳` remove, `✅`/`⚠` add)
@@ -54,6 +62,8 @@ use super::SharedData;
 /// ABORT→covered window is ~30-180s (backstop 32s + prior-owner long turns);
 /// 600s comfortably covers a long streaming prior turn while still bounding a
 /// truly-lost input to TTL + sweeper initial delay (180s) + pass interval (30s).
+/// The TTL gates ONLY the sweep's `⚠` fallback — the terminal-commit drain's
+/// `✅` cover is not TTL-bounded (see [`terminal_commit_covers_marker`]).
 pub(super) const ABORT_MARKER_TTL: std::time::Duration = std::time::Duration::from_secs(600);
 
 /// Durable record for an anchor whose synthetic turn-start ABORTed while the
@@ -135,16 +145,25 @@ pub(super) fn record(marker: &AbortedAnchorMarker) -> Result<(), String> {
     )
 }
 
-/// Drop a marker once its correction was delivered. Idempotent.
+/// Drop a marker once its correction was delivered (plus its claim sidecar so
+/// the store does not accumulate lock files). Idempotent. The sidecar unlink
+/// is benign even if a contender still holds an fd on the old inode: it
+/// re-reads the marker file under its claim and finds it gone (file stems are
+/// keyed on unique anchor snowflakes, so a stem is never reused for a
+/// different logical marker).
 pub(super) fn delete(marker: &AbortedAnchorMarker) {
     if let Some(root) = root() {
-        let path = root.join(format!("{}.json", marker.file_stem()));
-        let _ = std::fs::remove_file(path);
+        let stem = marker.file_stem();
+        let _ = std::fs::remove_file(root.join(format!("{stem}.json")));
+        let _ = std::fs::remove_file(root.join(format!("{stem}.json.lock")));
     }
 }
 
 /// Load every durable marker (sweep + restart survival: the store IS the
-/// restart state — no in-memory index to rebuild).
+/// restart state — no in-memory index to rebuild). Unparseable JSON (writes
+/// are atomic, so this means corruption or an incompatible schema, never a
+/// torn write) is QUARANTINED via a `.bad` rename instead of being silently
+/// re-skipped forever (verify r1 fix #3 — bounded noise, one WARN per file).
 pub(super) fn load_all() -> Vec<AbortedAnchorMarker> {
     let Some(root) = root() else {
         return Vec::new();
@@ -158,13 +177,33 @@ pub(super) fn load_all() -> Vec<AbortedAnchorMarker> {
         if path.extension().and_then(|e| e.to_str()) != Some("json") {
             continue;
         }
-        if let Ok(text) = std::fs::read_to_string(&path)
-            && let Ok(marker) = serde_json::from_str::<AbortedAnchorMarker>(&text)
-        {
-            out.push(marker);
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue; // transient read failure — retry next pass
+        };
+        match serde_json::from_str::<AbortedAnchorMarker>(&text) {
+            Ok(marker) => out.push(marker),
+            Err(error) => {
+                let quarantine = path.with_extension("json.bad");
+                let renamed = std::fs::rename(&path, &quarantine);
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %error,
+                    renamed_ok = renamed.is_ok(),
+                    "tui_direct_abort_marker: unparseable marker quarantined to .bad (never re-parsed; #3296 verify r1)"
+                );
+            }
         }
     }
     out
+}
+
+/// Re-read ONE marker fresh from disk (the under-claim read: a reconciler must
+/// decide on the post-claim state, never its pre-claim snapshot).
+fn reload(marker: &AbortedAnchorMarker) -> Option<AbortedAnchorMarker> {
+    let root = root()?;
+    let path = root.join(format!("{}.json", marker.file_stem()));
+    let text = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&text).ok()
 }
 
 /// Markers scoped to one `(provider, channel)` — the terminal-commit drain's
@@ -174,6 +213,56 @@ pub(super) fn load_for_channel(provider: &str, channel_id: u64) -> Vec<AbortedAn
         .into_iter()
         .filter(|m| m.channel_id == channel_id && m.provider.eq_ignore_ascii_case(provider))
         .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Per-marker claim (verify r1 fix #2 — the inflight.rs sidecar-flock pattern)
+// ---------------------------------------------------------------------------
+
+/// Held for the whole claim → re-read → react → delete/restamp span of one
+/// reconciler pass. Crash-safe (the kernel releases a flock with the process,
+/// so a mid-claim crash never orphans the marker — unlike a rename-claim).
+pub(super) struct MarkerClaim {
+    _file: std::fs::File,
+}
+
+impl Drop for MarkerClaim {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+            // Best effort unlock; closing the fd would release it anyway.
+            let _ = unsafe { libc::flock(self._file.as_raw_fd(), libc::LOCK_UN) };
+        }
+    }
+}
+
+/// NON-BLOCKING exclusive claim on one marker's `<stem>.json.lock` sidecar.
+/// `None` means the OTHER reconciler (drain vs sweep) owns the marker this
+/// instant — skip it; the loser's pass is idempotent and retries later. The
+/// claim is awaited across the Discord delivery deliberately: it is a file
+/// flock guard (not a `std::sync` lock — no `await_holding_lock` site), and
+/// the only possible waiter skips instead of blocking.
+pub(super) fn try_claim_marker(marker: &AbortedAnchorMarker) -> Option<MarkerClaim> {
+    let root = root()?;
+    let lock_path = root.join(format!("{}.json.lock", marker.file_stem()));
+    std::fs::create_dir_all(&root).ok()?;
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .ok()?;
+    #[cfg(unix)]
+    {
+        use std::os::fd::AsRawFd;
+        let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        if rc != 0 {
+            return None;
+        }
+    }
+    Some(MarkerClaim { _file: file })
 }
 
 // ---------------------------------------------------------------------------
@@ -223,16 +312,17 @@ pub(super) fn decide_marker_disposition(
 
 /// Does a terminal commit observed at `now_ms` cover this marker? Only a commit
 /// STRICTLY AFTER the abort counts (a pre-abort commit belongs to an older
-/// turn), and only within the TTL (bounding `✅` mis-fires from an unrelated
-/// commit after the session was recycled — SC2/R3).
-pub(super) fn terminal_commit_covers_marker(
-    now_ms: u64,
-    marker: &AbortedAnchorMarker,
-    ttl: std::time::Duration,
-) -> bool {
-    marker.anchor_message_id != 0
-        && now_ms > marker.aborted_at_ms
-        && now_ms.saturating_sub(marker.aborted_at_ms) <= ttl.as_millis() as u64
+/// turn). Deliberately NO TTL upper bound (verify r1, I10: covering commit
+/// time > aborted_at is the design condition): the sweep defers to a live
+/// same-session inflight indefinitely, so a foreign turn streaming past the
+/// TTL must still have its eventual commit accepted — a TTL bound here
+/// re-created the false `⚠`-on-answered-anchor symptom this module fixes.
+/// The recycled-session `✅` mis-fire the bound targeted (SC2/R3) stays
+/// narrow without it: a marker only outlives the TTL while the sweep is
+/// deferring, i.e. while a live same-`(provider, tmux, channel)` inflight —
+/// the covering prior owner — exists; otherwise the sweep already resolved it.
+pub(super) fn terminal_commit_covers_marker(now_ms: u64, marker: &AbortedAnchorMarker) -> bool {
+    marker.anchor_message_id != 0 && now_ms > marker.aborted_at_ms
 }
 
 // ---------------------------------------------------------------------------
@@ -252,8 +342,27 @@ pub(super) enum ReactionOp {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum ReactionDelivery {
     Delivered,
+    /// Transient failure (5xx, rate limit, transport) — keep the marker; a
+    /// later pass retries.
     Failed,
+    /// Permanent failure (404/403/410, e.g. Unknown Message 10008): the anchor
+    /// can NEVER be reacted on again — terminate the marker instead of
+    /// retrying forever (verify r1 fix #3).
+    FailedPermanent,
     HttpUnavailable,
+}
+
+/// Classify a reaction-create failure status into transient vs permanent.
+/// Reuses the sweeper's message-gone allowlist (404 NOT_FOUND — Unknown
+/// Message 10008 / Unknown Channel 10003 map here — 403 FORBIDDEN, 410 GONE;
+/// `placeholder_sweeper::is_permanent_message_gone_status`, the #3293-shared
+/// classifier) so every Discord-permanence verdict in this subtree agrees.
+fn classify_reaction_failure(status: Option<u16>) -> ReactionDelivery {
+    if status.is_some_and(super::placeholder_sweeper::is_permanent_message_gone_status) {
+        ReactionDelivery::FailedPermanent
+    } else {
+        ReactionDelivery::Failed
+    }
 }
 
 /// Boxed applier so tests record ops instead of calling Discord. The PRODUCTION
@@ -299,15 +408,26 @@ pub(super) fn shared_reaction_applier(shared: Arc<SharedData>) -> ReactionApplie
             match channel.create_reaction(&http, message, reaction).await {
                 Ok(_) => ReactionDelivery::Delivered,
                 Err(error) => {
-                    tracing::warn!(
-                        provider = %provider,
-                        channel_id,
-                        anchor_message_id,
-                        op = ?op,
-                        error = %error,
-                        "tui_direct_abort_marker: reaction correction delivery failed; marker preserved for retry (I6)"
-                    );
-                    ReactionDelivery::Failed
+                    let status = match &error {
+                        serenity::Error::Http(http_err) => {
+                            http_err.status_code().map(|status| status.as_u16())
+                        }
+                        _ => None,
+                    };
+                    let delivery = classify_reaction_failure(status);
+                    // The permanent case logs ONCE at its termination site in
+                    // the reconciler (where the marker is deleted) — not here.
+                    if delivery == ReactionDelivery::Failed {
+                        tracing::warn!(
+                            provider = %provider,
+                            channel_id,
+                            anchor_message_id,
+                            op = ?op,
+                            error = %error,
+                            "tui_direct_abort_marker: reaction correction delivery failed transiently; marker preserved for retry (I6)"
+                        );
+                    }
+                    delivery
                 }
             }
         })
@@ -350,11 +470,19 @@ pub(super) async fn drain_on_terminal_commit_with_applier(
     applier: &ReactionApplierFn,
 ) -> usize {
     let mut drained = 0usize;
-    for mut marker in load_for_channel(provider, channel_id) {
+    for marker in load_for_channel(provider, channel_id) {
         if marker.tmux_session_name != tmux_session_name {
             continue; // I4: a different session's marker is never this commit's
         }
-        if !terminal_commit_covers_marker(now_ms, &marker, ABORT_MARKER_TTL) {
+        // Mutual exclusion vs the sweep (verify r1 fix #2): claim, then decide
+        // on a FRESH re-read — the sweep may have resolved it since load.
+        let Some(_claim) = try_claim_marker(&marker) else {
+            continue; // the sweep owns this marker right now
+        };
+        let Some(mut marker) = reload(&marker) else {
+            continue; // resolved while unclaimed
+        };
+        if !terminal_commit_covers_marker(now_ms, &marker) {
             continue;
         }
         match applier(&marker, ReactionOp::Complete).await {
@@ -369,11 +497,36 @@ pub(super) async fn drain_on_terminal_commit_with_applier(
                     "tui_direct_abort_marker: aborted anchor covered by prior-owner terminal commit; ⏳ → ✅ delivered and marker drained (#3296)"
                 );
             }
+            ReactionDelivery::FailedPermanent => {
+                // The anchor message is permanently gone (404/403/410) — no
+                // reaction can EVER land; terminate instead of retrying
+                // forever (verify r1 fix #3). One WARN, here only.
+                delete(&marker);
+                tracing::warn!(
+                    provider = %marker.provider,
+                    channel_id = marker.channel_id,
+                    anchor_message_id = marker.anchor_message_id,
+                    "tui_direct_abort_marker: anchor permanently gone (404/403/410); covered marker terminated without ✅ (#3296)"
+                );
+            }
             ReactionDelivery::Failed | ReactionDelivery::HttpUnavailable => {
                 // I6 fail-open: the anchor IS covered — stamp it so the sweep
                 // retries the ✅ (and can never degrade it to ⚠).
                 marker.covered_at_ms = Some(now_ms);
-                let _ = record(&marker);
+                if let Err(error) = record(&marker) {
+                    // verify r1 fix #4: a swallowed stamp failure would let the
+                    // sweep ⚠ a COVERED anchor after the TTL. Surface it loudly;
+                    // the marker stays on disk un-stamped, so the next covering
+                    // drain pass retries the ✅ (idempotent — covers are not
+                    // TTL-bounded since verify r1 fix #1).
+                    tracing::error!(
+                        provider = %marker.provider,
+                        channel_id = marker.channel_id,
+                        anchor_message_id = marker.anchor_message_id,
+                        error = %error,
+                        "tui_direct_abort_marker: failed to persist covered_at stamp after a ✅ delivery failure; next covering commit retries (#3296)"
+                    );
+                }
             }
         }
     }
@@ -425,6 +578,15 @@ pub(super) async fn sweep_expired_with_applier(
             delete(&marker); // I5: corrupt record — nothing could ever target it
             continue;
         }
+        // Mutual exclusion vs the watcher drain (verify r1 fix #2): claim,
+        // then decide on a FRESH re-read — a terminal commit racing this pass
+        // may have covered or drained the marker since load.
+        let Some(_claim) = try_claim_marker(&marker) else {
+            continue; // the drain owns this marker right now
+        };
+        let Some(marker) = reload(&marker) else {
+            continue; // drained while unclaimed
+        };
         let disposition = decide_marker_disposition(
             now_ms,
             &marker,
@@ -450,6 +612,18 @@ pub(super) async fn sweep_expired_with_applier(
                     anchor_message_id = marker.anchor_message_id,
                     op = ?op,
                     "tui_direct_abort_marker: sweep resolved aborted anchor (#3296)"
+                );
+            }
+            ReactionDelivery::FailedPermanent => {
+                // Permanently gone anchor (404/403/410): terminate the marker
+                // instead of retrying every pass forever (verify r1 fix #3).
+                delete(&marker);
+                tracing::warn!(
+                    provider = %marker.provider,
+                    channel_id = marker.channel_id,
+                    anchor_message_id = marker.anchor_message_id,
+                    op = ?op,
+                    "tui_direct_abort_marker: anchor permanently gone (404/403/410); marker terminated by sweep (#3296)"
                 );
             }
             // I6: keep the marker for the next pass (delivery failed late).
@@ -655,34 +829,25 @@ mod tests {
     }
 
     #[test]
-    fn terminal_commit_cover_requires_post_abort_within_ttl() {
+    fn terminal_commit_cover_requires_strictly_post_abort_commit() {
         let m = marker("claude", 1, 10, 5_000);
         // Strictly-after-abort: a commit AT or BEFORE the abort instant belongs
         // to an older turn and must not cover (RED if `>=`).
-        assert!(!terminal_commit_covers_marker(5_000, &m, ABORT_MARKER_TTL));
-        assert!(!terminal_commit_covers_marker(4_000, &m, ABORT_MARKER_TTL));
-        assert!(terminal_commit_covers_marker(5_001, &m, ABORT_MARKER_TTL));
-        assert!(terminal_commit_covers_marker(
-            5_000 + TTL_MS,
-            &m,
-            ABORT_MARKER_TTL
-        ));
-        // Past the TTL an unrelated commit (recycled session) must not ✅ (SC2).
-        assert!(!terminal_commit_covers_marker(
-            5_000 + TTL_MS + 1,
-            &m,
-            ABORT_MARKER_TTL
-        ));
+        assert!(!terminal_commit_covers_marker(5_000, &m));
+        assert!(!terminal_commit_covers_marker(4_000, &m));
+        assert!(terminal_commit_covers_marker(5_001, &m));
+        assert!(terminal_commit_covers_marker(5_000 + TTL_MS, &m));
+        // verify r1 fix #1: a commit PAST the TTL still covers — the sweep
+        // defers to a live same-session inflight indefinitely, so a foreign
+        // turn streaming longer than the TTL must not lose its cover (RED on
+        // the old `<= ttl` bound: false ⚠ on an answered anchor).
+        assert!(terminal_commit_covers_marker(5_000 + TTL_MS + 1, &m));
         // Zero anchor id never covers (I5).
         let zero = AbortedAnchorMarker {
             anchor_message_id: 0,
             ..m
         };
-        assert!(!terminal_commit_covers_marker(
-            5_001,
-            &zero,
-            ABORT_MARKER_TTL
-        ));
+        assert!(!terminal_commit_covers_marker(5_001, &zero));
     }
 
     /// I5: the recorder refuses zero anchor ids outright.
@@ -876,6 +1041,270 @@ mod tests {
             1,
             "http-unavailable must fail open (marker preserved for the next pass, I6)"
         );
+    }
+
+    /// #3296 verify r1 (major): an ABORT followed by a foreign turn that
+    /// streams LONGER than the TTL. The sweep correctly holds while the
+    /// inflight is live, so the marker outlives the TTL — the eventual
+    /// covering commit must STILL drain `⏳ → ✅`, and the next sweep (inflight
+    /// gone) must find nothing to `⚠`. RED before verify-r1: the drain's TTL
+    /// bound refused the late cover (no `covered_at` stamp either), so the
+    /// very next sweep pass attached a false `⚠` to an ANSWERED anchor — the
+    /// exact symptom this PR exists to fix.
+    #[test]
+    fn late_covering_commit_after_long_turn_still_completes() {
+        let _root = test_root();
+        let m = marker("claude", 100, 563, 10_000);
+        record(&m).unwrap();
+        let rt = test_rt();
+        let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
+        // Sweep passes during the long foreign turn: live inflight → hold.
+        let resolved = rt.block_on(sweep_expired_with_applier(
+            "claude",
+            10_000 + TTL_MS + 1,
+            true,
+            &|_| true,
+            &applier,
+        ));
+        assert_eq!(resolved, 0);
+        // The foreign turn finally commits ~100s past the TTL.
+        let commit_at = 10_000 + TTL_MS + 100_000;
+        let drained = rt.block_on(drain_on_terminal_commit_with_applier(
+            "claude", "tmux-100", 100, commit_at, &applier,
+        ));
+        assert_eq!(
+            drained, 1,
+            "a covering commit after a >TTL foreign turn must still complete \
+             the anchor — RED pre-verify-r1 (drain refused TTL-expired covers \
+             while the sweep deferred to the same live inflight)"
+        );
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &[(563, ReactionOp::Complete)]
+        );
+        // Inflight cleared after the commit: the next sweep must have nothing
+        // left to ⚠ (the marker was drained above).
+        let resolved = rt.block_on(sweep_expired_with_applier(
+            "claude",
+            commit_at + 1,
+            true,
+            &|_| false,
+            &applier,
+        ));
+        assert_eq!(resolved, 0);
+        assert_eq!(
+            calls.lock().unwrap().len(),
+            1,
+            "no ⚠ may ever land on a covered anchor"
+        );
+    }
+
+    /// #3296 verify r1 (TOCTOU): the drain and the sweep must never BOTH
+    /// react to one marker. Simulates the race by running the watcher drain
+    /// from INSIDE the sweep's delivery window (a terminal commit arriving
+    /// mid-`⚠`). RED pre-claim: both reconcilers loaded the marker
+    /// independently and an answered-looking anchor collected `✅` + `⚠`.
+    #[test]
+    fn sweep_and_drain_cannot_both_react_to_one_marker() {
+        let _root = test_root();
+        let m = marker("claude", 100, 562, 10_000);
+        record(&m).unwrap();
+        let calls: RecordedOps = Arc::new(Mutex::new(Vec::new()));
+        let sweep_calls = calls.clone();
+        let sweep_applier: ReactionApplierFn = Box::new(move |marker, op| {
+            let calls = sweep_calls.clone();
+            let anchor = marker.anchor_message_id;
+            Box::pin(async move {
+                // A terminal commit races in while the sweep is delivering ⚠.
+                let drain_calls = calls.clone();
+                let drain_applier: ReactionApplierFn = Box::new(move |m, op| {
+                    let calls = drain_calls.clone();
+                    let anchor = m.anchor_message_id;
+                    Box::pin(async move {
+                        calls.lock().unwrap().push((anchor, op));
+                        ReactionDelivery::Delivered
+                    })
+                });
+                drain_on_terminal_commit_with_applier(
+                    "claude",
+                    "tmux-100",
+                    100,
+                    10_500,
+                    &drain_applier,
+                )
+                .await;
+                calls.lock().unwrap().push((anchor, op));
+                ReactionDelivery::Delivered
+            })
+        });
+        let resolved = test_rt().block_on(sweep_expired_with_applier(
+            "claude",
+            10_000 + TTL_MS + 1,
+            true,
+            &|_| false,
+            &sweep_applier,
+        ));
+        assert_eq!(resolved, 1);
+        let calls = calls.lock().unwrap();
+        assert_eq!(
+            calls.as_slice(),
+            &[(562, ReactionOp::FailureWarn)],
+            "exactly ONE reconciler may react per marker — RED without the \
+             per-marker claim (✅ AND ⚠ both landed on the same anchor)"
+        );
+        assert!(load_for_channel("claude", 100).is_empty());
+    }
+
+    /// #3296 verify r1 fix #2 (claim semantics): a marker claimed by one
+    /// reconciler is SKIPPED by the other — and processed normally once the
+    /// claim is released.
+    #[test]
+    fn claimed_marker_is_skipped_until_released() {
+        let _root = test_root();
+        let m = marker("claude", 100, 570, 10_000);
+        record(&m).unwrap();
+        let claim = try_claim_marker(&m).expect("first claim succeeds");
+        let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
+        let rt = test_rt();
+        let drained = rt.block_on(drain_on_terminal_commit_with_applier(
+            "claude", "tmux-100", 100, 10_500, &applier,
+        ));
+        assert_eq!(drained, 0, "drain must skip a claimed marker");
+        let resolved = rt.block_on(sweep_expired_with_applier(
+            "claude",
+            10_000 + TTL_MS + 1,
+            true,
+            &|_| false,
+            &applier,
+        ));
+        assert_eq!(resolved, 0, "sweep must skip a claimed marker");
+        assert!(calls.lock().unwrap().is_empty());
+        assert_eq!(load_for_channel("claude", 100).len(), 1);
+        drop(claim);
+        let drained = rt.block_on(drain_on_terminal_commit_with_applier(
+            "claude", "tmux-100", 100, 10_500, &applier,
+        ));
+        assert_eq!(drained, 1, "released claim → next pass processes normally");
+    }
+
+    /// #3296 verify r1 fix #3: a PERMANENT delivery failure (Unknown Message
+    /// 10008 → 404, etc.) terminates the marker on both reconcilers instead of
+    /// retrying every pass forever. RED pre-fix: the marker was preserved
+    /// indefinitely (covered-stamped by the drain, retried by every sweep).
+    #[test]
+    fn permanent_delivery_failure_terminates_marker() {
+        let _root = test_root();
+        let rt = test_rt();
+        let (applier, calls) = recording_applier(ReactionDelivery::FailedPermanent);
+        // Drain path: covering commit, but the anchor message is gone.
+        let m = marker("claude", 100, 571, 10_000);
+        record(&m).unwrap();
+        let drained = rt.block_on(drain_on_terminal_commit_with_applier(
+            "claude", "tmux-100", 100, 10_500, &applier,
+        ));
+        assert_eq!(drained, 0, "a terminated marker is not a delivered ✅");
+        assert!(
+            load_for_channel("claude", 100).is_empty(),
+            "permanently-failed marker must be terminated by the drain, \
+             not stamped covered and retried forever"
+        );
+        // Sweep path: same termination on the ⚠ fallback.
+        let m2 = marker("claude", 100, 572, 10_000);
+        record(&m2).unwrap();
+        let resolved = rt.block_on(sweep_expired_with_applier(
+            "claude",
+            10_000 + TTL_MS + 1,
+            true,
+            &|_| false,
+            &applier,
+        ));
+        assert_eq!(resolved, 0);
+        assert!(
+            load_all().is_empty(),
+            "permanently-failed marker must be terminated by the sweep"
+        );
+        assert_eq!(calls.lock().unwrap().len(), 2);
+    }
+
+    /// #3296 verify r1 fix #3: permanent-vs-transient classification reuses
+    /// the sweeper's message-gone allowlist (404/403/410 permanent; 5xx, 429,
+    /// no-status transient).
+    #[test]
+    fn reaction_failure_classification_matches_sweeper_allowlist() {
+        for status in [404, 403, 410] {
+            assert_eq!(
+                classify_reaction_failure(Some(status)),
+                ReactionDelivery::FailedPermanent,
+                "{status} must classify permanent"
+            );
+        }
+        for status in [500, 502, 503, 504, 429, 408, 401] {
+            assert_eq!(
+                classify_reaction_failure(Some(status)),
+                ReactionDelivery::Failed,
+                "{status} must classify transient"
+            );
+        }
+        assert_eq!(classify_reaction_failure(None), ReactionDelivery::Failed);
+    }
+
+    /// #3296 verify r1 fix #3: an unparseable marker is quarantined via a
+    /// `.bad` rename — never silently re-parsed (and re-skipped) every pass.
+    #[test]
+    fn unparseable_marker_is_quarantined_not_relooped() {
+        let _root = test_root();
+        let store = root().unwrap();
+        std::fs::write(store.join("claude_1_2.json"), "{not json").unwrap();
+        assert!(load_all().is_empty());
+        assert!(
+            !store.join("claude_1_2.json").exists(),
+            "corrupt marker must be renamed away"
+        );
+        assert!(
+            store.join("claude_1_2.json.bad").exists(),
+            "quarantined as .bad for post-mortem"
+        );
+    }
+
+    /// #3296 verify r1 fix #4: when BOTH the ✅ delivery and the covered_at
+    /// stamp rewrite fail, the marker survives un-stamped and the next
+    /// covering drain pass still completes it (covers are not TTL-bounded).
+    #[cfg(unix)]
+    #[test]
+    fn covered_stamp_persist_failure_is_retried_by_next_drain() {
+        use std::os::unix::fs::PermissionsExt;
+        let _root = test_root();
+        let store = root().unwrap();
+        let m = marker("claude", 100, 573, 10_000);
+        record(&m).unwrap();
+        // Pre-create the claim sidecar so the read-only store below blocks
+        // ONLY the stamp rewrite, not the claim acquisition.
+        drop(try_claim_marker(&m).expect("pre-create claim sidecar"));
+        std::fs::set_permissions(&store, std::fs::Permissions::from_mode(0o555)).unwrap();
+        let rt = test_rt();
+        let (failing, _ops) = recording_applier(ReactionDelivery::Failed);
+        let drained = rt.block_on(drain_on_terminal_commit_with_applier(
+            "claude", "tmux-100", 100, 10_500, &failing,
+        ));
+        std::fs::set_permissions(&store, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert_eq!(drained, 0);
+        let kept = load_for_channel("claude", 100);
+        assert_eq!(kept.len(), 1, "marker must survive the failed stamp");
+        assert_eq!(
+            kept[0].covered_at_ms, None,
+            "stamp write failed (read-only store) — marker stays un-stamped"
+        );
+        // The next covering commit retries and completes (✅ idempotent).
+        let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
+        let drained = rt.block_on(drain_on_terminal_commit_with_applier(
+            "claude", "tmux-100", 100, 11_000, &applier,
+        ));
+        assert_eq!(drained, 1, "next drain pass must retry the cover");
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &[(573, ReactionOp::Complete)]
+        );
+        assert!(load_for_channel("claude", 100).is_empty());
     }
 
     /// Sweep scoping: another provider's markers are never touched.

--- a/src/services/discord/tui_direct_abort_marker.rs
+++ b/src/services/discord/tui_direct_abort_marker.rs
@@ -16,13 +16,12 @@
 //!
 //! 1. **Terminal-commit drain** ([`drain_on_terminal_commit`]) — the tmux
 //!    watcher's terminal chokepoint calls this on every body-visible normal
-//!    commit, passing the committed turn's identity. A marker is covered ONLY
-//!    by a commit whose identity MATCHES the foreign prior inflight the ABORT
-//!    recorded (codex r1: positive correlation — the bare same-session +
-//!    after-abort wall-clock test falsely `✅`'d unanswered anchors). Covering
-//!    commits are deliberately NOT TTL-bounded (verify r1): the sweep defers
-//!    to a live same-session inflight, so a foreign turn streaming past the
-//!    TTL must still have its eventual commit accepted.
+//!    commit. A marker is covered ONLY by a commit whose identity MATCHES the
+//!    foreign prior inflight the ABORT recorded (codex r1: positive
+//!    correlation — wall-clock alone falsely `✅`'d unanswered anchors), and
+//!    covers are deliberately NOT TTL-bounded (verify r1: the sweep defers to
+//!    a live same-session inflight, so a foreign turn streaming past the TTL
+//!    must still have its eventual commit accepted).
 //! 2. **TTL sweep** ([`sweep_expired`]) — the placeholder sweeper's pass: once
 //!    [`ABORT_MARKER_TTL`] elapsed with NO live inflight for the session (a
 //!    long streaming turn holds the verdict; a NAME-LESS inflight holds only
@@ -42,9 +41,8 @@
 //! [`CommitTombstone`] BEFORE it clears the inflight row and runs the drain.
 //! The sweep 대조s uncovered markers against them (post-live-read, so a
 //! commit-caused row clear is never mistaken for "nothing covers this"), and
-//! the ABORT record path 대조s once at record time — replacing the r1
-//! "pre-covered" promotion, which treated bare row-absence as commit evidence
-//! even though force-clears (sweeper/stop/recovery) also delete rows.
+//! the ABORT record path 대조s once at record time — bare row-absence is
+//! never commit evidence (force-clears also delete rows).
 //!
 //! ## Invariants
 //! * **I1 (#3164 add≡remove)**: every reaction op (`⏳` remove, `✅`/`⚠` add)
@@ -72,20 +70,19 @@ use super::SharedData;
 /// How long an aborted anchor may wait for a covering terminal commit before
 /// the sweep declares it a genuine failure (`⏳ → ⚠`). Rationale: the observed
 /// ABORT→covered window is ~30-180s (backstop 32s + prior-owner long turns);
-/// 600s comfortably covers a long streaming prior turn while still bounding a
-/// truly-lost input to TTL + sweeper initial delay (180s) + pass interval (30s).
-/// The TTL gates ONLY the sweep's `⚠` fallback — the terminal-commit drain's
-/// `✅` cover is not TTL-bounded (see [`terminal_commit_covers_marker`]).
+/// 600s covers a long streaming prior turn while still bounding a truly-lost
+/// input to TTL + sweeper initial delay (180s) + pass interval (30s). Gates
+/// ONLY the sweep's `⚠` fallback — the terminal-commit drain's `✅` cover is
+/// not TTL-bounded (see [`terminal_commit_covers_marker`]).
 pub(super) const ABORT_MARKER_TTL: std::time::Duration = std::time::Duration::from_secs(600);
 
 /// Absolute bound on the sweep's live-inflight hold (codex r1 finding 2):
 /// once `aborted_at + TTL × THIS` (6 × 600s = 1 hour) elapses, an UNCOVERED
-/// marker takes the `⚠` fallback regardless of any live inflight. Without it,
-/// back-to-back turns, a recreated same-name tmux session, or a stale
+/// marker takes the `⚠` fallback regardless of any live inflight — without
+/// it, back-to-back turns, a recreated same-name tmux session, or a stale
 /// same-channel row could renew the hold forever and orphan the `⏳`.
-/// Documented trade-off: a genuinely-covering prior turn that streams for
-/// over an hour past the abort without committing loses its hold — accepted,
-/// since bounded convergence is the sweeper's contract (#3282).
+/// Trade-off: a covering prior turn streaming over an hour past the abort
+/// loses its hold — accepted; bounded convergence is the contract (#3282).
 pub(super) const ABORT_MARKER_HARD_CAP_TTL_MULTIPLIER: u64 = 6;
 
 /// Durable record for an anchor whose synthetic turn-start ABORTed while the
@@ -98,21 +95,19 @@ pub(super) struct AbortedAnchorMarker {
     /// Identity pin (I4): the ONLY message any `✅`/`⚠` correction may target.
     pub anchor_message_id: u64,
     pub tmux_session_name: String,
-    /// Wall-clock ms of the ABORT. A covering commit must be strictly later.
+    /// Wall-clock ms of the ABORT. A covering commit must not be earlier (r3).
     pub aborted_at_ms: u64,
     /// Stamped when a covering terminal commit was seen but the `✅` delivery
     /// failed (or http was unavailable) — the sweep retries the completion
     /// instead of ever degrading a covered anchor to `⚠` (I6). Also stamped at
-    /// RECORD time when the foreign prior inflight is already gone (see
-    /// [`AbortedAnchorMarker::for_abort`]).
+    /// RECORD time on tombstone evidence ([`AbortedAnchorMarker::for_abort`]).
     #[serde(default)]
     pub covered_at_ms: Option<u64>,
     /// Identity of the live FOREIGN prior inflight at the ABORT instant
     /// (codex r1: positive correlation — `inflight.rs` `InflightTurnIdentity`
     /// convention). The drain covers this marker ONLY on a terminal commit
     /// whose turn identity matches BOTH fields. `None` on legacy (pre-r1)
-    /// markers: those are never drain-covered — the sweep alone resolves them
-    /// within its TTL/hard-cap bound.
+    /// markers: never drain-covered — the sweep bound alone resolves them.
     #[serde(default)]
     pub foreign_user_msg_id: Option<u64>,
     #[serde(default)]
@@ -128,14 +123,14 @@ impl AbortedAnchorMarker {
     }
 
     /// Build the marker the ABORT path records. `foreign` is the foreign prior
-    /// inflight's `(user_msg_id, started_at)` — the live row read AT the record
-    /// instant, or (codex r2) the worker's LAST-VIEW identity when that row
-    /// vanished in the µs gap since the final backstop view. ALWAYS uncovered:
-    /// bare row-absence is NOT commit evidence (force-clears also delete rows;
-    /// the r1 "pre-covered" promotion false-`✅`'d those) — coverage needs the
-    /// drain or a commit-tombstone 대조. The pair cannot alias another turn:
-    /// one row exists per `(provider, channel)` and a successor starts ≥ the
-    /// 32s backstop after `started_at`, so equality identifies the turn.
+    /// inflight's `(user_msg_id, started_at)`: the worker's LAST-VIEW identity,
+    /// with the cleanup-instant row only as the no-view fallback (codex r3 —
+    /// see `tui_direct_pending_start::pin_abort_foreign_identity`). ALWAYS
+    /// uncovered: bare row-absence is NOT commit evidence (force-clears also
+    /// delete rows; r1's "pre-covered" promotion false-`✅`'d those) — coverage
+    /// needs the drain or a commit-tombstone 대조. The pair cannot alias
+    /// another turn: one row per `(provider, channel)` and a successor starts
+    /// ≥ the 32s backstop after `started_at` — equality identifies the turn.
     pub(super) fn for_abort(
         provider: String,
         channel_id: u64,
@@ -174,13 +169,12 @@ impl AbortedAnchorMarker {
 // Durable store (mirrors `tui_direct_pending_start`'s store + atomic writes)
 // ---------------------------------------------------------------------------
 
-// Thread-local test seam for the durable BASE root (the
+// Thread-local test seam for the durable BASE root both sibling stores
+// (markers + commit tombstones) join subdirs onto (the
 // `TEST_TMUX_ALIVE_OVERRIDE` convention, inflight.rs). Tests inject a tempdir
-// here instead of mutating the process-global `AGENTDESK_ROOT_DIR` env (env
-// mutation races lock-free root readers, e.g. the `tui_direct_pending_start`
-// worker tests' `persist()`); a thread-local needs no lock and the tests'
-// current-thread `block_on` runtimes stay on this thread. The override is the
-// BASE both sibling stores (markers + commit tombstones) join subdirs onto.
+// here, never the process-global `AGENTDESK_ROOT_DIR` env: env mutation races
+// lock-free root readers in other tests, while a thread-local needs no lock
+// (the tests' current-thread `block_on` runtimes stay on this thread).
 #[cfg(test)]
 thread_local! {
     static TEST_ROOT_OVERRIDE: std::cell::RefCell<Option<std::path::PathBuf>> =
@@ -331,8 +325,10 @@ pub(super) struct CommitTombstone {
 
 /// Persist a terminal-commit tombstone. Best-effort by design (a failed write
 /// degrades to the conservative `⚠`-after-cap path, never a false `✅`); the
-/// stem is keyed on the write instant so successive commits on one channel
-/// never erase earlier still-retained evidence.
+/// stem is keyed on the write instant PLUS a process-monotonic sequence so
+/// same-ms commits on one channel never overwrite earlier still-retained
+/// evidence (codex r3 — the ms-only stem ERASED the first commit's tombstone;
+/// the seq resets per process, but a restart spans more than one ms).
 pub(super) fn record_commit_tombstone(
     provider: &str,
     tmux_session_name: &str,
@@ -369,7 +365,9 @@ pub(super) fn record_commit_tombstone_at(
         committed_started_at: committed_started_at.to_string(),
         committed_at_ms: now_ms,
     };
-    let path = root.join(format!("{provider}_{channel_id}_{now_ms}.json"));
+    static STEM_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = STEM_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let path = root.join(format!("{provider}_{channel_id}_{now_ms}_{seq}.json"));
     let written = serde_json::to_string_pretty(&tombstone)
         .map_err(|e| e.to_string())
         .and_then(|data| {
@@ -458,11 +456,10 @@ fn commit_tombstone_matches_marker(marker: &AbortedAnchorMarker, t: &CommitTombs
 /// Record-instant 대조 (codex r2 — replaces the unfounded "pre-covered"
 /// promotion): a tombstone matching the marker's foreign identity ALREADY
 /// durable at record time means that turn terminal-committed before this
-/// marker existed (its drain pass could never see it) → stamp covered with the
-/// commit instant. No wall-clock condition: the identity was captured from a
-/// row observed LIVE after the anchor's input was provider-submitted, so that
-/// turn's unique terminal commit post-dates the submission regardless of how
-/// it interleaves with the marker write.
+/// marker existed (its drain pass could never see it) → stamp covered with
+/// the commit instant. No wall-clock condition — the structural argument that
+/// makes the sweep 대조's `>=` safe ([`post_abort_commit_tombstone`]) holds a
+/// fortiori for evidence predating the marker.
 pub(super) fn cover_from_commit_tombstone(marker: &mut AbortedAnchorMarker) -> bool {
     if marker.covered_at_ms.is_some() {
         return false;
@@ -478,14 +475,19 @@ pub(super) fn cover_from_commit_tombstone(marker: &mut AbortedAnchorMarker) -> b
 }
 
 /// Sweep-side 대조: a tombstone covers an UNCOVERED marker when it matches the
-/// foreign identity AND its commit is strictly later than the abort (the
-/// record-instant 대조 above owns evidence that predates the marker, so the
-/// subsidiary wall-clock guard costs nothing here and mirrors the drain's).
+/// foreign identity AND its commit is not EARLIER than the abort. `>=`, not
+/// `>` (codex r3): identity is the PRIMARY evidence — the ABORT fired because
+/// the recorded foreign turn stayed live through the whole 32s backstop, so a
+/// commit of THAT turn cannot predate the input submission (itself before the
+/// marker existed); an identity-matched same-ms commit is therefore
+/// necessarily post-submission, and strict `>` only ever rejected ANSWERED
+/// anchors at the ms boundary (false `⚠`). The record-instant 대조 above owns
+/// evidence predating the marker; this subsidiary guard mirrors the drain's.
 pub(super) fn post_abort_commit_tombstone(marker: &AbortedAnchorMarker) -> Option<u64> {
     load_commit_tombstones(&marker.provider, marker.channel_id)
         .into_iter()
         .find(|t| {
-            commit_tombstone_matches_marker(marker, t) && t.committed_at_ms > marker.aborted_at_ms
+            commit_tombstone_matches_marker(marker, t) && t.committed_at_ms >= marker.aborted_at_ms
         })
         .map(|t| t.committed_at_ms)
 }
@@ -618,11 +620,13 @@ pub(super) fn decide_marker_disposition(
 /// turn must BE the foreign prior inflight recorded at ABORT time (the old
 /// wall-clock-only condition let a racing prior-owner commit, a re-created
 /// same-name tmux session, and a dropped-input prior commit each false-`✅` a
-/// possibly-unanswered anchor); strictly-after-abort stays as a SUBSIDIARY
-/// guard only. Identity-absent (legacy) markers never cover here — the sweep
-/// bound is their sole terminator. Deliberately NO TTL upper bound (verify
-/// r1): the sweep defers to a live same-session inflight, so a foreign turn
-/// streaming past the TTL must still have its eventual commit accepted.
+/// possibly-unanswered anchor); not-earlier-than-abort stays as a SUBSIDIARY
+/// guard only (`>=` since codex r3 — a commit in the abort's OWN millisecond
+/// covers; safety argument at [`post_abort_commit_tombstone`]). Identity-
+/// absent (legacy) markers never cover here — the sweep bound is their sole
+/// terminator. Deliberately NO TTL upper bound (verify r1): the sweep defers
+/// to a live same-session inflight, so a foreign turn streaming past the TTL
+/// must still have its eventual commit accepted.
 pub(super) fn terminal_commit_covers_marker(
     now_ms: u64,
     marker: &AbortedAnchorMarker,
@@ -630,7 +634,7 @@ pub(super) fn terminal_commit_covers_marker(
     committed_started_at: &str,
 ) -> bool {
     marker.anchor_message_id != 0
-        && now_ms > marker.aborted_at_ms
+        && now_ms >= marker.aborted_at_ms
         && marker.matches_foreign_identity(committed_user_msg_id, committed_started_at)
 }
 
@@ -639,8 +643,7 @@ pub(super) fn terminal_commit_covers_marker(
 /// long-prior-turn hold). A NAME-LESS row defers ONLY when it IS the recorded
 /// foreign prior turn (codex r1 finding 2: the old `is_none_or(..)` treated
 /// EVERY name-less same-channel row as "could be the prior owner", letting an
-/// unrelated/stale inflight hold the marker; the hold is now positive-match
-/// only, and even a matching hold is bounded by the hard cap upstream).
+/// unrelated/stale inflight hold the marker; the hard cap bounds even a match).
 pub(super) fn inflight_defers_sweep(
     marker: &AbortedAnchorMarker,
     inflight_tmux_session_name: Option<&str>,
@@ -681,8 +684,7 @@ pub(super) enum ReactionDelivery {
 }
 
 /// Classify a reaction-create failure status into transient vs permanent.
-/// Reuses the sweeper's message-gone allowlist (404 NOT_FOUND — Unknown
-/// Message 10008 / Unknown Channel 10003 map here — 403 FORBIDDEN, 410 GONE;
+/// Reuses the sweeper's message-gone allowlist (404/403/410;
 /// `placeholder_sweeper::is_permanent_message_gone_status`, the #3293-shared
 /// classifier) so every Discord-permanence verdict in this subtree agrees.
 fn classify_reaction_failure(status: Option<u16>) -> ReactionDelivery {
@@ -836,9 +838,8 @@ pub(super) async fn drain_on_terminal_commit_with_applier(
                 );
             }
             ReactionDelivery::FailedPermanent => {
-                // The anchor message is permanently gone (404/403/410) — no
-                // reaction can EVER land; terminate instead of retrying
-                // forever (verify r1 fix #3). One WARN, here only.
+                // Permanently gone anchor (404/403/410): no reaction can EVER
+                // land; terminate, don't retry (verify r1 fix #3). WARN here only.
                 delete(&marker);
                 tracing::warn!(
                     provider = %marker.provider,
@@ -854,8 +855,7 @@ pub(super) async fn drain_on_terminal_commit_with_applier(
                 if let Err(error) = record(&marker) {
                     // verify r1 fix #4: surface loudly — a swallowed stamp
                     // failure would let the sweep ⚠ a COVERED anchor after the
-                    // TTL; un-stamped, the next covering drain pass retries
-                    // the ✅ (covers are not TTL-bounded since fix #1).
+                    // TTL; un-stamped, the next covering drain retries the ✅.
                     tracing::error!(
                         provider = %marker.provider,
                         channel_id = marker.channel_id,
@@ -1216,12 +1216,16 @@ mod tests {
     }
 
     #[test]
-    fn terminal_commit_cover_requires_strictly_post_abort_commit() {
+    fn terminal_commit_cover_accepts_same_ms_and_rejects_earlier() {
         let m = marker("claude", 1, 10, 5_000);
         let (cid, cstart) = committed(&m);
-        // Strictly-after-abort: a commit AT or BEFORE the abort instant belongs
-        // to an older turn and must not cover (RED if `>=`).
-        assert!(!terminal_commit_covers_marker(5_000, &m, cid, &cstart));
+        // codex r3 (RED ① — pure): a commit in the abort's OWN millisecond is
+        // a real cover — identity is the primary evidence (the foreign turn
+        // was live through the backstop, so its commit cannot predate the
+        // input submission); strict `>` falsely `⚠`'d these ANSWERED anchors.
+        // Strictly-earlier wall-clocks still never cover (subsidiary guard).
+        assert!(terminal_commit_covers_marker(5_000, &m, cid, &cstart));
+        assert!(!terminal_commit_covers_marker(4_999, &m, cid, &cstart));
         assert!(!terminal_commit_covers_marker(4_000, &m, cid, &cstart));
         assert!(terminal_commit_covers_marker(5_001, &m, cid, &cstart));
         assert!(terminal_commit_covers_marker(
@@ -1434,7 +1438,8 @@ mod tests {
     }
 
     /// I4/R3 + identity scoping: a commit for a DIFFERENT tmux session or a
-    /// commit at/before the abort instant must not touch the marker.
+    /// commit strictly BEFORE the abort ms must not touch the marker (a
+    /// same-ms commit covers since codex r3 — see the same-ms test below).
     #[test]
     fn drain_skips_foreign_session_and_pre_abort_commit() {
         let _root = test_root();
@@ -1454,9 +1459,9 @@ mod tests {
             &applier,
         ));
         assert_eq!(drained, 0);
-        // Commit not after the abort → no-op (an older turn's commit).
+        // Commit strictly earlier than the abort → no-op (clock anomaly).
         let drained = rt.block_on(drain_on_terminal_commit_with_applier(
-            "claude", "tmux-100", 100, 10_000, cid, &cstart, &applier,
+            "claude", "tmux-100", 100, 9_999, cid, &cstart, &applier,
         ));
         assert_eq!(drained, 0);
         assert!(calls.lock().unwrap().is_empty());
@@ -1962,8 +1967,8 @@ mod tests {
     /// path with the foreign row already GONE. With a matching tombstone the
     /// deletion WAS the prior owner's terminal commit → the marker records
     /// covered at the tombstone's commit instant (evidence-backed — note the
-    /// commit PRECEDES `aborted_at`, the case the sweep's strictly-post-abort
-    /// 대조 deliberately excludes). WITHOUT one (a placeholder-sweeper/stop/
+    /// commit PRECEDES `aborted_at`, the case the sweep's not-earlier-than-
+    /// abort 대조 deliberately excludes). WITHOUT one (a placeholder-sweeper/
     /// recovery force-clear) it records UNCOVERED and the sweep bound delivers
     /// the conservative `⚠` — RED pre-r2: bare row-absence pre-covered the
     /// marker and a force-cleared, genuinely-unanswered anchor got a false ✅.
@@ -2128,5 +2133,87 @@ mod tests {
             &[(565, ReactionOp::Complete)]
         );
         assert!(load_commit_tombstones("claude", 100).is_empty());
+    }
+
+    /// codex r3 (RED ① — behavior): a terminal commit landing in the SAME
+    /// millisecond as the abort covers the marker on BOTH reconcile paths.
+    /// RED pre-r3: the strict `commit_at > aborted_at` 대조 refused the cover
+    /// — the drain skipped the marker and the sweep's TTL bound then `⚠`'d an
+    /// ANSWERED anchor. Safe because identity, not wall-clock, is the primary
+    /// evidence: the recorded foreign turn was live through the 32s backstop,
+    /// so its commit cannot predate the input submission.
+    #[test]
+    fn same_ms_commit_covers_via_drain_and_sweep_tombstone() {
+        let _root = test_root();
+        let rt = test_rt();
+        // Drain path: the chokepoint clock equals the abort ms.
+        let m = marker("claude", 100, 566, 10_000);
+        record(&m).unwrap();
+        let (cid, cstart) = committed(&m);
+        let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
+        let drained = rt.block_on(drain_on_terminal_commit_with_applier(
+            "claude", "tmux-100", 100, 10_000, cid, &cstart, &applier,
+        ));
+        assert_eq!(
+            drained, 1,
+            "a same-ms commit must cover (RED pre-r3: strict `>` refused it)"
+        );
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &[(566, ReactionOp::Complete)]
+        );
+        // Sweep 대조 path: tombstone `committed_at_ms == aborted_at_ms`.
+        let m2 = marker("claude", 100, 567, 10_000);
+        record(&m2).unwrap();
+        let (cid2, cstart2) = committed(&m2);
+        record_commit_tombstone_at(10_000, "claude", "tmux-100", 100, cid2, &cstart2);
+        let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
+        let resolved = rt.block_on(sweep_expired_with_applier(
+            "claude",
+            10_000 + TTL_MS + 1,
+            true,
+            &|_| false,
+            &applier,
+        ));
+        assert_eq!(resolved, 1);
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &[(567, ReactionOp::Complete)],
+            "the same-ms tombstone must land ✅, never the TTL ⚠ (RED pre-r3)"
+        );
+        assert!(load_for_channel("claude", 100).is_empty());
+    }
+
+    /// codex r3 (RED ② — durable evidence): two commits on one
+    /// `(provider, channel)` inside the SAME millisecond must BOTH retain
+    /// their tombstones. RED pre-r3: the ms-only file stem made the second
+    /// write OVERWRITE the first — a marker pinned to the FIRST turn lost its
+    /// only commit evidence and degraded to the bounded `⚠` on an answered
+    /// anchor.
+    #[test]
+    fn same_ms_commit_tombstones_preserve_both_evidences() {
+        let _root = test_root();
+        record_commit_tombstone_at(50_000, "claude", "tmux-100", 100, 777, FOREIGN_STARTED_AT);
+        record_commit_tombstone_at(50_000, "claude", "tmux-100", 100, 778, FOREIGN_STARTED_AT);
+        let mut ids: Vec<u64> = load_commit_tombstones("claude", 100)
+            .into_iter()
+            .map(|t| t.committed_user_msg_id)
+            .collect();
+        ids.sort_unstable();
+        assert_eq!(
+            ids,
+            vec![777, 778],
+            "both same-ms tombstones must survive (RED pre-r3: the second \
+             stem overwrote the first — evidence erased)"
+        );
+        // The FIRST turn's surviving evidence still 대조-covers its marker
+        // (also exercises the r3 `>=`: commit ms == abort ms).
+        let mut m = marker("claude", 100, 568, 50_000);
+        m.foreign_user_msg_id = Some(777);
+        assert_eq!(
+            post_abort_commit_tombstone(&m),
+            Some(50_000),
+            "the first commit's retained tombstone must still cover its marker"
+        );
     }
 }

--- a/src/services/discord/tui_direct_abort_marker.rs
+++ b/src/services/discord/tui_direct_abort_marker.rs
@@ -88,7 +88,29 @@ impl AbortedAnchorMarker {
 // Durable store (mirrors `tui_direct_pending_start`'s store + atomic writes)
 // ---------------------------------------------------------------------------
 
+// Thread-local test seam for the durable root (the `TEST_TMUX_ALIVE_OVERRIDE`
+// convention, inflight.rs). Tests inject a tempdir here instead of mutating
+// the process-global `AGENTDESK_ROOT_DIR` env: env mutation races every test
+// that READS the root without holding the crate env lock (e.g. the
+// `tui_direct_pending_start` worker tests' `persist()`), and a thread-local
+// needs no lock at all (each test thread sees only its own override; the
+// current-thread `block_on` runtimes the tests use stay on this thread).
+#[cfg(test)]
+thread_local! {
+    static TEST_ROOT_OVERRIDE: std::cell::RefCell<Option<std::path::PathBuf>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+pub(super) fn set_test_root_override(path: Option<std::path::PathBuf>) {
+    TEST_ROOT_OVERRIDE.with(|cell| *cell.borrow_mut() = path);
+}
+
 fn root() -> Option<std::path::PathBuf> {
+    #[cfg(test)]
+    if let Some(path) = TEST_ROOT_OVERRIDE.with(|cell| cell.borrow().clone()) {
+        return Some(path);
+    }
     super::runtime_store::tui_direct_abort_marker_root()
 }
 
@@ -442,44 +464,32 @@ mod tests {
     use super::*;
     use std::sync::Mutex;
 
-    /// Serializes env-root mutation + restores `AGENTDESK_ROOT_DIR` on drop
-    /// (the `durable_restore_roundtrip_loads_fifo_order` precedent in
-    /// `tui_direct_pending_start`). Field order matters: tempdir first, then
-    /// env restore, then the shared env lock releases.
+    /// Injects a per-test tempdir as the durable root via the THREAD-LOCAL
+    /// override (never the process-global `AGENTDESK_ROOT_DIR` env — mutating
+    /// that races every test that reads the root without the crate env lock,
+    /// e.g. the `tui_direct_pending_start` worker tests' `persist()`). No lock
+    /// is needed: each test thread sees only its own override.
     struct TestRoot {
         _temp: tempfile::TempDir,
-        _env: EnvReset,
-        _lock: std::sync::MutexGuard<'static, ()>,
     }
 
-    struct EnvReset(Option<std::ffi::OsString>);
-    impl Drop for EnvReset {
+    impl Drop for TestRoot {
         fn drop(&mut self) {
-            match self.0.take() {
-                Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
-                None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
-            }
+            set_test_root_override(None);
         }
     }
 
     fn test_root() -> TestRoot {
-        let lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        let env = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
         let temp = tempfile::tempdir().unwrap();
-        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+        set_test_root_override(Some(temp.path().join("discord_tui_direct_abort_marker")));
         std::fs::create_dir_all(root().expect("durable root configured under temp")).unwrap();
-        TestRoot {
-            _temp: temp,
-            _env: env,
-            _lock: lock,
-        }
+        TestRoot { _temp: temp }
     }
 
-    /// Sync tests + an explicit current-thread runtime keep the env-lock guard
-    /// out of any async scope (no new `await_holding_lock` allow sites — the
-    /// repo ratchet is frozen at its baseline).
+    /// A current-thread runtime keeps the async drains on THIS thread so the
+    /// thread-local root override resolves inside them (and no
+    /// `await_holding_lock` allow sites are needed — the repo ratchet is
+    /// frozen at its baseline).
     fn test_rt() -> tokio::runtime::Runtime {
         tokio::runtime::Builder::new_current_thread()
             .enable_all()

--- a/src/services/discord/tui_direct_pending_start.rs
+++ b/src/services/discord/tui_direct_pending_start.rs
@@ -357,16 +357,29 @@ pub(super) type ClaimFn = Box<
         + Sync,
 >;
 
-/// Build the per-poll [`PriorTurnView`]. Provided by [`super::tui_prompt_relay`]
-/// (it owns inflight/mailbox/runtime-binding access). Returns `None` when the
-/// view cannot be computed yet (e.g. mailbox unavailable) — treated as "not
-/// finalized" so the worker keeps waiting.
+/// One worker poll's observation: the pure decision [`PriorTurnView`] plus the
+/// live FOREIGN prior inflight's identity at the read instant (`None` when no
+/// row exists or the row is our own anchor). The worker threads the LATEST
+/// observed identity into the ABORT cleanup as the marker's last-view identity
+/// (#3296 codex r2: when the row vanishes in the µs gap between the final
+/// backstop view and the cleanup's own read, the marker still pins WHICH turn
+/// it was waiting on, so commit-tombstone 대조 — not bare row-absence — decides
+/// `✅` vs `⚠`).
+pub(super) struct PriorTurnObservation {
+    pub view: PriorTurnView,
+    pub foreign_inflight_identity: Option<(u64, String)>,
+}
+
+/// Build the per-poll [`PriorTurnObservation`]. Provided by
+/// [`super::tui_prompt_relay`] (it owns inflight/mailbox/runtime-binding
+/// access). Returns `None` when the view cannot be computed yet (e.g. mailbox
+/// unavailable) — treated as "not finalized" so the worker keeps waiting.
 pub(super) type ViewFn = Box<
     dyn for<'a> Fn(
             &'a Arc<SharedData>,
             &'a TuiDirectPendingStart,
         ) -> std::pin::Pin<
-            Box<dyn std::future::Future<Output = Option<PriorTurnView>> + Send + 'a>,
+            Box<dyn std::future::Future<Output = Option<PriorTurnObservation>> + Send + 'a>,
         > + Send
         + Sync,
 >;
@@ -377,11 +390,14 @@ pub(super) type ViewFn = Box<
 /// hook records a durable aborted-anchor marker
 /// ([`super::tui_direct_abort_marker`]) so a later prior-owner terminal commit
 /// flips it `⏳ → ✅`, or the TTL'd sweep flips it `⏳ → ⚠` when nothing ever
-/// covered it. Provided by [`super::tui_prompt_relay`].
+/// covered it. The third argument is the worker's LAST-VIEW foreign inflight
+/// identity (codex r2 — see [`PriorTurnObservation`]). Provided by
+/// [`super::tui_prompt_relay`].
 pub(super) type AbortCleanupFn = Box<
     dyn for<'a> Fn(
             &'a Arc<SharedData>,
             &'a TuiDirectPendingStart,
+            Option<(u64, String)>,
         ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>>
         + Send
         + Sync,
@@ -431,21 +447,36 @@ async fn run_worker(
     let mut backstop_cycles: u32 = 0;
     let mut claim_attempts: u32 = 0;
     let worker_start = tokio::time::Instant::now();
+    // codex r2: the most recent poll's live FOREIGN inflight identity. Handed
+    // to the ABORT cleanup so the aborted-anchor marker pins WHICH turn it was
+    // deferring on even when that row vanishes before the cleanup's own read.
+    let mut last_foreign_identity: Option<(u64, String)> = None;
 
     loop {
         // ---- Wait window: poll until finalized or backstop expiry. ----
         let cycle_start = tokio::time::Instant::now();
         let outcome = loop {
-            if let Some(view) = view_fn(&shared, &record).await
-                && prior_turn_finalized(view)
-            {
-                break WaitOutcome::Finalized;
+            if let Some(obs) = view_fn(&shared, &record).await {
+                if obs.foreign_inflight_identity.is_some() {
+                    last_foreign_identity = obs.foreign_inflight_identity;
+                }
+                if prior_turn_finalized(obs.view) {
+                    break WaitOutcome::Finalized;
+                }
             }
             if cycle_start.elapsed() >= PENDING_START_BACKSTOP {
-                let view = view_fn(&shared, &record).await;
-                break match view {
-                    Some(view) if backstop_claim_is_safe(view) => WaitOutcome::BackstopClaimSafe,
-                    _ => WaitOutcome::BackstopForeignInflightLive,
+                break match view_fn(&shared, &record).await {
+                    Some(obs) => {
+                        if obs.foreign_inflight_identity.is_some() {
+                            last_foreign_identity = obs.foreign_inflight_identity;
+                        }
+                        if backstop_claim_is_safe(obs.view) {
+                            WaitOutcome::BackstopClaimSafe
+                        } else {
+                            WaitOutcome::BackstopForeignInflightLive
+                        }
+                    }
+                    None => WaitOutcome::BackstopForeignInflightLive,
                 };
             }
             tokio::time::sleep(PENDING_START_POLL).await;
@@ -490,8 +521,9 @@ async fn run_worker(
                     // #3282/#3296: no claim will ever run for this anchor, so
                     // the normal `⏳ → ✅` completion never fires — record the
                     // durable aborted-anchor marker here (the anchor keeps its
-                    // ⏳; the watcher drain / TTL sweep own the reconcile).
-                    abort_cleanup_fn(&shared, &record).await;
+                    // ⏳; the watcher drain / TTL sweep own the reconcile),
+                    // pinning the last-view foreign identity (codex r2).
+                    abort_cleanup_fn(&shared, &record, last_foreign_identity.clone()).await;
                     delete(&record);
                     return;
                 }
@@ -573,6 +605,15 @@ mod tests {
     fn worker_test_lock() -> std::sync::MutexGuard<'static, ()> {
         static LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
         LOCK.lock().unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    /// Wrap a pure view into the worker's per-poll observation (no foreign
+    /// identity — the common already-finalized case).
+    fn obs(view: PriorTurnView) -> PriorTurnObservation {
+        PriorTurnObservation {
+            view,
+            foreign_inflight_identity: None,
+        }
     }
 
     fn base_view() -> PriorTurnView {
@@ -693,21 +734,32 @@ mod tests {
     }
 
     /// #3282 test double for the ABORT-path anchor `⏳` cleanup, following the
-    /// `ViewFn`/`ClaimFn` boxed-closure convention. Records each invocation so a
-    /// test can pin WHEN the cleanup fires (terminal backstop ABORT only) and
-    /// when it must NOT (successful claim — the normal `⏳ → ✅` completion owns
-    /// the anchor; retry exhaustion — the record is retained for restart).
-    fn recording_abort_cleanup() -> (AbortCleanupFn, Arc<std::sync::atomic::AtomicU32>) {
+    /// `ViewFn`/`ClaimFn` boxed-closure convention. Records each invocation —
+    /// and the last-view foreign identity it received (codex r2) — so a test
+    /// can pin WHEN the cleanup fires (terminal backstop ABORT only) and what
+    /// identity the worker threaded, and when it must NOT fire (successful
+    /// claim — the normal `⏳ → ✅` completion owns the anchor; retry
+    /// exhaustion — the record is retained for restart).
+    type RecordedForeignIdentity = Arc<Mutex<Option<Option<(u64, String)>>>>;
+    fn recording_abort_cleanup() -> (
+        AbortCleanupFn,
+        Arc<std::sync::atomic::AtomicU32>,
+        RecordedForeignIdentity,
+    ) {
         use std::sync::atomic::{AtomicU32, Ordering};
         let calls = Arc::new(AtomicU32::new(0));
+        let identity: RecordedForeignIdentity = Arc::new(Mutex::new(None));
         let calls_for_fn = calls.clone();
-        let cleanup: AbortCleanupFn = Box::new(move |_shared, _record| {
+        let identity_for_fn = identity.clone();
+        let cleanup: AbortCleanupFn = Box::new(move |_shared, _record, foreign| {
             let calls = calls_for_fn.clone();
+            let identity = identity_for_fn.clone();
             Box::pin(async move {
                 calls.fetch_add(1, Ordering::SeqCst);
+                *identity.lock().unwrap_or_else(|poison| poison.into_inner()) = Some(foreign);
             })
         });
-        (cleanup, calls)
+        (cleanup, calls, identity)
     }
 
     fn record(provider: &str, channel_id: u64, anchor: u64) -> TuiDirectPendingStart {
@@ -762,14 +814,14 @@ mod tests {
         let a_view: ViewFn = Box::new(move |_shared, _record| {
             let undrained = a_undrained_for_view.clone();
             Box::pin(async move {
-                Some(PriorTurnView {
+                Some(obs(PriorTurnView {
                     // turn1 inflight present until drained.
                     inflight_present: undrained.load(Ordering::SeqCst),
                     inflight_is_own_anchor: false,
                     mailbox_blocking_turn_present: false,
                     mailbox_turn_is_own_anchor: false,
                     runtime_binding_present: true,
-                })
+                }))
             })
         });
         let a_undrained_for_claim = a_prior_undrained.clone();
@@ -796,7 +848,7 @@ mod tests {
             pending_synthetic_start_present("claude", 1),
             "A's pending start gates the watcher/idle-queue immediately"
         );
-        let (a_cleanup, a_cleanup_calls) = recording_abort_cleanup();
+        let (a_cleanup, a_cleanup_calls, _) = recording_abort_cleanup();
         let a_handle = tokio::spawn(run_worker(
             shared.clone(),
             rec_a,
@@ -809,13 +861,13 @@ mod tests {
         let b_claimed = Arc::new(AtomicBool::new(false));
         let b_view: ViewFn = Box::new(move |_shared, _record| {
             Box::pin(async move {
-                Some(PriorTurnView {
+                Some(obs(PriorTurnView {
                     inflight_present: false,
                     inflight_is_own_anchor: false,
                     mailbox_blocking_turn_present: false,
                     mailbox_turn_is_own_anchor: false,
                     runtime_binding_present: true,
-                })
+                }))
             })
         });
         let b_claimed_for_claim = b_claimed.clone();
@@ -828,7 +880,7 @@ mod tests {
         });
         let rec_b = record("claude", 2, 22);
         persist(&rec_b).unwrap();
-        let (b_cleanup, b_cleanup_calls) = recording_abort_cleanup();
+        let (b_cleanup, b_cleanup_calls, _) = recording_abort_cleanup();
         let b_handle = tokio::spawn(run_worker(
             shared.clone(),
             rec_b,
@@ -943,14 +995,19 @@ mod tests {
         let shared = super::super::make_shared_data_for_tests();
 
         // A foreign prior inflight is live FOREVER (never drains, never ours).
+        // Every poll observes its identity — the worker must thread the
+        // LAST-VIEW identity into the abort cleanup (codex r2).
         let view: ViewFn = Box::new(move |_shared, _record| {
             Box::pin(async move {
-                Some(PriorTurnView {
-                    inflight_present: true,
-                    inflight_is_own_anchor: false,
-                    mailbox_blocking_turn_present: true,
-                    mailbox_turn_is_own_anchor: false,
-                    runtime_binding_present: true,
+                Some(PriorTurnObservation {
+                    view: PriorTurnView {
+                        inflight_present: true,
+                        inflight_is_own_anchor: false,
+                        mailbox_blocking_turn_present: true,
+                        mailbox_turn_is_own_anchor: false,
+                        runtime_binding_present: true,
+                    },
+                    foreign_inflight_identity: Some((777, "2026-06-10 12:00:00".to_string())),
                 })
             })
         });
@@ -969,7 +1026,8 @@ mod tests {
         persist(&rec).unwrap();
         assert!(pending_synthetic_start_present("claude", 10));
 
-        let (abort_cleanup, abort_cleanup_calls) = recording_abort_cleanup();
+        let (abort_cleanup, abort_cleanup_calls, abort_cleanup_identity) =
+            recording_abort_cleanup();
         let handle = tokio::spawn(run_worker(shared.clone(), rec, view, claim, abort_cleanup));
 
         // Advance through the full escalation budget of backstop windows.
@@ -1001,6 +1059,18 @@ mod tests {
              anchor). RED if the ABORT branch skips abort_cleanup_fn (the \
              hourglass would linger with no reconcile owner)."
         );
+        assert_eq!(
+            abort_cleanup_identity
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner())
+                .clone(),
+            Some(Some((777, "2026-06-10 12:00:00".to_string()))),
+            "codex r2: the worker must thread the LAST-VIEW foreign inflight \
+             identity into the cleanup, so a row that vanishes before the \
+             cleanup's own read still yields an identity-pinned marker — RED \
+             if the hook receives None (the marker would be sweep-only and \
+             tombstone 대조 could never ✅ it)"
+        );
         reset_present_for_tests();
     }
 
@@ -1024,7 +1094,7 @@ mod tests {
 
         // Prior turn is finalized immediately — the wait window is not the point.
         let view: ViewFn =
-            Box::new(move |_shared, _record| Box::pin(async move { Some(base_view()) }));
+            Box::new(move |_shared, _record| Box::pin(async move { Some(obs(base_view())) }));
 
         // First two claims fail (transient), the third succeeds.
         let attempts = Arc::new(AtomicU32::new(0));
@@ -1039,7 +1109,7 @@ mod tests {
 
         let rec = record("claude", 11, 111);
         persist(&rec).unwrap();
-        let (abort_cleanup, abort_cleanup_calls) = recording_abort_cleanup();
+        let (abort_cleanup, abort_cleanup_calls, _) = recording_abort_cleanup();
         let handle = tokio::spawn(run_worker(shared.clone(), rec, view, claim, abort_cleanup));
 
         // Drive the retry backoffs. After the first false, assert the record is
@@ -1094,7 +1164,7 @@ mod tests {
         reset_present_for_tests();
         let shared = super::super::make_shared_data_for_tests();
         let view: ViewFn =
-            Box::new(move |_shared, _record| Box::pin(async move { Some(base_view()) }));
+            Box::new(move |_shared, _record| Box::pin(async move { Some(obs(base_view())) }));
 
         let attempts = Arc::new(AtomicU32::new(0));
         let attempts_for_fn = attempts.clone();
@@ -1108,7 +1178,7 @@ mod tests {
 
         let rec = record("claude", 12, 122);
         persist(&rec).unwrap();
-        let (abort_cleanup, abort_cleanup_calls) = recording_abort_cleanup();
+        let (abort_cleanup, abort_cleanup_calls, _) = recording_abort_cleanup();
         let handle = tokio::spawn(run_worker(shared.clone(), rec, view, claim, abort_cleanup));
 
         for _ in 0..(PENDING_START_MAX_CLAIM_ATTEMPTS + 2) {

--- a/src/services/discord/tui_direct_pending_start.rs
+++ b/src/services/discord/tui_direct_pending_start.rs
@@ -361,10 +361,10 @@ pub(super) type ClaimFn = Box<
 /// live FOREIGN prior inflight's identity at the read instant (`None` when no
 /// row exists or the row is our own anchor). The worker threads the LATEST
 /// observed identity into the ABORT cleanup as the marker's last-view identity
-/// (#3296 codex r2: when the row vanishes in the µs gap between the final
-/// backstop view and the cleanup's own read, the marker still pins WHICH turn
-/// it was waiting on, so commit-tombstone 대조 — not bare row-absence — decides
-/// `✅` vs `⚠`).
+/// — the PRIMARY pin since #3296 codex r3 ([`pin_abort_foreign_identity`]):
+/// it survives the row vanishing before the cleanup's own read AND it cannot
+/// be repointed by a successor row that took the slot in that gap, so the
+/// commit-tombstone 대조 decides `✅` vs `⚠` for the RIGHT turn.
 pub(super) struct PriorTurnObservation {
     pub view: PriorTurnView,
     pub foreign_inflight_identity: Option<(u64, String)>,
@@ -402,6 +402,28 @@ pub(super) type AbortCleanupFn = Box<
         + Send
         + Sync,
 >;
+
+/// #3296 codex r3: choose the foreign identity an aborted-anchor marker pins.
+/// The worker's LAST-VIEW identity is PRIMARY — that row was observed LIVE
+/// during the backstop window, so it is definitionally the turn the ABORT
+/// deferred on. The cleanup-instant inflight row is read (lazily) ONLY when
+/// no poll ever captured an identity: between the final backstop view and the
+/// cleanup's read, the foreign row may terminal-commit (tombstone + clear)
+/// and a SUCCESSOR row may already hold the `(provider, channel)` slot —
+/// preferring the current row pinned that WRONG turn (the genuine prior
+/// commit's tombstone then never matched the marker, and the successor's own
+/// commit could false-`✅` a possibly-unanswered anchor). The no-view fallback
+/// is deliberately kept conservative-best-effort: with no observed identity
+/// the cleanup-instant row is the only evidence available (a successor there
+/// would need the never-observed prior row to clear AND a new claim to land
+/// inside the same µs window), while pinning nothing forfeits drain coverage
+/// outright — a guaranteed bounded `⚠` even on an answered anchor.
+pub(super) fn pin_abort_foreign_identity(
+    last_view_foreign: Option<(u64, String)>,
+    read_cleanup_instant_row: impl FnOnce() -> Option<(u64, String)>,
+) -> Option<(u64, String)> {
+    last_view_foreign.or_else(read_cleanup_instant_row)
+}
 
 /// Spawn the DETACHED per-channel worker. Acquires the channel lock (FIFO
 /// serialization), polls the wait predicate until the prior turn finalizes (or
@@ -656,6 +678,46 @@ mod tests {
             prior_turn_finalized(view),
             "a crash-restored inflight for OUR OWN anchor is adopted, not waited on"
         );
+    }
+
+    /// #3296 codex r3 (RED ③ — pure): the ABORT cleanup pins the worker's
+    /// LAST-VIEW identity, never the cleanup-instant row, when both exist.
+    /// RED pre-r3: the relay hook preferred the live row — when the final
+    /// poll's foreign row terminal-committed (tombstone + clear) and a
+    /// SUCCESSOR row appeared before the cleanup's read, the marker pinned
+    /// the successor: the genuine prior commit's tombstone never matched (no
+    /// `✅` from the real answer, bounded `⚠` instead) and the successor's own
+    /// commit could false-`✅` the possibly-unanswered anchor.
+    #[test]
+    fn abort_pin_prefers_last_view_identity_over_successor_row() {
+        let last_view = Some((777_u64, "2026-06-10 12:00:00".to_string()));
+        let successor = Some((888_u64, "2026-06-10 12:01:00".to_string()));
+        assert_eq!(
+            pin_abort_foreign_identity(last_view.clone(), || successor.clone()),
+            last_view,
+            "last-view is PRIMARY: a successor row must never repoint the pin (RED ③)"
+        );
+        // The primary path must not even READ the current row — the
+        // cleanup-instant read is exactly what races the successor.
+        let row_read = std::cell::Cell::new(false);
+        assert_eq!(
+            pin_abort_foreign_identity(last_view.clone(), || {
+                row_read.set(true);
+                successor.clone()
+            }),
+            last_view
+        );
+        assert!(
+            !row_read.get(),
+            "the row read must be skipped when a last-view identity exists"
+        );
+        // No-view fallback: the cleanup-instant row is the only evidence left
+        // (conservative best-effort — see `pin_abort_foreign_identity`).
+        assert_eq!(
+            pin_abort_foreign_identity(None, || successor.clone()),
+            successor
+        );
+        assert_eq!(pin_abort_foreign_identity(None, || None), None);
     }
 
     #[test]

--- a/src/services/discord/tui_direct_pending_start.rs
+++ b/src/services/discord/tui_direct_pending_start.rs
@@ -371,14 +371,13 @@ pub(super) type ViewFn = Box<
         + Sync,
 >;
 
-/// #3282: Discord-side cleanup the worker runs on the terminal backstop ABORT
-/// (`backstop_abort_foreign_inflight_live`). The anchor message earned a `⏳`
-/// lifecycle reaction when the synthetic start was created; an ABORT means no
-/// claim ever saves an inflight for this anchor, so the normal watcher/recovery
-/// `⏳ → ✅` completion never fires — without explicit cleanup the hourglass
-/// lingers forever. Provided by [`super::tui_prompt_relay`] (it owns the
-/// provider/command bot http — the SAME bot identity that added the `⏳`, per
-/// the #3164 add≡remove invariant).
+/// #3282/#3296: Discord-side reconcile hook the worker runs on the terminal
+/// backstop ABORT (`backstop_abort_foreign_inflight_live`). The input was
+/// already provider-submitted by this point, so the anchor KEEPS its `⏳`; the
+/// hook records a durable aborted-anchor marker
+/// ([`super::tui_direct_abort_marker`]) so a later prior-owner terminal commit
+/// flips it `⏳ → ✅`, or the TTL'd sweep flips it `⏳ → ⚠` when nothing ever
+/// covered it. Provided by [`super::tui_prompt_relay`].
 pub(super) type AbortCleanupFn = Box<
     dyn for<'a> Fn(
             &'a Arc<SharedData>,
@@ -391,9 +390,9 @@ pub(super) type AbortCleanupFn = Box<
 /// Spawn the DETACHED per-channel worker. Acquires the channel lock (FIFO
 /// serialization), polls the wait predicate until the prior turn finalizes (or
 /// the 8s backstop fires), runs the claim, and deletes the record. On the
-/// terminal backstop ABORT it runs `abort_cleanup_fn` (the anchor `⏳` cleanup —
-/// #3282) before dropping the record. Returns immediately so the observer loop
-/// is never blocked.
+/// terminal backstop ABORT it runs `abort_cleanup_fn` (the aborted-anchor
+/// marker record — #3282/#3296) before dropping the record. Returns immediately
+/// so the observer loop is never blocked.
 pub(super) fn spawn_worker(
     shared: Arc<SharedData>,
     record: TuiDirectPendingStart,
@@ -473,7 +472,12 @@ async fn run_worker(
                     // Surface an observability event and drop only the synthetic
                     // OWNERSHIP claim (the provider prompt was already submitted;
                     // the watcher/bridge still relays its output).
-                    tracing::error!(
+                    // #3296: WARN, not ERROR — this branch fires by definition
+                    // only when a FOREIGN inflight is live on the SAME channel,
+                    // i.e. the input was already submitted and usually merges
+                    // into the prior owner's turn (a normal outcome, not a
+                    // failure). The event key is load-bearing — never change it.
+                    tracing::warn!(
                         provider = %record.provider,
                         channel_id = record.channel_id,
                         tmux_session_name = %record.tmux_session_name,
@@ -481,12 +485,12 @@ async fn run_worker(
                         backstop_cycles,
                         waited_ms = worker_start.elapsed().as_millis(),
                         event = "tui_direct_pending_start.backstop_abort_foreign_inflight_live",
-                        "tui_direct_pending_start: prior inflight stayed LIVE across the backstop escalation budget; ABORTING the synthetic turn-start claim without overwriting the live prior turn (provider output still relays via the prior turn's owner)"
+                        "tui_direct_pending_start: prior inflight stayed LIVE across the backstop escalation budget; ABORTING the synthetic turn-start claim without overwriting the live prior turn — input already submitted; abort marker recorded, reconcile lands ✅ via prior-owner completion or ⚠ via TTL fallback (#3296)"
                     );
-                    // #3282: no claim will ever run for this anchor, so the
-                    // normal `⏳ → ✅` completion never fires — clean up the
-                    // anchor's `⏳` here (same bot identity as the add, #3164)
-                    // instead of leaving the hourglass stranded forever.
+                    // #3282/#3296: no claim will ever run for this anchor, so
+                    // the normal `⏳ → ✅` completion never fires — record the
+                    // durable aborted-anchor marker here (the anchor keeps its
+                    // ⏳; the watcher drain / TTL sweep own the reconcile).
                     abort_cleanup_fn(&shared, &record).await;
                     delete(&record);
                     return;
@@ -991,10 +995,11 @@ mod tests {
         assert_eq!(
             abort_cleanup_calls.load(Ordering::SeqCst),
             1,
-            "#3282: the terminal backstop ABORT must run the anchor reaction \
-             cleanup EXACTLY ONCE (removes the stranded ⏳ — no claim will ever \
-             drive the normal ⏳ → ✅ completion for this anchor). RED if the \
-             ABORT branch skips abort_cleanup_fn (the hourglass lingers forever)."
+            "#3282/#3296: the terminal backstop ABORT must run the abort \
+             reconcile hook EXACTLY ONCE (records the aborted-anchor marker — \
+             no claim will ever drive the normal ⏳ → ✅ completion for this \
+             anchor). RED if the ABORT branch skips abort_cleanup_fn (the \
+             hourglass would linger with no reconcile owner)."
         );
         reset_present_for_tests();
     }

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -1741,54 +1741,54 @@ fn pending_start_claim_fn() -> super::tui_direct_pending_start::ClaimFn {
     })
 }
 
-/// #3282: the worker's terminal-ABORT reaction cleanup. When the backstop
-/// escalation budget is exhausted (`backstop_abort_foreign_inflight_live`) no
-/// claim ever saves an inflight for this anchor, so the normal watcher/recovery
-/// `⏳ → ✅` completion never fires — without this cleanup the anchor's `⏳`
-/// lingers forever (observed live on msg 1514080986529533972). Remove the `⏳`
-/// and swap in a `⚠` failure marker so the abort is visible rather than a
-/// silent eternal hourglass (precedent: the watcher's auth-expired `⏳ → ⚠`
-/// swap in tmux_watcher.rs).
-///
-/// Bot identity (#3164 invariant): the `⏳` was added with THIS relay's
-/// `shared.serenity_http_or_token_fallback()` (the provider/command bot —
-/// see the `command_http` add in `relay_observed_prompt`), and
-/// `remove_reaction_raw` only removes `@me`'s reaction. Resolving the SAME
-/// source here guarantees the identical `@me` identity, so the removal targets
-/// exactly the reaction the add created. On unavailability we skip with a
-/// warning — removing with a different bot identity would silently no-op.
+/// #3296 (supersedes the #3282 `⏳ → ⚠` swap): the worker's terminal-ABORT
+/// reconcile hook. By the time the backstop ABORT fires the input was ALREADY
+/// provider-submitted (the abort drops only the synthetic OWNERSHIP claim), so
+/// the anchor's `⏳` is still TRUE — and every live observation ended with the
+/// prior owner relaying the response, so the old `⚠` swap branded ANSWERED
+/// messages as failures. Instead: KEEP the `⏳` and record a durable
+/// aborted-anchor marker. The watcher terminal-commit drain flips it `⏳ → ✅`
+/// once a same-(provider,tmux,channel) commit covers it; the placeholder
+/// sweeper flips it `⏳ → ⚠` only after the TTL with no live inflight — a
+/// genuine failure still surfaces in bounded time (the sweeper owns the
+/// reclaim, so no #3282 eternal-hourglass regression). The marker is recorded
+/// even when http is currently unavailable (better than the old skip-entirely
+/// path); every later reaction op resolves
+/// `shared.serenity_http_or_token_fallback()` INSIDE the marker module — the
+/// same bot identity that added the `⏳` (#3164 add≡remove).
 fn pending_start_abort_cleanup_fn() -> super::tui_direct_pending_start::AbortCleanupFn {
-    Box::new(|shared, record| {
+    Box::new(|_shared, record| {
         Box::pin(async move {
-            // Defensive: a corrupted durable record could carry a zero anchor id;
-            // `MessageId::new(0)` panics (mirrors the watcher's user_msg_id != 0
-            // guard before its reaction swaps).
+            // Defensive (I5): a corrupted durable record could carry a zero
+            // anchor id — `MessageId::new(0)` panics and a zero-id marker could
+            // never be reconciled. `record()` rejects it too; skip outright.
             if record.anchor_message_id == 0 {
                 return;
             }
-            let Some(http) = shared.serenity_http_or_token_fallback() else {
-                tracing::warn!(
+            let marker = super::tui_direct_abort_marker::AbortedAnchorMarker {
+                provider: record.provider.clone(),
+                channel_id: record.channel_id,
+                anchor_message_id: record.anchor_message_id,
+                tmux_session_name: record.tmux_session_name.clone(),
+                aborted_at_ms: chrono::Utc::now().timestamp_millis().max(0) as u64,
+                covered_at_ms: None,
+            };
+            match super::tui_direct_abort_marker::record(&marker) {
+                Ok(()) => tracing::info!(
                     provider = %record.provider,
                     channel_id = record.channel_id,
                     tmux_session_name = %record.tmux_session_name,
                     anchor_message_id = record.anchor_message_id,
-                    "tui_direct_pending_start: skipping anchor ⏳ abort cleanup; provider serenity \
-                     http unavailable (removing with a different bot identity would no-op — #3164)"
-                );
-                return;
-            };
-            let channel_id = ChannelId::new(record.channel_id);
-            let anchor_message_id = MessageId::new(record.anchor_message_id);
-            super::formatting::remove_reaction_raw(&http, channel_id, anchor_message_id, '⏳')
-                .await;
-            super::formatting::add_reaction_raw(&http, channel_id, anchor_message_id, '⚠').await;
-            tracing::info!(
-                provider = %record.provider,
-                channel_id = record.channel_id,
-                tmux_session_name = %record.tmux_session_name,
-                anchor_message_id = record.anchor_message_id,
-                "tui_direct_pending_start: removed the anchor ⏳ and marked ⚠ after the synthetic turn-start ABORT (#3282)"
-            );
+                    "tui_direct_pending_start: synthetic turn-start ABORTed; anchor keeps ⏳ and a durable aborted-anchor marker was recorded — reconcile lands ✅ on prior-owner completion or ⚠ via TTL fallback (#3296)"
+                ),
+                Err(error) => tracing::warn!(
+                    provider = %record.provider,
+                    channel_id = record.channel_id,
+                    anchor_message_id = record.anchor_message_id,
+                    error = %error,
+                    "tui_direct_pending_start: failed to persist the aborted-anchor marker; anchor ⏳ may linger until manual cleanup (#3296)"
+                ),
+            }
         })
     })
 }
@@ -5619,6 +5619,85 @@ mod tests {
             ExternalInputRelayOwner::TmuxWatcher,
             ExternalInputRelayOwner::TmuxWatcher,
         ));
+    }
+
+    /// #3296 (RED-3): the ABORT cleanup hook records a durable aborted-anchor
+    /// marker and NO LONGER applies any reaction itself — the old #3282 path
+    /// swapped `⏳ → ⚠` here, branding answered messages as failures. RED on
+    /// the pre-#3296 code: no marker module/store exists and a `⚠` is added.
+    /// (Reaction-op accounting lives in `tui_direct_abort_marker`'s own tests;
+    /// this hook performs Discord IO only through that module, never directly.)
+    #[test]
+    fn abort_cleanup_records_marker_and_keeps_hourglass() {
+        // Env-root setup mirrors `durable_restore_roundtrip_loads_fifo_order`;
+        // the guard stays in sync scope (block_on, no await_holding_lock site).
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        struct EnvReset(Option<std::ffi::OsString>);
+        impl Drop for EnvReset {
+            fn drop(&mut self) {
+                match self.0.take() {
+                    Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
+                    None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
+                }
+            }
+        }
+        let _env = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        let temp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+
+        let shared = super::super::make_shared_data_for_tests();
+        let record = super::super::tui_direct_pending_start::TuiDirectPendingStart {
+            provider: "claude".to_string(),
+            channel_id: 4242,
+            tmux_session_name: "tmux-4242".to_string(),
+            prompt_text: "/loop tick".to_string(),
+            anchor_message_id: 777_001,
+            lease_relay_owner: "bridge_adapter".to_string(),
+            lease_runtime_kind: Some("claude_tui".to_string()),
+            lease_turn_id: None,
+            lease_session_key: None,
+            generation: 0,
+            created_at_ms: 0,
+            observed_at_ms: 0,
+            state: super::super::tui_direct_pending_start::PendingStartState::Waiting,
+            attempt_count: 0,
+        };
+        let cleanup = pending_start_abort_cleanup_fn();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(cleanup(&shared, &record));
+
+        let markers = super::super::tui_direct_abort_marker::load_for_channel("claude", 4242);
+        assert_eq!(
+            markers.len(),
+            1,
+            "the ABORT hook must persist exactly one durable aborted-anchor \
+             marker — RED on the old ⚠-swap path (no marker store existed)"
+        );
+        assert_eq!(
+            markers[0].anchor_message_id, 777_001,
+            "identity-pinned (I4)"
+        );
+        assert_eq!(
+            markers[0].covered_at_ms, None,
+            "freshly-aborted anchors are uncovered until a terminal commit lands"
+        );
+
+        // Zero anchor id (I5): nothing recorded, nothing panics.
+        let zero = super::super::tui_direct_pending_start::TuiDirectPendingStart {
+            anchor_message_id: 0,
+            ..record
+        };
+        rt.block_on(cleanup(&shared, &zero));
+        assert_eq!(
+            super::super::tui_direct_abort_marker::load_for_channel("claude", 4242).len(),
+            1,
+            "a zero anchor id must never be recorded (I5)"
+        );
     }
 
     // #3018: the tmux_watchers registry is the SINGLE authority for

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -826,7 +826,7 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
                 anchor_message.id.get(),
             )
             .await;
-            if super::tui_direct_pending_start::should_defer_synthetic_turn_start(prior) {
+            if super::tui_direct_pending_start::should_defer_synthetic_turn_start(prior.view) {
                 deferred_synthetic_start = true;
                 defer_synthetic_turn_start(
                     shared,
@@ -1484,16 +1484,19 @@ async fn claim_tui_direct_synthetic_turn(
 // #3154 — deferred synthetic turn-start (off the observer loop)
 // ===========================================================================
 
-/// Build the [`PriorTurnView`](super::tui_direct_pending_start::PriorTurnView)
+/// Build the
+/// [`PriorTurnObservation`](super::tui_direct_pending_start::PriorTurnObservation)
 /// for the synthetic-start deferral decision: read inflight, mailbox, and the
-/// fresh runtime binding for this provider/channel/session.
+/// fresh runtime binding. Besides the pure decision view it carries the live
+/// FOREIGN inflight's identity (codex r2) so the worker can pin it on the
+/// aborted-anchor marker even when the row vanishes before the ABORT cleanup.
 async fn synthetic_start_prior_turn_view(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
     channel_id: ChannelId,
     tmux_session_name: &str,
     own_anchor_id: u64,
-) -> super::tui_direct_pending_start::PriorTurnView {
+) -> super::tui_direct_pending_start::PriorTurnObservation {
     let inflight = super::inflight::load_inflight_state(provider, channel_id.get());
     let inflight_present = inflight.is_some();
     let inflight_is_own_anchor = inflight
@@ -1504,6 +1507,10 @@ async fn synthetic_start_prior_turn_view(
                 && state.user_msg_id == own_anchor_id
         })
         .unwrap_or(false);
+    let foreign_inflight_identity = inflight
+        .as_ref()
+        .filter(|_| !inflight_is_own_anchor)
+        .map(|state| (state.user_msg_id, state.started_at.clone()));
 
     let snapshot = super::mailbox_snapshot(shared, channel_id).await;
     // A BACKGROUND turn (monitor relay / self-paced loop) does not block — only a
@@ -1518,12 +1525,15 @@ async fn synthetic_start_prior_turn_view(
         crate::services::tui_prompt_dedupe::runtime_binding_for_tmux_session(tmux_session_name)
             .is_some();
 
-    super::tui_direct_pending_start::PriorTurnView {
-        inflight_present,
-        inflight_is_own_anchor,
-        mailbox_blocking_turn_present,
-        mailbox_turn_is_own_anchor,
-        runtime_binding_present,
+    super::tui_direct_pending_start::PriorTurnObservation {
+        view: super::tui_direct_pending_start::PriorTurnView {
+            inflight_present,
+            inflight_is_own_anchor,
+            mailbox_blocking_turn_present,
+            mailbox_turn_is_own_anchor,
+            runtime_binding_present,
+        },
+        foreign_inflight_identity,
     }
 }
 
@@ -1742,23 +1752,23 @@ fn pending_start_claim_fn() -> super::tui_direct_pending_start::ClaimFn {
 }
 
 /// #3296 (supersedes the #3282 `⏳ → ⚠` swap): the worker's terminal-ABORT
-/// reconcile hook. By the time the backstop ABORT fires the input was ALREADY
-/// provider-submitted (the abort drops only the synthetic OWNERSHIP claim), so
-/// the anchor's `⏳` is still TRUE — and every live observation ended with the
-/// prior owner relaying the response, so the old `⚠` swap branded ANSWERED
-/// messages as failures. Instead: KEEP the `⏳` and record a durable
-/// aborted-anchor marker pinning the live FOREIGN prior inflight's identity
-/// (codex r1). The watcher terminal-commit drain flips it `⏳ → ✅` ONLY when
-/// THAT turn commits (positive correlation — no unrelated same-session commit
-/// can cover); the placeholder sweeper flips it `⏳ → ⚠` after the TTL with no
-/// holding inflight (hard-cap bounded) — a genuine failure still surfaces in
-/// bounded time (the sweeper owns the reclaim, so no #3282 eternal-hourglass
-/// regression). The marker is recorded even when http is currently unavailable
-/// (better than the old skip-entirely path); every later reaction op resolves
-/// `shared.serenity_http_or_token_fallback()` INSIDE the marker module — the
-/// same bot identity that added the `⏳` (#3164 add≡remove).
+/// reconcile hook. The input was ALREADY provider-submitted by ABORT time (the
+/// abort drops only the synthetic OWNERSHIP claim), so the anchor's `⏳` is
+/// still TRUE — the old `⚠` swap branded ANSWERED messages as failures. So:
+/// KEEP the `⏳` and record a durable aborted-anchor marker pinning the
+/// FOREIGN prior inflight's identity (codex r1) — the live row at the record
+/// instant, or the worker's last-view identity when that row just vanished
+/// (codex r2). The marker is ALWAYS uncovered unless a commit tombstone proves
+/// the prior owner committed (`record_for_abort`'s 대조 — bare row-absence is
+/// never promoted to a cover; a force-clear/stop/recovery deletion correctly
+/// leaves it uncovered). The watcher drain flips it `⏳ → ✅` ONLY when THAT
+/// turn commits; the sweeper flips it `⏳ → ⚠` after the TTL with no holding
+/// inflight (hard-cap bounded — no #3282 eternal-hourglass regression). The
+/// marker is recorded even when http is currently unavailable; every later
+/// reaction op resolves `shared.serenity_http_or_token_fallback()` INSIDE the
+/// marker module — the same bot identity that added the `⏳` (#3164).
 fn pending_start_abort_cleanup_fn() -> super::tui_direct_pending_start::AbortCleanupFn {
-    Box::new(|_shared, record| {
+    Box::new(|_shared, record, last_view_foreign| {
         Box::pin(async move {
             // Defensive (I5): a corrupted durable record could carry a zero
             // anchor id — `MessageId::new(0)` panics and a zero-id marker could
@@ -1766,34 +1776,31 @@ fn pending_start_abort_cleanup_fn() -> super::tui_direct_pending_start::AbortCle
             if record.anchor_message_id == 0 {
                 return;
             }
-            // codex r1: load the foreign prior inflight AT the record instant.
-            // Present → its `(user_msg_id, started_at)` is pinned on the
-            // marker. Gone → it terminal-committed in the µs gap since the
-            // final backstop view read (which saw it LIVE) — that commit's
-            // drain chokepoint may predate this marker, so `for_abort`
-            // records the marker pre-covered (the sweep delivers the ✅).
+            // codex r2: prefer the row's identity AT the record instant; when
+            // the row is gone (it vanished in the µs gap since the final
+            // backstop view), fall back to the worker's last-view identity so
+            // the tombstone 대조 can still decide ✅ vs ⚠ for the marker.
             let foreign = ProviderKind::from_str(&record.provider)
                 .and_then(|provider| {
                     super::inflight::load_inflight_state(&provider, record.channel_id)
                 })
-                .map(|state| (state.user_msg_id, state.started_at));
-            let marker = super::tui_direct_abort_marker::AbortedAnchorMarker::for_abort(
+                .map(|state| (state.user_msg_id, state.started_at))
+                .or(last_view_foreign);
+            match super::tui_direct_abort_marker::record_for_abort(
                 record.provider.clone(),
                 record.channel_id,
                 record.anchor_message_id,
                 record.tmux_session_name.clone(),
-                chrono::Utc::now().timestamp_millis().max(0) as u64,
                 foreign,
-            );
-            match super::tui_direct_abort_marker::record(&marker) {
-                Ok(()) => tracing::info!(
+            ) {
+                Ok(marker) => tracing::info!(
                     provider = %record.provider,
                     channel_id = record.channel_id,
                     tmux_session_name = %record.tmux_session_name,
                     anchor_message_id = record.anchor_message_id,
                     foreign_user_msg_id = ?marker.foreign_user_msg_id,
-                    pre_covered = marker.covered_at_ms.is_some(),
-                    "tui_direct_pending_start: synthetic turn-start ABORTed; anchor keeps ⏳ and a durable aborted-anchor marker was recorded — reconcile lands ✅ on the recorded foreign turn's commit (pre-covered when it already committed) or ⚠ via the sweep bound (#3296)"
+                    tombstone_covered = marker.covered_at_ms.is_some(),
+                    "tui_direct_pending_start: synthetic turn-start ABORTed; anchor keeps ⏳ and a durable aborted-anchor marker was recorded — reconcile lands ✅ on the recorded foreign turn's commit (tombstone-covered when it already committed) or ⚠ via the sweep bound (#3296)"
                 ),
                 Err(error) => tracing::warn!(
                     provider = %record.provider,
@@ -5639,15 +5646,21 @@ mod tests {
     /// marker and NO LONGER applies any reaction itself — the old #3282 path
     /// swapped `⏳ → ⚠` here, branding answered messages as failures. RED on
     /// the pre-#3296 code: no marker module/store exists and a `⚠` is added.
+    /// codex r2 reverses the r1 tail: with the foreign row gone at the record
+    /// instant the marker must pin the worker's LAST-VIEW identity and stay
+    /// UNCOVERED unless a commit tombstone proves the deletion was a commit —
+    /// RED on the r1 code (row-absence alone pre-covered the marker, false-✅
+    /// ing force-cleared unanswered anchors).
     /// (Reaction-op accounting lives in `tui_direct_abort_marker`'s own tests;
     /// this hook performs Discord IO only through that module, never directly.)
     #[test]
     fn abort_cleanup_records_marker_and_keeps_hourglass() {
-        // Durable-root injection via the marker module's THREAD-LOCAL test
-        // seam (never the process-global `AGENTDESK_ROOT_DIR` env — mutating
-        // it races env-reading tests that hold no lock, e.g. the pending-start
-        // worker tests' `persist()`). The current-thread `block_on` below keeps
-        // the cleanup future on this thread so the override resolves inside it.
+        // Durable BASE-root injection via the marker module's THREAD-LOCAL
+        // test seam (never the process-global `AGENTDESK_ROOT_DIR` env —
+        // mutating it races env-reading tests that hold no lock, e.g. the
+        // pending-start worker tests' `persist()`). The current-thread
+        // `block_on` below keeps the cleanup future on this thread so the
+        // override resolves inside it.
         struct RootReset;
         impl Drop for RootReset {
             fn drop(&mut self) {
@@ -5657,7 +5670,7 @@ mod tests {
         let _root_reset = RootReset;
         let temp = tempfile::tempdir().unwrap();
         super::super::tui_direct_abort_marker::set_test_root_override(Some(
-            temp.path().join("discord_tui_direct_abort_marker"),
+            temp.path().to_path_buf(),
         ));
 
         let shared = super::super::make_shared_data_for_tests();
@@ -5682,7 +5695,11 @@ mod tests {
             .enable_all()
             .build()
             .unwrap();
-        rt.block_on(cleanup(&shared, &record));
+        // No inflight row exists for this channel in the test env (the row
+        // vanished post-final-view); the worker's last-view identity is what
+        // the marker must pin (codex r2).
+        let last_view = Some((888_777_u64, "2026-06-10 12:00:00".to_string()));
+        rt.block_on(cleanup(&shared, &record, last_view.clone()));
 
         let markers = super::super::tui_direct_abort_marker::load_for_channel("claude", 4242);
         assert_eq!(
@@ -5695,17 +5712,42 @@ mod tests {
             markers[0].anchor_message_id, 777_001,
             "identity-pinned (I4)"
         );
-        // codex r1: no inflight row exists for this channel in the test env,
-        // i.e. the foreign prior turn is ALREADY GONE at the record instant —
-        // the hook must record the marker PRE-COVERED with no pinned identity
-        // (the prior owner's commit raced ahead of the marker; the sweep
-        // delivers the ✅). The live-foreign branch (identity pinned,
-        // uncovered) is pinned by `for_abort_pins_identity_or_records_pre_covered`
-        // in the marker module's own tests.
-        assert_eq!(markers[0].foreign_user_msg_id, None);
-        assert!(
-            markers[0].covered_at_ms.is_some(),
-            "foreign row absent at the record instant ⇒ pre-covered (codex r1)"
+        assert_eq!(
+            markers[0].foreign_user_msg_id,
+            Some(888_777),
+            "row gone at the record instant ⇒ the LAST-VIEW identity is pinned \
+             (codex r2) — RED if None (the marker would be sweep-only)"
+        );
+        assert_eq!(
+            markers[0].covered_at_ms, None,
+            "no commit tombstone ⇒ UNCOVERED (codex r2 — RED on the r1 \
+             pre-covered promotion: bare row-absence is not commit evidence)"
+        );
+
+        // With a commit tombstone matching the last-view identity, the same
+        // row-gone abort records COVERED (evidence-backed — the deletion WAS
+        // the prior owner's terminal commit).
+        super::super::tui_direct_abort_marker::record_commit_tombstone_at(
+            55_000,
+            "claude",
+            "tmux-4242",
+            4242,
+            888_777,
+            "2026-06-10 12:00:00",
+        );
+        let record_b = super::super::tui_direct_pending_start::TuiDirectPendingStart {
+            anchor_message_id: 777_002,
+            ..record.clone()
+        };
+        rt.block_on(cleanup(&shared, &record_b, last_view));
+        let covered = super::super::tui_direct_abort_marker::load_for_channel("claude", 4242)
+            .into_iter()
+            .find(|m| m.anchor_message_id == 777_002)
+            .expect("second marker recorded");
+        assert_eq!(
+            covered.covered_at_ms,
+            Some(55_000),
+            "matching tombstone at record time ⇒ evidence-backed cover (r2)"
         );
 
         // Zero anchor id (I5): nothing recorded, nothing panics.
@@ -5713,10 +5755,10 @@ mod tests {
             anchor_message_id: 0,
             ..record
         };
-        rt.block_on(cleanup(&shared, &zero));
+        rt.block_on(cleanup(&shared, &zero, None));
         assert_eq!(
             super::super::tui_direct_abort_marker::load_for_channel("claude", 4242).len(),
-            1,
+            2,
             "a zero anchor id must never be recorded (I5)"
         );
     }

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -1756,17 +1756,15 @@ fn pending_start_claim_fn() -> super::tui_direct_pending_start::ClaimFn {
 /// abort drops only the synthetic OWNERSHIP claim), so the anchor's `⏳` is
 /// still TRUE — the old `⚠` swap branded ANSWERED messages as failures. So:
 /// KEEP the `⏳` and record a durable aborted-anchor marker pinning the
-/// FOREIGN prior inflight's identity (codex r1) — the live row at the record
-/// instant, or the worker's last-view identity when that row just vanished
-/// (codex r2). The marker is ALWAYS uncovered unless a commit tombstone proves
-/// the prior owner committed (`record_for_abort`'s 대조 — bare row-absence is
-/// never promoted to a cover; a force-clear/stop/recovery deletion correctly
-/// leaves it uncovered). The watcher drain flips it `⏳ → ✅` ONLY when THAT
-/// turn commits; the sweeper flips it `⏳ → ⚠` after the TTL with no holding
-/// inflight (hard-cap bounded — no #3282 eternal-hourglass regression). The
-/// marker is recorded even when http is currently unavailable; every later
-/// reaction op resolves `shared.serenity_http_or_token_fallback()` INSIDE the
-/// marker module — the same bot identity that added the `⏳` (#3164).
+/// FOREIGN prior inflight's identity — the worker's LAST-VIEW identity first,
+/// the cleanup-instant row only as the no-view fallback (codex r3,
+/// `pin_abort_foreign_identity`). The marker stays uncovered unless a commit
+/// tombstone proves the prior owner committed (`record_for_abort`'s 대조;
+/// force-clear/stop/recovery deletions stay uncovered). The watcher drain
+/// flips it `⏳ → ✅` ONLY when THAT turn commits; the sweeper flips it
+/// `⏳ → ⚠` after the TTL with no holding inflight (hard-cap bounded).
+/// Recorded even when http is unavailable; every later reaction op resolves
+/// the shared http INSIDE the marker module — the add≡remove identity (#3164).
 fn pending_start_abort_cleanup_fn() -> super::tui_direct_pending_start::AbortCleanupFn {
     Box::new(|_shared, record, last_view_foreign| {
         Box::pin(async move {
@@ -1776,16 +1774,18 @@ fn pending_start_abort_cleanup_fn() -> super::tui_direct_pending_start::AbortCle
             if record.anchor_message_id == 0 {
                 return;
             }
-            // codex r2: prefer the row's identity AT the record instant; when
-            // the row is gone (it vanished in the µs gap since the final
-            // backstop view), fall back to the worker's last-view identity so
-            // the tombstone 대조 can still decide ✅ vs ⚠ for the marker.
-            let foreign = ProviderKind::from_str(&record.provider)
-                .and_then(|provider| {
-                    super::inflight::load_inflight_state(&provider, record.channel_id)
-                })
-                .map(|state| (state.user_msg_id, state.started_at))
-                .or(last_view_foreign);
+            // codex r3: LAST-VIEW first — a SUCCESSOR row may hold the slot by
+            // now (prior row committed); the row read is a lazy fallback only.
+            let foreign = super::tui_direct_pending_start::pin_abort_foreign_identity(
+                last_view_foreign,
+                || {
+                    ProviderKind::from_str(&record.provider)
+                        .and_then(|provider| {
+                            super::inflight::load_inflight_state(&provider, record.channel_id)
+                        })
+                        .map(|state| (state.user_msg_id, state.started_at))
+                },
+            );
             match super::tui_direct_abort_marker::record_for_abort(
                 record.provider.clone(),
                 record.channel_id,

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -1747,13 +1747,14 @@ fn pending_start_claim_fn() -> super::tui_direct_pending_start::ClaimFn {
 /// the anchor's `⏳` is still TRUE — and every live observation ended with the
 /// prior owner relaying the response, so the old `⚠` swap branded ANSWERED
 /// messages as failures. Instead: KEEP the `⏳` and record a durable
-/// aborted-anchor marker. The watcher terminal-commit drain flips it `⏳ → ✅`
-/// once a same-(provider,tmux,channel) commit covers it; the placeholder
-/// sweeper flips it `⏳ → ⚠` only after the TTL with no live inflight — a
-/// genuine failure still surfaces in bounded time (the sweeper owns the
-/// reclaim, so no #3282 eternal-hourglass regression). The marker is recorded
-/// even when http is currently unavailable (better than the old skip-entirely
-/// path); every later reaction op resolves
+/// aborted-anchor marker pinning the live FOREIGN prior inflight's identity
+/// (codex r1). The watcher terminal-commit drain flips it `⏳ → ✅` ONLY when
+/// THAT turn commits (positive correlation — no unrelated same-session commit
+/// can cover); the placeholder sweeper flips it `⏳ → ⚠` after the TTL with no
+/// holding inflight (hard-cap bounded) — a genuine failure still surfaces in
+/// bounded time (the sweeper owns the reclaim, so no #3282 eternal-hourglass
+/// regression). The marker is recorded even when http is currently unavailable
+/// (better than the old skip-entirely path); every later reaction op resolves
 /// `shared.serenity_http_or_token_fallback()` INSIDE the marker module — the
 /// same bot identity that added the `⏳` (#3164 add≡remove).
 fn pending_start_abort_cleanup_fn() -> super::tui_direct_pending_start::AbortCleanupFn {
@@ -1765,21 +1766,34 @@ fn pending_start_abort_cleanup_fn() -> super::tui_direct_pending_start::AbortCle
             if record.anchor_message_id == 0 {
                 return;
             }
-            let marker = super::tui_direct_abort_marker::AbortedAnchorMarker {
-                provider: record.provider.clone(),
-                channel_id: record.channel_id,
-                anchor_message_id: record.anchor_message_id,
-                tmux_session_name: record.tmux_session_name.clone(),
-                aborted_at_ms: chrono::Utc::now().timestamp_millis().max(0) as u64,
-                covered_at_ms: None,
-            };
+            // codex r1: load the foreign prior inflight AT the record instant.
+            // Present → its `(user_msg_id, started_at)` is pinned on the
+            // marker. Gone → it terminal-committed in the µs gap since the
+            // final backstop view read (which saw it LIVE) — that commit's
+            // drain chokepoint may predate this marker, so `for_abort`
+            // records the marker pre-covered (the sweep delivers the ✅).
+            let foreign = ProviderKind::from_str(&record.provider)
+                .and_then(|provider| {
+                    super::inflight::load_inflight_state(&provider, record.channel_id)
+                })
+                .map(|state| (state.user_msg_id, state.started_at));
+            let marker = super::tui_direct_abort_marker::AbortedAnchorMarker::for_abort(
+                record.provider.clone(),
+                record.channel_id,
+                record.anchor_message_id,
+                record.tmux_session_name.clone(),
+                chrono::Utc::now().timestamp_millis().max(0) as u64,
+                foreign,
+            );
             match super::tui_direct_abort_marker::record(&marker) {
                 Ok(()) => tracing::info!(
                     provider = %record.provider,
                     channel_id = record.channel_id,
                     tmux_session_name = %record.tmux_session_name,
                     anchor_message_id = record.anchor_message_id,
-                    "tui_direct_pending_start: synthetic turn-start ABORTed; anchor keeps ⏳ and a durable aborted-anchor marker was recorded — reconcile lands ✅ on prior-owner completion or ⚠ via TTL fallback (#3296)"
+                    foreign_user_msg_id = ?marker.foreign_user_msg_id,
+                    pre_covered = marker.covered_at_ms.is_some(),
+                    "tui_direct_pending_start: synthetic turn-start ABORTed; anchor keeps ⏳ and a durable aborted-anchor marker was recorded — reconcile lands ✅ on the recorded foreign turn's commit (pre-covered when it already committed) or ⚠ via the sweep bound (#3296)"
                 ),
                 Err(error) => tracing::warn!(
                     provider = %record.provider,
@@ -5681,9 +5695,17 @@ mod tests {
             markers[0].anchor_message_id, 777_001,
             "identity-pinned (I4)"
         );
-        assert_eq!(
-            markers[0].covered_at_ms, None,
-            "freshly-aborted anchors are uncovered until a terminal commit lands"
+        // codex r1: no inflight row exists for this channel in the test env,
+        // i.e. the foreign prior turn is ALREADY GONE at the record instant —
+        // the hook must record the marker PRE-COVERED with no pinned identity
+        // (the prior owner's commit raced ahead of the marker; the sweep
+        // delivers the ✅). The live-foreign branch (identity pinned,
+        // uncovered) is pinned by `for_abort_pins_identity_or_records_pre_covered`
+        // in the marker module's own tests.
+        assert_eq!(markers[0].foreign_user_msg_id, None);
+        assert!(
+            markers[0].covered_at_ms.is_some(),
+            "foreign row absent at the record instant ⇒ pre-covered (codex r1)"
         );
 
         // Zero anchor id (I5): nothing recorded, nothing panics.

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -5629,23 +5629,22 @@ mod tests {
     /// this hook performs Discord IO only through that module, never directly.)
     #[test]
     fn abort_cleanup_records_marker_and_keeps_hourglass() {
-        // Env-root setup mirrors `durable_restore_roundtrip_loads_fifo_order`;
-        // the guard stays in sync scope (block_on, no await_holding_lock site).
-        let _lock = crate::config::shared_test_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        struct EnvReset(Option<std::ffi::OsString>);
-        impl Drop for EnvReset {
+        // Durable-root injection via the marker module's THREAD-LOCAL test
+        // seam (never the process-global `AGENTDESK_ROOT_DIR` env — mutating
+        // it races env-reading tests that hold no lock, e.g. the pending-start
+        // worker tests' `persist()`). The current-thread `block_on` below keeps
+        // the cleanup future on this thread so the override resolves inside it.
+        struct RootReset;
+        impl Drop for RootReset {
             fn drop(&mut self) {
-                match self.0.take() {
-                    Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
-                    None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
-                }
+                super::super::tui_direct_abort_marker::set_test_root_override(None);
             }
         }
-        let _env = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        let _root_reset = RootReset;
         let temp = tempfile::tempdir().unwrap();
-        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+        super::super::tui_direct_abort_marker::set_test_root_override(Some(
+            temp.path().join("discord_tui_direct_abort_marker"),
+        ));
 
         let shared = super::super::make_shared_data_for_tests();
         let record = super::super::tui_direct_pending_start::TuiDirectPendingStart {


### PR DESCRIPTION
## 요약 (#3296)

synthetic turn-start이 FOREIGN inflight 충돌로 ABORT할 때, 기존 #3282 청소 경로는 anchor의 ⏳를 제거하고 ⚠를 부착했다. 그러나 ABORT 시점에 입력은 이미 provider에 제출된 상태(`tui_direct_pending_start.rs` — abort는 synthetic OWNERSHIP claim만 폐기)이고, 관찰된 전 건이 prior owner 경유로 정상 응답됨 — 응답된 메시지에 ⚠가 영구 잔존해 실패로 오인됐다.

**채택 설계: 후보 ①+③ 조합 (② 기각).**

## 변경 내용

1. **신규 모듈 `tui_direct_abort_marker.rs`** (ratchet 미등재 신규 파일): durable `AbortedAnchorMarker` store (`runtime/discord_tui_direct_abort_marker/`, `critical_atomic_write`) + 순수 판정 함수 `decide_marker_disposition` / `terminal_commit_covers_marker` + `ReactionApplierFn` boxed-fn 주입.
2. **ABORT 청소 경로 개편** (`tui_prompt_relay.rs` `pending_start_abort_cleanup_fn`): "⏳ 제거+⚠ 부착" → "⏳ 유지 + durable marker 기록". http 가용성과 무관하게 marker 먼저 기록(기존 http-unavailable skip-entirely보다 개선). zero-id guard(I5) 유지.
3. **watcher terminal-commit 초크포인트** (`tmux_watcher.rs` ~11051, 완료 분기 직후): `terminal_output_committed && tui_direct_anchor_terminal_body_visible && !lifecycle_stage_paused` 가드 하에 같은 (provider,tmux,channel)의 정상 commit 시 marker 드레인 → ⏳→✅ (10:52형 커버). commit 시각은 `aborted_at` 초과 + TTL 이내만 인정(세션 재생성 후 무관 commit ✅ 오발화 차단 — SC2/R3).
4. **placeholder sweeper TTL 폴백** (`placeholder_sweeper.rs`, `status_panel_orphan_store::drain` 동형): TTL(600s) 경과 + 해당 세션 live inflight 부재 시에만 ⏳→⚠ — 진짜 실패에 ⚠ 보장, #3282(영원한 모래시계) 회귀 차단(sweeper가 회수 소유자). covered marker는 ✅ 재시도. 하트비트 로그에 `drained_abort_markers` 추가.
5. **ERROR→WARN 강등** (`tui_direct_pending_start.rs`): `backstop_abort_foreign_inflight_live`는 정의상 "FOREIGN inflight live + 같은 채널"에서만 발화(정상 합류 가능성 높음) — event 키 문자열 불변(I9). `claim_retry_exhausted`는 ERROR 유지(프롬프트 유실 인접).

## 불변식 준수

- **I1 (#3164 add≡remove)**: 신규 리액션 op 3종(⏳ remove / ✅ add / ⚠ add) 전부 모듈 내부에서 `shared.serenity_http_or_token_fallback()`만 해석. 헬퍼가 http 파라미터를 받지 않아 watcher http / sweeper 부트스트랩 http 오용이 타입 차원에서 불가.
- **I2 (#3154 no-overwrite)**: 드레인/스윕은 리액션과 marker 파일만 만진다 — inflight/mailbox/lease/anchor 슬롯 무접촉.
- **I3 (no-prompt-loss)**: pending-start record의 delete 계약 불변; transient claim 실패 시 record 보존(:529-545) 무변경.
- **I4 (#3174 turn-identity pin)**: 모든 ✅/⚠ 교정은 `marker.anchor_message_id` 핀 대상만 — 공유 `prompt_anchor_by_tmux` 슬롯 재독 금지(R3 aliasing 차단).
- **I5 (zero-id guard)**: `record()`가 zero id 거부 + cleanup hook/스윕에서 별도 가드.
- **I6 (fail-open)**: http 불가/전달 실패 시 marker 보존(covering commit은 `covered_at` 스탬프 → 스윕이 ✅ 재시도, ⚠ 강등 절대 불가).
- **I7 (⚠ 전역 시맨틱)**: 다른 4개 ⚠ 사이트(tmux_watcher:8084/8357/8524, turn_bridge:7816) 비대상 — 교정 스코프는 marker 존재로만 한정.
- **I8 (giant ratchet)**: tui_prompt_relay.rs 5417 (baseline 5438 내 중립), mod.rs 4986 (≤4987). tmux_watcher.rs 9583→9600 인상은 toml 주석에 #3296 사유 명기(설계 명시 허용 절차; 신규 로직 본체는 ratchet 미등재 신규 파일).
- **I9 (observability)**: `event=tui_direct_pending_start.backstop_abort_foreign_inflight_live` 문자열 불변 — 레벨만 ERROR→WARN.
- **I10 (보수적 커버 판정)**: ✅는 body-visible 정상 commit && commit>aborted_at && TTL 이내만; ⚠는 TTL 경과 && live inflight 부재만 — long-turn 진행 중 오⚠ 금지, 진짜 실패는 유계 시간(TTL 600s + 초기지연 180s + 주기 30s) 내 ⚠ 도달.
- **I11 (presence gate 무간섭)**: marker는 `pending_synthetic_start_present` 게이트에 불참 — ABORT 후 채널 즉시 정상 운용.

## 오교정 방어 (adversarial self-check)

- **SC1 (⏳ 유지가 #3282 재림?)**: durable marker + sweeper TTL이 재시작 생존 포함 ✅/⚠ 중 하나로 유계 수렴. #3282 원인은 '회수 소유자 부재'였고 이제 sweeper가 소유자.
- **SC2 (terminal-commit 드레인이 미응답 anchor에 ✅?)**: 기존 14:32형 shared-slot ✅가 이미 수용한 동일 위험 클래스(신규 위험 아님). identity-pin(I4) + `aborted_at` 초과 + TTL 바운드 + body-visible 정상 commit 가드로 한정.
- **SC3 (봇 정체성)**: applier가 http를 인자로 받지 않으므로 비대칭(#3164) 원천 차단; http 불가 시 marker 보존(I6).

## 테스트 (RED→GREEN 양방향)

- **RED-1 (커버됨→✅)**: `drain_on_terminal_commit_completes_covered_marker` — ⏳remove+✅add 1회 동일 핀 id, ⚠ 0회, marker 삭제.
- **RED-2 (안 커버됨→⚠ 유지)**: `sweep_holds_while_live_inflight_present`(보류) / `sweep_warns_after_ttl_without_inflight`(⚠ 1회+삭제) / `sweep_preserves_all_when_http_unavailable`(I6).
- **RED-3 (abort 경로 전환)**: `abort_cleanup_records_marker_and_keeps_hourglass` — marker 존재 + 리액션 직접 미적용 + zero-id 거부.
- **RED-4 (진실표)**: `decide_marker_disposition_truth_table` — {ttl}×{live inflight}×{covered}×{http} 전 조합.
- **경계**: `terminal_commit_cover_requires_post_abort_within_ttl`(strictly-after + TTL 바운드 + zero-id), `drain_skips_foreign_session_and_pre_abort_commit`(I4), `failed_delivery_stamps_covered_and_sweep_retries_completion`(I6 → ✅ 재시도, TTL 초과에도 ⚠ 불가), `sweep_is_provider_scoped`, `durable_roundtrip_survives_reload`(재시작 생존), `record_rejects_zero_anchor_id`(I5).
- **회귀 가드(green 유지)**: `backstop_foreign_inflight_live_aborts_without_claim` abort_cleanup 정확히 1회, `claim_false_*` 2종 record 보존(I3), `channel_a_defers...` 무변경 통과.
- 테스트 격리: marker store root는 thread-local `TEST_ROOT_OVERRIDE` 시임으로 주입(`AGENTDESK_ROOT_DIR` env 비변조 — env 변조는 lock 없이 root를 읽는 pending-start worker 테스트와 경합 발생 확인되어 배제, `TEST_TMUX_ALIVE_OVERRIDE` 선례).

## CI 게이트

- `cargo fmt --check` ✅ / `cargo check --lib --tests` (warning 0) ✅ / `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --lib` — 관련 모듈(tui_direct_abort_marker 11 + tui_direct_pending_start 14 + relay RED-3 + sweeper) 전부 ✅. 풀 스위트의 12개 실패는 origin/main 베이스라인과 **동일 집합**으로 확인된 머신-로컬 선재 플레이크(cli::doctor 모듈-로컬 env lock이 crate 공유 lock과 분리되어 발생하는 poison 캐스케이드 — main 7c1356a07에서 동일 재현, 본 변경과 무관).
- `audit_maintainability --check` ✅ (tmux_watcher 9600 인상 toml 주석 명기, tui_prompt_relay 5417 중립)
- `check_await_holding_lock_ratchet` ✅ (34, 신규 allow 사이트 0)
- `generate_inventory_docs` + `check_agent_maintenance_docs` ✅ (change-surfaces 동기화 + multinode-transition #3296 worker-local 노트)

Closes #3296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
