### PR TITLE
security(#3315): redact ADK prompt manifest full content from logs and /inspect

### DIFF
--- a/src/services/discord/commands/inspect/mod.rs
+++ b/src/services/discord/commands/inspect/mod.rs
@@ -123,7 +123,7 @@ async fn build_inspect_report(
             let Some(manifest) = load_latest_prompt_manifest(pool, channel_id).await? else {
                 return Ok(no_data_report());
             };
-            Ok(render_prompt_manifest_report(&manifest))
+            Ok(render_prompt_manifest_report(&manifest, false))
         }
         InspectView::Context => {
             let Some(turn) = load_latest_turn(pool, channel_id).await? else {

--- a/src/services/discord/commands/inspect/render_prompt.rs
+++ b/src/services/discord/commands/inspect/render_prompt.rs
@@ -7,8 +7,12 @@ use crate::db::prompt_manifests::{PromptContentVisibility, PromptManifest, Promp
 const SOURCE_MAX_CHARS: usize = 30;
 const PROMPT_LAYER_CONTENT_MAX_CHARS: usize = 360;
 const PROMPT_LAYER_CONTENT_MAX_LAYERS: usize = 6;
+const ADK_PROMPT_LAYER_PREVIEW_MAX_CHARS: usize = 100;
 
-pub(super) fn render_prompt_manifest_report(manifest: &PromptManifest) -> String {
+pub(super) fn render_prompt_manifest_report(
+    manifest: &PromptManifest,
+    is_privileged: bool,
+) -> String {
     let mut out = String::new();
     push_line(
         &mut out,
@@ -54,7 +58,11 @@ pub(super) fn render_prompt_manifest_report(manifest: &PromptManifest) -> String
     push_line(&mut out, "");
     push_line(
         &mut out,
-        "Layer content (ADK full source, user redacted preview)",
+        if is_privileged {
+            "Layer content (ADK full source, user redacted preview)"
+        } else {
+            "Layer content (ADK hash + bounded preview, user redacted preview)"
+        },
     );
     for layer in manifest
         .layers
@@ -70,7 +78,7 @@ pub(super) fn render_prompt_manifest_report(manifest: &PromptManifest) -> String
                 visibility_label(layer.content_visibility)
             ),
         );
-        for line in layer_display_body(layer)
+        for line in layer_display_body(layer, is_privileged)
             .lines()
             .flat_map(|line| wrap_line(line, REPORT_LINE_MAX - 2))
             .take(6)
@@ -125,18 +133,45 @@ fn format_prompt_manifest_storage(manifest: &PromptManifest) -> String {
     )
 }
 
-fn layer_display_body(layer: &PromptManifestLayer) -> String {
-    let raw = match layer.content_visibility {
-        PromptContentVisibility::AdkProvided => layer
+fn layer_display_body(layer: &PromptManifestLayer, is_privileged: bool) -> String {
+    match layer.content_visibility {
+        PromptContentVisibility::AdkProvided => format_adk_layer_display_body(layer, is_privileged),
+        PromptContentVisibility::UserDerived => {
+            let raw = layer
+                .redacted_preview
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or("(redacted preview 없음)");
+            truncate_chars(raw.trim(), PROMPT_LAYER_CONTENT_MAX_CHARS)
+        }
+    }
+}
+
+fn format_adk_layer_display_body(layer: &PromptManifestLayer, is_privileged: bool) -> String {
+    if is_privileged {
+        let raw = layer
             .full_content
             .as_deref()
             .filter(|value| !value.trim().is_empty())
-            .unwrap_or("(content 없음)"),
-        PromptContentVisibility::UserDerived => layer
-            .redacted_preview
-            .as_deref()
-            .filter(|value| !value.trim().is_empty())
-            .unwrap_or("(redacted preview 없음)"),
-    };
-    truncate_chars(raw.trim(), PROMPT_LAYER_CONTENT_MAX_CHARS)
+            .unwrap_or("(content 없음)");
+        return format!(
+            "sha256: {}\nfull source: {}",
+            layer.content_sha256,
+            truncate_chars(raw.trim(), PROMPT_LAYER_CONTENT_MAX_CHARS)
+        );
+    }
+
+    let preview = layer
+        .redacted_preview
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            layer
+                .full_content
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .map(|value| truncate_chars(value.trim(), ADK_PROMPT_LAYER_PREVIEW_MAX_CHARS))
+        .unwrap_or_else(|| "(preview 없음)".to_string());
+    format!("sha256: {}\npreview: {preview}", layer.content_sha256)
 }

--- a/src/services/discord/commands/inspect/tests.rs
+++ b/src/services/discord/commands/inspect/tests.rs
@@ -29,10 +29,13 @@ fn test_manifest() -> PromptManifest {
                 tokens_est: 100,
                 content_sha256: "a".repeat(64),
                 content_visibility: PromptContentVisibility::AdkProvided,
-                full_content: Some("ADK full body with ``` fence".to_string()),
-                redacted_preview: None,
+                full_content: Some(format!(
+                    "{}\nADK SECRET TAIL MUST NOT LEAK",
+                    "ADK full body with ``` fence ".repeat(8)
+                )),
+                redacted_preview: Some("ADK bounded preview with ``` fence".to_string()),
                 is_truncated: false,
-                original_bytes: Some(28),
+                original_bytes: Some(248),
             },
             PromptManifestLayer {
                 id: None,
@@ -85,16 +88,28 @@ mod prompt {
     use super::*;
 
     #[test]
-    fn prompt_report_uses_full_adk_body_but_only_redacted_user_preview() {
-        let report = render_prompt_manifest_report(&test_manifest());
+    fn prompt_report_uses_adk_preview_and_only_redacted_user_preview() {
+        let report = render_prompt_manifest_report(&test_manifest(), false);
 
-        assert!(report.contains("ADK full body"));
+        assert!(report.contains("Layer content (ADK hash + bounded preview"));
+        assert!(report.contains(&"a".repeat(64)));
+        assert!(report.contains("ADK bounded preview"));
+        assert!(!report.contains("ADK SECRET TAIL"));
         assert!(report.contains("redacted user preview"));
         assert!(!report.contains("SECRET USER BODY"));
         assert!(report.contains("``\u{200B}` fence"));
         assert!(report.contains("storage:"));
-        assert!(report.contains("58 original bytes"));
+        assert!(report.contains("278 original bytes"));
         assert!(report.contains("0 truncated"));
+    }
+
+    #[test]
+    fn privileged_prompt_report_can_show_full_adk_body() {
+        let report = render_prompt_manifest_report(&test_manifest(), true);
+
+        assert!(report.contains("Layer content (ADK full source"));
+        assert!(report.contains("ADK SECRET TAIL MUST NOT LEAK"));
+        assert!(!report.contains("SECRET USER BODY"));
     }
 }
 

--- a/src/services/discord/prompt_builder/dispatch_contract_tests.rs
+++ b/src/services/discord/prompt_builder/dispatch_contract_tests.rs
@@ -1,10 +1,11 @@
 use super::dispatch_contract::render_dispatch_contract;
 use super::manifest::{
     memory_recall_manifest_layer, prompt_manifest_content_sha256, recovery_context_manifest_layer,
+    role_prompt_manifest_layer, truncate_prompt_manifest_preview,
 };
 use super::*;
 use crate::db::prompt_manifests::PromptContentVisibility;
-use crate::services::discord::settings::MemoryBackendKind;
+use crate::services::discord::settings::{MemoryBackendKind, RoleBinding};
 use crate::services::observability::recovery_audit::{
     RecoveryAuditRecord, recovery_context_sha256,
 };
@@ -39,6 +40,62 @@ fn build_prompt_with_optional_manifest_for(
         None,
         Some("turn-current-task-test"),
     )
+}
+
+fn test_role_binding(role_id: &str) -> RoleBinding {
+    RoleBinding {
+        role_id: role_id.to_string(),
+        prompt_file: "/nonexistent".to_string(),
+        provider: None,
+        model: None,
+        reasoning_effort: None,
+        peer_agents_enabled: true,
+        quality_feedback_injection_enabled: true,
+        memory: Default::default(),
+    }
+}
+
+#[test]
+fn prompt_manifest_log_records_hash_metadata_without_full_content() {
+    // The `info!("recorded prompt manifest", ...)` call logs the manifest's
+    // `turn_id`/`channel_id`/`layer_count` plus the `?layer_hashes` field whose
+    // value is the Debug render of `prompt_manifest_layer_hashes(...)`. Asserting
+    // on that pure value (instead of capturing subscriber output) is
+    // deterministic — a global tracing callsite-interest race in the 3k-test
+    // binary otherwise leaves a captured buffer empty under parallel execution.
+    let current_task = CurrentTaskContext {
+        dispatch_id: Some("dispatch-log-secret"),
+        card_title: Some("Instrument prompt manifest logging"),
+        ..CurrentTaskContext::default()
+    };
+    let built = build_prompt_with_manifest_for(&current_task, Some("implementation"));
+
+    let manifest = built.manifest.expect("prompt manifest");
+    let dispatch_layer = manifest
+        .layers
+        .iter()
+        .find(|layer| layer.layer_name == "dispatch_contract")
+        .expect("dispatch_contract manifest layer");
+    let full_content = dispatch_layer.full_content.as_deref().unwrap();
+    let sensitive_contract_fragment = "PATCH /api/dispatches/dispatch-log-secret";
+    // Full content stays in the manifest for storage/audit even though it is
+    // never emitted to the log surface below.
+    assert!(full_content.contains(sensitive_contract_fragment));
+
+    // Exactly the metadata logged at info level — no full_content field exists.
+    let layer_hashes = format!("{:?}", prompt_manifest_layer_hashes(&manifest));
+    assert_eq!(manifest.layers.len(), 3);
+    assert_eq!(manifest.turn_id, "turn-current-task-test");
+    assert!(layer_hashes.contains("dispatch_contract"));
+    assert!(layer_hashes.contains(&dispatch_layer.content_sha256));
+    for layer in &manifest.layers {
+        assert!(layer_hashes.contains(layer.layer_name.as_str()));
+        assert!(layer_hashes.contains(layer.content_sha256.as_str()));
+    }
+    // The logged hash list must never carry the body or any sensitive fragment.
+    assert!(!layer_hashes.contains("full_content"));
+    assert!(!layer_hashes.contains(sensitive_contract_fragment));
+    assert!(!layer_hashes.contains("PATCH /api/dispatches"));
 }
 
 #[test]
@@ -143,12 +200,15 @@ fn dispatch_contract_layer_records_adk_full_content() {
         layer.content_visibility,
         PromptContentVisibility::AdkProvided
     );
-    assert!(layer.redacted_preview.is_none());
     assert_eq!(
         layer.full_content.as_deref(),
         render_dispatch_contract(Some("implementation"), &current_task).as_deref()
     );
     let full_content = layer.full_content.as_deref().unwrap();
+    assert_eq!(
+        layer.redacted_preview.as_deref(),
+        Some(truncate_prompt_manifest_preview(full_content, 200).as_str())
+    );
     assert_eq!(
         layer.content_sha256,
         prompt_manifest_content_sha256(full_content)
@@ -156,6 +216,30 @@ fn dispatch_contract_layer_records_adk_full_content() {
     assert!(full_content.contains("[Dispatch Contract]"));
     assert!(full_content.contains("`OUTCOME: noop`"));
     assert!(full_content.contains("PATCH /api/dispatches/dispatch-1537"));
+}
+
+#[test]
+fn role_prompt_layer_records_adk_preview_while_preserving_full_content() {
+    let binding = test_role_binding("project-agentdesk");
+    let full_content = format!(
+        "{}TAIL SECTION MUST REMAIN ONLY IN full_content",
+        "Role prompt authoritative source. ".repeat(12)
+    );
+    let expected_preview = truncate_prompt_manifest_preview(&full_content, 200);
+
+    let layer = role_prompt_manifest_layer(&binding, true, Some(full_content.clone()));
+
+    assert_eq!(layer.layer_name, "role_prompt");
+    assert!(layer.enabled);
+    assert_eq!(
+        layer.content_visibility,
+        PromptContentVisibility::AdkProvided
+    );
+    assert_eq!(layer.full_content.as_deref(), Some(full_content.as_str()));
+    assert_eq!(
+        layer.redacted_preview.as_deref(),
+        Some(expected_preview.as_str())
+    );
 }
 
 #[test]

--- a/src/services/discord/prompt_builder/manifest.rs
+++ b/src/services/discord/prompt_builder/manifest.rs
@@ -29,6 +29,7 @@ pub(super) const RECOVERY_CONTEXT_LAYER_REASON: &str = "provider-native resume f
 pub(super) const ROLE_PROMPT_LAYER_NAME: &str = "role_prompt";
 pub(super) const MEMORY_RECALL_LAYER_NAME: &str = "memory_recall";
 pub(super) const MEMORY_RECALL_LAYER_SOURCE: &str = "memento";
+const ADK_PROMPT_MANIFEST_PREVIEW_MAX_BYTES: usize = 200;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RecoveryContextManifestInput<'a> {
@@ -92,7 +93,12 @@ pub(super) fn dispatch_contract_manifest_layer(
     layer.chars = chars;
     layer.tokens_est = tokens_est;
     layer.content_sha256 = content_sha256;
-    layer.redacted_preview = None;
+    layer.redacted_preview = full_content
+        .as_deref()
+        .filter(|content| !content.trim().is_empty())
+        .map(|content| {
+            truncate_prompt_manifest_preview(content, ADK_PROMPT_MANIFEST_PREVIEW_MAX_BYTES)
+        });
     layer.full_content = full_content;
     layer
 }
@@ -208,6 +214,8 @@ pub(super) fn role_prompt_manifest_layer(
     full_content: Option<String>,
 ) -> PromptManifestLayer {
     let content = full_content.unwrap_or_default();
+    let redacted_preview = (!content.trim().is_empty())
+        .then(|| truncate_prompt_manifest_preview(&content, ADK_PROMPT_MANIFEST_PREVIEW_MAX_BYTES));
     let mut layer = PromptManifestLayer::from_content(
         ROLE_PROMPT_LAYER_NAME,
         enabled,
@@ -216,6 +224,7 @@ pub(super) fn role_prompt_manifest_layer(
         PromptContentVisibility::AdkProvided,
         content,
     );
+    layer.redacted_preview = redacted_preview;
     if !enabled {
         layer.full_content = None;
     }

--- a/src/services/discord/prompt_builder/mod.rs
+++ b/src/services/discord/prompt_builder/mod.rs
@@ -31,6 +31,31 @@ pub(super) struct BuiltSystemPrompt {
     pub(super) manifest: Option<PromptManifest>,
 }
 
+struct PromptManifestLayerHash<'a> {
+    name: &'a str,
+    sha256: &'a str,
+}
+
+impl std::fmt::Debug for PromptManifestLayerHash<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PromptManifestLayerHash")
+            .field("name", &self.name)
+            .field("sha256", &self.sha256)
+            .finish()
+    }
+}
+
+fn prompt_manifest_layer_hashes(manifest: &PromptManifest) -> Vec<PromptManifestLayerHash<'_>> {
+    manifest
+        .layers
+        .iter()
+        .map(|layer| PromptManifestLayerHash {
+            name: layer.layer_name.as_str(),
+            sha256: layer.content_sha256.as_str(),
+        })
+        .collect()
+}
+
 /// Dispatch prompt profile — controls which system prompt sections are injected.
 /// `Full` includes the normal Discord contract plus compact lookup indexes
 /// (used for implementation dispatches and normal turns).
@@ -383,13 +408,15 @@ pub(super) fn build_system_prompt_with_manifest(
         prompt_manifest_layers,
     );
     if let Some(prompt_manifest) = manifest.as_ref() {
-        if let Ok(manifest_json) = serde_json::to_string(prompt_manifest) {
-            tracing::info!(
-                target: "agentdesk.prompt_manifest",
-                prompt_manifest = %manifest_json,
-                "recorded prompt manifest"
-            );
-        }
+        let layer_hashes = prompt_manifest_layer_hashes(prompt_manifest);
+        tracing::info!(
+            target: "agentdesk.prompt_manifest",
+            turn_id = %prompt_manifest.turn_id,
+            channel_id = %prompt_manifest.channel_id,
+            layer_count = prompt_manifest.layers.len(),
+            layer_hashes = ?layer_hashes,
+            "recorded prompt manifest"
+        );
     }
 
     BuiltSystemPrompt {


### PR DESCRIPTION
Closes #3315.

## Problem
ADK-provided manifest layers (`role_prompt`, `dispatch_contract`) retained `full_content`, which flowed into two operator-visible surfaces:
- the info-level prompt-manifest log (`build_system_prompt_with_manifest` serialized the whole manifest JSON), and
- the `/adk inspect prompt` report (rendered ADK full source).

This disclosed internal role prompts and dispatch contracts (operational policy / tool guidance / workflow context).

## Fix
Operator-visible surfaces reduced to hash + bounded preview; storage/audit retention keeps `full_content` intact.
- Info log now emits `turn_id` / `channel_id` / `layer_count` + per-layer `name`+`sha256` (`layer_hashes`) instead of the full manifest JSON.
- `/inspect prompt` shows `sha256` + a 100-char bounded preview for ADK layers by default; full source only behind an explicit privileged render path. User-derived layers stay redacted-preview-only.
- ADK layers now carry a 200-byte redacted preview for debuggability (balance against over-redaction).

## Tests
- ADK vs user-derived display behavior, privileged full-source path, and that the log surface excludes full content / sensitive fragments.
- The manifest-log assertion is deterministic (asserts on the pure logged-field representation) to avoid a process-global `tracing` callsite-interest race that left a captured buffer empty under the parallel `cargo test` binary.

## Verification (isolated worktree)
- `cargo fmt --check`: clean
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test --lib prompt_builder` (27) + `commands::inspect` (6): pass; formerly-flaky log test now passes 5/5 across parallel runs
- `cargo audit`: 15 advisories, identical to `origin/main` baseline (no Cargo.toml/lock changes)
- Maintainability audit (`scripts/audit_maintainability.py`): pass (exit 0)
- No #3016 hot files touched; no frozen-giant ratchet impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)