### PR TITLE
refactor(#3038): VoiceBargeInRuntime S6 — extract TTS pipeline cluster

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -527,7 +527,8 @@ src/
 │   │   │   ├── live_cut_playback.rs
 │   │   │   ├── progress_playback.rs
 │   │   │   ├── routing.rs
-│   │   │   └── stt.rs
+│   │   │   ├── stt.rs
+│   │   │   └── tts_pipeline.rs
 │   │   ├── watchers/
 │   │   │   ├── lifecycle.rs
 │   │   │   └── lifecycle_decision.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -802,7 +802,7 @@
     was removed from `giant_file_registry.toml`; #3038 S5 locked the final
     root ratchet at 274 production lines).
   - `src/services/discord/session_runtime.rs` (1753 lines).
-  - `src/services/discord/voice_barge_in.rs` (3217 lines after #3038
+  - `src/services/discord/voice_barge_in.rs` (3136 lines after #3038
     VoiceBargeInRuntime S1 moved the STT method cluster to
     `src/services/discord/voice_barge_in/stt.rs` (314 production lines) and
     S2 moved the progress playback method cluster to
@@ -813,6 +813,8 @@
     `src/services/discord/voice_barge_in/routing.rs` (383 production lines),
     and S5 moved the live-cut playback cluster to
     `src/services/discord/voice_barge_in/live_cut_playback.rs` (120 production
+    lines), and S6 moved the TTS pipeline cluster to
+    `src/services/discord/voice_barge_in/tts_pipeline.rs` (86 production
     lines);
     voice STT/TTS, lobby routing, progress mirroring, and barge-in
     orchestration surface; tracked decompose target — see

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -109,7 +109,10 @@
 # #3038 VoiceBargeInRuntime S5: lowered 3332 -> 3217 (-115) as the live-cut
 # playback method cluster moved to `voice_barge_in/live_cut_playback.rs` (120
 # prod LoC, below the giant threshold). Locks in the shrink win.
-"src/services/discord/voice_barge_in.rs" = 3217
+# #3038 VoiceBargeInRuntime S6: lowered 3217 -> 3136 (-81) as the TTS pipeline
+# method cluster moved to `voice_barge_in/tts_pipeline.rs` (86 prod LoC, below
+# the giant threshold). Locks in the shrink win.
+"src/services/discord/voice_barge_in.rs" = 3136
 # #3248: +60 for the gap-1 deploy-survivable-relay fix —
 # `reseed_watcher_owned_finalizer_ledger` + two guarded reattach call-sites that
 # re-register the watcher-owned turn in the post-restart finalizer ledger (a P1

--- a/src/services/discord/voice_barge_in.rs
+++ b/src/services/discord/voice_barge_in.rs
@@ -55,6 +55,8 @@ mod progress_playback;
 mod routing;
 #[path = "voice_barge_in/stt.rs"]
 mod stt;
+#[path = "voice_barge_in/tts_pipeline.rs"]
+mod tts_pipeline;
 
 pub(in crate::services::discord) const INTERNAL_VOICE_MESSAGE_ID_START: u64 =
     9_000_000_000_000_000_000;
@@ -1613,30 +1615,6 @@ impl VoiceBargeInRuntime {
         }
     }
 
-    async fn set_runtime_tts_voice(&self, voice: String) {
-        let config = {
-            let mut config = self.voice_config_state.write().await;
-            config.tts.edge.voice = voice.clone();
-            config.clone()
-        };
-        if self.enabled {
-            // F10 (#2046): `.ok()` 가 Err 를 사일런트로 삼켜 TTS 가 통째로 꺼지던
-            // 회귀를 방지. 실패 시 경고 로그만 남기고 기존 TTS 인스턴스를 보존.
-            match TtsRuntime::from_voice_config(&config) {
-                Ok(rt) => {
-                    *self.tts.write().await = Some(rt);
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        error = %error,
-                        voice = %voice,
-                        "voice change ignored: TtsRuntime build failed, keeping previous TTS"
-                    );
-                }
-            }
-        }
-    }
-
     async fn apply_wake_word_command(&self, command: WakeWordCommand) -> Vec<String> {
         let mut config = self.voice_config_state.write().await;
         match command {
@@ -2965,65 +2943,6 @@ impl VoiceBargeInRuntime {
             acknowledgement,
             prompt,
         })
-    }
-
-    async fn synthesize_acknowledgement(
-        &self,
-        text: &str,
-        channel_id: ChannelId,
-    ) -> Option<PathBuf> {
-        self.synthesize_progress_tts(text, channel_id, "voice barge-in acknowledgement")
-            .await
-    }
-
-    async fn synthesize_progress_tts(
-        &self,
-        text: &str,
-        channel_id: ChannelId,
-        context: &'static str,
-    ) -> Option<PathBuf> {
-        #[cfg(test)]
-        {
-            let request_index = {
-                let mut requests = self
-                    .test_state
-                    .synth_requests
-                    .lock()
-                    .expect("voice test synth requests lock");
-                requests.push((channel_id.get(), text.to_string(), context));
-                requests.len()
-            };
-            if self.test_state.force_synth_success.load(Ordering::Relaxed) {
-                return Some(
-                    std::env::temp_dir()
-                        .join(format!("agentdesk-test-voice-progress-{request_index}.wav")),
-                );
-            }
-        }
-        let Some(tts) = self.tts.read().await.clone() else {
-            return None;
-        };
-        match tts.synthesize(text, TtsSynthesisKind::Progress).await {
-            Ok(output) => {
-                tracing::info!(
-                    channel_id = channel_id.get(),
-                    path = %output.path.display(),
-                    cache_status = ?output.cache_status,
-                    context,
-                    "voice progress TTS synthesized"
-                );
-                Some(output.path)
-            }
-            Err(error) => {
-                tracing::warn!(
-                    error = %error,
-                    channel_id = channel_id.get(),
-                    context,
-                    "voice progress TTS synthesis failed"
-                );
-                None
-            }
-        }
     }
 
     fn buffer_for_channel(&self, channel_id: ChannelId) -> Arc<Mutex<DeferredBargeInBuffer>> {

--- a/src/services/discord/voice_barge_in/tts_pipeline.rs
+++ b/src/services/discord/voice_barge_in/tts_pipeline.rs
@@ -1,0 +1,86 @@
+use super::*;
+
+impl VoiceBargeInRuntime {
+    pub(super) async fn set_runtime_tts_voice(&self, voice: String) {
+        let config = {
+            let mut config = self.voice_config_state.write().await;
+            config.tts.edge.voice = voice.clone();
+            config.clone()
+        };
+        if self.enabled {
+            // F10 (#2046): `.ok()` 가 Err 를 사일런트로 삼켜 TTS 가 통째로 꺼지던
+            // 회귀를 방지. 실패 시 경고 로그만 남기고 기존 TTS 인스턴스를 보존.
+            match TtsRuntime::from_voice_config(&config) {
+                Ok(rt) => {
+                    *self.tts.write().await = Some(rt);
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        error = %error,
+                        voice = %voice,
+                        "voice change ignored: TtsRuntime build failed, keeping previous TTS"
+                    );
+                }
+            }
+        }
+    }
+
+    pub(super) async fn synthesize_acknowledgement(
+        &self,
+        text: &str,
+        channel_id: ChannelId,
+    ) -> Option<PathBuf> {
+        self.synthesize_progress_tts(text, channel_id, "voice barge-in acknowledgement")
+            .await
+    }
+
+    pub(super) async fn synthesize_progress_tts(
+        &self,
+        text: &str,
+        channel_id: ChannelId,
+        context: &'static str,
+    ) -> Option<PathBuf> {
+        #[cfg(test)]
+        {
+            let request_index = {
+                let mut requests = self
+                    .test_state
+                    .synth_requests
+                    .lock()
+                    .expect("voice test synth requests lock");
+                requests.push((channel_id.get(), text.to_string(), context));
+                requests.len()
+            };
+            if self.test_state.force_synth_success.load(Ordering::Relaxed) {
+                return Some(
+                    std::env::temp_dir()
+                        .join(format!("agentdesk-test-voice-progress-{request_index}.wav")),
+                );
+            }
+        }
+        let Some(tts) = self.tts.read().await.clone() else {
+            return None;
+        };
+        match tts.synthesize(text, TtsSynthesisKind::Progress).await {
+            Ok(output) => {
+                tracing::info!(
+                    channel_id = channel_id.get(),
+                    path = %output.path.display(),
+                    cache_status = ?output.cache_status,
+                    context,
+                    "voice progress TTS synthesized"
+                );
+                Some(output.path)
+            }
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    channel_id = channel_id.get(),
+                    context,
+                    "voice progress TTS synthesis failed"
+                );
+                None
+            }
+        }
+    }
+}


### PR DESCRIPTION
EPIC #3038 god-object 트랙, VoiceBargeInRuntime S6 (S1~S5에 이은 6번째 슬라이스).

## 내용
- **TTS pipeline 클러스터** (`set_runtime_tts_voice`, `synthesize_acknowledgement`, `synthesize_progress_tts`)를 `voice_barge_in/tts_pipeline.rs`(86 LoC)로 verbatim 이동.
- ratchet 인하, visibility-only(pub(super) 3건), realtime 불변식 무변경.
- codex 적대 리뷰: 코드 결함 0, P2 1건(커밋 본문 마감 평가 과장) → 본문 교정 완료. **S7+ 후보 잔존**: agent-voice routing 헬퍼 블록(~398-485), foreground decision/parser(~599+) — EPIC 미종료.
- 구현 opus / 리뷰 codex.

## 게이트 (독립 재검증)
fmt / check / clippy -D warnings / voice 277 / discord (베이스·머지 후 각각 green) / audit ratchet / docs freshness

🤖 Generated with [Claude Code](https://claude.com/claude-code)