### PR TITLE
fix(#3394): 펜스-안전 패널 절단 — 섹션 단위 강등 + 패리티 백스톱

### DIFF
--- a/src/services/discord/placeholder_live_events/status_panel.rs
+++ b/src/services/discord/placeholder_live_events/status_panel.rs
@@ -33,9 +33,9 @@ pub(super) struct SubagentSlot {
     /// #3086: TUI-parity accounting from the finishing `SubagentEnd`; drives the
     /// `Done (N tools · M tokens · Xs)` summary on the render line.
     summary: Option<SubagentSummary>,
-    /// `true` when launched with `run_in_background`. Its immediate Task result
-    /// is only a launch ack (the slot keeps running), so an ack-only
-    /// `SubagentEnd` must NOT mark it ✓ — only a genuine completion finalizes it.
+    /// `true` when launched with `run_in_background`. Its immediate Task result is
+    /// only a launch ack (slot keeps running), so an ack-only `SubagentEnd` must
+    /// NOT mark it ✓ — only a genuine completion finalizes it.
     background: bool,
     /// #3391: monotonic, never-reused per-entry slot id (mirrors
     /// `TaskToolSlot::ordinal`) backing slot-identity subagent eviction.
@@ -100,8 +100,8 @@ pub(super) struct StatusPanelState {
 impl StatusPanelState {
     /// #3087: on a true session boundary (provider session id delta), clears the
     /// per-session content slots (subagents/tasks/todos/workflows) and resets the
-    /// derived status to `Running`, while PRESERVING the context/token usage and
-    /// session-panel snapshots. The ordinal counter is preserved (never cleared).
+    /// status to `Running`, PRESERVING context/token usage + session snapshots and
+    /// the ordinal counter (never cleared).
     pub(super) fn reset_session_content(&mut self) {
         self.status = DerivedStatus::Running;
         self.todos.clear();
@@ -212,21 +212,18 @@ impl StatusPanelState {
                 summary,
                 ack_only,
             } => {
-                // #3084: close the slot whose Task tool-use id matches the
-                // result (pairs a long-running subagent to its own result among
-                // parallels); fall back to the first unfinished slot only when
-                // no id is available or matches.
+                // #3084: close the slot whose Task tool-use id matches the result
+                // (pairs a long-running subagent to its own result among
+                // parallels); fall back to first-unfinished only without an id.
                 let id = tool_use_id.as_deref();
                 let matched = id.and_then(|id| {
                     self.subagents.iter().rposition(|slot| {
                         slot.finished.is_none() && slot.tool_use_id.as_deref() == Some(id)
                     })
                 });
-                // #3086 P1 / #3359: a summary-bearing OR id-bearing ack-only end
-                // is safe only on an exact id match — never fall back to the
-                // last-unfinished slot (would mis-mark an unrelated running
-                // subagent, or prematurely ✓ a still-running background dispatch).
-                // Id-less legacy acks may close only id-less slots.
+                // #3086 P1 / #3359: a summary- OR id-bearing ack-only end is safe
+                // only on an exact id match (else mis-marks a running/background
+                // subagent); id-less legacy acks may close only id-less slots.
                 let has_summary = summary.as_ref().is_some_and(|s| !s.is_empty());
                 let target = match matched {
                     Some(index) => Some(index),
@@ -400,8 +397,8 @@ impl StatusPanelState {
     }
 
     /// #3204/#3198: routes a running subagent's live step onto its slot's recent
-    /// line. Prefers the UNFINISHED slot whose Task id matches; an id-bearing
-    /// activity matching no slot is dropped (never mis-routed/resurrected).
+    /// line. Prefers the UNFINISHED id-matching slot; an id-bearing no-match is
+    /// dropped (never mis-routed/resurrected).
     fn set_subagent_activity(&mut self, tool_use_id: Option<String>, summary: String) {
         let id = tool_use_id.as_deref();
         let target =
@@ -543,22 +540,13 @@ pub(super) fn render_status_panel(
         cluster_enabled,
         local_instance_id.as_deref(),
     );
-    let recent_section = if matches!(header_status, DerivedStatus::Completed { .. }) {
-        None
-    } else {
-        live_block
-            .filter(|block| !block.trim().is_empty())
-            .map(|block| format!("{recent_header}\n{block}"))
-    };
-    if let Some(recent) = recent_section.as_ref() {
-        let mut with_recent = sections.clone();
-        with_recent.push(recent.clone());
-        let joined = join_status_panel_sections(&with_recent);
-        if joined.chars().count() <= STATUS_PANEL_MAX_CHARS {
-            return joined;
-        }
+    // #3394: append the fence-balanced Recent block as a trailing section so the
+    // protected truncation path drops it whole on overflow (never chops its ```).
+    if !matches!(header_status, DerivedStatus::Completed { .. })
+        && let Some(block) = live_block.filter(|block| !block.trim().is_empty())
+    {
+        sections.push(format!("{recent_header}\n{block}"));
     }
-
     truncate_status_panel_sections(sections)
 }
 
@@ -566,12 +554,24 @@ fn join_status_panel_sections(sections: &[String]) -> String {
     sections.join("\n\n")
 }
 
-pub(super) fn truncate_status_panel_sections(sections: Vec<String>) -> String {
+/// #3394: section-wise degradation. A blind char cut of the JOINED panel chops
+/// the trailing fenced section's closing ``` and Discord renders the dangling
+/// fence as literal text. So when the join overflows, DROP whole sections from
+/// the END (Recent first) — never cut inside one; only a lone surviving section
+/// that alone overflows is fence-safe-truncated. The shared `repair_fence_parity`
+/// backstop re-balances every return path.
+pub(super) fn truncate_status_panel_sections(mut sections: Vec<String>) -> String {
+    use crate::services::discord::single_message_panel::repair_fence_parity;
+    while sections.len() > 1
+        && join_status_panel_sections(&sections).chars().count() > STATUS_PANEL_MAX_CHARS
+    {
+        sections.pop();
+    }
     let joined = join_status_panel_sections(&sections);
     if joined.chars().count() <= STATUS_PANEL_MAX_CHARS {
-        return joined;
+        return repair_fence_parity(&joined);
     }
-    truncate_chars(&joined, STATUS_PANEL_MAX_CHARS)
+    repair_fence_parity(&truncate_chars(&joined, STATUS_PANEL_MAX_CHARS))
 }
 
 pub(super) fn render_recent_section_header(
@@ -656,8 +656,8 @@ pub(super) fn render_subagent_slot(slot: &SubagentSlot) -> String {
         line.push_str(" — ");
         line.push_str(&done);
     }
-    // #3391: reserve the marker width then append, so a finished subagent line
-    // always ENDS WITH its ✓/✗ (a long desc/summary can no longer swallow it).
+    // #3391: reserve marker width then append so a finished line always ENDS WITH
+    // its ✓/✗ (a long desc/summary can no longer swallow it).
     match slot.terminal_marker() {
         Some(marker) => truncate_chars_with_marker(&line, marker, EVENT_LINE_MAX_CHARS),
         None => truncate_chars(&line, EVENT_LINE_MAX_CHARS),

--- a/src/services/discord/placeholder_live_events/tests.rs
+++ b/src/services/discord/placeholder_live_events/tests.rs
@@ -5075,3 +5075,131 @@ fn task_notification_xml_workflow_gates_workflow_end_on_terminal_status() {
         "status=failed workflow XML must emit WorkflowEnd{{success:false}}: {failed_events:?}"
     );
 }
+
+// #3394: fence-safe truncation regression coverage.
+
+fn fence_count(text: &str) -> usize {
+    text.matches("```").count()
+}
+
+/// #3394 (1): when the joined panel exceeds the limit, the trailing fenced
+/// Recent block must be DROPPED WHOLE — not chopped into a dangling ```text — and
+/// the earlier sections must survive intact, with an even (balanced) fence count.
+#[test]
+fn truncate_panel_drops_trailing_fenced_section_whole_when_over_limit() {
+    let tasks = format!("Tasks\n{}", "T".repeat(880));
+    let subagents = format!("Subagents\n{}", "S".repeat(880));
+    let recent = format!("🖥️ Recent\n```text\n{}\n```", "R".repeat(400));
+    let sections = vec![tasks.clone(), subagents.clone(), recent];
+    // Precondition: the full join overflows, but Tasks+Subagents alone fit — so
+    // dropping ONLY the trailing fenced Recent block is the correct degradation.
+    assert!(sections.join("\n\n").chars().count() > STATUS_PANEL_MAX_CHARS);
+    assert!(
+        format!("{tasks}\n\n{subagents}").chars().count() <= STATUS_PANEL_MAX_CHARS,
+        "fixture sizing: earlier sections must fit once Recent is dropped"
+    );
+
+    let rendered = truncate_status_panel_sections(sections);
+
+    assert!(rendered.chars().count() <= STATUS_PANEL_MAX_CHARS);
+    // No unterminated fence and no literal dangling ```text.
+    assert_eq!(fence_count(&rendered) % 2, 0, "odd fence count: {rendered}");
+    assert!(!rendered.contains("```text"), "literal ```text leaked");
+    // Degradation is visible: Recent gone, earlier sections kept verbatim.
+    assert!(!rendered.contains("🖥️ Recent"), "Recent not dropped");
+    assert!(rendered.contains(&tasks), "Tasks section was cut");
+    assert!(rendered.contains(&subagents), "Subagents section was cut");
+}
+
+/// #3394 (2): a single fenced section that ALONE exceeds the limit can't be
+/// dropped (nothing else to shed), so it is fence-safe truncated — never left
+/// with a dangling opener.
+#[test]
+fn truncate_panel_fence_safe_when_single_section_overflows() {
+    let oversized = format!(
+        "🖥️ Recent\n```text\n{}\n```",
+        "X".repeat(STATUS_PANEL_MAX_CHARS + 200)
+    );
+    let rendered = truncate_status_panel_sections(vec![oversized]);
+
+    assert!(rendered.chars().count() <= STATUS_PANEL_MAX_CHARS);
+    assert_eq!(fence_count(&rendered) % 2, 0, "odd fence count: {rendered}");
+}
+
+/// #3394 (3): parity helper — balanced/odd, exact boundary, and the Discord
+/// no-nesting semantic (a ``` INSIDE a fenced block CLOSES it).
+#[test]
+fn repair_fence_parity_unit_cases() {
+    use crate::services::discord::single_message_panel::repair_fence_parity;
+    // Balanced input is returned unchanged.
+    let balanced = "a\n```text\nbody\n```\ntail";
+    assert_eq!(repair_fence_parity(balanced), balanced);
+    // No fences at all is unchanged.
+    assert_eq!(repair_fence_parity("plain text"), "plain text");
+    // Odd (dangling opener): the opener and everything after it is removed.
+    let odd = "header\n\n```text\nchopped body";
+    let repaired = repair_fence_parity(odd);
+    assert_eq!(fence_count(&repaired) % 2, 0);
+    assert!(!repaired.contains("```"));
+    assert_eq!(repaired, "header");
+    // Fence at the exact end (closer present) stays balanced/unchanged.
+    let closed = "```text\nx\n```";
+    assert_eq!(repair_fence_parity(closed), closed);
+    // Three fences (open/close/open) — the third is a dangling opener and is
+    // dropped; the first open+close pair (no nesting) is preserved.
+    let three = "```text\nfirst\n```\nmid\n```text\nsecond";
+    let repaired_three = repair_fence_parity(three);
+    assert_eq!(fence_count(&repaired_three) % 2, 0);
+    assert_eq!(repaired_three, "```text\nfirst\n```\nmid");
+}
+
+/// #3394 (3): a fence that LOOKS nested is a closer under Discord semantics, so
+/// a four-fence sequence is balanced and must be left untouched.
+#[test]
+fn repair_fence_parity_treats_inner_fence_as_closer() {
+    use crate::services::discord::single_message_panel::repair_fence_parity;
+    let four = "```\nouter\n```\n```\nsecond\n```";
+    assert_eq!(repair_fence_parity(four), four);
+    assert_eq!(fence_count(four) % 2, 0);
+}
+
+/// #3394 (3): the in-turn LIVE panel routes through the protected truncation
+/// path. With bloated Tasks/Subagents PLUS a fenced Recent live block (the
+/// reported screenshot shape), the rendered panel stays under the limit and never
+/// exposes a dangling fence (the ``` count is always even, balanced or dropped).
+#[test]
+fn live_status_panel_never_leaks_dangling_fence_when_bloated() {
+    let events = PlaceholderLiveEvents::default();
+    let channel_id = ChannelId::new(3394);
+
+    for idx in 0..STATUS_PANEL_SUBAGENT_LIMIT {
+        events.push_status_events(
+            channel_id,
+            status_events_from_tool_use(
+                "Task",
+                &json!({
+                    "subagent_type": "explorer",
+                    "description": format!("subagent {idx} {}", "d".repeat(180))
+                })
+                .to_string(),
+            ),
+        );
+    }
+    // Fenced Recent live block (mirrors recent_events.rs ```text fence).
+    for idx in 0..6 {
+        events.push_event(
+            channel_id,
+            RecentPlaceholderEvent::tool_use("Bash", &format!(r#"{{"command":"echo {idx}"}}"#))
+                .unwrap(),
+        );
+    }
+
+    let rendered = events.render_status_panel(channel_id, &ProviderKind::Claude, 1_700_000_000);
+
+    assert!(rendered.chars().count() <= STATUS_PANEL_MAX_CHARS);
+    assert_eq!(
+        fence_count(&rendered) % 2,
+        0,
+        "live panel leaked an unterminated fence: {rendered}"
+    );
+}

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -128,7 +128,9 @@ pub(in crate::services::discord) fn compose_completion_footer_text(
         body
     }
     .trim_end();
-    format!("{base}{suffix}")
+    // #3394: backstop the Discord-limit body trim — if it chopped a code fence in
+    // the streamed response body, re-balance before the block is appended.
+    repair_fence_parity(&format!("{base}{suffix}"))
 }
 
 pub(in crate::services::discord) fn finalize_streaming_footer_with_completion(
@@ -452,17 +454,59 @@ fn clamp_footer_panel_text(panel_text: &str) -> String {
 }
 
 fn clamp_footer_status_block(status_block: String) -> String {
+    // #3394: this is the universal live-panel finalization sink (every
+    // `compose_footer_status_block` call lands here, after the upstream 600-byte
+    // `clamp_footer_panel_text` body trim and this Discord-limit trim — either of
+    // which can chop the Recent block's closing ```). Re-balance fence parity on
+    // EVERY return path so Discord never renders a dangling fence as literal text.
     let max_bytes = super::DISCORD_MSG_LIMIT.saturating_sub(6);
-    if status_block.len() <= max_bytes {
-        return status_block;
+    let clamped = if status_block.len() <= max_bytes {
+        status_block
+    } else {
+        let ellipsis = "…";
+        let body_budget = max_bytes.saturating_sub(ellipsis.len());
+        if body_budget == 0 {
+            ellipsis.to_string()
+        } else {
+            let safe_end = super::formatting::floor_char_boundary(&status_block, body_budget);
+            format!("{}{}", &status_block[..safe_end], ellipsis)
+        }
+    };
+    repair_fence_parity(&clamped)
+}
+
+/// #3394: shared triple-backtick fence-parity backstop. Discord renders an
+/// UNTERMINATED code fence as literal text (the reported bug: a blind char cut
+/// chopped the closing ``` of the trailing fenced section). After ANY truncation
+/// of panel text, re-balance by counting ``` runs: if the count is ODD, the last
+/// opener is dangling, so REMOVE that opener and everything after it.
+///
+/// Removal is chosen over appending a closing fence because the truncated tail is
+/// already incomplete content — re-closing it would resurrect a tiny orphan code
+/// block of cut-off text; dropping it keeps the output clean. Under Discord
+/// semantics there is no fence nesting (a ``` inside a fenced block CLOSES it), so
+/// plain parity counting is correct. Lives here, the panel-text finalization
+/// layer; `status_panel.rs` calls it via the full crate path after its own
+/// section-wise truncation.
+pub(in crate::services::discord) fn repair_fence_parity(text: &str) -> String {
+    let mut count = 0usize;
+    let mut last_open: Option<usize> = None;
+    for (idx, _) in text.match_indices("```") {
+        // Every other fence (1st, 3rd, ...) is an opener; track the latest one.
+        if count % 2 == 0 {
+            last_open = Some(idx);
+        }
+        count += 1;
     }
-    let ellipsis = "…";
-    let body_budget = max_bytes.saturating_sub(ellipsis.len());
-    if body_budget == 0 {
-        return ellipsis.to_string();
+    if count % 2 == 0 {
+        return text.to_string();
     }
-    let safe_end = super::formatting::floor_char_boundary(&status_block, body_budget);
-    format!("{}{}", &status_block[..safe_end], ellipsis)
+    // Odd count: drop the dangling opener and its trailing content; trim the now
+    // exposed tail so no blank line is left where the fence used to start.
+    match last_open {
+        Some(cut) => text[..cut].trim_end().to_string(),
+        None => text.to_string(),
+    }
 }
 
 pub(in crate::services::discord) fn finalize_streaming_footer(
@@ -803,6 +847,26 @@ mod tests {
         assert!(panel.len() <= super::SINGLE_MESSAGE_PANEL_FOOTER_BUDGET_BYTES);
         assert!(panel.ends_with("\n…") || panel == "…");
         assert!(block.len() > super::SINGLE_MESSAGE_PANEL_FOOTER_BUDGET_BYTES);
+    }
+
+    /// #3394: the footer finalization sink must re-balance fence parity. A panel
+    /// whose fenced Recent block is chopped by the 600-byte body clamp must not
+    /// emit a dangling ``` for Discord to render as literal text.
+    #[test]
+    fn footer_status_block_repairs_dangling_fence_after_clamp_3394() {
+        let panel = format!(
+            "🟢 진행 중 — Claude (<t:1700000000:R>)\n🖥️ Recent\n```text\n{}\n```",
+            "echo hello\n".repeat(120)
+        );
+        let block = super::compose_footer_status_block("⠸", &panel);
+
+        let fences = block.matches("```").count();
+        assert_eq!(
+            fences % 2,
+            0,
+            "footer leaked an unterminated fence: {block}"
+        );
+        assert!(!block.contains("```text") || fences >= 2);
     }
 
     #[test]

--- a/src/services/discord/single_message_panel.rs
+++ b/src/services/discord/single_message_panel.rs
@@ -128,9 +128,43 @@ pub(in crate::services::discord) fn compose_completion_footer_text(
         body
     }
     .trim_end();
-    // #3394: backstop the Discord-limit body trim — if it chopped a code fence in
-    // the streamed response body, re-balance before the block is appended.
-    repair_fence_parity(&format!("{base}{suffix}"))
+    // #3394 round 2 (boundary-scoped repair): repair the BODY alone, THEN append
+    // the footer block — never run `repair_fence_parity` over the combined string.
+    // `repair_fence_parity` drops the last dangling opener THROUGH end-of-string,
+    // so a body whose fence was chopped by the Discord-limit trim above would, on
+    // the combined `{base}{suffix}`, take the appended footer down with it.
+    //
+    // #3391 delivered-ID honesty invariant: `delivered_terminal_ids` for this
+    // footer were already computed from the footer block (completion_footer.rs:202)
+    // and are evicted once this edit returns Ok. If repair ate the footer, the
+    // ✓/✗ marks would vanish from the delivered text yet their slots would still
+    // be evicted — reporting marks the user never saw. Repairing only the body
+    // keeps every footer mark in the delivered text, so whenever this edit
+    // succeeds every reported terminal slot's mark was actually present.
+    //
+    // The footer block is fence-balanced by construction: `render_completion_footer`
+    // emits only the Context line plus Tasks/Subagents slot lines (no fenced Recent
+    // block lives here), so it carries zero ``` runs (an even count). balanced base
+    // + balanced footer = balanced combined.
+    let base = repair_fence_parity(base);
+    let combined = format!("{base}{suffix}");
+    debug_assert_eq!(
+        combined.matches("```").count() % 2,
+        0,
+        "boundary-scoped repair left odd combined fence parity: {combined:?}"
+    );
+    // Runtime backstop: if the footer block ever did carry an odd fence (a future
+    // change to the completion-footer composition), repair the footer SEPARATELY so
+    // each part is balanced — never run a combined repair that could reach back
+    // across the boundary and delete the body's tail or the footer's marks. The
+    // already-repaired `base` stays balanced; balanced base + balanced footer =
+    // balanced combined. With today's fence-free footer this branch is unreachable,
+    // which the debug_assert above enforces in test builds.
+    if combined.matches("```").count() % 2 != 0 {
+        let repaired_suffix = repair_fence_parity(&suffix);
+        return format!("{base}{repaired_suffix}");
+    }
+    combined
 }
 
 pub(in crate::services::discord) fn finalize_streaming_footer_with_completion(
@@ -867,6 +901,106 @@ mod tests {
             "footer leaked an unterminated fence: {block}"
         );
         assert!(!block.contains("```text") || fences >= 2);
+    }
+
+    /// #3394 round 2 (P1): when the response BODY carries an unterminated code
+    /// fence (the Discord-limit trim cut inside a body fence), the boundary-scoped
+    /// repair must drop only the body's dangling opener and KEEP the appended
+    /// completion footer — its ✓ marks must survive. On HEAD the combined repair
+    /// deleted from the body opener through the footer, taking the ✓ with it while
+    /// #3391 still evicted the slot, breaking delivered-ID honesty.
+    #[test]
+    fn compose_completion_footer_repair_scoped_to_body_keeps_footer_marks_3394() {
+        let body = "Here is some output:\n\n```text\nchopped streamed body";
+        let footer = "Context   📦 154.6k / 1.0M tokens (15%)\n\nTasks\n└ Bash Finished job ✓";
+        let composed = super::compose_completion_footer_text(body, Some(footer));
+
+        // The footer block (and its terminal ✓) survives composition.
+        assert!(
+            composed.contains("Bash Finished job ✓"),
+            "footer ✓ was deleted by combined fence repair: {composed}"
+        );
+        assert!(composed.contains("Context   📦"));
+        assert!(composed.contains("Tasks"));
+        // The body's dangling opener is dropped (boundary-scoped repair).
+        assert!(
+            !composed.contains("```text"),
+            "body dangling fence leaked: {composed}"
+        );
+        assert!(composed.contains("Here is some output:"));
+        // Combined parity is even.
+        assert_eq!(
+            composed.matches("```").count() % 2,
+            0,
+            "composed text has odd fence parity: {composed}"
+        );
+    }
+
+    /// #3394 round 2 (P1): the registered-refresh composition site
+    /// (`completion_footer_edit_for_registered_target_at`, ~258) shares the
+    /// `compose_completion_footer_text` pattern. A registered body carrying an
+    /// unterminated fence must still emit the rendered footer's terminal ✓ in the
+    /// delivered edit text, with even combined parity — so the #3391 eviction that
+    /// follows a successful edit only drops marks the user actually saw.
+    #[test]
+    fn registered_refresh_repair_scoped_to_body_keeps_footer_marks_3394() {
+        let channel_id = ChannelId::new(3_394_201);
+        super::completion_footer_forget_registered_target(channel_id);
+        let shared = push_finished_and_running_background_tasks(channel_id);
+        let body_with_dangling_fence = "Streaming reply\n\n```text\ncut off mid fence";
+        let _ = super::register_completion_footer_target(
+            channel_id,
+            MessageId::new(3_394_301),
+            &ProviderKind::Claude,
+            1_800_000_000,
+            body_with_dangling_fence,
+            None,
+            true,
+        );
+
+        let edit = super::completion_footer_edit_for_registered_target_at(
+            shared.as_ref(),
+            channel_id,
+            "⠸",
+            1_800_000_001,
+        )
+        .expect("registered refresh should render the terminal mark");
+
+        assert!(
+            edit.text.contains("Bash Finished job ✓"),
+            "registered-refresh footer ✓ was deleted by fence repair: {}",
+            edit.text
+        );
+        assert!(edit.text.contains("Bash Running job ⠸"));
+        assert!(
+            !edit.text.contains("```text"),
+            "body dangling fence leaked: {}",
+            edit.text
+        );
+        assert_eq!(
+            edit.text.matches("```").count() % 2,
+            0,
+            "registered-refresh composed text has odd fence parity: {}",
+            edit.text
+        );
+        // #3391: the delivered ✓ slot identity is reported for this edit, and it is
+        // genuinely present in the delivered text above.
+        assert!(!edit.delivered_terminal_ids.is_empty());
+        super::completion_footer_forget_registered_target(channel_id);
+    }
+
+    /// #3394 round 2: a body with a BALANCED fence and a footer compose without
+    /// any repair touching the body's closed fence — parity stays even and both
+    /// the fenced body and the footer survive intact.
+    #[test]
+    fn compose_completion_footer_keeps_balanced_body_fence_intact_3394() {
+        let body = "intro\n\n```text\nclosed body\n```\noutro";
+        let footer = "Context   📦 1.0k / 1.0M tokens (1%)\n\nTasks\n└ Bash Done ✓";
+        let composed = super::compose_completion_footer_text(body, Some(footer));
+
+        assert!(composed.contains("```text\nclosed body\n```"));
+        assert!(composed.contains("Bash Done ✓"));
+        assert_eq!(composed.matches("```").count() % 2, 0);
     }
 
     #[test]


### PR DESCRIPTION
Closes #3394.

## 문제
패널이 2000자를 넘으면 `truncate_status_panel_sections`가 펜스 비인지 문자 절단 → Recent 코드블록 닫는 펜스가 잘려 Discord에 리터럴 ```text 노출 (사용자 스크린샷 재현 확인).

## 변경 (2커밋)
1. **round 1**: 절단 대신 **뒤에서부터 섹션 통째 드랍**(Recent 최우선 강등), 단독 초과 섹션은 펜스-안전 절단. `repair_fence_parity` 백스톱을 패널 최종화 싱크 전체(truncate_status_panel_sections / clamp_footer_status_block / compose_completion_footer_text)에 배선.
2. **round 2 (codex P1)**: 수리를 **본문 범위로 한정** — 본문의 미종결 펜스가 footer의 ✓ 라인을 삭제해 #3391 delivered-ID 정직성을 깨던 결합-문자열 수리 제거. footer는 구성상 펜스-균형(백틱 이스케이프) + 분리 수리 백스톱 + 결합 패리티 debug_assert.

## 검증
- codex 적대 리뷰 2라운드 → 최종 **VERDICT: CLEAN**
- fail-on-base/HEAD 검증 테스트: 재현(리터럴 펜스 누출)·단독 초과 섹션·패리티 헬퍼 경계·footer 보존 재현·registered-refresh 변형·균형 음성 대조
- 독립 게이트: fmt·clippy·placeholder_live_events 133·single_message_panel 48·discord 1653·audit(캡 인상 0, status_panel.rs 700 유지)·docs freshness
- 구현 opus / 리뷰 codex

🤖 Generated with [Claude Code](https://claude.com/claude-code)