### PR TITLE
perf(policies): cut N+1 queries & duplicate JSON parsing in JS policy/monitor/auto-queue hot paths

### DIFF
--- a/policies/auto-queue.js
+++ b/policies/auto-queue.js
@@ -177,9 +177,13 @@ var autoQueue = {
 
     var dispatch = dispatches[0];
     var context = {};
-    try { context = JSON.parse(dispatch.context || "{}"); } catch (e) { context = {}; }
+    if (dispatch.context && dispatch.context !== "{}" && dispatch.context !== "[]") {
+      try { context = JSON.parse(dispatch.context); } catch (e) { context = {}; }
+    }
     var result = {};
-    try { result = JSON.parse(dispatch.result || "{}"); } catch (e) { result = {}; }
+    if (dispatch.result && dispatch.result !== "{}" && dispatch.result !== "[]") {
+      try { result = JSON.parse(dispatch.result); } catch (e) { result = {}; }
+    }
     var gate = context.phase_gate;
     if (!gate || !gate.run_id || gate.batch_phase == null) {
       return;
@@ -334,8 +338,12 @@ var autoQueue = {
       }
       var gateContext = {};
       var gateResult = {};
-      try { gateContext = JSON.parse(gateDispatch.context || "{}"); } catch (e) { gateContext = {}; }
-      try { gateResult = JSON.parse(gateDispatch.result || "{}"); } catch (e) { gateResult = {}; }
+      if (gateDispatch.context && gateDispatch.context !== "{}" && gateDispatch.context !== "[]") {
+        try { gateContext = JSON.parse(gateDispatch.context); } catch (e) { gateContext = {}; }
+      }
+      if (gateDispatch.result && gateDispatch.result !== "{}" && gateDispatch.result !== "[]") {
+        try { gateResult = JSON.parse(gateDispatch.result); } catch (e) { gateResult = {}; }
+      }
       var expectedVerdict = (gateContext.phase_gate && gateContext.phase_gate.pass_verdict) || "phase_gate_passed";
       var gateVerdict = gateResult.verdict || gateResult.decision || gateResult.phase_gate_verdict || null;
       // #699 (round 2): sibling gate dispatches persisted before the server

--- a/policies/lib/auto-queue-phase-gate.js
+++ b/policies/lib/auto-queue-phase-gate.js
@@ -593,7 +593,9 @@ function _buildPhaseGateGroups(runId, phase) {
     }
 
     var latestResult = {};
-    try { latestResult = JSON.parse(row.latest_result || "{}"); } catch (e) { latestResult = {}; }
+    if (row.latest_result && row.latest_result !== "{}" && row.latest_result !== "[]") {
+      try { latestResult = JSON.parse(row.latest_result); } catch (e) { latestResult = {}; }
+    }
 
     groups[key].card_ids.push(row.kanban_card_id);
     if (row.github_issue_number !== null && row.github_issue_number !== undefined) {

--- a/policies/lib/kanban-card-metadata.js
+++ b/policies/lib/kanban-card-metadata.js
@@ -18,8 +18,11 @@ function _loadCardMetadata(cardId) {
   );
   if (rows.length === 0 || !rows[0].metadata) return {};
   try {
-    var parsed = JSON.parse(rows[0].metadata);
-    return parsed && typeof parsed === "object" ? parsed : {};
+    if (rows[0].metadata && rows[0].metadata !== "{}" && rows[0].metadata !== "[]") {
+      var parsed = JSON.parse(rows[0].metadata);
+      return parsed && typeof parsed === "object" ? parsed : {};
+    }
+    return {};
   } catch (e) {
     return {};
   }

--- a/policies/lib/merge-text-utils.js
+++ b/policies/lib/merge-text-utils.js
@@ -70,7 +70,7 @@ function firstPresent() {
 }
 
 function parseJsonObject(raw) {
-  if (!raw) return {};
+  if (!raw || raw === "{}" || raw === "[]") return {};
   try {
     return JSON.parse(raw) || {};
   } catch (e) {

--- a/policies/timeouts/active-monitor.js
+++ b/policies/timeouts/active-monitor.js
@@ -360,19 +360,12 @@ module.exports = function attachActiveMonitor(timeouts, helpers) {
       }
 
       // Clean up deadlock counters for sessions no longer working
-      var activeKeys = agentdesk.db.query(
-        "SELECT key FROM kv_meta WHERE key LIKE 'deadlock_check:%'"
+      agentdesk.db.execute(
+        "DELETE FROM kv_meta WHERE key LIKE 'deadlock_check:%' AND " +
+        "REPLACE(key, 'deadlock_check:', '') NOT IN (" +
+        "  SELECT session_key FROM sessions WHERE status IN ('turn_active', 'working')" +
+        ")"
       );
-      for (var ak = 0; ak < activeKeys.length; ak++) {
-        var sessKey = activeKeys[ak].key.replace("deadlock_check:", "");
-        var stillWorking = agentdesk.db.query(
-          "SELECT COUNT(*) as cnt FROM sessions WHERE session_key = ? AND status IN ('turn_active', 'working')",
-          [sessKey]
-        );
-        if (stillWorking.length > 0 && stillWorking[0].cnt === 0) {
-          agentdesk.db.execute("DELETE FROM kv_meta WHERE key = ?", [activeKeys[ak].key]);
-        }
-      }
 
       // Clean up old deadlock history entries (7일 이상)
       var historyKeys = agentdesk.db.query(

--- a/policies/timeouts/long-turn-monitor.js
+++ b/policies/timeouts/long-turn-monitor.js
@@ -143,19 +143,21 @@ module.exports = function attachLongTurnMonitor(timeouts, helpers) {
           );
           agentdesk.log.warn("[long-turn] " + (inf.channel_name || inf.channel_id) + " — " + Math.round(elapsedMin) + "min (" + currentThreshold + "min threshold)");
         }
+        // Pre-compute active inflight keys for O(1) lookups
+        var activeInflightSet = {};
+        for (var si = 0; si < inflights.length; si++) {
+          if (inflights[si].provider && inflights[si].channel_id) {
+            activeInflightSet[inflights[si].provider + ":" + inflights[si].channel_id] = true;
+          }
+        }
+
         // Clean up tier keys for inflights that no longer exist
         var tierKeys = agentdesk.db.query("SELECT key FROM kv_meta WHERE key LIKE 'long_turn_tier:%'");
         for (var tk = 0; tk < tierKeys.length; tk++) {
           var parts = tierKeys[tk].key.split(":");
           var tkProvider = parts[1];
           var tkChannel = parts[2];
-          var stillActive = false;
-          for (var si = 0; si < inflights.length; si++) {
-            if (inflights[si].provider === tkProvider && inflights[si].channel_id === tkChannel) {
-              stillActive = true; break;
-            }
-          }
-          if (!stillActive) {
+          if (!activeInflightSet[tkProvider + ":" + tkChannel]) {
             agentdesk.db.execute("DELETE FROM kv_meta WHERE key = ?", [tierKeys[tk].key]);
           }
         }
@@ -169,13 +171,7 @@ module.exports = function attachLongTurnMonitor(timeouts, helpers) {
           var eParts = extensionKeys[ek].key.split(":");
           var eProvider = eParts[1];
           var eChannel = eParts[2];
-          var extensionStillActive = false;
-          for (var ei = 0; ei < inflights.length; ei++) {
-            if (inflights[ei].provider === eProvider && inflights[ei].channel_id === eChannel) {
-              extensionStillActive = true; break;
-            }
-          }
-          if (!extensionStillActive) {
+          if (!activeInflightSet[eProvider + ":" + eChannel]) {
             agentdesk.db.execute("DELETE FROM kv_meta WHERE key = ?", [extensionKeys[ek].key]);
           }
         }


### PR DESCRIPTION
## 목표

정책/모니터/오토큐 핫패스에서 반복 실행되는 정리(cleanup) 루프의 비효율을 제거한다. 세션당 N+1 DB 쿼리, 인플라이트 매칭의 O(N*M) 중첩 루프, 빈/사소한 페이로드(`"{}"`, `"[]"`, falsy)에 대한 불필요한 `JSON.parse` 호출을 없애 동일한 동작을 유지하면서 모니터 틱당 DB 왕복과 CPU 사용을 줄인다.

## 쉬운 설명

데드락 카운터와 long-turn 타이머 키를 청소하는 백그라운드 점검이 세션·인플라이트 수가 많을수록 느려졌다. 이번 변경은 같은 청소를 한 번의 쿼리와 빠른 조회표로 처리하도록 바꾼다. 동작 결과(어떤 키가 지워지는지)는 이전과 완전히 동일하며, 점검이 더 가볍고 빨라진다.

## 개선되는 것

### Fix 1 — 데드락 카운터 정리 N+1 쿼리 제거 (`active-monitor.js`)
- Before: `deadlock_check:*` 키를 전부 SELECT한 뒤, 키마다 `sessions` 상태를 확인하는 쿼리를 돌리고 개별 DELETE를 실행 (키 N개 → 쿼리 1+N+α번).
- After: 활성 세션(`turn_active`, `working`)이 아닌 키를 단일 `DELETE ... WHERE key LIKE 'deadlock_check:%' AND REPLACE(...) NOT IN (SELECT session_key ...)` 한 문장으로 정리. 삭제 대상은 동일.

### Fix 2 — long-turn 키 정리 O(N*M) → O(N+M) (`long-turn-monitor.js`)
- Before: `long_turn_tier:*` / 연장(extension) 키마다 전체 `inflights` 배열을 선형 탐색해 활성 여부를 판정 (키 N개 × 인플라이트 M개).
- After: 인플라이트를 `provider:channel_id` 해시 셋(`activeInflightSet`)으로 한 번 선계산하고 키별로 O(1) 조회. 삭제 판정 결과는 동일.

### Fix 3 — 빈/사소한 페이로드의 불필요한 JSON 파싱 가드 (`auto-queue.js`, `auto-queue-phase-gate.js`, `kanban-card-metadata.js`, `merge-text-utils.js`)
- Before: dispatch context/result, phase-gate `latest_result`, 칸반 카드 metadata를 falsy 여부만 보고 매번 `JSON.parse` 호출 (`"{}"`, `"[]"`도 파싱).
- After: 값이 falsy거나 `"{}"`/`"[]"`이면 파싱을 건너뛰고 곧장 빈 객체 반환. 유효 JSON 처리 경로와 파싱 실패 시 폴백(빈 객체)은 그대로 유지.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| 데드락 카운터 정리(세션 N개) | SELECT 후 키별 상태 쿼리 + 개별 DELETE (~1+N 쿼리) | 단일 set-based DELETE 1회, 삭제 대상 동일 |
| long-turn 키 활성 판정 | 키마다 inflights 전체 선형 탐색 (O(N*M)) | 해시 셋 O(1) 조회 (O(N+M)) |
| 페이로드가 `"{}"` / `"[]"` / falsy | `JSON.parse` 실행 후 빈 객체 | 파싱 생략하고 즉시 빈 객체 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 활성 세션의 `deadlock_check` 키 | `NOT IN (활성 session_key)` 조건에서 제외 | 활성 키는 보존, 기존과 동일 |
| 손상된/잘못된 JSON 페이로드 | `try/catch`로 빈 객체 폴백 유지 | 파싱 가드가 정상 케이스를 깨지 않음 |
| inflight의 `provider`/`channel_id` 누락 | 셋에 등록하지 않아 매칭 미발생 → 키 정리됨 | 비활성으로 간주, 기존 선형 탐색과 동일 결과 |

## 해결한 내용

- `policies/timeouts/active-monitor.js`: 데드락 카운터 정리를 키별 SELECT+DELETE 루프에서 세트 기반 단일 DELETE로 교체. 모니터 틱당 DB 왕복을 N+1에서 1로 축소. (WHY: 세션 수에 비례해 쿼리가 선형 증가하던 핫패스 제거)
- `policies/timeouts/long-turn-monitor.js`: 인플라이트를 `provider:channel_id` 해시 셋으로 선계산하여 tier/extension 키 정리의 중첩 선형 탐색을 O(1) 조회로 전환. (WHY: 키×인플라이트 곱으로 늘어나던 비용 제거)
- `policies/auto-queue.js`, `policies/lib/auto-queue-phase-gate.js`, `policies/lib/kanban-card-metadata.js`, `policies/lib/merge-text-utils.js`: 빈/사소한 페이로드(`"{}"`, `"[]"`, falsy)에 대한 `JSON.parse` 호출을 가드로 차단. (WHY: 자주 비어 있는 dispatch/metadata 페이로드에서 불필요한 파싱 비용 제거, 동작은 동일)

## 검증

- 현재 PR head 기준 모든 필수 GitHub Actions 체크 통과(pass): Changed paths, Fast check, Fast check + non-PG tests, Fast targeted tests, High-risk recovery, Lint, Script checks 및 관련 required-context 체크.
- skip된 잡(Dashboard Node 22, matrix OS 변형, PostgreSQL tests)은 이 변경 범위와 무관하게 정상적으로 건너뜀.
- 로컬에서 `cargo`/테스트를 직접 실행하지 않았으며, 검증 근거는 위 CI 결과에 한정한다.
- 모든 변경은 동작 보존 리팩터링(같은 삭제 대상, 같은 폴백 동작)으로, 관측 가능한 출력 변화는 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
