### PR TITLE
fix(#3306): self-heal idle-relay registry/dedupe-mirror drift on routine sessions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -501,6 +501,7 @@ src/
 │   │   ├── idle_detector.rs
 │   │   ├── idle_recap.rs
 │   │   ├── idle_recap_interaction.rs
+│   │   ├── idle_relay_drift.rs
 │   │   ├── inflight.rs
 │   │   ├── inflight_heartbeat_sweeper.rs
 │   │   ├── internal_api.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -8,7 +8,7 @@
 > [`docs/generated/giant-file-registry.md`](../generated/giant-file-registry.md);
 > the rows below project the operational meaning of each entry.
 >
-> Last refreshed: 2026-06-11 (against #3303 deferred-claim anchor reconcile — the `tui_direct_abort_marker` module is decomposed into a directory module of `mod.rs` + `store.rs` + `deferred_claim.rs`, all non-giant, and a successful watcher-owned deferred claim now records an own-identity `DeferredClaim` marker so the anchor's `⏳` converges to `✅` on the own commit or a bounded sweep `⚠`; tmux_watcher / tui_prompt_relay / health recovery / placeholder_sweeper are 0-line changes; on top of #3216 resume-protection residual gaps on top of #3207 — session_runtime now adds a SAFE legacy NULL-channel_id fallback to the channel-scoped cwd resolves via resolve_cwd_for_session_key honored only for a single legacy row, plus a live-tmux recovery-cwd reconcile in auto_restore_session_force via reconcile_recovery_cwd and correct_session_cwd_to_tmux that adopts the live pane cwd over a divergent DB cwd and self-heals the row; #3207 comprehensive channel_id scoping of session-cwd DB resolves — auto_restore_session_force restart restore via restore_session_cwd_from_db and watcher recovery via load_restored_session_cwd require channel_id = $2; on top of #3105 dead/orphaned TUI-session mirror eviction made flake-resistant and run off the Tokio executor).
+> Last refreshed: 2026-06-11 (against #3306 idle-relay registry/dedupe-mirror drift self-heal — new non-giant `src/services/discord/idle_relay_drift.rs` rate-limits the per-session drift WARN and one-shot self-heals the authoritative registry from a DURABLE source — the settings binding or the `sessions.channel_id` durable column via the new `load_session_channel_id_pg` — guarded by live-pane + instance-id + mirror-agreement so #3018's single-authority / never-route-from-mirror invariant holds; `tui_prompt_relay.rs` net 0-line at the 5429 freeze, `mod.rs` +1 to the 4987 freeze, `db/dispatched_sessions.rs` +48; on top of #3303 deferred-claim anchor reconcile — the `tui_direct_abort_marker` module is decomposed into a directory module of `mod.rs` + `store.rs` + `deferred_claim.rs`, all non-giant, and a successful watcher-owned deferred claim now records an own-identity `DeferredClaim` marker so the anchor's `⏳` converges to `✅` on the own commit or a bounded sweep `⚠`; tmux_watcher / tui_prompt_relay / health recovery / placeholder_sweeper are 0-line changes; on top of #3216 resume-protection residual gaps on top of #3207 — session_runtime now adds a SAFE legacy NULL-channel_id fallback to the channel-scoped cwd resolves via resolve_cwd_for_session_key honored only for a single legacy row, plus a live-tmux recovery-cwd reconcile in auto_restore_session_force via reconcile_recovery_cwd and correct_session_cwd_to_tmux that adopts the live pane cwd over a divergent DB cwd and self-heals the row; #3207 comprehensive channel_id scoping of session-cwd DB resolves — auto_restore_session_force restart restore via restore_session_cwd_from_db and watcher recovery via load_restored_session_cwd require channel_id = $2; on top of #3105 dead/orphaned TUI-session mirror eviction made flake-resistant and run off the Tokio executor).
 
 ## Read This First
 
@@ -958,8 +958,9 @@
   - `src/db/kanban_cards/` (1932 total lines; kanban card persistence and
     GitHub sync lookup surface).
   - `src/db/postgres.rs` (1018 lines).
-  - `src/db/dispatched_sessions.rs` (1562 lines; dispatched session
-    persistence helpers).
+  - `src/db/dispatched_sessions.rs` (1610 lines; dispatched session
+    persistence helpers. #3306: +48 for the narrow `load_session_channel_id_pg`
+    durable-truth accessor the idle-relay drift self-heal reads).
   - `src/db/session_transcripts.rs` is a retained PG-cleanup surface (now below
     the giant-file threshold; bugfix only).
   - `src/db/prompt_manifests/` (directory, refactored).

--- a/src/db/dispatched_sessions.rs
+++ b/src/db/dispatched_sessions.rs
@@ -105,6 +105,54 @@ pub(crate) async fn load_force_kill_session_pg(
     )))
 }
 
