### PR TITLE
fix(#3299,#3300): extend memento nudge to codex + immediate-submit framing

### DIFF
--- a/src/services/claude_tui/hook_relay.rs
+++ b/src/services/claude_tui/hook_relay.rs
@@ -114,32 +114,56 @@ fn hook_success_stdout(provider: &str) -> &'static str {
 
 /// Stdout returned to the provider TUI for a relayed hook event.
 ///
-/// Defaults to the observational `hook_success_stdout`, but for a Claude
-/// `PostToolUse` event firing on a memento `recall`/`context` call it injects a
+/// Defaults to the observational `hook_success_stdout`, but for a memento
+/// `PostToolUse` search (`recall`/`context`) it injects an immediate
 /// `tool_feedback` nudge via `hookSpecificOutput.additionalContext`. The
 /// memory search→feedback ratio was effectively zero because models ignore the
 /// advisory `_meta.hints`; surfacing the ask in the model-visible PostToolUse
 /// context closes that loop without touching the Memento server or the prompt.
 ///
-/// Codex keeps the observational `{}` — its hook overrides are disabled by
-/// default and its `additionalContext` injection is unverified on the current
-/// CLI, so the nudge is Claude-only by design.
+/// Claude and Codex use different hook stdout contracts: Claude keeps
+/// `suppressOutput: true`, while Codex CLI 0.137.0 expects only the
+/// `hookSpecificOutput` block. Codex non-nudge events, including `Stop`, remain
+/// observational `{}`.
 fn hook_stdout(provider: &str, event: &str, payload: &Value) -> String {
-    if !provider.trim().eq_ignore_ascii_case("codex")
-        && event.trim().eq_ignore_ascii_case("PostToolUse")
-        && memento_search_tool_name(payload).is_some()
-    {
+    let provider_key = provider.trim().to_ascii_lowercase();
+    let event_is_post_tool_use = event.trim().eq_ignore_ascii_case("PostToolUse");
+    if event_is_post_tool_use && memento_search_tool_name(payload).is_some() {
         let additional_context = memento_feedback_instruction(extract_search_event_id(payload));
+        return hook_specific_stdout(&provider_key, "PostToolUse", additional_context);
+    }
+    if provider_key == "claude" && event.trim().eq_ignore_ascii_case("Stop") {
+        return hook_specific_stdout(
+            &provider_key,
+            "Stop",
+            memento_feedback_stop_flush_instruction(),
+        );
+    }
+    hook_success_stdout(provider).to_string()
+}
+
+fn hook_specific_stdout(
+    provider_key: &str,
+    event_name: &str,
+    additional_context: String,
+) -> String {
+    if provider_key == "codex" {
         return json!({
-            "suppressOutput": true,
             "hookSpecificOutput": {
-                "hookEventName": "PostToolUse",
+                "hookEventName": event_name,
                 "additionalContext": additional_context,
             }
         })
         .to_string();
     }
-    hook_success_stdout(provider).to_string()
+    json!({
+        "suppressOutput": true,
+        "hookSpecificOutput": {
+            "hookEventName": event_name,
+            "additionalContext": additional_context,
+        }
+    })
+    .to_string()
 }
 
 /// Returns the lowercased tool name when the PostToolUse payload is a memento
@@ -222,14 +246,24 @@ fn memento_feedback_instruction(search_event_id: Option<String>) -> String {
         None => "the search_event_id shown under `_meta.searchEventId` in that result".to_string(),
     };
     format!(
-        "Action required: you just received a memento search result. Before your next memento \
-recall/context/search call, submit one `mcp__memento__tool_feedback` call for THIS result with \
+        "Action required: you just received a memento search result. Submit one \
+`mcp__memento__tool_feedback` call immediately for THIS result with \
 {target}, `relevant` = whether any returned fragment was on-topic, and `sufficient` = whether the \
 results were enough to proceed. If `mcp__memento__tool_feedback` is not in your active tools \
 (memento tools are deferred), first load it with ToolSearch query \
-`select:mcp__memento__tool_feedback`, then make the call. This is a single quick step — do it now, \
-then continue."
+`select:mcp__memento__tool_feedback`, then make the call. Do this now, then continue."
     )
+}
+
+fn memento_feedback_stop_flush_instruction() -> String {
+    "Action required before ending this session: flush any pending memento search feedback now. \
+For each memento recall/context result from this session that does not yet have a matching \
+`mcp__memento__tool_feedback` call, submit one with the search_event_id shown under \
+`_meta.searchEventId` in that result, `relevant` = whether any returned fragment was on-topic, \
+and `sufficient` = whether the results were enough to proceed. Do not invent or guess \
+search_event_id values; if there were no memento search results or all feedback is already \
+submitted, no tool_feedback call is needed."
+        .to_string()
 }
 
 pub fn relay_hook_event(
@@ -504,9 +538,33 @@ mod tests {
         assert_eq!(value["hookSpecificOutput"]["hookEventName"], "PostToolUse");
         assert!(ctx.contains("search_event_id=22752"));
         assert!(ctx.contains("mcp__memento__tool_feedback"));
+        assert!(ctx.contains("immediately"));
+        let delayed_framing = ["Before", " your next"].concat();
+        assert!(!ctx.contains(&delayed_framing));
         // Deferred-tool friction hint: tell the model how to load the tool.
         assert!(ctx.contains("select:mcp__memento__tool_feedback"));
         assert_eq!(value["suppressOutput"], true);
+    }
+
+    #[test]
+    fn codex_posttooluse_memento_recall_injects_feedback_nudge_without_suppress_output() {
+        let payload = serde_json::json!({
+            "tool_name": "mcp__memento__recall",
+            "tool_response": [{
+                "type": "text",
+                "text": "{\"fragments\":[],\"_meta\":{\"searchEventId\":\"3300\"}}"
+            }]
+        });
+        let out = hook_stdout("codex", "PostToolUse", &payload);
+        let value: Value = serde_json::from_str(&out).unwrap();
+        let ctx = value["hookSpecificOutput"]["additionalContext"]
+            .as_str()
+            .unwrap();
+        assert_eq!(value["hookSpecificOutput"]["hookEventName"], "PostToolUse");
+        assert!(ctx.contains("search_event_id=3300"));
+        assert!(ctx.contains("mcp__memento__tool_feedback"));
+        assert!(ctx.contains("immediately"));
+        assert!(value.get("suppressOutput").is_none());
     }
 
     #[test]
@@ -521,6 +579,23 @@ mod tests {
             .unwrap();
         assert!(ctx.contains("_meta.searchEventId"));
         assert!(ctx.contains("mcp__memento__tool_feedback"));
+        assert!(!ctx.contains("search_event_id="));
+    }
+
+    #[test]
+    fn claude_stop_flushes_pending_feedback_with_suppress_output() {
+        let out = hook_stdout("claude", "Stop", &serde_json::json!({}));
+        let value: Value = serde_json::from_str(&out).unwrap();
+        let ctx = value["hookSpecificOutput"]["additionalContext"]
+            .as_str()
+            .unwrap();
+
+        assert_eq!(value["hookSpecificOutput"]["hookEventName"], "Stop");
+        assert_eq!(value["suppressOutput"], true);
+        assert!(ctx.contains("flush any pending memento search feedback now"));
+        assert!(ctx.contains("_meta.searchEventId"));
+        assert!(ctx.contains("Do not invent or guess search_event_id values"));
+        assert!(!ctx.contains("search_event_id="));
     }
 
     #[test]
@@ -537,8 +612,9 @@ mod tests {
             hook_stdout("claude", "PostToolUse", &forget),
             r#"{"suppressOutput":true}"#
         );
-        // Right event + search tool, but Codex stays observational.
-        assert_eq!(hook_stdout("codex", "PostToolUse", &recall), "{}");
+        // Codex non-nudge events keep the established empty success object.
+        assert_eq!(hook_stdout("codex", "PreToolUse", &recall), "{}");
+        assert_eq!(hook_stdout("codex", "Stop", &serde_json::json!({})), "{}");
     }
 
     #[test]

--- a/src/services/claude_tui/hook_relay.rs
+++ b/src/services/claude_tui/hook_relay.rs
@@ -125,19 +125,15 @@ fn hook_success_stdout(provider: &str) -> &'static str {
 /// `suppressOutput: true`, while Codex CLI 0.137.0 expects only the
 /// `hookSpecificOutput` block. Codex non-nudge events, including `Stop`, remain
 /// observational `{}`.
+///
+/// Session-end feedback flushing is not implemented in the hook relay; that
+/// path is deferred to #3332 for a server-side design.
 fn hook_stdout(provider: &str, event: &str, payload: &Value) -> String {
     let provider_key = provider.trim().to_ascii_lowercase();
     let event_is_post_tool_use = event.trim().eq_ignore_ascii_case("PostToolUse");
     if event_is_post_tool_use && memento_search_tool_name(payload).is_some() {
         let additional_context = memento_feedback_instruction(extract_search_event_id(payload));
         return hook_specific_stdout(&provider_key, "PostToolUse", additional_context);
-    }
-    if provider_key == "claude" && event.trim().eq_ignore_ascii_case("Stop") {
-        return hook_specific_stdout(
-            &provider_key,
-            "Stop",
-            memento_feedback_stop_flush_instruction(),
-        );
     }
     hook_success_stdout(provider).to_string()
 }
@@ -253,17 +249,6 @@ results were enough to proceed. If `mcp__memento__tool_feedback` is not in your 
 (memento tools are deferred), first load it with ToolSearch query \
 `select:mcp__memento__tool_feedback`, then make the call. Do this now, then continue."
     )
