### PR TITLE
fix(#3292): instrument post-gate handoff pending bytes; count Done-only windows as zero-harvest

### DIFF
--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -7006,14 +7006,15 @@ pub(super) fn spawn_turn_bridge(
                 && watcher_owns_assistant_relay
                 && watcher_relay_available_for_turn
                 && !terminal_error_path;
+        let response_unsent =
+            response_portion_after_offset(&full_response, response_sent_offset);
+        let response_pending_trimmed_empty = response_unsent.trim().is_empty();
         // #3268: `mut` so the post-gate self-healing handoff (below) can promote it.
         let mut bridge_relay_delegated_to_watcher = recovered_watcher_owns_output
             || should_delegate_bridge_relay_to_watcher(
                 watcher_owns_assistant_relay,
                 watcher_relay_available_for_turn,
-                !response_portion_after_offset(&full_response, response_sent_offset)
-                    .trim()
-                    .is_empty(),
+                !response_pending_trimmed_empty,
                 cancelled,
                 is_prompt_too_long,
                 transport_error,
@@ -7043,9 +7044,7 @@ pub(super) fn spawn_turn_bridge(
             adk_session_key.as_deref(),
             turn_id.as_str(),
             current_msg_id.get(),
-            response_portion_after_offset(&full_response, response_sent_offset)
-                .trim()
-                .is_empty(),
+            response_pending_trimmed_empty,
             watcher_owns_assistant_relay,
             watcher_relay_available_for_turn,
             standby_relay_owns_output,
@@ -7175,7 +7174,12 @@ pub(super) fn spawn_turn_bridge(
             watcher_owner_channel_id,
             channel_id,
             &provider,
+            dispatch_id.as_deref(),
+            adk_session_key.as_deref(),
+            turn_id.as_str(),
+            current_msg_id.get(),
             tmux_last_offset,
+            response_unsent,
             &mut inflight_state,
             &mut bridge_relay_delegated_to_watcher,
             &mut bridge_output_owner,

--- a/src/services/discord/turn_bridge/watcher_handoff.rs
+++ b/src/services/discord/turn_bridge/watcher_handoff.rs
@@ -147,12 +147,16 @@ pub(super) fn empty_terminal_response_visibility_kind(
     }
 }
 
+// "Handoff occurred" is positional, not a parameter: the only emit site runs
+// inside `maybe_hand_off_busy_turn_to_watcher` after the
+// `bridge_should_hand_off_busy_turn_to_watcher` gate and past the
+// proven-delivered early-return, so a pre-gate delegated turn can never reach
+// this kind (no per-turn noise).
 pub(super) fn post_gate_handoff_pending_response_visibility_kind(
-    handoff_occurred: bool,
     response_pending_bytes: usize,
     response_pending_trimmed_empty: bool,
 ) -> Option<&'static str> {
-    (handoff_occurred && response_pending_bytes > 0 && !response_pending_trimmed_empty)
+    (response_pending_bytes > 0 && !response_pending_trimmed_empty)
         .then_some("bridge_post_gate_handoff_pending_response")
 }
 
@@ -245,7 +249,6 @@ fn emit_post_gate_handoff_pending_response_visibility(
 ) {
     let response_pending_bytes = response_unsent.len();
     let Some(kind) = post_gate_handoff_pending_response_visibility_kind(
-        true,
         response_pending_bytes,
         response_unsent.trim().is_empty(),
     ) else {
@@ -522,20 +525,16 @@ mod tests {
     #[test]
     fn post_gate_handoff_pending_response_visibility_kind_truth_table() {
         assert_eq!(
-            post_gate_handoff_pending_response_visibility_kind(true, 12, false),
+            post_gate_handoff_pending_response_visibility_kind(12, false),
             Some("bridge_post_gate_handoff_pending_response"),
         );
         assert_eq!(
-            post_gate_handoff_pending_response_visibility_kind(false, 12, false),
-            None,
+            post_gate_handoff_pending_response_visibility_kind(0, false),
+            None
         );
         assert_eq!(
-            post_gate_handoff_pending_response_visibility_kind(true, 0, false),
-            None,
-        );
-        assert_eq!(
-            post_gate_handoff_pending_response_visibility_kind(true, 12, true),
-            None,
+            post_gate_handoff_pending_response_visibility_kind(12, true),
+            None
         );
     }
 }

--- a/src/services/discord/turn_bridge/watcher_handoff.rs
+++ b/src/services/discord/turn_bridge/watcher_handoff.rs
@@ -147,6 +147,15 @@ pub(super) fn empty_terminal_response_visibility_kind(
     }
 }
 
+pub(super) fn post_gate_handoff_pending_response_visibility_kind(
+    handoff_occurred: bool,
+    response_pending_bytes: usize,
+    response_pending_trimmed_empty: bool,
+) -> Option<&'static str> {
+    (handoff_occurred && response_pending_bytes > 0 && !response_pending_trimmed_empty)
+        .then_some("bridge_post_gate_handoff_pending_response")
+}
+
 /// #3281: emit the empty-terminal-response visibility event chosen by
 /// [`empty_terminal_response_visibility_kind`]. Moved out of
 /// `turn_bridge/mod.rs` (frozen giant baseline); the owner-`None` kind and
@@ -222,6 +231,42 @@ pub(super) fn emit_bridge_empty_terminal_response_visibility(
     );
 }
 
+#[allow(clippy::too_many_arguments)]
+fn emit_post_gate_handoff_pending_response_visibility(
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    dispatch_id: Option<&str>,
+    session_key: Option<&str>,
+    turn_id: &str,
+    current_msg_id: u64,
+    response_unsent: &str,
+    tmux_last_offset: Option<u64>,
+    turn_start_offset: Option<u64>,
+) {
+    let response_pending_bytes = response_unsent.len();
+    let Some(kind) = post_gate_handoff_pending_response_visibility_kind(
+        true,
+        response_pending_bytes,
+        response_unsent.trim().is_empty(),
+    ) else {
+        return;
+    };
+    crate::services::observability::emit_inflight_lifecycle_event(
+        provider.as_str(),
+        channel_id.get(),
+        dispatch_id,
+        session_key,
+        Some(turn_id),
+        kind,
+        serde_json::json!({
+            "current_msg_id": current_msg_id,
+            "response_pending_bytes": response_pending_bytes,
+            "tmux_last_offset": tmux_last_offset,
+            "turn_start_offset": turn_start_offset,
+        }),
+    );
+}
+
 /// #3268 (Defect B): the self-healing watcher handoff itself. When the gate
 /// fires, registers the watcher in the single-authority finalizer ledger,
 /// unpauses it at the bridge's confirmed offset with `turn_delivered = false`,
@@ -239,7 +284,12 @@ pub(super) fn maybe_hand_off_busy_turn_to_watcher(
     watcher_owner_channel_id: ChannelId,
     channel_id: ChannelId,
     provider: &ProviderKind,
+    dispatch_id: Option<&str>,
+    session_key: Option<&str>,
+    turn_id: &str,
+    current_msg_id: u64,
     tmux_last_offset: Option<u64>,
+    response_unsent: &str,
     inflight_state: &mut InflightTurnState,
     bridge_relay_delegated_to_watcher: &mut bool,
     bridge_output_owner: &mut Option<BridgeOutputOwner>,
@@ -288,6 +338,17 @@ pub(super) fn maybe_hand_off_busy_turn_to_watcher(
             );
             return;
         }
+        emit_post_gate_handoff_pending_response_visibility(
+            provider,
+            channel_id,
+            dispatch_id,
+            session_key,
+            turn_id,
+            current_msg_id,
+            response_unsent,
+            tmux_last_offset,
+            inflight_state.turn_start_offset,
+        );
         let ts = chrono::Local::now().format("%H:%M:%S");
         tracing::warn!(
             provider = %provider.as_str(),
@@ -426,6 +487,16 @@ mod tests {
             empty_terminal_response_visibility_kind(None, false, 42, false),
             None,
         );
+        // Delegated watcher + non-empty unsent response is not an empty-response signal.
+        assert_eq!(
+            empty_terminal_response_visibility_kind(
+                Some(BridgeOutputOwner::WatcherRelay),
+                false,
+                42,
+                false,
+            ),
+            None,
+        );
         // Terminal-error path → excluded (matches the pre-#3281 gate).
         assert_eq!(
             empty_terminal_response_visibility_kind(None, true, 42, true),
@@ -444,6 +515,26 @@ mod tests {
                 42,
                 true,
             ),
+            None,
+        );
+    }
+
+    #[test]
+    fn post_gate_handoff_pending_response_visibility_kind_truth_table() {
+        assert_eq!(
+            post_gate_handoff_pending_response_visibility_kind(true, 12, false),
+            Some("bridge_post_gate_handoff_pending_response"),
+        );
+        assert_eq!(
+            post_gate_handoff_pending_response_visibility_kind(false, 12, false),
+            None,
+        );
+        assert_eq!(
+            post_gate_handoff_pending_response_visibility_kind(true, 0, false),
+            None,
+        );
+        assert_eq!(
+            post_gate_handoff_pending_response_visibility_kind(true, 12, true),
             None,
         );
     }

--- a/src/services/session_backend.rs
+++ b/src/services/session_backend.rs
@@ -494,7 +494,7 @@ pub fn process_stream_line(
     // `StatusUpdate` (turn_duration housekeeping) is metadata, not content.
     let (harvested, text_bytes) = match &message {
         StreamMessage::Text { content } => (1, content.len() as u64),
-        StreamMessage::StatusUpdate { .. } => (0, 0),
+        StreamMessage::Done { .. } | StreamMessage::StatusUpdate { .. } => (0, 0),
         _ => (1, 0),
     };
     if sender.send(message).is_err() {
@@ -893,9 +893,9 @@ pub fn parse_assistant_extra_tool_uses(json: &Value) -> Vec<StreamMessage> {
 }
 
 /// #3281 observability-only summary of what one transcript read forwarded to
-/// the bridge (status-only telemetry and synthetic idle-timeout `Done`s are
-/// NOT counted): `forwarded_messages == 0` on a `Completed` read means a
-/// zero-harvest transcript window.
+/// the bridge (status telemetry and `Done` terminators are NOT counted):
+/// `forwarded_messages == 0` on a `Completed` read means a zero-harvest
+/// transcript window.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ReadHarvestStats {
     pub forwarded_messages: u64,
@@ -1212,14 +1212,80 @@ mod stream_tail_guard_tests {
         );
     }
 
+    /// #3292: a window that starts after assistant text and sees only the
+    /// `stop_hook_summary` terminator must still forward `Done` to the bridge,
+    /// but count as zero-harvest so the observability event can see it.
+    #[test]
+    fn done_only_window_forwards_done_but_counts_zero_harvest() {
+        let dir = tempfile::tempdir().unwrap();
+        let output_path = dir.path().join("done-only.jsonl");
+        std::fs::write(
+            &output_path,
+            concat!(
+                r#"{"type":"system","subtype":"stop_hook_summary","session_id":"sess-done"}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+
+        let (sender, receiver) = mpsc::channel();
+        let (result, stats) = read_output_file_until_result_with_harvest(
+            output_path.to_string_lossy().as_ref(),
+            0,
+            sender,
+            None,
+            SessionProbe::process(|| true),
+        )
+        .unwrap();
+
+        assert!(matches!(result, ReadOutputResult::Completed { .. }));
+        assert_eq!(stats.forwarded_messages, 0);
+        assert_eq!(stats.assistant_text_bytes, 0);
+        let messages: Vec<_> = receiver.try_iter().collect();
+        assert!(
+            messages.iter().any(
+                |message| matches!(message, StreamMessage::Done { session_id, .. } if session_id.as_deref() == Some("sess-done"))
+            ),
+            "Done still reaches the bridge: {messages:?}"
+        );
+    }
+
+    /// #3292 non-regression: normal assistant text still counts as harvested
+    /// content, while the following `Done` terminator does not inflate the
+    /// count.
+    #[test]
+    fn assistant_text_plus_done_counts_text_only() {
+        let (sender, receiver) = mpsc::channel();
+        let mut state = StreamLineState::new();
+        assert!(process_stream_line(
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}"#,
+            &sender,
+            &mut state,
+        ));
+        assert!(process_stream_line(
+            r#"{"type":"system","subtype":"stop_hook_summary","session_id":"sess-text"}"#,
+            &sender,
+            &mut state,
+        ));
+
+        assert_eq!(state.forwarded_message_count, 1);
+        assert_eq!(state.forwarded_assistant_text_bytes, 5);
+        let messages: Vec<_> = receiver.try_iter().collect();
+        assert!(messages.iter().any(
+            |message| matches!(message, StreamMessage::Text { content } if content == "hello")
+        ));
+        assert!(messages.iter().any(
+            |message| matches!(message, StreamMessage::Done { session_id, .. } if session_id.as_deref() == Some("sess-text"))
+        ));
+    }
+
     /// #3281 zero side: a transcript window containing ONLY housekeeping lines
     /// (queued-prompt attachment / last-prompt / ai-title / mode records /
     /// `turn_duration` telemetry) harvests nothing — the counters stay 0 even
     /// though `turn_duration` still reaches the bridge as a `StatusUpdate`.
     /// This is the substrate of the `Completed`-only zero-harvest gate: such a
-    /// read can only complete via the synthetic idle-timeout `Done` (also
-    /// uncounted), and the producer-exit log must then report `lines=0` as a
-    /// REAL measurement.
+    /// read may complete via an uncounted synthetic idle-timeout `Done`, and
+    /// the producer-exit log must then report `lines=0` as a REAL measurement.
     #[test]
     fn housekeeping_only_window_harvests_nothing() {
         let (sender, receiver) = std::sync::mpsc::channel();


### PR DESCRIPTION
## 변경 (#3281/#3291 후속, 관측 전용 — 동작 변경 없음)
- **item 2 (post-gate 미계측)**: gate timeout 후 watcher 승격 경로에서 pending-bytes 보조 이벤트 추가 — 발화 조건을 'actual post-gate handoff + 미전송 응답 非빈'으로 좁혀 per-turn 노이즈 없음. (#3277 사고 원형의 관측 갭 해소)
- **item 3 (Done-only 윈도우)**: session_backend harvest 계수에서 `StreamMessage::Done`을 (0,0)으로 — Done-only forwarded 턴이 zero-harvest로 잡힘. zero-harvest 소비자(`claude_tui_zero_harvest_*`)가 관측/로그 전용(차단 게이트 아님)임을 확인 후 직접 계수 변경 선택.
- **item 1 (per-turn 노이즈)**: no-op 결정 — `bridge_delegated_watcher_empty_response`는 정의상 정상 pre-gate 위임의 per-turn 마커이고, #3291이 추가한 payload 필드(tmux_last_offset/turn_start_offset)로 소비자 측 필터링.

## 게이트
fmt/check(0 warn)/clippy -D warnings/**전체 --lib 3249 passed**/watcher_handoff 5·turn_bridge 152/agent-maintenance(turn_bridge freeze 8366 정합)/audit/await ratchet 34 전부 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)