### PR TITLE
refactor(#3038): VoiceBargeInRuntime S8 — foreground decision/parser 클러스터 추출 (마지막 verbatim 슬라이스)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -524,6 +524,7 @@ src/
 │   │   │   └── cleanup.rs
 │   │   ├── voice_barge_in/
 │   │   │   ├── final_result_playback.rs
+│   │   │   ├── foreground_decision.rs
 │   │   │   ├── live_cut_playback.rs
 │   │   │   ├── progress_playback.rs
 │   │   │   ├── routing.rs

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -802,7 +802,7 @@
     was removed from `giant_file_registry.toml`; #3038 S5 locked the final
     root ratchet at 274 production lines).
   - `src/services/discord/session_runtime.rs` (1753 lines).
-  - `src/services/discord/voice_barge_in.rs` (3044 lines after #3038
+  - `src/services/discord/voice_barge_in.rs` (2823 lines after #3038
     VoiceBargeInRuntime S1 moved the STT method cluster to
     `src/services/discord/voice_barge_in/stt.rs` (314 production lines) and
     S2 moved the progress playback method cluster to
@@ -816,8 +816,10 @@
     lines), and S6 moved the TTS pipeline cluster to
     `src/services/discord/voice_barge_in/tts_pipeline.rs` (86 production
     lines), and S7 folded the agent-voice routing helper block into
-    `src/services/discord/voice_barge_in/routing.rs` (now 484 production
-    lines);
+    `src/services/discord/voice_barge_in/routing.rs` (now 500 production
+    lines), and S8 moved the foreground decision/parser cluster to
+    `src/services/discord/voice_barge_in/foreground_decision.rs` (214
+    production lines);
     voice STT/TTS, lobby routing, progress mirroring, and barge-in
     orchestration surface; tracked decompose target — see
     `giant-file-registry.md` (owner `voice-runtime`, deadline 2026-08-31,

--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -115,7 +115,10 @@
 # #3038 VoiceBargeInRuntime S7: lowered 3136 -> 3044 (-92) as the agent-voice
 # routing helper block folded into `voice_barge_in/routing.rs` (383 -> 484 prod
 # LoC, below the giant threshold). Locks in the shrink win.
-"src/services/discord/voice_barge_in.rs" = 3044
+# #3038 VoiceBargeInRuntime S8: lowered 3044 -> 2823 (-221) as the foreground
+# decision/parser cluster moved to `voice_barge_in/foreground_decision.rs` (214
+# prod LoC, below the giant threshold). Locks in the shrink win.
+"src/services/discord/voice_barge_in.rs" = 2823
 # #3248: +60 for the gap-1 deploy-survivable-relay fix —
 # `reseed_watcher_owned_finalizer_ledger` + two guarded reattach call-sites that
 # re-register the watcher-owned turn in the post-restart finalizer ledger (a P1

--- a/src/services/discord/voice_barge_in.rs
+++ b/src/services/discord/voice_barge_in.rs
@@ -47,6 +47,13 @@ use super::{SharedData, http, mailbox_has_active_turn, rate_limit_wait, settings
 
 #[path = "voice_barge_in/final_result_playback.rs"]
 mod final_result_playback;
+#[path = "voice_barge_in/foreground_decision.rs"]
+mod foreground_decision;
+// S8 (#3038): the foreground decision/parser cluster moved into the
+// `foreground_decision` child; re-import the two root-prod-consumed parsers so
+// `generate_foreground_ack_text` resolves them unqualified (the same two are the
+// only members reached from `mod tests`, via the existing `use super::*`).
+use foreground_decision::{foreground_ack_text, parse_voice_foreground_decision};
 #[path = "voice_barge_in/live_cut_playback.rs"]
 mod live_cut_playback;
 #[path = "voice_barge_in/progress_playback.rs"]
@@ -82,8 +89,6 @@ pub(in crate::services::discord) fn is_synthetic_voice_message_id(
 const STT_TRANSCRIPT_POLL_TIMEOUT: Duration = Duration::from_secs(5);
 const STT_TRANSCRIPT_POLL_INTERVAL: Duration = Duration::from_millis(200);
 const PROCESSING_CHIME_FILE_NAME: &str = "agentdesk-voice-processing-chime.wav";
-const VOICE_SILENCE_MARKER: &str = "ADK_VOICE_SILENCE";
-const VOICE_HANDOFF_BACKGROUND_MARKER: &str = "ADK_VOICE_HANDOFF_BACKGROUND:";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::services::discord) enum VoiceBargeInTranscriptOutcome {
@@ -385,35 +390,6 @@ fn voice_lobby_accepts_source_channel(config: &VoiceConfig, channel_id: ChannelI
     }
 }
 
-fn normalized_foreground_max_chars(value: usize) -> usize {
-    if value == 0 {
-        crate::voice::config::DEFAULT_FOREGROUND_MAX_CHARS
-    } else {
-        value
-    }
-}
-
-fn normalized_foreground_timeout_ms(value: u64) -> u64 {
-    if value == 0 {
-        crate::voice::config::DEFAULT_FOREGROUND_TIMEOUT_MS
-    } else {
-        value
-    }
-}
-
-fn foreground_ack_text(transcript: &str, language: &str) -> String {
-    let english = language.trim().to_ascii_lowercase().starts_with("en");
-    let looks_like_work = looks_like_background_work_request(transcript);
-    match (english, looks_like_work) {
-        (true, true) => {
-            "Got it. I will start that in the channel and come back briefly.".to_string()
-        }
-        (true, false) => "Got it. I am checking that now.".to_string(),
-        (false, true) => "알겠어요. 채널에서 바로 진행하고 짧게 다시 알려드릴게요.".to_string(),
-        (false, false) => "알겠어요. 바로 확인할게요.".to_string(),
-    }
-}
-
 async fn generate_foreground_ack_text(
     transcript: &str,
     language: &str,
@@ -502,167 +478,6 @@ async fn generate_foreground_ack_text(
     Some(parse_voice_foreground_decision(
         &text, transcript, language, max_chars,
     ))
-}
-
-fn parse_voice_foreground_decision(
-    text: &str,
-    transcript: &str,
-    language: &str,
-    max_chars: usize,
-) -> VoiceForegroundDecision {
-    let trimmed = text.trim();
-    if let Some(marker_line) = first_voice_foreground_marker_candidate(trimmed) {
-        if marker_line.eq_ignore_ascii_case(VOICE_SILENCE_MARKER) {
-            return VoiceForegroundDecision::Silence;
-        }
-        if let Some(summary) =
-            parse_voice_background_handoff_summary(&marker_line, transcript, language, max_chars)
-        {
-            return VoiceForegroundDecision::HandoffBackground(summary);
-        }
-    }
-    let spoken = foreground_spoken_only_with_limit(trimmed, language, max_chars);
-    if spoken.trim().is_empty() {
-        VoiceForegroundDecision::Silence
-    } else {
-        VoiceForegroundDecision::Speak(spoken)
-    }
-}
-
-fn first_voice_foreground_marker_candidate(text: &str) -> Option<String> {
-    let mut skipped_leading_fence = false;
-    for raw_line in text.lines() {
-        let line = strip_voice_marker_leading_wrappers(raw_line);
-        if line.is_empty() {
-            continue;
-        }
-
-        if let Some(after_fence) = strip_code_fence_prefix(line) {
-            let after_fence = strip_voice_marker_trailing_wrappers(after_fence);
-            if starts_with_voice_foreground_marker(after_fence) {
-                return Some(after_fence.to_string());
-            }
-            if !skipped_leading_fence {
-                skipped_leading_fence = true;
-                continue;
-            }
-        }
-
-        return Some(strip_voice_marker_trailing_wrappers(line).to_string());
-    }
-    None
-}
-
-fn strip_voice_marker_leading_wrappers(mut line: &str) -> &str {
-    for _ in 0..8 {
-        let trimmed = line.trim();
-        let Some(first) = trimmed.chars().next() else {
-            return "";
-        };
-        if first == '>' {
-            line = &trimmed[first.len_utf8()..];
-            continue;
-        }
-        if let Some(rest) = ["- ", "* ", "+ "]
-            .iter()
-            .find_map(|prefix| trimmed.strip_prefix(prefix))
-        {
-            line = rest;
-            continue;
-        }
-        if matches!(first, '"' | '\'') {
-            let rest = trimmed[first.len_utf8()..].trim_start();
-            if starts_with_wrapped_voice_foreground_marker(rest)
-                || strip_code_fence_prefix(rest).is_some()
-            {
-                line = rest;
-                continue;
-            }
-        }
-        return trimmed;
-    }
-    line.trim()
-}
-
-fn strip_voice_marker_trailing_wrappers(mut line: &str) -> &str {
-    for _ in 0..4 {
-        let trimmed = line.trim();
-        if let Some(rest) = trimmed
-            .strip_suffix("```")
-            .or_else(|| trimmed.strip_suffix("~~~"))
-        {
-            line = rest;
-            continue;
-        }
-        if let Some(last) = trimmed.chars().last()
-            && matches!(last, '"' | '\'')
-        {
-            line = &trimmed[..trimmed.len() - last.len_utf8()];
-            continue;
-        }
-        return trimmed;
-    }
-    line.trim()
-}
-
-fn strip_code_fence_prefix(line: &str) -> Option<&str> {
-    line.strip_prefix("```")
-        .or_else(|| line.strip_prefix("~~~"))
-}
-
-fn starts_with_voice_foreground_marker(line: &str) -> bool {
-    line.eq_ignore_ascii_case(VOICE_SILENCE_MARKER)
-        || strip_ascii_case_prefix(line, VOICE_HANDOFF_BACKGROUND_MARKER).is_some()
-}
-
-fn starts_with_wrapped_voice_foreground_marker(line: &str) -> bool {
-    starts_with_voice_foreground_marker(strip_voice_marker_trailing_wrappers(line))
-}
-
-fn strip_ascii_case_prefix<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {
-    let candidate = text.get(..prefix.len())?;
-    candidate
-        .eq_ignore_ascii_case(prefix)
-        .then(|| &text[prefix.len()..])
-}
-
-fn parse_voice_background_handoff_summary(
-    marker_line: &str,
-    transcript: &str,
-    language: &str,
-    max_chars: usize,
-) -> Option<String> {
-    let summary = strip_ascii_case_prefix(marker_line, VOICE_HANDOFF_BACKGROUND_MARKER)?.trim();
-    if summary.is_empty() {
-        Some(fallback_voice_background_handoff_summary(
-            transcript, language, max_chars,
-        ))
-    } else {
-        Some(summary.to_string())
-    }
-}
-
-fn fallback_voice_background_handoff_summary(
-    transcript: &str,
-    language: &str,
-    max_chars: usize,
-) -> String {
-    let summary = foreground_spoken_only_with_limit(transcript, language, max_chars);
-    let summary = summary.trim();
-    if !summary.is_empty() && !contains_voice_foreground_marker(summary) {
-        return summary.to_string();
-    }
-    if language.trim().to_ascii_lowercase().starts_with("en") {
-        "User requested background work.".to_string()
-    } else {
-        "사용자가 백그라운드 작업을 요청함".to_string()
-    }
-}
-
-fn contains_voice_foreground_marker(text: &str) -> bool {
-    let lower = text.to_ascii_lowercase();
-    lower.contains(&VOICE_SILENCE_MARKER.to_ascii_lowercase())
-        || lower.contains(&VOICE_HANDOFF_BACKGROUND_MARKER.to_ascii_lowercase())
 }
 
 fn voice_background_handoff_ack(language: &str) -> &'static str {
@@ -938,42 +753,6 @@ fn ensure_processing_chime_file(path: &Path) -> Result<(), String> {
     writer
         .finalize()
         .map_err(|error| format!("finalize processing chime {}: {error}", path.display()))
-}
-
-fn looks_like_background_work_request(transcript: &str) -> bool {
-    let text = transcript.to_ascii_lowercase();
-    [
-        "구현",
-        "수정",
-        "확인",
-        "검토",
-        "테스트",
-        "배포",
-        "이슈",
-        "로그",
-        "파일",
-        "검색",
-        "만들",
-        "고쳐",
-        "implement",
-        "fix",
-        "test",
-        "deploy",
-        "issue",
-        "log",
-        "file",
-        "search",
-        "review",
-    ]
-    .iter()
-    .any(|needle| {
-        if needle.is_ascii() {
-            text.split(|ch: char| !ch.is_ascii_alphanumeric())
-                .any(|word| word == *needle)
-        } else {
-            text.contains(needle)
-        }
-    })
 }
 
 struct DeferredBargeInDrain {

--- a/src/services/discord/voice_barge_in/foreground_decision.rs
+++ b/src/services/discord/voice_barge_in/foreground_decision.rs
@@ -1,0 +1,214 @@
+use super::*;
+
+const VOICE_SILENCE_MARKER: &str = "ADK_VOICE_SILENCE";
+const VOICE_HANDOFF_BACKGROUND_MARKER: &str = "ADK_VOICE_HANDOFF_BACKGROUND:";
+
+pub(super) fn foreground_ack_text(transcript: &str, language: &str) -> String {
+    let english = language.trim().to_ascii_lowercase().starts_with("en");
+    let looks_like_work = looks_like_background_work_request(transcript);
+    match (english, looks_like_work) {
+        (true, true) => {
+            "Got it. I will start that in the channel and come back briefly.".to_string()
+        }
+        (true, false) => "Got it. I am checking that now.".to_string(),
+        (false, true) => "알겠어요. 채널에서 바로 진행하고 짧게 다시 알려드릴게요.".to_string(),
+        (false, false) => "알겠어요. 바로 확인할게요.".to_string(),
+    }
+}
+
+pub(super) fn parse_voice_foreground_decision(
+    text: &str,
+    transcript: &str,
+    language: &str,
+    max_chars: usize,
+) -> VoiceForegroundDecision {
+    let trimmed = text.trim();
+    if let Some(marker_line) = first_voice_foreground_marker_candidate(trimmed) {
+        if marker_line.eq_ignore_ascii_case(VOICE_SILENCE_MARKER) {
+            return VoiceForegroundDecision::Silence;
+        }
+        if let Some(summary) =
+            parse_voice_background_handoff_summary(&marker_line, transcript, language, max_chars)
+        {
+            return VoiceForegroundDecision::HandoffBackground(summary);
+        }
+    }
+    let spoken = foreground_spoken_only_with_limit(trimmed, language, max_chars);
+    if spoken.trim().is_empty() {
+        VoiceForegroundDecision::Silence
+    } else {
+        VoiceForegroundDecision::Speak(spoken)
+    }
+}
+
+fn first_voice_foreground_marker_candidate(text: &str) -> Option<String> {
+    let mut skipped_leading_fence = false;
+    for raw_line in text.lines() {
+        let line = strip_voice_marker_leading_wrappers(raw_line);
+        if line.is_empty() {
+            continue;
+        }
+
+        if let Some(after_fence) = strip_code_fence_prefix(line) {
+            let after_fence = strip_voice_marker_trailing_wrappers(after_fence);
+            if starts_with_voice_foreground_marker(after_fence) {
+                return Some(after_fence.to_string());
+            }
+            if !skipped_leading_fence {
+                skipped_leading_fence = true;
+                continue;
+            }
+        }
+
+        return Some(strip_voice_marker_trailing_wrappers(line).to_string());
+    }
+    None
+}
+
+fn strip_voice_marker_leading_wrappers(mut line: &str) -> &str {
+    for _ in 0..8 {
+        let trimmed = line.trim();
+        let Some(first) = trimmed.chars().next() else {
+            return "";
+        };
+        if first == '>' {
+            line = &trimmed[first.len_utf8()..];
+            continue;
+        }
+        if let Some(rest) = ["- ", "* ", "+ "]
+            .iter()
+            .find_map(|prefix| trimmed.strip_prefix(prefix))
+        {
+            line = rest;
+            continue;
+        }
+        if matches!(first, '"' | '\'') {
+            let rest = trimmed[first.len_utf8()..].trim_start();
+            if starts_with_wrapped_voice_foreground_marker(rest)
+                || strip_code_fence_prefix(rest).is_some()
+            {
+                line = rest;
+                continue;
+            }
+        }
+        return trimmed;
+    }
+    line.trim()
+}
+
+fn strip_voice_marker_trailing_wrappers(mut line: &str) -> &str {
+    for _ in 0..4 {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed
+            .strip_suffix("```")
+            .or_else(|| trimmed.strip_suffix("~~~"))
+        {
+            line = rest;
+            continue;
+        }
+        if let Some(last) = trimmed.chars().last()
+            && matches!(last, '"' | '\'')
+        {
+            line = &trimmed[..trimmed.len() - last.len_utf8()];
+            continue;
+        }
+        return trimmed;
+    }
+    line.trim()
+}
+
+fn strip_code_fence_prefix(line: &str) -> Option<&str> {
+    line.strip_prefix("```")
+        .or_else(|| line.strip_prefix("~~~"))
+}
+
+fn starts_with_voice_foreground_marker(line: &str) -> bool {
+    line.eq_ignore_ascii_case(VOICE_SILENCE_MARKER)
+        || strip_ascii_case_prefix(line, VOICE_HANDOFF_BACKGROUND_MARKER).is_some()
+}
+
+fn starts_with_wrapped_voice_foreground_marker(line: &str) -> bool {
+    starts_with_voice_foreground_marker(strip_voice_marker_trailing_wrappers(line))
+}
+
+fn strip_ascii_case_prefix<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {
+    let candidate = text.get(..prefix.len())?;
+    candidate
+        .eq_ignore_ascii_case(prefix)
+        .then(|| &text[prefix.len()..])
+}
+
+fn parse_voice_background_handoff_summary(
+    marker_line: &str,
+    transcript: &str,
+    language: &str,
+    max_chars: usize,
+) -> Option<String> {
+    let summary = strip_ascii_case_prefix(marker_line, VOICE_HANDOFF_BACKGROUND_MARKER)?.trim();
+    if summary.is_empty() {
+        Some(fallback_voice_background_handoff_summary(
+            transcript, language, max_chars,
+        ))
+    } else {
+        Some(summary.to_string())
+    }
+}
+
+fn fallback_voice_background_handoff_summary(
+    transcript: &str,
+    language: &str,
+    max_chars: usize,
+) -> String {
+    let summary = foreground_spoken_only_with_limit(transcript, language, max_chars);
+    let summary = summary.trim();
+    if !summary.is_empty() && !contains_voice_foreground_marker(summary) {
+        return summary.to_string();
+    }
+    if language.trim().to_ascii_lowercase().starts_with("en") {
+        "User requested background work.".to_string()
+    } else {
+        "사용자가 백그라운드 작업을 요청함".to_string()
+    }
+}
+
+fn contains_voice_foreground_marker(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains(&VOICE_SILENCE_MARKER.to_ascii_lowercase())
+        || lower.contains(&VOICE_HANDOFF_BACKGROUND_MARKER.to_ascii_lowercase())
+}
+
+fn looks_like_background_work_request(transcript: &str) -> bool {
+    let text = transcript.to_ascii_lowercase();
+    [
+        "구현",
+        "수정",
+        "확인",
+        "검토",
+        "테스트",
+        "배포",
+        "이슈",
+        "로그",
+        "파일",
+        "검색",
+        "만들",
+        "고쳐",
+        "implement",
+        "fix",
+        "test",
+        "deploy",
+        "issue",
+        "log",
+        "file",
+        "search",
+        "review",
+    ]
+    .iter()
+    .any(|needle| {
+        if needle.is_ascii() {
+            text.split(|ch: char| !ch.is_ascii_alphanumeric())
+                .any(|word| word == *needle)
+        } else {
+            text.contains(needle)
+        }
+    })
+}

--- a/src/services/discord/voice_barge_in/routing.rs
+++ b/src/services/discord/voice_barge_in/routing.rs
@@ -482,3 +482,19 @@ fn agent_text_channel_matches(agent: &crate::config::AgentDef, channel_id: Chann
         .filter_map(|(_, channel)| channel)
         .any(|channel| channel.channel_id().as_deref() == Some(channel_id.as_str()))
 }
+
+fn normalized_foreground_max_chars(value: usize) -> usize {
+    if value == 0 {
+        crate::voice::config::DEFAULT_FOREGROUND_MAX_CHARS
+    } else {
+        value
+    }
+}
+
+fn normalized_foreground_timeout_ms(value: u64) -> u64 {
+    if value == 0 {
+        crate::voice::config::DEFAULT_FOREGROUND_TIMEOUT_MS
+    } else {
+        value
+    }
+}


### PR DESCRIPTION
EPIC #3038 god-object 트랙, VoiceBargeInRuntime S8 (S-시리즈 마지막 verbatim 슬라이스).

## 내용
- **foreground decision/parser 클러스터**: 13개 자유 함수(`foreground_ack_text`, `parse_voice_foreground_decision`, marker/wrapper·handoff-summary 파서들, `looks_like_background_work_request`) + `VOICE_*_MARKER` 상수 2개를 `voice_barge_in/foreground_decision.rs`(214 prod LoC)로 verbatim 이동. pub(super)는 2개만, 나머지 11개+상수는 private.
- **codex P2 fold-in**: config normalizer 2개(`normalized_foreground_max_chars`/`_timeout_ms`)의 유일 호출자가 routing.rs라 — routing.rs로 verbatim 이동(484→500 prod LoC).
- ratchet: voice_barge_in.rs **3044 → 2823 (-221)**.
- **마감 평가**: 루트 잔여 = orchestration-core 핫패스 + async provider-call 그룹(#2250 cancel 결합) + lifecycle/config 글루 — S-시리즈 규율 하의 clean verbatim 슬라이스 없음. **EPIC voice 트랙 종료** (3932 → 2823, 8슬라이스 누적 -1,109 + 자식 7개 모듈).
- codex 리뷰 3라운드 (P2 2건: 제외 정직성 → fold-in, 커밋 본문 모순 → 교정), 코드 결함 0.
- 구현 opus / 리뷰 codex.

## 게이트 (독립 재검증)
fmt / check / clippy -D warnings / voice 277 / discord 1653 / audit ratchet(2823 정확치) / docs freshness

🤖 Generated with [Claude Code](https://claude.com/claude-code)