### PR TITLE
fix(#3358): carry committed frontier forward for idle-relay synthetic start offsets

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -8,7 +8,7 @@
 > [`docs/generated/giant-file-registry.md`](../generated/giant-file-registry.md);
 > the rows below project the operational meaning of each entry.
 >
-> Last refreshed: 2026-06-12 (against #3089 completion-footer slice — `tmux.rs` suppression exposure tests now strip completion-only footer blocks so internal turns still delete cleanly; generated inventory includes the new `placeholder_live_events/completion_footer.rs` renderer module, and round 2 adds idle-animation TTL/failure-eviction/recovery-takeover forget; on top of #3038 run_bot S5 closing pass).
+> Last refreshed: 2026-06-13 (against #3358 round 2 — synthetic-inflight carry-forward now gated on same-generation evidence: `tmux.rs` re-exports the new `committed_frontier_for_current_generation` reader from `tmux_session_files.rs`, which pairs the per-channel committed watermark with the `.generation` mtime wrapper-identity signal so a stale pre-restart frontier cannot clamp a freshly-reset synthetic forward — the content-skip guard; `tui_prompt_relay.rs::synthetic_start_offset_carry_forward` now takes `Option<u64>` where `None` means no clamp. On top of #3089 completion-footer slice — `tmux.rs` suppression exposure tests strip completion-only footer blocks so internal turns still delete cleanly; generated inventory includes `placeholder_live_events/completion_footer.rs`; on top of #3038 run_bot S5 closing pass).
 
 ## Read This First
 

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -3984,8 +3984,20 @@ mod stall_recovery_tests {
         )
     }
 
+    /// #3358: the two monotonicity tests catch panics via `catch_unwind` while
+    /// sharing the process-global panic hook with every parallel test thread —
+    /// serialize them so a sibling's hook traffic cannot interleave (rare
+    /// parallel-run flake observed on loaded machines).
+    fn monotonic_3358_test_mutex() -> &'static std::sync::Mutex<()> {
+        static M: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        M.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
     #[test]
     fn synthetic_lagging_birth_reproduces_backward_regression_3358() {
+        let _serialized = monotonic_3358_test_mutex()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
         // REPRODUCE: a lagging birth re-claim over the committed frontier is a
         // same-identity backward write that trips the monotonicity guard. This is
         // the pre-fix incident; it MUST still be flagged so the guard's protective
@@ -4022,6 +4034,9 @@ mod stall_recovery_tests {
 
     #[test]
     fn synthetic_carry_forward_keeps_reclaim_monotonic_3358() {
+        let _serialized = monotonic_3358_test_mutex()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
         // FIX: birth carried up to the committed frontier → re-claim is forward/
         // equal, ZERO invariant violations, offsets end at the frontier.
         let temp = TempDir::new().unwrap();

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -3952,6 +3952,131 @@ mod stall_recovery_tests {
         assert_eq!(loaded[0].last_offset, 200);
     }
 
+    // #3358: pin the EXACT incident at the save level. The synthetic inflight's
+    // birth offset is the relay-cursor base AND the `turn_start_offset` identity
+    // key (`InflightTurnState::new`: turn_start_offset == last_offset, rso == 0).
+    //
+    // The on-disk row carries the watcher's COMMITTED frontier as last_offset
+    // (the watcher is the single authority — #3017 `confirmed_end_offset`). When
+    // the synthetic re-claims/refreshes the row, it writes its BIRTH offset back:
+    //   * Pre-fix: birth == lagging `relay_last_offset()` (2821677) < committed
+    //     frontier (2838484). Same identity (the watcher row is still keyed by
+    //     this turn's anchor + this birth turn_start_offset) → BACKWARD write →
+    //     the `last_offset` + `response_sent_offset` monotonicity guards fire (the
+    //     incident's ERROR triple). This is the REPRODUCE witness.
+    //   * Post-fix: `synthetic_start_offset_carry_forward` births the synthetic at
+    //     the committed frontier (2838484) — equal to the on-disk last_offset, so
+    //     the re-claim is a forward/equal write and NO invariant fires.
+    fn build_synth_3358(birth: u64) -> InflightTurnState {
+        InflightTurnState::new(
+            ProviderKind::Claude,
+            321,
+            Some("adk-cc".to_string()),
+            1,
+            1_514_752_860_691_370_014, // synthetic user_msg_id (anchor id)
+            9002,
+            "new synthetic prompt".to_string(),
+            None,
+            Some("AgentDesk-claude-adk-cc".to_string()),
+            Some("/tmp/out.jsonl".to_string()),
+            None,
+            birth,
+        )
+    }
+
+    #[test]
+    fn synthetic_lagging_birth_reproduces_backward_regression_3358() {
+        // REPRODUCE: a lagging birth re-claim over the committed frontier is a
+        // same-identity backward write that trips the monotonicity guard. This is
+        // the pre-fix incident; it MUST still be flagged so the guard's protective
+        // value is preserved for genuine regressions.
+        let temp = TempDir::new().unwrap();
+        let relay_last_offset: u64 = 2_821_677; // lagging birth (pre-fix).
+        let committed_frontier: u64 = 2_838_484; // watcher confirmed delivery.
+
+        // On-disk row: SAME identity as the lagging birth, last_offset already at
+        // the committed frontier (the watcher advanced it forward).
+        let mut on_disk = build_synth_3358(relay_last_offset);
+        on_disk.full_response = "X".repeat(20_000);
+        on_disk.response_sent_offset = 18_000;
+        on_disk.last_offset = committed_frontier;
+        save_inflight_state_in_root(temp.path(), &on_disk).unwrap();
+
+        // Lagging-birth re-claim: turn_start_offset == last_offset == lagging
+        // (2821677), rso == 0 — BACKWARD vs the committed frontier, same identity.
+        let lagging_reseed = build_synth_3358(relay_last_offset);
+        assert_eq!(lagging_reseed.turn_start_offset, Some(relay_last_offset));
+        let lag = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            validate_inflight_state_for_save(
+                temp.path(),
+                &inflight_state_path(temp.path(), &ProviderKind::Claude, 321),
+                &lagging_reseed,
+                "src/services/discord/inflight.rs:test",
+            );
+        }));
+        assert!(
+            lag.is_err() || cfg!(not(debug_assertions)),
+            "lagging-birth re-claim must trip the monotonicity guard (incident + genuine-regression witness)"
+        );
+    }
+
+    #[test]
+    fn synthetic_carry_forward_keeps_reclaim_monotonic_3358() {
+        // FIX: birth carried up to the committed frontier → re-claim is forward/
+        // equal, ZERO invariant violations, offsets end at the frontier.
+        let temp = TempDir::new().unwrap();
+        let relay_last_offset: u64 = 2_821_677;
+        let committed_frontier: u64 = 2_838_484;
+        // The carry-forward rule (mirrors tui_prompt_relay::
+        // synthetic_start_offset_carry_forward): birth = relay_last.max(committed).
+        let carried = relay_last_offset.max(committed_frontier);
+        assert_eq!(
+            carried, committed_frontier,
+            "carry-forward must lift birth to the frontier"
+        );
+
+        let mut on_disk = build_synth_3358(carried);
+        on_disk.full_response = "X".repeat(20_000);
+        on_disk.response_sent_offset = 18_000;
+        on_disk.last_offset = committed_frontier;
+        save_inflight_state_in_root(temp.path(), &on_disk).unwrap();
+
+        // Carried-birth re-claim: turn_start_offset == last_offset == frontier,
+        // rso == 0. The rso 0 is NOT a regression because the identity key matches
+        // (same turn) and `response_sent_offset_monotonic` only flags within-turn
+        // backward moves AFTER bytes were sent — here the re-claim's last_offset
+        // equals the on-disk frontier (forward/equal) and rso reset is the
+        // documented fresh-claim seed. Assert last_offset never regresses below
+        // the committed frontier.
+        let carried_reseed = build_synth_3358(carried);
+        let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            // Drive the enforcing watermark path: a carried-birth refresh writes
+            // last_offset == committed_frontier — forward/equal, accepted.
+            refresh_inflight_last_offset_if_matches_identity_in_root(
+                temp.path(),
+                &ProviderKind::Claude,
+                321,
+                &InflightTurnIdentity::from_state(&carried_reseed),
+                carried_reseed.turn_start_offset,
+                "/tmp/out.jsonl",
+                Some(carried_reseed.current_msg_id),
+                committed_frontier,
+                RelayOwnerKind::Watcher,
+            )
+        }));
+        assert!(res.is_ok(), "carried-birth refresh must not panic");
+        assert!(
+            res.unwrap(),
+            "carried-birth watermark write is forward/equal — accepted"
+        );
+        let loaded = load_inflight_states_from_root(temp.path(), &ProviderKind::Claude);
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(
+            loaded[0].last_offset, committed_frontier,
+            "offsets end at the committed frontier, never regressed"
+        );
+    }
+
     #[test]
     fn identity_heartbeat_refresh_advances_forward_offset_same_identity() {
         // #3017 I6: a forward watermark write for the same identity advances.

--- a/src/services/discord/inflight.rs
+++ b/src/services/discord/inflight.rs
@@ -4027,9 +4027,17 @@ mod stall_recovery_tests {
         let temp = TempDir::new().unwrap();
         let relay_last_offset: u64 = 2_821_677;
         let committed_frontier: u64 = 2_838_484;
-        // The carry-forward rule (mirrors tui_prompt_relay::
-        // synthetic_start_offset_carry_forward): birth = relay_last.max(committed).
-        let carried = relay_last_offset.max(committed_frontier);
+        // Drive the ACTUAL production carry-forward helper (not an inline copy) so
+        // this green test honestly tracks the production wiring — if the helper
+        // regressed, `carried` would no longer reach the frontier and the
+        // monotonicity assertions below would fail. The frontier is `Some(..)`
+        // because the watcher advanced it WITHIN this same wrapper generation (the
+        // claim choke-point validates that before clamping — #3358 round 2).
+        let carried =
+            crate::services::discord::tui_prompt_relay::synthetic_start_offset_carry_forward(
+                relay_last_offset,
+                Some(committed_frontier),
+            );
         assert_eq!(
             carried, committed_frontier,
             "carry-forward must lift birth to the frontier"
@@ -4074,6 +4082,46 @@ mod stall_recovery_tests {
         assert_eq!(
             loaded[0].last_offset, committed_frontier,
             "offsets end at the committed frontier, never regressed"
+        );
+    }
+
+    #[test]
+    fn synthetic_carry_forward_skipped_on_generation_mismatch_3358() {
+        // #3358 round 2 — Finding 1 guard, at the production-helper level.
+        //
+        // After a tmux wrapper RESTART the output stream legitimately resets to
+        // offset 0. The committed watermark from the PREVIOUS generation is stale;
+        // the claim choke-point detects the generation mismatch and passes `None`
+        // for the committed frontier. The helper MUST then fall back to the
+        // synthetic's own (lagging) birth offset — NOT lift it over the stale
+        // watermark, which would treat future bytes below that watermark as
+        // already delivered (CONTENT SKIP, strictly worse than the original
+        // ERROR-only bug). On HEAD (helper took a bare `u64` and always clamped)
+        // there was no way to express "stale → do not clamp", so this guard
+        // failed.
+        let relay_last_offset: u64 = 100; // fresh post-restart birth (lagging).
+        let stale_frontier: u64 = 2_838_484; // pre-restart, NUMERICALLY higher.
+
+        // Generation mismatch → `None`: NO clamp, born at its own cursor.
+        let birth =
+            crate::services::discord::tui_prompt_relay::synthetic_start_offset_carry_forward(
+                relay_last_offset,
+                None,
+            );
+        assert_eq!(
+            birth, relay_last_offset,
+            "a stale (different-generation) watermark must NOT clamp the new synthetic forward"
+        );
+
+        // Same generation → `Some(..)`: clamp DOES carry the frontier forward.
+        let same_gen_birth =
+            crate::services::discord::tui_prompt_relay::synthetic_start_offset_carry_forward(
+                relay_last_offset,
+                Some(stale_frontier),
+            );
+        assert_eq!(
+            same_gen_birth, stale_frontier,
+            "a same-generation committed frontier must still carry forward (the #3358 fix)"
         );
     }
 

--- a/src/services/discord/tmux.rs
+++ b/src/services/discord/tmux.rs
@@ -50,8 +50,7 @@ use super::tmux_restart_handoff::{
 use super::{
     SharedData, TmuxWatcherHandle, TmuxWatcherRegistry, lock_tmux_watcher_registry, rate_limit_wait,
 };
-// Keep the extracted lifecycle code as a tmux child module until the remaining
-// watcher helpers it calls are split out of this file.
+// Extracted lifecycle code stays a tmux child module until its callers split out.
 #[path = "tmux_reattach_offsets.rs"]
 mod tmux_reattach_offsets;
 #[path = "tmux_session_files.rs"]
@@ -60,6 +59,7 @@ mod tmux_session_files;
 mod watcher_lifecycle;
 
 use self::tmux_reattach_offsets::matching_recent_watcher_reattach_offset;
+pub(in crate::services::discord) use self::tmux_session_files::committed_frontier_for_current_generation;
 pub(super) use self::tmux_session_files::read_generation_file_mtime_ns;
 pub(in crate::services::discord) use self::tmux_session_files::reset_relay_watermark_on_generation_change;
 pub(in crate::services::discord) use self::tmux_session_files::reset_stale_relay_watermark_if_output_regressed;

--- a/src/services/discord/tmux_session_files.rs
+++ b/src/services/discord/tmux_session_files.rs
@@ -250,9 +250,21 @@ pub(in crate::services::discord) fn committed_frontier_for_current_generation(
 ) -> Option<u64> {
     use std::sync::atomic::Ordering::Acquire;
     let coord = shared.tmux_relay_coord(channel_id);
+    // #3358 r2 review P1 (TOCTOU): the (offset, generation) pair lives in two
+    // atomics — a concurrent commit between the loads could pair an OLD offset
+    // with the NEW wrapper's generation stamp and resurrect the stale clamp.
+    // Double-read fence: the generation stamp must agree on both sides of the
+    // offset load; a mid-transition mismatch returns None (no clamp — the
+    // content-skip-safe direction, same tradeoff as the stale-generation path).
+    let generation_before = coord.confirmed_end_generation_mtime_ns.load(Acquire);
+    let committed_offset = coord.confirmed_end_offset.load(Acquire);
+    let generation_after = coord.confirmed_end_generation_mtime_ns.load(Acquire);
+    if generation_before != generation_after {
+        return None;
+    }
     committed_frontier_for_same_generation(
-        coord.confirmed_end_offset.load(Acquire),
-        coord.confirmed_end_generation_mtime_ns.load(Acquire),
+        committed_offset,
+        generation_after,
         read_generation_file_mtime_ns(tmux_session_name),
     )
 }

--- a/src/services/discord/tmux_session_files.rs
+++ b/src/services/discord/tmux_session_files.rs
@@ -217,6 +217,46 @@ pub(super) fn watermark_after_output_regression(
     if same_wrapper { observed_output_end } else { 0 }
 }
 
+/// #3358 round 2 — gate the committed relay frontier on same-generation identity
+/// for the synthetic-inflight carry-forward. Returns `Some(committed)` ONLY when
+/// the watermark provably belongs to the CURRENT wrapper instance: it is non-zero
+/// AND its `confirmed_end_generation_mtime_ns` snapshot equals the live
+/// `.generation` mtime (both non-zero) — the same wrapper-identity rule
+/// `watermark_after_output_regression` / `reset_relay_watermark_on_generation_change`
+/// use. On a generation mismatch (post-restart) or unprovable identity it returns
+/// `None`, so a STALE frontier never clamps a freshly-reset synthetic forward (the
+/// content-skip risk). Pure for unit testing.
+pub(super) fn committed_frontier_for_same_generation(
+    committed_offset: u64,
+    stored_generation_mtime_ns: i64,
+    current_generation_mtime_ns: i64,
+) -> Option<u64> {
+    let same_wrapper = committed_offset != 0
+        && stored_generation_mtime_ns != 0
+        && current_generation_mtime_ns != 0
+        && stored_generation_mtime_ns == current_generation_mtime_ns;
+    same_wrapper.then_some(committed_offset)
+}
+
+/// #3358 round 2 — read the committed relay frontier for `channel_id`, gated on
+/// same-generation identity (`committed_frontier_for_same_generation`). `Some`
+/// only when the watermark belongs to the CURRENT wrapper for `tmux_session_name`,
+/// else `None` (the synthetic carry-forward's sole input — see
+/// `synthetic_start_offset_carry_forward`).
+pub(in crate::services::discord) fn committed_frontier_for_current_generation(
+    shared: &SharedData,
+    channel_id: ChannelId,
+    tmux_session_name: &str,
+) -> Option<u64> {
+    use std::sync::atomic::Ordering::Acquire;
+    let coord = shared.tmux_relay_coord(channel_id);
+    committed_frontier_for_same_generation(
+        coord.confirmed_end_offset.load(Acquire),
+        coord.confirmed_end_generation_mtime_ns.load(Acquire),
+        read_generation_file_mtime_ns(tmux_session_name),
+    )
+}
+
 /// Reset the shared relay watermark when the `.generation` mtime has CHANGED
 /// since the watermark was committed (#3016 #3017 codex r6/r7). This is the
 /// "different wrapper → reset to 0" case that
@@ -497,5 +537,38 @@ pub(super) async fn sweep_orphan_session_files() {
             swept,
             dir.display()
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // #3358 round 2 — Finding 1 guard at the pure-decision level.
+    #[test]
+    fn committed_frontier_gated_on_same_generation() {
+        // Same generation (both non-zero, equal) → carries the frontier.
+        assert_eq!(
+            committed_frontier_for_same_generation(2_838_484, 42, 42),
+            Some(2_838_484),
+            "a same-generation watermark must be eligible to carry forward"
+        );
+        // Generation mismatch (post-restart) → None: stale watermark must NOT clamp.
+        assert_eq!(
+            committed_frontier_for_same_generation(2_838_484, 42, 99),
+            None,
+            "a different-generation (stale) watermark must NOT be carried forward"
+        );
+        // Unprovable identity: either mtime 0 → None.
+        assert_eq!(
+            committed_frontier_for_same_generation(2_838_484, 0, 42),
+            None
+        );
+        assert_eq!(
+            committed_frontier_for_same_generation(2_838_484, 42, 0),
+            None
+        );
+        // No committed delivery yet (offset 0) → None even if generations match.
+        assert_eq!(committed_frontier_for_same_generation(0, 42, 42), None);
     }
 }

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -1284,6 +1284,29 @@ async fn finish_tui_direct_synthetic_pre_save_failure(
     let _ = super::mailbox_finish_turn(shared, provider, channel_id).await;
 }
 
+/// #3358 — offset-authority handover for synthetic inflight creation.
+///
+/// A new synthetic turn's `start_offset` (which seeds `turn_start_offset ==
+/// last_offset`, rso 0 in `InflightTurnState::new`) is the lagging
+/// `relay_last_offset()`. The tmux watcher is the SINGLE authority for the
+/// already-delivered frontier (`committed_relay_offset` / `confirmed_end_offset`,
+/// #3017). When `relay_last_offset()` lags that frontier, a later relay re-claim /
+/// refresh re-seeds the SAME-identity row at the lagging value AFTER the watcher
+/// advanced it — a backward write that trips the `last_offset` / `response_sent_offset`
+/// monotonicity invariants (the #3358 incident). CARRY-FORWARD the committed
+/// frontier so the synthetic is born at/above every byte already delivered;
+/// `turn_start_offset` and `last_offset` stay equal (the #3154-S4 identity==cursor
+/// invariant) and persistence never regresses. A genuine backward write OUTSIDE
+/// this handover (committed == 0 / not ahead) is untouched, so the guards still
+/// catch real regressions. Returns the clamped offset; the caller logs INFO once
+/// when it actually moved the frontier forward.
+fn synthetic_start_offset_carry_forward(
+    relay_last_offset: u64,
+    committed_relay_offset: u64,
+) -> u64 {
+    relay_last_offset.max(committed_relay_offset)
+}
+
 async fn claim_tui_direct_synthetic_turn(
     shared: &Arc<SharedData>,
     provider: &ProviderKind,
@@ -1302,10 +1325,27 @@ async fn claim_tui_direct_synthetic_turn(
         channel_id,
         binding.as_ref(),
     );
-    let start_offset = binding
+    let relay_last_offset = binding
         .as_ref()
         .map(crate::services::tui_prompt_dedupe::TuiRuntimeBinding::relay_last_offset)
         .unwrap_or(0);
+    // #3358: carry the watcher's committed frontier forward into the synthetic's
+    // birth offset so a later same-identity re-claim cannot regress it.
+    let committed_relay_offset = shared.committed_relay_offset(channel_id);
+    let start_offset =
+        synthetic_start_offset_carry_forward(relay_last_offset, committed_relay_offset);
+    if start_offset > relay_last_offset {
+        tracing::info!(
+            provider = %provider.as_str(),
+            channel_id = channel_id.get(),
+            tmux_session_name = %tmux_session_name,
+            anchor_message_id = anchor_message_id.get(),
+            relay_last_offset,
+            committed_relay_offset,
+            start_offset,
+            "#3358 synthetic inflight offset-authority handover: carried committed relay frontier forward"
+        );
+    }
     let relay_owner = if tui_direct_watcher_can_own_output(
         &shared.tmux_watchers,
         tmux_session_name,
@@ -8811,6 +8851,46 @@ mod tests {
             clamp_idle_tail_start_offset_to_committed(800, 300),
             800,
             "a lagging committed offset must not drag the start offset backwards"
+        );
+    }
+
+    // #3358: a new synthetic inflight whose `relay_last_offset()` LAGS the
+    // watcher's committed frontier must be born at/above that frontier so a
+    // later same-identity re-claim cannot regress `turn_start_offset` /
+    // `last_offset` below already-delivered bytes (the monotonicity ERROR triple).
+    #[test]
+    fn synthetic_start_offset_carries_committed_frontier_forward() {
+        // relay_last_offset lags (2821677) the watcher committed end (2838484):
+        // born at the committed frontier so no backward re-seed is possible.
+        assert_eq!(
+            synthetic_start_offset_carry_forward(2_821_677, 2_838_484),
+            2_838_484,
+            "lagging relay_last_offset must carry the committed frontier forward"
+        );
+        // Equal frontier → unchanged (born exactly at the committed end).
+        assert_eq!(
+            synthetic_start_offset_carry_forward(2_838_484, 2_838_484),
+            2_838_484
+        );
+    }
+
+    // #3358 genuine-regression guard: the carry-forward is BOUNDED to the
+    // synthetic-creation handover — it never DRAGS a healthy start offset
+    // backwards, and a missing/lagging committed frontier (outage / no confirmed
+    // delivery) leaves the relay_last_offset intact so the invariants still catch
+    // real backward writes elsewhere.
+    #[test]
+    fn synthetic_start_offset_carry_forward_never_regresses() {
+        // committed == 0 (watcher delivered nothing this process) → no-op.
+        assert_eq!(
+            synthetic_start_offset_carry_forward(2_821_677, 0),
+            2_821_677
+        );
+        // committed lags relay_last_offset → must NOT pull the start backwards.
+        assert_eq!(
+            synthetic_start_offset_carry_forward(900, 300),
+            900,
+            "a lagging committed frontier must never drag the synthetic start backwards"
         );
     }
 

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -1286,25 +1286,23 @@ async fn finish_tui_direct_synthetic_pre_save_failure(
 
 /// #3358 — offset-authority handover for synthetic inflight creation.
 ///
-/// A new synthetic turn's `start_offset` (which seeds `turn_start_offset ==
-/// last_offset`, rso 0 in `InflightTurnState::new`) is the lagging
-/// `relay_last_offset()`. The tmux watcher is the SINGLE authority for the
-/// already-delivered frontier (`committed_relay_offset` / `confirmed_end_offset`,
-/// #3017). When `relay_last_offset()` lags that frontier, a later relay re-claim /
-/// refresh re-seeds the SAME-identity row at the lagging value AFTER the watcher
-/// advanced it — a backward write that trips the `last_offset` / `response_sent_offset`
-/// monotonicity invariants (the #3358 incident). CARRY-FORWARD the committed
-/// frontier so the synthetic is born at/above every byte already delivered;
-/// `turn_start_offset` and `last_offset` stay equal (the #3154-S4 identity==cursor
-/// invariant) and persistence never regresses. A genuine backward write OUTSIDE
-/// this handover (committed == 0 / not ahead) is untouched, so the guards still
-/// catch real regressions. Returns the clamped offset; the caller logs INFO once
-/// when it actually moved the frontier forward.
-fn synthetic_start_offset_carry_forward(
+/// A synthetic is born at the lagging `relay_last_offset()`; when that lags the
+/// watcher's delivered frontier (#3017), a later same-identity re-claim re-seeds
+/// the row backward → trips the monotonicity guards (the incident). CARRY-FORWARD
+/// the frontier so the synthetic is born at/above every delivered byte.
+///
+/// #3358 round 2 — GATED: `committed_relay_offset` is `Some` ONLY when the gating
+/// accessor proved the watermark belongs to the CURRENT wrapper. After a restart
+/// the stream resets to 0; a stale PREVIOUS-generation watermark must NOT clamp
+/// forward — that marks future bytes below it as delivered → CONTENT SKIP (worse
+/// than the original ERROR-only bug). On mismatch the frontier is `None` and we
+/// fall back to pre-fix seeding (`relay_last_offset` only): the rare monotonicity
+/// ERROR beats a skip, and backward writes outside this handover stay guarded.
+pub(in crate::services::discord) fn synthetic_start_offset_carry_forward(
     relay_last_offset: u64,
-    committed_relay_offset: u64,
+    committed_relay_offset: Option<u64>,
 ) -> u64 {
-    relay_last_offset.max(committed_relay_offset)
+    relay_last_offset.max(committed_relay_offset.unwrap_or(0))
 }
 
 async fn claim_tui_direct_synthetic_turn(
@@ -1329,9 +1327,13 @@ async fn claim_tui_direct_synthetic_turn(
         .as_ref()
         .map(crate::services::tui_prompt_dedupe::TuiRuntimeBinding::relay_last_offset)
         .unwrap_or(0);
-    // #3358: carry the watcher's committed frontier forward into the synthetic's
-    // birth offset so a later same-identity re-claim cannot regress it.
-    let committed_relay_offset = shared.committed_relay_offset(channel_id);
+    // #3358 round 2: carry the committed frontier forward, but ONLY for the
+    // CURRENT wrapper generation (stale → `None` → no content skip).
+    let committed_relay_offset = super::tmux::committed_frontier_for_current_generation(
+        shared,
+        channel_id,
+        tmux_session_name,
+    );
     let start_offset =
         synthetic_start_offset_carry_forward(relay_last_offset, committed_relay_offset);
     if start_offset > relay_last_offset {
@@ -1341,7 +1343,7 @@ async fn claim_tui_direct_synthetic_turn(
             tmux_session_name = %tmux_session_name,
             anchor_message_id = anchor_message_id.get(),
             relay_last_offset,
-            committed_relay_offset,
+            committed_relay_offset = committed_relay_offset.unwrap_or(0),
             start_offset,
             "#3358 synthetic inflight offset-authority handover: carried committed relay frontier forward"
         );
@@ -8858,19 +8860,48 @@ mod tests {
     // watcher's committed frontier must be born at/above that frontier so a
     // later same-identity re-claim cannot regress `turn_start_offset` /
     // `last_offset` below already-delivered bytes (the monotonicity ERROR triple).
+    // The committed frontier is `Some(..)` here because the caller validated it
+    // against the CURRENT wrapper generation (see the generation-mismatch test).
     #[test]
     fn synthetic_start_offset_carries_committed_frontier_forward() {
         // relay_last_offset lags (2821677) the watcher committed end (2838484):
         // born at the committed frontier so no backward re-seed is possible.
         assert_eq!(
-            synthetic_start_offset_carry_forward(2_821_677, 2_838_484),
+            synthetic_start_offset_carry_forward(2_821_677, Some(2_838_484)),
             2_838_484,
             "lagging relay_last_offset must carry the committed frontier forward"
         );
         // Equal frontier → unchanged (born exactly at the committed end).
         assert_eq!(
-            synthetic_start_offset_carry_forward(2_838_484, 2_838_484),
+            synthetic_start_offset_carry_forward(2_838_484, Some(2_838_484)),
             2_838_484
+        );
+    }
+
+    // #3358 round 2 — Finding 1 guard: a STALE committed watermark from a
+    // PREVIOUS wrapper generation must NOT clamp the synthetic forward. The
+    // caller proves same-generation identity and passes `None` on mismatch, so
+    // the helper falls back to `relay_last_offset` only. This is the content-skip
+    // prevention: after a wrapper restart the stream resets to 0 and the new
+    // synthetic must be born at its own (lagging) relay cursor, NOT lifted over a
+    // stale frontier that would mark future bytes as already delivered.
+    #[test]
+    fn synthetic_start_offset_no_clamp_on_generation_mismatch() {
+        // Generation mismatch → caller passes `None`: pre-fix seeding
+        // (`relay_last_offset` only), even though a stale watermark (2838484) was
+        // numerically higher. The rare monotonicity ERROR here is preferable to a
+        // content skip (see helper doc).
+        assert_eq!(
+            synthetic_start_offset_carry_forward(2_821_677, None),
+            2_821_677,
+            "a generation-mismatched (stale) watermark must NOT clamp the synthetic forward"
+        );
+        // Fresh stream reset to 0 after restart, stale watermark unproven → birth
+        // stays at 0, so the watcher walks the new generation from the head.
+        assert_eq!(
+            synthetic_start_offset_carry_forward(0, None),
+            0,
+            "a fresh post-restart stream must not be lifted over a stale frontier (content skip)"
         );
     }
 
@@ -8881,14 +8912,14 @@ mod tests {
     // real backward writes elsewhere.
     #[test]
     fn synthetic_start_offset_carry_forward_never_regresses() {
-        // committed == 0 (watcher delivered nothing this process) → no-op.
+        // committed unprovable/absent (`None`) → no-op.
         assert_eq!(
-            synthetic_start_offset_carry_forward(2_821_677, 0),
+            synthetic_start_offset_carry_forward(2_821_677, None),
             2_821_677
         );
         // committed lags relay_last_offset → must NOT pull the start backwards.
         assert_eq!(
-            synthetic_start_offset_carry_forward(900, 300),
+            synthetic_start_offset_carry_forward(900, Some(300)),
             900,
             "a lagging committed frontier must never drag the synthetic start backwards"
         );


### PR DESCRIPTION
Fixes #3306-family follow-up #3358: idle-relay synthetic start offset could regress backward when the relay birth lagged the committed frontier.

## Changes
- `synthetic_start_offset_carry_forward(relay_last_offset, Option<committed_frontier>)` helper in `tui_prompt_relay.rs` — carries the committed frontier forward so synthetic starts never reclaim offsets behind it (trade-off: content-skip < monotonicity ERROR).
- Generation gate: committed frontier only honored when the `.generation` file mtime matches the stamped generation.
- TOCTOU fence (codex r2 P1): `committed_frontier_for_current_generation` double-reads the generation stamp around the offset load and bails on mismatch (`tmux_session_files.rs`).
- Flaky-pair hardening: `monotonic_3358_test_mutex()` serializes the two synthetic regression tests (1/3 flake under parallel load → 8 stress runs clean).

## Review rounds
- r1 opus: helper extraction + generation gate
- r2 codex: P1 TOCTOU on generation read → double-read fence
- r3 codex: VERDICT: CLEAN

Implementation: opus subagent + direct fixes / Review: codex (gpt-5.5 xhigh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
