### PR TITLE
refactor(#3038): run_bot S4 — move run_bot_build_shared_data into runtime_bootstrap/shared_data.rs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -472,6 +472,7 @@ src/
 │   │   │   ├── recovery_flush.rs
 │   │   │   ├── restored_state.rs
 │   │   │   ├── session_gc.rs
+│   │   │   ├── shared_data.rs
 │   │   │   ├── shutdown.rs
 │   │   │   ├── spawns.rs
 │   │   │   ├── startup_doctor.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -770,19 +770,21 @@
     `finalize_stale_streaming_footer` / `text_ends_with_streaming_footer` shared
     terminal-idle reconciliation helpers + their unit tests).
   - `src/services/discord/prompt_builder/` (directory, refactored).
-  - `src/services/discord/runtime_bootstrap.rs` (524 production lines after
-    #3038 run_bot S0/S3; characterization tests pin the startup-doctor barrier,
+  - `src/services/discord/runtime_bootstrap.rs` (369 production lines after
+    #3038 run_bot S0/S4; characterization tests pin the startup-doctor barrier,
     restored settings filters, queued-placeholder filtering/deletion, and
     gateway intents, then the low-risk clusters moved verbatim into
     `runtime_bootstrap/`: `restored_state.rs` (124), `queued_placeholders.rs`
     (193), `startup_doctor.rs` (156), `orphan_recovery.rs` (337),
     `session_gc.rs` (102 prod / 69 test), `framework_setup.rs` (287),
     `spawns.rs` (218), `recovery_flush.rs` (356), `voice.rs` (140),
-    `gateway_lease.rs` (187), `shutdown.rs` (203), and `intake.rs` (63).
+    `gateway_lease.rs` (187), `shutdown.rs` (203), `intake.rs` (63), and —
+    once the SharedData S1-S3 slices merged — `shared_data.rs` (176, the
+    `run_bot_build_shared_data` builder plus its side-effect-order doc).
     The namespace is capped at 700 prod lines per child module in
     `audit_maintainability_config.toml`; the root is no longer a prod giant and
-    was removed from `giant_file_registry.toml`, while S4
-    (`run_bot_build_shared_data`) stays gated on the SharedData slice).
+    was removed from `giant_file_registry.toml`; only the S5 accounting
+    cleanup slice remains).
   - `src/services/discord/session_runtime.rs` (1753 lines).
   - `src/services/discord/voice_barge_in.rs` (4657 lines; net +0 from #3034
     scoped dead-code allows on the test-only runtime API

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -4,7 +4,7 @@
 > moving any AgentDesk runtime, worker, dispatch, provider, MCP, merge, or test
 > execution path from one dcserver node to multiple nodes.
 >
-> Last refreshed: 2026-06-11 (against #3038 run_bot S2/S3 runtime_bootstrap directory split).
+> Last refreshed: 2026-06-12 (against #3038 run_bot S4 shared-data builder move).
 
 ## Read This First
 
@@ -383,6 +383,18 @@
 
 ### Audited touches
 
+- #3038 run_bot S4: `run_bot_build_shared_data` (and its side-effect-order
+  doc comment) moved verbatim from `runtime_bootstrap.rs` into
+  `runtime_bootstrap/shared_data.rs`, unblocked by the merged SharedData
+  S1-S3 slices. This is a **behavior-preserving module split**: the builder
+  body is token-identical apart from the documented `super::` →
+  `crate::services::discord::` path substitutions (8) and the `pub(super)`
+  visibility needed by the root re-import; the `run_bot` body, the builder's
+  side-effecting initializer order (`load_queue_exit_placeholder_clears` ↔
+  `load_generation` ↔ `TurnFinalizer::spawn` ↔ `StatusPanelController::spawn`
+  ↔ `broadcast::channel`), and the standby-before-lease call order are
+  unchanged. Worker-local module move only: no multinode ownership,
+  singleton, or lease assumption changes.
 - #3038 SharedData S3: `runtime_bootstrap.rs` gained restart-lifecycle
   characterization tests that pin the deferred-restart marker quick-exit path
   (`run_bot_spawn_deferred_restart_poller`) and the

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -119,7 +119,11 @@
 # #3038 run_bot S2/S3: lowered 1918 -> 524 by moving framework_setup,
 # spawns, recovery_flush, voice, gateway_lease, shutdown, and intake into
 # sub-700 `runtime_bootstrap/` modules. S4 shared-data builder remains gated.
-"src/services/discord/runtime_bootstrap.rs" = 524
+# #3038 run_bot S4: lowered 524 -> 369 by moving `run_bot_build_shared_data`
+# into `runtime_bootstrap/shared_data.rs` (gated on the SharedData S1-S3
+# slices, now merged). The root keeps only RunBotContext + run_bot +
+# mod/re-export plumbing; final registry/baseline cleanup is the S5 slice.
+"src/services/discord/runtime_bootstrap.rs" = 369
 # #3034 batch-8: lowered 2655 -> 2645 (dead-code removal: `stop_provider_channel_runtime`).
 # #3293: lowered 2645 -> 2641 (mailbox probe routed through the non-creating
 # `health/mailbox.rs::peeked_provider_mailbox_state`).

--- a/src/services/discord/runtime_bootstrap.rs
+++ b/src/services/discord/runtime_bootstrap.rs
@@ -8,6 +8,7 @@ mod queued_placeholders;
 mod recovery_flush;
 mod restored_state;
 mod session_gc;
+mod shared_data;
 mod shutdown;
 mod spawns;
 mod startup_doctor;
@@ -24,6 +25,7 @@ pub(in crate::services::discord) use self::queued_placeholders::{
     delete_stale_queued_placeholder_cards, delete_stale_queued_placeholder_cards_with,
     filter_restored_queued_placeholders,
 };
+use self::shared_data::run_bot_build_shared_data;
 use self::shutdown::{run_bot_run_gateway_backend, run_bot_spawn_sigterm_handler};
 #[cfg(test)]
 use self::voice::voice_auto_join_provider_map;
@@ -363,180 +365,6 @@ pub(crate) async fn run_bot(token: &str, provider: ProviderKind, context: RunBot
 // each helper runs the exact statements it replaced, in the same order,
 // and run_bot calls them in the same order with the same threaded state.
 // INITIALIZATION/SPAWN ORDER IS LOAD-BEARING — do not reorder. ──
-
-/// Build all owned `SharedData` fields and wrap in an `Arc`. Side-effecting
-/// initializers (`TurnFinalizer::spawn`, `StatusPanelController::spawn`,
-/// `runtime_store::load_generation`, `load_queue_exit_placeholder_clears`,
-/// the `inflight_signals` broadcast channel) run here in the exact same order
-/// as the original inline struct literal. `bot_settings`, `initial_skills`,
-/// `global_active`, `global_finalizing`, `pg_pool`, and `engine` are consumed
-/// by move; the `restored_*` slices are borrowed (they are reused later in
-/// run_bot for logging and session-reset bootstrap).
-#[allow(clippy::too_many_arguments)]
-fn run_bot_build_shared_data(
-    bot_settings: DiscordBotSettings,
-    initial_skills: Vec<(String, String)>,
-    provider: &ProviderKind,
-    token_hash: &str,
-    voice_barge_in: &Arc<voice_barge_in::VoiceBargeInRuntime>,
-    global_active: Arc<std::sync::atomic::AtomicUsize>,
-    global_finalizing: Arc<std::sync::atomic::AtomicUsize>,
-    shutdown_remaining: &Arc<std::sync::atomic::AtomicUsize>,
-    health_registry: &Arc<health::HealthRegistry>,
-    pg_pool: Option<sqlx::PgPool>,
-    engine: Option<crate::engine::PolicyEngine>,
-    api_port: u16,
-    placeholder_live_events_enabled: bool,
-    status_panel_v2_enabled: bool,
-    restored_model_overrides: &[(ChannelId, String)],
-    restored_fast_mode_channels: &[ChannelId],
-    restored_fast_mode_reset_entries: &[String],
-    restored_fast_mode_reset_channels: &[ChannelId],
-    restored_codex_goals_channels: &[ChannelId],
-    restored_codex_goals_reset_channels: &[ChannelId],
-) -> Arc<SharedData> {
-    Arc::new(SharedData {
-        core: Mutex::new(CoreState {
-            sessions: HashMap::new(),
-            active_meetings: HashMap::new(),
-        }),
-        mailboxes: ChannelMailboxRegistry::default(),
-        settings: tokio::sync::RwLock::new(bot_settings),
-        api_timestamps: dashmap::DashMap::new(),
-        skills_cache: tokio::sync::RwLock::new(initial_skills),
-        tmux_watchers: super::TmuxWatcherRegistry::new(),
-        tmux_relay_coords: dashmap::DashMap::new(),
-        placeholder_cleanup: Arc::new(
-            super::placeholder_cleanup::PlaceholderCleanupRegistry::default(),
-        ),
-        placeholder_controller: Arc::new(
-            super::placeholder_controller::PlaceholderController::default(),
-        ),
-        placeholder_live_events: Arc::new(
-            super::placeholder_live_events::PlaceholderLiveEvents::default(),
-        ),
-        placeholder_live_events_enabled,
-        status_panel_v2_enabled,
-        // #3038 S1: wrapped verbatim at the first-member position (evaluation-order preserved).
-        queued: QueuedPlaceholderState {
-            queued_placeholders: dashmap::DashMap::new(),
-            queue_exit_placeholder_clears: {
-                let map = dashmap::DashMap::new();
-                for (key, placeholder_msg_id) in
-                    super::queued_placeholders_store::load_queue_exit_placeholder_clears(
-                        provider, token_hash,
-                    )
-                {
-                    map.insert(key, placeholder_msg_id);
-                }
-                map
-            },
-            queued_placeholders_persist_locks: dashmap::DashMap::new(),
-        },
-        answer_flush_barrier: std::sync::Arc::new(
-            super::answer_flush_barrier::AnswerFlushBarrier::default(),
-        ),
-        // #3038 S3: wrapped at the first-member position with member
-        // expressions byte-identical. The three trailing members
-        // (`global_finalizing` / `shutdown_remaining` / `shutdown_counted`)
-        // move textually above the TurnFinalizer/StatusPanelController spawn
-        // calls, but all three are side-effect-free initializers (parameter
-        // move, `Arc::clone`, const constructor), so the relative order of
-        // every side-effecting initializer
-        // (`load_queue_exit_placeholder_clears` ↔ `load_generation` ↔
-        // `Instant::now` ↔ `TurnFinalizer::spawn` ↔
-        // `StatusPanelController::spawn` ↔ `broadcast::channel`) is
-        // preserved.
-        restart: RestartLifecycle {
-            recovering_channels: dashmap::DashMap::new(),
-            shutting_down: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            finalizing_turns: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            current_generation: runtime_store::load_generation(),
-            restart_pending: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            reconcile_done: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            deferred_hook_backlog: std::sync::atomic::AtomicUsize::new(0),
-            recovery_started_at: std::time::Instant::now(),
-            recovery_duration_ms: std::sync::atomic::AtomicU64::new(0),
-            global_active,
-            global_finalizing,
-            shutdown_remaining: shutdown_remaining.clone(),
-            shutdown_counted: std::sync::atomic::AtomicBool::new(false),
-        },
-        turn_finalizer: super::turn_finalizer::TurnFinalizer::spawn(),
-        status_panel_controller: super::status_panel_controller::StatusPanelController::spawn(
-            status_panel_v2_enabled,
-        ),
-        intake_dedup: dashmap::DashMap::new(),
-        dispatch_thread_parents: dashmap::DashMap::new(),
-        bot_connected: std::sync::atomic::AtomicBool::new(false),
-        last_turn_at: std::sync::Mutex::new(None),
-        // #3038 S2: wrapped verbatim at the first-member position (evaluation-order preserved).
-        overrides: SessionOverrideState {
-            model_overrides: {
-                let map = dashmap::DashMap::new();
-                for (channel_id, model) in restored_model_overrides {
-                    map.insert(*channel_id, model.clone());
-                }
-                map
-            },
-            fast_mode_channels: {
-                let set = dashmap::DashSet::new();
-                for channel_id in restored_fast_mode_channels {
-                    set.insert(*channel_id);
-                }
-                set
-            },
-            fast_mode_session_reset_pending: {
-                let set = dashmap::DashSet::new();
-                for entry in restored_fast_mode_reset_entries {
-                    set.insert(entry.clone());
-                }
-                set
-            },
-            codex_goals_channels: {
-                let set = dashmap::DashSet::new();
-                for channel_id in restored_codex_goals_channels {
-                    set.insert(*channel_id);
-                }
-                set
-            },
-            codex_goals_session_reset_pending: {
-                let set = dashmap::DashSet::new();
-                for channel_id in restored_codex_goals_reset_channels {
-                    set.insert(*channel_id);
-                }
-                set
-            },
-            model_session_reset_pending: dashmap::DashSet::new(),
-            session_reset_pending: bootstrap_session_reset_pending_channels(
-                restored_model_overrides,
-                restored_fast_mode_reset_channels,
-                restored_codex_goals_reset_channels,
-            ),
-            model_picker_pending: dashmap::DashMap::new(),
-        },
-        dispatch_role_overrides: dashmap::DashMap::new(),
-        voice_barge_in: voice_barge_in.clone(),
-        voice_pairings: Arc::new(voice_routing::VoiceChannelPairingStore::load_default()),
-        last_message_ids: dashmap::DashMap::new(),
-        catch_up_retry_pending: dashmap::DashMap::new(),
-        turn_start_times: dashmap::DashMap::new(),
-        channel_rosters: dashmap::DashMap::new(),
-        cached_serenity_ctx: tokio::sync::OnceCell::new(),
-        cached_bot_token: tokio::sync::OnceCell::new(),
-        token_hash: token_hash.to_string(),
-        provider: provider.clone(),
-        api_port,
-        pg_pool,
-        engine,
-        health_registry: Arc::downgrade(health_registry),
-        known_slash_commands: tokio::sync::OnceCell::new(),
-        // #2448: capacity 256 gives ~hundreds of in-flight turns headroom
-        // before a slow listener triggers `RecvError::Lagged`. The standby
-        // relay subscriber falls back to file polling on lag.
-        inflight_signals: tokio::sync::broadcast::channel(256).0,
-    })
-}
 
 #[cfg(test)]
 mod bootstrap_tests {

--- a/src/services/discord/runtime_bootstrap/shared_data.rs
+++ b/src/services/discord/runtime_bootstrap/shared_data.rs
@@ -1,0 +1,176 @@
+use super::*;
+
+/// Build all owned `SharedData` fields and wrap in an `Arc`. Side-effecting
+/// initializers (`TurnFinalizer::spawn`, `StatusPanelController::spawn`,
+/// `runtime_store::load_generation`, `load_queue_exit_placeholder_clears`,
+/// the `inflight_signals` broadcast channel) run here in the exact same order
+/// as the original inline struct literal. `bot_settings`, `initial_skills`,
+/// `global_active`, `global_finalizing`, `pg_pool`, and `engine` are consumed
+/// by move; the `restored_*` slices are borrowed (they are reused later in
+/// run_bot for logging and session-reset bootstrap).
+#[allow(clippy::too_many_arguments)]
+pub(super) fn run_bot_build_shared_data(
+    bot_settings: DiscordBotSettings,
+    initial_skills: Vec<(String, String)>,
+    provider: &ProviderKind,
+    token_hash: &str,
+    voice_barge_in: &Arc<voice_barge_in::VoiceBargeInRuntime>,
+    global_active: Arc<std::sync::atomic::AtomicUsize>,
+    global_finalizing: Arc<std::sync::atomic::AtomicUsize>,
+    shutdown_remaining: &Arc<std::sync::atomic::AtomicUsize>,
+    health_registry: &Arc<health::HealthRegistry>,
+    pg_pool: Option<sqlx::PgPool>,
+    engine: Option<crate::engine::PolicyEngine>,
+    api_port: u16,
+    placeholder_live_events_enabled: bool,
+    status_panel_v2_enabled: bool,
+    restored_model_overrides: &[(ChannelId, String)],
+    restored_fast_mode_channels: &[ChannelId],
+    restored_fast_mode_reset_entries: &[String],
+    restored_fast_mode_reset_channels: &[ChannelId],
+    restored_codex_goals_channels: &[ChannelId],
+    restored_codex_goals_reset_channels: &[ChannelId],
+) -> Arc<SharedData> {
+    Arc::new(SharedData {
+        core: Mutex::new(CoreState {
+            sessions: HashMap::new(),
+            active_meetings: HashMap::new(),
+        }),
+        mailboxes: ChannelMailboxRegistry::default(),
+        settings: tokio::sync::RwLock::new(bot_settings),
+        api_timestamps: dashmap::DashMap::new(),
+        skills_cache: tokio::sync::RwLock::new(initial_skills),
+        tmux_watchers: crate::services::discord::TmuxWatcherRegistry::new(),
+        tmux_relay_coords: dashmap::DashMap::new(),
+        placeholder_cleanup: Arc::new(
+            crate::services::discord::placeholder_cleanup::PlaceholderCleanupRegistry::default(),
+        ),
+        placeholder_controller: Arc::new(
+            crate::services::discord::placeholder_controller::PlaceholderController::default(),
+        ),
+        placeholder_live_events: Arc::new(
+            crate::services::discord::placeholder_live_events::PlaceholderLiveEvents::default(),
+        ),
+        placeholder_live_events_enabled,
+        status_panel_v2_enabled,
+        // #3038 S1: wrapped verbatim at the first-member position (evaluation-order preserved).
+        queued: QueuedPlaceholderState {
+            queued_placeholders: dashmap::DashMap::new(),
+            queue_exit_placeholder_clears: {
+                let map = dashmap::DashMap::new();
+                for (key, placeholder_msg_id) in
+                    crate::services::discord::queued_placeholders_store::load_queue_exit_placeholder_clears(
+                        provider, token_hash,
+                    )
+                {
+                    map.insert(key, placeholder_msg_id);
+                }
+                map
+            },
+            queued_placeholders_persist_locks: dashmap::DashMap::new(),
+        },
+        answer_flush_barrier: std::sync::Arc::new(
+            crate::services::discord::answer_flush_barrier::AnswerFlushBarrier::default(),
+        ),
+        // #3038 S3: wrapped at the first-member position with member
+        // expressions byte-identical. The three trailing members
+        // (`global_finalizing` / `shutdown_remaining` / `shutdown_counted`)
+        // move textually above the TurnFinalizer/StatusPanelController spawn
+        // calls, but all three are side-effect-free initializers (parameter
+        // move, `Arc::clone`, const constructor), so the relative order of
+        // every side-effecting initializer
+        // (`load_queue_exit_placeholder_clears` ↔ `load_generation` ↔
+        // `Instant::now` ↔ `TurnFinalizer::spawn` ↔
+        // `StatusPanelController::spawn` ↔ `broadcast::channel`) is
+        // preserved.
+        restart: RestartLifecycle {
+            recovering_channels: dashmap::DashMap::new(),
+            shutting_down: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            finalizing_turns: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            current_generation: runtime_store::load_generation(),
+            restart_pending: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            reconcile_done: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            deferred_hook_backlog: std::sync::atomic::AtomicUsize::new(0),
+            recovery_started_at: std::time::Instant::now(),
+            recovery_duration_ms: std::sync::atomic::AtomicU64::new(0),
+            global_active,
+            global_finalizing,
+            shutdown_remaining: shutdown_remaining.clone(),
+            shutdown_counted: std::sync::atomic::AtomicBool::new(false),
+        },
+        turn_finalizer: crate::services::discord::turn_finalizer::TurnFinalizer::spawn(),
+        status_panel_controller:
+            crate::services::discord::status_panel_controller::StatusPanelController::spawn(
+                status_panel_v2_enabled,
+            ),
+        intake_dedup: dashmap::DashMap::new(),
+        dispatch_thread_parents: dashmap::DashMap::new(),
+        bot_connected: std::sync::atomic::AtomicBool::new(false),
+        last_turn_at: std::sync::Mutex::new(None),
+        // #3038 S2: wrapped verbatim at the first-member position (evaluation-order preserved).
+        overrides: SessionOverrideState {
+            model_overrides: {
+                let map = dashmap::DashMap::new();
+                for (channel_id, model) in restored_model_overrides {
+                    map.insert(*channel_id, model.clone());
+                }
+                map
+            },
+            fast_mode_channels: {
+                let set = dashmap::DashSet::new();
+                for channel_id in restored_fast_mode_channels {
+                    set.insert(*channel_id);
+                }
+                set
+            },
+            fast_mode_session_reset_pending: {
+                let set = dashmap::DashSet::new();
+                for entry in restored_fast_mode_reset_entries {
+                    set.insert(entry.clone());
+                }
+                set
+            },
+            codex_goals_channels: {
+                let set = dashmap::DashSet::new();
+                for channel_id in restored_codex_goals_channels {
+                    set.insert(*channel_id);
+                }
+                set
+            },
+            codex_goals_session_reset_pending: {
+                let set = dashmap::DashSet::new();
+                for channel_id in restored_codex_goals_reset_channels {
+                    set.insert(*channel_id);
+                }
+                set
+            },
+            model_session_reset_pending: dashmap::DashSet::new(),
+            session_reset_pending: bootstrap_session_reset_pending_channels(
+                restored_model_overrides,
+                restored_fast_mode_reset_channels,
+                restored_codex_goals_reset_channels,
+            ),
+            model_picker_pending: dashmap::DashMap::new(),
+        },
+        dispatch_role_overrides: dashmap::DashMap::new(),
+        voice_barge_in: voice_barge_in.clone(),
+        voice_pairings: Arc::new(voice_routing::VoiceChannelPairingStore::load_default()),
+        last_message_ids: dashmap::DashMap::new(),
+        catch_up_retry_pending: dashmap::DashMap::new(),
+        turn_start_times: dashmap::DashMap::new(),
+        channel_rosters: dashmap::DashMap::new(),
+        cached_serenity_ctx: tokio::sync::OnceCell::new(),
+        cached_bot_token: tokio::sync::OnceCell::new(),
+        token_hash: token_hash.to_string(),
+        provider: provider.clone(),
+        api_port,
+        pg_pool,
+        engine,
+        health_registry: Arc::downgrade(health_registry),
+        known_slash_commands: tokio::sync::OnceCell::new(),
+        // #2448: capacity 256 gives ~hundreds of in-flight turns headroom
+        // before a slow listener triggers `RecvError::Lagged`. The standby
+        // relay subscriber falls back to file polling on lag.
+        inflight_signals: tokio::sync::broadcast::channel(256).0,
+    })
+}


### PR DESCRIPTION
## 요약 (#3038 run_bot S4, HANDOFF-3038-designs-20260610 설계 레시피)

SharedData S1~S3 슬라이스(#3301/#3354/#3355) 머지로 외부 게이트가 해제되어, run_bot 분해의 마지막 이동 슬라이스 S4를 실행한다: `run_bot_build_shared_data`(파라미터 20개, ~164 raw)와 그 부수효과-순서 doc 주석을 `runtime_bootstrap.rs` 루트에서 `runtime_bootstrap/shared_data.rs` 서브모듈로 **verbatim 이동**.

- `run_bot` 본문 0줄 수정, `mod.rs` 0줄 수정, `cli/dcserver.rs` 비접촉 — 외부 표면 동결 유지.
- 루트 변경은 `mod shared_data;` 선언 + `use self::shared_data::run_bot_build_shared_data;` 재수입 2줄뿐 (기존 S1~S3 인프라 패턴 그대로).
- `bootstrap_tests` / `restart_lifecycle_characterization_tests`는 루트 잔존, **단 한 줄도 수정 없이** 그대로 통과 (루트 private 재수입 경유) — 행동 동등성 증명.

## 본문 수정 회계 (설계 허용 3종 중 ① 경로 치환 + 가시성, 건별 전수 목록)

이동 본문은 아래 항목 외 토큰 변경 0 (기계 검증: 치환 역적용 후 토큰 스트림 일치 확인 — WORD-DIFF OK):

| # | 종류 | 내용 |
|---|------|------|
| 1 | 경로 ① | `super::TmuxWatcherRegistry` → `crate::services::discord::TmuxWatcherRegistry` |
| 2 | 경로 ① | `super::placeholder_cleanup::…` → `crate::services::discord::placeholder_cleanup::…` |
| 3 | 경로 ① | `super::placeholder_controller::…` → `crate::services::discord::placeholder_controller::…` |
| 4 | 경로 ① | `super::placeholder_live_events::…` → `crate::services::discord::placeholder_live_events::…` |
| 5 | 경로 ① | `super::queued_placeholders_store::load_queue_exit_placeholder_clears` → `crate::services::discord::queued_placeholders_store::…` |
| 6 | 경로 ① | `super::answer_flush_barrier::…` → `crate::services::discord::answer_flush_barrier::…` |
| 7 | 경로 ① | `super::turn_finalizer::TurnFinalizer::spawn()` → `crate::services::discord::turn_finalizer::TurnFinalizer::spawn()` |
| 8 | 경로 ① | `super::status_panel_controller::StatusPanelController::spawn` → `crate::services::discord::status_panel_controller::…` (치환으로 100자 초과 → rustfmt가 해당 initializer 1건만 줄바꿈 재배치; 토큰 불변) |
| 9 | 가시성 | `fn` → `pub(super) fn` (루트 재수입용; S1~S3 서브모듈과 동일 규약) |

신규 클론 0, 시그니처/파라미터 순서/본문 시퀀스 불변.

## 불변식 점검

- **[표면 동결]** `mod.rs:168-169`의 `pub(crate) use runtime_bootstrap::{RunBotContext, run_bot}` 경로 그대로 리졸브 (mod.rs 무수정).
- **[부수효과 순서]** builder 내 side-effecting initializer 순서(`load_queue_exit_placeholder_clears` ↔ `load_generation` ↔ `Instant::now` ↔ `TurnFinalizer::spawn` ↔ `StatusPanelController::spawn` ↔ `broadcast::channel`) byte-identical — 함수 통째 이동이라 비접촉.
- **[순서 계약 #2007/#2009]** run_bot 내 호출문(`internal_api::init` → builder → `tui_prompt_relay` spawn → `cached_bot_token.set` → voice → intake → lease 체크) 무수정.
- **[relay 비간섭]** `restore_tmux_watchers`(recovery_flush.rs) / `mailbox_restart_drain_all`(spawns/gateway_lease/shutdown) 호출부 비접촉 파일; `TurnFinalizer::spawn` 호출부는 이동 본문 내 — 위 표 7번 경로 치환 1건 외 byte-identical.
- **[락 규율]** 락 보유 .await 신규 도입 0 (이동 본문에 락 없음).
- **[회계 단조성]** giant baseline 524 → 369 인하 잠금(실측), `shared_data.rs` 176 prod LoC < namespace cap 700, 신규 ≥1000 registry 엔트리 0. S5(마감 회계)는 후속 슬라이스.

## 검증

- `cargo fmt --check` ✅
- `cargo check --lib` ✅ (Finished dev profile)
- `cargo clippy --lib` ✅ 신규 warning 0
- `cargo test --lib runtime_bootstrap` ✅ 13 passed (bootstrap_tests + thread_session_gc_tests + restart_lifecycle_characterization_tests, 무수정 통과)
- `cargo test --lib discord` ✅ 1509 passed; 0 failed
- `python3 scripts/audit_maintainability.py --check` ✅ exit 0
- `python3 -m unittest tests.test_audit_maintainability tests.test_inventory_giant_split` → 76개 중 75 passed; 1 실패는 **origin/main 클린 상태에서도 동일 실패하는 선재 결함** (`test_auto_queue_monitor_notification_source_is_allowed`가 #3295 Phase A에서 `health/send_gate.rs`로 이동한 `"auto-queue"`를 여전히 `health.rs`에서 찾음 — 본 PR 범위 밖, 별도 수정 권고)
- `python3 scripts/generate_inventory_docs.py` → `python3 scripts/check_agent_maintenance_docs.py` ✅ passed (커밋 후 HEAD 기준; multinode-transition "### Audited touches"에 #3038 S4 worker-local 항목 동반)
- word-diff 게이트 ✅ 치환 역적용 후 이동 본문 토큰 스트림 원본과 일치

🤖 Generated with [Claude Code](https://claude.com/claude-code)