### PR TITLE
ci(#3316): nightly dashboard Playwright smoke lane

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -29,8 +29,49 @@ jobs:
           cache: npm
           cache-dependency-path: dashboard/package-lock.json
 
-      - name: dashboard build/test
+      # PR-required gate: build + Vitest only (verify-dashboard.sh).
+      # Playwright smoke is intentionally nightly-only — see issue #3316.
+      - name: dashboard build/test (PR gate path)
         run: ./scripts/verify-dashboard.sh
+
+  # Playwright smoke is a nightly-only lane: it requires a headed Chromium
+  # browser and takes longer than the fast PR gate allows.  Kept separate so
+  # PR-required branch protection is never affected by E2E flakiness.
+  dashboard_playwright:
+    name: Dashboard Playwright smoke (nightly)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: dashboard/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+        working-directory: dashboard
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: dashboard
+
+      - name: Dashboard Playwright smoke
+        id: playwright
+        run: npm run test:e2e
+        working-directory: dashboard
+
+      - name: Upload Playwright report on failure
+        if: failure() && steps.playwright.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ github.run_id }}
+          path: |
+            dashboard/playwright-report/
+            dashboard/test-results/
+          retention-days: 14
 
   full_macos:
     name: Full tests (macos-latest)


### PR DESCRIPTION
## Summary

- Closes #3316
- Adds a new `dashboard_playwright` job to `ci-nightly.yml` that installs Chromium via `playwright install --with-deps` and runs `npm run test:e2e` (the existing `test:e2e` script in `dashboard/package.json`).
- The existing `dashboard` job (build + Vitest via `verify-dashboard.sh`) is **unchanged** — it remains the PR-required gate.
- On failure, the nightly Playwright job uploads the HTML report, screenshots, and traces as a 14-day retention artifact (`playwright-report-<run-id>`).

## What changed

- `.github/workflows/ci-nightly.yml` — added `dashboard_playwright` job; added a comment on the existing `dashboard` job clarifying it is the PR-gate path.

## Gate results

| Check | Result |
|-------|--------|
| YAML syntax (`python3 yaml.safe_load`) | PASS |
| Diff scope | 1 file, +42 / -1 |

## Test plan

- [ ] Trigger `CI Nightly` via `workflow_dispatch` and confirm `dashboard_playwright` job appears and runs `test:e2e`.
- [ ] Confirm existing `dashboard` (build/Vitest) job is unaffected.
- [ ] Introduce a deliberate smoke failure; confirm Playwright report artifact is uploaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)