### PR TITLE
fix(#3393): user-record <task-notification> XML을 패널 terminal StatusEvent로 브리지 — footer ✓가 라이브에서 동작

### DIFF
--- a/src/services/discord/placeholder_live_events/mod.rs
+++ b/src/services/discord/placeholder_live_events/mod.rs
@@ -45,7 +45,8 @@ use status_panel::{
 
 pub(in crate::services::discord) use recent_events::RecentPlaceholderEvent;
 pub(in crate::services::discord) use status_events::{
-    status_events_from_task_notification_with_tool_use_id, status_events_from_tool_result_with_id,
+    status_events_from_task_notification_with_tool_use_id,
+    status_events_from_task_notification_xml, status_events_from_tool_result_with_id,
     status_events_from_tool_use_with_id,
 };
 // #3034: the bare (no-id) variants are consumed only by the `tests` submodule
@@ -55,8 +56,8 @@ pub(in crate::services::discord) use status_events::{
 #[cfg(test)]
 pub(in crate::services::discord) use status_events::{
     status_events_from_json_for_footer_mode, status_events_from_task_notification,
-    status_events_from_tool_result, status_events_from_tool_use,
-    status_events_from_tool_use_with_id_for_footer_mode,
+    status_events_from_task_notification_xml_for_footer_mode, status_events_from_tool_result,
+    status_events_from_tool_use, status_events_from_tool_use_with_id_for_footer_mode,
 };
 
 pub(in crate::services::discord) use recent_events::events_from_json;

--- a/src/services/discord/placeholder_live_events/status_events.rs
+++ b/src/services/discord/placeholder_live_events/status_events.rs
@@ -145,13 +145,10 @@ pub(in crate::services::discord) fn status_events_from_tool_result_with_id(
             success: !is_error,
             tool_use_id: tool_use_id.map(str::to_string),
             summary: None,
-            // The Task `tool_result` always fires when the tool returns. Only a
-            // SUCCESSFUL `run_in_background` launch is an ack-only end: the
-            // dispatch succeeded and the subagent keeps running (often
-            // outliving the launching turn), so the panel must NOT mark it ✓.
-            // A FAILED launch (`is_error`) is terminal — the subagent never
-            // started — so it is not ack-only and the panel finalizes the slot
-            // as failed (✗), exactly like a foreground failure.
+            // A SUCCESSFUL `run_in_background` launch is ack-only: dispatch
+            // succeeded but the subagent keeps running (often outliving the
+            // turn), so the panel must NOT mark it ✓. A FAILED launch is terminal
+            // — the subagent never started — so it finalizes the slot as ✗.
             ack_only: !is_error,
         });
     }
@@ -193,8 +190,7 @@ pub(in crate::services::discord) fn status_events_from_task_notification_with_to
                     tool_use_id: tool_use_id.map(str::to_string),
                     summary: None,
                     // A terminal task_notification is the subagent's REAL
-                    // completion (including background subagents), so it always
-                    // finalizes the slot — not an ack.
+                    // completion (incl. background), so it finalizes — not an ack.
                     ack_only: false,
                 });
             }
@@ -219,6 +215,44 @@ pub(in crate::services::discord) fn status_events_from_task_notification_with_to
     events
 }
 
+/// #3393: bridge a raw `user`-record `<task-notification>` XML payload into the
+/// same live-panel [`StatusEvent`]s the (never-occurring) stream-json `system`
+/// path produced. Background/subagent completions reach the transcript ONLY as
+/// this XML, so without the bridge terminal slots never flip ✓ from real traffic
+/// (and the #3391 delivered-ack eviction never fires). Parses with the SHARED
+/// `tui_task_card` parser, derives kind from the summary prefix, then routes
+/// through `status_events_from_task_notification_with_tool_use_id` (its match
+/// arms own the kind→event mapping). An unknown/id-less terminal End is a slot
+/// no-op, so a double notification cannot flip a slot back. See `_for_footer_mode`.
+pub(in crate::services::discord) fn status_events_from_task_notification_xml(
+    raw: &str,
+) -> Vec<StatusEvent> {
+    status_events_from_task_notification_xml_for_footer_mode(raw, slots_enabled_by_footer_flag())
+}
+
+/// Footer-mode-injectable variant (mirrors the `_for_footer_mode` convention):
+/// legacy mode returns an empty vec so the separate-panel render path is
+/// untouched; tests inject the flag without the process-cached env read.
+pub(in crate::services::discord) fn status_events_from_task_notification_xml_for_footer_mode(
+    raw: &str,
+    footer_mode_enabled: bool,
+) -> Vec<StatusEvent> {
+    if !footer_mode_enabled {
+        return Vec::new();
+    }
+    let parsed = super::super::tui_task_card::parse_task_notification(raw);
+    let status = parsed.status.as_deref().unwrap_or("");
+    if status.is_empty() {
+        return Vec::new();
+    }
+    status_events_from_task_notification_with_tool_use_id(
+        parsed.kind(),
+        status,
+        parsed.summary.as_deref().unwrap_or(""),
+        parsed.tool_use_id.as_deref(),
+    )
+}
+
 pub(in crate::services::discord) fn status_events_from_json(value: &Value) -> Vec<StatusEvent> {
     status_events_from_json_for_footer_mode(value, background_bash_task_slots_enabled())
 }
@@ -232,12 +266,10 @@ pub(in crate::services::discord) fn status_events_from_json_for_footer_mode(
         return workflow_events;
     }
 
-    // A nested subagent record carries the launching Task's tool-use id as a
-    // top-level `parent_tool_use_id`. Its tool activity belongs to that subagent
-    // slot, not the main panel status, so route it to `SubagentActivity` keyed by
-    // the parent id (matched against the slot's stored Task tool-use id) rather
-    // than emitting a top-level `ToolStart` that would clobber the panel header
-    // and resurrect the foreground "tool running" status.
+    // A nested subagent record carries the launching Task's `parent_tool_use_id`.
+    // Its tool activity belongs to that subagent slot, so route it to
+    // `SubagentActivity` keyed by the parent id rather than a top-level `ToolStart`
+    // that would clobber the panel header / resurrect "tool running".
     if let Some(parent_id) = subagent_parent_tool_use_id(value) {
         return subagent_activity_status_events(value, parent_id);
     }
