### PR TITLE
refactor(#3038): VoiceBargeInRuntime S7 — agent-voice routing 헬퍼를 routing 자식으로 통합

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -802,7 +802,7 @@
     was removed from `giant_file_registry.toml`; #3038 S5 locked the final
     root ratchet at 274 production lines).
   - `src/services/discord/session_runtime.rs` (1753 lines).
-  - `src/services/discord/voice_barge_in.rs` (3136 lines after #3038
+  - `src/services/discord/voice_barge_in.rs` (3044 lines after #3038
     VoiceBargeInRuntime S1 moved the STT method cluster to
     `src/services/discord/voice_barge_in/stt.rs` (314 production lines) and
     S2 moved the progress playback method cluster to
@@ -815,6 +815,8 @@
     `src/services/discord/voice_barge_in/live_cut_playback.rs` (120 production
     lines), and S6 moved the TTS pipeline cluster to
     `src/services/discord/voice_barge_in/tts_pipeline.rs` (86 production
+    lines), and S7 folded the agent-voice routing helper block into
+    `src/services/discord/voice_barge_in/routing.rs` (now 484 production
     lines);
     voice STT/TTS, lobby routing, progress mirroring, and barge-in
     orchestration surface; tracked decompose target — see

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -112,7 +112,10 @@
 # #3038 VoiceBargeInRuntime S6: lowered 3217 -> 3136 (-81) as the TTS pipeline
 # method cluster moved to `voice_barge_in/tts_pipeline.rs` (86 prod LoC, below
 # the giant threshold). Locks in the shrink win.
-"src/services/discord/voice_barge_in.rs" = 3136
+# #3038 VoiceBargeInRuntime S7: lowered 3136 -> 3044 (-92) as the agent-voice
+# routing helper block folded into `voice_barge_in/routing.rs` (383 -> 484 prod
+# LoC, below the giant threshold). Locks in the shrink win.
+"src/services/discord/voice_barge_in.rs" = 3044
 # #3248: +60 for the gap-1 deploy-survivable-relay fix —
 # `reseed_watcher_owned_finalizer_ledger` + two guarded reattach call-sites that
 # re-register the watcher-owned turn in the post-restart finalizer ledger (a P1

--- a/src/services/discord/voice_barge_in.rs
+++ b/src/services/discord/voice_barge_in.rs
@@ -53,6 +53,12 @@ mod live_cut_playback;
 mod progress_playback;
 #[path = "voice_barge_in/routing.rs"]
 mod routing;
+// S7 (#3038): the agent-voice routing helper block moved into the `routing`
+// child; re-import the root-prod-consumed members so call sites resolve them
+// unqualified (the test-only members are re-imported inside `mod tests`).
+use routing::{
+    agent_voice_background_channel, agent_voice_matches_channel, effective_voice_source_channel,
+};
 #[path = "voice_barge_in/stt.rs"]
 mod stt;
 #[path = "voice_barge_in/tts_pipeline.rs"]
@@ -393,104 +399,6 @@ fn normalized_foreground_timeout_ms(value: u64) -> u64 {
     } else {
         value
     }
-}
-
-fn agent_voice_matches_channel(agent: &crate::config::AgentDef, channel_id: ChannelId) -> bool {
-    agent
-        .voice
-        .channel_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .and_then(|value| value.parse::<u64>().ok())
-        == Some(channel_id.get())
-}
-
-fn agent_voice_channel(agent: &crate::config::AgentDef) -> Option<ChannelId> {
-    agent
-        .voice
-        .channel_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .and_then(|value| value.parse::<u64>().ok())
-        .map(ChannelId::new)
-}
-
-fn agent_voice_background_channel(agent: &crate::config::AgentDef) -> Option<ChannelId> {
-    let preferred_provider = agent.provider.trim();
-    if !preferred_provider.is_empty()
-        && let Some((_, Some(channel))) = agent
-            .channels
-            .iter()
-            .into_iter()
-            .find(|(provider, channel)| *provider == preferred_provider && channel.is_some())
-        && let Some(channel_id) = channel
-            .channel_id()
-            .and_then(|value| value.parse::<u64>().ok())
-    {
-        return Some(ChannelId::new(channel_id));
-    }
-
-    agent
-        .channels
-        .iter()
-        .into_iter()
-        .filter_map(|(_, channel)| channel)
-        .find_map(|channel| {
-            channel
-                .channel_id()
-                .and_then(|value| value.parse::<u64>().ok())
-                .map(ChannelId::new)
-        })
-}
-
-fn agent_voice_background_channel_for(
-    agent: &crate::config::AgentDef,
-    voice_channel_id: ChannelId,
-) -> Option<ChannelId> {
-    agent_voice_matches_channel(agent, voice_channel_id)
-        .then(|| agent_voice_background_channel(agent))
-        .flatten()
-}
-
-fn agent_voice_channel_for_background(
-    agent: &crate::config::AgentDef,
-    background_channel_id: ChannelId,
-) -> Option<ChannelId> {
-    let voice_channel_id = agent_voice_channel(agent)?;
-    (agent_voice_background_channel(agent) == Some(background_channel_id))
-        .then_some(voice_channel_id)
-}
-
-fn agent_voice_source_channel_for_background(
-    config: &crate::config::Config,
-    background_channel_id: ChannelId,
-) -> Option<ChannelId> {
-    let mut matches = config
-        .agents
-        .iter()
-        .filter_map(|agent| agent_voice_channel_for_background(agent, background_channel_id));
-    let first = matches.next()?;
-    matches.next().is_none().then_some(first)
-}
-
-fn effective_voice_source_channel(
-    config: &crate::config::Config,
-    channel_id: ChannelId,
-) -> ChannelId {
-    agent_voice_source_channel_for_background(config, channel_id).unwrap_or(channel_id)
-}
-
-fn agent_text_channel_matches(agent: &crate::config::AgentDef, channel_id: ChannelId) -> bool {
-    let channel_id = channel_id.get().to_string();
-    agent
-        .channels
-        .iter()
-        // AgentChannels::iter returns a fixed array, so into_iter is required.
-        .into_iter()
-        .filter_map(|(_, channel)| channel)
-        .any(|channel| channel.channel_id().as_deref() == Some(channel_id.as_str()))
 }
 
 fn foreground_ack_text(transcript: &str, language: &str) -> String {
@@ -3137,6 +3045,12 @@ fn lock_monitor(
 #[cfg(test)]
 mod tests {
     use super::*;
+    // S7 (#3038): test-only agent-voice routing helpers now live in the
+    // `routing` child (the prod-consumed ones arrive via `use super::*`).
+    use super::routing::{
+        agent_voice_background_channel_for, agent_voice_channel_for_background,
+        agent_voice_source_channel_for_background,
+    };
     use std::sync::atomic::AtomicUsize;
 
     #[derive(Default)]

--- a/src/services/discord/voice_barge_in/routing.rs
+++ b/src/services/discord/voice_barge_in/routing.rs
@@ -381,3 +381,104 @@ impl VoiceBargeInRuntime {
         }
     }
 }
+
+pub(super) fn agent_voice_matches_channel(
+    agent: &crate::config::AgentDef,
+    channel_id: ChannelId,
+) -> bool {
+    agent
+        .voice
+        .channel_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .and_then(|value| value.parse::<u64>().ok())
+        == Some(channel_id.get())
+}
+
+fn agent_voice_channel(agent: &crate::config::AgentDef) -> Option<ChannelId> {
+    agent
+        .voice
+        .channel_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(ChannelId::new)
+}
+
+pub(super) fn agent_voice_background_channel(agent: &crate::config::AgentDef) -> Option<ChannelId> {
+    let preferred_provider = agent.provider.trim();
+    if !preferred_provider.is_empty()
+        && let Some((_, Some(channel))) = agent
+            .channels
+            .iter()
+            .into_iter()
+            .find(|(provider, channel)| *provider == preferred_provider && channel.is_some())
+        && let Some(channel_id) = channel
+            .channel_id()
+            .and_then(|value| value.parse::<u64>().ok())
+    {
+        return Some(ChannelId::new(channel_id));
+    }
+
+    agent
+        .channels
+        .iter()
+        .into_iter()
+        .filter_map(|(_, channel)| channel)
+        .find_map(|channel| {
+            channel
+                .channel_id()
+                .and_then(|value| value.parse::<u64>().ok())
+                .map(ChannelId::new)
+        })
+}
+
+pub(super) fn agent_voice_background_channel_for(
+    agent: &crate::config::AgentDef,
+    voice_channel_id: ChannelId,
+) -> Option<ChannelId> {
+    agent_voice_matches_channel(agent, voice_channel_id)
+        .then(|| agent_voice_background_channel(agent))
+        .flatten()
+}
+
+pub(super) fn agent_voice_channel_for_background(
+    agent: &crate::config::AgentDef,
+    background_channel_id: ChannelId,
+) -> Option<ChannelId> {
+    let voice_channel_id = agent_voice_channel(agent)?;
+    (agent_voice_background_channel(agent) == Some(background_channel_id))
+        .then_some(voice_channel_id)
+}
+
+pub(super) fn agent_voice_source_channel_for_background(
+    config: &crate::config::Config,
+    background_channel_id: ChannelId,
+) -> Option<ChannelId> {
+    let mut matches = config
+        .agents
+        .iter()
+        .filter_map(|agent| agent_voice_channel_for_background(agent, background_channel_id));
+    let first = matches.next()?;
+    matches.next().is_none().then_some(first)
+}
+
+pub(super) fn effective_voice_source_channel(
+    config: &crate::config::Config,
+    channel_id: ChannelId,
+) -> ChannelId {
+    agent_voice_source_channel_for_background(config, channel_id).unwrap_or(channel_id)
+}
+
+fn agent_text_channel_matches(agent: &crate::config::AgentDef, channel_id: ChannelId) -> bool {
+    let channel_id = channel_id.get().to_string();
+    agent
+        .channels
+        .iter()
+        // AgentChannels::iter returns a fixed array, so into_iter is required.
+        .into_iter()
+        .filter_map(|(_, channel)| channel)
+        .any(|channel| channel.channel_id().as_deref() == Some(channel_id.as_str()))
+}


### PR DESCRIPTION
EPIC #3038 god-object 트랙, VoiceBargeInRuntime S7. S6 codex 리뷰가 지목한 잔여 클러스터 처리.

## 내용
- agent-voice routing 헬퍼 8개(`agent_voice_matches_channel`, `agent_voice_channel`, reverse/source-channel 헬퍼, `agent_text_channel_matches` 등)를 기존 `voice_barge_in/routing.rs`로 verbatim 이동.
- ratchet: voice_barge_in.rs **3136 → 3044 (-92)**, routing.rs 383→484 (<1000).
- codex 리뷰 2라운드: r1 P0(rustfmt 강제 trailing comma — 의미 동일 확인)+P2(과잉 pub(super) 2건→private 축소), r2 P3(문서 카운트 487→484 교정). 최종 잔여 = rustfmt 강제 아티팩트만 (기존 슬라이스에서 수용된 동일 클래스).
- 커밋 본문 마감 평가: 잔여 = foreground decision/parser 클러스터(S8 후보).
- 구현 opus / 리뷰 codex.

## 게이트 (독립 재검증)
fmt / check / clippy -D warnings / voice 277 / discord 1636 / audit ratchet / docs freshness

🤖 Generated with [Claude Code](https://claude.com/claude-code)