### PR TITLE
fix(#3368): classify async launch-ack toolUseResult as non-completion in record reconstruction

### DIFF
--- a/src/services/discord/placeholder_live_events/subagent_rollout.rs
+++ b/src/services/discord/placeholder_live_events/subagent_rollout.rs
@@ -30,9 +30,9 @@ use crate::services::agent_protocol::SubagentSummary;
 
 /// Extracts the TUI summary from a parent-transcript `tool_result` record's
 /// top-level `toolUseResult` object. Returns `(summary, agent_id)` when the
-/// record looks like a finished subagent (i.e. it carries an `agentId` and/or
-/// any of the `total*` accounting fields). Returns `None` for ordinary tool
-/// results that have no subagent accounting.
+/// record looks like a finished subagent (i.e. it carries any of the `total*`
+/// accounting fields). Returns `None` for ordinary tool results and async
+/// launch acknowledgments that have no subagent completion accounting.
 pub(super) fn summary_from_tool_use_result(
     value: &Value,
 ) -> Option<(SubagentSummary, Option<String>)> {
@@ -41,11 +41,21 @@ pub(super) fn summary_from_tool_use_result(
     // the subagent accounting.
     let result = result.as_object()?;
 
+    if result.get("status").and_then(Value::as_str) == Some("async_launched")
+        || result.get("isAsync").and_then(Value::as_bool) == Some(true)
+    {
+        return None;
+    }
+
     let agent_id = result
         .get("agentId")
         .and_then(Value::as_str)
         .map(str::to_string)
         .filter(|id| !id.trim().is_empty());
+
+    let has_accounting_field = result.contains_key("totalToolUseCount")
+        || result.contains_key("totalTokens")
+        || result.contains_key("totalDurationMs");
 
     let tool_count = result.get("totalToolUseCount").and_then(as_u64_lenient);
     let tokens = result.get("totalTokens").and_then(as_u64_lenient);
@@ -62,9 +72,10 @@ pub(super) fn summary_from_tool_use_result(
         duration_secs,
     };
 
-    // Only treat this as a subagent completion when there is an agentId or at
-    // least one accounting field — otherwise it is an ordinary tool result.
-    if agent_id.is_none() && summary.is_empty() {
+    // `agentId` alone is present on async launch acknowledgments and is not a
+    // completion signal. Require explicit accounting, while preserving the
+    // existing non-empty summary path for any future summary extraction.
+    if !has_accounting_field && summary.is_empty() {
         return None;
     }
     Some((summary, agent_id))
@@ -204,6 +215,78 @@ mod tests {
         assert_eq!(summary.tokens, Some(90157));
         // 109275ms → 110s (ceil) — TUI rounds up partial seconds.
         assert_eq!(summary.duration_secs, Some(110));
+    }
+
+    #[test]
+    fn tool_use_result_async_launch_ack_is_not_a_completion_summary() {
+        let value = json!({
+            "type": "user",
+            "toolUseResult": {
+                "isAsync": true,
+                "status": "async_launched",
+                "agentId": "a31353d794c259eb9",
+                "description": "...",
+                "prompt": "...",
+                "outputFile": "...",
+                "canReadOutputFile": true
+            }
+        });
+
+        assert!(summary_from_tool_use_result(&value).is_none());
+    }
+
+    #[test]
+    fn tool_use_result_agent_id_without_accounting_is_not_a_completion_summary() {
+        let values = [
+            json!({
+                "type": "user",
+                "toolUseResult": {
+                    "isAsync": false,
+                    "status": "async_launched-ish",
+                    "agentId": "a31353d794c259eb9"
+                }
+            }),
+            json!({
+                "type": "user",
+                "toolUseResult": {
+                    "isAsync": false,
+                    "agentId": "a31353d794c259eb9"
+                }
+            }),
+            json!({
+                "type": "user",
+                "toolUseResult": {
+                    "isAsync": false,
+                    "status": "async_launched",
+                    "agentId": "a31353d794c259eb9"
+                }
+            }),
+        ];
+
+        for value in values {
+            assert!(
+                summary_from_tool_use_result(&value).is_none(),
+                "agentId-only result must not classify as completion: {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn tool_use_result_without_agent_id_but_with_accounting_is_a_completion_summary() {
+        let value = json!({
+            "type": "user",
+            "toolUseResult": {
+                "totalToolUseCount": 2,
+                "totalTokens": 1234,
+                "totalDurationMs": 1500
+            }
+        });
+
+        let (summary, agent_id) = summary_from_tool_use_result(&value).expect("completion summary");
+        assert_eq!(agent_id, None);
+        assert_eq!(summary.tool_count, Some(2));
+        assert_eq!(summary.tokens, Some(1234));
+        assert_eq!(summary.duration_secs, Some(2));
     }
 
     #[test]

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -2283,6 +2283,163 @@ fn status_panel_background_subagent_not_marked_done_on_launch_ack() {
     );
 }
 
+// #3368: the raw JSONL stream may contain an async launch-ack `toolUseResult`
+// with an agentId but no accounting. That is dispatch acknowledgment, not a
+// completion, so status_events_from_json must not synthesize SubagentEnd.
+#[test]
+fn status_events_json_async_launch_ack_does_not_close_background_subagent() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(875);
+
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({
+                "subagent_type": "bgworker",
+                "description": "Launch ack record reconstruction",
+                "run_in_background": true
+            })
+            .to_string(),
+            Some("toolu_launch_ack"),
+        ),
+    );
+
+    let reconstructed = status_events_from_json(&json!({
+        "type": "user",
+        "message": {
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": "toolu_launch_ack",
+                "is_error": false
+            }]
+        },
+        "toolUseResult": {
+            "isAsync": true,
+            "status": "async_launched",
+            "agentId": "a31353d794c259eb9",
+            "description": "...",
+            "prompt": "...",
+            "outputFile": "...",
+            "canReadOutputFile": true
+        }
+    }));
+    assert!(
+        !reconstructed
+            .iter()
+            .any(|event| matches!(event, StatusEvent::SubagentEnd { .. })),
+        "launch ack must not synthesize SubagentEnd: {reconstructed:?}"
+    );
+
+    events.push_status_events(channel_id, reconstructed);
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    let line = rendered
+        .lines()
+        .find(|line| line.contains("bgworker Launch ack record reconstruction"))
+        .unwrap_or_else(|| panic!("background subagent slot missing in: {rendered}"));
+    assert!(
+        !line.contains('✓') && !line.contains('✗') && !line.contains("Done ("),
+        "background subagent must stay running on async launch ack, got: {line}"
+    );
+}
+
+#[test]
+fn status_panel_async_completion_with_accounting_still_finalizes_subagent() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(876);
+
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({
+                "subagent_type": "asyncworker",
+                "description": "Completion accounting"
+            })
+            .to_string(),
+            Some("toolu_async_done"),
+        ),
+    );
+
+    events.push_status_events(
+        channel_id,
+        status_events_from_json(&json!({
+            "type": "user",
+            "message": {
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_async_done",
+                    "is_error": false
+                }]
+            },
+            "toolUseResult": {
+                "agentId": "aasyncdone000000",
+                "totalToolUseCount": 12,
+                "totalTokens": 5000,
+                "totalDurationMs": 30_000
+            }
+        })),
+    );
+
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    let line = rendered
+        .lines()
+        .find(|line| line.contains("asyncworker Completion accounting"))
+        .unwrap_or_else(|| panic!("async completion slot missing in: {rendered}"));
+    assert!(
+        line.contains("Done (12 tools · 5k tokens · 30s)") && line.contains('✓'),
+        "completion with accounting must still finalize, got: {line}"
+    );
+}
+
+#[test]
+fn status_panel_foreground_completion_without_agent_id_still_finalizes_subagent() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(877);
+
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({
+                "subagent_type": "fgworker",
+                "description": "No agent id completion"
+            })
+            .to_string(),
+            Some("toolu_fg_no_agent"),
+        ),
+    );
+
+    events.push_status_events(
+        channel_id,
+        status_events_from_json(&json!({
+            "type": "user",
+            "message": {
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_fg_no_agent",
+                    "is_error": false
+                }]
+            },
+            "toolUseResult": {
+                "totalToolUseCount": 3,
+                "totalTokens": 1500,
+                "totalDurationMs": 20_000
+            }
+        })),
+    );
+
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    let line = rendered
+        .lines()
+        .find(|line| line.contains("fgworker No agent id completion"))
+        .unwrap_or_else(|| panic!("foreground completion slot missing in: {rendered}"));
+    assert!(
+        line.contains("Done (3 tools · 1.5k tokens · 20s)") && line.contains('✓'),
+        "foreground completion without agentId must still finalize, got: {line}"
+    );
+}
+
 // #3359: an ack-only Task result with a non-matching tool_use_id must be
 // ignored, not routed through the last-unfinished fallback. The later
 // summary-bearing completion with the matching id is the first event allowed to


