### PR TITLE
fix(#3333): early-exit zero-start deferred drain when synthetic-start claim is abandoned

### DIFF
--- a/src/services/discord/queue_io.rs
+++ b/src/services/discord/queue_io.rs
@@ -20,9 +20,23 @@ const DEFERRED_IDLE_QUEUE_KICKOFF_RETRY_DELAY: std::time::Duration =
 // queued user reply should not wait for the next external Discord event just
 // because cached ctx/token arrived slightly after the first post-turn kickoff.
 const DEFERRED_IDLE_QUEUE_KICKOFF_MAX_ATTEMPTS: usize = 150;
+const DEFERRED_IDLE_QUEUE_ZERO_START_ABANDONED_CLAIM_PROBE_AFTER: usize = 3;
 
 fn should_retry_deferred_idle_queue_kickoff(attempt: usize) -> bool {
     attempt < DEFERRED_IDLE_QUEUE_KICKOFF_MAX_ATTEMPTS
+}
+
+fn note_zero_start_deferred_drain(
+    consecutive_zero_start_drains: &mut usize,
+    started: usize,
+    target_still_pending: bool,
+) -> bool {
+    if started == 0 && target_still_pending {
+        *consecutive_zero_start_drains = consecutive_zero_start_drains.saturating_add(1);
+    } else {
+        *consecutive_zero_start_drains = 0;
+    }
+    *consecutive_zero_start_drains >= DEFERRED_IDLE_QUEUE_ZERO_START_ABANDONED_CLAIM_PROBE_AFTER
 }
 
 /// #3005: pre-sleep before the very first deferred-drain attempt. The
@@ -96,6 +110,7 @@ fn schedule_deferred_idle_queue_kickoff_inner(
         if !initial_presleep.is_zero() {
             tokio::time::sleep(initial_presleep).await;
         }
+        let mut consecutive_zero_start_drains = 0usize;
         for attempt in 1..=DEFERRED_IDLE_QUEUE_KICKOFF_MAX_ATTEMPTS {
             if let (Some(ctx), Some(tok)) = (
                 shared.cached_serenity_ctx.get(),
@@ -126,6 +141,52 @@ fn schedule_deferred_idle_queue_kickoff_inner(
                     .await
                     .intervention_queue
                     .is_empty();
+                let should_probe_abandoned_claim = note_zero_start_deferred_drain(
+                    &mut consecutive_zero_start_drains,
+                    started,
+                    target_still_pending,
+                );
+                if should_probe_abandoned_claim {
+                    let abandoned_claim =
+                        super::tui_direct_pending_start::pending_synthetic_start_abandoned(
+                            provider.as_str(),
+                            channel_id.get(),
+                        );
+                    if abandoned_claim
+                        && super::tui_direct_pending_start::clear_abandoned_synthetic_start_presence(
+                            provider.as_str(),
+                            channel_id.get(),
+                        )
+                    {
+                        tracing::warn!(
+                            provider = provider.as_str(),
+                            channel_id = channel_id.get(),
+                            reason,
+                            attempt,
+                            consecutive_zero_start_drains,
+                            issue = "#3333",
+                            "Deferred drain: cleared abandoned synthetic-start presence after repeated zero-start drains; durable record retained for restart retry"
+                        );
+                        let final_started =
+                            super::kickoff_idle_queues(ctx, &shared, tok, &provider).await;
+                        let final_pending = !super::mailbox_snapshot(shared.as_ref(), channel_id)
+                            .await
+                            .intervention_queue
+                            .is_empty();
+                        if final_started == 0 && final_pending {
+                            tracing::warn!(
+                                provider = provider.as_str(),
+                                channel_id = channel_id.get(),
+                                reason,
+                                attempt,
+                                issue = "#3333",
+                                "Deferred drain: final one-shot drain after abandoned synthetic-start clear started zero turns; stopping bounded retry loop"
+                            );
+                        }
+                        return;
+                    }
+                    consecutive_zero_start_drains = 0;
+                }
                 if started == 0
                     && target_still_pending
                     && should_retry_deferred_idle_queue_kickoff(attempt)
@@ -165,6 +226,56 @@ fn schedule_deferred_idle_queue_kickoff_inner(
 mod presleep_tests {
     use super::*;
 
+    struct EnvReset(Option<std::ffi::OsString>);
+
+    impl Drop for EnvReset {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
+                None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
+            }
+        }
+    }
+
+    fn pending_record(
+        provider: &ProviderKind,
+        channel_id: ChannelId,
+    ) -> super::super::tui_direct_pending_start::TuiDirectPendingStart {
+        super::super::tui_direct_pending_start::TuiDirectPendingStart {
+            provider: provider.as_str().to_string(),
+            channel_id: channel_id.get(),
+            tmux_session_name: format!("tmux-{}", channel_id.get()),
+            prompt_text: "/loop tick".to_string(),
+            anchor_message_id: 9_333_300,
+            lease_relay_owner: "bridge_adapter".to_string(),
+            lease_runtime_kind: Some("claude_tui".to_string()),
+            lease_turn_id: None,
+            lease_session_key: None,
+            generation: 0,
+            created_at_ms: 0,
+            observed_at_ms: 0,
+            state: super::super::tui_direct_pending_start::PendingStartState::Waiting,
+            attempt_count: super::super::tui_direct_pending_start::PENDING_START_MAX_CLAIM_ATTEMPTS,
+        }
+    }
+
+    fn user_intervention(id: u64, text: &str) -> Intervention {
+        Intervention {
+            author_id: UserId::new(id),
+            author_is_bot: false,
+            message_id: MessageId::new(id),
+            source_message_ids: vec![MessageId::new(id)],
+            text: text.to_string(),
+            mode: InterventionMode::Soft,
+            created_at: Instant::now(),
+            reply_context: None,
+            has_reply_boundary: false,
+            merge_consecutive: false,
+            pending_uploads: Vec::new(),
+            voice_announcement: None,
+        }
+    }
+
     /// #3005: the finalize-completed immediate path must skip the 2s
     /// INITIAL_DELAY pre-sleep on the first attempt, while every other caller
     /// keeps the full delay (restart-window spin guard). The INITIAL_DELAY
@@ -186,5 +297,73 @@ mod presleep_tests {
             DEFERRED_IDLE_QUEUE_KICKOFF_INITIAL_DELAY,
             std::time::Duration::from_secs(2)
         );
+    }
+
+    #[test]
+    fn zero_start_abandoned_claim_probe_fires_on_third_consecutive_pending_zero() {
+        let mut consecutive = 0usize;
+        assert!(!note_zero_start_deferred_drain(&mut consecutive, 0, true));
+        assert!(!note_zero_start_deferred_drain(&mut consecutive, 0, true));
+        assert!(note_zero_start_deferred_drain(&mut consecutive, 0, true));
+        assert_eq!(
+            consecutive, DEFERRED_IDLE_QUEUE_ZERO_START_ABANDONED_CLAIM_PROBE_AFTER,
+            "the #3333 abandoned-claim probe must fire after 3 zero-start drains, not after the 150-attempt cap"
+        );
+
+        assert!(!note_zero_start_deferred_drain(&mut consecutive, 1, true));
+        assert_eq!(consecutive, 0, "a non-zero drain resets the zero-start run");
+        assert!(!note_zero_start_deferred_drain(&mut consecutive, 0, false));
+        assert_eq!(consecutive, 0, "an empty target queue is a normal exit");
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn abandoned_presence_clear_releases_idle_queue_gate_but_keeps_durable_record() {
+        let _lock = crate::services::turn_orchestrator::test_support::lock_test_env();
+        let _env = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        let tmp = tempfile::tempdir().expect("temp runtime root");
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", tmp.path()) };
+
+        super::super::tui_direct_pending_start::reset_present_for_tests();
+
+        let shared = make_shared_data_for_tests();
+        let provider = ProviderKind::Claude;
+        let channel_id = ChannelId::new(3_333_300);
+        shared
+            .mailbox(channel_id)
+            .replace_queue(
+                vec![user_intervention(3_333_301, "queued after abandoned claim")],
+                queue_persistence_context(&shared, &provider, channel_id),
+            )
+            .await;
+
+        let record = pending_record(&provider, channel_id);
+        super::super::tui_direct_pending_start::persist(&record).unwrap();
+        let snapshot = mailbox_snapshot(&shared, channel_id).await;
+        assert!(
+            !idle_queue_snapshot_has_kickable_backlog(&shared, &provider, channel_id, &snapshot),
+            "pending synthetic-start presence must block the idle queue before the #3333 clear"
+        );
+
+        assert!(
+            super::super::tui_direct_pending_start::clear_abandoned_synthetic_start_presence(
+                provider.as_str(),
+                channel_id.get(),
+            ),
+            "the abandoned durable record should allow presence-only clearing"
+        );
+        assert!(
+            idle_queue_snapshot_has_kickable_backlog(&shared, &provider, channel_id, &snapshot),
+            "after presence-only clear, the queued item is kickable by the final one-shot drain"
+        );
+        assert!(
+            super::super::tui_direct_pending_start::pending_synthetic_start_abandoned(
+                provider.as_str(),
+                channel_id.get(),
+            ),
+            "the durable record remains retained for restart retry; only the in-memory gate is cleared"
+        );
+
+        super::super::tui_direct_pending_start::reset_present_for_tests();
     }
 }

--- a/src/services/discord/queue_io.rs
+++ b/src/services/discord/queue_io.rs
@@ -316,9 +316,11 @@ mod presleep_tests {
         assert_eq!(consecutive, 0, "an empty target queue is a normal exit");
     }
 
-    #[allow(clippy::await_holding_lock)]
-    #[tokio::test]
-    async fn abandoned_presence_clear_releases_idle_queue_gate_but_keeps_durable_record() {
+    // Sync test + explicit block_on: the std-mutex test-env guards live only in
+    // this sync scope and never span an await, so no await_holding_lock allow is
+    // needed (#3034 ratchet stays frozen at its baseline).
+    #[test]
+    fn abandoned_presence_clear_releases_idle_queue_gate_but_keeps_durable_record() {
         let _lock = crate::services::turn_orchestrator::test_support::lock_test_env();
         let _env = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
         let tmp = tempfile::tempdir().expect("temp runtime root");
@@ -326,43 +328,54 @@ mod presleep_tests {
 
         super::super::tui_direct_pending_start::reset_present_for_tests();
 
-        let shared = make_shared_data_for_tests();
-        let provider = ProviderKind::Claude;
-        let channel_id = ChannelId::new(3_333_300);
-        shared
-            .mailbox(channel_id)
-            .replace_queue(
-                vec![user_intervention(3_333_301, "queued after abandoned claim")],
-                queue_persistence_context(&shared, &provider, channel_id),
-            )
-            .await;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        rt.block_on(async {
+            let shared = make_shared_data_for_tests();
+            let provider = ProviderKind::Claude;
+            let channel_id = ChannelId::new(3_333_300);
+            shared
+                .mailbox(channel_id)
+                .replace_queue(
+                    vec![user_intervention(3_333_301, "queued after abandoned claim")],
+                    queue_persistence_context(&shared, &provider, channel_id),
+                )
+                .await;
 
-        let record = pending_record(&provider, channel_id);
-        super::super::tui_direct_pending_start::persist(&record).unwrap();
-        let snapshot = mailbox_snapshot(&shared, channel_id).await;
-        assert!(
-            !idle_queue_snapshot_has_kickable_backlog(&shared, &provider, channel_id, &snapshot),
-            "pending synthetic-start presence must block the idle queue before the #3333 clear"
-        );
+            let record = pending_record(&provider, channel_id);
+            super::super::tui_direct_pending_start::persist(&record).unwrap();
+            let snapshot = mailbox_snapshot(&shared, channel_id).await;
+            assert!(
+                !idle_queue_snapshot_has_kickable_backlog(
+                    &shared,
+                    &provider,
+                    channel_id,
+                    &snapshot
+                ),
+                "pending synthetic-start presence must block the idle queue before the #3333 clear"
+            );
 
-        assert!(
-            super::super::tui_direct_pending_start::clear_abandoned_synthetic_start_presence(
-                provider.as_str(),
-                channel_id.get(),
-            ),
-            "the abandoned durable record should allow presence-only clearing"
-        );
-        assert!(
-            idle_queue_snapshot_has_kickable_backlog(&shared, &provider, channel_id, &snapshot),
-            "after presence-only clear, the queued item is kickable by the final one-shot drain"
-        );
-        assert!(
-            super::super::tui_direct_pending_start::pending_synthetic_start_abandoned(
-                provider.as_str(),
-                channel_id.get(),
-            ),
-            "the durable record remains retained for restart retry; only the in-memory gate is cleared"
-        );
+            assert!(
+                super::super::tui_direct_pending_start::clear_abandoned_synthetic_start_presence(
+                    provider.as_str(),
+                    channel_id.get(),
+                ),
+                "the abandoned durable record should allow presence-only clearing"
+            );
+            assert!(
+                idle_queue_snapshot_has_kickable_backlog(&shared, &provider, channel_id, &snapshot),
+                "after presence-only clear, the queued item is kickable by the final one-shot drain"
+            );
+            assert!(
+                super::super::tui_direct_pending_start::pending_synthetic_start_abandoned(
+                    provider.as_str(),
+                    channel_id.get(),
+                ),
+                "the durable record remains retained for restart retry; only the in-memory gate is cleared"
+            );
+        });
 
         super::super::tui_direct_pending_start::reset_present_for_tests();
     }

--- a/src/services/discord/tui_direct_pending_start.rs
+++ b/src/services/discord/tui_direct_pending_start.rs
@@ -149,6 +149,13 @@ pub(super) fn channel_lock(provider: &str, channel_id: u64) -> Arc<tokio::sync::
 static PRESENT: LazyLock<Mutex<HashMap<(String, u64), u32>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
+static ACTIVE_WORKERS: LazyLock<Mutex<HashMap<(String, u64), u32>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static PRECLAIMED_ACTIVE_WORKERS: LazyLock<Mutex<HashMap<(String, u64), u32>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+static PRESENCE_RECONCILE_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
 fn mark_present(provider: &str, channel_id: u64) {
     let mut map = PRESENT.lock().unwrap_or_else(|e| e.into_inner());
     *map.entry((provider.to_string(), channel_id)).or_insert(0) += 1;
@@ -162,6 +169,92 @@ fn mark_absent(provider: &str, channel_id: u64) {
             map.remove(&(provider.to_string(), channel_id));
         }
     }
+}
+
+fn clear_present(provider: &str, channel_id: u64) {
+    PRESENT
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .remove(&(provider.to_string(), channel_id));
+}
+
+struct ActiveWorkerGuard {
+    provider: String,
+    channel_id: u64,
+}
+
+impl ActiveWorkerGuard {
+    fn new(provider: &str, channel_id: u64) -> Self {
+        let mut workers = ACTIVE_WORKERS.lock().unwrap_or_else(|e| e.into_inner());
+        *workers
+            .entry((provider.to_string(), channel_id))
+            .or_insert(0) += 1;
+        Self {
+            provider: provider.to_string(),
+            channel_id,
+        }
+    }
+
+    fn from_preclaimed(provider: &str, channel_id: u64) -> Self {
+        Self {
+            provider: provider.to_string(),
+            channel_id,
+        }
+    }
+}
+
+impl Drop for ActiveWorkerGuard {
+    fn drop(&mut self) {
+        let mut workers = ACTIVE_WORKERS.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(count) = workers.get_mut(&(self.provider.clone(), self.channel_id)) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                workers.remove(&(self.provider.clone(), self.channel_id));
+            }
+        }
+    }
+}
+
+fn active_worker_present(provider: &str, channel_id: u64) -> bool {
+    ACTIVE_WORKERS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(&(provider.to_string(), channel_id))
+        .copied()
+        .unwrap_or(0)
+        > 0
+}
+
+fn preclaim_active_worker(provider: &str, channel_id: u64) {
+    {
+        let mut workers = ACTIVE_WORKERS.lock().unwrap_or_else(|e| e.into_inner());
+        *workers
+            .entry((provider.to_string(), channel_id))
+            .or_insert(0) += 1;
+    }
+    let mut preclaimed = PRECLAIMED_ACTIVE_WORKERS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    *preclaimed
+        .entry((provider.to_string(), channel_id))
+        .or_insert(0) += 1;
+}
+
+fn take_preclaimed_active_worker(provider: &str, channel_id: u64) -> Option<ActiveWorkerGuard> {
+    let mut preclaimed = PRECLAIMED_ACTIVE_WORKERS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let count = preclaimed.get_mut(&(provider.to_string(), channel_id))?;
+    *count = count.saturating_sub(1);
+    if *count == 0 {
+        preclaimed.remove(&(provider.to_string(), channel_id));
+    }
+    Some(ActiveWorkerGuard::from_preclaimed(provider, channel_id))
+}
+
+fn active_worker_guard_for_spawn(provider: &str, channel_id: u64) -> ActiveWorkerGuard {
+    take_preclaimed_active_worker(provider, channel_id)
+        .unwrap_or_else(|| ActiveWorkerGuard::new(provider, channel_id))
 }
 
 /// GATE probe consulted by the watcher no-inflight suppression and the idle
@@ -185,12 +278,24 @@ pub(super) fn pending_synthetic_start_present(provider: &str, channel_id: u64) -
 /// state before the respawned worker's first poll. The worker's terminal
 /// [`delete`] balances it.
 pub(super) fn mark_present_on_restore(provider: &str, channel_id: u64) {
+    let _guard = PRESENCE_RECONCILE_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
     mark_present(provider, channel_id);
+    preclaim_active_worker(provider, channel_id);
 }
 
 #[cfg(test)]
 pub(super) fn reset_present_for_tests() {
     PRESENT.lock().unwrap_or_else(|e| e.into_inner()).clear();
+    ACTIVE_WORKERS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clear();
+    PRECLAIMED_ACTIVE_WORKERS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -201,14 +306,8 @@ fn root() -> Option<std::path::PathBuf> {
     super::runtime_store::tui_direct_pending_start_root()
 }
 
-/// Persist (or update) a pending-start record and mark it present in the
-/// in-memory index. Called BEFORE any wait, immediately after the anchor/lease
-/// are created.
-pub(super) fn persist(record: &TuiDirectPendingStart) -> Result<(), String> {
-    mark_present(&record.provider, record.channel_id);
+fn write_record(record: &TuiDirectPendingStart) -> Result<(), String> {
     let Some(root) = root() else {
-        // No runtime root (tests / unconfigured): the in-memory presence index
-        // still gates the watcher / idle queue for this process lifetime.
         return Ok(());
     };
     let path = root.join(format!("{}.json", record.file_stem()));
@@ -222,13 +321,45 @@ pub(super) fn persist(record: &TuiDirectPendingStart) -> Result<(), String> {
     )
 }
 
+/// Persist (or update) a pending-start record and mark it present in the
+/// in-memory index. Called BEFORE any wait, immediately after the anchor/lease
+/// are created.
+pub(super) fn persist(record: &TuiDirectPendingStart) -> Result<(), String> {
+    let _guard = PRESENCE_RECONCILE_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    mark_present(&record.provider, record.channel_id);
+    write_record(record)?;
+    Ok(())
+}
+
 /// Delete a pending-start record AFTER the inflight save succeeds (or when the
 /// worker gives up). Idempotent.
 pub(super) fn delete(record: &TuiDirectPendingStart) {
+    let _guard = PRESENCE_RECONCILE_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
     mark_absent(&record.provider, record.channel_id);
     if let Some(root) = root() {
         let path = root.join(format!("{}.json", record.file_stem()));
         let _ = std::fs::remove_file(path);
+    }
+}
+
+fn update_claim_attempt_count(record: &mut TuiDirectPendingStart, claim_attempts: u32) {
+    record.attempt_count = claim_attempts;
+    let _guard = PRESENCE_RECONCILE_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    if let Err(error) = write_record(record) {
+        tracing::warn!(
+            provider = %record.provider,
+            channel_id = record.channel_id,
+            anchor_message_id = record.anchor_message_id,
+            claim_attempts,
+            error = %error,
+            "tui_direct_pending_start: failed to persist claim attempt count; retaining in-memory retry budget"
+        );
     }
 }
 
@@ -266,6 +397,42 @@ pub(super) fn load_all() -> Vec<TuiDirectPendingStart> {
             .then(a.anchor_message_id.cmp(&b.anchor_message_id))
     });
     out
+}
+
+fn records_for_channel(provider: &str, channel_id: u64) -> Vec<TuiDirectPendingStart> {
+    load_all()
+        .into_iter()
+        .filter(|record| record.provider == provider && record.channel_id == channel_id)
+        .collect()
+}
+
+fn channel_records_are_abandoned_locked(provider: &str, channel_id: u64) -> bool {
+    if active_worker_present(provider, channel_id) {
+        return false;
+    }
+    let records = records_for_channel(provider, channel_id);
+    !records.is_empty()
+        && records
+            .iter()
+            .all(|record| record.attempt_count >= PENDING_START_MAX_CLAIM_ATTEMPTS)
+}
+
+pub(super) fn pending_synthetic_start_abandoned(provider: &str, channel_id: u64) -> bool {
+    let _guard = PRESENCE_RECONCILE_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    channel_records_are_abandoned_locked(provider, channel_id)
+}
+
+pub(super) fn clear_abandoned_synthetic_start_presence(provider: &str, channel_id: u64) -> bool {
+    let _guard = PRESENCE_RECONCILE_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    if !channel_records_are_abandoned_locked(provider, channel_id) {
+        return false;
+    }
+    clear_present(provider, channel_id);
+    true
 }
 
 // ---------------------------------------------------------------------------
@@ -438,8 +605,10 @@ pub(super) fn spawn_worker(
     claim_fn: ClaimFn,
     abort_cleanup_fn: AbortCleanupFn,
 ) {
+    let active_guard = active_worker_guard_for_spawn(&record.provider, record.channel_id);
     super::task_supervisor::spawn_observed("tui_direct_pending_start_worker", async move {
-        run_worker(shared, record, view_fn, claim_fn, abort_cleanup_fn).await;
+        let _active_guard = active_guard;
+        run_worker_inner(shared, record, view_fn, claim_fn, abort_cleanup_fn).await;
     });
 }
 
@@ -456,9 +625,21 @@ enum WaitOutcome {
     BackstopForeignInflightLive,
 }
 
+#[cfg(test)]
 async fn run_worker(
     shared: Arc<SharedData>,
     record: TuiDirectPendingStart,
+    view_fn: ViewFn,
+    claim_fn: ClaimFn,
+    abort_cleanup_fn: AbortCleanupFn,
+) {
+    let _active_guard = ActiveWorkerGuard::new(&record.provider, record.channel_id);
+    run_worker_inner(shared, record, view_fn, claim_fn, abort_cleanup_fn).await;
+}
+
+async fn run_worker_inner(
+    shared: Arc<SharedData>,
+    mut record: TuiDirectPendingStart,
     view_fn: ViewFn,
     claim_fn: ClaimFn,
     abort_cleanup_fn: AbortCleanupFn,
@@ -591,6 +772,7 @@ async fn run_worker(
 
         // Transient claim failure: do NOT delete (P1-2). Retry, bounded.
         claim_attempts = claim_attempts.saturating_add(1);
+        update_claim_attempt_count(&mut record, claim_attempts);
         if claim_attempts >= PENDING_START_MAX_CLAIM_ATTEMPTS {
             tracing::error!(
                 provider = %record.provider,
@@ -741,6 +923,17 @@ mod tests {
         LOCK.lock().unwrap_or_else(|poison| poison.into_inner())
     }
 
+    struct EnvReset(Option<std::ffi::OsString>);
+
+    impl Drop for EnvReset {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(value) => unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", value) },
+                None => unsafe { std::env::remove_var("AGENTDESK_ROOT_DIR") },
+            }
+        }
+    }
+
     /// Wrap a pure view into the worker's per-poll observation (no foreign
     /// identity — the common already-finalized case).
     fn obs(view: PriorTurnView) -> PriorTurnObservation {
@@ -881,6 +1074,43 @@ mod tests {
         );
         mark_absent(provider, channel);
         assert!(!pending_synthetic_start_present(provider, channel));
+        reset_present_for_tests();
+    }
+
+    #[test]
+    fn abandoned_presence_clear_keeps_durable_record() {
+        let _guard = worker_test_lock();
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let _env = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        let temp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+
+        reset_present_for_tests();
+        let mut rec = record("claude", 70, 700);
+        rec.attempt_count = PENDING_START_MAX_CLAIM_ATTEMPTS;
+        persist(&rec).unwrap();
+
+        assert!(pending_synthetic_start_present("claude", 70));
+        assert!(
+            pending_synthetic_start_abandoned("claude", 70),
+            "a capped durable attempt_count with no active worker is an abandoned claim"
+        );
+        assert!(clear_abandoned_synthetic_start_presence("claude", 70));
+        assert!(
+            !pending_synthetic_start_present("claude", 70),
+            "the #3333 clear removes only the in-memory gate"
+        );
+        assert_eq!(
+            load_all()
+                .into_iter()
+                .filter(|record| record.provider == "claude" && record.channel_id == 70)
+                .count(),
+            1,
+            "the durable record must remain for restart retry"
+        );
+
         reset_present_for_tests();
     }
 
@@ -1335,6 +1565,13 @@ mod tests {
         use std::sync::atomic::{AtomicU32, Ordering};
 
         let _guard = worker_test_lock();
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let _env = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        let temp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+
         reset_present_for_tests();
         let shared = super::super::make_shared_data_for_tests();
         let view: ViewFn =
@@ -1371,6 +1608,18 @@ mod tests {
             "on retry exhaustion the record is RETAINED for restart re-attempt — \
              RED if the worker deletes after exhausting claims (turn-loss)."
         );
+        assert!(
+            pending_synthetic_start_abandoned("claude", 12),
+            "after the worker exits with retry exhaustion, the durable capped \
+             attempt_count plus no active worker identifies the record as abandoned"
+        );
+        let retained = records_for_channel("claude", 12);
+        assert_eq!(retained.len(), 1);
+        assert_eq!(
+            retained[0].attempt_count, PENDING_START_MAX_CLAIM_ATTEMPTS,
+            "retry exhaustion must be persisted so queue_io can distinguish \
+             abandoned claims from live workers"
+        );
         assert_eq!(
             abort_cleanup_calls.load(Ordering::SeqCst),
             0,
@@ -1378,6 +1627,71 @@ mod tests {
              re-attempt — the anchor's ⏳ must stay (the restored worker may still \
              claim and complete it normally), so the abort cleanup must NOT fire"
         );
+        reset_present_for_tests();
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test(start_paused = true)]
+    async fn live_worker_with_capped_attempt_count_is_not_abandoned() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let _guard = worker_test_lock();
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let _env = EnvReset(std::env::var_os("AGENTDESK_ROOT_DIR"));
+        let temp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
+
+        reset_present_for_tests();
+        let shared = super::super::make_shared_data_for_tests();
+        let finalized = Arc::new(AtomicBool::new(false));
+        let finalized_for_view = finalized.clone();
+        let view: ViewFn = Box::new(move |_shared, _record| {
+            let finalized = finalized_for_view.clone();
+            Box::pin(async move {
+                let view = if finalized.load(Ordering::SeqCst) {
+                    base_view()
+                } else {
+                    PriorTurnView {
+                        inflight_present: true,
+                        inflight_is_own_anchor: false,
+                        mailbox_blocking_turn_present: true,
+                        mailbox_turn_is_own_anchor: false,
+                        runtime_binding_present: true,
+                    }
+                };
+                Some(obs(view))
+            })
+        });
+        let claim: ClaimFn = Box::new(move |_shared, _record| Box::pin(async move { true }));
+
+        let mut rec = record("claude", 13, 133);
+        rec.attempt_count = PENDING_START_MAX_CLAIM_ATTEMPTS;
+        persist(&rec).unwrap();
+        let (abort_cleanup, _, _) = recording_abort_cleanup();
+        let handle = tokio::spawn(run_worker(shared.clone(), rec, view, claim, abort_cleanup));
+
+        tokio::task::yield_now().await;
+        assert!(
+            !pending_synthetic_start_abandoned("claude", 13),
+            "a live worker must protect a capped durable record from being \
+             treated as abandoned during restart re-claim"
+        );
+        assert!(
+            !clear_abandoned_synthetic_start_presence("claude", 13),
+            "presence clear must refuse while a worker is active"
+        );
+
+        finalized.store(true, Ordering::SeqCst);
+        tokio::time::advance(PENDING_START_POLL * 2).await;
+        tokio::task::yield_now().await;
+        handle.await.unwrap();
+        assert!(
+            !pending_synthetic_start_present("claude", 13),
+            "the live worker's successful claim clears the presence through the normal delete path"
+        );
+
         reset_present_for_tests();
     }
 

--- a/src/services/discord/tui_direct_pending_start.rs
+++ b/src/services/discord/tui_direct_pending_start.rs
@@ -1630,9 +1630,11 @@ mod tests {
         reset_present_for_tests();
     }
 
-    #[allow(clippy::await_holding_lock)]
-    #[tokio::test(start_paused = true)]
-    async fn live_worker_with_capped_attempt_count_is_not_abandoned() {
+    // Sync test + explicit block_on: the std-mutex test-env guards live only in
+    // this sync scope and never span an await, so no await_holding_lock allow is
+    // needed (#3034 ratchet stays frozen at its baseline).
+    #[test]
+    fn live_worker_with_capped_attempt_count_is_not_abandoned() {
         use std::sync::atomic::{AtomicBool, Ordering};
 
         let _guard = worker_test_lock();
@@ -1644,53 +1646,61 @@ mod tests {
         unsafe { std::env::set_var("AGENTDESK_ROOT_DIR", temp.path()) };
 
         reset_present_for_tests();
-        let shared = super::super::make_shared_data_for_tests();
-        let finalized = Arc::new(AtomicBool::new(false));
-        let finalized_for_view = finalized.clone();
-        let view: ViewFn = Box::new(move |_shared, _record| {
-            let finalized = finalized_for_view.clone();
-            Box::pin(async move {
-                let view = if finalized.load(Ordering::SeqCst) {
-                    base_view()
-                } else {
-                    PriorTurnView {
-                        inflight_present: true,
-                        inflight_is_own_anchor: false,
-                        mailbox_blocking_turn_present: true,
-                        mailbox_turn_is_own_anchor: false,
-                        runtime_binding_present: true,
-                    }
-                };
-                Some(obs(view))
-            })
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .start_paused(true)
+            .build()
+            .expect("test runtime");
+        rt.block_on(async {
+            let shared = super::super::make_shared_data_for_tests();
+            let finalized = Arc::new(AtomicBool::new(false));
+            let finalized_for_view = finalized.clone();
+            let view: ViewFn = Box::new(move |_shared, _record| {
+                let finalized = finalized_for_view.clone();
+                Box::pin(async move {
+                    let view = if finalized.load(Ordering::SeqCst) {
+                        base_view()
+                    } else {
+                        PriorTurnView {
+                            inflight_present: true,
+                            inflight_is_own_anchor: false,
+                            mailbox_blocking_turn_present: true,
+                            mailbox_turn_is_own_anchor: false,
+                            runtime_binding_present: true,
+                        }
+                    };
+                    Some(obs(view))
+                })
+            });
+            let claim: ClaimFn = Box::new(move |_shared, _record| Box::pin(async move { true }));
+
+            let mut rec = record("claude", 13, 133);
+            rec.attempt_count = PENDING_START_MAX_CLAIM_ATTEMPTS;
+            persist(&rec).unwrap();
+            let (abort_cleanup, _, _) = recording_abort_cleanup();
+            let handle = tokio::spawn(run_worker(shared.clone(), rec, view, claim, abort_cleanup));
+
+            tokio::task::yield_now().await;
+            assert!(
+                !pending_synthetic_start_abandoned("claude", 13),
+                "a live worker must protect a capped durable record from being \
+                 treated as abandoned during restart re-claim"
+            );
+            assert!(
+                !clear_abandoned_synthetic_start_presence("claude", 13),
+                "presence clear must refuse while a worker is active"
+            );
+
+            finalized.store(true, Ordering::SeqCst);
+            tokio::time::advance(PENDING_START_POLL * 2).await;
+            tokio::task::yield_now().await;
+            handle.await.unwrap();
+            assert!(
+                !pending_synthetic_start_present("claude", 13),
+                "the live worker's successful claim clears the presence through the normal delete path"
+            );
         });
-        let claim: ClaimFn = Box::new(move |_shared, _record| Box::pin(async move { true }));
-
-        let mut rec = record("claude", 13, 133);
-        rec.attempt_count = PENDING_START_MAX_CLAIM_ATTEMPTS;
-        persist(&rec).unwrap();
-        let (abort_cleanup, _, _) = recording_abort_cleanup();
-        let handle = tokio::spawn(run_worker(shared.clone(), rec, view, claim, abort_cleanup));
-
-        tokio::task::yield_now().await;
-        assert!(
-            !pending_synthetic_start_abandoned("claude", 13),
-            "a live worker must protect a capped durable record from being \
-             treated as abandoned during restart re-claim"
-        );
-        assert!(
-            !clear_abandoned_synthetic_start_presence("claude", 13),
-            "presence clear must refuse while a worker is active"
-        );
-
-        finalized.store(true, Ordering::SeqCst);
-        tokio::time::advance(PENDING_START_POLL * 2).await;
-        tokio::task::yield_now().await;
-        handle.await.unwrap();
-        assert!(
-            !pending_synthetic_start_present("claude", 13),
-            "the live worker's successful claim clears the presence through the normal delete path"
-        );
 
         reset_present_for_tests();
     }


### PR DESCRIPTION
## 설계
deferred drain 루프(queue_io.rs)가 zero-start 3회 연속이면 durable record를 재검증해 **abandoned claim**(claim_attempts 캡아웃 + live/preclaimed worker 부재)일 때만 in-memory presence gate를 clear하고, final one-shot drain 후 150회 비수렴 루프를 종료.

## 불변식
- durable record는 보존(restart 시 claim 재시도 → 사용자 prompt 유실 없음), attempt_count persist
- live worker/preclaimed restore worker 존재 시 capped record라도 abandoned 오판 금지
- persist/clear는 reconcile lock으로 직렬화 — same-channel 새 pending start와 race 없음
- 실제 backlog 정상 경로(non-zero drain) 무영향, 핫파일 무접촉

## 게이트
fmt/check(0 warn)/clippy -D warnings/test(queue_io 3, tui_direct_pending_start 20)/agent-maintenance/audit 전부 통과

## 라이브 근거
2026-06-11 05:04Z claim_retry_exhausted → 05:17:27Z attempt 150/150 캡아웃 → 큐 스톨(safe restart로만 복구)

🤖 Generated with [Claude Code](https://claude.com/claude-code)