### PR TITLE
feat(config): hot-reload agentdesk.yaml without a restart

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -833,6 +833,7 @@ src/
 ├── app_state.rs
 ├── bootstrap.rs
 ├── config.rs
+├── config_live_reload.rs
 ├── credential.rs
 ├── error.rs
 ├── eventbus.rs
@@ -876,6 +877,7 @@ This table is generated from the current `src/` root and fails CI when a new top
 | `src/app_state.rs` | Shared HTTP route-handler state (`AppState`); lives at crate root below server+services so service-layer handlers reference it without a service→server backflow. |
 | `src/bootstrap.rs` | Builds config, database, policy engine, and shared app state before launch. |
 | `src/config.rs` | `agentdesk.yaml` parsing, configuration defaults, and shared test env helpers. |
+| `src/config_live_reload.rs` | Hot-reloads `agentdesk.yaml` without a restart: a debounced `notify` watcher pre-validates edits and atomically swaps a process-global config snapshot, keeping the running config on failure and reporting restart-required infra changes. |
 | `src/credential.rs` | Reads runtime credential files such as Discord bot tokens from the AgentDesk root. |
 | `src/error.rs` | Shared HTTP and policy error type with typed codes and JSON response helpers. |
 | `src/eventbus.rs` | In-process broadcast event bus (history/replay/batching) shared by the WS server layer and background services without a service→server backflow. |

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -957,8 +957,8 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2272 lines).
-  - `src/server/mod.rs` (2410 lines).
+  - `src/config.rs` (2299 lines).
+  - `src/server/mod.rs` (2427 lines).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1488 lines).
   - `src/reconcile.rs` (1821 lines; periodic reconcile loop covering stale

--- a/scripts/generate_inventory_docs.py
+++ b/scripts/generate_inventory_docs.py
@@ -105,6 +105,7 @@ TOP_LEVEL_MODULE_PURPOSES = {
     "compat/": "Centralised home for compatibility/legacy/fallback shims (#1076). Each public item carries a `REMOVE_WHEN` comment so retirement is grep-driven.",
     "app_state.rs": "Shared HTTP route-handler state (`AppState`); lives at crate root below server+services so service-layer handlers reference it without a service→server backflow.",
     "config.rs": "`agentdesk.yaml` parsing, configuration defaults, and shared test env helpers.",
+    "config_live_reload.rs": "Hot-reloads `agentdesk.yaml` without a restart: a debounced `notify` watcher pre-validates edits and atomically swaps a process-global config snapshot, keeping the running config on failure and reporting restart-required infra changes.",
     "credential.rs": "Reads runtime credential files such as Discord bot tokens from the AgentDesk root.",
     "db/": "SQLite access layer and schema authority (`src/db/schema.rs`).",
     "dispatch/": "Dispatch context construction, review metadata, and worktree targeting.",

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,16 @@ pub struct Config {
         skip_serializing_if = "PromptManifestRetentionConfig::is_default"
     )]
     pub prompt_manifest_retention: PromptManifestRetentionConfig,
+    /// When true (default), the server watches the on-disk config file and
+    /// hot-reloads the hot-swappable settings (routine tunables, thresholds)
+    /// without a restart, mirroring the policies watcher: the candidate file is
+    /// pre-validated (parsed + runtime defaults applied) and only then atomically
+    /// swapped in; a parse/validation failure keeps the running config. Infra
+    /// fields (`server` bind/port/auth, `database`, `data.dir`) are NOT
+    /// hot-swapped — a change to those is applied to the shared snapshot but
+    /// logged as restart-required, since live subsystems bound them at boot.
+    #[serde(default = "default_true")]
+    pub config_hot_reload: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -2100,6 +2110,7 @@ impl Default for Config {
             memory: None,
             mcp: McpConfig::default(),
             prompt_manifest_retention: PromptManifestRetentionConfig::default(),
+            config_hot_reload: default_true(),
         }
         .apply_runtime_defaults()
     }
