### PR TITLE
security: harden secret redaction (PRIVATE_KEY/PEM blocks, broader auth-header, draft-resume fix)

### DIFF
--- a/dashboard/src/components/onboarding/useOnboardingDraftLifecycle.ts
+++ b/dashboard/src/components/onboarding/useOnboardingDraftLifecycle.ts
@@ -295,48 +295,15 @@ export function useOnboardingDraftLifecycle({
           if (preferredDraft === serverDraft) {
             draftToApply = { ...preferredDraft };
 
+            // The backend always redacts bot_tokens to null (see
+            // src/services/onboarding/mod.rs), so only owner/guild can be
+            // restored from server status here. Bot tokens are recovered from
+            // the persisted draft itself, not from status.
             if (statusData.owner_id && !draftToApply.ownerId) {
               draftToApply.ownerId = statusData.owner_id;
             }
             if (statusData.guild_id && !draftToApply.selectedGuild) {
               draftToApply.selectedGuild = statusData.guild_id;
-            }
-
-            if (!serverHasExistingSetup) {
-              if (statusData.bot_tokens?.command || statusData.bot_tokens?.command2) {
-                draftToApply.commandBots = [...draftToApply.commandBots];
-              }
-
-              if (statusData.bot_tokens?.command) {
-                if (draftToApply.commandBots.length > 0 && !draftToApply.commandBots[0].token) {
-                  draftToApply.commandBots[0] = {
-                    ...draftToApply.commandBots[0],
-                    provider: statusData.bot_providers?.command ?? draftToApply.commandBots[0].provider,
-                    token: statusData.bot_tokens.command,
-                  };
-                }
-              }
-              if (statusData.bot_tokens?.command2) {
-                if (draftToApply.commandBots.length < 2) {
-                  draftToApply.commandBots.push({
-                    provider: statusData.bot_providers?.command2 ?? "codex",
-                    token: statusData.bot_tokens.command2,
-                    botInfo: null,
-                  });
-                } else if (!draftToApply.commandBots[1].token) {
-                  draftToApply.commandBots[1] = {
-                    ...draftToApply.commandBots[1],
-                    provider: statusData.bot_providers?.command2 ?? draftToApply.commandBots[1].provider,
-                    token: statusData.bot_tokens.command2,
-                  };
-                }
-              }
-              if (statusData.bot_tokens?.announce && !draftToApply.announceToken) {
-                draftToApply.announceToken = statusData.bot_tokens.announce;
-              }
-              if (statusData.bot_tokens?.notify && !draftToApply.notifyToken) {
-                draftToApply.notifyToken = statusData.bot_tokens.notify;
-              }
             }
           }
 

--- a/dashboard/src/components/onboarding/useOnboardingDraftLifecycle.ts
+++ b/dashboard/src/components/onboarding/useOnboardingDraftLifecycle.ts
@@ -290,11 +290,70 @@ export function useOnboardingDraftLifecycle({
 
         if (preferredDraft) {
           suppressNextServerDraftSyncRef.current = preferredDraft === serverDraft;
+
+          let draftToApply = preferredDraft;
+          if (preferredDraft === serverDraft) {
+            draftToApply = { ...preferredDraft };
+
+            if (statusData.owner_id && !draftToApply.ownerId) {
+              draftToApply.ownerId = statusData.owner_id;
+            }
+            if (statusData.guild_id && !draftToApply.selectedGuild) {
+              draftToApply.selectedGuild = statusData.guild_id;
+            }
+
+            if (!serverHasExistingSetup) {
+              if (statusData.bot_tokens?.command || statusData.bot_tokens?.command2) {
+                draftToApply.commandBots = [...draftToApply.commandBots];
+              }
+
+              if (statusData.bot_tokens?.command) {
+                if (draftToApply.commandBots.length > 0 && !draftToApply.commandBots[0].token) {
+                  draftToApply.commandBots[0] = {
+                    ...draftToApply.commandBots[0],
+                    provider: statusData.bot_providers?.command ?? draftToApply.commandBots[0].provider,
+                    token: statusData.bot_tokens.command,
+                  };
+                }
+              }
+              if (statusData.bot_tokens?.command2) {
+                if (draftToApply.commandBots.length < 2) {
+                  draftToApply.commandBots.push({
+                    provider: statusData.bot_providers?.command2 ?? "codex",
+                    token: statusData.bot_tokens.command2,
+                    botInfo: null,
+                  });
+                } else if (!draftToApply.commandBots[1].token) {
+                  draftToApply.commandBots[1] = {
+                    ...draftToApply.commandBots[1],
+                    provider: statusData.bot_providers?.command2 ?? draftToApply.commandBots[1].provider,
+                    token: statusData.bot_tokens.command2,
+                  };
+                }
+              }
+              if (statusData.bot_tokens?.announce && !draftToApply.announceToken) {
+                draftToApply.announceToken = statusData.bot_tokens.announce;
+              }
+              if (statusData.bot_tokens?.notify && !draftToApply.notifyToken) {
+                draftToApply.notifyToken = statusData.bot_tokens.notify;
+              }
+            }
+          }
+
           applyDraft({
-            ...preferredDraft,
-            hasExistingSetup: serverHasExistingSetup || preferredDraft.hasExistingSetup,
+            ...draftToApply,
+            hasExistingSetup: serverHasExistingSetup || draftToApply.hasExistingSetup,
           });
           setHasExistingSetup(serverHasExistingSetup || preferredDraft.hasExistingSetup);
+
+          if (nextResumeState === "partial_apply") {
+            setError(
+              tr(
+                "이전 온보딩 적용이 중간에 멈췄습니다. 같은 설정으로 다시 완료를 실행하면 기존 채널을 재사용합니다.",
+                "A previous onboarding apply stopped mid-flight. Re-running completion with the same setup will reuse the existing channels.",
+              ),
+            );
+          }
           return;
         }
 

--- a/src/utils/redact.rs
+++ b/src/utils/redact.rs
@@ -2,8 +2,9 @@ use regex::Regex;
 use std::sync::{LazyLock, RwLock};
 use url::Url;
 
-static BEARER_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?i)\b(Authorization:\s*(?:Bearer|Bot)\s+)[^\s]+").unwrap());
+static AUTH_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)\b(authorization\s*:\s*(?:[a-z][a-z0-9._~+/-]*\s+)?)[^\r\n]+").unwrap()
+});
 static ASSIGNMENT_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?i)\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|DATABASE_URL|API[_-]?KEY)[A-Z0-9_]*\s*=\s*)[^\s]+")
         .unwrap()
