### PR TITLE
fix(#3335): register 00-escalation.js as hook-less helper policy

### DIFF
--- a/policies/00-escalation.js
+++ b/policies/00-escalation.js
@@ -346,3 +346,12 @@ function flushEscalations() {
     agentdesk.db.execute("DELETE FROM kv_meta WHERE key = ?", [rows[i].key]);
   }
 }
+
+// #3335: this file is a shared helper library (evaluated first via the 00-
+// prefix so escalate()/flushEscalations()/escalateToManualIntervention() are
+// globals for timeouts/ci-recovery/kanban-rules/review-automation). Register
+// a hook-less policy so the loader stops logging a load failure at every boot.
+agentdesk.registerPolicy({
+  name: "escalation-helpers",
+  priority: 0
+});

--- a/policies/__tests__/escalation-facade.test.js
+++ b/policies/__tests__/escalation-facade.test.js
@@ -16,6 +16,8 @@ test("00-escalation loadCardMetadata handles pre-parsed object metadata", () => 
   );
 
   var mockAgentdesk = {
+    // #3335: 00-escalation.js now registers a hook-less helper policy
+    registerPolicy: function() {},
     cards: {
       get: function(id) {
         if (id === "parsed") {
@@ -63,6 +65,8 @@ test("00-escalation loadManualInterventionState handles missing cards and parses
   );
 
   var mockAgentdesk = {
+    // #3335: 00-escalation.js now registers a hook-less helper policy
+    registerPolicy: function() {},
     cards: {
       get: function(id) {
         if (id === "valid") {
@@ -114,6 +118,8 @@ test("00-escalation escalationCardTitle uses github issue number", () => {
   );
 
   var mockAgentdesk = {
+    // #3335: 00-escalation.js now registers a hook-less helper policy
+    registerPolicy: function() {},
     cards: {
       get: function(id) {
         if (id === "with_issue") {


### PR DESCRIPTION
## 변경
- `policies/00-escalation.js` 끝에 hook 없는 `agentdesk.registerPolicy({name: "escalation-helpers", priority: 0})` 등록 추가 — 매 부팅 "did not call agentdesk.registerPolicy()" ERROR 노이즈 제거 + 헬퍼 라이브러리 의도 명시.
- `escalation-facade.test.js`의 로컬 mock 3곳에 registerPolicy no-op 스텁 추가.

## 배경 (#3335)
이 파일은 정책이 아니라 00- 접두사로 가장 먼저 eval되는 공유 헬퍼 라이브러리(escalate/flushEscalations/escalateToManualIntervention 전역 제공, timeouts/ci-recovery/kanban-rules/review-automation이 소비). 기능은 정상이었고 loader 분류만 실패해 5/21부터 가짜 ERROR 누적.

## 검증
- `node --test policies/__tests__/*.test.js`: 142/142 pass (수정 전 내 변경으로 3건 실패 → 스텁 추가로 해소)
- `cargo test --lib engine::loader`: 15/15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)