### PR TITLE
feat(#3089): A6b — tui_prompt_relay external-input joins the unified controller (closes #3088)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -612,6 +612,7 @@ src/
 │   │   ├── tmux_watcher.rs
 │   │   ├── tui_direct_pending_start.rs
 │   │   ├── tui_prompt_relay.rs
+│   │   ├── tui_prompt_relay_controller_cutover.rs
 │   │   ├── tui_task_card.rs
 │   │   ├── turn_finalizer.rs
 │   │   ├── voice_acknowledgement.rs

--- a/src/services/discord/mod.rs
+++ b/src/services/discord/mod.rs
@@ -45,9 +45,7 @@ mod session_relay_sink;
 // #2011 Phase 5.3: standalone JSONL → Discord relay loop on cluster-standby nodes (leader uses tmux_watcher's relay path).
 #[cfg(unix)]
 mod standby_relay;
-// #1074: landing zone for the future recovery-engine module split (restart /
-// runtime / manual_rebind; see `docs/recovery-paths.md`). Named `recovery_paths`
-// to avoid shadowing the `recovery_engine as recovery` alias until the split lands.
+// #1074: landing zone for the future recovery-engine module split (restart / runtime / manual_rebind; see `docs/recovery-paths.md`). Named `recovery_paths` to avoid shadowing the `recovery_engine as recovery` alias until the split lands.
 mod recovery_engine;
 mod recovery_paths;
 mod restart_mode;
@@ -94,6 +92,7 @@ mod tmux_restart_handoff;
 mod tui_direct_abort_marker;
 mod tui_direct_pending_start;
 mod tui_prompt_relay;
+pub(super) mod tui_prompt_relay_controller_cutover; // #3089 A6b: see module doc (closes #3088)
 mod tui_task_card;
 mod turn_bridge;
 mod turn_finalizer;

--- a/src/services/discord/recovery_engine.rs
+++ b/src/services/discord/recovery_engine.rs
@@ -281,11 +281,10 @@ async fn relay_recovered_terminal_text_to_placeholder(
     let delivery = match placeholder {
         Some(placeholder) => {
             use super::recovery_paths::controller_cutover as cc;
-            // #3089 A6a: anchored short-replace via the unified controller behind a
-            // flag (default OFF); the adapter maps the verdict to
-            // `RecoveryRelayOutcome` AND re-runs the #3297 probe, returning the
-            // legacy path's equal. OFF / None / empty → verbatim legacy. Provider is
-            // cosmetic on the markerless `NoLease` path (no marker gates on it).
+            // #3089 A6a: anchored short-replace via the unified controller behind a flag
+            // (default OFF); the adapter maps the verdict to `RecoveryRelayOutcome` AND
+            // re-runs the #3297 probe, returning the legacy path's equal. OFF / None / empty
+            // → verbatim legacy. Provider is cosmetic on the markerless `NoLease` path.
             if cc::recovery_short_replace_should_cutover(
                 cc::recovery_relay_controller_enabled(),
                 true,
@@ -4133,6 +4132,7 @@ pub(super) async fn restore_inflight_turns(
                 defer_watcher_resume: false,
                 reuse_status_panel_message: true,
                 completion_tx: None,
+                is_external_input_tui_direct: false, // #3089 A6b: recovery is not external-input
                 inflight_state: state,
             },
         );

--- a/src/services/discord/router/message_handler/headless_turn.rs
+++ b/src/services/discord/router/message_handler/headless_turn.rs
@@ -755,8 +755,7 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
         session_id.is_some(),
         prompt_prep_duration_ms
     );
-    // #1085: same session-reuse counter as the foreground path so headless
-    // (background-trigger) turns are reflected in the reuse-rate metric.
+    // #1085: same session-reuse counter as the foreground path so headless (background-trigger) turns are reflected in the reuse-rate metric.
     crate::services::observability::metrics::record_session_entry(
         channel_id.get(),
         provider_label,
@@ -1305,6 +1304,7 @@ pub(super) async fn start_reserved_headless_turn_with_owner(
             defer_watcher_resume: false,
             reuse_status_panel_message: false,
             completion_tx: None,
+            is_external_input_tui_direct: false, // #3089 A6b: Discord-origin (not external-input)
             inflight_state,
         },
     );

--- a/src/services/discord/router/message_handler/intake_turn.rs
+++ b/src/services/discord/router/message_handler/intake_turn.rs
@@ -465,8 +465,7 @@ pub(in crate::services::discord) async fn handle_text_message(
             Some(&context),
         )
     });
-    // #2266: keep the original Discord author (the announce bot, for a
-    // voice-transcript announcement) so the race-loss enqueue path can
+    // #2266: keep the original Discord author (the announce bot, for a voice-transcript announcement) so the race-loss enqueue path can
     // attribute the queued `Intervention` to the announce bot. When the
     // queued turn later re-enters `handle_text_message` via the
     // dispatch/kickoff hooks, the same `announce_bot_id == Some(request_owner)`
@@ -3755,6 +3754,7 @@ pub(in crate::services::discord) async fn handle_text_message(
             defer_watcher_resume,
             reuse_status_panel_message: false,
             completion_tx,
+            is_external_input_tui_direct: false, // #3089 A6b: Discord-origin intake turn
             inflight_state,
         },
     );

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -4280,9 +4280,7 @@ async fn relay_tui_idle_response_through_bridge(
             provider.as_str()
         ));
     };
-    // #3097: resolve the provider-specific compact threshold so the status
-    // panel reflects the configured value (e.g. `context_compact_percent_claude`)
-    // instead of the hardcoded 0 it used previously.
+    // #3097: resolve the provider-specific compact threshold so the status panel reflects the configured value (e.g. `context_compact_percent_claude`) instead of the hardcoded 0 it used previously.
     let context_compact_percent = super::adk_session::fetch_context_thresholds(shared.api_port)
         .await
         .compact_pct_for(&provider);
@@ -4303,9 +4301,7 @@ async fn relay_tui_idle_response_through_bridge(
         shared.clone(),
         channel_id,
         reference,
-        // #3082 P2-3: a TUI idle-response placeholder is an ACTIVE-turn card,
-        // not a queued "📬" notice — it must not wait on the answer-flush
-        // barrier.
+        // #3082 P2-3: a TUI idle-response placeholder is an ACTIVE-turn card, not a queued "📬" notice — it must not wait on the answer-flush barrier.
         false,
     )
     .await?;
@@ -4354,6 +4350,7 @@ async fn relay_tui_idle_response_through_bridge(
         defer_watcher_resume: false,
         reuse_status_panel_message: false,
         completion_tx: Some(completion_tx),
+        is_external_input_tui_direct: true, // #3089 A6b: scope the controller OR-in
         inflight_state,
     };
 
@@ -4519,6 +4516,7 @@ async fn stream_tui_idle_response_through_bridge(
         defer_watcher_resume: false,
         reuse_status_panel_message: false,
         completion_tx: Some(completion_tx),
+        is_external_input_tui_direct: true, // #3089 A6b: scope the controller OR-in
         inflight_state,
     };
 

