### PR TITLE
fix(#3304): canonical slash-command dedupe keys suppress duplicate synthetic turns from skill-expansion entries

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -638,7 +638,7 @@
     nested `usage` on the success result frame so watcher-owned codex turns
     persist token telemetry — never the session-cumulative
     `info.total_token_usage`).
-  - `src/services/tui_prompt_dedupe.rs` (1294 lines; shared TUI prompt
+  - `src/services/tui_prompt_dedupe.rs` (1356 lines; shared TUI prompt
     fingerprinting/dedupe state for hook and rollout relay paths, bugfix only
     outside an extraction plan; +88 from #3041 P1-4 codex: a per-record
     `generation: u64` nonce on `ExternalInputRelayLease` (process-global
@@ -656,7 +656,9 @@
     `external_input_relay_lease` and derives both presence + generation from that one
     atomic read, closing the present/generation TOCTOU) plus its dedicated accessor unit
     test; the watcher-snapshot no-clobber regression test is retained, rewritten to take
-    its G1/G2 snapshots from `external_input_relay_lease(...).map(|l| l.generation)`).
+    its G1/G2 snapshots from `external_input_relay_lease(...).map(|l| l.generation)`;
+    +62 from #3304: slash-command canonical prompt keys for `<command-*>` XML vs
+    `/command args` dedupe, plus focused loop skill-expansion regressions).
   - `src/services/discord/recovery_engine.rs` (4090 lines; #3016 phase-5b2
     dropped the `mailbox_finalize_owed` construction from the three recovery
     watcher-spawn handles; +9 from #3166

--- a/src/services/tui_prompt_dedupe.rs
+++ b/src/services/tui_prompt_dedupe.rs
@@ -2524,12 +2524,31 @@ mod tests {
         );
     }
 
+    // Live #3304 reproduction. The duplicate did NOT come from the isMeta
+    // skill-expansion entry (that is already filtered to None below): the two
+    // observation paths see ASYMMETRIC text for one submission — the hook path
+    // records the raw `/loop <args>` invocation echo a ScheduleWakeup writes
+    // into the terminal, while the idle transcript relay later extracts the
+    // string-content `<command-*>` wrapper entry. Before the slash canonical
+    // key their fuzzy keys diverged and the wrapper published a second
+    // synthetic turn (2026-06-11 05:15 incident).
     #[test]
-    fn ignores_live_loop_skill_expansion_meta_entry_after_command_xml_prompt() {
+    fn suppresses_transcript_command_xml_after_raw_invocation_echo() {
         let _guard = TEST_LOCK.lock().unwrap();
         reset_state();
         let command_args = "매 주기마다: (1) sonnet 모델 서브에이전트를 스폰해 \
             **adk-cc 채널(1479671298497183835)만** 조사시키고 보고받는다";
+
+        // 1st observation (hook path): raw invocation echo, published normally.
+        let invocation_echo = format!("/loop {command_args}");
+        assert_eq!(
+            observe_prompt_by_tmux("claude", "tmux-loop", &invocation_echo),
+            PromptObservation::PublishedSshDirect
+        );
+
+        // 2nd observation (idle transcript relay): the same submission as a
+        // command-XML wrapper. Without the slash canonical key this fuzzy-
+        // mismatched the echo and published a duplicate synthetic turn.
         let wrapper = format!(
             "<command-message>loop</command-message>\n\
              <command-name>/loop</command-name>\n\
@@ -2543,6 +2562,15 @@ mod tests {
             },
             "timestamp": "2026-06-10T20:15:20.334Z",
         });
+        let prompt = extract_claude_transcript_user_prompt(&command_json).expect("command prompt");
+        assert_eq!(
+            observe_prompt_by_tmux("claude", "tmux-loop", &prompt),
+            PromptObservation::SuppressedRecentDuplicate,
+            "#3304: the XML wrapper form must attribute to the raw invocation echo"
+        );
+
+        // The isMeta:true skill-expansion entry is machine context and never
+        // reaches dedupe at all (pre-existing filter, unrelated to the bug).
         let skill_expansion_json = serde_json::json!({
             "type": "user",
             "isMeta": true,
@@ -2559,20 +2587,10 @@ mod tests {
             },
             "timestamp": "2026-06-10T20:15:20.334Z",
         });
-
-        let prompt = extract_claude_transcript_user_prompt(&command_json).expect("command prompt");
-        assert_eq!(
-            observe_prompt_by_tmux("claude", "tmux-loop", &prompt),
-            PromptObservation::PublishedSshDirect
-        );
         assert_eq!(
             extract_claude_transcript_user_prompt(&skill_expansion_json),
             None,
             "Claude records slash-command skill expansion as isMeta=true machine context"
-        );
-        assert_eq!(
-            observe_prompt_by_tmux("claude", "tmux-loop", &prompt),
-            PromptObservation::SuppressedRecentDuplicate
         );
     }
 

