### PR TITLE
feat(#3089): B2a — extend delivered-frontier shadow-write to watcher + bridge (flag, default OFF)

### DIFF
--- a/src/services/discord/tmux_watcher/terminal_send.rs
+++ b/src/services/discord/tmux_watcher/terminal_send.rs
@@ -15,6 +15,7 @@ use super::*;
 
 use crate::services::discord::gateway::TurnGateway;
 use crate::services::discord::inflight::RelayOwnerKind;
+use crate::services::discord::outbound::delivery_record as dr;
 use crate::services::discord::outbound::turn_output_controller as toc;
 use crate::services::discord::placeholder_controller::{PlaceholderKey, PlaceholderLifecycle};
 use crate::services::discord::turn_finalizer::TurnKey;
@@ -326,6 +327,15 @@ pub(in crate::services::discord) async fn deliver_short_replace_via_controller<
         },
     )
     .await;
+
+    // #3089 B2a: shadow-mirror durable delivered frontier — flag-gated, observe-only, Delivered-only (I2), OFF=no-op. Extends B1's sink coverage to the watcher (A4) before B2b's authority flip.
+    dr::shadow_mirror_delivered_frontier(
+        shared,
+        provider,
+        channel_id,
+        (start, end),
+        dr::outcome_is_shadow_delivered(&outcome),
+    );
 
     match outcome {
         // Confirmed POST (edit OR #2757 fallback): the controller already ran

--- a/src/services/discord/turn_bridge/terminal_controller_cutover.rs
+++ b/src/services/discord/turn_bridge/terminal_controller_cutover.rs
@@ -17,6 +17,7 @@ use std::sync::OnceLock;
 
 use super::super::gateway::TurnGateway;
 use super::super::inflight::RelayOwnerKind;
+use super::super::outbound::delivery_record as dr;
 use super::super::outbound::turn_output_controller as toc;
 use super::super::placeholder_controller::{PlaceholderKey, PlaceholderLifecycle};
 use super::super::turn_finalizer::TurnKey;
@@ -260,7 +261,7 @@ pub(super) async fn deliver_short_replace_via_controller(
         );
         true
     };
-    toc::deliver_turn_output(
+    let outcome = toc::deliver_turn_output(
         gateway,
         toc::TurnOutputCtx {
             turn,
@@ -307,7 +308,20 @@ pub(super) async fn deliver_short_replace_via_controller(
             heartbeat: Some(&heartbeat),
         },
     )
-    .await
+    .await;
+    // #3089 B2a: shadow-mirror durable delivered frontier — flag-gated, observe-only,
+    // Delivered-only (I2), OFF=no-op. Keyed by `watcher_owner_channel_id` (the
+    // OFFSET-AUTHORITY channel where `advance_tmux_relay_confirmed_end` advanced
+    // `confirmed_end_offset`), NOT the edit-target `channel_id` — so the durable
+    // frontier and the in-memory authority B2b fuses share one channel key.
+    dr::shadow_mirror_delivered_frontier(
+        shared,
+        provider,
+        watcher_owner_channel_id,
+        (start, end),
+        dr::outcome_is_shadow_delivered(&outcome),
+    );
+    outcome
 }
 
 /// #3089 A5: borrowed `&mut` handles to the site-5 send-arm locals the controller


### PR DESCRIPTION
## #3089 Phase B2a — complete shadow-write coverage (watcher + bridge)

Completes the durable delivered-frontier shadow-write coverage that B1 started at the sink, **ahead of B2b's read-authority flip**. The flip reads `delivered_frontier` as the durable delivered-offset authority; for it to be safe, EVERY owner that advances `confirmed_end_offset` must already be shadow-writing the frontier — otherwise a watcher-/bridge-delivered turn would read a missing frontier under the flip (I3 conservative → re-relay/duplicate). B1 covered only the sink; B2a adds the remaining two.

### Coverage map (owners that advance `confirmed_end_offset`)
- **Sink** (A2b) — shadow-writes since B1.
- **Watcher** (A4) — ADDED: `shadow_mirror_delivered_frontier` in the `deliver_short_replace_via_controller` Delivered arm. Fires on the raw `outcome` BEFORE the `Delivered | NotDelivered` fold, gated by `outcome_is_shadow_delivered` → a `NotDelivered` does NOT shadow-write (I2).
- **Bridge** (A5) — ADDED: same, but keyed by `watcher_owner_channel_id` (the OFFSET-AUTHORITY channel where `advance_tmux_relay_confirmed_end` advances `confirmed_end_offset`), NOT the edit-target `channel_id` — so the durable frontier and the in-memory authority B2b fuses share one channel key (mirrors the A5 edit-vs-owner channel split).

Standby + recovery are `NoLease`/`advance:None` (no `confirmed_end` advance) → out of scope; sweeper has no offset advance.

### Safety
Still observe-only, flag-gated by the SAME `AGENTDESK_DELIVERY_RECORD_SHADOW` (default OFF) → deploy no-op. Reuses the B1-tested helpers verbatim; no controller change, no read change (that's B2b). Shadow failure/divergence only logs (never panics, never alters the owner's result/outcome).

### Verification
- build 0 warnings · clippy clean · fmt clean · `delivery_record` 16/16 · `terminal_controller_cutover` 10/10 · audit exit 0 (watcher +10 under cap, bridge cutover sibling) · `await_holding_lock` 34.
- Diff = only the two owner cutover files; inflight.rs + frozen owners' offset logic byte-unchanged.
- **Codex adversarial review: VERDICT CLEAN** (findings none — I2 Delivered-only confirmed incl. the watcher NotDelivered fold; bridge owner-channel keying verified correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)