### PR TITLE
fix(#3344): codex legacy wrapper 누적 usage가 CTW를 오염하지 않도록 provenance 게이트

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1113,11 +1113,14 @@ normal test growth is allowed): `src/services/analytics.rs`,
 `src/services/platform/tmux.rs`, `src/services/mcp_config.rs`,
 `src/services/process.rs`, `src/services/discord/tmux_lifecycle.rs`,
 `src/services/qwen_tmux_wrapper.rs`, `src/services/discord/session_relay_sink.rs`,
-`src/services/tui_turn_state.rs`, `src/services/session_backend.rs`,
+`src/services/tui_turn_state.rs`,
 `src/voice/turn_link.rs`, `src/services/discord/commands/config.rs`
 (#3038 S2: 1054 -> 954 after the session-override bookkeeping helpers
 moved verbatim to `discord/shared_state.rs` next to
 `SessionOverrideState`; still ratcheted at 954 in the frozen baseline).
+`src/services/session_backend.rs` left this list in #3344 (997 -> 1023 prod
+LoC after the shared terminal-usage provenance helper) and is registry-tracked
+again (giant_file_registry.toml, decompose_issue #3405).
 
 Same rule: `bugfix` only without a split issue.
 

--- a/scripts/giant_file_registry.toml
+++ b/scripts/giant_file_registry.toml
@@ -252,7 +252,7 @@ grandfathered = [
 file = "src/services/discord/voice_barge_in.rs"
 owner = "voice-runtime"
 deadline = "2026-08-31"
-decompose_issue = "#3036"
+decompose_issue = "#3405"
 
 [[entry]]
 # Crossed the 1000-prod-LoC threshold when #3034 restored per-item dead_code
@@ -261,7 +261,7 @@ decompose_issue = "#3036"
 file = "src/db/automation_candidates.rs"
 owner = "automation-pipeline"
 deadline = "2026-08-31"
-decompose_issue = "#3036"
+decompose_issue = "#3405"
 
 [[entry]]
 # Crossed the 1000-prod-LoC threshold when #3034 restored per-item dead_code
@@ -269,7 +269,7 @@ decompose_issue = "#3036"
 file = "src/voice/announce_meta.rs"
 owner = "voice-runtime"
 deadline = "2026-08-31"
-decompose_issue = "#3036"
+decompose_issue = "#3405"
 
 [[entry]]
 # Crossed the 1000-prod-LoC threshold when #3017 re-landed the single
@@ -280,7 +280,7 @@ decompose_issue = "#3036"
 file = "src/services/discord/session_relay_sink.rs"
 owner = "discord-relay"
 deadline = "2026-08-31"
-decompose_issue = "#3036"
+decompose_issue = "#3405"
 
 [[entry]]
 # Crossed the 1000-prod-LoC threshold when #3041 P1-0 landed the dormant
@@ -304,7 +304,7 @@ decompose_issue = "#3016"
 file = "src/services/discord/idle_recap.rs"
 owner = "discord-recap"
 deadline = "2026-08-31"
-decompose_issue = "#3036"
+decompose_issue = "#3405"
 
 # NOTE: src/services/discord/turn_bridge/terminal_delivery.rs previously had an
 # [[entry]] here; the #3028 splitter fix dropped its production LoC below the
@@ -327,3 +327,15 @@ file = "src/services/discord/turn_bridge/mod.rs"
 owner = "discord-relay"
 deadline = "2026-08-31"
 decompose_issue = "#3038"
+
+[[entry]]
+# Crossed the 1000-prod-LoC threshold (was 997, one line under) when #3344
+# round 2 landed the shared `adopt_terminal_result_usage` provenance/magnitude
+# gate plus its maintenance-rule doc — the gate is consumed by both the watcher
+# and the analytics re-parser, so it lives here next to `StreamLineState` /
+# `process_stream_line` rather than being duplicated. Active session-backend
+# surface; decompose the stream-parse + token-usage helpers out under #3036.
+file = "src/services/session_backend.rs"
+owner = "discord-relay"
+deadline = "2026-08-31"
+decompose_issue = "#3405"

--- a/src/services/discord/tmux_output_stream.rs
+++ b/src/services/discord/tmux_output_stream.rs
@@ -1,5 +1,28 @@
 use super::*;
 
+/// #3344: ceiling above which a terminal `result.usage` cannot be a per-call
+/// context occupancy and is therefore the session-cumulative shape.
+///
+/// The result-event fallback below adopts `result.usage` for providers that
+/// only normalize token counts onto the terminal frame (e.g. Qwen's tmux
+/// wrapper). The Codex legacy tmux wrapper can, on stale binaries or the
+/// exec-protocol path, emit a `usage` object carrying session-cumulative
+/// accounting (the issue's `input_tokens=344752` + `cache_read_input_tokens=
+/// 4022400` ≈ 4.37M). Summed into context occupancy and clamped to the model
+/// window, that renders a stable, misleading `100%`.
+///
+/// The largest context window the provider registry knows is 1_000_000
+/// (Claude/Gemini default). A per-call context occupancy therefore cannot
+/// exceed that window plus a small margin, so any `result.usage` whose
+/// input+cache occupancy clears this 2_000_000 ceiling is unambiguously
+/// cumulative and is SUPPRESSED rather than adopted — an absent CTW signal
+/// renders honestly as "unknown" (see `stream_line_state_token_usage` /
+/// `context_panel`), whereas a clamped 100% is a lie. Legitimate per-call
+/// usage from any current model stays far below this ceiling, so the Qwen and
+/// Codex-per-call fallbacks are unaffected. Claude never reaches this branch
+/// (`saw_per_message_usage` is always set on its per-message `usage` frames).
+const MAX_PLAUSIBLE_PER_CALL_CONTEXT_TOKENS: u64 = 2_000_000;
+
 /// Tracks tool/thinking status during watcher output processing.
 pub(in crate::services::discord) struct WatcherToolState {
     /// Current tool status line (e.g. "⚙ Bash: `ls`")
@@ -434,22 +457,43 @@ pub(in crate::services::discord) fn process_watcher_lines(
                     if !state.saw_per_message_usage
                         && let Some(usage) = val.get("usage")
                     {
-                        state.accum_input_tokens = usage
+                        let input_tokens = usage
                             .get("input_tokens")
                             .and_then(|v| v.as_u64())
                             .unwrap_or(0);
-                        state.accum_cache_read_tokens = usage
+                        let cache_read_tokens = usage
                             .get("cache_read_input_tokens")
                             .and_then(|v| v.as_u64())
                             .unwrap_or(0);
-                        state.accum_cache_create_tokens = usage
+                        let cache_create_tokens = usage
                             .get("cache_creation_input_tokens")
                             .and_then(|v| v.as_u64())
                             .unwrap_or(0);
-                        state.accum_output_tokens = usage
+                        let output_tokens = usage
                             .get("output_tokens")
                             .and_then(|v| v.as_u64())
                             .unwrap_or(0);
+                        // #3344: the Codex legacy tmux wrapper can hand back a
+                        // `result.usage` carrying session-cumulative accounting
+                        // (millions of input+cache tokens) rather than per-call
+                        // occupancy. Adopting it poisons CTW into a clamped,
+                        // misleading 100%. When the occupancy magnitude clears
+                        // the per-call plausibility ceiling, SUPPRESS the whole
+                        // usage adoption: leaving the accumulators at zero makes
+                        // `stream_line_state_token_usage` return None so the
+                        // panel/recap render an honest "unknown" instead of a
+                        // fabricated full window. Per-call usage from Qwen and
+                        // non-stale Codex wrappers stays well under the ceiling
+                        // and is adopted unchanged.
+                        let context_occupancy = input_tokens
+                            .saturating_add(cache_read_tokens)
+                            .saturating_add(cache_create_tokens);
+                        if context_occupancy <= MAX_PLAUSIBLE_PER_CALL_CONTEXT_TOKENS {
+                            state.accum_input_tokens = input_tokens;
+                            state.accum_cache_read_tokens = cache_read_tokens;
+                            state.accum_cache_create_tokens = cache_create_tokens;
+                            state.accum_output_tokens = output_tokens;
+                        }
                     }
 
                     state.final_result = Some(String::new());
@@ -796,6 +840,103 @@ mod tests {
             output_tokens: state.accum_output_tokens,
         };
         assert_eq!(usage.context_occupancy_input_tokens(), 1000);
+    }
+
+    /// #3344 regression: the Codex legacy tmux wrapper can hand back a
+    /// `result.usage` carrying session-cumulative accounting (the issue's exact
+    /// values: `cache_read_input_tokens=4022400`, `input_tokens=344752`, ~4.37M
+    /// occupancy against a 258400 window). The result-usage fallback must NOT
+    /// adopt it — leaving the accumulators at zero makes
+    /// `stream_line_state_token_usage` return None so the panel/recap render an
+    /// honest "unknown" instead of a clamped, misleading 100%. (Fails on base,
+    /// where the cumulative values were adopted verbatim.)
+    #[test]
+    fn process_watcher_lines_suppresses_cumulative_codex_wrapper_result_usage() {
+        let mut buffer = concat!(
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"codex reply\"}]}}\n",
+            "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"codex reply\",\"session_id\":\"sess-cdx\",\"duration_ms\":12,\"usage\":{\"input_tokens\":344752,\"cache_read_input_tokens\":4022400,\"output_tokens\":1280}}\n",
+        )
+        .to_string();
+        let mut state = StreamLineState::new();
+        let mut full_response = String::new();
+        let mut tool_state = WatcherToolState::new();
+
+        let outcome =
+            process_watcher_lines(&mut buffer, &mut state, &mut full_response, &mut tool_state);
+
+        assert!(outcome.found_result);
+        assert!(!state.saw_per_message_usage);
+        // The cumulative shape is suppressed: every accumulator stays zero, so
+        // context occupancy is unknown (no false full-window render).
+        assert_eq!(state.accum_input_tokens, 0);
+        assert_eq!(state.accum_cache_read_tokens, 0);
+        assert_eq!(state.accum_cache_create_tokens, 0);
+        assert_eq!(state.accum_output_tokens, 0);
+        let usage = crate::db::turns::TurnTokenUsage {
+            input_tokens: state.accum_input_tokens,
+            cache_create_tokens: state.accum_cache_create_tokens,
+            cache_read_tokens: state.accum_cache_read_tokens,
+            output_tokens: state.accum_output_tokens,
+        };
+        assert_eq!(usage.context_occupancy_input_tokens(), 0);
+    }
+
+    /// #3344: a Codex wrapper result frame whose per-call occupancy sits right
+    /// below the plausibility ceiling is still adopted — the suppression only
+    /// rejects the cumulative shape, never legitimate large-but-valid per-call
+    /// usage.
+    #[test]
+    fn process_watcher_lines_adopts_high_but_plausible_per_call_usage() {
+        let mut buffer = concat!(
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"codex reply\"}]}}\n",
+            "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"codex reply\",\"session_id\":\"sess-cdx\",\"duration_ms\":12,\"usage\":{\"input_tokens\":40000,\"cache_read_input_tokens\":900000,\"output_tokens\":120}}\n",
+        )
+        .to_string();
+        let mut state = StreamLineState::new();
+        let mut full_response = String::new();
+        let mut tool_state = WatcherToolState::new();
+
+        let outcome =
+            process_watcher_lines(&mut buffer, &mut state, &mut full_response, &mut tool_state);
+
+        assert!(outcome.found_result);
+        assert!(!state.saw_per_message_usage);
+        assert_eq!(state.accum_input_tokens, 40_000);
+        assert_eq!(state.accum_cache_read_tokens, 900_000);
+        assert_eq!(state.accum_output_tokens, 120);
+        let usage = crate::db::turns::TurnTokenUsage {
+            input_tokens: state.accum_input_tokens,
+            cache_create_tokens: state.accum_cache_create_tokens,
+            cache_read_tokens: state.accum_cache_read_tokens,
+            output_tokens: state.accum_output_tokens,
+        };
+        assert_eq!(usage.context_occupancy_input_tokens(), 940_000);
+    }
+
+    /// #3344 fallback regression: a provider that legitimately reports per-call
+    /// token counts solely on the terminal `result.usage` (Qwen's tmux wrapper)
+    /// must keep flowing through the fallback unchanged — the cumulative-shape
+    /// guard never trips for sane per-call magnitudes.
+    #[test]
+    fn process_watcher_lines_keeps_per_call_terminal_usage_fallback() {
+        let mut buffer = concat!(
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"qwen reply\"}]}}\n",
+            "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"qwen reply\",\"session_id\":\"sess-qwen\",\"duration_ms\":7,\"usage\":{\"input_tokens\":1200,\"cache_read_input_tokens\":300,\"cache_creation_input_tokens\":80,\"output_tokens\":256}}\n",
+        )
+        .to_string();
+        let mut state = StreamLineState::new();
+        let mut full_response = String::new();
+        let mut tool_state = WatcherToolState::new();
+
+        let outcome =
+            process_watcher_lines(&mut buffer, &mut state, &mut full_response, &mut tool_state);
+
+        assert!(outcome.found_result);
+        assert!(!state.saw_per_message_usage);
+        assert_eq!(state.accum_input_tokens, 1200);
+        assert_eq!(state.accum_cache_read_tokens, 300);
+        assert_eq!(state.accum_cache_create_tokens, 80);
+        assert_eq!(state.accum_output_tokens, 256);
     }
 
     #[test]

--- a/src/services/discord/tmux_output_stream.rs
+++ b/src/services/discord/tmux_output_stream.rs
@@ -1,28 +1,5 @@
 use super::*;
 
-/// #3344: ceiling above which a terminal `result.usage` cannot be a per-call
-/// context occupancy and is therefore the session-cumulative shape.
-///
-/// The result-event fallback below adopts `result.usage` for providers that
-/// only normalize token counts onto the terminal frame (e.g. Qwen's tmux
-/// wrapper). The Codex legacy tmux wrapper can, on stale binaries or the
-/// exec-protocol path, emit a `usage` object carrying session-cumulative
-/// accounting (the issue's `input_tokens=344752` + `cache_read_input_tokens=
-/// 4022400` ≈ 4.37M). Summed into context occupancy and clamped to the model
-/// window, that renders a stable, misleading `100%`.
-///
-/// The largest context window the provider registry knows is 1_000_000
-/// (Claude/Gemini default). A per-call context occupancy therefore cannot
-/// exceed that window plus a small margin, so any `result.usage` whose
-/// input+cache occupancy clears this 2_000_000 ceiling is unambiguously
-/// cumulative and is SUPPRESSED rather than adopted — an absent CTW signal
-/// renders honestly as "unknown" (see `stream_line_state_token_usage` /
-/// `context_panel`), whereas a clamped 100% is a lie. Legitimate per-call
-/// usage from any current model stays far below this ceiling, so the Qwen and
-/// Codex-per-call fallbacks are unaffected. Claude never reaches this branch
-/// (`saw_per_message_usage` is always set on its per-message `usage` frames).
-const MAX_PLAUSIBLE_PER_CALL_CONTEXT_TOKENS: u64 = 2_000_000;
-
 /// Tracks tool/thinking status during watcher output processing.
 pub(in crate::services::discord) struct WatcherToolState {
     /// Current tool status line (e.g. "⚙ Bash: `ls`")
@@ -444,57 +421,17 @@ pub(in crate::services::discord) fn process_watcher_lines(
                             }
                         }
                     }
-                    // #1918: for providers that emit per-message `usage` (Claude),
-                    // the assistant-message branch above already captured the
-                    // LAST API call's prompt and cumulative output, which is what
-                    // the status panel and analytics need. Result.usage in
-                    // multi-call turns is turn-cumulative on those CLIs and
-                    // inflates the displayed context occupancy past the window
-                    // size. For providers that only normalize token counts onto
-                    // the terminal `result` event (e.g. Qwen's tmux wrapper),
-                    // fall back to result.usage so session context status and
-                    // turn analytics are not lost.
-                    if !state.saw_per_message_usage
-                        && let Some(usage) = val.get("usage")
-                    {
-                        let input_tokens = usage
-                            .get("input_tokens")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                        let cache_read_tokens = usage
-                            .get("cache_read_input_tokens")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                        let cache_create_tokens = usage
-                            .get("cache_creation_input_tokens")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                        let output_tokens = usage
-                            .get("output_tokens")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                        // #3344: the Codex legacy tmux wrapper can hand back a
-                        // `result.usage` carrying session-cumulative accounting
-                        // (millions of input+cache tokens) rather than per-call
-                        // occupancy. Adopting it poisons CTW into a clamped,
-                        // misleading 100%. When the occupancy magnitude clears
-                        // the per-call plausibility ceiling, SUPPRESS the whole
-                        // usage adoption: leaving the accumulators at zero makes
-                        // `stream_line_state_token_usage` return None so the
-                        // panel/recap render an honest "unknown" instead of a
-                        // fabricated full window. Per-call usage from Qwen and
-                        // non-stale Codex wrappers stays well under the ceiling
-                        // and is adopted unchanged.
-                        let context_occupancy = input_tokens
-                            .saturating_add(cache_read_tokens)
-                            .saturating_add(cache_create_tokens);
-                        if context_occupancy <= MAX_PLAUSIBLE_PER_CALL_CONTEXT_TOKENS {
-                            state.accum_input_tokens = input_tokens;
-                            state.accum_cache_read_tokens = cache_read_tokens;
-                            state.accum_cache_create_tokens = cache_create_tokens;
-                            state.accum_output_tokens = output_tokens;
-                        }
-                    }
+                    // #1918/#3344: Claude emits per-message `usage`, so the
+                    // assistant-message branch already captured the LAST call's
+                    // occupancy. For terminal-usage providers, adopt the result
+                    // frame's nested usage with shared provenance + magnitude
+                    // gating: the Codex legacy wrapper's terminal accounting is
+                    // known-cumulative (top-level `input_tokens`/`output_tokens`
+                    // marker) and is suppressed so CTW renders honest "unknown"
+                    // instead of a fabricated full window; Qwen-shaped per-call
+                    // usage is adopted unchanged. See
+                    // `session_backend::adopt_terminal_result_usage`.
+                    crate::services::session_backend::adopt_terminal_result_usage(&val, state);
 
                     state.final_result = Some(String::new());
                     strip_leading_tui_response_chrome_in_place(full_response, &mut outcome);
@@ -802,18 +739,24 @@ mod tests {
         assert!(full_response.is_empty());
     }
 
-    /// #3275 cross-module contract: the codex tmux wrapper emits its result
-    /// frame with tokens as top-level fields plus a Claude-compatible nested
-    /// `usage` (receipt.rs subset convention). This is the exact frame shape
-    /// `emit_success_result` produces; the watcher's result-usage fallback
-    /// must adopt it so `stream_line_state_token_usage` turns Some and
-    /// watcher-owned completion persists session/turn token telemetry
-    /// (idle recap context source) instead of falling to "context unknown".
+    /// #3344 round 2 — provenance gate: the codex legacy tmux wrapper's
+    /// `emit_success_result` ALWAYS stamps the terminal frame with top-level
+    /// `input_tokens`/`output_tokens`. That marker means the frame's nested
+    /// `usage` is KNOWN-cumulative codex-legacy accounting, so it is NEVER
+    /// adopted as per-call context — even this small, early, plausible-looking
+    /// value (`input+cache_read = 1000`). RATIONALE: an honest-unknown CTW
+    /// beats a sometimes-right number. The same wrapper's nested `usage` grows
+    /// from per-call-ish early to wildly cumulative as the session advances; a
+    /// magnitude-only gate would adopt it through the entire blind window
+    /// (model window → 2M) and silently drift into a misleading 100%. The
+    /// legitimate per-call occupancy for codex turns flows from the session
+    /// `token_count` records (`info.last_token_usage`, #3331), not this frame.
+    /// (On base this small value was adopted; now suppressed.)
     #[test]
-    fn process_watcher_lines_adopts_codex_wrapper_result_usage() {
+    fn process_watcher_lines_suppresses_codex_legacy_early_per_call_usage() {
         let mut buffer = concat!(
             "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"codex reply\"}]}}\n",
-            "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"codex reply\",\"session_id\":\"sess-cdx\",\"duration_ms\":12,\"input_tokens\":8325687,\"output_tokens\":41600,\"usage\":{\"input_tokens\":400,\"cache_read_input_tokens\":600,\"output_tokens\":50}}\n",
+            "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"codex reply\",\"session_id\":\"sess-cdx\",\"duration_ms\":12,\"input_tokens\":30000,\"output_tokens\":50,\"usage\":{\"input_tokens\":400,\"cache_read_input_tokens\":600,\"output_tokens\":50}}\n",
         )
         .to_string();
         let mut state = StreamLineState::new();
@@ -824,37 +767,61 @@ mod tests {
             process_watcher_lines(&mut buffer, &mut state, &mut full_response, &mut tool_state);
 
         assert!(outcome.found_result);
-        // Codex wrapper assistant frames never carry per-message usage, so the
-        // result-frame fallback must engage.
         assert!(!state.saw_per_message_usage);
-        assert_eq!(state.accum_input_tokens, 400);
-        assert_eq!(state.accum_cache_read_tokens, 600);
+        // Codex-legacy provenance (top-level token fields present) → suppress.
+        assert_eq!(state.accum_input_tokens, 0);
+        assert_eq!(state.accum_cache_read_tokens, 0);
         assert_eq!(state.accum_cache_create_tokens, 0);
-        assert_eq!(state.accum_output_tokens, 50);
-        // Occupancy reconstruction: input + cache_read == the original codex
-        // last_token_usage.input_tokens — NOT the cumulative top-level 8.3M.
+        assert_eq!(state.accum_output_tokens, 0);
         let usage = crate::db::turns::TurnTokenUsage {
             input_tokens: state.accum_input_tokens,
             cache_create_tokens: state.accum_cache_create_tokens,
             cache_read_tokens: state.accum_cache_read_tokens,
             output_tokens: state.accum_output_tokens,
         };
-        assert_eq!(usage.context_occupancy_input_tokens(), 1000);
+        assert_eq!(usage.context_occupancy_input_tokens(), 0);
     }
 
-    /// #3344 regression: the Codex legacy tmux wrapper can hand back a
-    /// `result.usage` carrying session-cumulative accounting (the issue's exact
-    /// values: `cache_read_input_tokens=4022400`, `input_tokens=344752`, ~4.37M
-    /// occupancy against a 258400 window). The result-usage fallback must NOT
-    /// adopt it — leaving the accumulators at zero makes
-    /// `stream_line_state_token_usage` return None so the panel/recap render an
-    /// honest "unknown" instead of a clamped, misleading 100%. (Fails on base,
-    /// where the cumulative values were adopted verbatim.)
+    /// #3344 round 2 — blind-window pin: a codex-legacy frame whose nested
+    /// occupancy (500_000) sits ABOVE the model window (~258_400) but BELOW the
+    /// old 2M magnitude ceiling. The retired magnitude-only gate adopted this,
+    /// rendering a bogus clamped 100%. The provenance gate (top-level token
+    /// marker) suppresses it regardless of magnitude. (Fails on base, where the
+    /// 500k occupancy cleared the ceiling and was adopted.)
+    #[test]
+    fn process_watcher_lines_suppresses_codex_legacy_blind_window_usage() {
+        let mut buffer = concat!(
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"codex reply\"}]}}\n",
+            "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"codex reply\",\"session_id\":\"sess-cdx\",\"duration_ms\":12,\"input_tokens\":500000,\"output_tokens\":400,\"usage\":{\"input_tokens\":100000,\"cache_read_input_tokens\":400000,\"output_tokens\":400}}\n",
+        )
+        .to_string();
+        let mut state = StreamLineState::new();
+        let mut full_response = String::new();
+        let mut tool_state = WatcherToolState::new();
+
+        let outcome =
+            process_watcher_lines(&mut buffer, &mut state, &mut full_response, &mut tool_state);
+
+        assert!(outcome.found_result);
+        assert!(!state.saw_per_message_usage);
+        assert_eq!(state.accum_input_tokens, 0);
+        assert_eq!(state.accum_cache_read_tokens, 0);
+        assert_eq!(state.accum_cache_create_tokens, 0);
+        assert_eq!(state.accum_output_tokens, 0);
+    }
+
+    /// #3344 regression: the Codex legacy tmux wrapper can hand back a terminal
+    /// frame carrying session-cumulative accounting (the issue's exact values:
+    /// `cache_read_input_tokens=4022400`, `input_tokens=344752`, ~4.37M occupancy
+    /// against a 258400 window). With the top-level codex-legacy marker present,
+    /// the provenance gate suppresses it; the accumulators stay zero so
+    /// `stream_line_state_token_usage` returns None and the panel/recap render an
+    /// honest "unknown" instead of a clamped, misleading 100%.
     #[test]
     fn process_watcher_lines_suppresses_cumulative_codex_wrapper_result_usage() {
         let mut buffer = concat!(
             "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"codex reply\"}]}}\n",
-            "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"codex reply\",\"session_id\":\"sess-cdx\",\"duration_ms\":12,\"usage\":{\"input_tokens\":344752,\"cache_read_input_tokens\":4022400,\"output_tokens\":1280}}\n",
+            "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"codex reply\",\"session_id\":\"sess-cdx\",\"duration_ms\":12,\"input_tokens\":4367152,\"output_tokens\":1280,\"usage\":{\"input_tokens\":344752,\"cache_read_input_tokens\":4022400,\"output_tokens\":1280}}\n",
         )
         .to_string();
         let mut state = StreamLineState::new();
@@ -881,15 +848,16 @@ mod tests {
         assert_eq!(usage.context_occupancy_input_tokens(), 0);
     }
 
-    /// #3344: a Codex wrapper result frame whose per-call occupancy sits right
-    /// below the plausibility ceiling is still adopted — the suppression only
-    /// rejects the cumulative shape, never legitimate large-but-valid per-call
-    /// usage.
+    /// #3344 round 2 — backstop pin: a NON-codex terminal-usage provider (no
+    /// top-level token marker) whose nested occupancy clears the 2M
+    /// defense-in-depth ceiling is still rejected. The provenance gate does not
+    /// fire (no codex marker), so the magnitude backstop catches the
+    /// millions-scale garbage from any provider.
     #[test]
-    fn process_watcher_lines_adopts_high_but_plausible_per_call_usage() {
+    fn process_watcher_lines_backstop_rejects_other_provider_millions_usage() {
         let mut buffer = concat!(
-            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"codex reply\"}]}}\n",
-            "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"codex reply\",\"session_id\":\"sess-cdx\",\"duration_ms\":12,\"usage\":{\"input_tokens\":40000,\"cache_read_input_tokens\":900000,\"output_tokens\":120}}\n",
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"reply\"}]}}\n",
+            "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"reply\",\"session_id\":\"sess-x\",\"duration_ms\":12,\"usage\":{\"input_tokens\":3000000,\"cache_read_input_tokens\":1000000,\"output_tokens\":120}}\n",
         )
         .to_string();
         let mut state = StreamLineState::new();
@@ -901,16 +869,10 @@ mod tests {
 
         assert!(outcome.found_result);
         assert!(!state.saw_per_message_usage);
-        assert_eq!(state.accum_input_tokens, 40_000);
-        assert_eq!(state.accum_cache_read_tokens, 900_000);
-        assert_eq!(state.accum_output_tokens, 120);
-        let usage = crate::db::turns::TurnTokenUsage {
-            input_tokens: state.accum_input_tokens,
-            cache_create_tokens: state.accum_cache_create_tokens,
-            cache_read_tokens: state.accum_cache_read_tokens,
-            output_tokens: state.accum_output_tokens,
-        };
-        assert_eq!(usage.context_occupancy_input_tokens(), 940_000);
+        assert_eq!(state.accum_input_tokens, 0);
+        assert_eq!(state.accum_cache_read_tokens, 0);
+        assert_eq!(state.accum_cache_create_tokens, 0);
+        assert_eq!(state.accum_output_tokens, 0);
     }
 
     /// #3344 fallback regression: a provider that legitimately reports per-call

--- a/src/services/session_backend.rs
+++ b/src/services/session_backend.rs
@@ -296,6 +296,58 @@ impl StreamLineState {
     }
 }
 
+/// #3344: backstop ceiling for impossible-magnitude session-cumulative terminal
+/// usage from NON-codex providers (codex-legacy is gated by provenance, not
+/// magnitude — see [`adopt_terminal_result_usage`]). MAINTENANCE RULE: keep
+/// strictly above the largest registry context window (1_000_000) so it never
+/// rejects honest per-call usage.
+const MAX_PLAUSIBLE_PER_CALL_CONTEXT_TOKENS: u64 = 2_000_000;
+
+/// #3344: adopt a terminal `result` frame's nested `usage` into `state`'s
+/// per-call accumulators with provenance + magnitude gating. Shared by the
+/// watcher (`process_watcher_lines`) and the analytics re-parser
+/// (`process_stream_line`) so both consumers stay in sync.
+///
+/// Provenance gate (primary): the codex legacy wrapper's `emit_success_result`
+/// ALWAYS stamps top-level `input_tokens`/`output_tokens` (Qwen emits a nested
+/// `usage` only), so that marker identifies codex-legacy, whose terminal
+/// accounting is session-cumulative. Its nested `usage` is NEVER adopted — even
+/// small/early values — because honest-unknown CTW beats a sometimes-right
+/// number that drifts into a misleading clamped 100%; codex per-call occupancy
+/// flows from session `token_count` records (#3331). Magnitude gate (backstop):
+/// non-codex providers adopt unchanged unless input+cache clears
+/// [`MAX_PLAUSIBLE_PER_CALL_CONTEXT_TOKENS`]. Suppression leaves accumulators
+/// untouched → honest "unknown". Claude never reaches this path
+/// (`saw_per_message_usage` is set on its per-message `usage` frames).
+pub fn adopt_terminal_result_usage(frame: &Value, state: &mut StreamLineState) {
+    // Provenance: top-level token fields mark the codex legacy wrapper, whose
+    // terminal usage is known-cumulative — suppress always.
+    let is_codex_legacy_frame =
+        frame.get("input_tokens").is_some() || frame.get("output_tokens").is_some();
+    if state.saw_per_message_usage || is_codex_legacy_frame {
+        return;
+    }
+    let Some(usage) = frame.get("usage") else {
+        return;
+    };
+    let read = |key: &str| usage.get(key).and_then(|v| v.as_u64()).unwrap_or(0);
+    let (input, cache_read, cache_create, output) = (
+        read("input_tokens"),
+        read("cache_read_input_tokens"),
+        read("cache_creation_input_tokens"),
+        read("output_tokens"),
+    );
+    let occupancy = input
+        .saturating_add(cache_read)
+        .saturating_add(cache_create);
+    if occupancy <= MAX_PLAUSIBLE_PER_CALL_CONTEXT_TOKENS {
+        state.accum_input_tokens = input;
+        state.accum_cache_read_tokens = cache_read;
+        state.accum_cache_create_tokens = cache_create;
+        state.accum_output_tokens = output;
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TaskStartInfo {
     pub tool_use_id: Option<String>,
@@ -409,36 +461,10 @@ pub fn process_stream_line(
     }
 
     if msg_type == "result" {
-        // #1918: Claude CLI's result.usage in multi-call turns is
-        // turn-cumulative, so overwriting input/cache here would re-introduce
-        // the context-token inflation the per-message branch above already
-        // resolved. Only adopt result.usage when no per-message usage was
-        // observed (Qwen tmux wrappers report token counts solely on the
-        // terminal result event).
-        if !state.saw_per_message_usage
-            && let Some(usage) = json.get("usage")
-        {
-            let input_tokens = usage
-                .get("input_tokens")
-                .and_then(|value| value.as_u64())
-                .unwrap_or(0);
-            let cache_read = usage
-                .get("cache_read_input_tokens")
-                .and_then(|value| value.as_u64())
-                .unwrap_or(0);
-            let cache_creation = usage
-                .get("cache_creation_input_tokens")
-                .and_then(|value| value.as_u64())
-                .unwrap_or(0);
-            let output_tokens = usage
-                .get("output_tokens")
-                .and_then(|value| value.as_u64())
-                .unwrap_or(0);
-            state.accum_input_tokens = input_tokens;
-            state.accum_cache_read_tokens = cache_read;
-            state.accum_cache_create_tokens = cache_creation;
-            state.accum_output_tokens = output_tokens;
-        }
+        // #1918/#3344: provenance + magnitude gated. Codex-legacy terminal usage
+        // is known-cumulative and suppressed so analytics re-parse never carries
+        // poisoned context numbers. See [`adopt_terminal_result_usage`].
+        adopt_terminal_result_usage(&json, state);
 
         let cost_usd = json.get("cost_usd").and_then(|value| value.as_f64());
         let total_cost_usd = json.get("total_cost_usd").and_then(|value| value.as_f64());
@@ -1057,14 +1083,18 @@ mod stream_tail_guard_tests {
         ));
     }
 
-    /// #3275 cross-module contract: the codex tmux wrapper's result frame now
-    /// carries a Claude-compatible nested `usage` next to the legacy top-level
-    /// token fields. The result-usage fallback in `process_stream_line` must
-    /// adopt it so bridge analytics reparsing and recovery backfill
-    /// (`extract_turn_analytics_from_output_range`) return Some usage with the
-    /// per-call occupancy — not the cumulative top-level counters.
+    /// #3344 round 2 — analytics-path parity (Finding 2): the analytics
+    /// re-parser (`extract_turn_analytics_from_output_range` →
+    /// `process_stream_line`) is the SECOND consumer of terminal `result.usage`,
+    /// and `turn_analytics::resolve_output_analytics_snapshot` PREFERS its
+    /// output over the live snapshot. It must apply the same provenance gate:
+    /// the codex legacy wrapper's terminal frame (top-level
+    /// `input_tokens`/`output_tokens` marker) carries known-cumulative
+    /// accounting, so its nested `usage` is NOT adopted. The re-parse returns
+    /// the session id but `None` usage, so analytics never carries poisoned
+    /// context numbers. (On base this nested usage was adopted unconditionally.)
     #[test]
-    fn extract_turn_analytics_adopts_codex_wrapper_result_usage() {
+    fn extract_turn_analytics_suppresses_codex_wrapper_result_usage() {
         let dir = tempfile::tempdir().unwrap();
         let output_path = dir.path().join("codex-wrapper.jsonl");
         std::fs::write(
@@ -1072,7 +1102,7 @@ mod stream_tail_guard_tests {
             concat!(
                 "{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"sess-cdx\"}\n",
                 "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"codex reply\"}]}}\n",
-                "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"codex reply\",\"session_id\":\"sess-cdx\",\"duration_ms\":12,\"input_tokens\":8325687,\"output_tokens\":41600,\"usage\":{\"input_tokens\":400,\"cache_read_input_tokens\":600,\"output_tokens\":50}}\n",
+                "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"codex reply\",\"session_id\":\"sess-cdx\",\"duration_ms\":12,\"input_tokens\":8325687,\"output_tokens\":41600,\"usage\":{\"input_tokens\":500000,\"cache_read_input_tokens\":600,\"output_tokens\":50}}\n",
             ),
         )
         .unwrap();
@@ -1084,12 +1114,75 @@ mod stream_tail_guard_tests {
         );
 
         assert_eq!(session_id.as_deref(), Some("sess-cdx"));
-        let usage = usage.expect("codex wrapper result usage must be recoverable");
-        assert_eq!(usage.input_tokens, 400);
-        assert_eq!(usage.cache_read_tokens, 600);
-        assert_eq!(usage.cache_create_tokens, 0);
-        assert_eq!(usage.output_tokens, 50);
-        assert_eq!(usage.context_occupancy_input_tokens(), 1000);
+        // Codex-legacy provenance → nested usage suppressed → no poisoned
+        // analytics. `has_usage` is false so the re-parser returns None.
+        assert!(
+            usage.is_none(),
+            "codex-legacy terminal usage must be suppressed from analytics"
+        );
+    }
+
+    /// #3344 round 2 — analytics-path other-provider regression (Finding 2 /
+    /// Test 4): a terminal-usage provider WITHOUT the codex top-level marker
+    /// (Qwen's tmux wrapper) keeps flowing through the analytics re-parse
+    /// unchanged. The provenance gate does not fire; the magnitude backstop
+    /// passes for sane per-call values, so the per-call occupancy is recovered.
+    #[test]
+    fn extract_turn_analytics_adopts_qwen_terminal_usage() {
+        let dir = tempfile::tempdir().unwrap();
+        let output_path = dir.path().join("qwen-wrapper.jsonl");
+        std::fs::write(
+            &output_path,
+            concat!(
+                "{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"sess-qwen\"}\n",
+                "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"qwen reply\"}]}}\n",
+                "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"qwen reply\",\"session_id\":\"sess-qwen\",\"duration_ms\":7,\"usage\":{\"input_tokens\":1200,\"cache_read_input_tokens\":300,\"cache_creation_input_tokens\":80,\"output_tokens\":256}}\n",
+            ),
+        )
+        .unwrap();
+
+        let (session_id, usage) = super::extract_turn_analytics_from_output_range(
+            output_path.to_string_lossy().as_ref(),
+            0,
+            None,
+        );
+
+        assert_eq!(session_id.as_deref(), Some("sess-qwen"));
+        let usage = usage.expect("qwen terminal usage must be recoverable");
+        assert_eq!(usage.input_tokens, 1200);
+        assert_eq!(usage.cache_read_tokens, 300);
+        assert_eq!(usage.cache_create_tokens, 80);
+        assert_eq!(usage.output_tokens, 256);
+    }
+
+    /// #3344 round 2 — analytics-path backstop: a non-codex provider whose
+    /// nested occupancy clears the 2M ceiling is rejected by the magnitude
+    /// backstop even with no codex marker, so impossible-magnitude garbage from
+    /// any provider never poisons analytics.
+    #[test]
+    fn extract_turn_analytics_backstop_rejects_millions_usage() {
+        let dir = tempfile::tempdir().unwrap();
+        let output_path = dir.path().join("other-wrapper.jsonl");
+        std::fs::write(
+            &output_path,
+            concat!(
+                "{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"sess-x\"}\n",
+                "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"reply\"}]}}\n",
+                "{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"reply\",\"session_id\":\"sess-x\",\"duration_ms\":7,\"usage\":{\"input_tokens\":3000000,\"cache_read_input_tokens\":1000000,\"output_tokens\":256}}\n",
+            ),
+        )
+        .unwrap();
+
+        let (_session_id, usage) = super::extract_turn_analytics_from_output_range(
+            output_path.to_string_lossy().as_ref(),
+            0,
+            None,
+        );
+
+        assert!(
+            usage.is_none(),
+            "millions-scale terminal usage must be rejected by the backstop"
+        );
     }
 
     /// #3281 forensics pinned as code: the 2026-06-10 incident transcript shape


### PR DESCRIPTION
Closes #3344.

## 변경 (2커밋 + 메타 교정)
1. **round 1**: 2M 천장 게이트 (수백만 스케일 누적치 차단, 정직한 'unknown' 렌더).
2. **round 2 (codex P1 2건)**: ① in-band 마커 기반 **provenance 게이트** — codex legacy wrapper는 terminal result에 top-level input/output_tokens를 항상 스탬프(Qwen은 nested만) → 마커 감지 시 채택 자체를 차단(블라인드 윈도 272k~2M 해소), 2M 천장은 타 프로바이더 방어선으로 유지 ② **analytics 재파서**(session_backend.rs:418, turn_analytics가 선호)도 동일 공유 헬퍼 경유.
3. codex r2 P2: giant 등록 decompose_issue를 신규 #3405로, change-surfaces 재등재 주석 정리. session_backend.rs 1023 LoC giant 등록(승인된 메커니즘, deadline 2026-08-31).

## 검증
- codex 적대 리뷰 2라운드 — P1 전부 수정 검증("disabling the gate makes the blind-window tests fail"), 잔여 P2 메타 교정 완료
- fail-on-HEAD 테스트 8건 (블라인드 윈도/조기 세션/analytics/Qwen·백스톱 회귀)
- 게이트: fmt·clippy·tmux_output_stream 13·session_backend 10·discord 1657(동시빌드 부하 플레이크 1회는 4회 재실행 클린 확인)·audit·docs freshness
- 구현 opus / 리뷰 codex

🤖 Generated with [Claude Code](https://claude.com/claude-code)