### PR TITLE
refactor(#3038): SharedData S4 — extract PlaceholderState cluster

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -118,7 +118,7 @@
     lifecycle extraction surface from #1435; split further before adding new
     lifecycle behavior; #3016 phase-5b2 dropped the `mailbox_finalize_owed`
     construction from the watcher-spawn handle).
-  - `src/services/discord/tmux.rs` (2049 lines after #2558 dead-code sweep;
+  - `src/services/discord/tmux.rs` (2048 lines after #2558 dead-code sweep;
     +38 for suppressed-label noise, user report 2026-06-12: provider-aware
     status/footer stripping in the placeholder suppression decisions;
     +4 from #3167: the monitor-auto-turn start passes `ActiveTurnKind::Background`
@@ -133,7 +133,8 @@
     monotonic-CAS offset INLINE (synchronously) on a `Delivered` outcome; the
     finalizer actor's `CommitDelivery`/`ReleaseDelivery` handlers are DORMANT
     (retained for a later phase, not the live watcher path after the R2 revert);
-    still giant-file territory).
+    -1 from #3038 S4 after routing the placeholder/status-panel cluster
+    through `shared.ui`; still giant-file territory).
   - `src/services/discord/tmux_watcher.rs` (8122 production lines after
     #3038 tmux_watcher S1 moved top-level decision clusters A/B/C/E/F/I/J/K
     into `tmux_watcher/` child modules: `liveness.rs` (301),
@@ -716,7 +717,7 @@
     #3360 moving orphan pending-token auto-heal out to
     `health/relay_auto_heal.rs`; #3361 moved positive stall-watchdog liveness
     guard state/logging to `health/stall_liveness.rs`).
-  - `src/services/discord/router/message_handler/intake_turn.rs` (3771 lines;
+  - `src/services/discord/router/message_handler/intake_turn.rs` (3769 lines;
     Discord message intake turn orchestration split from the router message
     handler; bugfix only outside a further extraction plan; +9 from #3082
     queued-only answer-flush gate (`is_queued_notice` on the two
@@ -726,7 +727,8 @@
     `remove_reaction_raw` at the `started==true` promotion point, removing the
     stranded `📬`/`➕` so a processed message no longer shows `📬`+`✅`); +1 from
     #3038 S1 mechanical `.queued_placeholders` -> `.queued.queued_placeholders`
-    re-wire after lifting cluster C into `QueuedPlaceholderState`).
+    re-wire after lifting cluster C into `QueuedPlaceholderState`; -2 from #3038
+    S4 mechanical placeholder/status-panel `.ui` rewiring).
   - `src/services/discord/router/message_handler/headless_turn.rs` (1316 lines;
     headless Discord turn launch/terminal-response path split from the router
     message handler; bugfix only outside a further extraction plan).

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -81,7 +81,10 @@
 # Locks in the shrink win (ratchet down only).
 # #3089 S0: +5 for default-off single_message_panel wrapper/log trigger in
 # mod.rs; parser/cache body lives in `single_message_panel.rs`.
-"src/services/discord/mod.rs" = 4970
+# #3038 S4: lowered 4970 -> 4967 (-3) as the cluster-F field block (5
+# live-placeholder/status-panel fields) moved into `shared_state::PlaceholderState`.
+# Locks in the shrink win (ratchet down only).
+"src/services/discord/mod.rs" = 4967
 # #3305: the local-only pass-through lifecycle-skip (kind hoist + note-only return
 # branch + idle-loop skip) is offset by comment dedup in the same root, lowering the
 # frozen baseline 5438 -> 5429 (-9). Locks in the shrink win (#3028 ratchet).

