### PR TITLE
fix(dashboard): allow discord:// channel deep links in markdown rendering

### DIFF
--- a/dashboard/src/components/common/MarkdownContent.test.tsx
+++ b/dashboard/src/components/common/MarkdownContent.test.tsx
@@ -13,13 +13,29 @@ test("MarkdownContent renders links safely with target blank and noopener norefe
     root.render(
       <MarkdownContent
         content={
-          "[external](https://example.com) [same-origin](http://localhost:3000/settings) [protocol-relative](//localhost:3000/help) [anchor](#details) [evil](javascript:alert(1))"
+          "[external](https://example.com) [same-origin](http://localhost:3000/settings) [protocol-relative](//localhost:3000/help) [anchor](#details) [evil](javascript:alert(1)) [discord](discord://discord.com/channels/1/2) [discord-message](discord://discord.com/channels/1/2/3) [bad-discord](discord://evil.com/alert(1)) [bad-discord-2](discord:alert(1)) [bypass-discord](DiScOrD://evil.com/alert(1))"
         }
       />
     );
   });
 
   const links = div.querySelectorAll("a");
+  const parsedHrefs = Array.from(links).map((link) => link.getAttribute("href"));
+
+  expect(parsedHrefs).toContain("https://example.com");
+  expect(parsedHrefs).toContain("http://localhost:3000/settings");
+  expect(parsedHrefs).toContain("//localhost:3000/help");
+  expect(parsedHrefs).toContain("#details");
+  expect(parsedHrefs).not.toContain("javascript:alert(1)");
+
+  // Authorized discord links should be preserved.
+  expect(parsedHrefs).toContain("discord://discord.com/channels/1/2");
+  expect(parsedHrefs).toContain("discord://discord.com/channels/1/2/3");
+
+  // Unauthorized discord links should be stripped.
+  expect(parsedHrefs).not.toContain("discord://evil.com/alert(1)");
+  expect(parsedHrefs).not.toContain("discord:alert(1)");
+  expect(parsedHrefs).not.toContain("DiScOrD://evil.com/alert(1)");
 
   for (const link of links) {
     if (link.getAttribute("href") === "https://example.com") {
@@ -32,8 +48,6 @@ test("MarkdownContent renders links safely with target blank and noopener norefe
     ) {
       expect(link.hasAttribute("target")).toBe(false);
       expect(link.hasAttribute("rel")).toBe(false);
-    } else {
-      expect(link.getAttribute("href")).not.toBe("javascript:alert(1)");
     }
   }
 });

