### PR TITLE
fix(#3361): require positive liveness evidence before stall-watchdog forced cleanup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -406,7 +406,8 @@ src/
 │   │   │   ├── send_gate.rs
 │   │   │   ├── send_target.rs
 │   │   │   ├── session_enrichment.rs
-│   │   │   └── snapshot.rs
+│   │   │   ├── snapshot.rs
+│   │   │   └── stall_liveness.rs
 │   │   ├── inflight/
 │   │   │   └── budget.rs
 │   │   ├── outbound/

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -687,16 +687,17 @@
     `recovery_paths/restart.rs::dispose_recovery_relay_outcome` (permanent
     Discord 404/403/410 force-clear + 3-restart transient budget); the pure
     decision matrix lives in `recovery_paths/shared.rs`).
-  - `src/services/discord/health.rs` (402 prod lines after the #3038 Phase A
+  - `src/services/discord/health.rs` (417 prod lines after the #3038 Phase A
     directory decomposition; module root keeps the `HealthRegistry` core +
-    re-export surface, and the former monolith body lives in seven flat
+    re-export surface, and the former monolith body lives in flat
     `health/` submodules, all sub-1000 prod LoC: `runtime_resolve.rs` (321),
     `headless_turn.rs` (297), `send_target.rs` (150), `send_gate.rs` (374),
     `manual_delivery.rs` (580), `send_api.rs` (259), `relay_auto_heal.rs`
-    (123). Previously 2240 after the #3034 dead-code sweep, 2292 after
+    (123), `stall_liveness.rs` (527). Previously 2240 after the #3034
+    dead-code sweep, 2292 after
     #3038 send-to-agent dispatch extraction to `outbound/send_to_agent.rs`,
     #1879 snapshot/mailbox extraction, and #3082 answer-flush-barrier field).
-  - `src/services/discord/health/recovery.rs` (2637 lines; health recovery
+  - `src/services/discord/health/recovery.rs` (2615 lines; health recovery
     extraction surface, split further before adding non-bugfix behavior; +70
     from #3126 stall-watchdog completed-idle false-positive guard tests; +88
     from #3169 stall-watchdog jsonl-mtime liveness guard + tests, closing the
@@ -705,7 +706,8 @@
     `health/mailbox.rs::peeked_provider_mailbox_state` so repair probes stop
     minting permanent registry entries for non-existent channels; -4 from
     #3360 moving orphan pending-token auto-heal out to
-    `health/relay_auto_heal.rs`).
+    `health/relay_auto_heal.rs`; #3361 moved positive stall-watchdog liveness
+    guard state/logging to `health/stall_liveness.rs`).
   - `src/services/discord/router/message_handler/intake_turn.rs` (3771 lines;
     Discord message intake turn orchestration split from the router message
     handler; bugfix only outside a further extraction plan; +9 from #3082

--- a/src/services/discord/health.rs
+++ b/src/services/discord/health.rs
@@ -30,6 +30,7 @@ mod send_gate;
 mod send_target;
 mod session_enrichment;
 mod snapshot;
+mod stall_liveness;
 
 // `HeadlessAgentTurnReservation` has no external referent today (callers
 // destructure the reserve/start tuple); kept re-exported for the reserve→start

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -1511,6 +1511,9 @@ pub(crate) async fn run_stall_watchdog_pass(
     registry: &HealthRegistry,
     provider: &ProviderKind,
 ) -> usize {
+    let now_unix_secs = chrono::Utc::now().timestamp();
+    stall_liveness::gc_stall_watchdog_liveness_state(now_unix_secs);
+
     // Multi-bot deployments register several runtimes under one provider
     // name. Sweep *every* runtime's watcher channels (a name-only lookup
     // would only ever visit the first-registered runtime, so the second
@@ -1544,7 +1547,6 @@ pub(crate) async fn run_stall_watchdog_pass(
         return relay_auto_heal::run_orphan_token_auto_heal_pass(registry, provider, &runtimes)
             .await;
     }
-    let now_unix_secs = chrono::Utc::now().timestamp();
     let mut cleaned = 0usize;
     for (channel_id, shared) in candidate_channels {
         // Use the already-selected runtime. A provider-name scan can be
@@ -1710,10 +1712,8 @@ pub(crate) async fn run_stall_watchdog_pass(
             }
             liveness_decision = Some(decision);
         } else {
-            stall_liveness::clear_stall_watchdog_liveness_deferral(
-                provider,
-                channel_id,
-                snapshot.tmux_session.as_deref(),
+            stall_liveness::clear_stall_watchdog_liveness_state_if_healthy(
+                provider, channel_id, &snapshot,
             );
         }
         if !should_clean {

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -11,7 +11,7 @@ use crate::services::discord::{self as discord, SharedData};
 use crate::services::provider::{CancelToken, ProviderKind};
 
 use super::HealthRegistry;
-use super::relay_auto_heal;
+use super::{relay_auto_heal, stall_liveness};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct RuntimeTurnStopResult {
@@ -1347,50 +1347,6 @@ pub(crate) fn stall_watchdog_should_force_clean(
     age_secs >= 0 && (age_secs as u64) >= threshold_secs
 }
 
-/// #3169 Death #1 (stall-watchdog false-positive): a self-paced `ScheduleWakeup`
-/// loop session that just posted a PR is a *healthy completed* state, yet its
-/// loop turns carry `user_msg_id == 0` and so never get
-/// `terminal_delivery_committed` marked (`tmux_watcher.rs` commit guard). That
-/// defeats the #3126 committed-turn guard and, once a ready-for-input TUI
-/// capture races past the relay offset (`capture_lagged` desync, #2965), the row
-/// reads `attached + desynced + uncommitted + stale` — the exact force-clean
-/// signature — and the watchdog destroys a perfectly healthy session
-/// (worktree/conversation reset, real loss).
-///
-/// This is the second-layer guard: before force-cleaning a desynced channel we
-/// probe the same runtime-activity signal idle-kill (#3053) uses — the session
-/// jsonl / `.generation` marker mtime (`latest_runtime_activity_unix_nanos`).
-/// A loop that is mid-write keeps touching its jsonl even while the inflight
-/// relay row looks stale, so a write inside `freshness_threshold_secs` means the
-/// "desync" is a loop mid-write, not a hang → defer the force-clean.
-///
-/// A genuinely hung turn writes no provider events: its jsonl stays stale past
-/// the window, the probe does NOT defer, and the force-clean still fires. The
-/// window is anchored at the force-clean threshold so a marginal real hang (last
-/// partial write a few seconds after the relay froze) is at worst deferred a
-/// single watchdog pass before it is cleaned — never blanket-suppressed.
-///
-/// Returns `true` to DEFER (skip) the force-clean for this pass.
-pub(crate) fn stall_watchdog_jsonl_liveness_defers_force_clean(
-    latest_runtime_activity_unix_nanos: i64,
-    now_unix_secs: i64,
-    freshness_threshold_secs: u64,
-) -> bool {
-    // No observable jsonl/generation activity → cannot vouch for liveness; let
-    // the force-clean proceed (this is the genuine-hang / dead-session case).
-    if latest_runtime_activity_unix_nanos <= 0 {
-        return false;
-    }
-    let now_nanos = now_unix_secs.saturating_mul(1_000_000_000);
-    // A write at/after "now" (clock skew, just-touched) is unambiguously fresh.
-    if latest_runtime_activity_unix_nanos >= now_nanos {
-        return true;
-    }
-    let age_nanos = now_nanos.saturating_sub(latest_runtime_activity_unix_nanos);
-    let age_secs = age_nanos / 1_000_000_000;
-    (age_secs as u64) < freshness_threshold_secs
-}
-
 /// Detection-only counterpart to `stall_watchdog_should_force_clean`:
 /// returns `true` for the "completed-stale inflight on a healthy watcher"
 /// pattern that the deadlock-manager 30-min alarms keep flagging. All five
@@ -1618,7 +1574,7 @@ pub(crate) async fn run_stall_watchdog_pass(
             // #3169: same loop-mid-write liveness guard as the desynced force-
             // clean below — a freshly-written jsonl means this idle-foreground
             // anchor is a live loop turn, not a stranded one, so do not clear it.
-            && !stall_watchdog_jsonl_liveness_defers_force_clean(
+            && !stall_liveness::stall_watchdog_jsonl_liveness_defers_force_clean(
                 crate::services::dispatched_sessions::latest_runtime_activity_unix_nanos(
                     &tmux_session,
                 ),
@@ -1721,31 +1677,44 @@ pub(crate) async fn run_stall_watchdog_pass(
             STALL_WATCHDOG_THRESHOLD_SECS,
             registry.started_at_unix(),
         );
-        // #3169 Death #1: before the destructive desynced force-clean, probe the
-        // session's jsonl/.generation mtime (the same liveness signal idle-kill
-        // #3053 uses). A self-paced loop session that just posted a PR is mid-
-        // write — its loop turns carry user_msg_id==0 so the #3126 committed-turn
-        // guard never engages, and a capture_lagged (#2965) desync makes a
-        // healthy completed session read exactly like a hang. A fresh jsonl write
-        // means "loop mid-write != hang" → defer the force-clean this pass. A
-        // genuine hang writes no events, stays stale, and is still cleaned.
-        if should_clean
-            && let Some(tmux_session) = snapshot.tmux_session.as_deref()
-            && stall_watchdog_jsonl_liveness_defers_force_clean(
-                crate::services::dispatched_sessions::latest_runtime_activity_unix_nanos(
-                    tmux_session,
-                ),
-                now_unix_secs,
-                STALL_WATCHDOG_LIVENESS_FRESHNESS_SECS,
-            )
-        {
-            let ts = chrono::Local::now().format("%H:%M:%S");
-            tracing::info!(
-                "  [{ts}] 🌱 STALL-WATCHDOG: deferring force-clean for desynced channel {} (provider={}) — session jsonl freshly written (loop mid-write != hang, #3169)",
+        let judgment_basis = stall_liveness::StallWatchdogJudgmentBasis::from_snapshot(
+            &snapshot,
+            now_unix_secs,
+            registry.started_at_unix(),
+        );
+        let mut force_clean_inflight = None;
+        let mut liveness_decision = None;
+        if should_clean {
+            force_clean_inflight =
+                discord::inflight::load_inflight_state(provider, channel_id.get());
+            let decision = stall_liveness::evaluate_stall_watchdog_liveness(
+                provider,
                 channel_id,
-                provider.as_str(),
+                &snapshot,
+                force_clean_inflight.as_ref(),
+                now_unix_secs,
+                stall_liveness::STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+                stall_liveness::STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS,
             );
-            continue;
+            if decision.should_defer() {
+                stall_liveness::log_stall_watchdog_liveness_deferred(
+                    provider,
+                    channel_id,
+                    &snapshot,
+                    &judgment_basis,
+                    &decision,
+                    stall_liveness::STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+                    STALL_WATCHDOG_THRESHOLD_SECS,
+                );
+                continue;
+            }
+            liveness_decision = Some(decision);
+        } else {
+            stall_liveness::clear_stall_watchdog_liveness_deferral(
+                provider,
+                channel_id,
+                snapshot.tmux_session.as_deref(),
+            );
         }
         if !should_clean {
             // Detection-only sibling probe for "completed-stale" inflight
@@ -1831,10 +1800,14 @@ pub(crate) async fn run_stall_watchdog_pass(
             }
             continue;
         }
-        let ts = chrono::Local::now().format("%H:%M:%S");
-        tracing::warn!(
-            "  [{ts}] ⚡ STALL-WATCHDOG: forced cleanup for desynced channel {}",
-            channel_id
+        stall_liveness::log_stall_watchdog_force_cleanup_judgment(
+            provider,
+            channel_id,
+            &snapshot,
+            &judgment_basis,
+            liveness_decision.as_ref(),
+            stall_liveness::STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+            STALL_WATCHDOG_THRESHOLD_SECS,
         );
         // Force cleanup releases the durable inflight lock first, then asks
         // relay_recovery to clear the mailbox only if its fresh safety
@@ -1847,8 +1820,8 @@ pub(crate) async fn run_stall_watchdog_pass(
         // normal cleanup paths (`turn_bridge::mod.rs:3047-3048` and the four
         // `tmux_watcher` finalize sites) all skip this code path because the
         // turn never reached a watcher-side completion event.
-        let force_clean_inflight =
-            discord::inflight::load_inflight_state(provider, channel_id.get());
+        let force_clean_inflight = force_clean_inflight
+            .or_else(|| discord::inflight::load_inflight_state(provider, channel_id.get()));
         let pending_hourglass_user_msg_id = force_clean_inflight
             .as_ref()
             .filter(|state| state.user_msg_id != 0)
@@ -1885,6 +1858,11 @@ pub(crate) async fn run_stall_watchdog_pass(
             discord::formatting::remove_reaction_raw(&http, channel_id, user_msg_id.into(), '⏳')
                 .await;
         }
+        stall_liveness::clear_stall_watchdog_liveness_state(
+            provider,
+            channel_id,
+            snapshot.tmux_session.as_deref(),
+        );
         cleaned += 1;
     }
     cleaned + relay_auto_heal::run_orphan_token_auto_heal_pass(registry, provider, &runtimes).await
@@ -2636,6 +2614,7 @@ async fn maybe_recover_completed_stale_leak(
 
 #[cfg(test)]
 mod stall_watchdog_pure_tests {
+    use super::super::stall_liveness::stall_watchdog_jsonl_liveness_defers_force_clean;
     use super::{
         LeakRecoveryLedgerIdentity, STALL_WATCHDOG_THRESHOLD_SECS,
         force_clean_should_preserve_resume_selector, inflight_completed_stale_leak_detected,
@@ -2643,8 +2622,7 @@ mod stall_watchdog_pure_tests {
         leak_recovery_confirmed_chunk_count, leak_recovery_confirmed_prefix_from_ledger,
         leak_recovery_record_confirmed_chunk, leak_recovery_unrelayed_range,
         preserve_cancel_should_skip_provider_interrupt_for_idle_tui, render_leak_recovery_delivery,
-        stale_idle_foreground_queue_detected, stall_watchdog_jsonl_liveness_defers_force_clean,
-        stall_watchdog_should_force_clean,
+        stale_idle_foreground_queue_detected, stall_watchdog_should_force_clean,
         stall_watchdog_should_force_clean_orphan_explicit_background_work,
     };
     use crate::services::discord::relay_health::{RelayActiveTurn, RelayStallState};

--- a/src/services/discord/health/stall_liveness.rs
+++ b/src/services/discord/health/stall_liveness.rs
@@ -11,6 +11,7 @@ use super::snapshot::WatcherStateSnapshot;
 
 pub(super) const STALL_WATCHDOG_POSITIVE_LIVENESS_SECS: u64 = 120;
 pub(super) const STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS: u8 = 3;
+pub(super) const STALL_LIVENESS_STATE_TTL_SECS: u64 = 1800;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct StallLivenessKey {
@@ -23,11 +24,13 @@ struct StallLivenessKey {
 struct OffsetObservation {
     offset: u64,
     advanced_at_unix_secs: Option<i64>,
+    last_updated_unix_secs: i64,
 }
 
 #[derive(Clone, Debug)]
 struct DeferralState {
     count: u8,
+    last_updated_unix_secs: i64,
 }
 
 static OFFSET_OBSERVATIONS: LazyLock<dashmap::DashMap<StallLivenessKey, OffsetObservation>> =
@@ -191,6 +194,7 @@ pub(super) fn evaluate_stall_watchdog_liveness(
         key,
         DeferralState {
             count: deferral_count,
+            last_updated_unix_secs: now_unix_secs,
         },
     );
     StallWatchdogLivenessDecision {
@@ -198,14 +202,6 @@ pub(super) fn evaluate_stall_watchdog_liveness(
         evidence,
         max_deferrals,
     }
-}
-
-pub(super) fn clear_stall_watchdog_liveness_deferral(
-    provider: &ProviderKind,
-    channel_id: ChannelId,
-    tmux_session: Option<&str>,
-) {
-    DEFERRAL_STATE.remove(&StallLivenessKey::new(provider, channel_id, tmux_session));
 }
 
 pub(super) fn clear_stall_watchdog_liveness_state(
@@ -216,6 +212,34 @@ pub(super) fn clear_stall_watchdog_liveness_state(
     let key = StallLivenessKey::new(provider, channel_id, tmux_session);
     DEFERRAL_STATE.remove(&key);
     OFFSET_OBSERVATIONS.remove(&key);
+}
+
+pub(super) fn clear_stall_watchdog_liveness_state_if_healthy(
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    snapshot: &WatcherStateSnapshot,
+) -> bool {
+    if !stall_watchdog_liveness_state_is_healthy(snapshot) {
+        return false;
+    }
+    clear_stall_watchdog_liveness_state(provider, channel_id, snapshot.tmux_session.as_deref());
+    true
+}
+
+pub(super) fn gc_stall_watchdog_liveness_state(now_unix_secs: i64) {
+    OFFSET_OBSERVATIONS.retain(|_, observation| {
+        !liveness_state_expired(observation.last_updated_unix_secs, now_unix_secs)
+    });
+    DEFERRAL_STATE
+        .retain(|_, state| !liveness_state_expired(state.last_updated_unix_secs, now_unix_secs));
+}
+
+fn stall_watchdog_liveness_state_is_healthy(snapshot: &WatcherStateSnapshot) -> bool {
+    !snapshot.inflight_state_present || snapshot.inflight_terminal_delivery_committed
+}
+
+fn liveness_state_expired(last_updated_unix_secs: i64, now_unix_secs: i64) -> bool {
+    saturating_age_secs(last_updated_unix_secs, now_unix_secs) > STALL_LIVENESS_STATE_TTL_SECS
 }
 
 /// #3169: runtime jsonl / generation mtime liveness probe retained for the
@@ -398,6 +422,7 @@ fn observe_pane_offset(
         OffsetObservation {
             offset: current_offset,
             advanced_at_unix_secs,
+            last_updated_unix_secs: now_unix_secs,
         },
     );
     (
@@ -652,6 +677,25 @@ mod tests {
         )
     }
 
+    fn liveness_key(
+        provider: &ProviderKind,
+        channel: ChannelId,
+        tmux_session: &str,
+    ) -> StallLivenessKey {
+        StallLivenessKey::new(provider, channel, Some(tmux_session))
+    }
+
+    fn liveness_state_presence(key: &StallLivenessKey) -> (bool, bool) {
+        (
+            OFFSET_OBSERVATIONS.contains_key(key),
+            DEFERRAL_STATE.contains_key(key),
+        )
+    }
+
+    fn deferral_count(key: &StallLivenessKey) -> Option<u8> {
+        DEFERRAL_STATE.get(key).map(|state| state.count)
+    }
+
     #[test]
     fn positive_liveness_defers_cleanup_and_logs_reason() {
         let provider = ProviderKind::Codex;
@@ -798,5 +842,173 @@ mod tests {
             logs.contains("liveness_deferral_limit_reached=true"),
             "{logs}"
         );
+    }
+
+    #[test]
+    fn liveness_deferral_streak_survives_desync_flap_without_positive_health() {
+        let provider = ProviderKind::Codex;
+        let channel = ChannelId::new(3364);
+        let tmux_session = "AgentDesk-codex-liveness-flap";
+        let key = liveness_key(&provider, channel, tmux_session);
+        clear_stall_watchdog_liveness_state(&provider, channel, Some(tmux_session));
+        let file = tempfile::NamedTempFile::new().expect("temp transcript");
+        let inflight = inflight_with_output(
+            channel.get(),
+            tmux_session,
+            Some(file.path().display().to_string()),
+        );
+        let snap = snapshot(channel.get(), tmux_session, Some(20));
+        let now = chrono::Utc::now().timestamp();
+
+        for expected_count in 1..=2 {
+            let decision = evaluate_stall_watchdog_liveness(
+                &provider,
+                channel,
+                &snap,
+                Some(&inflight),
+                now,
+                STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+                STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS,
+            );
+            assert_eq!(
+                decision.action,
+                StallWatchdogLivenessAction::Defer {
+                    deferral_count: expected_count
+                }
+            );
+        }
+
+        let mut flapped_snapshot = snap.clone();
+        flapped_snapshot.desynced = false;
+        flapped_snapshot.relay_health.desynced = false;
+        assert!(!clear_stall_watchdog_liveness_state_if_healthy(
+            &provider,
+            channel,
+            &flapped_snapshot,
+        ));
+        assert_eq!(deferral_count(&key), Some(2));
+
+        let third = evaluate_stall_watchdog_liveness(
+            &provider,
+            channel,
+            &snap,
+            Some(&inflight),
+            now,
+            STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+            STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS,
+        );
+        assert_eq!(
+            third.action,
+            StallWatchdogLivenessAction::Defer { deferral_count: 3 }
+        );
+
+        let decision = evaluate_stall_watchdog_liveness(
+            &provider,
+            channel,
+            &snap,
+            Some(&inflight),
+            now,
+            STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+            STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS,
+        );
+        assert_eq!(
+            decision.action,
+            StallWatchdogLivenessAction::ProceedAfterDeferralLimit {
+                previous_deferrals: STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS
+            }
+        );
+
+        clear_stall_watchdog_liveness_state(&provider, channel, Some(tmux_session));
+    }
+
+    #[test]
+    fn healthy_recovery_clears_all_liveness_state() {
+        let provider = ProviderKind::Codex;
+        let channel = ChannelId::new(3365);
+        let tmux_session = "AgentDesk-codex-liveness-healthy-clear";
+        let key = liveness_key(&provider, channel, tmux_session);
+        clear_stall_watchdog_liveness_state(&provider, channel, Some(tmux_session));
+        let file = tempfile::NamedTempFile::new().expect("temp transcript");
+        let inflight = inflight_with_output(
+            channel.get(),
+            tmux_session,
+            Some(file.path().display().to_string()),
+        );
+        let snap = snapshot(channel.get(), tmux_session, Some(20));
+        let now = chrono::Utc::now().timestamp();
+
+        let decision = evaluate_stall_watchdog_liveness(
+            &provider,
+            channel,
+            &snap,
+            Some(&inflight),
+            now,
+            STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+            STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS,
+        );
+        assert!(decision.should_defer());
+        assert_eq!(liveness_state_presence(&key), (true, true));
+
+        let mut healthy_snapshot = snap.clone();
+        healthy_snapshot.inflight_terminal_delivery_committed = true;
+        assert!(clear_stall_watchdog_liveness_state_if_healthy(
+            &provider,
+            channel,
+            &healthy_snapshot,
+        ));
+        assert_eq!(liveness_state_presence(&key), (false, false));
+    }
+
+    #[test]
+    fn ttl_gc_removes_stale_liveness_state_and_keeps_fresh_entries() {
+        let provider = ProviderKind::Codex;
+        let old_channel = ChannelId::new(3366);
+        let fresh_channel = ChannelId::new(3367);
+        let old_tmux_session = "AgentDesk-codex-liveness-ttl-old";
+        let fresh_tmux_session = "AgentDesk-codex-liveness-ttl-fresh";
+        let old_key = liveness_key(&provider, old_channel, old_tmux_session);
+        let fresh_key = liveness_key(&provider, fresh_channel, fresh_tmux_session);
+        clear_stall_watchdog_liveness_state(&provider, old_channel, Some(old_tmux_session));
+        clear_stall_watchdog_liveness_state(&provider, fresh_channel, Some(fresh_tmux_session));
+
+        let now = 10_000;
+        let expired_at = now - STALL_LIVENESS_STATE_TTL_SECS as i64 - 1;
+        let fresh_at = now - STALL_LIVENESS_STATE_TTL_SECS as i64;
+        OFFSET_OBSERVATIONS.insert(
+            old_key.clone(),
+            OffsetObservation {
+                offset: 20,
+                advanced_at_unix_secs: Some(expired_at),
+                last_updated_unix_secs: expired_at,
+            },
+        );
+        DEFERRAL_STATE.insert(
+            old_key.clone(),
+            DeferralState {
+                count: 2,
+                last_updated_unix_secs: expired_at,
+            },
+        );
+        OFFSET_OBSERVATIONS.insert(
+            fresh_key.clone(),
+            OffsetObservation {
+                offset: 30,
+                advanced_at_unix_secs: Some(fresh_at),
+                last_updated_unix_secs: fresh_at,
+            },
+        );
+        DEFERRAL_STATE.insert(
+            fresh_key.clone(),
+            DeferralState {
+                count: 1,
+                last_updated_unix_secs: fresh_at,
+            },
+        );
+
+        gc_stall_watchdog_liveness_state(now);
+
+        assert_eq!(liveness_state_presence(&old_key), (false, false));
+        assert_eq!(liveness_state_presence(&fresh_key), (true, true));
+        clear_stall_watchdog_liveness_state(&provider, fresh_channel, Some(fresh_tmux_session));
     }
 }

--- a/src/services/discord/health/stall_liveness.rs
+++ b/src/services/discord/health/stall_liveness.rs
@@ -1,0 +1,802 @@
+use std::sync::LazyLock;
+
+use poise::serenity_prelude::ChannelId;
+
+use crate::services::agent_protocol::TaskNotificationKind;
+use crate::services::discord::inflight::InflightTurnState;
+use crate::services::discord::relay_health::RelayActiveTurn;
+use crate::services::provider::ProviderKind;
+
+use super::snapshot::WatcherStateSnapshot;
+
+pub(super) const STALL_WATCHDOG_POSITIVE_LIVENESS_SECS: u64 = 120;
+pub(super) const STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS: u8 = 3;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct StallLivenessKey {
+    provider: String,
+    channel_id: u64,
+    tmux_session: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct OffsetObservation {
+    offset: u64,
+    advanced_at_unix_secs: Option<i64>,
+}
+
+#[derive(Clone, Debug)]
+struct DeferralState {
+    count: u8,
+}
+
+static OFFSET_OBSERVATIONS: LazyLock<dashmap::DashMap<StallLivenessKey, OffsetObservation>> =
+    LazyLock::new(dashmap::DashMap::new);
+static DEFERRAL_STATE: LazyLock<dashmap::DashMap<StallLivenessKey, DeferralState>> =
+    LazyLock::new(dashmap::DashMap::new);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum StallWatchdogLivenessAction {
+    ProceedNoEvidence,
+    Defer { deferral_count: u8 },
+    ProceedAfterDeferralLimit { previous_deferrals: u8 },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct StallWatchdogLivenessDecision {
+    pub(super) action: StallWatchdogLivenessAction,
+    pub(super) evidence: StallWatchdogLivenessEvidence,
+    pub(super) max_deferrals: u8,
+}
+
+impl StallWatchdogLivenessDecision {
+    pub(super) fn should_defer(&self) -> bool {
+        matches!(self.action, StallWatchdogLivenessAction::Defer { .. })
+    }
+
+    fn deferral_count(&self) -> Option<u8> {
+        match self.action {
+            StallWatchdogLivenessAction::Defer { deferral_count } => Some(deferral_count),
+            StallWatchdogLivenessAction::ProceedAfterDeferralLimit { previous_deferrals } => {
+                Some(previous_deferrals)
+            }
+            StallWatchdogLivenessAction::ProceedNoEvidence => None,
+        }
+    }
+
+    fn limit_reached(&self) -> bool {
+        matches!(
+            self.action,
+            StallWatchdogLivenessAction::ProceedAfterDeferralLimit { .. }
+        )
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(super) struct StallWatchdogLivenessEvidence {
+    pub(super) pane_offset_current: Option<u64>,
+    pub(super) pane_offset_previous: Option<u64>,
+    pub(super) pane_offset_advanced_age_secs: Option<u64>,
+    pub(super) transcript_mtime_age_secs: Option<u64>,
+    pub(super) runtime_activity_age_secs: Option<u64>,
+    pub(super) background_synthetic_activity_age_secs: Option<u64>,
+    pub(super) background_synthetic_kind: Option<String>,
+}
+
+impl StallWatchdogLivenessEvidence {
+    fn reason_codes(&self, freshness_secs: u64) -> Vec<&'static str> {
+        let mut reasons = Vec::new();
+        if is_recent_age(self.pane_offset_advanced_age_secs, freshness_secs) {
+            reasons.push("pane_offset_advanced_recently");
+        }
+        if is_recent_age(self.transcript_mtime_age_secs, freshness_secs) {
+            reasons.push("transcript_mtime_recent");
+        }
+        if is_recent_age(self.runtime_activity_age_secs, freshness_secs) {
+            reasons.push("runtime_activity_mtime_recent");
+        }
+        if is_recent_age(self.background_synthetic_activity_age_secs, freshness_secs) {
+            reasons.push("background_synthetic_activity_recent");
+        }
+        reasons
+    }
+
+    fn reason_codes_csv(&self, freshness_secs: u64) -> String {
+        let reasons = self.reason_codes(freshness_secs);
+        if reasons.is_empty() {
+            "none".to_string()
+        } else {
+            reasons.join(",")
+        }
+    }
+
+    fn has_positive_liveness(&self, freshness_secs: u64) -> bool {
+        !self.reason_codes(freshness_secs).is_empty()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct StallWatchdogJudgmentBasis {
+    pub(super) inflight_age_secs: Option<u64>,
+    pub(super) inflight_age_anchor_unix_secs: Option<i64>,
+    pub(super) last_relay_age_secs: Option<u64>,
+    pub(super) last_outbound_activity_age_secs: Option<u64>,
+}
+
+impl StallWatchdogJudgmentBasis {
+    pub(super) fn from_snapshot(
+        snapshot: &WatcherStateSnapshot,
+        now_unix_secs: i64,
+        boot_unix_secs: i64,
+    ) -> Self {
+        let updated_at_unix = snapshot
+            .inflight_updated_at
+            .as_deref()
+            .and_then(crate::services::discord::inflight::parse_updated_at_unix);
+        let inflight_age_anchor_unix_secs =
+            updated_at_unix.map(|updated| updated.max(boot_unix_secs));
+        Self {
+            inflight_age_secs: inflight_age_anchor_unix_secs
+                .map(|anchor| saturating_age_secs(anchor, now_unix_secs)),
+            inflight_age_anchor_unix_secs,
+            last_relay_age_secs: unix_millis_age_secs(
+                positive_millis(snapshot.last_relay_ts_ms),
+                now_unix_secs,
+            ),
+            last_outbound_activity_age_secs: unix_millis_age_secs(
+                snapshot.relay_health.last_outbound_activity_ms,
+                now_unix_secs,
+            ),
+        }
+    }
+}
+
+pub(super) fn evaluate_stall_watchdog_liveness(
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    snapshot: &WatcherStateSnapshot,
+    inflight: Option<&InflightTurnState>,
+    now_unix_secs: i64,
+    freshness_secs: u64,
+    max_deferrals: u8,
+) -> StallWatchdogLivenessDecision {
+    let key = StallLivenessKey::new(provider, channel_id, snapshot.tmux_session.as_deref());
+    let evidence = StallWatchdogLivenessEvidence::collect(&key, snapshot, inflight, now_unix_secs);
+    if !evidence.has_positive_liveness(freshness_secs) {
+        DEFERRAL_STATE.remove(&key);
+        return StallWatchdogLivenessDecision {
+            action: StallWatchdogLivenessAction::ProceedNoEvidence,
+            evidence,
+            max_deferrals,
+        };
+    }
+
+    let prior_deferrals = DEFERRAL_STATE
+        .get(&key)
+        .map(|state| state.count)
+        .unwrap_or(0);
+    if prior_deferrals >= max_deferrals {
+        DEFERRAL_STATE.remove(&key);
+        return StallWatchdogLivenessDecision {
+            action: StallWatchdogLivenessAction::ProceedAfterDeferralLimit {
+                previous_deferrals: prior_deferrals,
+            },
+            evidence,
+            max_deferrals,
+        };
+    }
+
+    let deferral_count = prior_deferrals.saturating_add(1);
+    DEFERRAL_STATE.insert(
+        key,
+        DeferralState {
+            count: deferral_count,
+        },
+    );
+    StallWatchdogLivenessDecision {
+        action: StallWatchdogLivenessAction::Defer { deferral_count },
+        evidence,
+        max_deferrals,
+    }
+}
+
+pub(super) fn clear_stall_watchdog_liveness_deferral(
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    tmux_session: Option<&str>,
+) {
+    DEFERRAL_STATE.remove(&StallLivenessKey::new(provider, channel_id, tmux_session));
+}
+
+pub(super) fn clear_stall_watchdog_liveness_state(
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    tmux_session: Option<&str>,
+) {
+    let key = StallLivenessKey::new(provider, channel_id, tmux_session);
+    DEFERRAL_STATE.remove(&key);
+    OFFSET_OBSERVATIONS.remove(&key);
+}
+
+/// #3169: runtime jsonl / generation mtime liveness probe retained for the
+/// idle-foreground watchdog branch. Returns `true` to defer cleanup this pass.
+pub(super) fn stall_watchdog_jsonl_liveness_defers_force_clean(
+    latest_runtime_activity_unix_nanos: i64,
+    now_unix_secs: i64,
+    freshness_threshold_secs: u64,
+) -> bool {
+    unix_nanos_age_secs(latest_runtime_activity_unix_nanos, now_unix_secs)
+        .is_some_and(|age_secs| age_secs < freshness_threshold_secs)
+}
+
+pub(super) fn log_stall_watchdog_liveness_deferred(
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    snapshot: &WatcherStateSnapshot,
+    basis: &StallWatchdogJudgmentBasis,
+    decision: &StallWatchdogLivenessDecision,
+    freshness_secs: u64,
+    threshold_secs: u64,
+) {
+    let ts = chrono::Local::now().format("%H:%M:%S");
+    tracing::warn!(
+        event = "stall_watchdog_force_cleanup_deferred",
+        reason_code = "1446_stall_watchdog",
+        provider = provider.as_str(),
+        channel_id = channel_id.get(),
+        tmux_session = ?snapshot.tmux_session,
+        attached = snapshot.attached,
+        desynced = snapshot.desynced,
+        inflight_state_present = snapshot.inflight_state_present,
+        inflight_terminal_delivery_committed = snapshot.inflight_terminal_delivery_committed,
+        inflight_started_at = ?snapshot.inflight_started_at,
+        inflight_updated_at = ?snapshot.inflight_updated_at,
+        inflight_age_secs = ?basis.inflight_age_secs,
+        inflight_age_anchor_unix_secs = ?basis.inflight_age_anchor_unix_secs,
+        threshold_secs = threshold_secs,
+        last_relay_ts_ms = snapshot.last_relay_ts_ms,
+        last_relay_age_secs = ?basis.last_relay_age_secs,
+        last_relay_offset = snapshot.last_relay_offset,
+        last_capture_offset = ?snapshot.last_capture_offset,
+        unread_bytes = ?snapshot.unread_bytes,
+        tmux_session_alive = ?snapshot.tmux_session_alive,
+        watcher_owner_channel_id = ?snapshot.watcher_owner_channel_id,
+        relay_stall_state = snapshot.relay_stall_state.as_str(),
+        relay_active_turn = ?snapshot.relay_health.active_turn,
+        mailbox_active_user_msg_id = ?snapshot.mailbox_active_user_msg_id,
+        mailbox_has_cancel_token = snapshot.relay_health.mailbox_has_cancel_token,
+        queue_depth = snapshot.relay_health.queue_depth,
+        last_outbound_activity_age_secs = ?basis.last_outbound_activity_age_secs,
+        liveness_freshness_secs = freshness_secs,
+        liveness_reasons = decision.evidence.reason_codes_csv(freshness_secs),
+        pane_offset_current = ?decision.evidence.pane_offset_current,
+        pane_offset_previous = ?decision.evidence.pane_offset_previous,
+        pane_offset_advanced_age_secs = ?decision.evidence.pane_offset_advanced_age_secs,
+        transcript_mtime_age_secs = ?decision.evidence.transcript_mtime_age_secs,
+        runtime_activity_age_secs = ?decision.evidence.runtime_activity_age_secs,
+        background_synthetic_activity_age_secs = ?decision.evidence.background_synthetic_activity_age_secs,
+        background_synthetic_kind = ?decision.evidence.background_synthetic_kind,
+        deferral_count = ?decision.deferral_count(),
+        max_deferrals = decision.max_deferrals,
+        "  [{ts}] 🌱 STALL-WATCHDOG: deferred forced cleanup for desynced channel {} (provider={}) due to positive liveness evidence",
+        channel_id,
+        provider.as_str(),
+    );
+}
+
+pub(super) fn log_stall_watchdog_force_cleanup_judgment(
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    snapshot: &WatcherStateSnapshot,
+    basis: &StallWatchdogJudgmentBasis,
+    decision: Option<&StallWatchdogLivenessDecision>,
+    freshness_secs: u64,
+    threshold_secs: u64,
+) {
+    let ts = chrono::Local::now().format("%H:%M:%S");
+    let no_evidence = decision.is_some_and(|decision| {
+        matches!(
+            &decision.action,
+            StallWatchdogLivenessAction::ProceedNoEvidence
+        )
+    });
+    let limit_reached = decision.is_some_and(StallWatchdogLivenessDecision::limit_reached);
+    let liveness_reasons = decision
+        .map(|decision| decision.evidence.reason_codes_csv(freshness_secs))
+        .unwrap_or_else(|| "not_evaluated".to_string());
+    tracing::warn!(
+        event = "stall_watchdog_force_cleanup_judgment",
+        reason_code = "1446_stall_watchdog",
+        provider = provider.as_str(),
+        channel_id = channel_id.get(),
+        tmux_session = ?snapshot.tmux_session,
+        attached = snapshot.attached,
+        desynced = snapshot.desynced,
+        inflight_state_present = snapshot.inflight_state_present,
+        inflight_terminal_delivery_committed = snapshot.inflight_terminal_delivery_committed,
+        inflight_started_at = ?snapshot.inflight_started_at,
+        inflight_updated_at = ?snapshot.inflight_updated_at,
+        inflight_age_secs = ?basis.inflight_age_secs,
+        inflight_age_anchor_unix_secs = ?basis.inflight_age_anchor_unix_secs,
+        threshold_secs = threshold_secs,
+        last_relay_ts_ms = snapshot.last_relay_ts_ms,
+        last_relay_age_secs = ?basis.last_relay_age_secs,
+        last_relay_offset = snapshot.last_relay_offset,
+        last_capture_offset = ?snapshot.last_capture_offset,
+        unread_bytes = ?snapshot.unread_bytes,
+        tmux_session_alive = ?snapshot.tmux_session_alive,
+        watcher_owner_channel_id = ?snapshot.watcher_owner_channel_id,
+        relay_stall_state = snapshot.relay_stall_state.as_str(),
+        relay_active_turn = ?snapshot.relay_health.active_turn,
+        mailbox_active_user_msg_id = ?snapshot.mailbox_active_user_msg_id,
+        mailbox_has_cancel_token = snapshot.relay_health.mailbox_has_cancel_token,
+        queue_depth = snapshot.relay_health.queue_depth,
+        last_outbound_activity_age_secs = ?basis.last_outbound_activity_age_secs,
+        liveness_freshness_secs = freshness_secs,
+        liveness_reasons = liveness_reasons,
+        liveness_no_evidence = no_evidence,
+        liveness_deferral_limit_reached = limit_reached,
+        deferral_count = ?decision.and_then(StallWatchdogLivenessDecision::deferral_count),
+        max_deferrals = decision.map(|decision| decision.max_deferrals).unwrap_or(0),
+        "  [{ts}] ⚡ STALL-WATCHDOG: forced cleanup for desynced channel {}",
+        channel_id,
+    );
+}
+
+impl StallLivenessKey {
+    fn new(provider: &ProviderKind, channel_id: ChannelId, tmux_session: Option<&str>) -> Self {
+        Self {
+            provider: provider.as_str().to_string(),
+            channel_id: channel_id.get(),
+            tmux_session: tmux_session.map(str::to_string),
+        }
+    }
+}
+
+impl StallWatchdogLivenessEvidence {
+    fn collect(
+        key: &StallLivenessKey,
+        snapshot: &WatcherStateSnapshot,
+        inflight: Option<&InflightTurnState>,
+        now_unix_secs: i64,
+    ) -> Self {
+        let (pane_offset_previous, pane_offset_advanced_age_secs) =
+            observe_pane_offset(key, snapshot.last_capture_offset, now_unix_secs);
+        let background_synthetic =
+            background_synthetic_activity_age_secs(snapshot, inflight, now_unix_secs);
+        Self {
+            pane_offset_current: snapshot.last_capture_offset,
+            pane_offset_previous,
+            pane_offset_advanced_age_secs,
+            transcript_mtime_age_secs: transcript_mtime_age_secs(inflight, now_unix_secs),
+            runtime_activity_age_secs: runtime_activity_age_secs(snapshot, now_unix_secs),
+            background_synthetic_activity_age_secs: background_synthetic
+                .as_ref()
+                .map(|(_, age)| *age),
+            background_synthetic_kind: background_synthetic.map(|(kind, _)| kind),
+        }
+    }
+}
+
+fn observe_pane_offset(
+    key: &StallLivenessKey,
+    current_offset: Option<u64>,
+    now_unix_secs: i64,
+) -> (Option<u64>, Option<u64>) {
+    let Some(current_offset) = current_offset else {
+        OFFSET_OBSERVATIONS.remove(key);
+        return (None, None);
+    };
+    let previous = OFFSET_OBSERVATIONS.get(key).map(|entry| entry.clone());
+    let advanced_at_unix_secs = match previous.as_ref() {
+        Some(prev) if current_offset > prev.offset => Some(now_unix_secs),
+        Some(prev) if current_offset == prev.offset => prev.advanced_at_unix_secs,
+        _ => None,
+    };
+    OFFSET_OBSERVATIONS.insert(
+        key.clone(),
+        OffsetObservation {
+            offset: current_offset,
+            advanced_at_unix_secs,
+        },
+    );
+    (
+        previous.map(|prev| prev.offset),
+        advanced_at_unix_secs.map(|at| saturating_age_secs(at, now_unix_secs)),
+    )
+}
+
+fn transcript_mtime_age_secs(
+    inflight: Option<&InflightTurnState>,
+    now_unix_secs: i64,
+) -> Option<u64> {
+    let path = inflight
+        .and_then(|state| state.output_path.as_deref())
+        .map(str::trim)
+        .filter(|path| !path.is_empty())?;
+    path_mtime_unix_nanos(path).and_then(|nanos| unix_nanos_age_secs(nanos, now_unix_secs))
+}
+
+fn runtime_activity_age_secs(snapshot: &WatcherStateSnapshot, now_unix_secs: i64) -> Option<u64> {
+    let tmux_session = snapshot.tmux_session.as_deref()?;
+    let nanos =
+        crate::services::dispatched_sessions::latest_runtime_activity_unix_nanos(tmux_session);
+    unix_nanos_age_secs(nanos, now_unix_secs)
+}
+
+fn background_synthetic_activity_age_secs(
+    snapshot: &WatcherStateSnapshot,
+    inflight: Option<&InflightTurnState>,
+    now_unix_secs: i64,
+) -> Option<(String, u64)> {
+    let (kind, updated_at_ms) = background_synthetic_activity_anchor(snapshot, inflight)?;
+    unix_millis_age_secs(Some(updated_at_ms), now_unix_secs).map(|age| (kind, age))
+}
+
+fn background_synthetic_activity_anchor(
+    snapshot: &WatcherStateSnapshot,
+    inflight: Option<&InflightTurnState>,
+) -> Option<(String, i64)> {
+    let inflight_updated_ms = inflight
+        .and_then(|state| {
+            crate::services::discord::inflight::parse_updated_at_unix(&state.updated_at)
+        })
+        .and_then(|seconds| seconds.checked_mul(1000));
+    let activity_ms = max_optional_i64([
+        snapshot.relay_health.last_outbound_activity_ms,
+        positive_millis(snapshot.last_relay_ts_ms),
+        inflight_updated_ms,
+    ])?;
+
+    if snapshot.relay_health.active_turn == RelayActiveTurn::ExplicitBackground {
+        return Some((
+            "relay_active_turn:explicit_background".to_string(),
+            activity_ms,
+        ));
+    }
+    if let Some(kind) = inflight.and_then(|state| state.task_notification_kind) {
+        return Some((
+            format!("task_notification_kind:{}", task_kind_str(kind)),
+            activity_ms,
+        ));
+    }
+    if inflight.is_some_and(|state| state.long_running_placeholder_active) {
+        return Some(("long_running_placeholder_active".to_string(), activity_ms));
+    }
+    if inflight.is_some_and(|state| {
+        state.rebind_origin || state.user_msg_id == 0 || state.current_msg_id == 0
+    }) {
+        return Some(("synthetic_turn".to_string(), activity_ms));
+    }
+    None
+}
+
+fn task_kind_str(kind: TaskNotificationKind) -> &'static str {
+    kind.as_str()
+}
+
+fn max_optional_i64<const N: usize>(values: [Option<i64>; N]) -> Option<i64> {
+    values.into_iter().flatten().max()
+}
+
+fn path_mtime_unix_nanos(path: &str) -> Option<i64> {
+    std::fs::metadata(path)
+        .and_then(|meta| meta.modified())
+        .ok()
+        .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+        .and_then(|duration| i64::try_from(duration.as_nanos()).ok())
+}
+
+fn positive_millis(value: i64) -> Option<i64> {
+    (value > 0).then_some(value)
+}
+
+fn unix_millis_age_secs(unix_millis: Option<i64>, now_unix_secs: i64) -> Option<u64> {
+    let millis = unix_millis?;
+    let now_millis = now_unix_secs.saturating_mul(1000);
+    if millis >= now_millis {
+        return Some(0);
+    }
+    Some((now_millis.saturating_sub(millis) as u64) / 1000)
+}
+
+fn unix_nanos_age_secs(unix_nanos: i64, now_unix_secs: i64) -> Option<u64> {
+    if unix_nanos <= 0 {
+        return None;
+    }
+    let now_nanos = now_unix_secs.saturating_mul(1_000_000_000);
+    if unix_nanos >= now_nanos {
+        return Some(0);
+    }
+    Some((now_nanos.saturating_sub(unix_nanos) as u64) / 1_000_000_000)
+}
+
+fn saturating_age_secs(anchor_unix_secs: i64, now_unix_secs: i64) -> u64 {
+    now_unix_secs.saturating_sub(anchor_unix_secs).max(0) as u64
+}
+
+fn is_recent_age(age_secs: Option<u64>, freshness_secs: u64) -> bool {
+    age_secs.is_some_and(|age| age < freshness_secs)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{self, Write};
+    use std::sync::{Arc, Mutex};
+
+    use poise::serenity_prelude::ChannelId;
+    use tracing_subscriber::fmt::MakeWriter;
+
+    use crate::services::discord::relay_health::{RelayHealthSnapshot, RelayStallState};
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct CapturingWriter {
+        buffer: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl Write for CapturingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.buffer.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for CapturingWriter {
+        type Writer = CapturingWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    fn capture_warns<F>(f: F) -> String
+    where
+        F: FnOnce(),
+    {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let writer = CapturingWriter {
+            buffer: buffer.clone(),
+        };
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::WARN)
+            .with_ansi(false)
+            .without_time()
+            .with_writer(writer)
+            .finish();
+        let guard = tracing::subscriber::set_default(subscriber);
+        f();
+        drop(guard);
+        String::from_utf8_lossy(&buffer.lock().unwrap().clone()).into_owned()
+    }
+
+    fn snapshot(
+        channel_id: u64,
+        tmux_session: &str,
+        capture_offset: Option<u64>,
+    ) -> WatcherStateSnapshot {
+        WatcherStateSnapshot {
+            provider: ProviderKind::Codex.as_str().to_string(),
+            attached: true,
+            tmux_session: Some(tmux_session.to_string()),
+            watcher_owner_channel_id: Some(channel_id),
+            last_relay_offset: 10,
+            inflight_state_present: true,
+            last_relay_ts_ms: 1_700_000_000_000,
+            last_capture_offset: capture_offset,
+            unread_bytes: capture_offset.map(|offset| offset.saturating_sub(10)),
+            desynced: true,
+            reconnect_count: 0,
+            inflight_started_at: Some("2026-06-12 00:00:00".to_string()),
+            inflight_updated_at: Some("2026-06-12 00:00:00".to_string()),
+            inflight_user_msg_id: Some(9001),
+            inflight_current_msg_id: Some(9002),
+            tmux_session_alive: Some(true),
+            has_pending_queue: false,
+            mailbox_active_user_msg_id: Some(9001),
+            inflight_terminal_delivery_committed: false,
+            relay_stall_state: RelayStallState::TmuxAliveRelayDead,
+            relay_health: RelayHealthSnapshot {
+                provider: ProviderKind::Codex.as_str().to_string(),
+                channel_id,
+                active_turn: RelayActiveTurn::Foreground,
+                tmux_session: Some(tmux_session.to_string()),
+                tmux_alive: Some(true),
+                watcher_attached: true,
+                watcher_attached_stale: false,
+                watcher_owner_channel_id: Some(channel_id),
+                watcher_owns_live_relay: true,
+                bridge_inflight_present: true,
+                bridge_current_msg_id: Some(9002),
+                mailbox_has_cancel_token: true,
+                mailbox_active_user_msg_id: Some(9001),
+                queue_depth: 0,
+                pending_discord_callback_msg_id: Some(9002),
+                pending_thread_proof: false,
+                parent_channel_id: None,
+                thread_channel_id: None,
+                last_relay_ts_ms: Some(1_700_000_000_000),
+                last_outbound_activity_ms: None,
+                last_capture_offset: capture_offset,
+                last_relay_offset: 10,
+                unread_bytes: capture_offset.map(|offset| offset.saturating_sub(10)),
+                desynced: true,
+                stale_thread_proof: false,
+            },
+        }
+    }
+
+    fn inflight_with_output(
+        channel_id: u64,
+        tmux_session: &str,
+        path: Option<String>,
+    ) -> InflightTurnState {
+        InflightTurnState::new(
+            ProviderKind::Codex,
+            channel_id,
+            None,
+            1,
+            9001,
+            9002,
+            "test".to_string(),
+            Some("session".to_string()),
+            Some(tmux_session.to_string()),
+            path,
+            None,
+            0,
+        )
+    }
+
+    #[test]
+    fn positive_liveness_defers_cleanup_and_logs_reason() {
+        let provider = ProviderKind::Codex;
+        let channel = ChannelId::new(3361);
+        let tmux_session = "AgentDesk-codex-liveness-defers";
+        clear_stall_watchdog_liveness_state(&provider, channel, Some(tmux_session));
+        let file = tempfile::NamedTempFile::new().expect("temp transcript");
+        let inflight = inflight_with_output(
+            channel.get(),
+            tmux_session,
+            Some(file.path().display().to_string()),
+        );
+        let snap = snapshot(channel.get(), tmux_session, Some(20));
+        let now = chrono::Utc::now().timestamp();
+
+        let decision = evaluate_stall_watchdog_liveness(
+            &provider,
+            channel,
+            &snap,
+            Some(&inflight),
+            now,
+            STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+            STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS,
+        );
+        assert!(decision.should_defer());
+        assert_eq!(
+            decision
+                .evidence
+                .reason_codes_csv(STALL_WATCHDOG_POSITIVE_LIVENESS_SECS),
+            "transcript_mtime_recent"
+        );
+
+        let basis = StallWatchdogJudgmentBasis::from_snapshot(&snap, now, now - 10_000);
+        let logs = capture_warns(|| {
+            log_stall_watchdog_liveness_deferred(
+                &provider,
+                channel,
+                &snap,
+                &basis,
+                &decision,
+                STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+                600,
+            );
+        });
+        assert!(
+            logs.contains("stall_watchdog_force_cleanup_deferred"),
+            "{logs}"
+        );
+        assert!(logs.contains("transcript_mtime_recent"), "{logs}");
+    }
+
+    #[test]
+    fn no_liveness_evidence_proceeds_with_existing_cleanup() {
+        let provider = ProviderKind::Codex;
+        let channel = ChannelId::new(3362);
+        let tmux_session = "AgentDesk-codex-no-liveness";
+        clear_stall_watchdog_liveness_state(&provider, channel, Some(tmux_session));
+        let snap = snapshot(channel.get(), tmux_session, None);
+        let mut inflight = inflight_with_output(channel.get(), tmux_session, None);
+        inflight.updated_at = "2026-06-12 00:00:00".to_string();
+
+        let decision = evaluate_stall_watchdog_liveness(
+            &provider,
+            channel,
+            &snap,
+            Some(&inflight),
+            1_800_000_000,
+            STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+            STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS,
+        );
+        assert_eq!(
+            decision.action,
+            StallWatchdogLivenessAction::ProceedNoEvidence
+        );
+        assert!(!decision.should_defer());
+    }
+
+    #[test]
+    fn liveness_deferral_cap_allows_cleanup_after_three_passes_and_logs_limit() {
+        let provider = ProviderKind::Codex;
+        let channel = ChannelId::new(3363);
+        let tmux_session = "AgentDesk-codex-liveness-cap";
+        clear_stall_watchdog_liveness_state(&provider, channel, Some(tmux_session));
+        let file = tempfile::NamedTempFile::new().expect("temp transcript");
+        let inflight = inflight_with_output(
+            channel.get(),
+            tmux_session,
+            Some(file.path().display().to_string()),
+        );
+        let snap = snapshot(channel.get(), tmux_session, Some(20));
+        let now = chrono::Utc::now().timestamp();
+
+        for expected_count in 1..=STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS {
+            let decision = evaluate_stall_watchdog_liveness(
+                &provider,
+                channel,
+                &snap,
+                Some(&inflight),
+                now,
+                STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+                STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS,
+            );
+            assert_eq!(
+                decision.action,
+                StallWatchdogLivenessAction::Defer {
+                    deferral_count: expected_count
+                }
+            );
+        }
+
+        let decision = evaluate_stall_watchdog_liveness(
+            &provider,
+            channel,
+            &snap,
+            Some(&inflight),
+            now,
+            STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+            STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS,
+        );
+        assert_eq!(
+            decision.action,
+            StallWatchdogLivenessAction::ProceedAfterDeferralLimit {
+                previous_deferrals: STALL_WATCHDOG_MAX_LIVENESS_DEFERRALS
+            }
+        );
+
+        let basis = StallWatchdogJudgmentBasis::from_snapshot(&snap, now, now - 10_000);
+        let logs = capture_warns(|| {
+            log_stall_watchdog_force_cleanup_judgment(
+                &provider,
+                channel,
+                &snap,
+                &basis,
+                Some(&decision),
+                STALL_WATCHDOG_POSITIVE_LIVENESS_SECS,
+                600,
+            );
+        });
+        assert!(
+            logs.contains("stall_watchdog_force_cleanup_judgment"),
+            "{logs}"
+        );
+        assert!(
+            logs.contains("liveness_deferral_limit_reached=true"),
+            "{logs}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3361.

## Problem
2026-06-11 07:32:25Z, the stall-watchdog force-cleaned a healthy session on a desync false-positive (capture_lagged class), killing the live agent turn and stranding an orphan_pending_token (#3360, fixed). The judgment basis was not logged, making post-hoc diagnosis expensive.

## Fix
- New `health/stall_liveness.rs`: before any desynced force-clean, collect positive liveness evidence (pane offset advancement, transcript/jsonl mtime, runtime activity, background synthetic task activity). Any fresh signal (≤120s) defers the cleanup for that pass.
- Bounded deferral: max 3 consecutive deferrals per (provider, channel, session) key — a genuinely hung session that somehow keeps one signal fresh still gets cleaned on pass 4, with the limit logged.
- Structured WARN logs for both the deferral and the final force-clean judgment basis (reason codes CSV), so the next false-positive is diagnosable from logs alone.
- Existing #3169 jsonl probe and all heuristic thresholds unchanged; deferral state cleared when the channel recovers or after cleanup fires.

## Verification
- cargo fmt/check/clippy -D warnings clean
- `cargo test --lib stall_liveness` 3 pass (new), `cargo test --lib stall_watchdog` 25 pass
- audit_maintainability --check clean (신규 모듈 분리로 recovery.rs ratchet 부담 없음), agent-maintenance docs check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)