+/// #3306: narrow durable-truth accessor for the idle-relay drift self-heal.
+///
+/// Reads the `sessions.channel_id` column (the dispatch-time owner channel a
+/// session's own hook upsert records via
+/// `channel_id = COALESCE(EXCLUDED.channel_id, sessions.channel_id)`) plus the
+/// owning `instance_id`, so a registry-drifted ROUTINE tmux session — which has
+/// no settings channel binding and whose `agent_id`/`thread_channel_id` are NULL
+/// (so `load_force_kill_session_pg` cannot resolve it) — can re-derive its
+/// authoritative owner channel. The drift self-heal still gates this value
+/// behind a live-pane check, an instance-id guard, and a dedupe-mirror agreement
+/// check before promoting it; this function is read-only and never authoritative
+/// on its own.
+pub(crate) async fn load_session_channel_id_pg(
+    pool: &PgPool,
+    session_key: &str,
+) -> Result<Option<(u64, Option<String>)>, String> {
+    let row = sqlx::query("SELECT channel_id, instance_id FROM sessions WHERE session_key = $1")
+        .bind(session_key)
+        .fetch_optional(pool)
+        .await
+        .map_err(|error| {
+            format!(
+                "load session channel_id {session_key}: {}",
+                crate::utils::redact::redact_known_secrets(&error.to_string())
+            )
+        })?;
+
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let channel_id: Option<String> = row
+        .try_get("channel_id")
+        .map_err(|error| format!("decode channel_id for {session_key}: {error}"))?;
+    let instance_id: Option<String> = row
+        .try_get("instance_id")
+        .map_err(|error| format!("decode instance_id for {session_key}: {error}"))?;
+    let Some(channel_id) = channel_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value != 0)
+    else {
+        return Ok(None);
+    };
+    Ok(Some((channel_id, instance_id)))
+}
+
 pub(crate) async fn disconnect_session_and_prepare_retry_pg(
     pool: &PgPool,
     session_key: &str,

--- a/src/services/discord/idle_relay_drift.rs
+++ b/src/services/discord/idle_relay_drift.rs
@@ -1,0 +1,715 @@
+//! #3306: registry/dedupe-mirror drift self-heal for the idle transcript relay.
+//!
+//! ## Problem
+//!
+//! `claude_idle_transcript_relay` resolves a tmux-session→channel owner from the
+//! authoritative `tmux_watchers` registry. #3018 made the registry the SINGLE
+//! authority: a registry miss while the `tui_prompt_dedupe` mirror still holds a
+//! mapping is observable DRIFT, and the resolver drops (never routes from the
+//! mirror, which is not a reverse authority). That decision is preserved.
+//!
+//! For ROUTINE tmux sessions (e.g. `…claude-routine-token-daily-report-…`) the
+//! drift becomes PERMANENT: the watcher slot is freed when the routine turn ends
+//! (`remove_tmux_session_if_current`), the registry entry disappears, but the
+//! mirror (24h in-memory TTL) survives. The existing #3105 self-heal only
+//! promotes a SETTINGS-derived channel (`resolve_rehydrated_claude_tmux_channel_id`),
+//! and a routine tmux name matches NO settings channel binding — so its repair
+//! gate never opens. The idle loop then re-emits the per-poll drift WARN every
+//! ~500ms forever (52k+ WARN over two days) and the routine's relay output is
+//! dropped (functional defect: routine results never reach Discord) until a
+//! dcserver restart wipes the in-memory mirror and boot recovery re-claims the
+//! watcher.
+//!
+//! ## Fix (this module)
+//!
+//! 1. **Burst suppression**: rate-limit the per-session drift WARN (first
+//!    occurrence emits immediately for incident visibility; subsequent ones are
+//!    suppressed for a 5-minute window and re-emitted with `suppressed_count` and
+//!    `drift_age_secs`). The drop branch still does NOT advance the scan offset,
+//!    so a successful repair lets the next ~500ms poll re-scan the preserved tail
+//!    and relay it (re-relay, NOT loss).
+//!
+//! 2. **Drift self-heal** (Claude only — the settings resolver is Claude-specific
+//!    and the durable DB row column is written by the Claude/routine hook flow):
+//!    on drift, once per session (60s cooldown, single-flight) trigger a one-shot
+//!    async repair from a DURABLE source, in order:
+//!      (a) the existing settings binding (`resolve_rehydrated_claude_tmux_channel_id`)
+//!          — same trust level as #3105;
+//!      (b) `sessions.channel_id` (NEW), promoted ONLY behind three guards:
+//!          - the tmux session has a LIVE pane,
+//!          - the row's `instance_id` (if present) is THIS instance,
+//!          - the dedupe mirror's channel AGREES with the DB channel.
+//!    On a passing source the value is promoted via the existing
+//!    `restore_owner_channel_for_tmux_session` (the authoritative #3105 path) —
+//!    the single-authority registry model is unchanged.
+//!
+//! ## Why this is NOT a reverse-authority promotion of the mirror (#3018 intact)
+//!
+//! The promoted VALUE never comes from the mirror. It comes from settings or from
+//! `sessions.channel_id` (a durable value the session's own dispatch/hook flow
+//! recorded under a host+token-hash-namespaced key). The mirror is used only as
+//! (i) the drift detector (existing) and (ii) a BLOCK-only gate: if it disagrees
+//! with the DB channel, the repair is blocked (the drop is kept). A validator
+//! that can only block can never be the routing authority, so #3018's
+//! "never route from the mirror" invariant holds literally — the resolver's
+//! drift branch still returns `None`. Mis-delivery (relaying to the wrong
+//! channel) is strictly worse than a drop, so the decision core defaults to
+//! `Blocked` whenever the sources are ambiguous.
+
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::{Duration, Instant};
+
+use poise::serenity_prelude::ChannelId;
+
+use super::SharedData;
+use crate::services::provider::ProviderKind;
+
+/// Re-emit the per-session drift WARN at most once per this window after the
+/// first (immediate) occurrence. The first hit is never suppressed so a fresh
+/// incident is visible without delay.
+const DRIFT_WARN_COOLDOWN: Duration = Duration::from_secs(300);
+
+/// Minimum spacing between repair attempts for the same session, so a permanent
+/// no-source session does not re-spawn a repair task on every ~500ms poll.
+const DRIFT_REPAIR_COOLDOWN: Duration = Duration::from_secs(60);
+
+/// Purge per-session drift state entries untouched for longer than this, so the
+/// map cannot grow unbounded across the process lifetime.
+const DRIFT_STATE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+#[derive(Debug)]
+struct DriftState {
+    first_seen_at: Instant,
+    last_touched_at: Instant,
+    last_warn_at: Option<Instant>,
+    suppressed_count: u64,
+    last_repair_attempt_at: Option<Instant>,
+    repair_inflight: bool,
+}
+
+impl DriftState {
+    fn new(now: Instant) -> Self {
+        Self {
+            first_seen_at: now,
+            last_touched_at: now,
+            last_warn_at: None,
+            suppressed_count: 0,
+            last_repair_attempt_at: None,
+            repair_inflight: false,
+        }
+    }
+}
+
+static DRIFT_STATE: LazyLock<Mutex<HashMap<String, DriftState>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Outcome of the rate-limiter for a single drift observation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct WarnDecision {
+    /// Whether the caller should emit a WARN now.
+    pub(super) emit: bool,
+    /// Number of WARNs suppressed since the last emitted one (0 on the first
+    /// emit). Carried in the re-emitted WARN so the burst is quantified.
+    pub(super) suppressed_count: u64,
+    /// Seconds since the drift was first observed for this session.
+    pub(super) drift_age_secs: u64,
+}
+
+/// Pure rate-limiter core (time injected) so the suppression policy is unit
+/// testable without wall-clock dependence. Mutates `state` in place.
+fn decide_drift_warn(state: &mut DriftState, now: Instant) -> WarnDecision {
+    state.last_touched_at = now;
+    let drift_age_secs = now.saturating_duration_since(state.first_seen_at).as_secs();
+    let due = match state.last_warn_at {
+        None => true,
+        Some(last) => now.saturating_duration_since(last) >= DRIFT_WARN_COOLDOWN,
+    };
+    if due {
+        let suppressed = state.suppressed_count;
+        state.last_warn_at = Some(now);
+        state.suppressed_count = 0;
+        WarnDecision {
+            emit: true,
+            suppressed_count: suppressed,
+            drift_age_secs,
+        }
+    } else {
+        state.suppressed_count = state.suppressed_count.saturating_add(1);
+        WarnDecision {
+            emit: false,
+            suppressed_count: state.suppressed_count,
+            drift_age_secs,
+        }
+    }
+}
+
+fn purge_expired_locked(map: &mut HashMap<String, DriftState>, now: Instant) {
+    map.retain(|_, state| {
+        state.repair_inflight
+            || now.saturating_duration_since(state.last_touched_at) < DRIFT_STATE_TTL
+    });
+}
+
+/// Rate-limit decision for the resolver-internal drift WARN (the
+/// `resolve_owner_channel_authoritatively` "drift alert"). Shares the same
+/// per-session limiter as the idle-loop skip WARN so a session does not emit two
+/// uncapped streams. Returns the decision the caller folds into its log fields.
+pub(super) fn should_emit_drift_warn(tmux_session_name: &str) -> WarnDecision {
+    let now = Instant::now();
+    let mut map = DRIFT_STATE
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    purge_expired_locked(&mut map, now);
+    let state = map
+        .entry(tmux_session_name.to_string())
+        .or_insert_with(|| DriftState::new(now));
+    decide_drift_warn(state, now)
+}
+
+/// Source a repair value was promoted from (for the success log) or the reason a
+/// promotion was blocked / had no source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RepairSource {
+    /// Settings-derived channel binding (#3105 trust level).
+    Settings,
+    /// `sessions.channel_id` durable column (#3306), passed all guards.
+    SessionsTable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum BlockReason {
+    /// DB row's `instance_id` belongs to another instance.
+    ForeignInstance,
+    /// The tmux pane is no longer live.
+    DeadPane,
+    /// The dedupe mirror channel disagrees with the DB channel (possible session
+    /// name reuse / rebind — dropping is safer than mis-delivery).
+    MirrorMismatch,
+    /// A DB channel exists but no dedupe mirror witness is present to corroborate
+    /// it, so it must not be promoted.
+    NoMirrorWitness,
+}
+
+/// Decision of the repair core for a single session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum RepairDecision {
+    /// Promote `channel` from `source` into the authoritative registry.
+    Promote { source: RepairSource, channel: u64 },
+    /// A candidate value existed but a guard refused promotion (keep the drop).
+    Blocked(BlockReason),
+    /// No durable source resolved a channel (keep the drop, #3018 semantics).
+    NoSource,
+}
+
+/// Resolved facts the IO layer feeds into the pure repair decision core.
+#[derive(Debug, Clone, Default)]
+pub(super) struct RepairInputs {
+    /// Settings-derived channel (`resolve_rehydrated_claude_tmux_channel_id`).
+    pub(super) settings_channel: Option<u64>,
+    /// `sessions.channel_id` durable column value.
+    pub(super) db_channel: Option<u64>,
+    /// Owning `instance_id` from the DB row, if recorded.
+    pub(super) db_instance: Option<String>,
+    /// This process's instance id.
+    pub(super) local_instance: String,
+    /// Dedupe mirror's last-seen channel (drift witness / agreement check).
+    pub(super) mirror_channel: Option<u64>,
+    /// Whether the tmux session currently has a live pane.
+    pub(super) pane_live: bool,
+}
+
+/// Pure, IO-free repair decision (#3306). Mis-delivery is strictly worse than a
+/// drop, so ambiguity resolves to `Blocked`/`NoSource`, never a guess.
+///
+/// Precedence:
+/// 1. Settings binding (same trust as #3105) wins when the pane is live.
+/// 2. Otherwise `sessions.channel_id` may be promoted ONLY behind all three
+///    guards: live pane, matching instance, AND mirror-agrees.
+pub(super) fn evaluate_drift_repair(inputs: &RepairInputs) -> RepairDecision {
+    if !inputs.pane_live {
+        // A dead pane can never resolve (mirrors the #3105 dead-pane branch). If
+        // there is no candidate at all, report NoSource so callers don't log a
+        // spurious block.
+        if inputs.settings_channel.is_none() && inputs.db_channel.is_none() {
+            return RepairDecision::NoSource;
+        }
+        return RepairDecision::Blocked(BlockReason::DeadPane);
+    }
+
+    if let Some(channel) = inputs.settings_channel {
+        return RepairDecision::Promote {
+            source: RepairSource::Settings,
+            channel,
+        };
+    }
+
+    let Some(db_channel) = inputs.db_channel else {
+        return RepairDecision::NoSource;
+    };
+
+    // Guard (b): the DB row must belong to THIS instance (cross-host is already
+    // excluded by the hostname-embedded session_key, this also blocks a
+    // dev/release co-tenant row that slipped the token-hash namespace).
+    if let Some(db_instance) = inputs
+        .db_instance
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        if db_instance != inputs.local_instance.trim() {
+            return RepairDecision::Blocked(BlockReason::ForeignInstance);
+        }
+    }
+
+    // Guard (c): require a mirror witness AND agreement. A missing mirror means
+    // no corroboration (the drift condition itself would not hold without it);
+    // a disagreeing mirror signals a name-reuse / rebind window where the new
+    // dispatch already recorded a different channel — dropping is safer.
+    match inputs.mirror_channel {
+        None => RepairDecision::Blocked(BlockReason::NoMirrorWitness),
+        Some(mirror_channel) if mirror_channel != db_channel => {
+            RepairDecision::Blocked(BlockReason::MirrorMismatch)
+        }
+        Some(_) => RepairDecision::Promote {
+            source: RepairSource::SessionsTable,
+            channel: db_channel,
+        },
+    }
+}
+
+/// RAII guard that clears the `repair_inflight` flag on drop, so a panicking
+/// repair task can never leak the single-flight lock for a session.
+struct RepairInflightGuard {
+    tmux_session_name: String,
+}
+
+impl Drop for RepairInflightGuard {
+    fn drop(&mut self) {
+        let mut map = DRIFT_STATE
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if let Some(state) = map.get_mut(&self.tmux_session_name) {
+            state.repair_inflight = false;
+        }
+    }
+}
+
+/// Try to claim the single-flight repair slot for this session. Returns a guard
+/// (held until the repair task ends) when the caller may proceed, or `None` when
+/// a repair is already inflight or the 60s cooldown has not elapsed.
+fn try_begin_repair(tmux_session_name: &str, now: Instant) -> Option<RepairInflightGuard> {
+    let mut map = DRIFT_STATE
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    purge_expired_locked(&mut map, now);
+    let state = map
+        .entry(tmux_session_name.to_string())
+        .or_insert_with(|| DriftState::new(now));
+    if state.repair_inflight {
+        return None;
+    }
+    if let Some(last) = state.last_repair_attempt_at {
+        if now.saturating_duration_since(last) < DRIFT_REPAIR_COOLDOWN {
+            return None;
+        }
+    }
+    state.last_repair_attempt_at = Some(now);
+    state.repair_inflight = true;
+    Some(RepairInflightGuard {
+        tmux_session_name: tmux_session_name.to_string(),
+    })
+}
+
+/// Entry point invoked from the idle relay loop's drift (drop) branch. Emits a
+/// rate-limited WARN and, for Claude, fires a one-shot async repair (cooldown +
+/// single-flight gated).
+pub(super) fn on_idle_relay_drift(
+    shared: &Arc<SharedData>,
+    provider: ProviderKind,
+    tmux_session_name: &str,
+) {
+    let decision = should_emit_drift_warn(tmux_session_name);
+    if decision.emit {
+        tracing::warn!(
+            tmux_session_name = %tmux_session_name,
+            provider = %provider.as_str(),
+            suppressed_count = decision.suppressed_count,
+            drift_age_secs = decision.drift_age_secs,
+            "idle relay skipped: no authoritative owner channel for tmux session \
+             (registry/dedupe-mirror drift)"
+        );
+    }
+
+    // Repair is Claude-only: the settings resolver is Claude-specific and the
+    // durable DB column is written by the Claude/routine hook flow. Codex drift
+    // gets rate-limited WARN only.
+    if provider != ProviderKind::Claude {
+        return;
+    }
+
+    let now = Instant::now();
+    let Some(guard) = try_begin_repair(tmux_session_name, now) else {
+        return;
+    };
+
+    let shared = shared.clone();
+    let tmux_session_name = tmux_session_name.to_string();
+    super::task_supervisor::spawn_observed("idle_relay_drift_repair", async move {
+        // The guard is moved into the task so the single-flight slot stays held
+        // for the whole repair and is released (even on panic) on drop.
+        attempt_drift_repair(&shared, &tmux_session_name, guard).await;
+    });
+}
+
+#[cfg(unix)]
+async fn attempt_drift_repair(
+    shared: &Arc<SharedData>,
+    tmux_session_name: &str,
+    _guard: RepairInflightGuard,
+) {
+    // (a) settings source — synchronous, no lock held.
+    let settings_channel =
+        super::tui_prompt_relay::resolve_rehydrated_claude_tmux_channel_id(tmux_session_name);
+
+    // (b) durable DB source — `sessions.channel_id` for either the namespaced or
+    // the legacy session key. Only consulted when storage is configured.
+    let (db_channel, db_instance) = load_db_channel(shared, tmux_session_name).await;
+
+    // Drift witness / agreement check value (read-only mirror use).
+    let mirror_channel =
+        crate::services::tui_prompt_dedupe::owner_channel_for_tmux_session(tmux_session_name);
+
+    // Live-pane check on the blocking pool (synchronous tmux subprocess call).
+    let pane_live = {
+        let probe_name = tmux_session_name.to_string();
+        tokio::task::spawn_blocking(move || {
+            crate::services::tmux_diagnostics::tmux_session_has_live_pane(&probe_name)
+        })
+        .await
+        .unwrap_or(false)
+    };
+
+    let inputs = RepairInputs {
+        settings_channel,
+        db_channel,
+        db_instance,
+        local_instance:
+            crate::services::cluster::node_registry::resolve_self_instance_id_without_config(),
+        mirror_channel,
+        pane_live,
+    };
+
+    match evaluate_drift_repair(&inputs) {
+        RepairDecision::Promote { source, channel } => {
+            // All awaits are complete; `restore_owner_channel_for_tmux_session`
+            // briefly takes the registry lock synchronously (no await held).
+            let repaired = shared
+                .tmux_watchers
+                .restore_owner_channel_for_tmux_session(tmux_session_name, ChannelId::new(channel));
+            if repaired {
+                tracing::warn!(
+                    tmux_session_name = %tmux_session_name,
+                    channel_id = channel,
+                    repair_source = source.label(),
+                    provider = "claude",
+                    "repaired authoritative tmux-session→channel registry (drift-triggered); \
+                     idle relay can route again"
+                );
+            }
+        }
+        RepairDecision::Blocked(reason) => {
+            tracing::warn!(
+                tmux_session_name = %tmux_session_name,
+                block_reason = reason.label(),
+                db_channel_id = db_channel,
+                mirror_channel_id = mirror_channel,
+                provider = "claude",
+                "idle relay drift repair blocked; keeping the drop (no mis-delivery)"
+            );
+        }
+        RepairDecision::NoSource => {
+            tracing::debug!(
+                tmux_session_name = %tmux_session_name,
+                provider = "claude",
+                "idle relay drift repair found no durable source; keeping the drop"
+            );
+        }
+    }
+}
+
+#[cfg(unix)]
+async fn load_db_channel(
+    shared: &Arc<SharedData>,
+    tmux_session_name: &str,
+) -> (Option<u64>, Option<String>) {
+    let Some(pool) = shared.pg_pool.as_ref() else {
+        return (None, None);
+    };
+    let candidates = super::adk_session::build_session_key_candidates(
+        &shared.token_hash,
+        &ProviderKind::Claude,
+        tmux_session_name,
+    );
+    for session_key in candidates {
+        match crate::db::dispatched_sessions::load_session_channel_id_pg(pool, &session_key).await {
+            Ok(Some((channel_id, instance_id))) => return (Some(channel_id), instance_id),
+            Ok(None) => {}
+            Err(error) => {
+                tracing::debug!(
+                    session_key = %session_key,
+                    error = %error,
+                    "idle relay drift repair: session channel_id lookup failed"
+                );
+            }
+        }
+    }
+    (None, None)
+}
+
+impl RepairSource {
+    fn label(self) -> &'static str {
+        match self {
+            RepairSource::Settings => "settings",
+            RepairSource::SessionsTable => "sessions_table",
+        }
+    }
+}
+
+impl BlockReason {
+    fn label(self) -> &'static str {
+        match self {
+            BlockReason::ForeignInstance => "foreign_instance",
+            BlockReason::DeadPane => "dead_pane",
+            BlockReason::MirrorMismatch => "mirror_mismatch",
+            BlockReason::NoMirrorWitness => "no_mirror_witness",
+        }
+    }
+}
+
+/// Test-only: clear all per-session drift state so rate-limiter / single-flight
+/// tests do not leak across cases (the static map is process-global).
+#[cfg(test)]
+pub(super) fn reset_drift_state_for_tests() {
+    let mut map = DRIFT_STATE
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    map.clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inputs() -> RepairInputs {
+        RepairInputs {
+            settings_channel: None,
+            db_channel: None,
+            db_instance: None,
+            local_instance: "host-1234".to_string(),
+            mirror_channel: None,
+            pane_live: true,
+        }
+    }
+
+    // --- rate-limiter ---------------------------------------------------
+
+    #[test]
+    fn drift_warn_first_emits_then_suppresses_then_reemits() {
+        let start = Instant::now();
+        let mut state = DriftState::new(start);
+
+        // First occurrence emits immediately, zero suppressed.
+        let d0 = decide_drift_warn(&mut state, start);
+        assert!(d0.emit, "first drift WARN must emit immediately");
+        assert_eq!(d0.suppressed_count, 0);
+
+        // Within the cooldown: suppressed, count accumulates.
+        let t1 = start + Duration::from_secs(1);
+        let d1 = decide_drift_warn(&mut state, t1);
+        assert!(!d1.emit);
+        assert_eq!(d1.suppressed_count, 1);
+        let t2 = start + Duration::from_secs(2);
+        let d2 = decide_drift_warn(&mut state, t2);
+        assert!(!d2.emit);
+        assert_eq!(d2.suppressed_count, 2);
+
+        // After the cooldown: re-emit, carrying the accumulated suppressed count,
+        // then reset.
+        let t3 = start + DRIFT_WARN_COOLDOWN + Duration::from_secs(1);
+        let d3 = decide_drift_warn(&mut state, t3);
+        assert!(d3.emit, "WARN must re-emit after the cooldown window");
+        assert_eq!(
+            d3.suppressed_count, 2,
+            "re-emit carries the suppressed count"
+        );
+        assert!(d3.drift_age_secs >= DRIFT_WARN_COOLDOWN.as_secs());
+
+        // The next suppression window starts fresh.
+        let t4 = t3 + Duration::from_secs(1);
+        let d4 = decide_drift_warn(&mut state, t4);
+        assert!(!d4.emit);
+        assert_eq!(d4.suppressed_count, 1);
+    }
+
+    #[test]
+    fn drift_warn_sessions_are_independent() {
+        reset_drift_state_for_tests();
+        // Two distinct sessions each get their own immediate first emit.
+        assert!(should_emit_drift_warn("tmux-a").emit);
+        assert!(should_emit_drift_warn("tmux-b").emit);
+        // Second hit on A within the window is suppressed (independent of B).
+        assert!(!should_emit_drift_warn("tmux-a").emit);
+        reset_drift_state_for_tests();
+    }
+
+    // --- repair decision core ------------------------------------------
+
+    #[test]
+    fn settings_hit_live_pane_promotes_settings() {
+        let i = RepairInputs {
+            settings_channel: Some(111),
+            pane_live: true,
+            ..inputs()
+        };
+        assert_eq!(
+            evaluate_drift_repair(&i),
+            RepairDecision::Promote {
+                source: RepairSource::Settings,
+                channel: 111
+            }
+        );
+    }
+
+    #[test]
+    fn settings_miss_db_hit_mirror_agrees_instance_match_promotes_db() {
+        let i = RepairInputs {
+            db_channel: Some(222),
+            mirror_channel: Some(222),
+            db_instance: Some("host-1234".to_string()),
+            local_instance: "host-1234".to_string(),
+            pane_live: true,
+            ..inputs()
+        };
+        assert_eq!(
+            evaluate_drift_repair(&i),
+            RepairDecision::Promote {
+                source: RepairSource::SessionsTable,
+                channel: 222
+            }
+        );
+    }
+
+    // #3306 KEY regression: session-name REUSE. The DB row still points at the
+    // OLD channel (C1) while the new dispatch's mirror already recorded the NEW
+    // channel (C2). Promotion MUST be blocked — mis-delivery is worse than a drop.
+    #[test]
+    fn db_channel_disagrees_with_mirror_blocks_misdelivery() {
+        let i = RepairInputs {
+            db_channel: Some(1),     // C1 (stale)
+            mirror_channel: Some(2), // C2 (new dispatch witness)
+            pane_live: true,
+            ..inputs()
+        };
+        assert_eq!(
+            evaluate_drift_repair(&i),
+            RepairDecision::Blocked(BlockReason::MirrorMismatch)
+        );
+    }
+
+    #[test]
+    fn db_channel_without_mirror_witness_is_blocked() {
+        let i = RepairInputs {
+            db_channel: Some(222),
+            mirror_channel: None,
+            pane_live: true,
+            ..inputs()
+        };
+        assert_eq!(
+            evaluate_drift_repair(&i),
+            RepairDecision::Blocked(BlockReason::NoMirrorWitness)
+        );
+    }
+
+    #[test]
+    fn db_channel_foreign_instance_is_blocked() {
+        let i = RepairInputs {
+            db_channel: Some(222),
+            mirror_channel: Some(222),
+            db_instance: Some("other-host-9999".to_string()),
+            local_instance: "host-1234".to_string(),
+            pane_live: true,
+            ..inputs()
+        };
+        assert_eq!(
+            evaluate_drift_repair(&i),
+            RepairDecision::Blocked(BlockReason::ForeignInstance)
+        );
+    }
+
+    #[test]
+    fn dead_pane_blocks_any_candidate() {
+        let i = RepairInputs {
+            settings_channel: Some(111),
+            pane_live: false,
+            ..inputs()
+        };
+        assert_eq!(
+            evaluate_drift_repair(&i),
+            RepairDecision::Blocked(BlockReason::DeadPane)
+        );
+    }
+
+    #[test]
+    fn dead_pane_no_candidate_is_no_source() {
+        let i = RepairInputs {
+            pane_live: false,
+            ..inputs()
+        };
+        assert_eq!(evaluate_drift_repair(&i), RepairDecision::NoSource);
+    }
+
+    #[test]
+    fn all_sources_miss_is_no_source() {
+        // #3018 semantics preserved: no durable source ⇒ keep the drop.
+        assert_eq!(evaluate_drift_repair(&inputs()), RepairDecision::NoSource);
+    }
+
+    // --- cooldown / single-flight state machine ------------------------
+
+    #[test]
+    fn repair_cooldown_and_single_flight_gate() {
+        reset_drift_state_for_tests();
+        let start = Instant::now();
+
+        // First attempt claims the slot.
+        let guard = try_begin_repair("tmux-x", start);
+        assert!(guard.is_some(), "first repair attempt must be allowed");
+
+        // While inflight, a concurrent attempt is refused.
+        assert!(
+            try_begin_repair("tmux-x", start + Duration::from_secs(1)).is_none(),
+            "single-flight: no second inflight repair"
+        );
+
+        // Dropping the guard clears the inflight flag (even on panic).
+        drop(guard);
+
+        // Still within the cooldown ⇒ refused even though no longer inflight.
+        assert!(
+            try_begin_repair("tmux-x", start + Duration::from_secs(2)).is_none(),
+            "60s cooldown blocks rapid re-attempts"
+        );
+
+        // After the cooldown ⇒ allowed again.
+        assert!(
+            try_begin_repair(
+                "tmux-x",
+                start + DRIFT_REPAIR_COOLDOWN + Duration::from_secs(1)
+            )
+            .is_some(),
+            "cooldown elapsed ⇒ a new repair attempt is allowed"
+        );
+        reset_drift_state_for_tests();
+    }
+}

