### PR TITLE
refactor(#3038): relocate TUI hosting helpers to claude_tui child module (execute_streaming S3)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -332,6 +332,10 @@ src/
 │   │   ├── process.rs
 │   │   └── spawn_queue.rs
 │   ├── claude_tui/
+│   │   ├── hosting/
+│   │   │   ├── followup_support.rs
+│   │   │   ├── mod.rs
+│   │   │   └── warm_followup.rs
 │   │   ├── hook_bundle.rs
 │   │   ├── hook_relay.rs
 │   │   ├── hook_server.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1006,7 +1006,7 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
 - `src/services/dispatches/outbox_route.rs` (1089) — dispatch outbox route
   support extracted from the route layer; split before adding non-bugfix
   behavior.
-- `src/services/claude.rs` (3989), `src/services/gemini.rs` (1358),
+- `src/services/claude.rs` (2950), `src/services/gemini.rs` (1358),
   `src/services/qwen.rs` (2196), `src/services/codex.rs` (3001),
   `src/services/opencode.rs` (1881), `src/services/provider.rs` (1796) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
@@ -1023,10 +1023,10 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   with the `#[must_use] ClaudeTuiDraftRecoveryOutcome` carrier — behaviour-
   preserving, the +101 is the new outcome enum, the two verbatim-extraction doc
   contracts, and the call-site `match` dispatch (the recovery body itself is a
-  move). claude.rs is not in the giant-file ratchet baseline; this is a
-  freshness-annotation sync, not a baseline raise. Slice S3 relocates the
-  hosting cluster to a directory and drives claude.rs back under the giant
-  threshold.)
+  move). #3038 S3 relocates the TUI warm/follow-up hosting cluster into
+  `src/services/claude_tui/hosting/` child modules, ratchets claude.rs at 2950
+  production LoC, and leaves the #3262 turn-lock machinery in the claude.rs
+  root.)
 - `src/services/codex_tui/rollout_tail.rs` (1663) — Codex TUI rollout tail
   parsing and resume identity surface; split before adding non-bugfix behavior
   beyond the #2169 session identity fix.

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -17,6 +17,10 @@
 # documentation gate; extend this table to ratchet them too.
 
 [giant_file_ratchet]
+# #3038 execute_streaming S3: lowered claude.rs 3989 -> 2950 by moving the
+# TUI warm/follow-up hosting helpers into claude_tui/hosting/ child modules.
+# #3262 turn-lock acquisition/state/tests intentionally remain in claude.rs root.
+"src/services/claude.rs" = 2950
 # #3034 batch-8: the dead_code lint went live for the discord tree; the two
 # test-only `#[allow(dead_code)]` attributes on
 # `watcher_inflight_is_external_input_for_session` / the lease alias add +2 and

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -9,6 +9,10 @@ use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Duration;
 
 use crate::services::agent_protocol::{RuntimeHandoff, StreamMessage, is_valid_session_id};
+#[cfg(unix)]
+use crate::services::claude_tui::hosting::{
+    ClaudeTuiWarmFollowupOutcome, emit_claude_tui_zero_harvest, try_claude_tui_warm_followup,
+};
 use crate::services::discord::restart_report::{
     RESTART_REPORT_CHANNEL_ENV, RESTART_REPORT_PROVIDER_ENV,
 };
