### PR TITLE
refactor(#3038): run_bot S5 closing pass — gateway runtime tail extraction + ratchet accounting

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -470,6 +470,7 @@ src/
 │   │   ├── runtime_bootstrap/
 │   │   │   ├── framework_setup.rs
 │   │   │   ├── gateway_lease.rs
+│   │   │   ├── gateway_runtime.rs
 │   │   │   ├── intake.rs
 │   │   │   ├── orphan_recovery.rs
 │   │   │   ├── queued_placeholders.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -8,7 +8,7 @@
 > [`docs/generated/giant-file-registry.md`](../generated/giant-file-registry.md);
 > the rows below project the operational meaning of each entry.
 >
-> Last refreshed: 2026-06-11 (against #3306 idle-relay registry/dedupe-mirror drift self-heal — new non-giant `src/services/discord/idle_relay_drift.rs` rate-limits the per-session drift WARN and one-shot self-heals the authoritative registry from a DURABLE source — the settings binding or the `sessions.channel_id` durable column via the new `load_session_channel_id_pg` — guarded by live-pane + instance-id + mirror-agreement so #3018's single-authority / never-route-from-mirror invariant holds; `tui_prompt_relay.rs` net 0-line at the 5429 freeze, `mod.rs` +1 to the 4987 freeze, `db/dispatched_sessions.rs` +48; on top of #3303 deferred-claim anchor reconcile — the `tui_direct_abort_marker` module is decomposed into a directory module of `mod.rs` + `store.rs` + `deferred_claim.rs`, all non-giant, and a successful watcher-owned deferred claim now records an own-identity `DeferredClaim` marker so the anchor's `⏳` converges to `✅` on the own commit or a bounded sweep `⚠`; tmux_watcher / tui_prompt_relay / health recovery / placeholder_sweeper are 0-line changes; on top of #3216 resume-protection residual gaps on top of #3207 — session_runtime now adds a SAFE legacy NULL-channel_id fallback to the channel-scoped cwd resolves via resolve_cwd_for_session_key honored only for a single legacy row, plus a live-tmux recovery-cwd reconcile in auto_restore_session_force via reconcile_recovery_cwd and correct_session_cwd_to_tmux that adopts the live pane cwd over a divergent DB cwd and self-heals the row; #3207 comprehensive channel_id scoping of session-cwd DB resolves — auto_restore_session_force restart restore via restore_session_cwd_from_db and watcher recovery via load_restored_session_cwd require channel_id = $2; on top of #3105 dead/orphaned TUI-session mirror eviction made flake-resistant and run off the Tokio executor).
+> Last refreshed: 2026-06-12 (against #3038 run_bot S5 closing pass).
 
 ## Read This First
 
@@ -776,21 +776,22 @@
     `finalize_stale_streaming_footer` / `text_ends_with_streaming_footer` shared
     terminal-idle reconciliation helpers + their unit tests).
   - `src/services/discord/prompt_builder/` (directory, refactored).
-  - `src/services/discord/runtime_bootstrap.rs` (369 production lines after
-    #3038 run_bot S0/S4; characterization tests pin the startup-doctor barrier,
+  - `src/services/discord/runtime_bootstrap.rs` (274 production lines after
+    #3038 run_bot S0/S5; characterization tests pin the startup-doctor barrier,
     restored settings filters, queued-placeholder filtering/deletion, and
     gateway intents, then the low-risk clusters moved verbatim into
     `runtime_bootstrap/`: `restored_state.rs` (124), `queued_placeholders.rs`
     (193), `startup_doctor.rs` (156), `orphan_recovery.rs` (337),
     `session_gc.rs` (102 prod / 69 test), `framework_setup.rs` (287),
-    `spawns.rs` (218), `recovery_flush.rs` (356), `voice.rs` (140),
-    `gateway_lease.rs` (187), `shutdown.rs` (203), `intake.rs` (63), and —
-    once the SharedData S1-S3 slices merged — `shared_data.rs` (176, the
-    `run_bot_build_shared_data` builder plus its side-effect-order doc).
+    `spawns.rs` (229), `recovery_flush.rs` (357), `voice.rs` (140),
+    `gateway_lease.rs` (190), `shutdown.rs` (207), `intake.rs` (63),
+    `shared_data.rs` (176, the `run_bot_build_shared_data` builder plus its
+    side-effect-order doc), and `gateway_runtime.rs` (147, the leader runtime
+    tail from restored logging through backend event-loop entry).
     The namespace is capped at 700 prod lines per child module in
     `audit_maintainability_config.toml`; the root is no longer a prod giant and
-    was removed from `giant_file_registry.toml`; only the S5 accounting
-    cleanup slice remains).
+    was removed from `giant_file_registry.toml`; #3038 S5 locked the final
+    root ratchet at 274 production lines).
   - `src/services/discord/session_runtime.rs` (1753 lines).
   - `src/services/discord/voice_barge_in.rs` (4657 lines; net +0 from #3034
     scoped dead-code allows on the test-only runtime API

--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -4,7 +4,7 @@
 > moving any AgentDesk runtime, worker, dispatch, provider, MCP, merge, or test
 > execution path from one dcserver node to multiple nodes.
 >
-> Last refreshed: 2026-06-12 (against #3038 run_bot S4 shared-data builder move).
+> Last refreshed: 2026-06-12 (against #3038 run_bot S5 closing pass).
 
 ## Read This First
 
@@ -22,16 +22,19 @@
 ### `multinode / discord_gateway_singleton`
 
 - feature: `multinode / discord_gateway_singleton`
-- canonical_modules: `src/services/discord/runtime_bootstrap.rs` builds the
-  Serenity client and preserves the call order; `runtime_bootstrap/gateway_lease.rs`
-  owns gateway lease acquisition, keepalive, and self-fencing;
-  `runtime_bootstrap/shutdown.rs` owns SIGTERM persistence and gateway backend
-  execution; `runtime_bootstrap/intake.rs` owns the standby intake-worker spawn.
+- canonical_modules: `src/services/discord/runtime_bootstrap.rs` preserves the
+  bootstrap call order; `runtime_bootstrap/gateway_runtime.rs` builds the
+  Serenity client and enters the leader gateway event loop;
+  `runtime_bootstrap/gateway_lease.rs` owns gateway lease acquisition,
+  keepalive, and self-fencing; `runtime_bootstrap/shutdown.rs` owns SIGTERM
+  persistence and gateway backend execution; `runtime_bootstrap/intake.rs` owns
+  the standby intake-worker spawn.
 - legacy_modules: none. The current gateway owner is the active dcserver process
   for that provider.
 - do_not_edit_without_migration_plan:
   `src/services/discord/runtime_bootstrap.rs` gateway startup order plus
-  `src/services/discord/runtime_bootstrap/gateway_lease.rs` and
+  `src/services/discord/runtime_bootstrap/gateway_runtime.rs`,
+  `src/services/discord/runtime_bootstrap/gateway_lease.rs`, and
   `src/services/discord/runtime_bootstrap/shutdown.rs` lease/shutdown paths,
   especially watcher cancellation on gateway lease loss.
 - active_callsite_coverage: single-node runtime with an existing gateway lease.
@@ -386,6 +389,13 @@
 
 ### Audited touches
 
+- #3038 run_bot S5: the leader gateway runtime tail moved verbatim from
+  `runtime_bootstrap.rs` into `runtime_bootstrap/gateway_runtime.rs`: restored
+  generation/model/fast-mode logging, health registry registration,
+  slash-command/framework/client construction, gateway lease keepalive spawn,
+  SIGTERM handler spawn, and backend event-loop entry remain in the same order.
+  The root `run_bot` body now delegates that tail after the lease succeeds; no
+  gateway ownership, worker routing, singleton, or lease semantics changed.
 - #3038 run_bot S4: `run_bot_build_shared_data` (and its side-effect-order
   doc comment) moved verbatim from `runtime_bootstrap.rs` into
   `runtime_bootstrap/shared_data.rs`, unblocked by the merged SharedData

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -125,7 +125,10 @@
 # into `runtime_bootstrap/shared_data.rs` (gated on the SharedData S1-S3
 # slices, now merged). The root keeps only RunBotContext + run_bot +
 # mod/re-export plumbing; final registry/baseline cleanup is the S5 slice.
-"src/services/discord/runtime_bootstrap.rs" = 369
+# #3038 run_bot S5: lowered 369 -> 274 by moving the 120-line leader gateway
+# runtime tail into `runtime_bootstrap/gateway_runtime.rs`; all
+# `runtime_bootstrap/` child modules remain under the 700-line namespace cap.
+"src/services/discord/runtime_bootstrap.rs" = 274
 # #3034 batch-8: lowered 2655 -> 2645 (dead-code removal: `stop_provider_channel_runtime`).
 # #3293: lowered 2645 -> 2641 (mailbox probe routed through the non-creating
 # `health/mailbox.rs::peeked_provider_mailbox_state`).

--- a/src/services/discord/runtime_bootstrap.rs
+++ b/src/services/discord/runtime_bootstrap.rs
@@ -2,6 +2,7 @@ use super::*;
 
 mod framework_setup;
 mod gateway_lease;
+mod gateway_runtime;
 mod intake;
 mod orphan_recovery;
 mod queued_placeholders;
@@ -18,6 +19,7 @@ use self::framework_setup::{run_bot_build_slash_commands, run_bot_framework_setu
 use self::gateway_lease::{
     GatewayLeaseOutcome, run_bot_acquire_gateway_lease, run_bot_spawn_gateway_lease_keepalive,
 };
+use self::gateway_runtime::run_bot_start_gateway_runtime;
 use self::intake::run_bot_maybe_spawn_intake_worker;
 #[allow(unused_imports)]
 pub(in crate::services::discord) use self::queued_placeholders::{
@@ -240,123 +242,25 @@ pub(crate) async fn run_bot(token: &str, provider: ProviderKind, context: RunBot
         }
     };
 
-    {
-        let ts = chrono::Local::now().format("%H:%M:%S");
-        tracing::info!(
-            "  [{ts}] 🔑 dcserver generation: {}",
-            shared.restart.current_generation
-        );
-        if !restored_model_overrides.is_empty() {
-            tracing::info!(
-                "  [{ts}] 🧩 restored model overrides: {} channel(s)",
-                restored_model_overrides.len()
-            );
-        }
-        if !restored_fast_mode_channels.is_empty() {
-            tracing::info!(
-                "  [{ts}] ⚡ restored fast mode channels: {} channel(s)",
-                restored_fast_mode_channels.len()
-            );
-        }
-    }
-
-    // Register this provider with the health check registry
-    health_registry
-        .register(provider.as_str().to_string(), shared.clone())
-        .await;
-
-    let token_owned = token.to_string();
-    let shared_clone = shared.clone();
-    let voice_config_for_setup = voice_config.clone();
-    let voice_receiver_for_setup = voice_receiver.clone();
-
-    let slash_commands = run_bot_build_slash_commands();
-
-    let framework = poise::Framework::builder()
-        .options(poise::FrameworkOptions {
-            commands: slash_commands,
-            command_check: Some(|ctx| {
-                Box::pin(async move {
-                    let settings_snapshot = { ctx.data().shared.settings.read().await.clone() };
-                    let allowed = provider_handles_channel(
-                        ctx.serenity_context(),
-                        &ctx.data().provider,
-                        &settings_snapshot,
-                        ctx.channel_id(),
-                    )
-                    .await;
-                    if !allowed {
-                        let ts = chrono::Local::now().format("%H:%M:%S");
-                        tracing::info!(
-                            "  [{ts}] ⏭ CMD-GUARD: skipping /{} in channel {} for provider {}",
-                            ctx.command().name,
-                            ctx.channel_id(),
-                            ctx.data().provider.as_str()
-                        );
-                    }
-                    Ok(allowed)
-                })
-            }),
-            event_handler: |ctx, event, _framework, data| Box::pin(handle_event(ctx, event, data)),
-            ..Default::default()
-        })
-        .setup(move |ctx, _ready, framework| {
-            let shared_for_migrate = shared_clone.clone();
-            let health_registry_for_setup = health_registry.clone();
-            let provider_for_setup = provider_for_framework.clone();
-            let token_for_ready = token_owned.clone();
-            let voice_config_for_setup = voice_config_for_setup.clone();
-            let voice_receiver_for_setup = voice_receiver_for_setup.clone();
-            Box::pin(run_bot_framework_setup(
-                ctx,
-                _ready,
-                framework,
-                shared_for_migrate,
-                shared_clone,
-                health_registry_for_setup,
-                provider_for_setup,
-                token_for_ready,
-                token_owned,
-                voice_config_for_setup,
-                voice_receiver_for_setup,
-                startup_reconcile_remaining,
-                startup_doctor_started,
-                api_port,
-            ))
-        })
-        .build();
-
-    let intents = discord_gateway_intents();
-
-    let client = commands::register_songbird(serenity::ClientBuilder::new(token, intents))
-        .framework(framework)
-        .await
-        .expect("Failed to create Discord client");
-
-    let gateway_lease_task = gateway_lease.map(|lease| {
-        run_bot_spawn_gateway_lease_keepalive(
-            lease,
-            &shared,
-            &provider,
-            client.shard_manager.clone(),
-        )
-    });
-
-    // Graceful shutdown: on SIGTERM, persist queue/inflight/last_message state
-    // and quick-exit. tmux/TUI processes survive — the next dcserver instance
-    // rehydrates the channel bindings (see rehydrate_existing_claude_tui_bindings;
-    // polled every CLAUDE_IDLE_REHYDRATE_POLL_INTERVAL ≈ 5s) and resumes transcript
-    // tailing from the persisted last_offset.
-    run_bot_spawn_sigterm_handler(&shared, provider_for_shutdown);
-
-    run_bot_run_gateway_backend(
-        client,
-        &provider_for_error,
-        gateway_lease_task,
+    run_bot_start_gateway_runtime(
+        token,
+        provider,
+        provider_for_error,
+        provider_for_framework,
+        provider_for_shutdown,
+        startup_reconcile_remaining,
+        startup_doctor_started,
+        health_registry,
         startup_reconcile_remaining_for_client_start,
         startup_doctor_started_for_client_start,
         health_registry_for_client_start,
         api_port,
+        shared,
+        voice_config,
+        voice_receiver,
+        gateway_lease,
+        &restored_model_overrides,
+        &restored_fast_mode_channels,
     )
     .await;
 }

--- a/src/services/discord/runtime_bootstrap/gateway_runtime.rs
+++ b/src/services/discord/runtime_bootstrap/gateway_runtime.rs
@@ -1,0 +1,147 @@
+use super::*;
+
+/// Start the leader gateway runtime after the singleton lease succeeds.
+/// This is the final `run_bot` tail: restored-state logging, health
+/// registration, poise framework/client construction, gateway-lease keepalive,
+/// SIGTERM handler spawn, and the gateway backend event loop, in that order.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn run_bot_start_gateway_runtime(
+    token: &str,
+    provider: ProviderKind,
+    provider_for_error: ProviderKind,
+    provider_for_framework: ProviderKind,
+    provider_for_shutdown: ProviderKind,
+    startup_reconcile_remaining: Arc<std::sync::atomic::AtomicUsize>,
+    startup_doctor_started: Arc<std::sync::atomic::AtomicBool>,
+    health_registry: Arc<health::HealthRegistry>,
+    startup_reconcile_remaining_for_client_start: Arc<std::sync::atomic::AtomicUsize>,
+    startup_doctor_started_for_client_start: Arc<std::sync::atomic::AtomicBool>,
+    health_registry_for_client_start: Arc<health::HealthRegistry>,
+    api_port: u16,
+    shared: Arc<SharedData>,
+    voice_config: crate::voice::VoiceConfig,
+    voice_receiver: crate::voice::VoiceReceiver,
+    gateway_lease: Option<crate::db::postgres::AdvisoryLockLease>,
+    restored_model_overrides: &[(ChannelId, String)],
+    restored_fast_mode_channels: &[ChannelId],
+) {
+    {
+        let ts = chrono::Local::now().format("%H:%M:%S");
+        tracing::info!(
+            "  [{ts}] 🔑 dcserver generation: {}",
+            shared.restart.current_generation
+        );
+        if !restored_model_overrides.is_empty() {
+            tracing::info!(
+                "  [{ts}] 🧩 restored model overrides: {} channel(s)",
+                restored_model_overrides.len()
+            );
+        }
+        if !restored_fast_mode_channels.is_empty() {
+            tracing::info!(
+                "  [{ts}] ⚡ restored fast mode channels: {} channel(s)",
+                restored_fast_mode_channels.len()
+            );
+        }
+    }
+
+    // Register this provider with the health check registry
+    health_registry
+        .register(provider.as_str().to_string(), shared.clone())
+        .await;
+
+    let token_owned = token.to_string();
+    let shared_clone = shared.clone();
+    let voice_config_for_setup = voice_config.clone();
+    let voice_receiver_for_setup = voice_receiver.clone();
+
+    let slash_commands = run_bot_build_slash_commands();
+
+    let framework = poise::Framework::builder()
+        .options(poise::FrameworkOptions {
+            commands: slash_commands,
+            command_check: Some(|ctx| {
+                Box::pin(async move {
+                    let settings_snapshot = { ctx.data().shared.settings.read().await.clone() };
+                    let allowed = provider_handles_channel(
+                        ctx.serenity_context(),
+                        &ctx.data().provider,
+                        &settings_snapshot,
+                        ctx.channel_id(),
+                    )
+                    .await;
+                    if !allowed {
+                        let ts = chrono::Local::now().format("%H:%M:%S");
+                        tracing::info!(
+                            "  [{ts}] ⏭ CMD-GUARD: skipping /{} in channel {} for provider {}",
+                            ctx.command().name,
+                            ctx.channel_id(),
+                            ctx.data().provider.as_str()
+                        );
+                    }
+                    Ok(allowed)
+                })
+            }),
+            event_handler: |ctx, event, _framework, data| Box::pin(handle_event(ctx, event, data)),
+            ..Default::default()
+        })
+        .setup(move |ctx, _ready, framework| {
+            let shared_for_migrate = shared_clone.clone();
+            let health_registry_for_setup = health_registry.clone();
+            let provider_for_setup = provider_for_framework.clone();
+            let token_for_ready = token_owned.clone();
+            let voice_config_for_setup = voice_config_for_setup.clone();
+            let voice_receiver_for_setup = voice_receiver_for_setup.clone();
+            Box::pin(run_bot_framework_setup(
+                ctx,
+                _ready,
+                framework,
+                shared_for_migrate,
+                shared_clone,
+                health_registry_for_setup,
+                provider_for_setup,
+                token_for_ready,
+                token_owned,
+                voice_config_for_setup,
+                voice_receiver_for_setup,
+                startup_reconcile_remaining,
+                startup_doctor_started,
+                api_port,
+            ))
+        })
+        .build();
+
+    let intents = discord_gateway_intents();
+
+    let client = commands::register_songbird(serenity::ClientBuilder::new(token, intents))
+        .framework(framework)
+        .await
+        .expect("Failed to create Discord client");
+
+    let gateway_lease_task = gateway_lease.map(|lease| {
+        run_bot_spawn_gateway_lease_keepalive(
+            lease,
+            &shared,
+            &provider,
+            client.shard_manager.clone(),
+        )
+    });
+
+    // Graceful shutdown: on SIGTERM, persist queue/inflight/last_message state
+    // and quick-exit. tmux/TUI processes survive — the next dcserver instance
+    // rehydrates the channel bindings (see rehydrate_existing_claude_tui_bindings;
+    // polled every CLAUDE_IDLE_REHYDRATE_POLL_INTERVAL ≈ 5s) and resumes transcript
+    // tailing from the persisted last_offset.
+    run_bot_spawn_sigterm_handler(&shared, provider_for_shutdown);
+
+    run_bot_run_gateway_backend(
+        client,
+        &provider_for_error,
+        gateway_lease_task,
+        startup_reconcile_remaining_for_client_start,
+        startup_doctor_started_for_client_start,
+        health_registry_for_client_start,
+        api_port,
+    )
+    .await;
+}


### PR DESCRIPTION
EPIC #3038 run_bot closing slice (after S0-S4).

## What
- Extracted the last cohesive contiguous block: the 120-line leader gateway runtime tail → `runtime_bootstrap/gateway_runtime.rs` (character-identical body, 275 token proof in commit body; startup order preserved: restored-state logging → health registry → framework/client build → lease keepalive spawn → SIGTERM handler → gateway run).
- `run_bot` now 204 lines; remaining root blocks all <80 lines (largest 61) — no forced extractions.
- Accounting locked: runtime_bootstrap.rs baseline 369→274; all children under the 700 namespace cap (max recovery_flush.rs 357); spawn distribution unchanged (root 0 direct spawns).

## Verification
- fmt/clippy clean; runtime_bootstrap 13 tests, discord umbrella 1577 pass / 0 fail; audit ratchet + agent-maintenance docs clean on committed HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)