### PR TITLE
fix: resolve voice channels to their owning agent in the role-map resolver

### DIFF
--- a/src/services/discord/agentdesk_config.rs
+++ b/src/services/discord/agentdesk_config.rs
@@ -535,8 +535,36 @@ pub(super) fn resolve_role_binding(
     channel_name: Option<&str>,
 ) -> Option<RoleBinding> {
     let config = load_agentdesk_config()?;
-    let (agent, provider_key, channel) = find_channel_binding(&config, channel_id, channel_name)?;
-    Some(role_binding_from_channel(agent, provider_key, channel))
+    if let Some((agent, provider_key, channel)) =
+        find_channel_binding(&config, channel_id, channel_name)
+    {
+        return Some(role_binding_from_channel(agent, provider_key, channel));
+    }
+    // Voice channels are configured via `agents[].voice.channel_id`, not
+    // `agents[].channels`, so `find_channel_binding` never matches them. Without
+    // a role-map entry the voice transcript announce to the voice channel is
+    // rejected with 403 `channel not in role-map`, which makes voice_barge_in
+    // refuse the direct voice turn fallback and the agent never replies. Treat a
+    // configured voice channel as role-mapped to its owning agent so the
+    // announce + dispatch path is authorized automatically when voice is set up.
+    resolve_voice_channel_role_binding(&config, channel_id)
+}
+
+/// Resolve a role binding for a Discord voice channel declared in any agent's
+/// `voice.channel_id`. Returns `None` when no agent owns the channel.
+fn resolve_voice_channel_role_binding(
+    config: &Config,
+    channel_id: ChannelId,
+) -> Option<RoleBinding> {
+    let target = channel_id.get().to_string();
+    config.agents.iter().find_map(|agent| {
+        let voice_channel_id = agent.voice.channel_id.as_deref()?.trim();
+        if voice_channel_id != target {
+            return None;
+        }
+        let provider = ProviderKind::from_str(&agent.provider)?;
+        Some(role_binding_from_agent(agent, provider))
+    })
 }
 
 pub(super) fn resolve_worktree_isolation_policy(


### PR DESCRIPTION
## 목표

음성 채널(`agents[].voice.channel_id`)이 role-map 해석기에서 소유 에이전트로 매핑되지 않아 음성 announce/dispatch 경로가 403 `channel not in role-map`으로 거부되던 문제를 해결한다. 음성을 설정한 에이전트는 별도 설정 없이 자신의 음성 채널에 대해 자동으로 권한을 부여받아, 음성 통화에 정상적으로 응답하게 만드는 것이 목표다.

## 쉬운 설명

지금까지는 봇의 음성 채널이 권한 목록(role-map)에 등록되지 않아, 음성 대화 내용을 음성 채널에 알리려 할 때 차단되었습니다. 그 차단 때문에 음성 직접 응답(barge-in) 대체 경로까지 막혀 에이전트가 음성 호출에 아무 응답도 하지 않았습니다. 이제 `voice.channel_id`로 설정된 음성 채널은 그 채널을 소유한 에이전트에 자동으로 연결되어, 음성 설정만 해두면 별도 작업 없이 음성 응답이 동작합니다.

## 개선되는 것

### Fix 1 — 음성 채널을 소유 에이전트로 role-map 매핑

- Before: `resolve_role_binding`은 `find_channel_binding`(텍스트 채널용, `agents[].channels` 기준)만 조회했습니다. 음성 채널은 `agents[].voice.channel_id`에 설정되므로 매칭에 실패해 `None`이 반환되고, 음성 transcript announce가 403 `channel not in role-map`으로 거부되며 `voice_barge_in`이 직접 음성 턴 대체를 거부해 에이전트가 음성에 응답하지 못했습니다.
- After: `find_channel_binding`이 실패하면 새 `resolve_voice_channel_role_binding`로 폴백합니다. 설정된 모든 에이전트를 순회하며 `voice.channel_id`(trim 처리)가 대상 채널 ID와 일치하는 에이전트를 찾고, 그 에이전트의 `provider`로 role binding을 생성해 반환합니다. 일치하는 에이전트가 없으면 기존과 동일하게 `None`을 반환합니다.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| `voice.channel_id`로 설정된 음성 채널에서 role 조회 | `None` 반환 → 매핑 없음 | 소유 에이전트로 매핑된 `RoleBinding` 반환 |
| 음성 transcript를 음성 채널에 announce | 403 `channel not in role-map`으로 거부 | role-map 통과 → announce/dispatch 권한 부여 |
| 음성 호출에 대한 에이전트 응답 | barge-in 대체 경로 거부, 무응답 | 직접 음성 턴 대체 경로 동작, 정상 응답 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 어떤 에이전트도 해당 음성 채널을 소유하지 않음 | 폴백이 `None` 반환 | 기존 거부 동작 유지, 무권한 채널 권한 상승 없음 |
| 텍스트 채널(`agents[].channels`)로 조회 | `find_channel_binding`이 먼저 매칭되어 즉시 반환 | 폴백 미실행, 기존 텍스트 경로 영향 없음 |
| `provider` 문자열이 유효하지 않음 | `ProviderKind::from_str` 실패 시 해당 에이전트 건너뜀 | 잘못된 설정으로 인한 binding 생성 방지 |

## 해결한 내용

- `src/services/discord/agentdesk_config.rs`
  - `resolve_role_binding`: 단일 표현식 반환에서, `find_channel_binding` 성공 시 조기 반환하고 실패 시 음성 채널 폴백을 호출하는 구조로 변경. 텍스트 채널 우선 매칭을 보존하면서 음성 채널 미매칭 케이스를 보강하기 위함.
  - `resolve_voice_channel_role_binding`(신규): `config.agents`를 순회해 `voice.channel_id`(trim)와 대상 `channel_id`가 일치하는 에이전트를 찾아 `role_binding_from_agent`로 binding을 생성. 소유 에이전트가 없으면 `None` 반환. 음성 설정 시 announce/dispatch 경로를 자동 인가하기 위함.

## 검증

- CI 체크 전체 통과(actions run 27497309226 기준):
  - Fast check + non-PG tests (ubuntu-latest): pass
  - Fast targeted tests (ubuntu-latest): pass
  - Lint / Script checks / High-risk recovery / Changed paths 등 필수 컨텍스트: pass
  - Dashboard (Node 22), PostgreSQL tests (ubuntu-postgres), 매트릭스 OS 잡: skipping (변경 범위와 무관해 미실행)
- 변경 범위는 Discord role-map 해석기 단일 파일(`agentdesk_config.rs`)로 한정되며, 위 CI 외에 로컬 cargo 실행 등 추가로 확인된 테스트 증거는 없음.

## 배경

upstream `kunkunGames/AgentDesk` 포크에서 main으로 클린 cherry-pick된 자체 완결 개선(원본 커밋 99e7ba1, upstream #496).