--- a/dashboard/src/components/common/MarkdownContent.tsx
+++ b/dashboard/src/components/common/MarkdownContent.tsx
@@ -1,4 +1,4 @@
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 interface Props {
@@ -31,6 +31,17 @@ export default function MarkdownContent({ content, className }: Props) {
     <div className={classes}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
+        urlTransform={(url) => {
+          const lowerUrl = url.trim().toLowerCase();
+          if (lowerUrl.startsWith("discord:")) {
+            // Only allow specific discord protocol formats used in the app, strip others
+            if (/^discord:\/\/discord\.com\/channels\/[^\/]+\/[^\/]+(\/[^\/]+)?$/.test(lowerUrl)) {
+              return url;
+            }
+            return "";
+          }
+          return defaultUrlTransform(url);
+        }}
         components={{
           a: ({ node, ...props }) => {
             const externalProps = isExternalHref(props.href)


### PR DESCRIPTION
## 목표

`MarkdownContent`에서 `react-markdown`의 `defaultUrlTransform`이 `discord://` URI를 무조건 제거하면서, 백엔드가 내보내는 디스코드 채널 딥링크(`discord://discord.com/channels/{guild}/{channel}`)가 마크다운 렌더링 시 클릭 불가능한 텍스트로 깨지던 문제를 해결한다. 허용 포맷의 디스코드 딥링크는 보존하되, 그 외 모든 비표준/위험 스킴은 기존처럼 차단하는 화이트리스트 방식을 적용한다.

## 쉬운 설명

이전에는 메시지 본문에 디스코드 채널 링크가 있어도 마크다운에서 링크가 사라져 사용자가 클릭할 수 없었습니다. 이제 정해진 형태의 디스코드 채널 링크만 살아남아 정상적으로 클릭됩니다. `javascript:`나 위장된 디스코드 링크 같은 위험한 URL은 여전히 제거됩니다.

## 개선되는 것

### Fix 1 — discord:// 채널 딥링크 화이트리스트 허용

- Before: `react-markdown`이 `defaultUrlTransform`으로 모든 `discord:` 스킴을 빈 문자열로 치환 → 채널 딥링크가 `href` 없이 렌더링되어 클릭 불가.
- After: `urlTransform`을 직접 지정해 `discord://discord.com/channels/{guild}/{channel}` 및 선택적 메시지 ID(`/{message}`) 형태만 정규식으로 허용하고 원본 URL을 반환. 그 외 `discord:` 스킴(`discord://evil.com/...`, `discord:alert(1)`, 대소문자 위장 `DiScOrD://...`)은 빈 문자열로 차단. 디스코드 외 URL은 `defaultUrlTransform`에 위임해 기존 안전 동작을 그대로 유지.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| `discord://discord.com/channels/1/2` | href 제거되어 클릭 불가 | href 보존, 정상 링크 |
| `discord://discord.com/channels/1/2/3` (메시지 ID 포함) | href 제거 | href 보존 |
| `discord://evil.com/...` / `DiScOrD://...` / `discord:alert(1)` | (이미 제거됨) | 빈 문자열로 차단 유지 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| `javascript:alert(1)` 등 비디스코드 위험 스킴 | `defaultUrlTransform`에 위임 → 제거 | 기존 XSS 방어 유지 |
| `https://`, `//host`, `#anchor` 등 일반 링크 | `defaultUrlTransform`에 위임 | 외부/동일 출처/앵커 링크 동작 변화 없음 |
| 채널 ID 자리에 슬래시 포함 등 형식 불일치 discord 링크 | 정규식 미스매치 → 빈 문자열 | 화이트리스트 밖은 일괄 차단 |

## 해결한 내용

- `dashboard/src/components/common/MarkdownContent.tsx`: `react-markdown`에서 `defaultUrlTransform`을 함께 import하고, `ReactMarkdown`에 `urlTransform` 콜백을 추가. 입력 URL을 trim+소문자화해 `discord:` 접두 여부를 판별하고, 허용 정규식에 매칭될 때만 원본 URL을 반환하며 나머지 discord 스킴은 차단, 비디스코드 URL은 기존 `defaultUrlTransform`으로 위임한다. 보안(스킴 화이트리스트)을 유지하면서 정당한 딥링크만 통과시키는 것이 목적.
- `dashboard/src/components/common/MarkdownContent.test.tsx`: 링크 렌더링 테스트에 허용/차단 discord 케이스를 추가. `getAttribute("href")` 배열을 모아 허용 딥링크 2종 보존과 위장/비표준 discord 3종 차단을 명시적으로 단언하고, 기존 `javascript:` 차단 단언을 상단 화이트리스트 검증으로 통합.

## 검증

- Fast targeted tests (ubuntu-latest): pass — 변경 경로 대상 테스트 통과.
- Fast check / Fast check cross OS / Lint / Script checks / High-risk recovery / Changed paths 등 그 외 게이트: pass.
- Dashboard (Node 22) / Dashboard required context: fail — 단, 이는 `scripts/verify-dashboard.sh`의 `npm ci` 직후 "Dashboard security audit (high+)" 단계에서 사전 존재하던 esbuild/vite high-severity advisory(GHSA-gv7w-rqvm-qjhr)로 빌드/테스트 이전에 실패한 것으로, 본 PR의 마크다운 렌더러 변경(2개 파일, +29/-4)과 무관한 의존성 레벨 base/systemic 이슈다.
- 로컬에서 cargo/npm 테스트를 직접 실행하지는 않았으며, 위 검증은 모두 CI 결과 기준이다.
