### PR TITLE
feat(#3089): background bash tasks get panel/footer slots with exact-id finalize

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -415,6 +415,7 @@ src/
 │   │   │   ├── send_to_agent.rs
 │   │   │   └── transport.rs
 │   │   ├── placeholder_live_events/
+│   │   │   ├── background_task_events.rs
 │   │   │   ├── common.rs
 │   │   │   ├── completion_footer.rs
 │   │   │   ├── context_panel.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1011,8 +1011,8 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
 - `src/services/dispatches/outbox_route.rs` (1089) — dispatch outbox route
   support extracted from the route layer; split before adding non-bugfix
   behavior.
-- `src/services/claude.rs` (2950), `src/services/gemini.rs` (1358),
-  `src/services/qwen.rs` (2196), `src/services/codex.rs` (3001),
+- `src/services/claude.rs` (2948), `src/services/gemini.rs` (1358),
+  `src/services/qwen.rs` (2196), `src/services/codex.rs` (3002),
   `src/services/opencode.rs` (1881), `src/services/provider.rs` (1796) —
   provider adapters. (#3034 removed dead non-cancel `execute_command_simple*`
   twins from the claude/codex/gemini adapters and a superseded

--- a/src/services/agent_protocol.rs
+++ b/src/services/agent_protocol.rs
@@ -185,6 +185,10 @@ pub enum StreamMessage {
     /// Background task notification
     TaskNotification {
         task_id: String,
+        /// Originating tool-use id when the provider/harness surfaces one (for
+        /// example Claude Code background Bash `<tool-use-id>` notifications).
+        /// `None` means consumers must not guess an owner.
+        tool_use_id: Option<String>,
         status: String,
         summary: String,
         kind: TaskNotificationKind,
@@ -341,6 +345,15 @@ pub enum StatusEvent {
         task_id: Option<String>,
         summary: Option<String>,
         status: Option<String>,
+    },
+    BackgroundTaskStart {
+        name: String,
+        summary: String,
+        tool_use_id: String,
+    },
+    BackgroundTaskEnd {
+        tool_use_id: String,
+        success: bool,
     },
     TodoUpdate {
         items: Vec<StatusTodoItem>,

--- a/src/services/claude.rs
+++ b/src/services/claude.rs
@@ -1146,13 +1146,11 @@ IMPORTANT: Format your responses using Markdown for better readability:
                         status,
                         summary,
                         kind,
+                        ..
                     } => {
                         debug_log(&format!(
-                            "  >>> TaskNotification: task_id={}, status={}, kind={}, summary={}",
-                            task_id,
-                            status,
-                            kind.as_str(),
-                            summary
+                            "  >>> TaskNotification: task_id={task_id}, status={status}, kind={}, summary={summary}",
+                            kind.as_str()
                         ));
                     }
                     StreamMessage::StatusUpdate {

--- a/src/services/codex.rs
+++ b/src/services/codex.rs
@@ -2930,6 +2930,7 @@ fn handle_codex_json_line(
             if let Some(summary) = codex_background_event_summary(&json) {
                 let _ = sender.send(StreamMessage::TaskNotification {
                     task_id: CODEX_BACKGROUND_TASK_NOTIFICATION_ID.to_string(),
+                    tool_use_id: None,
                     status: CODEX_BACKGROUND_TASK_NOTIFICATION_STATUS.to_string(),
                     summary: summary.to_string(),
                     kind: crate::services::agent_protocol::TaskNotificationKind::Background,

--- a/src/services/discord/placeholder_live_events/background_task_events.rs
+++ b/src/services/discord/placeholder_live_events/background_task_events.rs
@@ -1,0 +1,108 @@
+use serde_json::Value;
+
+use crate::services::agent_protocol::StatusEvent;
+
+use super::common::{EVENT_LINE_MAX_CHARS, normalize_summary, normalize_tool_key, truncate_chars};
+
+pub(super) fn slots_enabled_by_footer_flag() -> bool {
+    // #3089: background Bash task slots are deliberately footer-mode gated so the
+    // legacy separate status-panel / completion-card render path is unchanged when
+    // AGENTDESK_SINGLE_MESSAGE_PANEL is off. `status_panel_v2_enabled` is already
+    // checked by the callers before status events are pushed/rendered.
+    super::super::single_message_panel::enabled()
+}
+
+pub(super) fn start_event_from_bash_tool_use(
+    name: &str,
+    value: &Value,
+    args_summary: Option<String>,
+    tool_use_id: Option<&str>,
+    footer_mode_enabled: bool,
+) -> Option<StatusEvent> {
+    if !footer_mode_enabled || !is_background_bash_tool(name) || !run_in_background(value) {
+        return None;
+    }
+    Some(StatusEvent::BackgroundTaskStart {
+        name: name.to_string(),
+        summary: task_summary(value).or(args_summary)?,
+        tool_use_id: clean_tool_use_id(tool_use_id)?,
+    })
+}
+
+pub(super) fn events_from_background_notification(
+    status: &str,
+    summary: &str,
+    tool_use_id: Option<&str>,
+) -> Vec<StatusEvent> {
+    if notification_is_terminal(status) {
+        if let Some(tool_use_id) = clean_tool_use_id(tool_use_id) {
+            return vec![StatusEvent::BackgroundTaskEnd {
+                tool_use_id,
+                success: !notification_is_error(status),
+            }];
+        }
+    }
+    (!summary.is_empty())
+        .then_some(StatusEvent::Heartbeat)
+        .into_iter()
+        .collect()
+}
+
+pub(super) fn tool_use_id_from_notification(value: &Value) -> Option<String> {
+    ["tool_use_id", "tool-use-id", "toolUseId"]
+        .into_iter()
+        .find_map(|key| value.get(key).and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string)
+}
+
+pub(super) fn notification_is_terminal(status: &str) -> bool {
+    matches!(
+        status.trim().to_ascii_lowercase().as_str(),
+        "completed"
+            | "done"
+            | "finished"
+            | "success"
+            | "failed"
+            | "error"
+            | "aborted"
+            | "killed"
+            | "stopped"
+            | "cancelled"
+            | "canceled"
+    )
+}
+
+pub(super) fn notification_is_error(status: &str) -> bool {
+    matches!(
+        status.trim().to_ascii_lowercase().as_str(),
+        "failed" | "error" | "aborted" | "killed" | "stopped" | "cancelled" | "canceled"
+    )
+}
+
+fn clean_tool_use_id(raw: Option<&str>) -> Option<String> {
+    raw.map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn is_background_bash_tool(name: &str) -> bool {
+    normalize_tool_key(name) == "bash"
+}
+
+fn run_in_background(value: &Value) -> bool {
+    value
+        .get("run_in_background")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn task_summary(value: &Value) -> Option<String> {
+    ["description", "desc", "command"]
+        .into_iter()
+        .find_map(|key| value.get(key).and_then(Value::as_str))
+        .map(normalize_summary)
+        .filter(|value| !value.is_empty())
+        .map(|summary| truncate_chars(&summary, EVENT_LINE_MAX_CHARS))
+}

--- a/src/services/discord/placeholder_live_events/completion_footer.rs
+++ b/src/services/discord/placeholder_live_events/completion_footer.rs
@@ -6,7 +6,7 @@ use super::common::{
 };
 use super::context_panel::render_context_panel_line;
 use super::status_panel::{StatusPanelState, SubagentSlot, render_subagent_slot};
-use super::task_panel::{TaskToolSlot, render_task_tool_slot};
+use super::task_panel::{TaskToolSlot, render_task_tool_slot, task_tool_terminal_marker};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::services::discord) struct CompletionFooterRender {
@@ -80,7 +80,9 @@ pub(super) fn render_completion_footer(
 fn render_completion_task_tool_slot(slot: &TaskToolSlot, indicator: &str) -> (String, bool) {
     let (marker, unfinished) = completion_task_marker(slot.status.as_deref(), indicator);
     let base = render_task_tool_slot(slot);
-    let line = if marker.is_empty() {
+    let line = if slot.background && task_tool_terminal_marker(slot.status.as_deref()).is_some() {
+        base
+    } else if marker.is_empty() {
         base
     } else {
         format!("{base} {marker}")
@@ -103,10 +105,20 @@ fn completion_task_marker<'a>(status: Option<&str>, indicator: &'a str) -> (&'a 
         ("✓", false)
     } else if matches!(
         normalized.as_str(),
-        "failed" | "failure" | "error" | "errored" | "aborted" | "cancelled" | "canceled"
+        "failed"
+            | "failure"
+            | "error"
+            | "errored"
+            | "aborted"
+            | "killed"
+            | "stopped"
+            | "cancelled"
+            | "canceled"
     ) || normalized.contains("fail")
         || normalized.contains("error")
         || normalized.contains("abort")
+        || normalized.contains("kill")
+        || normalized.contains("stop")
         || normalized.contains("cancel")
     {
         ("✗", false)

--- a/src/services/discord/placeholder_live_events/mod.rs
+++ b/src/services/discord/placeholder_live_events/mod.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 use crate::services::agent_protocol::StatusEvent;
 use crate::services::provider::ProviderKind;
 
+mod background_task_events;
 mod common;
 mod completion_footer;
 mod context_panel;
@@ -43,7 +44,7 @@ use status_panel::{
 
 pub(in crate::services::discord) use recent_events::RecentPlaceholderEvent;
 pub(in crate::services::discord) use status_events::{
-    status_events_from_task_notification, status_events_from_tool_result_with_id,
+    status_events_from_task_notification_with_tool_use_id, status_events_from_tool_result_with_id,
     status_events_from_tool_use_with_id,
 };
 // #3034: the bare (no-id) variants are consumed only by the `tests` submodule
@@ -52,7 +53,9 @@ pub(in crate::services::discord) use status_events::{
 // build.
 #[cfg(test)]
 pub(in crate::services::discord) use status_events::{
+    status_events_from_json_for_footer_mode, status_events_from_task_notification,
     status_events_from_tool_result, status_events_from_tool_use,
+    status_events_from_tool_use_with_id_for_footer_mode,
 };
 
 pub(in crate::services::discord) use recent_events::events_from_json;

--- a/src/services/discord/placeholder_live_events/status_events.rs
+++ b/src/services/discord/placeholder_live_events/status_events.rs
@@ -5,11 +5,16 @@ use crate::services::agent_protocol::{
 };
 
 use super::super::formatting::format_tool_input;
+use super::background_task_events::{
+    events_from_background_notification, notification_is_error, notification_is_terminal,
+    slots_enabled_by_footer_flag, start_event_from_bash_tool_use, tool_use_id_from_notification,
+};
 use super::common::{
     EVENT_LINE_MAX_CHARS, first_content_line, is_harness_task_tool_name, normalize_summary,
     normalize_tool_key, truncate_chars, value_to_compact_string,
 };
 
+#[cfg(test)]
 pub(in crate::services::discord) fn status_events_from_tool_use(
     name: &str,
     input: &str,
@@ -21,6 +26,20 @@ pub(in crate::services::discord) fn status_events_from_tool_use_with_id(
     name: &str,
     input: &str,
     tool_use_id: Option<&str>,
+) -> Vec<StatusEvent> {
+    status_events_from_tool_use_with_id_for_footer_mode(
+        name,
+        input,
+        tool_use_id,
+        background_bash_task_slots_enabled(),
+    )
+}
+
+pub(in crate::services::discord) fn status_events_from_tool_use_with_id_for_footer_mode(
+    name: &str,
+    input: &str,
+    tool_use_id: Option<&str>,
+    footer_mode_enabled: bool,
 ) -> Vec<StatusEvent> {
     let args_summary = format_tool_input(name, input)
         .trim()
@@ -53,6 +72,18 @@ pub(in crate::services::discord) fn status_events_from_tool_use_with_id(
             status,
         });
     }
+    if footer_mode_enabled {
+        let value = tool_input_value(input);
+        if let Some(event) = start_event_from_bash_tool_use(
+            name,
+            &value,
+            args_summary.clone(),
+            tool_use_id,
+            footer_mode_enabled,
+        ) {
+            events.push(event);
+        }
+    }
     if is_task_tool(name) {
         let value = tool_input_value(input);
         let background = value
@@ -83,6 +114,10 @@ pub(in crate::services::discord) fn status_events_from_tool_use_with_id(
         });
     }
     events
+}
+
+fn background_bash_task_slots_enabled() -> bool {
+    slots_enabled_by_footer_flag()
 }
 
 fn tool_input_value(input: &str) -> Value {
@@ -123,10 +158,20 @@ pub(in crate::services::discord) fn status_events_from_tool_result_with_id(
     events
 }
 
+#[cfg(test)]
 pub(in crate::services::discord) fn status_events_from_task_notification(
     kind: &str,
     status: &str,
     summary: &str,
+) -> Vec<StatusEvent> {
+    status_events_from_task_notification_with_tool_use_id(kind, status, summary, None)
+}
+
+pub(in crate::services::discord) fn status_events_from_task_notification_with_tool_use_id(
+    kind: &str,
+    status: &str,
+    summary: &str,
+    tool_use_id: Option<&str>,
 ) -> Vec<StatusEvent> {
     let mut events = Vec::new();
     match kind {
@@ -136,9 +181,9 @@ pub(in crate::services::discord) fn status_events_from_task_notification(
             if !summary.is_empty() {
                 events.push(StatusEvent::SubagentEvent { summary });
             }
-            if task_notification_is_terminal(status) {
+            if notification_is_terminal(status) {
                 events.push(StatusEvent::SubagentEnd {
-                    success: !task_notification_is_error(status),
+                    success: !notification_is_error(status),
                     tool_use_id: None,
                     summary: None,
                     // A terminal task_notification is the subagent's REAL
@@ -150,14 +195,16 @@ pub(in crate::services::discord) fn status_events_from_task_notification(
         }
         "background" => {
             let summary = first_content_line(summary);
-            if !summary.is_empty() {
-                events.push(StatusEvent::Heartbeat);
-            }
+            events.extend(events_from_background_notification(
+                status,
+                &summary,
+                tool_use_id,
+            ));
         }
         "workflow" => {
             events.push(StatusEvent::WorkflowEnd {
                 task_id: None,
-                success: !task_notification_is_error(status),
+                success: !notification_is_error(status),
                 summary: Some(first_content_line(summary)).filter(|value| !value.is_empty()),
             });
         }
@@ -167,6 +214,13 @@ pub(in crate::services::discord) fn status_events_from_task_notification(
 }
 
 pub(in crate::services::discord) fn status_events_from_json(value: &Value) -> Vec<StatusEvent> {
+    status_events_from_json_for_footer_mode(value, background_bash_task_slots_enabled())
+}
+
+pub(in crate::services::discord) fn status_events_from_json_for_footer_mode(
+    value: &Value,
+    footer_mode_enabled: bool,
+) -> Vec<StatusEvent> {
     let workflow_events = status_events_from_workflow_json(value);
     if !workflow_events.is_empty() {
         return workflow_events;
@@ -183,8 +237,8 @@ pub(in crate::services::discord) fn status_events_from_json(value: &Value) -> Ve
     }
 
     match value.get("type").and_then(Value::as_str).unwrap_or("") {
-        "assistant" => assistant_status_events(value),
-        "content_block_start" => content_block_start_status_events(value),
+        "assistant" => assistant_status_events(value, footer_mode_enabled),
+        "content_block_start" => content_block_start_status_events(value, footer_mode_enabled),
         "user" => user_status_events(value),
         "system" => system_status_events(value),
         "background_event" => background_status_events(value),
@@ -344,29 +398,7 @@ fn eta_secs_from_value(value: &Value) -> Option<u64> {
     None
 }
 
-fn task_notification_is_terminal(status: &str) -> bool {
-    matches!(
-        status.trim().to_ascii_lowercase().as_str(),
-        "completed"
-            | "done"
-            | "finished"
-            | "success"
-            | "failed"
-            | "error"
-            | "aborted"
-            | "cancelled"
-            | "canceled"
-    )
-}
-
-fn task_notification_is_error(status: &str) -> bool {
-    matches!(
-        status.trim().to_ascii_lowercase().as_str(),
-        "failed" | "error" | "aborted" | "cancelled" | "canceled"
-    )
-}
-
-fn assistant_status_events(value: &Value) -> Vec<StatusEvent> {
+fn assistant_status_events(value: &Value, footer_mode_enabled: bool) -> Vec<StatusEvent> {
     value
         .get("message")
         .and_then(|message| message.get("content"))
@@ -379,12 +411,18 @@ fn assistant_status_events(value: &Value) -> Vec<StatusEvent> {
             }
             let name = block.get("name").and_then(Value::as_str).unwrap_or("Tool");
             let input = value_to_compact_string(block.get("input").unwrap_or(&Value::Null));
-            status_events_from_tool_use(name, &input)
+            let tool_use_id = block.get("id").and_then(Value::as_str);
+            status_events_from_tool_use_with_id_for_footer_mode(
+                name,
+                &input,
+                tool_use_id,
+                footer_mode_enabled,
+            )
         })
         .collect()
 }
 
-fn content_block_start_status_events(value: &Value) -> Vec<StatusEvent> {
+fn content_block_start_status_events(value: &Value, footer_mode_enabled: bool) -> Vec<StatusEvent> {
     let Some(block) = value.get("content_block") else {
         return Vec::new();
     };
@@ -396,7 +434,13 @@ fn content_block_start_status_events(value: &Value) -> Vec<StatusEvent> {
         .get("input")
         .map(value_to_compact_string)
         .unwrap_or_default();
-    status_events_from_tool_use(name, &input)
+    let tool_use_id = block.get("id").and_then(Value::as_str);
+    status_events_from_tool_use_with_id_for_footer_mode(
+        name,
+        &input,
+        tool_use_id,
+        footer_mode_enabled,
+    )
 }
 
 fn user_status_events(value: &Value) -> Vec<StatusEvent> {
@@ -552,7 +596,13 @@ fn system_status_events(value: &Value) -> Vec<StatusEvent> {
         .unwrap_or("system");
     let status = value.get("status").and_then(Value::as_str).unwrap_or("");
     let summary = value.get("summary").and_then(Value::as_str).unwrap_or("");
-    status_events_from_task_notification(kind, status, summary)
+    let tool_use_id = tool_use_id_from_notification(value);
+    status_events_from_task_notification_with_tool_use_id(
+        kind,
+        status,
+        summary,
+        tool_use_id.as_deref(),
+    )
 }
 
 /// Returns the launching Task's tool-use id from a nested subagent record's

--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -12,8 +12,8 @@ use super::session_panel::{SessionPanelSnapshot, render_session_panel_line};
 use super::status_events::{is_schedule_wakeup_tool, parse_eta_secs};
 use super::subagent_summary::render_subagent_done_summary;
 use super::task_panel::{
-    TaskPanelSnapshot, TaskToolSlot, clean_task_tool_value, render_task_panel_line,
-    render_task_tool_slot,
+    TaskPanelSnapshot, TaskToolSlot, finish_background_task_tool_slot, render_task_panel_line,
+    render_task_tool_slot, upsert_background_task_tool_slot, upsert_task_tool_slot,
 };
 use super::workflow_panel::{
     WorkflowAgentSlot, WorkflowSlot, render_workflow_slot, trim_workflow_slot, trim_workflows,
@@ -238,7 +238,20 @@ impl StatusPanelState {
                 summary,
                 status,
             } => {
-                self.upsert_task_tool(name, task_id, summary, status);
+                upsert_task_tool_slot(&mut self.tasks, name, task_id, summary, status);
+            }
+            StatusEvent::BackgroundTaskStart {
+                name,
+                summary,
+                tool_use_id,
+            } => {
+                upsert_background_task_tool_slot(&mut self.tasks, name, summary, tool_use_id);
+            }
+            StatusEvent::BackgroundTaskEnd {
+                tool_use_id,
+                success,
+            } => {
+                finish_background_task_tool_slot(&mut self.tasks, &tool_use_id, success);
             }
             StatusEvent::TodoUpdate { items } => {
                 self.todos = items
@@ -372,42 +385,6 @@ impl StatusPanelState {
                 slot.recent = Some(summary);
             }
         }
-    }
-
-    fn upsert_task_tool(
-        &mut self,
-        name: String,
-        task_id: Option<String>,
-        summary: Option<String>,
-        status: Option<String>,
-    ) {
-        let task_id = task_id.and_then(clean_task_tool_value);
-        let summary = summary.and_then(clean_task_tool_value);
-        let status = status.and_then(clean_task_tool_value);
-        if let Some(task_id_value) = task_id.as_deref()
-            && let Some(slot) = self
-                .tasks
-                .iter_mut()
-                .rev()
-                .find(|slot| slot.task_id.as_deref() == Some(task_id_value))
-        {
-            slot.name = name;
-            if summary.is_some() {
-                slot.summary = summary;
-            }
-            if status.is_some() {
-                slot.status = status;
-            }
-            return;
-        }
-
-        self.tasks.push(TaskToolSlot {
-            name,
-            task_id,
-            summary,
-            status,
-        });
-        trim_tasks(&mut self.tasks);
     }
 
     fn workflow_slot_mut(&mut self, task_id: Option<String>) -> &mut WorkflowSlot {
@@ -663,13 +640,6 @@ fn sanitize_label(raw: &str) -> String {
 fn trim_subagents(slots: &mut Vec<SubagentSlot>) {
     if slots.len() > STATUS_PANEL_SUBAGENT_LIMIT {
         let excess = slots.len() - STATUS_PANEL_SUBAGENT_LIMIT;
-        slots.drain(0..excess);
-    }
-}
-
-fn trim_tasks(slots: &mut Vec<TaskToolSlot>) {
-    if slots.len() > STATUS_PANEL_TASK_LIMIT {
-        let excess = slots.len() - STATUS_PANEL_TASK_LIMIT;
         slots.drain(0..excess);
     }
 }

--- a/src/services/discord/placeholder_live_events/task_panel.rs
+++ b/src/services/discord/placeholder_live_events/task_panel.rs
@@ -90,11 +90,98 @@ pub(super) struct TaskToolSlot {
     pub(super) task_id: Option<String>,
     pub(super) summary: Option<String>,
     pub(super) status: Option<String>,
+    pub(super) tool_use_id: Option<String>,
+    pub(super) background: bool,
 }
 
 pub(super) fn clean_task_tool_value(raw: impl AsRef<str>) -> Option<String> {
     let value = first_content_line(raw.as_ref());
     (!value.is_empty()).then_some(value)
+}
+
+pub(super) fn upsert_task_tool_slot(
+    slots: &mut Vec<TaskToolSlot>,
+    name: String,
+    task_id: Option<String>,
+    summary: Option<String>,
+    status: Option<String>,
+) {
+    let task_id = task_id.and_then(clean_task_tool_value);
+    let summary = summary.and_then(clean_task_tool_value);
+    let status = status.and_then(clean_task_tool_value);
+    if let Some(task_id_value) = task_id.as_deref()
+        && let Some(slot) = slots
+            .iter_mut()
+            .rev()
+            .find(|slot| slot.task_id.as_deref() == Some(task_id_value))
+    {
+        slot.name = name;
+        if summary.is_some() {
+            slot.summary = summary;
+        }
+        if status.is_some() {
+            slot.status = status;
+        }
+        return;
+    }
+
+    slots.push(TaskToolSlot {
+        name,
+        task_id,
+        summary,
+        status,
+        tool_use_id: None,
+        background: false,
+    });
+    trim_task_tool_slots(slots);
+}
+
+pub(super) fn upsert_background_task_tool_slot(
+    slots: &mut Vec<TaskToolSlot>,
+    name: String,
+    summary: String,
+    tool_use_id: String,
+) {
+    let Some(tool_use_id) = clean_task_tool_value(tool_use_id) else {
+        return;
+    };
+    let summary = clean_task_tool_value(summary).unwrap_or_else(|| "Bash".to_string());
+    if let Some(slot) = slots
+        .iter_mut()
+        .rev()
+        .find(|slot| slot.background && slot.tool_use_id.as_deref() == Some(&tool_use_id))
+    {
+        slot.name = name;
+        slot.summary = Some(summary);
+        return;
+    }
+
+    slots.push(TaskToolSlot {
+        name,
+        task_id: None,
+        summary: Some(summary),
+        status: None,
+        tool_use_id: Some(tool_use_id),
+        background: true,
+    });
+    trim_task_tool_slots(slots);
+}
+
+pub(super) fn finish_background_task_tool_slot(
+    slots: &mut [TaskToolSlot],
+    tool_use_id: &str,
+    success: bool,
+) {
+    let Some(tool_use_id) = clean_task_tool_value(tool_use_id) else {
+        return;
+    };
+    if let Some(slot) = slots
+        .iter_mut()
+        .rev()
+        .find(|slot| slot.background && slot.tool_use_id.as_deref() == Some(&tool_use_id))
+    {
+        slot.status = Some(if success { "completed" } else { "failed" }.to_string());
+    }
 }
 
 pub(super) fn render_task_tool_slot(slot: &TaskToolSlot) -> String {
@@ -108,18 +195,68 @@ pub(super) fn render_task_tool_slot(slot: &TaskToolSlot) -> String {
             detail_parts.push(escape_status_panel_markdown(summary));
         }
     }
-    if let Some(status) = slot.status.as_deref() {
+    if !slot.background
+        && let Some(status) = slot.status.as_deref()
+    {
         detail_parts.push(escape_status_panel_markdown(status));
     }
 
-    let line = if detail_parts.is_empty() {
+    let mut line = if detail_parts.is_empty() {
         format!("└ {label}")
     } else {
         format!("└ {label} {}", detail_parts.join(" · "))
     };
+    if slot.background
+        && let Some(marker) = task_tool_terminal_marker(slot.status.as_deref())
+    {
+        line.push(' ');
+        line.push_str(marker);
+    }
     truncate_chars(&line, EVENT_LINE_MAX_CHARS)
+}
+
+pub(super) fn task_tool_terminal_marker(status: Option<&str>) -> Option<&'static str> {
+    let status = status.map(str::trim).filter(|value| !value.is_empty())?;
+    let normalized = status.to_ascii_lowercase();
+    if matches!(
+        normalized.as_str(),
+        "completed" | "complete" | "done" | "success" | "succeeded" | "ok"
+    ) || normalized.contains("complete")
+        || normalized.contains("success")
+        || normalized.contains("done")
+    {
+        Some("✓")
+    } else if matches!(
+        normalized.as_str(),
+        "failed"
+            | "failure"
+            | "error"
+            | "errored"
+            | "aborted"
+            | "killed"
+            | "stopped"
+            | "cancelled"
+            | "canceled"
+    ) || normalized.contains("fail")
+        || normalized.contains("error")
+        || normalized.contains("abort")
+        || normalized.contains("kill")
+        || normalized.contains("stop")
+        || normalized.contains("cancel")
+    {
+        Some("✗")
+    } else {
+        None
+    }
 }
 
 fn short_dispatch_id(dispatch_id: &str) -> String {
     dispatch_id.chars().take(DISPATCH_ID_SHORT_LEN).collect()
+}
+
+fn trim_task_tool_slots(slots: &mut Vec<TaskToolSlot>) {
+    if slots.len() > super::common::STATUS_PANEL_TASK_LIMIT {
+        let excess = slots.len() - super::common::STATUS_PANEL_TASK_LIMIT;
+        slots.drain(0..excess);
+    }
 }

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -1608,6 +1608,359 @@ fn completion_footer_running_background_subagent_animates_until_notification_don
 }
 
 #[test]
+fn background_bash_footer_mode_creates_running_task_slot_and_ack_stays_running() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_089_100);
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id_for_footer_mode(
+            "Bash",
+            &json!({
+                "command": "codex exec --skip-git-repo-check",
+                "description": "Launch codex for SharedData S4",
+                "run_in_background": true
+            })
+            .to_string(),
+            Some("toolu_bash_bg"),
+            true,
+        ),
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_result_with_id(Some("Bash"), false, Some("toolu_bash_bg")),
+    );
+
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    let line = rendered
+        .lines()
+        .find(|line| line.contains("Bash Launch codex for SharedData S4"))
+        .unwrap_or_else(|| panic!("background Bash task slot missing in: {rendered}"));
+
+    assert!(rendered.contains("Tasks"));
+    assert!(
+        !line.contains('✓') && !line.contains('✗') && !line.contains('⠸'),
+        "running background Bash slot must not show a terminal marker/spinner in live panel: {line}"
+    );
+}
+
+#[test]
+fn background_bash_notification_finalizes_only_exact_tool_use_id() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_089_101);
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id_for_footer_mode(
+            "Bash",
+            &json!({
+                "command": "codex exec",
+                "description": "Launch codex for voice S2",
+                "run_in_background": true
+            })
+            .to_string(),
+            Some("toolu_voice"),
+            true,
+        ),
+    );
+
+    events.push_status_events(
+        channel_id,
+        status_events_from_task_notification_with_tool_use_id(
+            "background",
+            "completed",
+            "Background command \"Launch codex for other\" completed (exit code 0)",
+            Some("toolu_other"),
+        ),
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_task_notification_with_tool_use_id(
+            "background",
+            "completed",
+            "Background command without id completed (exit code 0)",
+            None,
+        ),
+    );
+
+    let still_running =
+        events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    let running_line = still_running
+        .lines()
+        .find(|line| line.contains("Bash Launch codex for voice S2"))
+        .unwrap_or_else(|| panic!("background Bash task slot missing in: {still_running}"));
+    assert!(
+        !running_line.contains('✓') && !running_line.contains('✗'),
+        "non-matching or id-less notification must not finalize: {running_line}"
+    );
+
+    events.push_status_events(
+        channel_id,
+        status_events_from_task_notification_with_tool_use_id(
+            "background",
+            "completed",
+            "Background command \"Launch codex for voice S2\" completed (exit code 0)",
+            Some("toolu_voice"),
+        ),
+    );
+
+    let done = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    let done_line = done
+        .lines()
+        .find(|line| line.contains("Bash Launch codex for voice S2"))
+        .unwrap_or_else(|| panic!("background Bash task slot missing in: {done}"));
+    assert!(
+        done_line.contains('✓'),
+        "matching notification must mark ✓: {done_line}"
+    );
+}
+
+#[test]
+fn background_bash_failed_notification_marks_task_failed() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_089_102);
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id_for_footer_mode(
+            "Bash",
+            &json!({
+                "command": "deploy-release.sh",
+                "description": "Deploy release runtime",
+                "run_in_background": true
+            })
+            .to_string(),
+            Some("toolu_deploy"),
+            true,
+        ),
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_task_notification_with_tool_use_id(
+            "background",
+            "failed",
+            "Background command \"Deploy release runtime\" failed with exit code 1",
+            Some("toolu_deploy"),
+        ),
+    );
+
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    let line = rendered
+        .lines()
+        .find(|line| line.contains("Bash Deploy release runtime"))
+        .unwrap_or_else(|| panic!("background Bash task slot missing in: {rendered}"));
+    assert!(
+        line.contains('✗'),
+        "failed notification must mark ✗: {line}"
+    );
+}
+
+#[test]
+fn background_bash_record_reconstruction_ack_does_not_finalize_then_notification_flips() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_089_103);
+    events.push_status_events(
+        channel_id,
+        status_events_from_json_for_footer_mode(
+            &json!({
+                "type": "assistant",
+                "message": {
+                    "content": [{
+                        "type": "tool_use",
+                        "id": "toolu_record_bash",
+                        "name": "Bash",
+                        "input": {
+                            "command": "cd /tmp/adk && codex exec",
+                            "description": "Launch codex for SharedData S4",
+                            "run_in_background": true
+                        }
+                    }]
+                }
+            }),
+            true,
+        ),
+    );
+
+    let ack_events = status_events_from_json_for_footer_mode(
+        &json!({
+            "type": "user",
+            "message": {
+                "content": [{
+                    "tool_use_id": "toolu_record_bash",
+                    "type": "tool_result",
+                    "content": "Command running in background with ID: bdri3xti5. Output is being written to: /tmp/tasks/bdri3xti5.output.",
+                    "is_error": false
+                }]
+            },
+            "toolUseResult": {
+                "stdout": "",
+                "stderr": "",
+                "interrupted": false,
+                "isImage": false,
+                "noOutputExpected": false,
+                "backgroundTaskId": "bdri3xti5"
+            }
+        }),
+        true,
+    );
+    assert!(
+        !ack_events
+            .iter()
+            .any(|event| matches!(event, StatusEvent::BackgroundTaskEnd { .. })),
+        "background Bash launch ACK must not synthesize BackgroundTaskEnd: {ack_events:?}"
+    );
+    events.push_status_events(channel_id, ack_events);
+
+    let running = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    let running_line = running
+        .lines()
+        .find(|line| line.contains("Bash Launch codex for SharedData S4"))
+        .unwrap_or_else(|| panic!("background Bash task slot missing in: {running}"));
+    assert!(
+        !running_line.contains('✓') && !running_line.contains('✗'),
+        "launch ACK must leave reconstructed slot running: {running_line}"
+    );
+
+    events.push_status_events(
+        channel_id,
+        status_events_from_json_for_footer_mode(
+            &json!({
+                "type": "system",
+                "subtype": "task_notification",
+                "task_notification_kind": "background",
+                "task_id": "bdri3xti5",
+                "tool_use_id": "toolu_record_bash",
+                "status": "completed",
+                "summary": "Background command \"Launch codex for SharedData S4\" completed (exit code 0)"
+            }),
+            true,
+        ),
+    );
+
+    let done = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    let done_line = done
+        .lines()
+        .find(|line| line.contains("Bash Launch codex for SharedData S4"))
+        .unwrap_or_else(|| panic!("background Bash task slot missing in: {done}"));
+    assert!(
+        done_line.contains('✓'),
+        "matching reconstructed notification must flip ✓: {done_line}"
+    );
+}
+
+#[test]
+fn completion_footer_background_bash_animates_and_flips_on_notification() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_089_104);
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id_for_footer_mode(
+            "Bash",
+            &json!({
+                "command": "codex exec --skip-git-repo-check",
+                "description": "Delegate background task slots to codex",
+                "run_in_background": true
+            })
+            .to_string(),
+            Some("toolu_delegate"),
+            true,
+        ),
+    );
+
+    let running = events.render_completion_footer(channel_id, &ProviderKind::Claude, "⠸");
+    let running_block = running
+        .block
+        .expect("running background Bash should render");
+    assert!(running.has_unfinished_entries);
+    assert!(running_block.contains("Tasks"));
+    assert!(running_block.contains("Bash Delegate background task slots to codex ⠸"));
+    assert!(!running_block.contains('✓'));
+
+    events.push_status_events(
+        channel_id,
+        status_events_from_task_notification_with_tool_use_id(
+            "background",
+            "completed",
+            "Background command \"Delegate background task slots to codex\" completed (exit code 0)",
+            Some("toolu_delegate"),
+        ),
+    );
+    let done = events.render_completion_footer(channel_id, &ProviderKind::Claude, "⠼");
+    let done_block = done
+        .block
+        .expect("finished background Bash should stay visible");
+    assert!(!done.has_unfinished_entries);
+    assert!(done_block.contains("Bash Delegate background task slots to codex ✓"));
+    assert!(!done_block.contains('⠼'));
+}
+
+#[test]
+fn background_bash_slots_are_footer_flag_gated() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_089_105);
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id_for_footer_mode(
+            "Bash",
+            &json!({
+                "command": "codex exec",
+                "description": "Should stay hidden with footer flag off",
+                "run_in_background": true
+            })
+            .to_string(),
+            Some("toolu_hidden"),
+            false,
+        ),
+    );
+
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    assert!(!rendered.contains("Tasks"));
+    assert!(!rendered.contains("└ Bash Should stay hidden with footer flag off"));
+}
+
+#[test]
+fn background_bash_task_slots_trim_to_task_limit() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_089_106);
+    for idx in 0..=STATUS_PANEL_TASK_LIMIT {
+        let tool_use_id = format!("toolu_bg_{idx}");
+        events.push_status_events(
+            channel_id,
+            status_events_from_tool_use_with_id_for_footer_mode(
+                "Bash",
+                &json!({
+                    "command": format!("codex exec {idx}"),
+                    "description": format!("background bash task {idx}"),
+                    "run_in_background": true
+                })
+                .to_string(),
+                Some(&tool_use_id),
+                true,
+            ),
+        );
+    }
+
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+    let status_entry = events
+        .status_by_channel
+        .get(&channel_id)
+        .expect("status panel state");
+    let guard = status_entry
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    assert_eq!(guard.tasks.len(), STATUS_PANEL_TASK_LIMIT);
+    assert_eq!(
+        guard.tasks.first().and_then(|slot| slot.summary.as_deref()),
+        Some("background bash task 1")
+    );
+    assert_eq!(
+        guard.tasks.last().and_then(|slot| slot.summary.as_deref()),
+        Some("background bash task 10")
+    );
+    assert!(!rendered.contains("background bash task 0"));
+    assert!(rendered.contains("background bash task 1"));
+    assert!(rendered.contains("background bash task 10"));
+}
+
+#[test]
 fn completion_footer_budget_clamps_task_section_but_keeps_context_line() {
     let events = PlaceholderLiveEvents::default();
     let channel_id = ChannelId::new(192);

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -593,7 +593,7 @@ mod tests {
         channel_id: ChannelId,
     ) -> std::sync::Arc<super::super::SharedData> {
         let shared = super::super::make_shared_data_for_tests();
-        shared.placeholder_live_events.push_status_event(
+        shared.ui.placeholder_live_events.push_status_event(
             channel_id,
             StatusEvent::BackgroundTaskStart {
                 name: "Bash".to_string(),

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -39,7 +39,7 @@ fn completion_footer_registry() -> &'static Mutex<HashMap<u64, RegisteredComplet
     REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-pub(super) fn enabled() -> bool {
+pub(in crate::services::discord) fn enabled() -> bool {
     static CACHED: OnceLock<bool> = OnceLock::new();
     *CACHED.get_or_init(|| {
         let raw = std::env::var("AGENTDESK_SINGLE_MESSAGE_PANEL").ok();
@@ -589,6 +589,21 @@ mod tests {
         shared
     }
 
+    fn push_unfinished_background_task(
+        channel_id: ChannelId,
+    ) -> std::sync::Arc<super::super::SharedData> {
+        let shared = super::super::make_shared_data_for_tests();
+        shared.placeholder_live_events.push_status_event(
+            channel_id,
+            StatusEvent::BackgroundTaskStart {
+                name: "Bash".to_string(),
+                summary: "Run background codex".to_string(),
+                tool_use_id: format!("tool-{}", channel_id.get()),
+            },
+        );
+        shared
+    }
+
     #[test]
     fn single_message_panel_flag_defaults_off_when_unset() {
         assert!(!super::parse_single_message_panel_flag(None));
@@ -903,6 +918,39 @@ mod tests {
 
         assert!(edit.remove_after_edit);
         assert!(edit.text.contains("Subagents\n└ "));
+        assert!(edit.text.contains('…'));
+        assert!(!edit.text.contains('⠸'));
+        assert!(!edit.text.contains('✓'));
+
+        super::completion_footer_record_edit_result(channel_id, edit.remove_after_edit, true);
+        assert!(!super::completion_footer_has_registered_target(channel_id));
+    }
+
+    #[test]
+    fn completion_footer_ttl_freezes_unfinished_background_bash_task() {
+        let channel_id = ChannelId::new(3_089_011);
+        super::completion_footer_forget_registered_target(channel_id);
+        let shared = push_unfinished_background_task(channel_id);
+        let now = 1_800_000_000;
+        super::register_completion_footer_target(
+            channel_id,
+            MessageId::new(3_089_111),
+            &ProviderKind::Claude,
+            now - super::COMPLETION_FOOTER_MAX_IDLE_ANIMATION_SECS - 1,
+            "Final answer",
+            true,
+        );
+
+        let edit = super::completion_footer_edit_for_registered_target_at(
+            shared.as_ref(),
+            channel_id,
+            "⠸",
+            now,
+        )
+        .expect("expired unfinished background Bash footer should render one freeze edit");
+
+        assert!(edit.remove_after_edit);
+        assert!(edit.text.contains("Tasks\n└ Bash Run background codex"));
         assert!(edit.text.contains('…'));
         assert!(!edit.text.contains('⠸'));
         assert!(!edit.text.contains('✓'));

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -3204,12 +3204,7 @@ pub(super) fn spawn_turn_bridge(
                                 },
                             );
                         }
-                        StreamMessage::TaskNotification {
-                            summary,
-                            status,
-                            kind,
-                            ..
-                        } => {
+                        StreamMessage::TaskNotification { tool_use_id, summary, status, kind, .. } => {
                             inflight_state.task_notification_kind =
                                 merge_task_notification_kind(inflight_state.task_notification_kind, kind);
                             state_dirty = true;
@@ -3225,10 +3220,11 @@ pub(super) fn spawn_turn_bridge(
                             status_panel_dirty |= record_status_panel_events(
                                 shared_owned.as_ref(),
                                 channel_id,
-                                super::placeholder_live_events::status_events_from_task_notification(
+                                super::placeholder_live_events::status_events_from_task_notification_with_tool_use_id(
                                     kind.as_str(),
                                     &status,
                                     &summary,
+                                    tool_use_id.as_deref(),
                                 ),
                             );
                             if single_message_panel_footer_mode {

--- a/src/services/session_backend.rs
+++ b/src/services/session_backend.rs
@@ -530,6 +530,10 @@ pub fn parse_stream_message(json: &Value) -> Option<StreamMessage> {
     parse_stream_message_with_state(json, &state)
 }
 
+fn json_str<'a>(json: &'a Value, key: &str) -> Option<&'a str> {
+    json.get(key).and_then(Value::as_str)
+}
+
 pub(crate) fn parse_stream_message_with_state(
     json: &Value,
     state: &StreamLineState,
@@ -548,21 +552,15 @@ pub(crate) fn parse_stream_message_with_state(
                     })
                 }
                 "task_notification" => Some(StreamMessage::TaskNotification {
-                    task_id: json
-                        .get("task_id")
-                        .and_then(|value| value.as_str())
-                        .unwrap_or("")
-                        .to_string(),
-                    status: json
-                        .get("status")
-                        .and_then(|value| value.as_str())
-                        .unwrap_or("")
-                        .to_string(),
-                    summary: json
-                        .get("summary")
-                        .and_then(|value| value.as_str())
-                        .unwrap_or("")
-                        .to_string(),
+                    task_id: json_str(json, "task_id").unwrap_or("").to_string(),
+                    tool_use_id: ["tool_use_id", "tool-use-id", "toolUseId"]
+                        .into_iter()
+                        .find_map(|key| json_str(json, key))
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                        .map(str::to_string),
+                    status: json_str(json, "status").unwrap_or("").to_string(),
+                    summary: json_str(json, "summary").unwrap_or("").to_string(),
                     kind: classify_task_notification_kind(json, state),
                 }),
                 "stop_hook_summary" => Some(StreamMessage::Done {


### PR DESCRIPTION
EPIC #3089 — user-reported gap (2026-06-12): background Bash commands (long codex delegations etc.) were invisible on the live panel and completion footer; only Task/Agent subagents had slots.

## What (footer-mode gated; flag-off untouched)
- `Bash` tool_use with `run_in_background:true` → Tasks-section slot (description label, tool_use_id stored, background-marked).
- Launch-ack tool_result does NOT finalize (live path + record-reconstruction fixtures — the #3198/#3365/#3368 guard family extended to bash acks).
- Finalize ONLY on the background task-notification with EXACT tool_use_id match (session_backend threads the id mechanically); id-less notifications are ignored (completion-footer TTL freeze covers the tail).
- Renders in both the live footer and the completion footer; PR #3378's TTL/eviction/takeover safety applies via the shared refresh path; 600B budget + trim caps respected.
- Branch carries a merge of main (SharedData S4) with one mechanical `.ui.` routing fix in a test helper.

## Verification
- fmt/clippy clean; placeholder_live_events ×3, single_message, tmux, turn_bridge, session_backend suites green post-merge; audit + agent-maintenance docs clean on committed HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)