### PR TITLE
feat(#3089): B2b — flip relay dedup read-authority to durable frontier w/ #1270 generation guard (flag, default OFF)

### DIFF
--- a/src/services/discord/outbound/delivery_record.rs
+++ b/src/services/discord/outbound/delivery_record.rs
@@ -333,6 +333,60 @@ pub(in crate::services::discord) fn delivery_record_shadow_enabled() -> bool {
     })
 }
 
+/// #3089 B2b read-authority flag (`AGENTDESK_DELIVERY_RECORD_AUTHORITY`, OnceLock,
+/// default OFF). When OFF (default) the dedup gates read the legacy in-memory
+/// `committed_relay_offset` verbatim → byte-identical, deploy no-op. When ON the
+/// gates consult the durable `delivered_frontier` (fused with in-memory) so the
+/// "already-relayed → skip" decision survives a restart / cross-actor boundary.
+pub(in crate::services::discord) fn delivery_record_authority_enabled() -> bool {
+    static CACHED: OnceLock<bool> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        let on = std::env::var("AGENTDESK_DELIVERY_RECORD_AUTHORITY")
+            .ok()
+            .map(|v| v.trim().to_ascii_lowercase())
+            .is_some_and(|v| v == "1" || v == "true");
+        if on {
+            tracing::info!("  ✓ delivery_record_authority: enabled");
+        }
+        on
+    })
+}
+
+/// Pure fusion (testable): the effective committed offset under the flip. The
+/// durable frontier END can only RAISE the dedup floor above what the in-memory
+/// authority sees (a pre-restart / cross-actor delivery the live atomic missed);
+/// it must NEVER lower it. So fuse with `max` — a missed durable write (the
+/// coverage hazard) can therefore never drop the floor below in-memory and cause
+/// a false skip / lost relay. `None` durable (I3 conservative) → pure in-memory =
+/// exactly today's behavior. Pure-durable-only authority waits for B3 hydration.
+fn fuse_committed_offset(durable_end: Option<u64>, in_memory: u64) -> u64 {
+    match durable_end {
+        Some(end) => end.max(in_memory),
+        None => in_memory,
+    }
+}
+
+/// #3089 B2b: the effective "already-committed" offset the dedup/skip gates read.
+/// Flag OFF (default) → the legacy in-memory `committed_relay_offset` verbatim
+/// (no record read → deploy no-op). Flag ON → `max(delivered_frontier.end,
+/// in_memory)` (I3: missing/malformed record → in-memory only, never assume
+/// delivered). The in-memory authority is the relay coord's `confirmed_end_offset`
+/// for `channel`; the durable record is keyed by `(provider, channel)`.
+pub(in crate::services::discord) fn effective_committed_offset(
+    shared: &crate::services::discord::SharedData,
+    provider: &ProviderKind,
+    channel: ChannelId,
+) -> u64 {
+    let in_memory = shared.committed_relay_offset(channel);
+    if !delivery_record_authority_enabled() {
+        return in_memory;
+    }
+    let durable_end = read_record(provider, channel.get())
+        .and_then(|r| r.delivered_frontier)
+        .map(|f| f.range.1);
+    fuse_committed_offset(durable_end, in_memory)
+}
+
 /// I2 outcome map (pure, testable): the shadow-write fires ONLY for a confirmed
 /// `Delivered`. Every other outcome means the controller did NOT advance the
 /// offset — `NotDelivered` (identity gate refused), `Transient`/`Unknown`
@@ -716,5 +770,19 @@ mod tests {
         let after = read_record_at(&path).unwrap();
         assert_eq!(after.delivery_lease, Some(sample_lease()));
         assert_eq!(after.delivered_frontier.unwrap().range, (0, 5));
+    }
+
+    // ---- #3089 B2b authority flip (fusion) ----------------------------------
+
+    #[test]
+    fn fuse_committed_offset_conservative_max() {
+        // The durable frontier can only RAISE the dedup floor above in-memory,
+        // never lower it. A missed durable write (None, I3) → pure in-memory =
+        // today's behavior. Mutation target: flipping max→min or dropping the
+        // in-memory fusion would surface here.
+        assert_eq!(fuse_committed_offset(None, 20), 20); // I3: missing → in-memory
+        assert_eq!(fuse_committed_offset(Some(30), 20), 30); // durable raises floor
+        assert_eq!(fuse_committed_offset(Some(10), 20), 20); // stale-low durable never lowers
+        assert_eq!(fuse_committed_offset(Some(0), 0), 0);
     }
 }

