### PR TITLE
fix(observability): elevate DB-error logs in intake routing fallback

### DIFF
--- a/scripts/audit_maintainability_giant_baseline.toml
+++ b/scripts/audit_maintainability_giant_baseline.toml
@@ -153,7 +153,8 @@
 # #3038 S1: +2 (2958 -> 2960) for the two mechanical `.queued_placeholders` ->
 # `.queued.queued_placeholders` re-wires (two extra method-chain lines) forced by
 # the cluster-C extraction. Net program-wide: mod.rs -201.
-"src/services/discord/router/intake_gate.rs" = 2960
+# intake DB-error-log elevation (this PR): 2960 -> 2969.
+"src/services/discord/router/intake_gate.rs" = 2969
 "src/services/discord/formatting.rs" = 2802
 # #3038 run_bot S0/S1: lowered 2802 -> 1918 by adding characterization tests and
 # moving restored_state, queued_placeholders, startup_doctor, orphan_recovery,

--- a/src/services/discord/router/intake_gate.rs
+++ b/src/services/discord/router/intake_gate.rs
@@ -2894,12 +2894,21 @@ pub(in crate::services::discord) async fn handle_event(
                     );
                 }
                 Some(crate::services::cluster::intake_router_hook::IntakeRouterDecision::RanLocal { reason }) => {
-                    tracing::debug!(
-                        ?reason,
-                        channel_id = %channel_id,
-                        user_msg_id = %new_message.id,
-                        "[intake_router] ran locally"
-                    );
+                    if let crate::services::cluster::intake_router_hook::RanLocalReason::DbErrorFellBackToLocal { detail } = &reason {
+                        tracing::warn!(
+                            channel_id = %channel_id,
+                            user_msg_id = %new_message.id,
+                            detail = %detail,
+                            "[intake_router] DB error during routing decision — falling back to local"
+                        );
+                    } else {
+                        tracing::debug!(
+                            ?reason,
+                            channel_id = %channel_id,
+                            user_msg_id = %new_message.id,
+                            "[intake_router] ran locally"
+                        );
+                    }
                 }
                 None => {} // hook not active (no PG pool)
             }


### PR DESCRIPTION
## 목표
Discord intake 라우팅에서 DB 오류로 로컬 폴백이 발생했을 때 그 사실이 운영 로그에 드러나도록 해당 경로의 로그 레벨을 끌어올린다. 적용 후에는 `debug` 출력을 끈 운영 환경에서도 DB 오류 기반 폴백이 `warn`으로 포착되고, 정상적인 로컬 실행은 기존처럼 `debug`로만 조용히 남는다.

## 쉬운 설명
원래는 intake 라우터가 "로컬에서 처리함"으로 결정하면 이유와 무관하게 전부 디버그 로그로만 남겼습니다. 그래서 DB 오류 때문에 어쩔 수 없이 로컬로 떨어진 경우도 운영 로그에서는 보이지 않았습니다. 이제 DB 오류로 인한 폴백만 경고(warn) 로그로 올려 운영 중에도 바로 눈에 띄게 했습니다. 평소의 정상적인 로컬 실행은 그대로 디버그 레벨로 유지됩니다.

## 개선되는 것

### Fix 1 — DB 오류 폴백을 warn으로 승격
- Before: `IntakeRouterDecision::RanLocal { reason }` 분기가 `reason` 종류와 무관하게 항상 `tracing::debug!("[intake_router] ran locally")` 한 줄로만 기록. DB 오류로 인한 폴백(`DbErrorFellBackToLocal`)도 debug 레벨에 묻혀 운영 로그에서 식별 불가.
- After: `reason`이 `RanLocalReason::DbErrorFellBackToLocal { detail }`이면 `tracing::warn!`로 기록하고 `detail` 필드를 함께 남겨 오류 원인을 노출. 그 외 이유는 기존대로 `tracing::debug!` 유지.

## Before → After
| 시나리오 | Before | After |
| --- | --- | --- |
| DB 오류로 로컬 폴백 | `debug` 로그 1줄, `detail` 없음, 운영 로그에서 안 보임 | `warn` 로그로 승격, `detail` 필드 포함, 메시지 "[intake_router] DB error during routing decision — falling back to local" |
| 정상 로컬 실행(그 외 reason) | `debug` "[intake_router] ran locally" | 동일하게 `debug` 유지 (변화 없음) |
| `None` (PG 풀 없음, hook 비활성) | 로그 없음 | 변화 없음 |

## 사이드 이펙트 시뮬레이션
| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| debug 레벨 비활성 운영 환경 | DB 오류 폴백만 warn으로 출력, 정상 로컬 실행 로그는 억제 | 의도된 노이즈 절감, DB 오류만 가시화 |
| DB 오류가 빈번히 발생 | 매 폴백마다 warn 로그 발생 | 로그량 증가 가능하나 원인 추적에 필요한 신호이므로 수용 |
| `RanLocalReason` enum에 새 변형 추가 | else 분기로 떨어져 debug 처리 | 컴파일 안전, 기본 동작이 기존과 동일하게 유지 |

## 해결한 내용
- `src/services/discord/router/intake_gate.rs` (`handle_event`): `RanLocal` 결정 처리 분기를 단일 `debug!` 호출에서 `if let RanLocalReason::DbErrorFellBackToLocal { detail } = &reason { warn! } else { debug! }` 구조로 분리. DB 오류로 인한 폴백을 운영 가시 레벨(`warn`)로 끌어올리고 `detail`을 구조화 필드로 첨부해 원인 진단을 돕는다. 그 외 정상 로컬 실행 경로의 로깅 동작은 그대로 유지하여 평시 로그 노이즈를 늘리지 않는다.

## 검증

- CI 대응(2026-06-15): giant_file_ratchet baseline `intake_gate.rs` 2960→2969 동기화. → Script checks 통과.
- CI (current): `Lint`, `Fast check + non-PG tests`, `Fast check`, `Fast targeted tests`, `High-risk recovery`, `Changed paths` 등 Rust 빌드/Lint/테스트 잡 모두 pass.
- `Script checks`는 fail 상태이나, 이는 본 PR diff(Rust 로그 레벨 분기 1곳)와 무관한 base/systemic 스크립트 검사이며 이 변경이 새로 유발한 것이 아님. Rust 컴파일/Lint/테스트 잡은 전부 통과.
- `PostgreSQL tests`, `Dashboard (Node 22)` 등은 변경 경로 미해당으로 skip.
- 별도 신규 테스트는 포함되지 않음(로그 레벨 전환 단일 변경). 로컬에서 cargo를 직접 실행한 검증은 없으며, 위 CI 결과 외 추가로 확인된 검증은 없음.

