### PR TITLE
fix(turn-orchestrator): keep distinct uploads out of empty-text dedup

### DIFF
--- a/src/services/turn_orchestrator.rs
+++ b/src/services/turn_orchestrator.rs
@@ -156,6 +156,7 @@ pub(crate) fn enqueue_intervention(
             && last.text == intervention.text
             && last.reply_context == intervention.reply_context
             && last.has_reply_boundary == intervention.has_reply_boundary
+            && last.pending_uploads == intervention.pending_uploads
             && intervention_age_since(last, &intervention) <= INTERVENTION_DEDUP_WINDOW
         {
             return EnqueueInterventionResult {
@@ -4267,6 +4268,24 @@ mod enqueue_refusal_reason_tests {
             result.refusal_reason,
             Some(EnqueueRefusalReason::LastItemDedup),
         );
+    }
+
+    #[test]
+    fn upload_bearing_interventions_are_not_deduped_by_empty_text() {
+        let now = Instant::now();
+        let mut first = intervention(1, "", now);
+        first.pending_uploads =
+            vec!["[File uploaded] one.png → /tmp/one.png (1 bytes)".to_string()];
+        let mut second = intervention(2, "", now);
+        second.pending_uploads =
+            vec!["[File uploaded] two.png → /tmp/two.png (2 bytes)".to_string()];
+        let mut queue = vec![first];
+
+        let result = enqueue_intervention(&mut queue, second);
+
+        assert!(result.enqueued);
+        assert_eq!(result.refusal_reason, None);
+        assert_eq!(queue.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## 목표

`turn_orchestrator`의 "직전 항목 dedup" 가드가 첨부 전용(빈 텍스트) 개입을 잘못 중복 처리하던 문제를 고친다. dedup 동등성 비교에 `pending_uploads`를 추가하여, 서로 다른 파일을 가진 첨부 메시지가 `INTERVENTION_DEDUP_WINDOW`(10초) 안에서 같은 작성자로부터 연속 도착해도 두 번째 개입이 조용히 버려지지 않고 큐에 정상 적재되도록 한다.

## 쉬운 설명

파일만 첨부하고 본문 없이 메시지를 빠르게 두 번 보내면, 이전에는 두 번째 파일이 "중복"으로 간주되어 사라졌습니다. 이제는 첨부 파일이 다르면 서로 다른 메시지로 인식되어 둘 다 처리됩니다. 진짜 똑같은 재전송(같은 본문 + 같은 첨부)만 여전히 중복으로 걸러집니다.

## 개선되는 것

### Fix 1 — dedup 동등성에 `pending_uploads` 포함

- **Before**: `enqueue_intervention`의 last-item dedup은 `author_id`, `text`, `reply_context`, `has_reply_boundary`만 비교했다. 본문이 빈 첨부 전용 개입 두 건이 같은 작성자로부터 10초 dedup 윈도우 내에 들어오면, 첨부 파일이 달라도 위 필드가 전부 동일하게 평가되어 두 번째 개입이 `LastItemDedup`으로 거부되고 파일이 유실되었다.
- **After**: 비교 조건에 `last.pending_uploads == intervention.pending_uploads` 한 줄을 추가했다. 첨부 집합이 다르면 dedup이 성립하지 않아 두 번째 개입이 정상 enqueue되며, 본문과 첨부가 모두 동일한 실제 rapid-resend만 기존대로 차단된다.

## Before → After

| 시나리오 | Before | After |
| --- | --- | --- |
| 빈 텍스트 + 서로 다른 첨부 2건 연속(10초 내) | 두 번째가 `LastItemDedup`으로 거부, 파일 유실 | 두 건 모두 enqueue, `refusal_reason = None` |
| 빈 텍스트 + 동일 첨부 동일 본문 재전송 | dedup으로 거부 | dedup으로 거부 (동작 유지) |
| 큐 길이(서로 다른 첨부 2건) | 1 (한 건만 남음) | 2 (둘 다 보존) |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
| --- | --- | --- |
| 본문/첨부 모두 동일한 즉시 재전송 | 추가된 조건도 동일하게 평가되어 여전히 dedup 성립 | rapid-resend 가드 정상 유지 |
| 첨부 없는(빈 `pending_uploads`) 동일 텍스트 개입 | 양쪽 모두 빈 vec로 동일 비교 → 기존과 동일하게 dedup | 텍스트 전용 경로 영향 없음 |
| dedup 윈도우(10초) 경과 후 도착 | 첨부 동일 여부와 무관하게 `intervention_age_since` 조건에서 이미 dedup 미성립 | 기존 타이밍 가드 영향 없음 |

## 해결한 내용

- `src/services/turn_orchestrator.rs` — `enqueue_intervention`의 last-item dedup 조건에 `last.pending_uploads == intervention.pending_uploads` 비교를 추가(+1줄). dedup 동등성을 첨부 집합까지 확장해, 서로 다른 파일을 담은 첨부 전용 개입이 동일하게 취급되어 유실되던 결함을 차단한다. 같은 파일에 회귀 테스트 `upload_bearing_interventions_are_not_deduped_by_empty_text`를 추가하여, 빈 텍스트 + 상이한 `pending_uploads` 두 건이 모두 enqueue되고 큐 길이가 2가 됨을 검증한다(+18줄). 합계 +19/-0.

## 검증

- CI run 27497312177 실제 결과 (gh pr checks 기준):
  - PASS: `Fast check + non-PG tests (ubuntu-latest)`, `Fast targeted tests (ubuntu-latest)`, `Fast check (ubuntu-latest)`, `Lint`, `High-risk recovery`, `Script checks`, `Changed paths`, `Dashboard required context`, `Lint/High-risk required context`.
  - FAIL: `Fast check + non-PG tests (windows-latest)`, `Fast check cross OS required context (ubuntu-latest)`.
  - SKIP: `PostgreSQL tests (ubuntu-postgres)`, `Dashboard (Node 22)`.
- 신규 단위 테스트 `upload_bearing_interventions_are_not_deduped_by_empty_text`는 diff에 포함되어 있으며, 통과한 Linux non-PG 테스트 잡 범위에서 컴파일·실행되어 enqueue 동작을 확인한다. (로컬에서 cargo를 직접 실행하지는 않았다.)
- windows-latest 잡 실패는 이 PR과 무관한 base/systemic 이슈다. 로그상 원인은 알려진 `error[E0433]: could not find tmux in discord`(및 `super`)로, Windows에서 `tmux` 모듈이 해석되지 않는 플랫폼 의존 문제이며 본 PR diff(단일 비교 조건 추가 + 단위 테스트)는 해당 코드를 건드리지 않는다. `Fast check cross OS required context` 실패는 windows 잡 실패가 전파된 집계 컨텍스트일 뿐이다.