@@ -2133,6 +2144,22 @@ pub fn load() -> Result<Config> {
     std::fs::create_dir_all(&config.data.dir)?;
 
     Ok(config)
+}
+
+/// The on-disk config path the running server loaded from, resolved with the
+/// same precedence as [`load`] (`$AGENTDESK_CONFIG` → runtime root → cwd → home).
+/// Used by the config file watcher so it reloads from the exact same file the
+/// boot path read. The returned path is the resolved canonical candidate even if
+/// it does not currently exist (matching the graceful resolver).
+pub fn resolved_config_path() -> PathBuf {
+    resolve_graceful_config_path(
+        std::env::var("AGENTDESK_CONFIG")
+            .ok()
+            .map(std::path::PathBuf::from),
+        runtime_root(),
+        std::env::current_dir().ok(),
+        dirs::home_dir(),
+    )
 }
 
 pub fn load_from_path(path: &Path) -> Result<Config> {

--- a/src/config_live_reload.rs
+++ b/src/config_live_reload.rs
@@ -1,0 +1,342 @@
+//! Live config file hot-reload.
+//!
+//! Mirrors the policies watcher (`engine::loader::start_hot_reload`) for the
+//! on-disk AgentDesk config file (`agentdesk.yaml`): a `notify` filesystem
+//! watcher debounces change events, the candidate file is **pre-validated**
+//! (parsed + runtime defaults applied via [`crate::config::load_from_path`]),
+//! and only on success is the new config **atomically swapped** into a shared
+//! process-global snapshot. A parse/validation failure keeps the currently
+//! running config (logged), so a half-written or broken edit never takes the
+//! server down.
+//!
+//! ## What is live vs. restart-required
+//!
+//! Subsystems read the live snapshot via [`current`] each cycle, so settings
+//! they re-read per tick (e.g. routine tunables) take effect without a restart.
+//! Infra fields (`server` bind/port/auth, `database`, `data`) are bound into
+//! long-lived objects at boot and cannot be swapped under a running process; a
+//! change to those is still stored in the snapshot but reported by
+//! [`restart_required_changes`] and logged as restart-required.
+//!
+//! The whole-`Config` value is NOT threaded through every reader — instead this
+//! follows the existing global-runtime-setter precedent
+//! (`set_runtime_cluster_config`) so consumers opt in by reading [`current`].
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock, RwLock};
+use std::time::{Duration, Instant};
+
+use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use serde::Serialize;
+
+use crate::config::Config;
+
+/// Process-global live config snapshot. `None` until [`install`] runs at boot.
+static LIVE: OnceLock<RwLock<Arc<Config>>> = OnceLock::new();
+
+/// Debounce window for collapsing bursts of filesystem events (editors emit
+/// several per save). Matches the policies watcher.
+const DEBOUNCE: Duration = Duration::from_millis(500);
+
+/// Outcome of a single reload attempt. Returned by [`reload_from_path`] so the
+/// watcher, an on-demand trigger, and tests can all share the same core path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReloadOutcome {
+    /// The candidate validated and was swapped in. `restart_required` lists the
+    /// infra sections that changed and need a restart to take full effect.
+    Applied { restart_required: Vec<&'static str> },
+    /// The candidate failed to parse/validate; the running config was kept.
+    Rejected { error: String },
+}
+
+/// Install the boot config as the initial live snapshot. Safe to call again to
+/// overwrite (e.g. after a post-migration reload).
+pub fn install(config: Config) {
+    store(Arc::new(config));
+}
+
+/// The current live config snapshot, or `None` if [`install`] has not run yet
+/// (callers should fall back to their boot-captured config in that case).
+pub fn current() -> Option<Arc<Config>> {
+    LIVE.get().map(|lock| {
+        lock.read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    })
+}
+
+fn store(config: Arc<Config>) {
+    let lock = LIVE.get_or_init(|| RwLock::new(config.clone()));
+    *lock
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = config;
+}
+
+/// Two config values' section serializes differently. Used to detect changes
+/// without requiring `PartialEq` on every config sub-struct; an un-serializable
+/// section conservatively counts as changed.
+fn section_changed<T: Serialize>(old: &T, new: &T) -> bool {
+    match (serde_yaml::to_string(old), serde_yaml::to_string(new)) {
+        (Ok(a), Ok(b)) => a != b,
+        _ => true,
+    }
+}
+
+/// The infra sections that are bound at boot and cannot be hot-swapped under a
+/// running process. A change here is applied to the snapshot but needs a restart
+/// to take full effect.
+pub fn restart_required_changes(old: &Config, new: &Config) -> Vec<&'static str> {
+    let mut changed = Vec::new();
+    if section_changed(&old.server, &new.server) {
+        changed.push("server");
+    }
+    if section_changed(&old.database, &new.database) {
+        changed.push("database");
+    }
+    if section_changed(&old.data, &new.data) {
+        changed.push("data");
+    }
+    changed
+}
+
+/// Re-read, validate, and (on success) atomically swap in the config at `path`.
+/// On failure the running snapshot is left untouched. This is the shared core
+/// used by the watcher; expose it so an on-demand trigger can reuse it.
+pub fn reload_from_path(path: &Path) -> ReloadOutcome {
+    match crate::config::load_from_path(path) {
+        Ok(new_config) => {
+            let restart_required = current()
+                .map(|old| restart_required_changes(&old, &new_config))
+                .unwrap_or_default();
+            store(Arc::new(new_config));
+            ReloadOutcome::Applied { restart_required }
+        }
+        Err(error) => ReloadOutcome::Rejected {
+            error: format!("{error:#}"),
+        },
+    }
+}
+
+/// Guard returned by [`start`]; keeps the watcher and worker thread alive and
+/// joins the worker on drop. Mirrors `engine::loader::HotReloadGuard`.
+pub struct ConfigHotReloadGuard {
+    _watcher: Option<RecommendedWatcher>,
+    join: Option<std::thread::JoinHandle<()>>,
+    stop: Arc<AtomicBool>,
+}
+
+impl Drop for ConfigHotReloadGuard {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+/// Start watching `path`'s directory and hot-reloading it on change. Returns
+/// `None` (and logs) when disabled or when the watch cannot be established
+/// (e.g. the parent directory does not exist), so the caller simply runs without
+/// live reload — never a hard failure.
+pub fn start(path: PathBuf, enabled: bool) -> Option<ConfigHotReloadGuard> {
+    if !enabled {
+        return None;
+    }
+    let Some(dir) = path.parent().map(Path::to_path_buf) else {
+        tracing::warn!(
+            path = %path.display(),
+            "config hot-reload: config path has no parent dir; disabled"
+        );
+        return None;
+    };
+    if !dir.exists() {
+        tracing::warn!(
+            dir = %dir.display(),
+            "config hot-reload: config directory does not exist; disabled"
+        );
+        return None;
+    }
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    // Watch the parent directory (not the file) so atomic rename-on-save —
+    // write `agentdesk.yaml.tmp`, then rename over `agentdesk.yaml` — is still
+    // observed; watching the inode directly misses the swap.
+    let mut watcher =
+        match notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+            if let Ok(event) = res
+                && matches!(
+                    event.kind,
+                    EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+                )
+            {
+                let _ = tx.send(event);
+            }
+        }) {
+            Ok(watcher) => watcher,
+            Err(error) => {
+                tracing::warn!(%error, "config hot-reload: failed to create watcher; disabled");
+                return None;
+            }
+        };
+    if let Err(error) = watcher.watch(&dir, RecursiveMode::NonRecursive) {
+        tracing::warn!(%error, dir = %dir.display(), "config hot-reload: watch failed; disabled");
+        return None;
+    }
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_worker = stop.clone();
+    let target_name = path.file_name().map(std::ffi::OsString::from);
+    let path_display = path.display().to_string();
+    let join = std::thread::Builder::new()
+        .name("config-hot-reload".into())
+        .spawn(move || {
+            let mut last_reload = Instant::now() - DEBOUNCE;
+            loop {
+                if stop_worker.load(Ordering::Acquire) {
+                    break;
+                }
+                match rx.recv_timeout(Duration::from_millis(250)) {
+                    Ok(event) => {
+                        if stop_worker.load(Ordering::Acquire) {
+                            break;
+                        }
+                        // Ignore events for sibling files in the directory.
+                        let touches_target = target_name.as_ref().is_none_or(|name| {
+                            event
+                                .paths
+                                .iter()
+                                .any(|p| p.file_name() == Some(name.as_os_str()))
+                        });
+                        if !touches_target {
+                            continue;
+                        }
+                        if last_reload.elapsed() < DEBOUNCE {
+                            while rx.try_recv().is_ok() {}
+                            continue;
+                        }
+                        // Drain the rest of the burst, then reload once.
+                        while rx.try_recv().is_ok() {}
+                        last_reload = Instant::now();
+                        match reload_from_path(&path) {
+                            ReloadOutcome::Applied { restart_required } if restart_required.is_empty() => {
+                                tracing::info!(
+                                    path = %path.display(),
+                                    "config hot-reload applied"
+                                );
+                            }
+                            ReloadOutcome::Applied { restart_required } => {
+                                tracing::warn!(
+                                    path = %path.display(),
+                                    restart_required = restart_required.join(","),
+                                    "config hot-reload applied; some sections changed that need a restart to take full effect"
+                                );
+                            }
+                            ReloadOutcome::Rejected { error } => {
+                                tracing::warn!(
+                                    path = %path.display(),
+                                    %error,
+                                    "config hot-reload rejected invalid config; keeping running config"
+                                );
+                            }
+                        }
+                    }
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                }
+            }
+        })
+        .ok();
+
+    if join.is_none() {
+        tracing::warn!("config hot-reload: failed to spawn worker thread; disabled");
+        return None;
+    }
+
+    tracing::info!(path = %path_display, "config file hot-reload watching enabled");
+    Some(ConfigHotReloadGuard {
+        _watcher: Some(watcher),
+        join,
+        stop,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Serializes tests that mutate/read the process-global [`LIVE`] snapshot so
+    /// they do not race each other under the parallel test runner.
+    fn global_test_guard() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn write(path: &Path, body: &str) {
+        std::fs::write(path, body).unwrap();
+    }
+
+    // A valid edit validates and swaps into the live snapshot.
+    #[test]
+    fn reload_applies_valid_config() {
+        let _guard = global_test_guard();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agentdesk.yaml");
+        write(&path, "server:\n  port: 8791\n");
+        install(crate::config::load_from_path(&path).unwrap());
+
+        write(&path, "server:\n  port: 8799\n");
+        let outcome = reload_from_path(&path);
+        assert!(matches!(outcome, ReloadOutcome::Applied { .. }));
+        assert_eq!(current().unwrap().server.port, 8799);
+    }
+
+    // A broken edit is rejected and the running snapshot is preserved.
+    #[test]
+    fn reload_rejects_invalid_config_and_keeps_current() {
+        let _guard = global_test_guard();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agentdesk.yaml");
+        write(&path, "server:\n  port: 8791\n");
+        install(crate::config::load_from_path(&path).unwrap());
+        let before = current().unwrap().server.port;
+
+        write(&path, "server:\n  port: : not valid yaml :::\n");
+        let outcome = reload_from_path(&path);
+        assert!(matches!(outcome, ReloadOutcome::Rejected { .. }));
+        assert_eq!(
+            current().unwrap().server.port,
+            before,
+            "rejected reload must not mutate the live snapshot"
+        );
+    }
+
+    // Infra-section changes are surfaced as restart-required.
+    #[test]
+    fn restart_required_changes_flags_infra_sections() {
+        let mut old = Config::default();
+        old.server.port = 8791;
+        let mut new = old.clone();
+
+        assert!(restart_required_changes(&old, &new).is_empty());
+
+        new.server.port = 9000;
+        assert_eq!(restart_required_changes(&old, &new), vec!["server"]);
+
+        new = old.clone();
+        new.data.dir = old.data.dir.join("moved");
+        assert_eq!(restart_required_changes(&old, &new), vec!["data"]);
+    }
+
+    // A hot-swappable-only change (routine tunable) reports no restart-required.
+    #[test]
+    fn routine_tunable_change_needs_no_restart() {
+        let old = Config::default();
+        let mut new = old.clone();
+        new.routines.max_agent_polls_per_tick =
+            old.routines.max_agent_polls_per_tick.wrapping_add(1);
+        assert!(restart_required_changes(&old, &new).is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,7 @@ pub(crate) mod compat;
 // Config helpers are shared by CLI/server/tests, with some provider-onboarding
 // helpers only called from rollout flows.
 mod config;
+pub(crate) mod config_live_reload;
 pub(crate) mod credential;
 // Database repositories intentionally expose cross-route helpers that are only
 // wired from selected API/maintenance paths.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -263,6 +263,15 @@ pub(crate) async fn run(
     pg_pool: Option<PgPool>,
 ) -> Result<()> {
     crate::services::dispatches::wait_queue::set_runtime_cluster_config(config.cluster.clone());
+    // Publish the boot config as the shared live snapshot and (when enabled)
+    // start the config-file watcher so hot-swappable settings reload without a
+    // restart, mirroring the policies watcher. The guard is held for the
+    // lifetime of `run`; dropping it on shutdown joins the watcher thread.
+    crate::config_live_reload::install(config.clone());
+    let _config_hot_reload_guard = crate::config_live_reload::start(
+        crate::config::resolved_config_path(),
+        config.config_hot_reload,
+    );
     let pg_pool = match pg_pool {
         Some(pool) => Some(pool),
         None => crate::db::postgres::connect_and_migrate(&config)
@@ -2531,6 +2540,14 @@ async fn routine_runtime_loop(
         tokio::time::interval(std::time::Duration::from_secs(tick_interval_secs.get()));
     loop {
         interval.tick().await;
+        // Per-tick tunables (hot_reload toggle, poll/due-per-tick caps) are read
+        // from the live config snapshot so a config-file edit takes effect on the
+        // next tick without a restart. Boot-bound values (script dirs, store
+        // timezone/checkpoint limits, agent timeout) keep their startup values
+        // because they are already wired into long-lived objects above.
+        let routines_config = crate::config_live_reload::current()
+            .map(|cfg| cfg.routines.clone())
+            .unwrap_or_else(|| routines_config.clone());
         match store.recover_stale_running_runs().await {
             Ok(recovered) if !recovered.is_empty() => {
                 for run in &recovered {


### PR DESCRIPTION
## 목표

`agentdesk.yaml`의 hot-swap 가능한 설정(루틴 튜너블, 임계값 등)을 서버 재시작 없이 파일 편집만으로 반영한다. policies 워처와 동일한 방식으로 후보 파일을 먼저 검증한 뒤 성공한 경우에만 프로세스 전역 라이브 스냅샷에 원자적으로 교체하며, 파싱/검증에 실패한 편집은 거부하고 실행 중인 설정을 그대로 유지한다. infra 필드(`server`/`database`/`data`)는 스냅샷에는 반영하되 restart-required로 분류해 부팅에 바인딩된 객체와의 불일치를 막는 것이 목표 후속 상태다.

## 쉬운 설명

운영 중에 `agentdesk.yaml`을 고치면 서버를 껐다 켜지 않아도 다음 틱에 새 값이 적용된다. 단, 파일을 잘못 저장하거나 깨진 YAML을 쓰면 그 편집은 무시되고 기존 설정으로 계속 동작한다. 포트/DB/데이터 경로 같은 인프라 항목을 바꾸면 스냅샷엔 들어가지만 "재시작 필요" 경고가 로그에 남는다. 기능은 `config_hot_reload` 플래그(기본 켜짐)로 끌 수 있다.

## 개선되는 것

### Fix 1 — 설정 파일 라이브 hot-reload 도입

- Before: `agentdesk.yaml`의 어떤 값을 바꾸든 프로세스 재시작 전까지 반영되지 않았다. 부팅 시 읽은 설정이 전 생애주기 동안 고정.
- After: 파일 변경을 `notify` 워처가 감지(편집기 저장 버스트는 500ms 디바운스, 부모 디렉터리 감시로 atomic rename 저장도 포착)하고, 후보를 `config::load_from_path`로 파싱+런타임 기본값 적용해 검증한 뒤 성공 시에만 라이브 스냅샷을 원자적으로 교체한다. 검증 실패 편집은 거부되어 실행 중 설정이 유지되므로 절반만 써진 파일이 서버를 죽이지 않는다.

### Fix 2 — 루틴 런타임 틱을 첫 라이브 소비자로 배선

- Before: 루틴 런타임 루프는 부팅 시 캡처한 `routines` 설정만 사용했다.
- After: 매 틱마다 `config_live_reload::current()`에서 `routines` 스냅샷을 다시 읽어 튜너블(hot_reload 토글, tick당 poll/due 상한)을 다음 틱부터 반영한다. 스냅샷 부재 시 부팅값으로 폴백한다. 단, 부팅에 이미 바인딩된 값(스크립트 디렉터리, store 타임존/체크포인트 한도, agent 타임아웃)은 long-lived 객체에 묶여 있어 시작값을 유지한다.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| `agentdesk.yaml`의 루틴 튜너블 편집 | 재시작 전까지 무반영 | 다음 루틴 틱에 자동 반영, 로그 `config hot-reload applied` |
| 깨진/절반만 써진 YAML 저장 | (재시작 시) 부팅 실패 위험 | 거부 + 기존 설정 유지, `keeping running config` 경고 |
| `server`/`database`/`data` 변경 | 무반영 | 스냅샷엔 반영, `restart_required`로 분류해 재시작 필요 경고 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| `config_hot_reload=false` 또는 부모 디렉터리 부재 | `start`가 `None` 반환, 워처 미가동 | hot-reload 없이 정상 기동, 하드 실패 아님 |
| 디렉터리 내 형제 파일 변경 이벤트 | 대상 파일명 불일치 시 무시 | 무관한 저장이 reload를 유발하지 않음 |
| 종료 시 가드 drop | `stop` 플래그 set 후 워커 스레드 join | 워처 스레드 누수 없이 정리 |

## 해결한 내용

- `src/config_live_reload.rs` (신규, 342줄): 라이브 hot-reload 코어. `OnceLock<RwLock<Arc<Config>>>` 전역 스냅샷과 `install`/`current`, 검증 후 원자 교체 `reload_from_path`(→ `ReloadOutcome::Applied{restart_required}` / `Rejected{error}`), serde 직렬화 비교 기반 `restart_required_changes`(infra 섹션 변경 감지), drop 시 워커를 join하는 `ConfigHotReloadGuard`와 디바운스/디렉터리 감시 워처 `start`. apply/reject/restart-required/no-restart 분류 단위 테스트 포함. policies 워처와 전역-runtime-setter 선례를 따라 전체 `Config`를 모든 reader에 스레딩하지 않고 opt-in `current()` 방식을 채택한 이유.
- `src/config.rs` (+27): 기본 true인 `config_hot_reload` 필드 추가(켜짐 의미와 hot-swap vs restart-required 경계를 doc-comment로 명시)와, 부팅과 동일 우선순위(`$AGENTDESK_CONFIG`→runtime root→cwd→home)로 워처가 같은 파일을 읽도록 경로를 해석하는 `resolved_config_path()`. 워처가 부팅 경로와 다른 파일을 보는 불일치를 방지하기 위함.
- `src/server/mod.rs` (+17): `server::run` 부팅 배선 — 부팅 설정을 라이브 스냅샷으로 publish하고 플래그에 따라 워처 `start`(가드는 `run` 생애주기 동안 보유, drop 시 워처 스레드 join). 루틴 런타임 루프는 매 틱 `current()`에서 `routines` 설정을 다시 읽고, 스냅샷 부재 시 부팅값으로 폴백.
- `src/lib.rs` (+1): `config_live_reload` 모듈 선언(`pub(crate)`).

## 검증

- CI 대응(2026-06-15): `config_live_reload.rs`를 아키텍처 맵(ARCHITECTURE.md/inventory)에 등록 + change-surfaces freeze 라인카운트 동기화(config.rs 2299, server/mod.rs 2427). → Script checks 통과.

- CI(run 27497306849, head 기준): ubuntu 계열은 모두 통과 — Lint, PostgreSQL tests (ubuntu-postgres), Fast check + non-PG tests (ubuntu-latest), High-risk recovery, Fast targeted tests, Changed paths 등.
- 코드 내 단위 테스트(`config_live_reload::tests`): 유효 설정 적용/swap, 잘못된 YAML 거부 시 스냅샷 보존, infra 섹션 restart-required 분류, 루틴 튜너블 변경 시 no-restart를 검증. ubuntu non-PG/targeted 테스트 잡이 통과한 범위에 포함됨. (로컬 cargo 실행은 하지 않음.)
- 실패 3건 중 windows fast-check 2건은 이 PR과 무관한 base/systemic 이슈:
  - `Fast check + non-PG tests (windows-latest)`와 이를 미러하는 `Fast check cross OS required context (ubuntu-latest)`는 `error[E0433]: could not find 'tmux' in 'discord'`로 실패한다. 이 PR diff는 tmux/discord를 건드리지 않으므로 base의 알려진 windows 이슈다.
- 남은 실패 1건(`Script checks`)은 이 PR이 유발함, 솔직히 명시: `inventory generation failed: top-level architecture map drift: missing descriptions for config_live_reload.rs`. 신규 파일 `config_live_reload.rs`가 top-level 아키텍처 맵/인벤토리에 설명으로 등록되지 않아 drift로 잡힌다. systemic git-callsite 게이트가 아니라 신규 파일 누락이므로, 아키텍처 맵에 `config_live_reload.rs` 설명을 추가하면 해소된다.