@@ -90,7 +91,7 @@ pub(crate) fn redact_known_secrets(input: &str) -> String {
     let redacted = POSTGRES_DSN_RE.replace_all(input, |captures: &regex::Captures<'_>| {
         mask_dsn_password(captures.get(0).map(|m| m.as_str()).unwrap_or_default())
     });
-    let redacted = BEARER_RE.replace_all(&redacted, "${1}***");
+    let redacted = AUTH_HEADER_RE.replace_all(&redacted, "${1}***");
     let mut redacted = ASSIGNMENT_RE.replace_all(&redacted, "${1}***").into_owned();
     let secrets = match KNOWN_SECRETS.read() {
         Ok(guard) => guard.clone(),
@@ -126,15 +127,19 @@ mod tests {
     #[test]
     fn redact_known_secrets_masks_bearer_bot_and_assignments() {
         let redacted = redact_known_secrets(
-            "Authorization: Bearer live-token\nAuthorization: Bot discord-token\nDATABASE_URL=postgres://u:p@h/db\nOPENAI_API_KEY=sk-live",
+            "Authorization: Bearer live-token\nAuthorization: Bot discord-token\nAuthorization: Basic dXNlcjpwYXNz\nauthorization: Digest username=\"u\", nonce=\"nonce-secret\"\nDATABASE_URL=postgres://u:p@h/db\nOPENAI_API_KEY=sk-live",
         );
 
         assert!(redacted.contains("Authorization: Bearer ***"));
         assert!(redacted.contains("Authorization: Bot ***"));
+        assert!(redacted.contains("Authorization: Basic ***"));
+        assert!(redacted.contains("authorization: Digest ***"));
         assert!(redacted.contains("DATABASE_URL=***"));
         assert!(redacted.contains("OPENAI_API_KEY=***"));
         assert!(!redacted.contains("live-token"));
         assert!(!redacted.contains("discord-token"));
+        assert!(!redacted.contains("dXNlcjpwYXNz"));
+        assert!(!redacted.contains("nonce-secret"));
         assert!(!redacted.contains("sk-live"));
     }
 

--- a/src/utils/redact.rs
+++ b/src/utils/redact.rs
@@ -6,7 +6,15 @@ static AUTH_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?i)\b(authorization\s*:\s*(?:[a-z][a-z0-9._~+/-]*\s+)?)[^\r\n]+").unwrap()
 });
 static ASSIGNMENT_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|DATABASE_URL|API[_-]?KEY)[A-Z0-9_]*\s*=\s*)[^\s]+")