--- a/src/services/discord/idle_relay_drift.rs
+++ b/src/services/discord/idle_relay_drift.rs
@@ -57,12 +57,17 @@
 //! `Blocked` whenever the sources are ambiguous.
 
 use std::collections::HashMap;
-use std::sync::{Arc, LazyLock, Mutex};
+#[cfg(unix)]
+use std::sync::Arc;
+use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
+#[cfg(unix)]
 use poise::serenity_prelude::ChannelId;
 
+#[cfg(unix)]
 use super::SharedData;
+#[cfg(unix)]
 use crate::services::provider::ProviderKind;
 
 /// Re-emit the per-session drift WARN at most once per this window after the
@@ -72,6 +77,7 @@ const DRIFT_WARN_COOLDOWN: Duration = Duration::from_secs(300);
 
 /// Minimum spacing between repair attempts for the same session, so a permanent
 /// no-source session does not re-spawn a repair task on every ~500ms poll.
+#[cfg(unix)]
 const DRIFT_REPAIR_COOLDOWN: Duration = Duration::from_secs(60);
 
 /// Purge per-session drift state entries untouched for longer than this, so the
@@ -84,6 +90,7 @@ struct DriftState {
     last_touched_at: Instant,
     last_warn_at: Option<Instant>,
     suppressed_count: u64,
+    #[cfg_attr(not(unix), allow(dead_code))]
     last_repair_attempt_at: Option<Instant>,
     repair_inflight: bool,
 }
