### PR TITLE
feat(config): make follow-up TUI prompt-ready timeout configurable

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -957,7 +957,7 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2307 lines).
+  - `src/config.rs` (2320 lines).
   - `src/server/mod.rs` (2430 lines).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1488 lines).
@@ -1063,11 +1063,11 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   separator unified across the streamed `StreamMessage::Text` surface and the
   `final_text` assembly (one shared `push_message_text` boundary writer; the
   newline witness is the single source of truth so the two surfaces mirror).
-- `src/services/codex_tui/input.rs` (1350) — Codex TUI input readiness
+- `src/services/codex_tui/input.rs` (1366) — Codex TUI input readiness
   detector and prompt delivery surface (#2399 hardened the post-turn
   handoff deadline). Treat as giant-file territory; split before adding
   non-bugfix behavior beyond the readiness/cancel contract.
-- `src/services/claude_tui/input.rs` (1485) — Claude TUI input readiness
+- `src/services/claude_tui/input.rs` (1501) — Claude TUI input readiness
   detector, prompt delivery, and cancellation/offset handoff surface. Treat as
   giant-file territory; split before adding non-bugfix behavior beyond the
   readiness/cancel contract. (+191 from the #685/#720 reliability fixes:

--- a/src/config.rs
+++ b/src/config.rs
@@ -1341,6 +1341,18 @@ pub struct RuntimeSettingsConfig {
     pub github_repo_cache_sec: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rate_limit_stale_sec: Option<u64>,
+    /// Optional override (seconds) for the Follow-up TUI prompt-readiness wait.
+    /// When unset (or `0`), both the Claude and Codex TUI follow-up waits keep
+    /// the compiled-in 45s default (`FOLLOWUP_PROMPT_READY_TIMEOUT`). Read live
+    /// via `config_live_reload::current()` so an `agentdesk.yaml` edit applies
+    /// on the next readiness wait without a restart.
+    ///
+    /// Note: the Claude follow-up wait is still bounded by an independent 900s
+    /// busy-turn ceiling (`PROMPT_READY_ACTIVE_TURN_WAIT_CEILING`), but the Codex
+    /// follow-up wait has no such ceiling, so a very large value lets a long
+    /// prior Codex turn block the follow-up wait for the full configured duration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub followup_prompt_ready_timeout_secs: Option<u64>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub reset_overrides_on_restart: bool,
 }
@@ -1371,6 +1383,7 @@ impl RuntimeSettingsConfig {
             && self.rate_limit_danger_pct.is_none()
             && self.github_repo_cache_sec.is_none()
             && self.rate_limit_stale_sec.is_none()
+            && self.followup_prompt_ready_timeout_secs.is_none()
             && !self.reset_overrides_on_restart
     }
 }

--- a/src/services/claude_tui/input.rs
+++ b/src/services/claude_tui/input.rs
@@ -54,11 +54,27 @@ pub enum PromptReadinessKind {
     Followup,
 }
 
