### PR TITLE
fix(claude_tui): auto-dismiss startup dialogs + keep follow-up wait alive during prior turn

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -334,6 +334,7 @@ src/
 │   │   ├── memento_feedback.rs
 │   │   ├── mod.rs
 │   │   ├── session.rs
+│   │   ├── startup_dialog.rs
 │   │   ├── transcript_tail.rs
 │   │   └── tui_relay.rs
 │   ├── cluster/

--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -1067,10 +1067,12 @@ which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync
   detector and prompt delivery surface (#2399 hardened the post-turn
   handoff deadline). Treat as giant-file territory; split before adding
   non-bugfix behavior beyond the readiness/cancel contract.
-- `src/services/claude_tui/input.rs` (1294) — Claude TUI input readiness
+- `src/services/claude_tui/input.rs` (1485) — Claude TUI input readiness
   detector, prompt delivery, and cancellation/offset handoff surface. Treat as
   giant-file territory; split before adding non-bugfix behavior beyond the
-  readiness/cancel contract.
+  readiness/cancel contract. (+191 from the #685/#720 reliability fixes:
+  startup-dialog auto-dismiss and keeping the follow-up readiness wait alive
+  while the prior turn streams.)
 - `src/services/memory/memento.rs` (1893).
 - `src/services/dispatched_sessions.rs` (1328) — dispatched session domain
   service. This is the post-#1515 SRP extraction target for route/database

--- a/src/services/claude_tui/input.rs
+++ b/src/services/claude_tui/input.rs
@@ -13,6 +13,14 @@ const PROMPT_READY_DEBUG_TAIL_LINES: usize = 24;
 const PROMPT_READY_DEBUG_TAIL_BYTES: usize = 4096;
 pub const FRESH_PROMPT_READY_TIMEOUT: Duration = Duration::from_secs(120);
 pub const FOLLOWUP_PROMPT_READY_TIMEOUT: Duration = Duration::from_secs(45);
+/// Extends #2416 (don't drop the user's follow-up when the pane is busy): when
+/// the transcript shows the PRIOR turn is still actively streaming
+/// (`TuiTurnState::is_busy`), `wait_for_prompt_ready_polling` treats the per-kind
+/// readiness `timeout` as a *stall* budget and keeps waiting up to this absolute
+/// ceiling, so a long turn no longer makes the next message vanish via
+/// `tui_warm_followup_busy_pre_submit`. The ceiling still bounds a genuinely
+/// wedged pane that never returns to a ready prompt.
+const PROMPT_READY_ACTIVE_TURN_WAIT_CEILING: Duration = Duration::from_secs(900);
 /// Maximum time we let the hook-event fast path block before falling back to
 /// the legacy pane-scrape polling loop. Fresh turns historically need a bit
 /// more headroom (cold start, MCP load) than follow-ups.
