### PR TITLE
a11y: radiogroup, spinbutton, and dialog semantics with keyboard nav across dashboard modals & selectors

### DIFF
--- a/dashboard/src/components/OfficeManagerIconPicker.test.tsx
+++ b/dashboard/src/components/OfficeManagerIconPicker.test.tsx
@@ -74,11 +74,13 @@ describe("Office manager icon picker accessibility", () => {
 
     const selectedIcon = queryIconButton(target, "Icon 🎮");
     expect(selectedIcon.getAttribute("type")).toBe("button");
-    expect(selectedIcon.getAttribute("aria-pressed")).toBe("true");
+    expect(selectedIcon.getAttribute("role")).toBe("radio");
+    expect(selectedIcon.getAttribute("aria-checked")).toBe("true");
 
     const unselectedIcon = queryIconButton(target, "Icon 🏢");
     expect(unselectedIcon.getAttribute("type")).toBe("button");
-    expect(unselectedIcon.getAttribute("aria-pressed")).toBe("false");
+    expect(unselectedIcon.getAttribute("role")).toBe("radio");
+    expect(unselectedIcon.getAttribute("aria-checked")).toBe("false");
   });
 
   it("renders modal create icon buttons as non-submit toggle buttons with Korean labels", async () => {
@@ -103,6 +105,7 @@ describe("Office manager icon picker accessibility", () => {
 
     const defaultIcon = queryIconButton(target, "아이콘 🏢");
     expect(defaultIcon.getAttribute("type")).toBe("button");
-    expect(defaultIcon.getAttribute("aria-pressed")).toBe("true");
+    expect(defaultIcon.getAttribute("role")).toBe("radio");
+    expect(defaultIcon.getAttribute("aria-checked")).toBe("true");
   });
 });