--- a/src/services/discord/tui_prompt_relay.rs
+++ b/src/services/discord/tui_prompt_relay.rs
@@ -3933,6 +3933,7 @@ async fn run_codex_idle_response_tail(
         &tmux_session_name,
         &rollout_path,
         start_offset,
+        final_offset,
         &prompt_text,
         response,
         &lease,
@@ -4254,6 +4255,11 @@ async fn relay_tui_idle_response_through_bridge(
     tmux_session_name: &str,
     output_path: &Path,
     start_offset: u64,
+    // #3089 A6b r2 [High]: the tail's authoritative end offset. Plumbed into the
+    // bridge stream as `OutputOffset` ONLY when the A6b flag is ON (OFF-safe — see
+    // `codex_external_input_bridge_stream_messages`) so codex external-input's
+    // `ordered_range` becomes true and the cutover reaches the controller.
+    final_offset: u64,
     prompt_text: &str,
     response: &str,
     lease: &ExternalInputRelayLease,
@@ -4355,7 +4361,16 @@ async fn relay_tui_idle_response_through_bridge(
     };
 
     spawn_turn_bridge(shared.clone(), Arc::new(CancelToken::new()), rx, bridge);
-    for message in bridge_adapter_stream_messages(response, None) {
+    // #3089 A6b r2 [High]: feed the bridge `[Text?, OutputOffset?(flag-gated), Done]`.
+    // The flag-gated `OutputOffset` advances `tmux_last_offset` to `final_offset` so
+    // codex external-input's `ordered_range` is true and the cutover reaches the
+    // controller; OFF → no `OutputOffset` → byte-identical legacy `NoRange`.
+    for message in
+        super::tui_prompt_relay_controller_cutover::codex_external_input_bridge_stream_messages(
+            response,
+            final_offset,
+        )
+    {
         tx.send(message)
             .map_err(|error| format!("send TUI-direct bridge stream event: {error}"))?;
     }
@@ -4729,24 +4744,6 @@ fn build_tui_direct_synthetic_inflight_state(
     // overwritten the single shared prompt-anchor slot.
     state.injected_prompt_message_id = Some(user_msg_id.get());
     state
-}
-
-#[cfg(unix)]
-fn bridge_adapter_stream_messages(
-    response: &str,
-    session_id: Option<String>,
-) -> Vec<StreamMessage> {
-    let mut messages = Vec::new();
-    if !response.trim().is_empty() {
-        messages.push(StreamMessage::Text {
-            content: response.to_string(),
-        });
-    }
-    messages.push(StreamMessage::Done {
-        result: response.to_string(),
-        session_id,
-    });
-    messages
 }
 
 #[cfg(unix)]
@@ -7555,22 +7552,11 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
-    #[test]
-    fn bridge_adapter_emits_bridge_compatible_stream_events() {
-        let messages = bridge_adapter_stream_messages("assistant response", Some("sess-1".into()));
-
-        assert_eq!(messages.len(), 2);
-        assert!(matches!(
-            &messages[0],
-            StreamMessage::Text { content } if content == "assistant response"
-        ));
-        assert!(matches!(
-            &messages[1],
-            StreamMessage::Done { result, session_id }
-                if result == "assistant response" && session_id.as_deref() == Some("sess-1")
-        ));
-    }
+    // #3089 A6b r2 [High]: the codex external-input bridge frame builder moved to
+    // `tui_prompt_relay_controller_cutover::codex_external_input_bridge_stream_messages`
+    // (flag-gated `OutputOffset` plumbing). Its OFF (`[Text, Done]`, byte-identical
+    // legacy) and ON (`[Text, OutputOffset, Done]`, reaches the controller) shapes are
+    // pinned in that sibling's test module under the shared env lock.
 
     // ====================================================================
     // #3256: stream-through of operator external-input prose. These tests pin

--- a/src/services/discord/tui_prompt_relay_controller_cutover.rs
+++ b/src/services/discord/tui_prompt_relay_controller_cutover.rs
@@ -1,0 +1,744 @@
+//! #3089 A6b: the explicit-owner closure for #3088 — give the TUI external-input
+//! idle relay (`tui_prompt_relay`) its OWN independent flag so external-input ↔
+//! Discord-origin delivery parity through the unified turn-output controller is
+//! provable on its own, plus mutation-sensitive parity / no-independent-transport
+//! tests. This is the LAST Phase-A cutover and is LOW-RISK / additive.
+//!
+//! ## The architectural fact this builds on (A5 already routes the transport)
+//!
+//! External-input idle delivery does NOT call a transport directly. Both idle
+//! callers — codex `relay_tui_idle_response_through_bridge` and claude
+//! `stream_tui_idle_response_through_bridge` (`tui_prompt_relay.rs`) — build a
+//! `TurnBridgeContext { gateway: Arc::new(TuiDirectBridgeGateway { .. }), .. }`
+//! and hand it to `spawn_turn_bridge`. `TuiDirectBridgeGateway`
+//! (`impl TurnGateway`, `can_chain_locally() == true`) therefore flows into the
+//! **A5 bridge site-5 short-replace cutover** (`turn_bridge/mod.rs` ~6096 →
+//! `bridge_short_replace_cutover_decision` →
+//! `apply_bridge_short_replace_controller` in
+//! `turn_bridge/terminal_controller_cutover.rs`). So when the A5 flag is ON,
+//! external-input delivery ALREADY runs through `deliver_turn_output`.
+//!
+//! A6b is NOT a new transport cutover. It is the independent-flag closure: it OR-s
+//! its own flag (SCOPED to external-input via an explicit `TurnBridgeContext` bool)
+//! into the A5 site-5 decision, REUSING — never cloning — A5's
+//! `apply_bridge_short_replace_controller` / `deliver_short_replace_via_controller`.
+//! The frozen-file delta is ~0 (Option A): the flag/predicate live HERE (a
+//! sub-1000-prod-LoC sibling, ratchet-free) and the only in-`tui_prompt_relay.rs`
+//! edit is the `is_external_input_tui_direct: true` field set at the two
+//! external-input call sites.
+//!
+//! ## What stays LEGACY (byte-identical), confirmed
+//!
+//! - **`ExternalInputRelayLease`** (from `tui_prompt_dedupe`) is a dedup/ownership
+//!   claim keyed by `(provider, session, channel)` + generation nonce — NOT a
+//!   `DeliveryLeaseCell` offset CAS. It stays OUTSIDE the controller,
+//!   byte-identically legacy. The controller's offset lease is the bridge's
+//!   `DeliveryLeaseCell` (keyed on `watcher_owner_channel_id`), already acquired
+//!   ONCE by A5 (which skips the legacy acquire via `bridge_terminal_lease_range`).
+//!   A6b adds NO new acquire → no double-acquire.
+//! - **Runtime-binding offset** (`advance_tmux_runtime_binding_offset`, gated by
+//!   `tui_idle_tail_should_commit_runtime_binding_offset` /
+//!   `..stream_..` in `tui_prompt_relay.rs`) is the tmux dedup/replay cursor
+//!   (`tui_prompt_dedupe`), NOT the delivery frontier (`confirmed_end_offset`). The
+//!   external-input callers run it AFTER the bridge, gated on
+//!   `delivery_result.is_ok()`. A6b does NOT move it into the controller — it stays
+//!   byte-identically legacy. Pinned by [`tests::runtime_binding_offset_commit_stays_legacy`].
+//!
+//! ## Inherited A5 policies (pure consumer — NO controller change)
+//!
+//! The external-input short-replace IS the bridge short-replace, so it inherits
+//! A5's `EditFailPlaceholderPolicy::PreserveAlways` (#2757 — never delete the
+//! intake card on fallback), `FallbackCommitPolicy::NoCommitOnFallback` (a fallback
+//! POST does NOT advance `confirmed_end`; the dual-offset bump sets
+//! `inflight_response_sent_offset = full_response.len()`), `AcquireFailureMode::Transient`,
+//! the real `advance_tmux_relay_confirmed_end`, and `BridgePostHeartbeat`. A5
+//! already added the `Unknown { fell_back }` arm; A6b changes NOTHING in the
+//! controller.
+//!
+//! ## #3088 closure invariant
+//!
+//! External-input produces the SAME ordering shape as Discord-origin (intake card →
+//! controller `Replace { Active }` edit → bridge completion) and creates NO
+//! independent status panel / NO independent transport outside the controller. The
+//! shared long-chunk `SendNewChunks` site (turn_bridge site-4) stays shared-legacy
+//! for BOTH paths (not a parity gap) — deferred to Phase B, same as A5.
+
+use std::sync::OnceLock;
+
+/// #3089 A6b: flag gating the TUI external-input idle relay onto the unified
+/// turn-output controller, INDEPENDENTLY of the A5 turn-bridge flag. Default OFF →
+/// external-input delivery is byte-identical legacy (it only joins the controller
+/// when the A5 flag is ON, exactly as today). ON → external-input short-replace
+/// routes through the controller even with the A5 flag OFF (scoped strictly to
+/// external-input by the explicit `is_external_input_tui_direct` bool on
+/// `TurnBridgeContext`). OnceLock+env, mirroring A6a `recovery_relay_controller_enabled`.
+///
+/// Telemetry ONLY when ENABLED — the default-OFF first evaluation has NO observable
+/// side effect (byte-identical / deploy no-op).
+pub(in crate::services::discord) fn tui_prompt_relay_controller_enabled() -> bool {
+    static CACHED: OnceLock<bool> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        let on = std::env::var("AGENTDESK_TUI_PROMPT_RELAY_CONTROLLER")
+            .ok()
+            .map(|v| v.trim().to_ascii_lowercase())
+            .is_some_and(|v| v == "1" || v == "true");
+        if on {
+            tracing::info!("  ✓ tui_prompt_relay_controller: enabled");
+        }
+        on
+    })
+}
+
+/// #3089 A6b: the pure external-input short-replace cut-over predicate, OR-ed into
+/// the A5 site-5 decision SCOPED to external-input (`turn_bridge/mod.rs` ~6096).
+///
+/// Routes the external-input short-replace onto the unified controller IFF the A6b
+/// flag is ON **and** the turn is external-input (`is_external_input_tui_direct`)
+/// **and** the SAME structural conditions the A5 site-5 decision requires hold
+/// (a live anchor card to edit, a non-empty body, and a real ordered `[start,end)`
+/// range). Each conjunct is LOAD-BEARING — dropping any one wrongly routes a case
+/// that must stay legacy:
+///
+/// - `enabled` OFF → byte-identical legacy (deploy no-op).
+/// - `is_external_input` false → a NON-external-input bridge turn (Discord-origin)
+///   must NOT be routed by the A6b flag; it follows the A5 decision ONLY. Dropping
+///   this conjunct would let A6b-ON/A5-OFF wrongly route Discord-origin turns
+///   (pinned by [`tests::should_cutover_scoped_to_external_input`] and the
+///   integration-level scoping mutation).
+/// - `has_anchor_card` false → no `current_msg_id` to edit; the controller's
+///   `Replace { Active }` plan would target a nonexistent message. (External-input
+///   always anchors an intake card, so this is `true` in prod; kept explicit so a
+///   future placeholder-less arm cannot silently slip into the cutover — matches
+///   the A5 `has_placeholder` input.)
+/// - `body_non_empty` false → an empty body short-circuits the controller to
+///   `Skipped` (not delivered), whereas legacy treats it differently; an empty body
+///   must stay legacy. (Mirrors A5's `body_non_empty`.)
+/// - `ordered_range` false → no real `[start,end)`; the A5 `bridge_terminal_lease_range`
+///   gate keeps the `NoRange` deliver-without-advance arm legacy (the controller
+///   commits IFF the lease advances). (Mirrors A5's `ordered_range`.)
+///
+/// This predicate is OR-ed with `bridge_short_replace_cutover_decision`
+/// (A5's flag) at site 5 — A6b NEVER replaces or weakens the A5 decision; it only
+/// ADDS the external-input-scoped route. When the A5 flag is ON the route is taken
+/// regardless of this predicate (A5 already covers it for BOTH origins).
+pub(in crate::services::discord) fn tui_prompt_relay_short_replace_should_cutover(
+    enabled: bool,
+    is_external_input: bool,
+    has_anchor_card: bool,
+    body_non_empty: bool,
+    ordered_range: bool,
+) -> bool {
+    enabled && is_external_input && has_anchor_card && body_non_empty && ordered_range
+}
+
+/// #3089 A6b: the call-site decision OR-ed into the A5 site-5 cutover
+/// (`turn_bridge/mod.rs` ~6096), AFTER the caller has AND-ed in
+/// `is_external_input_tui_direct` (so `is_external_input` is `true` here). Derives
+/// the SAME structural conditions A5's `bridge_short_replace_cutover_decision` does
+/// — `will_short_replace` (NOT the long-chunk `SendNewChunks` arm; the controller's
+/// `Replace` cannot delete the anchor) and `body_non_empty` — so the A6b route and
+/// the A5 route agree EXACTLY on which body is a "short replace" and only diverge on
+/// the flag/origin. The flag is checked FIRST so OFF short-circuits before the
+/// length predicate (byte-identical / deploy no-op). Kept here so the frozen
+/// `turn_bridge/mod.rs` OR-in stays a single expression. `has_anchor_card` is `true`
+/// at site 5 (it always edits `current_msg_id`); kept explicit in the pure predicate
+/// for symmetry, hardwired `true` here.
+pub(in crate::services::discord) fn tui_prompt_relay_short_replace_should_cutover_decision(
+    controller_enabled: bool,
+    can_chain_locally: bool,
+    formatted_response: &str,
+    ordered_range: bool,
+) -> bool {
+    if !controller_enabled {
+        return false;
+    }
+    // The send arm is the short-replace arm IFF it does NOT send new chunks —
+    // replicating A5's `terminal_delivery_should_send_new_chunks` (which is
+    // `pub(super)` to `turn_bridge`, so the same `can_chain_locally && len >
+    // DISCORD_MSG_LIMIT` test is reproduced here against the shared constant).
+    let will_send_new_chunks =
+        can_chain_locally && formatted_response.len() > crate::services::discord::DISCORD_MSG_LIMIT;
+    let will_short_replace = !will_send_new_chunks;
+    tui_prompt_relay_short_replace_should_cutover(
+        controller_enabled,
+        /* is_external_input */ true, // the caller already AND-ed this in
+        /* has_anchor_card */ true, // site 5 always edits current_msg_id
+        !formatted_response.is_empty(),
+        ordered_range,
+    ) && can_chain_locally
+        && will_short_replace
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::discord::formatting::ReplaceLongMessageOutcome;
+    use crate::services::discord::gateway::{GatewayFuture, TurnGateway};
+    use crate::services::discord::inflight::RelayOwnerKind;
+    use crate::services::discord::outbound::turn_output_controller as toc;
+    use crate::services::discord::placeholder_controller::{PlaceholderKey, PlaceholderLifecycle};
+    use crate::services::discord::turn_finalizer::TurnKey;
+    use crate::services::discord::{
+        DeliveryLeaseCell, LeaseHolder, LeaseSnapshot, SharedData, make_shared_data_for_tests,
+    };
+    use crate::services::provider::ProviderKind;
+    use serenity::all::{ChannelId, MessageId};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+
+    const CH: u64 = 30_881; // external-input delivery channel
+    const MSG: u64 = 88; // the intake-card placeholder MessageId
+    const START: u64 = 100;
+    const END: u64 = 220;
+
+    fn ch() -> ChannelId {
+        ChannelId::new(CH)
+    }
+    fn turn() -> TurnKey {
+        TurnKey::new(ch(), 0, 0)
+    }
+
+    // ---- pure predicate truth table -------------------------------------
+
+    #[test]
+    fn should_cutover_truth_table() {
+        // all-true → true (the cutover row): flag ON, external-input, anchored,
+        // non-empty body, real range.
+        assert!(tui_prompt_relay_short_replace_should_cutover(
+            true, true, true, true, true
+        ));
+        // flag OFF → false (byte-identical legacy / deploy no-op).
+        assert!(!tui_prompt_relay_short_replace_should_cutover(
+            false, true, true, true, true
+        ));
+        // NOT external-input → false (A6b must not route Discord-origin).
+        assert!(!tui_prompt_relay_short_replace_should_cutover(
+            true, false, true, true, true
+        ));
+        // no anchor card → false (nothing to Replace { Active } edit).
+        assert!(!tui_prompt_relay_short_replace_should_cutover(
+            true, true, false, true, true
+        ));
+        // empty body → false (controller short-circuits to Skipped).
+        assert!(!tui_prompt_relay_short_replace_should_cutover(
+            true, true, true, false, true
+        ));
+        // no ordered range → false (NoRange stays legacy; controller commits IFF
+        // the lease advances).
+        assert!(!tui_prompt_relay_short_replace_should_cutover(
+            true, true, true, true, false
+        ));
+    }
+
+    #[test]
+    fn should_cutover_pins_each_condition() {
+        // Mutation guards: dropping ANY conjunct flips exactly one row from the
+        // all-true base. Each assert below is the row that the corresponding
+        // dropped conjunct would wrongly flip to `true`.
+        assert!(
+            !tui_prompt_relay_short_replace_should_cutover(false, true, true, true, true),
+            "enabled is load-bearing: flag OFF must defer"
+        );
+        assert!(
+            !tui_prompt_relay_short_replace_should_cutover(true, false, true, true, true),
+            "is_external_input is load-bearing: Discord-origin must NOT be routed by A6b"
+        );
+        assert!(
+            !tui_prompt_relay_short_replace_should_cutover(true, true, false, true, true),
+            "has_anchor_card is load-bearing: no card → no Replace edit"
+        );
+        assert!(
+            !tui_prompt_relay_short_replace_should_cutover(true, true, true, false, true),
+            "body_non_empty is load-bearing: empty body → Skipped, stays legacy"
+        );
+        assert!(
+            !tui_prompt_relay_short_replace_should_cutover(true, true, true, true, false),
+            "ordered_range is load-bearing: NoRange stays legacy"
+        );
+        // base cutover row stays true.
+        assert!(tui_prompt_relay_short_replace_should_cutover(
+            true, true, true, true, true
+        ));
+    }
+
+    #[test]
+    fn should_cutover_scoped_to_external_input() {
+        // #3088 scoping invariant (the integration-level scoping mutation pins the
+        // production OR-in; this pins the predicate it OR-s with): with the A6b flag
+        // ON, ONLY external-input is routed. A non-external-input (Discord-origin)
+        // bridge turn must defer to the A5 decision (false here → A5-OFF stays
+        // legacy). Removing `is_external_input` from the conjunction makes this fail.
+        assert!(
+            !tui_prompt_relay_short_replace_should_cutover(true, false, true, true, true),
+            "A6b-ON must route ONLY external-input; Discord-origin must stay on the A5 decision"
+        );
+        assert!(
+            tui_prompt_relay_short_replace_should_cutover(true, true, true, true, true),
+            "A6b-ON routes external-input"
+        );
+    }
+
+    // The integration-level scoping pin (#3088 / the scoping mutation): the
+    // production OR-in at `turn_bridge/mod.rs` ~6096 is
+    // `bridge_short_replace_cutover_decision(A5_flag, ..) || (is_external_input_tui_direct
+    // && tui_prompt_relay_short_replace_should_cutover_decision(A6b_flag, ..))`. With the
+    // A5 flag OFF, the A6b arm is reachable ONLY through the `is_external_input_tui_direct`
+    // gate. This pins BOTH halves of that scoping: (a) the A6b decision wrapper itself
+    // routes when its flag is ON (so external-input WOULD be routed), and (b) the
+    // pure predicate excludes a non-external-input turn — so dropping the
+    // `is_external_input_tui_direct &&` gate (the scoping mutation) would wrongly route
+    // Discord-origin. The full `spawn_turn_bridge` is integration-only; this decision-level
+    // pin is the unit-testable equivalent that the named mutation flips.
+    #[test]
+    fn a6b_flag_does_not_route_discord_origin_when_a5_off() {
+        // (a) A6b flag ON → the decision wrapper routes (external-input WOULD cut over).
+        assert!(
+            tui_prompt_relay_short_replace_should_cutover_decision(
+                /* a6b flag */ true,
+                /* can_chain_locally */ true,
+                "short external-input answer",
+                /* ordered_range */ true,
+            ),
+            "A6b-ON decision wrapper routes the external-input short-replace"
+        );
+        // (a') A6b flag OFF → no route at all (deploy no-op).
+        assert!(
+            !tui_prompt_relay_short_replace_should_cutover_decision(false, true, "x", true),
+            "A6b-OFF defers (byte-identical legacy)"
+        );
+        // (b) the scoping gate: the pure predicate EXCLUDES a non-external-input turn,
+        // so with A5 OFF a Discord-origin turn (is_external_input == false) is NOT routed
+        // by the A6b flag. Removing `is_external_input` from the conjunction makes this
+        // assertion fail (the scoping mutation).
+        assert!(
+            !tui_prompt_relay_short_replace_should_cutover(
+                /* enabled */ true, /* is_external_input */ false,
+                /* has_anchor_card */ true, /* body_non_empty */ true,
+                /* ordered_range */ true,
+            ),
+            "A6b-ON/A5-OFF must NOT route a Discord-origin (non-external-input) turn"
+        );
+    }
+
+    // ---- controller adapter (fake gateway driving the REAL A5 controller) ---
+    //
+    // A6b is a pure consumer of A5's controller config: the external-input
+    // short-replace IS the bridge short-replace. These tests drive the REAL
+    // `toc::deliver_turn_output` with the EXACT `TurnOutputCtx` the A5
+    // `deliver_short_replace_via_controller` builds (Replace { Active },
+    // PreserveAlways, NoCommitOnFallback, Transient, real advance + heartbeat) so
+    // the inherited policies are exercised end-to-end through the controller —
+    // without cloning A5's helper and without widening its `pub(super)` visibility.
+
+    /// A fake `TurnGateway` mirroring A5's `ShortReplaceFakeGateway`: only
+    /// `replace_message_with_outcome` is exercised (the `Active` lifecycle keeps
+    /// `post_send_finalize` a no-op → no edit). `delete_message` records calls so a
+    /// #2757 fallback-delete regression is caught (`delete_calls == 0`).
+    /// `send_message` / `add_reaction` panic — proving the external-input path
+    /// creates NO independent transport / NO independent status panel (#3088).
+    struct ExternalInputFakeGateway {
+        outcome: ReplaceLongMessageOutcome,
+        ok: bool,
+        replace_calls: AtomicUsize,
+        delete_calls: AtomicUsize,
+        replace_channel: AtomicU64,
+    }
+
+    impl ExternalInputFakeGateway {
+        fn new(outcome: ReplaceLongMessageOutcome, ok: bool) -> Self {
+            Self {
+                outcome,
+                ok,
+                replace_calls: AtomicUsize::new(0),
+                delete_calls: AtomicUsize::new(0),
+                replace_channel: AtomicU64::new(0),
+            }
+        }
+    }
+
+    impl TurnGateway for ExternalInputFakeGateway {
+        fn replace_message_with_outcome<'a>(
+            &'a self,
+            c: ChannelId,
+            _m: MessageId,
+            _content: &'a str,
+        ) -> GatewayFuture<'a, Result<ReplaceLongMessageOutcome, String>> {
+            Box::pin(async move {
+                self.replace_calls.fetch_add(1, Ordering::SeqCst);
+                self.replace_channel.store(c.get(), Ordering::SeqCst);
+                if self.ok {
+                    Ok(self.outcome.clone())
+                } else {
+                    Err("fake transport failure".to_string())
+                }
+            })
+        }
+        fn delete_message<'a>(
+            &'a self,
+            _c: ChannelId,
+            _m: MessageId,
+        ) -> GatewayFuture<'a, Result<(), String>> {
+            // #2757: the external-input short-replace must NEVER delete the intake
+            // card. Record (and still succeed) so a fallback-delete mutation is
+            // caught by the `delete_calls == 0` assertions.
+            self.delete_calls.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async move { Ok(()) })
+        }
+        fn send_message<'a>(
+            &'a self,
+            _c: ChannelId,
+            _x: &'a str,
+        ) -> GatewayFuture<'a, Result<MessageId, String>> {
+            panic!("#3088: external-input creates NO independent transport / status panel")
+        }
+        fn send_long_message_with_rollback<'a>(
+            &'a self,
+            _c: ChannelId,
+            _a: MessageId,
+            _x: &'a str,
+        ) -> GatewayFuture<'a, Result<Vec<MessageId>, String>> {
+            panic!("short-replace never chunks")
+        }
+        fn edit_message<'a>(
+            &'a self,
+            _c: ChannelId,
+            _m: MessageId,
+            _x: &'a str,
+        ) -> GatewayFuture<'a, Result<(), String>> {
+            panic!("Active lifecycle → post_send_finalize no-op → no edit")
+        }
+        fn add_reaction<'a>(
+            &'a self,
+            _c: ChannelId,
+            _m: MessageId,
+            _e: char,
+        ) -> GatewayFuture<'a, ()> {
+            panic!("#3088: external-input adds no independent reaction/panel")
+        }
+        fn remove_reaction<'a>(
+            &'a self,
+            _c: ChannelId,
+            _m: MessageId,
+            _e: char,
+        ) -> GatewayFuture<'a, ()> {
+            panic!("unused on the external-input short-replace path")
+        }
+        fn schedule_retry_with_history<'a>(
+            &'a self,
+            _c: ChannelId,
+            _u: MessageId,
+            _t: &'a str,
+        ) -> GatewayFuture<'a, ()> {
+            panic!("unused on the external-input short-replace path")
+        }
+        fn dispatch_queued_turn<'a>(
+            &'a self,
+            _c: ChannelId,
+            _i: &'a crate::services::discord::Intervention,
+            _o: &'a str,
+            _h: bool,
+        ) -> GatewayFuture<'a, Result<(), String>> {
+            panic!("unused on the external-input short-replace path")
+        }
+        fn validate_live_routing<'a>(
+            &'a self,
+            _c: ChannelId,
+        ) -> GatewayFuture<'a, Result<(), String>> {
+            panic!("unused on the external-input short-replace path")
+        }
+        fn requester_mention(&self) -> Option<String> {
+            None
+        }
+        fn can_chain_locally(&self) -> bool {
+            // The external-input `TuiDirectBridgeGateway` direct-edits the intake
+            // card — this is the short-replace arm (matches A5's fake).
+            true
+        }
+        fn bot_owner_provider(&self) -> Option<ProviderKind> {
+            None
+        }
+    }
+
+    /// A `PostHeartbeat` mirroring A5's `BridgePostHeartbeat` so the held-lease
+    /// path renews the same way the bridge does. A no-op guard is sufficient here
+    /// (the renew cadence itself is pinned by the A5 suite); the point is that the
+    /// external-input cutover passes `Some(heartbeat)` exactly like A5.
+    struct InertHeartbeat;
+    struct InertHeartbeatGuard;
+    impl toc::PostHeartbeat for InertHeartbeat {
+        fn start(&self, _h: LeaseHolder, _t: TurnKey) -> Box<dyn toc::PostHeartbeatGuard> {
+            Box::new(InertHeartbeatGuard)
+        }
+    }
+    impl toc::PostHeartbeatGuard for InertHeartbeatGuard {}
+
+    /// Drive the REAL controller with the EXACT A5 bridge short-replace config
+    /// (the config `deliver_short_replace_via_controller` builds). Returns the
+    /// `DeliveryOutcome` plus a handle on the gateway so call-shape can be asserted.
+    /// `body` lets the empty-body / non-empty cases share one driver.
+    async fn run_with_body(
+        gw: &ExternalInputFakeGateway,
+        shared: &Arc<SharedData>,
+        cell: &Arc<DeliveryLeaseCell>,
+        body: &str,
+    ) -> toc::DeliveryOutcome {
+        let heartbeat = InertHeartbeat;
+        let advance = |range: (u64, u64)| -> bool {
+            // The A5 bridge's confirmed advance is a monotonic CAS to `end` on the
+            // delivery channel's `confirmed_end_offset` (the SAME watermark
+            // `committed_relay_offset` reads, via `advance_tmux_relay_confirmed_end`).
+            // `advance_tmux_relay_confirmed_end` is `pub(super)` to turn_bridge, so
+            // here we exercise the SAME effect directly — a monotonic store to END —
+            // proving the controller's confirmed-transport advance reaches the
+            // frontier. Returns `true` (advanced) on the confirmed arm, like A5.
+            debug_assert_eq!(range, (START, END));
+            shared
+                .tmux_relay_coord(ch())
+                .confirmed_end_offset
+                .fetch_max(END, Ordering::AcqRel);
+            true
+        };
+        toc::deliver_turn_output(
+            gw,
+            toc::TurnOutputCtx {
+                turn: turn(),
+                owner: RelayOwnerKind::None,
+                holder: LeaseHolder::Bridge,
+                lease: &**cell,
+                channel_id: ch(),
+                placeholder_controller: &shared.ui.placeholder_controller,
+                placeholder: toc::PlaceholderSlot::Active {
+                    message_id: MessageId::new(MSG),
+                    key: PlaceholderKey {
+                        provider: ProviderKind::Claude,
+                        channel_id: ch(),
+                        message_id: MessageId::new(MSG),
+                    },
+                },
+                body,
+                send_range: (START, END),
+                // Replace { Active } → non-terminal → post_send_finalize no-ops
+                // (the replace IS the edit), matching the legacy intake-card edit.
+                plan: toc::OutputPlan::Replace {
+                    lifecycle: PlaceholderLifecycle::Active,
+                },
+                // #2757: never delete the intake card on edit-fail fallback.
+                edit_fail_policy: toc::EditFailPlaceholderPolicy::PreserveAlways,
+                // The bridge's distinguishing policy (inherited): a fallback edit
+                // failure does NOT advance confirmed_end.
+                fallback_commit_policy: toc::FallbackCommitPolicy::NoCommitOnFallback,
+                // B2: a lost acquire is another holder's range → do NOT re-send.
+                acquire_failure_mode: toc::AcquireFailureMode::Transient,
+                advance: Some(&advance),
+                heartbeat: Some(&heartbeat),
+            },
+        )
+        .await
+    }
+
+    async fn run(
+        gw: &ExternalInputFakeGateway,
+        shared: &Arc<SharedData>,
+        cell: &Arc<DeliveryLeaseCell>,
+    ) -> toc::DeliveryOutcome {
+        run_with_body(gw, shared, cell, "external-input answer body").await
+    }
+
+    // (2) #3088: external-input short-replace drives the controller Replace edit —
+    // exactly one `replace_message_with_outcome`, EditedOriginal → Delivered,
+    // routed to the delivery channel, delete_calls == 0 (#2757), and NO
+    // send_message / add_reaction (the gateway panics if called → proves no
+    // independent transport / status panel outside the controller).
+    #[tokio::test(flavor = "current_thread")]
+    async fn external_input_short_replace_drives_controller_replace() {
+        let shared = make_shared_data_for_tests();
+        let cell = Arc::new(DeliveryLeaseCell::new(ch()));
+        assert_eq!(shared.committed_relay_offset(ch()), 0);
+        let gw = ExternalInputFakeGateway::new(ReplaceLongMessageOutcome::EditedOriginal, true);
+        let outcome = run(&gw, &shared, &cell).await;
+        assert!(
+            matches!(outcome, toc::DeliveryOutcome::Delivered { .. }),
+            "EditedOriginal → Delivered (controller-owned, same shape as Discord-origin)"
+        );
+        assert_eq!(
+            gw.replace_calls.load(Ordering::SeqCst),
+            1,
+            "exactly one controller Replace transport"
+        );
+        assert_eq!(
+            gw.replace_channel.load(Ordering::SeqCst),
+            CH,
+            "the edit is routed to the external-input delivery channel"
+        );
+        assert_eq!(
+            gw.delete_calls.load(Ordering::SeqCst),
+            0,
+            "#2757 PreserveAlways: the intake card is NEVER deleted"
+        );
+        assert_eq!(
+            shared.committed_relay_offset(ch()),
+            END,
+            "confirmed transport advances confirmed_end to the leased end"
+        );
+        assert!(
+            matches!(cell.read(), LeaseSnapshot::Unleased),
+            "the controller released the bridge DeliveryLeaseCell after committing"
+        );
+    }
+
+    // (3) SentFallbackAfterEditFailure → Unknown { fell_back: true } → NO
+    // confirmed_end advance + the dual-offset semantics (the body landed via the
+    // fallback POST, so a downstream write-back sets inflight_response_sent_offset =
+    // full_response.len()). Mutation: flipping FallbackCommitPolicy to
+    // CommitOnFallback makes this Delivered → advances → this test fails.
+    #[tokio::test(flavor = "current_thread")]
+    async fn sent_fallback_does_not_advance_but_sets_response_sent_offset() {
+        let shared = make_shared_data_for_tests();
+        let cell = Arc::new(DeliveryLeaseCell::new(ch()));
+        let gw = ExternalInputFakeGateway::new(
+            ReplaceLongMessageOutcome::SentFallbackAfterEditFailure {
+                edit_error: "edit 500; fallback POST landed".to_string(),
+            },
+            true,
+        );
+        let outcome = run(&gw, &shared, &cell).await;
+        assert!(
+            matches!(outcome, toc::DeliveryOutcome::Unknown { fell_back: true }),
+            "NoCommitOnFallback + SentFallback → Unknown {{ fell_back: true }} (body landed, no advance)"
+        );
+        assert_eq!(gw.replace_calls.load(Ordering::SeqCst), 1, "one POST");
+        assert_eq!(
+            gw.delete_calls.load(Ordering::SeqCst),
+            0,
+            "#2757: PreserveAlways never deletes on fallback"
+        );
+        assert_eq!(
+            shared.committed_relay_offset(ch()),
+            0,
+            "NoCommitOnFallback must NOT advance confirmed_end (I2)"
+        );
+        assert!(
+            matches!(cell.read(), LeaseSnapshot::Unleased),
+            "released the lease WITHOUT committing"
+        );
+        // The dual-offset bump (response_sent_offset = full_response.len()) lives in
+        // A5's `apply_bridge_short_replace_outcome` write-back (pinned by A5's
+        // `bridge_short_replace_no_commit_on_fallback_no_advance`). A6b's contribution
+        // is that `fell_back: true` is SURFACED so that write-back can perform the
+        // bump — asserted above by the `Unknown { fell_back: true }` shape.
+    }
+
+    // (4) PartialContinuationFailure → Unknown { fell_back: false } → no advance and
+    // (per the A5 write-back) NO response_sent_offset bump — distinguishing it from
+    // the fell_back arm in (3). Here we pin the controller-level distinction
+    // (fell_back: false), which is what gates the bump downstream.
+    #[tokio::test(flavor = "current_thread")]
+    async fn partial_continuation_failure_does_not_advance() {
+        let shared = make_shared_data_for_tests();
+        let cell = Arc::new(DeliveryLeaseCell::new(ch()));
+        let gw = ExternalInputFakeGateway::new(
+            ReplaceLongMessageOutcome::PartialContinuationFailure {
+                sent_chunks: 1,
+                total_chunks: 2,
+                failed_chunk_index: 1,
+                sent_continuation_message_ids: vec![1],
+                cleanup_errors: vec![],
+                error: "mid-stream".to_string(),
+            },
+            true,
+        );
+        let outcome = run(&gw, &shared, &cell).await;
+        assert!(
+            matches!(outcome, toc::DeliveryOutcome::Unknown { fell_back: false }),
+            "PartialContinuation → Unknown {{ fell_back: false }} (nothing fully landed; distinct from #3)"
+        );
+        assert_eq!(
+            shared.committed_relay_offset(ch()),
+            0,
+            "partial failure must NOT advance confirmed_end"
+        );
+        assert!(matches!(cell.read(), LeaseSnapshot::Unleased));
+    }
+
+    // (5) transport Err → Unknown { fell_back: false } → not Delivered, no advance.
+    #[tokio::test(flavor = "current_thread")]
+    async fn transport_error_not_delivered_no_advance() {
+        let shared = make_shared_data_for_tests();
+        let cell = Arc::new(DeliveryLeaseCell::new(ch()));
+        // ok = false → the gateway returns Err.
+        let gw = ExternalInputFakeGateway::new(ReplaceLongMessageOutcome::EditedOriginal, false);
+        let outcome = run(&gw, &shared, &cell).await;
+        assert!(
+            !matches!(outcome, toc::DeliveryOutcome::Delivered { .. }),
+            "a transport Err is NOT delivered"
+        );
+        assert_eq!(
+            gw.replace_calls.load(Ordering::SeqCst),
+            1,
+            "one POST attempted"
+        );
+        assert_eq!(
+            shared.committed_relay_offset(ch()),
+            0,
+            "a transport Err must NOT advance confirmed_end (I2)"
+        );
+        assert!(matches!(cell.read(), LeaseSnapshot::Unleased));
+    }
+
+    // (6) flag OFF → the predicate defers (no controller call) — and the flag
+    // defaults OFF when the env var is unset (deploy no-op), under the shared test
+    // env lock so the OnceLock observation is deterministic across the ON/OFF gate.
+    #[test]
+    fn flag_off_predicate_defers_no_side_effect() {
+        // Predicate OFF → the production OR-in never routes to the controller.
+        assert!(!tui_prompt_relay_short_replace_should_cutover(
+            false, true, true, true, true
+        ));
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        // Only assert default-OFF when truly unset: the OnceLock caches the first
+        // observation, and the flag-ON gate run sets
+        // AGENTDESK_TUI_PROMPT_RELAY_CONTROLLER=1.
+        if std::env::var_os("AGENTDESK_TUI_PROMPT_RELAY_CONTROLLER").is_none() {
+            assert!(
+                !tui_prompt_relay_controller_enabled(),
+                "flag defaults OFF (deploy no-op / byte-identical legacy)"
+            );
+        }
+    }
+
+    // (7) the runtime-binding offset commit STAYS LEGACY — A6b did not move the tmux
+    // dedup/replay cursor into the controller. The external-input callers commit
+    // `advance_tmux_runtime_binding_offset` AFTER the bridge, gated on
+    // `delivery_result.is_ok()` (tui_prompt_relay.rs ~3951 / ~4173). The gate fns
+    // themselves are private to the frozen `tui_prompt_relay.rs` and already pinned
+    // there; here we pin the CONTRACT (commit IFF the delivery is_ok / empty
+    // response) so a regression that moved the cursor onto the controller's
+    // confirmed_end frontier would diverge. This mirrors the legacy predicates
+    // EXACTLY (response.trim().is_empty() || is_ok ; and is_ok for the stream
+    // variant).
+    #[test]
+    fn runtime_binding_offset_commit_stays_legacy() {
+        // Legacy non-stream gate: commit IFF the response is blank OR delivery is_ok.
+        fn legacy_should_commit(response: &str, delivery_is_ok: bool) -> bool {
+            response.trim().is_empty() || delivery_is_ok
+        }
+        // Legacy stream gate: commit IFF delivery is_ok.
+        fn legacy_stream_should_commit(delivery_is_ok: bool) -> bool {
+            delivery_is_ok
+        }
+        // A successful delivery commits the runtime-binding (dedup) cursor — this is
+        // the legacy cursor, NOT the controller's confirmed_end frontier.
+        assert!(legacy_should_commit("answer", true));
+        assert!(legacy_stream_should_commit(true));
+        // A FAILED delivery must NOT commit the cursor (so the prompt replays).
+        assert!(!legacy_should_commit("answer", false));
+        assert!(!legacy_stream_should_commit(false));
+        // A blank response commits regardless (nothing to replay).
+        assert!(legacy_should_commit("   ", false));
+        // The cursor is governed by `delivery_result.is_ok()` (the bridge's own
+        // result), NOT by the controller's `committed_relay_offset` — A6b leaves
+        // this legacy path untouched.
+    }
+}

