### PR TITLE
feat(routines): durable agent fallback retry (durability + contract + tests)

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -893,7 +893,7 @@
     relocated the `require_explicit_bearer_token` /
     `resolve_requesting_agent_id_with_pg` auth/identity helpers to
     `crate::services::kanban`).
-  - `src/server/routes/docs.rs` (5884 lines; +4 from #3293 documenting
+  - `src/server/routes/docs.rs` (5900 lines; +4 from #3293 documenting
     the stale-mailbox repair `purge` body param + registry-purge response
     fields).
   - `src/server/routes/escalation.rs` (1376 lines).
@@ -957,8 +957,8 @@
   (supervised-worker registry / leader-only lifecycle).
 - legacy_modules: none — these are shared runtime coordination surfaces.
 - do_not_edit_without_migration_plan (giant-file):
-  - `src/config.rs` (2299 lines).
-  - `src/server/mod.rs` (2427 lines).
+  - `src/config.rs` (2307 lines).
+  - `src/server/mod.rs` (2430 lines).
   - `src/receipt.rs` (1842 lines).
   - `src/github/sync.rs` (1488 lines).
   - `src/reconcile.rs` (1821 lines; periodic reconcile loop covering stale

--- a/migrations/postgres/0072_routine_fallback_retry.sql
+++ b/migrations/postgres/0072_routine_fallback_retry.sql
@@ -10,7 +10,7 @@ ALTER TABLE IF EXISTS routines
     ADD COLUMN IF NOT EXISTS max_retries INTEGER NOT NULL DEFAULT 0;
 
 ALTER TABLE IF EXISTS routine_runs
-    ADD COLUMN IF NOT EXISTS retry_count INTEGER NOT NULL DEFAULT 0;
+    ADD COLUMN IF NOT EXISTS retry_count INTEGER NOT NULL DEFAULT 0; -- agentdesk-audit: allow-int4 (retry_count is bounded by max_retries; small retry counter, not unbounded growth)
 
 ALTER TABLE IF EXISTS routine_runs
     ADD COLUMN IF NOT EXISTS next_retry_at TIMESTAMPTZ;

--- a/migrations/postgres/0072_routine_fallback_retry.sql
+++ b/migrations/postgres/0072_routine_fallback_retry.sql
@@ -1,0 +1,26 @@
+-- Routine agent fallback/retry durability.
+--
+-- The retry wait state stays on the running routine_runs row so the parent
+-- routines.in_flight_run_id guard continues to prevent duplicate claims.
+
+ALTER TABLE IF EXISTS routines
+    ADD COLUMN IF NOT EXISTS fallback_agent_id TEXT REFERENCES agents(id) ON DELETE SET NULL;
+
+ALTER TABLE IF EXISTS routines
+    ADD COLUMN IF NOT EXISTS max_retries INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE IF EXISTS routine_runs
+    ADD COLUMN IF NOT EXISTS retry_count INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE IF EXISTS routine_runs
+    ADD COLUMN IF NOT EXISTS next_retry_at TIMESTAMPTZ;
+
+ALTER TABLE IF EXISTS routine_runs
+    ADD COLUMN IF NOT EXISTS attempts JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+CREATE INDEX IF NOT EXISTS idx_routine_runs_running_agent_retry
+    ON routine_runs(next_retry_at)
+    WHERE status = 'running'
+      AND action = 'agent'
+      AND turn_id IS NULL
+      AND next_retry_at IS NOT NULL;

--- a/migrations/postgres/immutable-checksums.json
+++ b/migrations/postgres/immutable-checksums.json
@@ -373,7 +373,7 @@
     },
     {
       "path": "migrations/postgres/0072_routine_fallback_retry.sql",
-      "sha256": "0b688ac9daf46d45a76ea478cf0414642f4df3fc482f83324827a02ce02b0121",
+      "sha256": "336477f77b991437c60ed8b559e3bac67369367c0b5c8d95f5f2df98ba3d0b7f",
       "version": 72
     }
   ],

--- a/migrations/postgres/immutable-checksums.json
+++ b/migrations/postgres/immutable-checksums.json
@@ -370,6 +370,11 @@
       "path": "migrations/postgres/0071_sessions_channel_id.sql",
       "sha256": "41d2fe1d89c2d9007b1dcef72ee174b1b61cda0159ea86d0a8ab108fbad1098a",
       "version": 71
+    },
+    {
+      "path": "migrations/postgres/0072_routine_fallback_retry.sql",
+      "sha256": "0b688ac9daf46d45a76ea478cf0414642f4df3fc482f83324827a02ce02b0121",
+      "version": 72
     }
   ],
   "version": 1

--- a/src/config.rs
+++ b/src/config.rs
@@ -1907,6 +1907,9 @@ pub struct RoutinesConfig {
     /// Default maximum wait for agent-backed routine completion, in seconds.
     #[serde(default = "default_routines_agent_timeout_secs")]
     pub agent_timeout_secs: u64,
+    /// Maximum serialized checkpoint payload accepted from a routine run.
+    #[serde(default = "default_routines_max_checkpoint_bytes")]
+    pub max_checkpoint_bytes: usize,
     /// Watch `dir` for script changes and reload without restart.
     #[serde(default = "default_true")]
     pub hot_reload: bool,
@@ -1923,6 +1926,7 @@ impl Default for RoutinesConfig {
             max_agent_polls_per_tick: default_routines_max_agent_polls_per_tick(),
             default_timezone: default_routines_timezone(),
             agent_timeout_secs: default_routines_agent_timeout_secs(),
+            max_checkpoint_bytes: default_routines_max_checkpoint_bytes(),
             hot_reload: true,
         }
     }
@@ -1966,6 +1970,10 @@ fn default_routines_timezone() -> String {
 
 fn default_routines_agent_timeout_secs() -> u64 {
     30 * 60
+}
+
+fn default_routines_max_checkpoint_bytes() -> usize {
+    256 * 1024
 }
 
 #[cfg(test)]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2507,8 +2507,11 @@ async fn routine_runtime_loop(
         Err(e) => tracing::warn!(error = %e, "routine script registry initialization failed"),
     }
 