+/// Resolve the Follow-up readiness budget from the live config snapshot,
+/// falling back to the compiled-in 45s default. `config_live_reload::current()`
+/// returns `None` before boot install and in unit tests, so the const stays the
+/// safe fallback. A configured `0` is treated as unset to avoid an
+/// immediate-timeout footgun. See `RuntimeSettingsConfig::followup_prompt_ready_timeout_secs`.
+fn followup_prompt_ready_timeout() -> Duration {
+    crate::config_live_reload::current()
+        .and_then(|cfg| cfg.runtime.followup_prompt_ready_timeout_secs)
+        .filter(|secs| *secs > 0)
+        // Clamp to a generous upper bound (24h) so a bad hot-reload value (e.g.
+        // u64::MAX) cannot overflow `Instant + Duration` at the deadline
+        // computation and panic the readiness wait.
+        .map(|secs| Duration::from_secs(secs.min(86_400)))
+        .unwrap_or(FOLLOWUP_PROMPT_READY_TIMEOUT)
+}
+
 impl PromptReadinessKind {
     fn timeout(self) -> Duration {
         match self {
             Self::FreshTurn => FRESH_PROMPT_READY_TIMEOUT,
-            Self::Followup => FOLLOWUP_PROMPT_READY_TIMEOUT,
+            Self::Followup => followup_prompt_ready_timeout(),
         }
     }
 
@@ -1522,6 +1538,19 @@ fn split_literal_chunks(input: &str, max_chars: usize) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn followup_timeout_falls_back_to_default_without_live_config() {
+        // No config_live_reload::install() runs in unit tests, so current() is
+        // None and the compiled-in 45s default must hold byte-for-byte. The
+        // fresh-turn budget must stay independent.
+        assert_eq!(
+            followup_prompt_ready_timeout(),
+            FOLLOWUP_PROMPT_READY_TIMEOUT
+        );
+        assert_eq!(PromptReadinessKind::Followup.timeout().as_secs(), 45);
+        assert_eq!(PromptReadinessKind::FreshTurn.timeout().as_secs(), 120);
+    }
 
     #[test]
     fn prompt_submit_uses_literal_chunks_then_enter() {

--- a/src/services/codex_tui/input.rs
+++ b/src/services/codex_tui/input.rs
@@ -155,11 +155,27 @@ pub enum PromptReadinessKind {
     PostTurnHandoff,
 }
 
+/// Resolve the Follow-up readiness budget from the live config snapshot,
+/// falling back to the compiled-in 45s default. `config_live_reload::current()`
+/// returns `None` before boot install and in unit tests, so the const stays the
+/// safe fallback. A configured `0` is treated as unset to avoid an
+/// immediate-timeout footgun. See `RuntimeSettingsConfig::followup_prompt_ready_timeout_secs`.
+fn followup_prompt_ready_timeout() -> Duration {
+    crate::config_live_reload::current()
+        .and_then(|cfg| cfg.runtime.followup_prompt_ready_timeout_secs)
+        .filter(|secs| *secs > 0)
+        // Clamp to a generous upper bound (24h) so a bad hot-reload value (e.g.
+        // u64::MAX) cannot overflow `Instant + Duration` at the deadline
+        // computation and panic the readiness wait.
+        .map(|secs| Duration::from_secs(secs.min(86_400)))
+        .unwrap_or(FOLLOWUP_PROMPT_READY_TIMEOUT)
+}
+
 impl PromptReadinessKind {
     fn timeout(self) -> Duration {
         match self {
             Self::FreshTurn => FRESH_PROMPT_READY_TIMEOUT,
-            Self::Followup => FOLLOWUP_PROMPT_READY_TIMEOUT,
+            Self::Followup => followup_prompt_ready_timeout(),
             Self::PostTurnHandoff => POST_TURN_HANDOFF_PROBE_TIMEOUT,
         }
     }
@@ -1356,6 +1372,22 @@ mod tests {
     #[cfg(windows)]
     use std::os::windows::process::ExitStatusExt;
     use std::sync::atomic::Ordering;
+
+    #[test]
+    fn followup_timeout_falls_back_to_default_without_live_config() {
+        // current() is None in unit tests -> 45s default holds; the other arms
+        // (FreshTurn 120s, PostTurnHandoff 200ms) must be unchanged.
+        assert_eq!(
+            followup_prompt_ready_timeout(),
+            FOLLOWUP_PROMPT_READY_TIMEOUT
+        );
+        assert_eq!(PromptReadinessKind::Followup.timeout().as_secs(), 45);
+        assert_eq!(PromptReadinessKind::FreshTurn.timeout().as_secs(), 120);
+        assert_eq!(
+            PromptReadinessKind::PostTurnHandoff.timeout().as_millis(),
+            200
+        );
+    }
 
     #[cfg(unix)]
     fn successful_exit_status() -> std::process::ExitStatus {


### PR DESCRIPTION
## 목표

Follow-up TUI 프롬프트 준비 대기 시간(45초)을 코드 수정 없이 `agentdesk.yaml`로 조정할 수 있게 한다. 기존에는 Claude/Codex TUI 양쪽 모두 `FOLLOWUP_PROMPT_READY_TIMEOUT` 상수에 하드코딩되어 운영자가 follow-up 주입 창을 늘리려면 코드를 패치·재빌드해야 했다. `RuntimeSettingsConfig`에 `followup_prompt_ready_timeout_secs` 필드를 추가하고 두 provider가 라이브 설정 스냅샷에서 이 값을 읽도록 하여, 미설정 시 45초 기본값을 byte-identical하게 유지하면서 설정 시 재시작 없이 핫리로드로 적용되는 상태가 목표다.

## 쉬운 설명

follow-up 메시지를 주입할 때 프롬프트가 준비되기를 기다리는 시간이 지금은 45초로 고정이고, 이를 바꾸려면 소스 코드를 고쳐야 했습니다. 이제 `agentdesk.yaml`의 `runtime.followup_prompt_ready_timeout_secs` 값을 적으면 그 시간만큼 대기합니다. 값을 적지 않으면 기존과 똑같이 45초로 동작합니다. 설정을 바꿔도 재시작 없이 다음 대기부터 바로 적용됩니다.

## 개선되는 것

### Fix 1 — Follow-up 준비 대기 타임아웃 설정화 (Claude + Codex TUI)

- Before: `claude_tui`/`codex_tui` 양쪽에서 `PromptReadinessKind::Followup` arm이 상수 `FOLLOWUP_PROMPT_READY_TIMEOUT`(45초)에 고정. 운영자가 대기 창을 늘리려면 코드 패치 후 재빌드 필요. `agentdesk.yaml`에는 매칭되는 `RuntimeSettingsConfig` 필드가 없어 설정해도 no-op였음.
- After: `RuntimeSettingsConfig.followup_prompt_ready_timeout_secs: Option<u64>` 추가. 두 provider가 새 헬퍼 `followup_prompt_ready_timeout()`로 `config_live_reload::current()` 라이브 스냅샷에서 값을 읽어 `Followup` 준비 예산으로 사용. 미설정/`0`/부팅 install 이전(및 단위 테스트)에는 45초 상수로 폴백. 잘못된 값(예: `u64::MAX`)에 의한 `Instant + Duration` 오버플로 패닉을 막기 위해 24시간(86,400초) 상한으로 클램프. `FreshTurn`/`PostTurnHandoff` arm은 변경 없음.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| `followup_prompt_ready_timeout_secs` 미설정 | 45초 고정 | 45초 (byte-identical 폴백) |
| `agentdesk.yaml`에 `120` 설정 | 무시됨 (필드 없음, no-op) | 다음 readiness 대기부터 120초 적용 (재시작 불필요, 핫리로드) |
| `0` 설정 / 부팅 전 / 단위 테스트 | 해당 없음 | `0`은 즉시 타임아웃 footgun 방지 위해 미설정으로 취급 → 45초 폴백 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 비정상적으로 큰 값(`u64::MAX`) 핫리로드 | 86,400초로 클램프 후 `Duration` 생성 | deadline 계산 시 `Instant + Duration` 오버플로 패닉 회피 |
| Codex follow-up에 매우 큰 값 설정 | Codex에는 Claude의 900s busy-turn ceiling(`PROMPT_READY_ACTIVE_TURN_WAIT_CEILING`)이 없음 | 긴 직전 Codex 턴이 설정 시간 전체만큼 follow-up 대기를 막을 수 있음 (config.rs 주석으로 명시) |
| `current() == None` (부팅 전 / 단위 테스트) | 라이브 스냅샷 없음 → 상수 폴백 | 45초 보장, FreshTurn(120s)/PostTurnHandoff(200ms)는 독립 유지 |

## 해결한 내용

- `src/config.rs`: `RuntimeSettingsConfig`에 `followup_prompt_ready_timeout_secs: Option<u64>` 필드 추가(`#[serde(default, skip_serializing_if = "Option::is_none")]`)와 doc 코멘트(45초 폴백·핫리로드·Codex ceiling 부재 경고). `is_empty()`에 해당 필드 `is_none()` 조건을 추가해 빈 설정 직렬화 생략 동작 유지. WHY: 운영자 노출 설정 키를 단일 소스로 정의하고 빈 설정 직렬화 계약을 깨지 않기 위함.
- `src/services/claude_tui/input.rs`: `followup_prompt_ready_timeout()` 헬퍼 추가(라이브 스냅샷 읽기 · `0` 필터 · 24h 클램프 · 상수 폴백). `PromptReadinessKind::timeout()`의 `Followup` arm을 헬퍼 호출로 교체, `FreshTurn` arm은 그대로. 폴백 단위 테스트 추가. WHY: Claude follow-up 대기 예산만 설정 가능하게 하되 다른 arm 불변을 회귀 테스트로 고정.
- `src/services/codex_tui/input.rs`: 동일한 `followup_prompt_ready_timeout()` 헬퍼와 `Followup` arm 교체. `FreshTurn`/`PostTurnHandoff` arm은 변경 없음. 폴백 단위 테스트 추가(45초/FreshTurn 120s/PostTurnHandoff 200ms 보장). WHY: 두 provider의 동작을 동일 규칙으로 맞추고 Codex의 추가 arm까지 불변 검증.

## 검증

- 로컬에서 cargo를 실행하지 않았다. 아래는 `gh pr checks 3443`의 실제 현재 CI 결과다.
- 현재 이 브랜치의 CI는 **실패** 상태이며 머지 가능하지 않다. `Fast check`, `Fast check + non-PG tests (ubuntu/windows)`, `Lint`, `High-risk recovery`, `PostgreSQL tests`, `Script checks` 등 required check 대부분이 fail이다.
- 실패 원인: 추가된 헬퍼가 참조하는 `crate::config_live_reload` 모듈이 이 저장소 `main` 크레이트 루트에 아직 없어 컴파일이 깨진다(체리픽이 main에 없는 모듈 의존성을 끌어옴, `E0433` 계열). 이는 선행 스택 PR #3442(`config_live_reload` 모듈 추가)가 main에 먼저 머지돼야 해소되는 stack 의존성 문제이며, windows `cargo check` E0433 'could not find tmux'나 Script checks의 git callsite hard-gate 같은 systemic base 이슈와는 별개다.
- 통과한 것은 경로 필터/대시보드 컨텍스트뿐: `Changed paths` pass, `Dashboard required context` pass, `Dashboard (Node 22)` skipping.
- 코드 변경에는 두 모듈의 폴백 단위 테스트(`followup_timeout_falls_back_to_default_without_live_config`)가 포함되어 45초 폴백과 타 arm 불변을 검증하나, 위 컴파일 실패로 현재 CI에서 실행·통과가 확인되지 않았다. 머지 전 #3442 선행 머지로 `config_live_reload` 의존성을 먼저 해결해야 한다.