--- a/dashboard/src/components/OfficeManagerModal.tsx
+++ b/dashboard/src/components/OfficeManagerModal.tsx
@@ -306,13 +306,36 @@ export default function OfficeManagerModal({
                     >
                       {tr("아이콘", "Icon")}
                     </label>
-                    <div className="flex gap-1.5 flex-wrap">
-                      {OFFICE_ICONS.map((ic) => (
+                    <div className="flex gap-1.5 flex-wrap" role="radiogroup" aria-label={tr("아이콘", "Icon")}>
+                      {OFFICE_ICONS.map((ic, idx) => (
                         <button
                           key={ic}
                           type="button"
+                          role="radio"
                           aria-label={tr(`아이콘 ${ic}`, `Icon ${ic}`)}
-                          aria-pressed={draft.icon === ic}
+                          aria-checked={draft.icon === ic}
+                          tabIndex={draft.icon === ic || (!OFFICE_ICONS.includes(draft.icon) && idx === 0) ? 0 : -1}
+                          onKeyDown={(e) => {
+                            let nextIdx = idx;
+                            if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+                              e.preventDefault();
+                              nextIdx = (idx + 1) % OFFICE_ICONS.length;
+                            } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+                              e.preventDefault();
+                              nextIdx = (idx - 1 + OFFICE_ICONS.length) % OFFICE_ICONS.length;
+                            } else if (e.key === "Home") {
+                              e.preventDefault();
+                              nextIdx = 0;
+                            } else if (e.key === "End") {
+                              e.preventDefault();
+                              nextIdx = OFFICE_ICONS.length - 1;
+                            }
+                            if (nextIdx !== idx) {
+                              setDraft((prev) => ({ ...prev, icon: OFFICE_ICONS[nextIdx] }));
+                              const nextButton = e.currentTarget.parentElement?.children[nextIdx] as HTMLButtonElement | undefined;
+                              nextButton?.focus();
+                            }
+                          }}
                           onClick={() => setDraft((prev) => ({ ...prev, icon: ic }))}
                           className="flex h-8 w-8 items-center justify-center rounded text-base transition-all"
                           style={{
@@ -338,13 +361,36 @@ export default function OfficeManagerModal({
                     >
                       {tr("색상", "Color")}
                     </label>
-                    <div className="flex gap-1.5 flex-wrap">
-                      {OFFICE_COLORS.map((c) => (
+                    <div className="flex gap-1.5 flex-wrap" role="radiogroup" aria-label={tr("색상", "Color")}>
+                      {OFFICE_COLORS.map((c, idx) => (
                         <button
                           key={c}
                           type="button"
+                          role="radio"
                           aria-label={tr(`색상 ${c}`, `Color ${c}`)}
-                          aria-pressed={draft.color === c}
+                          aria-checked={draft.color === c}
+                          tabIndex={draft.color === c || (!OFFICE_COLORS.includes(draft.color) && idx === 0) ? 0 : -1}
+                          onKeyDown={(e) => {
+                            let nextIdx = idx;
+                            if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+                              e.preventDefault();
+                              nextIdx = (idx + 1) % OFFICE_COLORS.length;
+                            } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+                              e.preventDefault();
+                              nextIdx = (idx - 1 + OFFICE_COLORS.length) % OFFICE_COLORS.length;
+                            } else if (e.key === "Home") {
+                              e.preventDefault();
+                              nextIdx = 0;
+                            } else if (e.key === "End") {
+                              e.preventDefault();
+                              nextIdx = OFFICE_COLORS.length - 1;
+                            }
+                            if (nextIdx !== idx) {
+                              setDraft((prev) => ({ ...prev, color: OFFICE_COLORS[nextIdx] }));
+                              const nextButton = e.currentTarget.parentElement?.children[nextIdx] as HTMLButtonElement | undefined;
+                              nextButton?.focus();
+                            }
+                          }}
                           onClick={() => setDraft((prev) => ({ ...prev, color: c }))}
                           className={`w-7 h-7 rounded-full transition-all ${
                             draft.color === c

--- a/dashboard/src/components/OfficeManagerView.tsx
+++ b/dashboard/src/components/OfficeManagerView.tsx
@@ -375,13 +375,36 @@ export default function OfficeManagerView({
                     <div className="mb-1 text-xs font-medium" style={{ color: "var(--th-text-muted)" }}>
                       {tr("아이콘", "Icon")}
                     </div>
-                    <div className="flex flex-wrap gap-2">
-                      {OFFICE_ICONS.map((icon) => (
+                    <div className="flex flex-wrap gap-2" role="radiogroup" aria-label={tr("아이콘", "Icon")}>
+                      {OFFICE_ICONS.map((icon, idx) => (
                         <button
                           key={icon}
                           type="button"
+                          role="radio"
                           aria-label={tr(`아이콘 ${icon}`, `Icon ${icon}`)}
-                          aria-pressed={draft.icon === icon}
+                          aria-checked={draft.icon === icon}
+                          tabIndex={draft.icon === icon || (!OFFICE_ICONS.includes(draft.icon) && idx === 0) ? 0 : -1}
+                          onKeyDown={(e) => {
+                            let nextIdx = idx;
+                            if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+                              e.preventDefault();
+                              nextIdx = (idx + 1) % OFFICE_ICONS.length;
+                            } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+                              e.preventDefault();
+                              nextIdx = (idx - 1 + OFFICE_ICONS.length) % OFFICE_ICONS.length;
+                            } else if (e.key === "Home") {
+                              e.preventDefault();
+                              nextIdx = 0;
+                            } else if (e.key === "End") {
+                              e.preventDefault();
+                              nextIdx = OFFICE_ICONS.length - 1;
+                            }
+                            if (nextIdx !== idx) {
+                              setDraft((prev) => ({ ...prev, icon: OFFICE_ICONS[nextIdx] }));
+                              const nextButton = e.currentTarget.parentElement?.children[nextIdx] as HTMLButtonElement | undefined;
+                              nextButton?.focus();
+                            }
+                          }}
                           onClick={() => setDraft((prev) => ({ ...prev, icon }))}
                           className="flex h-10 w-10 items-center justify-center rounded-xl text-lg transition-colors"
                           style={{
@@ -403,13 +426,36 @@ export default function OfficeManagerView({
                     <div className="mb-1 text-xs font-medium" style={{ color: "var(--th-text-muted)" }}>
                       {tr("대표 색상", "Accent Color")}
                     </div>
-                    <div className="flex flex-wrap gap-2">
-                      {OFFICE_COLORS.map((color) => (
+                    <div className="flex flex-wrap gap-2" role="radiogroup" aria-label={tr("대표 색상", "Accent Color")}>
+                      {OFFICE_COLORS.map((color, idx) => (
                         <button
                           key={color}
                           type="button"
+                          role="radio"
                           aria-label={tr(`색상 ${color}`, `Color ${color}`)}
-                          aria-pressed={draft.color === color}
+                          aria-checked={draft.color === color}
+                          tabIndex={draft.color === color || (!OFFICE_COLORS.includes(draft.color) && idx === 0) ? 0 : -1}
+                          onKeyDown={(e) => {
+                            let nextIdx = idx;
+                            if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+                              e.preventDefault();
+                              nextIdx = (idx + 1) % OFFICE_COLORS.length;
+                            } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+                              e.preventDefault();
+                              nextIdx = (idx - 1 + OFFICE_COLORS.length) % OFFICE_COLORS.length;
+                            } else if (e.key === "Home") {
+                              e.preventDefault();
+                              nextIdx = 0;
+                            } else if (e.key === "End") {
+                              e.preventDefault();
+                              nextIdx = OFFICE_COLORS.length - 1;
+                            }
+                            if (nextIdx !== idx) {
+                              setDraft((prev) => ({ ...prev, color: OFFICE_COLORS[nextIdx] }));
+                              const nextButton = e.currentTarget.parentElement?.children[nextIdx] as HTMLButtonElement | undefined;
+                              nextButton?.focus();
+                            }
+                          }}
                           onClick={() => setDraft((prev) => ({ ...prev, color }))}
                           className="h-9 w-9 rounded-full border-2 transition-transform hover:scale-105"
                           style={{

--- a/dashboard/src/components/OfficeSelectorBar.tsx
+++ b/dashboard/src/components/OfficeSelectorBar.tsx
@@ -36,6 +36,7 @@ export default function OfficeSelectorBar({
     >
       <button
         onClick={() => onSelectOffice(null)}
+        aria-pressed={selectedOfficeId === null}
         className="whitespace-nowrap rounded-full px-2.5 py-1 text-xs font-medium transition-all"
         style={
           selectedOfficeId === null
@@ -55,6 +56,7 @@ export default function OfficeSelectorBar({
         <button
           key={o.id}
           onClick={() => onSelectOffice(o.id)}
+          aria-pressed={selectedOfficeId === o.id}
           className="flex items-center gap-1 whitespace-nowrap rounded-full px-2.5 py-1 text-xs font-medium transition-all"
           style={
             selectedOfficeId === o.id
@@ -66,7 +68,7 @@ export default function OfficeSelectorBar({
               : inactiveButtonStyle
           }
         >
-          <span>{o.icon}</span>
+          <span aria-hidden="true">{o.icon}</span>
           <span>{isKo ? o.name_ko || o.name : o.name}</span>
           {o.agent_count !== undefined && o.agent_count > 0 && (
             <span
@@ -92,6 +94,7 @@ export default function OfficeSelectorBar({
           border: "1px solid color-mix(in srgb, var(--th-border) 70%, transparent)",
         }}
         title={isKo ? "오피스 관리" : "Manage Offices"}
+        aria-label={isKo ? "오피스 관리" : "Manage Offices"}
       >
         <Settings size={14} />
       </button>

--- a/dashboard/src/components/agent-manager/AgentFormModal.tsx
+++ b/dashboard/src/components/agent-manager/AgentFormModal.tsx
@@ -239,10 +239,11 @@ export default function AgentFormModal({
             {/* 로캘 기반 현지 이름 필드 */}
             {locale.startsWith("ko") && (
               <div>
-                <label className="block text-xs mb-1.5 font-medium" style={{ color: "var(--th-text-secondary)" }}>
+                <label htmlFor="agent-name-ko" className="block text-xs mb-1.5 font-medium" style={{ color: "var(--th-text-secondary)" }}>
                   {tr("한글 이름", "Korean Name")}
                 </label>
                 <input
+                  id="agent-name-ko"
                   type="text"
                   {...register("name_ko")}
                   placeholder="도로롱"
@@ -253,10 +254,11 @@ export default function AgentFormModal({
             )}
             {locale.startsWith("ja") && (
               <div>
-                <label className="block text-xs mb-1.5 font-medium" style={{ color: "var(--th-text-secondary)" }}>
+                <label htmlFor="agent-name-ja" className="block text-xs mb-1.5 font-medium" style={{ color: "var(--th-text-secondary)" }}>
                   {t({ ko: "일본어 이름", en: "Japanese Name", ja: "日本語名", zh: "日语名" })}
                 </label>
                 <input
+                  id="agent-name-ja"
                   type="text"
                   {...register("name_ja")}
                   placeholder="ドロロン"
@@ -267,10 +269,11 @@ export default function AgentFormModal({
             )}
             {locale.startsWith("zh") && (
               <div>
-                <label className="block text-xs mb-1.5 font-medium" style={{ color: "var(--th-text-secondary)" }}>
+                <label htmlFor="agent-name-zh" className="block text-xs mb-1.5 font-medium" style={{ color: "var(--th-text-secondary)" }}>
                   {t({ ko: "중국어 이름", en: "Chinese Name", ja: "中国語名", zh: "中文名" })}
                 </label>
                 <input
+                  id="agent-name-zh"
                   type="text"
                   {...register("name_zh")}
                   placeholder="多罗隆"
@@ -290,10 +293,11 @@ export default function AgentFormModal({
                 />
               </div>
               <div>
-                <label className="block text-xs mb-1.5 font-medium" style={{ color: "var(--th-text-secondary)" }}>
+                <label htmlFor="agent-department" className="block text-xs mb-1.5 font-medium" style={{ color: "var(--th-text-secondary)" }}>
                   {tr("소속 부서", "Department")}
                 </label>
                 <select
+                  id="agent-department"
                   {...register("department_id")}
                   className={`${inputCls} cursor-pointer`}
                   style={inputStyle}
@@ -319,10 +323,11 @@ export default function AgentFormModal({
             <div className="space-y-4">
             {/* 성격/프롬프트 */}
             <div>
-              <label className="block text-xs mb-1.5 font-medium" style={{ color: "var(--th-text-secondary)" }}>
+              <label htmlFor="agent-personality" className="block text-xs mb-1.5 font-medium" style={{ color: "var(--th-text-secondary)" }}>
                 {tr("성격 / 역할 프롬프트", "Personality / Prompt")}
               </label>
               <textarea
+                id="agent-personality"
                 {...register("personality")}
                 rows={6}
                 placeholder={tr("전문 분야나 성격 설명...", "Expertise or personality...")}

--- a/dashboard/src/components/agent-manager/AgentFormModal.tsx
+++ b/dashboard/src/components/agent-manager/AgentFormModal.tsx
@@ -145,7 +145,7 @@ export default function AgentFormModal({
               aria-label={tr("스프라이트 번호", "Sprite Number")}
               aria-valuenow={spriteNum || 0}
               aria-valuemin={0}
-              aria-valuetext={spriteNum ? t({ ko: `스프라이트 ${spriteNum}`, en: `Sprite ${spriteNum}` }) : tr("선택 안됨", "Not selected")}
+              aria-valuetext={spriteNum ? t({ ko: `선택된 스프라이트: ${spriteNum}`, en: `Selected sprite: ${spriteNum}` }) : tr("선택 안됨", "Not selected")}
               tabIndex={0}
               onKeyDown={(e) => {
                 if (e.currentTarget !== e.target) {
@@ -316,7 +316,7 @@ export default function AgentFormModal({
                   onChange={(emoji) => setValue("avatar_emoji", emoji, { shouldDirty: true, shouldValidate: true })}
                   aria-label={
                     formValues.avatar_emoji
-                      ? t({ ko: `이모지 변경 (현재: ${formValues.avatar_emoji})`, en: `Change emoji (current: ${formValues.avatar_emoji})` })
+                      ? t({ ko: `선택된 이모지: ${formValues.avatar_emoji}, 이모지 변경`, en: `Selected emoji: ${formValues.avatar_emoji}, change emoji` })
                       : t({ ko: "이모지 선택기 열기", en: "Open emoji picker" })
                   }
                 />

--- a/dashboard/src/components/agent-manager/AgentFormModal.tsx
+++ b/dashboard/src/components/agent-manager/AgentFormModal.tsx
@@ -314,6 +314,11 @@ export default function AgentFormModal({
                 <EmojiPicker
                   value={formValues.avatar_emoji}
                   onChange={(emoji) => setValue("avatar_emoji", emoji, { shouldDirty: true, shouldValidate: true })}
+                  aria-label={
+                    formValues.avatar_emoji
+                      ? t({ ko: `이모지 변경 (현재: ${formValues.avatar_emoji})`, en: `Change emoji (current: ${formValues.avatar_emoji})` })
+                      : t({ ko: "이모지 선택기 열기", en: "Open emoji picker" })
+                  }
                 />
               </div>
               <div>

--- a/dashboard/src/components/agent-manager/AgentFormModal.tsx
+++ b/dashboard/src/components/agent-manager/AgentFormModal.tsx
@@ -139,10 +139,33 @@ export default function AgentFormModal({
           >
             <div className="space-y-4">
             {/* ── 스프라이트 얼굴 미리보기 + 위/아래 변경 ── */}
-            <div className="flex items-center gap-3" role="group" aria-label={tr("스프라이트 선택기", "Sprite Selector")}>
+            <div
+              className="flex items-center gap-3 rounded focus:outline-none focus:ring-2 focus:ring-[var(--th-accent-primary)] focus:ring-offset-2 focus:ring-offset-[var(--th-bg-surface)]"
+              role="spinbutton"
+              aria-label={tr("스프라이트 번호", "Sprite Number")}
+              aria-valuenow={spriteNum || 0}
+              aria-valuemin={0}
+              aria-valuetext={spriteNum ? t({ ko: `스프라이트 ${spriteNum}`, en: `Sprite ${spriteNum}` }) : tr("선택 안됨", "Not selected")}
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.currentTarget !== e.target) {
+                  return;
+                }
+                if (e.key === "ArrowUp") {
+                  e.preventDefault();
+                  const next = Math.max(1, spriteNum || 0) + 1;
+                  setValue("sprite_number", next, { shouldDirty: true, shouldValidate: true });
+                } else if (e.key === "ArrowDown") {
+                  e.preventDefault();
+                  const next = Math.max(1, (spriteNum || 1) - 1);
+                  setValue("sprite_number", next, { shouldDirty: true, shouldValidate: true });
+                }
+              }}
+            >
               <div className="flex flex-col items-center gap-1">
                 <button
                   type="button"
+                  tabIndex={-1}
                   aria-label={tr("다음 스프라이트", "Next Sprite")}
                   className="w-6 h-6 rounded flex items-center justify-center text-xs transition-colors"
                   style={{
@@ -183,6 +206,7 @@ export default function AgentFormModal({
                 </div>
                 <button
                   type="button"
+                  tabIndex={-1}
                   aria-label={tr("이전 스프라이트", "Previous Sprite")}
                   className="w-6 h-6 rounded flex items-center justify-center text-xs transition-colors"
                   style={{

--- a/dashboard/src/components/agent-manager/DepartmentFormModal.tsx
+++ b/dashboard/src/components/agent-manager/DepartmentFormModal.tsx
@@ -382,10 +382,11 @@ export default function DepartmentFormModal({
 
               {locale.startsWith("ko") && (
                 <div>
-                  <label className="block text-xs mb-1.5 font-medium" style={{ color: "var(--th-text-secondary)" }}>
+                  <label htmlFor="dept-name-ko" className="block text-xs mb-1.5 font-medium" style={{ color: "var(--th-text-secondary)" }}>
                     {tr("한글 이름", "Korean Name")}
                   </label>
                   <input
+                    id="dept-name-ko"
                     type="text"
                     {...register("name_ko")}
                     placeholder="개발팀"
@@ -396,10 +397,11 @@ export default function DepartmentFormModal({
               )}
               {locale.startsWith("ja") && (
                 <div>
-                  <label className="block text-xs mb-1.5 font-medium" style={{ color: "var(--th-text-secondary)" }}>
+                  <label htmlFor="dept-name-ja" className="block text-xs mb-1.5 font-medium" style={{ color: "var(--th-text-secondary)" }}>
                     {t({ ko: "일본어 이름", en: "Japanese Name", ja: "日本語名", zh: "日语名" })}
                   </label>
                   <input
+                    id="dept-name-ja"
                     type="text"
                     {...register("name_ja")}
                     placeholder="開発チーム"
@@ -410,10 +412,11 @@ export default function DepartmentFormModal({
               )}
               {locale.startsWith("zh") && (
                 <div>
-                  <label className="block text-xs mb-1.5 font-medium" style={{ color: "var(--th-text-secondary)" }}>
+                  <label htmlFor="dept-name-zh" className="block text-xs mb-1.5 font-medium" style={{ color: "var(--th-text-secondary)" }}>
                     {t({ ko: "중국어 이름", en: "Chinese Name", ja: "中国語名", zh: "中文名" })}
                   </label>
                   <input
+                    id="dept-name-zh"
                     type="text"
                     {...register("name_zh")}
                     placeholder="开发部"
@@ -424,10 +427,11 @@ export default function DepartmentFormModal({
               )}
 
               <div>
-                <label className="block text-xs mb-1.5 font-medium" style={{ color: "var(--th-text-secondary)" }}>
+                <label htmlFor="dept-description" className="block text-xs mb-1.5 font-medium" style={{ color: "var(--th-text-secondary)" }}>
                   {tr("부서 설명", "Description")}
                 </label>
                 <input
+                  id="dept-description"
                   type="text"
                   {...register("description")}
                   placeholder={tr("부서의 역할 간단 설명", "Brief description of the department")}
@@ -443,7 +447,11 @@ export default function DepartmentFormModal({
             description={tr("소속 에이전트가 공통으로 따르는 부서 지침을 적습니다.", "Write the shared instruction applied to agents in this department.")}
           >
             <div className="space-y-3">
+              <label htmlFor="dept-prompt" className="sr-only">
+                {tr("운영 프롬프트", "Department Prompt")}
+              </label>
               <textarea
+                id="dept-prompt"
                 {...register("prompt")}
                 rows={4}
                 placeholder={tr(

--- a/dashboard/src/components/agent-manager/DepartmentFormModal.tsx
+++ b/dashboard/src/components/agent-manager/DepartmentFormModal.tsx
@@ -320,7 +320,7 @@ export default function DepartmentFormModal({
                     onChange={(emoji) => setValue("icon", emoji, { shouldDirty: true, shouldValidate: true })}
                     aria-label={
                       form.icon
-                        ? t({ ko: `아이콘 변경 (현재: ${form.icon})`, en: `Change icon (current: ${form.icon})` })
+                        ? t({ ko: `선택된 아이콘: ${form.icon}, 아이콘 변경`, en: `Selected icon: ${form.icon}, change icon` })
                         : t({ ko: "아이콘 선택기 열기", en: "Open icon picker" })
                     }
                   />

--- a/dashboard/src/components/agent-manager/DepartmentFormModal.tsx
+++ b/dashboard/src/components/agent-manager/DepartmentFormModal.tsx
@@ -318,7 +318,7 @@ export default function DepartmentFormModal({
                   <EmojiPicker
                     value={form.icon}
                     onChange={(emoji) => setValue("icon", emoji, { shouldDirty: true, shouldValidate: true })}
-                    ariaLabel={
+                    aria-label={
                       form.icon
                         ? t({ ko: `아이콘 변경 (현재: ${form.icon})`, en: `Change icon (current: ${form.icon})` })
                         : t({ ko: "아이콘 선택기 열기", en: "Open icon picker" })

--- a/dashboard/src/components/agent-manager/EmojiPicker.test.tsx
+++ b/dashboard/src/components/agent-manager/EmojiPicker.test.tsx
@@ -45,7 +45,7 @@ describe("EmojiPicker", () => {
     const button = target.querySelector("button");
     expect(button).not.toBeNull();
     expect(button?.getAttribute("aria-expanded")).toBe("false");
-    expect(button?.getAttribute("aria-label")).toBe("Change emoji (current: 🤖)");
+    expect(button?.getAttribute("aria-label")).toBe("Selected emoji: 🤖, change emoji");
     expect(button?.getAttribute("aria-haspopup")).toBe("dialog");
   });
 

--- a/dashboard/src/components/agent-manager/EmojiPicker.tsx
+++ b/dashboard/src/components/agent-manager/EmojiPicker.tsx
@@ -36,12 +36,12 @@ export default function EmojiPicker({
   value,
   onChange,
   size = "md",
-  ariaLabel,
+  "aria-label": ariaLabel,
 }: {
   value: string;
   onChange: (emoji: string) => void;
   size?: "sm" | "md";
-  ariaLabel?: string;
+  "aria-label"?: string;
 }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -111,6 +111,7 @@ export default function EmojiPicker({
               height={pickerHeight}
               onSelect={handleEmojiSelect}
               width={pickerWidth}
+              value={value}
             />
           </Suspense>
         </div>

--- a/dashboard/src/components/agent-manager/EmojiPicker.tsx
+++ b/dashboard/src/components/agent-manager/EmojiPicker.tsx
@@ -76,7 +76,7 @@ export default function EmojiPicker({
         aria-label={
           ariaLabel ||
           (value
-            ? tr({ ko: `이모지 변경 (현재: ${value})`, en: `Change emoji (current: ${value})` })
+            ? tr({ ko: `선택된 이모지: ${value}, 이모지 변경`, en: `Selected emoji: ${value}, change emoji` })
             : tr({ ko: "이모지 선택기 열기", en: "Open emoji picker" }))
         }
       >

--- a/dashboard/src/components/agent-manager/EmojiPickerLibraryPanel.tsx
+++ b/dashboard/src/components/agent-manager/EmojiPickerLibraryPanel.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import EmojiPickerReact, {
   EmojiStyle,
   Theme,
@@ -8,30 +9,69 @@ interface EmojiPickerLibraryPanelProps {
   height: number;
   onSelect: (emoji: string) => void;
   width: number;
+  value?: string;
 }
 
 export default function EmojiPickerLibraryPanel({
   height,
   onSelect,
   width,
+  value,
 }: EmojiPickerLibraryPanelProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
   const handleEmojiClick = (emojiData: EmojiClickData) => {
     onSelect(emojiData.emoji);
   };
 
+  // emoji-picker-react (v4) renders each emoji as `button.epr-emoji` whose
+  // visible text is the native emoji. The library exposes no selected state, so
+  // we mark the current value with `aria-current="true"` for screen readers.
+  // aria-current is used (not aria-selected, which is ignored on an implicit
+  // role=button) so the "current selection in the set" is actually announced.
+  // The match is exact (ignoring the FE0F variation selector) so composed
+  // sequences that merely contain the same codepoint are not tagged.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!value || !container) return;
+
+    const normalize = (text: string) => text.replace(/\uFE0F/g, "").trim();
+    const target = normalize(value);
+
+    const syncSelected = () => {
+      container.querySelectorAll("button.epr-emoji").forEach((button) => {
+        if (normalize(button.textContent ?? "") === target) {
+          button.setAttribute("aria-current", "true");
+        } else {
+          button.removeAttribute("aria-current");
+        }
+      });
+    };
+
+    // Apply once for the emojis already mounted (observers do not replay the
+    // mutations that happened before observe()), then keep in sync as the
+    // library mounts/unmounts buttons during search, scroll and lazy loading.
+    syncSelected();
+    const observer = new MutationObserver(syncSelected);
+    observer.observe(container, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [value]);
+
   return (
-    <EmojiPickerReact
-      autoFocusSearch
-      emojiStyle={EmojiStyle.NATIVE}
-      height={height}
-      lazyLoadEmojis
-      onEmojiClick={handleEmojiClick}
-      previewConfig={{ showPreview: false }}
-      searchClearButtonLabel="Clear emoji search"
-      searchPlaceholder="Search emoji"
-      skinTonesDisabled={false}
-      theme={Theme.DARK}
-      width={width}
-    />
+    <div ref={containerRef}>
+      <EmojiPickerReact
+        autoFocusSearch
+        emojiStyle={EmojiStyle.NATIVE}
+        height={height}
+        lazyLoadEmojis
+        onEmojiClick={handleEmojiClick}
+        previewConfig={{ showPreview: false }}
+        searchClearButtonLabel="Clear emoji search"
+        searchPlaceholder="Search emoji"
+        skinTonesDisabled={false}
+        theme={Theme.DARK}
+        width={width}
+      />
+    </div>
   );
 }

--- a/dashboard/src/components/agent-manager/KanbanAssignIssueModal.tsx
+++ b/dashboard/src/components/agent-manager/KanbanAssignIssueModal.tsx
@@ -28,6 +28,8 @@ export default function KanbanAssignIssueModal({ ctx }: KanbanAssignIssueModalPr
       {assignIssue && (
         <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-center p-0 sm:p-4" style={{ backgroundColor: "var(--th-modal-overlay)" }}>
           <SurfaceCard
+            role="dialog"
+            aria-label={assignIssue.title}
             className="w-full max-w-lg rounded-t-3xl p-5 sm:rounded-3xl sm:p-6 space-y-4"
             style={{
               ...SURFACE_MODAL_CARD_STYLE,

--- a/dashboard/src/components/agent-manager/KanbanAssignIssueModal.tsx
+++ b/dashboard/src/components/agent-manager/KanbanAssignIssueModal.tsx
@@ -29,6 +29,7 @@ export default function KanbanAssignIssueModal({ ctx }: KanbanAssignIssueModalPr
         <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-center p-0 sm:p-4" style={{ backgroundColor: "var(--th-modal-overlay)" }}>
           <SurfaceCard
             role="dialog"
+            aria-modal="true"
             aria-label={assignIssue.title}
             className="w-full max-w-lg rounded-t-3xl p-5 sm:rounded-3xl sm:p-6 space-y-4"
             style={{

--- a/dashboard/src/components/agent-manager/KanbanStatusModals.tsx
+++ b/dashboard/src/components/agent-manager/KanbanStatusModals.tsx
@@ -31,6 +31,7 @@ export default function KanbanStatusModals({ ctx }: KanbanStatusModalsProps) {
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4" style={{ backgroundColor: "var(--th-modal-overlay)" }} onClick={() => setAssignBeforeReady(null)}>
           <SurfaceCard
             role="dialog"
+            aria-modal="true"
             aria-label={tr("담당자 할당", "Assign Agent")}
             onClick={(e) => e.stopPropagation()}
             className="w-full max-w-sm space-y-4 rounded-[28px] p-5"

--- a/dashboard/src/components/agent-manager/KanbanStatusModals.tsx
+++ b/dashboard/src/components/agent-manager/KanbanStatusModals.tsx
@@ -30,6 +30,8 @@ export default function KanbanStatusModals({ ctx }: KanbanStatusModalsProps) {
       {assignBeforeReady && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4" style={{ backgroundColor: "var(--th-modal-overlay)" }} onClick={() => setAssignBeforeReady(null)}>
           <SurfaceCard
+            role="dialog"
+            aria-label={tr("담당자 할당", "Assign Agent")}
             onClick={(e) => e.stopPropagation()}
             className="w-full max-w-sm space-y-4 rounded-[28px] p-5"
             style={{
@@ -87,6 +89,8 @@ export default function KanbanStatusModals({ ctx }: KanbanStatusModalsProps) {
         return (
           <div className="fixed inset-0 z-50 flex items-center justify-center p-4" style={{ backgroundColor: "var(--th-modal-overlay)" }}>
             <SurfaceCard
+              role="dialog"
+              aria-label={tr("카드 취소 확인", "Cancel cards")}
               onClick={(e) => e.stopPropagation()}
               className="w-full max-w-md space-y-4 rounded-[28px] p-5"
               style={{


### PR DESCRIPTION
## 목표

대시보드의 오피스/에이전트/칸반 모달과 셀렉터에서 누락된 접근성(a11y) 시맨틱을 보강한다. 토글형 아이콘·색상 선택기를 올바른 `radiogroup`/`radio` 패턴 + 키보드 네비게이션으로 바꾸고, 스프라이트 선택기를 `spinbutton`으로 노출하며, 폼 라벨과 입력을 `htmlFor`/`id`로 연결하고, 칸반 모달에 `dialog`/`aria-modal` 시맨틱을 추가한다. 결과적으로 스크린리더 사용자가 선택 상태와 현재 값을 정확히 인지하고 키보드만으로 조작할 수 있게 된다.

## 쉬운 설명

아이콘·색상·이모지·스프라이트를 고르는 UI가 보조기술(스크린리더)에서 "무엇이 선택됐는지", "여기가 모달인지"를 제대로 읽어주지 못하던 문제를 고친다. 이제 방향키로 아이콘/색상을 이동하며 고를 수 있고, 선택된 항목이 음성으로 안내된다. 폼 라벨을 클릭하면 해당 입력으로 포커스가 가고, 칸반 팝업은 모달로 인식된다. 화면에 보이는 동작이나 결과 값 자체는 동일하다.

## 개선되는 것

### Fix 1 — 아이콘/색상 선택기를 radiogroup으로 전환 + 키보드 이동
이전: `OfficeManagerModal`/`OfficeManagerView`의 아이콘·색상 버튼이 `aria-pressed`(토글 버튼) 시맨틱이라 "선택된 하나"를 그룹으로 안내하지 못했고, Tab으로 모든 버튼을 일일이 거쳐야 했다.
이후: 컨테이너에 `role="radiogroup"` + 그룹 `aria-label`, 각 버튼에 `role="radio"` + `aria-checked`를 부여한다. roving tabindex(선택 항목만 `tabIndex=0`, 미선택 시 첫 항목)와 Arrow/Home/End 키 핸들러로 그룹 내부를 방향키로 순회하며 선택이 즉시 갱신된다.

### Fix 2 — 스프라이트 선택기를 spinbutton으로 노출
이전: `AgentFormModal`의 스프라이트 위/아래 변경 영역이 단순 `role="group"`이라 현재 스프라이트 번호가 값으로 안내되지 않았다.
이후: 컨테이너를 `role="spinbutton"`으로 바꾸고 `aria-valuenow`/`aria-valuemin`/`aria-valuetext`로 현재 번호(또는 "선택 안됨")를 노출한다. `tabIndex=0` + ArrowUp/ArrowDown으로 값을 증감하며, 내부 ↑/↓ 버튼은 `tabIndex=-1`로 중복 포커스를 제거한다.

### Fix 3 — 폼 라벨과 입력 연결(htmlFor/id)
이전: `AgentFormModal`/`DepartmentFormModal`의 이름(ko/ja/zh)·부서·설명·성격·부서 프롬프트 라벨이 입력과 프로그래밍적으로 연결돼 있지 않았다.
이후: 각 `label`에 `htmlFor`, 각 입력에 대응 `id`를 부여한다. 시각 라벨이 없던 부서 프롬프트에는 `sr-only` 라벨을 추가해 접근 가능한 이름을 보장한다.

### Fix 4 — EmojiPicker 접근 가능한 이름 표준화 + 현재 선택 안내
이전: `EmojiPicker`가 커스텀 `ariaLabel` prop을 받았고 안내 문구가 "변경 (현재: X)" 형태였으며, 이모지 그리드는 현재 선택 항목을 보조기술에 알리지 못했다.
이후: prop을 표준 `aria-label`로 통일하고 문구를 "선택된 이모지: X, 이모지 변경" 형태로 일관화한다. `EmojiPickerLibraryPanel`은 `value`를 받아 `MutationObserver`로 라이브러리가 마운트하는 `button.epr-emoji` 중 현재 값(FE0F 변형 선택자 무시한 정확 매칭)에 `aria-current="true"`를 부여한다.

### Fix 5 — 칸반 모달 dialog 시맨틱 + OfficeSelectorBar 라벨
이전: `KanbanAssignIssueModal`/`KanbanStatusModals`의 팝업이 dialog로 인식되지 않았고, `OfficeSelectorBar`의 오피스 버튼은 선택 상태 안내와 설정 버튼 접근 이름이 없었다.
이후: 칸반 모달에 `role="dialog"`(필요 시 `aria-modal="true"`)와 `aria-label`을 추가한다. `OfficeSelectorBar`는 오피스 버튼에 `aria-pressed`, 장식용 아이콘에 `aria-hidden`, 설정 버튼에 `aria-label`을 추가한다.

## Before → After

| 시나리오 | Before | After |
|---|---|---|
| 오피스 아이콘 선택기를 스크린리더로 탐색 | 토글 버튼 묶음으로 읽혀 "선택된 하나"가 그룹으로 안내되지 않음, Tab으로 전체 순회 | `radiogroup`으로 묶이고 선택 항목이 `aria-checked`로 안내, 방향키로 순회 |
| AgentFormModal에서 스프라이트 번호 인지 | 현재 번호가 값으로 노출되지 않음 | `spinbutton` `aria-valuetext`로 "선택된 스프라이트: N" 안내, ↑/↓로 증감 |
| 이모지 그리드에서 현재 선택 확인 | 선택된 이모지가 보조기술에 안내되지 않음 | 현재 값 버튼에 `aria-current="true"`로 "현재 선택" 안내 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
|---|---|---|
| `draft.icon`/`draft.color`가 목록에 없는 초기값 | roving tabindex가 첫 항목(idx 0)을 `tabIndex=0`으로 폴백 | 포커스 진입점이 항상 1개 보장, 키보드 데드락 없음 |
| 이모지 라이브러리가 검색/스크롤로 버튼을 재마운트 | `MutationObserver`가 childList/subtree 변경마다 `syncSelected` 재적용 | 지연 로딩/검색 후에도 `aria-current` 동기화 유지 |
| 변형 선택자(FE0F)나 합성 이모지 비교 | normalize로 FE0F 제거 후 정확 일치 비교 | 같은 코드포인트를 포함만 한 시퀀스 오탐 방지 |

## 해결한 내용

- `dashboard/src/components/OfficeManagerModal.tsx`, `OfficeManagerView.tsx`: 아이콘/색상 선택기를 `radiogroup`/`radio`(`aria-checked`)로 전환하고 roving tabindex + Arrow/Home/End 키보드 네비게이션 추가. 토글(`aria-pressed`) 시맨틱이 "단일 선택 그룹"을 잘못 표현하던 문제 해결.
- `dashboard/src/components/agent-manager/AgentFormModal.tsx`: 스프라이트 영역을 `spinbutton`(`aria-valuenow/min/text`)으로 노출하고 ↑/↓ 키 증감 + 내부 버튼 `tabIndex=-1` 정리, 이름·부서·성격 등 라벨/입력 `htmlFor`/`id` 연결, EmojiPicker에 표준 `aria-label` 전달.
- `dashboard/src/components/agent-manager/DepartmentFormModal.tsx`: 라벨/입력 `htmlFor`/`id` 연결, 부서 프롬프트에 `sr-only` 라벨 추가, EmojiPicker prop을 `ariaLabel`→`aria-label`로 통일 및 문구 일관화.
- `dashboard/src/components/agent-manager/EmojiPicker.tsx`: prop을 `ariaLabel`→`"aria-label"`로 표준화, 기본 안내 문구를 "선택된 이모지: X" 형태로 변경, `value`를 라이브러리 패널로 전달.
- `dashboard/src/components/agent-manager/EmojiPickerLibraryPanel.tsx`: `value` prop과 `MutationObserver` 기반 `aria-current` 동기화 로직 추가(라이브러리가 선택 상태를 노출하지 않는 한계 보완). FE0F 무시 정확 매칭으로 오탐 방지.
- `dashboard/src/components/agent-manager/KanbanAssignIssueModal.tsx`, `KanbanStatusModals.tsx`: 팝업에 `role="dialog"`/`aria-modal`/`aria-label` 추가로 모달 시맨틱 보강.
- `dashboard/src/components/OfficeSelectorBar.tsx`: 오피스 버튼 `aria-pressed`, 장식 아이콘 `aria-hidden`, 설정 버튼 `aria-label` 추가.
- `dashboard/src/components/OfficeManagerIconPicker.test.tsx`, `agent-manager/EmojiPicker.test.tsx`: 위 시맨틱 변경(`aria-pressed`→`role/aria-checked`, 새 라벨 문구)에 맞춰 단언 갱신.

## 검증

- GitHub Actions(헤드 SHA 기준) 실행 결과 기록:
  - 통과: Fast check, Fast check cross OS, Fast targeted tests, Changed paths, High-risk recovery(+required context), Lint required context, Script checks.
  - 실패: `Dashboard (Node 22)` 및 그 미러인 `Dashboard required context`.
- `Dashboard (Node 22)` 실패 원인은 `npm audit`가 `esbuild`/`vite` 계열 transitive 의존성의 high-severity advisory(GHSA-gv7w-rqvm-qjhr)를 차단한 것으로, 이 PR diff는 의존성 매니페스트를 전혀 건드리지 않으므로 이 PR과 무관한 base/systemic 이슈다(`Dashboard required context`는 동일 실패를 미러링).
- 로컬에서 cargo/tsc/테스트를 직접 실행하지는 않았다. 위 검증은 CI 결과에 근거한다.
