### PR TITLE
fix(#3350): bound TUI-direct synthetic anchor ⏳ via inline-claim marker and finalize-time ensure

### DIFF
--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -656,3 +656,17 @@
   `serenity_http_or_token_fallback()` bot identity — no PG lease, no cross-node
   reads, no leader-only side effect. No new multinode ownership/singleton/lease
   assumption is introduced.
+- #3350 (synthetic-anchor hourglass bound for inline claims): the INLINE
+  synthetic claim (`tui_prompt_relay.rs`) now records the same #3303
+  `DeferredClaim` marker as the deferred worker (shared helper generalized in
+  `tui_direct_pending_start.rs`), and `turn_finalizer.rs::do_finalize` calls a
+  new `turn_finalizer/cleanup.rs` hook that idempotently ENSURES the marker
+  (`tui_direct_abort_marker/deferred_claim.rs::ensure_marker_for_own_synthetic_turn`)
+  for watcher-owned TUI-direct synthetic rows before the inflight clear. Both
+  are WRITES into the existing node-local
+  `runtime/discord_tui_direct_abort_marker/` store from the same node's own
+  relay observer / finalizer actor; reconcile/delivery stays with the existing
+  #3303 drain/sweep owners unchanged (zero new reaction call sites).
+  **Worker-local**: no PG lease, no cross-node reads, no leader-only side
+  effect. No new multinode ownership, singleton, or lease assumption is
+  introduced.

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -2138,6 +2138,11 @@ async fn finish_restored_watcher_active_turn(
     // confirmed a normal completion pass `false` and keep the restore-gated path.
     normal_completion: bool,
     kickoff_queue: bool,
+    // #3350 codex r1-1: the caller's PRE-CLEAR row snapshot for the #3303
+    // DeferredClaim marker ensure — inflight is cleared before this helper
+    // (see `user_msg_id`), so a row re-load cannot authenticate the watcher's
+    // synthetic turns. `None` keeps the row-reload fallback.
+    claim_snapshot: Option<super::turn_finalizer::SyntheticClaimSnapshot>,
     stop_source: &'static str,
 ) -> bool {
     // The mailbox is cleared now when EITHER gate holds:
@@ -2147,26 +2152,20 @@ async fn finish_restored_watcher_active_turn(
     //     restored/recovered watcher inherits its turn from the bridge, so
     //     it owns the cancel_token when the turn ends). Pre-existing.
     //
-    // #3016 phase-5b2: the third gate — `delegated_finalize_owed`, sourced from
-    // the per-handle `mailbox_finalize_owed` flag (#1452) — has been removed.
-    // At both production call sites the watcher already passes
-    // `normal_completion = true`, so the flag was redundant in this OR and only
-    // fed an observability log/event; the ledger's exactly-once phase gate makes
-    // a double `mailbox_finish_turn` idempotent.
+    // #3016 phase-5b2: the third gate (`delegated_finalize_owed`, the #1452
+    // `mailbox_finalize_owed` flag) is removed — both production sites pass
+    // `normal_completion = true`, and the ledger's exactly-once phase gate
+    // makes a double `mailbox_finish_turn` idempotent.
     //
-    // `kickoff_queue` is the dispatch-lifecycle gate (codex #1670 P2): the
-    // mailbox/inflight cleanup above is required for orphan prevention even
-    // when the dispatch finalization failed, but auto-dispatching the next
-    // queued turn must NOT happen on a failed dispatch — that decision is
-    // left to the operator/user. Callers pass `dispatch_ok` (or an
-    // equivalent gate) here.
+    // `kickoff_queue` is the dispatch-lifecycle gate (codex #1670 P2):
+    // cleanup must run even on a failed dispatch (orphan prevention), but
+    // auto-dispatching the next queued turn must not — callers pass
+    // `dispatch_ok` here.
     //
-    // #3016 (codex R1): the return value reports whether this helper actually
-    // DROVE the finalize (i.e. did NOT early-return). The caller folds it into
+    // #3016 (codex R1): returns whether this helper actually DROVE the
+    // finalize (did not early-return); the caller folds it into
     // `watcher_handled_mailbox_finish` so the post-finalize lifecycle (queue
-    // kickoff suppression + terminal-stop-candidate path) reflects the real
-    // finalize — otherwise the decoupled `normal_completion`-only finalize would
-    // leave that signal false and double-schedule kickoff / skip terminal-stop.
+    // kickoff suppression + terminal-stop) reflects the real finalize.
     if !normal_completion && !finish_mailbox_on_completion {
         return false;
     }
@@ -2190,11 +2189,12 @@ async fn finish_restored_watcher_active_turn(
     // caller's `kickoff_queue`.
     let outcome = shared
         .turn_finalizer
-        .submit_terminal(
+        .submit_terminal_with_claim_snapshot(
             super::turn_finalizer::TurnKey::new(channel_id, user_msg_id, shared.current_generation),
             provider.clone(),
             super::turn_finalizer::TerminalEvent::Complete,
             super::turn_finalizer::FinalizeContext::watcher(),
+            claim_snapshot,
             shared.clone(),
         )
         .await;

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -4079,6 +4079,12 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                             // flag (removed in #3016 phase-5b2).
                             true,
                             true,
+                            // #3350 codex r1-1: the row was cleared above — the
+                            // finalize-time marker ensure authenticates against
+                            // this pre-clear snapshot instead of a no-op re-load.
+                            pinned_pre_cleanup_inflight.as_ref().map(
+                                crate::services::discord::turn_finalizer::SyntheticClaimSnapshot::from_row,
+                            ),
                             "watcher fresh ready-for-input idle (structural/pane-idle completion)",
                         )
                         .await;
@@ -7146,6 +7152,27 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             lifecycle_stage_paused,
             inflight_state.is_some(),
         ) {
+            // #3350 issue-1 + codex r1-2 (lease-gated row-absent commit,
+            // tombstone-BEFORE-deliver): resolve the #3303 own-pin markers for
+            // the anchor we are ABOUT to ✅ — synchronously, before the Discord
+            // await below. The old deliver-then-resolve order let a TTL sweep
+            // firing during (or just before) the await claim the row-absent
+            // marker uncovered and stack a ⚠ next to the delivered ✅. If the
+            // ✅ delivery below then fails, the anchor keeps its ⏳ for retry
+            // with the marker already resolved — the same residual state as
+            // pre-PR (no marker existed), not a regression.
+            if let Some(anchor) = crate::services::tui_prompt_dedupe::prompt_anchor_for_response(
+                watcher_provider.as_str(),
+                &tmux_session_name,
+                channel_id.get(),
+            ) {
+                crate::services::discord::tui_direct_abort_marker::resolve_own_claim_markers_for_visibly_completed_anchor(
+                    watcher_provider.as_str(),
+                    &tmux_session_name,
+                    channel_id.get(),
+                    anchor.message_id,
+                );
+            }
             let completed = crate::services::discord::tui_prompt_relay::complete_tui_direct_prompt_anchor_lifecycle_if_present(
                 &http,
                 watcher_provider.as_str(),
@@ -7158,18 +7185,6 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 },
             )
             .await;
-            // #3350 issue-1 (lease-gated row-absent commit): a delivered ✅ has
-            // NO committed row left for the tombstone chokepoint below, so the
-            // #3303 own-pin marker would TTL-sweep a false ⚠ onto this ✅. Fix
-            // from the marker's pin: tombstone-first + claimed discard (I1).
-            if let Some(anchor) = completed.as_ref() {
-                crate::services::discord::tui_direct_abort_marker::resolve_own_claim_markers_for_visibly_completed_anchor(
-                    watcher_provider.as_str(),
-                    &tmux_session_name,
-                    channel_id.get(),
-                    anchor.message_id,
-                );
-            }
             // #3174: turn-identity guard on the ⏳ lifecycle vs the lease-gated
             // completion. The gate above can fire on the external-input LEASE
             // alone; a commit inside the sub-second `notify-post + ⏳-add`
@@ -7492,34 +7507,24 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 drop(data);
             }
             turn_result_relayed = true;
-            // #1670/#1708: Always consume the handoff debt and clear inflight
+            // #1670/#1708: always consume the handoff debt and clear inflight
             // when terminal output was committed — the bridge's
-            // `bridge_relay_delegated_to_watcher` arm in `turn_bridge/mod.rs`
-            // (the `else if` at ~line 4071) saves inflight and returns, so it
-            // never comes back to revoke the debt / clear the inflight even if
-            // dispatch finalization fails (organic `dispatch_id = null` turns
-            // surfaced this: a stale fallback dispatch_id reporting
-            // `dispatch_ok = false` used to orphan the inflight + mailbox
-            // cancel_token forever). Decoupling rule: `clear_inflight_state` +
-            // `finish_restored_watcher_active_turn` fire whenever the watcher
-            // committed terminal output (delivered or intentionally
-            // suppressed; bridge + watcher may call them concurrently —
-            // `mailbox_finish_turn` is idempotent), while anything genuinely
-            // dependent on the dispatch lifecycle (queue kickoff, dispatch
-            // followup, terminal-stop decision) stays gated on `dispatch_ok`
-            // further below.
-            // #3016 phase-5b2: the legacy `mailbox_finalize_owed` flag (and its
-            // `swap(false, AcqRel)` read here) is removed — exactly-once is the
-            // ledger's job; the Release-reset cross-turn safety is subsumed by
-            // the ledger phase gate.
-            // #3016 (codex R3): do NOT delete the on-disk inflight when it
-            // belongs to a NEWER follow-up turn (same session, started AT/AFTER
-            // this committed range) — the same offset decision that makes
-            // `pinned_finalize_user_msg_id` return 0 below gates the clear, so
-            // this stale-range pass cannot wipe the newer turn's inflight. Only
-            // the on-disk file is gated; the in-memory `inflight_state` used
-            // afterward is unaffected, and `cleared_by_watcher` fires only when
-            // the clear actually ran (preserve existing semantics).
+            // `bridge_relay_delegated_to_watcher` arm saves inflight and never
+            // returns to clear it even if dispatch finalization fails (a stale
+            // fallback dispatch_id with `dispatch_ok = false` used to orphan
+            // the inflight + cancel_token forever). Decoupling rule: clear +
+            // `finish_restored_watcher_active_turn` fire on every committed
+            // terminal (idempotent under bridge/watcher concurrency), while
+            // dispatch-lifecycle side-effects (queue kickoff, followup,
+            // terminal-stop) stay gated on `dispatch_ok` below.
+            // #3016 phase-5b2: the legacy `mailbox_finalize_owed` flag is
+            // removed — exactly-once is the ledger phase gate's job.
+            // #3016 (codex R3): do NOT delete on-disk inflight owned by a
+            // NEWER follow-up turn — the same offset decision that zeroes
+            // `pinned_finalize_user_msg_id` below gates this clear, so a
+            // stale-range pass cannot wipe it. Only the on-disk file is gated;
+            // the in-memory `inflight_state` and `cleared_by_watcher` keep
+            // their semantics.
             // #3296 codex r2: aborted-anchor reconcile, sited BEFORE the row
             // clear — tombstone evidence (committed turn identity) lands first,
             // then the drain covers, then the clear; a sweep claiming a marker
@@ -7591,42 +7596,29 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             // below is also `dispatch_ok`-gated and remains as a fallback
             // for paths where the helper short-circuited.
             // #3016 (codex R1+R2): derive the finalize id from the TURN-PINNED
-            // pre-relay snapshot, never from the late `inflight_state` re-read
-            // above. That late read reloads the on-disk inflight AFTER the
-            // relay/emit; the watcher loop is not turn-scoped (see the L~7327
-            // warning), so a follow-up turn may have already rewritten inflight on
-            // disk by then — its `user_msg_id` would belong to a NEWER turn. Under
-            // the old flag-gated path this finalize fired narrowly; with
-            // `normal_completion = true` it fires UNCONDITIONALLY, so a stale-id
-            // match here could `finish_turn_if_matches` and release the WRONG
-            // (follow-up) turn.
+            // pre-relay snapshot, never the late `inflight_state` re-read — the
+            // watcher loop is not turn-scoped (L~7327 warning), so a follow-up
+            // may have rewritten on-disk inflight after the relay/emit, and
+            // with `normal_completion = true` a stale-id match would
+            // `finish_turn_if_matches` the WRONG (follow-up) turn.
             //
-            // R2 (offset-aliasing): even the pre-relay snapshot
-            // `inflight_before_relay` (loaded L~6163) is NOT inherently pinned to
-            // the OUTPUT RANGE being completed. The watcher-yield guard
-            // `watcher_should_yield_to_inflight_state` (tmux.rs:2110-2111) lets the
-            // watcher PROCEED on this old range when a FOLLOW-UP turn on the SAME
-            // session has `turn_start_offset >= current_offset` (it starts AFTER
-            // this range). In that case the snapshot holds the newer turn's id, and
-            // a session-only filter would still pass it. `pinned_finalize_user_msg_id`
-            // gates on the range relationship — effective start
-            // `turn_start_offset.unwrap_or(last_offset) < current_offset` — exactly
-            // mirroring the guard, so a newer turn yields 0 (no exact ledger match;
-            // turn_finalizer L~526 refuses to release a mismatched live turn). It
-            // keeps the session-match + `user_msg_id != 0` checks too.
+            // R2 (offset-aliasing): even `inflight_before_relay` is not pinned
+            // to the OUTPUT RANGE being completed — the watcher-yield guard
+            // (tmux.rs:2110-2111) proceeds on this old range when a follow-up
+            // on the SAME session starts AT/AFTER `current_offset`, leaving the
+            // newer turn's id in the snapshot. `pinned_finalize_user_msg_id`
+            // mirrors the guard's range test (effective start
+            // `turn_start_offset.unwrap_or(last_offset) < current_offset`), so
+            // a newer turn yields 0 (turn_finalizer L~526 refuses a mismatched
+            // live turn); session-match + `user_msg_id != 0` checks kept.
+            // `current_offset` is this completion range's end (same value as
+            // `commit_watcher_direct_terminal_session_idle` below).
             //
-            // `current_offset` here is the end of the range this completion covers
-            // (same value passed to `commit_watcher_direct_terminal_session_idle`
-            // just below).
-            //
-            // R3 cross-ref: this SAME offset decision now also gates the
-            // `⏳ → ✅` reaction + transcript + analytics block and the
-            // `clear_inflight_state` above, via
-            // `completion_is_stale_for_newer_turn`
-            // (`committed_completion_is_stale_for_newer_turn` is the exact
-            // complement of this helper's `< current_offset` range test). So the
-            // newer-turn case yields 0 here AND skips those destructive
-            // side-effects — the two stay consistent by construction.
+            // R3 cross-ref: `completion_is_stale_for_newer_turn` (the exact
+            // complement of that `< current_offset` test) gates the `⏳ → ✅` /
+            // transcript / analytics block and the `clear_inflight_state`
+            // above, so "yields 0" and "skip destructive side-effects" stay
+            // consistent by construction.
             let restored_user_msg_id = pinned_finalize_user_msg_id(
                 inflight_before_relay.as_ref(),
                 &tmux_session_name,
@@ -7681,6 +7673,12 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                     // AlreadyFinalized here), so this cannot over-finalize.
                     true,
                     dispatch_ok,
+                    // #3350 codex r1-1: inflight was cleared above — carry the
+                    // pre-relay snapshot (the same row `restored_user_msg_id` was
+                    // pinned from) for the finalize-time marker ensure.
+                    inflight_before_relay.as_ref().map(
+                        crate::services::discord::turn_finalizer::SyntheticClaimSnapshot::from_row,
+                    ),
                     "restored watcher completed with queued backlog",
                 )
                 .await
@@ -8777,6 +8775,7 @@ mod tests {
             true,  // finish_mailbox_on_completion (restore semantics)
             false, // normal_completion (#3016: this path is restore-gated, not the decoupled normal-completion arm)
             false, // kickoff_queue
+            None,  // claim_snapshot (#3350 r1-1: not a synthetic-claim path)
             "terminal_delivery_timeout_cleanup_test",
         )
         .await;
@@ -8871,6 +8870,7 @@ mod tests {
             false, // finish_mailbox_on_completion — fresh live watcher
             true,  // normal_completion — confirmed terminal-output-committed point
             false, // kickoff_queue
+            None,
             "normal_completion_decouple_test",
         )
         .await;
@@ -8899,6 +8899,7 @@ mod tests {
             false,
             true,
             false,
+            None,
             "normal_completion_decouple_test_double",
         )
         .await;
@@ -8963,6 +8964,7 @@ mod tests {
             false,
             true,
             false,
+            None,
             "stale_guard_turn_a",
         )
         .await;
@@ -8999,6 +9001,7 @@ mod tests {
             false,
             true, // normal_completion fires unconditionally
             false,
+            None,
             "stale_guard_stale_id",
         )
         .await;
@@ -9021,6 +9024,7 @@ mod tests {
             false,
             true,
             false,
+            None,
             "stale_guard_turn_b",
         )
         .await;
@@ -9548,6 +9552,7 @@ mod tests {
             false, // finish_mailbox_on_completion — fresh live watcher
             true,  // normal_completion — S3: structural-signal-driven, flag-independent
             true,
+            None,
             "watcher fresh ready-for-input idle (structural completion terminator)",
         )
         .await;
@@ -9572,6 +9577,7 @@ mod tests {
             false,
             true,
             true,
+            None,
             "watcher fresh ready-for-input idle (structural completion terminator)",
         )
         .await;

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -7158,33 +7158,31 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 },
             )
             .await;