### PR DESCRIPTION
Closes #3368.

## Problem
Third recurrence of the premature-✓ class (after #3198, #3359/#3365), reproduced live 2026-06-12 02:39Z with the #3365 fix deployed. The TUI record-reconstruction path (`tmux_output_stream` → `status_events_from_json` → `summary_from_tool_use_result`) classified the async Agent launch-ack record (`toolUseResult` with `agentId` but zero accounting fields) as a completion, synthesizing `SubagentEnd{matching id, empty summary, ack_only:false}` — exact-id match + ack_only=false sails through both prior guards.

## Fix (subagent_rollout.rs only)
- `status=="async_launched"` or `isAsync:true` → explicit None (launch acknowledgment, not completion).
- Completion now requires at least one accounting field (`totalToolUseCount`/`totalTokens`/`totalDurationMs`); `agentId` presence alone no longer qualifies. Non-empty summary path preserved.
- Live tool_result path, panel matching arms, task-notification completion path, #3198/#3365 guards: untouched.

## Verification
- Regression fixture = the exact live launch-ack record (transcript 50947d90 line 3493): no SubagentEnd synthesized; legitimate completion records (accounting fields present) still finalize ✓; foreground unchanged; garbage-shape edge cases covered.
- fmt/clippy -D warnings clean; subagent_rollout 9 pass ×5 (no flake), placeholder_live_events 98, status_events 6; audit + agent-maintenance docs clean on committed HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)