@@ -450,33 +482,14 @@ fn content_block_start_status_events(value: &Value, footer_mode_enabled: bool) -
 }
 
 fn user_status_events(value: &Value) -> Vec<StatusEvent> {
-    // #3086: a finished subagent's `tool_result` carries a `toolUseResult`
-    // aggregate with subagent accounting (`agentId` / `total*`). Surface a
-    // TUI-parity `Done (N tools · M tokens · Xs)` summary by pairing the result
-    // to its slot via the content block's own `tool_use_id`. The accounting
-    // comes from the in-stream `toolUseResult` (no IO).
-    //
-    // #3086 P1: a single `user` record may BATCH several finished subagents'
-    // `tool_result` blocks, and each Task subagent result carries its OWN
-    // `toolUseResult` aggregate (its own `agentId`/`total*`). The aggregate for
-    // subagent A lives in A's own block; B's lives in B's. We therefore compute
-    // each block's summary FROM THAT SAME BLOCK and key it by THAT block's
-    // `tool_use_id` — the slot key the panel pairs on (#3084). We must NOT
-    // attach a single record-level aggregate to "the first id-bearing block":
-    // with multiple aggregate-bearing blocks that would put subagent A's Done
-    // summary on subagent B's slot.
-    //
-    // Legacy single-subagent records put the aggregate at the RECORD top level
-    // (one `tool_result` block, top-level `toolUseResult`). When no block
-    // carries its own aggregate, we fall back to attaching that record-level
-    // aggregate to the first id-bearing `tool_result` block (there is exactly
-    // one finished subagent in that shape, so a single owner is correct).
-    //
-    // We cannot read slot state here (it lives in the panel), so each
-    // summary-bearing `SubagentEnd` is keyed by the block's `tool_use_id`; the
-    // panel (status_panel.rs) requires that id to match a tracked subagent slot
-    // before applying it — a summary-bearing end with an unmatched id is dropped
-    // rather than mis-routed to the last unfinished slot.
+    // #3086: surface a TUI-parity `Done (...)` from each finished subagent's
+    // in-stream `toolUseResult` aggregate (no IO), keyed by the block's own
+    // `tool_use_id` (the slot key, #3084). #3086 P1: a BATCHED `user` record has
+    // one aggregate PER subagent — compute each summary from its own block, never
+    // attach one record-level aggregate to "the first id-bearing block" (that
+    // mis-routes A's Done onto B). Legacy single-subagent keeps the aggregate at
+    // the record top level (fall back to the first id-bearing block). The panel
+    // drops a summary-bearing end whose id matches no tracked slot.
     let blocks = value
         .get("message")
         .and_then(|message| message.get("content"))
@@ -484,19 +497,15 @@ fn user_status_events(value: &Value) -> Vec<StatusEvent> {
         .map(Vec::as_slice)
         .unwrap_or(&[]);
 
-    // Per-block aggregates take precedence: when ANY `tool_result` block carries
-    // its own `toolUseResult` aggregate, attribute each summary to its own block
-    // and never fall back to the record-level aggregate (which, in the batched
-    // shape, would be absent or ambiguous).
+    // Per-block aggregates take precedence (each summary attributed to its own
+    // block); the record-level fallback is disabled when any block carries one.
     let any_block_aggregate = blocks.iter().any(|block| {
         block.get("type").and_then(Value::as_str) == Some("tool_result")
             && super::subagent_rollout::summary_from_tool_use_result(block).is_some()
     });
 
-    // Legacy single-subagent fallback: the aggregate sits at the record top
-    // level. Attribute it to the first id-bearing `tool_result` block (only one
-    // finished subagent exists in that shape). Disabled when blocks carry their
-    // own aggregates, to avoid double-counting / mis-attribution.
+    // Legacy single-subagent fallback: the record-level aggregate, owned by the
+    // first id-bearing block (exactly one finished subagent in that shape).
     let record_summary = if any_block_aggregate {
         None
     } else {
@@ -565,21 +574,12 @@ fn user_status_events(value: &Value) -> Vec<StatusEvent> {
 }
 
 /// Builds the subagent [`SubagentSummary`](crate::services::agent_protocol::SubagentSummary)
-/// from a JSON object's `toolUseResult` aggregate. The object may be either an
-/// individual `tool_result` content block (batched multi-subagent case, where
-/// each Task result carries its own `toolUseResult`) or the whole `user` record
-/// (legacy single-subagent case, where the aggregate sits at the record top
-/// level). Returns `None` for ordinary (non-subagent) tool results.
-///
-/// #3086 P1: this runs on the live relay/status hot path, so it uses ONLY the
-/// in-stream `toolUseResult` aggregate — no disk IO. The aggregate is the exact
-/// accounting the TUI renders and is normally complete; any field it omits is
-/// simply left empty, and the render layer degrades to a partial `Done (...)`
-/// line. The previous synchronous per-subagent rollout fallback
-/// (`std::fs::read_to_string` of a potentially large `agent-<id>.jsonl`) was an
-/// unbounded blocking read on the async relay loop and is removed from this
-/// path. The IO-free rollout parser (`summary_from_rollout_str`) remains
-/// available for any off-hot-path / offline use.
+/// from a JSON object's `toolUseResult` aggregate — either an individual
+/// `tool_result` block (batched multi-subagent) or the whole `user` record
+/// (legacy single-subagent). `None` for ordinary tool results. #3086 P1: live
+/// hot path — uses ONLY the in-stream aggregate (no disk IO); the prior
+/// synchronous per-subagent rollout `read_to_string` (unbounded blocking read on
+/// the async loop) was removed. `summary_from_rollout_str` remains off-hot-path.
 fn subagent_summary_from_record(
     value: &Value,
 ) -> Option<crate::services::agent_protocol::SubagentSummary> {
@@ -626,9 +626,9 @@ fn subagent_parent_tool_use_id(value: &Value) -> Option<String> {
 
 /// Builds [`StatusEvent::SubagentActivity`] events for a nested subagent record,
 /// one per tool_use block, keyed by the parent Task id so the panel updates the
-/// owning subagent slot's recent line. The activity line is the same
-/// `[Tool] args` summary the main panel uses for a tool, so a long background
-/// subagent surfaces its current step instead of an opaque "running".
+/// owning subagent slot's recent line (same `[Tool] args` summary the main panel
+/// uses, so a long background subagent surfaces its step, not an opaque
+/// "running").
 fn subagent_activity_status_events(value: &Value, parent_id: String) -> Vec<StatusEvent> {
     let blocks: Vec<(&str, String)> = match value.get("type").and_then(Value::as_str) {
         Some("assistant") => value

--- a/src/services/discord/placeholder_live_events/status_events.rs
+++ b/src/services/discord/placeholder_live_events/status_events.rs
@@ -146,9 +146,8 @@ pub(in crate::services::discord) fn status_events_from_tool_result_with_id(
             tool_use_id: tool_use_id.map(str::to_string),
             summary: None,
             // A SUCCESSFUL `run_in_background` launch is ack-only: dispatch
-            // succeeded but the subagent keeps running (often outliving the
-            // turn), so the panel must NOT mark it ✓. A FAILED launch is terminal
-            // — the subagent never started — so it finalizes the slot as ✗.
+            // succeeded but the subagent keeps running, so don't mark it ✓. A
+            // FAILED launch is terminal (never started) → finalizes the slot ✗.
             ack_only: !is_error,
         });
     }
@@ -190,7 +189,7 @@ pub(in crate::services::discord) fn status_events_from_task_notification_with_to
                     tool_use_id: tool_use_id.map(str::to_string),
                     summary: None,
                     // A terminal task_notification is the subagent's REAL
-                    // completion (incl. background), so it finalizes — not an ack.
+                    // completion (incl. background) → finalizes, not an ack.
                     ack_only: false,
                 });
             }
@@ -204,11 +203,15 @@ pub(in crate::services::discord) fn status_events_from_task_notification_with_to
             ));
         }
         "workflow" => {
-            events.push(StatusEvent::WorkflowEnd {
-                task_id: None,
-                success: !notification_is_error(status),
-                summary: Some(first_content_line(summary)).filter(|value| !value.is_empty()),
-            });
+            // #3393 finding 3: gate WorkflowEnd on a TERMINAL status (success via
+            // !is_error), like the subagent/background arms — running emits nothing.
+            if notification_is_terminal(status) {
+                events.push(StatusEvent::WorkflowEnd {
+                    task_id: None,
+                    success: !notification_is_error(status),
+                    summary: Some(first_content_line(summary)).filter(|value| !value.is_empty()),
+                });
+            }
         }
         _ => {}
     }