@@ -36,8 +40,6 @@ use crate::services::tmux_diagnostics::{
 const CLAUDE_TUI_FRESH_PROMPT_MAX_READY_ATTEMPTS: usize = 2;
 #[cfg(unix)]
 const CLAUDE_TUI_FRESH_PROMPT_READY_BACKOFF_BASE: Duration = Duration::from_secs(5);
-#[cfg(unix)]
-const CLAUDE_TUI_STRANDED_DRAFT_CLEAR_ATTEMPTS: usize = 2;
 #[cfg(unix)]
 const CLAUDE_TUI_TRANSCRIPT_INITIAL_WAIT_TIMEOUT: Duration = Duration::from_secs(120);
 #[cfg(unix)]
@@ -194,7 +196,7 @@ pub fn toggle_debug() -> bool {
 }
 
 /// Debug logging helper — active when DEBUG_ENABLED is true.
-fn debug_log(msg: &str) {
+pub(crate) fn debug_log(msg: &str) {
     if !DEBUG_ENABLED.load(std::sync::atomic::Ordering::Relaxed) {
         return;
     }
@@ -221,7 +223,7 @@ pub fn debug_log_to(filename: &str, msg: &str) {
 /// the bridge-side handoff log line lets us classify each disconnect as
 /// cancel / IO error / CLI crash / synthetic-done / normal-done without
 /// guessing.
-fn log_producer_exit(
+pub(crate) fn log_producer_exit(
     kind: &'static str,
     session_id: Option<&str>,
     channel_id: Option<u64>,
@@ -1363,16 +1365,15 @@ IMPORTANT: Format your responses using Markdown for better readability:
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum ClaudeFollowupResult {
+pub(crate) enum ClaudeFollowupResult {
     Delivered,
     RecreateSession { error: String },
     FinalizeWithNotice { error: String, notice: String },
 }
 
 const FOLLOWUP_PARTIAL_OUTPUT_NOTICE: &str = "⚠ 세션이 응답 도중 중단되었습니다. 일부 출력이 이미 전송되어 자동 재시작하지 않았습니다. 이어서 계속하려면 같은 요청을 다시 보내며 계속해 달라고 적어 주세요.";
-const CLAUDE_TUI_BUSY_FOLLOWUP_NOTICE: &str = "⚠ Claude TUI가 아직 이전 터미널 턴을 처리 중이라 이 메시지를 주입하지 않았습니다. 현재 응답이 끝난 뒤 다시 보내 주세요.";
 
-fn classify_followup_result(
+pub(crate) fn classify_followup_result(
     read_result: ReadOutputResult,
     start_offset: u64,
     session_died_error: &str,
@@ -1395,7 +1396,7 @@ fn classify_followup_result(
 
 /// Stable string tag for producer-exit / zero-harvest observability (#3281).
 #[cfg(unix)]
-fn read_output_result_kind(read_result: &ReadOutputResult) -> &'static str {
+pub(crate) fn read_output_result_kind(read_result: &ReadOutputResult) -> &'static str {
     match read_result {
         ReadOutputResult::Completed { .. } => "completed",
         ReadOutputResult::SessionDied { .. } => "session_died",
@@ -1409,46 +1410,20 @@ fn read_output_result_kind(read_result: &ReadOutputResult) -> &'static str {
 /// `classify_followup_result` maps it to `Delivered` too, and a cancelled turn
 /// legitimately forwards nothing.
 #[cfg(unix)]
-fn tui_delivered_zero_harvest(read_result: &ReadOutputResult, harvest: &ReadHarvestStats) -> bool {
+pub(crate) fn tui_delivered_zero_harvest(
+    read_result: &ReadOutputResult,
+    harvest: &ReadHarvestStats,
+) -> bool {
     matches!(read_result, ReadOutputResult::Completed { .. }) && harvest.forwarded_messages == 0
 }
 
 /// #3281 health signal: one observability event per zero-harvest delivered TUI
 /// turn, so the residual loss window (e.g. a fallback start offset pointing
 /// past the response bytes) is measured in production instead of inferred.
-#[cfg(unix)]
-fn emit_claude_tui_zero_harvest(
-    kind: &str,
-    report_channel_id: Option<u64>,
-    tmux_session_name: &str,
-    transcript_path: &str,
-    start_offset: u64,
-    transcript_len: u64,
+pub(crate) fn emit_followup_restart_suppressed_notice(
+    sender: &Sender<StreamMessage>,
+    notice: &str,
 ) {
-    tracing::warn!(
-        tmux_session_name,
-        transcript_path,
-        start_offset,
-        transcript_len,
-        "claude_tui delivered turn harvested ZERO stream messages — the turn's response text never entered the bridge ({kind})"
-    );
-    crate::services::observability::emit_inflight_lifecycle_event(
-        "claude",
-        report_channel_id.unwrap_or(0),
-        None,
-        None,
-        None,
-        kind,
-        serde_json::json!({
-            "tmux_session_name": tmux_session_name,
-            "transcript_path": transcript_path,
-            "start_offset": start_offset,
-            "transcript_len": transcript_len,
-        }),
-    );
-}
-
-fn emit_followup_restart_suppressed_notice(sender: &Sender<StreamMessage>, notice: &str) {
     let _ = sender.send(StreamMessage::Text {
         content: format!("\n\n{}", notice),
     });
@@ -1459,416 +1434,11 @@ fn emit_followup_restart_suppressed_notice(sender: &Sender<StreamMessage>, notic
 }
 
 #[cfg(unix)]
-fn emit_claude_tui_busy_followup_notice(
-    sender: &Sender<StreamMessage>,
-    tmux_session_name: &str,
-    snapshot: &crate::services::claude_tui::input::PromptReadinessSnapshot,
-) {
-    tracing::warn!(
-        tmux_session_name,
-        prompt_marker_detected = snapshot.prompt_marker_detected,
-        prompt_draft_detected = snapshot.prompt_draft_detected,
-        prompt_draft_blocks_submission = snapshot.tmux_pane_alive && snapshot.prompt_draft_detected,
-        tmux_pane_alive = snapshot.tmux_pane_alive,
-        capture_available = snapshot.capture_available,
-        pane_tail = %snapshot.pane_tail,
-        "claude_tui follow-up blocked before prompt submission because hosted TUI is busy"
-    );
-    debug_log(&format!(
-        "Claude TUI follow-up blocked before prompt submission: session={} prompt_marker_detected={} prompt_draft_detected={} prompt_draft_blocks_submission={} tmux_pane_alive={} capture_available={} pane_tail:\n{}",
-        tmux_session_name,
-        snapshot.prompt_marker_detected,
-        snapshot.prompt_draft_detected,
-        snapshot.tmux_pane_alive && snapshot.prompt_draft_detected,
-        snapshot.tmux_pane_alive,
-        snapshot.capture_available,
-        snapshot.pane_tail
-    ));
-    let _ = sender.send(StreamMessage::Text {
-        content: CLAUDE_TUI_BUSY_FOLLOWUP_NOTICE.to_string(),
-    });
-    let _ = sender.send(StreamMessage::Done {
-        result: String::new(),
-        session_id: None,
-    });
-}
-
-#[cfg(unix)]
-fn claude_tui_followup_busy_before_submit(
-    tmux_session_name: &str,
-    transcript_path: Option<&std::path::Path>,
-) -> Option<crate::services::claude_tui::input::PromptReadinessSnapshot> {
-    let snapshot = crate::services::claude_tui::input::prompt_readiness_snapshot(tmux_session_name);
-    let transcript_turn_state = transcript_path.map(|transcript_path| {
-        crate::services::claude_tui::transcript_tail::observe_transcript_turn_state(transcript_path)
-    });
-    claude_tui_followup_busy_before_submit_from_snapshot(snapshot, transcript_turn_state)
-}
-
-#[cfg(unix)]
-fn claude_tui_followup_busy_before_submit_from_snapshot(
-    snapshot: crate::services::claude_tui::input::PromptReadinessSnapshot,
-    transcript_turn_state: Option<crate::services::tui_turn_state::TuiTurnState>,
-) -> Option<crate::services::claude_tui::input::PromptReadinessSnapshot> {
-    if let Some(transcript_turn_state) = transcript_turn_state {
-        match transcript_turn_state {
-            crate::services::tui_turn_state::TuiTurnState::Idle => {
-                if snapshot.tmux_pane_alive && snapshot.prompt_draft_detected {
-                    return Some(snapshot);
-                }
-                return None;
-            }
-            crate::services::tui_turn_state::TuiTurnState::Unknown
-                if snapshot.tmux_pane_alive && snapshot.prompt_draft_detected =>
-            {
-                return Some(snapshot);
-            }
-            state if state.is_busy() && snapshot.tmux_pane_alive => return Some(snapshot),
-            _ => {}
-        }
-    }
-    if snapshot.tmux_pane_alive && snapshot.prompt_draft_detected {
-        Some(snapshot)
-    } else {
-        None
-    }
-}
-
-#[cfg(unix)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ClaudeTuiStrandedPromptDraftState {
-    IdleTranscript,
-    UnknownTranscript,
-}
-
-#[cfg(unix)]
-impl ClaudeTuiStrandedPromptDraftState {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::IdleTranscript => "idle",
-            Self::UnknownTranscript => "unknown",
-        }
-    }
-}
-
-#[cfg(unix)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct ClaudeTuiWarmFollowupSubmitPlan {
-    submit_existing_session: bool,
-    recheck_busy_before_submit: bool,
-}
-
-#[cfg(unix)]
-fn claude_tui_warm_followup_submit_plan(
-    recreate_before_submit: bool,
-    prompt_draft_cleared_before_submit: bool,
-) -> ClaudeTuiWarmFollowupSubmitPlan {
-    ClaudeTuiWarmFollowupSubmitPlan {
-        submit_existing_session: !recreate_before_submit,
-        recheck_busy_before_submit: !prompt_draft_cleared_before_submit,
-    }
-}
-
-#[cfg(unix)]
-fn claude_tui_followup_stranded_prompt_draft_state(
-    snapshot: &crate::services::claude_tui::input::PromptReadinessSnapshot,
-    transcript_path: &std::path::Path,
-) -> Option<ClaudeTuiStrandedPromptDraftState> {
-    let transcript_turn_state =
-        crate::services::claude_tui::transcript_tail::observe_transcript_turn_state(
-            transcript_path,
-        );
-    if !claude_tui_snapshot_has_recoverable_prompt_draft(snapshot) {
-        return None;
-    }
-    match transcript_turn_state {
-        crate::services::tui_turn_state::TuiTurnState::Idle => {
-            Some(ClaudeTuiStrandedPromptDraftState::IdleTranscript)
-        }
-        crate::services::tui_turn_state::TuiTurnState::Unknown => {
-            Some(ClaudeTuiStrandedPromptDraftState::UnknownTranscript)
-        }
-        _ => None,
-    }
-}
-
-#[cfg(unix)]
-fn claude_tui_snapshot_has_recoverable_prompt_draft(
-    snapshot: &crate::services::claude_tui::input::PromptReadinessSnapshot,
-) -> bool {
-    snapshot.tmux_pane_alive
-        && snapshot.prompt_draft_detected
-        && !crate::services::claude_tui::input::claude_prompt_draft_is_idle_suggestion_tail(
-            &snapshot.pane_tail,
-        )
-        && crate::services::claude_tui::input::claude_prompt_draft_backspace_budget_from_tail(
-            &snapshot.pane_tail,
-        )
-        .is_some()
-}
-
-#[cfg(unix)]
-fn claude_tui_prompt_remained_in_input_buffer(
-    snapshot: &crate::services::claude_tui::input::PromptReadinessSnapshot,
-    prompt: &str,
-) -> bool {
-    if !snapshot.tmux_pane_alive || !snapshot.capture_available {
-        return false;
-    }
-    let prompt = prompt.trim();
-    if prompt.is_empty() {
-        return false;
-    }
-    snapshot.pane_tail.lines().rev().take(12).any(|line| {
-        let trimmed = line.trim_matches(|ch: char| ch.is_whitespace() || ch == '\u{00a0}');
-        let Some(rest) = trimmed.strip_prefix('\u{276f}') else {
-            return false;
-        };
-        let rest = rest.trim_matches(|ch: char| ch.is_whitespace() || ch == '\u{00a0}');
-        !rest
-            .get(..6)
-            .is_some_and(|prefix| prefix.eq_ignore_ascii_case("[User:"))
-            && rest.contains(prompt)
-    })
-}
-
-#[cfg(unix)]
-fn claude_tui_zero_advance_input_buffer_error(
-    tmux_session_name: &str,
-    transcript_path: &str,
-    start_offset: u64,
-    snapshot: &crate::services::claude_tui::input::PromptReadinessSnapshot,
-) -> String {
-    format!(
-        "claude tui follow-up produced no new transcript bytes and prompt remained in TUI input buffer; tmux_session={}; transcript_path={}; start_offset={}; capture_available={}; prompt_marker_detected={}; prompt_draft_detected={}; pane_tail={}",
-        tmux_session_name,
-        transcript_path,
-        start_offset,
-        snapshot.capture_available,
-        snapshot.prompt_marker_detected,
-        snapshot.prompt_draft_detected,
-        snapshot.pane_tail
-    )
-}
-
-#[cfg(all(test, unix))]
-mod claude_tui_prompt_buffer_tests {
-    use super::*;
-
-    #[test]
-    fn detects_stuck_followup_prompt_even_when_generic_draft_heuristic_ignores_footer() {
-        let snapshot = crate::services::claude_tui::input::PromptReadinessSnapshot {
-            prompt_marker_detected: true,
-            prompt_draft_detected: false,
-            tmux_pane_alive: true,
-            capture_available: true,
-            pane_tail: "\
-✻ Baked for 10m 9s
-────────────────────────────────────────────────────────────────────────────
-❯\u{00a0}응답에 정확히 한 줄로 [E2E:E6:AFTER] 만 출력해줘.
-────────────────────────────────────────────────────────────────────────────
-  CLAUDE.md: 1, MCP: 2 │ Tools: 5 done
-  ⏵⏵ bypass permissions on"
-                .to_string(),
-        };
-
-        assert!(claude_tui_prompt_remained_in_input_buffer(
-            &snapshot,
-            "응답에 정확히 한 줄로 [E2E:E6:AFTER] 만 출력해줘."
-        ));
-    }
-
-    #[test]
-    fn ignores_submitted_discord_history_prompt() {
-        let snapshot = crate::services::claude_tui::input::PromptReadinessSnapshot {
-            prompt_marker_detected: false,
-            prompt_draft_detected: false,
-            tmux_pane_alive: true,
-            capture_available: true,
-            pane_tail: "\
-❯ [User: 명령봇 (ID: 1)] 응답에 정확히 한 줄로 [E2E:E6:AFTER] 만 출력해줘.
-⏺ [E2E:E6:AFTER]"
-                .to_string(),
-        };
-
-        assert!(!claude_tui_prompt_remained_in_input_buffer(
-            &snapshot,
-            "응답에 정확히 한 줄로 [E2E:E6:AFTER] 만 출력해줘."
-        ));
-    }
-}
-
-#[cfg(unix)]
-fn claude_tui_unknown_transcript_draft_recreate_allowed(
-    snapshot: &crate::services::claude_tui::input::PromptReadinessSnapshot,
-) -> bool {
-    if !snapshot.tmux_pane_alive || !snapshot.prompt_draft_detected || !snapshot.capture_available {
-        return false;
-    }
-    let tail = snapshot.pane_tail.as_str();
-    let tail_lower = tail.to_ascii_lowercase();
-    if tail_lower.contains("esc to interrupt")
-        || tail_lower.contains("processing")
-        || tail_lower.contains("thinking")
-        || tail_lower.contains("running")
-    {
-        return false;
-    }
-    tail.contains("Baked for")
-        || tail.contains("Brewed for")
-        || (tail.contains("Tools:") && tail.contains(" done"))
-}
-
-#[cfg(unix)]
-fn ensure_tmux_key_send_success(
-    output: std::process::Output,
-    action_name: &str,
-) -> Result<(), String> {
-    if output.status.success() {
-        return Ok(());
-    }
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-    if stderr.is_empty() {
-        Err(format!("tmux send {action_name} failed: {}", output.status))
-    } else {
-        Err(format!("tmux send {action_name} failed: {stderr}"))
-    }
-}
-
-#[cfg(unix)]
-fn clear_claude_tui_draft_with_backspaces(
-    tmux_session_name: &str,
-    snapshot: &mut crate::services::claude_tui::input::PromptReadinessSnapshot,
-    cancel_token: Option<&CancelToken>,
-) -> Result<(), String> {
-    let Some(mut remaining) =
-        crate::services::claude_tui::input::claude_prompt_draft_backspace_budget_from_tail(
-            &snapshot.pane_tail,
-        )
-    else {
-        return Ok(());
-    };
-    let output = crate::services::platform::tmux::send_keys(tmux_session_name, &["C-e"])?;
-    ensure_tmux_key_send_success(output, "draft-clear-cursor-end")?;
-    while remaining > 0 {
-        if cancel_requested(cancel_token) {
-            return Err(
-                crate::services::claude_tui::input::PROMPT_READY_CANCELLED_ERROR.to_string(),
-            );
-        }
-        let batch = remaining.min(32);
-        let keys = vec!["BSpace"; batch];
-        let output = crate::services::platform::tmux::send_keys(tmux_session_name, &keys)?;
-        ensure_tmux_key_send_success(output, "draft-clear-backspace")?;
-        remaining -= batch;
-    }
-    std::thread::sleep(std::time::Duration::from_millis(120));
-    *snapshot = crate::services::claude_tui::input::prompt_readiness_snapshot(tmux_session_name);
-    Ok(())
-}
-
-#[cfg(unix)]
-fn clear_claude_tui_stranded_prompt_draft(
-    tmux_session_name: &str,
-    cancel_token: Option<&CancelToken>,
-) -> Result<crate::services::claude_tui::input::PromptReadinessSnapshot, String> {
-    let clear_key_plans: [&[&str]; 3] = [&["C-e", "C-u"], &["Escape"], &["C-e", "C-u"]];
-    let mut snapshot =
-        crate::services::claude_tui::input::prompt_readiness_snapshot(tmux_session_name);
-    if !snapshot.prompt_draft_detected || !snapshot.tmux_pane_alive {
-        return Ok(snapshot);
-    }
-
-    for attempt in 1..=CLAUDE_TUI_STRANDED_DRAFT_CLEAR_ATTEMPTS {
-        if cancel_requested(cancel_token) {
-            return Err(
-                crate::services::claude_tui::input::PROMPT_READY_CANCELLED_ERROR.to_string(),
-            );
-        }
-        for keys in clear_key_plans {
-            let output = crate::services::platform::tmux::send_keys(tmux_session_name, keys)?;
-            ensure_tmux_key_send_success(output, "clear-draft")?;
-            std::thread::sleep(std::time::Duration::from_millis(120));
-            if cancel_requested(cancel_token) {
-                return Err(
-                    crate::services::claude_tui::input::PROMPT_READY_CANCELLED_ERROR.to_string(),
-                );
-            }
-            snapshot =
-                crate::services::claude_tui::input::prompt_readiness_snapshot(tmux_session_name);
-            if !snapshot.prompt_draft_detected || !snapshot.tmux_pane_alive {
-                return Ok(snapshot);
-            }
-        }
-        clear_claude_tui_draft_with_backspaces(tmux_session_name, &mut snapshot, cancel_token)?;
-        if !snapshot.prompt_draft_detected || !snapshot.tmux_pane_alive {
-            return Ok(snapshot);
-        }
-        tracing::warn!(
-            tmux_session_name,
-            attempt,
-            prompt_marker_detected = snapshot.prompt_marker_detected,
-            prompt_draft_detected = snapshot.prompt_draft_detected,
-            tmux_pane_alive = snapshot.tmux_pane_alive,
-            capture_available = snapshot.capture_available,
-            pane_tail = %snapshot.pane_tail,
-            "claude_tui stranded prompt draft still present after clear attempt"
-        );
-    }
-
-    Ok(snapshot)
-}
-
-#[cfg(unix)]
-fn gently_clear_claude_tui_prompt_draft(
-    tmux_session_name: &str,
-    cancel_token: Option<&CancelToken>,
-) -> Result<crate::services::claude_tui::input::PromptReadinessSnapshot, String> {
-    let mut snapshot =
-        crate::services::claude_tui::input::prompt_readiness_snapshot(tmux_session_name);
-    if !snapshot.prompt_draft_detected || !snapshot.tmux_pane_alive {
-        return Ok(snapshot);
-    }
-
-    for attempt in 1..=CLAUDE_TUI_STRANDED_DRAFT_CLEAR_ATTEMPTS {
-        if cancel_requested(cancel_token) {
-            return Err(
-                crate::services::claude_tui::input::PROMPT_READY_CANCELLED_ERROR.to_string(),
-            );
-        }
-        let output =
-            crate::services::platform::tmux::send_keys(tmux_session_name, &["C-e", "C-u"])?;
-        ensure_tmux_key_send_success(output, "gentle-clear-draft")?;
-        std::thread::sleep(std::time::Duration::from_millis(120));
-        snapshot = crate::services::claude_tui::input::prompt_readiness_snapshot(tmux_session_name);
-        if !snapshot.prompt_draft_detected || !snapshot.tmux_pane_alive {
-            return Ok(snapshot);
-        }
-        clear_claude_tui_draft_with_backspaces(tmux_session_name, &mut snapshot, cancel_token)?;
-        if !snapshot.prompt_draft_detected || !snapshot.tmux_pane_alive {
-            return Ok(snapshot);
-        }
-        tracing::warn!(
-            tmux_session_name,
-            attempt,
-            prompt_marker_detected = snapshot.prompt_marker_detected,
-            prompt_draft_detected = snapshot.prompt_draft_detected,
-            tmux_pane_alive = snapshot.tmux_pane_alive,
-            capture_available = snapshot.capture_available,
-            pane_tail = %snapshot.pane_tail,
-            "claude_tui prompt draft still present after gentle clear attempt"
-        );
-    }
-
-    Ok(snapshot)
-}
-
-#[cfg(unix)]
 #[derive(Debug, Clone)]
-struct ClaudeTuiSessionResolution {
-    session_id: String,
-    transcript_path: std::path::PathBuf,
-    resume: bool,
+pub(crate) struct ClaudeTuiSessionResolution {
+    pub(crate) session_id: String,
+    pub(crate) transcript_path: std::path::PathBuf,
+    pub(crate) resume: bool,
 }
 
 #[cfg(unix)]
@@ -1912,7 +1482,7 @@ fn resolve_claude_tui_session_for_launch(
 }
 
 #[cfg(unix)]
-fn fresh_claude_tui_session_resolution(
+pub(crate) fn fresh_claude_tui_session_resolution(
     working_dir: &std::path::Path,
     claude_home: Option<&std::path::Path>,
 ) -> Result<ClaudeTuiSessionResolution, String> {
@@ -2053,7 +1623,7 @@ fn claude_tui_fresh_turn_start_offset(transcript_path: &std::path::Path) -> u64 
 }
 
 #[cfg(unix)]
-fn claude_tui_turn_start_offset_after_timestamp(
+pub(crate) fn claude_tui_turn_start_offset_after_timestamp(
     transcript_path: &std::path::Path,
     turn_started_at: chrono::DateTime<chrono::Utc>,
     fallback_offset: u64,
@@ -2334,661 +1904,6 @@ fn run_claude_tui_fresh_turn_and_finalize(
     Ok(())
 }
 
-/// Updated session resolution carried back to the orchestrator when a warm
-/// follow-up could not be delivered and the hosted session must be recreated.
-#[cfg(unix)]
-struct ClaudeTuiRecreateState {
-    resolved_session_id: String,
-    transcript_path: std::path::PathBuf,
-    transcript_path_string: String,
-    resume: bool,
-}
-
-/// Outcome of stranded prompt-draft recovery; `Terminal` forwards original Ok/Err exits before submit side effects, and `Proceed` carries the fall-through quartet/flags.
-#[cfg(unix)]
-#[must_use]
-enum ClaudeTuiDraftRecoveryOutcome {
-    /// Continue to submit-plan computation with the possibly recreated quartet plus busy/recreate/draft-cleared flags.
-    Proceed {
-        state: ClaudeTuiRecreateState,
-        busy_waited: bool,
-        recreate_before_submit: bool,
-        prompt_draft_cleared_before_submit: bool,
-    },
-    /// Recovery hit an original early return; forward the `Result` verbatim.
-    Terminal(Result<(), String>),
-}
-
-/// Outcome of an attempted warm follow-up against a live Claude TUI session.
-#[cfg(unix)]
-enum ClaudeTuiWarmFollowupOutcome {
-    /// Handled (delivered, aborted, or errored); return this without launch.
-    Terminal(Result<(), String>),
-    /// Could not proceed; fall through to fresh launch with this resolution.
-    Recreate(ClaudeTuiRecreateState),
-}
-
-/// Verbatim extraction of the warm-followup submit-and-stream block; `Terminal` carries the original early-return `Result` unchanged.
-/// `FallThroughRecreate` preserves `submit_existing_session == false` and `RecreateSession` kill-then-fresh-launch fall-through.
-#[cfg(unix)]
-#[must_use]
-enum ClaudeTuiWarmFollowupSubmitOutcome {
-    Terminal(Result<(), String>),
-    FallThroughRecreate,
-}
-
-/// Recover from a stranded prompt draft left in the composer before submit.
-/// Verbatim extraction: destructures state into the original mutable locals; cancellation returns `Ok(())`, fresh-resolution failures return `Err(..)`, and fall-through returns `Proceed` with quartet/flags.
-#[cfg(unix)]
-fn recover_claude_tui_stranded_prompt_draft(
-    state: ClaudeTuiRecreateState,
-    working_dir_path: &std::path::Path,
-    cancel_token: &Option<std::sync::Arc<CancelToken>>,
-    tmux_session_name: &str,
-    report_channel_id: Option<u64>,
-) -> ClaudeTuiDraftRecoveryOutcome {
-    let ClaudeTuiRecreateState {
-        mut resolved_session_id,
-        mut transcript_path,
-        mut transcript_path_string,
-        mut resume,
-    } = state;
-    // #2416: a single busy_waited flag tells the offset-capture site below
-    // that we need to re-read transcript length after the wait succeeded,
-    // because the previous TUI turn may have appended bytes while we were
-    // waiting (otherwise the follow-up reader would treat previous-turn
-    // bytes as new-turn output).
-    let mut busy_waited = false;
-    let mut recreate_before_submit = false;
-    let mut prompt_draft_cleared_before_submit = false;
-    if let Some(snapshot) =
-        claude_tui_followup_busy_before_submit(tmux_session_name, Some(&transcript_path))
-    {
-        if let Some(draft_state) =
-            claude_tui_followup_stranded_prompt_draft_state(&snapshot, &transcript_path)
-        {
-            let allow_recreate = matches!(
-                draft_state,
-                ClaudeTuiStrandedPromptDraftState::IdleTranscript
-            );
-            tracing::warn!(
-                tmux_session_name,
-                transcript_path = %transcript_path_string,
-                transcript_turn_state = draft_state.as_str(),
-                prompt_marker_detected = snapshot.prompt_marker_detected,
-                prompt_draft_detected = snapshot.prompt_draft_detected,
-                capture_available = snapshot.capture_available,
-                pane_tail = %snapshot.pane_tail,
-                "claude_tui follow-up found non-busy transcript with stranded composer draft; attempting draft clear"
-            );
-            debug_log(&format!(
-                "Claude TUI follow-up: {} transcript has stranded prompt draft, attempting clear (session={}, transcript={})",
-                draft_state.as_str(),
-                tmux_session_name,
-                transcript_path_string
-            ));
-            let clear_result = if allow_recreate {
-                clear_claude_tui_stranded_prompt_draft(tmux_session_name, cancel_token.as_deref())
-            } else {
-                gently_clear_claude_tui_prompt_draft(tmux_session_name, cancel_token.as_deref())
-            };
-            match clear_result {
-                Ok(post_clear_snapshot)
-                    if post_clear_snapshot.tmux_pane_alive
-                        && !post_clear_snapshot.prompt_draft_detected =>
-                {
-                    busy_waited = true;
-                    prompt_draft_cleared_before_submit = true;
-                    tracing::info!(
-                        tmux_session_name,
-                        transcript_turn_state = draft_state.as_str(),
-                        prompt_marker_detected = post_clear_snapshot.prompt_marker_detected,
-                        capture_available = post_clear_snapshot.capture_available,
-                        "claude_tui stranded prompt draft cleared before follow-up submit"
-                    );
-                    debug_log(&format!(
-                        "Claude TUI follow-up: stranded prompt draft cleared (session={} prompt_marker_detected={} capture_available={})",
-                        tmux_session_name,
-                        post_clear_snapshot.prompt_marker_detected,
-                        post_clear_snapshot.capture_available
-                    ));
-                }
-                Ok(post_clear_snapshot) => {
-                    let reason = if post_clear_snapshot.tmux_pane_alive {
-                        "stranded claude tui prompt draft persisted after clear attempts"
-                    } else {
-                        "claude tui pane died while clearing stranded prompt draft"
-                    };
-                    let recreate_after_persistent_draft = allow_recreate
-                        || (matches!(
-                            draft_state,
-                            ClaudeTuiStrandedPromptDraftState::UnknownTranscript
-                        ) && claude_tui_unknown_transcript_draft_recreate_allowed(
-                            &post_clear_snapshot,
-                        ));
-                    if !recreate_after_persistent_draft {
-                        tracing::warn!(
-                            tmux_session_name,
-                            transcript_turn_state = draft_state.as_str(),
-                            prompt_marker_detected = post_clear_snapshot.prompt_marker_detected,
-                            prompt_draft_detected = post_clear_snapshot.prompt_draft_detected,
-                            tmux_pane_alive = post_clear_snapshot.tmux_pane_alive,
-                            capture_available = post_clear_snapshot.capture_available,
-                            pane_tail = %post_clear_snapshot.pane_tail,
-                            "claude_tui unknown-transcript draft recovery did not clear draft; falling back to busy wait"
-                        );
-                        debug_log(&format!(
-                            "Claude TUI follow-up: {} under unknown transcript; falling back to busy wait (session={})",
-                            reason, tmux_session_name
-                        ));
-                    } else {
-                        tracing::warn!(
-                            tmux_session_name,
-                            prompt_marker_detected = post_clear_snapshot.prompt_marker_detected,
-                            prompt_draft_detected = post_clear_snapshot.prompt_draft_detected,
-                            tmux_pane_alive = post_clear_snapshot.tmux_pane_alive,
-                            capture_available = post_clear_snapshot.capture_available,
-                            pane_tail = %post_clear_snapshot.pane_tail,
-                            "claude_tui stranded prompt draft recovery will recreate hosted session"
-                        );
-                        debug_log(&format!(
-                            "Claude TUI follow-up: {} (session={})",
-                            reason, tmux_session_name
-                        ));
-                        crate::services::termination_audit::record_termination_for_tmux(
-                            tmux_session_name,
-                            None,
-                            "claude_tui_provider",
-                            "stranded_prompt_draft_recreate",
-                            Some(reason),
-                            None,
-                        );
-                        record_tmux_exit_reason(tmux_session_name, reason);
-                        crate::services::platform::tmux::kill_session(tmux_session_name, reason);
-                        let fresh_resolution =
-                            match fresh_claude_tui_session_resolution(working_dir_path, None) {
-                                Ok(resolution) => resolution,
-                                Err(error) => {
-                                    return ClaudeTuiDraftRecoveryOutcome::Terminal(Err(error));
-                                }
-                            };
-                        resolved_session_id = fresh_resolution.session_id;
-                        transcript_path = fresh_resolution.transcript_path;
-                        transcript_path_string = transcript_path.display().to_string();
-                        resume = fresh_resolution.resume;
-                        recreate_before_submit = true;
-                    }
-                }
-                Err(error)
-                    if crate::services::claude_tui::input::is_prompt_ready_cancelled_error(
-                        &error,
-                    ) =>
-                {
-                    debug_log(&format!(
-                        "Claude TUI follow-up: cancellation observed while clearing stranded prompt draft (session={})",
-                        tmux_session_name
-                    ));
-                    log_producer_exit(
-                        "tui_warm_followup_cancelled_during_draft_clear",
-                        Some(&resolved_session_id),
-                        report_channel_id,
-                        0,
-                        serde_json::json!({
-                            "tmux_session_name": tmux_session_name,
-                            "transcript_path": transcript_path_string,
-                        }),
-                    );
-                    return ClaudeTuiDraftRecoveryOutcome::Terminal(Ok(()));
-                }
-                Err(error) => {
-                    let recreate_after_clear_error = allow_recreate
-                        || (matches!(
-                            draft_state,
-                            ClaudeTuiStrandedPromptDraftState::UnknownTranscript
-                        ) && claude_tui_unknown_transcript_draft_recreate_allowed(&snapshot));
-                    if !recreate_after_clear_error {
-                        tracing::warn!(
-                            tmux_session_name,
-                            error = %error,
-                            "claude_tui unknown-transcript draft clear failed; falling back to busy wait"
-                        );
-                        debug_log(&format!(
-                            "Claude TUI follow-up: unknown-transcript draft clear failed, falling back to busy wait (session={} error={})",
-                            tmux_session_name, error
-                        ));
-                    } else {
-                        tracing::warn!(
-                            tmux_session_name,
-                            error = %error,
-                            "claude_tui stranded prompt draft clear failed; recreating hosted session"
-                        );
-                        crate::services::termination_audit::record_termination_for_tmux(
-                            tmux_session_name,
-                            None,
-                            "claude_tui_provider",
-                            "stranded_prompt_draft_clear_failed_recreate",
-                            Some(&format!(
-                                "claude tui stranded prompt draft clear failed: {}",
-                                error
-                            )),
-                            None,
-                        );
-                        record_tmux_exit_reason(
-                            tmux_session_name,
-                            &format!("claude tui stranded prompt draft clear failed: {}", error),
-                        );
-                        crate::services::platform::tmux::kill_session(
-                            tmux_session_name,
-                            &format!("claude tui stranded prompt draft clear failed: {}", error),
-                        );
-                        let fresh_resolution =
-                            match fresh_claude_tui_session_resolution(working_dir_path, None) {
-                                Ok(resolution) => resolution,
-                                Err(error) => {
-                                    return ClaudeTuiDraftRecoveryOutcome::Terminal(Err(error));
-                                }
-                            };
-                        resolved_session_id = fresh_resolution.session_id;
-                        transcript_path = fresh_resolution.transcript_path;
-                        transcript_path_string = transcript_path.display().to_string();
-                        resume = fresh_resolution.resume;
-                        recreate_before_submit = true;
-                    }
-                }
-            }
-        }
-    }
-    ClaudeTuiDraftRecoveryOutcome::Proceed {
-        state: ClaudeTuiRecreateState {
-            resolved_session_id,
-            transcript_path,
-            transcript_path_string,
-            resume,
-        },
-        busy_waited,
-        recreate_before_submit,
-        prompt_draft_cleared_before_submit,
-    }
-}
-
-#[cfg(unix)]
-fn run_claude_tui_warm_followup_submit_and_stream(
-    submit_plan: ClaudeTuiWarmFollowupSubmitPlan,
-    mut busy_waited: bool,
-    tmux_session_name: &str,
-    resolved_session_id: &str,
-    transcript_path: &std::path::Path,
-    transcript_path_string: &str,
-    prompt: &str,
-    sender: Sender<StreamMessage>,
-    cancel_token: Option<std::sync::Arc<CancelToken>>,
-    report_channel_id: Option<u64>,
-    hook_rx: tokio::sync::broadcast::Receiver<crate::services::claude_tui::hook_server::HookEvent>,
-) -> ClaudeTuiWarmFollowupSubmitOutcome {
-    if submit_plan.recheck_busy_before_submit
-        && let Some(snapshot) =
-            claude_tui_followup_busy_before_submit(tmux_session_name, Some(&transcript_path))
-    {
-        // #2416: instead of dropping the user's message when the TUI is busy,
-        // wait for the next prompt-ready window. The transcript-idle
-        // fallback covers Claude TUI redraws where the JSONL terminal
-        // envelope is authoritative but the prompt glyph is not visible.
-        match crate::services::claude_tui::input::wait_for_prompt_ready_or_idle_transcript(
-            tmux_session_name,
-            crate::services::claude_tui::input::PromptReadinessKind::Followup,
-            cancel_token.as_deref(),
-            &transcript_path,
-        ) {
-            Ok(()) => {
-                busy_waited = true;
-                debug_log(&format!(
-                    "Claude TUI follow-up: busy at first check, became ready after wait (session={})",
-                    tmux_session_name
-                ));
-            }
-            Err(err) => {
-                if crate::services::claude_tui::input::is_prompt_ready_cancelled_error(&err) {
-                    debug_log(&format!(
-                        "Claude TUI follow-up: cancellation observed during busy wait, aborting injection (session={})",
-                        tmux_session_name
-                    ));
-                    log_producer_exit(
-                        "tui_warm_followup_cancelled_during_busy_wait",
-                        Some(&resolved_session_id),
-                        report_channel_id,
-                        0,
-                        serde_json::json!({
-                            "tmux_session_name": tmux_session_name,
-                            "transcript_path": transcript_path_string,
-                        }),
-                    );
-                    return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Ok(()));
-                }
-                let timed_out =
-                    crate::services::claude_tui::input::is_prompt_ready_timeout_error(&err);
-                debug_log(&format!(
-                    "Claude TUI follow-up wait failed after busy snapshot (session={}, timed_out={}): {}",
-                    tmux_session_name, timed_out, err
-                ));
-                let post_wait_snapshot =
-                    crate::services::claude_tui::input::prompt_readiness_snapshot(
-                        tmux_session_name,
-                    );
-                emit_claude_tui_busy_followup_notice(
-                    &sender,
-                    tmux_session_name,
-                    &post_wait_snapshot,
-                );
-                log_producer_exit(
-                    "tui_warm_followup_busy_pre_submit",
-                    Some(&resolved_session_id),
-                    report_channel_id,
-                    0,
-                    serde_json::json!({
-                        "tmux_session_name": tmux_session_name,
-                        "transcript_path": transcript_path_string,
-                        "prompt_marker_detected": post_wait_snapshot.prompt_marker_detected,
-                        "prompt_draft_detected": post_wait_snapshot.prompt_draft_detected,
-                        "prompt_draft_blocks_submission": post_wait_snapshot.tmux_pane_alive && post_wait_snapshot.prompt_draft_detected,
-                        "tmux_pane_alive": post_wait_snapshot.tmux_pane_alive,
-                        "capture_available": post_wait_snapshot.capture_available,
-                        "initial_busy_snapshot_prompt_marker_detected": snapshot.prompt_marker_detected,
-                        "initial_busy_snapshot_prompt_draft_detected": snapshot.prompt_draft_detected,
-                        "wait_outcome": if timed_out { "timeout" } else { "error" },
-                        "wait_error": err,
-                    }),
-                );
-                return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Ok(()));
-            }
-        }
-    }
-    // #2416: capture the transcript offset AFTER the optional busy wait so
-    // that any bytes the previous TUI turn appended while we were waiting
-    // are not replayed as part of this follow-up's output window. This
-    // closes a Codex-flagged HIGH (stale offset → duplicate / early-done
-    // delivery accounting).
-    let fallback_start_offset = std::fs::metadata(&transcript_path)
-        .map(|meta| meta.len())
-        .unwrap_or(0);
-    // #2416: also honour cancellation that may have flipped during the
-    // up-to-45s busy wait. Without this, a user stop reaction / watchdog
-    // cancellation arriving mid-wait would still inject the prompt as
-    // soon as the TUI returns to ready. Closes a Codex-flagged HIGH.
-    if busy_waited && crate::services::provider::cancel_requested(cancel_token.as_deref()) {
-        debug_log(&format!(
-            "Claude TUI follow-up: cancellation observed after busy wait, aborting injection (session={})",
-            tmux_session_name
-        ));
-        log_producer_exit(
-            "tui_warm_followup_cancelled_after_busy_wait",
-            Some(&resolved_session_id),
-            report_channel_id,
-            0,
-            serde_json::json!({
-                "tmux_session_name": tmux_session_name,
-                "transcript_path": transcript_path_string,
-            }),
-        );
-        return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Ok(()));
-    }
-    let turn_started_at = chrono::Utc::now();
-    if let Err(error) = crate::services::claude_tui::input::send_followup_prompt_or_idle_transcript(
-        tmux_session_name,
-        prompt,
-        cancel_token.as_deref(),
-        &transcript_path,
-    ) {
-        if crate::services::claude_tui::input::is_prompt_ready_cancelled_error(&error) {
-            debug_log(&format!(
-                "Claude TUI follow-up: cancellation observed during prompt submission, aborting injection (session={})",
-                tmux_session_name
-            ));
-            log_producer_exit(
-                "tui_warm_followup_cancelled_during_prompt_submit",
-                Some(&resolved_session_id),
-                report_channel_id,
-                0,
-                serde_json::json!({
-                    "tmux_session_name": tmux_session_name,
-                    "transcript_path": transcript_path_string,
-                }),
-            );
-            return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Ok(()));
-        }
-        return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Err(error));
-    }
-    let hook_events_after = chrono::Utc::now();
-    let start_offset = claude_tui_turn_start_offset_after_timestamp(
-        &transcript_path,
-        turn_started_at,
-        fallback_start_offset,
-    );
-    let (read_result, harvest) = match read_claude_tui_transcript_until_done(
-        &transcript_path_string,
-        start_offset,
-        sender.clone(),
-        cancel_token.clone(),
-        tmux_session_name,
-        &resolved_session_id,
-        hook_rx,
-        hook_events_after,
-    ) {
-        Ok(result) => result,
-        Err(error) => {
-            return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Err(error));
-        }
-    };
-    // #3281: capture BEFORE `classify_followup_result` consumes the read
-    // result. The zero-harvest gate is `Completed`-only: classify maps
-    // `Cancelled` to `Delivered` too, and a cancelled turn legitimately
-    // forwards nothing.
-    let read_result_kind = read_output_result_kind(&read_result);
-    let delivered_zero_harvest = tui_delivered_zero_harvest(&read_result, &harvest);
-    let zero_advance_terminal_result = match &read_result {
-        ReadOutputResult::Completed { offset } | ReadOutputResult::Cancelled { offset } => {
-            *offset <= start_offset
-        }
-        ReadOutputResult::SessionDied { .. } => false,
-    };
-    if zero_advance_terminal_result {
-        let snapshot =
-            crate::services::claude_tui::input::prompt_readiness_snapshot(tmux_session_name);
-        if claude_tui_prompt_remained_in_input_buffer(&snapshot, prompt) {
-            return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Err(
-                claude_tui_zero_advance_input_buffer_error(
-                    tmux_session_name,
-                    &transcript_path_string,
-                    start_offset,
-                    &snapshot,
-                ),
-            ));
-        }
-    }
-    match classify_followup_result(
-        read_result,
-        start_offset,
-        "claude tui session died during follow-up output reading",
-    ) {
-        ClaudeFollowupResult::Delivered => {
-            emit_claude_tui_watcher_handoff(
-                &sender,
-                &transcript_path_string,
-                tmux_session_name,
-                &transcript_path,
-            );
-            let transcript_len = std::fs::metadata(&transcript_path)
-                .map(|meta| meta.len())
-                .unwrap_or(0);
-            if delivered_zero_harvest {
-                emit_claude_tui_zero_harvest(
-                    "claude_tui_zero_harvest_warm_followup_delivered",
-                    report_channel_id,
-                    tmux_session_name,
-                    &transcript_path_string,
-                    start_offset,
-                    transcript_len,
-                );
-            }
-            log_producer_exit(
-                "tui_warm_followup_delivered",
-                Some(&resolved_session_id),
-                report_channel_id,
-                // #3281: real forwarded-message count (was a hardcoded 0).
-                usize::try_from(harvest.forwarded_messages).unwrap_or(usize::MAX),
-                serde_json::json!({
-                    "tmux_session_name": tmux_session_name,
-                    "transcript_path": transcript_path_string,
-                    "assistant_text_bytes": harvest.assistant_text_bytes,
-                    "start_offset": start_offset,
-                    "transcript_len": transcript_len,
-                    "read_result_kind": read_result_kind,
-                }),
-            );
-            return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Ok(()));
-        }
-        ClaudeFollowupResult::RecreateSession { error } => {
-            debug_log(&format!(
-                "Claude TUI follow-up failed, recreating session: {}",
-                error
-            ));
-            crate::services::termination_audit::record_termination_for_tmux(
-                tmux_session_name,
-                None,
-                "claude_tui_provider",
-                "followup_failed_recreate",
-                Some(&format!(
-                    "claude tui follow-up failed, recreating: {}",
-                    error
-                )),
-                None,
-            );
-            record_tmux_exit_reason(
-                tmux_session_name,
-                &format!("claude tui follow-up failed, recreating: {}", error),
-            );
-            crate::services::platform::tmux::kill_session(
-                tmux_session_name,
-                &format!("claude tui follow-up failed, recreating: {}", error),
-            );
-        }
-        ClaudeFollowupResult::FinalizeWithNotice { error, notice } => {
-            debug_log(&format!(
-                "Claude TUI follow-up streamed partial output before session death — suppressing replay: {}",
-                error
-            ));
-            crate::services::termination_audit::record_termination_for_tmux(
-                tmux_session_name,
-                None,
-                "claude_tui_provider",
-                "followup_partial_output_no_replay",
-                Some(&format!(
-                    "claude tui partial follow-up output delivered: {}",
-                    error
-                )),
-                None,
-            );
-            record_tmux_exit_reason(
-                tmux_session_name,
-                &format!("claude tui partial follow-up output delivered: {}", error),
-            );
-            crate::services::platform::tmux::kill_session(
-                tmux_session_name,
-                &format!("claude tui partial follow-up output delivered: {}", error),
-            );
-            emit_followup_restart_suppressed_notice(&sender, &notice);
-            return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Ok(()));
-        }
-    }
-    ClaudeTuiWarmFollowupSubmitOutcome::FallThroughRecreate
-}
-
-/// Attempt a warm follow-up against an existing live Claude TUI tmux session.
-/// Mirrors the pre-refactor live-session branch: recovery, busy wait, submit/read/classify; `Terminal` returns before fresh-launch side effects, `Recreate` carries fall-through resolution.
-#[cfg(unix)]
-fn try_claude_tui_warm_followup(
-    mut resolved_session_id: String,
-    mut transcript_path: std::path::PathBuf,
-    mut transcript_path_string: String,
-    mut resume: bool,
-    working_dir_path: &std::path::Path,
-    prompt: &str,
-    sender: Sender<StreamMessage>,
-    cancel_token: Option<std::sync::Arc<CancelToken>>,
-    tmux_session_name: &str,
-    report_channel_id: Option<u64>,
-) -> ClaudeTuiWarmFollowupOutcome {
-    debug_log("Existing Claude TUI tmux session found — sending follow-up");
-    if let Some(ref token) = cancel_token {
-        *token.tmux_session.lock().unwrap_or_else(|e| e.into_inner()) =
-            Some(tmux_session_name.to_string());
-    }
-    let hook_rx = crate::services::claude_tui::hook_server::subscribe_hook_events();
-    let (busy_waited, recreate_before_submit, prompt_draft_cleared_before_submit) =
-        match recover_claude_tui_stranded_prompt_draft(
-            ClaudeTuiRecreateState {
-                resolved_session_id,
-                transcript_path,
-                transcript_path_string,
-                resume,
-            },
-            working_dir_path,
-            &cancel_token,
-            tmux_session_name,
-            report_channel_id,
-        ) {
-            ClaudeTuiDraftRecoveryOutcome::Proceed {
-                state,
-                busy_waited,
-                recreate_before_submit,
-                prompt_draft_cleared_before_submit,
-            } => {
-                resolved_session_id = state.resolved_session_id;
-                transcript_path = state.transcript_path;
-                transcript_path_string = state.transcript_path_string;
-                resume = state.resume;
-                (
-                    busy_waited,
-                    recreate_before_submit,
-                    prompt_draft_cleared_before_submit,
-                )
-            }
-            ClaudeTuiDraftRecoveryOutcome::Terminal(r) => {
-                return ClaudeTuiWarmFollowupOutcome::Terminal(r);
-            }
-        };
-    let submit_plan = claude_tui_warm_followup_submit_plan(
-        recreate_before_submit,
-        prompt_draft_cleared_before_submit,
-    );
-    if submit_plan.submit_existing_session {
-        match run_claude_tui_warm_followup_submit_and_stream(
-            submit_plan,
-            busy_waited,
-            tmux_session_name,
-            &resolved_session_id,
-            &transcript_path,
-            &transcript_path_string,
-            prompt,
-            sender,
-            cancel_token,
-            report_channel_id,
-            hook_rx,
-        ) {
-            ClaudeTuiWarmFollowupSubmitOutcome::Terminal(r) => {
-                return ClaudeTuiWarmFollowupOutcome::Terminal(r);
-            }
-            ClaudeTuiWarmFollowupSubmitOutcome::FallThroughRecreate => {}
-        }
-    }
-
-    ClaudeTuiWarmFollowupOutcome::Recreate(ClaudeTuiRecreateState {
-        resolved_session_id,
-        transcript_path,
-        transcript_path_string,
-        resume,
-    })
-}
-
 /// Tear down a stale (no live pane) Claude TUI tmux session before recreating it.
 /// Verbatim extraction of the pre-refactor `else if session_exists` branch.
 #[cfg(unix)]
@@ -3177,7 +2092,7 @@ fn claude_tui_fresh_prompt_ready_backoff(completed_attempts: usize) -> Duration 
 }
 
 #[cfg(unix)]
-fn emit_claude_tui_watcher_handoff(
+pub(crate) fn emit_claude_tui_watcher_handoff(
     sender: &Sender<StreamMessage>,
     transcript_path_string: &str,
     tmux_session_name: &str,
@@ -3208,7 +2123,7 @@ fn emit_claude_tui_watcher_handoff(
 }
 
 #[cfg(unix)]
-fn read_claude_tui_transcript_until_done(
+pub(crate) fn read_claude_tui_transcript_until_done(
     transcript_path: &str,
     start_offset: u64,
     sender: Sender<StreamMessage>,
@@ -4742,6 +3657,12 @@ mod local_tmux_lifecycle_tests {
 #[cfg(all(test, unix))]
 mod claude_tui_session_resolution_tests {
     use super::*;
+    use crate::services::claude_tui::hosting::{
+        ClaudeTuiDraftRecoveryOutcome, ClaudeTuiRecreateState, ClaudeTuiStrandedPromptDraftState,
+        claude_tui_followup_busy_before_submit_from_snapshot,
+        claude_tui_followup_stranded_prompt_draft_state,
+        claude_tui_unknown_transcript_draft_recreate_allowed, claude_tui_warm_followup_submit_plan,
+    };
 
     #[test]
     fn preserves_existing_resume_transcript() {

--- a/src/services/claude_tui/hosting/followup_support.rs
+++ b/src/services/claude_tui/hosting/followup_support.rs
@@ -1,0 +1,447 @@
+use std::sync::mpsc::Sender;
+
+use crate::services::agent_protocol::StreamMessage;
+use crate::services::claude::debug_log;
+use crate::services::provider::{CancelToken, cancel_requested};
+
+#[cfg(unix)]
+const CLAUDE_TUI_STRANDED_DRAFT_CLEAR_ATTEMPTS: usize = 2;
+#[cfg(unix)]
+const CLAUDE_TUI_BUSY_FOLLOWUP_NOTICE: &str = "⚠ Claude TUI가 아직 이전 터미널 턴을 처리 중이라 이 메시지를 주입하지 않았습니다. 현재 응답이 끝난 뒤 다시 보내 주세요.";
+
+#[cfg(unix)]
+pub(crate) fn emit_claude_tui_zero_harvest(
+    kind: &str,
+    report_channel_id: Option<u64>,
+    tmux_session_name: &str,
+    transcript_path: &str,
+    start_offset: u64,
+    transcript_len: u64,
+) {
+    tracing::warn!(
+        tmux_session_name,
+        transcript_path,
+        start_offset,
+        transcript_len,
+        "claude_tui delivered turn harvested ZERO stream messages — the turn's response text never entered the bridge ({kind})"
+    );
+    crate::services::observability::emit_inflight_lifecycle_event(
+        "claude",
+        report_channel_id.unwrap_or(0),
+        None,
+        None,
+        None,
+        kind,
+        serde_json::json!({
+            "tmux_session_name": tmux_session_name,
+            "transcript_path": transcript_path,
+            "start_offset": start_offset,
+            "transcript_len": transcript_len,
+        }),
+    );
+}
+
+#[cfg(unix)]
+pub(super) fn emit_claude_tui_busy_followup_notice(
+    sender: &Sender<StreamMessage>,
+    tmux_session_name: &str,
+    snapshot: &crate::services::claude_tui::input::PromptReadinessSnapshot,
+) {
+    tracing::warn!(
+        tmux_session_name,
+        prompt_marker_detected = snapshot.prompt_marker_detected,
+        prompt_draft_detected = snapshot.prompt_draft_detected,
+        prompt_draft_blocks_submission = snapshot.tmux_pane_alive && snapshot.prompt_draft_detected,
+        tmux_pane_alive = snapshot.tmux_pane_alive,
+        capture_available = snapshot.capture_available,
+        pane_tail = %snapshot.pane_tail,
+        "claude_tui follow-up blocked before prompt submission because hosted TUI is busy"
+    );
+    debug_log(&format!(
+        "Claude TUI follow-up blocked before prompt submission: session={} prompt_marker_detected={} prompt_draft_detected={} prompt_draft_blocks_submission={} tmux_pane_alive={} capture_available={} pane_tail:\n{}",
+        tmux_session_name,
+        snapshot.prompt_marker_detected,
+        snapshot.prompt_draft_detected,
+        snapshot.tmux_pane_alive && snapshot.prompt_draft_detected,
+        snapshot.tmux_pane_alive,
+        snapshot.capture_available,
+        snapshot.pane_tail
+    ));
+    let _ = sender.send(StreamMessage::Text {
+        content: CLAUDE_TUI_BUSY_FOLLOWUP_NOTICE.to_string(),
+    });
+    let _ = sender.send(StreamMessage::Done {
+        result: String::new(),
+        session_id: None,
+    });
+}
+
+#[cfg(unix)]
+pub(super) fn claude_tui_followup_busy_before_submit(
+    tmux_session_name: &str,
+    transcript_path: Option<&std::path::Path>,
+) -> Option<crate::services::claude_tui::input::PromptReadinessSnapshot> {
+    let snapshot = crate::services::claude_tui::input::prompt_readiness_snapshot(tmux_session_name);
+    let transcript_turn_state = transcript_path.map(|transcript_path| {
+        crate::services::claude_tui::transcript_tail::observe_transcript_turn_state(transcript_path)
+    });
+    claude_tui_followup_busy_before_submit_from_snapshot(snapshot, transcript_turn_state)
+}
+
+#[cfg(unix)]
+pub(crate) fn claude_tui_followup_busy_before_submit_from_snapshot(
+    snapshot: crate::services::claude_tui::input::PromptReadinessSnapshot,
+    transcript_turn_state: Option<crate::services::tui_turn_state::TuiTurnState>,
+) -> Option<crate::services::claude_tui::input::PromptReadinessSnapshot> {
+    if let Some(transcript_turn_state) = transcript_turn_state {
+        match transcript_turn_state {
+            crate::services::tui_turn_state::TuiTurnState::Idle => {
+                if snapshot.tmux_pane_alive && snapshot.prompt_draft_detected {
+                    return Some(snapshot);
+                }
+                return None;
+            }
+            crate::services::tui_turn_state::TuiTurnState::Unknown
+                if snapshot.tmux_pane_alive && snapshot.prompt_draft_detected =>
+            {
+                return Some(snapshot);
+            }
+            state if state.is_busy() && snapshot.tmux_pane_alive => return Some(snapshot),
+            _ => {}
+        }
+    }
+    if snapshot.tmux_pane_alive && snapshot.prompt_draft_detected {
+        Some(snapshot)
+    } else {
+        None
+    }
+}
+
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ClaudeTuiStrandedPromptDraftState {
+    IdleTranscript,
+    UnknownTranscript,
+}
+
+#[cfg(unix)]
+impl ClaudeTuiStrandedPromptDraftState {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::IdleTranscript => "idle",
+            Self::UnknownTranscript => "unknown",
+        }
+    }
+}
+
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ClaudeTuiWarmFollowupSubmitPlan {
+    pub(crate) submit_existing_session: bool,
+    pub(crate) recheck_busy_before_submit: bool,
+}
+
+#[cfg(unix)]
+pub(crate) fn claude_tui_warm_followup_submit_plan(
+    recreate_before_submit: bool,
+    prompt_draft_cleared_before_submit: bool,
+) -> ClaudeTuiWarmFollowupSubmitPlan {
+    ClaudeTuiWarmFollowupSubmitPlan {
+        submit_existing_session: !recreate_before_submit,
+        recheck_busy_before_submit: !prompt_draft_cleared_before_submit,
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn claude_tui_followup_stranded_prompt_draft_state(
+    snapshot: &crate::services::claude_tui::input::PromptReadinessSnapshot,
+    transcript_path: &std::path::Path,
+) -> Option<ClaudeTuiStrandedPromptDraftState> {
+    let transcript_turn_state =
+        crate::services::claude_tui::transcript_tail::observe_transcript_turn_state(
+            transcript_path,
+        );
+    if !claude_tui_snapshot_has_recoverable_prompt_draft(snapshot) {
+        return None;
+    }
+    match transcript_turn_state {
+        crate::services::tui_turn_state::TuiTurnState::Idle => {
+            Some(ClaudeTuiStrandedPromptDraftState::IdleTranscript)
+        }
+        crate::services::tui_turn_state::TuiTurnState::Unknown => {
+            Some(ClaudeTuiStrandedPromptDraftState::UnknownTranscript)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(unix)]
+fn claude_tui_snapshot_has_recoverable_prompt_draft(
+    snapshot: &crate::services::claude_tui::input::PromptReadinessSnapshot,
+) -> bool {
+    snapshot.tmux_pane_alive
+        && snapshot.prompt_draft_detected
+        && !crate::services::claude_tui::input::claude_prompt_draft_is_idle_suggestion_tail(
+            &snapshot.pane_tail,
+        )
+        && crate::services::claude_tui::input::claude_prompt_draft_backspace_budget_from_tail(
+            &snapshot.pane_tail,
+        )
+        .is_some()
+}
+
+#[cfg(unix)]
+pub(super) fn claude_tui_prompt_remained_in_input_buffer(
+    snapshot: &crate::services::claude_tui::input::PromptReadinessSnapshot,
+    prompt: &str,
+) -> bool {
+    if !snapshot.tmux_pane_alive || !snapshot.capture_available {
+        return false;
+    }
+    let prompt = prompt.trim();
+    if prompt.is_empty() {
+        return false;
+    }
+    snapshot.pane_tail.lines().rev().take(12).any(|line| {
+        let trimmed = line.trim_matches(|ch: char| ch.is_whitespace() || ch == '\u{00a0}');
+        let Some(rest) = trimmed.strip_prefix('\u{276f}') else {
+            return false;
+        };
+        let rest = rest.trim_matches(|ch: char| ch.is_whitespace() || ch == '\u{00a0}');
+        !rest
+            .get(..6)
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case("[User:"))
+            && rest.contains(prompt)
+    })
+}
+
+#[cfg(unix)]
+pub(super) fn claude_tui_zero_advance_input_buffer_error(
+    tmux_session_name: &str,
+    transcript_path: &str,
+    start_offset: u64,
+    snapshot: &crate::services::claude_tui::input::PromptReadinessSnapshot,
+) -> String {
+    format!(
+        "claude tui follow-up produced no new transcript bytes and prompt remained in TUI input buffer; tmux_session={}; transcript_path={}; start_offset={}; capture_available={}; prompt_marker_detected={}; prompt_draft_detected={}; pane_tail={}",
+        tmux_session_name,
+        transcript_path,
+        start_offset,
+        snapshot.capture_available,
+        snapshot.prompt_marker_detected,
+        snapshot.prompt_draft_detected,
+        snapshot.pane_tail
+    )
+}
+
+#[cfg(all(test, unix))]
+mod claude_tui_prompt_buffer_tests {
+    use super::*;
+
+    #[test]
+    fn detects_stuck_followup_prompt_even_when_generic_draft_heuristic_ignores_footer() {
+        let snapshot = crate::services::claude_tui::input::PromptReadinessSnapshot {
+            prompt_marker_detected: true,
+            prompt_draft_detected: false,
+            tmux_pane_alive: true,
+            capture_available: true,
+            pane_tail: "\
+✻ Baked for 10m 9s
+────────────────────────────────────────────────────────────────────────────
+❯\u{00a0}응답에 정확히 한 줄로 [E2E:E6:AFTER] 만 출력해줘.
+────────────────────────────────────────────────────────────────────────────
+  CLAUDE.md: 1, MCP: 2 │ Tools: 5 done
+  ⏵⏵ bypass permissions on"
+                .to_string(),
+        };
+
+        assert!(claude_tui_prompt_remained_in_input_buffer(
+            &snapshot,
+            "응답에 정확히 한 줄로 [E2E:E6:AFTER] 만 출력해줘."
+        ));
+    }
+
+    #[test]
+    fn ignores_submitted_discord_history_prompt() {
+        let snapshot = crate::services::claude_tui::input::PromptReadinessSnapshot {
+            prompt_marker_detected: false,
+            prompt_draft_detected: false,
+            tmux_pane_alive: true,
+            capture_available: true,
+            pane_tail: "\
+❯ [User: 명령봇 (ID: 1)] 응답에 정확히 한 줄로 [E2E:E6:AFTER] 만 출력해줘.
+⏺ [E2E:E6:AFTER]"
+                .to_string(),
+        };
+
+        assert!(!claude_tui_prompt_remained_in_input_buffer(
+            &snapshot,
+            "응답에 정확히 한 줄로 [E2E:E6:AFTER] 만 출력해줘."
+        ));
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn claude_tui_unknown_transcript_draft_recreate_allowed(
+    snapshot: &crate::services::claude_tui::input::PromptReadinessSnapshot,
+) -> bool {
+    if !snapshot.tmux_pane_alive || !snapshot.prompt_draft_detected || !snapshot.capture_available {
+        return false;
+    }
+    let tail = snapshot.pane_tail.as_str();
+    let tail_lower = tail.to_ascii_lowercase();
+    if tail_lower.contains("esc to interrupt")
+        || tail_lower.contains("processing")
+        || tail_lower.contains("thinking")
+        || tail_lower.contains("running")
+    {
+        return false;
+    }
+    tail.contains("Baked for")
+        || tail.contains("Brewed for")
+        || (tail.contains("Tools:") && tail.contains(" done"))
+}
+
+#[cfg(unix)]
+fn ensure_tmux_key_send_success(
+    output: std::process::Output,
+    action_name: &str,
+) -> Result<(), String> {
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if stderr.is_empty() {
+        Err(format!("tmux send {action_name} failed: {}", output.status))
+    } else {
+        Err(format!("tmux send {action_name} failed: {stderr}"))
+    }
+}
+
+#[cfg(unix)]
+fn clear_claude_tui_draft_with_backspaces(
+    tmux_session_name: &str,
+    snapshot: &mut crate::services::claude_tui::input::PromptReadinessSnapshot,
+    cancel_token: Option<&CancelToken>,
+) -> Result<(), String> {
+    let Some(mut remaining) =
+        crate::services::claude_tui::input::claude_prompt_draft_backspace_budget_from_tail(
+            &snapshot.pane_tail,
+        )
+    else {
+        return Ok(());
+    };
+    let output = crate::services::platform::tmux::send_keys(tmux_session_name, &["C-e"])?;
+    ensure_tmux_key_send_success(output, "draft-clear-cursor-end")?;
+    while remaining > 0 {
+        if cancel_requested(cancel_token) {
+            return Err(
+                crate::services::claude_tui::input::PROMPT_READY_CANCELLED_ERROR.to_string(),
+            );
+        }
+        let batch = remaining.min(32);
+        let keys = vec!["BSpace"; batch];
+        let output = crate::services::platform::tmux::send_keys(tmux_session_name, &keys)?;
+        ensure_tmux_key_send_success(output, "draft-clear-backspace")?;
+        remaining -= batch;
+    }
+    std::thread::sleep(std::time::Duration::from_millis(120));
+    *snapshot = crate::services::claude_tui::input::prompt_readiness_snapshot(tmux_session_name);
+    Ok(())
+}
+
+#[cfg(unix)]
+pub(super) fn clear_claude_tui_stranded_prompt_draft(
+    tmux_session_name: &str,
+    cancel_token: Option<&CancelToken>,
+) -> Result<crate::services::claude_tui::input::PromptReadinessSnapshot, String> {
+    let clear_key_plans: [&[&str]; 3] = [&["C-e", "C-u"], &["Escape"], &["C-e", "C-u"]];
+    let mut snapshot =
+        crate::services::claude_tui::input::prompt_readiness_snapshot(tmux_session_name);
+    if !snapshot.prompt_draft_detected || !snapshot.tmux_pane_alive {
+        return Ok(snapshot);
+    }
+
+    for attempt in 1..=CLAUDE_TUI_STRANDED_DRAFT_CLEAR_ATTEMPTS {
+        if cancel_requested(cancel_token) {
+            return Err(
+                crate::services::claude_tui::input::PROMPT_READY_CANCELLED_ERROR.to_string(),
+            );
+        }
+        for keys in clear_key_plans {
+            let output = crate::services::platform::tmux::send_keys(tmux_session_name, keys)?;
+            ensure_tmux_key_send_success(output, "clear-draft")?;
+            std::thread::sleep(std::time::Duration::from_millis(120));
+            if cancel_requested(cancel_token) {
+                return Err(
+                    crate::services::claude_tui::input::PROMPT_READY_CANCELLED_ERROR.to_string(),
+                );
+            }
+            snapshot =
+                crate::services::claude_tui::input::prompt_readiness_snapshot(tmux_session_name);
+            if !snapshot.prompt_draft_detected || !snapshot.tmux_pane_alive {
+                return Ok(snapshot);
+            }
+        }
+        clear_claude_tui_draft_with_backspaces(tmux_session_name, &mut snapshot, cancel_token)?;
+        if !snapshot.prompt_draft_detected || !snapshot.tmux_pane_alive {
+            return Ok(snapshot);
+        }
+        tracing::warn!(
+            tmux_session_name,
+            attempt,
+            prompt_marker_detected = snapshot.prompt_marker_detected,
+            prompt_draft_detected = snapshot.prompt_draft_detected,
+            tmux_pane_alive = snapshot.tmux_pane_alive,
+            capture_available = snapshot.capture_available,
+            pane_tail = %snapshot.pane_tail,
+            "claude_tui stranded prompt draft still present after clear attempt"
+        );
+    }
+
+    Ok(snapshot)
+}
+
+#[cfg(unix)]
+pub(super) fn gently_clear_claude_tui_prompt_draft(
+    tmux_session_name: &str,
+    cancel_token: Option<&CancelToken>,
+) -> Result<crate::services::claude_tui::input::PromptReadinessSnapshot, String> {
+    let mut snapshot =
+        crate::services::claude_tui::input::prompt_readiness_snapshot(tmux_session_name);
+    if !snapshot.prompt_draft_detected || !snapshot.tmux_pane_alive {
+        return Ok(snapshot);
+    }
+
+    for attempt in 1..=CLAUDE_TUI_STRANDED_DRAFT_CLEAR_ATTEMPTS {
+        if cancel_requested(cancel_token) {
+            return Err(
+                crate::services::claude_tui::input::PROMPT_READY_CANCELLED_ERROR.to_string(),
+            );
+        }
+        let output =
+            crate::services::platform::tmux::send_keys(tmux_session_name, &["C-e", "C-u"])?;
+        ensure_tmux_key_send_success(output, "gentle-clear-draft")?;
+        std::thread::sleep(std::time::Duration::from_millis(120));
+        snapshot = crate::services::claude_tui::input::prompt_readiness_snapshot(tmux_session_name);
+        if !snapshot.prompt_draft_detected || !snapshot.tmux_pane_alive {
+            return Ok(snapshot);
+        }
+        clear_claude_tui_draft_with_backspaces(tmux_session_name, &mut snapshot, cancel_token)?;
+        if !snapshot.prompt_draft_detected || !snapshot.tmux_pane_alive {
+            return Ok(snapshot);
+        }
+        tracing::warn!(
+            tmux_session_name,
+            attempt,
+            prompt_marker_detected = snapshot.prompt_marker_detected,
+            prompt_draft_detected = snapshot.prompt_draft_detected,
+            tmux_pane_alive = snapshot.tmux_pane_alive,
+            capture_available = snapshot.capture_available,
+            pane_tail = %snapshot.pane_tail,
+            "claude_tui prompt draft still present after gentle clear attempt"
+        );
+    }
+
+    Ok(snapshot)
+}

--- a/src/services/claude_tui/hosting/mod.rs
+++ b/src/services/claude_tui/hosting/mod.rs
@@ -1,0 +1,13 @@
+mod followup_support;
+mod warm_followup;
+
+pub(crate) use followup_support::emit_claude_tui_zero_harvest;
+#[cfg(test)]
+pub(crate) use followup_support::{
+    ClaudeTuiStrandedPromptDraftState, claude_tui_followup_busy_before_submit_from_snapshot,
+    claude_tui_followup_stranded_prompt_draft_state,
+    claude_tui_unknown_transcript_draft_recreate_allowed, claude_tui_warm_followup_submit_plan,
+};
+#[cfg(test)]
+pub(crate) use warm_followup::{ClaudeTuiDraftRecoveryOutcome, ClaudeTuiRecreateState};
+pub(crate) use warm_followup::{ClaudeTuiWarmFollowupOutcome, try_claude_tui_warm_followup};

--- a/src/services/claude_tui/hosting/warm_followup.rs
+++ b/src/services/claude_tui/hosting/warm_followup.rs
@@ -1,0 +1,676 @@
+use std::sync::mpsc::Sender;
+
+use crate::services::agent_protocol::StreamMessage;
+use crate::services::claude::{
+    ClaudeFollowupResult, classify_followup_result, claude_tui_turn_start_offset_after_timestamp,
+    debug_log, emit_claude_tui_watcher_handoff, emit_followup_restart_suppressed_notice,
+    fresh_claude_tui_session_resolution, log_producer_exit, read_claude_tui_transcript_until_done,
+    read_output_result_kind, tui_delivered_zero_harvest,
+};
+use crate::services::provider::{CancelToken, ReadOutputResult};
+use crate::services::tmux_diagnostics::record_tmux_exit_reason;
+
+use super::followup_support::{
+    ClaudeTuiStrandedPromptDraftState, ClaudeTuiWarmFollowupSubmitPlan,
+    claude_tui_followup_busy_before_submit, claude_tui_followup_stranded_prompt_draft_state,
+    claude_tui_prompt_remained_in_input_buffer,
+    claude_tui_unknown_transcript_draft_recreate_allowed, claude_tui_warm_followup_submit_plan,
+    claude_tui_zero_advance_input_buffer_error, clear_claude_tui_stranded_prompt_draft,
+    emit_claude_tui_busy_followup_notice, emit_claude_tui_zero_harvest,
+    gently_clear_claude_tui_prompt_draft,
+};
+
+/// Updated session resolution carried back to the orchestrator when a warm
+/// follow-up could not be delivered and the hosted session must be recreated.
+#[cfg(unix)]
+pub(crate) struct ClaudeTuiRecreateState {
+    pub(crate) resolved_session_id: String,
+    pub(crate) transcript_path: std::path::PathBuf,
+    pub(crate) transcript_path_string: String,
+    pub(crate) resume: bool,
+}
+
+/// Outcome of stranded prompt-draft recovery; `Terminal` forwards original Ok/Err exits before submit side effects, and `Proceed` carries the fall-through quartet/flags.
+#[cfg(unix)]
+#[must_use]
+pub(crate) enum ClaudeTuiDraftRecoveryOutcome {
+    /// Continue to submit-plan computation with the possibly recreated quartet plus busy/recreate/draft-cleared flags.
+    Proceed {
+        state: ClaudeTuiRecreateState,
+        busy_waited: bool,
+        recreate_before_submit: bool,
+        prompt_draft_cleared_before_submit: bool,
+    },
+    /// Recovery hit an original early return; forward the `Result` verbatim.
+    Terminal(Result<(), String>),
+}
+
+/// Outcome of an attempted warm follow-up against a live Claude TUI session.
+#[cfg(unix)]
+pub(crate) enum ClaudeTuiWarmFollowupOutcome {
+    /// Handled (delivered, aborted, or errored); return this without launch.
+    Terminal(Result<(), String>),
+    /// Could not proceed; fall through to fresh launch with this resolution.
+    Recreate(ClaudeTuiRecreateState),
+}
+
+/// Verbatim extraction of the warm-followup submit-and-stream block; `Terminal` carries the original early-return `Result` unchanged.
+/// `FallThroughRecreate` preserves `submit_existing_session == false` and `RecreateSession` kill-then-fresh-launch fall-through.
+#[cfg(unix)]
+#[must_use]
+enum ClaudeTuiWarmFollowupSubmitOutcome {
+    Terminal(Result<(), String>),
+    FallThroughRecreate,
+}
+
+/// Recover from a stranded prompt draft left in the composer before submit.
+/// Verbatim extraction: destructures state into the original mutable locals; cancellation returns `Ok(())`, fresh-resolution failures return `Err(..)`, and fall-through returns `Proceed` with quartet/flags.
+#[cfg(unix)]
+fn recover_claude_tui_stranded_prompt_draft(
+    state: ClaudeTuiRecreateState,
+    working_dir_path: &std::path::Path,
+    cancel_token: &Option<std::sync::Arc<CancelToken>>,
+    tmux_session_name: &str,
+    report_channel_id: Option<u64>,
+) -> ClaudeTuiDraftRecoveryOutcome {
+    let ClaudeTuiRecreateState {
+        mut resolved_session_id,
+        mut transcript_path,
+        mut transcript_path_string,
+        mut resume,
+    } = state;
+    // #2416: a single busy_waited flag tells the offset-capture site below
+    // that we need to re-read transcript length after the wait succeeded,
+    // because the previous TUI turn may have appended bytes while we were
+    // waiting (otherwise the follow-up reader would treat previous-turn
+    // bytes as new-turn output).
+    let mut busy_waited = false;
+    let mut recreate_before_submit = false;
+    let mut prompt_draft_cleared_before_submit = false;
+    if let Some(snapshot) =
+        claude_tui_followup_busy_before_submit(tmux_session_name, Some(&transcript_path))
+    {
+        if let Some(draft_state) =
+            claude_tui_followup_stranded_prompt_draft_state(&snapshot, &transcript_path)
+        {
+            let allow_recreate = matches!(
+                draft_state,
+                ClaudeTuiStrandedPromptDraftState::IdleTranscript
+            );
+            tracing::warn!(
+                tmux_session_name,
+                transcript_path = %transcript_path_string,
+                transcript_turn_state = draft_state.as_str(),
+                prompt_marker_detected = snapshot.prompt_marker_detected,
+                prompt_draft_detected = snapshot.prompt_draft_detected,
+                capture_available = snapshot.capture_available,
+                pane_tail = %snapshot.pane_tail,
+                "claude_tui follow-up found non-busy transcript with stranded composer draft; attempting draft clear"
+            );
+            debug_log(&format!(
+                "Claude TUI follow-up: {} transcript has stranded prompt draft, attempting clear (session={}, transcript={})",
+                draft_state.as_str(),
+                tmux_session_name,
+                transcript_path_string
+            ));
+            let clear_result = if allow_recreate {
+                clear_claude_tui_stranded_prompt_draft(tmux_session_name, cancel_token.as_deref())
+            } else {
+                gently_clear_claude_tui_prompt_draft(tmux_session_name, cancel_token.as_deref())
+            };
+            match clear_result {
+                Ok(post_clear_snapshot)
+                    if post_clear_snapshot.tmux_pane_alive
+                        && !post_clear_snapshot.prompt_draft_detected =>
+                {
+                    busy_waited = true;
+                    prompt_draft_cleared_before_submit = true;
+                    tracing::info!(
+                        tmux_session_name,
+                        transcript_turn_state = draft_state.as_str(),
+                        prompt_marker_detected = post_clear_snapshot.prompt_marker_detected,
+                        capture_available = post_clear_snapshot.capture_available,
+                        "claude_tui stranded prompt draft cleared before follow-up submit"
+                    );
+                    debug_log(&format!(
+                        "Claude TUI follow-up: stranded prompt draft cleared (session={} prompt_marker_detected={} capture_available={})",
+                        tmux_session_name,
+                        post_clear_snapshot.prompt_marker_detected,
+                        post_clear_snapshot.capture_available
+                    ));
+                }
+                Ok(post_clear_snapshot) => {
+                    let reason = if post_clear_snapshot.tmux_pane_alive {
+                        "stranded claude tui prompt draft persisted after clear attempts"
+                    } else {
+                        "claude tui pane died while clearing stranded prompt draft"
+                    };
+                    let recreate_after_persistent_draft = allow_recreate
+                        || (matches!(
+                            draft_state,
+                            ClaudeTuiStrandedPromptDraftState::UnknownTranscript
+                        ) && claude_tui_unknown_transcript_draft_recreate_allowed(
+                            &post_clear_snapshot,
+                        ));
+                    if !recreate_after_persistent_draft {
+                        tracing::warn!(
+                            tmux_session_name,
+                            transcript_turn_state = draft_state.as_str(),
+                            prompt_marker_detected = post_clear_snapshot.prompt_marker_detected,
+                            prompt_draft_detected = post_clear_snapshot.prompt_draft_detected,
+                            tmux_pane_alive = post_clear_snapshot.tmux_pane_alive,
+                            capture_available = post_clear_snapshot.capture_available,
+                            pane_tail = %post_clear_snapshot.pane_tail,
+                            "claude_tui unknown-transcript draft recovery did not clear draft; falling back to busy wait"
+                        );
+                        debug_log(&format!(
+                            "Claude TUI follow-up: {} under unknown transcript; falling back to busy wait (session={})",
+                            reason, tmux_session_name
+                        ));
+                    } else {
+                        tracing::warn!(
+                            tmux_session_name,
+                            prompt_marker_detected = post_clear_snapshot.prompt_marker_detected,
+                            prompt_draft_detected = post_clear_snapshot.prompt_draft_detected,
+                            tmux_pane_alive = post_clear_snapshot.tmux_pane_alive,
+                            capture_available = post_clear_snapshot.capture_available,
+                            pane_tail = %post_clear_snapshot.pane_tail,
+                            "claude_tui stranded prompt draft recovery will recreate hosted session"
+                        );
+                        debug_log(&format!(
+                            "Claude TUI follow-up: {} (session={})",
+                            reason, tmux_session_name
+                        ));
+                        crate::services::termination_audit::record_termination_for_tmux(
+                            tmux_session_name,
+                            None,
+                            "claude_tui_provider",
+                            "stranded_prompt_draft_recreate",
+                            Some(reason),
+                            None,
+                        );
+                        record_tmux_exit_reason(tmux_session_name, reason);
+                        crate::services::platform::tmux::kill_session(tmux_session_name, reason);
+                        let fresh_resolution =
+                            match fresh_claude_tui_session_resolution(working_dir_path, None) {
+                                Ok(resolution) => resolution,
+                                Err(error) => {
+                                    return ClaudeTuiDraftRecoveryOutcome::Terminal(Err(error));
+                                }
+                            };
+                        resolved_session_id = fresh_resolution.session_id;
+                        transcript_path = fresh_resolution.transcript_path;
+                        transcript_path_string = transcript_path.display().to_string();
+                        resume = fresh_resolution.resume;
+                        recreate_before_submit = true;
+                    }
+                }
+                Err(error)
+                    if crate::services::claude_tui::input::is_prompt_ready_cancelled_error(
+                        &error,
+                    ) =>
+                {
+                    debug_log(&format!(
+                        "Claude TUI follow-up: cancellation observed while clearing stranded prompt draft (session={})",
+                        tmux_session_name
+                    ));
+                    log_producer_exit(
+                        "tui_warm_followup_cancelled_during_draft_clear",
+                        Some(&resolved_session_id),
+                        report_channel_id,
+                        0,
+                        serde_json::json!({
+                            "tmux_session_name": tmux_session_name,
+                            "transcript_path": transcript_path_string,
+                        }),
+                    );
+                    return ClaudeTuiDraftRecoveryOutcome::Terminal(Ok(()));
+                }
+                Err(error) => {
+                    let recreate_after_clear_error = allow_recreate
+                        || (matches!(
+                            draft_state,
+                            ClaudeTuiStrandedPromptDraftState::UnknownTranscript
+                        ) && claude_tui_unknown_transcript_draft_recreate_allowed(&snapshot));
+                    if !recreate_after_clear_error {
+                        tracing::warn!(
+                            tmux_session_name,
+                            error = %error,
+                            "claude_tui unknown-transcript draft clear failed; falling back to busy wait"
+                        );
+                        debug_log(&format!(
+                            "Claude TUI follow-up: unknown-transcript draft clear failed, falling back to busy wait (session={} error={})",
+                            tmux_session_name, error
+                        ));
+                    } else {
+                        tracing::warn!(
+                            tmux_session_name,
+                            error = %error,
+                            "claude_tui stranded prompt draft clear failed; recreating hosted session"
+                        );
+                        crate::services::termination_audit::record_termination_for_tmux(
+                            tmux_session_name,
+                            None,
+                            "claude_tui_provider",
+                            "stranded_prompt_draft_clear_failed_recreate",
+                            Some(&format!(
+                                "claude tui stranded prompt draft clear failed: {}",
+                                error
+                            )),
+                            None,
+                        );
+                        record_tmux_exit_reason(
+                            tmux_session_name,
+                            &format!("claude tui stranded prompt draft clear failed: {}", error),
+                        );
+                        crate::services::platform::tmux::kill_session(
+                            tmux_session_name,
+                            &format!("claude tui stranded prompt draft clear failed: {}", error),
+                        );
+                        let fresh_resolution =
+                            match fresh_claude_tui_session_resolution(working_dir_path, None) {
+                                Ok(resolution) => resolution,
+                                Err(error) => {
+                                    return ClaudeTuiDraftRecoveryOutcome::Terminal(Err(error));
+                                }
+                            };
+                        resolved_session_id = fresh_resolution.session_id;
+                        transcript_path = fresh_resolution.transcript_path;
+                        transcript_path_string = transcript_path.display().to_string();
+                        resume = fresh_resolution.resume;
+                        recreate_before_submit = true;
+                    }
+                }
+            }
+        }
+    }
+    ClaudeTuiDraftRecoveryOutcome::Proceed {
+        state: ClaudeTuiRecreateState {
+            resolved_session_id,
+            transcript_path,
+            transcript_path_string,
+            resume,
+        },
+        busy_waited,
+        recreate_before_submit,
+        prompt_draft_cleared_before_submit,
+    }
+}
+
+#[cfg(unix)]
+fn run_claude_tui_warm_followup_submit_and_stream(
+    submit_plan: ClaudeTuiWarmFollowupSubmitPlan,
+    mut busy_waited: bool,
+    tmux_session_name: &str,
+    resolved_session_id: &str,
+    transcript_path: &std::path::Path,
+    transcript_path_string: &str,
+    prompt: &str,
+    sender: Sender<StreamMessage>,
+    cancel_token: Option<std::sync::Arc<CancelToken>>,
+    report_channel_id: Option<u64>,
+    hook_rx: tokio::sync::broadcast::Receiver<crate::services::claude_tui::hook_server::HookEvent>,
+) -> ClaudeTuiWarmFollowupSubmitOutcome {
+    if submit_plan.recheck_busy_before_submit
+        && let Some(snapshot) =
+            claude_tui_followup_busy_before_submit(tmux_session_name, Some(&transcript_path))
+    {
+        // #2416: instead of dropping the user's message when the TUI is busy,
+        // wait for the next prompt-ready window. The transcript-idle
+        // fallback covers Claude TUI redraws where the JSONL terminal
+        // envelope is authoritative but the prompt glyph is not visible.
+        match crate::services::claude_tui::input::wait_for_prompt_ready_or_idle_transcript(
+            tmux_session_name,
+            crate::services::claude_tui::input::PromptReadinessKind::Followup,
+            cancel_token.as_deref(),
+            &transcript_path,
+        ) {
+            Ok(()) => {
+                busy_waited = true;
+                debug_log(&format!(
+                    "Claude TUI follow-up: busy at first check, became ready after wait (session={})",
+                    tmux_session_name
+                ));
+            }
+            Err(err) => {
+                if crate::services::claude_tui::input::is_prompt_ready_cancelled_error(&err) {
+                    debug_log(&format!(
+                        "Claude TUI follow-up: cancellation observed during busy wait, aborting injection (session={})",
+                        tmux_session_name
+                    ));
+                    log_producer_exit(
+                        "tui_warm_followup_cancelled_during_busy_wait",
+                        Some(&resolved_session_id),
+                        report_channel_id,
+                        0,
+                        serde_json::json!({
+                            "tmux_session_name": tmux_session_name,
+                            "transcript_path": transcript_path_string,
+                        }),
+                    );
+                    return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Ok(()));
+                }
+                let timed_out =
+                    crate::services::claude_tui::input::is_prompt_ready_timeout_error(&err);
+                debug_log(&format!(
+                    "Claude TUI follow-up wait failed after busy snapshot (session={}, timed_out={}): {}",
+                    tmux_session_name, timed_out, err
+                ));
+                let post_wait_snapshot =
+                    crate::services::claude_tui::input::prompt_readiness_snapshot(
+                        tmux_session_name,
+                    );
+                emit_claude_tui_busy_followup_notice(
+                    &sender,
+                    tmux_session_name,
+                    &post_wait_snapshot,
+                );
+                log_producer_exit(
+                    "tui_warm_followup_busy_pre_submit",
+                    Some(&resolved_session_id),
+                    report_channel_id,
+                    0,
+                    serde_json::json!({
+                        "tmux_session_name": tmux_session_name,
+                        "transcript_path": transcript_path_string,
+                        "prompt_marker_detected": post_wait_snapshot.prompt_marker_detected,
+                        "prompt_draft_detected": post_wait_snapshot.prompt_draft_detected,
+                        "prompt_draft_blocks_submission": post_wait_snapshot.tmux_pane_alive && post_wait_snapshot.prompt_draft_detected,
+                        "tmux_pane_alive": post_wait_snapshot.tmux_pane_alive,
+                        "capture_available": post_wait_snapshot.capture_available,
+                        "initial_busy_snapshot_prompt_marker_detected": snapshot.prompt_marker_detected,
+                        "initial_busy_snapshot_prompt_draft_detected": snapshot.prompt_draft_detected,
+                        "wait_outcome": if timed_out { "timeout" } else { "error" },
+                        "wait_error": err,
+                    }),
+                );
+                return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Ok(()));
+            }
+        }
+    }
+    // #2416: capture the transcript offset AFTER the optional busy wait so
+    // that any bytes the previous TUI turn appended while we were waiting
+    // are not replayed as part of this follow-up's output window. This
+    // closes a Codex-flagged HIGH (stale offset → duplicate / early-done
+    // delivery accounting).
+    let fallback_start_offset = std::fs::metadata(&transcript_path)
+        .map(|meta| meta.len())
+        .unwrap_or(0);
+    // #2416: also honour cancellation that may have flipped during the
+    // up-to-45s busy wait. Without this, a user stop reaction / watchdog
+    // cancellation arriving mid-wait would still inject the prompt as
+    // soon as the TUI returns to ready. Closes a Codex-flagged HIGH.
+    if busy_waited && crate::services::provider::cancel_requested(cancel_token.as_deref()) {
+        debug_log(&format!(
+            "Claude TUI follow-up: cancellation observed after busy wait, aborting injection (session={})",
+            tmux_session_name
+        ));
+        log_producer_exit(
+            "tui_warm_followup_cancelled_after_busy_wait",
+            Some(&resolved_session_id),
+            report_channel_id,
+            0,
+            serde_json::json!({
+                "tmux_session_name": tmux_session_name,
+                "transcript_path": transcript_path_string,
+            }),
+        );
+        return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Ok(()));
+    }
+    let turn_started_at = chrono::Utc::now();
+    if let Err(error) = crate::services::claude_tui::input::send_followup_prompt_or_idle_transcript(
+        tmux_session_name,
+        prompt,
+        cancel_token.as_deref(),
+        &transcript_path,
+    ) {
+        if crate::services::claude_tui::input::is_prompt_ready_cancelled_error(&error) {
+            debug_log(&format!(
+                "Claude TUI follow-up: cancellation observed during prompt submission, aborting injection (session={})",
+                tmux_session_name
+            ));
+            log_producer_exit(
+                "tui_warm_followup_cancelled_during_prompt_submit",
+                Some(&resolved_session_id),
+                report_channel_id,
+                0,
+                serde_json::json!({
+                    "tmux_session_name": tmux_session_name,
+                    "transcript_path": transcript_path_string,
+                }),
+            );
+            return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Ok(()));
+        }
+        return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Err(error));
+    }
+    let hook_events_after = chrono::Utc::now();
+    let start_offset = claude_tui_turn_start_offset_after_timestamp(
+        &transcript_path,
+        turn_started_at,
+        fallback_start_offset,
+    );
+    let (read_result, harvest) = match read_claude_tui_transcript_until_done(
+        &transcript_path_string,
+        start_offset,
+        sender.clone(),
+        cancel_token.clone(),
+        tmux_session_name,
+        &resolved_session_id,
+        hook_rx,
+        hook_events_after,
+    ) {
+        Ok(result) => result,
+        Err(error) => {
+            return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Err(error));
+        }
+    };
+    // #3281: capture BEFORE `classify_followup_result` consumes the read
+    // result. The zero-harvest gate is `Completed`-only: classify maps
+    // `Cancelled` to `Delivered` too, and a cancelled turn legitimately
+    // forwards nothing.
+    let read_result_kind = read_output_result_kind(&read_result);
+    let delivered_zero_harvest = tui_delivered_zero_harvest(&read_result, &harvest);
+    let zero_advance_terminal_result = match &read_result {
+        ReadOutputResult::Completed { offset } | ReadOutputResult::Cancelled { offset } => {
+            *offset <= start_offset
+        }
+        ReadOutputResult::SessionDied { .. } => false,
+    };
+    if zero_advance_terminal_result {
+        let snapshot =
+            crate::services::claude_tui::input::prompt_readiness_snapshot(tmux_session_name);
+        if claude_tui_prompt_remained_in_input_buffer(&snapshot, prompt) {
+            return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Err(
+                claude_tui_zero_advance_input_buffer_error(
+                    tmux_session_name,
+                    &transcript_path_string,
+                    start_offset,
+                    &snapshot,
+                ),
+            ));
+        }
+    }
+    match classify_followup_result(
+        read_result,
+        start_offset,
+        "claude tui session died during follow-up output reading",
+    ) {
+        ClaudeFollowupResult::Delivered => {
+            emit_claude_tui_watcher_handoff(
+                &sender,
+                &transcript_path_string,
+                tmux_session_name,
+                &transcript_path,
+            );
+            let transcript_len = std::fs::metadata(&transcript_path)
+                .map(|meta| meta.len())
+                .unwrap_or(0);
+            if delivered_zero_harvest {
+                emit_claude_tui_zero_harvest(
+                    "claude_tui_zero_harvest_warm_followup_delivered",
+                    report_channel_id,
+                    tmux_session_name,
+                    &transcript_path_string,
+                    start_offset,
+                    transcript_len,
+                );
+            }
+            log_producer_exit(
+                "tui_warm_followup_delivered",
+                Some(&resolved_session_id),
+                report_channel_id,
+                // #3281: real forwarded-message count (was a hardcoded 0).
+                usize::try_from(harvest.forwarded_messages).unwrap_or(usize::MAX),
+                serde_json::json!({
+                    "tmux_session_name": tmux_session_name,
+                    "transcript_path": transcript_path_string,
+                    "assistant_text_bytes": harvest.assistant_text_bytes,
+                    "start_offset": start_offset,
+                    "transcript_len": transcript_len,
+                    "read_result_kind": read_result_kind,
+                }),
+            );
+            return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Ok(()));
+        }
+        ClaudeFollowupResult::RecreateSession { error } => {
+            debug_log(&format!(
+                "Claude TUI follow-up failed, recreating session: {}",
+                error
+            ));
+            crate::services::termination_audit::record_termination_for_tmux(
+                tmux_session_name,
+                None,
+                "claude_tui_provider",
+                "followup_failed_recreate",
+                Some(&format!(
+                    "claude tui follow-up failed, recreating: {}",
+                    error
+                )),
+                None,
+            );
+            record_tmux_exit_reason(
+                tmux_session_name,
+                &format!("claude tui follow-up failed, recreating: {}", error),
+            );
+            crate::services::platform::tmux::kill_session(
+                tmux_session_name,
+                &format!("claude tui follow-up failed, recreating: {}", error),
+            );
+        }
+        ClaudeFollowupResult::FinalizeWithNotice { error, notice } => {
+            debug_log(&format!(
+                "Claude TUI follow-up streamed partial output before session death — suppressing replay: {}",
+                error
+            ));
+            crate::services::termination_audit::record_termination_for_tmux(
+                tmux_session_name,
+                None,
+                "claude_tui_provider",
+                "followup_partial_output_no_replay",
+                Some(&format!(
+                    "claude tui partial follow-up output delivered: {}",
+                    error
+                )),
+                None,
+            );
+            record_tmux_exit_reason(
+                tmux_session_name,
+                &format!("claude tui partial follow-up output delivered: {}", error),
+            );
+            crate::services::platform::tmux::kill_session(
+                tmux_session_name,
+                &format!("claude tui partial follow-up output delivered: {}", error),
+            );
+            emit_followup_restart_suppressed_notice(&sender, &notice);
+            return ClaudeTuiWarmFollowupSubmitOutcome::Terminal(Ok(()));
+        }
+    }
+    ClaudeTuiWarmFollowupSubmitOutcome::FallThroughRecreate
+}
+
+/// Attempt a warm follow-up against an existing live Claude TUI tmux session.
+/// Mirrors the pre-refactor live-session branch: recovery, busy wait, submit/read/classify; `Terminal` returns before fresh-launch side effects, `Recreate` carries fall-through resolution.
+#[cfg(unix)]
+pub(crate) fn try_claude_tui_warm_followup(
+    mut resolved_session_id: String,
+    mut transcript_path: std::path::PathBuf,
+    mut transcript_path_string: String,
+    mut resume: bool,
+    working_dir_path: &std::path::Path,
+    prompt: &str,
+    sender: Sender<StreamMessage>,
+    cancel_token: Option<std::sync::Arc<CancelToken>>,
+    tmux_session_name: &str,
+    report_channel_id: Option<u64>,
+) -> ClaudeTuiWarmFollowupOutcome {
+    debug_log("Existing Claude TUI tmux session found — sending follow-up");
+    if let Some(ref token) = cancel_token {
+        *token.tmux_session.lock().unwrap_or_else(|e| e.into_inner()) =
+            Some(tmux_session_name.to_string());
+    }
+    let hook_rx = crate::services::claude_tui::hook_server::subscribe_hook_events();
+    let (busy_waited, recreate_before_submit, prompt_draft_cleared_before_submit) =
+        match recover_claude_tui_stranded_prompt_draft(
+            ClaudeTuiRecreateState {
+                resolved_session_id,
+                transcript_path,
+                transcript_path_string,
+                resume,
+            },
+            working_dir_path,
+            &cancel_token,
+            tmux_session_name,
+            report_channel_id,
+        ) {
+            ClaudeTuiDraftRecoveryOutcome::Proceed {
+                state,
+                busy_waited,
+                recreate_before_submit,
+                prompt_draft_cleared_before_submit,
+            } => {
+                resolved_session_id = state.resolved_session_id;
+                transcript_path = state.transcript_path;
+                transcript_path_string = state.transcript_path_string;
+                resume = state.resume;
+                (
+                    busy_waited,
+                    recreate_before_submit,
+                    prompt_draft_cleared_before_submit,
+                )
+            }
+            ClaudeTuiDraftRecoveryOutcome::Terminal(r) => {
+                return ClaudeTuiWarmFollowupOutcome::Terminal(r);
+            }
+        };
+    let submit_plan = claude_tui_warm_followup_submit_plan(
+        recreate_before_submit,
+        prompt_draft_cleared_before_submit,
+    );
+    if submit_plan.submit_existing_session {
+        match run_claude_tui_warm_followup_submit_and_stream(
+            submit_plan,
+            busy_waited,
+            tmux_session_name,
+            &resolved_session_id,
+            &transcript_path,
+            &transcript_path_string,
+            prompt,
+            sender,
+            cancel_token,
+            report_channel_id,
+            hook_rx,
+        ) {
+            ClaudeTuiWarmFollowupSubmitOutcome::Terminal(r) => {
+                return ClaudeTuiWarmFollowupOutcome::Terminal(r);
+            }
+            ClaudeTuiWarmFollowupSubmitOutcome::FallThroughRecreate => {}
+        }
+    }
+
+    ClaudeTuiWarmFollowupOutcome::Recreate(ClaudeTuiRecreateState {
+        resolved_session_id,
+        transcript_path,
+        transcript_path_string,
+        resume,
+    })
+}

--- a/src/services/claude_tui/mod.rs
+++ b/src/services/claude_tui/mod.rs
@@ -3,6 +3,8 @@ pub mod hook_relay;
 pub mod hook_server;
 #[cfg(test)]
 mod hook_server_memento_tests;
+#[cfg(unix)]
+pub(crate) mod hosting;
 pub mod input;
 pub(crate) mod memento_feedback;
 pub mod session;


### PR DESCRIPTION
EPIC #3038 execute_streaming final slice (after S1 #3298, S2 #3362).

## What
- Moved the S1/S2-extracted warm-followup hosting surface (1,139 lines) out of `src/services/claude.rs` into `src/services/claude_tui/hosting/{followup_support,warm_followup}.rs` with re-exports (zero call-site churn).
- Token-identity proofs (sha256 of normalized bodies) in the commit body; normalization = mechanical visibility/cfg only.
- HARD constraint honored: the #3262 turn-lock machinery (ClaudeTuiSessionTurnLock, lock table, acquisition in execute_streaming_local_tui_tmux) stays in claude.rs root — verified untouched.

## Verification
- fmt/clippy clean; claude suite + turn-lock tests green unmodified; audit ratchet (claude.rs down) + agent-maintenance docs clean on committed HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)