### PR TITLE
refactor(#3038): VoiceBargeInRuntime S5 — extract live-cut playback cluster

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -524,6 +524,7 @@ src/
 │   │   │   └── cleanup.rs
 │   │   ├── voice_barge_in/
 │   │   │   ├── final_result_playback.rs
+│   │   │   ├── live_cut_playback.rs
 │   │   │   ├── progress_playback.rs
 │   │   │   ├── routing.rs
 │   │   │   └── stt.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -802,7 +802,7 @@
     was removed from `giant_file_registry.toml`; #3038 S5 locked the final
     root ratchet at 274 production lines).
   - `src/services/discord/session_runtime.rs` (1753 lines).
-  - `src/services/discord/voice_barge_in.rs` (3332 lines after #3038
+  - `src/services/discord/voice_barge_in.rs` (3217 lines after #3038
     VoiceBargeInRuntime S1 moved the STT method cluster to
     `src/services/discord/voice_barge_in/stt.rs` (314 production lines) and
     S2 moved the progress playback method cluster to
@@ -810,7 +810,10 @@
     lines), and S3 moved the final-result playback cluster to
     `src/services/discord/voice_barge_in/final_result_playback.rs` (230
     production lines), and S4 moved the routing-resolution cluster to
-    `src/services/discord/voice_barge_in/routing.rs` (383 production lines);
+    `src/services/discord/voice_barge_in/routing.rs` (383 production lines),
+    and S5 moved the live-cut playback cluster to
+    `src/services/discord/voice_barge_in/live_cut_playback.rs` (120 production
+    lines);
     voice STT/TTS, lobby routing, progress mirroring, and barge-in
     orchestration surface; tracked decompose target — see
     `giant-file-registry.md` (owner `voice-runtime`, deadline 2026-08-31,

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -106,7 +106,10 @@
 # #3038 VoiceBargeInRuntime S4: lowered 3710 -> 3332 (-378) as the routing
 # resolution method cluster moved to `voice_barge_in/routing.rs` (383 prod LoC,
 # below the giant threshold). Locks in the shrink win.
-"src/services/discord/voice_barge_in.rs" = 3332
+# #3038 VoiceBargeInRuntime S5: lowered 3332 -> 3217 (-115) as the live-cut
+# playback method cluster moved to `voice_barge_in/live_cut_playback.rs` (120
+# prod LoC, below the giant threshold). Locks in the shrink win.
+"src/services/discord/voice_barge_in.rs" = 3217
 # #3248: +60 for the gap-1 deploy-survivable-relay fix —
 # `reseed_watcher_owned_finalizer_ledger` + two guarded reattach call-sites that
 # re-register the watcher-owned turn in the post-restart finalizer ledger (a P1

--- a/src/services/discord/voice_barge_in.rs
+++ b/src/services/discord/voice_barge_in.rs
@@ -47,6 +47,8 @@ use super::{SharedData, http, mailbox_has_active_turn, rate_limit_wait, settings
 
 #[path = "voice_barge_in/final_result_playback.rs"]
 mod final_result_playback;
+#[path = "voice_barge_in/live_cut_playback.rs"]
+mod live_cut_playback;
 #[path = "voice_barge_in/progress_playback.rs"]
 mod progress_playback;
 #[path = "voice_barge_in/routing.rs"]
@@ -1768,96 +1770,6 @@ impl VoiceBargeInRuntime {
         Some(sensitivity)
     }
 
-    #[allow(dead_code)] // #3034: test-only playback-reset; prod uses reset_after_playback_start_with_owner
-    pub(in crate::services::discord) fn reset_after_playback_start<P>(
-        &self,
-        channel_id: ChannelId,
-        player: Arc<P>,
-        cancellation: CancellationToken,
-    ) where
-        P: BargeInPlayerStop + 'static,
-    {
-        self.reset_after_playback_start_with_owner(channel_id, player, cancellation, None);
-    }
-
-    fn reset_after_playback_start_with_owner<P>(
-        &self,
-        channel_id: ChannelId,
-        player: Arc<P>,
-        cancellation: CancellationToken,
-        owner: Option<u64>,
-    ) where
-        P: BargeInPlayerStop + 'static,
-    {
-        if !self.barge_in_enabled {
-            return;
-        }
-
-        let sensitivity = self.current_sensitivity();
-        let monitor = self.monitor_for_channel(channel_id, sensitivity);
-        {
-            let mut monitor = lock_monitor(&monitor);
-            monitor.set_sensitivity(sensitivity);
-            monitor.reset_after_playback_start();
-        }
-
-        let player: Arc<dyn BargeInPlayerStop> = player;
-        self.playbacks.insert(
-            channel_id.get(),
-            Arc::new(LivePlaybackSession {
-                player,
-                cancellation,
-                owner,
-            }),
-        );
-    }
-
-    #[allow(dead_code)] // #3034: test-only playback clear; prod uses clear_playback_if_owner
-    pub(in crate::services::discord) fn clear_playback(&self, channel_id: ChannelId) {
-        self.playbacks.remove(&channel_id.get());
-    }
-
-    fn clear_playback_if_owner(&self, channel_id: ChannelId, owner: u64) {
-        self.playbacks
-            .remove_if(&channel_id.get(), |_, session| session.owner == Some(owner));
-    }
-
-    pub(in crate::services::discord) fn observe_live_pcm_i16(
-        &self,
-        channel_id: ChannelId,
-        samples: &[i16],
-    ) -> Option<LiveBargeInCut> {
-        if !self.barge_in_enabled || samples.is_empty() {
-            return None;
-        }
-
-        let playback = self
-            .playbacks
-            .get(&channel_id.get())
-            .map(|entry| entry.value().clone())?;
-        let sensitivity = self.current_sensitivity();
-        let monitor = self.monitor_for_channel(channel_id, sensitivity);
-        let mut monitor = lock_monitor(&monitor);
-        monitor.set_sensitivity(sensitivity);
-
-        let pcm = pcm_i16_to_le_bytes(samples);
-        match monitor.observe_pcm(&pcm, playback.player.as_ref(), &playback.cancellation) {
-            Ok(Some(cut)) => {
-                self.playbacks.remove(&channel_id.get());
-                Some(cut)
-            }
-            Ok(None) => None,
-            Err(error) => {
-                tracing::warn!(
-                    error = %error,
-                    channel_id = channel_id.get(),
-                    "voice live barge-in stop failed"
-                );
-                None
-            }
-        }
-    }
-
     pub(in crate::services::discord) async fn handle_processing_transcript(
         &self,
         shared: &Arc<SharedData>,
@@ -3119,33 +3031,6 @@ impl VoiceBargeInRuntime {
             .entry(channel_id.get())
             .or_insert_with(|| Arc::new(Mutex::new(DeferredBargeInBuffer::new())))
             .clone()
-    }
-
-    fn monitor_for_channel(
-        &self,
-        channel_id: ChannelId,
-        sensitivity: BargeInSensitivity,
-    ) -> Arc<std::sync::Mutex<LiveBargeInMonitor>> {
-        self.monitors
-            .entry(channel_id.get())
-            .or_insert_with(|| {
-                Arc::new(std::sync::Mutex::new(LiveBargeInMonitor::new(sensitivity)))
-            })
-            .clone()
-    }
-
-    fn current_sensitivity(&self) -> BargeInSensitivity {
-        // F18 (#2046): try_read 실패 시 boot-time default 가 아닌 가장 최근에
-        // 설정된 sensitivity 를 반환하도록 atomic mirror 로 폴백한다. TTL reset
-        // 이 일어나는 짧은 윈도우라도 사용자가 설정한 Conservative 가 잠깐
-        // Normal 로 평가되는 회귀를 막는다.
-        self.sensitivity.current()
-    }
-
-    fn update_existing_monitor_sensitivity(&self, sensitivity: BargeInSensitivity) {
-        for monitor in &self.monitors {
-            lock_monitor(monitor.value()).set_sensitivity(sensitivity);
-        }
     }
 }
 

--- a/src/services/discord/voice_barge_in/live_cut_playback.rs
+++ b/src/services/discord/voice_barge_in/live_cut_playback.rs
@@ -1,0 +1,120 @@
+use super::*;
+
+impl VoiceBargeInRuntime {
+    #[allow(dead_code)] // #3034: test-only playback-reset; prod uses reset_after_playback_start_with_owner
+    pub(in crate::services::discord) fn reset_after_playback_start<P>(
+        &self,
+        channel_id: ChannelId,
+        player: Arc<P>,
+        cancellation: CancellationToken,
+    ) where
+        P: BargeInPlayerStop + 'static,
+    {
+        self.reset_after_playback_start_with_owner(channel_id, player, cancellation, None);
+    }
+
+    pub(super) fn reset_after_playback_start_with_owner<P>(
+        &self,
+        channel_id: ChannelId,
+        player: Arc<P>,
+        cancellation: CancellationToken,
+        owner: Option<u64>,
+    ) where
+        P: BargeInPlayerStop + 'static,
+    {
+        if !self.barge_in_enabled {
+            return;
+        }
+
+        let sensitivity = self.current_sensitivity();
+        let monitor = self.monitor_for_channel(channel_id, sensitivity);
+        {
+            let mut monitor = lock_monitor(&monitor);
+            monitor.set_sensitivity(sensitivity);
+            monitor.reset_after_playback_start();
+        }
+
+        let player: Arc<dyn BargeInPlayerStop> = player;
+        self.playbacks.insert(
+            channel_id.get(),
+            Arc::new(LivePlaybackSession {
+                player,
+                cancellation,
+                owner,
+            }),
+        );
+    }
+
+    #[allow(dead_code)] // #3034: test-only playback clear; prod uses clear_playback_if_owner
+    pub(in crate::services::discord) fn clear_playback(&self, channel_id: ChannelId) {
+        self.playbacks.remove(&channel_id.get());
+    }
+
+    pub(super) fn clear_playback_if_owner(&self, channel_id: ChannelId, owner: u64) {
+        self.playbacks
+            .remove_if(&channel_id.get(), |_, session| session.owner == Some(owner));
+    }
+
+    pub(in crate::services::discord) fn observe_live_pcm_i16(
+        &self,
+        channel_id: ChannelId,
+        samples: &[i16],
+    ) -> Option<LiveBargeInCut> {
+        if !self.barge_in_enabled || samples.is_empty() {
+            return None;
+        }
+
+        let playback = self
+            .playbacks
+            .get(&channel_id.get())
+            .map(|entry| entry.value().clone())?;
+        let sensitivity = self.current_sensitivity();
+        let monitor = self.monitor_for_channel(channel_id, sensitivity);
+        let mut monitor = lock_monitor(&monitor);
+        monitor.set_sensitivity(sensitivity);
+
+        let pcm = pcm_i16_to_le_bytes(samples);
+        match monitor.observe_pcm(&pcm, playback.player.as_ref(), &playback.cancellation) {
+            Ok(Some(cut)) => {
+                self.playbacks.remove(&channel_id.get());
+                Some(cut)
+            }
+            Ok(None) => None,
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    channel_id = channel_id.get(),
+                    "voice live barge-in stop failed"
+                );
+                None
+            }
+        }
+    }
+
+    fn monitor_for_channel(
+        &self,
+        channel_id: ChannelId,
+        sensitivity: BargeInSensitivity,
+    ) -> Arc<std::sync::Mutex<LiveBargeInMonitor>> {
+        self.monitors
+            .entry(channel_id.get())
+            .or_insert_with(|| {
+                Arc::new(std::sync::Mutex::new(LiveBargeInMonitor::new(sensitivity)))
+            })
+            .clone()
+    }
+
+    pub(super) fn current_sensitivity(&self) -> BargeInSensitivity {
+        // F18 (#2046): try_read 실패 시 boot-time default 가 아닌 가장 최근에
+        // 설정된 sensitivity 를 반환하도록 atomic mirror 로 폴백한다. TTL reset
+        // 이 일어나는 짧은 윈도우라도 사용자가 설정한 Conservative 가 잠깐
+        // Normal 로 평가되는 회귀를 막는다.
+        self.sensitivity.current()
+    }
+
+    pub(super) fn update_existing_monitor_sensitivity(&self, sensitivity: BargeInSensitivity) {
+        for monitor in &self.monitors {
+            lock_monitor(monitor.value()).set_sensitivity(sensitivity);
+        }
+    }
+}


### PR DESCRIPTION
EPIC #3038 god-object 트랙, VoiceBargeInRuntime S5 (S1 stt → S2 progress → S3 final-result → S4 routing에 이은 5번째 슬라이스).

## 내용
- **live-cut playback 클러스터**를 `voice_barge_in/live_cut_playback.rs`(120 prod LoC) 자식 모듈로 verbatim 이동.
- ratchet: voice_barge_in.rs **3332 → 3217 (-115)**. realtime 불변식·필드 가시성 무변경.
- 구현 fable / 리뷰 codex (교차 검증, 세션 운용 규칙).

## 게이트 (독립 재검증)
fmt / check / clippy -D warnings / voice 277 passed / discord 1620 passed / audit ratchet green / docs freshness passed
codex 적대 리뷰 round 1: VERDICT CLEAN (findings 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)