@@ -217,22 +220,17 @@ pub(in crate::services::discord) fn status_events_from_task_notification_with_to
 
 /// #3393: bridge a raw `user`-record `<task-notification>` XML payload into the
 /// same live-panel [`StatusEvent`]s the (never-occurring) stream-json `system`
-/// path produced. Background/subagent completions reach the transcript ONLY as
-/// this XML, so without the bridge terminal slots never flip ✓ from real traffic
-/// (and the #3391 delivered-ack eviction never fires). Parses with the SHARED
-/// `tui_task_card` parser, derives kind from the summary prefix, then routes
-/// through `status_events_from_task_notification_with_tool_use_id` (its match
-/// arms own the kind→event mapping). An unknown/id-less terminal End is a slot
-/// no-op, so a double notification cannot flip a slot back. See `_for_footer_mode`.
+/// path produced — background/subagent completions reach the transcript ONLY as
+/// this XML; without the bridge slots never flip ✓ (#3391 eviction never fires).
 pub(in crate::services::discord) fn status_events_from_task_notification_xml(
     raw: &str,
 ) -> Vec<StatusEvent> {
     status_events_from_task_notification_xml_for_footer_mode(raw, slots_enabled_by_footer_flag())
 }
 
-/// Footer-mode-injectable variant (mirrors the `_for_footer_mode` convention):
-/// legacy mode returns an empty vec so the separate-panel render path is
-/// untouched; tests inject the flag without the process-cached env read.
+/// Footer-mode-injectable variant: legacy mode returns an empty vec (separate-
+/// panel path untouched). Parses with the SHARED `tui_task_card` parser, derives
+/// kind from the summary prefix, routes through the `_with_tool_use_id` mapper.
 pub(in crate::services::discord) fn status_events_from_task_notification_xml_for_footer_mode(
     raw: &str,
     footer_mode_enabled: bool,
@@ -245,12 +243,22 @@ pub(in crate::services::discord) fn status_events_from_task_notification_xml_for
     if status.is_empty() {
         return Vec::new();
     }
-    status_events_from_task_notification_with_tool_use_id(
+    let events = status_events_from_task_notification_with_tool_use_id(
         parsed.kind(),
         status,
         parsed.summary.as_deref().unwrap_or(""),
         parsed.tool_use_id.as_deref(),
-    )
+    );
+    // #3393 finding 1 (XML-scoped): drop an id-less terminal `SubagentEnd` — it
+    // would fall back in the panel to "the last unfinished slot" and flip/evict
+    // the WRONG one (permanently, post-#3391). A missing id → no terminal effect
+    // (heartbeat/activity kept). The `system` path keeps its id-less fallback.
+    events.into_iter().filter(idful_subagent_or_other).collect()
+}
+
+/// #3393 finding 1 XML-bridge drop predicate: `false` for an id-less `SubagentEnd`.
+fn idful_subagent_or_other(event: &StatusEvent) -> bool {
+    !matches!(event, StatusEvent::SubagentEnd { tool_use_id, .. } if tool_use_id.is_none())
 }
 
 pub(in crate::services::discord) fn status_events_from_json(value: &Value) -> Vec<StatusEvent> {
@@ -266,10 +274,10 @@ pub(in crate::services::discord) fn status_events_from_json_for_footer_mode(
         return workflow_events;
     }
 
-    // A nested subagent record carries the launching Task's `parent_tool_use_id`.
-    // Its tool activity belongs to that subagent slot, so route it to
-    // `SubagentActivity` keyed by the parent id rather than a top-level `ToolStart`
-    // that would clobber the panel header / resurrect "tool running".
+    // A nested subagent record carries the launching Task's `parent_tool_use_id`;
+    // its tool activity belongs to that slot, so route it to `SubagentActivity`
+    // keyed by the parent id rather than a top-level `ToolStart` that would
+    // clobber the panel header / resurrect "tool running".
     if let Some(parent_id) = subagent_parent_tool_use_id(value) {
         return subagent_activity_status_events(value, parent_id);
     }
@@ -484,12 +492,11 @@ fn content_block_start_status_events(value: &Value, footer_mode_enabled: bool) -
 fn user_status_events(value: &Value) -> Vec<StatusEvent> {
     // #3086: surface a TUI-parity `Done (...)` from each finished subagent's
     // in-stream `toolUseResult` aggregate (no IO), keyed by the block's own
-    // `tool_use_id` (the slot key, #3084). #3086 P1: a BATCHED `user` record has
-    // one aggregate PER subagent — compute each summary from its own block, never
-    // attach one record-level aggregate to "the first id-bearing block" (that
-    // mis-routes A's Done onto B). Legacy single-subagent keeps the aggregate at
-    // the record top level (fall back to the first id-bearing block). The panel
-    // drops a summary-bearing end whose id matches no tracked slot.
+    // `tool_use_id` (slot key, #3084). #3086 P1: a BATCHED record has one
+    // aggregate PER subagent — compute each from its own block (never attach the
+    // record-level aggregate to "the first id-bearing block", which mis-routes
+    // A's Done onto B). Legacy single-subagent keeps the record-level aggregate on
+    // the first id-bearing block; the panel drops an end whose id matches no slot.
     let blocks = value
         .get("message")
         .and_then(|message| message.get("content"))
@@ -533,11 +540,10 @@ fn user_status_events(value: &Value) -> Vec<StatusEvent> {
                 .and_then(Value::as_bool)
                 .unwrap_or(false);
 
-            // This block's OWN aggregate (batched multi-subagent case): attach
-            // the per-subagent summary here, keyed by THIS block's tool_use_id.
+            // This block's OWN aggregate (batched case), keyed by THIS block's
+            // tool_use_id; else the legacy record-level aggregate on the first
+            // id-bearing block.
             let block_summary = subagent_summary_from_record(block);
-            // Or, for the legacy single-subagent shape, the record-level
-            // aggregate owned by the first id-bearing block.
             let summary = block_summary.or_else(|| {
                 if Some(idx) == record_summary_owner_idx {
                     record_summary.clone()
@@ -547,9 +553,8 @@ fn user_status_events(value: &Value) -> Vec<StatusEvent> {
             });
 
             if let Some(summary) = summary {
-                // Pair by this block's own tool_use_id. The panel refuses to
-                // apply the summary unless the id matches a real, tracked slot,
-                // so a stray summary can never land on an unrelated running slot.
+                // Pair by this block's own tool_use_id; the panel refuses the
+                // summary unless the id matches a real tracked slot.
                 let tool_use_id = block
                     .get("tool_use_id")
                     .and_then(Value::as_str)
@@ -560,9 +565,8 @@ fn user_status_events(value: &Value) -> Vec<StatusEvent> {
                         success: !is_error,
                         tool_use_id,
                         summary: Some(summary),
-                        // A summary-bearing end carries real accounting
-                        // (`toolUseResult`/rollout) — a genuine completion that
-                        // always finalizes the slot, never just an ack.
+                        // A summary-bearing end carries real accounting — a
+                        // genuine completion that always finalizes, never an ack.
                         ack_only: false,
                     },
                 ];
@@ -574,12 +578,10 @@ fn user_status_events(value: &Value) -> Vec<StatusEvent> {
 }
 
 /// Builds the subagent [`SubagentSummary`](crate::services::agent_protocol::SubagentSummary)
-/// from a JSON object's `toolUseResult` aggregate — either an individual
-/// `tool_result` block (batched multi-subagent) or the whole `user` record
-/// (legacy single-subagent). `None` for ordinary tool results. #3086 P1: live
-/// hot path — uses ONLY the in-stream aggregate (no disk IO); the prior
-/// synchronous per-subagent rollout `read_to_string` (unbounded blocking read on
-/// the async loop) was removed. `summary_from_rollout_str` remains off-hot-path.
+/// from a JSON object's `toolUseResult` aggregate — an individual `tool_result`
+/// block (batched) or the whole `user` record (legacy single). `None` for
+/// ordinary results. #3086 P1: live hot path — in-stream aggregate only (no disk
+/// IO); the prior synchronous rollout `read_to_string` was removed.
 fn subagent_summary_from_record(
     value: &Value,
 ) -> Option<crate::services::agent_protocol::SubagentSummary> {
@@ -612,9 +614,8 @@ fn system_status_events(value: &Value) -> Vec<StatusEvent> {
 }
 
 /// Returns the launching Task's tool-use id from a nested subagent record's
-/// top-level `parent_tool_use_id` (Claude Code stream-json marks every
-/// subagent-internal `assistant`/`content_block_start` record with it). `None`
-/// for top-level records (no parent) so they take the normal panel path.
+/// top-level `parent_tool_use_id` (Claude Code marks every subagent-internal
+/// record with it). `None` for top-level records → normal panel path.
 fn subagent_parent_tool_use_id(value: &Value) -> Option<String> {
     ["parent_tool_use_id", "parentToolUseId"]
         .into_iter()
@@ -626,9 +627,8 @@ fn subagent_parent_tool_use_id(value: &Value) -> Option<String> {
 
 /// Builds [`StatusEvent::SubagentActivity`] events for a nested subagent record,
 /// one per tool_use block, keyed by the parent Task id so the panel updates the
-/// owning subagent slot's recent line (same `[Tool] args` summary the main panel
-/// uses, so a long background subagent surfaces its step, not an opaque
-/// "running").
+/// owning slot's recent line (same `[Tool] args` summary) — a long background
+/// subagent surfaces its step, not an opaque "running".
 fn subagent_activity_status_events(value: &Value, parent_id: String) -> Vec<StatusEvent> {
     let blocks: Vec<(&str, String)> = match value.get("type").and_then(Value::as_str) {
         Some("assistant") => value

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -4963,3 +4963,115 @@ fn task_notification_xml_bridge_inert_when_footer_mode_off() {
         "footer-mode-off bridge must be inert: {bridged:?}"
     );
 }
+
+// #3393 finding 1: an id-LESS subagent `<task-notification>` XML (no
+// `<tool-use-id>` child) must produce NO terminal effect. Before the fix the XML
+// bridge emitted `SubagentEnd { tool_use_id: None }`, the panel fell back to "the
+// last unfinished subagent slot", and the WRONG slot was finalized (and, with
+// #3391, evicted on delivery). The bridge now drops id-less terminal ends.
+#[test]
+fn task_notification_xml_idless_subagent_does_not_flip_or_evict_a_slot() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_393_004);
+    // A running FOREGROUND Task subagent slot keyed by its launch tool-use id.
+    // Foreground (not background) so an id-less ack-only fallback WOULD finalize
+    // it pre-fix — the strongest exposure of the bug.
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({
+                "subagent_type": "scout",
+                "description": "Scout issue #3393"
+            })
+            .to_string(),
+            Some("toolu_live_slot"),
+        ),
+    );
+
+    // Real-shape subagent variant WITHOUT a `<tool-use-id>` child (some repeats /
+    // lost-process notifications omit it). Terminal status `completed`.
+    let idless = "<task-notification>\n\
+        <task-id>idless1</task-id>\n\
+        <status>completed</status>\n\
+        <summary>Agent \"some other agent\" completed</summary>\n\
+        <result>Done.</result>\n\
+        </task-notification>";
+    let bridged = status_events_from_task_notification_xml_for_footer_mode(idless, true);
+    assert!(
+        !bridged
+            .iter()
+            .any(|e| matches!(e, StatusEvent::SubagentEnd { .. })),
+        "id-less subagent XML must NOT bridge a SubagentEnd: {bridged:?}"
+    );
+    events.push_status_events(channel_id, bridged);
+
+    // The slot is untouched: still present and still unfinished (no eviction, no
+    // ✓/✗ flip onto the wrong slot).
+    {
+        let entry = events
+            .status_by_channel
+            .get(&channel_id)
+            .expect("status panel state");
+        let guard = entry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert_eq!(
+            guard.subagents.len(),
+            1,
+            "id-less subagent notification must not evict the slot"
+        );
+        assert!(
+            guard.subagents[0].finished.is_none(),
+            "id-less subagent notification must leave the slot unfinished"
+        );
+    }
+
+    let footer = events.render_completion_footer(channel_id, &ProviderKind::Claude, "⠸");
+    assert!(
+        footer.has_unfinished_entries,
+        "the running subagent slot must remain unfinished"
+    );
+    let block = footer.block.expect("running subagent should render");
+    assert!(
+        !block.contains('✓'),
+        "id-less subagent notification must not flip ✓: {block}"
+    );
+}
+
+// #3393 finding 3: a workflow `<task-notification>` XML with a NON-terminal
+// status (e.g. running) must NOT emit `WorkflowEnd`; terminal statuses still map
+// success via `!is_error`, consistent with the subagent/background arms.
+#[test]
+fn task_notification_xml_workflow_gates_workflow_end_on_terminal_status() {
+    let running = "<task-notification><task-id>wf1</task-id><status>running</status>\
+        <summary>Dynamic workflow \"probe\" running</summary></task-notification>";
+    let running_events = status_events_from_task_notification_xml_for_footer_mode(running, true);
+    assert!(
+        !running_events
+            .iter()
+            .any(|e| matches!(e, StatusEvent::WorkflowEnd { .. })),
+        "status=running workflow XML must NOT emit WorkflowEnd: {running_events:?}"
+    );
+
+    let completed = "<task-notification><task-id>wf2</task-id><status>completed</status>\
+        <summary>Dynamic workflow \"probe\" completed</summary></task-notification>";
+    let completed_events =
+        status_events_from_task_notification_xml_for_footer_mode(completed, true);
+    assert!(
+        completed_events
+            .iter()
+            .any(|e| matches!(e, StatusEvent::WorkflowEnd { success: true, .. })),
+        "status=completed workflow XML must emit WorkflowEnd{{success:true}}: {completed_events:?}"
+    );
+
+    let failed = "<task-notification><task-id>wf3</task-id><status>failed</status>\
+        <summary>Dynamic workflow \"probe\" failed</summary></task-notification>";
+    let failed_events = status_events_from_task_notification_xml_for_footer_mode(failed, true);
+    assert!(
+        failed_events
+            .iter()
+            .any(|e| matches!(e, StatusEvent::WorkflowEnd { success: false, .. })),
+        "status=failed workflow XML must emit WorkflowEnd{{success:false}}: {failed_events:?}"
+    );
+}

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -4737,3 +4737,229 @@ fn status_events_toolsearch_pretty_json_args_summary_not_bare_brace() {
     assert_ne!(summary.trim(), "{");
     assert!(!summary.trim_end().ends_with('{'), "got: {summary}");
 }
+
+// ---------------------------------------------------------------------------
+// #3393: user-record `<task-notification>` XML → live panel terminal StatusEvents.
+//
+// Background-task / subagent completions reach the transcript ONLY as this XML
+// (never the stream-json `system` record the panel's `system_status_events`
+// parses). These tests drive the FULL ingestion: real-shape XML text (incl. the
+// hyphenated `<tool-use-id>` from the live transcript) → bridge parse → push →
+// `render_completion_footer` shows ✓. State-machine-only proof is explicitly
+// forbidden by the issue, so every assertion goes through the panel render.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn task_notification_xml_background_bash_flips_footer_slot_to_done() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_393_001);
+    // A running background Bash slot keyed by the launch tool-use id.
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id_for_footer_mode(
+            "Bash",
+            &json!({
+                "command": "gh run watch",
+                "description": "Wait until PR 3392 CI settles",
+                "run_in_background": true
+            })
+            .to_string(),
+            Some("toolu_01Ls2svfdnzcn9uGwA7aHjHW"),
+            true,
+        ),
+    );
+    let running = events.render_completion_footer(channel_id, &ProviderKind::Claude, "⠸");
+    let running_block = running
+        .block
+        .expect("running background Bash should render");
+    assert!(running.has_unfinished_entries);
+    assert!(running_block.contains("Bash Wait until PR 3392 CI settles ⠸"));
+    assert!(!running_block.contains('✓'));
+
+    // Real-shape XML user-record text (background Bash variant, hyphenated
+    // `<tool-use-id>` child tag, status `completed`) — copied from a live
+    // transcript notification.
+    let raw = "<task-notification>\n\
+        <task-id>b5gr0v9xj</task-id>\n\
+        <tool-use-id>toolu_01Ls2svfdnzcn9uGwA7aHjHW</tool-use-id>\n\
+        <output-file>/private/tmp/claude-501/sess/tasks/b5gr0v9xj.output</output-file>\n\
+        <status>completed</status>\n\
+        <summary>Background command \"Wait until PR 3392 CI settles\" completed (exit code 0)</summary>\n\
+        </task-notification>";
+    let bridged = status_events_from_task_notification_xml_for_footer_mode(raw, true);
+    assert!(
+        bridged
+            .iter()
+            .any(|e| matches!(e, StatusEvent::BackgroundTaskEnd { .. })),
+        "background XML must bridge to BackgroundTaskEnd: {bridged:?}"
+    );
+    events.push_status_events(channel_id, bridged);
+
+    let done = events.render_completion_footer(channel_id, &ProviderKind::Claude, "⠼");
+    let done_block = done
+        .block
+        .expect("finished background Bash should stay visible");
+    assert!(!done.has_unfinished_entries);
+    assert!(
+        done_block.contains("Bash Wait until PR 3392 CI settles ✓"),
+        "matching XML notification must flip ✓: {done_block}"
+    );
+    assert!(!done_block.contains('⠼'));
+}
+
+#[test]
+fn task_notification_xml_subagent_flips_footer_slot_to_done() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_393_002);
+    // A running Task subagent slot keyed by its launch tool-use id.
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id(
+            "Task",
+            &json!({
+                "subagent_type": "scout",
+                "description": "Scout issues #3275 #3276",
+                "run_in_background": true
+            })
+            .to_string(),
+            Some("toolu_018F3HtbweDDNEbi44HKAhhi"),
+        ),
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_result_with_id(
+            Some("Task"),
+            false,
+            Some("toolu_018F3HtbweDDNEbi44HKAhhi"),
+        ),
+    );
+    let running = events.render_completion_footer(channel_id, &ProviderKind::Claude, "⠸");
+    let running_block = running.block.expect("running subagent should render");
+    assert!(running.has_unfinished_entries);
+    assert!(running_block.contains("Subagents"));
+    assert!(!running_block.contains('✓'));
+
+    // Real-shape subagent variant: summary prefix `Agent "…" completed`, the
+    // SAME hyphenated `<tool-use-id>` as the launch — bridges to `SubagentEnd`.
+    let raw = "<task-notification>\n\
+        <task-id>a09e45d12a68015a5</task-id>\n\
+        <tool-use-id>toolu_018F3HtbweDDNEbi44HKAhhi</tool-use-id>\n\
+        <output-file>/private/tmp/claude-501/sess/tasks/a09e45d12a68015a5.output</output-file>\n\
+        <status>completed</status>\n\
+        <summary>Agent \"Scout issues #3275 #3276\" completed</summary>\n\
+        <result>Done.</result>\n\
+        </task-notification>";
+    let bridged = status_events_from_task_notification_xml_for_footer_mode(raw, true);
+    assert!(
+        bridged.iter().any(|e| matches!(
+            e,
+            StatusEvent::SubagentEnd {
+                ack_only: false,
+                ..
+            }
+        )),
+        "subagent XML must bridge to a finalizing SubagentEnd: {bridged:?}"
+    );
+    events.push_status_events(channel_id, bridged);
+
+    let done = events.render_completion_footer(channel_id, &ProviderKind::Claude, "⠼");
+    let done_block = done.block.expect("finished subagent should stay visible");
+    assert!(!done.has_unfinished_entries);
+    assert!(
+        done_block.contains("Scout issues #3275 #3276") && done_block.contains('✓'),
+        "matching subagent XML notification must flip ✓: {done_block}"
+    );
+}
+
+#[test]
+fn task_notification_xml_unknown_id_and_duplicate_and_nonterminal_are_safe() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3_393_003);
+    events.push_status_events(
+        channel_id,
+        status_events_from_tool_use_with_id_for_footer_mode(
+            "Bash",
+            &json!({
+                "command": "deploy.sh",
+                "description": "Deploy runtime",
+                "run_in_background": true
+            })
+            .to_string(),
+            Some("toolu_known"),
+            true,
+        ),
+    );
+
+    // (a) Unknown tool-use-id: terminal End for a slot we never opened — no-op.
+    let unknown = "<task-notification><task-id>x1</task-id>\
+        <tool-use-id>toolu_unknown</tool-use-id><status>completed</status>\
+        <summary>Background command \"Other\" completed (exit code 0)</summary></task-notification>";
+    events.push_status_events(
+        channel_id,
+        status_events_from_task_notification_xml_for_footer_mode(unknown, true),
+    );
+    let after_unknown = events.render_completion_footer(channel_id, &ProviderKind::Claude, "⠸");
+    let block = after_unknown.block.expect("known slot still renders");
+    assert!(
+        block.contains("Bash Deploy runtime ⠸") && !block.contains('✓'),
+        "unknown-id notification must not flip the known slot: {block}"
+    );
+
+    // (b) Non-terminal status: produces NO terminal End event.
+    let nonterminal = "<task-notification><task-id>x2</task-id>\
+        <tool-use-id>toolu_known</tool-use-id><status>running</status>\
+        <summary>Background command \"Deploy runtime\" running</summary></task-notification>";
+    let nonterminal_events =
+        status_events_from_task_notification_xml_for_footer_mode(nonterminal, true);
+    assert!(
+        !nonterminal_events
+            .iter()
+            .any(|e| matches!(e, StatusEvent::BackgroundTaskEnd { .. })),
+        "non-terminal status must not bridge a BackgroundTaskEnd: {nonterminal_events:?}"
+    );
+    events.push_status_events(channel_id, nonterminal_events);
+    let still_running = events
+        .render_completion_footer(channel_id, &ProviderKind::Claude, "⠸")
+        .block
+        .expect("slot still renders");
+    assert!(
+        !still_running.contains('✓'),
+        "non-terminal must not flip ✓: {still_running}"
+    );
+
+    // (c) Terminal match flips ✓; a DUPLICATE terminal notification must not flip
+    // the slot back to running.
+    let done_xml = "<task-notification><task-id>x3</task-id>\
+        <tool-use-id>toolu_known</tool-use-id><status>completed</status>\
+        <summary>Background command \"Deploy runtime\" completed (exit code 0)</summary></task-notification>";
+    events.push_status_events(
+        channel_id,
+        status_events_from_task_notification_xml_for_footer_mode(done_xml, true),
+    );
+    events.push_status_events(
+        channel_id,
+        status_events_from_task_notification_xml_for_footer_mode(done_xml, true),
+    );
+    let done = events
+        .render_completion_footer(channel_id, &ProviderKind::Claude, "⠼")
+        .block
+        .expect("done slot renders");
+    assert!(
+        done.contains("Bash Deploy runtime ✓") && !done.contains('⠼'),
+        "duplicate terminal notification must stay ✓, not flip back: {done}"
+    );
+}
+
+#[test]
+fn task_notification_xml_bridge_inert_when_footer_mode_off() {
+    // Footer-mode OFF → the bridge yields no events so the legacy separate-panel
+    // render path is untouched.
+    let raw = "<task-notification><task-id>off1</task-id>\
+        <tool-use-id>toolu_off</tool-use-id><status>completed</status>\
+        <summary>Background command \"x\" completed (exit code 0)</summary></task-notification>";
+    let bridged = status_events_from_task_notification_xml_for_footer_mode(raw, false);
+    assert!(
+        bridged.is_empty(),
+        "footer-mode-off bridge must be inert: {bridged:?}"
+    );
+}

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -704,7 +704,15 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             // for BOTH Post and Repeat outcomes (a repeat re-asserts terminal,
             // which is idempotent at the slot). Footer-mode gated inside the
             // bridge; an unknown/id-less notification is a slot no-op.
