### PR TITLE
feat(#3332): server-side conditional Stop flush for unsubmitted memento tool_feedback

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -335,7 +335,9 @@ src/
 │   │   ├── hook_bundle.rs
 │   │   ├── hook_relay.rs
 │   │   ├── hook_server.rs
+│   │   ├── hook_server_memento_tests.rs
 │   │   ├── input.rs
+│   │   ├── memento_feedback.rs
 │   │   ├── mod.rs
 │   │   ├── session.rs
 │   │   ├── transcript_tail.rs

--- a/src/services/claude_tui/hook_relay.rs
+++ b/src/services/claude_tui/hook_relay.rs
@@ -7,7 +7,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use url::Url;
 
+use crate::services::claude_tui::memento_feedback;
+
 const RELAY_TIMEOUT: Duration = Duration::from_secs(2);
+const STOP_RELAY_TIMEOUT: Duration = Duration::from_millis(750);
 const FAILURE_MARKER_TTL_SECS: i64 = 24 * 60 * 60;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -53,6 +56,19 @@ fn run_cli_with_name(
     };
 
     let effective_session_id = relay_event_session_id(provider, session_id, &payload);
+    if should_wait_for_stop_response(provider, event) {
+        let stdout = claude_stop_stdout_after_relay(
+            endpoint,
+            provider,
+            event,
+            &effective_session_id,
+            payload,
+            relay_name,
+        );
+        println!("{stdout}");
+        return Ok(());
+    }
+
     // Compute the hook stdout (which may carry a tool_feedback nudge for memento
     // searches) before `payload` is moved into the relay POST below.
     let stdout = hook_stdout(provider, event, &payload);
@@ -70,6 +86,62 @@ fn run_cli_with_name(
     }
     println!("{stdout}");
     Ok(())
+}
+
+fn should_wait_for_stop_response(provider: &str, event: &str) -> bool {
+    provider.trim().eq_ignore_ascii_case("claude") && event.trim().eq_ignore_ascii_case("Stop")
+}
+
+fn claude_stop_stdout_after_relay(
+    endpoint: &str,
+    provider: &str,
+    event: &str,
+    session_id: &str,
+    payload: Value,
+    relay_name: &str,
+) -> String {
+    let relay_result = relay_hook_event_response_with_timeout(
+        endpoint,
+        provider,
+        event,
+        session_id,
+        payload,
+        STOP_RELAY_TIMEOUT,
+    );
+    let stdout = stop_stdout_from_relay_result(provider, event, &relay_result);
+    if let Err(error) = relay_result {
+        eprintln!("agentdesk {relay_name} warning: {error}");
+        if let Err(marker_error) =
+            record_hook_relay_failure(endpoint, provider, event, session_id, &error)
+        {
+            eprintln!("agentdesk {relay_name} marker warning: {marker_error}");
+        }
+    }
+    stdout
+}
+
+fn stop_stdout_from_relay_result(
+    provider: &str,
+    event: &str,
+    relay_result: &Result<Value, String>,
+) -> String {
+    let Ok(response) = relay_result else {
+        return hook_success_stdout(provider).to_string();
+    };
+    stop_stdout_from_receiver_response(provider, event, response)
+}
+
+fn stop_stdout_from_receiver_response(provider: &str, event: &str, response: &Value) -> String {
+    if !should_wait_for_stop_response(provider, event) {
+        return hook_success_stdout(provider).to_string();
+    }
+    response
+        .get("memento_tool_feedback_flush")
+        .and_then(|flush| flush.get("additional_context"))
+        .and_then(Value::as_str)
+        .filter(|context| !context.trim().is_empty())
+        .map(|context| hook_specific_stdout("claude", "Stop", context.to_string()))
+        .unwrap_or_else(|| hook_success_stdout(provider).to_string())
 }
 
 fn relay_event_session_id(provider: &str, command_session_id: &str, payload: &Value) -> String {
@@ -167,21 +239,7 @@ fn hook_specific_stdout(
 /// `_meta.searchEventId` eligible for `tool_feedback`). `remember`, `forget`,
 /// and the rest are excluded.
 fn memento_search_tool_name(payload: &Value) -> Option<String> {
-    let tool_name = payload
-        .get("tool_name")
-        .and_then(Value::as_str)
-        .map(|name| name.trim().to_ascii_lowercase())?;
-    if !tool_name.contains("memento") {
-        return None;
-    }
-    // Match the trailing tool segment exactly so both `mcp__memento__recall` and
-    // the dotted `memento.recall` form qualify, while `recall_context_combined`
-    // or a non-memento server's `recall` do not.
-    let leaf = tool_name
-        .rsplit(|c| c == '_' || c == '.')
-        .next()
-        .unwrap_or("");
-    matches!(leaf, "recall" | "context").then_some(tool_name)
+    memento_feedback::memento_search_tool_name(payload)
 }
 
 /// Best-effort extraction of `searchEventId` from the PostToolUse payload.
@@ -193,62 +251,16 @@ fn memento_search_tool_name(payload: &Value) -> Option<String> {
 /// marker. Returns `None` when absent — the nudge still fires, just without an
 /// explicit id (the model has the id in its own recall result).
 fn extract_search_event_id(payload: &Value) -> Option<String> {
-    for hay in [payload.get("tool_response"), Some(payload)]
-        .into_iter()
-        .flatten()
-    {
-        if let Some(id) = scan_search_event_id(&hay.to_string()) {
-            return Some(id);
-        }
-    }
-    None
+    memento_feedback::extract_search_event_id(payload)
 }
 
+#[cfg(test)]
 fn scan_search_event_id(serialized: &str) -> Option<String> {
-    // Anchor on `searchEventId` as a JSON *key*: the marker must be followed by
-    // an (optionally backslash-escaped) closing quote and a `:`, then the value
-    // digits. This rejects longer keys (`searchEventIdHash`), bare-word mentions
-    // inside fragment text, and `null`/empty values — each of which would
-    // otherwise let a greedy digit scan capture an unrelated number. Multiple
-    // occurrences are tried so a non-matching first hit doesn't abort the scan.
-    let marker = "searchEventId";
-    let mut haystack = serialized;
-    loop {
-        let rel = haystack.find(marker)?;
-        let after = &haystack[rel + marker.len()..];
-        let key_tail = after
-            .strip_prefix("\\\"")
-            .or_else(|| after.strip_prefix('"'))
-            .unwrap_or(after)
-            .trim_start();
-        if let Some(value_part) = key_tail.strip_prefix(':') {
-            let value = value_part.trim_start();
-            let value = value
-                .strip_prefix("\\\"")
-                .or_else(|| value.strip_prefix('"'))
-                .unwrap_or(value);
-            let digits: String = value.chars().take_while(char::is_ascii_digit).collect();
-            if !digits.is_empty() {
-                return Some(digits);
-            }
-        }
-        haystack = after;
-    }
+    memento_feedback::scan_search_event_id(serialized)
 }
 
 fn memento_feedback_instruction(search_event_id: Option<String>) -> String {
-    let target = match search_event_id {
-        Some(id) => format!("search_event_id={id}"),
-        None => "the search_event_id shown under `_meta.searchEventId` in that result".to_string(),
-    };
-    format!(
-        "Action required: you just received a memento search result. Submit one \
-`mcp__memento__tool_feedback` call immediately for THIS result with \
-{target}, `relevant` = whether any returned fragment was on-topic, and `sufficient` = whether the \
-results were enough to proceed. If `mcp__memento__tool_feedback` is not in your active tools \
-(memento tools are deferred), first load it with ToolSearch query \
-`select:mcp__memento__tool_feedback`, then make the call. Do this now, then continue."
-    )
+    memento_feedback::immediate_feedback_instruction(search_event_id)
 }
 
 pub fn relay_hook_event(
@@ -258,15 +270,49 @@ pub fn relay_hook_event(
     session_id: &str,
     payload: Value,
 ) -> Result<(), String> {
+    post_hook_event_with_timeout(
+        endpoint,
+        provider,
+        event,
+        session_id,
+        payload,
+        RELAY_TIMEOUT,
+    )
+    .map(|_| ())
+}
+
+fn relay_hook_event_response_with_timeout(
+    endpoint: &str,
+    provider: &str,
+    event: &str,
+    session_id: &str,
+    payload: Value,
+    timeout: Duration,
+) -> Result<Value, String> {
+    let response =
+        post_hook_event_with_timeout(endpoint, provider, event, session_id, payload, timeout)?;
+    response
+        .into_json()
+        .map_err(|error| format!("parse hook receiver response: {error}"))
+}
+
+fn post_hook_event_with_timeout(
+    endpoint: &str,
+    provider: &str,
+    event: &str,
+    session_id: &str,
+    payload: Value,
+    timeout: Duration,
+) -> Result<ureq::Response, String> {
     let url = hook_url(endpoint, provider, event, session_id)?;
-    let agent = ureq::AgentBuilder::new().timeout(RELAY_TIMEOUT).build();
+    let agent = ureq::AgentBuilder::new().timeout(timeout).build();
     let response = agent
         .post(url.as_str())
         .set("Content-Type", "application/json")
         .send_json(payload)
         .map_err(|error| format!("post hook event: {error}"))?;
     if (200..300).contains(&response.status()) {
-        Ok(())
+        Ok(response)
     } else {
         Err(format!("hook receiver returned HTTP {}", response.status()))
     }
@@ -576,6 +622,54 @@ mod tests {
     }
 
     #[test]
+    fn claude_stop_uses_server_flush_response_when_present() {
+        let out = stop_stdout_from_receiver_response(
+            "claude",
+            "Stop",
+            &serde_json::json!({
+                "ok": true,
+                "memento_tool_feedback_flush": {
+                    "additional_context": "submit memento feedback for [42]"
+                }
+            }),
+        );
+        let value: Value = serde_json::from_str(&out).unwrap();
+
+        assert_eq!(value["suppressOutput"], true);
+        assert_eq!(value["hookSpecificOutput"]["hookEventName"], "Stop");
+        assert_eq!(
+            value["hookSpecificOutput"]["additionalContext"],
+            "submit memento feedback for [42]"
+        );
+    }
+
+    #[test]
+    fn claude_stop_relay_error_fails_open_observational() {
+        let out = stop_stdout_from_relay_result(
+            "claude",
+            "Stop",
+            &Err("post hook event: connection refused".to_string()),
+        );
+
+        assert_eq!(out, r#"{"suppressOutput":true}"#);
+    }
+
+    #[test]
+    fn codex_stop_ignores_server_flush_response() {
+        let out = stop_stdout_from_receiver_response(
+            "codex",
+            "Stop",
+            &serde_json::json!({
+                "memento_tool_feedback_flush": {
+                    "additional_context": "must not be surfaced to codex"
+                }
+            }),
+        );
+
+        assert_eq!(out, "{}");
+    }
+
+    #[test]
     fn non_search_and_non_posttooluse_stay_observational() {
         // Wrong event.
         let recall = serde_json::json!({ "tool_name": "mcp__memento__recall" });
@@ -642,6 +736,7 @@ mod tests {
         assert!(target("mcp__memento__recall_context_combined").is_none());
         assert!(target("mcp__memento__forget").is_none());
         assert!(target("mcp__other__recall").is_none());
+        assert!(target("recall").is_none());
     }
 
     #[test]

--- a/src/services/claude_tui/hook_server.rs
+++ b/src/services/claude_tui/hook_server.rs
@@ -9,6 +9,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::sync::{Notify, broadcast};
 
+use crate::services::claude_tui::memento_feedback::PendingMementoFeedbackTracker;
+
 const EVENT_BUFFER_CAPACITY: usize = 256;
 
 static HOOK_ENDPOINT: LazyLock<RwLock<Option<String>>> = LazyLock::new(|| RwLock::new(None));
@@ -107,12 +109,16 @@ pub struct HookEvent {
 #[derive(Clone)]
 pub struct HookServerState {
     event_tx: broadcast::Sender<HookEvent>,
+    memento_feedback: PendingMementoFeedbackTracker,
 }
 
 impl HookServerState {
     pub fn new() -> Self {
         let (event_tx, _) = broadcast::channel(EVENT_BUFFER_CAPACITY);
-        Self { event_tx }
+        Self {
+            event_tx,
+            memento_feedback: PendingMementoFeedbackTracker::default(),
+        }
     }
 
     pub fn subscribe(&self) -> broadcast::Receiver<HookEvent> {
@@ -215,6 +221,22 @@ async fn receive_hook(
         payload,
     };
     let event_name = event.kind.as_str().to_string();
+    let memento_stop_flush = match event.kind {
+        HookEventKind::PostToolUse => {
+            let _ = state
+                .memento_feedback
+                .observe_post_tool_use(&event.session_id, &event.payload);
+            None
+        }
+        HookEventKind::Stop if event.provider == "claude" => state
+            .memento_feedback
+            .take_stop_flush(&event.session_id, &event.payload),
+        HookEventKind::Stop | HookEventKind::SubagentStop => {
+            state.memento_feedback.clear_session(&event.session_id);
+            None
+        }
+        _ => None,
+    };
     if matches!(event.kind, HookEventKind::Unknown(_)) {
         tracing::warn!(
             provider,
@@ -223,7 +245,8 @@ async fn receive_hook(
             "unknown tui hook event accepted for provider-scoped telemetry"
         );
     }
-    if should_signal_prompt_ready(&event.provider, &event.kind) {
+    let stop_flush_injected = memento_stop_flush.is_some();
+    if should_signal_prompt_ready(&event.provider, &event.kind) && !stop_flush_injected {
         // Wake any task currently awaiting prompt readiness. `notify_waiters`
         // is edge-triggered: signals fired with no current waiters are
         // intentionally dropped so `wait_for_prompt_ready` cannot latch onto
@@ -284,17 +307,18 @@ async fn receive_hook(
     // * Every other event kind with `is_informational_empty_payload(payload) == true`
     //   is dropped at the broadcast boundary. The HTTP response stays 202
     //   so the relay CLI cannot tell — that contract is one-way fire-and-forget.
-    let should_drop_broadcast = payload_is_noise
-        && !matches!(
-            event.kind,
-            HookEventKind::Stop | HookEventKind::SubagentStop
-        );
+    let should_drop_broadcast = stop_flush_injected
+        || (payload_is_noise
+            && !matches!(
+                event.kind,
+                HookEventKind::Stop | HookEventKind::SubagentStop
+            ));
     if should_drop_broadcast {
         tracing::debug!(
             provider,
             event = event_name,
             session_id,
-            "tui hook event has empty payload; dropping broadcast (#2665)"
+            "tui hook event has empty payload or pending memento feedback flush; dropping broadcast"
         );
     } else if state.event_tx.send(event).is_err() {
         tracing::debug!(
@@ -305,15 +329,17 @@ async fn receive_hook(
         );
     }
 
-    (
-        StatusCode::ACCEPTED,
-        Json(json!({
-            "ok": true,
-            "provider": provider,
-            "event": event_name,
-            "session_id": session_id
-        })),
-    )
+    let mut body = json!({
+        "ok": true,
+        "provider": provider,
+        "event": event_name,
+        "session_id": session_id
+    });
+    if let Some(flush) = memento_stop_flush {
+        body["memento_tool_feedback_flush"] = flush.to_json();
+    }
+
+    (StatusCode::ACCEPTED, Json(body))
 }
 
 /// #2655: classification of the memento tool surface invoked in a hook

--- a/src/services/claude_tui/hook_server_memento_tests.rs
+++ b/src/services/claude_tui/hook_server_memento_tests.rs
@@ -1,0 +1,248 @@
+use axum::body::{Body, to_bytes};
+use axum::http::{Method, Request, StatusCode};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use super::hook_server::{HookServerState, hook_receiver_router_with_state};
+
+async fn response_json(response: axum::response::Response) -> Value {
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    serde_json::from_slice(&bytes).expect("json response")
+}
+
+#[tokio::test]
+async fn memento_search_then_tool_feedback_clears_pending_stop_flush() {
+    let state = HookServerState::new();
+    let app = hook_receiver_router_with_state(state);
+    let search_payload = json!({
+        "tool_name": "mcp__memento__recall",
+        "tool_response": [{"type":"text","text":"{\"_meta\":{\"searchEventId\":\"3332\"}}"}]
+    });
+    let feedback_payload = json!({
+        "tool_name": "mcp__memento__tool_feedback",
+        "tool_input": {"search_event_id": 3332, "relevant": true, "sufficient": true}
+    });
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/hooks/claude/PostToolUse?session_id=sess-feedback")
+                .header("content-type", "application/json")
+                .body(Body::from(search_payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/hooks/claude/PostToolUse?session_id=sess-feedback")
+                .header("content-type", "application/json")
+                .body(Body::from(feedback_payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/hooks/claude/Stop?session_id=sess-feedback")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = response_json(response).await;
+    assert!(body.get("memento_tool_feedback_flush").is_none());
+}
+
+#[tokio::test]
+async fn stop_without_pending_memento_search_stays_observational() {
+    let app = hook_receiver_router_with_state(HookServerState::new());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/hooks/claude/Stop?session_id=sess-no-pending")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = response_json(response).await;
+
+    assert_eq!(body["ok"], true);
+    assert!(body.get("memento_tool_feedback_flush").is_none());
+}
+
+#[tokio::test]
+async fn stop_with_pending_memento_search_flushes_once_and_clears() {
+    let state = HookServerState::new();
+    let app = hook_receiver_router_with_state(state);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/hooks/claude/PostToolUse?session_id=sess-pending")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "tool_name": "mcp__memento__context",
+                        "tool_response": {"_meta":{"searchEventId":"44"}}
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/hooks/claude/Stop?session_id=sess-pending")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = response_json(response).await;
+    let flush = &body["memento_tool_feedback_flush"];
+    assert_eq!(flush["search_event_ids"], json!(["44"]));
+    assert!(
+        flush["additional_context"]
+            .as_str()
+            .unwrap()
+            .contains("[44]")
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/hooks/claude/Stop?session_id=sess-pending")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = response_json(response).await;
+    assert!(body.get("memento_tool_feedback_flush").is_none());
+}
+
+#[tokio::test]
+async fn stop_hook_active_suppresses_memento_flush() {
+    let state = HookServerState::new();
+    let app = hook_receiver_router_with_state(state);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/hooks/claude/PostToolUse?session_id=sess-active")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "tool_name": "mcp__memento__recall",
+                        "tool_response": {"_meta":{"searchEventId":"45"}}
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/hooks/claude/Stop?session_id=sess-active")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"stop_hook_active":true}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = response_json(response).await;
+
+    assert!(body.get("memento_tool_feedback_flush").is_none());
+}
+
+#[tokio::test]
+async fn codex_stop_clears_pending_memento_search_without_flush() {
+    let state = HookServerState::new();
+    let app = hook_receiver_router_with_state(state);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/hooks/codex/PostToolUse?session_id=sess-codex")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "tool_name": "mcp__memento__recall",
+                        "tool_response": {"_meta":{"searchEventId":"46"}}
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/hooks/codex/Stop?session_id=sess-codex")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = response_json(response).await;
+    assert!(body.get("memento_tool_feedback_flush").is_none());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/hooks/claude/Stop?session_id=sess-codex")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body = response_json(response).await;
+    assert!(body.get("memento_tool_feedback_flush").is_none());
+}

--- a/src/services/claude_tui/memento_feedback.rs
+++ b/src/services/claude_tui/memento_feedback.rs
@@ -1,0 +1,576 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, RwLock};
+
+use chrono::{DateTime, Duration, Utc};
+use serde_json::{Value, json};
+
+pub(crate) const PENDING_SEARCH_TTL_SECS: i64 = 6 * 60 * 60;
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PendingMementoFeedbackTracker {
+    inner: Arc<RwLock<PendingMementoFeedbackState>>,
+}
+
+#[derive(Debug, Default)]
+struct PendingMementoFeedbackState {
+    sessions: BTreeMap<String, PendingSessionSearches>,
+}
+
+#[derive(Debug, Default)]
+struct PendingSessionSearches {
+    ids: BTreeMap<String, DateTime<Utc>>,
+    unknown_added_at: Vec<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PendingMementoFeedbackFlush {
+    pub search_event_ids: Vec<String>,
+    pub includes_unknown_searches: bool,
+    pub additional_context: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum MementoPostToolUseObservation {
+    Ignored,
+    SearchTracked { search_event_id: Option<String> },
+    FeedbackCleared { search_event_id: Option<String> },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MementoHookToolKind {
+    Search,
+    ToolFeedback,
+}
+
+impl PendingMementoFeedbackTracker {
+    pub(crate) fn observe_post_tool_use(
+        &self,
+        session_id: &str,
+        payload: &Value,
+    ) -> MementoPostToolUseObservation {
+        self.observe_post_tool_use_at(session_id, payload, Utc::now())
+    }
+
+    pub(crate) fn observe_post_tool_use_at(
+        &self,
+        session_id: &str,
+        payload: &Value,
+        now: DateTime<Utc>,
+    ) -> MementoPostToolUseObservation {
+        let Some(kind) = classify_memento_hook_tool(payload) else {
+            return MementoPostToolUseObservation::Ignored;
+        };
+        let session_id = session_id.trim();
+        if session_id.is_empty() {
+            return MementoPostToolUseObservation::Ignored;
+        }
+
+        let mut state = self
+            .inner
+            .write()
+            .unwrap_or_else(|error| error.into_inner());
+        state.prune_expired(now);
+        match kind {
+            MementoHookToolKind::Search => {
+                let search_event_id = extract_search_event_id(payload);
+                state.track_search(session_id, search_event_id.as_deref(), now);
+                MementoPostToolUseObservation::SearchTracked { search_event_id }
+            }
+            MementoHookToolKind::ToolFeedback => {
+                let search_event_id = extract_tool_feedback_search_event_id(payload);
+                state.clear_feedback(session_id, search_event_id.as_deref());
+                MementoPostToolUseObservation::FeedbackCleared { search_event_id }
+            }
+        }
+    }
+
+    pub(crate) fn take_stop_flush(
+        &self,
+        session_id: &str,
+        payload: &Value,
+    ) -> Option<PendingMementoFeedbackFlush> {
+        self.take_stop_flush_at(session_id, payload, Utc::now())
+    }
+
+    pub(crate) fn take_stop_flush_at(
+        &self,
+        session_id: &str,
+        payload: &Value,
+        now: DateTime<Utc>,
+    ) -> Option<PendingMementoFeedbackFlush> {
+        let session_id = session_id.trim();
+        if session_id.is_empty() {
+            return None;
+        }
+
+        let mut state = self
+            .inner
+            .write()
+            .unwrap_or_else(|error| error.into_inner());
+        state.prune_expired(now);
+        let Some(pending) = state.sessions.remove(session_id) else {
+            return None;
+        };
+        if stop_hook_active(payload) {
+            return None;
+        }
+        pending.into_flush()
+    }
+
+    pub(crate) fn clear_session(&self, session_id: &str) {
+        let session_id = session_id.trim();
+        if session_id.is_empty() {
+            return;
+        }
+        let mut state = self
+            .inner
+            .write()
+            .unwrap_or_else(|error| error.into_inner());
+        state.sessions.remove(session_id);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_count(&self, session_id: &str) -> usize {
+        let state = self.inner.read().unwrap_or_else(|error| error.into_inner());
+        state
+            .sessions
+            .get(session_id)
+            .map(PendingSessionSearches::len)
+            .unwrap_or(0)
+    }
+}
+
+impl PendingMementoFeedbackState {
+    fn track_search(
+        &mut self,
+        session_id: &str,
+        search_event_id: Option<&str>,
+        now: DateTime<Utc>,
+    ) {
+        let session = self.sessions.entry(session_id.to_string()).or_default();
+        match search_event_id.and_then(non_empty_string) {
+            Some(id) => {
+                session.ids.insert(id.to_string(), now);
+            }
+            None => session.unknown_added_at.push(now),
+        }
+    }
+
+    fn clear_feedback(&mut self, session_id: &str, search_event_id: Option<&str>) {
+        let Some(session) = self.sessions.get_mut(session_id) else {
+            return;
+        };
+        match search_event_id.and_then(non_empty_string) {
+            Some(id) => {
+                if session.ids.remove(id).is_none() && !session.unknown_added_at.is_empty() {
+                    session.unknown_added_at.pop();
+                }
+                if session.is_empty() {
+                    self.sessions.remove(session_id);
+                }
+            }
+            None => {
+                self.sessions.remove(session_id);
+            }
+        }
+    }
+
+    fn prune_expired(&mut self, now: DateTime<Utc>) {
+        let cutoff = now - Duration::seconds(PENDING_SEARCH_TTL_SECS);
+        self.sessions.retain(|_, pending| {
+            pending.ids.retain(|_, added_at| *added_at >= cutoff);
+            pending
+                .unknown_added_at
+                .retain(|added_at| *added_at >= cutoff);
+            !pending.is_empty()
+        });
+    }
+}
+
+impl PendingSessionSearches {
+    fn is_empty(&self) -> bool {
+        self.ids.is_empty() && self.unknown_added_at.is_empty()
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.ids.len() + self.unknown_added_at.len()
+    }
+
+    fn into_flush(self) -> Option<PendingMementoFeedbackFlush> {
+        if self.is_empty() {
+            return None;
+        }
+        let search_event_ids = self.ids.into_keys().collect::<Vec<_>>();
+        let includes_unknown_searches = !self.unknown_added_at.is_empty();
+        Some(PendingMementoFeedbackFlush {
+            additional_context: stop_feedback_flush_instruction(
+                &search_event_ids,
+                includes_unknown_searches,
+            ),
+            search_event_ids,
+            includes_unknown_searches,
+        })
+    }
+}
+
+impl PendingMementoFeedbackFlush {
+    pub(crate) fn to_json(&self) -> Value {
+        json!({
+            "additional_context": self.additional_context,
+            "search_event_ids": self.search_event_ids,
+            "includes_unknown_searches": self.includes_unknown_searches,
+        })
+    }
+}
+
+pub(crate) fn classify_memento_hook_tool(payload: &Value) -> Option<MementoHookToolKind> {
+    let tool_name = payload
+        .get("tool_name")
+        .and_then(Value::as_str)
+        .or_else(|| payload.get("toolName").and_then(Value::as_str))?
+        .trim();
+    let leaf = memento_tool_leaf(tool_name)?;
+    match leaf {
+        "recall" | "context" => Some(MementoHookToolKind::Search),
+        "tool_feedback" => Some(MementoHookToolKind::ToolFeedback),
+        _ => None,
+    }
+}
+
+pub(crate) fn memento_search_tool_name(payload: &Value) -> Option<String> {
+    matches!(
+        classify_memento_hook_tool(payload),
+        Some(MementoHookToolKind::Search)
+    )
+    .then(|| {
+        payload
+            .get("tool_name")
+            .and_then(Value::as_str)
+            .or_else(|| payload.get("toolName").and_then(Value::as_str))
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+    })
+}
+
+fn memento_tool_leaf(tool_name: &str) -> Option<&str> {
+    let lowered = tool_name.trim().to_ascii_lowercase();
+    let stripped = lowered
+        .strip_prefix("mcp__memento__")
+        .or_else(|| lowered.strip_prefix("memento."))
+        .or_else(|| lowered.strip_prefix("memento/"));
+    if let Some(stripped) = stripped {
+        return match stripped {
+            "recall" => Some("recall"),
+            "context" => Some("context"),
+            "tool_feedback" => Some("tool_feedback"),
+            _ => None,
+        };
+    }
+    let mut saw_memento_segment = false;
+    let mut last_segment = None;
+    for segment in lowered.split("__") {
+        saw_memento_segment |= segment == "memento";
+        last_segment = Some(segment);
+    }
+    if saw_memento_segment {
+        return match last_segment {
+            Some("recall") => Some("recall"),
+            Some("context") => Some("context"),
+            Some("tool_feedback") => Some("tool_feedback"),
+            _ => None,
+        };
+    }
+    None
+}
+
+pub(crate) fn extract_search_event_id(payload: &Value) -> Option<String> {
+    for hay in [payload.get("tool_response"), Some(payload)]
+        .into_iter()
+        .flatten()
+    {
+        if let Some(id) = search_event_id_from_value(hay) {
+            return Some(id);
+        }
+        if let Some(id) = scan_search_event_id(&hay.to_string()) {
+            return Some(id);
+        }
+    }
+    None
+}
+
+pub(crate) fn extract_tool_feedback_search_event_id(payload: &Value) -> Option<String> {
+    for key in ["tool_input", "toolInput", "input", "arguments", "args"] {
+        if let Some(container) = payload.get(key)
+            && let Some(id) = search_event_id_from_value(container)
+        {
+            return Some(id);
+        }
+    }
+    search_event_id_from_value(payload).or_else(|| scan_search_event_id(&payload.to_string()))
+}
+
+fn search_event_id_from_value(value: &Value) -> Option<String> {
+    match value {
+        Value::Object(map) => {
+            for key in [
+                "search_event_id",
+                "searchEventId",
+                "searchEventID",
+                "_searchEventId",
+                "_search_event_id",
+            ] {
+                if let Some(id) = map.get(key).and_then(string_or_integer) {
+                    return Some(id);
+                }
+            }
+            for nested in map.values() {
+                if let Some(id) = search_event_id_from_value(nested) {
+                    return Some(id);
+                }
+            }
+            None
+        }
+        Value::Array(items) => items.iter().find_map(search_event_id_from_value),
+        Value::String(text) => serde_json::from_str::<Value>(text)
+            .ok()
+            .and_then(|parsed| search_event_id_from_value(&parsed))
+            .or_else(|| scan_search_event_id(text)),
+        _ => None,
+    }
+}
+
+fn string_or_integer(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => non_empty_string(text).map(ToString::to_string),
+        Value::Number(number) => Some(number.to_string()).filter(|value| !value.is_empty()),
+        _ => None,
+    }
+}
+
+pub(crate) fn scan_search_event_id(serialized: &str) -> Option<String> {
+    for marker in ["searchEventId", "search_event_id", "_searchEventId"] {
+        if let Some(id) = scan_search_event_id_marker(serialized, marker) {
+            return Some(id);
+        }
+    }
+    None
+}
+
+fn scan_search_event_id_marker(serialized: &str, marker: &str) -> Option<String> {
+    let mut haystack = serialized;
+    loop {
+        let rel = haystack.find(marker)?;
+        let after = &haystack[rel + marker.len()..];
+        let key_tail = after
+            .strip_prefix("\\\"")
+            .or_else(|| after.strip_prefix('"'))
+            .unwrap_or(after)
+            .trim_start();
+        if let Some(value_part) = key_tail.strip_prefix(':') {
+            let value = value_part.trim_start();
+            let value = value
+                .strip_prefix("\\\"")
+                .or_else(|| value.strip_prefix('"'))
+                .unwrap_or(value);
+            let digits = value
+                .chars()
+                .take_while(char::is_ascii_digit)
+                .collect::<String>();
+            if !digits.is_empty() {
+                return Some(digits);
+            }
+        }
+        haystack = after;
+    }
+}
+
+pub(crate) fn immediate_feedback_instruction(search_event_id: Option<String>) -> String {
+    let target = match search_event_id {
+        Some(id) => format!("search_event_id={id}"),
+        None => "the search_event_id shown under `_meta.searchEventId` in that result".to_string(),
+    };
+    format!(
+        "Action required: you just received a memento search result. Submit one \
+`mcp__memento__tool_feedback` call immediately for THIS result with \
+{target}, `relevant` = whether any returned fragment was on-topic, and `sufficient` = whether the \
+results were enough to proceed. If `mcp__memento__tool_feedback` is not in your active tools \
+(memento tools are deferred), first load it with ToolSearch query \
+`select:mcp__memento__tool_feedback`, then make the call. Do this now, then continue."
+    )
+}
+
+fn stop_feedback_flush_instruction(
+    search_event_ids: &[String],
+    includes_unknown_searches: bool,
+) -> String {
+    let target = if search_event_ids.is_empty() {
+        "the pending search_event_id values shown under `_meta.searchEventId` in the memento search results".to_string()
+    } else {
+        format!(
+            "each pending search_event_id in [{}]",
+            search_event_ids.join(", ")
+        )
+    };
+    let unknown_clause = if includes_unknown_searches && !search_event_ids.is_empty() {
+        " For any pending memento search not listed, use the `_meta.searchEventId` shown in that result."
+    } else {
+        ""
+    };
+    format!(
+        "Action required before ending this turn: there are memento search results without \
+submitted feedback. Submit `mcp__memento__tool_feedback` for {target}, with `relevant` = whether \
+any returned fragment was on-topic and `sufficient` = whether the results were enough to proceed. \
+If `mcp__memento__tool_feedback` is not in your active tools (memento tools are deferred), first \
+load it with ToolSearch query `select:mcp__memento__tool_feedback`, then make the feedback call.\
+{unknown_clause} Do this now, then stop."
+    )
+}
+
+pub(crate) fn stop_hook_active(payload: &Value) -> bool {
+    payload
+        .get("stop_hook_active")
+        .or_else(|| payload.get("stopHookActive"))
+        .is_some_and(|value| match value {
+            Value::Bool(active) => *active,
+            Value::String(text) => text.trim().eq_ignore_ascii_case("true"),
+            _ => false,
+        })
+}
+
+fn non_empty_string(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then_some(trimmed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn tracks_search_and_clears_matching_tool_feedback_id() {
+        let tracker = PendingMementoFeedbackTracker::default();
+        let search = json!({
+            "tool_name": "mcp__memento__recall",
+            "tool_response": [{"type":"text","text":"{\"_meta\":{\"searchEventId\":\"22752\"}}"}]
+        });
+        let feedback = json!({
+            "tool_name": "mcp__memento__tool_feedback",
+            "tool_input": {"search_event_id": 22752, "relevant": true, "sufficient": true}
+        });
+
+        tracker.observe_post_tool_use_at("sess", &search, Utc::now());
+        assert_eq!(tracker.pending_count("sess"), 1);
+        tracker.observe_post_tool_use_at("sess", &feedback, Utc::now());
+
+        assert_eq!(tracker.pending_count("sess"), 0);
+    }
+
+    #[test]
+    fn tool_feedback_without_id_clears_session() {
+        let tracker = PendingMementoFeedbackTracker::default();
+        let now = Utc::now();
+        tracker.observe_post_tool_use_at(
+            "sess",
+            &json!({
+                "tool_name": "mcp__memento__recall",
+                "tool_response": {"_meta":{"searchEventId":"1"}}
+            }),
+            now,
+        );
+        tracker.observe_post_tool_use_at(
+            "sess",
+            &json!({
+                "tool_name": "mcp__memento__tool_feedback",
+                "tool_input": {"relevant": true, "sufficient": true}
+            }),
+            now,
+        );
+
+        assert_eq!(tracker.pending_count("sess"), 0);
+    }
+
+    #[test]
+    fn stop_flush_is_one_shot_and_lists_ids() {
+        let tracker = PendingMementoFeedbackTracker::default();
+        tracker.observe_post_tool_use_at(
+            "sess",
+            &json!({
+                "tool_name": "mcp__memento__context",
+                "tool_response": {"_meta":{"searchEventId":"42"}}
+            }),
+            Utc::now(),
+        );
+
+        let flush = tracker
+            .take_stop_flush_at("sess", &json!({}), Utc::now())
+            .unwrap();
+        assert_eq!(flush.search_event_ids, vec!["42"]);
+        assert!(flush.additional_context.contains("[42]"));
+        assert!(
+            flush
+                .additional_context
+                .contains("mcp__memento__tool_feedback")
+        );
+        assert!(
+            tracker
+                .take_stop_flush_at("sess", &json!({}), Utc::now())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn stop_hook_active_suppresses_and_clears_flush() {
+        let tracker = PendingMementoFeedbackTracker::default();
+        tracker.observe_post_tool_use_at(
+            "sess",
+            &json!({
+                "tool_name": "mcp__memento__recall",
+                "tool_response": {"_meta":{"searchEventId":"7"}}
+            }),
+            Utc::now(),
+        );
+
+        assert!(
+            tracker
+                .take_stop_flush_at("sess", &json!({"stop_hook_active": true}), Utc::now())
+                .is_none()
+        );
+        assert_eq!(tracker.pending_count("sess"), 0);
+    }
+
+    #[test]
+    fn ttl_prunes_old_searches() {
+        let tracker = PendingMementoFeedbackTracker::default();
+        let old = Utc::now() - Duration::seconds(PENDING_SEARCH_TTL_SECS + 1);
+        tracker.observe_post_tool_use_at(
+            "sess",
+            &json!({
+                "tool_name": "mcp__memento__recall",
+                "tool_response": {"_meta":{"searchEventId":"7"}}
+            }),
+            old,
+        );
+
+        assert!(
+            tracker
+                .take_stop_flush_at("sess", &json!({}), Utc::now())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn extracts_tool_feedback_search_event_id_from_stringified_input() {
+        let payload = json!({
+            "tool_name": "mcp__memento__tool_feedback",
+            "tool_input": "{\"search_event_id\":981,\"relevant\":true}"
+        });
+
+        assert_eq!(
+            extract_tool_feedback_search_event_id(&payload).as_deref(),
+            Some("981")
+        );
+    }
+}

--- a/src/services/claude_tui/mod.rs
+++ b/src/services/claude_tui/mod.rs
@@ -1,7 +1,10 @@
 pub mod hook_bundle;
 pub mod hook_relay;
 pub mod hook_server;
+#[cfg(test)]
+mod hook_server_memento_tests;
 pub mod input;
+pub(crate) mod memento_feedback;
 pub mod session;
 pub mod transcript_tail;
 pub mod tui_relay;


### PR DESCRIPTION
## 설계 (#3300 분리분)
stateless relay Stop hook의 무조건 주입(매 턴 종료 추가 모델 턴 강제 — #3330에서 제거된 회귀)을 피해, **hook_server가 세션별 미제출 검색을 추적**하고 미제출이 실제 있을 때만 Stop에서 1회 flush 주입:
- PostToolUse(recall/context) → search_event_id를 세션 pending에 추가
- PostToolUse(tool_feedback) → 제출 ID 개별 제거(추출 불가 시 세션 pending 전체 clear)
- Claude Stop → 서버 응답 750ms 대기, pending 있을 때만 additionalContext flush, **원자적 take-and-clear**로 1회만
- stop_hook_active=true / codex Stop / 서버 실패·타임아웃·파싱 실패 → 전부 기존 observational 유지(fail-open, 턴 종료 비차단)

## 제약 준수
- 메멘토 MCP 플러그인 무수정 (AgentDesk hook_server/hook_relay만)
- 핫파일 무접촉, PostToolUse 기존 stdout 선계산 경로 무변경(Stop만 POST-먼저 순서)

## 게이트
fmt/check(0 warn)/clippy -D warnings/hook_server·hook_relay 테스트/agent-maintenance/audit/await ratchet 34 전부 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)