--- a/src/services/discord/adk_session.rs
+++ b/src/services/discord/adk_session.rs
@@ -916,8 +916,8 @@ pub(super) async fn backfill_completed_panel_usage_and_maybe_inject_compact(
     // write ONLY; it must NOT gate the compact trigger below (#3262 issue #4: a
     // post-compact drop to ~0 usage is exactly the re-arm signal the trigger
     // needs, so a zero-usage turn-completion must still reach the trigger).
-    if occupied != 0 && context_window != 0 && shared.status_panel_v2_enabled {
-        shared.placeholder_live_events.set_context_panel_usage(
+    if occupied != 0 && context_window != 0 && shared.ui.status_panel_v2_enabled {
+        shared.ui.placeholder_live_events.set_context_panel_usage(
             channel_id,
             state.last_session_id.as_deref(),
             usage.input_tokens,

--- a/src/services/discord/gateway.rs
+++ b/src/services/discord/gateway.rs
@@ -387,6 +387,7 @@ pub(super) async fn drain_merged_queued_placeholders(
             .remove(&(channel_id, *message_id))
         {
             shared
+                .ui
                 .placeholder_controller
                 .detach_by_message(channel_id, placeholder_msg_id);
             to_delete.push(placeholder_msg_id);

--- a/src/services/discord/health/recovery.rs
+++ b/src/services/discord/health/recovery.rs
@@ -2285,7 +2285,7 @@ async fn maybe_recover_completed_stale_leak(
     let Some(delivery_text) = render_leak_recovery_delivery(
         &state.full_response,
         start,
-        shared.status_panel_v2_enabled,
+        shared.ui.status_panel_v2_enabled,
         provider,
     ) else {
         return false;

--- a/src/services/discord/idle_recap.rs
+++ b/src/services/discord/idle_recap.rs
@@ -267,6 +267,7 @@ pub(crate) async fn attach_live_context_usage(
         return;
     };
     let Some(live) = shared
+        .ui
         .placeholder_live_events
         .context_panel_snapshot(ChannelId::new(channel_id))
     else {

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -116,6 +116,9 @@ pub(crate) use restart_mode::InflightRestartMode;
 pub(crate) use router::HeadlessTurnStartError;
 #[cfg(unix)]
 pub(crate) use session_relay_sink::run_session_bound_discord_relay_supervisor;
+// #3038 S4: re-export the live-placeholder cluster type so `SharedData`
+// declarations/constructors keep the S1/S2/S3 unqualified surface.
+pub(in crate::services::discord) use shared_state::PlaceholderState;
 pub(in crate::services::discord) use shared_state::QueuedPlaceholderState;
 // #3038 S2: the cluster-D members were `pub(super)` on `SharedData` (visible up
 // to `crate::services`), so the group type is re-exported with that same scope.
@@ -2226,24 +2229,10 @@ pub(crate) struct SharedData {
     /// watcher and an incoming watcher share the same emission-slot atomic
     /// and confirmed-offset watermark. See `TmuxRelayCoord`.
     pub(super) tmux_relay_coords: dashmap::DashMap<ChannelId, Arc<TmuxRelayCoord>>,
-    /// Last known placeholder cleanup outcome keyed by provider/channel/message.
-    /// This local tombstone lets watcher finalization reason about cleanup
-    /// even after the inflight file has already been cleared.
-    pub(in crate::services::discord) placeholder_cleanup:
-        Arc<placeholder_cleanup::PlaceholderCleanupRegistry>,
-    /// Lifecycle FSM + edit coalescer for live-turn placeholder cards (#1255).
-    /// Both the `tmux_handed_off` async-dispatch path and the new Monitor /
-    /// `Bash run_in_background` live-turn path go through this controller so
-    /// that concurrent edits to the same placeholder message_id serialize
-    /// instead of racing.
-    pub(in crate::services::discord) placeholder_controller:
-        Arc<placeholder_controller::PlaceholderController>,
-    /// Per-channel recent tool/system events rendered in Active placeholder
-    /// cards when `placeholder.live_events_enabled` is enabled.
-    pub(in crate::services::discord) placeholder_live_events:
-        Arc<placeholder_live_events::PlaceholderLiveEvents>,
-    pub(in crate::services::discord) placeholder_live_events_enabled: bool,
-    pub(in crate::services::discord) status_panel_v2_enabled: bool,
+    /// #3038 cluster F — live-placeholder/status-panel state: cleanup tombstones,
+    /// edit controller, live-event feed, and live-event/status-panel gates.
+    /// Field docs live on `shared_state::PlaceholderState`; call sites use `shared.ui.*`.
+    pub(in crate::services::discord) ui: PlaceholderState,
     /// #3038 cluster C — queued-placeholder handoff state (the
     /// `queued_placeholders` mapping, the `queue_exit_placeholder_clears`
     /// sidecar mirror, and the per-channel `queued_placeholders_persist_locks`).
@@ -2586,11 +2575,19 @@ pub(super) fn make_shared_data_for_tests_with_storage(
         skills_cache: tokio::sync::RwLock::new(Vec::new()),
         tmux_watchers: TmuxWatcherRegistry::new(),
         tmux_relay_coords: dashmap::DashMap::new(),
-        placeholder_cleanup: Arc::new(placeholder_cleanup::PlaceholderCleanupRegistry::default()),
-        placeholder_controller: Arc::new(placeholder_controller::PlaceholderController::default()),
-        placeholder_live_events: Arc::new(placeholder_live_events::PlaceholderLiveEvents::default()),
-        placeholder_live_events_enabled: false,
-        status_panel_v2_enabled: false,
+        ui: PlaceholderState {
+            placeholder_cleanup: Arc::new(
+                placeholder_cleanup::PlaceholderCleanupRegistry::default(),
+            ),
+            placeholder_controller: Arc::new(
+                placeholder_controller::PlaceholderController::default(),
+            ),
+            placeholder_live_events: Arc::new(
+                placeholder_live_events::PlaceholderLiveEvents::default(),
+            ),
+            placeholder_live_events_enabled: false,
+            status_panel_v2_enabled: false,
+        },
         queued: QueuedPlaceholderState {
             queued_placeholders: dashmap::DashMap::new(),
             queue_exit_placeholder_clears: dashmap::DashMap::new(),
@@ -2848,11 +2845,10 @@ fn cleanup_retry_inflight_blocks_idle_kickoff(
         return false;
     }
 
-    shared.placeholder_cleanup.terminal_cleanup_retry_pending(
-        provider,
-        channel_id,
-        MessageId::new(state.current_msg_id),
-    )
+    shared
+        .ui
+        .placeholder_cleanup
+        .terminal_cleanup_retry_pending(provider, channel_id, MessageId::new(state.current_msg_id))
 }
 
 fn idle_queue_snapshot_has_kickable_backlog(
@@ -3230,6 +3226,7 @@ async fn queue_exit_drain_queued_placeholders(
                 .remove(&(channel_id, *message_id))
             {
                 shared
+                    .ui
                     .placeholder_controller
                     .detach_by_message(channel_id, placeholder_msg_id);
                 visible_cards_to_clear.push(QueueExitVisibleCard {

--- a/src/services/discord/placeholder_sweeper.rs
+++ b/src/services/discord/placeholder_sweeper.rs
@@ -513,7 +513,7 @@ async fn run_placeholder_sweep_pass(
                                         channel_id: serenity::ChannelId::new(state.channel_id),
                                         message_id: serenity::MessageId::new(msg_id),
                                     };
-                                    shared.placeholder_controller.detach(&key);
+                                    shared.ui.placeholder_controller.detach(&key);
                                 }
                             }
                         }
@@ -600,7 +600,7 @@ async fn run_placeholder_sweep_pass(
                                 channel_id: serenity::ChannelId::new(state.channel_id),
                                 message_id: serenity::MessageId::new(msg_id),
                             };
-                            shared.placeholder_controller.detach(&key);
+                            shared.ui.placeholder_controller.detach(&key);
                         }
                     }
                 }
@@ -816,7 +816,7 @@ async fn sweep_orphan_status_panel(
     // executing cutover needs the async `PanelSink` PR-2 deferred). The actor is
     // NOT spawned when v2 is off, so this v2 guard short-circuits the awaited
     // shadow read (whose ack would never be answered), mirroring `recovery_engine`.
-    if shared.status_panel_v2_enabled {
+    if shared.ui.status_panel_v2_enabled {
         let controller_target = shared
             .status_panel_controller
             .sweeper_reclaim_parity_id(

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -421,7 +421,7 @@ async fn complete_recovery_visible_turn(
         }
     }
 
-    if !shared.status_panel_v2_enabled {
+    if !shared.ui.status_panel_v2_enabled {
         return RecoveryCompletionOutcome::Emitted;
     }
     // #2427 D wire: explicit completion signal — most recovery paths
@@ -438,7 +438,7 @@ async fn complete_recovery_visible_turn(
     let started_at_unix = super::inflight::parse_started_at_unix(&state.started_at)
         .unwrap_or_else(|| chrono::Utc::now().timestamp());
     let Some(status_msg_id) = recovery_status_panel::completion_target(
-        shared.status_panel_v2_enabled,
+        shared.ui.status_panel_v2_enabled,
         state,
         provider,
         channel_id,

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -945,8 +945,8 @@ async fn reuse_merged_queued_placeholder(
     data.shared
         .insert_queued_placeholder_locked(channel_id, user_msg_id, placeholder_msg_id);
 
-    // Refresh the card body with the merged request text. `ensure_queued` is
-    // idempotent: an unchanged render coalesces, a changed one edits.
+    // Refresh the card body with merged request text; unchanged renders
+    // coalesce, changed ones edit.
     let gateway = super::super::gateway::DiscordGateway::new(
         ctx.http.clone(),
         data.shared.clone(),
@@ -970,17 +970,15 @@ async fn reuse_merged_queued_placeholder(
     };
     let outcome = data
         .shared
+        .ui
         .placeholder_controller
         .ensure_queued(&gateway, key, queued_input)
         .await;
 
-    // codex round-1 P2 (edit-failure rollback): only commit the re-key when the
-    // card actually renders (`Edited`/`Coalesced`). On `EditFailed`/`Rejected`
-    // the card on Discord may be gone or invalid, so restore the mapping to the
-    // prior source id and report failure — the caller then falls back to the
-    // fresh-card POST path, mirroring how `render_visible_queued_ack` treats a
-    // failed `ensure_queued`. The persistence lock is held across the rollback
-    // so no concurrent drain observes the half-applied re-key.
+    // codex round-1 P2 (edit-failure rollback): only commit the re-key after
+    // `Edited`/`Coalesced`. On `EditFailed`/`Rejected`, restore the prior source
+    // id and let the caller fall back to fresh POST, with the persistence lock
+    // held so no drain observes the half-applied re-key.
     if !matches!(
         outcome,
         super::super::placeholder_controller::PlaceholderControllerOutcome::Edited
@@ -1150,6 +1148,7 @@ async fn reuse_any_queued_placeholder_for_channel(
     };
     let outcome = data
         .shared
+        .ui
         .placeholder_controller
         .ensure_queued(&gateway, key, queued_input)
         .await;
@@ -1350,6 +1349,7 @@ async fn render_visible_queued_ack(
     };
     let outcome = data
         .shared
+        .ui
         .placeholder_controller
         .ensure_queued(&gateway, key, queued_input)
         .await;

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -2197,11 +2197,9 @@ pub(in crate::services::discord) async fn handle_text_message(
             // the mapping cannot change underneath this PATCH once we
             // hold the lock.
             //
-            // Invariant (round-10): the dispatch-state snapshot, the
-            // mapping insert, the ownership recheck, and the
-            // `ensure_queued` PATCH all share ONE held lock guard. Any
-            // alternative ordering would reopen either the round-4 hazard
-            // or the round-9-residual hazard codex flagged in round-10.
+            // Invariant (round-10): the dispatch-state snapshot, mapping insert,
+            // ownership recheck, and `ensure_queued` PATCH share ONE held lock
+            // guard; any alternate order reopens the round-4 or round-9 hazard.
             let persist_guard = persist_guard_for_render
                 .expect("round-10: persist guard must be held by the matching insert branch");
             if !shared.queued_placeholder_still_owned(channel_id, user_msg_id, placeholder_msg_id) {
@@ -2236,6 +2234,7 @@ pub(in crate::services::discord) async fn handle_text_message(
                         progress_line: None,
                     };
                 let outcome = shared
+                    .ui
                     .placeholder_controller
                     .ensure_queued(&gateway, key, queued_input)
                     .await;
@@ -2251,14 +2250,10 @@ pub(in crate::services::discord) async fn handle_text_message(
                         );
                     }
                     _ => {
-                        // Edit failed — roll back the mapping and delete the
-                        // raw `...` so the dispatch path never matches a
-                        // Discord message that no longer exists. The lock
-                        // guarantees the mapping cannot have changed since
-                        // our recheck above, so a single decision (still
-                        // owned → roll back) is sound. Use the `_locked`
-                        // variant to avoid re-acquiring the lock we
-                        // already hold (round-5 P2).
+                        // Edit failed — roll back the mapping and delete the raw
+                        // `...` so dispatch never matches a missing Discord
+                        // message. The lock guarantees the mapping is unchanged
+                        // since the recheck; use `_locked` to avoid reacquiring it.
                         let still_owned_under_lock = shared.queued_placeholder_still_owned(
                             channel_id,
                             user_msg_id,
@@ -2362,6 +2357,7 @@ pub(in crate::services::discord) async fn handle_text_message(
             }),
         );
         let _ = shared
+            .ui
             .placeholder_controller
             .ensure_active(&gateway, key, active_input)
             .await;
@@ -2372,6 +2368,7 @@ pub(in crate::services::discord) async fn handle_text_message(
         // controller row. Drop the entry now — streaming owns the card past
         // this point and the controller is no longer the source of truth.
         shared
+            .ui
             .placeholder_controller
             .detach_by_message(channel_id, existing);
         let ts = chrono::Local::now().format("%H:%M:%S");
@@ -3248,6 +3245,7 @@ pub(in crate::services::discord) async fn handle_text_message(
                         progress_line: None,
                     };
                 let outcome = shared
+                    .ui
                     .placeholder_controller
                     .ensure_queued(&gateway, key, queued_input)
                     .await;

--- a/src/services/discord/runtime_bootstrap/shared_data.rs
+++ b/src/services/discord/runtime_bootstrap/shared_data.rs
@@ -42,17 +42,22 @@ pub(super) fn run_bot_build_shared_data(
         skills_cache: tokio::sync::RwLock::new(initial_skills),
         tmux_watchers: crate::services::discord::TmuxWatcherRegistry::new(),
         tmux_relay_coords: dashmap::DashMap::new(),
-        placeholder_cleanup: Arc::new(
-            crate::services::discord::placeholder_cleanup::PlaceholderCleanupRegistry::default(),
-        ),
-        placeholder_controller: Arc::new(
-            crate::services::discord::placeholder_controller::PlaceholderController::default(),
-        ),
-        placeholder_live_events: Arc::new(
-            crate::services::discord::placeholder_live_events::PlaceholderLiveEvents::default(),
-        ),
-        placeholder_live_events_enabled,
-        status_panel_v2_enabled,
+        // #3038 S4: wrapped verbatim at the first-member position
+        // (evaluation-order preserved).
+        ui: PlaceholderState {
+            placeholder_cleanup: Arc::new(
+                crate::services::discord::placeholder_cleanup::PlaceholderCleanupRegistry::default(
+                ),
+            ),
+            placeholder_controller: Arc::new(
+                crate::services::discord::placeholder_controller::PlaceholderController::default(),
+            ),
+            placeholder_live_events: Arc::new(
+                crate::services::discord::placeholder_live_events::PlaceholderLiveEvents::default(),
+            ),
+            placeholder_live_events_enabled,
+            status_panel_v2_enabled,
+        },
         // #3038 S1: wrapped verbatim at the first-member position (evaluation-order preserved).
         queued: QueuedPlaceholderState {
             queued_placeholders: dashmap::DashMap::new(),

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -748,7 +748,7 @@ impl SessionBoundDiscordRelaySink {
             ))
         })?;
 
-        let formatted = if shared.status_panel_v2_enabled {
+        let formatted = if shared.ui.status_panel_v2_enabled {
             formatting::format_for_discord_with_status_panel(&delivery.response_text, &provider)
         } else {
             formatting::format_for_discord_with_provider(&delivery.response_text, &provider)

--- a/src/services/discord/shared_state.rs
+++ b/src/services/discord/shared_state.rs
@@ -1,4 +1,4 @@
-//! #3038 S1/S2/S3 — extracted field clusters of [`SharedData`].
+//! #3038 S1/S2/S3/S4 — extracted field clusters of [`SharedData`].
 //!
 //! This module hosts named sub-structs that group cohesive `SharedData` fields
 //! together with the inherent `impl SharedData` methods that exclusively own
@@ -22,7 +22,40 @@ use poise::serenity_prelude::{ChannelId, MessageId};
 
 use crate::services::provider::ProviderKind;
 
-use super::{ModelPickerPendingState, QueueExitVisibleCard, SharedData};
+use super::{
+    ModelPickerPendingState, QueueExitVisibleCard, SharedData, placeholder_cleanup,
+    placeholder_controller, placeholder_live_events,
+};
+
+/// #3038 cluster F — live-placeholder/status-panel state.
+///
+/// Groups the five contiguous fields that together own the user-visible live
+/// placeholder card surface: cleanup tombstones, serialized placeholder edits,
+/// the recent live-event/status-panel feed, and the two feature gates that
+/// decide whether those events render into placeholder cards or separate
+/// status panels. Field declarations, docs, and types moved verbatim from
+/// `discord/mod.rs`; the members keep their original
+/// `pub(in crate::services::discord)` visibility.
+pub(in crate::services::discord) struct PlaceholderState {
+    /// Last known placeholder cleanup outcome keyed by provider/channel/message.
+    /// This local tombstone lets watcher finalization reason about cleanup
+    /// even after the inflight file has already been cleared.
+    pub(in crate::services::discord) placeholder_cleanup:
+        Arc<placeholder_cleanup::PlaceholderCleanupRegistry>,
+    /// Lifecycle FSM + edit coalescer for live-turn placeholder cards (#1255).
+    /// Both the `tmux_handed_off` async-dispatch path and the new Monitor /
+    /// `Bash run_in_background` live-turn path go through this controller so
+    /// that concurrent edits to the same placeholder message_id serialize
+    /// instead of racing.
+    pub(in crate::services::discord) placeholder_controller:
+        Arc<placeholder_controller::PlaceholderController>,
+    /// Per-channel recent tool/system events rendered in Active placeholder
+    /// cards when `placeholder.live_events_enabled` is enabled.
+    pub(in crate::services::discord) placeholder_live_events:
+        Arc<placeholder_live_events::PlaceholderLiveEvents>,
+    pub(in crate::services::discord) placeholder_live_events_enabled: bool,
+    pub(in crate::services::discord) status_panel_v2_enabled: bool,
+}
 
 /// #3038 cluster C — the queued-placeholder handoff state.
 ///

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -227,7 +227,7 @@ pub(in crate::services::discord) fn completion_footer_edit_for_registered_target
     } else {
         indicator
     };
-    let rendered = shared.placeholder_live_events.render_completion_footer(
+    let rendered = shared.ui.placeholder_live_events.render_completion_footer(
         channel_id,
         &target.provider,
         render_indicator,
@@ -577,7 +577,7 @@ mod tests {
 
     fn push_unfinished_subagent(channel_id: ChannelId) -> std::sync::Arc<super::super::SharedData> {
         let shared = super::super::make_shared_data_for_tests();
-        shared.placeholder_live_events.push_status_event(
+        shared.ui.placeholder_live_events.push_status_event(
             channel_id,
             StatusEvent::SubagentStart {
                 subagent_type: Some("reviewer".to_string()),

--- a/src/services/discord/standby_relay.rs
+++ b/src/services/discord/standby_relay.rs
@@ -612,7 +612,7 @@ async fn deliver_response(
     provider: &ProviderKind,
     response_text: &str,
 ) -> bool {
-    let formatted = if shared.status_panel_v2_enabled {
+    let formatted = if shared.ui.status_panel_v2_enabled {
         formatting::format_for_discord_with_status_panel(response_text, provider)
     } else {
         formatting::format_for_discord_with_provider(response_text, provider)

--- a/src/services/discord/status_panel_orphan_store.rs
+++ b/src/services/discord/status_panel_orphan_store.rs
@@ -375,7 +375,7 @@ pub(in crate::services::discord) async fn drain(
         // when v2 is off. The controller actor task is NOT spawned when v2 is off,
         // so we MUST skip the awaited shadow read (its ack oneshot would never be
         // answered) — this guard is the v2-off short-circuit.
-        if shared.status_panel_v2_enabled {
+        if shared.ui.status_panel_v2_enabled {
             let controller_owns = shared
                 .status_panel_controller
                 .orphan_gate_owns_panel(

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -557,12 +557,10 @@ fn orphan_suppressed_placeholder_action(
 /// Unified entry point for every placeholder-suppression decision.
 ///
 /// Three production sites produced identical edit/delete/log scaffolding before
-/// #1055 (bridge-guard duplicate relay at `tmux_output_watcher_with_restore`,
-/// task-notification terminal suppress at the same function, and
-/// `reconcile_orphan_suppressed_placeholder_for_restored_watcher`). The
-/// `decide_placeholder_suppression` + `apply_placeholder_suppression` pair
-/// replaces those copies so a future placeholder-suppression regression can be
-/// fixed in exactly one location. See also `Shared Agent Rules` — DRY 강제.
+/// #1055 (`tmux_output_watcher_with_restore` bridge-guard duplicate relay,
+/// task-notification terminal suppress, and restored-watcher orphan reconcile).
+/// `decide_placeholder_suppression` + `apply_placeholder_suppression` replaces
+/// those copies so future regressions fix in one place. See `Shared Agent Rules`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PlaceholderSuppressOrigin {
     OrphanRestartHandoff,
@@ -801,7 +799,7 @@ fn record_placeholder_cleanup(
             detail
         );
     }
-    shared.placeholder_cleanup.record(PlaceholderCleanupRecord {
+    let record = PlaceholderCleanupRecord {
         provider: provider.clone(),
         channel_id,
         message_id,
@@ -809,7 +807,8 @@ fn record_placeholder_cleanup(
         operation,
         outcome,
         source,
-    });
+    };
+    shared.ui.placeholder_cleanup.record(record);
 }
 
 async fn delete_terminal_placeholder(

--- a/src/services/discord/tmux_output_stream.rs
+++ b/src/services/discord/tmux_output_stream.rs
@@ -82,14 +82,18 @@ pub(in crate::services::discord) fn flush_placeholder_live_events(
     let events = tool_state.take_placeholder_events();
     let status_events = tool_state.take_status_events();
     let mut dirty = false;
-    if (shared.placeholder_live_events_enabled || shared.status_panel_v2_enabled)
+    if (shared.ui.placeholder_live_events_enabled || shared.ui.status_panel_v2_enabled)
         && !events.is_empty()
     {
-        shared.placeholder_live_events.push_many(channel_id, events);
+        shared
+            .ui
+            .placeholder_live_events
+            .push_many(channel_id, events);
         dirty = true;
     }
-    if shared.status_panel_v2_enabled && !status_events.is_empty() {
+    if shared.ui.status_panel_v2_enabled && !status_events.is_empty() {
         shared
+            .ui
             .placeholder_live_events
             .push_status_events(channel_id, status_events);
         dirty = true;
@@ -114,7 +118,7 @@ pub(in crate::services::discord) fn build_watcher_placeholder_status_block(
     status_panel_msg_id: Option<serenity::MessageId>,
 ) -> String {
     if watcher_placeholder_uses_status_panel_only(
-        shared.status_panel_v2_enabled,
+        shared.ui.status_panel_v2_enabled,
         status_panel_msg_id,
     ) {
         return crate::services::discord::formatting::build_processing_status_block(indicator);
@@ -126,10 +130,10 @@ pub(in crate::services::discord) fn build_watcher_placeholder_status_block(
         full_response,
     );
     if watcher_placeholder_inlines_live_events(
-        shared.placeholder_live_events_enabled,
-        shared.status_panel_v2_enabled,
+        shared.ui.placeholder_live_events_enabled,
+        shared.ui.status_panel_v2_enabled,
         status_panel_msg_id,
-    ) && let Some(block) = shared.placeholder_live_events.render_block(channel_id)
+    ) && let Some(block) = shared.ui.placeholder_live_events.render_block(channel_id)
     {
         return format!("{status_block}\n{block}");
     }

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1314,7 +1314,7 @@ async fn cleanup_orphan_external_input_status_panel(
     tmux_session_name: &str,
     turn_is_external_input: bool,
 ) -> bool {
-    if !watcher_separate_status_panel_enabled(shared.status_panel_v2_enabled) {
+    if !watcher_separate_status_panel_enabled(shared.ui.status_panel_v2_enabled) {
         *status_panel_msg_id = None;
         return true;
     }
@@ -1424,7 +1424,7 @@ async fn complete_watcher_status_panel_v2(
     // for the turn the watcher actually finished. Recovery-driven
     // TurnCompleted still emits the guarded signal (see recovery_engine.rs)
     // because its state snapshot is pinned at recovery entry.
-    if !watcher_should_complete_separate_status_panel(shared.status_panel_v2_enabled) {
+    if !watcher_should_complete_separate_status_panel(shared.ui.status_panel_v2_enabled) {
         return true;
     }
     // EPIC #3078: completion parity is DEFERRED to the controller execute-cutover
@@ -1472,7 +1472,7 @@ async fn refresh_watcher_session_panel_from_lifecycle(
     user_msg_id: u64,
     tmux_session_name: &str,
 ) {
-    if !shared.status_panel_v2_enabled {
+    if !shared.ui.status_panel_v2_enabled {
         return;
     }
     let Some(pg_pool) = shared.pg_pool.as_ref() else {
@@ -1490,6 +1490,7 @@ async fn refresh_watcher_session_panel_from_lifecycle(
     {
         Ok(Some(event)) => {
             shared
+                .ui
                 .placeholder_live_events
                 .set_session_panel_lifecycle_event(
                     channel_id,
@@ -1500,6 +1501,7 @@ async fn refresh_watcher_session_panel_from_lifecycle(
         }
         Ok(None) => {
             shared
+                .ui
                 .placeholder_live_events
                 .clear_session_panel(channel_id);
         }
@@ -1984,7 +1986,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                     &http,
                     &shared,
                     channel_id,
-                    shared.status_panel_v2_enabled,
+                    shared.ui.status_panel_v2_enabled,
                     &mut completion_footer_idle,
                 )
                 .await;
@@ -2303,7 +2305,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         let mut placeholder_from_restored_inflight = placeholder_msg_id.is_some();
         let mut status_panel_msg_id: Option<serenity::MessageId> = stream_seed.status_panel_msg_id;
         let single_message_panel_footer_mode =
-            watcher_single_message_panel_footer_enabled(shared.status_panel_v2_enabled);
+            watcher_single_message_panel_footer_enabled(shared.ui.status_panel_v2_enabled);
         if single_message_panel_footer_mode {
             status_panel_msg_id = None;
         }
@@ -2349,9 +2351,9 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             && status_panel_msg_id.is_none()
             && !restored_assistant_text_seen;
         if watcher_fresh_turn_frame
-            && (shared.placeholder_live_events_enabled || shared.status_panel_v2_enabled)
+            && (shared.ui.placeholder_live_events_enabled || shared.ui.status_panel_v2_enabled)
         {
-            shared.placeholder_live_events.clear_channel(channel_id);
+            shared.ui.placeholder_live_events.clear_channel(channel_id);
         }
         let mut last_status_panel_text = String::new();
         let status_panel_started_at = chrono::Utc::now().timestamp();
@@ -3062,7 +3064,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         continue;
                     }
 
-                    if shared.status_panel_v2_enabled
+                    if shared.ui.status_panel_v2_enabled
                         && (single_message_panel_footer_mode || status_panel_msg_id.is_some())
                     {
                         // #3055: re-derive this turn's session lifecycle panel
@@ -3079,10 +3081,10 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         )
                         .await;
                     }
-                    if watcher_separate_status_panel_enabled(shared.status_panel_v2_enabled)
+                    if watcher_separate_status_panel_enabled(shared.ui.status_panel_v2_enabled)
                         && let Some(status_msg_id) = status_panel_msg_id
                     {
-                        let panel_text = shared.placeholder_live_events.render_status_panel(
+                        let panel_text = shared.ui.placeholder_live_events.render_status_panel(
                             channel_id,
                             &watcher_provider,
                             status_panel_started_at,
@@ -3299,7 +3301,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                             tool_state.current_tool_line.as_deref(),
                             task_notification_kind,
                         );
-                    if watcher_separate_status_panel_enabled(shared.status_panel_v2_enabled)
+                    if watcher_separate_status_panel_enabled(shared.ui.status_panel_v2_enabled)
                         && status_panel_msg_id.is_none()
                         && has_visible_streaming_work
                     {
@@ -3344,7 +3346,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                             status_panel_msg_id = Some(persisted);
                         } else if watcher_should_create_separate_status_panel(
                             single_message_panel_footer_mode,
-                            shared.status_panel_v2_enabled,
+                            shared.ui.status_panel_v2_enabled,
                             status_panel_msg_id.is_some(),
                             panel_eligible_turn,
                         ) && !watcher_external_input_turn_abandoned(
@@ -3575,7 +3577,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         // is `false` here (the enclosing gate requires `status_panel_msg_id
                         // .is_none()`), so the controller re-derives the SAME decision from
                         // the raw inputs the legacy branch above read. Legacy still executes.
-                        crate::services::discord::watcher_panel_parity::assert_watcher_create_parity(&shared, channel_id, shared.status_panel_v2_enabled, false, panel_eligible_turn, persisted_panel_msg_id);
+                        crate::services::discord::watcher_panel_parity::assert_watcher_create_parity(&shared, channel_id, shared.ui.status_panel_v2_enabled, false, panel_eligible_turn, persisted_panel_msg_id);
                     }
 
                     loop {
@@ -3697,7 +3699,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                         continue;
                     }
                     let display_text = build_watcher_streaming_edit_text(
-                        shared.status_panel_v2_enabled,
+                        shared.ui.status_panel_v2_enabled,
                         current_portion,
                         &status_block,
                         &watcher_provider,
@@ -6045,7 +6047,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             );
             false
         } else if watcher_direct_fallback_after_session_bound_ack {
-            let formatted = if shared.status_panel_v2_enabled {
+            let formatted = if shared.ui.status_panel_v2_enabled {
                 crate::services::discord::formatting::format_for_discord_with_status_panel(
                     direct_terminal_response,
                     &watcher_provider,
@@ -7782,7 +7784,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         let recent_turn_stop =
             recent_turn_stop_for_watcher_range(channel_id, &tmux_session_name, data_start_offset);
         let placeholder_cleanup_committed = placeholder_msg_id.is_some_and(|msg_id| {
-            shared.placeholder_cleanup.terminal_cleanup_committed(
+            shared.ui.placeholder_cleanup.terminal_cleanup_committed(
                 &provider_kind,
                 channel_id,
                 msg_id,

--- a/src/services/discord/tmux_watcher/panel_decisions.rs
+++ b/src/services/discord/tmux_watcher/panel_decisions.rs
@@ -181,7 +181,7 @@ pub(super) fn enqueue_watcher_status_panel_orphan(
     panel_msg_id: serenity::MessageId,
 ) {
     crate::services::discord::status_panel_orphan_store::enqueue_separate_status_panel_orphan(
-        shared.status_panel_v2_enabled,
+        shared.ui.status_panel_v2_enabled,
         provider,
         &shared.token_hash,
         channel_id.get(),

--- a/src/services/discord/tmux_watcher/single_message_footer.rs
+++ b/src/services/discord/tmux_watcher/single_message_footer.rs
@@ -91,8 +91,8 @@ pub(super) fn build_watcher_single_message_panel_status_block(
     full_response: &str,
     status_panel_msg_id: Option<serenity::MessageId>,
 ) -> String {
-    if watcher_single_message_panel_footer_enabled(shared.status_panel_v2_enabled) {
-        let panel_text = shared.placeholder_live_events.render_status_panel(
+    if watcher_single_message_panel_footer_enabled(shared.ui.status_panel_v2_enabled) {
+        let panel_text = shared.ui.placeholder_live_events.render_status_panel(
             channel_id,
             provider,
             started_at_unix,
@@ -218,11 +218,12 @@ pub(super) async fn complete_watcher_single_message_completion_footer(
     indicator: &str,
     background: bool,
 ) -> bool {
-    shared.placeholder_live_events.push_status_event(
+    shared.ui.placeholder_live_events.push_status_event(
         channel_id,
         crate::services::agent_protocol::StatusEvent::TurnCompleted { background },
     );
     let rendered = shared
+        .ui
         .placeholder_live_events
         .render_completion_footer(channel_id, provider, indicator);
     let Some(msg_id) = terminal_msg_id else {

--- a/src/services/discord/turn_bridge/headless_delivery.rs
+++ b/src/services/discord/turn_bridge/headless_delivery.rs
@@ -172,8 +172,8 @@ pub(super) async fn cleanup_headless_streaming_placeholder_after_delivery(
     match headless_streaming_placeholder_cleanup_action(
         last_edit_text,
         provider,
-        shared.status_panel_v2_enabled,
-        super::bridge_single_message_panel_footer_enabled(shared.status_panel_v2_enabled),
+        shared.ui.status_panel_v2_enabled,
+        super::bridge_single_message_panel_footer_enabled(shared.ui.status_panel_v2_enabled),
     ) {
         HeadlessPlaceholderCleanupAction::Delete => {
             if let Err(error) =

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -437,6 +437,7 @@ async fn refresh_session_panel_line_from_lifecycle(
     .await
     {
         Ok(Some(event)) => shared
+            .ui
             .placeholder_live_events
             .set_session_panel_lifecycle_event(
                 channel_id,
@@ -445,6 +446,7 @@ async fn refresh_session_panel_line_from_lifecycle(
                 &event.details_json,
             ),
         Ok(None) => shared
+            .ui
             .placeholder_live_events
             .clear_session_panel(channel_id),
         Err(error) => {
@@ -542,7 +544,7 @@ async fn refresh_task_panel_line_from_dispatch(
                 None
             }
         };
-    shared.placeholder_live_events.set_task_panel_info(
+    shared.ui.placeholder_live_events.set_task_panel_info(
         channel_id,
         crate::services::discord::placeholder_live_events::TaskPanelInfo {
             dispatch_id,
@@ -603,15 +605,20 @@ async fn ensure_active_placeholder_card<G: TurnGateway + ?Sized>(
     key: super::placeholder_controller::PlaceholderKey,
     input: super::placeholder_controller::PlaceholderActiveInput,
 ) -> super::placeholder_controller::PlaceholderControllerOutcome {
-    if shared.placeholder_live_events_enabled
-        && let Some(block) = shared.placeholder_live_events.render_block(key.channel_id)
+    if shared.ui.placeholder_live_events_enabled
+        && let Some(block) = shared
+            .ui
+            .placeholder_live_events
+            .render_block(key.channel_id)
     {
         return shared
+            .ui
             .placeholder_controller
             .ensure_active_with_live_events(gateway, key, input, block)
             .await;
     }
     shared
+        .ui
         .placeholder_controller
         .ensure_active(gateway, key, input)
         .await
@@ -622,10 +629,13 @@ fn record_placeholder_live_event(
     channel_id: ChannelId,
     event: Option<super::placeholder_live_events::RecentPlaceholderEvent>,
 ) {
-    if (shared.placeholder_live_events_enabled || shared.status_panel_v2_enabled)
+    if (shared.ui.placeholder_live_events_enabled || shared.ui.status_panel_v2_enabled)
         && let Some(event) = event
     {
-        shared.placeholder_live_events.push_event(channel_id, event);
+        shared
+            .ui
+            .placeholder_live_events
+            .push_event(channel_id, event);
     }
 }
 
@@ -634,8 +644,9 @@ fn record_status_panel_events(
     channel_id: ChannelId,
     events: Vec<StatusEvent>,
 ) -> bool {
-    if shared.status_panel_v2_enabled && !events.is_empty() {
+    if shared.ui.status_panel_v2_enabled && !events.is_empty() {
         shared
+            .ui
             .placeholder_live_events
             .push_status_events(channel_id, events);
         true
@@ -981,6 +992,7 @@ fn record_watcher_orphan_spinner_cleanup(
         );
     }
     shared
+        .ui
         .placeholder_cleanup
         .record(super::placeholder_cleanup::PlaceholderCleanupRecord {
             provider: provider.clone(),
@@ -2127,29 +2139,17 @@ pub(super) fn spawn_turn_bridge(
                 | super::inflight::RelayOwnerKind::SessionBoundRelay
                 | super::inflight::RelayOwnerKind::Unknown
         );
-        // #1255 live-turn long-running tool placeholder card.
-        //
-        // `last_assistant_text_line` captures the last non-empty single-line
-        // assistant prose emission so we can surface it as the placeholder
-        // card's `요약` slot (the "⏳ CI 통과 신호 대기" use case from the
-        // issue). It is reset on tool result / completion so a stale line
-        // never leaks into the next tool placeholder.
-        //
-        // `long_running_placeholder_active` is `Some(...)` while a Monitor /
-        // background-Bash call is mid-flight. It records the placeholder key
-        // we are driving so the matching ToolResult / Done event can call
-        // `controller.transition(Completed)`. The cancel / abort paths use
-        // the same handle.
+        // #1255 live-turn long-running tool placeholder card. Capture the last
+        // non-empty assistant line for the placeholder `요약` slot, then reset
+        // on tool result/completion so stale text never leaks. While Monitor /
+        // background-Bash work is mid-flight, `long_running_placeholder_active`
+        // stores the key so ToolResult/Done/cancel/abort hit the same handle.
         let mut last_assistant_text_line: Option<String> = None;
         // Pair the active key with the input snapshot, close-trigger kind, and
-        // an `ack_consumed` flag.
-        //
-        // Rollover uses the snapshot to retarget the controller onto the new
-        // `current_msg_id`; the close-trigger distinguishes Monitor-style
-        // ToolResult-closes from background-dispatch ack events; and
-        // `ack_consumed` (codex round-6 P2 on #1308) prevents subsequent
-        // unrelated ToolResults — for example a failing `Read`/`Grep` later
-        // in the same turn — from closing a still-running background card.
+        // `ack_consumed`: rollover retargets to the new `current_msg_id`, the
+        // trigger separates Monitor closes from background acks, and
+        // `ack_consumed` blocks unrelated later ToolResults from closing the
+        // still-running background card (codex round-6 P2 on #1308).
         let mut long_running_placeholder_active: Option<(
             super::placeholder_controller::PlaceholderKey,
             super::placeholder_controller::PlaceholderActiveInput,
@@ -2157,8 +2157,8 @@ pub(super) fn spawn_turn_bridge(
             bool, // ack_consumed
         )> = None;
         let mut active_background_child_session_ids: Vec<i64> = Vec::new();
-        if shared_owned.placeholder_live_events_enabled || shared_owned.status_panel_v2_enabled {
-            shared_owned.placeholder_live_events.clear_channel(channel_id);
+        if shared_owned.ui.placeholder_live_events_enabled || shared_owned.ui.status_panel_v2_enabled {
+            shared_owned.ui.placeholder_live_events.clear_channel(channel_id);
         }
         let mut transport_error = false;
         let mut api_friction_reports = Vec::new();
@@ -2358,20 +2358,20 @@ pub(super) fn spawn_turn_bridge(
             bridge.reuse_status_panel_message,
         );
         let single_message_panel_footer_mode =
-            bridge_single_message_panel_footer_enabled(shared_owned.status_panel_v2_enabled);
+            bridge_single_message_panel_footer_enabled(shared_owned.ui.status_panel_v2_enabled);
         if single_message_panel_footer_mode {
             status_panel_msg_id = None;
             inflight_state.status_message_id = None;
         }
         let mut last_status_panel_text = String::new();
-        let mut status_panel_dirty = shared_owned.status_panel_v2_enabled;
+        let mut status_panel_dirty = shared_owned.ui.status_panel_v2_enabled;
         let mut last_status_panel_edit = tokio::time::Instant::now() - status_interval;
         let status_panel_started_at = chrono::Utc::now().timestamp();
         let turn_start = std::time::Instant::now();
 
         maybe_create_bridge_separate_status_panel_response(
             single_message_panel_footer_mode,
-            shared_owned.status_panel_v2_enabled,
+            shared_owned.ui.status_panel_v2_enabled,
             gateway.as_ref(),
             channel_id,
             SPINNER[0],
@@ -2386,7 +2386,7 @@ pub(super) fn spawn_turn_bridge(
         )
         .await;
 
-        if shared_owned.status_panel_v2_enabled
+        if shared_owned.ui.status_panel_v2_enabled
             && let Some(dispatch_id) = dispatch_id.as_deref()
         {
             status_panel_dirty |= refresh_task_panel_line_from_dispatch(
@@ -2909,7 +2909,7 @@ pub(super) fn spawn_turn_bridge(
                                 }
                             }
                             if should_open_long_running_placeholder_controller(
-                                shared_owned.status_panel_v2_enabled,
+                                shared_owned.ui.status_panel_v2_enabled,
                             )
                                 && long_running_placeholder_active.is_none()
                                 && pending_long_running_open_after_state_save.is_none()
@@ -3046,20 +3046,14 @@ pub(super) fn spawn_turn_bridge(
                                     tool_use_id.as_deref(),
                                 ),
                             );
-                            // #1255: a long-running tool's ToolResult means the
-                            // background card can transition to its terminal
-                            // state.  We still keep the placeholder around for
-                            // the rest of the turn so the user can see the
-                            // status line; the controller's idempotent terminal
-                            // transition keeps duplicate edits free.
-                            // codex round-2 P1: only `Monitor`-style tools
-                            // deliver their real completion via `ToolResult`.
-                            // Background `Bash`/`Task`/`Agent` dispatches send
-                            // back a job/task id ack on `ToolResult` and the
-                            // actual work continues — terminating here would
-                            // close the card while the background job is
-                            // still running. Keep those open until `Done` /
-                            // cancel.
+                            // #1255: a long-running tool's ToolResult can move
+                            // the background card terminal while keeping the
+                            // placeholder visible for the rest of the turn; the
+                            // controller remains idempotent. codex round-2 P1:
+                            // only Monitor-style ToolResults are real
+                            // completions. Background Bash/Task/Agent results
+                            // are job/task acks, so keep those open until
+                            // Done/cancel.
                             if let Some((key, snapshot, close_trigger, ack_consumed)) =
                                 long_running_placeholder_active.take()
                             {
@@ -3105,12 +3099,12 @@ pub(super) fn spawn_turn_bridge(
                                     if pending_retarget_matches_key {
                                         let _ =
                                             pending_long_running_retarget_after_state_save.take();
-                                        shared_owned.placeholder_controller.detach(&key);
+                                        shared_owned.ui.placeholder_controller.detach(&key);
                                         inflight_state.long_running_placeholder_active = false;
                                         state_dirty = true;
                                     } else {
                                         let outcome = shared_owned
-                                            .placeholder_controller
+                                            .ui.placeholder_controller
                                             .transition(gateway.as_ref(), key.clone(), target)
                                             .await;
                                         // codex round-10 P2: only clear flag on
@@ -3331,11 +3325,11 @@ pub(super) fn spawn_turn_bridge(
                                         });
                                 if pending_retarget_matches_key {
                                     let _ = pending_long_running_retarget_after_state_save.take();
-                                    shared_owned.placeholder_controller.detach(&key);
+                                    shared_owned.ui.placeholder_controller.detach(&key);
                                     inflight_state.long_running_placeholder_active = false;
                                 } else {
                                     let outcome = shared_owned
-                                        .placeholder_controller
+                                        .ui.placeholder_controller
                                         .transition(gateway.as_ref(), key.clone(), target)
                                         .await;
                                     // codex round-10/11 P2/P3: on `EditFailed`,
@@ -3550,13 +3544,13 @@ pub(super) fn spawn_turn_bridge(
                             if let Some(ot) = output_tokens {
                                 accumulated_output_tokens = accumulated_output_tokens.max(ot);
                             }
-                            if shared_owned.status_panel_v2_enabled && has_context_token_data {
+                            if shared_owned.ui.status_panel_v2_enabled && has_context_token_data {
                                 let context_provider_session_id = new_raw_provider_session_id
                                     .as_deref()
                                     .or(new_session_id.as_deref())
                                     .or(inflight_state.session_id.as_deref());
                                 let context_dirty = shared_owned
-                                    .placeholder_live_events
+                                    .ui.placeholder_live_events
                                     .set_context_panel_usage(
                                         channel_id,
                                         context_provider_session_id,
@@ -4117,7 +4111,7 @@ pub(super) fn spawn_turn_bridge(
                 }
             }
 
-            if shared_owned.status_panel_v2_enabled
+            if shared_owned.ui.status_panel_v2_enabled
                 && last_session_panel_lifecycle_refresh.elapsed() >= status_interval
             {
                 last_session_panel_lifecycle_refresh = tokio::time::Instant::now();
@@ -4133,7 +4127,7 @@ pub(super) fn spawn_turn_bridge(
             let indicator = SPINNER[spin_idx % SPINNER.len()];
             spin_idx += 1;
 
-            if shared_owned.status_panel_v2_enabled
+            if shared_owned.ui.status_panel_v2_enabled
                 && bridge_status_panel_dirty_should_edit_separate_panel(
                     status_panel_dirty,
                     single_message_panel_footer_mode,
@@ -4141,7 +4135,7 @@ pub(super) fn spawn_turn_bridge(
                 && last_status_panel_edit.elapsed() >= status_interval
                 && let Some(status_msg_id) = status_panel_msg_id
             {
-                let panel_text = shared_owned.placeholder_live_events.render_status_panel(
+                let panel_text = shared_owned.ui.placeholder_live_events.render_status_panel(
                     channel_id,
                     &provider,
                     status_panel_started_at,
@@ -4322,7 +4316,7 @@ pub(super) fn spawn_turn_bridge(
                     &full_response,
                 );
                 let stable_display_text = build_turn_bridge_streaming_edit_text(
-                    shared_owned.status_panel_v2_enabled,
+                    shared_owned.ui.status_panel_v2_enabled,
                     current_portion,
                     &status_block,
                     &provider,
@@ -4352,13 +4346,13 @@ pub(super) fn spawn_turn_bridge(
                 }
             }
 
-            if shared_owned.placeholder_live_events_enabled
+            if shared_owned.ui.placeholder_live_events_enabled
                 && watcher_owns_assistant_relay
                 && let Some((key, input, _, _)) = long_running_placeholder_active.as_ref()
-                && let Some(block) = shared_owned.placeholder_live_events.render_block(channel_id)
+                && let Some(block) = shared_owned.ui.placeholder_live_events.render_block(channel_id)
             {
                 let outcome = shared_owned
-                    .placeholder_controller
+                    .ui.placeholder_controller
                     .ensure_active_with_live_events(
                         gateway.as_ref(),
                         key.clone(),
@@ -4454,7 +4448,7 @@ pub(super) fn spawn_turn_bridge(
                                 .as_ref()
                                 .is_some_and(|(active_key, _, _, _)| *active_key == old_key);
                             if active_still_matches_old_key {
-                                shared_owned.placeholder_controller.detach(&old_key);
+                                shared_owned.ui.placeholder_controller.detach(&old_key);
                                 let outcome = ensure_active_placeholder_card(
                                     shared_owned.as_ref(),
                                     gateway.as_ref(),
@@ -4560,7 +4554,7 @@ pub(super) fn spawn_turn_bridge(
                 && let Some((key, _, _, _)) = long_running_placeholder_active.take()
             {
                 let _ = pending_long_running_retarget_after_state_save.take();
-                shared_owned.placeholder_controller.detach(&key);
+                shared_owned.ui.placeholder_controller.detach(&key);
                 inflight_state.long_running_placeholder_active = false;
                 let _ = save_inflight_state(&inflight_state);
             }
@@ -4577,11 +4571,11 @@ pub(super) fn spawn_turn_bridge(
                     .is_some_and(|(pending_key, _, _, _, _)| *pending_key == key);
                 if pending_retarget_matches_key {
                     let _ = pending_long_running_retarget_after_state_save.take();
-                    shared_owned.placeholder_controller.detach(&key);
+                    shared_owned.ui.placeholder_controller.detach(&key);
                     inflight_state.long_running_placeholder_active = false;
                 } else {
                     let outcome = shared_owned
-                        .placeholder_controller
+                        .ui.placeholder_controller
                         .transition(gateway.as_ref(), key, target)
                         .await;
                     // codex round-10 P2: keep the persisted flag on EditFailed so
@@ -5190,12 +5184,12 @@ pub(super) fn spawn_turn_bridge(
                     .is_some_and(|(pending_key, _, _, _, _)| *pending_key == key);
                 if pending_retarget_matches_key {
                     let _ = pending_long_running_retarget_after_state_save.take();
-                    shared_owned.placeholder_controller.detach(&key);
+                    shared_owned.ui.placeholder_controller.detach(&key);
                     inflight_state.long_running_placeholder_active = false;
                     let _ = save_inflight_state(&inflight_state);
                 } else {
                     let outcome = shared_owned
-                        .placeholder_controller
+                        .ui.placeholder_controller
                         .transition(
                             gateway.as_ref(),
                             key.clone(),
@@ -5288,7 +5282,7 @@ pub(super) fn spawn_turn_bridge(
             } else if remaining_response.trim().is_empty() {
                 "[Stopped]".to_string()
             } else {
-                let formatted = if shared_owned.status_panel_v2_enabled {
+                let formatted = if shared_owned.ui.status_panel_v2_enabled {
                     super::formatting::format_for_discord_with_status_panel(
                         remaining_response,
                         &provider,
@@ -5496,7 +5490,7 @@ pub(super) fn spawn_turn_bridge(
                         channel_id
                     );
                     if should_delete_bridge_created_watcher_orphan_response(
-                        shared_owned.status_panel_v2_enabled,
+                        shared_owned.ui.status_panel_v2_enabled,
                         watcher_handoff_claim_outcome,
                         bridge_created_response_placeholder_msg_id,
                         current_msg_id,
@@ -5913,7 +5907,7 @@ pub(super) fn spawn_turn_bridge(
                     terminal_body_visible = true;
                 }
             } else {
-                delivery_response = if shared_owned.status_panel_v2_enabled {
+                delivery_response = if shared_owned.ui.status_panel_v2_enabled {
                     super::formatting::format_for_discord_with_status_panel(
                         &delivery_response,
                         &provider,
@@ -6480,7 +6474,7 @@ pub(super) fn spawn_turn_bridge(
         if status_panel_terminal_committed
             && bridge_should_emit_completion
             && (single_message_panel_footer_mode
-                || bridge_should_complete_separate_status_panel(shared_owned.status_panel_v2_enabled))
+                || bridge_should_complete_separate_status_panel(shared_owned.ui.status_panel_v2_enabled))
         {
             // #2849: before rendering the completed panel, backfill exact final
             // context usage when the live StatusUpdates never carried it (e.g.
@@ -6490,7 +6484,7 @@ pub(super) fn spawn_turn_bridge(
             // usage exists — so we never fabricate or reuse stale numbers.
             // set_context_panel_usage is a no-op when the live path already set
             // the same values, and is gated to context_window_tokens != 0.
-            if shared_owned.status_panel_v2_enabled {
+            if shared_owned.ui.status_panel_v2_enabled {
                 let context_provider_session_id = new_raw_provider_session_id
                     .as_deref()
                     .or(new_session_id.as_deref())
@@ -6506,7 +6500,7 @@ pub(super) fn spawn_turn_bridge(
                     context_provider_session_id,
                     accumulated_usage,
                 ) {
-                    shared_owned.placeholder_live_events.set_context_panel_usage(
+                    shared_owned.ui.placeholder_live_events.set_context_panel_usage(
                         channel_id,
                         context_provider_session_id,
                         usage.input_tokens,

--- a/src/services/discord/turn_bridge/single_message_footer.rs
+++ b/src/services/discord/turn_bridge/single_message_footer.rs
@@ -121,15 +121,15 @@ pub(super) fn build_bridge_single_message_panel_status_block(
     current_tool_line: Option<&str>,
     full_response: &str,
 ) -> String {
-    if bridge_single_message_panel_footer_enabled(shared.status_panel_v2_enabled) {
-        let panel_text = shared.placeholder_live_events.render_status_panel(
+    if bridge_single_message_panel_footer_enabled(shared.ui.status_panel_v2_enabled) {
+        let panel_text = shared.ui.placeholder_live_events.render_status_panel(
             channel_id,
             provider,
             started_at_unix,
         );
         return super::single_message_panel::compose_footer_status_block(indicator, &panel_text);
     }
-    if shared.status_panel_v2_enabled {
+    if shared.ui.status_panel_v2_enabled {
         super::formatting::build_processing_status_block(indicator)
     } else {
         super::formatting::build_placeholder_status_block(
@@ -180,9 +180,11 @@ pub(super) async fn complete_bridge_single_message_completion_footer(
     background: bool,
 ) -> bool {
     shared
+        .ui
         .placeholder_live_events
         .push_status_event(channel_id, StatusEvent::TurnCompleted { background });
     let rendered = shared
+        .ui
         .placeholder_live_events
         .render_completion_footer(channel_id, provider, indicator);
     super::single_message_panel::register_completion_footer_target(

--- a/src/services/discord/turn_bridge/status_panel.rs
+++ b/src/services/discord/turn_bridge/status_panel.rs
@@ -22,16 +22,18 @@ pub(super) async fn complete_status_panel_v2<G: TurnGateway + ?Sized>(
     source: &'static str,
     expected_user_msg_id: u64,
 ) -> bool {
-    if !shared.status_panel_v2_enabled {
+    if !shared.ui.status_panel_v2_enabled {
         return true;
     }
     shared
+        .ui
         .placeholder_live_events
         .push_status_event(channel_id, StatusEvent::TurnCompleted { background });
-    let panel_text =
-        shared
-            .placeholder_live_events
-            .render_status_panel(channel_id, provider, started_at_unix);
+    let panel_text = shared.ui.placeholder_live_events.render_status_panel(
+        channel_id,
+        provider,
+        started_at_unix,
+    );
 
     match status_panel_completion_action(status_panel_msg_id, last_status_panel_text, &panel_text) {
         StatusPanelCompletionAction::AlreadyCommitted => true,
@@ -140,16 +142,18 @@ pub(in crate::services::discord) async fn complete_status_panel_v2_with_http(
     source: &'static str,
     expected_user_msg_id: Option<u64>,
 ) -> bool {
-    if !shared.status_panel_v2_enabled {
+    if !shared.ui.status_panel_v2_enabled {
         return true;
     }
     shared
+        .ui
         .placeholder_live_events
         .push_status_event(channel_id, StatusEvent::TurnCompleted { background });
-    let panel_text =
-        shared
-            .placeholder_live_events
-            .render_status_panel(channel_id, provider, started_at_unix);
+    let panel_text = shared.ui.placeholder_live_events.render_status_panel(
+        channel_id,
+        provider,
+        started_at_unix,
+    );
 
     match status_panel_completion_action(status_panel_msg_id, last_status_panel_text, &panel_text) {
         StatusPanelCompletionAction::AlreadyCommitted => true,

--- a/src/services/discord/turn_bridge/status_panel_tests.rs
+++ b/src/services/discord/turn_bridge/status_panel_tests.rs
@@ -157,6 +157,7 @@ fn make_status_panel_v2_shared_for_tests() -> Arc<crate::services::discord::Shar
     let mut shared = super::super::make_shared_data_for_tests();
     Arc::get_mut(&mut shared)
         .expect("fresh test shared data should be uniquely owned")
+        .ui
         .status_panel_v2_enabled = true;
     shared
 }

--- a/src/services/discord/turn_bridge/terminal_delivery.rs
+++ b/src/services/discord/turn_bridge/terminal_delivery.rs
@@ -23,7 +23,7 @@ fn record_turn_bridge_terminal_replace_cleanup(
             detail
         );
     }
-    shared.placeholder_cleanup.record(
+    shared.ui.placeholder_cleanup.record(
         super::super::placeholder_cleanup::PlaceholderCleanupRecord {
             provider: provider.clone(),
             channel_id,
@@ -69,7 +69,7 @@ pub(super) async fn send_ordered_long_terminal_response(
         Ok(()) => super::super::placeholder_cleanup::PlaceholderCleanupOutcome::Succeeded,
         Err(error) => super::super::placeholder_cleanup::classify_delete_error(&error),
     };
-    shared.placeholder_cleanup.record(
+    shared.ui.placeholder_cleanup.record(
         super::super::placeholder_cleanup::PlaceholderCleanupRecord {
             provider: provider.clone(),
             channel_id,

--- a/src/services/discord/voice_barge_in.rs
+++ b/src/services/discord/voice_barge_in.rs
@@ -4465,17 +4465,21 @@ mod tests {
             skills_cache: tokio::sync::RwLock::new(Vec::new()),
             tmux_watchers: super::super::TmuxWatcherRegistry::new(),
             tmux_relay_coords: dashmap::DashMap::new(),
-            placeholder_cleanup: Arc::new(
-                super::super::placeholder_cleanup::PlaceholderCleanupRegistry::default(),
-            ),
-            placeholder_controller: Arc::new(
-                super::super::placeholder_controller::PlaceholderController::default(),
-            ),
-            placeholder_live_events: Arc::new(
-                super::super::placeholder_live_events::PlaceholderLiveEvents::default(),
-            ),
-            placeholder_live_events_enabled: false,
-            status_panel_v2_enabled: false,
+            // #3038 S4: wrapped verbatim at the first-member position
+            // (evaluation-order preserved).
+            ui: super::super::PlaceholderState {
+                placeholder_cleanup: Arc::new(
+                    super::super::placeholder_cleanup::PlaceholderCleanupRegistry::default(),
+                ),
+                placeholder_controller: Arc::new(
+                    super::super::placeholder_controller::PlaceholderController::default(),
+                ),
+                placeholder_live_events: Arc::new(
+                    super::super::placeholder_live_events::PlaceholderLiveEvents::default(),
+                ),
+                placeholder_live_events_enabled: false,
+                status_panel_v2_enabled: false,
+            },
             queued: super::super::QueuedPlaceholderState {
                 queued_placeholders: dashmap::DashMap::new(),
                 queue_exit_placeholder_clears: dashmap::DashMap::new(),

--- a/src/services/discord/watcher_panel_parity.rs
+++ b/src/services/discord/watcher_panel_parity.rs
@@ -112,7 +112,7 @@ pub(in crate::services::discord) async fn assert_watcher_reclaim_parity(
     provider: &ProviderKind,
     panel_msg_id: MessageId,
 ) {
-    if !shared.status_panel_v2_enabled {
+    if !shared.ui.status_panel_v2_enabled {
         return;
     }
     let controller_id = shared
@@ -262,7 +262,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn v2_off_short_circuits_without_panic() {
         let shared = super::super::make_shared_data_for_tests_with_storage(None, None);
-        assert!(!shared.status_panel_v2_enabled);
+        assert!(!shared.ui.status_panel_v2_enabled);
         let channel = ChannelId::new(4005);
         assert_watcher_reclaim_parity(
             &shared,


### PR DESCRIPTION
EPIC #3038 SharedData decomposition S4 (after S1-S3).

## What
- Five cohesive live-placeholder/status-panel fields → `shared_state::PlaceholderState` (`.ui.` routing): placeholder_cleanup, placeholder_controller, placeholder_live_events, placeholder_live_events_enabled, status_panel_v2_enabled.
- Verbatim discipline: mechanical `.field` → `.ui.field` substitutions; constructor wraps the same initializer expressions; injected Arc/atomic identity moved, never recreated (S3 no-flattening invariant preserved).
- Hot files (turn_bridge/mod.rs, tmux_watcher.rs, session_relay_sink.rs): single-token routing only + comment reflow to hold ratchets; turn_finalizer.rs untouched. Lock spans/CAS ordering/signal order unchanged.
- The queued-placeholder dual-ownership race comment intentionally NOT fixed here (future issue per slice rule).
- Accounting: mod.rs 4970→4967 ratchet, shared_state.rs 582 under cap.

## Verification
- fmt/clippy clean; shared_state + discord umbrella (1584) green; audit + agent-maintenance docs clean on committed HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)