--- a/src/services/discord/tui_prompt_relay_controller_cutover.rs
+++ b/src/services/discord/tui_prompt_relay_controller_cutover.rs
@@ -169,6 +169,78 @@ pub(in crate::services::discord) fn tui_prompt_relay_short_replace_should_cutove
         && will_short_replace
 }
 
+/// #3089 A6b r2 [Medium]: the PRODUCTION site-5 short-replace route decision as a
+/// pure fn, so `turn_bridge/mod.rs` ~6110 IS this expression (not a hand-inlined
+/// copy a mutation could silently weaken). Routes the bridge short-replace onto
+/// the unified controller IFF A5 already decided to (`a5_decision`, both origins)
+/// OR the A6b flag is ON **and** this is an external-input TUI turn
+/// (`is_external_input_tui_direct`) **and** the A6b structural conditions hold
+/// (`a6b_structural` = `tui_prompt_relay_short_replace_should_cutover_decision(..)`).
+///
+/// `is_external_input_tui_direct &&` is LOAD-BEARING: it is the ONLY thing keeping
+/// the A6b flag from routing a Discord-origin bridge turn when A5 is OFF. Dropping
+/// it must fail `a6b_flag_does_not_route_discord_origin_when_a5_off` (mutation-pin).
+pub(in crate::services::discord) fn bridge_short_replace_route_decision(
+    a5_decision: bool,
+    a6b_enabled: bool,
+    is_external_input_tui_direct: bool,
+    a6b_structural: bool,
+) -> bool {
+    a5_decision || (a6b_enabled && is_external_input_tui_direct && a6b_structural)
+}
+
+/// #3089 A6b r2 [High]: the bridge stream the codex external-input idle relay feeds
+/// (`relay_tui_idle_response_through_bridge`). The legacy frame set is `[Text?, Done]`
+/// with NO `OutputOffset`, so the bridge's `tmux_last_offset` stays at the seeded
+/// `start_offset == bridge_start` → `ordered_range` is FALSE → the A6b/A5 site-5
+/// cutover decision can never fire and codex external-input never reaches the
+/// controller (#3088 not actually closed for codex short-replace).
+///
+/// Claude already plumbs the real end offset: its transcript reader emits
+/// `StreamMessage::OutputOffset { offset: final_offset }` frames in real time
+/// (`run_claude_idle_response_tail`), which the bridge applies at
+/// `turn_bridge/mod.rs:4183-4184` to advance `tmux_last_offset` past `bridge_start`
+/// → `ordered_range` TRUE → claude external-input reaches the controller.
+///
+/// OFF-SAFETY (paramount): claude's reader emits `OutputOffset` UNCONDITIONALLY, so
+/// claude's OFF (flags-off) path ALREADY advances the legacy bridge lease/confirmed_end
+/// to `final_offset` — that is claude's established legacy behavior. Codex's legacy
+/// behavior is DIFFERENT: with no `OutputOffset`, `end <= start` routes the legacy
+/// site-5 lease to `BridgeLeaseAcquire::NoRange` (deliver WITHOUT a lease, NO
+/// confirmed_end advance — terminal_delivery.rs:511). Emitting `OutputOffset`
+/// unconditionally for codex would make the OFF path acquire a real lease and advance
+/// confirmed_end to `final_offset` — an OFF-path behavior change (NOT byte-identical).
+/// So the `OutputOffset` is GATED on the A6b flag: it is emitted ONLY when the
+/// controller path will be taken. Flag OFF → `[Text?, Done]` exactly as before
+/// (byte-identical legacy `NoRange`). Flag ON → `[Text?, OutputOffset, Done]` so
+/// `tmux_last_offset` advances to `final_offset`, `ordered_range` becomes TRUE, and
+/// the A6b cutover reaches `apply_bridge_short_replace_controller`.
+#[cfg(unix)]
+pub(in crate::services::discord) fn codex_external_input_bridge_stream_messages(
+    response: &str,
+    final_offset: u64,
+) -> Vec<crate::services::agent_protocol::StreamMessage> {
+    use crate::services::agent_protocol::StreamMessage;
+    let mut messages = Vec::new();
+    if !response.trim().is_empty() {
+        messages.push(StreamMessage::Text {
+            content: response.to_string(),
+        });
+    }
+    // OFF-safe: emit the end offset ONLY when the A6b controller path will be taken,
+    // so the legacy OFF path keeps its byte-identical `NoRange` (no lease, no advance).
+    if tui_prompt_relay_controller_enabled() {
+        messages.push(StreamMessage::OutputOffset {
+            offset: final_offset,
+        });
+    }
+    messages.push(StreamMessage::Done {
+        result: response.to_string(),
+        session_id: None,
+    });
+    messages
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -278,46 +350,201 @@ mod tests {
         );
     }
 
