### PR TITLE
fix(#3311): protect root TUI/hook control-plane routes and validate /tui/send input

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -917,7 +917,7 @@
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
   - `src/config.rs` (2272 lines).
-  - `src/server/mod.rs` (2239 lines).
+  - `src/server/mod.rs` (2267 lines).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1488 lines).
   - `src/reconcile.rs` (1809 lines; periodic reconcile loop covering stale

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -406,6 +406,15 @@ pub(crate) async fn run(
     let dashboard_service = ServeDir::new(&dashboard_dir)
         .append_index_html_on_directories(true)
         .fallback(ServeFile::new(dashboard_dir.join("index.html")));
+    let control_plane_auth_state = routes::AppState {
+        pg_pool: pg_pool.clone(),
+        engine: engine.clone(),
+        config: Arc::new(config.clone()),
+        broadcast_tx: broadcast_tx.clone(),
+        batch_buffer: batch_buffer.clone(),
+        health_registry: health_registry.clone(),
+        cluster_instance_id: Some(cluster_instance_id.clone()),
+    };
 
     let mut app = Router::new()
         .route("/ws", get(ws::ws_handler).with_state(broadcast_tx.clone()))
@@ -422,13 +431,25 @@ pub(crate) async fn run(
             ),
         );
     if _claude_tui_hook_endpoint.is_some() {
-        app = app.merge(crate::services::claude_tui::hook_server::hook_receiver_router());
+        app = app.merge(
+            crate::services::claude_tui::hook_server::hook_receiver_router().layer(
+                axum::middleware::from_fn_with_state(
+                    control_plane_auth_state.clone(),
+                    routes::auth::auth_middleware,
+                ),
+            ),
+        );
     }
     // `tui_relay` exposes the `claude_tui_send` / `claude_tui_wait` MCP
     // primitives (see audit issue #2652). It is always mounted because the
     // event-driven wait path is useful even when the hook receiver
     // endpoint has not been published yet (e.g. early-boot Codex calls).
-    app = app.merge(crate::services::claude_tui::tui_relay::router());
+    app = app.merge(crate::services::claude_tui::tui_relay::router().layer(
+        axum::middleware::from_fn_with_state(
+            control_plane_auth_state,
+            routes::auth::auth_middleware,
+        ),
+    ));
     let app = app.fallback_service(dashboard_service);
 
     let addr = format!("{}:{}", config.server.host, config.server.port);
@@ -2358,5 +2379,208 @@ async fn routine_runtime_loop(
             Ok(_) => {}
             Err(e) => tracing::warn!(error = %e, "routine due tick failed"),
         }
+    }
+}
+
+/// Auth-boundary integration tests for the root-mounted control-plane routers
+/// (`/tui/*`, `/hooks/*`). These live in the server layer because composing a
+/// router with `auth::auth_middleware` is a server-layer responsibility — the
+/// service modules only own the handler/validation behavior (#3311). The
+/// service-layer tests (control-character rejection, handler success) stay
+/// next to their handlers in `services::claude_tui`.
+#[cfg(test)]
+mod control_plane_auth_tests {
+    use std::net::SocketAddr;
+    use std::sync::Arc;
+
+    use axum::Router;
+    use axum::body::{Body, to_bytes};
+    use axum::extract::ConnectInfo;
+    use axum::http::{Method, Request, StatusCode, header::AUTHORIZATION};
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+
+    use crate::server::routes::AppState;
+    use crate::server::routes::auth::auth_middleware;
+    use crate::services::claude_tui::hook_server::{
+        HookServerState, hook_receiver_router_with_state,
+    };
+    use crate::services::claude_tui::tui_relay::{FakeSendBackend, router_with_send_backend};
+
+    fn test_app_state(auth_token: Option<&str>) -> AppState {
+        let mut config = crate::config::Config::default();
+        // Non-loopback host so the middleware cannot fall back to a host-based
+        // shortcut; the boundary must be proven by peer addr / Bearer alone.
+        config.server.host = "0.0.0.0".to_string();
+        config.server.auth_token = auth_token.map(str::to_string);
+        let tx = crate::eventbus::new_broadcast();
+        let buf = crate::eventbus::spawn_batch_flusher(tx.clone());
+        AppState {
+            pg_pool: None,
+            engine: crate::engine::PolicyEngine::new(&config).expect("test policy engine"),
+            config: Arc::new(config),
+            broadcast_tx: tx,
+            batch_buffer: buf,
+            health_registry: None,
+            cluster_instance_id: None,
+        }
+    }
+
+    fn protected_tui_router(auth_token: Option<&str>) -> Router {
+        router_with_send_backend(Arc::new(FakeSendBackend)).layer(
+            axum::middleware::from_fn_with_state(test_app_state(auth_token), auth_middleware),
+        )
+    }
+
+    fn protected_hook_router(auth_token: Option<&str>) -> Router {
+        hook_receiver_router_with_state(HookServerState::new()).layer(
+            axum::middleware::from_fn_with_state(test_app_state(auth_token), auth_middleware),
+        )
+    }
+
+    fn tui_send_request(peer: &str, token: Option<&str>, text: &str) -> Request<Body> {
+        let body = json!({
+            "session_name": "test-session",
+            "text": text,
+            "submit": true,
+        });
+        let mut request = Request::builder()
+            .method(Method::POST)
+            .uri("/tui/send")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("build request");
+        request.extensions_mut().insert(ConnectInfo(
+            peer.parse::<SocketAddr>().expect("valid socket addr"),
+        ));
+        if let Some(token) = token {
+            request.headers_mut().insert(
+                AUTHORIZATION,
+                format!("Bearer {token}").parse().expect("valid bearer"),
+            );
+        }
+        request
+    }
+
+    fn hook_request(peer: &str, token: Option<&str>) -> Request<Body> {
+        let mut request = Request::builder()
+            .method(Method::POST)
+            .uri("/hooks/claude/Stop?session_id=sess-auth")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"hook_event_name":"Stop"}"#))
+            .expect("build request");
+        request.extensions_mut().insert(ConnectInfo(
+            peer.parse::<SocketAddr>().expect("valid socket addr"),
+        ));
+        if let Some(token) = token {
+            request.headers_mut().insert(
+                AUTHORIZATION,
+                format!("Bearer {token}").parse().expect("valid bearer"),
+            );
+        }
+        request
+    }
+
+    async fn response_json(response: axum::response::Response) -> Value {
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        serde_json::from_slice(&bytes).expect("json response")
+    }
+
+    #[tokio::test]
+    async fn tui_send_rejects_unauthenticated_non_loopback_when_protected() {
+        let app = protected_tui_router(Some("secret"));
+
+        let response = app
+            .oneshot(tui_send_request("10.0.0.5:8791", None, "hello"))
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn tui_send_rejects_unauthenticated_non_loopback_when_unconfigured() {
+        // Defense in depth: even with no auth_token configured ("local-only
+        // mode"), a non-loopback caller must NOT reach the control plane.
+        let app = protected_tui_router(None);
+
+        let response = app
+            .oneshot(tui_send_request("10.0.0.5:8791", None, "hello"))
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn tui_send_valid_input_with_valid_auth_returns_success() {
+        let app = protected_tui_router(Some("secret"));
+
+        let response = app
+            .oneshot(tui_send_request(
+                "10.0.0.5:8791",
+                Some("secret"),
+                "hello\nworld",
+            ))
+            .await
+            .expect("response");
+        let status = response.status();
+        let body = response_json(response).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["session_name"], "test-session");
+        assert_eq!(body["bytes"].as_u64(), Some("hello\nworld".len() as u64));
+        assert_eq!(body["submitted"], true);
+    }
+
+    #[tokio::test]
+    async fn tui_send_allows_loopback_without_bearer_when_protected() {
+        let app = protected_tui_router(Some("secret"));
+
+        let response = app
+            .oneshot(tui_send_request("127.0.0.1:8791", None, "hello"))
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn hook_receiver_rejects_unauthenticated_non_loopback_when_protected() {
+        let app = protected_hook_router(Some("secret"));
+
+        let response = app
+            .oneshot(hook_request("10.0.0.5:8791", None))
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn hook_receiver_rejects_unauthenticated_non_loopback_when_unconfigured() {
+        let app = protected_hook_router(None);
+
+        let response = app
+            .oneshot(hook_request("10.0.0.5:8791", None))
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn hook_receiver_allows_loopback_without_bearer_when_protected() {
+        let app = protected_hook_router(Some("secret"));
+
+        let response = app
+            .oneshot(hook_request("127.0.0.1:8791", None))
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
     }
 }

--- a/src/server/routes/auth.rs
+++ b/src/server/routes/auth.rs
@@ -31,6 +31,8 @@ pub async fn get_session(State(state): State<AppState>) -> Json<serde_json::Valu
 /// paths because headers are trivially forgeable by a LAN attacker.
 fn is_internal_loopback_path(path: &str) -> bool {
     path.starts_with("/hook/")
+        || path.starts_with("/hooks/")
+        || path.starts_with("/tui/")
         || path == "/dispatched-sessions/webhook"
         || path.starts_with("/internal/")
 }
@@ -70,12 +72,40 @@ fn unauthorized_response() -> axum::response::Response {
 }
 
 /// Auth middleware: checks Bearer token against config.server.auth_token.
-/// If auth_token is not set, all requests pass through (local-only mode).
+/// If auth_token is not set, non-internal requests pass through (local-only
+/// mode). Internal control-plane routes still require loopback peer proof or a
+/// configured Bearer token.
 pub async fn auth_middleware(
     State(state): State<AppState>,
     req: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> axum::response::Response {
+    // Note: path is relative to the /api nest, so "/health" not "/api/health"
+    let path = req.uri().path();
+    let headers = req.headers().clone();
+    let peer = peer_addr_from_request(&req);
+
+    // Internal in-process paths (escalation emit, dispatch↔thread link,
+    // hook/* state mutations, root TUI/hook control-plane routes,
+    // dispatched-sessions webhook). Require strict loopback peer OR matching
+    // Bearer token — never accept Origin/Referer alone since those are
+    // forgeable from the LAN.
+    if is_internal_loopback_path(path) {
+        if is_loopback_peer(peer) {
+            return next.run(req).await;
+        }
+        if let Some(expected_token) = state.config.server.auth_token.as_deref() {
+            if !expected_token.is_empty() {
+                if let Some(token) = extract_bearer(&headers) {
+                    if crate::utils::auth::constant_time_token_eq(expected_token, token) {
+                        return next.run(req).await;
+                    }
+                }
+            }
+        }
+        return unauthorized_response();
+    }
+
     let Some(expected_token) = state.config.server.auth_token.as_deref() else {
         // No auth configured — pass through
         return next.run(req).await;
@@ -85,32 +115,10 @@ pub async fn auth_middleware(
         return next.run(req).await;
     }
 
-    // Note: path is relative to the /api nest, so "/health" not "/api/health"
-    let path = req.uri().path();
-
     // Truly-public endpoints. These return no privileged data and are safe to
     // expose without authentication on any interface.
     if path == "/health" || path == "/auth/session" {
         return next.run(req).await;
-    }
-
-    let headers = req.headers().clone();
-    let peer = peer_addr_from_request(&req);
-
-    // Internal in-process paths (escalation emit, dispatch↔thread link,
-    // hook/* state mutations, dispatched-sessions webhook). Require strict
-    // loopback peer OR matching Bearer token — never accept Origin/Referer
-    // alone since those are forgeable from the LAN.
-    if is_internal_loopback_path(path) {
-        if is_loopback_peer(peer) {
-            return next.run(req).await;
-        }
-        if let Some(token) = extract_bearer(&headers) {
-            if crate::utils::auth::constant_time_token_eq(expected_token, token) {
-                return next.run(req).await;
-            }
-        }
-        return unauthorized_response();
     }
 
     // Same-origin bypass (dashboard SPA served from this server). #2047
@@ -188,6 +196,9 @@ mod tests {
         assert!(is_internal_loopback_path("/hook/reset-status"));
         assert!(is_internal_loopback_path("/hook/skill-usage"));
         assert!(is_internal_loopback_path("/hook/session/abc"));
+        assert!(is_internal_loopback_path("/hooks/claude/Stop"));
+        assert!(is_internal_loopback_path("/tui/send"));
+        assert!(is_internal_loopback_path("/tui/wait"));
         assert!(is_internal_loopback_path("/dispatched-sessions/webhook"));
     }
 

--- a/src/services/claude_tui/hook_server.rs
+++ b/src/services/claude_tui/hook_server.rs
@@ -167,7 +167,7 @@ pub fn hook_receiver_router() -> Router {
     hook_receiver_router_with_state(HOOK_SERVER_STATE.clone())
 }
 
-fn hook_receiver_router_with_state(state: HookServerState) -> Router {
+pub(crate) fn hook_receiver_router_with_state(state: HookServerState) -> Router {
     Router::new()
         .route("/hooks/{provider}/{event}", post(receive_hook))
         .layer(DefaultBodyLimit::max(8 * 1024 * 1024))

--- a/src/services/claude_tui/input.rs
+++ b/src/services/claude_tui/input.rs
@@ -1250,7 +1250,7 @@ fn prompt_ready_debug_tail(pane: &str) -> String {
     crate::utils::format::safe_suffix(tail.trim(), PROMPT_READY_DEBUG_TAIL_BYTES).to_string()
 }
 
-fn validate_prompt_text(input: &str) -> Result<(), String> {
+pub(crate) fn validate_prompt_text(input: &str) -> Result<(), String> {
     // Block terminal control channels such as ESC bracketed-paste markers,
     // DEL, and C1 controls before either literal send or tmux paste-buffer
     // delivery can relay them into the hosted TUI.

--- a/src/services/claude_tui/tui_relay.rs
+++ b/src/services/claude_tui/tui_relay.rs
@@ -24,14 +24,15 @@
 //!   (`hook_server::subscribe_hook_events`) so we observe Stop events the
 //!   moment they land instead of polling the transcript every second.
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
-use axum::{Json, Router, routing::post};
+use axum::{Json, Router, extract::State, http::StatusCode, routing::post};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::time::Instant;
 
 use crate::services::claude_tui::hook_server::{HookEvent, HookEventKind, subscribe_hook_events};
+use crate::services::claude_tui::input::validate_prompt_text;
 use crate::services::platform::tmux;
 
 /// Hard ceiling on `claude_tui_wait` timeout so a misbehaving caller cannot
@@ -45,6 +46,43 @@ const DEFAULT_WAIT_TIMEOUT: Duration = Duration::from_secs(120);
 /// so concurrent sends to different sessions cannot stomp each other.
 fn allocate_buffer_name() -> String {
     format!("adk-tui-send-{}", uuid::Uuid::new_v4().simple())
+}
+
+pub(crate) trait SendBackend: Send + Sync {
+    fn has_session(&self, session_name: &str) -> bool;
+    fn load_buffer(&self, buffer_name: &str, text: &str) -> Result<(), String>;
+    fn paste_buffer(
+        &self,
+        session_name: &str,
+        buffer_name: &str,
+        delete: bool,
+    ) -> Result<(), String>;
+    fn send_enter(&self, session_name: &str) -> Result<(), String>;
+}
+
+struct TmuxSendBackend;
+
+impl SendBackend for TmuxSendBackend {
+    fn has_session(&self, session_name: &str) -> bool {
+        tmux::has_session(session_name)
+    }
+
+    fn load_buffer(&self, buffer_name: &str, text: &str) -> Result<(), String> {
+        tmux::load_buffer(buffer_name, text).map(|_| ())
+    }
+
+    fn paste_buffer(
+        &self,
+        session_name: &str,
+        buffer_name: &str,
+        delete: bool,
+    ) -> Result<(), String> {
+        tmux::paste_buffer(session_name, buffer_name, delete).map(|_| ())
+    }
+
+    fn send_enter(&self, session_name: &str) -> Result<(), String> {
+        tmux::send_keys(session_name, &["Enter"]).map(|_| ())
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -110,54 +148,70 @@ fn default_true() -> bool {
 }
 
 pub fn router() -> Router {
+    router_with_send_backend(Arc::new(TmuxSendBackend))
+}
+
+pub(crate) fn router_with_send_backend(backend: Arc<dyn SendBackend>) -> Router {
     Router::new()
         .route("/tui/send", post(handle_send))
         .route("/tui/wait", post(handle_wait))
+        .with_state(backend)
 }
 
-async fn handle_send(Json(req): Json<SendRequest>) -> Json<Value> {
+async fn handle_send(
+    State(backend): State<Arc<dyn SendBackend>>,
+    Json(req): Json<SendRequest>,
+) -> (StatusCode, Json<Value>) {
+    handle_send_with_backend(req, backend.as_ref())
+}
+
+fn handle_send_with_backend(
+    req: SendRequest,
+    backend: &dyn SendBackend,
+) -> (StatusCode, Json<Value>) {
     let session_name = req.session_name.trim().to_string();
     if session_name.is_empty() {
-        return Json(error_json("session_name is required"));
+        return bad_request_json("session_name is required");
     }
-    if !tmux::has_session(&session_name) {
-        return Json(error_json(&format!(
-            "tmux session not found: {session_name}"
-        )));
+    if let Err(error) = validate_prompt_text(&req.text) {
+        return bad_request_json(&error);
+    }
+    if !backend.has_session(&session_name) {
+        return ok_error_json(&format!("tmux session not found: {session_name}"));
     }
     if req.text.is_empty() && !req.submit {
         // Empty text + no submit would be a no-op. Surface this as a 400 so
         // upstream bugs do not silently swallow attempted relays.
-        return Json(error_json(
+        return bad_request_json(
             "text must not be empty when submit=false (call would be a no-op)",
-        ));
+        );
     }
 
     let bytes = req.text.len();
     if !req.text.is_empty() {
         let buffer_name = allocate_buffer_name();
-        if let Err(error) = tmux::load_buffer(&buffer_name, &req.text) {
-            return Json(error_json(&format!("tmux load-buffer failed: {error}")));
+        if let Err(error) = backend.load_buffer(&buffer_name, &req.text) {
+            return ok_error_json(&format!("tmux load-buffer failed: {error}"));
         }
 
         // `paste-buffer -p -r -d` pastes in bracketed-paste mode (so the TUI
         // recognises it as a paste, not many tiny keystrokes), preserves LF
         // (so it does NOT get auto-Enter'd by tmux), and deletes the buffer
         // after pasting.
-        if let Err(error) = tmux::paste_buffer(&session_name, &buffer_name, true) {
+        if let Err(error) = backend.paste_buffer(&session_name, &buffer_name, true) {
             // Best-effort cleanup of the orphan buffer is fine to skip:
             // tmux removes buffers when the server exits and we never reuse
             // the UUID-suffixed name.
-            return Json(error_json(&format!("tmux paste-buffer failed: {error}")));
+            return ok_error_json(&format!("tmux paste-buffer failed: {error}"));
         }
     }
 
     let mut submitted = false;
     if req.submit {
-        match tmux::send_keys(&session_name, &["Enter"]) {
-            Ok(_) => submitted = true,
+        match backend.send_enter(&session_name) {
+            Ok(()) => submitted = true,
             Err(error) => {
-                return Json(error_json(&format!("tmux send-keys Enter failed: {error}")));
+                return ok_error_json(&format!("tmux send-keys Enter failed: {error}"));
             }
         }
     }
@@ -168,7 +222,10 @@ async fn handle_send(Json(req): Json<SendRequest>) -> Json<Value> {
         bytes,
         submitted,
     };
-    Json(serde_json::to_value(resp).unwrap_or_else(|_| json!({ "ok": true })))
+    (
+        StatusCode::OK,
+        Json(serde_json::to_value(resp).unwrap_or_else(|_| json!({ "ok": true }))),
+    )
 }
 
 async fn handle_wait(Json(req): Json<WaitRequest>) -> Json<Value> {
@@ -306,11 +363,94 @@ fn error_json(message: &str) -> Value {
     json!({ "ok": false, "error": message })
 }
 
+fn ok_error_json(message: &str) -> (StatusCode, Json<Value>) {
+    (StatusCode::OK, Json(error_json(message)))
+}
+
+fn bad_request_json(message: &str) -> (StatusCode, Json<Value>) {
+    (StatusCode::BAD_REQUEST, Json(error_json(message)))
+}
+
+/// Test-only `SendBackend` exposed to the crate so the server-layer
+/// auth-boundary integration tests (which own the middleware wiring) can mount
+/// `/tui/send` without touching tmux. Kept next to the trait it implements; the
+/// auth-boundary assertions live under `crate::server` because middleware
+/// composition is a server-layer responsibility (#3311).
+#[cfg(test)]
+pub(crate) struct FakeSendBackend;
+
+#[cfg(test)]
+impl SendBackend for FakeSendBackend {
+    fn has_session(&self, _session_name: &str) -> bool {
+        true
+    }
+
+    fn load_buffer(&self, _buffer_name: &str, _text: &str) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn paste_buffer(
+        &self,
+        _session_name: &str,
+        _buffer_name: &str,
+        _delete: bool,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn send_enter(&self, _session_name: &str) -> Result<(), String> {
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::http::StatusCode;
     use chrono::Utc;
     use serde_json::json;
+
+    fn send_request(text: &str, submit: bool) -> SendRequest {
+        SendRequest {
+            session_name: "test-session".to_string(),
+            text: text.to_string(),
+            submit,
+        }
+    }
+
+    #[test]
+    fn handle_send_rejects_control_characters_with_bad_request() {
+        let (status, body) =
+            handle_send_with_backend(send_request("hello\u{1b}[31m", true), &FakeSendBackend);
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            body.0["error"],
+            "prompt contains unsupported terminal control characters"
+        );
+    }
+
+    #[test]
+    fn handle_send_rejects_empty_session_name() {
+        let mut req = send_request("hello", true);
+        req.session_name = "   ".to_string();
+        let (status, body) = handle_send_with_backend(req, &FakeSendBackend);
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body.0["error"], "session_name is required");
+    }
+
+    #[test]
+    fn handle_send_valid_input_returns_success() {
+        let (status, body) =
+            handle_send_with_backend(send_request("hello\nworld", true), &FakeSendBackend);
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body.0["ok"], true);
+        assert_eq!(body.0["session_name"], "test-session");
+        assert_eq!(body.0["bytes"].as_u64(), Some("hello\nworld".len() as u64));
+        assert_eq!(body.0["submitted"], true);
+    }
 
     fn make_event(provider: &str, sid: &str, kind: HookEventKind, payload: Value) -> HookEvent {
         HookEvent {


### PR DESCRIPTION
## Summary
Closes the audit finding (#3311, P0): `/tui/*` and `/hooks/*` were mounted at the root router outside `/api` auth, and `/tui/send` could paste arbitrary text bypassing the TUI prompt control-character validator.

## Changes
- `/tui/send`, `/tui/wait`, `/hooks/*` moved behind `auth_middleware`; internal-loopback-path check precedes the auth_token check so non-loopback callers are rejected even when no token is configured (defense-in-depth — localhost binding does not substitute for auth).
- `/tui/send` runs `validate_prompt_text` before `has_session`, blocking ESC/C0/C1/DEL control-character injection.
- Internal callers (hook_relay, rollout_tail) are loopback → no regression.

## Verification
- codex implemented; opus adversarial cross-review found no residual bypass (peer is ConnectInfo-based so headers can't be forged; `/ws` is broadcast-only and out of scope).
- Gates: fmt, clippy -D warnings, audit --check, tui_relay 11 + hook_server 17 + server auth 7 + auth 6 (76 passed). change-surfaces server/mod.rs freeze synced 2239→2267 (no baseline raise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)