### PR TITLE
feat(#3089): S0 — single_message_panel flag (default off) + characterization tests

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -575,6 +575,7 @@ src/
 │   │   ├── shadow_parity_warn.rs
 │   │   ├── shared_memory.rs
 │   │   ├── shared_state.rs
+│   │   ├── single_message_panel.rs
 │   │   ├── stall_recovery.rs
 │   │   ├── standby_relay.rs
 │   │   ├── status_panel_controller.rs

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -42,6 +42,9 @@
   instead of looping back through the internal HTTP cleanup route. The singleton
   assumption remains unchanged: the task is still spawned from the leased
   gateway runtime.
+- 2026-06-12 audit note (#3089 S0): `runtime_bootstrap` only initializes the
+  default-off `single_message_panel` flag for startup logging. Gateway lease,
+  startup order, worker ownership, and singleton assumptions are unchanged.
 - invariants: `singleton_on_leader`,
   `heartbeat_capability_registry_routing`.
 - allowed_changes: `bugfix` only before #876/#877. New gateway, reconnect,

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -75,7 +75,9 @@
 # #3038 S3: lowered 4980 -> 4965 (-15) as the cluster-E field block (13
 # restart-lifecycle fields) moved into `shared_state::RestartLifecycle`.
 # Locks in the shrink win (ratchet down only).
-"src/services/discord/mod.rs" = 4965
+# #3089 S0: +5 for default-off single_message_panel wrapper/log trigger in
+# mod.rs; parser/cache body lives in `single_message_panel.rs`.
+"src/services/discord/mod.rs" = 4970
 # #3305: the local-only pass-through lifecycle-skip (kind hoist + note-only return
 # branch + idle-loop skip) is offset by comment dedup in the same root, lowering the
 # frozen baseline 5438 -> 5429 (-9). Locks in the shrink win (#3028 ratchet).

--- a/src/services/discord/formatting.rs
+++ b/src/services/discord/formatting.rs
@@ -851,10 +851,88 @@ pub(super) fn format_for_discord_with_status_panel(
 mod status_panel_v2_formatter_tests {
     use super::{
         MonitorHandoffReason, MonitorHandoffStatus, build_monitor_handoff_placeholder,
-        build_monitor_handoff_placeholder_with_live_events, format_for_discord,
-        format_for_discord_with_provider,
+        build_monitor_handoff_placeholder_with_live_events, build_status_panel_streaming_edit_text,
+        build_streaming_placeholder_text, format_for_discord, format_for_discord_with_provider,
+        format_for_discord_with_status_panel, plan_streaming_rollover,
     };
     use crate::services::provider::ProviderKind;
+
+    const LIVENESS_FOOTER: &str = "⠸ 계속 처리 중";
+
+    #[test]
+    fn plan_streaming_rollover_strips_liveness_footer_from_frozen_chunk_s0() {
+        let footer = format!("\n\n{LIVENESS_FOOTER}");
+        let body_budget = super::DISCORD_MSG_LIMIT
+            .saturating_sub(footer.len() + super::STREAMING_PLACEHOLDER_MARGIN)
+            .max(1);
+        let current_portion = "x".repeat(body_budget + 64);
+
+        let plan = plan_streaming_rollover(&current_portion, LIVENESS_FOOTER)
+            .expect("current portion should roll over once footer budget is reserved");
+
+        assert_eq!(plan.frozen_chunk.len(), body_budget);
+        assert_eq!(plan.frozen_chunk, &current_portion[..plan.split_at]);
+        assert!(!plan.frozen_chunk.contains(LIVENESS_FOOTER));
+        assert!(plan.display_snapshot.ends_with(&footer));
+    }
+
+    #[test]
+    fn rollover_seed_starts_as_liveness_footer_only_s0() {
+        let seed = build_streaming_placeholder_text("", LIVENESS_FOOTER);
+
+        assert_eq!(seed, LIVENESS_FOOTER);
+    }
+
+    #[test]
+    fn plan_streaming_rollover_reserves_footer_length_before_2000_byte_limit_s0() {
+        let footer = format!("\n\n{LIVENESS_FOOTER}");
+        let body_budget = super::DISCORD_MSG_LIMIT
+            .saturating_sub(footer.len() + super::STREAMING_PLACEHOLDER_MARGIN)
+            .max(1);
+        let current_portion = "x".repeat(body_budget + 1);
+        assert!(current_portion.len() < super::DISCORD_MSG_LIMIT);
+
+        let plan = plan_streaming_rollover(&current_portion, LIVENESS_FOOTER)
+            .expect("body fits raw Discord limit but not the reserved footer budget");
+
+        assert_eq!(plan.split_at, body_budget);
+        assert!(plan.display_snapshot.len() <= super::DISCORD_MSG_LIMIT);
+        assert!(plan.display_snapshot.ends_with(&footer));
+    }
+
+    #[test]
+    fn no_rollover_body_and_footer_under_limit_stays_single_message_s0() {
+        let current_portion = "short streamed body";
+        let rendered = build_streaming_placeholder_text(current_portion, LIVENESS_FOOTER);
+
+        assert!(plan_streaming_rollover(current_portion, LIVENESS_FOOTER).is_none());
+        assert_eq!(rendered, format!("{current_portion}\n\n{LIVENESS_FOOTER}"));
+        assert!(rendered.len() < super::DISCORD_MSG_LIMIT);
+    }
+
+    #[test]
+    fn empty_body_with_near_limit_footer_stays_footer_only_s0() {
+        let oversized_footer = "⠸".repeat(super::DISCORD_MSG_LIMIT);
+        let rendered = build_streaming_placeholder_text("", &oversized_footer);
+
+        assert!(plan_streaming_rollover("", &oversized_footer).is_none());
+        assert!(rendered.len() <= super::DISCORD_MSG_LIMIT);
+        assert!(rendered.starts_with('⠸'));
+        assert!(!rendered.contains("\n\n"));
+    }
+
+    #[test]
+    fn single_message_panel_s0_streaming_footer_present_and_final_body_absent() {
+        let streamed = build_status_panel_streaming_edit_text(
+            "Final answer",
+            LIVENESS_FOOTER,
+            &ProviderKind::Codex,
+        );
+        assert_eq!(streamed, "Final answer\n\n⠸ 계속 처리 중");
+
+        let finalized = format_for_discord_with_status_panel(&streamed, &ProviderKind::Codex);
+        assert_eq!(finalized, "Final answer");
+    }
 
     #[test]
     fn monitor_handoff_active_keeps_processing_tail_last() {

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -69,6 +69,7 @@ pub(crate) mod shared_memory;
 // dedicated inherent impls). See `shared_state::QueuedPlaceholderState` and
 // `shared_state::SessionOverrideState`.
 mod shared_state;
+mod single_message_panel;
 mod stall_recovery;
 mod status_panel_orphan_store;
 pub(in crate::services::discord) mod streaming_finalizer;
@@ -676,8 +677,12 @@ pub(in crate::services::discord) fn advance_last_message_checkpoint(
     checkpoint
 }
 
-pub(in crate::services::discord) use queue_io::schedule_deferred_idle_queue_kickoff;
-pub(in crate::services::discord) use queue_io::schedule_deferred_idle_queue_kickoff_immediate;
+pub(in crate::services::discord) use queue_io::{
+    schedule_deferred_idle_queue_kickoff, schedule_deferred_idle_queue_kickoff_immediate,
+};
+pub(super) fn single_message_panel_enabled() -> bool {
+    single_message_panel::enabled()
+}
 /// Minimum interval between Discord placeholder edits for progress status.
 /// Configurable via AGENTDESK_STATUS_INTERVAL_SECS env var. Default: 5 seconds.
 pub(super) fn status_update_interval() -> Duration {

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -1,5 +1,6 @@
 use super::super::formatting::{
     MonitorHandoffReason, MonitorHandoffStatus, build_monitor_handoff_placeholder_with_live_events,
+    build_processing_status_block, build_streaming_placeholder_text, plan_streaming_rollover,
     redact_sensitive_for_placeholder,
 };
 use super::common::{
@@ -240,6 +241,44 @@ fn status_panel_renders_derived_tool_state_under_limit() {
     assert!(rendered.contains("도구 실행 중"));
     assert!(rendered.contains("[Bash]"));
     assert!(rendered.chars().count() <= STATUS_PANEL_MAX_CHARS);
+}
+
+#[test]
+fn characterize_rollover_seed_has_no_status_panel_content_s0() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3089);
+    let tool_args = json!({"command": "cargo test --lib placeholder_live_events"}).to_string();
+    events.push_status_events(channel_id, status_events_from_tool_use("Bash", &tool_args));
+    events.push_event(
+        channel_id,
+        RecentPlaceholderEvent::tool_use("Bash", &tool_args).unwrap(),
+    );
+
+    let panel = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    assert!(panel.contains("도구 실행 중"));
+    assert!(panel.contains("[Bash]"));
+    assert!(panel.contains("cargo test --lib placeholder_live_events"));
+
+    let status_block = build_processing_status_block("⠸");
+    let current_portion = "relay body ".repeat(250);
+    let plan = plan_streaming_rollover(&current_portion, &status_block)
+        .expect("representative relay body should roll over");
+    let rollover_seed = build_streaming_placeholder_text("", &status_block);
+
+    assert_eq!(rollover_seed, status_block);
+    assert!(
+        plan.display_snapshot
+            .ends_with(&format!("\n\n{status_block}"))
+    );
+    for status_panel_fragment in [
+        "도구 실행 중",
+        "[Bash]",
+        "cargo test --lib placeholder_live_events",
+    ] {
+        assert!(!rollover_seed.contains(status_panel_fragment));
+        assert!(!plan.display_snapshot.contains(status_panel_fragment));
+        assert!(!plan.frozen_chunk.contains(status_panel_fragment));
+    }
 }
 
 fn status_for(events: &PlaceholderLiveEvents, channel_id: ChannelId) -> DerivedStatus {

--- a/src/services/discord/runtime_bootstrap.rs
+++ b/src/services/discord/runtime_bootstrap.rs
@@ -104,6 +104,7 @@ pub(crate) async fn run_bot(token: &str, provider: ProviderKind, context: RunBot
 
     // Initialize debug logging from environment variable
     claude::init_debug_from_env();
+    super::single_message_panel_enabled();
 
     let mut bot_settings = load_bot_settings(token);
     bot_settings.provider = provider.clone();

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -1,0 +1,45 @@
+use std::sync::OnceLock;
+
+pub(super) fn enabled() -> bool {
+    static CACHED: OnceLock<bool> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        let raw = std::env::var("AGENTDESK_SINGLE_MESSAGE_PANEL").ok();
+        let enabled = parse_single_message_panel_flag(raw.as_deref());
+        let state = if enabled { "enabled" } else { "disabled" };
+        tracing::info!("  ✓ single_message_panel: {state}");
+        enabled
+    })
+}
+
+fn parse_single_message_panel_flag(raw: Option<&str>) -> bool {
+    raw.map(str::trim)
+        .is_some_and(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn single_message_panel_flag_defaults_off_when_unset() {
+        assert!(!super::parse_single_message_panel_flag(None));
+    }
+
+    #[test]
+    fn single_message_panel_flag_accepts_only_documented_truthy_values() {
+        for raw in ["1", "true", "TRUE", "TrUe", " true "] {
+            assert!(
+                super::parse_single_message_panel_flag(Some(raw)),
+                "{raw:?} should enable the flag"
+            );
+        }
+    }
+
+    #[test]
+    fn single_message_panel_flag_rejects_falsy_and_garbage_values() {
+        for raw in ["", "0", "false", "FALSE", "yes", "on", "garbage"] {
+            assert!(
+                !super::parse_single_message_panel_flag(Some(raw)),
+                "{raw:?} should leave the flag disabled"
+            );
+        }
+    }
+}


### PR DESCRIPTION
EPIC #3089 M1 slice S0 (of S0~S6). Zero behavior change; foundation for the single-message status panel integration approved 2026-06-12.

## What
- New `single_message_panel.rs`: pure parser `parse_single_message_panel_flag` + OnceLock-cached `enabled()` reading `AGENTDESK_SINGLE_MESSAGE_PANEL` ("1"/"true", case-insensitive). Default OFF. No production logic branches on it yet — only a startup INFO log via one bootstrap touch.
- Characterization tests pinning the current two-message model that S1+ will flip behind the flag:
  - `plan_streaming_rollover` footer strip / seed injection / 2000-char budget reservation (formatting.rs)
  - rollover seeds carry NO status-panel content (placeholder_live_events) — the exact invariant S1 changes
- #3016 frozen core hot files untouched. mod.rs baseline +5 with reason comment (wrapper + module decl only; body lives in the child module).

## Verification
- fmt/clippy -D warnings clean; single_message_panel 4 pass ×3, formatting 36 pass, placeholder_live_events 92 pass; audit + agent-maintenance docs clean on committed HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)