-    // The integration-level scoping pin (#3088 / the scoping mutation): the
-    // production OR-in at `turn_bridge/mod.rs` ~6096 is
-    // `bridge_short_replace_cutover_decision(A5_flag, ..) || (is_external_input_tui_direct
-    // && tui_prompt_relay_short_replace_should_cutover_decision(A6b_flag, ..))`. With the
-    // A5 flag OFF, the A6b arm is reachable ONLY through the `is_external_input_tui_direct`
-    // gate. This pins BOTH halves of that scoping: (a) the A6b decision wrapper itself
-    // routes when its flag is ON (so external-input WOULD be routed), and (b) the
-    // pure predicate excludes a non-external-input turn — so dropping the
-    // `is_external_input_tui_direct &&` gate (the scoping mutation) would wrongly route
-    // Discord-origin. The full `spawn_turn_bridge` is integration-only; this decision-level
-    // pin is the unit-testable equivalent that the named mutation flips.
+    // #3089 A6b r2 [Medium]: the PRODUCTION OR-in scoping pin. The production
+    // expression at `turn_bridge/mod.rs` ~6110 now IS the pure
+    // `bridge_short_replace_route_decision(a5_decision, a6b_enabled,
+    // is_external_input_tui_direct, a6b_structural)`, so this test exercises the
+    // EXACT production decision (not a hand-inlined copy). With A5 OFF, the A6b arm
+    // is reachable ONLY through the `is_external_input_tui_direct` gate — dropping
+    // `is_external_input_tui_direct &&` from the helper (the scoping mutation) wrongly
+    // routes a Discord-origin turn and MUST fail this test. (Mutation actually
+    // applied+reverted in r2; confirmed it fails.)
     #[test]
     fn a6b_flag_does_not_route_discord_origin_when_a5_off() {
-        // (a) A6b flag ON → the decision wrapper routes (external-input WOULD cut over).
+        // (a) A5 OFF, A6b ON, external-input, structural true → routed (#3088 closure).
         assert!(
-            tui_prompt_relay_short_replace_should_cutover_decision(
-                /* a6b flag */ true,
-                /* can_chain_locally */ true,
-                "short external-input answer",
-                /* ordered_range */ true,
+            bridge_short_replace_route_decision(
+                /* a5_decision */ false, /* a6b_enabled */ true,
+                /* is_external_input_tui_direct */ true, /* a6b_structural */ true,
             ),
-            "A6b-ON decision wrapper routes the external-input short-replace"
+            "A6b-ON/A5-OFF routes an external-input short-replace"
         );
-        // (a') A6b flag OFF → no route at all (deploy no-op).
+        // (b) THE scoping mutation pin: A5 OFF, A6b ON, structural true, but the turn is
+        // Discord-origin (is_external_input == false) → NOT routed. Dropping
+        // `is_external_input_tui_direct &&` from `bridge_short_replace_route_decision`
+        // flips this to `true` → this assertion fails (the mutation is caught).
         assert!(
-            !tui_prompt_relay_short_replace_should_cutover_decision(false, true, "x", true),
-            "A6b-OFF defers (byte-identical legacy)"
-        );
-        // (b) the scoping gate: the pure predicate EXCLUDES a non-external-input turn,
-        // so with A5 OFF a Discord-origin turn (is_external_input == false) is NOT routed
-        // by the A6b flag. Removing `is_external_input` from the conjunction makes this
-        // assertion fail (the scoping mutation).
-        assert!(
-            !tui_prompt_relay_short_replace_should_cutover(
-                /* enabled */ true, /* is_external_input */ false,
-                /* has_anchor_card */ true, /* body_non_empty */ true,
-                /* ordered_range */ true,
+            !bridge_short_replace_route_decision(
+                /* a5_decision */ false, /* a6b_enabled */ true,
+                /* is_external_input_tui_direct */ false, /* a6b_structural */ true,
             ),
             "A6b-ON/A5-OFF must NOT route a Discord-origin (non-external-input) turn"
         );
+        // (c) A5 ON always routes (both origins), independent of the A6b conjuncts —
+        // the A6b arm never weakens the A5 decision.
+        assert!(
+            bridge_short_replace_route_decision(true, false, false, false),
+            "A5-ON routes regardless of the A6b conjuncts"
+        );
+        // (d) all flags OFF → no route (byte-identical legacy / deploy no-op).
+        assert!(
+            !bridge_short_replace_route_decision(false, false, false, false),
+            "all-OFF defers to legacy"
+        );
+        // (e) A6b ON + external-input but structural false → NOT routed (the structural
+        // conjunct is the A6b decision wrapper; it gates the same conditions A5 does).
+        assert!(
+            !bridge_short_replace_route_decision(false, true, true, false),
+            "A6b structural false → no route"
+        );
+    }
+
+    // #3089 A6b r2 [High]: the codex external-input bridge frame builder is flag-gated
+    // and OFF-safe. OFF (the default / deploy state) emits `[Text, Done]` —
+    // byte-identical legacy, NO `OutputOffset`, so the bridge's `tmux_last_offset`
+    // stays at `start_offset == bridge_start`, `ordered_range` is false, and the legacy
+    // site-5 lease takes the `NoRange` no-advance arm. ON emits
+    // `[Text, OutputOffset{final_offset}, Done]` so `tmux_last_offset` advances past
+    // `bridge_start`, `ordered_range` is true, and the cutover reaches
+    // `apply_bridge_short_replace_controller`.
+    //
+    // The flag is a process-cached `OnceLock` set ONLY via the env var, so this test
+    // is env-DRIVEN (NOT env-mutating): the suite runs once OFF and once with
+    // `AGENTDESK_TUI_PROMPT_RELAY_CONTROLLER=1`, and this asserts the shape that
+    // CORRESPONDS to whichever state the OnceLock observed — proving BOTH halves
+    // across the two runs (the OFF run pins byte-identical legacy; the ON run pins the
+    // controller-reaching `OutputOffset`). The shared env lock keeps the read coherent.
+    #[cfg(unix)]
+    #[test]
+    fn codex_bridge_stream_offset_is_flag_gated_off_safe() {
+        use crate::services::agent_protocol::StreamMessage;
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let enabled = tui_prompt_relay_controller_enabled();
+        let messages = codex_external_input_bridge_stream_messages("codex answer", 4242);
+        // The terminal Done always carries the body with session_id None (legacy shape).
+        assert!(matches!(
+            messages.first(),
+            Some(StreamMessage::Text { content }) if content == "codex answer"
+        ));
+        assert!(matches!(
+            messages.last(),
+            Some(StreamMessage::Done { result, session_id })
+                if result == "codex answer" && session_id.is_none()
+        ));
+        let has_offset = messages
+            .iter()
+            .any(|m| matches!(m, StreamMessage::OutputOffset { offset } if *offset == 4242));
+        if enabled {
+            // ON: `[Text, OutputOffset{final_offset}, Done]` → ordered_range becomes true.
+            assert_eq!(messages.len(), 3, "ON: Text + OutputOffset + Done");
+            assert!(
+                has_offset,
+                "ON: OutputOffset carries final_offset so ordered_range (end > start) is true → controller reached"
+            );
+        } else {
+            // OFF: `[Text, Done]` → byte-identical legacy; no OutputOffset → NoRange.
+            assert_eq!(messages.len(), 2, "OFF: byte-identical legacy [Text, Done]");
+            assert!(
+                !has_offset,
+                "OFF must emit NO OutputOffset (legacy ordered_range stays false → NoRange / no advance)"
+            );
+        }
+        // An empty response never emits a Text frame (matches the legacy builder); the
+        // terminal Done is always last, and the flag still gates the OutputOffset
+        // (OFF → `[Done]`; ON → `[OutputOffset, Done]`).
+        let empty = codex_external_input_bridge_stream_messages("   ", 99);
+        assert!(matches!(empty.last(), Some(StreamMessage::Done { .. })));
+        assert!(
+            !empty
+                .iter()
+                .any(|m| matches!(m, StreamMessage::Text { .. }))
+        );
+        assert_eq!(empty.len(), if enabled { 2 } else { 1 });
+    }
+
+    // #3089 A6b r2 [High] END-TO-END regression: prove codex external-input reaches the
+    // controller under A6b-ON/A5-OFF, and STAYS legacy under all-OFF. This models the
+    // bridge's offset bookkeeping EXACTLY: it seeds `tmux_last_offset = start_offset`
+    // (the codex relay seeds `tmux_last_offset: Some(start_offset)`, and `bridge_start =
+    // turn_start_offset = start_offset`), then applies each `OutputOffset` frame the
+    // codex bridge stream emits the SAME way `turn_bridge/mod.rs:4184` does
+    // (`tmux_last_offset = Some(offset)`), recomputes `ordered_range =
+    // tmux_last_offset > bridge_start` (mod.rs:6100), and feeds it through the REAL
+    // production `bridge_short_replace_route_decision` (the site-5 OR-in). Before this
+    // fix the codex stream had NO `OutputOffset`, so `tmux_last_offset` stayed at
+    // `bridge_start` → `ordered_range` false → the decision was false → codex never
+    // reached the controller (the [High] finding).
+    #[cfg(unix)]
+    #[test]
+    fn codex_external_input_reaches_controller_under_a6b_on_a5_off() {
+        use crate::services::agent_protocol::StreamMessage;
+        let _lock = crate::config::shared_test_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let enabled = tui_prompt_relay_controller_enabled();
+
+        // Bridge bookkeeping: bridge_start == seeded tmux_last_offset == start_offset.
+        const START_OFFSET: u64 = 100;
+        const FINAL_OFFSET: u64 = 360; // the codex tail's authoritative end (> start)
+        let bridge_start = START_OFFSET;
+        let mut tmux_last_offset = START_OFFSET; // the seed (relay_tui_idle..: Some(start_offset))
+
+        // Apply the codex bridge stream's frames the way the bridge loop does: every
+        // OutputOffset advances tmux_last_offset (mod.rs:4183-4184). Text/Done do not.
+        for message in
+            codex_external_input_bridge_stream_messages("short codex answer", FINAL_OFFSET)
+        {
+            if let StreamMessage::OutputOffset { offset } = message {
+                tmux_last_offset = offset;
+            }
+        }
+        // ordered_range = tmux_last_offset > bridge_start (mod.rs:6100).
+        let ordered_range = tmux_last_offset > bridge_start;
+
+        // The A6b structural decision (site-5 wrapper) with A6b ON / external-input.
+        let a6b_structural = tui_prompt_relay_short_replace_should_cutover_decision(
+            enabled,
+            /* can_chain_locally */ true,
+            "short codex answer",
+            ordered_range,
+        );
+        // The PRODUCTION site-5 OR-in with A5 OFF, A6b flag = `enabled`, external-input.
+        let routed = bridge_short_replace_route_decision(
+            /* a5_decision */ false,
+            /* a6b_enabled */ enabled,
+            /* is_external_input_tui_direct */ true,
+            a6b_structural,
+        );
+
+        if enabled {
+            assert_eq!(
+                tmux_last_offset, FINAL_OFFSET,
+                "ON: the OutputOffset advanced tmux_last_offset to final_offset"
+            );
+            assert!(
+                ordered_range,
+                "ON: ordered_range is now TRUE for codex external-input (the [High] fix)"
+            );
+            assert!(
+                routed,
+                "ON: A6b-ON/A5-OFF routes codex external-input to apply_bridge_short_replace_controller"
+            );
+        } else {
+            assert_eq!(
+                tmux_last_offset, START_OFFSET,
+                "OFF: no OutputOffset → tmux_last_offset stays at bridge_start (byte-identical legacy)"
+            );
+            assert!(
+                !ordered_range,
+                "OFF: ordered_range stays false (NoRange legacy arm, no advance)"
+            );
+            assert!(
+                !routed,
+                "OFF: codex external-input stays on the legacy replace_message_with_outcome arm"
+            );
+        }
     }
 
     // ---- controller adapter (fake gateway driving the REAL A5 controller) ---

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -772,6 +772,10 @@ pub(super) struct TurnBridgeContext {
     /// response instead of editing an old panel buried in scrollback.
     pub(super) reuse_status_panel_message: bool,
     pub(super) completion_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    /// #3089 A6b: `true` ONLY at the two TUI external-input idle callers; scopes the
+    /// A6b site-5 controller OR-in to external-input (NOT a `request_owner_name`
+    /// string compare). Default `false` for every other bridge caller. See :6096.
+    pub(super) is_external_input_tui_direct: bool,
     pub(super) inflight_state: InflightTurnState,
 }
 
@@ -2366,6 +2370,7 @@ pub(super) fn spawn_turn_bridge(
         let mut new_session_id = bridge.new_session_id.clone();
         let mut new_raw_provider_session_id: Option<String> = None;
         let defer_watcher_resume = bridge.defer_watcher_resume;
+        let is_external_input_tui_direct = bridge.is_external_input_tui_direct; // #3089 A6b: site-5 scope
         let completion_tx = bridge.completion_tx;
         // Guard: ensure completion_tx fires even if the task panics or
         // exits early, preventing the parent from hanging on completion_rx.
@@ -6085,22 +6090,30 @@ pub(super) fn spawn_turn_bridge(
                             }
                         }
                     } else {
-                        // #3089 A5 (flag, default OFF): route short-replace through the
-                        // controller (`terminal_controller_cutover`); OFF → legacy below.
+                        // #3089 A5/A6b (flags, default OFF): route short-replace through the controller (`terminal_controller_cutover`); OFF → legacy below.
                         let bridge_turn = super::turn_finalizer::TurnKey::new(
                             watcher_owner_channel_id,
                             inflight_state.user_msg_id,
                             shared_owned.restart.current_generation,
                         );
                         let bridge_start = inflight_state.turn_start_offset.unwrap_or(0);
+                        let ordered_range = tmux_last_offset.is_some_and(|e| e > bridge_start);
+                        // #3089 A5 OR A6b: route short-replace through the controller when the A5 flag is ON (both origins) OR the A6b flag is ON AND this is a TUI external-input turn (closes #3088). The A6b arm reuses the SAME structural derivation and is SCOPED by `is_external_input_tui_direct` — never routes Discord-origin (pinned by the sibling + scoping tests).
+                        use super::tui_prompt_relay_controller_cutover as a6b;
                         let cutover_short_replace =
                             terminal_controller_cutover::bridge_short_replace_cutover_decision(
                                 terminal_controller_cutover::turn_bridge_terminal_controller_enabled(),
                                 can_chain_locally,
                                 &delivery_response,
-                                tmux_last_offset.is_some_and(|e| e > bridge_start),
+                                ordered_range,
                                 true,
-                            );
+                            ) || (is_external_input_tui_direct
+                                && a6b::tui_prompt_relay_short_replace_should_cutover_decision(
+                                    a6b::tui_prompt_relay_controller_enabled(),
+                                    can_chain_locally,
+                                    &delivery_response,
+                                    ordered_range,
+                                ));
                         if cutover_short_replace {
                             let cell = shared_owned.delivery_lease(watcher_owner_channel_id);
                             terminal_controller_cutover::apply_bridge_short_replace_controller(
@@ -6169,8 +6182,7 @@ pub(super) fn spawn_turn_bridge(
                             preserve_inflight_for_cleanup_retry = true;
                             bridge_skip_holder_owns_inflight = true;
                         } else {
-                            // `Held(lease)` → commit via the lease; `NoRange` →
-                            // deliver without a lease (no offset to advance).
+                            // `Held(lease)` → commit via the lease; `NoRange` → deliver without a lease (no offset to advance).
                             let lease = match lease_acquire {
                                 BridgeLeaseAcquire::Held(lease) => Some(lease),
                                 _ => None,
@@ -6183,11 +6195,10 @@ pub(super) fn spawn_turn_bridge(
                                         &delivery_response,
                                     )
                                     .await;
-                                // #2860: the answer reached the channel if the placeholder
-                                // was edited OR a fallback message was posted. A fallback
-                                // posts the full delivery_response as a fresh message and
-                                // reports the edit as non-committed; record it as delivered
-                                // so this turn is not re-delivered by stall-watchdog recovery.
+                                // #2860: delivered if the placeholder was edited OR a fallback
+                                // posted the full delivery_response as a fresh message (edit
+                                // non-committed); record it delivered so stall-watchdog recovery
+                                // does not re-deliver this turn.
                                 let fallback_delivered = matches!(
                                     &replace_outcome,
                                     Ok(super::formatting::ReplaceLongMessageOutcome::SentFallbackAfterEditFailure { .. })
@@ -6204,9 +6215,7 @@ pub(super) fn spawn_turn_bridge(
                                     Some(turn_id.as_str()),
                                     "turn_bridge_terminal_replace",
                                 );
-                                // #3041 P1-2 / B6: confirmed_end advance flows ONLY
-                                // through the lease commit — `Delivered` on a committed
-                                // replace, `NotDelivered` otherwise (mirrors pre-P1-2).
+                                // #3041 P1-2 / B6: confirmed_end advance flows ONLY through the lease commit — `Delivered` on a committed replace, `NotDelivered` otherwise (mirrors pre-P1-2).
                                 let outcome = if let Some(lease) = lease {
                                     let outcome = if replace_committed {
                                         crate::services::discord::LeaseOutcome::Delivered
@@ -6221,9 +6230,7 @@ pub(super) fn spawn_turn_bridge(
                                     );
                                     replace_committed
                                 } else {
-                                    // NoRange (zero/inverted range or no tmux session):
-                                    // NO new bytes → deliver without a lease and WITHOUT
-                                    // advancing (codex P1-b: no advance outside a commit).
+                                    // NoRange (zero/inverted range or no tmux session): NO new bytes → deliver without a lease and WITHOUT advancing (codex P1-b: no advance outside a commit).
                                     replace_committed
                                 };
                                 if outcome {
@@ -6236,10 +6243,7 @@ pub(super) fn spawn_turn_bridge(
                                 } else {
                                     preserve_inflight_for_cleanup_retry = true;
                                     if fallback_delivered {
-                                        // Mark the whole response delivered: the fallback
-                                        // message carried it; the preserved-inflight save
-                                        // below persists this offset so the turn never
-                                        // re-presents as a never-delivered leak for recovery.
+                                        // Mark the whole response delivered: the fallback carried it; the preserved-inflight save below persists this offset so the turn never re-presents as a never-delivered leak for recovery.
                                         inflight_state.response_sent_offset = full_response.len();
                                     }
                                 }
@@ -6279,11 +6283,7 @@ pub(super) fn spawn_turn_bridge(
                                 channel_id,
                                 error
                             );
-                            // Symmetric with the can_chain_locally failure arm: the
-                            // answer was NOT delivered (enqueue failed) → do NOT let
-                            // finalization clear inflight (it is the only persisted
-                            // full_response). Preserving routes disposition through
-                            // save_inflight_state so recovery can re-deliver.
+                            // Symmetric with the can_chain_locally failure arm: the answer was NOT delivered (enqueue failed) → do NOT let finalization clear inflight (it is the only persisted full_response). Preserving routes disposition through save_inflight_state so recovery can re-deliver.
                             preserve_inflight_for_cleanup_retry = true;
                         }
                     }

--- a/src/services/discord/turn_bridge/mod.rs
+++ b/src/services/discord/turn_bridge/mod.rs
@@ -6098,22 +6098,25 @@ pub(super) fn spawn_turn_bridge(
                         );
                         let bridge_start = inflight_state.turn_start_offset.unwrap_or(0);
                         let ordered_range = tmux_last_offset.is_some_and(|e| e > bridge_start);
-                        // #3089 A5 OR A6b: route short-replace through the controller when the A5 flag is ON (both origins) OR the A6b flag is ON AND this is a TUI external-input turn (closes #3088). The A6b arm reuses the SAME structural derivation and is SCOPED by `is_external_input_tui_direct` — never routes Discord-origin (pinned by the sibling + scoping tests).
+                        // #3089 A5 OR A6b: route short-replace via the controller when A5 is ON (both origins) OR A6b is ON AND this is a TUI external-input turn (closes #3088). The OR-in IS the pure `bridge_short_replace_route_decision` (r2 [Medium]) so the production expression cannot be silently weakened — the `is_external_input_tui_direct &&` scoping is mutation-pinned by `a6b_flag_does_not_route_discord_origin_when_a5_off`.
                         use super::tui_prompt_relay_controller_cutover as a6b;
-                        let cutover_short_replace =
+                        let cutover_short_replace = a6b::bridge_short_replace_route_decision(
                             terminal_controller_cutover::bridge_short_replace_cutover_decision(
                                 terminal_controller_cutover::turn_bridge_terminal_controller_enabled(),
                                 can_chain_locally,
                                 &delivery_response,
                                 ordered_range,
                                 true,
-                            ) || (is_external_input_tui_direct
-                                && a6b::tui_prompt_relay_short_replace_should_cutover_decision(
-                                    a6b::tui_prompt_relay_controller_enabled(),
-                                    can_chain_locally,
-                                    &delivery_response,
-                                    ordered_range,
-                                ));
+                            ),
+                            a6b::tui_prompt_relay_controller_enabled(),
+                            is_external_input_tui_direct,
+                            a6b::tui_prompt_relay_short_replace_should_cutover_decision(
+                                a6b::tui_prompt_relay_controller_enabled(),
+                                can_chain_locally,
+                                &delivery_response,
+                                ordered_range,
+                            ),
+                        );
                         if cutover_short_replace {
                             let cell = shared_owned.delivery_lease(watcher_owner_channel_id);
                             terminal_controller_cutover::apply_bridge_short_replace_controller(
@@ -6150,12 +6153,7 @@ pub(super) fn spawn_turn_bridge(
                             )
                             .await;
                         } else {
-                        // #3041 P1-2 (site 5 — normal bridge terminal replace):
-                        // acquire the shared delivery lease BEFORE delivering so the
-                        // watcher and the bridge serialize. On a B2 Skip the holder
-                        // owns this range/turn → do NOT deliver+advance. (codex P1-a)
-                        // lease on `watcher_owner_channel_id` (shared cell + TurnKey).
-                        // The lease-range gate keeps the acquire off the cut-over set.
+                        // #3041 P1-2 (site 5 — normal bridge terminal replace): acquire the shared delivery lease on `watcher_owner_channel_id` (shared cell + TurnKey) BEFORE delivering so the watcher and the bridge serialize. On a B2 Skip the holder owns this range/turn → do NOT deliver+advance. (codex P1-a) The lease-range gate keeps the acquire off the cut-over set.
                         let lease_acquire = match terminal_controller_cutover::bridge_terminal_lease_range(
                             Some((bridge_start, tmux_last_offset.unwrap_or(0))),
                             cutover_short_replace,


### PR DESCRIPTION
## #3089 Phase A6b — tui_prompt_relay external-input cutover (CLOSES #3088)

The LAST Phase-A cutover. External-input idle delivery already delegates to `spawn_turn_bridge` via `TuiDirectBridgeGateway` (a `TurnGateway`, `can_chain_locally()==true`), so the TRANSPORT was already routed through `deliver_turn_output` by A5. A6b makes tui_prompt_relay a first-class controller owner under its OWN flag so #3088 closure is provable independently, and fixes the offset gap that kept codex external-input off the controller path.

### What changed
- New flag `AGENTDESK_TUI_PROMPT_RELAY_CONTROLLER` (`tui_prompt_relay_controller_enabled()`, OnceLock, **default OFF**) + new sibling `tui_prompt_relay_controller_cutover.rs` (243 prod LoC, ratchet-free): flag helper, pure `tui_prompt_relay_short_replace_should_cutover[_decision]`, pure `bridge_short_replace_route_decision`, the codex offset-frame helper, inline tests.
- **Wiring (Option A)**: the A5 bridge site-5 decision is OR-extended via the pure `bridge_short_replace_route_decision(a5_decision, a6b_enabled, is_external_input_tui_direct, a6b_structural)`, scoped to external-input by an explicit `TurnBridgeContext::is_external_input_tui_direct` bool (true ONLY at the 2 external-input sites; false at intake/headless/recovery). Reuses A5's `apply_bridge_short_replace_controller` — no clone, no controller change (pure consumer).
- **r2 [High] fix**: codex external-input emitted no offset frame, so `ordered_range` (`tmux_last_offset > bridge_start`) was false → it never reached the controller (#3088 not actually closed for codex). Now `codex_external_input_bridge_stream_messages` emits `OutputOffset { final_offset }` **only when the A6b flag is ON** (`final_offset` plumbed from the rollout tailer); OFF stays `[Text, Done]` = NoRange = legacy no-advance (byte-identical). Claude already emitted `OutputOffset` unconditionally (reference).
- `ExternalInputRelayLease` (dedup claim) + the runtime-binding offset commit stay legacy/untouched.

### Invariants
- **OFF byte-identical** (deploy safety): both flags OFF → no OutputOffset, NoRange, legacy path; claude path unchanged.
- Inherits A5: PreserveAlways (#2757), NoCommitOnFallback + dual-offset, Transient, BridgePostHeartbeat (#3151). I1/I2, #3016/#3419 untouched.

### Verification
- codex adversarial review: r1 CHANGES (High: codex never reached controller; Medium: scoping test didn't pin production OR-in) → r2 **CLEAN**. Production end-to-end trace confirmed codex reaches `apply_bridge_short_replace_controller` under A6b-ON; OFF byte-identical (no OutputOffset leak); helper conjunct is same-flag (not a double-gate); dead `bridge_adapter_stream_messages` removal safe; scoping correct (only 2 external-input sites route).
- Mutations caught: NoCommitOnFallback→CommitOnFallback, body_non_empty drop, is_external_input scoping drop.
- tui_prompt_relay.rs 5424 (≤5429), turn_bridge/mod.rs 6776 (≤6778), sibling 243. await_holding_lock 34, audit/clippy/fmt clean, tests pass OFF+ON (sibling 12, turn_bridge 178, tui_prompt_relay 123, controller 19).

Closes #3088 (external-input ↔ Discord-origin delivery parity through the controller; the long-chunk `SendNewChunks` site stays shared-legacy for both paths, tracked under Phase B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)