### PR TITLE
refactor(#3038): SharedData S5 — extract RuntimeHttpCache cluster (cluster G)

### DIFF
--- a/docs/agent-maintenance/multinode-transition.md
+++ b/docs/agent-maintenance/multinode-transition.md
@@ -720,3 +720,13 @@
   **Worker-local**: no PG lease, no cross-node reads, no leader-only side
   effect. No new multinode ownership, singleton, or lease assumption is
   introduced.
+- #3038 S5 (SharedData cluster G — `RuntimeHttpCache`): pure field relocation;
+  `cached_serenity_ctx` / `cached_bot_token` and the
+  `serenity_http_or_token_fallback()` accessor moved verbatim from
+  `discord/mod.rs` into `shared_state.rs::RuntimeHttpCache`, with call sites
+  (including `runtime_bootstrap*` init and 2 single-token sites in the frozen
+  `turn_bridge/mod.rs`) rerouted `shared.cached_*` → `shared.http.cached_*`.
+  The leader-vs-standby semantics of the accessor (gateway ctx preferred,
+  token-built Http fallback on standby nodes) are byte-identical and stay
+  process-local. No new multinode ownership, singleton, or lease assumption
+  is introduced.

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -84,7 +84,10 @@
 # #3038 S4: lowered 4970 -> 4967 (-3) as the cluster-F field block (5
 # live-placeholder/status-panel fields) moved into `shared_state::PlaceholderState`.
 # Locks in the shrink win (ratchet down only).
-"src/services/discord/mod.rs" = 4967
+# #3038 S5: lowered 4967 -> 4944 (-23) as the cluster-G runtime HTTP cache
+# fields plus the `serenity_http_or_token_fallback` accessor moved into
+# `shared_state::RuntimeHttpCache`. Locks in the shrink win (ratchet down only).
+"src/services/discord/mod.rs" = 4944
 # #3305: the local-only pass-through lifecycle-skip (kind hoist + note-only return
 # branch + idle-loop skip) is offset by comment dedup in the same root, lowering the
 # frozen baseline 5438 -> 5429 (-9). Locks in the shrink win (#3028 ratchet).

--- a/src/services/discord/commands/control.rs
+++ b/src/services/discord/commands/control.rs
@@ -683,7 +683,7 @@ async fn persist_fast_mode_reset_marker(
     provider: &ProviderKind,
     pending: bool,
 ) {
-    let Some(token) = shared.cached_bot_token.get() else {
+    let Some(token) = shared.http.cached_bot_token.get() else {
         return;
     };
 
@@ -713,7 +713,7 @@ async fn persist_codex_goals_reset_marker(
     channel_id: serenity::ChannelId,
     pending: bool,
 ) {
-    let Some(token) = shared.cached_bot_token.get() else {
+    let Some(token) = shared.http.cached_bot_token.get() else {
         return;
     };
 
@@ -735,7 +735,7 @@ async fn clear_all_fast_mode_reset_markers(
     shared: &Arc<SharedData>,
     channel_id: serenity::ChannelId,
 ) {
-    let Some(token) = shared.cached_bot_token.get() else {
+    let Some(token) = shared.http.cached_bot_token.get() else {
         return;
     };
 

--- a/src/services/discord/health/headless_turn.rs
+++ b/src/services/discord/health/headless_turn.rs
@@ -108,12 +108,17 @@ pub async fn start_headless_agent_turn_in_dm(
     let (_, shared) = resolve_direct_meeting_runtime(registry, owner_channel_id, &owner_provider)
         .await
         .map_err(router::HeadlessTurnStartError::Internal)?;
-    let ctx = shared.cached_serenity_ctx.get().cloned().ok_or_else(|| {
-        router::HeadlessTurnStartError::Internal(format!(
-            "provider runtime is not ready for channel {}",
-            owner_channel_id.get()
-        ))
-    })?;
+    let ctx = shared
+        .http
+        .cached_serenity_ctx
+        .get()
+        .cloned()
+        .ok_or_else(|| {
+            router::HeadlessTurnStartError::Internal(format!(
+                "provider runtime is not ready for channel {}",
+                owner_channel_id.get()
+            ))
+        })?;
     let dm_channel = serenity::UserId::new(dm_user_id)
         .create_dm_channel(&ctx.http)
         .await
@@ -151,12 +156,17 @@ pub async fn reserve_headless_agent_turn_in_dm(
     let (_, shared) = resolve_direct_meeting_runtime(registry, owner_channel_id, owner_provider)
         .await
         .map_err(router::HeadlessTurnStartError::Internal)?;
-    let ctx = shared.cached_serenity_ctx.get().cloned().ok_or_else(|| {
-        router::HeadlessTurnStartError::Internal(format!(
-            "provider runtime is not ready for channel {}",
-            owner_channel_id.get()
-        ))
-    })?;
+    let ctx = shared
+        .http
+        .cached_serenity_ctx
+        .get()
+        .cloned()
+        .ok_or_else(|| {
+            router::HeadlessTurnStartError::Internal(format!(
+                "provider runtime is not ready for channel {}",
+                owner_channel_id.get()
+            ))
+        })?;
     let dm_channel = serenity::UserId::new(dm_user_id)
         .create_dm_channel(&ctx.http)
         .await
@@ -229,13 +239,19 @@ async fn start_reserved_headless_agent_turn_with_shared(
         )));
     }
 
-    let ctx = shared.cached_serenity_ctx.get().cloned().ok_or_else(|| {
-        router::HeadlessTurnStartError::Internal(format!(
-            "provider runtime is not ready for channel {}",
-            channel_id.get()
-        ))
-    })?;
+    let ctx = shared
+        .http
+        .cached_serenity_ctx
+        .get()
+        .cloned()
+        .ok_or_else(|| {
+            router::HeadlessTurnStartError::Internal(format!(
+                "provider runtime is not ready for channel {}",
+                channel_id.get()
+            ))
+        })?;
     let token = shared
+        .http
         .cached_bot_token
         .get()
         .cloned()

--- a/src/services/discord/health/runtime_resolve.rs
+++ b/src/services/discord/health/runtime_resolve.rs
@@ -159,7 +159,7 @@ pub(super) async fn resolve_direct_meeting_runtime(
     for (index, shared) in &shared_candidates {
         let settings = shared.settings.read().await.clone();
         let explicit_channel_match = settings.allowed_channel_ids.contains(&channel_id.get());
-        let live_channel_match = match shared.cached_serenity_ctx.get() {
+        let live_channel_match = match shared.http.cached_serenity_ctx.get() {
             Some(ctx) => {
                 crate::services::discord::provider_handles_channel(
                     ctx,
@@ -197,6 +197,7 @@ pub(super) async fn resolve_direct_meeting_runtime(
                 .to_string()
             })?;
         let http = shared
+            .http
             .cached_serenity_ctx
             .get()
             .map(|ctx| ctx.http.clone())
@@ -216,7 +217,7 @@ pub(super) async fn resolve_direct_meeting_runtime(
 
     if shared_candidates.len() == 1 {
         let (_, shared) = shared_candidates[0].clone();
-        if let Some(ctx) = shared.cached_serenity_ctx.get() {
+        if let Some(ctx) = shared.http.cached_serenity_ctx.get() {
             return Ok((ctx.http.clone(), shared));
         }
         let http = resolve_bot_http(registry, provider_name)
@@ -264,7 +265,7 @@ pub(super) async fn resolve_direct_meeting_shared(
     for (index, shared) in &shared_candidates {
         let settings = shared.settings.read().await.clone();
         let explicit_channel_match = settings.allowed_channel_ids.contains(&channel_id.get());
-        let live_channel_match = match shared.cached_serenity_ctx.get() {
+        let live_channel_match = match shared.http.cached_serenity_ctx.get() {
             Some(ctx) => {
                 crate::services::discord::provider_handles_channel(
                     ctx,

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -120,6 +120,7 @@ pub(crate) use session_relay_sink::run_session_bound_discord_relay_supervisor;
 // declarations/constructors keep the S1/S2/S3 unqualified surface.
 pub(in crate::services::discord) use shared_state::PlaceholderState;
 pub(in crate::services::discord) use shared_state::QueuedPlaceholderState;
+pub(in crate::services::discord) use shared_state::RuntimeHttpCache;
 // #3038 S2: the cluster-D members were `pub(super)` on `SharedData` (visible up
 // to `crate::services`), so the group type is re-exported with that same scope.
 pub(in crate::services) use shared_state::SessionOverrideState;
@@ -2320,10 +2321,12 @@ pub(crate) struct SharedData {
     pub(super) turn_start_times: dashmap::DashMap<ChannelId, std::time::Instant>,
     /// Per-channel known speakers collected lazily from incoming messages.
     pub(super) channel_rosters: dashmap::DashMap<ChannelId, Vec<UserRecord>>,
-    /// Cached serenity context for deferred queue drain (set once during ready event).
-    pub(super) cached_serenity_ctx: tokio::sync::OnceCell<serenity::Context>,
-    /// Cached bot token for deferred queue drain.
-    pub(super) cached_bot_token: tokio::sync::OnceCell<String>,
+    /// #3038 cluster G — cached Discord HTTP runtime state: the gateway
+    /// serenity context plus the bot-token fallback for standby REST sends.
+    /// Field docs live on `shared_state::RuntimeHttpCache`; call sites use
+    /// `shared.http.*` for direct cache reads and keep
+    /// `shared.serenity_http_or_token_fallback()` for the accessor.
+    pub(in crate::services::discord) http: RuntimeHttpCache,
     /// SHA-256 hash of the bot token — used to namespace the pending-queue directory
     /// so that multiple bots sharing the same runtime root cannot steal each other's queues.
     pub(super) token_hash: String,
@@ -2358,34 +2361,6 @@ pub(crate) struct SharedData {
 impl SharedData {
     pub(super) fn has_runtime_storage(&self) -> bool {
         self.pg_pool.is_some()
-    }
-
-    /// Phase 5.2 of intake-node-routing (issue #2009): return an `Arc<Http>`
-    /// that the response path (tmux watcher, placeholder updates, message
-    /// edits) can use to call Discord. On the leader the gateway-attached
-    /// runtime caches `cached_serenity_ctx`, and `ctx.http` is preferred so
-    /// the Http instance shares the same application_id and connection
-    /// pool the gateway already owns. On cluster-standby nodes the
-    /// OnceCell is empty (no gateway runtime ever ran), so we fall back to
-    /// a freshly constructed `serenity::http::Http` built from the bot
-    /// token cached in `cached_bot_token`. Returns `None` only when both
-    /// caches are empty — that means the runtime never reached the
-    /// "token known" milestone in `run_bot()`, which today only happens
-    /// before `bot_settings` finishes loading.
-    ///
-    /// Callers should treat `None` as a hard failure: they cannot post
-    /// to Discord without an Http instance. The current call sites
-    /// either propagate the failure (skip the work + warn) or have
-    /// their own panic-on-None invariant tied to `cached_bot_token`
-    /// being populated at `run_bot()` startup.
-    pub(super) fn serenity_http_or_token_fallback(&self) -> Option<Arc<serenity::http::Http>> {
-        if let Some(ctx) = self.cached_serenity_ctx.get() {
-            return Some(ctx.http.clone());
-        }
-        if let Some(token) = self.cached_bot_token.get() {
-            return Some(Arc::new(serenity::http::Http::new(token)));
-        }
-        None
     }
 
     fn mailbox(&self, channel_id: ChannelId) -> ChannelMailboxHandle {
@@ -2635,8 +2610,10 @@ pub(super) fn make_shared_data_for_tests_with_storage(
         catch_up_retry_pending: dashmap::DashMap::new(),
         turn_start_times: dashmap::DashMap::new(),
         channel_rosters: dashmap::DashMap::new(),
-        cached_serenity_ctx: tokio::sync::OnceCell::new(),
-        cached_bot_token: tokio::sync::OnceCell::new(),
+        http: RuntimeHttpCache {
+            cached_serenity_ctx: tokio::sync::OnceCell::new(),
+            cached_bot_token: tokio::sync::OnceCell::new(),
+        },
         token_hash: "test-token-hash".to_string(),
         provider: ProviderKind::Claude,
         api_port: 9,

--- a/src/services/discord/queue_io.rs
+++ b/src/services/discord/queue_io.rs
@@ -115,8 +115,8 @@ fn schedule_deferred_idle_queue_kickoff_inner(
         let mut consecutive_zero_start_drains = 0usize;
         for attempt in 1..=DEFERRED_IDLE_QUEUE_KICKOFF_MAX_ATTEMPTS {
             if let (Some(ctx), Some(tok)) = (
-                shared.cached_serenity_ctx.get(),
-                shared.cached_bot_token.get(),
+                shared.http.cached_serenity_ctx.get(),
+                shared.http.cached_bot_token.get(),
             ) {
                 let ts = chrono::Local::now().format("%H:%M:%S");
                 tracing::info!(

--- a/src/services/discord/runtime_bootstrap.rs
+++ b/src/services/discord/runtime_bootstrap.rs
@@ -195,7 +195,7 @@ pub(crate) async fn run_bot(token: &str, provider: ProviderKind, context: RunBot
     // setup callback — that second `set` is a no-op (`OnceCell::set`
     // returns Err on already-set), preserving the leader's existing
     // semantics.
-    let _ = shared.cached_bot_token.set(token.to_string());
+    let _ = shared.http.cached_bot_token.set(token.to_string());
 
     let voice_receiver =
         run_bot_init_voice_workers(&voice_config, &voice_barge_in, &shared, &provider);

--- a/src/services/discord/runtime_bootstrap/framework_setup.rs
+++ b/src/services/discord/runtime_bootstrap/framework_setup.rs
@@ -43,8 +43,9 @@ pub(super) async fn run_bot_framework_setup(
     shared_for_migrate
         .bot_connected
         .store(true, std::sync::atomic::Ordering::SeqCst);
-    let _ = shared_for_migrate.cached_serenity_ctx.set(ctx.clone());
+    let _ = shared_for_migrate.http.cached_serenity_ctx.set(ctx.clone());
     let _ = shared_for_migrate
+        .http
         .cached_bot_token
         .set(token_for_ready.clone());
     super::drain_pending_queue_exit_placeholder_clears(&shared_for_migrate).await;

--- a/src/services/discord/runtime_bootstrap/shared_data.rs
+++ b/src/services/discord/runtime_bootstrap/shared_data.rs
@@ -164,8 +164,10 @@ pub(super) fn run_bot_build_shared_data(
         catch_up_retry_pending: dashmap::DashMap::new(),
         turn_start_times: dashmap::DashMap::new(),
         channel_rosters: dashmap::DashMap::new(),
-        cached_serenity_ctx: tokio::sync::OnceCell::new(),
-        cached_bot_token: tokio::sync::OnceCell::new(),
+        http: RuntimeHttpCache {
+            cached_serenity_ctx: tokio::sync::OnceCell::new(),
+            cached_bot_token: tokio::sync::OnceCell::new(),
+        },
         token_hash: token_hash.to_string(),
         provider: provider.clone(),
         api_port,

--- a/src/services/discord/shared_state.rs
+++ b/src/services/discord/shared_state.rs
@@ -1,4 +1,4 @@
-//! #3038 S1/S2/S3/S4 — extracted field clusters of [`SharedData`].
+//! #3038 S1/S2/S3/S4/S5 — extracted field clusters of [`SharedData`].
 //!
 //! This module hosts named sub-structs that group cohesive `SharedData` fields
 //! together with the inherent `impl SharedData` methods that exclusively own
@@ -55,6 +55,50 @@ pub(in crate::services::discord) struct PlaceholderState {
         Arc<placeholder_live_events::PlaceholderLiveEvents>,
     pub(in crate::services::discord) placeholder_live_events_enabled: bool,
     pub(in crate::services::discord) status_panel_v2_enabled: bool,
+}
+
+/// #3038 cluster G — runtime Discord HTTP cache.
+///
+/// Groups the gateway serenity context and bot-token fallback used by
+/// non-gateway Discord REST paths. Field declarations, docs, and types moved
+/// verbatim from `discord/mod.rs`; direct readers all stay inside `discord`.
+pub(in crate::services::discord) struct RuntimeHttpCache {
+    /// Cached serenity context for deferred queue drain (set once during ready event).
+    pub(in crate::services::discord) cached_serenity_ctx: tokio::sync::OnceCell<serenity::Context>,
+    /// Cached bot token for deferred queue drain.
+    pub(in crate::services::discord) cached_bot_token: tokio::sync::OnceCell<String>,
+}
+
+impl SharedData {
+    /// Phase 5.2 of intake-node-routing (issue #2009): return an `Arc<Http>`
+    /// that the response path (tmux watcher, placeholder updates, message
+    /// edits) can use to call Discord. On the leader the gateway-attached
+    /// runtime caches `cached_serenity_ctx`, and `ctx.http` is preferred so
+    /// the Http instance shares the same application_id and connection
+    /// pool the gateway already owns. On cluster-standby nodes the
+    /// OnceCell is empty (no gateway runtime ever ran), so we fall back to
+    /// a freshly constructed `serenity::http::Http` built from the bot
+    /// token cached in `cached_bot_token`. Returns `None` only when both
+    /// caches are empty — that means the runtime never reached the
+    /// "token known" milestone in `run_bot()`, which today only happens
+    /// before `bot_settings` finishes loading.
+    ///
+    /// Callers should treat `None` as a hard failure: they cannot post
+    /// to Discord without an Http instance. The current call sites
+    /// either propagate the failure (skip the work + warn) or have
+    /// their own panic-on-None invariant tied to `cached_bot_token`
+    /// being populated at `run_bot()` startup.
+    pub(in crate::services::discord) fn serenity_http_or_token_fallback(
+        &self,
+    ) -> Option<Arc<serenity::http::Http>> {
+        if let Some(ctx) = self.http.cached_serenity_ctx.get() {
+            return Some(ctx.http.clone());
+        }
+        if let Some(token) = self.http.cached_bot_token.get() {
+            return Some(Arc::new(serenity::http::Http::new(token)));
+        }
+        None
+    }
 }
 
 /// #3038 cluster C — the queued-placeholder handoff state.

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -1797,7 +1797,7 @@ fn handle_watcher_runtime_handoff(
     if watcher_claimed {
         #[cfg(unix)]
         {
-            let on_standby = shared_owned.cached_serenity_ctx.get().is_none();
+            let on_standby = shared_owned.http.cached_serenity_ctx.get().is_none();
             if on_standby {
                 let ts = chrono::Local::now().format("%H:%M:%S");
                 tracing::info!(
@@ -3668,7 +3668,7 @@ pub(super) fn spawn_turn_bridge(
                                     // `cached_serenity_ctx` is set, spawn the
                                     // watcher as before so streaming partial
                                     // output continues to work.
-                                    let on_standby = shared_owned.cached_serenity_ctx.get().is_none();
+                                    let on_standby = shared_owned.http.cached_serenity_ctx.get().is_none();
                                     if on_standby {
                                         // Phase 5.3 of intake-node-routing (issue #2011):
                                         // skip the watcher entirely on standby and

--- a/src/services/discord/voice_barge_in.rs
+++ b/src/services/discord/voice_barge_in.rs
@@ -3620,7 +3620,7 @@ impl VoiceBargeInRuntime {
             );
             return;
         };
-        let Some(ctx) = shared.cached_serenity_ctx.get() else {
+        let Some(ctx) = shared.http.cached_serenity_ctx.get() else {
             crate::voice::metrics::discard(channel_id.get());
             tracing::debug!(
                 channel_id = channel_id.get(),
@@ -4114,8 +4114,10 @@ mod tests {
             catch_up_retry_pending: dashmap::DashMap::new(),
             turn_start_times: dashmap::DashMap::new(),
             channel_rosters: dashmap::DashMap::new(),
-            cached_serenity_ctx: tokio::sync::OnceCell::new(),
-            cached_bot_token: tokio::sync::OnceCell::new(),
+            http: super::super::RuntimeHttpCache {
+                cached_serenity_ctx: tokio::sync::OnceCell::new(),
+                cached_bot_token: tokio::sync::OnceCell::new(),
+            },
             token_hash: "voice-handoff-test-token-hash".to_string(),
             provider: ProviderKind::Claude,
             api_port: 9,

--- a/src/services/discord/voice_barge_in/progress_playback.rs
+++ b/src/services/discord/voice_barge_in/progress_playback.rs
@@ -360,7 +360,7 @@ impl VoiceBargeInRuntime {
             );
             return;
         };
-        let Some(ctx) = shared.cached_serenity_ctx.get() else {
+        let Some(ctx) = shared.http.cached_serenity_ctx.get() else {
             tracing::debug!(
                 channel_id = channel_id.get(),
                 guild_id = guild_id.get(),


### PR DESCRIPTION
EPIC #3038 god-object 트랙, SharedData S5 (S1 QueuedPlaceholderState → S2 SessionOverrideState → S3 RestartLifecycle → S4 PlaceholderState에 이은 5번째 클러스터).

## 내용
- **cluster G `RuntimeHttpCache`**: `cached_serenity_ctx` + `cached_bot_token` 2필드와 유일한 공동 리더 `serenity_http_or_token_fallback()`(#2009 phase 5.2)를 shared_state.rs로 verbatim 이동. 응집 근거 = 이 접근자가 정확히 이 두 필드를 우선순위로 소비(leader: gateway ctx, standby: token-built Http).
- 콜사이트는 기계적 단일 토큰 라우팅(`shared.cached_*` → `shared.http.cached_*`). #3016 동결 파일 turn_bridge/mod.rs는 2사이트 word-diff 순수 치환 확인.
- main 머지 시 voice S3(#3387)와 교차: S5가 치환한 1줄이 S3에서 `final_result_playback.rs`로 이사 → main 삭제 채택 + 이사한 사본에 동일 치환 적용 (`final_result_playback.rs:137`).
- 커밋 본문에 S5 이후 잔여 미그룹 필드 전수 인벤토리 + 보류 사유 (S4의 3개 소유권 경계 보류 유지).

## 게이트
fmt / check / clippy -D warnings / discord 1619 passed / voice 277 passed / audit ratchet green (mod.rs 4967↓) / agent-maintenance docs passed — 베이스와 머지 후 각각 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)