### PR TITLE
feat(#3089): S2 — bridge-path status panel as relay-body footer behind flag

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -510,6 +510,7 @@ src/
 │   │   │   ├── recall_feedback.rs
 │   │   │   ├── recovery_text.rs
 │   │   │   ├── retry_state.rs
+│   │   │   ├── single_message_footer.rs
 │   │   │   ├── skill_usage.rs
 │   │   │   ├── stale_resume.rs
 │   │   │   ├── status_panel.rs

--- a/scripts/audit_allowlist.toml
+++ b/scripts/audit_allowlist.toml
@@ -62,6 +62,9 @@ direct_discord_sends = [
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:b4849c24f5cb7d09",
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:1c6f6dcd93167903",
   "src/services/discord/turn_bridge/mod.rs#direct_discord_sends:9b9526b38f0691a8",
+  # #3089 S2: existing status-panel-v2 response-placeholder send moved out of
+  # turn_bridge/mod.rs into the bridge footer helper while preserving behavior.
+  "src/services/discord/turn_bridge/single_message_footer.rs#direct_discord_sends:d2d9f46d97bfa069",
   # #3038 turn_bridge S1: status-panel completion direct gateway calls moved
   # verbatim from turn_bridge/mod.rs to turn_bridge/status_panel.rs.
   "src/services/discord/turn_bridge/status_panel.rs#direct_discord_sends:8806b21b9432ae8a",

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -16,8 +16,116 @@ fn parse_single_message_panel_flag(raw: Option<&str>) -> bool {
         .is_some_and(|value| value == "1" || value.eq_ignore_ascii_case("true"))
 }
 
+pub(in crate::services::discord) fn footer_mode_enabled(
+    single_message_panel_enabled: bool,
+    status_panel_v2_enabled: bool,
+) -> bool {
+    single_message_panel_enabled && status_panel_v2_enabled
+}
+
+pub(in crate::services::discord) fn separate_status_panel_enabled_for_flags(
+    single_message_panel_enabled: bool,
+    status_panel_v2_enabled: bool,
+) -> bool {
+    status_panel_v2_enabled
+        && !footer_mode_enabled(single_message_panel_enabled, status_panel_v2_enabled)
+}
+
+pub(in crate::services::discord) fn live_events_dirty_should_force_status_update(
+    live_events_dirty: bool,
+    single_message_panel_footer_mode: bool,
+) -> bool {
+    live_events_dirty && !single_message_panel_footer_mode
+}
+
+pub(in crate::services::discord) fn compose_footer_status_block(
+    indicator: &str,
+    panel_text: &str,
+) -> String {
+    let spinner = super::formatting::build_processing_status_block(indicator);
+    let panel_text = panel_text.trim();
+    let status_block = if panel_text.is_empty() {
+        spinner
+    } else {
+        format!("{spinner}\n{panel_text}")
+    };
+    clamp_footer_status_block(status_block)
+}
+
+fn clamp_footer_status_block(status_block: String) -> String {
+    let max_bytes = super::DISCORD_MSG_LIMIT.saturating_sub(6);
+    if status_block.len() <= max_bytes {
+        return status_block;
+    }
+    let ellipsis = "…";
+    let body_budget = max_bytes.saturating_sub(ellipsis.len());
+    if body_budget == 0 {
+        return ellipsis.to_string();
+    }
+    let safe_end = super::formatting::floor_char_boundary(&status_block, body_budget);
+    format!("{}{}", &status_block[..safe_end], ellipsis)
+}
+
+pub(in crate::services::discord) fn finalize_streaming_footer(
+    last_edit_text: &str,
+    provider: &super::ProviderKind,
+) -> Option<String> {
+    let cleaned = strip_streaming_footer(last_edit_text, provider)?;
+    if cleaned.trim().is_empty() {
+        None
+    } else {
+        Some(cleaned)
+    }
+}
+
+pub(in crate::services::discord) fn strip_streaming_footer(
+    last_edit_text: &str,
+    provider: &super::ProviderKind,
+) -> Option<String> {
+    if let Some(finalized) =
+        super::formatting::finalize_stale_streaming_footer(last_edit_text, provider)
+    {
+        return Some(finalized);
+    }
+
+    if footer_starts_with_spinner(last_edit_text) {
+        return Some(String::new());
+    }
+
+    let (body, _footer) = split_footer(last_edit_text)?;
+    let cleaned = super::formatting::format_for_discord_with_status_panel(body, provider);
+    if cleaned == last_edit_text {
+        None
+    } else {
+        Some(cleaned)
+    }
+}
+
+fn split_footer(text: &str) -> Option<(&str, &str)> {
+    let mut search_end = text.len();
+    while let Some(idx) = text[..search_end].rfind("\n\n") {
+        let body = &text[..idx];
+        let footer = &text[(idx + 2)..];
+        if footer_starts_with_spinner(footer) {
+            return Some((body, footer));
+        }
+        search_end = idx;
+    }
+    None
+}
+
+fn footer_starts_with_spinner(footer: &str) -> bool {
+    let Some(first_footer_line) = footer.lines().find(|line| !line.trim().is_empty()) else {
+        return false;
+    };
+    super::formatting::is_streaming_placeholder_status_line(first_footer_line.trim())
+}
+
 #[cfg(test)]
 mod tests {
+    use super::super::DISCORD_MSG_LIMIT;
+    use super::super::ProviderKind;
+
     #[test]
     fn single_message_panel_flag_defaults_off_when_unset() {
         assert!(!super::parse_single_message_panel_flag(None));
@@ -41,5 +149,65 @@ mod tests {
                 "{raw:?} should leave the flag disabled"
             );
         }
+    }
+
+    #[test]
+    fn footer_mode_requires_both_flags() {
+        assert!(super::footer_mode_enabled(true, true));
+        assert!(!super::footer_mode_enabled(true, false));
+        assert!(!super::footer_mode_enabled(false, true));
+    }
+
+    #[test]
+    fn footer_status_block_keeps_spinner_first() {
+        let panel = "🟢 진행 중 — Claude (<t:1700000000:R>)\n\nSubagents\n└ review inspect";
+        let block = super::compose_footer_status_block("⠸", panel);
+
+        assert!(block.starts_with("⠸ 계속 처리 중\n🟢 진행 중"));
+        assert!(block.contains("Subagents\n└ review inspect"));
+    }
+
+    #[test]
+    fn terminal_footer_strip_removes_panel_block() {
+        let panel = "🟢 진행 중 — Claude (<t:1700000000:R>)\n\nSubagents\n└ review inspect";
+        let rendered = format!(
+            "Final answer\n\n{}",
+            super::compose_footer_status_block("⠸", panel)
+        );
+        let finalized = super::finalize_streaming_footer(&rendered, &ProviderKind::Claude)
+            .expect("panel footer should strip at terminal reconciliation");
+
+        assert_eq!(finalized, "Final answer");
+        assert!(!finalized.contains("계속 처리 중"));
+        assert!(!finalized.contains("Subagents"));
+    }
+
+    #[test]
+    fn footer_only_body_strips_to_empty_for_cleanup_callers() {
+        let panel = "🟢 진행 중 — Claude (<t:1700000000:R>)\n\nSubagents\n└ review inspect";
+        let rendered = super::compose_footer_status_block("⠸", panel);
+
+        assert_eq!(
+            super::strip_streaming_footer(&rendered, &ProviderKind::Claude),
+            Some(String::new())
+        );
+        assert_eq!(
+            super::finalize_streaming_footer(&rendered, &ProviderKind::Claude),
+            None
+        );
+    }
+
+    #[test]
+    fn footer_status_block_stays_within_discord_limit() {
+        let huge_panel = format!(
+            "🟢 진행 중 — Claude (<t:1700000000:R>)\n\nSubagents\n{}",
+            "└ reviewer ".repeat(1_000)
+        );
+        let status_block = super::compose_footer_status_block("⠸", &huge_panel);
+        let rendered =
+            super::super::formatting::build_streaming_placeholder_text("body", &status_block);
+
+        assert!(rendered.len() <= DISCORD_MSG_LIMIT);
+        assert!(rendered.contains("\n\n"));
     }
 }

--- a/src/services/discord/tmux_watcher/single_message_footer.rs
+++ b/src/services/discord/tmux_watcher/single_message_footer.rs
@@ -10,7 +10,10 @@ pub(super) fn watcher_single_message_panel_footer_enabled(status_panel_v2_enable
 }
 
 fn footer_mode_enabled(single_message_panel_enabled: bool, status_panel_v2_enabled: bool) -> bool {
-    single_message_panel_enabled && status_panel_v2_enabled
+    crate::services::discord::single_message_panel::footer_mode_enabled(
+        single_message_panel_enabled,
+        status_panel_v2_enabled,
+    )
 }
 
 pub(super) fn watcher_separate_status_panel_enabled(status_panel_v2_enabled: bool) -> bool {
@@ -24,15 +27,20 @@ fn separate_status_panel_enabled_for_flags(
     single_message_panel_enabled: bool,
     status_panel_v2_enabled: bool,
 ) -> bool {
-    status_panel_v2_enabled
-        && !footer_mode_enabled(single_message_panel_enabled, status_panel_v2_enabled)
+    crate::services::discord::single_message_panel::separate_status_panel_enabled_for_flags(
+        single_message_panel_enabled,
+        status_panel_v2_enabled,
+    )
 }
 
 pub(super) fn watcher_live_events_dirty_should_force_status_update(
     live_events_dirty: bool,
     single_message_panel_footer_mode: bool,
 ) -> bool {
-    live_events_dirty && !single_message_panel_footer_mode
+    crate::services::discord::single_message_panel::live_events_dirty_should_force_status_update(
+        live_events_dirty,
+        single_message_panel_footer_mode,
+    )
 }
 
 #[cfg(test)]
@@ -66,29 +74,9 @@ pub(super) fn watcher_should_complete_separate_status_panel(status_panel_v2_enab
 }
 
 fn compose_single_message_footer_status_block(indicator: &str, panel_text: &str) -> String {
-    let spinner = crate::services::discord::formatting::build_processing_status_block(indicator);
-    let panel_text = panel_text.trim();
-    let status_block = if panel_text.is_empty() {
-        spinner
-    } else {
-        format!("{spinner}\n{panel_text}")
-    };
-    clamp_single_message_footer_status_block(status_block)
-}
-
-fn clamp_single_message_footer_status_block(status_block: String) -> String {
-    let max_bytes = crate::services::discord::DISCORD_MSG_LIMIT.saturating_sub(6);
-    if status_block.len() <= max_bytes {
-        return status_block;
-    }
-    let ellipsis = "…";
-    let body_budget = max_bytes.saturating_sub(ellipsis.len());
-    if body_budget == 0 {
-        return ellipsis.to_string();
-    }
-    let safe_end =
-        crate::services::discord::formatting::floor_char_boundary(&status_block, body_budget);
-    format!("{}{}", &status_block[..safe_end], ellipsis)
+    crate::services::discord::single_message_panel::compose_footer_status_block(
+        indicator, panel_text,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -126,42 +114,9 @@ pub(super) fn finalize_single_message_panel_streaming_footer(
     last_edit_text: &str,
     provider: &ProviderKind,
 ) -> Option<String> {
-    if let Some(finalized) = crate::services::discord::formatting::finalize_stale_streaming_footer(
+    crate::services::discord::single_message_panel::finalize_streaming_footer(
         last_edit_text,
         provider,
-    ) {
-        return Some(finalized);
-    }
-
-    let (body, _footer) = split_single_message_panel_footer(last_edit_text)?;
-    let cleaned =
-        crate::services::discord::formatting::format_for_discord_with_status_panel(body, provider);
-    if cleaned.trim().is_empty() || cleaned == last_edit_text {
-        None
-    } else {
-        Some(cleaned)
-    }
-}
-
-fn split_single_message_panel_footer(text: &str) -> Option<(&str, &str)> {
-    let mut search_end = text.len();
-    while let Some(idx) = text[..search_end].rfind("\n\n") {
-        let body = &text[..idx];
-        let footer = &text[(idx + 2)..];
-        if single_message_panel_footer_starts_with_spinner(footer) {
-            return Some((body, footer));
-        }
-        search_end = idx;
-    }
-    None
-}
-
-fn single_message_panel_footer_starts_with_spinner(footer: &str) -> bool {
-    let Some(first_footer_line) = footer.lines().find(|line| !line.trim().is_empty()) else {
-        return false;
-    };
-    crate::services::discord::formatting::is_streaming_placeholder_status_line(
-        first_footer_line.trim(),
     )
 }
 

--- a/src/services/discord/turn_bridge/headless_delivery.rs
+++ b/src/services/discord/turn_bridge/headless_delivery.rs
@@ -108,7 +108,33 @@ fn headless_streaming_placeholder_cleanup_action(
     last_edit_text: &str,
     provider: &ProviderKind,
     status_panel_v2_enabled: bool,
+    single_message_panel_footer_mode: bool,
 ) -> HeadlessPlaceholderCleanupAction {
+    if single_message_panel_footer_mode {
+        if let Some(cleaned) =
+            super::finalize_bridge_streaming_footer(true, last_edit_text, provider)
+        {
+            return if cleaned == last_edit_text {
+                HeadlessPlaceholderCleanupAction::Skip
+            } else {
+                HeadlessPlaceholderCleanupAction::Edit(cleaned)
+            };
+        }
+        if let Some(cleaned) =
+            crate::services::discord::single_message_panel::strip_streaming_footer(
+                last_edit_text,
+                provider,
+            )
+        {
+            return if cleaned.trim().is_empty() {
+                HeadlessPlaceholderCleanupAction::Delete
+            } else if cleaned == last_edit_text {
+                HeadlessPlaceholderCleanupAction::Skip
+            } else {
+                HeadlessPlaceholderCleanupAction::Edit(cleaned)
+            };
+        }
+    }
     let mut cleaned = if status_panel_v2_enabled {
         super::formatting::format_for_discord_with_status_panel(last_edit_text, provider)
     } else {
@@ -147,6 +173,7 @@ pub(super) async fn cleanup_headless_streaming_placeholder_after_delivery(
         last_edit_text,
         provider,
         shared.status_panel_v2_enabled,
+        super::bridge_single_message_panel_footer_enabled(shared.status_panel_v2_enabled),
     ) {
         HeadlessPlaceholderCleanupAction::Delete => {
             if let Err(error) =
@@ -423,6 +450,7 @@ mod headless_delivery_tests {
             "[Bash] /bin/zsh -lc 'cargo test'\n⠙ Processing...",
             &ProviderKind::Codex,
             true,
+            false,
         );
 
         assert_eq!(action, HeadlessPlaceholderCleanupAction::Delete);
@@ -434,6 +462,7 @@ mod headless_delivery_tests {
             "⠂ Processing...\n\n```\n[Bash] /bin/zsh -lc 'grep -n foo src/lib.rs'\n[Bash] /bin/zsh -lc \"sed -n '1,40p' src/lib.rs\"\n```",
             &ProviderKind::Codex,
             true,
+            false,
         );
 
         assert_eq!(action, HeadlessPlaceholderCleanupAction::Delete);
@@ -445,6 +474,7 @@ mod headless_delivery_tests {
             "partial answer\n\n⠙ Processing...",
             &ProviderKind::Codex,
             true,
+            false,
         );
 
         assert_eq!(
@@ -458,6 +488,25 @@ mod headless_delivery_tests {
         let action = headless_streaming_placeholder_cleanup_action(
             "partial answer\n\n⠙ 계속 처리 중",
             &ProviderKind::Codex,
+            true,
+            false,
+        );
+
+        assert_eq!(
+            action,
+            HeadlessPlaceholderCleanupAction::Edit("partial answer".to_string())
+        );
+    }
+
+    #[test]
+    fn headless_cleanup_strips_single_message_panel_footer() {
+        let panel = "🟢 진행 중 — Claude (<t:1700000000:R>)\n\nSubagents\n└ review inspect";
+        let footer =
+            crate::services::discord::single_message_panel::compose_footer_status_block("⠸", panel);
+        let action = headless_streaming_placeholder_cleanup_action(
+            &format!("partial answer\n\n{footer}"),
+            &ProviderKind::Claude,
+            true,
             true,
         );
 

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -6,6 +6,7 @@ mod output_lifecycle;
 mod recall_feedback;
 mod recovery_text;
 mod retry_state;
+mod single_message_footer;
 mod skill_usage;
 mod stale_resume;
 mod status_panel;
@@ -48,6 +49,7 @@ pub(super) use recovery_text::{
     auto_retry_with_history, build_session_retry_context_from_history, release_retry_pending,
     store_session_retry_context, take_session_retry_context_for_turn_with_audit,
 };
+use single_message_footer::*;
 pub(super) use stale_resume::result_event_has_stale_resume_error;
 pub(in crate::services::discord) use status_panel::{
     complete_status_panel_v2_with_http, normalize_status_panel_message_id,
@@ -2356,43 +2358,34 @@ pub(super) fn spawn_turn_bridge(
             &mut inflight_state,
             bridge.reuse_status_panel_message,
         );
+        let single_message_panel_footer_mode =
+            bridge_single_message_panel_footer_enabled(shared_owned.status_panel_v2_enabled);
+        if single_message_panel_footer_mode {
+            status_panel_msg_id = None;
+            inflight_state.status_message_id = None;
+        }
         let mut last_status_panel_text = String::new();
         let mut status_panel_dirty = shared_owned.status_panel_v2_enabled;
         let mut last_status_panel_edit = tokio::time::Instant::now() - status_interval;
         let status_panel_started_at = chrono::Utc::now().timestamp();
         let turn_start = std::time::Instant::now();
 
-        if shared_owned.status_panel_v2_enabled
-            && (status_panel_msg_id.is_none() || status_panel_msg_id == Some(current_msg_id))
-        {
-            let response_placeholder = super::formatting::build_processing_status_block(SPINNER[0]);
-            match gateway.send_message(channel_id, &response_placeholder).await {
-                Ok(response_msg_id) => {
-                    if is_synthetic_headless_message_id(current_msg_id) {
-                        status_panel_msg_id = None;
-                        inflight_state.status_message_id = None;
-                    } else {
-                        status_panel_msg_id = Some(current_msg_id);
-                        inflight_state.status_message_id = Some(current_msg_id.get());
-                    }
-                    current_msg_id = response_msg_id;
-                    bridge_created_response_placeholder_msg_id = Some(response_msg_id);
-                    last_edit_text = response_placeholder.to_string();
-                    inflight_state.current_msg_id = current_msg_id.get();
-                    inflight_state.current_msg_len = last_edit_text.len();
-                    inflight_state.response_sent_offset = response_sent_offset;
-                    inflight_state.full_response = full_response.clone();
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        "[turn_bridge] failed to create status-panel-v2 response message in channel {}: {}",
-                        channel_id,
-                        error
-                    );
-                    status_panel_dirty = false;
-                }
-            }
-        }
+        maybe_create_bridge_separate_status_panel_response(
+            single_message_panel_footer_mode,
+            shared_owned.status_panel_v2_enabled,
+            gateway.as_ref(),
+            channel_id,
+            SPINNER[0],
+            &mut current_msg_id,
+            &mut status_panel_msg_id,
+            &mut bridge_created_response_placeholder_msg_id,
+            &mut last_edit_text,
+            &mut inflight_state,
+            response_sent_offset,
+            &full_response,
+            &mut status_panel_dirty,
+        )
+        .await;
 
         if shared_owned.status_panel_v2_enabled
             && let Some(dispatch_id) = dispatch_id.as_deref()
@@ -4129,7 +4122,10 @@ pub(super) fn spawn_turn_bridge(
             spin_idx += 1;
 
             if shared_owned.status_panel_v2_enabled
-                && status_panel_dirty
+                && bridge_status_panel_dirty_should_edit_separate_panel(
+                    status_panel_dirty,
+                    single_message_panel_footer_mode,
+                )
                 && last_status_panel_edit.elapsed() >= status_interval
                 && let Some(status_msg_id) = status_panel_msg_id
             {
@@ -4171,16 +4167,16 @@ pub(super) fn spawn_turn_bridge(
                     }
 
                     let indicator = SPINNER[spin_idx % SPINNER.len()];
-                    let status_block = if shared_owned.status_panel_v2_enabled {
-                        super::formatting::build_processing_status_block(indicator)
-                    } else {
-                        super::formatting::build_placeholder_status_block(
-                            indicator,
-                            prev_tool_status.as_deref(),
-                            current_tool_line.as_deref(),
-                            &full_response,
-                        )
-                    };
+                    let status_block = build_bridge_single_message_panel_status_block(
+                        shared_owned.as_ref(),
+                        channel_id,
+                        &provider,
+                        status_panel_started_at,
+                        indicator,
+                        prev_tool_status.as_deref(),
+                        current_tool_line.as_deref(),
+                        &full_response,
+                    );
                     let Some(plan) =
                         super::formatting::plan_streaming_rollover(current_portion, &status_block)
                     else {
@@ -4290,16 +4286,16 @@ pub(super) fn spawn_turn_bridge(
 
                 let current_portion =
                     response_portion_after_offset(&full_response, response_sent_offset);
-                let status_block = if shared_owned.status_panel_v2_enabled {
-                    super::formatting::build_processing_status_block(indicator)
-                } else {
-                    super::formatting::build_placeholder_status_block(
-                        indicator,
-                        prev_tool_status.as_deref(),
-                        current_tool_line.as_deref(),
-                        &full_response,
-                    )
-                };
+                let status_block = build_bridge_single_message_panel_status_block(
+                    shared_owned.as_ref(),
+                    channel_id,
+                    &provider,
+                    status_panel_started_at,
+                    indicator,
+                    prev_tool_status.as_deref(),
+                    current_tool_line.as_deref(),
+                    &full_response,
+                );
                 let stable_display_text = build_turn_bridge_streaming_edit_text(
                     shared_owned.status_panel_v2_enabled,
                     current_portion,
@@ -6448,7 +6444,10 @@ pub(super) fn spawn_turn_bridge(
         }
 
         let mut status_panel_completion_committed = true;
-        if status_panel_terminal_committed && bridge_should_emit_completion {
+        if status_panel_terminal_committed
+            && bridge_should_emit_completion
+            && bridge_should_complete_separate_status_panel(shared_owned.status_panel_v2_enabled)
+        {
             // #2849: before rendering the completed panel, backfill exact final
             // context usage when the live StatusUpdates never carried it (e.g.
             // silent/background turns). resolve_exact_completion_usage prefers

--- a/src/services/discord/turn_bridge/single_message_footer.rs
+++ b/src/services/discord/turn_bridge/single_message_footer.rs
@@ -1,0 +1,242 @@
+//! #3089 S2 single-message status-panel footer helpers for the turn bridge.
+
+use super::*;
+
+pub(super) fn bridge_single_message_panel_footer_enabled(status_panel_v2_enabled: bool) -> bool {
+    super::single_message_panel::footer_mode_enabled(
+        crate::services::discord::single_message_panel_enabled(),
+        status_panel_v2_enabled,
+    )
+}
+
+pub(super) fn bridge_separate_status_panel_enabled(status_panel_v2_enabled: bool) -> bool {
+    super::single_message_panel::separate_status_panel_enabled_for_flags(
+        crate::services::discord::single_message_panel_enabled(),
+        status_panel_v2_enabled,
+    )
+}
+
+pub(super) fn bridge_status_panel_dirty_should_edit_separate_panel(
+    status_panel_dirty: bool,
+    single_message_panel_footer_mode: bool,
+) -> bool {
+    super::single_message_panel::live_events_dirty_should_force_status_update(
+        status_panel_dirty,
+        single_message_panel_footer_mode,
+    )
+}
+
+#[cfg(test)]
+fn bridge_status_panel_msg_id_for_footer_mode(
+    single_message_panel_footer_mode: bool,
+    status_panel_msg_id: Option<MessageId>,
+) -> Option<MessageId> {
+    if single_message_panel_footer_mode {
+        None
+    } else {
+        status_panel_msg_id
+    }
+}
+
+pub(super) fn bridge_should_create_separate_status_panel(
+    single_message_panel_footer_mode: bool,
+    status_panel_v2_enabled: bool,
+    status_panel_msg_id: Option<MessageId>,
+    current_msg_id: MessageId,
+) -> bool {
+    !single_message_panel_footer_mode
+        && status_panel_v2_enabled
+        && (status_panel_msg_id.is_none() || status_panel_msg_id == Some(current_msg_id))
+}
+
+pub(super) fn bridge_should_complete_separate_status_panel(status_panel_v2_enabled: bool) -> bool {
+    bridge_separate_status_panel_enabled(status_panel_v2_enabled)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn maybe_create_bridge_separate_status_panel_response<G: TurnGateway + ?Sized>(
+    single_message_panel_footer_mode: bool,
+    status_panel_v2_enabled: bool,
+    gateway: &G,
+    channel_id: ChannelId,
+    initial_indicator: &str,
+    current_msg_id: &mut MessageId,
+    status_panel_msg_id: &mut Option<MessageId>,
+    bridge_created_response_placeholder_msg_id: &mut Option<MessageId>,
+    last_edit_text: &mut String,
+    inflight_state: &mut InflightTurnState,
+    response_sent_offset: usize,
+    full_response: &str,
+    status_panel_dirty: &mut bool,
+) {
+    if !bridge_should_create_separate_status_panel(
+        single_message_panel_footer_mode,
+        status_panel_v2_enabled,
+        *status_panel_msg_id,
+        *current_msg_id,
+    ) {
+        return;
+    }
+
+    let response_placeholder = super::formatting::build_processing_status_block(initial_indicator);
+    match gateway
+        .send_message(channel_id, &response_placeholder)
+        .await
+    {
+        Ok(response_msg_id) => {
+            if is_synthetic_headless_message_id(*current_msg_id) {
+                *status_panel_msg_id = None;
+                inflight_state.status_message_id = None;
+            } else {
+                *status_panel_msg_id = Some(*current_msg_id);
+                inflight_state.status_message_id = Some(current_msg_id.get());
+            }
+            *current_msg_id = response_msg_id;
+            *bridge_created_response_placeholder_msg_id = Some(response_msg_id);
+            *last_edit_text = response_placeholder.to_string();
+            inflight_state.current_msg_id = current_msg_id.get();
+            inflight_state.current_msg_len = last_edit_text.len();
+            inflight_state.response_sent_offset = response_sent_offset;
+            inflight_state.full_response = full_response.to_string();
+        }
+        Err(error) => {
+            tracing::warn!(
+                "[turn_bridge] failed to create status-panel-v2 response message in channel {}: {}",
+                channel_id,
+                error
+            );
+            *status_panel_dirty = false;
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn build_bridge_single_message_panel_status_block(
+    shared: &SharedData,
+    channel_id: ChannelId,
+    provider: &ProviderKind,
+    started_at_unix: i64,
+    indicator: &str,
+    prev_tool_status: Option<&str>,
+    current_tool_line: Option<&str>,
+    full_response: &str,
+) -> String {
+    if bridge_single_message_panel_footer_enabled(shared.status_panel_v2_enabled) {
+        let panel_text = shared.placeholder_live_events.render_status_panel(
+            channel_id,
+            provider,
+            started_at_unix,
+        );
+        return super::single_message_panel::compose_footer_status_block(indicator, &panel_text);
+    }
+    if shared.status_panel_v2_enabled {
+        super::formatting::build_processing_status_block(indicator)
+    } else {
+        super::formatting::build_placeholder_status_block(
+            indicator,
+            prev_tool_status,
+            current_tool_line,
+            full_response,
+        )
+    }
+}
+
+pub(super) fn finalize_bridge_streaming_footer(
+    single_message_panel_footer_mode: bool,
+    last_edit_text: &str,
+    provider: &ProviderKind,
+) -> Option<String> {
+    if single_message_panel_footer_mode {
+        super::single_message_panel::finalize_streaming_footer(last_edit_text, provider)
+    } else {
+        super::formatting::finalize_stale_streaming_footer(last_edit_text, provider)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::discord::DISCORD_MSG_LIMIT;
+
+    const PANEL: &str = "🟢 진행 중 — Claude (<t:1700000000:R>)\n\nSubagents\n└ review inspect";
+
+    #[test]
+    fn bridge_footer_mode_requires_both_flags() {
+        assert!(super::single_message_panel::footer_mode_enabled(true, true));
+        assert!(!super::single_message_panel::footer_mode_enabled(
+            true, false
+        ));
+        assert!(!super::single_message_panel::footer_mode_enabled(
+            false, true
+        ));
+    }
+
+    #[test]
+    fn bridge_footer_streaming_edit_text_includes_panel_footer() {
+        let status_block = super::single_message_panel::compose_footer_status_block("⠸", PANEL);
+        let rendered = super::super::build_turn_bridge_streaming_edit_text(
+            true,
+            "Bridge body",
+            &status_block,
+            &ProviderKind::Claude,
+        );
+
+        assert!(rendered.starts_with("Bridge body\n\n⠸ 계속 처리 중\n🟢 진행 중"));
+        assert!(rendered.contains("Subagents\n└ review inspect"));
+    }
+
+    #[test]
+    fn bridge_footer_disables_separate_panel_creation_and_binding() {
+        let footer_mode = super::single_message_panel::footer_mode_enabled(true, true);
+        let current = MessageId::new(7);
+
+        assert!(!bridge_should_create_separate_status_panel(
+            footer_mode,
+            true,
+            None,
+            current,
+        ));
+        assert_eq!(
+            bridge_status_panel_msg_id_for_footer_mode(footer_mode, Some(MessageId::new(42))),
+            None,
+        );
+    }
+
+    #[test]
+    fn bridge_terminal_footer_strips_panel_block() {
+        let rendered = format!(
+            "Final answer\n\n{}",
+            super::single_message_panel::compose_footer_status_block("⠸", PANEL)
+        );
+        let finalized = finalize_bridge_streaming_footer(true, &rendered, &ProviderKind::Claude)
+            .expect("panel footer should strip at terminal reconciliation");
+
+        assert_eq!(finalized, "Final answer");
+        assert!(!finalized.contains("계속 처리 중"));
+        assert!(!finalized.contains("Subagents"));
+    }
+
+    #[test]
+    fn bridge_footer_only_dirty_does_not_force_separate_panel_edit() {
+        assert!(!bridge_status_panel_dirty_should_edit_separate_panel(
+            true, true,
+        ));
+        assert!(bridge_status_panel_dirty_should_edit_separate_panel(
+            true, false,
+        ));
+    }
+
+    #[test]
+    fn bridge_pathological_panel_stays_within_discord_limit() {
+        let huge_panel = format!(
+            "🟢 진행 중 — Claude (<t:1700000000:R>)\n\nSubagents\n{}",
+            "└ reviewer ".repeat(1_000)
+        );
+        let status_block =
+            super::single_message_panel::compose_footer_status_block("⠸", &huge_panel);
+        let rendered = super::formatting::build_streaming_placeholder_text("body", &status_block);
+
+        assert!(rendered.len() <= DISCORD_MSG_LIMIT);
+        assert!(rendered.contains("\n\n"));
+    }
+}


### PR DESCRIPTION
EPIC #3089 M1 slice S2 (after S0 #3366, S1 #3367). Flag `AGENTDESK_SINGLE_MESSAGE_PANEL` still default OFF.

## What
- Shared composition helpers promoted from the S1 watcher child module into `single_message_panel.rs` (+168); watcher module delegates (its 8 S1 tests unchanged and green).
- New `turn_bridge/single_message_footer.rs` (242 lines incl. tests): bridge-path footer composition, terminal strip, gating predicates — mirrors S1.
- `turn_bridge/mod.rs` surgical wiring (±105, baseline 8417 kept): flag-on gates panel create/bind, completion family, #3078 parity calls; streamed-body edits carry the compact-panel footer; `status_message_id` stays None.
- `headless_delivery.rs`: flag-on cleanup path strips the footer (Skip/Edit/Delete actions preserved); flag-off falls through to the original code verbatim.
- audit_allowlist: one hash-keyed entry moved with the relocated v2 placeholder send (same pattern as prior #3038 moves, reason comment included).

## Verification
- fmt/clippy -D warnings clean; turn_bridge 159, tmux_watcher 162, single_message suites 25 ×3, formatting 36, placeholder_live_events 98 — flag-off invariance proven by untouched S0/S1 suites; audit + agent-maintenance docs clean on committed HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)