-}
-
-fn memento_feedback_stop_flush_instruction() -> String {
-    "Action required before ending this session: flush any pending memento search feedback now. \
-For each memento recall/context result from this session that does not yet have a matching \
-`mcp__memento__tool_feedback` call, submit one with the search_event_id shown under \
-`_meta.searchEventId` in that result, `relevant` = whether any returned fragment was on-topic, \
-and `sufficient` = whether the results were enough to proceed. Do not invent or guess \
-search_event_id values; if there were no memento search results or all feedback is already \
-submitted, no tool_feedback call is needed."
-        .to_string()
 }
 
 pub fn relay_hook_event(
@@ -583,19 +568,11 @@ mod tests {
     }
 
     #[test]
-    fn claude_stop_flushes_pending_feedback_with_suppress_output() {
-        let out = hook_stdout("claude", "Stop", &serde_json::json!({}));
-        let value: Value = serde_json::from_str(&out).unwrap();
-        let ctx = value["hookSpecificOutput"]["additionalContext"]
-            .as_str()
-            .unwrap();
-
-        assert_eq!(value["hookSpecificOutput"]["hookEventName"], "Stop");
-        assert_eq!(value["suppressOutput"], true);
-        assert!(ctx.contains("flush any pending memento search feedback now"));
-        assert!(ctx.contains("_meta.searchEventId"));
-        assert!(ctx.contains("Do not invent or guess search_event_id values"));
-        assert!(!ctx.contains("search_event_id="));
+    fn claude_stop_stays_observational_with_suppress_output() {
+        assert_eq!(
+            hook_stdout("claude", "Stop", &serde_json::json!({})),
+            r#"{"suppressOutput":true}"#
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 변경 (split 후 최종)
- **#3299**: memento PostToolUse nudge를 codex 세션에도 적용
- **#3300**: nudge에 즉시제출 프레이밍 추가
- ~~Stop hook flush~~ → **제거됨** (ca5316bd3): 매 Stop마다 무조건 additionalContext를 주입해 모든 턴 종료에 추가 모델 턴을 강제하는 회귀로 리뷰에서 판정. 서버측 조건부 주입 설계는 #3332로 분리.

## 계약
- Claude Stop → `{"suppressOutput":true}`, Codex Stop → `{}` (origin/main 동일)
- 게이트: fmt/check/clippy -D warnings/test(hook_relay 17 passed)/agent-maintenance 전부 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)