### PR TITLE
fix(#3314): preserve reused live Claude tmux session when wrapper I/O is missing

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -995,7 +995,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
 - `src/services/dispatches/outbox_route.rs` (1089) — dispatch outbox route
   support extracted from the route layer; split before adding non-bugfix
   behavior.
-- `src/services/claude.rs` (3948), `src/services/gemini.rs` (1358),
+- `src/services/claude.rs` (3991), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3001),
   `src/services/opencode.rs` (1881), `src/services/provider.rs` (1796) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -737,6 +737,7 @@ IMPORTANT: Format your responses using Markdown for better readability:
                 return execute_streaming_local_tmux(
                     &args,
                     prompt,
+                    session_id,
                     working_dir,
                     sender,
                     cancel_token,
@@ -2011,6 +2012,22 @@ fn classify_local_tmux_startup_plan(
     } else {
         LocalTmuxStartupPlan::ColdStart
     }
+}
+
+/// Decide whether a stale-classified tmux session must be preserved rather than
+/// killed-and-recreated. Mirrors the Codex (`codex.rs`) and Qwen (`qwen.rs`)
+/// guards: a pane that is still live (`has_live_pane`) AND was selected for
+/// provider-session reuse (a non-empty resume id) is carrying an active
+/// conversation, so missing wrapper I/O files alone must not trigger a kill.
+#[cfg(unix)]
+fn should_preserve_live_reused_provider_session(
+    resume_session_id: Option<&str>,
+    has_live_pane: bool,
+) -> bool {
+    resume_session_id
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty())
+        && has_live_pane
 }
 
 #[cfg(unix)]
@@ -3546,6 +3563,7 @@ mod claude_tui_ready_probe_tests {
 fn execute_streaming_local_tmux(
     args: &[String],
     prompt: &str,
+    session_id: Option<&str>,
     working_dir: &str,
     sender: Sender<StreamMessage>,
     cancel_token: Option<std::sync::Arc<CancelToken>>,
@@ -3572,13 +3590,18 @@ fn execute_streaming_local_tmux(
     // that older wrappers still hold open fds to — so a dcserver restart
     // that lost its /tmp files does not invalidate a still-alive tmux pane.
     let session_exists = tmux_session_exists(tmux_session_name);
+    let has_live_pane = tmux_session_has_live_pane(tmux_session_name);
     let resolved_output =
         crate::services::tmux_common::resolve_session_temp_path(tmux_session_name, "jsonl");
     let resolved_input =
         crate::services::tmux_common::resolve_session_temp_path(tmux_session_name, "input");
+    // Resume id selected for this turn (`--resume <sid>` was pushed by the
+    // caller when `session_id` is a valid id). Used to recognise a live pane
+    // that was deliberately reused for provider-session continuity.
+    let resume_session_id = session_id.filter(|sid| is_valid_session_id(sid));
     let startup_plan = classify_local_tmux_startup_plan(
         session_exists,
-        tmux_session_has_live_pane(tmux_session_name),
+        has_live_pane,
         resolved_output.is_some(),
         resolved_input.is_some(),
     );
@@ -3698,6 +3721,26 @@ fn execute_streaming_local_tmux(
                 return Ok(());
             }
         }
+    } else if startup_plan == LocalTmuxStartupPlan::RecreateStaleSession
+        && should_preserve_live_reused_provider_session(resume_session_id, has_live_pane)
+    {
+        // Parity with the Codex (codex.rs) and Qwen (qwen.rs) guards: refuse to
+        // kill a still-live pane that was deliberately selected for provider-
+        // session reuse just because its wrapper I/O files are momentarily
+        // missing (e.g. a dcserver restart lost /tmp, or runtime files were GC'd).
+        // The classifier still labels this `RecreateStaleSession`, but a live
+        // pane carrying an active `--resume` conversation must be preserved, not
+        // recreated. Fail safely with an operator-visible message instead.
+        tracing::warn!(
+            tmux_session_name,
+            session_id = resume_session_id.unwrap_or_default(),
+            output_path_present = resolved_output.is_some(),
+            input_path_present = resolved_input.is_some(),
+            "refusing to kill live Claude tmux selected for provider-session reuse"
+        );
+        return Err(format!(
+            "live Claude tmux session {tmux_session_name} was selected for reuse but wrapper I/O is unavailable; refusing stale cleanup/recreate"
+        ));
     } else if startup_plan == LocalTmuxStartupPlan::RecreateStaleSession {
         debug_log("Stale tmux session found — recreating");
         crate::services::termination_audit::record_termination_for_tmux(
@@ -4234,6 +4277,34 @@ mod local_tmux_lifecycle_tests {
                 "existing tmux sessions missing live ownership evidence must be killed and recreated"
             );
         }
+    }
+
+    #[test]
+    fn live_reused_provider_session_is_preserved_when_wrapper_io_is_missing() {
+        // Parity with codex.rs / qwen.rs: a live pane selected for reuse (valid,
+        // non-empty resume id) must be preserved even though the classifier
+        // labels it RecreateStaleSession because its wrapper I/O files are gone.
+        assert!(should_preserve_live_reused_provider_session(
+            Some("claude-session-1"),
+            true,
+        ));
+        // A genuinely dead pane (no live pane) is still recreated, even with a
+        // resume id — preservation must never over-protect a stale session.
+        assert!(!should_preserve_live_reused_provider_session(
+            Some("claude-session-1"),
+            false,
+        ));
+        // A live pane that was NOT selected for reuse (no/blank resume id) has
+        // no conversation to protect, so the normal recreate path applies.
+        assert!(!should_preserve_live_reused_provider_session(None, true));
+        assert!(!should_preserve_live_reused_provider_session(
+            Some("  "),
+            true
+        ));
+        assert!(!should_preserve_live_reused_provider_session(
+            Some(""),
+            true
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Closes #3314.

## Context
The implementer branch `fix/3314-claude-live-session-preserve` was never pushed and contained no changes, so this fix was authored during adversarial review.

## Problem
Claude's legacy local-tmux driver `execute_streaming_local_tmux` (the fallback path taken when the TUI hook endpoint is unavailable, e.g. right after a dcserver restart) classified any existing session lacking both runtime I/O paths as `RecreateStaleSession` and killed the tmux pane — even when the pane was still live and had been deliberately selected for provider-session reuse via `--resume`. After a restart, `/tmp` loss, or runtime-file GC this killed active Claude work. Codex (`codex.rs:2184`) and Qwen (`qwen.rs:1242`) already had explicit live-session preservation guards; Claude did not.

## Fix
- Add `should_preserve_live_reused_provider_session(resume_session_id, has_live_pane)` mirroring the Qwen 2-arg guard.
- Insert a guard ahead of the stale-recreate kill branch: when the pane is live AND a valid non-empty resume id was selected, refuse the kill and return an operator-visible error instead of recreating.
- Thread `session_id` into the legacy driver and update the call site.
- Add a regression test (`live_reused_provider_session_is_preserved_when_wrapper_io_is_missing`) alongside the Codex/Qwen equivalents.

## Non-regression / no over-preservation
- Genuinely dead panes (`has_live_pane == false`) still recreate.
- Live panes with no resume id (fresh sessions) still recreate.
- `classify_local_tmux_startup_plan` behavior is unchanged; the classifier tests stay green.

## Gates (isolated worktree)
- `cargo fmt --check`: clean
- `cargo clippy --lib --tests -- -D warnings`: clean
- `cargo test --lib services::claude::`: 40 passed, 0 failed
- `audit_maintainability.py --check`: exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)