--- a/src/services/discord/outbound/delivery_record.rs
+++ b/src/services/discord/outbound/delivery_record.rs
@@ -366,23 +366,44 @@ fn fuse_committed_offset(durable_end: Option<u64>, in_memory: u64) -> u64 {
     }
 }
 
+/// #1270 generation guard (pure, testable): trust the durable frontier to RAISE
+/// the dedup floor ONLY if it was written by the CURRENT wrapper generation. A
+/// stale-high frontier from a PRIOR same-named tmux generation must NOT be
+/// fused — the in-memory generation-reset already zeroed the live offset, and a
+/// mismatched durable value would falsely skip the NEW generation's fresh output
+/// (lost relay). `current_gen == 0` (no/unreadable `.generation` file) → cannot
+/// validate → distrust. Write/read parity: the durable `generation_mtime_ns` is
+/// the coord's `confirmed_end_generation_mtime_ns`, itself set from
+/// `read_generation_file_mtime_ns` at advance time (tmux.rs), so equality holds
+/// within a generation and breaks across one.
+fn durable_frontier_generation_current(durable_mtime: i64, current_gen_mtime: i64) -> bool {
+    current_gen_mtime != 0 && durable_mtime == current_gen_mtime
+}
+
 /// #3089 B2b: the effective "already-committed" offset the dedup/skip gates read.
 /// Flag OFF (default) → the legacy in-memory `committed_relay_offset` verbatim
 /// (no record read → deploy no-op). Flag ON → `max(delivered_frontier.end,
 /// in_memory)` (I3: missing/malformed record → in-memory only, never assume
-/// delivered). The in-memory authority is the relay coord's `confirmed_end_offset`
-/// for `channel`; the durable record is keyed by `(provider, channel)`.
+/// delivered), but ONLY when the durable frontier is from the CURRENT wrapper
+/// generation (#1270 guard — a stale prior-generation frontier is treated as
+/// `None`). The in-memory authority is the relay coord's `confirmed_end_offset`
+/// for `channel`; the durable record is keyed by `(provider, channel)`;
+/// `tmux_session_name` resolves the current generation watermark.
 pub(in crate::services::discord) fn effective_committed_offset(
     shared: &crate::services::discord::SharedData,
     provider: &ProviderKind,
     channel: ChannelId,
+    tmux_session_name: &str,
 ) -> u64 {
     let in_memory = shared.committed_relay_offset(channel);
     if !delivery_record_authority_enabled() {
         return in_memory;
     }
+    let current_gen =
+        crate::services::discord::tmux::read_generation_file_mtime_ns(tmux_session_name);
     let durable_end = read_record(provider, channel.get())
         .and_then(|r| r.delivered_frontier)
+        .filter(|f| durable_frontier_generation_current(f.generation_mtime_ns, current_gen))
         .map(|f| f.range.1);
     fuse_committed_offset(durable_end, in_memory)
 }
@@ -784,5 +805,16 @@ mod tests {
         assert_eq!(fuse_committed_offset(Some(30), 20), 30); // durable raises floor
         assert_eq!(fuse_committed_offset(Some(10), 20), 20); // stale-low durable never lowers
         assert_eq!(fuse_committed_offset(Some(0), 0), 0);
+    }
+
+    #[test]
+    fn generation_guard_distrusts_prior_and_unknown_generations() {
+        // #1270: trust the durable frontier ONLY if its generation_mtime_ns equals
+        // the CURRENT wrapper generation. A prior-generation (stale-high) frontier
+        // must be distrusted → not fused → no false skip of fresh output.
+        assert!(durable_frontier_generation_current(123, 123)); // same generation → trust
+        assert!(!durable_frontier_generation_current(100, 123)); // prior gen → distrust
+        assert!(!durable_frontier_generation_current(123, 0)); // no .generation file → distrust
+        assert!(!durable_frontier_generation_current(0, 0)); // both unknown → distrust
     }
 }

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -1341,9 +1341,9 @@ async fn run_idle_jsonl_relay_loop(
                     &session_name,
                     "idle_jsonl_relay",
                 );