+    Regex::new(r"(?i)\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|DATABASE_URL|API[_-]?KEY|PRIVATE[_-]?KEY)[A-Z0-9_]*\s*=\s*)[^\s]+")
+        .unwrap()
+});
+// PEM-encoded private keys span multiple whitespace-separated tokens and lines,
+// so the single-token ASSIGNMENT_RE value capture (`[^\s]+`) cannot mask the
+// whole body. Mask the entire `BEGIN..END ... PRIVATE KEY` block as one unit so
+// no portion of the key material survives in prompt/log paths.
+static PRIVATE_KEY_BLOCK_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?is)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----")
         .unwrap()
 });
 static POSTGRES_DSN_RE: LazyLock<Regex> =
@@ -75,12 +83,16 @@ pub(crate) fn register_common_env_secrets() {
     }
 
     for (key, value) in std::env::vars() {
-        let upper = key.to_ascii_uppercase();
+        // Normalize hyphens to underscores so hyphenated names exported via the
+        // `env 'GITHUB-PRIVATE-KEY=...'` form are matched just like underscore names.
+        let upper = key.to_ascii_uppercase().replace('-', "_");
         if upper.contains("TOKEN")
             || upper.contains("SECRET")
             || upper.contains("PASSWORD")
             || upper.contains("API_KEY")
             || upper.contains("APIKEY")
+            || upper.contains("PRIVATE_KEY")
+            || upper.contains("PRIVATEKEY")
         {
             register_secret_or_dsn(&value);
         }
@@ -88,7 +100,10 @@ pub(crate) fn register_common_env_secrets() {
 }
 
 pub(crate) fn redact_known_secrets(input: &str) -> String {
-    let redacted = POSTGRES_DSN_RE.replace_all(input, |captures: &regex::Captures<'_>| {
+    // Mask whole PEM private-key blocks first so later single-token rules cannot
+    // leave the key body behind, and so the registered-secret pass is unaffected.
+    let redacted = PRIVATE_KEY_BLOCK_RE.replace_all(input, "***");
+    let redacted = POSTGRES_DSN_RE.replace_all(&redacted, |captures: &regex::Captures<'_>| {
         mask_dsn_password(captures.get(0).map(|m| m.as_str()).unwrap_or_default())
     });
     let redacted = AUTH_HEADER_RE.replace_all(&redacted, "${1}***");
@@ -127,7 +142,7 @@ mod tests {
     #[test]
     fn redact_known_secrets_masks_bearer_bot_and_assignments() {
         let redacted = redact_known_secrets(
-            "Authorization: Bearer live-token\nAuthorization: Bot discord-token\nAuthorization: Basic dXNlcjpwYXNz\nauthorization: Digest username=\"u\", nonce=\"nonce-secret\"\nDATABASE_URL=postgres://u:p@h/db\nOPENAI_API_KEY=sk-live",
+            "Authorization: Bearer live-token\nAuthorization: Bot discord-token\nAuthorization: Basic dXNlcjpwYXNz\nauthorization: Digest username=\"u\", nonce=\"nonce-secret\"\nDATABASE_URL=postgres://u:p@h/db\nOPENAI_API_KEY=sk-live\nGITHUB_PRIVATE_KEY=gh-priv-key-secret\nPRIVATE_KEY=pk-secret",
         );
 
         assert!(redacted.contains("Authorization: Bearer ***"));
@@ -136,11 +151,42 @@ mod tests {
         assert!(redacted.contains("authorization: Digest ***"));
         assert!(redacted.contains("DATABASE_URL=***"));
         assert!(redacted.contains("OPENAI_API_KEY=***"));
+        assert!(redacted.contains("GITHUB_PRIVATE_KEY=***"));
+        assert!(redacted.contains("PRIVATE_KEY=***"));
         assert!(!redacted.contains("live-token"));
         assert!(!redacted.contains("discord-token"));
         assert!(!redacted.contains("dXNlcjpwYXNz"));
         assert!(!redacted.contains("nonce-secret"));
         assert!(!redacted.contains("sk-live"));
+        assert!(!redacted.contains("gh-priv-key-secret"));
+        assert!(!redacted.contains("pk-secret"));
+    }
+
+    #[test]
+    fn redact_known_secrets_masks_multiline_pem_private_key_block() {
+        let pem = "context before\nGITHUB_PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----\nMIIBVAIBADANBgkqhkiG9w0BAQEF\nAASCAj8wggI7AgEAAoIBAQDLEAK=\n-----END RSA PRIVATE KEY-----\ncontext after";
+        let redacted = redact_known_secrets(pem);
+
+        // The entire key body and PEM armor must be gone, including interior lines.
+        assert!(!redacted.contains("MIIBVAIBADANBgkqhkiG9w0BAQEF"));
+        assert!(!redacted.contains("AASCAj8wggI7AgEAAoIBAQDLEAK="));
+        assert!(!redacted.contains("BEGIN RSA PRIVATE KEY"));
+        assert!(!redacted.contains("END RSA PRIVATE KEY"));
+        // Surrounding non-secret context is preserved.
+        assert!(redacted.contains("context before"));
+        assert!(redacted.contains("context after"));
+        assert!(redacted.contains("GITHUB_PRIVATE_KEY=***"));
+    }
+
+    #[test]
+    fn redact_known_secrets_masks_bare_pem_block_without_assignment() {
+        let pem = "ssh failed: -----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAA\n-----END OPENSSH PRIVATE KEY----- (retrying)";
+        let redacted = redact_known_secrets(pem);
+
+        assert!(!redacted.contains("b3BlbnNzaC1rZXktdjEAAAAA"));
+        assert!(!redacted.contains("OPENSSH PRIVATE KEY"));
+        assert!(redacted.contains("ssh failed: ***"));
+        assert!(redacted.contains("(retrying)"));
     }
 
     #[test]


### PR DESCRIPTION
## 목표

프롬프트/로그 경로의 시크릿 누출 경로를 좁히고(`src/utils/redact.rs`), 온보딩 드래프트를 서버에서 재개할 때 중단 안내가 누락되던 UX 버그를 함께 고친다(`useOnboardingDraftLifecycle.ts`). 적용 후에는 PEM 개인키 블록·임의 스킴의 Authorization 헤더·`PRIVATE_KEY` 류 할당이 모두 마스킹되고, 서버 드래프트 재개 시 owner/guild 복원과 `partial_apply` 중단 경고가 정상 동작한다.

## 쉬운 설명

로그나 프롬프트에 개인키(PEM 블록), 인증 헤더, `PRIVATE_KEY` 값이 그대로 찍히던 빈틈을 막았습니다. 또한 온보딩을 도중에 저장했다가 다시 이어서 할 때, 이전 적용이 중간에 멈춘 경우 "같은 설정으로 다시 완료하면 기존 채널을 재사용한다"는 안내가 다시 보이도록 했습니다. 처음 PR에 있던 "서버가 가린 봇 토큰을 복원" 코드는 백엔드가 토큰을 항상 `null`로 내려주어 실제로는 아무것도 복원하지 못하는 죽은 코드였기에 제거했습니다.

## 개선되는 것

### Fix 1 — 시크릿 redaction 범위 확장 (`src/utils/redact.rs`)
- Authorization 헤더: Before는 `Bearer`/`Bot`만 마스킹. After는 임의 인증 스킴(`Basic`, `Digest` 등)과 줄 끝까지의 값 전체를 마스킹.
- 할당 패턴: Before는 `PRIVATE_KEY=...`를 놓침. After는 `ASSIGNMENT_RE`가 `PRIVATE[_-]?KEY` 할당도 매칭.
- 환경변수 등록: Before는 하이픈 이름(`GITHUB-PRIVATE-KEY`)을 흘림. After는 하이픈을 언더스코어로 정규화하고 `PRIVATE_KEY`/`PRIVATEKEY` 키를 글로벌 시크릿으로 등록.
- PEM 블록: Before는 여러 줄에 걸친 개인키 본문이 단일 토큰 캡처(`[^\s]+`)를 빠져나가 잔존. After는 `PRIVATE_KEY_BLOCK_RE`가 `BEGIN..END PRIVATE KEY` 블록 전체를 가장 먼저 한 단위로 마스킹.

### Fix 2 — 온보딩 서버 드래프트 재개 (`useOnboardingDraftLifecycle.ts`)
- owner/guild 복원: 서버 드래프트(`preferredDraft === serverDraft`)를 적용할 때 빈 필드에 한해 `statusData.owner_id`/`guild_id`를 복원(기존에 입력된 로컬 값은 덮어쓰지 않음).
- 중단 경고: `nextResumeState === "partial_apply"`일 때 채널 재사용 안내 메시지를 표시.
- 죽은 코드 제거(Codex P2 descope): 서버 드래프트의 `statusData.bot_tokens.{command,command2,announce,notify}` 토큰 복원 분기를 제거. 백엔드(`src/services/onboarding/mod.rs`)가 모든 봇 토큰을 항상 `None`으로 redact해 내려주므로 이 분기는 어떤 토큰도 복원하지 못하는 inert 코드였다(다만 `!token` 가드로 보호되어 무해했다). 토큰은 영속화된 드래프트 자체에서 복원된다.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| `Authorization: Basic dXNlcjpwYXNz` 로그 | 값 노출 | `Authorization: Basic ***` |
| 다중 줄 PEM `BEGIN..END RSA PRIVATE KEY` | 본문 라인 잔존 | 블록 전체 `***`, 주변 컨텍스트 보존 |
| `GITHUB-PRIVATE-KEY=...` 환경변수 | 미등록(흘림) | 정규화 후 글로벌 시크릿으로 등록·마스킹 |
| 서버 드래프트 재개 (`partial_apply`) | 중단 안내 없음 | owner/guild 복원 + `partial_apply` 안내 표시 |
| 서버 드래프트 봇 토큰 복원 분기 | 항상 `null`을 읽어 무동작(inert) | 죽은 코드 제거 (토큰은 드래프트에서 복원) |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| PEM 블록과 시크릿 할당이 한 입력에 혼재 | PEM 블록을 먼저 마스킹 후 할당/등록 시크릿 패스 수행 | 단일 토큰 규칙이 키 본문을 흘리지 않고, 등록 시크릿 패스도 영향 없음 |
| 일반 `Authorization` 헤더가 아닌 본문에 `Bearer` 단어 | `\bauthorization\s*:` 앵커가 필요해 헤더 형태에만 적용 | 무관한 텍스트를 과도하게 마스킹하지 않음 |
| 봇 토큰 복원 분기 제거 후 재개 | owner/guild 복원과 `partial_apply` 안내는 그대로 동작 | 토큰은 영속 드래프트에서 복원되어 기능 회귀 없음 |
| 기존 setup이 이미 있는 서버 드래프트 | owner/guild는 빈 필드에만 병합 | 기존 보안 설정 경로 유지, 로컬 입력값 미덮어쓰기 |

## 해결한 내용

- `src/utils/redact.rs`: `BEARER_RE` → `AUTH_HEADER_RE`로 교체해 임의 스킴 헤더 값을 줄 끝까지 마스킹. `ASSIGNMENT_RE`에 `PRIVATE[_-]?KEY` 추가. `register_common_env_secrets`에서 키 이름 하이픈을 언더스코어로 정규화하고 `PRIVATE_KEY`/`PRIVATEKEY` 포함 키를 등록. 신규 `PRIVATE_KEY_BLOCK_RE`를 도입해 `redact_known_secrets` 진입 직후 PEM 블록을 가장 먼저 한 단위로 마스킹 — 이유: 여러 줄/토큰에 걸친 키 본문이 단일 토큰 규칙을 우회하는 누출 경로를 닫기 위함. (scope: redaction 헬퍼 한정, 호출부 시그니처 불변)
- `dashboard/src/components/onboarding/useOnboardingDraftLifecycle.ts`: 서버 드래프트 적용 시 owner/guild를 빈 필드에 한해 복원하고 `partial_apply` 재개 시 채널 재사용 경고를 노출. Codex P2 지적에 따라 `statusData.bot_tokens.*` 토큰 복원 분기는 백엔드가 항상 `None`을 내려주어 무동작이므로 제거 — 이유: 죽은 코드를 정리하면서 동작하던 owner/guild 복원과 중단 안내는 보존(로컬 입력값 미덮어쓰기 불변식 유지). (scope: 서버 드래프트 hydrate 분기 한정)

## 검증

- redact 모듈 단위 테스트 추가/확장 (diff 포함): `redact_known_secrets_masks_bearer_bot_and_assignments`(Basic/Digest/`GITHUB_PRIVATE_KEY`/`PRIVATE_KEY` 케이스 보강), `redact_known_secrets_masks_multiline_pem_private_key_block`, `redact_known_secrets_masks_bare_pem_block_without_assignment`. (로컬 cargo는 실행하지 않음 — Rust 컴파일/테스트는 cloud CI 재실행으로 검증 예정)
- agent-maintenance freshness gate: `scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate` → exit 0 (change-surfaces 수정 불필요; 무관 문서의 'Last refreshed' WARNING만 존재).
- maintainability audit: `scripts/audit_maintainability.py --check` → exit 0.
- CI 현황: rebase 전 base SHA에서 빨갛던 체크는 **Dashboard (Node 22)** + **Dashboard required context** 뿐이며, 이는 이 PR과 무관한 **stale base의 esbuild/vite npm-audit advisory**였다. 현재 `main`은 해당 의존성을 이미 수정(vite `^8.0.16`)했고, 본 PR을 현재 `main`에 rebase하면서 그 픽스를 포함하므로 force-push 후 dashboard 게이트는 자동으로 green이 된다.
- **Windows fast-check now passes**: `Fast check + non-PG tests (windows-latest)` PASS. windows·dashboard 실패에 연동되던 aggregator 게이트(`Fast check cross OS required context`)도 PASS.
