### PR TITLE
feat(#3089): S4 — recovery/persistence coherence for single-message footer mode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -441,6 +441,8 @@ src/
 │   │   │   ├── memory_guidance.rs
 │   │   │   ├── mod.rs
 │   │   │   └── section_dedupe.rs
+│   │   ├── recovery_engine/
+│   │   │   └── status_panel.rs
 │   │   ├── recovery_paths/
 │   │   │   ├── mod.rs
 │   │   │   ├── restart.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -665,7 +665,7 @@
     its G1/G2 snapshots from `external_input_relay_lease(...).map(|l| l.generation)`;
     +62 from #3304: slash-command canonical prompt keys for `<command-*>` XML vs
     `/command args` dedupe, plus focused loop skill-expansion regressions).
-  - `src/services/discord/recovery_engine.rs` (4090 lines; #3016 phase-5b2
+  - `src/services/discord/recovery_engine.rs` (4077 lines; #3016 phase-5b2
     dropped the `mailbox_finalize_owed` construction from the three recovery
     watcher-spawn handles; +9 from #3166
     fetching real context thresholds for the recovered-turn status panel; +36 from #3099
@@ -686,7 +686,9 @@
     `RecoveryRelayOutcome` — the five notice branches route through
     `recovery_paths/restart.rs::dispose_recovery_relay_outcome` (permanent
     Discord 404/403/410 force-clear + 3-restart transient budget); the pure
-    decision matrix lives in `recovery_paths/shared.rs`).
+    decision matrix lives in `recovery_paths/shared.rs`; -13 from #3089 S4
+    moving single-message status-panel completion targeting into
+    `recovery_engine/status_panel.rs`).
   - `src/services/discord/health.rs` (417 prod lines after the #3038 Phase A
     directory decomposition; module root keeps the `HealthRegistry` core +
     re-export surface, and the former monolith body lives in flat

--- a/src/services/discord/placeholder_sweeper.rs
+++ b/src/services/discord/placeholder_sweeper.rs
@@ -1304,7 +1304,28 @@ mod safety_net_threshold_tests {
     //! before the sweeper does anything destructive.
     use super::{
         ABANDON_THRESHOLD_SECS, INITIAL_DELAY_SECS, STALL_THRESHOLD_SECS, SWEEP_INTERVAL_SECS,
+        panel_reclaim_target,
     };
+    use crate::services::provider::ProviderKind;
+
+    fn sweep_state_with_panel(status_message_id: Option<u64>) -> super::InflightTurnState {
+        let mut state = super::InflightTurnState::new(
+            ProviderKind::Claude,
+            4242,
+            None,
+            7,
+            9101,
+            9102,
+            "prompt".to_string(),
+            Some("session".to_string()),
+            Some("AgentDesk-claude-adk".to_string()),
+            Some("/tmp/recovery.jsonl".to_string()),
+            None,
+            0,
+        );
+        state.status_message_id = status_message_id;
+        state
+    }
 
     #[test]
     fn stall_threshold_is_at_least_five_minutes() {
@@ -1343,5 +1364,23 @@ mod safety_net_threshold_tests {
         // than one minute. 30s is the current cadence; pin the
         // upper bound.
         assert!(SWEEP_INTERVAL_SECS <= 60);
+    }
+
+    #[test]
+    fn off_to_on_stale_panel_still_reaches_sweeper_reclaim_target() {
+        let state = sweep_state_with_panel(Some(5001));
+
+        let target = panel_reclaim_target(&state, ABANDON_THRESHOLD_SECS);
+
+        assert_eq!(target.map(|id| id.get()), Some(5001));
+    }
+
+    #[test]
+    fn footer_mode_none_panel_has_no_sweeper_reclaim_target() {
+        let state = sweep_state_with_panel(None);
+
+        let target = panel_reclaim_target(&state, ABANDON_THRESHOLD_SECS);
+
+        assert_eq!(target, None);
     }
 }

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -25,6 +25,9 @@ use std::path::Path;
 #[cfg(unix)]
 use std::process::Command;
 
+#[path = "recovery_engine/status_panel.rs"]
+mod recovery_status_panel;
+
 #[cfg(not(unix))]
 fn tmux_session_has_live_pane(_name: &str) -> bool {
     false
@@ -429,9 +432,14 @@ async fn complete_recovery_visible_turn(
     );
     let started_at_unix = super::inflight::parse_started_at_unix(&state.started_at)
         .unwrap_or_else(|| chrono::Utc::now().timestamp());
-    let persisted_inflight = super::inflight::load_inflight_state(provider, channel_id.get());
-    let status_msg_id =
-        recovery_status_panel_message_id_for_completion(state, persisted_inflight.as_ref());
+    let Some(status_msg_id) = recovery_status_panel::completion_target(
+        shared.status_panel_v2_enabled,
+        state,
+        provider,
+        channel_id,
+    ) else {
+        return RecoveryCompletionOutcome::Emitted;
+    };
 
     // EPIC #3078 PR-2 — route recovery completion through the
     // `StatusPanelController` behind a parity check (shadow mode). The
@@ -472,27 +480,6 @@ async fn complete_recovery_visible_turn(
     )
     .await;
     RecoveryCompletionOutcome::Emitted
-}
-
-fn recovery_status_panel_message_id_for_completion(
-    state: &super::inflight::InflightTurnState,
-    persisted: Option<&super::inflight::InflightTurnState>,
-) -> Option<MessageId> {
-    persisted
-        .and_then(|inflight| {
-            if inflight.user_msg_id == state.user_msg_id {
-                super::turn_bridge::normalize_status_panel_message_id(
-                    inflight.status_message_id.map(MessageId::new),
-                )
-            } else {
-                None
-            }
-        })
-        .or_else(|| {
-            super::turn_bridge::normalize_status_panel_message_id(
-                state.status_message_id.map(MessageId::new),
-            )
-        })
 }
 
 /// EPIC #3078 PR-2 — the parity gate between the legacy recovery
@@ -537,8 +524,7 @@ mod recovery_dispatch_gate_tests {
 #[cfg(test)]
 mod recovery_completion_outcome_tests {
     use super::{
-        RecoveryCompletionOutcome, assert_recovery_completion_parity,
-        recovery_status_panel_message_id_for_completion,
+        RecoveryCompletionOutcome, assert_recovery_completion_parity, recovery_status_panel,
     };
     use crate::services::provider::ProviderKind;
 
@@ -580,7 +566,7 @@ mod recovery_completion_outcome_tests {
         persisted.status_message_id = Some(4004);
 
         let status_msg_id =
-            recovery_status_panel_message_id_for_completion(&snapshot, Some(&persisted));
+            recovery_status_panel::message_id_for_completion(&snapshot, Some(&persisted));
 
         assert_eq!(status_msg_id, Some(super::MessageId::new(4004)));
     }
@@ -593,9 +579,60 @@ mod recovery_completion_outcome_tests {
         persisted.status_message_id = Some(4004);
 
         let status_msg_id =
-            recovery_status_panel_message_id_for_completion(&snapshot, Some(&persisted));
+            recovery_status_panel::message_id_for_completion(&snapshot, Some(&persisted));
 
         assert_eq!(status_msg_id, Some(super::MessageId::new(3003)));
+    }
+
+    #[test]
+    fn footer_mode_skips_recovery_status_panel_completion_for_stale_persisted_id() {
+        let mut snapshot = state_for_recovery(9101);
+        snapshot.status_message_id = Some(3003);
+        let mut persisted = state_for_recovery(9101);
+        persisted.status_message_id = Some(4004);
+
+        let target = recovery_status_panel::completion_target_for_flags(
+            true,
+            true,
+            &snapshot,
+            Some(&persisted),
+        );
+
+        assert_eq!(
+            target, None,
+            "footer mode must not edit or SendFallback a separate recovery panel; the stale id is left for sweeper reclaim"
+        );
+    }
+
+    #[test]
+    fn flag_off_recovery_status_panel_completion_keeps_original_target() {
+        let mut snapshot = state_for_recovery(9101);
+        snapshot.status_message_id = Some(3003);
+        let mut persisted = state_for_recovery(9101);
+        persisted.status_message_id = Some(4004);
+
+        let target = recovery_status_panel::completion_target_for_flags(
+            false,
+            true,
+            &snapshot,
+            Some(&persisted),
+        );
+
+        assert_eq!(target, Some(Some(super::MessageId::new(4004))));
+    }
+
+    #[test]
+    fn flag_off_recovery_none_target_still_requests_send_fallback() {
+        let snapshot = state_for_recovery(9101);
+
+        let target =
+            recovery_status_panel::completion_target_for_flags(false, true, &snapshot, None);
+
+        assert_eq!(
+            target,
+            Some(None),
+            "flag-off v2 recovery preserves the SendFallback rollback behavior when no status_message_id was persisted"
+        );
     }
 
     // EPIC #3078 PR-2: for representative recovery-completion inputs, the
@@ -615,7 +652,7 @@ mod recovery_completion_outcome_tests {
         snapshot.status_message_id = Some(3003);
         let mut persisted = state_for_recovery(9101);
         persisted.status_message_id = Some(4004);
-        let legacy = recovery_status_panel_message_id_for_completion(&snapshot, Some(&persisted));
+        let legacy = recovery_status_panel::message_id_for_completion(&snapshot, Some(&persisted));
         assert_eq!(legacy, Some(super::MessageId::new(4004)));
 
         let ctl = StatusPanelController::spawn(true);
@@ -632,7 +669,7 @@ mod recovery_completion_outcome_tests {
         // collapses onto the single live entry it adopted, choosing the same id.
         let mut snapshot0 = state_for_recovery(0);
         snapshot0.status_message_id = Some(5005);
-        let legacy0 = recovery_status_panel_message_id_for_completion(&snapshot0, None);
+        let legacy0 = recovery_status_panel::message_id_for_completion(&snapshot0, None);
         assert_eq!(legacy0, Some(super::MessageId::new(5005)));
 
         let ctl0 = StatusPanelController::spawn(true);
@@ -647,7 +684,7 @@ mod recovery_completion_outcome_tests {
 
         // Case C: no panel id at all (None) — both agree on None.
         let snapshot_none = state_for_recovery(9300);
-        let legacy_none = recovery_status_panel_message_id_for_completion(&snapshot_none, None);
+        let legacy_none = recovery_status_panel::message_id_for_completion(&snapshot_none, None);
         assert_eq!(legacy_none, None);
 
         let ctl_none = StatusPanelController::spawn(true);

--- a/src/services/discord/recovery_engine/status_panel.rs
+++ b/src/services/discord/recovery_engine/status_panel.rs
@@ -1,0 +1,71 @@
+use poise::serenity_prelude::{ChannelId, MessageId};
+
+use super::super::{inflight, single_message_panel, turn_bridge};
+use crate::services::provider::ProviderKind;
+
+pub(super) fn completion_target(
+    status_panel_v2_enabled: bool,
+    state: &inflight::InflightTurnState,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+) -> Option<Option<MessageId>> {
+    if !single_message_panel::separate_status_panel_enabled(status_panel_v2_enabled) {
+        return None;
+    }
+    let persisted = inflight::load_inflight_state(provider, channel_id.get());
+    Some(message_id_for_completion(state, persisted.as_ref()))
+}
+
+#[cfg(test)]
+pub(super) fn completion_target_for_flags(
+    single_message_panel_enabled_flag: bool,
+    status_panel_v2_enabled: bool,
+    state: &inflight::InflightTurnState,
+    persisted: Option<&inflight::InflightTurnState>,
+) -> Option<Option<MessageId>> {
+    if !single_message_panel::separate_status_panel_enabled_for_flags(
+        single_message_panel_enabled_flag,
+        status_panel_v2_enabled,
+    ) {
+        return None;
+    }
+    Some(message_id_for_completion(state, persisted))
+}
+
+pub(super) fn message_id_for_completion(
+    state: &inflight::InflightTurnState,
+    persisted: Option<&inflight::InflightTurnState>,
+) -> Option<MessageId> {
+    persisted
+        .and_then(|inflight| {
+            if inflight.user_msg_id == state.user_msg_id {
+                turn_bridge::normalize_status_panel_message_id(
+                    inflight.status_message_id.map(MessageId::new),
+                )
+            } else {
+                None
+            }
+        })
+        .or_else(|| {
+            turn_bridge::normalize_status_panel_message_id(
+                state.status_message_id.map(MessageId::new),
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::single_message_panel_enabled;
+    use super::*;
+
+    #[test]
+    fn current_flag_helper_matches_for_flags() {
+        assert_eq!(
+            single_message_panel::separate_status_panel_enabled_for_flags(
+                single_message_panel_enabled(),
+                true,
+            ),
+            single_message_panel::separate_status_panel_enabled(true)
+        );
+    }
+}

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -33,6 +33,12 @@ pub(in crate::services::discord) fn separate_status_panel_enabled_for_flags(
         && !footer_mode_enabled(single_message_panel_enabled, status_panel_v2_enabled)
 }
 
+pub(in crate::services::discord) fn separate_status_panel_enabled(
+    status_panel_v2_enabled: bool,
+) -> bool {
+    separate_status_panel_enabled_for_flags(enabled(), status_panel_v2_enabled)
+}
+
 pub(in crate::services::discord) fn live_events_dirty_should_force_status_update(
     live_events_dirty: bool,
     single_message_panel_footer_mode: bool,

--- a/src/services/discord/status_panel_orphan_store.rs
+++ b/src/services/discord/status_panel_orphan_store.rs
@@ -168,6 +168,59 @@ pub(in crate::services::discord) fn enqueue(
     enqueue_in_root(&root, provider, token_hash, channel_id, panel_msg_id);
 }
 
+fn should_record_separate_status_panel_orphan_for_flags(
+    single_message_panel_enabled: bool,
+    status_panel_v2_enabled: bool,
+) -> bool {
+    super::single_message_panel::separate_status_panel_enabled_for_flags(
+        single_message_panel_enabled,
+        status_panel_v2_enabled,
+    )
+}
+
+fn enqueue_separate_status_panel_orphan_in_root_for_flags(
+    root: &Path,
+    single_message_panel_enabled: bool,
+    status_panel_v2_enabled: bool,
+    provider: &ProviderKind,
+    token_hash: &str,
+    channel_id: u64,
+    panel_msg_id: u64,
+) {
+    if !should_record_separate_status_panel_orphan_for_flags(
+        single_message_panel_enabled,
+        status_panel_v2_enabled,
+    ) {
+        return;
+    }
+    enqueue_in_root(root, provider, token_hash, channel_id, panel_msg_id);
+}
+
+/// Record a same-run separate status-panel orphan. Footer-mode turns never own a
+/// separate status panel, so they must not grow this store. Transition cleanup
+/// for stale flag-off panels uses the raw [`enqueue`] after an attempted sweeper
+/// delete, because those are real legacy panel messages that still need retry.
+pub(in crate::services::discord) fn enqueue_separate_status_panel_orphan(
+    status_panel_v2_enabled: bool,
+    provider: &ProviderKind,
+    token_hash: &str,
+    channel_id: u64,
+    panel_msg_id: u64,
+) {
+    let Some(root) = runtime_store::discord_status_panel_orphans_root() else {
+        return;
+    };
+    enqueue_separate_status_panel_orphan_in_root_for_flags(
+        &root,
+        super::single_message_panel_enabled(),
+        status_panel_v2_enabled,
+        provider,
+        token_hash,
+        channel_id,
+        panel_msg_id,
+    );
+}
+
 /// All pending `(channel_id, panel_msg_id)` records for this bot.
 pub(in crate::services::discord) fn load_pending(
     provider: &ProviderKind,
@@ -544,6 +597,38 @@ mod tests {
         assert_eq!(
             load_pending_in_root(root, &provider, "bot_b"),
             vec![(100, 6001)]
+        );
+    }
+
+    #[test]
+    fn footer_mode_status_panel_orphan_enqueue_is_noop_at_store_api() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let root = root.path();
+        let provider = ProviderKind::Claude;
+
+        enqueue_separate_status_panel_orphan_in_root_for_flags(
+            root, true, true, &provider, "tok", 100, 5001,
+        );
+
+        assert!(
+            load_pending_in_root(root, &provider, "tok").is_empty(),
+            "flag-on footer-mode turns must not create panel orphan records"
+        );
+    }
+
+    #[test]
+    fn flag_off_status_panel_orphan_enqueue_preserves_original_store_behavior() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let root = root.path();
+        let provider = ProviderKind::Claude;
+
+        enqueue_separate_status_panel_orphan_in_root_for_flags(
+            root, false, true, &provider, "tok", 100, 5001,
+        );
+
+        assert_eq!(
+            load_pending_in_root(root, &provider, "tok"),
+            vec![(100, 5001)]
         );
     }
 }

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1349,12 +1349,7 @@ async fn cleanup_orphan_external_input_status_panel(
         // clear its inflight before any retry runs, leaving no per-turn handle.
         // Record the panel in the durable store so the sweeper drain reclaims it
         // independent of inflight lifecycle.
-        crate::services::discord::status_panel_orphan_store::enqueue(
-            provider,
-            &shared.token_hash,
-            channel_id.get(),
-            panel_msg_id.get(),
-        );
+        enqueue_watcher_status_panel_orphan(shared.as_ref(), provider, channel_id, panel_msg_id);
         let ts = chrono::Local::now().format("%H:%M:%S");
         tracing::warn!(
             "  [{ts}] ⚠ watcher: orphan status-panel-v2 delete did not commit for channel {} panel_msg {}; kept local id + enqueued durable retry",
@@ -3459,11 +3454,11 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                                                 // inflight, so record it in the durable store for
                                                 // the sweeper drain to reclaim independent of turn
                                                 // lifecycle (#3003 codex P2 r14 pattern).
-                                                crate::services::discord::status_panel_orphan_store::enqueue(
+                                                enqueue_watcher_status_panel_orphan(
+                                                    shared.as_ref(),
                                                     &watcher_provider,
-                                                    &shared.token_hash,
-                                                    channel_id.get(),
-                                                    panel_msg.id.get(),
+                                                    channel_id,
+                                                    panel_msg.id,
                                                 );
                                             }
                                             // Resolve the handle from the row's CURRENT owned id as
@@ -3524,11 +3519,11 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                                             // #3003 (codex P2 r14): transient delete failure but the
                                             // duplicate exists and this path never persists it —
                                             // record it for the sweeper drain to reclaim.
-                                            crate::services::discord::status_panel_orphan_store::enqueue(
+                                            enqueue_watcher_status_panel_orphan(
+                                                shared.as_ref(),
                                                 &watcher_provider,
-                                                &shared.token_hash,
-                                                channel_id.get(),
-                                                panel_msg.id.get(),
+                                                channel_id,
+                                                panel_msg.id,
                                             );
                                             // #3003 (codex P2 r19/r22): adopt the CANONICAL persisted
                                             // panel ONLY for a same-turn overlapping-watcher duplicate
@@ -6887,11 +6882,11 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         // path, dropping the only handle to the panel that is still stuck at
                         // the processing state. Enqueue it in the durable store so the sweeper
                         // drain reclaims (deletes) it independent of inflight lifecycle.
-                        crate::services::discord::status_panel_orphan_store::enqueue(
+                        enqueue_watcher_status_panel_orphan(
+                            shared.as_ref(),
                             &watcher_provider,
-                            &shared.token_hash,
-                            channel_id.get(),
-                            panel_msg_id.get(),
+                            channel_id,
+                            panel_msg_id,
                         );
                         let ts = chrono::Local::now().format("%H:%M:%S");
                         tracing::warn!(

--- a/src/services/discord/tmux_watcher/panel_decisions.rs
+++ b/src/services/discord/tmux_watcher/panel_decisions.rs
@@ -174,6 +174,21 @@ pub(super) fn watcher_should_create_external_input_status_panel(
     status_panel_v2_enabled && !status_panel_present && inflight_represents_external_input
 }
 
+pub(super) fn enqueue_watcher_status_panel_orphan(
+    shared: &SharedData,
+    provider: &ProviderKind,
+    channel_id: ChannelId,
+    panel_msg_id: serenity::MessageId,
+) {
+    crate::services::discord::status_panel_orphan_store::enqueue_separate_status_panel_orphan(
+        shared.status_panel_v2_enabled,
+        provider,
+        &shared.token_hash,
+        channel_id.get(),
+        panel_msg_id.get(),
+    );
+}
+
 /// #3003 (codex P2): a status-panel-v2 message already persisted on the
 /// matching-session inflight row that the restore seed could not re-hydrate.
 ///


### PR DESCRIPTION
EPIC #3089 M1 slice S4 (after S0-S3). Flag still default OFF; flag-off byte-identical.

## What
Sweep slice: enumerated all 19 surfaces that read/write `status_message_id` or reason about panel-message existence; full audit table (A/B/C classification per surface) in the commit message.

Fixes:
- **(B)** `status_panel_orphan_store`: footer-aware enqueue wrapper — flag-on turns produce ZERO panel orphan records; watcher call sites swapped to the wrapper (4 sites, signature-level only; new logic in `tmux_watcher/panel_decisions.rs`).
- **(B/C)** `recovery_engine`: footer mode skips separate-panel completion entirely (None can no longer SendFallback into creating a new panel message); stale off→on `Some(id)` left for the sweeper; flag-off preserves original edit/SendFallback. New child `recovery_engine/status_panel.rs`.
- **(C)** `placeholder_sweeper`: pinned the off→on transition — stale panel ids reclaimed at the 1800s abandon threshold with footer mode on; on→off rollback (None → SendFallback) pinned.

## Verification
- fmt/clippy clean; turn_bridge 159, tmux_watcher 162, orphan_store ×3, sweeper, recovery, single_message suites green; audit + docs clean on committed HEAD; frozen files: call-site swaps only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)