-                let committed = shared.committed_relay_offset(channel);
-                // Classification already passed above → `in_new_session_grace = false`
-                // here consults ONLY the offset-authority dedup branch.
+                // #3089 B2b: durable-frontier dedup authority (flag OFF → in-memory verbatim).
+                let committed = dr::effective_committed_offset(&shared, &matched.provider, channel);
+                // Classification passed above → consults ONLY the offset-authority dedup branch.
                 match idle_relay_range_action(&payload, start, end, committed, false) {
                     IdleRelayRangeAction::SkipAlreadyRelayed => {
                         // Whole range already delivered by the watcher → skip.

--- a/src/services/discord/session_relay_sink.rs
+++ b/src/services/discord/session_relay_sink.rs
@@ -1310,21 +1310,19 @@ async fn run_idle_jsonl_relay_loop(
                 );
                 continue;
             };
-            // #3017 single output-offset authority: this idle path and the watcher both
-            // read the SAME JSONL (E-13: an inflight-less wake relayed twice). The watcher
-            // is PRIMARY and advances `confirmed_end_offset`; this backstop only CONSULTS
-            // it read-only (committed >= range end → skip) and does NOT advance (codex P1:
-            // `try_send_frame` only QUEUES → committing here could drop the response).
+            // #3017 single output-offset authority: this idle path and the watcher both read
+            // the SAME JSONL (E-13: an inflight-less wake relayed twice). The watcher is PRIMARY
+            // and advances `confirmed_end_offset`; this backstop only CONSULTS it read-only
+            // (committed >= range end → skip), no advance (codex P1: `try_send_frame` only QUEUES).
             let channel = ChannelId::new(channel_id);
             if let Some(shared) = health_registry
                 .shared_for_provider_on_channel(&matched.provider, channel)
                 .await
                 .or(health_registry.shared_for_provider(&matched.provider).await)
             {
-                // Codex P2: a stale-high `confirmed_end_offset` from a previous wrapper
-                // would skip the FRESH file's first bytes (dropped wake). Run the SAME
-                // generation-aware regression reset the watcher uses BEFORE reading the
-                // watermark, so a truncated/respawned JSONL resets it to 0 (fresh wrapper).
+                // Codex P2: a stale-high `confirmed_end_offset` from a previous wrapper would skip
+                // the FRESH file's first bytes (dropped wake). Run the SAME generation-aware
+                // regression reset the watcher uses, so a truncated/respawned JSONL resets to 0.
                 super::tmux::reset_stale_relay_watermark_if_output_regressed(
                     shared.as_ref(),
                     channel,
@@ -1332,17 +1330,21 @@ async fn run_idle_jsonl_relay_loop(
                     len,
                     "idle_jsonl_relay",
                 );
-                // Codex r7 P2: the EOF-regression reset above misses a respawned wrapper
-                // whose fresh JSONL already grew PAST the prior watermark. Apply the same
-                // generation-change reset so a stale watermark doesn't skip fresh output.
+                // Codex r7 P2: the EOF-regression reset misses a respawned wrapper whose fresh
+                // JSONL already grew PAST the prior watermark; the generation-change reset covers it.
                 super::tmux::reset_relay_watermark_on_generation_change(
                     shared.as_ref(),
                     channel,
                     &session_name,
                     "idle_jsonl_relay",
                 );
-                // #3089 B2b: durable-frontier dedup authority (flag OFF → in-memory verbatim).
-                let committed = dr::effective_committed_offset(&shared, &matched.provider, channel);
+                // #3089 B2b: durable-frontier dedup authority (flag OFF → in-memory).
+                let committed = dr::effective_committed_offset(
+                    &shared,
+                    &matched.provider,
+                    channel,
+                    &session_name,
+                );
                 // Classification passed above → consults ONLY the offset-authority dedup branch.
                 match idle_relay_range_action(&payload, start, end, committed, false) {
                     IdleRelayRangeAction::SkipAlreadyRelayed => {
@@ -1359,11 +1361,10 @@ async fn run_idle_jsonl_relay_loop(
                         continue;
                     }
                     IdleRelayRangeAction::SendSuffixFrom(from) => {
-                        // Codex r5 P2 + codex r6 P1 (black-hole): PARTIAL overlap — the
-                        // watcher delivered the `[start, committed)` prefix; deliver ONLY
-                        // the uncommitted suffix in THIS pass (bouncing to a next tick would
-                        // re-read a suffix that lost the `system/init` event → re-classified
-                        // and DROPPED). See `IdleRelayRangeAction::SendSuffixFrom`.
+                        // Codex r5 P2 + codex r6 P1 (black-hole): PARTIAL overlap — the watcher
+                        // delivered the `[start, committed)` prefix; deliver ONLY the uncommitted
+                        // suffix THIS pass (a next-tick bounce would re-read a suffix that lost the
+                        // `system/init` event → re-classified and DROPPED). See `SendSuffixFrom`.
                         let suffix =
                             match read_jsonl_range(&matched.expected_rollout_path, from, end) {
                                 Ok(suffix) => suffix,
@@ -1388,12 +1389,10 @@ async fn run_idle_jsonl_relay_loop(
                         }
                         continue;
                     }
-                    // `committed <= start` → nothing covered → fall through to the
-                    // full-range send below.
+                    // `committed <= start` → nothing covered → fall through to the full-range send.
                     IdleRelayRangeAction::SendFull => {}
-                    // Classification already happened above; this arm is
-                    // unreachable here because we pass `in_new_session_grace =
-                    // false` and the payload already passed the init gate.
+                    // Unreachable here: `in_new_session_grace = false` and the payload already
+                    // passed the init gate (classification happened above).
                     IdleRelayRangeAction::SkipClassified => {}
                 }
             }

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::services::discord::InflightTurnState;
+use crate::services::discord::outbound::delivery_record as dr; // #3089 B2b
 use crate::services::discord::replace_outcome_policy::watcher_partial_continuation_retry_plan;
 
 #[path = "tmux_watcher/liveness.rs"]
@@ -5507,7 +5508,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             // `current_offset` would MISS a prior commit at that smaller consumed
             // end and re-relay the already-committed terminal.
             let turn_consumed_offset = terminal_event_consumed_offset(current_offset, &all_data);
-            let committed = shared.committed_relay_offset(channel_id);
+            let committed = dr::effective_committed_offset(&shared, &watcher_provider, channel_id);
             if committed >= turn_consumed_offset && turn_consumed_offset > turn_data_start_offset {
                 let ts = chrono::Local::now().format("%H:%M:%S");
                 tracing::info!(
@@ -5680,18 +5681,17 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         // #3041 P1-3 (Part b, §3.2): REPLACE the blind re-send. Before re-sending the
         // terminal body after a non-`Delivered` session-bound ACK (the
         // `relay_terminal_ack_timeout` duplicate vector), reconcile against the offset
-        // authority FIRST, over the SAME consumed range
-        // `[data_start_offset, terminal_event_consumed_offset(current_offset, all_data))`.
+        // authority FIRST, over the SAME consumed range `[data_start_offset, terminal_event_consumed_offset(current_offset, all_data))`.
         // Part (a) advances `committed_relay_offset` to the watcher's own `end` on a
         // confirmed sink delivery, so the consult is exact: committed >= end → SKIP (sink
         // delivered; ACK lagged → no duplicate, failure-mode-①); committed < end → re-send
-        // the FULL response (no black-hole). codex BLOCKER 2: NO partial-suffix send (the
-        // render coordinate is not derivable from the JSONL byte offset), and delegation
-        // is all-or-nothing so `committed` is never strictly between start and end.
-        // Reconcile ONLY on the session-bound re-send path; plain watcher-direct unchanged.
+        // the FULL response (no black-hole). codex BLOCKER 2: NO partial-suffix send (render
+        // coordinate not derivable from the JSONL byte offset), delegation all-or-nothing so
+        // `committed` is never strictly between start/end. Reconcile ONLY on the session-bound re-send path; plain watcher-direct unchanged.
         let watcher_resend_range_start = data_start_offset;
         let watcher_resend_range_end = terminal_event_consumed_offset(current_offset, &all_data);
-        let watcher_resend_committed = shared.committed_relay_offset(channel_id);
+        let watcher_resend_committed =
+            dr::effective_committed_offset(&shared, &watcher_provider, channel_id); // #3089 B2b
         let watcher_resend_reconciled = session_bound_terminal_delivery_attempted
             && watcher_direct_fallback_intended
             && !matches!(
@@ -5731,7 +5731,7 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             // for a real Delivered commit → Skip). Reading it BEFORE the snapshot
             // could capture a pre-advance `committed < end` paired with a now-
             // Committed{Delivered} marker → a spurious SendFull duplicate.
-            let committed = shared.committed_relay_offset(channel_id);
+            let committed = dr::effective_committed_offset(&shared, &watcher_provider, channel_id);
             let now_ms = crate::services::discord::lease_now_ms();
             let (action, reclaim_expired_sink) = watcher_terminal_resend_action_gated(
                 &snapshot,

--- a/src/services/discord/tmux_watcher.rs
+++ b/src/services/discord/tmux_watcher.rs
@@ -5475,40 +5475,35 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                     "no_inflight_dedup",
                 );
             }
-            // Codex r6 P2: `reset_stale_relay_watermark_if_output_regressed` only
-            // resets when the current EOF is LOWER than the stored watermark. A
-            // respawned same-named wrapper whose fresh JSONL has ALREADY grown
-            // PAST the previous wrapper's watermark would NOT trip that
-            // EOF-regression check, so a fresh no-inflight result whose consumed
-            // end is below the stale watermark would be wrongly suppressed.
-            // Independently reset the watermark when the `.generation` mtime has
-            // CHANGED since the watermark was committed (a fresh wrapper names a
-            // different byte stream). Shared with the idle relay path.
+            // Codex r6 P2: `reset_stale_relay_watermark_if_output_regressed` only resets when the
+            // current EOF is LOWER than the stored watermark. A respawned same-named wrapper whose
+            // fresh JSONL ALREADY grew PAST the prior watermark would NOT trip that EOF-regression
+            // check → fresh output wrongly suppressed. Independently reset when the `.generation`
+            // mtime CHANGED since commit (fresh wrapper = different byte stream). Shared with idle.
             reset_relay_watermark_on_generation_change(
                 &shared,
                 channel_id,
                 &tmux_session_name,
                 "watcher_no_inflight_dedup",
             );
-            // Read-only check against the authority. If the sink (fed by the
-            // idle-JSONL relay or the watcher's own session-bound delegation)
-            // already COMMITTED at/past this turn's END, that range was already
-            // delivered — the watcher skips to avoid the duplicate. The watcher
-            // does NOT claim here (a claim followed by a relay failure would mark
-            // the range delivered while dropping it); it advances the authority
-            // only on a CONFIRMED relay at `advance_watcher_confirmed_end` below.
-            //
-            // Codex r5 P2: compare against this TURN's consumed terminal end, NOT
-            // the whole read batch end (`current_offset`). A batch can contain a
-            // completed turn PLUS trailing JSONL for a later turn —
-            // `process_watcher_lines` stops at the first result, so the turn's
-            // output actually ends at `current_offset - all_data.len()` (the
-            // unprocessed tail), which is exactly what the normal commit path
-            // advances to (`runtime_binding_candidate_offset`). Comparing against
-            // `current_offset` would MISS a prior commit at that smaller consumed
-            // end and re-relay the already-committed terminal.
+            // Read-only check against the authority: if the sink (idle-JSONL relay or the watcher's
+            // own session-bound delegation) already COMMITTED at/past this turn's END, that range
+            // was delivered → skip the duplicate. The watcher does NOT claim here (claim + relay
+            // failure would mark delivered while dropping it); it advances only on a CONFIRMED relay
+            // at `advance_watcher_confirmed_end` below.
+            // Codex r5 P2: compare against this TURN's consumed terminal end, NOT the whole read
+            // batch end (`current_offset`) — a batch can hold a completed turn PLUS a later turn's
+            // trailing JSONL; `process_watcher_lines` stops at the first result, so the turn ends at
+            // `current_offset - all_data.len()` (== the normal commit path's
+            // `runtime_binding_candidate_offset`). Using `current_offset` would MISS a prior commit
+            // at that smaller consumed end and re-relay the already-committed terminal.
             let turn_consumed_offset = terminal_event_consumed_offset(current_offset, &all_data);
-            let committed = dr::effective_committed_offset(&shared, &watcher_provider, channel_id);
+            let committed = dr::effective_committed_offset(
+                &shared,
+                &watcher_provider,
+                channel_id,
+                &tmux_session_name,
+            );
             if committed >= turn_consumed_offset && turn_consumed_offset > turn_data_start_offset {
                 let ts = chrono::Local::now().format("%H:%M:%S");
                 tracing::info!(
@@ -5690,8 +5685,12 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
         // `committed` is never strictly between start/end. Reconcile ONLY on the session-bound re-send path; plain watcher-direct unchanged.
         let watcher_resend_range_start = data_start_offset;
         let watcher_resend_range_end = terminal_event_consumed_offset(current_offset, &all_data);
-        let watcher_resend_committed =
-            dr::effective_committed_offset(&shared, &watcher_provider, channel_id); // #3089 B2b
+        let watcher_resend_committed = dr::effective_committed_offset(
+            &shared,
+            &watcher_provider,
+            channel_id,
+            &tmux_session_name,
+        ); // #3089 B2b
         let watcher_resend_reconciled = session_bound_terminal_delivery_attempted
             && watcher_direct_fallback_intended
             && !matches!(
@@ -5699,9 +5698,8 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
                 SessionBoundRelayAckOutcome::Delivered
             );
         let watcher_resend_action = if watcher_resend_reconciled {
-            // Self-heal a stale-high authority left by a respawned/truncated
-            // wrapper BEFORE consulting it, exactly as the no-inflight gate and the
-            // idle relay do — so a fresh range is never wrongly skipped (codex P2).
+            // Self-heal a stale-high authority left by a respawned/truncated wrapper BEFORE
+            // consulting it (as the no-inflight gate and idle relay do) → fresh range never skipped (codex P2).
             reset_relay_watermark_on_generation_change(
                 &shared,
                 channel_id,
@@ -5716,22 +5714,24 @@ pub(in crate::services::discord) async fn tmux_output_watcher_with_restore(
             //     NOT re-send this pass (the slow-sink-in-flight duplicate #3151).
             //   * Leased{Sink, expired} → reclaim the dead sink's marker, then
             //     SendFull (committed<end) — the no-black-hole arm.
-            //   * Committed{Sink} → reconcile vs committed offset: committed>=end →
-            //     Skip (delivered), committed<end → SendFull (#3159: a refused/
-            //     NotDelivered commit re-sends, no black-hole).
+            //   * Committed{Sink} → reconcile vs committed offset: committed>=end → Skip
+            //     (delivered), committed<end → SendFull (#3159: refused/NotDelivered re-sends).
             //   * Unleased / non-Sink holder → unchanged (defer to the existing
             //     committed-offset reconciliation).
             let gate_cell = shared.delivery_lease(channel_id);
             let snapshot = gate_cell.read();
-            // #3159 BUG 1 (codex race-1): read `committed` AFTER the lease snapshot.
-            // The sink's CLEAR protocol advances `committed` FIRST, THEN commits the
-            // marker (`Committed{Sink}`). So observing `Committed{Sink}` in `snapshot`
-            // happens-after the sink's committed-offset write; reading `committed`
-            // next is therefore guaranteed to see the advanced value (committed>=end
-            // for a real Delivered commit → Skip). Reading it BEFORE the snapshot
-            // could capture a pre-advance `committed < end` paired with a now-
-            // Committed{Delivered} marker → a spurious SendFull duplicate.
-            let committed = dr::effective_committed_offset(&shared, &watcher_provider, channel_id);
+            // #3159 BUG 1 (codex race-1): read `committed` AFTER the lease snapshot. The sink's
+            // CLEAR protocol advances `committed` FIRST, THEN commits the marker (`Committed{Sink}`),
+            // so observing `Committed{Sink}` happens-after the committed write → reading `committed`
+            // next sees the advanced value (committed>=end for a real Delivered → Skip). Reading it
+            // BEFORE the snapshot could pair a pre-advance `committed < end` with a now-Committed
+            // marker → a spurious SendFull duplicate.
+            let committed = dr::effective_committed_offset(
+                &shared,
+                &watcher_provider,
+                channel_id,
+                &tmux_session_name,
+            );
             let now_ms = crate::services::discord::lease_now_ms();
             let (action, reclaim_expired_sink) = watcher_terminal_resend_action_gated(
                 &snapshot,


### PR DESCRIPTION
## #3089 Phase B2b — flip relay dedup read-authority to the durable frontier

Flips the "already-relayed → skip" dedup gates from the non-durable in-memory `committed_relay_offset` (resets to 0 on restart) to the durable `delivered_frontier` (survives restart / cross-actor), behind a NEW default-OFF flag `AGENTDESK_DELIVERY_RECORD_AUTHORITY`. OFF (default) → legacy in-memory verbatim → byte-identical deploy no-op. Removes the uncoordinated-writer class behind #3416 for the main relay path (the #3154 monotonic guard stays observe-only → promoted to enforce in B3).

### Mechanism (`outbound/delivery_record.rs`, uncapped)
- `delivery_record_authority_enabled()` flag (OnceLock, telemetry only when ON).
- `effective_committed_offset(shared, provider, channel, tmux_session_name)`: OFF → in-memory verbatim (no record/disk read); ON → `fuse_committed_offset(durable_frontier.end, in_memory)` for a frontier that passes the #1270 generation guard.
- `fuse_committed_offset = max(durable, in_memory)` (conservative): durable can only RAISE the floor, never lower it → a missed durable write can't cause a false skip / lost relay; missing/malformed → in-memory (I3).
- **`durable_frontier_generation_current` (#1270 guard):** trust the durable frontier ONLY if its `generation_mtime_ns` equals the CURRENT wrapper generation (`read_generation_file_mtime_ns(tmux_session_name)`, ground-truth file mtime — same source the write paired via the coord). A STALE-HIGH frontier from a PRIOR same-named tmux generation → treated as None → never falsely skips the new generation's fresh output. `current_gen == 0` → distrust.

### Scope
Watcher 3 dedup gates (`tmux_watcher.rs`) + sink idle-JSONL backstop (`session_relay_sink.rs`) — provider + session cleanly in scope. The idle-tail join (#3235) is split to B2c (no provider at its chokepoint). Bridge frontier (B2a) is keyed by `watcher_owner_channel_id` → matches the per-channel in-memory authority these gates read.

### Verification
- build 0 warnings · clippy clean · fmt clean · `delivery_record` 18/18 · `session_relay_sink` 49/49 · `tmux_watcher` 175/175 · audit exit 0 (tmux_watcher held at 8223 / sink 1731 via #-tag-preserving comment compression) · `await_holding_lock` 34.
- Mutation-verified: `max`→`min`, `None`→`0`, and the generation guard →always-true all fail their tests. inflight.rs + the #3154 guard byte-unchanged.
- Diff = exactly the 3 files; only reads swapped (no write/advance/guard change).
- **Codex adversarial review: VERDICT CLEAN** (r1 flagged one [High] — the durable read ignored `generation_mtime_ns`, so a stale-high prior-generation frontier could falsely skip fresh output; fixed by the #1270 generation guard above; r2 sign-off CLEAN, findings none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)