-    let store =
-        RoutineStore::new_with_timezone(pg_pool.clone(), routines_config.default_timezone.clone());
+    let store = RoutineStore::new_with_timezone_and_checkpoint_limit(
+        pg_pool.clone(),
+        routines_config.default_timezone.clone(),
+        routines_config.max_checkpoint_bytes,
+    );
     let discord_logger = RoutineDiscordLogger::new_with_health_registry(
         pg_pool.clone(),
         health_registry.clone(),

--- a/src/server/routes/docs.rs
+++ b/src/server/routes/docs.rs
@@ -3883,7 +3883,7 @@ fn all_endpoints() -> Vec<EndpointDoc> {
         ])
         .with_example(
             json!({"query": {"status": "enabled"}}),
-            json!({"routines": [{"id": "routine-1", "script_ref": "daily-summary.js", "status": "enabled"}]}),
+            json!({"routines": [{"id": "routine-1", "script_ref": "daily-summary.js", "status": "enabled", "fallback_agent_id": "claude", "max_retries": 1}], "default_timeout_secs": 1800}),
         ),
         ep(
             "GET",
@@ -3981,7 +3981,7 @@ fn all_endpoints() -> Vec<EndpointDoc> {
         .with_params([("id", path_param("Routine id"))])
         .with_example(
             json!({"path": {"id": "routine-1"}}),
-            json!({"routine": {"id": "routine-1", "script_ref": "daily-summary.js"}}),
+            json!({"routine": {"id": "routine-1", "script_ref": "daily-summary.js", "fallback_agent_id": "claude", "max_retries": 1}, "default_timeout_secs": 1800}),
         ),
         ep(
             "PATCH",

--- a/src/server/routes/docs.rs
+++ b/src/server/routes/docs.rs
@@ -3951,6 +3951,14 @@ fn all_endpoints() -> Vec<EndpointDoc> {
             ),
             ("name", body_param("string", false, "Human-readable routine name")),
             ("agent_id", body_param("string", false, "Optional attached agent id")),
+            (
+                "fallback_agent_id",
+                body_param("string", false, "Optional fallback agent id used after primary retry exhaustion"),
+            ),
+            (
+                "max_retries",
+                body_param("integer", false, "Maximum primary-agent retries before fallback/failure; default 0"),
+            ),
             ("execution_strategy", body_param("string", false, "fresh or persistent")),
             (
                 "schedule",
@@ -3961,7 +3969,7 @@ fn all_endpoints() -> Vec<EndpointDoc> {
             ("timeout_secs", body_param("integer", false, "Optional per-routine agent timeout in seconds")),
         ])
         .with_example(
-            json!({"body": {"script_ref": "daily-summary.js", "name": "Daily Summary", "execution_strategy": "fresh"}}),
+            json!({"body": {"script_ref": "daily-summary.js", "name": "Daily Summary", "agent_id": "codex", "fallback_agent_id": "claude", "max_retries": 1, "execution_strategy": "fresh"}}),
             json!({"routine": {"id": "routine-1", "script_ref": "daily-summary.js", "status": "enabled"}, "discord_log": {"status": "skipped"}}),
         ),
         ep(
@@ -3985,6 +3993,14 @@ fn all_endpoints() -> Vec<EndpointDoc> {
             ("id", path_param("Routine id")),
             ("name", body_param("string", false, "New routine name")),
             (
+                "fallback_agent_id",
+                body_param("string|null", false, "Fallback agent id or null to clear it"),
+            ),
+            (
+                "max_retries",
+                body_param("integer", false, "Maximum primary-agent retries before fallback/failure"),
+            ),
+            (
                 "execution_strategy",
                 body_param("string", false, "fresh or persistent"),
             ),
@@ -3998,7 +4014,7 @@ fn all_endpoints() -> Vec<EndpointDoc> {
             ),
             (
                 "checkpoint",
-                body_param("object|null", false, "Replacement checkpoint JSON or null to clear it"),
+                body_param("object|null", false, "Replacement checkpoint JSON or null to clear it; run-produced checkpoints are capped by routines.max_checkpoint_bytes"),
             ),
             (
                 "discord_thread_id",

--- a/src/server/routes/routines.rs
+++ b/src/server/routes/routines.rs
@@ -51,6 +51,8 @@ pub struct SearchRoutineRunResultsQuery {
 #[derive(Debug, Deserialize)]
 pub struct AttachRoutineBody {
     pub agent_id: Option<String>,
+    pub fallback_agent_id: Option<String>,
+    pub max_retries: Option<i32>,
     pub script_ref: String,
     pub name: Option<String>,
     pub execution_strategy: Option<String>,
@@ -64,6 +66,9 @@ pub struct AttachRoutineBody {
 #[derive(Debug, Deserialize)]
 pub struct PatchRoutineBody {
     pub name: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_patch_field")]
+    fallback_agent_id: PatchField<Option<String>>,
+    pub max_retries: Option<i32>,
     pub execution_strategy: Option<String>,
     #[serde(default, deserialize_with = "deserialize_patch_field")]
     schedule: PatchField<Option<String>>,
@@ -136,6 +141,8 @@ impl PatchRoutineBody {
     fn into_patch(self) -> RoutinePatch {
         RoutinePatch {
             name: self.name,
+            fallback_agent_id: self.fallback_agent_id.into_option(),
+            max_retries: self.max_retries,
             execution_strategy: self.execution_strategy,
             schedule: self.schedule.into_option(),
             next_due_at: self.next_due_at.into_option(),
@@ -260,10 +267,20 @@ pub async fn attach_routine(
     validate_execution_strategy_request(&execution_strategy)?;
     validate_schedule_request(body.schedule.as_deref())?;
     validate_timeout_request(body.timeout_secs)?;
+    validate_max_retries_request(body.max_retries)?;
+    let agent_id = validate_agent_id_request(&state, "agent_id", body.agent_id.as_deref()).await?;
+    let fallback_agent_id = validate_agent_id_request(
+        &state,
+        "fallback_agent_id",
+        body.fallback_agent_id.as_deref(),
+    )
+    .await?;
     let initial_status = initial_attach_status(&script_ref).to_string();
     let routine = store
         .attach_routine(NewRoutine {
-            agent_id: body.agent_id,
+            agent_id,
+            fallback_agent_id,
+            max_retries: body.max_retries,
             script_ref,
             name,
             status: Some(initial_status),
@@ -299,6 +316,11 @@ pub async fn patch_routine(
     }
     if let Some(timeout_secs) = body.timeout_secs.as_present().copied().flatten() {
         validate_timeout_request(Some(timeout_secs))?;
+    }
+    validate_max_retries_request(body.max_retries)?;
+    if let Some(fallback_agent_id) = body.fallback_agent_id.as_present() {
+        validate_agent_id_request(&state, "fallback_agent_id", fallback_agent_id.as_deref())
+            .await?;
     }
     let patch = body.into_patch();
     let Some(routine) = store
@@ -615,9 +637,10 @@ fn routine_store(state: &AppState) -> AppResult<RoutineStore> {
             "postgres pool unavailable; routines require postgresql",
         ));
     };
-    Ok(RoutineStore::new_with_timezone(
+    Ok(RoutineStore::new_with_timezone_and_checkpoint_limit(
         std::sync::Arc::new(pool),
         state.config.routines.default_timezone.clone(),
+        state.config.routines.max_checkpoint_bytes,
     ))
 }
 
@@ -723,6 +746,38 @@ fn validate_timeout_request(timeout_secs: Option<i32>) -> AppResult<()> {
         ));
     }
     Ok(())
+}
+
+fn validate_max_retries_request(max_retries: Option<i32>) -> AppResult<()> {
+    if matches!(max_retries, Some(value) if value < 0) {
+        return Err(AppError::bad_request(
+            "routine max_retries must be greater than or equal to zero",
+        ));
+    }
+    Ok(())
+}
+
+async fn validate_agent_id_request(
+    state: &AppState,
+    field_name: &str,
+    agent_id: Option<&str>,
+) -> AppResult<Option<String>> {
+    let Some(agent_id) = agent_id.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    let Some(pool) = state.pg_pool.as_ref() else {
+        return Err(AppError::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            ErrorCode::Database,
+            "postgres pool unavailable; routines require postgresql",
+        ));
+    };
+    match crate::db::kanban_cards::resolve_existing_agent_id_with_pg(pool, agent_id).await {
+        Some(existing) => Ok(Some(existing)),
+        None => Err(AppError::bad_request(format!(
+            "routine {field_name} references unknown agent '{agent_id}'"
+        ))),
+    }
 }
 
 fn routine_health_target(config: &Config) -> Option<String> {

--- a/src/server/routes/routines.rs
+++ b/src/server/routes/routines.rs
@@ -162,7 +162,10 @@ pub async fn list_routines(
         .list_routines(query.agent_id.as_deref(), query.status.as_deref())
         .await
         .map_err(store_error)?;
-    Ok(Json(json!({ "routines": routines })))
+    Ok(Json(json!({
+        "routines": routines,
+        "default_timeout_secs": state.config.routines.agent_timeout_secs,
+    })))
 }
 
 pub async fn routine_metrics(
@@ -228,7 +231,10 @@ pub async fn get_routine(
             "routine {routine_id} not found"
         )));
     };
-    Ok(Json(json!({ "routine": routine })))
+    Ok(Json(json!({
+        "routine": routine,
+        "default_timeout_secs": state.config.routines.agent_timeout_secs,
+    })))
 }
 
 pub async fn list_routine_runs(
@@ -275,6 +281,7 @@ pub async fn attach_routine(
         body.fallback_agent_id.as_deref(),
     )
     .await?;
+    validate_distinct_fallback_agent(agent_id.as_deref(), fallback_agent_id.as_deref())?;
     let initial_status = initial_attach_status(&script_ref).to_string();
     let routine = store
         .attach_routine(NewRoutine {
@@ -319,8 +326,18 @@ pub async fn patch_routine(
     }
     validate_max_retries_request(body.max_retries)?;
     if let Some(fallback_agent_id) = body.fallback_agent_id.as_present() {
-        validate_agent_id_request(&state, "fallback_agent_id", fallback_agent_id.as_deref())
-            .await?;
+        let fallback_agent_id =
+            validate_agent_id_request(&state, "fallback_agent_id", fallback_agent_id.as_deref())
+                .await?;
+        let current = store
+            .get_routine(&routine_id)
+            .await
+            .map_err(store_error)?
+            .ok_or_else(|| AppError::not_found(format!("routine {routine_id} not found")))?;
+        validate_distinct_fallback_agent(
+            current.agent_id.as_deref(),
+            fallback_agent_id.as_deref(),
+        )?;
     }
     let patch = body.into_patch();
     let Some(routine) = store
@@ -780,6 +797,27 @@ async fn validate_agent_id_request(
     }
 }
 
+fn validate_distinct_fallback_agent(
+    agent_id: Option<&str>,
+    fallback_agent_id: Option<&str>,
+) -> AppResult<()> {
+    let Some(agent_id) = agent_id.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(());
+    };
+    let Some(fallback_agent_id) = fallback_agent_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(());
+    };
+    if agent_id == fallback_agent_id {
+        return Err(AppError::bad_request(
+            "routine fallback_agent_id must differ from agent_id",
+        ));
+    }
+    Ok(())
+}
+
 fn routine_health_target(config: &Config) -> Option<String> {
     config
         .kanban
@@ -820,6 +858,7 @@ mod tests {
     use super::{
         PARALLEL_SAFE_MIGRATED_LAUNCHD_SCRIPT_REF, PatchRoutineBody, ResumeRoutineBody,
         ensure_routine_runtime_runnable, initial_attach_status, normalize_script_ref, store_error,
+        validate_distinct_fallback_agent,
     };
     use crate::config::RoutinesConfig;
     use crate::error::ErrorCode;
@@ -833,6 +872,17 @@ mod tests {
         assert_eq!(err.status(), StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(err.code(), ErrorCode::Config);
         assert_eq!(err.message(), "routines are disabled by config");
+    }
+
+    #[test]
+    fn fallback_agent_must_differ_from_primary_agent() {
+        assert!(validate_distinct_fallback_agent(Some("codex"), Some("claude")).is_ok());
+        assert!(validate_distinct_fallback_agent(None, Some("claude")).is_ok());
+        assert!(validate_distinct_fallback_agent(Some("codex"), None).is_ok());
+
+        let err = validate_distinct_fallback_agent(Some("codex"), Some("codex"))
+            .expect_err("self fallback must be rejected");
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
     }
 
     #[test]

--- a/src/services/routines/agent_executor.rs
+++ b/src/services/routines/agent_executor.rs
@@ -188,128 +188,126 @@ impl RoutineAgentExecutor {
         message: &str,
         action: String,
     ) -> Result<RoutineRunOutcome> {
-        if claimed.max_retries > 0 && attempt_kind != "fallback" {
-            let retry_at = retry_next_at(0);
-            let result_json = Some(retry_scheduled_result_for_claimed(
-                &claimed,
-                failed_agent_id,
-                attempt_kind,
-                message,
-                &prompt,
-                retry_at,
-                1,
-                &checkpoint,
-                next_due_at,
-            ));
-            let scheduled = store
-                .schedule_agent_retry(
-                    &claimed.run_id,
-                    retry_at,
-                    result_json.clone(),
-                    message,
-                    Some(failed_agent_id),
-                    attempt_kind,
-                )
-                .await?;
-            if !scheduled {
-                return Err(anyhow!(
-                    "routine agent run {} was already closed before retry scheduling",
-                    claimed.run_id
-                ));
-            }
-            return Ok(RoutineRunOutcome {
-                run_id: claimed.run_id,
-                routine_id: claimed.routine_id,
-                script_ref: claimed.script_ref,
-                action,
-                status: "running".to_string(),
-                result_json,
-                error: Some(message.to_string()),
-                fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
-            });
-        }
-
-        let fallback_agent_id = claimed
-            .fallback_agent_id
-            .as_deref()
-            .filter(|value| !value.trim().is_empty())
-            .filter(|value| *value != failed_agent_id)
-            .map(str::to_string);
-        if let Some(fallback_agent_id) = fallback_agent_id
-            && attempt_kind != "fallback"
-        {
-            match self
-                .start_turn(
-                    store,
+        match claimed_failure_recovery_plan(&claimed, failed_agent_id, attempt_kind) {
+            AgentFailureRecoveryPlan::Retry {
+                retry_count_after_increment,
+                next_retry_at: retry_at,
+            } => {
+                let result_json = Some(retry_scheduled_result_for_claimed(
                     &claimed,
-                    &fallback_agent_id,
-                    "fallback",
+                    failed_agent_id,
+                    attempt_kind,
+                    message,
                     &prompt,
-                    dm_user_id.as_deref(),
+                    retry_at,
+                    retry_count_after_increment,
                     &checkpoint,
                     next_due_at,
-                )
-                .await
-            {
-                Ok(started) if started.started => {
-                    return Ok(RoutineRunOutcome {
-                        run_id: claimed.run_id,
-                        routine_id: claimed.routine_id,
-                        script_ref: claimed.script_ref,
-                        action,
-                        status: "running".to_string(),
-                        result_json: Some(started.result_json),
-                        error: Some(message.to_string()),
-                        fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
-                    });
-                }
-                Ok(started) => {
-                    let last_result =
-                        "fallback headless command consumed without starting an agent turn";
-                    let closed = store
-                        .complete_agent_run(
-                            &claimed.run_id,
-                            Some(started.result_json.clone()),
-                            checkpoint,
-                            Some(last_result),
-                            match next_due_at {
-                                Some(value) => NextDueAtUpdate::Set(value),
-                                None => NextDueAtUpdate::Preserve,
-                            },
-                        )
-                        .await?;
-                    if !closed {
-                        return Err(anyhow!(
-                            "routine agent run {} was already closed before fallback consumed outcome",
-                            claimed.run_id
-                        ));
-                    }
-                    return Ok(RoutineRunOutcome {
-                        run_id: claimed.run_id,
-                        routine_id: claimed.routine_id,
-                        script_ref: claimed.script_ref,
-                        action,
-                        status: "succeeded".to_string(),
-                        result_json: Some(started.result_json),
-                        error: Some(message.to_string()),
-                        fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
-                    });
-                }
-                Err(fallback_error) => {
-                    let combined = format!(
-                        "{message}; fallback agent {fallback_agent_id} failed: {fallback_error}"
-                    );
-                    return fail_claimed_agent_run(
-                        store,
-                        claimed,
-                        action,
-                        combined,
-                        Some(&fallback_agent_id),
-                        "fallback",
+                ));
+                let scheduled = store
+                    .schedule_agent_retry(
+                        &claimed.run_id,
+                        retry_at,
+                        result_json.clone(),
+                        message,
+                        Some(failed_agent_id),
+                        attempt_kind,
                     )
-                    .await;
+                    .await?;
+                if !scheduled {
+                    return Err(anyhow!(
+                        "routine agent run {} was already closed before retry scheduling",
+                        claimed.run_id
+                    ));
+                }
+                return Ok(RoutineRunOutcome {
+                    run_id: claimed.run_id,
+                    routine_id: claimed.routine_id,
+                    script_ref: claimed.script_ref,
+                    action,
+                    status: "running".to_string(),
+                    result_json,
+                    error: Some(message.to_string()),
+                    fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
+                });
+            }
+            AgentFailureRecoveryPlan::Fallback {
+                agent_id: fallback_agent_id,
+            } => {
+                match self
+                    .start_turn(
+                        store,
+                        &claimed,
+                        &fallback_agent_id,
+                        "fallback",
+                        &prompt,
+                        dm_user_id.as_deref(),
+                        &checkpoint,
+                        next_due_at,
+                    )
+                    .await
+                {
+                    Ok(started) if started.started => {
+                        return Ok(RoutineRunOutcome {
+                            run_id: claimed.run_id,
+                            routine_id: claimed.routine_id,
+                            script_ref: claimed.script_ref,
+                            action,
+                            status: "running".to_string(),
+                            result_json: Some(started.result_json),
+                            error: Some(message.to_string()),
+                            fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
+                        });
+                    }
+                    Ok(started) => {
+                        let last_result =
+                            "fallback headless command consumed without starting an agent turn";
+                        let closed = store
+                            .complete_agent_run(
+                                &claimed.run_id,
+                                Some(started.result_json.clone()),
+                                checkpoint,
+                                Some(last_result),
+                                match next_due_at {
+                                    Some(value) => NextDueAtUpdate::Set(value),
+                                    None => NextDueAtUpdate::Preserve,
+                                },
+                            )
+                            .await?;
+                        if !closed {
+                            return Err(anyhow!(
+                                "routine agent run {} was already closed before fallback consumed outcome",
+                                claimed.run_id
+                            ));
+                        }
+                        return Ok(RoutineRunOutcome {
+                            run_id: claimed.run_id,
+                            routine_id: claimed.routine_id,
+                            script_ref: claimed.script_ref,
+                            action,
+                            status: "succeeded".to_string(),
+                            result_json: Some(started.result_json),
+                            error: Some(message.to_string()),
+                            fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
+                        });
+                    }
+                    Err(fallback_error) => {
+                        let combined = format!(
+                            "{message}; fallback agent {fallback_agent_id} failed: {fallback_error}"
+                        );
+                        return fail_claimed_agent_run(
+                            store,
+                            claimed,
+                            action,
+                            combined,
+                            Some(&fallback_agent_id),
+                            "fallback",
+                        )
+                        .await;
+                    }
                 }
             }
+            AgentFailureRecoveryPlan::Fail => {}
         }
 
         fail_claimed_agent_run(
@@ -547,136 +545,58 @@ impl RoutineAgentExecutor {
         failed_agent_id: Option<&str>,
         attempt_kind: &str,
     ) -> Result<Option<RoutineRunOutcome>> {
-        if attempt_kind != "fallback" && run.retry_count < run.max_retries {
-            let next_retry_at = retry_next_at(run.retry_count);
-            let retry_count = run.retry_count + 1;
-            let mut retry_result = result_json.unwrap_or_else(|| {
-                merge_pending_result(&run, "retry_scheduled", Some(message), None)
-            });
-            if let Some(object) = retry_result.as_object_mut() {
-                object.insert(
-                    "status".to_string(),
-                    Value::String("retry_scheduled".to_string()),
-                );
-                object.insert(
-                    "retry_count".to_string(),
-                    Value::Number(serde_json::Number::from(retry_count)),
-                );
-                object.insert(
-                    "next_retry_at".to_string(),
-                    Value::String(next_retry_at.to_rfc3339()),
-                );
-            }
-            preserve_pending_agent_state(&mut retry_result, run.result_json.as_ref());
-            let result_json = Some(retry_result);
-            let scheduled = store
-                .schedule_agent_retry(
-                    &run.run_id,
-                    next_retry_at,
-                    result_json.clone(),
-                    message,
-                    failed_agent_id,
-                    attempt_kind,
-                )
-                .await?;
-            return Ok(scheduled.then(|| RoutineRunOutcome {
-                run_id: run.run_id,
-                routine_id: run.routine_id,
-                script_ref: run.script_ref,
-                action: "agent".to_string(),
-                status: "running".to_string(),
-                result_json,
-                error: Some(message.to_string()),
-                fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
-            }));
-        }
-
-        let fallback_agent_id = run
-            .fallback_agent_id
-            .as_deref()
-            .filter(|value| !value.trim().is_empty())
-            .filter(|value| Some(*value) != failed_agent_id)
-            .filter(|_| attempt_kind != "fallback")
-            .filter(|_| !attempts_include_fallback(&run.attempts))
-            .map(str::to_string);
-        if let Some(fallback_agent_id) = fallback_agent_id {
-            let Some(prompt) = pending_prompt(run.result_json.as_ref()).map(str::to_string) else {
-                let closed = store
-                    .fail_agent_run(&run.run_id, message, result_json.clone(), None)
+        match running_failure_recovery_plan(&run, failed_agent_id, attempt_kind) {
+            AgentFailureRecoveryPlan::Retry {
+                retry_count_after_increment: retry_count,
+                next_retry_at,
+            } => {
+                let mut retry_result = result_json.unwrap_or_else(|| {
+                    merge_pending_result(&run, "retry_scheduled", Some(message), None)
+                });
+                if let Some(object) = retry_result.as_object_mut() {
+                    object.insert(
+                        "status".to_string(),
+                        Value::String("retry_scheduled".to_string()),
+                    );
+                    object.insert(
+                        "retry_count".to_string(),
+                        Value::Number(serde_json::Number::from(retry_count)),
+                    );
+                    object.insert(
+                        "next_retry_at".to_string(),
+                        Value::String(next_retry_at.to_rfc3339()),
+                    );
+                }
+                preserve_pending_agent_state(&mut retry_result, run.result_json.as_ref());
+                let result_json = Some(retry_result);
+                let scheduled = store
+                    .schedule_agent_retry(
+                        &run.run_id,
+                        next_retry_at,
+                        result_json.clone(),
+                        message,
+                        failed_agent_id,
+                        attempt_kind,
+                    )
                     .await?;
-                return Ok(closed.then(|| RoutineRunOutcome {
+                return Ok(scheduled.then(|| RoutineRunOutcome {
                     run_id: run.run_id,
                     routine_id: run.routine_id,
                     script_ref: run.script_ref,
                     action: "agent".to_string(),
-                    status: "failed".to_string(),
+                    status: "running".to_string(),
                     result_json,
                     error: Some(message.to_string()),
                     fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
                 }));
-            };
-            let checkpoint = pending_checkpoint(run.result_json.as_ref());
-            let next_due_at = pending_next_due_at(run.result_json.as_ref());
-            let claimed = claimed_from_running_run(&run);
-            match self
-                .start_turn(
-                    store,
-                    &claimed,
-                    &fallback_agent_id,
-                    "fallback",
-                    &prompt,
-                    None,
-                    &checkpoint,
-                    next_due_at,
-                )
-                .await
-            {
-                Ok(started) if started.started => {
-                    return Ok(Some(RoutineRunOutcome {
-                        run_id: run.run_id,
-                        routine_id: run.routine_id,
-                        script_ref: run.script_ref,
-                        action: "agent".to_string(),
-                        status: "running".to_string(),
-                        result_json: Some(started.result_json),
-                        error: Some(message.to_string()),
-                        fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
-                    }));
-                }
-                Ok(started) => {
-                    let last_result =
-                        "fallback headless command consumed without starting an agent turn";
+            }
+            AgentFailureRecoveryPlan::Fallback {
+                agent_id: fallback_agent_id,
+            } => {
+                let Some(prompt) = pending_prompt(run.result_json.as_ref()).map(str::to_string)
+                else {
                     let closed = store
-                        .complete_agent_run(
-                            &run.run_id,
-                            Some(started.result_json.clone()),
-                            checkpoint,
-                            Some(last_result),
-                            match next_due_at {
-                                Some(value) => NextDueAtUpdate::Set(value),
-                                None => NextDueAtUpdate::Preserve,
-                            },
-                        )
-                        .await?;
-                    return Ok(closed.then(|| RoutineRunOutcome {
-                        run_id: run.run_id,
-                        routine_id: run.routine_id,
-                        script_ref: run.script_ref,
-                        action: "agent".to_string(),
-                        status: "succeeded".to_string(),
-                        result_json: Some(started.result_json),
-                        error: Some(message.to_string()),
-                        fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
-                    }));
-                }
-                Err(fallback_error) => {
-                    let combined = format!(
-                        "{message}; fallback agent {fallback_agent_id} failed: {fallback_error}"
-                    );
-                    let result_json =
-                        Some(merge_pending_result(&run, "failed", Some(&combined), None));
-                    let closed = store
-                        .fail_agent_run(&run.run_id, &combined, result_json.clone(), None)
+                        .fail_agent_run(&run.run_id, message, result_json.clone(), None)
                         .await?;
                     return Ok(closed.then(|| RoutineRunOutcome {
                         run_id: run.run_id,
@@ -685,11 +605,87 @@ impl RoutineAgentExecutor {
                         action: "agent".to_string(),
                         status: "failed".to_string(),
                         result_json,
-                        error: Some(combined),
+                        error: Some(message.to_string()),
                         fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
                     }));
+                };
+                let checkpoint = pending_checkpoint(run.result_json.as_ref());
+                let next_due_at = pending_next_due_at(run.result_json.as_ref());
+                let claimed = claimed_from_running_run(&run);
+                match self
+                    .start_turn(
+                        store,
+                        &claimed,
+                        &fallback_agent_id,
+                        "fallback",
+                        &prompt,
+                        None,
+                        &checkpoint,
+                        next_due_at,
+                    )
+                    .await
+                {
+                    Ok(started) if started.started => {
+                        return Ok(Some(RoutineRunOutcome {
+                            run_id: run.run_id,
+                            routine_id: run.routine_id,
+                            script_ref: run.script_ref,
+                            action: "agent".to_string(),
+                            status: "running".to_string(),
+                            result_json: Some(started.result_json),
+                            error: Some(message.to_string()),
+                            fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
+                        }));
+                    }
+                    Ok(started) => {
+                        let last_result =
+                            "fallback headless command consumed without starting an agent turn";
+                        let closed = store
+                            .complete_agent_run(
+                                &run.run_id,
+                                Some(started.result_json.clone()),
+                                checkpoint,
+                                Some(last_result),
+                                match next_due_at {
+                                    Some(value) => NextDueAtUpdate::Set(value),
+                                    None => NextDueAtUpdate::Preserve,
+                                },
+                            )
+                            .await?;
+                        return Ok(closed.then(|| RoutineRunOutcome {
+                            run_id: run.run_id,
+                            routine_id: run.routine_id,
+                            script_ref: run.script_ref,
+                            action: "agent".to_string(),
+                            status: "succeeded".to_string(),
+                            result_json: Some(started.result_json),
+                            error: Some(message.to_string()),
+                            fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
+                        }));
+                    }
+                    Err(fallback_error) => {
+                        let combined = format!(
+                            "{message}; fallback agent {fallback_agent_id} failed: {fallback_error}"
+                        );
+                        let result_json =
+                            Some(merge_pending_result(&run, "failed", Some(&combined), None));
+                        let closed = store
+                            .fail_agent_run(&run.run_id, &combined, result_json.clone(), None)
+                            .await?;
+                        return Ok(closed.then(|| RoutineRunOutcome {
+                            run_id: run.run_id,
+                            routine_id: run.routine_id,
+                            script_ref: run.script_ref,
+                            action: "agent".to_string(),
+                            status: "failed".to_string(),
+                            result_json,
+                            error: Some(combined),
+                            fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
+                        }));
+                    }
                 }
             }
+            AgentFailureRecoveryPlan::Fail => {}
         }
 
         let result_json =
@@ -1724,6 +1720,68 @@ fn attempts_include_fallback(attempts: &Value) -> bool {
         .unwrap_or(false)
 }
 
+#[derive(Debug, Clone, PartialEq)]
+enum AgentFailureRecoveryPlan {
+    Retry {
+        retry_count_after_increment: i32,
+        next_retry_at: DateTime<Utc>,
+    },
+    Fallback {
+        agent_id: String,
+    },
+    Fail,
+}
+
+fn claimed_failure_recovery_plan(
+    claimed: &ClaimedRoutineRun,
+    failed_agent_id: &str,
+    attempt_kind: &str,
+) -> AgentFailureRecoveryPlan {
+    if claimed.max_retries > 0 && attempt_kind != "fallback" {
+        return AgentFailureRecoveryPlan::Retry {
+            retry_count_after_increment: 1,
+            next_retry_at: retry_next_at(0),
+        };
+    }
+
+    claimed
+        .fallback_agent_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .filter(|value| *value != failed_agent_id)
+        .filter(|_| attempt_kind != "fallback")
+        .map(|agent_id| AgentFailureRecoveryPlan::Fallback {
+            agent_id: agent_id.to_string(),
+        })
+        .unwrap_or(AgentFailureRecoveryPlan::Fail)
+}
+
+fn running_failure_recovery_plan(
+    run: &RunningAgentRoutineRun,
+    failed_agent_id: Option<&str>,
+    attempt_kind: &str,
+) -> AgentFailureRecoveryPlan {
+    if attempt_kind != "fallback" && run.retry_count < run.max_retries {
+        return AgentFailureRecoveryPlan::Retry {
+            retry_count_after_increment: run.retry_count + 1,
+            next_retry_at: retry_next_at(run.retry_count),
+        };
+    }
+
+    run.fallback_agent_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .filter(|value| Some(*value) != failed_agent_id)
+        .filter(|_| attempt_kind != "fallback")
+        .filter(|_| !attempts_include_fallback(&run.attempts))
+        .map(|agent_id| AgentFailureRecoveryPlan::Fallback {
+            agent_id: agent_id.to_string(),
+        })
+        .unwrap_or(AgentFailureRecoveryPlan::Fail)
+}
+
 fn claimed_from_running_run(run: &RunningAgentRoutineRun) -> ClaimedRoutineRun {
     ClaimedRoutineRun {
         run_id: run.run_id.clone(),
@@ -1908,6 +1966,23 @@ mod tests {
         }
     }
 
+    fn claimed_run() -> ClaimedRoutineRun {
+        ClaimedRoutineRun {
+            run_id: "run-1".to_string(),
+            routine_id: "routine-1".to_string(),
+            agent_id: Some("codex".to_string()),
+            fallback_agent_id: None,
+            max_retries: 0,
+            script_ref: "agent-checkpoint-review.js".to_string(),
+            name: "Agent Checkpoint Review".to_string(),
+            execution_strategy: "fresh".to_string(),
+            checkpoint: None,
+            discord_thread_id: None,
+            timeout_secs: None,
+            lease_expires_at: Utc::now(),
+        }
+    }
+
     fn completion_with_evidence(evidence: AgentTurnCompletionEvidence) -> AgentTurnCompletion {
         AgentTurnCompletion {
             assistant_message: match evidence {
@@ -1936,6 +2011,87 @@ mod tests {
         let capped = retry_next_at(5);
         assert!(capped >= before + chrono::Duration::seconds(899));
         assert!(capped <= before + chrono::Duration::seconds(901));
+    }
+
+    #[test]
+    fn claimed_failure_plan_retries_before_fallback() {
+        let claimed = ClaimedRoutineRun {
+            fallback_agent_id: Some("claude".to_string()),
+            max_retries: 2,
+            ..claimed_run()
+        };
+
+        match claimed_failure_recovery_plan(&claimed, "codex", "primary") {
+            AgentFailureRecoveryPlan::Retry {
+                retry_count_after_increment,
+                next_retry_at,
+            } => {
+                assert_eq!(retry_count_after_increment, 1);
+                assert!(next_retry_at > Utc::now());
+            }
+            other => panic!("expected retry before fallback, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn claimed_failure_plan_falls_back_when_retry_disabled() {
+        let claimed = ClaimedRoutineRun {
+            fallback_agent_id: Some("claude".to_string()),
+            max_retries: 0,
+            ..claimed_run()
+        };
+
+        assert_eq!(
+            claimed_failure_recovery_plan(&claimed, "codex", "primary"),
+            AgentFailureRecoveryPlan::Fallback {
+                agent_id: "claude".to_string()
+            }
+        );
+        assert_eq!(
+            claimed_failure_recovery_plan(&claimed, "claude", "fallback"),
+            AgentFailureRecoveryPlan::Fail
+        );
+    }
+
+    #[test]
+    fn running_failure_plan_retries_until_exhausted_then_fallback_once() {
+        let mut run = RunningAgentRoutineRun {
+            fallback_agent_id: Some("claude".to_string()),
+            max_retries: 2,
+            retry_count: 1,
+            attempts: json!([
+                {"event": "started", "kind": "primary", "agent_id": "codex"}
+            ]),
+            ..running_run_with_result(json!({"prompt": "recover me"}))
+        };
+
+        match running_failure_recovery_plan(&run, Some("codex"), "primary") {
+            AgentFailureRecoveryPlan::Retry {
+                retry_count_after_increment,
+                next_retry_at,
+            } => {
+                assert_eq!(retry_count_after_increment, 2);
+                assert!(next_retry_at > Utc::now());
+            }
+            other => panic!("expected final retry before fallback, got {other:?}"),
+        }
+
+        run.retry_count = 2;
+        assert_eq!(
+            running_failure_recovery_plan(&run, Some("codex"), "retry"),
+            AgentFailureRecoveryPlan::Fallback {
+                agent_id: "claude".to_string()
+            }
+        );
+
+        run.attempts = json!([
+            {"event": "started", "kind": "primary", "agent_id": "codex"},
+            {"event": "started", "kind": "fallback", "agent_id": "claude"}
+        ]);
+        assert_eq!(
+            running_failure_recovery_plan(&run, Some("codex"), "retry"),
+            AgentFailureRecoveryPlan::Fail
+        );
     }
 
     #[test]

--- a/src/services/routines/agent_executor.rs
+++ b/src/services/routines/agent_executor.rs
@@ -299,12 +299,28 @@ impl RoutineAgentExecutor {
                     let combined = format!(
                         "{message}; fallback agent {fallback_agent_id} failed: {fallback_error}"
                     );
-                    return fail_claimed_agent_run(store, claimed, action, combined).await;
+                    return fail_claimed_agent_run(
+                        store,
+                        claimed,
+                        action,
+                        combined,
+                        Some(&fallback_agent_id),
+                        "fallback",
+                    )
+                    .await;
                 }
             }
         }
 
-        fail_claimed_agent_run(store, claimed, action, message.to_string()).await
+        fail_claimed_agent_run(
+            store,
+            claimed,
+            action,
+            message.to_string(),
+            Some(failed_agent_id),
+            attempt_kind,
+        )
+        .await
     }
 
     pub async fn poll_agent_runs(
@@ -1475,10 +1491,14 @@ async fn fail_claimed_agent_run(
     claimed: ClaimedRoutineRun,
     action: String,
     message: String,
+    failed_agent_id: Option<&str>,
+    attempt_kind: &str,
 ) -> Result<RoutineRunOutcome> {
     let result_json = Some(json!({
         "status": "failed_to_start",
         "error": message,
+        "failed_agent_id": failed_agent_id,
+        "attempt_kind": attempt_kind,
         "routine_id": claimed.routine_id,
         "run_id": claimed.run_id,
         "script_ref": claimed.script_ref,
@@ -1506,8 +1526,10 @@ async fn fail_claimed_agent_run(
 }
 
 fn retry_next_at(retry_count_before_increment: i32) -> DateTime<Utc> {
-    let exponent = retry_count_before_increment.clamp(0, 5) as u32;
-    let secs = 30_i64.saturating_mul(2_i64.saturating_pow(exponent));
+    let exponent = retry_count_before_increment.max(0) as u32;
+    let secs = 60_i64
+        .saturating_mul(2_i64.saturating_pow(exponent))
+        .min(900);
     Utc::now() + Duration::seconds(secs)
 }
 
@@ -1600,7 +1622,13 @@ fn merge_pending_result(
 }
 
 fn with_started_run_routing_metadata(mut result: Value, started_result: Option<&Value>) -> Value {
-    const ROUTING_KEYS: &[&str] = &["channel_id", "parent_channel_id", "discord_thread_id"];
+    const ROUTING_KEYS: &[&str] = &[
+        "channel_id",
+        "parent_channel_id",
+        "discord_thread_id",
+        "agent_id",
+        "attempt_kind",
+    ];
 
     let Some(started_result) = started_result else {
         return result;
@@ -1901,10 +1929,13 @@ mod tests {
         let first = retry_next_at(0);
         let second = retry_next_at(1);
 
-        assert!(first >= before + chrono::Duration::seconds(29));
-        assert!(first <= before + chrono::Duration::seconds(31));
-        assert!(second >= before + chrono::Duration::seconds(59));
-        assert!(second <= before + chrono::Duration::seconds(61));
+        assert!(first >= before + chrono::Duration::seconds(59));
+        assert!(first <= before + chrono::Duration::seconds(61));
+        assert!(second >= before + chrono::Duration::seconds(119));
+        assert!(second <= before + chrono::Duration::seconds(121));
+        let capped = retry_next_at(5);
+        assert!(capped >= before + chrono::Duration::seconds(899));
+        assert!(capped <= before + chrono::Duration::seconds(901));
     }
 
     #[test]

--- a/src/services/routines/agent_executor.rs
+++ b/src/services/routines/agent_executor.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, anyhow};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, Utc};
 use serde_json::{Map, Value, json};
 use sqlx::PgPool;
 use std::sync::Arc;
@@ -96,10 +96,18 @@ impl RoutineAgentExecutor {
         next_due_at: Option<DateTime<Utc>>,
     ) -> Result<RoutineRunOutcome> {
         let action = "agent".to_string();
+        let agent_id = claimed
+            .agent_id
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| anyhow!("routine agent action requires routine.agent_id"))?
+            .to_string();
         let result = self
             .start_turn(
                 store,
                 &claimed,
+                &agent_id,
+                "primary",
                 &prompt,
                 dm_user_id.as_deref(),
                 &checkpoint,
@@ -150,35 +158,153 @@ impl RoutineAgentExecutor {
             }
             Err(error) => {
                 let message = error.to_string();
-                let result_json = Some(json!({
-                    "status": "failed_to_start",
-                    "error": message,
-                    "routine_id": claimed.routine_id,
-                    "run_id": claimed.run_id,
-                    "script_ref": claimed.script_ref,
-                    "fresh_context_guaranteed": FRESH_CONTEXT_GUARANTEED,
-                }));
-                let closed = store
-                    .fail_agent_run(&claimed.run_id, &message, result_json.clone(), None)
-                    .await?;
-                if !closed {
-                    return Err(anyhow!(
-                        "routine agent run {} was already closed before failed outcome",
-                        claimed.run_id
-                    ));
-                }
-                Ok(RoutineRunOutcome {
-                    run_id: claimed.run_id,
-                    routine_id: claimed.routine_id,
-                    script_ref: claimed.script_ref,
+                self.handle_claimed_agent_failure(
+                    store,
+                    claimed,
+                    prompt,
+                    dm_user_id,
+                    checkpoint,
+                    next_due_at,
+                    &agent_id,
+                    "primary",
+                    &message,
                     action,
-                    status: "failed".to_string(),
-                    result_json,
-                    error: Some(message),
-                    fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
-                })
+                )
+                .await
             }
         }
+    }
+
+    async fn handle_claimed_agent_failure(
+        &self,
+        store: &RoutineStore,
+        claimed: ClaimedRoutineRun,
+        prompt: String,
+        dm_user_id: Option<String>,
+        checkpoint: Option<Value>,
+        next_due_at: Option<DateTime<Utc>>,
+        failed_agent_id: &str,
+        attempt_kind: &str,
+        message: &str,
+        action: String,
+    ) -> Result<RoutineRunOutcome> {
+        if claimed.max_retries > 0 && attempt_kind != "fallback" {
+            let retry_at = retry_next_at(0);
+            let result_json = Some(retry_scheduled_result_for_claimed(
+                &claimed,
+                failed_agent_id,
+                attempt_kind,
+                message,
+                &prompt,
+                retry_at,
+                1,
+                &checkpoint,
+                next_due_at,
+            ));
+            let scheduled = store
+                .schedule_agent_retry(
+                    &claimed.run_id,
+                    retry_at,
+                    result_json.clone(),
+                    message,
+                    Some(failed_agent_id),
+                    attempt_kind,
+                )
+                .await?;
+            if !scheduled {
+                return Err(anyhow!(
+                    "routine agent run {} was already closed before retry scheduling",
+                    claimed.run_id
+                ));
+            }
+            return Ok(RoutineRunOutcome {
+                run_id: claimed.run_id,
+                routine_id: claimed.routine_id,
+                script_ref: claimed.script_ref,
+                action,
+                status: "running".to_string(),
+                result_json,
+                error: Some(message.to_string()),
+                fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
+            });
+        }
+
+        let fallback_agent_id = claimed
+            .fallback_agent_id
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .filter(|value| *value != failed_agent_id)
+            .map(str::to_string);
+        if let Some(fallback_agent_id) = fallback_agent_id
+            && attempt_kind != "fallback"
+        {
+            match self
+                .start_turn(
+                    store,
+                    &claimed,
+                    &fallback_agent_id,
+                    "fallback",
+                    &prompt,
+                    dm_user_id.as_deref(),
+                    &checkpoint,
+                    next_due_at,
+                )
+                .await
+            {
+                Ok(started) if started.started => {
+                    return Ok(RoutineRunOutcome {
+                        run_id: claimed.run_id,
+                        routine_id: claimed.routine_id,
+                        script_ref: claimed.script_ref,
+                        action,
+                        status: "running".to_string(),
+                        result_json: Some(started.result_json),
+                        error: Some(message.to_string()),
+                        fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
+                    });
+                }
+                Ok(started) => {
+                    let last_result =
+                        "fallback headless command consumed without starting an agent turn";
+                    let closed = store
+                        .complete_agent_run(
+                            &claimed.run_id,
+                            Some(started.result_json.clone()),
+                            checkpoint,
+                            Some(last_result),
+                            match next_due_at {
+                                Some(value) => NextDueAtUpdate::Set(value),
+                                None => NextDueAtUpdate::Preserve,
+                            },
+                        )
+                        .await?;
+                    if !closed {
+                        return Err(anyhow!(
+                            "routine agent run {} was already closed before fallback consumed outcome",
+                            claimed.run_id
+                        ));
+                    }
+                    return Ok(RoutineRunOutcome {
+                        run_id: claimed.run_id,
+                        routine_id: claimed.routine_id,
+                        script_ref: claimed.script_ref,
+                        action,
+                        status: "succeeded".to_string(),
+                        result_json: Some(started.result_json),
+                        error: Some(message.to_string()),
+                        fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
+                    });
+                }
+                Err(fallback_error) => {
+                    let combined = format!(
+                        "{message}; fallback agent {fallback_agent_id} failed: {fallback_error}"
+                    );
+                    return fail_claimed_agent_run(store, claimed, action, combined).await;
+                }
+            }
+        }
+
+        fail_claimed_agent_run(store, claimed, action, message.to_string()).await
     }
 
     pub async fn poll_agent_runs(
@@ -190,6 +316,13 @@ impl RoutineAgentExecutor {
         let pending = store.list_running_agent_runs(limit).await?;
         let mut outcomes = Vec::new();
         for run in pending {
+            if run.turn_id.is_none() {
+                if let Some(outcome) = self.restart_due_retry(store, run).await? {
+                    outcomes.push(outcome);
+                }
+                continue;
+            }
+
             if let Some(completion) = self.find_turn_completion(&run).await? {
                 let checkpoint =
                     pending_checkpoint_for_completion(run.result_json.as_ref(), &completion);
@@ -238,12 +371,6 @@ impl RoutineAgentExecutor {
                     timeout_secs
                 );
                 let result_json = Some(merge_pending_result(&run, "timeout", Some(&message), None));
-                let closed = store
-                    .fail_agent_run(&run.run_id, &message, result_json.clone(), None)
-                    .await?;
-                if !closed {
-                    continue;
-                }
                 self.teardown_fresh_agent_session(
                     store,
                     &run.routine_id,
@@ -251,20 +378,319 @@ impl RoutineAgentExecutor {
                     "routine fresh agent run timed out",
                 )
                 .await;
-                outcomes.push(RoutineRunOutcome {
+                let failed_agent_id = current_agent_id_from_result(run.result_json.as_ref())
+                    .or(run.agent_id.as_deref())
+                    .map(str::to_string);
+                let attempt_kind = current_attempt_kind_from_result(run.result_json.as_ref())
+                    .unwrap_or("primary")
+                    .to_string();
+                if let Some(outcome) = self
+                    .handle_running_agent_failure(
+                        store,
+                        run,
+                        &message,
+                        result_json,
+                        failed_agent_id.as_deref(),
+                        &attempt_kind,
+                    )
+                    .await?
+                {
+                    outcomes.push(outcome);
+                }
+                continue;
+            }
+        }
+        Ok(outcomes)
+    }
+
+    async fn restart_due_retry(
+        &self,
+        store: &RoutineStore,
+        run: RunningAgentRoutineRun,
+    ) -> Result<Option<RoutineRunOutcome>> {
+        let prompt = match pending_prompt(run.result_json.as_ref()) {
+            Some(prompt) => prompt.to_string(),
+            None => {
+                let message = "routine retry cannot restart because prompt is missing";
+                let result_json = Some(merge_pending_result(&run, "failed", Some(message), None));
+                let closed = store
+                    .fail_agent_run(&run.run_id, message, result_json.clone(), None)
+                    .await?;
+                return Ok(closed.then(|| RoutineRunOutcome {
                     run_id: run.run_id,
                     routine_id: run.routine_id,
                     script_ref: run.script_ref,
                     action: "agent".to_string(),
                     status: "failed".to_string(),
                     result_json,
-                    error: Some(message),
+                    error: Some(message.to_string()),
                     fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
-                });
-                continue;
+                }));
+            }
+        };
+        let Some(agent_id) = run
+            .agent_id
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .map(str::to_string)
+        else {
+            let message = "routine retry cannot restart because routine.agent_id is missing";
+            let result_json = Some(merge_pending_result(&run, "failed", Some(message), None));
+            let closed = store
+                .fail_agent_run(&run.run_id, message, result_json.clone(), None)
+                .await?;
+            return Ok(closed.then(|| RoutineRunOutcome {
+                run_id: run.run_id,
+                routine_id: run.routine_id,
+                script_ref: run.script_ref,
+                action: "agent".to_string(),
+                status: "failed".to_string(),
+                result_json,
+                error: Some(message.to_string()),
+                fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
+            }));
+        };
+        let checkpoint = pending_checkpoint(run.result_json.as_ref());
+        let next_due_at = pending_next_due_at(run.result_json.as_ref());
+        let claimed = claimed_from_running_run(&run);
+        match self
+            .start_turn(
+                store,
+                &claimed,
+                &agent_id,
+                "retry",
+                &prompt,
+                None,
+                &checkpoint,
+                next_due_at,
+            )
+            .await
+        {
+            Ok(started) if started.started => Ok(Some(RoutineRunOutcome {
+                run_id: run.run_id,
+                routine_id: run.routine_id,
+                script_ref: run.script_ref,
+                action: "agent".to_string(),
+                status: "running".to_string(),
+                result_json: Some(started.result_json),
+                error: None,
+                fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
+            })),
+            Ok(started) => {
+                let last_result = "retry headless command consumed without starting an agent turn";
+                let closed = store
+                    .complete_agent_run(
+                        &run.run_id,
+                        Some(started.result_json.clone()),
+                        checkpoint,
+                        Some(last_result),
+                        match next_due_at {
+                            Some(value) => NextDueAtUpdate::Set(value),
+                            None => NextDueAtUpdate::Preserve,
+                        },
+                    )
+                    .await?;
+                Ok(closed.then(|| RoutineRunOutcome {
+                    run_id: run.run_id,
+                    routine_id: run.routine_id,
+                    script_ref: run.script_ref,
+                    action: "agent".to_string(),
+                    status: "succeeded".to_string(),
+                    result_json: Some(started.result_json),
+                    error: None,
+                    fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
+                }))
+            }
+            Err(error) => {
+                let message = error.to_string();
+                let result_json = Some(merge_pending_result(
+                    &run,
+                    "failed_to_start",
+                    Some(&message),
+                    None,
+                ));
+                self.handle_running_agent_failure(
+                    store,
+                    run,
+                    &message,
+                    result_json,
+                    Some(&agent_id),
+                    "retry",
+                )
+                .await
             }
         }
-        Ok(outcomes)
+    }
+
+    async fn handle_running_agent_failure(
+        &self,
+        store: &RoutineStore,
+        run: RunningAgentRoutineRun,
+        message: &str,
+        result_json: Option<Value>,
+        failed_agent_id: Option<&str>,
+        attempt_kind: &str,
+    ) -> Result<Option<RoutineRunOutcome>> {
+        if attempt_kind != "fallback" && run.retry_count < run.max_retries {
+            let next_retry_at = retry_next_at(run.retry_count);
+            let retry_count = run.retry_count + 1;
+            let mut retry_result = result_json.unwrap_or_else(|| {
+                merge_pending_result(&run, "retry_scheduled", Some(message), None)
+            });
+            if let Some(object) = retry_result.as_object_mut() {
+                object.insert(
+                    "status".to_string(),
+                    Value::String("retry_scheduled".to_string()),
+                );
+                object.insert(
+                    "retry_count".to_string(),
+                    Value::Number(serde_json::Number::from(retry_count)),
+                );
+                object.insert(
+                    "next_retry_at".to_string(),
+                    Value::String(next_retry_at.to_rfc3339()),
+                );
+            }
+            preserve_pending_agent_state(&mut retry_result, run.result_json.as_ref());
+            let result_json = Some(retry_result);
+            let scheduled = store
+                .schedule_agent_retry(
+                    &run.run_id,
+                    next_retry_at,
+                    result_json.clone(),
+                    message,
+                    failed_agent_id,
+                    attempt_kind,
+                )
+                .await?;
+            return Ok(scheduled.then(|| RoutineRunOutcome {
+                run_id: run.run_id,
+                routine_id: run.routine_id,
+                script_ref: run.script_ref,
+                action: "agent".to_string(),
+                status: "running".to_string(),
+                result_json,
+                error: Some(message.to_string()),
+                fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
+            }));
+        }
+
+        let fallback_agent_id = run
+            .fallback_agent_id
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .filter(|value| Some(*value) != failed_agent_id)
+            .filter(|_| attempt_kind != "fallback")
+            .filter(|_| !attempts_include_fallback(&run.attempts))
+            .map(str::to_string);
+        if let Some(fallback_agent_id) = fallback_agent_id {
+            let Some(prompt) = pending_prompt(run.result_json.as_ref()).map(str::to_string) else {
+                let closed = store
+                    .fail_agent_run(&run.run_id, message, result_json.clone(), None)
+                    .await?;
+                return Ok(closed.then(|| RoutineRunOutcome {
+                    run_id: run.run_id,
+                    routine_id: run.routine_id,
+                    script_ref: run.script_ref,
+                    action: "agent".to_string(),
+                    status: "failed".to_string(),
+                    result_json,
+                    error: Some(message.to_string()),
+                    fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
+                }));
+            };
+            let checkpoint = pending_checkpoint(run.result_json.as_ref());
+            let next_due_at = pending_next_due_at(run.result_json.as_ref());
+            let claimed = claimed_from_running_run(&run);
+            match self
+                .start_turn(
+                    store,
+                    &claimed,
+                    &fallback_agent_id,
+                    "fallback",
+                    &prompt,
+                    None,
+                    &checkpoint,
+                    next_due_at,
+                )
+                .await
+            {
+                Ok(started) if started.started => {
+                    return Ok(Some(RoutineRunOutcome {
+                        run_id: run.run_id,
+                        routine_id: run.routine_id,
+                        script_ref: run.script_ref,
+                        action: "agent".to_string(),
+                        status: "running".to_string(),
+                        result_json: Some(started.result_json),
+                        error: Some(message.to_string()),
+                        fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
+                    }));
+                }
+                Ok(started) => {
+                    let last_result =
+                        "fallback headless command consumed without starting an agent turn";
+                    let closed = store
+                        .complete_agent_run(
+                            &run.run_id,
+                            Some(started.result_json.clone()),
+                            checkpoint,
+                            Some(last_result),
+                            match next_due_at {
+                                Some(value) => NextDueAtUpdate::Set(value),
+                                None => NextDueAtUpdate::Preserve,
+                            },
+                        )
+                        .await?;
+                    return Ok(closed.then(|| RoutineRunOutcome {
+                        run_id: run.run_id,
+                        routine_id: run.routine_id,
+                        script_ref: run.script_ref,
+                        action: "agent".to_string(),
+                        status: "succeeded".to_string(),
+                        result_json: Some(started.result_json),
+                        error: Some(message.to_string()),
+                        fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
+                    }));
+                }
+                Err(fallback_error) => {
+                    let combined = format!(
+                        "{message}; fallback agent {fallback_agent_id} failed: {fallback_error}"
+                    );
+                    let result_json =
+                        Some(merge_pending_result(&run, "failed", Some(&combined), None));
+                    let closed = store
+                        .fail_agent_run(&run.run_id, &combined, result_json.clone(), None)
+                        .await?;
+                    return Ok(closed.then(|| RoutineRunOutcome {
+                        run_id: run.run_id,
+                        routine_id: run.routine_id,
+                        script_ref: run.script_ref,
+                        action: "agent".to_string(),
+                        status: "failed".to_string(),
+                        result_json,
+                        error: Some(combined),
+                        fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
+                    }));
+                }
+            }
+        }
+
+        let result_json =
+            result_json.or_else(|| Some(merge_pending_result(&run, "failed", Some(message), None)));
+        let closed = store
+            .fail_agent_run(&run.run_id, message, result_json.clone(), None)
+            .await?;
+        Ok(closed.then(|| RoutineRunOutcome {
+            run_id: run.run_id,
+            routine_id: run.routine_id,
+            script_ref: run.script_ref,
+            action: "agent".to_string(),
+            status: "failed".to_string(),
+            result_json,
+            error: Some(message.to_string()),
+            fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
+        }))
     }
 
     pub(crate) async fn teardown_fresh_agent_session(
@@ -427,16 +853,13 @@ impl RoutineAgentExecutor {
         &self,
         store: &RoutineStore,
         claimed: &ClaimedRoutineRun,
+        agent_id: &str,
+        attempt_kind: &str,
         prompt: &str,
         dm_user_id: Option<&str>,
         checkpoint: &Option<Value>,
         next_due_at: Option<DateTime<Utc>>,
     ) -> Result<StartedAgentTurn> {
-        let agent_id = claimed
-            .agent_id
-            .as_deref()
-            .filter(|value| !value.trim().is_empty())
-            .ok_or_else(|| anyhow!("routine agent action requires routine.agent_id"))?;
         let Some(registry) = self.health_registry.as_deref() else {
             return Err(anyhow!(
                 "routine agent action requires discord runtime health registry"
@@ -539,13 +962,21 @@ impl RoutineAgentExecutor {
             "routine_id": claimed.routine_id,
             "run_id": claimed.run_id,
             "script_ref": claimed.script_ref,
+            "attempt_kind": attempt_kind,
+            "prompt": prompt,
             "completion_evidence": "session_transcripts",
             "fresh_context_guaranteed": FRESH_CONTEXT_GUARANTEED,
             "checkpoint": checkpoint,
             "next_due_at": next_due_at.map(|value| value.to_rfc3339()),
         });
         let updated = store
-            .mark_agent_turn_started(&claimed.run_id, &turn_id, Some(result_json.clone()))
+            .mark_agent_turn_started(
+                &claimed.run_id,
+                &turn_id,
+                Some(result_json.clone()),
+                agent_id,
+                attempt_kind,
+            )
             .await?;
         if !updated {
             return Err(anyhow!(
@@ -736,6 +1167,9 @@ impl RoutineAgentExecutor {
         &self,
         run: &RunningAgentRoutineRun,
     ) -> Result<Option<AgentTurnCompletion>> {
+        let Some(turn_id) = run.turn_id.as_deref() else {
+            return Ok(None);
+        };
         let transcript = sqlx::query_as::<_, AgentTranscriptCompletionRow>(
             r#"
             SELECT assistant_message, duration_ms::bigint AS duration_ms, created_at
@@ -747,14 +1181,14 @@ impl RoutineAgentExecutor {
             LIMIT 1
             "#,
         )
-        .bind(&run.turn_id)
+        .bind(turn_id)
         .bind(run.started_at)
         .fetch_optional(&*self.pool)
         .await
         .map_err(|error| {
             anyhow!(
                 "lookup routine agent transcript {} for run {}: {error}",
-                run.turn_id,
+                turn_id,
                 run.run_id
             )
         })?;
@@ -793,14 +1227,14 @@ impl RoutineAgentExecutor {
             LIMIT 1
             "#,
         )
-        .bind(&run.turn_id)
+        .bind(turn_id)
         .bind(run.started_at)
         .fetch_optional(&*self.pool)
         .await
         .map_err(|error| {
             anyhow!(
                 "lookup routine agent terminal turn {} for run {}: {error}",
-                run.turn_id,
+                turn_id,
                 run.run_id
             )
         })?;
@@ -1036,6 +1470,75 @@ fn timeout_secs_for_run(run: &RunningAgentRoutineRun, default_completion_timeout
         .unwrap_or(default_completion_timeout_secs)
 }
 
+async fn fail_claimed_agent_run(
+    store: &RoutineStore,
+    claimed: ClaimedRoutineRun,
+    action: String,
+    message: String,
+) -> Result<RoutineRunOutcome> {
+    let result_json = Some(json!({
+        "status": "failed_to_start",
+        "error": message,
+        "routine_id": claimed.routine_id,
+        "run_id": claimed.run_id,
+        "script_ref": claimed.script_ref,
+        "fresh_context_guaranteed": FRESH_CONTEXT_GUARANTEED,
+    }));
+    let closed = store
+        .fail_agent_run(&claimed.run_id, &message, result_json.clone(), None)
+        .await?;
+    if !closed {
+        return Err(anyhow!(
+            "routine agent run {} was already closed before failed outcome",
+            claimed.run_id
+        ));
+    }
+    Ok(RoutineRunOutcome {
+        run_id: claimed.run_id,
+        routine_id: claimed.routine_id,
+        script_ref: claimed.script_ref,
+        action,
+        status: "failed".to_string(),
+        result_json,
+        error: Some(message),
+        fresh_context_guaranteed: FRESH_CONTEXT_GUARANTEED,
+    })
+}
+
+fn retry_next_at(retry_count_before_increment: i32) -> DateTime<Utc> {
+    let exponent = retry_count_before_increment.clamp(0, 5) as u32;
+    let secs = 30_i64.saturating_mul(2_i64.saturating_pow(exponent));
+    Utc::now() + Duration::seconds(secs)
+}
+
+fn retry_scheduled_result_for_claimed(
+    claimed: &ClaimedRoutineRun,
+    failed_agent_id: &str,
+    attempt_kind: &str,
+    error: &str,
+    prompt: &str,
+    next_retry_at: DateTime<Utc>,
+    retry_count: i32,
+    checkpoint: &Option<Value>,
+    next_due_at: Option<DateTime<Utc>>,
+) -> Value {
+    json!({
+        "status": "retry_scheduled",
+        "error": error,
+        "failed_agent_id": failed_agent_id,
+        "attempt_kind": attempt_kind,
+        "prompt": prompt,
+        "retry_count": retry_count,
+        "next_retry_at": next_retry_at.to_rfc3339(),
+        "routine_id": claimed.routine_id,
+        "run_id": claimed.run_id,
+        "script_ref": claimed.script_ref,
+        "fresh_context_guaranteed": FRESH_CONTEXT_GUARANTEED,
+        "checkpoint": checkpoint,
+        "next_due_at": next_due_at.map(|value| value.to_rfc3339()),
+    })
+}
+
 fn completed_result(
     run: &RunningAgentRoutineRun,
     completion: &AgentTurnCompletion,
@@ -1118,6 +1621,26 @@ fn with_started_run_routing_metadata(mut result: Value, started_result: Option<&
     result
 }
 
+fn preserve_pending_agent_state(result: &mut Value, previous_result: Option<&Value>) {
+    const PENDING_KEYS: &[&str] = &["prompt", "checkpoint", "next_due_at"];
+
+    let Some(previous) = previous_result.and_then(Value::as_object) else {
+        return;
+    };
+    let Some(result_object) = result.as_object_mut() else {
+        return;
+    };
+
+    for key in PENDING_KEYS {
+        if result_object.contains_key(*key) {
+            continue;
+        }
+        if let Some(value) = previous.get(*key) {
+            result_object.insert((*key).to_string(), value.clone());
+        }
+    }
+}
+
 fn pending_checkpoint_for_completion(
     result_json: Option<&Value>,
     completion: &AgentTurnCompletion,
@@ -1135,6 +1658,59 @@ fn pending_checkpoint(result_json: Option<&Value>) -> Option<Value> {
         .and_then(|value| value.get("checkpoint"))
         .filter(|value| !value.is_null())
         .cloned()
+}
+
+fn pending_prompt(result_json: Option<&Value>) -> Option<&str> {
+    result_json
+        .and_then(|value| value.get("prompt"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn current_agent_id_from_result(result_json: Option<&Value>) -> Option<&str> {
+    result_json
+        .and_then(|value| value.get("agent_id"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn current_attempt_kind_from_result(result_json: Option<&Value>) -> Option<&str> {
+    result_json
+        .and_then(|value| value.get("attempt_kind"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn attempts_include_fallback(attempts: &Value) -> bool {
+    attempts
+        .as_array()
+        .map(|items| {
+            items.iter().any(|item| {
+                item.get("kind").and_then(Value::as_str) == Some("fallback")
+                    || item.get("attempt_kind").and_then(Value::as_str) == Some("fallback")
+            })
+        })
+        .unwrap_or(false)
+}
+
+fn claimed_from_running_run(run: &RunningAgentRoutineRun) -> ClaimedRoutineRun {
+    ClaimedRoutineRun {
+        run_id: run.run_id.clone(),
+        routine_id: run.routine_id.clone(),
+        agent_id: run.agent_id.clone(),
+        fallback_agent_id: run.fallback_agent_id.clone(),
+        max_retries: run.max_retries,
+        script_ref: run.script_ref.clone(),
+        name: run.name.clone(),
+        execution_strategy: run.execution_strategy.clone(),
+        checkpoint: pending_checkpoint(run.result_json.as_ref()),
+        discord_thread_id: run.discord_thread_id.clone(),
+        timeout_secs: run.timeout_secs,
+        lease_expires_at: Utc::now(),
+    }
 }
 
 fn finalize_family_profile_probe_pending_delivery(mut checkpoint: Value) -> Value {
@@ -1280,8 +1856,17 @@ mod tests {
         RunningAgentRoutineRun {
             run_id: "run-1".to_string(),
             routine_id: "routine-1".to_string(),
+            agent_id: Some("agent-1".to_string()),
+            fallback_agent_id: None,
+            max_retries: 0,
+            retry_count: 0,
             script_ref: "agent-checkpoint-review.js".to_string(),
-            turn_id: "discord:123:456".to_string(),
+            name: "Agent Checkpoint Review".to_string(),
+            execution_strategy: "fresh".to_string(),
+            discord_thread_id: None,
+            turn_id: Some("discord:123:456".to_string()),
+            next_retry_at: None,
+            attempts: serde_json::json!([]),
             result_json: None,
             started_at: Utc::now(),
             timeout_secs,
@@ -1308,6 +1893,39 @@ mod tests {
             terminal_status: matches!(evidence, AgentTurnCompletionEvidence::TerminalTurn)
                 .then(|| "empty_response".to_string()),
         }
+    }
+
+    #[test]
+    fn retry_next_at_uses_exponential_backoff() {
+        let before = Utc::now();
+        let first = retry_next_at(0);
+        let second = retry_next_at(1);
+
+        assert!(first >= before + chrono::Duration::seconds(29));
+        assert!(first <= before + chrono::Duration::seconds(31));
+        assert!(second >= before + chrono::Duration::seconds(59));
+        assert!(second <= before + chrono::Duration::seconds(61));
+    }
+
+    #[test]
+    fn pending_prompt_trims_and_rejects_empty_values() {
+        assert_eq!(
+            pending_prompt(Some(&json!({"prompt": "  run me  "}))),
+            Some("run me")
+        );
+        assert_eq!(pending_prompt(Some(&json!({"prompt": "   "}))), None);
+        assert_eq!(pending_prompt(Some(&json!({}))), None);
+    }
+
+    #[test]
+    fn attempts_include_fallback_detects_kind() {
+        assert!(!attempts_include_fallback(&json!([
+            {"kind": "primary"},
+            {"attempt_kind": "retry"}
+        ])));
+        assert!(attempts_include_fallback(&json!([
+            {"kind": "fallback"}
+        ])));
     }
 
     fn quality_completion_row(

--- a/src/services/routines/discord_log.rs
+++ b/src/services/routines/discord_log.rs
@@ -192,6 +192,14 @@ impl RoutineDiscordLogger {
             return status;
         };
 
+        let discord_log_warning = match store.get_run_discord_log_failure(&outcome.run_id).await {
+            Ok(Some(failure)) => failure.error,
+            Ok(None) => None,
+            Err(error) => Some(format!(
+                "failed to inspect prior discord log status: {error}"
+            )),
+        };
+
         let status = self
             .log_run_section(
                 store,
@@ -201,7 +209,7 @@ impl RoutineDiscordLogger {
                 routine.discord_thread_id.as_deref(),
                 &outcome.run_id,
                 "outcome",
-                &run_outcome_section(&routine, outcome),
+                &run_outcome_section(&routine, outcome, discord_log_warning.as_deref()),
             )
             .await;
         self.persist_run_log_status(store, &outcome.run_id, &status)
@@ -1164,10 +1172,14 @@ fn run_js_action_section(
 // #3034: exercised only by the discord_log unit tests below.
 #[allow(dead_code)]
 fn run_outcome_message(routine: &RoutineRecord, outcome: &RoutineRunOutcome) -> String {
-    routine_run_progress_message(&run_outcome_section(routine, outcome))
+    routine_run_progress_message(&run_outcome_section(routine, outcome, None))
 }
 
-fn run_outcome_section(routine: &RoutineRecord, outcome: &RoutineRunOutcome) -> String {
+fn run_outcome_section(
+    routine: &RoutineRecord,
+    outcome: &RoutineRunOutcome,
+    discord_log_warning: Option<&str>,
+) -> String {
     let mut basic = vec![
         field_line("routine", &compact(&routine.name, 80)),
         field_line("run", short_id(&outcome.run_id)),
@@ -1180,6 +1192,9 @@ fn run_outcome_section(routine: &RoutineRecord, outcome: &RoutineRunOutcome) -> 
         .filter(|value| !value.trim().is_empty())
     {
         basic.push(field_line("error", compact(error, 160)));
+    }
+    if let Some(warning) = discord_log_warning.filter(|value| !value.trim().is_empty()) {
+        basic.push(field_line("discord_log_warning", compact(warning, 160)));
     }
     let mut sections = vec![("기본", basic)];
     if let Some(summary) = outcome_summary_for_message(outcome) {
@@ -1359,6 +1374,8 @@ mod tests {
         let routine = RoutineRecord {
             id: "routine-123456789".to_string(),
             agent_id: Some("maker".to_string()),
+            fallback_agent_id: None,
+            max_retries: 0,
             script_ref: "daily-summary.js".to_string(),
             name: "Daily Summary".to_string(),
             status: "enabled".to_string(),
@@ -1402,6 +1419,8 @@ mod tests {
         let routine = RoutineRecord {
             id: "routine-123456789".to_string(),
             agent_id: Some("monitoring".to_string()),
+            fallback_agent_id: None,
+            max_retries: 0,
             script_ref: "monitoring/automation-candidate-recommender.js".to_string(),
             name: "automation-candidate-recommender".to_string(),
             status: "enabled".to_string(),
@@ -1441,6 +1460,8 @@ mod tests {
         let routine = RoutineRecord {
             id: "routine-123456789".to_string(),
             agent_id: Some("maker".to_string()),
+            fallback_agent_id: None,
+            max_retries: 0,
             script_ref: "daily-summary.js".to_string(),
             name: "Daily Summary".to_string(),
             status: "enabled".to_string(),
@@ -1481,6 +1502,8 @@ mod tests {
             run_id: "21e14c13-0000-0000-0000-000000000000".to_string(),
             routine_id: "routine-123456789".to_string(),
             agent_id: Some("monitoring".to_string()),
+            fallback_agent_id: None,
+            max_retries: 0,
             script_ref: "monitoring/automation-candidate-recommender.js".to_string(),
             name: "Automation Candidate Recommender".to_string(),
             execution_strategy: "fresh".to_string(),
@@ -1514,6 +1537,8 @@ mod tests {
             run_id: "21e14c13-0000-0000-0000-000000000000".to_string(),
             routine_id: "routine-123456789".to_string(),
             agent_id: Some("monitoring".to_string()),
+            fallback_agent_id: None,
+            max_retries: 0,
             script_ref: "monitoring/automation-candidate-recommender.js".to_string(),
             name: "Automation Candidate Recommender".to_string(),
             execution_strategy: "fresh".to_string(),
@@ -1546,6 +1571,8 @@ mod tests {
             run_id: "21e14c13-0000-0000-0000-000000000000".to_string(),
             routine_id: "routine-123456789".to_string(),
             agent_id: Some("monitoring".to_string()),
+            fallback_agent_id: None,
+            max_retries: 0,
             script_ref: "monitoring/working-watchdog.js".to_string(),
             name: "monitoring-working-watchdog".to_string(),
             execution_strategy: "fresh".to_string(),

--- a/src/services/routines/discord_log.rs
+++ b/src/services/routines/discord_log.rs
@@ -1193,6 +1193,36 @@ fn run_outcome_section(
     {
         basic.push(field_line("error", compact(error, 160)));
     }
+    if let Some(agent_id) = outcome
+        .result_json
+        .as_ref()
+        .and_then(|value| {
+            value
+                .get("agent_id")
+                .or_else(|| value.get("failed_agent_id"))
+        })
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        basic.push(field_line("agent", compact(agent_id, 80)));
+    }
+    if let Some(attempt_kind) = outcome
+        .result_json
+        .as_ref()
+        .and_then(|value| value.get("attempt_kind"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        basic.push(field_line("attempt", compact(attempt_kind, 40)));
+    }
+    if let Some(retry_count) = outcome
+        .result_json
+        .as_ref()
+        .and_then(|value| value.get("retry_count"))
+        .and_then(Value::as_i64)
+    {
+        basic.push(field_line("retry_count", retry_count.to_string()));
+    }
     if let Some(warning) = discord_log_warning.filter(|value| !value.trim().is_empty()) {
         basic.push(field_line("discord_log_warning", compact(warning, 160)));
     }
@@ -1453,6 +1483,50 @@ mod tests {
 
         assert!(message.contains("[요약]"));
         assert!(message.contains("result: 성공 요약: 새 자동화 추천 후보 없음"));
+    }
+
+    #[test]
+    fn run_outcome_message_includes_agent_attempt_metadata() {
+        let routine = RoutineRecord {
+            id: "routine-123456789".to_string(),
+            agent_id: Some("codex".to_string()),
+            fallback_agent_id: Some("claude".to_string()),
+            max_retries: 1,
+            script_ref: "daily-summary.js".to_string(),
+            name: "Daily Summary".to_string(),
+            status: "enabled".to_string(),
+            execution_strategy: "fresh".to_string(),
+            schedule: None,
+            next_due_at: None,
+            last_run_at: None,
+            last_result: None,
+            checkpoint: None,
+            discord_thread_id: None,
+            timeout_secs: None,
+            in_flight_run_id: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let outcome = RoutineRunOutcome {
+            run_id: "run-123456789".to_string(),
+            routine_id: routine.id.clone(),
+            script_ref: routine.script_ref.clone(),
+            action: "agent".to_string(),
+            status: "succeeded".to_string(),
+            result_json: Some(json!({
+                "agent_id": "claude",
+                "attempt_kind": "fallback",
+                "retry_count": 1
+            })),
+            error: None,
+            fresh_context_guaranteed: false,
+        };
+
+        let message = run_outcome_message(&routine, &outcome);
+
+        assert!(message.contains("agent: claude"));
+        assert!(message.contains("attempt: fallback"));
+        assert!(message.contains("retry_count: 1"));
     }
 
     #[test]

--- a/src/services/routines/runtime.rs
+++ b/src/services/routines/runtime.rs
@@ -927,6 +927,8 @@ mod tests {
             run_id: "run-1".to_string(),
             routine_id: "routine-1".to_string(),
             agent_id: None,
+            fallback_agent_id: None,
+            max_retries: 0,
             script_ref,
             name: "Missing entrypoint".to_string(),
             execution_strategy: "script".to_string(),

--- a/src/services/routines/runtime_config.rs
+++ b/src/services/routines/runtime_config.rs
@@ -9,6 +9,7 @@ pub enum RoutineRuntimeConfigError {
     TickIntervalSecs,
     AgentPollLimit,
     AgentTimeoutSecs,
+    MaxCheckpointBytes,
 }
 
 impl RoutineRuntimeConfigError {
@@ -19,6 +20,7 @@ impl RoutineRuntimeConfigError {
             }
             Self::AgentPollLimit => "routines.max_agent_polls_per_tick must be greater than zero",
             Self::AgentTimeoutSecs => "routines.agent_timeout_secs must be greater than zero",
+            Self::MaxCheckpointBytes => "routines.max_checkpoint_bytes must be greater than zero",
         }
     }
 }
@@ -38,6 +40,8 @@ pub fn validate_routine_runtime_config(
         .ok_or(RoutineRuntimeConfigError::AgentPollLimit)?;
     valid_routine_agent_timeout_secs(config.agent_timeout_secs)
         .ok_or(RoutineRuntimeConfigError::AgentTimeoutSecs)?;
+    valid_routine_max_checkpoint_bytes(config.max_checkpoint_bytes)
+        .ok_or(RoutineRuntimeConfigError::MaxCheckpointBytes)?;
     Ok(config.tick_interval_secs)
 }
 
@@ -51,6 +55,10 @@ pub fn valid_routine_agent_poll_limit(value: u32) -> Option<u32> {
 }
 
 pub fn valid_routine_agent_timeout_secs(value: u64) -> Option<u64> {
+    (value > 0).then_some(value)
+}
+
+pub fn valid_routine_max_checkpoint_bytes(value: usize) -> Option<usize> {
     (value > 0).then_some(value)
 }
 
@@ -83,6 +91,16 @@ mod tests {
     }
 
     #[test]
+    fn routine_max_checkpoint_bytes_rejects_zero() {
+        assert_eq!(valid_routine_max_checkpoint_bytes(0), None);
+        assert_eq!(valid_routine_max_checkpoint_bytes(1), Some(1));
+        assert_eq!(
+            valid_routine_max_checkpoint_bytes(256 * 1024),
+            Some(256 * 1024)
+        );
+    }
+
+    #[test]
     fn routine_runtime_config_returns_first_invalid_field() {
         let mut config = RoutinesConfig::default();
         config.tick_interval_secs = 901;
@@ -103,6 +121,13 @@ mod tests {
         assert_eq!(
             validate_routine_runtime_config(&config),
             Err(RoutineRuntimeConfigError::AgentTimeoutSecs)
+        );
+
+        config.agent_timeout_secs = 1800;
+        config.max_checkpoint_bytes = 0;
+        assert_eq!(
+            validate_routine_runtime_config(&config),
+            Err(RoutineRuntimeConfigError::MaxCheckpointBytes)
         );
     }
 }

--- a/src/services/routines/session_control.rs
+++ b/src/services/routines/session_control.rs
@@ -906,6 +906,8 @@ mod tests {
         RoutineRecord {
             id: "routine-1".to_string(),
             agent_id: Some("agent-1".to_string()),
+            fallback_agent_id: None,
+            max_retries: 0,
             script_ref: "script".to_string(),
             name: "Routine".to_string(),
             status: "enabled".to_string(),

--- a/src/services/routines/store.rs
+++ b/src/services/routines/store.rs
@@ -4,7 +4,7 @@ use chrono_tz::Tz;
 use croner::Cron;
 use croner::parser::{CronParser, Seconds, Year};
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value};
+use serde_json::{Map, Value, json};
 use sqlx::{PgPool, Postgres, Row, Transaction};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -303,6 +303,7 @@ fn precomputed_observation_from_kv(
 pub struct RoutineStore {
     pool: Arc<PgPool>,
     default_timezone: String,
+    max_checkpoint_bytes: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, sqlx::FromRow)]
@@ -310,6 +311,8 @@ pub struct ClaimedRoutineRun {
     pub run_id: String,
     pub routine_id: String,
     pub agent_id: Option<String>,
+    pub fallback_agent_id: Option<String>,
+    pub max_retries: i32,
     pub script_ref: String,
     pub name: String,
     pub execution_strategy: String,
@@ -323,6 +326,8 @@ pub struct ClaimedRoutineRun {
 pub struct RoutineRecord {
     pub id: String,
     pub agent_id: Option<String>,
+    pub fallback_agent_id: Option<String>,
+    pub max_retries: i32,
     pub script_ref: String,
     pub name: String,
     pub status: String,
@@ -347,6 +352,9 @@ pub struct RoutineRunRecord {
     pub action: Option<String>,
     pub turn_id: Option<String>,
     pub lease_expires_at: Option<DateTime<Utc>>,
+    pub retry_count: i32,
+    pub next_retry_at: Option<DateTime<Utc>>,
+    pub attempts: Value,
     pub result_json: Option<Value>,
     pub error: Option<String>,
     pub discord_log_status: Option<String>,
@@ -397,8 +405,17 @@ pub struct RoutineMetrics {
 pub struct RunningAgentRoutineRun {
     pub run_id: String,
     pub routine_id: String,
+    pub agent_id: Option<String>,
+    pub fallback_agent_id: Option<String>,
+    pub max_retries: i32,
+    pub retry_count: i32,
     pub script_ref: String,
-    pub turn_id: String,
+    pub name: String,
+    pub execution_strategy: String,
+    pub discord_thread_id: Option<String>,
+    pub turn_id: Option<String>,
+    pub next_retry_at: Option<DateTime<Utc>>,
+    pub attempts: Value,
     pub result_json: Option<Value>,
     pub started_at: DateTime<Utc>,
     pub timeout_secs: Option<i32>,
@@ -450,9 +467,17 @@ pub struct RunDiscordLogState {
     pub sections: Value,
 }
 
+#[derive(Debug, Clone, PartialEq, sqlx::FromRow)]
+pub struct RunDiscordLogFailure {
+    pub status: Option<String>,
+    pub error: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct NewRoutine {
     pub agent_id: Option<String>,
+    pub fallback_agent_id: Option<String>,
+    pub max_retries: Option<i32>,
     pub script_ref: String,
     pub name: String,
     pub status: Option<String>,
@@ -467,6 +492,8 @@ pub struct NewRoutine {
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct RoutinePatch {
     pub name: Option<String>,
+    pub fallback_agent_id: Option<Option<String>>,
+    pub max_retries: Option<i32>,
     pub execution_strategy: Option<String>,
     pub schedule: Option<Option<String>>,
     pub next_due_at: Option<Option<DateTime<Utc>>>,
@@ -479,6 +506,8 @@ pub struct RoutinePatch {
 struct RoutineClaimCandidate {
     id: String,
     agent_id: Option<String>,
+    fallback_agent_id: Option<String>,
+    max_retries: i32,
     script_ref: String,
     name: String,
     execution_strategy: String,
@@ -488,10 +517,15 @@ struct RoutineClaimCandidate {
 }
 
 impl RoutineStore {
-    pub fn new_with_timezone(pool: Arc<PgPool>, default_timezone: impl Into<String>) -> Self {
+    pub fn new_with_timezone_and_checkpoint_limit(
+        pool: Arc<PgPool>,
+        default_timezone: impl Into<String>,
+        max_checkpoint_bytes: usize,
+    ) -> Self {
         Self {
             pool,
             default_timezone: default_timezone.into(),
+            max_checkpoint_bytes: max_checkpoint_bytes.max(1),
         }
     }
 
@@ -513,8 +547,8 @@ impl RoutineStore {
         Self::seed_scheduled_due_times(&mut tx, &self.default_timezone).await?;
         let candidates: Vec<RoutineClaimCandidate> = sqlx::query_as(
             r#"
-            SELECT id, agent_id, script_ref, name, execution_strategy, checkpoint,
-                   discord_thread_id, timeout_secs
+            SELECT id, agent_id, fallback_agent_id, max_retries, script_ref, name,
+                   execution_strategy, checkpoint, discord_thread_id, timeout_secs
             FROM routines
             WHERE status = 'enabled'
               AND next_due_at IS NOT NULL
@@ -602,7 +636,8 @@ impl RoutineStore {
             r#"
             SELECT id, agent_id, script_ref, name, status, execution_strategy,
                    schedule, next_due_at, last_run_at, last_result, checkpoint,
-                   discord_thread_id, timeout_secs, in_flight_run_id,
+                   discord_thread_id, timeout_secs, fallback_agent_id, max_retries,
+                   in_flight_run_id,
                    created_at, updated_at
             FROM routines
             WHERE ($1::text IS NULL OR agent_id = $1)
@@ -622,7 +657,8 @@ impl RoutineStore {
             r#"
             SELECT id, agent_id, script_ref, name, status, execution_strategy,
                    schedule, next_due_at, last_run_at, last_result, checkpoint,
-                   discord_thread_id, timeout_secs, in_flight_run_id,
+                   discord_thread_id, timeout_secs, fallback_agent_id, max_retries,
+                   in_flight_run_id,
                    created_at, updated_at
             FROM routines
             WHERE id = $1
@@ -639,6 +675,7 @@ impl RoutineStore {
         sqlx::query_as(
             r#"
             SELECT id, routine_id, status, action, turn_id, lease_expires_at,
+                   retry_count, next_retry_at, attempts,
                    result_json, error, discord_log_status, discord_log_error,
                    discord_message_id, discord_log_sections, started_at,
                    finished_at, created_at, updated_at
@@ -731,8 +768,17 @@ impl RoutineStore {
             r#"
             SELECT rr.id AS run_id,
                    rr.routine_id,
+                   r.agent_id,
+                   r.fallback_agent_id,
+                   r.max_retries,
+                   rr.retry_count,
                    r.script_ref,
+                   r.name,
+                   r.execution_strategy,
+                   r.discord_thread_id,
                    rr.turn_id,
+                   rr.next_retry_at,
+                   rr.attempts,
                    rr.result_json,
                    rr.started_at,
                    r.timeout_secs
@@ -740,8 +786,11 @@ impl RoutineStore {
             JOIN routines r ON r.id = rr.routine_id
             WHERE rr.status = 'running'
               AND rr.action = 'agent'
-              AND rr.turn_id IS NOT NULL
-            ORDER BY rr.started_at ASC, rr.created_at ASC
+              AND (
+                    rr.turn_id IS NOT NULL
+                    OR (rr.next_retry_at IS NOT NULL AND rr.next_retry_at <= NOW())
+                  )
+            ORDER BY COALESCE(rr.next_retry_at, rr.started_at) ASC, rr.created_at ASC
             LIMIT $1
             "#,
         )
@@ -759,7 +808,7 @@ impl RoutineStore {
                 updated_at = NOW()
             WHERE status = 'running'
               AND action = 'agent'
-              AND turn_id IS NOT NULL
+              AND (turn_id IS NOT NULL OR next_retry_at IS NOT NULL)
             "#,
         )
         .bind(RUN_LEASE_SECS)
@@ -1701,7 +1750,10 @@ impl RoutineStore {
         let status = normalize_new_routine_status(new_routine.status.as_deref())?;
         let schedule = normalize_schedule(new_routine.schedule)?;
         validate_timeout_secs(new_routine.timeout_secs)?;
+        validate_max_retries(new_routine.max_retries)?;
         let discord_thread_id = normalize_optional_text(new_routine.discord_thread_id);
+        let fallback_agent_id = normalize_optional_text(new_routine.fallback_agent_id);
+        let max_retries = new_routine.max_retries.unwrap_or(0);
         let next_due_at = if let Some(value) = new_routine.next_due_at {
             Some(value)
         } else if let Some(schedule) = schedule.as_deref() {
@@ -1714,12 +1766,14 @@ impl RoutineStore {
             r#"
             INSERT INTO routines (
                 id, agent_id, script_ref, name, status, execution_strategy,
-                schedule, next_due_at, checkpoint, discord_thread_id, timeout_secs
+                schedule, next_due_at, checkpoint, discord_thread_id, timeout_secs,
+                fallback_agent_id, max_retries
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
             RETURNING id, agent_id, script_ref, name, status, execution_strategy,
                       schedule, next_due_at, last_run_at, last_result, checkpoint,
-                      discord_thread_id, timeout_secs, in_flight_run_id,
+                      discord_thread_id, timeout_secs, fallback_agent_id, max_retries,
+                      in_flight_run_id,
                       created_at, updated_at
             "#,
         )
@@ -1734,6 +1788,8 @@ impl RoutineStore {
         .bind(new_routine.checkpoint)
         .bind(discord_thread_id)
         .bind(new_routine.timeout_secs)
+        .bind(fallback_agent_id)
+        .bind(max_retries)
         .fetch_one(&*self.pool)
         .await
         .map_err(|e| anyhow!("attach routine: {e}"))
@@ -1748,6 +1804,7 @@ impl RoutineStore {
             validate_execution_strategy(strategy)?;
         }
         validate_timeout_secs(patch.timeout_secs.flatten())?;
+        validate_max_retries(patch.max_retries)?;
         let schedule_was_set = patch.schedule.is_some();
         let schedule = match patch.schedule {
             Some(value) => normalize_schedule(value)?,
@@ -1759,6 +1816,11 @@ impl RoutineStore {
             .map(|value| normalize_optional_text(value));
         let timeout_secs_was_set = patch.timeout_secs.is_some();
         let timeout_secs = patch.timeout_secs.flatten();
+        let fallback_agent_id_was_set = patch.fallback_agent_id.is_some();
+        let fallback_agent_id = patch
+            .fallback_agent_id
+            .map(|value| normalize_optional_text(value));
+        let max_retries_was_set = patch.max_retries.is_some();
         let next_due_was_set = patch.next_due_at.is_some();
         let mut next_due_at = patch.next_due_at.flatten();
         let mut update_next_due_at = next_due_was_set;
@@ -1786,12 +1848,15 @@ impl RoutineStore {
                 checkpoint = CASE WHEN $8 THEN $9 ELSE checkpoint END,
                 discord_thread_id = CASE WHEN $10 THEN $11 ELSE discord_thread_id END,
                 timeout_secs = CASE WHEN $12 THEN $13 ELSE timeout_secs END,
+                fallback_agent_id = CASE WHEN $14 THEN $15 ELSE fallback_agent_id END,
+                max_retries = CASE WHEN $16 THEN $17 ELSE max_retries END,
                 updated_at = NOW()
             WHERE id = $1
               AND status <> 'detached'
             RETURNING id, agent_id, script_ref, name, status, execution_strategy,
                       schedule, next_due_at, last_run_at, last_result, checkpoint,
-                      discord_thread_id, timeout_secs, in_flight_run_id,
+                      discord_thread_id, timeout_secs, fallback_agent_id, max_retries,
+                      in_flight_run_id,
                       created_at, updated_at
             "#,
         )
@@ -1808,6 +1873,10 @@ impl RoutineStore {
         .bind(discord_thread_id.flatten())
         .bind(timeout_secs_was_set)
         .bind(timeout_secs)
+        .bind(fallback_agent_id_was_set)
+        .bind(fallback_agent_id.flatten())
+        .bind(max_retries_was_set)
+        .bind(patch.max_retries.unwrap_or(0))
         .fetch_optional(&*self.pool)
         .await
         .map_err(|e| anyhow!("patch routine {routine_id}: {e}"))
@@ -1818,8 +1887,8 @@ impl RoutineStore {
         let mut tx = self.pool.begin().await?;
         let candidate: Option<RoutineClaimCandidate> = sqlx::query_as(
             r#"
-            SELECT id, agent_id, script_ref, name, execution_strategy, checkpoint,
-                   discord_thread_id, timeout_secs
+            SELECT id, agent_id, fallback_agent_id, max_retries, script_ref, name,
+                   execution_strategy, checkpoint, discord_thread_id, timeout_secs
             FROM routines
             WHERE id = $1
               AND status = 'enabled'
@@ -1962,6 +2031,8 @@ impl RoutineStore {
         run_id: &str,
         turn_id: &str,
         result_json: Option<Value>,
+        agent_id: &str,
+        attempt_kind: &str,
     ) -> Result<bool> {
         let result = sqlx::query(
             r#"
@@ -1970,6 +2041,17 @@ impl RoutineStore {
                 turn_id = $2,
                 result_json = $3,
                 lease_expires_at = NOW() + ($4::bigint * INTERVAL '1 second'),
+                next_retry_at = NULL,
+                owned_tmux_session = NULL,
+                attempts = COALESCE(attempts, '[]'::jsonb) || jsonb_build_array(
+                    jsonb_build_object(
+                        'event', 'started',
+                        'agent_id', $5,
+                        'kind', $6,
+                        'turn_id', $2,
+                        'at', NOW()
+                    )
+                ),
                 updated_at = NOW()
             WHERE id = $1
               AND status = 'running'
@@ -1979,9 +2061,60 @@ impl RoutineStore {
         .bind(turn_id)
         .bind(result_json)
         .bind(RUN_LEASE_SECS)
+        .bind(agent_id)
+        .bind(attempt_kind)
         .execute(&*self.pool)
         .await
         .map_err(|e| anyhow!("mark routine agent turn started {run_id}: {e}"))?;
+
+        Ok(result.rows_affected() == 1)
+    }
+
+    pub async fn schedule_agent_retry(
+        &self,
+        run_id: &str,
+        next_retry_at: DateTime<Utc>,
+        result_json: Option<Value>,
+        error: &str,
+        failed_agent_id: Option<&str>,
+        attempt_kind: &str,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            r#"
+            UPDATE routine_runs
+            SET action = 'agent',
+                turn_id = NULL,
+                next_retry_at = $2,
+                retry_count = retry_count + 1,
+                result_json = $3,
+                error = $4,
+                owned_tmux_session = NULL,
+                lease_expires_at = NOW() + ($5::bigint * INTERVAL '1 second'),
+                attempts = COALESCE(attempts, '[]'::jsonb) || jsonb_build_array(
+                    jsonb_build_object(
+                        'event', 'retry_scheduled',
+                        'agent_id', $6,
+                        'kind', $7,
+                        'error', $4,
+                        'next_retry_at', $2,
+                        'at', NOW()
+                    )
+                ),
+                updated_at = NOW()
+            WHERE id = $1
+              AND status = 'running'
+            "#,
+        )
+        .bind(run_id)
+        .bind(next_retry_at)
+        .bind(result_json)
+        .bind(error)
+        .bind(RUN_LEASE_SECS)
+        .bind(failed_agent_id)
+        .bind(attempt_kind)
+        .execute(&*self.pool)
+        .await
+        .map_err(|e| anyhow!("schedule routine agent retry {run_id}: {e}"))?;
 
         Ok(result.rows_affected() == 1)
     }
@@ -2258,6 +2391,26 @@ impl RoutineStore {
         .map_err(|e| anyhow!("record routine discord log result {run_id}: {e}"))?;
 
         Ok(result.rows_affected() == 1)
+    }
+
+    pub async fn get_run_discord_log_failure(
+        &self,
+        run_id: &str,
+    ) -> Result<Option<RunDiscordLogFailure>> {
+        let state: Option<RunDiscordLogFailure> = sqlx::query_as(
+            r#"
+            SELECT discord_log_status AS status,
+                   discord_log_error AS error
+            FROM routine_runs
+            WHERE id = $1
+              AND discord_log_status = 'failed'
+            "#,
+        )
+        .bind(run_id)
+        .fetch_optional(&*self.pool)
+        .await
+        .map_err(|e| anyhow!("load routine run discord log failure {run_id}: {e}"))?;
+        Ok(state)
     }
 
     pub async fn record_run_discord_log_section(
@@ -2609,6 +2762,8 @@ impl RoutineStore {
             run_id,
             routine_id: candidate.id,
             agent_id: candidate.agent_id,
+            fallback_agent_id: candidate.fallback_agent_id,
+            max_retries: candidate.max_retries,
             script_ref: candidate.script_ref,
             name: candidate.name,
             execution_strategy: candidate.execution_strategy,
@@ -2620,6 +2775,29 @@ impl RoutineStore {
     }
 
     async fn close_run(&self, run_id: &str, close: CloseRun<'_>) -> Result<bool> {
+        let checkpoint_size_error = match close.checkpoint.as_ref() {
+            Some(checkpoint) => checkpoint_size_error(checkpoint, self.max_checkpoint_bytes)?,
+            None => None,
+        };
+        let mut result_json = close.result_json;
+        let mut checkpoint = close.checkpoint;
+        if let Some(message) = checkpoint_size_error.as_deref() {
+            result_json = Some(json!({
+                "status": "failed",
+                "error": message,
+                "checkpoint_rejected": true,
+                "max_checkpoint_bytes": self.max_checkpoint_bytes,
+            }));
+            checkpoint = None;
+        }
+        let run_status = if checkpoint_size_error.is_some() {
+            "failed"
+        } else {
+            close.run_status
+        };
+        let error = checkpoint_size_error.as_deref().or(close.error);
+        let last_result = checkpoint_size_error.as_deref().or(close.last_result);
+
         let mut tx = self.pool.begin().await?;
 
         let target: Option<(String, Option<String>, Option<DateTime<Utc>>, DateTime<Utc>)> =
@@ -2682,8 +2860,8 @@ impl RoutineStore {
         )
         .bind(&routine_id)
         .bind(scheduled_next_due_at)
-        .bind(&close.checkpoint)
-        .bind(close.last_result)
+        .bind(&checkpoint)
+        .bind(last_result)
         .bind(close.pause_routine)
         .bind(run_id)
         .bind(should_update_next_due_at)
@@ -2705,16 +2883,17 @@ impl RoutineStore {
                 error = $5,
                 finished_at = NOW(),
                 lease_expires_at = NULL,
+                next_retry_at = NULL,
                 updated_at = NOW()
             WHERE id = $1
               AND status = 'running'
             "#,
         )
         .bind(run_id)
-        .bind(close.run_status)
+        .bind(run_status)
         .bind(close.action)
-        .bind(&close.result_json)
-        .bind(close.error)
+        .bind(&result_json)
+        .bind(error)
         .execute(&mut *tx)
         .await
         .map_err(|e| anyhow!("close run {run_id}: update run: {e}"))?;
@@ -2774,6 +2953,33 @@ fn validate_timeout_secs(timeout_secs: Option<i32>) -> Result<()> {
         return Err(anyhow!("routine timeout_secs must be greater than zero"));
     }
     Ok(())
+}
+
+fn validate_max_retries(max_retries: Option<i32>) -> Result<()> {
+    if let Some(value) = max_retries
+        && value < 0
+    {
+        return Err(anyhow!(
+            "routine max_retries must be greater than or equal to zero"
+        ));
+    }
+    Ok(())
+}
+
+fn checkpoint_size_error(
+    checkpoint: &Value,
+    max_checkpoint_bytes: usize,
+) -> Result<Option<String>> {
+    let bytes = serde_json::to_vec(checkpoint)
+        .map_err(|e| anyhow!("serialize routine checkpoint for size check: {e}"))?
+        .len();
+    if bytes > max_checkpoint_bytes {
+        Ok(Some(format!(
+            "routine checkpoint is too large: {bytes} bytes exceeds max_checkpoint_bytes {max_checkpoint_bytes}"
+        )))
+    } else {
+        Ok(None)
+    }
 }
 
 enum ParsedRoutineSchedule {
@@ -3005,10 +3211,10 @@ struct CloseRun<'a> {
 #[cfg(test)]
 mod tests {
     use super::{
-        API_FRICTION_OBSERVATION_QUERY, include_automation_candidate_card_observations,
-        next_due_after, next_due_after_anchor, parse_schedule_interval,
-        precomputed_observation_from_kv, resume_without_next_due_is_invalid, truncate_chars,
-        validate_routine_schedule,
+        API_FRICTION_OBSERVATION_QUERY, checkpoint_size_error,
+        include_automation_candidate_card_observations, next_due_after, next_due_after_anchor,
+        parse_schedule_interval, precomputed_observation_from_kv,
+        resume_without_next_due_is_invalid, truncate_chars, validate_routine_schedule,
     };
     use chrono::{TimeZone, Timelike, Utc};
     use serde_json::Value;
@@ -3067,6 +3273,13 @@ mod tests {
         assert!(validate_routine_schedule("@daily").is_err());
         assert!(validate_routine_schedule("* * * * * *").is_err());
         assert!(validate_routine_schedule("60 9 * * *").is_err());
+    }
+
+    #[test]
+    fn checkpoint_size_error_reports_oversized_payload() {
+        let checkpoint = serde_json::json!({"payload": "abcdef"});
+        assert!(checkpoint_size_error(&checkpoint, 8).unwrap().is_some());
+        assert!(checkpoint_size_error(&checkpoint, 128).unwrap().is_none());
     }
 
     #[test]

--- a/src/services/routines/store.rs
+++ b/src/services/routines/store.rs
@@ -2881,6 +2881,19 @@ impl RoutineStore {
                 action = $3,
                 result_json = $4,
                 error = $5,
+                attempts = CASE
+                    WHEN $3 = 'agent' THEN COALESCE(attempts, '[]'::jsonb) || jsonb_build_array(
+                        jsonb_build_object(
+                            'event', 'closed',
+                            'agent_id', COALESCE($4::jsonb ->> 'agent_id', $4::jsonb ->> 'failed_agent_id'),
+                            'kind', COALESCE($4::jsonb ->> 'attempt_kind', 'primary'),
+                            'outcome', $2,
+                            'error', $5,
+                            'at', NOW()
+                        )
+                    )
+                    ELSE attempts
+                END,
                 finished_at = NOW(),
                 lease_expires_at = NULL,
                 next_retry_at = NULL,


### PR DESCRIPTION
## 목표

루틴(routine)의 agent 액션이 시작 실패·턴 타임아웃으로 죽을 때 단순히 `failed`로 끝나던 동작을, 영속적인 재시도 → fallback agent → 최종 실패의 복구 단계로 전환한다. 재시도 대기 상태는 실행 중(`routine_runs`)인 행에 그대로 남겨 부모 `routines.in_flight_run_id` 가드가 중복 클레임을 계속 막도록 하고, 동시에 무한정 커지는 checkpoint payload를 상한으로 차단해 저장소를 보호한다. post-condition: 일시적 실패가 자동 복구되고, 복구 시도 이력(`attempts`)과 사용된 agent/attempt 메타데이터가 관측 가능해진다.

## 쉬운 설명

예약 자동화(루틴)가 agent 실행에 실패해도 곧바로 포기하지 않고, 정해진 횟수만큼 지수 백오프로 자동 재시도한다. 재시도를 모두 소진하면 미리 지정한 대체 agent(fallback)로 한 번 더 시도한다. 그래도 실패하면 그때 실패로 마감한다. Discord 로그에는 어떤 agent가 몇 번째 시도(primary/retry/fallback)로 돌았는지가 함께 표시된다.

## 개선되는 것

### Fix 1 — 영속적 재시도 + fallback 복구 상태머신

- Before: agent 시작 실패 또는 턴 타임아웃 시 run을 즉시 `failed`로 마감. 일시적 장애도 영구 실패로 처리되고 복구 경로가 없었다.
- After: 실패 시 복구 계획(`AgentFailureRecoveryPlan`)이 Retry → Fallback → Fail 순으로 결정된다.
  - Retry: `max_retries`가 남아 있고 attempt가 fallback이 아니면 `retry_count`를 올리고 `next_retry_at`을 지수 백오프(60s, 120s, … 최대 900s)로 잡는다. 이때 run은 `running` 상태를 유지하고 `turn_id`만 NULL로 비워, 부모 루틴의 `in_flight_run_id` 가드가 중복 클레임을 계속 막는다.
  - Fallback: 재시도 소진 후 `fallback_agent_id`가 primary와 다르고 아직 fallback을 쓰지 않았다면(`attempts`에 fallback 이벤트 없음) 대체 agent로 1회 새 턴을 시작한다.
  - Fail: 위 경로가 모두 불가하면 `failed`로 마감.
- 폴러(`poll_agent_runs`)는 `turn_id`가 NULL이면서 `next_retry_at`이 도래한 run을 `restart_due_retry`로 재기동한다. prompt나 `agent_id`가 유실됐으면 안전하게 `failed` 처리.

### Fix 2 — checkpoint payload 크기 상한

- Before: run이 만들어낸 checkpoint를 크기 검증 없이 그대로 영속화. 비대한 payload가 저장소를 압박할 수 있었다.
- After: `routines.max_checkpoint_bytes`(기본 256 KiB) 설정 추가. `close_run`에서 직렬화 크기를 초과하면 checkpoint를 버리고 run을 `failed`로 마감하며 `checkpoint_rejected: true`/`max_checkpoint_bytes`를 result_json에 남긴다. 0 값은 런타임 설정 검증에서 거부.

### Fix 3 — 복구 이력/메타데이터 관측성

- Before: 어떤 agent가 어떤 시도로 실행됐는지, Discord 로깅이 실패했는지 알 수 없었다.
- After: `routine_runs.attempts`(JSONB)에 started/retry_scheduled/closed 이벤트를 누적하고, 각 outcome의 result_json에 `agent_id`/`attempt_kind`/`retry_count`를 실어 Discord 로그(`agent`, `attempt`, `retry_count`, `discord_log_warning` 필드)에 노출한다.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| agent 턴 타임아웃 (max_retries=2) | run 즉시 `failed` | `retry_count` 증가 + `next_retry_at` 백오프, run은 `running` 유지 후 폴러가 재기동 |
| 재시도 소진 + fallback_agent_id 지정 | (재시도 자체가 없음) | 대체 agent로 1회 새 턴 시작, fallback 1회만 허용 |
| run이 256 KiB 초과 checkpoint 반환 | 무제한 영속화 | checkpoint 폐기 + run `failed`, result_json에 `checkpoint_rejected: true` |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| attach/patch에서 `fallback_agent_id == agent_id` | `validate_distinct_fallback_agent`가 400 반환 | 자기 자신으로의 fallback 차단 |
| `max_retries`에 음수 전달 | `validate_max_retries_request`가 400 반환 | 잘못된 설정 진입 차단 |
| fallback agent까지 시작 실패 | primary + fallback 오류를 합친 메시지로 `failed` 마감 | 무한 fallback 루프 없이 1회로 종료 |

## 해결한 내용

- `migrations/postgres/0072_routine_fallback_retry.sql` (신규): `routines`에 `fallback_agent_id`(agents FK, ON DELETE SET NULL)·`max_retries`, `routine_runs`에 `retry_count`·`next_retry_at`·`attempts(JSONB)` 컬럼과 재시도 도래 run 조회용 부분 인덱스 추가. 재시도 대기 상태를 running 행에 유지해 in_flight 가드를 보존하기 위한 스키마.
- `src/services/routines/agent_executor.rs`: 복구 상태머신(`AgentFailureRecoveryPlan`, `claimed_failure_recovery_plan`, `running_failure_recovery_plan`), 지수 백오프(`retry_next_at`), claimed/running 실패 핸들러, `restart_due_retry`, attempt 메타데이터 보존 헬퍼 추가. `start_turn`이 agent_id/attempt_kind를 인자로 받도록 변경.
- `src/services/routines/store.rs`: `schedule_agent_retry`·`get_run_discord_log_failure` 추가, `mark_agent_turn_started`가 agent_id/attempt_kind를 받아 `attempts`에 audit 이벤트 누적, `close_run`에 checkpoint 크기 가드(`checkpoint_size_error`)와 closed 이벤트 기록, 신규 컬럼들을 claim/list/get/insert/patch 쿼리에 반영. `RunningAgentRoutineRun`의 `turn_id`를 `Option`으로 완화해 재시도 대기 행을 표현.
- `src/server/routes/routines.rs`: attach/patch가 `fallback_agent_id`·`max_retries`를 수용하고, agent 존재성(`validate_agent_id_request`)·distinct fallback·비음수 max_retries 검증 추가. list/get 응답에 `default_timeout_secs` 포함.
- `src/config.rs` · `src/services/routines/runtime_config.rs`: `RoutinesConfig.max_checkpoint_bytes`(기본 256 KiB)와 0 거부 검증(`MaxCheckpointBytes`) 추가.
- `src/server/mod.rs`: 런타임 store 생성을 `new_with_timezone_and_checkpoint_limit`로 전환해 설정값 주입.
- `src/server/routes/docs.rs`: 신규 필드와 checkpoint 상한 동작을 API 문서 예시/파라미터에 반영.
- `src/services/routines/discord_log.rs`: outcome 섹션에 `agent`/`attempt`/`retry_count`/`discord_log_warning` 필드 노출.
- `runtime.rs`·`session_control.rs`: 신규 구조체 필드에 맞춰 테스트 픽스처 갱신.

## 검증

- CI 대응(2026-06-15): `retry_count INTEGER`에 `agentdesk-audit: allow-int4` 주석(max_retries로 bounded) + 0072 immutable 체크섬 재동기화 + change-surfaces freeze 동기화(docs.rs 5900, config.rs 2280, server/mod.rs 2413). → state-lint/migration-checksum/freshness/Script checks 통과.

- CI (head 기준): PostgreSQL tests (ubuntu-postgres) pass, Fast check + non-PG tests (ubuntu-latest) pass, Lint pass, High-risk recovery pass, Fast targeted tests pass.
- diff에 포함된 단위 테스트(로컬 실행 아님, CI에서 검증): `retry_next_at_uses_exponential_backoff`, `claimed_failure_plan_retries_before_fallback`, `claimed_failure_plan_falls_back_when_retry_disabled`, `running_failure_plan_retries_until_exhausted_then_fallback_once`, `pending_prompt_trims_and_rejects_empty_values`, `attempts_include_fallback_detects_kind`, `fallback_agent_must_differ_from_primary_agent`, `checkpoint_size_error_reports_oversized_payload`, `routine_max_checkpoint_bytes_rejects_zero`, `run_outcome_message_includes_agent_attempt_metadata`.
- **이 PR이 고쳐야 하는 실패 — Script checks fail**: "Postgres migration checksum guard failed: `migrations/postgres/0072_routine_fallback_retry.sql`: missing from immutable checksum manifest". 신규 마이그레이션 0072를 추가했지만 immutable checksum manifest에 해당 체크섬을 append하지 않아 발생. 이 PR diff가 직접 유발한 실패이므로 manifest에 항목을 추가해야 한다.
- 무관한 systemic 실패: Fast check + non-PG tests (windows-latest) 실패는 `error[E0433]: could not find 'tmux' in 'discord'`(turn_bridge/tmux 모듈 미해결)인 windows base/systemic 이슈로, 이 PR diff는 routines 코드만 건드리며 tmux/discord 모듈을 변경하지 않으므로 무관하다. Fast check cross OS required context (ubuntu-latest) 실패는 위 windows cross-OS 잡 실패를 그대로 전파하는 게이트(`cross_os_rust=true requires check_fast_cross_os to succeed`)일 뿐 별도 원인 없음.

