### PR TITLE
fix(#3356): test_watcher_handle cfg 비대칭 정렬 — windows 레그 컴파일 복구

### DIFF
--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -5816,6 +5816,12 @@ mod tests {
     // tests (`idle_relay_drift`) prove WHICH durable source is chosen and the
     // mis-delivery guards; this end-to-end test pins the registry promotion +
     // resolver hand-off.
+    //
+    // #3356: gated to unix to match the `test_watcher_handle` helper (def at
+    // `#[cfg(unix)]` below) it consumes — every other caller of that helper is
+    // already `#[cfg(unix)]`, so this restores def/usage cfg symmetry and lets
+    // the windows leg compile (the helper does not exist on windows).
+    #[cfg(unix)]
     #[test]
     fn drift_triggered_restore_makes_routine_session_route_again() {
         let shared = super::super::make_shared_data_for_tests();


### PR DESCRIPTION
Closes #3356.

## 변경
`tui_prompt_relay.rs`의 `test_watcher_handle` 헬퍼는 `#[cfg(unix)]`인데 소비자 테스트 1곳(`drift_triggered_restore_makes_routine_session_route_again`)만 게이트가 없어 windows 레그에서 E0425. 해당 테스트에 `#[cfg(unix)]` 추가 (파일 내 동일 패턴 103곳과 일관). 프로덕션 로직 0줄 변경.

- 동명 헬퍼 3곳(tmux_watcher.rs / watchers/lifecycle.rs / watchdog.rs)은 이미 대칭 — 감사 결과 커밋 본문에 박제
- unix 테스트 수 불변 (3432→3432)
- windows 크로스체크는 로컬 SDK 부재로 grep 감사로 대체 (커밋 본문)

## 검증
codex 적대 리뷰 VERDICT: CLEAN / fmt·clippy·tui_prompt_relay 109·discord 1653·audit·docs freshness green
구현 opus / 리뷰 codex

🤖 Generated with [Claude Code](https://claude.com/claude-code)