+            // #3350 issue-1 (lease-gated row-absent commit): a delivered ✅ has
+            // NO committed row left for the tombstone chokepoint below, so the
+            // #3303 own-pin marker would TTL-sweep a false ⚠ onto this ✅. Fix
+            // from the marker's pin: tombstone-first + claimed discard (I1).
+            if let Some(anchor) = completed.as_ref() {
+                crate::services::discord::tui_direct_abort_marker::resolve_own_claim_markers_for_visibly_completed_anchor(
+                    watcher_provider.as_str(),
+                    &tmux_session_name,
+                    channel_id.get(),
+                    anchor.message_id,
+                );
+            }
             // #3174: turn-identity guard on the ⏳ lifecycle vs the lease-gated
             // completion. The gate above can fire on the external-input LEASE
-            // alone (`tui_direct_anchor_or_lease_present_for_lifecycle` is seeded
-            // from `prompt_anchor_present_before_relay || external_input_lease_before_relay`).
-            // If the provider committed terminal output inside the sub-second
-            // `notify-post + ⏳-add` Discord I/O window, the lease is present but
-            // THIS turn's `record_prompt_anchor` has not landed yet — so the
-            // completion above found no anchor and was a no-op (`None`). The lease
-            // is cleared after this delivery, so no later pass reconciles it and
-            // the ⏳ would be stranded. Record a deferred-completion marker keyed
-            // to this `(provider, tmux, channel)`; the SAME turn's
-            // `record_prompt_anchor` (in the relay) drains it and finishes the
-            // ⏳ → ✅ swap against the just-recorded anchor. Only record when the
-            // anchor is genuinely still absent (an anchor-less completion) — a
-            // `None` from a Discord `create_reaction` error keeps the anchor
-            // findable, and that path retries via the existing anchor lookup,
-            // so we must not also queue a deferred completion for it.
-            //
-            // #3174 codex P1: stamp the marker with the TURN IDENTITY — the
-            // `generation` of the lease this completion gated on
-            // (`external_input_lease_generation_before_relay`). The relay drains
-            // it ONLY when the generation matches THIS turn's recorded lease, so
-            // a NEWER same-(provider,tmux) turn inside the marker TTL can never
-            // complete the wrong turn's ⏳. Require the gating lease's generation
-            // to be known (`Some`): if the gate fired on the anchor alone there
-            // is no lease turn-identity to stamp, and the anchor-based path
-            // already owns the completion.
+            // alone; a commit inside the sub-second `notify-post + ⏳-add`
+            // window finds THIS turn's `record_prompt_anchor` not yet landed —
+            // the completion above no-ops (`None`) and the lease clears after
+            // delivery, stranding the ⏳. Record a deferred-completion marker
+            // keyed to `(provider, tmux, channel)`; the SAME turn's
+            // `record_prompt_anchor` (relay) drains it and finishes the swap.
+            // Only when the anchor is genuinely still absent — a `None` from a
+            // `create_reaction` error keeps the anchor findable and retries.
+            // codex P1: stamp the gating lease's `generation`; the relay drains
+            // ONLY on a matching generation, so a NEWER same-tmux turn cannot
+            // complete the wrong ⏳. Anchor-only firings stay anchor-based.
             if completed.is_none()
                 && let Some(turn_lease_generation) = external_input_lease_generation_before_relay
                 && crate::services::tui_prompt_dedupe::prompt_anchor_for_response(
@@ -7523,17 +7521,19 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             // afterward is unaffected, and `cleared_by_watcher` fires only when
             // the clear actually ran (preserve existing semantics).
             // #3296 codex r2: aborted-anchor reconcile, sited BEFORE the row
-            // clear — commit-tombstone evidence (committed turn identity) lands
-            // first, then the drain covers any marker pinned to this turn, then
-            // the clear. A sweep pass claiming a marker mid-commit can thus
-            // observe "no live row" only AFTER the tombstone is durable, so its
-            // 대조 lands ✅ instead of ⚠ (r2 finding 1 — the flock alone only
-            // serialized the reconcilers, it never ordered the verdicts); an
-            // ABORT recording its marker after this drain pass still converges
-            // via the tombstone (record-instant or sweep 대조).
-            if tui_direct_anchor_terminal_body_visible
-                && !completion_is_stale_for_newer_turn
+            // clear — tombstone evidence (committed turn identity) lands first,
+            // then the drain covers, then the clear; a sweep claiming a marker
+            // mid-commit sees "no live row" only AFTER the tombstone is durable,
+            // so its 대조 lands ✅ not ⚠ (r2 finding 1). An ABORT recording its
+            // marker after this drain still converges via the tombstone 대조.
+            // #3350 issue-1: ALSO tombstone+drain body-INVISIBLE commits of
+            // watcher-owned synthetic rows (suppressed task-notification
+            // completions) — their `⏳ → ✅` block fires regardless, and skipping
+            // here left their own-pin marker to a false TTL `⚠`.
+            if !completion_is_stale_for_newer_turn
                 && let Some(committed) = inflight_state.as_ref()
+                && (tui_direct_anchor_terminal_body_visible
+                    || committed_row_requires_marker_tombstone(committed))
             {
                 crate::services::discord::tui_direct_abort_marker::record_commit_tombstone(
                     watcher_provider.as_str(),

--- a/src/services/discord/tmux_watcher/commit_decisions.rs
+++ b/src/services/discord/tmux_watcher/commit_decisions.rs
@@ -138,6 +138,37 @@ pub(super) fn missing_inflight_after_session_bound_delivery(
     inflight_missing && !session_bound_relay_delivered
 }
 
+/// #3350 issue-1 pure core: must a committed pass tombstone+drain the row even
+/// when the TUI-direct anchor body was NOT visible (e.g. a suppressed
+/// task-notification completion)? A watcher-owned `ExternalInput` synthetic
+/// row converges its anchor `⏳ → ✅` on EVERY committed pass — suppressed
+/// included (`terminal_output_committed = relay_ok || relay_suppressed`) — and
+/// its #3303/#3350 DeferredClaim marker pins exactly this row's identity, so
+/// skipping the tombstone lets the TTL sweep stack a false `⚠` on that `✅`.
+/// Anything else (bridge-owned, Managed, id-0, session-less) keeps the #3296
+/// body-visible-only tombstone scope.
+pub(super) fn committed_synthetic_commit_requires_marker_tombstone(
+    turn_source_external: bool,
+    relay_owner_watcher: bool,
+    user_msg_id: u64,
+    tmux_session_present: bool,
+) -> bool {
+    turn_source_external && relay_owner_watcher && user_msg_id != 0 && tmux_session_present
+}
+
+/// Row adapter for [`committed_synthetic_commit_requires_marker_tombstone`].
+pub(super) fn committed_row_requires_marker_tombstone(
+    row: &crate::services::discord::inflight::InflightTurnState,
+) -> bool {
+    use crate::services::discord::inflight::{RelayOwnerKind, TurnSource};
+    committed_synthetic_commit_requires_marker_tombstone(
+        row.turn_source == TurnSource::ExternalInput,
+        row.relay_owner_kind == RelayOwnerKind::Watcher,
+        row.user_msg_id,
+        row.tmux_session_name.is_some(),
+    )
+}
+
 #[cfg(test)]
 mod runtime_binding_offset_tests {
     use super::*;
@@ -229,5 +260,34 @@ mod runtime_binding_offset_tests {
         assert!(!missing_inflight_after_session_bound_delivery(true, true));
         assert!(missing_inflight_after_session_bound_delivery(true, false));
         assert!(!missing_inflight_after_session_bound_delivery(false, false));
+    }
+
+    /// #3350 issue-1: a suppressed (body-invisible) committed pass must still
+    /// tombstone a watcher-owned ExternalInput synthetic row — that is the
+    /// exact class whose `⏳ → ✅` block fires while the old body-visible-only
+    /// tombstone gate skipped, stacking a TTL `⚠` on the `✅`.
+    #[test]
+    fn suppressed_commit_requires_tombstone_only_for_watcher_synthetic_rows() {
+        // The false-⚠ class: watcher-owned synthetic row with a real anchor.
+        assert!(committed_synthetic_commit_requires_marker_tombstone(
+            true, true, 42, true
+        ));
+        // Bridge-owned synthetic turn (SC3): finalizes via the bridge, no
+        // watcher tombstone owed outside the body-visible #3296 scope.
+        assert!(!committed_synthetic_commit_requires_marker_tombstone(
+            true, false, 42, true
+        ));
+        // Managed (non-synthetic) row keeps the #3296 body-visible-only scope.
+        assert!(!committed_synthetic_commit_requires_marker_tombstone(
+            false, true, 42, true
+        ));
+        // id-0 rows can never carry an own-pin marker (record rejects zero).
+        assert!(!committed_synthetic_commit_requires_marker_tombstone(
+            true, true, 0, true
+        ));
+        // Session-less rows are outside every marker's reconcile scope.
+        assert!(!committed_synthetic_commit_requires_marker_tombstone(
+            true, true, 42, false
+        ));
     }
 }

--- a/src/services/discord/tui_direct_abort_marker/deferred_claim.rs
+++ b/src/services/discord/tui_direct_abort_marker/deferred_claim.rs
@@ -164,9 +164,12 @@ pub(super) fn decide_deferred_claim_marker_disposition(
 /// proceeds identically).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(in crate::services::discord) enum EnsureClaimMarkerOutcome {
-    /// A marker for this anchor already exists. NEVER overwritten: a stamped
+    /// An own-pin `DeferredClaim` marker — or ANY already-covered (tombstoned)
+    /// marker — exists for this anchor. NEVER overwritten: a stamped
     /// `covered_at_ms` or the original TTL clock must survive (I6 — an
-    /// overwrite would demote a covered anchor to the TTL `⚠`).
+    /// overwrite would demote a covered anchor to the TTL `⚠`). An UNCOVERED
+    /// stale Abort marker does NOT yield this variant (#3350 codex r1-3): the
+    /// #3303 contract replaces it with the own pin, see the ensure docs.
     AlreadyPresent,
     /// No marker existed; one was recorded. `covered: true` means the
     /// record-instant tombstone 대조 found the own turn already committed, so
@@ -184,9 +187,16 @@ pub(in crate::services::discord) enum EnsureClaimMarkerOutcome {
 /// its anchor — this is the forward-fix for turns claimed before the #3350
 /// inline-claim record existed, and the safety net when that record failed.
 ///
-/// * If a marker with the same anchor already exists it is NEVER overwritten
-///   ([`EnsureClaimMarkerOutcome::AlreadyPresent`]) — the existing
-///   `covered_at_ms` stamp / TTL clock are preserved.
+/// * An existing own-pin `DeferredClaim` marker — or ANY already-covered
+///   (tombstoned) marker — is NEVER overwritten
+///   ([`EnsureClaimMarkerOutcome::AlreadyPresent`]): the `covered_at_ms`
+///   stamp / TTL clock are preserved.
+/// * An existing UNCOVERED stale Abort marker is REPLACED (#3350 codex r1-3),
+///   exactly like the claim-time record (#3303 contract: `record()`'s stem
+///   overwrite — see the module docs at [`record_for_deferred_claim`] and the
+///   `tui_direct_pending_start` R8 reclaim test). Left in place it would block
+///   the own pin forever: no commit can cover the foreign pin, so the TTL
+///   would false-`⚠` the successfully claimed anchor.
 /// * Otherwise [`record_for_deferred_claim`] is reused unchanged, including
 ///   the record-instant tombstone 대조: a turn that already terminal-committed
 ///   yields a `covered` marker the sweep resolves with an idempotent `✅`.
@@ -203,12 +213,22 @@ pub(in crate::services::discord) fn ensure_marker_for_own_synthetic_turn(
     if anchor_message_id == 0 {
         return EnsureClaimMarkerOutcome::SkippedZeroAnchor; // I5
     }
-    if super::load_for_channel(provider, channel_id)
-        .iter()
-        .any(|m| m.anchor_message_id == anchor_message_id)
+    let replaces_stale_abort = match super::load_for_channel(provider, channel_id)
+        .into_iter()
+        .find(|m| m.anchor_message_id == anchor_message_id)
     {
-        return EnsureClaimMarkerOutcome::AlreadyPresent;
-    }
+        Some(existing)
+            if existing.covered_at_ms.is_some()
+                || (existing.origin == MarkerOrigin::DeferredClaim
+                    && existing.foreign_user_msg_id == Some(anchor_message_id)) =>
+        {
+            return EnsureClaimMarkerOutcome::AlreadyPresent;
+        }
+        // Uncovered non-own-pin marker (stale Abort): fall through and let
+        // `record()`'s stem overwrite replace it with the own pin (r1-3).
+        Some(_) => true,
+        None => false,
+    };
     match record_for_deferred_claim(
         provider.to_string(),
         channel_id,
@@ -223,6 +243,7 @@ pub(in crate::services::discord) fn ensure_marker_for_own_synthetic_turn(
                 tmux_session_name = %tmux_session_name,
                 anchor_message_id,
                 tombstone_covered = marker.covered_at_ms.is_some(),
+                replaces_stale_abort,
                 "tui_direct_abort_marker: finalize-time ensure recorded the missing DeferredClaim marker — the anchor ⏳ now converges via drain ✅ / sweep TTL ⚠ (#3350)"
             );
             EnsureClaimMarkerOutcome::Recorded {
@@ -484,6 +505,93 @@ mod tests {
             super::super::load_for_channel("claude", 1),
             vec![existing],
             "covered_at / aborted_at / pin must survive the ensure untouched"
+        );
+    }
+
+    /// (b2) #3350 codex r1-3: an existing UNCOVERED own-pin DeferredClaim
+    /// marker also blocks the ensure — its TTL clock must not reset under
+    /// repeated finalizes (the bounded `⚠` would otherwise defer forever).
+    #[test]
+    fn ensure_keeps_uncovered_own_pin_deferred_claim_marker() {
+        let _root = test_root();
+        let existing = deferred_marker(1_000);
+        super::super::record(&existing).unwrap();
+        let outcome = ensure_marker_for_own_synthetic_turn(
+            "claude",
+            1,
+            10,
+            "tmux-1",
+            "2026-06-11 09:00:00", // a DIFFERENT started_at must not re-pin
+        );
+        assert_eq!(outcome, EnsureClaimMarkerOutcome::AlreadyPresent);
+        assert_eq!(
+            super::super::load_for_channel("claude", 1),
+            vec![existing],
+            "the aborted_at TTL clock and own pin survive untouched"
+        );
+    }
+
+    /// (b3) #3350 codex r1-3: an UNCOVERED stale Abort marker (foreign pin,
+    /// e.g. left by an abnormal restart) is REPLACED with the own-pin
+    /// DeferredClaim marker, mirroring the claim-time `record()` stem
+    /// overwrite (#3303 contract / the pending-start R8 reclaim test). RED
+    /// pre-fix: `AlreadyPresent` left the foreign pin in place — no commit
+    /// could ever cover it, so the TTL false-`⚠`'d the claimed anchor.
+    #[test]
+    fn ensure_replaces_uncovered_stale_abort_marker_with_own_pin() {
+        let _root = test_root();
+        super::super::record_for_abort(
+            "claude".into(),
+            1,
+            10,
+            "tmux-1".into(),
+            Some((999, "2026-06-09 08:00:00".into())),
+        )
+        .unwrap();
+        let outcome =
+            ensure_marker_for_own_synthetic_turn("claude", 1, 10, "tmux-1", OWN_STARTED_AT);
+        assert_eq!(
+            outcome,
+            EnsureClaimMarkerOutcome::Recorded { covered: false },
+            "RED pre-r1-3: the stale Abort marker blocked the ensure as AlreadyPresent"
+        );
+        let loaded = super::super::load_for_channel("claude", 1);
+        assert_eq!(loaded.len(), 1, "one stem, one marker (SC2)");
+        let m = &loaded[0];
+        assert_eq!(m.origin, MarkerOrigin::DeferredClaim);
+        assert_eq!(
+            m.foreign_user_msg_id,
+            Some(10),
+            "OWN pin replaces the foreign pin"
+        );
+        assert_eq!(m.foreign_started_at.as_deref(), Some(OWN_STARTED_AT));
+        assert_eq!(m.covered_at_ms, None);
+    }
+
+    /// (b4) #3350 codex r1-3 boundary: a COVERED (tombstoned) Abort marker is
+    /// never overwritten — its `✅` evidence must survive (I6: an overwrite
+    /// would demote the covered anchor back to the TTL `⚠`).
+    #[test]
+    fn ensure_preserves_covered_abort_marker() {
+        let _root = test_root();
+        let mut covered_abort = super::super::record_for_abort(
+            "claude".into(),
+            1,
+            10,
+            "tmux-1".into(),
+            Some((999, "2026-06-09 08:00:00".into())),
+        )
+        .unwrap();
+        covered_abort.covered_at_ms = Some(2_000);
+        super::super::record(&covered_abort).unwrap();
+        assert_eq!(
+            ensure_marker_for_own_synthetic_turn("claude", 1, 10, "tmux-1", OWN_STARTED_AT),
+            EnsureClaimMarkerOutcome::AlreadyPresent
+        );
+        assert_eq!(
+            super::super::load_for_channel("claude", 1),
+            vec![covered_abort],
+            "tombstoned (covered) evidence survives — never overwritten"
         );
     }
 

--- a/src/services/discord/tui_direct_abort_marker/deferred_claim.rs
+++ b/src/services/discord/tui_direct_abort_marker/deferred_claim.rs
@@ -159,6 +159,89 @@ pub(super) fn decide_deferred_claim_marker_disposition(
     MarkerDisposition::DeliverFailureWarn
 }
 
+/// Outcome of [`ensure_marker_for_own_synthetic_turn`] (#3350 ②). Purely
+/// informational for the caller — every variant is fail-open (the finalize
+/// proceeds identically).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::services::discord) enum EnsureClaimMarkerOutcome {
+    /// A marker for this anchor already exists. NEVER overwritten: a stamped
+    /// `covered_at_ms` or the original TTL clock must survive (I6 — an
+    /// overwrite would demote a covered anchor to the TTL `⚠`).
+    AlreadyPresent,
+    /// No marker existed; one was recorded. `covered: true` means the
+    /// record-instant tombstone 대조 found the own turn already committed, so
+    /// the sweep delivers an idempotent `✅`.
+    Recorded { covered: bool },
+    /// I5: a zero anchor id could never be reconciled.
+    SkippedZeroAnchor,
+    /// The durable write failed — warn only (I6 fail-open).
+    Failed,
+}
+
+/// #3350 ②: idempotent marker guarantee at TERMINAL FINALIZE time. Whatever
+/// submitter (watcher / bridge / monitor / backstop) finalizes a watcher-owned
+/// TUI-direct synthetic turn, a durable `DeferredClaim` marker must exist for
+/// its anchor — this is the forward-fix for turns claimed before the #3350
+/// inline-claim record existed, and the safety net when that record failed.
+///
+/// * If a marker with the same anchor already exists it is NEVER overwritten
+///   ([`EnsureClaimMarkerOutcome::AlreadyPresent`]) — the existing
+///   `covered_at_ms` stamp / TTL clock are preserved.
+/// * Otherwise [`record_for_deferred_claim`] is reused unchanged, including
+///   the record-instant tombstone 대조: a turn that already terminal-committed
+///   yields a `covered` marker the sweep resolves with an idempotent `✅`.
+/// * NO reaction is performed here — delivery belongs exclusively to the
+///   #3303 reconcilers (drain `✅` / sweep TTL `⚠`), so there is no false-`⚠`
+///   race against output that commits late after a Stopped event.
+pub(in crate::services::discord) fn ensure_marker_for_own_synthetic_turn(
+    provider: &str,
+    channel_id: u64,
+    anchor_message_id: u64,
+    tmux_session_name: &str,
+    own_started_at: &str,
+) -> EnsureClaimMarkerOutcome {
+    if anchor_message_id == 0 {
+        return EnsureClaimMarkerOutcome::SkippedZeroAnchor; // I5
+    }
+    if super::load_for_channel(provider, channel_id)
+        .iter()
+        .any(|m| m.anchor_message_id == anchor_message_id)
+    {
+        return EnsureClaimMarkerOutcome::AlreadyPresent;
+    }
+    match record_for_deferred_claim(
+        provider.to_string(),
+        channel_id,
+        anchor_message_id,
+        tmux_session_name.to_string(),
+        (anchor_message_id, own_started_at.to_string()),
+    ) {
+        Ok(marker) => {
+            tracing::info!(
+                provider = %provider,
+                channel_id,
+                tmux_session_name = %tmux_session_name,
+                anchor_message_id,
+                tombstone_covered = marker.covered_at_ms.is_some(),
+                "tui_direct_abort_marker: finalize-time ensure recorded the missing DeferredClaim marker — the anchor ⏳ now converges via drain ✅ / sweep TTL ⚠ (#3350)"
+            );
+            EnsureClaimMarkerOutcome::Recorded {
+                covered: marker.covered_at_ms.is_some(),
+            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                provider = %provider,
+                channel_id,
+                anchor_message_id,
+                error = %error,
+                "tui_direct_abort_marker: finalize-time ensure failed to persist the DeferredClaim marker; finalize proceeds without it (I6 fail-open — the anchor ⏳ may linger) (#3350)"
+            );
+            EnsureClaimMarkerOutcome::Failed
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::{ABORT_MARKER_HARD_CAP_TTL_MULTIPLIER, ABORT_MARKER_TTL};
@@ -326,6 +409,134 @@ mod tests {
                 MarkerDisposition::LeftIntactHttpUnavailable,
             );
         }
+    }
+
+    // ====================================================================
+    // #3350 ② — `ensure_marker_for_own_synthetic_turn` (finalize-time
+    // idempotent ensure). Durable-store tests use the mod.rs `TestRoot`
+    // pattern: a per-test tempdir via the THREAD-LOCAL store override.
+    // ====================================================================
+
+    struct TestRoot {
+        _temp: tempfile::TempDir,
+    }
+
+    impl Drop for TestRoot {
+        fn drop(&mut self) {
+            super::super::set_test_root_override(None);
+        }
+    }
+
+    fn test_root() -> TestRoot {
+        let temp = tempfile::tempdir().unwrap();
+        super::super::set_test_root_override(Some(temp.path().to_path_buf()));
+        TestRoot { _temp: temp }
+    }
+
+    fn test_rt() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    /// (a) #3350: with no marker present the ensure records one — uncovered,
+    /// pinned to the OWN identity, kind `DeferredClaim` (exactly what the
+    /// claim-time record would have written).
+    #[test]
+    fn ensure_records_uncovered_own_pin_when_absent() {
+        let _root = test_root();
+        let outcome =
+            ensure_marker_for_own_synthetic_turn("claude", 1, 900, "tmux-1", OWN_STARTED_AT);
+        assert_eq!(
+            outcome,
+            EnsureClaimMarkerOutcome::Recorded { covered: false }
+        );
+        let loaded = super::super::load_for_channel("claude", 1);
+        assert_eq!(loaded.len(), 1);
+        let m = &loaded[0];
+        assert_eq!(m.origin, MarkerOrigin::DeferredClaim);
+        assert_eq!(m.anchor_message_id, 900);
+        assert_eq!(m.foreign_user_msg_id, Some(900), "OWN pin only (SC1)");
+        assert_eq!(m.foreign_started_at.as_deref(), Some(OWN_STARTED_AT));
+        assert_eq!(m.covered_at_ms, None);
+    }
+
+    /// (b) #3350 / I6: an EXISTING marker is never overwritten — RED if the
+    /// ensure re-records (the covered_at stamp would vanish, demoting an
+    /// answered anchor to the TTL `⚠`, and the aborted_at TTL clock would
+    /// reset, deferring the bounded `⚠` forever under repeated finalizes).
+    #[test]
+    fn ensure_never_overwrites_existing_marker() {
+        let _root = test_root();
+        let mut existing = deferred_marker(1_000);
+        existing.covered_at_ms = Some(2_000);
+        super::super::record(&existing).unwrap();
+        let outcome = ensure_marker_for_own_synthetic_turn(
+            "claude",
+            1,
+            10,
+            "tmux-1",
+            "2026-06-11 09:00:00", // a DIFFERENT started_at must not re-pin
+        );
+        assert_eq!(outcome, EnsureClaimMarkerOutcome::AlreadyPresent);
+        assert_eq!(
+            super::super::load_for_channel("claude", 1),
+            vec![existing],
+            "covered_at / aborted_at / pin must survive the ensure untouched"
+        );
+    }
+
+    /// (c) #3350: when the own turn already terminal-committed (durable
+    /// tombstone), the ensure records a COVERED marker and the sweep delivers
+    /// the idempotent `✅` — never the TTL `⚠`.
+    #[test]
+    fn ensure_covers_from_own_tombstone_and_sweep_delivers_completion() {
+        let _root = test_root();
+        super::super::record_commit_tombstone_at(5_000, "claude", "tmux-1", 1, 901, OWN_STARTED_AT);
+        let outcome =
+            ensure_marker_for_own_synthetic_turn("claude", 1, 901, "tmux-1", OWN_STARTED_AT);
+        assert_eq!(
+            outcome,
+            EnsureClaimMarkerOutcome::Recorded { covered: true }
+        );
+
+        let calls: std::sync::Arc<std::sync::Mutex<Vec<(u64, super::super::ReactionOp)>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let calls_for_fn = calls.clone();
+        let applier: super::super::ReactionApplierFn = Box::new(move |marker, op| {
+            let calls = calls_for_fn.clone();
+            let anchor = marker.anchor_message_id;
+            Box::pin(async move {
+                calls.lock().unwrap().push((anchor, op));
+                super::super::ReactionDelivery::Delivered
+            })
+        });
+        let resolved = test_rt().block_on(super::super::sweep_expired_with_applier(
+            "claude",
+            5_001,
+            true,
+            &|_| false,
+            &applier,
+        ));
+        assert_eq!(resolved, 1);
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &[(901, super::super::ReactionOp::Complete)],
+            "an already-committed turn converges to the idempotent ✅ (never ⚠)"
+        );
+        assert!(super::super::load_for_channel("claude", 1).is_empty());
+    }
+
+    /// (d) #3350 / I5: a zero anchor id is rejected and nothing is persisted.
+    #[test]
+    fn ensure_skips_zero_anchor() {
+        let _root = test_root();
+        assert_eq!(
+            ensure_marker_for_own_synthetic_turn("claude", 1, 0, "tmux-1", OWN_STARTED_AT),
+            EnsureClaimMarkerOutcome::SkippedZeroAnchor
+        );
+        assert!(super::super::load_for_channel("claude", 1).is_empty());
     }
 
     /// The bool shorthand (existing test closures) maps to a probe that can

--- a/src/services/discord/tui_direct_abort_marker/mod.rs
+++ b/src/services/discord/tui_direct_abort_marker/mod.rs
@@ -2398,4 +2398,56 @@ mod tests {
         );
         assert!(load_for_channel("claude", 100).is_empty());
     }
+
+    /// #3350 codex r1-2 (tombstone-BEFORE-deliver): the watcher now runs the
+    /// resolver before awaiting the visible `⏳ → ✅` delivery. Race legs:
+    ///
+    /// * OLD order (RED contrast) — the sweep preempts while the watcher is
+    ///   still inside the delivery await, i.e. BEFORE any tombstone landed:
+    ///   the row-absent, TTL-expired, uncovered marker degrades to the `⚠`
+    ///   that then stacks next to the just-delivered `✅`.
+    /// * NEW order — the resolver (tombstone + claimed discard) runs first;
+    ///   the same sweep finds nothing to claim and delivers NOTHING.
+    #[test]
+    fn sweep_preempting_delivery_await_warns_only_under_the_old_order() {
+        let _root = test_root();
+        // OLD order: no tombstone yet when the sweep fires mid-await.
+        record(&deferred_marker("claude", 100, 914, 10_000)).unwrap();
+        let (warn_applier, warn_calls) = recording_applier(ReactionDelivery::Delivered);
+        let swept = test_rt().block_on(sweep_expired_with_applier(
+            "claude",
+            10_000 + TTL_MS,
+            true,
+            &|_marker: &AbortedAnchorMarker| false,
+            &warn_applier,
+        ));
+        assert_eq!(swept, 1);
+        assert_eq!(
+            warn_calls.lock().unwrap().as_slice(),
+            &[(914, ReactionOp::FailureWarn)],
+            "deliver-then-resolve let the mid-await sweep stack ⚠ next to the ✅"
+        );
+
+        // NEW order: resolver first (as the watcher call site now does), then
+        // the identical sweep — no ⚠, no duplicate ✅, store empty.
+        record(&deferred_marker("claude", 100, 915, 10_000)).unwrap();
+        assert_eq!(
+            resolve_own_claim_markers_for_visibly_completed_anchor("claude", "tmux-100", 100, 915),
+            1
+        );
+        let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
+        let swept = test_rt().block_on(sweep_expired_with_applier(
+            "claude",
+            10_000 + TTL_MS,
+            true,
+            &|_marker: &AbortedAnchorMarker| false,
+            &applier,
+        ));
+        assert_eq!(swept, 0, "nothing left for the preempting sweep to claim");
+        assert!(
+            calls.lock().unwrap().is_empty(),
+            "tombstone-first: the about-to-be-✅'d anchor sees no sweep reaction at all"
+        );
+        assert!(load_for_channel("claude", 100).is_empty());
+    }
 }

--- a/src/services/discord/tui_direct_abort_marker/mod.rs
+++ b/src/services/discord/tui_direct_abort_marker/mod.rs
@@ -208,7 +208,7 @@ mod deferred_claim;
 mod store;
 
 pub(in crate::services::discord) use deferred_claim::{
-    LiveInflightProbe, record_for_deferred_claim,
+    LiveInflightProbe, ensure_marker_for_own_synthetic_turn, record_for_deferred_claim,
 };
 use store::reload;
 #[cfg(test)]

--- a/src/services/discord/tui_direct_abort_marker/mod.rs
+++ b/src/services/discord/tui_direct_abort_marker/mod.rs
@@ -600,6 +600,61 @@ pub(super) async fn drain_on_terminal_commit_with_applier(
     drained
 }
 
+/// #3350 issue-1 (lease-gated row-absent commit): a VISIBLE `⏳ → ✅` was just
+/// delivered on `anchor_message_id`, but the committed row was already gone,
+/// so the watcher chokepoint has no row identity to tombstone. Source it from
+/// the marker instead: every DeferredClaim marker pinned to ITS OWN anchor
+/// (#3303 SC1) gets its pinned identity recorded as a commit tombstone FIRST
+/// (write-before-discard — a sweep claiming the marker mid-pass still 대조s
+/// `✅`, never `⚠`), then is discarded under the claim mutex. Reaction-free by
+/// design (#3350 I1): the `✅` is already on the message, so the marker's
+/// whole job — bounding the `⏳` — is done. Abort-kind markers (foreign pin)
+/// are left untouched: this commit proves nothing about the foreign prior
+/// turn, so their #3296 convergence (drain / sweep / hard cap) is preserved.
+pub(super) fn resolve_own_claim_markers_for_visibly_completed_anchor(
+    provider: &str,
+    tmux_session_name: &str,
+    channel_id: u64,
+    anchor_message_id: u64,
+) -> usize {
+    let mut resolved = 0usize;
+    for marker in load_for_channel(provider, channel_id) {
+        if marker.tmux_session_name != tmux_session_name
+            || marker.anchor_message_id != anchor_message_id
+            || marker.origin != MarkerOrigin::DeferredClaim
+            || marker.foreign_user_msg_id != Some(anchor_message_id)
+        {
+            continue; // SC1: own-pin DeferredClaim markers of THIS anchor only
+        }
+        let Some(own_started_at) = marker.foreign_started_at.clone() else {
+            continue; // identity-absent marker — the sweep bound alone resolves it
+        };
+        record_commit_tombstone(
+            provider,
+            tmux_session_name,
+            channel_id,
+            anchor_message_id,
+            &own_started_at,
+        );
+        let Some(_claim) = try_claim_marker(&marker) else {
+            continue; // a reconciler owns it; the durable tombstone keeps its verdict ✅
+        };
+        let Some(marker) = reload(&marker) else {
+            continue; // resolved while unclaimed
+        };
+        delete(&marker);
+        resolved += 1;
+        tracing::info!(
+            provider = %marker.provider,
+            channel_id = marker.channel_id,
+            tmux_session_name = %marker.tmux_session_name,
+            anchor_message_id = marker.anchor_message_id,
+            "tui_direct_abort_marker: own-pin marker discarded after a visible lease-gated ✅ (row-absent commit); tombstone recorded first so a racing sweep still lands ✅ (#3350)"
+        );
+    }
+    resolved
+}
+
 /// Placeholder-sweeper pass: retry `✅` for covered markers; apply the TTL'd
 /// `⏳ → ⚠` fallback for anchors no commit ever covered (held while a live
 /// inflight may still cover them, up to the hard cap). Returns resolved.
@@ -2242,5 +2297,105 @@ mod tests {
         let back: AbortedAnchorMarker =
             serde_json::from_str(&serde_json::to_string(&m).unwrap()).unwrap();
         assert_eq!(back, m, "DeferredClaim markers must round-trip losslessly");
+    }
+
+    // ====================================================================
+    // #3350 issue-1 — lease-gated row-absent commit resolution: the visible
+    // `⏳ → ✅` path with NO committed row must still resolve the own-pin
+    // DeferredClaim marker (tombstone-first + claimed discard, reaction-free).
+    // ====================================================================
+
+    /// RED pre-#3350-issue-1: a lease-gated visible ✅ left the own-pin marker
+    /// behind, so the TTL sweep stacked a ⚠ next to the delivered ✅. The
+    /// resolver must discard the marker AND leave a durable own-identity
+    /// tombstone — with ZERO reaction traffic of its own.
+    #[test]
+    fn lease_gated_completion_discards_own_pin_marker_and_records_tombstone() {
+        let _root = test_root();
+        let m = deferred_marker("claude", 100, 910, 10_000);
+        record(&m).unwrap();
+
+        let resolved =
+            resolve_own_claim_markers_for_visibly_completed_anchor("claude", "tmux-100", 100, 910);
+
+        assert_eq!(resolved, 1);
+        assert!(
+            load_for_channel("claude", 100).is_empty(),
+            "RED pre-#3350: the marker survived the visible ✅ and TTL-⚠'d it"
+        );
+        let tombstones = load_commit_tombstones("claude", 100);
+        assert_eq!(
+            tombstones.len(),
+            1,
+            "own-identity tombstone must be durable"
+        );
+        assert_eq!(tombstones[0].committed_user_msg_id, 910);
+        assert_eq!(tombstones[0].committed_started_at, OWN_STARTED_AT);
+        assert_eq!(tombstones[0].tmux_session_name, "tmux-100");
+    }
+
+    /// Scope pins: an Abort-kind marker on the SAME anchor (foreign pin — this
+    /// commit proves nothing about the foreign turn, #3296) and an own-pin
+    /// marker for a DIFFERENT anchor must both survive untouched, with no
+    /// tombstone fabricated for either.
+    #[test]
+    fn lease_gated_completion_leaves_abort_and_other_anchor_markers() {
+        let _root = test_root();
+        record(&marker("claude", 100, 911, 10_000)).unwrap(); // Abort, same anchor
+        record(&deferred_marker("claude", 100, 912, 10_000)).unwrap(); // other anchor
+
+        let resolved =
+            resolve_own_claim_markers_for_visibly_completed_anchor("claude", "tmux-100", 100, 911);
+
+        assert_eq!(resolved, 0);
+        assert_eq!(
+            load_for_channel("claude", 100).len(),
+            2,
+            "foreign-pin and other-anchor markers are out of the resolver's scope"
+        );
+        assert!(
+            load_commit_tombstones("claude", 100).is_empty(),
+            "no tombstone may be fabricated for a turn this ✅ does not prove"
+        );
+    }
+
+    /// Claim contention (write-before-discard): with the marker claimed by a
+    /// concurrent reconciler the resolver must SKIP the discard but still
+    /// persist the tombstone — the later sweep then 대조s ✅ (Complete), never
+    /// the hard-cap ⚠ it would otherwise deliver.
+    #[test]
+    fn claim_contended_lease_gated_resolution_converges_to_sweep_completion() {
+        let _root = test_root();
+        let m = deferred_marker("claude", 100, 913, 10_000);
+        record(&m).unwrap();
+        let held_claim = try_claim_marker(&m).expect("test holds the claim");
+
+        let resolved =
+            resolve_own_claim_markers_for_visibly_completed_anchor("claude", "tmux-100", 100, 913);
+        assert_eq!(resolved, 0, "claimed marker must not be discarded");
+        assert_eq!(load_for_channel("claude", 100).len(), 1);
+        assert_eq!(
+            load_commit_tombstones("claude", 100).len(),
+            1,
+            "tombstone must land even when the discard loses the claim race"
+        );
+
+        drop(held_claim);
+        let (applier, calls) = recording_applier(ReactionDelivery::Delivered);
+        let swept = test_rt().block_on(sweep_expired_with_applier(
+            "claude",
+            10_000 + TTL_MS * ABORT_MARKER_HARD_CAP_TTL_MULTIPLIER + 1,
+            true,
+            &|_marker: &AbortedAnchorMarker| false,
+            &applier,
+        ));
+        assert_eq!(swept, 1);
+        assert_eq!(
+            calls.lock().unwrap().as_slice(),
+            &[(913, ReactionOp::Complete)],
+            "the durable tombstone keeps the contended marker's verdict ✅ — \
+             without it this past-hard-cap sweep delivers the false ⚠"
+        );
+        assert!(load_for_channel("claude", 100).is_empty());
     }
 }

--- a/src/services/discord/tui_direct_pending_start.rs
+++ b/src/services/discord/tui_direct_pending_start.rs
@@ -829,54 +829,66 @@ async fn run_worker_inner(
 /// * **Fail-open** — every miss above (and a failed marker write) only warns:
 ///   the claim, the durable-record delete, and the turn proceed exactly as
 ///   before #3303.
-fn record_deferred_claim_marker_if_watcher_owned(record: &TuiDirectPendingStart) {
-    if record.anchor_message_id == 0 {
+/// #3350: the marker-record chokepoint SHARED by the deferred worker (#3303,
+/// via the thin [`record_deferred_claim_marker_if_watcher_owned`] wrapper) and
+/// the INLINE synthetic claim (`tui_prompt_relay`). Both claim paths must
+/// leave the same durable `DeferredClaim` marker, or an inline-claimed turn
+/// whose output is never committed (e.g. stale input right after `/clear`)
+/// keeps an eternal anchor `⏳`. Body unchanged from the #3303 helper — every
+/// guard above applies verbatim.
+pub(in crate::services::discord) fn record_claim_marker_if_watcher_owned(
+    provider: &str,
+    channel_id: u64,
+    anchor_message_id: u64,
+    tmux_session_name: &str,
+) {
+    if anchor_message_id == 0 {
         return; // I5: a zero anchor id could never be reconciled (record() rejects it too)
     }
     let lease = crate::services::tui_prompt_dedupe::external_input_relay_lease(
-        &record.provider,
-        &record.tmux_session_name,
-        record.channel_id,
+        provider,
+        tmux_session_name,
+        channel_id,
     );
     let relay_owner = lease.map(|lease| lease.relay_owner);
     if relay_owner != Some(crate::services::tui_prompt_dedupe::ExternalInputRelayOwner::TmuxWatcher)
     {
         tracing::debug!(
-            provider = %record.provider,
-            channel_id = record.channel_id,
-            tmux_session_name = %record.tmux_session_name,
-            anchor_message_id = record.anchor_message_id,
+            provider = %provider,
+            channel_id,
+            tmux_session_name = %tmux_session_name,
+            anchor_message_id,
             relay_owner = ?relay_owner,
             "tui_direct_pending_start: deferred-claim marker skipped — turn is not watcher-owned, the watcher chokepoint will never tombstone it (#3303 SC3)"
         );
         return;
     }
-    let Some(provider) = crate::services::provider::ProviderKind::from_str(&record.provider) else {
+    let Some(provider_kind) = crate::services::provider::ProviderKind::from_str(provider) else {
         tracing::warn!(
-            provider = %record.provider,
-            channel_id = record.channel_id,
-            anchor_message_id = record.anchor_message_id,
+            provider = %provider,
+            channel_id,
+            anchor_message_id,
             "tui_direct_pending_start: unparseable provider; deferred-claim marker skipped (fail-open, #3303)"
         );
         return;
     };
-    let Some(row) = super::inflight::load_inflight_state(&provider, record.channel_id) else {
+    let Some(row) = super::inflight::load_inflight_state(&provider_kind, channel_id) else {
         tracing::warn!(
-            provider = %record.provider,
-            channel_id = record.channel_id,
-            anchor_message_id = record.anchor_message_id,
+            provider = %provider,
+            channel_id,
+            anchor_message_id,
             "tui_direct_pending_start: no inflight row at the record instant after a successful claim; deferred-claim marker skipped (fail-open, #3303)"
         );
         return;
     };
-    let row_is_own_turn = row.user_msg_id == record.anchor_message_id
-        && row.tmux_session_name.as_deref() == Some(record.tmux_session_name.as_str());
+    let row_is_own_turn = row.user_msg_id == anchor_message_id
+        && row.tmux_session_name.as_deref() == Some(tmux_session_name);
     if !row_is_own_turn {
         tracing::warn!(
-            provider = %record.provider,
-            channel_id = record.channel_id,
-            tmux_session_name = %record.tmux_session_name,
-            anchor_message_id = record.anchor_message_id,
+            provider = %provider,
+            channel_id,
+            tmux_session_name = %tmux_session_name,
+            anchor_message_id,
             row_user_msg_id = row.user_msg_id,
             row_tmux_session_name = ?row.tmux_session_name,
             "tui_direct_pending_start: inflight row is not this claim's own synthetic turn; deferred-claim marker skipped (fail-open, #3303)"
@@ -884,29 +896,38 @@ fn record_deferred_claim_marker_if_watcher_owned(record: &TuiDirectPendingStart)
         return;
     }
     match super::tui_direct_abort_marker::record_for_deferred_claim(
-        record.provider.clone(),
-        record.channel_id,
-        record.anchor_message_id,
-        record.tmux_session_name.clone(),
-        (record.anchor_message_id, row.started_at),
+        provider.to_string(),
+        channel_id,
+        anchor_message_id,
+        tmux_session_name.to_string(),
+        (anchor_message_id, row.started_at),
     ) {
         Ok(marker) => tracing::info!(
-            provider = %record.provider,
-            channel_id = record.channel_id,
-            tmux_session_name = %record.tmux_session_name,
-            anchor_message_id = record.anchor_message_id,
+            provider = %provider,
+            channel_id,
+            tmux_session_name = %tmux_session_name,
+            anchor_message_id,
             own_started_at = ?marker.foreign_started_at,
             tombstone_covered = marker.covered_at_ms.is_some(),
             "tui_direct_pending_start: deferred-claim marker recorded pinning the OWN synthetic turn — its commit drains ⏳ → ✅, a never-committed turn converges to the bounded sweep ⚠ (#3303)"
         ),
         Err(error) => tracing::warn!(
-            provider = %record.provider,
-            channel_id = record.channel_id,
-            anchor_message_id = record.anchor_message_id,
+            provider = %provider,
+            channel_id,
+            anchor_message_id,
             error = %error,
             "tui_direct_pending_start: failed to persist the deferred-claim marker; claim proceeds without it (fail-open — pre-#3303 behavior, the anchor ⏳ may linger) (#3303)"
         ),
     }
+}
+
+fn record_deferred_claim_marker_if_watcher_owned(record: &TuiDirectPendingStart) {
+    record_claim_marker_if_watcher_owned(
+        &record.provider,
+        record.channel_id,
+        record.anchor_message_id,
+        &record.tmux_session_name,
+    );
 }
 
 #[cfg(test)]
@@ -2042,5 +2063,79 @@ mod tests {
             Some(own_started_at.as_str())
         );
         reset_present_for_tests();
+    }
+
+    /// #3350 (SC3 via the GENERALIZED helper): the relay's INLINE claim path
+    /// calls `record_claim_marker_if_watcher_owned` directly — a non-watcher
+    /// lease records nothing even with a perfectly matching own row (a
+    /// bridge-owned turn completes its own ⏳, so a marker would contradict
+    /// it with a TTL ⚠).
+    #[test]
+    fn generalized_helper_skips_non_watcher_lease() {
+        let _guard = worker_test_lock();
+        let _env_lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let _rig = DeferredClaimMarkerRig::new();
+
+        let tmux = "tmux-3350-24";
+        record_lease(
+            "claude",
+            tmux,
+            24,
+            crate::services::tui_prompt_dedupe::ExternalInputRelayOwner::BridgeAdapter,
+        );
+        let _ = save_own_inflight_row(24, 2400, tmux);
+
+        record_claim_marker_if_watcher_owned("claude", 24, 2400, tmux);
+
+        assert!(
+            super::super::tui_direct_abort_marker::load_for_channel("claude", 24).is_empty(),
+            "non-watcher lease must record no marker (SC3 — inline path)"
+        );
+    }
+
+    /// #3350: the generalized helper with a watcher lease + matching own row
+    /// records the SAME own-identity DeferredClaim marker the deferred worker
+    /// records — the inline claim path inherits #3303's guards verbatim (the
+    /// existing worker tests stay green through the thin delegation wrapper).
+    #[test]
+    fn generalized_helper_records_marker_for_watcher_lease_and_own_row() {
+        let _guard = worker_test_lock();
+        let _env_lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let _rig = DeferredClaimMarkerRig::new();
+
+        let tmux = "tmux-3350-25";
+        record_lease(
+            "claude",
+            tmux,
+            25,
+            crate::services::tui_prompt_dedupe::ExternalInputRelayOwner::TmuxWatcher,
+        );
+        let own_started_at = save_own_inflight_row(25, 2500, tmux);
+
+        record_claim_marker_if_watcher_owned("claude", 25, 2500, tmux);
+
+        let markers = super::super::tui_direct_abort_marker::load_for_channel("claude", 25);
+        assert_eq!(
+            markers.len(),
+            1,
+            "RED pre-#3350: the inline claim recorded nothing — a turn whose \
+             output never commits kept an eternal anchor ⏳"
+        );
+        assert_eq!(
+            markers[0].origin,
+            super::super::tui_direct_abort_marker::MarkerOrigin::DeferredClaim
+        );
+        assert_eq!(markers[0].anchor_message_id, 2500);
+        assert_eq!(markers[0].foreign_user_msg_id, Some(2500));
+        assert_eq!(
+            markers[0].foreign_started_at.as_deref(),
+            Some(own_started_at.as_str()),
+            "the pin is the freshly-claimed row's identity (SC1)"
+        );
+        assert_eq!(markers[0].covered_at_ms, None);
     }
 }

--- a/src/services/discord/tui_direct_pending_start.rs
+++ b/src/services/discord/tui_direct_pending_start.rs
@@ -930,6 +930,26 @@ fn record_deferred_claim_marker_if_watcher_owned(record: &TuiDirectPendingStart)
     );
 }
 
+/// #3350 issue-3: the observer INLINE-claim wiring, separated so a unit test
+/// can pin it — `relay_observed_prompt` must record the #3303 DeferredClaim
+/// marker IFF the inline synthetic claim actually claimed, forwarding the
+/// prompt's exact `(provider, channel, anchor, tmux)` identity. `recorder` is
+/// injected (`FnOnce` flavor of the `ClaimFn` injection convention);
+/// production passes [`record_claim_marker_if_watcher_owned`] itself, so the
+/// signature match is compiler-pinned at the call site.
+pub(in crate::services::discord) fn record_inline_claim_marker_if_claimed(
+    claimed: bool,
+    provider: &str,
+    channel_id: u64,
+    anchor_message_id: u64,
+    tmux_session_name: &str,
+    recorder: impl FnOnce(&str, u64, u64, &str),
+) {
+    if claimed {
+        recorder(provider, channel_id, anchor_message_id, tmux_session_name);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2137,5 +2157,33 @@ mod tests {
             "the pin is the freshly-claimed row's identity (SC1)"
         );
         assert_eq!(markers[0].covered_at_ms, None);
+    }
+
+    /// #3350 issue-3: pins the observer inline-claim wiring.
+    /// `relay_observed_prompt` routes through
+    /// `record_inline_claim_marker_if_claimed`, which must invoke the recorder
+    /// with the prompt's EXACT `(provider, channel, anchor, tmux)` identity
+    /// when the synthetic claim succeeded — and must invoke NOTHING when it
+    /// did not (an unclaimed prompt leaving a marker would TTL-⚠ a turn the
+    /// watcher never owned).
+    #[test]
+    fn inline_claim_marker_wiring_records_only_when_claimed() {
+        let recorded: std::cell::RefCell<Vec<(String, u64, u64, String)>> =
+            std::cell::RefCell::new(Vec::new());
+        record_inline_claim_marker_if_claimed(true, "claude", 42, 4242, "tmux-w", |p, c, a, t| {
+            recorded
+                .borrow_mut()
+                .push((p.to_string(), c, a, t.to_string()));
+        });
+        record_inline_claim_marker_if_claimed(false, "claude", 43, 4343, "tmux-w", |p, c, a, t| {
+            recorded
+                .borrow_mut()
+                .push((p.to_string(), c, a, t.to_string()));
+        });
+        assert_eq!(
+            *recorded.borrow(),
+            vec![("claude".to_string(), 42u64, 4242u64, "tmux-w".to_string())],
+            "claimed forwards the exact prompt identity; unclaimed records nothing"
+        );
     }
 }

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -705,11 +705,9 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             Err(error) => {
                 // #3075 codex P2: the `Post` outcome reserved a placeholder card slot
                 // (message_id == 0) before this post; on post failure release the
-                // reservation we own (exact-match while message_id is still 0) so the
-                // next same-task notification reserves fresh — otherwise the lingering
-                // placeholder forces every later one to `Pending`/no-op until the 1h
-                // stale purge. Clearing only changes the NEXT reservation's outcome,
-                // never turning an already-dropped repeat into a double-post.
+                // reservation we own so the next same-task notification reserves fresh
+                // (a lingering placeholder would force later ones to `Pending` no-ops
+                // until the 1h stale purge; the NEXT reservation alone is affected).
                 if matches!(injected_class, InjectedPromptClass::TaskNotificationEvent) {
                     let task_id =
                         super::tui_task_card::parse_task_notification(&prompt.prompt).task_id;
@@ -746,13 +744,10 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             );
         }
         // #3164: add `⏳` with the command(provider) bot so it matches the bot that
-        // removes it in `complete_tui_direct_prompt_anchor_lifecycle_if_present`; if
-        // that http was unavailable we skip the add (warned above) rather than strand
-        // the hourglass under the wrong identity.
-        // #3164 codex R2 issue-2: add the `⏳` BEFORE the anchor becomes findable
-        // (`record_prompt_anchor` below) — anchor-first would let a fast watcher
-        // complete (remove a not-yet-added `⏳`, post `✅`, clear the anchor) and the
-        // delayed add then re-leaves `⏳ + ✅`.
+        // removes it in `complete_tui_direct_prompt_anchor_lifecycle_if_present`; on
+        // unavailable http skip the add (warned above). codex R2 issue-2: add BEFORE
+        // the anchor becomes findable (`record_prompt_anchor`) — anchor-first lets a
+        // fast watcher complete first and the delayed add re-leaves `⏳ + ✅`.
         if let Some(command_http) = command_http.as_ref() {
             super::formatting::add_reaction_raw(command_http, channel_id, anchor_message.id, '⏳')
                 .await;
@@ -763,14 +758,12 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             channel_id.get(),
             anchor_message.id.get(),
         );
-        // #3174: turn-identity guard on the ⏳ lifecycle. If the watcher's lease-gated
-        // completion fired inside the sub-second notify+⏳-add window (before this
-        // `record_prompt_anchor`), it left a deferred-completion marker; now that THIS
-        // turn's anchor exists, drain it and finish the ⏳ → ✅ swap. P1: drain ONLY the
-        // marker matching `lease.generation` (never cross-consume a newer turn). P2
-        // (HTTP fail-open): PEEK first, consume only with `command_http`, else leave it
-        // for a later pass within its TTL. Decision is pure in
-        // [`decide_deferred_anchor_completion_drain`]. No-op on the common (no-marker) path.
+        // #3174: turn-identity guard on the ⏳ lifecycle. A lease-gated completion
+        // firing inside the sub-second notify+⏳-add window left a deferred marker;
+        // now that THIS turn's anchor exists, drain it (⏳ → ✅ swap). P1: drain ONLY
+        // the `lease.generation` match (never cross-consume a newer turn). P2: PEEK
+        // first, consume only with `command_http`, else leave it within its TTL.
+        // Pure decision: [`decide_deferred_anchor_completion_drain`]; no-marker no-op.
         match decide_deferred_anchor_completion_drain(
             &prompt.provider,
             &prompt.tmux_session_name,
@@ -806,9 +799,8 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             DeferredAnchorCompletionDrain::NoMarker => {}
         }
         // #3099: a `<task-notification>` auto-turn earns the same synthetic ownership
-        // as human direct input (its ⏳ cleanup is anchored on its own id in the
-        // watcher/recovery paths), so it does NOT short-circuit here. Only
-        // SystemContinuation skips this active-turn block (still relaying via the tail).
+        // as human direct input (its ⏳ cleanup anchors on its own id), so it does NOT
+        // short-circuit here. Only SystemContinuation skips this active-turn block.
         debug_assert!(
             injected_class.is_human_active_turn()
                 || matches!(injected_class, InjectedPromptClass::TaskNotificationEvent),
@@ -816,18 +808,15 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
         );
         // #3154 P1-3: set when the synthetic turn-start is DEFERRED to the detached
         // per-channel worker; the observer then must NOT spawn its own BridgeAdapter
-        // tail below (the worker claims as WATCHER owner after the prior turn drains
-        // and re-records the lease — a second observer tail would relay the SAME
-        // output twice, the original bug). The worker owns the relay-owner handoff.
+        // tail below (a second observer tail would relay the SAME output twice — the
+        // original bug). The worker owns the relay-owner handoff.
         if let Some(provider) = ProviderKind::from_str(&prompt.provider) {
-            // #3154 — TEMPORAL fix for turn-interleaving. Claiming the synthetic
-            // turn-start INLINE while the PRIOR turn's tail is still draining seeds
-            // `turn_start_offset` from the prior cursor → `response_sent_offset_
-            // monotonic` collision / duplicate relay; an inline wait also starves
-            // OTHER channels (single observer loop). So when the prior turn is not
-            // finalized, persist a DURABLE pending-start and hand the claim to a
-            // DETACHED per-channel worker (it waits, then claims a FRESH EOF offset).
-            // The common no-interleave case stays on the inline fast path.
+            // #3154 — TEMPORAL fix for turn-interleaving. An INLINE claim while the
+            // PRIOR turn's tail still drains seeds `turn_start_offset` from the prior
+            // cursor (duplicate relay), and an inline wait starves OTHER channels. So
+            // an un-finalized prior turn persists a DURABLE pending-start and hands
+            // the claim to a DETACHED per-channel worker (fresh EOF offset); the
+            // common no-interleave case stays on the inline fast path.
             let prior = synthetic_start_prior_turn_view(
                 shared,
                 &provider,
@@ -872,12 +861,23 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
                     lease.relay_owner = claim.relay_owner;
                     // Re-record overwrites the lease with a FRESH generation; adopt it
                     // back into `lease` so the bridge-tail guard below captures the
-                    // exact stored identity (otherwise the guard would hold the stale
-                    // generation and its Drop would clear nothing / the wrong lease).
+                    // exact stored identity (a stale generation's Drop would clear
+                    // nothing / the wrong lease).
                     lease = crate::services::tui_prompt_dedupe::record_external_input_turn_lease(
                         provider.as_str(),
                         &prompt.tmux_session_name,
                         lease,
+                    );
+                }
+                // #3350: the INLINE claim records the same #3303 DeferredClaim marker
+                // as the deferred worker, bounding a never-committed turn's anchor ⏳
+                // (drain ✅ / sweep TTL ⚠). SC3/own-row/I5 gates live in the helper.
+                if claim.claimed {
+                    super::tui_direct_pending_start::record_claim_marker_if_watcher_owned(
+                        &prompt.provider,
+                        channel_id.get(),
+                        anchor_message.id.get(),
+                        &prompt.tmux_session_name,
                     );
                 }
             }

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -870,16 +870,16 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
                     );
                 }
                 // #3350: the INLINE claim records the same #3303 DeferredClaim marker
-                // as the deferred worker, bounding a never-committed turn's anchor ⏳
-                // (drain ✅ / sweep TTL ⚠). SC3/own-row/I5 gates live in the helper.
-                if claim.claimed {
-                    super::tui_direct_pending_start::record_claim_marker_if_watcher_owned(
-                        &prompt.provider,
-                        channel_id.get(),
-                        anchor_message.id.get(),
-                        &prompt.tmux_session_name,
-                    );
-                }
+                // as the deferred worker (drain ✅ / sweep TTL ⚠). SC3/own-row/I5 gates
+                // live in the recorder; a pending_start test pins this wiring.
+                super::tui_direct_pending_start::record_inline_claim_marker_if_claimed(
+                    claim.claimed,
+                    &prompt.provider,
+                    channel_id.get(),
+                    anchor_message.id.get(),
+                    &prompt.tmux_session_name,
+                    super::tui_direct_pending_start::record_claim_marker_if_watcher_owned,
+                );
             }
         }
         tracing::info!(

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -995,20 +995,22 @@ async fn do_finalize(
 ) -> FinalizeOutcome {
     let channel_id = key.channel_id;
 
+    // #3350 ②: ensure the #3303 DeferredClaim marker for a watcher-owned TUI-direct
+    // synthetic turn BEFORE (A) erases the row evidence (gates/rationale: cleanup.rs).
+    cleanup::ensure_synthetic_claim_marker_before_clear(key, &provider);
+
     // (A) inflight clear. Only the deadline-armed gate-timeout backstop and the
     //     immediate no-owner restored-watcher path set `clear_inflight` (every
     //     live-caller bridge/watcher site clears inflight inline and passes
     //     `false`). Those two paths CONSOLIDATE the pre-#3016 1800s placeholder
-    //     sweeper, which was IDENTITY-GUARDED: it re-checked the on-disk
-    //     `user_msg_id` still named the same turn and refused to delete a
-    //     different (newer) turn's inflight, and never wiped a planned-restart /
-    //     rebind-origin marker. So when this finalize carries a real identity
-    //     (`user_msg_id != 0`) we reproduce that guard via
-    //     `clear_inflight_state_if_matches` — finalize NEVER deletes a newer
-    //     turn's inflight and preserves `PlannedRestartSkipped` /
-    //     `RebindOriginSkipped`. A true orphan (`user_msg_id == 0`, no identity
-    //     to authenticate against) falls back to the unguarded clear, exactly as
-    //     the orphan paths always had to.
+    //     sweeper, which was IDENTITY-GUARDED: it refused to delete a different
+    //     (newer) turn's inflight and never wiped a planned-restart /
+    //     rebind-origin marker. So a real identity (`user_msg_id != 0`)
+    //     reproduces that guard via `clear_inflight_state_if_matches` —
+    //     finalize NEVER deletes a newer turn's inflight and preserves
+    //     `PlannedRestartSkipped` / `RebindOriginSkipped`. A true orphan
+    //     (`user_msg_id == 0`, nothing to authenticate against) falls back to
+    //     the unguarded clear, exactly as the orphan paths always had to.
     if ctx.clear_inflight {
         if key.user_msg_id != 0 {
             let _ = super::inflight::clear_inflight_state_if_matches(
@@ -1028,12 +1030,11 @@ async fn do_finalize(
     //
     //     #3016 root-cause: when the terminal carries a real identity, use the
     //     IDENTITY-GUARDED finish so finalize only releases the token of the
-    //     turn it actually owns. This closes the wrong-turn race where a stale
-    //     channel-scoped terminal arriving after this turn finalized but before
-    //     the next turn registered (or after ledger GC) would otherwise release
-    //     the NEWER turn's token and decrement `global_active`. An ambiguous
-    //     id-0 (recovery/orphan) terminal keeps the channel-scoped finish — the
-    //     ledger gate + id-0 no-op guard already bound those.
+    //     turn it actually owns — closes the wrong-turn race where a stale
+    //     channel-scoped terminal arriving post-finalize (or after ledger GC)
+    //     would release the NEWER turn's token and decrement `global_active`.
+    //     An ambiguous id-0 (recovery/orphan) terminal keeps the channel-scoped
+    //     finish — the ledger gate + id-0 no-op guard already bound those.
     let finish = if key.user_msg_id != 0 {
         super::mailbox_finish_turn_if_matches(
             shared,

--- a/src/services/discord/turn_finalizer.rs
+++ b/src/services/discord/turn_finalizer.rs
@@ -35,6 +35,8 @@ use super::{DeliveryLeaseCell, LeaseHolder, LeaseOutcome};
 
 mod cleanup;
 
+pub(in crate::services::discord) use cleanup::SyntheticClaimSnapshot;
+
 /// How often the reconciler `Tick` fires to re-check deadline-armed
 /// gate-timeout entries and garbage-collect the ledger.
 const RECONCILE_INTERVAL: Duration = Duration::from_millis(1000);
@@ -524,6 +526,29 @@ impl TurnFinalizer {
         ctx: FinalizeContext,
         shared: Arc<SharedData>,
     ) -> FinalizeOutcome {
+        self.submit_terminal_with_claim_snapshot(key, provider, event, ctx, None, shared)
+            .await
+    }
+
+    /// #3350 codex r1-1: `submit_terminal` carrying the submit-time row
+    /// snapshot for the #3303 DeferredClaim marker ensure. Watcher submitters
+    /// clear the row BEFORE submitting, so `do_finalize`'s row re-load proves
+    /// nothing for their turns — the pre-clear snapshot is the identity
+    /// evidence. The idempotent, reaction-free ensure runs HERE, before the
+    /// exactly-once gate: an `AlreadyFinalized` loser's snapshot still ensures
+    /// (the winner may have finalized row/snapshot-less; gates: cleanup.rs).
+    pub(in crate::services::discord) async fn submit_terminal_with_claim_snapshot(
+        &self,
+        key: TurnKey,
+        provider: ProviderKind,
+        event: TerminalEvent,
+        ctx: FinalizeContext,
+        claim_snapshot: Option<SyntheticClaimSnapshot>,
+        shared: Arc<SharedData>,
+    ) -> FinalizeOutcome {
+        if let Some(snapshot) = claim_snapshot.as_ref() {
+            cleanup::ensure_synthetic_claim_marker_before_clear(key, &provider, Some(snapshot));
+        }
         let (ack, rx) = oneshot::channel();
         if self
             .tx
@@ -866,25 +891,18 @@ async fn handle_terminal(
     ctx: FinalizeContext,
     shared: &Arc<SharedData>,
 ) -> FinalizeOutcome {
-    // Resolve to the entry this terminal acts on. A real id uses its exact
-    // key; a channel-only id-0 terminal collapses onto the channel's single
-    // live entry (recovery/orphan path). A terminal for an unregistered turn is
-    // the orphan path (post-restart inflight on disk, no live `Start`); we
-    // still finalize it driven by the inflight identity — idempotent
-    // `mailbox_finish_turn` returns `removed_token = None` so the counter is
-    // untouched and inflight is cleared exactly once.
+    // Resolve to the entry this terminal acts on: a real id keys exactly; a
+    // channel-only id-0 collapses onto the channel's single live entry
+    // (recovery/orphan). An unregistered turn (post-restart inflight, no live
+    // `Start`) still finalizes below — idempotent, exactly-once.
     let ledger_key = resolve_ledger_key(ledger, key);
 
-    // Codex P1 — ambiguous channel-only terminal. A `user_msg_id == 0`
-    // submission whose resolver fell back to the literal orphan key (because a
-    // recently-`Finalized` entry exists) is most likely a STALE terminal of
-    // that finalized turn. If a DIFFERENT live entry exists for the channel
-    // (a queued follow-up that has since registered), running the
-    // channel-scoped `mailbox_finish_turn` here would release the follow-up's
-    // token and decrement `global_active` for a turn this terminal does not
-    // own. Treat it as a no-op so it cannot corrupt the next active turn. (A
-    // genuine orphan with NO live entry still finalizes below — its
-    // `mailbox_finish_turn` is harmless: idempotent + counter-gated.)
+    // Codex P1 — ambiguous channel-only terminal: an id-0 submission that fell
+    // back to the literal orphan key (a recently-`Finalized` entry exists) is
+    // most likely that turn's STALE terminal. With a DIFFERENT live entry on
+    // this channel, the channel-scoped finish would release the follow-up's
+    // token / decrement `global_active` — treat as no-op. (A genuine orphan
+    // with NO live entry still finalizes below; idempotent + counter-gated.)
     if key.user_msg_id == 0 && !ledger.contains_key(&ledger_key) {
         let channel_has_live_turn = ledger.iter().any(|(lk, e)| {
             lk.channel_id == key.channel_id
@@ -936,23 +954,15 @@ async fn handle_terminal(
                 .get_or_insert_with(|| Instant::now() + GATE_BACKSTOP);
             return FinalizeOutcome::Deferred;
         }
-        // No live relay owner → nothing will drive the pane to quiescence, so
-        // finalize now rather than wait out the backstop. This is the
-        // recovered/orphan watcher case (post-restart inflight on disk, never
-        // registered via the bridge handoff `register_start`) where there is no
-        // later watcher block to clear inflight or kick off the queue — the
-        // caller submits with `FinalizeContext::watcher()` while the
-        // `!lifecycle_stage_paused` cleanup block is SKIPPED and discards this
-        // outcome. So this immediate path MUST reproduce that skipped cleanup
-        // itself, exactly as the deadline-armed `gate_backstop()` would have:
-        //   * clear inflight here (the watcher never cleared it inline), so the
-        //     mailbox is not released while the inflight file keeps blocking
-        //     the channel; and
-        //   * kick off any queued soft-queue backlog, so a follow-up message
-        //     queued behind the restored turn actually dispatches instead of
-        //     staying stuck (regression of the EPIC's restart/#3011 goal).
-        // Without the kickoff the restored channel clears inflight but never
-        // drains its pending follow-up, leaving it effectively stuck.
+        // No live relay owner → nothing will drive the pane to quiescence;
+        // finalize now. This recovered/orphan watcher case (post-restart
+        // inflight, no `register_start`) has no later watcher block to clear
+        // inflight or kick the queue — the caller's `watcher()` submit SKIPS
+        // its cleanup block and discards this outcome, so reproduce what the
+        // deadline-armed `gate_backstop()` would have done: clear inflight
+        // here (else the file keeps blocking the channel after the mailbox
+        // release) AND kick off the queued soft-queue backlog (else a queued
+        // follow-up stays stuck — the EPIC restart/#3011 regression).
         effective_ctx.clear_inflight = true;
         effective_ctx.kickoff_queue = true;
     }
@@ -960,14 +970,11 @@ async fn handle_terminal(
     // Flip Pending → Finalizing, run the side-effects, flip → Finalized.
     entry.phase = Phase::Finalizing;
     let provider = entry.provider.clone();
-    // Codex P1 — finalize on the RESOLVED identity. An id-0 watcher/recovery
-    // terminal that collapsed onto a ledger entry registered (via
-    // `register_start`) with the real `user_msg_id` must finalize under THAT
-    // identity so `do_finalize` takes the guarded `finish_turn_if_matches` /
-    // `clear_inflight_state_if_matches` path. Otherwise the id-0 key would force
-    // the unguarded channel-scoped finish and could release a newer turn's token
-    // when the ledger entry is stale. When the submission already carries a real
-    // id, or the entry has no better identity (still id-0), this is the same key.
+    // Codex P1 — finalize on the RESOLVED identity: an id-0 terminal that
+    // collapsed onto an entry registered with the real `user_msg_id` finalizes
+    // under THAT identity, so `do_finalize` takes the guarded if-matches paths
+    // instead of the unguarded channel-scoped finish (which could release a
+    // newer turn's token when the entry is stale). Otherwise the same key.
     let finalize_key = if key.user_msg_id == 0 && entry.turn_key.user_msg_id != 0 {
         entry.turn_key
     } else {
@@ -996,21 +1003,19 @@ async fn do_finalize(
     let channel_id = key.channel_id;
 
     // #3350 ②: ensure the #3303 DeferredClaim marker for a watcher-owned TUI-direct
-    // synthetic turn BEFORE (A) erases the row evidence (gates/rationale: cleanup.rs).
-    cleanup::ensure_synthetic_claim_marker_before_clear(key, &provider);
+    // synthetic turn BEFORE (A) erases the row evidence. Codex r1-1: watcher
+    // submitters cleared the row pre-submit, so for them this row re-load proves
+    // nothing — their guarantee runs at submit time from the pre-clear snapshot
+    // (`submit_terminal_with_claim_snapshot`); rationale/gates: cleanup.rs.
+    cleanup::ensure_synthetic_claim_marker_before_clear(key, &provider, None);
 
-    // (A) inflight clear. Only the deadline-armed gate-timeout backstop and the
-    //     immediate no-owner restored-watcher path set `clear_inflight` (every
-    //     live-caller bridge/watcher site clears inflight inline and passes
-    //     `false`). Those two paths CONSOLIDATE the pre-#3016 1800s placeholder
-    //     sweeper, which was IDENTITY-GUARDED: it refused to delete a different
-    //     (newer) turn's inflight and never wiped a planned-restart /
-    //     rebind-origin marker. So a real identity (`user_msg_id != 0`)
-    //     reproduces that guard via `clear_inflight_state_if_matches` —
-    //     finalize NEVER deletes a newer turn's inflight and preserves
-    //     `PlannedRestartSkipped` / `RebindOriginSkipped`. A true orphan
-    //     (`user_msg_id == 0`, nothing to authenticate against) falls back to
-    //     the unguarded clear, exactly as the orphan paths always had to.
+    // (A) inflight clear. Only the gate-timeout backstop and the immediate
+    //     no-owner restored-watcher path set `clear_inflight` (live bridge /
+    //     watcher sites clear inline, pass `false`). They consolidate the
+    //     pre-#3016 IDENTITY-GUARDED 1800s sweeper: a real identity clears via
+    //     `clear_inflight_state_if_matches` — never a newer turn's inflight,
+    //     preserving `PlannedRestartSkipped` / `RebindOriginSkipped`; a true
+    //     orphan (id-0, nothing to authenticate) keeps the unguarded clear.
     if ctx.clear_inflight {
         if key.user_msg_id != 0 {
             let _ = super::inflight::clear_inflight_state_if_matches(
@@ -1023,18 +1028,13 @@ async fn do_finalize(
         }
     }
 
-    // (B) mailbox cancel_token release — the routed sites' single
-    //     `mailbox_finish_turn`. Idempotent: returns `removed_token = None` on
-    //     a second call, which is what makes a transitional double-finalize a
-    //     no-op during Phases 2-3.
-    //
-    //     #3016 root-cause: when the terminal carries a real identity, use the
-    //     IDENTITY-GUARDED finish so finalize only releases the token of the
-    //     turn it actually owns — closes the wrong-turn race where a stale
-    //     channel-scoped terminal arriving post-finalize (or after ledger GC)
-    //     would release the NEWER turn's token and decrement `global_active`.
-    //     An ambiguous id-0 (recovery/orphan) terminal keeps the channel-scoped
-    //     finish — the ledger gate + id-0 no-op guard already bound those.
+    // (B) mailbox cancel_token release — the routed sites' single, idempotent
+    //     `mailbox_finish_turn` (`removed_token = None` on a second call).
+    //     #3016 root-cause: a real identity uses the IDENTITY-GUARDED finish so
+    //     finalize only releases the token it owns — a stale channel-scoped
+    //     terminal post-finalize/ledger-GC must not release the NEWER turn's
+    //     token or decrement `global_active`. Ambiguous id-0 (recovery/orphan)
+    //     keeps the channel-scoped finish (ledger gate + id-0 no-op bound it).
     let finish = if key.user_msg_id != 0 {
         super::mailbox_finish_turn_if_matches(
             shared,
@@ -1360,7 +1360,7 @@ async fn run_backstop_finalize(
     }
     // Backstop finalize: the deferred terminal originated from the watcher but
     // no caller is around to clear inflight, so the backstop context clears it
-    // here.
+    // here — and the row, still on disk, feeds the marker-ensure row fallback.
     let _ = do_finalize(
         turn_key,
         provider,

--- a/src/services/discord/turn_finalizer/cleanup.rs
+++ b/src/services/discord/turn_finalizer/cleanup.rs
@@ -84,37 +84,86 @@ pub(super) fn should_ensure_synthetic_claim_marker(
         && row_tmux_session_present
 }
 
+/// #3350 codex r1-1: submit-time snapshot of the inflight-row fields the
+/// finalize-time marker ensure authenticates against. The production watcher
+/// submitters clear the row BEFORE submitting the finalize (tmux.rs
+/// `finish_restored_watcher_active_turn` docs), so a row re-load inside
+/// `do_finalize` is a guaranteed no-op for exactly the turns the ensure
+/// exists for — the snapshot, captured from the caller's pre-clear row pinned
+/// to the submitted turn, closes that guarantee hole.
+#[derive(Clone, Debug)]
+pub(in crate::services::discord) struct SyntheticClaimSnapshot {
+    pub(in crate::services::discord) user_msg_id: u64,
+    pub(in crate::services::discord) turn_source_external: bool,
+    pub(in crate::services::discord) relay_owner_watcher: bool,
+    pub(in crate::services::discord) injected_prompt_message_id: Option<u64>,
+    pub(in crate::services::discord) tmux_session_name: Option<String>,
+    pub(in crate::services::discord) started_at: String,
+}
+
+impl SyntheticClaimSnapshot {
+    pub(in crate::services::discord) fn from_row(
+        row: &crate::services::discord::inflight::InflightTurnState,
+    ) -> Self {
+        use crate::services::discord::inflight::{RelayOwnerKind, TurnSource};
+        Self {
+            user_msg_id: row.user_msg_id,
+            turn_source_external: row.turn_source == TurnSource::ExternalInput,
+            relay_owner_watcher: row.relay_owner_kind == RelayOwnerKind::Watcher,
+            injected_prompt_message_id: row.injected_prompt_message_id,
+            tmux_session_name: row.tmux_session_name.clone(),
+            started_at: row.started_at.clone(),
+        }
+    }
+}
+
 /// #3350 ②: `do_finalize` entry hook — whatever submitter (watcher / bridge /
 /// monitor / backstop) finalizes a watcher-owned TUI-direct synthetic turn,
 /// guarantee the durable #3303 DeferredClaim marker exists for its anchor.
-/// Idempotent (an existing marker is NEVER touched) and reaction-free: the
-/// `⏳` verdict belongs exclusively to the #3303 reconcilers (drain `✅` /
-/// sweep TTL `⚠`), so output that commits late after a Stopped event never
-/// races a false-`⚠` here. Runs for Cancel too — a cancelled turn with no
-/// commit converging to the TTL `⚠` is the honest signal. Must run BEFORE the
-/// `do_finalize` (A) inflight clear: the row is the evidence.
-pub(super) fn ensure_synthetic_claim_marker_before_clear(key: TurnKey, provider: &ProviderKind) {
-    use crate::services::discord::inflight::{RelayOwnerKind, TurnSource};
-
+/// Idempotent (an existing own-pin/covered marker is never touched; an
+/// uncovered stale Abort pin is replaced per the #3303 contract — see
+/// `ensure_marker_for_own_synthetic_turn`) and reaction-free: the `⏳`
+/// verdict belongs exclusively to the #3303 reconcilers (drain `✅` / sweep
+/// TTL `⚠`), so output that commits late after a Stopped event never races a
+/// false-`⚠` here. Runs for Cancel too — a cancelled turn with no commit
+/// converging to the TTL `⚠` is the honest signal.
+///
+/// Evidence source (codex r1-1): the SUBMIT-TIME snapshot wins when the
+/// submitter carried one — the watcher clears the row before submitting, so
+/// for its turns the re-load below proves nothing. The row re-load (which
+/// must then run BEFORE the `do_finalize` (A) inflight clear) remains the
+/// fallback for submitters that did not capture a snapshot.
+pub(super) fn ensure_synthetic_claim_marker_before_clear(
+    key: TurnKey,
+    provider: &ProviderKind,
+    submit_snapshot: Option<&SyntheticClaimSnapshot>,
+) {
     if key.user_msg_id == 0 {
         return;
     }
-    let Some(row) =
-        crate::services::discord::inflight::load_inflight_state(provider, key.channel_id.get())
-    else {
-        return;
+    let snapshot = match submit_snapshot {
+        Some(snapshot) => snapshot.clone(),
+        None => {
+            let Some(row) = crate::services::discord::inflight::load_inflight_state(
+                provider,
+                key.channel_id.get(),
+            ) else {
+                return;
+            };
+            SyntheticClaimSnapshot::from_row(&row)
+        }
     };
     if !should_ensure_synthetic_claim_marker(
         key.user_msg_id,
-        row.user_msg_id,
-        row.turn_source == TurnSource::ExternalInput,
-        row.relay_owner_kind == RelayOwnerKind::Watcher,
-        row.injected_prompt_message_id,
-        row.tmux_session_name.is_some(),
+        snapshot.user_msg_id,
+        snapshot.turn_source_external,
+        snapshot.relay_owner_watcher,
+        snapshot.injected_prompt_message_id,
+        snapshot.tmux_session_name.is_some(),
     ) {
         return;
     }
-    let Some(tmux) = row.tmux_session_name.as_deref() else {
+    let Some(tmux) = snapshot.tmux_session_name.as_deref() else {
         return;
     };
     let _ = crate::services::discord::tui_direct_abort_marker::ensure_marker_for_own_synthetic_turn(
@@ -122,7 +171,7 @@ pub(super) fn ensure_synthetic_claim_marker_before_clear(key: TurnKey, provider:
         key.channel_id.get(),
         key.user_msg_id,
         tmux,
-        &row.started_at,
+        &snapshot.started_at,
     );
 }
 
@@ -532,6 +581,139 @@ mod tests {
                 );
             });
         });
+    }
+
+    /// #3350 codex r1-1 (the production watcher shape): the watcher clears the
+    /// row BEFORE submitting the finalize, so the row re-load inside
+    /// `do_finalize` proves nothing — the submit-time snapshot must carry the
+    /// identity. RED pre-fix: with the row already gone the ensure was a
+    /// guaranteed no-op on exactly the watcher path it was built for (a turn
+    /// claimed before the inline record existed finalized with no marker —
+    /// eternal anchor ⏳). Also pins the negative: a snapshot pinned to a
+    /// DIFFERENT turn than the submitted key must ensure NOTHING.
+    #[test]
+    fn finalize_ensures_marker_from_submit_snapshot_when_watcher_precleared_row() {
+        use crate::services::discord::inflight::{
+            InflightTurnState, TurnSource, save_inflight_state,
+        };
+
+        with_isolated_runtime_root(|| {
+            test_rt().block_on(async {
+                let shared =
+                    super::super::super::make_shared_data_for_tests_with_storage(None, None);
+                let ch = ChannelId::new(3_350_200);
+                let tid = 3_350_201_u64;
+                shared
+                    .global_active
+                    .store(1, std::sync::atomic::Ordering::Relaxed);
+                let _token = seed_active_turn(&shared, ch, tid).await;
+                let fin = TurnFinalizer::spawn();
+                let key = TurnKey::new(ch, tid, 0);
+                fin.register_start(key, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
+
+                let mut row = InflightTurnState::new(
+                    ProviderKind::Claude,
+                    ch.get(),
+                    None,
+                    0,
+                    tid,
+                    0,
+                    "/loop tick".to_string(),
+                    None,
+                    Some("tmux-3350-pre".to_string()),
+                    None,
+                    None,
+                    0,
+                );
+                row.turn_source = TurnSource::ExternalInput;
+                row.set_relay_owner_kind(RelayOwnerKind::Watcher);
+                row.injected_prompt_message_id = Some(tid);
+                save_inflight_state(&row).expect("persist synthetic watcher row");
+
+                // The watcher's exact production sequence: snapshot, clear, submit.
+                let snapshot = super::SyntheticClaimSnapshot::from_row(&row);
+                assert!(snapshot.turn_source_external && snapshot.relay_owner_watcher);
+                assert_eq!(snapshot.user_msg_id, tid);
+                assert_eq!(snapshot.injected_prompt_message_id, Some(tid));
+                crate::services::discord::inflight::clear_inflight_state(
+                    &ProviderKind::Claude,
+                    ch.get(),
+                );
+
+                begin_reaction_cleanup_recording();
+                let outcome = fin
+                    .submit_terminal_with_claim_snapshot(
+                        key,
+                        ProviderKind::Claude,
+                        TerminalEvent::Complete,
+                        FinalizeContext::watcher(),
+                        Some(snapshot),
+                        shared.clone(),
+                    )
+                    .await;
+                assert!(matches!(outcome, FinalizeOutcome::Finalized { .. }));
+
+                let markers = crate::services::discord::tui_direct_abort_marker::load_for_channel(
+                    "claude",
+                    ch.get(),
+                );
+                assert_eq!(
+                    markers.len(),
+                    1,
+                    "RED pre-r1-1: the row-reload ensure no-op'd on the precleared watcher path"
+                );
+                assert_eq!(markers[0].anchor_message_id, tid);
+                assert_eq!(markers[0].foreign_user_msg_id, Some(tid), "OWN pin (SC1)");
+                assert_eq!(
+                    markers[0].foreign_started_at.as_deref(),
+                    Some(row.started_at.as_str()),
+                    "the pin is the SUBMIT-TIME snapshot identity"
+                );
+                assert!(
+                    take_reaction_cleanup_records().is_empty(),
+                    "the ensure stays reaction-free (#3303 reconcilers own delivery)"
+                );
+
+                // Negative: a snapshot for a DIFFERENT turn (newer row captured
+                // by mistake) fails the row-is-this-turn gate — no marker.
+                let ch2 = ChannelId::new(3_350_300);
+                let key2 = TurnKey::new(ch2, 3_350_301, 0);
+                let mut foreign = snapshot_for_other_turn(&row, 3_350_999);
+                foreign.tmux_session_name = Some("tmux-3350-pre".to_string());
+                let outcome = fin
+                    .submit_terminal_with_claim_snapshot(
+                        key2,
+                        ProviderKind::Claude,
+                        TerminalEvent::Complete,
+                        FinalizeContext::watcher(),
+                        Some(foreign),
+                        shared.clone(),
+                    )
+                    .await;
+                assert!(matches!(outcome, FinalizeOutcome::Finalized { .. }));
+                assert!(
+                    crate::services::discord::tui_direct_abort_marker::load_for_channel(
+                        "claude",
+                        ch2.get(),
+                    )
+                    .is_empty(),
+                    "a mismatched snapshot must never pin a marker onto the submitted key"
+                );
+            });
+        });
+    }
+
+    /// Helper for the negative leg: the same row's snapshot re-pinned to a
+    /// different `user_msg_id` (what a buggy caller passing a newer row's
+    /// snapshot would produce).
+    fn snapshot_for_other_turn(
+        row: &crate::services::discord::inflight::InflightTurnState,
+        other_user_msg_id: u64,
+    ) -> super::SyntheticClaimSnapshot {
+        let mut snapshot = super::SyntheticClaimSnapshot::from_row(row);
+        snapshot.user_msg_id = other_user_msg_id;
+        snapshot.injected_prompt_message_id = Some(other_user_msg_id);
+        snapshot
     }
 
     #[test]

--- a/src/services/discord/turn_finalizer/cleanup.rs
+++ b/src/services/discord/turn_finalizer/cleanup.rs
@@ -55,6 +55,77 @@ pub(super) fn finalized_reaction_lifecycle(
     );
 }
 
+/// #3350 ②: pure verdict — must this finalize ENSURE the #3303 DeferredClaim
+/// marker for the row it is finalizing? (Same pure-gate pattern as the
+/// `should_complete_…` helpers.) All six gates must hold:
+///
+/// * the terminal carries a real identity AND the row IS that turn (an id-0
+///   orphan or a mismatched/newer row proves nothing about this anchor);
+/// * the row is a TUI-direct synthetic turn (`turn_source == ExternalInput`);
+/// * SC3: WATCHER-owned only — a bridge-owned turn finalizes Done with its own
+///   `⏳` cleanup (`turn_bridge`), so a marker would contradict that normal
+///   completion with a TTL `⚠`;
+/// * I4: `injected_prompt_message_id` pins the row's OWN anchor
+///   (`user_msg_id`), never a later injection's overwrite of the shared slot;
+/// * a tmux session is present (the marker's reconcile scope needs it).
+pub(super) fn should_ensure_synthetic_claim_marker(
+    key_user_msg_id: u64,
+    row_user_msg_id: u64,
+    row_turn_source_external: bool,
+    row_relay_owner_watcher: bool,
+    row_injected_prompt_message_id: Option<u64>,
+    row_tmux_session_present: bool,
+) -> bool {
+    key_user_msg_id != 0
+        && row_user_msg_id == key_user_msg_id
+        && row_turn_source_external
+        && row_relay_owner_watcher
+        && row_injected_prompt_message_id == Some(key_user_msg_id)
+        && row_tmux_session_present
+}
+
+/// #3350 ②: `do_finalize` entry hook — whatever submitter (watcher / bridge /
+/// monitor / backstop) finalizes a watcher-owned TUI-direct synthetic turn,
+/// guarantee the durable #3303 DeferredClaim marker exists for its anchor.
+/// Idempotent (an existing marker is NEVER touched) and reaction-free: the
+/// `⏳` verdict belongs exclusively to the #3303 reconcilers (drain `✅` /
+/// sweep TTL `⚠`), so output that commits late after a Stopped event never
+/// races a false-`⚠` here. Runs for Cancel too — a cancelled turn with no
+/// commit converging to the TTL `⚠` is the honest signal. Must run BEFORE the
+/// `do_finalize` (A) inflight clear: the row is the evidence.
+pub(super) fn ensure_synthetic_claim_marker_before_clear(key: TurnKey, provider: &ProviderKind) {
+    use crate::services::discord::inflight::{RelayOwnerKind, TurnSource};
+
+    if key.user_msg_id == 0 {
+        return;
+    }
+    let Some(row) =
+        crate::services::discord::inflight::load_inflight_state(provider, key.channel_id.get())
+    else {
+        return;
+    };
+    if !should_ensure_synthetic_claim_marker(
+        key.user_msg_id,
+        row.user_msg_id,
+        row.turn_source == TurnSource::ExternalInput,
+        row.relay_owner_kind == RelayOwnerKind::Watcher,
+        row.injected_prompt_message_id,
+        row.tmux_session_name.is_some(),
+    ) {
+        return;
+    }
+    let Some(tmux) = row.tmux_session_name.as_deref() else {
+        return;
+    };
+    let _ = crate::services::discord::tui_direct_abort_marker::ensure_marker_for_own_synthetic_turn(
+        provider.as_str(),
+        key.channel_id.get(),
+        key.user_msg_id,
+        tmux,
+        &row.started_at,
+    );
+}
+
 /// Late `AlreadyFinalized` losers still perform guarded active-state cleanup.
 /// This is intentionally narrower than `do_finalize`: only the same real turn id
 /// can lose mailbox/inflight state, so a newer active turn is preserved.
@@ -290,6 +361,177 @@ mod tests {
                 )
             })
             .collect()
+    }
+
+    /// #3350 ②: `should_ensure_synthetic_claim_marker` truth table — each of
+    /// the six gates flips the verdict alone (RED per gate), and the all-green
+    /// row ensures (the `should_complete_…` truth-table pattern).
+    #[test]
+    fn should_ensure_synthetic_claim_marker_truth_table() {
+        // GREEN: real identity + own row + ExternalInput + Watcher + own
+        // injected pin + tmux present.
+        assert!(should_ensure_synthetic_claim_marker(
+            77,
+            77,
+            true,
+            true,
+            Some(77),
+            true
+        ));
+        // RED: id-0 orphan terminal — no identity to authenticate against.
+        assert!(!should_ensure_synthetic_claim_marker(
+            0,
+            0,
+            true,
+            true,
+            Some(0),
+            true
+        ));
+        // RED: the row is a different (newer) turn than the terminal's key.
+        assert!(!should_ensure_synthetic_claim_marker(
+            77,
+            78,
+            true,
+            true,
+            Some(77),
+            true
+        ));
+        // RED: not a TUI-direct synthetic turn (Discord-origin / monitor row).
+        assert!(!should_ensure_synthetic_claim_marker(
+            77,
+            77,
+            false,
+            true,
+            Some(77),
+            true
+        ));
+        // RED (SC3): bridge-owned rows complete their own ⏳ via turn_bridge —
+        // a marker would contradict the normal completion with a TTL ⚠.
+        assert!(!should_ensure_synthetic_claim_marker(
+            77,
+            77,
+            true,
+            false,
+            Some(77),
+            true
+        ));
+        // RED (I4): the injected ⏳ slot pins a LATER injection, not this
+        // anchor — and an absent pin proves nothing.
+        assert!(!should_ensure_synthetic_claim_marker(
+            77,
+            77,
+            true,
+            true,
+            Some(78),
+            true
+        ));
+        assert!(!should_ensure_synthetic_claim_marker(
+            77, 77, true, true, None, true
+        ));
+        // RED: no tmux session — the marker's reconcile scope needs one.
+        assert!(!should_ensure_synthetic_claim_marker(
+            77,
+            77,
+            true,
+            true,
+            Some(77),
+            false
+        ));
+    }
+
+    /// #3350 ② integration: a terminal finalize over a watcher-owned
+    /// TUI-direct synthetic row ensures the durable DeferredClaim marker
+    /// pinned to the row's OWN identity — and sends NO reaction (delivery
+    /// belongs exclusively to the #3303 reconcilers, so late-committing
+    /// output after a Stopped event can never race a false-⚠ here). RED
+    /// pre-#3350: a turn claimed before the inline-claim record existed (or
+    /// whose record failed) finalized with no marker → eternal anchor ⏳.
+    #[test]
+    fn finalize_ensures_deferred_claim_marker_for_synthetic_watcher_row() {
+        use crate::services::discord::inflight::{
+            InflightTurnState, TurnSource, save_inflight_state,
+        };
+
+        with_isolated_runtime_root(|| {
+            test_rt().block_on(async {
+                let shared =
+                    super::super::super::make_shared_data_for_tests_with_storage(None, None);
+                let ch = ChannelId::new(3_350_100);
+                let tid = 3_350_101_u64;
+                shared
+                    .global_active
+                    .store(1, std::sync::atomic::Ordering::Relaxed);
+                let _token = seed_active_turn(&shared, ch, tid).await;
+                let fin = TurnFinalizer::spawn();
+                let key = TurnKey::new(ch, tid, 0);
+                fin.register_start(key, ProviderKind::Claude, RelayOwnerKind::Watcher, &shared);
+
+                // The watcher-owned TUI-direct synthetic row the finalize reads
+                // (the exact shape the inline claim persists).
+                let mut row = InflightTurnState::new(
+                    ProviderKind::Claude,
+                    ch.get(),
+                    None,
+                    0,
+                    tid,
+                    0,
+                    "/loop tick".to_string(),
+                    None,
+                    Some("tmux-3350".to_string()),
+                    None,
+                    None,
+                    0,
+                );
+                row.turn_source = TurnSource::ExternalInput;
+                row.set_relay_owner_kind(RelayOwnerKind::Watcher);
+                row.injected_prompt_message_id = Some(tid);
+                save_inflight_state(&row).expect("persist synthetic watcher row");
+
+                begin_reaction_cleanup_recording();
+                let outcome = fin
+                    .submit_terminal(
+                        key,
+                        ProviderKind::Claude,
+                        TerminalEvent::Complete,
+                        FinalizeContext::bridge(),
+                        shared.clone(),
+                    )
+                    .await;
+                assert!(matches!(outcome, FinalizeOutcome::Finalized { .. }));
+
+                let markers = crate::services::discord::tui_direct_abort_marker::load_for_channel(
+                    "claude",
+                    ch.get(),
+                );
+                assert_eq!(
+                    markers.len(),
+                    1,
+                    "RED pre-#3350: finalize left no marker — the anchor ⏳ of a \
+                     turn claimed before the inline record existed had no \
+                     reconcile owner"
+                );
+                let marker = &markers[0];
+                assert_eq!(
+                    marker.origin,
+                    crate::services::discord::tui_direct_abort_marker::MarkerOrigin::DeferredClaim
+                );
+                assert_eq!(marker.anchor_message_id, tid);
+                assert_eq!(
+                    marker.foreign_user_msg_id,
+                    Some(tid),
+                    "the pin is the row's OWN identity (SC1 — never a foreign turn)"
+                );
+                assert_eq!(
+                    marker.foreign_started_at.as_deref(),
+                    Some(row.started_at.as_str())
+                );
+                assert!(
+                    take_reaction_cleanup_records().is_empty(),
+                    "the ensure must never send reactions — delivery is owned by \
+                     the #3303 drain ✅ / sweep TTL ⚠ (I1: zero new reaction sites)"
+                );
+            });
+        });
     }
 
     #[test]


### PR DESCRIPTION
Closes #3350.

## 설계 (durable marker, 필터 아님)

reason: 사건 시나리오(attach 직후 Stopped, committed output 없음)의 anchor ⏳가 어떤 reconciler에게도 소유되지 않아 영구 잔존. reaction을 새로 쏘는 대신 #3303 DeferredClaim marker를 두 지점에서 보장해 기존 reconciler(드레인 ✅ / 스윕 TTL ⚠)가 bounded 수렴시키도록 한다.

- **① inline claim** (`tui_prompt_relay.rs` 857 else-분기): 성공한 INLINE synthetic claim 직후 deferred worker와 동일한 marker 기록. #3303 헬퍼를 `tui_direct_pending_start.rs::record_claim_marker_if_watcher_owned`로 일반화(본문 그대로 이동), worker 경로는 thin wrapper로 위임 — 기존 테스트 전부 GREEN 유지.
- **② finalize ensure** (`turn_finalizer.rs::do_finalize` 입구 → `cleanup.rs::ensure_synthetic_claim_marker_before_clear`): 어떤 submitter(watcher/bridge/monitor/backstop, Cancel 포함)로 finalize되든, (A) inflight clear가 row 증거를 지우기 **전에** marker 존재를 멱등 보장. 순수 6-게이트 판정 `should_ensure_synthetic_claim_marker` + `ensure_marker_for_own_synthetic_turn`(기존 marker 절대 미덮어쓰기 — covered_at 스탬프/TTL 시계 보존). 배포 전 claim된 잔존 턴의 forward-fix.
- **③ catch-up**: 의도적 미변경 — marker가 디스크 영속이고 sweeper가 재시작 후에도 돌므로 ①②로 대체.

## 불변식 준수 근거

- **I1 (add≡remove)**: 신규 reaction 호출 지점 **0개**. 전달은 전부 기존 marker 모듈 내부 `shared_reaction_applier`(⏳ add와 동일 bot identity 해상). 통합 테스트가 finalize 경로의 reaction 레코드 0건을 핀.
- **SC1 (own-identity pinning)**: ①② 모두 `(anchor_message_id, row.started_at)` own 핀만 기록 — foreign 핀 불가 → false-✅ 불가. 테스트로 핀.
- **SC3**: ①은 기존 lease 재조회 게이트 그대로, ②는 `relay_owner_kind == Watcher` 게이트 — bridge-소유 정상완료를 TTL ⚠로 모순시키지 않음 (진리표 RED + 비-watcher lease 테스트).
- **I4/I5/I6**: injected_prompt_message_id 본인-anchor 핀 게이트 / zero-anchor 거부(`SkippedZeroAnchor`) / 실패 전부 warn-only fail-open. ensure의 기존-marker 보존은 테스트 2(b)가 RED로 핀.
- **무회귀**: 정상 watcher 턴 = marker → chokepoint tombstone → drain 멱등 ✅ 후 delete(#3303 happy path 동일). 정상 bridge/Discord-기원 턴 = 게이트 제외, 행동 불변. `gate_backstop`/`finalized_reaction_lifecycle` 무변경 (기존 reconciler_backstop 테스트 GREEN 유지로 확인).

## 테스트 (전부 신규 + 기존 회귀)

1. `cleanup.rs`: `should_ensure_synthetic_claim_marker` 6게이트 진리표 (게이트별 RED + 전부충족 GREEN).
2. `deferred_claim.rs`: (a) 부재→Recorded·uncovered·own핀·DeferredClaim, (b) 기존 covered marker→AlreadyPresent+스탬프 불변(RED 가드), (c) own tombstone→Recorded{covered:true}→sweep이 (anchor, Complete) 전달, (d) anchor==0→SkippedZeroAnchor+파일 없음.
3. `tui_direct_pending_start.rs`: 일반화 헬퍼 — 비-watcher lease 미기록(SC3) / watcher lease+own row 기록(SC1 핀).
4. `cleanup.rs` 통합: ExternalInput·Watcher·injected-핀 row 시드 → `submit_terminal(bridge ctx, Complete)` → marker 파일 존재 + reaction 레코드 0건.
5. 사건 수렴(스윕 TTL ⚠)은 기존 `row_absence_before_ttl_keeps_waiting`이 이미 핀 (중복 작성 안 함).

## CI 게이트 (self-passed)

- `cargo fmt --check` 클린
- `cargo check --lib` / `--all-targets` 클린
- `cargo test --lib` **3271 passed; 0 failed** (전체 스위트)
- `python3 scripts/audit_maintainability.py --check` exit 0 — **baseline raise 없음**: ② 본체를 비동결 자식 `turn_finalizer/cleanup.rs`로 배치(#3352 전례), 동결 giant 2개의 삽입분은 같은 파일 장문 주석 압축으로 상쇄(34a942ff4 전례, 이슈 참조·근거 보존)
- `generate_inventory_docs.py` → `check_agent_maintenance_docs.py` "freshness check passed" + multinode-transition.md Audited touches에 #3350 worker-local 분류 추가

## 잔여 사항

- 이미 finalize까지 끝난 과거의 죽은 ⏳(예: 메시지 1514623434200580176)는 forward-fix라 자동 회수 안 됨 — 1회 수동 정리 필요.
- gate_backstop ✅ 후 스윕 TTL ⚠ 스택 가능성은 #3303 기존 수용 의미론(신규 회귀 아님) — 필요 시 별도 이슈로 marker discard 후속 권고.

🤖 Generated with [Claude Code](https://claude.com/claude-code)