--- a/src/services/tui_prompt_dedupe.rs
+++ b/src/services/tui_prompt_dedupe.rs
@@ -1187,6 +1187,14 @@ pub(crate) fn prompts_match(expected: &str, observed: &str) -> bool {
     if expected_trimmed == observed_trimmed {
         return true;
     }
+    if let (Some(expected_command), Some(observed_command)) = (
+        slash_command_prompt_key(&expected_trimmed),
+        slash_command_prompt_key(&observed_trimmed),
+    ) {
+        if expected_command == observed_command {
+            return true;
+        }
+    }
     let expected_fuzzy = fuzzy_prompt_key(&expected_trimmed);
     let observed_fuzzy = fuzzy_prompt_key(&observed_trimmed);
     if expected_fuzzy == observed_fuzzy {
@@ -1205,6 +1213,60 @@ fn fuzzy_prompt_key(value: &str) -> String {
         .collect::<Vec<_>>()
         .join(" ")
         .to_ascii_lowercase()
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct SlashCommandPromptKey {
+    name: String,
+    args: String,
+}
+
+fn slash_command_prompt_key(value: &str) -> Option<SlashCommandPromptKey> {
+    slash_command_xml_prompt_key(value).or_else(|| slash_command_invocation_prompt_key(value))
+}
+
+fn slash_command_xml_prompt_key(value: &str) -> Option<SlashCommandPromptKey> {
+    let trimmed = value.trim();
+    if !(trimmed.starts_with("<command-message>") || trimmed.starts_with("<command-name>")) {
+        return None;
+    }
+    let command_name = extract_xml_tag(trimmed, "command-name")?;
+    let (name, name_args) = parse_slash_command_invocation(command_name)?;
+    let args = extract_xml_tag(trimmed, "command-args")
+        .and_then(non_empty)
+        .unwrap_or(name_args);
+    Some(SlashCommandPromptKey {
+        name,
+        args: fuzzy_prompt_key(&args),
+    })
+}
+
+fn slash_command_invocation_prompt_key(value: &str) -> Option<SlashCommandPromptKey> {
+    let (name, args) = parse_slash_command_invocation(value)?;
+    Some(SlashCommandPromptKey {
+        name,
+        args: fuzzy_prompt_key(&args),
+    })
+}
+
+fn parse_slash_command_invocation(value: &str) -> Option<(String, String)> {
+    let trimmed = value.trim();
+    let (name, args) = match trimmed.split_once(char::is_whitespace) {
+        Some((name, args)) => (name, args),
+        None => (trimmed, ""),
+    };
+    if !name.starts_with('/') || name.len() <= 1 {
+        return None;
+    }
+    Some((name.to_ascii_lowercase(), args.trim().to_string()))
+}
+
+fn extract_xml_tag<'a>(value: &'a str, tag: &str) -> Option<&'a str> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let after_open = value.split_once(&open)?.1;
+    let (body, _) = after_open.split_once(&close)?;
+    Some(body.trim())
 }
 
 fn normalize_provider(provider: &str) -> String {
@@ -2346,6 +2408,48 @@ mod tests {
     }
 
     #[test]
+    fn suppresses_recent_slash_command_xml_and_invocation_forms() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+        let wrapper = "<command-message>loop</command-message>\n\
+                       <command-name>/loop</command-name>\n\
+                       <command-args>check relay gaps every 30m</command-args>";
+
+        assert_eq!(
+            observe_prompt_by_tmux("claude", "tmux-loop", wrapper),
+            PromptObservation::PublishedSshDirect
+        );
+        assert_eq!(
+            observe_prompt_by_tmux("claude", "tmux-loop", "/loop  check relay gaps every 30m"),
+            PromptObservation::SuppressedRecentDuplicate
+        );
+    }
+
+    #[test]
+    fn slash_command_dedupe_does_not_collapse_raw_args_or_other_commands() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+        let wrapper = "<command-message>loop</command-message>\n\
+                       <command-name>/loop</command-name>\n\
+                       <command-args>check relay gaps every 30m</command-args>";
+
+        assert_eq!(
+            observe_prompt_by_tmux("claude", "tmux-loop", wrapper),
+            PromptObservation::PublishedSshDirect
+        );
+        assert_eq!(
+            observe_prompt_by_tmux("claude", "tmux-loop", "check relay gaps every 30m"),
+            PromptObservation::PublishedSshDirect,
+            "a real raw prompt matching only command args must not be dropped"
+        );
+        assert_eq!(
+            observe_prompt_by_tmux("claude", "tmux-loop", "/model check relay gaps every 30m"),
+            PromptObservation::PublishedSshDirect,
+            "a different slash command with the same args is a new submission"
+        );
+    }
+
+    #[test]
     fn pending_match_leaves_recent_tombstone_for_second_observer() {
         let _guard = TEST_LOCK.lock().unwrap();
         reset_state();
@@ -2421,6 +2525,58 @@ mod tests {
     }
 
     #[test]
+    fn ignores_live_loop_skill_expansion_meta_entry_after_command_xml_prompt() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+        let command_args = "매 주기마다: (1) sonnet 모델 서브에이전트를 스폰해 \
+            **adk-cc 채널(1479671298497183835)만** 조사시키고 보고받는다";
+        let wrapper = format!(
+            "<command-message>loop</command-message>\n\
+             <command-name>/loop</command-name>\n\
+             <command-args>{command_args}</command-args>"
+        );
+        let command_json = serde_json::json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": wrapper,
+            },
+            "timestamp": "2026-06-10T20:15:20.334Z",
+        });
+        let skill_expansion_json = serde_json::json!({
+            "type": "user",
+            "isMeta": true,
+            "message": {
+                "role": "user",
+                "content": [{
+                    "type": "text",
+                    "text": format!(
+                        "# /loop — schedule a recurring or self-paced prompt\n\n\
+                         Parse the input below into `[interval] <prompt…>` and schedule it.\n\n\
+                         ## Input\n\n{command_args}"
+                    ),
+                }],
+            },
+            "timestamp": "2026-06-10T20:15:20.334Z",
+        });
+
+        let prompt = extract_claude_transcript_user_prompt(&command_json).expect("command prompt");
+        assert_eq!(
+            observe_prompt_by_tmux("claude", "tmux-loop", &prompt),
+            PromptObservation::PublishedSshDirect
+        );
+        assert_eq!(
+            extract_claude_transcript_user_prompt(&skill_expansion_json),
+            None,
+            "Claude records slash-command skill expansion as isMeta=true machine context"
+        );
+        assert_eq!(
+            observe_prompt_by_tmux("claude", "tmux-loop", &prompt),
+            PromptObservation::SuppressedRecentDuplicate
+        );
+    }
+
+    #[test]
     fn ignores_claude_transcript_meta_user_message_text() {
         let json = serde_json::json!({
             "type": "user",
@@ -2435,6 +2591,39 @@ mod tests {
         });
 
         assert_eq!(extract_claude_transcript_user_prompt(&json), None);
+    }
+
+    #[test]
+    fn extracts_non_meta_claude_array_user_message_after_slash_command() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        reset_state();
+        let wrapper = "<command-message>loop</command-message>\n\
+                       <command-name>/loop</command-name>\n\
+                       <command-args>check relay gaps every 30m</command-args>";
+        assert_eq!(
+            observe_prompt_by_tmux("claude", "tmux-loop", wrapper),
+            PromptObservation::PublishedSshDirect
+        );
+
+        let json = serde_json::json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [
+                    { "type": "text", "text": "fresh array prompt" },
+                    { "type": "text", "text": "with attachment context" }
+                ],
+            },
+            "sessionId": "sess-tui",
+        });
+        let prompt = extract_claude_transcript_user_prompt(&json).expect("array prompt");
+
+        assert_eq!(prompt, "fresh array prompt\nwith attachment context");
+        assert_eq!(
+            observe_prompt_by_tmux("claude", "tmux-loop", &prompt),
+            PromptObservation::PublishedSshDirect,
+            "non-command array user content remains a real user submission"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 설계
같은 /loop 제출이 hook 경로(command-XML 래퍼)와 idle transcript 경로(스킬 본문 array 확장, `isMeta:true`)에서 서로 다른 텍스트로 추출되어 fuzzy dedupe가 불일치 → 중복 synthetic turn + FOREIGN ABORT 가짜 ⚠ (2026-06-11 05:15 라이브 사례). `tui_prompt_dedupe.rs`에 slash-command canonical dedupe key를 도입해 `<command-*>` XML 형태와 `/command args` 형태를 같은 제출로 귀속.

## 불변식
- raw args가 다르거나 다른 slash command면 별개 제출로 유지(오-suppress 금지)
- 비-command array 사용자 메시지(이미지 첨부 등) 추출/게시 동작 보존
- TTL 경계 레이스는 중복 게시 쪽으로 fail(유실 쪽 아님) — 신규 시간 윈도우 억제 없음
- frozen 핫파일(tui_prompt_relay.rs 등) 무수정 — 수정 표면 tui_prompt_dedupe.rs 한정

## 근거
실제 Claude transcript 구조 검증: command-XML user 엔트리(string content)와 스킬 확장 엔트리(array content, isMeta:true, 동일 promptId/timestamp) — 라이브 재현 픽스처로 회귀 고정.

## 게이트
fmt/check(0 warn)/clippy -D warnings/tui_prompt_dedupe 46·tui_prompt_relay 107 테스트/agent-maintenance/audit/await ratchet 34 전부 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)