### PR TITLE
perf(db): cut N+1 queries & duplicate JSON parsing in Rust auto-queue/dispatch hot paths

### DIFF
--- a/docs/agent-maintenance/change-surfaces.md
+++ b/docs/agent-maintenance/change-surfaces.md
@@ -92,7 +92,7 @@
 - do_not_edit_without_migration_plan (giant-file, awaiting split issue):
   - `src/dispatch/dispatch_context.rs` (2805 lines).
   - `src/dispatch/dispatch_create.rs` (1381 lines).
-  - `src/dispatch/dispatch_status.rs` (1493 lines).
+  - `src/dispatch/dispatch_status.rs` (1487 lines).
   - `src/services/dispatches/outbox_route.rs` (1089 lines; route extraction
     orchestration surface from #1722, split before adding non-bugfix behavior).
   - `src/services/dispatches/discord_delivery/orchestration.rs` (1490 lines;
@@ -876,7 +876,7 @@
   its query/command/view/FSM behavior lives under
   `src/services/auto_queue/{query,command,view,fsm,phase_gate}.rs` plus
   smaller route-delegation slices.
-  `src/services/auto_queue/activate_command.rs` (1351 lines, post-#1444
+  `src/services/auto_queue/activate_command.rs` (1354 lines, post-#1444
   idempotency-guard expansion + #3038 phase-helper decomposition) is the
   canonical activate/dispatch-next command surface; it is intentionally above
   the giant-file threshold and tracked here. The `activate_with_deps_pg`
@@ -1025,7 +1025,7 @@ Line counts are *production* LoC (the `Prod` column in `module-inventory.md`,
 which excludes `#[cfg(test)] mod` blocks); the freshness gate keeps them in sync.
 
 - `src/services/auto_queue.rs` (1546) and
-  `src/services/auto_queue/activate_command.rs` (1351); auto-queue route
+  `src/services/auto_queue/activate_command.rs` (1354); auto-queue route
   behavior is split across `src/services/auto_queue/*` slices, with
   `activate_command.rs` now giant-file territory.
   `src/services/auto_queue/cancel_run.rs` (1032) is also giant-file territory;

--- a/src/db/auto_queue/slots.rs
+++ b/src/db/auto_queue/slots.rs
@@ -88,12 +88,13 @@ pub async fn slot_has_recent_terminal_auto_queue_dispatch_pg(
         "SELECT EXISTS (
              SELECT 1
              FROM task_dispatches d
+             CROSS JOIN LATERAL (SELECT COALESCE(NULLIF(d.context, ''), '{{}}')::jsonb AS ctx) c
              WHERE d.to_agent_id = $1
                AND d.status IN ('completed', 'failed', 'cancelled')
                AND {slot_index_expr} = $2
-               AND COALESCE(((COALESCE(NULLIF(d.context, ''), '{{}}')::jsonb)->>'auto_queue')::BOOLEAN, FALSE) = TRUE
-               AND COALESCE(((COALESCE(NULLIF(d.context, ''), '{{}}')::jsonb)->>'sidecar_dispatch')::BOOLEAN, FALSE) = FALSE
-               AND (COALESCE(NULLIF(d.context, ''), '{{}}')::jsonb)->'phase_gate' IS NULL
+               AND COALESCE((c.ctx->>'auto_queue')::BOOLEAN, FALSE) = TRUE
+               AND COALESCE((c.ctx->>'sidecar_dispatch')::BOOLEAN, FALSE) = FALSE
+               AND c.ctx->'phase_gate' IS NULL
                AND COALESCE(d.completed_at, d.updated_at, d.created_at)
                    >= NOW() - make_interval(secs => $3::INT)
          )"

--- a/src/dispatch/dispatch_status.rs
+++ b/src/dispatch/dispatch_status.rs
@@ -672,10 +672,7 @@ async fn set_dispatch_status_on_pg_with_sync(
             Some(&current_status),
             to_status,
             transition_source,
-            result_json
-                .as_ref()
-                .and_then(|value| serde_json::from_str::<serde_json::Value>(value).ok())
-                .as_ref(),
+            result,
         );
         emit_dispatch_quality_event(
             dispatch_id,
@@ -685,10 +682,7 @@ async fn set_dispatch_status_on_pg_with_sync(
             Some(&current_status),
             to_status,
             transition_source,
-            result_json
-                .as_ref()
-                .and_then(|value| serde_json::from_str::<serde_json::Value>(value).ok())
-                .as_ref(),
+            result,
         );
 
         if plan.enqueue_status_reaction {

--- a/src/services/auto_queue/activate_command.rs
+++ b/src/services/auto_queue/activate_command.rs
@@ -71,9 +71,10 @@ pub(crate) async fn activate_with_deps_pg(
         let active_turn_count_now = sqlx::query_scalar::<_, i64>(
             "SELECT COUNT(*)::BIGINT
              FROM task_dispatches d
+             CROSS JOIN LATERAL (SELECT COALESCE(NULLIF(d.context, ''), '{}')::jsonb AS ctx) c
              WHERE d.status IN ('pending', 'dispatched')
-               AND COALESCE(((COALESCE(NULLIF(d.context, ''), '{}')::jsonb)->>'sidecar_dispatch')::BOOLEAN, FALSE) = FALSE
-               AND (COALESCE(NULLIF(d.context, ''), '{}')::jsonb)->'phase_gate' IS NULL
+               AND COALESCE((c.ctx->>'sidecar_dispatch')::BOOLEAN, FALSE) = FALSE
+               AND c.ctx->'phase_gate' IS NULL
                AND EXISTS (
                    SELECT 1
                    FROM auto_queue_entries e
@@ -940,9 +941,10 @@ async fn compute_activate_groups_to_dispatch(
     let active_turn_count = match sqlx::query_scalar::<_, i64>(
         "SELECT COUNT(*)::BIGINT
          FROM task_dispatches d
+         CROSS JOIN LATERAL (SELECT COALESCE(NULLIF(d.context, ''), '{}')::jsonb AS ctx) c
          WHERE d.status IN ('pending', 'dispatched')
-           AND COALESCE(((COALESCE(NULLIF(d.context, ''), '{}')::jsonb)->>'sidecar_dispatch')::BOOLEAN, FALSE) = FALSE
-           AND (COALESCE(NULLIF(d.context, ''), '{}')::jsonb)->'phase_gate' IS NULL
+           AND COALESCE((c.ctx->>'sidecar_dispatch')::BOOLEAN, FALSE) = FALSE
+           AND c.ctx->'phase_gate' IS NULL
            AND EXISTS (
                SELECT 1
                FROM auto_queue_entries e
@@ -1262,9 +1264,10 @@ async fn finalize_activate_run_and_build_response(
     let active_turn_count_after = sqlx::query_scalar::<_, i64>(
         "SELECT COUNT(*)::BIGINT
          FROM task_dispatches d
+         CROSS JOIN LATERAL (SELECT COALESCE(NULLIF(d.context, ''), '{}')::jsonb AS ctx) c
          WHERE d.status IN ('pending', 'dispatched')
-           AND COALESCE(((COALESCE(NULLIF(d.context, ''), '{}')::jsonb)->>'sidecar_dispatch')::BOOLEAN, FALSE) = FALSE
-           AND (COALESCE(NULLIF(d.context, ''), '{}')::jsonb)->'phase_gate' IS NULL
+           AND COALESCE((c.ctx->>'sidecar_dispatch')::BOOLEAN, FALSE) = FALSE
+           AND c.ctx->'phase_gate' IS NULL
            AND EXISTS (
                SELECT 1
                FROM auto_queue_entries e

--- a/src/services/auto_queue/query.rs
+++ b/src/services/auto_queue/query.rs
@@ -115,16 +115,19 @@ pub(super) async fn slot_has_dispatch_thread_history_pg(
     agent_id: &str,
     slot_index: i64,
 ) -> Result<bool, String> {
-    // Use a broad LIKE filter to drastically reduce the number of rows transferred over the network.
-    // We avoid strict JSON string matching or ::jsonb casts in SQL to prevent false negatives from whitespace
-    // and runtime query crashes on malformed legacy JSON data. The exact JSON validation is safely done in Rust.
+    // Use a strictly over-inclusive LIKE filter to reduce the number of rows transferred over the
+    // network without ever dropping a candidate row. We only filter on the slot value itself and
+    // deliberately avoid the literal `slot_index` key text, because legacy rows may store the JSON
+    // key escaped/differently; matching the key text would be a false negative that lets a reused
+    // slot skip reset_slot_thread_before_reuse and resume the wrong thread. We also avoid strict
+    // JSON string matching or ::jsonb casts in SQL to prevent runtime query crashes on malformed
+    // legacy JSON data. The exact JSON validation is safely done in Rust below.
     let rows = sqlx::query(
         "SELECT id, thread_id, context
          FROM task_dispatches
          WHERE to_agent_id = $1
            AND thread_id IS NOT NULL
            AND BTRIM(thread_id) != ''
-           AND context LIKE '%slot_index%'
            AND context LIKE '%' || $2::text || '%'",
     )
     .bind(agent_id)

--- a/src/services/auto_queue/query.rs
+++ b/src/services/auto_queue/query.rs
@@ -115,14 +115,20 @@ pub(super) async fn slot_has_dispatch_thread_history_pg(
     agent_id: &str,
     slot_index: i64,
 ) -> Result<bool, String> {
+    // Use a broad LIKE filter to drastically reduce the number of rows transferred over the network.
+    // We avoid strict JSON string matching or ::jsonb casts in SQL to prevent false negatives from whitespace
+    // and runtime query crashes on malformed legacy JSON data. The exact JSON validation is safely done in Rust.
     let rows = sqlx::query(
         "SELECT id, thread_id, context
          FROM task_dispatches
          WHERE to_agent_id = $1
            AND thread_id IS NOT NULL
-           AND BTRIM(thread_id) != ''",
+           AND BTRIM(thread_id) != ''
+           AND context LIKE '%slot_index%'
+           AND context LIKE '%' || $2::text || '%'",
     )
     .bind(agent_id)
+    .bind(slot_index)
     .fetch_all(pool)
     .await
     .map_err(|error| {


### PR DESCRIPTION
## 목표

auto-queue 활성화/디스패치 핫패스에서 같은 데이터를 반복해서 파싱하던 비용을 제거한다. 한 쿼리 안에서 `d.context`를 여러 번 `::jsonb`로 캐스팅하던 부분과 Rust에서 동일한 JSON 문자열을 두 번 `serde_json::from_str` 하던 부분을 한 번만 처리하도록 바꾸고, thread history 조회는 DB에서 광범위 `LIKE` 사전 필터로 네트워크로 넘어오는 행 수를 줄인다. 단, 그 사전 필터는 후보를 절대 누락시키지 않도록 strictly over-inclusive(과대 포함) 하게 유지한다. 결과적으로 동작과 결과값은 그대로이면서 hot path의 CPU/네트워크 비용만 낮아지는 상태를 목표로 한다.

## 쉬운 설명

자동 큐를 켜고 디스패치 상태를 갱신할 때 서버가 같은 JSON을 매번 다시 해석하던 낭비를 없앴습니다. 또 특정 슬롯의 디스패치 히스토리를 찾을 때 모든 행을 가져와 검사하는 대신, DB에서 1차로 후보를 좁혀 가져옵니다. 이 1차 필터는 일부러 넉넉하게 잡아 진짜 후보를 빠뜨리지 않으며, 정확한 판정은 기존처럼 Rust가 합니다. 사용자에게 보이는 결과(카운트, 상태값, 존재 여부)는 이전과 동일합니다.

## 개선되는 것

### Fix 1 — 한 쿼리 안 JSON 중복 캐스팅 제거 (auto-queue 카운트/판정 SQL)
- Before: 한 SELECT 안에서 `auto_queue`, `sidecar_dispatch`, `phase_gate` 각 조건마다 `(COALESCE(NULLIF(d.context,''),'{}')::jsonb)`를 따로 계산 → 행마다 같은 JSON을 2~3회 캐스팅.
- After: `CROSS JOIN LATERAL (SELECT ... ::jsonb AS ctx) c`로 행당 한 번만 jsonb로 만든 뒤 `c.ctx->>...`를 재사용. 결과는 동일, 행당 jsonb 변환 횟수만 1회로 축소.
- 적용 위치: `slot_has_recent_terminal_auto_queue_dispatch_pg` 및 active turn count 계산 3곳(`activate_with_deps_pg`, `compute_activate_groups_to_dispatch`, `finalize_activate_run_and_build_response`).

### Fix 2 — 디스패치 상태 핫패스의 이중 JSON 파싱 제거
- Before: `set_dispatch_status_on_pg_with_sync`에서 quality event를 emit하는 두 호출이 각각 `result_json`을 다시 `serde_json::from_str` 하여 `serde_json::Value`로 재파싱.
- After: 상위에서 이미 파싱해 둔 `result`를 두 호출에 그대로 전달. 같은 문자열을 두 번 파싱하던 비용 제거.

### Fix 3 — thread history 조회에 over-inclusive LIKE 사전 필터 추가
- Before: `slot_has_dispatch_thread_history_pg`가 `to_agent_id` + `thread_id` 비어있지 않음 조건만으로 모든 후보 행(id, thread_id, context)을 가져와 Rust에서 전수 검사 → 전송 행 수가 큼.
- After: SQL에 `context LIKE '%' || $2::text || '%'`(슬롯 값 기반) 사전 필터만 추가해 전송 행 수를 줄이고, 정확한 JSON 검증은 기존대로 Rust에서 수행.
- Codex P2 반영: 초기 구현에 있던 `context LIKE '%slot_index%'`(리터럴 키 텍스트) 조건을 제거했다. 레거시 행은 JSON 키가 이스케이프되어 저장될 수 있어, 키 텍스트를 강제로 매칭하면 Rust 검증 이전에 정당한 행을 떨어뜨리는 false negative가 발생한다. 그 결과 재사용된 슬롯이 `reset_slot_thread_before_reuse`를 건너뛰고 잘못된 thread를 재개할 위험이 있었다. 따라서 값 기반 단일 조건만 남겨 사전 필터를 strictly over-inclusive 하게 유지한다.

## Before → After

| 시나리오 | Before | After |
|---|---|---|
| active turn count 카운트 쿼리 | 행마다 `d.context`를 2~3회 `::jsonb` 캐스팅 | `CROSS JOIN LATERAL`로 행당 1회 캐스팅 후 `c.ctx` 재사용, 결과 동일 |
| 디스패치 상태 전이 시 quality event emit | `result_json`을 emit마다 `serde_json::from_str`로 재파싱(총 2회) | 상위에서 파싱한 `result`를 재사용, 추가 파싱 0회 |
| 슬롯 thread history 존재 여부 조회 | 조건에 맞는 모든 행을 받아 Rust 전수 검사 | DB 값 기반 `LIKE` 사전 필터로 후보 축소(과대 포함) 후 Rust 정밀 검증, 반환 bool 동일 |
| 레거시 행 JSON 키가 이스케이프됨 | (초기 구현) `LIKE '%slot_index%'`가 키 텍스트를 요구 → 후보에서 탈락(false negative) | 키 텍스트 조건 제거, 값 기반 조건만 적용 → 후보로 살아남아 Rust가 정확히 판정 |

## 사이드 이펙트 시뮬레이션

| 시나리오 | 동작 | 결론 |
|---|---|---|
| `d.context`가 빈 문자열/NULL | `COALESCE(NULLIF(...,''),'{}')`이 LATERAL 안에서 `{}`로 정규화 | 기존과 동일, 안전 |
| context가 malformed/레거시 JSON | SQL은 값 기반 `LIKE` 텍스트 매칭만 하고 jsonb 강제 캐스팅 안 함, 정밀 판정은 Rust | 쿼리 크래시/false negative 회피 |
| 레거시 JSON 키 이스케이프 행 | 키 텍스트 조건을 제거해 사전 필터가 행을 떨어뜨리지 않음 → Rust 검증으로 진입 | 재사용 슬롯이 reset을 건너뛰지 않음, 정확성 유지 |
| 슬롯 값 부분 문자열이 다른 필드에 우연히 포함 | `LIKE`는 over-inclusive 사전 필터이고 Rust에서 최종 확정 | 결과 정확성 유지, 일부 후보만 더 검사 |

## 해결한 내용

- `src/db/auto_queue/slots.rs`: `slot_has_recent_terminal_auto_queue_dispatch_pg`의 SQL을 `CROSS JOIN LATERAL`로 jsonb를 1회만 계산하게 재작성. 한 행에 대한 중복 jsonb 변환 제거가 목적이며 조건/결과 의미는 불변.
- `src/services/auto_queue/activate_command.rs`: active turn count를 세는 3개 쿼리(activate, group 계산, finalize)에 동일한 `CROSS JOIN LATERAL` 패턴 적용. auto-queue 활성화 경로에서 반복 캐스팅 비용 축소.
- `src/dispatch/dispatch_status.rs`: 상태 전이 핫패스에서 `result_json` 재파싱을 없애고 이미 파싱된 `result`를 두 emit 호출에 전달. 동일 문자열 이중 파싱 제거.
- `src/services/auto_queue/query.rs`: `slot_has_dispatch_thread_history_pg`에 슬롯 값 기반 `LIKE` 사전 필터와 `$2` 바인딩 추가. 단 Codex P2를 반영해 리터럴 키 텍스트 `LIKE '%slot_index%'` 조건은 제거하여 사전 필터를 strictly over-inclusive 하게 유지(정밀 JSON 검증은 Rust). 의도는 주석으로 명시.
- `docs/agent-maintenance/change-surfaces.md`: 이 PR이 건드린 giant-file의 동결(freeze) production-LoC 항목을 재생성된 inventory 값으로 동기화. `dispatch_status.rs` 1493→1487(prod 라인 ~6 감소), `activate_command.rs` 1351→1354(prod 라인 ~3 증가).

## 검증

- Windows / cross-OS: `Fast check + non-PG tests (windows-latest)`, `Fast check cross OS required context (ubuntu-latest)` 모두 현재 CI에서 통과(이전 본문의 실패 주장은 stale — 정정함).
- `Script checks`: 이 PR이 giant-file의 prod 라인 수를 변경해 발생한 freeze-drift였다. `change-surfaces.md`의 해당 동결 항목을 재생성된 `module-inventory.md`의 Prod 값으로 동기화하여 해소함.
- LIKE 사전 필터: Codex P2 지적대로 리터럴 키 텍스트 조건을 제거해 사전 필터를 over-inclusive 하게 유지하도록 완화함(false negative 회피).
- 로컬 유지보수 게이트(이 작업에서 실제 실행): `scripts/check_agent_maintenance_docs.py --warning-only --line-count-gate` exit 0, `scripts/audit_maintainability.py --check` exit 0(unrelated 문서의 'Last refreshed' 헤더 누락 경고는 비치명적, exit 0 유지). 둘 다 `/opt/homebrew/bin/python3.12`로 실행.
- 로컬 `cargo build/check/test`는 디스크/락 경합 회피를 위해 의도적으로 실행하지 않음. Rust 컴파일 검증은 cloud CI 재실행으로 검증 예정.