@@ -152,9 +159,9 @@ fn purge_expired_locked(map: &mut HashMap<String, DriftState>, now: Instant) {
 }
 
 /// Rate-limit decision for the resolver-internal drift WARN (the
-/// `resolve_owner_channel_authoritatively` "drift alert"). Shares the same
-/// per-session limiter as the idle-loop skip WARN so a session does not emit two
-/// uncapped streams. Returns the decision the caller folds into its log fields.
+/// `resolve_owner_channel_authoritatively` "drift alert"). The resolver is the
+/// single WARN owner; the idle drift hook only triggers repair. Returns the
+/// decision the caller folds into its log fields.
 pub(super) fn should_emit_drift_warn(tmux_session_name: &str) -> WarnDecision {
     let now = Instant::now();
     let mut map = DRIFT_STATE
@@ -169,6 +176,7 @@ pub(super) fn should_emit_drift_warn(tmux_session_name: &str) -> WarnDecision {
 
 /// Source a repair value was promoted from (for the success log) or the reason a
 /// promotion was blocked / had no source.
+#[cfg(unix)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum RepairSource {
     /// Settings-derived channel binding (#3105 trust level).
@@ -177,6 +185,7 @@ pub(super) enum RepairSource {
     SessionsTable,
 }
 
+#[cfg(unix)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum BlockReason {
     /// DB row's `instance_id` belongs to another instance.
@@ -192,6 +201,7 @@ pub(super) enum BlockReason {
 }
 
 /// Decision of the repair core for a single session.
+#[cfg(unix)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum RepairDecision {
     /// Promote `channel` from `source` into the authoritative registry.
@@ -203,6 +213,7 @@ pub(super) enum RepairDecision {
 }
 
 /// Resolved facts the IO layer feeds into the pure repair decision core.
+#[cfg(unix)]
 #[derive(Debug, Clone, Default)]
 pub(super) struct RepairInputs {
     /// Settings-derived channel (`resolve_rehydrated_claude_tmux_channel_id`).
@@ -226,6 +237,7 @@ pub(super) struct RepairInputs {
 /// 1. Settings binding (same trust as #3105) wins when the pane is live.
 /// 2. Otherwise `sessions.channel_id` may be promoted ONLY behind all three
 ///    guards: live pane, matching instance, AND mirror-agrees.
+#[cfg(unix)]
 pub(super) fn evaluate_drift_repair(inputs: &RepairInputs) -> RepairDecision {
     if !inputs.pane_live {
         // A dead pane can never resolve (mirrors the #3105 dead-pane branch). If
@@ -280,10 +292,12 @@ pub(super) fn evaluate_drift_repair(inputs: &RepairInputs) -> RepairDecision {
 
 /// RAII guard that clears the `repair_inflight` flag on drop, so a panicking
 /// repair task can never leak the single-flight lock for a session.
+#[cfg(unix)]
 struct RepairInflightGuard {
     tmux_session_name: String,
 }
 
+#[cfg(unix)]
 impl Drop for RepairInflightGuard {
     fn drop(&mut self) {
         let mut map = DRIFT_STATE
@@ -298,6 +312,7 @@ impl Drop for RepairInflightGuard {
 /// Try to claim the single-flight repair slot for this session. Returns a guard
 /// (held until the repair task ends) when the caller may proceed, or `None` when
 /// a repair is already inflight or the 60s cooldown has not elapsed.
+#[cfg(unix)]
 fn try_begin_repair(tmux_session_name: &str, now: Instant) -> Option<RepairInflightGuard> {
     let mut map = DRIFT_STATE
         .lock()
@@ -321,29 +336,18 @@ fn try_begin_repair(tmux_session_name: &str, now: Instant) -> Option<RepairInfli
     })
 }
 
-/// Entry point invoked from the idle relay loop's drift (drop) branch. Emits a
-/// rate-limited WARN and, for Claude, fires a one-shot async repair (cooldown +
-/// single-flight gated).
+/// Entry point invoked from the idle relay loop's drift (drop) branch. The
+/// resolver owns the single rate-limited drift WARN; this path only fires the
+/// Claude one-shot async repair (cooldown + single-flight gated).
+#[cfg(unix)]
 pub(super) fn on_idle_relay_drift(
     shared: &Arc<SharedData>,
     provider: ProviderKind,
     tmux_session_name: &str,
 ) {
-    let decision = should_emit_drift_warn(tmux_session_name);
-    if decision.emit {
-        tracing::warn!(
-            tmux_session_name = %tmux_session_name,
-            provider = %provider.as_str(),
-            suppressed_count = decision.suppressed_count,
-            drift_age_secs = decision.drift_age_secs,
-            "idle relay skipped: no authoritative owner channel for tmux session \
-             (registry/dedupe-mirror drift)"
-        );
-    }
-
     // Repair is Claude-only: the settings resolver is Claude-specific and the
     // durable DB column is written by the Claude/routine hook flow. Codex drift
-    // gets rate-limited WARN only.
+    // is WARN-only at the resolver.
     if provider != ProviderKind::Claude {
         return;
     }
@@ -467,6 +471,7 @@ async fn load_db_channel(
     (None, None)
 }
 
+#[cfg(unix)]
 impl RepairSource {
     fn label(self) -> &'static str {
         match self {
@@ -476,6 +481,7 @@ impl RepairSource {
     }
 }
 
+#[cfg(unix)]
 impl BlockReason {
     fn label(self) -> &'static str {
         match self {
@@ -501,6 +507,7 @@ pub(super) fn reset_drift_state_for_tests() {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
     fn inputs() -> RepairInputs {
         RepairInputs {
             settings_channel: None,
@@ -565,6 +572,7 @@ mod tests {
 
     // --- repair decision core ------------------------------------------
 
+    #[cfg(unix)]
     #[test]
     fn settings_hit_live_pane_promotes_settings() {
         let i = RepairInputs {
@@ -581,6 +589,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn settings_miss_db_hit_mirror_agrees_instance_match_promotes_db() {
         let i = RepairInputs {
@@ -603,6 +612,7 @@ mod tests {
     // #3306 KEY regression: session-name REUSE. The DB row still points at the
     // OLD channel (C1) while the new dispatch's mirror already recorded the NEW
     // channel (C2). Promotion MUST be blocked — mis-delivery is worse than a drop.
+    #[cfg(unix)]
     #[test]
     fn db_channel_disagrees_with_mirror_blocks_misdelivery() {
         let i = RepairInputs {
@@ -617,6 +627,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn db_channel_without_mirror_witness_is_blocked() {
         let i = RepairInputs {
@@ -631,6 +642,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn db_channel_foreign_instance_is_blocked() {
         let i = RepairInputs {
@@ -647,6 +659,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn dead_pane_blocks_any_candidate() {
         let i = RepairInputs {
@@ -660,6 +673,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn dead_pane_no_candidate_is_no_source() {
         let i = RepairInputs {
@@ -669,6 +683,7 @@ mod tests {
         assert_eq!(evaluate_drift_repair(&i), RepairDecision::NoSource);
     }
 
+    #[cfg(unix)]
     #[test]
     fn all_sources_miss_is_no_source() {
         // #3018 semantics preserved: no durable source ⇒ keep the drop.
@@ -677,6 +692,7 @@ mod tests {
 
     // --- cooldown / single-flight state machine ------------------------
 
+    #[cfg(unix)]
     #[test]
     fn repair_cooldown_and_single_flight_gate() {
         reset_drift_state_for_tests();

--- a/src/services/discord/idle_relay_drift.rs
+++ b/src/services/discord/idle_relay_drift.rs
@@ -507,6 +507,13 @@ pub(super) fn reset_drift_state_for_tests() {
 mod tests {
     use super::*;
 
+    // Serializes tests that touch the process-global `DRIFT_STATE` so parallel
+    // execution can't clear another test's state mid-assertion (#3306 codex r1:
+    // `repair_cooldown_and_single_flight_gate` raced a peer's
+    // `reset_drift_state_for_tests`). Tests that only use a LOCAL `DriftState`
+    // or the IO-free `evaluate_drift_repair` core do not need it.
+    static DRIFT_TEST_LOCK: Mutex<()> = Mutex::new(());
+
     #[cfg(unix)]
     fn inputs() -> RepairInputs {
         RepairInputs {
@@ -561,6 +568,7 @@ mod tests {
 
     #[test]
     fn drift_warn_sessions_are_independent() {
+        let _serial = DRIFT_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         reset_drift_state_for_tests();
         // Two distinct sessions each get their own immediate first emit.
         assert!(should_emit_drift_warn("tmux-a").emit);
@@ -695,6 +703,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn repair_cooldown_and_single_flight_gate() {
+        let _serial = DRIFT_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         reset_drift_state_for_tests();
         let start = Instant::now();
 

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod http;
 mod idle_detector;
 pub(crate) mod idle_recap;
 mod idle_recap_interaction;
+mod idle_relay_drift;
 mod inflight;
 mod inflight_heartbeat_sweeper;
 pub(crate) mod internal_api;

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -4939,11 +4939,15 @@ fn resolve_owner_channel_authoritatively(
             // #3018: registry miss + dedupe mirror hit == observable drift. Do NOT
             // fall back to the mirror (not a reverse authority). #3306: rate-limit
             // the per-poll "drift alert" so a permanently drifted routine session
-            // cannot flood the log (52k+ WARN); the message text is preserved.
-            if super::idle_relay_drift::should_emit_drift_warn(tmux_session_name).emit {
+            // cannot flood the log (52k+ WARN). The idle drift hook does not
+            // consume this limiter again; this resolver WARN is the single log.
+            let warn_decision = super::idle_relay_drift::should_emit_drift_warn(tmux_session_name);
+            if warn_decision.emit {
                 tracing::warn!(
                     tmux_session_name = %tmux_session_name,
                     dedupe_channel_id = dedupe_channel,
+                    suppressed_count = warn_decision.suppressed_count,
+                    drift_age_secs = warn_decision.drift_age_secs,
                     "tmux-session→channel registry miss while dedupe mirror has a mapping; \
                      treating registry as single authority and dropping (drift alert)"
                 );

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -2386,14 +2386,12 @@ fn spawn_claude_idle_transcript_relay(shared: Arc<SharedData>) {
             {
                 let Some(channel_id) = owner_channel_for_tmux_session(&shared, &tmux_session_name)
                 else {
-                    // #3018: registry has no owner channel for this active Claude
-                    // TUI binding — the idle relay cannot route, so it skips. Make
-                    // the skip visible (was a silent continue) so missing mappings
-                    // are diagnosable instead of silently dropping relay output.
-                    tracing::warn!(
-                        tmux_session_name = %tmux_session_name,
-                        provider = "claude",
-                        "Claude idle relay skipped: no authoritative owner channel for tmux session"
+                    // #3018/#3306: registry miss ⇒ drop. The drift handler
+                    // rate-limits the WARN and self-heals from a durable source.
+                    super::idle_relay_drift::on_idle_relay_drift(
+                        &shared,
+                        ProviderKind::Claude,
+                        &tmux_session_name,
                     );
                     continue;
                 };
@@ -3118,7 +3116,7 @@ fn resolve_idle_relay_transcript(
 }
 
 #[cfg(unix)]
-fn resolve_rehydrated_claude_tmux_channel_id(tmux_session_name: &str) -> Option<u64> {
+pub(super) fn resolve_rehydrated_claude_tmux_channel_id(tmux_session_name: &str) -> Option<u64> {
     let mut matched: Option<u64> = None;
     for binding in super::settings::list_registered_channel_bindings() {
         if binding.owner_provider != ProviderKind::Claude {
@@ -3323,13 +3321,12 @@ fn spawn_codex_idle_rollout_relay(shared: Arc<SharedData>) {
                 }
                 let Some(channel_id) = owner_channel_for_tmux_session(&shared, &tmux_session_name)
                 else {
-                    // #3018: registry has no owner channel for this active Codex
-                    // TUI binding — surface the relay skip (was a silent continue)
-                    // so missing mappings are diagnosable.
-                    tracing::warn!(
-                        tmux_session_name = %tmux_session_name,
-                        provider = "codex",
-                        "Codex idle relay skipped: no authoritative owner channel for tmux session"
+                    // #3018/#3306: registry miss ⇒ drop. Codex gets the
+                    // rate-limited drift WARN only (no settings/DB self-heal).
+                    super::idle_relay_drift::on_idle_relay_drift(
+                        &shared,
+                        ProviderKind::Codex,
+                        &tmux_session_name,
                     );
                     continue;
                 };
@@ -4939,15 +4936,18 @@ fn resolve_owner_channel_authoritatively(
     match (registry_owner, dedupe_owner) {
         (Some(registry_channel), _) => Some(registry_channel),
         (None, Some(dedupe_channel)) => {
-            // #3018: registry miss + dedupe mirror hit == observable drift.
-            // Do NOT fall back to the mirror (it is not a reverse authority);
-            // surface the drift so it is visible instead of routing on stale state.
-            tracing::warn!(
-                tmux_session_name = %tmux_session_name,
-                dedupe_channel_id = dedupe_channel,
-                "tmux-session→channel registry miss while dedupe mirror has a mapping; \
-                 treating registry as single authority and dropping (drift alert)"
-            );
+            // #3018: registry miss + dedupe mirror hit == observable drift. Do NOT
+            // fall back to the mirror (not a reverse authority). #3306: rate-limit
+            // the per-poll "drift alert" so a permanently drifted routine session
+            // cannot flood the log (52k+ WARN); the message text is preserved.
+            if super::idle_relay_drift::should_emit_drift_warn(tmux_session_name).emit {
+                tracing::warn!(
+                    tmux_session_name = %tmux_session_name,
+                    dedupe_channel_id = dedupe_channel,
+                    "tmux-session→channel registry miss while dedupe mirror has a mapping; \
+                     treating registry as single authority and dropping (drift alert)"
+                );
+            }
             None
         }
         (None, None) => None,
@@ -5843,6 +5843,62 @@ mod tests {
         );
 
         // Cleanup shared global dedupe state for cross-test isolation.
+        crate::services::tui_prompt_dedupe::evict_dead_tmux_mirror(tmux);
+    }
+
+    // #3306: a drift-triggered self-heal (the new path for ROUTINE sessions that
+    // have NO settings binding) must promote a durable channel via the SAME
+    // authoritative `restore_owner_channel_for_tmux_session` registry path the
+    // #3105 rehydrate uses — proving the registry stays the single authority and
+    // the resolver routes again after the drift WARN drop. The decision-core
+    // tests (`idle_relay_drift`) prove WHICH durable source is chosen and the
+    // mis-delivery guards; this end-to-end test pins the registry promotion +
+    // resolver hand-off.
+    #[test]
+    fn drift_triggered_restore_makes_routine_session_route_again() {
+        let shared = super::super::make_shared_data_for_tests();
+        // A routine tmux name that matches no settings channel binding (the
+        // exact class that drifts permanently before #3306).
+        let tmux = "AgentDesk-claude-routine-token-daily-report---token-manager";
+        let owner = ChannelId::new(1_512_635_194_124_013_681);
+
+        // Drift precondition: mirror holds a mapping, registry misses ⇒ drop.
+        crate::services::tui_prompt_dedupe::register_tmux_channel(tmux, owner.get());
+        assert_eq!(
+            owner_channel_for_tmux_session(&shared, tmux),
+            None,
+            "registry miss + mirror hit must drop (drift), never route from mirror"
+        );
+
+        // The drift repair (durable source promotion) re-registers the owner via
+        // the authoritative restore path — exactly what `attempt_drift_repair`
+        // does on a passing `RepairDecision::Promote`.
+        let repaired = shared
+            .tmux_watchers
+            .restore_owner_channel_for_tmux_session(tmux, owner);
+        assert!(repaired, "first drift-triggered restore reports a change");
+        assert_eq!(
+            owner_channel_for_tmux_session(&shared, tmux),
+            Some(owner),
+            "after the drift-triggered authoritative restore the session routes again"
+        );
+
+        // Live truth wins: a real watcher claim for the session must own it
+        // authoritatively, so a subsequent restore no-ops (the restored entry
+        // can never shadow a live watcher).
+        shared.tmux_watchers.insert(
+            owner,
+            test_watcher_handle(tmux, Path::new("/tmp/nope.jsonl")),
+        );
+        assert!(
+            !shared
+                .tmux_watchers
+                .restore_owner_channel_for_tmux_session(tmux, owner),
+            "restore must no-op while a live watcher owns the session (live truth wins)"
+        );
+
+        // Cleanup shared global state for cross-test isolation.
+        shared.tmux_watchers.remove(&owner);
         crate::services::tui_prompt_dedupe::evict_dead_tmux_mirror(tmux);
     }
 

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -4926,8 +4926,7 @@ fn owner_channel_for_tmux_session(
 }
 
 /// Pure decision core for [`owner_channel_for_tmux_session`], split out so the
-/// registry-as-single-authority and drift-alert behaviour can be unit tested
-/// without constructing a full `SharedData`.
+/// registry-single-authority + drift-alert behaviour is unit-testable.
 fn resolve_owner_channel_authoritatively(
     tmux_session_name: &str,
     registry_owner: Option<ChannelId>,
@@ -4936,11 +4935,8 @@ fn resolve_owner_channel_authoritatively(
     match (registry_owner, dedupe_owner) {
         (Some(registry_channel), _) => Some(registry_channel),
         (None, Some(dedupe_channel)) => {
-            // #3018: registry miss + dedupe mirror hit == observable drift. Do NOT
-            // fall back to the mirror (not a reverse authority). #3306: rate-limit
-            // the per-poll "drift alert" so a permanently drifted routine session
-            // cannot flood the log (52k+ WARN). The idle drift hook does not
-            // consume this limiter again; this resolver WARN is the single log.
+            // #3018: registry miss + mirror hit == drift; never route from the mirror
+            // (not a reverse authority). #3306: rate-limit this single drift-alert WARN.
             let warn_decision = super::idle_relay_drift::should_emit_drift_warn(tmux_session_name);
             if warn_decision.emit {
                 tracing::warn!(


### PR DESCRIPTION
Fixes #3306.

## Problem

The `claude_idle_transcript_relay` tmux-session→channel resolver (#3018) treats a **registry miss + dedupe-mirror hit** as observable drift and drops — the registry is the single authority and the mirror is never a reverse authority. For **routine** tmux sessions (`…claude-routine-token-daily-report-…` etc.) this drift became **permanent**: the watcher slot is freed at routine-turn end (`remove_tmux_session_if_current`), the registry entry disappears, but the in-memory dedupe mirror (24h TTL) survives. The existing #3105 self-heal only promotes a settings-derived channel, and a routine tmux name matches **no** settings channel binding, so its repair gate never opened.

Symptoms (2026-06-09 → 2026-06-10): **52,240 WARN** at ~500ms cadence (token-daily-report 30,039 / agent-feedback-briefing 16,777 / memento-hygiene 5,207), routine relay output **dropped** (results never reached Discord), recovered only by dcserver restart (which wipes the in-memory mirror and re-claims the watcher).

## Fix

New non-giant module `src/services/discord/idle_relay_drift.rs`:

1. **Burst suppression** — per-session WARN rate-limit. The first occurrence emits immediately (fresh incidents stay visible); subsequent hits are suppressed for a 5-minute window and re-emitted with `suppressed_count` + `drift_age_secs`. The drop branch still does **not** advance the scan offset, so after a repair the next ~500ms poll re-scans the preserved tail and relays it (re-relay, **not** loss).
2. **Drift self-heal** (Claude only — settings resolver is Claude-specific and the durable DB column is written by the Claude/routine hook flow). On drift, once per session (60s cooldown + Drop-guarded single-flight) a one-shot async task promotes a **durable** channel via the existing authoritative `restore_owner_channel_for_tmux_session`:
   - (a) settings binding (`resolve_rehydrated_claude_tmux_channel_id`) — same trust as #3105;
   - (b) `sessions.channel_id` durable column (new narrow `load_session_channel_id_pg` accessor), promoted **only** behind three guards: **live pane**, **matching `instance_id`**, and **dedupe-mirror agreement**.

## Invariants preserved (#3018)

The promoted **value never comes from the mirror** — it is settings or `sessions.channel_id` (a durable value the session's own dispatch/hook flow recorded under a host+token-hash-namespaced key). The mirror is used only as (i) the drift detector and (ii) a **block-only gate**: if it disagrees with the DB channel the repair is **blocked** and the drop is kept. A validator that can only block can never be the routing authority, so #3018's "never route from the mirror" rule holds literally — the resolver's drift branch still returns `None`.

**Mis-delivery is strictly worse than a drop**, so the pure decision core (`evaluate_drift_repair`) defaults to `Blocked`/`NoSource` on any ambiguity: session-name reuse (DB≠mirror → `MirrorMismatch`), foreign instance, dead pane, no mirror witness. The single-authority registry model is unchanged.

③ (routine runner registers a session-lifetime tmux→channel binding directly, decoupled from watcher lifetime) is **deferred to a follow-up issue**: ② already collapses the drift duration from "until restart" to "≤~1.5s (poll + repair)", and ③ has a separate blast radius (`routines/agent_executor.rs` + a new registry lifetime class).

## Tests

- `idle_relay_drift` pure-core unit tests (11): rate-limiter first-emit/suppress/re-emit + per-session independence; repair decision core (settings-promote, DB-promote-on-agreement, **DB≠mirror blocks mis-delivery** [name-reuse regression], no-mirror-witness, foreign-instance, dead-pane, all-miss=NoSource); cooldown + single-flight state machine.
- `tui_prompt_relay` registry integration (`drift_triggered_restore_makes_routine_session_route_again`): routine session drift → durable restore routes again → live watcher claim wins (restore no-ops). All #3018/#3105 regressions stay green.

## Gates

- `cargo fmt` ✓
- `cargo check --lib --tests` 0 warnings ✓
- `cargo clippy --lib --tests -- -D warnings` ✓
- targeted `cargo test --lib` suites (idle_relay_drift / tui_prompt_relay / tui_prompt_dedupe) ✓
- `generate_inventory_docs.py` + `check_agent_maintenance_docs.py` ✓ (freeze synced)
- `audit_maintainability.py --check` ✓ — frozen files within baselines: tui_prompt_relay.rs **5429/5429**, mod.rs **4987/4987**, tmux_watcher.rs 9580/9583, recovery.rs 2641/2641. db/dispatched_sessions.rs +48 (change-surfaces synced).
- `check_await_holding_lock_ratchet.py` = **34** (0 new allows — all awaits complete before the synchronous registry-lock call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)