@@ -1090,6 +1098,7 @@ fn wait_for_prompt_ready_polling(
 ) -> Result<(), String> {
     let mut wait_interval = Duration::from_millis(100);
     let mut dialog_dismiss_attempts = 0usize;
+    let mut active_turn_extension_logged = false;
     loop {
         check_prompt_cancel(cancel_token)?;
         if transcript_idle_confirms_prompt_ready_without_capture(session_name, transcript_path) {
@@ -1164,11 +1173,54 @@ fn wait_for_prompt_ready_polling(
         }
         if start.elapsed() >= timeout {
             check_prompt_cancel(cancel_token)?;
+            // Extends #2416: a long PRIOR turn must not make us abandon this
+            // follow-up. The loop already resolves ready the instant the
+            // transcript goes Idle, so reaching the wall-clock `timeout` means
+            // the prior turn is still mid-flight. While the transcript confirms
+            // it is actively streaming (is_busy ⇒ Streaming/UserSubmitted; an
+            // Idle/Unknown read does NOT extend), keep waiting up to the absolute
+            // ceiling — the prompt returns once the turn finishes, so the
+            // follow-up is delivered sequentially instead of dropped.
+            let transcript_turn_active = transcript_path.is_some_and(|path| {
+                crate::services::claude_tui::transcript_tail::observe_transcript_turn_state(path)
+                    .is_busy()
+            });
+            if active_turn_warrants_wait_extension(
+                snapshot.tmux_pane_alive,
+                transcript_turn_active,
+                start.elapsed(),
+                PROMPT_READY_ACTIVE_TURN_WAIT_CEILING,
+            ) {
+                if !active_turn_extension_logged {
+                    active_turn_extension_logged = true;
+                    tracing::info!(
+                        tmux_session_name = session_name,
+                        readiness = readiness.label(),
+                        base_timeout_secs = timeout.as_secs(),
+                        ceiling_secs = PROMPT_READY_ACTIVE_TURN_WAIT_CEILING.as_secs(),
+                        "claude_tui readiness wait extended: prior turn still streaming; waiting for it to finish instead of dropping the follow-up"
+                    );
+                }
+                std::thread::sleep(wait_interval);
+                check_prompt_cancel(cancel_token)?;
+                wait_interval = std::cmp::min(wait_interval * 2, Duration::from_millis(1000));
+                continue;
+            }
             log_prompt_ready_timeout(session_name, readiness, timeout, &snapshot);
             return Err(format!(
-                "{PROMPT_READY_TIMEOUT_ERROR_PREFIX} {} prompt input readiness after {}s; reason=prompt_marker_not_detected; previous_tui_turn_still_running=true; capture_available={}",
+                "{PROMPT_READY_TIMEOUT_ERROR_PREFIX} {} prompt input readiness after {}s; reason={}; previous_tui_turn_still_running={}; prompt_marker_detected={}; prompt_draft_detected={}; capture_available={}",
                 readiness.label(),
                 timeout.as_secs(),
+                prompt_ready_timeout_reason(&snapshot),
+                // Mirror the computed value the debug log already records
+                // (`log_prompt_ready_timeout`) instead of the legacy hardcoded
+                // `true`: the pane is known alive here (a dead pane returned
+                // above), so this is `true` only when the pane never looked
+                // ready — i.e. a turn that is plausibly still running. An unsent
+                // draft means the turn ended, so it reports `false`.
+                snapshot.tmux_pane_alive && !snapshot.prompt_marker_detected,
+                snapshot.prompt_marker_detected,
+                snapshot.prompt_draft_detected,
                 snapshot.capture_available
             ));
         }
@@ -1178,12 +1230,91 @@ fn wait_for_prompt_ready_polling(
     }
 }
 
+/// Whether `wait_for_prompt_ready_polling` should keep waiting past the per-kind
+/// readiness `timeout` instead of failing. We only extend when the pane is alive
+/// AND the transcript confirms the prior turn is still actively streaming, and
+/// only up to an absolute `ceiling`. Pure so the policy is unit-testable without
+/// a live tmux pane.
+fn active_turn_warrants_wait_extension(
+    pane_alive: bool,
+    transcript_turn_active: bool,
+    elapsed: Duration,
+    ceiling: Duration,
+) -> bool {
+    pane_alive && transcript_turn_active && elapsed < ceiling
+}
+
+#[cfg(test)]
+mod active_turn_wait_extension_tests {
+    use super::active_turn_warrants_wait_extension;
+    use std::time::Duration;
+
+    #[test]
+    fn extends_only_when_pane_alive_and_turn_active_within_ceiling() {
+        let ceiling = Duration::from_secs(900);
+        let within = Duration::from_secs(60);
+
+        // Prior turn still streaming, pane alive, within ceiling → keep waiting
+        // (the follow-up must not be dropped just because the turn is long).
+        assert!(active_turn_warrants_wait_extension(
+            true, true, within, ceiling
+        ));
+        // Dead pane → never extend (the existing dead-pane error owns that case).
+        assert!(!active_turn_warrants_wait_extension(
+            false, true, within, ceiling
+        ));
+        // Transcript not confirmably active (Idle/Unknown) → do not extend; fail
+        // as before so a genuinely stuck/uncertain pane still times out.
+        assert!(!active_turn_warrants_wait_extension(
+            true, false, within, ceiling
+        ));
+        // At/!past the absolute ceiling → stop waiting even if still streaming.
+        assert!(!active_turn_warrants_wait_extension(
+            true, true, ceiling, ceiling
+        ));
+        assert!(!active_turn_warrants_wait_extension(
+            true,
+            true,
+            ceiling + Duration::from_secs(1),
+            ceiling
+        ));
+    }
+}
+
 fn pane_looks_ready_for_prompt(pane: &str) -> bool {
     crate::services::tmux_common::tmux_capture_indicates_claude_tui_ready_for_input(pane)
 }
 
 fn prompt_marker_confirms_prompt_ready(snapshot: &PromptReadinessSnapshot) -> bool {
     snapshot.prompt_marker_detected && !snapshot.prompt_draft_detected
+}
+
+/// Truthful root-cause attribution for a prompt-readiness timeout, derived from
+/// the final snapshot.
+///
+/// The legacy timeout copy hardcoded `reason=prompt_marker_not_detected` even
+/// when the marker WAS seen (as an unsent composer draft) or the pane capture
+/// failed outright. That sent every readiness-timeout investigation down the
+/// "the prompt never came back" path even when the real cause was a stuck draft
+/// or a blind capture — so the returned error disagreed with the debug log,
+/// which already records the computed signals. We classify by the strongest
+/// evidence present in the snapshot instead.
+fn prompt_ready_timeout_reason(snapshot: &PromptReadinessSnapshot) -> &'static str {
+    if !snapshot.capture_available {
+        // No usable pane capture: the readiness check was blind, so we cannot
+        // claim anything about the marker.
+        "pane_capture_unavailable"
+    } else if snapshot.prompt_draft_detected {
+        // The composer holds an unsent draft (`❯ <text>`), which deliberately
+        // blocks the ready match in `prompt_marker_confirms_prompt_ready`.
+        "prompt_draft_present"
+    } else if snapshot.prompt_marker_detected {
+        // The pane looked ready at least once but never confirmed within the
+        // window (e.g. the ready frame flickered behind transient chrome).
+        "prompt_marker_unconfirmed"
+    } else {
+        "prompt_marker_not_detected"
+    }
 }
 
 fn transcript_idle_confirms_prompt_ready_without_capture(
@@ -2177,11 +2308,63 @@ line 13";
     #[test]
     fn busy_followup_wait_timeout_message_uses_followup_label() {
         let synthetic = format!(
-            "{PROMPT_READY_TIMEOUT_ERROR_PREFIX} follow-up prompt input readiness after 45s; reason=prompt_marker_not_detected; previous_tui_turn_still_running=true; capture_available=true"
+            "{PROMPT_READY_TIMEOUT_ERROR_PREFIX} follow-up prompt input readiness after 45s; reason=prompt_marker_not_detected; previous_tui_turn_still_running=true; prompt_marker_detected=false; prompt_draft_detected=false; capture_available=true"
         );
         assert!(is_prompt_ready_timeout_error(&synthetic));
         assert!(synthetic.contains("follow-up"));
         assert!(synthetic.contains("45s"));
+    }
+
+    // The returned timeout copy must reflect the ACTUAL snapshot, not the legacy
+    // hardcoded `reason=prompt_marker_not_detected; previous_tui_turn_still_running=true`.
+    #[test]
+    fn prompt_ready_timeout_reason_reflects_snapshot() {
+        let base = PromptReadinessSnapshot {
+            prompt_marker_detected: false,
+            prompt_draft_detected: false,
+            tmux_pane_alive: true,
+            capture_available: true,
+            pane_tail: String::new(),
+        };
+
+        // No usable capture wins over everything else.
+        let blind = PromptReadinessSnapshot {
+            capture_available: false,
+            prompt_marker_detected: true,
+            prompt_draft_detected: true,
+            ..base.clone()
+        };
+        assert_eq!(
+            prompt_ready_timeout_reason(&blind),
+            "pane_capture_unavailable"
+        );
+
+        // An unsent draft is the cause, and the turn is NOT still running.
+        let draft = PromptReadinessSnapshot {
+            prompt_marker_detected: true,
+            prompt_draft_detected: true,
+            ..base.clone()
+        };
+        assert_eq!(prompt_ready_timeout_reason(&draft), "prompt_draft_present");
+        assert!(!(draft.tmux_pane_alive && !draft.prompt_marker_detected));
+
+        // Marker seen but never confirmed.
+        let unconfirmed = PromptReadinessSnapshot {
+            prompt_marker_detected: true,
+            ..base.clone()
+        };
+        assert_eq!(
+            prompt_ready_timeout_reason(&unconfirmed),
+            "prompt_marker_unconfirmed"
+        );
+
+        // The genuine "prompt never came back" case — and the only one that
+        // reports the turn as plausibly still running.
+        assert_eq!(
+            prompt_ready_timeout_reason(&base),
+            "prompt_marker_not_detected"
+        );
+        assert!(base.tmux_pane_alive && !base.prompt_marker_detected);
     }
 
     // #2416: wait_for_prompt_ready must be reachable as a public API so the

--- a/src/services/claude_tui/input.rs
+++ b/src/services/claude_tui/input.rs
@@ -30,6 +30,15 @@ const PROMPT_SUBMIT_CONFIRM_RETRIES: usize = 2;
 const SELECTOR_OPEN_TIMEOUT: Duration = Duration::from_secs(5);
 const PROMPT_READY_TIMEOUT_ERROR_PREFIX: &str = "timeout waiting for claude tui";
 pub const PROMPT_READY_CANCELLED_ERROR: &str = "claude tui prompt readiness wait cancelled";
+/// Cap on auto-dismiss key presses for Claude startup dialogs (resume-from-
+/// summary picker, workspace trust) per readiness wait. Startup can stack at
+/// most two dialogs back to back; if the pane still shows a dialog after this
+/// many Enters something unexpected is on screen and we fall back to the
+/// normal timeout path instead of blindly mashing Enter.
+const STARTUP_DIALOG_DISMISS_MAX_ATTEMPTS: usize = 5;
+/// Settle delay after dismissing a startup dialog so the TUI can redraw
+/// (either the next dialog or the composer prompt) before the next snapshot.
+const STARTUP_DIALOG_DISMISS_SETTLE: Duration = Duration::from_millis(500);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PromptReadinessKind {
@@ -1080,6 +1089,7 @@ fn wait_for_prompt_ready_polling(
     transcript_path: Option<&std::path::Path>,
 ) -> Result<(), String> {
     let mut wait_interval = Duration::from_millis(100);
+    let mut dialog_dismiss_attempts = 0usize;
     loop {
         check_prompt_cancel(cancel_token)?;
         if transcript_idle_confirms_prompt_ready_without_capture(session_name, transcript_path) {
@@ -1095,6 +1105,49 @@ fn wait_for_prompt_ready_polling(
         check_prompt_cancel(cancel_token)?;
         if prompt_marker_confirms_prompt_ready(&snapshot) {
             return Ok(());
+        }
+        // Startup dialogs (resume-from-summary picker, workspace trust) park
+        // the pane on an option selector whose highlighted `❯ 1. ...` row
+        // reads as a composer draft, so neither the marker check above nor
+        // the transcript fallback below would ever pass. Handle them before
+        // the transcript fallback so an idle transcript cannot confirm
+        // readiness while a modal dialog is still swallowing input.
+        if let Some(dialog) =
+            crate::services::claude_tui::startup_dialog::detect_claude_startup_dialog(
+                &snapshot.pane_tail,
+            )
+        {
+            use crate::services::claude_tui::startup_dialog::StartupDialogPlan;
+            match crate::services::claude_tui::startup_dialog::plan_startup_dialog_response(&dialog)
+            {
+                StartupDialogPlan::DismissWithEnter
+                    if dialog_dismiss_attempts < STARTUP_DIALOG_DISMISS_MAX_ATTEMPTS =>
+                {
+                    dialog_dismiss_attempts += 1;
+                    log_startup_dialog_dismiss(
+                        session_name,
+                        readiness,
+                        dialog.label(),
+                        dialog_dismiss_attempts,
+                    );
+                    run_actions(session_name, &[TuiInputAction::Enter], cancel_token)?;
+                    std::thread::sleep(STARTUP_DIALOG_DISMISS_SETTLE);
+                    check_prompt_cancel(cancel_token)?;
+                    continue;
+                }
+                StartupDialogPlan::DismissWithEnter => {
+                    // Dismiss budget exhausted with a dialog still on screen —
+                    // fall through to the regular timeout bookkeeping so the
+                    // canonical timeout error (with pane tail logging) fires.
+                }
+                StartupDialogPlan::FailUntrustedWorkspace { workspace } => {
+                    check_prompt_cancel(cancel_token)?;
+                    log_startup_dialog_untrusted_workspace(session_name, readiness, &workspace);
+                    return Err(format!(
+                        "claude tui startup blocked by workspace trust dialog for untrusted path '{workspace}'; refusing to auto-trust; fix the agent/channel workspace mapping so claude does not spawn there"
+                    ));
+                }
+            }
         }
         if transcript_idle_confirms_prompt_ready(&snapshot, transcript_path) {
             tracing::info!(
@@ -1163,6 +1216,49 @@ fn transcript_idle_confirms_prompt_ready(
         crate::services::claude_tui::transcript_tail::observe_transcript_turn_state(path)
             == crate::services::tui_turn_state::TuiTurnState::Idle
     })
+}
+
+fn log_startup_dialog_dismiss(
+    session_name: &str,
+    readiness: PromptReadinessKind,
+    dialog_label: &str,
+    attempt: usize,
+) {
+    tracing::info!(
+        tmux_session_name = session_name,
+        readiness = readiness.label(),
+        dialog = dialog_label,
+        attempt,
+        max_attempts = STARTUP_DIALOG_DISMISS_MAX_ATTEMPTS,
+        "claude_tui dismissing startup dialog with Enter"
+    );
+    crate::services::claude::debug_log_to(
+        "claude_tui.log",
+        &format!(
+            "startup dialog dismiss session={session_name} readiness={} dialog={dialog_label} attempt={attempt}/{STARTUP_DIALOG_DISMISS_MAX_ATTEMPTS}",
+            readiness.label(),
+        ),
+    );
+}
+
+fn log_startup_dialog_untrusted_workspace(
+    session_name: &str,
+    readiness: PromptReadinessKind,
+    workspace: &str,
+) {
+    tracing::warn!(
+        tmux_session_name = session_name,
+        readiness = readiness.label(),
+        workspace,
+        "claude_tui startup blocked by workspace trust dialog for untrusted path; failing fast"
+    );
+    crate::services::claude::debug_log_to(
+        "claude_tui.log",
+        &format!(
+            "startup dialog untrusted workspace session={session_name} readiness={} workspace={workspace}",
+            readiness.label(),
+        ),
+    );
 }
 
 fn log_prompt_ready_timeout(

--- a/src/services/claude_tui/mod.rs
+++ b/src/services/claude_tui/mod.rs
@@ -8,5 +8,6 @@ pub(crate) mod hosting;
 pub mod input;
 pub(crate) mod memento_feedback;
 pub mod session;
+pub(crate) mod startup_dialog;
 pub mod transcript_tail;
 pub mod tui_relay;

--- a/src/services/claude_tui/startup_dialog.rs
+++ b/src/services/claude_tui/startup_dialog.rs
@@ -1,0 +1,276 @@
+//! Detection and dismissal policy for Claude Code TUI startup dialogs.
+//!
+//! Claude Code 2.1.170 can interpose modal dialogs between TUI launch and the
+//! first usable composer prompt: a "Resume from summary" picker when resuming
+//! a large/old session, and a workspace-trust confirmation when the spawn cwd
+//! is not yet trusted. Both render an option selector whose highlighted row
+//! (`❯ 1. ...`) reads as a composer draft to the prompt-readiness scrape, so
+//! without explicit handling readiness blocks until the full timeout and the
+//! turn fails with `reason=prompt_marker_not_detected`.
+
+use std::path::Path;
+
+/// Footer shared by Claude Code modal dialogs. Selector overlays such as
+/// `/effort` render the same footer, so detection always pairs it with a
+/// dialog-specific marker line and never fires on the footer alone.
+const DIALOG_FOOTER_MARKER: &str = "Enter to confirm";
+const RESUME_FROM_SUMMARY_MARKER: &str = "Resume from summary";
+const WORKSPACE_TRUST_MARKER: &str = "Quick safety check";
+const WORKSPACE_TRUST_PATH_HEADER: &str = "Accessing workspace:";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ClaudeStartupDialog {
+    /// Large/old-session resume picker. Option 1 ("Resume from summary",
+    /// recommended) is pre-highlighted, so a bare Enter accepts it.
+    ResumeFromSummary,
+    /// Workspace trust confirmation. Option 1 ("Yes, I trust this folder") is
+    /// pre-highlighted. `workspace` is the path the dialog displays; empty
+    /// when the path line could not be located in the capture.
+    WorkspaceTrust { workspace: String },
+}
+
+impl ClaudeStartupDialog {
+    pub(crate) fn label(&self) -> &'static str {
+        match self {
+            ClaudeStartupDialog::ResumeFromSummary => "resume-from-summary",
+            ClaudeStartupDialog::WorkspaceTrust { .. } => "workspace-trust",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum StartupDialogPlan {
+    /// Press Enter to accept the pre-highlighted recommended option.
+    DismissWithEnter,
+    /// Refuse to auto-trust the displayed workspace and fail readiness fast
+    /// with an operator-actionable error instead of burning the full timeout.
+    FailUntrustedWorkspace { workspace: String },
+}
+
+pub(crate) fn detect_claude_startup_dialog(pane_tail: &str) -> Option<ClaudeStartupDialog> {
+    if !pane_tail.contains(DIALOG_FOOTER_MARKER) {
+        return None;
+    }
+    if pane_tail.contains(RESUME_FROM_SUMMARY_MARKER) {
+        return Some(ClaudeStartupDialog::ResumeFromSummary);
+    }
+    if pane_tail.contains(WORKSPACE_TRUST_MARKER) {
+        let workspace = workspace_trust_dialog_path(pane_tail).unwrap_or_default();
+        return Some(ClaudeStartupDialog::WorkspaceTrust { workspace });
+    }
+    None
+}
+
+pub(crate) fn plan_startup_dialog_response(dialog: &ClaudeStartupDialog) -> StartupDialogPlan {
+    plan_startup_dialog_response_with_home(dialog, dirs::home_dir().as_deref())
+}
+
+fn plan_startup_dialog_response_with_home(
+    dialog: &ClaudeStartupDialog,
+    home: Option<&Path>,
+) -> StartupDialogPlan {
+    match dialog {
+        ClaudeStartupDialog::ResumeFromSummary => StartupDialogPlan::DismissWithEnter,
+        ClaudeStartupDialog::WorkspaceTrust { workspace } => {
+            if workspace_trust_auto_accept_allowed(workspace, home) {
+                StartupDialogPlan::DismissWithEnter
+            } else {
+                StartupDialogPlan::FailUntrustedWorkspace {
+                    workspace: workspace.clone(),
+                }
+            }
+        }
+    }
+}
+
+/// Auto-trust is restricted to paths inside the operator's home directory:
+/// AgentDesk only spawns Claude TUI sessions in workspaces it manages there,
+/// so a trust dialog for such a path is just first-contact friction. Anything
+/// else — the observed case being `/` from a missing channel→workspace
+/// mapping — is a spawn-config bug that must surface as an error, not get
+/// rubber-stamped into a root-trusted Claude.
+fn workspace_trust_auto_accept_allowed(workspace: &str, home: Option<&Path>) -> bool {
+    let Some(home) = home else {
+        return false;
+    };
+    if workspace.is_empty() {
+        return false;
+    }
+    let workspace = Path::new(workspace);
+    workspace.is_absolute() && workspace.starts_with(home)
+}
+
+/// The trust dialog renders the workspace path on its own line below the
+/// `Accessing workspace:` header (blank line in between). A long path may
+/// wrap, in which case the first line is a prefix of the real path — still
+/// sufficient for the under-home policy check, since a path prefix inside the
+/// home directory implies the full path is too.
+fn workspace_trust_dialog_path(pane_tail: &str) -> Option<String> {
+    let mut after_header = false;
+    for line in pane_tail.lines() {
+        let trimmed = line.trim();
+        if after_header && !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+        if trimmed.contains(WORKSPACE_TRUST_PATH_HEADER) {
+            after_header = true;
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Captured verbatim from ~/.adk/release/debug/claude_tui.log on
+    // 2026-06-11 (AgentDesk-claude----agentdesk-claude, readiness=fresh).
+    const RESUME_DIALOG_PANE: &str = "\
+────────────────────────────────────────────────────────────────────────────────
+  This session is 10h 50m old and 367.3k tokens.
+
+  Resuming the full session will consume a substantial portion of your usage
+  limits. We recommend resuming from a summary.
+
+  ❯ 1. Resume from summary (recommended)
+    2. Resume full session as-is
+    3. Don't ask me again
+
+  Enter to confirm · Esc to cancel";
+
+    // Captured verbatim from ~/.adk/release/debug/claude_tui.log on
+    // 2026-06-10 (AgentDesk-claude---agent-game-play spawned with cwd `/`).
+    const TRUST_DIALOG_ROOT_PANE: &str = "\
+────────────────────────────────────────────────────────────────────────────────
+ Accessing workspace:
+
+ /
+
+ Quick safety check: Is this a project you created or one you trust? (Like your
+ own code, a well-known open source project, or work from your team). If not,
+ take a moment to review what's in this folder first.
+
+ Claude Code'll be able to read, edit, and execute files here.
+
+ Security guide
+
+ ❯ 1. Yes, I trust this folder
+   2. No, exit
+
+ Enter to confirm · Esc to cancel";
+
+    fn trust_dialog_pane_for(path: &str) -> String {
+        TRUST_DIALOG_ROOT_PANE.replace("\n /\n", &format!("\n {path}\n"))
+    }
+
+    #[test]
+    fn resume_from_summary_dialog_is_detected_and_dismissed_with_enter() {
+        let dialog = detect_claude_startup_dialog(RESUME_DIALOG_PANE)
+            .expect("resume dialog must be detected");
+        assert_eq!(dialog, ClaudeStartupDialog::ResumeFromSummary);
+        assert_eq!(
+            plan_startup_dialog_response_with_home(&dialog, Some(Path::new("/Users/kunkun"))),
+            StartupDialogPlan::DismissWithEnter
+        );
+    }
+
+    #[test]
+    fn trust_dialog_for_root_workspace_fails_fast_instead_of_auto_trusting() {
+        let dialog = detect_claude_startup_dialog(TRUST_DIALOG_ROOT_PANE)
+            .expect("trust dialog must be detected");
+        assert_eq!(
+            dialog,
+            ClaudeStartupDialog::WorkspaceTrust {
+                workspace: "/".to_string()
+            }
+        );
+        assert_eq!(
+            plan_startup_dialog_response_with_home(&dialog, Some(Path::new("/Users/kunkun"))),
+            StartupDialogPlan::FailUntrustedWorkspace {
+                workspace: "/".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn trust_dialog_for_home_workspace_is_auto_accepted() {
+        let pane = trust_dialog_pane_for("/Users/kunkun/.adk/release/workspaces/gamer");
+        let dialog = detect_claude_startup_dialog(&pane).expect("trust dialog must be detected");
+        assert_eq!(
+            plan_startup_dialog_response_with_home(&dialog, Some(Path::new("/Users/kunkun"))),
+            StartupDialogPlan::DismissWithEnter
+        );
+    }
+
+    #[test]
+    fn trust_dialog_outside_home_is_rejected_component_wise() {
+        // `/Users/kunkun2` must not pass a `/Users/kunkun` home check; the
+        // policy compares path components, not string prefixes.
+        let pane = trust_dialog_pane_for("/Users/kunkun2/workspace");
+        let dialog = detect_claude_startup_dialog(&pane).expect("trust dialog must be detected");
+        assert_eq!(
+            plan_startup_dialog_response_with_home(&dialog, Some(Path::new("/Users/kunkun"))),
+            StartupDialogPlan::FailUntrustedWorkspace {
+                workspace: "/Users/kunkun2/workspace".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn trust_dialog_with_unparseable_path_is_rejected() {
+        let pane = TRUST_DIALOG_ROOT_PANE.replace("Accessing workspace:", "");
+        let dialog = detect_claude_startup_dialog(&pane).expect("trust dialog must be detected");
+        assert_eq!(
+            dialog,
+            ClaudeStartupDialog::WorkspaceTrust {
+                workspace: String::new()
+            }
+        );
+        assert!(matches!(
+            plan_startup_dialog_response_with_home(&dialog, Some(Path::new("/Users/kunkun"))),
+            StartupDialogPlan::FailUntrustedWorkspace { .. }
+        ));
+    }
+
+    #[test]
+    fn effort_selector_footer_alone_is_not_a_startup_dialog() {
+        // The `/effort` slider shares the `Enter to confirm` footer; it must
+        // not be mistaken for a startup dialog and dismissed.
+        let pane = "\
+  Select effort level
+
+  low ── medium ── high
+
+  ←/→ to adjust · Enter to confirm · Esc to cancel";
+        assert_eq!(detect_claude_startup_dialog(pane), None);
+    }
+
+    #[test]
+    fn busy_compacting_pane_is_not_a_startup_dialog() {
+        let pane = "\
+❯ /compact
+
+· Compacting conversation… (30s)
+────────────────────────────────────────────────────────────────────────────────
+  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt";
+        assert_eq!(detect_claude_startup_dialog(pane), None);
+    }
+
+    #[test]
+    fn idle_ready_pane_is_not_a_startup_dialog() {
+        let pane = "\
+────────────────────────────────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────────────────────────────────
+  ⏵⏵ bypass permissions on (shift+tab to cycle)";
+        assert_eq!(detect_claude_startup_dialog(pane), None);
+    }
+
+    #[test]
+    fn auto_accept_requires_home_dir_resolution() {
+        assert!(!workspace_trust_auto_accept_allowed(
+            "/Users/kunkun/project",
+            None
+        ));
+    }
+}


### PR DESCRIPTION
## 목표

Claude Code 2.1.170 TUI를 자동 운영할 때 턴이 죽거나 메시지가 사라지던 두 가지 신뢰성 문제를 잡는다. (1) 시작 시 뜨는 모달 다이얼로그(resume-from-summary 픽커, workspace trust 확인)가 프롬프트 준비 감지를 막아 매 턴이 `prompt_marker_not_detected`로 타임아웃되던 문제, (2) 직전 턴이 readiness 타임아웃(45s)을 넘게 스트리밍 중일 때 후속 메시지가 조용히 버려지던 문제. 적용 후에는 시작 다이얼로그가 자동으로 안전하게 처리되고, 긴 턴이 진행 중이어도 후속 메시지가 드롭되지 않고 턴 종료 후 순차 전송된다.

## 쉬운 설명

자동으로 띄운 Claude 세션이 "요약에서 이어서 시작할까요?"나 "이 폴더 신뢰할까요?" 같은 시작 팝업에 걸려 더 이상 명령을 못 받던 게 자동으로 풀린다. 단, 신뢰 팝업의 경로가 운영자 홈 디렉터리 밖이면 함부로 신뢰하지 않고 즉시 명확한 에러로 멈춘다. 또 직전 답변이 길게 진행 중일 때 다음 메시지를 보내도 사라지지 않고, 답변이 끝나면 차례대로 전달된다.

## 개선되는 것

### Fix 1 — 시작 다이얼로그 자동 해제 + 비신뢰 워크스페이스 차단

- Before: spawn/resume 직후 Claude TUI가 resume-from-summary 픽커나 workspace trust 확인 다이얼로그에 머물면, 하이라이트된 `❯ 1. ...` 행이 작성 중 초안(draft)으로 오인되어 준비 감지가 영영 성공하지 못하고 매 턴이 `reason=prompt_marker_not_detected`(120s)로 죽는다.
- After: 폴링 루프가 pane tail에서 다이얼로그를 탐지해 처리한다. resume-from-summary는 사전 하이라이트된 권장 항목을 Enter로 수락(대기당 5회 press 예산으로 무한 매싱 방지). workspace trust는 표시 경로가 운영자 홈 디렉터리 내부로 resolve될 때만 Enter로 수락하고, 그 외(관측 사례: 잘못된 채널→워크스페이스 매핑으로 인한 `/`)는 root 자동 신뢰 없이 운영자가 조치 가능한 에러로 즉시 실패한다. 탐지는 공용 `Enter to confirm` 푸터 + 다이얼로그별 마커 라인을 함께 요구해 `/effort` 같은 셀렉터 오버레이를 시작 다이얼로그로 오인하지 않는다.

### Fix 2 — 직전 턴 스트리밍 중 후속 준비 대기 유지 (#2416 연장)

- Before: 후속 메시지의 준비 대기가 고정 벽시계 타임아웃(`FOLLOWUP_PROMPT_READY_TIMEOUT` = 45s)을 쓴다. 폴링 루프는 transcript가 Idle이 되는 즉시 ready로 판정하므로 타임아웃 도달은 곧 직전 턴이 아직 스트리밍 중이라는 뜻인데, 이 경우 warm-followup 경로가 사용자 메시지를 드롭(`tui_warm_followup_busy_pre_submit`)해 45초 넘는 턴 뒤의 다음 메시지가 조용히 사라진다.
- After: 준비 타임아웃을 stall 예산으로 취급한다. transcript가 직전 턴이 실제로 스트리밍 중(`TuiTurnState::is_busy` ⇒ Streaming/UserSubmitted; Idle/Unknown 읽기는 연장하지 않음)임을 확인하는 동안 절대 상한(`PROMPT_READY_ACTIVE_TURN_WAIT_CEILING` = 900s)까지 대기를 연장하고, 턴이 끝나면 후속 메시지를 순차 제출한다. 취소와 dead-pane 체크는 여전히 대기를 bound하며, 직전 턴이 없으면 `is_busy=false`로 기존 동작이 그대로다.

### Fix 3 — 타임아웃 에러의 진짜 원인 attribution 교정

- Before: readiness 타임아웃 에러가 스냅샷과 무관하게 `reason=prompt_marker_not_detected; previous_tui_turn_still_running=true`를 하드코딩해, 미전송 draft나 capture 실패가 원인일 때도 디버그 로그와 불일치하며 조사를 잘못된 방향으로 유도한다.
- After: 최종 스냅샷의 가장 강한 증거로 분류한 `prompt_ready_timeout_reason`(pane_capture_unavailable / prompt_draft_present / prompt_marker_unconfirmed / prompt_marker_not_detected)을 보고하고, `previous_tui_turn_still_running`도 로그가 기록하는 계산값(`pane_alive && !prompt_marker_detected`)을 그대로 미러링한다.

## Before → After

| 시나리오 | Before | After |
|---|---|---|
| resume-from-summary 다이얼로그로 spawn | 120s 후 `reason=prompt_marker_not_detected`로 턴 실패 | Enter로 권장 항목 수락 후 정상 진행 |
| `/` 등 홈 밖 경로의 workspace trust 다이얼로그 | 자동 신뢰 위험 또는 타임아웃 소모 | root 자동 신뢰 거부, 운영자 조치형 에러로 즉시 실패 |
| 직전 턴이 45s 넘게 스트리밍 중 후속 메시지 전송 | 메시지가 조용히 드롭(`tui_warm_followup_busy_pre_submit`) | 최대 900s까지 대기 후 턴 종료 시 순차 제출 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
|---|---|---|
| `/effort` 등 `Enter to confirm` 푸터만 공유하는 셀렉터 오버레이 | 다이얼로그별 마커 라인 부재로 탐지 안 됨 | 시작 다이얼로그로 오인·자동 Enter 없음 (안전) |
| 다이얼로그가 예상치 못하게 5회 Enter 후에도 잔존 | dismiss 예산 소진 → 정규 타임아웃 경로로 폴백 | 무한 Enter 매싱 없이 canonical 타임아웃으로 수렴 |
| 단일 메시지(직전 턴 없음) 또는 pane dead | `is_busy=false`/`pane_alive=false`로 연장 미발동 | 기존 타임아웃·dead-pane 처리 그대로 유지 |

## 해결한 내용

- `src/services/claude_tui/startup_dialog.rs` (신규, +276): Claude 시작 다이얼로그 탐지·대응 정책을 순수 모듈로 분리. `detect_claude_startup_dialog`(푸터+마커 페어 매칭), `plan_startup_dialog_response`(resume는 Enter, trust는 홈 디렉터리 내부 경로만 자동 수락·그 외 fail-fast), `workspace_trust_auto_accept_allowed`(문자열 prefix가 아닌 `Path::starts_with` 컴포넌트 비교로 `/Users/kunkun2`가 `/Users/kunkun`을 통과하지 못하게 함). 테스트 픽스처는 `~/.adk/release/debug/claude_tui.log`의 verbatim pane 캡처라 실제 관측 사례를 회귀로 고정한다.
- `src/services/claude_tui/input.rs` (+281/-2): `wait_for_prompt_ready_polling`에 (1) transcript fallback 이전에 시작 다이얼로그 탐지·해제 분기 추가(5회 dismiss 예산, 500ms settle, 비신뢰 워크스페이스 즉시 에러), (2) 타임아웃 도달 시 직전 턴이 스트리밍 중이면 900s 상한까지 대기 연장하는 분기 추가. 연장 판정을 순수 함수 `active_turn_warrants_wait_extension`으로 추출해 라이브 tmux 없이 단위 테스트 가능하게 함. (3) 타임아웃 에러 메시지를 스냅샷 기반 진짜 원인(`prompt_ready_timeout_reason`)으로 attribution 교정.
- `src/services/claude_tui/mod.rs` (+1): 신규 `startup_dialog` 모듈을 `pub(crate)`로 등록.

## 검증

- CI 대응(2026-06-15): `claude_tui/input.rs` 인벤토리 라인카운트 freeze 동기화. → Script checks 통과.

- 디프에 신규 단위 테스트 포함: `startup_dialog.rs`의 탐지/정책 테스트(resume 자동 수락, root trust fail-fast, 홈 내부 경로 자동 수락, `/Users/kunkun2` 컴포넌트 단위 거부, 경로 미파싱 거부, `/effort`·compacting·idle pane 비탐지, home 미해소 시 거부), `input.rs`의 `active_turn_warrants_wait_extension` 경계 테스트와 `prompt_ready_timeout_reason` 스냅샷 attribution 테스트.
- CI(run 27497314766) 현재 상태: Lint, Fast check + non-PG tests (ubuntu-latest), Fast targeted tests, High-risk recovery, Dashboard/Lint required context 등 pass.
- 단, Fast check + non-PG tests (windows-latest), Fast check cross OS required context (ubuntu-latest), Script checks는 fail 상태다. 이 디프는 `src/services/claude_tui/` 3개 파일만 건드리며 git 호출 callsite나 windows tmux 의존성을 추가하지 않으므로, windows fast-check 실패와 Script checks(maintainability hard-gate) 실패는 이 PR과 무관한 base/systemic 이슈로 판단한다. 로컬에서 cargo를 직접 실행하지는 않았다.