-            bridge_task_notification_to_live_panel(shared, channel_id, &prompt.prompt);
+            //
+            // #3393 finding 2: gate the BRIDGE (not the card) on a START-ANCHORED
+            // check — a human prompt QUOTING a notification mid-message still gets
+            // its card but pushes NO terminal events, so a quoted live tool-use-id
+            // cannot false-close a running slot. Layered with finding 1 (the XML
+            // bridge requires a tool_use_id for any terminal End).
+            if is_start_anchored_task_notification(&prompt.prompt) {
+                bridge_task_notification_to_live_panel(shared, channel_id, &prompt.prompt);
+            }
             match super::tui_task_card::resolve_task_card_content(
                 &notify_http,
                 shared,
@@ -5102,7 +5110,10 @@ fn bridge_task_notification_to_live_panel(shared: &SharedData, channel_id: Chann
 }
 
 /// Detects the `<task-notification>` auto-turn tag injected by Claude Code /
-/// Codex when a background task reaches a terminal state.
+/// Codex when a background task reaches a terminal state. Deliberately
+/// CONTAINS-based: the CARD render must fire even for a human prompt that quotes
+/// a notification (it is still classified + rendered, never lost). The terminal
+/// BRIDGE uses the stricter `is_start_anchored_task_notification` instead.
 fn is_task_notification_prompt(prompt: &str) -> bool {
     let trimmed = prompt.trim_start();
     // Skip a leading terminal-control prefix some injectors prepend before the
@@ -5110,6 +5121,22 @@ fn is_task_notification_prompt(prompt: &str) -> bool {
     let normalized = strip_terminal_controls(trimmed);
     let normalized = normalized.trim_start();
     normalized.contains("<task-notification>") || normalized.contains("<task-notification ")
+}
+
+/// #3393 finding 2: START-ANCHORED gate for the live-panel terminal BRIDGE only.
+/// A REAL machine `<task-notification>` user-record begins with the tag after the
+/// shared normalization pipeline (strip_terminal_controls → trim →
+/// strip_leading_injection_wrapper → trim, mirroring #3100/#3388). A human direct
+/// prompt that merely QUOTES a notification mid-message keeps its CARD render (the
+/// contains-based classifier) but must NOT push terminal StatusEvents — combined
+/// with finding 1's id requirement this closes the false-close attack where a
+/// quoted live tool-use-id would otherwise finalize a real running slot.
+fn is_start_anchored_task_notification(prompt: &str) -> bool {
+    let normalized = strip_terminal_controls(prompt);
+    let normalized = normalized.trim_start();
+    let normalized = strip_leading_injection_wrapper(normalized);
+    let normalized = normalized.trim_start();
+    normalized.starts_with("<task-notification>") || normalized.starts_with("<task-notification ")
 }
 
 /// Detects start-anchored compact/session-continuation banners.
@@ -6132,6 +6159,61 @@ mod tests {
                 "<task-notification><status>completed</status></task-notification>"
             )
             .is_human_active_turn()
+        );
+    }
+
+    // #3393 finding 2: the live-panel terminal BRIDGE is gated on a START-ANCHORED
+    // check, distinct from the contains-based CARD classifier. A human direct
+    // prompt that QUOTES a notification (embedding a LIVE tool-use-id) still earns
+    // its card but must NOT push terminal StatusEvents — so a quoted id cannot
+    // false-close a real running slot. A bare real-shape record (incl. a leading
+    // injection-wrapper round-trip) still bridges.
+    #[test]
+    fn bridge_guard_is_start_anchored_not_contains() {
+        // Human prompt quoting a notification mid-message, with a LIVE tool-use-id
+        // that matches a real running slot: NOT start-anchored → no bridge.
+        let quoted = "please re-run this, it printed:\n\
+            <task-notification><tool-use-id>toolu_live_slot</tool-use-id>\
+            <status>completed</status>\
+            <summary>Agent \"x\" completed</summary></task-notification>";
+        assert!(
+            !is_start_anchored_task_notification(quoted),
+            "a mid-message quoted notification must NOT pass the bridge guard"
+        );
+        // …yet the contains-based classifier still routes it to the CARD (the
+        // card behavior is preserved; only the terminal bridge is suppressed).
+        assert_eq!(
+            classify_injected_prompt(quoted),
+            InjectedPromptClass::TaskNotificationEvent,
+        );
+
+        // A bare, start-anchored real-shape record bridges.
+        let bare = "<task-notification><tool-use-id>toolu_live_slot</tool-use-id>\
+            <status>completed</status>\
+            <summary>Agent \"x\" completed</summary></task-notification>";
+        assert!(
+            is_start_anchored_task_notification(bare),
+            "a bare start-anchored notification must pass the bridge guard"
+        );
+
+        // Leading terminal-control prefix is tolerated (stripped by the pipeline).
+        let ansi_prefixed = "\u{1b}[0m<task-notification><status>completed</status>\
+            </task-notification>";
+        assert!(
+            is_start_anchored_task_notification(ansi_prefixed),
+            "an ANSI-prefixed notification must still pass the bridge guard"
+        );
+
+        // SSH-direct injection-wrapper round-trip variant: the wrapper line + code
+        // fence are peeled by `strip_leading_injection_wrapper`, leaving the tag
+        // start-anchored → still bridges (mirrors the #3153 wrapper coverage).
+        let wrapped = "터미널에 직접 주입된 입력 (tmux : `s`):\n```text\n\
+            <task-notification><tool-use-id>toolu_live_slot</tool-use-id>\
+            <status>completed</status>\
+            <summary>Agent \"x\" completed</summary></task-notification>\n```";
+        assert!(
+            is_start_anchored_task_notification(wrapped),
+            "an injection-wrapper round-trip notification must pass the bridge guard"
         );
     }
 

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -695,6 +695,16 @@ async fn relay_observed_prompt(shared: &Arc<SharedData>, prompt: ObservedTuiProm
             let kind = slash_command_control_kind(&prompt.prompt);
             format_slash_command_control_note(&prompt.tmux_session_name, &kind, &prompt.prompt)
         } else if matches!(injected_class, InjectedPromptClass::TaskNotificationEvent) {
+            // #3393: background-task / subagent completions arrive ONLY as this
+            // `user`-record `<task-notification>` XML — never the stream-json
+            // `system` record the footer panel's `system_status_events` parses. So
+            // before the card render (which has its OWN store), bridge the SAME
+            // payload into the live-panel terminal StatusEvents so footer Tasks /
+            // Subagents flip ✓ and the #3391 delivered-ack eviction can fire. Runs
+            // for BOTH Post and Repeat outcomes (a repeat re-asserts terminal,
+            // which is idempotent at the slot). Footer-mode gated inside the
+            // bridge; an unknown/id-less notification is a slot no-op.
+            bridge_task_notification_to_live_panel(shared, channel_id, &prompt.prompt);
             match super::tui_task_card::resolve_task_card_content(
                 &notify_http,
                 shared,
@@ -5061,6 +5071,34 @@ fn strip_leading_local_command_caveat(text: &str) -> (&str, bool) {
         return (text, false);
     };
     (&text[end + CLOSE.len()..], true)
+}
+
+/// #3393: bridge an observed `<task-notification>` XML user-record into the live
+/// footer panel's terminal StatusEvents for `channel_id`. Background-task and
+/// subagent completions reach the transcript ONLY as this XML; the panel's own
+/// `system_status_events` parses a stream-json `system` record that never
+/// occurs, so without this bridge footer Tasks/Subagents never flip ✓ from real
+/// traffic and the #3391 delivered-ack eviction never triggers. The bridge is
+/// footer-mode gated INSIDE `status_events_from_task_notification_xml` (empty vec
+/// in legacy mode), and a terminal End for an unknown/id-less tool-use-id is a
+/// slot no-op, so a double notification cannot flip a slot back.
+fn bridge_task_notification_to_live_panel(shared: &SharedData, channel_id: ChannelId, raw: &str) {
+    let events = super::placeholder_live_events::status_events_from_task_notification_xml(raw);
+    if events.is_empty() {
+        return;
+    }
+    let parsed = super::tui_task_card::parse_task_notification(raw);
+    tracing::info!(
+        channel_id = channel_id.get(),
+        kind = parsed.kind(),
+        tool_use_id = parsed.tool_use_id.as_deref().unwrap_or(""),
+        status = parsed.status.as_deref().unwrap_or(""),
+        "#3393: bridged user-record <task-notification> XML to live panel terminal StatusEvents"
+    );
+    shared
+        .ui
+        .placeholder_live_events
+        .push_status_events(channel_id, events);
 }
 
 /// Detects the `<task-notification>` auto-turn tag injected by Claude Code /

--- a/src/services/discord/tui_task_card.rs
+++ b/src/services/discord/tui_task_card.rs
@@ -58,6 +58,10 @@ const RESULT_PREVIEW_LINES: usize = 3;
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(super) struct TaskNotification {
     pub task_id: Option<String>,
+    /// The launching tool's `tool_use_id` (e.g. `toolu_…`). Hyphenated child tag
+    /// in live payloads; the panel slot key the #3393 terminal bridge pairs on.
+    /// Some repeats / lost-process notifications omit it (then no slot flips).
+    pub tool_use_id: Option<String>,
     pub status: Option<String>,
     pub summary: Option<String>,
     pub result: Option<String>,
@@ -105,6 +109,10 @@ pub(super) fn parse_task_notification(raw: &str) -> TaskNotification {
     let usage_inner = usage.as_deref().unwrap_or("");
     TaskNotification {
         task_id: extract_tag(trimmed, &["task-id", "task_id"]),
+        // #3393: the launching tool's id is a distinct top-level child tag (both
+        // hyphen and underscore spellings observed); scoped to the whole payload
+        // like task-id, never the <usage> tail.
+        tool_use_id: extract_tag(trimmed, &["tool-use-id", "tool_use_id"]),
         status: extract_tag(trimmed, &["status"]),
         summary: extract_tag(trimmed, &["summary"]),
         result: extract_tag(trimmed, &["result"]),
@@ -121,6 +129,30 @@ pub(super) fn parse_task_notification(raw: &str) -> TaskNotification {
         agent_count: extract_tag(usage_inner, &["agent-count", "agent_count"]),
         duration_ms: extract_tag(usage_inner, &["duration-ms", "duration_ms"]),
         usage,
+    }
+}
+
+impl TaskNotification {
+    /// #3393: classify a parsed notification into the `task_notification_kind`
+    /// vocabulary the live-panel status bridge consumes
+    /// (`status_events_from_task_notification_with_tool_use_id`). Live payloads
+    /// carry NO `kind=` attribute, so the kind is read from the `<summary>`
+    /// prefix Claude Code emits:
+    ///   - `Background command "…"`  → `background` (a background Bash → its
+    ///     terminal status flips a `BackgroundTaskEnd` slot, keyed by tool-use-id).
+    ///   - `Dynamic workflow "…"`    → `workflow`.
+    ///   - `Agent "…"` / `Background agent "…"` / anything else → `subagent`
+    ///     (a `SubagentEnd`; the default is the safe one — it only finalizes a
+    ///     slot whose tool-use-id matches, so an unknown prefix never mis-fires).
+    pub(super) fn kind(&self) -> &'static str {
+        let summary = self.summary.as_deref().unwrap_or("").trim_start();
+        if summary.starts_with("Background command") {
+            "background"
+        } else if summary.starts_with("Dynamic workflow") {
+            "workflow"
+        } else {
+            "subagent"
+        }
     }
 }
 
@@ -769,6 +801,55 @@ mod tests {
             parse_task_notification(&underscore).task_id.as_deref(),
             Some("codex-bg-1")
         );
+    }
+
+    #[test]
+    fn parses_tool_use_id_and_derives_kind_from_summary_prefix() {
+        // #3393: real-shape background Bash notification — hyphenated tool-use-id
+        // child tag, `Background command "…"` summary → `background` kind.
+        let bg = "<task-notification><task-id>b5gr0v9xj</task-id>\
+            <tool-use-id>toolu_01Ls2svfdnzcn9uGwA7aHjHW</tool-use-id>\
+            <status>completed</status>\
+            <summary>Background command \"Wait until PR 3392 CI settles\" completed (exit code 0)</summary>\
+            </task-notification>";
+        let parsed = parse_task_notification(bg);
+        assert_eq!(
+            parsed.tool_use_id.as_deref(),
+            Some("toolu_01Ls2svfdnzcn9uGwA7aHjHW")
+        );
+        assert_eq!(parsed.kind(), "background");
+
+        // Subagent (`Agent "…"`) and workflow (`Dynamic workflow "…"`) prefixes.
+        let subagent = payload(&[
+            ("tool-use-id", "toolu_018F3HtbweDDNEbi44HKAhhi"),
+            ("status", "completed"),
+            ("summary", "Agent \"Scout issues\" completed"),
+        ]);
+        let parsed = parse_task_notification(&subagent);
+        assert_eq!(
+            parsed.tool_use_id.as_deref(),
+            Some("toolu_018F3HtbweDDNEbi44HKAhhi")
+        );
+        assert_eq!(parsed.kind(), "subagent");
+
+        let workflow = payload(&[
+            ("status", "completed"),
+            ("summary", "Dynamic workflow \"#3277 fix\" completed"),
+        ]);
+        assert_eq!(parse_task_notification(&workflow).kind(), "workflow");
+
+        // A lost-process `Background agent "…"` notification omits tool-use-id;
+        // it still classifies as `subagent` (the safe default) with `None` id.
+        let bg_agent = payload(&[
+            ("status", "failed"),
+            (
+                "summary",
+                "Background agent \"Rebase\" was running … did not complete.",
+            ),
+        ]);
+        let parsed = parse_task_notification(&bg_agent);
+        assert_eq!(parsed.tool_use_id, None);
+        assert_eq!(parsed.kind(), "subagent");
     }
 
     #[test]


### PR DESCRIPTION
Closes #3393.

## 문제
백그라운드 작업/서브에이전트 완료는 transcript에 user 레코드 `<task-notification>` XML로만 도착하는데, 패널 terminal 인제스천은 실존하지 않는 stream-json system 레코드만 파싱 → footer ✓는 라이브에서 구조적으로 불가능했고, #3391 eviction도 트리거 불가 (라이브 실측 2026-06-12 13:42Z).

## 변경 (2커밋)
1. **round 1**: tui_task_card.rs의 단일 XML 파서 공유(tool-use-id 추출 + summary 프리픽스 기반 kind 도출), `status_events_from_task_notification_xml[_for_footer_mode]` → 기존 kind→event 매핑 재사용, tui_prompt_relay.rs TaskNotificationEvent 분기(Post/Repeat 모두)에 브리지 + INFO 로그 1줄, footer-mode 게이팅.
2. **round 2 (codex P1+P2 2건)**: ① id-less terminal 이벤트 차단(XML 경로 한정 — 잘못된 "마지막 미완료 subagent" 종결 방지) ② 브리지 호출부 start-anchor 가드(인용 오탐 차단, 카드는 기존 동작 유지) ③ WorkflowEnd에 terminal 게이트.

## 검증
- codex 적대 리뷰 2라운드 → 최종 **VERDICT: CLEAN**
- fail-on-HEAD 검증 테스트 8건 (render-through 통합 4 + 파서 1 + r2 핀 3)
- 독립 게이트: fmt·clippy·placeholder_live_events 128·tui_prompt_relay 109·discord 1644·audit(캡 인상 0, status_events.rs 정확히 700 유지)·docs freshness
- 구현 opus / 리뷰 codex

🤖 Generated with [Claude Code](https://claude.com/claude-code)