### PR TITLE
fix(#3334): idempotent hourglass cleanup on abnormal finalize paths and restart catch-up

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -524,6 +524,7 @@ src/
 │   │   ├── placeholder_sweeper.rs
 │   │   ├── queue_io.rs
 │   │   ├── queued_placeholders_store.rs
+│   │   ├── reaction_cleanup.rs
 │   │   ├── recovery_engine.rs
 │   │   ├── relay_health.rs
 │   │   ├── relay_recovery.rs

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -387,6 +387,11 @@
   active-state. This is **worker-local**: it runs in the same process that owns
   the channel mailbox, finalizer actor, and local inflight file, and it adds no
   leader-only side effect, durable queue authority, or PG lease assumption.
+- #3334 reaction lifecycle cleanup: abnormal finalizer backstops and restart
+  catch-up now run idempotent same-message reaction cleanup through local Discord
+  HTTP helpers. This is **worker-local**: it touches only the recovered/finalized
+  Discord message id on the worker processing that channel and adds no shared
+  scheduling authority or cross-node lease dependency.
 - #3038 S1 (SharedData `QueuedPlaceholderState` extraction): `runtime_bootstrap.rs`
   changed in two helpers only — `run_bot_build_shared_data` (three consecutive
   queued-placeholder members wrapped into the new `queued:` group field;

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -34,6 +34,7 @@ mod placeholder_sweeper;
 mod prompt_builder;
 mod queue_io;
 mod queued_placeholders_store;
+mod reaction_cleanup;
 mod relay_health;
 mod relay_recovery;
 pub(crate) mod response_sanitizer;
@@ -4004,8 +4005,7 @@ async fn catch_up_missed_messages(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
 ) {
-    let retry_checkpoints = HashMap::new();
-    catch_up_missed_messages_inner(http, shared, provider, &retry_checkpoints).await;
+    catch_up_missed_messages_inner(http, shared, provider, &HashMap::new()).await;
 }
 
 async fn catch_up_missed_messages_inner(
@@ -4103,10 +4103,9 @@ async fn catch_up_missed_messages_inner(
         // Fetch messages after last_id (Discord returns oldest first with after=)
         // #1227: limit was 10 — channels with bursty bot activity (streaming
         // replies + many short turns) routinely fill that window with bot
-        // messages, pushing user messages outside the page entirely. Discord
-        // applies `limit` BEFORE author filtering, so an active channel
-        // (1 user : 9 bots) silently drops the user message. 50 keeps the
-        // single-page contract while giving headroom for the realistic
+        // messages, pushing user messages outside the page. Discord applies
+        // `limit` BEFORE author filtering; 50 keeps the single-page contract with
+        // headroom for the realistic
         // bot:user ratio. Discord per-channel rate limit (5 req / 5 sec)
         // has plenty of margin for this 5x cost.
         let messages = match channel_id
@@ -4214,6 +4213,7 @@ async fn catch_up_missed_messages_inner(
                 continue;
             }
 
+            reaction_cleanup::cleanup_recovered_catch_up_hourglass(http, channel_id, msg.id).await;
             mailbox_enqueue_intervention(
                 shared,
                 provider,

--- a/src/services/discord/reaction_cleanup.rs
+++ b/src/services/discord/reaction_cleanup.rs
@@ -1,0 +1,79 @@
+use std::sync::Arc;
+
+use poise::serenity_prelude as serenity;
+use serenity::{ChannelId, MessageId};
+
+pub(in crate::services::discord) async fn cleanup_recovered_catch_up_hourglass(
+    http: &Arc<serenity::Http>,
+    channel_id: ChannelId,
+    message_id: MessageId,
+) {
+    remove_reaction(http, channel_id, message_id, '⏳').await;
+}
+
+#[cfg(not(test))]
+async fn remove_reaction(
+    http: &Arc<serenity::Http>,
+    channel_id: ChannelId,
+    message_id: MessageId,
+    emoji: char,
+) {
+    super::formatting::remove_reaction_raw(http, channel_id, message_id, emoji).await;
+}
+
+#[cfg(test)]
+static REACTION_CLEANUP_RECORDS: std::sync::LazyLock<
+    std::sync::Mutex<Option<Vec<(u64, u64, char)>>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
+
+#[cfg(test)]
+fn begin_recording() {
+    *REACTION_CLEANUP_RECORDS
+        .lock()
+        .expect("reaction cleanup recorder lock") = Some(Vec::new());
+}
+
+#[cfg(test)]
+fn take_records() -> Vec<(u64, u64, char)> {
+    REACTION_CLEANUP_RECORDS
+        .lock()
+        .expect("reaction cleanup recorder lock")
+        .take()
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+async fn remove_reaction(
+    _http: &Arc<serenity::Http>,
+    channel_id: ChannelId,
+    message_id: MessageId,
+    emoji: char,
+) {
+    if let Some(records) = REACTION_CLEANUP_RECORDS
+        .lock()
+        .expect("reaction cleanup recorder lock")
+        .as_mut()
+    {
+        records.push((channel_id.get(), message_id.get(), emoji));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn recovered_catch_up_message_removes_stale_hourglass() {
+        let http = Arc::new(serenity::Http::new("Bot test-token"));
+        let channel_id = ChannelId::new(1514499617272627231);
+        let message_id = MessageId::new(1514500851761287319);
+
+        begin_recording();
+        cleanup_recovered_catch_up_hourglass(&http, channel_id, message_id).await;
+
+        assert_eq!(
+            take_records(),
+            vec![(channel_id.get(), message_id.get(), '⏳')]
+        );
+    }
+}

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -545,7 +545,6 @@ impl TurnFinalizer {
         };
         if matches!(out, FinalizeOutcome::AlreadyFinalized) {
             cleanup::already_finalized_active_state(key, &provider, &event, ctx, &shared).await;
-            cleanup::finalized_reaction_lifecycle(key, &event, ctx, &shared, "af").await;
         }
         out
     }
@@ -1135,7 +1134,7 @@ async fn do_finalize(
         has_pending_after_voice
     };
 
-    cleanup::finalized_reaction_lifecycle(key, event, ctx, shared, "finalized").await;
+    cleanup::finalized_reaction_lifecycle(key, event, ctx, shared, "finalized");
 
     // (F) relay-miss observability — emitted from inside the finalizer so the
     //     signal fires exactly once per finalize regardless of submitter.

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -218,9 +218,7 @@ pub(in crate::services::discord) enum TerminalEvent {
 
 /// Per-submission knobs that keep each routed call-site behaviourally
 /// identical to its pre-#3016 inline sequence during the incremental window.
-/// Each routed site maps exactly to the side-effects its inline code ran, so
-/// rewiring it through `do_finalize` is observably a no-op except for which
-/// code path issues the (identical) finalize.
+/// Routed sites preserve their old side-effects; only ownership moves.
 #[derive(Clone, Copy, Debug)]
 pub(in crate::services::discord) struct FinalizeContext {
     /// Whether `do_finalize` clears inflight as part of the finalize. Bridge
@@ -539,8 +537,7 @@ impl TurnFinalizer {
             })
             .is_err()
         {
-            // Actor task gone (teardown). Treat as already-finalized so the
-            // submitter does no further bookkeeping.
+            // Actor task gone: stop submitter-side bookkeeping.
             return FinalizeOutcome::AlreadyFinalized;
         }
         let Ok(out) = rx.await else {
@@ -548,6 +545,7 @@ impl TurnFinalizer {
         };
         if matches!(out, FinalizeOutcome::AlreadyFinalized) {
             cleanup::already_finalized_active_state(key, &provider, &event, ctx, &shared).await;
+            cleanup::finalized_reaction_lifecycle(key, &event, ctx, &shared, "af").await;
         }
         out
     }
@@ -1136,6 +1134,8 @@ async fn do_finalize(
         }
         has_pending_after_voice
     };
+
+    cleanup::finalized_reaction_lifecycle(key, event, ctx, shared, "finalized").await;
 
     // (F) relay-miss observability — emitted from inside the finalizer so the
     //     signal fires exactly once per finalize regardless of submitter.

--- a/src/services/discord/turn_finalizer/cleanup.rs
+++ b/src/services/discord/turn_finalizer/cleanup.rs
@@ -5,7 +5,30 @@ use crate::services::provider::ProviderKind;
 use super::{FinalizeContext, TerminalEvent, TurnKey};
 use crate::services::discord::SharedData;
 
-pub(super) async fn finalized_reaction_lifecycle(
+#[derive(Clone, Copy)]
+struct ReactionCleanupRequest {
+    channel_id: serenity::model::id::ChannelId,
+    message_id: serenity::model::id::MessageId,
+    add_checkmark: bool,
+    source: &'static str,
+}
+
+/// Backstop-only reaction cleanup for terminal paths that skipped the normal
+/// watcher `⏳ -> ✅` block.
+///
+/// Reachable production matrix:
+/// * `watcher` / `bridge` / `monitor` submitters pass `clear_inflight = false`,
+///   so they never run this helper; watcher owns the normal committed-output
+///   reaction block when it is safe to claim completion.
+/// * `gate_backstop()` is not a production `submit_terminal` context. It is
+///   reached only by `run_backstop_finalize -> do_finalize` after a deferred
+///   busy-pane gate, where no caller remains to clear inflight or the reaction.
+/// * the no-owner restored-watcher path mutates watcher context into the same
+///   `clear_inflight && kickoff_queue && !completion_cleanup && !voice` shape.
+///   That path also skipped the normal watcher block, so it needs this fallback.
+/// * `AlreadyFinalized` losers only inherit their submitter context, so they
+///   cannot become the backstop reaction owner after someone else won the gate.
+pub(super) fn finalized_reaction_lifecycle(
     key: TurnKey,
     event: &TerminalEvent,
     ctx: FinalizeContext,
@@ -21,10 +44,15 @@ pub(super) async fn finalized_reaction_lifecycle(
         return;
     }
     let message_id = serenity::model::id::MessageId::new(key.user_msg_id);
-    apply_reaction(shared, key.channel_id, message_id, '⏳', false, source).await;
-    if !matches!(event, TerminalEvent::Cancel) {
-        apply_reaction(shared, key.channel_id, message_id, '✅', true, source).await;
-    }
+    schedule_reaction_cleanup(
+        shared.clone(),
+        ReactionCleanupRequest {
+            channel_id: key.channel_id,
+            message_id,
+            add_checkmark: !matches!(event, TerminalEvent::Cancel),
+            source,
+        },
+    );
 }
 
 /// Late `AlreadyFinalized` losers still perform guarded active-state cleanup.
@@ -72,6 +100,32 @@ pub(super) async fn already_finalized_active_state(
     if !finish.has_pending {
         shared.dispatch_role_overrides.remove(&key.channel_id);
     }
+}
+
+#[cfg(not(test))]
+fn schedule_reaction_cleanup(shared: Arc<SharedData>, request: ReactionCleanupRequest) {
+    super::super::task_supervisor::spawn_observed("turn_finalizer_reaction_cleanup", async move {
+        apply_reaction(
+            &shared,
+            request.channel_id,
+            request.message_id,
+            '⏳',
+            false,
+            request.source,
+        )
+        .await;
+        if request.add_checkmark {
+            apply_reaction(
+                &shared,
+                request.channel_id,
+                request.message_id,
+                '✅',
+                true,
+                request.source,
+            )
+            .await;
+        }
+    });
 }
 
 #[cfg(not(test))]
@@ -132,8 +186,27 @@ pub(super) fn take_reaction_cleanup_records() -> Vec<ReactionCleanupRecord> {
 }
 
 #[cfg(test)]
-async fn apply_reaction(
-    _shared: &Arc<SharedData>,
+fn schedule_reaction_cleanup(_shared: Arc<SharedData>, request: ReactionCleanupRequest) {
+    record_reaction(
+        request.channel_id,
+        request.message_id,
+        '⏳',
+        false,
+        request.source,
+    );
+    if request.add_checkmark {
+        record_reaction(
+            request.channel_id,
+            request.message_id,
+            '✅',
+            true,
+            request.source,
+        );
+    }
+}
+
+#[cfg(test)]
+fn record_reaction(
     channel_id: serenity::model::id::ChannelId,
     message_id: serenity::model::id::MessageId,
     emoji: char,
@@ -192,10 +265,6 @@ mod tests {
         }
     }
 
-    fn reaction_context() -> FinalizeContext {
-        FinalizeContext::gate_backstop()
-    }
-
     async fn seed_active_turn(
         shared: &Arc<SharedData>,
         channel_id: ChannelId,
@@ -224,7 +293,7 @@ mod tests {
     }
 
     #[test]
-    fn backstop_finalize_removes_hourglass_and_marks_complete() {
+    fn reconciler_backstop_finalize_removes_hourglass_and_marks_complete() {
         with_isolated_runtime_root(|| {
             test_rt().block_on(async {
                 let shared =
@@ -267,7 +336,7 @@ mod tests {
     }
 
     #[test]
-    fn already_finalized_loser_runs_idempotent_reaction_cleanup() {
+    fn already_finalized_loser_does_not_claim_reaction_cleanup() {
         with_isolated_runtime_root(|| {
             test_rt().block_on(async {
                 let shared =
@@ -288,12 +357,12 @@ mod tests {
                         key,
                         ProviderKind::Claude,
                         TerminalEvent::Complete,
-                        reaction_context(),
+                        FinalizeContext::watcher(),
                         shared.clone(),
                     )
                     .await;
                 assert!(matches!(first, FinalizeOutcome::Finalized { .. }));
-                let _ = take_reaction_cleanup_records();
+                assert!(take_reaction_cleanup_records().is_empty());
 
                 begin_reaction_cleanup_recording();
                 let late = fin
@@ -301,51 +370,14 @@ mod tests {
                         key,
                         ProviderKind::Claude,
                         TerminalEvent::Complete,
-                        reaction_context(),
+                        FinalizeContext::bridge(),
                         shared.clone(),
                     )
                     .await;
                 assert!(matches!(late, FinalizeOutcome::AlreadyFinalized));
-                let records = take_reaction_cleanup_records();
-                assert_eq!(
-                    recorded_actions(&records),
-                    vec![(ch.get(), tid, '⏳', false), (ch.get(), tid, '✅', true)]
-                );
-                assert!(records.iter().all(|record| record.source == "af"));
-            });
-        });
-    }
-
-    #[test]
-    fn cancel_removes_hourglass_without_checkmark() {
-        with_isolated_runtime_root(|| {
-            test_rt().block_on(async {
-                let shared =
-                    super::super::super::make_shared_data_for_tests_with_storage(None, None);
-                let ch = ChannelId::new(3_334_300);
-                let tid = 3_334_301_u64;
-                shared
-                    .global_active
-                    .store(1, std::sync::atomic::Ordering::Relaxed);
-                let _token = seed_active_turn(&shared, ch, tid).await;
-                let fin = TurnFinalizer::spawn();
-                let key = TurnKey::new(ch, tid, 0);
-                fin.register_start(key, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
-
-                begin_reaction_cleanup_recording();
-                let outcome = fin
-                    .submit_terminal(
-                        key,
-                        ProviderKind::Claude,
-                        TerminalEvent::Cancel,
-                        reaction_context(),
-                        shared.clone(),
-                    )
-                    .await;
-                assert!(matches!(outcome, FinalizeOutcome::Finalized { .. }));
-                assert_eq!(
-                    recorded_actions(&take_reaction_cleanup_records()),
-                    vec![(ch.get(), tid, '⏳', false)]
+                assert!(
+                    take_reaction_cleanup_records().is_empty(),
+                    "reachable AlreadyFinalized losers inherit watcher/bridge/monitor context and must not masquerade as the backstop reaction owner"
                 );
             });
         });
@@ -403,8 +435,10 @@ mod tests {
                     .submit_terminal(
                         TurnKey::new(ch, old_tid, 0),
                         ProviderKind::Claude,
-                        TerminalEvent::Complete,
-                        reaction_context(),
+                        TerminalEvent::GateTimeout {
+                            pane_quiescent: Some(false),
+                        },
+                        FinalizeContext::watcher(),
                         shared.clone(),
                     )
                     .await;
@@ -426,8 +460,10 @@ mod tests {
                     .submit_terminal(
                         TurnKey::new(ChannelId::new(3_334_600), 0, 0),
                         ProviderKind::Claude,
-                        TerminalEvent::Complete,
-                        reaction_context(),
+                        TerminalEvent::GateTimeout {
+                            pane_quiescent: Some(false),
+                        },
+                        FinalizeContext::watcher(),
                         shared.clone(),
                     )
                     .await;

--- a/src/services/discord/turn_finalizer/cleanup.rs
+++ b/src/services/discord/turn_finalizer/cleanup.rs
@@ -5,6 +5,28 @@ use crate::services::provider::ProviderKind;
 use super::{FinalizeContext, TerminalEvent, TurnKey};
 use crate::services::discord::SharedData;
 
+pub(super) async fn finalized_reaction_lifecycle(
+    key: TurnKey,
+    event: &TerminalEvent,
+    ctx: FinalizeContext,
+    shared: &Arc<SharedData>,
+    source: &'static str,
+) {
+    if !ctx.clear_inflight
+        || !ctx.kickoff_queue
+        || ctx.allow_completion_cleanup
+        || ctx.drain_voice
+        || key.user_msg_id == 0
+    {
+        return;
+    }
+    let message_id = serenity::model::id::MessageId::new(key.user_msg_id);
+    apply_reaction(shared, key.channel_id, message_id, '⏳', false, source).await;
+    if !matches!(event, TerminalEvent::Cancel) {
+        apply_reaction(shared, key.channel_id, message_id, '✅', true, source).await;
+    }
+}
+
 /// Late `AlreadyFinalized` losers still perform guarded active-state cleanup.
 /// This is intentionally narrower than `do_finalize`: only the same real turn id
 /// can lose mailbox/inflight state, so a newer active turn is preserved.
@@ -49,5 +71,369 @@ pub(super) async fn already_finalized_active_state(
         .retain(|_, thread| *thread != key.channel_id);
     if !finish.has_pending {
         shared.dispatch_role_overrides.remove(&key.channel_id);
+    }
+}
+
+#[cfg(not(test))]
+async fn apply_reaction(
+    shared: &Arc<SharedData>,
+    channel_id: serenity::model::id::ChannelId,
+    message_id: serenity::model::id::MessageId,
+    emoji: char,
+    add: bool,
+    source: &'static str,
+) {
+    let Some(http) = shared.serenity_http_or_token_fallback() else {
+        tracing::warn!(
+            channel = channel_id.get(),
+            message = message_id.get(),
+            emoji = %emoji,
+            source,
+            "turn finalizer reaction cleanup skipped; provider serenity http unavailable"
+        );
+        return;
+    };
+    if add {
+        super::super::formatting::add_reaction_raw(&http, channel_id, message_id, emoji).await;
+    } else {
+        super::super::formatting::remove_reaction_raw(&http, channel_id, message_id, emoji).await;
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct ReactionCleanupRecord {
+    pub(super) channel_id: u64,
+    pub(super) message_id: u64,
+    pub(super) emoji: char,
+    pub(super) add: bool,
+    pub(super) source: &'static str,
+}
+
+#[cfg(test)]
+static REACTION_CLEANUP_RECORDS: std::sync::LazyLock<
+    std::sync::Mutex<Option<Vec<ReactionCleanupRecord>>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
+
+#[cfg(test)]
+pub(super) fn begin_reaction_cleanup_recording() {
+    *REACTION_CLEANUP_RECORDS
+        .lock()
+        .expect("reaction cleanup recorder lock") = Some(Vec::new());
+}
+
+#[cfg(test)]
+pub(super) fn take_reaction_cleanup_records() -> Vec<ReactionCleanupRecord> {
+    REACTION_CLEANUP_RECORDS
+        .lock()
+        .expect("reaction cleanup recorder lock")
+        .take()
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+async fn apply_reaction(
+    _shared: &Arc<SharedData>,
+    channel_id: serenity::model::id::ChannelId,
+    message_id: serenity::model::id::MessageId,
+    emoji: char,
+    add: bool,
+    source: &'static str,
+) {
+    if let Some(records) = REACTION_CLEANUP_RECORDS
+        .lock()
+        .expect("reaction cleanup recorder lock")
+        .as_mut()
+    {
+        records.push(ReactionCleanupRecord {
+            channel_id: channel_id.get(),
+            message_id: message_id.get(),
+            emoji,
+            add,
+            source,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{
+        FinalizeContext, FinalizeOutcome, GATE_BACKSTOP, RECONCILE_INTERVAL, TerminalEvent,
+        TurnFinalizer, TurnKey,
+    };
+    use super::*;
+    use crate::services::discord::inflight::RelayOwnerKind;
+    use crate::services::provider::{CancelToken, ProviderKind};
+    use serenity::model::id::{ChannelId, MessageId, UserId};
+
+    fn test_rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .start_paused(true)
+            .build()
+            .unwrap()
+    }
+
+    fn with_isolated_runtime_root(f: impl FnOnce()) {
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let prev = std::env::var_os("AGENTDESK_ROOT_DIR");
+        let tmp = tempfile::tempdir().expect("create temp runtime dir for reaction cleanup test");
+        unsafe {
+            std::env::set_var("AGENTDESK_ROOT_DIR", tmp.path().to_str().unwrap());
+        }
+        f();
+        unsafe {
+            match prev {
+                Some(value) => std::env::set_var("AGENTDESK_ROOT_DIR", value),
+                None => std::env::remove_var("AGENTDESK_ROOT_DIR"),
+            }
+        }
+    }
+
+    fn reaction_context() -> FinalizeContext {
+        FinalizeContext::gate_backstop()
+    }
+
+    async fn seed_active_turn(
+        shared: &Arc<SharedData>,
+        channel_id: ChannelId,
+        user_msg_id: u64,
+    ) -> Arc<CancelToken> {
+        let token = Arc::new(CancelToken::new());
+        shared
+            .mailbox(channel_id)
+            .restore_active_turn(token.clone(), UserId::new(7), MessageId::new(user_msg_id))
+            .await;
+        token
+    }
+
+    fn recorded_actions(records: &[ReactionCleanupRecord]) -> Vec<(u64, u64, char, bool)> {
+        records
+            .iter()
+            .map(|record| {
+                (
+                    record.channel_id,
+                    record.message_id,
+                    record.emoji,
+                    record.add,
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn backstop_finalize_removes_hourglass_and_marks_complete() {
+        with_isolated_runtime_root(|| {
+            test_rt().block_on(async {
+                let shared =
+                    super::super::super::make_shared_data_for_tests_with_storage(None, None);
+                let ch = ChannelId::new(3_334_100);
+                let tid = 3_334_101_u64;
+                shared
+                    .global_active
+                    .store(1, std::sync::atomic::Ordering::Relaxed);
+                let _token = seed_active_turn(&shared, ch, tid).await;
+                let fin = TurnFinalizer::spawn();
+                let key = TurnKey::new(ch, tid, 0);
+                fin.register_start(key, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
+
+                begin_reaction_cleanup_recording();
+                let deferred = fin
+                    .submit_terminal(
+                        key,
+                        ProviderKind::Claude,
+                        TerminalEvent::GateTimeout {
+                            pane_quiescent: Some(false),
+                        },
+                        FinalizeContext::watcher(),
+                        shared.clone(),
+                    )
+                    .await;
+                assert!(matches!(deferred, FinalizeOutcome::Deferred));
+
+                tokio::time::sleep(GATE_BACKSTOP + RECONCILE_INTERVAL * 3).await;
+                tokio::task::yield_now().await;
+
+                let records = take_reaction_cleanup_records();
+                assert_eq!(
+                    recorded_actions(&records),
+                    vec![(ch.get(), tid, '⏳', false), (ch.get(), tid, '✅', true)]
+                );
+                assert!(records.iter().all(|record| record.source == "finalized"));
+            });
+        });
+    }
+
+    #[test]
+    fn already_finalized_loser_runs_idempotent_reaction_cleanup() {
+        with_isolated_runtime_root(|| {
+            test_rt().block_on(async {
+                let shared =
+                    super::super::super::make_shared_data_for_tests_with_storage(None, None);
+                let ch = ChannelId::new(3_334_200);
+                let tid = 3_334_201_u64;
+                shared
+                    .global_active
+                    .store(1, std::sync::atomic::Ordering::Relaxed);
+                let _token = seed_active_turn(&shared, ch, tid).await;
+                let fin = TurnFinalizer::spawn();
+                let key = TurnKey::new(ch, tid, 0);
+                fin.register_start(key, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
+
+                begin_reaction_cleanup_recording();
+                let first = fin
+                    .submit_terminal(
+                        key,
+                        ProviderKind::Claude,
+                        TerminalEvent::Complete,
+                        reaction_context(),
+                        shared.clone(),
+                    )
+                    .await;
+                assert!(matches!(first, FinalizeOutcome::Finalized { .. }));
+                let _ = take_reaction_cleanup_records();
+
+                begin_reaction_cleanup_recording();
+                let late = fin
+                    .submit_terminal(
+                        key,
+                        ProviderKind::Claude,
+                        TerminalEvent::Complete,
+                        reaction_context(),
+                        shared.clone(),
+                    )
+                    .await;
+                assert!(matches!(late, FinalizeOutcome::AlreadyFinalized));
+                let records = take_reaction_cleanup_records();
+                assert_eq!(
+                    recorded_actions(&records),
+                    vec![(ch.get(), tid, '⏳', false), (ch.get(), tid, '✅', true)]
+                );
+                assert!(records.iter().all(|record| record.source == "af"));
+            });
+        });
+    }
+
+    #[test]
+    fn cancel_removes_hourglass_without_checkmark() {
+        with_isolated_runtime_root(|| {
+            test_rt().block_on(async {
+                let shared =
+                    super::super::super::make_shared_data_for_tests_with_storage(None, None);
+                let ch = ChannelId::new(3_334_300);
+                let tid = 3_334_301_u64;
+                shared
+                    .global_active
+                    .store(1, std::sync::atomic::Ordering::Relaxed);
+                let _token = seed_active_turn(&shared, ch, tid).await;
+                let fin = TurnFinalizer::spawn();
+                let key = TurnKey::new(ch, tid, 0);
+                fin.register_start(key, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
+
+                begin_reaction_cleanup_recording();
+                let outcome = fin
+                    .submit_terminal(
+                        key,
+                        ProviderKind::Claude,
+                        TerminalEvent::Cancel,
+                        reaction_context(),
+                        shared.clone(),
+                    )
+                    .await;
+                assert!(matches!(outcome, FinalizeOutcome::Finalized { .. }));
+                assert_eq!(
+                    recorded_actions(&take_reaction_cleanup_records()),
+                    vec![(ch.get(), tid, '⏳', false)]
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn watcher_context_skips_extra_reaction_calls() {
+        with_isolated_runtime_root(|| {
+            test_rt().block_on(async {
+                let shared =
+                    super::super::super::make_shared_data_for_tests_with_storage(None, None);
+                let ch = ChannelId::new(3_334_400);
+                let tid = 3_334_401_u64;
+                shared
+                    .global_active
+                    .store(1, std::sync::atomic::Ordering::Relaxed);
+                let _token = seed_active_turn(&shared, ch, tid).await;
+                let fin = TurnFinalizer::spawn();
+                let key = TurnKey::new(ch, tid, 0);
+                fin.register_start(key, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
+
+                begin_reaction_cleanup_recording();
+                let outcome = fin
+                    .submit_terminal(
+                        key,
+                        ProviderKind::Claude,
+                        TerminalEvent::Complete,
+                        FinalizeContext::watcher(),
+                        shared.clone(),
+                    )
+                    .await;
+                assert!(matches!(outcome, FinalizeOutcome::Finalized { .. }));
+                assert!(take_reaction_cleanup_records().is_empty());
+            });
+        });
+    }
+
+    #[test]
+    fn cleanup_targets_turn_identity_and_skips_synthetic_id_zero() {
+        with_isolated_runtime_root(|| {
+            test_rt().block_on(async {
+                let shared =
+                    super::super::super::make_shared_data_for_tests_with_storage(None, None);
+                let ch = ChannelId::new(3_334_500);
+                let old_tid = 3_334_501_u64;
+                let newer_tid = 3_334_502_u64;
+                shared
+                    .global_active
+                    .store(1, std::sync::atomic::Ordering::Relaxed);
+                let _newer = seed_active_turn(&shared, ch, newer_tid).await;
+                let fin = TurnFinalizer::spawn();
+
+                begin_reaction_cleanup_recording();
+                let outcome = fin
+                    .submit_terminal(
+                        TurnKey::new(ch, old_tid, 0),
+                        ProviderKind::Claude,
+                        TerminalEvent::Complete,
+                        reaction_context(),
+                        shared.clone(),
+                    )
+                    .await;
+                assert!(matches!(
+                    outcome,
+                    FinalizeOutcome::Finalized {
+                        removed_token: None,
+                        ..
+                    }
+                ));
+                let records = take_reaction_cleanup_records();
+                assert_eq!(recorded_actions(&records).len(), 2);
+                assert!(records.iter().all(|record| record.message_id == old_tid));
+                assert!(records.iter().all(|record| record.message_id != newer_tid));
+                assert!(shared.mailbox(ch).has_active_turn().await);
+
+                begin_reaction_cleanup_recording();
+                let zero = fin
+                    .submit_terminal(
+                        TurnKey::new(ChannelId::new(3_334_600), 0, 0),
+                        ProviderKind::Claude,
+                        TerminalEvent::Complete,
+                        reaction_context(),
+                        shared.clone(),
+                    )
+                    .await;
+                assert!(matches!(zero, FinalizeOutcome::Finalized { .. }));
+                assert!(take_reaction_cleanup_records().is_empty());
+            });
+        });
     }
 }


### PR DESCRIPTION
## 설계
⏳ 리액션 플립이 watcher 정상 finalize 블록에만 존재해 비정상 finalize(quiescence timeout → handoff/#3277 PROVEN-delivered, AlreadyFinalized 패자)와 재시작 catch-up에서 잔존하던 갭을 제거:
- **finalize 합류 (케이스 b)**: #3274에서 신설한 `turn_finalizer/cleanup.rs` 공통 멱등 정리에 리액션 정리 추가 — FinalizeContext predicate로 게이팅해 **정상 watcher/bridge 경로는 스킵**(기존 플립과 중복 Discord API 호출 없음). Cancel 이벤트는 ⏳ 제거만(✅ 금지), user_msg_id==0(synthetic) 스킵, turn identity 가드로 새 턴 무침범.
- **catch-up 선제 정리 (케이스 a)**: 신규 `discord/reaction_cleanup.rs` 헬퍼 — 이전 세션 메시지를 enqueue하기 전에 stale ⏳를 best-effort 멱등 제거. 이후 intake가 새 ⏳를 달면 정상 완료 경로가 최종 정리(레이스 안전). mod.rs 변경 ±12줄로 giant ratchet 무영향.

## 라이브 근거
2026-06-11 메시지 1514499617272627231(재시작 전 ⏳→catch-up 후 잔존), 1514500851761287319(quiescence-timeout finalize 후 잔존).

## 게이트
fmt/check(0 warn)/clippy -D warnings/turn_finalizer 85 테스트/agent-maintenance/audit(giant 0)/await ratchet 34 전부 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)